### PR TITLE
fix(lower): break/continue lowering — bind loop-label box before deref-store

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2860,8 +2860,13 @@ impl Lowerer {
     fn push_loop_labels(self, continue_label: i64, break_label: i64) -> Lowerer with Mut, Panic, Div {
         var lo = self
         if lo.loop_depth < 256 {
-            (*lo.loop_labels).continue_labels[lo.loop_depth as usize] = continue_label
-            (*lo.loop_labels).break_labels[lo.loop_depth as usize] = break_label
+            // Bind the box to a local before the deref-store: `(*lo.loop_labels).arr[i]=v`
+            // re-derefs a field-box each access, which mini miscompiles into a write to a
+            // discarded 4KB copy (the stores were lost -> break/continue read IR_INVALID_LABEL).
+            let lbl = lo.loop_labels
+            let d = lo.loop_depth as usize
+            (*lbl).continue_labels[d] = continue_label
+            (*lbl).break_labels[d] = break_label
             lo.loop_depth = lo.loop_depth + 1
             lo
         } else {
@@ -2881,7 +2886,8 @@ impl Lowerer {
         if self.loop_depth <= 0 {
             IR_INVALID_LABEL
         } else {
-            (*self.loop_labels).break_labels[(self.loop_depth - 1) as usize]
+            let lbl = self.loop_labels
+            (*lbl).break_labels[(self.loop_depth - 1) as usize]
         }
     }
 
@@ -2889,7 +2895,8 @@ impl Lowerer {
         if self.loop_depth <= 0 {
             IR_INVALID_LABEL
         } else {
-            (*self.loop_labels).continue_labels[(self.loop_depth - 1) as usize]
+            let lbl = self.loop_labels
+            (*lbl).continue_labels[(self.loop_depth - 1) as usize]
         }
     }
 


### PR DESCRIPTION
## What
`break` / `continue` inside any loop failed native-v2 lowering with `ir_bodies_failed`.

## Root cause
`push_loop_labels` stored labels via `(*lo.loop_labels).break_labels[i] = v` — a deref-store through a **field-box**. mini miscompiles that into a write to a discarded 4KB copy of `LowerLoopLabels`, so the stores were lost. At break/continue time, `current_break_label()` read back the `IR_INVALID_LABEL` init value → `report_error()` → `ir_bodies_failed`. Diagnosed with a probe: `loop_depth` was correctly **1**, but the label read **-1** — confirming the store, not the depth, was the casualty.

## Fix
Bind the box to a local before deref-store/read (`let lbl = lo.loop_labels; (*lbl)...`) in both writers (`push_loop_labels`) and readers (`current_break_label`, `current_continue_label`). The known mini Box-deref-store workaround.

## Verified (source→ELF)
- range+break = 3, range+continue = 9, while+break = 5, array+break = 3
- plain-for regression = 6 (no break) — unchanged
- capgate `tests/native_v2_capgate/run.sh` = **31/31**

🤖 Generated with [Claude Code](https://claude.com/claude-code)