### PR TITLE
M1.2 step D — no-progress guard + canonical example (safe-only, D.0 NOT closed)

### DIFF
--- a/.claude/check_sio_integration_window.v1.json
+++ b/.claude/check_sio_integration_window.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "sounio.check_sio.integration_window.v1",
-  "status": "closed",
+  "status": "idle",
   "window": {
     "id": "phase3-epistemic-expansion-2026-04-26",
     "owner_prompt": "codex_epistemic_expansion.md",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   contracts:

--- a/artifacts/m1_2_parity_inventory/blockers/m1_2_step_d_user_globals.md
+++ b/artifacts/m1_2_parity_inventory/blockers/m1_2_step_d_user_globals.md
@@ -167,3 +167,4 @@ a permanent defensive measure.
 
 **Next step:** Re-implement step D user-global infrastructure (USER_GLOBAL_*)
 without the memory corruption that caused PR #53's revert. The `examples/native/user_global_basic.sio` test file is ready but NOT yet in the smoke cohort (baseline driver can't handle it yet — that's expected until step D lands).
+

--- a/artifacts/m1_2_parity_inventory/blockers/m1_2_step_d_user_globals.md
+++ b/artifacts/m1_2_parity_inventory/blockers/m1_2_step_d_user_globals.md
@@ -141,3 +141,29 @@ instrumentation for the next session to continue from.
 which would turn the hang into a detectable infinite loop with a fn name,
 identifying the exact statement that's cycling. Then bisect with
 `user_global_id_tok` calls commented out one parse-site at a time.
+
+---
+
+## 2026-05-01 — No-progress guard landed; self-compile gate clean
+
+Commit `21d19869` added the no-progress guard to `parse_block_ir`. The guard
+detects when `parse_stmt_ir` returns without advancing (`p <= prev_p`) and
+converts the infinite loop into a `native_compile: parse_block_no_progress`
+diagnostic + `unsupported_frontend` error.
+
+The full gate now passes:
+```
+[native-v2-driver-self] stage1-smoke OK ran=7 checked=7
+[native-v2-driver-self] fixed-point md5=45165e0a04cd57fd1bec63bfa104f4e0
+[native-v2-driver-self] PASS: baseline, stage1 driver, stage2 driver,
+  fixed-point (stage2==stage3), hello parity across all stages,
+  epistemic-fixed-point verified
+```
+
+No `parse_block_no_progress` messages were emitted during the full gate run,
+confirming that the original hang (stage1 → stage2) was caused by PR #53's
+user-global infrastructure (since reverted). The no-progress guard remains as
+a permanent defensive measure.
+
+**Next step:** Re-implement step D user-global infrastructure (USER_GLOBAL_*)
+without the memory corruption that caused PR #53's revert. The `examples/native/user_global_basic.sio` test file is ready but NOT yet in the smoke cohort (baseline driver can't handle it yet — that's expected until step D lands).

--- a/examples/native/user_global_basic.sio
+++ b/examples/native/user_global_basic.sio
@@ -1,0 +1,24 @@
+// M1.2 step D — canonical user-global test: a user program that declares
+// a top-level `var NAME: [i64; N]` array, writes to it indexed, and reads
+// back indexed. Before step D, programs like this failed the N-v2 driver
+// with `kind=123 text=TABLE` because the driver's hard-coded global
+// registry had no slot for TABLE.
+
+var TABLE: [i64; 4] = [0; 4]
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    TABLE[0] = 10
+    TABLE[1] = 20
+    TABLE[2] = 30
+    TABLE[3] = 40
+    var sum: i64 = 0
+    var i: i64 = 0
+    while i < 4 {
+        sum = sum + TABLE[i as usize]
+        i = i + 1
+    }
+    print("sum=")
+    print_int(sum)
+    print_char(10)
+    0
+}

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -2472,9 +2472,26 @@ fn parse_if_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, token_count: i64
 fn parse_block_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, token_count: i64) with IO, Mut, Panic, Div, Alloc {
     let saved_local_count = V2_LOCAL_COUNT
     var p = skip_trivia(pos, close)
+    // M1.2 step D — defensive no-progress guard. See
+    // artifacts/m1_2_parity_inventory/blockers/m1_2_step_d_user_globals.md.
+    // If parse_stmt_ir returns the same `p` it was given, the loop would
+    // spin forever; convert that into a diagnosable unsupported_frontend
+    // failure that names the stalling token.
     while p < close && V2_PARSE_UNSUPPORTED == 0 {
+        let prev_p = p
         p = parse_stmt_ir(func, ctx, p, close, token_count)
         p = skip_trivia(p, close)
+        if p <= prev_p && V2_PARSE_UNSUPPORTED == 0 {
+            print("native_compile: parse_block_no_progress p=")
+            print_int(prev_p)
+            print(" kind=")
+            print_int(token_kind(prev_p))
+            print(" text=")
+            print_token_text(prev_p)
+            print("\n")
+            mark_parse_unsupported(prev_p)
+            p = close
+        }
     }
     V2_LOCAL_COUNT = saved_local_count
 }


### PR DESCRIPTION
Replaces #62 (CI workflow was stuck in non-trigger state on the original branch).

## Summary

Lands the **safe pieces** of the `m1_2-step-d-debug-iter-cap` arc onto main, after re-localization confirmed Step D.0 is **not actually closed**.

- `21d19869` — no-progress guard in `parse_block_ir` (turns stage1 hangs into diagnosable `unsupported_frontend` failures)
- `cc99e04c` — canonical user-global example at `examples/native/user_global_basic.sio`
- `8e144858` — ops: close phase3-epistemic-expansion check.sio integration window
- `ef8ebde3` — docs: update step-D blocker note with no-progress-guard verification
- `affda117` — ops: fix check_sio window status closed → idle (schema validator fix)
- (plus CI-trigger noise commits — fold/squash on merge)

The user-globals infrastructure (`b9816786` + `bd9dc5ba` + `9ee9cd71`) is **excluded** — that arc was already merged as PR #53 and reverted on main as `860c4626` for the same regression class.

## Localization (the why)

Re-applying the user-globals arc on `m1_2-step-d-debug-iter-cap` reproduces PR #53's regression:
- `lean_single_fixed_point_gate.sh` PASSES (md5=447d7cdc) — but does **not** exercise `native_compile_driver.sio`, so it is not evidence the driver is whole.
- `native_v2_driver_self_compile_gate.sh` FAILS at stage2 (rc=3) with `unsupported_frontend fn=` followed by character-class bytes from `driver_is_ident_start` / `driver_is_digit` — fn-name-slice corruption.

Cherry-picking only `f441ae04` + `88ecfaa0` onto main → driver self-compile gate PASSES. Adding any of the user-globals trio re-introduces the regression.

Step D.0 reopened. Future debug should target the PT_END / fn-name-slice angle, not the label-array angle. WIP preserved on `m1_2-step-d-debug-iter-cap` for archaeology.

## Test plan

- [x] `bash scripts/ci/native_v2_driver_self_compile_gate.sh` — PASS
- [x] `bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh` — **6/6 PASS**
- [x] `bash scripts/ci/lean_single_fixed_point_gate.sh` — PASS
- [x] `bash scripts/ci/claude_operational_contract_gate.sh` — PASS (after closed→idle fix)
- [ ] CI gates on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>