### PR TITLE
fix(parser,check): E041 ontology property weakening now fires in default Madaros

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3111,6 +3111,20 @@ fn onto_prop_pred(p: OntologyPropertyDecl) -> RefinementPred with Mut, Panic, Di
     }
 }
 
+// Field-wise RefinementPred constructor — the weakening check builds a predicate
+// from scalar fields read directly off the inline property array (no struct copy).
+fn onto_prop_pred_fields(op: i64, rhs_int: i64, rhs_float: f64, is_float: bool) -> RefinementPred with Mut, Panic, Div {
+    RefinementPred {
+        op: op,
+        var_name: empty_name(),
+        rhs_int: rhs_int,
+        rhs_float: rhs_float,
+        is_float: is_float,
+        left: None,
+        right: None,
+    }
+}
+
 fn checker_onto_check_roles_inplace(c: *mut Checker, roles: Option<Box<OntologyRoleDeclList> >, classes: Option<Box<OntologyClassDeclList> >) with Mut, Panic, Div, Alloc, IO {
     var cur = roles
     var k: i64 = 0
@@ -3145,12 +3159,12 @@ fn checker_onto_check_weakening_inplace(c: *mut Checker, classes: Option<Box<Ont
     while true {
         match ci {
             Some(clist) => {
-                // Do NOT copy (*clist).head into a local: OntologyClassDecl contains
-                // `properties: [OntologyPropertyDecl; 8]` (an array of structs), and
-                // copying that struct misaligns the array under Madaros codegen
-                // (struct-array offset bug) — reads of properties[a].pred_op then
-                // come back 0. Access fields directly through the list pointer and
-                // copy out only a single (array-free) OntologyPropertyDecl at a time.
+                // Read property predicate fields DIRECTLY off the inline array
+                // elements — do NOT copy the whole OntologyPropertyDecl (two embedded
+                // [i8;128] Names). The large-boxed-struct codegen was fixed by the
+                // bump-arena Box::new rework (#430); a direct
+                // `(*clist).head.properties[a].pred_op` through the boxed list is now
+                // correct, while copying the ~290 B struct out is unreliable.
                 var si: i64 = 0
                 while si < (*clist).head.superclass_count && si < 8 {
                     let sname = (*clist).head.superclass_names[si as usize]
@@ -3161,16 +3175,29 @@ fn checker_onto_check_weakening_inplace(c: *mut Checker, classes: Option<Box<Ont
                                 if name_eq((*plist).head.name, sname) {
                                     var a: i64 = 0
                                     while a < (*clist).head.property_count && a < 8 {
-                                        let cp = (*clist).head.properties[a as usize]
-                                        var b: i64 = 0
-                                        while b < (*plist).head.property_count && b < 8 {
-                                            let pp = (*plist).head.properties[b as usize]
-                                            if name_eq(cp.name, pp.name) && cp.pred_op > 0 && pp.pred_op > 0 {
-                                                if !pred_implies(onto_prop_pred(cp), onto_prop_pred(pp)) {
-                                                    checker_report_error_at_inplace(c, cp.span, 41, 0, 0, 0)
+                                        let c_op = (*clist).head.properties[a as usize].pred_op
+                                        if c_op > 0 {
+                                            let c_name = (*clist).head.properties[a as usize].name
+                                            var b: i64 = 0
+                                            while b < (*plist).head.property_count && b < 8 {
+                                                let p_op = (*plist).head.properties[b as usize].pred_op
+                                                if p_op > 0 && name_eq(c_name, (*plist).head.properties[b as usize].name) {
+                                                    let child_pred = onto_prop_pred_fields(
+                                                        c_op,
+                                                        (*clist).head.properties[a as usize].pred_rhs_int,
+                                                        (*clist).head.properties[a as usize].pred_rhs_float,
+                                                        (*clist).head.properties[a as usize].is_float)
+                                                    let parent_pred = onto_prop_pred_fields(
+                                                        p_op,
+                                                        (*plist).head.properties[b as usize].pred_rhs_int,
+                                                        (*plist).head.properties[b as usize].pred_rhs_float,
+                                                        (*plist).head.properties[b as usize].is_float)
+                                                    if !pred_implies(child_pred, parent_pred) {
+                                                        checker_report_error_at_inplace(c, (*clist).head.properties[a as usize].span, 41, 0, 0, 0)
+                                                    }
                                                 }
+                                                b = b + 1
                                             }
-                                            b = b + 1
                                         }
                                         a = a + 1
                                     }

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -10787,8 +10787,10 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 38 { print("cannot borrow exclusively while other borrows are active") }
     else if code == 39 { print("linear value has already been used") }
     else if code == 40 { print("linear value must be used") }
-    // Units/refinement (41-43)
-    else if code == 41 { print("units are incompatible in this operation") }
+    // Ontology property weakening (41); refinement (42-43)
+    // E041 is ontology subsumption (child property weakens parent) — the only
+    // reporter of error code 41. (No reporter uses 41 for unit incompatibility.)
+    else if code == 41 { print("ontology subsumption could not be verified") }
     else if code == 42 { print("value does not satisfy the refinement predicate") }
     else if code == 43 { print("incompatible unit dimensions in conversion") }
     // Phase A additions (44-51)

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -4312,24 +4312,25 @@ fn parse_ontology_item(p: Parser, visibility: Visibility) -> (Parser, Item) with
                             pa = pa.advance()  // consume "where"
                             pa = pa.expect_ident()  // consume variable name (should match prop_name)
 
-                            // Parse comparison operator
+                            // Parse comparison operator. The lexer emits combined
+                            // tokens for >= <= == != (GtEq/LtEq/EqEq/BangEq) — the
+                            // earlier `Gt` then `Eq` two-token form never matched a
+                            // `>=`/`<=`, leaving prop_op=0 so weakening (E041) never
+                            // fired. Check the combined tokens directly (mirrors
+                            // types.sio's refinement-predicate parser).
                             if pa.peek() == TokenKind::Gt {
                                 pa = pa.advance()
-                                if pa.peek() == TokenKind::Eq {
-                                    pa = pa.advance()
-                                    prop_op = 2  // GtEq
-                                } else {
-                                    prop_op = 1  // Gt
-                                }
+                                prop_op = 1  // Gt
+                            } else if pa.peek() == TokenKind::GtEq {
+                                pa = pa.advance()
+                                prop_op = 2  // GtEq
                             } else if pa.peek() == TokenKind::Lt {
                                 pa = pa.advance()
-                                if pa.peek() == TokenKind::Eq {
-                                    pa = pa.advance()
-                                    prop_op = 4  // LtEq
-                                } else {
-                                    prop_op = 3  // Lt
-                                }
-                            } else if pa.peek() == TokenKind::EqEq {
+                                prop_op = 3  // Lt
+                            } else if pa.peek() == TokenKind::LtEq {
+                                pa = pa.advance()
+                                prop_op = 4  // LtEq
+                            } else if pa.peek() == TokenKind::EqEq || pa.peek() == TokenKind::Eq {
                                 pa = pa.advance()
                                 prop_op = 5  // Eq
                             } else if pa.peek() == TokenKind::BangEq {


### PR DESCRIPTION
## Summary

Makes **E041 ontology property weakening** fire in the default Madaros engine — the last of the four ontology axioms (E156/E157/E158/E159 already fired). With this, the Contracts ontology gate no longer needs the lean_single pin for weakening.

## Root causes (two, both fixed)

1. **Parser (`items.sio`)** — the real blocker. The ontology `property … where x >= v` parser checked for a `Gt` token followed by a *separate* `Eq` token, but the lexer emits a single combined `GtEq` (likewise `LtEq`). So `>=`/`<=` predicates parsed with `prop_op = 0`, and the weakening check's `pred_op > 0` guard was never satisfied → E041 never fired. Now parses the combined `GtEq`/`LtEq`/`EqEq`/`BangEq` tokens directly (mirrors `types.sio`'s refinement-predicate parser). (`==`/`!=` already worked.)

2. **Checker (`check.sio`)** — read predicate fields directly off the inline `[OntologyPropertyDecl;8]` element instead of copying the whole struct (two embedded `[i8;128]` Names) out of the boxed list; the copy path is unreliable. Added `onto_prop_pred_fields` for a struct-copy-free predicate build. Also pointed the code-41 error message at its documented meaning ("ontology subsumption could not be verified"; no reporter uses 41 for unit incompatibility — see `check.sio:3029`).

This builds on the codegen fixes that landed first (#420 raw refs, 91e2586fc Option<Box<T>> deref, #430 bump-arena Box::new), which made direct reads through the boxed `OntologyClassDeclList` correct.

## Verification (rebuilt Madaros, run 28250132337)

- `ontology_property_weakening` → **rc=1**, message "ontology subsumption could not be verified" ✓
- `ontology_role_duplicate_decl` / `_bad_domain_or_range` / `_inverse_target_missing` → rc=1 ✓
- valid `ontology_roles_basic` → compiles ✓
- madaros-full / enum / loop gates → PASS ✓
- typecheck parity vs origin/main baseline: check.sio 11=11, items.sio 2=2 (no new errors)

Diagnosed via an instrumented build: the validator read `superclass_count=1`, parent found, `property_count=1`, but `pred_op=0` — pinpointing the parser token mismatch.

Closes the Madaros half of #417; unblocks removing the lean_single pin for ontology weakening.

🤖 Draft for compiler-owner review (gates focused).