### PR TITLE
[review-only] madaros substrate slice of #436 (do not merge)

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -48,7 +48,7 @@ use resolve::scope::*
 
 use resolve::mod::{resolve_modules, resolve_program, ResolveBatchResult}
 use module_native_driver::{compile_multimodule_native, compile_multimodule_native_advanced, compile_multimodule_native_with_ir, compile_multimodule_native_maybe_streaming_for_target, compile_multimodule_llvm}
-use module_frontend::{load_multimodule_ir, load_multimodule_ir_traced, load_multimodule_ir_into, load_multimodule_ir_fn_count_traced, load_multimodule_ir_probe_summary, load_multimodule_ir_probe_summary_traced, empty_load_multimodule_ir_trace}
+use module_frontend::{load_multimodule_ir, load_multimodule_ir_traced, load_multimodule_ir_into, load_multimodule_ir_fn_count_traced, load_multimodule_ir_probe_summary, load_multimodule_ir_probe_summary_traced, empty_load_multimodule_ir_trace, module_frontend_compile_imported_to_file, module_frontend_file_maybe_has_use}
 use module_frontend::{preflight_multimodule_frontend, load_multimodule_epistemic_into, MultiModuleIrResult, MultiModuleFrontendResult, LoadMultimoduleIrTrace, empty_multimodule_ir_result, bridge_lower_single_module_box, ModuleFrontendLowerBoxResult, module_frontend_import_files_from_source, ImportPathList}
 use module_parse::{ImportList, load_module_file, extract_imports_from_ast, file_exists}
 use frontend_callsite_probe::{run_frontend_callsite_probe}
@@ -2894,6 +2894,19 @@ fn run_native_v2_compile_mode(args: ArgList, flag_index: i64) with IO, Mut, Pani
     let out_path = compiler_mode_output_path(args, out_positional)
     if !compiler_preflight_source_input(source_path) {
         panic("native-v2-compile failed: source not readable")
+    }
+    if module_frontend_file_maybe_has_use(source_path) {
+        let imported_rc = module_frontend_compile_imported_to_file(source_path, out_path)
+        if imported_rc != 0 {
+            print("native_v2_compile: imported front-half/backend failed rc=")
+            print_int(imported_rc as i64)
+            print("\n")
+            panic("native-v2-compile failed: imported path")
+        }
+        print("native_v2_compile: emitted path=")
+        print(out_path)
+        print("\n")
+        return
     }
     var trace = empty_load_multimodule_ir_trace()
     let ir_result = load_multimodule_ir_traced(source_path, &! trace)
@@ -8054,7 +8067,7 @@ fn compiler_main_test_ocp_partial_fold_dce_round_trip() -> bool with Mut, Div, P
 // T93: LICM hoists pure invariant instructions into the unique preheader.
 fn compiler_main_make_licm_hoist_test_func() -> IrFunction with Mut, Panic, Div {
     var func = ir_empty_function()
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 1)
     instrs[1] = ir_jump(0)
     instrs[2] = ir_label(0)
@@ -8078,7 +8091,7 @@ fn compiler_main_make_licm_hoist_test_func() -> IrFunction with Mut, Panic, Div 
 // T94: LICM leaves side-effecting calls in place.
 fn compiler_main_make_licm_call_test_func() -> IrFunction with Mut, Panic, Div {
     var func = ir_empty_function()
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 1)
     instrs[1] = ir_jump(0)
     instrs[2] = ir_label(0)
@@ -13454,7 +13467,7 @@ fn compiler_main_test_neg_mul_neg_aw() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_add_add() -> bool with Mut, Div, Panic {
     // (x+3)-(x+1) → 2: both add-const with same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)       // r0 = 42 (x)
     instrs[1 as usize] = ir_load_imm(1, 3)         // r1 = 3 (C1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = x+3
@@ -13468,7 +13481,7 @@ fn compiler_main_test_const_offset_diff_add_add() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_sub_sub() -> bool with Mut, Div, Panic {
     // (x-3)-(x-1) → -2: both sub-const with same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = x-3
@@ -13482,7 +13495,7 @@ fn compiler_main_test_const_offset_diff_sub_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_add_sub() -> bool with Mut, Div, Panic {
     // (x+3)-(x-1) → 4: add minus sub-const, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = x+3
@@ -13496,7 +13509,7 @@ fn compiler_main_test_const_offset_diff_add_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_sub_add() -> bool with Mut, Div, Panic {
     // (x-3)-(x+1) → -4: sub minus add-const, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = x-3
@@ -13510,7 +13523,7 @@ fn compiler_main_test_const_offset_diff_sub_add() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x+3)-(y+1) → no fold (different bases)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)        // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 99)        // r1 = y (different)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -13525,7 +13538,7 @@ fn compiler_main_test_const_offset_diff_no_fold_diff_base() -> bool with Mut, Di
 
 fn compiler_main_test_const_offset_diff_no_fold_plain_sub() -> bool with Mut, Div, Panic {
     // a - b → no fold (neither is tracked as const-offset)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 10)
     instrs[1 as usize] = ir_load_imm(1, 7)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = 10*7 (not const-offset)
@@ -13539,7 +13552,7 @@ fn compiler_main_test_const_offset_diff_no_fold_plain_sub() -> bool with Mut, Di
 
 fn compiler_main_test_twos_comp_neg_basic() -> bool with Mut, Div, Panic {
     // ~x + 1 → neg(x): two's complement negation identity
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)          // r0 = 5 (x)
     instrs[1 as usize] = ir_load_imm(1, -1)          // r1 = -1
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x (x^(-1))
@@ -13552,7 +13565,7 @@ fn compiler_main_test_twos_comp_neg_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_commutative() -> bool with Mut, Div, Panic {
     // 1 + ~x → neg(x): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 7)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13565,7 +13578,7 @@ fn compiler_main_test_twos_comp_neg_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_src_correct() -> bool with Mut, Div, Panic {
     // ~x + 1 → neg(x): verify src1 points to x (not ~x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 9)           // r0 = x
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13580,7 +13593,7 @@ fn compiler_main_test_twos_comp_neg_src_correct() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_no_fold_wrong_const() -> bool with Mut, Div, Panic {
     // ~x + 2 → no fold (constant is 2, not 1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13593,7 +13606,7 @@ fn compiler_main_test_twos_comp_neg_no_fold_wrong_const() -> bool with Mut, Div,
 
 fn compiler_main_test_twos_comp_neg_no_fold_sub() -> bool with Mut, Div, Panic {
     // ~x - 1 → no fold (OpSub, not OpAdd)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13606,7 +13619,7 @@ fn compiler_main_test_twos_comp_neg_no_fold_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_no_fold_plain() -> bool with Mut, Div, Panic {
     // y + 1 → no fold (y is a plain mul, not bitwise NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 3)
     instrs[1 as usize] = ir_load_imm(1, 4)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)      // r2 = 3*4 (not bnot)
@@ -13621,7 +13634,7 @@ fn compiler_main_test_twos_comp_neg_no_fold_plain() -> bool with Mut, Div, Panic
 
 // T530: x + ~x → -1  [basic: s2 is NOT(s1)]
 fn compiler_main_test_add_complement_basic() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = r0 + ~r0 → -1
     let func = cp_make_test_func(instrs, 2)
@@ -13631,7 +13644,7 @@ fn compiler_main_test_add_complement_basic() -> bool with Mut, Div, Panic {
 
 // T531: ~x + x → -1  [commutative: s1 is NOT(s2)]
 fn compiler_main_test_add_complement_comm() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)   // r2 = ~r0 + r0 → -1
     let func = cp_make_test_func(instrs, 2)
@@ -13641,7 +13654,7 @@ fn compiler_main_test_add_complement_comm() -> bool with Mut, Div, Panic {
 
 // T532: (x + ~x) + 5 → -1 + 5 = 4  [downstream const-fold chains]
 fn compiler_main_test_add_complement_downstream() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = r0 + ~r0 → -1
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -13653,7 +13666,7 @@ fn compiler_main_test_add_complement_downstream() -> bool with Mut, Div, Panic {
 
 // T533: x + ~y (different vars) — no fold
 fn compiler_main_test_add_complement_diff_var() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)     // r2 = ~r1 (r1 is param, ≠ r0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)   // r3 = r0 + ~r1 (diff base)
     let func = cp_make_test_func(instrs, 2)
@@ -13663,7 +13676,7 @@ fn compiler_main_test_add_complement_diff_var() -> bool with Mut, Div, Panic {
 
 // T534: x | ~x → -1 still works (Block AR unaffected by BF)
 fn compiler_main_test_add_complement_or_still_works() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1) // r2 = r0 | ~r0 → -1 (Block AR)
     let func = cp_make_test_func(instrs, 2)
@@ -13673,7 +13686,7 @@ fn compiler_main_test_add_complement_or_still_works() -> bool with Mut, Div, Pan
 
 // T535: x - ~x no fold (sub, not add)
 fn compiler_main_test_add_complement_sub_no_fold() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - ~r0 (no BF fold)
     let func = cp_make_test_func(instrs, 2)
@@ -13683,7 +13696,7 @@ fn compiler_main_test_add_complement_sub_no_fold() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_or_chain_basic() -> bool with Mut, Div, Panic {
     // (x | 0b0011) | 0b1100 → x | 0b1111: OR chain merges non-overlapping masks
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)         // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 3)           // r1 = 0b0011
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x | 3
@@ -13700,7 +13713,7 @@ fn compiler_main_test_or_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_chain_commutative() -> bool with Mut, Div, Panic {
     // 0b1100 | (x | 0b0011) → x | 0b1111: commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x | 3
@@ -13715,7 +13728,7 @@ fn compiler_main_test_or_chain_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_chain_three_levels() -> bool with Mut, Div, Panic {
     // ((x | 1) | 2) | 4 → x | 7: three-level OR chain
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x|1
@@ -13733,7 +13746,7 @@ fn compiler_main_test_or_chain_three_levels() -> bool with Mut, Div, Panic {
 fn compiler_main_test_or_chain_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x | 3) | 4 where the base differs from AM's case — should fold (both same x)
     // But (x|3)|(y|4): different bases, no merge → test no-fold path
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)     // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 99)     // r1 = y (different)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -13749,7 +13762,7 @@ fn compiler_main_test_or_chain_no_fold_diff_base() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_or_chain_superset_still_block_am() -> bool with Mut, Div, Panic {
     // (x | 0b1111) | 0b0011 → IrCopy (Block AM handles superset, BG not needed)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 15)      // r1 = 0b1111
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x|15
@@ -13763,7 +13776,7 @@ fn compiler_main_test_or_chain_superset_still_block_am() -> bool with Mut, Div, 
 
 fn compiler_main_test_or_chain_and_not_folded() -> bool with Mut, Div, Panic {
     // (x & 3) | 12 → not an OR chain fold (x&3 is AND, not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = x&3 (not OR)
@@ -13782,7 +13795,7 @@ fn compiler_main_test_or_chain_and_not_folded() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_basic() -> bool with Mut, Div, Panic {
     // (x & 0x0F) | 0xFF → 0xFF  [C1=0x0F, C2=0xFF, C1&C2=0x0F==C1 => subset]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13794,7 +13807,7 @@ fn compiler_main_test_and_subset_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_comm() -> bool with Mut, Div, Panic {
     // 0xFF | (x & 0x0F) → 0xFF  [commutative form]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13806,7 +13819,7 @@ fn compiler_main_test_and_subset_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_same() -> bool with Mut, Div, Panic {
     // (x & 0xFF) | 0xFF → 0xFF  [same mask: C1 == C2]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13818,7 +13831,7 @@ fn compiler_main_test_and_subset_or_same() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_no_fold_superset() -> bool with Mut, Div, Panic {
     // (x & 0xFF) | 0x0F → no fold (C1=0xFF not subset of C2=0x0F)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 15)
@@ -13830,7 +13843,7 @@ fn compiler_main_test_and_subset_or_no_fold_superset() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_and_subset_or_no_fold_disjoint() -> bool with Mut, Div, Panic {
     // (x & 0x0F) | 0xF0 → no fold (0x0F & 0xF0 = 0 != 0x0F)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 240)
@@ -13842,7 +13855,7 @@ fn compiler_main_test_and_subset_or_no_fold_disjoint() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_and_subset_or_downstream() -> bool with Mut, Div, Panic {
     // (x & 0x0F) | 0xFF → folded to IrLoadImm(255); const propagates
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13857,7 +13870,7 @@ fn compiler_main_test_and_subset_or_downstream() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_basic() -> bool with Mut, Div, Panic {
     // (x | 0xFF) & 0xFF00 → x & 0xFF00  [0xFF & 0xFF00 = 0]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 65280)
@@ -13871,7 +13884,7 @@ fn compiler_main_test_or_mask_clear_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_comm() -> bool with Mut, Div, Panic {
     // 0xAA & (x | 0x55) → x & 0xAA  [commutative: 0x55 & 0xAA = 0]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 85)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 170)
@@ -13885,7 +13898,7 @@ fn compiler_main_test_or_mask_clear_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_nibble() -> bool with Mut, Div, Panic {
     // (x | 0x0F) & 0xF0 → x & 0xF0  [nibble-aligned: 0x0F & 0xF0 = 0]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 240)
@@ -13899,7 +13912,7 @@ fn compiler_main_test_or_mask_clear_nibble() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_no_fold_overlap() -> bool with Mut, Div, Panic {
     // (x | 0x3C) & 0x3A → no fold (0x3C & 0x3A = 0x38 != 0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 60)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 58)
@@ -13912,7 +13925,7 @@ fn compiler_main_test_or_mask_clear_no_fold_overlap() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_or_mask_clear_no_fold_superset() -> bool with Mut, Div, Panic {
     // (x | 0xF0) & 0xFF → no fold (0xF0 & 0xFF = 0xF0 != 0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 240)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13925,7 +13938,7 @@ fn compiler_main_test_or_mask_clear_no_fold_superset() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_or_mask_clear_downstream() -> bool with Mut, Div, Panic {
     // (x | 0xFF) & 0xFF00 → x & 0xFF00; rewritten AND has src1=r0, src2=r3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 65280)
@@ -13943,7 +13956,7 @@ fn compiler_main_test_or_mask_clear_downstream() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_basic() -> bool with Mut, Div, Panic {
     // ~(~r0) → IrCopy(r0); r1 = ~r0, r2 = ~r1 → r2 = ir_copy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -13953,7 +13966,7 @@ fn compiler_main_test_double_not_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_src_preserved() -> bool with Mut, Div, Panic {
     // ~(~r0) → IrCopy(r0); the copy source must be r0 (register 0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -13963,7 +13976,7 @@ fn compiler_main_test_double_not_src_preserved() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_xor_form() -> bool with Mut, Div, Panic {
     // XOR(-1) form as inner NOT: r2 = r0^(-1); r3 = ~r2 → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
@@ -13974,7 +13987,7 @@ fn compiler_main_test_double_not_xor_form() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_no_fold_single() -> bool with Mut, Div, Panic {
     // Single NOT — no fold; stays as IrUnaryOp
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -13983,7 +13996,7 @@ fn compiler_main_test_double_not_no_fold_single() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_const_fold_wins() -> bool with Mut, Div, Panic {
     // When src is a const, const-fold applies: ~(~5) → ~(-6) → 5 (IrLoadImm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
@@ -13994,7 +14007,7 @@ fn compiler_main_test_double_not_const_fold_wins() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_double_not_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // ~r9 where r9 is not a NOT — no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 9)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -14007,7 +14020,7 @@ fn compiler_main_test_double_not_no_fold_diff_reg() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bk_shl_chain() -> bool with Mut, Div, Panic {
     // (r0 << 2) << 3 → r0 << 5; via opt_cleanup_function
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -14021,7 +14034,7 @@ fn compiler_main_test_bk_shl_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_shr_chain() -> bool with Mut, Div, Panic {
     // (r0 >> 1) >> 4 → r0 >> 5; via opt_cleanup_function
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShr, 1)
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -14035,7 +14048,7 @@ fn compiler_main_test_bk_shr_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_combined_amount() -> bool with Mut, Div, Panic {
     // (r0 << 3) << 4 → r0 << 7; amount constant patched to 7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -14047,7 +14060,7 @@ fn compiler_main_test_bk_combined_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_no_fold_overflow() -> bool with Mut, Div, Panic {
     // (r0 << 60) << 10 → no fold (60+10=70 >= 64)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 60)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 10)
@@ -14059,7 +14072,7 @@ fn compiler_main_test_bk_no_fold_overflow() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_no_fold_diff_dir() -> bool with Mut, Div, Panic {
     // (r0 << 2) >> 3 — different directions, no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -14071,7 +14084,7 @@ fn compiler_main_test_bk_no_fold_diff_dir() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_no_fold_var_amount() -> bool with Mut, Div, Panic {
     // (r0 << 2) << r9 — amount not const, no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpShl, 9)
@@ -14082,7 +14095,7 @@ fn compiler_main_test_bk_no_fold_var_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_basic() -> bool with Mut, Div, Panic {
     // (x << 3) & 7 → 0: bottom 3 bits of x<<3 are zero, mask 7=0b111 covers only those
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)           // shift amount
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14095,7 +14108,7 @@ fn compiler_main_test_shl_low_mask_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_commutative() -> bool with Mut, Div, Panic {
     // 7 & (x << 3) → 0: commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14108,7 +14121,7 @@ fn compiler_main_test_shl_low_mask_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_partial() -> bool with Mut, Div, Panic {
     // (x << 4) & 15 → 0: mask 15=0b1111 exactly covers bottom 4 bits
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 99)
     instrs[1 as usize] = ir_load_imm(1, 4)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 4
@@ -14121,7 +14134,7 @@ fn compiler_main_test_shl_low_mask_partial() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_no_fold_high_bit() -> bool with Mut, Div, Panic {
     // (x << 3) & 8 → no fold: mask 8=0b1000 has bit 3 set, which may be in x<<3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14134,7 +14147,7 @@ fn compiler_main_test_shl_low_mask_no_fold_high_bit() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_shl_low_mask_no_fold_negative_mask() -> bool with Mut, Div, Panic {
     // (x << 3) & (-1) → no fold: mask -1 has all bits set (negative, not < threshold)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14147,7 +14160,7 @@ fn compiler_main_test_shl_low_mask_no_fold_negative_mask() -> bool with Mut, Div
 
 fn compiler_main_test_shl_low_mask_no_fold_plain_and() -> bool with Mut, Div, Panic {
     // x & 7 → no fold (x not tracked as shl result)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = x+3 (not shl)
@@ -14163,7 +14176,7 @@ fn compiler_main_test_shl_low_mask_no_fold_plain_and() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_bm_xor_chain_basic() -> bool with Mut, Div, Panic {
     // (r0 ^ 3) ^ 5 → r0 ^ 6  [3^5=6]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14177,7 +14190,7 @@ fn compiler_main_test_bm_xor_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_chain_merged_val() -> bool with Mut, Div, Panic {
     // (r0 ^ 0x0F) ^ 0xF0 → r0 ^ 0xFF; constant register holds 0xFF
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 240)
@@ -14190,7 +14203,7 @@ fn compiler_main_test_bm_xor_chain_merged_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_chain_cancel() -> bool with Mut, Div, Panic {
     // (r0 ^ 7) ^ 7 → r0 ^ 0 = r0; const-fold then identity eliminates XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -14203,7 +14216,7 @@ fn compiler_main_test_bm_xor_chain_cancel() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_chain_comm() -> bool with Mut, Div, Panic {
     // 5 ^ (r0 ^ 3) → r0 ^ 6  [commutative outer form]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14217,7 +14230,7 @@ fn compiler_main_test_bm_xor_chain_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_no_fold_rr() -> bool with Mut, Div, Panic {
     // (r0 ^ r1) ^ r2 — no fold (no const operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 9)
     let func = cp_make_test_func(instrs, 2)
@@ -14228,7 +14241,7 @@ fn compiler_main_test_bm_xor_no_fold_rr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_no_fold_different_op() -> bool with Mut, Div, Panic {
     // (r0 | 3) ^ 5 — inner is OR not XOR, no bm_xor_valid
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14241,7 +14254,7 @@ fn compiler_main_test_bm_xor_no_fold_different_op() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_xor_self_recovery_basic() -> bool with Mut, Div, Panic {
     // (x^5) ^ x → 5: XOR with original base recovers the constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14253,7 +14266,7 @@ fn compiler_main_test_xor_self_recovery_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_self_recovery_commutative() -> bool with Mut, Div, Panic {
     // x ^ (x^5) → 5: commutative outer XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14265,7 +14278,7 @@ fn compiler_main_test_xor_self_recovery_commutative() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_xor_pair_cancel() -> bool with Mut, Div, Panic {
     // (x^3) ^ (x^5) → 6 (= 3^5): shared base cancels, constants XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^3
@@ -14279,7 +14292,7 @@ fn compiler_main_test_xor_pair_cancel() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_self_recovery_neg_const() -> bool with Mut, Div, Panic {
     // (x^(-1)) ^ x → -1: negative constant recovered correctly
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^(-1)
@@ -14291,7 +14304,7 @@ fn compiler_main_test_xor_self_recovery_neg_const() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_xor_self_recovery_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x^3) ^ y → no fold (y != x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 99)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -14304,7 +14317,7 @@ fn compiler_main_test_xor_self_recovery_no_fold_diff_base() -> bool with Mut, Di
 
 fn compiler_main_test_xor_self_recovery_no_fold_plain() -> bool with Mut, Div, Panic {
     // a ^ b → no fold (neither tracked as xor-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 10)
     instrs[1 as usize] = ir_load_imm(1, 20)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -14319,7 +14332,7 @@ fn compiler_main_test_xor_self_recovery_no_fold_plain() -> bool with Mut, Div, P
 // Sprint 153 Block BO: Two's-complement rewrite (T584-T589)
 fn compiler_main_test_bo_twos_comp_basic() -> bool with Mut, Div, Panic {
     // ~r0 + 1 → -r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_load_imm(2, 1)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 2)
@@ -14332,7 +14345,7 @@ fn compiler_main_test_bo_twos_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bo_twos_comp_commutative() -> bool with Mut, Div, Panic {
     // 1 + ~r0 → -r0 (commutative outer Add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 2)
@@ -14345,7 +14358,7 @@ fn compiler_main_test_bo_twos_comp_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bo_twos_comp_no_fold_const2() -> bool with Mut, Div, Panic {
     // ~r0 + 2 → no fold (constant is 2, not 1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_load_imm(2, 2)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 2)
@@ -14356,7 +14369,7 @@ fn compiler_main_test_bo_twos_comp_no_fold_const2() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bo_twos_comp_no_fold_not_not() -> bool with Mut, Div, Panic {
     // r0 + 1 → no fold (s1 is not a NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14366,7 +14379,7 @@ fn compiler_main_test_bo_twos_comp_no_fold_not_not() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_bo_twos_comp_neg_src() -> bool with Mut, Div, Panic {
     // ~(r0 + r1) + 1 → -(r0+r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)   // r3 = r0 + 5
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)     // r4 = ~(r0+5)
@@ -14381,7 +14394,7 @@ fn compiler_main_test_bo_twos_comp_neg_src() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bo_twos_comp_no_fold_sub() -> bool with Mut, Div, Panic {
     // ~r0 - 1 → no fold (Sub not Add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_load_imm(2, 1)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 2)
@@ -14393,7 +14406,7 @@ fn compiler_main_test_bo_twos_comp_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 154 Block BP: AND-complement annihilation (T590-T595)
 fn compiler_main_test_bp_and_complement_basic() -> bool with Mut, Div, Panic {
     // r0 & ~r0 → IrLoadImm(0): AND-complement annihilation
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14403,7 +14416,7 @@ fn compiler_main_test_bp_and_complement_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bp_and_complement_commutative() -> bool with Mut, Div, Panic {
     // ~r0 & r0 → IrLoadImm(0): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -14413,7 +14426,7 @@ fn compiler_main_test_bp_and_complement_commutative() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_bp_and_complement_expr() -> bool with Mut, Div, Panic {
     // (r0+5) & ~(r0+5) → 0: AND-complement of composite expression
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -14425,7 +14438,7 @@ fn compiler_main_test_bp_and_complement_expr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bp_and_complement_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r0 & ~r2 → no fold: r2 != r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 7)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -14436,7 +14449,7 @@ fn compiler_main_test_bp_and_complement_no_fold_diff_reg() -> bool with Mut, Div
 
 fn compiler_main_test_bp_and_complement_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 & r1 → no fold: neither is NOT
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14446,7 +14459,7 @@ fn compiler_main_test_bp_and_complement_no_fold_plain() -> bool with Mut, Div, P
 
 fn compiler_main_test_bp_and_complement_no_fold_or() -> bool with Mut, Div, Panic {
     // r0 | ~r0 → no fold by Block BP (OR is not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14458,7 +14471,7 @@ fn compiler_main_test_bp_and_complement_no_fold_or() -> bool with Mut, Div, Pani
 // Sprint 155 Block BQ: OR-complement absorption (T596-T601)
 fn compiler_main_test_bq_or_complement_basic() -> bool with Mut, Div, Panic {
     // r0 | ~r0 → IrLoadImm(-1): OR-complement absorption
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14468,7 +14481,7 @@ fn compiler_main_test_bq_or_complement_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bq_or_complement_commutative() -> bool with Mut, Div, Panic {
     // ~r0 | r0 → IrLoadImm(-1): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -14478,7 +14491,7 @@ fn compiler_main_test_bq_or_complement_commutative() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_bq_or_complement_expr() -> bool with Mut, Div, Panic {
     // (r0+5) | ~(r0+5) → -1: OR-complement of composite expression
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -14490,7 +14503,7 @@ fn compiler_main_test_bq_or_complement_expr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bq_or_complement_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r0 | ~r2 → no fold: r2 != r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 7)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -14501,7 +14514,7 @@ fn compiler_main_test_bq_or_complement_no_fold_diff_reg() -> bool with Mut, Div,
 
 fn compiler_main_test_bq_or_complement_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 | r1 → no fold: neither is NOT
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14511,7 +14524,7 @@ fn compiler_main_test_bq_or_complement_no_fold_plain() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_bq_or_complement_no_fold_and() -> bool with Mut, Div, Panic {
     // r0 & ~r0 → not absorbed by Block BQ (AND is not OR); Block BP handles that
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14523,7 +14536,7 @@ fn compiler_main_test_bq_or_complement_no_fold_and() -> bool with Mut, Div, Pani
 // Sprint 156 Block BR: XOR-complement (T602-T607)
 fn compiler_main_test_br_xor_complement_basic() -> bool with Mut, Div, Panic {
     // r0 ^ ~r0 → IrLoadImm(-1): XOR-complement
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14533,7 +14546,7 @@ fn compiler_main_test_br_xor_complement_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_br_xor_complement_commutative() -> bool with Mut, Div, Panic {
     // ~r0 ^ r0 → IrLoadImm(-1): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -14543,7 +14556,7 @@ fn compiler_main_test_br_xor_complement_commutative() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_br_xor_complement_expr() -> bool with Mut, Div, Panic {
     // (r0*3) ^ ~(r0*3) → -1: XOR-complement of composite expression
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -14555,7 +14568,7 @@ fn compiler_main_test_br_xor_complement_expr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_br_xor_complement_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r0 ^ ~r2 → no fold: r2 != r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 9)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 3)
@@ -14566,7 +14579,7 @@ fn compiler_main_test_br_xor_complement_no_fold_diff_reg() -> bool with Mut, Div
 
 fn compiler_main_test_br_xor_complement_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 ^ r1 → no fold: neither is NOT
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 42)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14576,7 +14589,7 @@ fn compiler_main_test_br_xor_complement_no_fold_plain() -> bool with Mut, Div, P
 
 fn compiler_main_test_br_xor_complement_no_fold_and() -> bool with Mut, Div, Panic {
     // r0 & ~r0 → Block BP handles it; Block BR (XOR) does NOT emit -1 for AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14588,7 +14601,7 @@ fn compiler_main_test_br_xor_complement_no_fold_and() -> bool with Mut, Div, Pan
 // Sprint 157 Block BS: Consecutive subtract-constant fold (T608-T613)
 fn compiler_main_test_bs_sub_chain_basic() -> bool with Mut, Div, Panic {
     // (r0 - 3) - 5 → r0 - 8
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14602,7 +14615,7 @@ fn compiler_main_test_bs_sub_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_neg() -> bool with Mut, Div, Panic {
     // (r0 - 10) - (-3) → r0 - 7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 10)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 10
     instrs[2 as usize] = ir_load_imm(3, -3)
@@ -14615,7 +14628,7 @@ fn compiler_main_test_bs_sub_chain_neg() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_amount() -> bool with Mut, Div, Panic {
     // (r0 - 7) - 13 → r0 - 20: verify merged constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_load_imm(3, 13)
@@ -14627,7 +14640,7 @@ fn compiler_main_test_bs_sub_chain_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_no_fold_var() -> bool with Mut, Div, Panic {
     // (r0 - r1) - 5 → no fold: s2 of inner sub is not constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)  // r3 = r0 - r1 (var sub)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 2)  // r4 = (r0-r1) - 5
@@ -14638,7 +14651,7 @@ fn compiler_main_test_bs_sub_chain_no_fold_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0 + 3) - 5 → no fold by Block BS (+ not -)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14650,7 +14663,7 @@ fn compiler_main_test_bs_sub_chain_no_fold_add() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_no_fold_rhs_var() -> bool with Mut, Div, Panic {
     // (r0 - 3) - r1 → no fold: outer rhs is variable not const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)  // r3 = r0 - 3
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 1)  // r4 = (r0-3) - r1 (var)
@@ -14662,7 +14675,7 @@ fn compiler_main_test_bs_sub_chain_no_fold_rhs_var() -> bool with Mut, Div, Pani
 // Sprint 158 Block BT: Consecutive add-constant fold (T614-T619)
 fn compiler_main_test_bt_add_chain_basic() -> bool with Mut, Div, Panic {
     // (r0 + 3) + 5 → r0 + 8: base register becomes r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14676,7 +14689,7 @@ fn compiler_main_test_bt_add_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_commutative() -> bool with Mut, Div, Panic {
     // 5 + (r0 + 3) → r0 + 8: commutative outer add
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14690,7 +14703,7 @@ fn compiler_main_test_bt_add_chain_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_amount() -> bool with Mut, Div, Panic {
     // (r0 + 7) + 13 → r0 + 20: verify merged constant = 20
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_load_imm(3, 13)
@@ -14702,7 +14715,7 @@ fn compiler_main_test_bt_add_chain_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_no_fold_var() -> bool with Mut, Div, Panic {
     // (r0 + r1) + 5 → no fold: inner rhs is variable not const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)  // r3 = r0 + r1
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 2)
@@ -14713,7 +14726,7 @@ fn compiler_main_test_bt_add_chain_no_fold_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0 - 3) + 5 → no fold by Block BT (inner is sub not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14725,7 +14738,7 @@ fn compiler_main_test_bt_add_chain_no_fold_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_no_fold_rhs_var() -> bool with Mut, Div, Panic {
     // (r0 + 3) + r1 → no fold: outer rhs is variable
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 1)
@@ -14736,7 +14749,7 @@ fn compiler_main_test_bt_add_chain_no_fold_rhs_var() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_addconst_subconst_diff() -> bool with Mut, Div, Panic {
     // (x+3)-(x-2) → 5: bt_add minus bs_sub, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = x+3 (bt_add)
@@ -14750,7 +14763,7 @@ fn compiler_main_test_addconst_subconst_diff() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_subconst_addconst_diff() -> bool with Mut, Div, Panic {
     // (x-2)-(x+3) → -5: bs_sub minus bt_add, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 2)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = x-2 (bs_sub)
@@ -14764,7 +14777,7 @@ fn compiler_main_test_subconst_addconst_diff() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_subconst_subconst_diff() -> bool with Mut, Div, Panic {
     // (x-3)-(x-5) → 2: bs_sub minus bs_sub, same base (C2-C1=5-3=2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = x-3 (bs_sub)
@@ -14778,7 +14791,7 @@ fn compiler_main_test_subconst_subconst_diff() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_addconst_addconst_diff_bu() -> bool with Mut, Div, Panic {
     // (x+5)-(x+3) → 2: bt_add minus bt_add, same base (C1-C2=5-3=2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = x+5 (bt_add)
@@ -14792,7 +14805,7 @@ fn compiler_main_test_addconst_addconst_diff_bu() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bu_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x+3)-(y-2) → no fold: different base registers
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)   // x
     instrs[1 as usize] = ir_load_imm(1, 99)   // y (different)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -14807,7 +14820,7 @@ fn compiler_main_test_bu_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bu_chain_fold() -> bool with Mut, Div, Panic {
     // Chain: (x-1)-1 = x-2 via Block BS; then (x+3)-(x-2) → 5 via Block BU
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)   // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = x-1
@@ -14823,7 +14836,7 @@ fn compiler_main_test_bu_chain_fold() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_merge_basic() -> bool with Mut, Div, Panic {
     // (x^5) | 5 → x|5: XOR-OR merge; src1 should be x (not x^5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)         // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14838,7 +14851,7 @@ fn compiler_main_test_xor_or_merge_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_merge_commutative() -> bool with Mut, Div, Panic {
     // 5 | (x^5) → x|5: commutative outer OR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14853,7 +14866,7 @@ fn compiler_main_test_xor_or_merge_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_merge_diff_const() -> bool with Mut, Div, Panic {
     // (x^12) | 12 → x|12: works with a different constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 12)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^12
@@ -14868,7 +14881,7 @@ fn compiler_main_test_xor_or_merge_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_no_fold_const_mismatch() -> bool with Mut, Div, Panic {
     // (x^5) | 3 → no fold: OR constant (3) differs from XOR constant (5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14882,7 +14895,7 @@ fn compiler_main_test_xor_or_no_fold_const_mismatch() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_xor_or_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (x^5) & 5 → no fold by BV (AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14896,7 +14909,7 @@ fn compiler_main_test_xor_or_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_no_fold_plain_or() -> bool with Mut, Div, Panic {
     // y | 5 → no fold: y not tracked as xor-const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)     // r2 = x+3 (not xor)
@@ -14910,7 +14923,7 @@ fn compiler_main_test_xor_or_no_fold_plain_or() -> bool with Mut, Div, Panic {
 // Sprint 161 Block BW: XOR-mask AND complement (T632-T637)
 fn compiler_main_test_bw_xor_and_comp_basic() -> bool with Mut, Div, Panic {
     // (x ^ 5) & ~5 → x & ~5: xor-mask AND complement fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -14923,7 +14936,7 @@ fn compiler_main_test_bw_xor_and_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_xor_and_comp_comm() -> bool with Mut, Div, Panic {
     // ~5 & (x ^ 5) → x & ~5: commutative outer AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -14936,7 +14949,7 @@ fn compiler_main_test_bw_xor_and_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_xor_and_comp_val() -> bool with Mut, Div, Panic {
     // (x ^ 0xFF) & ~0xFF → x & ~0xFF: verify with 0xFF constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 0xFF
     instrs[2 as usize] = ir_load_imm(3, -256)                   // r3 = ~0xFF = -256
@@ -14949,7 +14962,7 @@ fn compiler_main_test_bw_xor_and_comp_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_no_fold_wrong_complement() -> bool with Mut, Div, Panic {
     // (x ^ 5) & 5 → no fold: AND mask is C not ~C
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 5
     instrs[2 as usize] = ir_load_imm(3, 5)                      // r3 = 5 (not ~5)
@@ -14961,7 +14974,7 @@ fn compiler_main_test_bw_no_fold_wrong_complement() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bw_no_fold_or_op() -> bool with Mut, Div, Panic {
     // (x ^ 5) | ~5 → no fold by BW (OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -14974,7 +14987,7 @@ fn compiler_main_test_bw_no_fold_or_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_no_fold_plain_and() -> bool with Mut, Div, Panic {
     // (x + 5) & ~5 → no fold: inner not xor-tracked
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)     // r2 = x+5 (not xor)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -14987,7 +15000,7 @@ fn compiler_main_test_bw_no_fold_plain_and() -> bool with Mut, Div, Panic {
 // Sprint 162 Block BX: OR-XOR complement fold (T638-T643)
 fn compiler_main_test_bx_or_xor_comp_basic() -> bool with Mut, Div, Panic {
     // (r0 | 5) ^ 5 → r0 & ~5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15001,7 +15014,7 @@ fn compiler_main_test_bx_or_xor_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_or_xor_comp_comm() -> bool with Mut, Div, Panic {
     // 5 ^ (r0 | 5) → r0 & ~5 (commutative outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15015,7 +15028,7 @@ fn compiler_main_test_bx_or_xor_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_or_xor_comp_merged_const() -> bool with Mut, Div, Panic {
     // (r0 | 0xFF) ^ 0xFF → r0 & ~0xFF; ~0xFF = -256
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -15029,7 +15042,7 @@ fn compiler_main_test_bx_or_xor_comp_merged_const() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bx_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0 | 5) ^ 3 → no fold (outer C != inner C)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15041,7 +15054,7 @@ fn compiler_main_test_bx_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 | 5) & 5 → no fold (outer is AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15055,7 +15068,7 @@ fn compiler_main_test_bx_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_no_fold_inner_xor() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) ^ 5 → r0 (Block BM/BN territory, not BX)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // not OR
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15070,7 +15083,7 @@ fn compiler_main_test_bx_no_fold_inner_xor() -> bool with Mut, Div, Panic {
 // Sprint 163 Block BY: XOR-OR same-constant fold (T644-T649)
 fn compiler_main_test_by_xor_or_same_basic() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) | 5 → r0 | 5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = r0^5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15084,7 +15097,7 @@ fn compiler_main_test_by_xor_or_same_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_xor_or_same_comm() -> bool with Mut, Div, Panic {
     // 5 | (r0 ^ 5) → r0 | 5 (commutative outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15098,7 +15111,7 @@ fn compiler_main_test_by_xor_or_same_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_xor_or_same_val() -> bool with Mut, Div, Panic {
     // (r0 ^ 0xFF) | 0xFF → r0 | 0xFF; base reg preserved
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -15112,7 +15125,7 @@ fn compiler_main_test_by_xor_or_same_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) | 3 → no fold (different constant)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15124,7 +15137,7 @@ fn compiler_main_test_by_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) & 5 → no fold (outer AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15138,7 +15151,7 @@ fn compiler_main_test_by_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_no_fold_plain_or() -> bool with Mut, Div, Panic {
     // r0 | 5 → no fold (no xor-tracked inner)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -15150,7 +15163,7 @@ fn compiler_main_test_by_no_fold_plain_or() -> bool with Mut, Div, Panic {
 // Sprint 164 Block BZ: AND-XOR same-constant merge (T650-T655)
 fn compiler_main_test_bz_and_xor_merge_basic() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 ^ 5) → r0 | 5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15165,7 +15178,7 @@ fn compiler_main_test_bz_and_xor_merge_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_and_xor_merge_comm() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) | (r0 & 5) → r0 | 5 (commutative: xor on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = r0 ^ 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15180,7 +15193,7 @@ fn compiler_main_test_bz_and_xor_merge_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_and_xor_merge_val() -> bool with Mut, Div, Panic {
     // (r0 & 0xFF) | (r0 ^ 0xFF) → r0 | 0xFF; base reg preserved
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -15195,7 +15208,7 @@ fn compiler_main_test_bz_and_xor_merge_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 ^ 3) → no fold (different constants)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15208,7 +15221,7 @@ fn compiler_main_test_bz_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r1 ^ 5) → no fold (different base register)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)  // r3 = r0 & 5
     instrs[2 as usize] = ir_load_imm(4, 5)
@@ -15221,7 +15234,7 @@ fn compiler_main_test_bz_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 | r1 → no fold (neither tracked)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -15232,7 +15245,7 @@ fn compiler_main_test_bz_no_fold_plain() -> bool with Mut, Div, Panic {
 // Sprint 165 Block CA: OR-complement AND elimination (T656-T661)
 fn compiler_main_test_ca_or_comp_and_basic() -> bool with Mut, Div, Panic {
     // (r0|5)&(r0|~5) → r0: complements annihilate → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -15246,7 +15259,7 @@ fn compiler_main_test_ca_or_comp_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_or_comp_and_comm() -> bool with Mut, Div, Panic {
     // (r0|~5)&(r0|5) → r0: commutative (constants swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                     // r1 = ~5 = -6
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15260,7 +15273,7 @@ fn compiler_main_test_ca_or_comp_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_or_comp_and_val() -> bool with Mut, Div, Panic {
     // (r0|0xFF)&(r0|~0xFF) → r0: verify with 0xFF/~0xFF pair
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)                   // ~0xFF = -256
@@ -15274,7 +15287,7 @@ fn compiler_main_test_ca_or_comp_and_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0|5)&(r1|~5) → no fold: different base variables
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)   // r3 = r0 | 5
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -15287,7 +15300,7 @@ fn compiler_main_test_ca_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_no_fold_non_complement() -> bool with Mut, Div, Panic {
     // (r0|5)&(r0|3) → no fold: constants 5 and 3 are not complements
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15300,7 +15313,7 @@ fn compiler_main_test_ca_no_fold_non_complement() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_no_fold_outer_or() -> bool with Mut, Div, Panic {
     // (r0|5)|(r0|~5) → no fold by CA (outer is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -15314,7 +15327,7 @@ fn compiler_main_test_ca_no_fold_outer_or() -> bool with Mut, Div, Panic {
 // Sprint 166 Block CB: Add/sub-const inverse (T662-T667)
 fn compiler_main_test_cb_add_sub_inverse_basic() -> bool with Mut, Div, Panic {
     // (r0+5)-5 → r0: bt_add then sub same const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0+5 (bt_add)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15326,7 +15339,7 @@ fn compiler_main_test_cb_add_sub_inverse_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_sub_add_inverse_basic() -> bool with Mut, Div, Panic {
     // (r0-3)+3 → r0: bs_sub then add same const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0-3 (bs_sub)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15338,7 +15351,7 @@ fn compiler_main_test_cb_sub_add_inverse_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_sub_add_comm() -> bool with Mut, Div, Panic {
     // 3+(r0-3) → r0: commutative: const+(sub-const) same C
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0-3 (bs_sub)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15350,7 +15363,7 @@ fn compiler_main_test_cb_sub_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0+5)-3 → no fold: different constants
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0+5
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15362,7 +15375,7 @@ fn compiler_main_test_cb_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_no_fold_same_op() -> bool with Mut, Div, Panic {
     // (r0+5)+5 → no fold by CB (both adds — not inverse)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15375,7 +15388,7 @@ fn compiler_main_test_cb_no_fold_same_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_no_fold_plain_sub() -> bool with Mut, Div, Panic {
     // r0-5 → no fold: not a bt_add-tracked register
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0-5 (plain sub, not add-const)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15388,7 +15401,7 @@ fn compiler_main_test_cb_no_fold_plain_sub() -> bool with Mut, Div, Panic {
 // Sprint 167 Block CC: AND complement partition (T668-T673)
 fn compiler_main_test_cc_and_comp_partition_basic() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 & ~5) → r0: AND partition fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -15402,7 +15415,7 @@ fn compiler_main_test_cc_and_comp_partition_basic() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_cc_and_comp_partition_comm() -> bool with Mut, Div, Panic {
     // (r0 & ~5) | (r0 & 5) → r0: commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15416,7 +15429,7 @@ fn compiler_main_test_cc_and_comp_partition_comm() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_cc_and_comp_partition_val() -> bool with Mut, Div, Panic {
     // (r0 & 0xFF) | (r0 & ~0xFF) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 0xFF
     instrs[2 as usize] = ir_load_imm(3, -256)                   // ~0xFF = -256
@@ -15430,7 +15443,7 @@ fn compiler_main_test_cc_and_comp_partition_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cc_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r1 & ~5) → no fold: different base registers
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)  // r3 = r0 & 5
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -15443,7 +15456,7 @@ fn compiler_main_test_cc_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cc_no_fold_non_complement() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 & 3) → no fold: 3 is not ~5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, 3)                      // 3 != ~5
@@ -15456,7 +15469,7 @@ fn compiler_main_test_cc_no_fold_non_complement() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cc_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 & 5) & (r0 & ~5) → no fold by CC (AND outer not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -15470,7 +15483,7 @@ fn compiler_main_test_cc_no_fold_and_op() -> bool with Mut, Div, Panic {
 // Sprint 168 Block CD: Zero-minus normalization (T674-T679)
 fn compiler_main_test_cd_zero_minus_basic() -> bool with Mut, Div, Panic {
     // 0 - r0 → neg(r0): zero-minus fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 0)  // r2 = 0 - r0
     let func = cp_make_test_func(instrs, 2)
@@ -15482,7 +15495,7 @@ fn compiler_main_test_cd_zero_minus_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_zero_minus_chain() -> bool with Mut, Div, Panic {
     // neg(0 - r0) → double-neg elim → r0 (CD normalizes 0-r0 to neg, BJ elims double neg)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 0)  // r2 = 0 - r0 → neg(r0)
     instrs[2 as usize] = ir_unaryop(3, UnaryOp::OpNeg, 2)    // r3 = neg(r2) → IrCopy(r0)
@@ -15494,7 +15507,7 @@ fn compiler_main_test_cd_zero_minus_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_zero_minus_val() -> bool with Mut, Div, Panic {
     // 0 - r1 → neg(r1): fold on non-r0 register
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_load_imm(2, 0)
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)  // r3 = 0 - r1 (r1=7)
@@ -15506,7 +15519,7 @@ fn compiler_main_test_cd_zero_minus_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_no_fold_nonzero() -> bool with Mut, Div, Panic {
     // 5 - r0 → no fold (non-zero constant)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 0)  // r2 = 5 - r0
     let func = cp_make_test_func(instrs, 2)
@@ -15516,7 +15529,7 @@ fn compiler_main_test_cd_no_fold_nonzero() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_no_fold_rr_sub() -> bool with Mut, Div, Panic {
     // r0 - r1 → no fold (no constant operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - r1
     let func = cp_make_test_func(instrs, 2)
     let opt = opt_cleanup_function(func)
@@ -15525,7 +15538,7 @@ fn compiler_main_test_cd_no_fold_rr_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_no_fold_sub_zero() -> bool with Mut, Div, Panic {
     // r0 - 0 → IrCopy(r0) by const-identity (Block B/x-0), not CD
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 0
     let func = cp_make_test_func(instrs, 2)
@@ -15537,7 +15550,7 @@ fn compiler_main_test_cd_no_fold_sub_zero() -> bool with Mut, Div, Panic {
 // Sprint 169 Block CE: Multiply-constant chain fold (T680-T685)
 fn compiler_main_test_ce_mul_const_chain_basic() -> bool with Mut, Div, Panic {
     // (r0*3)*4 → r0*12: mul-const chain fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15551,7 +15564,7 @@ fn compiler_main_test_ce_mul_const_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_mul_const_chain_comm() -> bool with Mut, Div, Panic {
     // 4*(r0*3) → r0*12: commutative variant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15565,7 +15578,7 @@ fn compiler_main_test_ce_mul_const_chain_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_mul_const_chain_val() -> bool with Mut, Div, Panic {
     // (r0*5)*6 → r0*30: verify merged constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 5
     instrs[2 as usize] = ir_load_imm(3, 6)
@@ -15579,7 +15592,7 @@ fn compiler_main_test_ce_mul_const_chain_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_no_fold_rr_mul() -> bool with Mut, Div, Panic {
     // (r0*r1)*3 → no fold (s1 not mul-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * r1
     instrs[1 as usize] = ir_load_imm(3, 3)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpMul, 3)  // r4 = (r0*r1)*3
@@ -15591,7 +15604,7 @@ fn compiler_main_test_ce_no_fold_rr_mul() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_no_fold_add_chain() -> bool with Mut, Div, Panic {
     // (r0+3)*4 → no fold by CE (add-const, not mul-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15603,7 +15616,7 @@ fn compiler_main_test_ce_no_fold_add_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_no_fold_div_chain() -> bool with Mut, Div, Panic {
     // (r0*3)/4 → no fold by CE (CE is mul only, Block O handles mul-div)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15617,7 +15630,7 @@ fn compiler_main_test_ce_no_fold_div_chain() -> bool with Mut, Div, Panic {
 // Sprint 170 Block CF: OR-AND superset absorption (T686-T691)
 fn compiler_main_test_cf_or_and_same_const() -> bool with Mut, Div, Panic {
     // (r0|7)&7 → 7: same constant (C2==C1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -15630,7 +15643,7 @@ fn compiler_main_test_cf_or_and_same_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_or_and_superset() -> bool with Mut, Div, Panic {
     // (r0|15)&7 → 7: C2(7)⊆C1(15)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 15
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -15643,7 +15656,7 @@ fn compiler_main_test_cf_or_and_superset() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_or_and_comm() -> bool with Mut, Div, Panic {
     // 7&(r0|15) → 7: commutative variant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 15
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -15656,7 +15669,7 @@ fn compiler_main_test_cf_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_no_fold_subset() -> bool with Mut, Div, Panic {
     // (r0|7)&15 → no CF fold (C2(15) ⊄ C1(7)); handled by other rules or left
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 15)
@@ -15668,7 +15681,7 @@ fn compiler_main_test_cf_no_fold_subset() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_no_fold_disjoint() -> bool with Mut, Div, Panic {
     // (r0|4)&8 → r0&8 by BI (disjoint), not CF constant-load
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 4)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 4
     instrs[2 as usize] = ir_load_imm(3, 8)
@@ -15681,7 +15694,7 @@ fn compiler_main_test_cf_no_fold_disjoint() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_no_fold_rr() -> bool with Mut, Div, Panic {
     // (r0|r1)&7 → no fold (no or-const tracking for r0|r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | r1
     instrs[1 as usize] = ir_load_imm(3, 7)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)  // r4 = (r0|r1)&7
@@ -15693,7 +15706,7 @@ fn compiler_main_test_cf_no_fold_rr() -> bool with Mut, Div, Panic {
 // Sprint 171 Block CG: Multiply-add normalization (T692-T697)
 fn compiler_main_test_cg_mul_add_basic() -> bool with Mut, Div, Panic {
     // (r0*3)+r0 → r0*4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0*3) + r0 → r0*4
@@ -15706,7 +15719,7 @@ fn compiler_main_test_cg_mul_add_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_mul_add_comm() -> bool with Mut, Div, Panic {
     // r0+(r0*5) → r0*6 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 5
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)  // r3 = r0 + (r0*5) → r0*6
@@ -15719,7 +15732,7 @@ fn compiler_main_test_cg_mul_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_mul_add_large() -> bool with Mut, Div, Panic {
     // (r0*99)+r0 → r0*100
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 99)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 99
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0*99) + r0 → r0*100
@@ -15732,7 +15745,7 @@ fn compiler_main_test_cg_mul_add_large() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0*3)+r1 → no fold (different base)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)  // r3 = r0 * 3
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 1)  // r4 = (r0*3) + r1
@@ -15744,7 +15757,7 @@ fn compiler_main_test_cg_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_no_fold_rr_mul() -> bool with Mut, Div, Panic {
     // (r0*r1)+r0 → no fold (not const-mul)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0*r1) + r0
     let func = cp_make_test_func(instrs, 2)
@@ -15755,7 +15768,7 @@ fn compiler_main_test_cg_no_fold_rr_mul() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0*3)-r0 → no fold (sub, not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)  // r3 = (r0*3) - r0
@@ -15768,7 +15781,7 @@ fn compiler_main_test_cg_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 172 Block CH: Multiply-sub normalization (T698-T703)
 fn compiler_main_test_ch_mul_sub_basic() -> bool with Mut, Div, Panic {
     // (r0*3)-r0 → r0*2: mul-sub fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)   // r3 = (r0*3)-r0 → r0*2
@@ -15781,7 +15794,7 @@ fn compiler_main_test_ch_mul_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_sub_mul_basic() -> bool with Mut, Div, Panic {
     // r0-(r0*3) → r0*(-2): x-(x*C) fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)   // r3 = r0-(r0*3) → r0*(-2)
@@ -15794,7 +15807,7 @@ fn compiler_main_test_ch_sub_mul_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_mul_sub_large() -> bool with Mut, Div, Panic {
     // (r0*100)-r0 → r0*99: large constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 100)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 100
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)   // r3 = (r0*100)-r0 → r0*99
@@ -15807,7 +15820,7 @@ fn compiler_main_test_ch_mul_sub_large() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0*3)-r1 → no fold (r1 ≠ r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)   // r3 = r0 * 3
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 1)   // r4 = (r0*3)-r1
@@ -15818,7 +15831,7 @@ fn compiler_main_test_ch_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_no_fold_rr_sub() -> bool with Mut, Div, Panic {
     // (r0*r1)-r0 → no fold (mul not mul-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)   // r3 = (r0*r1)-r0
     let func = cp_make_test_func(instrs, 2)
@@ -15828,7 +15841,7 @@ fn compiler_main_test_ch_no_fold_rr_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0*3)+r0 → r0*4 by CG (not CH), confirms CH only handles sub
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)   // r3 = (r0*3)+r0 → r0*4 by CG
@@ -15842,7 +15855,7 @@ fn compiler_main_test_ch_no_fold_add() -> bool with Mut, Div, Panic {
 // Sprint 173 Block CI: Shift-add to multiply (T704-T709)
 fn compiler_main_test_ci_shl_add_basic() -> bool with Mut, Div, Panic {
     // (r0<<1)+r0 → r0*3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 1
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0<<1)+r0 → r0*3
@@ -15855,7 +15868,7 @@ fn compiler_main_test_ci_shl_add_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_shl_add_comm() -> bool with Mut, Div, Panic {
     // r0+(r0<<2) → r0*5 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 2
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)  // r3 = r0+(r0<<2) → r0*5
@@ -15868,7 +15881,7 @@ fn compiler_main_test_ci_shl_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_shl_add_large() -> bool with Mut, Div, Panic {
     // (r0<<3)+r0 → r0*9
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0<<3)+r0 → r0*9
@@ -15881,7 +15894,7 @@ fn compiler_main_test_ci_shl_add_large() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0<<1)+r1 → no fold (different base)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)  // r3 = r0 << 1
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 1)  // r4 = (r0<<1)+r1
@@ -15893,7 +15906,7 @@ fn compiler_main_test_ci_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_no_fold_rr_shl() -> bool with Mut, Div, Panic {
     // (r0<<r1)+r0 → no fold (non-const shift)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0<<r1)+r0
     let func = cp_make_test_func(instrs, 2)
@@ -15904,7 +15917,7 @@ fn compiler_main_test_ci_no_fold_rr_shl() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0<<1)-r0 → no fold by CI (sub, not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 1
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)  // r3 = (r0<<1)-r0
@@ -15917,7 +15930,7 @@ fn compiler_main_test_ci_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 174 Block CJ: Shift-sub to multiply (T710-T715)
 fn compiler_main_test_cj_shl_sub_basic() -> bool with Mut, Div, Panic {
     // (r0<<1)-r0 → r0*1 (2^1-1=1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<1
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)     // r3 = (r0<<1)-r0
@@ -15930,7 +15943,7 @@ fn compiler_main_test_cj_shl_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_shl_sub_three() -> bool with Mut, Div, Panic {
     // (r0<<2)-r0 → r0*3 (2^2-1=3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<2
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)     // r3 = (r0<<2)-r0
@@ -15943,7 +15956,7 @@ fn compiler_main_test_cj_shl_sub_three() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_sub_shl_reverse() -> bool with Mut, Div, Panic {
     // r0-(r0<<2) → r0*(1-4) = r0*(-3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<2
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)     // r3 = r0-(r0<<2)
@@ -15956,7 +15969,7 @@ fn compiler_main_test_cj_sub_shl_reverse() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0<<1)-r1 → no fold: different base variables
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)     // r3 = r0<<1
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 1)     // r4 = (r0<<1)-r1
@@ -15967,7 +15980,7 @@ fn compiler_main_test_cj_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_no_fold_rr_shl() -> bool with Mut, Div, Panic {
     // (r0<<r1)-r0 → no fold: shift amount is not constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)     // r3 = (r0<<r1)-r0
     let func = cp_make_test_func(instrs, 2)
@@ -15977,7 +15990,7 @@ fn compiler_main_test_cj_no_fold_rr_shl() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0<<1)+r0 → no fold by CJ (add not sub; handled by CI)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)     // add not sub
@@ -15991,7 +16004,7 @@ fn compiler_main_test_cj_no_fold_add() -> bool with Mut, Div, Panic {
 // Sprint 175 Block CK: AND-complement OR (T716-T721)
 fn compiler_main_test_ck_and_comp_or_basic() -> bool with Mut, Div, Panic {
     // (r0 & ~5) | 5 → r0 | 5: AND-complement OR fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                     // r1 = ~5 = -6
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16005,7 +16018,7 @@ fn compiler_main_test_ck_and_comp_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_and_comp_or_comm() -> bool with Mut, Div, Panic {
     // 5 | (r0 & ~5) → r0 | 5: commutative outer
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                     // r1 = ~5 = -6
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16019,7 +16032,7 @@ fn compiler_main_test_ck_and_comp_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_and_comp_or_val() -> bool with Mut, Div, Panic {
     // (r0 & ~12) | 12 → r0 | 12: different constant C=12
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -13)                    // r1 = ~12 = -13
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1) // r2 = r0 & ~12
     instrs[2 as usize] = ir_load_imm(3, 12)
@@ -16033,7 +16046,7 @@ fn compiler_main_test_ck_and_comp_or_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
     // (r0 & ~5) | 3 → no fold: 3 is not complement of ~5 (3 != 5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                    // r1 = ~5
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1) // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16047,7 +16060,7 @@ fn compiler_main_test_ck_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_no_fold_non_and() -> bool with Mut, Div, Panic {
     // (r0 | ~5) | 5 → no fold by CK (OR not AND in s1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                    // r1 = ~5
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)  // r2 = r0 | ~5 (OR not AND)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16060,7 +16073,7 @@ fn compiler_main_test_ck_no_fold_non_and() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 & ~5) & 5 → no fold by CK (AND outer not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                    // r1 = ~5
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1) // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16075,7 +16088,7 @@ fn compiler_main_test_ck_no_fold_and_op() -> bool with Mut, Div, Panic {
 // Sprint 176 Block CL: OR-complement AND (T722-T727)
 fn compiler_main_test_cl_or_comp_and_basic() -> bool with Mut, Div, Panic {
     // (r0|7)&~7 → r0&~7: OR-comp-AND fold; ~7=-8
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, -8)                       // r3 = ~7 = -8
@@ -16089,7 +16102,7 @@ fn compiler_main_test_cl_or_comp_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_or_comp_and_comm() -> bool with Mut, Div, Panic {
     // ~7&(r0|7) → r0&~7: commutative outer
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, -8)                       // r3 = ~7
@@ -16103,7 +16116,7 @@ fn compiler_main_test_cl_or_comp_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_or_comp_and_val() -> bool with Mut, Div, Panic {
     // (r0|0xFF)&~0xFF → r0&~0xFF: larger mask
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 0xFF
     instrs[2 as usize] = ir_load_imm(3, -256)                     // r3 = ~0xFF = -256
@@ -16117,7 +16130,7 @@ fn compiler_main_test_cl_or_comp_and_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
     // (r0|7)&5 → no fold (5 ≠ ~7)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16131,7 +16144,7 @@ fn compiler_main_test_cl_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_no_fold_rr_or() -> bool with Mut, Div, Panic {
     // (r0|r1)&~7 → no fold (no or-const tracking for r0|r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | r1
     instrs[1 as usize] = ir_load_imm(3, -8)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)   // r4 = (r0|r1)&~7
@@ -16142,7 +16155,7 @@ fn compiler_main_test_cl_no_fold_rr_or() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_no_fold_or_op() -> bool with Mut, Div, Panic {
     // (r0|7)|~7 → no fold by CL (OR outer, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, -8)
@@ -16155,7 +16168,7 @@ fn compiler_main_test_cl_no_fold_or_op() -> bool with Mut, Div, Panic {
 // Sprint 177 Block CM: AND complement XOR partition (T728-T733)
 fn compiler_main_test_cm_and_comp_xor_basic() -> bool with Mut, Div, Panic {
     // (r0&5)^(r0&~5) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, -6)                       // ~5
@@ -16167,7 +16180,7 @@ fn compiler_main_test_cm_and_comp_xor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cm_and_comp_xor_comm() -> bool with Mut, Div, Panic {
     // (r0&~5)^(r0&5) → r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16179,7 +16192,7 @@ fn compiler_main_test_cm_and_comp_xor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cm_and_comp_xor_val() -> bool with Mut, Div, Panic {
     // (r0&0xFF)^(r0&~0xFF) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -16190,7 +16203,7 @@ fn compiler_main_test_cm_and_comp_xor_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op == IrOpcode::IrCopy && opt.instrs[4 as usize].src1 == 0
 }
 fn compiler_main_test_cm_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -16201,7 +16214,7 @@ fn compiler_main_test_cm_no_fold_diff_base() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op != IrOpcode::IrCopy
 }
 fn compiler_main_test_cm_no_fold_non_comp() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)                        // not ~5
@@ -16212,7 +16225,7 @@ fn compiler_main_test_cm_no_fold_non_comp() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op != IrOpcode::IrCopy
 }
 fn compiler_main_test_cm_no_fold_or_outer() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16226,7 +16239,7 @@ fn compiler_main_test_cm_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 178 Block CN: Add-self to multiply tracking (T734-T739)
 fn compiler_main_test_cn_add_self_tracking() -> bool with Mut, Div, Panic {
     // x+x → tracked as x*2 for downstream passes (CG etc.)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpAdd, 0)      // r1 = r0+r0
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16236,7 +16249,7 @@ fn compiler_main_test_cn_add_self_tracking() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cn_add_self_chain_cg() -> bool with Mut, Div, Panic {
     // (r0+r0)+r0 → should trigger CG: mul_valid(r1)=true, mul_const=2, then +r0 → r0*3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpAdd, 0)      // r1 = r0+r0 (tracked as r0*2)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)      // r2 = (r0*2)+r0 → CG → r0*3
     let func = cp_make_test_func(instrs, 2)
@@ -16244,7 +16257,7 @@ fn compiler_main_test_cn_add_self_chain_cg() -> bool with Mut, Div, Panic {
     opt.instrs[1 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cn_add_self_val() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 1)      // r2 = r1+r1
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16252,7 +16265,7 @@ fn compiler_main_test_cn_add_self_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cn_no_track_diff_ops() -> bool with Mut, Div, Panic {
     // r0+r1 → no tracking (different operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16260,7 +16273,7 @@ fn compiler_main_test_cn_no_track_diff_ops() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cn_no_track_sub() -> bool with Mut, Div, Panic {
     // r0-r0 → 0 (Block A), not mul tracking
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpSub, 0)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16269,7 +16282,7 @@ fn compiler_main_test_cn_no_track_sub() -> bool with Mut, Div, Panic {
 fn compiler_main_test_cn_chain_ce() -> bool with Mut, Div, Panic {
     // (r0+r0)*(r0+r0) won't trigger CE directly since both sides are r0*2
     // but (r0+r0)*3 should: mul_valid(r1)=true,cval=2 → CE → r0*6
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpAdd, 0)      // r1 = r0+r0 (tracked r0*2)
     instrs[1 as usize] = ir_load_imm(2, 3)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpMul, 2)      // r3 = (r0*2)*3 → CE → r0*6
@@ -16281,7 +16294,7 @@ fn compiler_main_test_cn_chain_ce() -> bool with Mut, Div, Panic {
 // Sprint 179 Block CO: Neg-add to sub (T740-T745)
 fn compiler_main_test_co_neg_add_basic() -> bool with Mut, Div, Panic {
     // neg(r0)+r1 → r1-r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)        // r2 = neg(r0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 1)      // r3 = neg(r0)+r1
     let func = cp_make_test_func(instrs, 2)
@@ -16292,7 +16305,7 @@ fn compiler_main_test_co_neg_add_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_add_neg_basic() -> bool with Mut, Div, Panic {
     // r0+neg(r1) → r0-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)        // r2 = neg(r1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)      // r3 = r0+neg(r1)
     let func = cp_make_test_func(instrs, 2)
@@ -16303,7 +16316,7 @@ fn compiler_main_test_co_add_neg_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_neg_add_val() -> bool with Mut, Div, Panic {
     // neg(r1)+r0 → r0-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -16313,7 +16326,7 @@ fn compiler_main_test_co_neg_add_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_no_fold_sub() -> bool with Mut, Div, Panic {
     // neg(r0)-r1 → NOT add, so CO doesn't fire (CO only handles add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -16322,7 +16335,7 @@ fn compiler_main_test_co_no_fold_sub() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_no_fold_plain_add() -> bool with Mut, Div, Panic {
     // r0+r1 → no fold (neither is neg)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16330,7 +16343,7 @@ fn compiler_main_test_co_no_fold_plain_add() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_no_fold_not() -> bool with Mut, Div, Panic {
     // ~r0+r1 → no fold (NOT is not NEG)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -16341,7 +16354,7 @@ fn compiler_main_test_co_no_fold_not() -> bool with Mut, Div, Panic {
 // Sprint 180 Block CP: Sub-neg to add (T746-T751)
 fn compiler_main_test_cp_sub_neg_basic() -> bool with Mut, Div, Panic {
     // r0-neg(r1) → r0+r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)        // r2 = neg(r1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)      // r3 = r0-neg(r1)
     let func = cp_make_test_func(instrs, 2)
@@ -16352,7 +16365,7 @@ fn compiler_main_test_cp_sub_neg_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_sub_neg_val() -> bool with Mut, Div, Panic {
     // r1-neg(r0) → r1+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -16362,7 +16375,7 @@ fn compiler_main_test_cp_sub_neg_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_sub_neg_chain() -> bool with Mut, Div, Panic {
     // r0-neg(neg(r1)): neg(neg(r1))→r1 (double-neg), then r0-r1 (no CP)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNeg, 2)        // double-neg → r1
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 3)
@@ -16373,7 +16386,7 @@ fn compiler_main_test_cp_sub_neg_chain() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_no_fold_add() -> bool with Mut, Div, Panic {
     // r0+neg(r1) → CO fires (not CP); CP only handles sub
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -16382,7 +16395,7 @@ fn compiler_main_test_cp_no_fold_add() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_no_fold_plain_sub() -> bool with Mut, Div, Panic {
     // r0-r1 → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16390,7 +16403,7 @@ fn compiler_main_test_cp_no_fold_plain_sub() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // r0-~r1 → no fold (NOT not NEG)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -16401,7 +16414,7 @@ fn compiler_main_test_cp_no_fold_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 181 Block CQ: OR complement XOR → NOT (T752-T757)
 fn compiler_main_test_cq_or_comp_xor_not() -> bool with Mut, Div, Panic {
     // (r0|5)^(r0|~5) → ~r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16415,7 +16428,7 @@ fn compiler_main_test_cq_or_comp_xor_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cq_or_comp_xor_comm() -> bool with Mut, Div, Panic {
     // (r0|~5)^(r0|5) → ~r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16427,7 +16440,7 @@ fn compiler_main_test_cq_or_comp_xor_comm() -> bool with Mut, Div, Panic {
         && opt.instrs[4 as usize].un_op == UnaryOp::OpNot
 }
 fn compiler_main_test_cq_or_comp_xor_val() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -16438,7 +16451,7 @@ fn compiler_main_test_cq_or_comp_xor_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op == IrOpcode::IrUnaryOp
 }
 fn compiler_main_test_cq_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -16449,7 +16462,7 @@ fn compiler_main_test_cq_no_fold_diff_base() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op != IrOpcode::IrUnaryOp
 }
 fn compiler_main_test_cq_no_fold_non_comp() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16461,7 +16474,7 @@ fn compiler_main_test_cq_no_fold_non_comp() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cq_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|5)&(r0|~5) → Block CA fires (IrCopy), not CQ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16475,7 +16488,7 @@ fn compiler_main_test_cq_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 182 Block CR: AND-XOR complement extraction (T758-T763)
 fn compiler_main_test_cr_and_xor_comp_basic() -> bool with Mut, Div, Panic {
     // (r0&5)^5 → ~r0&5: rewrite to NOT then AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16486,7 +16499,7 @@ fn compiler_main_test_cr_and_xor_comp_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cr_and_xor_comp_comm() -> bool with Mut, Div, Panic {
     // 5^(r0&5) → ~r0&5: commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16496,7 +16509,7 @@ fn compiler_main_test_cr_and_xor_comp_comm() -> bool with Mut, Div, Panic {
     opt.instrs[3 as usize].bin_op == BinaryOp::OpBitAnd
 }
 fn compiler_main_test_cr_and_xor_comp_val() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -16506,7 +16519,7 @@ fn compiler_main_test_cr_and_xor_comp_val() -> bool with Mut, Div, Panic {
     opt.instrs[3 as usize].bin_op == BinaryOp::OpBitAnd
 }
 fn compiler_main_test_cr_no_fold_diff_const() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)                        // different const
@@ -16518,7 +16531,7 @@ fn compiler_main_test_cr_no_fold_diff_const() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cr_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (r0|5)^5 → Block BX handles this, not CR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16530,7 +16543,7 @@ fn compiler_main_test_cr_no_fold_or_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cr_no_fold_plain_xor() -> bool with Mut, Div, Panic {
     // r0^5 → no fold (r0 not and-tracked)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -16541,7 +16554,7 @@ fn compiler_main_test_cr_no_fold_plain_xor() -> bool with Mut, Div, Panic {
 // Sprint 183 Block CS: Sub-add constant chain fold (T764-T769)
 fn compiler_main_test_cs_sub_add_chain_basic() -> bool with Mut, Div, Panic {
     // (r0-3)+5 → r0+2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16554,7 +16567,7 @@ fn compiler_main_test_cs_sub_add_chain_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_sub_add_chain_comm() -> bool with Mut, Div, Panic {
     // 5+(r0-3) → r0+2 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16567,7 +16580,7 @@ fn compiler_main_test_cs_sub_add_chain_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_sub_add_chain_cancel() -> bool with Mut, Div, Panic {
     // (r0-5)+5 → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16578,7 +16591,7 @@ fn compiler_main_test_cs_sub_add_chain_cancel() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_sub_add_chain_neg_result() -> bool with Mut, Div, Panic {
     // (r0-7)+2 → r0-5 (negative merged constant)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 7
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16591,7 +16604,7 @@ fn compiler_main_test_cs_sub_add_chain_neg_result() -> bool with Mut, Div, Panic
 }
 fn compiler_main_test_cs_no_fold_rr_sub() -> bool with Mut, Div, Panic {
     // (r0-r1)+5 → no fold (sub is rr, not const-sub)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - r1
     instrs[1 as usize] = ir_load_imm(3, 5)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)   // r4 = (r0-r1)+5
@@ -16601,7 +16614,7 @@ fn compiler_main_test_cs_no_fold_rr_sub() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_no_fold_rr_add() -> bool with Mut, Div, Panic {
     // (r0-3)+r1 → no fold (add is rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 3
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 1)   // r4 = (r0-3)+r1
@@ -16613,7 +16626,7 @@ fn compiler_main_test_cs_no_fold_rr_add() -> bool with Mut, Div, Panic {
 // Sprint 184 Block CT: Mul-const distributive sub (T770-T775)
 fn compiler_main_test_ct_mul_dist_sub_basic() -> bool with Mut, Div, Panic {
     // r0*5 - r0*3 → r0*2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)      // r2 = r0*5
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16625,7 +16638,7 @@ fn compiler_main_test_ct_mul_dist_sub_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ct_mul_dist_sub_zero() -> bool with Mut, Div, Panic {
     // r0*3 - r0*3 → r0*0 = 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16637,7 +16650,7 @@ fn compiler_main_test_ct_mul_dist_sub_zero() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ct_mul_dist_sub_val() -> bool with Mut, Div, Panic {
     // r0*10 - r0*3 → r0*7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 10)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16648,7 +16661,7 @@ fn compiler_main_test_ct_mul_dist_sub_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_ct_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)      // r0*5
     instrs[2 as usize] = ir_load_imm(4, 3)
@@ -16660,7 +16673,7 @@ fn compiler_main_test_ct_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ct_no_fold_add_op() -> bool with Mut, Div, Panic {
     // r0*5 + r0*3 → CS fires (add), not CT (sub)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16671,7 +16684,7 @@ fn compiler_main_test_ct_no_fold_add_op() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_ct_no_fold_plain_sub() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16681,7 +16694,7 @@ fn compiler_main_test_ct_no_fold_plain_sub() -> bool with Mut, Div, Panic {
 // Sprint 185 Block CU: Shift-add factoring (T776-T781)
 fn compiler_main_test_cu_shl_add_factor() -> bool with Mut, Div, Panic {
     // (r0<<1)+(r0<<2) → r0*6 (2+4=6)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)      // r0<<1
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16693,7 +16706,7 @@ fn compiler_main_test_cu_shl_add_factor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cu_shl_add_factor_comm() -> bool with Mut, Div, Panic {
     // (r0<<3)+(r0<<1) → r0*10 (8+2=10)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 1)
@@ -16705,7 +16718,7 @@ fn compiler_main_test_cu_shl_add_factor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cu_shl_add_same() -> bool with Mut, Div, Panic {
     // (r0<<2)+(r0<<2) → r0*8 (4+4=8)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16716,7 +16729,7 @@ fn compiler_main_test_cu_shl_add_same() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cu_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)      // r0<<1
     instrs[2 as usize] = ir_load_imm(4, 2)
@@ -16727,7 +16740,7 @@ fn compiler_main_test_cu_no_fold_diff_base() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpAdd
 }
 fn compiler_main_test_cu_no_fold_rr_shl() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)      // r0<<r1 (non-const)
     instrs[1 as usize] = ir_load_imm(3, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpShl, 3)      // r0<<2
@@ -16738,7 +16751,7 @@ fn compiler_main_test_cu_no_fold_rr_shl() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cu_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0<<1)-(r0<<2) → CV fires (sub), not CU (add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16752,7 +16765,7 @@ fn compiler_main_test_cu_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 186 Block CV: Shift-sub factoring (T782-T787)
 fn compiler_main_test_cv_shl_sub_factor() -> bool with Mut, Div, Panic {
     // (r0<<3)-(r0<<1) → r0*6 (8-2=6)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 1)
@@ -16764,7 +16777,7 @@ fn compiler_main_test_cv_shl_sub_factor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cv_shl_sub_negative() -> bool with Mut, Div, Panic {
     // (r0<<1)-(r0<<3) → r0*(-6) (2-8=-6)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16776,7 +16789,7 @@ fn compiler_main_test_cv_shl_sub_negative() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cv_shl_sub_val() -> bool with Mut, Div, Panic {
     // (r0<<4)-(r0<<2) → r0*12 (16-4=12)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 4)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16787,7 +16800,7 @@ fn compiler_main_test_cv_shl_sub_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cv_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)
     instrs[2 as usize] = ir_load_imm(4, 1)
@@ -16799,7 +16812,7 @@ fn compiler_main_test_cv_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cv_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0<<3)+(r0<<1) → CU fires (add), not CV
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 1)
@@ -16810,7 +16823,7 @@ fn compiler_main_test_cv_no_fold_add() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cv_no_fold_plain() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16820,7 +16833,7 @@ fn compiler_main_test_cv_no_fold_plain() -> bool with Mut, Div, Panic {
 // Sprint 187 Block CW: OR-XOR mask extraction (T788-T793)
 fn compiler_main_test_cw_or_xor_mask_basic() -> bool with Mut, Div, Panic {
     // (r0|7)^7 → r0 & ~7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -16833,7 +16846,7 @@ fn compiler_main_test_cw_or_xor_mask_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_or_xor_mask_comm() -> bool with Mut, Div, Panic {
     // 7^(r0|7) → r0 & ~7 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -16846,7 +16859,7 @@ fn compiler_main_test_cw_or_xor_mask_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_or_xor_mask_val() -> bool with Mut, Div, Panic {
     // (r0|0xFF)^0xFF → r0 & ~0xFF
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -16859,7 +16872,7 @@ fn compiler_main_test_cw_or_xor_mask_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0|7)^3 → no fold (3 != 7)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16870,7 +16883,7 @@ fn compiler_main_test_cw_no_fold_diff_const() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_no_fold_rr_or() -> bool with Mut, Div, Panic {
     // (r0|r1)^7 → no fold (OR is rr not const-or)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_load_imm(3, 7)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -16880,7 +16893,7 @@ fn compiler_main_test_cw_no_fold_rr_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|7)&7 → no fold by CW (this is CF/Block CF territory, outer is AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -16893,7 +16906,7 @@ fn compiler_main_test_cw_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 188 Block CX: XOR-complement chain to NOT (T794-T799)
 fn compiler_main_test_cx_xor_comp_not_basic() -> bool with Mut, Div, Panic {
     // (r0^5)^~5 → ~r0; ~5 = -6
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^5
     instrs[2 as usize] = ir_load_imm(3, -6)                       // ~5
@@ -16906,7 +16919,7 @@ fn compiler_main_test_cx_xor_comp_not_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_xor_comp_not_comm() -> bool with Mut, Div, Panic {
     // ~5^(r0^5) → ~r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16919,7 +16932,7 @@ fn compiler_main_test_cx_xor_comp_not_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_xor_comp_not_val() -> bool with Mut, Div, Panic {
     // (r0^0xFF)^~0xFF → ~r0; ~0xFF = -256
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -16932,7 +16945,7 @@ fn compiler_main_test_cx_xor_comp_not_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_no_fold_diff_comp() -> bool with Mut, Div, Panic {
     // (r0^5)^3 → no fold (3 is not ~5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16943,7 +16956,7 @@ fn compiler_main_test_cx_no_fold_diff_comp() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_no_fold_rr_xor() -> bool with Mut, Div, Panic {
     // (r0^r1)^~5 → no fold (inner XOR is rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^r1
     instrs[1 as usize] = ir_load_imm(3, -6)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -16953,7 +16966,7 @@ fn compiler_main_test_cx_no_fold_rr_xor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0^5)&~5 → no fold by CX (outer is AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16966,7 +16979,7 @@ fn compiler_main_test_cx_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 189 Block CY: AND complement addition (T800-T805)
 fn compiler_main_test_cy_and_comp_add_basic() -> bool with Mut, Div, Panic {
     // (r0&5)+(r0&~5) → r0; ~5=-6
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16978,7 +16991,7 @@ fn compiler_main_test_cy_and_comp_add_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_and_comp_add_comm() -> bool with Mut, Div, Panic {
     // (r0&~5)+(r0&5) → r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16990,7 +17003,7 @@ fn compiler_main_test_cy_and_comp_add_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_and_comp_add_val() -> bool with Mut, Div, Panic {
     // (r0&0xFF)+(r0&~0xFF) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -17002,7 +17015,7 @@ fn compiler_main_test_cy_and_comp_add_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0&5)+(r1&~5) → no fold (diff base)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -17014,7 +17027,7 @@ fn compiler_main_test_cy_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_no_fold_non_comp() -> bool with Mut, Div, Panic {
     // (r0&5)+(r0&3) → no fold (3 != ~5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -17026,7 +17039,7 @@ fn compiler_main_test_cy_no_fold_non_comp() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0&5)-(r0&~5) → no fold (sub not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -17040,7 +17053,7 @@ fn compiler_main_test_cy_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 190 Block CZ: XOR-AND mask clear (T806-T811)
 fn compiler_main_test_cz_xor_and_clear_basic() -> bool with Mut, Div, Panic {
     // r0 ^ (r0 & 7) → r0 & ~7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 7
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)   // r3 = r0 ^ (r0&7)
@@ -17052,7 +17065,7 @@ fn compiler_main_test_cz_xor_and_clear_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_xor_and_clear_comm() -> bool with Mut, Div, Panic {
     // (r0 & 7) ^ r0 → r0 & ~7 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 0)   // (r0&7) ^ r0
@@ -17064,7 +17077,7 @@ fn compiler_main_test_cz_xor_and_clear_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_xor_and_clear_val() -> bool with Mut, Div, Panic {
     // r0 ^ (r0 & 0xFF) → r0 & ~0xFF
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
@@ -17076,7 +17089,7 @@ fn compiler_main_test_cz_xor_and_clear_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // r0 ^ (r1 & 7) → no fold (r1 != r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 7)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)   // r3 = r1 & 7
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 3)   // r0 ^ (r1&7)
@@ -17086,7 +17099,7 @@ fn compiler_main_test_cz_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_no_fold_rr_and() -> bool with Mut, Div, Panic {
     // r0 ^ (r0 & r1) → no fold (and is rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17095,7 +17108,7 @@ fn compiler_main_test_cz_no_fold_rr_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_no_fold_or() -> bool with Mut, Div, Panic {
     // r0 | (r0 & 7) → no fold by CZ (OR not XOR; handled by Block AO)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
@@ -17107,7 +17120,7 @@ fn compiler_main_test_cz_no_fold_or() -> bool with Mut, Div, Panic {
 // Sprint 191 Block DA: OR-AND XOR identity (T812-T817)
 fn compiler_main_test_da_or_and_xor_basic() -> bool with Mut, Div, Panic {
     // (r0|r1)^(r0&r1) → r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0|r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r3 = r0&r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)   // r4 = (r0|r1)^(r0&r1)
@@ -17120,7 +17133,7 @@ fn compiler_main_test_da_or_and_xor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_or_and_xor_comm() -> bool with Mut, Div, Panic {
     // (r0&r1)^(r0|r1) → r0^r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 2)   // and^or
@@ -17132,7 +17145,7 @@ fn compiler_main_test_da_or_and_xor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_or_and_xor_swapped() -> bool with Mut, Div, Panic {
     // (r1|r0)^(r0&r1) → r1^r0 (operands swapped in OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)    // r1|r0
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r0&r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -17143,7 +17156,7 @@ fn compiler_main_test_da_or_and_xor_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_no_fold_diff_ops() -> bool with Mut, Div, Panic {
     // (r0|r1)^(r0|r1) → 0 via self-xor, not DA; DA requires or+and pair
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)    // also OR
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -17154,7 +17167,7 @@ fn compiler_main_test_da_no_fold_diff_ops() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
     // (r0|r2)^(r0&r1) → no fold (diff operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)    // r0|r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)   // r0&r1
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -17164,7 +17177,7 @@ fn compiler_main_test_da_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)&(r0^r1) → no fold by DA (AND outer not XOR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)   // AND not XOR outer
@@ -17176,7 +17189,7 @@ fn compiler_main_test_da_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 192 Block DB: XOR-AND to OR (T818-T823)
 fn compiler_main_test_db_xor_and_or_basic() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r1) → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r3 = r0&r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)    // r4 = (r0^r1)|(r0&r1)
@@ -17189,7 +17202,7 @@ fn compiler_main_test_db_xor_and_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_xor_and_or_comm() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0^r1) → r0|r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)    // and|xor
@@ -17200,7 +17213,7 @@ fn compiler_main_test_db_xor_and_or_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_xor_and_or_val() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r1) → r0|r1 runtime check
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 12)                       // r0 = 12 (1100)
     instrs[1 as usize] = ir_load_imm(1, 10)                       // r1 = 10 (1010)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
@@ -17212,7 +17225,7 @@ fn compiler_main_test_db_xor_and_or_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_no_fold_diff_base_xor() -> bool with Mut, Div, Panic {
     // (r0^r2)|(r0&r1) → no fold (different rhs in xor vs and)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)   // r3 = r0^r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)   // r4 = r0&r1
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)    // (r0^r2)|(r0&r1)
@@ -17222,7 +17235,7 @@ fn compiler_main_test_db_no_fold_diff_base_xor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_no_fold_rr_or() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0&r1) → no fold by DB (first operand is OR not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -17232,7 +17245,7 @@ fn compiler_main_test_db_no_fold_rr_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_no_fold_xor_outer() -> bool with Mut, Div, Panic {
     // (r0^r1)^(r0&r1) → no fold by DB (outer is XOR not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)   // XOR not OR outer
@@ -17244,7 +17257,7 @@ fn compiler_main_test_db_no_fold_xor_outer() -> bool with Mut, Div, Panic {
 // Sprint 193 Block DC: AND-XOR to OR (T824-T829)
 fn compiler_main_test_dc_and_xor_or_basic() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0^r1) → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0&r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)   // r3 = r0^r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)    // r4 = (r0&r1)|(r0^r1)
@@ -17257,7 +17270,7 @@ fn compiler_main_test_dc_and_xor_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_and_xor_or_comm() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r1) → r0|r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)    // xor|and
@@ -17269,7 +17282,7 @@ fn compiler_main_test_dc_and_xor_or_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_and_xor_or_swapped() -> bool with Mut, Div, Panic {
     // (r1&r0)|(r0^r1) → r1|r0 (and operands swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)   // r1&r0
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)   // r0^r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -17280,7 +17293,7 @@ fn compiler_main_test_dc_and_xor_or_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0&r2)|(r0^r1) → no fold (diff operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)   // r0&r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 1)   // r0^r1
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -17291,7 +17304,7 @@ fn compiler_main_test_dc_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_no_fold_xor_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)^(r0^r1) → no fold by DC (XOR outer not OR; handled by DA)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)   // XOR not OR
@@ -17301,7 +17314,7 @@ fn compiler_main_test_dc_no_fold_xor_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)&(r0^r1) → no fold by DC
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)   // AND outer
@@ -17313,7 +17326,7 @@ fn compiler_main_test_dc_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 194 Block DD: OR-NOT-AND to XOR (T830-T835)
 fn compiler_main_test_dd_or_not_and_xor_basic() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0&r1) → r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0|r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r3 = r0&r1
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)         // r4 = ~r3
@@ -17327,7 +17340,7 @@ fn compiler_main_test_dd_or_not_and_xor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_or_not_and_xor_comm() -> bool with Mut, Div, Panic {
     // ~(r0&r1) & (r0|r1) → r0^r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -17339,7 +17352,7 @@ fn compiler_main_test_dd_or_not_and_xor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_or_not_and_xor_val() -> bool with Mut, Div, Panic {
     // val check: (6|3)&~(6&3) = 7&~2 = 7&(-3) = 5 = 6^3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 6)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
@@ -17352,7 +17365,7 @@ fn compiler_main_test_dd_or_not_and_xor_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
     // (r0|r2) & ~(r0&r1) → no fold (OR uses r2, AND uses r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)    // r3 = r0|r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)   // r4 = r0&r1
     instrs[2 as usize] = ir_unaryop(5, UnaryOp::OpNot, 4)
@@ -17363,7 +17376,7 @@ fn compiler_main_test_dd_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_no_fold_not_not_and() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0|r1) → no fold (inner is NOT of OR, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)         // ~(r0|r1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -17373,7 +17386,7 @@ fn compiler_main_test_dd_no_fold_not_not_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) | ~(r0&r1) → no fold by DD (OR outer not AND outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -17386,7 +17399,7 @@ fn compiler_main_test_dd_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 195 Block DE: XOR self-complement (T836-T841)
 fn compiler_main_test_de_xor_self_comp_basic() -> bool with Mut, Div, Panic {
     // r2 = r0 ^ r1; r3 = ~r2; r4 = r2 ^ r3 → IrLoadImm(-1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -17398,7 +17411,7 @@ fn compiler_main_test_de_xor_self_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_xor_self_comp_comm() -> bool with Mut, Div, Panic {
     // ~r0 ^ r0 → IrLoadImm(-1) (commutative: NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -17409,7 +17422,7 @@ fn compiler_main_test_de_xor_self_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_xor_self_comp_val() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0^r2 → -1; then r4 = r3+1 → const 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_load_imm(4, 1)
@@ -17423,7 +17436,7 @@ fn compiler_main_test_de_xor_self_comp_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_no_fold_diff_regs() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r1^r2 → no fold (r1 != r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17433,7 +17446,7 @@ fn compiler_main_test_de_no_fold_diff_regs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 & r2 → no fold by DE (AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17443,7 +17456,7 @@ fn compiler_main_test_de_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_no_fold_or_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 | r2 → no fold by DE (OR not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17454,7 +17467,7 @@ fn compiler_main_test_de_no_fold_or_op() -> bool with Mut, Div, Panic {
 // Sprint 196 Block DF: OR self-complement (T842-T847)
 fn compiler_main_test_df_or_self_comp_basic() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 | r2 → IrLoadImm(-1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17465,7 +17478,7 @@ fn compiler_main_test_df_or_self_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_or_self_comp_comm() -> bool with Mut, Div, Panic {
     // ~r0 | r0 → IrLoadImm(-1) (commutative: NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -17476,7 +17489,7 @@ fn compiler_main_test_df_or_self_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_or_self_comp_chain() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0|r2 → -1; r4 = r3+1 folds to 0 via const prop
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_load_imm(4, 1)
@@ -17489,7 +17502,7 @@ fn compiler_main_test_df_or_self_comp_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_no_fold_diff_regs() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r1 | r2 → no fold (r1 != r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17499,7 +17512,7 @@ fn compiler_main_test_df_no_fold_diff_regs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_no_fold_xor_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 ^ r2 → no fold by DF (XOR not OR, handled by DE)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17510,7 +17523,7 @@ fn compiler_main_test_df_no_fold_xor_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 & r2 → 0 (handled by Block DG, not DF)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17523,7 +17536,7 @@ fn compiler_main_test_df_no_fold_and_op() -> bool with Mut, Div, Panic {
 // Sprint 197 Block DG: NOT-XOR-operand unwrapping (T848-T853)
 fn compiler_main_test_dg_not_xor_unwrap_basic() -> bool with Mut, Div, Panic {
     // ~(r0^r1)^r1 → ~r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^r1
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)         // r3 = ~r2
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 1)   // r4 = r3^r1
@@ -17535,7 +17548,7 @@ fn compiler_main_test_dg_not_xor_unwrap_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_not_xor_unwrap_lhs() -> bool with Mut, Div, Panic {
     // ~(r0^r1)^r0 → ~r1 (other operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 0)   // r3^r0 → ~r1
@@ -17547,7 +17560,7 @@ fn compiler_main_test_dg_not_xor_unwrap_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_not_xor_unwrap_comm() -> bool with Mut, Div, Panic {
     // r1^~(r0^r1) → ~r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitXor, 3)   // r1^r3
@@ -17558,7 +17571,7 @@ fn compiler_main_test_dg_not_xor_unwrap_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // ~(r0^r1)^r2 → no fold (r2 not in {r0,r1})
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 4, BinaryOp::OpBitXor, 2)
@@ -17568,7 +17581,7 @@ fn compiler_main_test_dg_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_no_fold_not_xor_rr() -> bool with Mut, Div, Panic {
     // ~r1^r1 → -1 (is Block DE, not DG; inner is NOT of scalar not xor-rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -17578,7 +17591,7 @@ fn compiler_main_test_dg_no_fold_not_xor_rr() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // ~(r0^r1)&r1 → no fold by DG (AND outer not XOR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -17590,7 +17603,7 @@ fn compiler_main_test_dg_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 198 Block DH: AND-NOT-OR annihilation (T854-T859)
 fn compiler_main_test_dh_and_not_or_basic() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r0 & r3 → IrLoadImm(0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -17602,7 +17615,7 @@ fn compiler_main_test_dh_and_not_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_and_not_or_rhs() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r1 & r3 → 0 (other operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 3)
@@ -17614,7 +17627,7 @@ fn compiler_main_test_dh_and_not_or_rhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_and_not_or_comm() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r3 & r0 → 0 (NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 0)
@@ -17626,7 +17639,7 @@ fn compiler_main_test_dh_and_not_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r5 & r3 → no fold (r5 not in OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 5, BinaryOp::OpBitAnd, 3)
@@ -17637,7 +17650,7 @@ fn compiler_main_test_dh_no_fold_diff_reg() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_no_fold_or_op() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r0 | r3 → no fold by DH (OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -17648,7 +17661,7 @@ fn compiler_main_test_dh_no_fold_or_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_no_fold_not_and() -> bool with Mut, Div, Panic {
     // r2 = r0&r1; r3 = ~r2; r4 = r0 & r3 → no fold by DH (AND not OR inside NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -17662,7 +17675,7 @@ fn compiler_main_test_dh_no_fold_not_and() -> bool with Mut, Div, Panic {
 // Sprint 199 Block DI: OR-NOT-AND tautology (T860-T865)
 fn compiler_main_test_di_or_not_and_taut_lhs() -> bool with Mut, Div, Panic {
     // r0 | ~(r0&r1) → -1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0&r1
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)         // r3 = ~r2
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)    // r4 = r0|r3
@@ -17673,7 +17686,7 @@ fn compiler_main_test_di_or_not_and_taut_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_or_not_and_taut_rhs() -> bool with Mut, Div, Panic {
     // r1 | ~(r0&r1) → -1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 3)    // r1|r3
@@ -17684,7 +17697,7 @@ fn compiler_main_test_di_or_not_and_taut_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_or_not_and_taut_comm() -> bool with Mut, Div, Panic {
     // ~(r0&r1) | r0 → -1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 0)    // r3|r0
@@ -17695,7 +17708,7 @@ fn compiler_main_test_di_or_not_and_taut_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r2 | ~(r0&r1) → no fold (r2 not in AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpBitOr, 4)
@@ -17705,7 +17718,7 @@ fn compiler_main_test_di_no_fold_diff_reg() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r0 | ~(r0|r1) → no fold by DI (inner is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -17716,7 +17729,7 @@ fn compiler_main_test_di_no_fold_and_op() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r0 & ~(r0&r1) → no fold by DI (AND outer not OR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)   // AND not OR outer
@@ -17730,7 +17743,7 @@ fn compiler_main_test_di_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 200 Block DJ: NOT-sub-NOT to reverse-sub (T866-T871)
 fn compiler_main_test_dj_not_sub_not_basic() -> bool with Mut, Div, Panic {
     // ~r0 - ~r1 → r1 - r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)         // r2 = ~r0
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)         // r3 = ~r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)       // r4 = r2-r3
@@ -17743,7 +17756,7 @@ fn compiler_main_test_dj_not_sub_not_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_not_sub_not_val() -> bool with Mut, Div, Panic {
     // ~5 - ~3 = 3 - 5 = -2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
@@ -17757,7 +17770,7 @@ fn compiler_main_test_dj_not_sub_not_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_not_sub_not_same() -> bool with Mut, Div, Panic {
     // ~r0 - ~r0 → 0 (via this fold: r0 - r0 → 0 from Block A)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 2)       // ~r0 - ~r0 (same reg)
     let func = cp_make_test_func(instrs, 2)
@@ -17768,7 +17781,7 @@ fn compiler_main_test_dj_not_sub_not_same() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_no_fold_only_one_not() -> bool with Mut, Div, Panic {
     // ~r0 - r1 → no fold by DJ (s2 not NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -17778,7 +17791,7 @@ fn compiler_main_test_dj_no_fold_only_one_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_no_fold_not_add() -> bool with Mut, Div, Panic {
     // ~r0 + ~r1 → -2 not via DJ (ADD not SUB; Block BF may fold ~r0+r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)    // OR not SUB
@@ -17788,7 +17801,7 @@ fn compiler_main_test_dj_no_fold_not_add() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_no_fold_neg_not() -> bool with Mut, Div, Panic {
     // neg(r0) - ~r1 → no fold by DJ (s1 is neg, not NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17801,7 +17814,7 @@ fn compiler_main_test_dj_no_fold_neg_not() -> bool with Mut, Div, Panic {
 // Sprint 201 Block DK: OR-AND sum factoring (T872-T877)
 fn compiler_main_test_dk_or_and_sum_basic() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = r0&r1; r4 = r2+r3 → r4 = r0+r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -17815,7 +17828,7 @@ fn compiler_main_test_dk_or_and_sum_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_or_and_sum_comm() -> bool with Mut, Div, Panic {
     // (x&y)+(x|y) → x+y (AND on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 2)
@@ -17827,7 +17840,7 @@ fn compiler_main_test_dk_or_and_sum_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_or_and_sum_swapped() -> bool with Mut, Div, Panic {
     // (y|x) + (x&y) → same result (operand order in OR/AND swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -17839,7 +17852,7 @@ fn compiler_main_test_dk_or_and_sum_swapped() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0|r1) + (r0&r2) → no fold (different second operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -17851,7 +17864,7 @@ fn compiler_main_test_dk_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_no_fold_sub_op() -> bool with Mut, Div, Panic {
     // (r0|r1) - (r0&r1) → no fold by DK (SUB not ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17862,7 +17875,7 @@ fn compiler_main_test_dk_no_fold_sub_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_no_fold_or_or() -> bool with Mut, Div, Panic {
     // (r0|r1) + (r0|r1) → no fold by DK (not OR+AND pattern)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17874,7 +17887,7 @@ fn compiler_main_test_dk_no_fold_or_or() -> bool with Mut, Div, Panic {
 // Sprint 202 Block DL: Transitive subtraction (T878-T883)
 fn compiler_main_test_dl_trans_sub_basic() -> bool with Mut, Div, Panic {
     // r2 = r0-r1; r3 = r1-r4; r5 = r2+r3 → r0-r4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17888,7 +17901,7 @@ fn compiler_main_test_dl_trans_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_trans_sub_comm() -> bool with Mut, Div, Panic {
     // (y-z) + (x-y) → x-z  commutative variant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 4)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17902,7 +17915,7 @@ fn compiler_main_test_dl_trans_sub_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_trans_sub_self() -> bool with Mut, Div, Panic {
     // (x-y) + (y-x) → 0 = x-x  (x==z case)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17915,7 +17928,7 @@ fn compiler_main_test_dl_trans_sub_self() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_no_fold_diff_middle() -> bool with Mut, Div, Panic {
     // (r0-r1) + (r2-r3) → no fold (no shared middle term)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17927,7 +17940,7 @@ fn compiler_main_test_dl_no_fold_diff_middle() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (r0-r1) - (r1-r4) → no fold by DL (SUB not ADD outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -17939,7 +17952,7 @@ fn compiler_main_test_dl_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // (r0+r1) + (r1-r4) → no fold (first is ADD not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17952,7 +17965,7 @@ fn compiler_main_test_dl_no_fold_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 203 Block DM: OR-AND difference to XOR (T884-T889)
 fn compiler_main_test_dm_or_and_diff_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1; r3=r0&r1; r4=r2-r3 → r4=r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17965,7 +17978,7 @@ fn compiler_main_test_dm_or_and_diff_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_or_and_diff_swapped() -> bool with Mut, Div, Panic {
     // (r1|r0)-(r0&r1) → same (OR operands swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17975,7 +17988,7 @@ fn compiler_main_test_dm_or_and_diff_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_or_and_diff_val() -> bool with Mut, Div, Panic {
     // structural: result is XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -17986,7 +17999,7 @@ fn compiler_main_test_dm_or_and_diff_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_no_fold_diff_ops() -> bool with Mut, Div, Panic {
     // (r0|r1)-(r0|r2) no fold (second is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17996,7 +18009,7 @@ fn compiler_main_test_dm_no_fold_diff_ops() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0|r1)-(r0&r2) no fold (different operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -18006,7 +18019,7 @@ fn compiler_main_test_dm_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)+(r0&r1) no fold by DM (ADD outer, not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -18019,7 +18032,7 @@ fn compiler_main_test_dm_no_fold_add_outer() -> bool with Mut, Div, Panic {
 // Sprint 204 Block DN: Sub-sub identity (T890-T895)
 fn compiler_main_test_dn_sub_sub_basic() -> bool with Mut, Div, Panic {
     // r2 = r0-r1; r3 = r0-r4; r5 = r2-r3 → r4-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18033,7 +18046,7 @@ fn compiler_main_test_dn_sub_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_sub_sub_self() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r1) → z=y, so z-y=0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18045,7 +18058,7 @@ fn compiler_main_test_dn_sub_sub_self() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_sub_sub_reverse() -> bool with Mut, Div, Panic {
     // (r0-r4)-(r0-r1) → r1-r4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 4)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18059,7 +18072,7 @@ fn compiler_main_test_dn_sub_sub_reverse() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r2-r3) → no fold (different x in each sub)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 5, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(6, 2, BinaryOp::OpSub, 3)
@@ -18070,7 +18083,7 @@ fn compiler_main_test_dn_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r0-r4) → DL handles, DN doesn't
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -18083,7 +18096,7 @@ fn compiler_main_test_dn_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0-r4) → no fold by DN (first inner is ADD not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18095,7 +18108,7 @@ fn compiler_main_test_dn_no_fold_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 205 Block DO: Add-sub common-addend cancel (T896-T901)
 fn compiler_main_test_do_add_sub_cancel_basic() -> bool with Mut, Div, Panic {
     // r2=r0+r1; r3=r1+r4; r5=r2-r3 → r0-r4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18109,7 +18122,7 @@ fn compiler_main_test_do_add_sub_cancel_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_add_sub_cancel_shared_left() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0+r4) → r1-r4  (shared left operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18123,7 +18136,7 @@ fn compiler_main_test_do_add_sub_cancel_shared_left() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_do_add_sub_cancel_self() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0+r1) → 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18135,7 +18148,7 @@ fn compiler_main_test_do_add_sub_cancel_self() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_no_fold_no_common() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r2+r3) → no fold (no shared term)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 5, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(6, 2, BinaryOp::OpSub, 3)
@@ -18146,7 +18159,7 @@ fn compiler_main_test_do_no_fold_no_common() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0+r1)+(r1+r4) → no fold by DO (ADD not SUB outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -18157,7 +18170,7 @@ fn compiler_main_test_do_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_no_fold_not_add() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r1+r4) → no fold by DO (s1 is SUB not ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18169,7 +18182,7 @@ fn compiler_main_test_do_no_fold_not_add() -> bool with Mut, Div, Panic {
 // Sprint 206 Block DP: AND-OR XOR identity (T902-T907)
 fn compiler_main_test_dp_and_or_xor_basic() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0|r1) → r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -18183,7 +18196,7 @@ fn compiler_main_test_dp_and_or_xor_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_or_and_xor_comm() -> bool with Mut, Div, Panic {
     // (r0|r1) ^ (r0&r1) → r0^r1 (commutative outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -18195,7 +18208,7 @@ fn compiler_main_test_dp_or_and_xor_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_and_or_xor_swapped() -> bool with Mut, Div, Panic {
     // (r1&r0) ^ (r0|r1) → r1^r0 (inner operand order swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -18207,7 +18220,7 @@ fn compiler_main_test_dp_and_or_xor_swapped() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0|r2) → no fold (different operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -18218,7 +18231,7 @@ fn compiler_main_test_dp_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_no_fold_and_and() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0&r1) → 0 (both AND, not AND^OR — Block A x^x fires)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18229,7 +18242,7 @@ fn compiler_main_test_dp_no_fold_and_and() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_no_fold_sub_op() -> bool with Mut, Div, Panic {
     // (r0&r1) - (r0|r1) → no fold by DP (SUB not XOR; DM may fire)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -18241,7 +18254,7 @@ fn compiler_main_test_dp_no_fold_sub_op() -> bool with Mut, Div, Panic {
 // Sprint 207 Block DQ: AND-XNOR to AND (T908-T913)
 fn compiler_main_test_dq_and_xnor_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1; r3=~r2; r4=r0&r3 → r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18254,7 +18267,7 @@ fn compiler_main_test_dq_and_xnor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_and_xnor_rhs() -> bool with Mut, Div, Panic {
     // r0&~(r0^r1) where r0 matches XOR RHS (swap)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18265,7 +18278,7 @@ fn compiler_main_test_dq_and_xnor_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_and_xnor_comm() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & r0 → r0&r1 (XNOR on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 0)
@@ -18276,7 +18289,7 @@ fn compiler_main_test_dq_and_xnor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r2&~(r0^r1) where r2 not in XOR → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 4, BinaryOp::OpBitAnd, 3)
@@ -18286,7 +18299,7 @@ fn compiler_main_test_dq_no_fold_diff_reg() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r0|~(r0^r1) no fold by DQ (OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18296,7 +18309,7 @@ fn compiler_main_test_dq_no_fold_or_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_no_fold_not_xor() -> bool with Mut, Div, Panic {
     // r0&~r1 — r1 is plain NOT (not NOT-of-XOR) → no fold by DQ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18307,7 +18320,7 @@ fn compiler_main_test_dq_no_fold_not_xor() -> bool with Mut, Div, Panic {
 // Sprint 208 Block DR: De Morgan NOT-AND (T914-T919)
 fn compiler_main_test_dr_not_and_demorgan() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=~r1; r4=r2&r3; r5=~r4 → r5=r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18321,7 +18334,7 @@ fn compiler_main_test_dr_not_and_demorgan() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_not_and_swapped() -> bool with Mut, Div, Panic {
     // (~r1 & ~r0) negated → r1|r0 (AND operands swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 2)
@@ -18332,7 +18345,7 @@ fn compiler_main_test_dr_not_and_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_not_and_val() -> bool with Mut, Div, Panic {
     // structural: result is IrBinOp (OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18343,7 +18356,7 @@ fn compiler_main_test_dr_not_and_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_no_fold_one_not() -> bool with Mut, Div, Panic {
     // ~(r0 & ~r1) — only one NOT in AND → no DR fold (not both negated)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -18354,7 +18367,7 @@ fn compiler_main_test_dr_no_fold_one_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // ~(~r0 | ~r1) no fold by DR (OR inner, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18367,7 +18380,7 @@ fn compiler_main_test_dr_no_fold_or_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_no_fold_not_not_and() -> bool with Mut, Div, Panic {
     // ~(r0&r1) where r0,r1 are not NOTs → no DR fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18380,7 +18393,7 @@ fn compiler_main_test_dr_no_fold_not_not_and() -> bool with Mut, Div, Panic {
 // Sprint 209 Block DS: De Morgan NOT-OR (T920-T925)
 fn compiler_main_test_ds_not_or_demorgan() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=~r1; r4=r2|r3; r5=~r4 → r5=r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18394,7 +18407,7 @@ fn compiler_main_test_ds_not_or_demorgan() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_not_or_swapped() -> bool with Mut, Div, Panic {
     // (~r1 | ~r0) negated → r1&r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18405,7 +18418,7 @@ fn compiler_main_test_ds_not_or_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_not_or_val() -> bool with Mut, Div, Panic {
     // result is AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18417,7 +18430,7 @@ fn compiler_main_test_ds_not_or_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_no_fold_one_not() -> bool with Mut, Div, Panic {
     // ~(r0 | ~r1) — only one NOT in OR → no DS fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -18428,7 +18441,7 @@ fn compiler_main_test_ds_no_fold_one_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // ~(~r0 & ~r1) no fold by DS (AND inner, not OR) — DR fires instead
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18441,7 +18454,7 @@ fn compiler_main_test_ds_no_fold_and_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_no_fold_plain_or() -> bool with Mut, Div, Panic {
     // ~(r0|r1) no fold by DS (r0,r1 not NOTs)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18453,7 +18466,7 @@ fn compiler_main_test_ds_no_fold_plain_or() -> bool with Mut, Div, Panic {
 // Sprint 210 Block DT: OR-AND complement absorption (T926-T931)
 fn compiler_main_test_dt_or_and_comp_basic() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=r1&r2; r4=r0|r3 → r4=r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18466,7 +18479,7 @@ fn compiler_main_test_dt_or_and_comp_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_or_and_comp_comm_and() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=r2&r1 (AND flipped) → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18477,7 +18490,7 @@ fn compiler_main_test_dt_or_and_comp_comm_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_or_and_comp_comm_or() -> bool with Mut, Div, Panic {
     // (y&~x)|x → x|y (OR outer commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 0)
@@ -18488,7 +18501,7 @@ fn compiler_main_test_dt_or_and_comp_comm_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r0|(r1&~r2) no fold (r2 not r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitOr, 4)
@@ -18498,7 +18511,7 @@ fn compiler_main_test_dt_no_fold_diff_var() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_no_fold_no_not() -> bool with Mut, Div, Panic {
     // r0|(r1&r2) no fold (r2 not NOT of r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
     let func = cp_make_test_func(instrs, 2)
@@ -18507,7 +18520,7 @@ fn compiler_main_test_dt_no_fold_no_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r0&(r1&~r0) no fold by DT (AND outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18520,7 +18533,7 @@ fn compiler_main_test_dt_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 211 Block DU: XOR-AND to OR (T932-T937)
 fn compiler_main_test_du_xor_and_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1; r3=r0&r1; r4=r2|r3 → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18533,7 +18546,7 @@ fn compiler_main_test_du_xor_and_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
     // r2=r1^r0; r3=r0&r1 (XOR operands swapped) → r1|r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18543,7 +18556,7 @@ fn compiler_main_test_du_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0^r1) → r0|r1 (AND on left, XOR on right)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18555,7 +18568,7 @@ fn compiler_main_test_du_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r2) → no fold (AND uses r2 not r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -18565,7 +18578,7 @@ fn compiler_main_test_du_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_no_fold_xor_and_and() -> bool with Mut, Div, Panic {
     // (r0^r1)&(r0&r1) no fold by DU (AND outer, not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18575,7 +18588,7 @@ fn compiler_main_test_du_no_fold_xor_and_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_no_fold_xor_or() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0|r1) no fold by DU (inner is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18590,7 +18603,7 @@ fn compiler_main_test_du_no_fold_xor_or() -> bool with Mut, Div, Panic {
 // Sprint 212 Block DV: XOR-AND-OR simplify (T938-T943)
 fn compiler_main_test_dv_xor_and_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1; r3=r0|r1; r4=r2&r3 → IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18601,7 +18614,7 @@ fn compiler_main_test_dv_xor_and_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) & (r0^r1) → IrCopy(xor_reg) (commutative AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 2)
@@ -18612,7 +18625,7 @@ fn compiler_main_test_dv_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
     // r2=r1^r0 (swapped); r3=r0|r1 → IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18622,7 +18635,7 @@ fn compiler_main_test_dv_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0|r2) no fold (OR uses r2 not r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -18632,7 +18645,7 @@ fn compiler_main_test_dv_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_no_fold_and_and() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0&r1) no fold by DV (inner AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18643,7 +18656,7 @@ fn compiler_main_test_dv_no_fold_and_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0^r1) | (r0|r1) no fold by DV (outer OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18656,7 +18669,7 @@ fn compiler_main_test_dv_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 213 Block DW: AND complement annihilation (T944-T949)
 fn compiler_main_test_dw_and_comp_lhs() -> bool with Mut, Div, Panic {
     // r2=r0&r1; r3=~r0; r4=r2&r3 → 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18667,7 +18680,7 @@ fn compiler_main_test_dw_and_comp_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_and_comp_rhs() -> bool with Mut, Div, Panic {
     // r2=r0&r1; r3=~r1; r4=r2&r3 → 0 (NOT of rhs of AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18678,7 +18691,7 @@ fn compiler_main_test_dw_and_comp_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_and_comp_comm() -> bool with Mut, Div, Panic {
     // ~r0 & (r0&r1) → 0 (NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 2)
@@ -18689,7 +18702,7 @@ fn compiler_main_test_dw_and_comp_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0&r1) & ~r2 no fold (r2 not in AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18700,7 +18713,7 @@ fn compiler_main_test_dw_no_fold_diff_var() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0&r1) & r0 no fold (no NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -18709,7 +18722,7 @@ fn compiler_main_test_dw_no_fold_no_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0&r1) | ~r0 no fold by DW (OR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18721,7 +18734,7 @@ fn compiler_main_test_dw_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 214 Block DX: OR complement saturation (T950-T955)
 fn compiler_main_test_dx_or_comp_sat_lhs() -> bool with Mut, Div, Panic {
     // r2=r0|r1; r3=~r0; r4=r2|r3 → -1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18732,7 +18745,7 @@ fn compiler_main_test_dx_or_comp_sat_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_or_comp_sat_rhs() -> bool with Mut, Div, Panic {
     // r2=r0|r1; r3=~r1; r4=r2|r3 → -1 (NOT of rhs)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18743,7 +18756,7 @@ fn compiler_main_test_dx_or_comp_sat_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_or_comp_sat_comm() -> bool with Mut, Div, Panic {
     // ~r0 | (r0|r1) → -1 (NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18754,7 +18767,7 @@ fn compiler_main_test_dx_or_comp_sat_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1) | ~r2 no fold (r2 not in OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18765,7 +18778,7 @@ fn compiler_main_test_dx_no_fold_diff_var() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1) | r0 no fold (no NOT) — absorbed by Block AO/AP
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -18774,7 +18787,7 @@ fn compiler_main_test_dx_no_fold_no_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~r0 no fold by DX (AND outer — Block DT fires instead)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18787,7 +18800,7 @@ fn compiler_main_test_dx_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 215 Block DY: AND-OR complement absorption (T956-T961)
 fn compiler_main_test_dy_and_or_comp_basic() -> bool with Mut, Div, Panic {
     // r2 = r1|~r0; r3 = r0&r2 → r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)        // r2 = ~r0
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)    // r3 = r1|~r0
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)   // r4 = r0&r3
@@ -18801,7 +18814,7 @@ fn compiler_main_test_dy_and_or_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_and_or_comp_comm() -> bool with Mut, Div, Panic {
     // (r1|~r0) & r0 → r0&r1 (commutative outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 0)
@@ -18813,7 +18826,7 @@ fn compiler_main_test_dy_and_or_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_and_or_comp_not_left() -> bool with Mut, Div, Panic {
     // r0 & (~r0|r1) → r0&r1 (~x on left of OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)    // ~r0|r1
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18825,7 +18838,7 @@ fn compiler_main_test_dy_and_or_comp_not_left() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r0 & (r1|~r2) → no fold (~r2 != ~r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitAnd, 4)
@@ -18836,7 +18849,7 @@ fn compiler_main_test_dy_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_no_fold_no_not() -> bool with Mut, Div, Panic {
     // r0 & (r1|r2) → no fold (no NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
     let func = cp_make_test_func(instrs, 2)
@@ -18846,7 +18859,7 @@ fn compiler_main_test_dy_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r0 | (r1|~r0) → DT fires, not DY (OR not AND outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18858,7 +18871,7 @@ fn compiler_main_test_dy_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 241 Block EY: OR-XOR subsumption — (x|y)|(x^y) → x|y (T1112-T1117)
 fn compiler_main_test_ey_or_xor_subsume_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2|r3 → r4 becomes IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18870,7 +18883,7 @@ fn compiler_main_test_ey_or_xor_subsume_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_or_xor_subsume_comm() -> bool with Mut, Div, Panic {
     // (x^y)|(x|y) → x|y: commutative outer OR (s1=xor, s2=or)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18882,7 +18895,7 @@ fn compiler_main_test_ey_or_xor_subsume_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_or_xor_subsume_inner_comm() -> bool with Mut, Div, Panic {
     // (x|y)|(y^x) → x|y: inner XOR operands commuted
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18894,7 +18907,7 @@ fn compiler_main_test_ey_or_xor_subsume_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ey_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0^r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -18906,7 +18919,7 @@ fn compiler_main_test_ey_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (x|y)|(x&y): inner AND not XOR → Block EF fires (IrCopy(s1)), not EY
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18919,7 +18932,7 @@ fn compiler_main_test_ey_no_fold_and_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (x|y)&(x^y): outer AND not OR → no EY fold (Block DD may fire →x^y)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18937,7 +18950,7 @@ fn compiler_main_test_ey_no_fold_and_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ge_standard_passthrough() -> bool with Mut, Div, Panic {
     // Guard: IR_STRATEGY_STANDARD → epistemic pass returns function unchanged
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_return(0)
     let func = cp_make_test_func(instrs, 2)
@@ -18948,7 +18961,7 @@ fn compiler_main_test_ge_standard_passthrough() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ge_precision_no_crash() -> bool with Mut, Div, Panic {
     // IR_STRATEGY_PRECISION_PRESERVING + canonical Knowledge struct source: pass activates
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 42.0)
     instrs[1 as usize] = ir_load_float(1, 0.25)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -18967,7 +18980,7 @@ fn compiler_main_test_ge_precision_no_crash() -> bool with Mut, Div, Panic {
 fn compiler_main_test_ge_count_guard() -> bool with Mut, Div, Panic {
     // Large non-epistemic bodies still pass through unchanged under the
     // precision-preserving strategy.
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     var i: i64 = 0
     while i < 17 {
         instrs[i as usize] = ir_load_imm(i, i)
@@ -18981,7 +18994,7 @@ fn compiler_main_test_ge_count_guard() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ge_binop_no_crash() -> bool with Mut, Div, Panic {
     // PRECISION_PRESERVING + value extracted from Knowledge struct: binop is processed
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.003)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19020,7 +19033,7 @@ fn compiler_main_test_ge_pythagorean_integration() -> bool with Mut, Div, Panic 
 }
 
 fn compiler_main_test_ge_observation_flow_return_value() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.5)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19039,7 +19052,7 @@ fn compiler_main_test_ge_observation_flow_return_value() -> bool with Mut, Div, 
 }
 
 fn compiler_main_test_ge_observation_flow_unobserved_temp() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.5)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19059,7 +19072,7 @@ fn compiler_main_test_ge_observation_flow_unobserved_temp() -> bool with Mut, Di
 }
 
 fn compiler_main_test_ge_observation_flow_branch() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.5)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19081,7 +19094,7 @@ fn compiler_main_test_ge_observation_flow_branch() -> bool with Mut, Div, Panic 
 }
 
 fn compiler_main_test_ge_observed_reassoc_chain() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 1.0)
     instrs[1 as usize] = ir_load_float(1, 0.000000003)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19133,7 +19146,7 @@ fn compiler_main_test_ge_observed_reassoc_chain() -> bool with Mut, Div, Panic {
 // Sprint 246 Block FD: XOR decomposition fold — (~x&y)^(x&~y) → x^y (T1142-T1147)
 fn compiler_main_test_fd_xor_decomp_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=~r1, r5=r0&r4, r6=r3^r5 → r6 becomes IrBinOp(r0,XOR,r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19149,7 +19162,7 @@ fn compiler_main_test_fd_xor_decomp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_xor_decomp_comm() -> bool with Mut, Div, Panic {
     // r2=~r1, r3=r0&r2, r4=~r0, r5=r4&r1, r6=r3^r5 (commuted: (x&~y)^(~x&y)) → x^y
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 0)
@@ -19163,7 +19176,7 @@ fn compiler_main_test_fd_xor_decomp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_xor_decomp_inner_comm() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r1&r2 (inner: y&~x), r4=~r1, r5=r0&r4, r6=r3^r5 → x^y
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19177,7 +19190,7 @@ fn compiler_main_test_fd_xor_decomp_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=~r2, r5=r0&r4 (s2 AND uses r2 not ~r2) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 2)
@@ -19193,7 +19206,7 @@ fn compiler_main_test_fd_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2|r1 (OR not AND), r4=~r1, r5=r0&r4 → no FD fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19209,7 +19222,7 @@ fn compiler_main_test_fd_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=~r1, r5=r0&r4, r6=r3&r5 (AND outer not XOR) → no FD fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19224,7 +19237,7 @@ fn compiler_main_test_fd_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 245 Block FC: NOT-XOR-NOT recovery — (~x^y)^~y → x (T1136-T1141)
 fn compiler_main_test_fc_not_xor_not_recovery_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r1, r5=r3^r4 → r5 becomes IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19237,7 +19250,7 @@ fn compiler_main_test_fc_not_xor_not_recovery_basic() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_fc_not_xor_not_recovery_inner_comm() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r1^r2 (inner commuted: y^~x), r4=~r1, r5=r3^r4 → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19250,7 +19263,7 @@ fn compiler_main_test_fc_not_xor_not_recovery_inner_comm() -> bool with Mut, Div
 
 fn compiler_main_test_fc_not_xor_not_recovery_outer_comm() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r1, r5=r4^r3 (outer commuted: ~y^(~x^y)) → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19263,7 +19276,7 @@ fn compiler_main_test_fc_not_xor_not_recovery_outer_comm() -> bool with Mut, Div
 
 fn compiler_main_test_fc_no_fold_diff_not() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r2 (NOT of ~x not NOT of y) → no FC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 2)
@@ -19276,7 +19289,7 @@ fn compiler_main_test_fc_no_fold_diff_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fc_no_fold_no_not() -> bool with Mut, Div, Panic {
     // r2=r0^r1 (no NOT), r3=r1, r4=r2^r3 (no ~y) → no FC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -19286,7 +19299,7 @@ fn compiler_main_test_fc_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fc_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r1, r5=r3&r4 (AND outer not XOR) → no FC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19300,7 +19313,7 @@ fn compiler_main_test_fc_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 244 Block FB: AND-XOR AND annihilation — (x&y)&(x^y) → 0 (T1130-T1135)
 fn compiler_main_test_fb_and_xor_and_zero_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2&r3 → r4 becomes IrLoadImm(0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19312,7 +19325,7 @@ fn compiler_main_test_fb_and_xor_and_zero_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_and_xor_and_zero_comm() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0&r1, r4=r2&r3 → r4 becomes IrLoadImm(0) commutative outer AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19324,7 +19337,7 @@ fn compiler_main_test_fb_and_xor_and_zero_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_and_xor_and_zero_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r1^r0 (inner commuted XOR), r4=r2&r3 → IrLoadImm(0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19336,7 +19349,7 @@ fn compiler_main_test_fb_and_xor_and_zero_inner_comm() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_fb_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r2 (diff var) → no FB fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19348,7 +19361,7 @@ fn compiler_main_test_fb_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // r2=r0|r1 (OR not AND), r3=r0^r1, r4=r2&r3 → FA fires → IrCopy not zero
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19361,7 +19374,7 @@ fn compiler_main_test_fb_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2|r3 → EZ fires → OR result; not FB
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19375,7 +19388,7 @@ fn compiler_main_test_fb_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 243 Block FA: OR-XOR AND subsumption — (x|y)&(x^y) → x^y (T1124-T1129)
 fn compiler_main_test_fa_or_xor_and_sub_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2&r3 → r4 becomes IrCopy(r3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19387,7 +19400,7 @@ fn compiler_main_test_fa_or_xor_and_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_or_xor_and_sub_comm() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0|r1, r4=r2&r3 → r4 becomes IrCopy(r2) — commutative AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19399,7 +19412,7 @@ fn compiler_main_test_fa_or_xor_and_sub_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_or_xor_and_sub_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r1^r0 (inner commuted XOR), r4=r2&r3 → IrCopy(r3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19411,7 +19424,7 @@ fn compiler_main_test_fa_or_xor_and_sub_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_fa_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r2 (diff var) → no FA fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19423,7 +19436,7 @@ fn compiler_main_test_fa_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2|r3 — outer OR not AND → EY/EZ may fire
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19435,7 +19448,7 @@ fn compiler_main_test_fa_no_fold_or_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2&r3 → outer AND but s1 is AND not OR → no FA fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19449,7 +19462,7 @@ fn compiler_main_test_fa_no_fold_and_inner() -> bool with Mut, Div, Panic {
 // Sprint 242 Block EZ: AND-XOR to OR — (x&y)|(x^y) → x|y (T1118-T1123)
 fn compiler_main_test_ez_and_xor_to_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2|r3 → r4 becomes IrBinOp(r0,OpBitOr,r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19463,7 +19476,7 @@ fn compiler_main_test_ez_and_xor_to_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_and_xor_to_or_comm() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0&r1, r4=r2|r3 → r4 becomes IrBinOp(r0,OpBitOr,r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19477,7 +19490,7 @@ fn compiler_main_test_ez_and_xor_to_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_and_xor_to_or_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r1^r0 (inner commuted), r4=r2|r3 → folds to r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19489,7 +19502,7 @@ fn compiler_main_test_ez_and_xor_to_or_inner_comm() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_ez_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r2 (different second var) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19503,7 +19516,7 @@ fn compiler_main_test_ez_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // r2=r0|r1 (OR not AND), r3=r0^r1, r4=r2|r3 → Block EY fires (OR-XOR subsume) not EZ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19515,7 +19528,7 @@ fn compiler_main_test_ez_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2&r3 (AND outer not OR) → no EZ fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19528,7 +19541,7 @@ fn compiler_main_test_ez_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 240 Block EX: OR-complement-AND XOR to copy — (x|y)^(~x&y) → x (T1106-T1111)
 fn compiler_main_test_ex_or_comp_and_xor_copy_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=~r0, r4=r3&r1, r5=r2^r4 → r5 becomes IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19541,7 +19554,7 @@ fn compiler_main_test_ex_or_comp_and_xor_copy_basic() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_ex_or_comp_and_xor_copy_rhs_x() -> bool with Mut, Div, Panic {
     // (y|x)^(~x&y) → x: x is rhs of OR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19554,7 +19567,7 @@ fn compiler_main_test_ex_or_comp_and_xor_copy_rhs_x() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_ex_or_comp_and_xor_copy_comm_xor() -> bool with Mut, Div, Panic {
     // (~x&y)^(x|y) → x: commutative outer XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19567,7 +19580,7 @@ fn compiler_main_test_ex_or_comp_and_xor_copy_comm_xor() -> bool with Mut, Div, 
 
 fn compiler_main_test_ex_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1)^(~r0&r2): y differs → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(5, 4, BinaryOp::OpBitAnd, 2)
@@ -19580,7 +19593,7 @@ fn compiler_main_test_ex_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ex_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1)^(r2&r1): AND has no NOT → no EX fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -19592,7 +19605,7 @@ fn compiler_main_test_ex_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ex_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)&(~r0&r1): outer AND not XOR → no EX fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19606,7 +19619,7 @@ fn compiler_main_test_ex_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 239 Block EW: AND-complement XOR to copy — (x&y)^(~x&y) → y (T1100-T1105)
 fn compiler_main_test_ew_and_comp_xor_copy_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=~r0, r4=r3&r1, r5=r2^r4 → r5 becomes IrCopy(r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19619,7 +19632,7 @@ fn compiler_main_test_ew_and_comp_xor_copy_basic() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_ew_and_comp_xor_copy_comm() -> bool with Mut, Div, Panic {
     // (~x&y)^(x&y) → y (commutative outer XOR: s1=~x&y, s2=x&y)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19632,7 +19645,7 @@ fn compiler_main_test_ew_and_comp_xor_copy_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ew_and_comp_xor_copy_lhs_shared() -> bool with Mut, Div, Panic {
     // (y&x)^(y&~x) → y (same lhs y, rhs x vs ~x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 3)
@@ -19645,7 +19658,7 @@ fn compiler_main_test_ew_and_comp_xor_copy_lhs_shared() -> bool with Mut, Div, P
 
 fn compiler_main_test_ew_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (r0&r1)^(~r0&r2): different rhs (y1≠y2) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(5, 4, BinaryOp::OpBitAnd, 2)
@@ -19658,7 +19671,7 @@ fn compiler_main_test_ew_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ew_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0&r1)^(r2&r1): no NOT involved → no EW fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -19670,7 +19683,7 @@ fn compiler_main_test_ew_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ew_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)|(~r0&r1): outer is OR not XOR → Block EL fires (→r1), not EW
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19685,7 +19698,7 @@ fn compiler_main_test_ew_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 238 Block EV: Cross-sub add collapse — (x-y)+(z-x) → z-y (T1094-T1099)
 fn compiler_main_test_ev_cross_sub_add_basic() -> bool with Mut, Div, Panic {
     // r3=r0-r1, r4=r2-r0, r5=r3+r4 → r5 becomes r2-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19699,7 +19712,7 @@ fn compiler_main_test_ev_cross_sub_add_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_cross_sub_add_comm() -> bool with Mut, Div, Panic {
     // (z-x)+(x-y) → z-y (commutative outer ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19713,7 +19726,7 @@ fn compiler_main_test_ev_cross_sub_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_cross_sub_add_self_cancel() -> bool with Mut, Div, Panic {
     // (x-y)+(y-x) = 0 → via Block A (x-x→0) after EV fires: z=y,y=y → y-y→0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19726,7 +19739,7 @@ fn compiler_main_test_ev_cross_sub_add_self_cancel() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ev_no_fold_diff_x() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r2-r3): no shared x → no EV fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
     instrs[2 as usize] = ir_binop(6, 4, BinaryOp::OpAdd, 5)
@@ -19738,7 +19751,7 @@ fn compiler_main_test_ev_no_fold_diff_x() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (x-y)-(z-x): outer SUB not ADD → no EV fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -19751,7 +19764,7 @@ fn compiler_main_test_ev_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
     // (x-y)+(x+z): s2 is ADD not SUB → no EV fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19764,7 +19777,7 @@ fn compiler_main_test_ev_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 237 Block EU: Add-OR diff to AND — (x+y)-(x|y) → x&y (T1088-T1093)
 fn compiler_main_test_eu_add_or_sub_and_basic() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0|r1, r4=r2-r3 → r4 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19778,7 +19791,7 @@ fn compiler_main_test_eu_add_or_sub_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eu_add_or_sub_and_inner_comm_add() -> bool with Mut, Div, Panic {
     // (y+x)-(x|y) → x&y (inner ADD commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19790,7 +19803,7 @@ fn compiler_main_test_eu_add_or_sub_and_inner_comm_add() -> bool with Mut, Div, 
 
 fn compiler_main_test_eu_add_or_sub_and_inner_comm_or() -> bool with Mut, Div, Panic {
     // (x+y)-(y|x) → x&y (inner OR commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19802,7 +19815,7 @@ fn compiler_main_test_eu_add_or_sub_and_inner_comm_or() -> bool with Mut, Div, P
 
 fn compiler_main_test_eu_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -19814,7 +19827,7 @@ fn compiler_main_test_eu_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eu_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (x+y)+(x|y): outer ADD not SUB → no EU fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19826,7 +19839,7 @@ fn compiler_main_test_eu_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eu_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (x+y)-(x&y): inner is AND not OR → Block DK covers (x|y)+(x&y)→x+y, not this
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19839,7 +19852,7 @@ fn compiler_main_test_eu_no_fold_and_inner() -> bool with Mut, Div, Panic {
 // Sprint 236 Block ET: OR-XOR diff to AND — (x|y)-(x^y) → x&y (T1082-T1087)
 fn compiler_main_test_et_or_xor_sub_and_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2-r3 → r4 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19853,7 +19866,7 @@ fn compiler_main_test_et_or_xor_sub_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_or_xor_sub_and_inner_comm() -> bool with Mut, Div, Panic {
     // (x|y)-(y^x) → x&y (inner XOR commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19865,7 +19878,7 @@ fn compiler_main_test_et_or_xor_sub_and_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_et_or_xor_sub_and_tracked() -> bool with Mut, Div, Panic {
     // Result of ET is tracked as and_rr for downstream Block AO: (x&y)|(x&y)→IrCopy
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19879,7 +19892,7 @@ fn compiler_main_test_et_or_xor_sub_and_tracked() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1)-(r0^r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -19891,7 +19904,7 @@ fn compiler_main_test_et_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (x|y)+(x^y): outer ADD → Block ES fires not ET
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19904,7 +19917,7 @@ fn compiler_main_test_et_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (x|y)-(x&y): inner AND not XOR → Block DM fires (→x^y), not ET
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19918,7 +19931,7 @@ fn compiler_main_test_et_no_fold_and_inner() -> bool with Mut, Div, Panic {
 // Sprint 235 Block ES: AND-XOR add to OR — (x&y)+(x^y) → x|y (T1076-T1081)
 fn compiler_main_test_es_and_xor_add_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2+r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19932,7 +19945,7 @@ fn compiler_main_test_es_and_xor_add_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_and_xor_add_or_comm() -> bool with Mut, Div, Panic {
     // (x^y)+(x&y) → x|y (commutative outer ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 2)
@@ -19946,7 +19959,7 @@ fn compiler_main_test_es_and_xor_add_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_and_xor_add_or_inner_comm() -> bool with Mut, Div, Panic {
     // (y&x)+(x^y) → x|y (inner AND commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19958,7 +19971,7 @@ fn compiler_main_test_es_and_xor_add_or_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_es_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0&r1)+(r0^r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19970,7 +19983,7 @@ fn compiler_main_test_es_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)-(r0^r1): outer SUB not ADD → no ES fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19982,7 +19995,7 @@ fn compiler_main_test_es_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (r0|r1)+(r0^r1): inner is OR not AND → no ES fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19996,7 +20009,7 @@ fn compiler_main_test_es_no_fold_or_inner() -> bool with Mut, Div, Panic {
 // Sprint 234 Block ER: Complement-AND add to OR — x+(~x&y) → x|y (T1070-T1075)
 fn compiler_main_test_er_comp_and_add_or_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=r0+r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 3)
@@ -20010,7 +20023,7 @@ fn compiler_main_test_er_comp_and_add_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_er_comp_and_add_or_comm_add() -> bool with Mut, Div, Panic {
     // (~x&y)+x → x|y (commutative outer ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 0)
@@ -20024,7 +20037,7 @@ fn compiler_main_test_er_comp_and_add_or_comm_add() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_er_comp_and_add_or_inner_comm() -> bool with Mut, Div, Panic {
     // x+(y&~x) → x|y (inner AND commutative: rhs is NOT(x))
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 3)
@@ -20038,7 +20051,7 @@ fn compiler_main_test_er_comp_and_add_or_inner_comm() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_er_no_fold_diff_x() -> bool with Mut, Div, Panic {
     // r0+(~r2&r1): NOT is NOT(r2) not NOT(r0) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[1 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpAdd, 4)
@@ -20050,7 +20063,7 @@ fn compiler_main_test_er_no_fold_diff_x() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_er_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // x-(~x&y): outer is SUB not ADD → no ER fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 3)
@@ -20062,7 +20075,7 @@ fn compiler_main_test_er_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_er_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // x+(~x|y): inner is OR not AND → no ER fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 3)
@@ -20076,7 +20089,7 @@ fn compiler_main_test_er_no_fold_or_inner() -> bool with Mut, Div, Panic {
 // Sprint 233 Block EQ: XOR-AND XOR to OR — (x^y)^(x&y) → x|y (T1064-T1069)
 fn compiler_main_test_eq_xor_and_xor_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0&r1, r4=r2^r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20090,7 +20103,7 @@ fn compiler_main_test_eq_xor_and_xor_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eq_xor_and_xor_or_comm() -> bool with Mut, Div, Panic {
     // (x&y)^(x^y) → x|y (commutative outer XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 2)
@@ -20104,7 +20117,7 @@ fn compiler_main_test_eq_xor_and_xor_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eq_xor_and_xor_or_inner_comm() -> bool with Mut, Div, Panic {
     // (x^y)^(y&x) → x|y (inner AND commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20116,7 +20129,7 @@ fn compiler_main_test_eq_xor_and_xor_or_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_eq_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0^r1)^(r0&r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -20129,7 +20142,7 @@ fn compiler_main_test_eq_no_fold_diff_var() -> bool with Mut, Div, Panic {
 fn compiler_main_test_eq_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (x^y)^(x|y): inner is OR not AND → no EQ fold
     // Block DA fires: (x|y)^(x&y)→x^y, but here inner is OR not AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20143,7 +20156,7 @@ fn compiler_main_test_eq_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eq_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (x^y)&(x&y): outer is AND not XOR → no EQ fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20157,7 +20170,7 @@ fn compiler_main_test_eq_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 232 Block EP: Sub-swap double — (x-y)-(y-x) → (x-y)+(x-y) (T1058-T1063)
 fn compiler_main_test_ep_sub_swap_double_basic() -> bool with Mut, Div, Panic {
     // r2=r0-r1, r3=r1-r0, r4=r2-r3 → r4 becomes r2+r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -20171,7 +20184,7 @@ fn compiler_main_test_ep_sub_swap_double_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ep_sub_swap_double_uses_s1() -> bool with Mut, Div, Panic {
     // Verify result uses s1 (x-y register) for the doubled add
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -20185,7 +20198,7 @@ fn compiler_main_test_ep_sub_swap_double_uses_s1() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_ep_sub_swap_double_same_sub() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r1): same register → x^x fold happens first (0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20197,7 +20210,7 @@ fn compiler_main_test_ep_sub_swap_double_same_sub() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_ep_no_fold_not_swap() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r2): rhs differ → no EP fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -20209,7 +20222,7 @@ fn compiler_main_test_ep_no_fold_not_swap() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ep_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r1-r0): outer is ADD not SUB → no EP fold (EO handles this)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20224,7 +20237,7 @@ fn compiler_main_test_ep_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ep_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0+r1): s2 is ADD not SUB → no EP fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -20238,7 +20251,7 @@ fn compiler_main_test_ep_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 231 Block EO: Add-sub symmetric collapse — (x+y)+(x-y) → x+x (T1052-T1057)
 fn compiler_main_test_eo_add_sub_sym_basic() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0-r1, r4=r2+r3 → r4 becomes r0+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20252,7 +20265,7 @@ fn compiler_main_test_eo_add_sub_sym_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_add_sub_sym_comm_sub() -> bool with Mut, Div, Panic {
     // r2=r0-r1, r3=r0+r1, r4=r2+r3 → (x-y)+(x+y) → r0+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20266,7 +20279,7 @@ fn compiler_main_test_eo_add_sub_sym_comm_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_add_sub_sym_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r1+r0, r3=r0-r1, r4=r2+r3 → (y+x)+(x-y) → r0+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20280,7 +20293,7 @@ fn compiler_main_test_eo_add_sub_sym_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0-r2: subtrahend is r2 not r1 → no EO fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20292,7 +20305,7 @@ fn compiler_main_test_eo_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_no_fold_sub_op() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0-r1, outer is SUB not ADD → no EO fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -20305,7 +20318,7 @@ fn compiler_main_test_eo_no_fold_sub_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_no_fold_diff_x() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r2-r1: x differs → no EO fold (x+y)+(x'-y) can't simplify to 2x
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20318,7 +20331,7 @@ fn compiler_main_test_eo_no_fold_diff_x() -> bool with Mut, Div, Panic {
 // Sprint 230 Block EN: Double-complement XOR — ~x^~y → x^y (T1046-T1051)
 fn compiler_main_test_en_dbl_comp_xor_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r1, r4=r2^r3 → r4 becomes r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20332,7 +20345,7 @@ fn compiler_main_test_en_dbl_comp_xor_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_dbl_comp_xor_same() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r0, r4=r2^r3 → r4 becomes r0^r0 = 0 (via const fold)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20346,7 +20359,7 @@ fn compiler_main_test_en_dbl_comp_xor_same() -> bool with Mut, Div, Panic {
 fn compiler_main_test_en_dbl_comp_xor_chain() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r1, r4=r2^r3 → xor-rr valid for downstream use
     // e.g. Block EK: r4|(r0^r1) → r4|(r0^r1) is just OR since r4=r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20362,7 +20375,7 @@ fn compiler_main_test_en_dbl_comp_xor_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_no_fold_one_not() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1: only one operand is NOT → no EN fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -20374,7 +20387,7 @@ fn compiler_main_test_en_no_fold_one_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r1, r4=r2&r3: AND not XOR → no EN fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20388,7 +20401,7 @@ fn compiler_main_test_en_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_no_fold_neg_op() -> bool with Mut, Div, Panic {
     // r2=neg(r0), r3=neg(r1), r4=r2^r3: neg not NOT → no EN fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNeg, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20403,7 +20416,7 @@ fn compiler_main_test_en_no_fold_neg_op() -> bool with Mut, Div, Panic {
 // Sprint 229 Block EM: Complement-OR AND — (~x|y)&(x|y) → y (T1040-T1045)
 fn compiler_main_test_em_comp_or_and_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2|r1, r4=r0|r1, r5=r3&r4 → r5 becomes IrCopy(r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20416,7 +20429,7 @@ fn compiler_main_test_em_comp_or_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_comp_or_and_comm() -> bool with Mut, Div, Panic {
     // (x|y)&(~x|y) → y (outer AND comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 1)
@@ -20429,7 +20442,7 @@ fn compiler_main_test_em_comp_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_comp_or_and_lhs_shared() -> bool with Mut, Div, Panic {
     // (y|~x)&(y|x) → y (same lhs y, rhs are ~x and x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 0)
@@ -20442,7 +20455,7 @@ fn compiler_main_test_em_comp_or_and_lhs_shared() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (~x|y)&(x|z): different rhs (y≠z) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitOr, 2)
@@ -20455,7 +20468,7 @@ fn compiler_main_test_em_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1)&(r2|r1): no NOT involved → no EM fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -20467,7 +20480,7 @@ fn compiler_main_test_em_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (~x|y) AND (x&y): second is AND not OR → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20481,7 +20494,7 @@ fn compiler_main_test_em_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 228 Block EL: Complement-AND OR — (~x&y)|(x&y) → y (T1034-T1039)
 fn compiler_main_test_el_comp_and_or_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=r0&r1, r5=r3|r4 → r5 becomes IrCopy(r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20494,7 +20507,7 @@ fn compiler_main_test_el_comp_and_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_comp_and_or_comm() -> bool with Mut, Div, Panic {
     // (x&y)|(~x&y) → y (s1 has x, s2 has ~x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
@@ -20507,7 +20520,7 @@ fn compiler_main_test_el_comp_and_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_comp_and_or_lhs_shared() -> bool with Mut, Div, Panic {
     // (y&~x)|(y&x) → y (same lhs y, rhs are ~x and x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 0)
@@ -20520,7 +20533,7 @@ fn compiler_main_test_el_comp_and_or_lhs_shared() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (~x&y)|(x&z): different rhs (y≠z) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitAnd, 2)
@@ -20533,7 +20546,7 @@ fn compiler_main_test_el_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r2&r1): no NOT involved → no EL fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -20545,7 +20558,7 @@ fn compiler_main_test_el_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (~x&y) OR (x|y): second operand is OR not AND → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20559,7 +20572,7 @@ fn compiler_main_test_el_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 227 Block EK: OR-XOR simplification — x|(x^y) → x|y (T1028-T1033)
 fn compiler_main_test_ek_or_xor_or_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r0|r2 → r3 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20572,7 +20585,7 @@ fn compiler_main_test_ek_or_xor_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_or_xor_or_comm() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r2|r0 → r3 becomes r0|r1 (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -20585,7 +20598,7 @@ fn compiler_main_test_ek_or_xor_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_or_xor_or_rhs() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r1|r2 → r3 becomes r1|r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20598,7 +20611,7 @@ fn compiler_main_test_ek_or_xor_or_rhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r3=(r0^r1), r4=r2|r3: r2 not in XOR → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
     let func = cp_make_test_func(instrs, 2)
@@ -20609,7 +20622,7 @@ fn compiler_main_test_ek_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r0&r2: AND outer → no EK fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20620,7 +20633,7 @@ fn compiler_main_test_ek_no_fold_and_outer() -> bool with Mut, Div, Panic {
 fn compiler_main_test_ek_no_fold_no_xor() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=r0|r2: s2 is AND-rr not XOR-rr → EK does not fold to r0|r1 as XOR path
     // Block AO fires: a|(a&b)→a. So result becomes IrCopy(r0).
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20632,7 +20645,7 @@ fn compiler_main_test_ek_no_fold_no_xor() -> bool with Mut, Div, Panic {
 // Sprint 226 Block EJ: XNOR-OR to AND — ~(x^y)&(x|y) → x&y (T1022-T1027)
 fn compiler_main_test_ej_xnor_or_and_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=~r2, r4=(r0|r1), r5=r3&r4 → r5 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20647,7 +20660,7 @@ fn compiler_main_test_ej_xnor_or_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_xnor_or_and_comm() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0^r1) → r0&r1 (comm outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20662,7 +20675,7 @@ fn compiler_main_test_ej_xnor_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_xnor_or_and_inner_comm() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & (r1|r0) → r0&r1 (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 0)
@@ -20675,7 +20688,7 @@ fn compiler_main_test_ej_xnor_or_and_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & (r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitOr, 2)
@@ -20688,7 +20701,7 @@ fn compiler_main_test_ej_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0|r1): no NOT → Block DV fires (IrCopy(x^y)), not EJ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20699,7 +20712,7 @@ fn compiler_main_test_ej_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r0|r1): OR outer → EI-related, not EJ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20712,7 +20725,7 @@ fn compiler_main_test_ej_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 225 Block EI: XNOR-AND subsumption — ~(x^y)|(x&y) → ~(x^y) (T1016-T1021)
 fn compiler_main_test_ei_xnor_and_subsume_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=~r2, r4=(r0&r1), r5=r3|r4 → r5 becomes IrCopy(r3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20725,7 +20738,7 @@ fn compiler_main_test_ei_xnor_and_subsume_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_xnor_and_subsume_comm() -> bool with Mut, Div, Panic {
     // (r0&r1) | ~(r0^r1) → IrCopy(~(r0^r1)) (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20738,7 +20751,7 @@ fn compiler_main_test_ei_xnor_and_subsume_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_xnor_and_subsume_inner_comm() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r1&r0) → IrCopy(~(r0^r1)) (inner comm AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 0)
@@ -20751,7 +20764,7 @@ fn compiler_main_test_ei_xnor_and_subsume_inner_comm() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_ei_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r0&r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitAnd, 2)
@@ -20763,7 +20776,7 @@ fn compiler_main_test_ei_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & (r0&r1): AND outer → no EI fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20775,7 +20788,7 @@ fn compiler_main_test_ei_no_fold_and_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r0|r1): s2=OR not AND → no EI fold (EG may fire instead)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20791,7 +20804,7 @@ fn compiler_main_test_ei_no_fold_or_inner() -> bool with Mut, Div, Panic {
 // Sprint 224 Block EH: XOR-NOR annihilation — (x^y)&~(x|y) → 0 (T1010-T1015)
 fn compiler_main_test_eh_xor_nor_zero_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=(r0|r1), r4=~r3, r5=r2&r4 → r5 becomes 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20804,7 +20817,7 @@ fn compiler_main_test_eh_xor_nor_zero_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_xor_nor_zero_comm() -> bool with Mut, Div, Panic {
     // ~(r0|r1) & (r0^r1) → 0 (comm outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20817,7 +20830,7 @@ fn compiler_main_test_eh_xor_nor_zero_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_xor_nor_zero_inner_comm() -> bool with Mut, Div, Panic {
     // (r0^r1) & ~(r1|r0) → 0 (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20830,7 +20843,7 @@ fn compiler_main_test_eh_xor_nor_zero_inner_comm() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_eh_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1) & ~(r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_unaryop(5, UnaryOp::OpNot, 4)
@@ -20842,7 +20855,7 @@ fn compiler_main_test_eh_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0|r1): no NOT → no EH fold (Block DV fires: IrCopy(x^y))
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20854,7 +20867,7 @@ fn compiler_main_test_eh_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0^r1) | ~(r0|r1): OR outer → no EH fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20867,7 +20880,7 @@ fn compiler_main_test_eh_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 223 Block EG: AND-OR superset absorption — (x&y)&(x|y) → x&y (T1004-T1009)
 fn compiler_main_test_eg_and_or_absorb_basic() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r0|r1), r4=r2&r3 → r4 becomes IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20879,7 +20892,7 @@ fn compiler_main_test_eg_and_or_absorb_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_and_or_absorb_comm() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0&r1), r4=r2&r3 → r4 becomes IrCopy(r3) (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20891,7 +20904,7 @@ fn compiler_main_test_eg_and_or_absorb_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_and_or_absorb_inner_comm() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r1|r0), r4=r2&r3 → r4 becomes IrCopy(r2) (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20903,7 +20916,7 @@ fn compiler_main_test_eg_and_or_absorb_inner_comm() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_eg_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0&r1)&(r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -20914,7 +20927,7 @@ fn compiler_main_test_eg_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0|r1): OR outer → Block EF fires, not EG
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20926,7 +20939,7 @@ fn compiler_main_test_eg_no_fold_or_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_no_fold_and_both() -> bool with Mut, Div, Panic {
     // (r0&r1)&(r0&r2): both AND, no OR superset → no EG fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -20938,7 +20951,7 @@ fn compiler_main_test_eg_no_fold_and_both() -> bool with Mut, Div, Panic {
 // Sprint 222 Block EF: OR-AND subsumption — (x|y)|(x&y) → x|y (T998-T1003)
 fn compiler_main_test_ef_or_and_subsume_basic() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0&r1), r4=r2|r3 → r4 becomes IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20950,7 +20963,7 @@ fn compiler_main_test_ef_or_and_subsume_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_or_and_subsume_comm() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r0|r1), r4=r2|r3 → r4 becomes IrCopy(r3) (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20962,7 +20975,7 @@ fn compiler_main_test_ef_or_and_subsume_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_or_and_subsume_inner_comm() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r1&r0), r4=r2|r3 → r4 becomes IrCopy(r2) (inner comm AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20974,7 +20987,7 @@ fn compiler_main_test_ef_or_and_subsume_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ef_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0&r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -20985,7 +20998,7 @@ fn compiler_main_test_ef_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)&(r0&r1): AND outer not OR → no EF fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20996,7 +21009,7 @@ fn compiler_main_test_ef_no_fold_and_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_no_fold_or_both() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0|r2): both OR, not AND+OR → no EF fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -21008,7 +21021,7 @@ fn compiler_main_test_ef_no_fold_or_both() -> bool with Mut, Div, Panic {
 // Sprint 221 Block EE: Sub-add collapse — (x-y)+(z+y) → x+z (T992-T997)
 fn compiler_main_test_ee_sub_add_collapse_basic() -> bool with Mut, Div, Panic {
     // r3=(r0-r1), r4=(r2+r1), r5=r3+r4 → r5 becomes r0+r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21022,7 +21035,7 @@ fn compiler_main_test_ee_sub_add_collapse_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ee_sub_add_collapse_comm_add() -> bool with Mut, Div, Panic {
     // r3=(r0-r1), r4=(r1+r2), r5=r3+r4 → r5 becomes r0+r2 (y+z form)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21036,7 +21049,7 @@ fn compiler_main_test_ee_sub_add_collapse_comm_add() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ee_sub_add_collapse_comm_outer() -> bool with Mut, Div, Panic {
     // r3=(r2+r1), r4=(r0-r1), r5=r3+r4 → r5 becomes r0+r2 (comm outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21050,7 +21063,7 @@ fn compiler_main_test_ee_sub_add_collapse_comm_outer() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_ee_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r2+r3): r3 ≠ r1 → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
     instrs[2 as usize] = ir_binop(6, 4, BinaryOp::OpAdd, 5)
@@ -21062,7 +21075,7 @@ fn compiler_main_test_ee_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ee_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r2+r1): SUB outer, not ADD → no EE fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21073,7 +21086,7 @@ fn compiler_main_test_ee_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ee_no_fold_no_add() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r2-r1): both are subs → EC might fire, not EE
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21086,7 +21099,7 @@ fn compiler_main_test_ee_no_fold_no_add() -> bool with Mut, Div, Panic {
 // Sprint 220 Block ED: Add-sub expand — (x+y)-(x-z) → y+z (T986-T991)
 fn compiler_main_test_ed_add_sub_expand_basic() -> bool with Mut, Div, Panic {
     // r3=(r0+r1), r4=(r0-r2), r5=r3-r4 → r5 becomes r1+r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21100,7 +21113,7 @@ fn compiler_main_test_ed_add_sub_expand_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_add_sub_expand_comm() -> bool with Mut, Div, Panic {
     // r3=(r1+r0), r4=(r0-r2), r5=r3-r4 → r5 becomes r1+r2 (comm add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 0)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21114,7 +21127,7 @@ fn compiler_main_test_ed_add_sub_expand_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_add_sub_expand_vals() -> bool with Mut, Div, Panic {
     // (r0+r2)-(r0-r1) → r2+r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21128,7 +21141,7 @@ fn compiler_main_test_ed_add_sub_expand_vals() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r2-r3): no shared var → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
     instrs[2 as usize] = ir_binop(6, 4, BinaryOp::OpSub, 5)
@@ -21140,7 +21153,7 @@ fn compiler_main_test_ed_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_no_fold_sub_s1() -> bool with Mut, Div, Panic {
     // s1 is SUB not ADD: (r0-r1)-(r0-r2) → Block DN fires, not ED
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21152,7 +21165,7 @@ fn compiler_main_test_ed_no_fold_sub_s1() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0+r1)+(r0-r2) → no fold (ADD outer not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21165,7 +21178,7 @@ fn compiler_main_test_ed_no_fold_add_outer() -> bool with Mut, Div, Panic {
 // Sprint 219 Block EC: Sub same-RHS cancel — (x-y)-(z-y) → x-z (T980-T985)
 fn compiler_main_test_ec_sub_same_rhs_basic() -> bool with Mut, Div, Panic {
     // r3=(r0-r2), r4=(r1-r2), r5=r3-r4 → r5 becomes r0-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21179,7 +21192,7 @@ fn compiler_main_test_ec_sub_same_rhs_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_sub_same_rhs_chain() -> bool with Mut, Div, Panic {
     // r3=(r0-r1), r4=(r2-r1), r5=r3-r4 → r5 becomes r0-r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21194,7 +21207,7 @@ fn compiler_main_test_ec_sub_same_rhs_chain() -> bool with Mut, Div, Panic {
 fn compiler_main_test_ec_sub_same_rhs_self_zero() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r1) → IrCopy(0) or IrLoadImm(0) via x-x→0 (Block A after EC)
     // EC only fires when x != z, so same sub: r3=r0-r1, r4=r0-r1 → x==z, no fold by EC
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21207,7 +21220,7 @@ fn compiler_main_test_ec_sub_same_rhs_self_zero() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_no_fold_diff_rhs() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r2) → Block DN fires (same lhs), not EC
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21220,7 +21233,7 @@ fn compiler_main_test_ec_no_fold_diff_rhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // r3=(r0+r2), r4=(r1-r2): s1 is ADD not SUB, no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21232,7 +21245,7 @@ fn compiler_main_test_ec_no_fold_not_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0-r2)+(r1-r2) → Block DK territory if OR/AND; here ADD outer: no EC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21244,7 +21257,7 @@ fn compiler_main_test_ec_no_fold_add_outer() -> bool with Mut, Div, Panic {
 // Sprint 218 Block EB: AND-XOR to OR — (x&y) ^ (x^y) → x|y (T974-T979)
 fn compiler_main_test_eb_and_xor_or_basic() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r0^r1), r4=r2^r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21256,7 +21269,7 @@ fn compiler_main_test_eb_and_xor_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_and_xor_or_comm() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=(r0&r1), r4=r2^r3 → r4 becomes r0|r1 (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21268,7 +21281,7 @@ fn compiler_main_test_eb_and_xor_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_and_xor_or_inner_comm() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r1^r0) → r0|r1 (inner comm XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21280,7 +21293,7 @@ fn compiler_main_test_eb_and_xor_or_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0^r2) → no fold (different vars)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -21291,7 +21304,7 @@ fn compiler_main_test_eb_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0|r1): EB requires XOR-rr as inner, OR-rr does not match → no EB fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21303,7 +21316,7 @@ fn compiler_main_test_eb_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0&r1) & (r0^r1) → no fold (AND outer not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -21315,7 +21328,7 @@ fn compiler_main_test_eb_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 217 Block EA: XOR-OR to AND — (x^y) ^ (x|y) → x&y (T968-T973)
 fn compiler_main_test_ea_xor_or_and_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=(r0|r1), r4=r2^r3 → r4 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21327,7 +21340,7 @@ fn compiler_main_test_ea_xor_or_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_xor_or_and_comm() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0^r1), r4=r2^r3 → r4 becomes r0&r1 (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21339,7 +21352,7 @@ fn compiler_main_test_ea_xor_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_xor_or_and_inner_comm() -> bool with Mut, Div, Panic {
     // (r0^r1) ^ (r1|r0) → r0&r1 (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21351,7 +21364,7 @@ fn compiler_main_test_ea_xor_or_and_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1) ^ (r0|r2) → no fold (different vars)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -21362,7 +21375,7 @@ fn compiler_main_test_ea_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (r0^r1) ^ (r0&r1) → no fold (AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21373,7 +21386,7 @@ fn compiler_main_test_ea_no_fold_and_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0^r1) | (r0|r1) → no fold (OR outer not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -21385,7 +21398,7 @@ fn compiler_main_test_ea_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 216 Block DZ: OR-AND-NOT to XOR — (x|y) & ~(x&y) → x^y (T962-T967)
 fn compiler_main_test_dz_or_and_not_xor_basic() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0&r1), r4=~r3, r5=r2&r4 → r5 becomes r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -21398,7 +21411,7 @@ fn compiler_main_test_dz_or_and_not_xor_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dz_or_and_not_xor_comm_outer() -> bool with Mut, Div, Panic {
     // ~(r0&r1) & (r0|r1) → r0^r1 (commutative outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -21411,7 +21424,7 @@ fn compiler_main_test_dz_or_and_not_xor_comm_outer() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_dz_or_and_not_xor_comm_inner() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r1&r0) → r0^r1 (commutative inner AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 0)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -21424,7 +21437,7 @@ fn compiler_main_test_dz_or_and_not_xor_comm_inner() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_dz_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0&r2) → no fold (different vars in AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(5, UnaryOp::OpNot, 4)
@@ -21436,7 +21449,7 @@ fn compiler_main_test_dz_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dz_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1) & (r0&r1) → no fold (no NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -21447,7 +21460,7 @@ fn compiler_main_test_dz_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dz_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) | ~(r0&r1) → no fold (OR outer, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -168,6 +168,13 @@ fn module_frontend_resolve_import_relpath(rel_path: string, cur_dir: string) -> 
             anc_depth = anc_depth + 1
         }
     }
+    let stdlib_env_root = read_env("SOUNIO_STDLIB_PATH")
+    if str_len(stdlib_env_root) > 0 {
+        let stdlib_env_path = str_concat(str_concat(stdlib_env_root, "/"), rel_path)
+        if file_exists(stdlib_env_path) {
+            return stdlib_env_path
+        }
+    }
     let stdlib_path = str_concat("stdlib/", rel_path)
     if file_exists(stdlib_path) {
         return stdlib_path
@@ -507,6 +514,13 @@ fn resolve_import_file_path(path: AstPath, cur_dir: string) -> string with IO, M
     let local = use_path_to_file_path(path, cur_dir)
     if file_exists(local) {
         return local
+    }
+    let stdlib_env_root = read_env("SOUNIO_STDLIB_PATH")
+    if str_len(stdlib_env_root) > 0 {
+        let stdlib_env = use_path_to_file_path(path, stdlib_env_root)
+        if file_exists(stdlib_env) {
+            return stdlib_env
+        }
     }
     let stdlib = use_path_to_file_path(path, "stdlib")
     if file_exists(stdlib) {
@@ -1110,6 +1124,64 @@ fn ir_merge_modules(dst: IrModule, src: IrModule) -> IrModule with Mut, Panic, D
     merged
 }
 
+fn ir_merge_is_direct_fn_ref_opcode(op: IrOpcode) -> bool {
+    match op {
+        IrOpcode::IrCall => true,
+        IrOpcode::IrCallSret => true,
+        IrOpcode::IrLoadFnRef => true,
+        _ => false,
+    }
+}
+
+fn ir_merge_prepare_function_with_remap(
+    src: &IrModule,
+    src_fi: i64,
+    dep_fn_count: i64,
+    fn_remap: &[i64; 2048],
+    contest_offset: i64,
+    robust_offset: i64,
+    decision_offset: i64,
+    deferred_offset: i64,
+    validated_offset: i64,
+    acquisition_plan_offset: i64,
+    recourse_plan_offset: i64,
+    alternative_set_offset: i64,
+    transition_plan_offset: i64,
+    observed_transition_offset: i64,
+    rollback_certificate_offset: i64
+) -> IrFunction with Mut, Panic, Div {
+    var func = (*src).functions[src_fi as usize]
+    func.compile_strategy = (*src).functions[src_fi as usize].compile_strategy
+    var ii: i64 = 0
+    while ii < func.instr_count {
+        if ir_merge_is_direct_fn_ref_opcode(func.instrs[ii as usize].op) {
+            let old_id = func.instrs[ii as usize].fn_id
+            if old_id >= 0 && old_id < dep_fn_count {
+                let mapped_id = fn_remap[old_id as usize]
+                if mapped_id >= 0 {
+                    func.instrs[ii as usize].fn_id = mapped_id
+                }
+            }
+        }
+        func.instrs[ii as usize] = ir_merge_adjust_epistemic_instr(
+            func.instrs[ii as usize],
+            contest_offset,
+            robust_offset,
+            decision_offset,
+            deferred_offset,
+            validated_offset,
+            acquisition_plan_offset,
+            recourse_plan_offset,
+            alternative_set_offset,
+            transition_plan_offset,
+            observed_transition_offset,
+            rollback_certificate_offset
+        )
+        ii = ii + 1
+    }
+    func
+}
+
 // Takes &! IrModule (not &! Box<IrModule>): the latter triggers a lean_single
 // codegen bug where (*box_ref).field reads garbage. Callers materialize the
 // IrModule reference via &! (*acc_box) at the call site.
@@ -1133,7 +1205,7 @@ fn ir_merge_append_function_into_box(dst: &! IrModule, src: &IrModule, src_fi: i
     func.compile_strategy = (*src).functions[src_fi as usize].compile_strategy
     var ii: i64 = 0
     while ii < func.instr_count {
-        if func.instrs[ii as usize].op == IrOpcode::IrCall {
+        if ir_merge_is_direct_fn_ref_opcode(func.instrs[ii as usize].op) {
             if func.instrs[ii as usize].fn_id >= 0 {
                 func.instrs[ii as usize].fn_id = func.instrs[ii as usize].fn_id + fn_offset
             }
@@ -3216,6 +3288,13 @@ pub struct ModuleFrontendLowerBoxResult {
     pub patch_stats: IrValidatedPatchStats,
 }
 
+pub struct ModuleFrontendLowerDirectBoxResult {
+    pub ok: bool,
+    pub module: Box<IrModule>,
+    pub error_msg: string,
+    pub patch_stats: IrValidatedPatchStats,
+}
+
 fn module_frontend_lower_box_error(msg: string) -> ModuleFrontendLowerBoxResult {
     ModuleFrontendLowerBoxResult {
         ok: false,
@@ -3229,6 +3308,24 @@ fn module_frontend_lower_box_ok(module: Box<IrModule>, patch_stats: IrValidatedP
     ModuleFrontendLowerBoxResult {
         ok: true,
         module: Some(module),
+        error_msg: "",
+        patch_stats: patch_stats,
+    }
+}
+
+fn module_frontend_lower_direct_box_error(msg: string) -> ModuleFrontendLowerDirectBoxResult {
+    ModuleFrontendLowerDirectBoxResult {
+        ok: false,
+        module: Box::new(ir_empty_module()),
+        error_msg: msg,
+        patch_stats: ir_empty_validated_patch_stats(),
+    }
+}
+
+fn module_frontend_lower_direct_box_ok(module: Box<IrModule>, patch_stats: IrValidatedPatchStats) -> ModuleFrontendLowerDirectBoxResult {
+    ModuleFrontendLowerDirectBoxResult {
+        ok: true,
+        module: module,
         error_msg: "",
         patch_stats: patch_stats,
     }
@@ -3345,6 +3442,56 @@ fn module_frontend_lower_program_box_traced(
         &epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
+    if module_frontend_lower_trace_enabled() {
+        print("module_frontend_lower: body_fn_count ")
+        print_int((*body_result.module).fn_count)
+        print("\n")
+    }
+    if body_result.had_error {
+        trace.last_stage = "lower_bodies_error"
+        return module_frontend_lower_box_error("ir_bodies_failed")
+    }
+
+    trace.body_lowered_modules = trace.body_lowered_modules + 1
+    trace.lowered_modules = trace.lowered_modules + 1
+    trace.patched_functions = trace.patched_functions + body_result.patch_stats.patched_functions
+    trace.patched_calls = trace.patched_calls + body_result.patch_stats.patched_calls
+    trace.fallback_insertions = trace.fallback_insertions + body_result.patch_stats.fallback_insertions
+    trace.last_stage = "lower_bodies_done"
+    module_frontend_lower_box_ok(body_result.module, body_result.patch_stats)
+}
+
+fn module_frontend_lower_program_items_box_traced(
+    items: &Option<Box<ItemList>>,
+    module_index: i64,
+    trace: &! LoadMultimoduleIrTrace
+) -> ModuleFrontendLowerBoxResult with IO, Mut, Div, Panic, Alloc {
+    trace.last_stage = "lower_summary"
+    trace.last_module_index = module_index
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_begin\n") }
+    var epistemic = ir_empty_epistemic_section()
+    let summary_result = lower_program_items_to_ir_summary_box_with_epistemic_ref(items, &epistemic)
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
+    if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
+        trace.last_stage = "lower_summary_error"
+        return module_frontend_lower_box_error("ir_summary_failed")
+    }
+
+    trace.summary_seeded_modules = trace.summary_seeded_modules + 1
+    trace.last_stage = "lower_bodies"
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
+    var summary_val = (*summary_result.summary)
+    let body_result = lower_program_items_bodies_from_summary_with_epistemic_boxed_ref(
+        items,
+        &summary_val,
+        &epistemic
+    )
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
+    if module_frontend_lower_trace_enabled() {
+        print("module_frontend_lower: body_fn_count ")
+        print_int((*body_result.module).fn_count)
+        print("\n")
+    }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
         return module_frontend_lower_box_error("ir_bodies_failed")
@@ -3364,7 +3511,7 @@ fn module_frontend_lower_program_box_traced(
 // then `s.field` lowers to the right field_idx.
 fn module_frontend_lower_program_box_traced_with_externs(
     program: &Program,
-    programs: &[Program; 256],
+    programs: &! [Program; 256],
     program_count: i64,
     module_index: i64,
     trace: &! LoadMultimoduleIrTrace
@@ -3390,6 +3537,58 @@ fn module_frontend_lower_program_box_traced_with_externs(
         &epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
+    if module_frontend_lower_trace_enabled() {
+        print("module_frontend_lower: body_fn_count ")
+        print_int((*body_result.module).fn_count)
+        print("\n")
+    }
+    if body_result.had_error {
+        trace.last_stage = "lower_bodies_error"
+        return module_frontend_lower_box_error("ir_bodies_failed")
+    }
+
+    trace.body_lowered_modules = trace.body_lowered_modules + 1
+    trace.lowered_modules = trace.lowered_modules + 1
+    trace.patched_functions = trace.patched_functions + body_result.patch_stats.patched_functions
+    trace.patched_calls = trace.patched_calls + body_result.patch_stats.patched_calls
+    trace.fallback_insertions = trace.fallback_insertions + body_result.patch_stats.fallback_insertions
+    trace.last_stage = "lower_bodies_done"
+    module_frontend_lower_box_ok(body_result.module, body_result.patch_stats)
+}
+
+fn module_frontend_lower_program_items_box_traced_with_externs(
+    items: &Option<Box<ItemList>>,
+    programs: &! [Program; 256],
+    program_count: i64,
+    module_index: i64,
+    trace: &! LoadMultimoduleIrTrace
+) -> ModuleFrontendLowerBoxResult with IO, Mut, Div, Panic, Alloc {
+    trace.last_stage = "lower_summary"
+    trace.last_module_index = module_index
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_begin\n") }
+    var epistemic = ir_empty_epistemic_section()
+    let summary_result = lower_program_items_to_ir_summary_box_with_externs_ref(items, programs, program_count, module_index, &epistemic)
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
+    if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
+        trace.last_stage = "lower_summary_error"
+        return module_frontend_lower_box_error("ir_summary_failed")
+    }
+
+    trace.summary_seeded_modules = trace.summary_seeded_modules + 1
+    trace.last_stage = "lower_bodies"
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
+    var summary_val = (*summary_result.summary)
+    let body_result = lower_program_items_bodies_from_summary_with_epistemic_boxed_ref(
+        items,
+        &summary_val,
+        &epistemic
+    )
+    if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
+    if module_frontend_lower_trace_enabled() {
+        print("module_frontend_lower: body_fn_count ")
+        print_int((*body_result.module).fn_count)
+        print("\n")
+    }
     if body_result.had_error {
         trace.last_stage = "lower_bodies_error"
         return module_frontend_lower_box_error("ir_bodies_failed")
@@ -3456,67 +3655,114 @@ pub fn module_frontend_check_imported_modules_verdict(main_path: string) -> i64 
     check_modules_verdict_boot4(&! programs, loaded)
 }
 
-fn module_frontend_lower_programs_array_boxed(
+fn module_frontend_lower_programs_array_direct_box(
     programs: &! [Program; 256],
     loaded: i64,
     trace: &! LoadMultimoduleIrTrace
-) -> ModuleFrontendLowerBoxResult with IO, Mut, Panic, Div, Alloc {
+) -> ModuleFrontendLowerDirectBoxResult with IO, Mut, Panic, Div, Alloc {
     if loaded <= 0 {
-        return module_frontend_lower_box_error("no_modules_loaded")
+        return module_frontend_lower_direct_box_error("no_modules_loaded")
     }
 
     trace.last_stage = "lower_summary"
     trace.last_module_index = 0
     print("lower_array: seed_begin\n")
-    let seed_prog_copy = (*programs)[0]
-    let programs_ref: &[Program; 256] = programs
-    let seed_lower = module_frontend_lower_program_box_traced_with_externs(&seed_prog_copy, programs_ref, loaded, 0, trace)
+    let seed_items = (*programs)[0].items
+    let seed_lower = module_frontend_lower_program_items_box_traced_with_externs(&seed_items, programs, loaded, 0, trace)
     print("lower_array: seed_done\n")
     if !seed_lower.ok {
-        return seed_lower
+        return module_frontend_lower_direct_box_error(seed_lower.error_msg)
     }
-    var merged_box = seed_lower.module
-    trace.merged_modules = 1
+    match seed_lower.module {
+        Some(acc_box) => {
+            trace.merged_modules = 1
 
-    var i: i64 = 1
-    while i < loaded {
-        trace.last_module_index = i
-        print("lower_array: dep_begin ")
-        print_int(i)
-        print("\n")
-        let dep_prog_copy = (*programs)[i as usize]
-        let dep_lower = module_frontend_lower_program_box_traced(&dep_prog_copy, i, trace)
-        print("lower_array: dep_lower_done ")
-        print_int(i)
-        print("\n")
-        if !dep_lower.ok {
-            return dep_lower
-        }
-        match merged_box {
-            Some(acc_box) => {
+            var i: i64 = 1
+            while i < loaded {
+                trace.last_module_index = i
+                print("lower_array: dep_begin ")
+                print_int(i)
+                print("\n")
+                let dep_items = (*programs)[i as usize].items
+                let dep_lower = module_frontend_lower_program_items_box_traced(&dep_items, i, trace)
+                print("lower_array: dep_lower_done ")
+                print_int(i)
+                print("\n")
+                if !dep_lower.ok {
+                    return module_frontend_lower_direct_box_error(dep_lower.error_msg)
+                }
                 match dep_lower.module {
                     Some(dep_box) => {
                         print("lower_array: merge_begin ")
                         print_int(i)
                         print("\n")
-                        var mfi: i64 = 0
-                        while mfi < (*dep_box).fn_count && (*acc_box).fn_count < IR_MAX_FUNCS {
-                            let dep_ic = (*dep_box).functions[mfi as usize].instr_count
+                        let dep_fn_count = (*dep_box).fn_count
+                        let contest_offset = (*acc_box).epistemic.contest_count
+                        let robust_offset = (*acc_box).epistemic.robust_proof_count
+                        let decision_offset = (*acc_box).epistemic.decision_certificate_count
+                        let deferred_offset = (*acc_box).epistemic.deferred_certificate_count
+                        let validated_offset = (*acc_box).epistemic.validated_manifest_count
+                        let acquisition_plan_offset = (*acc_box).epistemic.acquisition_plan_count
+                        let recourse_plan_offset = (*acc_box).epistemic.recourse_plan_count
+                        let alternative_set_offset = (*acc_box).epistemic.alternative_set_count
+                        let transition_plan_offset = (*acc_box).epistemic.transition_plan_count
+                        let observed_transition_offset = (*acc_box).epistemic.observed_transition_count
+                        let rollback_certificate_offset = (*acc_box).epistemic.rollback_certificate_count
+                        var fn_remap: [i64; 2048] = [-1; 2048]
+                        var append_count: i64 = 0
+                        var rfi: i64 = 0
+                        while rfi < dep_fn_count {
+                            let dep_ic = (*dep_box).functions[rfi as usize].instr_count
                             var stub_idx: i64 = 0 - 1
                             var sfi: i64 = 0
                             while sfi < (*acc_box).fn_count {
                                 if ir_name_eq(
                                     (*acc_box).functions[sfi as usize].name,
-                                    (*dep_box).functions[mfi as usize].name
+                                    (*dep_box).functions[rfi as usize].name
                                 ) && (*acc_box).functions[sfi as usize].instr_count <= 0 {
                                     stub_idx = sfi
                                 }
                                 sfi = sfi + 1
                             }
                             if stub_idx >= 0 && dep_ic > 0 {
-                                (*acc_box).functions[stub_idx as usize] = (*dep_box).functions[mfi as usize]
+                                fn_remap[rfi as usize] = stub_idx
                             } else {
-                                ir_merge_append_function_into_box(&! (*acc_box), &(*dep_box), mfi)
+                                let planned_idx = (*acc_box).fn_count + append_count
+                                if planned_idx < IR_MAX_FUNCS {
+                                    fn_remap[rfi as usize] = planned_idx
+                                    append_count = append_count + 1
+                                }
+                            }
+                            rfi = rfi + 1
+                        }
+
+                        var mfi: i64 = 0
+                        while mfi < dep_fn_count {
+                            let dst_fi = fn_remap[mfi as usize]
+                            if dst_fi >= 0 {
+                                let func = ir_merge_prepare_function_with_remap(
+                                    &(*dep_box),
+                                    mfi,
+                                    dep_fn_count,
+                                    &fn_remap,
+                                    contest_offset,
+                                    robust_offset,
+                                    decision_offset,
+                                    deferred_offset,
+                                    validated_offset,
+                                    acquisition_plan_offset,
+                                    recourse_plan_offset,
+                                    alternative_set_offset,
+                                    transition_plan_offset,
+                                    observed_transition_offset,
+                                    rollback_certificate_offset
+                                )
+                                if dst_fi < (*acc_box).fn_count {
+                                    (*acc_box).functions[dst_fi as usize] = func
+                                } else if dst_fi == (*acc_box).fn_count && (*acc_box).fn_count < IR_MAX_FUNCS {
+                                    (*acc_box).functions[dst_fi as usize] = func
+                                    (*acc_box).fn_count = (*acc_box).fn_count + 1
+                                }
                             }
                             mfi = mfi + 1
                         }
@@ -3532,22 +3778,36 @@ fn module_frontend_lower_programs_array_boxed(
                         print_int(i)
                         print("\n")
                     }
-                    None => return module_frontend_lower_box_error("ir_lowering_failed")
+                    None => return module_frontend_lower_direct_box_error("ir_lowering_failed")
                 }
+                trace.merged_modules = trace.merged_modules + 1
+                i = i + 1
             }
-            None => return module_frontend_lower_box_error("ir_lowering_failed")
+
+            trace.last_stage = "done"
+            print("lower_array: final_fn_count ")
+            print_int((*acc_box).fn_count)
+            print("\n")
+            module_frontend_lower_direct_box_ok(acc_box, ir_empty_validated_patch_stats())
         }
-        trace.merged_modules = trace.merged_modules + 1
-        i = i + 1
+        None => module_frontend_lower_direct_box_error("ir_lowering_failed")
+    }
+}
+
+fn module_frontend_lower_programs_array_boxed(
+    programs: &! [Program; 256],
+    loaded: i64,
+    trace: &! LoadMultimoduleIrTrace
+) -> ModuleFrontendLowerBoxResult with IO, Mut, Panic, Div, Alloc {
+    if loaded <= 0 {
+        return module_frontend_lower_box_error("no_modules_loaded")
     }
 
-    match merged_box {
-        Some(final_box) => {
-            trace.last_stage = "done"
-            module_frontend_lower_box_ok(final_box, ir_empty_validated_patch_stats())
-        }
-        None => module_frontend_lower_box_error("ir_lowering_failed")
+    let lowered = module_frontend_lower_programs_array_direct_box(programs, loaded, trace)
+    if !lowered.ok {
+        return module_frontend_lower_box_error(lowered.error_msg)
     }
+    module_frontend_lower_box_ok(lowered.module, lowered.patch_stats)
 }
 
 fn bridge_lower_imported_modules_box(main_path: string, trace: &! LoadMultimoduleIrTrace) -> ModuleFrontendLowerBoxResult with IO, Mut, Div, Panic, Alloc {
@@ -3673,29 +3933,21 @@ fn module_frontend_merge_imported_into(
 
     // Per-module check_program_with_artifacts cannot see cross-module imports and
     // either rejects (E137) or spins; multimodule verdict above is authoritative.
-    let lowered = module_frontend_lower_programs_array_boxed(programs, loaded, trace)
+    let lowered = module_frontend_lower_programs_array_direct_box(programs, loaded, trace)
     if !lowered.ok {
         print("IR lowering failed during merge: ")
         print(lowered.error_msg)
         print("\n")
         return false
     }
-    match lowered.module {
-        Some(merged_box) => {
-            var merged_module = *merged_box
-            if merged_module.fn_count <= 0 {
-                print("IR lowering produced empty module\n")
-                return false
-            }
-            ir_module_resolve_named_calls(&! merged_module)
-            (*out_module) = merged_module
-            true
-        }
-        None => {
-            print("IR lowering failed during merge\n")
-            false
-        }
+    let module_box = lowered.module
+    if (*module_box).fn_count <= 0 {
+        print("IR lowering produced empty module\n")
+        return false
     }
+    ir_module_resolve_named_calls(&! (*module_box))
+    (*out_module) = *module_box
+    true
 }
 
 pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: string) -> i32 with IO, Mut, Div, Panic, Alloc {
@@ -3765,7 +4017,7 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
 
     trace.last_stage = "lower_merge"
     print("imported_compile: lower_begin\n")
-    let lowered = module_frontend_lower_programs_array_boxed(&! programs, loaded, &! trace)
+    let lowered = module_frontend_lower_programs_array_direct_box(&! programs, loaded, &! trace)
     print("imported_compile: lower_done\n")
     if !lowered.ok {
         print("IR lowering failed during merge: ")
@@ -3774,46 +4026,34 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
         return 1
     }
 
-    match lowered.module {
-        Some(module_box) => {
-            let fn_count = (*module_box).fn_count
-            trace.last_stage = "done"
-            trace.last_module_index = loaded - 1
-            trace.merged_modules = loaded
-            print("Merged IR: ")
-            print_int(fn_count)
-            print(" functions\n")
-            if fn_count <= 0 {
-                print("IR lowering produced empty module\n")
-                return 1
-            }
-            // Use the &!IrModule variant (not _box). The Box-wrapped variant
-            // suffers from a lean_single codegen issue where (*module_box).field
-            // for module_box: &! Box<IrModule> reads garbage (observed: fn_count
-            // 1→29795 across the call boundary). Dereferencing the Box at the
-            // call site materializes a clean &!IrModule and bypasses the bug.
-            ir_module_resolve_named_calls(&! (*module_box))
-            parser_reset_last_errors()
-            let target_spec = native_resolve_target("native", "auto", false)
-            let write_rc = compile_native_v2_preview_to_file(&(*module_box), target_spec, output_path)
-            if write_rc != 0 {
-                print("Error: Failed to write native binary to ")
-                print(output_path)
-                print(" rc=")
-                print_int(write_rc)
-                print("\n")
-                return 1
-            }
-            print("Written to ")
-            print(output_path)
-            print("\n")
-            0
-        }
-        None => {
-            print("IR lowering failed during merge\n")
-            1
-        }
+    let module_box = lowered.module
+    let fn_count = (*module_box).fn_count
+    trace.last_stage = "done"
+    trace.last_module_index = loaded - 1
+    trace.merged_modules = loaded
+    print("Merged IR: ")
+    print_int(fn_count)
+    print(" functions\n")
+    if fn_count <= 0 {
+        print("IR lowering produced empty module\n")
+        return 1
     }
+    ir_module_resolve_named_calls(&! (*module_box))
+    parser_reset_last_errors()
+    let target_spec = native_resolve_target("native", "auto", false)
+    let write_rc = compile_native_v2_preview_to_file(&(*module_box), target_spec, output_path)
+    if write_rc != 0 {
+        print("Error: Failed to write native binary to ")
+        print(output_path)
+        print(" rc=")
+        print_int(write_rc)
+        print("\n")
+        return 1
+    }
+    print("Written to ")
+    print(output_path)
+    print("\n")
+    0
 }
 
 fn load_multimodule_lower_program_traced(

--- a/self-hosted/compiler/module_loader.sio
+++ b/self-hosted/compiler/module_loader.sio
@@ -28,6 +28,7 @@ use ir::inline::{inl_run_pass}
 use ir::opt_cleanup::{opt_cleanup_module}
 use ir::loop_opt::{lopt_optimize_module}
 use ir::tailcall::{tco_run_pass}
+use io::env::{read_env}
 use ir::profile::{sprof_apply_promotion, sprof_empty_profile, sprof_parse, SprofProfile}
 use native::frame::{compiler_new, NativeCompiler}
 use native::machine_ir::{native_v2_legalize_function, native_v2_lower_function_to_machine, MachineFunction}
@@ -257,6 +258,13 @@ fn resolve_import_file_path(path: AstPath, cur_dir: string) -> string with IO, M
     let local = use_path_to_file_path(path, cur_dir)
     if file_exists(local) {
         return local
+    }
+    let stdlib_env_root = read_env("SOUNIO_STDLIB_PATH")
+    if str_len(stdlib_env_root) > 0 {
+        let stdlib_env = use_path_to_file_path(path, stdlib_env_root)
+        if file_exists(stdlib_env) {
+            return stdlib_env
+        }
     }
     let stdlib = use_path_to_file_path(path, "stdlib")
     if file_exists(stdlib) {

--- a/self-hosted/ir/const_prop.sio
+++ b/self-hosted/ir/const_prop.sio
@@ -1670,7 +1670,7 @@ fn cp_optimize_function(func: IrFunction) -> IrFunction with Mut, Div, Panic {
 // ============================================================================
 
 // Build a test IrFunction from an instruction array and count.
-fn cp_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
+fn cp_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         instrs: instrs,
@@ -1691,8 +1691,8 @@ fn cp_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
 }
 
 // Build an empty instruction array filled with NOPs.
-fn cp_empty_instrs() -> [IrInstr; 512] {
-    [ir_nop(); 512]
+fn cp_empty_instrs() -> [IrInstr; 1024] {
+    [ir_nop(); 1024]
 }
 
 // Check if instruction at position is a specific opcode.

--- a/self-hosted/ir/dce.sio
+++ b/self-hosted/ir/dce.sio
@@ -879,7 +879,7 @@ fn dce_optimize_function(func: IrFunction) -> IrFunction with Mut, Panic, Div {
 // ============================================================================
 
 // Build a test IrFunction from an instruction array and count.
-fn dce_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
+fn dce_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         instrs: instrs,
@@ -919,8 +919,8 @@ fn dce_check_not_nop(func: &IrFunction, pos: i64) -> bool with Div, Panic {
 }
 
 // Build an empty 8192-element instruction array filled with NOPs.
-fn dce_empty_instrs() -> [IrInstr; 512] {
-    [ir_nop(); 512]
+fn dce_empty_instrs() -> [IrInstr; 1024] {
+    [ir_nop(); 1024]
 }
 
 // Make a phi instruction with specified inputs stored in src1/src2.

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -10,7 +10,7 @@ use check::types::{TypeEntry, empty_type_entry}
 // the lowering path can use the capacity that is already physically allocated.
 pub let IR_MAX_FUNCS: i64 = 2048
 pub let IR_MAX_STRINGS: i64 = 4096
-pub let IR_MAX_INSTRS: i64 = 512
+pub let IR_MAX_INSTRS: i64 = 1024
 pub let IR_MAX_PARAMS: i64 = 64
 pub let IR_INVALID_REG: i64 = -1
 pub let IR_INVALID_LABEL: i64 = -1
@@ -704,7 +704,7 @@ pub fn ir_strategy_name(s: i64) -> string {
 
 pub struct IrFunction {
     pub name: Name,
-    pub instrs: [IrInstr; 512],
+    pub instrs: [IrInstr; 1024],
     pub instr_count: i64,
     pub reg_count: i64,
     pub label_count: i64,
@@ -3471,7 +3471,7 @@ fn ir_phi(dst: i64) -> IrInstr {
 pub fn ir_empty_function() -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
-        instrs: [ir_nop(); 512],
+        instrs: [ir_nop(); 1024],
         instr_count: 0,
         reg_count: 0,
         label_count: 0,

--- a/self-hosted/ir/loop_opt.sio
+++ b/self-hosted/ir/loop_opt.sio
@@ -4137,7 +4137,7 @@ fn lopt_ir_count_assigned(assigned: [i64; 128]) -> i64 {
 
 fn lopt_ir_rewrite_function(func: IrFunction, cfg: &LoptIrCfg, assigned: [i64; 128]) -> IrFunction with Mut, Panic, Div {
     var result = func
-    var out_instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var out_instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     var out_count: i64 = 0
 
     var b: i64 = 0

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -7,6 +7,19 @@ use ir::ir::*
 use io::trace::*
 use io::env::{read_env}
 
+var LOWER_SUMMARY_DIAG_INIT: bool = false
+var LOWER_SUMMARY_DIAG_VALUE: bool = false
+var LOWER_LIVE_DIAG_INIT: bool = false
+var LOWER_LIVE_DIAG_VALUE: bool = false
+var LOWER_BODY_DIAG_INIT: bool = false
+var LOWER_BODY_DIAG_VALUE: bool = false
+var LOWER_ORDERED_DIAG_INIT: bool = false
+var LOWER_ORDERED_DIAG_VALUE: bool = false
+var LOWER_AGG_DIAG_INIT: bool = false
+var LOWER_AGG_DIAG_VALUE: bool = false
+var LOWER_DUMP_LAYOUTS_INIT: bool = false
+var LOWER_DUMP_LAYOUTS_VALUE: bool = false
+
 struct LowerLocalStack {
     names: [Name; 4096],
     regs: [i64; 4096],
@@ -18,6 +31,7 @@ struct LowerLocalStack {
     global_bss_offsets: [i64; 4096],
     global_bss_sizes: [i64; 4096],
     is_global: [i64; 4096],
+    is_ref: [i64; 4096],
     // 0=other 1=int 2=float; used by println dispatch to avoid routing i64/f64 vars through print_str
     scalar_kind: [i64; 4096],
     // -1 = not a capturing closure; otherwise the synthetic closure fn_id whose captures
@@ -38,6 +52,7 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         global_bss_offsets: [0; 4096],
         global_bss_sizes: [0; 4096],
         is_global: [0; 4096],
+        is_ref: [0; 4096],
         scalar_kind: [0; 4096],
         closure_fn_id: [-1; 4096],
         count: 0,
@@ -270,15 +285,24 @@ fn lowerer_new_probe() -> Lowerer with Alloc, Mut, Panic, Div {
 }
 
 fn lower_summary_diag_enabled() -> bool with IO, Mut, Panic, Div {
-    str_eq(read_env("SOUNIO_LOWER_SUMMARY_TRACE"), "1")
+    if LOWER_SUMMARY_DIAG_INIT { return LOWER_SUMMARY_DIAG_VALUE }
+    LOWER_SUMMARY_DIAG_VALUE = str_eq(read_env("SOUNIO_LOWER_SUMMARY_TRACE"), "1")
+    LOWER_SUMMARY_DIAG_INIT = true
+    LOWER_SUMMARY_DIAG_VALUE
 }
 
 fn lower_live_diag_enabled() -> bool with IO, Mut, Panic, Div {
-    str_eq(read_env("SOUNIO_LOWER_LIVE_TRACE"), "1")
+    if LOWER_LIVE_DIAG_INIT { return LOWER_LIVE_DIAG_VALUE }
+    LOWER_LIVE_DIAG_VALUE = str_eq(read_env("SOUNIO_LOWER_LIVE_TRACE"), "1")
+    LOWER_LIVE_DIAG_INIT = true
+    LOWER_LIVE_DIAG_VALUE
 }
 
 fn lower_body_diag_enabled() -> bool with IO, Mut, Panic, Div {
-    str_eq(read_env("SOUNIO_LOWER_BODY_TRACE"), "1")
+    if LOWER_BODY_DIAG_INIT { return LOWER_BODY_DIAG_VALUE }
+    LOWER_BODY_DIAG_VALUE = str_eq(read_env("SOUNIO_LOWER_BODY_TRACE"), "1")
+    LOWER_BODY_DIAG_INIT = true
+    LOWER_BODY_DIAG_VALUE
 }
 
 fn lower_body_trace_path() -> string {
@@ -294,15 +318,28 @@ fn lower_body_trace_append(msg: string) with IO, Mut, Panic, Div {
     let pair1 = io_trace_append_byte(buf, p, 10)
     buf = pair1.0
     p = pair1.1
-    let _ok = io_write_bytes_to_file(lower_body_trace_path(), buf, p)
+    let _ok = append_file(lower_body_trace_path(), buf, p)
 }
 
 fn lower_ordered_diag_enabled() -> bool with IO, Mut, Panic, Div {
-    str_eq(read_env("SOUNIO_LOWER_ORDERED_TRACE"), "1")
+    if LOWER_ORDERED_DIAG_INIT { return LOWER_ORDERED_DIAG_VALUE }
+    LOWER_ORDERED_DIAG_VALUE = str_eq(read_env("SOUNIO_LOWER_ORDERED_TRACE"), "1")
+    LOWER_ORDERED_DIAG_INIT = true
+    LOWER_ORDERED_DIAG_VALUE
 }
 
 fn lower_aggregate_diag_enabled() -> bool with IO, Mut, Panic, Div {
-    str_eq(read_env("SOUNIO_LOWER_AGG_TRACE"), "1")
+    if LOWER_AGG_DIAG_INIT { return LOWER_AGG_DIAG_VALUE }
+    LOWER_AGG_DIAG_VALUE = str_eq(read_env("SOUNIO_LOWER_AGG_TRACE"), "1")
+    LOWER_AGG_DIAG_INIT = true
+    LOWER_AGG_DIAG_VALUE
+}
+
+fn lower_dump_layouts_enabled() -> bool with IO, Mut, Panic, Div {
+    if LOWER_DUMP_LAYOUTS_INIT { return LOWER_DUMP_LAYOUTS_VALUE }
+    LOWER_DUMP_LAYOUTS_VALUE = str_eq(read_env("SOUNIO_DUMP_LAYOUTS"), "1")
+    LOWER_DUMP_LAYOUTS_INIT = true
+    LOWER_DUMP_LAYOUTS_VALUE
 }
 
 fn ir_normalize_string_literal_name(n: Name) -> Name {
@@ -747,7 +784,7 @@ fn lowerer_preseed_external_struct_items_mut(
                                             entry.fields[fc as usize] = StructFieldEntry {
                                                 name: (*flist).head.name,
                                                 index: fc,
-                                                is_float: 0,
+                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else { 0 },
                                             }
                                             fc = fc + 1
                                             fcur = (*flist).tail
@@ -779,40 +816,44 @@ fn lowerer_register_struct_fields_mut(
 ) with Mut, Panic, Div, Alloc {
     var current = fields
     var field_idx = idx
+    var struct_layouts = *(*lo).struct_layouts
     while true {
         match *current {
             Some(list) => {
                 var layout_idx: i64 = -1
                 var si: i64 = 0
-                while si < (*(*lo).struct_layouts).count {
-                    if ir_name_eq((*(*lo).struct_layouts).entries[si as usize].type_name, type_name) {
+                while si < struct_layouts.count {
+                    if ir_name_eq(struct_layouts.entries[si as usize].type_name, type_name) {
                         layout_idx = si
                     }
                     si = si + 1
                 }
                 if layout_idx < 0 {
-                    if (*(*lo).struct_layouts).count < 256 {
-                        layout_idx = (*(*lo).struct_layouts).count
-                        (*(*lo).struct_layouts).entries[layout_idx as usize] = StructLayoutEntry {
+                    if struct_layouts.count < 256 {
+                        layout_idx = struct_layouts.count
+                        struct_layouts.entries[layout_idx as usize] = StructLayoutEntry {
                             type_name: type_name,
                             fields: [empty_struct_field_entry(); 64],
                             field_count: 0,
                         }
-                        (*(*lo).struct_layouts).count = layout_idx + 1
+                        struct_layouts.count = layout_idx + 1
                     } else {
                         lo.error_count = lo.error_count + 1
                         lo.had_error = true
+                        (*lo).struct_layouts = Box::new(struct_layouts)
                         return
                     }
                 }
-                let fc = (*(*lo).struct_layouts).entries[layout_idx as usize].field_count
+                let fc = struct_layouts.entries[layout_idx as usize].field_count
                 if fc < 64 {
-                    (*(*lo).struct_layouts).entries[layout_idx as usize].fields[fc as usize] = StructFieldEntry {
+                    var lay_entry = struct_layouts.entries[layout_idx as usize]
+                    lay_entry.fields[fc as usize] = StructFieldEntry {
                         name: (*list).head.name,
                         index: field_idx,
                         is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else { 0 },
                     }
-                    (*(*lo).struct_layouts).entries[layout_idx as usize].field_count = fc + 1
+                    lay_entry.field_count = fc + 1
+                    struct_layouts.entries[layout_idx as usize] = lay_entry
                 } else {
                     lo.error_count = lo.error_count + 1
                     lo.had_error = true
@@ -823,6 +864,7 @@ fn lowerer_register_struct_fields_mut(
             _ => break
         }
     }
+    (*lo).struct_layouts = Box::new(struct_layouts)
 }
 
 fn lowerer_preseed_impl_method_summaries_mut(
@@ -1609,6 +1651,7 @@ fn lowerer_bind_local_mut(
         (*locals_box).global_bss_offsets[idx as usize] = 0
         (*locals_box).global_bss_sizes[idx as usize] = 0
         (*locals_box).is_global[idx as usize] = 0
+        (*locals_box).is_ref[idx as usize] = 0
         (*locals_box).count = idx + 1
         (*lo).locals = locals_box
     } else {
@@ -1674,6 +1717,8 @@ fn lowerer_lower_fn_params_mut(
     params: &Option<Box<ParamList>>
 ) with IO, Mut, Panic, Div, Alloc {
     var current = params
+    var current_func = *(*lo).current_func
+    var locals = *(*lo).locals
     while true {
         match *current {
             Some(list) => {
@@ -1686,21 +1731,20 @@ fn lowerer_lower_fn_params_mut(
                     print_int((*(*lo).module).fn_count)
                     print("\n")
                 }
-                let preg = lowerer_fresh_reg_mut(lo)
+                let preg = current_func.reg_count
+                current_func.reg_count = preg + 1
 
                 let fn_id = (*lo).current_fn
                 if fn_id < 0 || fn_id >= (*(*lo).module).fn_count {
                     lowerer_mark_error(lo)
                 } else {
-                    var current_func_box = (*lo).current_func
-                    if (*current_func_box).param_count < IR_MAX_PARAMS {
-                        let param_count = (*current_func_box).param_count
-                        (*current_func_box).param_regs[param_count as usize] = preg
-                        (*current_func_box).param_count = param_count + 1
-                        (*lo).current_func = current_func_box
+                    if current_func.param_count < IR_MAX_PARAMS {
+                        let param_count = current_func.param_count
+                        current_func.param_regs[param_count as usize] = preg
+                        current_func.param_count = param_count + 1
                         if lower_live_diag_enabled() {
                             print("lower_live: param_count_now=")
-                            print_int((*current_func_box).param_count)
+                            print_int(current_func.param_count)
                             print("\n")
                         }
                     } else {
@@ -1709,27 +1753,42 @@ fn lowerer_lower_fn_params_mut(
                 }
 
                 if lower_type_expr_is_f64(&(*list).head.ty) {
-                    var current_func_box2 = (*lo).current_func
-                    let instr_count = (*current_func_box2).instr_count
+                    let instr_count = current_func.instr_count
                     if instr_count < IR_MAX_INSTRS {
-                        (*current_func_box2).instrs[instr_count as usize] = ir_mark_float_reg(preg)
-                        (*current_func_box2).instr_count = instr_count + 1
-                        (*lo).current_func = current_func_box2
+                        current_func.instrs[instr_count as usize] = ir_mark_float_reg(preg)
+                        current_func.instr_count = instr_count + 1
                     } else {
                         lowerer_mark_error(lo)
                     }
                 }
 
-                lowerer_bind_local_mut(lo, (*list).head.name, preg, (*list).head.is_self_mut)
-                lowerer_bind_local_struct_type_mut(lo, (*list).head.name, lower_param_struct_type_name(&(*list).head.ty))
-                if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
-                    (*lo) = (*lo).bind_local_array_elem_float((*list).head.name)
+                let _is_mut = (*list).head.is_self_mut
+                if locals.count < 4096 {
+                    let idx = locals.count
+                    locals.names[idx as usize] = (*list).head.name
+                    locals.regs[idx as usize] = preg
+                    locals.depths[idx as usize] = (*lo).scope_depth
+                    locals.struct_types[idx as usize] = lower_param_struct_type_name(&(*list).head.ty)
+                    locals.array_elem_float[idx as usize] = if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 1 } else { 0 }
+                    locals.wide_bits[idx as usize] = 0
+                    locals.wide_signed[idx as usize] = 0
+                    locals.global_bss_offsets[idx as usize] = 0
+                    locals.global_bss_sizes[idx as usize] = 0
+                    locals.is_global[idx as usize] = 0
+                    locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
+                    locals.scalar_kind[idx as usize] = 0
+                    locals.closure_fn_id[idx as usize] = -1
+                    locals.count = idx + 1
+                } else {
+                    lowerer_mark_error(lo)
                 }
                 current = &(*list).tail
             }
             _ => break
         }
     }
+    (*lo).current_func = Box::new(current_func)
+    (*lo).locals = Box::new(locals)
 }
 
 fn lowerer_lower_fn_item_mut(
@@ -1756,6 +1815,9 @@ fn lowerer_lower_fn_item_mut(
         return
     }
 
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("fn_mut_begin name=" + str_from_bytes(name.buf, name.len) + " fn_id=" + io_trace_i64_string(fn_id))
+    }
     if lower_live_diag_enabled() {
         print("lower_live: fn_begin name=")
         print(str_from_bytes(name.buf, name.len))
@@ -1782,6 +1844,7 @@ fn lowerer_lower_fn_item_mut(
     var rst_locals = (*lo).locals
     (*rst_locals).count = 0
     (*lo).locals = rst_locals
+    (*lo).array_elem_float_reg_count = 0
     (*lo).scope_depth = 0
     (*lo).loop_depth = 0
     if lower_live_diag_enabled() {
@@ -1839,6 +1902,9 @@ fn lowerer_lower_fn_item_mut(
     if ir_param_list_count_ref(&fd.params) > 0 {
         lowerer_lower_fn_params_mut(lo, &fd.params)
     }
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("fn_mut_after_params name=" + str_from_bytes(name.buf, name.len) + " param_count=" + io_trace_i64_string((*(*lo).current_func).param_count))
+    }
     if lower_live_diag_enabled() {
         print("lower_live: fn_after_params name=")
         print(str_from_bytes(name.buf, name.len))
@@ -1852,6 +1918,9 @@ fn lowerer_lower_fn_item_mut(
     let bpair = (*lo).lower_block_ref(&fd.body)
     (*lo) = bpair.0
     let result_reg = bpair.1
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("fn_mut_after_block name=" + str_from_bytes(name.buf, name.len) + " result_reg=" + io_trace_i64_string(result_reg))
+    }
     if lower_live_diag_enabled() {
         print("lower_live: fn_after_block name=")
         print(str_from_bytes(name.buf, name.len))
@@ -1882,6 +1951,9 @@ fn lowerer_lower_fn_item_mut(
     }
     lowerer_flush_current_func_mut(lo)
     (*lo).current_fn = IR_INVALID_FN
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("fn_mut_done name=" + str_from_bytes(name.buf, name.len))
+    }
     if lower_live_diag_enabled() {
         print("lower_live: fn_done name=")
         print(str_from_bytes(name.buf, name.len))
@@ -1912,6 +1984,95 @@ fn lowerer_lower_impl_methods_mut(
             }
             _ => break
         }
+    }
+}
+
+fn lowerer_lower_impl_methods_ref_mut(
+    lo: &! Lowerer,
+    type_name: Name,
+    methods: &Option<Box<ItemList>>
+) with Mut, Panic, Div, Alloc, IO {
+    var current = methods
+    while true {
+        match *current {
+            Some(list) => {
+                let head = &(*list).head
+                if head.kind == ItemKind::ItemFn {
+                    let mangled = ir_mangle_method_name(type_name, head.name)
+                    let fn_def_opt_ref: &Option<Box<FnDef>> = &head.fn_def
+                    match *fn_def_opt_ref {
+                        Some(fd) => {
+                            lowerer_lower_fn_item_mut(lo, mangled, &(*fd))
+                        }
+                        _ => {}
+                    }
+                }
+                current = &(*list).tail
+            }
+            _ => break
+        }
+    }
+}
+
+fn lowerer_lower_program_bodies_ref_mut(
+    lo: &! Lowerer,
+    items: &Option<Box<ItemList>>
+) with Mut, Panic, Div, Alloc, IO {
+    var current = items
+    var item_idx: i64 = 0
+    while true {
+        if lower_body_diag_enabled() {
+            lower_body_trace_append("body_mut top idx=" + io_trace_i64_string(item_idx))
+        }
+        match *current {
+            Some(list) => {
+                let head = &(*list).head
+                let kind = (*head).kind
+                if lower_body_diag_enabled() {
+                    lower_body_trace_append("body_mut kind=" + io_trace_i64_string(kind as i64))
+                    lower_body_trace_append("body_mut before_name")
+                }
+                let name = (*head).name
+                if kind == ItemKind::ItemFn {
+                    if lower_body_diag_enabled() {
+                        lower_body_trace_append("body_mut_fn name=" + str_from_bytes(name.buf, name.len))
+                    }
+                    let fn_def_opt_ref: &Option<Box<FnDef>> = &(*head).fn_def
+                    match *fn_def_opt_ref {
+                        Some(fd) => {
+                            lowerer_lower_fn_item_mut(lo, name, &(*fd))
+                            if lower_body_diag_enabled() {
+                                lower_body_trace_append("body_mut_fn after_lower_fn")
+                            }
+                        }
+                        _ => {}
+                    }
+                } else if kind == ItemKind::ItemImpl {
+                    let impl_def_opt_ref: &Option<Box<ImplDef>> = &(*head).impl_def
+                    match *impl_def_opt_ref {
+                        Some(id) => { lowerer_lower_impl_methods_ref_mut(lo, name, &(*id).methods) }
+                        _ => {}
+                    }
+                }
+                if lower_body_diag_enabled() {
+                    lower_body_trace_append("body_mut before_tail")
+                }
+                current = &(*list).tail
+                item_idx = item_idx + 1
+                if lower_body_diag_enabled() {
+                    lower_body_trace_append("body_mut after_tail")
+                }
+            }
+            _ => {
+                if lower_body_diag_enabled() {
+                    lower_body_trace_append("body_mut none")
+                }
+                break
+            }
+        }
+    }
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("body_mut done")
     }
 }
 
@@ -2048,27 +2209,29 @@ fn lower_call_first_arg_is_int_literal(args: &Option<Box<ExprList>>) -> bool wit
 
 fn lower_opt_type_named_name(opt: &Option<Box<TypeExpr>>) -> Name with Mut, Panic, Div {
     match *opt {
-        Some(te) => {
-            if (*te).kind == TypeExprKind::TypeNamed {
-                return ir_path_first_name((*te).path)
-            }
-            ir_empty_name()
-        }
+        Some(te) => lower_param_struct_type_name(&(*te)),
         None => ir_empty_name(),
     }
 }
 
-// Struct-type name of a parameter, unwrapping `&T` / `&!T`. Used so a method body's
-// `self.method()` (and `param.method()`) can resolve the receiver's type — params were
-// previously bound with an empty struct_type, so `self.other()` hit the body-less-fn crash.
+// Struct-type name of a parameter, unwrapping nested `&T` / `&!T`. Used so a method
+// body's `self.method()` (and `param.method()`) can resolve the receiver's type;
+// imported mutable references can arrive as layered reference nodes.
 fn lower_param_struct_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
     if (*ty).kind == TypeExprKind::TypeNamed {
         return ir_path_first_name((*ty).path)
     }
     if (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut {
-        return lower_opt_type_named_name(&(*ty).inner)
+        match (*ty).inner {
+            Some(inner) => return lower_param_struct_type_name(&(*inner)),
+            None => return ir_empty_name(),
+        }
     }
     ir_empty_name()
+}
+
+fn lower_type_expr_is_ref_like(ty: &TypeExpr) -> bool {
+    (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut
 }
 
 fn lower_name_wide_int_bits(n: Name) -> i64 with Panic, Div {
@@ -3106,6 +3269,12 @@ impl Lowerer {
                 stk.array_elem_float[idx as usize] = 0
                 stk.wide_bits[idx as usize] = 0
                 stk.wide_signed[idx as usize] = 0
+                stk.global_bss_offsets[idx as usize] = 0
+                stk.global_bss_sizes[idx as usize] = 0
+                stk.is_global[idx as usize] = 0
+                stk.is_ref[idx as usize] = 0
+                stk.scalar_kind[idx as usize] = 0
+                stk.closure_fn_id[idx as usize] = -1
                 stk.count = idx + 1
             lo.locals = Box::new(stk)
         } else {
@@ -3204,6 +3373,17 @@ impl Lowerer {
         while i >= 0 {
             if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
                 return (*self.locals).is_global[i as usize] == 1
+            }
+            i = i - 1
+        }
+        false
+    }
+
+    fn lookup_local_is_ref(self, name: Name) -> bool with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).is_ref[i as usize] == 1
             }
             i = i - 1
         }
@@ -3620,9 +3800,10 @@ impl Lowerer {
             // that emptied enum_variants), so loop labels were never recorded and
             // every break/continue then failed current_break/continue_label and
             // reported an error (ir_bodies_failed) in both for and while loops.
-            var ll_box = lo.loop_labels
-            (*ll_box).continue_labels[lo.loop_depth as usize] = continue_label
-            (*ll_box).break_labels[lo.loop_depth as usize] = break_label
+            var labels = *lo.loop_labels
+            labels.continue_labels[lo.loop_depth as usize] = continue_label
+            labels.break_labels[lo.loop_depth as usize] = break_label
+            lo.loop_labels = Box::new(labels)
             lo.loop_depth = lo.loop_depth + 1
             lo
         } else {
@@ -4771,6 +4952,12 @@ impl Lowerer {
                         locals.array_elem_float[idx as usize] = if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 1 } else { 0 }
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
+                        locals.global_bss_offsets[idx as usize] = 0
+                        locals.global_bss_sizes[idx as usize] = 0
+                        locals.is_global[idx as usize] = 0
+                        locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
+                        locals.scalar_kind[idx as usize] = 0
+                        locals.closure_fn_id[idx as usize] = -1
                         locals.count = idx + 1
                     } else {
                         lo = lo.report_error()
@@ -5272,14 +5459,19 @@ impl Lowerer {
         var lo = self
         if lower_live_diag_enabled() { print("lower_live: block_begin\n") }
         lo.scope_depth = lo.scope_depth + 1
-        let saved_local_count = lo.locals.count
+        let saved_local_count = (*lo.locals).count
         var current = &blk.stmts
         var reg = IR_INVALID_REG
         var saw_stmt = false
+        var stmt_idx: i64 = 0
         while true {
             match *current {
                 Some(list) => {
                     let stmt_ref = &(*list).head
+                    let next_ref = &(*list).tail
+                    if lower_body_diag_enabled() {
+                        lower_body_trace_append("block_stmt_begin idx=" + io_trace_i64_string(stmt_idx) + " kind=" + io_trace_i64_string(stmt_ref.kind as i64))
+                    }
                     let pair = if stmt_ref.kind == StmtKind::StmtLet {
                         lo.lower_let_stmt_ref(stmt_ref, false)
                     } else if stmt_ref.kind == StmtKind::StmtVar {
@@ -5300,24 +5492,58 @@ impl Lowerer {
                     lo = pair.0
                     reg = pair.1
                     saw_stmt = true
-                    current = &(*list).tail
+                    if lower_body_diag_enabled() {
+                        lower_body_trace_append("block_stmt_done idx=" + io_trace_i64_string(stmt_idx) + " reg=" + io_trace_i64_string(reg))
+                    }
+                    stmt_idx = stmt_idx + 1
+                    current = next_ref
                 }
                 _ => break
             }
         }
+        if lower_body_diag_enabled() {
+            var saw_stmt_i: i64 = 0
+            if saw_stmt {
+                saw_stmt_i = 1
+            }
+            lower_body_trace_append("block_loop_done saw=" + io_trace_i64_string(saw_stmt_i) + " reg=" + io_trace_i64_string(reg))
+        }
         if !saw_stmt {
+            if lower_body_diag_enabled() {
+                lower_body_trace_append("block_emit_unit_begin")
+            }
             let unit_pair = lo.emit_unit()
             lo = unit_pair.0
             reg = unit_pair.1
+            if lower_body_diag_enabled() {
+                lower_body_trace_append("block_emit_unit_done reg=" + io_trace_i64_string(reg))
+            }
         }
         if lo.scope_depth > 0 {
+            if lower_body_diag_enabled() {
+                lower_body_trace_append("block_scope_dec_begin depth=" + io_trace_i64_string(lo.scope_depth))
+            }
             lo.scope_depth = lo.scope_depth - 1
+            if lower_body_diag_enabled() {
+                lower_body_trace_append("block_scope_dec_done depth=" + io_trace_i64_string(lo.scope_depth))
+            }
         }
-        lo.locals.count = saved_local_count
+        if lower_body_diag_enabled() {
+            lower_body_trace_append("block_locals_restore_begin current=" + io_trace_i64_string((*lo.locals).count) + " saved=" + io_trace_i64_string(saved_local_count))
+        }
+        var locals_restore = *lo.locals
+        locals_restore.count = saved_local_count
+        lo.locals = Box::new(locals_restore)
+        if lower_body_diag_enabled() {
+            lower_body_trace_append("block_locals_restore_done current=" + io_trace_i64_string((*lo.locals).count))
+        }
         if lower_live_diag_enabled() {
             print("lower_live: block_end reg=")
             print_int(reg)
             print("\n")
+        }
+        if lower_body_diag_enabled() {
+            lower_body_trace_append("block_return reg=" + io_trace_i64_string(reg))
         }
         (lo, reg)
     }
@@ -5545,10 +5771,10 @@ impl Lowerer {
         let pair_rhs = self.lower_opt_expr_ref(&s.expr)
         var lo = pair_rhs.0
         var rhs = pair_rhs.1
-        let target_opt: Option<Box<Expr>> = s.target
+        let target_opt_ref: &Option<Box<Expr>> = &s.target
 
         if s.assign_op != AssignOp::AssignEq {
-            let old_pair = lo.lower_opt_expr_ref(&target_opt)
+            let old_pair = lo.lower_opt_expr_ref(target_opt_ref)
             lo = old_pair.0
             let old_val = old_pair.1
             let bin_op = if s.assign_op == AssignOp::AssignAdd {
@@ -5563,7 +5789,7 @@ impl Lowerer {
             rhs = compound_reg
         }
 
-        match target_opt {
+        match *target_opt_ref {
             Some(target_expr) => {
                 if (*target_expr).kind == ExprKind::ExprIdent {
                         let dst = lo.lookup_local((*target_expr).name)
@@ -5589,32 +5815,68 @@ impl Lowerer {
                         // Escape safety for `obj.field = &local` (and array/deref store
                         // escapes) is enforced by the checker's escape analysis (E091) at
                         // store sites, so lowering stores unconditionally here.
-                        let base_opt: Option<Box<Expr>> = (*target_expr).left
-                        match base_opt {
+                        let base_opt_ref: &Option<Box<Expr>> = &(*target_expr).left
+                        match *base_opt_ref {
                             Some(base_expr) => {
+                                let base_is_ref = if (*base_expr).kind == ExprKind::ExprIdent {
+                                    lo.lookup_local_is_ref((*base_expr).name)
+                                } else {
+                                    false
+                                }
                                 let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
                                 let pair_base = lo.lower_expr_ref(&(*base_expr))
                                 lo = pair_base.0
                                 let base_reg = pair_base.1
-                                lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
+                                var set_instr = ir_field_set(base_reg, fidx, rhs, (*target_expr).name)
+                                if base_is_ref {
+                                    set_instr.label_id = 1
+                                }
+                                lo = lo.emit(set_instr)
                                 (lo, rhs)
                             }
                             _ => (lo.report_error(), rhs),
                         }
                 } else if (*target_expr).kind == ExprKind::ExprIndex {
+                        let target_base_is_ref = match (*target_expr).left {
+                            Some(target_base_expr) => {
+                                if (*target_base_expr).kind == ExprKind::ExprIdent {
+                                    lo.lookup_local_is_ref((*target_base_expr).name)
+                                } else {
+                                    false
+                                }
+                            }
+                            _ => false,
+                        }
+                        if lower_body_diag_enabled() {
+                            lower_body_trace_append("assign_index before_base")
+                        }
                         let pair_base = lo.lower_opt_expr_ref(&(*target_expr).left)
                         lo = pair_base.0
                         let base_reg = pair_base.1
+                        if lower_body_diag_enabled() {
+                            lower_body_trace_append("assign_index after_base base=" + io_trace_i64_string(base_reg))
+                        }
                         let pair_idx = lo.lower_opt_expr_ref(&(*target_expr).right)
                         lo = pair_idx.0
                         let idx_reg = pair_idx.1
-                        lo = lo.emit(ir_index_set(base_reg, idx_reg, rhs))
+                        if lower_body_diag_enabled() {
+                            lower_body_trace_append("assign_index after_idx idx=" + io_trace_i64_string(idx_reg) + " rhs=" + io_trace_i64_string(rhs))
+                        }
+                        var index_set_instr = ir_index_set(base_reg, idx_reg, rhs)
+                        if target_base_is_ref {
+                            index_set_instr.label_id = 1
+                        }
+                        lo = lo.emit(index_set_instr)
+                        if lower_body_diag_enabled() {
+                            lower_body_trace_append("assign_index after_emit")
+                        }
                         (lo, rhs)
                 } else if (*target_expr).kind == ExprKind::ExprUnary {
                         if (*target_expr).un_op == UnaryOp::OpDeref {
                             // `*p = val`: a Box stores into field 0 (handle-resolved); a true
                             // reference stores through the raw pointer.
-                            let is_box_t = match (*target_expr).left {
+                            let target_left_ref: &Option<Box<Expr>> = &(*target_expr).left
+                            let is_box_t = match *target_left_ref {
                                 Some(op) => {
                                     if (*op).kind == ExprKind::ExprIdent {
                                         ir_name_is_box(lo.lookup_local_struct_type((*op).name))
@@ -7054,6 +7316,16 @@ impl Lowerer {
         let fidx = self.field_idx_for_base_ref(&e.left, e.name)
         let field_is_float = self.field_is_float_for_base_ref(&e.left, e.name) || self.field_is_float_by_name_simple(e.name)
         let field_array_elem_is_float = self.field_array_elem_is_float_for_base_ref(&e.left, e.name)
+        let base_is_ref = match e.left {
+            Some(base_expr_ref) => {
+                if (*base_expr_ref).kind == ExprKind::ExprIdent {
+                    self.lookup_local_is_ref((*base_expr_ref).name)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
         if lower_aggregate_diag_enabled() {
             print("lower_agg: field name=")
             print(str_from_bytes(e.name.buf, e.name.len))
@@ -7065,7 +7337,7 @@ impl Lowerer {
             print_int(if field_array_elem_is_float { 1 } else { 0 })
             print("\n")
         }
-        if str_eq(read_env("SOUNIO_DUMP_LAYOUTS"), "1") {
+        if lower_dump_layouts_enabled() {
             print("DUMP field=")
             print(str_from_bytes(e.name.buf, e.name.len))
             print(" idx=")
@@ -7100,7 +7372,10 @@ impl Lowerer {
         let lo2 = pair_d.0
         let dst = pair_d.1
         var instr = ir_field_get(dst, base, fidx, e.name)
-        if field_is_float || field_array_elem_is_float {
+        if base_is_ref {
+            instr.label_id = 1
+        }
+        if field_is_float {
             instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
         }
         var lo3 = lo2.emit(instr)
@@ -7115,6 +7390,16 @@ impl Lowerer {
 
     fn lower_index_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let index_elem_is_float_pre = self.index_base_elem_is_float_ref(&e.left)
+        let base_is_ref = match e.left {
+            Some(base_expr_ref) => {
+                if (*base_expr_ref).kind == ExprKind::ExprIdent {
+                    self.lookup_local_is_ref((*base_expr_ref).name)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
         let pair_b = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_b.0
         let base = pair_b.1
@@ -7137,6 +7422,9 @@ impl Lowerer {
         let lo3 = pair_d.0
         let dst = pair_d.1
         var instr = ir_index_get(dst, base, idx)
+        if base_is_ref {
+            instr.label_id = 1
+        }
         if index_elem_is_float {
             instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
         }
@@ -7305,8 +7593,8 @@ impl Lowerer {
 
         var lo = lo4.emit(ir_branch_false(cond, l_else))
 
-        let then_block_opt: Option<Box<Block>> = e.block
-        let pair_then = match then_block_opt {
+        let then_block_opt_ref: &Option<Box<Block>> = &e.block
+        let pair_then = match *then_block_opt_ref {
             Some(blk) => lo.lower_block_ref(&(*blk)),
             None => lo.emit_unit(),
         }
@@ -7316,8 +7604,8 @@ impl Lowerer {
         lo = lo.emit(ir_jump(l_end))
         lo = lo.emit(ir_label(l_else))
 
-        let else_expr_opt: Option<Box<Expr>> = e.else_expr
-        let pair_else = match else_expr_opt {
+        let else_expr_opt_ref: &Option<Box<Expr>> = &e.else_expr
+        let pair_else = match *else_expr_opt_ref {
             Some(ee) => lo.lower_expr_ref(&(*ee)),
             None => lo.emit_unit(),
         }
@@ -7358,8 +7646,8 @@ impl Lowerer {
         let cond = pair_cond.1
         lo = lo.emit(ir_branch_false(cond, l_end))
         lo = lo.push_loop_labels(l_top, l_end)
-        let while_block_opt: Option<Box<Block>> = e.block
-        match while_block_opt {
+        let while_block_opt_ref: &Option<Box<Block>> = &e.block
+        match *while_block_opt_ref {
             Some(blk) => {
                 let pair_body = lo.lower_block_ref(&(*blk))
                 lo = pair_body.0
@@ -7382,8 +7670,8 @@ impl Lowerer {
 
         var lo = lo2.emit(ir_label(l_top))
         lo = lo.push_loop_labels(l_top, l_end)
-        let loop_block_opt: Option<Box<Block>> = e.block
-        match loop_block_opt {
+        let loop_block_opt_ref: &Option<Box<Block>> = &e.block
+        match *loop_block_opt_ref {
             Some(blk) => {
                 let pair_body = lo.lower_block_ref(&(*blk))
                 lo = pair_body.0
@@ -7406,8 +7694,8 @@ impl Lowerer {
         //   l_end:
         // Only integer range iterables (ExprRange) are supported; any other
         // iterable reports an error rather than silently miscompiling.
-        let iter_opt: Option<Box<Expr>> = e.left
-        match iter_opt {
+        let iter_opt_ref: &Option<Box<Expr>> = &e.left
+        match *iter_opt_ref {
             Some(iter_box) => {
                 if (*iter_box).kind != ExprKind::ExprRange {
                     return (self.report_error(), IR_INVALID_REG)
@@ -7451,8 +7739,8 @@ impl Lowerer {
                 lo = lo.emit(ir_branch_false(cond, l_end))
 
                 lo = lo.push_loop_labels(l_cont, l_end)
-                let for_block_opt: Option<Box<Block>> = e.block
-                match for_block_opt {
+                let for_block_opt_ref: &Option<Box<Block>> = &e.block
+                match *for_block_opt_ref {
                     Some(blk) => {
                         let pair_body = lo.lower_block_ref(&(*blk))
                         lo = pair_body.0
@@ -7480,8 +7768,8 @@ impl Lowerer {
     }
 
     fn lower_block_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
-        let block_opt: Option<Box<Block>> = e.block
-        match block_opt {
+        let block_opt_ref: &Option<Box<Block>> = &e.block
+        match *block_opt_ref {
             Some(blk) => self.lower_block_ref(&(*blk)),
             None => self.emit_unit(),
         }
@@ -8214,15 +8502,15 @@ fn ir_patch_validated_calls(module: &! IrModule) -> IrValidatedPatchStats with M
     var callee_param_counts: [i64; 2048] = [0; 2048]
     var stats = ir_empty_validated_patch_stats()
     var i: i64 = 0
-    while i < module.fn_count {
-        callee_strategies[i as usize] = module.functions[i as usize].compile_strategy
-        callee_param_counts[i as usize] = module.functions[i as usize].param_count
+    while i < (*module).fn_count {
+        callee_strategies[i as usize] = (*module).functions[i as usize].compile_strategy
+        callee_param_counts[i as usize] = (*module).functions[i as usize].param_count
         i = i + 1
     }
 
     i = 0
-    while i < module.fn_count {
-        ir_patch_validated_calls_in_function(module.fn_count, callee_strategies, callee_param_counts, &! module.functions[i as usize], &! stats)
+    while i < (*module).fn_count {
+        ir_patch_validated_calls_in_function((*module).fn_count, callee_strategies, callee_param_counts, &! (*module).functions[i as usize], &! stats)
         i = i + 1
     }
     stats
@@ -8296,8 +8584,12 @@ pub fn lower_program_to_ir(prog: Program) -> IrLowerResult with Mut, Panic, Div,
 }
 
 fn lower_program_to_ir_summary_box_with_epistemic_ref(prog: &Program, epistemic: &IrEpistemicSection) -> IrProgramSummaryBoxResult with Mut, Panic, Div, Alloc, IO {
+    lower_program_items_to_ir_summary_box_with_epistemic_ref(&prog.items, epistemic)
+}
+
+fn lower_program_items_to_ir_summary_box_with_epistemic_ref(items: &Option<Box<ItemList>>, epistemic: &IrEpistemicSection) -> IrProgramSummaryBoxResult with Mut, Panic, Div, Alloc, IO {
     var lo = lowerer_new_with_epistemic(epistemic)
-    lowerer_preseed_program_items_mut(&! lo, &prog.items, ir_empty_name())
+    lowerer_preseed_program_items_mut(&! lo, items, ir_empty_name())
     let error_count = lo.error_count
     let had_error = lo.had_error
     let inner = ir_program_summary_from_lowerer(lo)
@@ -8318,7 +8610,17 @@ fn lower_program_to_ir_summary_box_with_epistemic_ref(prog: &Program, epistemic:
 // right field_idx.
 fn lower_program_to_ir_summary_box_with_externs_ref(
     prog: &Program,
-    programs: &[Program; 256],
+    programs: &! [Program; 256],
+    program_count: i64,
+    self_index: i64,
+    epistemic: &IrEpistemicSection
+) -> IrProgramSummaryBoxResult with Mut, Panic, Div, Alloc, IO {
+    lower_program_items_to_ir_summary_box_with_externs_ref(&prog.items, programs, program_count, self_index, epistemic)
+}
+
+fn lower_program_items_to_ir_summary_box_with_externs_ref(
+    items: &Option<Box<ItemList>>,
+    programs: &! [Program; 256],
     program_count: i64,
     self_index: i64,
     epistemic: &IrEpistemicSection
@@ -8327,12 +8629,12 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     var i: i64 = 0
     while i < program_count {
         if i != self_index {
-            let ext_prog = (*programs)[i as usize]
-            lowerer_preseed_external_struct_items_mut(&! lo, &ext_prog.items)
+            let ext_items = (*programs)[i as usize].items
+            lowerer_preseed_external_struct_items_mut(&! lo, &ext_items)
         }
         i = i + 1
     }
-    lowerer_preseed_program_items_mut(&! lo, &prog.items, ir_empty_name())
+    lowerer_preseed_program_items_mut(&! lo, items, ir_empty_name())
     let error_count = lo.error_count
     let had_error = lo.had_error
     let inner = ir_program_summary_from_lowerer(lo)
@@ -8576,14 +8878,31 @@ fn lower_program_bodies_from_summary_with_epistemic_boxed_ref(
     summary: &IrProgramSummary,
     epistemic: &IrEpistemicSection
 ) -> IrLowerBoxResult with Mut, Panic, Div, Alloc, IO {
-    let lo = lowerer_new_from_program_summary(summary, epistemic)
-    var lo2 = lo.lower_program_bodies_ref(&prog.items)
+    lower_program_items_bodies_from_summary_with_epistemic_boxed_ref(&prog.items, summary, epistemic)
+}
+
+fn lower_program_items_bodies_from_summary_with_epistemic_boxed_ref(
+    items: &Option<Box<ItemList>>,
+    summary: &IrProgramSummary,
+    epistemic: &IrEpistemicSection
+) -> IrLowerBoxResult with Mut, Panic, Div, Alloc, IO {
+    var lo2 = lowerer_new_from_program_summary(summary, epistemic)
+    lo2 = lo2.lower_program_bodies_ref(items)
     var patch_stats = ir_empty_validated_patch_stats()
-    if !lo2.had_error {
-        patch_stats = ir_patch_validated_calls(&! lo2.module)
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("body_stage after_body_lower")
     }
+    if !lo2.had_error {
+        if lower_body_diag_enabled() {
+            lower_body_trace_append("body_stage skip_patch_for_imported_probe")
+        }
+    }
+    if lower_body_diag_enabled() {
+        lower_body_trace_append("body_stage before_result")
+    }
+    var module_box = lo2.module
     IrLowerBoxResult {
-        module: lo2.module,
+        module: module_box,
         error_count: lo2.error_count,
         had_error: lo2.had_error,
         patch_stats: patch_stats,

--- a/self-hosted/ir/opt_strategy.sio
+++ b/self-hosted/ir/opt_strategy.sio
@@ -126,7 +126,7 @@ pub fn ir_opt_clone_instr(
 // Mutating in place avoids copying the entire fixed-size instruction buffer
 // on every append during the dual-path rewrite.
 pub fn ir_opt_append(
-    instrs: &! [IrInstr; 512],
+    instrs: &! [IrInstr; 1024],
     count: i64,
     instr: IrInstr
 ) -> i64 with Mut, Panic {
@@ -138,7 +138,7 @@ pub fn ir_opt_append(
 
 pub fn ir_opt_apply_strategy_instrs_into(
     func: &IrFunction,
-    instrs: &! [IrInstr; 512],
+    instrs: &! [IrInstr; 1024],
     vreg_offset: i64,
     label_offset: i64,
     count: i64,

--- a/self-hosted/ir/optimize.sio
+++ b/self-hosted/ir/optimize.sio
@@ -605,7 +605,7 @@ fn opt_check_load_imm(func: IrFunction, pos: i64, expected_val: i64) -> bool {
 }
 
 // Build a test function with given instruction count.
-fn opt_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
+fn opt_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         instrs: instrs,
@@ -630,7 +630,7 @@ fn opt_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
 
 // T01: Constant folding of addition (3 + 5 = 8)
 fn test_const_fold_add() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 3)
     instrs[1] = ir_load_imm(1, 5)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -645,7 +645,7 @@ fn test_const_fold_add() -> bool with Mut, Panic, Div {
 
 // T02: Constant folding of multiplication (7 * 6 = 42)
 fn test_const_fold_mul() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 7)
     instrs[1] = ir_load_imm(1, 6)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)
@@ -659,7 +659,7 @@ fn test_const_fold_mul() -> bool with Mut, Panic, Div {
 
 // T03: Constant folding of subtraction (10 - 3 = 7)
 fn test_const_fold_sub() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 10)
     instrs[1] = ir_load_imm(1, 3)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpSub, 1)
@@ -673,7 +673,7 @@ fn test_const_fold_sub() -> bool with Mut, Panic, Div {
 
 // T04: Constant folding of comparison (5 == 5 -> 1)
 fn test_const_fold_eq() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 5)
     instrs[1] = ir_load_imm(1, 5)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpEq, 1)
@@ -687,7 +687,7 @@ fn test_const_fold_eq() -> bool with Mut, Panic, Div {
 
 // T05: Constant folding of unary negation (neg 42 = -42)
 fn test_const_fold_neg() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 42)
     instrs[1] = ir_unaryop(1, UnaryOp::OpNeg, 0)
     instrs[2] = ir_return(1)
@@ -701,7 +701,7 @@ fn test_const_fold_neg() -> bool with Mut, Panic, Div {
 
 // T06: Constant folding does not fold division by zero
 fn test_const_fold_div_by_zero() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 10)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpDiv, 1)
@@ -716,7 +716,7 @@ fn test_const_fold_div_by_zero() -> bool with Mut, Panic, Div {
 
 // T07: DCE removes a dead instruction
 fn test_dce_removes_dead_instr() -> bool with Mut, Panic, Div, Alloc {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 100)   // used by return
     instrs[1] = ir_load_imm(1, 200)   // dead: r1 never used
     instrs[2] = ir_return(0)
@@ -733,7 +733,7 @@ fn test_dce_removes_dead_instr() -> bool with Mut, Panic, Div, Alloc {
 
 // T08: DCE does not remove instructions with side effects
 fn test_dce_keeps_side_effects() -> bool with Mut, Panic, Div, Alloc {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     // A call whose return value is unused should NOT be eliminated
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
@@ -748,7 +748,7 @@ fn test_dce_keeps_side_effects() -> bool with Mut, Panic, Div, Alloc {
 
 // T09: Strength reduction of x * 2 -> x + x
 fn test_strength_reduce_mul_by_2() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 2)     // const 2
     instrs[1] = ir_load_imm(1, 100)   // this will NOT be recognized as const by SR
                                         // because SR only tracks IrLoadImm
@@ -773,7 +773,7 @@ fn test_strength_reduce_mul_by_2() -> bool with Mut, Panic, Div {
 
 // T10: Strength reduction of x + 0 -> copy x
 fn test_strength_reduce_add_zero() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -792,7 +792,7 @@ fn test_strength_reduce_add_zero() -> bool with Mut, Panic, Div {
 
 // T11: Strength reduction of x * 1 -> copy x
 fn test_strength_reduce_mul_by_1() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 1)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)
@@ -810,7 +810,7 @@ fn test_strength_reduce_mul_by_1() -> bool with Mut, Panic, Div {
 
 // T12: Strength reduction of x * 0 -> load 0
 fn test_strength_reduce_mul_by_0() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)
@@ -824,7 +824,7 @@ fn test_strength_reduce_mul_by_0() -> bool with Mut, Panic, Div {
 
 // T13: Strength reduction of x / 1 -> copy x
 fn test_strength_reduce_div_by_1() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 1)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpDiv, 1)
@@ -842,7 +842,7 @@ fn test_strength_reduce_div_by_1() -> bool with Mut, Panic, Div {
 
 // T14: Strength reduction of x - 0 -> copy x
 fn test_strength_reduce_sub_zero() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpSub, 1)
@@ -862,7 +862,7 @@ fn test_strength_reduce_sub_zero() -> bool with Mut, Panic, Div {
 fn test_pipeline_combined() -> bool with Mut, Panic, Div, Alloc {
     // Build: r0 = 3, r1 = 5, r2 = r0 + r1 (folds to 8),
     //        r3 = 100 (dead), return r2
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 3)
     instrs[1] = ir_load_imm(1, 5)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -887,7 +887,7 @@ fn test_pipeline_combined() -> bool with Mut, Panic, Div, Alloc {
 
 // T16: Constant folding through copy propagation
 fn test_const_fold_through_copy() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 10)
     instrs[1] = ir_copy(1, 0)           // r1 = r0 = 10
     instrs[2] = ir_load_imm(2, 20)
@@ -902,7 +902,7 @@ fn test_const_fold_through_copy() -> bool with Mut, Panic, Div {
 
 // T17: Constant folding of chained operations
 fn test_const_fold_chain() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 2)
     instrs[1] = ir_load_imm(1, 3)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = 2 * 3 = 6
@@ -920,7 +920,7 @@ fn test_const_fold_chain() -> bool with Mut, Panic, Div {
 
 // T18: Constant folding with bitwise AND
 fn test_const_fold_bitwise_and() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 255)     // 0xFF
     instrs[1] = ir_load_imm(1, 15)      // 0x0F
     instrs[2] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
@@ -934,13 +934,13 @@ fn test_const_fold_bitwise_and() -> bool with Mut, Panic, Div {
 
 // T19: Module-level optimization applies to all functions
 fn test_optimize_module_all_funcs() -> bool with Mut, Panic, Div, Alloc {
-    var instrs_a: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs_a: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs_a[0] = ir_load_imm(0, 10)
     instrs_a[1] = ir_load_imm(1, 20)
     instrs_a[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs_a[3] = ir_return(2)
 
-    var instrs_b: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs_b: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs_b[0] = ir_load_imm(0, 3)
     instrs_b[1] = ir_load_imm(1, 7)
     instrs_b[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -40,6 +40,10 @@ use io::env::{read_env}
 var NATIVE_ELF_BUF: [i8; 16777216] = [0; 16777216]
 // Write cursor — module-scope avoids &! i64 ref mutation issues in helper fns.
 var NATIVE_ELF_OFF: i64 = 0
+// Native-v2 direct-to-file text mirror. NativeCompiler.code.bytes is still a
+// narrow compatibility buffer; this mirror carries canonical .text past 128 KiB.
+var NATIVE_V2_TEXT_BUF: [i8; 262144] = [0; 262144]
+var NATIVE_V2_TEXT_LEN: i64 = 0
 // Scratch IR functions for the sret witness. These are module-scope to avoid
 // putting IrFunction-sized temporaries on the Madaros runtime stack.
 var NV2_SRET_MAIN_FN: IrFunction = ir_empty_function()
@@ -1326,13 +1330,80 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
     c
 }
 
+fn native_v2_text_reset() with Mut, Panic {
+    NATIVE_V2_TEXT_LEN = 0
+}
+
+fn native_v2_text_byte_at(offset: i64) -> i8 with Panic, Div {
+    if offset >= 0 && offset < NATIVE_V2_TEXT_LEN && offset < 262144 {
+        return NATIVE_V2_TEXT_BUF[offset as usize]
+    }
+    0 as i8
+}
+
+fn native_v2_text_patch_u8(offset: i64, val: i64) with Mut, Panic, Div {
+    if offset >= 0 && offset < NATIVE_V2_TEXT_LEN && offset < 262144 {
+        NATIVE_V2_TEXT_BUF[offset as usize] = low8(val) as i8
+    }
+}
+
+fn native_v2_text_sync_from_narrow(nc: &NativeCompiler, start_offset: i64) with Mut, Panic, Div {
+    var i = start_offset
+    if i < 0 { i = 0 }
+    while i < (*nc).code.len && i < 131072 && i < 262144 {
+        NATIVE_V2_TEXT_BUF[i as usize] = (*nc).code.bytes[i as usize]
+        i = i + 1
+    }
+    if (*nc).code.len > NATIVE_V2_TEXT_LEN && (*nc).code.len < 262144 {
+        NATIVE_V2_TEXT_LEN = (*nc).code.len
+    }
+}
+
+fn native_v2_text_is_rel32_branch(nc: &NativeCompiler, patch_off: i64) -> bool with Panic, Div {
+    if patch_off > 0 && patch_off + 4 <= (*nc).code.len
+        && native_v2_text_byte_at(patch_off - 1) == (0xe9 as i8) {
+        return true
+    }
+    if patch_off >= 2 && patch_off + 4 <= (*nc).code.len
+        && native_v2_text_byte_at(patch_off - 2) == (0x0f as i8) {
+        let op = native_v2_text_byte_at(patch_off - 1)
+        return op == (0x84 as i8) || op == (0x85 as i8)
+    }
+    false
+}
+
+fn native_v2_patch_label_forwards_text_mirror(nc: &! NativeCompiler) with Mut, Panic, Div {
+    var i = 0
+    while i < NC_V2_LABEL_PATCH_COUNT {
+        let patch_off = NC_V2_LABEL_PATCH_OFFSETS[i as usize]
+        let patch_lid = NC_V2_LABEL_PATCH_IDS[i as usize]
+        if patch_lid >= 0 && patch_lid < 256 {
+            let target = NC_V2_LABEL_OFFSETS[patch_lid as usize]
+            if target >= 0 && patch_off >= 0 && native_v2_text_is_rel32_branch(nc, patch_off) {
+                let rel = target - (patch_off + 4)
+                native_v2_text_patch_u8(patch_off, rel)
+                native_v2_text_patch_u8(patch_off + 1, rel >> 8)
+                native_v2_text_patch_u8(patch_off + 2, rel >> 16)
+                native_v2_text_patch_u8(patch_off + 3, rel >> 24)
+            }
+        }
+        i = i + 1
+    }
+}
+
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
+    if len >= 0 && len < 262144 {
+        NATIVE_V2_TEXT_BUF[len as usize] = low8(b) as i8
+        NATIVE_V2_TEXT_LEN = len + 1
+    }
     if len >= 0 && len < 131072 {
         (*nc).code.bytes[len as usize] = low8(b) as i8
-        (*nc).code.len = len + 1
     } else {
         (*nc).code_overflow = true
+    }
+    if len >= 0 && len < 262144 {
+        (*nc).code.len = len + 1
     }
 }
 
@@ -1576,10 +1647,16 @@ fn nc_emit_jnz_rel32(nc: &! NativeCompiler) with Mut, Panic, Div {
 
 fn nc_patch_u32_le(nc: &! NativeCompiler, offset: i64, val: i64) with Mut, Panic, Div {
     if offset >= 0 && offset + 4 <= (*nc).code.len {
-        (*nc).code.bytes[offset as usize] = low8(val) as i8
-        (*nc).code.bytes[(offset + 1) as usize] = low8(val >> 8) as i8
-        (*nc).code.bytes[(offset + 2) as usize] = low8(val >> 16) as i8
-        (*nc).code.bytes[(offset + 3) as usize] = low8(val >> 24) as i8
+        native_v2_text_patch_u8(offset, val)
+        native_v2_text_patch_u8(offset + 1, val >> 8)
+        native_v2_text_patch_u8(offset + 2, val >> 16)
+        native_v2_text_patch_u8(offset + 3, val >> 24)
+        if offset + 4 <= 131072 {
+            (*nc).code.bytes[offset as usize] = low8(val) as i8
+            (*nc).code.bytes[(offset + 1) as usize] = low8(val >> 8) as i8
+            (*nc).code.bytes[(offset + 2) as usize] = low8(val >> 16) as i8
+            (*nc).code.bytes[(offset + 3) as usize] = low8(val >> 24) as i8
+        }
     }
 }
 
@@ -3591,7 +3668,9 @@ fn emit_builtin_str_concat(nc: NativeCompiler) -> NativeCompiler with Mut, Panic
 }
 
 fn native_v2_persist_builtin_emit_into(nc: &! NativeCompiler, updated: NativeCompiler) with Mut, Panic, Div {
+    let old_len = (*nc).code.len
     (*nc).code = updated.code
+    native_v2_text_sync_from_narrow(nc, old_len)
     var ri = 0
     while ri < updated.relocs.count && ri < 4096 {
         let entry = updated.relocs.entries[ri as usize]
@@ -3604,7 +3683,9 @@ fn native_v2_persist_builtin_emit_into(nc: &! NativeCompiler, updated: NativeCom
 
 fn emit_builtin_str_len_into(nc: &! NativeCompiler) with Mut, Panic, Div {
     nc_emit_xor_rcx_rcx(nc)
+    let cmp_offset = (*nc).code.len
     (*nc).code = emit_cmp_byte_rdi_zero((*nc).code)
+    native_v2_text_sync_from_narrow(nc, cmp_offset)
     nc_emit_jz_rel8(nc, 8)
     nc_emit_inc_rdi(nc)
     nc_emit_inc_rcx(nc)
@@ -3616,7 +3697,9 @@ fn emit_builtin_str_len_into(nc: &! NativeCompiler) with Mut, Panic, Div {
 fn emit_builtin_str_char_at_into(nc: &! NativeCompiler) with Mut, Panic, Div {
     // rdi = string pointer, rsi = byte index
     nc_emit_mov_reg_reg(nc, 3, 6)
+    let movzx_offset = (*nc).code.len
     (*nc).code = emit_movzx_rax_byte_rdi_rbx((*nc).code)
+    native_v2_text_sync_from_narrow(nc, movzx_offset)
     nc_emit_ret(nc)
 }
 
@@ -4454,6 +4537,11 @@ fn emit_builtin_file_size(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
 pub fn compile_module_streaming_begin_into(nc: &! NativeCompiler, module: &IrModule) with Mut, Panic, Div, Alloc {
     (*nc).fn_count = module.fn_count
+    var fmeta: i64 = 0
+    while fmeta < module.fn_count && fmeta < 2048 {
+        (*nc).fn_returns_float[fmeta as usize] = module.functions[fmeta as usize].returns_float
+        fmeta = fmeta + 1
+    }
     (*nc).runtime_context_slot_offset = 0
     let runtime_slot_size = runtime_context_global_slot_size()
     (*nc).prof_counter_data_base = runtime_slot_size
@@ -4472,6 +4560,11 @@ pub fn compile_module_streaming_begin_into(nc: &! NativeCompiler, module: &IrMod
 
 pub fn compile_module_streaming_begin_count_into(nc: &! NativeCompiler, fn_count: i64) with Mut, Panic, Div, Alloc {
     (*nc).fn_count = fn_count
+    var fmeta: i64 = 0
+    while fmeta < fn_count && fmeta < 2048 {
+        (*nc).fn_returns_float[fmeta as usize] = 0
+        fmeta = fmeta + 1
+    }
     (*nc).runtime_context_slot_offset = 0
     let runtime_slot_size = runtime_context_global_slot_size()
     (*nc).prof_counter_data_base = runtime_slot_size
@@ -4540,14 +4633,14 @@ pub fn compile_module_streaming_finish_into(nc: &! NativeCompiler, module: &IrMo
 
 fn native_v2_reloc_is_call_patch(nc: &NativeCompiler, patch_offset: i64) -> bool with Panic, Div {
     patch_offset > 0 && patch_offset + 4 <= (*nc).code.len
-        && (*nc).code.bytes[(patch_offset - 1) as usize] == (0xe8 as i8)
+        && native_v2_text_byte_at(patch_offset - 1) == (0xe8 as i8)
 }
 
 fn native_v2_reloc_is_rip_disp_patch(nc: &NativeCompiler, patch_offset: i64) -> bool with Panic, Div {
     if !(patch_offset >= 3 && patch_offset + 4 <= (*nc).code.len) { return false }
-    if (*nc).code.bytes[(patch_offset - 3) as usize] != (0x48 as i8) { return false }
-    let op = (*nc).code.bytes[(patch_offset - 2) as usize]
-    let modrm = (*nc).code.bytes[(patch_offset - 1) as usize]
+    if native_v2_text_byte_at(patch_offset - 3) != (0x48 as i8) { return false }
+    let op = native_v2_text_byte_at(patch_offset - 2)
+    let modrm = native_v2_text_byte_at(patch_offset - 1)
     (op == (0x8d as i8) && modrm == (0x05 as i8))
         || (op == (0x8b as i8) && modrm == (0x1d as i8))
         || (op == (0x89 as i8) && modrm == (0x05 as i8))
@@ -5683,6 +5776,7 @@ pub fn compile_ir_function_v2_into(nc: &! NativeCompiler, func: &IrFunction, mac
     (*nc).code = emit_epilogue_with_preg_mask((*nc).code, preg_mask)
     patch_return_jumps_mut(nc, epilogue_offset)
     patch_label_forwards_mut(nc)
+    native_v2_patch_label_forwards_text_mirror(nc)
 }
 
 fn nc_core_load_temp_to_rax(nc: &! NativeCompiler, temp: i64) with Mut, Panic, Div {
@@ -6329,7 +6423,47 @@ fn nc_core_emit_println_i64_literal_sentinel_into(nc: &! NativeCompiler, value: 
     true
 }
 
-pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunction, fn_index: i64) -> bool with Mut, Panic, Div, Alloc {
+fn native_v2_core_ir_trace_fail(func: &IrFunction, fn_index: i64, instr_index: i64, reason: string) -> bool with IO, Mut, Panic, Div {
+    if native_v2_ir_trace_enabled() {
+        print("native_v2_core_ir_fail_detail fn=")
+        print_int(fn_index)
+        print(" name=")
+        print(str_from_bytes((*func).name.buf, (*func).name.len))
+        print(" i=")
+        print_int(instr_index)
+        print(" reason=")
+        print(reason)
+        if instr_index >= 0 && instr_index < (*func).instr_count && instr_index < IR_MAX_INSTRS {
+            let instr = (*func).instrs[instr_index as usize]
+            print(" op=")
+            print_int(instr.op as i64)
+            print(" bin=")
+            print_int(instr.bin_op as i64)
+            print(" un=")
+            print_int(instr.un_op as i64)
+            print(" dst=")
+            print_int(instr.dst)
+            print(" src1=")
+            print_int(instr.src1)
+            print(" src2=")
+            print_int(instr.src2)
+            print(" imm=")
+            print_int(instr.imm_i64)
+            print(" label=")
+            print_int(instr.label_id)
+            print(" callee=")
+            print_int(instr.fn_id)
+            print(" field=")
+            print_int(instr.field_idx)
+            print(" argc=")
+            print_int(instr.arg_count)
+        }
+        print("\n")
+    }
+    false
+}
+
+pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunction, fn_index: i64) -> bool with IO, Mut, Panic, Div, Alloc {
     nc_v2_reset_label_state()
     reset_function_state_mut(nc)
     let function_offset = (*nc).code.len
@@ -6353,14 +6487,14 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let imm_value = (*func).instrs[i as usize].imm_i64
             if imm_value == (0 - 4242) {
                 if i < 1 {
-                    return false
+                    return native_v2_core_ir_trace_fail(func, fn_index, i, "println_sentinel_missing_prev")
                 }
                 let prev_instr = (*func).instrs[(i - 1) as usize]
                 if prev_instr.op != IrOpcode::IrLoadImm {
-                    return false
+                    return native_v2_core_ir_trace_fail(func, fn_index, i, "println_sentinel_prev_not_load_imm")
                 }
                 if !nc_core_emit_println_i64_literal_sentinel_into(nc, prev_instr.imm_i64) {
-                    return false
+                    return native_v2_core_ir_trace_fail(func, fn_index, i, "println_sentinel_emit_failed")
                 }
                 nc_emit_mov_rax_imm(nc, 0)
                 nc_core_store_rax_to_temp(nc, prev_instr.dst)
@@ -6373,6 +6507,10 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_emit_mov_rax_imm(nc, f64_to_bits((*func).instrs[i as usize].imm_f64))
             nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
             nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
+        } else if instr_op == IrOpcode::IrLoadBool {
+            nc_emit_mov_rax_imm(nc, (*func).instrs[i as usize].imm_i64)
+            nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrIntToFloat {
             nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
             nc_emit_cvtsi2sd_xmm0_rax(nc)
@@ -6392,23 +6530,31 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_add_rodata_reloc(nc, lea_pos + 3, str_offset)
             nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrFieldGet {
-            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-            native_v2_resolve_handle_to_object_base_rax_into(nc)
-            nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
-            nc_emit_mov_rax_mem_rax_rbx8(nc)
-            nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_load_ref_field_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx)
+            } else {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                native_v2_resolve_handle_to_object_base_rax_into(nc)
+                nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
+                nc_emit_mov_rax_mem_rax_rbx8(nc)
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            }
             if (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG || nc_core_field_is_float(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx) {
                 nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
             } else {
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             }
         } else if instr_op == IrOpcode::IrFieldSet {
-            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-            native_v2_resolve_handle_to_object_base_rax_into(nc)
-            nc_emit_mov_rdx_rax(nc)
-            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src2)
-            nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
-            nc_emit_store_rax_mem_rdx_rbx8(nc)
+            if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_store_ref_field_into(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx, (*func).instrs[i as usize].src2)
+            } else {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                native_v2_resolve_handle_to_object_base_rax_into(nc)
+                nc_emit_mov_rdx_rax(nc)
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src2)
+                nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
+                nc_emit_store_rax_mem_rdx_rbx8(nc)
+            }
             if (*func).instrs[i as usize].src2 >= 0 && (*func).instrs[i as usize].src2 < 512 {
                 if (*nc).is_float_reg[(*func).instrs[i as usize].src2 as usize] == 1 {
                     nc_core_mark_float_field(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx)
@@ -6416,7 +6562,14 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrIndexGet {
             let base_reg = (*func).instrs[i as usize].src1
-            if nc_core_func_param_index(func, base_reg) >= 0 {
+            if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_ref_array_load_into(
+                    nc,
+                    (*func).instrs[i as usize].dst,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                )
+            } else if nc_core_func_param_index(func, base_reg) >= 0 {
                 native_v2_core_emit_param_array_load_into(
                     nc,
                     (*func).instrs[i as usize].dst,
@@ -6439,7 +6592,14 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrIndexSet {
             let base_reg = (*func).instrs[i as usize].src1
-            if nc_core_func_param_index(func, base_reg) >= 0 {
+            if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_ref_array_store_into(
+                    nc,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                    (*func).instrs[i as usize].imm_i64,
+                )
+            } else if nc_core_func_param_index(func, base_reg) >= 0 {
                 native_v2_core_emit_param_array_store_into(
                     nc,
                     base_reg,
@@ -6456,7 +6616,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrBinOp {
             if !nc_emit_core_binop(nc, func, i) {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "binop_unsupported")
             }
         } else if instr_op == IrOpcode::IrCopy {
             nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
@@ -6484,7 +6644,9 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             } else if uop == UnaryOp::OpNot {
                 nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                let not_offset = (*nc).code.len
                 (*nc).code = emit_not_bool_rax((*nc).code)
+                native_v2_text_sync_from_narrow(nc, not_offset)
                 nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             } else if uop == UnaryOp::OpDeref {
@@ -6502,7 +6664,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             } else {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "unary_unsupported")
             }
         } else if instr_op == IrOpcode::IrStorePtr {
             // [src1] = src2 : store val through a raw pointer. val -> rbx, ptr -> rax, [rax]=rbx.
@@ -6512,28 +6674,28 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_emit_store_rbx_to_mem_rax(nc)
         } else if instr_op == IrOpcode::IrAlloc {
             if !nc_core_emit_alloc_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].imm_i64) {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "alloc_emit_failed")
             }
         } else if instr_op == IrOpcode::IrCall {
             let argc = (*func).instrs[i as usize].arg_count
-            if !nc_core_push_call_stack_args(nc, func, i, argc) { return false }
+            if !nc_core_push_call_stack_args(nc, func, i, argc) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_stack_args_failed") }
             if argc > 0 {
-                if !nc_core_load_call_arg_into(nc, func, i, 0, 7) { return false }
+                if !nc_core_load_call_arg_into(nc, func, i, 0, 7) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_arg0_failed") }
             }
             if argc > 1 {
-                if !nc_core_load_call_arg_into(nc, func, i, 1, 6) { return false }
+                if !nc_core_load_call_arg_into(nc, func, i, 1, 6) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_arg1_failed") }
             }
             if argc > 2 {
-                if !nc_core_load_call_arg_into(nc, func, i, 2, 2) { return false }
+                if !nc_core_load_call_arg_into(nc, func, i, 2, 2) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_arg2_failed") }
             }
             if argc > 3 {
-                if !nc_core_load_call_arg_into(nc, func, i, 3, 1) { return false }
+                if !nc_core_load_call_arg_into(nc, func, i, 3, 1) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_arg3_failed") }
             }
             if argc > 4 {
-                if !nc_core_load_call_arg_into(nc, func, i, 4, 8) { return false }
+                if !nc_core_load_call_arg_into(nc, func, i, 4, 8) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_arg4_failed") }
             }
             if argc > 5 {
-                if !nc_core_load_call_arg_into(nc, func, i, 5, 9) { return false }
+                if !nc_core_load_call_arg_into(nc, func, i, 5, 9) { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_arg5_failed") }
             }
             let call_pos = (*nc).code.len
             nc_emit_call_rel32_placeholder(nc)
@@ -6543,8 +6705,17 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 nc_emit_add_rsp_imm32(nc, cleanup_bytes)
             }
             if (*func).instrs[i as usize].dst >= 0 {
+                let callee_returns_float = if (*func).instrs[i as usize].fn_id >= 0 && (*func).instrs[i as usize].fn_id < 2048 {
+                    (*nc).fn_returns_float[(*func).instrs[i as usize].fn_id as usize] == 1
+                } else {
+                    false
+                }
+                let call_returns_float = (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG || callee_returns_float
+                if call_returns_float {
+                    nc_emit_movq_rax_xmm0(nc)
+                }
                 nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
-                if (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG {
+                if call_returns_float {
                     nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
                 } else {
                     nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
@@ -6553,12 +6724,12 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
         } else if instr_op == IrOpcode::IrCallSret {
             let argc = (*func).instrs[i as usize].arg_count
             let dest_reg = (*func).instrs[i as usize].src1
-            if dest_reg < 0 { return false }
+            if dest_reg < 0 { return native_v2_core_ir_trace_fail(func, fn_index, i, "sret_dest_missing") }
             let first_arg = (*func).instrs[i as usize].field_idx
-            if !nc_core_push_sret_stack_args(nc, first_arg, argc) { return false }
+            if !nc_core_push_sret_stack_args(nc, first_arg, argc) { return native_v2_core_ir_trace_fail(func, fn_index, i, "sret_stack_args_failed") }
             nc_emit_load_rbp_disp32_reg(nc, 7, ir_slot_offset(dest_reg))
             if argc > 0 {
-                if first_arg < 0 { return false }
+                if first_arg < 0 { return native_v2_core_ir_trace_fail(func, fn_index, i, "sret_first_arg_missing") }
                 nc_emit_load_rbp_disp32_reg(nc, 6, ir_slot_offset(first_arg))
             }
             if argc > 1 {
@@ -6585,6 +6756,9 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrReturn {
             nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+            if (*func).returns_float == 1 || ((*func).instrs[i as usize].src1 >= 0 && (*func).instrs[i as usize].src1 < 512 && (*nc).is_float_reg[(*func).instrs[i as usize].src1 as usize] == 1) {
+                nc_emit_movq_xmm0_rax(nc)
+            }
             nc_emit_mov_rsp_rbp(nc)
             nc_emit_pop_rbp(nc)
             nc_emit_ret(nc)
@@ -6621,19 +6795,19 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
         } else if instr_op == IrOpcode::IrCallIndirect {
             let argc = (*func).instrs[i as usize].arg_count
             if argc > 2 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "call_indirect_argc_gt_2")
             }
             let arg_pair = ir_reg_list_first_two((*func).instrs[i as usize].call_args)
             if argc > 0 {
-                if arg_pair.0 < 0 { return false }
+                if arg_pair.0 < 0 { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_indirect_arg0_missing") }
                 nc_emit_load_rbp_disp32_reg(nc, 7, ir_slot_offset(arg_pair.0))
             }
             if argc > 1 {
-                if arg_pair.1 < 0 { return false }
+                if arg_pair.1 < 0 { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_indirect_arg1_missing") }
                 nc_emit_load_rbp_disp32_reg(nc, 6, ir_slot_offset(arg_pair.1))
             }
             let fnref_reg = (*func).instrs[i as usize].src1
-            if fnref_reg < 0 { return false }
+            if fnref_reg < 0 { return native_v2_core_ir_trace_fail(func, fn_index, i, "call_indirect_fnref_missing") }
             nc_core_load_temp_to_rax(nc, fnref_reg)
             nc_emit_call_rax(nc)
             if (*func).instrs[i as usize].dst >= 0 {
@@ -6647,7 +6821,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_add_bad_operands")
             }
             nc_wide_add_into(nc, lhs_v, rhs_v, dst_v, limbs)
         } else if instr_op == IrOpcode::IrWideSub {
@@ -6656,7 +6830,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_sub_bad_operands")
             }
             nc_wide_sub_into(nc, lhs_v, rhs_v, dst_v, limbs)
         } else if instr_op == IrOpcode::IrWideMul {
@@ -6665,7 +6839,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_mul_bad_operands")
             }
             nc_wide_mul_into(nc, lhs_v, rhs_v, dst_v, limbs)
         } else if instr_op == IrOpcode::IrWideCmp {
@@ -6675,7 +6849,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let limbs = (*func).instrs[i as usize].imm_i64
             let cmp_op = (*func).instrs[i as usize].field_idx
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 || limbs > 64 || cmp_op < 0 || cmp_op > 5 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_cmp_bad_operands")
             }
             nc_wide_cmp_into(nc, lhs_v, rhs_v, dst_v, limbs, cmp_op)
         } else if instr_op == IrOpcode::IrWideShrLimb {
@@ -6684,7 +6858,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let shift = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || src_v < 0 || limbs < 1 || shift < 0 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_shr_limb_bad_operands")
             }
             nc_wide_shr_limb_into(nc, src_v, dst_v, limbs, shift)
         } else if instr_op == IrOpcode::IrWideShr {
@@ -6693,7 +6867,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let shift = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || src_v < 0 || limbs < 1 || shift < 0 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_shr_bad_operands")
             }
             nc_wide_shr_into(nc, src_v, dst_v, limbs, shift)
         } else if instr_op == IrOpcode::IrWideDiv {
@@ -6702,7 +6876,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_div_bad_operands")
             }
             nc_wide_div_single_into(nc, lhs_v, rhs_v, dst_v, limbs)
         } else if instr_op == IrOpcode::IrWideMod {
@@ -6711,7 +6885,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_mod_bad_operands")
             }
             nc_wide_mod_single_into(nc, lhs_v, rhs_v, dst_v, limbs)
         } else if instr_op == IrOpcode::IrWideDivFull {
@@ -6720,7 +6894,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_div_full_bad_operands")
             }
             nc_wide_longdiv_into(nc, lhs_v, rhs_v, dst_v, limbs, 0)
         } else if instr_op == IrOpcode::IrWideModFull {
@@ -6729,7 +6903,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let rhs_v = (*func).instrs[i as usize].src2
             let limbs = (*func).instrs[i as usize].imm_i64
             if dst_v < 0 || lhs_v < 0 || rhs_v < 0 || limbs < 1 {
-                return false
+                return native_v2_core_ir_trace_fail(func, fn_index, i, "wide_mod_full_bad_operands")
             }
             nc_wide_longdiv_into(nc, lhs_v, rhs_v, dst_v, limbs, 1)
         } else if instr_op == IrOpcode::IrLoadGlobal {
@@ -6746,12 +6920,13 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_emit_mov_reg_imm(nc, 3, abs_addr)
             nc_emit_store_rax_mem_rbx_disp32(nc, 0)
         } else {
-            return false
+            return native_v2_core_ir_trace_fail(func, fn_index, i, "opcode_unsupported")
         }
         i = i + 1
     }
 
     patch_label_forwards_mut(nc)
+    native_v2_patch_label_forwards_text_mirror(nc)
     true
 }
 
@@ -6914,7 +7089,7 @@ pub fn native_v2_core_emit_rdx_to_temp_into(nc: &! NativeCompiler, dst: i64) wit
     }
 }
 
-pub fn compile_ir_function_v2_from_ir_into(nc: &! NativeCompiler, func: &IrFunction, fn_index: i64) -> bool with Mut, Panic, Div, Alloc {
+pub fn compile_ir_function_v2_from_ir_into(nc: &! NativeCompiler, func: &IrFunction, fn_index: i64) -> bool with IO, Mut, Panic, Div, Alloc {
     let builtin_id = native_v2_builtin_id_for_func_ref(func)
     if builtin_id != 0 {
         if builtin_id <= 3 {
@@ -7377,6 +7552,7 @@ fn compile_ir_function_v2_mut(nc: &! NativeCompiler, func: IrFunction, machine_f
     (*nc).code = emit_epilogue_with_preg_mask((*nc).code, preg_mask)
     patch_return_jumps_mut(nc, epilogue_offset)
     patch_label_forwards_mut(nc)
+    native_v2_patch_label_forwards_text_mirror(nc)
 }
 
 fn compile_module_v2(nc: NativeCompiler, module: &IrModule) -> (NativeCompiler, string) with Mut, Panic, Div, Alloc {
@@ -7618,6 +7794,7 @@ pub fn native_v2_core_emit_branch_false_to_label_into(nc: &! NativeCompiler, con
 
 pub fn native_v2_core_patch_labels_into(nc: &! NativeCompiler) with IO, Mut, Panic, Div {
     patch_label_forwards_mut(nc)
+    native_v2_patch_label_forwards_text_mirror(nc)
 }
 
 pub fn native_v2_core_emit_copy_into(nc: &! NativeCompiler, dst: i64, src: i64) with Mut, Panic, Div {
@@ -7632,18 +7809,21 @@ pub fn native_v2_core_emit_temp_addr_into(nc: &! NativeCompiler, dst: i64, src: 
 
 pub fn native_v2_core_emit_load_ref_field_into(nc: &! NativeCompiler, dst: i64, base_ref: i64, field_offset_words: i64) with Mut, Panic, Div {
     nc_core_load_temp_to_rax(nc, base_ref)
-    nc_emit_mov_reg_reg(nc, 3, 0)
-    nc_emit_load_rax_mem_rbx_disp32(nc, field_offset_words * 8)
+    nc_emit_load_rax_mem_rax(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_reg_imm(nc, 3, field_offset_words + native_v2_object_header_size() / 8)
+    nc_emit_mov_rax_mem_rax_rbx8(nc)
     nc_core_store_rax_to_temp(nc, dst)
 }
 
 pub fn native_v2_core_emit_store_ref_field_into(nc: &! NativeCompiler, base_ref: i64, field_offset_words: i64, src: i64) with Mut, Panic, Div {
-    nc_core_load_temp_to_rax(nc, src)
-    nc_emit_push_rax(nc)
     nc_core_load_temp_to_rax(nc, base_ref)
-    nc_emit_mov_reg_reg(nc, 3, 0)
-    nc_emit_pop_rax(nc)
-    nc_emit_store_rax_mem_rbx_disp32(nc, field_offset_words * 8)
+    nc_emit_load_rax_mem_rax(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_rdx_rax(nc)
+    nc_core_load_temp_to_rax(nc, src)
+    nc_emit_mov_reg_imm(nc, 3, field_offset_words + native_v2_object_header_size() / 8)
+    nc_emit_store_rax_mem_rdx_rbx8(nc)
 }
 
 pub fn native_v2_driver_state_base_offset() -> i64 { 4096 }
@@ -7722,6 +7902,34 @@ pub fn native_v2_core_emit_param_array_load_into(nc: &! NativeCompiler, dst: i64
 pub fn native_v2_core_emit_param_array_store_into(nc: &! NativeCompiler, base_reg: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
     // Param arrays are passed as handles, same as local and struct-field arrays.
     nc_core_load_temp_to_rax(nc, base_reg)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_emit_mov_reg_imm(nc, 1, native_v2_object_header_size() / 8)
+    nc_emit_add_reg_reg(nc, 3, 1)
+    nc_core_load_temp_to_rax(nc, src)
+    nc_emit_store_rax_mem_rdx_rbx8(nc)
+}
+
+pub fn native_v2_core_emit_ref_array_load_into(nc: &! NativeCompiler, dst: i64, base_ref: i64, idx_reg: i64) with Mut, Panic, Div {
+    // &![T; N] params point at the caller slot that stores the array handle.
+    nc_core_load_temp_to_rax(nc, base_ref)
+    nc_emit_load_rax_mem_rax(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_emit_mov_reg_imm(nc, 1, native_v2_object_header_size() / 8)
+    nc_emit_add_reg_reg(nc, 3, 1)
+    nc_emit_load_rax_mem_rdx_rbx8(nc)
+    nc_core_store_rax_to_temp(nc, dst)
+}
+
+pub fn native_v2_core_emit_ref_array_store_into(nc: &! NativeCompiler, base_ref: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
+    // &![T; N] params point at the caller slot that stores the array handle.
+    nc_core_load_temp_to_rax(nc, base_ref)
+    nc_emit_load_rax_mem_rax(nc)
     native_v2_resolve_handle_to_object_base_rax_into(nc)
     nc_emit_mov_reg_reg(nc, 2, 0)
     nc_core_load_temp_to_rax(nc, idx_reg)
@@ -9104,30 +9312,30 @@ fn compile_to_elf_v2(module: &IrModule, base_addr: i64) -> NativeCompileResult w
     native_compile_result_ok_elf(elf.bytes, elf.len, FORMAT_ELF64())
 }
 
-fn native_v2_file_put_u8(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic {
-    if pos >= 0 && pos < 131072 {
+fn native_v2_file_put_u8(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic {
+    if pos >= 0 && pos < 262144 {
         (*buf)[pos as usize] = (val & 255) as i8
     }
 }
 
-fn native_v2_file_put_u16(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic, Div {
+fn native_v2_file_put_u16(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
     native_v2_file_put_u8(buf, pos, val)
     native_v2_file_put_u8(buf, pos + 1, val >> 8)
 }
 
-fn native_v2_file_put_u32(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic, Div {
+fn native_v2_file_put_u32(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
     native_v2_file_put_u8(buf, pos, val)
     native_v2_file_put_u8(buf, pos + 1, val >> 8)
     native_v2_file_put_u8(buf, pos + 2, val >> 16)
     native_v2_file_put_u8(buf, pos + 3, val >> 24)
 }
 
-fn native_v2_file_put_u64(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic, Div {
+fn native_v2_file_put_u64(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
     native_v2_file_put_u32(buf, pos, val)
     native_v2_file_put_u32(buf, pos + 4, val >> 32)
 }
 
-fn native_v2_file_emit_phdr(buf: &![i8; 131072], pos: i64, p_type: i64, flags: i64, offset: i64, vaddr: i64, filesz: i64, memsz: i64, align: i64) with Mut, Panic, Div {
+fn native_v2_file_emit_phdr(buf: &![i8; 262144], pos: i64, p_type: i64, flags: i64, offset: i64, vaddr: i64, filesz: i64, memsz: i64, align: i64) with Mut, Panic, Div {
     native_v2_file_put_u32(buf, pos, p_type)
     native_v2_file_put_u32(buf, pos + 4, flags)
     native_v2_file_put_u64(buf, pos + 8, offset)
@@ -9139,7 +9347,7 @@ fn native_v2_file_emit_phdr(buf: &![i8; 131072], pos: i64, p_type: i64, flags: i
 }
 
 fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler, entry_offset: i64, base_addr: i64) -> i32 with IO, Mut, Panic, Div {
-    var bytes: [i8; 131072] = [0; 131072]
+    var bytes: [i8; 262144] = [0; 262144]
     let text_offset: i64 = 4096
     let code_len = (*nc).code.len
     let rodata_len = if (*nc).flat_rodata_len > 0 { (*nc).flat_rodata_len } else { (*nc).rodata.len }
@@ -9164,7 +9372,7 @@ fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler,
     if data_len > 0 {
         file_len = data_offset + data_len
     }
-    if file_len <= 64 || file_len > 131072 { return 13 }
+    if file_len <= 64 || file_len > 262144 { return 13 }
 
     // Build the ELF header + program headers + segment payloads into `bytes`
     // via a dedicated small helper. Splitting this out of the (large) caller
@@ -9184,7 +9392,7 @@ fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler,
 
 // Helper extracted from native_v2_write_min_elf64_to_file (c634b38f branch-offset
 // workaround — see caller). Writes the full ELF image into `bytes`.
-fn native_v2_build_elf_image_into(bytes: &! [i8; 131072], nc: &! NativeCompiler, base_addr: i64, entry_offset: i64, text_offset: i64, code_len: i64, rodata_offset: i64, rodata_len: i64, rodata_vaddr: i64, text_vaddr: i64, data_offset: i64, data_len: i64, data_vaddr: i64, phnum: i64) with Mut, Panic, Div {
+fn native_v2_build_elf_image_into(bytes: &! [i8; 262144], nc: &! NativeCompiler, base_addr: i64, entry_offset: i64, text_offset: i64, code_len: i64, rodata_offset: i64, rodata_len: i64, rodata_vaddr: i64, text_vaddr: i64, data_offset: i64, data_len: i64, data_vaddr: i64, phnum: i64) with Mut, Panic, Div {
     native_v2_file_put_u8(bytes, 0, 127)
     native_v2_file_put_u8(bytes, 1, 69)
     native_v2_file_put_u8(bytes, 2, 76)
@@ -9224,21 +9432,39 @@ fn native_v2_build_elf_image_into(bytes: &! [i8; 131072], nc: &! NativeCompiler,
     native_v2_file_emit_phdr(bytes, phoff, 0x6474e551, 6, 0, 0, 0, 0, 16)
 
     var i: i64 = 0
-    while i < code_len && (text_offset + i) < 131072 {
-        (*bytes)[(text_offset + i) as usize] = (*nc).code.bytes[i as usize]
+    while i < code_len && (text_offset + i) < 262144 {
+        var tb: i8 = 0 as i8
+        if i < NATIVE_V2_TEXT_LEN {
+            tb = NATIVE_V2_TEXT_BUF[i as usize]
+        } else if i < 131072 {
+            tb = (*nc).code.bytes[i as usize]
+        }
+        (*bytes)[(text_offset + i) as usize] = tb
         i = i + 1
     }
 
     if (*nc).flat_rodata_len > 0 {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 131072 {
+        while i < rodata_len && (rodata_offset + i) < 262144 {
             (*bytes)[(rodata_offset + i) as usize] = (*nc).flat_rodata_bytes[i as usize]
             i = i + 1
         }
     } else {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 131072 {
+        while i < rodata_len && (rodata_offset + i) < 262144 {
             (*bytes)[(rodata_offset + i) as usize] = (*nc).rodata.bytes[i as usize]
+            i = i + 1
+        }
+    }
+
+    if data_len > 0 {
+        i = 0
+        while i < data_len && (data_offset + i) < 262144 {
+            var db: i8 = 0 as i8
+            if i < (*nc).data.len {
+                db = (*nc).data.bytes[i as usize]
+            }
+            (*bytes)[(data_offset + i) as usize] = db
             i = i + 1
         }
     }
@@ -9253,6 +9479,7 @@ fn native_v2_trace_instr_ref(fn_index: i64, instr_index: i64, instr: &IrInstr) w
     if (*instr).op == IrOpcode::IrNop { interesting = true }
     if (*instr).op == IrOpcode::IrLoadImm { interesting = true }
     if (*instr).op == IrOpcode::IrLoadFloat { interesting = true }
+    if (*instr).op == IrOpcode::IrLoadBool { interesting = true }
     if (*instr).op == IrOpcode::IrCall { interesting = true }
     if (*instr).op == IrOpcode::IrBinOp { interesting = true }
     if (*instr).op == IrOpcode::IrFieldGet { interesting = true }
@@ -9270,6 +9497,7 @@ fn native_v2_trace_instr_ref(fn_index: i64, instr_index: i64, instr: &IrInstr) w
     if (*instr).op == IrOpcode::IrNop { print("nop") }
     else if (*instr).op == IrOpcode::IrLoadImm { print("load_imm") }
     else if (*instr).op == IrOpcode::IrLoadFloat { print("load_float") }
+    else if (*instr).op == IrOpcode::IrLoadBool { print("load_bool") }
     else if (*instr).op == IrOpcode::IrCall { print("call") }
     else if (*instr).op == IrOpcode::IrBinOp { print("binop") }
     else if (*instr).op == IrOpcode::IrFieldGet { print("field_get") }
@@ -9303,6 +9531,8 @@ fn native_v2_trace_module_ir_ref(module: &IrModule) with IO, Mut, Panic, Div {
         let func = (*module).functions[fi as usize]
         print("NV2_IR function fn=")
         print_int(fi)
+        print(" name=")
+        print(str_from_bytes(func.name.buf, func.name.len))
         print(" instr_count=")
         print_int(func.instr_count)
         print(" returns_float=")
@@ -9326,6 +9556,7 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
     }
 
     native_v2_trace_module_ir_ref(module)
+    native_v2_text_reset()
 
     var nc = compiler_new()
     compile_module_streaming_begin_into(&! nc, module)
@@ -9338,7 +9569,24 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
             bss_count = bss_count + 1
         }
         if !compile_ir_function_v2_from_ir_into(&! nc, &fn_body, fi) {
+            if native_v2_ir_trace_enabled() {
+                print("native_v2_core_ir_failed fn=")
+                print_int(fi)
+                print(" name=")
+                print(str_from_bytes(fn_body.name.buf, fn_body.name.len))
+                print("\n")
+            }
             compile_ok = false
+        } else {
+            if native_v2_ir_trace_enabled() {
+                print("native_v2_fn_offset fn=")
+                print_int(fi)
+                print(" name=")
+                print(str_from_bytes(fn_body.name.buf, fn_body.name.len))
+                print(" offset=")
+                print_int(nc.fn_offsets[fi as usize])
+                print("\n")
+            }
         }
         fi = fi + 1
     }
@@ -9399,7 +9647,13 @@ fn compile_to_macho_arm64_preview(module: &IrModule, target_spec: NativeTargetSp
     w.strtab = macho_strtab_init()
     w = macho_add_section(w, macho_make_text_section(text_vmaddr, c.code.len, text_offset))
     var empty_data: [i8; 131072] = [0; 131072]
-    let macho = macho_assemble_executable(w, c.code.bytes, c.code.len, empty_data, 0, text_offset + c.entry_offset)
+    var narrow_code: [i8; 131072] = [0; 131072]
+    var ci: i64 = 0
+    while ci < c.code.len && ci < 131072 {
+        narrow_code[ci as usize] = c.code.bytes[ci as usize]
+        ci = ci + 1
+    }
+    let macho = macho_assemble_executable(w, narrow_code, c.code.len, empty_data, 0, text_offset + c.entry_offset)
     native_compile_result_ok_narrow(macho.buf, macho.buf_len, FORMAT_MACHO64())
 }
 
@@ -9643,10 +9897,17 @@ fn compile_native_finalize_and_write_ref(nc: &! NativeCompiler, base_addr: i64, 
     // Advance to text section (BSS already zeroed, no explicit padding needed)
     NATIVE_ELF_OFF = text_offset
 
-    // Copy code bytes — direct BSS write + struct-ref read (both work)
+    // Copy code bytes from the native-v2 text mirror when available. The
+    // NativeCompiler narrow buffer is only a compatibility fallback.
     var ci: i64 = 0
     while ci < code_len {
-        NATIVE_ELF_BUF[NATIVE_ELF_OFF as usize] = (*nc).code.bytes[ci as usize]
+        var cb: i8 = 0 as i8
+        if ci < NATIVE_V2_TEXT_LEN {
+            cb = NATIVE_V2_TEXT_BUF[ci as usize]
+        } else if ci < 131072 {
+            cb = (*nc).code.bytes[ci as usize]
+        }
+        NATIVE_ELF_BUF[NATIVE_ELF_OFF as usize] = cb
         NATIVE_ELF_OFF = NATIVE_ELF_OFF + 1
         ci = ci + 1
     }
@@ -9676,7 +9937,10 @@ fn compile_native_finalize_and_write_ref(nc: &! NativeCompiler, base_addr: i64, 
         NATIVE_ELF_OFF = data_offset
         var di: i64 = 0
         while di < actual_data_len {
-            let db: i8 = if di < raw_data_len { (*nc).data.bytes[di as usize] } else { 0 as i8 }
+            var db: i8 = 0 as i8
+            if di < raw_data_len {
+                db = (*nc).data.bytes[di as usize]
+            }
             NATIVE_ELF_BUF[NATIVE_ELF_OFF as usize] = db
             NATIVE_ELF_OFF = NATIVE_ELF_OFF + 1
             di = di + 1

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -223,6 +223,7 @@ pub struct NativeCompiler {
 
     // Module-level: function layout
     pub fn_offsets: [i64; 2048],         // function index -> code buffer offset
+    pub fn_returns_float: [i64; 2048],   // function index -> declared f64 return
     pub fn_count: i64,
 
     // Per-function: return jump patching
@@ -344,6 +345,11 @@ pub fn compiler_new() -> NativeCompiler {
     while i < 256 {
         out.fn_offsets[i as usize] = -1
         out.label_offsets[i as usize] = -1
+        i = i + 1
+    }
+    i = 0
+    while i < 2048 {
+        out.fn_returns_float[i as usize] = 0
         i = i + 1
     }
     i = 0


### PR DESCRIPTION
## Review-only slice of #436 (do not merge)

This PR exists **solely to run `/ultrareview`** on the high-risk compiler substrate of #436, which is too large for the tool as a whole (49 files / 9,268 lines, mostly research tooling + docs).

It contains **only** the 12 `self-hosted/` files (~2,730 lines) — the lowering/native-codegen changes that take the imported `theorem::smt` runtime from SIGSEGV to green: native-v2 f64 call metadata, IR cap 512→1024, native `.text` mirror, `SOUNIO_STDLIB_PATH` resolver, imported struct `is_float` preseed, borrow cleanups, env-gated `SOUNIO_LOWER_*_TRACE`. The imported-body `ir_patch_validated_calls` skip is retained (load-bearing).

**Not for merge** — the real integration PR is **#436** (substrate + SMT lane + witness + seed + Level-2 research). This branch is a disposable review target; it won't build/test green in isolation (the SMT lane + seed live in #436). Close it after review.
