### PR TITLE
[ci] dissertation gate: add biomaterial_release (6th test)

### DIFF
--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -12,6 +12,7 @@
 #   3. rapamycin_epistemic_pbpk    BBB/Pgp clinical claims, AUC-CV, CL inverse
 #   4. rapamycin_epistemic_adaptive Bogacki-Shampine 3(2) + variance lookbehind
 #   5. rapamycin_gum_vs_mc         GUM linearization vs Monte-Carlo (ratio<10)
+#   6. biomaterial_release         Cypher DES — zero/first-order/Higuchi + 14-comp PBPK
 #
 # Each test ends with "PASS\n" on success. Gate fails if any test rc != 0
 # or stdout doesn't contain "PASS".
@@ -51,6 +52,7 @@ TESTS=(
   "rapamycin_epistemic_pbpk     tests/run-pass/rapamycin_epistemic_pbpk.sio"
   "rapamycin_epistemic_adaptive tests/run-pass/rapamycin_epistemic_adaptive.sio"
   "rapamycin_gum_vs_mc          tests/run-pass/rapamycin_gum_vs_mc.sio"
+  "biomaterial_release          stdlib/darwin_pbpk/release/biomaterial_release.sio"
 )
 
 fails=0

--- a/stdlib/darwin_pbpk/release/biomaterial_release.sio
+++ b/stdlib/darwin_pbpk/release/biomaterial_release.sio
@@ -26,13 +26,13 @@
 //
 // Author: Demetrios Chiuratto Agourakis
 
-use tsit5_pbpk14::*
+use darwin_pbpk::tsit5_pbpk14::*
 
 // ============================================================================
 // MATH HELPERS
 // ============================================================================
 
-fn rel_exp(x: f64) -> f64 {
+fn rel_exp(x: f64) -> f64 with Mut, Div {
     // exp(x) via (1 + x/1024)^1024 — relative error < 0.01% for |x| < 10
     var r = 1.0 + x / 1024.0
     var i = 0
@@ -85,7 +85,7 @@ fn release_higuchi(total_dose: f64, kh: f64) -> ReleaseModel {
 // ============================================================================
 // Returns total drug released from t=0 to t, capped at total_dose.
 
-fn release_cumulative(rel: ReleaseModel, t: f64) -> f64 {
+fn release_cumulative(rel: ReleaseModel, t: f64) -> f64 with Mut, Div, Panic {
     if t <= 0.0 { return 0.0 }
     var q = 0.0
     if rel.model == 1 {
@@ -110,7 +110,7 @@ fn release_cumulative(rel: ReleaseModel, t: f64) -> f64 {
 // ============================================================================
 // For Higuchi at t~0, rate is capped to avoid singularity.
 
-fn release_rate(rel: ReleaseModel, t: f64) -> f64 {
+fn release_rate(rel: ReleaseModel, t: f64) -> f64 with Mut, Div, Panic {
     // Stop releasing once total_dose is exhausted
     let q_so_far = release_cumulative(rel, t)
     if q_so_far >= rel.total_dose { return 0.0 }
@@ -135,7 +135,7 @@ fn release_rate(rel: ReleaseModel, t: f64) -> f64 {
 // ============================================================================
 // Integral of release_rate from t to t+dt, ensuring we don't exceed total_dose.
 
-fn release_step_amount(rel: ReleaseModel, t: f64, dt: f64) -> f64 {
+fn release_step_amount(rel: ReleaseModel, t: f64, dt: f64) -> f64 with Mut, Div, Panic {
     let q_before = release_cumulative(rel, t)
     let q_after = release_cumulative(rel, t + dt)
     return q_after - q_before
@@ -270,7 +270,7 @@ fn des_sirolimus_zero_order() -> ReleaseModel {
 }
 
 // Rapamycin PBPK params (same as epistemic_pbpk14.sio)
-fn des_rapamycin_params() -> PBPKParams14 {
+fn des_rapamycin_params() -> PBPKParams14 with Mut {
     var prm = default_pbpk_params()
     prm.cl_hepatic = 12.4
     prm.cl_renal = 0.3


### PR DESCRIPTION
## Summary

Adds the Cypher DES (sirolimus-eluting stent) biomaterial-release reference model as the 6th sub-gate in `dissertation_pbpk_suite`.

### Fixes to make biomaterial_release.sio compile + run

1. **Import path** corrected for sub-directory: `use tsit5_pbpk14::*` → `use darwin_pbpk::tsit5_pbpk14::*`. Matches the `scenarios/` pattern.
2. **Effect declarations** added on 5 helpers (`rel_exp`, `release_cumulative`, `release_rate`, `release_step_amount`, `des_rapamycin_params`).

After fixes: 8 in-source tests pass (zero-order / first-order / Higuchi release + 14-comp PBPK operator splitting + mass conservation).

## Gate result (6/6 PASS)

```
rapamycin_iso_budget         PASS
rapamycin_rk4_budget         PASS
rapamycin_epistemic_pbpk     PASS
rapamycin_epistemic_adaptive PASS
rapamycin_gum_vs_mc          PASS
biomaterial_release          PASS  ← NEW
```

## Test plan

- [x] `bash scripts/ci/dissertation_pbpk_suite_gate.sh` → 6/6 PASS
- [x] `./bin/souc check stdlib/darwin_pbpk/release/biomaterial_release.sio` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)