### PR TITLE
tools(madaros): show draft state in PR queue

### DIFF
--- a/scripts/dev/madaros_pr_resolution_queue.sh
+++ b/scripts/dev/madaros_pr_resolution_queue.sh
@@ -178,7 +178,7 @@ awk -F '\t' '
 echo "resolution_queue:"
 awk -F '\t' '
   NR > 1 {
-    printf "- %s category=%s mergeable=%s action=%s url=%s\n", $1, $7, $6, $9, $10
+    printf "- %s category=%s draft=%s mergeable=%s action=%s url=%s\n", $1, $7, $5, $6, $9, $10
     if ($8 != "") {
       printf "  overlap=%s\n", $8
     }


### PR DESCRIPTION
## Summary
- include `draft=true|false` in the human-readable `resolution_queue` output from `scripts/dev/madaros_pr_resolution_queue.sh`
- keeps the TSV unchanged, but makes governance containment visible without opening the TSV

## Validation
- `bash -n scripts/dev/madaros_pr_resolution_queue.sh`
- `git diff --check`
- `scripts/dev/madaros_pr_resolution_queue.sh --check /tmp/sounio-madaros-pr-resolution-draft-display.tsv` returns rc=1 as expected while #313 remains a compiler-owner overlap, and now prints `#313 category=compiler_owner_overlap draft=true ...`

## Notes
No compiler files changed. #313 was converted to draft separately as a reversible containment action because it is still the single current compiler-owner overlap for Madaros production readiness.