### PR TITLE
docs(audit): triage archived Madaros notes

### DIFF
--- a/docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md
+++ b/docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md
@@ -1,0 +1,90 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-archive-triage-2026-06-21
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-archive-triage-2026-06-21
+-->
+
+# Madaros Archive Triage — 2026-06-21
+
+## Scope
+
+This note resolves the Bucket B `docs/audit/MADAROS_*.md` items from the
+primary-checkout archive without replaying stale compiler diagnostics as current
+truth.
+
+Archive source:
+
+- `/workspace/sounio/docs/audit/MADAROS_*.md` in the protected dirty primary
+  checkout.
+
+Current baseline used for this triage:
+
+- `origin/main` at `044969dfe47bbb800bf868779b7e93f8b52981e0`
+  (`Merge pull request #349 from Sounio-lang/codex/hello-example-io`).
+- `bin/madaros` SHA256:
+  `0159bb83fd47bcfab3fd424f91f02023f23ec0cd2028f3c543fa3210a8a0f13c`.
+- `bin/madaros-linux-x86_64` SHA256:
+  `506d24c47e6a735340b0f8ced2072fa1baf485bb8d65461857b5a8d5565b0cef`.
+
+## Disposition Summary
+
+| Archive item | Disposition | Reason |
+|---|---|---|
+| `MADAROS_BOXNEW_SIGSEGV_2026-06-19.md` | already represented on `origin/main` | The checked-in file is newer than the archived primary copy and includes the 2026-06-20 production Slurm result. |
+| `MADAROS_NATIVE_V2_CODEGEN_CENSUS_2026-06-19.md` | archive-only, superseded | The raw census predates the checked-in `MADAROS_PRINT_INT_DISPATCH_2026-06-20.md` and `MADAROS_FOR_LOOP_LOWERING_2026-06-20.md` follow-ups, and it contains acknowledged harness false readings for enum and method cases. |
+| `MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md` | archive-only, do not promote raw | Useful forensics, but it depends on stripped-binary/core state from an older prebuilt and overlaps the active Root 2 compiler lane. |
+| `MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md` | archive-only, do not promote raw | Useful correction to the old census, but current disposition is tied to the same by-value/SRET family being handled in compiler work. |
+| `MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md` | archive-only, do not promote raw | Deep core note; needs a fresh repro or trace on the current Madaros lane before becoming authoritative repo docs. |
+| `MADAROS_SRET_ROOT_SYNTHESIS_2026-06-20.md` | archive-only, do not promote raw | Historical synthesis of Root 1 and Root 2; current action belongs in the compiler lane, not a docs-only replay. |
+
+## Current Repo Truth
+
+The current repo already has three governed Madaros audit notes:
+
+- `docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md`
+- `docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md`
+- `docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md`
+
+Those files are the checked-in audit surface for the Box, integer-print, and
+for-loop findings. The primary archive also contains later enum/method/root
+notes, but they are not safe to promote as standalone truth because:
+
+- they were written against an older prebuilt state,
+- several statements are explicitly corrections to an earlier broken harness,
+- they overlap compiler-adjacent Root 2/SRET work,
+- the active compiler lane must own source fixes and fresh reproducer evidence.
+
+## Actionable Compiler Handoff
+
+The archived enum, method, Root 2, and SRET notes should be treated as evidence
+for the compiler lane, not as source changes and not as independent docs truth.
+
+If another agent wants to convert them into a compiler task, use the blocker
+contract shape from `.claude/PARALLEL_BLOCKER_CONTRACT.md`:
+
+- Blocker-ID: `MADAROS-ROOT2-SRET-ARCHIVE-TRIAGE-2026-06-21`
+- Severity: high
+- Class: compiler/runtime-lowering
+- Evidence level: archive forensics plus current repo triage
+- Owner: compiler lane
+- Acceptance gate: fresh current-branch repro for enum variant and method-call
+  cases, then a focused Madaros/native gate on the same branch that changes
+  compiler code
+- Next action: re-run the enum/method repros on the current compiler lane and
+  decide whether the Root 2/SRET fix already covers them or needs a focused
+  patch
+
+## Explicit Non-Actions
+
+This PR intentionally does not:
+
+- copy the raw archived `MADAROS_*.md` files into `origin/main`,
+- edit `self-hosted/*`,
+- edit `bin/madaros` or the raw Madaros ELF,
+- claim the Root 2/SRET compiler blocker is fixed.
+
+The result is a source-controlled disposition for the archive bucket, while the
+actual compiler repair remains in the compiler lane with non-overlap preserved.

--- a/docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md
+++ b/docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md
@@ -28,8 +28,8 @@ protected `/workspace/sounio` checkout.
 
 ## Current Baseline
 
-- Current `origin/main`: `32ed3d3d71a94a6b328d2fff71395f8af7ed8c19`
-  (`Merge pull request #347 from Sounio-lang/codex/agents-ctx7-contract`).
+- Current `origin/main`: `044969dfe47bbb800bf868779b7e93f8b52981e0`
+  (`Merge pull request #349 from Sounio-lang/codex/hello-example-io`).
 - The primary archive was created from `/workspace/sounio` without destructive
   cleanup.
 - The MCP patch bucket from the primary archive is already represented on
@@ -39,6 +39,8 @@ protected `/workspace/sounio` checkout.
   documentation contract.
 - The worktree governance gate is resolved by #346 and runs in the `Contracts`
   CI job.
+- The `examples/hello.sio` bucket is resolved by #349; PR CI and post-merge
+  `main` CI both passed.
 
 ## Resolution Queue
 
@@ -64,9 +66,9 @@ state is local workspace state rather than a proven branch:
 
 | Item | Initial finding | Required gate |
 |---|---|---|
-| `examples/hello.sio` | changes hello from return-only to `println("Hello, Sounio")` with `with IO` | `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/run_sio_test_suite.sh hello --verbose` |
-| `examples/erdos/reproducer_madaros_codegen_2026-06-16g.sio` | likely a debugging reproducer, not a general example | classify against current Madaros gates before adding |
-| `docs/audit/MADAROS_*.md` from archive | useful forensic notes, but several contradict newer fixed state | promote only after refresh against current `origin/main` and current binary SHA |
+| `examples/hello.sio` | resolved by #349 | `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/run_sio_test_suite.sh hello --verbose`; PR CI and post-merge `main` CI passed |
+| `examples/erdos/reproducer_madaros_codegen_2026-06-16g.sio` | already identical on current `origin/main` | no PR; keep as already represented |
+| `docs/audit/MADAROS_*.md` from archive | classified by `docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md` | raw files are archive-only unless a compiler lane refreshes them against current binaries and gates |
 
 Exit criterion: one narrow PR per item or a written discard reason.
 
@@ -128,7 +130,10 @@ Codex must not write to Claude-owned compiler files during the same phase.
 
 1. Keep `origin/main` green and use it as the only production baseline.
 2. Resolve Bucket A by recording it as already done.
-3. Review Bucket B one item at a time, starting with `examples/hello.sio`.
+3. Review Bucket B one item at a time. `examples/hello.sio` is complete via
+   #349, the Erdos reproducer is already present on `origin/main`, and archived
+   Madaros notes are classified by
+   `docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md`.
 4. Mark Bucket C as archive-only unless a future source contract is created.
 5. Harden or discard Bucket D scripts; never commit them raw.
 6. Treat Bucket E as compiler work requiring a reproducer, a focused gate, and

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 734
-- Repo-backed topics: 584
+- Total governed topics: 735
+- Repo-backed topics: 585
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 442
+- Authority count `repo_only`: 443
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 446 topics
+- A2: 447 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -104,6 +104,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.g1-wip.verdict-parity-2026-06-02 | repo_only | docs/audit/g1_wip/VERDICT_PARITY_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1864,6 +1864,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-archive-triage-2026-06-21",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md",


### PR DESCRIPTION
## Summary
- add a governed triage note for archived primary-checkout Madaros audit docs
- update the primary checkout reconciliation plan after #349 and the Erdos comparison
- regenerate docs governance metadata for the new audit topic

## Validation
- node scripts/docs/sync_governance_metadata.mjs
- bash scripts/dev/check_docs_registry.sh
- bash scripts/dev/check_docs_consistency.sh
- bash scripts/dev/check_workflow_script_refs.sh
- bash scripts/ci/check_issue_template_contracts.sh
- git diff --check
- SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-audit-docs)$' scripts/dev/worktree_branch_audit.sh --check

## Notes
- No compiler files, binaries, or self-hosted sources were edited.
- Raw archived Madaros notes remain archive-only; compiler-adjacent Root 2/SRET work stays with the compiler lane.