### PR TITLE
fix(check): no SIGSEGV on measure() — clears ~41% of remaining checker crashes

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3994,7 +3994,22 @@ fn checker_check_call_args_inplace(c: *mut Checker, args: Option<Box<ExprList> >
 }
 
 // *mut ExprCall handler — transcription of check_call_expr's normal path (14605-14687).
+fn checker_check_measure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    // measure(v: T, uncertainty: f64) -> Knowledge<T>. Inplace transcription of
+    // check_measure_expr — the by-value bridge (checker_check_expr_mut) SRET-smashed
+    // the 164KB Checker once enums were populated, so EVERY measure() crashed --check
+    // (~41% of remaining checker crashers).
+    let first_arg = expr_list_head(e.args)
+    let v_ty = checker_check_opt_expr_inplace(c, first_arg)
+    ty_knowledge(v_ty, 0.0 - 1.0)
+}
+
 fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    // Intercept the common epistemic builtin measure() with an inplace handler before the
+    // by-value bridge below (which SRET-smashes on the 164KB Checker return).
+    if call_expr_is_builtin_measure(e.left) {
+        return checker_check_measure_expr_inplace(c, e)
+    }
     if call_expr_should_bridge_by_value(e) {
         return checker_check_expr_mut(c, e)
     }


### PR DESCRIPTION
Follow-up to #246/#247. `checker_check_call_expr_inplace` bridged all special builtins to the by-value `checker_check_expr_mut`, whose ~164KB Checker SRET-move smashes the return once enums are populated — so every `measure(v, uncertainty: e)` crashed `--check` (~41%, 47/115, of remaining checker crashers; all the sensitivity/knowledge tests). Fix: intercept `measure` before the bridge with an inplace handler returning `Knowledge<T>`. Other epistemic/decision builtins follow the same recipe (backlog). Verified: measure / k.value / sensitivity_of / real crasher all check: OK; regressions clean; capgate 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)