### PR TITLE
feat: compound bitwise assignment (&= |= ^= <<= >>=)

### DIFF
--- a/self-hosted/check/compat.sio
+++ b/self-hosted/check/compat.sio
@@ -1028,6 +1028,11 @@ pub fn compound_assign_to_binop(op: AssignOp) -> BinaryOp {
         AssignOp::AssignMul => BinaryOp::OpMul
         AssignOp::AssignDiv => BinaryOp::OpDiv
         AssignOp::AssignRem => BinaryOp::OpRem
+        AssignOp::AssignBitAnd => BinaryOp::OpBitAnd
+        AssignOp::AssignBitOr => BinaryOp::OpBitOr
+        AssignOp::AssignBitXor => BinaryOp::OpBitXor
+        AssignOp::AssignShl => BinaryOp::OpShl
+        AssignOp::AssignShr => BinaryOp::OpShr
         AssignOp::AssignEq => BinaryOp::OpAdd  // should not happen, fallback
     }
 }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4448,6 +4448,11 @@ impl Lowerer {
                                     else if s.assign_op == AssignOp::AssignMul { bop = BinaryOp::OpMul }
                                     else if s.assign_op == AssignOp::AssignDiv { bop = BinaryOp::OpDiv }
                                     else if s.assign_op == AssignOp::AssignRem { bop = BinaryOp::OpRem }
+                                    else if s.assign_op == AssignOp::AssignBitAnd { bop = BinaryOp::OpBitAnd }
+                                    else if s.assign_op == AssignOp::AssignBitOr { bop = BinaryOp::OpBitOr }
+                                    else if s.assign_op == AssignOp::AssignBitXor { bop = BinaryOp::OpBitXor }
+                                    else if s.assign_op == AssignOp::AssignShl { bop = BinaryOp::OpShl }
+                                    else if s.assign_op == AssignOp::AssignShr { bop = BinaryOp::OpShr }
                                     lo = lo.emit(ir_binop(dst, dst, bop, rhs))
                                 }
                                 (lo, dst)
@@ -4476,6 +4481,11 @@ impl Lowerer {
                                     else if s.assign_op == AssignOp::AssignMul { bop = BinaryOp::OpMul }
                                     else if s.assign_op == AssignOp::AssignDiv { bop = BinaryOp::OpDiv }
                                     else if s.assign_op == AssignOp::AssignRem { bop = BinaryOp::OpRem }
+                                    else if s.assign_op == AssignOp::AssignBitAnd { bop = BinaryOp::OpBitAnd }
+                                    else if s.assign_op == AssignOp::AssignBitOr { bop = BinaryOp::OpBitOr }
+                                    else if s.assign_op == AssignOp::AssignBitXor { bop = BinaryOp::OpBitXor }
+                                    else if s.assign_op == AssignOp::AssignShl { bop = BinaryOp::OpShl }
+                                    else if s.assign_op == AssignOp::AssignShr { bop = BinaryOp::OpShr }
                                     let pr = lo.fresh_reg()
                                     lo = pr.0
                                     let res = pr.1
@@ -4508,6 +4518,11 @@ impl Lowerer {
                             else if s.assign_op == AssignOp::AssignMul { bop = BinaryOp::OpMul }
                             else if s.assign_op == AssignOp::AssignDiv { bop = BinaryOp::OpDiv }
                             else if s.assign_op == AssignOp::AssignRem { bop = BinaryOp::OpRem }
+                            else if s.assign_op == AssignOp::AssignBitAnd { bop = BinaryOp::OpBitAnd }
+                            else if s.assign_op == AssignOp::AssignBitOr { bop = BinaryOp::OpBitOr }
+                            else if s.assign_op == AssignOp::AssignBitXor { bop = BinaryOp::OpBitXor }
+                            else if s.assign_op == AssignOp::AssignShl { bop = BinaryOp::OpShl }
+                            else if s.assign_op == AssignOp::AssignShr { bop = BinaryOp::OpShr }
                             let pr = lo.fresh_reg()
                             lo = pr.0
                             let res = pr.1

--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -325,6 +325,11 @@ pub enum AssignOp {
     AssignMul,
     AssignDiv,
     AssignRem,
+    AssignBitAnd,
+    AssignBitOr,
+    AssignBitXor,
+    AssignShl,
+    AssignShr,
 }
 
 pub struct Stmt {

--- a/self-hosted/parser/parser.sio
+++ b/self-hosted/parser/parser.sio
@@ -715,6 +715,18 @@ pub fn parser_assign_op_code(p: Parser) -> i64 with Panic {
             if a == (42 as i8) { return 3 }
             if a == (47 as i8) { return 4 }
             if a == (37 as i8) { return 5 }
+            if a == (38 as i8) { return 6 }    // &=
+            if a == (124 as i8) { return 7 }   // |=
+            if a == (94 as i8) { return 8 }    // ^=
+        }
+    }
+    if len == 3 {
+        let a = CURSOR_SOURCE[start as usize]
+        let b = CURSOR_SOURCE[(start + 1) as usize]
+        let c = CURSOR_SOURCE[(start + 2) as usize]
+        if c == (61 as i8) {
+            if a == (60 as i8) && b == (60 as i8) { return 9 }    // <<=
+            if a == (62 as i8) && b == (62 as i8) { return 10 }   // >>=
         }
     }
     -1

--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -216,6 +216,11 @@ fn parse_assign_op(kind: TokenKind) -> AssignOp {
         TokenKind::StarEq => AssignOp::AssignMul,
         TokenKind::SlashEq => AssignOp::AssignDiv,
         TokenKind::PercentEq => AssignOp::AssignRem,
+        TokenKind::AmpEq => AssignOp::AssignBitAnd,
+        TokenKind::PipeEq => AssignOp::AssignBitOr,
+        TokenKind::CaretEq => AssignOp::AssignBitXor,
+        TokenKind::ShlEq => AssignOp::AssignShl,
+        TokenKind::ShrEq => AssignOp::AssignShr,
         _ => AssignOp::AssignEq,
     }
 }
@@ -226,6 +231,11 @@ fn assign_op_from_code(code: i64) -> AssignOp {
     if code == 3 { return AssignOp::AssignMul }
     if code == 4 { return AssignOp::AssignDiv }
     if code == 5 { return AssignOp::AssignRem }
+    if code == 6 { return AssignOp::AssignBitAnd }
+    if code == 7 { return AssignOp::AssignBitOr }
+    if code == 8 { return AssignOp::AssignBitXor }
+    if code == 9 { return AssignOp::AssignShl }
+    if code == 10 { return AssignOp::AssignShr }
     AssignOp::AssignEq
 }
 


### PR DESCRIPTION
## What
`+= -= *= /= %=` worked but bitwise/shift compound assignments were **parse_failed**: `parser_assign_op_code` only recognized the len-2 arithmetic ops (no len-3 branch for `<<=`/`>>=`), and `AssignOp` had no bitwise variants.

## Wired end-to-end
- **AssignOp** += `AssignBitAnd/BitOr/BitXor/Shl/Shr` (ast.sio)
- **parser_assign_op_code**: `&= |= ^=` (len 2, codes 6–8) + new len-3 branch for `<<= >>=` (codes 9–10); `assign_op_from_code` maps 6–10; `parse_assign_op` maps the tokens (parser.sio/stmts.sio)
- **lower_assign_stmt_ref**: the compound read-modify-write (from the prior compound-assign fix) maps the 5 new ops to `OpBitAnd/Or/Xor/Shl/Shr` across all three targets — var / array elem / struct field (lower.sio)
- **compound_assign_to_binop**: 5 new match arms for `--check` (compat.sio)

## Verified (source→ELF)
`a=12; a&=10`→**8**; `a|=3`→15; `a^=10`→6; `a<<=4`→16; `a>>=2`→16; `a+=5`→15 (arithmetic compound unchanged). Uses the `OpBitAnd`/`OpShl`/… backend emitters from #254.

## Note
capgate's `16_float` failure is the concurrent agent's unfinished f64 change in `codegen_x86_linux.sio` (shared worktree), not this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)