### PR TITLE
fix(madaros): impl methods work end-to-end (parser + checker + codegen)

### DIFF
--- a/docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md
+++ b/docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md
@@ -18,6 +18,7 @@ work end-to-end:
 | 1. Parser | `impl C { fn … }` SIGSEGV at parse | `parse_impl_item` called `parse_fn_item(false, false)` — the **bool `false` was passed for the `visibility: Visibility` struct param** (ABI mismatch; built only because the type error is a non-fatal warning) | pass `visibility_private()` |
 | 2. Checker | `obj.method()` → **E011** (method not found) | the `*mut` collect spine **no-op'd `impl`** (method sigs never registered) | add `checker_collect_impl_item_bridge` and wire `ItemImpl` into `checker_collect_item_inplace` (mirrors the existing check bridge) |
 | 3. Codegen | type-checks, then SIGSEGV at lowering | `lower_method_call_expr_ref` resolved the call by the **bare** method name, but impl methods are lowered as **mangled** free fns (`ir_mangle_method_name`) → call to a body-less fn | derive the receiver's struct type and look up the **mangled** name |
+| 3b. Receiver type | `self.method()` / `param.method()` SIGSEGV (layer-3 crash) | function **params were bound with an empty `struct_type`** (both the functional `lower_fn_params_ref` and the `*mut lowerer_lower_fn_params_mut`), so the receiver type was unknown for `self`/struct params → bare-name fallback | register each param's struct type at binding (`lower_param_struct_type_name`, unwrapping `&`/`&!`; `*mut` setter `lowerer_bind_local_struct_type_mut`) |
 
 Note layer 1's exit-139 was briefly confounded with ROOT 1's stack overflow (testing the
 raw binary without `ulimit`); with `ulimit -s unlimited` (which `bin/madaros` sets) the
@@ -35,16 +36,21 @@ layers separate cleanly.
 ## Verified (madaros built from this exact source)
 
 - `impl C { fn m() {} }` → `--check` OK (was SIGSEGV).
-- `c.five() → 5`; `c.get()/c.add() → 40 42`; `method1 (c.get()) → 42`;
+- Local receiver: `c.five() → 5`; `c.get()/c.add() → 40 42`; `method1 → 42`;
   nested `a.plus(a.val()) → 200`.
-- No regression in the non-method paths (changes are gated to impl/method/method-call);
-  free fns and enums still compile and run; madaros self-builds.
+- **`self.method()`** (sibling call `a.twice() → 42`) and **`param.method()`**
+  (`relay(x).get() → 99`) — both were SIGSEGV before the param-struct-type fix.
+- No regression: the param-struct-type change (the only broad one — it touches all params)
+  is **measured neutral** — identical 32/60 run-pass exit-0 on `madaros` with vs without it,
+  zero changed tests. The other three changes are gated to impl/method/method-call code
+  paths (unreachable from non-method programs). madaros self-builds.
 
 ## Honest scope
 
-- Receiver-type resolution in layer 3 handles the common **local-receiver** case
-  (`c.method()`, `self.method()` via `lookup_local_struct_type`); method calls on arbitrary
-  sub-expressions (e.g. `f().method()`) fall back to the bare name and are out of scope here.
+- Receiver-type resolution handles **local / `self` / struct-param** receivers
+  (via the now-registered param/local struct types). Method calls on arbitrary
+  sub-expression results (e.g. `f().method()`) fall back to the bare name and are out of
+  scope here.
 - Independent of (and composes with) the struct-field-index fix #413 — `self.<field>` on a
   by-ref receiver already worked; local struct-field reads still need #413.
 

--- a/docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md
+++ b/docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md
@@ -1,0 +1,53 @@
+# Madaros impl methods — working end-to-end (three-layer fix, 2026-06-23)
+
+*Branch:* `fix/madaros-impl-method-checker` (off `main`).
+*Result:* `obj.method()` now parses, type-checks, compiles, and runs correctly under Madaros.
+Refines/corrects `MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md` (which mis-attributed the
+crash to a checker by-value miscompile).
+
+## Summary
+
+Method support was broken at **three independent layers**, each masking the next. The
+triage's "checker by-value miscompile" hypothesis was wrong — instrument-and-observe
+(per-step tracing, the same method that cracked the struct-field bug) showed the first
+crash is in the **parser**, before the checker ever runs. Three small fixes make methods
+work end-to-end:
+
+| Layer | Symptom | Root | Fix |
+|---|---|---|---|
+| 1. Parser | `impl C { fn … }` SIGSEGV at parse | `parse_impl_item` called `parse_fn_item(false, false)` — the **bool `false` was passed for the `visibility: Visibility` struct param** (ABI mismatch; built only because the type error is a non-fatal warning) | pass `visibility_private()` |
+| 2. Checker | `obj.method()` → **E011** (method not found) | the `*mut` collect spine **no-op'd `impl`** (method sigs never registered) | add `checker_collect_impl_item_bridge` and wire `ItemImpl` into `checker_collect_item_inplace` (mirrors the existing check bridge) |
+| 3. Codegen | type-checks, then SIGSEGV at lowering | `lower_method_call_expr_ref` resolved the call by the **bare** method name, but impl methods are lowered as **mangled** free fns (`ir_mangle_method_name`) → call to a body-less fn | derive the receiver's struct type and look up the **mangled** name |
+
+Note layer 1's exit-139 was briefly confounded with ROOT 1's stack overflow (testing the
+raw binary without `ulimit`); with `ulimit -s unlimited` (which `bin/madaros` sets) the
+layers separate cleanly.
+
+## Files
+
+- `self-hosted/parser/items.sio` — `parse_fn_item(visibility_private(), false)` at the two
+  `(false, false)` sites (impl methods + study-block fns).
+- `self-hosted/check/check.sio` — `checker_collect_impl_item_bridge` + `ItemImpl` arm in
+  `checker_collect_item_inplace`.
+- `self-hosted/ir/lower.sio` — `lower_method_recv_type` helper + mangled call name in
+  `lower_method_call_expr_ref`.
+
+## Verified (madaros built from this exact source)
+
+- `impl C { fn m() {} }` → `--check` OK (was SIGSEGV).
+- `c.five() → 5`; `c.get()/c.add() → 40 42`; `method1 (c.get()) → 42`;
+  nested `a.plus(a.val()) → 200`.
+- No regression in the non-method paths (changes are gated to impl/method/method-call);
+  free fns and enums still compile and run; madaros self-builds.
+
+## Honest scope
+
+- Receiver-type resolution in layer 3 handles the common **local-receiver** case
+  (`c.method()`, `self.method()` via `lookup_local_struct_type`); method calls on arbitrary
+  sub-expressions (e.g. `f().method()`) fall back to the bare name and are out of scope here.
+- Independent of (and composes with) the struct-field-index fix #413 — `self.<field>` on a
+  by-ref receiver already worked; local struct-field reads still need #413.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; every claim backed by re-runnable
+`madaros compile/--check/run` commands and the per-step traces used to localise each layer.

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -2979,8 +2979,14 @@ fn checker_collect_item_inplace(c: *mut Checker, item: Item) with Mut, Panic, Di
         checker_collect_enum_def_inplace(c, item.name, item.enum_def, item.visibility, (*c).current_module)
     } else if item.kind == ItemKind::ItemUse {
         checker_collect_use_item_inplace(c, item)
+    } else if item.kind == ItemKind::ItemImpl {
+        // Collect impl method signatures so `obj.method()` resolves at call sites.
+        // Without this the *mut spine no-op'd impl, leaving methods unregistered (E011).
+        // Bridged to the by-value collect_impl_def (mirrors checker_check_impl_item_bridge);
+        // its ~8MB SRET frame stays isolated in the bridge leaf.
+        checker_collect_impl_item_bridge(c, item.impl_def)
     } else {
-        // ItemSession / impl / typealias / policy / … — not yet collected by the
+        // ItemSession / typealias / policy / … — not yet collected by the
         // *mut spine (no-op, same as before). *mut collectors pending.
     }
 }
@@ -3214,6 +3220,12 @@ fn checker_report_multitest_correction_required_inplace(c: *mut Checker, span: S
 // carry the frame at compile time even for impl-free programs like `fn main(){}`).
 fn checker_check_impl_item_bridge(c: *mut Checker, opt: Option<Box<ImplDef> >) with Mut, Panic, Div, Alloc, IO {
     checker_store_from_value(c, (*c).check_impl_item(opt))
+}
+
+// Dedicated leaf for the by-value collect_impl_def bridge (registers impl method
+// signatures). Same isolation rationale as the check bridge above.
+fn checker_collect_impl_item_bridge(c: *mut Checker, opt: Option<Box<ImplDef> >) with Mut, Panic, Div, Alloc, IO {
+    checker_store_from_value(c, (*c).collect_impl_def(opt))
 }
 
 fn checker_check_item_inplace(c: *mut Checker, item: Item) with Mut, Panic, Div, Alloc, IO {

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6828,7 +6828,27 @@ impl Lowerer {
         (lo3, dst)
     }
 
+    // Receiver struct type for a method call, when the receiver is a simple local
+    // (e.g. `c.method()` -> type of `c`). Used to mangle the call to the same name the
+    // impl method was registered under. Empty when the type can't be determined here.
+    fn lower_method_recv_type(self, left: &Option<Box<Expr>>) -> Name with Mut, Panic, Div, Alloc {
+        match *left {
+            Some(recv) => {
+                if (*recv).kind == ExprKind::ExprIdent {
+                    return self.lookup_local_struct_type((*recv).name)
+                }
+                ir_empty_name()
+            }
+            _ => ir_empty_name()
+        }
+    }
+
     fn lower_method_call_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        // Impl methods are lowered as mangled free functions (ir_mangle_method_name).
+        // A `recv.method()` call must resolve to that SAME mangled name; using the bare
+        // method name finds/creates a body-less fn -> codegen crash.
+        let recv_type = self.lower_method_recv_type(&e.left)
+        let call_name = if recv_type.len > 0 { ir_mangle_method_name(recv_type, e.name) } else { e.name }
         let pair_b = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_b.0
         let base_reg = pair_b.1
@@ -6837,7 +6857,7 @@ impl Lowerer {
         let arg_list: Option<Box<IrRegList>> = if pair_args.count <= 0 { None } else { Some(Box::new(pair_args.regs)) }
         let arg_count = pair_args.count
         let args2 = lo2.prepend_arg(base_reg, arg_list)
-        let pair_fn = lo2.find_or_add_fn_id(e.name)
+        let pair_fn = lo2.find_or_add_fn_id(call_name)
         let lo3 = pair_fn.0
         let fn_id = pair_fn.1
         let pair_call = lo3.ir_lower_prepend_validated_arg(fn_id, args2, arg_count + 1)
@@ -6847,7 +6867,7 @@ impl Lowerer {
         let pair_d = lo4.fresh_reg()
         let lo5 = pair_d.0
         let dst = pair_d.1
-        var call_instr_m = ir_call(dst, fn_id, e.name, final_args, final_argc)
+        var call_instr_m = ir_call(dst, fn_id, call_name, final_args, final_argc)
         if fn_id >= 0 && fn_id < (*lo5.module).fn_count {
             if (*lo5.module).functions[fn_id as usize].returns_float == 1 {
                 call_instr_m.imm_flags = IR_FLOAT_REG_MARKER_FLAG

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1536,6 +1536,27 @@ fn lowerer_bind_local_mut(
     }
 }
 
+// *mut analogue of bind_local_struct_type: record a local/param's struct type so
+// `recv.method()` and `recv.field` resolve the receiver type. Single-level store through
+// the Box (safe under the by-value-aggregate miscompile). No-op for non-struct types.
+fn lowerer_bind_local_struct_type_mut(
+    lo: &! Lowerer,
+    name: Name,
+    type_name: Name
+) with Mut, Alloc, Panic, Div {
+    if type_name.len <= 0 { return }
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).struct_types[i as usize] = type_name
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
+    }
+}
+
 fn lowerer_mark_local_global_mut(
     lo: &! Lowerer,
     name: Name,
@@ -1620,6 +1641,7 @@ fn lowerer_lower_fn_params_mut(
                 }
 
                 lowerer_bind_local_mut(lo, (*list).head.name, preg, (*list).head.is_self_mut)
+                lowerer_bind_local_struct_type_mut(lo, (*list).head.name, lower_param_struct_type_name(&(*list).head.ty))
                 if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
                     (*lo) = (*lo).bind_local_array_elem_float((*list).head.name)
                 }
@@ -1954,6 +1976,19 @@ fn lower_opt_type_named_name(opt: &Option<Box<TypeExpr>>) -> Name with Mut, Pani
         }
         None => ir_empty_name(),
     }
+}
+
+// Struct-type name of a parameter, unwrapping `&T` / `&!T`. Used so a method body's
+// `self.method()` (and `param.method()`) can resolve the receiver's type — params were
+// previously bound with an empty struct_type, so `self.other()` hit the body-less-fn crash.
+fn lower_param_struct_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
+    if (*ty).kind == TypeExprKind::TypeNamed {
+        return ir_path_first_name((*ty).path)
+    }
+    if (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut {
+        return lower_opt_type_named_name(&(*ty).inner)
+    }
+    ir_empty_name()
 }
 
 fn lower_name_wide_int_bits(n: Name) -> i64 with Panic, Div {
@@ -4543,7 +4578,7 @@ impl Lowerer {
                         locals.names[idx as usize] = (*list).head.name
                         locals.regs[idx as usize] = preg
                         locals.depths[idx as usize] = lo.scope_depth
-                        locals.struct_types[idx as usize] = ir_empty_name()
+                        locals.struct_types[idx as usize] = lower_param_struct_type_name(&(*list).head.ty)
                         locals.array_elem_float[idx as usize] = if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 1 } else { 0 }
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -870,7 +870,11 @@ impl Parser {
 
             if parser_peek(p) != TokenKind::RBrace && parser_peek(p) != TokenKind::Eof {
                 if parser_peek(p) == TokenKind::Fn {
-                    let pair2 = p.parse_fn_item(false, false)
+                    // First arg is `visibility: Visibility` (a struct), NOT a bool. Passing
+                    // `false` here was an ABI mismatch (bool bits read as a Visibility) that
+                    // corrupted the call and SIGSEGV'd on every impl method; it built only
+                    // because the type error is a non-fatal warning. Methods default private.
+                    let pair2 = p.parse_fn_item(visibility_private(), false)
                     p = pair2.0
                     let method = pair2.1
                     rev_methods_opt = Some(Box::new(ItemList { head: method, tail: rev_methods_opt }))
@@ -4003,7 +4007,8 @@ fn parse_study_item(p: Parser, visibility: Visibility) -> (Parser, Item) with Mu
         let entry_name = pa.current_name()
 
         if parser_peek(pa) == TokenKind::Fn {
-            let fn_pair = pa.parse_fn_item(false, false)
+            // visibility param is a Visibility struct, not a bool (see parse_impl_item).
+            let fn_pair = pa.parse_fn_item(visibility_private(), false)
             pa = fn_pair.0
         } else if entry_name.len == 10 && entry_name.buf[0] == 104 as i8 && entry_name.buf[9] == 115 as i8 {
             let hyp_pair = parse_study_hypothesis(pa)


### PR DESCRIPTION
## Make impl methods work end-to-end under Madaros

`obj.method()` was broken at **multiple independent layers**, each masking the next. Instrument-and-observe localization showed the triage's "checker by-value miscompile" guess was wrong — the first crash is in the **parser**.

| Layer | Symptom | Root | Fix |
|---|---|---|---|
| **Parser** | `impl C { fn … }` → SIGSEGV at parse | `parse_impl_item` passed the bool `false` for the **`visibility: Visibility` struct** param (ABI mismatch; built only because the type error is a non-fatal *warning*) | pass `visibility_private()` |
| **Checker** | `obj.method()` → **E011** | the `*mut` collect spine **no-op'd `impl`** → method sigs never registered | add `checker_collect_impl_item_bridge`, wire `ItemImpl` into `checker_collect_item_inplace` |
| **Codegen** | type-checks, then SIGSEGV | call resolved by the **bare** method name, but methods lower as **mangled** free fns → body-less fn | derive receiver type, look up the **mangled** name |
| **Receiver type** | `self.method()` / `param.method()` SIGSEGV | params bound with **empty `struct_type`** (both lowering spines) | register each param's struct type at binding (`lower_param_struct_type_name`, `*mut lowerer_bind_local_struct_type_mut`) |

### Verified (madaros built from this source; `ulimit -s unlimited` as `bin/madaros` sets)
- `impl C { fn m(){} }` → `--check` OK (was SIGSEGV)
- local: `c.five()→5`, `c.get()/c.add()→40 42`, `method1→42`, nested `a.plus(a.val())→200`
- **`self.method()`** (`a.twice()→42`) and **`param.method()`** (`relay(x).get()→99`) — both were SIGSEGV
- **No regression measured** for the one broad change (param struct-type binding): identical 32/60 run-pass exit-0 with vs without it, zero changed tests. The other three changes are gated to impl/method/method-call paths (unreachable from non-method programs). madaros self-builds.

### Scope
- Handles local / `self` / struct-param receivers. Method calls on arbitrary sub-expression results (`f().method()`) fall back to the bare name and are out of scope.
- Independent of #413 (struct-field-index); composes with it.

Detail: `docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md`. Closes another major Madaros codegen root toward Madaros-official.
