### PR TITLE
fix(madaros): Option<Box<T>> deref — recursive data structures (linked lists/trees)

### DIFF
--- a/docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md
+++ b/docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md
@@ -1,0 +1,54 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-option-box-deref-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-option-box-deref-2026-06-24
+-->
+
+# Madaros recursive data — `Some(nx) => (*nx).field` works (2026-06-24)
+
+*Branch off `main`. `match opt { Some(nx) => (*nx).field }` on an `Option<Box<T>>` now
+works; previously it crashed (139). This unblocks recursive data structures — linked lists,
+trees — whose traversal goes through exactly this pattern.*
+
+## Root cause
+
+`Option<Box<T>>` is a nullable pointer: `Some` carries the **Box handle**, `None` is 0.
+`bind_match_sub_pattern` bound the `Some(nx)` payload via `bind_local(nx, scrut)` **without
+recording that `nx` is a Box**. So a body `(*nx).field` hit the `is_box_deref` check
+(`lookup_local_struct_type(nx) == "Box"`), found it **false**, and lowered `*nx` as a **raw**
+`IrUnaryOp(OpDeref)` — `mov rax,[rax]` on a *handle* (not a raw address) → bad load → crash.
+A plain `let b = Box::new(…); (*b).v` works because the let-binding *does* tag the local
+`"Box"`; the `Some`-bound payload was the one place that didn't.
+
+## Fix
+1. **`bind_match_sub_pattern`** (`lower.sio`): after binding the `Some(nx)` payload, tag it
+   `"Box"` (`bind_local_struct_type(nx, "Box")`), so `*nx` lowers to the box-handle deref
+   (`IrFieldGet 0`). Safe for non-Box payloads: the tag only changes how `*nx` lowers, and
+   deref/field-access of a non-Box payload (e.g. `Option<i64>`) is not valid code anyway —
+   `Option<i64>` `Some(v) => v` is unaffected, and `Option<struct>` direct field access does
+   not compile today regardless.
+2. **`lower_let_stmt`** (`lower.sio`): `let b = <ident>` now propagates the source variable's
+   struct type, so a re-bound box (`let b = nx; (*b).v`) also resolves correctly.
+
+## Verified (madaros from this source, `ulimit -s unlimited`)
+- Recursive linked-list `sum(&node) → 42`; `cnt(&node) → 2`; 3-node list `→ 42`.
+- `Some(nx) => (*nx).v → 42`; `let b = nx; (*b).v → 42` (ident propagation).
+- No regression: `Option<i64>` `Some(v) => v+1 → 42`, `Some(40) => v+2 → 42`; 53/90 run-pass =
+  prebuilt main +6, 0 regressed; madaros self-builds.
+
+## Honest scope
+- Fixes the `Option<Box<T>>` payload deref. `Option<struct>` (unboxed payload) direct field
+  access is a separate, still-open gap (does not compile). Enum *payload* patterns
+  (`E::A(x)`) are a separate frontend gap (E005). Array `++` (true array concat) is a
+  separate codegen gap.
+- The Box tag on the `Some`-payload is a structural heuristic (the payload of `Some` on an
+  `Option<Box<T>>` is always a Box); it is not type-driven (the lowerer does not track field
+  types), but it is sound for the reasons above.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; root isolated by a decisive probe ladder
+(construct/None/ref-param work; `Some(nx)=>(*nx)` crashes) and confirmed against the
+`is_box_deref` lowering. Every claim backed by a re-runnable probe.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 773
-- Repo-backed topics: 623
+- Total governed topics: 774
+- Repo-backed topics: 624
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 105
-- Authority count `repo_only`: 480
+- Authority count `repo_only`: 481
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 484 topics
+- A2: 485 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -132,6 +132,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-native-v2-codegen-census-2026-06-19 | repo_only | docs/audit/MADAROS_NATIVE_V2_CODEGEN_CENSUS_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-open-pr-worktree-disposition-2026-06-21 | repo_only | docs/audit/MADAROS_OPEN_PR_WORKTREE_DISPOSITION_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-operational-handoff-2026-06-21 | repo_only | docs/audit/MADAROS_OPERATIONAL_HANDOFF_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-option-box-deref-2026-06-24 | repo_only | docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-post-merge-closeout-2026-06-22 | repo_only | docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-production-readiness-plan-2026-06-21 | repo_only | docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2508,6 +2508,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-option-box-deref-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-post-merge-closeout-2026-06-22",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md",

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -5515,6 +5515,13 @@ impl Lowerer {
                         // handle) rather than a raw IrUnaryOp(OpDeref) pointer load.
                         lo = lo.bind_local_struct_type(s.name, callee_struct_name)
                     }
+                } else if (*expr_box).kind == ExprKind::ExprIdent {
+                    // `let b = nx`: propagate the source variable's struct type (e.g. a Box
+                    // bound from `Some(nx)`) so `*b` / field access on b resolve correctly.
+                    let src_st = lo.lookup_local_struct_type((*expr_box).name)
+                    if src_st.len > 0 {
+                        lo = lo.bind_local_struct_type(s.name, src_st)
+                    }
                 }
             }
             _ => {}
@@ -6743,7 +6750,15 @@ impl Lowerer {
             Some(list) => {
                 let inner = (*list).head
                 if inner.kind == PatternKind::PatBinding {
-                    self.bind_local(inner.name, scrut, inner.is_mut)
+                    var lo = self.bind_local(inner.name, scrut, inner.is_mut)
+                    // The payload of `Some(nx)` on an Option<Box<T>> is a Box handle, so mark
+                    // the bound variable as a Box: `*nx` then lowers to the box-handle deref
+                    // (IrFieldGet 0) instead of raw-dereferencing the handle (which crashed —
+                    // the recursive-data root). Safe for non-Box payloads: marking only
+                    // changes how `*nx` lowers, and deref/field-access of a non-Box payload
+                    // (e.g. Option<i64>) is not valid code anyway.
+                    lo = lo.bind_local_struct_type(inner.name, make_name("Box"))
+                    lo
                 } else if inner.kind == PatternKind::PatWildcard {
                     // _ inside Some(_) — no binding needed
                     self


### PR DESCRIPTION
## Recursive data — `Some(nx) => (*nx).field` on `Option<Box<T>>`

`match opt { Some(nx) => (*nx).field }` crashed (139), blocking **all recursive data structures** (linked lists, trees). Root: `bind_match_sub_pattern` bound the `Some(nx)` payload (a Box **handle**) without tagging `nx` as a `Box`, so `*nx` lowered as a **raw** `OpDeref` (`mov rax,[rax]`) on the handle instead of the box-handle deref (`IrFieldGet 0`). A plain `let b = Box::new(…); (*b).v` worked because the let-binding tags the local `"Box"` — the `Some`-payload was the one spot that didn't.

### Fix (`lower.sio`)
1. `bind_match_sub_pattern` tags the `Some(nx)` payload `"Box"` — sound because the tag only changes how `*nx` lowers, and non-Box payloads (`Option<i64>`) don't support deref/field anyway.
2. `let b = <ident>` propagates the source's struct type (re-bound boxes resolve).

### Verified
Recursive `sum→42`, `cnt→2`, 3-node list `→42`; `Some(nx)=>(*nx).v→42`; `let b=nx→42`. No regression: `Option<i64> Some(v)=>v+1→42`; **53/90 run-pass = prebuilt +6, 0 regressed**; self-builds.

### Scope
`Option<struct>` (unboxed payload) field access, enum *payload* patterns (`E::A(x)`, E005), and array `++` are separate gaps. Detail: `docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md`.
