### PR TITLE
ops: re-flip check_sio window status closed → idle (unblock contract gate)

### DIFF
--- a/.claude/check_sio_integration_window.v1.json
+++ b/.claude/check_sio_integration_window.v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "sounio.check_sio.integration_window.v1",
-  "status": "closed",
+  "status": "idle",
   "window": {
     "id": "phase3-epistemic-expansion-2026-04-26",
     "owner_prompt": "codex_epistemic_expansion.md",


### PR DESCRIPTION
## Summary

Main's \`Contracts\` CI gate has been red since commit \`a9318507\` — that commit set the phase3-epistemic-expansion window to \`\"closed\"\` but \`scripts/ci/check_check_sio_integration_window.sh\` only accepts \`\"active\"\` or \`\"idle\"\`. Every PR opened against main since then fails the gate at \`check_sio_window\`. Observed on **#65** and **#69** (both blocked from clean CI green).

This re-flips the file to \`\"idle\"\`, which:
- matches what the validator accepts
- is **also** semantically accurate — the \`queue\` field has \`kimi_diagnostic_hardening.md\` at position 2, so the window is genuinely between-states with a next prompt waiting (textbook idle state)
- preserves \`closed_at_utc\` / \`closed_because\` as informational metadata

## Why not update the validator?

Option (a) — teach the validator to accept \`\"closed\"\` — was considered. Same effective unblock, but bigger blast radius (need to audit any other consumer of this file's \`status\` field). Picked (b) for surgical scope.

## Test plan

- [x] \`bash scripts/ci/claude_operational_contract_gate.sh\` — PASS locally
- [ ] CI green on this PR's \`Contracts\` job
- [ ] Verify #65 and #69 unstick after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>