### PR TITLE
[scripts] erdos_lean_pipeline: private mktemp dir (fix insecure /tmp)

### DIFF
--- a/scripts/run_erdos_lean_pipeline.sh
+++ b/scripts/run_erdos_lean_pipeline.sh
@@ -9,18 +9,24 @@ echo ""
 cd /workspace/sounio-erdos
 export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
 
+# Private per-run temp dir (mode 700) — avoids predictable /tmp path,
+# symlink clobber and TOCTOU (CWE-377/59/367).
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+PROOF_FILE="$TMP_DIR/erdos_proofs.lean"
+
 echo "1. Running Sounio to emulate GPU kernel and generate formal proofs..."
-./bin/souc run examples/erdos_straus_gpu_lean.sio > /tmp/erdos_proofs.lean
+./bin/souc run examples/erdos_straus_gpu_lean.sio > "$PROOF_FILE"
 
 echo "2. GPU execution complete. Generated Lean 4 file:"
-head -15 /tmp/erdos_proofs.lean
+head -15 "$PROOF_FILE"
 echo "..."
-tail -3 /tmp/erdos_proofs.lean
+tail -3 "$PROOF_FILE"
 
 echo ""
 echo "3. Invoking Lean 4 to formally verify all GPU witnesses..."
 # Lean 4 compiler check (will fail if `by decide` cannot prove the theorem)
-lean /tmp/erdos_proofs.lean
+lean "$PROOF_FILE"
 
 echo ""
 echo "✅ All GPU witnesses formally verified by Lean 4!"


### PR DESCRIPTION
`run_erdos_lean_pipeline.sh` wrote+read `/tmp/erdos_proofs.lean` — a predictable path. A local attacker could pre-create a symlink there to clobber/redirect the generated Lean proofs or race producer vs consumer (CWE-377 insecure temp file / CWE-59 symlink following / CWE-367 TOCTOU).

Fix: per-run `$(mktemp -d)` (mode 700) + `trap 'rm -rf' EXIT`, write/read via `$PROOF_FILE`. Removes the predictable path, the symlink target, and the TOCTOU window. No functional change; `bash -n` clean.

Flagged by the automated push security review.