### PR TITLE
feat(website): GSAP-aligned animation token layer + D3 empirical doc revision

### DIFF
--- a/docs/implementation/D3_RESIDUAL_TYPECHECK_SPRINT.md
+++ b/docs/implementation/D3_RESIDUAL_TYPECHECK_SPRINT.md
@@ -14,11 +14,25 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.implementation
 
 # D3 Residual Typecheck Sprint
 
+> **Revision 2026-05-28 (post-D3-A-v2 empirical run)**: the original D3-A
+> strategy in this doc (file-wide `pub fn` sweep) was empirically falsified.
+> Two pub-sweeps (`ir/lower.sio`, `check/check.sio`) produced **zero**
+> cascade delta. Only 1 of 439 E200s is preceded by a non-pub warning — `pub
+> fn` is advisory only (see `feedback_sounio_visibility_model`). The real
+> lever is **missing-imports + empty-stub population + missing-symbol
+> definitions**. D3-A section below has been rewritten accordingly.
+>
+> **Phase D as it actually landed on main**: struct-of-arrays attempt
+> (`OcpConstFoldState`) was REVERTED in `1e29c2545` — Sounio cannot index
+> array fields of structs (`state.field[idx]` → "value is not indexable").
+> Only the cap-raise survived (Codex's `7d3166367`). Bootstrap fp on main
+> is `541bc868140beac2d54da976ba8ea976` (gen3 == gen4), not the earlier
+> `baa0c060…` from the pre-revert attempt.
+
 ## Goal
 
-Drive `./bin/souc compile self-hosted/main.sio` to **0 real errors** on the
-`modular/typecheck-drift-clean` branch, after Phase D (`OcpConstFoldState`
-refactor + `local_cap` 1024 → 2048) clears the E007 structural blocker.
+Drive the modular compiler entrypoint to **0 real errors** with the cap-raise
+binary (`local_cap()` = 2048) Phase D landed on main.
 
 This sprint is the closure of task ledger item #20 ("D3 residual typecheck"),
 deleted as future-session scope at the end of the 2026-05-28 modular session.
@@ -27,68 +41,175 @@ capacity.
 
 ## Predecessors
 
-- **Phase A** (`modular/pub-pass`, `7773167`): A1-A4 surface-pubs across hlir/,
-  gpu/mod.sio.
-- **Phase B** (`modular/body-bugs`, `ac93615`): B1-B5 parser body fixes +
-  `resolve_path` rename.
-- **Phase A-ext** (`1bff958`): A-extended pub sweep — 113 hard errors cleared
-  on `parser/items.sio`.
-- **Phase B-ext** (`8bf6d8f`): `check.sio` body bugs — 21 → 3 phantom (zero
-  real).
-- **Phase D** (`8e1cb0c`, `ef715d2`, `1c44156`): `OcpConstFoldState` struct,
-  64-tracker bundling, `local_cap()` raised to 2048. Bootstrap fixed-point
-  re-blessed at md5 `baa0c060b7ad3f007f8a0d0176d27b7e` (gen2 == gen3).
+- **Phase A** (`777316727`): A1-A4 surface-pubs across hlir/, gpu/mod.sio.
+  Now understood as cosmetic — see Empirical Revision note above.
+- **Phase B** (`ac936159a`): B1-B5 parser body fixes + `resolve_path` rename.
+  The real win was the `use parser::{types,exprs,stmts,patterns}::*` imports
+  B2 added — NOT the pub markers.
+- **Phase A-ext** (`1bff9588f`): A-extended pub sweep on check/ structs +
+  ir/ir.sio Ir* structs. The struct pubs DID matter (hard error class) —
+  function pubs in same commit were cosmetic.
+- **Phase B-ext** (`8bf6d8f96`): `check.sio` body bugs — 21 → 3 phantom via
+  missing-import sweep (compat.sio, epistemic.sio, effects.sio). Pattern
+  confirmed: imports close cascades, pub markers do not.
+- **Phase D struct revert** (`1e29c2545`): removed OcpConstFoldState attempt;
+  Sounio struct-array-field-indexing limitation documented.
+- **Phase D cap-raise** (`7d3166367`, Codex Review): `local_cap()` 1024 → 2048
+  + 138 `[T; 1024]` tables grown to `[T; 2048]`; ~700KB BSS growth.
+  Bootstrap fp `541bc868140beac2d54da976ba8ea976` (gen3 == gen4).
 
-Reference commits showing the fix shape D3 will apply at scale:
-`8b8648b2` (items.sio 113 → 12), `5bba0375` (check 35 → 0), `f5b6b655`
-(import/visibility drift across 5 phase modules).
+Reference commits showing the **real** fix shape: `8b8648b2` (items.sio
+113 → 12 via `use` + annotation, NOT pub), `5bba0375` (check phase imports +
+type annotations).
 
 ## Baseline
 
-After phase-d merges into `modular/typecheck-drift-clean`, `souc compile
-self-hosted/main.sio` is expected to report **827 real errors**:
+After Phase D landed on main, the modular entrypoint reports **898 real
+errors** (verified 2026-05-28 against main `03d7c842b`):
 
-- **388 explicit errors** — typecheck failures on identifiers, paths, match
+- **459 explicit errors** — typecheck failures on identifiers, paths, match
   arms, fields.
-- **439 E200 errors** — body-level resolution drift in expression positions
-  (same class as the 21 → 3 phantom cluster B-ext closed on `check.sio` and
-  the 113 cluster A-ext closed on `items.sio`).
+- **439 E200 errors** — body-level resolution drift in expression positions.
 
-Capture the baseline as the first action:
+Top error classes:
+
+| Class | Count |
+|---|---:|
+| `E200 unknown identifier` | 439 |
+| `error: unknown field access` | 162 |
+| `error: value is not indexable` | 99 |
+| `error: assignment type mismatch` | 84 |
+| `error: if condition must be bool` | 34 |
+| `error: arithmetic operands must have matching numeric types` | 19 |
+| `error: logical and requires bool operands` | 18 |
+| `error: comparison operands must have the same type` | 16 |
+
+Top files by standalone error count (verified 2026-05-28):
+
+| File | Errors |
+|---|---:|
+| `self-hosted/gpu/hlir_to_gpu.sio` | 359 |
+| `self-hosted/ir/dce.sio` | 263 |
+| `self-hosted/ir/const_prop.sio` | 162 |
+| `self-hosted/wasm/lower.sio` | 158 |
+| `self-hosted/ir/opt_cleanup.sio` | 100 |
+| `self-hosted/wasm/encode.sio` | 85 |
+| `self-hosted/check/check.sio` | 21 |
+| `self-hosted/native/codegen_x86_linux.sio` | 13 |
+| `self-hosted/native/lower_ir.sio` | 9 |
+| `self-hosted/ir/lower.sio` | 8 |
+
+### Binary invocation gotcha
+
+The `./bin/souc` shell wrapper on main does NOT dispatch `compile`/`check`
+subcommands correctly to the underlying `mini_native` binary, which accepts
+only `<src> <out>` 2-arg form. Capture the baseline by invoking the binary
+directly:
 
 ```bash
-./bin/souc compile self-hosted/main.sio 2>&1 | tee /tmp/d3_baseline.log
-grep -E '^error\[E[0-9]+\]' /tmp/d3_baseline.log | sort | uniq -c | sort -rn \
-  > /tmp/d3_buckets.txt
+./bin/souc-linux-x86_64 self-hosted/compiler/main.sio /tmp/d3_compile_out \
+  > /tmp/d3_baseline.log 2>&1
+grep -cE '^(error:|E[0-9]+)' /tmp/d3_baseline.log    # → 898
+grep -E '^(error:|E[0-9]+)' /tmp/d3_baseline.log | \
+  sed -E 's/at line [0-9]+//; s/`[^`]+`/X/g' | \
+  sort | uniq -c | sort -rn > /tmp/d3_buckets.txt
 ```
+
+Per-file checks via the wrapper still work: `./bin/souc check <file>`.
 
 ## Plan
 
 Three sub-phases, mirroring the established A → B → B-ext rhythm. Each
 sub-phase is one session, max.
 
-### D3-A — Surface-pub + `use` sweep on `main.sio` and direct dependencies
+### D3-A — Missing imports + missing-symbol fixes (REVISED)
 
-Apply the Phase A pattern: `use parser::types::*`, `use parser::exprs::*`,
-`use parser::stmts::*`-style imports and `pub` on any helper referenced
-cross-module. Iterate by bucket: expect a few files to dominate (in A-ext,
-`items.sio` alone held 113 of ~250 cleared).
+The pub-sweep strategy in this section's earlier version was empirically
+falsified by the D3-A v2 trial run (2026-05-28). Two whole-file pub passes
+(`ir/lower.sio`, `check/check.sio`) produced zero cascade delta because
+`pub fn` is advisory-only. The real leverage points discovered by that
+trial are five concrete missing-symbol/missing-import causes:
 
-Gate after each file:
+**1. Missing `use ir::ir::*` in `dce.sio` and `const_prop.sio`** (highest
+ROI). Both files use `IrOpcode::*` enum variants and `IrFunction`/`IrInstr`
+struct fields with no import. Adding the import closes ~290 standalone
+errors and the downstream main.sio cascade.
 
-```bash
-./bin/souc check <file>                           # local clean
-./bin/souc compile self-hosted/main.sio 2>&1 \
-  | grep -c '^error\['                            # monotone reduction
+```sounio
+// At top of self-hosted/ir/dce.sio and self-hosted/ir/const_prop.sio
+use ir::ir::*
 ```
 
-Stop the sub-phase when the error count plateaus on `use`/`pub` edits alone —
-the tail is body-level (D3-B).
+**2. Empty stub `self-hosted/wasm/core.sio`** containing only `module
+wasm::core`. Importers `wasm/encode.sio` (85 errors) and `wasm/lower.sio`
+(158 errors) do `use wasm::core::*` which resolves to an empty namespace,
+causing `WASM_TYPE_*`, `WasmLocal` etc. to E200. Fix: populate the stub
+with the symbols those importers actually need. Audit referenced names
+with `grep -rE '\bWasmLocal|WASM_TYPE_' self-hosted/wasm/{encode,lower}.sio`.
+
+**3. Missing constant `ESPV_OP_BITWISE_OR`** in
+`self-hosted/gpu/epistemic_spirv.sio` (only `ESPV_OP_BITWISE_XOR` exists at
+line 88). 5 sites in the file reference the missing constant. Add:
+
+```sounio
+let ESPV_OP_BITWISE_OR: i64 = 198    // adjacent to BITWISE_XOR=197
+```
+
+Note: per `feedback_module_let_constant_import_bug.md`, module-level `let`
+constants don't export cleanly across modules. The 5 use sites here are
+intra-file, so this works. Cross-module `let`-constant references that
+remain in main.sio after D3-A are scope for D3-B.
+
+**4. Missing builtin `f64_to_bits`** referenced in `native/lower_ir.sio`,
+`native/machine_ir.sio`, `compiler/main.sio`, `wasm/lower.sio`. Defined
+nowhere. Add a definition in a stdlib or native utility file and export it.
+Sounio has no `f64.to_bits()` method intrinsic; this is a real missing
+symbol. Each call site generates one E200 — count the call sites with
+`grep -rn 'f64_to_bits' self-hosted/` and add to the closure count.
+
+**5. Tuple-element bool-binding pattern** triggers
+"if condition must be bool" in 43+ sites across `check/check.sio` (18×),
+`ir/tailcall.sio` (4×), `ir/opt_cleanup.sio` (21×):
+
+```sounio
+// Before — fires error even though pair.0 is declared bool
+let is_valid = pair.0
+if is_valid { … }
+
+// After — inline avoids the souc binding-loses-bool issue
+if pair.0 { … }
+```
+
+This is a souc bug (the binding should preserve its type) but the inline
+workaround is mechanical and closes 43+ errors.
+
+### D3-A execution order
+
+Tackle by ROI:
+
+1. (1) `dce.sio` + `const_prop.sio` use lines — closes ~290 standalone errors
+2. (2) `wasm/core.sio` stub population — closes ~240 wasm standalone errors
+3. (5) tuple-bool inline pass — closes ~43 errors
+4. (3) `ESPV_OP_BITWISE_OR` constant — closes 5 errors
+5. (4) `f64_to_bits` builtin — closes 5-10 errors
+
+Gate after each fix:
+
+```bash
+./bin/souc check <file>                           # local clean (no regression)
+./bin/souc-linux-x86_64 self-hosted/compiler/main.sio /tmp/m > /tmp/d3.log 2>&1
+grep -cE '^(error:|E[0-9]+)' /tmp/d3.log          # → monotone reduction
+```
+
+Target: 898 → ≤ 350. Stop when remaining errors are isolated body bugs
+(D3-B scope) rather than cascade roots.
 
 **Watch out**: `feedback_module_let_constant_import_bug.md` documents a
 35-second stack overflow on explicit `use module::{CONST}` for module-level
-`let` constants. Use the three documented workarounds; do not trigger the bug
-path.
+`let` constants. For fix (3), keep the constant intra-file. For
+cross-module constant references, defer to D3-B (workarounds: inline-define
+in callers, or replace `let X: i64 = N` with `pub fn X() -> i64 { N }` +
+update call sites).
 
 ### D3-B — Body-bug class fixes (parser-style annotations)
 
@@ -152,20 +273,23 @@ from real before editing.
 
 | Path | Lines | Role |
 |---|---:|---|
-| `self-hosted/main.sio` | 2,464 | D3 primary target; owns the 827 residual errors. |
-| `self-hosted/ir/opt_cleanup.sio` | 7,525 | Phase D refactor surface; do not regress. |
-| `self-hosted/compiler/lean_single.sio` | — | `local_cap()` at line 891; do not edit in D3. |
-| `self-hosted/check/check.sio` | 16,061 | Cleared to 3 phantom / 0 real by B-ext; gate via `souc check`. |
-| `self-hosted/parser/items.sio` | 4,308 | Reference shape for D3-B body fixes. |
+| `self-hosted/compiler/main.sio` | 2,464 | D3 primary cascade target; owns the 898 residual errors via imports. |
+| `self-hosted/ir/dce.sio` | — | D3-A fix #1: add `use ir::ir::*`; ~263 standalone errors. |
+| `self-hosted/ir/const_prop.sio` | — | D3-A fix #1: add `use ir::ir::*`; ~162 standalone errors. |
+| `self-hosted/wasm/core.sio` | — | D3-A fix #2: populate empty stub; unblocks wasm/encode + wasm/lower. |
+| `self-hosted/gpu/epistemic_spirv.sio` | — | D3-A fix #3: add `ESPV_OP_BITWISE_OR`. |
+| `self-hosted/gpu/hlir_to_gpu.sio` | — | 359 standalone errors; investigate in D3-B (mix of body bugs + missing symbols). |
+| `self-hosted/ir/opt_cleanup.sio` | — | Phase D revert surface; do not regress. 100 standalone errors (21 tuple-bool sites for D3-A fix #5). |
+| `self-hosted/compiler/lean_single.sio` | — | `local_cap()` = 2048; do not edit in D3. |
 | `tests/modular/probe_*.sio` | 7 files | Liveness probes — keep all green. |
 
 ## End-to-end verification
 
 ```bash
-make clean && make build                                 # gen2 == gen3 == baa0c060…
-./bin/souc compile self-hosted/main.sio                  # 0 errors
+make clean && make build                                 # gen3 == gen4 == 541bc868…
+./bin/souc-linux-x86_64 self-hosted/compiler/main.sio /tmp/m  # 0 errors
 bash scripts/ci/modular_main_typecheck_gate.sh           # MODULAR_MAIN_TYPECHECK_PASS
-./bin/souc check self-hosted/check/check.sio             # 0 errors (no regression)
+./bin/souc check self-hosted/check/check.sio             # ≤ 3 phantom (no real regression)
 ./bin/souc check self-hosted/parser/items.sio            # ≤ 12 (unchanged)
 ```
 

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -340,44 +340,52 @@ a:focus-visible {
 }
 
 /* ============================================
-   SCROLL ANIMATIONS
+   ANIMATION TOKENS
    ============================================ */
-.scroll-reveal {
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+
+/* Timing curves — kept in sync with GSAP ease names used across scripts */
+:root {
+  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);   /* power2.out */
+  --ease-in-out: cubic-bezier(0.45, 0, 0.55, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Duration scale — mirrors GSAP durations in components */
+  --dur-fast:   0.35s;
+  --dur-base:   0.55s;
+  --dur-slow:   0.75s;
+  --dur-crawl:  1.0s;
+
+  /* Stagger step — used as base unit in GSAP stagger calls */
+  --stagger:    0.08s;
 }
 
-.scroll-reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
+/* ============================================
+   GSAP HELPERS
+   ============================================ */
+
+/* GPU-compositing hint for elements GSAP will animate */
+.gsap-target {
+  will-change: transform, opacity;
 }
 
-@supports (animation-timeline: scroll()) {
-  .scroll-reveal-native {
-    animation: scrollFadeIn linear both;
+/* Remove will-change after GSAP is done (set via clearProps or JS) */
+.gsap-done {
+  will-change: auto;
+}
+
+/* No-JS progressive enhancement — reveal-up fires via CSS when GSAP
+   never loads. GSAP overrides opacity/transform immediately on load,
+   so these keyframes only run in the no-JS path. */
+@keyframes reveal-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0);    }
+}
+
+@supports (animation-timeline: view()) {
+  .animate-on-scroll {
+    animation: reveal-up var(--dur-base) var(--ease-out) both;
     animation-timeline: view();
-    animation-range: entry 0% entry 40%;
-  }
-
-  @keyframes scrollFadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(30px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-}
-
-@keyframes filmFade {
-  0%, 46% {
-    opacity: 1;
-  }
-  54%, 100% {
-    opacity: 0;
+    animation-range: entry 0% entry 35%;
   }
 }
 
@@ -392,10 +400,6 @@ a:focus-visible {
     scroll-behavior: auto !important;
   }
 
-  .scroll-reveal {
-    opacity: 1;
-    transform: none;
-  }
 }
 
 /* ============================================
@@ -425,10 +429,6 @@ a:focus-visible {
   padding: clamp(3.5rem, 7vw, 6rem) 0;
 }
 
-.section-deferred {
-  content-visibility: auto;
-  contain-intrinsic-size: 1px 960px;
-}
 
 .premium-grid {
   display: grid;


### PR DESCRIPTION
## Summary

Two independent changes on this branch:

### 1. `website/src/styles/global.css` — animation system cleanup

Replaced the defunct `SCROLL ANIMATIONS` section (`.scroll-reveal` CSS class, orphaned `filmFade` @keyframes, dead `.section-deferred` rule) with a GSAP-aligned token layer:

- CSS custom properties: `--ease-out`, `--ease-spring`, `--dur-fast/base/slow/crawl`, `--stagger`
- `.gsap-target` / `.gsap-done` GPU compositing helpers (`will-change`)
- `@keyframes reveal-up` — shared enter keyframe
- `.animate-on-scroll` — `animation-timeline: view()` progressive no-JS fallback

This completes the GSAP scroll-reveal pass (pages → [lang] routes → components → React/TSX → layouts → global CSS) that shipped across the prior session.

### 2. `docs/implementation/D3_RESIDUAL_TYPECHECK_SPRINT.md` — empirical revision

After the D3-A v2 trial falsified the pub-sweep premise (two whole-file pub passes → zero cascade delta on `main.sio` because `pub fn` is advisory-only), the sprint doc was revised to reflect the five real fixes ordered by ROI:

| # | Fix | Est. closure |
|---|---|---:|
| 1 | `use ir::ir::*` in `dce.sio` + `const_prop.sio` | ~290 |
| 2 | Populate empty `wasm/core.sio` stub | ~240 |
| 3 | Add `ESPV_OP_BITWISE_OR` constant | 5 sites |
| 4 | Define `f64_to_bits` builtin | 5–10 sites |
| 5 | Tuple-bool-binding inline pass | 43+ sites |

## Test plan

- [x] `npm run build` clean (411 pages, Website CI passes)
- [x] No `.scroll-reveal`, `.section-deferred`, or global `filmFade` references remain
- [ ] D3-A executor applies compiler fixes (1)–(5) with monotone error decrease

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)