### PR TITLE
ci(madaros): green-skip prebuilt refresh when the gate fails on a broken main

### DIFF
--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -30,21 +30,36 @@ jobs:
         with:
           ref: main
 
-      - name: Build Madaros and run the full gate
+      - name: Build Madaros (seed-decoupled)
         run: |
           export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
-          # build-madaros seeds from the committed lean_single ELF (not the
-          # bin/souc wrapper) and the gate fails the job if the build is bad,
-          # so we never commit a broken binary.
-          make madaros-full-gate
+          # Seeds from the committed lean_single ELF (not the bin/souc wrapper).
+          # A build/infra failure here is a real problem -> fail the job (red).
+          make build-madaros
+          test -s artifacts/self-hosted/madaros
+
+      - name: Gate the built Madaros
+        id: gate
+        run: |
+          export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+          # A GATE failure means current main's Madaros is not shippable (often
+          # because main itself is broken) -> do NOT fail the job and do NOT
+          # commit; keep the last-good prebuilt. Only a green gate refreshes.
+          if bash scripts/ci/madaros_full_gate.sh; then
+            echo "passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Madaros full gate did not pass on current main — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
+          fi
 
       - name: Install built Madaros as the checked-in prebuilt
+        if: steps.gate.outputs.passed == 'true'
         run: |
-          test -s artifacts/self-hosted/madaros
           cp artifacts/self-hosted/madaros bin/madaros-linux-x86_64
           chmod +x bin/madaros-linux-x86_64
 
       - name: Commit and push if the prebuilt changed
+        if: steps.gate.outputs.passed == 'true'
         run: |
           if git diff --quiet -- bin/madaros-linux-x86_64; then
             echo "bin/madaros-linux-x86_64 is unchanged — nothing to commit."
@@ -59,8 +74,8 @@ jobs:
           git add bin/madaros-linux-x86_64
           git commit -m "build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]
 
-          Auto-rebuilt from ${SRC_REF} via 'make madaros-full-gate' (all checks
-          passed). Keeps the out-of-box Madaros default in lockstep with
+          Auto-rebuilt from ${SRC_REF} (make build-madaros) and passed the
+          Madaros full gate. Keeps the out-of-box Madaros default current with
           self-hosted/compiler/main.sio. Binary size: ${BYTES} bytes."
 
           # Land on the latest main (it may have advanced during the build).


### PR DESCRIPTION
Refines the weekly Madaros-prebuilt-refresh workflow (#300) based on a manual `workflow_dispatch` verification run.

## What the verification found
The runner **built Madaros fine** (RAM/time/seed all OK) but `madaros_full_gate.sh` **failed** (`run0.elf` exit 200) because **current `main`'s source has regressed** (4 `match must be exhaustive` errors in `resolve.sio` vs 1 in the last good build; consistent with `main`'s CI being red all day). The commit-back was correctly skipped — but the *job went red*.

## Change
Split the single `make madaros-full-gate` step into:
- **Build** (`make build-madaros`) — a real build/infra break still **fails the job (red)**.
- **Gate** (`madaros_full_gate.sh`) — a gate failure (current main not shippable) is now a **green soft-skip**: logs a `::warning::`, keeps the last-good prebuilt, and skips the commit via `if: steps.gate.outputs.passed == 'true'`.

Only a green gate refreshes `bin/madaros-linux-x86_64`. This avoids alert-fatigue on the weekly job (main is broken often right now) while preserving the never-commit-a-broken-binary guarantee.

## Validated
- Repo `check_workflow_script_refs.sh` gate passes (fixed a greedy-regex false-positive from an embedded script path in the commit message).
- No tabs; structure matches existing workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)