### PR TITLE
fix(epistemic): migrate propagate.sio HOF generics to fn-pointer params

### DIFF
--- a/stdlib/epistemic/propagate.sio
+++ b/stdlib/epistemic/propagate.sio
@@ -238,13 +238,11 @@ pub fn product_correlated(
 // Propagate bivariate f(x,y) with uncertainty via central-difference Jacobian.
 // Uses delta method: Var(f) ≈ (df/dx)²·Var(x) + (df/dy)²·Var(y)
 // plus cross-term for correlated propagation.
-pub fn propagate_fn_2d<F>(
-    f: F,
+pub fn propagate_fn_2d(
+    f: fn(f64, f64) -> f64,
     x: Epistemic,
     y: Epistemic,
-) -> Epistemic
-where F: fn(f64, f64) -> f64
-{
+) -> Epistemic with Mut, Div, Panic {
     let eps = 1.0e-7
 
     // Central differences for partial derivatives
@@ -289,14 +287,20 @@ pub fn propagate_2d_analytic(
 
 use random::xoshiro::{Xoshiro256, xoshiro_seed, standard_normal}
 
+// Helper: draw two N(0,1) samples in one call.
+// Workaround for ownership::double_mut_borrow on consecutive `standard_normal(&!rng)` in a loop.
+fn standard_normal_pair(rng: &!Xoshiro256) -> (f64, f64) with Prob, Mut, Div, Panic {
+    let a = standard_normal(rng)
+    let b = standard_normal(rng)
+    (a, b)
+}
+
 // Monte Carlo variance propagation for arbitrary functions
-pub fn monte_carlo<F>(
+pub fn monte_carlo(
     x: Epistemic,
-    f: F,
+    f: fn(f64) -> f64,
     n_samples: i64,
-) -> Epistemic
-where F: fn(f64) -> f64
-{
+) -> Epistemic with Prob, Mut, Div, Panic {
     let std = sqrt_f64(x.variance)
 
     var sum = 0.0
@@ -327,14 +331,12 @@ where F: fn(f64) -> f64
 }
 
 // Monte Carlo for bivariate function
-pub fn monte_carlo_2d<F>(
+pub fn monte_carlo_2d(
     x: Epistemic,
     y: Epistemic,
-    f: F,
+    f: fn(f64, f64) -> f64,
     n_samples: i64,
-) -> Epistemic
-where F: fn(f64, f64) -> f64
-{
+) -> Epistemic with Prob, Mut, Div, Panic {
     let std_x = sqrt_f64(x.variance)
     let std_y = sqrt_f64(y.variance)
 
@@ -344,11 +346,9 @@ where F: fn(f64, f64) -> f64
 
     var i = 0
     while i < n_samples {
-        let z1 = standard_normal(&!rng)
-        let z2 = standard_normal(&!rng)
-
-        let sample_x = x.val + z1 * std_x
-        let sample_y = y.val + z2 * std_y
+        let zz = standard_normal_pair(&!rng)
+        let sample_x = x.val + zz.0 * std_x
+        let sample_y = y.val + zz.1 * std_y
 
         let result = f(sample_x, sample_y)
         sum = sum + result
@@ -376,7 +376,7 @@ fn abs_f64(x: f64) -> f64 {
     if x < 0.0 { 0.0 - x } else { x }
 }
 
-fn exp_f64(x: f64) -> f64 with Mut {
+fn exp_f64(x: f64) -> f64 with Mut, Div, Panic {
     if x > 10.0 { return 22026.465794806718 * exp_f64(x - 10.0) }
     if x < -10.0 { return 0.00004539992976248485 * exp_f64(x + 10.0) }
 


### PR DESCRIPTION
## Problem

`stdlib/epistemic/propagate.sio` defines three higher-order functions with generic-over-function-type bounds:

```sio
pub fn propagate_fn_2d<F>(f: F, …) -> Epistemic where F: fn(f64, f64) -> f64 { f(…) }
pub fn monte_carlo<F>(…)    where F: fn(f64) -> f64       { … }
pub fn monte_carlo_2d<F>(…) where F: fn(f64, f64) -> f64  { … }
```

This `where F: fn(...)` form is **not supported by the toolchain**, verified by direct test:

| form | `bin/souc` (build) | `--check` binary |
|---|---|---|
| value generic `id<T>(x: T) -> T` | ✅ compiles + runs | — |
| **HOF `f<F>(…) where F: fn(…)`** | ❌ parses but **uncallable** (`error: unknown identifier <fn>` at call site) | ❌ can't parse (227 errors) |
| **fn-pointer `f: fn(…) -> T`** | ✅ compiles + runs | ✅ parses |

So the HOF-generic functions are build-broken: defining them is fine, but any caller fails to compile, and the self-hosted `--check` can't parse the file at all.

## Fix

Convert the three functions from `<F> where F: fn(...)` to explicit fn-pointer params `f: fn(...) -> T` — the form `bin/souc` compiles and runs (execution-verified in isolation). Also carries the in-progress effect annotations and the `standard_normal_pair` helper (double-mut-borrow workaround).

## Result

`propagate.sio` now **parses clean (32 items)** via the `--check` binary — previously **227 parse errors** — and the fn-pointer call form is execution-verified in `bin/souc`. 1 file changed.

## Context

This is the generics→fn-pointer migration that was in progress; landing it standalone unblocks `propagate.sio`. It is independent of #273/#274 (which were already moved off `propagate.sio` for exactly this reason — see #273's `product_nonassoc` relocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)