### PR TITLE
feat(native-v2): unary !/- + bitwise & | ^ << >> codegen (backend_fail −22)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6015,8 +6015,28 @@ impl Lowerer {
             let pair_d = lo1.fresh_reg()
             let lo2 = pair_d.0
             let dst = pair_d.1
-            let lo3 = lo2.emit(ir_unaryop(dst, e.un_op, src))
-            (lo3, dst)
+            // The native-v2 backend has no ir_unaryop emitter (-> to_file rc=12), so desugar
+            // the arithmetic/logical unary ops to the binops it already supports.
+            // `-x` => `0 - x`; `!b` => `b == 0` (logical not on 0/1 bools — there is no
+            // bitwise-not UnaryOp variant). Deref/ref keep the existing ir_unaryop path.
+            if e.un_op == UnaryOp::OpNeg {
+                let pair_z = lo2.fresh_reg()
+                let lo3 = pair_z.0
+                let zero = pair_z.1
+                let lo4 = lo3.emit(ir_load_imm(zero, 0))
+                let lo5 = lo4.emit(ir_binop(dst, zero, BinaryOp::OpSub, src))
+                (lo5, dst)
+            } else if e.un_op == UnaryOp::OpNot {
+                let pair_z = lo2.fresh_reg()
+                let lo3 = pair_z.0
+                let zero = pair_z.1
+                let lo4 = lo3.emit(ir_load_imm(zero, 0))
+                let lo5 = lo4.emit(ir_binop(dst, src, BinaryOp::OpEq, zero))
+                (lo5, dst)
+            } else {
+                let lo3 = lo2.emit(ir_unaryop(dst, e.un_op, src))
+                (lo3, dst)
+            }
         } else if e.kind == ExprKind::ExprFieldAccess {
             let pair_b = self.lower_opt_expr_ref(&e.left)
             let lo1 = pair_b.0

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1915,6 +1915,34 @@ fn nc_emit_sub_rax_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
     nc_emit_byte(nc, 0xd8)
 }
 
+// and rax, rbx  (0x48 0x21 0xd8) — bitwise AND for the v2 core binop emitter.
+fn nc_emit_and_rax_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_byte(nc, 0x48)
+    nc_emit_byte(nc, 0x21)
+    nc_emit_byte(nc, 0xd8)
+}
+
+// or rax, rbx  (0x48 0x09 0xd8) — bitwise OR for the v2 core binop emitter.
+fn nc_emit_or_rax_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_byte(nc, 0x48)
+    nc_emit_byte(nc, 0x09)
+    nc_emit_byte(nc, 0xd8)
+}
+
+// shl rax, cl  (0x48 0xd3 0xe0) — logical/arith left shift by the count in CL.
+fn nc_emit_shl_rax_cl(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_byte(nc, 0x48)
+    nc_emit_byte(nc, 0xd3)
+    nc_emit_byte(nc, 0xe0)
+}
+
+// sar rax, cl  (0x48 0xd3 0xf8) — arithmetic right shift by the count in CL (signed >>).
+fn nc_emit_sar_rax_cl(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_byte(nc, 0x48)
+    nc_emit_byte(nc, 0xd3)
+    nc_emit_byte(nc, 0xf8)
+}
+
 // --- Zig-style wide-int (N-limb of u64) emit primitives + ops ---
 // adc rax, rbx (rax += rbx + CF). 0x48 0x11 0xd8. MOV loads/stores between limbs preserve CF.
 fn nc_emit_adc_rax_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
@@ -5674,6 +5702,50 @@ fn nc_emit_core_binop(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64
         else if op == BinaryOp::OpEq { nc_emit_sete_al(nc) }
         else { nc_emit_setne_al(nc) }
         nc_emit_movzx_rax_al(nc)
+        nc_core_store_rax_to_temp(nc, dst)
+        return true
+    }
+    // Bitwise AND/OR/XOR — commutative, same load shape as OpAdd (rax=rhs, rbx=lhs).
+    if op == BinaryOp::OpBitAnd {
+        nc_core_load_temp_to_rax(nc, lhs)
+        nc_emit_push_rax(nc)
+        nc_core_load_temp_to_rax(nc, rhs)
+        nc_emit_pop_rbx(nc)
+        nc_emit_and_rax_rbx(nc)
+        nc_core_store_rax_to_temp(nc, dst)
+        return true
+    }
+    if op == BinaryOp::OpBitOr {
+        nc_core_load_temp_to_rax(nc, lhs)
+        nc_emit_push_rax(nc)
+        nc_core_load_temp_to_rax(nc, rhs)
+        nc_emit_pop_rbx(nc)
+        nc_emit_or_rax_rbx(nc)
+        nc_core_store_rax_to_temp(nc, dst)
+        return true
+    }
+    if op == BinaryOp::OpBitXor {
+        nc_core_load_temp_to_rax(nc, lhs)
+        nc_emit_push_rax(nc)
+        nc_core_load_temp_to_rax(nc, rhs)
+        nc_emit_pop_rbx(nc)
+        nc_emit_xor_rax_rbx(nc)
+        nc_core_store_rax_to_temp(nc, dst)
+        return true
+    }
+    // Shifts — non-commutative: lhs in rax, count in CL. Load rhs first (the OpSub shape)
+    // so that after the pop rax=lhs, rbx=rhs(count); move the count into rcx then shift.
+    if op == BinaryOp::OpShl || op == BinaryOp::OpShr {
+        nc_core_load_temp_to_rax(nc, rhs)
+        nc_emit_push_rax(nc)
+        nc_core_load_temp_to_rax(nc, lhs)
+        nc_emit_pop_rbx(nc)
+        nc_emit_mov_reg_reg(nc, 1, 3)   // mov rcx, rbx  (count -> cl)
+        if op == BinaryOp::OpShl {
+            nc_emit_shl_rax_cl(nc)
+        } else {
+            nc_emit_sar_rax_cl(nc)
+        }
         nc_core_store_rax_to_temp(nc, dst)
         return true
     }


### PR DESCRIPTION
## What
Two native-v2 source→ELF codegen gaps, both `FAIL to_file rc=12` (backend_fail):

1. **Unary `!` / `-`** (lower.sio): no `ir_unaryop` backend emitter → desugar in the lowerer to supported binops: `-x` → `0 - x`, `!b` → `b == 0`. Deref/ref keep the existing path.
2. **Bitwise/shift `& | ^ << >>`** (codegen_x86_linux.sio): `nc_emit_core_binop` fell through to `false` for these. Added x86 emitters (`and`/`or rax,rbx`; `shl`/`sar rax,cl`) + the 5 cases, mirroring `emit_binop_code`.

## Verified (VALUES, not just ELF-presence)
`6&3=2, 6|3=7, 6^3=5, 1<<4=16, 64>>2=16, (-8)>>1=-4` (proves SAR), `!true=0/!false=1`, `-x` correct. **capgate 31/31.**

## Census
backend_fail **170→148**, elf_ok 68→72. The 17 demos that moved to crash_runtime are self-contained programs calling undefined test fns (single-module limit) — now compiling past the backend, exiting non-zero (expected, not miscompiles).

## Note
`OpShr` → SAR (arithmetic/signed), matching existing `emit_binop_code`. Latent-wrong for `u64 >>` with high bit set; no type info at this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)