### PR TITLE
check: refinement types in the modular checker (foundation + compound predicates, +7)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1185,10 +1185,20 @@ fn checker_lower_refinement_type_mut(c: *mut Checker, opt: Option<Box<Refinement
                 Some(bte) => {
                     let base_ty = checker_lower_type_expr_mut(c, *bte)
                     if ri.pred_op > 0 {
-                        let pred = if ri.pred_is_float {
+                        let pred1 = if ri.pred_is_float {
                             pred_make_float(ri.pred_op, ri.var_name, ri.pred_float_val)
                         } else {
                             pred_make_int(ri.pred_op, ri.var_name, ri.pred_int_val)
+                        }
+                        let pred = if ri.pred_conn > 0 {
+                            let pred2 = if ri.pred_is_float2 {
+                                pred_make_float(ri.pred_op2, ri.var_name, ri.pred_float_val2)
+                            } else {
+                                pred_make_int(ri.pred_op2, ri.var_name, ri.pred_int_val2)
+                            }
+                            pred_make_compound(ri.pred_conn, pred1, pred2)
+                        } else {
+                            pred1
                         }
                         let rt = RefinementType { base_type: base_ty, var_name: ri.var_name, predicate: pred }
                         let synth_name = make_refinement_synth_name((*c).refinements.count)
@@ -11996,12 +12006,22 @@ impl Checker {
                         let pair = self.lower_type_expr(*bte)
                         var c = pair.0
                         let base_ty = pair.1
-                        // Build refinement predicate from inline annotation
+                        // Build refinement predicate from inline annotation (single or compound)
                         if ri.pred_op > 0 {
-                            let pred = if ri.pred_is_float {
+                            let pred1 = if ri.pred_is_float {
                                 pred_make_float(ri.pred_op, ri.var_name, ri.pred_float_val)
                             } else {
                                 pred_make_int(ri.pred_op, ri.var_name, ri.pred_int_val)
+                            }
+                            let pred = if ri.pred_conn > 0 {
+                                let pred2 = if ri.pred_is_float2 {
+                                    pred_make_float(ri.pred_op2, ri.var_name, ri.pred_float_val2)
+                                } else {
+                                    pred_make_int(ri.pred_op2, ri.var_name, ri.pred_int_val2)
+                                }
+                                pred_make_compound(ri.pred_conn, pred1, pred2)
+                            } else {
+                                pred1
                             }
                             let rt = RefinementType { base_type: base_ty, var_name: ri.var_name, predicate: pred }
                             let synth_name = make_refinement_synth_name(c.refinements.count)

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1172,6 +1172,40 @@ fn checker_lower_fn_type_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry with Mu
     ty_fn(sig_id)
 }
 
+// *mut transcription of lower_refinement_type (by-value): the inplace type-lowering spine
+// lacked a TypeRefinement arm and fell to the silent _ => checker_note_type_error_mut, so an
+// inline refinement type `{ x: T | x op v }` (param/return/let) silently failed in the
+// no-import path. Lower the base type, build the predicate, register a synthetic refinement,
+// return ty_with_refinement.
+fn checker_lower_refinement_type_mut(c: *mut Checker, opt: Option<Box<RefinementInfo> >) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(info) => {
+            let ri = *info
+            match ri.base_type {
+                Some(bte) => {
+                    let base_ty = checker_lower_type_expr_mut(c, *bte)
+                    if ri.pred_op > 0 {
+                        let pred = if ri.pred_is_float {
+                            pred_make_float(ri.pred_op, ri.var_name, ri.pred_float_val)
+                        } else {
+                            pred_make_int(ri.pred_op, ri.var_name, ri.pred_int_val)
+                        }
+                        let rt = RefinementType { base_type: base_ty, var_name: ri.var_name, predicate: pred }
+                        let synth_name = make_refinement_synth_name((*c).refinements.count)
+                        (*c).refinements = refinement_table_add((*c).refinements, synth_name, rt)
+                        let ref_idx = (*c).refinements.count - 1
+                        ty_with_refinement(base_ty, ref_idx)
+                    } else {
+                        base_ty
+                    }
+                }
+                None => ty_error()
+            }
+        }
+        None => ty_error()
+    }
+}
+
 fn checker_lower_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     if !checker_enter_type_expr_mut(c) {
         return ty_error()
@@ -1268,6 +1302,7 @@ fn checker_lower_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry with 
         TypeExprKind::TypeReference => checker_lower_ref_type_dispatch_mut(c, te.inner, false)
         TypeExprKind::TypeRefMut => checker_lower_ref_type_dispatch_mut(c, te.inner, true)
         TypeExprKind::TypeFn => checker_lower_fn_type_mut(c, te)
+        TypeExprKind::TypeRefinement => checker_lower_refinement_type_mut(c, te.refinement_info)
         _ => {
             checker_note_type_error_mut(c)
             ty_error()
@@ -2835,6 +2870,15 @@ fn checker_check_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, P
         result = checker_check_array_lit_inplace(c, e)
     } else if e.kind == ExprKind::ExprUnary {
         result = checker_check_unary_expr_inplace(c, e)
+        // Record a negated integer literal as the last literal so a refinement-literal check
+        // on `let x: { n | n > 0 } = -5` sees the folded value (-5) and flags the violation.
+        if e.un_op == UnaryOp::OpNeg {
+            let folded_neg = checker_eval_const_int_opt_expr_mut(c, Some(Box::new(e)))
+            if folded_neg.0 != 0 {
+                (*c).last_literal_int = folded_neg.1
+                (*c).last_literal_kind = 1
+            }
+        }
     } else if e.kind == ExprKind::ExprFieldAccess {
         result = checker_check_field_access_inplace(c, e)
     } else if e.kind == ExprKind::ExprIndex {
@@ -4334,6 +4378,20 @@ fn checker_check_call_arg_refinement_boundary_inplace(c: *mut Checker, arg_expr:
     }
     if arg_expr.kind == ExprKind::ExprFloatLit {
         let result = refine_static_check_float_literal(expected_ref.predicate, arg_expr.float_val)
+        if result == refine_static_result_proved() {
+            (*c).refine_static_proved = (*c).refine_static_proved + 1
+        } else {
+            (*c).refine_violations = (*c).refine_violations + 1
+            checker_report_error_at_inplace(c, call_span, 42, 0, 0, 0)
+        }
+        return
+    }
+
+    // Constant-fold non-literal integer args (e.g. -5 = OpNeg, 0 - 5 = OpSub) and check the
+    // predicate, so a definite violation is a compile error rather than a deferred W040 warning.
+    let folded_arg = checker_eval_const_int_opt_expr_mut(c, Some(Box::new(arg_expr)))
+    if folded_arg.0 != 0 {
+        let result = refine_static_check_int_literal(expected_ref.predicate, folded_arg.1)
         if result == refine_static_result_proved() {
             (*c).refine_static_proved = (*c).refine_static_proved + 1
         } else {

--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -877,6 +877,13 @@ pub struct RefinementInfo {
     pred_int_val: i64,
     pred_float_val: f64,
     pred_is_float: bool,
+    // Optional second clause for a compound predicate `v op1 a && v op2 b` (same var).
+    // pred_conn: 0 = none (single clause), 7 = And, 8 = Or (matching the refinement engine).
+    pred_conn: i64,
+    pred_op2: i64,
+    pred_int_val2: i64,
+    pred_float_val2: f64,
+    pred_is_float2: bool,
 }
 
 pub struct TypeExpr {

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -361,6 +361,9 @@ impl Parser {
         } else if op == TokenKind::EqEq || op == TokenKind::Eq {
             pred_op = 5
             p = p.advance()
+        } else if op == TokenKind::BangEq {
+            pred_op = 6
+            p = p.advance()
         }
 
         var pred_int_val: i64 = 0

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -380,6 +380,36 @@ impl Parser {
             p = p.advance()
         }
 
+        // Optional second clause for a compound predicate: `v op1 a && v op2 b` (or `||`).
+        var pred_conn: i64 = 0
+        var pred_op2: i64 = 0
+        var pred_int_val2: i64 = 0
+        var pred_float_val2: f64 = 0.0
+        var pred_is_float2 = false
+        let conn_tok = parser_peek(p)
+        if conn_tok == TokenKind::AmpAmp || conn_tok == TokenKind::PipePipe {
+            if conn_tok == TokenKind::AmpAmp { pred_conn = 7 } else { pred_conn = 8 }
+            p = p.advance()  // skip && / ||
+            if parser_peek(p) == TokenKind::Ident { p = p.advance() }  // skip the (same) var ref
+            let op2 = parser_peek(p)
+            if op2 == TokenKind::Gt { pred_op2 = 1; p = p.advance() }
+            else if op2 == TokenKind::GtEq { pred_op2 = 2; p = p.advance() }
+            else if op2 == TokenKind::Lt { pred_op2 = 3; p = p.advance() }
+            else if op2 == TokenKind::LtEq { pred_op2 = 4; p = p.advance() }
+            else if op2 == TokenKind::EqEq || op2 == TokenKind::Eq { pred_op2 = 5; p = p.advance() }
+            else if op2 == TokenKind::BangEq { pred_op2 = 6; p = p.advance() }
+            if parser_peek(p) == TokenKind::FloatLit {
+                pred_float_val2 = p.current().float_value
+                pred_is_float2 = true
+                p = p.advance()
+            } else if parser_peek(p) == TokenKind::IntLit {
+                pred_int_val2 = p.current().int_value
+                pred_float_val2 = p.current().int_value as f64
+                pred_is_float2 = false
+                p = p.advance()
+            }
+        }
+
         p = p.expect(TokenKind::RBrace)
         let span = p.span_from(start)
         let info = RefinementInfo {
@@ -389,6 +419,11 @@ impl Parser {
             pred_int_val: pred_int_val,
             pred_float_val: pred_float_val,
             pred_is_float: pred_is_float,
+            pred_conn: pred_conn,
+            pred_op2: pred_op2,
+            pred_int_val2: pred_int_val2,
+            pred_float_val2: pred_float_val2,
+            pred_is_float2: pred_is_float2,
         }
         (p, TypeExpr {
             kind: TypeExprKind::TypeRefinement,


### PR DESCRIPTION
## Summary

Stacked on #242. Brings inline refinement types (`{ x: T | pred }`) to life in the modular `*mut` checker — a dissertation-critical feature (medical-dose bounds, etc.). **Accurate census (timeout 25, both binaries, 0 timeouts) vs the pre-refinement tip: PASS 290 → 297 (+7), CRASH 65 unchanged, 0 PASS→FAIL, 0 FAIL→CRASH.**

`check.sio` + `parser/types.sio` + `parser/ast.sio` only — `lean_single.sio` untouched.

### Build A — foundation + violation-detection
- `checker_lower_type_expr_mut` lacked a `TypeRefinement` arm (silent `ty_error`) → inline refinements silently failed in the no-import path. Added the `*mut` lowering arm (mirrors by-value `lower_refinement_type`) + the `!=` predicate op.
- Proper lowering means a static violation must be a compile **error**, not a deferred W040 warning. Extended the call-arg boundary to constant-fold non-literal int args (`-5`, `0 - 5`) and record negated literals as `last_literal` for the let-binding check. (A foundation-only attempt regressed 3 violation tests reject→accept; this completion fixes them.)

### Build B — compound predicates
`RefinementInfo` gains an optional second clause (`pred_conn` 7=And/8=Or + op2/val2); `parse_refinement_type` parses the trailing `&&`/`||`; both lowering paths build a compound `RefinementPred` via `pred_make_compound` (the engine already evaluates And/Or).

**Wins:** `refinement_inline`, `let_binding`, `medical_dose`, `non_zero`, `or_predicate`, `probability`, `return`.

## Soundness (verified)
All compile-fail refinement violations still **reject**, including `refinement_compound_violation`, `refinement_inline_param_violation`, `refinement_let_violation`, `refinement_violation_positive`.

## Out of scope (unrelated gaps, not refinement)
6 refinement tests remain FAIL, blocked by gaps *outside* refinement (verified — the compound type itself parses): `let _ =` underscore binding (`guard_and`/`guard_or` fail only at their `let _` line), the `type` alias keyword (`float_bound`/`satisfied`), and arithmetic-RHS predicates (`nested_arithmetic`). Each is a separate small lever.

Orthogonal to the i128 (`types.sio`/`compat.sio` int-width / native) and SRET (`ir/*`) lanes.