### PR TITLE
docs(audit): classify bucket D scripts

### DIFF
--- a/docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md
+++ b/docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md
@@ -1,0 +1,100 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.bucket-d-script-hardening-2026-06-21
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.bucket-d-script-hardening-2026-06-21
+-->
+
+# Bucket D Script Hardening — 2026-06-21
+
+## Scope
+
+This note resolves the primary-checkout reconciliation Bucket D disposition.
+Bucket D contains helper scripts found in the dirty protected checkout. They are
+not automatically production source.
+
+Current baseline:
+
+- `origin/main` at `45a1e19310ba24005d1b6c83676828945f7fd9ca`
+  (`Merge pull request #350 from Sounio-lang/codex/madaros-audit-docs`).
+- Archive/source for local-only candidates: protected `/workspace/sounio`.
+
+## Disposition
+
+| Item | Current state | Disposition |
+|---|---|---|
+| `scripts/coverage_report.sh` | not present on `origin/main`; archived script has a malformed `basename " $f" .mdx` line and no CI contract | do not promote raw; replace only with a tested website coverage command |
+| `scripts/validate_mdx.sh` | not present on `origin/main`; archived script mutates dependencies with `npm install --no-save` and uses uninitialized counters under `set -u` | do not promote raw; use existing website quality checks until a no-mutation validator is added |
+| `scripts/translate_all_locales.sh` | not present on `origin/main`; archived script assumes `.venv`, a cluster-internal Beagle URL, and writes logs into repo root | do not promote raw; future version must be operator-only and fully parameterized |
+| `slurm-jobs/madaros-frame-fix/fetch_stack_fix.sh` | present on `origin/main` and identical to archive | already represented; no replay |
+| `slurm-jobs/madaros-frame-fix/submit_stack_fix.sh` | present on `origin/main`; archive copy is stale compared with current diagnostic no-ulimit contract | keep current `origin/main`; no replay |
+
+## Required Gates Before Any Future Script Promotion
+
+Any future PR that promotes one of the three local-only scripts must include:
+
+- a scoped script path under `scripts/dev/`, `scripts/ops/`, or `scripts/website/`
+  instead of a vague root-level helper,
+- `bash -n` for shell syntax,
+- `shellcheck` when available, or a documented reason if unavailable in the
+  workspace image,
+- a dry-run mode that does not mutate dependencies, write repo-root logs, or
+  contact internal services by default,
+- a CI or documented operator contract naming exactly when the script is safe
+  to run,
+- no hardcoded cluster-internal API endpoint unless it is behind an explicit
+  environment variable with a safe default.
+
+## Concrete Future Shapes
+
+### Website Coverage
+
+If locale coverage is needed, implement it as a deterministic report command
+that reads `website/src/content/**` and prints counts only. It should not write
+files and should pass:
+
+```bash
+bash -n scripts/website/coverage_report.sh
+scripts/website/coverage_report.sh
+```
+
+### MDX Validation
+
+If a standalone MDX validator is still useful beyond the website workflow, it
+must use checked-in website dependencies. It must not run `npm install`.
+Acceptance gate:
+
+```bash
+cd website
+npm ci
+npm run quality
+```
+
+A separate shell wrapper may call the website command, but should not become a
+second dependency manager.
+
+### Locale Translation
+
+Translation must be operator-only, not CI. A future helper should require:
+
+- `OPENAI_API_BASE`
+- `MODEL_NAME`
+- `TARGET_LOCALE` or an explicit locale list
+- `TRANSLATION_LOG_DIR` outside the repo by default
+
+It must support `--dry-run` and refuse to run when the API base/model is not
+explicitly supplied.
+
+### Slurm Frame-Fix Helpers
+
+The Slurm frame-fix helpers are already source-controlled. Changes to them must
+be validated against the current foundry/Slurm contract and should not be mixed
+with website/locale tooling.
+
+## Result
+
+Bucket D is classified, but no raw script is promoted. This keeps `origin/main`
+clean while preserving the exact path to productionize any helper that is still
+needed.

--- a/docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md
+++ b/docs/audit/PRIMARY_CHECKOUT_RECONCILIATION_PLAN_2026-06-21.md
@@ -98,8 +98,9 @@ The archived helper scripts are not production-ready as-is:
 | `scripts/translate_all_locales.sh` | hardcodes an internal Beagle service and writes logs in repo root | parameterize endpoint/model/output path and document that it is operator-only |
 | `slurm-jobs/madaros-frame-fix/*.sh` | operational Slurm helpers tied to a specific Madaros frame-fix lane | refresh against current foundry/Slurm contract before adding |
 
-Exit criterion: do not commit raw scripts. Promote only via a dedicated tooling
-PR with shell validation and an operator-facing contract.
+Exit criterion: `docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md` records
+the disposition. Do not commit raw scripts. Promote only via a dedicated
+tooling PR with shell validation and an operator-facing contract.
 
 ### Bucket E — Compiler-Adjacent High Risk
 
@@ -135,7 +136,9 @@ Codex must not write to Claude-owned compiler files during the same phase.
    Madaros notes are classified by
    `docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md`.
 4. Mark Bucket C as archive-only unless a future source contract is created.
-5. Harden or discard Bucket D scripts; never commit them raw.
+5. Harden or discard Bucket D scripts; never commit them raw. Current
+   disposition is recorded in
+   `docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md`.
 6. Treat Bucket E as compiler work requiring a reproducer, a focused gate, and
    explicit non-overlap with Claude's lane.
 7. After every PR, wait for CI and remove the temporary worktree/branch.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 735
-- Repo-backed topics: 585
+- Total governed topics: 736
+- Repo-backed topics: 586
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 443
+- Authority count `repo_only`: 444
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 447 topics
+- A2: 448 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -72,6 +72,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.roadmap-v0.5.0-part3 | archived | docs/archived/ROADMAP_v0.5.0_PART3.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.strategic-growth-plan | archived | docs/archived/STRATEGIC_GROWTH_PLAN.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.bucket-d-script-hardening-2026-06-21 | repo_only | docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.chi5-real-axiom-audit-2026-05-30 | repo_only | docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-demo-sweep-2026-06-02 | repo_only | docs/audit/EPISTEMIC_DEMO_SWEEP_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-nn-backward-e2e-2026-06-02 | repo_only | docs/audit/EPISTEMIC_NN_BACKWARD_E2E_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1128,6 +1128,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.bucket-d-script-hardening-2026-06-21",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.chi5-real-axiom-audit-2026-05-30",
       "collection": "repo",
       "repo_doc_path": "docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md",


### PR DESCRIPTION
## Summary
- add a governed Bucket D script-hardening disposition
- record that raw coverage/MDX/translation scripts must not be promoted as-is
- update the primary checkout reconciliation plan and docs governance metadata

## Validation
- node scripts/docs/sync_governance_metadata.mjs
- bash scripts/dev/check_docs_registry.sh
- bash scripts/dev/check_docs_consistency.sh
- bash scripts/dev/check_workflow_script_refs.sh
- bash scripts/ci/check_issue_template_contracts.sh
- git diff --check
- SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-bucket-d-script-hardening)$' scripts/dev/worktree_branch_audit.sh --check

## Notes
- No archived raw scripts were added.
- No compiler, Slurm helper, or binary files were edited.