### PR TITLE
[nv2] M1.2 — close `no_open_brace` HOF cluster (re-land of #56 with smoke pin)

### DIFF
--- a/examples/native/hof_param_signature.sio
+++ b/examples/native/hof_param_signature.sio
@@ -1,0 +1,21 @@
+// M1.2 — HOF parameter signature smoke test.
+// Validates that find_fn_lbrace and the parameter walker handle a
+// `fn(T) -> T` parameter type without bailing on the inner `fn`
+// keyword or running off the end. Before this fix, the program
+// failed compile with `unsupported_frontend reason=no_open_brace`
+// because the body lookahead aborted at the parameter-type `fn`.
+//
+// The fn-ref parameter `f` is not invoked here — calling a fn-ref
+// is a separate gap. Discarding the param keeps this regression
+// test focused on the parameter-list walker.
+
+fn takes_hof_sig(f: fn(i64) -> i64, x: i64) -> i64 {
+    x + 1
+}
+
+fn main() -> i64 with IO {
+    let r = takes_hof_sig(0, 41)
+    print_int(r)
+    print_char(10)
+    0
+}

--- a/scripts/ci/native_v2_driver_self_compile_gate.sh
+++ b/scripts/ci/native_v2_driver_self_compile_gate.sh
@@ -162,6 +162,15 @@ SMOKE_COHORT=(
   # refinement syntax. The new baseline-rc=124 → FAIL guard above turns
   # this entry into a hard regression test for that bug class.
   "tests/run-pass/refinement_nested_arithmetic.sio"
+  # HOF parameter signature regression test (post-#56-revert re-land).
+  # Validates that `find_fn_lbrace` and the parameter walker handle a
+  # `fn(T) -> T` parameter type without bailing on the inner `fn`
+  # keyword or running off the end. PR #56 was reverted because of a
+  # purported logical_ops hang that turned out to be transient; this
+  # entry pins the actual fix forward — both the baseline (with the
+  # fix) and stage1 must compile this file successfully, so any future
+  # change that re-breaks find_fn_lbrace fails the gate immediately.
+  "examples/native/hof_param_signature.sio"
 )
 
 printf '[native-v2-driver-self] stage1-smoke timeout=%ss cohort=%d\n' \

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -2949,11 +2949,12 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
 }
 
 fn find_fn_lbrace(token_count: i64, name_str_pos: i64) -> i64 with Mut, Panic, Div {
-    // Find the opening { of the function whose name token is at name_str_pos
     var j = name_str_pos + 1
     while j < token_count {
         if token_kind(j) == TK_LBRACE { return j }
-        if token_kind(j) == TK_FN { return -1 }
+        if token_kind(j) == TK_FN && j + 1 < token_count && token_kind(j + 1) == TK_IDENT {
+            return -1
+        }
         j = j + 1
     }
     -1
@@ -4422,9 +4423,18 @@ fn compile_user_fn(fn_name_tok: i64, fn_id: i64, token_count: i64) -> bool with 
                     V2_CURRENT_PARAM_COUNT = param_idx + 1
                     param_idx = param_idx + 1
                 }
-                // skip past colon, type, optional comma
                 ppos = ppos + 1
-                while ppos < open_pos && token_kind(ppos) != TK_COMMA && token_kind(ppos) != TK_RPAREN {
+                var paren_depth: i64 = 0
+                var angle_depth: i64 = 0
+                while ppos < open_pos {
+                    let tk = token_kind(ppos)
+                    if paren_depth == 0 && angle_depth == 0 {
+                        if tk == TK_COMMA || tk == TK_RPAREN { break }
+                    }
+                    if tk == TK_LPAREN { paren_depth = paren_depth + 1 }
+                    else if tk == TK_RPAREN { paren_depth = paren_depth - 1 }
+                    else if tk == TK_LT { angle_depth = angle_depth + 1 }
+                    else if tk == TK_GT { angle_depth = angle_depth - 1 }
                     ppos = ppos + 1
                 }
                 if ppos < open_pos && token_kind(ppos) == TK_COMMA { ppos = ppos + 1 }


### PR DESCRIPTION
## Summary

Re-lands the two-line core of reverted PR #56:

1. **`find_fn_lbrace`**: bail only on top-level `fn IDENT`, so an `fn` in a parameter type (`f: fn(i64) -> i64`) doesn't trigger a spurious `no_open_brace` failure.
2. **Param-skip**: respect `(`/`)` and `<`/`>` depth so the unknown-type fall-through doesn't terminate prematurely on the inner `)`/`>` of a HOF parameter type or generic.

## Why this re-land is safe

PR #56 was reverted (commit 523cd61f) because the R2.1 refinement-canary gate flagged a baseline hang on `examples/native/logical_ops.sio`. **That hang is not reproducible after R2.2 landed** (the self-resolver completeness sweep, commit 967eb4e0): wall-clock measurements on the full smoke cohort show every file completing in <10ms with the fix applied (fib=2ms, while_loop=2ms, **logical_ops=8ms**, array_basics=3ms, struct_basic=3ms). The transient hang was likely caused by the combination of #56 with the older driver state, not the fix itself.

## New regression pin

Adds `examples/native/hof_param_signature.sio` — a minimal smoke test that declares a HOF parameter (`fn(i64) -> i64`) and calls the wrapper. The wrapper does not invoke `f` (calling a fn-ref param is a separate gap), keeping the test focused on the parameter-list walker.

- **Without the fix**: baseline rejects with `unsupported_frontend reason=no_open_brace`.
- **With the fix**: prints 42 cleanly.

Pinned into `scripts/ci/native_v2_driver_self_compile_gate.sh` smoke cohort. Both baseline AND stage1 must compile and run it successfully — any future change that re-breaks `find_fn_lbrace` or the param walker fails the gate immediately.

## Effect on the inventory

`closure_fn_ref.sio`, `closure_hof.sio`, and similar HOF tests now reach the function body instead of failing parse with `no_open_brace`. They surface the next gap (calling a fn-ref parameter as a callable) which is a separate cluster filed for follow-up.

## Verification

- `scripts/ci/lean_single_fixed_point_gate.sh` — **PASS** (md5 unchanged: `447d7cdcec5c48ecd3bcf8b5d5b34b01`).
- `scripts/ci/native_v2_driver_self_compile_gate.sh` — **PASS** end-to-end:
  - stage1-smoke OK (**7/7** ran, **7/7** checked, including the new HOF entry)
  - stage2/stage3 self-compile fixed-point (md5=`b9ea0736e90d4b8ceb7a5edf09a4965c`)
  - epistemic-fixed-point (instr=16878, u_c=0)
  - hello stdout parity across baseline / stage1 / stage2 / stage3.

## Test plan

- [x] Baseline (no fix): rejects `hof_param_signature.sio` with `no_open_brace`
- [x] Baseline + fix: `hof_param_signature.sio` prints 42
- [x] logical_ops (the canary that flagged #56): compiles in 8ms, no hang
- [x] lean_single_fp gate PASS
- [x] native-v2 self-compile gate PASS (full)
- [x] Smoke cohort 7/7 with HOF positive test pinned