### PR TITLE
tools(madaros): add PR resolution queue

### DIFF
--- a/scripts/dev/madaros_pr_resolution_queue.sh
+++ b/scripts/dev/madaros_pr_resolution_queue.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+REPO="${SOUNIO_GITHUB_REPO:-Sounio-lang/sounio}"
+LIMIT="${SOUNIO_MADAROS_PR_QUEUE_LIMIT:-50}"
+OUT=""
+CHECK_MODE=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/madaros_pr_resolution_queue.sh [--check] [OUT.tsv]
+
+Writes a TSV queue for open PR disposition during Madaros production-readiness
+work. The queue is advisory by default; --check fails while any PR overlaps
+the active Claude compiler lane.
+
+Options:
+  --check        fail if a PR overlaps Claude-owned compiler files
+  -h, --help     show this help
+
+Environment:
+  SOUNIO_GITHUB_REPO                  default: Sounio-lang/sounio
+  SOUNIO_MADAROS_PR_QUEUE_LIMIT       default: 50
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --check)
+      CHECK_MODE=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "$OUT" ]]; then
+        echo "error: multiple output paths provided" >&2
+        usage >&2
+        exit 2
+      fi
+      OUT="$1"
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$OUT" ]]; then
+  OUT="$(mktemp /tmp/sounio-madaros-pr-resolution.XXXXXX.tsv)"
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh is required for PR resolution queue" >&2
+  exit 2
+fi
+
+owned_file_re='^(self-hosted/compiler/main\.sio|self-hosted/native/codegen\.sio|self-hosted/native/codegen_x86_linux\.sio|self-hosted/native/lower_ir\.sio|self-hosted/native/suite\.sio)$'
+compiler_surface_re='^(self-hosted/compiler/|self-hosted/native/|bin/(souc|madaros)(-|$)|scripts/(ci|dev|lib|ops)/)'
+docs_governance_re='^(docs/governance/|docs/audit/|AGENTS\.md|CLAUDE\.md|CLAUDE_HANDOFF\.md|ONBOARDING\.md|\.claude/)'
+
+tmp_dir="$(mktemp -d /tmp/sounio-madaros-pr-resolution.XXXXXX)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+printf 'pr\ttitle\tbase\thead\tdraft\tmergeable\tcategory\toverlap_files\taction\turl\n' >"$OUT"
+
+pr_list="$(
+  gh pr list --repo "$REPO" --state open --limit "$LIMIT" \
+    --json number --jq '.[].number' 2>/dev/null || true
+)"
+
+if [[ -n "$pr_list" ]]; then
+  while IFS= read -r pr; do
+    [[ -n "$pr" ]] || continue
+
+    meta_path="$tmp_dir/pr-$pr.json"
+    if ! gh pr view "$pr" --repo "$REPO" \
+      --json number,title,baseRefName,headRefName,isDraft,mergeable,url,files \
+      >"$meta_path" 2>/dev/null; then
+      printf '#%s\tunavailable\tunknown\tunknown\tunknown\tunknown\tmetadata_unavailable\t\tinspect gh pr view failure\t\n' "$pr" >>"$OUT"
+      continue
+    fi
+
+    python3 - "$meta_path" "$owned_file_re" "$compiler_surface_re" "$docs_governance_re" >>"$OUT" <<'PY'
+import json
+import re
+import sys
+
+path, owned_re, compiler_re, docs_re = sys.argv[1:5]
+owned = re.compile(owned_re)
+compiler = re.compile(compiler_re)
+docs = re.compile(docs_re)
+
+with open(path, "r", encoding="utf-8") as fh:
+    pr = json.load(fh)
+
+files = [item.get("path", "") for item in pr.get("files", [])]
+owned_hits = [name for name in files if owned.search(name)]
+compiler_hits = [name for name in files if compiler.search(name)]
+docs_hits = [name for name in files if docs.search(name)]
+
+base = pr.get("baseRefName") or "unknown"
+mergeable = pr.get("mergeable") or "UNKNOWN"
+is_draft = pr.get("isDraft")
+
+if owned_hits:
+    category = "compiler_owner_overlap"
+    overlap = ",".join(owned_hits)
+    action = "resolve ownership or close/rebuild before Madaros production-ready"
+elif base != "main":
+    category = "non_main_base"
+    overlap = ",".join(compiler_hits[:8])
+    action = "exclude from main production-readiness queue unless explicitly promoted"
+elif compiler_hits:
+    category = "compiler_adjacent_review"
+    overlap = ",".join(compiler_hits[:8])
+    action = "require compiler-owner review and focused gates before merge"
+elif mergeable == "CONFLICTING":
+    category = "stale_conflicting"
+    overlap = ""
+    action = "rebase/reconstruct from current origin/main or close stale branch"
+elif is_draft:
+    category = "draft_not_merge_candidate"
+    overlap = ""
+    action = "keep out of production-readiness evidence until marked ready"
+elif docs_hits:
+    category = "docs_governance_conflict"
+    overlap = ",".join(docs_hits[:8])
+    action = "refresh docs registry/governance metadata before merge"
+else:
+    category = "ordinary_open_pr"
+    overlap = ""
+    action = "normal PR review; no current Madaros ownership blocker detected"
+
+fields = [
+    f"#{pr.get('number')}",
+    pr.get("title") or "",
+    base,
+    pr.get("headRefName") or "",
+    str(bool(is_draft)).lower(),
+    mergeable,
+    category,
+    overlap,
+    action,
+    pr.get("url") or "",
+]
+
+def cell(value: str) -> str:
+    return str(value).replace("\t", " ").replace("\n", " ")
+
+print("\t".join(cell(field) for field in fields))
+PY
+  done <<<"$pr_list"
+fi
+
+echo "pr_resolution_tsv=$OUT"
+awk -F '\t' '
+  NR > 1 {
+    total++
+    category[$7]++
+  }
+  END {
+    printf "summary total=%d", total
+    for (name in category) {
+      printf " %s=%d", name, category[name]
+    }
+    printf "\n"
+  }
+' "$OUT"
+
+echo "resolution_queue:"
+awk -F '\t' '
+  NR > 1 {
+    printf "- %s category=%s mergeable=%s action=%s url=%s\n", $1, $7, $6, $9, $10
+    if ($8 != "") {
+      printf "  overlap=%s\n", $8
+    }
+  }
+' "$OUT"
+
+if [[ "$CHECK_MODE" == "1" ]]; then
+  if awk -F '\t' 'NR > 1 && $7 == "compiler_owner_overlap" { found = 1 } END { exit found ? 0 : 1 }' "$OUT"; then
+    echo "madaros PR resolution queue failed: compiler ownership overlap remains" >&2
+    exit 1
+  fi
+  echo "madaros PR resolution queue passed"
+fi

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -10,6 +10,7 @@ RUN_OPEN_BLOCKERS=0
 RUN_SOURCE_TO_ELF=0
 CHECK_COMPILER_LANE=0
 CHECK_COMPILER_PR_OVERLAP=0
+CHECK_PR_RESOLUTION_QUEUE=0
 IN_PRODUCTION_READY_CHECK=0
 COMPILER_LANE_PATH="${SOUNIO_MADAROS_COMPILER_LANE:-/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b}"
 REFRESH_GH=0
@@ -17,6 +18,7 @@ STRICT=0
 PRODUCTION_READY=0
 PRODUCTION_READY_FAILED=0
 COMPILER_PR_OVERLAP_FAILED=0
+PR_RESOLUTION_QUEUE_FAILED=0
 OPEN_BLOCKERS_FAILED=0
 OPEN_BLOCKERS_OUT_DIR=""
 OPEN_BLOCKERS_REPORT=""
@@ -43,6 +45,9 @@ Options:
   --check-compiler-pr-overlap
                        inspect open PRs for overlap with Claude-owned compiler
                        files and fail under --strict if any overlap exists
+  --check-pr-resolution-queue
+                       print the open PR resolution queue and fail under
+                       --strict if compiler ownership overlap remains
   --compiler-lane DIR  override active compiler lane path
   --run-open-blockers  run scripts/ci/madaros_open_blockers_probe.sh
   --run-source-to-elf  run scripts/ci/madaros_source_to_elf_gate.sh
@@ -67,6 +72,9 @@ while (($#)); do
       ;;
     --check-compiler-pr-overlap)
       CHECK_COMPILER_PR_OVERLAP=1
+      ;;
+    --check-pr-resolution-queue)
+      CHECK_PR_RESOLUTION_QUEUE=1
       ;;
     --compiler-lane)
       shift
@@ -349,6 +357,23 @@ run_open_blockers_probe() {
   return 0
 }
 
+run_pr_resolution_queue_check() {
+  local queue_failed=0
+
+  set +e
+  scripts/dev/madaros_pr_resolution_queue.sh --check
+  queue_failed=$?
+  set -e
+
+  if [[ "$queue_failed" != "0" ]]; then
+    PR_RESOLUTION_QUEUE_FAILED=1
+    if [[ "$STRICT" == "1" && "$IN_PRODUCTION_READY_CHECK" != "1" ]]; then
+      return "$queue_failed"
+    fi
+  fi
+  return 0
+}
+
 if [[ "$REFRESH_GH" == "1" ]]; then
   git fetch --prune origin
 fi
@@ -383,6 +408,7 @@ cat <<'EOF'
 3. scripts/ci/madaros_open_blockers_probe.sh
 4. scripts/ci/madaros_source_to_elf_gate.sh
 5. one active compiler owner for the BSS/global blocker
+6. scripts/dev/madaros_pr_resolution_queue.sh
 EOF
 
 section "Active Blockers"
@@ -464,11 +490,23 @@ if [[ "$CHECK_COMPILER_PR_OVERLAP" == "1" ]]; then
   run_compiler_pr_overlap_check
 fi
 
+if [[ "$CHECK_PR_RESOLUTION_QUEUE" == "1" ]]; then
+  section "PR Resolution Queue"
+  run_pr_resolution_queue_check
+fi
+
 if [[ "$PRODUCTION_READY" == "1" ]]; then
   if [[ "$CHECK_COMPILER_PR_OVERLAP" != "1" ]]; then
     section "Compiler PR Overlap"
     IN_PRODUCTION_READY_CHECK=1
     run_compiler_pr_overlap_check
+    IN_PRODUCTION_READY_CHECK=0
+  fi
+
+  if [[ "$CHECK_PR_RESOLUTION_QUEUE" != "1" ]]; then
+    section "PR Resolution Queue"
+    IN_PRODUCTION_READY_CHECK=1
+    run_pr_resolution_queue_check
     IN_PRODUCTION_READY_CHECK=0
   fi
 
@@ -482,9 +520,9 @@ if [[ "$PRODUCTION_READY" == "1" ]]; then
   echo "main_ci_conclusion=$MAIN_CI_CONCLUSION"
   echo "main_ci_head=$MAIN_CI_HEAD"
   echo "main_ci_url=$MAIN_CI_URL"
-  if [[ "$ISSUE_356_STATE" == "CLOSED" && "$COMPILER_PR_OVERLAP_FAILED" == "0" && "$OPEN_BLOCKERS_FAILED" == "0" && "$MAIN_CI_STATUS" == "completed" && "$MAIN_CI_CONCLUSION" == "success" && "$MAIN_CI_HEAD" == "$full_origin_main_sha" ]]; then
+  if [[ "$ISSUE_356_STATE" == "CLOSED" && "$COMPILER_PR_OVERLAP_FAILED" == "0" && "$PR_RESOLUTION_QUEUE_FAILED" == "0" && "$OPEN_BLOCKERS_FAILED" == "0" && "$MAIN_CI_STATUS" == "completed" && "$MAIN_CI_CONCLUSION" == "success" && "$MAIN_CI_HEAD" == "$full_origin_main_sha" ]]; then
     echo "status[production_ready]=pass"
-    echo "reason=issue_356_closed_no_compiler_pr_overlap_open_blockers_closed_and_current_main_ci_green"
+    echo "reason=issue_356_closed_no_compiler_pr_overlap_pr_queue_clear_open_blockers_closed_and_current_main_ci_green"
   else
     echo "status[production_ready]=fail"
     if [[ "$MAIN_CI_STATUS" != "completed" || "$MAIN_CI_CONCLUSION" != "success" || "$MAIN_CI_HEAD" != "$full_origin_main_sha" ]]; then
@@ -500,6 +538,10 @@ if [[ "$PRODUCTION_READY" == "1" ]]; then
     if [[ "$COMPILER_PR_OVERLAP_FAILED" != "0" ]]; then
       echo "reason=compiler_pr_overlap"
       echo "required=resolve open PR overlap with the active Claude compiler lane or transfer ownership explicitly"
+    fi
+    if [[ "$PR_RESOLUTION_QUEUE_FAILED" != "0" ]]; then
+      echo "reason=pr_resolution_queue_blocked"
+      echo "required=resolve the open PR disposition queue entries that overlap compiler ownership"
     fi
     if [[ "$OPEN_BLOCKERS_FAILED" != "0" ]]; then
       echo "reason=open_blockers_not_closed"
@@ -530,6 +572,7 @@ After BSS/global behavior changes:
 Integration shepherd:
   scripts/dev/madaros_readiness_status.sh --strict
   scripts/dev/madaros_readiness_status.sh --check-compiler-pr-overlap
+  scripts/dev/madaros_readiness_status.sh --check-pr-resolution-queue
   scripts/dev/madaros_readiness_status.sh --production-ready
 EOF
 


### PR DESCRIPTION
## Summary
- add `scripts/dev/madaros_pr_resolution_queue.sh` to classify open PRs into an actionable Madaros production-readiness queue
- flag compiler-owner overlap as a check failure while keeping ordinary/stale/non-main PRs advisory
- wire `scripts/dev/madaros_readiness_status.sh --check-pr-resolution-queue` and include the queue in `--production-ready`

## Current queue result
- total open PRs: 8
- `compiler_owner_overlap`: 1 (#313 touching `self-hosted/compiler/main.sio`)
- `stale_conflicting`: 4 (#329, #308, #297, #287)
- `compiler_adjacent_review`: 2 (#241, #232)
- `non_main_base`: 1 (#226)

## Validation
- `bash -n scripts/dev/madaros_pr_resolution_queue.sh scripts/dev/madaros_readiness_status.sh`
- `git diff --check`
- `scripts/dev/madaros_pr_resolution_queue.sh --check /tmp/sounio-madaros-pr-resolution-test.tsv` returns rc=1 because #313 still overlaps compiler ownership
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --strict`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --production-ready` returns rc=1 with `pr_resolution_queue_blocked` plus the existing #356/open-blocker reasons

## Notes
No compiler files changed. This makes the open-PR cleanup plan executable instead of relying on manual GitHub inspection.