### PR TITLE
docs(audit): retire superseded source-to-ELF worktree

### DIFF
--- a/docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md
+++ b/docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md
@@ -76,17 +76,21 @@ it explains the failure mode, but the current authoritative cleanup status is:
     `/tmp/sounio-madaros-source-elf-fix`,
     `/tmp/sounio-main-post335`,
     `/tmp/sounio-madaros-hardening`.
+  - The stale source-to-ELF worktree was archived and removed:
+    `/workspace/sounio-madaros-source-elf-main`.
+    Its local branch commits and dirty patch were preserved under
+    `/workspace/sounio-worktree-archives/madaros-source-to-elf-main-20260620/`.
 - Post-cleanup inventory:
-  - raw TSV: `/tmp/sounio-worktree-audit-20260620-post336-after-tmp-clean.tsv`
-  - total worktrees: 75
-  - dirty worktrees: 58
+  - raw TSV: `/tmp/sounio-worktree-audit-20260620-post-source-elf-retire.tsv`
+  - total worktrees: 74
+  - dirty worktrees: 57
   - prunable worktree records: 0
-  - dirty critical worktrees: 8
-  - critical-diff vs `origin/main`: 52
+  - dirty critical worktrees: 7
+  - critical-diff vs `origin/main`: 51
   - open PRs represented by current worktrees: 3
 
 The remaining blocker is therefore narrower: owner-by-owner disposition of the
-8 dirty critical worktrees. It is no longer a generic unclassified PR/prebuilt
+7 dirty critical worktrees. It is no longer a generic unclassified PR/prebuilt
 blocker.
 
 ## Post-#336 Resolution Plan
@@ -109,10 +113,16 @@ parked outside the Madaros production-readiness lane.
 
    #335 and #336 prove that current `origin/main` already passes the
    source-to-ELF, enum, loop, and full Madaros gates. Therefore
-   `/workspace/sounio-madaros-source-elf-main` is no longer an active fix lane.
-   The only remaining action is to archive its local four-line
-   `module_frontend.sio` dirt and any still-useful test/gate notes, then remove
-   the worktree.
+   `/workspace/sounio-madaros-source-elf-main` is no longer an active fix lane
+   and has been removed from the active worktree set. Its archived evidence is:
+
+   - `codex-madaros-source-to-elf-main.bundle`
+   - `local-commits.txt`
+   - `uncommitted.patch`
+   - `SHA256SUMS`
+
+   under
+   `/workspace/sounio-worktree-archives/madaros-source-to-elf-main-20260620/`.
 
 3. Split compiler-core lanes from product/demo lanes.
 
@@ -268,7 +278,6 @@ per-worktree status/diff inspection.
 | `/workspace/sounio-codex` | branch `codex/calls-5-6-args`; no PR; stale against current `origin/main`; dirty compiler/native files plus untracked `native_v2_branch_gate.sh` and `native_v2_calls_arity_gate.sh` | stale local WIP with salvageable native-v2 calls/branch fixture bundle | Do not merge from this worktree. Create a fresh branch from `origin/main` and port only the fixture/gate bundle plus any still-failing minimal compiler patch, then run native-v2 focused gates. Otherwise archive patch and remove. |
 | `/workspace/sounio-language-reality-gate` | branch `codex/madaros-language-reality-gate`; upstream exists; no PR; dirty IR/native patch remains broad across `self-hosted/ir/*`, `self-hosted/native/*`, `render_native_compile_driver_lean.sio`, and `scripts/ci/madaros_wide_int_gate.sh` | active-or-stale high-risk compiler lane, not cleanup-safe | Requires owner decision. If active, replay into an isolated current-main worktree and split into IR, native, and gate commits. If inactive, archive patch before removal. |
 | `/workspace/sounio-language-showcase` | branch `codex/language-showcase`; no PR; stale product/example set plus three untracked CI gates | stale large showcase/foundry lane, not compiler-core | Salvage as one or more non-compiler PRs from current `origin/main`, with offload review if external-facing clinical/teaching artifacts are kept. Do not let this lane block compiler cleanup. |
-| `/workspace/sounio-madaros-source-elf-main` | branch `codex/madaros-source-to-elf-main`; upstream incorrectly points at `origin/main`; dirty critical change is only `self-hosted/compiler/module_frontend.sio`; #335/#336 now prove current source-to-ELF gates pass | superseded source-to-ELF lane | Archive local patch/evidence, then remove the worktree. Do not salvage into compiler production path unless a fresh clean-main gate reproduces a remaining source-to-ELF failure. |
 | `/workspace/sounio-scientific-workbench` | branch `codex/scientific-workbench`; no PR; untracked `examples/scientific_workbench/` plus `scripts/ci/scientific_workbench_e2e_gate.sh`; depends on native visual frontend gates in branch diff | stale scientific-workbench product lane | Salvage as a fresh non-compiler PR only if examples and gate still run on current main. Otherwise archive/remove. Do not mix with compiler production-readiness. |
 | `/workspace/sounio-sret` | branch `claude/sret-builtins`; no PR; stale local bundle includes `docs/audit/NATIVE_V2_SRET_BUILTINS_AUDIT_2026-06-06.md`, `tests/native_v2_sret_builtins/`, and `scripts/ci/native_v2_sret_builtins_gate.sh` | stale local SRET gate bundle with no commits ahead | Salvage bundle onto current main only if the SRET witness gap remains after the current Madaros gates. Otherwise archive patch and remove. |
 | `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b` | branch `worktree-agent-adc1cd8b9d52ba53b`; no PR; dirty native/compiler patch remains in `main.sio`, `codegen.sio`, `codegen_x86_linux.sio`, `lower_ir.sio`, and `suite.sio`; handoff identifies this as active Claude compiler lane | active Claude lane, do not touch | Coordinate with Claude. It must refresh against `02ad4473dcff9fd2b42b2135e47e17b43abbb304` before any merge candidate is considered. Codex must not edit these files concurrently. |
@@ -364,7 +373,7 @@ Blocker-ID: `GOV-WORKTREE-SPRAWL-20260620`
   - dirty critical worktrees either claimed, parked, or cleaned by owner
   - workflow/gate provenance emitted for Madaros builds
 - next action:
-  - classify each of the remaining 8 dirty critical worktrees by owner and
+  - classify each of the remaining 7 dirty critical worktrees by owner and
     action: salvage, close/remove, or active lane
   - evolve `scripts/dev/worktree_branch_audit.sh` into a failing governance gate
   - add durable Madaros build provenance artifacts/checks beyond the current


### PR DESCRIPTION
## Summary

- mark `/workspace/sounio-madaros-source-elf-main` as archived/removed instead of pending cleanup
- update the audit inventory from 8 dirty critical worktrees to 7
- record the archive location for the removed lane:
  `/workspace/sounio-worktree-archives/madaros-source-to-elf-main-20260620/`

## Archive Contents

- `codex-madaros-source-to-elf-main.bundle`
- `local-commits.txt`
- `uncommitted.patch`
- `SHA256SUMS`

## Validation

- `git bundle verify /workspace/sounio-worktree-archives/madaros-source-to-elf-main-20260620/codex-madaros-source-to-elf-main.bundle`
- `SOUNIO_AUDIT_INCLUDE_PRS=1 bash scripts/dev/worktree_branch_audit.sh /tmp/sounio-worktree-audit-20260620-post-source-elf-retire.tsv`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/madaros_source_to_elf_gate.sh`
- `node scripts/docs/sync_governance_metadata.mjs`
- `node scripts/docs/check_docs_registry.mjs`
- `git diff --check`
