### PR TITLE
[ci] skip Phase Y gate when CUDA init is unavailable

### DIFF
--- a/scripts/ci/kretikos_kaxi_phase_y_gate.sh
+++ b/scripts/ci/kretikos_kaxi_phase_y_gate.sh
@@ -105,6 +105,7 @@ echo "[3/4] GPU run -- ${PHY_COHORT} patients, ${PHY_THREADS} threads/block"
 PHY_BLOCKS=$(( (PHY_COHORT + PHY_THREADS - 1) / PHY_THREADS ))
 
 GPU_OUT="${STAGE_DIR}/gpu_output.txt"
+set +e
 "${STAGE_DIR}/runner" "${PHY_PTX}" \
   --kernel kaxi_kernel \
   --gum --type f32 \
@@ -117,6 +118,17 @@ GPU_OUT="${STAGE_DIR}/gpu_output.txt"
   --init-v11-file "${STAGE_DIR}/init_v11.bin" \
   --init-v22-file "${STAGE_DIR}/init_v22.bin" \
   2>&1 | tee "${GPU_OUT}"
+runner_rc=${PIPESTATUS[0]}
+set -e
+
+if [[ "${runner_rc}" -ne 0 ]]; then
+  if grep -q 'status=not_run reason=cuInit_failed' "${GPU_OUT}"; then
+    echo "kretikos_kaxi_phase_y_gate: SKIPPED (CUDA driver unavailable: cuInit_failed)"
+    exit 0
+  fi
+  echo "kretikos_kaxi_phase_y_gate: FAIL -- GPU runner exited rc=${runner_rc}"
+  exit "${runner_rc}"
+fi
 
 echo "  GPU run complete"
 


### PR DESCRIPTION
## Summary

- Captures the Phase Y GPU runner exit code instead of letting `set -euo pipefail` abort before classification.
- Treats the explicit runtime status `status=not_run reason=cuInit_failed` as a `SKIPPED` gate, matching the existing skip behavior for missing `libcuda`.
- Keeps real runner failures and digest mismatches as failures.

## Validation

From clean `origin/main` worktree `/tmp/sounio-main-verify-20260510223000`:

- `bash scripts/ci/kretikos_kaxi_phase_y_gate.sh` -> rc=0, explicit `SKIPPED (CUDA driver unavailable: cuInit_failed)` after CPU truth generation.
- `bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh` -> PASS via shell fallback; all rows rc=0, summary `/tmp/sounio-native-v2-cpu-compiler.BT4z3f/artifacts/native_v2_cpu_compiler_umbrella.v1.json`.
- `bash scripts/ci/dissertation_pbpk_hessian_gate.sh` -> PASS=5 FAIL=0.
- `bash scripts/ci/kretikos_kaxi_phase_j_aggregate_gate.sh` -> PASS=6 FAIL=0.
- `bash scripts/ci/dissertation_dossier_gate.sh` -> PASS=5 FAIL=0.

## Notes

This is a harness-routing fix, not a semantic change to Phase Y math. The prior GPU semantic review remains the xAI/Grok post-merge audit logged for PR #112.