### PR TITLE
fix(madaros): match guards — evaluate if-cond arms (were silently ignored)

### DIFF
--- a/docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md
+++ b/docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md
@@ -1,0 +1,52 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-match-guards-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-match-guards-2026-06-24
+-->
+
+# Madaros match guards — working (2026-06-24)
+
+*Branch off `main`. `match n { x if x > 10 => … }` now evaluates the guard; previously the
+guard was silently ignored and the first pattern-matching arm was always taken — a silent
+wrong result.*
+
+## Root cause — the guard was parsed and thrown away
+
+`MatchArm` had no guard field (`{ pattern, body, span }`), and the parser
+(`exprs.sio`) parsed the `if <cond>` then **discarded it**:
+`let _guard_box = parser_take_expr_box()` (the `_` prefix). So no guard ever reached the
+checker or lowering, and every guarded arm behaved as unguarded → the first arm whose
+*pattern* matched won, ignoring the condition.
+
+## Fix (4 layers)
+1. **AST** (`ast.sio`): add `guard: Option<Box<Expr>>` to `MatchArm`.
+2. **Parser** (`exprs.sio`): capture the guard into the arm (`guard: guard_opt`) instead of
+   discarding it; the two desugar constructions (`while let`/`?`-style) pass `guard: None`.
+3. **Lowering** (`lower.sio`): new `lower_arm_guard` — after the pattern matches and bindings
+   are made, evaluate the guard and `branch_false(guard, l_skip)` so a false guard **falls
+   through to the next arm**. Wildcard/binding arms now allocate an `l_skip` too (dead when
+   there is no guard). Applied to all pattern kinds (wildcard, binding, Some/None/variant,
+   int-literal, bool).
+4. **Checker** (`check.sio`): type-check the guard with the pattern variables in scope.
+
+## Verified (madaros from this source, exit codes are mod 256)
+- `match n { x if x>10 => 100, x if x>0 => 50, _ => 0 }`: `classify(5) → 50` (was 100).
+- 4-way chain `g`: `g(5)=3, g(50)=2, g(500)=1, g(0)=4` (correct fall-through across 3 guards).
+- Guard on an enum pattern: `E::A if n>0 => 1` selects correctly.
+- No-regression: guard-less `Option`/enum matches still `→ 42 / 23`; 53/90 run-pass =
+  prebuilt main +6, 0 regressed; madaros self-builds.
+
+## Honest scope
+- The guard reads the bound pattern variables at the arm; standard semantics.
+- The checker type-checks the guard expression but does not yet *enforce* it is `bool`
+  (madaros leniency); a non-bool guard would still lower (the `branch_false` tests the value).
+- Tuple/struct destructuring patterns with guards follow the same path but were not
+  separately exercised here.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; root found by reading the parser
+(`_guard_box` discard) and the guard-less `MatchArm` struct. Every claim backed by a
+re-runnable probe (with the mod-256 exit-code caveat).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 772
-- Repo-backed topics: 622
+- Total governed topics: 773
+- Repo-backed topics: 623
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 105
-- Authority count `repo_only`: 479
+- Authority count `repo_only`: 480
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 483 topics
+- A2: 484 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -126,6 +126,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-match-guards-2026-06-24 | repo_only | docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-method-call-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-multimodule-native-seed-segfault-2026-06-22 | repo_only | docs/audit/MADAROS_MULTIMODULE_NATIVE_SEED_SEGFAULT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-native-v2-codegen-census-2026-06-19 | repo_only | docs/audit/MADAROS_NATIVE_V2_CODEGEN_CENSUS_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2370,6 +2370,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-match-guards-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-method-call-sigsegv-2026-06-20",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md",

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -6093,6 +6093,13 @@ fn checker_check_match_arm_inplace(c: *mut Checker, arm: MatchArm, scrut_ty: Typ
     (*c).borrows = (*c).borrows.push_scope()
     checker_push_const_scope_inplace(c)
     checker_bind_pattern_inplace(c, arm.pattern, scrut_ty)
+    // Type-check the `if <cond>` guard (if any) with the pattern variables in scope.
+    match arm.guard {
+        Some(g) => {
+            let _guard_ty = checker_check_expr_inplace(c, *g)
+        }
+        _ => {}
+    }
     let body_ty = checker_check_expr_inplace(c, arm.body)
     checker_pop_const_scope_inplace(c)
     (*c).borrows = (*c).borrows.pop_scope()

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -5932,24 +5932,48 @@ impl Lowerer {
     }
 
     // Lower a single match arm: test pattern, conditionally execute body
+    // If the arm has an `if <cond>` guard, evaluate it (pattern variables are already bound)
+    // and fall through to l_skip (treat as a non-match) when the guard is false.
+    fn lower_arm_guard(self, guard: &Option<Box<Expr> >, l_skip: i64) -> Lowerer with Mut, Panic, Div, Alloc, IO {
+        match *guard {
+            Some(g) => {
+                let pair = self.lower_expr_ref(&(*g))
+                var lo = pair.0
+                lo.emit(ir_branch_false(pair.1, l_skip))
+            }
+            _ => self,
+        }
+    }
+
     fn lower_match_arm_ref(self, scrut: i64, res: i64, l_end: i64, arm: &MatchArm) -> Lowerer with Mut, Panic, Div, Alloc, IO {
         let pat = &arm.pattern
         if pat.kind == PatternKind::PatWildcard {
-            // Wildcard always matches — evaluate body unconditionally
-            let pair = self.lower_expr_ref(&arm.body)
-            var lo = pair.0
-            let body_reg = pair.1
-            lo = lo.emit(ir_copy(res, body_reg))
-            lo = lo.emit(ir_jump(l_end))
-            lo
-        } else if pat.kind == PatternKind::PatBinding {
-            // Binding always matches — bind scrutinee to name, evaluate body
-            var lo = self.bind_local(pat.name, scrut, pat.is_mut)
+            // Wildcard matches the pattern unconditionally; an `if` guard can still reject it,
+            // so allocate l_skip (dead when there is no guard).
+            let pair_l = self.fresh_label()
+            var lo = pair_l.0
+            let l_skip = pair_l.1
+            lo = lo.lower_arm_guard(&arm.guard, l_skip)
             let pair = lo.lower_expr_ref(&arm.body)
             lo = pair.0
             let body_reg = pair.1
             lo = lo.emit(ir_copy(res, body_reg))
             lo = lo.emit(ir_jump(l_end))
+            lo = lo.emit(ir_label(l_skip))
+            lo
+        } else if pat.kind == PatternKind::PatBinding {
+            // Binding matches the pattern; bind the scrutinee, then a guard may reject it.
+            var lo = self.bind_local(pat.name, scrut, pat.is_mut)
+            let pair_l = lo.fresh_label()
+            lo = pair_l.0
+            let l_skip = pair_l.1
+            lo = lo.lower_arm_guard(&arm.guard, l_skip)
+            let pair = lo.lower_expr_ref(&arm.body)
+            lo = pair.0
+            let body_reg = pair.1
+            lo = lo.emit(ir_copy(res, body_reg))
+            lo = lo.emit(ir_jump(l_end))
+            lo = lo.emit(ir_label(l_skip))
             lo
         } else if pat.kind == PatternKind::PatEnum {
             let variant_name = ir_path_last_name(pat.path)
@@ -5965,6 +5989,7 @@ impl Lowerer {
                 lo = lo.emit(ir_branch_false(scrut, l_skip))
                 // Bind the inner pattern (first sub_pattern) to scrutinee value
                 lo = lo.bind_match_sub_pattern(scrut, pat.sub_patterns)
+                lo = lo.lower_arm_guard(&arm.guard, l_skip)
                 let pair_b = lo.lower_expr_ref(&arm.body)
                 lo = pair_b.0
                 let body_reg = pair_b.1
@@ -5979,6 +6004,7 @@ impl Lowerer {
                 let l_skip = pair_l.1
                 // Branch if scrutinee != 0 (skip this arm)
                 lo = lo.emit(ir_branch_true(scrut, l_skip))
+                lo = lo.lower_arm_guard(&arm.guard, l_skip)
                 let pair_b = lo.lower_expr_ref(&arm.body)
                 lo = pair_b.0
                 let body_reg = pair_b.1
@@ -6002,6 +6028,7 @@ impl Lowerer {
                     let cmp_reg = pair_cmp.1
                     lo = lo.emit(ir_binop(cmp_reg, scrut, BinaryOp::OpEq, disc_reg))
                     lo = lo.emit(ir_branch_false(cmp_reg, l_skip))
+                    lo = lo.lower_arm_guard(&arm.guard, l_skip)
                     let pair_b = lo.lower_expr_ref(&arm.body)
                     lo = pair_b.0
                     let body_reg = pair_b.1
@@ -6028,6 +6055,7 @@ impl Lowerer {
             let cmp_reg = pair_cmp.1
             lo = lo.emit(ir_binop(cmp_reg, scrut, BinaryOp::OpEq, lit_reg))
             lo = lo.emit(ir_branch_false(cmp_reg, l_skip))
+            lo = lo.lower_arm_guard(&arm.guard, l_skip)
             let pair_b = lo.lower_expr_ref(&arm.body)
             lo = pair_b.0
             let body_reg = pair_b.1
@@ -6040,6 +6068,7 @@ impl Lowerer {
             var lo = pair_l.0
             let l_skip = pair_l.1
             lo = lo.emit(ir_branch_false(scrut, l_skip))
+            lo = lo.lower_arm_guard(&arm.guard, l_skip)
             let pair_b = lo.lower_expr_ref(&arm.body)
             lo = pair_b.0
             let body_reg = pair_b.1
@@ -6052,6 +6081,7 @@ impl Lowerer {
             var lo = pair_l.0
             let l_skip = pair_l.1
             lo = lo.emit(ir_branch_true(scrut, l_skip))
+            lo = lo.lower_arm_guard(&arm.guard, l_skip)
             let pair_b = lo.lower_expr_ref(&arm.body)
             lo = pair_b.0
             let body_reg = pair_b.1

--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -353,6 +353,7 @@ pub struct Stmt {
 
 pub struct MatchArm {
     pattern: Pattern,
+    guard: Option<Box<Expr> >,
     body: Expr,
     span: Span,
 }

--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -827,11 +827,12 @@ impl Parser {
             let pair2 = p.parse_pattern()
             p = pair2.0
             let pattern = pair2.1
+            var guard_opt: Option<Box<Expr> > = None
             if parser_peek(p) == TokenKind::If {
                 p = p.advance()
                 p.no_struct_lit = true
                 p = p.parse_expr()
-                let _guard_box = parser_take_expr_box()
+                guard_opt = Some(parser_take_expr_box())
                 p.no_struct_lit = false
             }
             p = p.expect(TokenKind::FatArrow)
@@ -851,7 +852,7 @@ impl Parser {
                 // body in LAST_EXPR
             }
             let body_box = parser_take_expr_box()
-            let arm = MatchArm { pattern: pattern, body: *body_box, span: p.span_from(arm_start) }
+            let arm = MatchArm { pattern: pattern, guard: guard_opt, body: *body_box, span: p.span_from(arm_start) }
             rev_arms_opt = Some(Box::new(MatchArmList { head: arm, tail: rev_arms_opt }))
 
             // Skip comma between arms
@@ -916,6 +917,7 @@ impl Parser {
         success_expr.block = Some(Box::new(success_block))
         let success_arm = MatchArm {
             pattern: success_pattern,
+            guard: None,
             body: success_expr,
             span: success_block.span,
         }
@@ -933,6 +935,7 @@ impl Parser {
         var break_expr = mk_expr(ExprKind::ExprBreak, span)
         let break_arm = MatchArm {
             pattern: wildcard_pattern,
+            guard: None,
             body: break_expr,
             span: span,
         }


### PR DESCRIPTION
## Match guards — `match n { x if x > 10 => … }`

Guards were **silently ignored** — the first arm whose *pattern* matched always won, regardless of the condition (a silent wrong result). Root: `MatchArm` had no guard field and the parser parsed the `if <cond>` then **discarded it** (`let _guard_box = parser_take_expr_box()`).

### Fix (4 layers)
1. **AST**: `guard: Option<Box<Expr>>` on `MatchArm`
2. **Parser**: capture the guard (was discarded); desugars pass `guard: None`
3. **Lowering**: `lower_arm_guard` — after the pattern matches + bindings, `branch_false(guard, l_skip)` so a false guard **falls through** to the next arm (all pattern kinds; wildcard/binding now allocate `l_skip`, dead when unguarded)
4. **Checker**: type-check the guard with pattern vars in scope

### Verified (exit codes mod 256)
- `classify(5)[x>10=>100, x>0=>50, _=>0] → 50` (was 100)
- 4-guard chain: `g(5)=3, g(50)=2, g(500)=1, g(0)=4`
- Enum-pattern guard `E::A if n>0` selects correctly
- No-regression: guard-less Option/enum matches still `→42/23`; **53/90 run-pass = prebuilt +6, 0 regressed**; self-builds

### Scope
Standard guard semantics (reads bound pattern vars). The checker type-checks the guard but doesn't yet *enforce* `bool` (madaros leniency). Detail: `docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md`.
