### PR TITLE
feat(lower): for-in over an inferred-type array local (let a = [..])

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4387,7 +4387,20 @@ impl Lowerer {
                     }
                 }
             }
-            None => {}
+            None => {
+                // Inferred array: `let a = [e0, e1, ...]` with no `[T; N]` annotation.
+                // Count the initializer literal's elements so `for x in a` can bound
+                // its index loop, mirroring the annotated case above.
+                let init_opt: Option<Box<Expr> > = s.expr
+                match init_opt {
+                    Some(initbox) => {
+                        if (*initbox).kind == ExprKind::ExprArrayLit {
+                            lo = lo.set_top_elem_count(count_expr_list_ref(&(*initbox).args))
+                        }
+                    }
+                    None => {}
+                }
+            }
         }
         (lo, reg)
     }


### PR DESCRIPTION
#252 handled annotated `let a: [T; N]`; an inferred `let a = [10,20,30]` (no annotation) left the element count untracked → `for x in a` hit ir_bodies_failed. Now the no-annotation arm of `lower_let_stmt_ref` counts the ExprArrayLit initializer. Verified: `let a=[10,20,30]; for x in a{s+=x}`=60 (was ir_bodies_failed), `[1,2,3,4,5]`=15; annotated/direct-literal unchanged. Coordinated with the concurrent Card B lane targeting the same gap. capgate 16_float = agent's f64, not this commit. lower.sio only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)