### PR TITLE
[nv2] M1.2 step 3a — scientific notation in float literals

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -1843,10 +1843,68 @@ fn parse_atom_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64) -> ExprParse w
         if token_kind(pos + 1) == TK_DOT && token_kind(pos + 2) == TK_INT {
             let r = alloc_reg(ctx)
             let frac_digits = token_decimal_digit_count(pos + 2)
-            let scale = decimal_scale_for_digits(frac_digits)
-            let mantissa = (pt_read_int_value(pos) * scale) + pt_read_int_value(pos + 2)
+            var scale: i64 = decimal_scale_for_digits(frac_digits)
+            var mantissa: i64 = (pt_read_int_value(pos) * scale) + pt_read_int_value(pos + 2)
+            var next_pos: i64 = pos + 3
+            // Optional sci-notation exponent. driver_lex_source_to_globals splits
+            // `1.0e10` into INT DOT INT IDENT(e10) and `1.0e-10` into
+            // INT DOT INT IDENT(e) MINUS INT. Inline detection (not a helper
+            // call) keeps the driver's user fn count below the PT_END/fn-name
+            // corruption threshold tracked in issue #71.
+            if token_kind(next_pos) == TK_IDENT {
+                let exp_start = pt_read_start(next_pos)
+                let exp_end = pt_read_end(next_pos)
+                if exp_end > exp_start {
+                    let first_ch = CURSOR_SOURCE[exp_start as usize]
+                    if first_ch == 101 as i8 || first_ch == 69 as i8 {
+                        // Walk remaining chars: must be all digits to qualify.
+                        var ei: i64 = exp_start + 1
+                        var all_digits: i64 = 1
+                        var inline_value: i64 = 0
+                        while ei < exp_end {
+                            let ch = CURSOR_SOURCE[ei as usize]
+                            if ch >= 48 as i8 && ch <= 57 as i8 {
+                                inline_value = inline_value * 10 + ((ch as i64) - 48)
+                                ei = ei + 1
+                            } else {
+                                all_digits = 0
+                                ei = exp_end
+                            }
+                        }
+                        if all_digits != 0 {
+                            let inline_digits = exp_end - exp_start - 1
+                            if inline_digits > 0 {
+                                // `eN` form: positive exponent encoded inline.
+                                var pi: i64 = 0
+                                while pi < inline_value { mantissa = mantissa * 10; pi = pi + 1 }
+                                next_pos = next_pos + 1
+                            } else {
+                                // bare `e`/`E` followed by [+/-] INT.
+                                let sign_tok = next_pos + 1
+                                let digits_tok = next_pos + 2
+                                if token_kind(sign_tok) == TK_MINUS && token_kind(digits_tok) == TK_INT {
+                                    let neg_val = pt_read_int_value(digits_tok)
+                                    var pi: i64 = 0
+                                    while pi < neg_val { scale = scale * 10; pi = pi + 1 }
+                                    next_pos = digits_tok + 1
+                                } else if token_kind(sign_tok) == TK_PLUS && token_kind(digits_tok) == TK_INT {
+                                    let pos_val = pt_read_int_value(digits_tok)
+                                    var pi: i64 = 0
+                                    while pi < pos_val { mantissa = mantissa * 10; pi = pi + 1 }
+                                    next_pos = digits_tok + 1
+                                } else if token_kind(sign_tok) == TK_INT {
+                                    let plain_val = pt_read_int_value(sign_tok)
+                                    var pi: i64 = 0
+                                    while pi < plain_val { mantissa = mantissa * 10; pi = pi + 1 }
+                                    next_pos = sign_tok + 1
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             ufn_record_load_f64_scaled(r, mantissa, scale)
-            return ExprParse { ok: 1, reg: r, next: pos + 3}
+            return ExprParse { ok: 1, reg: r, next: next_pos }
         }
         let r = alloc_reg(ctx)
         ufn_record_load_imm(r, pt_read_int_value(pos))


### PR DESCRIPTION
## Summary

Adds inline scientific-notation handling to the native-v2 driver's float-literal parser (commit `500127a7`).

The driver's lexer splits `1.0e10` into `INT DOT INT IDENT(e10)` and `1.0e-10` into `INT DOT INT IDENT(e) MINUS INT`. This change detects the exponent suffix inline in `parse_atom_ir` and folds it into the mantissa scaling. Inline (not a helper call) to keep the driver's user-fn count below the PT_END/fn-name corruption threshold tracked in issue #71.

## Test plan

- [x] Driver type-check (`bash scripts/ci/native_v2_serious_track_gate.sh`)
- [ ] Smoke: `1.0e10`, `1.0e-10`, `2.5e3`, `0.5e0` literals via the native-v2 driver

## Notes

Single commit. Independent of #74 (step-D); both target `main` separately.