### PR TITLE
[codex] Record PBPK claim-control audit fallback

### DIFF
--- a/artifacts/omega/pbpk_claim_truth_table_audit_followup.md
+++ b/artifacts/omega/pbpk_claim_truth_table_audit_followup.md
@@ -1,0 +1,69 @@
+# PBPK Claim Truth Table Audit Follow-Up
+
+Date: 2026-05-10
+Agent: Codex
+Local source commit: `0d2f20707209829a7e9904bf5c8c7440cec4e9ad` in `/tmp/sounio-pbpk-audit-followup`
+Related merge: PR #121, squash commit `a1739301ffeeccf8fc69177124e7a82bef551c0d`
+
+## Why This Exists
+
+PR #121 merged the dissertation-facing PBPK/GUM/GPU claim-control docs through the GitHub connector because local HTTPS push auth was unavailable. The local implementation commit also updated the canonical append-only audit files, but those two log edits were not part of the connector-published PR.
+
+This follow-up records the exact missing audit intent in a small connector-safe artifact. The canonical local log replay remains available in `/tmp/sounio-pbpk-audit-followup` as commit `0d2f20707209829a7e9904bf5c8c7440cec4e9ad`.
+
+## Missing `.claude/llm_offload_log.md` Rows
+
+| Date | Agent | Task | Provider | Target | Outcome | Commit |
+|------|-------|------|----------|--------|---------|--------|
+| 2026-05-10 | Codex | fan-out external-facing review | deepseek + xai + gemini | `docs/dissertation/chapter_clinical_verified_outline.md` | WAIVED - API_FAIL fallback: `bin/llm-offload --raw docs/dissertation/chapter_clinical_verified_outline.md deepseek xai gemini` returned rc=0 and output dir `/tmp/llm-offload-zjQPkM`, but produced no provider files; `bin/llm-offload --status` reported keys file `/workspace/.home/openvscode-server/.agents/codex-2/.sounio-keys.env` NOT FOUND. Manual fallback review limited the edit to citing `pbpk_claim_truth_table.md` as the PBPK/GUM/GPU claim-control artifact and forbidding PBPK14 single-kernel claims. | pending |
+| 2026-05-10 | Codex | fan-out external-facing review | deepseek + xai + gemini | `docs/dissertation/dossier_template.md` | WAIVED - API_FAIL fallback: `bin/llm-offload --raw docs/dissertation/dossier_template.md deepseek xai gemini` returned rc=0 and output dir `/tmp/llm-offload-Irw5f5`, but produced no provider files; `bin/llm-offload --status` reported keys file `/workspace/.home/openvscode-server/.agents/codex-2/.sounio-keys.env` NOT FOUND. Manual fallback review limited the edit to claim-control wording and an audit-trail pointer, with PBPK14 GPU-first and speedup claims left gated as future work. | pending |
+| 2026-05-10 | Codex | fan-out external-facing review | deepseek + xai + gemini | `docs/dissertation/pbpk_claim_truth_table.md` | WAIVED - API_FAIL fallback: `bin/llm-offload --raw docs/dissertation/pbpk_claim_truth_table.md deepseek xai gemini` returned rc=0 and output dir `/tmp/llm-offload-3UW4l8`, but produced no provider files; `bin/llm-offload --status` reported keys file `/workspace/.home/openvscode-server/.agents/codex-2/.sounio-keys.env` NOT FOUND. Manual fallback review kept claims scoped to repo paths and executable gates, with PBPK14 GPU and speedup language marked future/unsupported. Re-review before dissertation submission recommended when provider keys are available. | pending |
+
+## Missing `artifacts/omega/agent_handoff.log.md` Entries
+
+```text
+agent: codex
+time_utc: 2026-05-10T22:52:26Z
+files:
+  - docs/dissertation/chapter_clinical_verified_outline.md
+  - docs/dissertation/dossier_template.md
+  - artifacts/omega/agent_handoff.log.md
+  - .claude/llm_offload_log.md
+intent: integrate PBPK claim truth table as the dissertation prose claim-control artifact without broadening GPU or clinical claims
+checks:
+  - git diff --check
+  - bash scripts/ci/check_parallel_blocker_contract.sh
+  - scripts/dev/check_offload_policy.sh
+  - bin/llm-offload --raw docs/dissertation/chapter_clinical_verified_outline.md deepseek xai gemini (API_FAIL/WAIVED logged: missing keys file)
+  - bin/llm-offload --raw docs/dissertation/dossier_template.md deepseek xai gemini (API_FAIL/WAIVED logged: missing keys file)
+commit: pending
+status: lock-released
+
+---
+
+agent: codex
+time_utc: 2026-05-10T22:06:51Z
+files:
+  - docs/dissertation/pbpk_claim_truth_table.md
+  - artifacts/omega/agent_handoff.log.md
+  - .claude/llm_offload_log.md
+intent: CLAIM docs/dissertation/pbpk_claim_truth_table.md for a conservative dissertation-facing PBPK/GUM/GPU claim truth table grounded in repo evidence
+checks:
+  - git diff --check
+  - bash scripts/ci/check_parallel_blocker_contract.sh
+  - bash scripts/ci/dissertation_pbpk_suite_gate.sh
+  - bash scripts/ci/kretikos_kaxi_phase_y_gate.sh
+  - bin/llm-offload --raw docs/dissertation/pbpk_claim_truth_table.md deepseek xai gemini (API_FAIL/WAIVED logged: missing keys file)
+commit: pending
+status: lock-released
+```
+
+## Local Validation Before Follow-Up
+
+- `git diff --check` passed.
+- `bash scripts/ci/check_parallel_blocker_contract.sh` passed.
+- `scripts/dev/check_offload_policy.sh` passed.
+
+## Remaining Canonicalization Note
+
+When normal Git push auth is available, the preferred cleanup is to replay local commit `0d2f20707209829a7e9904bf5c8c7440cec4e9ad` or equivalent rows into the canonical append-only logs directly. This file is the connector-safe record of the same evidence.


### PR DESCRIPTION
## Summary

Adds a small connector-safe audit follow-up for the PBPK claim truth table work merged in PR #121.

The original local follow-up commit updated the canonical append-only logs directly, but local HTTPS push auth is unavailable in this session and the GitHub connector only safely published small file payloads. This artifact records the exact missing offload rows and handoff entries, plus the local source commit for later canonical replay.

## Validation

Local isolated worktree validation before connector publish:

- `git diff --check` passed
- `bash scripts/ci/check_parallel_blocker_contract.sh` passed
- `scripts/dev/check_offload_policy.sh` passed

## Note

Canonical log replay remains available locally as commit `0d2f20707209829a7e9904bf5c8c7440cec4e9ad` in `/tmp/sounio-pbpk-audit-followup`.