### PR TITLE
fix(madaros): builtin emission — persist for the fallback family (str_slice/file_size)

### DIFF
--- a/docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md
+++ b/docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md
@@ -1,0 +1,52 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-builtin-emission-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-builtin-emission-2026-06-24
+-->
+
+# Madaros builtin emission — fix the by-value `NativeCompiler` corruption (2026-06-24)
+
+*Branch off `main` (with string concat #422). The fallback builtin emitter corrupted
+`fn_offsets`, so several builtins crashed when called; `str_slice` and `file_size` now work.*
+
+## Root cause (same as str_concat #422)
+
+`compile_ir_function_v2_from_ir_into` dispatches builtins: a few have dedicated `*mut`/persist
+emitters (`str_len`, `str_char_at`, `str_eq`, and `str_concat` from #422), and the rest fall
+through to `native_v2_emit_builtin_by_id_into`, which emitted each via
+`(*nc) = emit_builtin_X((*nc))` — a **full by-value `NativeCompiler` replacement**. That large
+aggregate is hit by the by-value-aggregate miscompile and **drops `fn_offsets`**, so the
+function's recorded offset is wrong and every `call` to it jumps to a bad address (crash
+*before* the builtin's first instruction).
+
+`str_len` worked because it uses the `*mut` `emit_builtin_str_len_into`; `str_eq`/`str_concat`
+work because they use `native_v2_persist_builtin_emit_into` (a *selective* code+relocs copy
+onto the existing `nc`, preserving `fn_offsets`).
+
+## Fix
+
+Route **every** builtin in `native_v2_emit_builtin_by_id_into` through
+`native_v2_persist_builtin_emit_into(nc, emit_builtin_X((*nc)))` instead of
+`(*nc) = emit_builtin_X((*nc))`. Same proven workaround as #422, applied to the whole family.
+
+## Verified (madaros from this source)
+- **Now work (were crashing): `str_len(str_slice("hello",1,4)) → 4`, `file_size(path) → 13`.**
+- Still correct: `str_char_at("hello",1) → 101`, `str_eq → 1`, string concat `"ab"+"cde" → 5`.
+- No regression: 47/80 run-pass = prebuilt main +6, 0 regressed; madaros self-builds.
+
+## Honest scope — what this does NOT fix
+- **`read_file` still crashes (139)** — measured identical on the prebuilt main, so it is a
+  **separate, pre-existing bug** in `read_file` itself (not the emission path). Out of scope.
+- **`sqrt`, `starts_with`, `exp`, `log`, `sin`, `cos` fail with `E137` (parse error)** on both
+  this build and the prebuilt — a **separate frontend/parser gap**, not the emission bug.
+  Those builtins never reach codegen, so this fix cannot affect them.
+- This fix removes the *emission-corruption* root for the fallback builtins; the remaining
+  read_file / math-builtin failures are distinct roots to be triaged separately.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; root localised by instrumenting the str_concat
+builtin (the call crashed before the entry marker → corrupted `fn_offsets`), then generalised
+to the whole fallback. Every claim backed by a re-runnable probe.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 771
-- Repo-backed topics: 621
+- Total governed topics: 772
+- Repo-backed topics: 622
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 105
-- Authority count `repo_only`: 478
+- Authority count `repo_only`: 479
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 482 topics
+- A2: 483 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -119,6 +119,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-builtin-emission-2026-06-24 | repo_only | docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-closures-step1-fix-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP1_FIX_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-closures-step2-capture-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2209,6 +2209,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-builtin-emission-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-closures-step1-fix-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_CLOSURES_STEP1_FIX_2026-06-24.md",

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -5469,21 +5469,27 @@ fn native_v2_emit_builtin_by_id_into(nc: &! NativeCompiler, builtin_id: i64) wit
     }
     if builtin_id == 4 { emit_builtin_get_arg_count_into(nc); return }
     if builtin_id == 5 { emit_builtin_get_arg_into(nc); return }
-    if builtin_id == 6 { (*nc) = emit_builtin_str_len((*nc)); return }
-    if builtin_id == 20 { (*nc) = emit_builtin_str_char_at((*nc)); return }
-    if builtin_id == 7 { (*nc) = emit_builtin_str_eq((*nc)); return }
-    if builtin_id == 8 { (*nc) = emit_builtin_str_slice((*nc)); return }
-    if builtin_id == 9 { (*nc) = emit_builtin_starts_with((*nc)); return }
-    if builtin_id == 10 { (*nc) = emit_builtin_str_concat((*nc)); return }
-    if builtin_id == 11 { (*nc) = emit_builtin_read_file((*nc)); return }
-    if builtin_id == 12 { (*nc) = emit_builtin_write_file((*nc)); return }
-    if builtin_id == 13 { (*nc) = emit_builtin_file_size((*nc)); return }
-    if builtin_id == 14 { (*nc) = emit_builtin_sqrt((*nc)); return }
-    if builtin_id == 15 { (*nc) = emit_builtin_print_f64((*nc)); return }
-    if builtin_id == 16 { (*nc) = emit_builtin_exp((*nc)); return }
-    if builtin_id == 17 { (*nc) = emit_builtin_log((*nc)); return }
-    if builtin_id == 18 { (*nc) = emit_builtin_sin((*nc)); return }
-    if builtin_id == 19 { (*nc) = emit_builtin_cos((*nc)); return }
+    // Each builtin is emitted via native_v2_persist_builtin_emit_into (copies the appended
+    // code + data relocs onto the existing nc), NOT `(*nc) = emit_builtin_X((*nc))`: the
+    // full by-value NativeCompiler replacement is hit by the large-aggregate miscompile and
+    // corrupts fn_offsets, so the function's recorded offset was wrong and every call to it
+    // jumped to a bad address (str_slice/sqrt/print_f64/… all crashed). Same root + fix as
+    // str_concat/str_eq.
+    if builtin_id == 6 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_len((*nc))); return }
+    if builtin_id == 20 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_char_at((*nc))); return }
+    if builtin_id == 7 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_eq((*nc))); return }
+    if builtin_id == 8 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_slice((*nc))); return }
+    if builtin_id == 9 { native_v2_persist_builtin_emit_into(nc, emit_builtin_starts_with((*nc))); return }
+    if builtin_id == 10 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_concat((*nc))); return }
+    if builtin_id == 11 { native_v2_persist_builtin_emit_into(nc, emit_builtin_read_file((*nc))); return }
+    if builtin_id == 12 { native_v2_persist_builtin_emit_into(nc, emit_builtin_write_file((*nc))); return }
+    if builtin_id == 13 { native_v2_persist_builtin_emit_into(nc, emit_builtin_file_size((*nc))); return }
+    if builtin_id == 14 { native_v2_persist_builtin_emit_into(nc, emit_builtin_sqrt((*nc))); return }
+    if builtin_id == 15 { native_v2_persist_builtin_emit_into(nc, emit_builtin_print_f64((*nc))); return }
+    if builtin_id == 16 { native_v2_persist_builtin_emit_into(nc, emit_builtin_exp((*nc))); return }
+    if builtin_id == 17 { native_v2_persist_builtin_emit_into(nc, emit_builtin_log((*nc))); return }
+    if builtin_id == 18 { native_v2_persist_builtin_emit_into(nc, emit_builtin_sin((*nc))); return }
+    if builtin_id == 19 { native_v2_persist_builtin_emit_into(nc, emit_builtin_cos((*nc))); return }
 }
 
 pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func: MachineFunction, fn_index: i64) -> NativeCompiler with Mut, Panic, Div, Alloc {


### PR DESCRIPTION
## Builtin emission — fix the by-value `NativeCompiler` corruption

Several builtins crashed *when called* (the `call` jumped to a bad address) because the fallback emitter `native_v2_emit_builtin_by_id_into` used `(*nc) = emit_builtin_X((*nc))` — a **full by-value `NativeCompiler` replacement** that the large-aggregate miscompile corrupts, dropping `fn_offsets`. Same root + fix as str_concat (#422): route every builtin through `native_v2_persist_builtin_emit_into` (selective code+relocs copy, preserves `fn_offsets`).

### Verified
- **Now work (were crashing): `str_slice → 4`, `file_size → 13`.**
- Still correct: `str_char_at → 101`, `str_eq → 1`, string concat `"ab"+"cde" → 5`.
- No regression: **47/80 run-pass = prebuilt main +6, 0 regressed**; self-builds.

### Honest scope (separate roots, NOT this fix)
- `read_file` still crashes (139) — **measured identical on prebuilt main** → separate pre-existing bug in read_file itself.
- `sqrt`/`starts_with`/`exp`/`log`/`sin`/`cos` → **E137 parse error** (both builds) → separate frontend gap; they never reach codegen.

Detail: `docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md`.
