### PR TITLE
[codex] gate package PBPK GUM contract in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: bash scripts/ci/claude_operational_contract_gate.sh
       - name: Ontology validation
         run: bash scripts/ci/run_ontology_validation.sh --mode rebuilt ontology
+      - name: Package-backed PBPK/GUM contract
+        run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Upload contract artifacts
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Wire `scripts/ci/package_pbpk_gum_gate.sh` into the CI `Contracts` job.
- Promote the package-backed PBPK/GUM witness from a manual downstream gate to a PR-enforced contract.

## Validation
- `git diff --check`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/package_pbpk_gum_gate.sh`

## Paths
- Uses the default `bin/souc` resolution through `scripts/lib/resolve_souc.sh` inside the package gate.
- No fallback path introduced.