### PR TITLE
Revert PR #75 (sci-notation) — broke driver_self_compile gate

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -1843,68 +1843,10 @@ fn parse_atom_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64) -> ExprParse w
         if token_kind(pos + 1) == TK_DOT && token_kind(pos + 2) == TK_INT {
             let r = alloc_reg(ctx)
             let frac_digits = token_decimal_digit_count(pos + 2)
-            var scale: i64 = decimal_scale_for_digits(frac_digits)
-            var mantissa: i64 = (pt_read_int_value(pos) * scale) + pt_read_int_value(pos + 2)
-            var next_pos: i64 = pos + 3
-            // Optional sci-notation exponent. driver_lex_source_to_globals splits
-            // `1.0e10` into INT DOT INT IDENT(e10) and `1.0e-10` into
-            // INT DOT INT IDENT(e) MINUS INT. Inline detection (not a helper
-            // call) keeps the driver's user fn count below the PT_END/fn-name
-            // corruption threshold tracked in issue #71.
-            if token_kind(next_pos) == TK_IDENT {
-                let exp_start = pt_read_start(next_pos)
-                let exp_end = pt_read_end(next_pos)
-                if exp_end > exp_start {
-                    let first_ch = CURSOR_SOURCE[exp_start as usize]
-                    if first_ch == 101 as i8 || first_ch == 69 as i8 {
-                        // Walk remaining chars: must be all digits to qualify.
-                        var ei: i64 = exp_start + 1
-                        var all_digits: i64 = 1
-                        var inline_value: i64 = 0
-                        while ei < exp_end {
-                            let ch = CURSOR_SOURCE[ei as usize]
-                            if ch >= 48 as i8 && ch <= 57 as i8 {
-                                inline_value = inline_value * 10 + ((ch as i64) - 48)
-                                ei = ei + 1
-                            } else {
-                                all_digits = 0
-                                ei = exp_end
-                            }
-                        }
-                        if all_digits != 0 {
-                            let inline_digits = exp_end - exp_start - 1
-                            if inline_digits > 0 {
-                                // `eN` form: positive exponent encoded inline.
-                                var pi: i64 = 0
-                                while pi < inline_value { mantissa = mantissa * 10; pi = pi + 1 }
-                                next_pos = next_pos + 1
-                            } else {
-                                // bare `e`/`E` followed by [+/-] INT.
-                                let sign_tok = next_pos + 1
-                                let digits_tok = next_pos + 2
-                                if token_kind(sign_tok) == TK_MINUS && token_kind(digits_tok) == TK_INT {
-                                    let neg_val = pt_read_int_value(digits_tok)
-                                    var pi: i64 = 0
-                                    while pi < neg_val { scale = scale * 10; pi = pi + 1 }
-                                    next_pos = digits_tok + 1
-                                } else if token_kind(sign_tok) == TK_PLUS && token_kind(digits_tok) == TK_INT {
-                                    let pos_val = pt_read_int_value(digits_tok)
-                                    var pi: i64 = 0
-                                    while pi < pos_val { mantissa = mantissa * 10; pi = pi + 1 }
-                                    next_pos = digits_tok + 1
-                                } else if token_kind(sign_tok) == TK_INT {
-                                    let plain_val = pt_read_int_value(sign_tok)
-                                    var pi: i64 = 0
-                                    while pi < plain_val { mantissa = mantissa * 10; pi = pi + 1 }
-                                    next_pos = sign_tok + 1
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            let scale = decimal_scale_for_digits(frac_digits)
+            let mantissa = (pt_read_int_value(pos) * scale) + pt_read_int_value(pos + 2)
             ufn_record_load_f64_scaled(r, mantissa, scale)
-            return ExprParse { ok: 1, reg: r, next: next_pos }
+            return ExprParse { ok: 1, reg: r, next: pos + 3}
         }
         let r = alloc_reg(ctx)
         ufn_record_load_imm(r, pt_read_int_value(pos))


### PR DESCRIPTION
## Why

PR #75 (sci-notation in float literals) merged cleanly but broke \`native_v2_driver_self_compile_gate.sh\` after merge. Stage1 driver compiled by the new souc fails to compile stage2 with the \`fn_id=32 name=<spaces> token=1841 kind=123 of=280\` PT_END / fn-name-token corruption fingerprint tracked in issue #71.

Root cause is the same class of corruption hypothesized in #71: adding ~35 lines of inline code to \`parse_atom_ir\` triggers shared-state corruption during stage1 self-compile. The trigger is parser-code-growth metrics (instruction layout, BSS, something not yet pinned down), not user fn count.

## How I confirmed (via PR #73's bisect, which I subsequently realized was inverted)

4-cell test matrix — only one combination fails:

| lean_single (priority-flips from 8bcb81a6) | native_compile_driver.sio (sci-notation from #75) | gate |
|---|---|---|
| with priority-flips | pre-#75 | PASS |
| reverted | pre-#75 | PASS |
| reverted | with sci-notation | **FAIL** |
| with priority-flips | with sci-notation | **FAIL** |

So sci-notation alone is the trigger. The 8bcb81a6 priority-flips that PR #73 attempted to revert were never the cause.

## Trade-off

Loses sci-notation support in the N-v2 driver — programs with \`1.0e10\` / \`1.0e-10\` literals will fall back to the old \`text=e\` failure. Acceptable until #71 is root-caused: this affects ~10 punch-list cases vs an entirely red \`driver_self_compile\` gate that blocks all PRs.

Manual repro of sci-notation correctness still works in lean_single (Track A) — that's untouched.

## Test plan

- [x] \`bash scripts/ci/native_v2_driver_self_compile_gate.sh\` — PASS locally
- [ ] CI driver_self_compile passes
- [ ] PR #65 / #69 / any other downstream now-blocked PR clears Contracts/driver_self_compile

## Re-land path

Sci-notation re-lands after issue #71 root-causes the parser-code-growth corruption mechanism. The implementation in #75 was correct in isolation (manual reprō for 1.0e2/1.0e-3/1.0e-10/5.0e2 all worked); only the bootstrapped binary fails at self-compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>