### PR TITLE
native-v2: support zero-arg closure fnrefs

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -452,6 +452,33 @@ status: lock-released
 
 agent: codex
 lane: 4
+time_utc: 2026-05-13T09:52:55Z
+files:
+  - self-hosted/compiler/native_compile_driver.sio
+  - artifacts/omega/agent_handoff.log.md
+intent: Lane 4 RELEASE — native-v2 parity hardening for zero-parameter closure literals tokenized as `||`. N-v2 now recognizes `|| expr` in expression-start positions, preserves normal boolean `a || b` as a non-closure operator, and closes the `tests/run-pass/closure_basic.sio` compile/parity row after PR #140 landed.
+worktree: /tmp/sounio-lane-4-nv2-parity
+branch: codex/lane-4-nv2-zero-closure-20260513
+checks:
+  - post-PR #140 inventory /tmp/lane4-parity-post-20260513T0147: corpus=421 ok=173 nv2_compile=190 nv2_run=57 a_only=0 both_fail=1 a_fail=0
+  - targeted compile: bin/souc run self-hosted/compiler/native_compile_driver.sio -- tests/run-pass/closure_basic.sio -o /tmp/closure_basic_nv2_zero (rc=0)
+  - targeted runtime parity: /tmp/closure_basic_nv2_zero stdout/exit matched Track A (rc=0)
+  - closure inventory /tmp/lane4-parity-zero-closure-20260513T0950: closure_basic=ok
+  - full inventory /tmp/lane4-parity-zero-full-20260513T0953: corpus=422 ok=175 nv2_compile=189 nv2_run=57 a_only=0 both_fail=1 a_fail=0
+  - pinned full inventory /tmp/lane4-parity-zero-full-pinned-20260513T0956 with SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc: corpus=422 ok=175 nv2_compile=189 nv2_run=57 a_only=0 both_fail=1 a_fail=0
+  - bin/souc check self-hosted/compiler/native_compile_driver.sio (rc=0)
+  - bash scripts/ci/native_v2_serious_track_gate.sh (rc=0)
+  - bash scripts/ci/lean_single_fixed_point_gate.sh (rc=0; fixed-point md5=1c89bbde4db02b708febd46fb5448520)
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc bash scripts/ci/compiler_stage_contract_gate.sh (rc=0; pass=14 known_blocker=1)
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-zero-umbrella-20260513T0956 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh (rc=0; shell fallback used for aggregator)
+  - default compiler_stage_contract_gate.sh resolved /workspace/sounio/bin/souc and failed diagnostic_assign_to_immut_rejects; pinned SOUC_BIN run above is the branch-local evidence
+  - git diff --check (rc=0)
+status: lock-released
+
+---
+
+agent: codex
+lane: 4
 time_utc: 2026-05-13T01:40:42Z
 files:
   - self-hosted/compiler/native_compile_driver.sio

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -1855,41 +1855,52 @@ fn probe_closure_body_expr(body_start: i64, param_start: i64, param_count: i64) 
 }
 
 fn try_scan_closure_literal(pos: i64, token_count: i64) -> i64 with Mut, Panic, Div, Alloc {
-    if token_kind(pos) != TK_OR { return pos + 1 }
+    let start_kind = token_kind(pos)
+    if start_kind != TK_OR && start_kind != TK_OROR { return pos + 1 }
     let param_start = V2_CLOSURE_PARAM_TOTAL
     var param_count: i64 = 0
     var p = pos + 1
-    while p < token_count && token_kind(p) != TK_OR {
-        if param_start + param_count >= 512 {
+    if start_kind == TK_OROR {
+        if pos > 0 {
+            let prev_kind = token_kind(pos - 1)
+            if prev_kind != TK_EQ && prev_kind != TK_LPAREN && prev_kind != TK_COMMA && prev_kind != TK_RETURN && prev_kind != TK_LBRACE {
+                return pos + 1
+            }
+        }
+        p = pos
+    } else {
+        while p < token_count && token_kind(p) != TK_OR {
+            if param_start + param_count >= 512 {
+                V2_CLOSURE_PARAM_TOTAL = param_start
+                return pos + 1
+            }
+            if token_kind(p) != TK_IDENT || token_kind(p + 1) != TK_COLON || token_kind(p + 2) != TK_IDENT {
+                V2_CLOSURE_PARAM_TOTAL = param_start
+                return pos + 1
+            }
+            if !token_text_eq(p + 2, "i64") && !token_text_eq(p + 2, "f64") {
+                V2_CLOSURE_PARAM_TOTAL = param_start
+                return pos + 1
+            }
+            let pslot = param_start + param_count
+            V2_CLOSURE_PARAM_NAME_TOK[pslot as usize] = p
+            if token_text_eq(p + 2, "f64") {
+                V2_CLOSURE_PARAM_IS_F64[pslot as usize] = 1
+            } else {
+                V2_CLOSURE_PARAM_IS_F64[pslot as usize] = 0
+            }
+            param_count = param_count + 1
+            p = p + 3
+            if token_kind(p) == TK_COMMA { p = p + 1 }
+            else if token_kind(p) != TK_OR {
+                V2_CLOSURE_PARAM_TOTAL = param_start
+                return pos + 1
+            }
+        }
+        if p >= token_count || token_kind(p) != TK_OR || param_count <= 0 {
             V2_CLOSURE_PARAM_TOTAL = param_start
             return pos + 1
         }
-        if token_kind(p) != TK_IDENT || token_kind(p + 1) != TK_COLON || token_kind(p + 2) != TK_IDENT {
-            V2_CLOSURE_PARAM_TOTAL = param_start
-            return pos + 1
-        }
-        if !token_text_eq(p + 2, "i64") && !token_text_eq(p + 2, "f64") {
-            V2_CLOSURE_PARAM_TOTAL = param_start
-            return pos + 1
-        }
-        let pslot = param_start + param_count
-        V2_CLOSURE_PARAM_NAME_TOK[pslot as usize] = p
-        if token_text_eq(p + 2, "f64") {
-            V2_CLOSURE_PARAM_IS_F64[pslot as usize] = 1
-        } else {
-            V2_CLOSURE_PARAM_IS_F64[pslot as usize] = 0
-        }
-        param_count = param_count + 1
-        p = p + 3
-        if token_kind(p) == TK_COMMA { p = p + 1 }
-        else if token_kind(p) != TK_OR {
-            V2_CLOSURE_PARAM_TOTAL = param_start
-            return pos + 1
-        }
-    }
-    if p >= token_count || token_kind(p) != TK_OR || param_count <= 0 {
-        V2_CLOSURE_PARAM_TOTAL = param_start
-        return pos + 1
     }
     var body_start = p + 1
     var literal_end: i64 = -1
@@ -2574,7 +2585,7 @@ fn parse_atom_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64) -> ExprParse w
     if k == TK_MATCH {
         return parse_match_expr_ir(func, ctx, pos)
     }
-    if k == TK_OR {
+    if k == TK_OR || k == TK_OROR {
         return parse_closure_literal_ref_ir(ctx, pos)
     }
     if k == TK_BANG {


### PR DESCRIPTION
## Summary
- extend native-v2 closure scanning to recognize zero-parameter closure literals tokenized as `||`
- limit `|| expr` closure recognition to expression-start positions so boolean `a || b` remains an infix operator
- close `tests/run-pass/closure_basic.sio` in Track A vs N-v2 parity and record Lane 4 evidence

## Validation
- `bin/souc check self-hosted/compiler/native_compile_driver.sio`
- `bin/souc run self-hosted/compiler/native_compile_driver.sio -- tests/run-pass/closure_basic.sio -o /tmp/closure_basic_nv2_zero`
- `bin/souc compile tests/run-pass/closure_basic.sio -o /tmp/closure_basic_track_a_zero`
- `/tmp/closure_basic_track_a_zero` and `/tmp/closure_basic_nv2_zero` both exited 0 with matching stdout
- `SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-zero-closure-20260513T0950 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/closure_*.sio'` => `closure_basic.sio` ok
- `SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-zero-full-pinned-20260513T0956 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'` => corpus=422 ok=175 nv2_compile=189 nv2_run=57 a_only=0 both_fail=1 a_fail=0
- `bash scripts/ci/native_v2_serious_track_gate.sh`
- `bash scripts/ci/lean_single_fixed_point_gate.sh`
- `SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc bash scripts/ci/compiler_stage_contract_gate.sh`
- `SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-zero-umbrella-20260513T0956 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh`
- `git diff --check`

## Notes
- The unpinned compiler stage gate resolved `/workspace/sounio/bin/souc` and failed `diagnostic_assign_to_immut_rejects`; rerunning with branch-local `SOUC_BIN` passed. The pinned run is the branch evidence.
- LLM-offload: not invoked; this is compiler parsing/lowering plumbing, not math claims, clinical-pathway code, or an external-facing artifact.