### PR TITLE
ci(lean-proofs): build all default-target modules, not just 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,10 +164,17 @@ jobs:
               | sh -s -- -y --no-modify-path
           fi
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
-      - name: Build EGC proof modules
+      - name: Build all default-target proof modules
         run: |
           cd formal/lean4
-          lake build SounioGradedModal SounioMeasConf SounioProofObligation
+          # Build every @[default_target] in lakefile.lean (currently 27).
+          # Previously this step only built SounioGradedModal/MeasConf/
+          # ProofObligation, which let other top-level modules (e.g.
+          # SounioFloatInstance, SounioCausality, SounioPathionBridge)
+          # silently rot without CI catching breakage. PR #66's audit
+          # surfaced this — a PR adding a broken SounioFloatInstance
+          # passed "Lean Proofs ✓" because no other module imported it.
+          lake build
       - name: Verify egc_graded_soundness is axiom-free
         run: |
           cd formal/lean4


### PR DESCRIPTION
## Summary

Closes the CI gap surfaced by PR #66's audit: \`lean-proofs\` was only building 3 of the 27 \`@[default_target]\` libraries in \`formal/lean4/lakefile.lean\`. Any new top-level module that no other module imports (SounioFloatInstance was the trigger) could pass \"Lean Proofs ✓\" while being broken.

Fix: replace the explicit 3-target build with plain \`lake build\` so every default target is exercised.

## Why

PR #66 (now closed) added a \`SounioFloatInstance\` module with 24+ Lean compile errors, 2 \`sorry\`, and 18+ Mathlib uses despite a \"no Mathlib\" claim — and CI showed green. Local validation caught it. The CI shouldn't depend on every audit being run by hand.

## Test plan

- [ ] CI run on this PR — build time should grow (more libraries built) but still complete within the 20-min timeout
- [ ] If green: confirms all 27 default targets currently compile on main
- [ ] Future PRs adding new top-level modules will be exercised automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>