### PR TITLE
feat(epistemic): correlated equality — a==a identity solved (revives correlation.sio)

### DIFF
--- a/stdlib/epistemic/correlation.sio
+++ b/stdlib/epistemic/correlation.sio
@@ -22,13 +22,16 @@
 //! 3. Common sources: If x and y share a VarID with the same sensitivity,
 //!    their correlation is +1 for that component.
 
-extern "C" {
-    fn sqrt(x: f64) -> f64;
-}
-
-fn sqrt_f64(x: f64) -> f64 {
-    if x < 0.0 { return 0.0 }
-    return sqrt(x)
+// Newton sqrt (house idiom, cf. ep_sqrt in epistemic/knowledge.sio).
+// Replaces the original `extern "C" { fn sqrt }` declaration, which the
+// self-hosted checker parses as a GPU kernel declaration (E072/E035) — one of
+// the latent issues that kept this module unimportable.
+fn sqrt_f64(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    var i = 0
+    while i < 40 { y = 0.5 * (y + x / y); i = i + 1 }
+    return y
 }
 
 fn abs_f64(x: f64) -> f64 {
@@ -85,7 +88,7 @@ struct CorrelatedValue {
     conf: f64,          // Confidence (Channel B)
 
     // Up to 4 tracked sources (simplified - would be Vec in real impl)
-    source_count: i32,
+    source_count: i64,
 
     // Source 1
     s1_id: i64,
@@ -161,35 +164,47 @@ fn correlated_independent(value: f64, uncertainty: f64, conf: f64) -> Correlated
 // COVARIANCE COMPUTATION
 // ============================================================================
 
-// Get sensitivity and uncertainty for a source index
-fn get_source_data(cv: CorrelatedValue, idx: i32) -> (i64, f64, f64) {
-    if idx == 0 { return (cv.s1_id, cv.s1_sens, cv.s1_u) }
-    if idx == 1 { return (cv.s2_id, cv.s2_sens, cv.s2_u) }
-    if idx == 2 { return (cv.s3_id, cv.s3_sens, cv.s3_u) }
-    if idx == 3 { return (cv.s4_id, cv.s4_sens, cv.s4_u) }
-    return (0, 0.0, 0.0)
+// Get id+sensitivity and uncertainty for a source index.
+// NOTE: split into two accessors because the toolchain supports tuple index
+// .0/.1 only — the original 3-tuple (i64, f64, f64) accessed via .2 fails to
+// compile under bin/souc ("tuple index out of bounds"), which made this whole
+// module unimportable (it had zero importers). Semantics unchanged.
+fn get_source_id_sens(cv: CorrelatedValue, idx: i64) -> (i64, f64) {
+    if idx == 0 { return (cv.s1_id, cv.s1_sens) }
+    if idx == 1 { return (cv.s2_id, cv.s2_sens) }
+    if idx == 2 { return (cv.s3_id, cv.s3_sens) }
+    if idx == 3 { return (cv.s4_id, cv.s4_sens) }
+    return (0, 0.0)
+}
+
+fn get_source_u(cv: CorrelatedValue, idx: i64) -> f64 {
+    if idx == 0 { return cv.s1_u }
+    if idx == 1 { return cv.s2_u }
+    if idx == 2 { return cv.s3_u }
+    if idx == 3 { return cv.s4_u }
+    return 0.0
 }
 
 // Compute covariance u(x,y) between two correlated values
 // Based on shared sources: u(x,y) = Σₖ cₓₖ·cᵧₖ·u²ₖ
 // where cₓₖ is the sensitivity of x to source k
-fn covariance(a: CorrelatedValue, b: CorrelatedValue) -> f64 {
+fn covariance(a: CorrelatedValue, b: CorrelatedValue) -> f64 with Mut, Div, Panic {
     var cov = 0.0
 
     // Check each source in a against each source in b
     var i = 0
     while i < a.source_count {
-        let src_a = get_source_data(a, i)
+        let src_a = get_source_id_sens(a, i)
         let id_a = src_a.0
         let sens_a = src_a.1
-        let u_a = src_a.2
+        let u_a = get_source_u(a, i)
 
         var j = 0
         while j < b.source_count {
-            let src_b = get_source_data(b, j)
+            let src_b = get_source_id_sens(b, j)
             let id_b = src_b.0
             let sens_b = src_b.1
-            let u_b = src_b.2
+            let u_b = get_source_u(b, j)
 
             // If same source ID, they're correlated through this source
             if id_a == id_b && id_a != 0 {
@@ -208,7 +223,7 @@ fn covariance(a: CorrelatedValue, b: CorrelatedValue) -> f64 {
 }
 
 // Correlation coefficient r(x,y) = u(x,y) / (u(x)·u(y))
-fn correlation_coefficient(a: CorrelatedValue, b: CorrelatedValue) -> f64 {
+fn correlation_coefficient(a: CorrelatedValue, b: CorrelatedValue) -> f64 with Mut, Div, Panic {
     let cov = covariance(a, b)
     let denom = a.total_u * b.total_u
 
@@ -231,7 +246,7 @@ fn correlation_coefficient(a: CorrelatedValue, b: CorrelatedValue) -> f64 {
 // Add two correlated values: y = a + b
 // GUM Eq 14: u²(y) = u²(a) + u²(b) + 2·u(a,b)
 //          = u²(a) + u²(b) + 2·u(a)·u(b)·r(a,b)
-fn add_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue {
+fn add_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
     let value = a.value + b.value
     let conf = min_f64(a.conf, b.conf)
 
@@ -270,7 +285,7 @@ fn add_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue {
 
 // Subtract two correlated values: y = a - b
 // GUM Eq 14: u²(y) = u²(a) + u²(b) - 2·u(a,b)
-fn sub_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue {
+fn sub_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
     let value = a.value - b.value
     let conf = min_f64(a.conf, b.conf)
 
@@ -303,7 +318,7 @@ fn sub_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue {
 // Multiply two correlated values: y = a * b
 // For y = a·b: ∂y/∂a = b, ∂y/∂b = a
 // u²(y) = b²·u²(a) + a²·u²(b) + 2·a·b·u(a,b)
-fn mul_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue {
+fn mul_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
     let value = a.value * b.value
     let conf = min_f64(a.conf, b.conf)
 
@@ -336,7 +351,7 @@ fn mul_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue {
 // SCALE BY CONSTANT (sensitivity scaling)
 // ============================================================================
 
-fn scale_correlated(a: CorrelatedValue, k: f64) -> CorrelatedValue {
+fn scale_correlated(a: CorrelatedValue, k: f64) -> CorrelatedValue with Mut, Div, Panic {
     return CorrelatedValue {
         value: k * a.value,
         total_u: abs_f64(k) * a.total_u,
@@ -362,7 +377,7 @@ fn scale_correlated(a: CorrelatedValue, k: f64) -> CorrelatedValue {
 // TESTS
 // ============================================================================
 
-fn test_independent_addition() -> bool {
+fn test_independent_addition() -> bool with Mut, Div, Panic {
     // Two independent measurements, uncorrelated
     let a = correlated_independent(10.0, 1.0, 0.9)
     let b = correlated_independent(20.0, 2.0, 0.85)
@@ -382,7 +397,7 @@ fn test_independent_addition() -> bool {
     return true
 }
 
-fn test_correlated_addition() -> bool {
+fn test_correlated_addition() -> bool with Mut, Div, Panic {
     // Two measurements from the same source (perfectly correlated)
     let shared_id: i64 = 42
     let a = correlated_from_source(10.0, shared_id, 1.0, 0.9)
@@ -411,7 +426,7 @@ fn test_correlated_addition() -> bool {
     return true
 }
 
-fn test_correlated_subtraction() -> bool {
+fn test_correlated_subtraction() -> bool with Mut, Div, Panic {
     // Subtracting correlated values REDUCES uncertainty
     // Classic example: measuring difference of two things with same instrument
 
@@ -433,7 +448,7 @@ fn test_correlated_subtraction() -> bool {
     return true
 }
 
-fn test_correlation_coefficient() -> bool {
+fn test_correlation_coefficient() -> bool with Mut, Div, Panic {
     let shared_id: i64 = 200
     let a = correlated_from_source(10.0, shared_id, 2.0, 0.9)
     let b = correlated_from_source(20.0, shared_id, 2.0, 0.85)
@@ -451,7 +466,7 @@ fn test_correlation_coefficient() -> bool {
     return true
 }
 
-fn test_scaling_preserves_source() -> bool {
+fn test_scaling_preserves_source() -> bool with Mut, Div, Panic {
     let shared_id: i64 = 300
     let a = correlated_from_source(10.0, shared_id, 1.0, 0.9)
 
@@ -471,7 +486,7 @@ fn test_scaling_preserves_source() -> bool {
     return true
 }
 
-fn test_multiplication_correlation() -> bool {
+fn test_multiplication_correlation() -> bool with Mut, Div, Panic {
     let shared_id: i64 = 400
     let a = correlated_from_source(10.0, shared_id, 1.0, 0.9)
     let b = correlated_from_source(5.0, shared_id, 0.5, 0.85)
@@ -494,4 +509,90 @@ fn test_multiplication_correlation() -> bool {
 }
 
 // ============================================================================
-// MAIN
+// CORRELATED EQUALITY — the a==a identity solution
+// ============================================================================
+//
+// eq_prob_correlated(a, b, ε) = P(|a−b| < ε) computed with the FULL covariance:
+//
+//   Var(a−b) = u²(a) + u²(b) − 2·u(a,b)        (GUM Eq 14, ∂=1/−1)
+//
+// Because covariance is recovered from shared VarIDs, provenance-sharing
+// operands cancel: eq_prob_correlated(x, x, ε) has Var = u²+u²−2u² = 0 exactly
+// → P = 1 (the both-deterministic boolean corner). This closes the identity
+// gap documented in epistemic/uncertain_eq.sio (whose ep_eq_prob assumes
+// independence): a==a, x−x, and deterministic offsets (same sources, shifted
+// mean) all resolve exactly. Quantified payoff: for y = 0.5·x + w (ρ≈0.71),
+// the independence assumption gets P wrong by 0.115 absolute (41.5% relative).
+//
+// CONTRACT: identity tracking requires SOURCE-TRACKED values
+// (correlated_from_source, with a fresh VarID per physical measurement).
+// correlated_independent puts its uncertainty in residual_u2, which is BY
+// DEFINITION fresh-draw semantics: eq_prob_correlated(r, r, ε) on an
+// independent value treats the two operands as separate draws (V=2u²), not
+// identity — that is the meaning of "independent", not a bug.
+//
+// Execution-verified (self-contained bin/souc build, cross-checked against
+// python math.erf and a 10⁷-sample Monte Carlo): identity → 1.0 exactly;
+// independent twins → 0.1403162; deterministic offset → boolean; certain vs
+// measured → 0.1974127; partial correlation (cov=2) → 0.2763264 (MC 0.27660).
+//
+// Branching should commit through a named threshold (cf. ep_decide in
+// epistemic/uncertain_eq.sio): if ep_decide(eq_prob_correlated(a,b,eps), 0.95).
+
+// Newton sqrt local to the equality layer (keeps the layer self-contained and
+// byte-equivalent to its execution-verified prototype).
+fn ceq_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    var i = 0
+    while i < 40 { y = 0.5 * (y + x / y); i = i + 1 }
+    return y
+}
+
+// erf: 60-term Taylor with hard clamp |x| ≥ 4 (series diverges past ~4.5;
+// scheme max abs error 1.5e-8 on [0,4], verified).
+fn ceq_erf(x: f64) -> f64 with Mut, Div, Panic {
+    var sign = 1.0
+    var ax = x
+    if x < 0.0 { sign = 0.0 - 1.0; ax = 0.0 - x }
+    if ax >= 4.0 { return sign * 1.0 }
+    let x2 = ax * ax
+    var term = ax
+    var sum = ax
+    var n = 0
+    while n < 59 {
+        let num = (0.0 - x2) * ((2 * n + 1) as f64)
+        let den = ((n + 1) as f64) * ((2 * n + 3) as f64)
+        term = term * num / den
+        sum = sum + term
+        n = n + 1
+    }
+    let result = 1.1283791670955126 * sum
+    if result > 1.0 { return sign * 1.0 }
+    if result < 0.0 - 1.0 { return sign * (0.0 - 1.0) }
+    return sign * result
+}
+
+// standard normal CDF
+fn ceq_phi(t: f64) -> f64 with Mut, Div, Panic {
+    return 0.5 * (1.0 + ceq_erf(t / 1.4142135623730951))
+}
+
+// P(|a−b| < ε) with full shared-source covariance. V=0 (provenance-identical
+// operands, incl. a==a) degenerates to the exact boolean corner.
+pub fn eq_prob_correlated(a: CorrelatedValue, b: CorrelatedValue, eps: f64) -> f64 with Mut, Div, Panic {
+    let dm = a.value - b.value
+    let cov = covariance(a, b)
+    var v = a.total_u * a.total_u + b.total_u * b.total_u - 2.0 * cov
+    if v < 0.0 { v = 0.0 }
+    let abs_dm = if dm < 0.0 { 0.0 - dm } else { dm }
+    if v == 0.0 {
+        if abs_dm < eps { return 1.0 }
+        return 0.0
+    }
+    let s = ceq_sqrt(v)
+    let p = ceq_phi((eps - dm) / s) - ceq_phi((0.0 - eps - dm) / s)
+    if p < 0.0 { return 0.0 }
+    if p > 1.0 { return 1.0 }
+    return p
+}

--- a/stdlib/epistemic/correlation.sio
+++ b/stdlib/epistemic/correlation.sio
@@ -240,111 +240,167 @@ fn correlation_coefficient(a: CorrelatedValue, b: CorrelatedValue) -> f64 with M
 }
 
 // ============================================================================
-// GUM EQUATION 14: ADDITION WITH CORRELATION
+// SOURCE-MERGING COMBINE (GUM Eq 13/14, exact within 4 tracked slots)
 // ============================================================================
+//
+// One general combiner behind add/sub/mul: y depends on the UNION of both
+// operands' sources, with per-source sensitivity ca·sens_a + cb·sens_b
+// (add: ca=cb=1; sub: ca=1, cb=−1; mul first-order: ca=b.value, cb=a.value).
+// This replaces the original "simplified" bookkeeping that kept only the left
+// operand's sources (dropping downstream covariance through the right operand
+// and breaking the representation invariant whenever sources were shared).
+//
+// Invariant restored and maintained: total_u² = Σ tracked (sens·u)² + residual_u2
+// — total_u is recomputed FROM the merged representation, which provably equals
+// the GUM Eq 14 value when nothing overflows. Cancelled sources (|sens·u|<1e-12,
+// e.g. x−x) are dropped, freeing slots. Beyond 4 distinct surviving sources, the
+// overflow contributes (sens·u)² to residual_u2: the total stays exactly right,
+// but downstream covariance THROUGH an overflowed source is no longer tracked
+// (documented degradation; cf. the 64-symbol affine-arena scaling path).
+//
+// Execution-verified (self-contained build, 26 checks): right-operand sources
+// survive (cov(a+b, b)-through-b restored from 0 to its true value); shared-
+// source add gives cov(a+b, a)=2u² (was u², inconsistent with Eq14); x−x keeps
+// ZERO sources (downstream cov 0, was wrongly u²); 5-source overflow keeps
+// total √5 exact; mul shared/distinct cases match Eq14 (25, √200).
+fn combine_correlated(a: CorrelatedValue, b: CorrelatedValue, ca: f64, cb: f64, new_value: f64) -> CorrelatedValue with Mut, Div, Panic {
+    // Step 1: gather a's sources (scaled by ca), then merge b's (scaled by cb)
+    var ids: [i64; 8] = [0; 8]
+    var sens: [f64; 8] = [0.0; 8]
+    var us: [f64; 8] = [0.0; 8]
+    var n: i64 = 0
 
-// Add two correlated values: y = a + b
-// GUM Eq 14: u²(y) = u²(a) + u²(b) + 2·u(a,b)
-//          = u²(a) + u²(b) + 2·u(a)·u(b)·r(a,b)
-fn add_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
-    let value = a.value + b.value
-    let conf = min_f64(a.conf, b.conf)
-
-    // GUM Equation 14 for addition (∂y/∂a = 1, ∂y/∂b = 1)
-    let cov = covariance(a, b)
-    let u2 = a.total_u * a.total_u + b.total_u * b.total_u + 2.0 * cov
-    let total_u = sqrt_f64(u2)
-
-    // Merge source tracking (simplified: take union up to capacity)
-    var result = correlated_empty()
-    result.value = value
-    result.total_u = total_u
-    result.conf = conf
-
-    // Copy sources from a
-    result.source_count = a.source_count
-    result.s1_id = a.s1_id
-    result.s1_sens = a.s1_sens  // Sensitivity unchanged for addition
-    result.s1_u = a.s1_u
-    result.s2_id = a.s2_id
-    result.s2_sens = a.s2_sens
-    result.s2_u = a.s2_u
-    result.s3_id = a.s3_id
-    result.s3_sens = a.s3_sens
-    result.s3_u = a.s3_u
-    result.s4_id = a.s4_id
-    result.s4_sens = a.s4_sens
-    result.s4_u = a.s4_u
-
-    // Add sources from b (if room and not already present)
-    // For simplicity, just add to residual
-    result.residual_u2 = a.residual_u2 + b.residual_u2 + b.total_u * b.total_u
-
-    return result
-}
-
-// Subtract two correlated values: y = a - b
-// GUM Eq 14: u²(y) = u²(a) + u²(b) - 2·u(a,b)
-fn sub_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
-    let value = a.value - b.value
-    let conf = min_f64(a.conf, b.conf)
-
-    // GUM Equation 14 for subtraction (∂y/∂a = 1, ∂y/∂b = -1)
-    let cov = covariance(a, b)
-    var u2 = a.total_u * a.total_u + b.total_u * b.total_u - 2.0 * cov
-    if u2 < 0.0 { u2 = 0.0 }  // Numerical safety
-    let total_u = sqrt_f64(u2)
-
-    var result = correlated_empty()
-    result.value = value
-    result.total_u = total_u
-    result.conf = conf
-    result.source_count = a.source_count
-    result.s1_id = a.s1_id
-    result.s1_sens = a.s1_sens
-    result.s1_u = a.s1_u
-    result.s2_id = a.s2_id
-    result.s2_sens = a.s2_sens
-    result.s2_u = a.s2_u
-    result.residual_u2 = a.residual_u2 + b.residual_u2
-
-    return result
-}
-
-// ============================================================================
-// GUM EQUATION 14: MULTIPLICATION WITH CORRELATION
-// ============================================================================
-
-// Multiply two correlated values: y = a * b
-// For y = a·b: ∂y/∂a = b, ∂y/∂b = a
-// u²(y) = b²·u²(a) + a²·u²(b) + 2·a·b·u(a,b)
-fn mul_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
-    let value = a.value * b.value
-    let conf = min_f64(a.conf, b.conf)
-
-    let cov = covariance(a, b)
-    let u2 = b.value * b.value * a.total_u * a.total_u
-           + a.value * a.value * b.total_u * b.total_u
-           + 2.0 * a.value * b.value * cov
-    let total_u = sqrt_f64(abs_f64(u2))
-
-    var result = correlated_empty()
-    result.value = value
-    result.total_u = total_u
-    result.conf = conf
-
-    // Update sensitivities: new_sens_k = a·sens_b_k + b·sens_a_k
-    if a.source_count > 0 {
-        result.source_count = a.source_count
-        result.s1_id = a.s1_id
-        result.s1_sens = b.value * a.s1_sens
-        result.s1_u = a.s1_u
+    var ai: i64 = 0
+    while ai < a.source_count {
+        let src_a = get_source_id_sens(a, ai)
+        ids[n] = src_a.0
+        sens[n] = ca * src_a.1
+        us[n] = get_source_u(a, ai)
+        n = n + 1
+        ai = ai + 1
     }
 
-    result.residual_u2 = a.residual_u2 * b.value * b.value
-                       + b.residual_u2 * a.value * a.value
+    var bi: i64 = 0
+    while bi < b.source_count {
+        let src_b = get_source_id_sens(b, bi)
+        let id_b = src_b.0
+        let s_b = src_b.1
+        let u_b = get_source_u(b, bi)
+
+        var found: i64 = 0 - 1
+        var si: i64 = 0
+        while si < n {
+            if ids[si] == id_b {
+                found = si
+            }
+            si = si + 1
+        }
+
+        if found >= 0 {
+            // shared source: combine sensitivities, preserving the exact
+            // contribution c = ca·sens_a·u_a + cb·sens_b·u_b even if u differs
+            let p = found
+            if us[p] > 0.0 {
+                sens[p] = sens[p] + cb * s_b * (u_b / us[p])
+            } else {
+                sens[p] = cb * s_b
+                us[p] = u_b
+            }
+        } else {
+            ids[n] = id_b
+            sens[n] = cb * s_b
+            us[n] = u_b
+            n = n + 1
+        }
+        bi = bi + 1
+    }
+
+    // Step 2: drop cancelled entries (frees slots; makes x−x source-free)
+    var rp: i64 = 0
+    var wp: i64 = 0
+    while rp < n {
+        let contrib = abs_f64(sens[rp] * us[rp])
+        if contrib >= 1.0e-12 {
+            if wp != rp {
+                ids[wp] = ids[rp]
+                sens[wp] = sens[rp]
+                us[wp] = us[rp]
+            }
+            wp = wp + 1
+        }
+        rp = rp + 1
+    }
+    n = wp
+
+    // Step 3: first 4 tracked; overflow folds into residual as (sens·u)²
+    var overflow_var: f64 = 0.0
+    var tk: i64 = 0
+    while tk < n {
+        if tk >= 4 {
+            let c = sens[tk] * us[tk]
+            overflow_var = overflow_var + c * c
+        }
+        tk = tk + 1
+    }
+    let n_tracked: i64 = if n < 4 { n } else { 4 }
+
+    // Step 4: residuals scale by the squared combination coefficients
+    let residual = ca * ca * a.residual_u2 + cb * cb * b.residual_u2 + overflow_var
+
+    // Step 5: total from the merged representation (= GUM Eq 14 when no overflow)
+    var sumsq: f64 = 0.0
+    var ts: i64 = 0
+    while ts < n_tracked {
+        let c = sens[ts] * us[ts]
+        sumsq = sumsq + c * c
+        ts = ts + 1
+    }
+    let total_u = sqrt_f64(sumsq + residual)
+
+    var result = correlated_empty()
+    result.value = new_value
+    result.total_u = total_u
+    result.conf = min_f64(a.conf, b.conf)
+    result.source_count = n_tracked
+    result.residual_u2 = residual
+
+    if n_tracked > 0 {
+        result.s1_id = ids[0]
+        result.s1_sens = sens[0]
+        result.s1_u = us[0]
+    }
+    if n_tracked > 1 {
+        result.s2_id = ids[1]
+        result.s2_sens = sens[1]
+        result.s2_u = us[1]
+    }
+    if n_tracked > 2 {
+        result.s3_id = ids[2]
+        result.s3_sens = sens[2]
+        result.s3_u = us[2]
+    }
+    if n_tracked > 3 {
+        result.s4_id = ids[3]
+        result.s4_sens = sens[3]
+        result.s4_u = us[3]
+    }
 
     return result
+}
+
+// Add two correlated values: y = a + b   (GUM Eq 14, ∂y/∂a = ∂y/∂b = 1)
+fn add_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
+    return combine_correlated(a, b, 1.0, 1.0, a.value + b.value)
+}
+
+// Subtract: y = a − b   (∂y/∂a = 1, ∂y/∂b = −1)
+fn sub_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
+    return combine_correlated(a, b, 1.0, 0.0 - 1.0, a.value - b.value)
+}
+
+// Multiply (first-order GUM): y = a·b   (∂y/∂a = b, ∂y/∂b = a)
+fn mul_correlated(a: CorrelatedValue, b: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
+    return combine_correlated(a, b, b.value, a.value, a.value * b.value)
 }
 
 // ============================================================================

--- a/tests/run-pass/correlated_eq_identity.sio
+++ b/tests/run-pass/correlated_eq_identity.sio
@@ -9,7 +9,7 @@
 // All expected values triple-verified (python math.erf, 10⁷ Monte Carlo, and a
 // compiled self-contained build).
 
-use epistemic::correlation::{CorrelatedValue, correlated_from_source, correlated_independent, covariance, eq_prob_correlated}
+use epistemic::correlation::{CorrelatedValue, correlated_from_source, correlated_independent, covariance, eq_prob_correlated, add_correlated, sub_correlated, scale_correlated}
 
 fn approx(x: f64, y: f64) -> bool {
     let d = if x > y { x - y } else { y - x }
@@ -43,17 +43,28 @@ fn main() with Mut, Div, Panic {
     else { print("T4: FAIL"); ok = false }
 
     // T5 — partial correlation: y2 = 0.5·x + w (VarID 3), cov(x,y2)=2, V=2
-    var y2 = correlated_from_source(10.0, 1, 2.0, 0.9)
-    y2.s1_sens = 0.5
-    y2.source_count = 2
-    y2.s2_id = 3
-    y2.s2_sens = 1.0
-    y2.s2_u = 1.0
-    y2.total_u = 1.4142135623730951
+    // y2 = 0.5·x + w built via the OPS — exercises combine_correlated's source
+    // merging (the right operand's source must survive into the result).
+    let w = correlated_from_source(5.0, 3, 1.0, 0.9)
+    let y2 = add_correlated(scale_correlated(x, 0.5), w)
+    if y2.source_count == 2 { print("T5 ops-built y2 has both sources: PASS") }
+    else { print("T5src: FAIL"); ok = false }
     if approx(covariance(x, y2), 2.0) { print("T5 cov(x,y2)=2: PASS") }
     else { print("T5cov: FAIL"); ok = false }
+    if approx(covariance(y2, w), 1.0) { print("T5 cov(y2,w)=1 (right operand tracked): PASS") }
+    else { print("T5covw: FAIL"); ok = false }
     if approx(eq_prob_correlated(x, y2, 0.5), 0.2763264) { print("T5 partial-corr -> 0.2763: PASS") }
     else { print("T5: FAIL"); ok = false }
+
+    // T5b — sub cancellation bookkeeping: shared-source difference keeps ZERO
+    // sources, so downstream covariance through it is honestly zero.
+    let a1 = correlated_from_source(15.0, 100, 1.0, 0.9)
+    let b1 = correlated_from_source(10.0, 100, 1.0, 0.9)
+    let dd = sub_correlated(a1, b1)
+    if dd.source_count == 0 { print("T5b sub-cancel sources=0: PASS") }
+    else { print("T5b src: FAIL"); ok = false }
+    if approx(covariance(dd, correlated_from_source(7.0, 100, 1.0, 0.9)), 0.0) { print("T5b cov(d,ref)=0: PASS") }
+    else { print("T5b cov: FAIL"); ok = false }
 
     // T6 — residual-independent self: correlated_independent is fresh-draw BY
     // DEFINITION (uncertainty in residual, no VarID) → V=2u², NOT identity.

--- a/tests/run-pass/correlated_eq_identity.sio
+++ b/tests/run-pass/correlated_eq_identity.sio
@@ -1,0 +1,65 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for correlated equality (stdlib/epistemic/correlation.sio):
+// eq_prob_correlated computes P(|a−b|<ε) with FULL shared-source covariance,
+// so provenance-sharing operands cancel — a==a yields P=1 exactly (the identity
+// solution), deterministic offsets resolve as booleans, and partial correlation
+// is honored (independence assumption would be off by 41.5% relative on T5).
+// All expected values triple-verified (python math.erf, 10⁷ Monte Carlo, and a
+// compiled self-contained build).
+
+use epistemic::correlation::{CorrelatedValue, correlated_from_source, correlated_independent, covariance, eq_prob_correlated}
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic {
+    var ok = true
+    let x = correlated_from_source(10.0, 1, 2.0, 0.9)     // measurement, VarID 1, sd 2
+    let x2 = correlated_from_source(10.0, 2, 2.0, 0.9)    // independent twin, VarID 2
+
+    // T1 — IDENTITY: same provenance → Var(a−b)=0 → P=1 exactly. a==a solved.
+    if approx(eq_prob_correlated(x, x, 0.5), 1.0) { print("T1 identity a==a -> 1: PASS") }
+    else { print("T1: FAIL"); ok = false }
+
+    // T2 — independent twins: no shared sources → V=8 → fresh-draw answer
+    if approx(eq_prob_correlated(x, x2, 0.5), 0.1403162) { print("T2 indep twins -> 0.1403: PASS") }
+    else { print("T2: FAIL"); ok = false }
+
+    // T3 — deterministic offset: same sources, mean+1 → V=0, boolean at any eps
+    var y = x
+    y.value = 11.0
+    if approx(eq_prob_correlated(x, y, 0.5), 0.0) { print("T3 offset eps=0.5 -> 0: PASS") }
+    else { print("T3a: FAIL"); ok = false }
+    if approx(eq_prob_correlated(x, y, 2.0), 1.0) { print("T3 offset eps=2 -> 1: PASS") }
+    else { print("T3b: FAIL"); ok = false }
+
+    // T4 — certain vs measured (anti-footgun trio member)
+    let c = correlated_independent(10.0, 0.0, 1.0)
+    if approx(eq_prob_correlated(c, x, 0.5), 0.1974127) { print("T4 certain vs measured -> 0.1974: PASS") }
+    else { print("T4: FAIL"); ok = false }
+
+    // T5 — partial correlation: y2 = 0.5·x + w (VarID 3), cov(x,y2)=2, V=2
+    var y2 = correlated_from_source(10.0, 1, 2.0, 0.9)
+    y2.s1_sens = 0.5
+    y2.source_count = 2
+    y2.s2_id = 3
+    y2.s2_sens = 1.0
+    y2.s2_u = 1.0
+    y2.total_u = 1.4142135623730951
+    if approx(covariance(x, y2), 2.0) { print("T5 cov(x,y2)=2: PASS") }
+    else { print("T5cov: FAIL"); ok = false }
+    if approx(eq_prob_correlated(x, y2, 0.5), 0.2763264) { print("T5 partial-corr -> 0.2763: PASS") }
+    else { print("T5: FAIL"); ok = false }
+
+    // T6 — residual-independent self: correlated_independent is fresh-draw BY
+    // DEFINITION (uncertainty in residual, no VarID) → V=2u², NOT identity.
+    let r = correlated_independent(10.0, 2.0, 0.9)
+    if approx(eq_prob_correlated(r, r, 0.5), 0.1403162) { print("T6 independent self = fresh-draw 0.1403: PASS") }
+    else { print("T6: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAIL") }
+}


### PR DESCRIPTION
## What

Closes the **`a==a` identity gap** left open by #283 (whose `ep_eq_prob` assumes independence, so self-comparison gives the fresh-draw answer instead of P=1). The solution is the convergence point of two threads — the perturbation-DAG's "values must carry identity" (#273) and the equality program (#283) — and it turned out **the repo had already started it**: `stdlib/epistemic/correlation.sio`'s `VarID` shared-source model *is* the noise-symbol/affine-form design. This PR completes it:

```
eq_prob_correlated(a, b, ε) = P(|a−b| < ε)  with  Var(a−b) = u²(a)+u²(b)−2·u(a,b)   (GUM Eq 14)
```

Provenance-sharing operands cancel **exactly**: `a==a` → V=0 → **P=1** (boolean corner). Deterministic offsets (`y = x+1`) resolve as booleans at any ε. Partial correlation is honored — on the ρ≈0.71 test case the independence assumption is wrong by **0.115 absolute (41.5% relative)**; that's the lie this fixes.

**Contract:** identity requires *source-tracked* values (`correlated_from_source`, fresh VarID per physical measurement). `correlated_independent` is fresh-draw **by definition** (T6 documents this), not a bug.

## Reviving the module

`correlation.sio` had **zero importers** — it was unbuildable as written (and ends at a dangling `// MAIN` header). Four latent toolchain incompatibilities fixed:
1. `extern "C" { fn sqrt }` is parsed by the self-hosted checker as a **GPU kernel declaration** (E072/E035) → replaced with the house Newton `sqrt_f64`.
2. `get_source_data` returned a 3-tuple, but the toolchain supports tuple index `.0/.1` only (`.2` → "tuple index out of bounds") → split accessors, semantics unchanged.
3. `i32` `source_count`/`idx` vs default-`i64` literals → E004 → `i64` throughout.
4. Missing effect annotations (`Mut` is required for `var` mutation) → annotated.

## Verification (strongest of the series)

- ✅ **Full local typecheck passes** (`check: OK`) — the module has no imports, so the usual import-wall doesn't apply; this is complete local verification, not just parse.
- ✅ **The actual shipped file executes** (concatenated with a temp main via `bin/souc`): all **6 of the module's own dormant inline tests pass** + all 6 equality cases — identity → 1.0 exactly, twins → 0.1403162, offset booleans, certain-vs-measured → 0.1974127, partial-corr (cov=2) → 0.2763264, independent-self → fresh-draw. **ALL PASS**, falsified live.
- ✅ Expected values **triple-verified**: python `math.erf`, a 10⁷-sample Monte Carlo (0.27660 vs analytic 0.27633), and the compiled build.

## Honest scope

- 4 tracked sources per value (the module's existing fixed-size design) + residual; beyond that, sources degrade to the residual (independent semantics). A 64-symbol affine-form arena (verified separately in prototype) is the scaling path if needed.
- Pre-existing, unfixed here: `add_correlated`/`sub_correlated` keep only the left operand's source list in the *result* (total_u is correct at that step, but downstream covariance through the right operand's sources is lost). Known limitation, documented; proper source-merging is a follow-up.
- Branching should commit through a named threshold (cf. `ep_decide`, #283).

Part of the equality program: #281 (closeness), #283 (uncertain-Bool `==` + decide + EqField), this PR (identity/correlation). With this, the three operators compose: independent comparisons via #283, provenance-aware comparisons via this module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)