### PR TITLE
fix(ci): land sounio-units/formats/io-primitives packages; pin PBPK gate to lean_single

### DIFF
--- a/packages/sounio-formats/docs/README.md
+++ b/packages/sounio-formats/docs/README.md
@@ -1,0 +1,5 @@
+# sounio-formats
+
+Curated package for YAML, TOML, and MessagePack parsers.
+
+Canonical implementations: `stdlib/yaml/`, `stdlib/toml/`, `stdlib/msgpack/`.

--- a/packages/sounio-formats/sounio.toml
+++ b/packages/sounio-formats/sounio.toml
@@ -1,0 +1,35 @@
+[package]
+name = "sounio-formats"
+version = "0.1.0"
+description = "Structured data format parsers: YAML, TOML, and MessagePack"
+authors = ["Sounio Project"]
+license = "Apache-2.0"
+edition = "2026"
+readme = "docs/README.md"
+keywords = ["yaml", "toml", "msgpack", "serialization", "parser"]
+categories = ["encoding", "io", "core"]
+
+[epistemic]
+score = 0.82
+confidence-threshold = 0.80
+provenance-level = "medium"
+gum-compliant = false
+
+[lib]
+path = "src/lib.sio"
+name = "sounio_formats"
+
+[[test]]
+name = "test_yaml_e2e"
+path = "tests/test_yaml_e2e.sio"
+run = true
+
+[[test]]
+name = "test_toml_e2e"
+path = "tests/test_toml_e2e.sio"
+run = true
+
+[[test]]
+name = "test_msgpack_e2e"
+path = "tests/test_msgpack_e2e.sio"
+run = true

--- a/packages/sounio-formats/src/lib.sio
+++ b/packages/sounio-formats/src/lib.sio
@@ -1,0 +1,49 @@
+// packages/sounio-formats/src/lib.sio
+// Package facade — canonical parsers live in stdlib/{yaml,toml,msgpack}/.
+
+pub use yaml::parser::{
+    YAML_STRING,
+    YAML_NUMBER,
+    YAML_BOOL,
+    YAML_NULL,
+    YamlDoc,
+    yaml_doc_new,
+    yaml_parse,
+    yaml_get_string,
+    yaml_get_number,
+    yaml_get_bool,
+    yaml_doc_count,
+    yaml_self_test,
+}
+
+pub use toml::parser::{
+    TOML_STRING,
+    TOML_INTEGER,
+    TOML_FLOAT,
+    TOML_BOOL,
+    TomlDoc,
+    toml_doc_new,
+    toml_parse,
+    toml_get_string,
+    toml_get_number,
+    toml_get_bool,
+    toml_doc_count,
+    toml_self_test,
+}
+
+pub use msgpack::lib::{
+    MsgPackBuf,
+    msgpack_new,
+    msgpack_pack_bool,
+    msgpack_pack_f64,
+    msgpack_pack_fixstr,
+    msgpack_pack_i64,
+    msgpack_pack_nil,
+    msgpack_unpack_bool,
+    msgpack_unpack_bool_advance,
+    msgpack_unpack_f64,
+    msgpack_unpack_f64_advance,
+    msgpack_unpack_i64,
+    msgpack_unpack_i64_advance,
+    msgpack_unpack_type,
+}

--- a/packages/sounio-formats/tests/test_msgpack_e2e.sio
+++ b/packages/sounio-formats/tests/test_msgpack_e2e.sio
@@ -1,0 +1,244 @@
+//@ run-pass
+// tests/stdlib/msgpack/test_msgpack.sio
+//
+// Tests for stdlib/msgpack/lib.sio:
+//   - Pack/unpack i64 round-trip
+//   - Pack/unpack f64 round-trip (zero)
+//   - Pack nil, bool
+//   - Multiple values in one buffer
+
+use msgpack::lib::{
+    MsgPackBuf, msgpack_new,
+    msgpack_pack_nil, msgpack_pack_bool,
+    msgpack_pack_i64, msgpack_pack_f64,
+    msgpack_pack_fixstr,
+    msgpack_unpack_type,
+    msgpack_unpack_i64, msgpack_unpack_i64_advance,
+    msgpack_unpack_f64, msgpack_unpack_f64_advance,
+    msgpack_unpack_bool,
+}
+
+fn run_tests() -> i32 with IO, Mut, Panic, Div {
+    var pass: i32 = 0
+    var fail: i32 = 0
+
+    // -------------------------------------------------------------------------
+    // Test 1: Pack nil
+    // -------------------------------------------------------------------------
+    print("Test 1: pack nil... ")
+    var buf = msgpack_new()
+    buf = msgpack_pack_nil(buf)
+    if buf.len == 1 && (buf.data[0] as i32) == 192 {
+        print("PASS\n")
+        pass = pass + 1
+    } else {
+        print("FAIL\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: Pack bool false
+    // -------------------------------------------------------------------------
+    print("Test 2: pack bool false... ")
+    var buf2 = msgpack_new()
+    buf2 = msgpack_pack_bool(buf2, 0)
+    if buf2.len == 1 && (buf2.data[0] as i32) == 194 {
+        print("PASS\n")
+        pass = pass + 1
+    } else {
+        print("FAIL\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: Pack bool true
+    // -------------------------------------------------------------------------
+    print("Test 3: pack bool true... ")
+    var buf3 = msgpack_new()
+    buf3 = msgpack_pack_bool(buf3, 1)
+    if buf3.len == 1 && (buf3.data[0] as i32) == 195 {
+        print("PASS\n")
+        pass = pass + 1
+    } else {
+        print("FAIL\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: Unpack bool
+    // -------------------------------------------------------------------------
+    print("Test 4: unpack bool... ")
+    let bval = msgpack_unpack_bool(&buf3, 0)
+    if bval == 1 {
+        print("PASS\n")
+        pass = pass + 1
+    } else {
+        print("FAIL\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 5: Pack/unpack positive fixint (42)
+    // -------------------------------------------------------------------------
+    print("Test 5: pack/unpack fixint 42... ")
+    var buf5 = msgpack_new()
+    buf5 = msgpack_pack_i64(buf5, 42)
+    // fixint: 1 byte
+    if buf5.len == 1 {
+        let v = msgpack_unpack_i64(&buf5, 0)
+        if v == 42 {
+            print("PASS\n")
+            pass = pass + 1
+        } else {
+            print("FAIL (wrong value)\n")
+            fail = fail + 1
+        }
+    } else {
+        print("FAIL (wrong length)\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 6: Pack/unpack negative fixint (-1)
+    // -------------------------------------------------------------------------
+    print("Test 6: pack/unpack fixint -1... ")
+    var buf6 = msgpack_new()
+    buf6 = msgpack_pack_i64(buf6, 0 - 1)
+    if buf6.len == 1 {
+        let v6 = msgpack_unpack_i64(&buf6, 0)
+        if v6 == 0 - 1 {
+            print("PASS\n")
+            pass = pass + 1
+        } else {
+            print("FAIL (wrong value)\n")
+            fail = fail + 1
+        }
+    } else {
+        print("FAIL (wrong length)\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 7: Pack/unpack large i64 (1000) via int64 format
+    // -------------------------------------------------------------------------
+    print("Test 7: pack/unpack i64 1000... ")
+    var buf7 = msgpack_new()
+    buf7 = msgpack_pack_i64(buf7, 1000)
+    // 1000 > 127, not negative fixint, so uses int64 format = 9 bytes
+    if buf7.len == 9 {
+        let v7 = msgpack_unpack_i64(&buf7, 0)
+        if v7 == 1000 {
+            print("PASS\n")
+            pass = pass + 1
+        } else {
+            print("FAIL (wrong value)\n")
+            fail = fail + 1
+        }
+    } else {
+        print("FAIL (wrong length)\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 8: Pack/unpack f64 zero round-trip
+    // -------------------------------------------------------------------------
+    print("Test 8: pack/unpack f64 0.0... ")
+    var buf8 = msgpack_new()
+    buf8 = msgpack_pack_f64(buf8, 0.0)
+    // 0xcb + 8 bytes = 9 bytes
+    if buf8.len == 9 {
+        let fv = msgpack_unpack_f64(&buf8, 0)
+        if fv == 0.0 {
+            print("PASS\n")
+            pass = pass + 1
+        } else {
+            print("FAIL (wrong value)\n")
+            fail = fail + 1
+        }
+    } else {
+        print("FAIL (wrong length)\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 9: Pack/unpack f64 non-zero (1.0)
+    // -------------------------------------------------------------------------
+    print("Test 9: pack/unpack f64 1.0... ")
+    var buf9 = msgpack_new()
+    buf9 = msgpack_pack_f64(buf9, 1.0)
+    if buf9.len == 9 {
+        let fv9 = msgpack_unpack_f64(&buf9, 0)
+        // Check round-trip within tolerance
+        let diff9 = fv9 - 1.0
+        let adiff9 = if diff9 < 0.0 { 0.0 - diff9 } else { diff9 }
+        if adiff9 < 0.001 {
+            print("PASS\n")
+            pass = pass + 1
+        } else {
+            print("FAIL (wrong value)\n")
+            fail = fail + 1
+        }
+    } else {
+        print("FAIL (wrong length)\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 10: Type detection
+    // -------------------------------------------------------------------------
+    print("Test 10: unpack_type nil=0, bool=1, int=2, float=3... ")
+    var buf10 = msgpack_new()
+    buf10 = msgpack_pack_nil(buf10)
+    buf10 = msgpack_pack_bool(buf10, 1)
+    buf10 = msgpack_pack_i64(buf10, 5)
+    buf10 = msgpack_pack_f64(buf10, 0.0)
+    let t0 = msgpack_unpack_type(&buf10, 0)
+    let t1 = msgpack_unpack_type(&buf10, 1)
+    let t2 = msgpack_unpack_type(&buf10, 2)
+    let pos_f = msgpack_unpack_i64_advance(&buf10, 2)
+    let t3 = msgpack_unpack_type(&buf10, pos_f)
+    if t0 == 0 && t1 == 1 && t2 == 2 && t3 == 3 {
+        print("PASS\n")
+        pass = pass + 1
+    } else {
+        print("FAIL\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 11: Multiple values in one buffer — sequential pack/unpack
+    // -------------------------------------------------------------------------
+    print("Test 11: multiple values in buffer... ")
+    var buf11 = msgpack_new()
+    buf11 = msgpack_pack_i64(buf11, 10)
+    buf11 = msgpack_pack_i64(buf11, 20)
+    buf11 = msgpack_pack_i64(buf11, 30)
+    // All are fixints (1 byte each)
+    let v11a = msgpack_unpack_i64(&buf11, 0)
+    let p11a = msgpack_unpack_i64_advance(&buf11, 0)
+    let v11b = msgpack_unpack_i64(&buf11, p11a)
+    let p11b = msgpack_unpack_i64_advance(&buf11, p11a)
+    let v11c = msgpack_unpack_i64(&buf11, p11b)
+    if v11a == 10 && v11b == 20 && v11c == 30 {
+        print("PASS\n")
+        pass = pass + 1
+    } else {
+        print("FAIL\n")
+        fail = fail + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Summary
+    // -------------------------------------------------------------------------
+    print("\nPassed: ")
+    print(pass)
+    print(" Failed: ")
+    print(fail)
+    print("\n")
+    if fail > 0 { return 1 }
+    return 0
+}
+
+fn main() -> i32 with Mut, Panic, Div {
+    return run_tests()
+}

--- a/packages/sounio-formats/tests/test_toml_e2e.sio
+++ b/packages/sounio-formats/tests/test_toml_e2e.sio
@@ -1,0 +1,326 @@
+//@ run-pass
+//! tests/stdlib/toml/test_toml.sio
+//!
+//! Tests for toml::parser — minimal flat TOML parser.
+//!
+//! Design notes:
+//! - Sounio JIT: &!Struct field mutations propagate; &!array does NOT.
+//! - After any &!doc call, use direct field access (doc.types[i], doc.num_vals[i], etc.).
+//! - String retrieval: use doc.str_vals[idx] directly; toml_get_string out-copy is JIT-best-effort.
+
+use toml::parser::{
+    TOML_STRING, TOML_INTEGER, TOML_FLOAT, TOML_BOOL,
+    TomlDoc,
+    toml_doc_new,
+    toml_parse,
+    toml_get_string, toml_get_number, toml_get_bool,
+    toml_doc_count,
+    toml_self_test,
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn near(a: f64, b: f64) -> bool {
+    let d = a - b
+    let ad = if d < 0.0 { 0.0 - d } else { d }
+    ad < 0.0001
+}
+
+// Build a [u8; 4096] parse buffer from a known-size byte sequence.
+// This function encodes the test TOML:
+//   name = "sounio"\nversion = 3\npi = 3.14\ndebug = true\n
+// Returns the buffer and populates len_out via a wrapper struct.
+struct RawBuf {
+    data: [u8; 4096],
+    len:  i32,
+}
+
+fn mk_basic_toml() -> RawBuf  with Mut{
+    var b = RawBuf { data: [0; 4096], len: 0 }
+    // "name = "sounio"\n"
+    // n  a  m  e     =     "  s  o  u  n  i  o  "  \n
+    b.data[0]  = (110 as u8)  // n
+    b.data[1]  = (97 as u8)   // a
+    b.data[2]  = (109 as u8)  // m
+    b.data[3]  = (101 as u8)  // e
+    b.data[4]  = (32 as u8)   // space
+    b.data[5]  = (61 as u8)   // =
+    b.data[6]  = (32 as u8)   // space
+    b.data[7]  = (34 as u8)   // "
+    b.data[8]  = (115 as u8)  // s
+    b.data[9]  = (111 as u8)  // o
+    b.data[10] = (117 as u8)  // u
+    b.data[11] = (110 as u8)  // n
+    b.data[12] = (105 as u8)  // i
+    b.data[13] = (111 as u8)  // o
+    b.data[14] = (34 as u8)   // "
+    b.data[15] = (10 as u8)   // \n
+    // "version = 3\n"
+    b.data[16] = (118 as u8)  // v
+    b.data[17] = (101 as u8)  // e
+    b.data[18] = (114 as u8)  // r
+    b.data[19] = (115 as u8)  // s
+    b.data[20] = (105 as u8)  // i
+    b.data[21] = (111 as u8)  // o
+    b.data[22] = (110 as u8)  // n
+    b.data[23] = (32 as u8)   // space
+    b.data[24] = (61 as u8)   // =
+    b.data[25] = (32 as u8)   // space
+    b.data[26] = (51 as u8)   // 3
+    b.data[27] = (10 as u8)   // \n
+    // "pi = 3.14\n"
+    b.data[28] = (112 as u8)  // p
+    b.data[29] = (105 as u8)  // i
+    b.data[30] = (32 as u8)   // space
+    b.data[31] = (61 as u8)   // =
+    b.data[32] = (32 as u8)   // space
+    b.data[33] = (51 as u8)   // 3
+    b.data[34] = (46 as u8)   // .
+    b.data[35] = (49 as u8)   // 1
+    b.data[36] = (52 as u8)   // 4
+    b.data[37] = (10 as u8)   // \n
+    // "debug = true\n"
+    b.data[38] = (100 as u8)  // d
+    b.data[39] = (101 as u8)  // e
+    b.data[40] = (98 as u8)   // b
+    b.data[41] = (117 as u8)  // u
+    b.data[42] = (103 as u8)  // g
+    b.data[43] = (32 as u8)   // space
+    b.data[44] = (61 as u8)   // =
+    b.data[45] = (32 as u8)   // space
+    b.data[46] = (116 as u8)  // t
+    b.data[47] = (114 as u8)  // r
+    b.data[48] = (117 as u8)  // u
+    b.data[49] = (101 as u8)  // e
+    b.data[50] = (10 as u8)   // \n
+    b.len = 51
+    b
+}
+
+// ============================================================================
+// Test: type constants
+// ============================================================================
+
+fn test_type_constants() -> i32  with Mut{
+    var fail: i32 = 0
+    if TOML_STRING()  != 0 { fail = fail + 1 }
+    if TOML_INTEGER() != 1 { fail = fail + 1 }
+    if TOML_FLOAT()   != 2 { fail = fail + 1 }
+    if TOML_BOOL()    != 3 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: parse name = "sounio", version = 3, pi = 3.14, debug = true
+// ============================================================================
+
+fn test_basic_parse() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    let buf = mk_basic_toml()
+    var doc = toml_doc_new()
+    let res = toml_parse(&buf.data, buf.len, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 4 { fail = fail + 1 }
+
+    // Slot 0: name = "sounio"  (string)
+    if doc.types[0] != 0 { fail = fail + 1 }  // TOML_STRING
+    if doc.str_lens[0] != 6 { fail = fail + 1 }
+    // str_vals[][i] skipped — nested-array stride bug in JIT
+
+    // Slot 1: version = 3  (integer)
+    if doc.types[1] != 1 { fail = fail + 1 }  // TOML_INTEGER
+    if !near(doc.num_vals[1], 3.0) { fail = fail + 1 }
+
+    // Slot 2: pi = 3.14  (float)
+    if doc.types[2] != 2 { fail = fail + 1 }  // TOML_FLOAT
+    if !near(doc.num_vals[2], 3.14) { fail = fail + 1 }
+
+    // Slot 3: debug = true  (bool)
+    if doc.types[3] != 3 { fail = fail + 1 }  // TOML_BOOL
+    if doc.bool_vals[3] != 1 { fail = fail + 1 }
+
+    fail
+}
+
+// ============================================================================
+// Test: comments are ignored
+// ============================================================================
+
+fn test_comments() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "# this is a comment\nx = 1\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0]  = (35 as u8)   // #
+    raw[1]  = (32 as u8)   // space
+    raw[2]  = (99 as u8)   // c
+    raw[3]  = (111 as u8)  // o
+    raw[4]  = (109 as u8)  // m
+    raw[5]  = (109 as u8)  // m
+    raw[6]  = (101 as u8)  // e
+    raw[7]  = (110 as u8)  // n
+    raw[8]  = (116 as u8)  // t
+    raw[9]  = (10 as u8)   // \n
+    raw[10] = (120 as u8)  // x
+    raw[11] = (32 as u8)   // space
+    raw[12] = (61 as u8)   // =
+    raw[13] = (32 as u8)   // space
+    raw[14] = (49 as u8)   // 1
+    raw[15] = (10 as u8)   // \n
+    var doc = toml_doc_new()
+    let res = toml_parse(&raw, 16, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if !near(doc.num_vals[0], 1.0) { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: blank lines are ignored
+// ============================================================================
+
+fn test_blank_lines() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "\n\na = 5\n\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0] = (10 as u8)   // \n
+    raw[1] = (10 as u8)   // \n
+    raw[2] = (97 as u8)   // a
+    raw[3] = (32 as u8)   // space
+    raw[4] = (61 as u8)   // =
+    raw[5] = (32 as u8)   // space
+    raw[6] = (53 as u8)   // 5
+    raw[7] = (10 as u8)   // \n
+    raw[8] = (10 as u8)   // \n
+    var doc = toml_doc_new()
+    let res = toml_parse(&raw, 9, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if !near(doc.num_vals[0], 5.0) { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: false bool
+// ============================================================================
+
+fn test_bool_false() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "enabled = false\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0]  = (101 as u8)  // e
+    raw[1]  = (110 as u8)  // n
+    raw[2]  = (97 as u8)   // a
+    raw[3]  = (98 as u8)   // b
+    raw[4]  = (108 as u8)  // l
+    raw[5]  = (101 as u8)  // e
+    raw[6]  = (100 as u8)  // d
+    raw[7]  = (32 as u8)   // space
+    raw[8]  = (61 as u8)   // =
+    raw[9]  = (32 as u8)   // space
+    raw[10] = (102 as u8)  // f
+    raw[11] = (97 as u8)   // a
+    raw[12] = (108 as u8)  // l
+    raw[13] = (115 as u8)  // s
+    raw[14] = (101 as u8)  // e
+    raw[15] = (10 as u8)   // \n
+    var doc = toml_doc_new()
+    let res = toml_parse(&raw, 16, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if doc.types[0] != 3 { fail = fail + 1 }  // TOML_BOOL
+    if doc.bool_vals[0] != 0 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: toml_get_number and toml_get_bool on parsed doc
+// ============================================================================
+
+fn test_get_accessors() -> i32 with Mut, Div, Panic {
+    // toml_get_number/bool use toml_find_key which searches doc.keys (nested
+    // array), affected by the JIT nested-array stride bug. Skip key-lookup
+    // tests; verify direct-slot access instead.
+    var fail: i32 = 0
+    let buf = mk_basic_toml()
+    var doc = toml_doc_new()
+    toml_parse(&buf.data, buf.len, &!doc)
+    // Slot 1 = version = 3 (integer), slot 3 = debug = true (bool)
+    if !near(doc.num_vals[1], 3.0) { fail = fail + 1 }
+    if doc.bool_vals[3] != 1 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: toml_doc_count
+// ============================================================================
+
+fn test_doc_count() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    let buf = mk_basic_toml()
+    var doc = toml_doc_new()
+    toml_parse(&buf.data, buf.len, &!doc)
+    if toml_doc_count(&doc) != 4 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: inline self-test from parser module
+// ============================================================================
+
+fn test_self_test() -> i32 with Mut, Div, Panic {
+    toml_self_test()
+}
+
+// ============================================================================
+// Test: negative float
+// ============================================================================
+
+fn test_negative_float() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "temp = -1.5\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0]  = (116 as u8)  // t
+    raw[1]  = (101 as u8)  // e
+    raw[2]  = (109 as u8)  // m
+    raw[3]  = (112 as u8)  // p
+    raw[4]  = (32 as u8)   // space
+    raw[5]  = (61 as u8)   // =
+    raw[6]  = (32 as u8)   // space
+    raw[7]  = (45 as u8)   // -
+    raw[8]  = (49 as u8)   // 1
+    raw[9]  = (46 as u8)   // .
+    raw[10] = (53 as u8)   // 5
+    raw[11] = (10 as u8)   // \n
+    var doc = toml_doc_new()
+    let res = toml_parse(&raw, 12, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if doc.types[0] != 2 { fail = fail + 1 }  // TOML_FLOAT
+    if !near(doc.num_vals[0], 0.0 - 1.5) { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+fn main() -> i32 with Mut, Div, Panic {
+    var total_fail: i32 = 0
+
+    total_fail = total_fail + test_type_constants()
+    total_fail = total_fail + test_basic_parse()
+    total_fail = total_fail + test_comments()
+    total_fail = total_fail + test_blank_lines()
+    total_fail = total_fail + test_bool_false()
+    total_fail = total_fail + test_get_accessors()
+    total_fail = total_fail + test_doc_count()
+    total_fail = total_fail + test_negative_float()
+    total_fail = total_fail + test_self_test()
+
+    if total_fail == 0 {
+        return 0
+    }
+    1
+}

--- a/packages/sounio-formats/tests/test_yaml_e2e.sio
+++ b/packages/sounio-formats/tests/test_yaml_e2e.sio
@@ -1,0 +1,369 @@
+//@ run-pass
+//! tests/stdlib/yaml/test_yaml.sio
+//!
+//! Tests for yaml::parser — minimal flat YAML parser.
+//!
+//! Design notes:
+//! - Sounio JIT: &!Struct field mutations propagate; &!array does NOT.
+//! - After any &!doc call, use direct field access (doc.types[i], doc.num_vals[i], etc.).
+//! - String retrieval: use doc.str_vals[idx] directly; yaml_get_string out-copy is JIT-best-effort.
+
+use yaml::parser::{
+    YAML_STRING, YAML_NUMBER, YAML_BOOL, YAML_NULL,
+    YamlDoc,
+    yaml_doc_new,
+    yaml_parse,
+    yaml_get_string, yaml_get_number, yaml_get_bool,
+    yaml_doc_count,
+    yaml_self_test,
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn near(a: f64, b: f64) -> bool {
+    let d = a - b
+    let ad = if d < 0.0 { 0.0 - d } else { d }
+    ad < 0.0001
+}
+
+struct RawBuf {
+    data: [u8; 4096],
+    len:  i32,
+}
+
+// Build test YAML:
+//   name: sounio\ncount: 42\npi: 3.14\nactive: true\nnone: null\n
+fn mk_basic_yaml() -> RawBuf  with Mut{
+    var b = RawBuf { data: [0; 4096], len: 0 }
+    // "name: sounio\n"
+    b.data[0]  = (110 as u8)  // n
+    b.data[1]  = (97 as u8)   // a
+    b.data[2]  = (109 as u8)  // m
+    b.data[3]  = (101 as u8)  // e
+    b.data[4]  = (58 as u8)   // :
+    b.data[5]  = (32 as u8)   // space
+    b.data[6]  = (115 as u8)  // s
+    b.data[7]  = (111 as u8)  // o
+    b.data[8]  = (117 as u8)  // u
+    b.data[9]  = (110 as u8)  // n
+    b.data[10] = (105 as u8)  // i
+    b.data[11] = (111 as u8)  // o
+    b.data[12] = (10 as u8)   // \n
+    // "count: 42\n"
+    b.data[13] = (99 as u8)   // c
+    b.data[14] = (111 as u8)  // o
+    b.data[15] = (117 as u8)  // u
+    b.data[16] = (110 as u8)  // n
+    b.data[17] = (116 as u8)  // t
+    b.data[18] = (58 as u8)   // :
+    b.data[19] = (32 as u8)   // space
+    b.data[20] = (52 as u8)   // 4
+    b.data[21] = (50 as u8)   // 2
+    b.data[22] = (10 as u8)   // \n
+    // "pi: 3.14\n"
+    b.data[23] = (112 as u8)  // p
+    b.data[24] = (105 as u8)  // i
+    b.data[25] = (58 as u8)   // :
+    b.data[26] = (32 as u8)   // space
+    b.data[27] = (51 as u8)   // 3
+    b.data[28] = (46 as u8)   // .
+    b.data[29] = (49 as u8)   // 1
+    b.data[30] = (52 as u8)   // 4
+    b.data[31] = (10 as u8)   // \n
+    // "active: true\n"
+    b.data[32] = (97 as u8)   // a
+    b.data[33] = (99 as u8)   // c
+    b.data[34] = (116 as u8)  // t
+    b.data[35] = (105 as u8)  // i
+    b.data[36] = (118 as u8)  // v
+    b.data[37] = (101 as u8)  // e
+    b.data[38] = (58 as u8)   // :
+    b.data[39] = (32 as u8)   // space
+    b.data[40] = (116 as u8)  // t
+    b.data[41] = (114 as u8)  // r
+    b.data[42] = (117 as u8)  // u
+    b.data[43] = (101 as u8)  // e
+    b.data[44] = (10 as u8)   // \n
+    // "none: null\n"
+    b.data[45] = (110 as u8)  // n
+    b.data[46] = (111 as u8)  // o
+    b.data[47] = (110 as u8)  // n
+    b.data[48] = (101 as u8)  // e
+    b.data[49] = (58 as u8)   // :
+    b.data[50] = (32 as u8)   // space
+    b.data[51] = (110 as u8)  // n
+    b.data[52] = (117 as u8)  // u
+    b.data[53] = (108 as u8)  // l
+    b.data[54] = (108 as u8)  // l
+    b.data[55] = (10 as u8)   // \n
+    b.len = 56
+    b
+}
+
+// ============================================================================
+// Test: type constants
+// ============================================================================
+
+fn test_type_constants() -> i32  with Mut, Div{
+    var fail: i32 = 0
+    if YAML_STRING() != 0 { fail = fail + 1 }
+    if YAML_NUMBER() != 1 { fail = fail + 1 }
+    if YAML_BOOL()   != 2 { fail = fail + 1 }
+    if YAML_NULL()   != 3 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: parse name/count/pi/active/none
+// ============================================================================
+
+fn test_basic_parse() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    let buf = mk_basic_yaml()
+    var doc = yaml_doc_new()
+    let res = yaml_parse(&buf.data, buf.len, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 5 { fail = fail + 1 }
+
+    // Slot 0: name = "sounio"  (bare string)
+    if doc.types[0] != 0 { fail = fail + 1 }  // YAML_STRING
+    if doc.str_lens[0] != 6 { fail = fail + 1 }
+    // str_vals[][i] skipped — nested-array stride bug in JIT
+
+    // Slot 1: count = 42  (number)
+    if doc.types[1] != 1 { fail = fail + 1 }  // YAML_NUMBER
+    if !near(doc.num_vals[1], 42.0) { fail = fail + 1 }
+
+    // Slot 2: pi = 3.14  (number)
+    if doc.types[2] != 1 { fail = fail + 1 }  // YAML_NUMBER
+    if !near(doc.num_vals[2], 3.14) { fail = fail + 1 }
+
+    // Slot 3: active = true  (bool)
+    if doc.types[3] != 2 { fail = fail + 1 }  // YAML_BOOL
+    if doc.num_vals[3] < 0.5 { fail = fail + 1 }
+
+    // Slot 4: none = null  (null)
+    if doc.types[4] != 3 { fail = fail + 1 }  // YAML_NULL
+
+    fail
+}
+
+// ============================================================================
+// Test: quoted string  title: "hello world"
+// ============================================================================
+
+fn test_quoted_string() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "title: "hello world"\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0]  = (116 as u8)  // t
+    raw[1]  = (105 as u8)  // i
+    raw[2]  = (116 as u8)  // t
+    raw[3]  = (108 as u8)  // l
+    raw[4]  = (101 as u8)  // e
+    raw[5]  = (58 as u8)   // :
+    raw[6]  = (32 as u8)   // space
+    raw[7]  = (34 as u8)   // "
+    raw[8]  = (104 as u8)  // h
+    raw[9]  = (101 as u8)  // e
+    raw[10] = (108 as u8)  // l
+    raw[11] = (108 as u8)  // l
+    raw[12] = (111 as u8)  // o
+    raw[13] = (32 as u8)   // space
+    raw[14] = (119 as u8)  // w
+    raw[15] = (111 as u8)  // o
+    raw[16] = (114 as u8)  // r
+    raw[17] = (108 as u8)  // l
+    raw[18] = (100 as u8)  // d
+    raw[19] = (34 as u8)   // "
+    raw[20] = (10 as u8)   // \n
+    var doc = yaml_doc_new()
+    let res = yaml_parse(&raw, 21, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if doc.types[0] != 0 { fail = fail + 1 }   // YAML_STRING
+    if doc.str_lens[0] != 11 { fail = fail + 1 }  // "hello world" = 11 bytes
+    // str_vals[][i] skipped — nested-array stride bug in JIT
+    fail
+}
+
+// ============================================================================
+// Test: yes/no as booleans
+// ============================================================================
+
+fn test_yes_no() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "flag1: yes\nflag2: no\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0]  = (102 as u8)  // f
+    raw[1]  = (108 as u8)  // l
+    raw[2]  = (97 as u8)   // a
+    raw[3]  = (103 as u8)  // g
+    raw[4]  = (49 as u8)   // 1
+    raw[5]  = (58 as u8)   // :
+    raw[6]  = (32 as u8)   // space
+    raw[7]  = (121 as u8)  // y
+    raw[8]  = (101 as u8)  // e
+    raw[9]  = (115 as u8)  // s
+    raw[10] = (10 as u8)   // \n
+    raw[11] = (102 as u8)  // f
+    raw[12] = (108 as u8)  // l
+    raw[13] = (97 as u8)   // a
+    raw[14] = (103 as u8)  // g
+    raw[15] = (50 as u8)   // 2
+    raw[16] = (58 as u8)   // :
+    raw[17] = (32 as u8)   // space
+    raw[18] = (110 as u8)  // n
+    raw[19] = (111 as u8)  // o
+    raw[20] = (10 as u8)   // \n
+    var doc = yaml_doc_new()
+    let res = yaml_parse(&raw, 21, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 2 { fail = fail + 1 }
+    if doc.types[0] != 2 { fail = fail + 1 }  // YAML_BOOL
+    if doc.num_vals[0] < 0.5 { fail = fail + 1 }  // yes → 1
+    if doc.types[1] != 2 { fail = fail + 1 }  // YAML_BOOL
+    if doc.num_vals[1] > 0.5 { fail = fail + 1 }  // no → 0
+    fail
+}
+
+// ============================================================================
+// Test: tilde as null  "x: ~\n"
+// ============================================================================
+
+fn test_tilde_null() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0] = (120 as u8)  // x
+    raw[1] = (58 as u8)   // :
+    raw[2] = (32 as u8)   // space
+    raw[3] = (126 as u8)  // ~
+    raw[4] = (10 as u8)   // \n
+    var doc = yaml_doc_new()
+    let res = yaml_parse(&raw, 5, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if doc.types[0] != 3 { fail = fail + 1 }  // YAML_NULL
+    fail
+}
+
+// ============================================================================
+// Test: # comments ignored
+// ============================================================================
+
+fn test_comments() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "# header\nval: 7\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0] = (35 as u8)   // #
+    raw[1] = (32 as u8)   // space
+    raw[2] = (104 as u8)  // h
+    raw[3] = (10 as u8)   // \n
+    raw[4] = (118 as u8)  // v
+    raw[5] = (97 as u8)   // a
+    raw[6] = (108 as u8)  // l
+    raw[7] = (58 as u8)   // :
+    raw[8] = (32 as u8)   // space
+    raw[9] = (55 as u8)   // 7
+    raw[10] = (10 as u8)  // \n
+    var doc = yaml_doc_new()
+    let res = yaml_parse(&raw, 11, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if !near(doc.num_vals[0], 7.0) { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: accessor functions
+// ============================================================================
+
+fn test_get_accessors() -> i32 with Mut, Div, Panic {
+    // yaml_get_number/bool use yaml_find_key which searches doc.keys (nested
+    // array), affected by the JIT nested-array stride bug. Use direct-slot
+    // access instead.
+    var fail: i32 = 0
+    let buf = mk_basic_yaml()
+    var doc = yaml_doc_new()
+    yaml_parse(&buf.data, buf.len, &!doc)
+    // Slot 1 = count = 42, slot 3 = active = true
+    if !near(doc.num_vals[1], 42.0) { fail = fail + 1 }
+    if doc.num_vals[3] < 0.5 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: yaml_doc_count
+// ============================================================================
+
+fn test_doc_count() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    let buf = mk_basic_yaml()
+    var doc = yaml_doc_new()
+    yaml_parse(&buf.data, buf.len, &!doc)
+    if yaml_doc_count(&doc) != 5 { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: negative number
+// ============================================================================
+
+fn test_negative_number() -> i32 with Mut, Div, Panic {
+    var fail: i32 = 0
+    // "delta: -2.5\n"
+    var raw: [u8; 4096] = [0; 4096]
+    raw[0]  = (100 as u8)  // d
+    raw[1]  = (101 as u8)  // e
+    raw[2]  = (108 as u8)  // l
+    raw[3]  = (116 as u8)  // t
+    raw[4]  = (97 as u8)   // a
+    raw[5]  = (58 as u8)   // :
+    raw[6]  = (32 as u8)   // space
+    raw[7]  = (45 as u8)   // -
+    raw[8]  = (50 as u8)   // 2
+    raw[9]  = (46 as u8)   // .
+    raw[10] = (53 as u8)   // 5
+    raw[11] = (10 as u8)   // \n
+    var doc = yaml_doc_new()
+    let res = yaml_parse(&raw, 12, &!doc)
+    if res != 0 { fail = fail + 1 }
+    if doc.count != 1 { fail = fail + 1 }
+    if doc.types[0] != 1 { fail = fail + 1 }  // YAML_NUMBER
+    if !near(doc.num_vals[0], 0.0 - 2.5) { fail = fail + 1 }
+    fail
+}
+
+// ============================================================================
+// Test: inline self-test from parser module
+// ============================================================================
+
+fn test_self_test() -> i32 with Mut, Div, Panic {
+    yaml_self_test()
+}
+
+// ============================================================================
+// main
+// ============================================================================
+
+fn main() -> i32 with Mut, Div, Panic {
+    var total_fail: i32 = 0
+
+    total_fail = total_fail + test_type_constants()
+    total_fail = total_fail + test_basic_parse()
+    total_fail = total_fail + test_quoted_string()
+    total_fail = total_fail + test_yes_no()
+    total_fail = total_fail + test_tilde_null()
+    total_fail = total_fail + test_comments()
+    total_fail = total_fail + test_get_accessors()
+    total_fail = total_fail + test_doc_count()
+    total_fail = total_fail + test_negative_number()
+    total_fail = total_fail + test_self_test()
+
+    if total_fail == 0 {
+        return 0
+    }
+    1
+}

--- a/packages/sounio-io-primitives/docs/README.md
+++ b/packages/sounio-io-primitives/docs/README.md
@@ -1,0 +1,5 @@
+# sounio-io-primitives
+
+Byte paths, structured logging, and comparison utilities.
+
+Canonical implementations: `stdlib/path/`, `stdlib/log/`, `stdlib/cmp/`.

--- a/packages/sounio-io-primitives/sounio.toml
+++ b/packages/sounio-io-primitives/sounio.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sounio-io-primitives"
+version = "0.1.0"
+description = "Low-level I/O primitives: byte paths, structured logging, and comparisons"
+authors = ["Sounio Project"]
+license = "Apache-2.0"
+edition = "2026"
+readme = "docs/README.md"
+keywords = ["path", "log", "cmp", "io", "primitives"]
+categories = ["core", "io"]
+
+[epistemic]
+score = 0.80
+confidence-threshold = 0.75
+provenance-level = "medium"
+gum-compliant = false
+
+[lib]
+path = "src/lib.sio"
+name = "sounio_io_primitives"
+
+[[test]]
+name = "test_log_path_cmp_e2e"
+path = "tests/test_log_path_cmp_e2e.sio"
+run = true

--- a/packages/sounio-io-primitives/src/lib.sio
+++ b/packages/sounio-io-primitives/src/lib.sio
@@ -1,0 +1,46 @@
+// packages/sounio-io-primitives/src/lib.sio
+// Package facade — canonical implementations in stdlib/{path,log,cmp}/.
+
+pub use path::lib::{
+    Path,
+    path_new,
+    path_from_bytes,
+    path_join,
+    path_parent,
+    path_extension,
+    path_basename,
+    path_stem,
+    path_filename,
+    path_is_absolute,
+    path_eq,
+}
+
+pub use log::lib::{
+    LOG_DEBUG,
+    LOG_ERROR,
+    LOG_FATAL,
+    LOG_INFO,
+    LOG_TRACE,
+    LOG_WARN,
+    LogBuffer,
+    log_append,
+    log_buffer_new,
+    log_clear,
+    log_count,
+    log_count_level,
+    log_filter_level,
+    log_last_value,
+}
+
+pub use cmp::lib::{
+    cmp_i64,
+    cmp_f64,
+    min_i64,
+    max_i64,
+    min_f64,
+    max_f64,
+    clamp_f64,
+    clamp_i64,
+    approx_eq,
+    sign_f64,
+}

--- a/packages/sounio-io-primitives/tests/test_log_path_cmp_e2e.sio
+++ b/packages/sounio-io-primitives/tests/test_log_path_cmp_e2e.sio
@@ -1,0 +1,213 @@
+//@ run-pass
+// E2E: stdlib/log, stdlib/path, stdlib/cmp
+//
+// Log:  append 5 entries at different levels, filter by WARN, count
+// Path: join "src" + "main.sio" → "src/main.sio", extension → "sio", parent → "src"
+// Cmp:  ordering, clamp, approx_eq
+
+use log::lib::*;
+use path::lib::*;
+use cmp::lib::*;
+
+// ---------------------------------------------------------------------------
+// Helpers for building paths from byte slices
+// ---------------------------------------------------------------------------
+
+fn make_path_3(a: u8, b: u8, c: u8) -> Path  with Mut{
+    var p = path_new()
+    p.data[0] = a
+    p.data[1] = b
+    p.data[2] = c
+    p.len = 3
+    p
+}
+
+fn make_path_8(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, g: u8, h: u8) -> Path  with Mut{
+    var p = path_new()
+    p.data[0] = a
+    p.data[1] = b
+    p.data[2] = c
+    p.data[3] = d
+    p.data[4] = e
+    p.data[5] = f
+    p.data[6] = g
+    p.data[7] = h
+    p.len = 8
+    p
+}
+
+// ---------------------------------------------------------------------------
+// Log tests
+// ---------------------------------------------------------------------------
+
+fn test_log() -> i32 with Mut {
+    // Level constants
+    if LOG_TRACE() != 0 { return 101 }
+    if LOG_DEBUG() != 1 { return 102 }
+    if LOG_INFO()  != 2 { return 103 }
+    if LOG_WARN()  != 3 { return 104 }
+    if LOG_ERROR() != 4 { return 105 }
+    if LOG_FATAL() != 5 { return 106 }
+
+    // Create buffer with min_level = INFO (2)
+    var buf = log_buffer_new(LOG_INFO())
+
+    // Append 5 entries at levels: TRACE(filtered), DEBUG(filtered), INFO, WARN, ERROR
+    log_append(&! buf, LOG_TRACE(), 10, 1.0, 1000)  // filtered
+    log_append(&! buf, LOG_DEBUG(), 20, 2.0, 1001)  // filtered
+    log_append(&! buf, LOG_INFO(),  30, 3.0, 1002)
+    log_append(&! buf, LOG_WARN(),  40, 4.0, 1003)
+    log_append(&! buf, LOG_ERROR(), 50, 5.0, 1004)
+
+    // 3 entries should be stored (INFO, WARN, ERROR)
+    if log_count(&buf) != 3 { return 107 }
+
+    // Count by level
+    if log_count_level(&buf, LOG_INFO())  != 1 { return 108 }
+    if log_count_level(&buf, LOG_WARN())  != 1 { return 109 }
+    if log_count_level(&buf, LOG_ERROR()) != 1 { return 110 }
+    if log_count_level(&buf, LOG_TRACE()) != 0 { return 111 }
+
+    // Last value should be 5.0 (the ERROR entry)
+    let lv = log_last_value(&buf)
+    if lv != 5.0 { return 112 }
+
+    // Filter by WARN
+    var warn_buf = log_buffer_new(LOG_WARN())
+    log_filter_level(&buf, LOG_WARN(), &! warn_buf)
+    if log_count(&warn_buf) != 1 { return 113 }
+    if log_count_level(&warn_buf, LOG_WARN()) != 1 { return 114 }
+
+    // Clear
+    log_clear(&! buf)
+    if log_count(&buf) != 0 { return 115 }
+
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Path tests
+// ---------------------------------------------------------------------------
+
+fn test_path() -> i32  with Mut, Div{
+    // Build "src" (115, 114, 99) and "main.sio" (109,97,105,110,46,115,105,111)
+    // ASCII: s=115 r=114 c=99 m=109 a=97 i=105 n=110 .=46 s=115 i=105 o=111
+    let src_path  = make_path_3(115, 114, 99)                           // "src"
+    let main_path = make_path_8(109, 97, 105, 110, 46, 115, 105, 111)  // "main.sio"
+
+    // path_join: "src" + "main.sio" → "src/main.sio"
+    let joined = path_join(&src_path, &main_path)
+    // Expected length: 3 + 1 + 8 = 12
+    if joined.len != 12 { return 201 }
+    // Check separator at index 3
+    if joined.data[3] != 47 { return 202 }  // '/'
+
+    // path_extension: "main.sio" → "sio"
+    let ext = path_extension(&joined)
+    // "sio" = 3 bytes
+    if ext.len != 3 { return 203 }
+    if ext.data[0] != 115 { return 204 }  // 's'
+    if ext.data[1] != 105 { return 205 }  // 'i'
+    if ext.data[2] != 111 { return 206 }  // 'o'
+
+    // path_parent: "src/main.sio" → "src"
+    let parent = path_parent(&joined)
+    if parent.len != 3 { return 207 }
+    if !path_eq(&parent, &src_path) { return 208 }
+
+    // path_filename: "src/main.sio" → "main.sio"
+    let fname = path_filename(&joined)
+    if fname.len != 8 { return 209 }
+    if !path_eq(&fname, &main_path) { return 210 }
+
+    // path_stem: "src/main.sio" → "main"
+    let stem = path_stem(&joined)
+    // "main" = 4 bytes (109,97,105,110)
+    if stem.len != 4 { return 211 }
+    if stem.data[0] != 109 { return 212 }  // 'm'
+    if stem.data[3] != 110 { return 213 }  // 'n'
+
+    // path_is_absolute: "src" is not absolute, "/src" would be
+    if path_is_absolute(&src_path) { return 214 }
+
+    // Build "/src" = (47, 115, 114, 99)
+    var abs_path = path_new()
+    abs_path.data[0] = 47   // '/'
+    abs_path.data[1] = 115  // 's'
+    abs_path.data[2] = 114  // 'r'
+    abs_path.data[3] = 99   // 'c'
+    abs_path.len = 4
+    if !path_is_absolute(&abs_path) { return 215 }
+
+    // path_eq
+    let src2 = make_path_3(115, 114, 99)
+    if !path_eq(&src_path, &src2) { return 216 }
+    if path_eq(&src_path, &main_path) { return 217 }
+
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Cmp tests
+// ---------------------------------------------------------------------------
+
+fn test_cmp() -> i32 {
+    // cmp_i64
+    if cmp_i64(1, 2) != -1 { return 301 }
+    if cmp_i64(2, 2) !=  0 { return 302 }
+    if cmp_i64(3, 2) !=  1 { return 303 }
+
+    // cmp_f64
+    if cmp_f64(1.0, 2.0) != -1 { return 304 }
+    if cmp_f64(2.0, 2.0) !=  0 { return 305 }
+    if cmp_f64(3.0, 2.0) !=  1 { return 306 }
+
+    // min/max i64
+    if min_i64(3, 7) != 3 { return 307 }
+    if max_i64(3, 7) != 7 { return 308 }
+    if min_i64(-5, 0) != -5 { return 309 }
+    if max_i64(-5, 0) != 0 { return 310 }
+
+    // min/max f64
+    if min_f64(1.5, 2.5) != 1.5 { return 311 }
+    if max_f64(1.5, 2.5) != 2.5 { return 312 }
+
+    // clamp_f64
+    if clamp_f64(5.0, 0.0, 3.0) != 3.0 { return 313 }
+    if clamp_f64(-1.0, 0.0, 3.0) != 0.0 { return 314 }
+    if clamp_f64(1.5, 0.0, 3.0) != 1.5 { return 315 }
+
+    // clamp_i64
+    if clamp_i64(10, 0, 5) != 5 { return 316 }
+    if clamp_i64(-3, 0, 5) != 0 { return 317 }
+    if clamp_i64(3, 0, 5)  != 3 { return 318 }
+
+    // approx_eq
+    if !approx_eq(1.0, 1.0, 1e-10) { return 319 }
+    if !approx_eq(1.0, 1.0 + 1e-11, 1e-10) { return 320 }
+    if approx_eq(1.0, 2.0, 1e-10) { return 321 }
+
+    // sign_f64
+    if sign_f64(-3.0) != -1.0 { return 322 }
+    if sign_f64(0.0)  !=  0.0 { return 323 }
+    if sign_f64(7.0)  !=  1.0 { return 324 }
+
+    0
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+fn main() -> i32 with Mut, Div {
+    let r1 = test_log()
+    if r1 != 0 { return r1 }
+
+    let r2 = test_path()
+    if r2 != 0 { return r2 }
+
+    let r3 = test_cmp()
+    if r3 != 0 { return r3 }
+
+    0
+}

--- a/packages/sounio-units/docs/README.md
+++ b/packages/sounio-units/docs/README.md
@@ -1,0 +1,23 @@
+# sounio-units
+
+Canonical package for SI dimensional analysis and metrological calibration.
+
+## Import
+
+```sounio
+use sounio_units::*
+```
+
+## Stdlib compatibility
+
+Legacy imports remain valid via shims:
+
+- `use units::lib::*` → `stdlib/units/lib.sio`
+- `use units::mod::*` → `stdlib/units/mod.sio`
+- `use metrology::calibration::*` → `stdlib/metrology/calibration.sio`
+
+## References
+
+- JCGM 100:2008 (GUM)
+- JCGM 200:2012 (VIM)
+- ISO 17025:2017

--- a/packages/sounio-units/sounio.toml
+++ b/packages/sounio-units/sounio.toml
@@ -1,0 +1,34 @@
+[package]
+name = "sounio-units"
+version = "0.1.0"
+description = "Dimensional analysis and ISO/BIPM metrological calibration with GUM uncertainty propagation"
+authors = ["Sounio Project"]
+license = "Apache-2.0"
+edition = "2026"
+repository = "https://github.com/sounio-lang/sounio"
+readme = "docs/README.md"
+keywords = ["units", "metrology", "gum", "dimensional-analysis", "calibration"]
+categories = ["scientific", "metrology", "core"]
+
+[epistemic]
+score = 0.90
+confidence-threshold = 0.90
+provenance-level = "strong"
+gum-compliant = true
+regulatory-ready = false
+validation-coverage = 0.85
+uncertainty-propagation = "first-order-gum"
+
+[lib]
+path = "src/lib.sio"
+name = "sounio_units"
+
+[[test]]
+name = "test_units_e2e"
+path = "tests/test_units_e2e.sio"
+run = true
+
+[[test]]
+name = "test_calibration_e2e"
+path = "tests/test_calibration_e2e.sio"
+run = true

--- a/packages/sounio-units/src/lib.sio
+++ b/packages/sounio-units/src/lib.sio
@@ -1,0 +1,59 @@
+// packages/sounio-units/src/lib.sio
+// Package facade — canonical implementations live in stdlib until Madaros
+// resolves packages/ imports. See packages/PACKAGE_INDEX.md.
+
+pub use units::lib::{
+    UnitDim,
+    Quantity,
+
+    dim_dimensionless,
+    dim_mass,
+    dim_length,
+    dim_time,
+    dim_temperature,
+    dim_amount,
+    dim_current,
+    dim_velocity,
+    dim_acceleration,
+    dim_force,
+    dim_energy,
+    dim_power,
+    dim_pressure,
+
+    dim_eq,
+
+    quantity_new,
+    quantity_is_compatible,
+    quantity_add,
+    quantity_sub,
+    quantity_mul,
+    quantity_div,
+    quantity_scale,
+
+    convert_celsius_to_kelvin,
+    convert_kelvin_to_celsius,
+    convert_kg_to_g,
+    convert_g_to_kg,
+    convert_m_to_cm,
+    convert_cm_to_m,
+    convert_joule_to_ev,
+    convert_ev_to_joule,
+}
+
+pub use metrology::calibration::{
+    CalCertificate,
+    CalPoint,
+    CorrectedValue,
+    TypeAEval,
+    cal_apply,
+    cal_cert_add_point,
+    cal_cert_new,
+    cal_point_combined_u,
+    cal_point_expanded_u,
+    cal_point_new,
+    cal_print_certificate,
+    type_a_eval,
+    type_b_from_expanded,
+    type_b_from_resolution,
+    type_b_rectangular,
+}

--- a/packages/sounio-units/tests/test_calibration_e2e.sio
+++ b/packages/sounio-units/tests/test_calibration_e2e.sio
@@ -1,0 +1,43 @@
+//@ run-pass
+// packages/sounio-units/tests/test_calibration_e2e.sio
+
+use metrology::calibration::{
+    cal_point_new,
+    cal_point_combined_u,
+    type_a_eval,
+    type_b_rectangular,
+}
+
+fn abs_diff(a: f64, b: f64) -> f64 {
+    let d = a - b
+    if d < 0.0 { 0.0 - d } else { d }
+}
+
+fn test_cal_combined_u() -> bool with Div, Panic, Mut {
+    let p = cal_point_new(100.0, 100.05, 0.01, 0.005, 0.003, 20.0)
+    let u_c = cal_point_combined_u(p)
+    abs_diff(u_c, 0.011576) < 0.0001
+}
+
+fn test_type_a() -> bool with Mut, Panic, Div {
+    var readings: [f64; 16] = [0.0; 16]
+    readings[0] = 10.01
+    readings[1] = 9.99
+    readings[2] = 10.00
+    readings[3] = 10.02
+    readings[4] = 9.98
+    let eval = type_a_eval(&readings, 5)
+    if !eval.valid { return false }
+    abs_diff(eval.mean, 10.0) < 0.001
+}
+
+fn test_type_b() -> bool with Div, Panic, Mut {
+    let u = type_b_rectangular(0.5)
+    abs_diff(u, 0.28868) < 0.0001
+}
+
+fn main() with Mut, Panic, Div {
+    assert(test_cal_combined_u())
+    assert(test_type_a())
+    assert(test_type_b())
+}

--- a/packages/sounio-units/tests/test_units_e2e.sio
+++ b/packages/sounio-units/tests/test_units_e2e.sio
@@ -1,0 +1,42 @@
+//@ run-pass
+// packages/sounio-units/tests/test_units_e2e.sio
+
+use units::lib::*
+
+fn sqrt_u(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    var i = 0
+    while i < 30 {
+        y = 0.5 * (y + x / y)
+        i = i + 1
+    }
+    y
+}
+
+fn assert_close(actual: f64, expected: f64, tol: f64) with Panic {
+    let diff = actual - expected
+    let ad = if diff < 0.0 { 0.0 - diff } else { diff }
+    assert(ad <= tol)
+}
+
+fn test_newton_second_law() with Mut, Div, Panic {
+    let mass_q = quantity_new(10.0, 0.1, dim_mass())
+    let accel_q = quantity_new(9.81, 0.01, dim_acceleration())
+    let force_q = quantity_mul(mass_q, accel_q)
+    assert(dim_eq(force_q.dim, dim_force()))
+    assert_close(force_q.value, 98.1, 1.0e-9)
+}
+
+fn test_gum_propagation() with Mut, Div, Panic {
+    let x1 = quantity_new(10.0, 0.1, dim_length())
+    let x2 = quantity_new(20.0, 0.2, dim_length())
+    let sum = quantity_add(x1, x2)
+    assert_close(sum.value, 30.0, 1.0e-9)
+    assert_close(sum.uncertainty, sqrt_u(0.01 + 0.04), 1.0e-9)
+}
+
+fn main() with Mut, Div, Panic {
+    test_newton_second_law()
+    test_gum_propagation()
+}

--- a/scripts/ci/package_pbpk_gum_gate.sh
+++ b/scripts/ci/package_pbpk_gum_gate.sh
@@ -5,11 +5,25 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
-sounio_require_souc
-if ! "$SOUC_BIN" --help 2>/dev/null | grep -q "run <file.sio>"; then
-  export SOUNIO_SOUC_BIN="$SOUC_BIN"
-  SOUC_BIN="$ROOT_DIR/scripts/ci/souc-native-wrapper.sh"
+
+# The PETAB baseline and PBPK/GUM workflow import stdlib + packages/* modules.
+# lean_single resolves those imports and enforces the full effect/ontology
+# surface; the Madaros default (bin/souc since 2026-06-14) does not yet — it
+# fails this workflow with a spurious "effect not declared (missing: GPU)"
+# during multimodule thin-link. Pin the raw ELF to lean_single, matching the
+# package import sub-gate (package_import_science_gate.sh). The raw lean_single
+# ELF only accepts the positional `SRC OUT` CLI, so route the souc `run`/`compile`
+# verbs this gate uses through souc-native-wrapper.sh. Override via SOUNIO_SOUC_BIN.
+LEAN_SOUC="${SOUNIO_SOUC_BIN:-$ROOT_DIR/bin/souc-lean-single-x86_64}"
+if [[ ! -x "$LEAN_SOUC" ]]; then
+  LEAN_SOUC="$ROOT_DIR/bin/souc-linux-x86_64"
 fi
+if [[ ! -x "$LEAN_SOUC" ]]; then
+  echo '[package-pbpk-gum] FAIL: lean_single compiler ELF not found' >&2
+  exit 1
+fi
+export SOUNIO_SOUC_BIN="$LEAN_SOUC"
+SOUC_BIN="$ROOT_DIR/scripts/ci/souc-native-wrapper.sh"
 
 export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
 

--- a/tests/packages/package_import_units_witness.sio
+++ b/tests/packages/package_import_units_witness.sio
@@ -1,0 +1,24 @@
+//@ run-pass
+//@ expect-stdout: package import units witness:
+
+use units::lib::{
+    dim_mass,
+    dim_eq,
+    quantity_new,
+    quantity_mul,
+}
+
+fn test_quantity_mul_value() -> bool with Mut, Div, Panic {
+    let m = quantity_new(2.0, 0.0, dim_mass())
+    let a = quantity_new(3.0, 0.0, dim_mass())
+    let p = quantity_mul(m, a)
+    p.value == 6.0
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if test_quantity_mul_value() {
+        println("package import units witness: passed")
+    } else {
+        println("package import units witness: failed")
+    }
+}


### PR DESCRIPTION
## Problem

With the ontology-validation step fixed (#319), the **Contracts** job advances to and fails its next step: **Package-backed PBPK/GUM contract** (`scripts/ci/package_pbpk_gum_gate.sh`). Two pre-existing, previously-masked breakages:

1. **Dangling package references.** Commit `13d16b1e9` expanded `package_import_science_gate.sh` to require 3 packages (`sounio-units`, `sounio-formats`, `sounio-io-primitives`) + a witness (`package_import_units_witness.sio`) that were authored on branch `research/erdos-compiler-wip` (`b8828063d`) but **never merged to main**. The gate fails with `FileNotFoundError: packages/sounio-units/sounio.toml`.
2. **Madaros default oracle.** The gate runs the PETAB baseline + PBPK/GUM workflow via `bin/souc`→Madaros, which fails with a spurious `effect not declared (missing: GPU)` during multimodule thin-link.

Both were hidden because the ontology step failed first under `set -e`.

## Fix

- **Land the 3 packages + units witness** from `b8828063d` (manifests, `src/`, `tests/`, `docs/`) — completing the merge that `13d16b1e9` assumed.
- **Pin `package_pbpk_gum_gate.sh`** baseline+workflow runs to the lean_single ELF (through `souc-native-wrapper.sh` for the `run`/`compile` verbs), mirroring the lean_single pin the import sub-gate already uses. lean_single resolves `packages/` imports and the full effect surface; the Madaros gap is tracked separately.

## Verification

```
$ bash scripts/ci/package_pbpk_gum_gate.sh
[package-import-science] PASS: multi-package import contract is gated
PACKAGE_PBPK_GUM_OK
[package-pbpk-gum] PASS: PBPK/GUM consumes epistemic-core as a package
```

With this + #319, all Contracts steps pass locally.

## Context

Second of two PRs unmasking the long-red Contracts job. #319 fixed ontology validation; this fixes the package/PBPK steps. The underlying Madaros capability gaps (ontology collection, package resolution, effect-checking on this workflow) are tracked as follow-up language work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)