### PR TITLE
[lane-7] kill 3 more python invocations (driver_self_compile + metal_algebra)

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -496,3 +496,33 @@ checks:
   - bash -n on all 3 files: rc=0
 commit: pending
 status: lock-released
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T16:43:00Z
+files:
+  - scripts/ci/native_v2_driver_self_compile_gate.sh
+  - scripts/ci/native_v2_metal_algebra_gate.sh
+intent: Lane 7 follow-up — kill 3 python invocations across 2 native_v2 gates. driver_self_compile: byte-diff (line 366, FAIL-path debug) + SIEP binary chunk parse (line 380). metal_algebra: 1 trivial status reader (line 211). Deferring 2 heavy metal_algebra heredocs (TSV walker line 66 + nested-cases emitter line 148) to next follow-up.
+status: lock-acquired
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T16:52:00Z
+files:
+  - scripts/ci/native_v2_driver_self_compile_gate.sh
+  - scripts/ci/native_v2_metal_algebra_gate.sh
+intent: Lane 7 RELEASE — killed 3 python invocations across 2 native_v2 gates. driver_self_compile (2): byte-diff debug -> cmp -l + bash arithmetic for octal-to-hex; SIEP binary chunk parse -> grep -ab + dd + od. metal_algebra (1 of 3): trivial json.load["status"] reader -> kretikos kaxi-validate-evidence --print "status". Verified equivalence on real artifact (SIEP read /tmp/sret-marker4.310163/stage1 = "1:25328:0" matches python). Deferred 2 heavy metal_algebra heredocs (TSV walker line 66 + nested-cases emitter line 148) to next follow-up.
+checks:
+  - bash -n on both files: rc=0
+  - SIEP parser (real artifact): bash output identical to python (1:25328:0)
+  - byte-diff (synthetic 6-byte test): identical output ("2 byte(s) differ" + per-offset "0x2: 02 vs 99")
+  - status reader: kaxi-validate-evidence --print = python json.load["status"] = "pass"
+  - driver_self_compile python3 count: 2 -> 0
+  - metal_algebra python3 count: 3 -> 2
+commit: pending
+status: lock-released

--- a/scripts/ci/native_v2_driver_self_compile_gate.sh
+++ b/scripts/ci/native_v2_driver_self_compile_gate.sh
@@ -363,12 +363,13 @@ if [[ "$stage3_rc" -ne 0 ]]; then
 fi
 if ! cmp -s "$STAGE2_DRIVER" "$STAGE3_DRIVER"; then
   echo "[native-v2-driver-self] FAIL: fixed-point broken -- stage2 != stage3" >&2
-  python3 -c "
-a=open('$STAGE2_DRIVER','rb').read(); b=open('$STAGE3_DRIVER','rb').read()
-diffs=[(i,a[i],b[i]) for i in range(min(len(a),len(b))) if a[i]!=b[i]]
-print(f'  {len(diffs)} byte(s) differ')
-for i,x,y in diffs[:5]: print(f'  offset 0x{i:x}: {x:02x} vs {y:02x}')
-" >&2 || true
+  # Pure-bash byte-diff debug (replaces python3 -c heredoc).
+  # cmp -l emits "byteoff val1 val2" with values in octal; we render hex.
+  diff_total=$(cmp -l "$STAGE2_DRIVER" "$STAGE3_DRIVER" 2>/dev/null | wc -l)
+  printf '  %s byte(s) differ\n' "$diff_total" >&2
+  cmp -l "$STAGE2_DRIVER" "$STAGE3_DRIVER" 2>/dev/null | head -n 5 | while read -r off v1 v2; do
+    printf '  offset 0x%x: %02x vs %02x\n' $((off - 1)) $((8#$v1)) $((8#$v2)) >&2
+  done || true
   exit 1
 fi
 check_driver_elf_layout "$STAGE3_DRIVER" "$STAGE3_SECTIONS_LOG" "stage3 driver"
@@ -376,24 +377,20 @@ STAGE2_MD5="$(md5sum "$STAGE2_DRIVER" | cut -d' ' -f1)"
 printf '[native-v2-driver-self] fixed-point md5=%s\n' "$STAGE2_MD5"
 
 # ── Epistemic fixed-point: read .sounio.epistemic from stage1/2/3 ────────────
+# Pure-bash SIEP chunk reader (replaces python struct.unpack heredoc).
+# SIEP chunk layout: 'SIEP' magic at offset 0, u32 version at +4,
+# u64 instr_count at +8, u64 u_c_scaled at +16. All little-endian.
 read_epistemic() {
-  python3 - "$1" <<'PYEOF'
-import struct, sys, os
-path = sys.argv[1]
-if not os.path.exists(path):
-    print("absent")
-    sys.exit(0)
-data = open(path, 'rb').read()
-idx = data.find(b'SIEP')
-if idx < 0:
-    print("absent")
-    sys.exit(0)
-chunk = data[idx:idx+24]
-version = struct.unpack_from('<I', chunk, 4)[0]
-instr_count = struct.unpack_from('<Q', chunk, 8)[0]
-u_c_scaled = struct.unpack_from('<Q', chunk, 16)[0]
-print(f"{version}:{instr_count}:{u_c_scaled}")
-PYEOF
+  local path="$1"
+  if [[ ! -f "$path" ]]; then echo "absent"; return 0; fi
+  local idx
+  idx=$(LC_ALL=C grep -ab -o 'SIEP' "$path" 2>/dev/null | head -n 1 | cut -d: -f1)
+  if [[ -z "$idx" ]]; then echo "absent"; return 0; fi
+  local version instr_count u_c_scaled
+  version=$(dd if="$path" bs=1 skip=$((idx+4)) count=4 2>/dev/null | od -An -t u4 | tr -d ' ')
+  instr_count=$(dd if="$path" bs=1 skip=$((idx+8)) count=8 2>/dev/null | od -An -t u8 | tr -d ' ')
+  u_c_scaled=$(dd if="$path" bs=1 skip=$((idx+16)) count=8 2>/dev/null | od -An -t u8 | tr -d ' ')
+  echo "${version}:${instr_count}:${u_c_scaled}"
 }
 
 STAGE1_EP="$(read_epistemic "$STAGE1_DRIVER")"

--- a/scripts/ci/native_v2_metal_algebra_gate.sh
+++ b/scripts/ci/native_v2_metal_algebra_gate.sh
@@ -205,11 +205,7 @@ if fail_count:
     raise SystemExit(1)
 PY
 
-summary_status="$(python3 - "$SUMMARY_JSON" <<'PY'
-import json, sys
-print(json.load(open(sys.argv[1]))["status"])
-PY
-)"
+summary_status="$("$ROOT_DIR/bin/kretikos" kaxi-validate-evidence "$SUMMARY_JSON" --print "status")"
 
 echo "[native-v2-metal-algebra] status=$summary_status summary=$SUMMARY_JSON"
 if [[ "$summary_status" == "fail" ]]; then


### PR DESCRIPTION
## Follow-up to PRs #100, #102

Three pure-bash replacements, no new infrastructure required:

| File:Line | Heredoc shape | Replacement |
|---|---|---|
| `native_v2_driver_self_compile_gate.sh:366` | `python3 -c` byte-diff debug (FAIL path) | `cmp -l` + bash `$((8#NN))` octal-to-int |
| `native_v2_driver_self_compile_gate.sh:380` | `python3 - <<'PYEOF'` SIEP binary chunk parse via `struct.unpack` | `grep -ab` magic offset + `dd` bytes + `od` LE u32/u64 |
| `native_v2_metal_algebra_gate.sh:208` | 3-line `json.load(...)["status"]` reader | `kretikos kaxi-validate-evidence --print "status"` |

`bash -n` clean on both files. driver_self_compile python3 count: 2 → **0**. metal_algebra: 3 → **2**.

## Verification (unit level)

### SIEP parser — real artifact

```
$ python3 -c "..." /tmp/sret-marker4.310163/stage1
1:25328:0

$ read_epistemic /tmp/sret-marker4.310163/stage1   # bash version
1:25328:0
```

Identical. Layout: `SIEP` magic, u32 version at +4, u64 instr_count at +8, u64 u_c_scaled at +16. Bash uses `grep -ab -o` for magic offset, `dd bs=1 skip count` for byte slicing, `od -An -t u4/u8` for little-endian decoding.

### Byte-diff debug — synthetic 6-byte fixtures

```
fixture A: 00 01 02 03 04 05
fixture B: 00 01 99 03 04 aa

python:
  2 byte(s) differ
  offset 0x2: 02 vs 99
  offset 0x5: 05 vs aa

bash:
  2 byte(s) differ
  offset 0x2: 02 vs 99
  offset 0x5: 05 vs aa
```

Identical formatting. Bash uses `cmp -l | head -n 5 | while read off v1 v2; do printf '%x %02x %02x' $((off-1)) $((8#$v1)) $((8#$v2)); done`. The `$((8#NN))` form parses NN as octal — POSIX bash, no gawk dependency.

### Status reader — synthetic summary.json

```
$ kretikos kaxi-validate-evidence /tmp/lane7-summary.json --print "status"
pass
$ python3 -c "import json; print(json.load(open('/tmp/lane7-summary.json'))['status'])"
pass
```

Identical.

## Lane 7 cumulative progress

| Stage | Native-v2 python invocation count |
|---|---|
| Lane 7 entry | ~9 |
| After PR #100 | ~8 |
| After PR #102 | ~5 |
| **After this PR** | **~2** |

## Remaining (next Lane 7 follow-up)

`native_v2_metal_algebra_gate.sh` has 2 heavy heredocs left:
- Line 66: TSV walker that reads MSL files and runs 7 string-pattern structural checks per kernel
- Line 148: summary JSON emitter with nested `cases: [...rows]` array (uses `csv.DictReader` to ingest TSV rows produced by heredoc 1)

Both interrelated (heredoc 2 reads heredoc 1's output). Next PR will likely take both in one pass via bash `while read` + `kretikos json-emit --raw-json cases=$CASES_JSON`.

## Lane

- Lane: 7 (python-extermination beyond kretikos core)
- Owner: Claude #1
- Branch: `coord/lane-7-followup-2gates`
- Evidence-Level: E3 (gate-bound) for SIEP test, E2 (classified) for the heavy gates whose end-to-end runs CI will exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)