### PR TITLE
[codex] Fix Madaros println f64 dispatch

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -3294,21 +3294,27 @@ impl Lowerer {
     }
 
     // Returns the print builtin name for println's first argument.
-    //   int literal / i64 var (scalar_kind=1) → print_int  (itoa+write)
-    //   everything else                        → print      (strlen+write, safe fallback)
-    // Note: f64 vars (scalar_kind=2) intentionally fall through to print here because
-    // emit_builtin_print_f64 reads its argument from RDI (integer ABI) but our inline
-    // println call path passes floats via XMM0 (float ABI), causing a mismatch.
-    // Wiring up f64 dispatch requires threading the float-arg ABI into println lowering.
+    //   int literal / i64 var (scalar_kind=1) → print_int
+    //   f64-valued expression                 → print_f64
+    //   everything else                       → print
+    // Routing f64 through print treats the IEEE bits as a char* and segfaults.
+    // The native backend's print_f64 builtin consumes the lowered f64 payload
+    // through the same integer slot convention used by emitted call arguments.
     fn println_dispatch_name(self, args: &Option<Box<ExprList>>) -> Name with Mut, Panic, Div, Alloc {
         match *args {
             Some(list) => {
                 let hk = (*list).head.kind
                 if hk == ExprKind::ExprIntLit {
                     make_name("print_int")
+                } else if self.expr_result_is_float_ref(&(*list).head) {
+                    make_name("print_f64")
                 } else if hk == ExprKind::ExprIdent {
                     let sk = self.lookup_local_scalar_kind((*list).head.name)
-                    if sk == 1 { make_name("print_int") } else { make_name("print") }
+                    if sk == 1 {
+                        make_name("print_int")
+                    } else {
+                        make_name("print")
+                    }
                 } else {
                     make_name("print")
                 }
@@ -3905,8 +3911,24 @@ impl Lowerer {
         if (*e).kind == ExprKind::ExprFloatLit {
             return true
         }
+        if (*e).kind == ExprKind::ExprIdent {
+            return self.lookup_local_scalar_kind((*e).name) == 2
+        }
         if (*e).kind == ExprKind::ExprCast {
             return lower_cast_type_is_f64(&(*e).cast_type)
+        }
+        if (*e).kind == ExprKind::ExprCall {
+            match (*e).left {
+                Some(callee_expr) => {
+                    let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
+                    let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
+                    if fn_id >= 0 && fn_id < self.module.fn_count {
+                        return self.module.functions[fn_id as usize].returns_float == 1
+                    }
+                }
+                None => {}
+            }
+            return false
         }
         if (*e).kind == ExprKind::ExprFieldAccess {
             return self.field_is_float_for_base_ref(&(*e).left, (*e).name) || self.field_is_float_by_name_simple((*e).name)
@@ -5481,7 +5503,7 @@ impl Lowerer {
         } else {
             match s.expr {
                 Some(expr_box_sk) => {
-                    if (*expr_box_sk).kind == ExprKind::ExprFloatLit {
+                    if lo.expr_result_is_float_ref(&(*expr_box_sk)) {
                         lo = lo.bind_local_scalar_kind(s.name, 2)
                     } else if (*expr_box_sk).kind == ExprKind::ExprIntLit {
                         lo = lo.bind_local_scalar_kind(s.name, 1)

--- a/tests/run-pass/println_f64_call_return.sio
+++ b/tests/run-pass/println_f64_call_return.sio
@@ -1,0 +1,11 @@
+//@ run-pass
+//@ expect-stdout: 4.500000
+
+fn as_f64(x: f64) -> f64 {
+    return x
+}
+
+fn main() with IO {
+    let x = as_f64(4.5)
+    println(x)
+}

--- a/tests/run-pass/println_f64_literal.sio
+++ b/tests/run-pass/println_f64_literal.sio
@@ -1,0 +1,6 @@
+//@ run-pass
+//@ expect-stdout: 1.500000
+
+fn main() with IO {
+    println(1.5)
+}

--- a/tests/run-pass/println_f64_var.sio
+++ b/tests/run-pass/println_f64_var.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+//@ expect-stdout: 2.250000
+
+fn main() with IO {
+    let x: f64 = 2.25
+    println(x)
+}


### PR DESCRIPTION
## Summary
- Route `println` arguments with f64-valued results to `print_f64` instead of the string `print` builtin.
- Extend f64 result detection to identifiers and calls whose lowered function metadata has `returns_float`.
- Add run-pass regressions for f64 literal, annotated f64 local, and f64 function-return local.

## Root Cause
`println_dispatch_name` only recognized integer literals / i64 locals and sent other arguments to `print`, which treats its input as a string pointer. f64 values routed there could compile successfully but segfault at runtime.

## Validation
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH -u MADAROS_BIN -u SOUNIO_MADAROS_BIN bash scripts/ci/build_modular_madaros.sh /tmp/sounio-madaros-f64-print-build/madaros` -> `Madaros ready`
- `SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/sounio-madaros-f64-print-build/madaros SOUNIO_TEST_JOBS=1 bash scripts/run_sio_test_suite.sh --filter println_f64 --verbose` -> 3/3 pass
- `SOUNIO_SERIOUS_CONFORMANCE_SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/sounio-madaros-f64-print-build/madaros bash scripts/ci/serious_language_conformance_gate.sh` -> expected nonzero, 11/16 pass; `epistemic-bmi-run` now passes, remaining failures are `observe-io-boundary`, `generics-multi-run`, `gum-compliance-run`, `gum-iso-budget-run`, and `knowledge-boundary-diagnostic`
- `git diff --check` -> pass

## Remaining Blockers
GUM failures are now beyond the `println(f64)` dispatch root: `gum_compliance` advances through f64 printing to Test 6 before segfaulting, and `gum_iso_budget` appears tied to `variance_of(...)`/epistemic builtin lowering rather than basic f64 printing.

## LLM-offload
Not invoked. This PR touches compiler lowering and runtime regression tests only; it does not modify math claims, clinical-pathway source, or external-facing artifacts.