### PR TITLE
[codegen] exit_group(231) for program exit — fixes GPU teardown-hang

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -22647,9 +22647,13 @@ fn compile_all() -> i64 with IO, Mut, Panic, Div {
         em(0xe8)
         let rel = FN_OFF[main_fn as usize] - (CL + 4)
         em32(rel)
-        // exit(rax): Linux syscall 60
+        // exit_group(rax): Linux syscall 231 — terminates ALL threads.
+        // SYS_exit (60) ends only the calling (main) thread, so when a program
+        // dlopen's libcuda (which spawns CUDA driver background threads) the
+        // process hangs after main returns. exit_group reaps every thread,
+        // fixing the GPU teardown-hang. Strictly more correct for all programs.
         em(0x89); em(0xc7)
-        em(0xb8); em32(60)
+        em(0xb8); em32(231)
         em(0x0f); em(0x05)
     }
 


### PR DESCRIPTION
The x86-64 program epilogue in `lean_single.sio` emitted **SYS_exit (60)**, which terminates only the calling thread. A program that `dlopen`s `libcuda.so.1` inherits the CUDA driver's background threads, so after `main` returns the process **hangs** (main thread gone, driver threads alive). Switch the final exit to **exit_group (231)**, which reaps every thread.

**Found and verified by running real GPU code:** a souc-compiled `gpu_vec_add` kernel on an NVIDIA L4 (sm_89, same arch as the RTX 4000 Ada) — before: printed `PASS` then hung (timeout exit 124); after rebuilding souc with this fix: prints `PASS` and exits 0 cleanly. Strictly more correct for any multithreaded program; no behavior change for single-threaded ones.

NB: the checked-in `bin/souc-linux-x86_64` must be regenerated through the normal bootstrap/sign pipeline for the fix to take effect in the canonical artifact.