### PR TITLE
[lane-3] paper-168 k=10 cocycle subspace decomposition (2048-ions, dim 1024)

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -759,3 +759,36 @@ intent: Lane 3 CLAIM (stacked on PR #115) — extend cohomological subspace deco
 checks:
   - bin/souc check examples/cocycle_subspace_k8.sio (rc=0, pre-state baseline includes PR #115)
 status: lock-acquired
+
+---
+
+agent: claude
+lane: 3
+time_utc: 2026-05-10T23:35:00Z
+files:
+  - examples/cocycle_subspace_k9.sio (NEW)
+  - docs/papers/main/168-theorem.typ
+  - docs/papers/main/168-revision-notes.md
+  - scripts/ci/paper168_cocycle_subspace_gate.sh
+intent: Lane 3 RELEASE (retroactive; missed in PR #116 commit) — k=9 1024-ion subspace decomposition delivered. All three conjectures from PR #115 confirmed at k=9. (1) T_9 = 67,101,720 = 168·399415 (Conjecture 5 holds at six consecutive levels k=4..9). (2) **Three-level saturation**: 23 distinct count classes, value set bit-identical at k=7, k=8, k=9. (3) count=168 anomaly mult=75183 = 3·25061 continues two-prime non-7 signature; multiplicity ratios {5.74, 6.21, 6.76, 7.24} monotone increasing toward 2³=8. Wall clock 11.5s. Merged via PR #116 (commit 958c8fba).
+checks:
+  - bin/souc compile + run /tmp/k9_bin (ALL PASS in 11.5s; T_9=67101720; P_9=788035; 23 classes)
+  - bash scripts/ci/paper168_cocycle_subspace_gate.sh (PASS=6 FAIL=0 rc=0 in 15.5s)
+  - post-merge gate on origin/main rc=0 (verified after PR #116 landed)
+commit: 958c8fba
+status: lock-released
+
+---
+
+agent: claude
+lane: 3
+time_utc: 2026-05-10T23:51:27Z
+files:
+  - examples/cocycle_subspace_k10.sio (NEW)
+  - docs/papers/main/168-theorem.typ
+  - docs/papers/main/168-revision-notes.md
+  - scripts/ci/paper168_cocycle_subspace_gate.sh
+intent: Lane 3 CLAIM — extend cohomological subspace decomposition to k=10 (2048-ions, dim 1024). Enumerates [10 choose 3]_2 = 6,347,715 three-dim subspaces of (Z/2)^10 in the 1024-dim CD algebra. Direct 3-LI-generator enumeration. 1024² × 2 i64 = 16 MB BSS per multiplication table (4× k=9); total static BSS estimated ~21.3 MB. Tests whether saturation holds at a FOURTH consecutive level (k=7,8,9,10) and pushes Conjecture 5 formula to its seventh consecutive level (predicted T_10 = 168·3195575 = 536,856,600). Worktree /workspace/sounio-lane-3-paper168-k10 on branch coord/lane-3-paper-168-k10, branched off origin/main (with #114/#115/#116 landed). Wall clock estimate: 3-5 minutes on x86-64 native; gate timeout 600s.
+checks:
+  - bin/souc check examples/cocycle_subspace_k9.sio (rc=0, pre-state baseline includes PR #116)
+status: lock-acquired

--- a/docs/dissertation/pbpk_claim_truth_table.md
+++ b/docs/dissertation/pbpk_claim_truth_table.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.dissertation.pbpk-claim-truth-table
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.dissertation.pbpk-claim-truth-table
+-->
+
 # PBPK Dissertation Claim Truth Table
 
 Purpose: map PBPK, GUM, and GPU dissertation-language candidates to the current repository evidence. This is an evidence table, not promotional copy. Use the narrowest claim that the cited files and gates can actually support.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 397
-- Repo-backed topics: 355
+- Total governed topics: 398
+- Repo-backed topics: 356
 - Website-backed topics: 55
 - Dual-canon topics: 13
 - Authority count `archived`: 19
 - Authority count `dual`: 13
 - Authority count `historical`: 78
-- Authority count `repo_only`: 245
+- Authority count `repo_only`: 246
 - Authority count `website_only`: 42
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 201 topics
+- A2: 202 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 29 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -108,6 +108,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.decisions.readme | repo_only | docs/decisions/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.chapter-clinical-verified-outline | repo_only | docs/dissertation/chapter_clinical_verified_outline.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.dossier-template | repo_only | docs/dissertation/dossier_template.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.dissertation.pbpk-claim-truth-table | repo_only | docs/dissertation/pbpk_claim_truth_table.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ecosystem.curated-packages | repo_only | docs/ecosystem/CURATED_PACKAGES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ecosystem.ecosystem-roadmap-2026 | repo_only | docs/ecosystem/ECOSYSTEM_ROADMAP_2026.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ecosystem.pkg-manager-sota-position | repo_only | docs/ecosystem/PKG_MANAGER_SOTA_POSITION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1990,6 +1990,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.dissertation.pbpk-claim-truth-table",
+      "collection": "repo",
+      "repo_doc_path": "docs/dissertation/pbpk_claim_truth_table.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.ecosystem.curated-packages",
       "collection": "repo",
       "repo_doc_path": "docs/ecosystem/CURATED_PACKAGES.md",

--- a/docs/papers/main/168-revision-notes.md
+++ b/docs/papers/main/168-revision-notes.md
@@ -640,3 +640,133 @@ GL(k', F₂) ⊂ GL(k, F₂) actions for k' < k.
 - Lane 3 build target green: cocycle_subspace_{168,k5,k6,k7,k8,k9}.sio
   all compile and pass their internal checks.
 - Wall clock: full k=9 enumeration in 11.5 s on Linux x86-64 native.
+
+---
+
+## Revision 3.5 — Lane 3 follow-up: k=10 (2048-ions, dim 1024) confirms four-level saturation; anomaly factorisation refines (2026-05-10)
+
+Lane 3 continuation past Revision 3.4 (three-level saturation result):
+added the seventh empirical data point in the 1024-dimensional Cayley-
+Dickson algebra. Two purposes: test the four-level-plateau hypothesis,
+and check whether the count-168 anomaly factorisation continues with
+exactly two primes.
+
+### What's new
+
+- `examples/cocycle_subspace_k10.sio` (NEW). Builds the 1024×1024
+  multiplication table for the k=10 CD algebra (2048-ions) via seven
+  CD doublings 𝕆→𝕊→𝕋→𝕮→ℝ→𝕍→𝕂→𝕃. Static memory: 1024² × 2 i64
+  = 16 MB BSS for the k=10 table alone, plus ~5.34 MB for all lower-CD
+  tables ≈ 21.3 MB total. Compiles cleanly under the Sounio native
+  compiler (no observed BSS-zero-init limit even at 16 MB).
+- Enumerates 6,347,715 = P_10 three-dim subspaces of (ℤ/2)^10 via
+  direct 3-LI-generator enumeration. Total enumeration wall clock:
+  **95 s** on Linux x86-64. Inner-loop VLIST optimization: 7³ = 343
+  associator calls per canonical.
+- `@table:subspace-k10` added to Section 7.
+
+### Empirical findings
+
+**23 distinct count classes** at k=10 — same count AND same values as
+k=7, 8, 9. The class set
+{72, 76, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110,
+ 168, 180, 184, 186, 188, 190, 194}
+is now confirmed bit-identical across **four consecutive levels**
+(k=7, 8, 9, 10).
+
+| Count | Mult.    | Count | Mult.    |
+|---:|---:|---:|---:|
+| 194 | 29295    | 100 | 13671    |
+| 190 | 117180   | 98  | 160146   |
+| 188 | 13671    | 96  | 15442    |
+| 186 | 87885    | 94  | 376929   |
+| 184 | 13671    | 92  | 14994    |
+| 180 | 441      | 90  | 597618   |
+| 168 | 569327   | 88  | 1368423  |
+| 110 | 29295    | 86  | 351540   |
+| 108 | 451584   | 84  | 13671    |
+| 106 | 117180   | 76  | 1354752  |
+| 104 | 13671    | 72  | 520149   |
+| 102 | 117180   | —   | —        |
+
+(Sum = 6,347,715 = P_10, ✓.)
+
+### Three findings
+
+1. **Saturation across four consecutive levels.** Class-count chain
+   {1, 2, 7, 16, 23, 23, 23, 23} at k ∈ {3..10}. Distinct-count set
+   stays bit-identical at k=7, 8, 9, 10. Very strong evidence the
+   limiting set is exactly the 23 values listed above.
+
+2. **Conjecture 5 holds at SEVEN consecutive levels.** Predicted
+   T_10 = 168·(P_10 − 4·P_9) = 168·3195575 = 536,856,600.
+   Measured: 536,856,600 (bit-exact). Closed-form
+   `T_k = 168·(2^{k-1}−1)(2^{k-2}−1)(2^{k-1}+3)/21` validated at
+   k ∈ {4, 5, 6, 7, 8, 9, 10}.
+
+3. **Anomaly factorisation transitions from two primes to three.**
+   At k=6,7,8,9 the count-168 multiplicity was a two-prime non-7
+   product. At k=10 the multiplicity is 569327 = **11 · 73 · 709**
+   — THREE primes, still non-7. The "two-prime" pattern was therefore
+   not the structural feature; the structural feature is **non-7
+   divisibility**. The number of prime factors evidently grows
+   slowly with k.
+
+### Updated anomaly factorisation table
+
+| k  | mult     | factorisation     | non-7 form              |
+|----|---------:|:------------------|:------------------------|
+| 4  | 0        | —                 | (no count=168 class)    |
+| 5  | 43       | 43 (prime)        | single prime, non-7     |
+| 6  | 247      | 13 · 19           | two primes, non-7       |
+| 7  | 1535     | 5 · 307           | two primes, non-7       |
+| 8  | 10383    | 3 · 3461          | two primes, non-7       |
+| 9  | 75183    | 3 · 25061         | two primes, non-7       |
+| 10 | 569327   | 11 · 73 · 709     | **three** primes, non-7 |
+
+At k=10 the largest prime factor (709) is dramatically smaller than
+at k=9 (25061), even though the multiplicity itself is 7.57× larger.
+This reflects the structural transition from two- to three-prime
+factorisation rather than a discontinuity in the orbit structure.
+
+### Anomaly multiplicity growth ratios
+
+Consecutive ratios mult(k+1) / mult(k):
+
+| k → k+1 | Ratio |
+|---------|------:|
+| 5 → 6   | 5.74  |
+| 6 → 7   | 6.21  |
+| 7 → 8   | 6.76  |
+| 8 → 9   | 7.24  |
+| 9 → 10  | 7.57  |
+
+Monotone increasing, converging from below toward 8 = 2³. Five
+consecutive ratios now support this conjecture.
+
+### Pattern in non-anomaly multiplicities
+
+The factor 31 = 2⁵ − 1 continues to appear in many k=10 multiplicities,
+e.g. count=184/188 mult=13671 = 3² · 7² · 31; count=110/194 mult=29295
+= 3³ · 5 · 7² · 31. The GL(5, F₂) subgroup observation from Revision 3.4
+extends. Notable new factor: count=88 has mult=1368423 = 3 · 7 · 65163,
+the dominant class at k=10 (1.37 M subspaces out of 6.35 M, 21.6%).
+
+### Memory observation
+
+The Sounio native compiler handles a 16 MB static array
+`[i64; 1048576]` without complaint. This is the largest single static
+allocation in the example chain to date. The total static BSS for
+k=10 including all lower CD tables is ~21.3 MB.
+
+### Status
+
+- T_3, T_4, T_5, T_6, T_7, T_8, T_9, T_10 all numerically confirmed
+  against Conjecture 5 closed form (**seven** consecutive levels at k≥4).
+- Revised Open Question 1 now has **seven** empirical inputs (k=4..10)
+  AND a four-level saturation result: 23 orbit classes confirmed at
+  k=7, 8, 9, 10 — very strong evidence for the limiting-orbit-set
+  conjecture.
+- Lane 3 build target green: cocycle_subspace_{168,k5,k6,k7,k8,k9,k10}.sio
+  all compile and pass their internal checks.
+- Wall clock: full k=10 enumeration in 95 s on Linux x86-64 native.

--- a/docs/papers/main/168-theorem.typ
+++ b/docs/papers/main/168-theorem.typ
@@ -439,6 +439,38 @@ Three more results survive the passage to $k = 9$:
 
 - *Anomaly multiplicity grows geometrically.* The count-$168$ multiplicities ${43, 247, 1535, 10383, 75183}$ at $k in {5, 6, 7, 8, 9}$ give ratios $5.74, 6.21, 6.76, 7.24$, monotone increasing and apparently converging from below toward $8 = 2^3$. The factorisations $43, 247 = 13 dot 19, 1535 = 5 dot 307, 10383 = 3 dot 3461, 75183 = 3 dot 25061$ continue the "single prime or two-prime non-$7$" signature (note $25061$ is prime, as is $3461$). The other twenty-two multiplicities at $k = 9$ are again all $7$-divisible, including the entire super-octonionic family ${180, 184, 186, 188, 190, 194}$ with $7$-divisible multiplicities ${217, 3255, 9765, 3255, 13020, 3255}$ where $217 = 7 dot 31$ is the smallest. The factor $31 = 2^5 - 1$ appears in many $k = 9$ multiplicities, suggesting a $"GL"(5, FF_2)$ subgroup structure inherited from the trigintaduonion level.
 
+A seventh level ($k = 10$, $dim = 1024$) was added to test the four-level-plateau hypothesis. The direct $3$-LI-generator enumeration scans the $1023^3 slash 6 approx 178$ million raw triples in approximately $95$ seconds wall clock and resolves all $P_{10} = 6347715 = binom(10,3)_2$ canonical subspaces:
+
+#figure(
+  table(
+    columns: 4,
+    align: (center, center, center, center),
+    stroke: 0.5pt,
+    [*Count*], [*Multiplicity*], [*Count*], [*Multiplicity*],
+    [194], [29295],   [100], [13671],
+    [190], [117180],  [98],  [160146],
+    [188], [13671],   [96],  [15442],
+    [186], [87885],   [94],  [376929],
+    [184], [13671],   [92],  [14994],
+    [180], [441],     [90],  [597618],
+    [168], [569327],  [88],  [1368423],
+    [110], [29295],   [86],  [351540],
+    [108], [451584],  [84],  [13671],
+    [106], [117180],  [76],  [1354752],
+    [104], [13671],   [72],  [520149],
+    [102], [117180],  [--],  [--],
+  ),
+  caption: [Distribution of nonzero basis associator counts at $k = 10$, exhaustive over all $6347715$ three-dimensional subspaces of $(ZZ slash 2)^{10}$. Verified in Sounio (`examples/cocycle_subspace_k10.sio`); total $T_{10} = 536856600 = 3195575 dot 168$ matches the prediction of Conjecture 5. The class set (twenty-three count values) is *bit-identical* to the class sets at $k = 7, 8, 9$.],
+) <table:subspace-k10>
+
+The $k = 10$ data delivers a four-level saturation plateau and an unexpected refinement of the anomaly factorisation pattern:
+
+- *Saturation across four levels.* The class-count chain extends to ${1, 2, 7, 16, 23, 23, 23, 23}$ at $k in {3, 4, 5, 6, 7, 8, 9, 10}$. The distinct-count set ${72, 76, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110, 168, 180, 184, 186, 188, 190, 194}$ is bit-identical across four consecutive Cayley–Dickson levels. The conjecture that the limiting distinct-count set is exactly twenty-three is now strongly supported.
+
+- *Conjecture 5 holds at seven consecutive levels.* Predicted $T_{10} = 168 dot (P_{10} - 4 P_9) = 168 dot 3195575 = 536856600$; measured: $536856600$ bit-exact. The closed form is validated without exception at $k in {4, 5, 6, 7, 8, 9, 10}$.
+
+- *Anomaly factorisation transitions from two primes to three.* The count-$168$ multiplicity at $k = 10$ is $569327 = 11 dot 73 dot 709$, with all three factors prime. This breaks the "two-prime" pattern that held at $k = 6, 7, 8, 9$ but preserves the structural feature — the multiplicity is still not divisible by $7$. The pattern is therefore refined from "two-prime non-$7$" to "non-$7$ with bounded prime count growing slowly with $k$". The multiplicity ratio $569327 slash 75183 approx 7.57$ extends the monotone-increasing sequence ${5.74, 6.21, 6.76, 7.24, 7.57}$, still approaching $8 = 2^3$ from below. Every other multiplicity at $k = 10$ remains $7$-divisible, including all six super-octonionic counts and the highly composite multiplicities like $1368423 = 3 dot 7 dot 65163$ at count $88$ or $1354752 = 2^9 dot 3^3 dot 7^2$ at count $76$.
+
 == Implications
 
 1. *Conjecture 5 is structurally richer than its compact form $T_k = 168(P_k - 4 P_(k-1))$ suggests.* The simple "subtract trivial subspaces" interpretation is empirically false: at $k = 5$ no 3-dimensional subspace carries the trivial cocycle, and the per-subspace counts span seven distinct values. The arithmetic identity $T_k = 168(P_k - 4 P_(k-1))$ is therefore a *cohomological balance*, with positive contributions from "super-octonionic" subspaces (e.g. count $180$ at $k = 5$) cancelling against partial-cocycle subspaces (counts below 168). A complete proof must enumerate the cocycle restriction classes and weight them with their LI nonzero contributions, recovering the closed form $T_k = 168 dot (2^(k-1) - 1)(2^(k-2) - 1)(2^(k-1) + 3) slash 21$.
@@ -456,7 +488,7 @@ This is the natural categorical home for the algebras and organizes the Sounio c
   *Revised Open Question 1.* _Classify the cocycle restriction classes that arise as $phi_k|_V$ for 3-dimensional subspaces $V <= (ZZ slash 2)^k$, with their multiplicities, and prove Conjecture 5 by weighting each class by its LI nonzero associator count._
 ]
 
-@table:subspace, @table:subspace-k5, @table:subspace-k6, @table:subspace-k7, @table:subspace-k8, and @table:subspace-k9 supply six empirical inputs for this classification. The multiplicities at $k = 4, 5, 6, 7, 8, 9$ are predominantly multiples of $7$ and $21$, consistent with an orbit-counting derivation under the $"GL"(k, FF_2)$ action lifting the canonical $"PSL"(2,7)$-action on the Fano cocycle. *At $k = 8$ and $k = 9$ every non-anomaly multiplicity is $7$-divisible* — the single exception at each level is the count-$168$ class with multiplicity $10383 = 3 dot 3461$ ($k = 8$) and $75183 = 3 dot 25061$ ($k = 9$), extending the level-specific "two-prime non-$7$" signature ($247 = 13 dot 19$ at $k = 6$, $1535 = 5 dot 307$ at $k = 7$, $10383 = 3 dot 3461$ at $k = 8$, $75183 = 3 dot 25061$ at $k = 9$, with ratios $5.74, 6.21, 6.76, 7.24$ converging to $8$ from below). The class-set saturation at $k = 7$ is now confirmed across three consecutive levels ($k = 7, 8, 9$), reducing the classification target from an infinite family to a finite set of $23$ orbits: a complete proof must identify *two* orbit families — the $"PSL"(2,7)$-derived multiples of $7$, and the count-$168$ anomaly with its level-dependent two-prime non-$7$ signature.
+@table:subspace, @table:subspace-k5, @table:subspace-k6, @table:subspace-k7, @table:subspace-k8, @table:subspace-k9, and @table:subspace-k10 supply seven empirical inputs for this classification. The multiplicities at $k = 4, 5, 6, 7, 8, 9, 10$ are predominantly multiples of $7$ and $21$, consistent with an orbit-counting derivation under the $"GL"(k, FF_2)$ action lifting the canonical $"PSL"(2,7)$-action on the Fano cocycle. *At $k = 8, 9, 10$ every non-anomaly multiplicity is $7$-divisible*; the only exception at each level is the count-$168$ class. The anomaly-multiplicity factorisations at $k = 6, 7, 8, 9, 10$ are $247 = 13 dot 19$, $1535 = 5 dot 307$, $10383 = 3 dot 3461$, $75183 = 3 dot 25061$, $569327 = 11 dot 73 dot 709$ — all non-$7$, with the count of prime factors transitioning from two (at $k = 6..9$) to three (at $k = 10$). The growth ratios ${5.74, 6.21, 6.76, 7.24, 7.57}$ are monotone increasing and converge from below toward $8 = 2^3$. The class-set saturation at $k = 7$ is now confirmed across four consecutive levels ($k = 7, 8, 9, 10$), reducing the classification target from an infinite family to a finite set of $23$ orbits: a complete proof must identify *two* orbit families — the $"PSL"(2,7)$-derived multiples of $7$, and the count-$168$ anomaly with its level-dependent non-$7$ signature.
 
 == Computational verification of the cohomological construction
 
@@ -469,5 +501,6 @@ The cohomological reformulation is computationally validated in Sounio:
 - `examples/cocycle_subspace_k7.sio` — extends to routons (dim $128$); enumerates the 11811 three-dimensional subspaces of $(ZZ slash 2)^7$ via canonical lex-minimal LI quadruples of dual functionals, with VLIST inner-loop optimization (precompute $V$'s seven nonzero elements before triple iteration), producing @table:subspace-k7 (3/3 PASS, $T_7 = 1046808 = 6231 dot 168$ confirmed).
 - `examples/cocycle_subspace_k8.sio` — extends to voudons (dim $256$); enumerates the 97155 three-dimensional subspaces of $(ZZ slash 2)^8$. The dual-functional walk used at $k = 4..7$ is infeasible at $k = 8$ ($approx 1.4$ billion raw LI quintuples), so this case switches to direct 3-LI-generator enumeration (canonical $v_1 < v_2 < v_3$, $v_3 in.not "span"(v_1, v_2)$, each generator the minimum of its coset). Produces @table:subspace-k8 (3/3 PASS, $T_8 = 8385048 = 49911 dot 168$ confirmed) and establishes the class-set saturation at twenty-three count values from $k = 7$ onward.
 - `examples/cocycle_subspace_k9.sio` — extends to $1024$-ions (dim $512$); enumerates the 788035 three-dimensional subspaces of $(ZZ slash 2)^9$ via the same direct $3$-generator enumeration as $k = 8$, with one additional Cayley–Dickson doubling step (six total: $OO -> SS -> TT -> "Chingons" -> "Routons" -> "Voudons" -> "1024-ions"$). Produces @table:subspace-k9 (3/3 PASS, $T_9 = 67101720 = 399415 dot 168$ confirmed) and confirms saturation at twenty-three count values across three consecutive levels ($k = 7, 8, 9$). Wall clock: $approx 11.5$ s on Linux x86-64 native.
+- `examples/cocycle_subspace_k10.sio` — extends to $2048$-ions (dim $1024$); enumerates the 6,347,715 three-dimensional subspaces of $(ZZ slash 2)^{10}$ via the same direct $3$-generator enumeration as $k = 8, 9$, with one more Cayley–Dickson doubling step (seven total). Static memory: $1024^2 dot 2$ i64 $= 16$ MB BSS for the $k = 10$ multiplication table alone (plus $approx 5.34$ MB for all lower-CD tables). Produces @table:subspace-k10 (3/3 PASS, $T_{10} = 536856600 = 3195575 dot 168$ confirmed) and confirms saturation across four consecutive levels ($k = 7, 8, 9, 10$). Wall clock: $approx 95$ s on Linux x86-64 native; gate timeout 600 s.
 
 #bibliography("168-refs.yml", style: "springer-mathphys")

--- a/examples/cocycle_subspace_k10.sio
+++ b/examples/cocycle_subspace_k10.sio
@@ -1,0 +1,704 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cohomological subspace decomposition at k=10 (2048-ions, dim 1024)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Lane 3 continuation past cocycle_subspace_k9.sio. Walks one more level
+// up the Cayley-Dickson tower and enumerates the 6,347,715 = P_10 =
+// [10 choose 3]_2 three-dimensional subspaces of (Z/2)^10 in the
+// 1024-dim CD algebra.
+//
+// Predicted total (Conjecture 5, validated at k=4..9):
+//   T_k = 168 * (P_k - 4 * P_{k-1})
+//   T_10 = 168 * (6,347,715 - 4 * 788,035) = 168 * 3,195,575 = 536,856,600.
+//
+// Tests whether the three-level saturation plateau {23, 23, 23} at
+// k ∈ {7, 8, 9} extends to a FOURTH consecutive level. Class-count chain
+// so far: {1, 2, 7, 16, 23, 23, 23} at k ∈ {3..9}.
+//
+// Memory: this is the bulkiest example in the chain. 1024² = 1,048,576
+// entries per table = 8 MB per i64 array. Two arrays (MUL+SGN) for k=10
+// alone = 16 MB BSS. Total static memory including all lower CD doublings:
+// ~21.3 MB. If the Sounio native compiler rejects the 1M-entry static
+// array, fall back to either i32 entries (8 MB combined) or chunked
+// allocation (not yet attempted in the chain).
+//
+// Runtime: ~3-5 min wall clock. Comprises:
+//   - count_total at 1023³ ≈ 1.07G associator triples
+//   - canonical enumeration over ~1023³/6 ≈ 178M raw triples
+//   - 6,347,715 canonicals × 7³ = 2.18G inner associator calls
+// All inner calls are ~6 array lookups; total ~10G ops. Bound the gate
+// timeout at 600s.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Octonion multiplication table.
+var O_MUL: [i64; 64] = [0; 64]
+var O_SGN: [i64; 64] = [0; 64]
+
+fn init_oct() with Mut {
+    var i = 0
+    while i < 8 {
+        O_MUL[0 * 8 + i] = i
+        O_SGN[0 * 8 + i] = 1
+        O_MUL[i * 8 + 0] = i
+        O_SGN[i * 8 + 0] = 1
+        i = i + 1
+    }
+    i = 1
+    while i < 8 {
+        O_MUL[i * 8 + i] = 0
+        O_SGN[i * 8 + i] = 0 - 1
+        i = i + 1
+    }
+    var FA: [i64; 7] = [1, 2, 3, 4, 5, 6, 7]
+    var FB: [i64; 7] = [2, 3, 4, 5, 6, 7, 1]
+    var FC: [i64; 7] = [4, 5, 6, 7, 1, 2, 3]
+    var t = 0
+    while t < 7 {
+        let a = FA[t]
+        let b = FB[t]
+        let c = FC[t]
+        O_MUL[a * 8 + b] = c
+        O_SGN[a * 8 + b] = 1
+        O_MUL[b * 8 + a] = c
+        O_SGN[b * 8 + a] = 0 - 1
+        O_MUL[b * 8 + c] = a
+        O_SGN[b * 8 + c] = 1
+        O_MUL[c * 8 + b] = a
+        O_SGN[c * 8 + b] = 0 - 1
+        O_MUL[c * 8 + a] = b
+        O_SGN[c * 8 + a] = 1
+        O_MUL[a * 8 + c] = b
+        O_SGN[a * 8 + c] = 0 - 1
+        t = t + 1
+    }
+}
+
+var S_MUL: [i64; 256] = [0; 256]
+var S_SGN: [i64; 256] = [0; 256]
+var T_MUL: [i64; 1024] = [0; 1024]
+var T_SGN: [i64; 1024] = [0; 1024]
+var C_MUL: [i64; 4096] = [0; 4096]
+var C_SGN: [i64; 4096] = [0; 4096]
+var R_MUL: [i64; 16384] = [0; 16384]
+var R_SGN: [i64; 16384] = [0; 16384]
+var V_MUL: [i64; 65536] = [0; 65536]
+var V_SGN: [i64; 65536] = [0; 65536]
+var K_MUL: [i64; 262144] = [0; 262144]
+var K_SGN: [i64; 262144] = [0; 262144]
+var L_MUL: [i64; 1048576] = [0; 1048576]
+var L_SGN: [i64; 1048576] = [0; 1048576]
+
+fn init_doublings() with Mut, Panic {
+    // Step 1: build S (sedenions, dim 16) from O (octonions, dim 8).
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            let a_part = i & 7
+            let top_a = i >> 3
+            let b_part = j & 7
+            let top_b = j >> 3
+            let ab_idx = O_MUL[a_part * 8 + b_part]
+            let ab_sgn = O_SGN[a_part * 8 + b_part]
+            let ba_idx = O_MUL[b_part * 8 + a_part]
+            let ba_sgn = O_SGN[b_part * 8 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            S_MUL[i * 16 + j] = r_idx + r_top * 8
+            S_SGN[i * 16 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 2: build T (trigintaduonions, dim 32) from S.
+    i = 0
+    while i < 32 {
+        var j = 0
+        while j < 32 {
+            let a_part = i & 15
+            let top_a = i >> 4
+            let b_part = j & 15
+            let top_b = j >> 4
+            let ab_idx = S_MUL[a_part * 16 + b_part]
+            let ab_sgn = S_SGN[a_part * 16 + b_part]
+            let ba_idx = S_MUL[b_part * 16 + a_part]
+            let ba_sgn = S_SGN[b_part * 16 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            T_MUL[i * 32 + j] = r_idx + r_top * 16
+            T_SGN[i * 32 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 3: build C (chingons, dim 64) from T.
+    i = 0
+    while i < 64 {
+        var j = 0
+        while j < 64 {
+            let a_part = i & 31
+            let top_a = i >> 5
+            let b_part = j & 31
+            let top_b = j >> 5
+            let ab_idx = T_MUL[a_part * 32 + b_part]
+            let ab_sgn = T_SGN[a_part * 32 + b_part]
+            let ba_idx = T_MUL[b_part * 32 + a_part]
+            let ba_sgn = T_SGN[b_part * 32 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            C_MUL[i * 64 + j] = r_idx + r_top * 32
+            C_SGN[i * 64 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 4: build R (routons, dim 128) from C.
+    i = 0
+    while i < 128 {
+        var j = 0
+        while j < 128 {
+            let a_part = i & 63
+            let top_a = i >> 6
+            let b_part = j & 63
+            let top_b = j >> 6
+            let ab_idx = C_MUL[a_part * 64 + b_part]
+            let ab_sgn = C_SGN[a_part * 64 + b_part]
+            let ba_idx = C_MUL[b_part * 64 + a_part]
+            let ba_sgn = C_SGN[b_part * 64 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            R_MUL[i * 128 + j] = r_idx + r_top * 64
+            R_SGN[i * 128 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 5: build V (voudons, dim 256) from R.
+    i = 0
+    while i < 256 {
+        var j = 0
+        while j < 256 {
+            let a_part = i & 127
+            let top_a = i >> 7
+            let b_part = j & 127
+            let top_b = j >> 7
+            let ab_idx = R_MUL[a_part * 128 + b_part]
+            let ab_sgn = R_SGN[a_part * 128 + b_part]
+            let ba_idx = R_MUL[b_part * 128 + a_part]
+            let ba_sgn = R_SGN[b_part * 128 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            V_MUL[i * 256 + j] = r_idx + r_top * 128
+            V_SGN[i * 256 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 6: build K (1024-ions, dim 512) from V.
+    i = 0
+    while i < 512 {
+        var j = 0
+        while j < 512 {
+            let a_part = i & 255
+            let top_a = i >> 8
+            let b_part = j & 255
+            let top_b = j >> 8
+            let ab_idx = V_MUL[a_part * 256 + b_part]
+            let ab_sgn = V_SGN[a_part * 256 + b_part]
+            let ba_idx = V_MUL[b_part * 256 + a_part]
+            let ba_sgn = V_SGN[b_part * 256 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            K_MUL[i * 512 + j] = r_idx + r_top * 256
+            K_SGN[i * 512 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // Step 7: build L (2048-ions, dim 1024) from K.
+    i = 0
+    while i < 1024 {
+        var j = 0
+        while j < 1024 {
+            let a_part = i & 511
+            let top_a = i >> 9
+            let b_part = j & 511
+            let top_b = j >> 9
+            let ab_idx = K_MUL[a_part * 512 + b_part]
+            let ab_sgn = K_SGN[a_part * 512 + b_part]
+            let ba_idx = K_MUL[b_part * 512 + a_part]
+            let ba_sgn = K_SGN[b_part * 512 + a_part]
+            var r_idx = 0
+            var r_sgn = 0
+            var r_top = 0
+            if top_a == 0 {
+                if top_b == 0 {
+                    r_idx = ab_idx
+                    r_sgn = ab_sgn
+                    r_top = 0
+                } else {
+                    r_idx = ba_idx
+                    r_sgn = ba_sgn
+                    r_top = 1
+                }
+            } else {
+                if top_b == 0 {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 1
+                        r_top = 1
+                    } else {
+                        r_idx = ab_idx
+                        r_sgn = 0 - ab_sgn
+                        r_top = 1
+                    }
+                } else {
+                    if b_part == 0 {
+                        r_idx = a_part
+                        r_sgn = 0 - 1
+                        r_top = 0
+                    } else {
+                        r_idx = ba_idx
+                        r_sgn = ba_sgn
+                        r_top = 0
+                    }
+                }
+            }
+            L_MUL[i * 1024 + j] = r_idx + r_top * 512
+            L_SGN[i * 1024 + j] = r_sgn
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+var LR_IDX: i64 = 0
+var LR_SGN: i64 = 0
+
+fn ten_bmul(i_idx: i64, i_sgn: i64, j_idx: i64, j_sgn: i64) with Mut, Panic {
+    LR_IDX = L_MUL[i_idx * 1024 + j_idx]
+    LR_SGN = i_sgn * j_sgn * L_SGN[i_idx * 1024 + j_idx]
+}
+
+fn ten_associator_nonzero(x: i64, y: i64, z: i64) -> i64 with Mut, Panic {
+    ten_bmul(x, 1, y, 1)
+    let li_t = LR_IDX
+    let ls_t = LR_SGN
+    ten_bmul(li_t, ls_t, z, 1)
+    let l_idx = LR_IDX
+    let l_sgn = LR_SGN
+    ten_bmul(y, 1, z, 1)
+    let ri_t = LR_IDX
+    let rs_t = LR_SGN
+    ten_bmul(x, 1, ri_t, rs_t)
+    let r_idx = LR_IDX
+    let r_sgn = LR_SGN
+    if l_idx != r_idx { return 1 }
+    if l_sgn != r_sgn { return 1 }
+    0
+}
+
+// VLIST holds the 7 nonzero elements of V = span(v1, v2, v3).
+var VLIST: [i64; 8] = [0; 8]
+
+fn build_v_k10(v1: i64, v2: i64, v3: i64) with Mut {
+    VLIST[0] = v1
+    VLIST[1] = v2
+    VLIST[2] = v3
+    VLIST[3] = v1 ^ v2
+    VLIST[4] = v1 ^ v3
+    VLIST[5] = v2 ^ v3
+    VLIST[6] = v1 ^ v2 ^ v3
+}
+
+fn count_subspace_assoc_3d_k10() -> i64 with Mut, Panic {
+    var n = 0
+    var ii = 0
+    while ii < 7 {
+        let i = VLIST[ii]
+        var jj = 0
+        while jj < 7 {
+            let j = VLIST[jj]
+            var kk = 0
+            while kk < 7 {
+                let k = VLIST[kk]
+                if ten_associator_nonzero(i, j, k) == 1 {
+                    n = n + 1
+                }
+                kk = kk + 1
+            }
+            jj = jj + 1
+        }
+        ii = ii + 1
+    }
+    n
+}
+
+fn count_total_ten() -> i64 with Mut, Panic {
+    var n = 0
+    var i = 1
+    while i < 1024 {
+        var j = 1
+        while j < 1024 {
+            var k = 1
+            while k < 1024 {
+                if ten_associator_nonzero(i, j, k) == 1 {
+                    n = n + 1
+                }
+                k = k + 1
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+// Distribution buckets — 128 still ample (saturation at 23 from k=7).
+var BUCKET_VAL: [i64; 128] = [0; 128]
+var BUCKET_CNT: [i64; 128] = [0; 128]
+var N_BUCKETS: i64 = 0
+var BUCKET_OVERFLOW: i64 = 0
+
+fn record_bucket(v: i64) with Mut, Panic {
+    var i = 0
+    while i < N_BUCKETS {
+        if BUCKET_VAL[i] == v {
+            BUCKET_CNT[i] = BUCKET_CNT[i] + 1
+            return
+        }
+        i = i + 1
+    }
+    if N_BUCKETS < 128 {
+        BUCKET_VAL[N_BUCKETS] = v
+        BUCKET_CNT[N_BUCKETS] = 1
+        N_BUCKETS = N_BUCKETS + 1
+    } else {
+        BUCKET_OVERFLOW = BUCKET_OVERFLOW + 1
+    }
+}
+
+fn main() -> i32 with IO, Mut, Panic {
+    println("═══════════════════════════════════════════════════════════════")
+    println("  Subspace decomposition at k=10 (2048-ions, dim 1024)")
+    println("═══════════════════════════════════════════════════════════════")
+
+    init_oct()
+    init_doublings()
+
+    var pass = 0
+    var fail = 0
+
+    // 1. Sanity: total nonzero 2048-ion associators = T_10 (predicted 168·3195575).
+    let total = count_total_ten()
+    print("  Total 2048-ion associators: ")
+    print_int(total)
+    print(" (expected 536856600 = 168 * 3195575)\n")
+    if total == 536856600 {
+        print("  [PASS] T_10 = 536856600 = 3195575 * 168\n")
+        pass = pass + 1
+    } else {
+        print("  [FAIL] T_10 mismatch\n")
+        fail = fail + 1
+    }
+
+    // 2. Enumerate 6,347,715 = P_10 three-dim subspaces of (Z/2)^10.
+    //    Direct 3-LI-generator enumeration: canonical (v1, v2, v3) with
+    //    v1 < v2 < v3, v3 ∉ {v1, v2, v1^v2}, and each generator the
+    //    minimum of its remaining coset (lex-min RREF basis).
+    var seen = 0
+    var v1 = 1
+    while v1 < 1024 {
+        var v2 = v1 + 1
+        while v2 < 1024 {
+            let s12 = v1 ^ v2
+            var v3 = v2 + 1
+            while v3 < 1024 {
+                if v3 != s12 {
+                    let s13 = v1 ^ v3
+                    let s23 = v2 ^ v3
+                    let s123 = v1 ^ v2 ^ v3
+                    var ok = 1
+                    if s12 < v1 { ok = 0 }
+                    if s13 < v1 { ok = 0 }
+                    if s23 < v1 { ok = 0 }
+                    if s123 < v1 { ok = 0 }
+                    if s12 < v2 { ok = 0 }
+                    if s13 < v2 { ok = 0 }
+                    if s23 < v2 { ok = 0 }
+                    if s123 < v2 { ok = 0 }
+                    if s13 < v3 { ok = 0 }
+                    if s23 < v3 { ok = 0 }
+                    if s123 < v3 { ok = 0 }
+                    if ok == 1 {
+                        build_v_k10(v1, v2, v3)
+                        let cnt = count_subspace_assoc_3d_k10()
+                        record_bucket(cnt)
+                        seen = seen + 1
+                    }
+                }
+                v3 = v3 + 1
+            }
+            v2 = v2 + 1
+        }
+        v1 = v1 + 1
+    }
+    print("  Enumerated 3-dim subspaces: ")
+    print_int(seen)
+    print(" (expected 6347715 = P_10)\n")
+    if seen == 6347715 {
+        print("  [PASS] P_10 = 6347715 enumerated correctly\n")
+        pass = pass + 1
+    } else {
+        print("  [FAIL] subspace enumeration count\n")
+        fail = fail + 1
+    }
+
+    // 3. Bucket-overflow guard.
+    if BUCKET_OVERFLOW == 0 {
+        print("  [PASS] bucket capacity sufficient (no overflow)\n")
+        pass = pass + 1
+    } else {
+        print("  [FAIL] BUCKET overflow: ")
+        print_int(BUCKET_OVERFLOW)
+        print(" classes truncated — recompile with larger BUCKET arrays\n")
+        fail = fail + 1
+    }
+
+    // 4. Print distribution.
+    print("\n  Distribution of per-subspace nonzero associator counts:\n")
+    var i = 0
+    while i < N_BUCKETS {
+        print("    count=")
+        print_int(BUCKET_VAL[i])
+        print(" -> ")
+        print_int(BUCKET_CNT[i])
+        print(" subspaces\n")
+        i = i + 1
+    }
+    print("  Total distinct count classes: ")
+    print_int(N_BUCKETS)
+    print("\n")
+
+    print("\nPassed: ")
+    print_int(pass)
+    print("\nFailed: ")
+    print_int(fail)
+    print("\n")
+    if fail == 0 { println("ALL PASS") }
+    else { println("SOME FAILED") }
+    0
+}

--- a/scripts/ci/paper168_cocycle_subspace_gate.sh
+++ b/scripts/ci/paper168_cocycle_subspace_gate.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Lane 3 — Paper 168 cocycle subspace enumeration gate.
 #
-# Compiles and runs the six cocycle_subspace_*.sio examples that
+# Compiles and runs the seven cocycle_subspace_*.sio examples that
 # back §7 of paper 168 ("On 168") and verifies each prints ALL PASS:
 #
-#   k=4 (sedenions,    dim 16)  examples/cocycle_subspace_168.sio
-#   k=5 (32-ions,      dim 32)  examples/cocycle_subspace_k5.sio
-#   k=6 (chingons,     dim 64)  examples/cocycle_subspace_k6.sio
-#   k=7 (routons,      dim 128) examples/cocycle_subspace_k7.sio
-#   k=8 (voudons,      dim 256) examples/cocycle_subspace_k8.sio
-#   k=9 (1024-ions,    dim 512) examples/cocycle_subspace_k9.sio
+#   k=4  (sedenions,    dim 16)   examples/cocycle_subspace_168.sio
+#   k=5  (32-ions,      dim 32)   examples/cocycle_subspace_k5.sio
+#   k=6  (chingons,     dim 64)   examples/cocycle_subspace_k6.sio
+#   k=7  (routons,      dim 128)  examples/cocycle_subspace_k7.sio
+#   k=8  (voudons,      dim 256)  examples/cocycle_subspace_k8.sio
+#   k=9  (1024-ions,    dim 512)  examples/cocycle_subspace_k9.sio
+#   k=10 (2048-ions,    dim 1024) examples/cocycle_subspace_k10.sio
 #
 # Each example does its own self-check (T_k matches Conjecture 5,
 # P_k enumeration matches the Gaussian binomial [k choose 3]_2),
@@ -79,7 +80,7 @@ run_case() {
 }
 
 echo "═══════════════════════════════════════════════════════════════"
-echo "  Paper 168 — cocycle subspace enumeration gate (k=4..9)"
+echo "  Paper 168 — cocycle subspace enumeration gate (k=4..10)"
 echo "═══════════════════════════════════════════════════════════════"
 
 # k=4 (cocycle_subspace_168.sio) predates the cohomological reformulation
@@ -114,6 +115,11 @@ run_case "k8" \
 run_case "k9" \
     "examples/cocycle_subspace_k9.sio" \
     "788035 = P_9" \
+    "yes"
+
+run_case "k10" \
+    "examples/cocycle_subspace_k10.sio" \
+    "6347715 = P_10" \
     "yes"
 
 echo ""


### PR DESCRIPTION
## Summary

- Seventh empirical data point for Revised Open Question 1 of paper 168 §7. Tests the four-level-saturation hypothesis raised by #116 and probes the count=168 anomaly factorisation pattern.
- **Saturation across four consecutive levels.** Class-count chain {1, 2, 7, 16, 23, 23, 23, **23**} at k ∈ {3..10}. The class value set is bit-identical at k=7, 8, 9, 10. Very strong evidence the limiting distinct-count set is exactly 23.
- **Conjecture 5 holds at seven consecutive levels.** Predicted T_10 = 168·3195575 = 536,856,600. Measured: 536,856,600. Closed-form `T_k = 168·(2^{k-1}−1)(2^{k-2}−1)(2^{k-1}+3)/21` validated at k ∈ {4..10}.
- **Anomaly factorisation transitions two primes → three primes.** At k=6..9 the count=168 multiplicity was a two-prime non-7 product. At k=10 it is **569327 = 11 · 73 · 709** — three primes, still non-7. The structural feature is non-7-divisibility, not two-prime-ness.

## Memory & runtime

- **Static BSS**: 1024² × 2 i64 = 16 MB for the k=10 multiplication table alone (4× k=9), total ~21.3 MB including all lower CD tables. Sounio native compiler handles this without complaint.
- **Wall clock**: **95 s** for full enumeration of 6,347,715 = P_10 canonical 3-dim subspaces.
- **Gate** `paper168_cocycle_subspace_gate.sh` now covers k=4..10 in **1 m 51 s** (k=10 dominates ~95 s).

## Anomaly multiplicity table (updated)

| k  | mult    | factorisation         | non-7 form              |
|----|--------:|:----------------------|:------------------------|
| 5  | 43      | 43 (prime)            | single prime, non-7     |
| 6  | 247     | 13 · 19               | two primes, non-7       |
| 7  | 1535    | 5 · 307               | two primes, non-7       |
| 8  | 10383   | 3 · 3461              | two primes, non-7       |
| 9  | 75183   | 3 · 25061             | two primes, non-7       |
| 10 | 569327  | **11 · 73 · 709**     | **three** primes, non-7 |

Multiplicity ratios {5.74, 6.21, 6.76, 7.24, 7.57} monotone increasing toward 2³ = 8.

## Files

- `examples/cocycle_subspace_k10.sio` (NEW). Same direct 3-LI-generator enumeration framework as k=8, 9, with one more Cayley-Dickson doubling (𝕂 → 𝕃, dim 512 → 1024). Adds `L_MUL` / `L_SGN` at 1,048,576 i64 each.
- `scripts/ci/paper168_cocycle_subspace_gate.sh` — adds k=10 case.
- `docs/papers/main/168-theorem.typ` (§7) — appended `@table:subspace-k10` and three findings paragraph (four-level saturation, Conjecture 5 at seven levels, anomaly two→three prime transition).
- `docs/papers/main/168-revision-notes.md` — appended Revision 3.5 with full distribution table, anomaly factorisation update, and memory observation (16 MB BSS handled).
- `artifacts/omega/agent_handoff.log.md` — Lane-3 CLAIM + RELEASE entries (plus retroactive k=9 RELEASE).

## Test plan

- [x] `./bin/souc check examples/cocycle_subspace_k10.sio` → rc=0
- [x] `./bin/souc compile examples/cocycle_subspace_k10.sio -o /tmp/k10 && /tmp/k10` → ALL PASS, T_10=536856600, P_10=6347715, 23 classes, no bucket overflow, 95 s
- [x] `bash scripts/ci/paper168_cocycle_subspace_gate.sh` → 7/7 PASS in 1m51s
- [ ] Umbrella regression check post-merge.
- [ ] Reviewer Typst-builds `docs/papers/main/168-theorem.typ` and confirms `@table:subspace-k10` renders.
- [ ] Math-review by domain specialist (Majid, Rowell, or Etingof) before AACA/EJM submission per Section 7 risks (offload waiver recorded in `.claude/llm_offload_log.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)