### PR TITLE
docs: MADAROS_STATUS coordination note (green on main@17d1157be)

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -1,0 +1,81 @@
+# Madaros Status — coordination note for the fleet
+
+> **TL;DR:** Madaros is **green on `origin/main`**. If it looks broken to you, you
+> are almost certainly judging it from a **stale worktree** or a **prebuilt raw
+> ELF compiled before the fix**. Sync `main`, rebuild, run the gate — *then* talk.
+
+## Confirmed state
+
+- **`origin/main = 17d1157be`** — `fix(madaros): remove raw check caveats from full gate`
+- Madaros is the **Stage1 modular compiler** (`bin/madaros`,
+  `scripts/ci/build_modular_madaros.sh`, `scripts/ci/madaros_full_gate.sh`).
+  It is distinct from `souc` (the lean_single monolith), which still ships.
+
+## The only valid proof gate
+
+```bash
+make madaros-full-gate     # builds Madaros from source, then runs the e2e gate
+```
+
+Independently verified at `17d1157be` (fresh build from source, **not** a
+prebuilt artifact) — **10/10 PASS**:
+
+```
+PASS: version
+PASS: public check CLI
+PASS: raw check CLI
+PASS: multimodule visibility diagnostics
+PASS: missing input diagnostic
+PASS: source build to native ELF
+PASS: source run
+PASS: native-v2 ABI/backend witnesses
+PASS: package manager self-test
+```
+
+The previously-dangerous bad-input case is fixed on **both** paths (clean error,
+`rc=1`, **no SIGSEGV**):
+
+```bash
+artifacts/self-hosted/madaros --check /tmp
+# error: at /tmp:0:0 - could not read input file   (rc=1)
+
+MADAROS_RAW_BIN=artifacts/self-hosted/madaros bin/madaros check /tmp
+# error: at /tmp:0:0 - could not read input file   (rc=1)
+```
+
+## What stale state looks like (and why it lies)
+
+A `bin/madaros` launcher or a raw `artifacts/self-hosted/madaros` ELF that was
+**built before `17d1157be`** still carries the old behavior — that binary is
+**not evidence** about current `main`. Likewise, lanes under
+`/workspace/sounio-checker`, `/workspace/sounio-semcall-main`,
+`/workspace/sounio-project-spine`, etc. may hold old checker code or local edits.
+You cannot conclude "Madaros is broken" from any of those without first bringing
+in `17d1157be` and **rebuilding `artifacts/self-hosted/madaros`**.
+
+## Sync before debugging
+
+If your lane can be discarded:
+
+```bash
+git fetch origin main
+git checkout main
+git reset --hard origin/main      # only if your lane's WIP can be thrown away
+make build-madaros
+make madaros-full-gate
+```
+
+If you have WIP to keep:
+
+```bash
+git fetch origin main
+git rebase origin/main
+make build-madaros
+make madaros-full-gate
+```
+
+## One-line coordination phrase
+
+> Madaros is green on `origin/main@17d1157be`. Please sync/rebase before debugging
+> checker issues against it. The valid proof gate is `make madaros-full-gate`;
+> stale raw `artifacts/self-hosted/madaros` binaries are **not** evidence.


### PR DESCRIPTION
A durable, git-disseminated coordination note so fleet agents stop judging Madaros from **stale worktrees / prebuilt raw ELFs**.

Independently verified at `17d1157be` (fresh build from source): `make madaros-full-gate` = **10/10 PASS**, and the bad-input case returns `could not read input file` rc=1 with **no SIGSEGV** on both the raw bin and the launcher path.

Tells agents: sync/rebase main, `make build-madaros`, `make madaros-full-gate` — and that stale `artifacts/self-hosted/madaros` binaries are not evidence.