### PR TITLE
docs(audit): add primary checkout reconciliation plan

### DIFF
--- a/docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md
+++ b/docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md
@@ -1,0 +1,142 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.primary-checkout-reconciliation-plan-2026-06-21
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.primary-checkout-reconciliation-plan-2026-06-21
+-->
+
+# Primary Checkout Reconciliation Plan — 2026-06-21
+
+## Scope
+
+This plan turns the preserved dirty primary-checkout archive into an ordered
+resolution queue. The archive is:
+
+- `/workspace/sounio-worktree-archives/primary-main-dirty-20260620/`
+
+The goal is to reduce ambiguity without replaying stale or compiler-adjacent
+work into `origin/main`. Each bucket must end as one of:
+
+- a small PR with a named validation gate
+- a blocker under `.claude/PARALLEL_BLOCKER_CONTRACT.md`
+- an archived/discarded local artifact with the reason recorded
+
+No step in this plan requires cleaning, resetting, rebasing, or switching the
+protected `/workspace/sounio` checkout.
+
+## Current Baseline
+
+- Current `origin/main`: `32ed3d3d71a94a6b328d2fff71395f8af7ed8c19`
+  (`Merge pull request #347 from Sounio-lang/codex/agents-ctx7-contract`).
+- The primary archive was created from `/workspace/sounio` without destructive
+  cleanup.
+- The MCP patch bucket from the primary archive is already represented on
+  `origin/main` by `81fa4976e` (`fix(mcp): align check json invocation and test
+  paths`).
+- The `AGENTS.md` bucket is resolved by #347, which adds the Codex-facing `ctx7`
+  documentation contract.
+- The worktree governance gate is resolved by #346 and runs in the `Contracts`
+  CI job.
+
+## Resolution Queue
+
+### Bucket A — Already Resolved
+
+These items require no replay from the archive:
+
+| Item | Disposition | Evidence |
+|---|---|---|
+| `tools/mcp/sounio_mcp/check.py` | already applied | `81fa4976e` |
+| `tools/mcp/sounio_mcp/test.py` | already applied | `81fa4976e` |
+| `tools/mcp/tests/test_loop.py` | already applied | `81fa4976e` |
+| `tools/mcp/tests/test_tools.py` | already applied | `81fa4976e` |
+| `AGENTS.md` | resolved | #347 |
+| `scripts/dev/worktree_branch_audit.sh` | superseded | #346 adds check mode and CI wiring |
+
+Exit criterion: no PR. Keep the archive as provenance only.
+
+### Bucket B — Safe To Review, Not Safe To Auto-Promote
+
+These items are small, but they still need normal review because the archived
+state is local workspace state rather than a proven branch:
+
+| Item | Initial finding | Required gate |
+|---|---|---|
+| `examples/hello.sio` | changes hello from return-only to `println("Hello, Sounio")` with `with IO` | `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/run_sio_test_suite.sh hello --verbose` |
+| `examples/erdos/reproducer_madaros_codegen_2026-06-16g.sio` | likely a debugging reproducer, not a general example | classify against current Madaros gates before adding |
+| `docs/audit/MADAROS_*.md` from archive | useful forensic notes, but several contradict newer fixed state | promote only after refresh against current `origin/main` and current binary SHA |
+
+Exit criterion: one narrow PR per item or a written discard reason.
+
+### Bucket C — Local Operational Artifacts
+
+These items should not be committed to `origin/main` unless a separate repo
+contract exists for them:
+
+| Item | Reason |
+|---|---|
+| `.beagle/context/**` | workspace hydration state, not source |
+| `artifacts/omega/agent_handoff.log.md` | local agent log; preserve in archive, do not replay |
+| `data/processed/expansion/**` | large generated data; inventoried but intentionally not copied |
+| `bin/madaros.bak-20260619` | local backup binary/wrapper; never promote as source |
+
+Exit criterion: archive only, unless a future task explicitly creates a source
+contract for one of these surfaces.
+
+### Bucket D — Scripts Requiring Hardening Before Promotion
+
+The archived helper scripts are not production-ready as-is:
+
+| Item | Finding | Required before PR |
+|---|---|---|
+| `scripts/coverage_report.sh` | contains a malformed `basename " $f" .mdx` line and lacks a CI contract | fix shell issues, add `shellcheck`/dry-run style validation |
+| `scripts/validate_mdx.sh` | uses `TOTAL`/`FAILURES` under `set -u` without initialization and installs packages at runtime | initialize state, avoid implicit dependency mutation, validate under `website` workflow expectations |
+| `scripts/translate_all_locales.sh` | hardcodes an internal Beagle service and writes logs in repo root | parameterize endpoint/model/output path and document that it is operator-only |
+| `slurm-jobs/madaros-frame-fix/*.sh` | operational Slurm helpers tied to a specific Madaros frame-fix lane | refresh against current foundry/Slurm contract before adding |
+
+Exit criterion: do not commit raw scripts. Promote only via a dedicated tooling
+PR with shell validation and an operator-facing contract.
+
+### Bucket E — Compiler-Adjacent High Risk
+
+These items must not be replayed directly while Claude owns an active compiler
+lane:
+
+| Item | Risk | Required gate |
+|---|---|---|
+| `bin/madaros` | launcher/default compiler behavior can contaminate all gates | inspect against `scripts/lib/resolve_madaros.sh`; run source-bootstrap and focused Madaros gates |
+| `self-hosted/native/machine_ir.sio` | compiler IR surface; may overlap native/codegen work | reproducer first, then focused native gate; no edit if it overlaps Claude's active files |
+
+Exit criterion: either a clean isolated compiler PR or a blocker record with
+owner, severity, evidence level, acceptance gate, and next action.
+
+## Claude Coordination Rule
+
+The active Claude compiler lane currently owns compiler changes. Codex must not
+edit the same files in parallel. Codex may:
+
+- inspect the lane
+- run read-only diffs or gates
+- prepare independent governance/tooling PRs
+- review the result after Claude's edit completes
+
+Codex must not write to Claude-owned compiler files during the same phase.
+
+## Operating Order
+
+1. Keep `origin/main` green and use it as the only production baseline.
+2. Resolve Bucket A by recording it as already done.
+3. Review Bucket B one item at a time, starting with `examples/hello.sio`.
+4. Mark Bucket C as archive-only unless a future source contract is created.
+5. Harden or discard Bucket D scripts; never commit them raw.
+6. Treat Bucket E as compiler work requiring a reproducer, a focused gate, and
+   explicit non-overlap with Claude's lane.
+7. After every PR, wait for CI and remove the temporary worktree/branch.
+
+## Stop Rule
+
+If a bucket cannot be classified with current evidence, do not guess and do not
+apply the archive patch. Record the missing evidence and convert it into a
+blocker or a focused probe.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 733
-- Repo-backed topics: 583
+- Total governed topics: 734
+- Repo-backed topics: 584
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 441
+- Authority count `repo_only`: 442
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 445 topics
+- A2: 446 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -116,6 +116,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.pbpk14-identifiability-2026-06-14 | repo_only | docs/audit/PBPK14_IDENTIFIABILITY_2026-06-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.pbpk14-modelform-stiff-repair-2026-06-14 | repo_only | docs/audit/PBPK14_MODELFORM_STIFF_REPAIR_2026-06-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.pl-adoption-audit-2026-05-27 | repo_only | docs/audit/PL_ADOPTION_AUDIT_2026-05-27.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.primary-checkout-reconciliation-plan-2026-06-21 | repo_only | docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.dispatch | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.fix.proposed-fix | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/fix/PROPOSED_FIX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r2-3-compiler-tuple-return-bug.r2-2-synthesis | repo_only | docs/audit/r2_3_compiler_tuple_return_bug/R2_2_SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2140,6 +2140,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.primary-checkout-reconciliation-plan-2026-06-21",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.r2-3-compiler-tuple-return-bug.dispatch",
       "collection": "repo",
       "repo_doc_path": "docs/audit/r2_3_compiler_tuple_return_bug/DISPATCH.md",


### PR DESCRIPTION
## Summary
- add a durable reconciliation plan for the preserved dirty primary checkout archive
- classify archive buckets into already-resolved, reviewable, archive-only, hardening-required, and compiler-high-risk categories
- register the audit doc in docs governance metadata

## Validation
- ./sounio-whereami --quick
- node scripts/docs/sync_governance_metadata.mjs
- bash scripts/dev/check_docs_consistency.sh
- bash scripts/dev/check_docs_registry.sh
- bash scripts/dev/check_workflow_script_refs.sh
- git diff --check
- SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b)$' scripts/dev/worktree_branch_audit.sh --check

## Notes
- This is governance/documentation only: no compiler, runtime, wrapper, or MCP source edits.
- The plan explicitly keeps bin/madaros and self-hosted/native/machine_ir.sio out of replay until they have focused probes/gates and non-overlap with the Claude compiler lane.