### PR TITLE
Select Kretikos profile from source recognition

### DIFF
--- a/bin/kretikos
+++ b/bin/kretikos
@@ -226,6 +226,64 @@ __kretikos_normalize_profile() {
     tr '[:upper:]' '[:lower:]' <<<"$1" | tr '-' '_'
 }
 
+__kretikos_source_profile_record_from_kaxi_recognition() {
+    local src="$1"
+    local recog_driver_src="$ROOT_DIR/self-hosted/gpu/kretikos_kaxi_source_recognizer.sio"
+    if [[ ! -f "$recog_driver_src" ]]; then
+        return 1
+    fi
+
+    local old_umask recog_dir recog_elf recognition_out recog_utc
+    old_umask="$(umask)"
+    umask 077
+    recog_dir="$(mktemp -d "${TMPDIR:-/tmp}/kretikos-source-profile-recog.XXXXXX")" || {
+        umask "$old_umask"
+        return 1
+    }
+    umask "$old_umask"
+    recog_elf="$recog_dir/source-recog.elf"
+    recognition_out="$recog_dir/recognition.json"
+
+    if ! __kretikos_compile_source "$recog_driver_src" "$recog_elf" >/dev/null 2>&1; then
+        rm -rf "$recog_dir"
+        return 1
+    fi
+    chmod +x "$recog_elf"
+    recog_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    if ! "$recog_elf" "$src" "$src" "$recog_utc" >"$recognition_out" 2>/dev/null; then
+        rm -rf "$recog_dir"
+        return 1
+    fi
+
+    local parts status kaxi_pattern runtime_rung profile_hint fallback_path
+    mapfile -t parts < <("$KRETIKOS_SELF" kaxi-validate-evidence "$recognition_out" \
+        --print-or-empty status \
+        --print-or-empty kaxi_pattern \
+        --print-or-empty runtime_rung \
+        --print-or-empty profile_hint \
+        --print-or-empty fallback_path 2>/dev/null || true)
+    rm -rf "$recog_dir"
+
+    status="${parts[0]:-}"
+    kaxi_pattern="${parts[1]:-}"
+    runtime_rung="${parts[2]:-}"
+    profile_hint="${parts[3]:-}"
+    fallback_path="${parts[4]:-}"
+
+    if [[ "$status" != "pass" || "$profile_hint" != "none" || "$fallback_path" != "none" ]]; then
+        return 1
+    fi
+
+    case "$kaxi_pattern:$runtime_rung" in
+        source_vec_add_f32:vec_add_f32)
+            echo "vec_add_f32|vec_add_f32|vec_add_f32|sounio_bare_vec_add_f32_sm80|semantic_source_profile|vec_add|1"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
 __kretikos_source_profile_record() {
     local src="$1"
     if [[ ! -f "$src" ]]; then
@@ -244,6 +302,13 @@ __kretikos_source_profile_record() {
     profile="$(__kretikos_normalize_profile "$directive")"
 
     if [[ -z "$profile" ]]; then
+        local semantic_record
+        semantic_record="$(__kretikos_source_profile_record_from_kaxi_recognition "$src" 2>/dev/null || true)"
+        if [[ -n "$semantic_record" ]]; then
+            echo "$semantic_record"
+            return 0
+        fi
+
         if grep -Eq 'kernel[[:space:]]+fn[[:space:]]+.*(epistemic_dual|knowledge_dual)' "$src"; then
             profile="epistemic_dual_output_f32"
         elif grep -Eq 'kernel[[:space:]]+fn[[:space:]]+.*epistemic.*vec.*add' "$src"; then

--- a/scripts/ci/kretikos_semantic_profile_gate.sh
+++ b/scripts/ci/kretikos_semantic_profile_gate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Kretikos semantic source-profile gate.
+#
+# Proves the narrow no-comment path:
+#   checked Sounio source -> pure-Sounio source-shape recognizer
+#   recognized source_vec_add_f32 -> runtime-backed Kretikos profile
+#   profile -> lowering certificate with explicit runtime boundary
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KRETIKOS="$ROOT_DIR/bin/kretikos"
+
+if [[ ! -x "$KRETIKOS" ]]; then
+  echo "error: missing Kretikos launcher: $KRETIKOS" >&2
+  exit 1
+fi
+
+export SOUNIO_KRETIKOS_COMPILER="${SOUNIO_KRETIKOS_COMPILER:-$ROOT_DIR/bin/souc}"
+
+OUT_DIR="${KRETIKOS_SEMANTIC_PROFILE_OUT:-}"
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/kretikos-semantic-profile.XXXXXX")"
+fi
+mkdir -p "$OUT_DIR"
+
+LOWER_SOURCE="$ROOT_DIR/examples/kretikos/lower_vec_add_f32.sio"
+PROFILE_LOG="$OUT_DIR/profile_source.log"
+RUN_DIR="$OUT_DIR/run_source"
+LOWERING_JSON="$OUT_DIR/kaxi_source_lowering.json"
+CERT_JSON="$OUT_DIR/kaxi_lowering_certificate.json"
+
+echo "=== Kretikos semantic profile gate ==="
+echo "out_dir: $OUT_DIR"
+"$KRETIKOS" compiler-info | tee "$OUT_DIR/compiler_info.log"
+
+if grep -Eq '^[[:space:]]*//[[:space:]]*kretikos:[[:space:]]*profile[[:space:]]*=' "$LOWER_SOURCE"; then
+  echo "error: semantic profile gate source must not carry a kretikos profile directive" >&2
+  exit 1
+fi
+
+echo "[1/5] source check: no-comment lowering source"
+"$KRETIKOS" check "$LOWER_SOURCE" >"$OUT_DIR/check_lower_source.log" 2>&1
+
+echo "[2/5] profile-source: pure-Sounio recognizer selects vec_add_f32"
+"$KRETIKOS" profile-source "$LOWER_SOURCE" | tee "$PROFILE_LOG"
+grep -q 'profile=vec_add_f32' "$PROFILE_LOG"
+grep -q 'class=semantic_source_profile' "$PROFILE_LOG"
+grep -q 'runtime_backed=1' "$PROFILE_LOG"
+
+echo "[3/5] run-source: no-comment source emits runtime-backed bundle"
+"$KRETIKOS" run-source "$LOWER_SOURCE" -o "$RUN_DIR" --force >"$OUT_DIR/run_source.log" 2>&1
+"$KRETIKOS" kaxi-validate-evidence "$RUN_DIR/kretikos_source_profile.v1.json" \
+  --expect status=profiled \
+  --expect profile=vec_add_f32 \
+  --expect runtime_backed=true \
+  >"$OUT_DIR/run_source_profile.validate.log" 2>&1
+
+echo "[4/5] K-AXI source lowering still recognizes source_vec_add_f32"
+"$KRETIKOS" kaxi-lower-source "$LOWER_SOURCE" -o "$LOWERING_JSON" >"$OUT_DIR/kaxi_lower_source.log" 2>&1
+"$KRETIKOS" kaxi-validate-evidence "$LOWERING_JSON" \
+  --expect status=pass \
+  --expect lowering.source_lowered_to_kaxi=true \
+  --expect lowering.kaxi_pattern=source_vec_add_f32 \
+  >"$OUT_DIR/kaxi_lower_source.validate.log" 2>&1
+
+echo "[5/5] lowering certificate with semantic profile runtime bundle"
+"$KRETIKOS" kaxi-lowering-certificate "$LOWER_SOURCE" \
+  -o "$CERT_JSON" \
+  --force \
+  --allow-runtime-blocked \
+  >"$OUT_DIR/kaxi_lowering_certificate.log" 2>&1
+
+mapfile -t CERT_PARTS < <("$KRETIKOS" kaxi-validate-evidence "$CERT_JSON" \
+  --print status \
+  --print profile.name \
+  --print lowering.kaxi_pattern \
+  --print runtime.blocked)
+
+CERT_STATUS="${CERT_PARTS[0]}"
+CERT_PROFILE="${CERT_PARTS[1]}"
+CERT_PATTERN="${CERT_PARTS[2]}"
+CERT_RUNTIME_BLOCKED="${CERT_PARTS[3]}"
+
+case "$CERT_STATUS" in
+  pass|partial_runtime_blocked) ;;
+  *)
+    echo "error: unexpected certificate status: $CERT_STATUS" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$CERT_PROFILE" != "vec_add_f32" || "$CERT_PATTERN" != "source_vec_add_f32" ]]; then
+  echo "error: certificate did not preserve semantic profile/lowering facts" >&2
+  exit 1
+fi
+
+if [[ "$CERT_STATUS" == "partial_runtime_blocked" && "$CERT_RUNTIME_BLOCKED" != "true" ]]; then
+  echo "error: partial runtime certificate did not mark runtime.blocked=true" >&2
+  exit 1
+fi
+
+echo "kretikos_semantic_profile: PASS status=$CERT_STATUS profile=$CERT_PROFILE pattern=$CERT_PATTERN runtime_blocked=$CERT_RUNTIME_BLOCKED"
+echo "kretikos_semantic_profile: artifacts=$OUT_DIR"


### PR DESCRIPTION
## Summary

- Add a Kretikos profile-selection path that invokes the existing pure-Sounio K-AXI source recognizer when a source has no `// kretikos: profile=...` directive.
- Keep the new semantic path deliberately narrow: only `source_vec_add_f32` + `runtime_rung=vec_add_f32` maps to a runtime-backed `vec_add_f32` source profile for now.
- Preserve the existing explicit directive and legacy name-heuristic fallback behavior.
- Add `scripts/ci/kretikos_semantic_profile_gate.sh` to prove the no-comment source profile path, run-source bundle emission, K-AXI lowering, and lowering certificate.

## Evidence

- `bash -n bin/kretikos`
- `bash -n scripts/ci/kretikos_semantic_profile_gate.sh`
- `git diff --check`
- `KRETIKOS_SEMANTIC_PROFILE_OUT=/tmp/kretikos-semantic-profile-1 scripts/ci/kretikos_semantic_profile_gate.sh`
  - `kretikos_semantic_profile: PASS status=pass profile=vec_add_f32 pattern=source_vec_add_f32 runtime_blocked=false`
- `KRETIKOS_MODULAR_BRIDGE_OUT=/tmp/kretikos-modular-bridge-semantic-profile scripts/ci/kretikos_modular_bridge_gate.sh`
  - `kretikos_modular_bridge: PASS status=pass runtime_blocked=false`
- `LOGIN_POD_NAME=slurm-pilot-login-slinky-5ffb48b759-8hmc2 ./bin/kretikos hpc source examples/kretikos/lower_vec_add_f32.sio`
  - Slurm job `2436` completed on `gpuorangefs-r770-proxmox`
  - `device=NVIDIA_L4`, `driver=13020`, `cc=8.9`
  - `Comment=kretikos_source=pass profile=vec_add_f32 reason=runtime_vec_add_f32_pass ... cert=pass cert_kind=source_lowering`

## Boundaries

- This does not claim arbitrary Sounio GPU lowering.
- This does not remove the explicit profile directive path.
- The only semantic source-profile mapping introduced here is `source_vec_add_f32 -> vec_add_f32`.