### PR TITLE
[stats] Make v1 workflows run-pass

### DIFF
--- a/examples/stats/v1_descriptive_workflow.sio
+++ b/examples/stats/v1_descriptive_workflow.sio
@@ -1,6 +1,6 @@
 use stats::v1::{describe, summary_evidence_mean}
 
-fn main() with Mut, Div, Panic {
+fn main() -> i32 with Mut, Div, Panic {
     var systolic: [f64; 100] = [0.0; 100]
     systolic[0] = 118.0
     systolic[1] = 121.0
@@ -10,8 +10,10 @@ fn main() with Mut, Div, Panic {
 
     let summary = describe(systolic, 5)
 
-    assert(summary.n == 5)
-    assert(summary.mean > 120.0 && summary.mean < 122.0)
-    assert(summary.std_error > 1.0)
-    assert(summary_evidence_mean(&summary) > 0.80)
+    if summary.n != 5 { return 1 }
+    if summary.mean < 120.0 { return 2 }
+    if summary.mean > 122.0 { return 3 }
+    if summary.std_error < 1.0 { return 4 }
+    if summary_evidence_mean(&summary) < 0.80 { return 5 }
+    return 0
 }

--- a/examples/stats/v1_group_comparison_workflow.sio
+++ b/examples/stats/v1_group_comparison_workflow.sio
@@ -1,6 +1,6 @@
 use stats::v1::{compare_groups, comparison_evidence_mean}
 
-fn main() with Mut, Div, Panic {
+fn main() -> i32 with Mut, Div, Panic {
     var standard_care: [f64; 100] = [0.0; 100]
     standard_care[0] = 10.0
     standard_care[1] = 11.0
@@ -17,7 +17,8 @@ fn main() with Mut, Div, Panic {
 
     let result = compare_groups(standard_care, 5, new_protocol, 5)
 
-    assert(result.mean_diff < 0.0)
-    assert(result.ci_lower < result.ci_upper)
-    assert(comparison_evidence_mean(&result) > 0.90)
+    if result.mean_diff >= 0.0 { return 1 }
+    if result.ci_lower >= result.ci_upper { return 2 }
+    if comparison_evidence_mean(&result) < 0.90 { return 3 }
+    return 0
 }

--- a/examples/stats/v1_regression_workflow.sio
+++ b/examples/stats/v1_regression_workflow.sio
@@ -1,21 +1,22 @@
 use stats::v1::{regress_simple, regression_evidence_mean}
 
-fn main() with Mut, Div, Panic {
-    var exposure: [f64; 100] = [0.0; 100]
-    var outcome: [f64; 100] = [0.0; 100]
+fn main() -> i32 with Mut, Div, Panic {
+    var x: [f64; 100] = [0.0; 100]
+    var y: [f64; 100] = [0.0; 100]
 
     var i: i64 = 0
     while i < 10 {
-        exposure[i as usize] = i as f64
-        outcome[i as usize] = 2.0 + 3.0 * (i as f64) + 0.1
+        x[i as usize] = i as f64
+        y[i as usize] = 2.0 + 3.0 * (i as f64) + 0.1
         i = i + 1
     }
 
-    let workflow = regress_simple(exposure, outcome, 10)
+    let workflow = regress_simple(x, y, 10)
 
-    assert(workflow.model.slope > 2.5)
-    assert(workflow.model.slope < 3.5)
-    assert(workflow.model.r_squared > 0.95)
-    assert(workflow.model.n == 10)
-    assert(regression_evidence_mean(&workflow) > 0.90)
+    if workflow.model.slope < 2.5 { return 1 }
+    if workflow.model.slope > 3.5 { return 2 }
+    if workflow.model.r_squared < 0.95 { return 3 }
+    if workflow.model.n != 10 { return 4 }
+    if regression_evidence_mean(&workflow) < 0.90 { return 5 }
+    return 0
 }

--- a/tests/stdlib/stats/test_v1_public_api.sio
+++ b/tests/stdlib/stats/test_v1_public_api.sio
@@ -1,4 +1,4 @@
-//@ check-only
+//@ run-pass
 // stats::v1 public API workflows: descriptive, group comparison, regression.
 
 use stats::v1::{
@@ -56,51 +56,70 @@ fn local_abs(x: f64) -> f64 {
     if x < 0.0 { 0.0 - x } else { x }
 }
 
-fn test_descriptive_workflow() with Mut, Div, Panic {
+fn test_descriptive_workflow() -> i32 with Mut, Div, Panic {
     let data = make_group_a()
     let summary = describe(data, 5)
 
-    assert(summary.n == 5)
-    assert(local_abs(summary.mean - 14.0) < 0.001)
-    assert(summary.variance > 9.9 && summary.variance < 10.1)
-    assert(summary.std_dev > 3.1 && summary.std_dev < 3.2)
-    assert(summary.std_error > 1.4 && summary.std_error < 1.5)
-    assert(summary_evidence_mean(&summary) > 0.80)
+    if summary.n != 5 { return 1 }
+    if local_abs(summary.mean - 14.0) > 0.001 { return 2 }
+    if summary.variance < 9.9 { return 3 }
+    if summary.variance > 10.1 { return 4 }
+    if summary.std_dev < 3.1 { return 5 }
+    if summary.std_dev > 3.2 { return 6 }
+    if summary.std_error < 1.4 { return 7 }
+    if summary.std_error > 1.5 { return 8 }
+    if summary_evidence_mean(&summary) < 0.80 { return 9 }
+    return 0
 }
 
-fn test_group_comparison_workflow() with Mut, Div, Panic {
+fn test_group_comparison_workflow() -> i32 with Mut, Div, Panic {
     let a = make_group_a()
     let b = make_group_b()
     let comparison = compare_groups(a, 5, b, 5)
 
-    assert(comparison.n_a == 5)
-    assert(comparison.n_b == 5)
-    assert(local_abs(comparison.mean_diff + 2.0) < 0.001)
-    assert(comparison.se_diff > 1.9 && comparison.se_diff < 2.1)
-    assert(comparison.ci_lower < comparison.ci_upper)
-    assert(comparison_evidence_mean(&comparison) > 0.90)
+    if comparison.n_a != 5 { return 10 }
+    if comparison.n_b != 5 { return 11 }
+    if local_abs(comparison.mean_diff + 2.0) > 0.001 { return 12 }
+    if comparison.se_diff < 1.9 { return 13 }
+    if comparison.se_diff > 2.1 { return 14 }
+    if comparison.ci_lower >= comparison.ci_upper { return 15 }
+    if comparison_evidence_mean(&comparison) < 0.90 { return 16 }
+    return 0
 }
 
-fn test_regression_workflow() with Mut, Div, Panic {
+fn test_regression_workflow() -> i32 with Mut, Div, Panic {
     let x = make_x()
     let y = make_y()
     let workflow = regress_simple(x, y, 10)
 
-    assert(workflow.model.intercept > 1.5 && workflow.model.intercept < 2.5)
-    assert(workflow.model.slope > 2.5 && workflow.model.slope < 3.5)
-    assert(workflow.model.r_squared > 0.95)
-    assert(workflow.model.n == 10)
-    assert(regression_evidence_mean(&workflow) > 0.90)
+    if workflow.model.intercept < 1.5 { return 20 }
+    if workflow.model.intercept > 2.5 { return 21 }
+    if workflow.model.slope < 2.5 { return 22 }
+    if workflow.model.slope > 3.5 { return 23 }
+    if workflow.model.r_squared < 0.95 { return 24 }
+    if workflow.model.n != 10 { return 25 }
+    if regression_evidence_mean(&workflow) < 0.90 { return 26 }
+    return 0
 }
 
-fn test_beta_exports() with Mut, Div, Panic {
+fn test_beta_exports() -> i32 with Mut, Div, Panic {
     let confidence = beta_confidence(9.0, 1.0)
-    assert(confidence_mean(&confidence) > 0.80)
+    if confidence_mean(&confidence) < 0.80 { return 30 }
+    return 0
 }
 
-fn main() with Mut, Div, Panic {
-    test_descriptive_workflow()
-    test_group_comparison_workflow()
-    test_regression_workflow()
-    test_beta_exports()
+fn main() -> i32 with Mut, Div, Panic {
+    let d = test_descriptive_workflow()
+    if d != 0 { return d }
+
+    let g = test_group_comparison_workflow()
+    if g != 0 { return g }
+
+    let r = test_regression_workflow()
+    if r != 0 { return r }
+
+    let b = test_beta_exports()
+    if b != 0 { return b }
+
+    return 0
 }


### PR DESCRIPTION
## Summary
- make all stats v1 workflow examples executable with `main() -> i32`
- convert `test_v1_public_api.sio` from check-only/assert-style into `run-pass`
- prove the three promised workflows through `souc run`: descriptive, group comparison, and regression

## Validation
- `timeout 15s ./bin/souc run examples/stats/v1_descriptive_workflow.sio`
- `timeout 15s ./bin/souc run examples/stats/v1_group_comparison_workflow.sio`
- `timeout 15s ./bin/souc run examples/stats/v1_regression_workflow.sio`
- `timeout 15s ./bin/souc run tests/stdlib/stats/test_v1_public_api.sio`
- `bash scripts/run_sio_test_suite.sh v1_public_api`
- `./bin/souc check examples/stats/v1_descriptive_workflow.sio`
- `./bin/souc check examples/stats/v1_group_comparison_workflow.sio`
- `./bin/souc check examples/stats/v1_regression_workflow.sio`
- `git diff --check`
- `git diff --cached --check`
- `scripts/dev/check_offload_policy.sh`

## Notes
- no math formulas changed here; prior xai math-review remains the relevant review for the stats v1 API semantics
- this patch closes the gap where regression had only check-level coverage instead of a real runtime gate
