### PR TITLE
fix(epistemic): consolidate #273 assoc-variance refinements (drop obsolete module)

### DIFF
--- a/stdlib/epistemic/propagate.sio
+++ b/stdlib/epistemic/propagate.sio
@@ -269,9 +269,10 @@ pub fn product_nonassoc(
     kappa: f64,
 ) -> Epistemic with Mut, Div, Panic, NonAssoc {
     let field = assoc_field_octonion(a, b, c, kappa)
+    let total = af_augmented_variance(base.variance, &field)
     Epistemic {
         val: base.val,
-        variance: af_augmented_variance(base.variance, &field),
+        variance: if total < 0.0 { 0.0 } else { total },   // variance ≥ 0 (guards κ<0 / FP drift)
         confidence: base.confidence,
     }
 }


### PR DESCRIPTION
Resolves the #273 conflict by consolidating its genuine refinements onto main, dropping the now-obsolete separate module.

## Why #273 conflicted
#273 added `stdlib/epistemic/propagate_nonassoc.sio` as its own module *specifically* to avoid `propagate.sio`'s HOF generics (its own header says so). But **#277** (merged) migrated those generics to fn-pointers, and main already houses `product_nonassoc` in `propagate.sio:266`. So #273's module-extraction is redundant and collides with main.

## What this lands (the real value of #273, minus the dead module)
- **`propagate.sio`**: clamp `product_nonassoc` variance ≥ 0 (guards κ<0 / FP drift)
- **`uncertain_octonion.sio`**: same variance ≥ 0 guard on the mul3 path
- **`perturbation_graph.sio`**: replace the *overclaiming* "order-safe for ANY association" doc with the honest **N≤3** scope (N≥4 is path-dependent → `associator_field::pentagon_variance`)

## Not included
- ❌ `propagate_nonassoc.sio` (duplicate of `propagate.sio:266` post-#277)
- ❌ test re-point to that module (test keeps importing `epistemic::propagate`)

## Verification
`souc check` (lean_single) A/B vs main: **zero new errors** on all three files. The pre-existing multi-module *run-path* failure (E137) is identical on pristine main (6=6) — unrelated to this change.

Closes #273.