### PR TITLE
native-v2: fix algebra runtime SRET paths

### DIFF
--- a/artifacts/omega/agent_handoff.log.md
+++ b/artifacts/omega/agent_handoff.log.md
@@ -18,6 +18,36 @@ status: lock-open|lock-released|blocked
 ---
 
 agent: codex
+time_utc: 2026-05-14T00:10:20Z
+files:
+  - self-hosted/compiler/native_compile_driver.sio
+  - tests/run-pass/native_v2_f32_struct_sret.sio
+  - tests/run-pass/native_v2_array_tail_return.sio
+  - artifacts/omega/agent_handoff.log.md
+intent: fix N-v2 algebra runtime divergence by preserving f32 struct SRET fields and tail-expression array returns
+checks:
+  - bin/souc run tests/run-pass/native_v2_f32_struct_sret.sio
+  - bin/souc run tests/run-pass/native_v2_array_tail_return.sio
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-algebra-runtime-fixed-20260513T1 bash scripts/ci/track_a_nv2_parity_inventory.sh tests/run-pass/algebra_g2_invariants.sio tests/run-pass/algebra_g2_invariants_import.sio tests/run-pass/native_v2_f32_struct_sret.sio tests/run-pass/native_v2_array_tail_return.sio
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-algebra-runtime-rebased-20260514T1 bash scripts/ci/track_a_nv2_parity_inventory.sh tests/run-pass/algebra_g2_invariants.sio tests/run-pass/algebra_g2_invariants_import.sio tests/run-pass/native_v2_f32_struct_sret.sio tests/run-pass/native_v2_array_tail_return.sio
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_NATIVE_V2_GATE_DIR=/tmp/lane4-algebra-runtime-serious-gate-20260514T1 bash scripts/ci/native_v2_serious_track_gate.sh
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_NATIVE_V2_GATE_DIR=/tmp/lane4-algebra-runtime-serious-gate-rebased-20260514T1 bash scripts/ci/native_v2_serious_track_gate.sh
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-algebra-runtime-full-20260514T1 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-algebra-runtime-full-rebased-20260514T1 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'
+  - SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc bash scripts/ci/compiler_stage_contract_gate.sh
+notes: |
+  Root causes: f32 struct fields were not marked as floating slots, corrupting
+  8-field SRET values in the inline G2 test; tail-expression returns of local
+  [f64; N] arrays emitted scalar returns, zeroing imported stdlib oct_basis
+  results. Both algebra_g2_invariants.sio and algebra_g2_invariants_import.sio
+  now classify as ok in the parity inventory. Full run-pass inventory:
+  corpus=424, ok=185, nv2_compile=187, nv2_run=51, both_fail=1.
+commit: pending
+status: lock-released
+
+---
+
+agent: codex
 time_utc: 2026-05-13T12:27:09Z
 files:
   - scripts/ci/track_a_nv2_parity_inventory.sh

--- a/self-hosted/compiler/native_compile_driver.sio
+++ b/self-hosted/compiler/native_compile_driver.sio
@@ -1575,7 +1575,7 @@ fn scan_struct_field_types(token_count: i64) with Mut, Panic, Div {
         if name_tok + 2 < token_count {
             if token_kind(name_tok + 1) == TK_COLON && token_kind(name_tok + 2) == TK_IDENT {
                 type_sidx = find_struct_idx_tok(name_tok + 2)
-                if token_text_eq(name_tok + 2, "f64") {
+                if token_text_eq(name_tok + 2, "f64") || token_text_eq(name_tok + 2, "f32") {
                     STRUCT_FIELD_IS_F64[fi as usize] = 1
                 }
                 if name_tok + 5 < token_count && token_kind(name_tok + 3) == TK_LT && token_kind(name_tok + 4) == TK_IDENT && token_kind(name_tok + 5) == TK_GT && token_text_eq(name_tok + 4, "f64") {
@@ -1591,7 +1591,7 @@ fn scan_struct_field_types(token_count: i64) with Mut, Panic, Div {
                     STRUCT_FIELD_ARRAY_SIZE[fi as usize] = pt_read_int_value(semi_pos + 1)
                 }
                 // Mark element type as f64 when array element type is f64
-                if token_kind(name_tok + 3) == TK_IDENT && token_text_eq(name_tok + 3, "f64") {
+                if token_kind(name_tok + 3) == TK_IDENT && (token_text_eq(name_tok + 3, "f64") || token_text_eq(name_tok + 3, "f32")) {
                     STRUCT_FIELD_IS_F64[fi as usize] = 1
                 }
             }
@@ -4416,6 +4416,14 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
             ufn_record_return(zero_ret)
             return p + 1
         }
+        if token_kind(after_return) == TK_IDENT {
+            let direct_arr_base = lookup_local_tok(ctx, after_return)
+            let direct_arr_len = lookup_local_alen_tok(ctx, after_return)
+            if direct_arr_base >= 0 && direct_arr_len > 0 && token_kind(after_return + 1) != TK_LBRACKET {
+                ufn_record_return_struct(direct_arr_base, direct_arr_len)
+                return after_return + 1
+            }
+        }
         V2_LAST_STRUCT_IDX = -1
         V2_LAST_ARR_LEN = 0
         let parsed = parse_expr_ir(func, ctx, p + 1)
@@ -4502,6 +4510,11 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
                         V2_LAST_STRUCT_IDX = -1
                         return early_tail_expr.next
                     }
+                    if V2_LAST_ARR_LEN > 0 {
+                        ufn_record_return_struct(early_tail_expr.reg, V2_LAST_ARR_LEN)
+                        V2_LAST_ARR_LEN = 0
+                        return early_tail_expr.next
+                    }
                     ufn_record_return(early_tail_expr.reg)
                     return early_tail_expr.next
                 }
@@ -4524,6 +4537,11 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
                     if V2_LAST_STRUCT_IDX >= 0 {
                         ufn_record_return_struct(call.reg, STRUCT_FLAT_SIZE[V2_LAST_STRUCT_IDX as usize])
                         V2_LAST_STRUCT_IDX = -1
+                        return call.next
+                    }
+                    if V2_LAST_ARR_LEN > 0 {
+                        ufn_record_return_struct(call.reg, V2_LAST_ARR_LEN)
+                        V2_LAST_ARR_LEN = 0
                         return call.next
                     }
                     ufn_record_return(call.reg)
@@ -4562,6 +4580,11 @@ fn parse_stmt_ir(func: &! i64, ctx: &! V2DriverContext, pos: i64, close: i64, to
                     if V2_LAST_STRUCT_IDX >= 0 {
                         ufn_record_return_struct(early_local_tail.reg, STRUCT_FLAT_SIZE[V2_LAST_STRUCT_IDX as usize])
                         V2_LAST_STRUCT_IDX = -1
+                        return early_local_tail.next
+                    }
+                    let early_local_alen = lookup_local_alen_by_reg(ctx, early_local_tail.reg)
+                    if early_local_alen > 0 {
+                        ufn_record_return_struct(early_local_tail.reg, early_local_alen)
                         return early_local_tail.next
                     }
                     ufn_record_return(early_local_tail.reg)
@@ -5122,9 +5145,21 @@ fn scan_user_fns(token_count: i64, first_fn_id: i64) with Mut, Panic, Div {
                                 ret_is_f64 = 1
                             }
                         }
-                        // detect -> [T; N] array return (TK_LBRACKET=178, TK_SEMI=180)
-                        if j + 4 < token_count && token_kind(j + 1) == 178 && token_kind(j + 3) == 180 && token_kind(j + 4) == TK_INT {
-                            ret_arr_size = pt_read_int_value(j + 4)
+                        // Detect -> [T; N] array return. Scan to the body
+                        // opener instead of relying on exact offsets; imported
+                        // stdlib signatures may carry trivia/effects nearby.
+                        var ret_scan = j + 1
+                        while ret_scan + 3 < token_count && token_kind(ret_scan) != TK_LBRACE && token_kind(ret_scan) != TK_FN {
+                            if token_kind(ret_scan) == TK_LBRACKET {
+                                var ret_semi = ret_scan + 1
+                                while ret_semi < token_count && token_kind(ret_semi) != TK_SEMI && token_kind(ret_semi) != TK_RBRACKET && token_kind(ret_semi) != TK_LBRACE {
+                                    ret_semi = ret_semi + 1
+                                }
+                                if ret_semi + 1 < token_count && token_kind(ret_semi) == TK_SEMI && token_kind(ret_semi + 1) == TK_INT {
+                                    ret_arr_size = pt_read_int_value(ret_semi + 1)
+                                }
+                            }
+                            ret_scan = ret_scan + 1
                         }
                         break
                     }

--- a/tests/run-pass/native_v2_array_tail_return.sio
+++ b/tests/run-pass/native_v2_array_tail_return.sio
@@ -1,0 +1,18 @@
+//@ run-pass
+
+fn basis(idx: i64) -> [f64; 8] with Mut {
+    var out: [f64; 8] = [0.0; 8]
+    out[idx] = 1.0
+    out
+}
+
+fn main() -> i32 with IO, Mut {
+    var e1 = basis(1)
+    var e2 = basis(2)
+    if e1[1] > 0.99 && e2[2] > 0.99 {
+        println("ALL PASS")
+        return 0
+    }
+    println("FAIL")
+    1
+}

--- a/tests/run-pass/native_v2_f32_struct_sret.sio
+++ b/tests/run-pass/native_v2_f32_struct_sret.sio
@@ -1,0 +1,27 @@
+//@ run-pass
+
+struct Vec8f32 {
+    x0: f32, x1: f32, x2: f32, x3: f32,
+    x4: f32, x5: f32, x6: f32, x7: f32,
+}
+
+fn basis(idx: i32) -> Vec8f32 {
+    if idx == 1 {
+        return Vec8f32 { x0: 0.0, x1: 1.0, x2: 0.0, x3: 0.0, x4: 0.0, x5: 0.0, x6: 0.0, x7: 0.0 }
+    }
+    if idx == 2 {
+        return Vec8f32 { x0: 0.0, x1: 0.0, x2: 1.0, x3: 0.0, x4: 0.0, x5: 0.0, x6: 0.0, x7: 0.0 }
+    }
+    Vec8f32 { x0: 0.0, x1: 0.0, x2: 0.0, x3: 0.0, x4: 0.0, x5: 0.0, x6: 0.0, x7: 0.0 }
+}
+
+fn main() -> i32 with IO {
+    let e1 = basis(1)
+    let e2 = basis(2)
+    if e1.x1 > 0.99 && e2.x2 > 0.99 {
+        println("ALL PASS")
+        return 0
+    }
+    println("FAIL")
+    1
+}


### PR DESCRIPTION
## Summary
- fix N-v2 f32 struct field typing so 8-field SRET returns preserve float slots
- fix N-v2 tail-expression returns of local arrays so [f64; N] results use the existing SRET return path instead of scalar return
- add two focused run-pass regressions for f32 struct SRET and array tail returns

## Root-cause classification
- tests/run-pass/algebra_g2_invariants.sio failed because its by-value f32 Oct struct fields were not marked as floating slots in native_compile_driver.sio; N-v2 SRET returned garbage/zeroed basis components.
- tests/run-pass/algebra_g2_invariants_import.sio failed after import prebundling because stdlib oct_basis returns [f64; 8] via a tail expression. The early local-tail path emitted a scalar return instead of returning the local array through SRET.

## Evidence
- bin/souc run tests/run-pass/native_v2_f32_struct_sret.sio
- bin/souc run tests/run-pass/native_v2_array_tail_return.sio
- SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-algebra-runtime-rebased-20260514T1 bash scripts/ci/track_a_nv2_parity_inventory.sh tests/run-pass/algebra_g2_invariants.sio tests/run-pass/algebra_g2_invariants_import.sio tests/run-pass/native_v2_f32_struct_sret.sio tests/run-pass/native_v2_array_tail_return.sio
  - corpus=4, ok=4, nv2_compile=0, nv2_run=0
- SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_NATIVE_V2_GATE_DIR=/tmp/lane4-algebra-runtime-serious-gate-rebased-20260514T1 bash scripts/ci/native_v2_serious_track_gate.sh
- SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc SOUNIO_PARITY_INVENTORY_DIR=/tmp/lane4-algebra-runtime-full-rebased-20260514T1 bash scripts/ci/track_a_nv2_parity_inventory.sh 'tests/run-pass/*.sio'
  - corpus=424, ok=185, nv2_compile=187, nv2_run=51, both_fail=1
- SOUC_BIN=/tmp/sounio-lane-4-nv2-algebra-runtime-b/bin/souc bash scripts/ci/compiler_stage_contract_gate.sh
  - COMPILER_STAGE_CONTRACT_GATE_PASS pass=14 known_blocker=1
- git diff --check

## Notes
No LLM-offload was invoked: this changes native compiler lowering/runtime plumbing and regression tests, not external-facing artifacts, clinical-pathway code, or dissertation/math claim text.