### PR TITLE
ci: allow focused native runtime release gate runs

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
+    inputs:
+      native-runtime-filter:
+        description: "Optional native runtime case/path filter, e.g. import_struct_shorthand_42"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -127,6 +132,7 @@ jobs:
     timeout-minutes: 15
     env:
       SOUNIO_SELFHOST_HOST_GATE_DIR: /tmp/sounio-selfhost-macos-arm64
+      FILTER: ${{ github.event.inputs.native-runtime-filter || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Download source-bootstrap macOS compiler artifact

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -35,6 +35,11 @@ Releases are **event-driven**, not calendar-driven. A release is cut when:
 
 There is no fixed cadence. Research languages evolve in bursts aligned with paper deadlines and sprint completions.
 
+Manual `Release Gate` runs may set `native-runtime-filter` to narrow the Apple
+Self-Host native runtime proof during blocker triage. Filtered runs are
+diagnostic evidence only; an unfiltered release gate is still required before a
+release can be considered ready.
+
 ## Release Checklist
 
 Before tagging a release:


### PR DESCRIPTION
## Summary

- adds a manual `native-runtime-filter` input to `Release Gate`
- passes that value as `FILTER` into the Apple Self-Host job
- documents that filtered release-gate runs are diagnostic only and do not replace an unfiltered release gate

## Why

Issue #359 is isolated to the Apple Self-Host native runtime proof for `import_struct_shorthand_42`. The underlying scripts already support `FILTER`, but the release workflow did not expose it through `workflow_dispatch`, making focused macOS runtime repros unnecessarily expensive.

After this lands, a focused probe can be dispatched with:

```bash
gh workflow run release-gate.yml \
  --repo Sounio-lang/sounio \
  --ref main \
  -f native-runtime-filter=import_struct_shorthand_42
```

## Validation

- `./sounio-whereami --quick`
- `node` workflow string-contract check for `native-runtime-filter` and Apple `FILTER`
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/ci/check_issue_template_contracts.sh`
- `git diff --check`
- `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-release-gate-native-filter)$' scripts/dev/worktree_branch_audit.sh --check`

Local limitation: `actionlint` and PyYAML are not available in this workspace image, so GitHub's workflow parser/PR checks are the YAML syntax authority.

## LLM-offload

Not required: CI/release diagnostic routing only; no math claims, clinical-pathway code, or external-facing artifact.
