### PR TITLE
feat(check): escape analysis for raw references — reject `&local` escapes (E091)

### DIFF
--- a/docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md
+++ b/docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md
@@ -1,0 +1,253 @@
+# Madaros raw-reference codegen — forensic dispatch
+
+**Date:** 2026-06-21
+**Author:** Claude (Codex-coordinated; this is the object-model/codegen lane)
+**Status:** SCOPED — implementation is mechanically tractable but **soundness-blocked**; do not land the codegen until the frontend gains escape analysis (see §4).
+**Related:** #392 (box-deref codegen + raw-ref loud-fail), #393 (line-start `*b`/`&x` parse), #394 (`Box<T>` param deref E005).
+
+---
+
+## 1. Symptom
+
+Raw references are rejected at native_v2 codegen:
+
+```sounio
+fn load(r: &i64) -> i64 { *r }
+fn main() -> i64 { let x = 42; load(&x) }
+```
+
+→ `Native compilation failed: native_driver_function_codegen_failed`.
+
+Both `&x` (OpRef) and `*r` (deref of a true `&T`) fail. `&!x` (OpRefMut) too.
+
+## 2. Where it fails (contradiction resolved)
+
+The active native_v2 path is the **core_ir** loop (`nc_core_*`), not the
+`native_v2_emit_*` / MIR `MachineInstr` layer. In
+`self-hosted/native/codegen_x86_linux.sio`, the `IrUnaryOp` case:
+
+```
+6460  } else if instr_op == IrOpcode::IrUnaryOp {
+6469      if uop == UnaryOp::OpNeg { ... }
+6474      else if uop == UnaryOp::OpNot { ... }
+6479      else {
+6480          return false        // <-- OpRef / OpRefMut / OpDeref(raw &T) -> codegen_failed
+6481      }
+```
+
+This is #392's deliberate fail-loud. Note: the `native_v2_emit_unary_code`
+helper (line ~4990) *does* have an `OpDeref` arm, but it is on the **inactive**
+MIR path — it does not run for these programs. So both `&x` and `*r` die at 6480.
+
+Lowerer side (`self-hosted/ir/lower.sio` `lower_unary_expr_ref`, ~6772): box
+deref is already rerouted to `IrFieldGet(0)`; everything else emits
+`ir_unaryop(dst, e.un_op, src)` where for `&x`, `src` is x's **loaded value**,
+not its address.
+
+## 3. The implementation is mechanically tractable (~10 lines)
+
+Decisive fact: in the core_ir path **every IR temp/register is an addressable
+stack slot**:
+
+```
+nc_core_load_temp_to_rax(temp)  = load  rax, [rbp + ir_slot_offset(temp)]
+nc_core_store_rax_to_temp(temp) = store [rbp + ir_slot_offset(temp)], rax
+```
+
+So:
+- **`*r` (OpDeref of raw &T):** load src (the pointer) to rax, `emit_load_rax_mem_rax` (rax ← [rax]), store dst. The load primitive already exists (used at line 4997). Always safe given a valid pointer.
+- **`&x` (OpRef):** the operand already sits at `rbp + ir_slot_offset(src)`, so `lea rax, [rbp + ir_slot_offset(src)]` (the existing `MIR_OP_LEA_STACK` primitive at line 5333), store dst. Mechanically trivial.
+
+(Lowering nuance: the lowerer copies x's value into a fresh temp before `&`, so
+`&x` would yield the address of that **copy slot**, not x's canonical slot. That
+is fine for read-only `*(&x)` — you read back the same value — but means
+mutation through `&!T` would not write x. `&!T` is deferred regardless.)
+
+## 4. SOUNDNESS BLOCKER — why this must NOT land yet
+
+Enabling `&x` re-introduces a **silent dangling-pointer miscompile** for
+escaping references — the worst class for an epistemic language, and exactly
+what the loud-fail prevents.
+
+**Verified on a clean current-main build** (run 27920658457, off
+`probe/rawref-baseline` @ `ad69883df`, so #393's parser fix is in — no
+line-start `*r` contamination), `--check` **ACCEPTS** all of:
+
+| Program | Frontend verdict | If codegen enabled |
+|---|---|---|
+| `fn bad() -> &i64 { let x = 7; let r = &x; r }` | **ACCEPT** | returns a dangling stack address |
+| `struct Holder { p: &i64 } fn bad() -> Holder { let x=7; let r=&x; Holder{p:r} }` | **ACCEPT** | escapes a dangling ref in a struct |
+| `fn ok() -> i64 { let x=7; let r=&x; *r }` (safe, in-frame) | ACCEPT | correct |
+| `fn load(r:&i64)->i64{*r} ... load(&x)` (safe) | ACCEPT | correct |
+
+The borrow-checker (`try_shared_borrow` / `try_exclusive_borrow`) tracks
+**in-scope aliasing** but performs **no escape/lifetime analysis** — it does not
+reject returning or storing a reference to a local. So the loud-fail at 6480 is
+the *only* thing preventing the dangling-pointer miscompile, and it is
+**correct** until escape analysis exists.
+
+There is no safe useful subset to ship early: `*r` alone is useless without
+`&x` to create a reference, and `&x` is precisely the escape-prone operation.
+
+## 5. Recommended path (dependency order)
+
+1. **Frontend escape analysis (prerequisite).** Reject a reference to a local
+   when it can outlive the local: returning a `&T`/`&!T` to a local, storing it
+   in a returned/heap aggregate, etc. This is the real work and the gate.
+2. **Then** add the ~10-line core_ir codegen from §3 (lea for OpRef, load for
+   OpDeref) and remove the 6480 loud-fail for the now-provably-safe cases.
+3. Lowering: make `&<local ident>` lea the local's **canonical** slot (not a
+   value copy) so a future `&!T` can mutate through the reference.
+
+**Scope even after escape analysis** — land `&<local>` + `*ref`, read-only,
+non-escaping, primitive inner first. Defer: `&!T` mutation-through-ref, refs to
+struct fields / array elements, reference returns, any escaping ref.
+
+## 6. Escape analysis — completeness requirement + channel inventory
+
+A **partial** escape analysis does NOT unblock codegen: if it misses any escape
+channel, enabling ref codegen still ships a silent dangling pointer. So the
+loud-fail (§2) must stay until escape analysis is **complete** across every
+channel by which a local-rooted reference can outlive its frame.
+
+"Complete" = control every escape channel. Channels you can cheaply **forbid**
+(reject constructing) cost far less than channels you must **analyse** — and a
+measurement of `self-hosted/` + `stdlib/` shows the forbiddable channels are
+near-empty, so this is bounded, not a multi-session lifetime system:
+
+| Channel | Count | Disposition |
+|---|---:|---|
+| ref-typed struct fields (`field: &T`) | 4 | forbid (or special-case); near-empty |
+| ref-typed globals | 5 | referent is static → benign |
+| `Box<&T>` / refs in arrays | 0 | forbid; none exist |
+| ref returns (`-> &T`) | 5 | **analyse** — all 5 are param-derived (valid), must accept |
+
+The only channel needing real dataflow is **return** (and escaping stores):
+distinguish a reference whose place-root is a **frame-bound local** (reject) from
+one rooted in a **reference parameter** / global (accept). The 5 stdlib ref
+returns (`get(self: &MetaResult) -> &Epistemic`, `atlas_get_region(atlas: &Atlas)
+-> &AtlasRegion`, `current_token`/`peek_token`, `het`) are all param-derived and
+**must not** be false-rejected.
+
+### Proposed return-provenance analysis (bounded)
+1. Tag each binding's reference **provenance**: `&<local>` → LOCAL; `&<param>` /
+   `&param.field` / `&param[..]` → PARAM (outlives); global → STATIC.
+2. Propagate through `let r = &x` so `r` carries x's provenance.
+3. At a `return <e>` where the return type is `&T`/`&!T` (or an escaping store):
+   reject if `<e>`'s provenance is LOCAL.
+4. Forbid the exotic channels (ref struct fields beyond the 4, `Box<&T>`, ref
+   arrays) outright until they're analysed.
+
+Borrow infra note: `borrow.sio` `BorrowEnv` tracks borrow **state**, not ref
+**provenance** — provenance is a new per-binding tag. `borrows.sio`
+(`BorrowChecker` v2) is more elaborate but appears not fully wired; confirm
+before building on it.
+
+## 7. Q1 literature grounding (deep-research, 2026-06-22)
+
+Two adversarially-verified deep-research passes (PLDI/POPL/OOPSLA/ICFP/TOPLAS;
+3-vote verification) converge on a design that **matches §6's return-provenance
+proposal** and supplies the soundness theorem to mirror. Verified claims:
+
+**Established floor.**
+- *Second-class values* (Osvald, Essertel, Wu, Rompf — OOPSLA 2016): one binary
+  qualifier `n` (first/second-class) on STLC; Coq-mechanized type soundness
+  (Thm 3.5), leak-freedom "evaluation never leaks stack references" (Thm 3.2),
+  and Cor 3.6 "well-typed programs respect stack-based lifetimes for second-class
+  values". Three baseline rules ≈ our spec: (i) first-class fn may not capture a
+  second-class free var, (ii) fns may not **return** second-class values, (iii)
+  second-class may not be **stored** in fields / mutable vars. [verified 2-0]
+- *Tofte–Talpin region inference* (Inf.&Comp. 1997; Tofte–Birkedal TOPLAS 1998):
+  `letregion` LIFO + **region polymorphism** (region vars as extra params) is the
+  theory for "reject frame-local escape, accept parameter-rooted pass-through";
+  co-inductive consistency Thm 6.1. [verified 3-0]
+
+**Verified frontier — the propagation rule (answers §6's open design question).**
+- *Capture calculus* CC<:□ (Boruch-Gruszecki, Odersky, et al. — TOPLAS 2023,
+  arXiv 2105.11896): capture sets on types; Coq progress+preservation; the
+  **capture-prediction lemma** (Cor 2.6 / Lemma 4.11) = the capture set is a
+  *sound over-approximation* of a value's free vars. [verified 3-0]
+- **The exact decidable propagation function** `cv(t)` — syntax-directed, no
+  fixpoint/quantifier: `cv(x)={x}`; `cv(let x=s in t)=cv(s) ∪ cv(t)\{x}`;
+  `cv(λ(x).t)=cv(t)\{x}`; `cv(box)={}`. The let-rule (**union-minus-binder**) is
+  exactly taint-through-binding: any subterm rooted in a frame-local taints the
+  binding; a parameter-rooted ref carries only the parameter. [verified 3-0]
+- **Escape side-condition**: reject a result whose type would capture the root
+  capability `cap`; *avoidance* widens an escaping local's type to the smallest
+  supertype not mentioning it (→ `{cap}` when fresh) → rejected. Scala 3 capture
+  checking ships this diagnostic ("…persists longer than its allowed lifetime").
+  [verified 3-0]
+- **Effects** (`&!T` / algebraic effects, our Q4): capture calculus already
+  handles effect handlers via a *single* non-escape side-condition in the
+  `(handle)` rule (handler's `{x}` not a subcapture of the result type) — the
+  light machinery suffices for effects; full reachability is only forced by
+  genuinely **shared mutable** state. [verified 3-0]
+
+**Caveats:** Scala cc tracks capabilities, not literal stack-frame refs (sound
+*analogy*, not identity). Reachability-types specifics (Bao/Wei/Rompf, freshness,
+Preservation-of-Separation) and the exact Q2 undecidability bound (semi-unification,
+Kfoury 1990) were rate-limited to 0-0 *abstain* (not refuted) — treat as leads.
+
+### Recommended design (research-grounded, supersedes §6 step list)
+**Land first — binary provenance qualifier, decidable, sound:**
+- Tag each binding LOCAL vs FIRST-CLASS (outlives-frame): `&<local>` → LOCAL;
+  `&<param>` / `&param.field` / global → FIRST-CLASS.
+- Propagate by the `cv` taint rule: `let r = e` ⇒ `r` inherits LOCAL if any
+  frame-local is in `cv(e)` (union-minus-binder over let/field-projection/reborrow).
+- **Reject** any `return <e>` (ret type `&T`/`&!T`) or escaping store where
+  `cv(<e>)` contains a frame-local; **accept** parameter/global-rooted.
+- Keep regions **monomorphic** to stay decidable (avoid the semi-unification
+  boundary). Soundness theorem to mirror: second-class Thm 3.5 + Cor 3.6.
+- This is a one-bit collapse of a capture set — coarser, so it will reject a few
+  valid mixed-origin programs a capture set would accept (acceptable first cut).
+
+**Upgrade path (only if the binary qualifier over-rejects in practice):**
+binary → finite **capture sets** (CC<:□: per-variable identity, fewer false
+rejects, effects via `(handle)`) → full **reachability qualifiers** (shared
+mutable `&!T`, Preservation-of-Separation; System Capless, Lean-mechanized,
+SPLASH 2025).
+
+Sources: arXiv 2105.11896 (CC<:□/TOPLAS'23), dl.acm.org/10.1145/3022671.2984009
+(Osvald'16), ToTa Inf.&Comp.1997 / TOPLAS'98, arXiv 2509.07609 (Capless),
+arXiv 2307.13844 (reachability — lead), docs.scala-lang.org scala3 cc.
+
+## 8. Implementation status — increment 1 LANDED (2026-06-22)
+
+The frontend escape analysis (§7 recommended design) is implemented on branch
+`feat/escape-analysis-raw-refs` (commit 648d79300, `borrow.sio` + `check.sio`,
++129): a binary provenance qualifier on `BorrowEntry` (0=first-class, 1=LOCAL),
+propagated by `checker_expr_provenance` (the cv-taint rule), with the body-tail
+provenance captured in a `Checker.escape_provenance` side-channel (mirrors
+`last_literal_kind`) and checked at the return-compat + explicit-return sites.
+New diagnostic **E091** "reference to a local variable escapes its scope".
+
+**Verified (off-pod build run 27937904382, build + Madaros gate green):**
+- The 3 escape cases REJECT with E091: `let r=&x; r` returned, `&x` returned,
+  `Holder { p: &x }` returned.
+- The 5 valid cases ACCEPT: `&self.f` returned, `&self.f` via let, ref-param
+  pass-through, in-frame `*r`, `&x` passed to a call.
+- **Zero false-rejects** across a 160-file sweep (all stdlib + self-hosted
+  check/parser/ir) incl. the 5 real stdlib `-> &T` returns.
+
+**Deferred channels (increment-1 boundary — INCOMPLETENESS, not unsoundness;**
+**these slip the frontend but the codegen loud-fail at §2 still guards them, so**
+**no silent miscompile — they MUST be closed before raw-ref codegen is enabled):**
+- Interprocedural: a call returning a ref tainted by a `&local` argument
+  (`fn id(r:&i64)->&i64{r}; id(&x)` returned) — needs call-result taint = OR of
+  ref-arg provenances. CONFIRMED slips (ACCEPT).
+- Nested block / if tails (`{ let x=7; &x }` as the function tail) — needs
+  `checker_expr_provenance` to recurse through `ExprBlock`/`ExprIf`. CONFIRMED
+  slips (ACCEPT).
+- Arrays of refs and ref-typed struct-field reads (the 4 `field: &T` sites) —
+  needs array-lit taint + ref-field projection.
+
+**Property:** the analysis only ADDS rejections (E091); it never enables codegen,
+so it cannot introduce a miscompile. Worst case is a false-reject (verified 0) or
+a missed escape (caught later by the loud-fail). The unwired 1846-line
+`self-hosted/check/lifetimes.sio` NLL checker remains the precision/completeness
+upgrade path.
+
+## 9. Reproducers
+
+`/tmp/rrtest/{esc_return,esc_struct,safe_inframe,safe_param}.sio` (see §4 table).
+Baseline compiler: artifact `madaros-built` from run 27920658457.

--- a/self-hosted/check/borrow.sio
+++ b/self-hosted/check/borrow.sio
@@ -21,6 +21,7 @@ pub struct BorrowEntry {
     is_linear: bool,     // Whether this is a linear type variable
     consumed: bool,      // Whether a linear variable has been consumed
     scope_depth: i64,    // Scope where this entry was created
+    provenance: i64,     // escape provenance: 0=first-class (param/global/safe), 1=local (frame-bound ref)
 }
 
 fn empty_borrow_entry() -> BorrowEntry {
@@ -31,6 +32,7 @@ fn empty_borrow_entry() -> BorrowEntry {
         is_linear: false,
         consumed: false,
         scope_depth: 0,
+        provenance: 0,
     }
 }
 
@@ -92,6 +94,7 @@ impl BorrowEnv {
                 is_linear: is_linear,
                 consumed: false,
                 scope_depth: env.scope_depth,
+                provenance: 0,
             }
             env.count = env.count + 1
         }
@@ -108,6 +111,32 @@ impl BorrowEnv {
             i = i - 1
         }
         -1
+    }
+
+    // Scope depth where a name was bound (-1 if not tracked). Params are bound at
+    // depth 1 (the fn param scope); body-locals at depth >= 2 (the body block pushes
+    // a second scope). So scope_depth_of(name) >= 2 iff name is a frame-bound local.
+    fn scope_depth_of(self, name: Name) -> i64 with Mut, Panic, Div {
+        let idx = self.find(name)
+        if idx < 0 { return -1 }
+        self.entries[idx].scope_depth
+    }
+
+    // Escape provenance of a binding (0=first-class, 1=local); 0 if not tracked.
+    fn provenance_of(self, name: Name) -> i64 with Mut, Panic, Div {
+        let idx = self.find(name)
+        if idx < 0 { return 0 }
+        self.entries[idx].provenance
+    }
+
+    // Record the escape provenance of a binding (set after track at let/var sites).
+    fn set_provenance(self, name: Name, prov: i64) -> BorrowEnv with Mut, Panic, Div {
+        var env = self
+        let idx = env.find(name)
+        if idx >= 0 {
+            env.entries[idx].provenance = prov
+        }
+        env
     }
 
     // Try to take a shared borrow (&x)

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -239,6 +239,7 @@ pub struct Checker {
     last_literal_int: i64,
     last_literal_float: f64,
     last_literal_kind: i64,   // 0=none, 1=int, 2=float
+    escape_provenance: i64,   // tail-expr escape provenance: 0=safe, 1=local ref escapes the frame
     loop_depth: i64,
     suppress_linear_consume_depth: i64,
     type_depth: i64,
@@ -735,6 +736,7 @@ fn checker_new() -> Checker with Mut, Panic, Div {
         last_literal_int: 0,
         last_literal_float: 0.0,
         last_literal_kind: 0,
+        escape_provenance: 0,
         loop_depth: 0,
         suppress_linear_consume_depth: 0,
         type_depth: 0,
@@ -830,6 +832,7 @@ fn checker_init_in_place(raw: *mut Checker) with Mut, Panic, Div, Alloc {
     (*raw).last_literal_int = 0
     (*raw).last_literal_float = 0.0
     (*raw).last_literal_kind = 0
+    (*raw).escape_provenance = 0
     (*raw).loop_depth = 0
     (*raw).suppress_linear_consume_depth = 0
     (*raw).type_depth = 0
@@ -3164,12 +3167,18 @@ fn checker_check_fn_item_inplace(c: *mut Checker, opt: Option<Box<FnDef> >) with
             (*c).borrows = (*c).borrows.push_scope()
             checker_push_const_scope_inplace(c)
             checker_bind_fn_params_inplace(c, (*fd).params)
+            (*c).escape_provenance = 0
             let body_ty = checker_check_block_inplace(c, (*fd).body)
             if sig_id >= 0 {
                 let sig2 = (*c).fn_sigs.get(sig_id)
                 if !checker_fn_body_return_compatible_inplace(c, body_ty, sig2.return_type) {
                     checker_report_mismatch_inplace(c, (*fd).span, 8, sig2.return_type, body_ty)
                 }
+            }
+            // Raw-reference escape: the body tail yields a reference rooted in a
+            // frame-local (e.g. `let r = &x; r` or `Holder { p: &x }`) → dangling.
+            if (*c).escape_provenance == 1 {
+                checker_report_error_at_inplace(c, (*fd).span, 91, 0, 0, 0)
             }
             if (*c).multitest_count > 1 && !(*c).multitest_corrected {
                 checker_report_multitest_correction_required_inplace(c, (*fd).span, (*c).multitest_count)
@@ -3208,6 +3217,75 @@ fn checker_check_block_inplace(c: *mut Checker, blk: Block) -> TypeEntry with Mu
     result_ty
 }
 
+// ============================================================
+// Escape provenance (raw-reference escape analysis)
+//
+// 0 = first-class: rooted in a reference parameter / global → outlives the frame.
+// 1 = LOCAL: rooted in a frame-bound let/var local → must NOT escape via return or
+// an escaping store. Propagated by the capture-calculus cv-taint rule (see
+// docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md §7): cv(&x)=LOCAL iff x is a
+// frame-local; let r=e gives r the provenance of e; &self.f keeps the root (param)
+// provenance; a struct literal is tainted LOCAL if any field is.
+// ============================================================
+
+// Is the ROOT of a borrowed place a frame-bound local? Walks ident / field-access /
+// unary chains to the root variable and tests its borrow scope_depth (params live at
+// depth 1, body-locals at depth >= 2). Unknown roots → false (conservative: never a
+// false-reject; an unhandled escape would still hit the codegen loud-fail, not a
+// silent miscompile).
+fn checker_place_root_local(c: *mut Checker, place: Expr) -> bool with Mut, Panic, Div, Alloc, IO {
+    if place.kind == ExprKind::ExprIdent {
+        (*c).borrows.scope_depth_of(place.name) >= 2
+    } else if place.kind == ExprKind::ExprFieldAccess {
+        let ptr = expr_opt_get(place.left)
+        if ptr == 0 as *mut Expr { return false }
+        checker_place_root_local(c, *ptr)
+    } else if place.kind == ExprKind::ExprUnary {
+        let ptr = expr_opt_get(place.left)
+        if ptr == 0 as *mut Expr { return false }
+        checker_place_root_local(c, *ptr)
+    } else {
+        false
+    }
+}
+
+fn checker_expr_provenance(c: *mut Checker, e: Expr) -> i64 with Mut, Panic, Div, Alloc, IO {
+    if e.kind == ExprKind::ExprUnary {
+        if e.un_op == UnaryOp::OpRef || e.un_op == UnaryOp::OpRefMut {
+            let ptr = expr_opt_get(e.left)
+            if ptr == 0 as *mut Expr { return 0 }
+            if checker_place_root_local(c, *ptr) { 1 } else { 0 }
+        } else {
+            0
+        }
+    } else if e.kind == ExprKind::ExprIdent {
+        (*c).borrows.provenance_of(e.name)
+    } else if e.kind == ExprKind::ExprStructLit {
+        var prov = 0
+        var cur = e.fields
+        var guard = 0
+        while guard < 1024 {
+            guard = guard + 1
+            match cur {
+                Some(list) => {
+                    if checker_expr_provenance(c, (*list).head.value) == 1 { prov = 1 }
+                    cur = (*list).tail
+                }
+                None => break
+            }
+        }
+        prov
+    } else {
+        0
+    }
+}
+
+fn checker_expr_provenance_opt(c: *mut Checker, opt: Option<Box<Expr> >) -> i64 with Mut, Panic, Div, Alloc, IO {
+    let ptr = expr_opt_get(opt)
+    if ptr == 0 as *mut Expr { return 0 }
+    checker_expr_provenance(c, *ptr)
+}
+
 fn checker_check_stmts_inplace(c: *mut Checker, opt: Option<Box<StmtList> >) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     var cursor = opt
     var last_ty = ty_unit()
@@ -3215,6 +3293,19 @@ fn checker_check_stmts_inplace(c: *mut Checker, opt: Option<Box<StmtList> >) -> 
         match cursor {
             Some(list) => {
                 last_ty = checker_check_stmt_inplace(c, (*list).head)
+                // Capture the escape provenance of the block's TAIL expression
+                // (the value the block/function yields) while the AST is still live;
+                // the return-compatibility site only sees the TypeEntry.
+                match (*list).tail {
+                    None => {
+                        if (*list).head.kind == StmtKind::StmtExpr {
+                            (*c).escape_provenance = checker_expr_provenance_opt(c, (*list).head.expr)
+                        } else {
+                            (*c).escape_provenance = 0
+                        }
+                    }
+                    Some(_) => {}
+                }
                 cursor = (*list).tail
             }
             None => break
@@ -3271,6 +3362,11 @@ fn checker_check_return_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with
         Some(val_expr) => {
             if !checker_contextual_expr_compatible(*val_expr, val_ty, (*c).current_return_type) {
                 checker_report_mismatch_inplace(c, e.span, 8, (*c).current_return_type, val_ty)
+            }
+            // Raw-reference escape: `return &local` / `return r` where r is rooted
+            // in a frame-local → dangling reference.
+            if checker_expr_provenance(c, *val_expr) == 1 {
+                checker_report_error_at_inplace(c, e.span, 91, 0, 0, 0)
             }
         }
         None => {
@@ -5981,6 +6077,8 @@ fn checker_check_let_stmt_inplace(c: *mut Checker, s: Stmt) -> TypeEntry with Mu
     // Track variable for borrow checking (linear if struct is declared linear)
     let lin = checker_is_linear_type_inplace(c, bind_ty)
     (*c).borrows = (*c).borrows.track(s.name, lin)
+    // Propagate escape provenance: `let r = &x` taints r LOCAL; `let r = &self.f` keeps it first-class.
+    (*c).borrows = (*c).borrows.set_provenance(s.name, checker_expr_provenance_opt(c, s.expr))
     ty_unit()
 }
 
@@ -6028,6 +6126,7 @@ fn checker_check_var_stmt_inplace(c: *mut Checker, s: Stmt) -> TypeEntry with Mu
     }
     let lin = checker_is_linear_type_inplace(c, bind_ty)
     (*c).borrows = (*c).borrows.track(s.name, lin)
+    (*c).borrows = (*c).borrows.set_provenance(s.name, checker_expr_provenance_opt(c, s.expr))
     ty_unit()
 }
 
@@ -9987,6 +10086,7 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 6 { print("conditions must be of type `bool`") }
     else if code == 7 { print("branches have incompatible types") }
     else if code == 8 { print("return value does not match function's declared return type") }
+    else if code == 91 { print("reference to a local variable escapes its scope") }
     else if code == 9 { print("argument type does not match parameter") }
     else if code == 10 { print("wrong number of arguments in this call") }
     // Member access (11-16)


### PR DESCRIPTION
## What

Implements the **frontend escape analysis** that is the soundness prerequisite for raw-reference (`&x` / `*r`) codegen. Returning or storing a reference to a frame-bound local is now a static error (**E091**), while references derived from reference parameters stay valid.

```sounio
fn bad() -> &i64 { let x = 7; let r = &x; r }   // E091: reference to a local variable escapes its scope
fn get(self: &Holder) -> &i64 { &self.f }       // OK — rooted in a reference parameter
```

## Why

The compiler previously accepted `return &local` and storing `&local` in a returned struct with **no escape analysis** — so enabling `&x` codegen would ship a silent dangling-pointer miscompile. This closes that gap on the frontend; the codegen loud-fail stays until the deferred channels (below) are also closed.

## Design (Q1-grounded)

Two adversarial deep-research passes (PLDI/POPL/OOPSLA/TOPLAS, 3-vote verified — see `docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md` §7) converged on a **binary provenance qualifier** propagated by the **capture-calculus `cv`-taint rule**:

- `provenance` field on `BorrowEntry` — 0 = first-class (rooted in a param/global), 1 = LOCAL (rooted in a frame-local; borrow `scope_depth >= 2`).
- `checker_expr_provenance`: `cv(&x)` = LOCAL iff `x` is a frame-local; `let r = e` gives `r` the provenance of `e`; `&self.f` keeps the param root; a struct literal is tainted LOCAL if any field is.
- Body-tail provenance is captured in a `Checker.escape_provenance` side-channel (mirrors `last_literal_kind`, since the return-compat site only has the TypeEntry), and checked at the return-compat + explicit-return sites.

Soundness mirrors Osvald et al. second-class values (Coq Thm 3.5 / Cor 3.6).

## Verification (off-pod build run 27937904382 — build + Madaros gate green)

| Case | Result |
|---|---|
| `let r=&x; r` returned / `&x` returned / `Holder{p:&x}` returned | **REJECT (E091)** ✅ |
| `&self.f` returned / `&self.f` via let / ref-param pass-through / in-frame `*r` / `&x` to a call | **ACCEPT** ✅ |
| 160-file sweep (all stdlib + self-hosted check/parser/ir), incl. the 5 real stdlib `-> &T` returns | **0 false-rejects** ✅ |

## Deferred (increment-1 boundary — incompleteness, **not** unsoundness)

These slip the frontend but the codegen loud-fail still guards them (no silent miscompile); they must be closed before raw-ref codegen is enabled: interprocedural call-result taint (`id(&x)` returned), nested block/if tails, arrays of refs / ref-typed struct fields. The analysis only *adds* rejections (E091) and never enables codegen, so it cannot introduce a miscompile.

2 files (`check.sio`, `borrow.sio`, +129) + the dispatch/design doc. The unwired 1846-line `lifetimes.sio` NLL checker is the precision/completeness upgrade path.
