### PR TITLE
docs: ONBOARDING.md — canonical agent operating rules

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,73 @@
+# Sounio — Regras de Operação para Agentes
+
+> Toda sessão de agente (Claude, Codex, Cursor, Kimi, …) começa por aqui.
+> Fonte de verdade em runtime: `cd /workspace/sounio && ./sounio-whereami --quick`.
+
+## 0. Primeiro comando, sempre
+
+```bash
+cd /workspace/sounio && ./sounio-whereami --quick
+```
+
+Ele reporta: pod, usuário, repo, **branch atual**, nó K8s, compilador selecionado,
+GPU owner, estado do Slurm e OrangeFS. Não adivinhe o mapa — leia o whereami.
+
+## 1. Dois mundos — não confunda
+
+| Mundo | Caminho | whereami |
+|---|---|---|
+| Workspace / pod K8s | `/workspace/sounio` | `cd /workspace/sounio && ./sounio-whereami --quick` |
+| Host / control plane | `/home/devsounio/projects/sounio` | `/home/devsounio/projects/sounio/sounio-whereami --quick` |
+
+- Dentro do pod, **`/home/devsounio` não existe**. Não assuma que existe.
+- Caminhos VM-era (`/home/demetrios/RustroverProjects/sounio`) são históricos e mortos.
+
+## 2. Branch é a verdade operacional
+
+- A **branch atualmente em checkout** manda nesta sessão.
+- **Não** troque para `main` ou `integration/sounio-dev-ready-base` só porque docs antigos mencionam.
+- `BEAGLE_WORKSPACE_BRANCH` ≠ branch git atual. Sempre confira `git branch --show-current`.
+- Imprima a branch depois de qualquer checkout, antes de assumir que pegou.
+
+## 3. Superfícies — onde rodar o quê
+
+- `/workspace/sounio` = superfície interativa: **edição + checks leves OK**.
+- **Validação pesada / stress** → Sounio Compiler Foundry / Slurm, **nunca** no workspace.
+- Output de runs → raízes de artefato da foundry, **não** na árvore viva.
+- OrangeFS (`/orangefs/training`) está ausente local; presente só no login Slurm.
+
+## 4. Compilador
+
+- Wrapper canônico: `bin/souc` (resolve `bin/souc-linux-x86_64`).
+- `$SOUC check <arquivo>.sio` / `$SOUC compile <src> -o <out>`.
+
+## 5. Cluster
+
+- GPU owner deste pod: reportado pelo whereami (lane GPU fica no habitat-0).
+- `sinfo` direto pode dar timeout no workspace → whereami cai pro login pod.
+- Submissão de jobs k8s/Slurm: via BeagleCockpit MCP. **Nunca** escreva YAML à mão.
+
+## 6. Hard No
+
+- Não `reset`, `clean`, `rebase` nem troca de branch sem o usuário pedir explicitamente.
+- Não rode stress pesado em `/workspace/sounio`.
+- Não use `/workspace/sounio` como scratch de batch.
+- Não assuma `/home/devsounio` dentro do pod.
+- Não `git add -A` em branch compartilhada (vaza WIP de outros agentes).
+
+## 7. Coordenação multi-agente
+
+- Múltiplas sessões Opus/Codex rodam concorrentes neste repo.
+- **Coordene antes de editar arquivos compartilhados.** Re-cheque `git status` antes de stage.
+- Edits podem aparecer no commit de outro agente sob mensagens não-relacionadas. Não brigue com a história.
+
+## 8. Precedência quando docs divergem
+
+1. Arquivos reais do repo + scripts executáveis
+2. Docs de governança commitados
+3. Contratos de prompt históricos
+4. Suposições (último recurso)
+
+---
+
+Contratos por-CLI: `CLAUDE.md` (Claude Code) · `AGENTS.md` (Codex) · `CLAUDE_HANDOFF.md` (estado de handoff).


### PR DESCRIPTION
Single-source operating rules for all agents (Claude / Codex / Cursor / Kimi).

Contents: orientation via `sounio-whereami`, two-worlds path map (pod vs host
control plane), branch-is-truth, surface boundaries, Hard No list, multi-agent
coordination, doc precedence.

Clean branch off `main` — only adds `ONBOARDING.md`, no GPU/Kretikos lane work.
Supersedes the doc commit in #170 (that PR conflicts on the Kretikos lane).

Shareable link: https://claude.ai/claude-code/onboard/Zi0vHDGtC038

🤖 Generated with [Claude Code](https://claude.com/claude-code)