### PR TITLE
[codex] Bridge Kretikos GPU runtime to modular compiler

### DIFF
--- a/bin/kretikos
+++ b/bin/kretikos
@@ -112,16 +112,60 @@ __kretikos_token_value() {
     tr ' ' '\n' <<<"$text" | awk -F= -v k="$key" '$1 == k { print $2; exit }'
 }
 
+__kretikos_compiler_help() {
+    "$SOUC_BIN" --help 2>&1 || true
+}
+
+__kretikos_compiler_mode() {
+    local help
+    help="$(__kretikos_compiler_help)"
+    if grep -q "Commands:" <<<"$help" || grep -q "<COMMAND>" <<<"$help"; then
+        echo "subcommand"
+    else
+        echo "positional"
+    fi
+}
+
+KRETIKOS_COMPILER_MODE="$(__kretikos_compiler_mode)"
+
+__kretikos_compile_source() {
+    local src="$1"
+    local out="$2"
+    case "$KRETIKOS_COMPILER_MODE" in
+        subcommand)
+            "$SOUC_BIN" compile "$src" -o "$out"
+            ;;
+        positional)
+            "$SOUC_BIN" "$src" "$out"
+            ;;
+        *)
+            echo "error: unknown Kretikos compiler mode: $KRETIKOS_COMPILER_MODE" >&2
+            return 1
+            ;;
+    esac
+}
+
 __kretikos_check_source() {
     local src="$1"
-    if [[ -x "$SCRIPT_DIR/souc" ]]; then
-        "$SCRIPT_DIR/souc" check "$src"
-    else
-        local out="${TMPDIR:-/tmp}/kretikos-check.elf"
-        rm -f "$out"
-        "$SOUC_BIN" "$src" "$out" >/dev/null
-        rm -f "$out"
-    fi
+    local out
+    out="$(mktemp "${TMPDIR:-/tmp}/kretikos-check.XXXXXX.elf")" || return 1
+    rm -f "$out"
+    case "$KRETIKOS_COMPILER_MODE" in
+        subcommand)
+            "$SOUC_BIN" check "$src"
+            ;;
+        positional)
+            __kretikos_compile_source "$src" "$out" >/dev/null
+            ;;
+        *)
+            echo "error: unknown Kretikos compiler mode: $KRETIKOS_COMPILER_MODE" >&2
+            rm -f "$out"
+            return 1
+            ;;
+    esac
+    local rc=$?
+    rm -f "$out"
+    return "$rc"
 }
 
 __kretikos_hpc_require_script() {
@@ -292,9 +336,13 @@ case "$CMD" in
         fi
         OUT="/tmp/kretikos-run.elf"
         rm -f "$OUT"
-        "$SOUC_BIN" "$1" "$OUT"
+        __kretikos_compile_source "$1" "$OUT"
         chmod +x "$OUT"
         "$OUT"
+        ;;
+    compiler-info)
+        COMPILER_PATH="$(__kretikos_repo_path "$SOUC_BIN")"
+        echo "kretikos: compiler - path=$COMPILER_PATH mode=$KRETIKOS_COMPILER_MODE"
         ;;
     profile-source)
         if [[ $# -lt 1 ]]; then
@@ -914,7 +962,7 @@ case "$CMD" in
             exit 1
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile PTX emitter driver" >&2
             exit 1
         }
@@ -997,7 +1045,7 @@ case "$CMD" in
             exit 1
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile Metal emitter driver" >&2
             exit 1
         }
@@ -1089,7 +1137,7 @@ case "$CMD" in
             exit 1
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile SPIR-V emitter driver" >&2
             exit 1
         }
@@ -1190,7 +1238,7 @@ case "$CMD" in
                 ;;
         esac
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile K-AXI emitter driver" >&2
             exit 1
         }
@@ -1313,7 +1361,7 @@ case "$CMD" in
                 ;;
         esac
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile K-AXI→PTX driver" >&2
             exit 1
         }
@@ -1438,7 +1486,7 @@ USAGE
             exit 2
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile json-emit driver" >&2
             exit 1
         }
@@ -1476,7 +1524,7 @@ USAGE
             exit 2
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile validate-evidence driver" >&2
             exit 1
         }
@@ -1505,7 +1553,7 @@ USAGE
             exit 2
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile cubin-validate driver" >&2
             exit 1
         }
@@ -1557,7 +1605,7 @@ USAGE
             *) echo "error: unsupported mode '$MODE'" >&2; exit 1 ;;
         esac
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile K-AXI compile driver" >&2
             exit 1
         }
@@ -1664,7 +1712,7 @@ USAGE
         SUMMARY_DRIVER_ELF="$SUMMARY_DRIVER_DIR/asm-summary.elf"
         SUMMARY_JSON="$SUMMARY_DRIVER_DIR/summary.json"
         trap 'rm -rf "$SUMMARY_DRIVER_DIR"' EXIT INT TERM
-        "$SOUC_BIN" "$SUMMARY_DRIVER_SRC" "$SUMMARY_DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$SUMMARY_DRIVER_SRC" "$SUMMARY_DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile kaxi-asm-summary driver" >&2
             exit 1
         }
@@ -2240,7 +2288,7 @@ USAGE
         umask "$OLD_UMASK"
         RECOG_DRIVER_ELF="$RECOG_DRIVER_DIR/source-recog.elf"
         trap 'rm -rf "$RECOG_DRIVER_DIR"' EXIT INT TERM
-        "$SOUC_BIN" "$RECOG_DRIVER_SRC" "$RECOG_DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$RECOG_DRIVER_SRC" "$RECOG_DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile kaxi-source-recognizer driver" >&2
             exit 1
         }
@@ -2394,7 +2442,7 @@ USAGE
 
     kaxi-lowering-certificate)
         if [[ $# -lt 1 ]]; then
-            echo "usage: kretikos kaxi-lowering-certificate <source.sio> -o <file.json> [--work-dir <dir>] [--force] [--require-runtime]" >&2
+            echo "usage: kretikos kaxi-lowering-certificate <source.sio> -o <file.json> [--work-dir <dir>] [--force] [--allow-runtime-blocked] [--require-runtime]" >&2
             exit 1
         fi
         SRC="$1"
@@ -2404,6 +2452,8 @@ USAGE
         FORCE=0
         RUNTIME_ARG=(--validate-runtime)
         RUNTIME_MODE="auto"
+        ALLOW_RUNTIME_BLOCKED=0
+        RUNTIME_BLOCKED=0
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 -o|--output)
@@ -2423,6 +2473,10 @@ USAGE
                     RUNTIME_MODE="auto"
                     shift
                     ;;
+                --allow-runtime-blocked)
+                    ALLOW_RUNTIME_BLOCKED=1
+                    shift
+                    ;;
                 --require-runtime)
                     RUNTIME_ARG=(--require-runtime)
                     RUNTIME_MODE="required"
@@ -2440,7 +2494,7 @@ USAGE
         done
 
         if [[ -z "$OUT" ]]; then
-            echo "usage: kretikos kaxi-lowering-certificate <source.sio> -o <file.json> [--work-dir <dir>] [--force] [--require-runtime]" >&2
+            echo "usage: kretikos kaxi-lowering-certificate <source.sio> -o <file.json> [--work-dir <dir>] [--force] [--allow-runtime-blocked] [--require-runtime]" >&2
             exit 1
         fi
         if [[ ! -f "$SRC" ]]; then
@@ -2480,11 +2534,14 @@ USAGE
             --kaxi-witness-output "$KAXI_WITNESS" >/dev/null
 
         mkdir -p "$RUNTIME_DIR"
-        "$KRETIKOS_SELF" run-source "$SRC" -o "$RUNTIME_DIR" --force "${RUNTIME_ARG[@]}" >"$RUN_SOURCE_LOG" 2>&1 || {
-            cat "$RUN_SOURCE_LOG" >&2
-            echo "error: K-AXI lowering certificate runtime/profile bundle step failed" >&2
-            exit 1
-        }
+        if ! "$KRETIKOS_SELF" run-source "$SRC" -o "$RUNTIME_DIR" --force "${RUNTIME_ARG[@]}" >"$RUN_SOURCE_LOG" 2>&1; then
+            if [[ "$RUNTIME_MODE" == "required" || "$ALLOW_RUNTIME_BLOCKED" -ne 1 ]]; then
+                cat "$RUN_SOURCE_LOG" >&2
+                echo "error: K-AXI lowering certificate runtime/profile bundle step failed" >&2
+                exit 1
+            fi
+            RUNTIME_BLOCKED=1
+        fi
 
         # Compose kaxi-lowering-certificate JSON. Reads up to 4 JSON files
         # (source_lowering, kaxi_witness, runtime_profile, bundle), runs
@@ -2624,10 +2681,10 @@ USAGE
         elif [[ "$KW_STATUS" != "pass" ]]; then
             __FAIL_ELEMS+=("$(printf '{"kind": "kaxi_witness_not_pass", "status": "%s"}' "$(__json_str_escape "$KW_STATUS")")")
         fi
-        if [[ ! -f "$RUNTIME_PROFILE_PATH" ]]; then
+        if [[ "$RUNTIME_BLOCKED" -ne 1 && ! -f "$RUNTIME_PROFILE_PATH" ]]; then
             __FAIL_ELEMS+=("$(printf '{"kind": "missing_runtime_source_profile", "path": "%s"}' "$(__json_str_escape "$RUNTIME_PROFILE_PATH")")")
         fi
-        if [[ ! -f "$BUNDLE_PATH" ]]; then
+        if [[ "$RUNTIME_BLOCKED" -ne 1 && ! -f "$BUNDLE_PATH" ]]; then
             __FAIL_ELEMS+=("$(printf '{"kind": "missing_runtime_bundle", "path": "%s"}' "$(__json_str_escape "$BUNDLE_PATH")")")
         fi
         if [[ -f "$SOURCE_LOWERING" ]]; then
@@ -2683,7 +2740,11 @@ USAGE
         fi
         if [[ ${#__FAIL_ELEMS[@]} -eq 0 ]]; then
             FAILURES_ARRAY="[]"
-            STATUS_VAL="pass"
+            if [[ "$RUNTIME_BLOCKED" -eq 1 ]]; then
+                STATUS_VAL="partial_runtime_blocked"
+            else
+                STATUS_VAL="pass"
+            fi
         else
             FAILURES_ARRAY="[$(IFS=,; echo "${__FAIL_ELEMS[*]}")]"
             STATUS_VAL="fail"
@@ -2698,8 +2759,17 @@ USAGE
             "$(__scalar_or_null "$RP_RUNTIME_RUNG")" \
             "$(__scalar_or_null "$RP_KERNEL")")"
         BUNDLE_STATUS_LIT="$(__scalar_or_null "$BD_STATUS")"
-        RUNTIME_OBJ="$(printf '{"mode": "%s", "source_profile": %s, "bundle_status": %s, "structural_checks": %s, "artifacts": %s, "runtime_validation": %s, "toolchain_validation": %s}' \
+        if [[ "$RUNTIME_BLOCKED" -eq 1 ]]; then
+            RUNTIME_BLOCKED_LIT="true"
+            RUNTIME_BLOCKED_REASON_LIT="$(__scalar_or_null "cubin_or_runtime_bundle_unavailable")"
+        else
+            RUNTIME_BLOCKED_LIT="false"
+            RUNTIME_BLOCKED_REASON_LIT="null"
+        fi
+        RUNTIME_OBJ="$(printf '{"mode": "%s", "blocked": %s, "blocked_reason": %s, "source_profile": %s, "bundle_status": %s, "structural_checks": %s, "artifacts": %s, "runtime_validation": %s, "toolchain_validation": %s}' \
             "$(__json_str_escape "$RUNTIME_MODE")" \
+            "$RUNTIME_BLOCKED_LIT" \
+            "$RUNTIME_BLOCKED_REASON_LIT" \
             "$RP_FULL_JSON" \
             "$BUNDLE_STATUS_LIT" \
             "$BD_SC_JSON" \
@@ -3007,7 +3077,7 @@ USAGE
         DRIVER_ELF="$DRIVER_DIR/driver.elf"
         trap 'rm -rf "$DRIVER_DIR"' EXIT INT TERM
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile CPU emulation driver" >&2
             exit 1
         }
@@ -3182,7 +3252,7 @@ USAGE
             fi
             ;;
             *)
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile CUBIN emitter driver" >&2
             exit 1
         }
@@ -3858,7 +3928,7 @@ NF {
             exit 2
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile siep-probe driver" >&2
             exit 1
         }
@@ -3884,7 +3954,7 @@ NF {
             exit 2
         fi
 
-        "$SOUC_BIN" "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
+        __kretikos_compile_source "$DRIVER_SRC" "$DRIVER_ELF" >/dev/null 2>&1 || {
             echo "error: failed to compile umbrella-aggregate driver" >&2
             exit 1
         }

--- a/scripts/ci/kretikos_cubin_runtime_structural_gate.sh
+++ b/scripts/ci/kretikos_cubin_runtime_structural_gate.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Kretikos CUBIN/runtime structural gate for the modular compiler bridge.
+#
+# This gate requires the runtime-backed vec_add_f32 profile to emit both PTX
+# and CUBIN artifacts and to produce a full K-AXI lowering certificate. It does
+# not require a local CUDA driver; driver execution remains a separate platform
+# rung.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KRETIKOS="$ROOT_DIR/bin/kretikos"
+
+if [[ ! -x "$KRETIKOS" ]]; then
+  echo "error: missing Kretikos launcher: $KRETIKOS" >&2
+  exit 1
+fi
+
+export SOUNIO_KRETIKOS_COMPILER="${SOUNIO_KRETIKOS_COMPILER:-$ROOT_DIR/bin/souc}"
+
+OUT_DIR="${KRETIKOS_CUBIN_RUNTIME_OUT:-}"
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kretikos-cubin-runtime.XXXXXX")"
+fi
+mkdir -p "$OUT_DIR"
+
+PROFILE_SOURCE="$ROOT_DIR/examples/kretikos/real_vec_add.sio"
+LOWER_SOURCE="$ROOT_DIR/examples/kretikos/lower_vec_add_f32.sio"
+RUNTIME_DIR="$OUT_DIR/runtime"
+CERT_JSON="$OUT_DIR/kaxi_lowering_certificate.json"
+
+echo "=== Kretikos CUBIN/runtime structural gate ==="
+echo "out_dir: $OUT_DIR"
+"$KRETIKOS" compiler-info | tee "$OUT_DIR/compiler_info.log"
+
+echo "[1/4] runtime-backed source bundle"
+"$KRETIKOS" run-source "$PROFILE_SOURCE" -o "$RUNTIME_DIR" --force \
+  >"$OUT_DIR/run_source.log" 2>&1
+
+echo "[2/4] validate emitted source runtime profile"
+"$KRETIKOS" kaxi-validate-evidence "$RUNTIME_DIR/kretikos_source_profile.v1.json" \
+  --expect status=profiled \
+  --expect profile=vec_add_f32 \
+  --expect runtime_backed=true \
+  --expect bundle_manifest=kretikos_bundle.v1.json \
+  >"$OUT_DIR/source_profile.validate.log" 2>&1
+
+echo "[3/4] validate emitted runtime bundle"
+mapfile -t BUNDLE_PARTS < <("$KRETIKOS" kaxi-validate-evidence "$RUNTIME_DIR/kretikos_bundle.v1.json" \
+  --print status \
+  --print runtime_validation.status \
+  --print runtime_validation.reason)
+
+BUNDLE_STATUS="${BUNDLE_PARTS[0]}"
+BUNDLE_RUNTIME_STATUS="${BUNDLE_PARTS[1]}"
+BUNDLE_RUNTIME_REASON="${BUNDLE_PARTS[2]}"
+
+if [[ "$BUNDLE_STATUS" != "emitted" ]]; then
+  echo "error: runtime bundle was not emitted: $BUNDLE_STATUS" >&2
+  exit 1
+fi
+
+case "$BUNDLE_RUNTIME_STATUS/$BUNDLE_RUNTIME_REASON" in
+  pass/*|not_run/cuda_driver_missing) ;;
+  *)
+    echo "error: unexpected runtime classification: $BUNDLE_RUNTIME_STATUS/$BUNDLE_RUNTIME_REASON" >&2
+    exit 1
+    ;;
+esac
+
+echo "[4/4] strict source-to-K-AXI certificate with runtime bundle"
+"$KRETIKOS" kaxi-lowering-certificate "$LOWER_SOURCE" \
+  -o "$CERT_JSON" \
+  --force \
+  >"$OUT_DIR/kaxi_lowering_certificate.log" 2>&1
+
+mapfile -t CERT_PARTS < <("$KRETIKOS" kaxi-validate-evidence "$CERT_JSON" \
+  --print status \
+  --print lowering.source_lowered_to_kaxi \
+  --print lowering.kaxi_pattern \
+  --print runtime.blocked \
+  --print runtime.bundle_status \
+  --print runtime.runtime_validation.status \
+  --print runtime.runtime_validation.reason)
+
+CERT_STATUS="${CERT_PARTS[0]}"
+CERT_LOWERED="${CERT_PARTS[1]}"
+CERT_PATTERN="${CERT_PARTS[2]}"
+CERT_RUNTIME_BLOCKED="${CERT_PARTS[3]}"
+CERT_BUNDLE_STATUS="${CERT_PARTS[4]}"
+CERT_RUNTIME_STATUS="${CERT_PARTS[5]}"
+CERT_RUNTIME_REASON="${CERT_PARTS[6]}"
+
+if [[ "$CERT_STATUS" != "pass" ]]; then
+  echo "error: certificate did not pass: $CERT_STATUS" >&2
+  exit 1
+fi
+
+if [[ "$CERT_LOWERED" != "true" || "$CERT_PATTERN" != "source_vec_add_f32" ]]; then
+  echo "error: certificate did not preserve source->K-AXI lowering facts" >&2
+  exit 1
+fi
+
+if [[ "$CERT_RUNTIME_BLOCKED" != "false" || "$CERT_BUNDLE_STATUS" != "emitted" ]]; then
+  echo "error: runtime bundle not present in certificate" >&2
+  exit 1
+fi
+
+case "$CERT_RUNTIME_STATUS/$CERT_RUNTIME_REASON" in
+  pass/*|not_run/cuda_driver_missing) ;;
+  *)
+  echo "error: unexpected local runtime classification: $CERT_RUNTIME_STATUS/$CERT_RUNTIME_REASON" >&2
+  exit 1
+  ;;
+esac
+
+echo "kretikos_cubin_runtime_structural: PASS status=$CERT_STATUS runtime=$CERT_RUNTIME_STATUS/$CERT_RUNTIME_REASON"
+echo "kretikos_cubin_runtime_structural: artifacts=$OUT_DIR"

--- a/scripts/ci/kretikos_modular_bridge_gate.sh
+++ b/scripts/ci/kretikos_modular_bridge_gate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Kretikos modular compiler bridge gate.
+#
+# Proves the narrow integration surface that should move first while the
+# modular compiler lands:
+#   checked Sounio source -> Kretikos profile classification
+#   checked Sounio source -> K-AXI lowering witness
+#   lowering witness -> certificate with explicit runtime/CUBIN status
+#
+# This gate intentionally does not claim arbitrary GPU lowering.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KRETIKOS="$ROOT_DIR/bin/kretikos"
+
+if [[ ! -x "$KRETIKOS" ]]; then
+  echo "error: missing Kretikos launcher: $KRETIKOS" >&2
+  exit 1
+fi
+
+export SOUNIO_KRETIKOS_COMPILER="${SOUNIO_KRETIKOS_COMPILER:-$ROOT_DIR/bin/souc}"
+
+OUT_DIR="${KRETIKOS_MODULAR_BRIDGE_OUT:-}"
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kretikos-modular-bridge.XXXXXX")"
+fi
+mkdir -p "$OUT_DIR"
+
+REAL_SOURCE="$ROOT_DIR/examples/kretikos/real_vec_add.sio"
+LOWER_SOURCE="$ROOT_DIR/examples/kretikos/lower_vec_add_f32.sio"
+PROFILE_LOG="$OUT_DIR/profile_source.log"
+LOWERING_JSON="$OUT_DIR/kaxi_source_lowering.json"
+CERT_JSON="$OUT_DIR/kaxi_lowering_certificate.json"
+
+echo "=== Kretikos modular bridge gate ==="
+echo "out_dir: $OUT_DIR"
+"$KRETIKOS" compiler-info | tee "$OUT_DIR/compiler_info.log"
+
+echo "[1/5] source check: runtime-backed profile source"
+"$KRETIKOS" check "$REAL_SOURCE" >"$OUT_DIR/check_real_source.log" 2>&1
+
+echo "[2/5] profile-source: runtime-backed classification"
+"$KRETIKOS" profile-source "$REAL_SOURCE" | tee "$PROFILE_LOG"
+grep -q 'profile=vec_add_f32' "$PROFILE_LOG"
+grep -q 'runtime_backed=1' "$PROFILE_LOG"
+
+echo "[3/5] source check: shape-lowering source"
+"$KRETIKOS" check "$LOWER_SOURCE" >"$OUT_DIR/check_lower_source.log" 2>&1
+
+echo "[4/5] K-AXI source lowering"
+"$KRETIKOS" kaxi-lower-source "$LOWER_SOURCE" -o "$LOWERING_JSON" >"$OUT_DIR/kaxi_lower_source.log" 2>&1
+"$KRETIKOS" kaxi-validate-evidence "$LOWERING_JSON" \
+  --expect status=pass \
+  --expect lowering.source_lowered_to_kaxi=true \
+  --expect lowering.kaxi_pattern=source_vec_add_f32 \
+  >"$OUT_DIR/kaxi_lower_source.validate.log" 2>&1
+
+echo "[5/5] lowering certificate with honest runtime boundary"
+"$KRETIKOS" kaxi-lowering-certificate "$LOWER_SOURCE" \
+  -o "$CERT_JSON" \
+  --force \
+  --allow-runtime-blocked \
+  >"$OUT_DIR/kaxi_lowering_certificate.log" 2>&1
+
+mapfile -t CERT_PARTS < <("$KRETIKOS" kaxi-validate-evidence "$CERT_JSON" \
+  --print status \
+  --print lowering.source_lowered_to_kaxi \
+  --print lowering.kaxi_pattern \
+  --print runtime.blocked)
+
+CERT_STATUS="${CERT_PARTS[0]}"
+CERT_LOWERED="${CERT_PARTS[1]}"
+CERT_PATTERN="${CERT_PARTS[2]}"
+CERT_RUNTIME_BLOCKED="${CERT_PARTS[3]}"
+
+case "$CERT_STATUS" in
+  pass|partial_runtime_blocked) ;;
+  *)
+    echo "error: unexpected certificate status: $CERT_STATUS" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$CERT_LOWERED" != "true" || "$CERT_PATTERN" != "source_vec_add_f32" ]]; then
+  echo "error: certificate did not preserve source->K-AXI lowering facts" >&2
+  exit 1
+fi
+
+if [[ "$CERT_STATUS" == "partial_runtime_blocked" && "$CERT_RUNTIME_BLOCKED" != "true" ]]; then
+  echo "error: partial runtime certificate did not mark runtime.blocked=true" >&2
+  exit 1
+fi
+
+echo "kretikos_modular_bridge: PASS status=$CERT_STATUS runtime_blocked=$CERT_RUNTIME_BLOCKED"
+echo "kretikos_modular_bridge: artifacts=$OUT_DIR"

--- a/self-hosted/gpu/kretikos_emit_cubin.sio
+++ b/self-hosted/gpu/kretikos_emit_cubin.sio
@@ -120,8 +120,8 @@ fn main() -> i32 with IO, Mut, Panic, Div {
     }
 
     var i: i64 = 0
-    while i < buf.len {
-        print_byte_decimal(buf.data[i as usize])
+    while i < gpu_bare_buf_len(buf) {
+        print_byte_decimal(gpu_bare_buf_get(buf, i))
         print("\n")
         i = i + 1
     }

--- a/self-hosted/gpu/nvidia_bare.sio
+++ b/self-hosted/gpu/nvidia_bare.sio
@@ -52,6 +52,14 @@ struct GpuBareBuf {
     len: i64,
 }
 
+pub fn gpu_bare_buf_len(buf: GpuBareBuf) -> i64 {
+    buf.len
+}
+
+pub fn gpu_bare_buf_get(buf: GpuBareBuf, i: i64) -> i64 {
+    buf.data[i as usize]
+}
+
 fn gpu_bare_buf_new() -> GpuBareBuf {
     GpuBareBuf { data: [0; 2560], len: 0 }
 }

--- a/slurm-jobs/kretikos/submit-kretikos-source.sh
+++ b/slurm-jobs/kretikos/submit-kretikos-source.sh
@@ -101,12 +101,16 @@ RUN_ID="${RUN_ID:-kretikos-source-$(date -u +%Y%m%dT%H%M%S)-${BASHPID}}"
 LOCAL_TARBALL="${LOCAL_TARBALL:-/tmp/${RUN_ID}.tgz}"
 LOCAL_SBATCH="${LOCAL_SBATCH:-/tmp/${RUN_ID}.sbatch}"
 REMOTE_SBATCH="${REMOTE_SBATCH:-/tmp/${RUN_ID}.sbatch}"
+REMOTE_PAYLOAD_TGZ="${REMOTE_PAYLOAD_TGZ:-${KRETIKOS_HPC_WORKER_TMP}/${RUN_ID}.payload.tgz}"
 LOCAL_LOADER="${LOCAL_LOADER:-/tmp/${RUN_ID}.kretikos_nvidia_bare_loader}"
 SOURCE_PAYLOAD_NAME="${RUN_ID}.source.sio"
 LOADER_PAYLOAD_NAME="$(basename "${LOCAL_LOADER}")"
 SOURCE_PAYLOAD="/tmp/${SOURCE_PAYLOAD_NAME}"
 
 cleanup() {
+  if [[ "${KRETIKOS_HPC_KEEP_LOCAL:-0}" == "1" ]]; then
+    return
+  fi
   rm -f "${SOURCE_PAYLOAD}" "${LOCAL_TARBALL}" "${LOCAL_SBATCH}" "${LOCAL_LOADER}" 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -120,20 +124,18 @@ tar -C "${ROOT_DIR}" -czf "${LOCAL_TARBALL}" \
   bin/kretikos \
   bin/souc \
   bin/souc-linux-x86_64 \
-  self-hosted/gpu/kretikos_emit_ptx.sio \
-  self-hosted/gpu/kretikos_emit_cubin.sio \
-  self-hosted/gpu/kretikos_emit_kaxi.sio \
-  self-hosted/gpu/kretikos_kaxi_validate_evidence.sio \
-  self-hosted/gpu/kretikos_json_emit.sio \
-  self-hosted/gpu/kaxi_backend.sio \
-  self-hosted/gpu/ptx.sio \
-  self-hosted/gpu/nvidia_bare.sio \
+  self-hosted/gpu/*.sio \
   scripts/gpu/nvidia_bare_driver_loader.c \
   stdlib \
   -C /tmp "${LOADER_PAYLOAD_NAME}" "${SOURCE_PAYLOAD_NAME}"
 tar -tzf "${LOCAL_TARBALL}" >/dev/null
 
-PAYLOAD_B64="$(base64 -w 0 "${LOCAL_TARBALL}" 2>/dev/null || base64 "${LOCAL_TARBALL}" | tr -d '\n')"
+WORKER_POD_FOR_PAYLOAD="$("${KUBECTL_BIN}" -n "${NS}" get pods -l "${KRETIKOS_HPC_WORKER_POD_LABEL}" -o wide \
+  | awk -v node="${KRETIKOS_HPC_WORKER_NODE}" '$7 == node { print $1; exit }')"
+if [[ -z "${WORKER_POD_FOR_PAYLOAD}" ]]; then
+  echo "could not resolve worker pod for node ${KRETIKOS_HPC_WORKER_NODE}" >&2
+  exit 1
+fi
 
 cat > "${LOCAL_SBATCH}" <<EOF
 #!/usr/bin/env bash
@@ -163,6 +165,7 @@ CERTIFY_KAXI="${KRETIKOS_HPC_CERTIFY_KAXI}"
 SOURCE_PAYLOAD_NAME="${SOURCE_PAYLOAD_NAME}"
 LOADER_PAYLOAD_NAME="${LOADER_PAYLOAD_NAME}"
 KRETIKOS_VEC_N="${KRETIKOS_VEC_N}"
+REMOTE_PAYLOAD_TGZ="${REMOTE_PAYLOAD_TGZ}"
 
 mark() {
   local msg="\$1"
@@ -186,10 +189,8 @@ trap 'fail "\$?" "\$LINENO"' ERR
 rm -rf "\${LOCAL_ROOT}"
 mkdir -p "\${SOUNIO_DIR}" "\${BUNDLE_DIR}" "\${CERT_DIR}"
 mark "kretikos_source=running phase=decode_payload"
-cat > "\${LOCAL_ROOT}/payload.tgz.b64" <<'PAYLOAD_EOF'
-${PAYLOAD_B64}
-PAYLOAD_EOF
-base64 -d "\${LOCAL_ROOT}/payload.tgz.b64" > "\${LOCAL_ROOT}/payload.tgz"
+cp "\${REMOTE_PAYLOAD_TGZ}" "\${LOCAL_ROOT}/payload.tgz"
+rm -f "\${REMOTE_PAYLOAD_TGZ}"
 tar -xzf "\${LOCAL_ROOT}/payload.tgz" -C "\${SOUNIO_DIR}"
 mv "\${SOUNIO_DIR}/\${LOADER_PAYLOAD_NAME}" "\${SOUNIO_DIR}/kretikos_nvidia_bare_loader"
 chmod +x "\${SOUNIO_DIR}/bin/kretikos" "\${SOUNIO_DIR}/bin/souc" "\${SOUNIO_DIR}/bin/souc-linux-x86_64" "\${SOUNIO_DIR}/kretikos_nvidia_bare_loader"
@@ -366,7 +367,8 @@ if [[ "\${PUBLISH_RESULTS}" == "1" ]]; then
 fi
 EOF
 
-echo "[3/5] uploading sbatch to login pod"
+echo "[3/5] staging payload and uploading sbatch"
+"${KUBECTL_BIN}" -n "${NS}" cp "${LOCAL_TARBALL}" "${WORKER_POD_FOR_PAYLOAD}:${REMOTE_PAYLOAD_TGZ}" >/dev/null
 "${KUBECTL_BIN}" -n "${NS}" cp "${LOCAL_SBATCH}" "${LOGIN_POD}:${REMOTE_SBATCH}" >/dev/null
 
 echo "[4/5] submitting to Slurm"


### PR DESCRIPTION
## Summary

This PR connects the Kretikos GPU runtime lane to the modular compiler branch without claiming a broader GPU backend than the evidence supports.

It adds compiler-mode routing in `bin/kretikos` so Kretikos internal drivers work with both subcommand-style compilers and the positional modular compiler shape (`souc <source> <output>`). It also fixes the CUBIN emitter driver to respect modular privacy checks by using public `GpuBareBuf` accessors, and repairs the Slurm runtime submitter so large payloads are staged through worker-local `/tmp` instead of embedded as oversized sbatch heredocs.

## Changes

- Add Kretikos compiler mode detection and `compiler-info`.
- Route internal Kretikos driver compilation through the detected compiler mode.
- Add strict/partial runtime boundary handling for K-AXI lowering certificates.
- Add public `gpu_bare_buf_len` and `gpu_bare_buf_get` accessors.
- Update `kretikos_emit_cubin.sio` to avoid private `GpuBareBuf` field access.
- Stage Slurm payloads to worker-local `/tmp` and package all `self-hosted/gpu/*.sio` runtime driver dependencies.
- Add `scripts/ci/kretikos_modular_bridge_gate.sh`.
- Add `scripts/ci/kretikos_cubin_runtime_structural_gate.sh`.

## Validation

Local structural gates:

```text
KRETIKOS_MODULAR_BRIDGE_OUT=/tmp/kretikos-modular-bridge-final3 \
  scripts/ci/kretikos_modular_bridge_gate.sh
=> kretikos_modular_bridge: PASS status=pass runtime_blocked=false
```

```text
KRETIKOS_CUBIN_RUNTIME_OUT=/tmp/kretikos-cubin-runtime-final3 \
  scripts/ci/kretikos_cubin_runtime_structural_gate.sh
=> kretikos_cubin_runtime_structural: PASS status=pass runtime=not_run/cuda_driver_missing
```

Slurm CUDA runtime gate:

```text
LOGIN_POD_NAME=slurm-pilot-login-slinky-5ffb48b759-8hmc2 \
WAIT_TIMEOUT_SECONDS=900 \
SOUNIO_KRETIKOS_HPC_GATE_DIR=/tmp/kretikos-hpc-slurm-final2 \
  bash scripts/ci/kretikos_hpc_slurm_runtime_gate.sh
=> kretikos_hpc_slurm_runtime_gate: PASS out=/tmp/kretikos-hpc-slurm-final2 total=13 failed=0
```

Aggregate audit:

```text
status=pass
total=13
failed=0
device=NVIDIA_L4
driver=13020
compute_capability=8.9
artifact_runtime_failures=0
supported_kaxi_certificate_failures=0
```

Hygiene:

```text
git diff --check
bash -n bin/kretikos scripts/ci/kretikos_modular_bridge_gate.sh \
  scripts/ci/kretikos_cubin_runtime_structural_gate.sh \
  slurm-jobs/kretikos/submit-kretikos-source.sh \
  scripts/ci/kretikos_hpc_slurm_runtime_gate.sh
```

## Boundaries

This proves the modular compiler can drive the Kretikos runtime-backed GPU lane and that the Slurm worker can execute all 13 Kretikos manifest profiles through CUDA Driver API runtime validation.

It does not claim arbitrary Sounio GPU lowering. The Kretikos profiles remain the supported runtime-backed surface in this PR.

Worker-side `ptxas` and `nvdisasm` were missing and classified as toolchain inspection gaps, not runtime failures. Runtime acceptance is the CUDA Driver API path through the Slurm worker.