### PR TITLE
fix(madaros): native_v2 codegen — print-int, for-loops, enum registration, break/continue (+ regression gates)

### DIFF
--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -62,11 +62,16 @@ jobs:
           # A GATE failure means current main's Madaros is not shippable (often
           # because main itself is broken) -> do NOT fail the job and do NOT
           # commit; keep the last-good prebuilt. Only a green gate refreshes.
-          if bash scripts/ci/madaros_full_gate.sh; then
+          # The full gate is the broad contract; the enum + loop gates additionally
+          # build+run enum-variant USE and for/while + break/continue (which the full
+          # gate never exercised), so a prebuilt that regresses those is not shipped.
+          if bash scripts/ci/madaros_full_gate.sh \
+             && bash scripts/ci/madaros_enum_gate.sh \
+             && bash scripts/ci/madaros_loop_gate.sh; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
           else
             echo "passed=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Madaros full gate did not pass on current main — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
+            echo "::warning::A Madaros gate (full / enum / loop) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
           fi
 
       - name: Install built Madaros as the checked-in prebuilt

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ madaros-enum-gate:   ## Run the focused enum declaration + variant-use regressio
 	@echo "→ Running Madaros enum regression gate"
 	bash scripts/ci/madaros_enum_gate.sh
 
+madaros-loop-gate:   ## Run the focused for/while + break/continue regression gate
+	@echo "→ Running Madaros loop regression gate"
+	bash scripts/ci/madaros_loop_gate.sh
+
 clean:               ## Remove generated ELF artifacts (gen1, gen2, gen3)
 	rm -f gen1.elf gen2.elf gen3.elf gen4.elf
 	@echo "✓ Cleaned generated artifacts"

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ madaros-wide-int-gate: ## Run the wide-integer (i128/i256) experimental gate
 	@echo "→ Running Madaros wide-integer gate"
 	bash scripts/ci/madaros_wide_int_gate.sh
 
+madaros-enum-gate:   ## Run the focused enum declaration + variant-use regression gate
+	@echo "→ Running Madaros enum regression gate"
+	bash scripts/ci/madaros_enum_gate.sh
+
 clean:               ## Remove generated ELF artifacts (gen1, gen2, gen3)
 	rm -f gen1.elf gen2.elf gen3.elf gen4.elf
 	@echo "✓ Cleaned generated artifacts"

--- a/docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md
+++ b/docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md
@@ -1,0 +1,64 @@
+# Madaros native_v2: `for i in a..b` range-loop lowering (2026-06-20)
+
+Branch `fix/madaros-for-loop-lowering` off `origin/main` @ `659492156`.
+
+## Bug
+`for i in 0..10 { … }` builds with `native_v2_compile: front-half failed: ir_bodies_failed`
+(no ELF, rc 0). `--check` passes; `while` loops work.
+
+Root cause: `ExprForIn` has **no case** in the IR lowerer's expression dispatch
+(`lower.sio` `lower_expr_ref`) — the only reference was a debug `print("for_in")`. Every
+`for` loop therefore fell through to the dispatch's final `else` → `report_error()` →
+`ir_bodies_failed`. For-loops were simply never lowered.
+
+## Fix (this commit)
+Add `lower_for_in_expr_ref`, desugaring `for i in start..end { body }` into the **same IR
+shape the working `while` loop emits**:
+```
+i = start
+l_top:  cond = (i < end)        ; i <= end for inclusive (..=) ranges
+        if !cond goto l_end
+        body
+l_cont: i = i + 1               ; continue target AND fallthrough
+        goto l_top
+l_end:
+```
+- Loop var bound via `bind_local` (mutable, stable slot), incremented via `ir_copy`.
+- `push_loop_labels(l_cont, l_end)` so `continue` jumps to the increment (not skipping it)
+  and `break` exits — matching the for-loop contract.
+- Inclusive vs exclusive via `ExprRange.bin_op` (`OpRangeInclusive` → `OpLe`, else `OpLt`).
+- Bound evaluated **once** before the loop (matches lean_single semantics — required for the
+  gen2==gen3 fixed point, since the compiler's own source uses `for i in 0..n`).
+- New dispatch case `ExprForIn → lower_for_in_expr_ref`.
+
+## Safety analysis (why this is correct without a local run)
+- **No regression:** before this change all `for` loops hit `report_error()`. After it,
+  range-`for` lowers; non-range iterables (`for x in arr`) and half-open ranges
+  (`for i in 0..`, `.right == None`) **still** `report_error()` — explicit guards, no
+  silent miscompile.
+- **`end_reg` survives the loop back-edge:** `build` emits the **core_ir dedicated-slot
+  model** — `ir_slot_offset(vreg) = -(vreg+1)*8`, one never-reused stack slot per vreg
+  (confirmed by disassembly: generated code uses sequential `-0x8/-0x10/-0x18/-0x20`
+  slots). `end_reg` is written once before `l_top` and only read inside; nothing else
+  writes its slot. This is the exact mechanism by which a `while` loop's outside-initialised
+  counter `i` survives the back-edge — proven working (`while i<n {…}` → correct sums).
+- Type-check-neutral: `--check self-hosted/compiler/main.sio` = 755 errors with and without
+  the change (pre-existing prebuilt-vs-bundle noise).
+
+## Validation status — PENDING REBUILD
+The prebuilt binary cannot exercise a source change. After a madaros rebuild
+(CI `madaros-prebuilt-refresh.yml` ref=`fix/madaros-for-loop-lowering`, or batched with
+Codex's rebuild), run this matrix (exit-code verified, avoiding the still-broken int-println):
+```sounio
+fn main()->i64 { var s=0  for i in 0..10 { s=s+i }  s }          // expect 45
+fn main()->i64 { let n=10  var s=0  for i in 0..n { s=s+i }  s }  // expect 45 (end as live value)
+fn main()->i64 { var s=0  for i in 0..=10 { s=s+i }  s }         // expect 55 (inclusive)
+fn main()->i64 { var s=0  for i in 0..0 { s=s+1 }  s }           // expect 0  (empty)
+fn main()->i64 { var s=0  for i in 0..10 { if i==5 { break }  s=s+i }  s }     // expect 10
+fn main()->i64 { var s=0  for i in 0..5 { if i==2 { continue }  s=s+i }  s }   // expect 8 (continue increments)
+fn main()->i64 { var s=0  for i in 0..3 { for j in 0..3 { s=s+1 } }  s }       // expect 9 (nested)
+fn main()->i64 { var a:[i64;3]=[10,20,30]  var s=0  for i in 0..3 { s=s+a[i] }  s }  // expect 60
+// for x in arr  ->  must still fail cleanly (report_error / ir_bodies_failed), no crash
+```
+This fix is plausibly on the **gen2==gen3 critical path** (the compiler uses `for i in 0..n`),
+unlike the int-println fix.

--- a/docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md
+++ b/docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-for-loop-lowering-2026-06-20
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-for-loop-lowering-2026-06-20
+-->
+
 # Madaros native_v2: `for i in a..b` range-loop lowering (2026-06-20)
 
 Branch `fix/madaros-for-loop-lowering` off `origin/main` @ `659492156`.

--- a/docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md
+++ b/docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md
@@ -1,0 +1,55 @@
+# Madaros native_v2: `println`/`print` of an integer literal — fix (2026-06-20)
+
+Branch `fix/madaros-print-int-dispatch` off `origin/main` @ `659492156`.
+
+## Bug
+`println(42)` / `print(42)` SIGSEGV at runtime of the generated ELF (not at compile).
+`println("…")` works. Reproduced and isolated by core-dump disassembly of the *generated*
+program (`/tmp/pi.elf`):
+
+```
+main:            mov $0x2a,%rax ; ... ; mov 42,%rdi ; call print_str_helper
+print_str_helper(0x401067):  mov %rdi,%rsi ; movzbq (%rdi),%rax  <-- CRASH (rdi=42 as char*)
+                             ... strlen then write(fd, ptr, len)
+```
+
+`println(x)` is lowered (`self-hosted/ir/lower.sio`, println branch) to
+`print(x); print_char('\n')`, and `print` resolves to the `print_str` builtin
+(strlen+write). For an integer argument the raw value is handed to `print_str` as a
+`char*`, so the strlen loop dereferences address `0x2a` → SIGSEGV. There is no
+int→string dispatch. (Original code comment even said: *"println works for any argument
+type that print accepts (primarily strings)."*)
+
+## Why lowering, not codegen
+The native_v2 backend already has a correct integer printer — `print_int`
+(`emit_builtin_print_int_into`, div-by-10 itoa). Proven locally with the prebuilt binary:
+`print_int(42)` → `42`, `print_int(var)` → works; `print(42)` → SIGSEGV. The backend
+only tracks int-vs-float per reg (`is_float_reg`), **not** string-vs-int, so it has no
+marker to dispatch on at codegen time. The dispatch must happen in lowering, where the
+argument AST is available.
+
+## Fix (this commit)
+In `lower.sio`, route `println`/`print` of an **integer literal** (`ExprKind::ExprIntLit`)
+to the `print_int` builtin instead of `print`/`print_str`. New free helper
+`lower_call_first_arg_is_int_literal`. Defaults to `print` (string) for every other
+argument form → **zero string regression**.
+
+## Scope / known limitation (honest)
+- `struct Expr` (parser/ast.sio) carries **no inferred type** on a general expression, so
+  at lowering only an integer *literal* is unambiguously typed. `println(n)` where `n` is
+  an int **variable** or an arithmetic result is **not** covered and still uses `print_str`
+  (i.e. still crashes). Fixing the general case needs checker type info threaded into
+  lowering (or a string-vs-int reg/local marker added to lowering+codegen).
+- `println(<float>)` is a separate bug: `print_f64` is not wired as a native_v2 builtin
+  (a direct `print_f64(3.14)` build fails). Not addressed here.
+- Likely a user-facing correctness/completeness win, **not** a gen2==gen3 fixed-point
+  unblocker (the compiler formats its own numbers via buffers, not `println(int)`).
+
+## Validation status
+- `--check` of `self-hosted/compiler/main.sio` with the prebuilt madaros: **755 errors
+  both with and without this change** (pre-existing prebuilt-vs-full-bundle noise) →
+  the edit is **type-check-neutral** (adds no new errors).
+- End-to-end behaviour (int literal actually prints) is **unverified pending a madaros
+  rebuild** from this source — the prebuilt binary cannot exercise the source change.
+  Verify after rebuild (CI `madaros-prebuilt-refresh.yml` ref=`fix/madaros-print-int-dispatch`):
+  `println(42)` prints `42\n` rc 0; `println("hi")` still prints `hi`; full census unchanged.

--- a/docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md
+++ b/docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-print-int-dispatch-2026-06-20
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-print-int-dispatch-2026-06-20
+-->
+
 # Madaros native_v2: `println`/`print` of an integer literal — fix (2026-06-20)
 
 Branch `fix/madaros-print-int-dispatch` off `origin/main` @ `659492156`.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 730
-- Repo-backed topics: 580
+- Total governed topics: 732
+- Repo-backed topics: 582
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 438
+- Authority count `repo_only`: 440
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 442 topics
+- A2: 444 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -105,6 +105,8 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-audit-2026-06-10 | repo_only | docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-stack-clash-2026-05-29 | repo_only | docs/audit/MODULAR_COMPILER_STACK_CLASH_2026-05-29.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-pipe-coverage-map-2026-06-01 | repo_only | docs/audit/MODULAR_PIPE_COVERAGE_MAP_2026-06-01.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1887,6 +1887,52 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-for-loop-lowering-2026-06-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.madaros-print-int-dispatch-2026-06-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.modular-compiler-audit-2026-06-10",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md",

--- a/scripts/ci/madaros_enum_gate.sh
+++ b/scripts/ci/madaros_enum_gate.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Focused regression gate for enum declaration + enum variant USE in Madaros.
+#
+# Why this exists: enum-variant use (E::A, `match` on an enum, `E::A as i64`)
+# SIGSEGV'd the native_v2 compiler because lowerer_register_enum_variants_mut wrote
+# the variant table with a two-level nested store
+# (`(*(*lo).enum_variants).entries[idx] = ...`) that the codegen silently discards,
+# leaving enum_variants empty so lookup_variant_discriminant fell through to a
+# corrupt module.functions scan. See docs/audit/MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md.
+#
+# The generic full gate never exercised enum USE, so the bug shipped green. This
+# gate builds AND runs each fixture and checks the exit code, so it FAILS on a
+# pre-fix Madaros (compile SIGSEGV / wrong discriminant) and PASSES once fixed.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MADAROS="${MADAROS_BIN:-$ROOT_DIR/bin/madaros}"
+WORK="${SOUNIO_MADAROS_ENUM_GATE_DIR:-$(mktemp -d /tmp/sounio-madaros-enum.XXXXXX)}"
+KEEP_WORK="${SOUNIO_MADAROS_ENUM_GATE_KEEP:-0}"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+mkdir -p "$WORK"
+
+fail() { echo "[madaros-enum] FAIL: $*" >&2; exit 1; }
+pass() { echo "[madaros-enum] PASS: $*"; }
+
+# build_run <name> <expected-exit> <source>
+# Builds the source to an ELF (compiler must not crash) and runs it, asserting the
+# program's exit code. A compiler SIGSEGV shows up as a missing emit marker.
+build_run() {
+  local name="$1" expected="$2" src="$3"
+  local sio="$WORK/$name.sio" elf="$WORK/$name.elf" log="$WORK/$name.log"
+  printf '%s\n' "$src" > "$sio"
+
+  set +e
+  "$MADAROS" build "$sio" -o "$elf" >"$log" 2>&1
+  local crc=$?
+  set -e
+  if ! grep -Fq "native_v2_compile: emitted path=$elf" "$log"; then
+    echo "[madaros-enum] build log tail for $name (rc=$crc):" >&2
+    tail -n 20 "$log" >&2 || true
+    fail "$name: compiler did not emit an ELF (Root2 enum-registration regression?)"
+  fi
+  [[ -s "$elf" ]] || fail "$name: missing ELF $elf"
+  chmod +x "$elf"
+
+  set +e
+  "$elf"
+  local rrc=$?
+  set -e
+  if [[ "$rrc" != "$expected" ]]; then
+    fail "$name: expected exit $expected, got $rrc"
+  fi
+  pass "$name (exit $rrc)"
+}
+
+printf '[madaros-enum] madaros=%s\n' "$MADAROS"
+printf '[madaros-enum] work=%s\n' "$WORK"
+
+# Declaration only (never regressed, but pins the baseline).
+build_run enum_decl_unused 5 'enum E { A, B }
+fn main() -> i64 { 5 }'
+
+# Variant USE in a let binding — the exact Root2 SIGSEGV repro.
+build_run enum_let_use 5 'enum E { A, B }
+fn main() -> i64 { let e = E::A
+    5 }'
+
+# Variant value via discriminant (default discriminants start at 0: A=0, B=1).
+build_run enum_as_int 1 'enum E { A, B }
+fn main() -> i64 { E::B as i64 }'
+
+# Match on an enum scrutinee resolves to the right arm value.
+build_run enum_match_b 20 'enum E { A, B }
+fn main() -> i64 { let e = E::B
+    match e { E::A => 10, E::B => 20 } }'
+
+# Three-variant enum: discriminant ordering A=0,B=1,C=2 through a match.
+build_run enum_match_three 2 'enum C { X, Y, Z }
+fn main() -> i64 { let c = C::Z
+    match c { C::X => 0, C::Y => 1, C::Z => 2 } }'
+
+echo "[madaros-enum] all enum regression fixtures passed"

--- a/scripts/ci/madaros_enum_gate.sh
+++ b/scripts/ci/madaros_enum_gate.sh
@@ -37,17 +37,20 @@ build_run() {
   local name="$1" expected="$2" src="$3"
   local sio="$WORK/$name.sio" elf="$WORK/$name.elf" log="$WORK/$name.log"
   printf '%s\n' "$src" > "$sio"
+  rm -f "$elf"
 
+  # Check ELF-produced (not a build-subcommand log marker): the production launcher
+  # path prints "Output:" while the raw build subcommand prints "emitted path=";
+  # both produce the ELF on success, and a compiler crash produces none.
   set +e
   "$MADAROS" build "$sio" -o "$elf" >"$log" 2>&1
   local crc=$?
   set -e
-  if ! grep -Fq "native_v2_compile: emitted path=$elf" "$log"; then
+  if [[ ! -s "$elf" ]]; then
     echo "[madaros-enum] build log tail for $name (rc=$crc):" >&2
     tail -n 20 "$log" >&2 || true
-    fail "$name: compiler did not emit an ELF (Root2 enum-registration regression?)"
+    fail "$name: compiler produced no ELF (Root2 enum-registration regression?)"
   fi
-  [[ -s "$elf" ]] || fail "$name: missing ELF $elf"
   chmod +x "$elf"
 
   set +e

--- a/scripts/ci/madaros_loop_gate.sh
+++ b/scripts/ci/madaros_loop_gate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Focused regression gate for for/while loops + break/continue in Madaros.
+#
+# break/continue were silently broken in BOTH for and while: push_loop_labels
+# recorded loop labels with a two-level nested store
+# (`(*lo.loop_labels).break_labels[depth] = ...`) that the codegen discards, so
+# current_break/continue_label found no target and every break/continue reported
+# ir_bodies_failed. for-in range loops were also unlowered before the ExprForIn
+# lowering landed. The generic full gate exercised neither, so both shipped green.
+# This gate builds AND runs each fixture and checks the exit code.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"; cd "$ROOT_DIR"
+MADAROS="${MADAROS_BIN:-$ROOT_DIR/bin/madaros}"
+WORK="${SOUNIO_MADAROS_LOOP_GATE_DIR:-$(mktemp -d /tmp/sounio-madaros-loop.XXXXXX)}"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+[[ "${SOUNIO_MADAROS_LOOP_GATE_KEEP:-0}" == "1" ]] || trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK"
+fail() { echo "[madaros-loop] FAIL: $*" >&2; exit 1; }
+pass() { echo "[madaros-loop] PASS: $*"; }
+build_run() {
+  local name="$1" expected="$2" src="$3"
+  local sio="$WORK/$name.sio" elf="$WORK/$name.elf" log="$WORK/$name.log"
+  printf '%s\n' "$src" > "$sio"
+  set +e; "$MADAROS" build "$sio" -o "$elf" >"$log" 2>&1; local crc=$?; set -e
+  if ! grep -Fq "native_v2_compile: emitted path=$elf" "$log"; then
+    echo "[madaros-loop] build log tail for $name (rc=$crc):" >&2; tail -n 20 "$log" >&2 || true
+    fail "$name: compiler did not emit an ELF (loop/break-continue lowering regression?)"
+  fi
+  [[ -s "$elf" ]] || fail "$name: missing ELF $elf"; chmod +x "$elf"
+  set +e; "$elf"; local rrc=$?; set -e
+  [[ "$rrc" == "$expected" ]] || fail "$name: expected exit $expected, got $rrc"
+  pass "$name (exit $rrc)"
+}
+printf '[madaros-loop] madaros=%s\n' "$MADAROS"
+build_run for_sum        45 'fn main() -> i64 { var s = 0
+    for i in 0..10 { s = s + i }
+    s }'
+build_run for_inclusive  55 'fn main() -> i64 { var s = 0
+    for i in 0..=10 { s = s + i }
+    s }'
+build_run for_var_end    45 'fn main() -> i64 { let n = 10
+    var s = 0
+    for i in 0..n { s = s + i }
+    s }'
+build_run for_array      60 'fn main() -> i64 { var a: [i64; 3] = [10, 20, 30]
+    var s = 0
+    for i in 0..3 { s = s + a[i] }
+    s }'
+build_run nested_for      9 'fn main() -> i64 { var s = 0
+    for i in 0..3 { for j in 0..3 { s = s + 1 } }
+    s }'
+build_run for_break      10 'fn main() -> i64 { var s = 0
+    for i in 0..10 { if i == 5 { break }
+        s = s + i }
+    s }'
+build_run for_continue    8 'fn main() -> i64 { var s = 0
+    for i in 0..5 { if i == 2 { continue }
+        s = s + i }
+    s }'
+build_run while_break     10 'fn main() -> i64 { var s = 0
+    var i = 0
+    while i < 10 { if i == 5 { break }
+        s = s + i
+        i = i + 1 }
+    s }'
+echo "[madaros-loop] all loop/break/continue fixtures passed"

--- a/scripts/ci/madaros_loop_gate.sh
+++ b/scripts/ci/madaros_loop_gate.sh
@@ -20,13 +20,15 @@ pass() { echo "[madaros-loop] PASS: $*"; }
 build_run() {
   local name="$1" expected="$2" src="$3"
   local sio="$WORK/$name.sio" elf="$WORK/$name.elf" log="$WORK/$name.log"
-  printf '%s\n' "$src" > "$sio"
+  printf '%s\n' "$src" > "$sio"; rm -f "$elf"
+  # Check ELF-produced (production launcher prints "Output:", raw build subcommand
+  # prints "emitted path="; both produce the ELF on success, a crash produces none).
   set +e; "$MADAROS" build "$sio" -o "$elf" >"$log" 2>&1; local crc=$?; set -e
-  if ! grep -Fq "native_v2_compile: emitted path=$elf" "$log"; then
+  if [[ ! -s "$elf" ]]; then
     echo "[madaros-loop] build log tail for $name (rc=$crc):" >&2; tail -n 20 "$log" >&2 || true
-    fail "$name: compiler did not emit an ELF (loop/break-continue lowering regression?)"
+    fail "$name: compiler produced no ELF (loop/break-continue lowering regression?)"
   fi
-  [[ -s "$elf" ]] || fail "$name: missing ELF $elf"; chmod +x "$elf"
+  chmod +x "$elf"
   set +e; "$elf"; local rrc=$?; set -e
   [[ "$rrc" == "$expected" ]] || fail "$name: expected exit $expected, got $rrc"
   pass "$name (exit $rrc)"

--- a/self-hosted/io/env.sio
+++ b/self-hosted/io/env.sio
@@ -8,13 +8,27 @@ module io::env
 
 pub fn read_env(key: string) -> string with IO, Mut, Div, Panic {
     let env_path = "/proc/self/environ"
-    let size = file_size(env_path)
-    if size <= 0 {
-        return ""
-    }
+    // NOTE: file_size() returns 0 for procfs files (the kernel reports st_size=0
+    // for /proc/self/environ), so it CANNOT bound the scan. read_file() mmaps a
+    // zero-filled buffer and reads the full NUL-delimited environ block into it;
+    // byte-indexing sees past the per-entry NULs. Derive the content length by
+    // scanning to the boundary double-NUL: the kernel-written content ends at the
+    // last entry's NUL, after which the mmap zero-fill yields a second NUL. Env
+    // entries are never empty, so the first 0,0 pair is the true end. The 1 MiB cap
+    // guards against a pathological missing terminator.
     let data = read_file(env_path)
     let key_len = str_len(key)
     if key_len <= 0 {
+        return ""
+    }
+    var size: i64 = 0
+    while size < 1048576 {
+        if data[size as usize] == 0 && data[(size + 1) as usize] == 0 {
+            break
+        }
+        size = size + 1
+    }
+    if size <= 0 {
         return ""
     }
 

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6752,6 +6752,89 @@ impl Lowerer {
         lo.emit_unit()
     }
 
+    fn lower_for_in_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        // Desugar `for i in start..end { body }` into the working while-loop IR:
+        //   i = start
+        //   l_top:  if !(i < end) goto l_end      // i <= end for inclusive ranges
+        //           body
+        //   l_cont: i = i + 1                      // continue target + fallthrough
+        //           goto l_top
+        //   l_end:
+        // Only integer range iterables (ExprRange) are supported; any other
+        // iterable reports an error rather than silently miscompiling.
+        let iter_opt: Option<Box<Expr>> = e.left
+        match iter_opt {
+            Some(iter_box) => {
+                if (*iter_box).kind != ExprKind::ExprRange {
+                    return (self.report_error(), IR_INVALID_REG)
+                }
+                // Half-open ranges (`for i in 0..`) have no end bound; the loop
+                // condition would compare against an invalid register. Reject rather
+                // than silently miscompile.
+                match (*iter_box).right {
+                    None => return (self.report_error(), IR_INVALID_REG),
+                    _ => {}
+                }
+                let pair_start = self.lower_opt_expr_ref(&(*iter_box).left)
+                var lo = pair_start.0
+                let start_reg = pair_start.1
+                let pair_iv = lo.fresh_reg()
+                lo = pair_iv.0
+                let iv = pair_iv.1
+                lo = lo.emit(ir_copy(iv, start_reg))
+                lo = lo.bind_local(e.name, iv, true)
+
+                let pair_end = lo.lower_opt_expr_ref(&(*iter_box).right)
+                lo = pair_end.0
+                let end_reg = pair_end.1
+
+                let pair_top = lo.fresh_label()
+                lo = pair_top.0
+                let l_top = pair_top.1
+                let pair_cont = lo.fresh_label()
+                lo = pair_cont.0
+                let l_cont = pair_cont.1
+                let pair_end_lbl = lo.fresh_label()
+                lo = pair_end_lbl.0
+                let l_end = pair_end_lbl.1
+
+                lo = lo.emit(ir_label(l_top))
+                let cmp_op = if (*iter_box).bin_op == BinaryOp::OpRangeInclusive { BinaryOp::OpLe } else { BinaryOp::OpLt }
+                let pair_cond = lo.fresh_reg()
+                lo = pair_cond.0
+                let cond = pair_cond.1
+                lo = lo.emit(ir_binop(cond, iv, cmp_op, end_reg))
+                lo = lo.emit(ir_branch_false(cond, l_end))
+
+                lo = lo.push_loop_labels(l_cont, l_end)
+                let for_block_opt: Option<Box<Block>> = e.block
+                match for_block_opt {
+                    Some(blk) => {
+                        let pair_body = lo.lower_block_ref(&(*blk))
+                        lo = pair_body.0
+                    }
+                    None => {}
+                }
+                lo = lo.pop_loop_labels()
+
+                lo = lo.emit(ir_label(l_cont))
+                let pair_one = lo.fresh_reg()
+                lo = pair_one.0
+                let one_reg = pair_one.1
+                lo = lo.emit(ir_load_imm(one_reg, 1))
+                let pair_next = lo.fresh_reg()
+                lo = pair_next.0
+                let next_reg = pair_next.1
+                lo = lo.emit(ir_binop(next_reg, iv, BinaryOp::OpAdd, one_reg))
+                lo = lo.emit(ir_copy(iv, next_reg))
+                lo = lo.emit(ir_jump(l_top))
+                lo = lo.emit(ir_label(l_end))
+                lo.emit_unit()
+            }
+            None => (self.report_error(), IR_INVALID_REG),
+        }
+    }
+
     fn lower_block_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let block_opt: Option<Box<Block>> = e.block
         match block_opt {
@@ -7035,6 +7118,8 @@ impl Lowerer {
             self.lower_while_expr_ref(e)
         } else if e.kind == ExprKind::ExprLoop {
             self.lower_loop_expr_ref(e)
+        } else if e.kind == ExprKind::ExprForIn {
+            self.lower_for_in_expr_ref(e)
         } else if e.kind == ExprKind::ExprBlock {
             self.lower_block_expr_ref(e)
         } else if e.kind == ExprKind::ExprReturn {

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1817,6 +1817,21 @@ fn lower_opt_type_is_array_of_f64(opt: &Option<Box<TypeExpr>>) -> bool with Mut,
     }
 }
 
+// True iff the first call argument is an integer LITERAL (ExprIntLit). This is the
+// only argument form whose primitive type is unambiguously integer at lowering time
+// (the AST carries no inferred type on a general Expr — see struct Expr in parser/ast.sio).
+// Used to route println/print of an int literal to the print_int builtin (decimal
+// itoa+write) instead of the print/print_str builtin (strlen+write), which would
+// otherwise dereference the integer value as a char* and SIGSEGV. Non-literal int
+// arguments (variables, arithmetic) are NOT detected here and still use print_str;
+// fixing those requires threading checker type info into lowering.
+fn lower_call_first_arg_is_int_literal(args: &Option<Box<ExprList>>) -> bool with Mut, Panic, Div, Alloc {
+    match *args {
+        Some(list) => (*list).head.kind == ExprKind::ExprIntLit,
+        _ => false,
+    }
+}
+
 fn lower_opt_type_named_name(opt: &Option<Box<TypeExpr>>) -> Name with Mut, Panic, Div {
     match *opt {
         Some(te) => {
@@ -6255,8 +6270,12 @@ impl Lowerer {
             None => ir_empty_name(),
         }
         if name_eq(callee_name, make_name("print")) || name_eq(callee_name, make_name("print_int")) || name_eq(callee_name, make_name("print_char")) {
+            // Redirect bare print(<int literal>) to the print_int builtin: print
+            // (=print_str) treats its argument as a char* and would deref the integer
+            // value as a pointer. Explicit print_int / print_char are left untouched.
+            let print_builtin_name = if name_eq(callee_name, make_name("print")) && lower_call_first_arg_is_int_literal(&e.args) { make_name("print_int") } else { callee_name }
             var lo_builtin = self
-            let fn_id_builtin = lowerer_find_or_add_fn_id_mut(&! lo_builtin, callee_name)
+            let fn_id_builtin = lowerer_find_or_add_fn_id_mut(&! lo_builtin, print_builtin_name)
             let pair_args_builtin: LowerExprArgsResult = lo_builtin.lower_expr_args_ref(&e.args)
             let lo_args_builtin = pair_args_builtin.lowerer
             let args_builtin: Option<Box<IrRegList>> = if pair_args_builtin.count <= 0 { None } else { Some(Box::new(pair_args_builtin.regs)) }
@@ -6264,15 +6283,18 @@ impl Lowerer {
             let pair_dst_builtin = lo_args_builtin.fresh_reg()
             let lo_dst_builtin = pair_dst_builtin.0
             let dst_builtin = pair_dst_builtin.1
-            let lo_call_builtin = lo_dst_builtin.emit(ir_call(dst_builtin, fn_id_builtin, callee_name, args_builtin, argc_builtin))
+            let lo_call_builtin = lo_dst_builtin.emit(ir_call(dst_builtin, fn_id_builtin, print_builtin_name, args_builtin, argc_builtin))
             return (lo_call_builtin, dst_builtin)
         }
         if name_eq(callee_name, make_name("println")) {
-            // Lower println(x) -> print(x); print_char('\n') so the native-v2 backend
-            // does not need a dedicated println builtin and so println works for any
-            // argument type that print accepts (primarily strings).
+            // Lower println(x) -> print_kind(x); print_char('\n') so the native-v2
+            // backend does not need a dedicated println builtin. print_kind is print_int
+            // when x is an integer literal (decimal itoa+write) and otherwise print
+            // (=print_str, strlen+write). Routing an int literal to print_str would
+            // dereference the integer value as a char* and SIGSEGV.
+            let pl_print_name = if lower_call_first_arg_is_int_literal(&e.args) { make_name("print_int") } else { make_name("print") }
             var lo_pl = self
-            let fn_id_print = lowerer_find_or_add_fn_id_mut(&! lo_pl, make_name("print"))
+            let fn_id_print = lowerer_find_or_add_fn_id_mut(&! lo_pl, pl_print_name)
             let pair_args_pl: LowerExprArgsResult = lo_pl.lower_expr_args_ref(&e.args)
             let lo_args_pl = pair_args_pl.lowerer
             let args_pl: Option<Box<IrRegList>> = if pair_args_pl.count <= 0 { None } else { Some(Box::new(pair_args_pl.regs)) }
@@ -6280,7 +6302,7 @@ impl Lowerer {
             let pair_dst_pl = lo_args_pl.fresh_reg()
             let lo_dst_pl = pair_dst_pl.0
             let dst_pl = pair_dst_pl.1
-            var lo_call_pl = lo_dst_pl.emit(ir_call(dst_pl, fn_id_print, make_name("print"), args_pl, argc_pl))
+            var lo_call_pl = lo_dst_pl.emit(ir_call(dst_pl, fn_id_print, pl_print_name, args_pl, argc_pl))
 
             let fn_id_print_char = lowerer_find_or_add_fn_id_mut(&! lo_call_pl, make_name("print_char"))
             let pair_nl_reg = lo_call_pl.fresh_reg()

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -3263,8 +3263,15 @@ impl Lowerer {
     fn push_loop_labels(self, continue_label: i64, break_label: i64) -> Lowerer with Mut, Panic, Div {
         var lo = self
         if lo.loop_depth < 256 {
-            (*lo.loop_labels).continue_labels[lo.loop_depth as usize] = continue_label
-            (*lo.loop_labels).break_labels[lo.loop_depth as usize] = break_label
+            // Store through an extracted single-level Box pointer: the two-level
+            // nested stores `(*lo.loop_labels).break_labels[depth] = ...` are
+            // discarded by the codegen (the same two-level-nested-store miscompile
+            // that emptied enum_variants), so loop labels were never recorded and
+            // every break/continue then failed current_break/continue_label and
+            // reported an error (ir_bodies_failed) in both for and while loops.
+            var ll_box = lo.loop_labels
+            (*ll_box).continue_labels[lo.loop_depth as usize] = continue_label
+            (*ll_box).break_labels[lo.loop_depth as usize] = break_label
             lo.loop_depth = lo.loop_depth + 1
             lo
         } else {

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -579,13 +579,20 @@ fn lowerer_register_enum_variants_mut(
         match *current {
             Some(list) => {
                 if (*(*lo).enum_variants).count < 1024 {
-                    let idx = (*(*lo).enum_variants).count
-                    (*(*lo).enum_variants).entries[idx as usize] = EnumVariantEntry {
+                    // Extract the Box pointer to a local first, then store through it
+                    // once: the two-level nested store
+                    // `(*(*lo).enum_variants).entries[idx] = ...` is discarded by the
+                    // codegen (the documented two-level-nested-store miscompile), which
+                    // left enum_variants empty and broke all enum-variant uses. This
+                    // mirrors the working struct-layout registration idiom (var sl_box).
+                    var ev_box = (*lo).enum_variants
+                    let idx = (*ev_box).count
+                    (*ev_box).entries[idx as usize] = EnumVariantEntry {
                         enum_name: enum_name,
                         variant_name: (*list).head.name,
                         discriminant: disc,
                     }
-                    (*(*lo).enum_variants).count = idx + 1
+                    (*ev_box).count = idx + 1
                 } else {
                     lo.error_count = lo.error_count + 1
                     lo.had_error = true
@@ -3755,7 +3762,7 @@ impl Lowerer {
                         let enum_def_opt: Option<Box<EnumDef>> = head.enum_def
                         match enum_def_opt {
                             Some(ed) => {
-                                lo = lo.register_enum_variants_ref(name, &(*ed).variants, 0)
+                                lowerer_register_enum_variants_mut(&! lo, name, &(*ed).variants, 0)
                             }
                             _ => {}
                         }
@@ -3838,7 +3845,7 @@ impl Lowerer {
                         let enum_def_opt: Option<Box<EnumDef>> = head.enum_def
                         match enum_def_opt {
                             Some(ed) => {
-                                lo = lo.register_enum_variants_ref(name, &(*ed).variants, 0)
+                                lowerer_register_enum_variants_mut(&! lo, name, &(*ed).variants, 0)
                             }
                             _ => {}
                         }
@@ -4080,7 +4087,7 @@ impl Lowerer {
                     } else if kind == ItemKind::ItemEnum {
                         let enum_def_opt: Option<Box<EnumDef>> = head.enum_def
                         match enum_def_opt {
-                            Some(ed) => { lo = lo.register_enum_variants_ref(name, &(*ed).variants, 0) }
+                            Some(ed) => { lowerer_register_enum_variants_mut(&! lo, name, &(*ed).variants, 0) }
                             _ => {}
                         }
                     } else if kind == ItemKind::ItemImpl {


### PR DESCRIPTION
## Summary

Fixes a cluster of **native_v2 codegen** defects that made Madaros crash or silently
mislower common programs, plus two focused regression gates. Root cause for three of
them is the **same `(*lo.box).field[idx] = …` two-level-nested-store miscompile**
(the codegen discards two-level nested stores), worked around at each site by
extracting the `Box` pointer to a local first (mirrors the working struct-layout idiom).

All fixes verified on a freshly built Madaros (via `madaros-prebuilt-refresh.yml` on this
branch), by building **and running** each program and checking exit codes.

## Commits

| Commit | Fix | Verified |
|---|---|---|
| `read_env` | derive environ length by buffer scan, not `file_size` (procfs `st_size`=0 made every env var invisible; re-enables `SOUNIO_LOWER_*_TRACE`) — m2 cherry-pick | env flags read |
| `print-int` | route `println`/`print` of an **integer literal** to the `print_int` builtin; previously the int was passed to `print_str` as a `char*` → SIGSEGV | `println(42)`→`42`, `println("hi")`→`hi` |
| `for-in` | lower `ExprForIn` range loops (had **no** dispatch case → `ir_bodies_failed`); desugars to the working while-loop IR, bound evaluated once | `0..10`=45, `0..=10`=55, `0..n`=45, `arr[i]`=60 |
| **Root 2** | register enum variants via extracted `Box` ptr; the two-level store left `enum_variants` empty → enum-variant **use** SIGSEGV'd the compiler | `let e=E::A`→ok, `match`→20, `E::B as i64`=1 |
| break/continue | record loop labels via extracted `Box` ptr; the two-level store discarded labels → every `break`/`continue` (for **and** while) → `ir_bodies_failed` | `break`=10, `continue`=8, `while break`=10 |
| enum gate | `scripts/ci/madaros_enum_gate.sh` + `make madaros-enum-gate` | PASS fixed / FAIL pre-fix |
| loop gate | `scripts/ci/madaros_loop_gate.sh` + `make madaros-loop-gate` | PASS fixed / FAIL pre-fix |

The new gates **build and run** their fixtures (not just `--check`) because every bug here
was a compile-time crash or wrong-value the generic full gate never exercised.

## ⚠️ Base / merge caveat

This branch is based on **pre-#328 `659492156`**, not current `main`. PR #328's Madaros
prebuilt **SIGSEGVs on every program in the workspace pod** (even `fn main()->i64{5}`,
even at `ulimit -s unlimited`) while passing the CI gate on `ubuntu-24.04` — an
env-sensitive regression (suspect: #328's in-place `(*(*lo).module).functions[i]` write).
Building off pre-#328 was the only way to get a pod-runnable Madaros to validate these
fixes. See the coordination thread in `artifacts/omega/agent_handoff.log.md`.

**Before merge:** reconcile with current `main` (the `read_env` commit overlaps Codex's
m2 lane; the `lower.sio` println region overlaps #328). Happy to rebase onto whatever base
the integration shepherd settles, ideally a #328-regression-fixed `main`.

## Not addressed (same miscompile family, follow-ups)

`Box::new` and method-call still crash (Codex's lane); the impl-block path also hits a
separate Root-1 stack-overflow (25.7 MB frame). The general fix is the codegen one — make
two-level nested stores land — which retires the per-site workarounds here.
