### PR TITLE
feat(epistemic): affine arithmetic over non-associative algebra — correlation-honest substrate

### DIFF
--- a/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
+++ b/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
@@ -1,0 +1,79 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13
+-->
+
+# Affine arithmetic over a non-associative algebra: non-associativity as a noise symbol
+
+Status: **frontier opened — core mechanism designed, N=3 case proven (paper + execution), novelty boundary established against prior art.**
+Branch: `feat/affine-nonassoc-uncertainty`. Demonstrator: `examples/epistemic/affine_nonassoc_demo.sio` (self-contained, builds + runs, all claims green 2026-06-13).
+
+## The frontier target
+
+The reject-defaults map named the next default to reject: **"independence is a lie" generalized from the perturbation-DAG to every `+` and `*`.** The existing uncertainty substrate already folds non-associativity into a *scalar* variance budget — `UncertainOct.mul3` and `PerturbGraph.pg_mul` add `κ·‖[a,b,c]‖²`. But both assume **leaf independence**: `pg_mul` combines operands as `‖j‖²·Var(i) + ‖i‖²·Var(j)`, with no representation of shared error sources. That independence assumption is exactly the default to reject.
+
+**Affine arithmetic (AA)** is the correct substrate for that rejection. A value is
+```
+x = x0 + Σ_k  d_k · ε_k
+```
+where `ε_k ∈ [−1,1]` are shared scalar noise symbols and the coefficients `x0, d_k` are octonion-valued (`[f64;8]`). Two values that share a symbol are *correlated through it*; a symbol with equal-and-opposite coefficients cancels exactly. Correlation is structural, not a separate covariance matrix. The one budget is `Var(x) = Σ_k ‖d_k‖²`.
+
+## The crux that forks the design (resolved)
+
+The naive pitch — "a non-associative product injects one scalar structural symbol `κ‖[a,b,c]‖²`" — is **false**, and the falsity is the whole point. Take `a = a0 + a1·ε`, `b = b0`, `c = c0` (b, c exact):
+
+| association | ε-coefficient |
+|---|---|
+| `(a·b)·c` | `(a1·b0)·c0` |
+| `a·(b·c)` | `a1·(b0·c0)` |
+| **difference** | **`[a1, b0, c0]`** (the associator) |
+
+Non-associativity perturbs **every shared symbol's coefficient**, and the perturbation stays *correlated* with whatever owns that symbol. The order-ambiguity does not live in a separate independent scalar add-on — it is distributed across the symbol row. The scalar `κ‖[a,b,c]‖²` model is a lossy projection of this onto an independent budget.
+
+This forked two designs:
+- **Path 1 (leaf-correlation only):** shared symbols at leaves for additive correlation; keep the norm-rule + scalar structural term for products. Correct and shippable, but this is *textbook AA applied* — not frontier.
+- **Path 2 (octonion-coefficient affine forms propagated through products):** confronts the per-symbol associator spread. **This is the research and the novelty.** N=3 is closed and buildable (matches the already-proven "DAG order-safe IFF N≤3"); N≥4 needs the associahedron machinery (`pentagon_variance`, commit `73fa72b91`) because there the spread is over 5 associations (Catalan C₃).
+
+We are on **Path 2**.
+
+## Verified result (N=3)
+
+`examples/epistemic/affine_nonassoc_demo.sio` implements octonion-coefficient affine forms with a first-order product rule `∂/∂ε_k = a0·d_k(b) + d_k(a)·b0` (octonion order preserved, hence non-associativity preserved). It asserts three claims numerically and **runs green**:
+
+1. **Exact conditioning = zero covariance.** `x − x` → affine `Var = 0`; the independence-assuming scalar model is forced to report `2·Var(x) = 0.08`. (Realizes the exact-conditioning/zero-covariance lead, arXiv:2312.17141, as the canonical AA cancellation.)
+2. **Correlation honesty.** `Var(x+y)` = `4‖d‖²` when `x,y` share a symbol vs `2‖d‖²` when independent — tracked, not assumed.
+3. **Non-associativity is a noise-symbol perturbation.** For `[e1,e2,e4]` (non-Fano, `‖associator‖² = 4`), the ε-coefficient spread between `((ab)c)` and `(a(bc))` equals `[a1,b0,c0]` to machine zero. The order-ambiguity rides the *same symbol* as `a`'s input uncertainty.
+
+The N=3 hand-calc is therefore proven both on paper and by execution.
+
+## Novelty boundary (honest — do not round up)
+
+A focused prior-art sweep (9 queries) places the boundary precisely:
+- **Fusing roundoff + epistemic/input uncertainty in one affine form is textbook** — Stolfi & de Figueiredo. The fresh-symbol-per-nonlinear-op *is* the roundoff term. Not novel.
+- **"Associator as uncertainty" exists as a concept** in non-associative quantum mechanics (arXiv:1411.3710; PRL 121.201602) — but as a *bound on simultaneous measurability of observables*, not a propagated variance carried inside a value representation. Adjacent, different direction.
+- **No prior art** for: AA operating *over a non-associative algebra*, with the associator `[a,b,c]` injected as a *first-class affine noise symbol* so product order-ambiguity becomes propagated variance, fused with roundoff and epistemic symbols — nor for the **PL/type-system framing** of it. The closest computational analog (ZC502 Isaac-Sim physical-consistency plugin, Feb 2026) independently mechanizes the octonion associator as a numerical-drift diagnostic but makes the *opposite* modeling choice (structural signal, explicitly *not* noise, no AA).
+
+**The novel residue is the narrow fused mechanization + its language framing, not any single ingredient.** Claims must be scoped to that.
+
+### Key references
+- Stolfi & de Figueiredo, *Affine Arithmetic: Concepts and Applications* — roundoff + input uncertainty fused via shared noise symbols.
+- arXiv:1411.3710 / PRL 121.201602 — associator bounds an uncertainty (concept-level prior art, different sense).
+- ZC502, *Isaac-Sim Physical-consistency plugin* v0.4.2 (2026) — associator as drift diagnostic, opposite choice, no AA.
+- Goubault & Putot, perturbed affine arithmetic / zonotopes (arXiv:0807.2961) — AA-as-error-tracking over ℝ (associative), the machinery this extends.
+
+## Roadmap
+
+1. **[done]** Self-contained N=3 demonstrator, runs green.
+2. **[done]** `stdlib/epistemic/affine_octonion.sio` — correlation-honest affine octonion VALUE type (`AffOct`): first-order symbol tracking + lumped-independent `rough` bucket for the 2nd-order remainder. All construction via exported functions (no cross-module struct literal). Verified self-contained: exact conditioning `Var(x−x)=0`, correlation `0.16` vs `0.08`, product first-order `0.09` + rough `0.0009`. Importing run-pass test added for CI.
+3. **[done]** `PerturbGraph` upgraded to correlation-honest — scalar `pvar[n]` replaced by a per-node affine symbol row `psym[n][k]`; structural associator kept as a separate independent scalar `pstruct[n]`. Because octonions are a composition algebra, the first-order product rule **exactly reproduces** the old `nj·Var(i)+ni·Var(j)` on disjoint symbols, so the prior behavior is the disjoint-symbol special case — verified self-contained: order-safe `left==right==4.75`, Fano `0.75` UNCHANGED, plus squaring `Var(a·a)=4·Var(a)=1.0` (was wrongly `0.5` under independence). Public API unchanged (added effects only); order-safe run-pass test extended with the squaring case.
+4. **N≥4 spread** — wire the associahedron/`pentagon_variance` work into the coefficient-spread term (the 5-association Catalan-C₃ enclosure).
+5. **Per-symbol structural distribution** — the open piece: representing the order-ambiguity associator as a *correlated* affine coefficient (the proven N=3 fact) rather than the conservative independent `pstruct` scalar. The coupled-symbol enclosure problem.
+6. **Type-system framing** — surface `NonAssoc` (already an effect) as the carrier: a non-associative product *is* a variance-producing effect, and the affine form is its propagated witness. This is the PL-novel half.
+
+## Why this is the right "big step"
+
+It advances the telos (uncertainty-as-default-substrate, "my mind and the world") rather than the toolchain that serves it, it is falsifiable and already falsified-green at N=3, and the prior-art sweep shows the narrow mechanization is unworked. It does **not** block on the arm64 self-host (it runs today on `bin/souc`), so it proceeds in parallel with closing that out.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 729
-- Repo-backed topics: 579
+- Total governed topics: 730
+- Repo-backed topics: 580
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 437
+- Authority count `repo_only`: 438
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 441 topics
+- A2: 442 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -72,6 +72,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.roadmap-v0.5.0-part3 | archived | docs/archived/ROADMAP_v0.5.0_PART3.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.strategic-growth-plan | archived | docs/archived/STRATEGIC_GROWTH_PLAN.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13 | repo_only | docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.chi5-real-axiom-audit-2026-05-30 | repo_only | docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-demo-sweep-2026-06-02 | repo_only | docs/audit/EPISTEMIC_DEMO_SWEEP_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-nn-backward-e2e-2026-06-02 | repo_only | docs/audit/EPISTEMIC_NN_BACKWARD_E2E_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1128,6 +1128,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.chi5-real-axiom-audit-2026-05-30",
       "collection": "repo",
       "repo_doc_path": "docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md",

--- a/examples/epistemic/affine_nonassoc_demo.sio
+++ b/examples/epistemic/affine_nonassoc_demo.sio
@@ -1,0 +1,302 @@
+// examples/epistemic/affine_nonassoc_demo.sio
+//
+// FRONTIER DEMONSTRATOR — affine arithmetic over a non-associative algebra,
+// with non-associativity carried as a noise symbol in the SAME affine budget
+// as correlated input uncertainty.
+//
+// Self-contained (no imports) so it builds + RUNS with a single
+//   bin/souc affine_nonassoc_demo.sio out && chmod +x out && ./out
+// per the project rule that the --check harness lies but the emitted ELF runs.
+//
+// An affine octonion is   x = x0 + Σ_k  d_k · ε_k     (k = 0..NSYM-1)
+// where ε_k are shared scalar noise symbols (unit variance) and the
+// coefficients x0, d_k are OCTONION-valued ([f64;8]). Two values that share a
+// symbol ε_k are CORRELATED through it; a symbol that appears with equal and
+// opposite coefficients cancels exactly (zero covariance). Variance is the one
+// budget   Var(x) = Σ_k ‖d_k‖².
+//
+// Three claims, each asserted numerically:
+//   (1) EXACT CONDITIONING = ZERO COVARIANCE. x − x carries variance 0 in the
+//       affine model; the independence-assuming scalar model reports 2·Var(x).
+//   (2) CORRELATION HONESTY. Sharing a symbol changes the sum's variance versus
+//       treating the two operands as independent — the affine form tracks it,
+//       a scalar variance budget cannot.
+//   (3) NON-ASSOCIATIVITY IS A NOISE-SYMBOL PERTURBATION. For a triple product
+//       a·b·c where a carries a noise symbol, the ε-coefficient of ((a·b)·c)
+//       and of (a·(b·c)) DIFFER by exactly the associator [a1,b0,c0]. The
+//       order-ambiguity does not live in a separate scalar add-on — it is
+//       distributed across the symbol row and stays correlated with the input
+//       that owns the symbol. (This is the N=3 hand-calc, verified by running.)
+
+// ───────────────────────── octonion primitives (inlined) ─────────────────────
+
+fn oct_mul(a: &[f64; 8], b: &[f64; 8], out: &![f64; 8]) with Mut, Div, NonAssoc {
+    var r0 = a[0] * b[0]
+    r0 = r0 - a[1] * b[1] - a[2] * b[2] - a[3] * b[3]
+    r0 = r0 - a[4] * b[4] - a[5] * b[5] - a[6] * b[6] - a[7] * b[7]
+    out[0] = r0
+    var r1 = a[0] * b[1] + a[1] * b[0]
+    r1 = r1 + a[2] * b[3] - a[3] * b[2]
+    r1 = r1 + a[4] * b[5] - a[5] * b[4]
+    r1 = r1 - a[6] * b[7] + a[7] * b[6]
+    out[1] = r1
+    var r2 = a[0] * b[2] + a[2] * b[0]
+    r2 = r2 - a[1] * b[3] + a[3] * b[1]
+    r2 = r2 + a[4] * b[6] - a[6] * b[4]
+    r2 = r2 + a[5] * b[7] - a[7] * b[5]
+    out[2] = r2
+    var r3 = a[0] * b[3] + a[3] * b[0]
+    r3 = r3 + a[1] * b[2] - a[2] * b[1]
+    r3 = r3 + a[4] * b[7] - a[7] * b[4]
+    r3 = r3 - a[5] * b[6] + a[6] * b[5]
+    out[3] = r3
+    var r4 = a[0] * b[4] + a[4] * b[0]
+    r4 = r4 - a[1] * b[5] + a[5] * b[1]
+    r4 = r4 - a[2] * b[6] + a[6] * b[2]
+    r4 = r4 - a[3] * b[7] + a[7] * b[3]
+    out[4] = r4
+    var r5 = a[0] * b[5] + a[5] * b[0]
+    r5 = r5 + a[1] * b[4] - a[4] * b[1]
+    r5 = r5 - a[2] * b[7] + a[7] * b[2]
+    r5 = r5 + a[3] * b[6] - a[6] * b[3]
+    out[5] = r5
+    var r6 = a[0] * b[6] + a[6] * b[0]
+    r6 = r6 + a[1] * b[7] - a[7] * b[1]
+    r6 = r6 + a[2] * b[4] - a[4] * b[2]
+    r6 = r6 - a[3] * b[5] + a[5] * b[3]
+    out[6] = r6
+    var r7 = a[0] * b[7] + a[7] * b[0]
+    r7 = r7 - a[1] * b[6] + a[6] * b[1]
+    r7 = r7 + a[2] * b[5] - a[5] * b[2]
+    r7 = r7 + a[3] * b[4] - a[4] * b[3]
+    out[7] = r7
+}
+
+fn oct_norm_sq(a: &[f64; 8]) -> f64 with Mut {
+    var sum: f64 = 0.0
+    var i: i64 = 0
+    while i < 8 { sum = sum + a[i] * a[i]; i = i + 1 }
+    sum
+}
+
+fn oct_associator(a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], out: &![f64; 8])
+    with Mut, Div, NonAssoc {
+    var ab: [f64; 8] = [0.0; 8]
+    oct_mul(a, b, &!ab)
+    var ab_c: [f64; 8] = [0.0; 8]
+    oct_mul(&ab, c, &!ab_c)
+    var bc: [f64; 8] = [0.0; 8]
+    oct_mul(b, c, &!bc)
+    var a_bc: [f64; 8] = [0.0; 8]
+    oct_mul(a, &bc, &!a_bc)
+    var i: i64 = 0
+    while i < 8 { out[i] = ab_c[i] - a_bc[i]; i = i + 1 }
+}
+
+// ───────────────────────── affine octonion form ──────────────────────────────
+// NSYM noise symbols; coefficient of symbol k lives at co[k*8 + c].
+
+struct AffOct {
+    c0: [f64; 8],    // central octonion value
+    co: [f64; 32],   // 4 symbols × 8 components
+}
+
+fn aff_zero() -> AffOct {
+    AffOct { c0: [0.0; 8], co: [0.0; 32] }
+}
+
+fn aff_set_central(a: &!AffOct, v: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { a.c0[c] = v[c]; c = c + 1 }
+}
+
+fn aff_set_sym(a: &!AffOct, k: i64, coeff: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { a.co[k * 8 + c] = coeff[c]; c = c + 1 }
+}
+
+fn aff_get_sym(a: &AffOct, k: i64, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = a.co[k * 8 + c]; c = c + 1 }
+}
+
+// A leaf: central value v, perturbed along octonion direction `coeff` by symbol k.
+fn aff_leaf(v: &[f64; 8], k: i64, coeff: &[f64; 8]) -> AffOct with Mut {
+    var a = aff_zero()
+    aff_set_central(&!a, v)
+    aff_set_sym(&!a, k, coeff)
+    a
+}
+
+// One variance budget: Σ_k ‖d_k‖² over all noise symbols.
+fn aff_variance(a: &AffOct) -> f64 with Mut {
+    var total: f64 = 0.0
+    var k: i64 = 0
+    while k < 4 {
+        var d: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!d)
+        total = total + oct_norm_sq(&d)
+        k = k + 1
+    }
+    total
+}
+
+fn aff_sub(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = a.c0[c] - b.c0[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 32 { out.co[i] = a.co[i] - b.co[i]; i = i + 1 }
+}
+
+fn aff_add(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = a.c0[c] + b.c0[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 32 { out.co[i] = a.co[i] + b.co[i]; i = i + 1 }
+}
+
+// First-order affine octonion product (preserves octonion ORDER, hence
+// non-associativity).  central = a0·b0 ; ∂/∂ε_k = a0·d_k(b) + d_k(a)·b0.
+fn aff_mul(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut, Div, NonAssoc {
+    var a0: [f64; 8] = [0.0; 8]
+    var b0: [f64; 8] = [0.0; 8]
+    var c: i64 = 0
+    while c < 8 { a0[c] = a.c0[c]; b0[c] = b.c0[c]; c = c + 1 }
+
+    var prod: [f64; 8] = [0.0; 8]
+    oct_mul(&a0, &b0, &!prod)
+    aff_set_central(out, &prod)
+
+    var k: i64 = 0
+    while k < 4 {
+        var da: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!da)
+        var db: [f64; 8] = [0.0; 8]
+        aff_get_sym(b, k, &!db)
+        // a0 · db  +  da · b0
+        var t1: [f64; 8] = [0.0; 8]
+        oct_mul(&a0, &db, &!t1)
+        var t2: [f64; 8] = [0.0; 8]
+        oct_mul(&da, &b0, &!t2)
+        var sum: [f64; 8] = [0.0; 8]
+        var c2: i64 = 0
+        while c2 < 8 { sum[c2] = t1[c2] + t2[c2]; c2 = c2 + 1 }
+        aff_set_sym(out, k, &sum)
+        k = k + 1
+    }
+}
+
+fn f_abs(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
+fn scaled(x: f64) -> i64 { (x * 1000000.0) as i64 }
+
+// ───────────────────────────────── demo ─────────────────────────────────────
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    var fails: i64 = 0
+
+    // ── Claim 1: exact conditioning = zero covariance ──
+    // x = v + d·ε0 .   x − x  must have variance 0 (symbol cancels), whereas the
+    // independence-assuming scalar model would report Var(x)+Var(x) = 2‖d‖².
+    var v: [f64; 8] = [0.0; 8]
+    v[0] = 3.0
+    v[1] = 1.0
+    var d: [f64; 8] = [0.0; 8]
+    d[1] = 0.2          // noise direction along e1, ‖d‖² = 0.04
+    let x = aff_leaf(&v, 0, &d)
+    let var_x = aff_variance(&x)
+
+    var xmx = aff_zero()
+    aff_sub(&x, &x, &!xmx)
+    let var_xmx = aff_variance(&xmx)
+    let scalar_indep_model = var_x + var_x   // what a scalar budget is forced to say
+
+    println("── Claim 1: exact conditioning = zero covariance ──")
+    print(scaled(var_x))      ; println("   = Var(x)  (×1e6)")
+    print(scaled(scalar_indep_model)); println("   = scalar-model Var(x−x), independence assumed")
+    print(scaled(var_xmx))    ; println("   = affine    Var(x−x)  → exact zero")
+    if f_abs(var_xmx) < 0.000000001 { println("  PASS: affine collapses correlated difference to 0") }
+    else { println("  FAIL"); fails = fails + 1 }
+    if scalar_indep_model > 0.0000001 { println("  (scalar model overstates by 2·Var(x) — the lie)") }
+
+    // ── Claim 2: correlation honesty ──
+    // Same magnitude budget on two leaves, combined two ways:
+    //   shared symbol  (correlated)   vs   distinct symbols (independent).
+    var w: [f64; 8] = [0.0; 8]
+    w[0] = 2.0
+    w[2] = 1.0
+    let y_shared = aff_leaf(&w, 0, &d)   // shares ε0 with x
+    let y_indep  = aff_leaf(&w, 1, &d)   // own symbol ε1
+
+    var sum_corr = aff_zero()
+    aff_add(&x, &y_shared, &!sum_corr)
+    var sum_ind = aff_zero()
+    aff_add(&x, &y_indep, &!sum_ind)
+    let var_corr = aff_variance(&sum_corr)   // ‖d+d‖² = 4‖d‖²
+    let var_ind  = aff_variance(&sum_ind)    // ‖d‖²+‖d‖² = 2‖d‖²
+
+    println("")
+    println("── Claim 2: correlation honesty (Var of x+y) ──")
+    print(scaled(var_corr)); println("   = correlated  (shared ε0): 4‖d‖²")
+    print(scaled(var_ind)) ; println("   = independent (own ε1):   2‖d‖²")
+    if var_corr > var_ind + 0.0000001 { println("  PASS: shared-symbol correlation raises variance — tracked, not assumed") }
+    else { println("  FAIL"); fails = fails + 1 }
+
+    // ── Claim 3: non-associativity is a noise-symbol perturbation ──
+    // a = a0 + a1·ε0 ;  b, c exact (no symbols).
+    // ε0-coefficient of ((a·b)·c) is (a1·b0)·c0 ; of (a·(b·c)) is a1·(b0·c0).
+    // Their difference must equal the associator [a1, b0, c0].
+    var a0: [f64; 8] = [0.0; 8]
+    a0[0] = 1.0                 // a central = 1
+    var a1: [f64; 8] = [0.0; 8]
+    a1[1] = 1.0                 // a noise direction = e1
+    var b0: [f64; 8] = [0.0; 8]
+    b0[2] = 1.0                 // b = e2
+    var c0: [f64; 8] = [0.0; 8]
+    c0[4] = 1.0                 // c = e4   ([e1,e2,e4] is non-Fano → associator ≠ 0)
+
+    let a = aff_leaf(&a0, 0, &a1)
+    var b = aff_zero(); aff_set_central(&!b, &b0)
+    var cc = aff_zero(); aff_set_central(&!cc, &c0)
+
+    var ab = aff_zero(); aff_mul(&a, &b, &!ab)
+    var ab_c = aff_zero(); aff_mul(&ab, &cc, &!ab_c)       // ((a·b)·c)
+    var bc = aff_zero(); aff_mul(&b, &cc, &!bc)
+    var a_bc = aff_zero(); aff_mul(&a, &bc, &!a_bc)        // (a·(b·c))
+
+    var coeff_left: [f64; 8] = [0.0; 8]
+    aff_get_sym(&ab_c, 0, &!coeff_left)
+    var coeff_right: [f64; 8] = [0.0; 8]
+    aff_get_sym(&a_bc, 0, &!coeff_right)
+
+    // measured spread between associations, on the noise coefficient
+    var spread: [f64; 8] = [0.0; 8]
+    var c3: i64 = 0
+    while c3 < 8 { spread[c3] = coeff_left[c3] - coeff_right[c3]; c3 = c3 + 1 }
+
+    // the algebra's own associator [a1, b0, c0]
+    var assoc: [f64; 8] = [0.0; 8]
+    oct_associator(&a1, &b0, &c0, &!assoc)
+
+    var max_diff: f64 = 0.0
+    var c4: i64 = 0
+    while c4 < 8 {
+        let dd = f_abs(spread[c4] - assoc[c4])
+        if dd > max_diff { max_diff = dd }
+        c4 = c4 + 1
+    }
+    let assoc_mag = oct_norm_sq(&assoc)
+
+    println("")
+    println("── Claim 3: non-associativity perturbs the noise symbol ──")
+    print(scaled(assoc_mag)); println("   = ‖associator‖²  (>0 ⇒ genuinely non-associative triple)")
+    print(scaled(max_diff)) ; println("   = max |coeff-spread − associator| over components (→0)")
+    if assoc_mag > 0.0000001 && max_diff < 0.000000001 {
+        println("  PASS: ε0-coefficient spread between ((ab)c) and (a(bc)) == [a1,b0,c0]")
+        println("        the order-ambiguity rides the SAME symbol as a's input uncertainty")
+    } else { println("  FAIL"); fails = fails + 1 }
+
+    println("")
+    if fails == 0 { println("ALL CLAIMS VERIFIED"); return 0 }
+    print(fails); println(" claim(s) FAILED")
+    return 1
+}

--- a/stdlib/epistemic/affine_octonion.sio
+++ b/stdlib/epistemic/affine_octonion.sio
@@ -1,0 +1,180 @@
+// stdlib/epistemic/affine_octonion.sio — correlation-honest affine octonion value
+//
+// AffOct is the affine-arithmetic upgrade of UncertainOct (uncertain_octonion.sio).
+// Where UncertainOct carries a single SCALAR variance and therefore must assume
+// its operands are INDEPENDENT, AffOct carries the value as an affine form
+//
+//     x = x0 + Σ_k  d_k · ε_k          (k = 0 .. NSYM-1)
+//
+// over a shared pool of scalar noise symbols ε_k ∈ [−1,1]. The coefficients
+// x0, d_k are octonion-valued ([f64;8]). Two values that were built from the
+// SAME symbol are correlated through it; a symbol that ends up with equal and
+// opposite coefficients cancels EXACTLY. Correlation is therefore structural —
+// carried by shared symbol identity — not approximated by a covariance matrix.
+// This is the realization of "independence is a lie" at the level of every
+// value: x − x has variance 0, not 2·Var(x).
+//
+// The one budget is   Var(x) = Σ_k ‖d_k‖²  +  rough,  where `rough` is a single
+// lumped, conservatively-INDEPENDENT bucket for the second-order product
+// remainder (standard affine arithmetic). HONESTY SCOPE: AffOct is
+// correlation-honest to FIRST ORDER; the second-order multiplicative remainder
+// is enclosed independently in `rough`, so independence re-enters at 2nd order
+// (this is the usual AA trade-off, stated so callers do not over-claim).
+//
+// NON-ASSOCIATIVITY is deliberately NOT handled here. A binary value type cannot
+// see a triple, so it cannot carry the order-ambiguity associator (proven to
+// live distributed across the symbol coefficients — see
+// docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md). The structural term
+// belongs to the perturbation DAG (perturbation_graph.sio), which has triple
+// identity; this module is the correlation-honest measurement layer beneath it.
+//
+// No new algebra: reuses the verified primitives in algebra::octonion.
+// Construction is ONLY via the exported aff_* functions (no cross-module struct
+// literal), and all combinators write through a bare &! out-param (the safe
+// deref-store path), mirroring perturbation_graph.sio.
+
+use algebra::octonion::{oct_mul, oct_norm_sq}
+
+// Number of shared noise symbols. Each independent error source is assigned a
+// distinct symbol index by the caller; shared indices encode correlation.
+// co holds NSYM octonion coefficients flattened: symbol k component c at co[k*8+c].
+pub struct AffOct {
+    c0:    [f64; 8],    // central octonion value
+    co:    [f64; 64],   // NSYM(=8) symbol coefficients, co[k*8 + c]
+    rough: f64,         // lumped INDEPENDENT 2nd-order/roundoff variance bucket
+}
+
+fn aff_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    var i = 0
+    while i < 30 { y = 0.5 * (y + x / y); i = i + 1 }
+    y
+}
+
+// A zeroed affine form (central 0, no symbols). The struct literal lives ONLY
+// here, so consumers never construct AffOct across a module boundary.
+pub fn aff_new() -> AffOct {
+    AffOct { c0: [0.0; 8], co: [0.0; 64], rough: 0.0 }
+}
+
+// An exactly-known octonion (zero uncertainty).
+pub fn aff_certain(out: &!AffOct, v: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = v[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 64 { out.co[i] = 0.0; i = i + 1 }
+    out.rough = 0.0
+}
+
+// A measured octonion: central value v, perturbed along octonion direction
+// `coeff` by noise symbol `sym`. ‖coeff‖² is this leaf's variance.
+pub fn aff_leaf(out: &!AffOct, v: &[f64; 8], sym: i64, coeff: &[f64; 8]) with Mut {
+    aff_certain(out, v)
+    var c: i64 = 0
+    while c < 8 { out.co[sym * 8 + c] = coeff[c]; c = c + 1 }
+}
+
+pub fn aff_get_sym(a: &AffOct, k: i64, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = a.co[k * 8 + c]; c = c + 1 }
+}
+
+pub fn aff_central(a: &AffOct, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = a.c0[c]; c = c + 1 }
+}
+
+// The one variance budget: Σ_k ‖d_k‖²  +  the independent roughness bucket.
+pub fn aff_variance(a: &AffOct) -> f64 with Mut {
+    var total: f64 = 0.0
+    var k: i64 = 0
+    while k < 8 {
+        var d: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!d)
+        total = total + oct_norm_sq(&d)
+        k = k + 1
+    }
+    total + a.rough
+}
+
+pub fn aff_std(a: &AffOct) -> f64 with Mut, Div, Panic {
+    aff_sqrt(aff_variance(a))
+}
+
+// Total deviation rad(a) = Σ_k ‖d_k‖ — the affine "radius", used to bound the
+// second-order product remainder.
+fn aff_radius(a: &AffOct) -> f64 with Mut, Div, Panic {
+    var r: f64 = 0.0
+    var k: i64 = 0
+    while k < 8 {
+        var d: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!d)
+        r = r + aff_sqrt(oct_norm_sq(&d))
+        k = k + 1
+    }
+    r
+}
+
+// x + y. Shared symbols ADD (correlation amplifies); opposite coefficients
+// cancel. rough buckets add (independent).
+pub fn aff_add(out: &!AffOct, a: &AffOct, b: &AffOct) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = a.c0[c] + b.c0[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 64 { out.co[i] = a.co[i] + b.co[i]; i = i + 1 }
+    out.rough = a.rough + b.rough
+}
+
+// x − y. The exact-conditioning case: aff_sub(x, x) ⇒ every coefficient cancels
+// ⇒ variance 0 (zero covariance), where a scalar model is forced to report
+// Var(x)+Var(x).
+pub fn aff_sub(out: &!AffOct, a: &AffOct, b: &AffOct) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = a.c0[c] - b.c0[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 64 { out.co[i] = a.co[i] - b.co[i]; i = i + 1 }
+    out.rough = a.rough + b.rough
+}
+
+// Binary octonion product, first-order correlation-honest. Octonion ORDER is
+// preserved (a on the left), so the product is non-commutative as it must be.
+//   central     :  a0 · b0
+//   ∂/∂ε_k      :  a0 · d_k(b)  +  d_k(a) · b0        (shared symbols tracked)
+//   2nd order   :  enclosed independently in rough, bounded by rad(a)·rad(b),
+//                  plus the norm-propagated input rough budgets.
+pub fn aff_mul(out: &!AffOct, a: &AffOct, b: &AffOct) with Mut, Div, Panic, NonAssoc {
+    var a0: [f64; 8] = [0.0; 8]
+    aff_central(a, &!a0)
+    var b0: [f64; 8] = [0.0; 8]
+    aff_central(b, &!b0)
+
+    var prod: [f64; 8] = [0.0; 8]
+    oct_mul(&a0, &b0, &!prod)
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = prod[c]; c = c + 1 }
+
+    var k: i64 = 0
+    while k < 8 {
+        var da: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!da)
+        var db: [f64; 8] = [0.0; 8]
+        aff_get_sym(b, k, &!db)
+        var t1: [f64; 8] = [0.0; 8]
+        oct_mul(&a0, &db, &!t1)
+        var t2: [f64; 8] = [0.0; 8]
+        oct_mul(&da, &b0, &!t2)
+        var cc: i64 = 0
+        while cc < 8 { out.co[k * 8 + cc] = t1[cc] + t2[cc]; cc = cc + 1 }
+        k = k + 1
+    }
+
+    // independent budgets: input roughness propagated through the norm rule,
+    // plus the fresh second-order remainder bound rad(a)·rad(b).
+    let na = oct_norm_sq(&a0)
+    let nb = oct_norm_sq(&b0)
+    let ra = aff_radius(a)
+    let rb = aff_radius(b)
+    let remainder = ra * rb
+    out.rough = nb * a.rough + na * b.rough + remainder * remainder
+}

--- a/stdlib/epistemic/perturbation_graph.sio
+++ b/stdlib/epistemic/perturbation_graph.sio
@@ -4,37 +4,70 @@
 // binary chaining: a.mul(b).mul(c) cannot add the structural term, because the
 // intermediate product has forgotten its operands. This module fixes that by
 // giving each value IDENTITY in a perturbation DAG — a Wengert tape: a flat arena
-// of nodes addressed by index (no Box-per-node, so it avoids the large-boxed-
-// struct codegen hazard; the arena is mutated through a bare `&!` param, the safe
-// deref-store path).
+// of nodes addressed by index (no Box-per-node; the arena is mutated through a
+// bare `&!` param, the safe deref-store path, and is created by value exactly
+// once via pg_new — verified safe at ~269KB).
 //
-// Each product node records its two operands. When a product node (a·b) is
-// multiplied by c, the triple (a,b,c) is recoverable from the graph, so the
-// regrouping associator κ·‖[a,b,c]‖² is added automatically — at every internal
-// node, for ANY association. Binary chaining becomes order-safe: ((a·b)·c) and
-// (a·(b·c)) carry the same total variance, equal to the explicit mul3.
+// CORRELATION-HONEST measurement (the affine upgrade). Each node carries not a
+// scalar variance but an AFFINE coefficient ROW over the leaf noise symbols:
+//   node n  ≈  value(n)  +  Σ_k  psym[n][k] · ε_k        (ε_k the leaf symbols)
+// Each leaf is assigned a fresh symbol; a node's variance is Σ_k ‖psym[n][k]‖².
+// Because octonions are a COMPOSITION algebra (‖a·b‖ = ‖a‖·‖b‖), the first-order
+// product rule  psym[out][k] = vi·psym[j][k] + psym[i][k]·vj  reproduces the old
+// independence rule  ‖j‖²·Var(i) + ‖i‖²·Var(j)  EXACTLY when the operands' symbol
+// sets are DISJOINT. So the previous scalar model is recovered as the
+// disjoint-symbol special case — and when a leaf is REUSED (a diamond / squaring
+// a·a), the shared symbol is tracked instead of double-counted: Var(a·a)=4·Var(a),
+// not 2·Var(a). This retires "independence is a lie" in the live substrate.
+// HONESTY SCOPE: correlation-honest to FIRST ORDER (the standard affine-arithmetic
+// trade-off); the second-order multiplicative remainder is not tracked here.
 //
-// This is the runtime correlation graph: a type cannot see correlation, so the
-// VALUE must carry identity. No new algebra — reuses algebra::octonion.
+// STRUCTURAL (non-associativity) variance is kept in a SEPARATE independent scalar
+// pstruct[n] — the regrouping associator κ·‖[a,b,c]‖² — propagated through products
+// by the same norm rule. It is independent of the leaf measurement symbols (its
+// per-symbol affine distribution is the open N≥? coupled-symbol problem; see
+// docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md). Keeping it scalar makes
+// the upgrade a strict superset of the prior behavior.
 //
-// Execution-verified (self-contained build): left chain, right chain, and mul3
-// all yield 4.75 for a non-Fano triple (σ²=0.25 each, κ=1); Fano triple yields
-// 0.75; the order-naive binary would drop to 0.75. All paths agree.
+// SCOPE — structural order-safety still holds iff N ≤ 3 (PROVEN, both directions):
+//   • N=3: the single regrouping node's associator IS the entire order-spread,
+//     so ((a·b)·c) and (a·(b·c)) carry the SAME variance, equal to mul3.
+//   • N≥4: the per-node rule is PATH-DEPENDENT (disproven by counterexample); the
+//     exact parenthesization-independent N≥4 spread is the associahedron vertex
+//     variance — algebra::associator_field::pentagon_variance (N=4).
+//
+// Execution-verified (self-contained build): for the triple, left chain, right
+// chain, and mul3 all yield 4.75 (non-Fano, σ²=0.25, κ=1); Fano yields 0.75;
+// squaring a·a yields 4·Var(a). No new algebra — reuses algebra::octonion.
 
 use algebra::octonion::{oct_mul, oct_associator, oct_norm_sq}
 
-// Arena capacity: 64 nodes (vals flattened to 64 * 8 = 512 f64).
+// Arena capacity PG_CAP = 64 nodes. Each node carries an affine row over up to
+// PG_CAP leaf symbols: psym flattened as psym[n*512 + k*8 + c]  (512 = 64*8).
 pub struct PerturbGraph {
-    count: i64,
-    vals: [f64; 512],   // node n, component c, at vals[n*8 + c]
-    pvar: [f64; 64],    // per-node variance budget
-    kind: [i64; 64],    // 0 = leaf, 1 = product
-    lc:   [i64; 64],    // left operand index  (products only)
-    rc:   [i64; 64],    // right operand index (products only)
+    count:   i64,
+    vals:    [f64; 512],     // node n component c at vals[n*8 + c]
+    psym:    [f64; 32768],   // node n, symbol k, component c at psym[n*512 + k*8 + c]
+    pstruct: [f64; 64],      // per-node INDEPENDENT structural variance (associator)
+    kind:    [i64; 64],      // 0 = leaf, 1 = product
+    lc:      [i64; 64],      // left operand index  (products only)
+    rc:      [i64; 64],      // right operand index (products only)
+    nsym:    i64,            // next free leaf-symbol index
 }
 
 pub fn pg_new() -> PerturbGraph {
-    PerturbGraph { count: 0, vals: [0.0; 512], pvar: [0.0; 64], kind: [0; 64], lc: [0; 64], rc: [0; 64] }
+    PerturbGraph {
+        count: 0, vals: [0.0; 512], psym: [0.0; 32768], pstruct: [0.0; 64],
+        kind: [0; 64], lc: [0; 64], rc: [0; 64], nsym: 0,
+    }
+}
+
+fn pg_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    var i = 0
+    while i < 30 { y = 0.5 * (y + x / y); i = i + 1 }
+    y
 }
 
 fn pg_get(g: &!PerturbGraph, n: i64, out: &![f64; 8]) with Mut {
@@ -42,21 +75,38 @@ fn pg_get(g: &!PerturbGraph, n: i64, out: &![f64; 8]) with Mut {
     while c < 8 { out[c] = g.vals[n * 8 + c]; c = c + 1 }
 }
 
-// Add a measured leaf octonion; returns its node index.
-pub fn pg_leaf(g: &!PerturbGraph, v: &[f64; 8], std_dev: f64) -> i64 with Mut {
+fn pg_getsym(g: &!PerturbGraph, n: i64, k: i64, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = g.psym[n * 512 + k * 8 + c]; c = c + 1 }
+}
+
+// Add a measured leaf octonion; returns its node index. The leaf gets a FRESH
+// noise symbol with coefficient std·unit(v), so ‖coeff‖² = std² (the same
+// variance the scalar model assigned) — independent of ‖v‖.
+pub fn pg_leaf(g: &!PerturbGraph, v: &[f64; 8], std_dev: f64) -> i64 with Mut, Div, Panic {
     let n = g.count
+    if n >= 64 { return -1 }   // arena full (PG_CAP = 64): signal, never OOB-write
+    let k = g.nsym
     var c: i64 = 0
     while c < 8 { g.vals[n * 8 + c] = v[c]; c = c + 1 }
-    g.pvar[n] = std_dev * std_dev
+    let nv = oct_norm_sq(v)
+    let inv = if nv > 0.0 { std_dev / pg_sqrt(nv) } else { 0.0 }
+    var c2: i64 = 0
+    while c2 < 8 { g.psym[n * 512 + k * 8 + c2] = v[c2] * inv; c2 = c2 + 1 }
+    g.pstruct[n] = 0.0
     g.kind[n] = 0
     g.count = n + 1
+    g.nsym = k + 1
     n
 }
 
-// Multiply nodes i and j; returns the product node. The regrouping associator is
-// added automatically for whichever operand is itself a product, so chaining is
-// order-safe:  Var = ‖j‖²·Var(i) + ‖i‖²·Var(j) + κ·(regrouping ‖α‖²).
+// Multiply nodes i and j; returns the product node.
+//   measurement : psym[out][k] = vi·psym[j][k] + psym[i][k]·vj   (first order,
+//                 octonion order preserved; correlation tracked via shared symbols)
+//   structural  : pstruct[out] = ‖j‖²·pstruct[i] + ‖i‖²·pstruct[j]
+//                 + κ·‖regrouping associator‖²    (order-safe through triples)
 pub fn pg_mul(g: &!PerturbGraph, i: i64, j: i64, kappa: f64) -> i64 with Mut, Div, NonAssoc {
+    if g.count >= 64 { return -1 }   // arena full (PG_CAP = 64): signal, never OOB-write
     var vi: [f64; 8] = [0.0; 8]
     pg_get(g, i, &!vi)
     var vj: [f64; 8] = [0.0; 8]
@@ -66,6 +116,27 @@ pub fn pg_mul(g: &!PerturbGraph, i: i64, j: i64, kappa: f64) -> i64 with Mut, Di
     let ni = oct_norm_sq(&vi)
     let nj = oct_norm_sq(&vj)
 
+    let n = g.count
+    var c: i64 = 0
+    while c < 8 { g.vals[n * 8 + c] = prod[c]; c = c + 1 }
+
+    // first-order affine propagation over the shared leaf-symbol pool
+    var k: i64 = 0
+    while k < 64 {
+        var da: [f64; 8] = [0.0; 8]
+        pg_getsym(g, i, k, &!da)
+        var db: [f64; 8] = [0.0; 8]
+        pg_getsym(g, j, k, &!db)
+        var t1: [f64; 8] = [0.0; 8]
+        oct_mul(&vi, &db, &!t1)
+        var t2: [f64; 8] = [0.0; 8]
+        oct_mul(&da, &vj, &!t2)
+        var cc: i64 = 0
+        while cc < 8 { g.psym[n * 512 + k * 8 + cc] = t1[cc] + t2[cc]; cc = cc + 1 }
+        k = k + 1
+    }
+
+    // structural (non-associativity) variance — independent scalar
     var structural: f64 = 0.0
     // left operand is a product (a·b): regrouping ambiguity is [a, b, j]
     if g.kind[i] == 1 {
@@ -87,11 +158,8 @@ pub fn pg_mul(g: &!PerturbGraph, i: i64, j: i64, kappa: f64) -> i64 with Mut, Di
         oct_associator(&vi, &ra, &rb, &!as2)
         structural = structural + kappa * oct_norm_sq(&as2)
     }
-
-    let n = g.count
-    var c: i64 = 0
-    while c < 8 { g.vals[n * 8 + c] = prod[c]; c = c + 1 }
-    g.pvar[n] = nj * g.pvar[i] + ni * g.pvar[j] + structural
+    let sv = nj * g.pstruct[i] + ni * g.pstruct[j] + structural
+    g.pstruct[n] = if sv < 0.0 { 0.0 } else { sv }   // variance ≥ 0 (guards κ<0 / FP drift)
     g.kind[n] = 1
     g.lc[n] = i
     g.rc[n] = j
@@ -99,6 +167,18 @@ pub fn pg_mul(g: &!PerturbGraph, i: i64, j: i64, kappa: f64) -> i64 with Mut, Di
     n
 }
 
-pub fn pg_variance(g: &!PerturbGraph, n: i64) -> f64 { g.pvar[n] }
+// Total variance budget for node n: Σ_k ‖psym[n][k]‖² (correlated measurement)
+// + pstruct[n] (independent structural).
+pub fn pg_variance(g: &!PerturbGraph, n: i64) -> f64 with Mut {
+    var total: f64 = 0.0
+    var k: i64 = 0
+    while k < 64 {
+        var d: [f64; 8] = [0.0; 8]
+        pg_getsym(g, n, k, &!d)
+        total = total + oct_norm_sq(&d)
+        k = k + 1
+    }
+    total + g.pstruct[n]
+}
 
 pub fn pg_component(g: &!PerturbGraph, n: i64, c: i64) -> f64 { g.vals[n * 8 + c] }

--- a/tests/run-pass/affine_octonion_correlation.sio
+++ b/tests/run-pass/affine_octonion_correlation.sio
@@ -1,0 +1,91 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+//
+// L0 acceptance for AffOct (stdlib/epistemic/affine_octonion.sio) — the
+// correlation-honest affine octonion value. Where UncertainOct carries a scalar
+// variance and must ASSUME independence, AffOct carries the value as an affine
+// form over shared noise symbols ε_k, so correlation is structural (shared
+// symbol identity) and exact cancellation is possible.
+//
+// Three facts, each the thing a scalar variance budget CANNOT express:
+//   (1) exact conditioning = zero covariance:  Var(x − x) = 0, not 2·Var(x).
+//   (2) correlation honesty:  Var(x + y) is 4‖d‖² when x,y share a symbol but
+//       2‖d‖² when independent.
+//   (3) binary product is correlation-honest to first order; the second-order
+//       remainder is enclosed in the independent `rough` bucket (rad(a)·rad(b)).
+//
+// Numbers (d along e1, ‖d‖²=0.04):
+//   Var(x)=0.04 ; Var(x−x)=0 ; Var(x+y_shared)=0.16 ; Var(x+y_indep)=0.08
+//   product a=(1)+0.3e1·ε0, b=(e2)+0.1e3·ε1 :
+//     ‖co_0‖²=0.09 (da·b0) ; rough=(0.3·0.1)²=0.0009 ; Var=0.1009
+
+use epistemic::affine_octonion::{
+    AffOct, aff_new, aff_leaf, aff_add, aff_sub, aff_mul, aff_variance, aff_get_sym
+}
+use algebra::octonion::oct_norm_sq
+
+fn approx(x: f64, y: f64) -> bool {
+    let d = if x > y { x - y } else { y - x }
+    d < 0.0001
+}
+
+fn main() with Mut, Div, Panic, NonAssoc {
+    var ok = true
+
+    var v: [f64; 8] = [0.0; 8]
+    v[0] = 3.0
+    v[1] = 1.0
+    var d: [f64; 8] = [0.0; 8]
+    d[1] = 0.2                                  // ‖d‖² = 0.04
+    var x = aff_new()
+    aff_leaf(&!x, &v, 0, &d)
+
+    // (1) exact conditioning
+    var xmx = aff_new()
+    aff_sub(&!xmx, &x, &x)
+    if approx(aff_variance(&x), 0.04) { print("Var(x)=0.04: PASS") }
+    else { print("Var(x): FAIL"); ok = false }
+    if approx(aff_variance(&xmx), 0.0) { print("Var(x-x)=0 (zero covariance): PASS") }
+    else { print("Var(x-x): FAIL"); ok = false }
+
+    // (2) correlation honesty
+    var w: [f64; 8] = [0.0; 8]
+    w[0] = 2.0
+    w[2] = 1.0
+    var ysh = aff_new()
+    aff_leaf(&!ysh, &w, 0, &d)                  // shares ε0 with x
+    var yin = aff_new()
+    aff_leaf(&!yin, &w, 1, &d)                  // own ε1
+    var scorr = aff_new()
+    aff_add(&!scorr, &x, &ysh)
+    var sind = aff_new()
+    aff_add(&!sind, &x, &yin)
+    if approx(aff_variance(&scorr), 0.16) { print("Var(x+y) correlated=0.16: PASS") }
+    else { print("correlated sum: FAIL"); ok = false }
+    if approx(aff_variance(&sind), 0.08) { print("Var(x+y) independent=0.08: PASS") }
+    else { print("independent sum: FAIL"); ok = false }
+
+    // (3) binary product: first-order coeff + lumped second-order rough
+    var va: [f64; 8] = [0.0; 8]
+    va[0] = 1.0
+    var da: [f64; 8] = [0.0; 8]
+    da[1] = 0.3
+    var a = aff_new()
+    aff_leaf(&!a, &va, 0, &da)
+    var vb: [f64; 8] = [0.0; 8]
+    vb[2] = 1.0
+    var db: [f64; 8] = [0.0; 8]
+    db[3] = 0.1
+    var b = aff_new()
+    aff_leaf(&!b, &vb, 1, &db)
+    var ab = aff_new()
+    aff_mul(&!ab, &a, &b)
+    var s0: [f64; 8] = [0.0; 8]
+    aff_get_sym(&ab, 0, &!s0)
+    if approx(oct_norm_sq(&s0), 0.09) { print("product first-order coeff=0.09: PASS") }
+    else { print("product first order: FAIL"); ok = false }
+    if approx(aff_variance(&ab), 0.1009) { print("product Var=0.1009 (incl. rough): PASS") }
+    else { print("product variance: FAIL"); ok = false }
+
+    if ok { print("ALL PASS") } else { print("SOME FAILED") }
+}

--- a/tests/run-pass/perturbation_graph_order_safe.sio
+++ b/tests/run-pass/perturbation_graph_order_safe.sio
@@ -62,5 +62,15 @@ fn main() with Mut, Div, Panic, NonAssoc {
     if approx(pg_variance(&!g3, fabc), 0.75) { print("Fano chain = 0.75: PASS") }
     else { print("Fano: FAIL"); ok = false }
 
+    // CORRELATION HONESTY (affine upgrade): squaring reuses the SAME leaf, so its
+    // single shared noise symbol must be tracked, not double-counted as two
+    // independent leaves. Var(a·a) = (2·a·δa)² = 4·Var(a) = 4·0.25 = 1.0; the old
+    // independence-assuming scalar model would have said ‖a‖²·Var+‖a‖²·Var = 0.5.
+    var g4 = pg_new()
+    let sa  = pg_leaf(&!g4, &e1, 0.5)
+    let saa = pg_mul(&!g4, sa, sa, 1.0)
+    if approx(pg_variance(&!g4, saa), 1.0) { print("squaring a·a = 1.0 (shared symbol): PASS") }
+    else { print("squaring correlation: FAIL"); ok = false }
+
     if ok { print("ALL PASS") } else { print("SOME FAIL") }
 }


### PR DESCRIPTION
Stacked on #273 (base: `feat/assoc-variance-clean`).

Opens the frontier **"independence is a lie, generalized to every `+`/`*`"** — correlated-error affine arithmetic fused with the variance budget, over the non-associative octonions. Three commits, each falsified-green by execution.

## What lands

1. **Affine arithmetic over a non-associative algebra + N=3 demonstrator** (`a34eddec2`)
   - `examples/epistemic/affine_nonassoc_demo.sio` (self-contained, runs green) + design doc.
   - Proves the crux on paper **and** by execution: for a triple product, the ε-coefficient of `((a·b)·c)` and `(a·(b·c))` differ by exactly the associator `[a1,b0,c0]`. Non-associativity is a **distributed, correlated** perturbation of the noise-symbol row, not a scalar add-on.

2. **`AffOct` — correlation-honest affine octonion value type** (`f65b8143c`)
   - `stdlib/epistemic/affine_octonion.sio`: value `x = x0 + Σ d_k·ε_k`; shared symbols = correlation, exact cancellation possible. First-order symbol tracking + a lumped-independent `rough` bucket for the 2nd-order remainder.
   - Exact conditioning `Var(x−x)=0` (not `2·Var(x)`); correlation `4‖d‖²` shared vs `2‖d‖²` independent.

3. **`PerturbGraph` upgraded to correlation-honest** (`2485e103d`)
   - Scalar per-node `pvar[n]` → per-node affine symbol row `psym[n][k]`; structural associator split into an independent scalar `pstruct[n]`.
   - **Key property:** octonions are a composition algebra (‖a·b‖=‖a‖‖b‖), so the first-order product rule **exactly reproduces** the old `nj·Var(i)+ni·Var(j)` on disjoint symbols — the prior scalar model is now provably the *disjoint-symbol special case*. A reused leaf (diamond / squaring) is tracked via its shared symbol instead of double-counted: `Var(a·a)=4·Var(a)`, not `2·Var(a)`.

## Novelty boundary (honest — not rounded up)
A focused prior-art sweep places it precisely: fusing roundoff + epistemic uncertainty in affine arithmetic is **textbook** (Stolfi/de Figueiredo); "associator as uncertainty" exists as a *concept* in non-associative QM (arXiv:1411.3710, as a measurement bound). **No prior art** for affine arithmetic *over a non-associative algebra* with the associator injected as a first-class affine noise symbol. The narrow fused mechanization is the novel residue. See `docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md`.

## Verification & honest residual
All claims verified by building + running self-contained single-file ELFs (the local lean_single `bin/souc` `run` subcommand and stdlib-import resolution are broken; multimodule is the CI/Madaros path). Run-pass tests added/extended for CI:
- `tests/run-pass/affine_octonion_correlation.sio` (new)
- `tests/run-pass/perturbation_graph_order_safe.sio` (extended with the squaring/correlation case)

`PerturbGraph`'s public API is unchanged except added effects (`pg_leaf` +`Div,Panic`, `pg_variance` +`Mut`); its only caller is the order-safe test (no `lib.sio` re-export). **The green CI/Madaros bundle build is the gate for the import path + the effect-signature change** — please treat it as load-bearing on review.

Backward compatibility proven: order-safe `((a·b)·c)==(a·(b·c))==4.75`, Fano `0.75` — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)