### PR TITLE
[codex] add package-backed PBPK GUM gate

### DIFF
--- a/scripts/ci/package_pbpk_gum_gate.sh
+++ b/scripts/ci/package_pbpk_gum_gate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
+sounio_require_souc
+
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+BASELINE="tests/stdlib/darwin_pbpk/test_observed_petab_fit_e2e.sio"
+WORKFLOW="tests/packages/package_pbpk_gum_workflow.sio"
+OUT_DIR="$(mktemp -d /tmp/sounio-package-pbpk-gum.XXXXXX)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+printf '[package-pbpk-gum] souc=%s\n' "$SOUC_BIN"
+printf '[package-pbpk-gum] stdlib=%s\n' "$SOUNIO_STDLIB_PATH"
+
+printf '[package-pbpk-gum] run package import contract gate\n'
+bash "$ROOT_DIR/scripts/ci/package_import_science_gate.sh" >"$OUT_DIR/package_import_science.log" 2>&1
+cat "$OUT_DIR/package_import_science.log"
+
+printf '[package-pbpk-gum] run canonical observed PETAB baseline %s\n' "$BASELINE"
+if ! "$SOUC_BIN" run "$BASELINE" >"$OUT_DIR/observed_petab.log" 2>&1; then
+  cat "$OUT_DIR/observed_petab.log" >&2
+  echo '[package-pbpk-gum] FAIL: canonical observed PETAB baseline failed' >&2
+  exit 1
+fi
+if ! grep -qF 'OBSERVED_PETAB_FIT_OK' "$OUT_DIR/observed_petab.log"; then
+  cat "$OUT_DIR/observed_petab.log" >&2
+  echo '[package-pbpk-gum] FAIL: canonical observed PETAB marker missing' >&2
+  exit 1
+fi
+
+printf '[package-pbpk-gum] run package-backed PBPK/GUM workflow %s\n' "$WORKFLOW"
+if ! "$SOUC_BIN" run "$WORKFLOW" >"$OUT_DIR/package_pbpk_gum.log" 2>&1; then
+  cat "$OUT_DIR/package_pbpk_gum.log" >&2
+  echo '[package-pbpk-gum] FAIL: package-backed PBPK/GUM workflow failed' >&2
+  exit 1
+fi
+cat "$OUT_DIR/package_pbpk_gum.log"
+if ! grep -qF 'PACKAGE_PBPK_GUM_OK' "$OUT_DIR/package_pbpk_gum.log"; then
+  echo '[package-pbpk-gum] FAIL: package-backed PBPK/GUM marker missing' >&2
+  exit 1
+fi
+
+echo '[package-pbpk-gum] PASS: PBPK/GUM consumes epistemic-core as a package'

--- a/tests/packages/package_pbpk_gum_workflow.sio
+++ b/tests/packages/package_pbpk_gum_workflow.sio
@@ -1,0 +1,138 @@
+//@ run-pass
+// @ timeout: 60
+//@ expect-stdout: PACKAGE_PBPK_GUM_OK
+
+use epistemic_core::*
+use darwin_pbpk::brain_plasma_tac::*
+use darwin_pbpk::fit::problem::*
+use darwin_pbpk::fit::objective::*
+use darwin_pbpk::io::observed_csv::*
+use darwin_pbpk::io::observed_tsv::*
+use darwin_pbpk::io::normalization::*
+use darwin_pbpk::schema::observation::*
+
+fn pbkgum_abs(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn pbkgum_near(a: f64, b: f64, tol: f64) -> bool {
+    pbkgum_abs(a - b) <= tol
+}
+
+fn build_observations() -> NormalizedObservationTable with Mut, Div, Panic {
+    let csv_line_1 = "s1,15,min,plasma,blood,central,,10.225,ug/L,1.044,lcms,synthetic_ref"
+    let csv_line_2 = "s1,4,h,brain,brain,tissue,,0.285,ug/L,0.981,lcms,synthetic_ref"
+    let tsv_line = "s2\t1\th\tplasma\tblood\tcentral\t\t0.003112\tmg/L\t0.004049\tlcms\tsynthetic_ref"
+
+    let raw_csv_1 = parse_observed_csv(csv_line_1)
+    let raw_csv_2 = parse_observed_csv(csv_line_2)
+    let raw_tsv = parse_observed_tsv(tsv_line)
+
+    let norm_csv_1 = normalize_observations(raw_csv_1, "rapamycin_iv_bolus_ref")
+    let norm_csv_2 = normalize_observations(raw_csv_2, "rapamycin_iv_bolus_ref")
+    let norm_tsv = normalize_observations(raw_tsv, "rapamycin_iv_bolus_ref")
+    let norm_csv = normalized_observation_table_concat(norm_csv_1, norm_csv_2)
+    normalized_observation_table_concat(norm_csv, norm_tsv)
+}
+
+fn test_measurement_lift() -> bool with Mut, Div, Panic {
+    let observations = build_observations()
+    if normalized_observation_count(observations) != 3 { return false }
+
+    let plasma = normalized_observation_get(observations, 0)
+    let brain = normalized_observation_get(observations, 1)
+
+    let plasma_k = measure_with_confidence(plasma.measurement, plasma.measurement_uncertainty, 0.97, plasma.source)
+    let brain_k = measure_with_confidence(brain.measurement, brain.measurement_uncertainty, 0.97, brain.source)
+    let ratio = knowledge_div(&brain_k, &plasma_k)
+
+    let value_ok = knowledge_value(&ratio) > 0.02 && knowledge_value(&ratio) < 0.04
+    let uncertainty_ok = knowledge_uncertainty(&ratio) > 0.09 && knowledge_uncertainty(&ratio) < 0.11
+    let confidence_ok = pbkgum_near(knowledge_confidence(&ratio), 0.97, 0.000001)
+    value_ok && uncertainty_ok && confidence_ok
+}
+
+fn test_tac_residual_lift() -> bool with Mut, Div, Panic {
+    let observations = build_observations()
+    let tac = rapamycin_brain_plasma_reference_tac()
+    if tac.success == false { return false }
+
+    let obs = normalized_observation_get(observations, 0)
+    let obs_k = measure_with_confidence(obs.measurement, obs.measurement_uncertainty, 0.98, obs.source)
+    let pred_k = measure_with_confidence(tac.blood_values[1], tac.blood_uncertainties[1], 0.96, "rapamycin_tac_blood_15min")
+
+    let residual_value = knowledge_value(&obs_k) - knowledge_value(&pred_k)
+    let residual = gum_propagate_2(residual_value, 1.0, &obs_k, -1.0, &pred_k)
+
+    let value_ok = pbkgum_abs(knowledge_value(&residual)) < 0.02
+    let uncertainty_ok = knowledge_uncertainty(&residual) > 0.0
+    let confidence_ok = pbkgum_near(knowledge_confidence(&residual), 0.96, 0.000001)
+    value_ok && uncertainty_ok && confidence_ok
+}
+
+fn test_objective_lift() -> bool with Mut, Div, Panic {
+    let observations = build_observations()
+    let tac = rapamycin_brain_plasma_reference_tac()
+    if tac.success == false { return false }
+
+    let problem = calibration_problem_new(observations, "rapamycin_iv_bolus_ref")
+    let objective = calibration_objective(problem, tac)
+    if objective.success == false { return false }
+    if objective.n_points != 3 { return false }
+
+    let rmse_k = measure_with_confidence(objective.rmse, objective.rmse * 0.05, 0.96, "pbpk_calibration_rmse")
+    let n_k = measure(objective.n_points as f64, 0.0, "pbpk_observation_count")
+    let total_rmse = knowledge_mul(&rmse_k, &n_k)
+
+    let rmse_ok = knowledge_value(&rmse_k) > 0.0 && knowledge_value(&rmse_k) < 0.001
+    let total_ok = knowledge_value(&total_rmse) > 0.0 && knowledge_value(&total_rmse) < 0.003
+    let uncertainty_ok = knowledge_uncertainty(&total_rmse) > 0.0
+    let gate_ok = confidence_check(&rmse_k, 0.95)
+    rmse_ok && total_ok && uncertainty_ok && gate_ok
+}
+
+fn test_objective_gum_budget() -> bool with Mut, Div, Panic {
+    let observations = build_observations()
+    let tac = rapamycin_brain_plasma_reference_tac()
+    if tac.success == false { return false }
+
+    let problem = calibration_problem_new(observations, "rapamycin_iv_bolus_ref")
+    let objective = calibration_objective(problem, tac)
+    if objective.success == false { return false }
+
+    let chi2_k = measure_with_confidence(objective.chi2, objective.chi2 * 0.02, 0.97, "pbpk_chi2")
+    let rmse_k = measure_with_confidence(objective.rmse, objective.rmse * 0.05, 0.96, "pbpk_rmse")
+    let score_value = knowledge_value(&chi2_k) + 100.0 * knowledge_value(&rmse_k)
+    let score = gum_propagate_2(score_value, 1.0, &chi2_k, 100.0, &rmse_k)
+
+    let score_ok = knowledge_value(&score) > 0.0 && knowledge_value(&score) < 0.5
+    let uncertainty_ok = knowledge_uncertainty(&score) > 0.0
+    let confidence_ok = pbkgum_near(knowledge_confidence(&score), 0.96, 0.000001)
+    score_ok && uncertainty_ok && confidence_ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    var passed: i64 = 0
+    var total: i64 = 0
+
+    total = total + 1
+    if test_measurement_lift() { passed = passed + 1 } else { println("FAIL: test_measurement_lift") }
+
+    total = total + 1
+    if test_tac_residual_lift() { passed = passed + 1 } else { println("FAIL: test_tac_residual_lift") }
+
+    total = total + 1
+    if test_objective_lift() { passed = passed + 1 } else { println("FAIL: test_objective_lift") }
+
+    total = total + 1
+    if test_objective_gum_budget() { passed = passed + 1 } else { println("FAIL: test_objective_gum_budget") }
+
+    print("package pbpk gum workflow: ")
+    print_int(passed)
+    print("/")
+    print_int(total)
+    println(" passed")
+
+    assert(passed == total)
+    println("PACKAGE_PBPK_GUM_OK")
+}


### PR DESCRIPTION
## Summary
- Add a downstream package-backed Darwin PBPK/PETAB workflow witness that imports `epistemic_core::*` directly.
- Lift observed measurements, TAC residuals, calibration RMSE, and chi2/RMSE score budgets through the package GUM knowledge API.
- Add `scripts/ci/package_pbpk_gum_gate.sh` to run the package import contract, canonical observed PETAB baseline, and the new package-backed workflow.

## Validation
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/packages/package_pbpk_gum_workflow.sio`
- `bash -n scripts/ci/package_pbpk_gum_gate.sh`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/package_pbpk_gum_gate.sh`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/run_sio_test_suite.sh` -> 782 pass, 128 skip, 0 fail
- `git diff --cached --check`
- `bin/llm-offload -t math-review -p xai -i tests/packages/package_pbpk_gum_workflow.sio` -> `NO MATHEMATICAL CONTENT TO REVIEW`

## Paths
- Uses the default `bin/souc` path resolved through `scripts/lib/resolve_souc.sh`.
- No fallback path introduced.