### PR TITLE
fix(madaros): zero-capture closures work end-to-end (step 1)

### DIFF
--- a/docs/audit/MADAROS_CLOSURES_STEP1_FIX_2026-06-24.md
+++ b/docs/audit/MADAROS_CLOSURES_STEP1_FIX_2026-06-24.md
@@ -1,0 +1,65 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-closures-step1-fix-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-closures-step1-fix-2026-06-24
+-->
+
+# Madaros zero-capture closures — working end-to-end (step 1, 2026-06-24)
+
+*Branch:* `wip/madaros-closures-step1` (off `main`). Resolves the closure triage
+(`MADAROS_CLOSURES_TRIAGE_2026-06-23.md`) **step 1**: `(|x| x)(n)` and `let f = |x| …; f(n)`
+now compile and run correctly. (Capture is step 2; still out of scope.)
+
+## Summary
+
+Closures were broken at five points, four of which are the **same systemic root**: the
+Madaros native codegen (the lean_single-built seed) drops/partials a store when its target
+is a **field-accessed Box dereferenced inline** (`(*lo.field).x = v` or
+`(*lo.field).arr[i] = v`). The working idiom everywhere else in the lowerer is to **extract
+the Box to a local first** (`var b = lo.field; (*b).x = v`), which `fresh_reg` and
+`lowerer_flush_current_func_mut` already use. The closure path did not.
+
+## The five fixes (all in `lower_closure_expr_ref` / `lower_call_expr_ref`)
+
+1. **Compile crash (let-bound):** the closure used the *functional* `find_or_add_fn_id`,
+   whose ADD path returns a 128 KB `IrFunction` by value (miscompiled) → switched to the
+   `*mut` `lowerer_find_or_add_fn_id_mut` (as regular calls do).
+2. **Inline callee:** `lower_call_expr_ref` resolved the callee by *name*; an inline closure
+   `(|x| x)(n)` has no name, so it fell through to `find_or_add_fn_id(empty)` → a body-less
+   call. Now an expression callee is lowered to a fn-ref reg + `ir_call_indirect`.
+3. **`current_func_loaded`:** the functional lowering reads param info from `lo.current_func`
+   only when `current_func_loaded` is true (else from the empty module placeholder); the
+   closure never set it. Now saved/set/restored around the closure body.
+4. **Param metadata dropped (extract-Box):** `(*lo.current_func).param_count = pc+1` (deref
+   of a field-accessed Box) was dropped → `param_count` stayed 0 → no parameter prologue →
+   SIGSEGV. Fixed by extracting the func Box to a local first (`var cf = lo.current_func;
+   (*cf).param_count = …`). Verified: the param is then passed (`f(7) → 7`).
+5. **Body instrs dropped (extract-Box):** the flush `(*lo.module).functions[id] = *func` (a
+   field-accessed-Box two-level store) was **partial** — `param_count` copied but the body
+   instr array did not, so the closure returned its parameter instead of the body result
+   (`|x| 99 → 7`). Fixed by extracting the module Box first, as
+   `lowerer_flush_current_func_mut` does.
+
+## Verified (madaros built from this source, `ulimit -s unlimited` as `bin/madaros` sets)
+
+- `(|x| x)(42) → 42`; `let f=|x| x; f(42) → 42`; `let f=|x| x+10; f(32) → 42`
+- `|x| 99 → 99`; `|x| x+100; f(23) → 123`; `|a,b| a*b+2; f(8,5) → 42`
+- two closures in one program: `f(10)+g(31) → 42`
+- **No regression:** identical 18/40 run-pass exit-0 vs the prebuilt main madaros (0
+  regressed); structs (`P{7,35}.a+.b → 42`), enums (`C::G → 2`), methods, fn-pointers, free
+  fns all still run. madaros self-builds.
+
+## Honest scope
+
+- **Zero-capture only.** Capturing closures (`|x| x + k`) are step 2 — the body still wipes
+  the enclosing locals (`empty_lower_local_stack()`); no free-variable analysis / environment
+  yet. The triage's step 2/3 remain.
+- The receiver/callee handling covers local + inline closures; `f().method()`-style call
+  chains are unchanged.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; every claim backed by re-runnable
+`madaros compile/run` probes and the staged param_count traces used to localise each store.

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -7612,11 +7612,16 @@ impl Lowerer {
         let saved_locals = lo.locals
         let saved_scope = lo.scope_depth
         let saved_loop = lo.loop_depth
+        let saved_loaded = lo.current_func_loaded
 
-        // 3. Switch to the closure function context
+        // 3. Switch to the closure function context. current_func_loaded MUST be true so
+        // the functional lowering (current_fn_validated_reg / param resolution) reads from
+        // lo.current_func — not the empty module placeholder, which is what zeroed
+        // param_count and produced a malformed closure body.
         lo.current_fn = closure_fn_id
         lo.current_func = Box::new(ir_empty_function())
         (*lo.current_func).name = closure_name
+        lo.current_func_loaded = true
         lo.locals = Box::new(empty_lower_local_stack())
         lo.scope_depth = 0
         lo.loop_depth = 0
@@ -7629,11 +7634,19 @@ impl Lowerer {
                     let preg_pair = lo.fresh_reg()
                     lo = preg_pair.0
                     let preg = preg_pair.1
-                    if (*lo.current_func).param_count < IR_MAX_PARAMS {
-                        let pc = (*lo.current_func).param_count
-                        (*lo.current_func).param_regs[pc as usize] = preg
-                        (*lo.current_func).param_count = pc + 1
+                    // Extract the current_func Box to a local before mutating: the direct
+                    // `(*lo.current_func).param_count = …` store (deref a field-accessed Box)
+                    // is dropped by the by-value-aggregate miscompile — the same reason
+                    // fresh_reg copies `lo.current_func` to a local first. Without this,
+                    // param_count stayed 0, the codegen emitted no parameter prologue, and
+                    // the closure SIGSEGV'd when called.
+                    var cf_box = lo.current_func
+                    if (*cf_box).param_count < IR_MAX_PARAMS {
+                        let pc = (*cf_box).param_count
+                        (*cf_box).param_regs[pc as usize] = preg
+                        (*cf_box).param_count = pc + 1
                     }
+                    lo.current_func = cf_box
                     lo = lo.bind_local((*plist).head.name, preg, false)
                     params = &(*plist).tail
                 }
@@ -7646,37 +7659,19 @@ impl Lowerer {
         lo = body_pair.0
         lo = lo.emit(ir_return(body_pair.1))
 
-        // Re-assert the param metadata on the final closure func. The functional body
-        // lowering copies the 128 KB IrFunction by value (`var func = *lo.current_func`),
-        // and the by-value-aggregate miscompile zeroes param_count/param_regs (reg_count
-        // survives only because the body re-grows it). Without this the codegen emits no
-        // parameter-load prologue and the closure crashes when called. Closure params are
-        // the first regs (0..pcount-1), allocated before the body.
-        var pcount: i64 = 0
-        var pc_cur: &Option<Box<ClosureParamList>> = &e.closure_params
-        while true {
-            match *pc_cur {
-                Some(pl) => {
-                    pcount = pcount + 1
-                    pc_cur = &(*pl).tail
-                }
-                _ => break
-            }
-        }
-        (*lo.current_func).param_count = pcount
-        var pri: i64 = 0
-        while pri < pcount {
-            (*lo.current_func).param_regs[pri as usize] = pri
-            pri = pri + 1
-        }
-
-        // 7. Flush the completed closure function back to the module — single-level store
-        // through the Box, avoiding a 25 MB by-value IrModule copy on the stack.
-        (*lo.module).functions[closure_fn_id as usize] = *lo.current_func
+        // 7. Flush the completed closure function back to the module. Extract the module
+        // Box to a local first (as lowerer_flush_current_func_mut does) — the direct
+        // `(*lo.module).functions[id] = …` store derefs a field-accessed Box and is
+        // dropped/partial under the by-value-aggregate miscompile, which lost the body
+        // instrs (the closure returned its param instead of the body's result).
+        var flush_mod_box = lo.module
+        (*flush_mod_box).functions[closure_fn_id as usize] = *lo.current_func
+        lo.module = flush_mod_box
 
         // 8. Restore the original function context
         lo.current_fn = saved_fn
         lo.current_func = saved_func
+        lo.current_func_loaded = saved_loaded
         lo.locals = saved_locals
         lo.scope_depth = saved_scope
         lo.loop_depth = saved_loop

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6681,6 +6681,28 @@ impl Lowerer {
         if self.contest_witness_kind_from_callee(callee_name) >= 0 {
             return self.lower_contest_witness_call(e.span, callee_name)
         }
+        // Inline expression callee (e.g. `(|x| x)(n)`): no resolvable name — lower the
+        // callee expression to a fn-ref reg and dispatch indirectly, rather than falling
+        // through to find_or_add_fn_id(empty) (which calls a body-less fn -> crash).
+        if callee_name.len <= 0 {
+            match *callee_opt_ref {
+                Some(_) => {
+                    let pair_cal = self.lower_opt_expr_ref(&e.left)
+                    let lo_cal = pair_cal.0
+                    let callee_reg = pair_cal.1
+                    let pair_args_x: LowerExprArgsResult = lo_cal.lower_expr_args_ref(&e.args)
+                    let lo_x = pair_args_x.lowerer
+                    let args_x: Option<Box<IrRegList>> = if pair_args_x.count <= 0 { None } else { Some(Box::new(pair_args_x.regs)) }
+                    let argc_x = pair_args_x.count
+                    let pair_dx = lo_x.fresh_reg()
+                    let lo_dx = pair_dx.0
+                    let dst_x = pair_dx.1
+                    let lo_cx = lo_dx.emit(ir_call_indirect(dst_x, callee_reg, args_x, argc_x))
+                    return (lo_cx, dst_x)
+                }
+                _ => {}
+            }
+        }
         let callee_local_reg = self.lookup_local(callee_name)
         if callee_local_reg >= 0 {
             let pair_args_i: LowerExprArgsResult = self.lower_expr_args_ref(&e.args)
@@ -7572,11 +7594,13 @@ impl Lowerer {
     // Sprint 228: Lambda-lift a closure expression into a synthetic top-level function.
     // Returns (Lowerer, fn_ref_reg) where fn_ref_reg holds the fn_id.
     fn lower_closure_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
-        // 1. Create a unique name and register the synthetic function
-        let closure_name = self.make_closure_name()
-        let pair_fn = self.find_or_add_fn_id(closure_name)
-        var lo = pair_fn.0
-        let closure_fn_id = pair_fn.1
+        var lo = self
+        // 1. Create a unique name and register the synthetic function. Use the *mut
+        // find_or_add (like regular calls): the functional find_or_add_fn_id ADD path
+        // builds + returns a 128 KB IrFunction by value, which the by-value-aggregate
+        // miscompile turned into a lowering SIGSEGV.
+        let closure_name = lo.make_closure_name()
+        let closure_fn_id = lowerer_find_or_add_fn_id_mut(&! lo, closure_name)
 
         if closure_fn_id < 0 {
             return lo.emit_unit()
@@ -7622,10 +7646,33 @@ impl Lowerer {
         lo = body_pair.0
         lo = lo.emit(ir_return(body_pair.1))
 
-        // 7. Flush the completed closure function back to the module
-        var module = *lo.module
-        module.functions[closure_fn_id as usize] = *lo.current_func
-        lo.module = Box::new(module)
+        // Re-assert the param metadata on the final closure func. The functional body
+        // lowering copies the 128 KB IrFunction by value (`var func = *lo.current_func`),
+        // and the by-value-aggregate miscompile zeroes param_count/param_regs (reg_count
+        // survives only because the body re-grows it). Without this the codegen emits no
+        // parameter-load prologue and the closure crashes when called. Closure params are
+        // the first regs (0..pcount-1), allocated before the body.
+        var pcount: i64 = 0
+        var pc_cur: &Option<Box<ClosureParamList>> = &e.closure_params
+        while true {
+            match *pc_cur {
+                Some(pl) => {
+                    pcount = pcount + 1
+                    pc_cur = &(*pl).tail
+                }
+                _ => break
+            }
+        }
+        (*lo.current_func).param_count = pcount
+        var pri: i64 = 0
+        while pri < pcount {
+            (*lo.current_func).param_regs[pri as usize] = pri
+            pri = pri + 1
+        }
+
+        // 7. Flush the completed closure function back to the module — single-level store
+        // through the Box, avoiding a 25 MB by-value IrModule copy on the stack.
+        (*lo.module).functions[closure_fn_id as usize] = *lo.current_func
 
         // 8. Restore the original function context
         lo.current_fn = saved_fn


### PR DESCRIPTION
## Zero-capture closures work end-to-end (step 1)

Resolves step 1 of the closure triage: `(|x| x)(n)` and `let f = |x| …; f(n)` now compile **and run correctly**. (Capture is step 2; out of scope.)

Closures were broken at five points, **four of which are the same systemic root**: the Madaros native codegen drops/partials a store whose target is a **field-accessed Box dereferenced inline** (`(*lo.field).x = v`). The working idiom (already used by `fresh_reg` / `lowerer_flush_current_func_mut`) is to **extract the Box to a local first**. The closure path didn't.

### The five fixes (`lower_closure_expr_ref` / `lower_call_expr_ref`)
1. **let-bound compile crash** → use `*mut lowerer_find_or_add_fn_id_mut` (the functional ADD path returns a 128 KB `IrFunction` by value, miscompiled).
2. **inline callee** → lower an expression callee to a fn-ref + `ir_call_indirect`, not `find_or_add_fn_id(empty)`.
3. **`current_func_loaded=true`** around the body (param resolution reads `lo.current_func`, not the empty module placeholder).
4. **param metadata** → extract the func Box first; the inline `(*lo.current_func).param_count = …` store was dropped (→ no prologue → SIGSEGV).
5. **flush** → extract the module Box first; the inline two-level store was *partial*, dropping the body instrs (closure returned its parameter, e.g. `|x| 99 → 7`).

### Verified
- `(|x| x)(42)→42`, `let f=|x| x; f(42)→42`, `|x| 99→99`, `|x| x+100; f(23)→123`, `|a,b| a*b+2; f(8,5)→42`, two closures `f(10)+g(31)→42`
- **No regression**: identical 18/40 run-pass exit-0 vs prebuilt main madaros (0 regressed); structs (`→42`), enums (`→2`), methods, fn-pointers, free fns all run; madaros self-builds.

### Scope
Zero-capture only. Capturing closures (`|x| x+k`) are **step 2** — the body still wipes enclosing locals; no free-var analysis/environment yet.

Detail: `docs/audit/MADAROS_CLOSURES_STEP1_FIX_2026-06-24.md`.
