### PR TITLE
[lane-7] kill 3 more python heredocs in native_v2_*_gate.sh

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -466,3 +466,33 @@ checks:
   - live python3 count in file: 0
 commit: pending
 status: lock-released
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T16:28:00Z
+files:
+  - scripts/ci/native_v2_hof_closure_gate.sh
+  - scripts/ci/native_v2_imported_core_abi_gate.sh
+  - scripts/ci/native_v2_imported_hof_abi_gate.sh
+intent: Lane 7 follow-up — kill 3 same-shape python heredocs across native_v2_*_gate.sh. hof_closure is a validator (replace with kretikos kaxi-validate-evidence --expect); imported_core_abi + imported_hof_abi are json.dump emitters (replace with kretikos json-emit + bash date -u + sha256sum). Byte-identity verified modulo generated_at_utc timestamp.
+status: lock-acquired
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T16:38:00Z
+files:
+  - scripts/ci/native_v2_hof_closure_gate.sh
+  - scripts/ci/native_v2_imported_core_abi_gate.sh
+  - scripts/ci/native_v2_imported_hof_abi_gate.sh
+intent: Lane 7 follow-up RELEASE — killed 3 python heredocs (1 validator, 2 json.dump emitters). hof_closure: replaced json.loads validator with kretikos kaxi-validate-evidence (E2E gate run PASS, validate-evidence reports "PASS 1 checks"). imported_{core,hof}_abi: replaced json.dump emitters with kretikos json-emit + bash date -u + sha256sum. JSON output byte-identical to python in isolation test (mock env, both produce identical sort_keys=True output). Live python3 count in all 3 files: 0. bash -n clean.
+checks:
+  - bash scripts/ci/native_v2_hof_closure_gate.sh (PASS, validate-evidence: PASS 1 checks)
+  - isolation test imported_core_abi: BYTE IDENTICAL (kretikos json-emit vs json.dump sort_keys=True)
+  - isolation test imported_hof_abi: BYTE IDENTICAL (same)
+  - bash -n on all 3 files: rc=0
+commit: pending
+status: lock-released

--- a/scripts/ci/native_v2_hof_closure_gate.sh
+++ b/scripts/ci/native_v2_hof_closure_gate.sh
@@ -16,16 +16,9 @@ SOUNIO_NATIVE_V2_SCIENCE_SPINE_DIR="$OUT_DIR" \
 SOUNIO_NATIVE_V2_SCIENCE_SPINE_MANIFEST="$MANIFEST_PATH" \
   bash scripts/ci/native_v2_epistemic_science_spine_gate.sh
 
-python3 - "$SUMMARY_JSON" <<'PY'
-import json
-import pathlib
-import sys
-
-summary_path = pathlib.Path(sys.argv[1])
-payload = json.loads(summary_path.read_text(encoding="utf-8"))
-if payload.get("fallback_path") != "none":
-    raise SystemExit(f"fallback_path={payload.get('fallback_path')!r}")
-PY
+# Validate fallback_path via pure-Sounio kaxi-validate-evidence (replaces python json.loads heredoc).
+"$ROOT_DIR/bin/kretikos" kaxi-validate-evidence "$SUMMARY_JSON" \
+    --expect "fallback_path=none"
 
 echo "[native-v2-hof] PASS: HOF closure promotion gate; fallback_path=none"
 echo "[native-v2-hof] summary=$SUMMARY_JSON"

--- a/scripts/ci/native_v2_imported_core_abi_gate.sh
+++ b/scripts/ci/native_v2_imported_core_abi_gate.sh
@@ -110,45 +110,27 @@ if [[ "$runtime_rc" -ne 42 ]]; then
   exit 1
 fi
 
-python3 - "$SUMMARY_JSON" "$SOUC_BIN" "$PROGRAM" "$ELF" "$OUT_DIR" <<'PY'
-import hashlib
-import json
-import pathlib
-import sys
-from datetime import datetime, timezone
-
-summary_path = pathlib.Path(sys.argv[1])
-souc_bin = sys.argv[2]
-program = sys.argv[3]
-elf = pathlib.Path(sys.argv[4])
-out_dir = pathlib.Path(sys.argv[5])
-
-def sha256(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-payload = {
-    "schema": "sounio.native_v2_imported_core_abi.v2",
-    "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    "status": "pass",
-    "compiler_resolved": souc_bin,
-    "compiler_entrypoint": "self-hosted/compiler/lean.sio",
-    "target": "x86_64-linux",
-    "program": program,
-    "native_elf": str(elf),
-    "native_elf_sha256": sha256(elf),
-    "runtime_exit": 42,
-    "fallback_path": "none",
-    "host_callback": "none",
-    "imported_prebundle_native": False,
-    "source_markers": 0,
-    "artifact_dir": str(out_dir),
-}
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+# Emit summary JSON via pure-Sounio kretikos json-emit (replaces python json.dump heredoc).
+# Schema sounio.native_v2_imported_core_abi.v2. Args ordered alphabetically by key.
+ELF_SHA256="$(sha256sum "$ELF" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$ELF" | awk '{print $1}')"
+GENERATED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%S.%6NZ)"
+"$ROOT_DIR/bin/kretikos" json-emit \
+    --string "artifact_dir=$OUT_DIR" \
+    --string "compiler_entrypoint=self-hosted/compiler/lean.sio" \
+    --string "compiler_resolved=$SOUC_BIN" \
+    --string "fallback_path=none" \
+    --string "generated_at_utc=$GENERATED_AT_UTC" \
+    --string "host_callback=none" \
+    --bool   "imported_prebundle_native=false" \
+    --string "native_elf=$ELF" \
+    --string "native_elf_sha256=$ELF_SHA256" \
+    --string "program=$PROGRAM" \
+    --int    "runtime_exit=42" \
+    --string "schema=sounio.native_v2_imported_core_abi.v2" \
+    --int    "source_markers=0" \
+    --string "status=pass" \
+    --string "target=x86_64-linux" \
+    > "$SUMMARY_JSON"
 
 echo "[native-v2-imported-core-abi] PASS: imported core ABI uses modular IR native driver directly"
 echo "[native-v2-imported-core-abi] summary=$SUMMARY_JSON"

--- a/scripts/ci/native_v2_imported_hof_abi_gate.sh
+++ b/scripts/ci/native_v2_imported_hof_abi_gate.sh
@@ -128,49 +128,30 @@ if [[ "$runtime_rc" -ne 42 ]]; then
   exit 1
 fi
 
-python3 - "$SUMMARY_JSON" "$SOUC_BIN" "$PROGRAM" "$IMPORTED_MODULE" "$ELF" "$OUT_DIR" <<'PY'
-import hashlib
-import json
-import pathlib
-import sys
-from datetime import datetime, timezone
-
-summary_path = pathlib.Path(sys.argv[1])
-souc_bin = sys.argv[2]
-program = sys.argv[3]
-imported_module = sys.argv[4]
-elf = pathlib.Path(sys.argv[5])
-out_dir = pathlib.Path(sys.argv[6])
-
-def sha256(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-payload = {
-    "schema": "sounio.native_v2_imported_hof_abi.v1",
-    "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    "status": "pass",
-    "compiler_resolved": souc_bin,
-    "compiler_entrypoint": "self-hosted/compiler/lean.sio",
-    "target": "x86_64-linux",
-    "program": program,
-    "imported_module": imported_module,
-    "native_elf": str(elf),
-    "native_elf_sha256": sha256(elf),
-    "runtime_exit": 42,
-    "fallback_path": "none",
-    "host_callback": "none",
-    "imported_prebundle_native": False,
-    "hof_abi_scope": "named_fn_refs_and_fn_typed_params_returns_no_captures",
-    "imported_body_lowering": "compact_imported_body_lowering_v1_no_source_marker",
-    "source_markers": 0,
-    "artifact_dir": str(out_dir),
-}
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+# Emit summary JSON via pure-Sounio kretikos json-emit (replaces python json.dump heredoc).
+# Schema sounio.native_v2_imported_hof_abi.v1. Args ordered alphabetically by key.
+ELF_SHA256="$(sha256sum "$ELF" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$ELF" | awk '{print $1}')"
+GENERATED_AT_UTC="$(date -u +%Y-%m-%dT%H:%M:%S.%6NZ)"
+"$ROOT_DIR/bin/kretikos" json-emit \
+    --string "artifact_dir=$OUT_DIR" \
+    --string "compiler_entrypoint=self-hosted/compiler/lean.sio" \
+    --string "compiler_resolved=$SOUC_BIN" \
+    --string "fallback_path=none" \
+    --string "generated_at_utc=$GENERATED_AT_UTC" \
+    --string "hof_abi_scope=named_fn_refs_and_fn_typed_params_returns_no_captures" \
+    --string "host_callback=none" \
+    --string "imported_body_lowering=compact_imported_body_lowering_v1_no_source_marker" \
+    --string "imported_module=$IMPORTED_MODULE" \
+    --bool   "imported_prebundle_native=false" \
+    --string "native_elf=$ELF" \
+    --string "native_elf_sha256=$ELF_SHA256" \
+    --string "program=$PROGRAM" \
+    --int    "runtime_exit=42" \
+    --string "schema=sounio.native_v2_imported_hof_abi.v1" \
+    --int    "source_markers=0" \
+    --string "status=pass" \
+    --string "target=x86_64-linux" \
+    > "$SUMMARY_JSON"
 
 echo "[native-v2-imported-hof-abi] PASS: imported HOF ABI v1 uses modular IR native driver directly"
 echo "[native-v2-imported-hof-abi] summary=$SUMMARY_JSON"


### PR DESCRIPTION
## Follow-up to PR #100

Three same-shape replacements across the native-v2 gate surface:

| File | Heredoc shape | Replacement |
|---|---|---|
| `native_v2_hof_closure_gate.sh` | `json.loads` validator (9 LoC) | `kretikos kaxi-validate-evidence --expect "fallback_path=none"` |
| `native_v2_imported_core_abi_gate.sh` | `json.dump` emitter (36 LoC), schema `sounio.native_v2_imported_core_abi.v2` | `kretikos json-emit` + bash `sha256sum` + `date -u` |
| `native_v2_imported_hof_abi_gate.sh` | `json.dump` emitter (41 LoC), schema `sounio.native_v2_imported_hof_abi.v1` | `kretikos json-emit` + bash `sha256sum` + `date -u` |

All three pass `bash -n`. Live `python3` count in each file: **0** (was 1 each).

## Verification

### hof_closure (validator) — full end-to-end

```
$ SOUNIO_NATIVE_V2_HOF_CLOSURE_DIR=/tmp/lane7-post-hof bash scripts/ci/native_v2_hof_closure_gate.sh
[native-v2-science-spine] PASS: stage1 self-compile, corpus ELF/runtime parity, deterministic replay, and summary evidence
validate-evidence: PASS 1 checks
[native-v2-hof] PASS: HOF closure promotion gate; fallback_path=none
```

### imported_core_abi + imported_hof_abi (emitters) — isolation test

Both gates take >180s end-to-end (full `lean.sio` compile chain), so I verified the emitter logic at unit level against the python `json.dump(sort_keys=True)` baseline with mock env vars:

```bash
# Both produced byte-identical JSON output:
$ diff /tmp/lane7-emit.json /tmp/lane7-py.json && echo "BYTE IDENTICAL"
BYTE IDENTICAL (imported_core_abi)

$ diff /tmp/lane7-emit-hof.json /tmp/lane7-py-hof.json && echo "BYTE IDENTICAL"
BYTE IDENTICAL (imported_hof_abi)
```

End-to-end gate runs deferred to CI (which has the time budget); the emitter logic is byte-equivalent so they should pass.

## Native_v2 python footprint progress

| Stage | Count |
|---|---|
| Before PR #100 (Lane 7 entry) | ~9 |
| After PR #100 | ~8 |
| **After this PR** | **~5** |

## Remaining (queued for next Lane 7 PR)

- `native_v2_metal_algebra_gate.sh` (3 heredocs, mixed shape)
- `native_v2_driver_self_compile_gate.sh` (2 heredocs — one is binary `SIEP` chunk parse via `struct.unpack`, needs new Sounio binary reader or use existing `kretikos cubin-validate`)

## Lane

- Lane: 7 (python-extermination beyond kretikos core)
- Owner: Claude #1
- Branch: `coord/lane-7-followup-3gates`
- Worktree: `/workspace/sounio-lane-7-3gates`
- Evidence-Level: E2 (classified) for emitters, E3 (gate-bound) for hof_closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)