### PR TITLE
native-v2: prebundle octonion imports in parity inventory

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -17,6 +17,31 @@ status: lock-open|lock-released|blocked
 
 ---
 
+agent: codex
+time_utc: 2026-05-13T12:27:09Z
+files:
+  - scripts/ci/track_a_nv2_parity_inventory.sh
+  - artifacts/omega/agent_handoff.log.md
+intent: use existing native_prebundle lowering for algebra::octonion imports in the Track A/N-v2 parity inventory
+checks:
+  - bash -n scripts/ci/track_a_nv2_parity_inventory.sh
+  - git diff --check
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-import-stdlib-script-20260513T4 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/algebra_g2_invariants_import.sio' 'tests/run-pass/associator_variance_mc.sio'
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-import-stdlib-full-20260513T1 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'
+  - bash scripts/ci/native_v2_serious_track_gate.sh
+notes: |
+  algebra_g2_invariants_import.sio now compiles through the N-v2 inventory path
+  after prebundling stdlib/algebra/octonion.sio, moving from nv2_compile to
+  nv2_run. Its remaining runtime divergence matches the existing G2 algebra
+  semantic layer, not import resolution. associator_variance_mc.sio remains an
+  N-v2 compile failure and is not covered by this import-prebundle slice. Full
+  run-pass inventory: corpus=422, ok=176, nv2_compile=187, nv2_run=58,
+  both_fail=1.
+commit: pending
+status: lock-released
+
+---
+
 agent: claude
 time_utc: 2026-04-26T00:00:00Z
 files:

--- a/scripts/ci/track_a_nv2_parity_inventory.sh
+++ b/scripts/ci/track_a_nv2_parity_inventory.sh
@@ -121,8 +121,25 @@ for src in "${INPUTS[@]}"; do
   if [[ $a_compile -eq 0 && -f "$a_elf" ]]; then chmod +x "$a_elf"; fi
 
   # ── Compile with Track N-v2. ────────────────────────────────────────────────
+  nv2_src="$src"
+  if grep -Eq '^[[:space:]]*use[[:space:]]+algebra::octonion(::|[[:space:]])' "$src"; then
+    bundled_src="$case_dir/nv2.prebundled.sio"
+    prebundle_log="$LOG_DIR/$slug.nv2.prebundle.log"
+    set +e
+    timeout 30 "$SOUC_BIN" run self-hosted/compiler/native_prebundle.sio -- "$src" -o "$bundled_src" --root stdlib >"$prebundle_log" 2>&1
+    prebundle_rc=$?
+    set -e
+    if [[ $prebundle_rc -eq 0 && -s "$bundled_src" ]]; then
+      nv2_src="$bundled_src"
+    else
+      {
+        printf '[parity-inv] native_prebundle failed rc=%s for %s\n' "$prebundle_rc" "$src"
+        cat "$prebundle_log" 2>/dev/null || true
+      } >>"$nv2_log"
+    fi
+  fi
   set +e
-  timeout 30 "$NV2_STAGE1" "$src" "$nv2_elf" >"$nv2_log" 2>&1
+  timeout 30 "$NV2_STAGE1" "$nv2_src" "$nv2_elf" >>"$nv2_log" 2>&1
   nv2_compile=$?
   set -e
   if [[ $nv2_compile -eq 0 && -f "$nv2_elf" ]]; then chmod +x "$nv2_elf"; fi


### PR DESCRIPTION
## Summary
- route parity-inventory cases importing algebra::octonion through the existing native_prebundle.sio helper before N-v2 stage1 compilation
- preserve direct N-v2 behavior outside the inventory script while making the stdlib import row visible as runtime divergence instead of unresolved import/call plumbing
- add an agent handoff note with the focused and full-inventory evidence

## Evidence
- bash -n scripts/ci/track_a_nv2_parity_inventory.sh
- git diff --check
- SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-import-stdlib-script-20260513T4 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/algebra_g2_invariants_import.sio' 'tests/run-pass/associator_variance_mc.sio'
  - algebra_g2_invariants_import.sio: nv2_run
  - associator_variance_mc.sio: nv2_compile
- SOUC_BIN=/tmp/sounio-lane-4-nv2-parity/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-parity-import-stdlib-full-20260513T1 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'
  - corpus=422, ok=176, nv2_compile=187, nv2_run=58, both_fail=1
- bash scripts/ci/native_v2_serious_track_gate.sh

## Notes
This is an inventory/prebundle slice, not a semantic algebra fix. The imported G2 invariant test now compiles under the N-v2 inventory path and exposes the existing runtime divergence layer.