### PR TITLE
fix(parser): desugar tuple-destructuring let (a,b)=e to bind pattern vars

### DIFF
--- a/docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md
+++ b/docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md
@@ -1,0 +1,112 @@
+---
+docs:meta
+title: Madaros tuple-let binding desugar (parser)
+date: 2026-06-25
+status: fix landed (parse+check verified; value-semantics seed-verified)
+scope: self-hosted/parser/stmts.sio
+---
+
+# Madaros tuple-destructuring `let (a, b) = e` — binding desugar
+
+## Problem (the dispatch)
+
+The residual self-host typecheck errors after the line-start operator parser fix
+(`MADAROS_SELFHOST_TYPEENV_SRET_2026-06-25.md`) included a distinct class:
+tuple-destructuring `let (a, b) = e` did not bind its pattern variables, so every
+later use of `a`/`b` reported E137 (use of undeclared variable). Concentrated in
+the GPU SPIR-V modules (`gpu/epistemic_spirv.sio` etc.), which thread state with
+`let (idsN, x) = spv_alloc_id(s.ids)`.
+
+## Root cause
+
+`Stmt` (parser/ast.sio:330) carries a single `name: Name` — it cannot represent a
+tuple pattern. `parse_let_stmt` parsed the pattern but only set `name` when
+`pat.kind == PatBinding`; for a tuple pattern the parsed pattern was **discarded**
+and `name` stayed `empty_name()`. So `let (a, b) = e` produced one `StmtLet` with
+an empty name and the initializer — `a` and `b` were never recorded.
+
+## Fix (parser-only desugar)
+
+`self-hosted/parser/stmts.sio`. `let (a, b) = e` desugars to:
+
+```
+let __tupN = e      // primary StmtLet, returned by parse_let_stmt
+let a = __tupN.0     // pushed to TPLET_PENDING
+let b = __tupN.1     // pushed to TPLET_PENDING
+```
+
+drained by `parse_block` in source order. `N` is a per-parse counter so multiple
+tuple-lets in one block (the GPU pattern) get unique temps. Wildcards (`_`) are
+skipped (no binding emitted).
+
+### Why desugar, not a `pat` field on `Stmt`
+
+Adding `pat: Option<Box<Pattern>>` to `Stmt` and binding it in the checker would
+clear E137 but **break codegen**: `lower.sio` reads `s.name`/`s.expr`, so `a`/`b`
+would typecheck yet never destructure into IR — a green metric hiding a build
+break. The desugar instead reuses the fully-proven single-name `let` and tuple
+`.N` indexing paths on **both** the check and codegen sides, so it is correct
+regardless of which checker let-path runs and through lowering. Zero `Stmt`/
+checker changes.
+
+### Mechanism notes
+
+- Helpers are free functions defined before `impl Parser` to satisfy
+  define-before-use without depending on `stmt_list_append` /
+  `reverse_stmt_list_opt` (which appear later in the file).
+- `TPLET_PENDING` is a LIFO cons; `tplet_emit_elems` recurses on the tail
+  **before** pushing the head, so the pending list reads head→tail in source
+  order (FIFO). `parse_block` conses each onto the reverse-built `rev_stmts_opt`,
+  so after the block-end reverse the order is `primary, a, b`. Mirrors the
+  `reverse_stmt_list_loop` and `LAST_ASSIGN_TARGET` idioms already in the file.
+- `current_name()` reads the token's source text, so the real parser already
+  produces field name `"0"` for `pair.0`; the synthetic `ExprFieldAccess` built
+  here uses the same digit-`Name` representation the checker decodes
+  (check.sio:4538 reads `e.name.buf` as ascii digits).
+
+## Verification
+
+- **Build:** seed (lean_single) compiled the full self-hosted source with the
+  modified parser → working madaros (fns=9907). A break in non-tuple `let`
+  parsing would have failed this build over ~550k LOC.
+- **Check (Madaros, fresh build):** literal-RHS tuple-lets typecheck 100% clean
+  (E137 eliminated): `let (a,b)=(7,9)`, multiple lets per block, wildcard
+  `let (_,v)`, 3-tuple — all 0 errors. Non-tuple `let` unchanged (`check: OK`).
+- **Value semantics (lean_single seed, a known-working backend):** the
+  hand-written **desugared form** for `let (a,b)=(5,7)` prints **5 then 7** —
+  element ordering correct (`a←.0`, `b←.1`, not swapped). This is the load-bearing
+  proof that `check`-clean alone cannot give (a swapped desugar would also
+  typecheck). The seed itself cannot compile 3-element `.2` (old-engine limit);
+  the GPU modules use exclusively 2-tuples, and the 3-tuple path is the same code
+  with `idx+1` and is check-clean on the new build.
+- **Regression:** 0 error-count regressions across a 25-file run-pass sample
+  (artifacts vs new build); the desugar path only fires when a tuple-let
+  populated the queue, so non-tuple parsing is behaviour-identical.
+
+## Honest scope — what this does NOT do (next dispatch)
+
+Removing the E137s **unmasks** pre-existing, orthogonal bugs that were hidden
+behind them (E000 is a per-module fallback that only prints when no other
+diagnostic emitted; the E137s were setting `diag_emitted`, masking these):
+
+1. **Tuple types in function signatures fail typecheck (E000).** An *uncalled*
+   `fn pr() -> (i64, i64) { (1,2) }` errors; a tuple param errors. So the GPU
+   modules' `spv_alloc_id`-style tuple-returning helpers still fail to typecheck
+   after this fix. (A tuple *literal* bound locally — `let p = (1,2)` — is fine.)
+2. **`[i8;32]` vs `[i64;32]` array binding mismatches** surface in
+   `epistemic_spirv.sio` (2× E001) once the checker reaches past the former
+   E137 early-bail. These cannot originate from this diff (it only emits tuple
+   `.N` field access); they are real pre-existing errors now reached.
+3. **Madaros native run/`println(int)` backend is broken for all programs**
+   (SIGSEGV on `println(5+3)` too) — value witnesses here were taken via the
+   lean_single seed, not the madaros backend.
+
+**Therefore: the 588 residual E137 are addressed at the binding level, but the
+GPU SPIR-V modules do NOT yet fully typecheck or compile** — the tuple-signature
+and array-type bugs above are the next dispatch.
+
+## AI disclosure
+
+Diagnosis and fix by AI agent (Claude) under human direction; every claim is
+re-runnable against the cited source lines, the fresh build, and the lean_single
+seed.

--- a/docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md
+++ b/docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-tuple-let-desugar-2026-06-25
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-tuple-let-desugar-2026-06-25
+-->
+
 ---
 docs:meta
 title: Madaros tuple-let binding desugar (parser)

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 841
-- Repo-backed topics: 691
+- Total governed topics: 842
+- Repo-backed topics: 692
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 485
+- Authority count `repo_only`: 486
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 489 topics
+- A2: 490 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -145,6 +145,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-sret-root-synthesis-2026-06-20 | repo_only | docs/audit/MADAROS_SRET_ROOT_SYNTHESIS_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-string-concat-2026-06-24 | repo_only | docs/audit/MADAROS_STRING_CONCAT_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-struct-field-index-fallback-2026-06-23 | repo_only | docs/audit/MADAROS_STRUCT_FIELD_INDEX_FALLBACK_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-tuple-let-desugar-2026-06-25 | repo_only | docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-audit-2026-06-10 | repo_only | docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-compiler-stack-clash-2026-05-29 | repo_only | docs/audit/MODULAR_COMPILER_STACK_CLASH_2026-05-29.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.modular-pipe-coverage-map-2026-06-01 | repo_only | docs/audit/MODULAR_PIPE_COVERAGE_MAP_2026-06-01.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2807,6 +2807,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-tuple-let-desugar-2026-06-25",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.modular-compiler-audit-2026-06-10",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MODULAR_COMPILER_AUDIT_2026-06-10.md",

--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -5,7 +5,7 @@
 
 use parser::ast::*
 use lexer::token::*
-use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_take_expr_box, parser_advance, parser_assign_op_code, error_expr}
+use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_take_expr_box, parser_advance, parser_assign_op_code, error_expr, mk_expr}
 
 // Lean compiler safety: keep assignment targets out of the local frame while
 // recursively parsing the RHS. Holding both Boxes locally corrupts some nested
@@ -26,6 +26,101 @@ fn stmt_take_assign_target() -> Box<Expr> with Mut, Alloc {
             LAST_ASSIGN_TARGET = None
             Box::new(error_expr(Span { file_id: 0, start: 0, end: 0 }))
         },
+    }
+}
+
+// ============================================================
+// Tuple-let desugaring side table.
+//
+// `let (a, b) = e` cannot be represented by a single Stmt (which has one `name`
+// field), so the parser desugars it to a primary `let __tupN = e` (returned as
+// the statement) plus per-element `let a = __tupN.0` / `let b = __tupN.1`
+// bindings pushed here and drained by parse_block in source order. This reuses
+// the fully-proven single-name let and tuple-`.N` indexing paths on BOTH the
+// checker and codegen sides — unlike carrying a pattern on Stmt, which would
+// typecheck but never destructure in lowering. Mirrors the LAST_ASSIGN_TARGET
+// idiom (keep the large Stmt nodes off the parse frame).
+//
+// Defined as free helpers before `impl Parser` so callers (parse_let_stmt,
+// parse_block) satisfy the define-before-use rule without depending on
+// stmt_list_append / reverse_stmt_list_opt (which appear later in this file).
+// ============================================================
+var TPLET_PENDING: Option<Box<StmtList>> = None
+var TPLET_COUNTER: i64 = 0
+
+// Name holding the decimal ascii of a non-negative integer (tuple index 0,1,..).
+fn tplet_index_name(n: i64) -> Name with Mut, Panic, Div {
+    var name = empty_name()
+    if n <= 0 {
+        name.buf[0] = 48 as i8
+        name.len = 1
+        return name
+    }
+    var digits: [i8; 24] = [0; 24]
+    var cnt: i64 = 0
+    var v = n
+    while v > 0 {
+        digits[cnt as usize] = (48 + (v % 10)) as i8
+        v = v / 10
+        cnt = cnt + 1
+    }
+    var i: i64 = 0
+    while i < cnt {
+        name.buf[i as usize] = digits[(cnt - 1 - i) as usize]
+        i = i + 1
+    }
+    name.len = cnt
+    name
+}
+
+// Unique temp Name `__tupN` for the desugared tuple value (N = call counter).
+fn tplet_temp_name(ctr: i64) -> Name with Mut, Panic, Div {
+    var name = make_name("__tup")
+    let d = tplet_index_name(ctr)
+    var i: i64 = 0
+    while i < d.len {
+        name.buf[(name.len + i) as usize] = d.buf[i as usize]
+        i = i + 1
+    }
+    name.len = name.len + d.len
+    name
+}
+
+// Push an element binding to the FIFO pending queue. Implemented as a LIFO cons;
+// tplet_emit_elems recurses-before-push so source order ends up FIFO at the head.
+fn tplet_push(s: Stmt) with Mut, Alloc {
+    let prev = TPLET_PENDING
+    TPLET_PENDING = Some(Box::new(StmtList { head: s, tail: prev }))
+}
+
+// Emit `let <binder> = __tup.<idx>` for each sub-pattern of a tuple let.
+// Wildcards / non-binding sub-patterns are skipped (no variable to bind).
+// Recurses on the tail BEFORE pushing the head so that, combined with the LIFO
+// tplet_push, the pending list reads head->tail in source order (FIFO).
+fn tplet_emit_elems(opt: Option<Box<PatternList>>, temp: Name, span: Span, idx: i64) with Mut, Panic, Div, Alloc {
+    match opt {
+        Some(list) => {
+            let sub = (*list).head
+            tplet_emit_elems((*list).tail, temp, span, idx + 1)
+            if sub.kind == PatternKind::PatBinding {
+                var ident = mk_expr(ExprKind::ExprIdent, span)
+                ident.name = temp
+                var field = mk_expr(ExprKind::ExprFieldAccess, span)
+                field.name = tplet_index_name(idx)
+                field.left = Some(Box::new(ident))
+                let elem = Stmt {
+                    kind: StmtKind::StmtLet,
+                    span: span,
+                    name: sub.name,
+                    ty: None,
+                    expr: Some(Box::new(field)),
+                    target: None,
+                    assign_op: AssignOp::AssignEq,
+                }
+                tplet_push(elem)
+            }
+        },
+        None => {},
     }
 }
 
@@ -92,6 +187,21 @@ impl Parser {
 
             rev_stmts_opt = Some(Box::new(StmtList { head: stmt, tail: rev_stmts_opt }))
 
+            // Drain tuple-let element bindings desugared by parse_let_stmt. The
+            // pending list reads head->tail in source order; consing each onto
+            // the reverse-built rev_stmts_opt keeps them right after their
+            // primary `let __tupN = e` once the block list is reversed.
+            while true {
+                match TPLET_PENDING {
+                    Some(node) => {
+                        let elem = (*node).head
+                        TPLET_PENDING = (*node).tail
+                        rev_stmts_opt = Some(Box::new(StmtList { head: elem, tail: rev_stmts_opt }))
+                    },
+                    None => break,
+                }
+            }
+
             // Skip optional semicolons between statements
             while parser_peek(p) == TokenKind::Semi {
                 p = p.advance()
@@ -151,6 +261,27 @@ impl Parser {
         let init_box = parser_take_expr_box()
 
         let span = p.span_from(start)
+
+        // Tuple-destructuring let: `let (a, b) = e`. The pattern cannot live on
+        // the single-name Stmt, so desugar to `let __tupN = e` (returned here)
+        // plus `let a = __tupN.0` / `let b = __tupN.1` pushed to TPLET_PENDING
+        // and drained by parse_block. See the tuple-let side table above.
+        if pat.kind == PatternKind::PatTuple {
+            let ctr = TPLET_COUNTER
+            TPLET_COUNTER = TPLET_COUNTER + 1
+            let temp = tplet_temp_name(ctr)
+            tplet_emit_elems(pat.sub_patterns, temp, span, 0)
+            return (p, Stmt {
+                kind: StmtKind::StmtLet,
+                span: span,
+                name: temp,
+                ty: ty_opt,
+                expr: Some(init_box),
+                target: None,
+                assign_op: AssignOp::AssignEq,
+            })
+        }
+
         (p, Stmt {
             kind: StmtKind::StmtLet,
             span: span,


### PR DESCRIPTION
Stacked on #430 (base = `feat/madaros-bump-arena`) — this PR adds exactly one commit.

## Problem

`let (a, b) = e` parsed the tuple pattern then **discarded** it (`Stmt` carries a single `name`), so `a`/`b` were never recorded → E137 on every use. These were the residual self-host E137 after the line-start operator fix, concentrated in the GPU SPIR-V modules.

## Fix (parser-only desugar)

`let (a,b)=e` → `let __tupN=e` (returned) + `let a=__tupN.0` / `let b=__tupN.1` pushed to a pending queue drained by `parse_block` in source order. Reuses the fully-proven single-name `let` and tuple-`.N` indexing on **both** check and codegen sides — unlike carrying a pattern on `Stmt`, which would typecheck but never destructure in lowering. Wildcards skipped; per-parse counter for unique temps; helpers free-defined before `impl Parser` to avoid forward refs.

## Verification

- Seed (lean_single) rebuilt the full self-hosted source with the modified parser → working madaros (fns=9907).
- Literal-RHS tuple-lets typecheck 100% clean (E137 eliminated); non-tuple `let` unchanged.
- **Element ordering value-correct on the seed backend:** `let (a,b)=(5,7)` → prints **5 then 7** (not swapped) — the load-bearing proof `check`-clean alone cannot give. (Madaros's own native backend SIGSEGVs on all programs, incl. `println(5+3)`, so witnesses were taken via the seed.)
- 0 regressions across a 25-file run-pass sample.

## Honest scope — what this does NOT do (next dispatch)

Removing the E137 **unmasks** three pre-existing, orthogonal bugs they were hiding (E000 is a per-module fallback suppressed when any other diagnostic emits):

1. **Tuple types in function signatures fail typecheck (E000)** — even an uncalled `fn pr()->(i64,i64)`; so the GPU modules' tuple-returning helpers still fail.
2. **`[i8;32]`/`[i64;32]` array mismatches** in `epistemic_spirv.sio` (2× E001), now reached past the former E137 early-bail.
3. **Madaros native run/`println` backend SIGSEGVs on all programs.**

**The 588 residual E137 are addressed at the binding level, but the GPU SPIR-V modules do NOT yet fully typecheck/compile** — bugs #1/#2 are the next dispatch. See `docs/audit/MADAROS_TUPLE_LET_DESUGAR_2026-06-25.md`.