### PR TITLE
[ci] dissertation gate: 8 tests (clinical validation + GUM-vs-MC)

### DIFF
--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -3,7 +3,7 @@
 #
 # Dissertation evidence gate: rapamycin (sirolimus) PBPK validation suite.
 #
-# Five independent rapamycin tests cover the dissertation's applied PBPK
+# Eight independent rapamycin tests cover the dissertation's applied PBPK
 # layer — the *evidence* that the three core contributions (GUM-through-ODE,
 # compile-time confidence, ISO budgets) actually work on a real drug:
 #
@@ -13,6 +13,10 @@
 #   4. rapamycin_epistemic_adaptive Bogacki-Shampine 3(2) + variance lookbehind
 #   5. rapamycin_gum_vs_mc         GUM linearization vs Monte-Carlo (ratio<10)
 #   6. biomaterial_release         Cypher DES — zero/first-order/Higuchi + 14-comp PBPK
+#   7. rapamycin_clinical          14-comp clinical validation: brain/blood ratio,
+#                                  Vd_ss, GUM budget vs Lampen 1998, Schreiber 1991
+#   8. gum_vs_mc                   ISO budget vs Monte-Carlo: 5x cost advantage,
+#                                  parameter-level attribution, CV=20% vs CV=60%
 #
 # Each test ends with "PASS\n" on success. Gate fails if any test rc != 0
 # or stdout doesn't contain "PASS".
@@ -53,6 +57,8 @@ TESTS=(
   "rapamycin_epistemic_adaptive tests/run-pass/rapamycin_epistemic_adaptive.sio"
   "rapamycin_gum_vs_mc          tests/run-pass/rapamycin_gum_vs_mc.sio"
   "biomaterial_release          stdlib/darwin_pbpk/release/biomaterial_release.sio"
+  "rapamycin_clinical           stdlib/darwin_pbpk/validation/rapamycin_clinical.sio"
+  "gum_vs_mc                    stdlib/darwin_pbpk/validation/gum_vs_mc.sio"
 )
 
 fails=0


### PR DESCRIPTION
## Summary

Adds two more dissertation validation files into `dissertation_pbpk_suite`:

- **rapamycin_clinical** — 14-comp clinical validation (8 in-source tests). Brain/blood ratio (Lampen 1998), Vd_ss, **first ever ISO 17025 uncertainty budget for a PBPK model**.
- **gum_vs_mc** — ISO §8 GUM vs Monte-Carlo at N=20 (6 in-source tests). 5x cost advantage, parameter-level attribution.

Neither file required source edits — both already had main() and `ALL N TESTS PASSED` markers matching the gate's regex.

## Gate result (8/8 PASS)

```
rapamycin_iso_budget          rapamycin_rk4_budget
rapamycin_epistemic_pbpk      rapamycin_epistemic_adaptive
rapamycin_gum_vs_mc           biomaterial_release
rapamycin_clinical  ← NEW     gum_vs_mc  ← NEW
```

## Test plan

- [x] `bash scripts/ci/dissertation_pbpk_suite_gate.sh` → 8/8 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)