### PR TITLE
fix(scripts): reject leading-dash output path in build_native_souc

### DIFF
--- a/scripts/ci/build_native_souc.sh
+++ b/scripts/ci/build_native_souc.sh
@@ -98,6 +98,10 @@ bootstrap_via_boot4_chain() {
 
 LEAN="$ROOT_DIR/self-hosted/compiler/lean_single.sio"
 OUT="${1:-/tmp/souc-native}"
+if [[ "$OUT" == -* ]]; then
+    echo "error: output path must not start with '-': $OUT" >&2
+    exit 2
+fi
 FORCE_SOURCE_BOOTSTRAP="${SOUNIO_FORCE_SOURCE_BOOTSTRAP:-0}"
 LEAN_BYTES="$(portable_size "$LEAN")"
 BOOT4_DIRECT_SRC_CAP=1048576

--- a/scripts/dev/check_outpath_leading_dash.sh
+++ b/scripts/dev/check_outpath_leading_dash.sh
@@ -13,10 +13,8 @@ cd "$ROOT_DIR"
 OUTPATH_LD_SCRIPTS=(
   scripts/ontology/build_dontology_ffi_importer.sh
   scripts/ci/build_modular_madaros.sh
+  scripts/ci/build_native_souc.sh
 )
-# NOTE: scripts/ci/build_native_souc.sh has the same shape but is a serialized
-# high-risk file (AGENTS.md never-edit-in-parallel list) and is intentionally
-# not edited/covered here; it is tracked as a finding for the compiler lane.
 
 BOGUS="-bogus-outpath-ld"
 failed=0


### PR DESCRIPTION
## What

Closes the last reported instance of the `bc0513783` leak class (tracked as a finding in #412).

`scripts/ci/build_native_souc.sh` took its output path as `OUT="${1:-/tmp/souc-native}"` with no guard, so a stray flag-like token (e.g. an accidental `--help`) would silently become the write target. Adds the same reachable Pattern-B guard as the other build scripts: exit 2 before any bootstrap/build work if `OUT` starts with `-`.

## Changes
- `scripts/ci/build_native_souc.sh`: 4-line guard right after the `OUT=` assignment, before any main-body use of `OUT`.
- `scripts/dev/check_outpath_leading_dash.sh`: add `build_native_souc.sh` to the covered set (now 3 scripts); drop the stale "not covered / finding" note.

## Safety
- Serialized file (`scripts/ci/build_native_souc.sh`, AGENTS.md never-edit-in-parallel list) — edited on an isolated branch.
- Guard is reachable and behavior-preserving: no legitimate caller passes a leading-dash output path. Verified the guard fires immediately on a `-bogus` arg (no build invoked).
- The CI **Native Self-Host** and **Source-Bootstrap Self-Host** jobs build via this script and serve as the real validation that legitimate paths still work.

## Verification
- `bash -n` on both files; `check_outpath_leading_dash.sh` → pass (3 scripts).

Non-breaking; LLM-offload not required; no blockers.