### PR TITLE
Lane C: fix nested-generic '>>' close (unblocks Seq<Knowledge<f64>>)

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -5061,6 +5061,12 @@ fn scan_type(p0: i64) with IO, Mut, Panic, Div {
             if knowledge_hash_invalid(inner_hash) { invalid_eps = 1 }
             if TK[p as usize] == close_tk {
                 p = p + 1
+            } else if close_tk == 24 && TK[p as usize] == 39 {
+                // '>>' closes this inner generic (e.g. Seq<Knowledge<f64>>); split the
+                // token and leave a single '>' (24) for the enclosing type parser.
+                TK[p as usize] = 24
+                TS[p as usize] = TS[p as usize] + 1
+                p = p + 1
             } else {
                 invalid_eps = 1
                 p = skip_type_meta_item(p, close_tk)

--- a/tests/run-pass/seq_knowledge_nested_generic.sio
+++ b/tests/run-pass/seq_knowledge_nested_generic.sio
@@ -1,0 +1,30 @@
+//@ run-pass
+//@ description: Seq<Knowledge<f64>> — nested-generic '>>' close now parses (Lane C prereq)
+//
+// Regression for the nested-generic close bug: `Seq<Knowledge<f64>>` ends in `>>`, which the
+// lexer tokenizes as one right-shift token. The inner Knowledge type-parse now splits it
+// (leaving a single `>` for the enclosing Seq), so a Seq of epistemic values works with the
+// natural `>>` syntax — no space needed. Also covers Seq<Seq<i64>> nesting.
+
+fn main() with IO, Alloc, Mut, Epistemic {
+    var s: Seq<Knowledge<f64>> = seq_new()
+    s.push(measure(10.0, uncertainty: 2.0))
+    s.push(measure(12.0, uncertainty: 1.0))
+    s.push(measure(20.0, uncertainty: 0.5))
+    var i: i64 = 0
+    var sum: f64 = 0.0
+    while i < s.count() {
+        let v: f64 = acknowledge(s[i], "batch read")
+        sum = sum + v
+        i = i + 1
+    }
+    var ok: i64 = 1
+    if s.count() != 3 { ok = 0 }
+    if sum < 41.9999 { ok = 0 }
+    if sum > 42.0001 { ok = 0 }
+
+    var nested: Seq<Seq<i64>> = seq_new()
+    if nested.count() != 0 { ok = 0 }
+
+    if ok == 1 { print("seq_knowledge_nested_generic: PASS\n") } else { print("seq_knowledge_nested_generic: FAIL\n") }
+}


### PR DESCRIPTION
## Summary
Fixes a nested-generic parse bug: `Seq<Knowledge<f64>>` ends in `>>`, which the lexer tokenizes as a single right-shift token (39). `Seq<T>`'s type-parse already split it, but the inner `Knowledge<T>` parse did not — so the type was marked invalid and the **rest of the function body was swallowed** (the program exited early after the declaration).

Fix mirrors Seq's split in the Knowledge close block: on `close_tk == '>'` and a `>>` token, consume one `>` and leave a single `>` (24) for the enclosing type parser.

## Effect
- `Seq<Knowledge<f64>>` works with natural `>>` syntax (was: required a space `> >`).
- **Nested generics work generally** (`Seq<Seq<i64>>`).
- This is the **Lane C prerequisite** (batched epistemic ops over the K-axis); `kaxi_fuse` reduction is the unblocked follow-on.

## Verification
- Fixed point holds (stage1==stage2==stage3, md5 `24c85901`).
- Umbrella: **12/12 sub-gates rc=0**.
- `tests/run-pass/seq_knowledge_nested_generic.sio`: count=3, sum=42 → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)