### PR TITLE
fix(parser): drop unsafe assignment lookahead + for-in over sized array params (Card B)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2569,6 +2569,26 @@ impl Lowerer {
         lo
     }
 
+    // Static element count of a `[T; N]` array type (N a literal), else 0. Lets a
+    // sized-array FUNCTION PARAMETER (`fn f(a: [i64; 3])`) carry its length so
+    // `for x in a` can bound an index loop — the param analogue of the let-binding
+    // elem_count tracking. (from the Card B lane)
+    fn type_array_literal_elem_count(self, ty: &TypeExpr) -> i64 with Mut, Panic, Div, Alloc {
+        if (*ty).kind != TypeExprKind::TypeArray {
+            return 0
+        }
+        let sz_opt: Option<Box<Expr> > = (*ty).array_size
+        match sz_opt {
+            Some(szbox) => {
+                if (*szbox).kind == ExprKind::ExprIntLit {
+                    return (*szbox).int_val
+                }
+            }
+            None => {}
+        }
+        0
+    }
+
     fn enter_scope(self) -> Lowerer with Mut {
         var lo = self
         lo.scope_depth = lo.scope_depth + 1
@@ -3740,6 +3760,8 @@ impl Lowerer {
                         locals.names[idx as usize] = (*list).head.name
                         locals.regs[idx as usize] = preg
                         locals.depths[idx as usize] = lo.scope_depth
+                        locals.limbs[idx as usize] = 0
+                        locals.elem_counts[idx as usize] = lo.type_array_literal_elem_count(&(*list).head.ty)
                         locals.count = idx + 1
                     } else {
                         lo = lo.report_error()

--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -216,13 +216,11 @@ impl Parser {
             else if ak == TokenKind::SlashEq { assign_code = 4 }
             else if ak == TokenKind::PercentEq { assign_code = 5 }
         }
-        if assign_code < 0 && p1.pos >= 0 && p1.pos + 1 < p1.token_count {
-            let next_code = PT_KIND_CODE[(p1.pos + 1) as usize]
-            if next_code == 137 || next_code == 154 || next_code == 155 || next_code == 156 || next_code == 157 || next_code == 168 {
-                assign_p = parser_advance(p1)
-                assign_code = parser_assign_op_code(assign_p)
-            }
-        }
+        // Only an assignment operator at the CURRENT parser position binds this
+        // expression. The old one-token lookahead (if the NEXT token was an
+        // assign-op) made `if cond { } <newline> x = ...` parse as a bogus
+        // assignment to the whole `if` expression — the top ir_bodies_failed
+        // cluster (300314 ExprIf / 300316 ExprWhile / 300313 ExprCall targets).
         if assign_code >= 0 {
             // Assignment
             stmt_store_assign_target(parser_take_expr_box())

--- a/tests/native_v2_capgate/32_for_in_array_literal.sio
+++ b/tests/native_v2_capgate/32_for_in_array_literal.sio
@@ -1,0 +1,8 @@
+fn main() -> i64 {
+    let data = [1, 2, 3]
+    var total: i64 = 0
+    for v in data {
+        total = total + v
+    }
+    total
+}

--- a/tests/native_v2_capgate/EXPECTED.txt
+++ b/tests/native_v2_capgate/EXPECTED.txt
@@ -29,3 +29,4 @@
 29_wide_i128_var_assign 2
 30_wide_i128_divfull 5
 31_wide_i128_modfull 183
+32_for_in_array_literal 6


### PR DESCRIPTION
Two fixes from the Card B lane, taken over and landed on `feat` after the #266 card-a merge re-introduced the lookahead bug into the trunk.

## 1. Assignment-lookahead regression (the big one)
`parse_expr_or_assign_stmt` looked one token **ahead** and, if the next token was an assign-op, treated the just-parsed expression as the assignment target. That turned `if cond { } <newline> x = ...` into a bogus assignment to the whole `if` expression → `ir_bodies_failed`. This was the **top repeatable cluster** (300314 ExprIf / 300316 ExprWhile / 300313 ExprCall targets), and the #266 merge had brought it onto `feat` via Card A's parser.

Removed the lookahead — only an assign-op at the **current** position binds. Verified `if 1<2 {x=5} x=9; x` = 9 (was ir_bodies_failed); while/call variants likewise.

## 2. for-in over sized array parameters
`fn f(a: [i64; 3])` now carries its element count (`type_array_literal_elem_count` helper wired into param binding) so `for x in a` bounds an index loop — the param analogue of #252/#265. Verified `sum([10,20,30])` = 60.

Plus capgate fixture `32_for_in_array_literal` (inferred-array for-in → 6).

## Verified
**capgate 32/32.** My earlier PRs (literals/escapes/compound-assign/method/for-in) and Card A's parser coverage (generics, tuple destructure) all intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)