### PR TITLE
fix(madaros): in-place ontology axiom enforcement + drop AVX-512 startup guard

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -2862,6 +2862,183 @@ fn checker_check_items_inplace(c: *mut Checker, items: Option<Box<ItemList> >) w
     }
 }
 
+// ============================================================================
+// In-place ontology axiom validation (Madaros boot4 path).
+//
+// The by-value collect_ontology_def path loses its error state in Madaros: it
+// threads a ~164KB Checker through deep `c = c.method()` recursion, which the
+// native codegen miscompiles (the same large-struct copy bug the *mut spine
+// exists to avoid). These helpers validate ontology axioms directly on the
+// parsed AST lists (pointer-sized, no large copies) and report through
+// checker_report_error_at_inplace:
+//   E156 role domain class not found, E157 role range class not found,
+//   E158 inverse_of target role not found, E159 duplicate role declaration,
+//   E041 ontology subsumption could not be verified (child property weakens parent).
+// ============================================================================
+
+fn onto_class_list_has(classes: Option<Box<OntologyClassDeclList> >, target: Name) -> bool with Mut, Panic, Div {
+    var cur = classes
+    while true {
+        match cur {
+            Some(list) => {
+                if name_eq((*list).head.name, target) {
+                    return true
+                }
+                cur = (*list).tail
+            }
+            None => break
+        }
+    }
+    false
+}
+
+fn onto_role_list_has(roles: Option<Box<OntologyRoleDeclList> >, target: Name) -> bool with Mut, Panic, Div {
+    var cur = roles
+    while true {
+        match cur {
+            Some(list) => {
+                if name_eq((*list).head.name, target) {
+                    return true
+                }
+                cur = (*list).tail
+            }
+            None => break
+        }
+    }
+    false
+}
+
+fn onto_role_count_in_prefix(roles: Option<Box<OntologyRoleDeclList> >, k: i64, target: Name) -> i64 with Mut, Panic, Div {
+    var cur = roles
+    var j: i64 = 0
+    var n: i64 = 0
+    while j < k {
+        match cur {
+            Some(list) => {
+                if name_eq((*list).head.name, target) {
+                    n = n + 1
+                }
+                cur = (*list).tail
+            }
+            None => break
+        }
+        j = j + 1
+    }
+    n
+}
+
+fn onto_prop_pred(p: OntologyPropertyDecl) -> RefinementPred with Mut, Panic, Div {
+    RefinementPred {
+        op: p.pred_op,
+        var_name: p.name,
+        rhs_int: p.pred_rhs_int,
+        rhs_float: p.pred_rhs_float,
+        is_float: p.is_float,
+        left: None,
+        right: None,
+    }
+}
+
+fn checker_onto_check_roles_inplace(c: *mut Checker, roles: Option<Box<OntologyRoleDeclList> >, classes: Option<Box<OntologyClassDeclList> >) with Mut, Panic, Div, Alloc, IO {
+    var cur = roles
+    var k: i64 = 0
+    while true {
+        match cur {
+            Some(list) => {
+                let decl = (*list).head
+                let dup_before = onto_role_count_in_prefix(roles, k, decl.name)
+                if dup_before > 0 || decl.duplicate_modifier_bits != 0 {
+                    checker_report_error_at_inplace(c, decl.span, 159, 0, 0, 0)
+                } else {
+                    if decl.has_domain && !onto_class_list_has(classes, decl.domain_name) {
+                        checker_report_error_at_inplace(c, decl.span, 156, 0, 0, 0)
+                    }
+                    if decl.has_range && !onto_class_list_has(classes, decl.range_name) {
+                        checker_report_error_at_inplace(c, decl.span, 157, 0, 0, 0)
+                    }
+                    if decl.has_inverse && !onto_role_list_has(roles, decl.inverse_name) {
+                        checker_report_error_at_inplace(c, decl.span, 158, 0, 0, 0)
+                    }
+                }
+                cur = (*list).tail
+                k = k + 1
+            }
+            None => break
+        }
+    }
+}
+
+fn checker_onto_check_weakening_inplace(c: *mut Checker, classes: Option<Box<OntologyClassDeclList> >) with Mut, Panic, Div, Alloc, IO {
+    var ci = classes
+    while true {
+        match ci {
+            Some(clist) => {
+                // Do NOT copy (*clist).head into a local: OntologyClassDecl contains
+                // `properties: [OntologyPropertyDecl; 8]` (an array of structs), and
+                // copying that struct misaligns the array under Madaros codegen
+                // (struct-array offset bug) — reads of properties[a].pred_op then
+                // come back 0. Access fields directly through the list pointer and
+                // copy out only a single (array-free) OntologyPropertyDecl at a time.
+                var si: i64 = 0
+                while si < (*clist).head.superclass_count && si < 8 {
+                    let sname = (*clist).head.superclass_names[si as usize]
+                    var pi = classes
+                    while true {
+                        match pi {
+                            Some(plist) => {
+                                if name_eq((*plist).head.name, sname) {
+                                    var a: i64 = 0
+                                    while a < (*clist).head.property_count && a < 8 {
+                                        let cp = (*clist).head.properties[a as usize]
+                                        var b: i64 = 0
+                                        while b < (*plist).head.property_count && b < 8 {
+                                            let pp = (*plist).head.properties[b as usize]
+                                            if name_eq(cp.name, pp.name) && cp.pred_op > 0 && pp.pred_op > 0 {
+                                                if !pred_implies(onto_prop_pred(cp), onto_prop_pred(pp)) {
+                                                    checker_report_error_at_inplace(c, cp.span, 41, 0, 0, 0)
+                                                }
+                                            }
+                                            b = b + 1
+                                        }
+                                        a = a + 1
+                                    }
+                                }
+                                pi = (*plist).tail
+                            }
+                            None => break
+                        }
+                    }
+                    si = si + 1
+                }
+                ci = (*clist).tail
+            }
+            None => break
+        }
+    }
+}
+
+pub fn checker_validate_ontology_items_inplace(c: *mut Checker, items: Option<Box<ItemList> >) with Mut, Panic, Div, Alloc, IO {
+    var cur = items
+    while true {
+        match cur {
+            Some(list) => {
+                let item = (*list).head
+                if item.kind == ItemKind::ItemOntology {
+                    match item.ontology_def {
+                        Some(odef) => {
+                            checker_onto_check_roles_inplace(c, (*odef).roles, (*odef).classes)
+                            checker_onto_check_weakening_inplace(c, (*odef).classes)
+                        }
+                        None => {}
+                    }
+                }
+                cur = (*list).tail
+            }
+            None => break
+        }
+    }
+}
+
 // *mut E042 emitter — mirrors report_multitest_correction_required (6140) but
 // mutates (*c) in place instead of copying the 8MB Checker by value.
 fn checker_report_multitest_correction_required_inplace(c: *mut Checker, span: Span, test_count: i64) with Mut, IO, Panic, Div {

--- a/self-hosted/check/mod.sio
+++ b/self-hosted/check/mod.sio
@@ -525,32 +525,20 @@ pub fn check_items_verdict_boot4_with_module_path(items: Option<Box<ItemList>>, 
 // each program's real module_path as current_module.  Returns 0=ok, 1=reject.
 // Ontology semantic verdict. The boot4/Madaros in-place checker spine
 // (checker_collect_item_inplace) does not collect ItemOntology, so ontology
-// role/property/inverse axiom violations (E156–E160) slip through. The full
-// by-value path (collect_items -> collect_ontology_def) does enforce them.
-// Run a focused by-value ontology-only collection over the item list on a fresh
-// checker and report a reject (1) if any ontology axiom error was raised.
-// Returns 0 when clean. This closes the gap without copying the main 164KB
-// in-place Checker (the fresh by-value checker mirrors check_program's own
-// collect path, which Madaros already executes).
+// role/property/inverse axiom violations (E156–E160) slip through. The by-value
+// collect_ontology_def path cannot be reused here: threading the ~164KB Checker
+// through its deep recursion is miscompiled by the native backend (the large-
+// struct copy bug the *mut spine exists to avoid), so its error state is lost.
+// Instead validate axioms in place over the parsed AST via
+// checker_validate_ontology_items_inplace (no large copies). Returns 1 on any
+// ontology axiom error, 0 when clean.
 pub fn check_items_ontology_verdict(items: Option<Box<ItemList>>) -> i64 with Mut, Panic, Div, Alloc, IO {
-    var checker = checker_new()
-    var cursor = items
-    while true {
-        match cursor {
-            Some(list) => {
-                let item = (*list).head
-                if item.kind == ItemKind::ItemOntology {
-                    checker = checker.collect_ontology_def(item.ontology_def)
-                }
-                cursor = (*list).tail
-            }
-            None => break
-        }
-    }
-    if checker.had_error || checker.error_count > 0 {
-        return 1
-    }
-    0
+    let checker_ptr = check_mod_alloc_checker()
+    checker_init_in_place(checker_ptr)
+    checker_validate_ontology_items_inplace(checker_ptr, items)
+    let bad = if (*checker_ptr).had_error || (*checker_ptr).error_count > 0 { 1 } else { 0 }
+    heap_free(checker_ptr as i64)
+    bad
 }
 
 pub fn check_modules_verdict_boot4(programs: &! [Program; 256], count: i64) -> i64 with Mut, Panic, Div, Alloc, IO {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -8116,15 +8116,15 @@ fn emit_entry_trampoline_heap_args_into(nc: &! NativeCompiler) with Mut, Panic, 
 }
 
 fn emit_entry_trampoline_avx_metadata_into(nc: &! NativeCompiler) with Mut, Panic, Div {
+    // Detect AVX10/AVX-512 vector level and record the VL capability mask in the
+    // runtime context (r15 = mask: bit0=128, bit1=256, bit2=512). We deliberately
+    // do NOT abort when no vector support is present: a hard exit(200) here made
+    // EVERY emitted program — including pure-scalar ones with no AVX-512 in their
+    // body (e.g. `fn main(){0}`) — refuse to run on common non-AVX-512 CPUs (most
+    // cloud/CI runners), which froze the prebuilt-refresh gate (run0 exit 200).
+    // Scalar codegen emits no EVEX, so it runs anywhere; SIMD codegen still needs
+    // AVX-512 hardware until runtime VL dispatch reads simd_capability_mask.
     nc_emit_avx10_detect(nc)
-    nc_emit_test_rax_rax(nc)
-    let avx_jnz = (*nc).code.len
-    nc_emit_jnz_rel32(nc)
-    nc_emit_mov_rdi_imm(nc, 200)
-    nc_emit_mov_rax_imm(nc, 60)
-    nc_emit_syscall(nc)
-    let avx_ok = (*nc).code.len
-    nc_patch_u32_le(nc, avx_jnz + 2, avx_ok - (avx_jnz + 6))
     nc_emit_mov_rax_r15(nc)
     emit_store_rax_runtime_context_field_into(nc, runtime_context_field_simd_capability_mask())
     if (*nc).descriptor_data_offset >= 0 {


### PR DESCRIPTION
Closes most of the Madaros ontology-enforcement gap (root cause behind the long-red Contracts ontology step) and unblocks the frozen Madaros prebuilt refresh. Supersedes the by-value wiring from #322 (which was verified ineffective in Madaros).

## 1. run0 / AVX-512 startup guard (`codegen_x86_linux.sio`)
The entry trampoline emitted an AVX10/AVX-512 `cpuid` probe that called `exit(200)` before `main` when no vector support was present — so **every** emitted binary, including pure-scalar `fn main(){0}`, refused to run on non-AVX-512 CPUs (GitHub/cloud runners). That failed `madaros_full_gate`'s `run0` and froze the prebuilt since it landed. Keep detection + store the VL mask; **drop the hard abort**. Scalar output now runs on any x86-64.

Verified on a CI-built Madaros: the full `madaros_full_gate` passes on the non-AVX-512 runner; the emitted ELF no longer contains the `exit(200)` guard.

## 2. In-place ontology axiom enforcement (`check.sio` + `mod.sio`)
The boot4/Madaros in-place checker spine doesn't collect `ItemOntology`, and the by-value `collect_ontology_def` loses its error state in Madaros (the ~164KB `Checker` copy is miscompiled — confirmed by diagnostic). New `checker_validate_ontology_items_inplace` validates axioms **directly on the parsed AST** (pointer-sized, no large-struct copies) and reports via `checker_report_error_at_inplace`.

**Enforced now (verified on CI-built Madaros, zero false positives across all run-pass ontology fixtures):**
- `E159` duplicate role declaration
- `E157` role range class not found
- `E158` inverse_of target role not found

## Known remaining gap (out of scope)
`E041` property weakening does **not** fire: the modular parser stores property predicates via a struct-array element write (`properties[i] = OntologyPropertyDecl{...}`) that Madaros miscompiles — `properties[i].pred_op` reads back `0`, so the `where` constraint never reaches the AST. That's a separate native **struct-array-store** codegen bug, tracked in #325 (the inert weakening check is kept; it'll work once that bug is fixed). The `lean_single` CI pins (#319/#320) remain.

## Verification (CI-built binary, ref=this branch)
```
ontology_role_duplicate_decl        exit=1  (E159)
ontology_role_bad_domain_or_range   exit=1  (E157)
ontology_role_inverse_target_missing exit=1 (E158)
ontology_property_weakening         exit=0  (known gap)
run0                                exit=0
run-pass ontology false positives:  none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)