### PR TITLE
feat(pbpk28): clinical-validation modules w/ terminal half-life fit (rapamycin oral, semaglutide SC)

### DIFF
--- a/stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio
+++ b/stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio
@@ -1,0 +1,291 @@
+// stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio
+//
+// PBPK28 CLINICAL VALIDATION — RAPAMYCIN (predicted-vs-observed concentration profile)
+//
+// Closes the "PBPK28 has no external validation" gap: simulates the 28-state
+// permeability-limited kernel with a first-order ORAL absorption depot, samples
+// whole-blood concentration at the observed study timepoints, and compares
+// point-by-point against a published clinical profile via GMFE / % within 2-fold
+// (the FDA/EMA PBPK credibility metric).
+//
+// ============================================================================
+// OBSERVED DATA IS PENDING — DO NOT FABRICATE.
+// The observed concentration-time series must be supplied by a literature-MCP
+// session reading the source paper. Until obs_n() > 0 this file runs the model
+// and prints an ILLUSTRATIVE predicted profile, then emits
+//   PBPK28_RAPAMYCIN_CLINICAL_PENDING_OBSERVED
+// (NOT a PASS). When the observed arrays + study design are filled in, it computes
+// GMFE and emits PBPK28_RAPAMYCIN_CLINICAL_PASS / _FAIL_HONEST.
+//
+// Provenance to fill (lit session):
+//   source     : <Ferron 1997 Clin Pharmacol Ther 61:696-708, Fig/Table, n=24>
+//   dose/route : <e.g. 2 mg oral single dose>
+//   matrix     : WHOLE BLOOD (sirolimus is assayed in whole blood, not plasma)
+//   ka, F      : oral absorption rate-constant (1/h) and bioavailability
+//   OBS_T/OBS_C: digitized (time h, conc mg/L) points
+//
+// Method: per-step CN (pbpk28_full_cn_step), oral depot driven through the
+// release term rel = F * ka * A_depot; A_depot depletes at ka * A_depot.
+// Acceptance: GMFE <= 2.0 OR >= 80% of points within 2-fold.
+//
+// NOTE (coupling): PBPK28 Kp/TMDD params are known to diverge from literature
+// (gap_report: rapamycin_kp_values, *_tmdd_params; adipose capping). A poor GMFE
+// here is a TRUE result (FAIL_HONEST), not a reason to loosen the threshold.
+//
+// Author: Demetrios Chiuratto Agourakis
+
+use darwin_pbpk::core::pbpk28_params::*
+use darwin_pbpk::tsit5_pbpk28::*
+
+// ============================================================================
+// MATH HELPERS (native compiler has no stdlib transcendentals here)
+// ============================================================================
+
+fn pv_abs(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    return x
+}
+
+fn pv_finite(x: f64) -> bool {
+    if x != x { return false }
+    return pv_abs(x) < 1.0e12
+}
+
+// exp via repeated squaring (matches rapamycin_clinical.sio cv_exp)
+fn pv_exp(x: f64) -> f64 with Mut {
+    var r = 1.0 + x / 1024.0
+    var i = 0
+    while i < 10 {
+        r = r * r
+        i = i + 1
+    }
+    return r
+}
+
+fn pv_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 - 999999.0 }
+    var sx = x
+    var scale = 0
+    while sx > 2.0 {
+        sx = sx / 2.718281828459045
+        scale = scale + 1
+    }
+    while sx < 0.5 {
+        sx = sx * 2.718281828459045
+        scale = scale - 1
+    }
+    let u = (sx - 1.0) / (sx + 1.0)
+    let u2 = u * u
+    let result = 2.0 * (u + u * u2 / 3.0 + u * u2 * u2 / 5.0
+                       + u * u2 * u2 * u2 / 7.0 + u * u2 * u2 * u2 * u2 / 9.0)
+    var sf = 0.0
+    var si = 0
+    if scale > 0 {
+        while si < scale { sf = sf + 1.0; si = si + 1 }
+    } else {
+        while si < (0 - scale) { sf = sf - 1.0; si = si + 1 }
+    }
+    return result + sf
+}
+
+// FE = max(pred/obs, obs/pred), always >= 1.0
+fn pv_fold_error(pred: f64, obs: f64) -> f64 {
+    if obs <= 0.0 || pred <= 0.0 { return 999.0 }
+    let r = pred / obs
+    let ri = obs / pred
+    if r > ri { return r }
+    return ri
+}
+
+// ============================================================================
+// OBSERVED DATA — PENDING (supplied by literature-MCP session)
+// ============================================================================
+// obs_n() = 0 is the PENDING sentinel. Set it to the number of digitized points
+// and fill obs_t_at / obs_c_at + the study-design constants below.
+
+fn obs_n() -> i32 { return 0 }
+
+fn obs_t_at(i: i32) -> f64 {
+    // hours post-dose; fill from the source figure/table
+    return 0.0
+}
+
+fn obs_c_at(i: i32) -> f64 {
+    // observed WHOLE-BLOOD sirolimus concentration, mg/L
+    return 0.0
+}
+
+// Study design (fill with the observed study's regimen)
+fn study_dose_mg() -> f64 { return 2.0 }   // PLACEHOLDER (illustrative)
+fn oral_ka()      -> f64 { return 0.5 }    // PLACEHOLDER 1/h (illustrative)
+fn oral_f()       -> f64 { return 0.15 }   // PLACEHOLDER sirolimus oral F ~0.14
+
+// ============================================================================
+// SIMULATE-AND-SAMPLE — 28-state CN with first-order oral depot
+// ============================================================================
+// Returns predicted whole-blood concentration (cv[0], mg/L) at time `t_target`
+// hours, for an oral dose `dose` with absorption (ka, F).
+
+fn pbpk28_oral_blood_at(prm: PBPKParams28, dose: f64, ka: f64, f_bio: f64,
+                        t_target: f64) -> f64 with Mut, Div, Panic {
+    let dt = 0.05
+    var st = pbpk28_state_zero()
+    var a_depot = dose          // mg in gut depot at t=0 (oral)
+    var t = 0.0
+    var out = 0.0
+    var captured = false
+    while t < t_target {
+        let dt_use = if t + dt > t_target { t_target - t } else { dt }
+        let rel = f_bio * ka * a_depot         // mg/h reaching systemic blood
+        let st_new = pbpk28_full_cn_step(st, prm, rel, dt_use)
+        a_depot = a_depot - ka * a_depot * dt_use
+        if a_depot < 0.0 { a_depot = 0.0 }
+        t = t + dt_use
+        st = st_new
+        if !pv_finite(st.cv[0]) { return 0.0 }
+        out = st.cv[0]
+        captured = true
+    }
+    if captured == false { return st.cv[0] }
+    return out
+}
+
+// ============================================================================
+// MAIN — predicted-vs-observed, or PENDING
+// ============================================================================
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    println("========================================================")
+    println("  PBPK28 CLINICAL VALIDATION — Rapamycin (whole blood)")
+    println("  Predicted-vs-observed concentration-time profile")
+    println("========================================================")
+
+    let prm = pbpk28_params_rapamycin()
+    let dose = study_dose_mg()
+    let ka = oral_ka()
+    let f_bio = oral_f()
+    let n = obs_n()
+
+    if n <= 0 {
+        // PENDING: show an illustrative predicted profile (real model output for
+        // the placeholder oral regimen), but compute NO GMFE and emit no PASS.
+        println("  OBSERVED DATA PENDING — illustrative predicted profile only")
+        println("  (placeholder oral dose mg / ka / F shown; not a validation)")
+        println(dose)
+        println(ka)
+        println(f_bio)
+        var k = 0
+        let grid: [f64; 8] = [0.5, 1.0, 2.0, 4.0, 8.0, 24.0, 72.0, 168.0]
+        var cn: [f64; 8] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        while k < 8 {
+            let tt = grid[k]
+            let cpred = pbpk28_oral_blood_at(prm, dose, ka, f_bio, tt)
+            cn[k] = cpred
+            println(tt)
+            println(cpred)
+            k = k + 1
+        }
+
+        // ----------------------------------------------------------------
+        // TERMINAL HALF-LIFE FIT (computed, not eyeballed)
+        // ----------------------------------------------------------------
+        // Log-linear regression of ln(C) vs t over the post-peak declining
+        // tail gives lambda_z; t_half = ln(2)/lambda_z. This converts the
+        // "model over-clears" observation into a NUMBER that can be compared
+        // against sirolimus's real terminal t_half (~62 h). A small fitted
+        // t_half here is the quantitative signature of gap #2 (capped Kp ->
+        // tiny Vd). Still illustrative (placeholder oral regimen) and emits
+        // NO pass/fail — diagnostic only.
+        var pk = 0
+        var pkv = cn[0]
+        var jj = 1
+        while jj < 8 {
+            if cn[jj] > pkv { pkv = cn[jj]; pk = jj }
+            jj = jj + 1
+        }
+        var sx = 0.0
+        var sy = 0.0
+        var sxx = 0.0
+        var sxy = 0.0
+        var npt = 0.0
+        // start one point AFTER Cmax: excluding the peak (where dC/dt ~ 0) is
+        // standard NCA practice and avoids biasing lambda_z shallow.
+        var m = pk + 1
+        while m < 8 {
+            let cm = cn[m]
+            if cm > 1.0e-9 && pv_finite(cm) {
+                let xx = grid[m]
+                let yy = pv_ln(cm)
+                sx = sx + xx
+                sy = sy + yy
+                sxx = sxx + xx * xx
+                sxy = sxy + xx * yy
+                npt = npt + 1.0
+            }
+            m = m + 1
+        }
+        println("  terminal half-life fit (illustrative diagnostic):")
+        if npt >= 2.0 {
+            let denom = npt * sxx - sx * sx
+            if pv_abs(denom) > 1.0e-12 {
+                let slope = (npt * sxy - sx * sy) / denom
+                let lambda_z = 0.0 - slope
+                if lambda_z > 0.0 {
+                    println("  lambda_z (1/h) =")
+                    println(lambda_z)
+                    println("  t_half (h) =")
+                    println(0.6931471805599453 / lambda_z)
+                } else {
+                    println("  t_half: non-eliminating tail (lambda_z <= 0)")
+                }
+            } else {
+                println("  t_half: degenerate fit (no time spread)")
+            }
+        } else {
+            println("  t_half: insufficient finite tail points")
+        }
+
+        println("PBPK28_RAPAMYCIN_CLINICAL_PENDING_OBSERVED")
+        return 0
+    }
+
+    // Observed data present: predicted-vs-observed GMFE + % within 2-fold.
+    var sum_ln_fe = 0.0
+    var within2 = 0
+    var nf = 0.0
+    var i = 0
+    while i < n {
+        let tt = obs_t_at(i)
+        let cobs = obs_c_at(i)
+        let cpred = pbpk28_oral_blood_at(prm, dose, ka, f_bio, tt)
+        let fe = pv_fold_error(cpred, cobs)
+        println(tt)
+        println(cobs)
+        println(cpred)
+        println(fe)
+        sum_ln_fe = sum_ln_fe + pv_ln(fe)
+        if fe <= 2.0 { within2 = within2 + 1 }
+        nf = nf + 1.0
+        i = i + 1
+    }
+
+    let gmfe = pv_exp(sum_ln_fe / nf)
+    var pct2 = 0.0
+    var w = 0
+    var wf = 0.0
+    while w < within2 { wf = wf + 1.0; w = w + 1 }
+    pct2 = 100.0 * wf / nf
+
+    println("  GMFE =")
+    println(gmfe)
+    println("  % within 2-fold =")
+    println(pct2)
+
+    // FDA/EMA acceptance: GMFE <= 2.0 OR >= 80% within 2-fold
+    if gmfe <= 2.0 || pct2 >= 80.0 {
+        println("PBPK28_RAPAMYCIN_CLINICAL_PASS")
+        return 0
+    }
+    println("PBPK28_RAPAMYCIN_CLINICAL_FAIL_HONEST")
+    return 1
+}

--- a/stdlib/darwin_pbpk/validation/pbpk28_semaglutide_clinical.sio
+++ b/stdlib/darwin_pbpk/validation/pbpk28_semaglutide_clinical.sio
@@ -1,0 +1,276 @@
+// stdlib/darwin_pbpk/validation/pbpk28_semaglutide_clinical.sio
+//
+// PBPK28 CLINICAL VALIDATION — SEMAGLUTIDE (predicted-vs-observed plasma profile)
+//
+// Simulates the 28-state permeability-limited kernel with a first-order
+// SUBCUTANEOUS depot (semaglutide's native route), samples PLASMA concentration
+// at the observed study timepoints, and compares point-by-point against a
+// published clinical profile via GMFE / % within 2-fold (FDA/EMA metric).
+//
+// ============================================================================
+// OBSERVED DATA IS PENDING — DO NOT FABRICATE.
+// The observed concentration-time series must be supplied by a literature-MCP
+// session reading the source paper. Until obs_n() > 0 this file runs the model
+// and prints an ILLUSTRATIVE predicted profile, then emits
+//   PBPK28_SEMAGLUTIDE_CLINICAL_PENDING_OBSERVED
+// (NOT a PASS). When the observed arrays + study design are filled in, it computes
+// GMFE and emits PBPK28_SEMAGLUTIDE_CLINICAL_PASS / _FAIL_HONEST.
+//
+// Provenance to fill (lit session):
+//   source     : <Overgaard 2019 Clin Pharmacokinet / phase-1, Fig/Table, n=>
+//   dose/route : <e.g. 1 mg subcutaneous single dose>
+//   matrix     : PLASMA
+//   ka_sc, F_sc: SC absorption rate-constant (1/h) and bioavailability (~0.89)
+//   OBS_T/OBS_C: digitized (time h, conc) points (units to match source, e.g. nmol/L)
+//
+// Method: per-step CN (pbpk28_full_cn_step); SC depot driven through the release
+// term rel = F_sc * ka_sc * A_depot; A_depot depletes at ka_sc * A_depot.
+// Acceptance: GMFE <= 2.0 OR >= 80% of points within 2-fold.
+//
+// Author: Demetrios Chiuratto Agourakis
+
+use darwin_pbpk::core::pbpk28_params::*
+use darwin_pbpk::tsit5_pbpk28::*
+
+// ============================================================================
+// MATH HELPERS (native compiler has no stdlib transcendentals here)
+// ============================================================================
+
+fn sv_abs(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    return x
+}
+
+fn sv_finite(x: f64) -> bool {
+    if x != x { return false }
+    return sv_abs(x) < 1.0e12
+}
+
+fn sv_exp(x: f64) -> f64 with Mut {
+    var r = 1.0 + x / 1024.0
+    var i = 0
+    while i < 10 {
+        r = r * r
+        i = i + 1
+    }
+    return r
+}
+
+fn sv_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 - 999999.0 }
+    var sx = x
+    var scale = 0
+    while sx > 2.0 {
+        sx = sx / 2.718281828459045
+        scale = scale + 1
+    }
+    while sx < 0.5 {
+        sx = sx * 2.718281828459045
+        scale = scale - 1
+    }
+    let u = (sx - 1.0) / (sx + 1.0)
+    let u2 = u * u
+    let result = 2.0 * (u + u * u2 / 3.0 + u * u2 * u2 / 5.0
+                       + u * u2 * u2 * u2 / 7.0 + u * u2 * u2 * u2 * u2 / 9.0)
+    var sf = 0.0
+    var si = 0
+    if scale > 0 {
+        while si < scale { sf = sf + 1.0; si = si + 1 }
+    } else {
+        while si < (0 - scale) { sf = sf - 1.0; si = si + 1 }
+    }
+    return result + sf
+}
+
+fn sv_fold_error(pred: f64, obs: f64) -> f64 {
+    if obs <= 0.0 || pred <= 0.0 { return 999.0 }
+    let r = pred / obs
+    let ri = obs / pred
+    if r > ri { return r }
+    return ri
+}
+
+// ============================================================================
+// OBSERVED DATA — PENDING (supplied by literature-MCP session)
+// ============================================================================
+
+fn obs_n() -> i32 { return 0 }
+
+fn obs_t_at(i: i32) -> f64 {
+    // hours post-dose; fill from the source figure/table
+    return 0.0
+}
+
+fn obs_c_at(i: i32) -> f64 {
+    // observed PLASMA semaglutide concentration (units to match source)
+    return 0.0
+}
+
+// Study design (fill with the observed study's regimen)
+fn study_dose_mg() -> f64 { return 1.0 }     // PLACEHOLDER (illustrative)
+fn sc_ka()        -> f64 { return 0.01155 }  // PLACEHOLDER 1/h (ln2/60h, Overgaard 2019)
+fn sc_f()         -> f64 { return 0.89 }      // PLACEHOLDER SC bioavailability
+
+// ============================================================================
+// SIMULATE-AND-SAMPLE — 28-state CN with first-order SC depot
+// ============================================================================
+
+fn pbpk28_sc_blood_at(prm: PBPKParams28, dose: f64, ka: f64, f_bio: f64,
+                      t_target: f64) -> f64 with Mut, Div, Panic {
+    let dt = 0.05
+    var st = pbpk28_state_zero()
+    var a_depot = dose          // mg in SC depot at t=0
+    var t = 0.0
+    var out = 0.0
+    var captured = false
+    while t < t_target {
+        let dt_use = if t + dt > t_target { t_target - t } else { dt }
+        let rel = f_bio * ka * a_depot         // mg/h reaching systemic blood
+        let st_new = pbpk28_full_cn_step(st, prm, rel, dt_use)
+        a_depot = a_depot - ka * a_depot * dt_use
+        if a_depot < 0.0 { a_depot = 0.0 }
+        t = t + dt_use
+        st = st_new
+        if !sv_finite(st.cv[0]) { return 0.0 }
+        out = st.cv[0]
+        captured = true
+    }
+    if captured == false { return st.cv[0] }
+    return out
+}
+
+// ============================================================================
+// MAIN — predicted-vs-observed, or PENDING
+// ============================================================================
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    println("========================================================")
+    println("  PBPK28 CLINICAL VALIDATION — Semaglutide (plasma)")
+    println("  Predicted-vs-observed concentration-time profile")
+    println("========================================================")
+
+    let prm = pbpk28_params_semaglutide()
+    let dose = study_dose_mg()
+    let ka = sc_ka()
+    let f_bio = sc_f()
+    let n = obs_n()
+
+    if n <= 0 {
+        println("  OBSERVED DATA PENDING — illustrative predicted profile only")
+        println("  (placeholder SC dose mg / ka / F shown; not a validation)")
+        println(dose)
+        println(ka)
+        println(f_bio)
+        var k = 0
+        // weekly SC: sample out to ~504 h (3 weeks); t1/2 ~ 165 h. The 240/336/
+        // 504 h tail gives the terminal-slope fit three post-peak points.
+        let grid: [f64; 9] = [6.0, 24.0, 48.0, 72.0, 120.0, 168.0, 240.0, 336.0, 504.0]
+        var cn: [f64; 9] = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        while k < 9 {
+            let tt = grid[k]
+            let cpred = pbpk28_sc_blood_at(prm, dose, ka, f_bio, tt)
+            cn[k] = cpred
+            println(tt)
+            println(cpred)
+            k = k + 1
+        }
+
+        // ----------------------------------------------------------------
+        // TERMINAL HALF-LIFE FIT (computed, not eyeballed)
+        // ----------------------------------------------------------------
+        // Log-linear regression of ln(C) vs t over the post-peak declining
+        // tail gives lambda_z; t_half = ln(2)/lambda_z. Lets the illustrative
+        // profile be checked against semaglutide's real terminal t_half
+        // (~165 h, weekly kinetics). Still illustrative (placeholder SC
+        // regimen) and emits NO pass/fail — diagnostic only.
+        var pk = 0
+        var pkv = cn[0]
+        var jj = 1
+        while jj < 9 {
+            if cn[jj] > pkv { pkv = cn[jj]; pk = jj }
+            jj = jj + 1
+        }
+        var sx = 0.0
+        var sy = 0.0
+        var sxx = 0.0
+        var sxy = 0.0
+        var npt = 0.0
+        // start one point AFTER Cmax: excluding the peak (where dC/dt ~ 0) is
+        // standard NCA practice and avoids biasing lambda_z shallow.
+        var m = pk + 1
+        while m < 9 {
+            let cm = cn[m]
+            if cm > 1.0e-9 && sv_finite(cm) {
+                let xx = grid[m]
+                let yy = sv_ln(cm)
+                sx = sx + xx
+                sy = sy + yy
+                sxx = sxx + xx * xx
+                sxy = sxy + xx * yy
+                npt = npt + 1.0
+            }
+            m = m + 1
+        }
+        println("  terminal half-life fit (illustrative diagnostic):")
+        if npt >= 2.0 {
+            let denom = npt * sxx - sx * sx
+            if sv_abs(denom) > 1.0e-12 {
+                let slope = (npt * sxy - sx * sy) / denom
+                let lambda_z = 0.0 - slope
+                if lambda_z > 0.0 {
+                    println("  lambda_z (1/h) =")
+                    println(lambda_z)
+                    println("  t_half (h) =")
+                    println(0.6931471805599453 / lambda_z)
+                } else {
+                    println("  t_half: non-eliminating tail (lambda_z <= 0)")
+                }
+            } else {
+                println("  t_half: degenerate fit (no time spread)")
+            }
+        } else {
+            println("  t_half: insufficient finite tail points")
+        }
+
+        println("PBPK28_SEMAGLUTIDE_CLINICAL_PENDING_OBSERVED")
+        return 0
+    }
+
+    var sum_ln_fe = 0.0
+    var within2 = 0
+    var nf = 0.0
+    var i = 0
+    while i < n {
+        let tt = obs_t_at(i)
+        let cobs = obs_c_at(i)
+        let cpred = pbpk28_sc_blood_at(prm, dose, ka, f_bio, tt)
+        let fe = sv_fold_error(cpred, cobs)
+        println(tt)
+        println(cobs)
+        println(cpred)
+        println(fe)
+        sum_ln_fe = sum_ln_fe + sv_ln(fe)
+        if fe <= 2.0 { within2 = within2 + 1 }
+        nf = nf + 1.0
+        i = i + 1
+    }
+
+    let gmfe = sv_exp(sum_ln_fe / nf)
+    var pct2 = 0.0
+    var w = 0
+    var wf = 0.0
+    while w < within2 { wf = wf + 1.0; w = w + 1 }
+    pct2 = 100.0 * wf / nf
+
+    println("  GMFE =")
+    println(gmfe)
+    println("  % within 2-fold =")
+    println(pct2)
+
+    if gmfe <= 2.0 || pct2 >= 80.0 {
+        println("PBPK28_SEMAGLUTIDE_CLINICAL_PASS")
+        return 0
+    }
+    println("PBPK28_SEMAGLUTIDE_CLINICAL_FAIL_HONEST")
+    return 1
+}


### PR DESCRIPTION
## What

Two predicted-vs-observed **PBPK28 clinical-validation** modules that run the shipped 28-state Crank–Nicolson kernel through first-order absorption depots:

- `pbpk28_rapamycin_clinical.sio` — oral depot, whole-blood matrix
- `pbpk28_semaglutide_clinical.sio` — SC depot, plasma matrix

Each compares model output against an observed concentration–time profile via inline **GMFE / %-within-2-fold** (the FDA/EMA PBPK credibility metric).

## Honest PENDING state (no fabrication)

Observed data is held in a `PENDING_OBSERVED` state via an `obs_n()==0` sentinel: the modules run the model and print an *illustrative* predicted profile but compute **no GMFE and emit no PASS** until a literature-MCP session supplies digitized points + study design. The five inputs to fill (per drug) are marked at the top of each file.

`metrics.sio` was found to be dead code (no compile, no consumers, in no gate), so the GMFE math is inlined per the existing `rapamycin_clinical.sio` pattern rather than depending on it.

## Terminal half-life fit (computed, not eyeballed)

The illustrative branch now does a log-linear `lambda_z` regression of `ln(C)` vs `t` over the post-peak declining tail (Cmax excluded per NCA practice; `t½ = ln(2)/lambda_z`), with honest fallbacks for non-eliminating / degenerate / under-supported tails. This turns "the model over-clears" into a number:

| Module | Fitted t½ | Real terminal t½ | Read |
|---|---|---|---|
| Rapamycin | **3.11 h** | ~62 h | ~20× too fast — quantitative signature of gap #2 (capped Kp → tiny Vd) |
| Semaglutide | **226.7 h** | ~165 h | physiological order of magnitude; 9-pt grid out to 504 h gives a 3-point terminal tail |

## Gate registration deliberately held

Not yet registered in `dissertation_pbpk_suite_gate.sh` — registering a `PENDING` module would green a gate that hasn't validated anything. Registration converts to PASS/FAIL_HONEST once observed data lands.

## Verification

Both modules compile (`souc compile`, exit 0) and run, emitting `PENDING_OBSERVED` with the computed t½ diagnostics shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)