### PR TITLE
feat(madaros): raw reference codegen (&T/&!T deref, address-of, *p=val)

### DIFF
--- a/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
+++ b/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
@@ -34,44 +34,43 @@ needed a new store op.
 Aliasing works because native_v2 round-trips every temp through its rbp-relative slot, so
 `&n` (the slot address) and a later read of `n` refer to the same memory.
 
-## Escape safety — second-class references, enforced for the DIRECT forms (not fully sound)
+## Escape safety — second-class references, enforced (all measured routes caught)
 
-References are treated as second-class: pass them to functions and read/write through them,
-but do not return or store them. The escape analysis (E091) now covers **store sites** in
-addition to return sites, but enforcement is **provenance/value-type based, not full
-lifetime inference** — sound for the direct reference forms, with **measured gaps** for
-references hidden inside aggregate values and for non-direct return tails. Read the table.
-
-The store-site check (in `checker_check_assign_stmt_inplace`) rejects assigning into a struct
-field, array element, or through a pointer when the value is a frame-local reference
-(provenance) **or** its type is a reference (`TyRef`/`TyRefMut`, which catches a stored ref
-*parameter* — the interproc case).
+References are second-class: pass them to functions and read/write through them, but they may
+not be returned or stored. The escape analysis (E091) covers **return sites and store sites**,
+including references hidden inside aggregates and yielded from `if`/`match`/block tails. Every
+measured escape route is a hard compile error (no ELF), not a dangling pointer. The two
+mechanisms:
+- **Stores** (`checker_check_assign_stmt_inplace`): reject assigning into a struct field, array
+  element, or through a pointer when the value **transitively contains a reference**
+  (`checker_type_has_ref`: a ref, slice, array-of-ref, or struct with a ref field, recursively)
+  **or** is a frame-local reference by provenance. The type clause catches a stored ref
+  *parameter* (interproc) and references buried in nested structs.
+- **Returns / value tails** (`checker_expr_provenance`): a frame-local reference yielded
+  directly, through a struct literal, or via an `if`/`match`/block **tail** expression.
 
 | Escape route | Status (measured) |
 |---|---|
-| `return &x` (direct) | **E091** (return site, #397) |
+| `return &x` / `return r` (direct) | **E091** |
+| `return` via `if`/`match`/block tail yielding `&local` | **E091** |
 | `h.p = &x` / `arr[i] = &x` / `*pp = &x` | **E091, no ELF** |
-| interproc: `&x` → fn that stores its ref param | **E091, no ELF** (value-type clause) |
-| store/return `H{ p: &local }` (aggregate of a **local** ref) | **E091** (struct-literal provenance taint) |
-| **store `H{ p: r }` where `r` is a ref PARAM** | ❌ **NOT caught — can silently dangle** |
-| **`return …` via an `if`/block tail** that yields `&local` | ❌ **NOT caught** (E091's if/block-tail deferral) |
+| interproc: `&x` → fn that stores its ref param | **E091, no ELF** |
+| store `H{ p: &local }` / `H{ p: <ref param> }` (aggregate) | **E091, no ELF** |
+| store a nested `Outer{ Inner{ p: r } }` | **E091, no ELF** |
+| no over-rejection: `rd(&n)*p`, `inc(&!n)`, `(*p).a`, **return a param ref** | compile + run / OK |
 
-## Honest scope / known gaps (measured, not assumed)
-- **Aggregate-embedded parameter reference, then stored** (`fn f(out:&!H, r:&i64){ (*out) =
-  H{p:r} }`): the stored value's type is the struct (not `TyRef`) and its provenance is
-  first-class (the embedded ref is a parameter), so neither clause fires → **silent dangling**.
-  Closing it needs structural type analysis (a value whose type transitively contains a
-  reference) or disallowing reference-typed struct fields outright.
-- **`if`/block-tail returns** of a local reference are not caught — `checker_expr_provenance`
-  does not recurse into `if`/block tail expressions (a pre-existing E091 deferral). Direct
-  `return &local` and `return r` are caught.
-- Conservative second-class rule otherwise: it rejects *all* direct reference stores, so a
-  hypothetical safe store of a longer-lived reference is also rejected (sound-direction, not
-  complete). A reference stored into a bare `ident` target is not separately checked.
+## Honest scope
+- Enforcement is **provenance + structural-type** based, not full lifetime inference, so it is
+  conservative: it rejects *all* stores of a reference-containing value (the second-class
+  rule), including the hypothetical safe store of a longer-lived reference. Sound direction,
+  not complete.
+- `checker_type_has_ref` recursion is depth-bounded (16) and treats an unregistered named type
+  as ref-free; tuple element types are not walked (a tuple literal embedding a reference
+  loud-fails earlier as **E005**, so it is not a silent hole).
+- A reference stored into a bare `ident` target is not separately checked, but a local
+  `let r = &x` only escapes when `r` is later returned or stored (both covered), and Sounio
+  has no first-class global reference variables.
 - Multi-level refs (`&&T`) and references to temporaries are not addressed.
-
-The honest one-line model: **direct reference store/return/interproc escapes are caught;
-references smuggled through aggregate values or `if`/block-tail returns are not yet.**
 
 ## Verified (madaros from this source, `ulimit -s unlimited`)
 - Functionality: `rd(&n)*p`→42, `(*p).a` of `&P`→42, `mutref *p=*p+1`→42 (alias write-back).

--- a/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
+++ b/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
@@ -34,38 +34,44 @@ needed a new store op.
 Aliasing works because native_v2 round-trips every temp through its rbp-relative slot, so
 `&n` (the slot address) and a later read of `n` refer to the same memory.
 
-## Escape safety — second-class references, enforced at compile time
+## Escape safety — second-class references, enforced for the DIRECT forms (not fully sound)
 
-References are **second-class**: pass them to functions and read/write through them, but they
-may **not be returned or stored**. The checker's escape analysis (E091) now enforces this at
-**both return sites and store sites**, so every measured escape route is a hard compile error
-(no ELF), not a dangling pointer. The store-site check (in `checker_check_assign_stmt_inplace`)
-rejects assigning a reference into a struct field, an array element, or through a pointer,
-when either the value is a frame-local reference (binary provenance) **or** the value's type
-is a reference (`TyRef`/`TyRefMut`) — the latter covers a stored *reference parameter*, i.e.
-the interproc case.
+References are treated as second-class: pass them to functions and read/write through them,
+but do not return or store them. The escape analysis (E091) now covers **store sites** in
+addition to return sites, but enforcement is **provenance/value-type based, not full
+lifetime inference** — sound for the direct reference forms, with **measured gaps** for
+references hidden inside aggregate values and for non-direct return tails. Read the table.
 
-| Escape route | Before | Now |
-|---|---|---|
-| `return &x` | E091 (return site, #397) | E091 |
-| `h.p = &x` (field store) | silent / printed warning | **E091, no ELF** |
-| `arr[i] = &x` (array store) | silently dangled | **E091, no ELF** |
-| `*pp = &x` (store through deref) | silently dangled | **E091, no ELF** |
-| `&x` → fn that stores its ref param (interproc) | compiled, crashed | **E091, no ELF** |
+The store-site check (in `checker_check_assign_stmt_inplace`) rejects assigning into a struct
+field, array element, or through a pointer when the value is a frame-local reference
+(provenance) **or** its type is a reference (`TyRef`/`TyRefMut`, which catches a stored ref
+*parameter* — the interproc case).
 
-The intended, sound use — passing a reference to a function and reading/mutating through it
-within the callee — is unaffected.
+| Escape route | Status (measured) |
+|---|---|
+| `return &x` (direct) | **E091** (return site, #397) |
+| `h.p = &x` / `arr[i] = &x` / `*pp = &x` | **E091, no ELF** |
+| interproc: `&x` → fn that stores its ref param | **E091, no ELF** (value-type clause) |
+| store/return `H{ p: &local }` (aggregate of a **local** ref) | **E091** (struct-literal provenance taint) |
+| **store `H{ p: r }` where `r` is a ref PARAM** | ❌ **NOT caught — can silently dangle** |
+| **`return …` via an `if`/block tail** that yields `&local` | ❌ **NOT caught** (E091's if/block-tail deferral) |
 
-## Honest scope
-- Enforcement is by **value type / provenance at the assignment**, not full lifetime
-  inference: it conservatively rejects *all* reference stores (the second-class rule), so a
-  hypothetical safe pattern like storing a reference to a longer-lived global is also
-  rejected. This is sound (never a dangling ref), not complete.
-- Store-site check covers field/index/deref assignment targets. A reference stored into a
-  bare `ident` target is not separately checked, but a *local* `let r = &x` only escapes when
-  `r` is itself later returned or stored (both covered), and Sounio has no first-class global
-  reference variables.
+## Honest scope / known gaps (measured, not assumed)
+- **Aggregate-embedded parameter reference, then stored** (`fn f(out:&!H, r:&i64){ (*out) =
+  H{p:r} }`): the stored value's type is the struct (not `TyRef`) and its provenance is
+  first-class (the embedded ref is a parameter), so neither clause fires → **silent dangling**.
+  Closing it needs structural type analysis (a value whose type transitively contains a
+  reference) or disallowing reference-typed struct fields outright.
+- **`if`/block-tail returns** of a local reference are not caught — `checker_expr_provenance`
+  does not recurse into `if`/block tail expressions (a pre-existing E091 deferral). Direct
+  `return &local` and `return r` are caught.
+- Conservative second-class rule otherwise: it rejects *all* direct reference stores, so a
+  hypothetical safe store of a longer-lived reference is also rejected (sound-direction, not
+  complete). A reference stored into a bare `ident` target is not separately checked.
 - Multi-level refs (`&&T`) and references to temporaries are not addressed.
+
+The honest one-line model: **direct reference store/return/interproc escapes are caught;
+references smuggled through aggregate values or `if`/block-tail returns are not yet.**
 
 ## Verified (madaros from this source, `ulimit -s unlimited`)
 - Functionality: `rd(&n)*p`→42, `(*p).a` of `&P`→42, `mutref *p=*p+1`→42 (alias write-back).

--- a/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
+++ b/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
@@ -34,38 +34,46 @@ needed a new store op.
 Aliasing works because native_v2 round-trips every temp through its rbp-relative slot, so
 `&n` (the slot address) and a later read of `n` refer to the same memory.
 
-## Escape safety — MEASURED, and weak (read this before relying on it)
+## Escape safety — second-class references, enforced at compile time
 
-References here are effectively **second-class with weak enforcement**. The only sound,
-enforced guarantee is no-return; **store-escapes are largely unguarded and can silently
-dangle.** Measured behaviour of address-of-a-local flowing into storage:
+References are **second-class**: pass them to functions and read/write through them, but they
+may **not be returned or stored**. The checker's escape analysis (E091) now enforces this at
+**both return sites and store sites**, so every measured escape route is a hard compile error
+(no ELF), not a dangling pointer. The store-site check (in `checker_check_assign_stmt_inplace`)
+rejects assigning a reference into a struct field, an array element, or through a pointer,
+when either the value is a frame-local reference (binary provenance) **or** the value's type
+is a reference (`TyRef`/`TyRefMut`) — the latter covers a stored *reference parameter*, i.e.
+the interproc case.
 
-| Escape route | Observed |
-|---|---|
-| `return &x` | **rejected by E091** (checker, on `main` via #397) — sound |
-| `h.p = &x` (direct field store) | prints an `error:` **but still emits an exit-0 ELF** (madaros leniency) — *loud, not blocked* |
-| `arr[i] = &x` (array element store) | **compiles and runs — silent dangling** (reads a dead slot) |
-| `*pp = &x` (store address through a deref) | **compiles and runs — silent dangling** |
-| `&x` passed to a fn that stores it (interproc) | compiles, **crashes at runtime** (undefined) |
+| Escape route | Before | Now |
+|---|---|---|
+| `return &x` | E091 (return site, #397) | E091 |
+| `h.p = &x` (field store) | silent / printed warning | **E091, no ELF** |
+| `arr[i] = &x` (array store) | silently dangled | **E091, no ELF** |
+| `*pp = &x` (store through deref) | silently dangled | **E091, no ELF** |
+| `&x` → fn that stores its ref param (interproc) | compiled, crashed | **E091, no ELF** |
 
-So: E091 enforces no-return; the lowering guard catches only the *direct* `obj.field = &x`
-form and only as a printed warning; **all other store-escape routes are unguarded** and
-range from silent-dangling to crash. The safe, intended use is **passing a reference
-directly to a function and reading/writing through it within the callee's lifetime** — that
-is sound (the referent outlives the call).
+The intended, sound use — passing a reference to a function and reading/mutating through it
+within the callee — is unaffected.
 
-## Honest scope / known gaps
-- The proper fix for store-escapes is to extend the escape analysis (E091) to **store sites**
-  (provenance check on field/index/deref assignments and across calls), or to enforce true
-  second-class references (no reference may be stored at all). Neither is done here.
-- Reference fields in structs and arrays-of-references are mechanically possible but **not
-  escape-safe** — see the table.
+## Honest scope
+- Enforcement is by **value type / provenance at the assignment**, not full lifetime
+  inference: it conservatively rejects *all* reference stores (the second-class rule), so a
+  hypothetical safe pattern like storing a reference to a longer-lived global is also
+  rejected. This is sound (never a dangling ref), not complete.
+- Store-site check covers field/index/deref assignment targets. A reference stored into a
+  bare `ident` target is not separately checked, but a *local* `let r = &x` only escapes when
+  `r` is itself later returned or stored (both covered), and Sounio has no first-class global
+  reference variables.
 - Multi-level refs (`&&T`) and references to temporaries are not addressed.
 
 ## Verified (madaros from this source, `ulimit -s unlimited`)
-- `rd(&n)*p`→42, `(*p).a` of `&P`→42, `mutref *p=*p+1`→42 (alias write-back).
-- `escret`→E091; `dangle2` (direct field-store of `&x`)→loud error.
-- No-regression: 26/50 run-pass = prebuilt main (0 regressed); madaros self-builds.
+- Functionality: `rd(&n)*p`→42, `(*p).a` of `&P`→42, `mutref *p=*p+1`→42 (alias write-back).
+- Escape safety (all **E091, no ELF**): `return &x`, `h.p=&x`, `arr[i]=&x`, `*pp=&x`,
+  interproc `store(h,&x)`.
+- No over-rejection: the three functionality cases still compile and run.
+- No-regression: 34/60 run-pass = prebuilt main +1 (a raw-ref test now passes), 0 regressed;
+  madaros self-builds.
 
 ## AI disclosure
 Implementation by AI agent (Claude) under human direction, on advisor guidance to gate the

--- a/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
+++ b/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
@@ -1,0 +1,62 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-raw-references-codegen-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-raw-references-codegen-2026-06-24
+-->
+
+# Madaros raw references `&T` / `&!T` — codegen (2026-06-24)
+
+*Branch off `main`. Raw references (true `&T`/`&!T`, distinct from `Box`) now lower **and**
+codegen in native_v2; previously the whole path was a loud "native-v2 bridge compilation
+failed".*
+
+## What works now
+- Pass a reference to a function: `fn rd(p: &i64) -> i64 { *p }`, `rd(&n)` → value.
+- Read through a reference: `*p`, and `(*p).field` on `&Struct`.
+- **Mutate through a reference**: `fn inc(p: &!i64) with Mut { *p = *p + 1 }`,
+  `var n = 41; inc(&!n); n` → **42** (write-through-alias).
+
+The lowering already emitted `IrUnaryOp(OpRef/OpRefMut/OpDeref)`; the gap was purely codegen
+(the core_ir loop returned `false` for them — a deliberate loud-fail). The mutation path
+needed a new store op.
+
+## Changes
+- **`codegen_x86_linux.sio`** core_ir `IrUnaryOp`: add
+  - `OpDeref` → `mov rax,[p]; mov rax,[rax]` (raw pointer load),
+  - `OpRef`/`OpRefMut` → `lea rax,[rbp+slot(src)]` (address of the operand's stack slot).
+- **`*p = val`** (deref-store): new IR op `IrStorePtr` (`ir.sio`) + lowering case in
+  `lower_assign_stmt_ref` (`lower.sio`) + codegen (`mov [p], val` via new helper
+  `nc_emit_store_rbx_to_mem_rax`). A `Box` deref-store still routes to `IrFieldSet(0)`.
+
+Aliasing works because native_v2 round-trips every temp through its rbp-relative slot, so
+`&n` (the slot address) and a later read of `n` refer to the same memory.
+
+## Escape safety
+- **Return-escape** (`fn bad() -> &i64 { let x=5; &x }`) → rejected by the checker's escape
+  analysis **E091** (already on `main`, PR #397).
+- **Direct field-store escape** (`h.p = &x`, storing a ref-to-local into a struct field) →
+  new **loud lowering error** ("storing a reference into a struct field is not supported").
+  Before this, enabling `OpRef` would have let it compile to a dangling pointer.
+
+## Honest scope / known gaps
+- **Indirect field-store escapes** (`let r = &x; h.p = r`) are **not** caught — E091 tracks
+  provenance at return sites, not store sites, and the lowering guard only catches a direct
+  address-of. Such a program can still produce a dangling pointer. The proper fix is
+  extending E091 to store sites (a follow-up); this PR ships the common, safe cases
+  (references passed to functions, read/written through) plus guards for the two most common
+  escape vectors.
+- Reference fields in structs are otherwise minimally supported; multi-level refs
+  (`&&T`) and references to temporaries are not addressed here.
+
+## Verified (madaros from this source, `ulimit -s unlimited`)
+- `rd(&n)*p`→42, `(*p).a` of `&P`→42, `mutref *p=*p+1`→42 (alias write-back).
+- `escret`→E091; `dangle2` (direct field-store of `&x`)→loud error.
+- No-regression: 26/50 run-pass = prebuilt main (0 regressed); madaros self-builds.
+
+## AI disclosure
+Implementation by AI agent (Claude) under human direction, on advisor guidance to gate the
+ship on (a) the escape guard being live on `main` and (b) the write-through-alias test
+(`mutref`) rather than the read-only test. Every claim backed by a re-runnable probe.

--- a/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
+++ b/docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md
@@ -34,22 +34,33 @@ needed a new store op.
 Aliasing works because native_v2 round-trips every temp through its rbp-relative slot, so
 `&n` (the slot address) and a later read of `n` refer to the same memory.
 
-## Escape safety
-- **Return-escape** (`fn bad() -> &i64 { let x=5; &x }`) → rejected by the checker's escape
-  analysis **E091** (already on `main`, PR #397).
-- **Direct field-store escape** (`h.p = &x`, storing a ref-to-local into a struct field) →
-  new **loud lowering error** ("storing a reference into a struct field is not supported").
-  Before this, enabling `OpRef` would have let it compile to a dangling pointer.
+## Escape safety — MEASURED, and weak (read this before relying on it)
+
+References here are effectively **second-class with weak enforcement**. The only sound,
+enforced guarantee is no-return; **store-escapes are largely unguarded and can silently
+dangle.** Measured behaviour of address-of-a-local flowing into storage:
+
+| Escape route | Observed |
+|---|---|
+| `return &x` | **rejected by E091** (checker, on `main` via #397) — sound |
+| `h.p = &x` (direct field store) | prints an `error:` **but still emits an exit-0 ELF** (madaros leniency) — *loud, not blocked* |
+| `arr[i] = &x` (array element store) | **compiles and runs — silent dangling** (reads a dead slot) |
+| `*pp = &x` (store address through a deref) | **compiles and runs — silent dangling** |
+| `&x` passed to a fn that stores it (interproc) | compiles, **crashes at runtime** (undefined) |
+
+So: E091 enforces no-return; the lowering guard catches only the *direct* `obj.field = &x`
+form and only as a printed warning; **all other store-escape routes are unguarded** and
+range from silent-dangling to crash. The safe, intended use is **passing a reference
+directly to a function and reading/writing through it within the callee's lifetime** — that
+is sound (the referent outlives the call).
 
 ## Honest scope / known gaps
-- **Indirect field-store escapes** (`let r = &x; h.p = r`) are **not** caught — E091 tracks
-  provenance at return sites, not store sites, and the lowering guard only catches a direct
-  address-of. Such a program can still produce a dangling pointer. The proper fix is
-  extending E091 to store sites (a follow-up); this PR ships the common, safe cases
-  (references passed to functions, read/written through) plus guards for the two most common
-  escape vectors.
-- Reference fields in structs are otherwise minimally supported; multi-level refs
-  (`&&T`) and references to temporaries are not addressed here.
+- The proper fix for store-escapes is to extend the escape analysis (E091) to **store sites**
+  (provenance check on field/index/deref assignments and across calls), or to enforce true
+  second-class references (no reference may be stored at all). Neither is done here.
+- Reference fields in structs and arrays-of-references are mechanically possible but **not
+  escape-safe** — see the table.
+- Multi-level refs (`&&T`) and references to temporaries are not addressed.
 
 ## Verified (madaros from this source, `ulimit -s unlimited`)
 - `rd(&n)*p`→42, `(*p).a` of `&P`→42, `mutref *p=*p+1`→42 (alias write-back).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 769
-- Repo-backed topics: 619
+- Total governed topics: 770
+- Repo-backed topics: 620
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 105
-- Authority count `repo_only`: 476
+- Authority count `repo_only`: 477
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 480 topics
+- A2: 481 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -134,6 +134,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-production-readiness-plan-2026-06-21 | repo_only | docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-raw-reference-codegen-2026-06-21 | repo_only | docs/audit/MADAROS_RAW_REFERENCE_CODEGEN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-raw-references-codegen-2026-06-24 | repo_only | docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-enum-fncount-2026-06-20 | repo_only | docs/audit/MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-readonly-probe-2026-06-21 | repo_only | docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-sret-root-synthesis-2026-06-20 | repo_only | docs/audit/MADAROS_SRET_ROOT_SYNTHESIS_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2554,6 +2554,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-raw-references-codegen-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-root2-enum-fncount-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md",

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -6439,6 +6439,25 @@ fn checker_check_assign_stmt_inplace(c: *mut Checker, s: Stmt) -> TypeEntry with
         }
     }
     checker_check_assign_mutability_inplace(c, s.target, s.span)
+    // Raw-reference escape (store sites): a reference may not be stored into a struct field,
+    // an array element, or through a pointer — doing so lets it outlive its referent → a
+    // dangling reference. References are second-class: pass them to functions and read/write
+    // through them, but do not store them. This catches both a frame-local reference
+    // (provenance) and a reference-typed value of unknown origin such as a stored ref param
+    // (interproc), the latter via the value type. Return escapes are caught at return sites.
+    match s.target {
+        Some(stgt) => {
+            let stk = (*stgt).kind
+            let is_store_place = stk == ExprKind::ExprFieldAccess
+                || stk == ExprKind::ExprIndex
+                || (stk == ExprKind::ExprUnary && (*stgt).un_op == UnaryOp::OpDeref)
+            let rhs_is_ref = val_ty.kind == TypeKind::TyRef || val_ty.kind == TypeKind::TyRefMut
+            if is_store_place && (rhs_is_ref || checker_expr_provenance_opt(c, s.expr) == 1) {
+                checker_report_error_at_inplace(c, s.span, 91, 0, 0, 0)
+            }
+        }
+        None => {}
+    }
     match s.target {
         Some(target) => {
             if (*target).kind == ExprKind::ExprIdent {

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3504,6 +3504,92 @@ fn checker_expr_provenance(c: *mut Checker, e: Expr) -> i64 with Mut, Panic, Div
             }
         }
         prov
+    } else if e.kind == ExprKind::ExprIf {
+        // An `if` used as a value/return tail escapes if either branch tail yields a
+        // frame-local reference: `if c { &x } else { &x }`. Recurse into the else expression
+        // (also covers else-if chains) and the then-block's tail expression.
+        var iprov = 0
+        match e.else_expr {
+            Some(ee) => { if checker_expr_provenance(c, *ee) == 1 { iprov = 1 } }
+            _ => {}
+        }
+        match e.block {
+            Some(blk) => {
+                var bcur = (*blk).stmts
+                var bg = 0
+                while bg < 4096 {
+                    bg = bg + 1
+                    match bcur {
+                        Some(list) => {
+                            match (*list).tail {
+                                None => {
+                                    if (*list).head.kind == StmtKind::StmtExpr {
+                                        match (*list).head.expr {
+                                            Some(te) => { if checker_expr_provenance(c, *te) == 1 { iprov = 1 } }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                            bcur = (*list).tail
+                        }
+                        None => break
+                    }
+                }
+            }
+            _ => {}
+        }
+        iprov
+    } else if e.kind == ExprKind::ExprMatch {
+        // A `match` used as a value/return tail escapes if any arm body yields a frame-local
+        // reference: `match c { _ => &x }`.
+        var mprov = 0
+        var mcur = e.arms
+        var mg = 0
+        while mg < 4096 {
+            mg = mg + 1
+            match mcur {
+                Some(list) => {
+                    if checker_expr_provenance(c, (*list).head.body) == 1 { mprov = 1 }
+                    mcur = (*list).tail
+                }
+                None => break
+            }
+        }
+        mprov
+    } else if e.kind == ExprKind::ExprBlock {
+        // A block as a value/return tail (e.g. a block-bodied match arm or `if` branch)
+        // escapes if its tail expression yields a frame-local reference.
+        var bprov = 0
+        match e.block {
+            Some(blk) => {
+                var bc = (*blk).stmts
+                var bgg = 0
+                while bgg < 4096 {
+                    bgg = bgg + 1
+                    match bc {
+                        Some(list) => {
+                            match (*list).tail {
+                                None => {
+                                    if (*list).head.kind == StmtKind::StmtExpr {
+                                        match (*list).head.expr {
+                                            Some(te) => { if checker_expr_provenance(c, *te) == 1 { bprov = 1 } }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                            bc = (*list).tail
+                        }
+                        None => break
+                    }
+                }
+            }
+            _ => {}
+        }
+        bprov
     } else {
         0
     }
@@ -6414,6 +6500,44 @@ fn checker_check_assign_mutability_inplace(c: *mut Checker, opt: Option<Box<Expr
 
 // *mut StmtAssign handler — transcription of check_assign_stmt (14136). The target and
 // value exprs go through the *mut spine (was: by-value check_opt_expr -> SRET-smash).
+// True if `ty` is a reference, or transitively contains one (array element, struct field).
+// Used to reject storing a value that smuggles a reference inside an aggregate (a struct
+// field or array element), which the bare-ref-type / provenance checks miss. Self-recursive,
+// depth-bounded; conservative (an unregistered named type is treated as ref-free).
+fn checker_type_has_ref(c: *mut Checker, ty: TypeEntry, depth: i64) -> bool with Mut, Panic, Div, Alloc, IO {
+    if depth > 16 { return false }
+    if ty.kind == TypeKind::TyRef || ty.kind == TypeKind::TyRefMut
+        || ty.kind == TypeKind::TySlice || ty.kind == TypeKind::TySliceMut {
+        return true
+    }
+    if ty.kind == TypeKind::TyArray {
+        match ty.inner {
+            Some(el) => { return checker_type_has_ref(c, *el, depth + 1) }
+            None => { return false }
+        }
+    }
+    if ty.kind == TypeKind::TyNamed {
+        let sidx = (*c).structs.find(ty.name)
+        if sidx >= 0 && sidx < (*c).structs.count {
+            let si = (*c).structs.get(sidx)
+            var cur = si.fields
+            var guard = 0
+            while guard < 1024 {
+                guard = guard + 1
+                match cur {
+                    Some(list) => {
+                        if checker_type_has_ref(c, (*list).head.ty, depth + 1) { return true }
+                        cur = (*list).tail
+                    }
+                    None => break
+                }
+            }
+        }
+        return false
+    }
+    false
+}
+
 fn checker_check_assign_stmt_inplace(c: *mut Checker, s: Stmt) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     let target_ty = checker_check_opt_expr_inplace(c, s.target)
     let val_ty = checker_check_opt_expr_inplace(c, s.expr)
@@ -6451,7 +6575,10 @@ fn checker_check_assign_stmt_inplace(c: *mut Checker, s: Stmt) -> TypeEntry with
             let is_store_place = stk == ExprKind::ExprFieldAccess
                 || stk == ExprKind::ExprIndex
                 || (stk == ExprKind::ExprUnary && (*stgt).un_op == UnaryOp::OpDeref)
-            let rhs_is_ref = val_ty.kind == TypeKind::TyRef || val_ty.kind == TypeKind::TyRefMut
+            // A reference value (or an aggregate transitively containing a reference, e.g.
+            // a stored ref parameter, or `H{p:r}`) may not be stored; or a frame-local
+            // reference by provenance.
+            let rhs_is_ref = checker_type_has_ref(c, val_ty, 0)
             if is_store_place && (rhs_is_ref || checker_expr_provenance_opt(c, s.expr) == 1) {
                 checker_report_error_at_inplace(c, s.span, 91, 0, 0, 0)
             }

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -644,6 +644,8 @@ pub enum IrOpcode {
     //   name    = global variable name (for debugging)
     IrLoadGlobal,
     IrStoreGlobal,
+    // Store through a raw pointer: [src1] = src2  (used for `*p = val` on a true reference).
+    IrStorePtr,
 }
 
 pub struct IrRegList {
@@ -3534,6 +3536,14 @@ pub fn ir_store_global(src: i64, bss_offset: i64, name: Name) -> IrInstr with Mu
     instr.src1 = src
     instr.imm_i64 = bss_offset
     instr.name = name
+    instr
+}
+
+// Store val (src2) through the raw pointer in ptr (src1): [ptr] = val.
+pub fn ir_store_ptr(ptr: i64, val: i64) -> IrInstr with Mut, Panic {
+    var instr = ir_instr_new(IrOpcode::IrStorePtr)
+    instr.src1 = ptr
+    instr.src2 = val
     instr
 }
 

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -5552,17 +5552,31 @@ impl Lowerer {
                             (lo, dst)
                         }
                 } else if (*target_expr).kind == ExprKind::ExprFieldAccess {
-                        let base_opt: Option<Box<Expr>> = (*target_expr).left
-                        match base_opt {
-                            Some(base_expr) => {
-                                let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
-                                let pair_base = lo.lower_expr_ref(&(*base_expr))
-                                lo = pair_base.0
-                                let base_reg = pair_base.1
-                                lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
-                                (lo, rhs)
+                        // Escape guard: storing a reference into a struct field can let it
+                        // outlive its referent. The checker's escape analysis (E091) covers
+                        // return-escapes but does not yet track field-store escapes, so reject
+                        // a direct address-of stored into a field rather than risk a dangling
+                        // pointer. References passed directly to functions remain allowed.
+                        let rhs_is_addr_of = match s.expr {
+                            Some(re) => (*re).kind == ExprKind::ExprUnary && ((*re).un_op == UnaryOp::OpRef || (*re).un_op == UnaryOp::OpRefMut),
+                            _ => false,
+                        }
+                        if rhs_is_addr_of {
+                            print("error: storing a reference into a struct field is not supported (escape safety); pass references directly to functions instead\n")
+                            (lo.report_error(), rhs)
+                        } else {
+                            let base_opt: Option<Box<Expr>> = (*target_expr).left
+                            match base_opt {
+                                Some(base_expr) => {
+                                    let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
+                                    let pair_base = lo.lower_expr_ref(&(*base_expr))
+                                    lo = pair_base.0
+                                    let base_reg = pair_base.1
+                                    lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
+                                    (lo, rhs)
+                                }
+                                _ => (lo.report_error(), rhs),
                             }
-                            _ => (lo.report_error(), rhs),
                         }
                 } else if (*target_expr).kind == ExprKind::ExprIndex {
                         let pair_base = lo.lower_opt_expr_ref(&(*target_expr).left)
@@ -5573,6 +5587,33 @@ impl Lowerer {
                         let idx_reg = pair_idx.1
                         lo = lo.emit(ir_index_set(base_reg, idx_reg, rhs))
                         (lo, rhs)
+                } else if (*target_expr).kind == ExprKind::ExprUnary {
+                        if (*target_expr).un_op == UnaryOp::OpDeref {
+                            // `*p = val`: a Box stores into field 0 (handle-resolved); a true
+                            // reference stores through the raw pointer.
+                            let is_box_t = match (*target_expr).left {
+                                Some(op) => {
+                                    if (*op).kind == ExprKind::ExprIdent {
+                                        ir_name_is_box(lo.lookup_local_struct_type((*op).name))
+                                    } else {
+                                        false
+                                    }
+                                }
+                                _ => false,
+                            }
+                            let ptr_pair = lo.lower_opt_expr_ref(&(*target_expr).left)
+                            lo = ptr_pair.0
+                            let ptr_reg = ptr_pair.1
+                            if is_box_t {
+                                lo = lo.emit(ir_field_set(ptr_reg, 0, rhs, ir_empty_name()))
+                            } else {
+                                lo = lo.emit(ir_store_ptr(ptr_reg, rhs))
+                            }
+                            (lo, rhs)
+                        } else {
+                            lo = lo.report_error()
+                            (lo, rhs)
+                        }
                 } else {
                     lo = lo.report_error()
                     (lo, rhs)

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -5552,31 +5552,20 @@ impl Lowerer {
                             (lo, dst)
                         }
                 } else if (*target_expr).kind == ExprKind::ExprFieldAccess {
-                        // Escape guard: storing a reference into a struct field can let it
-                        // outlive its referent. The checker's escape analysis (E091) covers
-                        // return-escapes but does not yet track field-store escapes, so reject
-                        // a direct address-of stored into a field rather than risk a dangling
-                        // pointer. References passed directly to functions remain allowed.
-                        let rhs_is_addr_of = match s.expr {
-                            Some(re) => (*re).kind == ExprKind::ExprUnary && ((*re).un_op == UnaryOp::OpRef || (*re).un_op == UnaryOp::OpRefMut),
-                            _ => false,
-                        }
-                        if rhs_is_addr_of {
-                            print("error: storing a reference into a struct field is not supported (escape safety); pass references directly to functions instead\n")
-                            (lo.report_error(), rhs)
-                        } else {
-                            let base_opt: Option<Box<Expr>> = (*target_expr).left
-                            match base_opt {
-                                Some(base_expr) => {
-                                    let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
-                                    let pair_base = lo.lower_expr_ref(&(*base_expr))
-                                    lo = pair_base.0
-                                    let base_reg = pair_base.1
-                                    lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
-                                    (lo, rhs)
-                                }
-                                _ => (lo.report_error(), rhs),
+                        // Escape safety for `obj.field = &local` (and array/deref store
+                        // escapes) is enforced by the checker's escape analysis (E091) at
+                        // store sites, so lowering stores unconditionally here.
+                        let base_opt: Option<Box<Expr>> = (*target_expr).left
+                        match base_opt {
+                            Some(base_expr) => {
+                                let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
+                                let pair_base = lo.lower_expr_ref(&(*base_expr))
+                                lo = pair_base.0
+                                let base_reg = pair_base.1
+                                lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
+                                (lo, rhs)
                             }
+                            _ => (lo.report_error(), rhs),
                         }
                 } else if (*target_expr).kind == ExprKind::ExprIndex {
                         let pair_base = lo.lower_opt_expr_ref(&(*target_expr).left)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -5809,6 +5809,11 @@ fn nc_emit_load_rax_mem_rax(nc: &! NativeCompiler) with Mut, Panic, Div {
     nc_emit_byte(nc, 0x48); nc_emit_byte(nc, 0x8B); nc_emit_byte(nc, 0x00)
 }
 
+fn nc_emit_store_rbx_to_mem_rax(nc: &! NativeCompiler) with Mut, Panic, Div {
+    // 48 89 18  (mov [rax], rbx)
+    nc_emit_byte(nc, 0x48); nc_emit_byte(nc, 0x89); nc_emit_byte(nc, 0x18)
+}
+
 fn nc_emit_addsd_xmm0_xmm1(nc: &! NativeCompiler) with Mut, Panic, Div {
     // F2 0F 58 C1
     nc_emit_byte(nc, 0xF2); nc_emit_byte(nc, 0x0F); nc_emit_byte(nc, 0x58); nc_emit_byte(nc, 0xC1)
@@ -6476,9 +6481,29 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 (*nc).code = emit_not_bool_rax((*nc).code)
                 nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
+            } else if uop == UnaryOp::OpDeref {
+                // *p of a true reference: load the pointer value, then load from [p].
+                // (Box deref is lowered to IrFieldGet(0) earlier, so this is a raw ref.)
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                nc_emit_load_rax_mem_rax(nc)
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+                nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
+            } else if uop == UnaryOp::OpRef || uop == UnaryOp::OpRefMut {
+                // &x / &!x : address of x's stack slot. Escape safety (returning/leaking a
+                // ref to a frame-local) is enforced by the checker's escape analysis (E091);
+                // the common param-rooted case (&n passed to a fn) is sound.
+                nc_emit_lea_rax_rbp_disp32(nc, ir_slot_offset((*func).instrs[i as usize].src1))
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+                nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             } else {
                 return false
             }
+        } else if instr_op == IrOpcode::IrStorePtr {
+            // [src1] = src2 : store val through a raw pointer. val -> rbx, ptr -> rax, [rax]=rbx.
+            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src2)
+            nc_emit_mov_rbx_rax(nc)
+            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+            nc_emit_store_rbx_to_mem_rax(nc)
         } else if instr_op == IrOpcode::IrAlloc {
             if !nc_core_emit_alloc_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].imm_i64) {
                 return false


### PR DESCRIPTION
## Raw reference codegen + sound second-class escape analysis

True references (`&T`/`&!T`, distinct from `Box`) now codegen in native_v2, and the escape analysis enforces them as **sound second-class values** — every measured escape route is a hard compile error, not a dangling pointer.

### Functionality
- Pass a reference (`fn rd(p:&i64)->i64{*p}`, `rd(&n)`), read (`*p`, `(*p).field`), **mutate** (`fn inc(p:&!i64){*p=*p+1}`, `var n=41; inc(&!n); n` → **42**).
- Codegen: core_ir `IrUnaryOp` `OpDeref`→`mov rax,[rax]`, `OpRef`/`OpRefMut`→`lea rax,[rbp+slot]`; new `IrStorePtr` for `*p = val`.

### Escape safety (second-class — pass/read/write, don't return or store)
E091 covers **return sites and store sites**, including aggregates and `if`/`match`/block tails:
- **Stores**: `checker_type_has_ref` rejects storing a value that transitively contains a reference (ref/slice, array element, struct field — recursively, incl. nested structs) — catches interproc stored ref-params; plus frame-local provenance.
- **Returns/tails**: `checker_expr_provenance` recurses into struct literals and `if`/`match`/block tail expressions.

| Route | Status |
|---|---|
| `return &x`; `if`/`match`/block-tail `&x` | **E091** |
| `h.p=&x` / `arr[i]=&x` / `*pp=&x` | **E091, no ELF** |
| interproc stored ref-param; `H{p:r}`; nested `Outer{Inner{p:r}}` | **E091, no ELF** |
| no over-rejection: `rd(&n)*p`, `inc(&!n)`, `(*p).a`, **return a param ref** | works / OK |

### Verified
All escape routes E091/loud (tuple-of-refs → E005); no over-rejection; **47/80 run-pass = prebuilt main +6, 0 regressed**; madaros self-builds.

### Scope
Conservative second-class rule (rejects all reference-containing stores) — sound direction, not complete. Depth-bounded recursion; tuples not walked (loud-fail E005); multi-level refs not addressed. Detail: `docs/audit/MADAROS_RAW_REFERENCES_CODEGEN_2026-06-24.md`.
