### PR TITLE
docs(madaros): correct production readiness status

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -44,13 +44,18 @@ is preserved as `bin/souc-lean-single-x86_64`.
 - Madaros is the **Stage1 modular compiler** (`bin/madaros`,
   `scripts/ci/build_modular_madaros.sh`, `scripts/ci/madaros_full_gate.sh`).
   It is distinct from `souc` (the lean_single monolith), which still ships.
-- As of `origin/main@b1f6bb1b7`, production readiness is governed by
+- As of `origin/main@0d714587f`, production readiness is governed by
   `docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md` and issue #356.
   The known-open blocker probe still reproduces:
   - `BLK-20260621-codex-source-elf-normal-bss`: minimal global read/write
     source-to-ELF witnesses compile-segfault with `rc=139`.
   - `BLK-20260621-codex-madaros-build-segfault`: promoted-workspace local
     self-build still exits `build_rc_139`.
+- `scripts/dev/madaros_readiness_status.sh --check-compiler-lane` is the
+  current coordination command for checking the active Claude compiler lane
+  without taking write ownership. Its next-gate output includes the lowering
+  diagnostic command for the current BSS/global blocker:
+  `scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering`.
 
 Do not say "Madaros is production-ready" until those blocker records are closed
 or explicitly narrowed with new acceptance gates.
@@ -135,7 +140,10 @@ make madaros-full-gate
 
 ## One-line coordination phrase
 
-> Madaros is green on `origin/main` and the green base begins at `17d1157be`.
-> Please sync/rebase before debugging checker issues against it. The valid proof
-> gate is `make madaros-full-gate`; stale raw `artifacts/self-hosted/madaros`
-> binaries are **not** evidence.
+> Madaros is the default `bin/souc` compiler on current `origin/main`, but it is
+> **not production-ready yet**: issue #356 still tracks the source-to-ELF
+> BSS/global compile-segfault and promoted-workspace self-build parity blockers.
+> Please sync to current `origin/main`, avoid stale raw ELFs as evidence, and use
+> `scripts/dev/madaros_readiness_status.sh --check-compiler-lane` plus
+> `scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering` before
+> changing compiler-owned files.

--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -24,10 +24,10 @@ The plan coordinates:
 
 Current baseline:
 
-- `origin/main`: `b1f6bb1b70a73fd545d23f0326d91e6f960da89d`
-  (`tools(madaros): add compiler lane readiness probe`, #374).
-- `main` CI after #374: success
-  (<https://github.com/Sounio-lang/sounio/actions/runs/27907470086>).
+- `origin/main`: `0d714587f46af0529b9f85010d62583550bef66d`
+  (`tools(madaros): surface lowering diagnostics in readiness status`, #377).
+- `main` CI after #377: success
+  (<https://github.com/Sounio-lang/sounio/actions/runs/27909711839>).
 - `Madaros Prebuilt Refresh` on `1d0dc6baa`: remote seed-decoupled build and
   `madaros_full_gate` succeeded. The promoted workspace local self-build still
   segfaults and is tracked separately as a workspace parity blocker.
@@ -127,6 +127,7 @@ Madaros is production-ready only when all of these are true:
 | Worktree disposition queue | Current worktree/branch/PR disposition queue is committed and merged | #372 plus post-merge `main` CI |
 | Readiness status command | `scripts/dev/madaros_readiness_status.sh` prints the current baseline, GitHub state, audit gate, blockers, and next gates | #373 plus post-merge `main` CI |
 | Compiler-lane status command | `scripts/dev/madaros_readiness_status.sh --check-compiler-lane` inspects the active Claude lane and runs read-only check-clean probes with summarized logs | #374 plus post-merge `main` CI |
+| Lowering-diagnostic status pointer | `scripts/dev/madaros_readiness_status.sh` prints the `--diagnose-lowering` command needed before editing the BSS/global compiler path | #377 plus post-merge `main` CI |
 | Direct-call argument ABI | `call_arg_id_exit42` exits 42 in normal/native_v2/build and is now a regression control, not an open blocker | #367 plus post-merge local verification |
 
 ## Phase 0 — Freeze Source Of Truth


### PR DESCRIPTION
## Summary
- update Madaros status docs to current origin/main after #377
- remove the stale "Madaros is green on origin/main" coordination phrase
- point agents at #356, readiness status, and lowering diagnostics before compiler edits

## Validation
- git diff --check
- bash scripts/dev/check_docs_registry.sh

## Notes
- No compiler files changed.
- This preserves Claude ownership of the active compiler/codegen lane while making the resolution plan explicit.