### PR TITLE
ci: wire output-path invariant guards into the Contracts job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
           bash scripts/ci/heuristic_firewall_gate.sh
       - name: Worktree governance gate
         run: bash scripts/dev/worktree_branch_audit.sh --check
+      - name: Output-path invariants
+        run: bash scripts/dev/check_outpath_invariant.sh
+      - name: Output-path leading-dash guard
+        run: bash scripts/dev/check_outpath_leading_dash.sh
       - name: Claude operational contract
         run: bash scripts/ci/claude_operational_contract_gate.sh
       - name: Ontology validation


### PR DESCRIPTION
## What

Wires the two regression guards added in #403 and #412 into the CI `Contracts` job so they enforce on every PR/push instead of sitting dormant:

- `scripts/dev/check_outpath_invariant.sh` — Pattern A: `--check`/`-*` flag handling for the `[--check] [OUT.tsv]` family (`worktree_branch_audit.sh`, `madaros_pr_resolution_queue.sh`).
- `scripts/dev/check_outpath_leading_dash.sh` — Pattern B: leading-dash output-path rejection for positional-output build scripts (`build_modular_madaros.sh`, `build_dontology_ffi_importer.sh`).

Together they prevent the `bc0513783` leak class (a flag-like token silently becoming the OUT write target) from recurring in any covered script.

## Change
Two new steps in `contracts` job, placed right after the existing "Worktree governance gate" step. Exact-match of the surrounding step format (no parser/structural change).

## Notes
- This edits serialized `.github/workflows/ci.yml` (AGENTS.md never-edit-in-parallel list) on an isolated branch — quick merge, rebase on conflict.
- `scripts/ci/build_native_souc.sh` (same leak shape, also serialized) is NOT covered by Pattern-B here; tracked as a finding in #412 for the compiler lane.
- If the YAML were malformed the whole workflow would fail to start; `Contracts` running these steps confirms validity.

Non-breaking; LLM-offload not required; no blockers.