### PR TITLE
tools(madaros): surface lowering diagnostics in readiness status

### DIFF
--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -298,6 +298,10 @@ Compiler owner:
   env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
     scripts/ci/madaros_open_blockers_probe.sh
 
+To localize the current BSS/global phase before editing compiler files:
+  env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+    scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering
+
 After BSS/global behavior changes:
   update scripts/ci/madaros_open_blockers_probe.sh from known-open expectations to closed expectations
   bash scripts/ci/madaros_source_to_elf_gate.sh


### PR DESCRIPTION
## Summary

- Adds the new `madaros_open_blockers_probe.sh --diagnose-lowering` command to the readiness status `Next Gates` section.
- Keeps behavior unchanged; this only points compiler owners at the merged diagnostic before editing BSS/global lowering.

## Validation

- `bash -n scripts/dev/madaros_readiness_status.sh`
- `scripts/dev/madaros_readiness_status.sh --no-audit | tail -n 30`
- `git diff --check`

## Notes

No compiler files changed. This just closes the loop between #376's new diagnostic and the command center output.