### PR TITLE
fix(seed): general lvalue base for deref indexed-field stores (double-deref); fixed point preserved

### DIFF
--- a/docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md
+++ b/docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md
@@ -1,0 +1,59 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24
+-->
+
+# Seed fix: general lvalue base for deref indexed-field stores (2026-06-24)
+
+*Second fix to the lean_single bootstrap seed. Closes the **complex-base** indexed-store class
+that blocked heap-indirect data structures (the path to Madaros self-hosting).*
+
+## The bug
+
+A store whose LHS is a deref of an **arbitrary pointer expression** —
+`(*(*c).w).data[i] = v`, and the exact shape the heap-indirect checker uses,
+`(*(*c).fn_sigs.entries).data[i] = sig` — was **silently dropped**. A simple-name deref store
+`(*p).field[i] = v` worked.
+
+## Root cause
+
+lean_single dispatches stores via ~16 shape-specific handlers, **every one of which hardcodes
+a simple-variable root** (`var_find(ns, ne)`). There is **no general lvalue-address routine**.
+When the base is a complex expression (`(*c).w`), no pattern matches, the LHS is parsed as a
+read-only expression, the `=` is hit as an unrecognized token and skipped, and the RHS is
+discarded.
+
+## Fix (additive — existing handlers untouched)
+
+1. `stmt_is_deref_complex_field_array_store` — detector for `(*<complex>).field[idx] = …`,
+   discriminated from the simple-name form by `TK[p0+2]==6` (the inner is parenthesized);
+   paren-matches the outer `(` to locate `.field[ … ] =`.
+2. `compile_deref_complex_field_array_store_x86` — evaluates the **base pointer with
+   `compile_or`** (so any nesting works), then stores: push base, push index, `rhs→rdx`,
+   pop index→rcx, pop base→rax, `lea rax,[rax+foff]`, `mov [rax+rcx*esize], …`. Field offset
+   and element size are resolved from the base pointer's pointee struct type.
+3. Dispatch: route the complex shape ahead of the simple-name deref handlers (no conflict —
+   they require a simple-name root).
+
+This generalises the lvalue base for the indexed-field deref store, closing the whole
+complex-base class in one handler rather than a shape at a time.
+
+## Verified
+- `(*(*c).w).data[i]: 0 → 42`; inline double-deref `→ 99`. No regression: simple
+  `(*p).inner.arr[i] → 42`, the #427 value-nested `o.inner.b → 42`, 15/15 run-pass no-139.
+- **Fixed point preserved**: `make build` gen2==gen3 bit-identical (CI self-host legs are the
+  canonical gate).
+
+## Why
+This is the access shape heap-indirect Checker tables (the rustc-`TyCtxt` pattern) require.
+With it, the scale fix that makes Madaros type-check its own 117-module source becomes
+expressible without dodges. Scalar complex-base derefs and the a64 path are follow-ups.
+
+## AI disclosure
+Fix by AI agent (Claude) under human direction; the missing-general-lvalue root was located by
+an Explore sub-agent over the seed; every claim is backed by a re-runnable compile+run and the
+md5 fixed-point check.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 839
-- Repo-backed topics: 689
+- Total governed topics: 840
+- Repo-backed topics: 690
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 483
+- Authority count `repo_only`: 484
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 487 topics
+- A2: 488 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -179,6 +179,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.r3-1-tup-cache-collision-fix.dispatch | repo_only | docs/audit/r3_1_tup_cache_collision_fix/DISPATCH.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.r3-1-tup-cache-collision-fix.synthesis | repo_only | docs/audit/r3_1_tup_cache_collision_fix/SYNTHESIS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.readme | repo_only | docs/audit/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24 | repo_only | docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sigsegv-pbpk28-private-struct-2026-06-02 | repo_only | docs/audit/SIGSEGV_PBPK28_PRIVATE_STRUCT_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.sounio-release-production-readiness-2026-06-22 | repo_only | docs/audit/SOUNIO_RELEASE_PRODUCTION_READINESS_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3589,6 +3589,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.seed-fix-general-lvalue-deref-store-2026-06-24",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.seed-fix-value-nested-field-store-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/SEED_FIX_VALUE_NESTED_FIELD_STORE_2026-06-24.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -4559,6 +4559,36 @@ fn stmt_is_deref_field_array_store(p0: i64) -> bool with Panic, Mut {
     return TK[p as usize] == 16
 }
 
+// (*<complex-expr>).field[idx] = expr — indexed field store through a deref whose base is an
+// arbitrary parenthesized expression (e.g. (*(*c).w).data[i]). Discriminated from the
+// simple-name form by TK[p0+2]==6 (the inner is itself parenthesized). Paren-matches the
+// outer ( to locate .field[ ... ] = . Handled by compile_deref_complex_field_array_store_x86,
+// which evaluates the base with compile_or (so any nesting works).
+fn stmt_is_deref_complex_field_array_store(p0: i64) -> bool with Panic, Mut {
+    if TK[p0 as usize] != 6 { return false }        // (
+    if TK[(p0 + 1) as usize] != 19 { return false } // *
+    if TK[(p0 + 2) as usize] != 6 { return false }  // ( — parenthesized (complex) inner base
+    var p = p0 + 1
+    var pdepth: i64 = 1
+    while p < TC && pdepth > 0 {
+        if TK[p as usize] == 6 { pdepth = pdepth + 1 }
+        if TK[p as usize] == 7 { pdepth = pdepth - 1 }
+        p = p + 1
+    }
+    if p + 2 >= TC { return false }
+    if TK[p as usize] != 50 { return false }         // .
+    if TK[(p + 1) as usize] != 3 { return false }    // field name
+    if TK[(p + 2) as usize] != 41 { return false }   // [
+    var q = p + 3
+    var bdepth: i64 = 1
+    while q < TC && bdepth > 0 {
+        if TK[q as usize] == 41 { bdepth = bdepth + 1 }
+        if TK[q as usize] == 42 { bdepth = bdepth - 1 }
+        q = q + 1
+    }
+    return q < TC && TK[q as usize] == 16            // =
+}
+
 // (*name).f1.f2 = expr  — TWO-level nested store through an explicit deref.
 // Tokens: ( * name ) . f1 . f2 =  →  6 19 3 7 50 3 50 3 16
 // lean_single had detectors for (*p).f= and (*p).f[i]= but NOT the two-hop forms,
@@ -18751,6 +18781,80 @@ fn compile_deref_field_array_store_x86() with IO, Mut, Panic, Div {
     }
 }
 
+// (*<expr>).field[idx] = expr — indexed field store through a deref of an ARBITRARY
+// pointer expression (not just a simple var). The base pointer is produced by evaluating
+// the inner expression with compile_or, so any nesting works — e.g. (*(*c).w).data[i] or
+// (*(*c).fn_sigs.entries).data[i]. lean_single previously had no general lvalue-address
+// path: every deref store hardcoded a simple-name root via var_find, so a complex base
+// fell through and the store was silently dropped. This closes the whole complex-base
+// indexed-store class.
+fn compile_deref_complex_field_array_store_x86() with IO, Mut, Panic, Div {
+    EP = EP + 2  // skip outer ( *
+    compile_or()  // inner expr -> base pointer in rax
+    let base_ty = EXPR_TY
+    let base_hash = EXPR_TY_HASH
+    if TK[EP as usize] == 7 { EP = EP + 1 }  // skip outer )
+    if type_is_pointer_like(base_ty, base_hash) == false {
+        tc_error(EP, "indexed field store through deref requires pointer base")
+        return
+    }
+    let inner_ty = ptr_hash_inner_ty(base_hash)
+    let inner_hash = ptr_hash_inner_hash(base_hash)
+    if inner_ty != 6 {
+        tc_error(EP, "field access through pointer/ref requires struct pointee")
+        return
+    }
+    let si = st_find(inner_hash)
+    if si < 0 {
+        tc_error(EP, "unknown field access")
+        return
+    }
+    em(0x50)  // push base pointer
+    if TK[EP as usize] == 50 { EP = EP + 1 }  // skip .
+    let field_tok = EP
+    let fns = TS[EP as usize]
+    let fne = TE[EP as usize]
+    let fh = gl_name_hash(fns, fne)
+    EP = EP + 1  // skip field name
+    if TK[EP as usize] == 41 { EP = EP + 1 }  // skip [
+    if current_fn_allows_mutation() == false {
+        tc_effect_violation(field_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+    }
+    compile_or()  // index in rax
+    if TK[EP as usize] == 37 { EP = EP + 1; EP = EP + 1 }  // as usize
+    if TK[EP as usize] == 42 { EP = EP + 1 }  // ]
+    if TK[EP as usize] == 16 { EP = EP + 1 }  // =
+    em(0x50)  // push index
+    compile_or()  // rhs in rax
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+    ST_QUERY_NS = fns
+    ST_QUERY_NE = fne
+    let foff = st_field_offset(si, fh)
+    let fty = st_field_ty(si, fh)
+    let fhash = st_field_hash(si, fh)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if fty != 8 {
+        tc_error(field_tok, "indexed field store requires array field")
+        em(0x59); em(0x59)
+        return
+    }
+    if ty_eq(arr_hash_elem_ty(fhash), arr_hash_elem_hash(fhash), rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    materialize_aggregate_array_element_x86(fhash)
+    em(0x48); em(0x89); em(0xc2)  // mov rdx, rax (rhs)
+    em(0x59)  // pop rcx (index)
+    em(0x58)  // pop rax (base pointer)
+    if foff != 0 { em(0x48); em(0x8d); em(0x80); em32(foff) }  // lea rax, [rax + foff]
+    if arr_hash_esiz(fhash) == 8 {
+        em(0x48); em(0x89); em(0x14); em(0xc8)  // mov [rax + rcx*8], rdx
+    } else {
+        em(0x88); em(0x14); em(0x08)  // mov [rax + rcx], dl
+    }
+}
+
 // (*name).f1.f2 = expr — two-level nested scalar/aggregate store through a deref.
 // Mirrors the single-field stmt_is_deref_field_store path, but resolves a second
 // inline struct hop and sums both field offsets. f1 must be an inline struct field.
@@ -21136,6 +21240,11 @@ fn compile_stmt() with IO, Mut, Panic, Div {
     // (*name).field[idx] = expr  (explicit-deref store into a struct array field)
     if stmt_is_deref_field_array_store(EP) {
         compile_deref_field_array_store_x86()
+        return
+    }
+    // (*<complex-expr>).field[idx] = expr  (e.g. (*(*c).w).data[i]) — general deref base
+    if stmt_is_deref_complex_field_array_store(EP) {
+        compile_deref_complex_field_array_store_x86()
         return
     }
     // (*ARRAY_PTR)[idx] = expr


### PR DESCRIPTION
## Second seed fix — the seed's first general lvalue-address path

A store whose LHS is a deref of an **arbitrary pointer expression** — `(*(*c).w).data[i] = v`, and the exact shape the heap-indirect checker uses `(*(*c).fn_sigs.entries).data[i] = sig` — was **silently dropped**. Simple-name `(*p).field[i] = v` worked.

**Root:** lean_single has ~16 shape-specific store handlers, **every one hardcoding a simple-variable root** (`var_find`) — no general lvalue-address routine. A complex base falls through, the `=` is skipped as an unknown token, and the RHS discarded.

### Fix (additive — existing handlers untouched)
- `stmt_is_deref_complex_field_array_store` — detector (discriminated by `TK[p0+2]==6` = parenthesized inner; paren-matches the outer `(`).
- `compile_deref_complex_field_array_store_x86` — evaluates the **base pointer via `compile_or`** (any nesting), then push base / push index / rhs→rdx / pop index→rcx / pop base→rax / `lea +foff` / `mov [rax+rcx*esize]`.
- Routed ahead of the simple-name deref handlers (no conflict). **Closes the whole complex-base indexed-store class** in one handler.

### Verified
- `(*(*c).w).data[i]: 0 → 42`; inline double-deref → 99. No regression: simple `(*p).inner.arr[i] → 42`, #427 value-nested `o.inner.b → 42`, **15/15 run-pass no-139**.
- **FIXED POINT PRESERVED**: `make build` → `✓ FIXED POINT OK`, gen2 == gen3 **bit-identical** (md5 `aa8db237…`).

### Why
This is the access shape **heap-indirect Checker tables** (rustc's `TyCtxt` pattern) need to make Madaros type-check its own 117-module source **without dodges**. Detail: `docs/audit/SEED_FIX_GENERAL_LVALUE_DEREF_STORE_2026-06-24.md`.

⚠️ Seed change — CI self-host legs are the canonical gen2==gen3 gate.