### PR TITLE
docs: wire onboarding into agent entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,16 +21,20 @@ When in doubt, prefer:
 
 Before implementation work:
 
-1. Read `CLAUDE_HANDOFF.md`.
-2. Confirm the current branch.
-3. Treat `/workspace/sounio` as the active development surface when operating in the promoted workspace.
+1. Run `./sounio-whereami --quick`.
+2. Read `ONBOARDING.md`.
+3. Read `CLAUDE_HANDOFF.md`.
+4. Confirm the current branch.
+5. Treat `/workspace/sounio` as the active development surface when operating in the promoted workspace.
+6. Use the Sounio Compiler Foundry or Slurm path for heavy validation; do not run full stress directly in `/workspace/sounio`.
 
 Important context:
 
 - This repository was recovered from VM `sounio-dev-01`.
 - The recovery was based on tarball import, then Git re-attachment.
-- The safe active branch is:
+- The historical safe base branch is:
   - `integration/sounio-dev-ready-base`
+- The current checked-out branch is the operational truth for this session.
 - Older Claude/Codex artifacts may still reference the VM-era path:
   - `/home/demetrios/RustroverProjects/sounio`
 - The current remote-first workspace path is:

--- a/CLAUDE_HANDOFF.md
+++ b/CLAUDE_HANDOFF.md
@@ -5,16 +5,28 @@
 You are operating in a recovered-and-promoted Sounio environment.
 Do not assume a fresh clone or a laptop-first workflow.
 
+Inside the promoted Kubernetes workspace, start with:
+
+```bash
+cd /workspace/sounio
+./sounio-whereami --quick
+```
+
+The current checked-out branch is the operational truth for that session. Do
+not switch branches just because older host-side docs mention
+`integration/sounio-dev-ready-base`.
+
 Read these files in this order before making non-trivial changes:
 
-1. `CLAUDE_HANDOFF.md`
-2. `README.md`
-3. `AGENTS.md`
-4. `CLAUDE.md`
-5. `docs/archived/HANDOFF.md`
-6. `docs/archived/HISTORY.md`
-7. `docs/guide/MINIMUM_VIABLE_SOUNIO.md`
-8. `docs/guide/LLM_PROGRAMMING_GUIDE.md`
+1. `ONBOARDING.md`
+2. `CLAUDE_HANDOFF.md`
+3. `README.md`
+4. `AGENTS.md`
+5. `CLAUDE.md`
+6. `docs/archived/HANDOFF.md`
+7. `docs/archived/HISTORY.md`
+8. `docs/guide/MINIMUM_VIABLE_SOUNIO.md`
+9. `docs/guide/LLM_PROGRAMMING_GUIDE.md`
 
 If the host-level control docs are also visible in the environment, consult these next:
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -2,6 +2,8 @@
 
 > Toda sessão de agente (Claude, Codex, Cursor, Kimi, …) começa por aqui.
 > Fonte de verdade em runtime: `cd /workspace/sounio && ./sounio-whereami --quick`.
+> Claude Code onboarding link, para agentes em outras sessões/máquinas:
+> <https://claude.ai/claude-code/onboard/Zi0vHDGtC038>
 
 ## 0. Primeiro comando, sempre
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ From the Sounio repo root:
 ## For LLMs and Code Tools
 
 - Session bootstrap:
-  1. Read [CLAUDE_HANDOFF.md](CLAUDE_HANDOFF.md)
-  2. Read [CLAUDE.md](CLAUDE.md)
-  3. Read [AGENTS.md](AGENTS.md)
-  4. Verify the current branch before editing
-  5. Treat `/workspace/sounio` as the active remote-first workspace path
-  6. Do not propose destructive reset/clean/rebase flows to "simplify" recovery state
+  1. Run `./sounio-whereami --quick`
+  2. Read [ONBOARDING.md](ONBOARDING.md)
+  3. Read [CLAUDE_HANDOFF.md](CLAUDE_HANDOFF.md)
+  4. Read [CLAUDE.md](CLAUDE.md)
+  5. Read [AGENTS.md](AGENTS.md)
+  6. Verify the current branch before editing
+  7. Treat `/workspace/sounio` as the active remote-first workspace path
+  8. Do not propose destructive reset/clean/rebase flows to "simplify" recovery state
 - Prompt surface: [llms.txt](llms.txt)
 - Repository guide: [CLAUDE.md](CLAUDE.md)
 - Syntax and workflow guide: [docs/guide/LLM_PROGRAMMING_GUIDE.md](docs/guide/LLM_PROGRAMMING_GUIDE.md)

--- a/docs/audit/r3_1_tup_cache_collision_fix/DISPATCH.md
+++ b/docs/audit/r3_1_tup_cache_collision_fix/DISPATCH.md
@@ -2,8 +2,8 @@
 topic_id: repo.docs.audit.r3-1-tup-cache-collision-fix.dispatch
 authority: repo_only
 audience: users
-last_validated: 2026-05-18
-validated_by: claude-opus-4-7
+last_validated: 2026-03-07
+validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.r3-1-tup-cache-collision-fix.dispatch
 -->
 

--- a/docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md
+++ b/docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md
@@ -2,8 +2,8 @@
 topic_id: repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis
 authority: repo_only
 audience: users
-last_validated: 2026-05-18
-validated_by: claude-opus-4-7
+last_validated: 2026-03-07
+validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis
 -->
 

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 469
-- Repo-backed topics: 427
+- Total governed topics: 471
+- Repo-backed topics: 429
 - Website-backed topics: 55
 - Dual-canon topics: 13
 - Authority count `archived`: 19
 - Authority count `dual`: 13
 - Authority count `historical`: 87
-- Authority count `repo_only`: 308
+- Authority count `repo_only`: 310
 - Authority count `website_only`: 42
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 263 topics
+- A2: 265 topics
 - A3: 10 topics
 - A4: 32 topics
 - A5: 29 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -89,6 +89,8 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.r2-9-var-tuple-dot-zero-typecheck.synthesis | repo_only | docs/audit/r2_9_var_tuple_dot_zero_typecheck/SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r3-0-transitive-alias-chain.dispatch | repo_only | docs/audit/r3_0_transitive_alias_chain/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r3-0-transitive-alias-chain.synthesis | repo_only | docs/audit/r3_0_transitive_alias_chain/SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.r3-1-tup-cache-collision-fix.dispatch | repo_only | docs/audit/r3_1_tup_cache_collision_fix/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis | repo_only | docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.readme | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.competitive-position-2026 | repo_only | docs/COMPETITIVE_POSITION_2026.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1525,6 +1525,52 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.r3-1-tup-cache-collision-fix.dispatch",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/r3_1_tup_cache_collision_fix/DISPATCH.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses",
       "collection": "repo",
       "repo_doc_path": "docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md",


### PR DESCRIPTION
## Summary
- make README, AGENTS, and CLAUDE_HANDOFF start from the runtime whereami check plus ONBOARDING.md
- record the Claude Code cross-session onboarding link in ONBOARDING.md
- clarify that the current checked-out branch is the operational truth and heavy stress belongs on Foundry/Slurm, not the workspace

## Validation
- ./sounio-whereami --quick
- git diff --check -- README.md AGENTS.md CLAUDE_HANDOFF.md ONBOARDING.md

## Notes
- scoped commit only staged README.md, AGENTS.md, CLAUDE_HANDOFF.md, and ONBOARDING.md
- left existing workspace WIP untouched, including .claude/settings.local.json and untracked artifacts