### PR TITLE
fix(parser): pt_read_kind missing impl/self/Self/type/loop keywords (#1 parse_fail cause)

### DIFF
--- a/self-hosted/parser/parser.sio
+++ b/self-hosted/parser/parser.sio
@@ -577,6 +577,15 @@ pub fn pt_read_kind(idx: i64) -> TokenKind with Panic {
             if a == (116 as i8) && b == (114 as i8) && c == (117 as i8) && d == (101 as i8) { return TokenKind::True }
             if a == (101 as i8) && b == (110 as i8) && c == (117 as i8) && d == (109 as i8) { return TokenKind::Enum }
             if a == (117 as i8) && b == (110 as i8) && c == (105 as i8) && d == (116 as i8) { return TokenKind::Unit }
+            // These length-4 keywords were present in the lexer table but MISSING here, so
+            // pt_read_kind (the authoritative peek/dispatch classifier) re-classified them as
+            // Ident — `impl` blocks never dispatched, and `self` params failed to parse
+            // (the else branch wanted `self : type`). Mirror the lexer for them.
+            if a == (105 as i8) && b == (109 as i8) && c == (112 as i8) && d == (108 as i8) { return TokenKind::Impl }        // "impl"
+            if a == (115 as i8) && b == (101 as i8) && c == (108 as i8) && d == (102 as i8) { return TokenKind::SelfLower }   // "self"
+            if a == (83 as i8)  && b == (101 as i8) && c == (108 as i8) && d == (102 as i8) { return TokenKind::SelfUpper }   // "Self"
+            if a == (116 as i8) && b == (121 as i8) && c == (112 as i8) && d == (101 as i8) { return TokenKind::Type }        // "type"
+            if a == (108 as i8) && b == (111 as i8) && c == (111 as i8) && d == (112 as i8) { return TokenKind::Loop }        // "loop"
         }
         if len == 5 {
             let a = CURSOR_SOURCE[start as usize]


### PR DESCRIPTION
## What
`pt_read_kind` (the authoritative classifier `parser_peek`/`Parser::peek` use) re-derives each token kind from source bytes, but its **length-4 keyword block was missing `impl`, `self`, `Self`, `type`, `loop`** — they re-classified as `Ident`.

## Impact
- **`impl` blocks never dispatched** (`parse_item` saw `Ident`) → every method-bearing program failed to parse. **#1 parse_fail root cause** and a hard **self-hosting blocker** (mc couldn't parse its own impl/self source).
- **`fn foo(self)` failed**: `parse_param`'s `SelfLower` branch never fired → it demanded `self: type`.

Same class as the earlier const/kernel/extern fixes. `self` *expressions* are unaffected (expr parser already maps `SelfLower`→`ExprIdent "self"`); the checker binds self-params via the `is_self` flag.

## Verified
- `loop { ... break }` compiles + runs (exit 5)
- `--check` now **parses** impl/self method programs (3 items, no parse error — was parse_failed)
- **capgate 31/31**

## Known next gap (honest)
Method *calls* (`p.g()`, even static `P::five()`) now parse + check + lower + emit ELF, but the emitted code **SIGSEGVs at runtime** — native-v2 method-call codegen was never reachable before and needs work. Method programs move parse_failed → runtime-crash (parse layer now correct; codegen is the next target). `loop`/`type` are complete wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)