### PR TITLE
fix(scripts): reject leading-dash output paths in build scripts

### DIFF
--- a/scripts/ci/build_modular_madaros.sh
+++ b/scripts/ci/build_modular_madaros.sh
@@ -22,6 +22,10 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 OUT="${1:-$ROOT_DIR/artifacts/self-hosted/madaros}"
+if [[ "$OUT" == -* ]]; then
+    echo "error: output path must not start with '-': $OUT" >&2
+    exit 2
+fi
 
 # Resolve seed compiler. The seed MUST be the lean_single bootstrap ELF — never
 # the bin/souc wrapper (a #!-script that now routes to Madaros). Seeding from the

--- a/scripts/dev/check_outpath_leading_dash.sh
+++ b/scripts/dev/check_outpath_leading_dash.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# Pattern-B output-path scripts: the first positional is the OUTPUT path
+# (OUT="${1:-default}"), with no flag grammar. A stray leading-dash token
+# (e.g. an accidental --help) must be rejected rather than silently used as
+# the write target — otherwise the script writes a dash-named file (or a
+# binary) into the workspace. See docs/audit/WORKTREE_AUDIT_CHECK_LEAK_2026-06-23.md
+# for the sibling Pattern-A guard.
+OUTPATH_LD_SCRIPTS=(
+  scripts/ontology/build_dontology_ffi_importer.sh
+  scripts/ci/build_modular_madaros.sh
+)
+# NOTE: scripts/ci/build_native_souc.sh has the same shape but is a serialized
+# high-risk file (AGENTS.md never-edit-in-parallel list) and is intentionally
+# not edited/covered here; it is tracked as a finding for the compiler lane.
+
+BOGUS="-bogus-outpath-ld"
+failed=0
+
+check_script() {
+  local script="$1"
+
+  if [[ ! -f "$script" ]]; then
+    echo "missing script: $script" >&2
+    failed=1
+    return
+  fi
+
+  if ! grep -qE 'OUT="\$\{1:-' "$script"; then
+    echo "regression: $script no longer uses the OUT=\"\${1:-...}\" positional-output form"
+    failed=1
+  fi
+
+  # Only run the dynamic check when the guard is actually present, so a
+  # regressed script is never invoked with a dash arg (which would itself
+  # trigger the build-leak this test guards against).
+  if ! grep -qE '== -\*' "$script"; then
+    echo "regression: $script has no leading-dash output-path guard"
+    failed=1
+    return
+  fi
+
+  # Dynamic (fast): a leading-dash first arg must exit non-zero during arg
+  # handling, before any build/compile work, and must not leave a residue.
+  if bash "$script" "$BOGUS" >/dev/null 2>&1; then
+    echo "regression: $script accepted a leading-dash output path"
+    failed=1
+  fi
+  if [[ -e "$ROOT_DIR/$BOGUS" ]]; then
+    echo "regression: $script wrote a dash-named residue ($BOGUS)"
+    failed=1
+    rm -f -- "$ROOT_DIR/$BOGUS"
+  fi
+}
+
+for script in "${OUTPATH_LD_SCRIPTS[@]}"; do
+  check_script "$script"
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "output-path leading-dash check passed (${#OUTPATH_LD_SCRIPTS[@]} scripts)"

--- a/scripts/ontology/build_dontology_ffi_importer.sh
+++ b/scripts/ontology/build_dontology_ffi_importer.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT="${1:-/tmp/sounio-dontology-ffi-importer}"
+if [[ "$OUT" == -* ]]; then
+  echo "error: output path must not start with '-': $OUT" >&2
+  exit 2
+fi
 
 cc -std=c11 -Wall -Wextra -Werror -O2 \
   "$ROOT_DIR/scripts/ontology/dontology_ffi_importer.c" \


### PR DESCRIPTION
## What

Closes the remaining leak class from #401/#403. Two build scripts take the output path as the first positional (`OUT="${1:-default}"`), so a stray flag-like token (e.g. an accidental `--help`) was silently used as the write target — potentially writing a dash-named file or a compiler binary into the workspace.

## Changes
- `scripts/ci/build_modular_madaros.sh`: reject `OUT` starting with `-` (exit 2) before `resolve_seed`/`mkdir`/build.
- `scripts/ontology/build_dontology_ffi_importer.sh`: same guard before the `cc` invocation.
- `scripts/dev/check_outpath_leading_dash.sh` (new, Pattern-B regression test): for each covered script, asserts the positional-output form + the guard statically, then dynamically invokes it with a leading-dash arg expecting a non-zero exit and no residue.

## Safety
- The guard is **reachable** and **behavior-preserving** — no legitimate caller passes a leading-dash output path. Verified: `build_modular_madaros.sh /tmp/valid-out` still proceeds normally.
- The test gates its dynamic check on the static guard being present, so a regressed script is **never** invoked with a dash arg (no build-leak triggered by the test itself).

## Verification
- `bash scripts/dev/check_outpath_leading_dash.sh` → pass (2 scripts).
- Stripping the guard from `build_modular_madaros.sh` → test fails on the static check and skips the dynamic run (no residue, no build).

## Reported (not edited — serialized)
`scripts/ci/build_native_souc.sh` has the same `OUT="${1:-/tmp/souc-native}"` shape with no guard but is on the AGENTS.md never-edit-in-parallel list. Tracked as a finding for the compiler lane to guard independently.

Non-breaking; LLM-offload not required; no blockers.