### PR TITLE
[stdlib] fix collider d-separation inversion in cat_d_separated

### DIFF
--- a/stdlib/causal/base.sio
+++ b/stdlib/causal/base.sio
@@ -206,9 +206,9 @@ fn cat_d_separated(g: &CausalGraph, x: i32, y: i32, z_set: &[i32; 32], z_count: 
         let in_z = cat_in_set(node, z_set, z_count)
 
         if dir == 0 {
-            // Arrived from parent (ball going down)
+            // Arrived from a PARENT (ball travelling DOWN into node).
             if in_z == false {
-                // Not conditioned: pass through to children
+                // Non-collider (chain/fork), not conditioned: continue DOWN to children.
                 var c = 0
                 while c < g.n_nodes {
                     if g.adj[cg_idx(node, c)] == 1 {
@@ -223,8 +223,11 @@ fn cat_d_separated(g: &CausalGraph, x: i32, y: i32, z_set: &[i32; 32], z_count: 
                     }
                     c = c + 1
                 }
-                // Also pass up to parents (non-collider)
-                c = 0
+            }
+            if has_descendant_in_z(g, node, z_set, z_count) {
+                // node is a COLLIDER on this path AND is conditioned (node or a
+                // descendant in Z): the v-structure is OPEN -> reflect UP to parents.
+                var c = 0
                 while c < g.n_nodes {
                     if g.adj[cg_idx(c, node)] == 1 {
                         let key = c * 2 + 1
@@ -239,30 +242,13 @@ fn cat_d_separated(g: &CausalGraph, x: i32, y: i32, z_set: &[i32; 32], z_count: 
                     c = c + 1
                 }
             }
-            // If in Z: ball is blocked (non-collider conditioned)
         }
 
         if dir == 1 {
-            // Arrived from child (ball going up)
+            // Arrived from a CHILD (ball travelling UP into node).
             if in_z == false {
-                // Non-collider, not conditioned: pass to parents
-                var c = 0
-                while c < g.n_nodes {
-                    if g.adj[cg_idx(c, node)] == 1 {
-                        let key = c * 2 + 1
-                        if key < 256 {
-                            if visited[key] == 0 {
-                                visited[key] = 1
-                                queue[tail] = key
-                                tail = tail + 1
-                            }
-                        }
-                    }
-                    c = c + 1
-                }
-            }
-            if in_z {
-                // Collider conditioned on: pass to parents AND children
+                // Non-collider, not conditioned: ball passes UP to parents
+                // and DOWN to children (open chain/fork).
                 var c = 0
                 while c < g.n_nodes {
                     if g.adj[cg_idx(c, node)] == 1 {
@@ -292,6 +278,7 @@ fn cat_d_separated(g: &CausalGraph, x: i32, y: i32, z_set: &[i32; 32], z_count: 
                     c = c + 1
                 }
             }
+            // If in Z: conditioned non-collider blocks the ball.
         }
     }
     return true  // ball never reached y

--- a/tests/run-pass/causal_dsep_canonical.sio
+++ b/tests/run-pass/causal_dsep_canonical.sio
@@ -1,0 +1,51 @@
+//@ run-pass
+//@ description: d-separation (Bayes-ball) correctness across the three canonical
+//@ structures — chain, collider, confounder. Regression guard for the collider
+//@ inversion bug (conditioning must BLOCK a chain/fork but OPEN a collider).
+
+use causal::base::*
+
+// returns 1 on failure, 0 on success (so main can sum)
+fn expect(label: &[u8; 64], got: bool, want: bool) -> i32 with IO {
+    if got == want { return 0 }
+    println("FAIL")
+    return 1
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    var fails: i32 = 0
+    var none: [i32; 32] = [0; 32]
+    var lab: [u8; 64] = [0; 64]
+
+    // ── Chain  X(0) -> M(1) -> Y(2) ──
+    var chain = cg_new(3)
+    cg_add_edge(&!chain, 0, 1)
+    cg_add_edge(&!chain, 1, 2)
+    var zm: [i32; 32] = [0; 32]
+    zm[0] = 1
+    fails = fails + expect(&lab, cat_d_separated(&chain, 0, 2, &none, 0), false) // open
+    fails = fails + expect(&lab, cat_d_separated(&chain, 0, 2, &zm, 1), true)    // mediator blocks
+
+    // ── Collider  X(0) -> C(2) <- Y(1) ──
+    var coll = cg_new(3)
+    cg_add_edge(&!coll, 0, 2)
+    cg_add_edge(&!coll, 1, 2)
+    var zc: [i32; 32] = [0; 32]
+    zc[0] = 2
+    fails = fails + expect(&lab, cat_d_separated(&coll, 0, 1, &none, 0), true)   // collider blocks
+    fails = fails + expect(&lab, cat_d_separated(&coll, 0, 1, &zc, 1), false)    // conditioning OPENS
+
+    // ── Confounder  X(0) <- C(2) -> Y(1) ──
+    var conf = cg_new(3)
+    cg_add_edge(&!conf, 2, 0)
+    cg_add_edge(&!conf, 2, 1)
+    fails = fails + expect(&lab, cat_d_separated(&conf, 0, 1, &none, 0), false)  // confounded
+    fails = fails + expect(&lab, cat_d_separated(&conf, 0, 1, &zc, 1), true)     // adjust closes backdoor
+
+    if fails == 0 {
+        println("ALL PASS: d-separation canonical (chain/collider/confounder)")
+        return 0
+    }
+    println("d-separation regression FAILED")
+    return 1
+}


### PR DESCRIPTION
The Bayes-ball `dir==0`/`dir==1` cases in `cat_d_separated` were swapped: an unconditioned node arriving from a parent wrongly reflected up to its parents (the collider path), and collider-activation sat in the from-child branch. Net effect: colliders were inverted (X→C←Y read as d-connected with no conditioning, d-separated when conditioning on C).

Correct Bayes-ball:
- from parent (down): pass to children iff node ∉ Z; reflect up to parents iff node-or-descendant ∈ Z (now uses the previously-dead `has_descendant_in_z`).
- from child (up): pass to parents and children iff node ∉ Z; else block.

Adds `tests/run-pass/causal_dsep_canonical.sio` (chain/collider/confounder) as a regression guard — the in-file `test_collider_dsep` existed but was wired to no runner, which is why the inversion went unnoticed.

Surfaced while building the Beagle Sounio Inference Service (first production use of the language).