### PR TITLE
tools(madaros): summarize contained compiler overlaps

### DIFF
--- a/scripts/dev/madaros_pr_resolution_queue.sh
+++ b/scripts/dev/madaros_pr_resolution_queue.sh
@@ -165,12 +165,21 @@ awk -F '\t' '
   NR > 1 {
     total++
     category[$7]++
+    if ($7 == "compiler_owner_overlap") {
+      if ($5 == "true") {
+        compiler_owner_overlap_draft++
+      } else {
+        compiler_owner_overlap_ready++
+      }
+    }
   }
   END {
     printf "summary total=%d", total
     for (name in category) {
       printf " %s=%d", name, category[name]
     }
+    printf " compiler_owner_overlap_draft=%d compiler_owner_overlap_ready=%d",
+      compiler_owner_overlap_draft, compiler_owner_overlap_ready
     printf "\n"
   }
 ' "$OUT"


### PR DESCRIPTION
## Summary
- split compiler-owner PR overlap summary into draft-contained and ready/non-draft counts
- keep `--check` semantics unchanged: any compiler-owner overlap still fails the production-readiness queue
- makes #313 containment visible as `compiler_owner_overlap_draft=1 compiler_owner_overlap_ready=0`

## Validation
- `bash -n scripts/dev/madaros_pr_resolution_queue.sh`
- `git diff --check`
- `scripts/dev/madaros_pr_resolution_queue.sh --check /tmp/sounio-pr-queue-overlap-containment.tsv` returns rc=1 as expected, with summary `compiler_owner_overlap=1 compiler_owner_overlap_draft=1 compiler_owner_overlap_ready=0`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --production-ready` returns rc=1 as expected and includes the new summary counters

## Notes
No compiler files changed. Production-ready remains blocked until #356 and #313 ownership disposition are actually resolved.