### PR TITLE
[codex] Fix native out-param field stores

### DIFF
--- a/scripts/ci/native_v2_out_param_boundary_gate.sh
+++ b/scripts/ci/native_v2_out_param_boundary_gate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
+sounio_require_souc
+
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+OUT_DIR="${SOUNIO_NATIVE_V2_OUT_PARAM_BOUNDARY_DIR:-$(mktemp -d /tmp/sounio-native-v2-out-param-boundary.XXXXXX)}"
+LOG_DIR="$OUT_DIR/logs"
+ARTIFACT_DIR="$OUT_DIR/artifacts"
+
+SAME_SRC="tests/selfhost/native_runtime/abi_out_param_boundary_same_file_42.sio"
+IMPORTED_SRC="tests/selfhost/native_runtime/abi_out_param_boundary_imported_42.sio"
+HELPER_SRC="tests/selfhost/native_runtime/abi_out_param_boundary_helper.sio"
+BUNDLE="$ARTIFACT_DIR/abi_out_param_boundary_imported_42.bundle.sio"
+SAME_BIN="$ARTIFACT_DIR/abi_out_param_boundary_same_file_42.native"
+IMPORTED_BIN="$ARTIFACT_DIR/abi_out_param_boundary_imported_42.native"
+
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
+
+printf '[native-v2-out-param-boundary] souc=%s\n' "$SOUC_BIN"
+printf '[native-v2-out-param-boundary] out=%s\n' "$OUT_DIR"
+
+for src in "$SAME_SRC" "$IMPORTED_SRC" "$HELPER_SRC"; do
+  if [[ ! -f "$src" ]]; then
+    echo "[native-v2-out-param-boundary] FAIL: missing fixture $src" >&2
+    exit 1
+  fi
+done
+
+"$SOUC_BIN" check self-hosted/compiler/native_compile_driver.sio \
+  >"$LOG_DIR/native_compile_driver.check.log" 2>&1
+"$SOUC_BIN" check "$SAME_SRC" >"$LOG_DIR/same_file.check.log" 2>&1
+"$SOUC_BIN" check "$IMPORTED_SRC" >"$LOG_DIR/imported.check.log" 2>&1
+
+run_native_case() {
+  local label="$1"
+  local src="$2"
+  local bin="$3"
+  local compile_log="$LOG_DIR/${label}.compile.log"
+  local stdout_log="$LOG_DIR/${label}.stdout"
+  local stderr_log="$LOG_DIR/${label}.stderr"
+  local runtime_rc=0
+
+  "$SOUC_BIN" run self-hosted/compiler/native_compile_driver.sio -- \
+    "$src" -o "$bin" >"$compile_log" 2>&1
+
+  if [[ ! -x "$bin" ]]; then
+    echo "[native-v2-out-param-boundary] FAIL: native binary not executable for $label: $bin" >&2
+    tail -n 40 "$compile_log" >&2 || true
+    exit 1
+  fi
+
+  set +e
+  "$bin" >"$stdout_log" 2>"$stderr_log"
+  runtime_rc=$?
+  set -e
+
+  if [[ "$runtime_rc" -ne 42 ]]; then
+    echo "[native-v2-out-param-boundary] FAIL: expected exit 42 for $label, got $runtime_rc" >&2
+    cat "$stdout_log" >&2 || true
+    cat "$stderr_log" >&2 || true
+    exit 1
+  fi
+
+  printf '[native-v2-out-param-boundary] ok: %s exit=%s\n' "$label" "$runtime_rc"
+}
+
+run_native_case same_file "$SAME_SRC" "$SAME_BIN"
+
+"$SOUC_BIN" run self-hosted/compiler/native_prebundle.sio -- \
+  "$IMPORTED_SRC" -o "$BUNDLE" --root tests/selfhost/native_runtime \
+  >"$LOG_DIR/imported.prebundle.log" 2>&1
+
+if [[ ! -s "$BUNDLE" ]]; then
+  echo "[native-v2-out-param-boundary] FAIL: bundle not produced" >&2
+  cat "$LOG_DIR/imported.prebundle.log" >&2 || true
+  exit 1
+fi
+
+source_markers="$(awk 'BEGIN { n = 0 } /^\/\/ SOURCE:/ { n += 1 } END { print n }' "$BUNDLE")"
+if [[ "$source_markers" -ne 2 ]]; then
+  echo "[native-v2-out-param-boundary] FAIL: expected 2 SOURCE markers, got $source_markers" >&2
+  grep '^// SOURCE:' "$BUNDLE" >&2 || true
+  exit 1
+fi
+
+if grep -Eq '^(use |module )' "$BUNDLE"; then
+  echo "[native-v2-out-param-boundary] FAIL: bundle still contains use/module lines" >&2
+  grep -En '^(use |module )' "$BUNDLE" >&2 || true
+  exit 1
+fi
+
+if ! grep -q '^// SOURCE: tests/selfhost/native_runtime/abi_out_param_boundary_helper.sio$' "$BUNDLE"; then
+  echo "[native-v2-out-param-boundary] FAIL: bundle missing helper source marker" >&2
+  grep '^// SOURCE:' "$BUNDLE" >&2 || true
+  exit 1
+fi
+
+if ! grep -q '^// SOURCE: tests/selfhost/native_runtime/abi_out_param_boundary_imported_42.sio$' "$BUNDLE"; then
+  echo "[native-v2-out-param-boundary] FAIL: bundle missing imported main source marker" >&2
+  grep '^// SOURCE:' "$BUNDLE" >&2 || true
+  exit 1
+fi
+
+run_native_case imported_helper "$BUNDLE" "$IMPORTED_BIN"
+
+echo "[native-v2-out-param-boundary] PASS: same-file and prebundled imported &! out-param field stores exit 42"

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -2842,9 +2842,25 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
             if sidx >= 0 {
                 let foff = struct_field_offset_tok(sidx, p + 2)
                 if foff >= 0 {
+                    let base_is_ref = lookup_local_is_ref_tok(ctx, p)
                     V2_LAST_STRUCT_IDX = -1
                     let parsed = parse_expr_ir(func, ctx, p + 4)
                     if parsed.ok != 0 {
+                        if base_is_ref != 0 {
+                            if V2_LAST_STRUCT_IDX >= 0 {
+                                let inner_flat = STRUCT_FLAT_SIZE[V2_LAST_STRUCT_IDX as usize]
+                                var ci: i64 = 0
+                                while ci < inner_flat {
+                                    ufn_record_store_ref_field(base_reg, foff + ci, parsed.reg + ci)
+                                    ci = ci + 1
+                                }
+                                V2_LAST_STRUCT_IDX = -1
+                                return parsed.next
+                            }
+                            ufn_record_store_ref_field(base_reg, foff, parsed.reg)
+                            V2_LAST_STRUCT_IDX = -1
+                            return parsed.next
+                        }
                         if V2_LAST_STRUCT_IDX >= 0 {
                             let inner_flat = STRUCT_FLAT_SIZE[V2_LAST_STRUCT_IDX as usize]
                             var ci: i64 = 0
@@ -2856,6 +2872,7 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
                             return parsed.next
                         }
                         ufn_record_copy(base_reg + foff, parsed.reg)
+                        V2_LAST_STRUCT_IDX = -1
                         return parsed.next
                     }
                     mark_parse_unsupported(p + 4)
@@ -4052,7 +4069,7 @@ fn drv_emit_temp_addr(dst: i64, src: i64) with Mut, Panic, Div {
 fn drv_emit_load_ref_field(dst: i64, base_ref: i64, field_offset_words: i64) with Mut, Panic, Div {
     drv_core_load_temp_to_rax(base_ref)
     drv_emit_mov_reg_reg(3, 0)
-    drv_emit_load_rax_mem_rbx_disp32(field_offset_words * 8)
+    drv_emit_load_rax_mem_rbx_disp32(0 - (field_offset_words * 8))
     drv_core_store_rax_to_temp(dst)
 }
 
@@ -4061,7 +4078,7 @@ fn drv_emit_store_ref_field(base_ref: i64, field_offset_words: i64, src: i64) wi
     drv_emit_push_rax()
     drv_core_load_temp_to_rax(src)
     drv_emit_pop_rbx()
-    drv_emit_store_rax_mem_rbx_disp32(field_offset_words * 8)
+    drv_emit_store_rax_mem_rbx_disp32(0 - (field_offset_words * 8))
 }
 
 fn drv_global_is_byte(global_id: i64) -> bool {

--- a/tests/selfhost/native_runtime/abi_out_param_boundary_helper.sio
+++ b/tests/selfhost/native_runtime/abi_out_param_boundary_helper.sio
@@ -1,0 +1,11 @@
+module abi_out_param_boundary_helper
+
+struct BoundaryPair {
+    a: i64,
+    b: i64,
+}
+
+fn fill(out: &! BoundaryPair) with Mut {
+    out.a = 19
+    out.b = 23
+}

--- a/tests/selfhost/native_runtime/abi_out_param_boundary_imported_42.sio
+++ b/tests/selfhost/native_runtime/abi_out_param_boundary_imported_42.sio
@@ -1,0 +1,7 @@
+use abi_out_param_boundary_helper::{BoundaryPair, fill}
+
+fn main() -> i32 with Mut, Panic, Div {
+    var p = BoundaryPair { a: 0, b: 0 }
+    fill(&!p)
+    return (p.a + p.b) as i32
+}

--- a/tests/selfhost/native_runtime/abi_out_param_boundary_same_file_42.sio
+++ b/tests/selfhost/native_runtime/abi_out_param_boundary_same_file_42.sio
@@ -1,0 +1,15 @@
+struct BoundaryPair {
+    a: i64,
+    b: i64,
+}
+
+fn fill(out: &! BoundaryPair) with Mut {
+    out.a = 19
+    out.b = 23
+}
+
+fn main() -> i32 with Mut, Panic, Div {
+    var p = BoundaryPair { a: 0, b: 0 }
+    fill(&!p)
+    return (p.a + p.b) as i32
+}


### PR DESCRIPTION
## Summary
- Fix native-v2 field mutation through `&!` out-params so reference-backed struct fields use ref-field stores instead of local copies.
- Correct ref-field stack displacements to match native temp slots below `rbp`.
- Add a focused same-file plus prebundled imported out-param boundary gate.

## Validation
- `git diff --check`
- `scripts/ci/native_v2_out_param_boundary_gate.sh`
- `scripts/selfhost/selfhost_native_runtime_abi_debug.sh`
- `scripts/ci/native_v2_struct_param_gate.sh`
- `scripts/ci/native_v2_struct_mutation_gate.sh`
- `scripts/ci/package_import_science_gate.sh`
- `scripts/ci/native_v2_imported_core_abi_gate.sh`

## Notes
- Default resolver path via `scripts/lib/resolve_souc.sh`.
- No LLM-offload review required: this touches native compiler/runtime ABI code, not math claims, clinical-pathway code, or external-facing artifacts.