### PR TITLE
test(governance): lock worktree-audit --check OUT-path invariant

### DIFF
--- a/docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md
+++ b/docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.worktree-audit-check-leak-2026-06-23
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.worktree-audit-check-leak-2026-06-23
+-->
+
 # Worktree Audit `--check` Output Leak
 
 Date: 2026-06-23

--- a/docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md
+++ b/docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md
@@ -1,0 +1,67 @@
+# Worktree Audit `--check` Output Leak
+
+Date: 2026-06-23
+Status: closed (root cause already fixed; residue cleaned; regression test added)
+Evidence level: E3 (gate-bound — `scripts/dev/check_audit_out_invariant.sh`)
+
+## Symptom
+
+An untracked 69 KB file literally named `--check` appeared at the repository root
+(`/workspace/sounio/--check`). Its contents were the full TSV worktree inventory
+produced by `scripts/dev/worktree_branch_audit.sh` (header
+`path\tbranch\thead\tupstream\tstate\tdirty_count\t...`), with none of the
+script's stdout markers (`audit_tsv=`, `total=`, `critical_dirty_worktrees:`).
+
+The presence of only the TSV body (no stdout) proves the file was the script's
+`$OUT` target, not a stdout redirect.
+
+## Root cause
+
+Commit `bc0513783~1` parsed the output path positionally:
+
+```sh
+OUT="${1:-}"
+```
+
+so an invocation of the form
+
+```sh
+scripts/dev/worktree_branch_audit.sh --check
+```
+
+silently assigned `OUT="--check"`. Because `$OUT` is a relative path resolved
+against the repo root (the script does `cd "$ROOT_DIR"`), the inventory was
+written to `./--check`.
+
+## Fix (already landed)
+
+`bc0513783` (2026-06-21, on `origin/main`) replaced the positional capture with
+a real argument loop:
+
+- `--check)` sets `CHECK_MODE=1`,
+- `-*` rejects unknown leading-dash tokens,
+- `*)` is the only path that can set `OUT`.
+
+With this parser there is no way for a leading-dash token to become `OUT`, so
+the script cannot regenerate `./--check`. The single live caller
+(`scripts/dev/madaros_readiness_status.sh`) already uses the safe form
+`worktree_branch_audit.sh --check "$audit_out"` with a `/tmp` mktemp path.
+
+## Residue + action
+
+The `./--check` file was stale output from a run against the pre-fix version and
+was never cleaned up. It has been removed from the working tree. No tracked file
+depended on it (legitimate inventories are written under `/tmp/...tsv`).
+
+## Regression guard
+
+`scripts/dev/check_audit_out_invariant.sh` locks the invariant:
+
+1. the vulnerable `OUT="${1:-}"` form must not return;
+2. `--check` must remain a dedicated flag case;
+3. unknown `-*` tokens must be rejected;
+4. an unknown flag exits non-zero before any worktree scanning (fast, no full
+   audit run, not flaky against global worktree state).
+
+Verified: the guard passes on `origin/main` and fails when run against
+`bc0513783~1:scripts/dev/worktree_branch_audit.sh`.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 741
-- Repo-backed topics: 591
+- Total governed topics: 742
+- Repo-backed topics: 592
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 104
-- Authority count `repo_only`: 449
+- Authority count `repo_only`: 450
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 453 topics
+- A2: 454 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -162,6 +162,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.windows-assert-a64-parity.str-eq | repo_only | docs/audit/windows_assert_a64_parity/STR_EQ.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.windows-assert-a64-parity.str-slice | repo_only | docs/audit/windows_assert_a64_parity/STR_SLICE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.windows-assert-a64-parity.trig-builtins | repo_only | docs/audit/windows_assert_a64_parity/TRIG_BUILTINS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.worktree-audit-check-leak-2026-06-23 | repo_only | docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.worktree-branch-governance-audit-2026-06-20 | repo_only | docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.font-licenses | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/FONT_LICENSES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.brand.sounio-brand-pack-v4-complete.00-readme.readme | repo_only | docs/brand/Sounio_Brand_Pack_v4_COMPLETE/00_README/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3198,6 +3198,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.worktree-audit-check-leak-2026-06-23",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.worktree-branch-governance-audit-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/WORKTREE_BRANCH_GOVERNANCE_AUDIT_2026-06-20.md",

--- a/scripts/dev/check_audit_out_invariant.sh
+++ b/scripts/dev/check_audit_out_invariant.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+AUDIT="scripts/dev/worktree_branch_audit.sh"
+
+if [[ ! -f "$AUDIT" ]]; then
+  echo "missing audit script: $AUDIT" >&2
+  exit 1
+fi
+
+failed=0
+
+# Invariant 1: the vulnerable pre-bc0513783 form must not return. That version
+# parsed the output path as OUT="${1:-}", so an invocation like
+# `worktree_branch_audit.sh --check` silently set OUT="--check" and wrote the
+# TSV inventory into ./--check at the repo root.
+if grep -nE 'OUT="\$\{1:-\}"' "$AUDIT" >/dev/null; then
+  echo "regression: $AUDIT uses OUT=\"\${1:-}\" which swallows flags as the output path"
+  failed=1
+fi
+
+# Invariant 2: --check must be intercepted as a real flag (CHECK_MODE), not
+# reachable as a positional OUT path. A dedicated case guarantees the token
+# can never become the write target.
+if ! grep -nE '^[[:space:]]*--check\)' "$AUDIT" >/dev/null; then
+  echo "regression: $AUDIT has no dedicated --check) flag case"
+  failed=1
+fi
+
+# Invariant 3: unknown leading-dash tokens must be rejected so they cannot
+# become OUT through some future positional fallback.
+if ! grep -nE '^[[:space:]]*-\*\)' "$AUDIT" >/dev/null; then
+  echo "regression: $AUDIT has no -*) unknown-option rejection"
+  failed=1
+fi
+
+# Dynamic check (fast, no full audit run): an unknown flag must exit non-zero
+# before any worktree scanning happens. This proves the -*) branch is live.
+if bash "$AUDIT" --bogus-audit-invariant >/dev/null 2>&1; then
+  echo "regression: $AUDIT accepted an unknown --bogus flag"
+  failed=1
+fi
+
+# Dynamic check (fast): --help must succeed without writing any TSV and without
+# leaving a ./--check residue behind.
+bash "$AUDIT" --help >/dev/null 2>&1 || {
+  echo "regression: $AUDIT --help did not exit 0"
+  failed=1
+}
+if [[ -e "$ROOT_DIR/--check" ]]; then
+  echo "regression: $AUDIT left a ./--check residue at the repo root"
+  failed=1
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "audit OUT-path invariant check passed"


### PR DESCRIPTION
## What

Pre-`bc0513783`, `scripts/dev/worktree_branch_audit.sh` parsed its output path positionally as `OUT="${1:-}"`, so an invocation like `... --check` silently set `OUT=--check` and wrote the full TSV worktree inventory into `./--check` at the repo root. That root cause is **already fixed** on `origin/main` (`--check` is now a real flag; `-*` is rejected). This PR prevents the class of bug from regressing and cleans up the leftover evidence.

## Changes (additive, disjoint write-set)

- `scripts/dev/check_audit_out_invariant.sh` — fast, deterministic regression guard (no full-audit run; not flaky against global worktree state):
  1. the vulnerable `OUT="${1:-}"` form must not return;
  2. `--check` must remain a dedicated flag case;
  3. unknown `-*` tokens must be rejected;
  4. an unknown flag exits non-zero before any worktree scanning; `--help` exits 0 with no `./--check` residue.
- `docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md` — root-cause + status note.

## Verification

- Guard **passes** on `origin/main`.
- Guard **fails** against `bc0513783~1:scripts/dev/worktree_branch_audit.sh` (proven both ways).
- Ran the audit as the leak happened (`worktree_branch_audit.sh --check`, no OUT): TSV went to `/tmp/sounio-worktree-audit.*.tsv`; **no `./--check` created**.

## Notes

- No live bug remains in the script, so no dead-code guards were added (claim-discipline).
- Stale `./--check` residue (untracked) was removed from the primary worktree; not part of this commit since it was never tracked.
- LLM-offload: not-required (no math/clinical/external-facing artifacts). No blockers.