### PR TITLE
tools(madaros): stabilize pending main CI parsing

### DIFF
--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -427,12 +427,11 @@ if have gh; then
       --json databaseId,name,status,conclusion,headSha,url \
       --jq '
         [.[] | select(.name == "CI")][0]
-        | if . == null then empty else [.status, (.conclusion // ""), .headSha, .url] | @tsv end
+        | if . == null then empty else [.status, (if ((.conclusion // "") == "") then "none" else .conclusion end), .headSha, .url] | @tsv end
       ' 2>/dev/null || true
   )"
   if [[ -n "$main_ci_fields" ]]; then
     IFS=$'\t' read -r MAIN_CI_STATUS MAIN_CI_CONCLUSION MAIN_CI_HEAD MAIN_CI_URL <<<"$main_ci_fields"
-    [[ -n "$MAIN_CI_CONCLUSION" ]] || MAIN_CI_CONCLUSION="none"
   fi
 
   gh run list --repo "$REPO" --branch main --limit 10 \


### PR DESCRIPTION
## Summary
- normalize empty pending GitHub Actions conclusions to `none` before emitting TSV
- prevents `main_ci_conclusion`, `main_ci_head`, and `main_ci_url` from shifting while the latest main CI is still in progress

## Validation
- `bash -n scripts/dev/madaros_readiness_status.sh`
- `git diff --check`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --production-ready` returns rc=1 and reports pending main CI as:
  - `main_ci_status=in_progress`
  - `main_ci_conclusion=none`
  - `main_ci_head=252e46a1be4a2069e6a802ba68f33149a4bf96d9`
  - `main_ci_url=https://github.com/Sounio-lang/sounio/actions/runs/27914100041`