### PR TITLE
fix(parser): line-start tight `*b`/`&x` parses as deref/ref, not infix mul/bitand

### DIFF
--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -92,6 +92,22 @@ impl Parser {
                 break
             }
 
+            // `*`/`&`/`&!` are both infix (mul/bitand) and prefix (deref/ref).
+            // At the start of a line, a *tight* one (no space before its
+            // operand: `*b`, `&x`) is a prefix expression beginning a NEW
+            // statement -- without this `let b = Box::new(7)\n*b` glues into
+            // `Box::new(7) * b`. A *spaced* one (`* energy_accurate`) is a
+            // multiply/bitand continuation and must keep flowing (mirrors
+            // Swift's whitespace-asymmetry rule: left space + no right space =
+            // prefix). Trailing continuations (`a *\n b`) are unaffected: the
+            // newline sits before the rhs, not before the operator.
+            if p.had_newline_before()
+                && (op_kind == TokenKind::Star || op_kind == TokenKind::Amp || op_kind == TokenKind::AmpBang)
+                && p.pos + 1 < p.token_count
+                && PT_END[p.pos as usize] == PT_START[(p.pos + 1) as usize] {
+                break
+            }
+
             let prec = tk_precedence(op_kind)
 
             // Stop if current operator has lower or equal precedence


### PR DESCRIPTION
## What

A leading `*`/`&`/`&!` that is **tight** to its operand (no space: `*b`, `&x`) at the start of a line now begins a **new statement** instead of gluing onto the previous expression as an infix `mul`/`bitand`.

Before:
```sounio
let b = Box::new(7)
*b
```
parsed as `let b = Box::new(7) * b` → `error[E137]: use of undeclared variable` (self-referential `b`), and the function body collapsed to a single `let` (return type `()`).

After: it parses as two statements — the `let`, then a `*b` deref expression.

## Why this is the narrow, corpus-safe rule

`*`/`&` are **both** infix (`mul`/`bitand`) and prefix (`deref`/`ref`). The codebase genuinely uses *spaced* leading operators as continuations:

- `examples/quantum_ml_pipeline.sio:368` — `let all_ok = vqe_ok\n  * energy_accurate\n  * ...`
- `stdlib/medical/kg_reason.sio:267` — `... \n  * kg.relations[r].embedding[i]`

So an unconditional break would **regress** those. The discriminator is whitespace asymmetry (mirrors Swift's operator rule): the break fires only when

1. there is a newline **before** the operator (left whitespace), **and**
2. the operator is `*`/`&`/`&!`, **and**
3. it is **tight** to its operand — `PT_END[op] == PT_START[op+1]` (no right whitespace).

`* energy_accurate` (spaced) keeps flowing as multiply; `*b` (tight) breaks. Trailing continuations (`a *⏎ b`) are unaffected — the newline sits before the RHS, not the operator. Same-line `a*b` is unaffected (no newline-before).

## Verification

Built off-pod via `madaros-prebuilt-refresh` (`workflow_dispatch`, `ref=fix/madaros-linestart-deref-parse`); checked the uploaded artifact:

- repro `let b = Box::new(7)\n*b` — E137 **gone**, `*b` is a deref statement.
- regression `let all = a\n * b\n * c` — still `30` (multiply chain intact).
- same-line `a*b` — still `42`.

> Note: end-to-end `run`→`7` on the repro also needs the Box-deref **codegen** from #392 (not on this branch); this PR is the **parser** fix and is verified via `check` (E137 disappearance). Independent of the object-model lane.

1 file, `self-hosted/parser/exprs.sio` (+16).
