### PR TITLE
chore(gitignore): ignore patch/merge leftovers (*.orig, *.rej)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ artifacts/diagnostic/
 *.temp
 *.bak
 *.backup
+*.orig
+*.rej
 
 # Environment
 .env


### PR DESCRIPTION
## What

Adds the two common artifact patterns that were genuinely uncovered in `.gitignore`:

- `*.orig`
- `*.rej`

(patch(1) / merge-tool leftovers). `*.swp`, `*.swo`, `.DS_Store`, `*.tmp`, `*.temp`, `*.bak`, `*~` were already covered.

## Note on scope
An earlier survey reported "5 gaps" — that was a faulty regex (`\*swp` instead of `\*\.swp`). After direct verification, only `*.orig` and `*.rej` are actually missing.

## Verification
- `git check-ignore -v test.orig foo.rej` matches the new lines.
- `git ls-files | grep -E "\.(orig|rej)$"` is empty → no tracked file affected (no `git rm --cached` needed).
- Existing patterns (`*.bak`, `*.tmp`) still match.

Non-breaking; LLM-offload not required; no blockers.