### PR TITLE
ci(madaros): gate production blocker records

### DIFF
--- a/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
+++ b/docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md
@@ -200,13 +200,21 @@ Severity: B1
 Class: compiler-semantics
 Owner: Claude compiler/codegen lane unless ownership transfers explicitly
 Lane: Madaros source-to-ELF global/BSS lowering
+Worktree: /workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b
+Branch: worktree-agent-adc1cd8b9d52ba53b
 Canonical-Issue: https://github.com/Sounio-lang/sounio/issues/356
 Files-Owned: self-hosted/compiler/main.sio, self-hosted/native/codegen.sio, self-hosted/native/codegen_x86_linux.sio, self-hosted/native/lower_ir.sio, self-hosted/native/suite.sio
+Files-Read-Only: scripts/ci/madaros_open_blockers_probe.sh, scripts/ci/madaros_source_to_elf_gate.sh, scripts/dev/madaros_readiness_status.sh
+Do-Not-Touch: self-hosted/compiler/main.sio, self-hosted/native/codegen.sio, self-hosted/native/codegen_x86_linux.sio, self-hosted/native/lower_ir.sio, self-hosted/native/suite.sio unless ownership transfers explicitly
+Repro: env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering
 Observed: global_read_exit4 normal/native_v2/build => compile_rc_139; global_store_exit7 build => compile_rc_139
 Expected: global_read_exit4 exits 4 and global_store_exit7 exits 7 from emitted ELF, without raw Madaros compile segfault
 Acceptance-Gate: scripts/ci/madaros_open_blockers_probe.sh is updated from known-open to closed-BSS expectations and passes; scripts/ci/madaros_source_to_elf_gate.sh also passes
 Evidence-Level: E3
 Evidence: https://github.com/Sounio-lang/sounio/issues/356#issuecomment-4762337445
+Fallback-Path: none
+Legacy-Kept: yes
+LLM-Offload: not-required
 Next-Action: inspect the standard source-to-ELF/native emission path after successful typecheck and merged-IR capture, especially global/BSS symbol allocation or emission
 ```
 
@@ -219,13 +227,21 @@ Severity: B2
 Class: platform-resource
 Owner: integration shepherd / workspace-runtime lane unless compiler owner proves semantic root
 Lane: promoted workspace local self-build parity
+Worktree: /workspace/sounio
+Branch: main
 Canonical-Issue: https://github.com/Sounio-lang/sounio/issues/356
 Files-Owned: none by Codex
 Files-Read-Only: scripts/ci/build_modular_madaros.sh, scripts/dev/souc-build-lock.sh, self-hosted/compiler/main.sio
+Do-Not-Touch: bin/madaros, bin/souc, self-hosted/compiler/main.sio unless a focused parity lane is opened
+Repro: env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/build_modular_madaros.sh /tmp/sounio-madaros-self-build-check/madaros
 Observed: clean promoted-workspace build exits rc=139 while GitHub Madaros Prebuilt Refresh build+gate succeeds on the same commit
 Expected: local promoted workspace build agrees with remote seed-decoupled build, or docs/gates explicitly mark local workspace self-build as non-authoritative for production readiness
 Acceptance-Gate: local build_modular_madaros.sh passes in a clean workspace worktree, or release/readiness docs classify GitHub prebuilt refresh as authoritative and local workspace self-build as a platform/parity blocker
 Evidence-Level: E4
+Evidence: https://github.com/Sounio-lang/sounio/issues/356#issuecomment-4763092558
+Fallback-Path: GitHub Madaros Prebuilt Refresh remains authoritative while green because local promoted workspace self-build is classified as platform/parity
+Legacy-Kept: yes
+LLM-Offload: not-required
 Next-Action: investigate workspace/runtime parity, not broad compiler bootstrap failure, unless a compiler owner proves a semantic root
 ```
 

--- a/scripts/ci/claude_operational_contract_gate.sh
+++ b/scripts/ci/claude_operational_contract_gate.sh
@@ -50,6 +50,9 @@ CHECKS+=("$check_json")
 check_json="$(run_check parallel_blocker_contract bash scripts/ci/check_parallel_blocker_contract.sh || true)"
 CHECKS+=("$check_json")
 
+check_json="$(run_check madaros_blocker_contract bash scripts/ci/madaros_blocker_contract_gate.sh || true)"
+CHECKS+=("$check_json")
+
 checks_joined=""
 for item in "${CHECKS[@]}"; do
   if [[ -n "$checks_joined" ]]; then

--- a/scripts/ci/madaros_blocker_contract_gate.sh
+++ b/scripts/ci/madaros_blocker_contract_gate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+DOC="${SOUNIO_MADAROS_BLOCKER_DOC:-docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md}"
+
+if [[ ! -f "$DOC" ]]; then
+  echo "error: missing Madaros blocker doc: $DOC" >&2
+  exit 1
+fi
+
+python3 - "$DOC" <<'PY'
+import re
+import sys
+
+doc_path = sys.argv[1]
+with open(doc_path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+
+required_ids = [
+    "BLK-20260621-codex-source-elf-normal-bss",
+    "BLK-20260621-codex-madaros-build-segfault",
+]
+
+required_fields = [
+    "Blocker-ID",
+    "Status",
+    "Severity",
+    "Class",
+    "Owner",
+    "Lane",
+    "Worktree",
+    "Branch",
+    "Files-Owned",
+    "Do-Not-Touch",
+    "Repro",
+    "Observed",
+    "Expected",
+    "Acceptance-Gate",
+    "Evidence-Level",
+    "Evidence",
+    "Fallback-Path",
+    "Legacy-Kept",
+    "LLM-Offload",
+    "Next-Action",
+]
+
+optional_but_expected = ["Files-Read-Only"]
+allowed_status = {
+    "proposed",
+    "reproduced",
+    "classified",
+    "owned",
+    "fixing",
+    "review-ready",
+    "merge-ready",
+    "closed",
+    "waived",
+}
+allowed_severity = {"B0", "B1", "B2", "B3", "B4"}
+allowed_evidence = {"E0", "E1", "E2", "E3", "E4"}
+
+blocks = {}
+for match in re.finditer(r"```text\n(.*?)\n```", text, re.S):
+    block = match.group(1)
+    id_match = re.search(r"^Blocker-ID:\s*(\S+)\s*$", block, re.M)
+    if id_match:
+        blocks[id_match.group(1)] = block
+
+errors = []
+for blocker_id in required_ids:
+    block = blocks.get(blocker_id)
+    if block is None:
+        errors.append(f"{blocker_id}: missing fenced blocker record")
+        continue
+
+    values = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        values[key.strip()] = value.strip()
+
+    for field in required_fields:
+        if not values.get(field):
+            errors.append(f"{blocker_id}: missing or empty field {field}")
+
+    for field in optional_but_expected:
+        if field not in values:
+            errors.append(f"{blocker_id}: missing expected field {field}")
+
+    if values.get("Status") and values["Status"] not in allowed_status:
+        errors.append(f"{blocker_id}: invalid Status {values['Status']}")
+    if values.get("Severity") and values["Severity"] not in allowed_severity:
+        errors.append(f"{blocker_id}: invalid Severity {values['Severity']}")
+    if values.get("Evidence-Level") and values["Evidence-Level"] not in allowed_evidence:
+        errors.append(f"{blocker_id}: invalid Evidence-Level {values['Evidence-Level']}")
+    if values.get("Repro", "").lower() in {"none", "n/a"}:
+        errors.append(f"{blocker_id}: Repro must be an executable command or explicit missing resource")
+    if "https://github.com/Sounio-lang/sounio/issues/356" not in values.get("Evidence", ""):
+        errors.append(f"{blocker_id}: Evidence must cite canonical issue #356 evidence")
+
+if errors:
+    print("MADAROS_BLOCKER_CONTRACT_FAIL", file=sys.stderr)
+    for error in errors:
+        print(f"error: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"MADAROS_BLOCKER_CONTRACT_PASS doc={doc_path} blockers={len(required_ids)}")
+PY

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -570,6 +570,7 @@ After BSS/global behavior changes:
   post-merge main CI green
 
 Integration shepherd:
+  scripts/ci/madaros_blocker_contract_gate.sh
   scripts/dev/madaros_readiness_status.sh --strict
   scripts/dev/madaros_readiness_status.sh --check-compiler-pr-overlap
   scripts/dev/madaros_readiness_status.sh --check-pr-resolution-queue


### PR DESCRIPTION
## Summary
- complete the two active Madaros blocker records in `docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md` with required parallel-blocker-contract fields
- add `scripts/ci/madaros_blocker_contract_gate.sh` to validate both blocker records stay complete
- include the new gate in `scripts/ci/claude_operational_contract_gate.sh` and surface it in the readiness next-gates list

## Validation
- `bash -n scripts/ci/madaros_blocker_contract_gate.sh scripts/ci/claude_operational_contract_gate.sh scripts/dev/madaros_readiness_status.sh`
- `git diff --check`
- `scripts/ci/madaros_blocker_contract_gate.sh`
- `SOUNIO_CLAUDE_CONTRACT_OUT=/tmp/sounio-claude-operational-contract.json bash scripts/ci/claude_operational_contract_gate.sh`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --strict`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --production-ready` returns rc=1 with the existing expected production blockers

## Notes
No compiler files changed. This makes the remaining #356 blockers contract-checked rather than only described in issue comments.