### PR TITLE
feat(epistemic): uncertain-Bool equality (P(|a−b|<ε)) + ep_decide + EqField windows

### DIFF
--- a/stdlib/epistemic/uncertain_eq.sio
+++ b/stdlib/epistemic/uncertain_eq.sio
@@ -1,0 +1,186 @@
+// stdlib/epistemic/uncertain_eq.sio — equality on uncertain values as an UNCERTAIN BOOL
+//
+// The resolution of the graded-equality dialectic: `==` on two Epistemic values
+// returns neither a crisp bool (the certainty lie) nor a raw divergence (which
+// re-booleanizes hidden at every if-site). It returns the BERNOULLI PROBABILITY
+// that the two values coincide at a declared resolution ε:
+//
+//   ep_eq_prob(a, b, ε) = P(|a − b| < ε),   a−b ~ N(Δμ, σ₁²+σ₂²)  (independent)
+//                       = Φ((ε−Δμ)/s) − Φ((−ε−Δμ)/s),  s = √(σ₁²+σ₂²)
+//
+// Control flow commits through ep_decide(p, confidence) — the named-threshold
+// primitive: the bet is visible at the commitment site, never hidden.
+//
+// WHY THIS AND NOT A GRADED METRIC AS `==` (adversarially established):
+//   • Hellinger-as-== has a δ-catastrophe: a point mass vs ANY continuous density
+//     is mutually singular → H = 1 no matter how small σ is or how close the
+//     means — so every literal-vs-measurement comparison reads "maximally
+//     unequal" AND the σ-magnitude is erased. Here instead: literal 10 vs
+//     10±0.01 at ε=0.5 → P ≈ 1 (equal); vs 10±1000 → P ≈ 0.0004. Smooth in σ,
+//     no singularity; the both-certain corner is EXACTLY boolean.
+//   • A raw [0,1]/[0,∞] return forces a hidden threshold at every `if` — the
+//     convenient default this language exists to reject. ep_decide names it.
+//
+// BOTH-CERTAIN CORNER: σ₁=σ₂=0 → P = 1 if |Δμ|<ε else 0 (exact boolean equality,
+// detected explicitly — no division, no 0/0).
+//
+// INDEPENDENCE CAVEAT (honest scope): s² = σ₁²+σ₂² assumes a and b independent.
+// Self-comparison ep_eq_prob(&x, &x, ε) computes with s²=2σ², which is WRONG for
+// the identity case (should be P=1) — value identity/correlation tracking is the
+// perturbation-graph frontier (see epistemic/perturbation_graph.sio), not solved
+// here. ε is an explicit parameter; deriving it from operand precision/units as
+// a language default is the future parser/typechecker lift.
+//
+// HELPERS are local (ueq_exp, ueq_erf): NOT imported from propagate.sio, whose
+// higher-order generic fns do not build on this base (see PR #277). The erf is a
+// 60-term Taylor series with hard clamp at |x| ≥ 4 — verified max abs error
+// 1.5e-8 on [0,4]; the clamp is essential (the series diverges catastrophically
+// past ~4.5). ep_sqrt is reused from epistemic::knowledge.
+//
+// EqField: the diagnostic windows (Hellinger overlap, W₂ closeness, z-score),
+// one artifact computed once — the associator-field pattern. Windows are for
+// MEASURING the relationship between two distributions; p_equal + ep_decide are
+// for branching. Execution-verified: all values cross-checked against two
+// independent computations (python math.erf vs compiled SOUNIO) to 1e-4.
+
+use epistemic::knowledge::{Epistemic, ep_sqrt}
+
+// ============================================================================
+// PRIVATE MATH HELPERS
+// ============================================================================
+
+fn ueq_exp_core(x: f64) -> f64 with Mut, Div, Panic {
+    var s: f64 = 1.0
+    var term: f64 = 1.0
+    var n: i64 = 1
+    while n < 30 {
+        term = term * x / (n as f64)
+        s = s + term
+        n = n + 1
+    }
+    s
+}
+
+fn ueq_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x > 10.0 {
+        return 22026.465794806718 * ueq_exp_core(x - 10.0)
+    }
+    if x < (0.0 - 10.0) {
+        return 0.00004539992976248485 * ueq_exp_core(x + 10.0)
+    }
+    ueq_exp_core(x)
+}
+
+// erf via 60-term Taylor with clamp at |x| >= 4 (series diverges beyond; the
+// clamp's own error 1−erf(4) ≈ 1.5e-8 is the scheme's max error on [0,4]).
+fn ueq_erf(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 {
+        return 0.0 - ueq_erf(0.0 - x)
+    }
+    if x >= 4.0 {
+        return 1.0
+    }
+    let two_over_sqrtpi: f64 = 1.1283791670955126
+    let x2: f64 = x * x
+    var term: f64 = x
+    var s: f64 = x
+    var n: i64 = 0
+    while n < 59 {
+        let num: f64 = (0.0 - x2) * ((2 * n + 1) as f64)
+        let den: f64 = ((n + 1) as f64) * ((2 * n + 3) as f64)
+        term = term * num / den
+        s = s + term
+        n = n + 1
+    }
+    two_over_sqrtpi * s
+}
+
+// standard normal CDF: Φ(t) = 0.5·(1 + erf(t/√2))
+fn ueq_phi(t: f64) -> f64 with Mut, Div, Panic {
+    0.5 * (1.0 + ueq_erf(t / 1.4142135623730951))
+}
+
+// ============================================================================
+// THE UNCERTAIN-BOOL EQUALITY
+// ============================================================================
+
+// P(|a − b| < ε) under independence. Both-certain corner = exact boolean.
+// Result clamped to [0,1] (absorbs erf-scheme rounding at the tails).
+pub fn ep_eq_prob(a: &Epistemic, b: &Epistemic, eps: f64) -> f64 with Mut, Div, Panic {
+    let s2: f64 = a.variance + b.variance
+    let dm: f64 = a.val - b.val
+    if s2 == 0.0 {
+        let abs_dm: f64 = if dm < 0.0 { 0.0 - dm } else { dm }
+        if abs_dm < eps { return 1.0 }
+        return 0.0
+    }
+    let s: f64 = ep_sqrt(s2)
+    let p: f64 = ueq_phi((eps - dm) / s) - ueq_phi((0.0 - eps - dm) / s)
+    if p < 0.0 { return 0.0 }
+    if p > 1.0 { return 1.0 }
+    p
+}
+
+// The named-threshold commitment primitive: branching on an uncertain equality
+// must declare its confidence — `if ep_decide(ep_eq_prob(a,b,eps), 0.95)` — so
+// the bet is visible at the commitment site instead of hidden in the operator.
+pub fn ep_decide(p: f64, confidence: f64) -> bool {
+    p >= confidence
+}
+
+// ============================================================================
+// EqField — diagnostic windows on one comparison (associator-field pattern)
+// ============================================================================
+
+// One artifact, four windows, computed once:
+//   p_equal:   P(|a−b|<ε)            — the control-flow window (via ep_decide)
+//   hellinger: H ∈ [0,1]             — distributional overlap/distinguishability
+//   w2:        √(Δμ²+(σ₁−σ₂)²) ∈ [0,∞] — transport closeness (matches
+//              graded_eq.sio's ep_distance; carries value units)
+//   z:         |Δμ|/√(σ₁²+σ₂²)      — the scientist's significance window
+//
+// Hellinger is a WINDOW, not the operator, because of its δ-pathology: a point
+// mass vs any continuous density is mutually singular → H=1 regardless of how
+// small σ is (σ-magnitude erased). Correct as a measure of distributional
+// distinguishability; catastrophic as a default `==`. Diagnostics only.
+pub struct EqField {
+    p_equal: f64,
+    hellinger: f64,
+    w2: f64,
+    z: f64,
+}
+
+pub fn ep_eq_field(a: &Epistemic, b: &Epistemic, eps: f64) -> EqField with Mut, Div, Panic {
+    let p: f64 = ep_eq_prob(a, b, eps)
+
+    let s1: f64 = ep_sqrt(a.variance)
+    let s2v: f64 = ep_sqrt(b.variance)
+    let dm: f64 = a.val - b.val
+    let abs_dm: f64 = if dm < 0.0 { 0.0 - dm } else { dm }
+    let ssum: f64 = a.variance + b.variance
+
+    // Hellinger: H² = 1 − √(2σ₁σ₂/(σ₁²+σ₂²))·exp(−Δμ²/(4(σ₁²+σ₂²)));
+    // both-certain corner (0/0 in the formula) handled as exact boolean.
+    var h: f64 = 0.0
+    if ssum == 0.0 {
+        if abs_dm > 0.000001 { h = 1.0 }
+    } else {
+        let ratio: f64 = (2.0 * s1 * s2v) / ssum
+        let exp_arg: f64 = (0.0 - dm * dm) / (4.0 * ssum)
+        let h2: f64 = 1.0 - ep_sqrt(ratio) * ueq_exp(exp_arg)
+        if h2 < 0.0 { h = 0.0 } else { h = ep_sqrt(h2) }
+    }
+
+    // W₂ closeness (2-Wasserstein for Gaussians)
+    let w2: f64 = ep_sqrt(dm * dm + (s1 - s2v) * (s1 - s2v))
+
+    // z-score; meaningless in the both-certain corner (sentinel 1e9 if different)
+    var z: f64 = 0.0
+    if ssum == 0.0 {
+        if abs_dm > 0.000001 { z = 1000000000.0 }
+    } else {
+        z = abs_dm / ep_sqrt(ssum)
+    }
+
+    EqField { p_equal: p, hellinger: h, w2: w2, z: z }
+}

--- a/tests/run-pass/uncertain_eq_bernoulli.sio
+++ b/tests/run-pass/uncertain_eq_bernoulli.sio
@@ -1,0 +1,67 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for uncertain-Bool equality (stdlib/epistemic/uncertain_eq.sio):
+// `==` on uncertain values returns the Bernoulli P(|a−b|<ε); branching commits
+// through ep_decide(p, confidence). All expected values independently verified
+// (python math.erf vs compiled SOUNIO, agree to 1e-4).
+//
+// The anti-footgun trio (P3/P4/P5) is the point: a certain literal vs a precise
+// measurement IS equal (P≈1), vs a moderate one is smoothly partial (0.197), vs
+// a wide one is honestly near-zero (0.0004) — no Hellinger δ-catastrophe, and
+// the both-certain corner is exactly boolean.
+
+use epistemic::knowledge::Epistemic
+use epistemic::uncertain_eq::{ep_eq_prob, ep_decide, EqField, ep_eq_field}
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic {
+    var ok = true
+    let c10 = Epistemic::measured(10.0, 0.0)      // certain 10 (literal)
+    let c13 = Epistemic::measured(13.0, 0.0)      // certain 13
+    let m_tight = Epistemic::measured(10.0, 0.01) // precise measurement
+    let m_mid = Epistemic::measured(10.0, 2.0)    // moderate uncertainty
+    let m_wide = Epistemic::measured(10.0, 1000.0)// wide uncertainty
+    let m5 = Epistemic::measured(10.0, 5.0)
+    let b6 = Epistemic::measured(13.0, 6.0)
+
+    // both-certain corner = exact boolean
+    if approx(ep_eq_prob(&c10, &c10, 0.5), 1.0) { print("P1 certain==certain same -> 1: PASS") }
+    else { print("P1: FAIL"); ok = false }
+    if approx(ep_eq_prob(&c10, &c13, 0.5), 0.0) { print("P2 certain==certain diff -> 0: PASS") }
+    else { print("P2: FAIL"); ok = false }
+
+    // the anti-footgun trio (the Hellinger catastrophe is gone)
+    if approx(ep_eq_prob(&c10, &m_mid, 0.5), 0.1974127) { print("P3 literal vs 10±2 -> 0.197 (smooth): PASS") }
+    else { print("P3: FAIL"); ok = false }
+    if approx(ep_eq_prob(&c10, &m_tight, 0.5), 1.0) { print("P4 literal vs 10±0.01 -> 1 (equal!): PASS") }
+    else { print("P4: FAIL"); ok = false }
+    if approx(ep_eq_prob(&c10, &m_wide, 0.5), 0.0003989) { print("P5 literal vs 10±1000 -> ~0: PASS") }
+    else { print("P5: FAIL"); ok = false }
+
+    // monotone in the declared resolution ε
+    let p7a = ep_eq_prob(&m_mid, &m5, 0.5)
+    let p7b = ep_eq_prob(&m_mid, &m5, 2.0)
+    let p7c = ep_eq_prob(&m_mid, &m5, 5.0)
+    if approx(p7a, 0.0739754) { print("P7a eps=0.5 -> 0.0740: PASS") } else { print("P7a: FAIL"); ok = false }
+    if approx(p7b, 0.2896534) { print("P7b eps=2 -> 0.2897: PASS") } else { print("P7b: FAIL"); ok = false }
+    if approx(p7c, 0.6468396) { print("P7c eps=5 -> 0.6468: PASS") } else { print("P7c: FAIL"); ok = false }
+    if p7a < p7b && p7b < p7c { print("P7 monotone in eps: PASS") } else { print("P7 monotone: FAIL"); ok = false }
+
+    // the commitment primitive: threshold named at the decision site
+    if ep_decide(0.99, 0.95) { print("decide(0.99 at 0.95) -> true: PASS") } else { print("decide-true: FAIL"); ok = false }
+    if ep_decide(0.5, 0.95) { print("decide-false: FAIL"); ok = false } else { print("decide(0.5 at 0.95) -> false: PASS") }
+
+    // EqField diagnostic windows, computed once
+    let ef = ep_eq_field(&m_mid, &b6, 0.5)
+    if approx(ef.p_equal, 0.0563211) { print("EqField p_equal=0.0563: PASS") } else { print("EqField p: FAIL"); ok = false }
+    if approx(ef.hellinger, 0.5174665) { print("EqField hellinger=0.5175: PASS") } else { print("EqField H: FAIL"); ok = false }
+    if approx(ef.w2, 5.0) { print("EqField w2=5: PASS") } else { print("EqField w2: FAIL"); ok = false }
+    if approx(ef.z, 0.4743416) { print("EqField z=0.4743: PASS") } else { print("EqField z: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}


### PR DESCRIPTION
## What

The resolution of the graded-equality dialectic (round 2, adversarially routed): `==` on uncertain values returns **neither a crisp bool** (the certainty lie) **nor a raw divergence** (which re-booleanizes via a hidden threshold at every `if`-site). It returns the **Bernoulli probability of coincidence at a declared resolution**:

```
ep_eq_prob(a, b, ε) = P(|a−b| < ε),   a−b ~ N(Δμ, σ₁²+σ₂²)   (independent)
ep_decide(p, confidence)              — branching commits HERE, threshold named
ep_eq_field(a, b, ε)                  — diagnostic windows: p_equal / hellinger / w2 / z
```

2 files, +253, pure additions. Companion to #281 (whose `ep_distance` is the W₂ *closeness* window — see relabel there).

## Why this design (what the adversarial round established)

- **Hellinger-as-`==` has a δ-catastrophe**: a point mass vs *any* continuous density is mutually singular → H=1 regardless of σ — so every literal-vs-measurement comparison reads "maximally unequal" and σ-magnitude is erased. With uncertainty-by-default, the two flagship defaults would destroy each other. Execution-verified, not rhetoric.
- **Raw graded returns re-booleanize in hiding**: `if (a==b) < τ` smuggles the convenient default back at every branch. `ep_decide` makes the bet visible at the commitment site — the same primitive the control-flow dialectic derived independently (convergence = confidence).
- **The divergences survive as windows** (associator-field pattern: one artifact, computed once): Hellinger = distinguishability diagnostics, W₂ = closeness, z = significance. Explicitly not for control flow.

The anti-footgun trio (in the test): literal `10` vs `10±0.01` at ε=0.5 → **P=1.0 (equal!)**; vs `10±2` → 0.197 (smooth); vs `10±1000` → 0.0004 (honest). Both-certain corner is *exactly* boolean — no division, no 0/0.

## Verification

- ✅ All expected values computed by **two independent paths** (python `math.erf` vs compiled SOUNIO self-contained build) — agree to 1e-4 across 10 P-cases + 3 windows; executed **ALL PASS** and **falsified live** (wrong constant → FAIL → restored).
- ✅ erf scheme validated: 60-term Taylor + hard clamp at |x|≥4, max abs error 1.5e-8 on [0,4]; clamp essential (series diverges to −2.0 by x=5).
- ✅ Parse-verified + falsified; `ep_sqrt` reuse (30-iter) execution-checked.
- ⚠️ Cross-module typecheck/run-pass need CI (single-module checker skips imports).

## Honest scope

- **Independence assumed**: self-comparison `ep_eq_prob(&x,&x,ε)` computes with s²=2σ² (wrong for identity) — value identity/correlation tracking is the perturbation-graph frontier (#273), documented in the header.
- **ε is an explicit parameter**; deriving it from operand precision/units as a language default is the future parser/typechecker lift.
- Local `exp`/`erf` helpers (no dependency on `propagate.sio`'s broken HOF generics — cf #277).

🤖 Generated with [Claude Code](https://claude.com/claude-code)