### PR TITLE
fix(lower): compound assignment ignored the operator (silent miscompile)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4437,7 +4437,19 @@ impl Lowerer {
                                     (lo, dst)
                                 }
                             } else {
-                                lo = lo.emit(ir_copy(dst, rhs))
+                                // Compound assignment (`a += b`, `a *= b`, …): the op was
+                                // being IGNORED — only the rhs was copied, so `a += 5`
+                                // silently became `a = 5`. Apply the op: `dst = dst OP rhs`.
+                                if s.assign_op == AssignOp::AssignEq {
+                                    lo = lo.emit(ir_copy(dst, rhs))
+                                } else {
+                                    var bop = BinaryOp::OpAdd
+                                    if s.assign_op == AssignOp::AssignSub { bop = BinaryOp::OpSub }
+                                    else if s.assign_op == AssignOp::AssignMul { bop = BinaryOp::OpMul }
+                                    else if s.assign_op == AssignOp::AssignDiv { bop = BinaryOp::OpDiv }
+                                    else if s.assign_op == AssignOp::AssignRem { bop = BinaryOp::OpRem }
+                                    lo = lo.emit(ir_binop(dst, dst, bop, rhs))
+                                }
                                 (lo, dst)
                             }
                         }
@@ -4449,8 +4461,28 @@ impl Lowerer {
                                 lo = pair_base.0
                                 let base_reg = pair_base.1
                                 let fidx = lo.field_idx_from_name_simple((*target_expr).name)
-                                lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
-                                (lo, rhs)
+                                if s.assign_op == AssignOp::AssignEq {
+                                    lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
+                                    (lo, rhs)
+                                } else {
+                                    // Compound `obj.f OP= rhs`: read the field, apply the op,
+                                    // write back (was ignoring the op = silently `obj.f = rhs`).
+                                    let pc = lo.fresh_reg()
+                                    lo = pc.0
+                                    let cur = pc.1
+                                    lo = lo.emit(ir_field_get(cur, base_reg, fidx, (*target_expr).name))
+                                    var bop = BinaryOp::OpAdd
+                                    if s.assign_op == AssignOp::AssignSub { bop = BinaryOp::OpSub }
+                                    else if s.assign_op == AssignOp::AssignMul { bop = BinaryOp::OpMul }
+                                    else if s.assign_op == AssignOp::AssignDiv { bop = BinaryOp::OpDiv }
+                                    else if s.assign_op == AssignOp::AssignRem { bop = BinaryOp::OpRem }
+                                    let pr = lo.fresh_reg()
+                                    lo = pr.0
+                                    let res = pr.1
+                                    lo = lo.emit(ir_binop(res, cur, bop, rhs))
+                                    lo = lo.emit(ir_field_set(base_reg, fidx, res, (*target_expr).name))
+                                    (lo, res)
+                                }
                             }
                             _ => (lo.report_error(), rhs),
                         }
@@ -4461,8 +4493,28 @@ impl Lowerer {
                         let pair_idx = lo.lower_opt_expr_ref(&(*target_expr).right)
                         lo = pair_idx.0
                         let idx_reg = pair_idx.1
-                        lo = lo.emit(ir_index_set(base_reg, idx_reg, rhs))
-                        (lo, rhs)
+                        if s.assign_op == AssignOp::AssignEq {
+                            lo = lo.emit(ir_index_set(base_reg, idx_reg, rhs))
+                            (lo, rhs)
+                        } else {
+                            // Compound `arr[i] OP= rhs`: read the element, apply the op,
+                            // write it back (was ignoring the op = silently `arr[i] = rhs`).
+                            let pc = lo.fresh_reg()
+                            lo = pc.0
+                            let cur = pc.1
+                            lo = lo.emit(ir_index_get(cur, base_reg, idx_reg))
+                            var bop = BinaryOp::OpAdd
+                            if s.assign_op == AssignOp::AssignSub { bop = BinaryOp::OpSub }
+                            else if s.assign_op == AssignOp::AssignMul { bop = BinaryOp::OpMul }
+                            else if s.assign_op == AssignOp::AssignDiv { bop = BinaryOp::OpDiv }
+                            else if s.assign_op == AssignOp::AssignRem { bop = BinaryOp::OpRem }
+                            let pr = lo.fresh_reg()
+                            lo = pr.0
+                            let res = pr.1
+                            lo = lo.emit(ir_binop(res, cur, bop, rhs))
+                            lo = lo.emit(ir_index_set(base_reg, idx_reg, res))
+                            (lo, res)
+                        }
                 } else {
                     lo = lo.report_error()
                     (lo, rhs)


### PR DESCRIPTION
## What
`lower_assign_stmt_ref` lowered only the RHS and copied it to the target, **ignoring `s.assign_op`**. So `a += 5` silently became `a = 5`, `a *= 3` → `a = 3`, etc. — **wrong values, no crash**.

Confirmed before: `a=10; a+=5` → 5 (want 15); `a=4; a*=3` → 3 (want 12); `a=17; a%=5` → 5 (want 2).

## Fix
Apply the operator for all three assignable targets — local var (`ExprIdent`), array element (`ExprIndex`), struct field (`ExprFieldAccess`): when `assign_op != AssignEq`, emit `dst = dst OP rhs` (read-modify-write for index/field via `ir_index_get`/`ir_field_get` + `ir_binop` + set).

## Verified (source→ELF)
`a+=5`→**15**, `a*=3`→12, `a%=5`→2, `arr[i]+=5`→25, `obj.f+=5`→15; plain `a=5`→5 (unchanged). Wide-int (i128) compound assign left as a follow-up (rare; needs limb-wise adc/sbb).

## Note
`lower.sio` only. capgate's `16_float` failure in the shared worktree is a concurrent agent's unfinished f64 dispatch change in `codegen_x86_linux.sio`, not part of this commit — the committed branch keeps the working f64 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)