### PR TITLE
[ci] dissertation gate: add des_sirolimus + pop_sim (10 tests)

### DIFF
--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -3,7 +3,7 @@
 #
 # Dissertation evidence gate: rapamycin (sirolimus) PBPK validation suite.
 #
-# Eight independent rapamycin tests cover the dissertation's applied PBPK
+# Ten independent rapamycin tests cover the dissertation's applied PBPK
 # layer — the *evidence* that the three core contributions (GUM-through-ODE,
 # compile-time confidence, ISO budgets) actually work on a real drug:
 #
@@ -17,6 +17,10 @@
 #                                  Vd_ss, GUM budget vs Lampen 1998, Schreiber 1991
 #   8. gum_vs_mc                   ISO budget vs Monte-Carlo: 5x cost advantage,
 #                                  parameter-level attribution, CV=20% vs CV=60%
+#   9. des_sirolimus               Cypher DES extended scenario: epistemic ep_des_run
+#                                  with cross-domain uncertainty (release + PK)
+#  10. rapamycin_pop_sim           Population simulation: 32 virtual patients
+#                                  with lognormal CL/fu/Kp variability + percentile
 #
 # Each test ends with "PASS\n" on success. Gate fails if any test rc != 0
 # or stdout doesn't contain "PASS".
@@ -59,6 +63,8 @@ TESTS=(
   "biomaterial_release          stdlib/darwin_pbpk/release/biomaterial_release.sio"
   "rapamycin_clinical           stdlib/darwin_pbpk/validation/rapamycin_clinical.sio"
   "gum_vs_mc                    stdlib/darwin_pbpk/validation/gum_vs_mc.sio"
+  "des_sirolimus                stdlib/darwin_pbpk/scenarios/des_sirolimus.sio"
+  "rapamycin_pop_sim            stdlib/darwin_pbpk/population/pop_sim.sio"
 )
 
 fails=0

--- a/stdlib/darwin_pbpk/population/pop_sim.sio
+++ b/stdlib/darwin_pbpk/population/pop_sim.sio
@@ -24,7 +24,7 @@
 //
 // Author: Demetrios Chiuratto Agourakis
 
-use tsit5_pbpk14::*
+use darwin_pbpk::tsit5_pbpk14::*
 
 // ============================================================================
 // PSEUDO-RANDOM NUMBER GENERATOR (LCG)
@@ -62,7 +62,7 @@ fn rng_value(rng: RNG) -> f64 {
 // MATH HELPERS
 // ============================================================================
 
-fn ps_sqrt(x: f64) -> f64 {
+fn ps_sqrt(x: f64) -> f64 with Mut, Div {
     if x <= 0.0 { return 0.0 }
     var y = x
     var i = 0
@@ -75,7 +75,7 @@ fn ps_abs(x: f64) -> f64 {
     return x
 }
 
-fn ps_ln(x: f64) -> f64 {
+fn ps_ln(x: f64) -> f64 with Mut, Div {
     if x <= 0.0 { return 0.0 - 999999.0 }
     var sx = x
     var scale = 0
@@ -214,7 +214,7 @@ fn sort_f64(arr: [f64; 64], n: i32) -> [f64; 64] with Mut {
     return sorted
 }
 
-fn percentile(sorted: [f64; 64], n: i32, pct: f64) -> f64 {
+fn percentile(sorted: [f64; 64], n: i32, pct: f64) -> f64 with Mut, Div {
     if n <= 0 { return 0.0 }
     let nf = n as f64
     let rank = pct / 100.0 * (nf - 1.0)
@@ -232,7 +232,7 @@ fn percentile(sorted: [f64; 64], n: i32, pct: f64) -> f64 {
 // RAPAMYCIN PARAMETERS + PRIORS
 // ============================================================================
 
-fn pop_rapamycin_params() -> PBPKParams14 {
+fn pop_rapamycin_params() -> PBPKParams14 with Mut {
     var prm = default_pbpk_params()
     prm.cl_hepatic = 12.4
     prm.cl_renal = 0.3

--- a/stdlib/darwin_pbpk/scenarios/des_sirolimus.sio
+++ b/stdlib/darwin_pbpk/scenarios/des_sirolimus.sio
@@ -40,13 +40,13 @@
 //
 // Author: Demetrios Chiuratto Agourakis
 
-use tsit5_pbpk14::*
+use darwin_pbpk::tsit5_pbpk14::*
 
 // ============================================================================
 // MATH HELPERS
 // ============================================================================
 
-fn des_sqrt(x: f64) -> f64 {
+fn des_sqrt(x: f64) -> f64 with Mut, Div {
     if x <= 0.0 { return 0.0 }
     var y = x
     var i = 0
@@ -68,14 +68,14 @@ fn des_finite(x: f64) -> bool {
 // HIGUCHI RELEASE (inlined for self-containment)
 // ============================================================================
 
-fn higuchi_cumulative(kh: f64, total_dose: f64, t: f64) -> f64 {
+fn higuchi_cumulative(kh: f64, total_dose: f64, t: f64) -> f64 with Mut, Div {
     if t <= 0.0 { return 0.0 }
     let q = kh * des_sqrt(t)
     if q > total_dose { return total_dose }
     return q
 }
 
-fn higuchi_step_amount(kh: f64, total_dose: f64, t: f64, dt: f64) -> f64 {
+fn higuchi_step_amount(kh: f64, total_dose: f64, t: f64, dt: f64) -> f64 with Mut, Div {
     let q_before = higuchi_cumulative(kh, total_dose, t)
     let q_after = higuchi_cumulative(kh, total_dose, t + dt)
     return q_after - q_before
@@ -170,7 +170,7 @@ fn des_simulate(
 // RAPAMYCIN PARAMETERS
 // ============================================================================
 
-fn des_rapamycin_params() -> PBPKParams14 {
+fn des_rapamycin_params() -> PBPKParams14 with Mut {
     var prm = default_pbpk_params()
     prm.cl_hepatic = 12.4
     prm.cl_renal = 0.3


### PR DESCRIPTION
## Summary

Two more dissertation library files into `dissertation_pbpk_suite`:

- **des_sirolimus** (596 lines, 8 tests) — extended Cypher DES with cross-domain uncertainty (release × PK). Release-domain uncertainty dominates 30:1 over PK-domain.
- **rapamycin_pop_sim** (543 lines, 6 tests) — 32 virtual patients with lognormal CL/fu/Kp variability (Ferron 1997 / Schreiber 1991 / Lampen 1998). Closes "population simulation" gap from dissertation 6-gap list.

Each needed (1) qualified import (sub-dirs need `darwin_pbpk::tsit5_pbpk14`); (2) effect declarations on math helpers + struct-init factories.

## Gate result (10/10 PASS)

```
rapamycin_iso_budget          rapamycin_rk4_budget
rapamycin_epistemic_pbpk      rapamycin_epistemic_adaptive
rapamycin_gum_vs_mc           biomaterial_release
rapamycin_clinical            gum_vs_mc
des_sirolimus      ← NEW      rapamycin_pop_sim  ← NEW
```

## Test plan

- [x] `bash scripts/ci/dissertation_pbpk_suite_gate.sh` → 10/10 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)