### PR TITLE
fix(check): enforce ontology axioms in Madaros boot4 verdict path

### DIFF
--- a/self-hosted/check/mod.sio
+++ b/self-hosted/check/mod.sio
@@ -514,12 +514,45 @@ pub fn check_items_verdict_boot4_with_module_path(items: Option<Box<ItemList>>, 
         return 1
     }
     heap_free(checker_ptr as i64)
+    if check_items_ontology_verdict(items) != 0 {
+        return 1
+    }
     0
 }
 
 // Multi-module typecheck verdict: load all programs into a single checker so
 // cross-module names are resolvable, but perform the visibility check with
 // each program's real module_path as current_module.  Returns 0=ok, 1=reject.
+// Ontology semantic verdict. The boot4/Madaros in-place checker spine
+// (checker_collect_item_inplace) does not collect ItemOntology, so ontology
+// role/property/inverse axiom violations (E156–E160) slip through. The full
+// by-value path (collect_items -> collect_ontology_def) does enforce them.
+// Run a focused by-value ontology-only collection over the item list on a fresh
+// checker and report a reject (1) if any ontology axiom error was raised.
+// Returns 0 when clean. This closes the gap without copying the main 164KB
+// in-place Checker (the fresh by-value checker mirrors check_program's own
+// collect path, which Madaros already executes).
+pub fn check_items_ontology_verdict(items: Option<Box<ItemList>>) -> i64 with Mut, Panic, Div, Alloc, IO {
+    var checker = checker_new()
+    var cursor = items
+    while true {
+        match cursor {
+            Some(list) => {
+                let item = (*list).head
+                if item.kind == ItemKind::ItemOntology {
+                    checker = checker.collect_ontology_def(item.ontology_def)
+                }
+                cursor = (*list).tail
+            }
+            None => break
+        }
+    }
+    if checker.had_error || checker.error_count > 0 {
+        return 1
+    }
+    0
+}
+
 pub fn check_modules_verdict_boot4(programs: &! [Program; 256], count: i64) -> i64 with Mut, Panic, Div, Alloc, IO {
     if count <= 0 {
         return 0
@@ -555,6 +588,15 @@ pub fn check_modules_verdict_boot4(programs: &! [Program; 256], count: i64) -> i
         return 1
     }
     heap_free(checker_ptr as i64)
+
+    // Ontology axiom validation per module (see check_items_ontology_verdict).
+    var k: i64 = 0
+    while k < count && k < 256 {
+        if check_items_ontology_verdict((*programs)[k as usize].items) != 0 {
+            return 1
+        }
+        k = k + 1
+    }
     0
 }
 
@@ -1536,6 +1578,10 @@ pub fn check_items_verdict_boot4_with_ontocache_sidecar(items: Option<Box<ItemLi
     checker_collect_items_mut(checker_ptr, items)
     let had_error = checker_check_items_inner_store_return_had_error_mut(checker_ptr, items)
     if had_error == 1 {
+        heap_free(checker_ptr as i64)
+        return 1
+    }
+    if check_items_ontology_verdict(items) != 0 {
         heap_free(checker_ptr as i64)
         return 1
     }


### PR DESCRIPTION
## What

Closes the **Madaros ontology-enforcement gap** (root cause behind the long-red Contracts ontology step, fixed at the gate level in #319).

The boot4/Madaros in-place checker spine (`checker_collect_item_inplace`, `check.sio:2832`) handles only `ItemFn/Struct/Enum/Use`; **`ItemOntology` hits the `else` no-op**, so ontology role/property/inverse axiom violations (E156–E160) were silently accepted by the default engine. `lean_single` and the by-value path (`collect_items → collect_ontology_def`) enforce them.

## How

New `check_items_ontology_verdict(items)` in `check/mod.sio`: a focused by-value ontology-only collection on a fresh checker, returning reject (1) on any ontology axiom error. It **reuses the proven `collect_ontology_def`** (the same by-value collect path `check_program` already runs in Madaros) rather than copying the 164KB in-place `Checker`, so it sidesteps the stale-stack codegen bug the in-place spine exists to avoid.

Wired into all three boot4 verdict entrypoints:
- `check_items_verdict_boot4_with_module_path` (single module)
- `check_items_verdict_boot4_with_ontocache_sidecar` (single module + cache)
- `check_modules_verdict_boot4` (per module)

## Verification status — please read

- ✅ Type-checks under `lean_single` (the stage0 that builds Madaros).
- ⚠️ **The Madaros binary could not be rebuilt or run in the authoring workspace.** The `lean_single` seed segfaults compiling `main.sio` there — reproduced on a clean tree, with all four checked-in seeds, sandboxed and not. The committed Jun-16 `bin/madaros-linux-x86_64` was built elsewhere. So binary-level behavior (does Madaros now reject the 4 fixtures? does the by-value loop compile cleanly?) is **unverified locally**.
- Validation path: CI's `madaros-prebuilt-refresh` workflow (`make build-madaros` + `madaros_full_gate.sh`). That workflow **refuses to refresh the prebuilt if the gate fails**, so a miscompile is a safe no-op (gap stays open, no regression).

## Scope

Does **not** change the `lean_single` CI pins from #319/#320 — the ontology-validation and PBPK gates still need `lean_single` for the *separate* Madaros package-resolution and GPU-effect gaps. This closes only the ontology-collection gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)