### PR TITLE
docs(madaros): record post-merge blocker closeout

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -10,11 +10,12 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.madaros-status
 # Madaros Status — coordination note for the fleet
 
 > **TL;DR:** Madaros is the **default compiler**: `bin/souc` routes to Madaros.
-> Do not treat stale worktrees or old raw ELFs as current evidence. Also do not
-> overclaim production readiness: current `origin/main` still tracks open
-> source-to-ELF/global-BSS and promoted-workspace self-build blockers in
-> GitHub issue #356. Sync `main`, use the checked prebuilt or rebuild, run the
-> named gate, and classify the result against the active blocker records.
+> The 2026-06-21 blocker cluster in GitHub issue #356 is closed on
+> `main@4c452498c`: source-to-ELF global/BSS witnesses are controls, #313 is
+> closed, and promoted-workspace self-build parity is green. Do not treat stale
+> worktrees or old raw ELFs as current evidence. Sync `main`, use the checked
+> prebuilt or rebuild, run the named gates, and classify any new failure against
+> current post-merge evidence rather than reopening the closed blocker set.
 
 ## Madaros is the default compiler (`bin/souc` → Madaros)
 
@@ -44,21 +45,24 @@ is preserved as `bin/souc-lean-single-x86_64`.
 - Madaros is the **Stage1 modular compiler** (`bin/madaros`,
   `scripts/ci/build_modular_madaros.sh`, `scripts/ci/madaros_full_gate.sh`).
   It is distinct from `souc` (the lean_single monolith), which still ships.
-- As of `origin/main@0d714587f`, production readiness is governed by
-  `docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md` and issue #356.
-  The known-open blocker probe still reproduces:
+- As of `origin/main@4c452498c`, the blocker cluster governed by
+  `docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md` and issue #356
+  is closed. The closeout record is
+  `docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md`.
   - `BLK-20260621-codex-source-elf-normal-bss`: minimal global read/write
-    source-to-ELF witnesses compile-segfault with `rc=139`.
+    source-to-ELF witnesses are regression controls.
   - `BLK-20260621-codex-madaros-build-segfault`: promoted-workspace local
-    self-build still exits `build_rc_139`.
+    self-build now exits `build_rc_0`.
+  - PR #313 is closed, satisfying the ownership disposition requirement.
 - `scripts/dev/madaros_readiness_status.sh --check-compiler-lane` is the
-  current coordination command for checking the active Claude compiler lane
-  without taking write ownership. Its next-gate output includes the lowering
-  diagnostic command for the current BSS/global blocker:
-  `scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering`.
+  current coordination command for checking active compiler lanes without
+  taking write ownership. `scripts/ci/madaros_open_blockers_probe.sh
+  --diagnose-lowering` now confirms closed expectations for the former
+  BSS/global and self-build witnesses.
 
-Do not say "Madaros is production-ready" until those blocker records are closed
-or explicitly narrowed with new acceptance gates.
+Do not say "Madaros is production-ready" merely because #356 is closed. Say the
+specific 2026-06-21 blocker cluster is closed, then use the production-ready
+definition below for any broader release claim.
 
 ## The only valid proof gate
 
@@ -140,10 +144,10 @@ make madaros-full-gate
 
 ## One-line coordination phrase
 
-> Madaros is the default `bin/souc` compiler on current `origin/main`, but it is
-> **not production-ready yet**: issue #356 still tracks the source-to-ELF
-> BSS/global compile-segfault and promoted-workspace self-build parity blockers.
-> Please sync to current `origin/main`, avoid stale raw ELFs as evidence, and use
-> `scripts/dev/madaros_readiness_status.sh --check-compiler-lane` plus
-> `scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering` before
-> changing compiler-owned files.
+> Madaros is the default `bin/souc` compiler on current `origin/main`, and the
+> 2026-06-21 #356 blocker cluster is closed on `main@4c452498c`: #313 is closed,
+> source-to-ELF BSS/global witnesses are controls, and promoted-workspace
+> self-build parity is green. Please sync to current `origin/main`, avoid stale
+> raw ELFs as evidence, and use `scripts/dev/madaros_readiness_status.sh
+> --check-compiler-lane` plus `scripts/ci/madaros_open_blockers_probe.sh
+> --diagnose-lowering` before changing compiler-owned files.

--- a/docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md
+++ b/docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md
@@ -1,0 +1,123 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-post-merge-closeout-2026-06-22
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-post-merge-closeout-2026-06-22
+-->
+
+# Madaros Post-Merge Closeout - 2026-06-22
+
+## Scope
+
+This note closes the 2026-06-21 Madaros blocker cluster that was tracked in
+GitHub issue #356. It records what is closed, what proved it, and what should
+not be reopened from stale evidence.
+
+This is a status/audit artifact, not a new compiler patch.
+
+## Closed Items
+
+| Item | Final status | Evidence |
+|---|---|---|
+| `BLK-20260621-codex-source-elf-normal-bss` | Closed; now a regression control | `scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering` returned `rc=0`; `global_read_exit4` exits `4`; `global_store_exit7` exits `7`; lowering diagnostics reached `bodies_done` with markers present |
+| PR #313 ownership disposition | Closed | PR #313 was closed on 2026-06-21T22:32:52Z as stale/conflicting compiler-owner overlap |
+| `BLK-20260621-codex-madaros-build-segfault` | Closed; now a regression control | Default promoted-workspace self-build returns `build_rc_0`; `self_build_madaros` is a control row in `scripts/ci/madaros_open_blockers_probe.sh` |
+| GitHub issue #356 | Closed | Closed on 2026-06-22T01:17:18Z after PR #395 merged and main CI completed successfully |
+
+## Merge Evidence
+
+- PR: #395, `fix(madaros): resolve workspace self-build parity`.
+- Merge commit: `4c452498c156c0ce143ae48763abfaf0fb2c7b5d`.
+- Main CI: run `27923484270`, completed `success`.
+- Green main jobs:
+  - `Contracts`
+  - `Sounio Lint`
+  - `Source-Bootstrap Self-Host (Linux x86_64)`
+  - `Native Self-Host (Linux x86_64)`
+  - `Native Self-Host (macOS arm64)`
+  - `Full Test Suite`
+  - `Lean Proofs`
+  - `Website`
+
+## Local Final Evidence
+
+Final local checks were run in an isolated worktree derived from current
+`origin/main`, not in the protected dirty primary checkout.
+
+```bash
+scripts/ci/madaros_open_blockers_probe.sh --diagnose-lowering
+# rc=0
+
+scripts/ci/madaros_source_to_elf_gate.sh
+# rc=0
+
+git diff --check
+# rc=0
+```
+
+The open-blocker probe reported these resolved rows:
+
+```text
+control  global_read_exit4    normal      4          4          ok
+control  global_read_exit4    native_v2   4          4          ok
+control  global_read_exit4    build       4          4          ok
+control  global_store_exit7   build       7          7          ok
+control  self_build_madaros   self_build  build_rc_0 build_rc_0 ok
+```
+
+## Root Cause
+
+`lean_single` import resolution could fall through to bogus base-directory
+`mod.sio` candidates for module-qualified imports encountered inside imported
+files. The observed bad shape was:
+
+```text
+self-hosted/parser/parser/types/mod.sio
+```
+
+The intended module candidate was:
+
+```text
+self-hosted/parser/types.sio
+```
+
+The final fix is intentionally narrow:
+
+- keep loaded-path lookup before duplicate imports hit filesystem fallback,
+- avoid base-directory `mod.sio` fallback for module-qualified raw paths after
+  the base path read fails,
+- preserve `stdlib` precedence, so imports such as `tensor::ops` continue to
+  resolve to `stdlib/tensor/ops.sio` rather than `self-hosted/tensor/ops.sio`.
+
+The broad self-hosted-first variant was rejected because it made tensor/PINN
+tests resolve the wrong module family.
+
+## What Not To Reopen From
+
+Do not reopen #356 from any of these alone:
+
+- a stale `bin/madaros` or `artifacts/self-hosted/madaros` ELF,
+- a stale worktree that predates `main@4c452498c`,
+- warnings emitted during successful self-builds,
+- the historical PR #313 branch,
+- old `build_rc_139` logs from before PR #395.
+
+If a new failure appears, create a new blocker with fresh current-main evidence
+and a new acceptance gate.
+
+## Residual Warning Debt
+
+The closeout does not claim all Madaros warning debt is gone. The following
+families still deserve separate classification work, but they are not #356
+blockers:
+
+- assignment-type warnings in GPU/SPIR-V modules,
+- borrow diagnostics in `stdlib/tensor/ops.sio` that do not currently fail the
+  native test run,
+- stack-frame-too-large warnings in large checker/native modules,
+- parser expression match-arm warnings.
+
+Recommended next lane: create a warning-debt tracker that classifies each family
+as harmless, stale false positive, type-system bug, or runtime-risk predictor.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 739
-- Repo-backed topics: 589
+- Total governed topics: 740
+- Repo-backed topics: 590
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 447
+- Authority count `repo_only`: 448
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 451 topics
+- A2: 452 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -109,6 +109,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-operational-handoff-2026-06-21 | repo_only | docs/audit/MADAROS_OPERATIONAL_HANDOFF_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-post-merge-closeout-2026-06-22 | repo_only | docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-production-readiness-plan-2026-06-21 | repo_only | docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-readonly-probe-2026-06-21 | repo_only | docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1979,6 +1979,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-post-merge-closeout-2026-06-22",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-print-int-dispatch-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md",


### PR DESCRIPTION
## Summary
- update Madaros status to reflect that the 2026-06-21 #356 blocker cluster is closed on main@4c452498c
- add a post-merge closeout audit note with merge, CI, local gate, root-cause, and stale-evidence guidance
- sync docs governance metadata for the new governed topic

## Checks
- git diff --check
- scripts/dev/check_docs_registry.sh
- scripts/dev/check_docs_consistency.sh

## LLM offload
- Not invoked: documentation/status closeout only; no math claims, clinical-pathway code, or external-facing artifact changes.