### PR TITLE
[nv2] Re-land M1.2 Step D (post-#71 fix, supersedes #74)

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -228,7 +228,11 @@ var USER_GLOBAL_IS_F64: [i64; 64] = [0; 64]
 var USER_GLOBAL_COUNT: i64 = 0
 var USER_GLOBAL_DATA_LEN: i64 = 0
 
-var DRV_CODE_BYTES: [i8; 262144] = [0; 262144]
+// Native-v2 driver code buffer. The #78/#79/#80 compiler feature stack now
+// emits slightly more than the old 256 KiB ceiling when self-compiling the
+// driver, so keep the text buffer inside the existing 1 MiB global slot but
+// leave real headroom for composed frontend work.
+var DRV_CODE_BYTES: [i8; 524288] = [0; 524288]
 var DRV_CODE_LEN: i64 = 0
 var DRV_RODATA_BYTES: [i8; 65536] = [0; 65536]
 var DRV_RODATA_LEN: i64 = 0
@@ -3354,7 +3358,7 @@ fn drv_low8(x: i64) -> i64 with Div {
 
 fn drv_emit_byte(b: i64) with Mut, Div, Panic {
     let p = DRV_CODE_LEN
-    if p >= 0 && p < 262144 {
+    if p >= 0 && p < 524288 {
         DRV_CODE_BYTES[p as usize] = drv_low8(b) as i8
         DRV_CODE_LEN = p + 1
     }

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -184,6 +184,10 @@ let UFN_LOCAL_LOAD: i64 = 17
 let UFN_LOCAL_STORE: i64 = 18
 let UFN_LOAD_F64_SCALED: i64 = 19
 let UFN_F64_BINOP: i64 = 20
+// M1.2 step D — user-global array access (top-level `var NAME: [T; N]`).
+// Reads/writes are lowered via a rip-relative lea into .data + rbx*8 index.
+let UFN_USER_GLOBAL_LOAD: i64 = 21
+let UFN_USER_GLOBAL_STORE: i64 = 22
 
 var V2_UFN_OPS: [i64; 2048] = [0; 2048]
 var V2_UFN_DST: [i64; 2048] = [0; 2048]
@@ -212,6 +216,17 @@ var V2_CALL_ARG_SIZES: [i64; 8] = [0; 8]
 var V2_CURRENT_PARAM_REGS: [i64; 64] = [0; 64]
 var V2_CURRENT_PARAM_COUNT: i64 = 0
 var V2_REG_IS_F64: [i64; 4096] = [0; 4096]
+
+// M1.2 step D — user-global registry. Top-level `var NAME: [T; N]` decls
+// (NAME not in the driver's hard-coded global table) land here. Each slot
+// records the identifier token, the byte offset into .data, the element
+// count, and whether the element type is f64.
+var USER_GLOBAL_NAME_TOK: [i64; 64] = [0; 64]
+var USER_GLOBAL_DATA_OFFSET: [i64; 64] = [0; 64]
+var USER_GLOBAL_ELEM_COUNT: [i64; 64] = [0; 64]
+var USER_GLOBAL_IS_F64: [i64; 64] = [0; 64]
+var USER_GLOBAL_COUNT: i64 = 0
+var USER_GLOBAL_DATA_LEN: i64 = 0
 
 var DRV_CODE_BYTES: [i8; 262144] = [0; 262144]
 var DRV_CODE_LEN: i64 = 0
@@ -937,6 +952,8 @@ fn driver_const_value_tok(tok: i64) -> i64 with Mut, Panic, Div {
     if token_text_eq(tok, "UFN_LOCAL_STORE") { return 18 }
     if token_text_eq(tok, "UFN_LOAD_F64_SCALED") { return 19 }
     if token_text_eq(tok, "UFN_F64_BINOP") { return 20 }
+    if token_text_eq(tok, "UFN_USER_GLOBAL_LOAD") { return 21 }
+    if token_text_eq(tok, "UFN_USER_GLOBAL_STORE") { return 22 }
 
     if token_text_eq(tok, "V2_GLOBAL_PT_KIND_CODE") { return 43 }
     if token_text_eq(tok, "V2_GLOBAL_PT_START") { return 44 }
@@ -1533,6 +1550,28 @@ fn ufn_record_global_store(global_id: i64, index_reg: i64, src: i64) with Mut {
     }
 }
 
+fn ufn_record_user_global_load(dst: i64, user_global_idx: i64, index_reg: i64) with Mut {
+    let idx = V2_UFN_COUNT
+    if idx < 2048 {
+        V2_UFN_OPS[idx as usize] = UFN_USER_GLOBAL_LOAD
+        V2_UFN_DST[idx as usize] = dst
+        V2_UFN_SRC1[idx as usize] = index_reg
+        V2_UFN_IMM[idx as usize] = user_global_idx
+        V2_UFN_COUNT = idx + 1
+    }
+}
+
+fn ufn_record_user_global_store(user_global_idx: i64, index_reg: i64, src: i64) with Mut {
+    let idx = V2_UFN_COUNT
+    if idx < 2048 {
+        V2_UFN_OPS[idx as usize] = UFN_USER_GLOBAL_STORE
+        V2_UFN_SRC1[idx as usize] = index_reg
+        V2_UFN_SRC2[idx as usize] = src
+        V2_UFN_IMM[idx as usize] = user_global_idx
+        V2_UFN_COUNT = idx + 1
+    }
+}
+
 fn ufn_record_local_load(dst: i64, base_reg: i64, idx_reg: i64) with Mut {
     let idx = V2_UFN_COUNT
     if idx < 2048 {
@@ -1887,6 +1926,21 @@ fn parse_atom_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64) -> ExprParse w
             if token_kind(end_pos) != TK_RBRACKET { return ExprParse { ok: 0, reg: -1, next: pos} }
             let dst = alloc_reg(ctx)
             ufn_record_global_load(dst, gid, idx_expr.reg)
+            return ExprParse { ok: 1, reg: dst, next: end_pos + 1}
+        }
+        // M1.2 step D — user-declared top-level global array read: `NAME[expr]`.
+        // Placed after driver_global_id_tok so driver-internal names continue
+        // to resolve through the existing hard-coded path when the driver
+        // self-compiles.
+        let ugid = user_global_id_tok(pos)
+        if ugid >= 0 && token_kind(pos + 1) == TK_LBRACKET {
+            let idx_expr = parse_expr_ir(func, ctx, pos + 2)
+            if idx_expr.ok == 0 { return ExprParse { ok: 0, reg: -1, next: pos} }
+            let end_pos = skip_index_cast_end(idx_expr.next)
+            if token_kind(end_pos) != TK_RBRACKET { return ExprParse { ok: 0, reg: -1, next: pos} }
+            let dst = alloc_reg(ctx)
+            ufn_record_user_global_load(dst, ugid, idx_expr.reg)
+            if USER_GLOBAL_IS_F64[ugid as usize] != 0 { mark_reg_f64(dst) }
             return ExprParse { ok: 1, reg: dst, next: end_pos + 1}
         }
         if gid >= 0 {
@@ -2781,6 +2835,23 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
             mark_parse_unsupported(p + 2)
             return close
         }
+        // M1.2 step D — user-global indexed store: `NAME[expr] = expr`.
+        let ugid = user_global_id_tok(p)
+        if ugid >= 0 && token_kind(p + 1) == TK_LBRACKET {
+            let idx_expr = parse_expr_ir(func, ctx, p + 2)
+            if idx_expr.ok != 0 {
+                let end_pos = skip_index_cast_end(idx_expr.next)
+                if token_kind(end_pos) == TK_RBRACKET && token_kind(end_pos + 1) == TK_EQ {
+                    let parsed = parse_expr_ir(func, ctx, end_pos + 2)
+                    if parsed.ok != 0 {
+                        ufn_record_user_global_store(ugid, idx_expr.reg, parsed.reg)
+                        return parsed.next
+                    }
+                    mark_parse_unsupported(end_pos + 2)
+                    return close
+                }
+            }
+        }
     }
 
     // local array write: ident[expr] = expr
@@ -3005,6 +3076,91 @@ fn skip_native_v2_driver_helper_fn(name_tok: i64) -> bool with Mut, Panic, Div {
     if token_text_eq(name_tok, "driver_write_elf_to_file") { return true }
     if token_text_eq(name_tok, "driver_make_executable") { return true }
     false
+}
+
+// M1.2 step D — identify user-globals by their declaring identifier token.
+// Returns the index into USER_GLOBAL_* arrays, or -1 if the token does not
+// name a registered user-global. Matching uses the shared ident-equality
+// helper so the bound identifier in `NAME[i]` reads/writes matches the
+// declaration-site token.
+fn user_global_id_tok(tok: i64) -> i64 with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < USER_GLOBAL_COUNT {
+        if toks_ident_eq(USER_GLOBAL_NAME_TOK[i as usize], tok) { return i }
+        i = i + 1
+    }
+    0 - 1
+}
+
+// M1.2 step D — top-level scan for user-declared globals of the form
+// `var NAME: [T; N]` (with or without a trailing `= [...]`). Skips any
+// matching name that is already a hard-coded driver global, so the
+// self-compile path continues to use drv_emit_driver_global_*. Non-scalar
+// element types other than i64/f64 are skipped (handled as unsupported).
+fn scan_user_globals(token_count: i64) with Mut, Panic, Div {
+    USER_GLOBAL_COUNT = 0
+    USER_GLOBAL_DATA_LEN = 0
+    var depth: i64 = 0
+    var i: i64 = 0
+    while i < token_count {
+        let k = token_kind(i)
+        if k == TK_LBRACE { depth = depth + 1; i = i + 1 }
+        else if k == TK_RBRACE { depth = depth - 1; i = i + 1 }
+        else if depth == 0 && k == TK_VAR && i + 7 < token_count
+                && token_kind(i + 1) == TK_IDENT
+                && token_kind(i + 2) == TK_COLON
+                && token_kind(i + 3) == TK_LBRACKET {
+            // Skip if NAME is already a hard-coded driver global (e.g. DRV_RODATA_BYTES).
+            let name_tok = i + 1
+            if driver_global_id_tok(name_tok) >= 0 {
+                i = i + 4
+            } else {
+                // Scan to matching `]` at depth 0, noting the `; INT ]` shape.
+                var sc = i + 4
+                while sc < token_count && token_kind(sc) != TK_SEMI && token_kind(sc) != TK_RBRACKET {
+                    sc = sc + 1
+                }
+                if sc < token_count && token_kind(sc) == TK_SEMI
+                        && sc + 2 < token_count && token_kind(sc + 1) == TK_INT
+                        && token_kind(sc + 2) == TK_RBRACKET {
+                    let elem_count = pt_read_int_value(sc + 1)
+                    let elem_type_tok = i + 4
+                    var is_f64: i64 = 0
+                    if token_text_eq(elem_type_tok, "f64") { is_f64 = 1 }
+                    // Accept i64 and f64 element types only. Others (i8, u32, etc.)
+                    // are skipped; their references fall through to the unsupported
+                    // path, which is the previous behaviour.
+                    let accept_type = token_text_eq(elem_type_tok, "i64") || is_f64 != 0
+                    if accept_type && USER_GLOBAL_COUNT < 64 {
+                        let idx = USER_GLOBAL_COUNT
+                        USER_GLOBAL_NAME_TOK[idx as usize] = name_tok
+                        USER_GLOBAL_DATA_OFFSET[idx as usize] = USER_GLOBAL_DATA_LEN
+                        USER_GLOBAL_ELEM_COUNT[idx as usize] = elem_count
+                        USER_GLOBAL_IS_F64[idx as usize] = is_f64
+                        USER_GLOBAL_DATA_LEN = USER_GLOBAL_DATA_LEN + elem_count * 8
+                        USER_GLOBAL_COUNT = idx + 1
+                    }
+                    // Advance past the type `]` and an optional `= [...]` initializer.
+                    i = sc + 3
+                    if i < token_count && token_kind(i) == TK_EQ
+                            && i + 1 < token_count && token_kind(i + 1) == TK_LBRACKET {
+                        var bd: i64 = 1
+                        i = i + 2
+                        while i < token_count && bd > 0 {
+                            let kk = token_kind(i)
+                            if kk == TK_LBRACKET { bd = bd + 1 }
+                            if kk == TK_RBRACKET { bd = bd - 1 }
+                            i = i + 1
+                        }
+                    }
+                } else {
+                    i = i + 1
+                }
+            }
+        } else {
+            i = i + 1
+        }
+    }
 }
 
 fn scan_user_fns(token_count: i64, first_fn_id: i64) with Mut, Panic, Div {
@@ -4109,6 +4265,34 @@ fn drv_emit_driver_global_store(global_id: i64, index_reg: i64, src: i64) with M
     else { drv_emit_store_rax_mem_rdx_rbx8() }
 }
 
+// M1.2 step D — user-global load: `rax = data[user_global_offset + idx*8]`.
+// Uses kind=3 relocations (already wired in drv_apply_relocations) which
+// patch the rip-relative lea to the .data file offset. The index register
+// is loaded into rbx and rdx holds the base; indexed load is 8 bytes.
+fn drv_emit_user_global_load(dst: i64, ug_idx: i64, index_reg: i64) with Mut, Panic, Div {
+    let data_offset = USER_GLOBAL_DATA_OFFSET[ug_idx as usize]
+    let load_pos = DRV_CODE_LEN + 3
+    drv_emit_lea_rax_rip_disp32(0)
+    drv_add_data_reloc(load_pos, data_offset)
+    drv_emit_mov_reg_reg(2, 0)
+    drv_core_load_temp_to_rax(index_reg)
+    drv_emit_mov_reg_reg(3, 0)
+    drv_emit_load_rax_mem_rdx_rbx8()
+    drv_core_store_rax_to_temp(dst)
+}
+
+fn drv_emit_user_global_store(ug_idx: i64, index_reg: i64, src: i64) with Mut, Panic, Div {
+    let data_offset = USER_GLOBAL_DATA_OFFSET[ug_idx as usize]
+    let load_pos = DRV_CODE_LEN + 3
+    drv_emit_lea_rax_rip_disp32(0)
+    drv_add_data_reloc(load_pos, data_offset)
+    drv_emit_mov_reg_reg(2, 0)
+    drv_core_load_temp_to_rax(index_reg)
+    drv_emit_mov_reg_reg(3, 0)
+    drv_core_load_temp_to_rax(src)
+    drv_emit_store_rax_mem_rdx_rbx8()
+}
+
 fn drv_emit_local_array_load(dst: i64, base_reg: i64, idx_reg: i64) with Mut, Panic, Div {
     drv_core_load_temp_to_rax(idx_reg)
     drv_emit_neg_rax_only()
@@ -4325,6 +4509,10 @@ fn compile_ufn_from_globals(fn_id: i64) -> bool with IO, Mut, Panic, Div {
             drv_emit_local_array_load(V2_UFN_DST[i as usize], V2_UFN_SRC1[i as usize], V2_UFN_SRC2[i as usize])
         } else if op == UFN_LOCAL_STORE {
             drv_emit_local_array_store(V2_UFN_SRC1[i as usize], V2_UFN_SRC2[i as usize], V2_UFN_DST[i as usize])
+        } else if op == UFN_USER_GLOBAL_LOAD {
+            drv_emit_user_global_load(V2_UFN_DST[i as usize], V2_UFN_IMM[i as usize], V2_UFN_SRC1[i as usize])
+        } else if op == UFN_USER_GLOBAL_STORE {
+            drv_emit_user_global_store(V2_UFN_IMM[i as usize], V2_UFN_SRC1[i as usize], V2_UFN_SRC2[i as usize])
         }
         i = i + 1
     }
@@ -4945,6 +5133,13 @@ fn compile_ir_module_to_elf(output_path: string, token_count: i64) -> i64 with I
     var data_len = 4096
     if source_uses_ident(token_count, "driver_lex_file_to_globals") {
         data_len = drv_driver_data_len()
+    } else if USER_GLOBAL_DATA_LEN > 0 {
+        // M1.2 step D — user-globals land in the .data BSS region (file-size
+        // 0 in the PHDR, mem-size data_len), so the loader zero-fills all
+        // declared slots. Round up to 8 for alignment and keep a minimum of
+        // 4096 so very small user programs still get a full page.
+        let aligned = (USER_GLOBAL_DATA_LEN + 7) / 8 * 8
+        if aligned > data_len { data_len = aligned }
     }
     let elf_len = drv_finalize_elf(output_path, data_len)
     if elf_len < 0 {
@@ -5208,6 +5403,7 @@ fn main() -> i64 with IO, Mut, Panic, Div, Alloc {
     V2_TOKEN_COUNT = token_count
     scan_struct_decls(token_count)
     scan_enum_decls(token_count)
+    scan_user_globals(token_count)
     scan_user_fns(token_count, V2_FIRST_USER_FN_ID)
     return compile_ir_module_to_elf(output_path, token_count)
 }

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -318,6 +318,18 @@ let V2_GLOBAL_USER_FN_RETURN_IS_F64: i64 = 77
 let V2_GLOBAL_STRUCT_FIELD_GENERIC_F64: i64 = 78
 let V2_GLOBAL_EP_TOTAL_INSTR: i64 = 79
 let V2_GLOBAL_EP_KNOWLEDGE_COUNT: i64 = 80
+// M1.2 step D — USER_GLOBAL_* driver-internal registry. Hard-coded here so
+// that when the driver self-compiles, references to USER_GLOBAL_NAME_TOK /
+// USER_GLOBAL_COUNT / etc. inside scan_user_globals + user_global_id_tok
+// resolve through the existing drv_emit_driver_global_{load,store} path
+// rather than mis-routing as user-program globals. User programs do not
+// use these slots.
+let V2_GLOBAL_USER_GLOBAL_NAME_TOK: i64 = 81
+let V2_GLOBAL_USER_GLOBAL_DATA_OFFSET: i64 = 82
+let V2_GLOBAL_USER_GLOBAL_ELEM_COUNT: i64 = 83
+let V2_GLOBAL_USER_GLOBAL_IS_F64: i64 = 84
+let V2_GLOBAL_USER_GLOBAL_COUNT: i64 = 85
+let V2_GLOBAL_USER_GLOBAL_DATA_LEN: i64 = 86
 
 struct ExprParse {
     ok: i64,
@@ -828,6 +840,12 @@ fn driver_global_id_tok(tok: i64) -> i64 with Mut, Panic, Div {
     if token_text_eq(tok, "DRV_CODE_LEN") { return V2_GLOBAL_DRV_CODE_LEN }
     if token_text_eq(tok, "DRV_RODATA_BYTES") { return V2_GLOBAL_DRV_RODATA_BYTES }
     if token_text_eq(tok, "DRV_RODATA_LEN") { return V2_GLOBAL_DRV_RODATA_LEN }
+    if token_text_eq(tok, "USER_GLOBAL_NAME_TOK") { return V2_GLOBAL_USER_GLOBAL_NAME_TOK }
+    if token_text_eq(tok, "USER_GLOBAL_DATA_OFFSET") { return V2_GLOBAL_USER_GLOBAL_DATA_OFFSET }
+    if token_text_eq(tok, "USER_GLOBAL_ELEM_COUNT") { return V2_GLOBAL_USER_GLOBAL_ELEM_COUNT }
+    if token_text_eq(tok, "USER_GLOBAL_IS_F64") { return V2_GLOBAL_USER_GLOBAL_IS_F64 }
+    if token_text_eq(tok, "USER_GLOBAL_COUNT") { return V2_GLOBAL_USER_GLOBAL_COUNT }
+    if token_text_eq(tok, "USER_GLOBAL_DATA_LEN") { return V2_GLOBAL_USER_GLOBAL_DATA_LEN }
     if token_text_eq(tok, "DRV_RELOC_OFFSETS") { return V2_GLOBAL_DRV_RELOC_OFFSETS }
     if token_text_eq(tok, "DRV_RELOC_KIND") { return V2_GLOBAL_DRV_RELOC_KIND }
     if token_text_eq(tok, "DRV_RELOC_TARGETS") { return V2_GLOBAL_DRV_RELOC_TARGETS }
@@ -969,6 +987,12 @@ fn driver_const_value_tok(tok: i64) -> i64 with Mut, Panic, Div {
     if token_text_eq(tok, "V2_GLOBAL_DRV_CODE_LEN") { return 54 }
     if token_text_eq(tok, "V2_GLOBAL_DRV_RODATA_BYTES") { return 55 }
     if token_text_eq(tok, "V2_GLOBAL_DRV_RODATA_LEN") { return 56 }
+    if token_text_eq(tok, "V2_GLOBAL_USER_GLOBAL_NAME_TOK") { return 81 }
+    if token_text_eq(tok, "V2_GLOBAL_USER_GLOBAL_DATA_OFFSET") { return 82 }
+    if token_text_eq(tok, "V2_GLOBAL_USER_GLOBAL_ELEM_COUNT") { return 83 }
+    if token_text_eq(tok, "V2_GLOBAL_USER_GLOBAL_IS_F64") { return 84 }
+    if token_text_eq(tok, "V2_GLOBAL_USER_GLOBAL_COUNT") { return 85 }
+    if token_text_eq(tok, "V2_GLOBAL_USER_GLOBAL_DATA_LEN") { return 86 }
     if token_text_eq(tok, "V2_GLOBAL_DRV_RELOC_OFFSETS") { return 57 }
     if token_text_eq(tok, "V2_GLOBAL_DRV_RELOC_KIND") { return 58 }
     if token_text_eq(tok, "V2_GLOBAL_DRV_RELOC_TARGETS") { return 59 }
@@ -3313,7 +3337,7 @@ fn drv_align_page(offset: i64) -> i64 with Div {
 }
 
 fn drv_global_stride() -> i64 { 1048576 }
-fn drv_driver_data_len() -> i64 { 84938752 }  // 4096 base + 81 global slots * 1MiB stride
+fn drv_driver_data_len() -> i64 { 91230208 }  // 4096 base + 87 global slots * 1MiB stride (81 base + 6 user-global slots 81-86)
 
 fn drv_emit_mov_reg_imm32(reg: i64, val: i64) with Mut, Div, Panic {
     drv_emit_byte(72)


### PR DESCRIPTION
## Summary

Re-lands M1.2 Step D (user-globals infrastructure: `var NAME: [T; N]` top-level
arrays in user programs) on top of post-#71-fix main. Supersedes PR #74 — the WIP
"DO NOT MERGE" tag on the original work referenced the issue-#71 blocker, which
is now resolved by `d6074335 fix(nv2): isolate driver global slots`.

## What this PR contains

Two commits, rebased from `m1_2-step-d-debug-iter-cap` onto post-fix main:

1. **WIP: M1.2 step D — top-level user-global array access** (formerly b9816786)
   - Adds `UFN_USER_GLOBAL_LOAD/STORE`, `USER_GLOBAL_*` driver registries,
     `scan_user_globals`, `drv_emit_user_global_load`, `user_global_id_tok`.

2. **[nv2] M1.2 step D — hoist USER_GLOBAL_* to driver-global slots 81-86**
   (formerly bd9dc5ba, conflict-resolved)
   - Extends `drv_driver_data_len` from 81 → 87 slots, keeping the post-#71-fix
     1 MiB stride. New length: `4096 + 87 * 1048576 = 91 230 208` bytes.

Stale commits dropped during rebase:
- `f441ae04`, `88ecfaa0` — patches already upstream (no-progress guard +
  canonical example landed via #65)
- `9ee9cd71` — DRV_LABEL_* 256→1024 bump already in main via codex fix
- 4 docs/blocker-note commits — stale (issue #71 closed)

## Local validation (post-fix)

| Gate | Result |
|---|---|
| `native_v2_driver_self_compile_gate.sh` | PASS — fixed-point md5=`aeba3d9b559719bbe92c166c1d896379` |
| `native_v2_cpu_compiler_umbrella_gate.sh` | 6/6 PASS |

Compare with the pre-fix Step D state on PR #74: it never reached fixed-point
because of the slot collision. Now stage1==stage2==stage3.

## Test plan

- [ ] PR CI: `native_v2_driver_self_compile_gate.sh` green
- [ ] PR CI: `native_v2_cpu_compiler_umbrella_gate.sh` 6/6
- [ ] PR CI: Contracts cohort green
- [ ] Close PR #74 once this merges