### PR TITLE
Fix Madaros variance_of lowering for measured values

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -5432,6 +5432,8 @@ fn call_expr_should_bridge_by_value(e: Expr) -> bool with Mut, Panic, Div, Alloc
     if call_expr_is_builtin_rollback_transition(e.left) { return true }
     if call_expr_is_builtin_lift_knowledge(e.left) { return true }
     if call_expr_is_builtin_measure(e.left) { return true }
+    if call_expr_is_builtin_variance_of(e.left) { return true }
+    if call_expr_is_builtin_uncertainty_of(e.left) { return true }
     if call_expr_contest_witness_kind(e.left) >= 0 { return true }
     false
 }
@@ -5583,6 +5585,21 @@ fn checker_check_measure_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
     let first_arg = expr_list_head(e.args)
     let v_ty = checker_check_opt_expr_inplace(c, first_arg)
     ty_knowledge(v_ty, 0.0 - 1.0)
+}
+
+fn checker_check_variance_metric_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    let first_arg = expr_list_head(e.args)
+    let second_arg = expr_list_second(e.args)
+    match first_arg {
+        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        Some(_) => {}
+    }
+    match second_arg {
+        Some(_) => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        None => {}
+    }
+    checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
+    ty_f64()
 }
 
 // slice_len(s: &[T]) -> i64. Inplace transcription of check_slice_len_call_expr —
@@ -5761,6 +5778,12 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
     // by-value bridge below (which SRET-smashes on the 164KB Checker return).
     if call_expr_is_builtin_measure(e.left) {
         return checker_check_measure_expr_inplace(c, e)
+    }
+    if call_expr_is_builtin_variance_of(e.left) {
+        return checker_check_variance_metric_expr_inplace(c, e)
+    }
+    if call_expr_is_builtin_uncertainty_of(e.left) {
+        return checker_check_variance_metric_expr_inplace(c, e)
     }
     if call_expr_is_builtin_slice_len(e.left) {
         return checker_check_slice_len_expr_inplace(c, e)
@@ -11764,6 +11787,30 @@ fn call_expr_is_builtin_measure(opt: Option<Box<Expr> >) -> bool with Mut, Panic
                 return false
             }
             name_matches_str7((*expr).name, 109, 101, 97, 115, 117, 114, 101)
+        }
+        None => false
+    }
+}
+
+fn call_expr_is_builtin_variance_of(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprIdent {
+                return false
+            }
+            name_matches_str11((*expr).name, 118, 97, 114, 105, 97, 110, 99, 101, 95, 111, 102)
+        }
+        None => false
+    }
+}
+
+fn call_expr_is_builtin_uncertainty_of(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprIdent {
+                return false
+            }
+            name_matches_str14((*expr).name, 117, 110, 99, 101, 114, 116, 97, 105, 110, 116, 121, 95, 111, 102)
         }
         None => false
     }
@@ -18363,6 +18410,12 @@ impl Checker {
         if call_expr_is_builtin_measure(e.left) {
             return self.check_measure_expr(e)
         }
+        if call_expr_is_builtin_variance_of(e.left) {
+            return self.check_variance_metric_expr(e)
+        }
+        if call_expr_is_builtin_uncertainty_of(e.left) {
+            return self.check_variance_metric_expr(e)
+        }
         if call_expr_is_builtin_slice_len(e.left) {
             return self.check_slice_len_call_expr(e)
         }
@@ -20351,6 +20404,22 @@ impl Checker {
         let c = v_pair.0
         let v_ty = v_pair.1
         (c, ty_knowledge(v_ty, 0.0 - 1.0))
+    }
+
+    fn check_variance_metric_expr(self, e: Expr) -> (Checker, TypeEntry) with Mut, Panic, Div, Alloc, IO {
+        let first_arg = expr_list_head(e.args)
+        let second_arg = expr_list_second(e.args)
+        var c = self
+        match first_arg {
+            None => c = c.report_error_at(e.span, 10, 0, 0, 0)
+            Some(_) => {}
+        }
+        match second_arg {
+            Some(_) => c = c.report_error_at(e.span, 10, 0, 0, 0)
+            None => {}
+        }
+        c = c.check_expr_list_no_type_no_linear_consume(e.args)
+        (c, ty_f64())
     }
 
     fn borrow_state_and_shared_count(self, name: Name) -> (i64, i64) with Mut, Panic, Div, Alloc, IO {

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -20,6 +20,8 @@ struct LowerLocalStack {
     is_global: [i64; 4096],
     // 0=other 1=int 2=float; used by println dispatch to avoid routing i64/f64 vars through print_str
     scalar_kind: [i64; 4096],
+    // f64 register carrying the GUM variance shadow for scalar locals, or -1 when absent.
+    variance_regs: [i64; 4096],
     // -1 = not a capturing closure; otherwise the synthetic closure fn_id whose captures
     // must be injected when this local is called (closures step 2).
     closure_fn_id: [i64; 4096],
@@ -39,6 +41,7 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         global_bss_sizes: [0; 4096],
         is_global: [0; 4096],
         scalar_kind: [0; 4096],
+        variance_regs: [-1; 4096],
         closure_fn_id: [-1; 4096],
         count: 0,
     }
@@ -134,6 +137,9 @@ struct Lowerer {
     struct_layouts: Box<StructLayoutTable>,
     array_elem_float_regs: [i64; 512],
     array_elem_float_reg_count: i64,
+    variance_base_regs: [i64; 1024],
+    variance_value_regs: [i64; 1024],
+    variance_base_reg_count: i64,
     // Sprint 28: Debug-mode witness enforcement
     debug_mode: bool,
     // Sprint 44: probe-mode lowering skips heavyweight epistemic metadata lookup.
@@ -143,6 +149,7 @@ struct Lowerer {
     // bound local knows it is a capturing closure.
     closure_caps: Box<ClosureCapTable>,
     pending_closure_fn_id: i64,
+    pending_variance_reg: i64,
 }
 
 struct IrPreparedCallArgs {
@@ -246,10 +253,14 @@ fn lowerer_new() -> Lowerer with Alloc {
         struct_layouts: Box::new(empty_struct_layout_table()),
         array_elem_float_regs: [IR_INVALID_REG; 512],
         array_elem_float_reg_count: 0,
+        variance_base_regs: [IR_INVALID_REG; 1024],
+        variance_value_regs: [IR_INVALID_REG; 1024],
+        variance_base_reg_count: 0,
         debug_mode: false,
         probe_mode: false,
         closure_caps: Box::new(empty_closure_cap_table()),
         pending_closure_fn_id: -1,
+        pending_variance_reg: -1,
     }
 }
 
@@ -1609,6 +1620,8 @@ fn lowerer_bind_local_mut(
         (*locals_box).global_bss_offsets[idx as usize] = 0
         (*locals_box).global_bss_sizes[idx as usize] = 0
         (*locals_box).is_global[idx as usize] = 0
+        (*locals_box).scalar_kind[idx as usize] = 0
+        (*locals_box).variance_regs[idx as usize] = -1
         (*locals_box).count = idx + 1
         (*lo).locals = locals_box
     } else {
@@ -3119,6 +3132,7 @@ impl Lowerer {
                 stk.array_elem_float[idx as usize] = 0
                 stk.wide_bits[idx as usize] = 0
                 stk.wide_signed[idx as usize] = 0
+                stk.variance_regs[idx as usize] = -1
                 stk.count = idx + 1
             lo.locals = Box::new(stk)
         } else {
@@ -3291,6 +3305,285 @@ impl Lowerer {
             i = i - 1
         }
         0
+    }
+
+    fn bind_local_variance_reg(self, name: Name, variance_reg: i64) -> Lowerer with Mut, Alloc, Panic, Div {
+        var lo = self
+        var stk = *lo.locals
+        var i = stk.count - 1
+        while i >= 0 {
+            if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
+                stk.variance_regs[i as usize] = variance_reg
+                lo.locals = Box::new(stk)
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
+    fn lookup_local_variance_reg(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).variance_regs[i as usize]
+            }
+            i = i - 1
+        }
+        -1
+    }
+
+    fn bind_variance_for_base_reg(self, base_reg: i64, variance_reg: i64) -> Lowerer with Mut, Panic, Div {
+        var lo = self
+        if base_reg < 0 || variance_reg < 0 {
+            return lo
+        }
+        var i: i64 = 0
+        while i < lo.variance_base_reg_count {
+            if lo.variance_base_regs[i as usize] == base_reg {
+                lo.variance_value_regs[i as usize] = variance_reg
+                return lo
+            }
+            i = i + 1
+        }
+        if lo.variance_base_reg_count < 1024 {
+            let idx = lo.variance_base_reg_count
+            lo.variance_base_regs[idx as usize] = base_reg
+            lo.variance_value_regs[idx as usize] = variance_reg
+            lo.variance_base_reg_count = idx + 1
+        }
+        lo
+    }
+
+    fn lookup_variance_for_base_reg(self, base_reg: i64) -> i64 with Mut, Panic, Div {
+        var i: i64 = 0
+        while i < self.variance_base_reg_count {
+            if self.variance_base_regs[i as usize] == base_reg {
+                return self.variance_value_regs[i as usize]
+            }
+            i = i + 1
+        }
+        -1
+    }
+
+    fn emit_zero_variance(self) -> (Lowerer, i64) with Mut, Panic, Div {
+        self.emit_f64_const(0.0)
+    }
+
+    fn name_is_variance_of(self, n: Name) -> bool with Div {
+        n.len == 11
+        && n.buf[0] == 118 as i8 && n.buf[1] == 97 as i8
+        && n.buf[2] == 114 as i8 && n.buf[3] == 105 as i8
+        && n.buf[4] == 97 as i8 && n.buf[5] == 110 as i8
+        && n.buf[6] == 99 as i8 && n.buf[7] == 101 as i8
+        && n.buf[8] == 95 as i8 && n.buf[9] == 111 as i8
+        && n.buf[10] == 102 as i8
+    }
+
+    fn name_is_uncertainty_of(self, n: Name) -> bool with Div {
+        n.len == 14
+        && n.buf[0] == 117 as i8 && n.buf[1] == 110 as i8
+        && n.buf[2] == 99 as i8 && n.buf[3] == 101 as i8
+        && n.buf[4] == 114 as i8 && n.buf[5] == 116 as i8
+        && n.buf[6] == 97 as i8 && n.buf[7] == 105 as i8
+        && n.buf[8] == 110 as i8 && n.buf[9] == 116 as i8
+        && n.buf[10] == 121 as i8 && n.buf[11] == 95 as i8
+        && n.buf[12] == 111 as i8 && n.buf[13] == 102 as i8
+    }
+
+    fn lower_measure_value_arg_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match *args {
+            Some(list) => self.lower_expr_ref(&(*list).head),
+            None => self.emit_unit(),
+        }
+    }
+
+    fn lower_measure_uncertainty_arg_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match *args {
+            Some(list) => {
+                match (*list).tail {
+                    Some(rest) => self.lower_expr_ref(&(*rest).head),
+                    None => self.emit_unit(),
+                }
+            }
+            None => self.emit_unit(),
+        }
+    }
+
+    fn emit_variance_add(self, lhs_v: i64, rhs_v: i64) -> (Lowerer, i64) with Mut, Panic, Div {
+        let pair = self.fresh_reg()
+        var lo = pair.0
+        let dst = pair.1
+        lo = lo.emit(ir_binop(dst, lhs_v, BinaryOp::OpAdd, rhs_v))
+        lo = lo.emit(ir_mark_float_reg(dst))
+        (lo, dst)
+    }
+
+    fn emit_variance_scale(self, variance_reg: i64, scale_reg: i64) -> (Lowerer, i64) with Mut, Panic, Div {
+        let pair_sq = self.fresh_reg()
+        var lo = pair_sq.0
+        let scale_sq = pair_sq.1
+        lo = lo.emit(ir_binop(scale_sq, scale_reg, BinaryOp::OpMul, scale_reg))
+        lo = lo.emit(ir_mark_float_reg(scale_sq))
+        let pair_dst = lo.fresh_reg()
+        lo = pair_dst.0
+        let dst = pair_dst.1
+        lo = lo.emit(ir_binop(dst, scale_sq, BinaryOp::OpMul, variance_reg))
+        lo = lo.emit(ir_mark_float_reg(dst))
+        (lo, dst)
+    }
+
+    fn expr_is_same_ident_ref(self, lhs: &Option<Box<Expr>>, rhs: &Option<Box<Expr>>) -> bool with Mut, Panic, Div {
+        match *lhs {
+            Some(l) => {
+                if (*l).kind == ExprKind::ExprIdent {
+                    match *rhs {
+                        Some(r) => {
+                            if (*r).kind == ExprKind::ExprIdent {
+                                return ir_name_eq((*l).name, (*r).name)
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+        false
+    }
+
+    fn lower_knowledge_variance_for_ident(self, name: Name) -> (Lowerer, i64) with Mut, Panic, Div, Alloc {
+        let shadow = self.lookup_local_variance_reg(name)
+        if shadow >= 0 {
+            return (self, shadow)
+        }
+        let base = self.lookup_local(name)
+        if base < 0 {
+            return (self, -1)
+        }
+        let base_shadow = self.lookup_variance_for_base_reg(base)
+        if base_shadow >= 0 {
+            return (self, base_shadow)
+        }
+        let pair = self.fresh_reg()
+        var lo = pair.0
+        let dst = pair.1
+        var instr = ir_field_get(dst, base, 1, make_name("variance"))
+        instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
+        lo = lo.emit(instr)
+        lo = lo.emit(ir_mark_float_reg(dst))
+        (lo, dst)
+    }
+
+    fn lower_expr_variance_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        if (*e).kind == ExprKind::ExprCall {
+            match (*e).left {
+                Some(callee_expr) => {
+                    let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
+                    if ir_name_is_measure(callee_name) {
+                        let unc_pair = self.lower_measure_uncertainty_arg_ref(&(*e).args)
+                        var lo = unc_pair.0
+                        let unc_reg = unc_pair.1
+                        lo = lo.emit(ir_mark_float_reg(unc_reg))
+                        let pair_v = lo.fresh_reg()
+                        lo = pair_v.0
+                        let variance_reg = pair_v.1
+                        lo = lo.emit(ir_binop(variance_reg, unc_reg, BinaryOp::OpMul, unc_reg))
+                        lo = lo.emit(ir_mark_float_reg(variance_reg))
+                        return (lo, variance_reg)
+                    }
+                }
+                _ => {}
+            }
+            return (self, -1)
+        }
+        if (*e).kind == ExprKind::ExprIdent {
+            let local_v = self.lookup_local_variance_reg((*e).name)
+            if local_v >= 0 {
+                return (self, local_v)
+            }
+            if ir_name_eq(self.lookup_local_struct_type((*e).name), make_name("Knowledge")) {
+                return self.lower_knowledge_variance_for_ident((*e).name)
+            }
+            return (self, -1)
+        }
+        if (*e).kind == ExprKind::ExprFloatLit || (*e).kind == ExprKind::ExprIntLit {
+            return self.emit_zero_variance()
+        }
+        if (*e).kind == ExprKind::ExprFieldAccess {
+            if ir_name_eq((*e).name, make_name("value")) {
+                match (*e).left {
+                    Some(base_expr) => {
+                        if (*base_expr).kind == ExprKind::ExprIdent {
+                            return self.lower_knowledge_variance_for_ident((*base_expr).name)
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return (self, -1)
+        }
+        if (*e).kind == ExprKind::ExprBinary {
+            let same_ident = self.expr_is_same_ident_ref(&(*e).left, &(*e).right)
+            if same_ident && (*e).bin_op == BinaryOp::OpSub {
+                return self.emit_zero_variance()
+            }
+            let pair_lv = match (*e).left {
+                Some(l_expr) => self.lower_expr_variance_ref(&(*l_expr)),
+                _ => (self, -1),
+            }
+            var lo = pair_lv.0
+            let lv0 = pair_lv.1
+            let lv_pair = if lv0 >= 0 { (lo, lv0) } else { lo.emit_zero_variance() }
+            lo = lv_pair.0
+            let lv = lv_pair.1
+
+            let pair_rv = match (*e).right {
+                Some(r_expr) => lo.lower_expr_variance_ref(&(*r_expr)),
+                _ => (lo, -1),
+            }
+            lo = pair_rv.0
+            let rv0 = pair_rv.1
+            let rv_pair = if rv0 >= 0 { (lo, rv0) } else { lo.emit_zero_variance() }
+            lo = rv_pair.0
+            let rv = rv_pair.1
+
+            if (*e).bin_op == BinaryOp::OpAdd || (*e).bin_op == BinaryOp::OpSub {
+                if same_ident && (*e).bin_op == BinaryOp::OpAdd {
+                    let two_pair = lo.emit_f64_const(2.0)
+                    lo = two_pair.0
+                    return lo.emit_variance_scale(lv, two_pair.1)
+                }
+                return lo.emit_variance_add(lv, rv)
+            }
+            if (*e).bin_op == BinaryOp::OpMul {
+                if same_ident {
+                    let lhs_val_pair = lo.lower_opt_expr_ref(&(*e).left)
+                    lo = lhs_val_pair.0
+                    let two_pair = lo.emit_f64_const(2.0)
+                    lo = two_pair.0
+                    let scale_pair = lo.fresh_reg()
+                    lo = scale_pair.0
+                    let scale = scale_pair.1
+                    lo = lo.emit(ir_binop(scale, two_pair.1, BinaryOp::OpMul, lhs_val_pair.1))
+                    lo = lo.emit(ir_mark_float_reg(scale))
+                    return lo.emit_variance_scale(lv, scale)
+                }
+                let lhs_val_pair = lo.lower_opt_expr_ref(&(*e).left)
+                lo = lhs_val_pair.0
+                let lhs_val = lhs_val_pair.1
+                let rhs_val_pair = lo.lower_opt_expr_ref(&(*e).right)
+                lo = rhs_val_pair.0
+                let rhs_val = rhs_val_pair.1
+                let term_l_pair = lo.emit_variance_scale(lv, rhs_val)
+                lo = term_l_pair.0
+                let term_r_pair = lo.emit_variance_scale(rv, lhs_val)
+                lo = term_r_pair.0
+                return lo.emit_variance_add(term_l_pair.1, term_r_pair.1)
+            }
+            return (lo, -1)
+        }
+        (self, -1)
     }
 
     // Returns the print builtin name for println's first argument.
@@ -3921,6 +4214,9 @@ impl Lowerer {
             match (*e).left {
                 Some(callee_expr) => {
                     let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
+                    if self.name_is_variance_of(callee_name) || self.name_is_uncertainty_of(callee_name) {
+                        return true
+                    }
                     let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
                     if fn_id >= 0 && fn_id < self.module.fn_count {
                         return self.module.functions[fn_id as usize].returns_float == 1
@@ -5486,6 +5782,10 @@ impl Lowerer {
             lo = lo.bind_local_closure_fn_id(s.name, lo.pending_closure_fn_id)
             lo.pending_closure_fn_id = -1
         }
+        if lo.pending_variance_reg >= 0 {
+            lo = lo.bind_local_variance_reg(s.name, lo.pending_variance_reg)
+            lo.pending_variance_reg = -1
+        }
         if lower_opt_type_is_array_of_f64(&s.ty) {
             lo = lo.bind_local_array_elem_float(s.name)
         } else {
@@ -5514,6 +5814,23 @@ impl Lowerer {
                 }
                 _ => {}
             }
+        }
+        match s.expr {
+            Some(expr_box_var) => {
+                if lo.lookup_local_variance_reg(s.name) >= 0 {
+                    if lo.expr_result_is_float_ref(&(*expr_box_var)) {
+                        lo = lo.bind_local_scalar_kind(s.name, 2)
+                    }
+                } else {
+                    let var_pair = lo.lower_expr_variance_ref(&(*expr_box_var))
+                    lo = var_pair.0
+                    if var_pair.1 >= 0 {
+                        lo = lo.bind_local_variance_reg(s.name, var_pair.1)
+                        lo = lo.bind_local_scalar_kind(s.name, 2)
+                    }
+                }
+            }
+            _ => {}
         }
         let annotated_wide_bits = lower_opt_type_wide_bits(&s.ty)
         if annotated_wide_bits > 64 {
@@ -5580,6 +5897,15 @@ impl Lowerer {
         let pair_rhs = self.lower_opt_expr_ref(&s.expr)
         var lo = pair_rhs.0
         var rhs = pair_rhs.1
+        var rhs_variance: i64 = -1
+        match s.expr {
+            Some(rhs_expr_var) => {
+                let rhs_var_pair = lo.lower_expr_variance_ref(&(*rhs_expr_var))
+                lo = rhs_var_pair.0
+                rhs_variance = rhs_var_pair.1
+            }
+            _ => {}
+        }
         let target_opt: Option<Box<Expr>> = s.target
 
         if s.assign_op != AssignOp::AssignEq {
@@ -5618,6 +5944,10 @@ impl Lowerer {
                                 lo = lo.emit(ir_store_global(rhs, bss_off_local, (*target_expr).name))
                             }
                             lo = lo.emit(ir_copy(dst, rhs))
+                            if rhs_variance >= 0 {
+                                lo = lo.bind_local_variance_reg((*target_expr).name, rhs_variance)
+                                lo = lo.bind_local_scalar_kind((*target_expr).name, 2)
+                            }
                             (lo, dst)
                         }
                 } else if (*target_expr).kind == ExprKind::ExprFieldAccess {
@@ -6493,27 +6823,17 @@ impl Lowerer {
     }
 
     // Sprint 116: measure(v, uncertainty) → Knowledge<f64> struct construction
-    fn lower_measure_call(self, _span: Span, args: Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+    fn lower_measure_call_ref(self, _span: Span, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         // Extract first argument: value
-        let value_expr = match args {
-            Some(list) => Some(Box::new((*list).head))
-            None => None
-        }
-        let value_pair = self.lower_opt_expr(value_expr)
+        let value_pair = self.lower_measure_value_arg_ref(args)
         let lo1 = value_pair.0
         let value_reg = value_pair.1
 
         // Extract second argument: uncertainty
-        let unc_expr = match args {
-            Some(list) => match (*list).tail {
-                Some(rest) => Some(Box::new((*rest).head))
-                None => None
-            }
-            None => None
-        }
-        let unc_pair = lo1.lower_opt_expr(unc_expr)
-        let lo2 = unc_pair.0
+        let unc_pair = lo1.lower_measure_uncertainty_arg_ref(args)
+        var lo2 = unc_pair.0
         let unc_reg = unc_pair.1
+        lo2 = lo2.emit(ir_mark_float_reg(unc_reg))
 
         // IrAlloc for Knowledge struct
         let dst_pair = lo2.fresh_reg()
@@ -6528,7 +6848,8 @@ impl Lowerer {
         let var_pair = lo5.fresh_reg()
         let lo6 = var_pair.0
         let variance_reg = var_pair.1
-        let lo7 = lo6.emit(ir_binop(variance_reg, unc_reg, BinaryOp::OpMul, unc_reg))
+        var lo7 = lo6.emit(ir_binop(variance_reg, unc_reg, BinaryOp::OpMul, unc_reg))
+        lo7 = lo7.emit(ir_mark_float_reg(variance_reg))
         let lo8 = lo7.emit(ir_field_set(dst_reg, 1, variance_reg, make_name("variance")))
 
         // field 2: confidence = 1.0
@@ -6536,9 +6857,42 @@ impl Lowerer {
         let lo9 = conf_pair.0
         let conf_reg = conf_pair.1
         let lo10 = lo9.emit(ir_load_float(conf_reg, 1.0))
-        let lo11 = lo10.emit(ir_field_set(dst_reg, 2, conf_reg, make_name("confidence")))
+        var lo11 = lo10.emit(ir_field_set(dst_reg, 2, conf_reg, make_name("confidence")))
+        lo11 = lo11.bind_variance_for_base_reg(dst_reg, variance_reg)
+        lo11.pending_variance_reg = variance_reg
 
         (lo11, dst_reg)
+    }
+
+    fn lower_variance_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match *args {
+            Some(list) => {
+                let pair_v = self.lower_expr_variance_ref(&(*list).head)
+                var lo = pair_v.0
+                if pair_v.1 >= 0 {
+                    lo = lo.emit(ir_mark_float_reg(pair_v.1))
+                    return (lo, pair_v.1)
+                }
+                lo.emit_zero_variance()
+            }
+            _ => self.emit_zero_variance(),
+        }
+    }
+
+    fn lower_uncertainty_of_call_ref(self, args: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        let pair_v = self.lower_variance_of_call_ref(args)
+        var lo = pair_v.0
+        let variance_reg = pair_v.1
+        let sqrt_id = lowerer_find_or_add_fn_id_mut(&! lo, make_name("sqrt"))
+        let sqrt_args: Option<Box<IrRegList>> = Some(Box::new(ir_reg_list_single(variance_reg)))
+        let pair_dst = lo.fresh_reg()
+        lo = pair_dst.0
+        let dst = pair_dst.1
+        var instr = ir_call(dst, sqrt_id, make_name("sqrt"), sqrt_args, 1)
+        instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
+        lo = lo.emit(instr)
+        lo = lo.emit(ir_mark_float_reg(dst))
+        (lo, dst)
     }
 
     // lift_knowledge(k: Knowledge<T>) → IrLiftKnowledge (zero-cost copy; epistemic bridge H5.4)
@@ -6917,7 +7271,13 @@ impl Lowerer {
             return self.lower_lift_knowledge_call(e.span, e.args)
         }
         if ir_name_is_measure(callee_name) {
-            return self.lower_measure_call(e.span, e.args)
+            return self.lower_measure_call_ref(e.span, &e.args)
+        }
+        if self.name_is_variance_of(callee_name) {
+            return self.lower_variance_of_call_ref(&e.args)
+        }
+        if self.name_is_uncertainty_of(callee_name) {
+            return self.lower_uncertainty_of_call_ref(&e.args)
         }
         if self.contest_witness_kind_from_callee(callee_name) >= 0 {
             return self.lower_contest_witness_call(e.span, callee_name)

--- a/tests/run-pass/variance_of_literal.sio
+++ b/tests/run-pass/variance_of_literal.sio
@@ -1,0 +1,12 @@
+//@ run-pass
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let v = variance_of(1.0)
+    print("variance_of_literal="); println(v)
+    if v != 0.0 {
+        print("FAIL\n")
+        return 1
+    }
+    print("PASS\n")
+    return 0
+}

--- a/tests/run-pass/variance_of_measure_sum.sio
+++ b/tests/run-pass/variance_of_measure_sum.sio
@@ -1,0 +1,29 @@
+//@ run-pass
+
+fn main() -> i64 with IO, Mut, Epistemic {
+    let ka: Knowledge<f64> = measure(10.0, uncertainty: 2.0)
+    let kb: Knowledge<f64> = measure(3.0, uncertainty: 3.0)
+    let a = ka.value
+    let b = kb.value
+    let total = a + b
+    let vt = variance_of(total)
+    let va = variance_of(a)
+    let vb = variance_of(b)
+    print("variance_total="); println(vt)
+    print("variance_a="); println(va)
+    print("variance_b="); println(vb)
+    if vt != 13.0 {
+        print("FAIL total\n")
+        return 1
+    }
+    if va != 4.0 {
+        print("FAIL a\n")
+        return 1
+    }
+    if vb != 9.0 {
+        print("FAIL b\n")
+        return 1
+    }
+    print("PASS\n")
+    return 0
+}


### PR DESCRIPTION
## Summary
- teach the checker to type `variance_of(...)` and `uncertainty_of(...)` as builtin `f64` calls instead of falling through to undeclared/unknown call handling
- add Madaros IR lowering for `variance_of`/`uncertainty_of` over literals, `measure(...)`, `Knowledge` locals, `.value` shadows, and simple propagated arithmetic
- add focused run-pass coverage for literal zero variance and measured-value variance propagation

## Validation
- `SOUC_BIN=$PWD/bin/souc bash scripts/ci/build_modular_madaros.sh /tmp/sounio-madaros-gum-variance-build/madaros` PASS, produced `/tmp/sounio-madaros-gum-variance-build/madaros` (95,202,702 bytes)
- direct smoke: `variance_of(k)` prints `4.000000`; `uncertainty_of(k)` prints `2.000000`
- `SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/sounio-madaros-gum-variance-build/madaros bash scripts/run_sio_test_suite.sh --filter variance_of --verbose` PASS 2/2
- `SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/sounio-madaros-gum-variance-build/madaros bash scripts/run_sio_test_suite.sh --filter gum_iso_budget --verbose` PASS 2/2
- `SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/sounio-madaros-gum-variance-build/madaros bash scripts/run_sio_test_suite.sh --filter gum_correlated --verbose` PASS 1/1
- `SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/sounio-madaros-gum-variance-build/madaros bash scripts/ci/serious_language_conformance_gate.sh` FAIL 12/16, remaining failures: `observe-io-boundary`, `generics-multi-run`, `gum-compliance-run`, `knowledge-boundary-diagnostic`

## Known remaining blockers
- `gum-compliance-run` still exits through the serious conformance gate; this PR does not claim full GUM closure.
- Separate Madaros f64 decimal-literal behavior observed during validation: `1.5` and `2.25` print as `1.000000` and `2.000000`; the new tests avoid fractional decimal expectations.
- Separate Knowledge value runtime behavior observed during validation: direct `println(k.value)` exits 139 and `let a = k.value; println(a)` prints `0.000000`; this PR routes `variance_of(k.value)` through the new variance shadow path but does not claim to repair general `.value` extraction.

LLM-offload reviews invoked: none; compiler lowerer/checker/test work only, no math claims, clinical-pathway code, or external-facing artifact changes.
