### PR TITLE
fix(check): no SIGSEGV on break/continue (inplace dispatch gap)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -2695,6 +2695,10 @@ fn checker_check_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, P
         result = checker_check_range_expr_inplace(c, e)
     } else if e.kind == ExprKind::ExprTupleLit {
         result = checker_check_tuple_lit_inplace(c, e)
+    } else if e.kind == ExprKind::ExprBreak {
+        result = checker_check_break_expr_inplace(c, e)
+    } else if e.kind == ExprKind::ExprContinue {
+        result = checker_check_continue_expr_inplace(c, e)
     } else {
         result = checker_check_expr_mut(c, e)
     }
@@ -2766,6 +2770,24 @@ fn checker_check_tuple_lit_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         Some(elem_list) => ty_tuple(*elem_list)
         None => ty_unit()
     }
+}
+
+// *mut ExprBreak / ExprContinue handlers. Both were missing from the inplace dispatch
+// → fell to by-value checker_check_expr_mut → 164KB Checker SRET-smash. ANY loop using
+// break/continue crashed --check (in larger enum-populated files). Faithful to the
+// by-value check_break_expr / check_continue_expr (codes 44/45, return ty_never()).
+fn checker_check_break_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    if (*c).loop_depth == 0 {
+        checker_report_error_at_inplace(c, e.span, 44, 0, 0, 0)
+    }
+    ty_never()
+}
+
+fn checker_check_continue_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    if (*c).loop_depth == 0 {
+        checker_report_error_at_inplace(c, e.span, 45, 0, 0, 0)
+    }
+    ty_never()
 }
 
 // FIX #2 (spine-completion): *mut ExprPath leaf handler. Faithful in-place transcription


### PR DESCRIPTION
ExprBreak/ExprContinue were missing from the `checker_check_expr_inplace` dispatch → by-value bridge → 164KB Checker SRET-smash. Any loop with break/continue crashed `--check` in larger enum-populated files (16/70 remaining checker crashers). Fix: inplace handlers + dispatch cases (faithful to by-value, codes 44/45). `for_in_loops.sio` now passes; capgate 31/31; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)