### PR TITLE
[lane-7] native_v2_dissertation_rapamycin_gate: kill python json.dump heredoc

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -439,3 +439,30 @@ checks:
   - bin/souc compile examples/cocycle_subspace_k6.sio -o /tmp/k6 && /tmp/k6 (ALL PASS)
 commit: pending
 status: lock-released
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T16:08:00Z
+files:
+  - scripts/ci/native_v2_dissertation_rapamycin_gate.sh
+intent: Lane 7 ONLINE (NEW lane, scope=python-extermination beyond kretikos core). Phase 6 cubin-emit was already done — bin/kretikos has 0 live python heredocs. Pivoting Lane 7 to extend python-extermination into scripts/ci/native_v2_*.sh which still have ~20+ python3 invocations. First target: native_v2_dissertation_rapamycin_gate.sh:136 — 1 json.dump heredoc. Replace with `kretikos json-emit` (existing Phase 1 primitive). Diff before/after summary.json. Bounded, low-risk.
+checks:
+  - bash scripts/ci/native_v2_dissertation_rapamycin_gate.sh (pre-state baseline)
+status: lock-acquired
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T16:18:00Z
+files:
+  - scripts/ci/native_v2_dissertation_rapamycin_gate.sh
+intent: Lane 7 RELEASE — replaced 1 python3 json.dump heredoc (line 136, 33 LoC) with `kretikos json-emit` invocation (19 LoC). Schema sounio.native_v2_dissertation_rapamycin.v1 byte-identical pre/post (diff = none, including key order via alphabetical args). First Lane 7 win extending python-extermination beyond kretikos core into scripts/ci/native_v2_*.sh. Remaining native_v2_* python heredocs flagged for follow-up: native_v2_metal_algebra_gate.sh (3), native_v2_hof_closure_gate.sh (1), native_v2_driver_self_compile_gate.sh (2), native_v2_imported_core_abi_gate.sh (1), native_v2_imported_hof_abi_gate.sh (1).
+checks:
+  - bash scripts/ci/native_v2_dissertation_rapamycin_gate.sh (PASS, baseline vs post: byte-identical)
+  - bash -n scripts/ci/native_v2_dissertation_rapamycin_gate.sh (rc=0)
+  - live python3 count in file: 0
+commit: pending
+status: lock-released

--- a/scripts/ci/native_v2_dissertation_rapamycin_gate.sh
+++ b/scripts/ci/native_v2_dissertation_rapamycin_gate.sh
@@ -133,41 +133,28 @@ rapa_sha="$(portable_sha256 "$RAPA_BIN_1")"
 rapa_bytes="$(portable_size "$RAPA_BIN_1")"
 stage1_sha="$(portable_sha256 "$STAGE1_DRIVER")"
 
-python3 - "$SUMMARY_JSON" "$rapa_sha" "$rapa_bytes" "$stage1_sha" "$sqrts_verified" "$SOUC_BIN" <<'PY'
-import json, sys, pathlib
-summary_path = pathlib.Path(sys.argv[1])
-rapa_sha = sys.argv[2]
-rapa_bytes = int(sys.argv[3])
-stage1_sha = sys.argv[4]
-sqrts_verified = sys.argv[5] == "true"
-souc_bin = sys.argv[6]
-
-payload = {
-    "schema": "sounio.native_v2_dissertation_rapamycin.v1",
-    "dissertation_gate": "pass",
-    "status": "pass",
-    "compiler_resolved": souc_bin,
-    "target": "x86_64-linux",
-    "fallback_path": "none",
-    "host_callback": "none",
-    "driver_source": "self-hosted/compiler/native_compile_driver.sio",
-    "test_source": "tests/native-v2/science_spine/rapamycin_des_gum.sio",
-    "test_fixture": "tests/native-v2/science_spine/rapamycin_des_gum.stdout",
-    "stage1_driver_sha256": stage1_sha,
-    "rapa_bin_sha256": rapa_sha,
-    "rapa_bin_bytes": rapa_bytes,
-    "stage1_deterministic": True,
-    "rapa_deterministic": True,
-    "gum_sse2_verified": sqrts_verified,
-    "claims": [
-        "gum_through_ode",
-        "iso_uncertainty_budget",
-        "compile_time_confidence_gate",
-        "rapamycin_3comp_native_elf",
-    ],
-}
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+# Emit summary JSON via pure-Sounio kretikos json-emit (replaces python json.dump heredoc).
+# Schema sounio.native_v2_dissertation_rapamycin.v1. Args ordered alphabetically by key
+# to preserve byte-identity with prior python `sort_keys=True` output.
+"$ROOT_DIR/bin/kretikos" json-emit \
+  --array-strings "claims=gum_through_ode|iso_uncertainty_budget|compile_time_confidence_gate|rapamycin_3comp_native_elf" \
+  --string "compiler_resolved=$SOUC_BIN" \
+  --string "dissertation_gate=pass" \
+  --string "driver_source=self-hosted/compiler/native_compile_driver.sio" \
+  --string "fallback_path=none" \
+  --bool "gum_sse2_verified=$sqrts_verified" \
+  --string "host_callback=none" \
+  --int "rapa_bin_bytes=$rapa_bytes" \
+  --string "rapa_bin_sha256=$rapa_sha" \
+  --bool "rapa_deterministic=true" \
+  --string "schema=sounio.native_v2_dissertation_rapamycin.v1" \
+  --bool "stage1_deterministic=true" \
+  --string "stage1_driver_sha256=$stage1_sha" \
+  --string "status=pass" \
+  --string "target=x86_64-linux" \
+  --string "test_fixture=tests/native-v2/science_spine/rapamycin_des_gum.stdout" \
+  --string "test_source=tests/native-v2/science_spine/rapamycin_des_gum.sio" \
+  > "$SUMMARY_JSON"
 
 echo "[dissertation-rapa] PASS"
 echo "[dissertation-rapa] dissertation_gate=pass, sqrtsd_verified=$sqrts_verified"


### PR DESCRIPTION
## Lane 7 origin story

Lane 7 was kicked off as "phase-6 cubin-emit" but inventory revealed Phase 6 is **already done** — `bin/kretikos` has 0 live python3 invocations as of 2026-05-09 (Phases 1-6 of the kretikos core python-extermination plan all landed). Pivoted Lane 7 to its natural successor: extending python-extermination **beyond the kretikos core** into the wider `scripts/ci/native_v2_*.sh` surface, where ~9 python3 invocations across 6 gate files still live.

This PR is the first one. Smallest target picked first — single `json.dump` heredoc, well-defined byte-identity criterion, low blast radius.

## What

`scripts/ci/native_v2_dissertation_rapamycin_gate.sh:136` had a 33-line python heredoc emitting `sounio.native_v2_dissertation_rapamycin.v1` summary JSON via `json.dump(sort_keys=True)`. Replaced with a single `kretikos json-emit` invocation (19 lines, args ordered alphabetically by key for byte-identity).

## Verification

Captured before+after summary.json from running the gate twice with different `SOUNIO_DISSERTATION_RAPA_DIR` values:

```
$ SOUNIO_DISSERTATION_RAPA_DIR=/tmp/dissrapa-baseline    bash scripts/ci/native_v2_dissertation_rapamycin_gate.sh
[dissertation-rapa] PASS

$ SOUNIO_DISSERTATION_RAPA_DIR=/tmp/dissrapa-postchange  bash scripts/ci/native_v2_dissertation_rapamycin_gate.sh
[dissertation-rapa] PASS

$ diff /tmp/dissrapa-baseline/artifacts/summary.json /tmp/dissrapa-postchange/artifacts/summary.json
$ echo $?
0
```

Byte-identical: every field matches (compiler_resolved, all sha256s, rapa_bin_bytes, schema, all booleans, claims array). Python's `sort_keys=True` reproduced by alphabetical arg ordering.

## Diff scope

- Single file: `scripts/ci/native_v2_dissertation_rapamycin_gate.sh`
- `+19/-33 LoC` net (heredoc replaced with shorter command)
- Live `python3` count in this file: **0** (was 1)

## Follow-up Lane 7 targets (queued)

| File | python3 heredocs | Difficulty |
|---|---|---|
| `native_v2_metal_algebra_gate.sh` | 3 | medium (one is a TSV→JSON walker) |
| `native_v2_hof_closure_gate.sh` | 1 | easy (validator) |
| `native_v2_driver_self_compile_gate.sh` | 2 (1 inline `-c`, 1 heredoc) | easy |
| `native_v2_imported_core_abi_gate.sh` | 1 | easy |
| `native_v2_imported_hof_abi_gate.sh` | 1 | easy |

Plus `scripts/research/run_glm_benchmarks.sh`, `scripts/research/run_fpga_epistemic_seed.sh`, `scripts/selfhost/selfhost_*_gate.sh` (broader scope, Lane 7 future).

## Lane

- Lane: 7 (NEW — python-extermination beyond kretikos core)
- Owner: Claude #1
- Worktree: `/workspace/sounio-lane-7-phase6`
- Branch: `coord/lane-7-phase6-cubin-emit` (kept name from kickoff prompt even though scope pivoted; rename after merge if desired)
- Evidence-Level: E3 (gate-bound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)