### PR TITLE
fix(website): correct component import depth in pt/graphics.mdx

### DIFF
--- a/website/src/content/showcases/pt/graphics.mdx
+++ b/website/src/content/showcases/pt/graphics.mdx
@@ -10,8 +10,8 @@ last_validated: "2026-03-07"
 validated_by: "A6"
 source_of_truth: "docs/governance/topic-registry.v1.json#website.showcases.pt.graphics"
 ---
-import RenderPreview from '../../components/common/RenderPreview.astro';
-import TerminalOutput from '../../components/common/TerminalOutput';
+import RenderPreview from '../../../components/common/RenderPreview.astro';
+import TerminalOutput from '../../../components/common/TerminalOutput';
 
 # Gráficos e Renderização
 


### PR DESCRIPTION
## Problem

The **Website** (and **Vercel**) CI checks have been red on `main` for a while:

```
[ERROR] [vite] ✗ Could not resolve "../../components/common/RenderPreview.astro"
from "src/content/showcases/pt/graphics.mdx"
```

`pt/graphics.mdx` imported with 2-level relative paths
(`../../components/common/...`). From `src/content/showcases/pt/` that resolves to
the non-existent `src/content/components/common/`. Every other locale showcase
(`es`, `ja`, `zh`, `zh-hk`, `el`) correctly uses 3-level paths
(`../../../components/common/...`).

## Fix

Align `pt/graphics.mdx`'s two imports (`RenderPreview`, `TerminalOutput`) with the
other locales — `../../../components/common/...`.

## Verification

A scan of all content MDX confirms **all 16 relative component imports now resolve
to existing files** (previously 2 unresolved, both in this file).

> Note: a full local `astro build` can't complete in the CI sandbox here — it dies
> at astro's Wasm setup with an address-space OOM (137Gi free; a Node/V8 Wasm limit
> in this environment, unrelated to the change). CI's runner is unaffected. The
> "could not resolve" failure is a static import-resolution error, deterministically
> verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)