### PR TITLE
Revert no-op dynamic-frame edit in dead native_v2_core_begin_function_from_ir_into

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6609,10 +6609,7 @@ pub fn native_v2_core_begin_function_from_ir_into(nc: &! NativeCompiler, func: &
     native_compiler_add_symbol_func_ref(nc, fn_index, func)
     nc_emit_push_rbp(nc)
     nc_emit_mov_rbp_rsp(nc)
-    let frame_sz = align16((*func).reg_count * 8)
-    if frame_sz > 0 {
-        nc_emit_sub_rsp_imm32(nc, frame_sz)
-    }
+    nc_emit_sub_rsp_imm32(nc, 512)
 }
 
 pub fn native_v2_core_emit_load_imm_into(nc: &! NativeCompiler, dst: i64, value: i64) with Mut, Panic, Div {


### PR DESCRIPTION
Reverts the `7fa3c3524` no-op (dead function, zero call sites — still dead on main) from `sub rsp,512` → `align16` back to `sub rsp,512`. Behaviorally null (dead code); removes a misleading 'fix' and realigns the dead twin with its live sibling. Live emitters' dynamic frames untouched. Fresh on current main, superseding the stale closed PR #303. The real stack-overflow fix landed separately as 5b42e985b.