### PR TITLE
ci: block releases on open release blockers

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -158,10 +158,32 @@ jobs:
             /tmp/sounio-native-acceptance-macos-arm64
           retention-days: 7
 
+  open-release-blockers:
+    name: Open Release Blockers
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check open release-blocker issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label release-blocker \
+            --json number,title,url \
+            --jq '.[] | "#\(.number) \(.title) \(.url)"' \
+            > /tmp/open-release-blockers.txt
+          if [ -s /tmp/open-release-blockers.txt ]; then
+            echo "OPEN_RELEASE_BLOCKERS"
+            cat /tmp/open-release-blockers.txt
+            exit 1
+          fi
+          echo "NO_OPEN_RELEASE_BLOCKERS"
+
   release-dashboard:
     name: Release Dashboard
     runs-on: ubuntu-24.04
-    needs: [seed-policy, rust-free-proof, lsp-smoke, full-selfhost, source-bootstrap-selfhost, apple-selfhost]
+    needs: [seed-policy, rust-free-proof, lsp-smoke, full-selfhost, source-bootstrap-selfhost, apple-selfhost, open-release-blockers]
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -177,4 +199,5 @@ jobs:
           echo "| Full Self-Host | ${{ needs.full-selfhost.result }} |" >> /tmp/release-status.md
           echo "| Source-Bootstrap Self-Host | ${{ needs.source-bootstrap-selfhost.result }} |" >> /tmp/release-status.md
           echo "| Apple Self-Host | ${{ needs.apple-selfhost.result }} |" >> /tmp/release-status.md
+          echo "| Open Release Blockers | ${{ needs.open-release-blockers.result }} |" >> /tmp/release-status.md
           cat /tmp/release-status.md

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -30,7 +30,8 @@ Releases are **event-driven**, not calendar-driven. A release is cut when:
 
 1. A significant feature milestone is reached (new stdlib domain, compiler backend, paper submission)
 2. A critical bug fix warrants immediate distribution
-3. The release-readiness dashboard (`.github/workflows/release-readiness-dashboard.yml`) reports green
+3. The release dashboard job in `.github/workflows/release-gate.yml` reports
+   green, including zero open issues labeled `release-blocker`
 
 There is no fixed cadence. Research languages evolve in bursts aligned with paper deadlines and sprint completions.
 


### PR DESCRIPTION
## Summary

- adds an `Open Release Blockers` job to `.github/workflows/release-gate.yml`
- fails the release gate when any open issue is labeled `release-blocker`
- includes the blocker result in the existing `Release Dashboard` job
- updates `docs/RELEASE_POLICY.md` to point at `release-gate.yml` instead of the non-existent `release-readiness-dashboard.yml`

## Why

Issue #356 is now the canonical Madaros Root2/SRET production blocker and is labeled `release-blocker`. Before this change, the release dashboard could still report green without checking open release-blocker issues. This makes release-readiness reflect the live blocker list.

## Expected current behavior

While #356 remains open, the new release-gate job should fail intentionally and print the open blocker. After the compiler lane closes #356, the job should pass.

## Validation

- `./sounio-whereami --quick`
- `gh issue list --repo Sounio-lang/sounio --state open --label release-blocker --json number,title,url --jq '.[] | "#\(.number) \(.title) \(.url)"'`
  - confirmed #356 is detected
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/ci/check_issue_template_contracts.sh`
- `node scripts/docs/check_docs_registry.mjs`
- `git diff --check`
- `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-release-gate-open-blockers)$' scripts/dev/worktree_branch_audit.sh --check`

Local limitation: `actionlint`, Ruby, and PyYAML were not available in this workspace image, so YAML syntax validation is left to GitHub's workflow parser/PR checks.

## LLM-offload

Not required: CI/release governance only; no math claims, clinical-pathway code, or external-facing artifact.
