### PR TITLE
ci(governance): gate dirty critical worktrees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: bash scripts/ci/check_issue_template_contracts.sh
       - name: Legacy path hygiene
         run: bash scripts/ci/check_legacy_paths.sh
+      - name: Worktree governance gate
+        run: bash scripts/dev/worktree_branch_audit.sh --check
       - name: Claude operational contract
         run: bash scripts/ci/claude_operational_contract_gate.sh
       - name: Ontology validation

--- a/docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md
+++ b/docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md
@@ -125,6 +125,20 @@ blocker; it is now specifically primary-checkout reconciliation plus Claude-lane
 coordination. The primary checkout is now evidence-preserved but intentionally
 not cleaned.
 
+Follow-up governance gate:
+
+- `scripts/dev/worktree_branch_audit.sh --check` now fails when unallowed
+  critical dirty worktrees or prunable worktree records are present.
+- The CI `Contracts` job runs that gate in strict mode. Fresh CI clones should
+  have zero prunable records and zero unallowed dirty critical worktrees.
+- Local operation may temporarily allow known active lanes by setting
+  `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE`, but that exception must name exact
+  worktree paths and keep `unallowed_critical_dirty=0`.
+- The current known active exceptions are the protected primary checkout and
+  the Claude-owned compiler lane:
+  - `/workspace/sounio`
+  - `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b`
+
 ## Post-#336 Resolution Plan
 
 This is the active plan for turning the audit into cleanup. It is intentionally
@@ -200,6 +214,18 @@ parked outside the Madaros production-readiness lane.
    - workspace context hydration (`.beagle/context/**`)
    - audit/handoff notes and Slurm helper scripts
    - large generated data inventory (`data/processed/expansion`)
+
+7. Enforce the audit as a gate, not a report.
+
+   The audit script now supports `--check`. In check mode the default contract is:
+
+   - `SOUNIO_AUDIT_MAX_PRUNABLE=0`
+   - `SOUNIO_AUDIT_MAX_CRITICAL_DIRTY=0`
+   - no implicit allowance for dirty compiler/native/CI paths
+
+   Local operators may set `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE` only for
+   explicitly claimed active lanes. The useful invariant is not "no work can be
+   dirty"; it is "no dirty critical worktree is invisible or ownerless."
 
 ## Original Snapshot
 

--- a/scripts/dev/worktree_branch_audit.sh
+++ b/scripts/dev/worktree_branch_audit.sh
@@ -6,7 +6,53 @@ cd "$ROOT_DIR"
 
 BASE_REF="${SOUNIO_AUDIT_BASE_REF:-origin/main}"
 INCLUDE_PRS="${SOUNIO_AUDIT_INCLUDE_PRS:-0}"
-OUT="${1:-}"
+CHECK_MODE=0
+OUT=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/worktree_branch_audit.sh [--check] [OUT.tsv]
+
+Writes a TSV inventory of git worktrees and prints summary counts.
+
+Options:
+  --check        fail if governance thresholds are exceeded
+  -h, --help     show this help
+
+Check-mode environment:
+  SOUNIO_AUDIT_MAX_PRUNABLE              default: 0
+  SOUNIO_AUDIT_MAX_CRITICAL_DIRTY        default: 0
+  SOUNIO_AUDIT_MAX_DIRTY                 optional
+  SOUNIO_AUDIT_MAX_OPEN_PR               optional
+  SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE   optional awk regex for allowed paths
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --check)
+      CHECK_MODE=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$OUT" ]]; then
+        echo "error: multiple output paths provided" >&2
+        usage >&2
+        exit 2
+      fi
+      OUT="$1"
+      ;;
+  esac
+  shift
+done
 
 if [[ -z "$OUT" ]]; then
   OUT="$(mktemp /tmp/sounio-worktree-audit.XXXXXX.tsv)"
@@ -85,12 +131,12 @@ write_rows() {
     fi
 
     critical_dirty="$(
-      git -C "$wt_path" status --porcelain -- "${CRITICAL_PATHS[@]}" 2>/dev/null \
+      { git -C "$wt_path" status --porcelain -- "${CRITICAL_PATHS[@]}" 2>/dev/null || true; } \
         | sed 's/[[:space:]]\+/ /g' \
         | paste -sd ';' -
     )"
     critical_vs="$(
-      git -C "$wt_path" diff --name-only "$BASE_REF"...HEAD -- "${CRITICAL_PATHS[@]}" 2>/dev/null \
+      { git -C "$wt_path" diff --name-only "$BASE_REF"...HEAD -- "${CRITICAL_PATHS[@]}" 2>/dev/null || true; } \
         | paste -sd ',' -
     )"
     pr="$(pr_for_branch "$branch")"
@@ -107,20 +153,77 @@ write_rows() {
 } > "$OUT"
 
 echo "audit_tsv=$OUT"
+summary="$(
+  awk -F '\t' '
+    BEGIN {
+      allow_critical_dirty_re = ENVIRON["SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE"]
+    }
+    NR > 1 {
+      total++
+      if ($5 != "clean") dirty++
+      if ($5 ~ /^PRUNABLE/) prunable++
+      if ($9 != "") {
+        critical_dirty++
+        if (allow_critical_dirty_re == "" || $1 !~ allow_critical_dirty_re) {
+          unallowed_critical_dirty++
+        }
+      }
+      if ($10 != "") critical_vs_base++
+      if ($11 != "") open_pr++
+    }
+    END {
+      printf "total=%d dirty=%d prunable=%d critical_dirty=%d unallowed_critical_dirty=%d critical_vs_base=%d open_pr=%d\n",
+        total, dirty, prunable, critical_dirty, unallowed_critical_dirty, critical_vs_base, open_pr
+    }
+  ' "$OUT"
+)"
+echo "$summary"
+
+summary_value() {
+  local key="$1"
+  printf '%s\n' "$summary" | tr ' ' '\n' | awk -F= -v key="$key" '$1 == key { print $2 }'
+}
+
+check_threshold() {
+  local label="$1" actual="$2" max="$3"
+  if [[ -n "$max" && "$actual" =~ ^[0-9]+$ && "$max" =~ ^[0-9]+$ && "$actual" -gt "$max" ]]; then
+    echo "gate_violation: $label=$actual exceeds max=$max" >&2
+    return 1
+  fi
+  return 0
+}
+
+echo "critical_dirty_worktrees:"
 awk -F '\t' '
-  NR > 1 {
-    total++
-    if ($5 != "clean") dirty++
-    if ($5 ~ /^PRUNABLE/) prunable++
-    if ($9 != "") critical_dirty++
-    if ($10 != "") critical_vs_base++
-    if ($11 != "") open_pr++
+  BEGIN {
+    allow_critical_dirty_re = ENVIRON["SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE"]
   }
-  END {
-    printf "total=%d dirty=%d prunable=%d critical_dirty=%d critical_vs_base=%d open_pr=%d\n",
-      total, dirty, prunable, critical_dirty, critical_vs_base, open_pr
+  NR > 1 {
+    if ($9 != "") {
+      prefix = "unallowed"
+      if (allow_critical_dirty_re != "" && $1 ~ allow_critical_dirty_re) {
+        prefix = "allowed"
+      }
+      print "- [" prefix "] " $1 " | " $2 " | " $9
+    }
   }
 ' "$OUT"
 
-echo "critical_dirty_worktrees:"
-awk -F '\t' 'NR > 1 && $9 != "" { print "- " $1 " | " $2 " | " $9 }' "$OUT"
+if [[ "$CHECK_MODE" == "1" ]]; then
+  max_prunable="${SOUNIO_AUDIT_MAX_PRUNABLE:-0}"
+  max_critical_dirty="${SOUNIO_AUDIT_MAX_CRITICAL_DIRTY:-0}"
+  max_dirty="${SOUNIO_AUDIT_MAX_DIRTY:-}"
+  max_open_pr="${SOUNIO_AUDIT_MAX_OPEN_PR:-}"
+
+  failed=0
+  check_threshold "prunable" "$(summary_value prunable)" "$max_prunable" || failed=1
+  check_threshold "unallowed_critical_dirty" "$(summary_value unallowed_critical_dirty)" "$max_critical_dirty" || failed=1
+  check_threshold "dirty" "$(summary_value dirty)" "$max_dirty" || failed=1
+  check_threshold "open_pr" "$(summary_value open_pr)" "$max_open_pr" || failed=1
+
+  if [[ "$failed" != "0" ]]; then
+    echo "worktree audit gate failed; inspect $OUT" >&2
+    exit 1
+  fi
+  echo "worktree audit gate passed"
+fi


### PR DESCRIPTION
## Summary

Turn the worktree audit from a passive report into an enforceable governance gate.

- add `--check` mode to `scripts/dev/worktree_branch_audit.sh`
- fail check mode on unallowed dirty critical worktrees or prunable worktree records
- support exact local exceptions through `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE`
- run the gate from the CI `Contracts` job
- document the operational resolution plan and current known exceptions

## Validation

- `bash -n scripts/dev/worktree_branch_audit.sh`
- `git diff --check`
- `node scripts/docs/sync_governance_metadata.mjs`
- `node scripts/docs/check_docs_registry.mjs`
- `bash scripts/dev/check_workflow_script_refs.sh`
- strict local failure proof: `bash scripts/dev/worktree_branch_audit.sh --check /tmp/sounio-worktree-audit-gate-strict.tsv` returned rc=1 because the two known critical dirty lanes were unallowed
- local allowlist proof: `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE=... bash scripts/dev/worktree_branch_audit.sh --check /tmp/sounio-worktree-audit-gate-postcommit.tsv` passed with `unallowed_critical_dirty=0`
- clean-clone CI simulation: `/tmp/sounio-worktree-audit-gate-ci-clone` passed strict `--check` with `dirty=0 prunable=0 critical_dirty=0 unallowed_critical_dirty=0`

## Notes

No LLM-offload invoked: this touches internal governance/CI documentation and shell plumbing, not math claims, clinical-pathway code, or external-facing artifacts.
