### PR TITLE
check: effect-polymorphic closures + parser effect-list fix (sound +14)

### DIFF
--- a/.claude/AGENT_HANDOFF.md
+++ b/.claude/AGENT_HANDOFF.md
@@ -246,3 +246,29 @@ RESOLUTION:
   (checked out by a live agent; git would refuse, and removal would disrupt
   that agent). It will retire naturally when that agent advances; until then it
   carries no unique commits.
+
+---
+
+## Active agent lanes (2026-06-04) — modular-checker / parser lane claim
+
+Three concurrent lanes; this entry claims the **modular-checker / parser** lane to
+avoid file + build-lock collisions.
+
+- **This lane (modular checker → parser):** closure/HOF unlock LANDED, **PR #235**
+  (`check/closure-hof-triple-e008`, sound +7, modular checker only). **Next lever:
+  async `spawn`/`await` parser cluster** (11 tests: async_basic/channels/join/sleep/
+  spawn/...) — INVESTIGATED, DEFERRED: async is a parser+checker FEATURE (needs
+  check.sio semantics for spawn/await builtins = i128 territory; parser-only = +0,
+  the const/kernel/extern double-block trap). **Pivoted to PARSE-TO-PASS items**:
+  parser productions that flip FAIL→PASS with parser-only changes (tuple-let
+  `let (a,b)=`, struct/while-for patterns, turbofish, match patterns) — checker
+  already handles the resulting AST. `self-hosted/parser/*` only, zero check.sio
+  overlap with i128.
+- **i128 / arbitrary-width-int lane** (`feat/i128-modular`): owns `check/types.sio`,
+  `check/compat.sio`, `check/check.sio` (int-width additions) + native codegen
+  (`native/codegen_x86_linux.sio`, `native/encode.sio`, `ir/ir.sio`). I avoid these.
+- **SRET / source→ELF lane** (`sret-fix-probe`): owns `self-hosted/ir/*` (lower.sio,
+  IR lowering, for-loops). I avoid these.
+
+Build discipline: all heavy `souc main.sio` builds via `scripts/dev/souc-build-lock.sh`
+(never two at once). Census gotcha: `chmod +x` the mc ELF before running.

--- a/.claude/AGENT_HANDOFF.md
+++ b/.claude/AGENT_HANDOFF.md
@@ -257,13 +257,16 @@ avoid file + build-lock collisions.
 - **This lane (modular checker → parser):** closure/HOF unlock LANDED, **PR #235**
   (`check/closure-hof-triple-e008`, sound +7, modular checker only). **Next lever:
   async `spawn`/`await` parser cluster** (11 tests: async_basic/channels/join/sleep/
-  spawn/...) — INVESTIGATED, DEFERRED: async is a parser+checker FEATURE (needs
-  check.sio semantics for spawn/await builtins = i128 territory; parser-only = +0,
-  the const/kernel/extern double-block trap). **Pivoted to PARSE-TO-PASS items**:
-  parser productions that flip FAIL→PASS with parser-only changes (tuple-let
-  `let (a,b)=`, struct/while-for patterns, turbofish, match patterns) — checker
-  already handles the resulting AST. `self-hosted/parser/*` only, zero check.sio
-  overlap with i128.
+  spawn/...) — DEFERRED (parser+checker FEATURE, needs check.sio spawn/await
+  semantics = i128 territory). **LEVER 2 DONE + PUSHED** (`parser/fn-type-effects-list-e008`):
+  parser effect-list fix + closure-LITERAL SRET dodge + EFFECT-POLYMORPHIC HOF model →
+  SOUND +14 (269→283, 0 regr). ⚠️ **COORDINATION: this branch SUPERSEDES PR #235's
+  effect-SUBSUMPTION model** (fn_sigs_effects_subset) with effect-polymorphism
+  (closure-arg effects propagate to the call site). It edits check.sio (closure
+  checker, call-arg path, a new Checker field `closure_inference_depth` declared LAST).
+  If i128 is mid-edit on check.sio, expect a merge touch-point in the closure/call-arg
+  regions (different from i128's int-width sites). PR #235's subsumption helpers are now
+  dead — fold/revise when landing.
 - **i128 / arbitrary-width-int lane** (`feat/i128-modular`): owns `check/types.sio`,
   `check/compat.sio`, `check/check.sio` (int-width additions) + native codegen
   (`native/codegen_x86_linux.sio`, `native/encode.sio`, `ir/ir.sio`). I avoid these.

--- a/docs/audit/g1_wip/CLOSURE_EFFECT_POLY_HOF_MODULAR_2026-06-04.md
+++ b/docs/audit/g1_wip/CLOSURE_EFFECT_POLY_HOF_MODULAR_2026-06-04.md
@@ -1,0 +1,66 @@
+# Effect-polymorphic closures + inplace effect inference (modular *mut checker)
+
+**Date:** 2026-06-04
+**Branch:** `parser/fn-type-effects-list-e008` (off `check/closure-hof-triple-e008`)
+**Scope:** `self-hosted/parser/types.sio`, `self-hosted/check/check.sio` only — `lean_single.sio`
+untouched, canonical gate unaffected. **Supersedes PR #235's effect-subsumption model.**
+
+## Result (vs same-session closure-tip baseline 269 PASS / 72 CRASH)
+
+**PASS 269 → 283 (+14), CRASH 72 → 65; zero PASS→FAIL, zero FAIL→CRASH, zero negative-suite regressions.**
+
+Three sub-fixes, each verified by full per-file census (the layout-robust signal; raw PASS-count is
+not stable across `bin/souc` build instances — see the campaign note):
+
+### 1. Parser — effect-list no longer swallows the next parameter (+5)
+`parse_effect_list` (parser/types.sio) consumed a trailing `, name:` as another effect, so a
+`fn(T)->U with Eff,...` type used as a NON-last parameter failed to parse (the next param name was
+eaten). Fix: break the loop when the comma is followed by `ident :` (`parser_peek_ahead(p,2)==Colon`).
+Wins: `test_diffgeo`, `test_functional`, `test_multigrid`, `test_stochastic_calc` (scientific) +
+`closure_effect_checked`.
+
+### 2. Closure-literal SRET dodge (+6 CRASH→PASS)
+`checker_check_closure_expr_inplace` still called three BY-VALUE `Checker` helpers
+(`collect_closure_params → {checker}`, `bind_closure_params → Checker`, `lower_opt_closure_return →
+(Checker, TypeEntry)`), each returning the ~164 KB `Checker` by value (tuple-wrapped in the return
+case) — the SRET large-struct-return miscompile — so **any** closure literal `|x| …` SIGSEGV'd at
+check time. Added `*mut` transcriptions using the existing inplace primitives. Wins:
+`closure_arity_2`, `closure_basic`, `closure_escape`, `closure_linear`, `closure_returned`,
+`closure_effect_transparent_hof`.
+
+### 3. Effect-polymorphic HOF model (resolves a self-contradictory test suite)
+The corpus contained two incompatible intended semantics for a bare `fn(T)->U` HOF param:
+- `closure_effect_transparent_hof` (run-pass): "unannotated fn param is effect-polymorphic —
+  requires the effect at the call site" → IO closure from an IO caller PASSES.
+- `effects_closure_escape` (compile-fail): "pure HOF — f must be pure" → reject any effectful value.
+
+Operator decision: **effect-polymorphism**. Implementation:
+- **Closure-body effect inference:** a `closure_inference_depth` counter (new `Checker` field,
+  declared last to preserve layout) makes `checker_check_callee_effects_inplace` ACCUMULATE a
+  callee's effects into `current_effects` while checking a closure body (instead of enforcing), so
+  the closure's inferred effect set captures them. `print`/`println`/`print_int`/`print_char` (IO
+  builtins, not in `fn_sigs`) are recognized by name during inference.
+- **Polymorphic params:** removed effect comparison from `fn_sigs_structurally_compatible` (a bare
+  param accepts any-effect value by signature).
+- **Call-site propagation:** in `checker_check_call_args_inner_inplace`, a fn-typed argument's
+  effects are propagated via `checker_check_callee_effects_inplace` — enforced against the enclosing
+  function's declared effects at depth 0, accumulated into an outer closure at depth > 0.
+
+Outcome — all three reconciled: `closure_effect_escape` REJECTS (its caller `pure_fn` lacks IO),
+`closure_effect_transparent_hof` PASSES (caller `main` has IO), `effects_closure_escape` still
+rejects (its `fn(x){}` anonymous-fn syntax, unrelated to effects).
+
+## Soundness verification
+- Named effectful fn → HOF from a **pure** caller: **rejects**; from an **IO** caller: **passes**
+  (the common case, not just closures).
+- IO/GPU/Async closures from a pure caller: reject. The earlier `eff1`/GPU/Async "must reject"
+  probes were subsumption-model artifacts — under polymorphism they correctly PASS when the caller
+  declares the effect.
+- Negative suite (fn/closure compile-fail subset): 0 reject→accept regressions.
+
+## Known incompleteness (stated, not hidden)
+- The negative scan was **targeted** (fn/closure compile-fail), not the full 250 — the full loop
+  stalls on pre-existing 3 GB-bss SIGSEGV crashers even with `ulimit -c 0`.
+- IO-builtin recognition is a **hardcoded list** (`print`/`println`/`print_int`/`print_char`); a
+  closure using a different IO builtin from a pure caller would under-reject. This is an
+  incompleteness of the inference, not a complete effect system.

--- a/docs/audit/g1_wip/CLOSURE_HOF_STRUCTURAL_FN_COMPAT_MODULAR_2026-06-04.md
+++ b/docs/audit/g1_wip/CLOSURE_HOF_STRUCTURAL_FN_COMPAT_MODULAR_2026-06-04.md
@@ -1,5 +1,16 @@
 # Closure / HOF unlock — structural fn-type compatibility (modular *mut checker)
 
+> ⚠️ **SUPERSEDED (effect model only), 2026-06-04.** The "Effect subtyping" section below
+> describes an effect-SUBSUMPTION model (a value's effects must be ⊆ the param's), and presents
+> the `eff1`/GPU/Async *rejections* as verified-sound. That model was **wrong**: it only ever
+> "passed" because closure literals crashed before reaching the check. Branch
+> `parser/fn-type-effects-list-e008` replaced it with **effect-POLYMORPHISM** — bare `fn(T)->U`
+> params accept any-effect value by signature, and a fn/closure argument's effects propagate to
+> the HOF **call site** (the enclosing function must declare them). Under the correct model
+> `eff1`/GPU/Async PASS (their caller declares the effect); rejection happens only when the *caller*
+> lacks it (`closure_effect_escape`). The structural-compatibility mechanism (sig-id → structural)
+> in this doc remains correct; only the effect-comparison part is superseded.
+
 **Date:** 2026-06-04
 **Branch:** `check/closure-hof-triple-e008` (off `check/field-deref-ref-e008` @ `7c18aae54`)
 **Commits (atomic, stacked):**

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -2146,45 +2146,14 @@ fn checker_report_error_at_inplace(c: *mut Checker, span: Span, code: i64, msg_a
     print_error_note(code)
 }
 
-// Ambient (pervasive/total) effects do not gate fn-type subtyping: Mut, Alloc,
-// Panic and Div are either signalled at the type level (mutation via `&!` refs) or
-// are total-program effects, and the run-pass corpus uniformly passes functions
-// over-declaring them (e.g. `fn(f64)->f64 with Mut,Panic,Div`) to bare HOF params.
-// Observable effects (IO, GPU, Async, Prob, Observe, …) DO gate, so the "pure HOF"
-// rule (effects_closure_escape) still rejects an IO function where pure is required.
-fn is_ambient_effect(id: i64) -> bool {
-    id == 1 || id == 2 || id == 3 || id == 4   // Mut, Alloc, Panic, Div
-}
-
-// Effect subsumption: every OBSERVABLE effect performed by `got` must be permitted
-// by `allowed`. A function value may use fewer observable effects than the required
-// fn-type allows, but never more; ambient effects in `got` are ignored (see above).
-fn fn_sigs_effects_subset(got: FnSig, allowed: FnSig) -> bool with Mut, Panic, Div {
-    var i: i64 = 0
-    while i < got.effect_count {
-        let e = got.effects[i as usize]
-        if !is_ambient_effect(e) {
-            var found = false
-            var j: i64 = 0
-            while j < allowed.effect_count {
-                if allowed.effects[j as usize] == e { found = true }
-                j = j + 1
-            }
-            if !found { return false }
-        }
-        i = i + 1
-    }
-    true
-}
-
 // Structural function-type compatibility: `got` is usable where `expected` is
-// required if they share arity, pairwise-compatible parameter and return types,
-// the same linearity, and `got`'s effects are a subset of `expected`'s. Named
-// functions used as first-class values and `fn(T)->U` annotations register
-// SEPARATE FnSig entries (distinct sig_ids), so the sig_id-equality test in
-// types_compatible() spuriously rejects structurally identical function types;
-// this compares the stored signatures directly. Effects and linearity ARE checked
-// (directionally for effects) so the guard never relaxes an effect/linearity rule.
+// required if they share arity, pairwise-compatible parameter and return types, and
+// the same linearity. Named functions used as first-class values and `fn(T)->U`
+// annotations register SEPARATE FnSig entries (distinct sig_ids), so the
+// sig_id-equality test in types_compatible() spuriously rejects structurally
+// identical function types; this compares the stored signatures directly. Effects are
+// NOT compared here — bare fn-type params are effect-polymorphic; a value's effects
+// are propagated to the HOF call site instead (checker_check_call_args_inner_inplace).
 fn fn_sigs_structurally_compatible(expected: FnSig, got: FnSig) -> bool with Mut, Panic, Div, Alloc {
     if expected.param_count != got.param_count { return false }
     if expected.is_linear_closure != got.is_linear_closure { return false }
@@ -4253,8 +4222,8 @@ fn checker_check_callee_effects_inplace(c: *mut Checker, span: Span, callee_effe
     }
     // Inference mode: while checking a closure body, ACCUMULATE the callee's effects
     // into current_effects (deduped, capped at 8) so the closure's inferred effect set
-    // captures them. Enforcement (below) is skipped here — the closure is later checked
-    // for compatibility against the expected fn-type via fn_sigs_effects_subset.
+    // captures them. Enforcement (below) is skipped here — the closure's effects are
+    // later propagated to the HOF call site where its caller must declare them.
     if (*c).closure_inference_depth > 0 {
         var i: i64 = 0
         while i < callee_effect_count {

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3716,15 +3716,61 @@ fn checker_check_struct_lit_inplace(c: *mut Checker, e: Expr) -> TypeEntry with 
 // checked IN PLACE (checker_check_opt_expr_inplace); the shallow setup (param collect / return
 // lower / param bind) stays bridged-by-value (single copies, survivable). Faithful to the
 // by-value logic incl. Sprint-231 capture analysis + Epistemic auto-inject.
-fn checker_check_closure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
-    let params_result = (*c).collect_closure_params(e.closure_params)
-    checker_store_from_value(c, params_result.checker)
-    let params = params_result.params
-    let param_count = params_result.count
+// *mut transcriptions of the closure-param/return helpers. The by-value versions
+// (collect_closure_params -> CollectClosureParamsResult{checker}, bind_closure_params
+// -> Checker, lower_opt_closure_return -> (Checker, TypeEntry)) each RETURN the ~164KB
+// Checker by value (tuple-wrapped, in the return case) — the SRET large-struct-return
+// miscompile — so ANY closure literal `|x| ...` SIGSEGV'd at check time. These mutate
+// the Checker in place through the existing inplace primitives and return only the
+// small payload, dodging the copy.
+fn checker_collect_closure_param_list_inplace(c: *mut Checker, pl: ClosureParamList) -> (FnParamList, i64) with Mut, Panic, Div, Alloc, IO {
+    let head_ty = checker_lower_type_expr_mut(c, pl.head.ty)
+    let head_param = FnParamInfo { name: pl.head.name, ty: head_ty }
+    match pl.tail {
+        None => (FnParamList { head: head_param, tail: None }, 1)
+        Some(rest) => {
+            let rest_result = checker_collect_closure_param_list_inplace(c, *rest)
+            (FnParamList { head: head_param, tail: Some(Box::new(rest_result.0)) }, 1 + rest_result.1)
+        }
+    }
+}
 
-    let ret_pair = (*c).lower_opt_closure_return(e.closure_return)
-    checker_store_from_value(c, ret_pair.0)
-    let ret_ty = ret_pair.1
+fn checker_collect_closure_params_inplace(c: *mut Checker, opt: Option<Box<ClosureParamList> >) -> (Option<Box<FnParamList> >, i64) with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(pl) => {
+            let r = checker_collect_closure_param_list_inplace(c, *pl)
+            (Some(Box::new(r.0)), r.1)
+        }
+        None => (None, 0)
+    }
+}
+
+fn checker_bind_closure_params_inplace(c: *mut Checker, opt: Option<Box<ClosureParamList> >) with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(pl) => {
+            let p = (*pl).head
+            let param_ty = checker_lower_type_expr_mut(c, p.ty)
+            (*c).env = (*c).env.bind(p.name, param_ty, false)
+            checker_const_int_bind_unknown_inplace(c, p.name)
+            checker_bind_closure_params_inplace(c, (*pl).tail)
+        }
+        None => {}
+    }
+}
+
+fn checker_lower_opt_closure_return_inplace(c: *mut Checker, opt: Option<Box<TypeExpr> >) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(te) => checker_lower_type_expr_mut(c, *te)
+        None => ty_unknown()
+    }
+}
+
+fn checker_check_closure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    let params_pair = checker_collect_closure_params_inplace(c, e.closure_params)
+    let params = params_pair.0
+    let param_count = params_pair.1
+
+    let ret_ty = checker_lower_opt_closure_return_inplace(c, e.closure_return)
 
     let saved_effects = (*c).current_effects
     let saved_effect_count = (*c).current_effect_count
@@ -3735,10 +3781,9 @@ fn checker_check_closure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
     (*c).borrows = (*c).borrows.push_scope()
     checker_push_const_scope_inplace(c)
 
-    let bound = (*c).bind_closure_params(e.closure_params)
-    checker_store_from_value(c, bound)
+    checker_bind_closure_params_inplace(c, e.closure_params)
 
-    // THE FIX: body checked in place (was the by-value c.check_opt_expr recursion).
+    // Body checked in place (was the by-value c.check_opt_expr recursion).
     let body_ty = checker_check_opt_expr_inplace(c, e.closure_body)
 
     let inferred_ret_ty = if ret_ty.kind == TypeKind::TyUnknown {

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -192,6 +192,11 @@ pub struct Checker {
     refine_violations: i64,       // predicates definitely violated (compile error)
     // Condition-narrowing guard stack: up to 8 nested if-conditions.
     refine_cond_env: RefineStaticEnv,
+    // Closure-body effect inference depth: >0 while checking a closure body, so a
+    // callee's declared effects ACCUMULATE into current_effects (inference) rather
+    // than being enforced. Declared last to preserve existing field offsets
+    // (the modular checker's crash surface is layout-sensitive).
+    closure_inference_depth: i64,
 }
 
 // Wrapper for inferred type arguments (avoids &![T;N] JIT bug)
@@ -680,6 +685,7 @@ fn checker_new() -> Checker with Mut, Panic, Div {
         refine_runtime_checked: 0,
         refine_violations: 0,
         refine_cond_env: refine_static_env_new(),
+        closure_inference_depth: 0,
     }
 }
 
@@ -742,6 +748,7 @@ fn checker_init_in_place(raw: *mut Checker) with Mut, Panic, Div, Alloc {
     (*raw).current_impl_type = ty_error()
     (*raw).current_effects = [0; 8]
     (*raw).current_effect_count = 0
+    (*raw).closure_inference_depth = 0
     (*raw).multitest_count = 0
     (*raw).multitest_corrected = false
     (*raw).last_literal_int = 0
@@ -2189,7 +2196,12 @@ fn fn_sigs_structurally_compatible(expected: FnSig, got: FnSig) -> bool with Mut
         i = i + 1
     }
     if !types_compatible(expected.return_type, got.return_type) { return false }
-    fn_sigs_effects_subset(got, expected)
+    // Effects are NOT a fn-type compatibility concern: bare fn-type params are
+    // effect-polymorphic. A function value's effects propagate to the HOF CALL SITE
+    // (see arg-effect propagation in checker_check_call_args_inner_inplace), where the
+    // enclosing function must declare them. So any closure/fn matching by signature
+    // (arity + param/return types + linearity) is compatible.
+    true
 }
 
 fn checker_report_mismatch_inplace(c: *mut Checker, span: Span, code: i64, expected: TypeEntry, got: TypeEntry) with Mut, IO, Panic, Div, Alloc {
@@ -3783,8 +3795,12 @@ fn checker_check_closure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
 
     checker_bind_closure_params_inplace(c, e.closure_params)
 
-    // Body checked in place (was the by-value c.check_opt_expr recursion).
+    // Body checked in place (was the by-value c.check_opt_expr recursion). Raise the
+    // inference depth so callee effects in the body accumulate into current_effects
+    // (closure effect inference) instead of being enforced against the closure.
+    (*c).closure_inference_depth = (*c).closure_inference_depth + 1
     let body_ty = checker_check_opt_expr_inplace(c, e.closure_body)
+    (*c).closure_inference_depth = (*c).closure_inference_depth - 1
 
     let inferred_ret_ty = if ret_ty.kind == TypeKind::TyUnknown {
         body_ty
@@ -4069,6 +4085,14 @@ fn checker_check_call_args_inner_inplace(c: *mut Checker, args: Option<Box<ExprL
             if implicit_borrow && (*c).suppress_linear_consume_depth > 0 {
                 (*c).suppress_linear_consume_depth = (*c).suppress_linear_consume_depth - 1
             }
+            // Effect-polymorphic HOF arguments: a function/closure value passed as an
+            // argument performs its effects at THIS call site, so propagate them to the
+            // enclosing context — enforced against the enclosing fn's declared effects at
+            // depth 0, or accumulated into an outer closure's inferred effects at depth>0.
+            if arg_ty.kind == TypeKind::TyFn && arg_ty.fn_sig_id >= 0 && arg_ty.fn_sig_id < (*c).fn_sigs.count {
+                let arg_sig = (*c).fn_sigs.get(arg_ty.fn_sig_id)
+                checker_check_callee_effects_inplace(c, call_span, arg_sig.effects, arg_sig.effect_count)
+            }
             let has_param_info = !name_is_empty(param_info.name) || param_info.ty.kind != TypeKind::TyError
             if has_param_info {
                 if !call_arg_types_compatible(arg_expr, arg_ty, param_info.ty) {
@@ -4109,6 +4133,23 @@ fn checker_check_call_args_inner_inplace(c: *mut Checker, args: Option<Box<ExprL
 
 fn checker_check_call_args_inplace(c: *mut Checker, args: Option<Box<ExprList> >, params: Option<Box<FnParamList> >, expected_count: i64, call_span: Span) with Mut, Panic, Div, Alloc, IO {
     checker_check_call_args_inner_inplace(c, args, params, 0, expected_count, call_span)
+}
+
+// print / println / print_int / print_char are IO builtins that are NOT registered in
+// fn_sigs (they resolve to ty_error), so their IO effect is invisible to the effects
+// system. Recognize them by name so closure-body inference can capture their IO.
+fn call_callee_is_print_builtin(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprIdent { return false }
+            if name_matches_str5((*expr).name, 112, 114, 105, 110, 116) { return true }            // print
+            if name_matches_str7((*expr).name, 112, 114, 105, 110, 116, 108, 110) { return true }  // println
+            if name_matches_str9((*expr).name, 112, 114, 105, 110, 116, 95, 105, 110, 116) { return true }  // print_int
+            if name_matches_str10((*expr).name, 112, 114, 105, 110, 116, 95, 99, 104, 97, 114) { return true } // print_char
+            false
+        }
+        None => false
+    }
 }
 
 // *mut ExprCall handler — transcription of check_call_expr's normal path (14605-14687).
@@ -4185,6 +4226,16 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         let call_start_borrows = (*c).borrows
         checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
         checker_release_call_arg_borrows_inplace(c, e.args, None, call_start_borrows)
+        // During closure inference, treat a print-family builtin call as performing IO
+        // so the closure's inferred effect set includes it (these are not in fn_sigs).
+        if (*c).closure_inference_depth > 0 && call_callee_is_print_builtin(e.left) {
+            if (*c).current_effect_count < 8 {
+                if !has_effect_id((*c).current_effects, (*c).current_effect_count, 0) {
+                    (*c).current_effects[(*c).current_effect_count as usize] = 0
+                    (*c).current_effect_count = (*c).current_effect_count + 1
+                }
+            }
+        }
         callee_ty
     } else {
         checker_report_error_at_inplace(c, e.span, 17, 0, 0, 0)
@@ -4198,6 +4249,24 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
 
 fn checker_check_callee_effects_inplace(c: *mut Checker, span: Span, callee_effects: [i64; 8], callee_effect_count: i64) with Mut, IO, Panic, Div, Alloc {
     if callee_effect_count == 0 {
+        return
+    }
+    // Inference mode: while checking a closure body, ACCUMULATE the callee's effects
+    // into current_effects (deduped, capped at 8) so the closure's inferred effect set
+    // captures them. Enforcement (below) is skipped here — the closure is later checked
+    // for compatibility against the expected fn-type via fn_sigs_effects_subset.
+    if (*c).closure_inference_depth > 0 {
+        var i: i64 = 0
+        while i < callee_effect_count {
+            let eff_id = callee_effects[i as usize]
+            if (*c).current_effect_count < 8 {
+                if !has_effect_id((*c).current_effects, (*c).current_effect_count, eff_id) {
+                    (*c).current_effects[(*c).current_effect_count as usize] = eff_id
+                    (*c).current_effect_count = (*c).current_effect_count + 1
+                }
+            }
+            i = i + 1
+        }
         return
     }
     if effects_subset(callee_effects, callee_effect_count, (*c).current_effects, (*c).current_effect_count) {

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -572,6 +572,12 @@ impl Parser {
         var rev_list = EffectList { head: first, tail: None }
 
         while parser_peek(p) == TokenKind::Comma {
+            // A comma followed by `ident :` begins the NEXT parameter (`name: type`),
+            // not another effect. This happens when a `fn(T)->U with Eff,...` type is a
+            // parameter and more parameters follow. Without this, the effect-list loop
+            // greedily swallows the next param name as an effect and the signature
+            // fails to parse. peek_ahead(2) is the token after the comma's next ident.
+            if parser_peek_ahead(p, 2) == TokenKind::Colon { break }
             p = p.advance()  // skip ,
             let eff_name = p.current_name()
             let eff = EffectRef { name_buf: [0; 64], name_len: eff_name.len }


### PR DESCRIPTION
## Summary

Stacked on #235. Unlocks closure literals and higher-order/effect-bearing programs in the modular `*mut` checker, and establishes the **effect-polymorphic** HOF model.

**Result vs same-session closure-tip baseline (269 PASS / 72 CRASH): PASS 269 → 283 (+14), CRASH 72 → 65; zero PASS→FAIL, zero FAIL→CRASH, zero negative-suite regressions.**

`self-hosted/parser/types.sio` + `self-hosted/check/check.sio` only — `lean_single.sio` untouched, canonical gate unaffected.

## ⚠️ Supersedes #235's effect model
#235's audit doc described an effect-**subsumption** model (and presented the `eff1`/GPU/Async *rejections* as sound). That was wrong — it only "passed" because closure literals crashed before the check. This PR replaces it with **effect-polymorphism** and corrects #235's doc with a supersession banner (commit on the #235 branch). The dead subsumption helpers (`fn_sigs_effects_subset`/`is_ambient_effect`) are removed here.

## Three sub-fixes (each verified by full per-file census)

1. **Parser — effect-list no longer swallows the next parameter** (+5). `parse_effect_list` consumed a trailing `, name:` as another effect, so `fn(T)->U with Eff,...` as a non-last param failed to parse. Fix: break when the comma is followed by `ident :`. Wins: `test_diffgeo/functional/multigrid/stochastic_calc` (scientific) + `closure_effect_checked`.

2. **Closure-literal SRET dodge** (+6 CRASH→PASS). `checker_check_closure_expr_inplace` called three by-value `Checker` helpers (returning the ~164KB `Checker` by value — the SRET miscompile), so **any** `|x| …` literal SIGSEGV'd. Added `*mut` transcriptions. Wins: `closure_arity_2/basic/escape/linear/returned/effect_transparent_hof`.

3. **Effect-polymorphic HOF model** (resolves a self-contradictory test suite). Bare `fn(T)->U` params accept any-effect value by signature; a fn/closure argument's effects propagate to the **call site** (the enclosing fn must declare them). Implemented via a `closure_inference_depth` counter (closure-body effect inference, incl. `print`-family IO recognition) + call-site propagation in `checker_check_call_args_inner_inplace`. Reconciles all three previously-contradictory tests: `closure_effect_escape` REJECTS (pure caller lacks IO), `closure_effect_transparent_hof` PASSES (caller has IO), `effects_closure_escape` still rejects (its `fn(x){}` syntax).

## Soundness
Verified the common case: a named effectful fn passed to a HOF **rejects** from a pure caller, **passes** from an IO caller. `eff1`/GPU/Async closures reject from a pure caller. (Under polymorphism, the earlier "must reject from IO main" expectations were subsumption-model artifacts and now correctly pass.)

## Known incompleteness (stated, not hidden)
- Negative scan was **targeted** (fn/closure compile-fail subset), not the full 250 — the full loop stalls on pre-existing 3GB-bss SIGSEGV crashers even with `ulimit -c 0`.
- IO-builtin recognition is a **hardcoded list** (`print/println/print_int/print_char`); a closure using a different IO builtin from a pure caller would under-reject — an inference incompleteness, not a complete effect system.
- Measurement is `--check` against a same-session baseline; the documented `322/0` campaign baseline does not reproduce with the committed `bin/souc` (per-file non-crash transitions are the reliable signal).

Audit: `docs/audit/g1_wip/CLOSURE_EFFECT_POLY_HOF_MODULAR_2026-06-04.md`.