### PR TITLE
ci(madaros): weekly + on-demand refresh of prebuilt bin/madaros-linux-x86_64

### DIFF
--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -1,0 +1,79 @@
+name: Madaros Prebuilt Refresh
+
+# Keeps the checked-in Madaros default (bin/madaros-linux-x86_64) current with
+# self-hosted/compiler/main.sio. The binary is ~86 MB and git has no LFS, so this
+# runs on a WEEKLY schedule (and on-demand) rather than per push — bounded history
+# growth, ~one 86 MB blob per week at most, and only when the binary actually
+# changed. Triggers are schedule + manual dispatch only, so the commit-back never
+# re-triggers this workflow; the commit also carries [skip ci] so the binary bump
+# does not spin up the full CI suite.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: madaros-prebuilt-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Rebuild and commit bin/madaros-linux-x86_64
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Build Madaros and run the full gate
+        run: |
+          export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+          # build-madaros seeds from the committed lean_single ELF (not the
+          # bin/souc wrapper) and the gate fails the job if the build is bad,
+          # so we never commit a broken binary.
+          make madaros-full-gate
+
+      - name: Install built Madaros as the checked-in prebuilt
+        run: |
+          test -s artifacts/self-hosted/madaros
+          cp artifacts/self-hosted/madaros bin/madaros-linux-x86_64
+          chmod +x bin/madaros-linux-x86_64
+
+      - name: Commit and push if the prebuilt changed
+        run: |
+          if git diff --quiet -- bin/madaros-linux-x86_64; then
+            echo "bin/madaros-linux-x86_64 is unchanged — nothing to commit."
+            exit 0
+          fi
+
+          SRC_REF="$(git rev-parse --short HEAD)"
+          BYTES="$(wc -c < bin/madaros-linux-x86_64)"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bin/madaros-linux-x86_64
+          git commit -m "build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]
+
+          Auto-rebuilt from ${SRC_REF} via 'make madaros-full-gate' (all checks
+          passed). Keeps the out-of-box Madaros default in lockstep with
+          self-hosted/compiler/main.sio. Binary size: ${BYTES} bytes."
+
+          # Land on the latest main (it may have advanced during the build).
+          # The binary is a generated artifact, so a rebase is normally clean.
+          for attempt in 1 2 3; do
+            git fetch origin main
+            if git rebase origin/main && git push origin HEAD:main; then
+              echo "Refreshed prebuilt pushed to main (attempt ${attempt})."
+              exit 0
+            fi
+            git rebase --abort 2>/dev/null || true
+            echo "push attempt ${attempt} failed; retrying after fetch…" >&2
+            sleep 5
+          done
+          echo "ERROR: could not push refreshed prebuilt after 3 attempts." >&2
+          exit 1


### PR DESCRIPTION
Keeps the shipped `bin/madaros-linux-x86_64` (the out-of-box Madaros default) current with `self-hosted/compiler/main.sio`, so it doesn't silently drift.

## Design (operator-chosen cadence: weekly + manual)
`.github/workflows/madaros-prebuilt-refresh.yml`:
- **Triggers:** weekly `schedule` (Mon 06:00 UTC) + `workflow_dispatch` (manual). **No push trigger** → the commit-back can't re-trigger the workflow.
- **Build:** `make madaros-full-gate` — builds Madaros seed-decoupled (from the committed lean_single ELF, not the `bin/souc` wrapper) and runs the 9-check gate. A bad build **fails the job**, so a broken binary is never committed.
- **Commit-back:** copies the built ELF to `bin/madaros-linux-x86_64` and commits **only if it changed**, with `[skip ci]` (so the binary bump doesn't spin up full CI). Rebases onto latest `main` with a small retry loop for mid-build races. Needs `permissions: contents: write`.

## Why weekly, not per-push
The binary is ~86 MB and changes on most codegen commits; git has no LFS here. Per-push commit would add GBs of history per week. Weekly bounds it to ~one 86 MB blob/week, only when actually changed.

## Validation
- YAML structure matches the existing `release-gate.yml` shape; no tabs.
- Repo's own `check_workflow_script_refs.sh` gate passes.
- Embedded commit-step bash syntax-checked (`bash -n`).
- The build/gate/copy path is the same one verified green this session.

First run can be triggered manually (`workflow_dispatch`) to confirm runner build time/RAM fit before relying on the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)