### PR TITLE
[codex] Fix MCP check JSON invocation and path-stable tests

### DIFF
--- a/tools/mcp/sounio_mcp/check.py
+++ b/tools/mcp/sounio_mcp/check.py
@@ -40,7 +40,7 @@ async def sounio_check(source_path: str) -> dict[str, Any]:
             "stderr": "",
         }
 
-    result = await run_command([souc, "check", "--json", source], timeout_sec=30)
+    result = await run_command([souc, "check", source, "--json"], timeout_sec=30)
     diagnostics = diagnostics_from_payload(result.stdout, result.stderr)
     if result.timed_out and not diagnostics:
         diagnostics = [

--- a/tools/mcp/sounio_mcp/test.py
+++ b/tools/mcp/sounio_mcp/test.py
@@ -55,7 +55,7 @@ async def _run_one(souc: Path, path: Path) -> tuple[str, dict[str, Any] | None]:
     )
     check_only = "check-only" in ann
     if is_compile_fail or check_only:
-        result = await run_command([souc, "check", "--json", path], timeout_sec=30)
+        result = await run_command([souc, "check", path, "--json"], timeout_sec=30)
         diagnostics = diagnostics_from_payload(result.stdout, result.stderr)
         if is_compile_fail:
             expected = ann.get("error-pattern", [""])[0]

--- a/tools/mcp/tests/fixtures/mcp_hello.sio
+++ b/tools/mcp/tests/fixtures/mcp_hello.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+//@ expect-stdout: MCP_HELLO_OK
+
+fn main() with IO {
+    println("MCP_HELLO_OK")
+    return 0
+}

--- a/tools/mcp/tests/test_loop.py
+++ b/tools/mcp/tests/test_loop.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from examples.llmloop_recipe import run_benchmark
+from sounio_mcp.common import REPO_ROOT
 
 
 @pytest.mark.asyncio
 async def test_error_fix_loop_converges_on_fixture_set() -> None:
-    fixtures = sorted(Path("tests/fixtures/broken").glob("*.sio"))
+    fixtures = sorted((REPO_ROOT / "tests" / "fixtures" / "broken").glob("*.sio"))
     report = await run_benchmark(fixtures, max_iterations=10, seed=1729)
     assert report["fixtures"] == 20
     assert report["convergence_rate"] >= 0.8

--- a/tools/mcp/tests/test_tools.py
+++ b/tools/mcp/tests/test_tools.py
@@ -23,17 +23,20 @@ async def test_sounio_check_reports_broken_fixture() -> None:
 
 @pytest.mark.asyncio
 async def test_sounio_check_shared_schema_envelope_validates() -> None:
+    from sounio_mcp.common import REPO_ROOT
+
     result = await sounio_check("tests/fixtures/broken_dose.sio")
-    with open("tools/shared/diagnostic_schema.json", encoding="utf-8") as handle:
+    schema_path = REPO_ROOT / "tools" / "shared" / "diagnostic_schema.json"
+    with open(schema_path, encoding="utf-8") as handle:
         schema = json.load(handle)
     Draft202012Validator(schema).validate(result["diagnostic_envelope"])
 
 
 @pytest.mark.asyncio
 async def test_sounio_run_hello() -> None:
-    result = await sounio_run("examples/hello.sio")
+    result = await sounio_run("tools/mcp/tests/fixtures/mcp_hello.sio")
     assert result["status"] == "ok"
-    assert "Hello, Sounio" in result["stdout"]
+    assert "MCP_HELLO_OK" in result["stdout"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Calls `souc check <source> --json` from MCP check/test paths, matching the current compiler CLI behavior.
- Makes MCP tests resolve fixtures and shared schemas from `REPO_ROOT` instead of the caller working directory.
- Adds a tiny MCP-owned run fixture so `test_sounio_run_hello` no longer depends on the global `examples/hello.sio` sample text.

## Why

The MCP server is the LLM-codegen surface. Its tests should be stable regardless of caller CWD and should not depend on examples whose pedagogical content can change independently from MCP behavior.

## Validation

- `cd tools/mcp && uv run --extra dev pytest tests/` passed: 12 passed.
- `git diff --check` passed.

## Notes

- `python3 -m pip install -e '.[dev]'` could not run directly because the container Python is externally managed under PEP 668.
- `python3 -m venv` could not run because `python3-venv` is not installed.
- `uv` provided the isolated validation environment without touching the global Python install.
