### PR TITLE
[nv2] M1.2 — surface inner error behind user_fn_failed

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -4418,10 +4418,21 @@ fn compile_ufn_from_globals(fn_id: i64) -> bool with IO, Mut, Panic, Div {
             drv_emit_load_string_offset(V2_UFN_DST[i as usize], ro_off)
         } else if op == UFN_BINOP {
             if !drv_emit_any_binop(V2_UFN_DST[i as usize], src1_val, V2_UFN_BINOP_CODE[i as usize], V2_UFN_SRC2[i as usize]) {
+                // M1.2 — surface which binop opcode tripped us.
+                print("native_compile: binop_unsupported op=BINOP code=")
+                print_int(V2_UFN_BINOP_CODE[i as usize])
+                print(" ufn_idx=")
+                print_int(i)
+                print("\n")
                 return false
             }
         } else if op == UFN_F64_BINOP {
             if !drv_emit_f64_binop(V2_UFN_DST[i as usize], src1_val, V2_UFN_BINOP_CODE[i as usize], V2_UFN_SRC2[i as usize]) {
+                print("native_compile: binop_unsupported op=F64_BINOP code=")
+                print_int(V2_UFN_BINOP_CODE[i as usize])
+                print(" ufn_idx=")
+                print_int(i)
+                print("\n")
                 return false
             }
         } else if op == UFN_LABEL {
@@ -4652,8 +4663,14 @@ fn compile_user_fn(fn_name_tok: i64, fn_id: i64, token_count: i64) -> bool with 
         return false
     }
     if !compile_ufn_from_globals(fn_id) {
+        // M1.2 — surface the function name and IR-op count so we can tell
+        // which UFN opcode tripped `compile_ufn_from_globals`.
         print("native_compile: user_fn_unsupported fn_id=")
         print_int(fn_id)
+        print(" name=")
+        print_token_text(fn_name_tok)
+        print(" ufn_ops=")
+        print_int(V2_UFN_COUNT)
         print("\n")
         return false
     }
@@ -5073,7 +5090,17 @@ fn compile_ir_module_to_elf(output_path: string, token_count: i64) -> i64 with I
         let ufn_name_tok = V2_USER_FN_TOKEN_IDX[ui as usize]
         let ufn_id = V2_USER_FN_IDS[ui as usize]
         if !compile_user_fn(ufn_name_tok, ufn_id, token_count) {
-            print("native_compile: user_fn_failed\n")
+            // M1.2 — surface the inner error behind user_fn_failed so the
+            // parity-inventory cluster for this message is no longer opaque.
+            print("native_compile: user_fn_failed fn_id=")
+            print_int(ufn_id)
+            print(" name=")
+            print_token_text(ufn_name_tok)
+            print(" index=")
+            print_int(ui)
+            print(" of=")
+            print_int(user_fn_count)
+            print("\n")
             return 3
         }
         EP_TOTAL_INSTR = EP_TOTAL_INSTR + V2_UFN_COUNT


### PR DESCRIPTION
## Summary

PUNCH_LIST attack-order item #1 (\"improve diagnostics\"). The native-v2 driver was dropping three pieces of context every time a user function failed to compile, producing the opaque line:

```
native_compile: user_fn_failed
```

22 failures in `tests/run-pass` and 5 in the broader corpus clustered on this message with no further detail. This PR threads information through the three emit sites:

- `user_fn_failed fn_id=<id> name=<tok> index=<i> of=<count>` — names the failing user fn + its queue position.
- `user_fn_unsupported fn_id=<id> name=<tok> ufn_ops=<V2_UFN_COUNT>` — reports how many UFN ops were recorded before codegen gave up.
- `binop_unsupported op=<BINOP|F64_BINOP> code=<N> ufn_idx=<i>` — the only two `return false` sites inside the opcode dispatch; names the unsupported binop.

## Verification

Example on `tests/run-pass/algebra_g2_invariants.sio`:
- **Before:** \`native_compile: user_fn_failed\`
- **After:** \`unsupported_frontend fn=cd_sigma_r token=1555 kind=152 text=<<\` + \`user_fn_failed fn_id=40 name=cd_sigma_r index=8 of=20\`

The underlying \`<<\` (shift-left) cluster that the diagnostic was hiding is now immediately visible to the next inventory pass.

## Gates

- \`scripts/ci/lean_single_fixed_point_gate.sh\` — PASS.
- \`scripts/ci/native_v2_driver_self_compile_gate.sh\` stage1-smoke — PASS (6/6 ran, 6/6 checked).
- Stage2 self-compile still fails with the pre-existing limitation (unrelated to this change; documented in \`artifacts/m1_2_parity_inventory/blockers/m1_2_step_d_user_globals.md\`).

## Test plan

- [x] Baseline souc runs new driver on hello.sio → 42
- [x] Stage1 compiles hello.sio → 42 (no codegen regression)
- [x] algebra_g2_invariants.sio shows enriched diagnostic
- [x] lean_single_fixed_point_gate.sh PASS
- [x] native_v2_driver_self_compile_gate.sh stage1-smoke PASS