### PR TITLE
fix(check): lower tuple types in function signatures (E000 → typed)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -1436,6 +1436,24 @@ fn checker_lower_fn_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry wi
     ty_fn(sig_id)
 }
 
+fn checker_lower_type_expr_list_mut(c: *mut Checker, tel: TypeExprList) -> TypeEntryList with Mut, Panic, Div, Alloc, IO {
+    let head_ty = checker_lower_type_expr_mut(c, tel.head)
+    match tel.tail {
+        None => TypeEntryList { head: head_ty, tail: None }
+        Some(rest) => {
+            let rest_list = checker_lower_type_expr_list_mut(c, *rest)
+            TypeEntryList { head: head_ty, tail: Some(Box::new(rest_list)) }
+        }
+    }
+}
+
+fn checker_lower_tuple_type_mut(c: *mut Checker, opt: Option<Box<TypeExprList> >) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(tel) => ty_tuple(checker_lower_type_expr_list_mut(c, *tel))
+        None => ty_unit()
+    }
+}
+
 fn checker_lower_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
     if !checker_enter_type_expr_mut(c) {
         return ty_error()
@@ -1530,6 +1548,7 @@ fn checker_lower_type_expr_mut(c: *mut Checker, te: TypeExpr) -> TypeEntry with 
         }
         TypeExprKind::TypeFn => checker_lower_fn_type_expr_mut(c, te)
         TypeExprKind::TypeArray => checker_lower_array_type_mut(c, te.inner, te.array_size)
+        TypeExprKind::TypeTuple => checker_lower_tuple_type_mut(c, te.type_args)
         TypeExprKind::TypeReference => checker_lower_ref_type_mut(c, te.inner)
         TypeExprKind::TypeRefMut => checker_lower_ref_mut_type_mut(c, te.inner)
         _ => {

--- a/tests/compile-fail/tuple_signature_param_arity_mismatch.sio
+++ b/tests/compile-fail/tuple_signature_param_arity_mismatch.sio
@@ -1,0 +1,10 @@
+//@ compile-fail
+//@ error-pattern: "argument type does not match parameter"
+
+fn sum_pair(p: (i64, i64)) -> i64 {
+    p.0 + p.1
+}
+
+fn main() {
+    let total = sum_pair((1, 2, 3))
+}

--- a/tests/compile-fail/tuple_signature_param_type_mismatch.sio
+++ b/tests/compile-fail/tuple_signature_param_type_mismatch.sio
@@ -1,0 +1,10 @@
+//@ compile-fail
+//@ error-pattern: "argument type does not match parameter"
+
+fn sum_pair(p: (i64, i64)) -> i64 {
+    p.0 + p.1
+}
+
+fn main() {
+    let total = sum_pair((1.5, 2))
+}

--- a/tests/run-pass/tuple_signature_param_return.sio
+++ b/tests/run-pass/tuple_signature_param_return.sio
@@ -1,0 +1,16 @@
+//@ run-pass
+//@ check-only
+
+fn make_pair(x: i64) -> (i64, i64) {
+    (x, x + 1)
+}
+
+fn sum_pair(p: (i64, i64)) -> i64 {
+    p.0 + p.1
+}
+
+fn main() {
+    let p = make_pair(20)
+    let total = sum_pair(p)
+    assert(total == 41)
+}

--- a/tests/run-pass/tuple_signature_uncalled_param.sio
+++ b/tests/run-pass/tuple_signature_uncalled_param.sio
@@ -1,0 +1,9 @@
+//@ run-pass
+//@ check-only
+
+fn first(p: (i64, i64)) -> i64 {
+    p.0
+}
+
+fn main() {
+}

--- a/tests/run-pass/tuple_signature_uncalled_return.sio
+++ b/tests/run-pass/tuple_signature_uncalled_return.sio
@@ -1,0 +1,9 @@
+//@ run-pass
+//@ check-only
+
+fn pr() -> (i64, i64) {
+    (1, 2)
+}
+
+fn main() {
+}


### PR DESCRIPTION
## Problem

`checker_lower_type_expr_mut` had no `TypeExprKind::TypeTuple` arm, so a tuple type in a **return or parameter** position fell to the default and lowered to `ty_error` → silent **E000**. Tuple values inferred from a local literal already worked (`ty_tuple`); only the signature-position `TypeExpr → TypeEntry` lowering was missing.

This was the deeper bug unmasked by the tuple-let binding fix (#431) — it blocks the GPU SPIR-V modules, which thread state via `let (idsN, x) = spv_alloc_id(...)` returning tuples.

## Fix

Add `checker_lower_type_expr_list_mut` + `checker_lower_tuple_type_mut` and plug the `TypeTuple` arm (check.sio:1551), mirroring the by-value `lower_tuple_type` path. Empty tuple → unit.

## Verification (fresh Madaros build)

**Accept** (0 errors): tuple return type (uncalled), tuple param, tuple param+return, **nested** `((i64,i64),i64)`, 3-tuple.

**Reject** (soundness — no over-acceptance): return-element mismatch `(i64,bool)←(1,2)`, annotation arity `(i64,i64)←(1,2,3)`, annotation type `(i64,bool)←(1,2)`, plus param arity/type mismatches at call sites (E009).

**Real module**: `epistemic_spirv.sio` loses its tuple-signature E000s — only the 2 separate `[i8;32]`/`[i64;32]` E001 array mismatches remain (a distinct pre-existing bug, **not** addressed here).

Tests: 3 positive (run-pass) + 2 negative (compile-fail); aggregated harness 5/5.