### PR TITLE
[nv2] M1.2 — close `no_open_brace` HOF cluster (find_fn_lbrace + param-skip)

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -2949,11 +2949,17 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
 }
 
 fn find_fn_lbrace(token_count: i64, name_str_pos: i64) -> i64 with Mut, Panic, Div {
-    // Find the opening { of the function whose name token is at name_str_pos
+    // Find the opening { of the function whose name token is at name_str_pos.
+    // M1.2 — recognise `fn` inside parameter types (e.g. `f: fn(i64) -> i64`).
+    // The next top-level fn definition is always `fn IDENT`; an `fn` in a
+    // type position is followed by `(`. We bail only on the former so HOF
+    // signatures don't trip a spurious `no_open_brace` failure.
     var j = name_str_pos + 1
     while j < token_count {
         if token_kind(j) == TK_LBRACE { return j }
-        if token_kind(j) == TK_FN { return -1 }
+        if token_kind(j) == TK_FN && j + 1 < token_count && token_kind(j + 1) == TK_IDENT {
+            return -1
+        }
         j = j + 1
     }
     -1
@@ -4422,9 +4428,22 @@ fn compile_user_fn(fn_name_tok: i64, fn_id: i64, token_count: i64) -> bool with 
                     V2_CURRENT_PARAM_COUNT = param_idx + 1
                     param_idx = param_idx + 1
                 }
-                // skip past colon, type, optional comma
+                // skip past colon, type, optional comma. M1.2 — respect
+                // bracket depth so HOF param types like `fn(i64) -> i64`
+                // (which contain `(` `)`) and generics like `Vec<i32>`
+                // don't terminate the skip prematurely on the inner `)`.
                 ppos = ppos + 1
-                while ppos < open_pos && token_kind(ppos) != TK_COMMA && token_kind(ppos) != TK_RPAREN {
+                var paren_depth: i64 = 0
+                var angle_depth: i64 = 0
+                while ppos < open_pos {
+                    let tk = token_kind(ppos)
+                    if paren_depth == 0 && angle_depth == 0 {
+                        if tk == TK_COMMA || tk == TK_RPAREN { break }
+                    }
+                    if tk == TK_LPAREN { paren_depth = paren_depth + 1 }
+                    else if tk == TK_RPAREN { paren_depth = paren_depth - 1 }
+                    else if tk == TK_LT { angle_depth = angle_depth + 1 }
+                    else if tk == TK_GT { angle_depth = angle_depth - 1 }
                     ppos = ppos + 1
                 }
                 if ppos < open_pos && token_kind(ppos) == TK_COMMA { ppos = ppos + 1 }


### PR DESCRIPTION
## Summary

Closes the **HOF sub-cluster of the 23-case `no_open_brace` failures** (PUNCH_LIST.md headline #2 actionable cluster). Two coordinated fixes in `native_compile_driver.sio`:

1. **`find_fn_lbrace`**: recognise `fn` inside parameter types (e.g. `f: fn(i64) -> i64`). Previously bailed at the inner `fn` keyword.
2. **Param-skip with bracket depth**: `(`/`)` and `<`/`>` depth tracking so HOF params and generics like `Vec<i32>` don't terminate the unknown-type fall-through prematurely on the inner `)`/`>`.

Rebased on top of upstream 967eb4e0 (R2.2 — driver self-resolver completeness sweep + DRV_LABEL bump), which superseded my own #55 with the same label-table bump.

## Effect on the inventory

`closure_fn_ref.sio`, `closure_hof.sio`, and similar HOF tests now reach the body and fail with `unresolved_call text=f` — a separate gap (calling a fn-ref parameter as a callable) filed for follow-up. The misleading `no_open_brace` is gone.

## Deferred (intentionally out of scope)

`extern "C" { fn sqrt(x: f64) -> f64; }` forward declarations still fall through `find_fn_lbrace` and produce `no_open_brace` for the libm helpers themselves. A `has_body` peek-ahead in `scan_user_fns` would close this sub-cluster, but the obvious implementation (multiple `var pk` declarations with a paren-depth tracking loop) triggers a stage2 self-compile divergence — `set_func_name_print_int` becomes mis-resolved when stage1 compiles the new scan_user_fns body. Filed as a separate task.

## Verification

- `scripts/ci/lean_single_fixed_point_gate.sh` — **PASS**.
- `scripts/ci/native_v2_driver_self_compile_gate.sh` — **PASS** end-to-end (stage1-smoke 6/6, stage2/stage3 fixed-point, epistemic instr=16878, hello parity all stages).

## Test plan

- [x] HOF `closure_fn_ref.sio` reaches body
- [x] hello.sio prints 42 across baseline / stage1 / stage2 / stage3
- [x] lean_single fixed-point gate PASS
- [x] native-v2 self-compile gate PASS (full)