### PR TITLE
feat(epistemic): graded closeness on uncertain values (2-Wasserstein)

### DIFF
--- a/stdlib/epistemic/graded_eq.sio
+++ b/stdlib/epistemic/graded_eq.sio
@@ -1,23 +1,28 @@
-// stdlib/epistemic/graded_eq.sio — graded equality on uncertain values ("== is a lie")
+// stdlib/epistemic/graded_eq.sio — graded CLOSENESS on uncertain values (2-Wasserstein)
 //
-// SOUNIO already rejected certainty-by-default: an Epistemic value is a distribution
-// (mean = val, variance), not a point. So an honest `==` on two Epistemic values cannot
-// return a crisp bool — it must return the DISTANCE between their distributions. Boolean
-// equality is recovered as the d=0 (V=2) special case you explicitly CLAIM.
+// RELABELED after the round-2 equality dialectic: this module's ep_distance is the
+// transport/closeness measure ("how near are these, in value units?"), NOT equality
+// ("are these the same?"). The two are different questions: equality is about
+// coincidence at a resolution and lives in epistemic/uncertain_eq.sio
+// (ep_eq_prob = P(|a−b|<ε), an uncertain Bool, committed via ep_decide); closeness
+// is this module's W₂, which also appears as the .w2 diagnostic window of
+// uncertain_eq's EqField. The code below is unchanged — it was correct; the
+// original header's claim that it was "the honest ==" overstated it.
 //
 // For the Gaussian corner Epistemic lives in, the 2-Wasserstein distance is closed-form
 // and a genuine (Lawvere) metric:
 //   W2( N(μ₁,σ₁²), N(μ₂,σ₂²) ) = √( (μ₁−μ₂)² + (σ₁−σ₂)² ),   σᵢ = √(varianceᵢ)
 // Metric axioms (identity, symmetry, triangle) hold; two certain values (variance 0)
-// reduce to ordinary point distance |μ₁−μ₂| (the V=2 corner); and — the point — two values
-// with the SAME mean but different uncertainty are NOT equal, the difference a boolean
-// mean-comparison silently lies about.
+// reduce to ordinary point distance |μ₁−μ₂|; and two values with the SAME mean but
+// different uncertainty are at positive distance — a difference a boolean
+// mean-comparison silently ignores.
 //
 // SCOPE (honest): closed-form only in the Gaussian corner. Non-Gaussian distributions need
 // W₂ via the quantile integral (sampling/quadrature) — out of scope here. This is first-order
 // data; function-equality (the Met-not-cartesian-closed wall) is deliberately out of scope.
-// W₂ is a defensible-but-load-bearing choice (vs total-variation / Hellinger): chosen because
-// it reduces to ordinary distance in the certain corner.
+// W₂ is the right metric for CLOSENESS precisely because it carries value units and
+// degenerates to ordinary distance in the certain corner; for EQUALITY those same
+// properties were disqualifying (see uncertain_eq.sio's header for the full argument).
 //
 // Execution-verified (self-contained build, bin/souc): all metric axioms + corners pass.
 

--- a/stdlib/epistemic/graded_eq.sio
+++ b/stdlib/epistemic/graded_eq.sio
@@ -1,0 +1,37 @@
+// stdlib/epistemic/graded_eq.sio — graded equality on uncertain values ("== is a lie")
+//
+// SOUNIO already rejected certainty-by-default: an Epistemic value is a distribution
+// (mean = val, variance), not a point. So an honest `==` on two Epistemic values cannot
+// return a crisp bool — it must return the DISTANCE between their distributions. Boolean
+// equality is recovered as the d=0 (V=2) special case you explicitly CLAIM.
+//
+// For the Gaussian corner Epistemic lives in, the 2-Wasserstein distance is closed-form
+// and a genuine (Lawvere) metric:
+//   W2( N(μ₁,σ₁²), N(μ₂,σ₂²) ) = √( (μ₁−μ₂)² + (σ₁−σ₂)² ),   σᵢ = √(varianceᵢ)
+// Metric axioms (identity, symmetry, triangle) hold; two certain values (variance 0)
+// reduce to ordinary point distance |μ₁−μ₂| (the V=2 corner); and — the point — two values
+// with the SAME mean but different uncertainty are NOT equal, the difference a boolean
+// mean-comparison silently lies about.
+//
+// SCOPE (honest): closed-form only in the Gaussian corner. Non-Gaussian distributions need
+// W₂ via the quantile integral (sampling/quadrature) — out of scope here. This is first-order
+// data; function-equality (the Met-not-cartesian-closed wall) is deliberately out of scope.
+// W₂ is a defensible-but-load-bearing choice (vs total-variation / Hellinger): chosen because
+// it reduces to ordinary distance in the certain corner.
+//
+// Execution-verified (self-contained build, bin/souc): all metric axioms + corners pass.
+
+use epistemic::knowledge::{Epistemic, ep_sqrt}
+
+// Graded equality: the 2-Wasserstein distance in [0,∞]. Zero iff same distribution.
+pub fn ep_distance(a: &Epistemic, b: &Epistemic) -> f64 with Mut, Div, Panic {
+    let dm = a.val - b.val
+    let ds = ep_sqrt(a.variance) - ep_sqrt(b.variance)
+    ep_sqrt(dm * dm + ds * ds)
+}
+
+// Boolean equality, recovered as the claimed special case: equal within tolerance eps
+// (the d→0 / V=2 corner). On two *certain* values this is exact point equality up to eps.
+pub fn ep_approx_eq(a: &Epistemic, b: &Epistemic, eps: f64) -> bool with Mut, Div, Panic {
+    ep_distance(a, b) < eps
+}

--- a/tests/run-pass/graded_eq_wasserstein.sio
+++ b/tests/run-pass/graded_eq_wasserstein.sio
@@ -1,0 +1,56 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for graded equality (stdlib/epistemic/graded_eq.sio): `==` on uncertain
+// values returns the 2-Wasserstein distance, not a bool — and boolean equality is recovered
+// as the d<eps special case. All values via Epistemic::measured(mean, std_dev).
+//   a=(10,σ2) b=(13,σ6) c=(10,σ5):
+//   d(a,c)=√(0²+(2−5)²)=3   d(a,b)=√(3²+4²)=5   certain (σ0) → W2=|Δmean|.
+
+use epistemic::knowledge::Epistemic
+use epistemic::graded_eq::{ep_distance, ep_approx_eq}
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic {
+    var ok = true
+    let a = Epistemic::measured(10.0, 2.0)
+    let b = Epistemic::measured(13.0, 6.0)
+    let c = Epistemic::measured(10.0, 5.0)   // same mean as a, different uncertainty
+
+    // metric axiom: identity
+    if approx(ep_distance(&a, &a), 0.0) { print("identity d(a,a)=0: PASS") }
+    else { print("identity: FAIL"); ok = false }
+    // metric axiom: symmetry
+    if approx(ep_distance(&a, &b), ep_distance(&b, &a)) { print("symmetry: PASS") }
+    else { print("symmetry: FAIL"); ok = false }
+
+    // the thesis: same mean, different uncertainty -> distance 3 (graded == sees it)
+    if approx(ep_distance(&a, &c), 3.0) { print("same-mean diff-uncertainty -> d=3: PASS") }
+    else { print("same-mean: FAIL"); ok = false }
+
+    // recover exact equality at d=0; reject at d>0
+    let a2 = Epistemic::measured(10.0, 2.0)
+    if ep_approx_eq(&a, &a2, 0.0001) { print("identical -> approx_eq TRUE: PASS") }
+    else { print("recover-true: FAIL"); ok = false }
+    if ep_approx_eq(&a, &c, 0.0001) { print("recover-false: FAIL"); ok = false }
+    else { print("different -> approx_eq FALSE: PASS") }
+
+    // certain (V=2) corner: variance 0 -> W2 = |Δmean|
+    let p = Epistemic::measured(10.0, 0.0)
+    let q = Epistemic::measured(13.0, 0.0)
+    if approx(ep_distance(&p, &q), 3.0) { print("certain corner W2=|dmean|=3: PASS") }
+    else { print("certain: FAIL"); ok = false }
+
+    // metric axiom: triangle inequality
+    let dac = ep_distance(&a, &c)
+    let dab = ep_distance(&a, &b)
+    let dbc = ep_distance(&b, &c)
+    if dac <= dab + dbc + 0.0001 { print("triangle d(a,c)<=d(a,b)+d(b,c): PASS") }
+    else { print("triangle: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}


### PR DESCRIPTION
## What

"`==` is a lie." SOUNIO already rejected certainty-by-default — an `Epistemic` value is a *distribution* (mean = `val`, `variance`), not a point — so an honest equality on two of them **cannot return a crisp bool; it must return the distance between their distributions.** Boolean equality is recovered as the `d=0` (`V=2`) special case you explicitly claim.

For the Gaussian corner `Epistemic` lives in, that distance is closed-form and a genuine **Lawvere metric** (2-Wasserstein):

```
ep_distance(a,b) = √( (μ₁−μ₂)² + (σ₁−σ₂)² ),   σ = √variance
ep_approx_eq(a,b,ε) = ep_distance(a,b) < ε      // boolean == reclaimed as the d→0 corner
```

2 files, +93. Reuses `ep_sqrt` (no duplicate sqrt); free functions, no `impl`/generics.

## Why it's the right shape

Two values with the **same mean but different uncertainty** come back at distance 3 — the difference a boolean mean-comparison *silently lies about*. Identical distributions → `d=0` → exact equality reclaimed. Two **certain** values (variance 0) → `W₂ = |Δmean|` → graded `==` degenerates to ordinary point distance (the `V=2` corner, by construction). This is graded equality *forced by* the existing uncertainty substrate, not bolted on.

## Verification

- ✅ **Execution-verified** (self-contained `bin/souc` build, `ALL PASS`): metric axioms — identity `d(a,a)=0`, symmetry, triangle inequality — plus the same-mean/different-uncertainty thesis, exact-equality recovery at `d=0`, and the certain-corner reduction.
- ✅ **Parse-verified + falsified** (3 items; injected syntax error → parse failure).
- ⚠️ Cross-module typecheck/run-pass need CI (single-module checker skips imports).

## Honest scope (the dialectic's boundaries, kept)

- **Gaussian corner only** for the closed form; non-Gaussian `W₂` needs the quantile integral (sampling/quadrature) — out of scope.
- **First-order data only**; function-equality is the `Met`-not-cartesian-closed wall, deliberately out of scope (and undecidable anyway).
- **`W₂` is a defensible-but-load-bearing choice** (vs total-variation / Hellinger), picked because it reduces to ordinary distance in the certain corner. "Which metric is the right default" is a genuine open design question.

This is the first running increment of the "graded equality" frontier from the reject-defaults research program — the narrowed, *forced* thesis that survived the dialectic ("you already rejected certainty, so your `==` is already a lie"), now sound and computable in SOUNIO's native corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)