### PR TITLE
feat(epistemic): exact N=4 order-spread via associahedron (pentagon_variance)

### DIFF
--- a/stdlib/epistemic/order_spread_exact.sio
+++ b/stdlib/epistemic/order_spread_exact.sio
@@ -42,9 +42,10 @@ pub fn product4_exact(
     a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], d: &[f64; 8],
     kappa: f64,
 ) -> Epistemic with Mut, Div, Panic, NonAssoc {
+    let total = base.variance + kappa * order_spread4(a, b, c, d)
     Epistemic {
         val: base.val,
-        variance: base.variance + kappa * order_spread4(a, b, c, d),
+        variance: if total < 0.0 { 0.0 } else { total },   // variance ≥ 0 (guards κ<0 / FP drift)
         confidence: base.confidence,
     }
 }

--- a/stdlib/epistemic/order_spread_exact.sio
+++ b/stdlib/epistemic/order_spread_exact.sio
@@ -1,0 +1,50 @@
+// stdlib/epistemic/order_spread_exact.sio — EXACT N=4 order-ambiguity (associahedron)
+//
+// The perturbation DAG (perturbation_graph.sio) is order-safe only THROUGH
+// TRIPLES; at N≥4 its per-node accumulation is path-dependent (proven: the five
+// parenthesizations of a·b·c·d give five different variances). The EXACT,
+// parenthesization-INDEPENDENT order-spread for a 4-factor octonion product is
+// the associahedron K4 (pentagon) vertex variance — the variance over all five
+// parenthesizations. This module exposes that as the exact N=4 path, reusing the
+// verified pentagon primitives in algebra::associator_field.
+//
+// Convention note: this reports the population VARIANCE of the 5 vertices, which
+// differs in normalization from the triple / DAG path (which reports κ·‖[a,b,c]‖²
+// = the squared associator = squared distance between the two triple vertices).
+// Both are legitimate measures of order-ambiguity; they do not share a constant.
+// Use the DAG for incremental products that are order-safe through triples; use
+// this for an EXACT N=4 spread.
+//
+// Execution-verified (self-contained build, real octonion arithmetic): a generic
+// 4-tuple gives order_spread4 = 2.044226 (matches the associator_field pentagon
+// investigation), and it is parenthesization-independent by construction — it
+// evaluates every parenthesization.
+
+use algebra::associator_field::{pentagon_products, pentagon_variance}
+use epistemic::knowledge::Epistemic
+
+// Exact, parenthesization-independent order-spread of (a·b·c·d): the K4 pentagon
+// vertex variance over all five parenthesizations.
+pub fn order_spread4(
+    a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], d: &[f64; 8],
+) -> f64 with Mut, Div, Panic, NonAssoc {
+    var ps: [f64; 40] = [0.0; 40]
+    pentagon_products(a, b, c, d, &!ps)
+    pentagon_variance(&ps)
+}
+
+// Augment a scalar observable computed through a 4-factor non-associative product
+// with the EXACT order-ambiguity variance κ·spread. Parenthesization-independent,
+// hence order-safe at N=4 by construction (unlike the incremental DAG, which is
+// exact only through triples).
+pub fn product4_exact(
+    base: Epistemic,
+    a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], d: &[f64; 8],
+    kappa: f64,
+) -> Epistemic with Mut, Div, Panic, NonAssoc {
+    Epistemic {
+        val: base.val,
+        variance: base.variance + kappa * order_spread4(a, b, c, d),
+        confidence: base.confidence,
+    }
+}

--- a/tests/run-pass/order_spread_exact_n4.sio
+++ b/tests/run-pass/order_spread_exact_n4.sio
@@ -1,0 +1,39 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for the EXACT N=4 order-spread (stdlib/epistemic/order_spread_exact.sio).
+// Unlike the incremental DAG (order-safe only through triples), this evaluates all
+// five parenthesizations of a·b·c·d, so it is exact and parenthesization-independent
+// for N=4. On a fixed generic 4-tuple the associahedron (pentagon) vertex variance
+// is 2.044226; augmenting a base GUM variance of 0.25 with κ=1 gives 2.294226.
+
+use epistemic::order_spread_exact::{order_spread4, product4_exact}
+use epistemic::knowledge::Epistemic
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic, NonAssoc {
+    var ok = true
+    let a: [f64; 8] = [0.3, 0.1, 0.4, 0.1, 0.5, 0.9, 0.2, 0.6]
+    let b: [f64; 8] = [0.2, 0.7, 0.1, 0.8, 0.2, 0.8, 0.1, 0.9]
+    let c: [f64; 8] = [0.1, 0.6, 0.1, 0.8, 0.0, 0.3, 0.9, 0.7]
+    let d: [f64; 8] = [0.5, 0.7, 0.2, 0.9, 0.1, 0.4, 0.6, 0.3]
+
+    let s = order_spread4(&a, &b, &c, &d)
+    if approx(s, 2.044226) { print("exact spread = 2.044226: PASS") }
+    else { print("exact spread: FAIL"); ok = false }
+    if s > 0.0 { print("spread positive: PASS") }
+    else { print("positive: FAIL"); ok = false }
+
+    let base = Epistemic::measured(10.0, 0.5)   // variance 0.25
+    let e = product4_exact(base, &a, &b, &c, &d, 1.0)
+    if approx(e.val, 10.0) { print("value preserved: PASS") }
+    else { print("value: FAIL"); ok = false }
+    if approx(e.variance, 2.294226) { print("augmented variance = 0.25 + spread: PASS") }
+    else { print("augmented: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}


### PR DESCRIPTION
## What

The companion exact path to the incremental perturbation DAG in #273. The DAG is order-safe **only through triples**; at N≥4 its per-node accumulation is path-dependent (proven in #273: the five parenthesizations of a·b·c·d give five different variances). This PR adds the **exact, parenthesization-independent** N=4 order-ambiguity:

- **`order_spread4(a,b,c,d)`** — the associahedron K4 (pentagon) vertex variance over all five parenthesizations, reusing the verified `algebra::associator_field` pentagon primitives (`pentagon_products` + `pentagon_variance`).
- **`product4_exact(base, a,b,c,d, κ)`** — augments an `Epistemic`'s variance by `κ · order_spread4`. Parenthesization-independent ⇒ order-safe at N=4 *by construction*.

2 files, +89, pure additions.

## Verification

- ✅ **Execution-verified** (self-contained single-file build, real `oct_mul`): a generic 4-tuple gives `order_spread4 = 2.044226` (matches the #273 pentagon investigation); `product4_exact` augments 0.25 → 2.294226 (κ=1). ALL PASS, rc=0.
- ✅ **stdlib file parses clean + falsified** (free functions, no `impl`, so no checker-blindness; injected syntax error → parse failure).
- ⚠️ **Cross-module typecheck + run-pass execution need CI** (single-module checker skips imports; run harness backend unavailable locally).

## Convention note (honest)

`order_spread4` reports the **population variance of the 5 vertices**. This is a *different normalization* from the triple/DAG path, which reports `κ·‖[a,b,c]‖²` (the squared associator = squared distance between the 2 triple vertices). They do not share a constant; both are legitimate measures of order-ambiguity. Use the DAG for incremental products order-safe through triples; use this for an exact N=4 spread.

## Relationship to #273

#273 builds the synthesis + the incremental DAG and *proves* the DAG's order-safety is sharp at N≤3. This PR supplies the exact N≥4 quantity that proof points to. Independent of #273's code (only shares `associator_field` + `Epistemic`, both in the base), so it can merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)