### PR TITLE
fix(lower): native-v2 method calls resolve to mangled body, else fail closed

### DIFF
--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -2072,6 +2072,27 @@ pub fn ir_name_eq(a: Name, b: Name) -> bool with Mut, Panic, Div {
     true
 }
 
+// True if `full` is a mangled method name `Type_<method>` for this method — i.e. `full`
+// ends with `method` and the char just before is `_`. Used to resolve native-v2 method
+// calls (bare method name) back to a registered mangled method body.
+pub fn ir_name_ends_with_method(full: Name, method: Name) -> bool with Mut, Panic, Div {
+    if full.len <= method.len {
+        return false
+    }
+    let sep_idx = full.len - method.len - 1
+    if full.buf[sep_idx] != (95 as i8) {   // '_'
+        return false
+    }
+    var k: i64 = 0
+    while k < method.len {
+        if full.buf[(sep_idx + 1 + k) as usize] != method.buf[k as usize] {
+            return false
+        }
+        k = k + 1
+    }
+    true
+}
+
 pub fn ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut, Panic, Div {
     var n = Name { buf: [0; 128], len: len }
     if len > 0 { n.buf[0] = a }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2845,6 +2845,31 @@ impl Lowerer {
         }
     }
 
+    // Resolve a method call to an already-registered (mangled) method body WITHOUT minting
+    // a stub. Methods are preseeded under `Type_method` names, but native-v2 has no receiver
+    // type to mangle with, so match by name: exact, or a fn whose name ends in `_<method>`.
+    // Return the index ONLY if EXACTLY ONE candidate matches (otherwise the dispatch would be
+    // ambiguous and silently wrong — `len`/`push`/`get` collide across types); return -1 to
+    // let the caller fail closed. Never returns a fresh stub (calling an empty body SIGSEGVs).
+    fn resolve_method_fn_id(self, method_name: Name) -> i64 with Mut, Panic, Div {
+        var found: i64 = -1
+        var count: i64 = 0
+        var i: i64 = 0
+        while i < (*self.module).fn_count {
+            let fname = (*self.module).functions[i as usize].name
+            if ir_name_eq(fname, method_name) || ir_name_ends_with_method(fname, method_name) {
+                found = i
+                count = count + 1
+            }
+            i = i + 1
+        }
+        if count == 1 {
+            found
+        } else {
+            -1
+        }
+    }
+
     fn fn_ends_with_return(self) -> bool with Mut, Panic, Div {
         if self.current_fn < 0 || self.current_fn >= self.module.fn_count {
             return false
@@ -6068,9 +6093,14 @@ impl Lowerer {
             let arg_list: Option<Box<IrRegList>> = if pair_args.count <= 0 { None } else { Some(Box::new(pair_args.regs)) }
             let arg_count = pair_args.count
             let args2 = lo2.prepend_arg(base_reg, arg_list)
-            let pair_fn = lo2.find_or_add_fn_id(e.name)
-            let lo3 = pair_fn.0
-            let fn_id = pair_fn.1
+            // Resolve to an already-registered (mangled) method body; do NOT mint a stub.
+            // An unresolved or ambiguous method fails CLOSED (report_error -> ir_bodies_failed,
+            // no ELF) instead of emitting a call into an empty body that SIGSEGVs at runtime.
+            let fn_id = lo2.resolve_method_fn_id(e.name)
+            if fn_id < 0 {
+                return lo2.report_error().emit_unit()
+            }
+            let lo3 = lo2
             let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args2, arg_count + 1)
             let lo4 = pair_call.lo
             let final_args = pair_call.args


### PR DESCRIPTION
## What
After #258 let `impl`/`self` parse, method calls reached native-v2 lowering and **SIGSEGV'd at runtime**: `ExprMethodCall` did `find_or_add_fn_id(e.name)` with the **bare** name (`"g"`), but methods are preseeded/emitted only under **mangled** names (`"P_g"`). The bare lookup matched nothing and **minted an empty stub**; the call jumped into that empty body → crash.

## Fix
native-v2 has no receiver type (it skips the checker), so it can't mangle. Resolve by **suffix**: a registered fn whose name `== method` or ends in `_<method>`. Use it **only if exactly one** candidate matches (correct); on zero or ambiguous (`>1` — e.g. `len`/`push`/`get` colliding across types) **fail closed** (`report_error` → `ir_bodies_failed`, no ELF). Never mint a stub. New: `Lowerer::resolve_method_fn_id` + `ir_name_ends_with_method`.

## Verified (source→ELF)
- single-impl `p.g()`=7, `p.add(3)`=10 now **run correctly**
- two structs each with `g()` → **NO-ELF** (ambiguous, fails closed — was SIGSEGV)
- `loop`=5
- **No more segfaulting method binaries** — method programs are now correct or graceful-fail, never crash.

Change is in the native-v2 `ExprMethodCall` arm only; checker/summary path untouched (`--check` on methods still parses+checks).

## Note
The build I tested (mc_mm) showed capgate 30/31 due to a **concurrent agent's in-progress f64 work** in `codegen_x86_linux.sio` (uncommitted in the shared worktree — it swaps the f64 binop dispatch to an incomplete `nc_emit_core_float_binop`, breaking `16_float`). That change is **not** part of this PR (only `lower.sio` + `ir.sio` are committed); the committed branch keeps the working `nc_emit_core_binop_f64` path. This fix is f64-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)