### PR TITLE
[codex] restore Madaros visibility and refresh prebuilt

### DIFF
--- a/docs/compiler/KNOWN_LIMITATIONS.md
+++ b/docs/compiler/KNOWN_LIMITATIONS.md
@@ -67,11 +67,11 @@ Tiers below mirror the public-claim registry's `claim_level`/`closure_status` co
 | **Hypercomplex NN (broad)** | `hypercomplex.nn = prototype` | Research/prototype unless a named gate covers the exact behavior. |
 | **Direct-driver execution at scale** | `direct_driver = prototype` | Large-surface direct-driver execution is a maturity frontier. |
 | **Windows target** | `platform.windows = prototype` | PE/COFF lane wired; not stable. |
-| **`binary.source` (modular self-hosted tree)** | `prototype` | `lean_single.sio` remains the checked binary source until parity gates prove a swap. See "Multi-Module Bundle Gap" below. |
+| **`binary.source` (modular self-hosted tree)** | `validated_research` | The checked x86-64 Madaros prebuilt is built from `self-hosted/compiler/main.sio` and covered by the named Madaros source-to-ELF/full gates. This claim applies to `bin/madaros-linux-x86_64`, not the legacy `bin/souc-linux-x86_64`; `lean_single.sio` remains the bootstrap seed and escape hatch. |
 
 ### Active Known Bugs / Architectural Gaps
 
-**Multi-module bundle compile — RESOLVED 2026-05-29.** All three G1 architectural roots closed. Bundle: **0 errors** (arc 766 → 0, commits `fcce29dd3` through `8c4f619de`). The modular self-hosted tree (`self-hosted/compiler/main.sio`) now compiles clean. The gate to "modular source replaces `lean_single.sio`" is open.
+**Multi-module bundle compile — RESOLVED 2026-05-29.** All three G1 architectural roots closed. Bundle: **0 errors** (arc 766 → 0, commits `fcce29dd3` through `8c4f619de`). The modular self-hosted tree (`self-hosted/compiler/main.sio`) now compiles clean. The checked x86-64 Madaros prebuilt is source-built from that modular tree and covered by `scripts/ci/madaros_full_gate.sh` plus `scripts/ci/madaros_source_to_elf_gate.sh`. This is a validated-research source-built Madaros lane, not a claim that `lean_single.sio` has been retired as the bootstrap seed.
 
 Previously tracked G1 roots, all closed:
 
@@ -195,13 +195,13 @@ Cross-compiled binaries must be executed on the target OS. The compiler runs on 
 
 ---
 
-## Single-source build path (`lean_single.sio`)
+## Legacy bootstrap seed (`lean_single.sio`)
 
-**Status:** active constraint. Not a bug; a maturity-stage reality that contributors must know about before editing type-system logic.
+**Status:** bootstrap seed and escape hatch. Not a bug; a maturity-stage reality that contributors must know about before editing compiler logic.
 
 ### What the situation actually is
 
-The shipped compiler binary (`bin/souc-linux-x86_64`, consumed by the `bin/souc` launcher) is produced today from a **single self-hosted source file**:
+The preserved bootstrap compiler binary (`bin/souc-linux-x86_64`, also available through `SOUNIO_SOUC_ENGINE=lean_single`) is produced from a **single self-hosted source file**:
 
 - `self-hosted/compiler/lean_single.sio`
 
@@ -214,7 +214,7 @@ The modular directory layout most readers expect —
 - `self-hosted/ir/`
 - `self-hosted/native/`
 
-— does exist, is kept in sync by hand, and describes the architectural decomposition we aim to bootstrap from. **It is not yet the source the binary is built from.** The 2-stage bootstrap recipe below uses `lean_single.sio` exclusively:
+— is now the source for the checked x86-64 Madaros prebuilt (`bin/madaros-linux-x86_64`). The 2-stage bootstrap recipe below remains the legacy seed/escape-hatch path and uses `lean_single.sio` exclusively:
 
 ```bash
 ./bin/souc-linux-x86_64 self-hosted/compiler/lean_single.sio /tmp/souc-stage1
@@ -224,7 +224,7 @@ cp /tmp/souc-stage2 bin/souc-linux-x86_64
 
 ### Implication for contributors
 
-Any change to the type system, effects table, error codes, or surface syntax **must be made in `lean_single.sio`** to reach the binary. Changes made only to the modular tree are silently absent from the shipped compiler, even if the repo builds green and the tests pass against the stale binary.
+Changes to the default user-facing compiler path must land in the modular tree and be proven through the Madaros gates before refreshing `bin/madaros-linux-x86_64`. Changes needed for the legacy seed or explicit `SOUNIO_SOUC_ENGINE=lean_single` path still need the corresponding `lean_single.sio` update.
 
 Examples of this pattern in recent history:
 
@@ -233,14 +233,14 @@ Examples of this pattern in recent history:
 
 ### Risk of silent divergence
 
-Because the two universes are kept in lock-step by discipline rather than by a test, a change that touches only one side can pass CI without any signal. Until an operational-parity harness lands under `tests/parity/`, reviewers of a PR that modifies type-system logic should explicitly confirm that `lean_single.sio` was touched and that a 2-stage bootstrap was run.
+Because the modular compiler and legacy seed are no longer the same source file, reviewers should check which lane a PR affects. Default Madaros changes need the modular-source build plus named Madaros gates; legacy-seed changes still need a `lean_single.sio` bootstrap proof.
 
 ### Planned resolution
 
 1. **Parity harness (`tests/parity/`, planned near-term).** For a fixed set of `.sio` programs drawn from `examples/` and `tests/compile-fail/`, compile via both paths and diff the stdout/stderr and exit codes (not the binaries — timestamps and symbol ordering make binary-equality unreliable). Divergence flips CI red.
-2. **Source swap (roadmap, long term).** Rebuild `bin/souc-linux-x86_64` from the modular tree and retire `lean_single.sio`. This is a multi-week refactor and is not a Wave 9 target.
+2. **Bootstrap retirement (roadmap, long term).** Retire `lean_single.sio` as an escape hatch once the modular compiler has enough fixed-point and parity evidence.
 
-Until both land, treat `lean_single.sio` as the source of truth for the binary and treat the modular tree as the maintained future target.
+Until that lands, treat the modular tree as the source for the default Madaros prebuilt and `lean_single.sio` as the seed/escape-hatch source.
 
 ---
 

--- a/docs/serious-language/public-claim-registry.v1.tsv
+++ b/docs/serious-language/public-claim-registry.v1.tsv
@@ -6,7 +6,7 @@ spec.drift	stable	closed	gate	scripts/ci/serious_language_spec_drift_gate.sh	-	C
 claim.closure	stable	closed	gate	scripts/ci/serious_language_claim_closure_gate.sh	-	Claim public PL docs close through registered claims, doc-surface policy, and evidence checks.
 claim.line_annotations	stable	closed	gate	scripts/ci/serious_language_claim_closure_gate.sh	-	Claim high-value public PL claims are pinned to exact doc lines and anchor text.
 selfhost	validated_research	closed	gate	scripts/ci/selfhost_host_gate.sh	-	Claim a checked self-host lane with gates, not finished production self-hosting.
-binary.source	prototype	downgraded	doc	docs/compiler/KNOWN_LIMITATIONS.md	-	State that lean_single remains the checked binary source until parity gates prove a swap.
+binary.source	validated_research	closed	gate	scripts/ci/madaros_full_gate.sh,scripts/ci/madaros_source_to_elf_gate.sh	-	Claim the checked x86-64 Madaros prebuilt is built from the modular compiler tree and passes named source-to-ELF/full gates; lean_single remains the bootstrap seed and escape hatch.
 platform.linux_x86_64	stable	closed	conformance_claim	core.execution	core.execution	Claim Linux x86-64 small-program run evidence only for checked artifacts.
 platform.macos	validated_research	closed	gate	.github/workflows/ci.yml	-	Claim checked macOS artifact lanes, not Apple JIT or native-v2 parity.
 platform.windows	prototype	downgraded	doc	docs/compiler/KNOWN_LIMITATIONS.md	-	Describe Windows target support as prototype only.

--- a/docs/serious-language/public-claim-registry.v1.tsv
+++ b/docs/serious-language/public-claim-registry.v1.tsv
@@ -39,6 +39,6 @@ algebra.168	validated_research	closed	doc	formal/lean4/SounioCayleyDickson.lean	
 hypercomplex.nn	prototype	downgraded	gate	scripts/stdlib/stdlib_hyper_execution_gate.sh	-	Describe hypercomplex ML as research/prototype unless a named gate covers the exact behavior.
 ontology	validated_research	closed	gate	scripts/ci/run_ontology_validation.sh	-	Claim rebuilt ontology validation surfaces only.
 clinical.pharm	validated_research	closed	gate	scripts/ci/package_pbpk_gum_gate.sh	-	Claim strict clinical-pathway scope with external review and no PHI.
-install	prototype	downgraded	doc	INSTALL.md	-	Use checked repo artifact install path; do not promise broad package-manager installation.
+install	validated_research	closed	gate	scripts/ci/sounio_install_support_gate.sh	-	Claim the checked repo-artifact install smoke path only; do not promise package-manager or release-tarball distribution.
 website.docs	prototype	downgraded	gate	scripts/dev/check_docs_registry.sh	-	Docs are extensive but filtered through readiness and claim closure.
 paper.bundle	prototype	downgraded	gate	scripts/paper/build_serious_language_bundle.sh	-	Claim a reproducibility scaffold that must be reviewed per generated bundle.

--- a/scripts/ci/sounio_install_support_gate.sh
+++ b/scripts/ci/sounio_install_support_gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+WORK_DIR="${SOUNIO_INSTALL_SUPPORT_GATE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/sounio-install-support.XXXXXX")}"
+KEEP_WORK_DIR="${SOUNIO_INSTALL_SUPPORT_GATE_KEEP_WORK_DIR:-0}"
+PREFIX="$WORK_DIR/prefix"
+LOG_DIR="$WORK_DIR/logs"
+
+cleanup() {
+  if [[ "$KEEP_WORK_DIR" != "1" ]]; then
+    rm -rf "$WORK_DIR"
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$LOG_DIR"
+
+run_step() {
+  local label="$1"
+  shift
+  local log="$LOG_DIR/$label.log"
+
+  echo "[install-support] >>> $label"
+  if "$@" >"$log" 2>&1; then
+    echo "[install-support] <<< $label PASS log=$log"
+  else
+    local rc=$?
+    echo "[install-support] !!! $label FAIL rc=$rc log=$log" >&2
+    tail -n 80 "$log" >&2 || true
+    return "$rc"
+  fi
+}
+
+assert_executable() {
+  local path="$1"
+  if [[ ! -x "$path" ]]; then
+    echo "[install-support] FAIL: expected executable at $path" >&2
+    exit 1
+  fi
+}
+
+assert_nonempty_log() {
+  local label="$1"
+  local log="$LOG_DIR/$label.log"
+  if [[ ! -s "$log" ]]; then
+    echo "[install-support] FAIL: $label produced empty output ($log)" >&2
+    exit 1
+  fi
+}
+
+echo "SOUNIO_INSTALL_SUPPORT_GATE_START"
+echo "repo=$ROOT_DIR"
+echo "work_dir=$WORK_DIR"
+echo "prefix=$PREFIX"
+
+if [[ ! -x "$ROOT_DIR/scripts/install.sh" ]]; then
+  echo "[install-support] FAIL: scripts/install.sh is not executable" >&2
+  exit 1
+fi
+
+run_step install env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_STDLIB_PATH \
+  -u MADAROS_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
+  bash "$ROOT_DIR/scripts/install.sh" --prefix "$PREFIX" --force
+
+INSTALLED_SOUC="$PREFIX/bin/souc"
+INSTALLED_MADAROS="$PREFIX/bin/madaros"
+assert_executable "$INSTALLED_SOUC"
+
+if [[ ! -x "$PREFIX/bin/madaros" || ! -x "$PREFIX/bin/madaros-linux-x86_64" ]]; then
+  echo "[install-support] FAIL: installed prefix is missing the Madaros launcher/raw ELF needed by bin/souc --version/info" >&2
+  echo "[install-support] expected: $PREFIX/bin/madaros and $PREFIX/bin/madaros-linux-x86_64" >&2
+  echo "[install-support] install log: $LOG_DIR/install.log" >&2
+  tail -n 40 "$LOG_DIR/install.log" >&2 || true
+  exit 1
+fi
+
+INSTALLED_STDLIB="$PREFIX/lib/sounio/stdlib"
+if [[ ! -d "$INSTALLED_STDLIB" ]]; then
+  echo "[install-support] FAIL: expected installed stdlib at $INSTALLED_STDLIB" >&2
+  exit 1
+fi
+
+run_step souc-version env -u SOUC_BIN -u SOUNIO_SOUC_BIN \
+  -u MADAROS_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
+  SOUNIO_STDLIB_PATH="$INSTALLED_STDLIB" "$INSTALLED_SOUC" --version
+assert_nonempty_log souc-version
+
+run_step madaros-version env -u MADAROS_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
+  "$INSTALLED_MADAROS" --version
+assert_nonempty_log madaros-version
+
+run_step souc-info env -u SOUC_BIN -u SOUNIO_SOUC_BIN \
+  -u MADAROS_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
+  SOUNIO_STDLIB_PATH="$INSTALLED_STDLIB" "$INSTALLED_SOUC" info
+assert_nonempty_log souc-info
+
+run_step souc-check-hello env -u SOUC_BIN -u SOUNIO_SOUC_BIN \
+  -u MADAROS_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
+  SOUNIO_STDLIB_PATH="$INSTALLED_STDLIB" "$INSTALLED_SOUC" check examples/hello.sio
+
+if [[ "$KEEP_WORK_DIR" == "1" ]]; then
+  echo "SOUNIO_INSTALL_SUPPORT_GATE_ARTIFACT_DIR=$WORK_DIR"
+fi
+echo "SOUNIO_INSTALL_SUPPORT_GATE_PASS prefix=$PREFIX"

--- a/scripts/ci/sounio_release_production_readiness_gate.sh
+++ b/scripts/ci/sounio_release_production_readiness_gate.sh
@@ -172,7 +172,7 @@ summary_json = Path(sys.argv[3])
 # A surface may remain prototype in the repo, but then the broad release claim
 # must fail until the surface is closed or removed from the release contract.
 release_critical = {
-    "binary.source": "checked binary still depends on lean_single as source; modular source-swap parity is not closed",
+    "binary.source": "checked modular Madaros prebuilt source-build evidence is not closed",
     "direct_driver": "large-surface direct-driver execution remains a maturity frontier",
     "stdlib.surface": "broad stdlib callability is explicitly downgraded",
     "tooling.package": "package manager has no public registry launch/support contract",

--- a/scripts/ci/sounio_release_production_readiness_gate.sh
+++ b/scripts/ci/sounio_release_production_readiness_gate.sh
@@ -146,6 +146,9 @@ if [[ "$RUN_LIVE_GATES" == "1" ]]; then
     bash "$ROOT_DIR/scripts/dev/madaros_readiness_status.sh" --no-audit --production-ready
   run_live_step docs-registry bash "$ROOT_DIR/scripts/dev/check_docs_registry.sh"
   run_live_step docs-consistency bash "$ROOT_DIR/scripts/dev/check_docs_consistency.sh"
+  run_live_step install-support env -u SOUC_BIN -u SOUNIO_SOUC_BIN -u SOUNIO_STDLIB_PATH \
+    -u MADAROS_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
+    bash "$ROOT_DIR/scripts/ci/sounio_install_support_gate.sh"
   run_live_step serious-language-claim-closure env -u SOUC_BIN -u SOUNIO_STDLIB_PATH \
     bash "$ROOT_DIR/scripts/ci/serious_language_claim_closure_gate.sh"
   write_live_tsv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,6 +94,13 @@ case "$TARGET" in
   *) echo "error: unrecognised --target $TARGET" >&2; exit 2;;
 esac
 MADAROS_ART_BIN="$ROOT_DIR/artifacts/self-hosted/madaros"
+MADAROS_PREBUILT_BIN="$ROOT_DIR/bin/madaros-linux-x86_64"
+MADAROS_SHIP_BIN=""
+if [[ -x "$MADAROS_ART_BIN" ]]; then
+  MADAROS_SHIP_BIN="$MADAROS_ART_BIN"
+elif [[ "$TARGET" == "x86_64" && -x "$MADAROS_PREBUILT_BIN" ]]; then
+  MADAROS_SHIP_BIN="$MADAROS_PREBUILT_BIN"
+fi
 
 if [[ ! -x "$ART_BIN" ]]; then
   echo "error: missing artifact: $ART_BIN" >&2
@@ -119,8 +126,8 @@ echo "Sounio install plan:"
 echo "  prefix:  $PREFIX"
 echo "  target:  $TARGET"
 echo "  binary:  $ART_BIN -> $BIN_DIR/souc-self-hosted-$TARGET"
-if [[ -x "$MADAROS_ART_BIN" ]]; then
-  echo "  madaros: $MADAROS_ART_BIN -> $BIN_DIR/madaros-linux-x86_64"
+if [[ -n "$MADAROS_SHIP_BIN" ]]; then
+  echo "  madaros: $MADAROS_SHIP_BIN -> $BIN_DIR/madaros-linux-x86_64"
 else
   echo "  madaros: <not built; run make build-madaros to include Stage1>"
 fi
@@ -157,9 +164,9 @@ install -m 0644 "$ROOT_DIR/scripts/lib/macos_codesign.sh"    "$LIB_SCRIPTS/"
 # lib/ locations so the launcher's relative lookups resolve cleanly.
 install -m 0755 "$ROOT_DIR/bin/souc" "$BIN_DIR/souc"
 
-if [[ -x "$MADAROS_ART_BIN" ]]; then
+if [[ -n "$MADAROS_SHIP_BIN" ]]; then
   install -m 0755 "$ROOT_DIR/bin/madaros" "$BIN_DIR/madaros"
-  install -m 0755 "$MADAROS_ART_BIN" "$BIN_DIR/madaros-linux-x86_64"
+  install -m 0755 "$MADAROS_SHIP_BIN" "$BIN_DIR/madaros-linux-x86_64"
 fi
 
 # Mirror scripts/lib at $PREFIX/scripts/lib so launcher's

--- a/self-hosted/check/mod.sio
+++ b/self-hosted/check/mod.sio
@@ -542,6 +542,10 @@ pub fn check_items_ontology_verdict(items: Option<Box<ItemList>>) -> i64 with Mu
 }
 
 pub fn check_modules_verdict_boot4(programs: &! [Program; 256], count: i64) -> i64 with Mut, Panic, Div, Alloc, IO {
+    check_modules_verdict_boot4_with_visibility(programs, count, false)
+}
+
+pub fn check_modules_verdict_boot4_with_visibility(programs: &! [Program; 256], count: i64, enforce_visibility: bool) -> i64 with Mut, Panic, Div, Alloc, IO {
     if count <= 0 {
         return 0
     }
@@ -554,7 +558,7 @@ pub fn check_modules_verdict_boot4(programs: &! [Program; 256], count: i64) -> i
     // import context, so re-enforcing definition-visibility here produces false E175/
     // E176/E177 on the (legitimately imported) cross-module private functions that the
     // single-crate compiler relies on. Defer visibility to the frontend.
-    (*checker_ptr).enforce_visibility = false
+    (*checker_ptr).enforce_visibility = enforce_visibility
 
     // Pass 1: collect signatures/definitions from every module into one shared
     // set of tables.  Each item is stamped with its real defining_module so

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -22,7 +22,7 @@ use check::refinement::*
 use check::units::*
 use check::env::*
 use check::traits::*
-use check::mod::{check_program, check_program_epistemic_into, check_modules_verdict_boot4}
+use check::mod::{check_program, check_program_epistemic_into, check_modules_verdict_boot4_with_visibility}
 use check::ownership::*
 use check::lint::*
 use check::layout::*
@@ -1936,7 +1936,7 @@ fn run_check_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Allo
     print("run_check_mode: about to check ")
     print_int(loaded)
     print(" modules\n")
-    let verdict = check_modules_verdict_boot4(&! programs, loaded)
+    let verdict = check_modules_verdict_boot4_with_visibility(&! programs, loaded, true)
     print("run_check_mode: verdict=")
     print_int(verdict)
     print("\n")


### PR DESCRIPTION
## Summary

- restore strict multimodule visibility diagnostics for `bin/madaros check` while keeping frontend/imported compilation paths permissive where needed
- add and wire an install-support smoke gate for the checked repo-artifact install path
- refresh `bin/madaros-linux-x86_64` from the modular compiler source and narrow public claims for `install` and `binary.source` to gate-backed `validated_research` evidence

## Root Cause

The CLI multimodule check path was using `check_modules_verdict_boot4`, whose visibility enforcement was globally disabled for frontend/imported compilation paths. That made negative fixtures for private structs/functions/enums pass when they should reject with E176/E175/E177.

Separately, `scripts/install.sh` only packaged `artifacts/self-hosted/madaros`, so a release checkout with the shipped prebuilt but no local build artifact installed a `souc` path that fell back to `lean_single`.

## Validation

All of the following were run from the isolated worktree with compiler override env vars cleared where relevant:

- rebuilt Madaros from `self-hosted/compiler/main.sio` to `/tmp/madaros-visibility-install-fix-2b89543f`
- copied that artifact to `bin/madaros-linux_x86_64` / `bin/madaros-linux-x86_64` equivalent checked prebuilt path; final SHA256: `e9052fd08283009b8a66966bdd10db150aba7d23e040e65c2f9a033e4cb47585`
- `bin/madaros check tests/multimodule/visibility_struct_private_main.sio` rejects with E176
- `bin/madaros check tests/multimodule/visibility_fn_private_main.sio` rejects with E175
- `bin/madaros check tests/multimodule/visibility_enum_private_main.sio` rejects with E177
- `bash scripts/ci/madaros_source_to_elf_gate.sh` PASS
- `bash scripts/ci/madaros_enum_gate.sh` PASS
- `bash scripts/ci/madaros_loop_gate.sh` PASS
- `bash scripts/ci/madaros_full_gate.sh` PASS
- `bash scripts/ci/sounio_install_support_gate.sh` PASS
- `bash scripts/dev/check_docs_registry.sh` PASS
- `bash scripts/dev/check_docs_consistency.sh` PASS
- `bash scripts/ci/sounio_release_production_readiness_gate.sh --skip-live-gates --allow-non-main` still FAILS honestly with 5 remaining broad release blockers: `direct_driver`, `stdlib.surface`, `tooling.package`, `tooling.editor`, `website.docs`

Known baseline: `scripts/ci/serious_language_claim_closure_gate.sh` still fails in conformance preparation, now `total=16 passed=6 failed=10`; this is not introduced by this PR.

## LLM Offload

- xAI raw review for install claim correction: `/tmp/llm-offload-dqb5Sd` and follow-up `/tmp/llm-offload-Tn8veC`
- xAI raw review for `binary.source` claim/prebuilt refresh: `/tmp/llm-offload-0mqyf9`
- DeepSeek/Gemini calls errored in the fan-out; xAI completed and the resulting overclaim/narrowing feedback was applied.
