### PR TITLE
native-v2: support typed f64 closure fnrefs

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -425,6 +425,44 @@ status: lock-acquired
 
 ---
 
+agent: codex
+lane: 4
+time_utc: 2026-05-13T01:57:24Z
+files:
+  - self-hosted/compiler/native_compile_driver.sio
+  - artifacts/omega/agent_handoff.log.md
+intent: Lane 4 RELEASE — native-v2 parity hardening for typed closure literals with explicit return arrows and braced single-expression bodies. N-v2 now scans `|x: f64| -> f64 { expr }`, consumes the braced closure literal correctly, and preserves the f64 return tag across function-reference copies and indirect calls. This closes the `tests/run-pass/approx_propagation.sio` compile/parity row without changing `/workspace/sounio` dirty checkout state or ABIDE/ORC artifacts.
+worktree: /tmp/sounio-lane-4-nv2-parity
+branch: codex/lane-4-nv2-parity-20260513b
+checks:
+  - baseline inventory /tmp/lane4-parity-baseline-20260513T0141: corpus=421 ok=172 nv2_compile=191 nv2_run=57 a_only=0 both_fail=1 a_fail=0
+  - targeted compile: bin/souc run self-hosted/compiler/native_compile_driver.sio -- tests/run-pass/approx_propagation.sio -o /tmp/approx_nv2_after2 (rc=0)
+  - targeted runtime parity: /tmp/approx_nv2_after2 stdout matched Track A (`1.414214`, rc=0)
+  - targeted inventory /tmp/lane4-parity-closure-target-20260513T0146: approx_propagation=ok
+  - post inventory /tmp/lane4-parity-post-20260513T0147: corpus=421 ok=173 nv2_compile=190 nv2_run=57 a_only=0 both_fail=1 a_fail=0
+  - bin/souc check self-hosted/compiler/native_compile_driver.sio (rc=0)
+  - bash scripts/ci/native_v2_serious_track_gate.sh (rc=0)
+  - bash scripts/ci/lean_single_fixed_point_gate.sh (rc=0; fixed-point md5=1c89bbde4db02b708febd46fb5448520)
+  - bash scripts/ci/compiler_stage_contract_gate.sh (rc=0; pass=14 known_blocker=1)
+  - SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-umbrella-20260513T0149 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh (rc=0; shell fallback used for aggregator)
+  - git diff --check (rc=0)
+status: lock-released
+
+---
+
+agent: codex
+lane: 4
+time_utc: 2026-05-13T01:40:42Z
+files:
+  - self-hosted/compiler/native_compile_driver.sio
+  - self-hosted/native/**
+intent: Lane 4 CLAIM — native-v2 Track A vs N-v2 parity hardening. Fresh isolated worktree `/tmp/sounio-lane-4-nv2-parity` on branch `codex/lane-4-nv2-parity-20260513b`, based on `origin/main`. Scope is one narrow actionable `nv2_compile` or `nv2_run` parity gap from `scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'`; preserve `/workspace/sounio` dirty checkout and do not touch ABIDE/ORC research artifacts.
+checks:
+  - pending: bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'
+status: lock-acquired
+
+---
+
 agent: claude
 lane: 3
 time_utc: 2026-05-10T16:45:00Z

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -470,9 +470,22 @@ fn mark_reg_fnref(reg: i64) with Mut {
     }
 }
 
+fn mark_reg_fnref_f64(reg: i64) with Mut {
+    if reg >= 0 && reg < 4096 {
+        V2_REG_IS_F64[reg as usize] = 3
+    }
+}
+
 fn reg_is_fnref(reg: i64) -> bool {
     if reg >= 0 && reg < 4096 {
-        return V2_REG_IS_F64[reg as usize] == 2
+        return V2_REG_IS_F64[reg as usize] == 2 || V2_REG_IS_F64[reg as usize] == 3
+    }
+    false
+}
+
+fn reg_is_fnref_f64(reg: i64) -> bool {
+    if reg >= 0 && reg < 4096 {
+        return V2_REG_IS_F64[reg as usize] == 3
     }
     false
 }
@@ -1788,7 +1801,11 @@ fn parse_closure_literal_ref_ir(ctx: &! V2DriverContext, pos: i64) -> ExprParse 
     if cidx < 0 { return ExprParse { ok: 0, reg: -1, next: pos} }
     let dst = alloc_reg(ctx)
     ufn_record_load_imm(dst, V2_CLOSURE_FN_IDS[cidx as usize])
-    mark_reg_fnref(dst)
+    if V2_CLOSURE_RETURN_IS_F64[cidx as usize] != 0 {
+        mark_reg_fnref_f64(dst)
+    } else {
+        mark_reg_fnref(dst)
+    }
     return ExprParse { ok: 1, reg: dst, next: V2_CLOSURE_BODY_END[cidx as usize]}
 }
 
@@ -1874,12 +1891,47 @@ fn try_scan_closure_literal(pos: i64, token_count: i64) -> i64 with Mut, Panic, 
         V2_CLOSURE_PARAM_TOTAL = param_start
         return pos + 1
     }
-    let body_start = p + 1
+    var body_start = p + 1
+    var literal_end: i64 = -1
+    if token_kind(body_start) == TK_ARROW {
+        body_start = body_start + 1
+        if token_kind(body_start) != TK_IDENT {
+            V2_CLOSURE_PARAM_TOTAL = param_start
+            return pos + 1
+        }
+        body_start = body_start + 1
+        while body_start < token_count && token_kind(body_start) != TK_LBRACE {
+            body_start = body_start + 1
+        }
+        if body_start >= token_count || token_kind(body_start) != TK_LBRACE {
+            V2_CLOSURE_PARAM_TOTAL = param_start
+            return pos + 1
+        }
+        var brace_depth: i64 = 1
+        var body_close = body_start + 1
+        while body_close < token_count && brace_depth > 0 {
+            let bk = token_kind(body_close)
+            if bk == TK_LBRACE { brace_depth = brace_depth + 1 }
+            if bk == TK_RBRACE { brace_depth = brace_depth - 1 }
+            if brace_depth > 0 { body_close = body_close + 1 }
+        }
+        if body_close >= token_count || token_kind(body_close) != TK_RBRACE {
+            V2_CLOSURE_PARAM_TOTAL = param_start
+            return pos + 1
+        }
+        body_start = body_start + 1
+        literal_end = body_close + 1
+    }
     let probe = probe_closure_body_expr(body_start, param_start, param_count)
     if probe.ok == 0 || probe.next <= body_start {
         V2_CLOSURE_PARAM_TOTAL = param_start
         return pos + 1
     }
+    if literal_end >= 0 && probe.next != literal_end - 1 {
+        V2_CLOSURE_PARAM_TOTAL = param_start
+        return pos + 1
+    }
+    if literal_end < 0 { literal_end = probe.next }
     let cidx = V2_CLOSURE_COUNT
     if cidx >= 128 {
         V2_CLOSURE_PARAM_TOTAL = param_start
@@ -1887,14 +1939,14 @@ fn try_scan_closure_literal(pos: i64, token_count: i64) -> i64 with Mut, Panic, 
     }
     V2_CLOSURE_START_TOK[cidx as usize] = pos
     V2_CLOSURE_BODY_START[cidx as usize] = body_start
-    V2_CLOSURE_BODY_END[cidx as usize] = probe.next
+    V2_CLOSURE_BODY_END[cidx as usize] = literal_end
     V2_CLOSURE_PARAM_START[cidx as usize] = param_start
     V2_CLOSURE_PARAM_COUNT[cidx as usize] = param_count
     V2_CLOSURE_FN_IDS[cidx as usize] = V2_FIRST_USER_FN_ID + V2_USER_FN_COUNT + 1 + cidx
     V2_CLOSURE_RETURN_IS_F64[cidx as usize] = probe.reg
     V2_CLOSURE_PARAM_TOTAL = param_start + param_count
     V2_CLOSURE_COUNT = cidx + 1
-    return probe.next
+    return literal_end
 }
 
 fn scan_closure_literals(token_count: i64) with Mut, Panic, Div, Alloc {
@@ -2308,7 +2360,8 @@ fn ufn_record_copy(dst: i64, src: i64) with Mut {
         V2_UFN_DST[idx as usize] = dst
         V2_UFN_SRC1[idx as usize] = src
         V2_UFN_COUNT = idx + 1
-        if reg_is_fnref(src) { mark_reg_fnref(dst) }
+        if reg_is_fnref_f64(src) { mark_reg_fnref_f64(dst) }
+        else if reg_is_fnref(src) { mark_reg_fnref(dst) }
         else if reg_is_f64(src) { mark_reg_f64(dst) }
         else { mark_reg_i64(dst) }
     }
@@ -3353,6 +3406,7 @@ fn parse_fn_call_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64) -> ExprPars
         }
         let dst_ind = alloc_reg(ctx)
         ufn_record_call(dst_ind, V2_BUILTIN_INDIRECT_CALL, base_ind, total_argc + 1)
+        if reg_is_fnref_f64(indirect_fn_reg) { mark_reg_f64(dst_ind) }
         return ExprParse { ok: 1, reg: dst_ind, next: cur + 1}
     }
     // check if callee returns a struct
@@ -6788,7 +6842,11 @@ fn compile_closure_fn(cidx: i64) -> bool with IO, Mut, Panic, Div, Alloc {
     V2_UFN_COUNT = 0
     var func: i64 = 0
     let body = parse_expr_ir(&! func, &! ctx, V2_CLOSURE_BODY_START[cidx as usize])
-    if body.ok == 0 || body.next != V2_CLOSURE_BODY_END[cidx as usize] {
+    let body_end = V2_CLOSURE_BODY_END[cidx as usize]
+    var body_consumed: i64 = 0
+    if body.next == body_end { body_consumed = 1 }
+    if token_kind(body.next) == TK_RBRACE && body.next + 1 == body_end { body_consumed = 1 }
+    if body.ok == 0 || body_consumed == 0 {
         print("native_compile: closure_unsupported token=")
         print_int(V2_CLOSURE_START_TOK[cidx as usize])
         print("\n")


### PR DESCRIPTION
## Summary
- Teach the native-v2 driver to scan typed closure literals with explicit return arrows and braced single-expression bodies, e.g. `|x: f64| -> f64 { expr }`.
- Preserve function-reference return type metadata for f64 closures through copies and indirect calls.
- Closes one Track A vs N-v2 run-pass parity row: `tests/run-pass/approx_propagation.sio`.

## Evidence
- Baseline inventory `/tmp/lane4-parity-baseline-20260513T0141`: corpus=421 ok=172 nv2_compile=191 nv2_run=57 a_only=0 both_fail=1 a_fail=0.
- Post inventory `/tmp/lane4-parity-post-20260513T0147`: corpus=421 ok=173 nv2_compile=190 nv2_run=57 a_only=0 both_fail=1 a_fail=0.
- Targeted runtime parity: N-v2 `approx_propagation` matched Track A stdout `1.414214`, rc=0.

## Validation
- `bin/souc check self-hosted/compiler/native_compile_driver.sio`
- `bash scripts/ci/native_v2_serious_track_gate.sh`
- `bash scripts/ci/lean_single_fixed_point_gate.sh`
- `bash scripts/ci/compiler_stage_contract_gate.sh`
- `SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-umbrella-20260513T0149 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh`
- `git diff --check`

## LLM-offload
Not invoked: compiler-only native-v2 plumbing, no math claims, clinical-pathway code, or external-facing artifacts.