### PR TITLE
tools(madaros): guard ready conflicting PRs

### DIFF
--- a/scripts/dev/madaros_pr_resolution_queue.sh
+++ b/scripts/dev/madaros_pr_resolution_queue.sh
@@ -165,6 +165,9 @@ awk -F '\t' '
   NR > 1 {
     total++
     category[$7]++
+    if ($3 == "main" && $5 != "true" && $6 == "CONFLICTING") {
+      ready_conflicting_main_pr++
+    }
     if ($7 == "compiler_owner_overlap") {
       if ($5 == "true") {
         compiler_owner_overlap_draft++
@@ -180,6 +183,7 @@ awk -F '\t' '
     }
     printf " compiler_owner_overlap_draft=%d compiler_owner_overlap_ready=%d",
       compiler_owner_overlap_draft, compiler_owner_overlap_ready
+    printf " ready_conflicting_main_pr=%d", ready_conflicting_main_pr
     printf "\n"
   }
 ' "$OUT"
@@ -195,6 +199,10 @@ awk -F '\t' '
 ' "$OUT"
 
 if [[ "$CHECK_MODE" == "1" ]]; then
+  if awk -F '\t' 'NR > 1 && $3 == "main" && $5 != "true" && $6 == "CONFLICTING" { found = 1 } END { exit found ? 0 : 1 }' "$OUT"; then
+    echo "madaros PR resolution queue failed: ready conflicting main PR remains" >&2
+    exit 1
+  fi
   if awk -F '\t' 'NR > 1 && $7 == "compiler_owner_overlap" { found = 1 } END { exit found ? 0 : 1 }' "$OUT"; then
     echo "madaros PR resolution queue failed: compiler ownership overlap remains" >&2
     exit 1


### PR DESCRIPTION
## Summary
- add `ready_conflicting_main_pr` to the Madaros PR resolution queue summary
- make `--check` fail if any PR targeting `main` is both `mergeable=CONFLICTING` and non-draft
- preserves existing behavior: compiler-owner overlap still fails the queue even when draft-contained

## Validation
- `bash -n scripts/dev/madaros_pr_resolution_queue.sh`
- `git diff --check`
- synthetic TSV awk check detects a ready conflicting main PR
- `scripts/dev/madaros_pr_resolution_queue.sh --check /tmp/sounio-pr-queue-ready-conflict-guard.tsv` returns rc=1 due to existing #313 compiler-owner overlap and reports `ready_conflicting_main_pr=0`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN scripts/dev/madaros_readiness_status.sh --no-audit --production-ready` returns rc=1 as expected and includes `ready_conflicting_main_pr=0`

## Notes
No compiler files changed. This makes the draft-sweep containment durable by failing if a conflicting PR against main becomes ready/non-draft again.