### PR TITLE
[ci] dissertation gate: haloperidol/D2 layer (14 tests)

### DIFF
--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # scripts/ci/dissertation_pbpk_suite_gate.sh
 #
-# Dissertation evidence gate: rapamycin (sirolimus) PBPK validation suite.
+# Dissertation evidence gate: PBPK validation suite (rapamycin + haloperidol).
 #
-# Ten independent rapamycin tests cover the dissertation's applied PBPK
-# layer — the *evidence* that the three core contributions (GUM-through-ODE,
-# compile-time confidence, ISO budgets) actually work on a real drug:
+# 14 independent tests cover the dissertation's applied PBPK layer — the
+# *evidence* that the three core contributions (GUM-through-ODE, compile-time
+# confidence, ISO budgets) actually work on real drugs:
 #
+# Rapamycin (sirolimus) — primary dissertation drug:
 #   1. rapamycin_iso_budget        Euler 3-comp, ISO §8 budget, IV bolus 6 mg
 #   2. rapamycin_rk4_budget        RK4 3-comp, GUM through 4-stage RK
 #   3. rapamycin_epistemic_pbpk    BBB/Pgp clinical claims, AUC-CV, CL inverse
@@ -15,12 +16,19 @@
 #   6. biomaterial_release         Cypher DES — zero/first-order/Higuchi + 14-comp PBPK
 #   7. rapamycin_clinical          14-comp clinical validation: brain/blood ratio,
 #                                  Vd_ss, GUM budget vs Lampen 1998, Schreiber 1991
-#   8. gum_vs_mc                   ISO budget vs Monte-Carlo: 5x cost advantage,
-#                                  parameter-level attribution, CV=20% vs CV=60%
-#   9. des_sirolimus               Cypher DES extended scenario: epistemic ep_des_run
-#                                  with cross-domain uncertainty (release + PK)
-#  10. rapamycin_pop_sim           Population simulation: 32 virtual patients
-#                                  with lognormal CL/fu/Kp variability + percentile
+#   8. gum_vs_mc                   ISO budget vs Monte-Carlo: 5x cost advantage
+#   9. des_sirolimus               Cypher DES extended scenario: cross-domain GUM
+#  10. rapamycin_pop_sim           32 virtual patients with lognormal CL/fu/Kp
+#
+# Haloperidol — second drug for cross-validation of method generality:
+#  11. haloperidol_d2_pet          D2 receptor occupancy via PET, Hill-Langmuir
+#                                  saturation, therapeutic-window vs EPS-threshold
+#  12. haloperidol_oral_pbpk       Oral PBPK with repeated dosing, CYP3A4-CYP2D6
+#                                  metabolism, CNS coverage projection
+#  13. d2_gum                      D2 receptor PD: GUM uncertainty over kpuu_brain,
+#                                  ps_bbb permeability, mixed-evidence confidence
+#  14. d2_voi                      D2 value-of-information: which experiment to
+#                                  prioritize given current PK/PD evidence
 #
 # Each test ends with "PASS\n" on success. Gate fails if any test rc != 0
 # or stdout doesn't contain "PASS".
@@ -65,6 +73,10 @@ TESTS=(
   "gum_vs_mc                    stdlib/darwin_pbpk/validation/gum_vs_mc.sio"
   "des_sirolimus                stdlib/darwin_pbpk/scenarios/des_sirolimus.sio"
   "rapamycin_pop_sim            stdlib/darwin_pbpk/population/pop_sim.sio"
+  "haloperidol_d2_pet           stdlib/darwin_pbpk/validation/haloperidol_d2_pet.sio"
+  "haloperidol_oral_pbpk        stdlib/darwin_pbpk/validation/haloperidol_oral_pbpk.sio"
+  "d2_gum                       stdlib/darwin_pbpk/pd/d2_gum.sio"
+  "d2_voi                       stdlib/darwin_pbpk/pd/d2_voi.sio"
 )
 
 fails=0

--- a/stdlib/darwin_pbpk/pd/d2_voi.sio
+++ b/stdlib/darwin_pbpk/pd/d2_voi.sio
@@ -169,7 +169,7 @@ pub fn d2_voi_print(v: D2VoI, budget: D2GUMBudget) with IO, Mut, Panic, Div {
         let pdx = p as usize
         let rank_k = (k + 1) as i64
         print("  ")
-        print_i64(rank_k);                             print("    | ")
+        print_int(rank_k);                             print("    | ")
         print(d2voi_param_name(p));                    print(" | ")
         print_f64(v.share[pdx] * 100.0);              print(" | ")
         print_f64(v.confidence[pdx]);                  print(" | ")


### PR DESCRIPTION
## Summary

Extends `dissertation_pbpk_suite` from 10→14 tests by wiring the haloperidol/D2-receptor PD layer. Cross-validates the dissertation's metrology machinery on a second drug with a different PK profile.

| # | Test | Coverage |
|---|---|---|
| 11 | haloperidol_d2_pet | D2 PET, Hill-Langmuir, therapeutic window vs EPS |
| 12 | haloperidol_oral_pbpk | Oral PBPK, multi-dose, CYP3A4/CYP2D6 |
| 13 | d2_gum | GUM over kpuu_brain + ps_bbb (mixed-evidence) |
| 14 | d2_voi | Value-of-info: which experiment to prioritize |

Source fix: `print_i64` → `print_int` (Sounio builtin) in `d2_voi.sio:172`.

## Gate result (14/14 PASS)

```
Rapamycin (10):  iso_budget · rk4_budget · epistemic_pbpk · epistemic_adaptive ·
                 gum_vs_mc · biomaterial_release · rapamycin_clinical ·
                 gum_vs_mc(validation) · des_sirolimus · pop_sim
Haloperidol (4): d2_pet · oral_pbpk · d2_gum · d2_voi   ← NEW
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)