### PR TITLE
[lane-4] native-v2: accept scalar refinement parameters

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -122,3 +122,10 @@ No commit blocker — findings are documentation/precision artifacts, not formul
 | Date | Agent | Task | Provider | Target | Outcome | Note |
 |------|-------|------|----------|--------|---------|------|
 | 2026-05-10 | Claude Opus 4.7 | fan-out | n/a | `docs/dissertation/dossier_template.md` | WAIVED | Structural section skeleton (§1-§9 headings + placeholder rows) for the regulatory dossier renderer in `scripts/dissertation/dossier_generator.sio`. Contains no novel claims, no derivations, no clinical assertions — every concrete value/derivation is sourced from upstream artifacts already gated in main: Phase Y (`benchmarks/pbpk/gum_budget.csv`, commit 2b6b5b1a), Phase J (`scripts/ci/kretikos_kaxi_phase_j_gate.sh`, commit cbe6716e), and `stdlib/darwin_pbpk/validation/rapamycin_clinical.sio` (Lane 2). The template's §6 Hessian section is forward-compatible-only; it explicitly emits "_(Hessian budget not available in this run.)_" until Lane 8a lands. Functional test: `bash scripts/ci/dissertation_dossier_gate.sh` PASS=5 FAIL=0 rc=0; smoke test stdout bytewise-matches committed golden snapshot. Pre-publication review by Demetrios's pharmacologist advisor recommended before any actual regulatory submission. |
+
+---
+## 2026-05-10 — Lane 4 native-v2 refinement parameters
+
+| Date | Agent | Task | Provider | Target | Outcome | Note |
+|------|-------|------|----------|--------|---------|------|
+| 2026-05-10 | Codex | review | xai (Grok 4.1) | `self-hosted/compiler/native_compile_driver.sio` Lane 4 diff | CAUGHT_BUG then fixed | Reviewer flagged that refinement parameter lowering detected `f64` via a brittle positional token probe. Fixed by scanning inside the refinement braces for the inner `name: Type` binder up to `|`, accepting only `i32`, `i64`, and `f64`, and preserving the unsupported-refinement diagnostic for malformed/non-scalar cases. Post-fix targeted inventory: `/tmp/lane4-refinement-inventory-post-xai-20260510T220243Z` (8/8 ok). Post-fix full inventory: `/tmp/lane4-parity-post-xai-20260510T220257Z` (`ok=155`, `nv2_compile=180`). Raw transcript: `/tmp/llm-offload-07bTJ1/`. |

--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -762,6 +762,38 @@ status: lock-acquired
 
 ---
 
+agent: codex
+lane: 4
+time_utc: 2026-05-10T20:28:36Z
+files:
+  - self-hosted/compiler/native_compile_driver.sio
+intent: Lane 4 CLAIM/RELEASE - native-v2 hardening for scalar refinement-typed function parameters. Refreshed from origin/main@e6a247dd, kept tests/run-pass read-only, and reduced the current run-pass parity inventory by lowering parameter refinements as their inner scalar runtime type in the N-v2 driver while leaving predicate enforcement to the existing frontend/typecheck path.
+worktree: /workspace/sounio-lane-4-nv2
+branch: coord/lane-4-nv2-hardening
+checks:
+  - bin/souc check self-hosted/compiler/native_compile_driver.sio (rc=0)
+  - baseline inventory /tmp/lane4-parity-inventory-20260510T203929Z: corpus=410 ok=147 nv2_compile=188 nv2_run=70 a_only=1 both_fail=4 a_fail=0
+  - targeted inventory /tmp/lane4-refinement-inventory-20260510T204417Z: corpus=8 ok=8 nv2_compile=0 nv2_run=0
+  - post inventory /tmp/lane4-parity-post-20260510T204428Z: corpus=410 ok=155 nv2_compile=180 nv2_run=70 a_only=1 both_fail=4 a_fail=0
+  - xAI offload review /tmp/llm-offload-07bTJ1: CAUGHT_BUG - replaced positional refinement type probe with brace-local inner binder/type scan
+  - post-xAI targeted inventory /tmp/lane4-refinement-inventory-post-xai-20260510T220243Z: corpus=8 ok=8 nv2_compile=0 nv2_run=0
+  - post-xAI full inventory /tmp/lane4-parity-post-xai-20260510T220257Z: corpus=410 ok=155 nv2_compile=180 nv2_run=70 a_only=1 both_fail=4 a_fail=0
+  - bash scripts/ci/native_v2_serious_track_gate.sh (rc=0)
+  - bash scripts/ci/lean_single_fixed_point_gate.sh (rc=0; fixed-point md5=1c89bbde4db02b708febd46fb5448520)
+  - SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-post-umbrella-20260510T204612Z bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh (rc=0; shell fallback used for aggregator)
+  - post-xAI full umbrella attempt /tmp/lane4-post-xai-umbrella-20260510T234331Z: native-v2 subgates rc=0, phase_y_gum_pbpk rc=1 due local CUDA cuInit_failed cuda_result=304
+  - SOUNIO_KAXI_PHASE_Y_GATE_SKIP=1 SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-post-xai-umbrella-skip-phase-y-20260510T235309Z bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh (rc=0; shell fallback used for aggregator; Phase Y explicitly skipped because local CUDA device admission failed)
+  - post-rebase direct Phase Y GPU retry /tmp/lane4-phase-y-gpu-retry-20260511T094129Z: rc=0; device=NVIDIA RTX 4000 Ada Generation cc=8.9; TC-1/TC-2/TC-3 PASS
+  - post-rebase full GPU umbrella /tmp/lane4-post-rebase-umbrella-gpu-20260511T102012Z: rc=0; all 12 rows PASS including phase_y_gum_pbpk rc=0; shell fallback used for aggregator
+  - git diff --check (rc=0)
+commit: 3c6a46cc (pushed to origin/coord/lane-4-nv2-hardening; PR #129)
+status: lock-released
+blocker-closed:
+  Blocker-ID: BLK-20260510-lane4-publish-auth
+  closed: 2026-05-11 — gh auth live, pushed from workspace container
+
+---
+
 agent: claude
 lane: 3
 time_utc: 2026-05-10T23:35:00Z

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -4741,9 +4741,17 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
 
 fn find_fn_lbrace(token_count: i64, name_str_pos: i64) -> i64 with Mut, Panic, Div {
     var j = name_str_pos + 1
+    var paren_depth: i64 = 0
     while j < token_count {
-        if token_kind(j) == TK_LBRACE { return j }
-        if token_kind(j) == TK_FN && j + 1 < token_count && token_kind(j + 1) == TK_IDENT {
+        let k = token_kind(j)
+        if k == TK_LPAREN {
+            paren_depth = paren_depth + 1
+        } else if k == TK_RPAREN {
+            if paren_depth > 0 { paren_depth = paren_depth - 1 }
+        } else if k == TK_LBRACE && paren_depth == 0 {
+            return j
+        }
+        if k == TK_FN && j + 1 < token_count && token_kind(j + 1) == TK_IDENT {
             return -1
         }
         j = j + 1
@@ -6759,17 +6767,48 @@ fn compile_user_fn(fn_name_tok: i64, fn_id: i64, token_count: i64) -> bool with 
         while ppos < open_pos && token_kind(ppos) != TK_RPAREN {
             if token_kind(ppos) == TK_IDENT {
                 let param_name_tok = ppos
-                // Refinement type `{ d: T | pred }` in param position — N-v2 has
-                // no general type-parser for brace-balanced predicates. Refuse
-                // cleanly with reason=refinement_type and skip the predicate.
+                // Refinement type `{ d: T | pred }` in param position. N-v2 does
+                // not enforce the predicate here, but the runtime representation is
+                // the inner scalar type, matching Track A for these run-pass cases.
                 var refinement_skip: i64 = 0
                 if ppos + 2 <= open_pos && token_kind(ppos + 1) == TK_COLON && token_kind(ppos + 2) == TK_LBRACE {
-                    // open_pos may BE this `{` because find_fn_lbrace returned the
-                    // refinement's brace as the (incorrectly-detected) fn body. Mark
-                    // the function unsupported and let the emitter print the diagnostic.
-                    mark_parse_unsupported_refinement(ppos + 2)
                     refinement_skip = 1
-                    ppos = open_pos
+                    let refinement_end = find_matching_rbrace(ppos + 2, open_pos)
+                    if refinement_end < 0 {
+                        mark_parse_unsupported_refinement(ppos + 2)
+                        ppos = open_pos
+                    } else {
+                        var refinement_type_tok: i64 = -1
+                        var rtp = ppos + 3
+                        while rtp + 2 < refinement_end && refinement_type_tok < 0 && token_kind(rtp) != TK_OR {
+                            if token_kind(rtp) == TK_IDENT && token_kind(rtp + 1) == TK_COLON && token_kind(rtp + 2) == TK_IDENT {
+                                refinement_type_tok = rtp + 2
+                            }
+                            rtp = rtp + 1
+                        }
+                        let refinement_type_ok =
+                            refinement_type_tok >= 0 &&
+                            (token_text_eq(refinement_type_tok, "i32") ||
+                             token_text_eq(refinement_type_tok, "i64") ||
+                             token_text_eq(refinement_type_tok, "f64"))
+                        if !refinement_type_ok {
+                            mark_parse_unsupported_refinement(ppos + 2)
+                            ppos = open_pos
+                        } else {
+                            let vreg = alloc_reg(&! ctx)
+                            remember_local_tok(&! ctx, param_name_tok, vreg)
+                            if token_text_eq(refinement_type_tok, "f64") {
+                                mark_reg_f64(vreg)
+                            }
+                            if param_idx < 64 {
+                                V2_CURRENT_PARAM_REGS[param_idx as usize] = vreg
+                            }
+                            V2_CURRENT_PARAM_COUNT = param_idx + 1
+                            param_idx = param_idx + 1
+                            ppos = refinement_end + 1
+                            if ppos < open_pos && token_kind(ppos) == TK_COMMA { ppos = ppos + 1 }
+                        }
+                    }
                 }
                 if refinement_skip == 0 {
                 // peek at type: param_name : TypeName


### PR DESCRIPTION
## Summary

- Parses refinement-typed function parameters (\`{ x: i64 | x > 0 }\`) as their inner scalar runtime type in the native-v2 compile path.
- Scans inside the refinement braces for the inner binder/type rather than a positional token probe (xAI review caught the positional-probe bug before merge).
- Parity gain: ok 147→155, nv2\_compile 188→180 (8 previously nv2-compile-only tests now fully pass).

## Gates (all PASS)

- \`bin/souc check self-hosted/compiler/native_compile_driver.sio\` rc=0
- \`bash scripts/ci/native_v2_serious_track_gate.sh\` rc=0
- \`bash scripts/ci/lean_single_fixed_point_gate.sh\` rc=0 (gen2==gen3, md5=1c89bbde4db02b708febd46fb5448520)
- \`SOUNIO_KAXI_PHASE_Y_GATE_SKIP=1 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh\` rc=0
- Post-rebase full GPU umbrella (Phase Y included, device RTX 4000 Ada cc=8.9) rc=0

## Merge order

Next in sequence after Lane 1 (PR \#95, already merged). Lane 4 serialises against Lane 1 on \`bin/souc-linux-x86\_64\`; no binary token consumed by this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)