### PR TITLE
[ci] dissertation gate: revive 3 stale demos as smoke tests (22)

### DIFF
--- a/examples/dissertation_demo.sio
+++ b/examples/dissertation_demo.sio
@@ -447,8 +447,8 @@ fn main() with IO, Mut, Div, Panic {
     else { println("    Result:     FAIL") }
     print("    Worst CV:   "); print_val(clinical_worst_cv); print("% at t=")
     print_val(clinical_worst_t); println(" h")
-    print("    Violations: "); print_i64(n_violations); print(" / ")
-    print_i64(n_rec - 1); println(" time points")
+    print("    Violations: "); print_int(n_violations); print(" / ")
+    print_int(n_rec - 1); println(" time points")
     println("")
 
     var strict_pass = true
@@ -467,8 +467,8 @@ fn main() with IO, Mut, Div, Panic {
     println("  GATE 2: STRICT (max CV = 5%)")
     if strict_pass { println("    Result:     PASS") }
     else { println("    Result:     FAIL") }
-    print("    Violations: "); print_i64(strict_violations); print(" / ")
-    print_i64(n_rec - 1); println(" time points")
+    print("    Violations: "); print_int(strict_violations); print(" / ")
+    print_int(n_rec - 1); println(" time points")
 
     // ══════════════════════════════════════════════════════════════════
     // CONTRIBUTION 3: ISO Uncertainty Budget

--- a/examples/dissertation_interactive.sio
+++ b/examples/dissertation_interactive.sio
@@ -22,7 +22,7 @@ fn sqrt64(x: f64) -> f64 with Mut {
 fn min64(a: f64, b: f64) -> f64 { if a < b { a } else { b } }
 
 fn pf(v: f64) with IO { print_f64(v) }
-fn pi(v: i64) with IO { print_i64(v) }
+fn pi(v: i64) with IO { print_int(v) }
 
 // ── Data types (same as other demos) ──
 struct EState { values: [f64; 64], variances: [f64; 64], n: i64 }

--- a/examples/dissertation_plot.sio
+++ b/examples/dissertation_plot.sio
@@ -33,8 +33,6 @@ fn print_xy(x: f64, y: f64) with IO {
     print_f64(x); print(","); print_f64(y)
 }
 
-fn print_int(v: i64) with IO { print_i64(v) }
-
 // ── Data types ──
 
 struct EState { values: [f64; 64], variances: [f64; 64], n: i64 }
@@ -257,7 +255,7 @@ fn main() with IO, Mut, Div, Panic {
         println("\" stroke=\"#e8e8e8\" stroke-width=\"1\"/>")
         print("<text x=\""); print_f64(gx); print("\" y=\""); print_f64(py + ph + 16.0)
         print("\" text-anchor=\"middle\" font-size=\"10\" fill=\"#666\">")
-        print_i64(g * 4); println("</text>")
+        print_int(g * 4); println("</text>")
         g = g + 1
     }
 
@@ -329,8 +327,6 @@ fn main() with IO, Mut, Div, Panic {
     println("\" fill=\"none\" stroke=\"#e41a1c\" stroke-width=\"2.5\"/>")
 
     // ── Legend ──
-    let lx = px + pw - 160
-    let ly = py + 15
     println("<rect x=\"620\" y=\"50\" width=\"150\" height=\"100\" fill=\"white\" fill-opacity=\"0.9\" stroke=\"#ccc\" rx=\"4\"/>")
 
     print("<line x1=\"630\" y1=\"70\" x2=\"650\" y2=\"70\" stroke=\"#e41a1c\" stroke-width=\"2.5\"/>")

--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -84,6 +84,16 @@ TESTS=(
   "dissertation_scenario_gate   examples/dissertation_scenario_gate_demo.sio"
 )
 
+# Smoke entries: artifact-emitting demos (HTML, SVG, narrative reports).
+# These don't have PASS markers because they aren't test runners — they
+# render dissertation visuals for figures/appendices. Gate only checks
+# rc=0 and that stdout has at least 100 bytes.
+TESTS_SMOKE=(
+  "dissertation_demo            examples/dissertation_demo.sio"
+  "dissertation_interactive     examples/dissertation_interactive.sio"
+  "dissertation_plot            examples/dissertation_plot.sio"
+)
+
 fails=0
 results=()
 
@@ -128,6 +138,51 @@ for entry in "${TESTS[@]}"; do
   results+=("PASS  $name")
 done
 
+# Smoke tests: dissertation visualisation/narrative demos. rc=0 + non-trivial
+# output. No PASS marker required.
+for entry in "${TESTS_SMOKE[@]}"; do
+  name="${entry%% *}"
+  src="${entry##* }"
+  log="$STAGE_DIR/$name.log"
+
+  echo ""
+  echo "[$name] (smoke)"
+  echo "  src=$src"
+
+  if [[ ! -f "$src" ]]; then
+    echo "  FAIL: source missing"
+    fails=$((fails + 1))
+    results+=("FAIL  $name  source_missing")
+    continue
+  fi
+
+  set +e
+  timeout "$TIMEOUT_SECONDS" "$SOUC_BIN" run "$src" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  if [[ $rc -ne 0 ]]; then
+    echo "  FAIL: rc=$rc (timeout=$TIMEOUT_SECONDS)"
+    tail -5 "$log" | sed 's/^/    /'
+    fails=$((fails + 1))
+    results+=("FAIL  $name  rc=$rc")
+    continue
+  fi
+
+  out_bytes=$(wc -c < "$log")
+  if [[ $out_bytes -lt 100 ]]; then
+    echo "  FAIL: output too short ($out_bytes bytes < 100)"
+    fails=$((fails + 1))
+    results+=("FAIL  $name  short_output")
+    continue
+  fi
+
+  echo "  PASS (rc=0, ${out_bytes}B emitted, log=$log)"
+  results+=("PASS  $name (smoke)")
+done
+
+total=$((${#TESTS[@]} + ${#TESTS_SMOKE[@]}))
+
 echo ""
 echo "=== Summary ==="
 for r in "${results[@]}"; do
@@ -136,9 +191,9 @@ done
 
 if [[ $fails -ne 0 ]]; then
   echo ""
-  echo "dissertation_pbpk_suite_gate: FAIL ($fails / ${#TESTS[@]} tests failed)"
+  echo "dissertation_pbpk_suite_gate: FAIL ($fails / $total tests failed)"
   exit 1
 fi
 
 echo ""
-echo "dissertation_pbpk_suite_gate: PASS (${#TESTS[@]}/${#TESTS[@]} rapamycin PBPK tests)"
+echo "dissertation_pbpk_suite_gate: PASS ($total/$total rapamycin PBPK tests + smoke demos)"


### PR DESCRIPTION
## Summary

Three previously-broken dissertation examples revived and added to `dissertation_pbpk_suite` as smoke tests. Now 22 total entries cover the full dissertation evidence + visualisation surface.

### Source fixes

| File | Fix |
|---|---|
| `dissertation_demo.sio` | 4× `print_i64` → `print_int` |
| `dissertation_interactive.sio` | `pi()` wrapper called nonexistent `print_i64` |
| `dissertation_plot.sio` | (a) deleted recursive user redef of `print_int`; (b) removed dead `lx`/`ly` vars mixing f64+i64 |

### Smoke-test mode

Demos emit artifacts (HTML, SVG, narrative reports), not test claims. New `TESTS_SMOKE` list checks `rc=0 AND output ≥ 100 bytes` instead of requiring a PASS marker.

| Demo | Artifact |
|---|---|
| `dissertation_demo` | 142-line text narrative for thesis appendices |
| `dissertation_interactive` | HTML + JS dashboard |
| `dissertation_plot` | 11kB SVG (plasma/liver/kidney/fat + 95% GUM CI) |

## Gate result (22/22 PASS)

```
TESTS         (19)  Rapamycin (10) + Haloperidol (4) + dissertation demos (5)
TESTS_SMOKE   (3)   dissertation_demo · dissertation_interactive · dissertation_plot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)