### PR TITLE
[nv2] M1.2 D.0 re-land — bump DRV_LABEL_* 256 → 1024 (isolated)

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -214,9 +214,18 @@ var DRV_RELOC_COUNT: i64 = 0
 var DRV_FN_OFFSETS: [i64; 2048] = [0; 2048]
 var DRV_FN_COUNT: i64 = 0
 var DRV_ENTRY_OFFSET: i64 = 0
-var DRV_LABEL_OFFSETS: [i64; 256] = [0; 256]
-var DRV_LABEL_PATCH_OFFSETS: [i64; 256] = [0; 256]
-var DRV_LABEL_PATCH_IDS: [i64; 256] = [0; 256]
+// M1.2 — label arrays bumped from 256 → 1024 (PR #53 D.0 re-land,
+// bisected per blockers/m1_2_pr53_bss_corruption_regression.md).
+// `driver_const_value_tok` is a long if-chain that compiles into many
+// labels; baseline driver already runs near the 256 ceiling, and any
+// additional control flow (HOF param-skip with bracket-depth tracking
+// landing in a follow-up commit) silently dropped patches past 256,
+// causing stage1 to mis-compile hello.sio (42 → 76/78). The other two
+// pieces of the original PR #53 (USER_GLOBAL_* slots + scan_user_globals
+// scaffold) remain reverted and stay separate commits when they relaunch.
+var DRV_LABEL_OFFSETS: [i64; 1024] = [0; 1024]
+var DRV_LABEL_PATCH_OFFSETS: [i64; 1024] = [0; 1024]
+var DRV_LABEL_PATCH_IDS: [i64; 1024] = [0; 1024]
 var DRV_LABEL_PATCH_COUNT: i64 = 0
 var DRV_ELF_LEN: i64 = 0
 var DRV_ELF_BYTES: [i8; 1048576] = [0; 1048576]
@@ -3661,14 +3670,14 @@ fn drv_add_data_reloc(patch_offset: i64, data_off: i64) with Mut, Panic {
 }
 
 fn drv_define_label(label_id: i64) with Mut, Panic {
-    if label_id >= 0 && label_id < 256 {
+    if label_id >= 0 && label_id < 1024 {
         DRV_LABEL_OFFSETS[label_id as usize] = DRV_CODE_LEN
     }
 }
 
 fn drv_add_label_patch(patch_offset: i64, label_id: i64) with Mut, Panic {
     let idx = DRV_LABEL_PATCH_COUNT
-    if idx >= 0 && idx < 256 {
+    if idx >= 0 && idx < 1024 {
         DRV_LABEL_PATCH_OFFSETS[idx as usize] = patch_offset
         DRV_LABEL_PATCH_IDS[idx as usize] = label_id
         DRV_LABEL_PATCH_COUNT = idx + 1
@@ -3680,7 +3689,7 @@ fn drv_patch_labels() with Mut, Div, Panic {
     while i < DRV_LABEL_PATCH_COUNT {
         let off = DRV_LABEL_PATCH_OFFSETS[i as usize]
         let lid = DRV_LABEL_PATCH_IDS[i as usize]
-        if lid >= 0 && lid < 256 {
+        if lid >= 0 && lid < 1024 {
             let target = DRV_LABEL_OFFSETS[lid as usize]
             let rel = target - (off + 4)
             drv_patch_u32_le(off, rel)
@@ -3692,7 +3701,7 @@ fn drv_patch_labels() with Mut, Div, Panic {
 fn drv_reset_function_state() with Mut, Panic {
     DRV_LABEL_PATCH_COUNT = 0
     var i: i64 = 0
-    while i < 256 {
+    while i < 1024 {
         DRV_LABEL_OFFSETS[i as usize] = -1
         i = i + 1
     }
@@ -3711,7 +3720,7 @@ fn drv_reset_codegen(fn_count: i64) with Mut, Panic {
         i = i + 1
     }
     i = 0
-    while i < 256 {
+    while i < 1024 {
         DRV_LABEL_OFFSETS[i as usize] = -1
         i = i + 1
     }


### PR DESCRIPTION
## Summary

Re-lands the first piece of reverted PR #53, isolated per the bisect plan in [\`blockers/m1_2_pr53_bss_corruption_regression.md\`](https://github.com/Sounio-lang/sounio/blob/main/artifacts/m1_2_parity_inventory/blockers/m1_2_pr53_bss_corruption_regression.md).

This commit contains **ONLY** the label-array size bump and matching bounds checks (256 → 1024). The other two pieces of the original PR — USER_GLOBAL_* slots and the scan_user_globals scaffold — remain reverted and will land as separate commits when they relaunch.

## Why isolate

The blocker doc attributes the original PR #53 BSS-corruption symptom to the **combination** of three changes. Bundling them prevented bisecting the actual regression. This isolated +18 KB BSS bump (vs. the ~1.5 MB shift from user-global slots) is well below the regression envelope.

## Why we still need it

`driver_const_value_tok` is an else-if chain that compiles into many labels — the baseline driver already runs near the 256-label ceiling. Any subsequent change adding control flow (e.g. the HOF parameter-type fix planned for the follow-up commit, which adds bracket-depth tracking) pushes past 256, silently drops patches in \`drv_add_label_patch\` / \`drv_patch_labels\` (both gated by \`< 256\`), and stage1 mis-compiles hello.sio (42 → 76 or 78).

## Verification

- \`scripts/ci/lean_single_fixed_point_gate.sh\` — **PASS** (stage1 == stage2 == stage3, md5 unchanged from main: \`447d7cdcec5c48ecd3bcf8b5d5b34b01\`).
- \`scripts/ci/native_v2_driver_self_compile_gate.sh\` — **PASS** end-to-end:
  - stage1-smoke OK (6/6 ran, 6/6 checked)
  - stage2/stage3 self-compile fixed-point (md5=\`5ab0989139610d4272d20b73099134ff\`)
  - epistemic-fixed-point (instr=16702, u_c=0)
  - hello stdout parity across baseline / stage1 / stage2 / stage3.

## Test plan

- [x] Driver typechecks
- [x] Baseline souc → hello.sio prints 42
- [x] lean_single_fp gate PASS
- [x] native-v2 self-compile gate PASS through stage2/stage3
- [x] Hello parity across all 4 stages