### PR TITLE
feat(madaros): capturing closures (closures step 2)

### DIFF
--- a/docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md
+++ b/docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md
@@ -1,0 +1,77 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-closures-step2-capture-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-closures-step2-capture-2026-06-24
+-->
+
+# Madaros capturing closures — working (closures step 2, 2026-06-24)
+
+*Branch off `main` (with zero-capture closures #418). Resolves step 2 of the closure
+triage: `let k = …; let f = |x| x + k; f(…)` now captures `k` correctly.*
+
+## Approach — extra leading params + call-site injection (no heap closure object)
+
+A capturing closure that is **directly bound and called within the same function** does not
+need a first-class runtime closure object. The synthetic closure fn takes the captured
+values as **leading params**, and the captured enclosing registers are **injected at the
+direct call site**. The closure value therefore never enters the unified bare-fn-ref
+representation, so **#418 zero-capture closures and fn-pointer interop are untouched**, and
+no new aggregate-store sites are introduced (dodging the by-value-aggregate miscompile).
+
+### Pieces (all in `self-hosted/ir/lower.sio`)
+1. **Free-variable scan** (`scan_captures_opt`/`scan_captures_expr`, methods): recursively
+   walk the closure body BEFORE wiping locals; an ident that resolves via `self.lookup_local`
+   and is not a closure param is a capture. (Method form uses `self` for the enclosing
+   scope — see the parser note below.)
+2. **Leading capture params**: in `lower_closure_expr_ref`, bind each captured name to a
+   leading synthetic-fn param (reusing the extract-Box-first param binding from #418), then
+   the lambda's own params.
+3. **Capture table** keyed by synthetic fn_id (`ClosureCapTable` + `record_closure_caps` /
+   `find_closure_cap_idx` methods) storing the captured **enclosing** regs.
+4. **Binding side-channel**: `pending_closure_fn_id` (set by the closure lowering, consumed
+   by the let-binding) + a `closure_fn_id` slot on each local (`bind_local_closure_fn_id`).
+5. **Call-site injection**: in `lower_call_expr_ref`, a call of a capturing-closure local
+   emits a **direct** `ir_call(synthetic_fn, [captured_regs…, arg_regs…])` (IrCall relocs by
+   fn_id; up to 6 reg args + stack spill).
+6. **Escaping guard**: a capturing-closure local used as a **value** (passed to a fn,
+   returned, aliased) — i.e. reaching the ident-as-value lowering rather than the callee
+   path — is a **loud compile error**, not a silent wrong result.
+
+## Verified (madaros built from this source, `ulimit -s unlimited`)
+- Headline `let k=7; \|x\| x+k; f(5) → 12`; capture-only `let k=100; \|x\| k; f(99) → 100`.
+- Multi-capture `let a=10;let b=2; \|x\| x+a+b; f(30) → 42`; multi-call `\|x\| x+k (k=5);
+  f(1)+f(2) → 13`.
+- **#418 no-regression**: `(\|x\| x)(42) → 42`, zero-capture `callit(f) → 42`, `let f=add1;
+  f(41) → 42`; structs/enums/methods/fn-pointers compose.
+- **Escaping guard**: `callit(\|x\| x+k)` now emits *"capturing closure cannot be used as a
+  value (escaping closures are not yet supported)"* — previously a silent wrong `21`.
+- No-regression sweep: identical **26/50** run-pass exit-0 vs prebuilt main (0 regressed);
+  madaros self-builds.
+
+## Honest scope
+- **Captured `let` values, read at call time.** A captured `var` mutated between the
+  closure's creation and its call would diverge (call-time read) — out of scope; use a
+  `let` snapshot. Up to 8 captures; up to 6 total (caps+args) in registers, rest spill.
+- **Direct call only.** Escaping capturing closures (passed/returned/stored) are a compile
+  error by design — the next increment would give them a heap closure object (fn-ptr + env)
+  using this same free-var analysis.
+- The closure body scan handles `left/right/else/args` sub-expressions; block-bodied
+  closures with captures inside `{ … }` statements are not yet scanned.
+
+## Parser/checker notes (workarounds, not bugs introduced)
+- The parser rejects `&(*field_box)` (a shared ref of a deref of a **field-accessed** box) —
+  `&!(*local_box)` is fine. So the scan and table lookups are **methods** using `self`
+  rather than free functions taking `&LowerLocalStack` / `&(*self.closure_caps)`.
+- One **non-fatal** checker diagnostic remains (`expected &[struct;256], got &![struct;256]`)
+  on the boxed `ClosureCapTable.entries` access — a `&`/`&!`-kind false positive. The
+  emitted code is correct (every test passes, 0 regressions, self-build); extracting the
+  table to a local would risk the by-value-aggregate copy miscompile, so the direct box
+  access is intentional.
+
+## AI disclosure
+Implementation by AI agent (Claude) under human direction, on advisor guidance to use the
+extra-params scheme over a heap closure object. Every claim backed by a re-runnable
+`madaros compile/run` probe.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 768
-- Repo-backed topics: 618
+- Total governed topics: 769
+- Repo-backed topics: 619
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 105
-- Authority count `repo_only`: 475
+- Authority count `repo_only`: 476
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 479 topics
+- A2: 480 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -120,6 +120,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-closures-step1-fix-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP1_FIX_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-closures-step2-capture-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2232,6 +2232,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-closures-step2-capture-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md",

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -20,6 +20,9 @@ struct LowerLocalStack {
     is_global: [i64; 4096],
     // 0=other 1=int 2=float; used by println dispatch to avoid routing i64/f64 vars through print_str
     scalar_kind: [i64; 4096],
+    // -1 = not a capturing closure; otherwise the synthetic closure fn_id whose captures
+    // must be injected when this local is called (closures step 2).
+    closure_fn_id: [i64; 4096],
     count: i64,
 }
 
@@ -36,8 +39,69 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         global_bss_sizes: [0; 4096],
         is_global: [0; 4096],
         scalar_kind: [0; 4096],
+        closure_fn_id: [-1; 4096],
         count: 0,
     }
+}
+
+// --- Capturing-closure support (closures step 2) ---
+// A capturing closure is lowered as a synthetic fn whose LEADING params are the captured
+// values, followed by the lambda's own params. The closure is never given a first-class
+// runtime value (it stays out of the bare fn-ref representation, so #418 zero-capture
+// closures + fn-pointer interop are untouched); instead the captured enclosing regs are
+// injected at a direct call site. All stores use the extract-Box-first / copy-modify-
+// writeback idiom to dodge the by-value-aggregate-store miscompile.
+struct CaptureList {
+    names: [Name; 8],
+    regs: [i64; 8],
+    count: i64,
+}
+fn empty_capture_list() -> CaptureList {
+    CaptureList { names: [ir_empty_name(); 8], regs: [IR_INVALID_REG; 8], count: 0 }
+}
+fn capture_list_add(caps: CaptureList, name: Name, reg: i64) -> CaptureList with Mut, Panic, Div {
+    var c = caps
+    var i: i64 = 0
+    while i < c.count {
+        if ir_name_eq(c.names[i as usize], name) { return c }
+        i = i + 1
+    }
+    if c.count < 8 {
+        let idx = c.count
+        c.names[idx as usize] = name
+        c.regs[idx as usize] = reg
+        c.count = idx + 1
+    }
+    c
+}
+
+struct ClosureCapEntry {
+    fn_id: i64,
+    cap_count: i64,
+    caps: [i64; 8],
+}
+struct ClosureCapTable {
+    entries: [ClosureCapEntry; 256],
+    count: i64,
+}
+fn empty_closure_cap_table() -> ClosureCapTable {
+    ClosureCapTable {
+        entries: [ClosureCapEntry { fn_id: -1, cap_count: 0, caps: [IR_INVALID_REG; 8] }; 256],
+        count: 0,
+    }
+}
+fn lower_name_in_closure_params(params: &Option<Box<ClosureParamList>>, name: Name) -> bool with Mut, Panic, Div {
+    var cur = params
+    while true {
+        match *cur {
+            Some(pl) => {
+                if ir_name_eq((*pl).head.name, name) { return true }
+                cur = &(*pl).tail
+            }
+            _ => break
+        }
+    }
+    false
 }
 
 struct LowerLoopLabels {
@@ -74,6 +138,11 @@ struct Lowerer {
     debug_mode: bool,
     // Sprint 44: probe-mode lowering skips heavyweight epistemic metadata lookup.
     probe_mode: bool,
+    // Closures step 2: captured-reg table keyed by synthetic closure fn_id, and a
+    // side-channel set by lower_closure_expr_ref and consumed by the let-binding so the
+    // bound local knows it is a capturing closure.
+    closure_caps: Box<ClosureCapTable>,
+    pending_closure_fn_id: i64,
 }
 
 struct IrPreparedCallArgs {
@@ -179,6 +248,8 @@ fn lowerer_new() -> Lowerer with Alloc {
         array_elem_float_reg_count: 0,
         debug_mode: false,
         probe_mode: false,
+        closure_caps: Box::new(empty_closure_cap_table()),
+        pending_closure_fn_id: -1,
     }
 }
 
@@ -3073,6 +3144,33 @@ impl Lowerer {
         lo
     }
 
+    // Mark a local as a capturing closure bound to synthetic fn `fn_id` (closures step 2).
+    fn bind_local_closure_fn_id(self, name: Name, fn_id: i64) -> Lowerer with Mut, Alloc, Panic, Div {
+        var lo = self
+        var stk = *lo.locals
+        var i = stk.count - 1
+        while i >= 0 {
+            if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
+                stk.closure_fn_id[i as usize] = fn_id
+                lo.locals = Box::new(stk)
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
+    fn lookup_local_closure_fn_id(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).closure_fn_id[i as usize]
+            }
+            i = i - 1
+        }
+        -1
+    }
+
     fn bind_local_wide_type(self, name: Name, bits: i64, signed: i64) -> Lowerer with Mut, Alloc, Panic, Div {
         var lo = self
         if bits <= 64 { return lo }
@@ -5323,6 +5421,12 @@ impl Lowerer {
         var lo = pair.0
         let reg = pair.1
         lo = lo.bind_local(s.name, reg, is_mut)
+        // Closures step 2: if the RHS was a capturing closure, mark this local so a later
+        // `name(args)` call injects the captured regs (direct call to the synthetic fn).
+        if lo.pending_closure_fn_id >= 0 {
+            lo = lo.bind_local_closure_fn_id(s.name, lo.pending_closure_fn_id)
+            lo.pending_closure_fn_id = -1
+        }
         if lower_opt_type_is_array_of_f64(&s.ty) {
             lo = lo.bind_local_array_elem_float(s.name)
         } else {
@@ -6705,6 +6809,30 @@ impl Lowerer {
         }
         let callee_local_reg = self.lookup_local(callee_name)
         if callee_local_reg >= 0 {
+            // Capturing closure (closures step 2): direct-call the synthetic fn with
+            // [captured_regs..., args...]. IrCall relocs by fn_id, so the name is unused.
+            let ccap_fn = self.lookup_local_closure_fn_id(callee_name)
+            if ccap_fn >= 0 {
+                let pair_args_c: LowerExprArgsResult = self.lower_expr_args_ref(&e.args)
+                let lo_c = pair_args_c.lowerer
+                var arglist_c: Option<Box<IrRegList>> = if pair_args_c.count <= 0 { None } else { Some(Box::new(pair_args_c.regs)) }
+                var total_c = pair_args_c.count
+                let cidx = lo_c.find_closure_cap_idx(ccap_fn)
+                if cidx >= 0 {
+                    let ccount = (*lo_c.closure_caps).entries[cidx as usize].cap_count
+                    var jc = ccount - 1
+                    while jc >= 0 {
+                        arglist_c = ir_reg_list_prepend((*lo_c.closure_caps).entries[cidx as usize].caps[jc as usize], arglist_c)
+                        jc = jc - 1
+                    }
+                    total_c = total_c + ccount
+                }
+                let pair_dc = lo_c.fresh_reg()
+                let lo_dc = pair_dc.0
+                let dst_c = pair_dc.1
+                let lo_cc = lo_dc.emit(ir_call(dst_c, ccap_fn, ir_empty_name(), arglist_c, total_c))
+                return (lo_cc, dst_c)
+            }
             let pair_args_i: LowerExprArgsResult = self.lower_expr_args_ref(&e.args)
             let lo_i = pair_args_i.lowerer
             let args_i: Option<Box<IrRegList>> = if pair_args_i.count <= 0 { None } else { Some(Box::new(pair_args_i.regs)) }
@@ -7407,6 +7535,16 @@ impl Lowerer {
             }
             let src = self.lookup_local(e.name)
             if src >= 0 {
+                // Closures step 2: a capturing closure used as a VALUE (passed to a fn,
+                // returned, aliased) would lose its captures — the synthetic fn has leading
+                // capture params the receiver can't fill — yielding a silent wrong result.
+                // Reject loudly instead. (Direct calls are handled in lower_call_expr_ref
+                // before reaching here, so this only fires for non-callee uses.)
+                if self.lookup_local_closure_fn_id(e.name) >= 0 {
+                    print("error: capturing closure cannot be used as a value (escaping closures are not yet supported); only a direct call of the closure is allowed\n")
+                    let loe = self.report_error()
+                    return (loe, src)
+                }
                 (self, src)
             } else {
                 let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, e.name)
@@ -7593,6 +7731,83 @@ impl Lowerer {
 
     // Sprint 228: Lambda-lift a closure expression into a synthetic top-level function.
     // Returns (Lowerer, fn_ref_reg) where fn_ref_reg holds the fn_id.
+    // Recursive free-variable scan (closures step 2): collect idents in `body` that resolve
+    // as enclosing locals and are not closure params (= captures). Self-recursive; uses
+    // self.lookup_local for the enclosing scope (no &LowerLocalStack arg).
+    fn scan_captures_expr(self, body: &Expr, params: &Option<Box<ClosureParamList>>, caps: CaptureList) -> CaptureList with Mut, Panic, Div, Alloc {
+        var c = caps
+        if (*body).kind == ExprKind::ExprIdent {
+            let nm = (*body).name
+            if !lower_name_in_closure_params(params, nm) {
+                let r = self.lookup_local(nm)
+                if r >= 0 { c = capture_list_add(c, nm, r) }
+            }
+            return c
+        }
+        match (*body).left {
+            Some(l) => { c = self.scan_captures_expr(&(*l), params, c) }
+            _ => {}
+        }
+        match (*body).right {
+            Some(r) => { c = self.scan_captures_expr(&(*r), params, c) }
+            _ => {}
+        }
+        match (*body).else_expr {
+            Some(eo) => { c = self.scan_captures_expr(&(*eo), params, c) }
+            _ => {}
+        }
+        var cur = &(*body).args
+        while true {
+            match *cur {
+                Some(el) => {
+                    c = self.scan_captures_expr(&(*el).head, params, c)
+                    cur = &(*el).tail
+                }
+                _ => break
+            }
+        }
+        c
+    }
+    fn scan_captures_opt(self, body: &Option<Box<Expr>>, params: &Option<Box<ClosureParamList>>, caps: CaptureList) -> CaptureList with Mut, Panic, Div, Alloc {
+        match *body {
+            Some(b) => { self.scan_captures_expr(&(*b), params, caps) }
+            _ => { caps }
+        }
+    }
+
+    // Index of the closure-capture entry for `fn_id` (-1 if none). Method form avoids
+    // passing &(*self.closure_caps) (ref of a deref of a field-accessed Box), which the
+    // parser rejects.
+    fn find_closure_cap_idx(self, fn_id: i64) -> i64 with Mut, Panic, Div, Alloc {
+        var i: i64 = 0
+        while i < (*self.closure_caps).count {
+            if (*self.closure_caps).entries[i as usize].fn_id == fn_id { return i }
+            i = i + 1
+        }
+        -1
+    }
+
+    // Record a capturing closure's captured enclosing regs, keyed by its synthetic fn_id.
+    // Copy-modify-writeback on the whole table (like bind_local_struct_type) — no
+    // &!ClosureCapTable free-function param.
+    fn record_closure_caps(self, fn_id: i64, caps: CaptureList) -> Lowerer with Mut, Panic, Div, Alloc {
+        var lo = self
+        var tbl = *lo.closure_caps
+        if tbl.count < 256 {
+            let idx = tbl.count
+            var e = ClosureCapEntry { fn_id: fn_id, cap_count: caps.count, caps: [IR_INVALID_REG; 8] }
+            var i: i64 = 0
+            while i < caps.count {
+                e.caps[i as usize] = caps.regs[i as usize]
+                i = i + 1
+            }
+            tbl.entries[idx as usize] = e
+            tbl.count = idx + 1
+            lo.closure_caps = Box::new(tbl)
+        }
+        lo
+    }
+
     fn lower_closure_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         var lo = self
         // 1. Create a unique name and register the synthetic function. Use the *mut
@@ -7614,6 +7829,12 @@ impl Lowerer {
         let saved_loop = lo.loop_depth
         let saved_loaded = lo.current_func_loaded
 
+        // 2b. Scan the closure body for captured free variables (idents bound in the
+        // enclosing scope, not lambda params) BEFORE wiping locals. Captures become LEADING
+        // params on the synthetic fn and are injected at the (direct) call site.
+        var captures = empty_capture_list()
+        captures = lo.scan_captures_opt(&e.closure_body, &e.closure_params, captures)
+
         // 3. Switch to the closure function context. current_func_loaded MUST be true so
         // the functional lowering (current_fn_validated_reg / param resolution) reads from
         // lo.current_func — not the empty module placeholder, which is what zeroed
@@ -7625,6 +7846,25 @@ impl Lowerer {
         lo.locals = Box::new(empty_lower_local_stack())
         lo.scope_depth = 0
         lo.loop_depth = 0
+
+        // 3b. Bind captured variables as LEADING params of the synthetic fn, so the body's
+        // free `k` resolves to a param (not 0). The captured enclosing regs themselves are
+        // injected at the call site; here we only allocate param regs + bind the names.
+        var ci: i64 = 0
+        while ci < captures.count {
+            let cap_pair = lo.fresh_reg()
+            lo = cap_pair.0
+            let cap_preg = cap_pair.1
+            var cf_box_cap = lo.current_func
+            if (*cf_box_cap).param_count < IR_MAX_PARAMS {
+                let pcc = (*cf_box_cap).param_count
+                (*cf_box_cap).param_regs[pcc as usize] = cap_preg
+                (*cf_box_cap).param_count = pcc + 1
+            }
+            lo.current_func = cf_box_cap
+            lo = lo.bind_local(captures.names[ci as usize], cap_preg, false)
+            ci = ci + 1
+        }
 
         // 4. Set up closure parameters from ClosureParamList
         var params: &Option<Box<ClosureParamList>> = &e.closure_params
@@ -7675,6 +7915,14 @@ impl Lowerer {
         lo.locals = saved_locals
         lo.scope_depth = saved_scope
         lo.loop_depth = saved_loop
+
+        // 8b. For a capturing closure, record the captured ENCLOSING regs keyed by fn_id and
+        // flag the pending closure so the let-binding marks its local. (Zero-capture closures
+        // stay bare fn-refs — unchanged from #418.) Extract the Box to a local first.
+        if captures.count > 0 {
+            lo = lo.record_closure_caps(closure_fn_id, captures)
+            lo.pending_closure_fn_id = closure_fn_id
+        }
 
         // 9. In the original function, emit IrLoadFnRef to return the fn_id
         let ref_pair = lo.fresh_reg()


### PR DESCRIPTION
## Capturing closures (closures step 2)

`let k = …; let f = |x| x + k; f(…)` now **captures `k` correctly** — previously the captured variable silently resolved to `0`.

### Approach — extra leading params + call-site injection (advisor-guided)
A capturing closure that is **directly bound and called in the same function** doesn't need a heap closure object. Its captures become **leading params** on the synthetic fn, injected at the **direct** call site. The closure value never enters the unified bare-fn-ref representation, so **#418 zero-capture closures + fn-pointer interop are untouched**, and **no new aggregate-store sites** are added (dodging the by-value-aggregate miscompile).

### Pieces (`self-hosted/ir/lower.sio`)
- Recursive **free-variable scan** (methods, `self.lookup_local`) before wiping locals
- **Leading capture params** (extract-Box-first binding)
- **`ClosureCapTable`** keyed by synthetic fn_id + `pending_closure_fn_id` side-channel + per-local `closure_fn_id`
- **Call-site injection**: direct `ir_call(fn, [caps…, args…])`
- **Escaping guard**: a capturing closure used as a *value* (passed/returned/aliased) is a **loud compile error**, not a silent wrong result

### Verified
- `|x| x+k; f(5)→12`, `|x| k→100`, `|x| x+a+b; f(30)→42`, `f(1)+f(2)→13`
- **#418 no-regression**: inline/zero-cap/fn-ptr all `→42`; structs/enums/methods compose
- **Escaping**: `callit(|x| x+k)` now errors loudly (was silent `21`)
- 26/50 run-pass = prebuilt main (**0 regressed**); madaros self-builds

### Scope
Immutable-`let` captures, read at call time; direct call only (escaping → compile error, a future heap-closure increment would lift this); up to 8 captures. One **non-fatal** checker `&`/`&!` false-positive remains on the boxed table access — codegen is correct (all tests + self-build pass).

Detail: `docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md`.
