### PR TITLE
test(madaros): track self-build blocker in open probe

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -68,7 +68,7 @@ Madaros is production-ready only when all of these are true:
 | Root 2 operator gate | Acceptance probes are packaged but intentionally red while blocker is open | #354 plus post-merge `main` CI |
 | Root 2 target-worktree gate | Current `main` can run the gate against older active compiler lanes via `--root` | #355 plus post-merge `main` CI |
 | Root 2/BSS lowerer floor | BSS globals lower through the stable mut path; native_v2/build global witnesses are healthy | #362 plus post-merge `main` CI |
-| Open blocker probe | `scripts/ci/madaros_open_blockers_probe.sh` keeps known-open direct-call/BSS witnesses executable without promoting them to the source-to-ELF manifest | #363 plus post-merge `main` CI |
+| Open blocker probe | `scripts/ci/madaros_open_blockers_probe.sh` keeps known-open direct-call, BSS, and self-build witnesses executable without promoting them to production manifests | #363/#367 plus post-merge `main` CI; self-build witness added after #368 |
 | Governance control surfaces | Worktree audit treats agent contracts and governance scripts as critical surfaces | #365 plus post-merge `main` CI |
 | Production readiness plan | Current-main readiness plan is committed and merged | #366 plus post-merge local verification |
 | Direct-call argument ABI | `call_arg_id_exit42` exits 42 in normal/native_v2/build and is now a regression control, not an open blocker | #367 plus post-merge local verification |

--- a/scripts/ci/madaros_open_blockers_probe.sh
+++ b/scripts/ci/madaros_open_blockers_probe.sh
@@ -137,6 +137,37 @@ run_case() {
     "$blocker_id" "$case_id" "$mode" "$expected_open_exit" "$actual_exit" "$status" >>"$REPORT"
 }
 
+run_self_build_case() {
+  local blocker_id="$1"
+  local case_id="$2"
+  local expected_open_exit="$3"
+
+  local build_dir="$OUT_DIR/self_build"
+  local out_bin="$build_dir/madaros"
+  local build_log="$LOG_DIR/${case_id}.build.log"
+
+  mkdir -p "$build_dir"
+
+  set +e
+  env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+    bash scripts/ci/build_modular_madaros.sh "$out_bin" >"$build_log" 2>&1
+  local build_rc=$?
+  set -e
+
+  local actual_exit="build_rc_${build_rc}"
+  if [[ "$build_rc" -eq 0 && -x "$out_bin" ]]; then
+    actual_exit="build_rc_0"
+  fi
+
+  local status="still_open"
+  if [[ "$actual_exit" != "$expected_open_exit" ]]; then
+    status="changed"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$blocker_id" "$case_id" "self_build" "$expected_open_exit" "$actual_exit" "$status" >>"$REPORT"
+}
+
 # Controls: user-function calls, with and without arguments, are no longer the
 # open source-to-ELF blocker.
 run_case "control" "call_noarg_exit42" "$SRC_DIR/call_noarg_exit42.sio" "normal" "42"
@@ -153,6 +184,13 @@ run_case "BLK-20260621-codex-source-elf-normal-bss" "global_read_exit4" "$SRC_DI
 run_case "BLK-20260621-codex-source-elf-normal-bss" "global_read_exit4" "$SRC_DIR/global_read_exit4.sio" "native_v2" "compile_rc_139"
 run_case "BLK-20260621-codex-source-elf-normal-bss" "global_read_exit4" "$SRC_DIR/global_read_exit4.sio" "build" "compile_rc_139"
 run_case "BLK-20260621-codex-source-elf-normal-bss" "global_store_exit7" "$SRC_DIR/global_store_exit7.sio" "build" "compile_rc_139"
+
+# BLK-20260621-codex-madaros-build-segfault:
+# Current main segfaults while the lean_single seed compiles
+# self-hosted/compiler/main.sio into the modular Madaros artifact. This witness
+# keeps that production-readiness blocker executable without editing compiler
+# files owned by the active compiler lane.
+run_self_build_case "BLK-20260621-codex-madaros-build-segfault" "self_build_madaros" "build_rc_139"
 
 cat "$REPORT"
 


### PR DESCRIPTION
## Summary

Adds the current Madaros Stage1 self-build segfault to the canonical known-open blocker probe.

- adds `self_build_madaros` as a `BLK-20260621-codex-madaros-build-segfault` witness
- runs `scripts/ci/build_modular_madaros.sh` with compiler/env overrides unset
- expects current known-open behavior `build_rc_139`
- leaves source-to-ELF controls untouched and keeps direct-call argument ABI as a passing control
- updates the readiness plan line describing the probe scope

This is a Codex-safe gate/probe change only. No compiler-owned files were edited.

## Validation

- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/madaros_open_blockers_probe.sh`
- `bash scripts/ci/madaros_source_to_elf_gate.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash -n scripts/ci/madaros_open_blockers_probe.sh`
- `git diff --check`
- `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-selfbuild-open-probe)$' scripts/dev/worktree_branch_audit.sh --check`

## Blocker

Tracks #356 and the blocker record `BLK-20260621-codex-madaros-build-segfault`.

LLM-offload not required: internal compiler readiness probe/docs only.