### PR TITLE
[codex] cover Madaros tmp directory check in full gate

### DIFF
--- a/docs/status/madaros_main_proof_17d115.md
+++ b/docs/status/madaros_main_proof_17d115.md
@@ -1,0 +1,80 @@
+# Madaros Main Proof - 17d1157be
+
+Date: 2026-06-14
+
+Worktree:
+
+- Path: `/workspace/sounio-madaros-main-proof`
+- Branch: `codex/madaros-main-proof-17d115`
+- Base: `origin/main`
+- Commit: `17d1157be540d32bb583dd03ca7072a6026e2027`
+- Subject: `fix(madaros): remove raw check caveats from full gate`
+
+## Rebuild Proof
+
+Command:
+
+```bash
+make build-madaros
+```
+
+Result:
+
+- `build_madaros_rc=0`
+- Produced `artifacts/self-hosted/madaros`
+- Size observed after rebuild: `82M`
+
+## Canonical Full Gate
+
+Command:
+
+```bash
+make madaros-full-gate
+```
+
+Results:
+
+- `madaros_full_gate_rc=0` before adding literal `/tmp` directory checks.
+- `madaros_full_gate_with_tmp_rc=0` after adding literal `/tmp` directory checks to `scripts/ci/madaros_full_gate.sh`.
+
+The updated gate output ended with:
+
+```text
+[madaros-full] PASS: version
+[madaros-full] PASS: public check CLI
+[madaros-full] PASS: raw check CLI
+[madaros-full] PASS: multimodule visibility diagnostics
+[madaros-full] PASS: missing input diagnostic
+[madaros-full] PASS: source build to native ELF
+[madaros-full] PASS: source run
+[madaros-full] PASS: native-v2 ABI/backend witnesses
+[madaros-full] PASS: package manager self-test
+[madaros-full] PASS: public CLI, source ELF path, ABI witnesses, visibility, and pkg self-test
+```
+
+## Dangerous `/tmp` Check
+
+Commands:
+
+```bash
+artifacts/self-hosted/madaros --check /tmp
+MADAROS_RAW_BIN=artifacts/self-hosted/madaros bin/madaros check /tmp
+```
+
+Manual results before the gate update:
+
+- Raw binary: `raw_tmp_rc=1`
+- Wrapper with explicit raw binary: `wrapper_tmp_rc=1`
+- Both emitted:
+
+```text
+error: at /tmp:0:0 - could not read input file
+```
+
+No SIGSEGV was observed.
+
+These exact cases are now covered by `make madaros-full-gate`.
+
+## Coordination Rule
+
+Madaros is green on `origin/main@17d1157be`. Agents must fetch/rebase or reset to that commit, rebuild `artifacts/self-hosted/madaros`, and run `make madaros-full-gate` before treating checker/Madaros failures as current evidence. Dirty worktrees and stale raw binaries are not evidence against the current Madaros state.

--- a/scripts/ci/madaros_full_gate.sh
+++ b/scripts/ci/madaros_full_gate.sh
@@ -79,6 +79,8 @@ pass "public check CLI"
 expect_log_contains "check: OK" "$WORK/raw_empty.log"
 expect_exit 1 "$RAW_MADAROS" --check "$WORK/missing.sio" >"$WORK/raw_missing.log" 2>&1
 expect_log_contains "could not read input file" "$WORK/raw_missing.log"
+expect_exit 1 "$RAW_MADAROS" --check /tmp >"$WORK/raw_tmp_dir.log" 2>&1
+expect_log_contains "could not read input file" "$WORK/raw_tmp_dir.log"
 pass "raw check CLI"
 
 "$MADAROS" check tests/multimodule/visibility_struct_pub_main.sio >"$WORK/visibility_struct_pub.log" 2>&1
@@ -98,6 +100,8 @@ pass "multimodule visibility diagnostics"
 
 expect_exit 1 "$MADAROS" check "$WORK/missing.sio" >"$WORK/missing.log" 2>&1
 expect_log_contains "could not read input file" "$WORK/missing.log"
+expect_exit 1 env MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" check /tmp >"$WORK/wrapper_tmp_dir.log" 2>&1
+expect_log_contains "could not read input file" "$WORK/wrapper_tmp_dir.log"
 pass "missing input diagnostic"
 
 "$MADAROS" build "$WORK/run0.sio" -o "$WORK/run0.elf" >"$WORK/build.log" 2>&1


### PR DESCRIPTION
## Summary

- Adds the literal `/tmp` directory checks to `scripts/ci/madaros_full_gate.sh` for both the raw Madaros ELF and the public wrapper path with `MADAROS_RAW_BIN`.
- Adds `docs/status/madaros_main_proof_17d115.md` recording the clean rebuild/full-gate proof for `origin/main@17d1157be` and the coordination rule for stale worktrees/artifacts.

## Why

`origin/main@17d1157be` is green for the Madaros full gate, but several active worktrees are stale, dirty, or using prebuilt raw artifacts. The dangerous `/tmp` check had been manually verified, but was not literally part of `make madaros-full-gate`. This PR makes that proof executable in the canonical gate.

## Validation

Run from `/workspace/sounio-madaros-main-proof`:

- `make build-madaros` -> `build_madaros_rc=0`
- `make madaros-full-gate` before the gate change -> `madaros_full_gate_rc=0`
- `artifacts/self-hosted/madaros --check /tmp` -> `raw_tmp_rc=1`, clean `could not read input file`
- `MADAROS_RAW_BIN=artifacts/self-hosted/madaros bin/madaros check /tmp` -> `wrapper_tmp_rc=1`, clean `could not read input file`
- `bash -n scripts/ci/madaros_full_gate.sh` -> `0`
- `make madaros-full-gate` after the gate change -> `madaros_full_gate_with_tmp_rc=0`
- `git diff --check` -> `0`

## Notes

No LLM offload was invoked: this changes compiler gate coverage and status documentation only; it does not touch math claims, clinical-pathway code, or external-facing scientific claims.
