### PR TITLE
[lane-7] kill 6 python heredocs in 6 gate scripts

### DIFF
--- a/scripts/ci/native_v2_gum_primitives_gate.sh
+++ b/scripts/ci/native_v2_gum_primitives_gate.sh
@@ -199,56 +199,92 @@ else
   echo "[native-v2-gum] NOTE: objdump not available -- sqrtsd scan skipped"
 fi
 
-python3 - "$SUMMARY_JSON" "$RESULTS_TSV" "$SOUC_BIN" "$MANIFEST_PATH" \
-         "$STAGE1_DRIVER" "$STAGE1_DRIVER_2" "$OUT_DIR" "$GUM_SSE2_VERIFIED" <<'PY'
-import csv, hashlib, json, pathlib, sys
+# Pure-bash summary JSON emitter (replaces python3 csv.DictReader + json.dump heredoc).
+# TSV header: case_id($1) program($2) claim_class($3) expected_exit($4) pass1_exit($5)
+#   pass2_exit($6) stdout($7) status($8) pass1_sha256($9) pass2_sha256($10) bytes($11)
+# Keys sorted alphabetically per sort_keys=True.
+MANIFEST_SHA256="$(sha256sum "$MANIFEST_PATH" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$MANIFEST_PATH" | awk '{print $1}')"
+STAGE1_SHA256="$(sha256sum "$STAGE1_DRIVER" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$STAGE1_DRIVER" | awk '{print $1}')"
+STAGE1_2_SHA256="$(sha256sum "$STAGE1_DRIVER_2" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$STAGE1_DRIVER_2" | awk '{print $1}')"
+if [[ "$STAGE1_SHA256" == "$STAGE1_2_SHA256" ]]; then
+  stage1_deterministic=true
+else
+  stage1_deterministic=false
+fi
+gum_sse2_bool=false
+[[ "${GUM_SSE2_VERIFIED,,}" == "true" ]] && gum_sse2_bool=true
+case_count="$(awk 'NR>1 && NF>0' "$RESULTS_TSV" | wc -l | tr -d ' ')"
+pass_count_gum="$(awk -F'\t' 'NR>1 && $8=="ok"' "$RESULTS_TSV" | wc -l | tr -d ' ')"
+fail_count_gum=$(( case_count - pass_count_gum ))
+if [[ "$pass_count_gum" -eq "$case_count" ]]; then
+  status_str="pass"
+else
+  status_str="fail"
+fi
 
-summary_path = pathlib.Path(sys.argv[1])
-results_path = pathlib.Path(sys.argv[2])
-souc_bin = sys.argv[3]
-manifest_path = pathlib.Path(sys.argv[4])
-stage1_path = pathlib.Path(sys.argv[5])
-stage1_replay_path = pathlib.Path(sys.argv[6])
-out_dir = pathlib.Path(sys.argv[7])
-gum_sse2 = sys.argv[8].lower() == "true"
-
-def sha256(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-rows = []
-with open(results_path, "r", encoding="utf-8") as f:
-    rows = list(csv.DictReader(f, delimiter="\t"))
-
-payload = {
-    "schema": "sounio.native_v2_gum_primitives.v1",
-    "status": "pass" if all(r["status"] == "ok" for r in rows) else "fail",
-    "compiler_resolved": souc_bin,
-    "target": "x86_64-linux",
-    "fallback_path": "none",
-    "host_callback": "none",
-    "driver_source": "self-hosted/compiler/native_compile_driver.sio",
-    "manifest": str(manifest_path),
-    "manifest_sha256": sha256(manifest_path),
-    "stage1_driver_sha256": sha256(stage1_path),
-    "stage1_driver_deterministic": sha256(stage1_path) == sha256(stage1_replay_path),
-    "gum_sse2_verified": gum_sse2,
-    "sota_claim": "ISO JCGM 100:2008 GUM uncertainty propagation as native x86-64 SSE2 IR primitive",
-    "case_count": len(rows),
-    "pass_count": sum(1 for r in rows if r["status"] == "ok"),
-    "fail_count": sum(1 for r in rows if r["status"] != "ok"),
-    "results_tsv": str(results_path),
-    "artifact_dir": str(out_dir),
-    "cases": rows,
+CASES_JSON="$(awk -F'\t' '
+function jsesc(s,    out, i, c) {
+  out = ""
+  for (i = 1; i <= length(s); i++) {
+    c = substr(s, i, 1)
+    if (c == "\\") out = out "\\\\"
+    else if (c == "\"") out = out "\\\""
+    else if (c == "\n") out = out "\\n"
+    else if (c == "\r") out = out "\\r"
+    else if (c == "\t") out = out "\\t"
+    else out = out c
+  }
+  return out
 }
+NR==1 { next }
+NR>1 && NF>=8 {
+  if (printed) printf ",\n"
+  printed = 1
+  printf "    {\n"
+  printf "      \"bytes\": \"%s\",\n",          jsesc($11)
+  printf "      \"case_id\": \"%s\",\n",        jsesc($1)
+  printf "      \"claim_class\": \"%s\",\n",    jsesc($3)
+  printf "      \"expected_exit\": \"%s\",\n",  jsesc($4)
+  printf "      \"pass1_exit\": \"%s\",\n",     jsesc($5)
+  printf "      \"pass1_sha256\": \"%s\",\n",   jsesc($9)
+  printf "      \"pass2_exit\": \"%s\",\n",     jsesc($6)
+  printf "      \"pass2_sha256\": \"%s\",\n",   jsesc($10)
+  printf "      \"program\": \"%s\",\n",        jsesc($2)
+  printf "      \"status\": \"%s\",\n",         jsesc($8)
+  printf "      \"stdout\": \"%s\"\n",          jsesc($7)
+  printf "    }"
+}
+END { if (printed) printf "\n" }
+' "$RESULTS_TSV")"
+CASES_JSON="[
+$CASES_JSON
+  ]"
 
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-if payload["status"] != "pass" or not payload["stage1_driver_deterministic"]:
-    raise SystemExit(1)
-PY
+"$ROOT_DIR/bin/kretikos" json-emit \
+  --string  "artifact_dir=$OUT_DIR" \
+  --int     "case_count=$case_count" \
+  --raw-json "cases=$CASES_JSON" \
+  --string  "compiler_resolved=$SOUC_BIN" \
+  --string  "driver_source=self-hosted/compiler/native_compile_driver.sio" \
+  --int     "fail_count=$fail_count_gum" \
+  --string  "fallback_path=none" \
+  --bool    "gum_sse2_verified=$gum_sse2_bool" \
+  --string  "host_callback=none" \
+  --string  "manifest=$MANIFEST_PATH" \
+  --string  "manifest_sha256=$MANIFEST_SHA256" \
+  --int     "pass_count=$pass_count_gum" \
+  --string  "results_tsv=$RESULTS_TSV" \
+  --string  "schema=sounio.native_v2_gum_primitives.v1" \
+  --string  "sota_claim=ISO JCGM 100:2008 GUM uncertainty propagation as native x86-64 SSE2 IR primitive" \
+  --bool    "stage1_driver_deterministic=$stage1_deterministic" \
+  --string  "stage1_driver_sha256=$STAGE1_SHA256" \
+  --string  "status=$status_str" \
+  --string  "target=x86_64-linux" \
+  > "$SUMMARY_JSON"
+
+if [[ "$status_str" != "pass" || "$stage1_deterministic" != "true" ]]; then
+  exit 1
+fi
 
 echo "[native-v2-gum] PASS: sqrt_f64 SSE2, ISO GUM addition, GUM multiplication, epistemic PBPK confidence gate, deterministic replay"
 echo "[native-v2-gum] summary=$SUMMARY_JSON"

--- a/scripts/ci/native_v2_imported_body_lowering_gate.sh
+++ b/scripts/ci/native_v2_imported_body_lowering_gate.sh
@@ -142,59 +142,42 @@ run_case imported_core tests/selfhost/native_runtime/import_core_abi_42.sio 6
 run_case imported_hof tests/selfhost/native_runtime/import_hof_abi_42.sio 6
 run_case imported_mixed tests/selfhost/native_runtime/import_body_lowering_42.sio 7
 
-python3 - "$SUMMARY_JSON" "$SOUC_BIN" "$OUT_DIR" "$ARTIFACT_DIR/cases.tsv" <<'PY'
-import hashlib
-import json
-import pathlib
-import sys
-from datetime import datetime, timezone
+# Pure-bash summary JSON emitter (replaces python3 hashlib + json.dump heredoc).
+# Reads cases.tsv (name\tprogram\tfunctions\telf), computes sha256 per ELF,
+# builds cases array with keys sorted alphabetically, then emits summary JSON.
+CASES_JSON="$(
+  first=true
+  while IFS=$'\t' read -r name program functions elf_path; do
+    [[ -z "$name" ]] && continue
+    elf_sha="$(sha256sum "$elf_path" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$elf_path" | awk '{print $1}')"
+    [[ "$first" == true ]] && first=false || printf ','
+    printf '{"functions":%d,"name":"%s","native_elf":"%s","native_elf_sha256":"%s","program":"%s","runtime_exit":42}' \
+      "$functions" "$name" "$elf_path" "$elf_sha" "$program"
+  done < "$ARTIFACT_DIR/cases.tsv"
+)"
+CASES_JSON="[$CASES_JSON]"
+case_count="$(grep -c . "$ARTIFACT_DIR/cases.tsv" 2>/dev/null || echo 0)"
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-summary_path = pathlib.Path(sys.argv[1])
-souc_bin = sys.argv[2]
-out_dir = pathlib.Path(sys.argv[3])
-cases_path = pathlib.Path(sys.argv[4])
-
-def sha256(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-cases = []
-for line in cases_path.read_text(encoding="utf-8").splitlines():
-    name, program, functions, elf = line.split("\t")
-    elf_path = pathlib.Path(elf)
-    cases.append({
-        "name": name,
-        "program": program,
-        "functions": int(functions),
-        "native_elf": str(elf_path),
-        "native_elf_sha256": sha256(elf_path),
-        "runtime_exit": 42,
-    })
-
-payload = {
-    "schema": "sounio.native_v2_imported_body_lowering.v1",
-    "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    "status": "pass",
-    "compiler_resolved": souc_bin,
-    "compiler_entrypoint": "self-hosted/compiler/lean.sio",
-    "target": "x86_64-linux",
-    "case_count": len(cases),
-    "pass_count": len(cases),
-    "fail_count": 0,
-    "cases": cases,
-    "fallback_path": "none",
-    "host_callback": "none",
-    "imported_prebundle_native": False,
-    "imported_body_lowering": "compact_imported_body_lowering_v1_no_source_marker",
-    "scope": "i64 imported summaries, small struct returns, named fn refs, fn-typed params/returns, no captures",
-    "source_markers": 0,
-    "artifact_dir": str(out_dir),
-}
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+"$ROOT_DIR/bin/kretikos" json-emit \
+  --string "artifact_dir=$OUT_DIR" \
+  --int    "case_count=$case_count" \
+  --raw-json "cases=$CASES_JSON" \
+  --string "compiler_entrypoint=self-hosted/compiler/lean.sio" \
+  --string "compiler_resolved=$SOUC_BIN" \
+  --int    "fail_count=0" \
+  --string "fallback_path=none" \
+  --string "generated_at_utc=$ts" \
+  --string "host_callback=none" \
+  --string "imported_body_lowering=compact_imported_body_lowering_v1_no_source_marker" \
+  --bool   "imported_prebundle_native=false" \
+  --int    "pass_count=$case_count" \
+  --string "schema=sounio.native_v2_imported_body_lowering.v1" \
+  --string "scope=i64 imported summaries, small struct returns, named fn refs, fn-typed params/returns, no captures" \
+  --int    "source_markers=0" \
+  --string "status=pass" \
+  --string "target=x86_64-linux" \
+  > "$SUMMARY_JSON"
 
 echo "[native-v2-imported-body-lowering] PASS: imported body lowering v1 covers core, HOF, and mixed witnesses"
 echo "[native-v2-imported-body-lowering] summary=$SUMMARY_JSON"

--- a/scripts/ci/native_v2_imported_captured_closure_boundary_gate.sh
+++ b/scripts/ci/native_v2_imported_captured_closure_boundary_gate.sh
@@ -117,56 +117,32 @@ if [[ "$runtime_rc" -ne 42 ]]; then
   exit 1
 fi
 
-python3 - "$SUMMARY_JSON" "$SOUC_BIN" "$PROGRAM" "$MODULE" "$ELF" "$OUT_DIR" <<'PY'
-import hashlib
-import json
-import pathlib
-import sys
-from datetime import datetime, timezone
+# Pure-bash summary JSON emitter (replaces python3 hashlib + json.dump heredoc).
+elf_sha="$(sha256sum "$ELF" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$ELF" | awk '{print $1}')"
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-summary_path = pathlib.Path(sys.argv[1])
-souc_bin = sys.argv[2]
-program = sys.argv[3]
-module = sys.argv[4]
-elf = pathlib.Path(sys.argv[5])
-out_dir = pathlib.Path(sys.argv[6])
-
-def sha256(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-payload = {
-    "schema": "sounio.native_v2_imported_captured_closure_boundary.v1",
-    "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    "status": "pass",
-    "compiler_resolved": souc_bin,
-    "compiler_entrypoint": "self-hosted/compiler/lean.sio",
-    "target": "x86_64-linux",
-    "program": program,
-    "imported_module": module,
-    "native_elf": str(elf),
-    "native_elf_sha256": sha256(elf),
-    "runtime_exit": 42,
-    "functions": 3,
-    "fallback_path": "none",
-    "host_callback": "none",
-    "imported_prebundle_native": False,
-    "scope": "single_i64_capture_imported_factory_only",
-    "captured_closure_environments": True,
-    "capture_lowering": "shape_specialized_i64_factory_no_heap_env",
-    "unsupported": [
-        "general_heap_closure_env",
-        "linear_captures",
-        "epistemic_captures",
-        "multi_capture_envs",
-    ],
-    "artifact_dir": str(out_dir),
-}
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+"$ROOT_DIR/bin/kretikos" json-emit \
+  --string "artifact_dir=$OUT_DIR" \
+  --string "capture_lowering=shape_specialized_i64_factory_no_heap_env" \
+  --bool   "captured_closure_environments=true" \
+  --string "compiler_entrypoint=self-hosted/compiler/lean.sio" \
+  --string "compiler_resolved=$SOUC_BIN" \
+  --string "fallback_path=none" \
+  --int    "functions=3" \
+  --string "generated_at_utc=$ts" \
+  --string "host_callback=none" \
+  --string "imported_module=$MODULE" \
+  --bool   "imported_prebundle_native=false" \
+  --string "native_elf=$ELF" \
+  --string "native_elf_sha256=$elf_sha" \
+  --string "program=$PROGRAM" \
+  --int    "runtime_exit=42" \
+  --string "schema=sounio.native_v2_imported_captured_closure_boundary.v1" \
+  --string "scope=single_i64_capture_imported_factory_only" \
+  --string "status=pass" \
+  --string "target=x86_64-linux" \
+  --array-strings "unsupported=general_heap_closure_env|linear_captures|epistemic_captures|multi_capture_envs" \
+  > "$SUMMARY_JSON"
 
 echo "[native-v2-imported-captured-closure-boundary] PASS: imported captured i64 closure factory uses modular IR native driver directly"
 echo "[native-v2-imported-captured-closure-boundary] summary=$SUMMARY_JSON"

--- a/scripts/ci/native_v2_imported_closure_boundary_gate.sh
+++ b/scripts/ci/native_v2_imported_closure_boundary_gate.sh
@@ -124,50 +124,30 @@ if [[ "$runtime_rc" -ne 42 ]]; then
   exit 1
 fi
 
-python3 - "$SUMMARY_JSON" "$SOUC_BIN" "$PROGRAM" "$MODULE" "$ELF" "$OUT_DIR" "$functions_count" <<'PY'
-import hashlib
-import json
-import pathlib
-import sys
-from datetime import datetime, timezone
+# Pure-bash summary JSON emitter (replaces python3 hashlib + json.dump heredoc).
+elf_sha="$(sha256sum "$ELF" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$ELF" | awk '{print $1}')"
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-summary_path = pathlib.Path(sys.argv[1])
-souc_bin = sys.argv[2]
-program = sys.argv[3]
-module = sys.argv[4]
-elf = pathlib.Path(sys.argv[5])
-out_dir = pathlib.Path(sys.argv[6])
-functions_count = int(sys.argv[7])
-
-def sha256(path):
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-payload = {
-    "schema": "sounio.native_v2_imported_closure_boundary.v1",
-    "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-    "status": "pass",
-    "compiler_resolved": souc_bin,
-    "compiler_entrypoint": "self-hosted/compiler/lean.sio",
-    "target": "x86_64-linux",
-    "program": program,
-    "imported_module": module,
-    "native_elf": str(elf),
-    "native_elf_sha256": sha256(elf),
-    "runtime_exit": 42,
-    "functions": functions_count,
-    "fallback_path": "none",
-    "host_callback": "none",
-    "imported_prebundle_native": False,
-    "scope": "noncapturing_closure_literals_only",
-    "captured_closure_environments": False,
-    "artifact_dir": str(out_dir),
-}
-summary_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+"$ROOT_DIR/bin/kretikos" json-emit \
+  --string "artifact_dir=$OUT_DIR" \
+  --bool   "captured_closure_environments=false" \
+  --string "compiler_entrypoint=self-hosted/compiler/lean.sio" \
+  --string "compiler_resolved=$SOUC_BIN" \
+  --string "fallback_path=none" \
+  --int    "functions=$functions_count" \
+  --string "generated_at_utc=$ts" \
+  --string "host_callback=none" \
+  --string "imported_module=$MODULE" \
+  --bool   "imported_prebundle_native=false" \
+  --string "native_elf=$ELF" \
+  --string "native_elf_sha256=$elf_sha" \
+  --string "program=$PROGRAM" \
+  --int    "runtime_exit=42" \
+  --string "schema=sounio.native_v2_imported_closure_boundary.v1" \
+  --string "scope=noncapturing_closure_literals_only" \
+  --string "status=pass" \
+  --string "target=x86_64-linux" \
+  > "$SUMMARY_JSON"
 
 echo "[native-v2-imported-closure-boundary] PASS: imported noncapturing closure boundary uses modular IR native driver directly"
 echo "[native-v2-imported-closure-boundary] summary=$SUMMARY_JSON"

--- a/scripts/ci/selfhost_host_gate.sh
+++ b/scripts/ci/selfhost_host_gate.sh
@@ -210,13 +210,8 @@ assert_file_kind "$PRINT_SMOKE_BIN" "$HOST_FILE_KIND"
 PRINT_OUTPUT="$("$PRINT_SMOKE_BIN" 2>&1)"
 assert_output_equals $'3.141590\n-0.500000\n2.000000' "$PRINT_OUTPUT" "native_print_f64_smoke"
 
-python3 - "$READ_DATA_BIN" <<'PY'
-import struct
-import sys
-
-with open(sys.argv[1], "wb") as f:
-    f.write(struct.pack("<ddq", 3.14159, -0.5, 42))
-PY
+# Write test binary: little-endian f64(3.14159) f64(-0.5) i64(42)
+printf '\x6e\x86\x1b\xf0\xf9\x21\x09\x40\x00\x00\x00\x00\x00\x00\xe0\xbf\x2a\x00\x00\x00\x00\x00\x00\x00' > "$READ_DATA_BIN"
 
 "$STAGE2_BIN" self-hosted/compiler/native_read64_smoke.sio "$READ_SMOKE_BIN" --target "$HOST_TARGET" >"$LOG_DIR/read64.log" 2>&1
 chmod +x "$READ_SMOKE_BIN" 2>/dev/null || true

--- a/scripts/ci/souc_v2_gate.sh
+++ b/scripts/ci/souc_v2_gate.sh
@@ -192,11 +192,8 @@ run_test_exact \
     $'3.141590\n-0.500000\n2.000000'
 
 # Test: read_file + read_f64/read_i64
-python3 - <<'PY'
-import struct
-with open('/tmp/gate_read64.bin', 'wb') as f:
-    f.write(struct.pack('<ddq', 3.14159, -0.5, 42))
-PY
+# Write test binary: little-endian f64(3.14159) f64(-0.5) i64(42)
+printf '\x6e\x86\x1b\xf0\xf9\x21\x09\x40\x00\x00\x00\x00\x00\x00\xe0\xbf\x2a\x00\x00\x00\x00\x00\x00\x00' > /tmp/gate_read64.bin
 run_test_exact \
     "read64_smoke" \
     self-hosted/compiler/native_read64_smoke.sio \


### PR DESCRIPTION
## Summary

- `selfhost_host_gate.sh` — `struct.pack('<ddq', 3.14159, -0.5, 42)` → `printf` with hardcoded LE bytes
- `souc_v2_gate.sh` — same `struct.pack` → `printf` hex bytes
- `native_v2_imported_closure_boundary_gate.sh` — `json.dump` → `kretikos json-emit`
- `native_v2_imported_captured_closure_boundary_gate.sh` — `json.dump` → `kretikos json-emit` + `array-strings` for `unsupported[]`
- `native_v2_imported_body_lowering_gate.sh` — `json.dump` + TSV reader → `kretikos json-emit` + shell `while read` cases
- `native_v2_gum_primitives_gate.sh` — `csv.DictReader` + `json.dump` → `kretikos json-emit` + awk TSV-to-JSON-array

## Lane-7 cumulative progress (after this PR)

| PR | File | Killed |
|----|------|--------|
| #100 | dissertation_rapamycin_gate | 1 |
| #102 | hof_closure + imported_core/hof_abi | 3 |
| #104 | driver_self_compile + metal_algebra status | 3 |
| #107 | metal_algebra remaining | 2 |
| #108 | selfhost gates (3 files) | 3 |
| #113 | selfhost_cycle_gate | 4 |
| this | 6 scripts (struct.pack + JSON emitters) | 6 |

**Total: 22 python heredocs killed across 12 files**

## Test plan

- [ ] `bash scripts/ci/selfhost_host_gate.sh` — binary read smoke passes
- [ ] `bash scripts/ci/souc_v2_gate.sh` — read64 test passes
- [ ] `bash scripts/ci/native_v2_imported_closure_boundary_gate.sh` — JSON summary written
- [ ] `bash scripts/ci/native_v2_imported_captured_closure_boundary_gate.sh` — JSON summary written
- [ ] `bash scripts/ci/native_v2_imported_body_lowering_gate.sh` — cases TSV parsed, JSON emitted
- [ ] `bash scripts/ci/native_v2_gum_primitives_gate.sh` — GUM SSE2 gate passes
- [ ] `grep -rn 'python3 -' scripts/ci/*.sh` — 0 hits for 6 converted scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)