### PR TITLE
tools(madaros): add compiler lane readiness probe

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -78,6 +78,12 @@ The next actionable integration command for Codex or the release shepherd is:
 scripts/dev/madaros_readiness_status.sh --strict
 ```
 
+To include the active Claude compiler lane's read-only check-clean threshold:
+
+```bash
+scripts/dev/madaros_readiness_status.sh --check-compiler-lane
+```
+
 The required BSS closure evidence is:
 
 - `global_read_exit4` exits `4` in `normal`, `native_v2`, and `build`.
@@ -119,7 +125,8 @@ Madaros is production-ready only when all of these are true:
 | Governance control surfaces | Worktree audit treats agent contracts and governance scripts as critical surfaces | #365 plus post-merge `main` CI |
 | Production readiness plan | Current-main readiness plan is committed and merged | #366 plus post-merge local verification |
 | Worktree disposition queue | Current worktree/branch/PR disposition queue is committed and merged | #372 plus post-merge `main` CI |
-| Readiness status command | `scripts/dev/madaros_readiness_status.sh` prints the current baseline, GitHub state, audit gate, blockers, and next gates | current branch pending merge |
+| Readiness status command | `scripts/dev/madaros_readiness_status.sh` prints the current baseline, GitHub state, audit gate, blockers, and next gates | #373 plus post-merge `main` CI |
+| Compiler-lane status command | `scripts/dev/madaros_readiness_status.sh --check-compiler-lane` inspects the active Claude lane and runs read-only check-clean probes with summarized logs | current branch pending merge |
 | Direct-call argument ABI | `call_arg_id_exit42` exits 42 in normal/native_v2/build and is now a regression control, not an open blocker | #367 plus post-merge local verification |
 
 ## Phase 0 — Freeze Source Of Truth
@@ -418,12 +425,13 @@ env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
 For Codex/integration:
 
 ```bash
-cd /tmp/sounio-madaros-next
+cd <current-readiness-worktree>
 git status --short --branch
 scripts/dev/madaros_readiness_status.sh --strict
+scripts/dev/madaros_readiness_status.sh --check-compiler-lane
 bash scripts/dev/check_docs_registry.sh
 bash scripts/dev/check_docs_consistency.sh
-SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-next)$' \
+SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|<current-readiness-worktree>)$' \
   scripts/dev/worktree_branch_audit.sh --check
 ```
 

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -8,6 +8,8 @@ REPO="${SOUNIO_GITHUB_REPO:-Sounio-lang/sounio}"
 RUN_AUDIT=1
 RUN_OPEN_BLOCKERS=0
 RUN_SOURCE_TO_ELF=0
+CHECK_COMPILER_LANE=0
+COMPILER_LANE_PATH="${SOUNIO_MADAROS_COMPILER_LANE:-/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b}"
 REFRESH_GH=0
 STRICT=0
 
@@ -22,6 +24,10 @@ next gates that close the active blocker.
 Options:
   --refresh-gh          git fetch origin before reading origin/main
   --no-audit           skip worktree governance audit
+  --check-compiler-lane
+                       inspect the active compiler lane and run read-only
+                       check-clean probes for the Claude-owned compiler files
+  --compiler-lane DIR  override active compiler lane path
   --run-open-blockers  run scripts/ci/madaros_open_blockers_probe.sh
   --run-source-to-elf  run scripts/ci/madaros_source_to_elf_gate.sh
   --strict             exit nonzero if audit or optional gates fail
@@ -36,6 +42,18 @@ while (($#)); do
       ;;
     --no-audit)
       RUN_AUDIT=0
+      ;;
+    --check-compiler-lane)
+      CHECK_COMPILER_LANE=1
+      ;;
+    --compiler-lane)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --compiler-lane requires a directory" >&2
+        usage >&2
+        exit 2
+      fi
+      COMPILER_LANE_PATH="$1"
       ;;
     --run-open-blockers)
       RUN_OPEN_BLOCKERS=1
@@ -81,6 +99,105 @@ run_status_command() {
   echo "status[$label]=fail rc=$rc"
   if [[ "$STRICT" == "1" ]]; then
     return "$rc"
+  fi
+  return 0
+}
+
+summarize_check_log() {
+  local log_path="$1"
+
+  if [[ ! -s "$log_path" ]]; then
+    echo "  diagnostics=none"
+    return 0
+  fi
+
+  if have rg; then
+    local total_errors
+    total_errors="$(rg -c '^error\[' "$log_path" 2>/dev/null || true)"
+    [[ -n "$total_errors" ]] || total_errors=0
+    echo "  error_lines=$total_errors"
+    rg -o 'error\[E[0-9]+' "$log_path" 2>/dev/null \
+      | sed 's/error\[//' \
+      | sort | uniq -c | awk '{ print "  error[" $2 "]=" $1 }' || true
+    echo "  tail:"
+    tail -n 20 "$log_path" | sed 's/^/    /'
+    return 0
+  fi
+
+  echo "  tail:"
+  tail -n 20 "$log_path" | sed 's/^/    /'
+}
+
+run_compiler_lane_check() {
+  local lane_path="$1"
+  local lane_failed=0
+
+  echo "compiler_lane=$lane_path"
+  if [[ ! -d "$lane_path" ]]; then
+    echo "status[compiler_lane]=missing"
+    if [[ "$STRICT" == "1" ]]; then
+      return 1
+    fi
+    return 0
+  fi
+
+  local lane_head lane_branch dirty_files out_dir
+  lane_head="$(git -C "$lane_path" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+  lane_branch="$(git -C "$lane_path" branch --show-current 2>/dev/null || true)"
+  [[ -n "$lane_branch" ]] || lane_branch="detached"
+  out_dir="${SOUNIO_MADAROS_COMPILER_LANE_LOG_DIR:-$(mktemp -d /tmp/sounio-madaros-compiler-lane.XXXXXX)}"
+
+  echo "compiler_lane_branch=$lane_branch"
+  echo "compiler_lane_head=$lane_head"
+  echo "compiler_lane_logs=$out_dir"
+  echo "compiler_lane_dirty_files:"
+  dirty_files="$(git -C "$lane_path" status --short -- \
+    self-hosted/compiler/main.sio \
+    self-hosted/native/codegen.sio \
+    self-hosted/native/codegen_x86_linux.sio \
+    self-hosted/native/lower_ir.sio \
+    self-hosted/native/suite.sio \
+    2>/dev/null || true)"
+  if [[ -n "$dirty_files" ]]; then
+    printf '%s\n' "$dirty_files" | sed 's/^/  /'
+  else
+    echo "  none"
+  fi
+
+  local check_files=(
+    self-hosted/native/lower_ir.sio
+    self-hosted/native/codegen.sio
+    self-hosted/native/codegen_x86_linux.sio
+  )
+
+  local file safe_file log_path rc
+  for file in "${check_files[@]}"; do
+    safe_file="${file//\//__}"
+    log_path="$out_dir/${safe_file}.check.log"
+    echo "+ compiler_lane_check $file"
+    set +e
+    env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+      "$lane_path/bin/souc" check "$file" >"$log_path" 2>&1
+    rc=$?
+    set -e
+
+    if [[ "$rc" -eq 0 ]]; then
+      echo "status[compiler_lane:$file]=pass"
+    else
+      echo "status[compiler_lane:$file]=fail rc=$rc"
+      summarize_check_log "$log_path"
+      lane_failed=1
+    fi
+  done
+
+  if [[ "$lane_failed" == "0" ]]; then
+    echo "status[compiler_lane]=pass"
+    return 0
+  fi
+
+  echo "status[compiler_lane]=fail"
+  if [[ "$STRICT" == "1" ]]; then
+    return 1
   fi
   return 0
 }
@@ -168,6 +285,11 @@ if [[ "$RUN_AUDIT" == "1" ]]; then
   run_status_command audit \
     env SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE:-$audit_allow_default}" \
       scripts/dev/worktree_branch_audit.sh --check "$audit_out"
+fi
+
+if [[ "$CHECK_COMPILER_LANE" == "1" ]]; then
+  section "Compiler Lane"
+  run_compiler_lane_check "$COMPILER_LANE_PATH"
 fi
 
 section "Next Gates"


### PR DESCRIPTION
## Summary

Extends `scripts/dev/madaros_readiness_status.sh` with an optional read-only compiler-lane probe:

```bash
scripts/dev/madaros_readiness_status.sh --check-compiler-lane
```

The probe inspects the active Claude compiler lane, reports its branch/head/dirty compiler files, and runs the three documented check-clean probes:

- `self-hosted/native/lower_ir.sio`
- `self-hosted/native/codegen.sio`
- `self-hosted/native/codegen_x86_linux.sio`

It captures full logs under `/tmp` and prints summarized error counts plus a short tail, avoiding the huge raw diagnostic flood from `bin/souc check`.

## Why

The readiness plan says the active Claude compiler lane must become check-clean before source-to-ELF results from that lane are treated as semantic evidence. This makes that coordination point executable while preserving file ownership: Codex still does not edit compiler/codegen files.

## Current observed lane result

Against `/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b`, non-strict mode reports:

- `lower_ir.sio`: `rc=1`, `error_lines=265`, including `error[E137]=262`
- `codegen.sio`: `rc=1`, `error_lines=2268`, including `error[E137]=2238`
- `codegen_x86_linux.sio`: `rc=1`, `error_lines=2426`, including `error[E137]=2403`

Strict mode correctly exits nonzero while the lane is not check-clean.

## Validation

- `bash -n scripts/dev/madaros_readiness_status.sh`
- `scripts/dev/madaros_readiness_status.sh --strict`
- `scripts/dev/madaros_readiness_status.sh --no-audit --check-compiler-lane`
- `scripts/dev/madaros_readiness_status.sh --no-audit --check-compiler-lane --strict` returns `rc=1` while the active lane is not check-clean
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `git diff --check`

## LLM-offload

Not invoked: this is internal readiness tooling/docs and read-only compiler-lane status, not math claims, clinical-pathway code, or external-facing artifacts.
