### PR TITLE
feat(epistemic): non-associativity feeds uncertainty (associator → variance)

### DIFF
--- a/docs/design/native_visual_frontend_roadmap.md
+++ b/docs/design/native_visual_frontend_roadmap.md
@@ -1,0 +1,23 @@
+# Native Visual Frontend Roadmap
+
+Sounio visualization is moving from chart helpers to a native visual frontend.
+
+## V1: CPU Canvas
+
+- Visual IR in `stdlib/viz/ir.sio`.
+- Native renderer in `stdlib/viz/viz_canvas.sio`.
+- Scientific layers in `stdlib/viz/physchem.sio` and existing `viz::sci`.
+- Headless CI proof through `tests/run-pass/viz_headless.sio`.
+- No display server required.
+
+## V1.5: Static HTML/SVG
+
+- `stdlib/viz/viz_html.sio` serializes the same Visual IR as static markup.
+- JavaScript is not used for scientific semantics.
+- Exported markup can be viewed externally, but the model remains Sounio data.
+
+## V2: GPU Renderer
+
+Deferred until general `bin/souc --backend gpu` wiring exists for ordinary programs.
+
+GPU work should add a renderer over Visual IR, not move molecule, field, unit, uncertainty, or simulation semantics into shader-side ad hoc state.

--- a/examples/viz_3d/main.sio
+++ b/examples/viz_3d/main.sio
@@ -7,24 +7,61 @@
 use display::window::{Window, window_open, window_set_title, window_present, window_pending,
                        window_next_event, window_close}
 use display::canvas::{Canvas, canvas_from_window, canvas_clear}
+use display::canvas_ext::{canvas_draw_line_aa}
 use display::event::{EV_CLOSE, EV_KEY_PRESS}
-use render::renderer3d::{Camera3D, Light3D, Tri3D, Vec3f,
-                          r3d_depth_buf_alloc, r3d_depth_buf_clear, r3d_render,
-                          r3d_sqrt, r3d_normalise}
+use render::renderer3d::{Camera3D, Light3D, Vec3f,
+                          r3d_depth_buf_alloc, r3d_depth_buf_clear,
+                          r3d_project, r3d_shade, r3d_rasterize_tri_gouraud,
+                          r3d_normalise}
 
 // ============================================================
 // Rotation helpers (Y and X axis)
 // ============================================================
 
-fn rot_cos(t: f64) -> f64 with Div {
-    // cos via Taylor: 1 - t²/2 + t⁴/24 - t⁶/720
+// Taylor series accurate on [0, π/2]; combined with quadrant reduction below.
+fn trig_core_cos(t: f64) -> f64 with Div {
     let t2 = t * t
-    1.0 - t2 * (0.5 - t2 * (1.0 / 24.0 - t2 / 720.0))
+    1.0 - t2 * (0.5 - t2 * (1.0 / 24.0 - t2 * (1.0 / 720.0 - t2 / 40320.0)))
+}
+fn trig_core_sin(t: f64) -> f64 with Div {
+    let t2 = t * t
+    t * (1.0 - t2 * (1.0 / 6.0 - t2 * (1.0 / 120.0 - t2 * (1.0 / 5040.0 - t2 / 362880.0))))
 }
 
-fn rot_sin(t: f64) -> f64 with Div {
-    let t2 = t * t
-    t * (1.0 - t2 * (1.0 / 6.0 - t2 * (1.0 / 120.0 - t2 / 5040.0)))
+fn rot_cos(t: f64) -> f64 with Mut, Div {
+    let half_pi: f64 = 1.57079632679490
+    let pi: f64 = 3.14159265358979
+    let two_pi: f64 = 6.28318530717958
+    var a: f64 = t
+    if a > two_pi { a = a - two_pi }
+    if a < 0.0 { a = a + two_pi }
+    if a <= half_pi {
+        trig_core_cos(a)
+    } else if a <= pi {
+        0.0 - trig_core_cos(pi - a)
+    } else if a <= pi + half_pi {
+        0.0 - trig_core_cos(a - pi)
+    } else {
+        trig_core_cos(two_pi - a)
+    }
+}
+
+fn rot_sin(t: f64) -> f64 with Mut, Div {
+    let half_pi: f64 = 1.57079632679490
+    let pi: f64 = 3.14159265358979
+    let two_pi: f64 = 6.28318530717958
+    var a: f64 = t
+    if a > two_pi { a = a - two_pi }
+    if a < 0.0 { a = a + two_pi }
+    if a <= half_pi {
+        trig_core_sin(a)
+    } else if a <= pi {
+        trig_core_sin(pi - a)
+    } else if a <= pi + half_pi {
+        0.0 - trig_core_sin(a - pi)
+    } else {
+        0.0 - trig_core_sin(two_pi - a)
+    }
 }
 
 fn rotate_y(x: f64, y: f64, z: f64, angle: f64, out: &!Vec3f) with Mut, Div {
@@ -64,84 +101,109 @@ fn cross_norm(
 //   B = ( √(8/9),  -1/3,  0)
 //   C = (-√(2/9), -1/3,  √(2/3))
 //   D = (-√(2/9), -1/3, -√(2/3))
+//
+// Vertex normals = normalised average of 3 adjacent face normals.
+// Combined with per-face base colours and r3d_shade, this gives Gouraud
+// shading: smooth gradients + Blinn-Phong specular that travels around.
 
-fn tet_build(tris: &![Tri3D; 4096], ry: f64, rx: f64) -> i64 with Mut, Div {
-    // Vertex model positions
-    let ax: f64 = 0.0;       let ay: f64 = 1.0;        let az: f64 = 0.0
+fn tet_draw_gouraud(
+    angle_y: f64, angle_x: f64,
+    cam: &Camera3D, light: &Light3D,
+    depth_buf: *mut i64, c: &!Canvas,
+) with Mut, Div {
+    let ax: f64 = 0.0;       let ay: f64 = 1.0;             let az: f64 = 0.0
     let bx: f64 = 0.942809;  let by: f64 = 0.0 - 0.333333;  let bz: f64 = 0.0
     let cx: f64 = 0.0 - 0.471405; let cy: f64 = 0.0 - 0.333333; let cz: f64 = 0.816497
     let dx: f64 = 0.0 - 0.471405; let dy: f64 = 0.0 - 0.333333; let dz: f64 = 0.0 - 0.816497
 
-    // Apply rotation (Y then X)
     var ra = Vec3f { x: 0.0, y: 0.0, z: 0.0 }
     var rb = Vec3f { x: 0.0, y: 0.0, z: 0.0 }
     var rc = Vec3f { x: 0.0, y: 0.0, z: 0.0 }
     var rd = Vec3f { x: 0.0, y: 0.0, z: 0.0 }
-
     var tmp = Vec3f { x: 0.0, y: 0.0, z: 0.0 }
 
-    rotate_y(ax, ay, az, ry, &!tmp)
-    rotate_x(tmp.x, tmp.y, tmp.z, rx, &!ra)
+    rotate_y(ax, ay, az, angle_y, &!tmp)
+    rotate_x(tmp.x, tmp.y, tmp.z, angle_x, &!ra)
+    rotate_y(bx, by, bz, angle_y, &!tmp)
+    rotate_x(tmp.x, tmp.y, tmp.z, angle_x, &!rb)
+    rotate_y(cx, cy, cz, angle_y, &!tmp)
+    rotate_x(tmp.x, tmp.y, tmp.z, angle_x, &!rc)
+    rotate_y(dx, dy, dz, angle_y, &!tmp)
+    rotate_x(tmp.x, tmp.y, tmp.z, angle_x, &!rd)
 
-    rotate_y(bx, by, bz, ry, &!tmp)
-    rotate_x(tmp.x, tmp.y, tmp.z, rx, &!rb)
-
-    rotate_y(cx, cy, cz, ry, &!tmp)
-    rotate_x(tmp.x, tmp.y, tmp.z, rx, &!rc)
-
-    rotate_y(dx, dy, dz, ry, &!tmp)
-    rotate_x(tmp.x, tmp.y, tmp.z, rx, &!rd)
-
-    // Scale and translate; camera at pos_z=20, tz=5 → depth≈15, scale≈27 px/unit
-    let scale: f64 = 2.5
+    let scale: f64 = 2.0
     let tz: f64 = 5.0
-
     let va_x = ra.x * scale; let va_y = ra.y * scale; let va_z = ra.z * scale + tz
     let vb_x = rb.x * scale; let vb_y = rb.y * scale; let vb_z = rb.z * scale + tz
     let vc_x = rc.x * scale; let vc_y = rc.y * scale; let vc_z = rc.z * scale + tz
     let vd_x = rd.x * scale; let vd_y = rd.y * scale; let vd_z = rd.z * scale + tz
 
-    // Face 0: A-B-C (red) — outward normal points away from D: use (C-A)×(B-A)
+    // Face normals (outward)
+    // Face 0: A-B-C  Face 1: A-B-D  Face 2: A-C-D  Face 3: B-C-D
     let n0 = cross_norm(vc_x - va_x, vc_y - va_y, vc_z - va_z,
                         vb_x - va_x, vb_y - va_y, vb_z - va_z)
-    (*tris)[0] = Tri3D {
-        v0x: va_x, v0y: va_y, v0z: va_z,
-        v1x: vb_x, v1y: vb_y, v1z: vb_z,
-        v2x: vc_x, v2y: vc_y, v2z: vc_z,
-        nx: n0.x, ny: n0.y, nz: n0.z,
-        base_r: 220, base_g: 80, base_b: 60,
-    }
-    // Face 1: A-B-D (green)
     let n1 = cross_norm(vb_x - va_x, vb_y - va_y, vb_z - va_z,
                         vd_x - va_x, vd_y - va_y, vd_z - va_z)
-    (*tris)[1] = Tri3D {
-        v0x: va_x, v0y: va_y, v0z: va_z,
-        v1x: vb_x, v1y: vb_y, v1z: vb_z,
-        v2x: vd_x, v2y: vd_y, v2z: vd_z,
-        nx: n1.x, ny: n1.y, nz: n1.z,
-        base_r: 80, base_g: 200, base_b: 120,
-    }
-    // Face 2: A-C-D (blue) — outward normal points away from B: use (D-A)×(C-A)
     let n2 = cross_norm(vd_x - va_x, vd_y - va_y, vd_z - va_z,
                         vc_x - va_x, vc_y - va_y, vc_z - va_z)
-    (*tris)[2] = Tri3D {
-        v0x: va_x, v0y: va_y, v0z: va_z,
-        v1x: vc_x, v1y: vc_y, v1z: vc_z,
-        v2x: vd_x, v2y: vd_y, v2z: vd_z,
-        nx: n2.x, ny: n2.y, nz: n2.z,
-        base_r: 80, base_g: 140, base_b: 255,
-    }
-    // Face 3: B-C-D (yellow)
     let n3 = cross_norm(vc_x - vb_x, vc_y - vb_y, vc_z - vb_z,
                         vd_x - vb_x, vd_y - vb_y, vd_z - vb_z)
-    (*tris)[3] = Tri3D {
-        v0x: vb_x, v0y: vb_y, v0z: vb_z,
-        v1x: vc_x, v1y: vc_y, v1z: vc_z,
-        v2x: vd_x, v2y: vd_y, v2z: vd_z,
-        nx: n3.x, ny: n3.y, nz: n3.z,
-        base_r: 255, base_g: 220, base_b: 60,
-    }
-    4
+
+    // Vertex normals: A∈{0,1,2}  B∈{0,1,3}  C∈{0,2,3}  D∈{1,2,3}
+    let vna = r3d_normalise(n0.x+n1.x+n2.x, n0.y+n1.y+n2.y, n0.z+n1.z+n2.z)
+    let vnb = r3d_normalise(n0.x+n1.x+n3.x, n0.y+n1.y+n3.y, n0.z+n1.z+n3.z)
+    let vnc = r3d_normalise(n0.x+n2.x+n3.x, n0.y+n2.y+n3.y, n0.z+n2.z+n3.z)
+    let vnd = r3d_normalise(n1.x+n2.x+n3.x, n1.y+n2.y+n3.y, n1.z+n2.z+n3.z)
+
+    // Project all 4 vertices to screen
+    let pa = r3d_project(va_x, va_y, va_z, cam, c.width, c.height)
+    let pb = r3d_project(vb_x, vb_y, vb_z, cam, c.width, c.height)
+    let pc = r3d_project(vc_x, vc_y, vc_z, cam, c.width, c.height)
+    let pd = r3d_project(vd_x, vd_y, vd_z, cam, c.width, c.height)
+
+    // Face 0: A-B-C (red 220,80,60)
+    let f0a = r3d_shade(220, 80, 60, vna.x, vna.y, vna.z, light)
+    let f0b = r3d_shade(220, 80, 60, vnb.x, vnb.y, vnb.z, light)
+    let f0c = r3d_shade(220, 80, 60, vnc.x, vnc.y, vnc.z, light)
+    r3d_rasterize_tri_gouraud(
+        pa.x as i64, pa.y as i64, pb.x as i64, pb.y as i64, pc.x as i64, pc.y as i64,
+        pa.z, pb.z, pc.z, f0a, f0b, f0c, depth_buf, c)
+    canvas_draw_line_aa(c, pa.x as i64, pa.y as i64, pb.x as i64, pb.y as i64, 66, 24, 18)
+    canvas_draw_line_aa(c, pb.x as i64, pb.y as i64, pc.x as i64, pc.y as i64, 66, 24, 18)
+    canvas_draw_line_aa(c, pc.x as i64, pc.y as i64, pa.x as i64, pa.y as i64, 66, 24, 18)
+
+    // Face 1: A-B-D (green 80,200,120)
+    let f1a = r3d_shade(80, 200, 120, vna.x, vna.y, vna.z, light)
+    let f1b = r3d_shade(80, 200, 120, vnb.x, vnb.y, vnb.z, light)
+    let f1d = r3d_shade(80, 200, 120, vnd.x, vnd.y, vnd.z, light)
+    r3d_rasterize_tri_gouraud(
+        pa.x as i64, pa.y as i64, pb.x as i64, pb.y as i64, pd.x as i64, pd.y as i64,
+        pa.z, pb.z, pd.z, f1a, f1b, f1d, depth_buf, c)
+    canvas_draw_line_aa(c, pa.x as i64, pa.y as i64, pb.x as i64, pb.y as i64, 24, 60, 36)
+    canvas_draw_line_aa(c, pb.x as i64, pb.y as i64, pd.x as i64, pd.y as i64, 24, 60, 36)
+    canvas_draw_line_aa(c, pd.x as i64, pd.y as i64, pa.x as i64, pa.y as i64, 24, 60, 36)
+
+    // Face 2: A-C-D (blue 80,140,255)
+    let f2a = r3d_shade(80, 140, 255, vna.x, vna.y, vna.z, light)
+    let f2c = r3d_shade(80, 140, 255, vnc.x, vnc.y, vnc.z, light)
+    let f2d = r3d_shade(80, 140, 255, vnd.x, vnd.y, vnd.z, light)
+    r3d_rasterize_tri_gouraud(
+        pa.x as i64, pa.y as i64, pc.x as i64, pc.y as i64, pd.x as i64, pd.y as i64,
+        pa.z, pc.z, pd.z, f2a, f2c, f2d, depth_buf, c)
+    canvas_draw_line_aa(c, pa.x as i64, pa.y as i64, pc.x as i64, pc.y as i64, 24, 42, 76)
+    canvas_draw_line_aa(c, pc.x as i64, pc.y as i64, pd.x as i64, pd.y as i64, 24, 42, 76)
+    canvas_draw_line_aa(c, pd.x as i64, pd.y as i64, pa.x as i64, pa.y as i64, 24, 42, 76)
+
+    // Face 3: B-C-D (yellow 255,220,60)
+    let f3b = r3d_shade(255, 220, 60, vnb.x, vnb.y, vnb.z, light)
+    let f3c = r3d_shade(255, 220, 60, vnc.x, vnc.y, vnc.z, light)
+    let f3d = r3d_shade(255, 220, 60, vnd.x, vnd.y, vnd.z, light)
+    r3d_rasterize_tri_gouraud(
+        pb.x as i64, pb.y as i64, pc.x as i64, pc.y as i64, pd.x as i64, pd.y as i64,
+        pb.z, pc.z, pd.z, f3b, f3c, f3d, depth_buf, c)
+    canvas_draw_line_aa(c, pb.x as i64, pb.y as i64, pc.x as i64, pc.y as i64, 76, 66, 18)
+    canvas_draw_line_aa(c, pc.x as i64, pc.y as i64, pd.x as i64, pd.y as i64, 76, 66, 18)
+    canvas_draw_line_aa(c, pd.x as i64, pd.y as i64, pb.x as i64, pb.y as i64, 76, 66, 18)
 }
 
 // ============================================================
@@ -175,20 +237,11 @@ fn main() with IO, Alloc, Mut, Div {
         dy: 0.577350,
         dz: 0.577350,
         r: 255, g: 255, b: 255,
-        ambient: 0.45,
+        ambient: 0.22,
     }
 
-    var tris: [Tri3D; 4096] = [Tri3D {
-        v0x: 0.0, v0y: 0.0, v0z: 0.0,
-        v1x: 0.0, v1y: 0.0, v1z: 0.0,
-        v2x: 0.0, v2y: 0.0, v2z: 0.0,
-        nx: 0.0, ny: 0.0, nz: 1.0,
-        base_r: 0, base_g: 0, base_b: 0,
-    }; 4096]
-
-    var n_tris: i64 = 0
     var angle_y: f64 = 0.6
-    var angle_x: f64 = 0.4
+    var angle_x: f64 = 0.3
 
     var running = true
     while running {
@@ -202,14 +255,15 @@ fn main() with IO, Alloc, Mut, Div {
         canvas_clear(&!c, 18, 20, 30)
         r3d_depth_buf_clear(depth_buf, W, H)
 
-        n_tris = tet_build(&!tris, angle_y, angle_x)
-        r3d_render(&tris, n_tris, &cam, &light, depth_buf, &!c)
+        tet_draw_gouraud(angle_y, angle_x, &cam, &light, depth_buf, &!c)
 
         window_present(&!win)
 
-        // Advance rotation (approx 1°/frame)
+        // Tumble: Y ~1°/frame, X ~0.4°/frame — shows all faces and specular highlights
         angle_y = angle_y + 0.017453
         if angle_y > 6.28318 { angle_y = angle_y - 6.28318 }
+        angle_x = angle_x + 0.004
+        if angle_x > 6.28318 { angle_x = angle_x - 6.28318 }
     }
 
     heap_free(depth_buf as *mut i8)

--- a/examples/viz_html_export/main.sio
+++ b/examples/viz_html_export/main.sio
@@ -1,0 +1,47 @@
+// examples/viz_html_export/main.sio — static HTML/SVG export over Visual IR
+
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_scene_set_time, viz_add_line_chart, viz_add_heatmap, viz_add_control, viz_add_molecule, viz_add_scalar_field, viz_add_vector_field, viz_add_trajectory, viz_add_spectrum, viz_add_mesh, VIZ_CONTROL_BUTTON}
+use viz::viz_html::{viz_html_emit_scene}
+use viz::physchem::{molecule_h2o, scalar_field_radial, vector_field_vortex, trajectory_spiral, spectrum_absorption_demo}
+use render::renderer3d::{Tri3D}
+
+fn main() with IO, Mut, Div {
+    var scene = viz_scene_new()
+    var xs: [f64; 1024] = [0.0; 1024]
+    var ys: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 8 {
+        xs[i as usize] = i as f64
+        ys[i as usize] = (i * i) as f64
+        i = i + 1
+    }
+    var hm: [f64; 4096] = [0.0; 4096]
+    var hmi: i64 = 0
+    while hmi < 16 {
+        hm[hmi as usize] = hmi as f64
+        hmi = hmi + 1
+    }
+    let mol = molecule_h2o()
+    let field = scalar_field_radial(4, 4)
+    let vectors = vector_field_vortex(4, 4)
+    let traj = trajectory_spiral(18)
+    let spectrum = spectrum_absorption_demo(32)
+    var tris: [Tri3D; 128] = [Tri3D {
+        v0x: -0.3, v0y: -0.3, v0z: -2.0,
+        v1x: 0.3, v1y: -0.3, v1z: -2.0,
+        v2x: 0.0, v2y: 0.3, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 170, base_g: 220, base_b: 130,
+    }; 128]
+    viz_scene_set_time(&!scene, 6.0)
+    viz_add_line_chart(&!scene, &xs, &ys, 8, viz_layout_rect(20, 20, 160, 70), viz_style_rgb(255, 120, 80))
+    viz_add_spectrum(&!scene, spectrum, viz_layout_rect(20, 88, 160, 28))
+    viz_add_heatmap(&!scene, &hm, 4, 4, 0.0, 15.0, viz_layout_rect(20, 128, 72, 52))
+    viz_add_molecule(&!scene, mol, viz_layout_rect(110, 128, 48, 52), viz_style_rgb(210, 220, 240))
+    viz_add_scalar_field(&!scene, field, viz_layout_rect(172, 128, 48, 52))
+    viz_add_vector_field(&!scene, vectors, viz_layout_rect(232, 128, 48, 52))
+    viz_add_trajectory(&!scene, traj, viz_layout_rect(184, 84, 96, 32))
+    viz_add_mesh(&!scene, &tris, 1, viz_layout_rect(204, 24, 56, 56), viz_style_rgb(170, 220, 130))
+    viz_add_control(&!scene, VIZ_CONTROL_BUTTON, viz_layout_rect(20, 188, 80, 16), 0.0, 0.0, 1.0)
+    viz_html_emit_scene(&scene, 300, 210)
+}

--- a/examples/viz_lab/main.sio
+++ b/examples/viz_lab/main.sio
@@ -1,0 +1,81 @@
+// examples/viz_lab/main.sio — native visual frontend smoke demo
+
+use display::canvas::{Canvas, canvas_clear}
+use display::event::{Event, EV_MOUSE_PRESS, EV_MOTION, MOUSE_LEFT}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_add_line_chart, viz_add_uncertainty_band, viz_add_heatmap, viz_add_control, viz_add_molecule, viz_add_scalar_field, viz_add_mesh, viz_scene_set_time, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TABS, VIZ_CONTROL_TOGGLE}
+use viz::viz_app::{viz_app_new, viz_app_handle_event}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::physchem::{molecule_h2o, scalar_field_radial}
+use render::renderer3d::{Tri3D}
+
+fn lab_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn lab_read(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn lab_event(kind: i64, key: i64, x: i64, y: i64) -> Event {
+    Event { kind: kind, key: key, x: x, y: y, mods: 0 }
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var c = lab_canvas(320, 240)
+    canvas_clear(&!c, 8, 12, 18)
+    var app = viz_app_new(8, 12, 18)
+
+    var scene = viz_scene_new()
+    var xs: [f64; 1024] = [0.0; 1024]
+    var ys: [f64; 1024] = [0.0; 1024]
+    var vars: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 16 {
+        xs[i as usize] = i as f64
+        ys[i as usize] = 4.0 + (i as f64) * 0.25
+        vars[i as usize] = 0.05 + (i as f64) * 0.01
+        i = i + 1
+    }
+
+    let mol = molecule_h2o()
+    let field = scalar_field_radial(8, 8)
+    assert(mol.atom_count == 3)
+    var tris: [Tri3D; 128] = [Tri3D {
+        v0x: -0.35, v0y: -0.30, v0z: -2.0,
+        v1x: 0.35, v1y: -0.30, v1z: -2.0,
+        v2x: 0.0, v2y: 0.35, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 170, base_g: 220, base_b: 130,
+    }; 128]
+    viz_scene_set_time(&!scene, 2.0)
+    viz_add_line_chart(&!scene, &xs, &ys, 16, viz_layout_rect(16, 16, 130, 80), viz_style_rgb(255, 140, 90))
+    viz_add_uncertainty_band(&!scene, &xs, &ys, &vars, 16, viz_layout_rect(164, 16, 130, 80), viz_style_rgb(90, 190, 255))
+    viz_add_heatmap(&!scene, &field.values, field.rows, field.cols, field.min_value, field.max_value, viz_layout_rect(16, 116, 110, 80))
+    viz_add_molecule(&!scene, mol, viz_layout_rect(148, 168, 72, 54), viz_style_rgb(210, 220, 240))
+    viz_add_scalar_field(&!scene, field, viz_layout_rect(236, 168, 64, 54))
+    viz_add_mesh(&!scene, &tris, 1, viz_layout_rect(112, 104, 72, 54), viz_style_rgb(170, 220, 130))
+    let slider_id = viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(156, 130, 120, 22), scene.time, 0.0, 10.0)
+    let tabs_id = viz_add_control(&!scene, VIZ_CONTROL_TABS, viz_layout_rect(16, 204, 108, 20), 0.0, 0.0, 3.0)
+    let toggle_id = viz_add_control(&!scene, VIZ_CONTROL_TOGGLE, viz_layout_rect(236, 132, 28, 18), 0.0, 0.0, 1.0)
+    assert(viz_app_handle_event(&!app, &!scene, lab_event(EV_MOUSE_PRESS, MOUSE_LEFT, 168, 140)))
+    assert(scene.selected_node == slider_id)
+    assert(viz_app_handle_event(&!app, &!scene, lab_event(EV_MOTION, 0, 216, 140)))
+    assert(scene.time == 5.0)
+    assert(viz_app_handle_event(&!app, &!scene, lab_event(EV_MOUSE_PRESS, MOUSE_LEFT, 98, 212)))
+    assert(scene.selected_node == tabs_id)
+    assert(scene.active_tab == 3)
+    assert(viz_app_handle_event(&!app, &!scene, lab_event(EV_MOUSE_PRESS, MOUSE_LEFT, 244, 140)))
+    assert(scene.selected_node == toggle_id)
+    assert(scene.nodes[toggle_id as usize].value == 1.0)
+    assert(app.dirty)
+
+    canvas_clear(&!c, app.bg_r, app.bg_g, app.bg_b)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(lab_read(&c, 30, 30) != 0)
+    assert(lab_read(&c, 20, 120) != 0)
+    assert(lab_read(&c, 160, 195) != 0)
+
+    heap_free(c.pixels as *mut i8)
+    println("VIZ_LAB_READY")
+}

--- a/examples/viz_lab_window/main.sio
+++ b/examples/viz_lab_window/main.sio
@@ -1,0 +1,73 @@
+// examples/viz_lab_window/main.sio - optional native Visual IR window demo
+//
+// Compile-gated only in CI. Run manually with DISPLAY set.
+
+use display::window::{window_open, window_set_title, window_close}
+use render::renderer3d::{Tri3D}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_add_line_chart, viz_add_uncertainty_band, viz_add_control, viz_add_molecule, viz_add_scalar_field, viz_add_mesh, viz_scene_set_time, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TABS, VIZ_CONTROL_TOGGLE}
+use viz::viz_app::{viz_app_new}
+use viz::viz_window::{viz_window_step}
+use viz::physchem::{molecule_h2o, scalar_field_radial}
+
+fn main() with IO, Alloc, Mut, Div {
+    let W: i64 = 420
+    let H: i64 = 280
+
+    var title: [i8; 128] = [0; 128]
+    title[0] = 83   // S
+    title[1] = 111  // o
+    title[2] = 117  // u
+    title[3] = 110  // n
+    title[4] = 105  // i
+    title[5] = 111  // o
+    title[6] = 32
+    title[7] = 86   // V
+    title[8] = 105  // i
+    title[9] = 122  // z
+    title[10] = 32
+    title[11] = 76  // L
+    title[12] = 97  // a
+    title[13] = 98  // b
+    let title_len: i64 = 14
+
+    var win = window_open(W, H)
+    window_set_title(&!win, &title, title_len)
+
+    var app = viz_app_new(8, 12, 18)
+    var scene = viz_scene_new()
+    var xs: [f64; 1024] = [0.0; 1024]
+    var ys: [f64; 1024] = [0.0; 1024]
+    var vars: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 16 {
+        xs[i as usize] = i as f64
+        ys[i as usize] = 2.0 + (i as f64) * 0.35
+        vars[i as usize] = 0.08 + (i as f64) * 0.01
+        i = i + 1
+    }
+
+    let mol = molecule_h2o()
+    let field = scalar_field_radial(8, 8)
+    var tris: [Tri3D; 128] = [Tri3D {
+        v0x: -0.35, v0y: -0.30, v0z: -2.0,
+        v1x: 0.35, v1y: -0.30, v1z: -2.0,
+        v2x: 0.0, v2y: 0.35, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 170, base_g: 220, base_b: 130,
+    }; 128]
+    viz_scene_set_time(&!scene, 2.0)
+    viz_add_line_chart(&!scene, &xs, &ys, 16, viz_layout_rect(20, 20, 170, 90), viz_style_rgb(255, 140, 90))
+    viz_add_uncertainty_band(&!scene, &xs, &ys, &vars, 16, viz_layout_rect(220, 20, 170, 90), viz_style_rgb(90, 190, 255))
+    viz_add_molecule(&!scene, mol, viz_layout_rect(30, 140, 90, 70), viz_style_rgb(210, 220, 240))
+    viz_add_scalar_field(&!scene, field, viz_layout_rect(150, 140, 90, 70))
+    viz_add_mesh(&!scene, &tris, 1, viz_layout_rect(326, 204, 64, 64), viz_style_rgb(170, 220, 130))
+    viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(260, 142, 120, 22), scene.time, 0.0, 10.0)
+    viz_add_control(&!scene, VIZ_CONTROL_TABS, viz_layout_rect(260, 178, 120, 22), 0.0, 0.0, 3.0)
+    viz_add_control(&!scene, VIZ_CONTROL_TOGGLE, viz_layout_rect(260, 214, 32, 18), 0.0, 0.0, 1.0)
+
+    while app.running {
+        viz_window_step(&!app, &!scene, &!win, 32)
+    }
+
+    window_close(&!win)
+}

--- a/examples/viz_physchem_demo/main.sio
+++ b/examples/viz_physchem_demo/main.sio
@@ -1,0 +1,90 @@
+// examples/viz_physchem_demo/main.sio - Physico-chemistry Visual IR demo
+
+use display::canvas::{Canvas, canvas_clear}
+use render::renderer3d::{Tri3D}
+use viz::ir::{
+    viz_scene_new, viz_layout_rect, viz_style_rgb, viz_scene_set_time,
+    viz_add_line_chart, viz_add_uncertainty_band,
+    viz_add_molecule, viz_add_scalar_field, viz_add_vector_field,
+    viz_add_trajectory, viz_add_spectrum, viz_add_mesh,
+}
+use viz::physchem::{
+    molecule_h2o, molecule_rapamycin_coarse, scalar_field_radial,
+    vector_field_vortex, trajectory_spiral, spectrum_absorption_demo,
+}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::viz_html::{viz_html_emit_scene}
+
+fn demo_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn demo_read(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var scene = viz_scene_new()
+    viz_scene_set_time(&!scene, 9.0)
+
+    let water = molecule_h2o()
+    let rapamycin = molecule_rapamycin_coarse()
+    let scalar = scalar_field_radial(8, 8)
+    let vectors = vector_field_vortex(6, 6)
+    let trajectory = trajectory_spiral(32)
+    let spectrum = spectrum_absorption_demo(48)
+
+    var t: [f64; 1024] = [0.0; 1024]
+    var mean: [f64; 1024] = [0.0; 1024]
+    var variance: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 16 {
+        t[i as usize] = i as f64
+        mean[i as usize] = 2.0 + (i as f64) * 0.18
+        variance[i as usize] = 0.04 + (i as f64) * 0.004
+        i = i + 1
+    }
+
+    var tris: [Tri3D; 128] = [Tri3D {
+        v0x: -0.35, v0y: -0.35, v0z: -2.0,
+        v1x: 0.35, v1y: -0.35, v1z: -2.0,
+        v2x: 0.0, v2y: 0.35, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 170, base_g: 220, base_b: 130,
+    }; 128]
+
+    viz_add_molecule(&!scene, water, viz_layout_rect(12, 12, 72, 60), viz_style_rgb(210, 220, 240))
+    viz_add_molecule(&!scene, rapamycin, viz_layout_rect(98, 12, 112, 60), viz_style_rgb(180, 210, 160))
+    viz_add_scalar_field(&!scene, scalar, viz_layout_rect(12, 92, 72, 64))
+    viz_add_vector_field(&!scene, vectors, viz_layout_rect(98, 92, 72, 64))
+    viz_add_trajectory(&!scene, trajectory, viz_layout_rect(184, 92, 104, 64))
+    viz_add_spectrum(&!scene, spectrum, viz_layout_rect(12, 174, 160, 36))
+    viz_add_mesh(&!scene, &tris, 1, viz_layout_rect(202, 12, 72, 60), viz_style_rgb(170, 220, 130))
+    viz_add_line_chart(&!scene, &t, &mean, 16, viz_layout_rect(184, 174, 104, 36), viz_style_rgb(255, 150, 90))
+    viz_add_uncertainty_band(&!scene, &t, &mean, &variance, 16, viz_layout_rect(12, 226, 276, 36), viz_style_rgb(90, 190, 255))
+
+    assert(scene.molecule_count == 2)
+    assert(scene.field_count == 1)
+    assert(scene.vector_field_count == 1)
+    assert(scene.trajectory_count == 1)
+    assert(scene.spectrum_count == 1)
+    assert(scene.mesh_count == 1)
+
+    var c = demo_canvas(300, 280)
+    canvas_clear(&!c, 5, 8, 12)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(demo_read(&c, 48, 42) != 0)
+    assert(demo_read(&c, 150, 42) != 0)
+    assert(demo_read(&c, 24, 104) != 0)
+    assert(demo_read(&c, 98, 92) != 0)
+    assert(demo_read(&c, 184, 92) != 0)
+    assert(demo_read(&c, 12, 174) != 0)
+    assert(demo_read(&c, 238, 42) != 0)
+    assert(demo_read(&c, 200, 190) != 0)
+    assert(demo_read(&c, 24, 240) != 0)
+    heap_free(c.pixels as *mut i8)
+
+    viz_html_emit_scene(&scene, 300, 280)
+    println("VIZ_PHYSCHEM_DEMO_READY")
+}

--- a/stdlib/display/canvas_ext.sio
+++ b/stdlib/display/canvas_ext.sio
@@ -1,7 +1,7 @@
 // stdlib/display/canvas_ext.sio — Extended canvas drawing primitives
 //
-// Adds antialiased lines, filled triangle, and Surface→Canvas blit
-// on top of the base canvas.sio API.
+// Adds antialiased lines, filled triangle, Surface→Canvas blit,
+// and Phong-shaded sphere primitive.
 //
 // Pixel format (same as canvas.sio): lower 32 bits = 0x00RRGGBB
 //   B in byte 0, G in byte 1, R in byte 2.
@@ -219,5 +219,98 @@ pub fn canvas_blit_surface(
             sx = sx + 1
         }
         sy = sy + 1
+    }
+}
+
+// ============================================================
+// Phong-shaded sphere — for molecular / 3D atom rendering
+// ============================================================
+//
+// Light L = (0.447, -0.632, 0.632): upper-left-front, normalized.
+// Blinn-Phong half-vector H = normalize(L + V) ≈ (0.247, -0.350, 0.903).
+// Shading: ambient=0.32 + Lambertian diffuse + Blinn-Phong specular^32.
+// Soft rim darkening: (nz*0.35 + 0.65) keeps dark atoms visible.
+
+fn sph_sqrt(x: f64) -> f64 with Div {
+    if x <= 0.0 { return 0.0 }
+    var g: f64 = 0.6
+    g = (g + x / g) * 0.5
+    g = (g + x / g) * 0.5
+    g = (g + x / g) * 0.5
+    g = (g + x / g) * 0.5
+    g = (g + x / g) * 0.5
+    g
+}
+
+// Renders a Blinn-Phong-shaded sphere at (cx,cy) with radius r.
+pub fn canvas_sphere_shaded(
+    c: &!Canvas,
+    cx: i64, cy: i64, r: i64,
+    base_r: i64, base_g: i64, base_b: i64,
+) with Mut, Div {
+    if r <= 0 { return }
+    let r_f: f64 = r as f64
+    let r2   = r * r
+
+    // Light direction — upper-left-front, normalised (0.447, -0.632, 0.632)
+    let lx: f64 =         0.447
+    let ly: f64 = 0.0 - 0.632
+    // Blinn-Phong half-vector H = normalize(L + V), V = (0,0,1)
+    // H ≈ (0.247, -0.350, 0.903) — precomputed constant
+    let hx: f64 =         0.247
+    let hy: f64 = 0.0 - 0.350
+    let hz: f64 =         0.903
+
+    let ambient:  f64 = 0.32
+    let spec_str: f64 = 0.90
+
+    let x_min = cext_clamp(cx - r, 0, c.width  - 1)
+    let x_max = cext_clamp(cx + r, 0, c.width  - 1)
+    let y_min = cext_clamp(cy - r, 0, c.height - 1)
+    let y_max = cext_clamp(cy + r, 0, c.height - 1)
+
+    var py = y_min
+    while py <= y_max {
+        var px = x_min
+        while px <= x_max {
+            let dx = px - cx
+            let dy = py - cy
+            if dx * dx + dy * dy <= r2 {
+                let nx_f = (dx as f64) / r_f
+                let ny_f = (dy as f64) / r_f
+                let nz2  = 1.0 - nx_f * nx_f - ny_f * ny_f
+                let nz_f = sph_sqrt(nz2)
+
+                // Lambertian diffuse: N · L (lz=0.632)
+                let ndotl   = nx_f * lx + ny_f * ly + nz_f * 0.632
+                let diffuse = if ndotl > 0.0 { ndotl } else { 0.0 }
+
+                // Blinn-Phong specular: (N · H)^32
+                let ndoth = nx_f * hx + ny_f * hy + nz_f * hz
+                let s1 = if ndoth > 0.0 { ndoth } else { 0.0 }
+                let s2 = s1 * s1
+                let s4 = s2 * s2
+                let s8 = s4 * s4
+                let s16 = s8 * s8
+                let s32 = s16 * s16
+
+                // Soft rim: keeps silhouette visible (nz*0.35+0.65 maps [0,1]→[0.65,1])
+                let rim = nz_f * 0.35 + 0.65
+
+                let intensity = (ambient + (1.0 - ambient) * diffuse) * rim
+
+                let fr = (base_r as f64) * intensity + 255.0 * spec_str * s32
+                let fg = (base_g as f64) * intensity + 255.0 * spec_str * s32
+                let fb = (base_b as f64) * intensity + 255.0 * spec_str * s32
+
+                let ir = if fr > 255.0 { 255 } else { fr as i64 }
+                let ig = if fg > 255.0 { 255 } else { fg as i64 }
+                let ib = if fb > 255.0 { 255 } else { fb as i64 }
+
+                write_i64(c.pixels, py * c.width + px, ib | (ig << 8) | (ir << 16))
+            }
+            px = px + 1
+        }
+        py = py + 1
     }
 }

--- a/stdlib/display/canvas_ext.sio
+++ b/stdlib/display/canvas_ext.sio
@@ -231,7 +231,7 @@ pub fn canvas_blit_surface(
 // Shading: ambient=0.32 + Lambertian diffuse + Blinn-Phong specular^32.
 // Soft rim darkening: (nz*0.35 + 0.65) keeps dark atoms visible.
 
-fn sph_sqrt(x: f64) -> f64 with Div {
+fn sph_sqrt(x: f64) -> f64 with Mut, Div {
     if x <= 0.0 { return 0.0 }
     var g: f64 = 0.6
     g = (g + x / g) * 0.5

--- a/stdlib/epistemic/perturbation_graph.sio
+++ b/stdlib/epistemic/perturbation_graph.sio
@@ -1,0 +1,104 @@
+// stdlib/epistemic/perturbation_graph.sio — order-safe uncertain octonion products
+//
+// The value-semantics UncertainOct (uncertain_octonion.sio) is order-NAIVE under
+// binary chaining: a.mul(b).mul(c) cannot add the structural term, because the
+// intermediate product has forgotten its operands. This module fixes that by
+// giving each value IDENTITY in a perturbation DAG — a Wengert tape: a flat arena
+// of nodes addressed by index (no Box-per-node, so it avoids the large-boxed-
+// struct codegen hazard; the arena is mutated through a bare `&!` param, the safe
+// deref-store path).
+//
+// Each product node records its two operands. When a product node (a·b) is
+// multiplied by c, the triple (a,b,c) is recoverable from the graph, so the
+// regrouping associator κ·‖[a,b,c]‖² is added automatically — at every internal
+// node, for ANY association. Binary chaining becomes order-safe: ((a·b)·c) and
+// (a·(b·c)) carry the same total variance, equal to the explicit mul3.
+//
+// This is the runtime correlation graph: a type cannot see correlation, so the
+// VALUE must carry identity. No new algebra — reuses algebra::octonion.
+//
+// Execution-verified (self-contained build): left chain, right chain, and mul3
+// all yield 4.75 for a non-Fano triple (σ²=0.25 each, κ=1); Fano triple yields
+// 0.75; the order-naive binary would drop to 0.75. All paths agree.
+
+use algebra::octonion::{oct_mul, oct_associator, oct_norm_sq}
+
+// Arena capacity: 64 nodes (vals flattened to 64 * 8 = 512 f64).
+pub struct PerturbGraph {
+    count: i64,
+    vals: [f64; 512],   // node n, component c, at vals[n*8 + c]
+    pvar: [f64; 64],    // per-node variance budget
+    kind: [i64; 64],    // 0 = leaf, 1 = product
+    lc:   [i64; 64],    // left operand index  (products only)
+    rc:   [i64; 64],    // right operand index (products only)
+}
+
+pub fn pg_new() -> PerturbGraph {
+    PerturbGraph { count: 0, vals: [0.0; 512], pvar: [0.0; 64], kind: [0; 64], lc: [0; 64], rc: [0; 64] }
+}
+
+fn pg_get(g: &!PerturbGraph, n: i64, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = g.vals[n * 8 + c]; c = c + 1 }
+}
+
+// Add a measured leaf octonion; returns its node index.
+pub fn pg_leaf(g: &!PerturbGraph, v: &[f64; 8], std_dev: f64) -> i64 with Mut {
+    let n = g.count
+    var c: i64 = 0
+    while c < 8 { g.vals[n * 8 + c] = v[c]; c = c + 1 }
+    g.pvar[n] = std_dev * std_dev
+    g.kind[n] = 0
+    g.count = n + 1
+    n
+}
+
+// Multiply nodes i and j; returns the product node. The regrouping associator is
+// added automatically for whichever operand is itself a product, so chaining is
+// order-safe:  Var = ‖j‖²·Var(i) + ‖i‖²·Var(j) + κ·(regrouping ‖α‖²).
+pub fn pg_mul(g: &!PerturbGraph, i: i64, j: i64, kappa: f64) -> i64 with Mut, Div, NonAssoc {
+    var vi: [f64; 8] = [0.0; 8]
+    pg_get(g, i, &!vi)
+    var vj: [f64; 8] = [0.0; 8]
+    pg_get(g, j, &!vj)
+    var prod: [f64; 8] = [0.0; 8]
+    oct_mul(&vi, &vj, &!prod)
+    let ni = oct_norm_sq(&vi)
+    let nj = oct_norm_sq(&vj)
+
+    var structural: f64 = 0.0
+    // left operand is a product (a·b): regrouping ambiguity is [a, b, j]
+    if g.kind[i] == 1 {
+        var la: [f64; 8] = [0.0; 8]
+        pg_get(g, g.lc[i], &!la)
+        var lb: [f64; 8] = [0.0; 8]
+        pg_get(g, g.rc[i], &!lb)
+        var as1: [f64; 8] = [0.0; 8]
+        oct_associator(&la, &lb, &vj, &!as1)
+        structural = structural + kappa * oct_norm_sq(&as1)
+    }
+    // right operand is a product (b·c): regrouping ambiguity is [i, b, c]
+    if g.kind[j] == 1 {
+        var ra: [f64; 8] = [0.0; 8]
+        pg_get(g, g.lc[j], &!ra)
+        var rb: [f64; 8] = [0.0; 8]
+        pg_get(g, g.rc[j], &!rb)
+        var as2: [f64; 8] = [0.0; 8]
+        oct_associator(&vi, &ra, &rb, &!as2)
+        structural = structural + kappa * oct_norm_sq(&as2)
+    }
+
+    let n = g.count
+    var c: i64 = 0
+    while c < 8 { g.vals[n * 8 + c] = prod[c]; c = c + 1 }
+    g.pvar[n] = nj * g.pvar[i] + ni * g.pvar[j] + structural
+    g.kind[n] = 1
+    g.lc[n] = i
+    g.rc[n] = j
+    g.count = n + 1
+    n
+}
+
+pub fn pg_variance(g: &!PerturbGraph, n: i64) -> f64 { g.pvar[n] }
+
+pub fn pg_component(g: &!PerturbGraph, n: i64, c: i64) -> f64 { g.vals[n * 8 + c] }

--- a/stdlib/epistemic/propagate.sio
+++ b/stdlib/epistemic/propagate.sio
@@ -11,6 +11,7 @@
 //! - Monte Carlo propagation for complex cases
 
 use epistemic::knowledge::{Epistemic, ep_clamp_conf, ep_min_conf, ep_decay, ep_combine};
+use algebra::associator_field::{assoc_field_octonion, af_augmented_variance};
 
 // ============================================================================
 // UNIVARIATE PROPAGATION
@@ -228,6 +229,50 @@ pub fn product_correlated(
         val: x.val * y.val,
         variance: max_f64(variance, 0.0),
         confidence: ep_combine(x.confidence, y.confidence),
+    }
+}
+
+// ============================================================================
+// NON-ASSOCIATIVE STRUCTURAL PROPAGATION
+// ============================================================================
+//
+// When a scalar observable is computed through a product of non-associative
+// quantities (octonions, sedenions), the *order* of multiplication is not
+// free: (a·b)·c ≠ a·(b·c). That order-indeterminacy is a genuine, structural
+// uncertainty on the result — distinct from measurement variance — and the
+// associator [a,b,c] = (a·b)·c − a·(b·c) measures it exactly.
+//
+// This is the join of the two theses the language is built on: non-associativity
+// is not merely *blocked* at the optimizer (the Fano reassociation gate in
+// ir/egraph.sio) — it *feeds* the uncertainty budget here. Certainty about
+// evaluation order is something you must earn (an associative / Fano triple,
+// where ‖α‖² = 0), not something assumed for convenience:
+//
+//   Var_total = Var_GUM + κ·‖[a,b,c]‖²
+//
+// Associative triple   ⇒ ‖α‖² = 0 ⇒ no augmentation (order was safe).
+// Non-associative triple ⇒ variance grows by exactly the order-ambiguity carried.
+//
+// The associator coupling itself is the verified primitive in
+// algebra::associator_field (window 7); this makes it a first-class propagation
+// rule alongside sum/product/quotient rather than a manual, opt-in call.
+
+// Augment a scalar observable's variance with the order-indeterminacy of the
+// non-associative octonion triple (a,b,c) it was computed through.
+// `base.val` is unchanged (the structural term is uncertainty, not a bias);
+// confidence passes through, since the order-ambiguity is expressed in the
+// variance channel per the GUM-augmentation model — not double-counted as a
+// separate confidence penalty.
+pub fn product_nonassoc(
+    base: Epistemic,
+    a: &[f64; 8], b: &[f64; 8], c: &[f64; 8],
+    kappa: f64,
+) -> Epistemic with Mut, Div, Panic, NonAssoc {
+    let field = assoc_field_octonion(a, b, c, kappa)
+    Epistemic {
+        val: base.val,
+        variance: af_augmented_variance(base.variance, &field),
+        confidence: base.confidence,
     }
 }
 

--- a/stdlib/epistemic/uncertain_octonion.sio
+++ b/stdlib/epistemic/uncertain_octonion.sio
@@ -1,0 +1,119 @@
+// stdlib/epistemic/uncertain_octonion.sio — uncertainty-carrying octonion
+//
+// UncertainOct is the octonion analogue of Epistemic (epistemic::knowledge):
+// an octonion value [f64; 8] bundled with a scalar variance budget. Its whole
+// reason to exist is that the multiplication operations fold non-associativity
+// into the variance *by construction* — you cannot form a triple product
+// without the order-ambiguity κ·‖[a,b,c]‖² being added to the result's
+// uncertainty. The synthesis ("associativity failure is a source of variance")
+// is not an opt-in helper here; it is what `mul3` IS.
+//
+// Variance model (first-order delta method on norms). Octonions form a
+// COMPOSITION algebra: ‖a·b‖ = ‖a‖·‖b‖. For c = a·b with independent
+// perturbations δa, δb, first order gives δc ≈ δa·b + a·δb, so
+//   Var(a·b) ≈ ‖b‖²·Var(a) + ‖a‖²·Var(b).
+// A triple product ((a·b)·c) applies this twice and then adds the structural
+// term — the part no binary rule can see, because non-associativity only
+// exists for three operands.
+//
+// No new algebra: reuses the verified primitives in algebra::octonion.
+
+use algebra::octonion::{oct_mul, oct_associator, oct_norm_sq}
+
+// Newton sqrt — matches the ep_sqrt / af_sqrt idiom elsewhere in the tree.
+fn uoct_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    var i = 0
+    while i < 30 { y = 0.5 * (y + x / y); i = i + 1 }
+    y
+}
+
+pub struct UncertainOct {
+    val: [f64; 8],   // the octonion value
+    variance: f64,   // scalar variance budget (σ²) on the octonion
+}
+
+impl UncertainOct {
+    // An exactly-known octonion (zero variance).
+    pub fn certain(v: [f64; 8]) -> UncertainOct {
+        UncertainOct { val: v, variance: 0.0 }
+    }
+
+    // A measured octonion with standard deviation std_dev on its magnitude.
+    pub fn measured(v: [f64; 8], std_dev: f64) -> UncertainOct {
+        UncertainOct { val: v, variance: std_dev * std_dev }
+    }
+
+    pub fn variance(self: &UncertainOct) -> f64 { self.variance }
+
+    pub fn component(self: &UncertainOct, i: i64) -> f64 { self.val[i] }
+
+    pub fn std(self: &UncertainOct) -> f64 with Mut, Div, Panic {
+        uoct_sqrt(self.variance)
+    }
+
+    pub fn norm(self: &UncertainOct) -> f64 with Mut, Div, Panic {
+        let v = self.val
+        uoct_sqrt(oct_norm_sq(&v))
+    }
+
+    // Binary product. Order-free (two operands have no associator), so it
+    // propagates only measurement variance:  Var(a·b) ≈ ‖b‖²Var(a)+‖a‖²Var(b).
+    // NOTE: chaining binaries — a.mul(b).mul(c) — is order-NAIVE: it cannot add
+    // the structural term, because at each step it sees only a product and one
+    // factor, never the triple. For a three-factor product use `mul3`, which is
+    // the order-aware primitive. (Removing this caveat needs a perturbation DAG.)
+    pub fn mul(self: &UncertainOct, other: &UncertainOct) -> UncertainOct
+        with Mut, Div, NonAssoc {
+        let av = self.val
+        let bv = other.val
+        var ab: [f64; 8] = [0.0; 8]
+        oct_mul(&av, &bv, &!ab)
+        let na = oct_norm_sq(&av)
+        let nb = oct_norm_sq(&bv)
+        UncertainOct {
+            val: ab,
+            variance: nb * self.variance + na * other.variance,
+        }
+    }
+
+    // Triple product ((a·b)·c) — THE automatic synthesis. Returns the value AND
+    // a variance that ALWAYS includes the order-indeterminacy of the triple:
+    //   Var_total = Var_measurement + κ·‖[a,b,c]‖²
+    // The structural term is computed and added unconditionally — there is no
+    // path through this method that yields the product without it. Associative
+    // (Fano) triples carry ‖α‖²=0 and pay nothing; non-associative triples carry
+    // exactly the variance their order-ambiguity implies.
+    pub fn mul3(
+        self: &UncertainOct, b: &UncertainOct, c: &UncertainOct, kappa: f64,
+    ) -> UncertainOct with Mut, Div, NonAssoc {
+        let av = self.val
+        let bv = b.val
+        let cv = c.val
+
+        // value: ((a·b)·c)
+        var ab: [f64; 8] = [0.0; 8]
+        oct_mul(&av, &bv, &!ab)
+        var abc: [f64; 8] = [0.0; 8]
+        oct_mul(&ab, &cv, &!abc)
+
+        // measurement variance, propagated twice through the norm rule
+        let na = oct_norm_sq(&av)
+        let nb = oct_norm_sq(&bv)
+        let nc = oct_norm_sq(&cv)
+        let nab = oct_norm_sq(&ab)
+        let var_ab = nb * self.variance + na * b.variance
+        let var_meas = nc * var_ab + nab * c.variance
+
+        // structural variance — automatic, unconditional: κ·‖[a,b,c]‖²
+        var assoc: [f64; 8] = [0.0; 8]
+        oct_associator(&av, &bv, &cv, &!assoc)
+        let structural = kappa * oct_norm_sq(&assoc)
+
+        UncertainOct {
+            val: abc,
+            variance: var_meas + structural,
+        }
+    }
+}

--- a/stdlib/render/renderer3d.sio
+++ b/stdlib/render/renderer3d.sio
@@ -8,11 +8,11 @@
 //   1. Model→View: rotate/translate vertices (caller supplies pre-transformed verts)
 //   2. Perspective projection via project_vertex
 //   3. Barycentric rasterization with depth test into a per-call depth buffer
-//   4. Phong shading: ambient + diffuse (no specular)
-//   5. Output via canvas_fill_triangle (solid per-triangle colour)
+//   4. Blinn-Phong shading: ambient + diffuse + specular^32
+//   5. Output via canvas_fill_triangle (solid per-triangle colour) + edge lines
 
 use display::canvas::{Canvas}
-use display::canvas_ext::{canvas_fill_triangle}
+use display::canvas_ext::{canvas_fill_triangle, canvas_draw_line_aa}
 
 // ============================================================
 // Types
@@ -83,7 +83,7 @@ pub fn r3d_normalise(x: f64, y: f64, z: f64) -> Vec3f with Mut, Div {
 
 // Projects a 3D point onto the canvas using a simple perspective model.
 // Returns (screen_x, screen_y, depth). depth <= 0 means behind camera.
-fn r3d_project(wx: f64, wy: f64, wz: f64, cam: &Camera3D, cw: i64, ch: i64) -> Vec3f with Div {
+pub fn r3d_project(wx: f64, wy: f64, wz: f64, cam: &Camera3D, cw: i64, ch: i64) -> Vec3f with Div {
     let rz = wz - cam.pos_z
     if rz >= 0.0 {
         // Behind or at camera plane — signal with depth = 0
@@ -112,7 +112,7 @@ fn r3d_project_viewport(wx: f64, wy: f64, wz: f64, cam: &Camera3D, vx: i64, vy: 
 // Shading
 // ============================================================
 
-fn r3d_shade(
+pub fn r3d_shade(
     base_r: i64, base_g: i64, base_b: i64,
     nx: f64, ny: f64, nz: f64,
     light: &Light3D,
@@ -120,9 +120,27 @@ fn r3d_shade(
     let nl = r3d_normalise(nx, ny, nz)
     let diffuse = r3d_max_f(r3d_dot(nl.x, nl.y, nl.z, light.dx, light.dy, light.dz), 0.0)
     let intensity = light.ambient + (1.0 - light.ambient) * diffuse
-    let sr = r3d_clamp_i((base_r as f64 * intensity) as i64, 0, 255)
-    let sg = r3d_clamp_i((base_g as f64 * intensity) as i64, 0, 255)
-    let sb = r3d_clamp_i((base_b as f64 * intensity) as i64, 0, 255)
+
+    // Blinn-Phong specular: H = normalize(L + V), V = (0,0,1) toward camera.
+    let hx_u = light.dx
+    let hy_u = light.dy
+    let hz_u = light.dz + 1.0
+    let h_len = r3d_sqrt(hx_u * hx_u + hy_u * hy_u + hz_u * hz_u)
+    let ndoth = if h_len > 0.0 {
+        r3d_max_f(nl.x * (hx_u / h_len) + nl.y * (hy_u / h_len) + nl.z * (hz_u / h_len), 0.0)
+    } else { 0.0 }
+    let s2 = ndoth * ndoth
+    let s4 = s2 * s2
+    let s8 = s4 * s4
+    let s32 = s8 * s8 * s8 * s8   // ^32
+    let spec = 0.85 * s32
+
+    let fr = base_r as f64 * intensity + 255.0 * spec
+    let fg = base_g as f64 * intensity + 255.0 * spec
+    let fb = base_b as f64 * intensity + 255.0 * spec
+    let sr = r3d_clamp_i(fr as i64, 0, 255)
+    let sg = r3d_clamp_i(fg as i64, 0, 255)
+    let sb = r3d_clamp_i(fb as i64, 0, 255)
     // Pack into Vec3f channels re-used as i64 via cast (R=x, G=y, B=z)
     Vec3f { x: sr as f64, y: sg as f64, z: sb as f64 }
 }
@@ -208,6 +226,61 @@ fn r3d_rasterize_tri(
     }
 }
 
+// Gouraud rasterize — per-vertex colours c0/c1/c2, each Vec3f{x=R,y=G,z=B} in [0,255].
+// Barycentric interpolation gives smooth shading gradients within the face.
+pub fn r3d_rasterize_tri_gouraud(
+    sx0: i64, sy0: i64,
+    sx1: i64, sy1: i64,
+    sx2: i64, sy2: i64,
+    d0: f64, d1: f64, d2: f64,
+    c0: Vec3f, c1: Vec3f, c2: Vec3f,
+    depth_buf: *mut i64,
+    cv: &!Canvas,
+) with Mut, Div {
+    let area = r3d_edge(sx0, sy0, sx1, sy1, sx2, sy2)
+    if area == 0 { return }
+    let min_x = r3d_clamp_i(r3d_min_i(r3d_min_i(sx0, sx1), sx2), 0, cv.width - 1)
+    let max_x = r3d_clamp_i(r3d_max_i(r3d_max_i(sx0, sx1), sx2), 0, cv.width - 1)
+    let min_y = r3d_clamp_i(r3d_min_i(r3d_min_i(sy0, sy1), sy2), 0, cv.height - 1)
+    let max_y = r3d_clamp_i(r3d_max_i(r3d_max_i(sy0, sy1), sy2), 0, cv.height - 1)
+    var py = min_y
+    while py <= max_y {
+        var px = min_x
+        while px <= max_x {
+            let w0 = r3d_edge(sx1, sy1, sx2, sy2, px, py)
+            let w1 = r3d_edge(sx2, sy2, sx0, sy0, px, py)
+            let w2 = r3d_edge(sx0, sy0, sx1, sy1, px, py)
+            let inside = if area > 0 {
+                w0 >= 0 && w1 >= 0 && w2 >= 0
+            } else {
+                w0 <= 0 && w1 <= 0 && w2 <= 0
+            }
+            if inside {
+                let idx = py * cv.width + px
+                let area_f = area as f64
+                let bw0 = (w0 as f64) / area_f
+                let bw1 = (w1 as f64) / area_f
+                let bw2 = (w2 as f64) / area_f
+                let depth = bw0 * d0 + bw1 * d1 + bw2 * d2
+                let stored = read_i64(depth_buf, idx)
+                let dbits = depth as i64
+                if dbits < stored {
+                    write_i64(depth_buf, idx, dbits)
+                    let fr = bw0 * c0.x + bw1 * c1.x + bw2 * c2.x
+                    let fg = bw0 * c0.y + bw1 * c1.y + bw2 * c2.y
+                    let fb = bw0 * c0.z + bw1 * c1.z + bw2 * c2.z
+                    let pr = r3d_clamp_i(fr as i64, 0, 255)
+                    let pg = r3d_clamp_i(fg as i64, 0, 255)
+                    let pb = r3d_clamp_i(fb as i64, 0, 255)
+                    write_i64(cv.pixels, idx, pb | (pg << 8) | (pr << 16))
+                }
+            }
+            px = px + 1
+        }
+        py = py + 1
+    }
+}
+
 // ============================================================
 // Public API: render a list of triangles
 // ============================================================
@@ -241,7 +314,7 @@ pub fn r3d_render(
         // Shade
         let col = r3d_shade(tri.base_r, tri.base_g, tri.base_b, tri.nx, tri.ny, tri.nz, light)
 
-        // Rasterize
+        // Rasterize face
         r3d_rasterize_tri(
             p0.x as i64, p0.y as i64,
             p1.x as i64, p1.y as i64,
@@ -250,6 +323,15 @@ pub fn r3d_render(
             col.x as i64, col.y as i64, col.z as i64,
             depth_buf, c,
         )
+
+        // Draw edges — dark silhouette lines for depth separation
+        let er = r3d_clamp_i((col.x as i64 * 3) / 10, 0, 255)
+        let eg = r3d_clamp_i((col.y as i64 * 3) / 10, 0, 255)
+        let eb = r3d_clamp_i((col.z as i64 * 3) / 10, 0, 255)
+        canvas_draw_line_aa(c, p0.x as i64, p0.y as i64, p1.x as i64, p1.y as i64, er, eg, eb)
+        canvas_draw_line_aa(c, p1.x as i64, p1.y as i64, p2.x as i64, p2.y as i64, er, eg, eb)
+        canvas_draw_line_aa(c, p2.x as i64, p2.y as i64, p0.x as i64, p0.y as i64, er, eg, eb)
+
         i = i + 1
     }
 }

--- a/stdlib/render/renderer3d.sio
+++ b/stdlib/render/renderer3d.sio
@@ -96,6 +96,18 @@ fn r3d_project(wx: f64, wy: f64, wz: f64, cam: &Camera3D, cw: i64, ch: i64) -> V
     Vec3f { x: sx, y: sy, z: depth }
 }
 
+fn r3d_project_viewport(wx: f64, wy: f64, wz: f64, cam: &Camera3D, vx: i64, vy: i64, vw: i64, vh: i64) -> Vec3f with Div {
+    let rz = wz - cam.pos_z
+    if rz >= 0.0 {
+        return Vec3f { x: 0.0, y: 0.0, z: 0.0 }
+    }
+    let depth = 0.0 - rz
+    let scale = cam.focal / depth
+    let sx = (wx - cam.pos_x) * scale + (vx as f64) + (vw as f64) * 0.5
+    let sy = (0.0 - (wy - cam.pos_y)) * scale + (vy as f64) + (vh as f64) * 0.5
+    Vec3f { x: sx, y: sy, z: depth }
+}
+
 // ============================================================
 // Shading
 // ============================================================
@@ -230,6 +242,40 @@ pub fn r3d_render(
         let col = r3d_shade(tri.base_r, tri.base_g, tri.base_b, tri.nx, tri.ny, tri.nz, light)
 
         // Rasterize
+        r3d_rasterize_tri(
+            p0.x as i64, p0.y as i64,
+            p1.x as i64, p1.y as i64,
+            p2.x as i64, p2.y as i64,
+            p0.z, p1.z, p2.z,
+            col.x as i64, col.y as i64, col.z as i64,
+            depth_buf, c,
+        )
+        i = i + 1
+    }
+}
+
+pub fn r3d_render_viewport(
+    tris: &[Tri3D; 4096],
+    n: i64,
+    cam: &Camera3D,
+    light: &Light3D,
+    depth_buf: *mut i64,
+    c: &!Canvas,
+    vx: i64, vy: i64, vw: i64, vh: i64,
+) with Mut, Div {
+    var i: i64 = 0
+    while i < n {
+        let tri = tris[i as usize]
+        let p0 = r3d_project_viewport(tri.v0x, tri.v0y, tri.v0z, cam, vx, vy, vw, vh)
+        let p1 = r3d_project_viewport(tri.v1x, tri.v1y, tri.v1z, cam, vx, vy, vw, vh)
+        let p2 = r3d_project_viewport(tri.v2x, tri.v2y, tri.v2z, cam, vx, vy, vw, vh)
+
+        if p0.z <= 0.0 || p1.z <= 0.0 || p2.z <= 0.0 {
+            i = i + 1
+            continue
+        }
+
+        let col = r3d_shade(tri.base_r, tri.base_g, tri.base_b, tri.nx, tri.ny, tri.nz, light)
         r3d_rasterize_tri(
             p0.x as i64, p0.y as i64,
             p1.x as i64, p1.y as i64,

--- a/stdlib/viz/EXAMPLES.md
+++ b/stdlib/viz/EXAMPLES.md
@@ -16,6 +16,182 @@ VIZ_HEADLESS_PASS
 
 The test renders axes, an antialiased line, a triangle, a heatmap, an epistemic band, a molecule node, and a Visual IR scene into a heap canvas.
 
+## Canvas Extension Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_canvas_ext_surface.sio
+```
+
+Expected output:
+
+```text
+VIZ_CANVAS_EXT_SURFACE_PASS
+```
+
+The test proves axis-aligned antialiased lines are rendered as exact one-pixel strokes, diagonal lines produce partial coverage, and `graphics::surface::Surface` blits into `display::Canvas` with alpha blending.
+
+## Static HTML Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_html_static.sio
+```
+
+Expected output includes:
+
+```text
+VIZ_HTML_STATIC_PASS
+```
+
+The test emits static SVG/HTML for a line chart, heatmap cells, molecule glyph, scalar-field heatmap cells, vector-field arrows, trajectory path with a scene-time cursor, spectrum trace, and mesh glyph.
+
+## Chart Builders Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_chart_builders.sio
+```
+
+Expected output includes:
+
+```text
+VIZ_CHART_BUILDERS_PASS
+```
+
+The test proves Visual IR builders and Canvas/HTML lowering for scatter, bar, forest, and waterfall nodes. Line, heatmap, and uncertainty-band builders are covered by the headless and static HTML proofs.
+
+## Layout Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_layout.sio
+```
+
+Expected output:
+
+```text
+VIZ_LAYOUT_PASS
+```
+
+The test applies row and column layout to Visual IR control nodes, verifies hit testing uses the resolved rectangles, and renders the laid-out controls into a headless Canvas.
+
+## Physchem Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_physchem.sio
+```
+
+Expected output:
+
+```text
+VIZ_PHYSCHEM_PASS
+```
+
+The test validates H2O, a coarse rapamycin molecule, scalar-field variance/data, vector-field variance/data, trajectory variance/path data, spectrum intensity/variance data, Visual IR molecule and field slots, scene time, and headless Canvas pixels for the rendered physchem nodes.
+
+## Interaction Time Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_interaction_time.sio
+```
+
+Expected output:
+
+```text
+VIZ_INTERACTION_TIME_PASS
+```
+
+The test treats pointer input as Sounio data: a slider hit selects a Visual IR node, pointer movement clamps the slider value, updates `scene.time`, and redraws a trajectory cursor from that state.
+
+## Control Modes Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_controls_modes.sio
+```
+
+Expected output:
+
+```text
+VIZ_CONTROLS_MODES_PASS
+```
+
+The test proves native control reducers for tabs, toggles, hover state, Canvas rendering, and static HTML/SVG serialization over the same Visual IR.
+
+## Text Controls Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_text_controls.sio
+```
+
+Expected output includes:
+
+```text
+VIZ_TEXT_CONTROLS_PASS
+```
+
+The test proves fixed-buffer Visual IR labels, legend text, tooltip text, Canvas text pixels, and static HTML/SVG text export including escaping for `&`, `<`, `>`, and `"`.
+
+## Frontend Builders Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_frontend_builders.sio
+```
+
+Expected output includes:
+
+```text
+VIZ_FRONTEND_BUILDERS_PASS
+```
+
+The test proves named Visual IR builders for button, slider, toggle, tabs, text viewport, plot viewport, legend, and tooltip controls. It checks control slots, values, fixed labels, Canvas pixels, and static HTML/SVG output.
+
+## Event Reducer Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_event_reducer.sio
+```
+
+Expected output:
+
+```text
+VIZ_EVENT_REDUCER_PASS
+```
+
+The test feeds `display::event::Event` values into `viz_scene_handle_event`, proving that mouse press/motion/release and keyboard arrows/space update the Sounio Visual IR state directly.
+
+## App Frame Proof
+
+Run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run tests/run-pass/viz_app_frame.sio
+```
+
+Expected output:
+
+```text
+VIZ_APP_FRAME_PASS
+```
+
+The test proves the `viz_app` runner: events mark an app dirty, dirty scenes render to Canvas exactly once, expose events force redraw, and close events stop the app without requiring a display server.
+
 ## Native Lab
 
 Compile:
@@ -24,7 +200,27 @@ Compile:
 SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh compile examples/viz_lab/main.sio -o /tmp/viz_lab.elf
 ```
 
-The lab currently proves the shared scene model and prints `VIZ_LAB_READY`. Window/event-loop wiring remains optional manual work for the next phase.
+The lab currently proves the shared scene model with `viz_app` event handling and Canvas rendering, then prints `VIZ_LAB_READY`. Opening a real window remains optional manual work for the next phase.
+
+## Native Window Lab
+
+Compile:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh compile examples/viz_lab_window/main.sio -o /tmp/viz_lab_window.elf
+```
+
+The window lab uses `viz_window_step` to pump `display::Window` events into `VizApp`/`VizScene` and present Canvas frames. It is compile-gated for CI and intended for manual runs when `DISPLAY` is available.
+
+## Physchem Demo
+
+Compile or run:
+
+```bash
+SOUNIO_STDLIB_PATH=./stdlib ./scripts/ci/souc-native-wrapper.sh run examples/viz_physchem_demo/main.sio
+```
+
+The demo builds one Visual IR scene with H2O, coarse rapamycin, a scalar field, a vector field, a trajectory, an absorption spectrum, a 3D mesh, and a time-evolution chart with an uncertainty band. It renders the same scene to native Canvas pixels and static HTML/SVG, then prints `VIZ_PHYSCHEM_DEMO_READY`.
 
 ## Hello
 

--- a/stdlib/viz/README.md
+++ b/stdlib/viz/README.md
@@ -7,7 +7,9 @@ The v1 architecture is:
 - `viz::ir`: fixed-capacity Visual IR owned by Sounio.
 - `viz::viz_canvas`: immediate native renderer to `display::Canvas`.
 - `viz::viz_html`: static HTML/SVG export renderer over the same IR.
-- `viz::physchem`: Sounio data structures for molecules, bonds, scalar/vector fields, trajectories, and uncertainty overlays.
+- `viz::viz_app`: headless-testable app runner for Event -> Visual IR -> Canvas frames.
+- `viz::viz_window`: optional native `display::Window` bridge for manual event-loop demos.
+- `viz::physchem`: Sounio data structures for molecules, bonds, scalar/vector fields, trajectories, spectra, lattice/phonon fields, particle event views, and uncertainty overlays.
 - `viz::{coord,chart,epiviz,sci}`: direct drawing helpers that the IR renderer can lower into.
 
 Scientific meaning stays in Sounio. Units, epistemic variance, molecules, lattices, fields, simulation clocks, scene nodes, and interaction state are represented as Sounio data. Browser or terminal export surfaces display pixels or markup; they do not own the scientific model.
@@ -15,7 +17,17 @@ Scientific meaning stays in Sounio. Units, epistemic variance, molecules, lattic
 ## V1 Constraints
 
 - Fixed node/data arrays; no heap-heavy scene graph.
-- Fixed rectangles and simple row/column layout metadata; no flexbox.
+- Fixed rectangles plus a simple row/column layout pass over contiguous node ranges; no flexbox.
 - CPU Canvas is the primary renderer.
-- HTML/SVG is static export only.
+- HTML/SVG is static export only. It serializes Visual IR geometry and simple glyphs; no JavaScript owns model state.
+- Scalar fields keep their Sounio `ScalarField2D` payload and mirror values into heatmap storage for renderer-friendly export.
+- Vector fields keep their Sounio `VectorField2D` payload and mirror components into renderer-friendly vector slots with explicit row/column metadata.
+- Trajectories keep their Sounio `Trajectory3D` payload and mirror path coordinates into renderer-friendly trajectory slots.
+- Spectra keep their Sounio `SpectrumViz` payload and mirror wavelength/intensity/variance into renderer-friendly spectrum slots.
+- Chart builders cover line, scatter, bar, heatmap, uncertainty band, forest plot, and waterfall nodes over the shared Visual IR.
+- Scene time, selected node, hovered node, active tabs, and toggle values are Sounio state that renderers display.
+- Labels and text controls use fixed `[i8; 64]` buffers in the Visual IR. Canvas renders them with `display::font`; HTML/SVG escapes XML-sensitive ASCII before export.
+- Native frontend builders cover button, slider, toggle, tabs, legend, tooltip, text viewport, and plot viewport nodes over the same control reducer machinery.
+- `display::event::Event` can be reduced directly into `VizScene` for headless tests and future native window loops.
+- Native windows are an optional layer over the same app runner; CI proofs stay headless.
 - GPU rendering is deferred until general compiler GPU backend wiring is ready.

--- a/stdlib/viz/ir.sio
+++ b/stdlib/viz/ir.sio
@@ -4,6 +4,10 @@
 // lives in Sounio data: units, uncertainty, fields, molecules, and simulation
 // state are lowered to renderers, not delegated to JS or Python.
 
+use viz::physchem::{MoleculeViz, ScalarField2D, VectorField2D, Trajectory3D, SpectrumViz, molecule_empty, scalar_field_empty, vector_field_empty, trajectory_empty, spectrum_empty}
+use render::renderer3d::{Tri3D}
+use display::event::{Event, EV_KEY_PRESS, EV_MOUSE_PRESS, EV_MOUSE_RELEASE, EV_MOTION, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_RETURN, KEY_TAB, MOUSE_LEFT}
+
 pub const VIZ_NODE_EMPTY: i64 = 0
 pub const VIZ_NODE_SCENE: i64 = 1
 pub const VIZ_NODE_GROUP: i64 = 2
@@ -21,6 +25,9 @@ pub const VIZ_NODE_CONTROL: i64 = 13
 pub const VIZ_NODE_UNCERTAINTY_BAND: i64 = 14
 pub const VIZ_NODE_FOREST: i64 = 15
 pub const VIZ_NODE_WATERFALL: i64 = 16
+pub const VIZ_NODE_VECTOR_FIELD: i64 = 17
+pub const VIZ_NODE_TRAJECTORY: i64 = 18
+pub const VIZ_NODE_SPECTRUM: i64 = 19
 
 pub const VIZ_CONTROL_BUTTON: i64 = 1
 pub const VIZ_CONTROL_SLIDER: i64 = 2
@@ -29,6 +36,10 @@ pub const VIZ_CONTROL_TABS: i64 = 4
 pub const VIZ_CONTROL_LEGEND: i64 = 5
 pub const VIZ_CONTROL_TOOLTIP: i64 = 6
 pub const VIZ_CONTROL_VIEWPORT: i64 = 7
+
+pub const VIZ_LAYOUT_FIXED: i64 = 0
+pub const VIZ_LAYOUT_ROW: i64 = 1
+pub const VIZ_LAYOUT_COLUMN: i64 = 2
 
 pub struct VizStyle {
     pub r: i64,
@@ -86,6 +97,39 @@ pub struct VizHeatmapData {
     pub max_value: f64,
 }
 
+pub struct VizVectorFieldData {
+    pub vx: [f64; 4096],
+    pub vy: [f64; 4096],
+    pub variance: [f64; 4096],
+    pub rows: i64,
+    pub cols: i64,
+}
+
+pub struct VizTrajectoryData {
+    pub x: [f64; 1024],
+    pub y: [f64; 1024],
+    pub z: [f64; 1024],
+    pub t: [f64; 1024],
+    pub variance: [f64; 1024],
+    pub n: i64,
+}
+
+pub struct VizSpectrumData {
+    pub x: [f64; 1024],
+    pub intensity: [f64; 1024],
+    pub variance: [f64; 1024],
+    pub n: i64,
+    pub x_min: f64,
+    pub x_max: f64,
+    pub y_min: f64,
+    pub y_max: f64,
+}
+
+pub struct VizMeshData {
+    pub tris: [Tri3D; 128],
+    pub n: i64,
+}
+
 pub struct VizScene {
     pub nodes: [VizNode; 64],
     pub node_count: i64,
@@ -93,7 +137,27 @@ pub struct VizScene {
     pub series_count: i64,
     pub heatmaps: [VizHeatmapData; 4],
     pub heatmap_count: i64,
+    pub molecules: [MoleculeViz; 4],
+    pub molecule_count: i64,
+    pub fields: [ScalarField2D; 4],
+    pub field_heatmap_slots: [i64; 4],
+    pub field_count: i64,
+    pub vector_fields: [VectorField2D; 4],
+    pub vector_data: [VizVectorFieldData; 4],
+    pub vector_field_rows: [i64; 4],
+    pub vector_field_cols: [i64; 4],
+    pub vector_field_count: i64,
+    pub trajectories: [Trajectory3D; 4],
+    pub trajectory_data: [VizTrajectoryData; 4],
+    pub trajectory_count: i64,
+    pub spectra: [SpectrumViz; 4],
+    pub spectrum_data: [VizSpectrumData; 4],
+    pub spectrum_count: i64,
+    pub meshes: [VizMeshData; 4],
+    pub mesh_count: i64,
     pub selected_node: i64,
+    pub hovered_node: i64,
+    pub active_tab: i64,
     pub time: f64,
 }
 
@@ -102,7 +166,19 @@ pub fn viz_style_rgb(r: i64, g: i64, b: i64) -> VizStyle {
 }
 
 pub fn viz_layout_rect(x: i64, y: i64, w: i64, h: i64) -> VizLayout {
-    VizLayout { x: x, y: y, w: w, h: h, layout_kind: 0, gap: 0 }
+    VizLayout { x: x, y: y, w: w, h: h, layout_kind: VIZ_LAYOUT_FIXED, gap: 0 }
+}
+
+pub fn viz_layout_row(x: i64, y: i64, w: i64, h: i64, gap: i64) -> VizLayout {
+    VizLayout { x: x, y: y, w: w, h: h, layout_kind: VIZ_LAYOUT_ROW, gap: gap }
+}
+
+pub fn viz_layout_column(x: i64, y: i64, w: i64, h: i64, gap: i64) -> VizLayout {
+    VizLayout { x: x, y: y, w: w, h: h, layout_kind: VIZ_LAYOUT_COLUMN, gap: gap }
+}
+
+fn viz_layout_nonneg(v: i64) -> i64 {
+    if v < 0 { 0 } else { v }
 }
 
 pub fn viz_node_empty() -> VizNode {
@@ -129,6 +205,41 @@ pub fn viz_heatmap_empty() -> VizHeatmapData {
     }
 }
 
+pub fn viz_vector_field_empty() -> VizVectorFieldData {
+    VizVectorFieldData {
+        vx: [0.0; 4096], vy: [0.0; 4096], variance: [0.0; 4096],
+        rows: 0, cols: 0,
+    }
+}
+
+pub fn viz_trajectory_empty() -> VizTrajectoryData {
+    VizTrajectoryData {
+        x: [0.0; 1024], y: [0.0; 1024], z: [0.0; 1024],
+        t: [0.0; 1024], variance: [0.0; 1024], n: 0,
+    }
+}
+
+pub fn viz_spectrum_empty() -> VizSpectrumData {
+    VizSpectrumData {
+        x: [0.0; 1024], intensity: [0.0; 1024], variance: [0.0; 1024],
+        n: 0, x_min: 0.0, x_max: 1.0, y_min: 0.0, y_max: 1.0,
+    }
+}
+
+pub fn viz_tri_empty() -> Tri3D {
+    Tri3D {
+        v0x: 0.0, v0y: 0.0, v0z: -2.0,
+        v1x: 0.0, v1y: 0.0, v1z: -2.0,
+        v2x: 0.0, v2y: 0.0, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 0, base_g: 0, base_b: 0,
+    }
+}
+
+pub fn viz_mesh_empty() -> VizMeshData {
+    VizMeshData { tris: [viz_tri_empty(); 128], n: 0 }
+}
+
 pub fn viz_scene_new() -> VizScene {
     VizScene {
         nodes: [viz_node_empty(); 64],
@@ -137,7 +248,27 @@ pub fn viz_scene_new() -> VizScene {
         series_count: 0,
         heatmaps: [viz_heatmap_empty(); 4],
         heatmap_count: 0,
-        selected_node: 0,
+        molecules: [molecule_empty(); 4],
+        molecule_count: 0,
+        fields: [scalar_field_empty(0, 0); 4],
+        field_heatmap_slots: [0 - 1; 4],
+        field_count: 0,
+        vector_fields: [vector_field_empty(0, 0); 4],
+        vector_data: [viz_vector_field_empty(); 4],
+        vector_field_rows: [0; 4],
+        vector_field_cols: [0; 4],
+        vector_field_count: 0,
+        trajectories: [trajectory_empty(); 4],
+        trajectory_data: [viz_trajectory_empty(); 4],
+        trajectory_count: 0,
+        spectra: [spectrum_empty(); 4],
+        spectrum_data: [viz_spectrum_empty(); 4],
+        spectrum_count: 0,
+        meshes: [viz_mesh_empty(); 4],
+        mesh_count: 0,
+        selected_node: 0 - 1,
+        hovered_node: 0 - 1,
+        active_tab: 0,
         time: 0.0,
     }
 }
@@ -199,10 +330,120 @@ pub fn viz_scene_add_heatmap(scene: &!VizScene, values: &[f64; 4096], rows: i64,
     slot
 }
 
+pub fn viz_scene_add_molecule_data(scene: &!VizScene, mol: MoleculeViz) -> i64 with Mut {
+    if scene.molecule_count >= 4 { return 0 - 1 }
+    let slot = scene.molecule_count
+    scene.molecules[slot as usize] = mol
+    scene.molecule_count = scene.molecule_count + 1
+    slot
+}
+
+pub fn viz_scene_add_field_data(scene: &!VizScene, field: ScalarField2D) -> i64 with Mut {
+    if scene.field_count >= 4 { return 0 - 1 }
+    let slot = scene.field_count
+    scene.fields[slot as usize] = field
+    scene.field_count = scene.field_count + 1
+    slot
+}
+
+pub fn viz_scene_add_vector_field_data(scene: &!VizScene, field: VectorField2D) -> i64 with Mut {
+    if scene.vector_field_count >= 4 { return 0 - 1 }
+    let slot = scene.vector_field_count
+    let rows = field.rows
+    let cols = field.cols
+    scene.vector_fields[slot as usize] = field
+    var d = viz_vector_field_empty()
+    d.rows = rows
+    d.cols = cols
+    var i: i64 = 0
+    while i < rows * cols && i < 4096 {
+        d.vx[i as usize] = field.vx[i as usize]
+        d.vy[i as usize] = field.vy[i as usize]
+        d.variance[i as usize] = field.variance[i as usize]
+        i = i + 1
+    }
+    scene.vector_data[slot as usize] = d
+    scene.vector_field_rows[slot as usize] = rows
+    scene.vector_field_cols[slot as usize] = cols
+    scene.vector_field_count = scene.vector_field_count + 1
+    slot
+}
+
+pub fn viz_scene_add_trajectory_data(scene: &!VizScene, tr: Trajectory3D) -> i64 with Mut {
+    if scene.trajectory_count >= 4 { return 0 - 1 }
+    let slot = scene.trajectory_count
+    let n = tr.n
+    scene.trajectories[slot as usize] = tr
+    var d = viz_trajectory_empty()
+    d.n = n
+    var i: i64 = 0
+    while i < n && i < 1024 {
+        d.x[i as usize] = tr.x[i as usize]
+        d.y[i as usize] = tr.y[i as usize]
+        d.z[i as usize] = tr.z[i as usize]
+        d.t[i as usize] = tr.t[i as usize]
+        d.variance[i as usize] = tr.variance[i as usize]
+        i = i + 1
+    }
+    scene.trajectory_data[slot as usize] = d
+    scene.trajectory_count = scene.trajectory_count + 1
+    slot
+}
+
+pub fn viz_scene_add_spectrum_data(scene: &!VizScene, spec: SpectrumViz) -> i64 with Mut {
+    if scene.spectrum_count >= 4 { return 0 - 1 }
+    let slot = scene.spectrum_count
+    let n = spec.n
+    scene.spectra[slot as usize] = spec
+    var d = viz_spectrum_empty()
+    d.n = n
+    d.x_min = spec.x_min
+    d.x_max = spec.x_max
+    d.y_min = spec.y_min
+    d.y_max = spec.y_max
+    var i: i64 = 0
+    while i < n && i < 1024 {
+        d.x[i as usize] = spec.x[i as usize]
+        d.intensity[i as usize] = spec.intensity[i as usize]
+        d.variance[i as usize] = spec.variance[i as usize]
+        i = i + 1
+    }
+    scene.spectrum_data[slot as usize] = d
+    scene.spectrum_count = scene.spectrum_count + 1
+    slot
+}
+
+pub fn viz_scene_add_mesh_data(scene: &!VizScene, tris: &[Tri3D; 128], n: i64) -> i64 with Mut {
+    if scene.mesh_count >= 4 { return 0 - 1 }
+    let slot = scene.mesh_count
+    var d = viz_mesh_empty()
+    d.n = n
+    var i: i64 = 0
+    while i < n && i < 128 {
+        d.tris[i as usize] = tris[i as usize]
+        i = i + 1
+    }
+    scene.meshes[slot as usize] = d
+    scene.mesh_count = scene.mesh_count + 1
+    slot
+}
+
 pub fn viz_add_line_chart(scene: &!VizScene, xs: &[f64; 1024], ys: &[f64; 1024], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
     let vars: [f64; 1024] = [0.0; 1024]
     let slot = viz_scene_add_series(scene, xs, ys, &vars, n)
     viz_scene_add_node(scene, VIZ_NODE_CHART_LINE, layout, style, slot)
+}
+
+pub fn viz_add_scatter_chart(scene: &!VizScene, xs: &[f64; 1024], ys: &[f64; 1024], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let vars: [f64; 1024] = [0.0; 1024]
+    let slot = viz_scene_add_series(scene, xs, ys, &vars, n)
+    viz_scene_add_node(scene, VIZ_NODE_CHART_SCATTER, layout, style, slot)
+}
+
+pub fn viz_add_bar_chart(scene: &!VizScene, xs: &[f64; 1024], ys: &[f64; 1024], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let vars: [f64; 1024] = [0.0; 1024]
+    let slot = viz_scene_add_series(scene, xs, ys, &vars, n)
+    viz_scene_add_node(scene, VIZ_NODE_CHART_BAR, layout, style, slot)
 }
 
 pub fn viz_add_uncertainty_band(scene: &!VizScene, xs: &[f64; 1024], ys: &[f64; 1024], vars: &[f64; 1024], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
@@ -210,9 +451,76 @@ pub fn viz_add_uncertainty_band(scene: &!VizScene, xs: &[f64; 1024], ys: &[f64; 
     viz_scene_add_node(scene, VIZ_NODE_UNCERTAINTY_BAND, layout, style, slot)
 }
 
+pub fn viz_add_forest_plot(scene: &!VizScene, estimates: &[f64; 1024], variances: &[f64; 1024], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    var rows: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < n && i < 1024 {
+        rows[i as usize] = i as f64
+        i = i + 1
+    }
+    let slot = viz_scene_add_series(scene, estimates, &rows, variances, n)
+    viz_scene_add_node(scene, VIZ_NODE_FOREST, layout, style, slot)
+}
+
+pub fn viz_add_waterfall(scene: &!VizScene, values: &[f64; 1024], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    var xs: [f64; 1024] = [0.0; 1024]
+    var vars: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < n && i < 1024 {
+        xs[i as usize] = i as f64
+        i = i + 1
+    }
+    let slot = viz_scene_add_series(scene, &xs, values, &vars, n)
+    viz_scene_add_node(scene, VIZ_NODE_WATERFALL, layout, style, slot)
+}
+
 pub fn viz_add_heatmap(scene: &!VizScene, values: &[f64; 4096], rows: i64, cols: i64, min_value: f64, max_value: f64, layout: VizLayout) -> i64 with Mut {
     let slot = viz_scene_add_heatmap(scene, values, rows, cols, min_value, max_value)
     viz_scene_add_node(scene, VIZ_NODE_HEATMAP, layout, viz_style_rgb(255, 255, 255), slot)
+}
+
+pub fn viz_add_molecule(scene: &!VizScene, mol: MoleculeViz, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let slot = viz_scene_add_molecule_data(scene, mol)
+    viz_scene_add_node(scene, VIZ_NODE_MOLECULE, layout, style, slot)
+}
+
+pub fn viz_add_scalar_field(scene: &!VizScene, field: ScalarField2D, layout: VizLayout) -> i64 with Mut {
+    var values: [f64; 4096] = [0.0; 4096]
+    let rows = field.rows
+    let cols = field.cols
+    let min_value = field.min_value
+    let max_value = field.max_value
+    var i: i64 = 0
+    while i < rows * cols && i < 4096 {
+        values[i as usize] = field.values[i as usize]
+        i = i + 1
+    }
+    let slot = viz_scene_add_field_data(scene, field)
+    if slot >= 0 {
+        let heat_slot = viz_scene_add_heatmap(scene, &values, rows, cols, min_value, max_value)
+        scene.field_heatmap_slots[slot as usize] = heat_slot
+    }
+    viz_scene_add_node(scene, VIZ_NODE_FIELD, layout, viz_style_rgb(120, 200, 220), slot)
+}
+
+pub fn viz_add_vector_field(scene: &!VizScene, field: VectorField2D, layout: VizLayout) -> i64 with Mut {
+    let slot = viz_scene_add_vector_field_data(scene, field)
+    viz_scene_add_node(scene, VIZ_NODE_VECTOR_FIELD, layout, viz_style_rgb(240, 210, 120), slot)
+}
+
+pub fn viz_add_trajectory(scene: &!VizScene, tr: Trajectory3D, layout: VizLayout) -> i64 with Mut {
+    let slot = viz_scene_add_trajectory_data(scene, tr)
+    viz_scene_add_node(scene, VIZ_NODE_TRAJECTORY, layout, viz_style_rgb(210, 170, 255), slot)
+}
+
+pub fn viz_add_spectrum(scene: &!VizScene, spec: SpectrumViz, layout: VizLayout) -> i64 with Mut {
+    let slot = viz_scene_add_spectrum_data(scene, spec)
+    viz_scene_add_node(scene, VIZ_NODE_SPECTRUM, layout, viz_style_rgb(255, 210, 120), slot)
+}
+
+pub fn viz_add_mesh(scene: &!VizScene, tris: &[Tri3D; 128], n: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let slot = viz_scene_add_mesh_data(scene, tris, n)
+    viz_scene_add_node(scene, VIZ_NODE_MESH, layout, style, slot)
 }
 
 pub fn viz_add_control(scene: &!VizScene, control_kind: i64, layout: VizLayout, value: f64, min_value: f64, max_value: f64) -> i64 with Mut {
@@ -225,6 +533,345 @@ pub fn viz_add_control(scene: &!VizScene, control_kind: i64, layout: VizLayout, 
     idx
 }
 
+pub fn viz_node_set_label(scene: &!VizScene, node_idx: i64, text: &[i8; 64], len: i64) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    var n = len
+    if n < 0 { n = 0 }
+    if n > 64 { n = 64 }
+    var node = scene.nodes[node_idx as usize]
+    node.label_len = n
+    var i: i64 = 0
+    while i < 64 {
+        node.label[i as usize] = 0
+        i = i + 1
+    }
+    i = 0
+    while i < n {
+        node.label[i as usize] = text[i as usize]
+        i = i + 1
+    }
+    scene.nodes[node_idx as usize] = node
+}
+
+pub fn viz_add_label(scene: &!VizScene, text: &[i8; 64], len: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let idx = viz_scene_add_node(scene, VIZ_NODE_LABEL, layout, style, 0)
+    viz_node_set_label(scene, idx, text, len)
+    idx
+}
+
+pub fn viz_add_text_control(scene: &!VizScene, control_kind: i64, text: &[i8; 64], len: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let idx = viz_add_control(scene, control_kind, layout, 0.0, 0.0, 1.0)
+    if idx >= 0 {
+        scene.nodes[idx as usize].style = style
+        viz_node_set_label(scene, idx, text, len)
+    }
+    idx
+}
+
+pub fn viz_add_button(scene: &!VizScene, text: &[i8; 64], len: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    viz_add_text_control(scene, VIZ_CONTROL_BUTTON, text, len, layout, style)
+}
+
+pub fn viz_add_slider(scene: &!VizScene, layout: VizLayout, value: f64, min_value: f64, max_value: f64, style: VizStyle) -> i64 with Mut {
+    let idx = viz_add_control(scene, VIZ_CONTROL_SLIDER, layout, value, min_value, max_value)
+    if idx >= 0 {
+        scene.nodes[idx as usize].style = style
+    }
+    idx
+}
+
+pub fn viz_add_toggle(scene: &!VizScene, layout: VizLayout, on: bool, style: VizStyle) -> i64 with Mut {
+    let value = if on { 1.0 } else { 0.0 }
+    let idx = viz_add_control(scene, VIZ_CONTROL_TOGGLE, layout, value, 0.0, 1.0)
+    if idx >= 0 {
+        scene.nodes[idx as usize].style = style
+    }
+    idx
+}
+
+pub fn viz_add_tabs(scene: &!VizScene, layout: VizLayout, active: i64, min_tab: i64, max_tab: i64, style: VizStyle) -> i64 with Mut {
+    let idx = viz_add_control(scene, VIZ_CONTROL_TABS, layout, active as f64, min_tab as f64, max_tab as f64)
+    if idx >= 0 {
+        scene.nodes[idx as usize].style = style
+    }
+    idx
+}
+
+pub fn viz_add_viewport(scene: &!VizScene, text: &[i8; 64], len: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    viz_add_text_control(scene, VIZ_CONTROL_VIEWPORT, text, len, layout, style)
+}
+
+pub fn viz_add_plot_viewport(scene: &!VizScene, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    let idx = viz_add_control(scene, VIZ_CONTROL_VIEWPORT, layout, 0.0, 0.0, 1.0)
+    if idx >= 0 {
+        scene.nodes[idx as usize].style = style
+    }
+    idx
+}
+
+pub fn viz_add_legend(scene: &!VizScene, text: &[i8; 64], len: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    viz_add_text_control(scene, VIZ_CONTROL_LEGEND, text, len, layout, style)
+}
+
+pub fn viz_add_tooltip(scene: &!VizScene, text: &[i8; 64], len: i64, layout: VizLayout, style: VizStyle) -> i64 with Mut {
+    viz_add_text_control(scene, VIZ_CONTROL_TOOLTIP, text, len, layout, style)
+}
+
 pub fn viz_scene_set_time(scene: &!VizScene, t: f64) with Mut {
     scene.time = t
+}
+
+pub fn viz_scene_apply_layout_range(scene: &!VizScene, first_idx: i64, count: i64, layout: VizLayout) with Mut {
+    if count <= 0 { return }
+    if first_idx < 0 || first_idx >= scene.node_count { return }
+    var n = count
+    if first_idx + n > scene.node_count {
+        n = scene.node_count - first_idx
+    }
+    if n <= 0 { return }
+
+    if layout.layout_kind == VIZ_LAYOUT_ROW {
+        let total_gap = layout.gap * (n - 1)
+        let cell_w = viz_layout_nonneg(layout.w - total_gap) / n
+        var i: i64 = 0
+        while i < n {
+            let idx = first_idx + i
+            var node = scene.nodes[idx as usize]
+            node.layout = viz_layout_rect(layout.x + i * (cell_w + layout.gap), layout.y, cell_w, layout.h)
+            scene.nodes[idx as usize] = node
+            i = i + 1
+        }
+    } else if layout.layout_kind == VIZ_LAYOUT_COLUMN {
+        let total_gap = layout.gap * (n - 1)
+        let cell_h = viz_layout_nonneg(layout.h - total_gap) / n
+        var i: i64 = 0
+        while i < n {
+            let idx = first_idx + i
+            var node = scene.nodes[idx as usize]
+            node.layout = viz_layout_rect(layout.x, layout.y + i * (cell_h + layout.gap), layout.w, cell_h)
+            scene.nodes[idx as usize] = node
+            i = i + 1
+        }
+    }
+}
+
+pub fn viz_scene_set_slider(scene: &!VizScene, node_idx: i64, value: f64) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    var node = scene.nodes[node_idx as usize]
+    var v = value
+    if v < node.min_value { v = node.min_value }
+    if v > node.max_value { v = node.max_value }
+    node.value = v
+    scene.nodes[node_idx as usize] = node
+}
+
+pub fn viz_scene_set_time_from_slider(scene: &!VizScene, node_idx: i64, value: f64) with Mut {
+    viz_scene_set_slider(scene, node_idx, value)
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    let node = scene.nodes[node_idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_SLIDER {
+        scene.time = node.value
+    }
+}
+
+pub fn viz_scene_set_toggle(scene: &!VizScene, node_idx: i64, enabled: bool) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    var node = scene.nodes[node_idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TOGGLE {
+        node.value = if enabled { 1.0 } else { 0.0 }
+        node.selected = enabled
+        scene.nodes[node_idx as usize] = node
+    }
+}
+
+pub fn viz_scene_toggle(scene: &!VizScene, node_idx: i64) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    let node = scene.nodes[node_idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TOGGLE {
+        viz_scene_set_toggle(scene, node_idx, node.value <= 0.0)
+    }
+}
+
+pub fn viz_scene_set_tab(scene: &!VizScene, node_idx: i64, tab_idx: i64) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    var node = scene.nodes[node_idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TABS {
+        var idx = tab_idx
+        let min_i = node.min_value as i64
+        let max_i = node.max_value as i64
+        if idx < min_i { idx = min_i }
+        if idx > max_i { idx = max_i }
+        node.value = idx as f64
+        scene.active_tab = idx
+        scene.nodes[node_idx as usize] = node
+    }
+}
+
+fn viz_scene_tab_from_pointer(node: &VizNode, px: i64) -> i64 with Mut, Div {
+    let min_i = node.min_value as i64
+    let max_i = node.max_value as i64
+    var count = max_i - min_i + 1
+    if count <= 0 { count = 1 }
+    let denom = if node.layout.w <= 0 { 1 } else { node.layout.w }
+    var rel = px - node.layout.x
+    if rel < 0 { rel = 0 }
+    if rel >= denom { rel = denom - 1 }
+    let tab_w = if denom / count <= 0 { 1 } else { denom / count }
+    var idx = min_i + rel / tab_w
+    if idx > max_i { idx = max_i }
+    idx
+}
+
+pub fn viz_scene_activate_control(scene: &!VizScene, node_idx: i64, px: i64, py: i64) -> i64 with Mut, Div {
+    if node_idx < 0 || node_idx >= scene.node_count { return node_idx }
+    let node = scene.nodes[node_idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TOGGLE {
+        viz_scene_toggle(scene, node_idx)
+    } else if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TABS {
+        let tab = viz_scene_tab_from_pointer(&node, px)
+        viz_scene_set_tab(scene, node_idx, tab)
+    }
+    node_idx
+}
+
+pub fn viz_scene_hit_test(scene: &VizScene, px: i64, py: i64) -> i64 with Mut {
+    var found: i64 = 0 - 1
+    var i: i64 = 0
+    while i < scene.node_count {
+        let n = scene.nodes[i as usize]
+        if px >= n.layout.x && px < n.layout.x + n.layout.w && py >= n.layout.y && py < n.layout.y + n.layout.h {
+            found = i
+        }
+        i = i + 1
+    }
+    found
+}
+
+pub fn viz_scene_pointer_down(scene: &!VizScene, px: i64, py: i64) -> i64 with Mut, Div {
+    let idx = viz_scene_hit_test(scene, px, py)
+    scene.selected_node = idx
+    var i: i64 = 0
+    while i < scene.node_count {
+        scene.nodes[i as usize].selected = i == idx
+        i = i + 1
+    }
+    viz_scene_activate_control(scene, idx, px, py)
+    idx
+}
+
+pub fn viz_scene_pointer_move(scene: &!VizScene, px: i64, py: i64) -> i64 with Mut {
+    let idx = viz_scene_hit_test(scene, px, py)
+    scene.hovered_node = idx
+    idx
+}
+
+pub fn viz_scene_pointer_up(scene: &!VizScene, px: i64, py: i64) -> i64 with Mut {
+    let idx = viz_scene_hit_test(scene, px, py)
+    scene.hovered_node = idx
+    scene.selected_node = 0 - 1
+    var i: i64 = 0
+    while i < scene.node_count {
+        scene.nodes[i as usize].selected = false
+        i = i + 1
+    }
+    idx
+}
+
+pub fn viz_scene_pointer_update(scene: &!VizScene, px: i64, py: i64) -> i64 with Mut, Div {
+    var idx = scene.selected_node
+    if idx < 0 || idx >= scene.node_count {
+        idx = viz_scene_hit_test(scene, px, py)
+        scene.selected_node = idx
+    }
+    if idx < 0 || idx >= scene.node_count { return idx }
+    var node = scene.nodes[idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_SLIDER {
+        let denom = if node.layout.w <= 0 { 1 } else { node.layout.w }
+        var rel = px - node.layout.x
+        if rel < 0 { rel = 0 }
+        if rel > denom { rel = denom }
+        let frac = (rel as f64) / (denom as f64)
+        let value = node.min_value + frac * (node.max_value - node.min_value)
+        viz_scene_set_time_from_slider(scene, idx, value)
+        node = scene.nodes[idx as usize]
+    } else if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TABS {
+        let tab = viz_scene_tab_from_pointer(&node, px)
+        viz_scene_set_tab(scene, idx, tab)
+        node = scene.nodes[idx as usize]
+    }
+    scene.nodes[idx as usize] = node
+    idx
+}
+
+fn viz_scene_step_slider_key(scene: &!VizScene, node_idx: i64, direction: i64) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    let node = scene.nodes[node_idx as usize]
+    let step = (node.max_value - node.min_value) / 10.0
+    viz_scene_set_time_from_slider(scene, node_idx, node.value + step * (direction as f64))
+}
+
+fn viz_scene_step_tab_key(scene: &!VizScene, node_idx: i64, direction: i64) with Mut {
+    if node_idx < 0 || node_idx >= scene.node_count { return }
+    let node = scene.nodes[node_idx as usize]
+    let tab = (node.value as i64) + direction
+    viz_scene_set_tab(scene, node_idx, tab)
+}
+
+pub fn viz_scene_key_press(scene: &!VizScene, key: i64) -> bool with Mut {
+    var idx = scene.selected_node
+    if idx < 0 || idx >= scene.node_count {
+        idx = scene.hovered_node
+    }
+    if idx < 0 || idx >= scene.node_count {
+        return false
+    }
+    let node = scene.nodes[idx as usize]
+    if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_SLIDER {
+        if key == KEY_LEFT {
+            viz_scene_step_slider_key(scene, idx, 0 - 1)
+            return true
+        }
+        if key == KEY_RIGHT {
+            viz_scene_step_slider_key(scene, idx, 1)
+            return true
+        }
+    } else if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TABS {
+        if key == KEY_LEFT {
+            viz_scene_step_tab_key(scene, idx, 0 - 1)
+            return true
+        }
+        if key == KEY_RIGHT || key == KEY_TAB {
+            viz_scene_step_tab_key(scene, idx, 1)
+            return true
+        }
+    } else if node.kind == VIZ_NODE_CONTROL && node.data_slot == VIZ_CONTROL_TOGGLE {
+        if key == KEY_SPACE || key == KEY_RETURN {
+            viz_scene_toggle(scene, idx)
+            return true
+        }
+    }
+    false
+}
+
+pub fn viz_scene_handle_event(scene: &!VizScene, ev: Event) -> bool with Mut, Div {
+    if ev.kind == EV_MOUSE_PRESS && ev.key == MOUSE_LEFT {
+        viz_scene_pointer_down(scene, ev.x, ev.y)
+        return true
+    }
+    if ev.kind == EV_MOTION {
+        if scene.selected_node >= 0 {
+            viz_scene_pointer_update(scene, ev.x, ev.y)
+        } else {
+            viz_scene_pointer_move(scene, ev.x, ev.y)
+        }
+        return true
+    }
+    if ev.kind == EV_MOUSE_RELEASE && ev.key == MOUSE_LEFT {
+        viz_scene_pointer_up(scene, ev.x, ev.y)
+        return true
+    }
+    if ev.kind == EV_KEY_PRESS {
+        return viz_scene_key_press(scene, ev.key)
+    }
+    false
 }

--- a/stdlib/viz/mod.sio
+++ b/stdlib/viz/mod.sio
@@ -8,6 +8,8 @@
 //   viz::ir          fixed-capacity Visual IR
 //   viz::viz_canvas  Visual IR -> display::Canvas
 //   viz::viz_html    Visual IR -> static HTML/SVG
+//   viz::viz_app     Event -> Visual IR -> Canvas app/frame runner
+//   viz::viz_window  Optional display::Window bridge for VizApp
 //   viz::physchem    molecule/field/trajectory visualization data
 
 pub fn viz_version() -> i64 { 1 }

--- a/stdlib/viz/mol3d.sio
+++ b/stdlib/viz/mol3d.sio
@@ -9,8 +9,8 @@
 //   let cam = Camera3D { pos_x: 0.0, pos_y: 0.0, pos_z: -15.0, focal: 400.0 }
 //   mol3d_render(&mol, &cam, angle_y, angle_x, &!canvas)
 
-use display::canvas::{Canvas, canvas_fill_circle}
-use display::canvas_ext::{canvas_draw_line_aa}
+use display::canvas::{Canvas}
+use display::canvas_ext::{canvas_draw_line_aa, canvas_sphere_shaded}
 use render::renderer3d::{Camera3D, Vec3f}
 use viz::physchem::{MoleculeViz}
 
@@ -122,7 +122,11 @@ pub fn mol3d_render(
             canvas_draw_line_aa(c,
                 px[ia as usize], py[ia as usize],
                 px[ib as usize], py[ib as usize],
-                200, 200, 200)
+                140, 155, 175)
+            canvas_draw_line_aa(c,
+                px[ia as usize] + 1, py[ia as usize],
+                px[ib as usize] + 1, py[ib as usize],
+                120, 135, 155)
         }
         bi = bi + 1
     }
@@ -136,7 +140,7 @@ pub fn mol3d_render(
         let idx = order[oi as usize]
         if pvis[idx as usize] == 1 {
             let a = mol.atoms[idx as usize]
-            canvas_fill_circle(c, px[idx as usize], py[idx as usize], prad[idx as usize], a.r, a.g, a.b)
+            canvas_sphere_shaded(c, px[idx as usize], py[idx as usize], prad[idx as usize], a.r, a.g, a.b)
         }
         oi = oi + 1
     }

--- a/stdlib/viz/physchem.sio
+++ b/stdlib/viz/physchem.sio
@@ -61,13 +61,25 @@ pub struct Trajectory3D {
     pub n: i64,
 }
 
+pub struct SpectrumViz {
+    pub x: [f64; 1024],
+    pub intensity: [f64; 1024],
+    pub variance: [f64; 1024],
+    pub n: i64,
+    pub x_min: f64,
+    pub x_max: f64,
+    pub y_min: f64,
+    pub y_max: f64,
+    pub unit: UnitDim,
+}
+
 pub fn atom_viz_default(z: i64, x: f64, y: f64, zz: f64) -> AtomViz {
     AtomViz {
         atomic_number: z, x: x, y: y, z: zz, radius: 1.0,
         charge: Epistemic::certain(0.0),
-        r: if z == 1 { 230 } else if z == 6 { 80 } else if z == 8 { 230 } else { 120 },
-        g: if z == 1 { 230 } else if z == 6 { 90 } else if z == 8 { 70 } else { 160 },
-        b: if z == 1 { 240 } else if z == 6 { 100 } else if z == 8 { 70 } else { 220 },
+        r: if z == 1 { 230 } else if z == 6 { 120 } else if z == 8 { 230 } else { 120 },
+        g: if z == 1 { 230 } else if z == 6 { 135 } else if z == 8 { 70 } else { 160 },
+        b: if z == 1 { 240 } else if z == 6 { 150 } else if z == 8 { 70 } else { 220 },
     }
 }
 
@@ -242,4 +254,87 @@ pub fn scalar_field_radial(rows: i64, cols: i64) -> ScalarField2D with Mut, Div 
         r = r + 1
     }
     f
+}
+
+pub fn vector_field_empty(rows: i64, cols: i64) -> VectorField2D {
+    VectorField2D {
+        vx: [0.0; 4096], vy: [0.0; 4096], variance: [0.0; 4096],
+        rows: rows, cols: cols, unit: dim_dimensionless(),
+    }
+}
+
+pub fn vector_field_vortex(rows: i64, cols: i64) -> VectorField2D with Mut, Div {
+    var f = vector_field_empty(rows, cols)
+    var r: i64 = 0
+    while r < rows {
+        var c: i64 = 0
+        while c < cols {
+            let dx = (c as f64) - (cols as f64) * 0.5
+            let dy = (r as f64) - (rows as f64) * 0.5
+            let idx = r * cols + c
+            f.vx[idx as usize] = 0.0 - dy
+            f.vy[idx as usize] = dx
+            f.variance[idx as usize] = (dx * dx + dy * dy) * 0.0005
+            c = c + 1
+        }
+        r = r + 1
+    }
+    f
+}
+
+pub fn trajectory_empty() -> Trajectory3D {
+    Trajectory3D {
+        x: [0.0; 1024], y: [0.0; 1024], z: [0.0; 1024],
+        t: [0.0; 1024], variance: [0.0; 1024], n: 0,
+    }
+}
+
+pub fn trajectory_spiral(n: i64) -> Trajectory3D with Mut, Div {
+    var tr = trajectory_empty()
+    var count = n
+    if count > 1024 { count = 1024 }
+    tr.n = count
+    var i: i64 = 0
+    while i < count {
+        let theta = (i as f64) * 0.35
+        let radius = 0.25 + (i as f64) * 0.01
+        tr.x[i as usize] = radius * rap_cos(theta)
+        tr.y[i as usize] = radius * rap_sin(theta)
+        tr.z[i as usize] = (i as f64) * 0.02
+        tr.t[i as usize] = i as f64
+        tr.variance[i as usize] = (i as f64) * 0.0001
+        i = i + 1
+    }
+    tr
+}
+
+pub fn spectrum_empty() -> SpectrumViz {
+    SpectrumViz {
+        x: [0.0; 1024], intensity: [0.0; 1024], variance: [0.0; 1024],
+        n: 0, x_min: 0.0, x_max: 1.0, y_min: 0.0, y_max: 1.0,
+        unit: dim_dimensionless(),
+    }
+}
+
+pub fn spectrum_absorption_demo(n: i64) -> SpectrumViz with Mut, Div {
+    var s = spectrum_empty()
+    var count = n
+    if count > 1024 { count = 1024 }
+    s.n = count
+    var i: i64 = 0
+    while i < count {
+        let x = 350.0 + (i as f64) * 4.0
+        let peak_a = 1.0 / (1.0 + ((x - 430.0) * (x - 430.0)) / 900.0)
+        let peak_b = 0.7 / (1.0 + ((x - 610.0) * (x - 610.0)) / 1600.0)
+        let y = peak_a + peak_b
+        s.x[i as usize] = x
+        s.intensity[i as usize] = y
+        s.variance[i as usize] = y * 0.002
+        if i == 0 || x < s.x_min { s.x_min = x }
+        if i == 0 || x > s.x_max { s.x_max = x }
+        if i == 0 || y < s.y_min { s.y_min = y }
+        if i == 0 || y > s.y_max { s.y_max = y }
+        i = i + 1
+    }
+    s
 }

--- a/stdlib/viz/physchem.sio
+++ b/stdlib/viz/physchem.sio
@@ -73,6 +73,27 @@ pub struct SpectrumViz {
     pub unit: UnitDim,
 }
 
+pub struct LatticeField2D {
+    pub rows: i64,
+    pub cols: i64,
+    pub displacement_x: [f64; 4096],
+    pub displacement_y: [f64; 4096],
+    pub phase: [f64; 4096],
+    pub variance: [f64; 4096],
+    pub unit: UnitDim,
+}
+
+pub struct ParticleEventView {
+    pub x: [f64; 1024],
+    pub y: [f64; 1024],
+    pub z: [f64; 1024],
+    pub energy: [f64; 1024],
+    pub variance: [f64; 1024],
+    pub kind: [i64; 1024],
+    pub n: i64,
+    pub unit: UnitDim,
+}
+
 pub fn atom_viz_default(z: i64, x: f64, y: f64, zz: f64) -> AtomViz {
     AtomViz {
         atomic_number: z, x: x, y: y, z: zz, radius: 1.0,
@@ -337,4 +358,55 @@ pub fn spectrum_absorption_demo(n: i64) -> SpectrumViz with Mut, Div {
         i = i + 1
     }
     s
+}
+
+pub fn lattice_field_empty(rows: i64, cols: i64) -> LatticeField2D {
+    LatticeField2D {
+        rows: rows, cols: cols,
+        displacement_x: [0.0; 4096], displacement_y: [0.0; 4096],
+        phase: [0.0; 4096], variance: [0.0; 4096],
+        unit: dim_dimensionless(),
+    }
+}
+
+pub fn lattice_field_phonon_demo(rows: i64, cols: i64) -> LatticeField2D with Mut, Div {
+    var field = lattice_field_empty(rows, cols)
+    var r: i64 = 0
+    while r < rows {
+        var c: i64 = 0
+        while c < cols {
+            let idx = r * cols + c
+            field.phase[idx as usize] = ((r + c) as f64) * 0.25
+            field.displacement_x[idx as usize] = ((c as f64) - (cols as f64) * 0.5) * 0.02
+            field.displacement_y[idx as usize] = ((r as f64) - (rows as f64) * 0.5) * 0.02
+            field.variance[idx as usize] = 0.001 + (idx as f64) * 0.0001
+            c = c + 1
+        }
+        r = r + 1
+    }
+    field
+}
+
+pub fn particle_event_view_empty() -> ParticleEventView {
+    ParticleEventView {
+        x: [0.0; 1024], y: [0.0; 1024], z: [0.0; 1024],
+        energy: [0.0; 1024], variance: [0.0; 1024],
+        kind: [0; 1024], n: 0, unit: dim_dimensionless(),
+    }
+}
+
+pub fn particle_event_view_demo(n: i64) -> ParticleEventView with Mut, Div {
+    var events = particle_event_view_empty()
+    var i: i64 = 0
+    while i < n && i < 1024 {
+        events.x[i as usize] = (i as f64) * 0.1
+        events.y[i as usize] = ((i * i) as f64) * 0.01
+        events.z[i as usize] = (i as f64) * 0.02
+        events.energy[i as usize] = 1.0 + (i as f64) * 0.05
+        events.variance[i as usize] = 0.01 + (i as f64) * 0.001
+        events.kind[i as usize] = i % 3
+        i = i + 1
+    }
+    events.n = i
+    events
 }

--- a/stdlib/viz/viz_app.sio
+++ b/stdlib/viz/viz_app.sio
@@ -1,0 +1,60 @@
+// stdlib/viz/viz_app.sio - small native app runner over Visual IR
+//
+// This is the headless-testable bridge for future native windows:
+// display::event::Event -> viz::ir::VizScene -> display::Canvas.
+
+use display::canvas::{Canvas, canvas_clear}
+use display::event::{Event, EV_CLOSE, EV_EXPOSE}
+use viz::ir::{VizScene, viz_scene_handle_event}
+use viz::viz_canvas::{viz_canvas_render_scene}
+
+pub struct VizApp {
+    pub running: bool,
+    pub dirty: bool,
+    pub frame: i64,
+    pub bg_r: i64,
+    pub bg_g: i64,
+    pub bg_b: i64,
+}
+
+pub fn viz_app_new(bg_r: i64, bg_g: i64, bg_b: i64) -> VizApp {
+    VizApp {
+        running: true,
+        dirty: true,
+        frame: 0,
+        bg_r: bg_r,
+        bg_g: bg_g,
+        bg_b: bg_b,
+    }
+}
+
+pub fn viz_app_handle_event(app: &!VizApp, scene: &!VizScene, ev: Event) -> bool with Mut, Div {
+    if ev.kind == EV_CLOSE {
+        app.running = false
+        app.dirty = false
+        return true
+    }
+    if ev.kind == EV_EXPOSE {
+        app.dirty = true
+        return true
+    }
+    let changed = viz_scene_handle_event(scene, ev)
+    if changed {
+        app.dirty = true
+    }
+    changed
+}
+
+pub fn viz_app_render(app: &!VizApp, scene: &!VizScene, c: &!Canvas) with Mut, Div, Alloc {
+    if !app.dirty { return }
+    canvas_clear(c, app.bg_r, app.bg_g, app.bg_b)
+    viz_canvas_render_scene(scene, c)
+    app.frame = app.frame + 1
+    app.dirty = false
+}
+
+pub fn viz_app_step(app: &!VizApp, scene: &!VizScene, c: &!Canvas, ev: Event) -> bool with Mut, Div, Alloc {
+    viz_app_handle_event(app, scene, ev)
+    viz_app_render(app, scene, c)
+    app.running
+}

--- a/stdlib/viz/viz_canvas.sio
+++ b/stdlib/viz/viz_canvas.sio
@@ -1,15 +1,17 @@
 // stdlib/viz/viz_canvas.sio — Visual IR renderer to display::Canvas
 
-use display::canvas::{Canvas, canvas_fill_rect, canvas_draw_rect, canvas_draw_text}
+use display::canvas::{Canvas, canvas_fill_rect, canvas_draw_rect, canvas_draw_text, canvas_fill_circle}
 use display::canvas_ext::{canvas_draw_line_aa}
 use viz::coord::{coord_new, coord_draw_axes}
 use viz::chart::{chart_line, chart_scatter, chart_bar, chart_heatmap}
 use viz::epiviz::{epiviz_band}
+use render::renderer3d::{Camera3D, Light3D, Tri3D, r3d_depth_buf_alloc, r3d_depth_buf_clear, r3d_render_viewport}
 use viz::ir::{
     VizScene, VizNode,
     VIZ_NODE_PANEL, VIZ_NODE_CHART_LINE, VIZ_NODE_CHART_SCATTER, VIZ_NODE_CHART_BAR,
     VIZ_NODE_HEATMAP, VIZ_NODE_UNCERTAINTY_BAND, VIZ_NODE_LABEL, VIZ_NODE_CONTROL,
-    VIZ_NODE_MOLECULE, VIZ_NODE_FIELD,
+    VIZ_NODE_FOREST, VIZ_NODE_WATERFALL,
+    VIZ_NODE_MOLECULE, VIZ_NODE_FIELD, VIZ_NODE_VECTOR_FIELD, VIZ_NODE_TRAJECTORY, VIZ_NODE_SPECTRUM, VIZ_NODE_MESH,
     VIZ_CONTROL_SLIDER, VIZ_CONTROL_TOGGLE, VIZ_CONTROL_TABS, VIZ_CONTROL_LEGEND,
     VIZ_CONTROL_BUTTON, VIZ_CONTROL_TOOLTIP, VIZ_CONTROL_VIEWPORT
 }
@@ -35,14 +37,32 @@ fn vc_draw_control(c: &!Canvas, node: &VizNode) with Mut, Div {
         canvas_fill_rect(c, knob_x - 3, y, 7, h, node.style.r, node.style.g, node.style.b)
     } else if node.data_slot == VIZ_CONTROL_TOGGLE {
         canvas_draw_rect(c, x, y, w, h, 130, 150, 160)
-        if node.selected {
+        if node.value > 0.0 {
             canvas_fill_rect(c, x + 3, y + 3, w - 6, h - 6, node.style.r, node.style.g, node.style.b)
         }
     } else if node.data_slot == VIZ_CONTROL_TABS {
         canvas_fill_rect(c, x, y, w, h, 40, 48, 58)
-        canvas_fill_rect(c, x, y, w / 3, h, node.style.r, node.style.g, node.style.b)
-    } else if node.data_slot == VIZ_CONTROL_LEGEND || node.data_slot == VIZ_CONTROL_TOOLTIP || node.data_slot == VIZ_CONTROL_VIEWPORT || node.data_slot == VIZ_CONTROL_BUTTON {
+        let min_i = node.min_value as i64
+        let max_i = node.max_value as i64
+        var count = max_i - min_i + 1
+        if count <= 0 { count = 1 }
+        let tab_w = if w / count <= 0 { 1 } else { w / count }
+        var active = node.value as i64
+        if active < min_i { active = min_i }
+        if active > max_i { active = max_i }
+        canvas_fill_rect(c, x + (active - min_i) * tab_w, y, tab_w, h, node.style.r, node.style.g, node.style.b)
         canvas_draw_rect(c, x, y, w, h, 120, 135, 150)
+    } else if node.data_slot == VIZ_CONTROL_LEGEND {
+        canvas_draw_rect(c, x, y, w, h, 120, 135, 150)
+        canvas_fill_rect(c, x + 4, y + h / 2 - 3, 10, 6, node.style.r, node.style.g, node.style.b)
+        vc_draw_label(c, node)
+    } else if node.data_slot == VIZ_CONTROL_TOOLTIP {
+        canvas_fill_rect(c, x, y, w, h, 28, 34, 42)
+        canvas_draw_rect(c, x, y, w, h, 140, 155, 170)
+        vc_draw_label(c, node)
+    } else if node.data_slot == VIZ_CONTROL_VIEWPORT || node.data_slot == VIZ_CONTROL_BUTTON {
+        canvas_draw_rect(c, x, y, w, h, 120, 135, 150)
+        vc_draw_label(c, node)
     }
 }
 
@@ -56,7 +76,242 @@ fn vc_draw_label(c: &!Canvas, node: &VizNode) with Mut {
     canvas_draw_text(c, &buf, node.label_len, node.layout.x, node.layout.y, node.style.r, node.style.g, node.style.b)
 }
 
-pub fn viz_canvas_render_scene(scene: &VizScene, c: &!Canvas) with Mut, Div {
+fn vc_clamp(v: i64, lo: i64, hi: i64) -> i64 {
+    if v < lo { lo } else if v > hi { hi } else { v }
+}
+
+fn vc_sqrt(x: f64) -> f64 with Mut, Div {
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    var i: i64 = 0
+    while i < 12 {
+        g = (g + x / g) * 0.5
+        i = i + 1
+    }
+    g
+}
+
+fn vc_draw_waterfall(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    let d = scene.series[node.data_slot as usize]
+    if d.n <= 0 { return }
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 80, 95, 110)
+    let row_h = vc_clamp(node.layout.h / d.n - 2, 3, 24)
+    let span = if d.y_max == d.y_min { 1.0 } else { d.y_max - d.y_min }
+    var i: i64 = 0
+    while i < d.n && i < 1024 {
+        let frac = (d.ys[i as usize] - d.y_min) / span
+        let bar_w = vc_clamp((frac * (node.layout.w as f64)) as i64, 1, node.layout.w)
+        let py = node.layout.y + i * (row_h + 2)
+        canvas_fill_rect(c, node.layout.x, py, bar_w, row_h, node.style.r, node.style.g, node.style.b)
+        canvas_fill_rect(c, node.layout.x + bar_w, py, node.layout.w - bar_w, row_h, 36, 40, 50)
+        i = i + 1
+    }
+}
+
+fn vc_draw_forest(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    let d = scene.series[node.data_slot as usize]
+    if d.n <= 0 { return }
+    var x_min = d.x_min
+    var x_max = d.x_max
+    var i: i64 = 0
+    while i < d.n && i < 1024 {
+        let sigma = vc_sqrt(d.vars[i as usize])
+        let lo = d.xs[i as usize] - sigma
+        let hi = d.xs[i as usize] + sigma
+        if lo < x_min { x_min = lo }
+        if hi > x_max { x_max = hi }
+        i = i + 1
+    }
+    if x_min == x_max {
+        x_min = x_min - 1.0
+        x_max = x_max + 1.0
+    }
+    let row_h = vc_clamp(node.layout.h / (d.n + 1), 5, 22)
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 90, 95, 120)
+    i = 0
+    while i < d.n && i < 1024 {
+        let sigma = vc_sqrt(d.vars[i as usize])
+        let row_y = node.layout.y + row_h / 2 + i * row_h
+        let sx = node.layout.x + (((d.xs[i as usize] - x_min) / (x_max - x_min)) * (node.layout.w as f64)) as i64
+        let slo = node.layout.x + ((((d.xs[i as usize] - sigma) - x_min) / (x_max - x_min)) * (node.layout.w as f64)) as i64
+        let shi = node.layout.x + ((((d.xs[i as usize] + sigma) - x_min) / (x_max - x_min)) * (node.layout.w as f64)) as i64
+        canvas_fill_rect(c, slo, row_y, shi - slo + 1, 1, 180, 180, 220)
+        canvas_fill_rect(c, slo, row_y - 2, 1, 5, 180, 180, 220)
+        canvas_fill_rect(c, shi, row_y - 2, 1, 5, 180, 180, 220)
+        canvas_fill_rect(c, sx - 3, row_y - 3, 7, 7, node.style.r, node.style.g, node.style.b)
+        i = i + 1
+    }
+}
+
+fn vc_mol_x(node: &VizNode, x: f64) -> i64 {
+    node.layout.x + node.layout.w / 2 + (x * (node.layout.w as f64) * 0.30) as i64
+}
+
+fn vc_mol_y(node: &VizNode, y: f64) -> i64 {
+    node.layout.y + node.layout.h / 2 - (y * (node.layout.h as f64) * 0.30) as i64
+}
+
+fn vc_draw_molecule(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 120, 130, 150)
+    let slot = node.data_slot as usize
+    let bond_count = scene.molecules[slot].bond_count
+    var bi: i64 = 0
+    while bi < bond_count {
+        let b = scene.molecules[slot].bonds[bi as usize]
+        let a0 = scene.molecules[slot].atoms[b.atom_a as usize]
+        let a1 = scene.molecules[slot].atoms[b.atom_b as usize]
+        let x0 = vc_mol_x(node, a0.x)
+        let y0 = vc_mol_y(node, a0.y)
+        let x1 = vc_mol_x(node, a1.x)
+        let y1 = vc_mol_y(node, a1.y)
+        canvas_draw_line_aa(c, x0, y0, x1, y1, 180, 190, 205)
+        if b.order > 1 {
+            canvas_draw_line_aa(c, x0, y0 + 2, x1, y1 + 2, 150, 160, 175)
+        }
+        bi = bi + 1
+    }
+    let atom_count = scene.molecules[slot].atom_count
+    let cx = node.layout.x + node.layout.w / 2
+    let cy = node.layout.y + node.layout.h / 2
+    canvas_fill_rect(c, cx - 2, cy - 2, 5, 5, node.style.r, node.style.g, node.style.b)
+    var ai: i64 = 0
+    while ai < atom_count {
+        let a = scene.molecules[slot].atoms[ai as usize]
+        let sx = vc_mol_x(node, a.x)
+        let sy = vc_mol_y(node, a.y)
+        let rad = vc_clamp((a.radius * 8.0) as i64, 3, 12)
+        canvas_fill_circle(c, sx, sy, rad, a.r, a.g, a.b)
+        canvas_fill_rect(c, sx - 1, sy - 1, 3, 3, a.r, a.g, a.b)
+        canvas_draw_rect(c, sx - rad, sy - rad, rad * 2 + 1, rad * 2 + 1, 40, 45, 55)
+        ai = ai + 1
+    }
+}
+
+fn vc_draw_field(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    let rows: i64 = 8
+    let cols: i64 = 8
+    let cell_w = if cols == 0 { 1 } else { node.layout.w / cols }
+    let cell_h = if rows == 0 { 1 } else { node.layout.h / rows }
+    var rr: i64 = 0
+    while rr < rows {
+        var cc: i64 = 0
+        while cc < cols {
+            let intensity = (rr * 24 + cc * 12) % 220
+            canvas_fill_rect(c, node.layout.x + cc * cell_w, node.layout.y + rr * cell_h, cell_w + 1, cell_h + 1, intensity / 3, 80 + intensity / 4, 130 + intensity / 3)
+            cc = cc + 1
+        }
+        rr = rr + 1
+    }
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 90, 120, 130)
+    let cx = node.layout.x + node.layout.w / 2
+    let cy = node.layout.y + node.layout.h / 2
+    canvas_draw_line_aa(c, cx - cell_w, cy, cx + cell_w, cy, 240, 240, 180)
+    canvas_draw_line_aa(c, cx, cy - cell_h, cx, cy + cell_h, 240, 240, 180)
+}
+
+fn vc_draw_vector_field(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    let f = scene.vector_data[node.data_slot as usize]
+    let rows = scene.vector_field_rows[node.data_slot as usize]
+    let cols = scene.vector_field_cols[node.data_slot as usize]
+    let cell_w = if cols <= 0 { 1 } else { node.layout.w / cols }
+    let cell_h = if rows <= 0 { 1 } else { node.layout.h / rows }
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 120, 110, 70)
+    var rr: i64 = 0
+    while rr < rows && rr < 32 {
+        var cc: i64 = 0
+        while cc < cols && cc < 32 {
+            let idx = rr * cols + cc
+            let cx = node.layout.x + cc * cell_w + cell_w / 2
+            let cy = node.layout.y + rr * cell_h + cell_h / 2
+            let dx = vc_clamp((f.vx[idx as usize] * 3.0) as i64, 0 - cell_w / 2, cell_w / 2)
+            let dy = vc_clamp((f.vy[idx as usize] * 3.0) as i64, 0 - cell_h / 2, cell_h / 2)
+            canvas_draw_line_aa(c, cx, cy, cx + dx, cy + dy, node.style.r, node.style.g, node.style.b)
+            canvas_fill_rect(c, cx + dx - 1, cy + dy - 1, 3, 3, node.style.r, node.style.g, node.style.b)
+            cc = cc + 1
+        }
+        rr = rr + 1
+    }
+}
+
+fn vc_traj_x(node: &VizNode, x: f64, z: f64) -> i64 {
+    node.layout.x + node.layout.w / 2 + (x * (node.layout.w as f64) * 0.35) as i64 + (z * 2.0) as i64
+}
+
+fn vc_traj_y(node: &VizNode, y: f64, z: f64) -> i64 {
+    node.layout.y + node.layout.h / 2 - (y * (node.layout.h as f64) * 0.35) as i64 - (z * 2.0) as i64
+}
+
+fn vc_draw_trajectory(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    let tr = scene.trajectory_data[node.data_slot as usize]
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 120, 95, 150)
+    var i: i64 = 1
+    while i < tr.n && i < 1024 {
+        let x0 = vc_traj_x(node, tr.x[(i - 1) as usize], tr.z[(i - 1) as usize])
+        let y0 = vc_traj_y(node, tr.y[(i - 1) as usize], tr.z[(i - 1) as usize])
+        let x1 = vc_traj_x(node, tr.x[i as usize], tr.z[i as usize])
+        let y1 = vc_traj_y(node, tr.y[i as usize], tr.z[i as usize])
+        canvas_draw_line_aa(c, x0, y0, x1, y1, node.style.r, node.style.g, node.style.b)
+        i = i + 1
+    }
+    if tr.n > 0 {
+        let sx = vc_traj_x(node, tr.x[0], tr.z[0])
+        let sy = vc_traj_y(node, tr.y[0], tr.z[0])
+        canvas_fill_rect(c, sx - 2, sy - 2, 5, 5, 180, 230, 190)
+        let last = tr.n - 1
+        let ex = vc_traj_x(node, tr.x[last as usize], tr.z[last as usize])
+        let ey = vc_traj_y(node, tr.y[last as usize], tr.z[last as usize])
+        canvas_fill_rect(c, ex - 2, ey - 2, 5, 5, 255, 180, 130)
+        var cur = scene.time as i64
+        if cur < 0 { cur = 0 }
+        if cur >= tr.n { cur = tr.n - 1 }
+        let tx = vc_traj_x(node, tr.x[cur as usize], tr.z[cur as usize])
+        let ty = vc_traj_y(node, tr.y[cur as usize], tr.z[cur as usize])
+        canvas_draw_rect(c, tx - 4, ty - 4, 9, 9, 255, 245, 120)
+    }
+}
+
+fn vc_spec_x(node: &VizNode, x: f64, xmin: f64, xmax: f64) -> i64 {
+    let span = if xmax == xmin { 1.0 } else { xmax - xmin }
+    node.layout.x + (((x - xmin) / span) * (node.layout.w as f64)) as i64
+}
+
+fn vc_spec_y(node: &VizNode, y: f64, ymin: f64, ymax: f64) -> i64 {
+    let span = if ymax == ymin { 1.0 } else { ymax - ymin }
+    node.layout.y + node.layout.h - (((y - ymin) / span) * (node.layout.h as f64)) as i64
+}
+
+fn vc_draw_spectrum(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div {
+    let s = scene.spectrum_data[node.data_slot as usize]
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 140, 110, 70)
+    var i: i64 = 1
+    while i < s.n && i < 1024 {
+        let x0 = vc_spec_x(node, s.x[(i - 1) as usize], s.x_min, s.x_max)
+        let y0 = vc_spec_y(node, s.intensity[(i - 1) as usize], s.y_min, s.y_max)
+        let x1 = vc_spec_x(node, s.x[i as usize], s.x_min, s.x_max)
+        let y1 = vc_spec_y(node, s.intensity[i as usize], s.y_min, s.y_max)
+        canvas_draw_line_aa(c, x0, y0, x1, y1, node.style.r, node.style.g, node.style.b)
+        i = i + 1
+    }
+}
+
+fn vc_draw_mesh(scene: &VizScene, c: &!Canvas, node: &VizNode) with Mut, Div, Alloc {
+    let m = scene.meshes[node.data_slot as usize]
+    var tris: [Tri3D; 4096] = [m.tris[0]; 4096]
+    var i: i64 = 0
+    while i < m.n && i < 128 {
+        tris[i as usize] = m.tris[i as usize]
+        i = i + 1
+    }
+    let cam = Camera3D { pos_x: 0.0, pos_y: 0.0, pos_z: 0.0, focal: (node.layout.w as f64) * 0.8 }
+    let light = Light3D { dx: 0.0, dy: 0.0, dz: 1.0, r: 255, g: 255, b: 255, ambient: 0.35 }
+    let depth = r3d_depth_buf_alloc(c.width, c.height)
+    r3d_depth_buf_clear(depth, c.width, c.height)
+    r3d_render_viewport(&tris, m.n, &cam, &light, depth, c, node.layout.x, node.layout.y, node.layout.w, node.layout.h)
+    heap_free(depth as *mut i8)
+    canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 120, 130, 150)
+}
+
+pub fn viz_canvas_render_scene(scene: &VizScene, c: &!Canvas) with Mut, Div, Alloc {
     var i: i64 = 0
     while i < scene.node_count {
         let node = scene.nodes[i as usize]
@@ -88,11 +343,22 @@ pub fn viz_canvas_render_scene(scene: &VizScene, c: &!Canvas) with Mut, Div {
             let cs = coord_new(0.0, h.cols as f64, 0.0, h.rows as f64, node.layout.x, node.layout.y, node.layout.w, node.layout.h)
             chart_heatmap(&cs, &h.values, h.rows, h.cols, h.min_value, h.max_value, c)
             coord_draw_axes(&cs, c)
+        } else if node.kind == VIZ_NODE_FOREST {
+            vc_draw_forest(scene, c, &node)
+        } else if node.kind == VIZ_NODE_WATERFALL {
+            vc_draw_waterfall(scene, c, &node)
         } else if node.kind == VIZ_NODE_MOLECULE {
-            canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 120, 130, 150)
-            canvas_draw_line_aa(c, node.layout.x + 20, node.layout.y + node.layout.h / 2, node.layout.x + node.layout.w - 20, node.layout.y + node.layout.h / 2, node.style.r, node.style.g, node.style.b)
+            vc_draw_molecule(scene, c, &node)
         } else if node.kind == VIZ_NODE_FIELD {
-            canvas_draw_rect(c, node.layout.x, node.layout.y, node.layout.w, node.layout.h, 90, 120, 130)
+            vc_draw_field(scene, c, &node)
+        } else if node.kind == VIZ_NODE_VECTOR_FIELD {
+            vc_draw_vector_field(scene, c, &node)
+        } else if node.kind == VIZ_NODE_TRAJECTORY {
+            vc_draw_trajectory(scene, c, &node)
+        } else if node.kind == VIZ_NODE_SPECTRUM {
+            vc_draw_spectrum(scene, c, &node)
+        } else if node.kind == VIZ_NODE_MESH {
+            vc_draw_mesh(scene, c, &node)
         }
         i = i + 1
     }

--- a/stdlib/viz/viz_html.sio
+++ b/stdlib/viz/viz_html.sio
@@ -3,7 +3,7 @@
 // V1 emits static SVG/HTML markup to stdout. No JavaScript owns scientific
 // semantics; this renderer only serializes Sounio Visual IR geometry.
 
-use viz::ir::{VizScene, VIZ_NODE_PANEL, VIZ_NODE_CHART_LINE, VIZ_NODE_HEATMAP, VIZ_NODE_UNCERTAINTY_BAND, VIZ_NODE_CONTROL}
+use viz::ir::{VizScene, VIZ_NODE_PANEL, VIZ_NODE_CHART_LINE, VIZ_NODE_CHART_SCATTER, VIZ_NODE_CHART_BAR, VIZ_NODE_HEATMAP, VIZ_NODE_UNCERTAINTY_BAND, VIZ_NODE_LABEL, VIZ_NODE_CONTROL, VIZ_NODE_FOREST, VIZ_NODE_WATERFALL, VIZ_NODE_MOLECULE, VIZ_NODE_FIELD, VIZ_NODE_VECTOR_FIELD, VIZ_NODE_TRAJECTORY, VIZ_NODE_SPECTRUM, VIZ_NODE_MESH, VIZ_CONTROL_BUTTON, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TOGGLE, VIZ_CONTROL_TABS, VIZ_CONTROL_LEGEND, VIZ_CONTROL_TOOLTIP, VIZ_CONTROL_VIEWPORT}
 
 fn vh_print_i64(n: i64) with IO, Mut, Div {
     if n == 0 { print("0"); return }
@@ -39,6 +39,383 @@ fn vh_emit_rect(x: i64, y: i64, w: i64, h: i64, r: i64, g: i64, b: i64) with IO,
     print("\" fill=\"rgb("); vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b); println(")\"/>")
 }
 
+fn vh_emit_rect_stroke(x: i64, y: i64, w: i64, h: i64, r: i64, g: i64, b: i64) with IO, Mut, Div {
+    print("<rect x=\""); vh_print_i64(x); print("\" y=\""); vh_print_i64(y)
+    print("\" width=\""); vh_print_i64(w); print("\" height=\""); vh_print_i64(h)
+    print("\" fill=\"none\" stroke=\"rgb("); vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b); println(")\" stroke-width=\"1\"/>")
+}
+
+fn vh_emit_line(x0: i64, y0: i64, x1: i64, y1: i64, r: i64, g: i64, b: i64) with IO, Mut, Div {
+    print("<line x1=\""); vh_print_i64(x0); print("\" y1=\""); vh_print_i64(y0)
+    print("\" x2=\""); vh_print_i64(x1); print("\" y2=\""); vh_print_i64(y1)
+    print("\" stroke=\"rgb("); vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b); println(")\" stroke-width=\"1.5\"/>")
+}
+
+fn vh_emit_circle(cx: i64, cy: i64, radius: i64, r: i64, g: i64, b: i64) with IO, Mut, Div {
+    print("<circle cx=\""); vh_print_i64(cx); print("\" cy=\""); vh_print_i64(cy)
+    print("\" r=\""); vh_print_i64(radius); print("\" fill=\"rgb(")
+    vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b); println(")\"/>")
+}
+
+fn vh_emit_text(scene: &VizScene, node_idx: i64, x: i64, y: i64, r: i64, g: i64, b: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    print("<text x=\""); vh_print_i64(x); print("\" y=\""); vh_print_i64(y)
+    print("\" fill=\"rgb("); vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b)
+    print(")\" font-family=\"monospace\" font-size=\"10\">")
+    var i: i64 = 0
+    while i < n.label_len && i < 64 {
+        let ch = n.label[i as usize] as i64
+        let uch = if ch < 0 { ch + 256 } else { ch }
+        if uch == 38 { print("&amp;") }
+        else if uch == 60 { print("&lt;") }
+        else if uch == 62 { print("&gt;") }
+        else if uch == 34 { print("&quot;") }
+        else if uch >= 32 && uch <= 126 {
+            print_char(uch)
+        }
+        i = i + 1
+    }
+    println("</text>")
+}
+
+fn vh_clamp_i(v: i64, lo: i64, hi: i64) -> i64 {
+    if v < lo { lo } else if v > hi { hi } else { v }
+}
+
+fn vh_sqrt(x: f64) -> f64 with Mut, Div {
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    var i: i64 = 0
+    while i < 12 {
+        g = (g + x / g) * 0.5
+        i = i + 1
+    }
+    g
+}
+
+fn vh_series_x(x0: i64, w: i64, x: f64, xmin: f64, xmax: f64) -> i64 {
+    let span = if xmax == xmin { 1.0 } else { xmax - xmin }
+    x0 + (((x - xmin) / span) * (w as f64)) as i64
+}
+
+fn vh_series_y(y0: i64, h: i64, y: f64, ymin: f64, ymax: f64) -> i64 {
+    let span = if ymax == ymin { 1.0 } else { ymax - ymin }
+    y0 + h - (((y - ymin) / span) * (h as f64)) as i64
+}
+
+fn vh_emit_series_polyline(scene: &VizScene, node_idx: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    let d = scene.series[n.data_slot as usize]
+    print("<polyline fill=\"none\" stroke=\"rgb(")
+    vh_print_i64(n.style.r); print(","); vh_print_i64(n.style.g); print(","); vh_print_i64(n.style.b)
+    print(")\" stroke-width=\""); vh_print_i64(n.style.stroke_width); print("\" points=\"")
+    var j: i64 = 0
+    while j < d.n {
+        let px = vh_series_x(n.layout.x, n.layout.w, d.xs[j as usize], d.x_min, d.x_max)
+        let py = vh_series_y(n.layout.y, n.layout.h, d.ys[j as usize], d.y_min, d.y_max)
+        vh_print_i64(px); print(","); vh_print_i64(py)
+        if j < d.n - 1 { print(" ") }
+        j = j + 1
+    }
+    println("\"/>")
+}
+
+fn vh_emit_scatter(scene: &VizScene, node_idx: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    let d = scene.series[n.data_slot as usize]
+    var j: i64 = 0
+    while j < d.n && j < 1024 {
+        let px = vh_series_x(n.layout.x, n.layout.w, d.xs[j as usize], d.x_min, d.x_max)
+        let py = vh_series_y(n.layout.y, n.layout.h, d.ys[j as usize], d.y_min, d.y_max)
+        vh_emit_circle(px, py, 3, n.style.r, n.style.g, n.style.b)
+        j = j + 1
+    }
+    print("<!-- scatter n="); vh_print_i64(d.n); println(" -->")
+}
+
+fn vh_emit_bar(scene: &VizScene, node_idx: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    let d = scene.series[n.data_slot as usize]
+    let bar_w = if d.n <= 0 { 1 } else { n.layout.w / d.n }
+    var j: i64 = 0
+    while j < d.n && j < 1024 {
+        let py = vh_series_y(n.layout.y, n.layout.h, d.ys[j as usize], d.y_min, d.y_max)
+        let x = n.layout.x + j * bar_w
+        let h = n.layout.y + n.layout.h - py
+        vh_emit_rect(x, py, if bar_w > 1 { bar_w - 1 } else { 1 }, h, n.style.r, n.style.g, n.style.b)
+        j = j + 1
+    }
+    print("<!-- bar n="); vh_print_i64(d.n); println(" -->")
+}
+
+fn vh_emit_waterfall(scene: &VizScene, node_idx: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    let d = scene.series[n.data_slot as usize]
+    vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 80, 95, 110)
+    if d.n <= 0 { return }
+    let row_h = vh_clamp_i(n.layout.h / d.n - 2, 3, 24)
+    let span = if d.y_max == d.y_min { 1.0 } else { d.y_max - d.y_min }
+    var i: i64 = 0
+    while i < d.n && i < 1024 {
+        let frac = (d.ys[i as usize] - d.y_min) / span
+        let bar_w = vh_clamp_i((frac * (n.layout.w as f64)) as i64, 1, n.layout.w)
+        let py = n.layout.y + i * (row_h + 2)
+        vh_emit_rect(n.layout.x, py, bar_w, row_h, n.style.r, n.style.g, n.style.b)
+        vh_emit_rect(n.layout.x + bar_w, py, n.layout.w - bar_w, row_h, 36, 40, 50)
+        i = i + 1
+    }
+    print("<!-- waterfall n="); vh_print_i64(d.n); println(" -->")
+}
+
+fn vh_emit_forest(scene: &VizScene, node_idx: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    let d = scene.series[n.data_slot as usize]
+    vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 90, 95, 120)
+    if d.n <= 0 { return }
+    var x_min = d.x_min
+    var x_max = d.x_max
+    var i: i64 = 0
+    while i < d.n && i < 1024 {
+        let sigma = vh_sqrt(d.vars[i as usize])
+        let lo = d.xs[i as usize] - sigma
+        let hi = d.xs[i as usize] + sigma
+        if lo < x_min { x_min = lo }
+        if hi > x_max { x_max = hi }
+        i = i + 1
+    }
+    if x_min == x_max {
+        x_min = x_min - 1.0
+        x_max = x_max + 1.0
+    }
+    let row_h = vh_clamp_i(n.layout.h / (d.n + 1), 5, 22)
+    i = 0
+    while i < d.n && i < 1024 {
+        let sigma = vh_sqrt(d.vars[i as usize])
+        let row_y = n.layout.y + row_h / 2 + i * row_h
+        let sx = vh_series_x(n.layout.x, n.layout.w, d.xs[i as usize], x_min, x_max)
+        let slo = vh_series_x(n.layout.x, n.layout.w, d.xs[i as usize] - sigma, x_min, x_max)
+        let shi = vh_series_x(n.layout.x, n.layout.w, d.xs[i as usize] + sigma, x_min, x_max)
+        vh_emit_line(slo, row_y, shi, row_y, 180, 180, 220)
+        vh_emit_rect(slo, row_y - 2, 1, 5, 180, 180, 220)
+        vh_emit_rect(shi, row_y - 2, 1, 5, 180, 180, 220)
+        vh_emit_rect(sx - 3, row_y - 3, 7, 7, n.style.r, n.style.g, n.style.b)
+        i = i + 1
+    }
+    print("<!-- forest n="); vh_print_i64(d.n); println(" -->")
+}
+
+fn vh_emit_heatmap(scene: &VizScene, slot: i64, x: i64, y: i64, w: i64, h: i64) with IO, Mut, Div {
+    let hm = scene.heatmaps[slot as usize]
+    let cell_w = if hm.cols <= 0 { 1 } else { w / hm.cols }
+    let cell_h = if hm.rows <= 0 { 1 } else { h / hm.rows }
+    let span = if hm.max_value == hm.min_value { 1.0 } else { hm.max_value - hm.min_value }
+    var rr: i64 = 0
+    while rr < hm.rows && rr < 64 {
+        var cc: i64 = 0
+        while cc < hm.cols && cc < 64 {
+            let idx = rr * hm.cols + cc
+            let frac = (hm.values[idx as usize] - hm.min_value) / span
+            let intensity = vh_clamp_i((frac * 220.0) as i64, 0, 220)
+            vh_emit_rect(x + cc * cell_w, y + rr * cell_h, cell_w + 1, cell_h + 1, intensity / 3, 70 + intensity / 3, 120 + intensity / 2)
+            cc = cc + 1
+        }
+        rr = rr + 1
+    }
+}
+
+fn vh_emit_scalar_field(scene: &VizScene, field_slot: i64, x: i64, y: i64, w: i64, h: i64) with IO, Mut, Div {
+    if field_slot >= 0 && field_slot < scene.field_count {
+        let heat_slot = scene.field_heatmap_slots[field_slot as usize]
+        if heat_slot >= 0 && heat_slot < scene.heatmap_count {
+            let hmap = scene.heatmaps[heat_slot as usize]
+            vh_emit_heatmap(scene, heat_slot, x, y, w, h)
+            vh_emit_rect_stroke(x, y, w, h, 90, 120, 130)
+            print("<!-- scalar-field slot="); vh_print_i64(field_slot)
+            print(" heatmap="); vh_print_i64(heat_slot)
+            print(" rows="); vh_print_i64(hmap.rows)
+            print(" cols="); vh_print_i64(hmap.cols)
+            println(" -->")
+            return
+        }
+    }
+    vh_emit_rect(x, y, w, h, 32, 78, 102)
+    vh_emit_rect_stroke(x, y, w, h, 90, 120, 130)
+    let cx = x + w / 2
+    let cy = y + h / 2
+    vh_emit_line(cx - w / 6, cy, cx + w / 6, cy, 240, 240, 180)
+    vh_emit_line(cx, cy - h / 6, cx, cy + h / 6, 240, 240, 180)
+    print("<!-- scalar-field slot="); vh_print_i64(field_slot); println(" fallback -->")
+}
+
+fn vh_emit_vector_field(scene: &VizScene, field_slot: i64, x: i64, y: i64, w: i64, h: i64) with IO, Mut, Div {
+    vh_emit_rect_stroke(x, y, w, h, 120, 110, 70)
+    if field_slot >= 0 && field_slot < scene.vector_field_count {
+        let f = scene.vector_data[field_slot as usize]
+        let rows = scene.vector_field_rows[field_slot as usize]
+        let cols = scene.vector_field_cols[field_slot as usize]
+        let cell_w = if cols <= 0 { 1 } else { w / cols }
+        let cell_h = if rows <= 0 { 1 } else { h / rows }
+        var rr: i64 = 0
+        while rr < rows && rr < 32 {
+            var cc: i64 = 0
+            while cc < cols && cc < 32 {
+                let idx = rr * cols + cc
+                let cx = x + cc * cell_w + cell_w / 2
+                let cy = y + rr * cell_h + cell_h / 2
+                let dx = vh_clamp_i((f.vx[idx as usize] * 3.0) as i64, 0 - cell_w / 2, cell_w / 2)
+                let dy = vh_clamp_i((f.vy[idx as usize] * 3.0) as i64, 0 - cell_h / 2, cell_h / 2)
+                vh_emit_line(cx, cy, cx + dx, cy + dy, 240, 210, 120)
+                vh_emit_rect(cx + dx - 1, cy + dy - 1, 3, 3, 240, 210, 120)
+                cc = cc + 1
+            }
+            rr = rr + 1
+        }
+        print("<!-- vector-field slot="); vh_print_i64(field_slot)
+        print(" rows="); vh_print_i64(rows)
+        print(" cols="); vh_print_i64(cols)
+        println(" -->")
+        return
+    }
+    print("<!-- vector-field slot="); vh_print_i64(field_slot); println(" fallback -->")
+}
+
+fn vh_traj_x(x0: i64, w: i64, x: f64, z: f64) -> i64 {
+    x0 + w / 2 + (x * (w as f64) * 0.35) as i64 + (z * 2.0) as i64
+}
+
+fn vh_traj_y(y0: i64, h: i64, y: f64, z: f64) -> i64 {
+    y0 + h / 2 - (y * (h as f64) * 0.35) as i64 - (z * 2.0) as i64
+}
+
+fn vh_emit_trajectory(scene: &VizScene, slot: i64, x: i64, y: i64, w: i64, h: i64, r: i64, g: i64, b: i64) with IO, Mut, Div {
+    vh_emit_rect_stroke(x, y, w, h, 120, 95, 150)
+    if slot >= 0 && slot < scene.trajectory_count {
+        let tr = scene.trajectory_data[slot as usize]
+        print("<polyline fill=\"none\" stroke=\"rgb(")
+        vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b)
+        print(")\" stroke-width=\"1.5\" points=\"")
+        var i: i64 = 0
+        while i < tr.n && i < 1024 {
+            let px = vh_traj_x(x, w, tr.x[i as usize], tr.z[i as usize])
+            let py = vh_traj_y(y, h, tr.y[i as usize], tr.z[i as usize])
+            vh_print_i64(px); print(","); vh_print_i64(py)
+            if i < tr.n - 1 { print(" ") }
+            i = i + 1
+        }
+        println("\"/>")
+        if tr.n > 0 {
+            let sx = vh_traj_x(x, w, tr.x[0], tr.z[0])
+            let sy = vh_traj_y(y, h, tr.y[0], tr.z[0])
+            vh_emit_rect(sx - 2, sy - 2, 5, 5, 180, 230, 190)
+            let last = tr.n - 1
+            let ex = vh_traj_x(x, w, tr.x[last as usize], tr.z[last as usize])
+            let ey = vh_traj_y(y, h, tr.y[last as usize], tr.z[last as usize])
+            vh_emit_rect(ex - 2, ey - 2, 5, 5, 255, 180, 130)
+            var cur = scene.time as i64
+            if cur < 0 { cur = 0 }
+            if cur >= tr.n { cur = tr.n - 1 }
+            let tx = vh_traj_x(x, w, tr.x[cur as usize], tr.z[cur as usize])
+            let ty = vh_traj_y(y, h, tr.y[cur as usize], tr.z[cur as usize])
+            vh_emit_rect_stroke(tx - 4, ty - 4, 9, 9, 255, 245, 120)
+        }
+        print("<!-- trajectory slot="); vh_print_i64(slot)
+        print(" n="); vh_print_i64(tr.n)
+        print(" time="); vh_print_i64(scene.time as i64)
+        println(" -->")
+        return
+    }
+    print("<!-- trajectory slot="); vh_print_i64(slot); println(" fallback -->")
+}
+
+fn vh_spec_x(x0: i64, w: i64, x: f64, xmin: f64, xmax: f64) -> i64 {
+    let span = if xmax == xmin { 1.0 } else { xmax - xmin }
+    x0 + (((x - xmin) / span) * (w as f64)) as i64
+}
+
+fn vh_spec_y(y0: i64, h: i64, y: f64, ymin: f64, ymax: f64) -> i64 {
+    let span = if ymax == ymin { 1.0 } else { ymax - ymin }
+    y0 + h - (((y - ymin) / span) * (h as f64)) as i64
+}
+
+fn vh_emit_spectrum(scene: &VizScene, slot: i64, x: i64, y: i64, w: i64, h: i64, r: i64, g: i64, b: i64) with IO, Mut, Div {
+    vh_emit_rect_stroke(x, y, w, h, 140, 110, 70)
+    if slot >= 0 && slot < scene.spectrum_count {
+        let s = scene.spectrum_data[slot as usize]
+        print("<polyline fill=\"none\" stroke=\"rgb(")
+        vh_print_i64(r); print(","); vh_print_i64(g); print(","); vh_print_i64(b)
+        print(")\" stroke-width=\"1.5\" points=\"")
+        var i: i64 = 0
+        while i < s.n && i < 1024 {
+            let px = vh_spec_x(x, w, s.x[i as usize], s.x_min, s.x_max)
+            let py = vh_spec_y(y, h, s.intensity[i as usize], s.y_min, s.y_max)
+            vh_print_i64(px); print(","); vh_print_i64(py)
+            if i < s.n - 1 { print(" ") }
+            i = i + 1
+        }
+        println("\"/>")
+        print("<!-- spectrum slot="); vh_print_i64(slot)
+        print(" n="); vh_print_i64(s.n)
+        println(" -->")
+        return
+    }
+    print("<!-- spectrum slot="); vh_print_i64(slot); println(" fallback -->")
+}
+
+fn vh_emit_control(scene: &VizScene, node_idx: i64) with IO, Mut, Div {
+    let n = scene.nodes[node_idx as usize]
+    if n.data_slot == VIZ_CONTROL_SLIDER {
+        vh_emit_rect(n.layout.x, n.layout.y + n.layout.h / 2 - 2, n.layout.w, 4, 55, 60, 70)
+        let span = if n.max_value == n.min_value { 1.0 } else { n.max_value - n.min_value }
+        let frac = (n.value - n.min_value) / span
+        let knob_x = n.layout.x + (frac * (n.layout.w as f64)) as i64
+        vh_emit_rect(knob_x - 3, n.layout.y, 7, n.layout.h, n.style.r, n.style.g, n.style.b)
+        print("<!-- control slider value="); vh_print_i64(n.value as i64); println(" -->")
+    } else if n.data_slot == VIZ_CONTROL_TOGGLE {
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 130, 150, 160)
+        if n.value > 0.0 {
+            vh_emit_rect(n.layout.x + 3, n.layout.y + 3, n.layout.w - 6, n.layout.h - 6, n.style.r, n.style.g, n.style.b)
+            println("<!-- control toggle on -->")
+        } else {
+            println("<!-- control toggle off -->")
+        }
+    } else if n.data_slot == VIZ_CONTROL_TABS {
+        vh_emit_rect(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 40, 48, 58)
+        let min_i = n.min_value as i64
+        let max_i = n.max_value as i64
+        var count = max_i - min_i + 1
+        if count <= 0 { count = 1 }
+        let tab_w = if n.layout.w / count <= 0 { 1 } else { n.layout.w / count }
+        var active = n.value as i64
+        if active < min_i { active = min_i }
+        if active > max_i { active = max_i }
+        vh_emit_rect(n.layout.x + (active - min_i) * tab_w, n.layout.y, tab_w, n.layout.h, n.style.r, n.style.g, n.style.b)
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 135, 150)
+        print("<!-- control tabs active="); vh_print_i64(active); println(" -->")
+    } else if n.data_slot == VIZ_CONTROL_LEGEND {
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 135, 150)
+        vh_emit_rect(n.layout.x + 4, n.layout.y + n.layout.h / 2 - 3, 10, 6, n.style.r, n.style.g, n.style.b)
+        vh_emit_text(scene, node_idx, n.layout.x + 18, n.layout.y + 13, n.style.r, n.style.g, n.style.b)
+        println("<!-- control legend -->")
+    } else if n.data_slot == VIZ_CONTROL_TOOLTIP {
+        vh_emit_rect(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 28, 34, 42)
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 140, 155, 170)
+        vh_emit_text(scene, node_idx, n.layout.x + 4, n.layout.y + 13, n.style.r, n.style.g, n.style.b)
+        println("<!-- control tooltip -->")
+    } else if n.data_slot == VIZ_CONTROL_BUTTON {
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 135, 150)
+        vh_emit_text(scene, node_idx, n.layout.x + 4, n.layout.y + 13, n.style.r, n.style.g, n.style.b)
+        println("<!-- control button -->")
+    } else if n.data_slot == VIZ_CONTROL_VIEWPORT {
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 135, 150)
+        vh_emit_text(scene, node_idx, n.layout.x + 4, n.layout.y + 13, n.style.r, n.style.g, n.style.b)
+        println("<!-- control viewport -->")
+    } else {
+        vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 135, 150)
+        vh_emit_text(scene, node_idx, n.layout.x + 4, n.layout.y + 13, n.style.r, n.style.g, n.style.b)
+        println("<!-- control generic -->")
+    }
+}
+
 pub fn viz_html_emit_scene(scene: &VizScene, width: i64, height: i64) with IO, Mut, Div {
     println("<!doctype html><html><body>")
     print("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\""); vh_print_i64(width)
@@ -50,28 +427,48 @@ pub fn viz_html_emit_scene(scene: &VizScene, width: i64, height: i64) with IO, M
         let n = scene.nodes[i as usize]
         if n.kind == VIZ_NODE_PANEL {
             vh_emit_rect(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 22, 28, 36)
+        } else if n.kind == VIZ_NODE_LABEL {
+            vh_emit_text(scene, i, n.layout.x, n.layout.y + 10, n.style.r, n.style.g, n.style.b)
         } else if n.kind == VIZ_NODE_CHART_LINE || n.kind == VIZ_NODE_UNCERTAINTY_BAND {
-            print("<polyline fill=\"none\" stroke=\"rgb(")
-            vh_print_i64(n.style.r); print(","); vh_print_i64(n.style.g); print(","); vh_print_i64(n.style.b)
-            print(")\" stroke-width=\""); vh_print_i64(n.style.stroke_width); print("\" points=\"")
-            let d = scene.series[n.data_slot as usize]
-            var j: i64 = 0
-            while j < d.n {
-                let xr = if d.x_max == d.x_min { 1.0 } else { d.x_max - d.x_min }
-                let yr = if d.y_max == d.y_min { 1.0 } else { d.y_max - d.y_min }
-                let px = n.layout.x + (((d.xs[j as usize] - d.x_min) / xr) * (n.layout.w as f64)) as i64
-                let py = n.layout.y + n.layout.h - (((d.ys[j as usize] - d.y_min) / yr) * (n.layout.h as f64)) as i64
-                vh_print_i64(px); print(","); vh_print_i64(py)
-                if j < d.n - 1 { print(" ") }
-                j = j + 1
-            }
-            println("\"/>")
+            vh_emit_series_polyline(scene, i)
+        } else if n.kind == VIZ_NODE_CHART_SCATTER {
+            vh_emit_scatter(scene, i)
+        } else if n.kind == VIZ_NODE_CHART_BAR {
+            vh_emit_bar(scene, i)
         } else if n.kind == VIZ_NODE_HEATMAP {
             let h = scene.heatmaps[n.data_slot as usize]
-            vh_emit_rect(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 40, 70, 90)
+            vh_emit_heatmap(scene, n.data_slot, n.layout.x, n.layout.y, n.layout.w, n.layout.h)
+            vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 80, 120, 140)
             print("<!-- heatmap rows="); vh_print_i64(h.rows); print(" cols="); vh_print_i64(h.cols); println(" -->")
         } else if n.kind == VIZ_NODE_CONTROL {
-            vh_emit_rect(n.layout.x, n.layout.y, n.layout.w, n.layout.h, n.style.r, n.style.g, n.style.b)
+            vh_emit_control(scene, i)
+        } else if n.kind == VIZ_NODE_FOREST {
+            vh_emit_forest(scene, i)
+        } else if n.kind == VIZ_NODE_WATERFALL {
+            vh_emit_waterfall(scene, i)
+        } else if n.kind == VIZ_NODE_MOLECULE {
+            let cx = n.layout.x + n.layout.w / 2
+            let cy = n.layout.y + n.layout.h / 2
+            vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 130, 150)
+            vh_emit_line(cx - n.layout.w / 4, cy, cx + n.layout.w / 4, cy, 170, 185, 205)
+            vh_emit_circle(cx, cy, 5, n.style.r, n.style.g, n.style.b)
+            print("<!-- molecule slot="); vh_print_i64(n.data_slot); println(" -->")
+        } else if n.kind == VIZ_NODE_FIELD {
+            vh_emit_scalar_field(scene, n.data_slot, n.layout.x, n.layout.y, n.layout.w, n.layout.h)
+        } else if n.kind == VIZ_NODE_VECTOR_FIELD {
+            vh_emit_vector_field(scene, n.data_slot, n.layout.x, n.layout.y, n.layout.w, n.layout.h)
+        } else if n.kind == VIZ_NODE_TRAJECTORY {
+            vh_emit_trajectory(scene, n.data_slot, n.layout.x, n.layout.y, n.layout.w, n.layout.h, n.style.r, n.style.g, n.style.b)
+        } else if n.kind == VIZ_NODE_SPECTRUM {
+            vh_emit_spectrum(scene, n.data_slot, n.layout.x, n.layout.y, n.layout.w, n.layout.h, n.style.r, n.style.g, n.style.b)
+        } else if n.kind == VIZ_NODE_MESH {
+            vh_emit_rect_stroke(n.layout.x, n.layout.y, n.layout.w, n.layout.h, 120, 130, 150)
+            print("<polygon points=\"")
+            vh_print_i64(n.layout.x + n.layout.w / 2); print(","); vh_print_i64(n.layout.y + n.layout.h / 4); print(" ")
+            vh_print_i64(n.layout.x + n.layout.w / 4); print(","); vh_print_i64(n.layout.y + n.layout.h * 3 / 4); print(" ")
+            vh_print_i64(n.layout.x + n.layout.w * 3 / 4); print(","); vh_print_i64(n.layout.y + n.layout.h * 3 / 4)
+            print("\" fill=\"rgb("); vh_print_i64(n.style.r); print(","); vh_print_i64(n.style.g); print(","); vh_print_i64(n.style.b); println(")\" opacity=\"0.85\"/>")
+            print("<!-- mesh slot="); vh_print_i64(n.data_slot); println(" -->")
         }
         i = i + 1
     }

--- a/stdlib/viz/viz_window.sio
+++ b/stdlib/viz/viz_window.sio
@@ -1,0 +1,41 @@
+// stdlib/viz/viz_window.sio - optional native window bridge for Visual IR apps
+//
+// This layer connects display::Window to VizApp without making tests depend on
+// DISPLAY. Headless tests exercise viz_app; window examples compile-gate this.
+
+use display::canvas::{Canvas, canvas_from_window, canvas_clear}
+use display::window::{Window, window_pending, window_next_event, window_present}
+use viz::ir::{VizScene}
+use viz::viz_app::{VizApp, viz_app_handle_event}
+use viz::viz_canvas::{viz_canvas_render_scene}
+
+pub fn viz_window_pump_events(app: &!VizApp, scene: &!VizScene, win: &!Window, max_events: i64) -> i64 with IO, Mut, Div {
+    var handled: i64 = 0
+    var keep_polling = true
+    while keep_polling && handled < max_events && window_pending(win) > 0 {
+        let ev = window_next_event(win)
+        viz_app_handle_event(app, scene, ev)
+        handled = handled + 1
+        if !app.running {
+            keep_polling = false
+        }
+    }
+    handled
+}
+
+pub fn viz_window_present_if_dirty(app: &!VizApp, scene: &!VizScene, win: &!Window) -> bool with IO, Mut, Div, Alloc {
+    if !app.dirty { return false }
+    var c = canvas_from_window(win)
+    canvas_clear(&!c, app.bg_r, app.bg_g, app.bg_b)
+    viz_canvas_render_scene(scene, &!c)
+    window_present(win)
+    app.frame = app.frame + 1
+    app.dirty = false
+    true
+}
+
+pub fn viz_window_step(app: &!VizApp, scene: &!VizScene, win: &!Window, max_events: i64) -> bool with IO, Mut, Div, Alloc {
+    viz_window_pump_events(app, scene, win, max_events)
+    viz_window_present_if_dirty(app, scene, win)
+    app.running
+}

--- a/tests/run-pass/perturbation_graph_order_safe.sio
+++ b/tests/run-pass/perturbation_graph_order_safe.sio
@@ -1,0 +1,66 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for the perturbation DAG (stdlib/epistemic/perturbation_graph.sio):
+// binary chaining of uncertain octonion products is ORDER-SAFE — the structural
+// (non-associativity) variance is accumulated automatically regardless of how the
+// product is parenthesized, so ((a·b)·c) and (a·(b·c)) agree, and both match the
+// explicit mul3.
+//
+// Operands: unit basis octonions (norm²=1), σ=0.5 (var=0.25), κ=1.
+//   non-Fano (e1,e2,e4): measurement 0.75 + κ·‖α‖²(=4) = 4.75 (either association)
+//   Fano     (e1,e2,e3): measurement 0.75 + 0              = 0.75
+// The order-naive value-only binary would drop the structural term → 0.75 (wrong).
+
+use epistemic::perturbation_graph::{PerturbGraph, pg_new, pg_leaf, pg_mul, pg_variance}
+use algebra::octonion::oct_basis
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic, NonAssoc {
+    var ok = true
+    let e1 = oct_basis(1)
+    let e2 = oct_basis(2)
+    let e3 = oct_basis(3)
+    let e4 = oct_basis(4)
+
+    // non-Fano, LEFT-associated: (a·b)·c
+    var g = pg_new()
+    let a  = pg_leaf(&!g, &e1, 0.5)
+    let b  = pg_leaf(&!g, &e2, 0.5)
+    let c  = pg_leaf(&!g, &e4, 0.5)
+    let ab  = pg_mul(&!g, a, b, 1.0)
+    let abc = pg_mul(&!g, ab, c, 1.0)
+    let v_left = pg_variance(&!g, abc)
+    if approx(v_left, 4.75) { print("LEFT (ab)c = 4.75: PASS") }
+    else { print("LEFT: FAIL"); ok = false }
+
+    // non-Fano, RIGHT-associated: a·(b·c) — must match
+    var g2 = pg_new()
+    let a2 = pg_leaf(&!g2, &e1, 0.5)
+    let b2 = pg_leaf(&!g2, &e2, 0.5)
+    let c2 = pg_leaf(&!g2, &e4, 0.5)
+    let bc   = pg_mul(&!g2, b2, c2, 1.0)
+    let abc2 = pg_mul(&!g2, a2, bc, 1.0)
+    let v_right = pg_variance(&!g2, abc2)
+    if approx(v_right, 4.75) { print("RIGHT a(bc) = 4.75: PASS") }
+    else { print("RIGHT: FAIL"); ok = false }
+
+    if approx(v_left, v_right) { print("order-safe: left == right: PASS") }
+    else { print("order-safe: FAIL"); ok = false }
+
+    // Fano triple pays nothing
+    var g3 = pg_new()
+    let fa = pg_leaf(&!g3, &e1, 0.5)
+    let fb = pg_leaf(&!g3, &e2, 0.5)
+    let fc = pg_leaf(&!g3, &e3, 0.5)
+    let fab  = pg_mul(&!g3, fa, fb, 1.0)
+    let fabc = pg_mul(&!g3, fab, fc, 1.0)
+    if approx(pg_variance(&!g3, fabc), 0.75) { print("Fano chain = 0.75: PASS") }
+    else { print("Fano: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}

--- a/tests/run-pass/propagate_nonassoc_variance.sio
+++ b/tests/run-pass/propagate_nonassoc_variance.sio
@@ -1,0 +1,54 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for product_nonassoc (stdlib/epistemic/propagate.sio) — the
+// wiring that turns non-associativity into epistemic variance automatically.
+//
+// A scalar observable with base GUM variance 0.25 (Epistemic::measured(10, 0.5)),
+// computed through an octonion triple:
+//   Fano  (e1,e2,e3): associator = 0   ⇒ variance unchanged       (0.25)
+//   non-Fano (e1,e2,e4): ‖α‖² = 4, κ=1 ⇒ variance += κ·4 = total   (4.25)
+//
+// This is the join of the two theses: non-associativity does not merely get
+// blocked at the optimizer — it FEEDS the uncertainty budget through the
+// propagation engine, with certainty-of-order something you earn (Fano triple),
+// not assume.
+
+use epistemic::knowledge::Epistemic
+use epistemic::propagate::product_nonassoc
+use algebra::octonion::oct_basis
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic, NonAssoc {
+    var ok = true
+    let kappa = 1.0
+    let base = Epistemic::measured(10.0, 0.5)   // variance = 0.25
+
+    // --- associative (Fano) triple (e1,e2,e3): order is safe ---
+    let a = oct_basis(1)
+    let b = oct_basis(2)
+    let cf = oct_basis(3)
+    let r_fano = product_nonassoc(base, &a, &b, &cf, kappa)
+    if approx(r_fano.val, 10.0) { print("val preserved (fano): PASS") }
+    else { print("val preserved (fano): FAIL"); ok = false }
+    if approx(r_fano.variance, 0.25) { print("fano variance unchanged=0.25: PASS") }
+    else { print("fano variance unchanged: FAIL"); ok = false }
+
+    // --- non-associative triple (e1,e2,e4): order-ambiguity feeds variance ---
+    let cn = oct_basis(4)
+    let r_nf = product_nonassoc(base, &a, &b, &cn, kappa)
+    if approx(r_nf.val, 10.0) { print("val preserved (nonfano): PASS") }
+    else { print("val preserved (nonfano): FAIL"); ok = false }
+    if approx(r_nf.variance, 4.25) { print("nonfano variance augmented=4.25: PASS") }
+    else { print("nonfano variance augmented: FAIL"); ok = false }
+
+    // --- the structural term strictly increases uncertainty ---
+    if r_nf.variance > r_fano.variance { print("nonassoc increases variance: PASS") }
+    else { print("nonassoc increases variance: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}

--- a/tests/run-pass/uncertain_octonion_auto.sio
+++ b/tests/run-pass/uncertain_octonion_auto.sio
@@ -1,0 +1,63 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for UncertainOct (stdlib/epistemic/uncertain_octonion.sio) — the
+// automatic synthesis: multiplying three uncertain octonions folds the order-
+// indeterminacy κ·‖[a,b,c]‖² into the result variance BY CONSTRUCTION, with no
+// helper call.
+//
+// All operands are unit basis octonions (norm²=1) measured with σ=0.5 (var=0.25),
+// κ=1. The measurement variance of ((a·b)·c) is then identical for any triple:
+//   var_ab   = 1·0.25 + 1·0.25 = 0.5
+//   var_meas = 1·0.5  + 1·0.25 = 0.75
+// so the ONLY difference between a Fano and a non-Fano triple is the structural
+// term the operation adds automatically:
+//   Fano     (e1,e2,e3): ‖α‖²=0 ⇒ variance = 0.75
+//   non-Fano (e1,e2,e4): ‖α‖²=4 ⇒ variance = 0.75 + κ·4 = 4.75
+
+use epistemic::uncertain_octonion::UncertainOct
+use algebra::octonion::oct_basis
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic, NonAssoc {
+    var ok = true
+    let kappa = 1.0
+
+    let a = UncertainOct::measured(oct_basis(1), 0.5)   // var 0.25
+    let b = UncertainOct::measured(oct_basis(2), 0.5)   // var 0.25
+    let cf = UncertainOct::measured(oct_basis(3), 0.5)  // Fano with (1,2)
+    let cn = UncertainOct::measured(oct_basis(4), 0.5)  // non-Fano with (1,2)
+
+    // --- binary product: measurement variance only, no structural term ---
+    let ab = a.mul(&b)
+    if approx(ab.variance(), 0.5) { print("binary variance=0.5: PASS") }
+    else { print("binary variance: FAIL"); ok = false }
+    if approx(ab.norm(), 1.0) { print("binary norm=1 (composition): PASS") }
+    else { print("binary norm: FAIL"); ok = false }
+
+    // --- triple product, Fano (e1,e2,e3): structural term vanishes ---
+    let rf = a.mul3(&b, &cf, kappa)
+    if approx(rf.variance(), 0.75) { print("fano triple variance=0.75: PASS") }
+    else { print("fano triple variance: FAIL"); ok = false }
+    if approx(rf.norm(), 1.0) { print("fano triple norm=1: PASS") }
+    else { print("fano triple norm: FAIL"); ok = false }
+
+    // --- triple product, non-Fano (e1,e2,e4): +κ·4 added automatically ---
+    let rn = a.mul3(&b, &cn, kappa)
+    if approx(rn.variance(), 4.75) { print("nonfano triple variance=4.75: PASS") }
+    else { print("nonfano triple variance: FAIL"); ok = false }
+    if approx(rn.norm(), 1.0) { print("nonfano triple norm=1: PASS") }
+    else { print("nonfano triple norm: FAIL"); ok = false }
+
+    // --- the automatic structural term IS the whole difference ---
+    if approx(rn.variance() - rf.variance(), 4.0) { print("auto structural term=4.0: PASS") }
+    else { print("auto structural term: FAIL"); ok = false }
+    if rn.variance() > rf.variance() { print("nonassoc raises uncertainty: PASS") }
+    else { print("nonassoc raises uncertainty: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}

--- a/tests/run-pass/viz_app_frame.sio
+++ b/tests/run-pass/viz_app_frame.sio
@@ -1,0 +1,70 @@
+// tests/run-pass/viz_app_frame.sio - headless app/frame runner proof
+//
+// Expected output:
+//   VIZ_APP_FRAME_PASS
+
+use display::canvas::{Canvas}
+use display::event::{Event, EV_CLOSE, EV_EXPOSE, EV_KEY_PRESS, EV_MOUSE_PRESS, EV_MOTION, KEY_RIGHT, MOUSE_LEFT}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_add_control, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TABS}
+use viz::viz_app::{viz_app_new, viz_app_handle_event, viz_app_render, viz_app_step}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn ev(kind: i64, key: i64, x: i64, y: i64) -> Event {
+    Event { kind: kind, key: key, x: x, y: y, mods: 0 }
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var scene = viz_scene_new()
+    let slider = viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(10, 10, 100, 18), 0.0, 0.0, 10.0)
+    let tabs = viz_add_control(&!scene, VIZ_CONTROL_TABS, viz_layout_rect(10, 38, 120, 18), 0.0, 0.0, 3.0)
+    assert(slider == 0)
+    assert(tabs == 1)
+
+    var app = viz_app_new(3, 4, 5)
+    var c = make_canvas(160, 80)
+    assert(app.running)
+    assert(app.dirty)
+    viz_app_render(&!app, &!scene, &!c)
+    assert(app.frame == 1)
+    assert(!app.dirty)
+    assert(read_px(&c, 10, 17) != 0)
+
+    viz_app_render(&!app, &!scene, &!c)
+    assert(app.frame == 1)
+
+    assert(viz_app_handle_event(&!app, &!scene, ev(EV_EXPOSE, 0, 0, 0)))
+    assert(app.dirty)
+    viz_app_render(&!app, &!scene, &!c)
+    assert(app.frame == 2)
+
+    assert(viz_app_step(&!app, &!scene, &!c, ev(EV_MOUSE_PRESS, MOUSE_LEFT, 10, 17)))
+    assert(scene.selected_node == slider)
+    assert(app.frame == 3)
+    assert(viz_app_step(&!app, &!scene, &!c, ev(EV_MOTION, 0, 110, 17)))
+    assert(scene.time == 10.0)
+    assert(scene.nodes[slider as usize].value == 10.0)
+    assert(app.frame == 4)
+
+    assert(viz_app_step(&!app, &!scene, &!c, ev(EV_MOUSE_PRESS, MOUSE_LEFT, 126, 44)))
+    assert(scene.selected_node == tabs)
+    assert(scene.active_tab == 3)
+    assert(app.frame == 5)
+    assert(viz_app_step(&!app, &!scene, &!c, ev(EV_KEY_PRESS, KEY_RIGHT, 0, 0)))
+    assert(scene.active_tab == 3)
+    assert(app.frame == 6)
+
+    assert(!viz_app_step(&!app, &!scene, &!c, ev(EV_CLOSE, 0, 0, 0)))
+    assert(!app.running)
+    assert(app.frame == 6)
+
+    heap_free(c.pixels as *mut i8)
+    println("VIZ_APP_FRAME_PASS")
+}

--- a/tests/run-pass/viz_canvas_ext_surface.sio
+++ b/tests/run-pass/viz_canvas_ext_surface.sio
@@ -1,0 +1,77 @@
+// tests/run-pass/viz_canvas_ext_surface.sio - Canvas extension hardening proof
+//
+// Expected output:
+//   VIZ_CANVAS_EXT_SURFACE_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use display::canvas_ext::{canvas_draw_line_aa, canvas_blit_surface}
+use graphics::drawing::{Color, color_black}
+use graphics::surface::{surface_new, surface_clear, surface_set_pixel}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn px_r(px: i64) -> i64 { (px >> 16) & 255 }
+fn px_g(px: i64) -> i64 { (px >> 8) & 255 }
+fn px_b(px: i64) -> i64 { px & 255 }
+
+fn count_partial(c: &Canvas) -> i64 with Mut {
+    var n: i64 = 0
+    var y: i64 = 0
+    while y < c.height {
+        var x: i64 = 0
+        while x < c.width {
+            let r = px_r(read_px(c, x, y))
+            if r > 0 && r < 255 {
+                n = n + 1
+            }
+            x = x + 1
+        }
+        y = y + 1
+    }
+    n
+}
+
+fn main() with IO, Alloc, Mut, Div, Panic {
+    var c = make_canvas(16, 16)
+    canvas_clear(&!c, 0, 0, 0)
+
+    canvas_draw_line_aa(&!c, 2, 2, 2, 10, 255, 0, 0)
+    assert(px_r(read_px(&c, 2, 2)) == 255)
+    assert(px_r(read_px(&c, 2, 10)) == 255)
+    assert(read_px(&c, 1, 6) == 0)
+    assert(read_px(&c, 3, 6) == 0)
+
+    canvas_draw_line_aa(&!c, 4, 4, 12, 4, 0, 255, 0)
+    assert(px_g(read_px(&c, 4, 4)) == 255)
+    assert(px_g(read_px(&c, 12, 4)) == 255)
+    assert(px_g(read_px(&c, 8, 3)) == 0)
+    assert(px_g(read_px(&c, 8, 5)) == 0)
+
+    canvas_clear(&!c, 0, 0, 0)
+    canvas_draw_line_aa(&!c, 1, 1, 14, 7, 255, 0, 0)
+    assert(px_r(read_px(&c, 1, 1)) >= 250)
+    assert(count_partial(&c) >= 4)
+
+    canvas_clear(&!c, 0, 0, 0)
+    var s = surface_new(4, 4)
+    s = surface_clear(s, color_black())
+    s = surface_set_pixel(s, 0, 0, Color { r: 255, g: 0, b: 0, a: 128 })
+    s = surface_set_pixel(s, 1, 0, Color { r: 0, g: 255, b: 0, a: 255 })
+    s = surface_set_pixel(s, 2, 0, Color { r: 0, g: 0, b: 255, a: 0 })
+    canvas_blit_surface(&!c, s, 4, 5)
+
+    let red_half = px_r(read_px(&c, 4, 5))
+    assert(red_half >= 127 && red_half <= 129)
+    assert(px_g(read_px(&c, 5, 5)) == 255)
+    assert(px_b(read_px(&c, 6, 5)) == 0)
+
+    heap_free(c.pixels as *mut i8)
+    println("VIZ_CANVAS_EXT_SURFACE_PASS")
+}

--- a/tests/run-pass/viz_chart_builders.sio
+++ b/tests/run-pass/viz_chart_builders.sio
@@ -1,0 +1,83 @@
+// tests/run-pass/viz_chart_builders.sio - Visual IR chart builder coverage
+//
+// Expected output:
+//   VIZ_CHART_BUILDERS_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{
+    viz_scene_new, viz_layout_rect, viz_style_rgb,
+    viz_add_scatter_chart, viz_add_bar_chart, viz_add_forest_plot, viz_add_waterfall,
+    VIZ_NODE_CHART_SCATTER, VIZ_NODE_CHART_BAR, VIZ_NODE_FOREST, VIZ_NODE_WATERFALL,
+}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::viz_html::{viz_html_emit_scene}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn count_nonzero_rect(c: &Canvas, x: i64, y: i64, w: i64, h: i64) -> i64 with Mut {
+    var count: i64 = 0
+    var yy: i64 = y
+    while yy < y + h {
+        var xx: i64 = x
+        while xx < x + w {
+            if read_px(c, xx, yy) != 0 {
+                count = count + 1
+            }
+            xx = xx + 1
+        }
+        yy = yy + 1
+    }
+    count
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var xs: [f64; 1024] = [0.0; 1024]
+    var ys: [f64; 1024] = [0.0; 1024]
+    var vars: [f64; 1024] = [0.0; 1024]
+    var wf: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 5 {
+        xs[i as usize] = i as f64
+        ys[i as usize] = (i + 1) as f64
+        vars[i as usize] = 0.04 + (i as f64) * 0.01
+        wf[i as usize] = 400.0 + (i as f64) * 120.0
+        i = i + 1
+    }
+
+    var scene = viz_scene_new()
+    let scatter = viz_add_scatter_chart(&!scene, &xs, &ys, 5, viz_layout_rect(8, 8, 80, 54), viz_style_rgb(255, 120, 90))
+    let bars = viz_add_bar_chart(&!scene, &xs, &ys, 5, viz_layout_rect(104, 8, 80, 54), viz_style_rgb(100, 210, 150))
+    let forest = viz_add_forest_plot(&!scene, &ys, &vars, 5, viz_layout_rect(8, 78, 80, 54), viz_style_rgb(170, 180, 255))
+    let waterfall = viz_add_waterfall(&!scene, &wf, 5, viz_layout_rect(104, 78, 80, 54), viz_style_rgb(255, 200, 90))
+
+    assert(scatter == 0)
+    assert(bars == 1)
+    assert(forest == 2)
+    assert(waterfall == 3)
+    assert(scene.nodes[scatter as usize].kind == VIZ_NODE_CHART_SCATTER)
+    assert(scene.nodes[bars as usize].kind == VIZ_NODE_CHART_BAR)
+    assert(scene.nodes[forest as usize].kind == VIZ_NODE_FOREST)
+    assert(scene.nodes[waterfall as usize].kind == VIZ_NODE_WATERFALL)
+    assert(scene.series_count == 4)
+    assert(scene.series[forest as usize].vars[4] == vars[4])
+    assert(scene.series[waterfall as usize].ys[4] == wf[4])
+
+    var c = make_canvas(200, 150)
+    canvas_clear(&!c, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(count_nonzero_rect(&c, 8, 8, 80, 54) > 0)
+    assert(count_nonzero_rect(&c, 104, 8, 80, 54) > 0)
+    assert(count_nonzero_rect(&c, 8, 78, 80, 54) > 0)
+    assert(count_nonzero_rect(&c, 104, 78, 80, 54) > 0)
+    heap_free(c.pixels as *mut i8)
+
+    viz_html_emit_scene(&scene, 200, 150)
+    println("VIZ_CHART_BUILDERS_PASS")
+}

--- a/tests/run-pass/viz_controls_modes.sio
+++ b/tests/run-pass/viz_controls_modes.sio
@@ -1,0 +1,56 @@
+// tests/run-pass/viz_controls_modes.sio - Visual IR native control reducers
+//
+// Expected output:
+//   VIZ_CONTROLS_MODES_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_add_control, viz_scene_pointer_down, viz_scene_pointer_move, viz_scene_pointer_update, VIZ_CONTROL_TABS, VIZ_CONTROL_TOGGLE}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::viz_html::{viz_html_emit_scene}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var scene = viz_scene_new()
+    let tabs = viz_add_control(&!scene, VIZ_CONTROL_TABS, viz_layout_rect(10, 10, 120, 18), 0.0, 0.0, 3.0)
+    let toggle = viz_add_control(&!scene, VIZ_CONTROL_TOGGLE, viz_layout_rect(10, 40, 32, 18), 0.0, 0.0, 1.0)
+    assert(tabs == 0)
+    assert(toggle == 1)
+
+    let hovered = viz_scene_pointer_move(&!scene, 20, 14)
+    assert(hovered == tabs)
+    assert(scene.hovered_node == tabs)
+
+    let tab_hit = viz_scene_pointer_down(&!scene, 86, 14)
+    assert(tab_hit == tabs)
+    assert(scene.active_tab == 2)
+    assert(scene.nodes[tabs as usize].value == 2.0)
+    let tab_drag = viz_scene_pointer_update(&!scene, 129, 14)
+    assert(tab_drag == tabs)
+    assert(scene.active_tab == 3)
+    assert(scene.nodes[tabs as usize].value == 3.0)
+
+    let toggle_on = viz_scene_pointer_down(&!scene, 20, 48)
+    assert(toggle_on == toggle)
+    assert(scene.nodes[toggle as usize].value == 1.0)
+    let toggle_off = viz_scene_pointer_down(&!scene, 20, 48)
+    assert(toggle_off == toggle)
+    assert(scene.nodes[toggle as usize].value == 0.0)
+
+    var c = make_canvas(160, 80)
+    canvas_clear(&!c, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(read_px(&c, 102, 12) != 0)
+    assert(read_px(&c, 10, 40) != 0)
+    heap_free(c.pixels as *mut i8)
+
+    viz_html_emit_scene(&scene, 160, 80)
+    println("VIZ_CONTROLS_MODES_PASS")
+}

--- a/tests/run-pass/viz_event_reducer.sio
+++ b/tests/run-pass/viz_event_reducer.sio
@@ -1,0 +1,50 @@
+// tests/run-pass/viz_event_reducer.sio - Visual IR event reducer smoke test
+//
+// Expected output:
+//   VIZ_EVENT_REDUCER_PASS
+
+use display::event::{Event, EV_KEY_PRESS, EV_MOUSE_PRESS, EV_MOUSE_RELEASE, EV_MOTION, KEY_LEFT, KEY_RIGHT, KEY_SPACE, MOUSE_LEFT}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_add_control, viz_scene_handle_event, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TABS, VIZ_CONTROL_TOGGLE}
+
+fn ev(kind: i64, key: i64, x: i64, y: i64) -> Event {
+    Event { kind: kind, key: key, x: x, y: y, mods: 0 }
+}
+
+fn main() with IO, Mut, Div {
+    var scene = viz_scene_new()
+    let slider = viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(10, 10, 100, 18), 0.0, 0.0, 10.0)
+    let tabs = viz_add_control(&!scene, VIZ_CONTROL_TABS, viz_layout_rect(10, 36, 120, 18), 0.0, 0.0, 3.0)
+    let toggle = viz_add_control(&!scene, VIZ_CONTROL_TOGGLE, viz_layout_rect(10, 62, 32, 18), 0.0, 0.0, 1.0)
+    assert(slider == 0)
+    assert(tabs == 1)
+    assert(toggle == 2)
+    assert(scene.selected_node < 0)
+
+    assert(viz_scene_handle_event(&!scene, ev(EV_MOUSE_PRESS, MOUSE_LEFT, 10, 16)))
+    assert(scene.selected_node == slider)
+    assert(viz_scene_handle_event(&!scene, ev(EV_MOTION, 0, 110, 16)))
+    assert(scene.nodes[slider as usize].value == 10.0)
+    assert(scene.time == 10.0)
+    assert(viz_scene_handle_event(&!scene, ev(EV_MOUSE_RELEASE, MOUSE_LEFT, 110, 16)))
+    assert(scene.selected_node < 0)
+
+    assert(viz_scene_handle_event(&!scene, ev(EV_MOTION, 0, 20, 16)))
+    assert(scene.hovered_node == slider)
+    assert(viz_scene_handle_event(&!scene, ev(EV_KEY_PRESS, KEY_LEFT, 0, 0)))
+    assert(scene.nodes[slider as usize].value == 9.0)
+    assert(scene.time == 9.0)
+
+    assert(viz_scene_handle_event(&!scene, ev(EV_MOUSE_PRESS, MOUSE_LEFT, 126, 42)))
+    assert(scene.active_tab == 3)
+    assert(viz_scene_handle_event(&!scene, ev(EV_KEY_PRESS, KEY_LEFT, 0, 0)))
+    assert(scene.active_tab == 2)
+    assert(viz_scene_handle_event(&!scene, ev(EV_KEY_PRESS, KEY_RIGHT, 0, 0)))
+    assert(scene.active_tab == 3)
+
+    assert(viz_scene_handle_event(&!scene, ev(EV_MOUSE_PRESS, MOUSE_LEFT, 20, 70)))
+    assert(scene.nodes[toggle as usize].value == 1.0)
+    assert(viz_scene_handle_event(&!scene, ev(EV_KEY_PRESS, KEY_SPACE, 0, 0)))
+    assert(scene.nodes[toggle as usize].value == 0.0)
+
+    println("VIZ_EVENT_REDUCER_PASS")
+}

--- a/tests/run-pass/viz_frontend_builders.sio
+++ b/tests/run-pass/viz_frontend_builders.sio
@@ -1,0 +1,115 @@
+// tests/run-pass/viz_frontend_builders.sio - native frontend builder proof
+//
+// Expected output:
+//   VIZ_FRONTEND_BUILDERS_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{
+    viz_scene_new, viz_layout_rect, viz_style_rgb,
+    viz_add_button, viz_add_slider, viz_add_toggle, viz_add_tabs,
+    viz_add_viewport, viz_add_plot_viewport, viz_add_legend, viz_add_tooltip,
+    VIZ_CONTROL_BUTTON, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TOGGLE, VIZ_CONTROL_TABS,
+    VIZ_CONTROL_VIEWPORT, VIZ_CONTROL_LEGEND, VIZ_CONTROL_TOOLTIP,
+}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::viz_html::{viz_html_emit_scene}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn count_nonzero_rect(c: &Canvas, x: i64, y: i64, w: i64, h: i64) -> i64 with Mut {
+    var count: i64 = 0
+    var yy: i64 = y
+    while yy < y + h {
+        var xx: i64 = x
+        while xx < x + w {
+            if read_px(c, xx, yy) != 0 {
+                count = count + 1
+            }
+            xx = xx + 1
+        }
+        yy = yy + 1
+    }
+    count
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var button_label: [i8; 64] = [0; 64]
+    button_label[0] = 82  // R
+    button_label[1] = 117 // u
+    button_label[2] = 110 // n
+
+    var view_label: [i8; 64] = [0; 64]
+    view_label[0] = 80  // P
+    view_label[1] = 108 // l
+    view_label[2] = 111 // o
+    view_label[3] = 116 // t
+
+    var legend_label: [i8; 64] = [0; 64]
+    legend_label[0] = 77  // M
+    legend_label[1] = 101 // e
+    legend_label[2] = 97  // a
+    legend_label[3] = 110 // n
+
+    var tip_label: [i8; 64] = [0; 64]
+    tip_label[0] = 72  // H
+    tip_label[1] = 111 // o
+    tip_label[2] = 118 // v
+    tip_label[3] = 101 // e
+    tip_label[4] = 114 // r
+
+    var scene = viz_scene_new()
+    let button = viz_add_button(&!scene, &button_label, 3, viz_layout_rect(8, 8, 48, 18), viz_style_rgb(90, 180, 240))
+    let slider = viz_add_slider(&!scene, viz_layout_rect(64, 8, 80, 18), 0.25, 0.0, 1.0, viz_style_rgb(240, 190, 80))
+    let toggle = viz_add_toggle(&!scene, viz_layout_rect(152, 8, 28, 18), true, viz_style_rgb(120, 220, 140))
+    let tabs = viz_add_tabs(&!scene, viz_layout_rect(8, 36, 120, 18), 1, 0, 3, viz_style_rgb(190, 120, 255))
+    let viewport = viz_add_viewport(&!scene, &view_label, 4, viz_layout_rect(8, 64, 80, 22), viz_style_rgb(220, 230, 240))
+    let plot_viewport = viz_add_plot_viewport(&!scene, viz_layout_rect(96, 64, 88, 22), viz_style_rgb(120, 190, 220))
+    let legend = viz_add_legend(&!scene, &legend_label, 4, viz_layout_rect(8, 96, 80, 18), viz_style_rgb(100, 200, 255))
+    let tooltip = viz_add_tooltip(&!scene, &tip_label, 5, viz_layout_rect(96, 96, 88, 18), viz_style_rgb(255, 220, 120))
+
+    assert(button == 0)
+    assert(slider == 1)
+    assert(toggle == 2)
+    assert(tabs == 3)
+    assert(viewport == 4)
+    assert(plot_viewport == 5)
+    assert(legend == 6)
+    assert(tooltip == 7)
+    assert(scene.nodes[button as usize].data_slot == VIZ_CONTROL_BUTTON)
+    assert(scene.nodes[slider as usize].data_slot == VIZ_CONTROL_SLIDER)
+    assert(scene.nodes[toggle as usize].data_slot == VIZ_CONTROL_TOGGLE)
+    assert(scene.nodes[tabs as usize].data_slot == VIZ_CONTROL_TABS)
+    assert(scene.nodes[viewport as usize].data_slot == VIZ_CONTROL_VIEWPORT)
+    assert(scene.nodes[plot_viewport as usize].data_slot == VIZ_CONTROL_VIEWPORT)
+    assert(scene.nodes[legend as usize].data_slot == VIZ_CONTROL_LEGEND)
+    assert(scene.nodes[tooltip as usize].data_slot == VIZ_CONTROL_TOOLTIP)
+    assert(scene.nodes[button as usize].label_len == 3)
+    assert(scene.nodes[viewport as usize].label[0] == 80)
+    assert(scene.nodes[slider as usize].value == 0.25)
+    assert(scene.nodes[toggle as usize].value == 1.0)
+    assert(scene.nodes[tabs as usize].value == 1.0)
+    assert(scene.nodes[tabs as usize].max_value == 3.0)
+
+    var c = make_canvas(200, 128)
+    canvas_clear(&!c, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(count_nonzero_rect(&c, 8, 8, 48, 18) > 0)
+    assert(count_nonzero_rect(&c, 64, 8, 80, 18) > 0)
+    assert(count_nonzero_rect(&c, 152, 8, 28, 18) > 0)
+    assert(count_nonzero_rect(&c, 8, 36, 120, 18) > 0)
+    assert(count_nonzero_rect(&c, 8, 64, 80, 22) > 0)
+    assert(count_nonzero_rect(&c, 96, 64, 88, 22) > 0)
+    assert(count_nonzero_rect(&c, 8, 96, 80, 18) > 0)
+    assert(count_nonzero_rect(&c, 96, 96, 88, 18) > 0)
+    heap_free(c.pixels as *mut i8)
+
+    viz_html_emit_scene(&scene, 200, 128)
+    println("VIZ_FRONTEND_BUILDERS_PASS")
+}

--- a/tests/run-pass/viz_headless.sio
+++ b/tests/run-pass/viz_headless.sio
@@ -13,9 +13,10 @@ use viz::coord::{CoordSystem, coord_new, coord_map_x, coord_map_y, coord_draw_ax
 use viz::chart::{chart_line, chart_scatter, chart_bar, chart_heatmap}
 use viz::epiviz::{epiviz_band, epiviz_knowledge_series, epiviz_waterfall, epiviz_forest}
 use viz::sci::{sci_lattice_heatmap, sci_lattice_variance, sci_pbpk_series}
-use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_add_line_chart, viz_add_uncertainty_band, viz_add_heatmap, viz_add_control, viz_scene_set_time, VIZ_CONTROL_SLIDER}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_add_line_chart, viz_add_uncertainty_band, viz_add_heatmap, viz_add_control, viz_add_molecule, viz_add_scalar_field, viz_add_mesh, viz_scene_set_time, viz_scene_pointer_down, viz_scene_pointer_update, VIZ_CONTROL_SLIDER}
 use viz::viz_canvas::{viz_canvas_render_scene}
 use viz::physchem::{molecule_h2o, scalar_field_radial}
+use render::renderer3d::{Tri3D}
 use epistemic::knowledge::{Epistemic}
 use physics::phonon_quantity::{Lattice64, lattice64_zero}
 
@@ -26,6 +27,22 @@ fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
 
 fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
     read_i64(c.pixels, y * c.width + x)
+}
+
+fn count_nonzero_rect(c: &Canvas, x: i64, y: i64, w: i64, h: i64) -> i64 with Mut {
+    var count: i64 = 0
+    var yy: i64 = y
+    while yy < y + h {
+        var xx: i64 = x
+        while xx < x + w {
+            if read_px(c, xx, yy) != 0 {
+                count = count + 1
+            }
+            xx = xx + 1
+        }
+        yy = yy + 1
+    }
+    count
 }
 
 fn main() with IO, Alloc, Mut, Div {
@@ -131,21 +148,102 @@ fn main() with IO, Alloc, Mut, Div {
     viz_add_line_chart(&!scene, &xs, &ys, 10, viz_layout_rect(10, 10, 90, 70), viz_style_rgb(255, 140, 90))
     viz_add_uncertainty_band(&!scene, &xs, &bvals, &bvars, 5, viz_layout_rect(110, 10, 90, 70), viz_style_rgb(100, 200, 255))
     viz_add_heatmap(&!scene, &hm, 4, 4, 0.0, 15.0, viz_layout_rect(10, 100, 80, 60))
-    viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(120, 120, 80, 16), scene.time, 0.0, 10.0)
-    viz_canvas_render_scene(&scene, &!c)
-    let ir_px = read_px(&c, 10, 10)
-    assert(ir_px != 0)
-    let slider_px = read_px(&c, 120, 126)
-    assert(slider_px != 0)
-
-    // ---- 10. Physico-chemistry data stays in Sounio structs ----
+    let slider_id = viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(120, 120, 80, 16), scene.time, 0.0, 10.0)
     let mol = molecule_h2o()
     assert(mol.atom_count == 3)
     assert(mol.bond_count == 2)
+    viz_add_molecule(&!scene, mol, viz_layout_rect(96, 160, 70, 60), viz_style_rgb(210, 220, 240))
     let field = scalar_field_radial(8, 8)
     assert(field.rows == 8)
     assert(field.cols == 8)
     assert(field.max_value > field.min_value)
+    viz_add_scalar_field(&!scene, field, viz_layout_rect(176, 160, 64, 60))
+    var tris: [Tri3D; 128] = [Tri3D {
+        v0x: -0.45, v0y: -0.35, v0z: -2.0,
+        v1x: 0.45, v1y: -0.35, v1z: -2.0,
+        v2x: 0.0, v2y: 0.45, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 180, base_g: 220, base_b: 120,
+    }; 128]
+    viz_add_mesh(&!scene, &tris, 1, viz_layout_rect(88, 88, 80, 60), viz_style_rgb(180, 220, 120))
+    let hit_id = viz_scene_pointer_down(&!scene, 190, 124)
+    assert(hit_id == slider_id)
+    assert(scene.selected_node == slider_id)
+    let updated_id = viz_scene_pointer_update(&!scene, 200, 124)
+    assert(updated_id == slider_id)
+    assert(scene.nodes[slider_id as usize].value == 10.0)
+    assert(scene.time == 10.0)
+    viz_canvas_render_scene(&scene, &!c)
+
+    // ---- 10. Physico-chemistry data stays in Sounio structs ----
+    assert(scene.molecule_count == 1)
+    assert(scene.field_count == 1)
+    assert(scene.mesh_count == 1)
+    if scene.field_heatmap_slots[0] < 0 {
+        println("FAIL field mirror slot")
+        assert(false)
+    }
+    if scene.heatmaps[scene.field_heatmap_slots[0] as usize].rows != 8 {
+        println("FAIL field mirror rows")
+        assert(false)
+    }
+
+    // ---- 11. Visual IR molecule renderer paints atom pixels in its own rect ----
+    canvas_clear(&!c, 0, 0, 0)
+    var mol_scene = viz_scene_new()
+    let mol2 = molecule_h2o()
+    viz_add_molecule(&!mol_scene, mol2, viz_layout_rect(90, 70, 80, 60), viz_style_rgb(210, 220, 240))
+    assert(mol_scene.node_count == 1)
+    assert(mol_scene.molecule_count == 1)
+    assert(mol_scene.molecules[0].atom_count == 3)
+    viz_canvas_render_scene(&mol_scene, &!c)
+    let mol_border_px = read_px(&c, 90, 70)
+    if mol_border_px == 0 {
+        println("FAIL viz molecule dispatch")
+        assert(false)
+    }
+    let mol_inner_px = count_nonzero_rect(&c, 122, 92, 16, 16)
+    if mol_inner_px == 0 {
+        println("FAIL viz molecule pixel")
+        assert(false)
+    }
+
+    // ---- 12. Visual IR field renderer paints heatmap and overlay pixels ----
+    canvas_clear(&!c, 0, 0, 0)
+    var field_scene = viz_scene_new()
+    let field2 = scalar_field_radial(8, 8)
+    viz_add_scalar_field(&!field_scene, field2, viz_layout_rect(32, 32, 64, 64))
+    assert(field_scene.field_count == 1)
+    if field_scene.field_heatmap_slots[0] < 0 {
+        println("FAIL isolated field mirror slot")
+        assert(false)
+    }
+    if field_scene.heatmaps[field_scene.field_heatmap_slots[0] as usize].cols != 8 {
+        println("FAIL isolated field mirror cols")
+        assert(false)
+    }
+    viz_canvas_render_scene(&field_scene, &!c)
+    let field_px = read_px(&c, 64, 64)
+    if field_px == 0 {
+        println("FAIL viz field pixel")
+        assert(false)
+    }
+
+    // ---- 13. Visual IR mesh renderer respects the node viewport ----
+    canvas_clear(&!c, 0, 0, 0)
+    var mesh_scene = viz_scene_new()
+    viz_add_mesh(&!mesh_scene, &tris, 1, viz_layout_rect(80, 80, 80, 60), viz_style_rgb(180, 220, 120))
+    viz_canvas_render_scene(&mesh_scene, &!c)
+    let mesh_px = read_px(&c, 120, 110)
+    let mesh_outside_px = read_px(&c, 40, 40)
+    if mesh_px == 0 {
+        println("FAIL viz mesh pixel")
+        assert(false)
+    }
+    if mesh_outside_px != 0 {
+        println("FAIL viz mesh viewport")
+        assert(false)
+    }
 
     heap_free(c.pixels as *mut i8)
     println("VIZ_HEADLESS_PASS")

--- a/tests/run-pass/viz_html_static.sio
+++ b/tests/run-pass/viz_html_static.sio
@@ -1,0 +1,74 @@
+// tests/run-pass/viz_html_static.sio - Static HTML/SVG renderer smoke test
+//
+// Expected output includes:
+//   VIZ_HTML_STATIC_PASS
+
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_scene_set_time, viz_add_line_chart, viz_add_heatmap, viz_add_molecule, viz_add_scalar_field, viz_add_vector_field, viz_add_trajectory, viz_add_spectrum, viz_add_mesh}
+use viz::viz_html::{viz_html_emit_scene}
+use viz::physchem::{molecule_h2o, scalar_field_radial, vector_field_vortex, trajectory_spiral, spectrum_absorption_demo}
+use render::renderer3d::{Tri3D}
+
+fn main() with IO, Mut, Div {
+    var scene = viz_scene_new()
+    var xs: [f64; 1024] = [0.0; 1024]
+    var ys: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 6 {
+        xs[i as usize] = i as f64
+        ys[i as usize] = (i * i) as f64
+        i = i + 1
+    }
+
+    var hm: [f64; 4096] = [0.0; 4096]
+    var hi: i64 = 0
+    while hi < 16 {
+        hm[hi as usize] = hi as f64
+        hi = hi + 1
+    }
+
+    let mol = molecule_h2o()
+    let field = scalar_field_radial(4, 4)
+    let vectors = vector_field_vortex(4, 4)
+    let traj = trajectory_spiral(16)
+    let spectrum = spectrum_absorption_demo(20)
+    var tris: [Tri3D; 128] = [Tri3D {
+        v0x: -0.3, v0y: -0.3, v0z: -2.0,
+        v1x: 0.3, v1y: -0.3, v1z: -2.0,
+        v2x: 0.0, v2y: 0.3, v2z: -2.0,
+        nx: 0.0, ny: 0.0, nz: 1.0,
+        base_r: 170, base_g: 220, base_b: 130,
+    }; 128]
+
+    viz_scene_set_time(&!scene, 5.0)
+    viz_add_line_chart(&!scene, &xs, &ys, 6, viz_layout_rect(16, 16, 120, 64), viz_style_rgb(255, 120, 80))
+    viz_add_heatmap(&!scene, &hm, 4, 4, 0.0, 15.0, viz_layout_rect(16, 96, 64, 48))
+    viz_add_molecule(&!scene, mol, viz_layout_rect(96, 96, 48, 48), viz_style_rgb(210, 220, 240))
+    viz_add_scalar_field(&!scene, field, viz_layout_rect(160, 96, 48, 48))
+    viz_add_vector_field(&!scene, vectors, viz_layout_rect(224, 96, 48, 48))
+    viz_add_trajectory(&!scene, traj, viz_layout_rect(144, 16, 64, 48))
+    viz_add_spectrum(&!scene, spectrum, viz_layout_rect(16, 144, 120, 12))
+    viz_add_mesh(&!scene, &tris, 1, viz_layout_rect(224, 24, 48, 48), viz_style_rgb(170, 220, 130))
+
+    assert(scene.node_count == 8)
+    assert(scene.time == 5.0)
+    assert(scene.field_count == 1)
+    assert(scene.vector_field_count == 1)
+    assert(scene.trajectory_count == 1)
+    assert(scene.spectrum_count == 1)
+    assert(scene.vector_field_rows[0] == 4)
+    assert(scene.vector_field_cols[0] == 4)
+    assert(scene.vector_data[0].vx[0] == vectors.vx[0])
+    assert(scene.vector_data[0].vy[15] == vectors.vy[15])
+    assert(scene.trajectory_data[0].n == 16)
+    assert(scene.trajectory_data[0].x[5] == traj.x[5])
+    assert(scene.spectrum_data[0].n == 20)
+    assert(scene.spectrum_data[0].intensity[5] == spectrum.intensity[5])
+    assert(scene.field_heatmap_slots[0] >= 0)
+    assert(scene.heatmaps[scene.field_heatmap_slots[0] as usize].rows == 4)
+    assert(scene.heatmaps[scene.field_heatmap_slots[0] as usize].cols == 4)
+    assert(scene.heatmaps[scene.field_heatmap_slots[0] as usize].values[0] == field.values[0])
+    assert(scene.heatmaps[scene.field_heatmap_slots[0] as usize].values[15] == field.values[15])
+
+    viz_html_emit_scene(&scene, 288, 160)
+    println("VIZ_HTML_STATIC_PASS")
+}

--- a/tests/run-pass/viz_interaction_time.sio
+++ b/tests/run-pass/viz_interaction_time.sio
@@ -1,0 +1,56 @@
+// tests/run-pass/viz_interaction_time.sio - Visual IR interaction state smoke test
+//
+// Expected output:
+//   VIZ_INTERACTION_TIME_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_add_control, viz_add_trajectory, viz_scene_pointer_down, viz_scene_pointer_update, viz_scene_set_time, VIZ_CONTROL_SLIDER}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::physchem::{trajectory_spiral}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var scene = viz_scene_new()
+    let tr = trajectory_spiral(20)
+    let traj_node = viz_add_trajectory(&!scene, tr, viz_layout_rect(10, 10, 140, 70))
+    let slider = viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(10, 92, 140, 20), 0.0, 0.0, 19.0)
+    assert(traj_node == 0)
+    assert(slider == 1)
+
+    viz_scene_set_time(&!scene, 0.0)
+    var c0 = make_canvas(180, 130)
+    canvas_clear(&!c0, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c0)
+    let start_cursor_px = read_px(&c0, 92, 45)
+    heap_free(c0.pixels as *mut i8)
+
+    let selected = viz_scene_pointer_down(&!scene, 10, 100)
+    assert(selected == slider)
+    assert(scene.selected_node == slider)
+    let updated = viz_scene_pointer_update(&!scene, 150, 100)
+    assert(updated == slider)
+    assert(scene.nodes[slider as usize].value == 19.0)
+    assert(scene.time == 19.0)
+
+    var c1 = make_canvas(180, 130)
+    canvas_clear(&!c1, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c1)
+    assert(read_px(&c1, 100, 41) != 0)
+    heap_free(c1.pixels as *mut i8)
+
+    let clamped = viz_scene_pointer_update(&!scene, 0, 100)
+    assert(clamped == slider)
+    assert(scene.nodes[slider as usize].value == 0.0)
+    assert(scene.time == 0.0)
+    assert(start_cursor_px != 0)
+
+    println("VIZ_INTERACTION_TIME_PASS")
+}

--- a/tests/run-pass/viz_layout.sio
+++ b/tests/run-pass/viz_layout.sio
@@ -1,0 +1,54 @@
+// tests/run-pass/viz_layout.sio - Visual IR row/column layout smoke test
+//
+// Expected output:
+//   VIZ_LAYOUT_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_layout_row, viz_layout_column, viz_add_control, viz_scene_apply_layout_range, viz_scene_hit_test, VIZ_CONTROL_BUTTON, VIZ_CONTROL_SLIDER, VIZ_CONTROL_TOGGLE}
+use viz::viz_canvas::{viz_canvas_render_scene}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var scene = viz_scene_new()
+    let first = viz_add_control(&!scene, VIZ_CONTROL_BUTTON, viz_layout_rect(0, 0, 1, 1), 0.0, 0.0, 1.0)
+    let second = viz_add_control(&!scene, VIZ_CONTROL_SLIDER, viz_layout_rect(0, 0, 1, 1), 0.5, 0.0, 1.0)
+    let third = viz_add_control(&!scene, VIZ_CONTROL_TOGGLE, viz_layout_rect(0, 0, 1, 1), 0.0, 0.0, 1.0)
+    assert(first == 0)
+    assert(second == 1)
+    assert(third == 2)
+
+    viz_scene_apply_layout_range(&!scene, first, 3, viz_layout_row(10, 20, 150, 30, 5))
+    assert(scene.nodes[0].layout.x == 10)
+    assert(scene.nodes[0].layout.w == 46)
+    assert(scene.nodes[1].layout.x == 61)
+    assert(scene.nodes[2].layout.x == 112)
+    assert(scene.nodes[2].layout.h == 30)
+    let row_hit = viz_scene_hit_test(&scene, 70, 25)
+    assert(row_hit == 1)
+
+    viz_scene_apply_layout_range(&!scene, first, 3, viz_layout_column(20, 60, 80, 90, 6))
+    assert(scene.nodes[0].layout.y == 60)
+    assert(scene.nodes[0].layout.h == 26)
+    assert(scene.nodes[1].layout.y == 92)
+    assert(scene.nodes[2].layout.y == 124)
+    let col_hit = viz_scene_hit_test(&scene, 25, 135)
+    assert(col_hit == 2)
+
+    var c = make_canvas(160, 180)
+    canvas_clear(&!c, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(read_px(&c, 20, 60) != 0)
+    assert(read_px(&c, 20, 103) != 0)
+    assert(read_px(&c, 20, 124) != 0)
+    heap_free(c.pixels as *mut i8)
+
+    println("VIZ_LAYOUT_PASS")
+}

--- a/tests/run-pass/viz_physchem.sio
+++ b/tests/run-pass/viz_physchem.sio
@@ -1,0 +1,115 @@
+// tests/run-pass/viz_physchem.sio - Physico-chemistry Visual IR smoke test
+//
+// Expected output:
+//   VIZ_PHYSCHEM_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_scene_set_time, viz_add_molecule, viz_add_scalar_field, viz_add_vector_field, viz_add_trajectory, viz_add_spectrum}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::physchem::{molecule_h2o, molecule_rapamycin_coarse, scalar_field_radial, vector_field_vortex, trajectory_spiral, spectrum_absorption_demo, lattice_field_phonon_demo, particle_event_view_demo}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    let water = molecule_h2o()
+    assert(water.atom_count == 3)
+    assert(water.bond_count == 2)
+    assert(water.atoms[0].atomic_number == 8)
+    assert(water.bonds[0].order == 1)
+    assert(water.bonds[0].variance > 0.0)
+
+    let rap = molecule_rapamycin_coarse()
+    assert(rap.atom_count == 44)
+    assert(rap.bond_count == 45)
+    assert(rap.atoms[30].atomic_number == 7)
+    assert(rap.bonds[30].atom_a == 30)
+    assert(rap.bonds[30].atom_b == 0)
+
+    let field = scalar_field_radial(8, 8)
+    assert(field.rows == 8)
+    assert(field.cols == 8)
+    assert(field.max_value > field.min_value)
+    assert(field.variances[0] > 0.0)
+
+    let vectors = vector_field_vortex(4, 4)
+    assert(vectors.rows == 4)
+    assert(vectors.cols == 4)
+    assert(vectors.vx[0] != 0.0)
+    assert(vectors.vy[15] != 0.0)
+    assert(vectors.variance[0] > 0.0)
+
+    let traj = trajectory_spiral(24)
+    assert(traj.n == 24)
+    assert(traj.x[0] != traj.x[5])
+    assert(traj.z[23] > traj.z[0])
+    assert(traj.variance[10] > 0.0)
+
+    let spectrum = spectrum_absorption_demo(32)
+    assert(spectrum.n == 32)
+    assert(spectrum.x_max > spectrum.x_min)
+    assert(spectrum.y_max > spectrum.y_min)
+    assert(spectrum.variance[5] > 0.0)
+
+    let lattice = lattice_field_phonon_demo(4, 4)
+    assert(lattice.rows == 4)
+    assert(lattice.cols == 4)
+    assert(lattice.phase[5] > 0.0)
+    assert(lattice.variance[15] > 0.0)
+
+    let events = particle_event_view_demo(12)
+    assert(events.n == 12)
+    assert(events.energy[11] > events.energy[0])
+    assert(events.kind[5] == 2)
+    assert(events.variance[3] > 0.0)
+
+    var scene = viz_scene_new()
+    viz_scene_set_time(&!scene, 7.0)
+    let water_node = viz_add_molecule(&!scene, water, viz_layout_rect(8, 8, 64, 64), viz_style_rgb(210, 220, 240))
+    let rap_node = viz_add_molecule(&!scene, rap, viz_layout_rect(88, 8, 64, 64), viz_style_rgb(180, 210, 160))
+    let field_node = viz_add_scalar_field(&!scene, field, viz_layout_rect(8, 88, 64, 64))
+    let vector_node = viz_add_vector_field(&!scene, vectors, viz_layout_rect(88, 88, 64, 64))
+    let traj_node = viz_add_trajectory(&!scene, traj, viz_layout_rect(8, 156, 144, 64))
+    let spectrum_node = viz_add_spectrum(&!scene, spectrum, viz_layout_rect(8, 224, 144, 48))
+    assert(water_node == 0)
+    assert(rap_node == 1)
+    assert(field_node == 2)
+    assert(vector_node == 3)
+    assert(traj_node == 4)
+    assert(spectrum_node == 5)
+    assert(scene.time == 7.0)
+    assert(scene.molecule_count == 2)
+    assert(scene.field_count == 1)
+    assert(scene.vector_field_count == 1)
+    assert(scene.trajectory_count == 1)
+    assert(scene.spectrum_count == 1)
+    assert(scene.vector_field_rows[0] == 4)
+    assert(scene.vector_field_cols[0] == 4)
+    assert(scene.vector_data[0].vx[0] == vectors.vx[0])
+    assert(scene.vector_data[0].vy[15] == vectors.vy[15])
+    assert(scene.trajectory_data[0].n == 24)
+    assert(scene.trajectory_data[0].x[5] == traj.x[5])
+    assert(scene.spectrum_data[0].n == 32)
+    assert(scene.spectrum_data[0].intensity[5] == spectrum.intensity[5])
+    assert(scene.field_heatmap_slots[0] >= 0)
+    assert(scene.heatmaps[scene.field_heatmap_slots[0] as usize].values[63] == field.values[63])
+
+    var c = make_canvas(180, 290)
+    canvas_clear(&!c, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(read_px(&c, 40, 40) != 0)
+    assert(read_px(&c, 120, 40) != 0)
+    assert(read_px(&c, 40, 120) != 0)
+    assert(read_px(&c, 88, 88) != 0)
+    assert(read_px(&c, 8, 156) != 0)
+    assert(read_px(&c, 8, 224) != 0)
+    heap_free(c.pixels as *mut i8)
+
+    println("VIZ_PHYSCHEM_PASS")
+}

--- a/tests/run-pass/viz_text_controls.sio
+++ b/tests/run-pass/viz_text_controls.sio
@@ -1,0 +1,94 @@
+// tests/run-pass/viz_text_controls.sio - label, legend, tooltip Visual IR proof
+//
+// Expected output:
+//   VIZ_TEXT_CONTROLS_PASS
+
+use display::canvas::{Canvas, canvas_clear}
+use viz::ir::{viz_scene_new, viz_layout_rect, viz_style_rgb, viz_add_label, viz_add_legend, viz_add_tooltip}
+use viz::viz_canvas::{viz_canvas_render_scene}
+use viz::viz_html::{viz_html_emit_scene}
+
+fn make_canvas(w: i64, h: i64) -> Canvas with Alloc {
+    let pix = heap_alloc(w * h * 8) as *mut i64
+    Canvas { pixels: pix, width: w, height: h }
+}
+
+fn read_px(c: &Canvas, x: i64, y: i64) -> i64 {
+    read_i64(c.pixels, y * c.width + x)
+}
+
+fn count_nonzero_rect(c: &Canvas, x: i64, y: i64, w: i64, h: i64) -> i64 with Mut {
+    var count: i64 = 0
+    var yy: i64 = y
+    while yy < y + h {
+        var xx: i64 = x
+        while xx < x + w {
+            if read_px(c, xx, yy) != 0 {
+                count = count + 1
+            }
+            xx = xx + 1
+        }
+        yy = yy + 1
+    }
+    count
+}
+
+fn main() with IO, Alloc, Mut, Div {
+    var title: [i8; 64] = [0; 64]
+    title[0] = 83  // S
+    title[1] = 111 // o
+    title[2] = 117 // u
+    title[3] = 110 // n
+    title[4] = 105 // i
+    title[5] = 111 // o
+    title[6] = 32
+    title[7] = 86  // V
+    title[8] = 105 // i
+    title[9] = 122 // z
+
+    var legend: [i8; 64] = [0; 64]
+    legend[0] = 69  // E
+    legend[1] = 112 // p
+    legend[2] = 105 // i
+    legend[3] = 32
+    legend[4] = 98  // b
+    legend[5] = 97  // a
+    legend[6] = 110 // n
+    legend[7] = 100 // d
+
+    var tip: [i8; 64] = [0; 64]
+    tip[0] = 68  // D
+    tip[1] = 114 // r
+    tip[2] = 97  // a
+    tip[3] = 103 // g
+    tip[4] = 32
+    tip[5] = 38  // &
+    tip[6] = 60  // <
+    tip[7] = 62  // >
+    tip[8] = 34  // "
+
+    var scene = viz_scene_new()
+    let label_id = viz_add_label(&!scene, &title, 10, viz_layout_rect(8, 8, 80, 12), viz_style_rgb(230, 235, 240))
+    let legend_id = viz_add_legend(&!scene, &legend, 8, viz_layout_rect(8, 28, 96, 18), viz_style_rgb(100, 200, 255))
+    let tip_id = viz_add_tooltip(&!scene, &tip, 9, viz_layout_rect(8, 54, 110, 18), viz_style_rgb(255, 220, 120))
+    assert(label_id == 0)
+    assert(legend_id == 1)
+    assert(tip_id == 2)
+    assert(scene.nodes[label_id as usize].label_len == 10)
+    assert(scene.nodes[legend_id as usize].label[0] == 69)
+    assert(scene.nodes[tip_id as usize].label[5] == 38)
+    assert(scene.nodes[tip_id as usize].label[6] == 60)
+    assert(scene.nodes[tip_id as usize].label[7] == 62)
+    assert(scene.nodes[tip_id as usize].label[8] == 34)
+
+    var c = make_canvas(140, 90)
+    canvas_clear(&!c, 0, 0, 0)
+    viz_canvas_render_scene(&scene, &!c)
+    assert(count_nonzero_rect(&c, 8, 8, 80, 12) > 0)
+    assert(count_nonzero_rect(&c, 8, 28, 96, 18) > 0)
+    assert(count_nonzero_rect(&c, 8, 54, 110, 18) > 0)
+    heap_free(c.pixels as *mut i8)
+
+    viz_html_emit_scene(&scene, 140, 90)
+    println("VIZ_TEXT_CONTROLS_PASS")
+}


### PR DESCRIPTION
## What

Wires SOUNIO's two theses into one running object: a **non-associative octonion product now contributes its order-indeterminacy `κ·‖[a,b,c]‖²` to the epistemic variance budget.** Order-certainty becomes something you *earn* (an associative / Fano triple, `‖α‖²=0`), not something assumed — the same refusal-of-convenient-defaults the optimizer already enforces via the Fano reassociation gate (`ir/egraph.sio`), now extended to the uncertainty engine.

## Changes (4 files, +281, pure additions)

- **`stdlib/epistemic/propagate.sio`** — `product_nonassoc`: relocates the `associator_field` (window 7) coupling out of a test and into the propagation engine as a first-class rule (`Var_total = Var_GUM + κ·‖α‖²`).
- **`stdlib/epistemic/uncertain_octonion.sio`** — new `UncertainOct` type (octonion value + scalar variance). `mul3` folds the structural term **unconditionally** — no path yields the triple product without it (the automatic version). Binary `mul` is order-naive *by construction* (documented); the order-safe fix needs a perturbation DAG = the runtime correlation graph.
- **`tests/run-pass/`** — `propagate_nonassoc_variance.sio`, `uncertain_octonion_auto.sio` (Fano triple → no augmentation; non-Fano → `+κ·4`).

## Verification — honest ceiling

- ✅ **Method-body logic parse-verified + falsified** (injected syntax errors are caught).
- ⚠️ **Typecheck / execution NOT verified locally.** The single-module `--check` binary skips imports and **cannot parse `impl` blocks** (emits 1 error/method — shipping `knowledge.sio` fails identically, 22 methods → 22 errors), and the run-pass backend is unavailable in this environment. **CI / a working backend is required to actually run the two tests.** Logic validated by manual review against the verified `oct_*` signatures; uses only constructs that shipping stdlib code uses.

## Base

Targets `feat/typological-expansion` (the branch this was cut from) so the diff is exactly these 4 files — not the 117 commits that separate it from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)