### PR TITLE
ops: allow Root2 gate to target compiler worktrees

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -161,6 +161,14 @@ Packaged operator gate:
 scripts/ops/madaros_root2_acceptance_gate.sh
 ```
 
+From a current checkout, the same gate can target an older active compiler lane
+without copying files into that lane:
+
+```bash
+scripts/ops/madaros_root2_acceptance_gate.sh \
+  --root /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b
+```
+
 Use `--allow-fail` only for diagnostic snapshots while the blocker is still
 open; a merge-ready compiler lane must run the gate without `--allow-fail`.
 

--- a/docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md
+++ b/docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md
@@ -203,9 +203,19 @@ git status --short --branch
 scripts/ops/madaros_root2_acceptance_gate.sh
 ```
 
+If the active compiler lane is on an older base that does not contain the gate,
+run it from a current checkout and target the lane explicitly:
+
+```bash
+cd /tmp/sounio-main-final
+scripts/ops/madaros_root2_acceptance_gate.sh \
+  --root /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b
+```
+
 For diagnostics before the compiler fix is ready, use
-`scripts/ops/madaros_root2_acceptance_gate.sh --allow-fail --out-dir <dir>` to
-capture logs without converting the probe into a failed shell session.
+`scripts/ops/madaros_root2_acceptance_gate.sh --root <repo> --allow-fail
+--out-dir <dir>` to capture logs without converting the probe into a failed
+shell session.
 
 Self-test of the packaged gate on `origin/main` at `4e8a5b48b`:
 

--- a/scripts/ops/madaros_root2_acceptance_gate.sh
+++ b/scripts/ops/madaros_root2_acceptance_gate.sh
@@ -8,14 +8,13 @@
 set -u -o pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-cd "$ROOT_DIR" || exit 1
 
 ALLOW_FAIL=0
 OUT_DIR="${SOUNIO_MADAROS_ROOT2_GATE_DIR:-}"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/ops/madaros_root2_acceptance_gate.sh [--allow-fail] [--out-dir DIR]
+Usage: scripts/ops/madaros_root2_acceptance_gate.sh [--allow-fail] [--out-dir DIR] [--root DIR]
 
 Runs the current Madaros Root2/SRET acceptance probes with SOUC/Madaros routing
 environment variables unset:
@@ -25,7 +24,9 @@ environment variables unset:
   3. scripts/run_sio_test_suite.sh sret_forwarding --verbose
 
 By default the script exits non-zero if any probe fails. Use --allow-fail for
-read-only diagnostic snapshots while the blocker is still open.
+read-only diagnostic snapshots while the blocker is still open. Use --root to
+run the gate from a current checkout against an older compiler worktree without
+copying this script into that worktree.
 USAGE
 }
 
@@ -36,7 +37,19 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --out-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "[madaros-root2] --out-dir requires a directory" >&2
+        exit 2
+      fi
       OUT_DIR="$2"
+      shift 2
+      ;;
+    --root)
+      if [[ $# -lt 2 ]]; then
+        echo "[madaros-root2] --root requires a repository directory" >&2
+        exit 2
+      fi
+      ROOT_DIR="$2"
       shift 2
       ;;
     -h|--help)
@@ -50,6 +63,9 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+ROOT_DIR="$(cd "$ROOT_DIR" && pwd)" || exit 1
+cd "$ROOT_DIR" || exit 1
 
 if [[ -z "$OUT_DIR" ]]; then
   OUT_DIR="$(mktemp -d /tmp/sounio-madaros-root2-gate.XXXXXX)"


### PR DESCRIPTION
## Summary

- adds `--root DIR` to `scripts/ops/madaros_root2_acceptance_gate.sh`
- lets a current checkout run the Root2/SRET acceptance gate against an older active compiler worktree without copying files into that lane
- documents the target-worktree invocation in the Madaros readiness/probe notes

## Why

The active Claude compiler lane is based before the packaged gate landed, so it cannot run `scripts/ops/madaros_root2_acceptance_gate.sh` from inside the lane without rebasing or copying the script. This keeps ownership clean: Codex can run the current gate against the Claude-owned worktree read-only, while Claude remains the sole writer for compiler files.

## Validation

- `bash -n scripts/ops/madaros_root2_acceptance_gate.sh`
- `scripts/ops/madaros_root2_acceptance_gate.sh --help`
- `scripts/ops/madaros_root2_acceptance_gate.sh --root /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b --allow-fail --out-dir /tmp/sounio-root2-gate-root-option-claude`
  - `madaros_operational_contract`: PASS
  - `native_v2_enum_match`: FAIL rc=139, expected while blocker open
  - `sret_forwarding`: FAIL rc=1, expected while blocker open
- missing-argument checks for `--root` and `--out-dir` return rc=2
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/ci/check_issue_template_contracts.sh`
- `git diff --check`
- `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-root2-gate-target)$' scripts/dev/worktree_branch_audit.sh --check`

## LLM-offload

Not required: repo-internal ops/docs gate routing only; no math claims, clinical-pathway code, or external-facing artifact.
