### PR TITLE
[nv2-parity] println(f64) no longer adds implicit newline

### DIFF
--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -3063,11 +3063,17 @@ fn parse_fn_call_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64) -> ExprPars
         }
         let inner_dst = alloc_reg(ctx)
         ufn_record_call(inner_dst, inner_fn_id, arg.reg, 1)
-        let nl_reg = alloc_reg(ctx)
-        let nl_dst = alloc_reg(ctx)
-        ufn_record_load_imm(nl_reg, 10)
-        ufn_record_call(nl_dst, V2_BUILTIN_PRINT_CHAR, nl_reg, 1)
-        return ExprParse { ok: 1, reg: nl_dst, next: arg.next + 1}
+        // lean_single's emit_print_int bakes '\n' into its buffer and
+        // println(string) also adds '\n'. But println(f64) in lean_single
+        // calls emit_print_f64 with no trailing newline — match that.
+        if inner_fn_id != V2_BUILTIN_PRINT_F64 {
+            let nl_reg = alloc_reg(ctx)
+            let nl_dst = alloc_reg(ctx)
+            ufn_record_load_imm(nl_reg, 10)
+            ufn_record_call(nl_dst, V2_BUILTIN_PRINT_CHAR, nl_reg, 1)
+            return ExprParse { ok: 1, reg: nl_dst, next: arg.next + 1}
+        }
+        return ExprParse { ok: 1, reg: inner_dst, next: arg.next + 1}
     }
     // assert(cond): inline expansion — branch around a sys_exit(1) call.
     // Semantics: if cond == 0 → exit(1); else → continue.


### PR DESCRIPTION
## Summary

- `lean_single`'s `emit_print_int` bakes `\n` into its output buffer, so `println(i64)` naturally terminates with a newline. But `lean_single`'s `println(f64)` calls `emit_print_f64` with **no** trailing newline.
- NV2 was unconditionally appending `print_char(10)` after every `println` argument, causing a spurious `\n` on all `println(f64)` call sites.
- Fix: skip the `print_char(10)` emission in NV2's `println` handler when `inner_fn_id == V2_BUILTIN_PRINT_F64`.

## Parity inventory gain (corpus = 428 files)

| Bucket | Before | After | Δ |
|--------|--------|-------|---|
| ok | 164 | 184 | **+20** |
| nv2\_run diverge | 72 | 59 | **−13** |
| nv2\_compile fail | 188 | 180 | (Lane 4, already on main) |

## Gates (all PASS)

- `bin/souc check self-hosted/compiler/native_compile_driver.sio` rc=0
- `bash scripts/ci/lean_single_fixed_point_gate.sh` rc=0 (md5=1c89bbde…, unchanged)
- `bash scripts/ci/native_v2_serious_track_gate.sh` rc=0
- `SOUNIO_KAXI_PHASE_Y_GATE_SKIP=1 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh` rc=0 (all 12 rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)