### PR TITLE
[lane-7] kill all 4 python heredocs in selfhost_cycle_gate.sh

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -560,3 +560,32 @@ checks:
   - validator path resolution: $ROOT_DIR/../bin/kretikos resolves correctly; positive + negative tests both correct
 commit: pending
 status: lock-released
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T17:42:00Z
+files:
+  - scripts/selfhost/selfhost_cycle_gate.sh
+intent: Lane 7 follow-up — kill 4 python heredocs in selfhost_cycle_gate.sh: manifest_key extractor (line 50, json.load["key_id"]), run_with_timeout fallback (line 88, identical to #108), independence-contract schema validator (line 131, identical to #108), cycle_digest extractor (line 158, validates stage1==stage2 + prints 3 KEY=VALUE lines).
+status: lock-acquired
+
+---
+
+agent: claude
+lane: 7
+time_utc: 2026-05-10T17:48:00Z
+files:
+  - scripts/selfhost/selfhost_cycle_gate.sh
+intent: Lane 7 RELEASE — killed all 4 python heredocs in selfhost_cycle_gate.sh. (1) manifest_key extractor -> kaxi-validate-evidence --print-or-empty "key_id". (2) run_with_timeout fallback -> perl alarm (same as #108). (3) independence-contract schema validator -> kaxi-validate-evidence --expect (same as #108). (4) cycle_digest extractor (most complex: stage1==stage2 assertion, missing-field check, deterministic bool->1/0 conversion, 3-line KEY=VALUE output) -> 4× kaxi-validate-evidence --print-or-empty + bash assertions + manual bool conversion to match python's "1 if deterministic else 0".
+checks:
+  - bash -n scripts/selfhost/selfhost_cycle_gate.sh: rc=0
+  - python3 count: 4 -> 0
+  - extract_cycle_digest isolation tests (3 cases):
+    - happy path: 3 lines printed correctly, rc=0
+    - missing field: error message + rc=1 (matches python SystemExit)
+    - non-deterministic: error with stage1=/stage2= + rc=1 (matches python)
+  - kaxi-validate-evidence --print and --print-or-empty smoke-tested with bool, int, string field reads
+commit: pending
+status: lock-released

--- a/scripts/selfhost/selfhost_cycle_gate.sh
+++ b/scripts/selfhost/selfhost_cycle_gate.sh
@@ -44,18 +44,13 @@ resolve_bootstrap_seed_trusted_key() {
     return 0
   fi
 
-  if [[ -f "$BOOTSTRAP_MANIFEST_METADATA_PATH" ]] && command -v python3 >/dev/null 2>&1; then
+  if [[ -f "$BOOTSTRAP_MANIFEST_METADATA_PATH" ]]; then
+    # Pure-Sounio key extraction (replaces python json.load["key_id"] heredoc).
+    # ROOT_DIR in scripts/selfhost/*.sh resolves to scripts/, not repo root —
+    # use ../bin/kretikos. --print-or-empty matches python's `payload.get(key, "")`.
     local manifest_key
-    manifest_key="$(
-      python3 - "$BOOTSTRAP_MANIFEST_METADATA_PATH" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    payload = json.load(f)
-print(payload.get("key_id", ""))
-PY
-    )"
+    manifest_key="$("$ROOT_DIR/../bin/kretikos" kaxi-validate-evidence \
+        "$BOOTSTRAP_MANIFEST_METADATA_PATH" --print-or-empty "key_id" 2>/dev/null || true)"
     if [[ -n "$manifest_key" ]]; then
       echo "$manifest_key"
       return 0
@@ -84,20 +79,13 @@ run_with_timeout() {
     return $?
   fi
 
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - "$seconds" "$@" <<'PY'
-import subprocess
-import sys
-
-seconds = int(sys.argv[1])
-command = sys.argv[2:]
-try:
-    completed = subprocess.run(command, timeout=seconds)
-    sys.exit(completed.returncode)
-except subprocess.TimeoutExpired:
-    sys.exit(124)
-PY
-    return $?
+  # Pure-perl timeout fallback (replaces python3 subprocess.run heredoc).
+  # See selfhost_zero_fallback_gate.sh for rationale.
+  if command -v perl >/dev/null 2>&1; then
+    perl -e 'alarm $ARGV[0]; shift @ARGV; exec @ARGV; exit 127' "$seconds" "$@"
+    local rc=$?
+    [[ $rc -eq 142 ]] && rc=124
+    return $rc
   fi
 
   "$@"
@@ -128,15 +116,9 @@ echo "bootstrap_manifest=$BOOTSTRAP_MANIFEST_PATH"
 echo "independence_contract=$INDEPENDENCE_CONTRACT_PATH"
 
 if [ -f "$INDEPENDENCE_CONTRACT_PATH" ]; then
-  python3 - "$INDEPENDENCE_CONTRACT_PATH" <<'PY'
-import json
-import pathlib
-import sys
-
-obj = json.loads(pathlib.Path(sys.argv[1]).read_text())
-if obj.get("schema") != "sounio.independence.contract.v1":
-    raise SystemExit(f"invalid independence contract schema: {obj.get('schema')}")
-PY
+  # Validate schema via pure-Sounio kaxi-validate-evidence (replaces python json.loads).
+  "$ROOT_DIR/../bin/kretikos" kaxi-validate-evidence "$INDEPENDENCE_CONTRACT_PATH" \
+    --expect "schema=sounio.independence.contract.v1"
 fi
 
 if [ "$SKIP_BUILD" = "1" ]; then
@@ -155,29 +137,37 @@ fi
 
 extract_cycle_digest() {
   local report_path="$1"
-  python3 - "$report_path" <<'PY'
-import json
-import sys
+  # Pure-bash cycle digest extractor (replaces python json.load heredoc).
+  # Reads stage1_digest, stage2_digest, deterministic, artifacts_checked
+  # via kaxi-validate-evidence --print-or-empty. Asserts both digests
+  # nonempty AND equal; emits 3 KEY=VALUE lines on success.
+  local kretikos="$ROOT_DIR/../bin/kretikos"
+  local stage1 stage2 det art
+  stage1="$("$kretikos" kaxi-validate-evidence "$report_path" --print-or-empty "stage1_digest" 2>/dev/null || true)"
+  stage2="$("$kretikos" kaxi-validate-evidence "$report_path" --print-or-empty "stage2_digest" 2>/dev/null || true)"
+  det="$("$kretikos" kaxi-validate-evidence "$report_path" --print-or-empty "deterministic" 2>/dev/null || true)"
+  art="$("$kretikos" kaxi-validate-evidence "$report_path" --print-or-empty "artifacts_checked" 2>/dev/null || true)"
 
-with open(sys.argv[1], "r", encoding="utf-8") as f:
-    payload = json.load(f)
+  if [[ -z "$stage1" || -z "$stage2" ]]; then
+    echo "missing cycle digest fields in $report_path" >&2
+    return 1
+  fi
+  if [[ "$stage1" != "$stage2" ]]; then
+    echo "non-deterministic cycle report $report_path stage1=$stage1 stage2=$stage2" >&2
+    return 1
+  fi
+  # Match python's "1 if deterministic else 0" — JSON true -> "1", anything else -> "0".
+  if [[ "$det" == "true" ]]; then
+    det="1"
+  else
+    det="0"
+  fi
+  # Default missing artifacts_checked to 0 (matches python's payload.get("artifacts_checked", 0)).
+  [[ -z "$art" ]] && art="0"
 
-stage1 = payload.get("stage1_digest", "")
-stage2 = payload.get("stage2_digest", "")
-deterministic = payload.get("deterministic", False)
-artifacts_checked = payload.get("artifacts_checked", 0)
-
-if not stage1 or not stage2:
-    raise SystemExit(f"missing cycle digest fields in {sys.argv[1]}")
-if stage1 != stage2:
-    raise SystemExit(
-        f"non-deterministic cycle report {sys.argv[1]} stage1={stage1} stage2={stage2}"
-    )
-
-print(f"cycle_digest={stage1}")
-print(f"deterministic={'1' if deterministic else '0'}")
-print(f"artifacts_checked={artifacts_checked}")
-PY
+  echo "cycle_digest=$stage1"
+  echo "deterministic=$det"
+  echo "artifacts_checked=$art"
 }
 
 run_cycle_stage() {


### PR DESCRIPTION
## What

Closes `scripts/selfhost/selfhost_cycle_gate.sh`'s python footprint. 4 heredocs → 0:

| Line | Heredoc | Replacement |
|---|---|---|
| 50 | `json.load["key_id"]` extractor | `kaxi-validate-evidence --print-or-empty "key_id"` |
| 88 | `run_with_timeout` python fallback | perl alarm (same as #108) |
| 131 | independence-contract schema validator | `kaxi-validate-evidence --expect` (same as #108) |
| 158 | cycle_digest extractor (stage1==stage2 assertion + 3-line KEY=VALUE output) | 4× `kaxi-validate-evidence --print-or-empty` + bash assertions |

`bash -n` clean. python3 count in this file: 4 → **0**.

## Verification — isolation tests on `extract_cycle_digest`

Most complex of the 4 replacements. Tested on 3 synthetic fixtures:

```
Test 1: happy path
  bash:    cycle_digest=abc123 / deterministic=1 / artifacts_checked=7  rc=0
  python:  cycle_digest=abc123 / deterministic=1 / artifacts_checked=7  rc=0
  -> identical

Test 2: missing fields
  bash:    "missing cycle digest fields in <path>"  rc=1
  python:  same f-string from SystemExit                  rc=1
  -> identical

Test 3: non-deterministic (stage1 != stage2)
  bash:    "non-deterministic cycle report <path> stage1=aaa stage2=bbb"  rc=1
  python:  same f-string from SystemExit                                  rc=1
  -> identical
```

The bool-to-int conversion (`if det == "true" then 1 else 0`) matches Python's `"1 if deterministic else 0"`. Missing `artifacts_checked` defaults to "0" matching `payload.get("artifacts_checked", 0)`.

## Lane 7 cumulative (7 PRs, 16 python invocations killed)

| PR | File(s) | Killed |
|---|---|---|
| #100 | dissertation_rapamycin | 1 |
| #102 | hof_closure + 2× imported_*_abi | 3 |
| #104 | driver_self_compile + metal_algebra status | 3 |
| #107 | metal_algebra final 2 | 2 |
| #108 | selfhost zero_fallback + driver_output_parity | 3 |
| **this** | **selfhost_cycle_gate (4 heredocs)** | **4** |

All selfhost gates with simple python heredocs now clean. Native_v2 surface clean. Kretikos core clean (since 2026-05-09).

## Pre-existing path bug (still flagged, NOT fixed here)

The selfhost gates still have the `ROOT_DIR = scripts/` (not repo root) bug from #108. My validator calls use `$ROOT_DIR/../bin/kretikos` for correct resolution. End-to-end gate runs blocked on the line-6 source bug; logic verified at unit level.

## Lane

- Lane: 7 (python-extermination, expanded scope)
- Owner: Claude #1
- Branch: `coord/lane-7-cycle-gate`
- Evidence-Level: E2 (classified) — unit tests pass; e2e blocked by pre-existing path bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)