### PR TITLE
docs(agents): add ctx7 documentation contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,24 @@
 # AGENTS.md
 
+<!-- context7 -->
+Use the `ctx7` CLI to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service -- even well-known ones like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This includes API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Use even when you think you know the answer -- your training data may not reflect recent changes. Prefer this over web search for library docs.
+
+Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts.
+
+## Steps
+
+1. Resolve library: `npx ctx7@latest library <name> "<user's question>"`
+2. Pick the best match (ID format: `/org/project`) by: exact name match, description relevance, code snippet count, source reputation (High/Medium preferred), and benchmark score (higher is better). If results don't look right, try alternate names or queries (e.g., "next.js" not "nextjs", or rephrase the question)
+3. Fetch docs: `npx ctx7@latest docs <libraryId> "<user's question>"`
+4. Answer using the fetched documentation
+
+You MUST call `library` first to get a valid ID unless the user provides one directly in `/org/project` format. Use the user's full question as the query -- specific and detailed queries return better results than vague single words. Do not run more than 3 commands per question. Do not include sensitive information (API keys, passwords, credentials) in queries.
+
+For version-specific docs, use `/org/project/version` from the `library` output (e.g., `/vercel/next.js/v14.3.0`).
+
+If a command fails with a quota error, inform the user and suggest `npx ctx7@latest login` or setting `CONTEXT7_API_KEY` env var for higher limits. Do not silently fall back to training data.
+<!-- context7 -->
+
 ## Purpose
 
 This file is the Codex-facing project contract for the Sounio repository.
@@ -217,6 +236,14 @@ Use Context7 only for:
 - external tool/library/framework documentation
 - up-to-date Codex / MCP / Claude Code docs
 - version-specific external references
+
+When Context7 applies, use the `ctx7` CLI flow above:
+
+1. `npx ctx7@latest library <name> "<user's question>"`
+2. `npx ctx7@latest docs <libraryId> "<user's question>"`
+
+Do not skip the library-resolution step unless the user already provided a valid `/org/project` library ID.
+Do not run more than three Context7 commands for one question.
 
 Do **not** use Context7 as a substitute for repository-local truth.
 Repository-local truth must come from direct inspection of the repo.


### PR DESCRIPTION
## Summary

Replay the safe `AGENTS.md` portion of the protected primary checkout archive onto current `origin/main`.

- adds the ctx7/Context7 documentation lookup contract at the top of `AGENTS.md`
- makes the existing Context7 section point to the concrete `ctx7` CLI flow
- keeps this PR scoped to Codex-facing governance text only

## Primary archive reconciliation

From `/workspace/sounio-worktree-archives/primary-main-dirty-20260620/uncommitted.patch`:

- MCP files are already applied on `origin/main` via `81fa4976e fix(mcp): align check json invocation and test paths`
- this PR replays only `AGENTS.md`
- `.beagle/context/**`, `bin/madaros`, `self-hosted/native/machine_ir.sio`, `examples/hello.sio`, and handoff/log artifacts remain parked for separate owner-safe decisions

## Validation

- `git diff --check`
- `node scripts/docs/sync_governance_metadata.mjs`
- `node scripts/docs/check_docs_registry.mjs`
- `bash scripts/dev/check_workflow_script_refs.sh`
- strict local worktree gate intentionally failed because the protected primary checkout and active Claude compiler lane are unallowed in local state
- allowlisted local worktree gate passed with `unallowed_critical_dirty=0` for exactly `/workspace/sounio` and `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b`

## Offload

Not invoked: internal Codex governance instructions only; no math claims, clinical-pathway code, or external-facing artifact.
