### PR TITLE
docs(audit): link Root2 blocker issue

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -24,10 +24,13 @@ The plan coordinates:
 
 Current baseline:
 
-- `origin/main`: `4e8a5b48b1356b2c6ee061ef37c3a8065c06ca75`
-  (`Merge pull request #353 from Sounio-lang/codex/madaros-root2-readonly-probe`).
+- `origin/main`: `91551953cedefb780cba9fe7ebd61c8a8a5b301d`
+  (`Merge pull request #355 from Sounio-lang/codex/madaros-root2-gate-target`).
+- `main` CI run `27892902187`: success.
+- Canonical live blocker: GitHub issue #356.
 - Protected dirty primary checkout: `/workspace/sounio`.
-- Current planning worktree: `/tmp/sounio-madaros-root2-operator-gate`.
+- Current planning worktree: create a fresh isolated worktree from `origin/main`
+  for each narrow readiness change.
 
 The goal is not to make every old worktree disappear immediately. The goal is
 to ensure that only current, gated, ownership-clear work can influence Madaros
@@ -59,6 +62,8 @@ Madaros is production-ready only when all of these are true:
 | `examples/hello.sio` | Prints and exits cleanly | #349 plus post-merge `main` CI |
 | Archived Madaros docs | Raw notes are triaged, not promoted | #350 plus post-merge `main` CI |
 | Bucket D scripts | Raw local scripts are blocked from promotion | #351 plus post-merge `main` CI |
+| Root 2 operator gate | Acceptance probes are packaged but intentionally red while blocker is open | #354 plus post-merge `main` CI |
+| Root 2 target-worktree gate | Current `main` can run the gate against older active compiler lanes via `--root` | #355 plus post-merge `main` CI |
 
 ## Phase 0 — Freeze Source Of Truth
 
@@ -114,15 +119,16 @@ Actions:
 
 ```text
 Blocker-ID: MADAROS-ROOT2-SRET-ARCHIVE-TRIAGE-2026-06-21
-Status: classified
+Status: reproduced
 Severity: B1
 Class: compiler-semantics
 Owner: compiler lane
 Lane: Madaros Root 2/SRET/enum/method-call repair
+Canonical-Issue: https://github.com/Sounio-lang/sounio/issues/356
 Files-Owned: self-hosted/compiler/main.sio, self-hosted/native/codegen.sio, self-hosted/native/codegen_x86_linux.sio, self-hosted/native/lower_ir.sio, self-hosted/native/suite.sio
-Acceptance-Gate: fresh current-branch enum and method-call repros plus focused Madaros/native gate on the branch that changes compiler code
-Evidence-Level: E2
-Next-Action: rerun enum/method repros on the current compiler lane and decide whether the Root 2/SRET patch closes them
+Acceptance-Gate: scripts/ops/madaros_root2_acceptance_gate.sh --root <compiler-worktree> passes without --allow-fail from the branch that changes compiler code
+Evidence-Level: E1
+Next-Action: compiler owner closes native_v2_enum_match and sret_forwarding segfaults, then reruns the gate without --allow-fail before any PR
 ```
 
 Exit:
@@ -298,6 +304,7 @@ SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.cla
 Stop and create a blocker if:
 
 - a Codex lane needs to edit a Claude-owned compiler file,
+- Root 2/SRET acceptance diverges from canonical issue #356,
 - a gate passes only because of `SOUC_BIN`, `MADAROS_BIN`, or stdlib path
   contamination,
 - an archived Madaros note contradicts fresh current-branch evidence,

--- a/docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md
+++ b/docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md
@@ -17,9 +17,10 @@ change compiler source.
 
 Current production baseline:
 
-- `origin/main`: `4e8a5b48b1356b2c6ee061ef37c3a8065c06ca75`
-  (`Merge pull request #353 from Sounio-lang/codex/madaros-root2-readonly-probe`).
-- `main` CI run `27891934564`: success.
+- `origin/main`: `91551953cedefb780cba9fe7ebd61c8a8a5b301d`
+  (`Merge pull request #355 from Sounio-lang/codex/madaros-root2-gate-target`).
+- `main` CI run `27892902187`: success.
+- Canonical live blocker: GitHub issue #356.
 
 Read-only probed lane:
 
@@ -175,21 +176,22 @@ Severity: B1
 Class: compiler-semantics
 Owner: compiler lane
 Lane: Madaros Root 2/SRET/enum/method-call repair
+Canonical-Issue: https://github.com/Sounio-lang/sounio/issues/356
 Worktree: /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b
 Branch: worktree-agent-adc1cd8b9d52ba53b
 Files-Owned: self-hosted/compiler/main.sio, self-hosted/native/codegen.sio, self-hosted/native/codegen_x86_linux.sio, self-hosted/native/lower_ir.sio, self-hosted/native/suite.sio
 Files-Read-Only: docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md, scripts/ci/native_v2_enum_match_gate.sh, scripts/ci/madaros_operational_contract_gate.sh, scripts/run_sio_test_suite.sh, tests/run-pass/sret_forwarding_minimal.sio, tests/run-pass/sret_forwarding_cross_module_cd_mul.sio
 Do-Not-Touch: Claude-owned compiler files listed above unless ownership transfers
-Repro: env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/native_v2_enum_match_gate.sh
+Repro: scripts/ops/madaros_root2_acceptance_gate.sh --root /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b --allow-fail
 Observed: driver check passes, raw Madaros native-v2 compile path segfaults with exit 139
 Expected: enum native-v2 driver emits executable that prints 2 and exits 0
-Acceptance-Gate: native_v2_enum_match_gate.sh plus sret_forwarding_minimal and sret_forwarding_cross_module_cd_mul run-pass probes pass under environment-clean routing
+Acceptance-Gate: scripts/ops/madaros_root2_acceptance_gate.sh --root <compiler-worktree> passes without --allow-fail from the branch that changes compiler code
 Evidence-Level: E1
-Evidence: /tmp/sounio-native-v2-enum-match.JSe8FE/driver.check.log and /tmp/sounio-native-v2-enum-match.JSe8FE/enum_match.compile.log on the 2026-06-21 workspace
+Evidence: /tmp/sounio-root2-gate-root-option-main-91551953c on the 2026-06-21 workspace
 Fallback-Path: none
 Legacy-Kept: yes
 LLM-Offload: not-required
-Next-Action: compiler owner should decide whether the in-place lower/codegen rewrite is meant to close this; then rerun the same env-clean gate and SRET forwarding probes before any PR
+Next-Action: compiler owner should close the native_v2_enum_match and sret_forwarding segfaults, then rerun the root-targeted gate without --allow-fail before any PR
 ```
 
 ## Next Commands For Compiler Owner


### PR DESCRIPTION
## Summary

- updates Madaros readiness/probe docs to current `origin/main` (`91551953c`) and CI (`27892902187`)
- links canonical live blocker issue #356 from both audit docs
- records #354/#355 as closed gate/tooling steps and points acceptance at `scripts/ops/madaros_root2_acceptance_gate.sh --root <compiler-worktree>`

## Why

The production-readiness plan was still pointing at the pre-gate baseline and had no GitHub issue anchor for the live Root2/SRET blocker. This keeps future agents from treating old conflicting PRs as the production fix and gives the compiler owner a single acceptance record.

## Validation

- `./sounio-whereami --quick`
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/ci/check_issue_template_contracts.sh`
- `git diff --check`
- `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-root2-issue-link)$' scripts/dev/worktree_branch_audit.sh --check`

## LLM-offload

Not required: repo-internal audit/governance docs only; no math claims, clinical-pathway code, or external-facing artifact.
