### PR TITLE
fix: parse arm64 struct shorthand initializers

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -30570,7 +30570,12 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
                         let fne = TE[EP as usize]
                         let fh = gl_name_hash(fns, fne)
                         EP = EP + 1
-                        if TK[EP as usize] == 43 { EP = EP + 1 }
+                        let shorthand_ep = field_tok
+                        if TK[EP as usize] == 43 {
+                            EP = EP + 1
+                        } else {
+                            EP = shorthand_ep
+                        }
                     ST_QUERY_NS = fns
                     ST_QUERY_NE = fne
                         let foff = st_field_offset(si, fh)


### PR DESCRIPTION
## Summary
- mirror the x86 struct-literal shorthand EP rewind in the arm64 lean_single parser
- fixes the arm64 self-hosted compiler path that emitted zeroed fields for imported `Struct { x, y }` initializers

## Evidence
- `git diff --check`
- `FILTER=import_struct_shorthand_42 WORK_DIR=/tmp/sounio-apple-shorthand-local-proof bash scripts/selfhost/selfhost_native_runtime_proof.sh` -> pass=1 fail=0 skip=98 on Linux control
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN artifacts/self-hosted/souc-self-hosted-x86_64 self-hosted/compiler/lean_single.sio /tmp/sounio-apple-shorthand-lean-single/souc-self-hosted-arm64-macos.patched --target aarch64-macos` -> emitted arm64 Mach-O with exit 0

## Notes
- This PR targets issue #359. The decisive proof is a Release Gate dispatch on macOS with `native-runtime-filter=import_struct_shorthand_42`.
- No LLM offload required: internal compiler/runtime fix, no math claims, clinical-pathway code, or external-facing artifact.