### PR TITLE
fix(madaros): Box deref via field-0 read; raw references fail loudly (native_v2)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -5245,6 +5245,11 @@ impl Lowerer {
                         if ret_name.len > 0 {
                             lo = lo.bind_local_struct_type(s.name, ret_name)
                         }
+                    } else {
+                        // `let b = Box::new(...)`: tag the local's struct-type slot with
+                        // "Box" so `*b` lowers to a field-0 read (box deref through the
+                        // handle) rather than a raw IrUnaryOp(OpDeref) pointer load.
+                        lo = lo.bind_local_struct_type(s.name, callee_struct_name)
                     }
                 }
             }
@@ -6765,13 +6770,36 @@ impl Lowerer {
     }
 
     fn lower_unary_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        // `*b` where b is a Box reads field 0 of the heap object (where lower_box_new
+        // stored the value via ir_field_set(ptr, 0, val)), so route Box deref to
+        // IrFieldGet(0) — codegen resolves the handle. IrUnaryOp(OpDeref) stays a raw
+        // pointer load for true references (&T), which are raw addresses, not handles.
+        let is_box_deref = if e.un_op == UnaryOp::OpDeref {
+            let opt_ref = &e.left
+            match *opt_ref {
+                Some(operand) => {
+                    if (*operand).kind == ExprKind::ExprIdent {
+                        ir_name_is_box(self.lookup_local_struct_type((*operand).name))
+                    } else {
+                        false
+                    }
+                }
+                None => false,
+            }
+        } else {
+            false
+        }
         let pair_s = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_s.0
         let src = pair_s.1
         let pair_d = lo1.fresh_reg()
         let lo2 = pair_d.0
         let dst = pair_d.1
-        let lo3 = lo2.emit(ir_unaryop(dst, e.un_op, src))
+        let lo3 = if is_box_deref {
+            lo2.emit(ir_field_get(dst, src, 0, ir_empty_name()))
+        } else {
+            lo2.emit(ir_unaryop(dst, e.un_op, src))
+        }
         (lo3, dst)
     }
 

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6457,6 +6457,34 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                     nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
                 }
             }
+        } else if instr_op == IrOpcode::IrUnaryOp {
+            // Unary ops were never handled in the core_ir instruction loop, so any
+            // *b (deref), &x / &!x (ref), !b (not), or unary neg made
+            // compile_ir_function_v2_core_ir_into return false ->
+            // native_driver_function_codegen_failed. Emit them here.
+            let uop = (*func).instrs[i as usize].un_op
+            if uop == UnaryOp::OpRef || uop == UnaryOp::OpRefMut {
+                // &x / &!x: address of the operand's dedicated stack slot.
+                nc_emit_lea_rax_rbp_disp32(nc, ir_slot_offset((*func).instrs[i as usize].src1))
+            } else if uop == UnaryOp::OpDeref {
+                // Box deref: the operand is a heap-object HANDLE (e.g. from Box::new),
+                // not a raw pointer, so resolve it to the object base and read field 0
+                // — where lower_box_new stores the value via ir_field_set(ptr, 0, val)
+                // — exactly as IrFieldGet does. A raw mov rax,[rax] faults on the handle.
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                native_v2_resolve_handle_to_object_base_rax_into(nc)
+                nc_emit_mov_reg_imm(nc, 3, native_v2_object_header_size() / 8)
+                nc_emit_mov_rax_mem_rax_rbx8(nc)
+            } else {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                if uop == UnaryOp::OpNeg {
+                    nc_emit_neg_rax(nc)                    // rax = -rax
+                } else if uop == UnaryOp::OpNot {
+                    (*nc).code = emit_not_bool_rax((*nc).code)
+                }
+            }
+            nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrAlloc {
             if !nc_core_emit_alloc_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].imm_i64) {
                 return false

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6466,18 +6466,14 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             if uop == UnaryOp::OpRef || uop == UnaryOp::OpRefMut {
                 // &x / &!x: address of the operand's dedicated stack slot.
                 nc_emit_lea_rax_rbp_disp32(nc, ir_slot_offset((*func).instrs[i as usize].src1))
-            } else if uop == UnaryOp::OpDeref {
-                // Box deref: the operand is a heap-object HANDLE (e.g. from Box::new),
-                // not a raw pointer, so resolve it to the object base and read field 0
-                // — where lower_box_new stores the value via ir_field_set(ptr, 0, val)
-                // — exactly as IrFieldGet does. A raw mov rax,[rax] faults on the handle.
-                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-                native_v2_resolve_handle_to_object_base_rax_into(nc)
-                nc_emit_mov_reg_imm(nc, 3, native_v2_object_header_size() / 8)
-                nc_emit_mov_rax_mem_rax_rbx8(nc)
             } else {
                 nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-                if uop == UnaryOp::OpNeg {
+                if uop == UnaryOp::OpDeref {
+                    // Raw pointer deref for true references (&T). Box deref is lowered
+                    // to IrFieldGet(0) instead (the lowerer marks Box locals), because a
+                    // Box is a heap-object HANDLE, not a raw pointer.
+                    nc_emit_load_rax_mem_rax(nc)           // rax = *rax
+                } else if uop == UnaryOp::OpNeg {
                     nc_emit_neg_rax(nc)                    // rax = -rax
                 } else if uop == UnaryOp::OpNot {
                     (*nc).code = emit_not_bool_rax((*nc).code)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6458,29 +6458,27 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 }
             }
         } else if instr_op == IrOpcode::IrUnaryOp {
-            // Unary ops were never handled in the core_ir instruction loop, so any
-            // *b (deref), &x / &!x (ref), !b (not), or unary neg made
-            // compile_ir_function_v2_core_ir_into return false ->
-            // native_driver_function_codegen_failed. Emit them here.
+            // IrUnaryOp had no case in the core_ir loop, so *b / &x / !b / neg all
+            // returned false -> native_driver_function_codegen_failed. Box deref is
+            // now lowered to IrFieldGet(0) (the lowerer marks Box locals), so here we
+            // only see neg / not / and raw references. neg and not are pure value ops;
+            // raw references (&x / &!x / *raw_ptr of a true &T) are NOT yet supported
+            // in native_v2 — emitting lea/load for them produces code that crashes,
+            // so fail LOUDLY (codegen error) rather than ship a silent miscompile.
             let uop = (*func).instrs[i as usize].un_op
-            if uop == UnaryOp::OpRef || uop == UnaryOp::OpRefMut {
-                // &x / &!x: address of the operand's dedicated stack slot.
-                nc_emit_lea_rax_rbp_disp32(nc, ir_slot_offset((*func).instrs[i as usize].src1))
-            } else {
+            if uop == UnaryOp::OpNeg {
                 nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-                if uop == UnaryOp::OpDeref {
-                    // Raw pointer deref for true references (&T). Box deref is lowered
-                    // to IrFieldGet(0) instead (the lowerer marks Box locals), because a
-                    // Box is a heap-object HANDLE, not a raw pointer.
-                    nc_emit_load_rax_mem_rax(nc)           // rax = *rax
-                } else if uop == UnaryOp::OpNeg {
-                    nc_emit_neg_rax(nc)                    // rax = -rax
-                } else if uop == UnaryOp::OpNot {
-                    (*nc).code = emit_not_bool_rax((*nc).code)
-                }
+                nc_emit_neg_rax(nc)
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+                nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
+            } else if uop == UnaryOp::OpNot {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                (*nc).code = emit_not_bool_rax((*nc).code)
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+                nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
+            } else {
+                return false
             }
-            nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
-            nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrAlloc {
             if !nc_core_emit_alloc_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].imm_i64) {
                 return false


### PR DESCRIPTION
## Summary

Makes **`Box::new` + deref (`*b`) work** in the native_v2 build path, and turns the
previously-silent reference-deref crash into an honest compile error.

Root: the core_ir instruction loop (`compile_ir_function_v2_core_ir_into`) had **no
case for `IrUnaryOp`**, so any `*b` (deref), `&x`/`&!x` (ref), `!b` (not), or unary neg
fell through to the final `else` and returned false →
`native_driver_function_codegen_failed`. `Box` deref therefore type-checked but never
codegen'd.

## What changed (2 files, +51/-1)

1. **`IrUnaryOp` codegen case added** (`codegen_x86_linux.sio`). Handles unary **neg**
   and **not** (pure value ops).
2. **Box-vs-reference split done in the lowerer** (`lower.sio`), where the type is known
   — codegen can't tell a heap **handle** (`Box`) from a raw **address** (`&T`):
   - `lower_let_stmt` tags a local bound from `Box::new(...)` with struct-type `"Box"`.
   - `lower_unary_expr_ref` lowers `*b` of such a local to **`IrFieldGet(0)`** — resolve
     the handle, read field 0 (where `lower_box_new` stores the value via
     `ir_field_set(ptr, 0, val)`). The existing `IrFieldGet` codegen already does this.
3. **Raw references fail loudly** (`&x` / `&!x` / `*r` of a true `&T`). These are not yet
   supported in native_v2 (a deeper object-model item: arg-passing + primitive-ref
   deref), and emitting `lea`/`load` for them produces crashing code — so the codegen
   returns false (clean `codegen_failed`) rather than ship a **silent miscompile**.

## Verification (rebuilt artifact, production bare path)

| | Result |
|---|---|
| `let b=Box::new(7); let v=*b; v` | **7** ✅ |
| `Box::new(P{x:42}); let p=*b; p.x` | **42** ✅ |
| `print_int(*b)` (Box::new(99)) | **99** ✅ |
| raw reference `fn get(r:&i64){*r}; get(&x)` | clean `codegen_failed` (rc 1) — **not** a 139 crash |
| no regression: `5+7` / `p.x` / `for 0..10` / enum `match` | 12 / 5 / 45 / 20 ✅ |

Type-check neutral (755 `--check` errors on `main.sio` with and without — pre-existing
prebuilt-vs-bundle noise).

## Not in this PR (separate, flagged for follow-up)

- **Parser**: a bare `*b` at line-start parses as `expr * b` (binary-op continuation
  across the newline; not Box-specific — `let n=5` ⏎ `*n` fails the same). Use
  `let v = *b` / `return *b` meanwhile.
- **Checker**: deref of a declared `Box<T>` **parameter** hits E005 (the declared type's
  inner isn't populated, unlike `Box::new` locals).
- **Full raw-reference support** (`&x` / `*r` of primitives) — a deeper object-model item.
