### PR TITLE
fix(check): carry Option<T> payload type so match-bound deref typechecks (E005 half of #326)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1061,7 +1061,12 @@ fn checker_lower_single_wrapper_arg_mut(c: *mut Checker, opt: Option<Box<TypeExp
 // this *mut helper exactly as checker_lower_single_wrapper_arg_mut does.
 fn checker_lower_named_type_with_args_mut(c: *mut Checker, path: AstPath, type_args: Option<Box<TypeExprList> >) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     let name = checker_copy_string_list_to_name(path.segments)
-    if name_matches_str3(name, 66, 111, 120) {
+    // Carry the single type argument in .inner for Box<T> and Option<T>. Box was
+    // already handled (so `*b` on a Box<T> param types as T); Option<T> needs the
+    // same so that `match opt { Some(x) => ... }` can bind x to the payload type
+    // T (the PatEnum binder reads scrut_ty.inner). "Box"=66,111,120 ;
+    // "Option"=79,112,116,105,111,110. Other named types defer unchanged.
+    if name_matches_str3(name, 66, 111, 120) || name_matches_str6(name, 79, 112, 116, 105, 111, 110) {
         match type_args {
             Some(args) => {
                 match (*args).tail {
@@ -5685,7 +5690,15 @@ fn checker_bind_pattern_inplace(c: *mut Checker, pat: Pattern, scrut_ty: TypeEnt
         let lin = checker_is_linear_type_inplace(c, scrut_ty)
         (*c).borrows = (*c).borrows.track(pat.name, lin)
     } else if pat.kind == PatternKind::PatEnum {
-        checker_bind_pattern_list_inplace(c, pat.sub_patterns, scrut_ty)
+        // Single-payload variant (e.g. Some(x) on Option<T>/Box<T>): the scrutinee
+        // carries the payload type in .inner (Box/Option lowering). Bind the payload
+        // sub-pattern to that inner type so (*x) / (*x).field type correctly. Fall
+        // back to scrut_ty when there is no inner (other enums — positional variant
+        // field types are not otherwise tracked).
+        match scrut_ty.inner {
+            Some(inner_box) => checker_bind_pattern_list_inplace(c, pat.sub_patterns, *inner_box)
+            None => checker_bind_pattern_list_inplace(c, pat.sub_patterns, scrut_ty)
+        }
     } else if pat.kind == PatternKind::PatStruct {
         checker_bind_struct_pat_fields_inplace(c, pat.pat_fields, scrut_ty)
     } else if pat.kind == PatternKind::PatTuple {


### PR DESCRIPTION
## What

Closes the **typecheck (E005) half** of the match-bound Box-deref family (#326). `match opt { Some(b) => (*b).field }` on an `Option<Box<T>>` was rejected at typecheck with `E005` ("this unary operation is not defined for the type").

## Root cause (full chain, from #326)

- `(*b)` → `unary_result_type(OpDeref, …)` returns `ty_error()` because the operand's `.inner` is `None` (`compat.sio:948`).
- `.inner` is `None` because `b` (from `Some(b)`) was bound to the **whole scrutinee** type, not the payload: the `PatEnum` binder forwarded `scrut_ty` to positional sub-patterns (`check.sio`, with an in-source admission *"variant field types not tracked yet, use scrut_ty as fallback"*).
- And even if it looked, `Option<Box<Cls>>` lowered to a bare `ty_named("Option")` with `.inner = None` — the generic arg was dropped (only `Box<T>` was special-cased to carry its arg).

## Fix (two minimal changes, mirroring the existing `Box<T>` precedent)

1. **`checker_lower_named_type_with_args_mut`** — carry the single type arg in `.inner` for `Option<T>` as well as `Box<T>`. `types_compatible` compares only the name for `TyNamed` (`compat.sio:64`), so Option compatibility is unchanged.
2. **`checker_bind_pattern_inplace` `PatEnum`** — when the scrutinee carries an inner payload type, bind the payload sub-pattern to `*scrut_ty.inner` (so `Some(b)` on `Option<Box<Cls>>` binds `b: Box<Cls>`); fall back to `scrut_ty` otherwise.

## Verification (CI-built Madaros, exact branch build)

- **E005 fixed**: `B` (param-fn match-deref) and `D` (helper-return match-deref) no longer reject at typecheck.
- **No regression**: `madaros_full_gate`, `madaros_enum_gate`, `madaros_loop_gate` all **PASS** on the build; ontology role checks (E157/E158/E159) still reject; positive `Option<i64>` matching now types the payload correctly (`Some(7)=>x` → 7, `Some(5)=>x+3` → 8).
- Out of scope: the **codegen half** — `let n = Some(Box::new(..)); match n { Some(b) => (*b) }` still fails with `native-v2 bridge compilation failed` (now the single remaining failure mode for all three forms; lives in the IR/bridge lowering the `codex/madaros-boxnew-*` work owns).

This consolidates the family from two failure modes (E005 + bridge) to one (bridge), and removes a real type-checker bug — payload binding now produces the correct type even for plain `Option<T>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)