### PR TITLE
test(dissertation): register pbpk28 clinical-validation modules (pending-aware)

### DIFF
--- a/scripts/ci/dissertation_pbpk_suite_gate.sh
+++ b/scripts/ci/dissertation_pbpk_suite_gate.sh
@@ -130,7 +130,21 @@ TESTS_SMOKE=(
   "dissertation_pop_demo      examples/dissertation_pop_pbpk_pd_demo.sio"
 )
 
+# Clinical-validation modules: registered NOW (run every build for compile+run
+# health) but PENDING-aware — they only ENFORCE validation once observed data
+# lands. While obs_n()==0 each emits *_CLINICAL_PENDING_OBSERVED and is reported
+# as PENDING (counts as neither pass nor fail; gate stays green). When the
+# literature-MCP session fills the observed arrays + study design, the same
+# module emits *_CLINICAL_PASS (counts as pass) or *_CLINICAL_FAIL_HONEST (fails
+# the gate — green means validated against clinical data). Registration thus
+# self-activates with zero further edits here.
+TESTS_PENDING=(
+  "pbpk28_rapamycin_clinical    stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio"
+  "pbpk28_semaglutide_clinical  stdlib/darwin_pbpk/validation/pbpk28_semaglutide_clinical.sio"
+)
+
 fails=0
+pending=0
 results=()
 
 for entry in "${TESTS[@]}"; do
@@ -217,7 +231,58 @@ for entry in "${TESTS_SMOKE[@]}"; do
   results+=("PASS  $name (smoke)")
 done
 
-total=$((${#TESTS[@]} + ${#TESTS_SMOKE[@]}))
+# Clinical-validation modules: PENDING-aware enforcement (see TESTS_PENDING).
+for entry in "${TESTS_PENDING[@]}"; do
+  name="${entry%% *}"
+  src="${entry##* }"
+  log="$STAGE_DIR/$name.log"
+
+  echo ""
+  echo "[$name] (clinical validation, pending-aware)"
+  echo "  src=$src"
+
+  if [[ ! -f "$src" ]]; then
+    echo "  FAIL: source missing"
+    fails=$((fails + 1))
+    results+=("FAIL  $name  source_missing")
+    continue
+  fi
+
+  set +e
+  timeout "$TIMEOUT_SECONDS" "$SOUC_BIN" run "$src" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  if [[ $rc -ne 0 ]]; then
+    echo "  FAIL: rc=$rc (timeout=$TIMEOUT_SECONDS)"
+    tail -5 "$log" | sed 's/^/    /'
+    fails=$((fails + 1))
+    results+=("FAIL  $name  rc=$rc")
+    continue
+  fi
+
+  if grep -qE "_CLINICAL_PASS$" "$log"; then
+    echo "  PASS (predicted-vs-observed validation passed, log=$log)"
+    results+=("PASS  $name (clinical validation)")
+  elif grep -qE "_CLINICAL_FAIL_HONEST$" "$log"; then
+    echo "  FAIL: clinical validation failed honestly — predicted-vs-observed"
+    echo "        GMFE outside FDA/EMA acceptance (model != clinical data)."
+    tail -8 "$log" | sed 's/^/    /'
+    fails=$((fails + 1))
+    results+=("FAIL  $name  clinical_fail_honest")
+  elif grep -qE "_CLINICAL_PENDING_OBSERVED$" "$log"; then
+    echo "  PENDING: registered, awaiting observed data (obs_n()==0) — not yet validating"
+    pending=$((pending + 1))
+    results+=("PEND  $name  awaiting_observed_data")
+  else
+    echo "  FAIL: no recognized clinical-validation marker (PASS / FAIL_HONEST / PENDING_OBSERVED)"
+    tail -5 "$log" | sed 's/^/    /'
+    fails=$((fails + 1))
+    results+=("FAIL  $name  no_marker")
+  fi
+done
+
+total=$((${#TESTS[@]} + ${#TESTS_SMOKE[@]} + ${#TESTS_PENDING[@]}))
 
 echo ""
 echo "=== Summary ==="
@@ -232,4 +297,8 @@ if [[ $fails -ne 0 ]]; then
 fi
 
 echo ""
-echo "dissertation_pbpk_suite_gate: PASS ($total/$total rapamycin PBPK tests + smoke demos)"
+if [[ $pending -ne 0 ]]; then
+  echo "dissertation_pbpk_suite_gate: PASS ($((total - pending))/$total active; $pending clinical-validation module(s) PENDING — registered, awaiting observed data)"
+else
+  echo "dissertation_pbpk_suite_gate: PASS ($total/$total PBPK tests + smoke demos)"
+fi


### PR DESCRIPTION
## What

Registers the two PBPK28 clinical-validation modules (merged in #182) into `dissertation_pbpk_suite_gate.sh` — but **without** masking their unvalidated state.

A new **PENDING-aware** tier (`TESTS_PENDING`) runs both modules every build and classifies by the outcome marker:

| Module output | Gate result |
|---|---|
| `*_CLINICAL_PENDING_OBSERVED` (obs_n()==0) | **PENDING** — neither pass nor fail; gate stays green; module is visible, not dark |
| `*_CLINICAL_PASS` | pass |
| `*_CLINICAL_FAIL_HONEST` | **gate FAILS** (red = validated against clinical data) |
| no marker / rc≠0 | fail |

## Why this shape

Registration **self-activates**: the moment a literature-MCP session fills `obs_n()`/`obs_t`/`obs_c` + study design in either module, it stops emitting `PENDING_OBSERVED` and emits `PASS` or `FAIL_HONEST` — and the gate enforces it with **zero further edits here**. This satisfies "register once observed data lands" mechanically rather than relying on a future manual step.

Per maintainer decision, `FAIL_HONEST` **hard-fails** the gate: green means "validated against clinical data." Note this means once rapamycin data lands, the gate will go red until gap #2 (capped Kp → 3.1h half-life vs sirolimus ~62h) is reconciled — which is the correct, honest signal, not a regression to paper over.

## Verification

- Gate stays green today: `PASS (50/52 active; 2 clinical-validation module(s) PENDING — registered, awaiting observed data)`
- All four markers route correctly (PASS→pass, FAIL_HONEST→red, PENDING_OBSERVED→green, missing→fail)
- `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)