### PR TITLE
tools(madaros): add readiness status command

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -24,10 +24,10 @@ The plan coordinates:
 
 Current baseline:
 
-- `origin/main`: `c70075772db4265e4f14790c423711f9e6a02d63`
-  (`docs(madaros): add production blocker resolution plan`, #371).
-- `main` CI after #371: success
-  (<https://github.com/Sounio-lang/sounio/actions/runs/27905347997>).
+- `origin/main`: `2ec115e989ac5a58468623d6bd90a18b8207c492`
+  (`docs(madaros): record current worktree disposition queue`, #372).
+- `main` CI after #372: success
+  (<https://github.com/Sounio-lang/sounio/actions/runs/27906018387>).
 - `Madaros Prebuilt Refresh` on `1d0dc6baa`: remote seed-decoupled build and
   `madaros_full_gate` succeeded. The promoted workspace local self-build still
   segfaults and is tracked separately as a workspace parity blocker.
@@ -72,6 +72,12 @@ env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
   bash scripts/ci/madaros_open_blockers_probe.sh
 ```
 
+The next actionable integration command for Codex or the release shepherd is:
+
+```bash
+scripts/dev/madaros_readiness_status.sh --strict
+```
+
 The required BSS closure evidence is:
 
 - `global_read_exit4` exits `4` in `normal`, `native_v2`, and `build`.
@@ -112,6 +118,8 @@ Madaros is production-ready only when all of these are true:
 | Open blocker probe | `scripts/ci/madaros_open_blockers_probe.sh` keeps known-open direct-call, BSS, and local workspace self-build parity witnesses executable without promoting them to production manifests | #363/#367/#369 plus post-merge `main` CI |
 | Governance control surfaces | Worktree audit treats agent contracts and governance scripts as critical surfaces | #365 plus post-merge `main` CI |
 | Production readiness plan | Current-main readiness plan is committed and merged | #366 plus post-merge local verification |
+| Worktree disposition queue | Current worktree/branch/PR disposition queue is committed and merged | #372 plus post-merge `main` CI |
+| Readiness status command | `scripts/dev/madaros_readiness_status.sh` prints the current baseline, GitHub state, audit gate, blockers, and next gates | current branch pending merge |
 | Direct-call argument ABI | `call_arg_id_exit42` exits 42 in normal/native_v2/build and is now a regression control, not an open blocker | #367 plus post-merge local verification |
 
 ## Phase 0 — Freeze Source Of Truth
@@ -410,11 +418,12 @@ env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
 For Codex/integration:
 
 ```bash
-cd /tmp/sounio-bss-segfault-investigate
+cd /tmp/sounio-madaros-next
 git status --short --branch
+scripts/dev/madaros_readiness_status.sh --strict
 bash scripts/dev/check_docs_registry.sh
 bash scripts/dev/check_docs_consistency.sh
-SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-bss-segfault-investigate)$' \
+SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-next)$' \
   scripts/dev/worktree_branch_audit.sh --check
 ```
 

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+REPO="${SOUNIO_GITHUB_REPO:-Sounio-lang/sounio}"
+RUN_AUDIT=1
+RUN_OPEN_BLOCKERS=0
+RUN_SOURCE_TO_ELF=0
+REFRESH_GH=0
+STRICT=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/madaros_readiness_status.sh [options]
+
+Print the current Madaros production-readiness control surface: baseline,
+local audit status, GitHub issue/PR/CI state when gh is available, and the
+next gates that close the active blocker.
+
+Options:
+  --refresh-gh          git fetch origin before reading origin/main
+  --no-audit           skip worktree governance audit
+  --run-open-blockers  run scripts/ci/madaros_open_blockers_probe.sh
+  --run-source-to-elf  run scripts/ci/madaros_source_to_elf_gate.sh
+  --strict             exit nonzero if audit or optional gates fail
+  -h, --help           show this help
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --refresh-gh)
+      REFRESH_GH=1
+      ;;
+    --no-audit)
+      RUN_AUDIT=0
+      ;;
+    --run-open-blockers)
+      RUN_OPEN_BLOCKERS=1
+      ;;
+    --run-source-to-elf)
+      RUN_SOURCE_TO_ELF=1
+      ;;
+    --strict)
+      STRICT=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+run_status_command() {
+  local label="$1"
+  shift
+
+  echo "+ $*"
+  if "$@"; then
+    echo "status[$label]=pass"
+    return 0
+  fi
+
+  local rc=$?
+  echo "status[$label]=fail rc=$rc"
+  if [[ "$STRICT" == "1" ]]; then
+    return "$rc"
+  fi
+  return 0
+}
+
+if [[ "$REFRESH_GH" == "1" ]]; then
+  git fetch --prune origin
+fi
+
+current_branch="$(git branch --show-current 2>/dev/null || true)"
+[[ -n "$current_branch" ]] || current_branch="detached"
+current_sha="$(git rev-parse --short=12 HEAD)"
+origin_main_sha="$(git rev-parse --short=12 origin/main 2>/dev/null || echo unknown)"
+full_origin_main_sha="$(git rev-parse origin/main 2>/dev/null || echo unknown)"
+
+section "Baseline"
+echo "repo=$ROOT_DIR"
+echo "branch=$current_branch"
+echo "head=$current_sha"
+echo "origin_main=$origin_main_sha"
+echo "origin_main_full=$full_origin_main_sha"
+
+if [[ -e /workspace/sounio/.git ]]; then
+  primary_head="$(git -C /workspace/sounio rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+  primary_status="$(git -C /workspace/sounio status --short 2>/dev/null | wc -l | tr -d ' ')"
+  primary_relation="$(git -C /workspace/sounio status --short --branch 2>/dev/null | head -n1 || true)"
+  echo "primary_checkout=/workspace/sounio"
+  echo "primary_head=$primary_head"
+  echo "primary_dirty_entries=$primary_status"
+  echo "primary_relation=$primary_relation"
+fi
+
+section "Production Influence Set"
+cat <<'EOF'
+1. clean origin/main
+2. issue #356 blocker records
+3. scripts/ci/madaros_open_blockers_probe.sh
+4. scripts/ci/madaros_source_to_elf_gate.sh
+5. one active compiler owner for the BSS/global blocker
+EOF
+
+section "Active Blockers"
+cat <<'EOF'
+BLK-20260621-codex-source-elf-normal-bss
+  class=compiler-semantics
+  owner=Claude compiler/codegen lane unless ownership transfers explicitly
+  acceptance=global_read_exit4 exits 4; global_store_exit7 exits 7; open-blocker probe converted from known-open to closed expectation; source-to-ELF gate green
+
+BLK-20260621-codex-madaros-build-segfault
+  class=platform-resource
+  owner=integration shepherd / workspace-runtime lane unless compiler owner proves semantic root
+  acceptance=local promoted workspace build agrees with GitHub prebuilt refresh, or remains explicitly non-authoritative for production readiness
+EOF
+
+section "GitHub"
+if have gh; then
+  gh issue view 356 --repo "$REPO" \
+    --json state,title,url,updatedAt \
+    --jq '"issue_356_state=\(.state) updated_at=\(.updatedAt) url=\(.url) title=\(.title)"' \
+    2>/dev/null || echo "issue_356_state=unavailable"
+
+  gh pr list --repo "$REPO" --state open --limit 40 \
+    --json number,title,headRefName,baseRefName,isDraft,mergeable,url \
+    --jq '
+      "open_prs=" + (length|tostring),
+      "known_conflicting_prs=" + ([.[] | select(.mergeable == "CONFLICTING")] | length | tostring),
+      "unknown_mergeability_prs=" + ([.[] | select(.mergeable == "UNKNOWN")] | length | tostring),
+      (.[] | "pr=#\(.number) mergeable=\(.mergeable) draft=\(.isDraft) base=\(.baseRefName) head=\(.headRefName) url=\(.url)")
+    ' 2>/dev/null || echo "open_prs=unavailable"
+
+  gh run list --repo "$REPO" --branch main --limit 10 \
+    --json databaseId,name,status,conclusion,headSha,url \
+    --jq '
+      .[]
+      | select(.name == "CI" or .name == "Madaros Prebuilt Refresh")
+      | "run=\(.databaseId) name=\(.name) status=\(.status) conclusion=\(.conclusion) head=\(.headSha[0:12]) url=\(.url)"
+    ' 2>/dev/null || echo "runs=unavailable"
+else
+  echo "gh=missing"
+fi
+
+if [[ "$RUN_AUDIT" == "1" ]]; then
+  section "Worktree Audit"
+  audit_allow_default="^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|$ROOT_DIR)$"
+  audit_out="${SOUNIO_MADAROS_READINESS_AUDIT_OUT:-$(mktemp /tmp/sounio-madaros-readiness-audit.XXXXXX.tsv)}"
+  run_status_command audit \
+    env SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE:-$audit_allow_default}" \
+      scripts/dev/worktree_branch_audit.sh --check "$audit_out"
+fi
+
+section "Next Gates"
+cat <<'EOF'
+Compiler owner:
+  env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+    scripts/ci/madaros_open_blockers_probe.sh
+
+After BSS/global behavior changes:
+  update scripts/ci/madaros_open_blockers_probe.sh from known-open expectations to closed expectations
+  bash scripts/ci/madaros_source_to_elf_gate.sh
+  PR CI green
+  post-merge main CI green
+
+Integration shepherd:
+  scripts/dev/madaros_readiness_status.sh --strict
+EOF
+
+if [[ "$RUN_OPEN_BLOCKERS" == "1" ]]; then
+  section "Open Blocker Probe"
+  run_status_command open_blockers \
+    env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+      scripts/ci/madaros_open_blockers_probe.sh
+fi
+
+if [[ "$RUN_SOURCE_TO_ELF" == "1" ]]; then
+  section "Source-To-ELF Gate"
+  run_status_command source_to_elf \
+    env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+      bash scripts/ci/madaros_source_to_elf_gate.sh
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/dev/madaros_readiness_status.sh`, a lightweight operational status command for the Madaros production-readiness lane.

It reports:

- current `origin/main` baseline and protected primary-checkout state
- issue #356 blocker surface
- open PR mergeability and recent main CI / Madaros Prebuilt Refresh runs when `gh` is available
- worktree audit status with explicit allow-list for known active lanes
- exact next gates for the compiler owner and integration shepherd

Also refreshes the Madaros readiness plan baseline to post-#372 `main` and points Codex/integration at the new status command.

## Why

The worktree/branch audit is only useful if it becomes an executable resolution loop. This command gives the release shepherd one place to answer "what blocks Madaros production-ready now?" without relying on stale notes or the dirty primary checkout.

## Validation

- `scripts/dev/madaros_readiness_status.sh --help`
- `bash -n scripts/dev/madaros_readiness_status.sh`
- `scripts/dev/madaros_readiness_status.sh --strict`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `git diff --check`

## LLM-offload

Not invoked: this change touches internal compiler-readiness tooling/docs only, not math claims, clinical-pathway code, or external-facing artifacts.
