### PR TITLE
ci(graphics): raise stack limit so graphics_smoke gate stops segfaulting

### DIFF
--- a/scripts/ci/graphics_scaffold_gate.sh
+++ b/scripts/ci/graphics_scaffold_gate.sh
@@ -9,6 +9,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SOUC="${ROOT_DIR}/bin/souc"
 
+# Graphics value-types are large and passed by value on the stack: a Surface is
+# ~2 MB (four [i64; 65536] channel arrays) and a TiledSurface embeds 9 of them
+# (~18 MB), exceeding the default ~8-12 MB stack and SIGSEGVing at runtime (the
+# binaries are logically correct — they pass with a larger stack). Raise the
+# stack soft limit before running them. Guarded so the gate still runs where the
+# limit cannot be changed. FOLLOW-UP: shrink Surface channel storage so graphics
+# value-types fit the default stack (tracking issue #187).
+ulimit -S -s unlimited 2>/dev/null || ulimit -S -s 262144 2>/dev/null || true
+
 echo "=== Graphics Scaffold Gate ==="
 
 # 1. Check all module files compile


### PR DESCRIPTION
## What
`scripts/ci/graphics_scaffold_gate.sh` ran the compiled `graphics_smoke` at the default ~12 MB stack and **SIGSEGV'd** (rc=139) on `origin/main`. This raises the stack soft limit (guarded) before running the graphics binaries.

## Root cause
Graphics value-types are passed **by value on the stack**:
- `Surface` = four `[i64; 65536]` channel arrays ≈ **2 MB**
- `TiledSurface` embeds **9 Surfaces** ≈ **18 MB**

`test_tiled_surface` passes/returns the ~18 MB struct by value → stack overflow. The binary is **logically correct** — it runs clean to `PASS graphics_smoke` under `ulimit -s unlimited` (verified).

## This PR
One-line guarded `ulimit -S -s` raise. Band-aid; does not change graphics code.

## Follow-up
**#187** — shrink `Surface` channel storage (pack RGBA into one array) so graphics value-types fit the default stack and the band-aid can be removed. The graphics companion gate (PR #185) needs the same `ulimit` line for its tiled smokes.

## Verification
`bash scripts/ci/graphics_scaffold_gate.sh` → rc=0, `=== Graphics Scaffold Gate: PASS ===`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)