### PR TITLE
fix(native-v2): keep legal temps above IR slots

### DIFF
--- a/self-hosted/native/machine_ir.sio
+++ b/self-hosted/native/machine_ir.sio
@@ -607,6 +607,7 @@ pub fn _add_instr_byval(func: MachineFunction, instr: MachineInstr) -> MachineFu
 pub fn native_v2_lower_function_to_machine(func: IrFunction) -> MachineFunction with Mut, Panic, Div, Alloc {
     var out = machine_function_new()
     out.base_slot_count = func.reg_count
+    out.temp_count = func.reg_count
     out.source_instr_count = func.instr_count
 
     var i: i64 = 0
@@ -1280,8 +1281,9 @@ pub fn native_v2_lower_legal_function_from_ir_ref(func: &IrFunction, out: &! Mac
 
 pub fn native_v2_legalize_function(func: MachineFunction) -> MachineFunction with Mut, Panic, Div {
     var out = machine_function_new()
-    out.base_slot_count = func.base_slot_count
-    out.temp_count = func.base_slot_count
+    let base_slots = if func.base_slot_count > func.temp_count { func.base_slot_count } else { func.temp_count }
+    out.base_slot_count = base_slots
+    out.temp_count = base_slots
     out.source_instr_count = func.source_instr_count
     if !func.supported {
         out.supported = false

--- a/tests/native-v2/param_slot_legalize_boundary_witness.sio
+++ b/tests/native-v2/param_slot_legalize_boundary_witness.sio
@@ -1,0 +1,51 @@
+// Native-v2 parameter-slot legalize boundary witness.
+//
+// Legalization temps must start after IR vregs. If temp allocation restarts at
+// zero, MOV_IMM/LOAD_STACK temps reuse parameter slots and user-function
+// arguments are overwritten before return.
+
+use ir::ir::{ir_empty_function, ir_load_imm, ir_return}
+use native::machine_ir::{MIR_OP_MOV_IMM, MIR_OP_STORE_STACK, native_v2_lower_function_to_machine, native_v2_legalize_function}
+
+fn main() -> i64 with IO, Mut, Panic, Div, Alloc {
+    var func = ir_empty_function()
+    func.reg_count = 2
+    func.param_count = 1
+    func.param_regs[0] = 0
+    func.instrs[0] = ir_load_imm(1, 42)
+    func.instrs[1] = ir_return(0)
+    func.instr_count = 2
+
+    let lowered = native_v2_lower_function_to_machine(func)
+    if lowered.temp_count < func.reg_count {
+        print("lower temp_count below reg_count\n")
+        return 1
+    }
+
+    let legal = native_v2_legalize_function(lowered)
+    if legal.blocks[0].instr_count < 2 {
+        print("legal instr_count too small\n")
+        return 2
+    }
+
+    let mov = legal.blocks[0].instrs[0]
+    let store = legal.blocks[0].instrs[1]
+    if mov.opcode != MIR_OP_MOV_IMM {
+        print("expected first legal instr MOV_IMM\n")
+        return 3
+    }
+    if store.opcode != MIR_OP_STORE_STACK {
+        print("expected second legal instr STORE_STACK\n")
+        return 4
+    }
+    if mov.dst.value < func.reg_count {
+        print("legal temp overlaps IR vreg slot\n")
+        return 5
+    }
+    if store.dst.value != 1 || store.src1.value != mov.dst.value {
+        print("store does not move temp into IR dst slot\n")
+        return 6
+    }
+
+    0
+}


### PR DESCRIPTION
## Summary
- preserves IR vreg slot count as the MachineIR legal temp base
- makes legalize use max(base_slot_count, temp_count) so legal temps do not restart at slot 0
- adds a focused native-v2 witness for param-slot/temp overlap

## Why
Current Madaros source-to-ELF direct-call argument witness compiles but exits 0:
`fn id(x: i64) -> i64 { x }; main { id(42) }`.
Disassembly shows the callee correctly spills `rdi` to the parameter slot, then a legal temp writes zero into the same slot before return. The source shape points to MachineIR legal temp allocation overlapping IR parameter vregs.

## Local validation
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bin/souc check self-hosted/native/machine_ir.sio` PASS
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bin/souc check tests/native-v2/param_slot_legalize_boundary_witness.sio` PASS
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN MADAROS_BIN=/tmp/madaros-main-artifact-27899899652/madaros SOUNIO_MADAROS_BIN=/tmp/madaros-main-artifact-27899899652/madaros SOUNIO_MADAROS_OPEN_BLOCKERS_DIR=/tmp/madaros-direct-call-param-slot-baseline scripts/ci/madaros_open_blockers_probe.sh` PASS, confirming baseline blockers reproduce before rebuild

## Not yet proven locally
- Local `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-direct-call-param-slot-fixed` segfaults in the seed compiler before producing Madaros, even with `ulimit -s unlimited`.
- Decisive validation should be GitHub Actions `Madaros Prebuilt Refresh` against `codex/direct-call-param-slot`, then rerun `madaros_open_blockers_probe.sh` with the uploaded artifact.

Blocker-ID: BLK-20260621-codex-source-elf-direct-call-arg
Status: fixing
Severity: B1
Class: compiler-semantics
Owner: Codex
Lane: Madaros source-to-ELF direct-call argument
Worktree: /tmp/sounio-direct-call-param-slot
Branch: codex/direct-call-param-slot
Files-Owned: self-hosted/native/machine_ir.sio, tests/native-v2/param_slot_legalize_boundary_witness.sio
Do-Not-Touch: self-hosted/compiler/main.sio, self-hosted/native/codegen.sio, self-hosted/native/codegen_x86_linux.sio, self-hosted/native/lower_ir.sio, self-hosted/native/suite.sio
Acceptance-Gate: Madaros Prebuilt Refresh on this ref plus scripts/ci/madaros_source_to_elf_gate.sh
Evidence-Level: E2
LLM-Offload: not-required
Next-Action: run Madaros Prebuilt Refresh for codex/direct-call-param-slot and inspect the uploaded artifact gates