### PR TITLE
ci(madaros): require source-to-ELF gate before prebuilt refresh

### DIFF
--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -64,14 +64,17 @@ jobs:
           # commit; keep the last-good prebuilt. Only a green gate refreshes.
           # The full gate is the broad contract; the enum + loop gates additionally
           # build+run enum-variant USE and for/while + break/continue (which the full
-          # gate never exercised), so a prebuilt that regresses those is not shipped.
+          # gate never exercised). The source-to-ELF gate covers the raw
+          # --native-v2-compile bridge, so a prebuilt that regresses the direct
+          # source -> native-v2 -> ELF path is not shipped.
           if bash scripts/ci/madaros_full_gate.sh \
              && bash scripts/ci/madaros_enum_gate.sh \
-             && bash scripts/ci/madaros_loop_gate.sh; then
+             && bash scripts/ci/madaros_loop_gate.sh \
+             && bash scripts/ci/madaros_source_to_elf_gate.sh; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
           else
             echo "passed=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::A Madaros gate (full / enum / loop) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
+            echo "::warning::A Madaros gate (full / enum / loop / source-to-ELF) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
           fi
 
       - name: Install built Madaros as the checked-in prebuilt
@@ -97,8 +100,9 @@ jobs:
           git commit -m "build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]
 
           Auto-rebuilt from ${SRC_REF} (make build-madaros) and passed the
-          Madaros full gate. Keeps the out-of-box Madaros default current with
-          self-hosted/compiler/main.sio. Binary size: ${BYTES} bytes."
+          Madaros full, enum, loop, and source-to-ELF gates. Keeps the
+          out-of-box Madaros default current with self-hosted/compiler/main.sio.
+          Binary size: ${BYTES} bytes."
 
           # Land on the latest main (it may have advanced during the build).
           # The binary is a generated artifact, so a rebase is normally clean.

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -39,6 +39,7 @@ require_executable bin/madaros
 require_file scripts/lib/resolve_madaros.sh
 require_file scripts/ci/build_modular_madaros.sh
 require_file scripts/ci/madaros_full_gate.sh
+require_file scripts/ci/madaros_source_to_elf_gate.sh
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   git merge-base --is-ancestor "$GREEN_BASE" HEAD ||
@@ -71,6 +72,8 @@ require_grep 'error[E176' scripts/ci/madaros_full_gate.sh
 require_grep 'error[E177' scripts/ci/madaros_full_gate.sh
 require_grep '--native-v2-emit-sret' scripts/ci/madaros_full_gate.sh
 require_grep 'pkg self-test' scripts/ci/madaros_full_gate.sh
+require_grep 'madaros_source_to_elf_gate.sh' .github/workflows/madaros-prebuilt-refresh.yml
+require_grep 'source-to-ELF' .github/workflows/madaros-prebuilt-refresh.yml
 
 require_grep 'DEFAULT ENGINE: Madaros' bin/souc
 require_grep 'bin/madaros-linux-x86_64' bin/souc


### PR DESCRIPTION
## Summary
- Require `scripts/ci/madaros_source_to_elf_gate.sh` before the Madaros prebuilt refresh workflow can publish `bin/madaros-linux-x86_64`.
- Extend the operational contract gate so future contract checks assert this refresh wiring exists.

## Evidence / why
- Clean `origin/main` worktree at `323c859d` passed `madaros_enum_gate.sh` and `madaros_loop_gate.sh` with `bin/madaros-linux-x86_64` sha256 `04a6982414a13c17b52a7df1f9b7e75ae33193f26dca11b50a3754d9c7b4216d`.
- The same clean worktree failed `scripts/ci/madaros_source_to_elf_gate.sh` on `lit42` via raw `--native-v2-compile` SIGSEGV after `/tmp/nv2_m1_after_lower`, `/tmp/nv2_m2_before_backend`, and `/tmp/nv2_m3_before_backend` were written.
- `madaros_full_gate.sh` did not cover that raw bridge path, so the previous refresh was able to ship a prebuilt that passed full/enum/loop but not source-to-ELF.

## Validation
- `bash -n scripts/ci/madaros_operational_contract_gate.sh scripts/ci/madaros_source_to_elf_gate.sh`
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh && bash scripts/dev/check_docs_registry.sh`
- `git diff --check`

## Not fixed here
- This PR intentionally does not claim to fix the backend SIGSEGV. It prevents future false-green prebuilt refreshes until the source-to-ELF bridge is repaired.
- Local clean rebuild via Stage0 also currently SIGSEGVs in `make build-madaros` on this workspace, so that remains a production-readiness blocker to investigate separately.

LLM-offload reviews invoked: none; this is CI/governance wiring, not math, clinical, or external-facing content.