### PR TITLE
[lane-3] k=6 chingon subspace decomposition (16 cocycle classes)

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -410,3 +410,32 @@ checks:
   - sweep inventory: rapamycin_iso_budget.sio (fixed in PR #98), rapamycin_rk4_budget.sio (fixed here), rapamycin_clinical.sio (already complete), rapamycin_epistemic_adaptive.sio (no budget claim, skip), rapamycin_gum_vs_mc.sio (intentional .value in MC sampling, skip), gum_vs_mc.sio (intentional, skip), des_sirolimus*.sio (no empty budget, skip), pop_sim.sio (no empty budget, skip), steady_state_runner.sio (no empty budget, skip)
 commit: pending
 status: lock-released
+
+---
+
+agent: claude
+lane: 3
+time_utc: 2026-05-10T16:00:00Z
+files:
+  - examples/cocycle_subspace_k6.sio (NEW)
+  - docs/papers/main/168-theorem.typ
+  - docs/papers/main/168-revision-notes.md
+intent: Lane 3 CLAIM — extend cohomological subspace decomposition to k=6 (chingons, dim 64). Per Revised OQ1 in §7 of paper 168 (just merged in PR #92), the next computational step is to enumerate the 1395 = P_6 three-dimensional subspaces of (Z/2)^6 and tally per-subspace nonzero associator counts. Predicted T_6 = 168 * 775 = 130200. Will reveal whether the 7-class distribution at k=5 simplifies, complicates, or generalizes structurally.
+status: lock-acquired
+
+---
+
+agent: claude
+lane: 3
+time_utc: 2026-05-10T16:45:00Z
+files:
+  - examples/cocycle_subspace_k6.sio (NEW)
+  - docs/papers/main/168-theorem.typ
+  - docs/papers/main/168-revision-notes.md
+intent: Lane 3 RELEASE — k=6 chingon subspace decomposition delivered. T_6 = 130200 confirmed; 1395 = P_6 subspaces enumerated; **16 distinct count classes** found (vs 7 at k=5, 2 at k=4). Three super-octonionic classes (180/184/188) emerge at k=6 with mult 21 each. Principal anomaly: count=168 mult=247=13·19, not 7-divisible — flagged as the orbit family the classification must explain. Section 7 of paper 168 now carries @table:subspace-k6 plus updated implications. Build target green.
+checks:
+  - bin/souc check examples/cocycle_subspace_168.sio (rc=0)
+  - bin/souc compile examples/cocycle_subspace_k5.sio -o /tmp/k5 && /tmp/k5 (ALL PASS)
+  - bin/souc compile examples/cocycle_subspace_k6.sio -o /tmp/k6 && /tmp/k6 (ALL PASS)
+commit: pending
+status: lock-released

--- a/docs/papers/main/168-revision-notes.md
+++ b/docs/papers/main/168-revision-notes.md
@@ -268,3 +268,59 @@ The three risks initially raised have been retired:
    Bremner-Hentzel) or (b) directly verified by computation (`@table:subspace`,
    `@table:subspace-k5`, the closed-form $T_k$ identity). No speculative
    interpretation remains in the section that could embarrass on review.
+
+---
+
+## Revision 3.1 — Lane 3 follow-up: k=6 chingon distribution (2026-05-10)
+
+Lane 3 of the 6-agent overlay added the third data point requested by
+Revised Open Question 1 of Section 7: per-subspace nonzero associator
+counts in the 64-dimensional chingon algebra.
+
+### What's new
+
+- `examples/cocycle_subspace_k6.sio` (NEW). Builds the 64×64 chingon basis
+  multiplication table via three CD doublings (𝕆→𝕊→𝕋→𝕮). Enumerates the
+  1395 = P_6 three-dimensional subspaces of (ℤ/2)⁶ by canonical lex-minimal
+  LI triples of dual functionals (V is codim-3 at k=6, so canonical
+  enumeration requires triples not pairs). 2/2 PASS, T_6 = 130200 confirmed.
+- `@table:subspace-k6` added to Section 7. The third data point in the
+  Conjecture 5 cocycle classification.
+
+### Empirical findings
+
+**16 distinct count classes** at k=6 (vs 7 at k=5, 2 at k=4, 1 at k=3):
+
+| Count | Mult. | Count | Mult. |
+|---:|---:|---:|---:|
+| 188 | 21 | 96 | 112 |
+| 184 | 21 | 94 | 84 |
+| 180 | 21 | 92 | 84 |
+| 168 | 247 | 90 | 63 |
+| 108 | 84 | 88 | 273 |
+| 104 | 21 | 84 | 21 |
+| 100 | 21 | 76 | 252 |
+| 98 | 21 | 72 | 49 |
+
+Notable observations:
+- Class count grows superlinearly: **1 → 2 → 7 → 16** across k=3→6.
+- Three super-octonionic classes (counts 180, 184, 188) at k=6, each with
+  multiplicity 21. At k=5 there was only one super-octonionic class
+  (count=180, mult=7). Super-octonionic structure proliferates with k.
+- Most multiplicities at k=6 are divisible by 7 or 21 (consistent with
+  PSL(2,7)-orbit derivation), with one anomaly: **count=168 at multiplicity
+  247 = 13·19**, NOT divisible by 7. This is the principal anomaly the
+  classification must explain.
+- Sum across classes: 149016 = T_6 + 18816, with overcount 18816 = 112·168.
+  Pattern across k: overcount/168 = 1, 12, 112 at k=4, 5, 6 (factor ~10× per step).
+- Counts span 72 to 188 (vs 76-180 at k=5, 96-168 at k=4); spread widens
+  with k, consistent with richer cocycle obstruction structure.
+
+### Status
+
+- T_3, T_4, T_5, T_6 all numerically confirmed against Conjecture 5 closed
+  form 168·(2^{k−1}−1)(2^{k−2}−1)(2^{k−1}+3)/21.
+- Revised Open Question 1 now has three empirical inputs (k=4, 5, 6) for
+  cocycle restriction class enumeration.
+- Lane 3 build target green: cocycle_subspace_168.sio rc=0,
+  cocycle_subspace_k5.sio PASS, cocycle_subspace_k6.sio PASS.

--- a/docs/papers/main/168-theorem.typ
+++ b/docs/papers/main/168-theorem.typ
@@ -327,6 +327,28 @@ The same enumeration extended to the trigintaduonions ($k = 5$) reveals that the
 
 Salient features of @table:subspace-k5: the multiplicities $(7, 43, 7, 35, 21, 21, 21)$ are integers dividing or divisible by $7 = $ rank of $"PSL"(2,7)$ acting on Fano points, suggesting an underlying orbit structure; one class has count $180 > 168$, demonstrating that some 3-dimensional subspaces of trigintaduonions carry *more* nonzero basis associators than the pure octonion subalgebra (a phenomenon impossible in alternative algebras and absent at $k = 4$). Sum of LI nonzero counts across the seven classes: $7 dot 180 + 43 dot 168 + 7 dot 108 + 35 dot 96 + 21 dot 92 + 21 dot 88 + 21 dot 76 = 17976 = T_5 + 2016$, with the overcount $2016 = 12 dot 168 = 36 dot 56$ corresponding to a structured set of non-LI nonzero triples in trigintaduonions.
 
+The same enumeration carried one further level up the tower to the chingons ($k = 6$, $dim = 64$) gives the third data point. Of the $P_6 = 1395$ three-dimensional subspaces of $(ZZ slash 2)^6$, the per-subspace counts span *sixteen* distinct values:
+
+#figure(
+  table(
+    columns: 4,
+    align: (center, center, center, center),
+    stroke: 0.5pt,
+    [*Count*], [*Multiplicity*], [*Count*], [*Multiplicity*],
+    [188], [21], [96], [112],
+    [184], [21], [94], [84],
+    [180], [21], [92], [84],
+    [168], [247], [90], [63],
+    [108], [84], [88], [273],
+    [104], [21], [84], [21],
+    [100], [21], [76], [252],
+    [98], [21], [72], [49],
+  ),
+  caption: [Distribution of nonzero basis associator counts at $k = 6$, exhaustive over all $1395$ three-dimensional subspaces of $(ZZ slash 2)^6$. Verified in Sounio (`examples/cocycle_subspace_k6.sio`).],
+) <table:subspace-k6>
+
+The class count grows superlinearly across the tower: $1$ class at $k = 3$, $2$ at $k = 4$, $7$ at $k = 5$, $16$ at $k = 6$. At $k = 6$ the spread of counts widens (from $72$ to $188$); three super-octonionic classes (counts $180, 184, 188$) emerge with multiplicity $21$ each. Most multiplicities at $k = 6$ are divisible by $7$ or $21$ (consistent with $"PSL"(2,7)$-orbit structure), with the notable exception of count $168$ at multiplicity $247 = 13 dot 19$, which suggests a contribution from a different orbit family. The sum across all sixteen classes is $149016 = T_6 + 18816$ with overcount $18816 = 112 dot 168$.
+
 == Implications
 
 1. *Conjecture 5 is structurally richer than its compact form $T_k = 168(P_k - 4 P_(k-1))$ suggests.* The simple "subtract trivial subspaces" interpretation is empirically false: at $k = 5$ no 3-dimensional subspace carries the trivial cocycle, and the per-subspace counts span seven distinct values. The arithmetic identity $T_k = 168(P_k - 4 P_(k-1))$ is therefore a *cohomological balance*, with positive contributions from "super-octonionic" subspaces (e.g. count $180$ at $k = 5$) cancelling against partial-cocycle subspaces (counts below 168). A complete proof must enumerate the cocycle restriction classes and weight them with their LI nonzero contributions, recovering the closed form $T_k = 168 dot (2^(k-1) - 1)(2^(k-2) - 1)(2^(k-1) + 3) slash 21$.
@@ -344,7 +366,7 @@ This is the natural categorical home for the algebras and organizes the Sounio c
   *Revised Open Question 1.* _Classify the cocycle restriction classes that arise as $phi_k|_V$ for 3-dimensional subspaces $V <= (ZZ slash 2)^k$, with their multiplicities, and prove Conjecture 5 by weighting each class by its LI nonzero associator count._
 ]
 
-@table:subspace and @table:subspace-k5 supply the first two empirical inputs for this classification. The multiplicities $(8, 7)$ at $k = 4$ and $(7, 43, 7, 35, 21, 21, 21)$ at $k = 5$ — all multiples of common Fano-orbit cardinalities — strongly suggest an orbit-counting derivation under the $"GL"(k, FF_2)$ action lifting the canonical $"PSL"(2,7)$-action on the Fano cocycle.
+@table:subspace, @table:subspace-k5, and @table:subspace-k6 supply three empirical inputs for this classification. The multiplicities at $k = 4, 5, 6$ are predominantly multiples of $7$ and $21$, consistent with an orbit-counting derivation under the $"GL"(k, FF_2)$ action lifting the canonical $"PSL"(2,7)$-action on the Fano cocycle. The exception at $k = 6$ — count $168$ at multiplicity $247 = 13 dot 19$ — is the principal anomaly to explain: a complete classification must identify the orbit family producing this specific non-7-divisible contribution.
 
 == Computational verification of the cohomological construction
 
@@ -353,5 +375,6 @@ The cohomological reformulation is computationally validated in Sounio:
 - `examples/phi_fano_cohomological.sio` — implements $phi_("Fano")$ via $"tr"(y dot x^6)$ over $FF_8$ from scratch, defines basis multiplication $e_x dot e_y = (-1)^(phi(x, y)) e_(x xor y)$, and verifies that the resulting algebra satisfies (i) 168 nonzero basis associators, (ii) norm dichotomy ${0, 2}$, (iii) alternativity (7/7 PASS).
 - `examples/cocycle_subspace_168.sio` — enumerates the 15 three-dimensional subspaces of $(ZZ slash 2)^4$ via dual functionals, computes per-subspace associator counts using the Cayley–Dickson sedenion table, produces @table:subspace.
 - `examples/cocycle_subspace_k5.sio` — extends to trigintaduonions; enumerates the 155 three-dimensional subspaces of $(ZZ slash 2)^5$ via canonical pairs of dual functionals, produces @table:subspace-k5 (2/2 PASS, $T_5 = 15960$ confirmed).
+- `examples/cocycle_subspace_k6.sio` — extends to chingons (dim $64$); enumerates the 1395 three-dimensional subspaces of $(ZZ slash 2)^6$ via canonical lex-minimal LI triples of dual functionals, produces @table:subspace-k6 (2/2 PASS, $T_6 = 130200$ confirmed).
 
 #bibliography("168-refs.yml", style: "springer-mathphys")

--- a/examples/cocycle_subspace_k6.sio
+++ b/examples/cocycle_subspace_k6.sio
@@ -1,0 +1,486 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cohomological subspace decomposition at k=6 (chingons, dim 64)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Lane 3 of the 6-agent overlay. Extends cocycle_subspace_k5.sio (which
+// revealed a 7-class distribution at k=5) one further level up the
+// Cayley-Dickson tower, enumerating the 1395 = P_6 three-dimensional
+// subspaces of (Z/2)^6 in the 64-dim chingon algebra.
+//
+// Predicted total: T_6 = 168 * (P_6 - 4 * P_5) = 168 * 775 = 130200.
+//
+// The third data point (k=4: 3 classes, k=5: 7 classes, k=6: ?) feeds
+// the Revised Open Question 1 of paper 168 §7: classify the cocycle
+// restriction classes that arise as phi_k|_V and prove Conjecture 5
+// by weighting each class by its LI nonzero associator count.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Octonion multiplication table.
+var O_MUL: [i64; 64] = [0; 64]
+var O_SGN: [i64; 64] = [0; 64]
+
+fn init_oct() with Mut {
+    var i = 0
+    while i < 8 {
+        O_MUL[0 * 8 + i] = i
+        O_SGN[0 * 8 + i] = 1
+        O_MUL[i * 8 + 0] = i
+        O_SGN[i * 8 + 0] = 1
+        i = i + 1
+    }
+    i = 1
+    while i < 8 {
+        O_MUL[i * 8 + i] = 0
+        O_SGN[i * 8 + i] = 0 - 1
+        i = i + 1
+    }
+    var FA: [i64; 7] = [1, 2, 3, 4, 5, 6, 7]
+    var FB: [i64; 7] = [2, 3, 4, 5, 6, 7, 1]
+    var FC: [i64; 7] = [4, 5, 6, 7, 1, 2, 3]
+    var t = 0
+    while t < 7 {
+        let a = FA[t]
+        let b = FB[t]
+        let c = FC[t]
+        O_MUL[a * 8 + b] = c
+        O_SGN[a * 8 + b] = 1
+        O_MUL[b * 8 + a] = c
+        O_SGN[b * 8 + a] = 0 - 1
+        O_MUL[b * 8 + c] = a
+        O_SGN[b * 8 + c] = 1
+        O_MUL[c * 8 + b] = a
+        O_SGN[c * 8 + b] = 0 - 1
+        O_MUL[c * 8 + a] = b
+        O_SGN[c * 8 + a] = 1
+        O_MUL[a * 8 + c] = b
+        O_SGN[a * 8 + c] = 0 - 1
+        t = t + 1
+    }
+}
+
+var S_MUL: [i64; 256] = [0; 256]
+var S_SGN: [i64; 256] = [0; 256]
+var T_MUL: [i64; 1024] = [0; 1024]
+var T_SGN: [i64; 1024] = [0; 1024]
+var C_MUL: [i64; 4096] = [0; 4096]
+var C_SGN: [i64; 4096] = [0; 4096]
+
+fn init_doublings() with Mut, Panic {
+    // Step 1: build S (sedenions, dim 16) from O (octonions, dim 8).
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            let a_part = i & 7
+            let top_a = i >> 3
+            let b_part = j & 7
+            let top_b = j >> 3
+            let ab_idx = O_MUL[a_part * 8 + b_part]
+            let ab_sgn = O_SGN[a_part * 8 + b_part]
+            let ba_idx = O_MUL[b_part * 8 + a_part]
+            let ba_sgn = O_SGN[b_part * 8 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            S_MUL[i * 16 + j] = r_idx + r_top * 8
+            S_SGN[i * 16 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 2: build T (trigintaduonions, dim 32) from S.
+    i = 0
+    while i < 32 {
+        var j = 0
+        while j < 32 {
+            let a_part = i & 15
+            let top_a = i >> 4
+            let b_part = j & 15
+            let top_b = j >> 4
+            let ab_idx = S_MUL[a_part * 16 + b_part]
+            let ab_sgn = S_SGN[a_part * 16 + b_part]
+            let ba_idx = S_MUL[b_part * 16 + a_part]
+            let ba_sgn = S_SGN[b_part * 16 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            T_MUL[i * 32 + j] = r_idx + r_top * 16
+            T_SGN[i * 32 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 3: build C (chingons, dim 64) from T.
+    i = 0
+    while i < 64 {
+        var j = 0
+        while j < 64 {
+            let a_part = i & 31
+            let top_a = i >> 5
+            let b_part = j & 31
+            let top_b = j >> 5
+            let ab_idx = T_MUL[a_part * 32 + b_part]
+            let ab_sgn = T_SGN[a_part * 32 + b_part]
+            let ba_idx = T_MUL[b_part * 32 + a_part]
+            let ba_sgn = T_SGN[b_part * 32 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            C_MUL[i * 64 + j] = r_idx + r_top * 32
+            C_SGN[i * 64 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+var CR_IDX: i64 = 0
+var CR_SGN: i64 = 0
+
+fn chi_bmul(i_idx: i64, i_sgn: i64, j_idx: i64, j_sgn: i64) with Mut, Panic {
+    CR_IDX = C_MUL[i_idx * 64 + j_idx]
+    CR_SGN = i_sgn * j_sgn * C_SGN[i_idx * 64 + j_idx]
+}
+
+fn chi_associator_nonzero(x: i64, y: i64, z: i64) -> i64 with Mut, Panic {
+    chi_bmul(x, 1, y, 1)
+    let li_t = CR_IDX
+    let ls_t = CR_SGN
+    chi_bmul(li_t, ls_t, z, 1)
+    let l_idx = CR_IDX
+    let l_sgn = CR_SGN
+    chi_bmul(y, 1, z, 1)
+    let ri_t = CR_IDX
+    let rs_t = CR_SGN
+    chi_bmul(x, 1, ri_t, rs_t)
+    let r_idx = CR_IDX
+    let r_sgn = CR_SGN
+    if l_idx != r_idx { return 1 }
+    if l_sgn != r_sgn { return 1 }
+    0
+}
+
+fn popcount_mod2(v: i64) -> i64 with Mut {
+    var p = 0
+    var w = v
+    while w > 0 {
+        p = p ^ (w & 1)
+        w = w >> 1
+    }
+    p
+}
+
+fn in_subspace(x: i64, c1: i64, c2: i64) -> i64 with Mut {
+    if popcount_mod2(c1 & x) != 0 { return 0 }
+    if popcount_mod2(c2 & x) != 0 { return 0 }
+    1
+}
+
+// 3-dim V at codim 3 (k=6): kernel of three LI functionals.
+fn in_subspace_3d(x: i64, c1: i64, c2: i64, c3: i64) -> i64 with Mut {
+    if popcount_mod2(c1 & x) != 0 { return 0 }
+    if popcount_mod2(c2 & x) != 0 { return 0 }
+    if popcount_mod2(c3 & x) != 0 { return 0 }
+    1
+}
+
+fn count_subspace_assoc_3d(c1: i64, c2: i64, c3: i64) -> i64 with Mut, Panic {
+    var n = 0
+    var i = 1
+    while i < 64 {
+        if in_subspace_3d(i, c1, c2, c3) == 1 {
+            var j = 1
+            while j < 64 {
+                if in_subspace_3d(j, c1, c2, c3) == 1 {
+                    var k = 1
+                    while k < 64 {
+                        if in_subspace_3d(k, c1, c2, c3) == 1 {
+                            if chi_associator_nonzero(i, j, k) == 1 {
+                                n = n + 1
+                            }
+                        }
+                        k = k + 1
+                    }
+                }
+                j = j + 1
+            }
+        }
+        i = i + 1
+    }
+    n
+}
+
+fn count_subspace_assoc_k6(c1: i64, c2: i64) -> i64 with Mut, Panic {
+    var n = 0
+    var i = 1
+    while i < 64 {
+        if in_subspace(i, c1, c2) == 1 {
+            var j = 1
+            while j < 64 {
+                if in_subspace(j, c1, c2) == 1 {
+                    var k = 1
+                    while k < 64 {
+                        if in_subspace(k, c1, c2) == 1 {
+                            if chi_associator_nonzero(i, j, k) == 1 {
+                                n = n + 1
+                            }
+                        }
+                        k = k + 1
+                    }
+                }
+                j = j + 1
+            }
+        }
+        i = i + 1
+    }
+    n
+}
+
+fn count_total_chi() -> i64 with Mut, Panic {
+    var n = 0
+    var i = 1
+    while i < 64 {
+        var j = 1
+        while j < 64 {
+            var k = 1
+            while k < 64 {
+                if chi_associator_nonzero(i, j, k) == 1 {
+                    n = n + 1
+                }
+                k = k + 1
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+// Distribution buckets — up to 16 distinct count values.
+var BUCKET_VAL: [i64; 32] = [0; 32]
+var BUCKET_CNT: [i64; 32] = [0; 32]
+var N_BUCKETS: i64 = 0
+
+fn record_bucket(v: i64) with Mut, Panic {
+    var i = 0
+    while i < N_BUCKETS {
+        if BUCKET_VAL[i] == v {
+            BUCKET_CNT[i] = BUCKET_CNT[i] + 1
+            return
+        }
+        i = i + 1
+    }
+    if N_BUCKETS < 32 {
+        BUCKET_VAL[N_BUCKETS] = v
+        BUCKET_CNT[N_BUCKETS] = 1
+        N_BUCKETS = N_BUCKETS + 1
+    }
+}
+
+fn main() -> i32 with IO, Mut, Panic {
+    println("═══════════════════════════════════════════════════════════════")
+    println("  Subspace decomposition at k=6 (chingons, dim 64)")
+    println("═══════════════════════════════════════════════════════════════")
+
+    init_oct()
+    init_doublings()
+
+    var pass = 0
+    var fail = 0
+
+    // 1. Sanity: total nonzero associators = T_6 = 168 * 775 = 130200.
+    let total = count_total_chi()
+    print("  Total chingon associators: ")
+    print_int(total)
+    print(" (expected 130200)\n")
+    if total == 130200 {
+        print("  [PASS] T_6 = 130200 = 775 * 168\n")
+        pass = pass + 1
+    } else {
+        print("  [FAIL] T_6 mismatch\n")
+        fail = fail + 1
+    }
+
+    // 2. Enumerate 1395 = P_6 three-dim subspaces V.
+    //    At k=6, V is codim-3, dual V^perp is 3-dim; we need TRIPLES of
+    //    LI functionals (c1, c2, c3). Canonical: (c1, c2, c3) is the
+    //    lex-smallest LI ordered basis of span(c1, c2, c3).
+    var seen = 0
+    var c1 = 1
+    while c1 < 64 {
+        var c2 = c1 + 1
+        while c2 < 64 {
+            let s12 = c1 ^ c2
+            var c3 = c2 + 1
+            while c3 < 64 {
+                if c3 != s12 {
+                    let s13 = c1 ^ c3
+                    let s23 = c2 ^ c3
+                    let s123 = c1 ^ c2 ^ c3
+                    // c1 smallest of all 7 nonzero span elements (auto since
+                    // c1 < c2 < c3, but s12 < c1 possible — check)
+                    var ok = 1
+                    if s12 < c1 { ok = 0 }
+                    if s13 < c1 { ok = 0 }
+                    if s23 < c1 { ok = 0 }
+                    if s123 < c1 { ok = 0 }
+                    // c2 smallest after c1 (already < c3; check not > s12 if s12 != c1)
+                    if s12 < c2 { ok = 0 }
+                    if s13 < c2 { ok = 0 }
+                    if s23 < c2 { ok = 0 }
+                    if s123 < c2 { ok = 0 }
+                    // c3 smallest of LI-to-{c1, c2} elements (s13, s23, s123)
+                    if s13 < c3 { ok = 0 }
+                    if s23 < c3 { ok = 0 }
+                    if s123 < c3 { ok = 0 }
+                    if ok == 1 {
+                        let cnt = count_subspace_assoc_3d(c1, c2, c3)
+                        record_bucket(cnt)
+                        seen = seen + 1
+                    }
+                }
+                c3 = c3 + 1
+            }
+            c2 = c2 + 1
+        }
+        c1 = c1 + 1
+    }
+    print("  Enumerated 3-dim subspaces: ")
+    print_int(seen)
+    print(" (expected 1395 = P_6)\n")
+    if seen == 1395 {
+        print("  [PASS] P_6 = 1395 enumerated correctly\n")
+        pass = pass + 1
+    } else {
+        print("  [FAIL] subspace enumeration count\n")
+        fail = fail + 1
+    }
+
+    // 3. Print distribution.
+    print("\n  Distribution of per-subspace nonzero associator counts:\n")
+    var i = 0
+    while i < N_BUCKETS {
+        print("    count=")
+        print_int(BUCKET_VAL[i])
+        print(" -> ")
+        print_int(BUCKET_CNT[i])
+        print(" subspaces\n")
+        i = i + 1
+    }
+    print("  Total distinct count classes: ")
+    print_int(N_BUCKETS)
+    print("\n")
+
+    print("\nPassed: ")
+    print_int(pass)
+    print("\nFailed: ")
+    print_int(fail)
+    print("\n")
+    if fail == 0 { println("ALL PASS") }
+    else { println("SOME FAILED") }
+    0
+}


### PR DESCRIPTION
## Summary

Lane 3 deliverable: third empirical input for Revised Open Question 1 of Section 7 (paper 168, merged in PR #92). Adds k=6 chingon subspace decomposition.

- $T_6 = 130200$ confirmed.
- $P_6 = 1395$ subspaces enumerated via canonical lex-minimal LI triples of dual functionals.
- **16 distinct count classes** appear (vs 7 at k=5, 2 at k=4).
- Three super-octonionic classes (counts 180, 184, 188), multiplicity 21 each.
- Principal anomaly: count=168 at multiplicity 247 = 13·19 (not 7-divisible).

## Class growth across the tower

| k | Algebra | dim | T_k | # subspaces (P_k) | # distinct classes |
|---:|---|---:|---:|---:|---:|
| 3 | 𝕆 | 8 | 168 | 1 | 1 |
| 4 | 𝕊 | 16 | 1848 | 15 | 2 |
| 5 | 𝕋 | 32 | 15960 | 155 | 7 |
| 6 | 𝕮 | 64 | 130200 | 1395 | **16** |

## Files changed

- `examples/cocycle_subspace_k6.sio` (new, 486 lines).
- `docs/papers/main/168-theorem.typ` — `@table:subspace-k6` added; implications updated.
- `docs/papers/main/168-revision-notes.md` — Revision 3.1 entry.
- `artifacts/omega/agent_handoff.log.md` — Lane 3 CLAIM + RELEASE.

## Build target (Lane 3 contract)

- [x] `bin/souc check examples/cocycle_subspace_168.sio` rc=0
- [x] `bin/souc compile examples/cocycle_subspace_k5.sio -o /tmp/k5 && /tmp/k5` ALL PASS
- [x] `bin/souc compile examples/cocycle_subspace_k6.sio -o /tmp/k6 && /tmp/k6` ALL PASS (2/2)

## Out of scope

Compiler edits, native-v2, K-AXI emitter (Lanes 1, 4, 5).

## Test plan

- [ ] CI green (Contracts, Native Self-Host, Lean Proofs, Sounio Lint, Full Test Suite, Website)
- [ ] Re-run `examples/cocycle_subspace_k6.sio` post-merge to confirm reproducibility
- [ ] Pre-publication math review by domain specialist (Majid / Rowell / Etingof / Bremner) — recommended but not blocking; Section 7 claims are restatement + computational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)