### PR TITLE
fix(lexer): flat lexer crashed on binary/octal/underscore/char literals

### DIFF
--- a/self-hosted/lexer/mod.sio
+++ b/self-hosted/lexer/mod.sio
@@ -644,8 +644,38 @@ pub fn lex_source_to_globals(source_len: i64) -> i64 with Mut, Div, Panic {
                 tc = tc + 1
                 continue
             }
-            while pos < n && is_digit(CURSOR_SOURCE[pos as usize]) {
-                value = value * 10 + ((CURSOR_SOURCE[pos as usize] - 48 as i8) as i64)
+            if ch == 48 as i8 && pos + 1 < n &&
+               (CURSOR_SOURCE[(pos + 1) as usize] == 98 as i8 || CURSOR_SOURCE[(pos + 1) as usize] == 66 as i8) {  // 0b / 0B
+                pos = pos + 2
+                col = col + 2
+                while pos < n && (is_bin_digit(CURSOR_SOURCE[pos as usize]) || CURSOR_SOURCE[pos as usize] == 95 as i8) {
+                    let bc = CURSOR_SOURCE[pos as usize]
+                    if bc != 95 as i8 { value = value * 2 + ((bc - 48 as i8) as i64) }
+                    pos = pos + 1
+                    col = col + 1
+                }
+                parser_set_token_flat(tc, 124, start, pos, line, start_col, value)
+                tc = tc + 1
+                continue
+            }
+            if ch == 48 as i8 && pos + 1 < n &&
+               (CURSOR_SOURCE[(pos + 1) as usize] == 111 as i8 || CURSOR_SOURCE[(pos + 1) as usize] == 79 as i8) {  // 0o / 0O
+                pos = pos + 2
+                col = col + 2
+                while pos < n && (is_oct_digit(CURSOR_SOURCE[pos as usize]) || CURSOR_SOURCE[pos as usize] == 95 as i8) {
+                    let oc = CURSOR_SOURCE[pos as usize]
+                    if oc != 95 as i8 { value = value * 8 + ((oc - 48 as i8) as i64) }
+                    pos = pos + 1
+                    col = col + 1
+                }
+                parser_set_token_flat(tc, 124, start, pos, line, start_col, value)
+                tc = tc + 1
+                continue
+            }
+            // Decimal digits, skipping `_` separators (1_000 -> 1000).
+            while pos < n && (is_digit(CURSOR_SOURCE[pos as usize]) || CURSOR_SOURCE[pos as usize] == 95 as i8) {
+                let dc = CURSOR_SOURCE[pos as usize]
+                if dc != 95 as i8 { value = value * 10 + ((dc - 48 as i8) as i64) }
                 pos = pos + 1
                 col = col + 1
             }
@@ -683,6 +713,40 @@ pub fn lex_source_to_globals(source_len: i64) -> i64 with Mut, Div, Panic {
                 col = col + 1
             }
             parser_set_token_flat(tc, 126, start, pos, line, start_col, 0)
+            tc = tc + 1
+            continue
+        }
+
+        if ch == 39 as i8 {  // '\'' — char literal. The flat lexer had no handler, so
+            // `'A'` split into `'`/`A`/`'` punctuation tokens and crashed downstream.
+            let start = pos
+            let start_col = col
+            pos = pos + 1
+            col = col + 1
+            var cval: i64 = 0
+            if pos < n {
+                if CURSOR_SOURCE[pos as usize] == 92 as i8 && pos + 1 < n {  // backslash escape
+                    let e = CURSOR_SOURCE[(pos + 1) as usize]
+                    if e == 110 as i8 { cval = 10 }        // \n
+                    else if e == 116 as i8 { cval = 9 }    // \t
+                    else if e == 114 as i8 { cval = 13 }   // \r
+                    else if e == 48 as i8 { cval = 0 }     // \0
+                    else if e == 92 as i8 { cval = 92 }    // backslash
+                    else if e == 39 as i8 { cval = 39 }    // \'
+                    else { cval = (e as i64) }
+                    pos = pos + 2
+                    col = col + 2
+                } else {
+                    cval = (CURSOR_SOURCE[pos as usize] as i64)
+                    pos = pos + 1
+                    col = col + 1
+                }
+            }
+            if pos < n && CURSOR_SOURCE[pos as usize] == 39 as i8 {  // closing '
+                pos = pos + 1
+                col = col + 1
+            }
+            parser_set_token_flat(tc, 127, start, pos, line, start_col, cval)
             tc = tc + 1
             continue
         }


### PR DESCRIPTION
## What
The flat tokenizer `lex_source_to_globals` (the path MC actually uses) handled `0x` hex but **not** `0b`/`0o` prefixes, `_` digit separators, or char literals:
- `0b1010` lexed as `0` + `b1010` (identifier); `0o17` as `0` + `o17`
- `1_000` as `1` + `_000`
- `'A'` fell through to punctuation, splitting into `'` `A` `'`

All four then **SIGSEGV'd** native-v2 downstream (`--check` survived; the value was just garbage). Diagnosed by instrumenting `ExprIntLit` lowering — `e.int_val` came back **0** (0b/0o, scan stopped at the prefix letter) and **1** (`1_000`, stopped at `_`): pure decimal-up-to-first-nondigit.

## Fix (lexer only)
Mirror the existing `0x` block + `scan_number`:
- `0b`/`0B` → base-2 accumulate, skip `_`
- `0o`/`0O` → base-8 accumulate, skip `_`
- decimal → skip `_` separators (`1_000`→1000)
- `'c'` → char token (code 127 = CharLit) with the char code as value, incl. `\n \t \r \0 \\ \'` escapes

(`pt_read_kind` already re-classifies the now-correct span as BinLit/OctLit/CharLit for dispatch.)

## Verified (source→ELF)
`0b1010`=10, `0o17`=15, `1_000`=1000, `'A' as i64`=65, `'A'=='A'`→7, `1_0`=10; `0xFF`=255 and plain decimals unchanged. **capgate**'s `16_float` failure is the concurrent agent's f64 change in `codegen_x86_linux.sio`, not this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)