### PR TITLE
docs(release): define broad production readiness gate

### DIFF
--- a/docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md
+++ b/docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md
@@ -1,0 +1,158 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.sounio-release-production-readiness-2026-06-22
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.sounio-release-production-readiness-2026-06-22
+-->
+
+# Sounio Release Production Readiness - 2026-06-22
+
+## Scope
+
+This note defines the broader release-production-ready standard for Sounio. It
+is intentionally stricter than the Madaros production-ready gate.
+
+Madaros readiness answers:
+
+- Is the default compiler path currently green on `main`?
+- Are the tracked Madaros production blockers closed?
+- Is the compiler-owner PR queue clear enough for the current compiler lane?
+
+Sounio release production readiness answers a larger product question:
+
+- Can the repository safely present Sounio as a broad production-ready language
+  distribution, including compiler source lineage, stdlib surface, tooling,
+  installation, docs, package flow, and public support wording?
+
+As of `origin/main@f9e139a6c4ea7ff5a6e63387c807bbe0578a189c`, the answer is:
+
+- **Madaros production-ready:** yes, by the existing executable gate.
+- **Broad Sounio release production-ready:** no, by the stricter release gate
+  introduced here.
+
+This is not a regression. It is a higher bar.
+
+## Executable Gate
+
+Use:
+
+```bash
+scripts/ci/sounio_release_production_readiness_gate.sh
+```
+
+The gate requires:
+
+1. Clean checkout at `origin/main`.
+2. Madaros production readiness:
+   `scripts/dev/madaros_readiness_status.sh --no-audit --production-ready`.
+3. Docs registry and docs consistency checks.
+4. Serious-language public claim closure:
+   `scripts/ci/serious_language_claim_closure_gate.sh`.
+5. No release-critical public product surface remaining
+   `prototype`/`downgraded` in
+   `docs/serious-language/public-claim-registry.v1.tsv`.
+
+For fast classification without rerunning live gates:
+
+```bash
+scripts/ci/sounio_release_production_readiness_gate.sh --skip-live-gates
+```
+
+The skip mode is for triage only. It is not sufficient for a release sign-off.
+When changing the gate itself on a feature branch, use `--allow-non-main` to
+validate the classification logic before merge. Do not use `--allow-non-main`
+for release sign-off.
+
+## Release-Critical Blockers
+
+These claim IDs currently block broad release-production-ready status:
+
+| Claim ID | Current status | Why it blocks broad release |
+|---|---|---|
+| `binary.source` | `prototype` / `downgraded` | The checked binary still depends on `lean_single` as the source path; modular source-swap parity is not closed. |
+| `direct_driver` | `prototype` / `downgraded` | Large-surface direct-driver execution remains a maturity frontier. |
+| `stdlib.surface` | `prototype` / `downgraded` | Broad stdlib callability is explicitly not claimed. |
+| `tooling.package` | `prototype` / `downgraded` | There is no public package registry/support contract. |
+| `tooling.editor` | `prototype` / `downgraded` | Formatter, REPL, and editor tooling are prototype surfaces. |
+| `install` | `prototype` / `downgraded` | Installation is repo-artifact based, not a broad supported distribution path. |
+| `website.docs` | `prototype` / `downgraded` | Docs are extensive but still require readiness filtering before public support wording. |
+
+Each row may be resolved in one of two honest ways:
+
+1. Close the claim with evidence and move it to `stable` or
+   `validated_research` with `closure_status=closed`.
+2. Remove the surface from the release support contract and avoid claiming a
+   broad production-ready language distribution.
+
+The gate intentionally does not count downgraded claims as release-ready simply
+because they are honestly downgraded. Honest downgrade is sufficient for public
+claim closure; it is not sufficient for a production release claim.
+
+## What Already Passes
+
+The narrower Madaros production-ready contract is green on current `main`:
+
+- issue #356 is closed,
+- the tracked BSS/global and self-build blockers are resolved,
+- current `main` CI is green,
+- the Madaros prebuilt refresh is green,
+- compiler-owner overlap is clear,
+- PR-resolution queue is contained,
+- source-to-ELF semantic gate is green.
+
+Those facts support "Madaros is production-ready by its current gate." They do
+not support "Sounio as a whole is a broad production-ready language
+distribution."
+
+## Live Validation Result
+
+Running the new gate with live checks on this branch reached this split:
+
+- `madaros-production-ready`: pass.
+- `docs-registry`: pass.
+- `docs-consistency`: pass.
+- `serious-language-claim-closure`: fail.
+
+The claim-closure failure currently bottoms out in
+`scripts/ci/serious_language_conformance_gate.sh`, where the bounded
+serious-language conformance spine reported `4/16` passing cases. Failing claim
+areas included structs, effect diagnostics, observe diagnostics, imports,
+generics, GUM/Knowledge execution, ownership diagnostics, and epistemic boundary
+diagnostics.
+
+That conformance failure is a release-wide blocker independent of the seven
+release-critical `prototype`/`downgraded` product-surface blockers above.
+
+## Acceptance Gates For Closure
+
+Broad release production readiness should not be declared until these are true:
+
+- `scripts/ci/sounio_release_production_readiness_gate.sh` exits `0`.
+- `scripts/dev/madaros_readiness_status.sh --no-audit --production-ready`
+  exits `0`.
+- `scripts/ci/serious_language_claim_closure_gate.sh` exits `0`.
+- `scripts/dev/check_docs_registry.sh` exits `0`.
+- `scripts/dev/check_docs_consistency.sh` exits `0`.
+- Current `main` CI is green.
+- Any release-critical claim in
+  `docs/serious-language/public-claim-registry.v1.tsv` is either closed at
+  `stable`/`validated_research` or intentionally removed from the broad release
+  support contract.
+
+## Current Recommended Wording
+
+Safe:
+
+> Madaros, the default `bin/souc` compiler path, is production-ready by the
+> current Madaros gate on `main@f9e139a6`. Sounio remains a serious research
+> language with validated compiler and scientific surfaces, but it is not yet a
+> broad production-ready language distribution.
+
+Unsafe:
+
+> Sounio is production-ready.
+
+That wording outruns the current claim registry and release-critical product
+surface evidence.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 740
-- Repo-backed topics: 590
+- Total governed topics: 741
+- Repo-backed topics: 591
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 448
+- Authority count `repo_only`: 449
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 452 topics
+- A2: 453 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -149,6 +149,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis | repo_only | docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.readme | repo_only | docs/audit/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sigsegv-pbpk28-private-struct-2026-06-02 | repo_only | docs/audit/SIGSEGV_PBPK28_PRIVATE_STRUCT_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.sounio-release-production-readiness-2026-06-22 | repo_only | docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sret-large-struct-smtcontext.dispatch | repo_only | docs/audit/sret_large_struct_smtcontext/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.windows-assert-a64-parity.ad-hessian-diagonal | repo_only | docs/audit/windows_assert_a64_parity/AD_HESSIAN_DIAGONAL.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.windows-assert-a64-parity.ad-hessian-offdiagonal | repo_only | docs/audit/windows_assert_a64_parity/AD_HESSIAN_OFFDIAGONAL.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2899,6 +2899,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.sounio-release-production-readiness-2026-06-22",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sret-large-struct-smtcontext.dispatch",
       "collection": "repo",
       "repo_doc_path": "docs/audit/sret_large_struct_smtcontext/DISPATCH.md",

--- a/scripts/ci/sounio_release_production_readiness_gate.sh
+++ b/scripts/ci/sounio_release_production_readiness_gate.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+RUN_LIVE_GATES=1
+ALLOW_NON_MAIN=0
+ARTIFACT_ROOT="${SOUNIO_RELEASE_PRODUCTION_READINESS_ARTIFACT_ROOT:-/tmp/sounio-release-production-readiness-$(date -u +%Y%m%dT%H%M%SZ)}"
+CLAIM_REGISTRY="${SOUNIO_PUBLIC_CLAIM_REGISTRY:-$ROOT_DIR/docs/serious-language/public-claim-registry.v1.tsv}"
+BLOCKER_TSV="$ARTIFACT_ROOT/release_blockers.tsv"
+SUMMARY_JSON="$ARTIFACT_ROOT/summary.v1.json"
+LIVE_TSV="$ARTIFACT_ROOT/live_gates.tsv"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci/sounio_release_production_readiness_gate.sh [--skip-live-gates] [--allow-non-main]
+
+Evaluates the broad Sounio release-production-ready contract. This is stricter
+than Madaros production readiness:
+  - current checkout must be clean and at origin/main,
+  - Madaros production readiness must pass,
+  - public claim closure and docs governance gates must pass,
+  - release-critical product surfaces must not remain prototype/downgraded.
+
+The gate is expected to fail until every release-critical blocker is either
+closed with evidence or explicitly removed from the release support contract.
+
+Use --allow-non-main only to validate changes to this gate on a feature branch.
+Do not use it for release sign-off.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-live-gates)
+      RUN_LIVE_GATES=0
+      shift
+      ;;
+    --allow-non-main)
+      ALLOW_NON_MAIN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$ARTIFACT_ROOT"
+
+run_step() {
+  local label="$1"
+  shift
+  local log="$ARTIFACT_ROOT/$label.log"
+  echo "[release-production] >>> $label"
+  if "$@" >"$log" 2>&1; then
+    echo "[release-production] <<< $label PASS log=$log"
+  else
+    local rc=$?
+    echo "[release-production] !!! $label FAIL rc=$rc log=$log" >&2
+    tail -n 80 "$log" >&2 || true
+    return "$rc"
+  fi
+}
+
+declare -a LIVE_LABELS=()
+declare -a LIVE_STATUSES=()
+declare -a LIVE_LOGS=()
+
+record_live_step() {
+  local label="$1"
+  local status="$2"
+  local log="$3"
+  LIVE_LABELS+=("$label")
+  LIVE_STATUSES+=("$status")
+  LIVE_LOGS+=("$log")
+}
+
+run_live_step() {
+  local label="$1"
+  shift
+  local log="$ARTIFACT_ROOT/$label.log"
+  if run_step "$label" "$@"; then
+    record_live_step "$label" "pass" "$log"
+  else
+    record_live_step "$label" "fail" "$log"
+  fi
+}
+
+write_live_tsv() {
+  {
+    echo -e "step\tstatus\tlog"
+    local i
+    for ((i = 0; i < ${#LIVE_LABELS[@]}; i++)); do
+      echo -e "${LIVE_LABELS[$i]}\t${LIVE_STATUSES[$i]}\t${LIVE_LOGS[$i]}"
+    done
+  } > "$LIVE_TSV"
+}
+
+echo "== Sounio Release Production Readiness =="
+echo "repo=$ROOT_DIR"
+echo "branch=$(git branch --show-current 2>/dev/null || true)"
+echo "head=$(git rev-parse HEAD 2>/dev/null || true)"
+echo "origin_main=$(git rev-parse origin/main 2>/dev/null || true)"
+echo "artifacts=$ARTIFACT_ROOT"
+
+dirty_entries="$(git status --porcelain | wc -l | tr -d ' ')"
+if [[ "$dirty_entries" != "0" ]]; then
+  echo "status[checkout]=fail"
+  echo "reason=dirty_checkout entries=$dirty_entries"
+  git status --short
+  exit 1
+fi
+echo "status[checkout]=pass"
+
+head_sha="$(git rev-parse HEAD)"
+origin_main_sha="$(git rev-parse origin/main)"
+if [[ "$head_sha" != "$origin_main_sha" ]]; then
+  if [[ "$ALLOW_NON_MAIN" == "1" ]]; then
+    echo "status[origin_main]=warn"
+    echo "reason=head_not_origin_main_allowed_for_branch_validation head=$head_sha origin_main=$origin_main_sha"
+  else
+    echo "status[origin_main]=fail"
+    echo "reason=head_not_origin_main head=$head_sha origin_main=$origin_main_sha"
+    exit 1
+  fi
+else
+  echo "status[origin_main]=pass"
+fi
+
+if [[ ! -f "$CLAIM_REGISTRY" ]]; then
+  echo "status[claim_registry]=fail"
+  echo "reason=missing_claim_registry path=$CLAIM_REGISTRY"
+  exit 2
+fi
+
+if [[ "$RUN_LIVE_GATES" == "1" ]]; then
+  run_live_step madaros-production-ready env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN \
+    bash "$ROOT_DIR/scripts/dev/madaros_readiness_status.sh" --no-audit --production-ready
+  run_live_step docs-registry bash "$ROOT_DIR/scripts/dev/check_docs_registry.sh"
+  run_live_step docs-consistency bash "$ROOT_DIR/scripts/dev/check_docs_consistency.sh"
+  run_live_step serious-language-claim-closure env -u SOUC_BIN -u SOUNIO_STDLIB_PATH \
+    bash "$ROOT_DIR/scripts/ci/serious_language_claim_closure_gate.sh"
+  write_live_tsv
+fi
+
+set +e
+python3 - "$CLAIM_REGISTRY" "$BLOCKER_TSV" "$SUMMARY_JSON" <<'PY'
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+registry = Path(sys.argv[1])
+blocker_tsv = Path(sys.argv[2])
+summary_json = Path(sys.argv[3])
+
+# Release-critical means the surface is part of a broad "production-ready
+# language/product" claim rather than a research/prototype support contract.
+# A surface may remain prototype in the repo, but then the broad release claim
+# must fail until the surface is closed or removed from the release contract.
+release_critical = {
+    "binary.source": "checked binary still depends on lean_single as source; modular source-swap parity is not closed",
+    "direct_driver": "large-surface direct-driver execution remains a maturity frontier",
+    "stdlib.surface": "broad stdlib callability is explicitly downgraded",
+    "tooling.package": "package manager has no public registry launch/support contract",
+    "tooling.editor": "formatter, REPL, and editor tooling are prototype surfaces",
+    "install": "installation is repo-artifact based, not a broad supported distribution path",
+    "website.docs": "docs are extensive but not yet filtered into a release-grade public support contract",
+}
+
+allowed_levels = {"stable", "validated_research"}
+allowed_closure = {"closed"}
+rows: dict[str, dict[str, str]] = {}
+
+with registry.open(newline="", encoding="utf-8") as handle:
+    reader = csv.DictReader(handle, delimiter="\t")
+    required = [
+        "claim_id",
+        "claim_level",
+        "closure_status",
+        "evidence_kind",
+        "evidence_ref",
+        "spec_refs",
+        "public_wording",
+    ]
+    if reader.fieldnames != required:
+        raise SystemExit(f"claim registry header mismatch: {reader.fieldnames!r}")
+    for row in reader:
+        rows[row["claim_id"]] = {key: (value or "").strip() for key, value in row.items()}
+
+blockers: list[dict[str, str]] = []
+for claim_id, reason in release_critical.items():
+    row = rows.get(claim_id)
+    if row is None:
+        blockers.append({
+            "claim_id": claim_id,
+            "claim_level": "missing",
+            "closure_status": "missing",
+            "evidence_ref": "-",
+            "reason": f"release-critical claim missing from registry: {reason}",
+        })
+        continue
+    if row["claim_level"] not in allowed_levels or row["closure_status"] not in allowed_closure:
+        blockers.append({
+            "claim_id": claim_id,
+            "claim_level": row["claim_level"],
+            "closure_status": row["closure_status"],
+            "evidence_ref": row["evidence_ref"],
+            "reason": reason,
+        })
+
+blocker_tsv.parent.mkdir(parents=True, exist_ok=True)
+with blocker_tsv.open("w", encoding="utf-8", newline="") as handle:
+    writer = csv.DictWriter(
+        handle,
+        fieldnames=["claim_id", "claim_level", "closure_status", "evidence_ref", "reason"],
+        delimiter="\t",
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(blockers)
+
+summary = {
+    "schema": "sounio.release_production_readiness.v1",
+    "status": "pass" if not blockers else "fail",
+    "release_critical_claims": sorted(release_critical),
+    "blocker_count": len(blockers),
+    "blocker_tsv": str(blocker_tsv),
+    "blockers": blockers,
+}
+summary_json.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+print(f"release_critical_claims={len(release_critical)}")
+print(f"blockers={len(blockers)}")
+for blocker in blockers:
+    print(
+        "blocker "
+        f"claim_id={blocker['claim_id']} "
+        f"level={blocker['claim_level']} "
+        f"closure={blocker['closure_status']} "
+        f"evidence={blocker['evidence_ref']} "
+        f"reason={blocker['reason']}"
+    )
+
+if blockers:
+    raise SystemExit(1)
+PY
+classification_rc=$?
+set -e
+
+live_failures=0
+for status in "${LIVE_STATUSES[@]}"; do
+  if [[ "$status" != "pass" ]]; then
+    live_failures=$((live_failures + 1))
+  fi
+done
+
+echo "live_gates=$LIVE_TSV"
+echo "summary=$SUMMARY_JSON"
+if [[ "$live_failures" -gt 0 || "$classification_rc" -ne 0 ]]; then
+  echo "status[release_production_ready]=fail"
+  echo "reason=live_failures_${live_failures}_classification_rc_${classification_rc}"
+  exit 1
+fi
+
+echo "status[release_production_ready]=pass"


### PR DESCRIPTION
## Summary
- add `scripts/ci/sounio_release_production_readiness_gate.sh` for a broader Sounio release-production-ready contract beyond Madaros readiness
- add `docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md` with current status, release-critical blockers, and safe wording
- sync docs governance metadata for the new audit document

## Current verdict
- Madaros production-ready: pass
- Broad Sounio release production-ready: fail by current evidence

## Evidence
- `bash -n scripts/ci/sounio_release_production_readiness_gate.sh`
- `scripts/dev/check_docs_registry.sh`
- `scripts/dev/check_docs_consistency.sh`
- `git diff --check`
- `scripts/ci/sounio_release_production_readiness_gate.sh --skip-live-gates --allow-non-main` -> fails with 7 release-critical blockers
- `scripts/ci/sounio_release_production_readiness_gate.sh --allow-non-main` -> Madaros/docs pass; serious-language claim closure fails; 7 release-critical blockers reported

## Blockers surfaced by the new gate
- `binary.source`
- `direct_driver`
- `stdlib.surface`
- `tooling.package`
- `tooling.editor`
- `install`
- `website.docs`

## LLM offload
- Not invoked: governance/status gate and repo-internal release-readiness documentation only; no math claims, clinical-pathway code, or external-facing submission artifact.