### PR TITLE
ops: add Madaros Root2 acceptance gate

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -24,10 +24,10 @@ The plan coordinates:
 
 Current baseline:
 
-- `origin/main`: `a6c2e1f771505b4824908a185f6e1309f47e97b0`
-  (`Merge pull request #351 from Sounio-lang/codex/bucket-d-script-hardening`).
+- `origin/main`: `4e8a5b48b1356b2c6ee061ef37c3a8065c06ca75`
+  (`Merge pull request #353 from Sounio-lang/codex/madaros-root2-readonly-probe`).
 - Protected dirty primary checkout: `/workspace/sounio`.
-- Current planning worktree: `/tmp/sounio-madaros-production-plan`.
+- Current planning worktree: `/tmp/sounio-madaros-root2-operator-gate`.
 
 The goal is not to make every old worktree disappear immediately. The goal is
 to ensure that only current, gated, ownership-clear work can influence Madaros
@@ -155,6 +155,15 @@ env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
   bash scripts/run_sio_test_suite.sh <focused-suite> --verbose
 ```
 
+Packaged operator gate:
+
+```bash
+scripts/ops/madaros_root2_acceptance_gate.sh
+```
+
+Use `--allow-fail` only for diagnostic snapshots while the blocker is still
+open; a merge-ready compiler lane must run the gate without `--allow-fail`.
+
 Exit:
 
 - Archive notes are replaced by current evidence or explicitly closed as stale.
@@ -177,6 +186,8 @@ Minimum local gates:
 ```bash
 env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
   bash scripts/run_sio_test_suite.sh <new-focused-tests> --verbose
+
+scripts/ops/madaros_root2_acceptance_gate.sh
 
 bash scripts/ci/build_native_souc.sh
 ```

--- a/docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md
+++ b/docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md
@@ -17,9 +17,9 @@ change compiler source.
 
 Current production baseline:
 
-- `origin/main`: `f9e186318d08dbcc1d25b8bdbe454d2eda43626f`
-  (`Merge pull request #352 from Sounio-lang/codex/madaros-production-plan`).
-- `main` CI run `27891359138`: success.
+- `origin/main`: `4e8a5b48b1356b2c6ee061ef37c3a8065c06ca75`
+  (`Merge pull request #353 from Sounio-lang/codex/madaros-root2-readonly-probe`).
+- `main` CI run `27891934564`: success.
 
 Read-only probed lane:
 
@@ -194,17 +194,36 @@ Next-Action: compiler owner should decide whether the in-place lower/codegen rew
 
 ## Next Commands For Compiler Owner
 
-Run from the Claude lane:
+Run the packaged operator gate from the Claude lane:
 
 ```bash
 cd /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b
 git status --short --branch
 
-env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
-  bash scripts/ci/native_v2_enum_match_gate.sh
+scripts/ops/madaros_root2_acceptance_gate.sh
+```
 
-env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
-  bash scripts/run_sio_test_suite.sh sret_forwarding --verbose
+For diagnostics before the compiler fix is ready, use
+`scripts/ops/madaros_root2_acceptance_gate.sh --allow-fail --out-dir <dir>` to
+capture logs without converting the probe into a failed shell session.
+
+Self-test of the packaged gate on `origin/main` at `4e8a5b48b`:
+
+```bash
+scripts/ops/madaros_root2_acceptance_gate.sh \
+  --allow-fail \
+  --out-dir /tmp/sounio-root2-operator-gate-selftest
+```
+
+Result:
+
+```text
+madaros_operational_contract: PASS
+native_v2_enum_match: FAIL rc=139
+sret_forwarding: FAIL rc=1
+  sret_forwarding_minimal.sio: PASS
+  sret_forwarding_cross_module_cd_mul.sio: FAIL run exited 1
+  sret_forwarding_tuple_aggregate.sio: SKIP no-annotation
 ```
 
 If those remain red after the in-place rewrite, narrow with a debugger/core on

--- a/scripts/ops/madaros_root2_acceptance_gate.sh
+++ b/scripts/ops/madaros_root2_acceptance_gate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Operator gate for the Madaros Root2/SRET/enum repair lane.
+#
+# This is intentionally not wired into CI while the blocker is open. It packages
+# the current acceptance repros so the compiler owner can rerun the same
+# environment-clean checks before marking the lane ready.
+
+set -u -o pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR" || exit 1
+
+ALLOW_FAIL=0
+OUT_DIR="${SOUNIO_MADAROS_ROOT2_GATE_DIR:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ops/madaros_root2_acceptance_gate.sh [--allow-fail] [--out-dir DIR]
+
+Runs the current Madaros Root2/SRET acceptance probes with SOUC/Madaros routing
+environment variables unset:
+
+  1. scripts/ci/madaros_operational_contract_gate.sh
+  2. scripts/ci/native_v2_enum_match_gate.sh
+  3. scripts/run_sio_test_suite.sh sret_forwarding --verbose
+
+By default the script exits non-zero if any probe fails. Use --allow-fail for
+read-only diagnostic snapshots while the blocker is still open.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-fail)
+      ALLOW_FAIL=1
+      shift
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[madaros-root2] unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$(mktemp -d /tmp/sounio-madaros-root2-gate.XXXXXX)"
+fi
+mkdir -p "$OUT_DIR" || exit 1
+
+printf '[madaros-root2] root=%s\n' "$ROOT_DIR"
+printf '[madaros-root2] out=%s\n' "$OUT_DIR"
+printf '[madaros-root2] allow_fail=%s\n' "$ALLOW_FAIL"
+
+FAILURES=0
+
+run_probe() {
+  local name="$1"
+  shift
+  local log="$OUT_DIR/$name.log"
+
+  printf '[madaros-root2] RUN %s\n' "$name"
+  env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN "$@" >"$log" 2>&1
+  local rc=$?
+
+  if [[ "$rc" -eq 0 ]]; then
+    printf '[madaros-root2] PASS %s\n' "$name"
+  else
+    printf '[madaros-root2] FAIL %s rc=%s log=%s\n' "$name" "$rc" "$log" >&2
+    tail -n 80 "$log" >&2 || true
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+run_probe madaros_operational_contract \
+  bash scripts/ci/madaros_operational_contract_gate.sh
+
+run_probe native_v2_enum_match \
+  bash scripts/ci/native_v2_enum_match_gate.sh
+
+run_probe sret_forwarding \
+  bash scripts/run_sio_test_suite.sh sret_forwarding --verbose
+
+printf '[madaros-root2] failures=%s\n' "$FAILURES"
+
+if [[ "$FAILURES" -ne 0 && "$ALLOW_FAIL" -ne 1 ]]; then
+  printf '[madaros-root2] FAIL: acceptance gate still red\n' >&2
+  exit 1
+fi
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  printf '[madaros-root2] DIAGNOSTIC: failures allowed for open blocker\n'
+else
+  printf '[madaros-root2] PASS: Root2/SRET acceptance probes are green\n'
+fi


### PR DESCRIPTION
## Summary
- add `scripts/ops/madaros_root2_acceptance_gate.sh` as the packaged operator gate for the Root2/SRET/enum blocker
- update the production-readiness plan to use the packaged gate as a merge-readiness check
- update the read-only probe with current main baseline and operator-gate selftest results

## Validation
- `bash -n scripts/ops/madaros_root2_acceptance_gate.sh`
- `scripts/ops/madaros_root2_acceptance_gate.sh --help`
- `scripts/ops/madaros_root2_acceptance_gate.sh --allow-fail --out-dir /tmp/sounio-root2-operator-gate-selftest`
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/ci/check_issue_template_contracts.sh`
- `git diff --check`
- `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-root2-operator-gate)$' scripts/dev/worktree_branch_audit.sh --check`\n\n## Notes\n- `shellcheck` is unavailable in the workspace image.\n- The new gate is not wired into CI while the blocker is open; compiler lanes should run it without `--allow-fail` before merge readiness.\n\n## LLM-offload reviews invoked\n- not required: repo-internal ops/docs gate only; no math claims, clinical-pathway code, or external-facing artifact changed\n