### PR TITLE
native-v2: support untyped closure fnrefs

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -452,6 +452,31 @@ status: lock-released
 
 agent: codex
 lane: 4
+time_utc: 2026-05-13T10:40:34Z
+files:
+  - self-hosted/compiler/native_compile_driver.sio
+  - artifacts/omega/agent_handoff.log.md
+intent: Lane 4 RELEASE — native-v2 parity hardening for untyped non-capturing closure parameters. N-v2 now scans `|x| expr` and `|x, y| expr` as i64-param closure literals while preserving typed `|x: T|` handling. This closes `tests/run-pass/closure_hof.sio`; `closure_capture.sio` remains intentionally outside this slice because captured environments are not represented by the current non-capturing fnref ABI.
+worktree: /tmp/sounio-lane-4-nv2-parity
+branch: codex/lane-4-nv2-closure-capture-20260513
+checks:
+  - closure classification inventory /tmp/lane4-parity-closure-next-20260513Tnext: closure_capture=nv2_compile, closure_hof=nv2_compile, closure_effect_infer=nv2_compile
+  - targeted compile: bin/souc run self-hosted/compiler/native_compile_driver.sio -- tests/run-pass/closure_hof.sio -o /tmp/closure_hof_nv2_untyped (rc=0)
+  - targeted runtime parity: /tmp/closure_hof_nv2_untyped stdout/exit matched Track A (`PASS`, rc=0)
+  - closure inventory /tmp/lane4-parity-untyped-closure-20260513T1030: corpus=15 ok=7 nv2_compile=5 nv2_run=2 a_only=0 both_fail=1 a_fail=0; closure_hof=ok
+  - pinned full inventory /tmp/lane4-parity-untyped-closure-full-20260513T1031 with SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc: corpus=422 ok=176 nv2_compile=188 nv2_run=57 a_only=0 both_fail=1 a_fail=0
+  - bin/souc check self-hosted/compiler/native_compile_driver.sio (rc=0)
+  - bash scripts/ci/native_v2_serious_track_gate.sh (rc=0)
+  - bash scripts/ci/lean_single_fixed_point_gate.sh (rc=0; fixed-point md5=1c89bbde4db02b708febd46fb5448520)
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc bash scripts/ci/compiler_stage_contract_gate.sh (rc=0; pass=14 known_blocker=1)
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-untyped-closure-umbrella-20260513T1032 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh (rc=0; shell fallback used for aggregator)
+  - git diff --check (rc=0)
+status: lock-released
+
+---
+
+agent: codex
+lane: 4
 time_utc: 2026-05-13T09:52:55Z
 files:
   - self-hosted/compiler/native_compile_driver.sio

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -1874,23 +1874,34 @@ fn try_scan_closure_literal(pos: i64, token_count: i64) -> i64 with Mut, Panic, 
                 V2_CLOSURE_PARAM_TOTAL = param_start
                 return pos + 1
             }
-            if token_kind(p) != TK_IDENT || token_kind(p + 1) != TK_COLON || token_kind(p + 2) != TK_IDENT {
+            if token_kind(p) != TK_IDENT {
                 V2_CLOSURE_PARAM_TOTAL = param_start
                 return pos + 1
             }
-            if !token_text_eq(p + 2, "i64") && !token_text_eq(p + 2, "f64") {
-                V2_CLOSURE_PARAM_TOTAL = param_start
-                return pos + 1
+            let param_name_tok = p
+            var param_is_f64: i64 = 0
+            if token_kind(p + 1) == TK_COLON {
+                if token_kind(p + 2) != TK_IDENT {
+                    V2_CLOSURE_PARAM_TOTAL = param_start
+                    return pos + 1
+                }
+                if !token_text_eq(p + 2, "i64") && !token_text_eq(p + 2, "f64") {
+                    V2_CLOSURE_PARAM_TOTAL = param_start
+                    return pos + 1
+                }
+                if token_text_eq(p + 2, "f64") { param_is_f64 = 1 }
+                p = p + 3
+            } else {
+                p = p + 1
             }
             let pslot = param_start + param_count
-            V2_CLOSURE_PARAM_NAME_TOK[pslot as usize] = p
-            if token_text_eq(p + 2, "f64") {
+            V2_CLOSURE_PARAM_NAME_TOK[pslot as usize] = param_name_tok
+            if param_is_f64 != 0 {
                 V2_CLOSURE_PARAM_IS_F64[pslot as usize] = 1
             } else {
                 V2_CLOSURE_PARAM_IS_F64[pslot as usize] = 0
             }
             param_count = param_count + 1
-            p = p + 3
             if token_kind(p) == TK_COMMA { p = p + 1 }
             else if token_kind(p) != TK_OR {
                 V2_CLOSURE_PARAM_TOTAL = param_start


### PR DESCRIPTION
## Summary
- extend native-v2 closure scanning to accept untyped i64 parameters like `|x| expr` and `|x, y| expr`
- close the non-capturing HOF row `tests/run-pass/closure_hof.sio`
- classify `closure_capture.sio` as remaining captured-environment work, not part of this non-capturing fnref ABI slice

## Validation
- `bin/souc check self-hosted/compiler/native_compile_driver.sio`
- `bin/souc run self-hosted/compiler/native_compile_driver.sio -- tests/run-pass/closure_hof.sio -o /tmp/closure_hof_nv2_untyped`
- `bin/souc compile tests/run-pass/closure_hof.sio -o /tmp/closure_hof_track_a_untyped`
- `/tmp/closure_hof_track_a_untyped` and `/tmp/closure_hof_nv2_untyped` both printed `PASS` and exited 0
- `SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-untyped-closure-20260513T1030 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/closure_*.sio'` => corpus=15 ok=7 nv2_compile=5 nv2_run=2 a_only=0 both_fail=1 a_fail=0; `closure_hof.sio` ok
- `SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-untyped-closure-full-20260513T1031 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'` => corpus=422 ok=176 nv2_compile=188 nv2_run=57 a_only=0 both_fail=1 a_fail=0
- `bash scripts/ci/native_v2_serious_track_gate.sh`
- `bash scripts/ci/lean_single_fixed_point_gate.sh`
- `SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc bash scripts/ci/compiler_stage_contract_gate.sh`
- `SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_NATIVE_V2_CPU_COMPILER_DIR=/tmp/lane4-untyped-closure-umbrella-20260513T1032 bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh`
- `git diff --check`

## Remaining Work
- `tests/run-pass/closure_capture.sio` still fails at captured closure literals because the current native-v2 fnref representation lowers non-capturing closures to generated functions and does not carry an environment pointer.
- `tests/run-pass/closure_effect_infer.sio` still fails at effect/block closure handling; also out of scope here.

## LLM-offload
Not invoked; this is compiler parser/lowering plumbing, not math claims, clinical-pathway code, or an external-facing artifact.