### PR TITLE
[ci] dissertation gate: add 5 example demos (19 tests)

### DIFF
--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -77,6 +77,11 @@ TESTS=(
   "haloperidol_oral_pbpk        stdlib/darwin_pbpk/validation/haloperidol_oral_pbpk.sio"
   "d2_gum                       stdlib/darwin_pbpk/pd/d2_gum.sio"
   "d2_voi                       stdlib/darwin_pbpk/pd/d2_voi.sio"
+  "dissertation_pbpk_rapamycin  examples/dissertation_pbpk_rapamycin.sio"
+  "dissertation_oral_pd         examples/dissertation_oral_pd_demo.sio"
+  "dissertation_steady_state    examples/dissertation_steady_state_demo.sio"
+  "dissertation_steady_state_fullvd examples/dissertation_steady_state_fullvd_demo.sio"
+  "dissertation_scenario_gate   examples/dissertation_scenario_gate_demo.sio"
 )
 
 fails=0
@@ -111,7 +116,7 @@ for entry in "${TESTS[@]}"; do
     continue
   fi
 
-  if ! grep -qE "^PASS$|ALL [0-9]+ TESTS PASSED" "$log"; then
+  if ! grep -qE "^PASS$|^ALL PASS$|ALL [0-9]+ TESTS PASSED|^ *(DEMO|SS DEMO|SS FULLVD|SCENARIO GATE|PK/PD DEMO) OK$" "$log"; then
     echo "  FAIL: no PASS marker in stdout"
     tail -5 "$log" | sed 's/^/    /'
     fails=$((fails + 1))

--- a/stdlib/darwin_pbpk/drugs/rapamycin.sio
+++ b/stdlib/darwin_pbpk/drugs/rapamycin.sio
@@ -29,7 +29,7 @@
 //     0.65-0.80: replicated in vivo, n>30, consistent
 //     0.80-0.95: meta-analysis or regulatory submission-grade data
 
-use tsit5_pbpk14::*;
+use darwin_pbpk::tsit5_pbpk14::*;
 
 // ============================================================================
 // MATH HELPERS (local, to avoid relying on import availability)


### PR DESCRIPTION
## Summary

Final round of dissertation surface coverage. Wires the 5 runnable `examples/dissertation_*.sio` demos into `dissertation_pbpk_suite`, growing it from 14→19 tests.

| # | Test | Marker |
|---|---|---|
| 15 | dissertation_pbpk_rapamycin | `ALL PASS` |
| 16 | dissertation_oral_pd | `PK/PD DEMO OK` |
| 17 | dissertation_steady_state | `SS DEMO OK` |
| 18 | dissertation_steady_state_fullvd | `SS FULLVD OK` |
| 19 | dissertation_scenario_gate | `SCENARIO GATE OK` |

### Source fix

`stdlib/darwin_pbpk/drugs/rapamycin.sio` used bare `use tsit5_pbpk14::*` which resolved to a missing `self-hosted/tsit5_pbpk14.sio` from sub-directory context. Switched to qualified `darwin_pbpk::tsit5_pbpk14::*`. This unblocked four transitively-importing demos.

### PASS-regex broadening

Gate now accepts additional dissertation-demo markers (`DEMO OK`, `SS DEMO OK`, `SS FULLVD OK`, `SCENARIO GATE OK`, `PK/PD DEMO OK`, `ALL PASS`) on top of `^PASS$` and `ALL N TESTS PASSED`.

### Out of scope

Three dissertation examples (`dissertation_demo`, `dissertation_interactive`, `dissertation_plot`) have unknown-identifier errors from removed APIs. They need substantive rewrites — not just import/effect fixes.

## Gate result (19/19 PASS)

```
Rapamycin core (5):     iso_budget · rk4_budget · epistemic_pbpk · epistemic_adaptive · gum_vs_mc
Rapamycin extended (5): biomaterial_release · rapamycin_clinical · gum_vs_mc · des_sirolimus · pop_sim
Haloperidol (4):        d2_pet · oral_pbpk · d2_gum · d2_voi
Dissertation demos (5): pbpk_rapamycin · oral_pd · steady_state · steady_state_fullvd · scenario_gate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)