### PR TITLE
Tighten serious-language conformance evidence

### DIFF
--- a/tests/conformance/import_public.sio
+++ b/tests/conformance/import_public.sio
@@ -1,0 +1,8 @@
+//@ check-pass
+// Positive import visibility check for the serious-language conformance spine.
+
+use import_public_a::{imported_add}
+
+fn main() -> i64 {
+    imported_add(20, 22)
+}

--- a/tests/conformance/import_public_a.sio
+++ b/tests/conformance/import_public_a.sio
@@ -1,0 +1,6 @@
+//@ auxiliary
+// Provider module for the bounded conformance import check.
+
+pub fn imported_add(a: i64, b: i64) -> i64 {
+    a + b
+}

--- a/tests/conformance/manifest.v1.tsv
+++ b/tests/conformance/manifest.v1.tsv
@@ -3,15 +3,15 @@ core-hello-check	check	examples/hello.sio	0	-	-	core.syntax
 core-hello-run	run	examples/hello.sio	0	-	-	core.execution
 core-struct-run	run	examples/native/struct_basic.sio	0	7	-	core.structs
 effects-superset-run	run	tests/run-pass/effect_superset_ok.sio	0	effect superset: PASS	-	effects.subtyping
-effects-missing-diagnostic	check-fail	tests/compile-fail/effect_missing.sio	nonzero	-	effect not declared	effects.diagnostics
+effects-missing-diagnostic	check-fail	tests/compile-fail/effect_missing.sio	nonzero	effect not declared	-	effects.diagnostics
 observe-io-boundary	check-fail	tests/compile-fail/observe_io_boundary.sio	nonzero	-	cannot print Unobserved<T>	epistemic.observe
-modules-import-check	check	tests/run-pass/import_basic.sio	0	-	-	modules.imports
+modules-import-check	check	tests/conformance/import_public.sio	0	-	-	modules.imports
 generics-struct-run	run	tests/run-pass/generic_struct_basic.sio	0	generic struct parse ok	-	generics.structs
 generics-multi-run	run	tests/run-pass/generics_multi_param.sio	0	first_of_two: PASS	-	generics.functions
 ownership-release-check	check	tests/run-pass/borrow_call_explicit_release.sio	0	-	-	ownership.borrowing
-ownership-conflict-diagnostic	check-fail	tests/compile-fail/borrow_call_conflict_explicit.sio	nonzero	-	cannot borrow as mutable	ownership.borrowing
+ownership-conflict-diagnostic	check-fail	tests/compile-fail/borrow_call_conflict_explicit.sio	nonzero	cannot borrow exclusively while other borrows are active	-	ownership.borrowing
 gum-compliance-run	run	tests/run-pass/gum_compliance.sio	0	All 7 tests match GUM	-	epistemic.gum
 gum-iso-budget-run	run	tests/run-pass/gum_iso_budget.sio	0	PASS	-	epistemic.gum
 epistemic-bmi-run	run	tests/run-pass/epistemic_bmi.sio	0	BMI uncertainty	-	epistemic.knowledge
 knowledge-boundary-diagnostic	check-fail	tests/compile-fail/knowledge_no_silent_unwrap.sio	nonzero	-	expected confidence level not satisfied	epistemic.boundary
-epistemic-effect-diagnostic	check-fail	tests/compile-fail/epistemic_epsilon_mismatch.sio	nonzero	-	requires `with Epistemic`	epistemic.boundary
+epistemic-effect-diagnostic	check-fail	tests/compile-fail/epistemic_epsilon_mismatch.sio	nonzero	requires `with Epistemic`	-	epistemic.boundary


### PR DESCRIPTION
## Summary
- move three conformance diagnostic expectations from stderr to stdout, matching where the current compiler emits diagnostics
- update the ownership conflict expected text to the current diagnostic
- point the modules import conformance case at a dedicated public-import fixture under `tests/conformance/`

## Evidence
- `./bin/souc check tests/conformance/import_public.sio` passes
- `bash scripts/ci/serious_language_conformance_gate.sh` improves from `6/16` to `10/16` while still failing the remaining true blockers
- `SOUC_BIN=/tmp/sounio-direct-driver-sota/bin/souc bash scripts/run_sio_test_suite.sh import_basic_a --verbose` passes
- `bash scripts/dev/check_docs_registry.sh` passes
- `git diff --check` passes

## Remaining conformance blockers
This PR does not close serious-language conformance. Remaining failures after this patch:
- `observe-io-boundary`: checker accepts `println(Unobserved<T>)`; real semantic miss
- `generics-multi-run`: generic function substitution/monomorphization still fails (`expected T`, found `i64`)
- `gum-compliance-run`: runtime segfault, rooted by subagent triage to `println(f64)` dispatch/codegen
- `gum-iso-budget-run`: same `println(f64)` runtime segfault class
- `epistemic-bmi-run`: same `println(f64)` runtime segfault class
- `knowledge-boundary-diagnostic`: fixture/expected diagnostic is stale; current rejection is `unknown struct type`, so it does not prove the intended no-silent-unwrap boundary

## LLM-offload reviews invoked
None. This is a conformance harness/fixture hygiene change only; no math claim, clinical-pathway code, or external-facing paper/dissertation artifact was edited.
