### PR TITLE
docs(audit): retire stale native calls arity worktree

### DIFF
--- a/docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md
+++ b/docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md
@@ -24,7 +24,7 @@ compiler artifacts, and PRs that overlap serialized files.
 This audit has been acted on. The original snapshot below is preserved because
 it explains the failure mode, but the current authoritative cleanup status is:
 
-- Current `origin/main`: `eb869e0830f2d25095f864d4ed9fe477e433863a`
+- Current `origin/main`: `819a4c5b58cdba034f626301ce2646de71f2d2ac`
 - #331 merged and production default refreshed:
   - #331 merge commit: `c5d0366d40490c18b927ef0d03cf98705697b6c2`
   - prebuilt refresh commit: `b73a11f5838f138f3d06b591f832e98d501214f3`
@@ -93,17 +93,21 @@ it explains the failure mode, but the current authoritative cleanup status is:
     `/workspace/sounio-sret`. Its dirty Slurm patch plus untracked SRET audit,
     gate, and test-bundle files were preserved under
     `/workspace/sounio-worktree-archives/sret-builtins-20260620/`.
+  - The stale native-v2 calls/branch arity worktree was archived and removed:
+    `/workspace/sounio-codex`. Its local compiler/native patch plus untracked
+    native-v2 examples, gates, and IR driver were preserved under
+    `/workspace/sounio-worktree-archives/calls-5-6-args-20260620/`.
 - Post-cleanup inventory:
-  - raw TSV: `/tmp/sounio-worktree-audit-20260620-post-sret-retire.tsv`
-  - total worktrees: 71
-  - dirty worktrees: 54
+  - raw TSV: `/tmp/sounio-worktree-audit-20260620-post-calls-arity-retire.tsv`
+  - total worktrees: 70
+  - dirty worktrees: 53
   - prunable worktree records: 0
-  - dirty critical worktrees: 4
+  - dirty critical worktrees: 3
   - critical-diff vs `origin/main`: 49
   - open PRs represented by current worktrees: 3
 
 The remaining blocker is therefore narrower: owner-by-owner disposition of the
-4 dirty critical worktrees. It is no longer a generic unclassified PR/prebuilt
+3 dirty critical worktrees. It is no longer a generic unclassified PR/prebuilt
 blocker.
 
 ## Post-#336 Resolution Plan
@@ -148,8 +152,8 @@ parked outside the Madaros production-readiness lane.
 
 4. Put every remaining compiler WIP behind an owner and a current-main replay.
 
-   `/workspace/sounio-codex` and `/workspace/sounio-language-reality-gate` are
-   not eligible for direct merge from their current worktrees. Each must either:
+   `/workspace/sounio-language-reality-gate` is not eligible for direct merge
+   from its current worktree. It must either:
 
    - be replayed onto a fresh `origin/main` worktree with a minimal patch and
      focused gates, or
@@ -269,26 +273,25 @@ These worktrees have uncommitted changes in critical compiler/CI paths:
 | Worktree | Branch | Critical dirty files |
 |---|---|---|
 | `/workspace/sounio` | `main` | `artifacts/omega/agent_handoff.log.md`, `bin/madaros`, `self-hosted/native/machine_ir.sio` |
-| `/workspace/sounio-codex` | `codex/calls-5-6-args` | `self-hosted/compiler/native_compile_driver.sio`, `self-hosted/native/codegen_x86_linux.sio`, `self-hosted/native/encode.sio`, new native-v2 CI gates |
 | `/workspace/sounio-language-reality-gate` | `codex/madaros-language-reality-gate` | broad dirty set across `self-hosted/ir/*`, `self-hosted/native/*`, `render_native_compile_driver_lean.sio`, `scripts/ci/madaros_wide_int_gate.sh` |
 | `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b` | `worktree-agent-adc1cd8b9d52ba53b` | `self-hosted/compiler/main.sio`, `self-hosted/native/codegen.sio`, `self-hosted/native/codegen_x86_linux.sio`, `self-hosted/native/lower_ir.sio`, `self-hosted/native/suite.sio` |
 
 ## Critical Worktree Disposition Plan
 
-This table is the actionable cleanup plan after #331/#332/#335/#336/#338/#339/#340
+This table is the actionable cleanup plan after #331/#332/#335/#336/#338/#339/#340/#341
 and the Madaros prebuilt refreshes. It was refreshed from `origin/main` at
-`eb869e0830f2d25095f864d4ed9fe477e433863a`, the audit TSV
-`/tmp/sounio-worktree-audit-20260620-post-sret-retire.tsv`, and direct
+`819a4c5b58cdba034f626301ce2646de71f2d2ac`, the audit TSV
+`/tmp/sounio-worktree-audit-20260620-post-calls-arity-retire.tsv`, and direct
 per-worktree status/diff inspection.
 
 | Worktree | Evidence | Classification | Required Action |
 |---|---|---|---|
-| `/workspace/sounio` | local `main` is 31 behind `origin/main`; dirty critical files are `artifacts/omega/agent_handoff.log.md`, `bin/madaros`, `self-hosted/native/machine_ir.sio`; `./sounio-whereami --quick` is missing in this stale checkout; environment still points `SOUC_BIN` and `SOUNIO_STDLIB_PATH` back into this checkout | protected primary surface, not evidence-clean | Do not reset. Reconcile only in an isolated branch/worktree: first version the current governance plan, then separately decide whether local `bin/madaros` and `machine_ir.sio` are salvageable or stale WIP. |
-| `/workspace/sounio-codex` | branch `codex/calls-5-6-args`; no PR; stale against current `origin/main`; dirty compiler/native files plus untracked `native_v2_branch_gate.sh` and `native_v2_calls_arity_gate.sh` | stale local WIP with salvageable native-v2 calls/branch fixture bundle | Do not merge from this worktree. Create a fresh branch from `origin/main` and port only the fixture/gate bundle plus any still-failing minimal compiler patch, then run native-v2 focused gates. Otherwise archive patch and remove. |
+| `/workspace/sounio` | local `main` is 32 behind `origin/main`; dirty critical files are `artifacts/omega/agent_handoff.log.md`, `bin/madaros`, `self-hosted/native/machine_ir.sio`; `./sounio-whereami --quick` is missing in this stale checkout; environment still points `SOUC_BIN` and `SOUNIO_STDLIB_PATH` back into this checkout | protected primary surface, not evidence-clean | Do not reset. Reconcile only in an isolated branch/worktree: first version the current governance plan, then separately decide whether local `bin/madaros` and `machine_ir.sio` are salvageable or stale WIP. |
+| `/workspace/sounio-codex` | branch `codex/calls-5-6-args`; no PR; 352 behind and 0 ahead of current `origin/main`; dirty compiler/native patch plus native-v2 calls/branch fixture bundle archived under `/workspace/sounio-worktree-archives/calls-5-6-args-20260620/`; local worktree and branch removed | stale local native-v2 calls/branch fixture bundle; parked outside active worktree set | Future salvage must start from current `origin/main` and use the archive as evidence only. |
 | `/workspace/sounio-language-reality-gate` | branch `codex/madaros-language-reality-gate`; upstream exists; no PR; dirty IR/native patch remains broad across `self-hosted/ir/*`, `self-hosted/native/*`, `render_native_compile_driver_lean.sio`, and `scripts/ci/madaros_wide_int_gate.sh` | active-or-stale high-risk compiler lane, not cleanup-safe | Requires owner decision. If active, replay into an isolated current-main worktree and split into IR, native, and gate commits. If inactive, archive patch before removal. |
 | `/workspace/sounio-language-showcase` | branch `codex/language-showcase`; no PR; stale product/example/foundry set plus three untracked CI gates; archived under `/workspace/sounio-worktree-archives/language-showcase-20260620/`; local worktree and branch removed | stale large showcase/foundry lane, not compiler-core; parked outside active worktree set | Future salvage must start from current `origin/main` and use the archive as evidence only. Offload review is required before publishing any clinical or external-facing artifacts. |
 | `/workspace/sounio-sret` | branch `claude/sret-builtins`; no PR; 351 behind and 0 ahead of current `origin/main`; stale local bundle archived under `/workspace/sounio-worktree-archives/sret-builtins-20260620/`; local worktree and branch removed | stale local SRET gate bundle with no commits ahead; parked outside active worktree set | Future salvage must start from current `origin/main` and use the archive as evidence only. |
-| `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b` | branch `worktree-agent-adc1cd8b9d52ba53b`; no PR; 87 behind current `origin/main`; dirty native/compiler patch remains in `main.sio`, `codegen.sio`, `codegen_x86_linux.sio`, `lower_ir.sio`, and `suite.sio`; handoff identifies this as active Claude compiler lane | active Claude lane, do not touch | Coordinate with Claude. It must refresh against `eb869e0830f2d25095f864d4ed9fe477e433863a` before any merge candidate is considered. Codex must not edit these files concurrently. |
+| `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b` | branch `worktree-agent-adc1cd8b9d52ba53b`; no PR; 88 behind current `origin/main`; dirty native/compiler patch remains in `main.sio`, `codegen.sio`, `codegen_x86_linux.sio`, `lower_ir.sio`, and `suite.sio`; handoff identifies this as active Claude compiler lane | active Claude lane, do not touch | Coordinate with Claude. It must refresh against `819a4c5b58cdba034f626301ce2646de71f2d2ac` before any merge candidate is considered. Codex must not edit these files concurrently. |
 
 The next governance gate should fail only after these dispositions are recorded
 as explicit lane states. Until then, these remaining lanes are not equivalent: some are
@@ -382,7 +385,7 @@ Blocker-ID: `GOV-WORKTREE-SPRAWL-20260620`
   - dirty critical worktrees either claimed, parked, or cleaned by owner
   - workflow/gate provenance emitted for Madaros builds
 - next action:
-  - classify each of the remaining 4 dirty critical worktrees by owner and
+  - classify each of the remaining 3 dirty critical worktrees by owner and
     action: salvage, close/remove, or active lane
   - evolve `scripts/dev/worktree_branch_audit.sh` into a failing governance gate
   - add durable Madaros build provenance artifacts/checks beyond the current


### PR DESCRIPTION
## Summary

- records retirement of stale `/workspace/sounio-codex`
- preserves the native-v2 calls/branch WIP bundle under `/workspace/sounio-worktree-archives/calls-5-6-args-20260620/`
- refreshes governance audit counts after removal: 70 total worktrees, 53 dirty, 3 critical dirty, 49 critical-vs-base

## Evidence preserved

Archive contents include:

- `status-porcelain.txt`
- `uncommitted.patch`
- `untracked-files.txt`
- `untracked-copy/`
- `head-log.txt`
- `README.md`
- `SHA256SUMS`

Dirty state was also stashed before removing the worktree:

- `stash@{0}: On codex/calls-5-6-args: archive stale calls arity lane before worktree cleanup`

## Validation

- `sha256sum -c /workspace/sounio-worktree-archives/calls-5-6-args-20260620/SHA256SUMS`
- `SOUNIO_AUDIT_INCLUDE_PRS=1 bash scripts/dev/worktree_branch_audit.sh /tmp/sounio-worktree-audit-20260620-post-calls-arity-retire.tsv`
- `node scripts/docs/sync_governance_metadata.mjs`
- `node scripts/docs/check_docs_registry.mjs`
- `git diff --check`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/madaros_operational_contract_gate.sh`

## Offload

Not invoked. This PR only updates internal governance/audit state and archive disposition; it does not publish math claims, clinical-pathway code, or external-facing artifacts.
