### PR TITLE
fix(ci): let Madaros full gate run from clean prebuilt worktrees

### DIFF
--- a/scripts/ci/madaros_full_gate.sh
+++ b/scripts/ci/madaros_full_gate.sh
@@ -7,7 +7,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 MADAROS="${MADAROS_BIN:-$ROOT_DIR/bin/madaros}"
-RAW_MADAROS="${MADAROS_RAW_BIN:-$ROOT_DIR/artifacts/self-hosted/madaros}"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+if [[ -z "$RAW_MADAROS" ]]; then
+  if [[ -x "$ROOT_DIR/artifacts/self-hosted/madaros" ]]; then
+    RAW_MADAROS="$ROOT_DIR/artifacts/self-hosted/madaros"
+  else
+    RAW_MADAROS="$ROOT_DIR/bin/madaros-linux-x86_64"
+  fi
+fi
 WORK="${SOUNIO_MADAROS_FULL_GATE_DIR:-$(mktemp -d /tmp/sounio-madaros-full.XXXXXX)}"
 KEEP_WORK="${SOUNIO_MADAROS_FULL_GATE_KEEP:-0}"
 


### PR DESCRIPTION
## Summary
- lets `madaros_full_gate.sh` use `bin/madaros-linux-x86_64` as the raw ELF fallback when `artifacts/self-hosted/madaros` is absent
- keeps `MADAROS_RAW_BIN` override and built artifact preference intact
- fixes clean-worktree validation after the prebuilt refresh commit

## Evidence
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/madaros_full_gate.sh` PASS from clean post-refresh worktree
- `bash scripts/ci/madaros_operational_contract_gate.sh` PASS
- `git diff --check` PASS

## Context
After #335 and the `main` prebuilt refresh, `madaros_source_to_elf_gate.sh`, enum gate, and loop gate passed out-of-box with the checked-in prebuilt. The full gate still failed because it hardcoded `artifacts/self-hosted/madaros` for raw checks. This aligns the harness with the repo's default prebuilt contract.
