### PR TITLE
ci(governance): audit governance control surfaces

### DIFF
--- a/scripts/dev/worktree_branch_audit.sh
+++ b/scripts/dev/worktree_branch_audit.sh
@@ -59,6 +59,12 @@ if [[ -z "$OUT" ]]; then
 fi
 
 CRITICAL_PATHS=(
+  AGENTS.md
+  CLAUDE.md
+  CLAUDE_HANDOFF.md
+  ONBOARDING.md
+  .claude/AGENT_OFFLOAD_POLICY.md
+  .claude/PARALLEL_BLOCKER_CONTRACT.md
   self-hosted/compiler
   self-hosted/ir
   self-hosted/native
@@ -67,7 +73,9 @@ CRITICAL_PATHS=(
   bin/souc
   bin/souc-linux-x86_64
   scripts/ci
+  scripts/dev
   scripts/lib
+  scripts/ops
   .github/workflows
   artifacts/omega/agent_handoff.log.md
 )


### PR DESCRIPTION
## Summary

Hardens `scripts/dev/worktree_branch_audit.sh` so the worktree audit treats governance/control-plane files as critical surfaces too.

New critical paths include:
- `AGENTS.md`, `CLAUDE.md`, `CLAUDE_HANDOFF.md`, `ONBOARDING.md`
- `.claude/AGENT_OFFLOAD_POLICY.md`, `.claude/PARALLEL_BLOCKER_CONTRACT.md`
- `scripts/dev`, `scripts/ops`

## Why

During the Madaros production-readiness audit, the primary checkout was found to be `behind 68` and executing a stale untracked `scripts/dev/worktree_branch_audit.sh`. That produced misleading output (`audit_tsv=--check`) because the primary checkout was shadowing the canonical script on `origin/main`.

The audit itself should report this kind of governance drift. Before this patch, `scripts/dev` and the agent/governance contracts were outside the critical dirty set.

## Validation

Syntax/format:

```bash
bash -n scripts/dev/worktree_branch_audit.sh
git diff --check
```

Both passed.

Real audit with existing known dirty lanes allowlisted:

```bash
SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-direct-call-param-slot|/tmp/sounio-governance-audit-hardening|/workspace/sounio-effects)$' \
  scripts/dev/worktree_branch_audit.sh --check
```

Passed:

```text
total=74 dirty=53 prunable=0 critical_dirty=4 unallowed_critical_dirty=0 critical_vs_base=51 open_pr=0
worktree audit gate passed
```

Intentional detection proof without allowlisting `/workspace/sounio-effects`:

```text
critical_dirty=4 unallowed_critical_dirty=1
- [unallowed] /workspace/sounio-effects | claude/effects-enforcement | ?? scripts/dev/effects_annotate.sh
worktree audit gate failed
```

That is the desired behavior: previously invisible governance/tooling drift is now visible as a critical dirty worktree unless explicitly allowlisted.

## Notes

- No compiler files changed.
- No LLM-offload required; this is internal governance/tooling only.
- This does not resolve the Madaros semantic blockers; it makes the parallel-work audit stricter so compiler lanes do not hide tooling/governance drift.
