### PR TITLE
chore(repo): hygiene baseline — gitignore, editorconfig, policy doc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,38 @@
+# EditorConfig — consistent formatting across editors. https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# Sounio source
+[*.sio]
+indent_size = 4
+
+[*.{rs,c,h}]
+indent_size = 4
+
+[*.lean]
+indent_size = 2
+
+[*.{js,mjs,ts,tsx,jsx,json,astro}]
+indent_size = 2
+
+[*.{yml,yaml,toml}]
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.sh]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,17 @@ data/external/openesm/
 .g1gate/
 docs/audit/g1_wip/mc_g2c.elf
 .dbg/
+
+# ── Repo hygiene (chore/repo-hygiene) ───────────────────────────────────────
+# Local rebuild/seed binary scratch — never commit; reproducible from source.
+bin/*.new
+bin/*.prev*
+bin/*.backup.*
+# Timestamped/ad-hoc backups anywhere (e.g. *.backup.20260616).
+*.backup.*
+# Build output trees (no tracked content; tool-generated).
+logs/
+target/
+build/
+# Processed data products — regenerable from data/raw + scripts; large/churny.
+data/processed/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,14 @@ Sounio enforces a pre-commit peer review audit by external AI engines on math, c
 
 ---
 
+## Repository hygiene
+
+Branch, worktree, and file-commit conventions (and why binaries don't belong in
+source history) live in **[docs/REPO_HYGIENE.md](docs/REPO_HYGIENE.md)**. Please
+read it before opening a PR.
+
+---
+
 ## License
 
 By contributing to Sounio, you agree that your contributions will be licensed under the **Apache License, Version 2.0** (with copyright assigned to Sounio Language Project).

--- a/docs/REPO_HYGIENE.md
+++ b/docs/REPO_HYGIENE.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.repo-hygiene
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.repo-hygiene
+-->
+
 # Repository hygiene
 
 Conventions that keep Sounio reviewable as it scales across many contributors

--- a/docs/REPO_HYGIENE.md
+++ b/docs/REPO_HYGIENE.md
@@ -1,0 +1,63 @@
+# Repository hygiene
+
+Conventions that keep Sounio reviewable as it scales across many contributors
+and automated agents. This is policy, not just cleanup — please follow it.
+
+## Branches
+
+- **Naming:** `type/slug` — `feat/`, `fix/`, `chore/`, `docs/`, `ci/`,
+  `refactor/`, `perf/`, `research/`. Keep slugs short and descriptive.
+- **Lifecycle:** branch from `main`, open a PR, **squash-merge**, then **delete
+  the branch** (GitHub does this automatically; `--delete-branch` locally).
+- **Don't let branches accumulate.** A merged PR's branch is dead — delete it.
+  Stale unmerged branches should be revived into a PR or dropped.
+- Cross-reference *merged PRs*, not just `git branch --merged`, when pruning:
+  a squash-merged branch's commits are **not** ancestors of `main`, so it shows
+  as "not merged" even though it is fully integrated.
+
+## Worktrees
+
+Parallel work (multiple agents/features) uses `git worktree`, not branch
+switching in a shared checkout.
+
+- **Never `git checkout` a different branch in a checkout another worker uses.**
+  Switching the shared tree pulls files out from under in-flight work. Add a
+  dedicated worktree instead: `git worktree add ../sounio-<slug> <branch>`.
+- **Clean up when done:** `git worktree remove <path>` (no `--force`; it refuses
+  if dirty, which is the point). Then `git worktree prune`.
+- **Hygiene passes use git's safe guards only** — `git worktree prune`,
+  `git branch -d` (never `-D`), `git worktree remove` without `--force`. Force
+  is the line between safe and destructive; don't cross it in a sweep. Removing
+  even a clean worktree *directory* can break an agent `cd`'d into it, so live
+  directory removal is owner-approved, not automatic.
+
+## Files that must not be committed
+
+Binaries and large/generated artifacts do not belong in source history.
+`.gitignore` enforces this for new files; the categories:
+
+- Build output: `target/`, `build/`, `logs/`, `dist/`.
+- Local seed/rebuild scratch: `bin/*.new`, `bin/*.prev*`, `bin/*.backup.*`,
+  any `*.backup.*`.
+- Generated data products: `data/processed/`, `artifacts/` (large, regenerable).
+
+If you genuinely need a checked-in binary (e.g. a bootstrap seed compiler), it
+belongs in **Git LFS**, not the main object store.
+
+## Known debt (tracked separately)
+
+- **Large binaries already in history** (e.g. a ~90 MB `bin/` seed, multi-MB
+  `artifacts/` blobs). Removing these is a *coordinated, scheduled* operation
+  (`git lfs migrate` / history rewrite + force-push across all branches and
+  worktrees) — **not** an unsupervised hygiene change. Do not `filter-repo` ad
+  hoc; it breaks every outstanding branch and worktree.
+- **CI:** keep `main` green. Checks failing on `main` itself are tracked as
+  issues; a PR that does not *add* failures relative to `main` is not blocked by
+  pre-existing red, but the goal is zero red.
+
+## PRs
+
+- One logical change per PR; scope the diff (don't sweep unrelated dirty files).
+- Describe what was verified. If CI is red, state whether it's pre-existing on
+  `main` or introduced by the PR.
+- Co-authored/automated commits: keep trailers; squash to a clean message.

--- a/docs/REPO_HYGIENE.md
+++ b/docs/REPO_HYGIENE.md
@@ -50,7 +50,8 @@ belongs in **Git LFS**, not the main object store.
   `artifacts/` blobs). Removing these is a *coordinated, scheduled* operation
   (`git lfs migrate` / history rewrite + force-push across all branches and
   worktrees) — **not** an unsupervised hygiene change. Do not `filter-repo` ad
-  hoc; it breaks every outstanding branch and worktree.
+  hoc; it breaks every outstanding branch and worktree. Full coordinated
+  procedure: **[REPO_LFS_MIGRATION.md](REPO_LFS_MIGRATION.md)**.
 - **CI:** keep `main` green. Checks failing on `main` itself are tracked as
   issues; a PR that does not *add* failures relative to `main` is not blocked by
   pre-existing red, but the goal is zero red.

--- a/docs/REPO_LFS_MIGRATION.md
+++ b/docs/REPO_LFS_MIGRATION.md
@@ -1,0 +1,93 @@
+# Runbook: migrate large binaries out of git history (Git LFS)
+
+**Status: planned, not executed.** This is a *coordinated, scheduled* operation —
+it rewrites history and force-pushes every ref, which breaks every outstanding
+branch, PR, and worktree. Do not run it ad hoc. Read all of it first.
+
+## Why
+
+The repo carries large binaries/artifacts in history, which bloats every clone
+and fetch. Worst offenders (tracked, `git ls-tree -r -l HEAD | sort -k4 -nr`):
+
+| size | path | disposition |
+|------|------|-------------|
+| ~90 MB | `bin/madaros-linux-x86_64` | seed binary → **LFS** (or drop; regenerable from source) |
+| ~77 MB | `artifacts/research/eeg_hessian/sliding_seizure_manifest.tsv` | generated → **purge** (regenerable) |
+| ~43 MB | `artifacts/omega/native_backend_v2_scalar_smoke.aarch64-macos.bin` | generated → **purge** |
+| ~29 MB | `formal/lean4/SounioSatG529.lean` | source-ish (generated cert) → keep or LFS |
+| ~26 MB | `docs/training/finetune/sounio_corpus.txt` | data → **LFS** or external |
+| 5–17 MB | `datasets/*.jsonl`, `artifacts/llm_training/*`, brand PDFs/SVGs | data/assets → **LFS** |
+
+~1269 files live under `bin/` + `artifacts/` total. `artifacts/` is already
+`.gitignore`d, so most were force-added or pre-date the ignore — they should be
+purged from history, not just untracked.
+
+## Decision rule
+
+- **Regenerable from source/scripts** (most of `artifacts/`, processed data,
+  smoke `.bin`s) → **purge from history** (`git filter-repo --path ... --invert-paths`),
+  keep ignored going forward.
+- **Genuinely needed checked-in binaries** (e.g. a bootstrap seed compiler) →
+  **track in LFS** (`git lfs migrate import`).
+- When unsure, prefer purge + a documented regeneration command over LFS.
+
+## Preconditions (do these first)
+
+1. **Branch/PR cleanup** — fewer refs = less to rewrite and re-push. Land or
+   close the stale PRs and prune merged branches *before* the rewrite.
+2. **Announce a freeze window.** No merges/pushes during the rewrite.
+3. **Enable Git LFS** on the GitHub repo (Settings → confirm LFS + check the
+   storage/bandwidth quota for the sizes above).
+4. Inventory and **record every open PR's head SHA** (so PRs can be re-pushed and
+   reopened if the rewrite changes their refs):
+   `gh pr list --state open --limit 400 --json number,headRefName,headRefOid > pr_snapshot.json`
+
+## Procedure (mirror clone — never on a working clone)
+
+```bash
+# 0. Fresh mirror (history-only; no worktrees attached)
+git clone --mirror git@github.com:Sounio-lang/sounio.git sounio-rewrite.git
+cd sounio-rewrite.git
+
+# 1a. PURGE regenerable artifacts from all history
+#     (install: pipx install git-filter-repo)
+git filter-repo --invert-paths \
+  --path artifacts/research/eeg_hessian/sliding_seizure_manifest.tsv \
+  --path artifacts/omega/native_backend_v2_scalar_smoke.aarch64-macos.bin \
+  --path-glob 'artifacts/**'            # scope precisely; review the list first
+
+# 1b. MIGRATE the binaries worth keeping into LFS
+git lfs migrate import --everything \
+  --include="bin/madaros-linux-x86_64,docs/training/finetune/sounio_corpus.txt,datasets/**/*.jsonl"
+
+# 2. Sanity: repo size dropped, history intact for source
+git count-objects -vH
+git log --oneline -5
+
+# 3. Force-push the rewritten history (THIS is the irreversible step)
+git push --force --mirror
+```
+
+## After the rewrite (everyone, mandatory)
+
+- **All clones and worktrees are now invalid** — old history diverged. Each
+  contributor/agent must **re-clone** (worktrees cannot survive a mirror rewrite;
+  delete and recreate them).
+- Commit the enforcement rules on the rewritten `main`:
+  - `.gitattributes` — `*.jsonl filter=lfs diff=lfs merge=lfs -text`, the seed
+    binary path, etc.
+  - `.gitignore` — already hardened (`artifacts/`, `data/processed/`, build dirs).
+- **Re-push and reopen open PRs** from `pr_snapshot.json` if their refs were
+  dropped (PR head branches must be re-pushed against the rewritten base).
+- Bust CI caches that pin old SHAs.
+
+## Risks & rollback
+
+- **Irreversible once force-pushed.** Keep the pre-rewrite mirror
+  (`sounio-rewrite.git` before step 3, plus a server-side backup ref/tag) until
+  the team confirms the new history is good — that is the only rollback.
+- Open PRs across rewritten bases will show as needing re-push; budget time to
+  restore them (cf. the branch-deletion incident — closed/diverged PRs are
+  recoverable from recorded head SHAs, but it's manual).
+- Estimate downtime: with N open PRs + worktrees, the re-clone/re-push tail is
+  the slow part, not the rewrite itself.

--- a/docs/REPO_LFS_MIGRATION.md
+++ b/docs/REPO_LFS_MIGRATION.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.repo-lfs-migration
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.repo-lfs-migration
+-->
+
 # Runbook: migrate large binaries out of git history (Git LFS)
 
 **Status: planned, not executed.** This is a *coordinated, scheduled* operation —

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 729
-- Repo-backed topics: 579
+- Total governed topics: 731
+- Repo-backed topics: 581
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 437
+- Authority count `repo_only`: 439
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 441 topics
+- A2: 443 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -454,6 +454,8 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.reference.epistemic-api | repo_only | docs/reference/EPISTEMIC_API.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.reference.stdlib-reference | repo_only | docs/reference/STDLIB_REFERENCE.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.release-policy | repo_only | docs/RELEASE_POLICY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.repo-hygiene | repo_only | docs/REPO_HYGIENE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.repo-lfs-migration | repo_only | docs/REPO_LFS_MIGRATION.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.associator-spectral-bound-status | historical | docs/research/associator_spectral_bound_status.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.bbb-pbpk-dissertation-chapter | historical | docs/research/bbb_pbpk_dissertation_chapter.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.beta0-octonion-gum-derivation | historical | docs/research/beta0_octonion_gum_derivation.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -9936,6 +9936,52 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.repo-hygiene",
+      "collection": "repo",
+      "repo_doc_path": "docs/REPO_HYGIENE.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.repo-lfs-migration",
+      "collection": "repo",
+      "repo_doc_path": "docs/REPO_LFS_MIGRATION.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.associator-spectral-bound-status",
       "collection": "repo",
       "repo_doc_path": "docs/research/associator_spectral_bound_status.md",


### PR DESCRIPTION
## Summary
Tier-0 repository hygiene — **safe, reversible, no tracked files removed, no history rewrite**. First step toward presenting Sounio as a serious PL repo.

- **`.gitignore` hardening** — ignore local seed/rebuild scratch (`bin/*.new`, `bin/*.prev*`, `bin/*.backup.*`, `*.backup.*`), build output (`logs/ target/ build/`), and generated data (`data/processed/`). Closes the gaps that let `*.backup.20260616` and `data/processed/*.json` sit untracked in working trees.
- **`.editorconfig`** — consistent charset/EOL/indent across `.sio`/Rust/C/Lean/TS/Py/YAML/Make.
- **`docs/REPO_HYGIENE.md`** — branch + worktree + file-commit policy, incl. the squash-merge `--no-merged` caveat, the "hygiene passes use git's safe guards only (no `--force`/`-D`)" rule, and the binaries-in-history debt scoped as a coordinated LFS follow-up.
- **`CONTRIBUTING.md`** — links the policy.

## Deliberately NOT in this PR (owner-approved follow-ups)
These are irreversible / outward-facing / need coordination, tracked in `REPO_HYGIENE.md`:
- Pruning merged remote/local branches (123 local, 112 remote; ~27 merged) and triaging the 28 open PRs.
- Removing stale worktree directories (76 live worktrees — can't auto-distinguish abandoned vs. active).
- Migrating large committed binaries (~90 MB `bin/` seed, multi-MB `artifacts/` blobs) to Git LFS — a scheduled history rewrite + force-push, not an ad-hoc change.

## Note on CI
`main` is currently red on four pre-existing checks (Contracts, Website, Native Self-Host Linux, Metal opcode smoke) independent of this change; this PR touches only ignore rules + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)