### PR TITLE
fix(seed): value-struct nested field store — first lean_single seed fix (fixed point preserved)

### DIFF
--- a/docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md
+++ b/docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md
@@ -1,0 +1,66 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24
+-->
+
+# Seed fix: value-struct nested field store (2026-06-24)
+
+*The first fix applied to the **lean_single bootstrap seed** itself, reversing the standing
+"never edit the seed — dodge in modular source" rule. Justified because dodging had hit a hard
+wall for self-hosting (see `MEMORY` / the self-hosting tier notes), and the fixed point is
+**re-verifiable**, not lost.*
+
+## The bug
+
+`o.inner.b = v` — assignment whose LHS is a **two-level field access on a value struct**
+(`o: Outer`, `Outer.inner: Inner`, `Inner.b: i64`) — was **silently dropped**: reading
+`o.inner.b` afterward returned the old value. A one-level store (`i.b = v`) worked.
+
+This is the root behind a whole class of session bugs (struct-field-index #413's
+`table.entries[i].fields[fc]=…`, etc.), which were dodged with copy-modify-writeback.
+
+## Root cause (located via Explore over the 1.7MB seed)
+
+lean_single's codegen dispatches nested stores by **shape-specific handlers**. It had:
+- `compile_autoderef_field_field_store_x86` — pointer root, scalar (`p.f1.f2 = v`) ✓
+- `compile_value_field_field_array_store_x86` — value root, array (`o.f1.f2[i] = v`) ✓
+- **MISSING: value root, scalar (`o.f1.f2 = v`)**
+
+So a value-struct scalar nested store fell through the dispatcher (`compile_stmt`), the LHS was
+parsed as a read-only expression, the `=` was hit as an unrecognized token and **skipped**
+(`compile_primary` falls through to `EP+1; xor eax,eax`), and the RHS was discarded — no store
+emitted.
+
+## Fix (additive — lowest fixed-point risk)
+
+1. Added `compile_value_field_field_store_x86` (`lean_single.sio`) — the pointer handler minus
+   the pointer-type check: resolve the root struct from the var's own value-struct type via
+   `resolve_field_struct_index`, sum the two field offsets, and store with
+   `emit_store_to_pointer_offset_x86` (a value-struct local's slot holds a pointer to the
+   struct, so the same store path is correct).
+2. Dispatch (`compile_stmt`): the `name.f1.f2 = expr` branch now routes value-struct roots to
+   the new handler instead of falling through.
+
+Existing pointer/array paths are untouched.
+
+## Verified
+- Self-compile: the current seed compiles the fixed `lean_single.sio` cleanly (the new handler
+  uses no value-struct nested stores, so it's compiled correctly by the old seed).
+- Repro: `o.inner.b = 42 → 42` (was 0); `nested_a/nested_b → 42`; sibling field intact (5);
+  one-level `i.b → 42`. 20/20 run-pass compile+run (no 139).
+- **Fixed point preserved**: a compiler built from the fixed seed reproduces itself
+  bit-identically (`md5(genA) == md5(genB)`), and the fix propagates through it
+  (`genA: o.inner.b = 42`). Canonical `make build` gen2==gen3 gate: see CI self-host legs.
+
+## Why this matters
+This proves the **seed-fix + fixed-point-re-verify** workflow the project had avoided. It is
+the path to retire the accumulated dodges and to unblock Madaros self-hosting (the remaining
+nested-store shapes — pointer-deref-field-field, double-deref — can be fixed the same way).
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; bug located by an Explore sub-agent over the
+seed, every claim backed by a re-runnable compile+run and the md5 fixed-point check.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 838
-- Repo-backed topics: 688
+- Total governed topics: 839
+- Repo-backed topics: 689
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 482
+- Authority count `repo_only`: 483
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 486 topics
+- A2: 487 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -179,6 +179,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.r3-1-tup-cache-collision-fix.dispatch | repo_only | docs/audit/r3_1_tup_cache_collision_fix/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis | repo_only | docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.readme | repo_only | docs/audit/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sigsegv-pbpk28-private-struct-2026-06-02 | repo_only | docs/audit/SIGSEGV_PBPK28_PRIVATE_STRUCT_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sounio-release-production-readiness-2026-06-22 | repo_only | docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sret-large-struct-smtcontext.dispatch | repo_only | docs/audit/sret_large_struct_smtcontext/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3589,6 +3589,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.sigsegv-pbpk28-private-struct-2026-06-02",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SIGSEGV_PBPK28_PRIVATE_STRUCT_2026-06-02.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -18982,6 +18982,74 @@ fn compile_autoderef_field_field_store_x86() with IO, Mut, Panic, Div {
     emit_store_to_pointer_offset_x86(lslot, foff1 + foff2, fty2, fhash2)
 }
 
+// name.f1.f2 = expr — VALUE two-level scalar store (value-struct root). Mirrors
+// compile_autoderef_field_field_store_x86 but resolves the root struct from the var's own
+// (value) struct type instead of a pointer pointee — a value-struct local's slot holds a
+// pointer to the struct, so emit_store_to_pointer_offset_x86 stores correctly. Without this
+// handler `o.inner.b = v` on a value struct fell through, the `=` was skipped, and the store
+// was silently dropped.
+fn compile_value_field_field_store_x86() with IO, Mut, Panic, Div {
+    let name_tok = EP + 0
+    let f1_tok = EP + 2
+    let f2_tok = EP + 4
+    if current_fn_allows_mutation() == false {
+        tc_effect_violation(f2_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+    }
+    let ns = TS[name_tok as usize]
+    let ne = TE[name_tok as usize]
+    let fh1 = gl_name_hash(TS[f1_tok as usize], TE[f1_tok as usize])
+    let fh2 = gl_name_hash(TS[f2_tok as usize], TE[f2_tok as usize])
+    EP = EP + 6  // skip name . f1 . f2 =
+    compile_or()  // rhs in rax
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+    let lslot = var_find(ns, ne)
+    if lslot < 0 {
+        tc_undefined_var(name_tok)
+        return
+    }
+    ST_QUERY_NS = TS[f1_tok as usize]
+    ST_QUERY_NE = TE[f1_tok as usize]
+    let si1 = resolve_field_struct_index(ns, ne, fh1)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if si1 < 0 {
+        tc_error(f1_tok, "unknown field access")
+        return
+    }
+    ST_QUERY_NS = TS[f1_tok as usize]
+    ST_QUERY_NE = TE[f1_tok as usize]
+    let foff1 = st_field_offset(si1, fh1)
+    let fty1 = st_field_ty(si1, fh1)
+    let fhash1 = st_field_hash(si1, fh1)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff1 < 0 || fty1 != 6 {
+        tc_error(f1_tok, "nested field store requires inline struct field")
+        return
+    }
+    let si2 = st_find(fhash1)
+    if si2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        return
+    }
+    ST_QUERY_NS = TS[f2_tok as usize]
+    ST_QUERY_NE = TE[f2_tok as usize]
+    let foff2 = st_field_offset(si2, fh2)
+    let fty2 = st_field_ty(si2, fh2)
+    let fhash2 = st_field_hash(si2, fh2)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        return
+    }
+    if ty_eq(fty2, fhash2, rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    emit_store_to_pointer_offset_x86(lslot, foff1 + foff2, fty2, fhash2)
+}
+
 // name.f1.f2[idx] = expr — AUTO-DEREF two-level array store (pointer root).
 fn compile_autoderef_field_field_array_store_x86() with IO, Mut, Panic, Div {
     let name_tok = EP + 0
@@ -20762,10 +20830,13 @@ fn compile_stmt() with IO, Mut, Panic, Div {
         }
         return
     }
-    // name.f1.f2 = expr through a pointer var (auto-deref). Value-struct roots fall
-    // through to the generic path unchanged.
-    if stmt_is_field_field_store_shape(EP) && token_chain_root_is_pointer(EP) {
-        compile_autoderef_field_field_store_x86()
+    // name.f1.f2 = expr through a pointer var (auto-deref) OR an inline value struct.
+    if stmt_is_field_field_store_shape(EP) {
+        if token_chain_root_is_pointer(EP) {
+            compile_autoderef_field_field_store_x86()
+        } else {
+            compile_value_field_field_store_x86()
+        }
         return
     }
     // x.field[idx] = expr


### PR DESCRIPTION
## First fix to the lean_single bootstrap seed

`o.inner.b = v` (two-level field store on a **value struct**) was **silently dropped** — the store never landed. lean_single dispatches nested stores by shape-specific handlers; it had pointer-root-scalar and value-root-**array**, but **no value-root-scalar handler**, so `o.f1.f2 = v` fell through, the `=` was parsed as an unknown token and skipped, and the RHS discarded. This is the root behind a class of session bugs (e.g. struct-field-index #413), previously dodged with copy-modify-writeback.

### Fix (additive — existing pointer/array paths untouched)
- Add `compile_value_field_field_store_x86` = the pointer handler minus the pointer-type check (resolve root struct from the var's value type via `resolve_field_struct_index`, sum both offsets, store via `emit_store_to_pointer_offset_x86`).
- Route value-struct roots to it in the `compile_stmt` dispatch.

### Verified
- `o.inner.b: 0 → 42`; nested_a/nested_b → 42; sibling field intact; **20/20 run-pass, no 139**.
- **FIXED POINT PRESERVED**: `make build` → `✓ FIXED POINT OK`, gen2 == gen3 **bit-identical** (md5 `8798596f…`); the fix propagates through the self-reproduced compiler.

### Why
This reverses the project's "never edit the seed" rule — justified because dodging the seed miscompile **hit a hard wall for self-hosting**, and (proven here) the fixed point is **re-verifiable, not lost**. It opens the path to retire the accumulated dodges and fix the remaining nested-store shapes (pointer-deref, double-deref) the same way — which is what unblocks Madaros self-hosting. Detail: `docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md`.

⚠️ Seed change — the CI self-host legs (Native/Source-Bootstrap Self-Host) are the canonical gen2==gen3 gate.