### PR TITLE
fix(madaros): string concatenation (route + to str_concat + fix the builtin)

### DIFF
--- a/docs/audit/MADAROS_STRING_CONCAT_2026-06-24.md
+++ b/docs/audit/MADAROS_STRING_CONCAT_2026-06-24.md
@@ -1,0 +1,58 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-string-concat-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-string-concat-2026-06-24
+-->
+
+# Madaros string concatenation — working (2026-06-24)
+
+*Branch off `main`. `"a" + "b"` and `s ++ t` on strings now produce the concatenated string;
+previously string `+` lowered as an integer add of the two pointers (garbage), and the
+`str_concat` builtin crashed when called.*
+
+## Two fixes
+
+### 1. Lowering: route string `+`/`++` to the `str_concat` builtin (`lower.sio`)
+`OpAdd`/`OpConcat` fell through to a generic integer binop. Added string detection
+(`expr_result_is_string_ref`: a string literal, a string-typed local tracked with the new
+`scalar_kind = 3`, or a nested string concat) and, when either operand is a string,
+`lower_binary_expr_ref` emits a call to the `str_concat` builtin instead of an integer add.
+Numeric `+` is unaffected.
+
+### 2. Codegen: the `str_concat` builtin was never reachable (`codegen_x86_linux.sio`)
+Even a direct `str_concat("ab","cde")` crashed *before* the builtin's first instruction — the
+`call` resolved to a bad address. `str_len` (also a builtin) worked because it is emitted via
+the `*mut` `emit_builtin_str_len_into`; `str_concat` fell through to
+`native_v2_emit_builtin_by_id_into` → `(*nc) = emit_builtin_str_concat((*nc))`, a **full
+by-value `NativeCompiler` replacement** that the large-aggregate miscompile corrupts
+(dropping `fn_offsets`), so the function's recorded offset was wrong and every call to it
+jumped to garbage. Fixed by routing `str_concat` (builtin id 10) through
+`native_v2_persist_builtin_emit_into` — the same selective code+relocs copy `str_eq` already
+uses — preserving `fn_offsets`.
+
+This is the **same by-value-aggregate miscompile** behind the struct/method/closure/method-
+param roots; the established workaround (avoid the by-value copy of a large aggregate) applies
+again.
+
+## Verified (madaros from this source)
+- `str_len(str_concat("ab","cde")) → 5` (builtin reachable + correct).
+- `"ab"+"cde" → abcde`; `let a="foo"; a+"bar" → foobar`; string vars `s+t → xy`;
+  nested `(a+b)+(c+d) → abcd`.
+- No regression: numeric `40+2 → 42`, `str_len("abc") → 3`; 47/80 run-pass = prebuilt main
+  +6, 0 regressed; madaros self-builds.
+
+## Honest scope
+- String detection covers string literals, string-typed locals (`scalar_kind 3`), and nested
+  string concats. A string returned from a non-builtin function and then concatenated may not
+  be detected (the local's kind would not be 3); such a value falls back to integer add.
+- Array `++` (a true array concat, not via `str_concat`) is still unimplemented — `OpConcat`
+  on non-string operands falls through to the (failing) integer binop. Separate gap.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; the builtin root cause was localised by
+instrumenting `emit_builtin_str_concat` with staged `exit()` markers (the call crashed before
+the entry marker → bad call target → corrupted `fn_offsets`). Every claim backed by a
+re-runnable probe.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 770
-- Repo-backed topics: 620
+- Total governed topics: 771
+- Repo-backed topics: 621
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 105
-- Authority count `repo_only`: 477
+- Authority count `repo_only`: 478
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 481 topics
+- A2: 482 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -138,6 +138,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-root2-enum-fncount-2026-06-20 | repo_only | docs/audit/MADAROS_ROOT2_ENUM_FNCOUNT_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-root2-readonly-probe-2026-06-21 | repo_only | docs/audit/MADAROS_ROOT2_READONLY_PROBE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-sret-root-synthesis-2026-06-20 | repo_only | docs/audit/MADAROS_SRET_ROOT_SYNTHESIS_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-string-concat-2026-06-24 | repo_only | docs/audit/MADAROS_STRING_CONCAT_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-struct-field-index-fallback-2026-06-23 | repo_only | docs/audit/MADAROS_STRUCT_FIELD_INDEX_FALLBACK_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-audit-2026-06-10 | repo_only | docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-stack-clash-2026-05-29 | repo_only | docs/audit/MODULAR_COMPILER_STACK_CLASH_2026-05-29.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2646,6 +2646,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-string-concat-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_STRING_CONCAT_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-struct-field-index-fallback-2026-06-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_STRUCT_FIELD_INDEX_FALLBACK_2026-06-23.md",

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -3864,6 +3864,30 @@ impl Lowerer {
         }
     }
 
+    // String-ness of an expression result, for routing `+`/`++` on strings to the
+    // str_concat builtin (string locals are tracked with scalar_kind 3).
+    fn opt_expr_result_is_string_ref(self, opt: &Option<Box<Expr>>) -> bool with Mut, Panic, Div, Alloc {
+        match *opt {
+            Some(expr) => self.expr_result_is_string_ref(&(*expr)),
+            _ => false,
+        }
+    }
+
+    fn expr_result_is_string_ref(self, e: &Expr) -> bool with Mut, Panic, Div, Alloc {
+        if (*e).kind == ExprKind::ExprStringLit {
+            return true
+        }
+        if (*e).kind == ExprKind::ExprIdent {
+            return self.lookup_local_scalar_kind((*e).name) == 3
+        }
+        if (*e).kind == ExprKind::ExprBinary {
+            if (*e).bin_op == BinaryOp::OpAdd || (*e).bin_op == BinaryOp::OpConcat {
+                return self.opt_expr_result_is_string_ref(&(*e).left) || self.opt_expr_result_is_string_ref(&(*e).right)
+            }
+        }
+        false
+    }
+
     fn expr_result_is_float_ref(self, e: &Expr) -> bool with Mut, Panic, Div, Alloc {
         if (*e).kind == ExprKind::ExprFloatLit {
             return true
@@ -5448,6 +5472,9 @@ impl Lowerer {
                         lo = lo.bind_local_scalar_kind(s.name, 2)
                     } else if (*expr_box_sk).kind == ExprKind::ExprIntLit {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
+                    } else if lo.expr_result_is_string_ref(&(*expr_box_sk)) {
+                        // Track string locals (kind 3) so `s + t` / `s ++ t` route to str_concat.
+                        lo = lo.bind_local_scalar_kind(s.name, 3)
                     }
                 }
                 _ => {}
@@ -6932,6 +6959,17 @@ impl Lowerer {
         let pair_d = if wide_bits > 64 && cmp_op < 0 { lo2.fresh_wide_reg(alloc_limbs) } else { lo2.fresh_reg() }
         var lo3 = pair_d.0
         let dst = pair_d.1
+        // String concatenation: `s + t` / `s ++ t` route to the str_concat builtin (heap
+        // alloc + copy), instead of an integer add of the string pointers.
+        if e.bin_op == BinaryOp::OpAdd || e.bin_op == BinaryOp::OpConcat {
+            if lo3.opt_expr_result_is_string_ref(&e.left) || lo3.opt_expr_result_is_string_ref(&e.right) {
+                var lo_sc = lo3
+                let sc_fn = lowerer_find_or_add_fn_id_mut(&! lo_sc, make_name("str_concat"))
+                let sc_args: Option<Box<IrRegList>> = Some(Box::new(ir_reg_list_cons(lhs, Some(Box::new(ir_reg_list_single(rhs))))))
+                let lo_call = lo_sc.emit(ir_call(dst, sc_fn, make_name("str_concat"), sc_args, 2))
+                return (lo_call, dst)
+            }
+        }
         if lhs_expr_is_float {
             lo3 = lo3.emit(ir_mark_float_reg(lhs))
         }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6946,6 +6946,14 @@ pub fn compile_ir_function_v2_from_ir_into(nc: &! NativeCompiler, func: &IrFunct
             native_v2_persist_builtin_emit_into(nc, emit_builtin_str_eq((*nc)))
             return true
         }
+        if builtin_id == 10 {
+            // str_concat: route through persist (selectively copies code + relocs), like
+            // str_eq, instead of `(*nc) = emit_builtin_str_concat((*nc))` — the full
+            // by-value NativeCompiler replacement is hit by the large-aggregate miscompile
+            // and corrupts fn_offsets, so the call to str_concat resolved to a bad address.
+            native_v2_persist_builtin_emit_into(nc, emit_builtin_str_concat((*nc)))
+            return true
+        }
         native_v2_emit_builtin_by_id_into(nc, builtin_id)
         return true
     }


### PR DESCRIPTION
## String concatenation — `"a" + "b"` / `s ++ t`

String concat now produces the concatenated string. Two fixes:

### 1. Lowering — route string `+`/`++` to `str_concat` (`lower.sio`)
`OpAdd`/`OpConcat` fell through to an **integer add of the two pointers** (garbage). Added string detection (`expr_result_is_string_ref`: string literal, string-typed local via new `scalar_kind 3`, or nested string concat) and emit a `str_concat` call when an operand is a string. Numeric `+` unaffected.

### 2. Codegen — the `str_concat` builtin was unreachable (`codegen_x86_linux.sio`)
Even `str_concat("ab","cde")` crashed **before its first instruction** — the `call` resolved to a bad address. `str_len` works via the `*mut` `emit_builtin_str_len_into`; `str_concat` used `(*nc) = emit_builtin_str_concat((*nc))` — a **full by-value `NativeCompiler` replacement** that the large-aggregate miscompile corrupts (dropping `fn_offsets`). Routed it through `native_v2_persist_builtin_emit_into` (the selective copy `str_eq` already uses), preserving `fn_offsets`.

Same by-value-aggregate miscompile as the struct/method/closure roots — established workaround applies again. Localized by instrumenting the builtin with staged `exit()` markers.

### Verified
`str_len(str_concat("ab","cde"))→5`, `"ab"+"cde"→abcde`, `a+"bar"→foobar`, `s+t→xy`, nested `(a+b)+(c+d)→abcd`; no regression (`40+2→42`, `str_len("abc")→3`; **47/80 run-pass = prebuilt +6, 0 regressed**); self-builds.

### Scope
Detects string literals / string locals / nested concats; a string from a non-builtin fn then concatenated may fall back to integer add. Array `++` (true array concat) is still unimplemented (separate gap). Detail: `docs/audit/MADAROS_STRING_CONCAT_2026-06-24.md`.
