### PR TITLE
Fix Madaros GUM conformance run

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -8054,7 +8054,7 @@ fn compiler_main_test_ocp_partial_fold_dce_round_trip() -> bool with Mut, Div, P
 // T93: LICM hoists pure invariant instructions into the unique preheader.
 fn compiler_main_make_licm_hoist_test_func() -> IrFunction with Mut, Panic, Div {
     var func = ir_empty_function()
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 1)
     instrs[1] = ir_jump(0)
     instrs[2] = ir_label(0)
@@ -8078,7 +8078,7 @@ fn compiler_main_make_licm_hoist_test_func() -> IrFunction with Mut, Panic, Div 
 // T94: LICM leaves side-effecting calls in place.
 fn compiler_main_make_licm_call_test_func() -> IrFunction with Mut, Panic, Div {
     var func = ir_empty_function()
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 1)
     instrs[1] = ir_jump(0)
     instrs[2] = ir_label(0)
@@ -13454,7 +13454,7 @@ fn compiler_main_test_neg_mul_neg_aw() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_add_add() -> bool with Mut, Div, Panic {
     // (x+3)-(x+1) → 2: both add-const with same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)       // r0 = 42 (x)
     instrs[1 as usize] = ir_load_imm(1, 3)         // r1 = 3 (C1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = x+3
@@ -13468,7 +13468,7 @@ fn compiler_main_test_const_offset_diff_add_add() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_sub_sub() -> bool with Mut, Div, Panic {
     // (x-3)-(x-1) → -2: both sub-const with same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = x-3
@@ -13482,7 +13482,7 @@ fn compiler_main_test_const_offset_diff_sub_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_add_sub() -> bool with Mut, Div, Panic {
     // (x+3)-(x-1) → 4: add minus sub-const, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = x+3
@@ -13496,7 +13496,7 @@ fn compiler_main_test_const_offset_diff_add_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_sub_add() -> bool with Mut, Div, Panic {
     // (x-3)-(x+1) → -4: sub minus add-const, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = x-3
@@ -13510,7 +13510,7 @@ fn compiler_main_test_const_offset_diff_sub_add() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_const_offset_diff_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x+3)-(y+1) → no fold (different bases)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)        // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 99)        // r1 = y (different)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -13525,7 +13525,7 @@ fn compiler_main_test_const_offset_diff_no_fold_diff_base() -> bool with Mut, Di
 
 fn compiler_main_test_const_offset_diff_no_fold_plain_sub() -> bool with Mut, Div, Panic {
     // a - b → no fold (neither is tracked as const-offset)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 10)
     instrs[1 as usize] = ir_load_imm(1, 7)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = 10*7 (not const-offset)
@@ -13539,7 +13539,7 @@ fn compiler_main_test_const_offset_diff_no_fold_plain_sub() -> bool with Mut, Di
 
 fn compiler_main_test_twos_comp_neg_basic() -> bool with Mut, Div, Panic {
     // ~x + 1 → neg(x): two's complement negation identity
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)          // r0 = 5 (x)
     instrs[1 as usize] = ir_load_imm(1, -1)          // r1 = -1
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x (x^(-1))
@@ -13552,7 +13552,7 @@ fn compiler_main_test_twos_comp_neg_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_commutative() -> bool with Mut, Div, Panic {
     // 1 + ~x → neg(x): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 7)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13565,7 +13565,7 @@ fn compiler_main_test_twos_comp_neg_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_src_correct() -> bool with Mut, Div, Panic {
     // ~x + 1 → neg(x): verify src1 points to x (not ~x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 9)           // r0 = x
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13580,7 +13580,7 @@ fn compiler_main_test_twos_comp_neg_src_correct() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_no_fold_wrong_const() -> bool with Mut, Div, Panic {
     // ~x + 2 → no fold (constant is 2, not 1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13593,7 +13593,7 @@ fn compiler_main_test_twos_comp_neg_no_fold_wrong_const() -> bool with Mut, Div,
 
 fn compiler_main_test_twos_comp_neg_no_fold_sub() -> bool with Mut, Div, Panic {
     // ~x - 1 → no fold (OpSub, not OpAdd)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = ~x
@@ -13606,7 +13606,7 @@ fn compiler_main_test_twos_comp_neg_no_fold_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_twos_comp_neg_no_fold_plain() -> bool with Mut, Div, Panic {
     // y + 1 → no fold (y is a plain mul, not bitwise NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 3)
     instrs[1 as usize] = ir_load_imm(1, 4)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)      // r2 = 3*4 (not bnot)
@@ -13621,7 +13621,7 @@ fn compiler_main_test_twos_comp_neg_no_fold_plain() -> bool with Mut, Div, Panic
 
 // T530: x + ~x → -1  [basic: s2 is NOT(s1)]
 fn compiler_main_test_add_complement_basic() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = r0 + ~r0 → -1
     let func = cp_make_test_func(instrs, 2)
@@ -13631,7 +13631,7 @@ fn compiler_main_test_add_complement_basic() -> bool with Mut, Div, Panic {
 
 // T531: ~x + x → -1  [commutative: s1 is NOT(s2)]
 fn compiler_main_test_add_complement_comm() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)   // r2 = ~r0 + r0 → -1
     let func = cp_make_test_func(instrs, 2)
@@ -13641,7 +13641,7 @@ fn compiler_main_test_add_complement_comm() -> bool with Mut, Div, Panic {
 
 // T532: (x + ~x) + 5 → -1 + 5 = 4  [downstream const-fold chains]
 fn compiler_main_test_add_complement_downstream() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = r0 + ~r0 → -1
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -13653,7 +13653,7 @@ fn compiler_main_test_add_complement_downstream() -> bool with Mut, Div, Panic {
 
 // T533: x + ~y (different vars) — no fold
 fn compiler_main_test_add_complement_diff_var() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)     // r2 = ~r1 (r1 is param, ≠ r0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)   // r3 = r0 + ~r1 (diff base)
     let func = cp_make_test_func(instrs, 2)
@@ -13663,7 +13663,7 @@ fn compiler_main_test_add_complement_diff_var() -> bool with Mut, Div, Panic {
 
 // T534: x | ~x → -1 still works (Block AR unaffected by BF)
 fn compiler_main_test_add_complement_or_still_works() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1) // r2 = r0 | ~r0 → -1 (Block AR)
     let func = cp_make_test_func(instrs, 2)
@@ -13673,7 +13673,7 @@ fn compiler_main_test_add_complement_or_still_works() -> bool with Mut, Div, Pan
 
 // T535: x - ~x no fold (sub, not add)
 fn compiler_main_test_add_complement_sub_no_fold() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)     // r1 = ~r0
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - ~r0 (no BF fold)
     let func = cp_make_test_func(instrs, 2)
@@ -13683,7 +13683,7 @@ fn compiler_main_test_add_complement_sub_no_fold() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_or_chain_basic() -> bool with Mut, Div, Panic {
     // (x | 0b0011) | 0b1100 → x | 0b1111: OR chain merges non-overlapping masks
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)         // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 3)           // r1 = 0b0011
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x | 3
@@ -13700,7 +13700,7 @@ fn compiler_main_test_or_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_chain_commutative() -> bool with Mut, Div, Panic {
     // 0b1100 | (x | 0b0011) → x | 0b1111: commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x | 3
@@ -13715,7 +13715,7 @@ fn compiler_main_test_or_chain_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_chain_three_levels() -> bool with Mut, Div, Panic {
     // ((x | 1) | 2) | 4 → x | 7: three-level OR chain
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x|1
@@ -13733,7 +13733,7 @@ fn compiler_main_test_or_chain_three_levels() -> bool with Mut, Div, Panic {
 fn compiler_main_test_or_chain_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x | 3) | 4 where the base differs from AM's case — should fold (both same x)
     // But (x|3)|(y|4): different bases, no merge → test no-fold path
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)     // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 99)     // r1 = y (different)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -13749,7 +13749,7 @@ fn compiler_main_test_or_chain_no_fold_diff_base() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_or_chain_superset_still_block_am() -> bool with Mut, Div, Panic {
     // (x | 0b1111) | 0b0011 → IrCopy (Block AM handles superset, BG not needed)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 15)      // r1 = 0b1111
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = x|15
@@ -13763,7 +13763,7 @@ fn compiler_main_test_or_chain_superset_still_block_am() -> bool with Mut, Div, 
 
 fn compiler_main_test_or_chain_and_not_folded() -> bool with Mut, Div, Panic {
     // (x & 3) | 12 → not an OR chain fold (x&3 is AND, not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = x&3 (not OR)
@@ -13782,7 +13782,7 @@ fn compiler_main_test_or_chain_and_not_folded() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_basic() -> bool with Mut, Div, Panic {
     // (x & 0x0F) | 0xFF → 0xFF  [C1=0x0F, C2=0xFF, C1&C2=0x0F==C1 => subset]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13794,7 +13794,7 @@ fn compiler_main_test_and_subset_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_comm() -> bool with Mut, Div, Panic {
     // 0xFF | (x & 0x0F) → 0xFF  [commutative form]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13806,7 +13806,7 @@ fn compiler_main_test_and_subset_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_same() -> bool with Mut, Div, Panic {
     // (x & 0xFF) | 0xFF → 0xFF  [same mask: C1 == C2]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13818,7 +13818,7 @@ fn compiler_main_test_and_subset_or_same() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_and_subset_or_no_fold_superset() -> bool with Mut, Div, Panic {
     // (x & 0xFF) | 0x0F → no fold (C1=0xFF not subset of C2=0x0F)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 15)
@@ -13830,7 +13830,7 @@ fn compiler_main_test_and_subset_or_no_fold_superset() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_and_subset_or_no_fold_disjoint() -> bool with Mut, Div, Panic {
     // (x & 0x0F) | 0xF0 → no fold (0x0F & 0xF0 = 0 != 0x0F)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 240)
@@ -13842,7 +13842,7 @@ fn compiler_main_test_and_subset_or_no_fold_disjoint() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_and_subset_or_downstream() -> bool with Mut, Div, Panic {
     // (x & 0x0F) | 0xFF → folded to IrLoadImm(255); const propagates
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13857,7 +13857,7 @@ fn compiler_main_test_and_subset_or_downstream() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_basic() -> bool with Mut, Div, Panic {
     // (x | 0xFF) & 0xFF00 → x & 0xFF00  [0xFF & 0xFF00 = 0]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 65280)
@@ -13871,7 +13871,7 @@ fn compiler_main_test_or_mask_clear_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_comm() -> bool with Mut, Div, Panic {
     // 0xAA & (x | 0x55) → x & 0xAA  [commutative: 0x55 & 0xAA = 0]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 85)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 170)
@@ -13885,7 +13885,7 @@ fn compiler_main_test_or_mask_clear_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_nibble() -> bool with Mut, Div, Panic {
     // (x | 0x0F) & 0xF0 → x & 0xF0  [nibble-aligned: 0x0F & 0xF0 = 0]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 240)
@@ -13899,7 +13899,7 @@ fn compiler_main_test_or_mask_clear_nibble() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_or_mask_clear_no_fold_overlap() -> bool with Mut, Div, Panic {
     // (x | 0x3C) & 0x3A → no fold (0x3C & 0x3A = 0x38 != 0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 60)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 58)
@@ -13912,7 +13912,7 @@ fn compiler_main_test_or_mask_clear_no_fold_overlap() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_or_mask_clear_no_fold_superset() -> bool with Mut, Div, Panic {
     // (x | 0xF0) & 0xFF → no fold (0xF0 & 0xFF = 0xF0 != 0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 240)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -13925,7 +13925,7 @@ fn compiler_main_test_or_mask_clear_no_fold_superset() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_or_mask_clear_downstream() -> bool with Mut, Div, Panic {
     // (x | 0xFF) & 0xFF00 → x & 0xFF00; rewritten AND has src1=r0, src2=r3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 65280)
@@ -13943,7 +13943,7 @@ fn compiler_main_test_or_mask_clear_downstream() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_basic() -> bool with Mut, Div, Panic {
     // ~(~r0) → IrCopy(r0); r1 = ~r0, r2 = ~r1 → r2 = ir_copy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -13953,7 +13953,7 @@ fn compiler_main_test_double_not_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_src_preserved() -> bool with Mut, Div, Panic {
     // ~(~r0) → IrCopy(r0); the copy source must be r0 (register 0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -13963,7 +13963,7 @@ fn compiler_main_test_double_not_src_preserved() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_xor_form() -> bool with Mut, Div, Panic {
     // XOR(-1) form as inner NOT: r2 = r0^(-1); r3 = ~r2 → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
@@ -13974,7 +13974,7 @@ fn compiler_main_test_double_not_xor_form() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_no_fold_single() -> bool with Mut, Div, Panic {
     // Single NOT — no fold; stays as IrUnaryOp
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -13983,7 +13983,7 @@ fn compiler_main_test_double_not_no_fold_single() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_double_not_const_fold_wins() -> bool with Mut, Div, Panic {
     // When src is a const, const-fold applies: ~(~5) → ~(-6) → 5 (IrLoadImm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
@@ -13994,7 +13994,7 @@ fn compiler_main_test_double_not_const_fold_wins() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_double_not_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // ~r9 where r9 is not a NOT — no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 9)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -14007,7 +14007,7 @@ fn compiler_main_test_double_not_no_fold_diff_reg() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bk_shl_chain() -> bool with Mut, Div, Panic {
     // (r0 << 2) << 3 → r0 << 5; via opt_cleanup_function
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -14021,7 +14021,7 @@ fn compiler_main_test_bk_shl_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_shr_chain() -> bool with Mut, Div, Panic {
     // (r0 >> 1) >> 4 → r0 >> 5; via opt_cleanup_function
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShr, 1)
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -14035,7 +14035,7 @@ fn compiler_main_test_bk_shr_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_combined_amount() -> bool with Mut, Div, Panic {
     // (r0 << 3) << 4 → r0 << 7; amount constant patched to 7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -14047,7 +14047,7 @@ fn compiler_main_test_bk_combined_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_no_fold_overflow() -> bool with Mut, Div, Panic {
     // (r0 << 60) << 10 → no fold (60+10=70 >= 64)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 60)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 10)
@@ -14059,7 +14059,7 @@ fn compiler_main_test_bk_no_fold_overflow() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_no_fold_diff_dir() -> bool with Mut, Div, Panic {
     // (r0 << 2) >> 3 — different directions, no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -14071,7 +14071,7 @@ fn compiler_main_test_bk_no_fold_diff_dir() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bk_no_fold_var_amount() -> bool with Mut, Div, Panic {
     // (r0 << 2) << r9 — amount not const, no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpShl, 9)
@@ -14082,7 +14082,7 @@ fn compiler_main_test_bk_no_fold_var_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_basic() -> bool with Mut, Div, Panic {
     // (x << 3) & 7 → 0: bottom 3 bits of x<<3 are zero, mask 7=0b111 covers only those
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)           // shift amount
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14095,7 +14095,7 @@ fn compiler_main_test_shl_low_mask_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_commutative() -> bool with Mut, Div, Panic {
     // 7 & (x << 3) → 0: commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14108,7 +14108,7 @@ fn compiler_main_test_shl_low_mask_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_partial() -> bool with Mut, Div, Panic {
     // (x << 4) & 15 → 0: mask 15=0b1111 exactly covers bottom 4 bits
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 99)
     instrs[1 as usize] = ir_load_imm(1, 4)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 4
@@ -14121,7 +14121,7 @@ fn compiler_main_test_shl_low_mask_partial() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_shl_low_mask_no_fold_high_bit() -> bool with Mut, Div, Panic {
     // (x << 3) & 8 → no fold: mask 8=0b1000 has bit 3 set, which may be in x<<3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14134,7 +14134,7 @@ fn compiler_main_test_shl_low_mask_no_fold_high_bit() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_shl_low_mask_no_fold_negative_mask() -> bool with Mut, Div, Panic {
     // (x << 3) & (-1) → no fold: mask -1 has all bits set (negative, not < threshold)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)   // r2 = x << 3
@@ -14147,7 +14147,7 @@ fn compiler_main_test_shl_low_mask_no_fold_negative_mask() -> bool with Mut, Div
 
 fn compiler_main_test_shl_low_mask_no_fold_plain_and() -> bool with Mut, Div, Panic {
     // x & 7 → no fold (x not tracked as shl result)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = x+3 (not shl)
@@ -14163,7 +14163,7 @@ fn compiler_main_test_shl_low_mask_no_fold_plain_and() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_bm_xor_chain_basic() -> bool with Mut, Div, Panic {
     // (r0 ^ 3) ^ 5 → r0 ^ 6  [3^5=6]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14177,7 +14177,7 @@ fn compiler_main_test_bm_xor_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_chain_merged_val() -> bool with Mut, Div, Panic {
     // (r0 ^ 0x0F) ^ 0xF0 → r0 ^ 0xFF; constant register holds 0xFF
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 240)
@@ -14190,7 +14190,7 @@ fn compiler_main_test_bm_xor_chain_merged_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_chain_cancel() -> bool with Mut, Div, Panic {
     // (r0 ^ 7) ^ 7 → r0 ^ 0 = r0; const-fold then identity eliminates XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -14203,7 +14203,7 @@ fn compiler_main_test_bm_xor_chain_cancel() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_chain_comm() -> bool with Mut, Div, Panic {
     // 5 ^ (r0 ^ 3) → r0 ^ 6  [commutative outer form]
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14217,7 +14217,7 @@ fn compiler_main_test_bm_xor_chain_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_no_fold_rr() -> bool with Mut, Div, Panic {
     // (r0 ^ r1) ^ r2 — no fold (no const operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 9)
     let func = cp_make_test_func(instrs, 2)
@@ -14228,7 +14228,7 @@ fn compiler_main_test_bm_xor_no_fold_rr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bm_xor_no_fold_different_op() -> bool with Mut, Div, Panic {
     // (r0 | 3) ^ 5 — inner is OR not XOR, no bm_xor_valid
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14241,7 +14241,7 @@ fn compiler_main_test_bm_xor_no_fold_different_op() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_xor_self_recovery_basic() -> bool with Mut, Div, Panic {
     // (x^5) ^ x → 5: XOR with original base recovers the constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14253,7 +14253,7 @@ fn compiler_main_test_xor_self_recovery_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_self_recovery_commutative() -> bool with Mut, Div, Panic {
     // x ^ (x^5) → 5: commutative outer XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14265,7 +14265,7 @@ fn compiler_main_test_xor_self_recovery_commutative() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_xor_pair_cancel() -> bool with Mut, Div, Panic {
     // (x^3) ^ (x^5) → 6 (= 3^5): shared base cancels, constants XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^3
@@ -14279,7 +14279,7 @@ fn compiler_main_test_xor_pair_cancel() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_self_recovery_neg_const() -> bool with Mut, Div, Panic {
     // (x^(-1)) ^ x → -1: negative constant recovered correctly
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, -1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^(-1)
@@ -14291,7 +14291,7 @@ fn compiler_main_test_xor_self_recovery_neg_const() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_xor_self_recovery_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x^3) ^ y → no fold (y != x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 99)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -14304,7 +14304,7 @@ fn compiler_main_test_xor_self_recovery_no_fold_diff_base() -> bool with Mut, Di
 
 fn compiler_main_test_xor_self_recovery_no_fold_plain() -> bool with Mut, Div, Panic {
     // a ^ b → no fold (neither tracked as xor-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 10)
     instrs[1 as usize] = ir_load_imm(1, 20)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -14319,7 +14319,7 @@ fn compiler_main_test_xor_self_recovery_no_fold_plain() -> bool with Mut, Div, P
 // Sprint 153 Block BO: Two's-complement rewrite (T584-T589)
 fn compiler_main_test_bo_twos_comp_basic() -> bool with Mut, Div, Panic {
     // ~r0 + 1 → -r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_load_imm(2, 1)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 2)
@@ -14332,7 +14332,7 @@ fn compiler_main_test_bo_twos_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bo_twos_comp_commutative() -> bool with Mut, Div, Panic {
     // 1 + ~r0 → -r0 (commutative outer Add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 2)
@@ -14345,7 +14345,7 @@ fn compiler_main_test_bo_twos_comp_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bo_twos_comp_no_fold_const2() -> bool with Mut, Div, Panic {
     // ~r0 + 2 → no fold (constant is 2, not 1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_load_imm(2, 2)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 2)
@@ -14356,7 +14356,7 @@ fn compiler_main_test_bo_twos_comp_no_fold_const2() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bo_twos_comp_no_fold_not_not() -> bool with Mut, Div, Panic {
     // r0 + 1 → no fold (s1 is not a NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14366,7 +14366,7 @@ fn compiler_main_test_bo_twos_comp_no_fold_not_not() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_bo_twos_comp_neg_src() -> bool with Mut, Div, Panic {
     // ~(r0 + r1) + 1 → -(r0+r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)   // r3 = r0 + 5
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)     // r4 = ~(r0+5)
@@ -14381,7 +14381,7 @@ fn compiler_main_test_bo_twos_comp_neg_src() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bo_twos_comp_no_fold_sub() -> bool with Mut, Div, Panic {
     // ~r0 - 1 → no fold (Sub not Add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_load_imm(2, 1)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 2)
@@ -14393,7 +14393,7 @@ fn compiler_main_test_bo_twos_comp_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 154 Block BP: AND-complement annihilation (T590-T595)
 fn compiler_main_test_bp_and_complement_basic() -> bool with Mut, Div, Panic {
     // r0 & ~r0 → IrLoadImm(0): AND-complement annihilation
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14403,7 +14403,7 @@ fn compiler_main_test_bp_and_complement_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bp_and_complement_commutative() -> bool with Mut, Div, Panic {
     // ~r0 & r0 → IrLoadImm(0): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -14413,7 +14413,7 @@ fn compiler_main_test_bp_and_complement_commutative() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_bp_and_complement_expr() -> bool with Mut, Div, Panic {
     // (r0+5) & ~(r0+5) → 0: AND-complement of composite expression
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -14425,7 +14425,7 @@ fn compiler_main_test_bp_and_complement_expr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bp_and_complement_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r0 & ~r2 → no fold: r2 != r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 7)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -14436,7 +14436,7 @@ fn compiler_main_test_bp_and_complement_no_fold_diff_reg() -> bool with Mut, Div
 
 fn compiler_main_test_bp_and_complement_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 & r1 → no fold: neither is NOT
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14446,7 +14446,7 @@ fn compiler_main_test_bp_and_complement_no_fold_plain() -> bool with Mut, Div, P
 
 fn compiler_main_test_bp_and_complement_no_fold_or() -> bool with Mut, Div, Panic {
     // r0 | ~r0 → no fold by Block BP (OR is not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14458,7 +14458,7 @@ fn compiler_main_test_bp_and_complement_no_fold_or() -> bool with Mut, Div, Pani
 // Sprint 155 Block BQ: OR-complement absorption (T596-T601)
 fn compiler_main_test_bq_or_complement_basic() -> bool with Mut, Div, Panic {
     // r0 | ~r0 → IrLoadImm(-1): OR-complement absorption
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14468,7 +14468,7 @@ fn compiler_main_test_bq_or_complement_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bq_or_complement_commutative() -> bool with Mut, Div, Panic {
     // ~r0 | r0 → IrLoadImm(-1): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -14478,7 +14478,7 @@ fn compiler_main_test_bq_or_complement_commutative() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_bq_or_complement_expr() -> bool with Mut, Div, Panic {
     // (r0+5) | ~(r0+5) → -1: OR-complement of composite expression
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -14490,7 +14490,7 @@ fn compiler_main_test_bq_or_complement_expr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bq_or_complement_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r0 | ~r2 → no fold: r2 != r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 7)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -14501,7 +14501,7 @@ fn compiler_main_test_bq_or_complement_no_fold_diff_reg() -> bool with Mut, Div,
 
 fn compiler_main_test_bq_or_complement_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 | r1 → no fold: neither is NOT
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14511,7 +14511,7 @@ fn compiler_main_test_bq_or_complement_no_fold_plain() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_bq_or_complement_no_fold_and() -> bool with Mut, Div, Panic {
     // r0 & ~r0 → not absorbed by Block BQ (AND is not OR); Block BP handles that
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14523,7 +14523,7 @@ fn compiler_main_test_bq_or_complement_no_fold_and() -> bool with Mut, Div, Pani
 // Sprint 156 Block BR: XOR-complement (T602-T607)
 fn compiler_main_test_br_xor_complement_basic() -> bool with Mut, Div, Panic {
     // r0 ^ ~r0 → IrLoadImm(-1): XOR-complement
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14533,7 +14533,7 @@ fn compiler_main_test_br_xor_complement_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_br_xor_complement_commutative() -> bool with Mut, Div, Panic {
     // ~r0 ^ r0 → IrLoadImm(-1): commutative form
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -14543,7 +14543,7 @@ fn compiler_main_test_br_xor_complement_commutative() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_br_xor_complement_expr() -> bool with Mut, Div, Panic {
     // (r0*3) ^ ~(r0*3) → -1: XOR-complement of composite expression
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -14555,7 +14555,7 @@ fn compiler_main_test_br_xor_complement_expr() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_br_xor_complement_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r0 ^ ~r2 → no fold: r2 != r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 9)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 3)
@@ -14566,7 +14566,7 @@ fn compiler_main_test_br_xor_complement_no_fold_diff_reg() -> bool with Mut, Div
 
 fn compiler_main_test_br_xor_complement_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 ^ r1 → no fold: neither is NOT
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 42)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14576,7 +14576,7 @@ fn compiler_main_test_br_xor_complement_no_fold_plain() -> bool with Mut, Div, P
 
 fn compiler_main_test_br_xor_complement_no_fold_and() -> bool with Mut, Div, Panic {
     // r0 & ~r0 → Block BP handles it; Block BR (XOR) does NOT emit -1 for AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(1, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -14588,7 +14588,7 @@ fn compiler_main_test_br_xor_complement_no_fold_and() -> bool with Mut, Div, Pan
 // Sprint 157 Block BS: Consecutive subtract-constant fold (T608-T613)
 fn compiler_main_test_bs_sub_chain_basic() -> bool with Mut, Div, Panic {
     // (r0 - 3) - 5 → r0 - 8
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14602,7 +14602,7 @@ fn compiler_main_test_bs_sub_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_neg() -> bool with Mut, Div, Panic {
     // (r0 - 10) - (-3) → r0 - 7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 10)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 10
     instrs[2 as usize] = ir_load_imm(3, -3)
@@ -14615,7 +14615,7 @@ fn compiler_main_test_bs_sub_chain_neg() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_amount() -> bool with Mut, Div, Panic {
     // (r0 - 7) - 13 → r0 - 20: verify merged constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_load_imm(3, 13)
@@ -14627,7 +14627,7 @@ fn compiler_main_test_bs_sub_chain_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_no_fold_var() -> bool with Mut, Div, Panic {
     // (r0 - r1) - 5 → no fold: s2 of inner sub is not constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)  // r3 = r0 - r1 (var sub)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 2)  // r4 = (r0-r1) - 5
@@ -14638,7 +14638,7 @@ fn compiler_main_test_bs_sub_chain_no_fold_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0 + 3) - 5 → no fold by Block BS (+ not -)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14650,7 +14650,7 @@ fn compiler_main_test_bs_sub_chain_no_fold_add() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bs_sub_chain_no_fold_rhs_var() -> bool with Mut, Div, Panic {
     // (r0 - 3) - r1 → no fold: outer rhs is variable not const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)  // r3 = r0 - 3
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 1)  // r4 = (r0-3) - r1 (var)
@@ -14662,7 +14662,7 @@ fn compiler_main_test_bs_sub_chain_no_fold_rhs_var() -> bool with Mut, Div, Pani
 // Sprint 158 Block BT: Consecutive add-constant fold (T614-T619)
 fn compiler_main_test_bt_add_chain_basic() -> bool with Mut, Div, Panic {
     // (r0 + 3) + 5 → r0 + 8: base register becomes r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14676,7 +14676,7 @@ fn compiler_main_test_bt_add_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_commutative() -> bool with Mut, Div, Panic {
     // 5 + (r0 + 3) → r0 + 8: commutative outer add
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14690,7 +14690,7 @@ fn compiler_main_test_bt_add_chain_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_amount() -> bool with Mut, Div, Panic {
     // (r0 + 7) + 13 → r0 + 20: verify merged constant = 20
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_load_imm(3, 13)
@@ -14702,7 +14702,7 @@ fn compiler_main_test_bt_add_chain_amount() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_no_fold_var() -> bool with Mut, Div, Panic {
     // (r0 + r1) + 5 → no fold: inner rhs is variable not const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)  // r3 = r0 + r1
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 2)
@@ -14713,7 +14713,7 @@ fn compiler_main_test_bt_add_chain_no_fold_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0 - 3) + 5 → no fold by Block BT (inner is sub not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -14725,7 +14725,7 @@ fn compiler_main_test_bt_add_chain_no_fold_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bt_add_chain_no_fold_rhs_var() -> bool with Mut, Div, Panic {
     // (r0 + 3) + r1 → no fold: outer rhs is variable
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 1)
@@ -14736,7 +14736,7 @@ fn compiler_main_test_bt_add_chain_no_fold_rhs_var() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_addconst_subconst_diff() -> bool with Mut, Div, Panic {
     // (x+3)-(x-2) → 5: bt_add minus bs_sub, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = x+3 (bt_add)
@@ -14750,7 +14750,7 @@ fn compiler_main_test_addconst_subconst_diff() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_subconst_addconst_diff() -> bool with Mut, Div, Panic {
     // (x-2)-(x+3) → -5: bs_sub minus bt_add, same base
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 2)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = x-2 (bs_sub)
@@ -14764,7 +14764,7 @@ fn compiler_main_test_subconst_addconst_diff() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_subconst_subconst_diff() -> bool with Mut, Div, Panic {
     // (x-3)-(x-5) → 2: bs_sub minus bs_sub, same base (C2-C1=5-3=2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = x-3 (bs_sub)
@@ -14778,7 +14778,7 @@ fn compiler_main_test_subconst_subconst_diff() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_addconst_addconst_diff_bu() -> bool with Mut, Div, Panic {
     // (x+5)-(x+3) → 2: bt_add minus bt_add, same base (C1-C2=5-3=2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)   // r2 = x+5 (bt_add)
@@ -14792,7 +14792,7 @@ fn compiler_main_test_addconst_addconst_diff_bu() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bu_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (x+3)-(y-2) → no fold: different base registers
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)   // x
     instrs[1 as usize] = ir_load_imm(1, 99)   // y (different)
     instrs[2 as usize] = ir_load_imm(2, 3)
@@ -14807,7 +14807,7 @@ fn compiler_main_test_bu_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bu_chain_fold() -> bool with Mut, Div, Panic {
     // Chain: (x-1)-1 = x-2 via Block BS; then (x+3)-(x-2) → 5 via Block BU
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)   // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 1)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = x-1
@@ -14823,7 +14823,7 @@ fn compiler_main_test_bu_chain_fold() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_merge_basic() -> bool with Mut, Div, Panic {
     // (x^5) | 5 → x|5: XOR-OR merge; src1 should be x (not x^5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)         // r0 = x
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14838,7 +14838,7 @@ fn compiler_main_test_xor_or_merge_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_merge_commutative() -> bool with Mut, Div, Panic {
     // 5 | (x^5) → x|5: commutative outer OR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14853,7 +14853,7 @@ fn compiler_main_test_xor_or_merge_commutative() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_merge_diff_const() -> bool with Mut, Div, Panic {
     // (x^12) | 12 → x|12: works with a different constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 12)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^12
@@ -14868,7 +14868,7 @@ fn compiler_main_test_xor_or_merge_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_no_fold_const_mismatch() -> bool with Mut, Div, Panic {
     // (x^5) | 3 → no fold: OR constant (3) differs from XOR constant (5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14882,7 +14882,7 @@ fn compiler_main_test_xor_or_no_fold_const_mismatch() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_xor_or_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (x^5) & 5 → no fold by BV (AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 5)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x^5
@@ -14896,7 +14896,7 @@ fn compiler_main_test_xor_or_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_xor_or_no_fold_plain_or() -> bool with Mut, Div, Panic {
     // y | 5 → no fold: y not tracked as xor-const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)     // r2 = x+3 (not xor)
@@ -14910,7 +14910,7 @@ fn compiler_main_test_xor_or_no_fold_plain_or() -> bool with Mut, Div, Panic {
 // Sprint 161 Block BW: XOR-mask AND complement (T632-T637)
 fn compiler_main_test_bw_xor_and_comp_basic() -> bool with Mut, Div, Panic {
     // (x ^ 5) & ~5 → x & ~5: xor-mask AND complement fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -14923,7 +14923,7 @@ fn compiler_main_test_bw_xor_and_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_xor_and_comp_comm() -> bool with Mut, Div, Panic {
     // ~5 & (x ^ 5) → x & ~5: commutative outer AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -14936,7 +14936,7 @@ fn compiler_main_test_bw_xor_and_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_xor_and_comp_val() -> bool with Mut, Div, Panic {
     // (x ^ 0xFF) & ~0xFF → x & ~0xFF: verify with 0xFF constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 0xFF
     instrs[2 as usize] = ir_load_imm(3, -256)                   // r3 = ~0xFF = -256
@@ -14949,7 +14949,7 @@ fn compiler_main_test_bw_xor_and_comp_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_no_fold_wrong_complement() -> bool with Mut, Div, Panic {
     // (x ^ 5) & 5 → no fold: AND mask is C not ~C
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = x ^ 5
     instrs[2 as usize] = ir_load_imm(3, 5)                      // r3 = 5 (not ~5)
@@ -14961,7 +14961,7 @@ fn compiler_main_test_bw_no_fold_wrong_complement() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bw_no_fold_or_op() -> bool with Mut, Div, Panic {
     // (x ^ 5) | ~5 → no fold by BW (OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -14974,7 +14974,7 @@ fn compiler_main_test_bw_no_fold_or_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bw_no_fold_plain_and() -> bool with Mut, Div, Panic {
     // (x + 5) & ~5 → no fold: inner not xor-tracked
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)     // r2 = x+5 (not xor)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -14987,7 +14987,7 @@ fn compiler_main_test_bw_no_fold_plain_and() -> bool with Mut, Div, Panic {
 // Sprint 162 Block BX: OR-XOR complement fold (T638-T643)
 fn compiler_main_test_bx_or_xor_comp_basic() -> bool with Mut, Div, Panic {
     // (r0 | 5) ^ 5 → r0 & ~5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15001,7 +15001,7 @@ fn compiler_main_test_bx_or_xor_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_or_xor_comp_comm() -> bool with Mut, Div, Panic {
     // 5 ^ (r0 | 5) → r0 & ~5 (commutative outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15015,7 +15015,7 @@ fn compiler_main_test_bx_or_xor_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_or_xor_comp_merged_const() -> bool with Mut, Div, Panic {
     // (r0 | 0xFF) ^ 0xFF → r0 & ~0xFF; ~0xFF = -256
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -15029,7 +15029,7 @@ fn compiler_main_test_bx_or_xor_comp_merged_const() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_bx_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0 | 5) ^ 3 → no fold (outer C != inner C)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15041,7 +15041,7 @@ fn compiler_main_test_bx_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 | 5) & 5 → no fold (outer is AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15055,7 +15055,7 @@ fn compiler_main_test_bx_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bx_no_fold_inner_xor() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) ^ 5 → r0 (Block BM/BN territory, not BX)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // not OR
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15070,7 +15070,7 @@ fn compiler_main_test_bx_no_fold_inner_xor() -> bool with Mut, Div, Panic {
 // Sprint 163 Block BY: XOR-OR same-constant fold (T644-T649)
 fn compiler_main_test_by_xor_or_same_basic() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) | 5 → r0 | 5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = r0^5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15084,7 +15084,7 @@ fn compiler_main_test_by_xor_or_same_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_xor_or_same_comm() -> bool with Mut, Div, Panic {
     // 5 | (r0 ^ 5) → r0 | 5 (commutative outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15098,7 +15098,7 @@ fn compiler_main_test_by_xor_or_same_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_xor_or_same_val() -> bool with Mut, Div, Panic {
     // (r0 ^ 0xFF) | 0xFF → r0 | 0xFF; base reg preserved
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -15112,7 +15112,7 @@ fn compiler_main_test_by_xor_or_same_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) | 3 → no fold (different constant)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15124,7 +15124,7 @@ fn compiler_main_test_by_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) & 5 → no fold (outer AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15138,7 +15138,7 @@ fn compiler_main_test_by_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_by_no_fold_plain_or() -> bool with Mut, Div, Panic {
     // r0 | 5 → no fold (no xor-tracked inner)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -15150,7 +15150,7 @@ fn compiler_main_test_by_no_fold_plain_or() -> bool with Mut, Div, Panic {
 // Sprint 164 Block BZ: AND-XOR same-constant merge (T650-T655)
 fn compiler_main_test_bz_and_xor_merge_basic() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 ^ 5) → r0 | 5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15165,7 +15165,7 @@ fn compiler_main_test_bz_and_xor_merge_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_and_xor_merge_comm() -> bool with Mut, Div, Panic {
     // (r0 ^ 5) | (r0 & 5) → r0 | 5 (commutative: xor on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)  // r2 = r0 ^ 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15180,7 +15180,7 @@ fn compiler_main_test_bz_and_xor_merge_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_and_xor_merge_val() -> bool with Mut, Div, Panic {
     // (r0 & 0xFF) | (r0 ^ 0xFF) → r0 | 0xFF; base reg preserved
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -15195,7 +15195,7 @@ fn compiler_main_test_bz_and_xor_merge_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 ^ 3) → no fold (different constants)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15208,7 +15208,7 @@ fn compiler_main_test_bz_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r1 ^ 5) → no fold (different base register)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)  // r3 = r0 & 5
     instrs[2 as usize] = ir_load_imm(4, 5)
@@ -15221,7 +15221,7 @@ fn compiler_main_test_bz_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_bz_no_fold_plain() -> bool with Mut, Div, Panic {
     // r0 | r1 → no fold (neither tracked)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -15232,7 +15232,7 @@ fn compiler_main_test_bz_no_fold_plain() -> bool with Mut, Div, Panic {
 // Sprint 165 Block CA: OR-complement AND elimination (T656-T661)
 fn compiler_main_test_ca_or_comp_and_basic() -> bool with Mut, Div, Panic {
     // (r0|5)&(r0|~5) → r0: complements annihilate → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -15246,7 +15246,7 @@ fn compiler_main_test_ca_or_comp_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_or_comp_and_comm() -> bool with Mut, Div, Panic {
     // (r0|~5)&(r0|5) → r0: commutative (constants swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                     // r1 = ~5 = -6
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15260,7 +15260,7 @@ fn compiler_main_test_ca_or_comp_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_or_comp_and_val() -> bool with Mut, Div, Panic {
     // (r0|0xFF)&(r0|~0xFF) → r0: verify with 0xFF/~0xFF pair
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)                   // ~0xFF = -256
@@ -15274,7 +15274,7 @@ fn compiler_main_test_ca_or_comp_and_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0|5)&(r1|~5) → no fold: different base variables
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)   // r3 = r0 | 5
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -15287,7 +15287,7 @@ fn compiler_main_test_ca_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_no_fold_non_complement() -> bool with Mut, Div, Panic {
     // (r0|5)&(r0|3) → no fold: constants 5 and 3 are not complements
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15300,7 +15300,7 @@ fn compiler_main_test_ca_no_fold_non_complement() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ca_no_fold_outer_or() -> bool with Mut, Div, Panic {
     // (r0|5)|(r0|~5) → no fold by CA (outer is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -15314,7 +15314,7 @@ fn compiler_main_test_ca_no_fold_outer_or() -> bool with Mut, Div, Panic {
 // Sprint 166 Block CB: Add/sub-const inverse (T662-T667)
 fn compiler_main_test_cb_add_sub_inverse_basic() -> bool with Mut, Div, Panic {
     // (r0+5)-5 → r0: bt_add then sub same const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0+5 (bt_add)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15326,7 +15326,7 @@ fn compiler_main_test_cb_add_sub_inverse_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_sub_add_inverse_basic() -> bool with Mut, Div, Panic {
     // (r0-3)+3 → r0: bs_sub then add same const
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0-3 (bs_sub)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15338,7 +15338,7 @@ fn compiler_main_test_cb_sub_add_inverse_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_sub_add_comm() -> bool with Mut, Div, Panic {
     // 3+(r0-3) → r0: commutative: const+(sub-const) same C
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0-3 (bs_sub)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15350,7 +15350,7 @@ fn compiler_main_test_cb_sub_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0+5)-3 → no fold: different constants
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0+5
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -15362,7 +15362,7 @@ fn compiler_main_test_cb_no_fold_diff_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_no_fold_same_op() -> bool with Mut, Div, Panic {
     // (r0+5)+5 → no fold by CB (both adds — not inverse)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15375,7 +15375,7 @@ fn compiler_main_test_cb_no_fold_same_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cb_no_fold_plain_sub() -> bool with Mut, Div, Panic {
     // r0-5 → no fold: not a bt_add-tracked register
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0-5 (plain sub, not add-const)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15388,7 +15388,7 @@ fn compiler_main_test_cb_no_fold_plain_sub() -> bool with Mut, Div, Panic {
 // Sprint 167 Block CC: AND complement partition (T668-T673)
 fn compiler_main_test_cc_and_comp_partition_basic() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 & ~5) → r0: AND partition fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, -6)                     // r3 = ~5 = -6
@@ -15402,7 +15402,7 @@ fn compiler_main_test_cc_and_comp_partition_basic() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_cc_and_comp_partition_comm() -> bool with Mut, Div, Panic {
     // (r0 & ~5) | (r0 & 5) → r0: commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -15416,7 +15416,7 @@ fn compiler_main_test_cc_and_comp_partition_comm() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_cc_and_comp_partition_val() -> bool with Mut, Div, Panic {
     // (r0 & 0xFF) | (r0 & ~0xFF) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 0xFF
     instrs[2 as usize] = ir_load_imm(3, -256)                   // ~0xFF = -256
@@ -15430,7 +15430,7 @@ fn compiler_main_test_cc_and_comp_partition_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cc_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r1 & ~5) → no fold: different base registers
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)  // r3 = r0 & 5
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -15443,7 +15443,7 @@ fn compiler_main_test_cc_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cc_no_fold_non_complement() -> bool with Mut, Div, Panic {
     // (r0 & 5) | (r0 & 3) → no fold: 3 is not ~5
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, 3)                      // 3 != ~5
@@ -15456,7 +15456,7 @@ fn compiler_main_test_cc_no_fold_non_complement() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cc_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 & 5) & (r0 & ~5) → no fold by CC (AND outer not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -15470,7 +15470,7 @@ fn compiler_main_test_cc_no_fold_and_op() -> bool with Mut, Div, Panic {
 // Sprint 168 Block CD: Zero-minus normalization (T674-T679)
 fn compiler_main_test_cd_zero_minus_basic() -> bool with Mut, Div, Panic {
     // 0 - r0 → neg(r0): zero-minus fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 0)  // r2 = 0 - r0
     let func = cp_make_test_func(instrs, 2)
@@ -15482,7 +15482,7 @@ fn compiler_main_test_cd_zero_minus_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_zero_minus_chain() -> bool with Mut, Div, Panic {
     // neg(0 - r0) → double-neg elim → r0 (CD normalizes 0-r0 to neg, BJ elims double neg)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 0)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 0)  // r2 = 0 - r0 → neg(r0)
     instrs[2 as usize] = ir_unaryop(3, UnaryOp::OpNeg, 2)    // r3 = neg(r2) → IrCopy(r0)
@@ -15494,7 +15494,7 @@ fn compiler_main_test_cd_zero_minus_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_zero_minus_val() -> bool with Mut, Div, Panic {
     // 0 - r1 → neg(r1): fold on non-r0 register
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_load_imm(2, 0)
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)  // r3 = 0 - r1 (r1=7)
@@ -15506,7 +15506,7 @@ fn compiler_main_test_cd_zero_minus_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_no_fold_nonzero() -> bool with Mut, Div, Panic {
     // 5 - r0 → no fold (non-zero constant)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 0)  // r2 = 5 - r0
     let func = cp_make_test_func(instrs, 2)
@@ -15516,7 +15516,7 @@ fn compiler_main_test_cd_no_fold_nonzero() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_no_fold_rr_sub() -> bool with Mut, Div, Panic {
     // r0 - r1 → no fold (no constant operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - r1
     let func = cp_make_test_func(instrs, 2)
     let opt = opt_cleanup_function(func)
@@ -15525,7 +15525,7 @@ fn compiler_main_test_cd_no_fold_rr_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cd_no_fold_sub_zero() -> bool with Mut, Div, Panic {
     // r0 - 0 → IrCopy(r0) by const-identity (Block B/x-0), not CD
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 0)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)  // r2 = r0 - 0
     let func = cp_make_test_func(instrs, 2)
@@ -15537,7 +15537,7 @@ fn compiler_main_test_cd_no_fold_sub_zero() -> bool with Mut, Div, Panic {
 // Sprint 169 Block CE: Multiply-constant chain fold (T680-T685)
 fn compiler_main_test_ce_mul_const_chain_basic() -> bool with Mut, Div, Panic {
     // (r0*3)*4 → r0*12: mul-const chain fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15551,7 +15551,7 @@ fn compiler_main_test_ce_mul_const_chain_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_mul_const_chain_comm() -> bool with Mut, Div, Panic {
     // 4*(r0*3) → r0*12: commutative variant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15565,7 +15565,7 @@ fn compiler_main_test_ce_mul_const_chain_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_mul_const_chain_val() -> bool with Mut, Div, Panic {
     // (r0*5)*6 → r0*30: verify merged constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 5
     instrs[2 as usize] = ir_load_imm(3, 6)
@@ -15579,7 +15579,7 @@ fn compiler_main_test_ce_mul_const_chain_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_no_fold_rr_mul() -> bool with Mut, Div, Panic {
     // (r0*r1)*3 → no fold (s1 not mul-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * r1
     instrs[1 as usize] = ir_load_imm(3, 3)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpMul, 3)  // r4 = (r0*r1)*3
@@ -15591,7 +15591,7 @@ fn compiler_main_test_ce_no_fold_rr_mul() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_no_fold_add_chain() -> bool with Mut, Div, Panic {
     // (r0+3)*4 → no fold by CE (add-const, not mul-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)  // r2 = r0 + 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15603,7 +15603,7 @@ fn compiler_main_test_ce_no_fold_add_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ce_no_fold_div_chain() -> bool with Mut, Div, Panic {
     // (r0*3)/4 → no fold by CE (CE is mul only, Block O handles mul-div)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_load_imm(3, 4)
@@ -15617,7 +15617,7 @@ fn compiler_main_test_ce_no_fold_div_chain() -> bool with Mut, Div, Panic {
 // Sprint 170 Block CF: OR-AND superset absorption (T686-T691)
 fn compiler_main_test_cf_or_and_same_const() -> bool with Mut, Div, Panic {
     // (r0|7)&7 → 7: same constant (C2==C1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -15630,7 +15630,7 @@ fn compiler_main_test_cf_or_and_same_const() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_or_and_superset() -> bool with Mut, Div, Panic {
     // (r0|15)&7 → 7: C2(7)⊆C1(15)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 15
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -15643,7 +15643,7 @@ fn compiler_main_test_cf_or_and_superset() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_or_and_comm() -> bool with Mut, Div, Panic {
     // 7&(r0|15) → 7: commutative variant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 15)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 15
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -15656,7 +15656,7 @@ fn compiler_main_test_cf_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_no_fold_subset() -> bool with Mut, Div, Panic {
     // (r0|7)&15 → no CF fold (C2(15) ⊄ C1(7)); handled by other rules or left
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 15)
@@ -15668,7 +15668,7 @@ fn compiler_main_test_cf_no_fold_subset() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_no_fold_disjoint() -> bool with Mut, Div, Panic {
     // (r0|4)&8 → r0&8 by BI (disjoint), not CF constant-load
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 4)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 4
     instrs[2 as usize] = ir_load_imm(3, 8)
@@ -15681,7 +15681,7 @@ fn compiler_main_test_cf_no_fold_disjoint() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cf_no_fold_rr() -> bool with Mut, Div, Panic {
     // (r0|r1)&7 → no fold (no or-const tracking for r0|r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | r1
     instrs[1 as usize] = ir_load_imm(3, 7)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)  // r4 = (r0|r1)&7
@@ -15693,7 +15693,7 @@ fn compiler_main_test_cf_no_fold_rr() -> bool with Mut, Div, Panic {
 // Sprint 171 Block CG: Multiply-add normalization (T692-T697)
 fn compiler_main_test_cg_mul_add_basic() -> bool with Mut, Div, Panic {
     // (r0*3)+r0 → r0*4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0*3) + r0 → r0*4
@@ -15706,7 +15706,7 @@ fn compiler_main_test_cg_mul_add_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_mul_add_comm() -> bool with Mut, Div, Panic {
     // r0+(r0*5) → r0*6 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 5
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)  // r3 = r0 + (r0*5) → r0*6
@@ -15719,7 +15719,7 @@ fn compiler_main_test_cg_mul_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_mul_add_large() -> bool with Mut, Div, Panic {
     // (r0*99)+r0 → r0*100
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 99)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 99
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0*99) + r0 → r0*100
@@ -15732,7 +15732,7 @@ fn compiler_main_test_cg_mul_add_large() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0*3)+r1 → no fold (different base)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)  // r3 = r0 * 3
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 1)  // r4 = (r0*3) + r1
@@ -15744,7 +15744,7 @@ fn compiler_main_test_cg_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_no_fold_rr_mul() -> bool with Mut, Div, Panic {
     // (r0*r1)+r0 → no fold (not const-mul)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0*r1) + r0
     let func = cp_make_test_func(instrs, 2)
@@ -15755,7 +15755,7 @@ fn compiler_main_test_cg_no_fold_rr_mul() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cg_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0*3)-r0 → no fold (sub, not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)  // r3 = (r0*3) - r0
@@ -15768,7 +15768,7 @@ fn compiler_main_test_cg_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 172 Block CH: Multiply-sub normalization (T698-T703)
 fn compiler_main_test_ch_mul_sub_basic() -> bool with Mut, Div, Panic {
     // (r0*3)-r0 → r0*2: mul-sub fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)   // r3 = (r0*3)-r0 → r0*2
@@ -15781,7 +15781,7 @@ fn compiler_main_test_ch_mul_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_sub_mul_basic() -> bool with Mut, Div, Panic {
     // r0-(r0*3) → r0*(-2): x-(x*C) fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)   // r3 = r0-(r0*3) → r0*(-2)
@@ -15794,7 +15794,7 @@ fn compiler_main_test_ch_sub_mul_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_mul_sub_large() -> bool with Mut, Div, Panic {
     // (r0*100)-r0 → r0*99: large constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 100)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 100
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)   // r3 = (r0*100)-r0 → r0*99
@@ -15807,7 +15807,7 @@ fn compiler_main_test_ch_mul_sub_large() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0*3)-r1 → no fold (r1 ≠ r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)   // r3 = r0 * 3
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 1)   // r4 = (r0*3)-r1
@@ -15818,7 +15818,7 @@ fn compiler_main_test_ch_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_no_fold_rr_sub() -> bool with Mut, Div, Panic {
     // (r0*r1)-r0 → no fold (mul not mul-const)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)   // r3 = (r0*r1)-r0
     let func = cp_make_test_func(instrs, 2)
@@ -15828,7 +15828,7 @@ fn compiler_main_test_ch_no_fold_rr_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ch_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0*3)+r0 → r0*4 by CG (not CH), confirms CH only handles sub
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)   // r2 = r0 * 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)   // r3 = (r0*3)+r0 → r0*4 by CG
@@ -15842,7 +15842,7 @@ fn compiler_main_test_ch_no_fold_add() -> bool with Mut, Div, Panic {
 // Sprint 173 Block CI: Shift-add to multiply (T704-T709)
 fn compiler_main_test_ci_shl_add_basic() -> bool with Mut, Div, Panic {
     // (r0<<1)+r0 → r0*3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 1
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0<<1)+r0 → r0*3
@@ -15855,7 +15855,7 @@ fn compiler_main_test_ci_shl_add_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_shl_add_comm() -> bool with Mut, Div, Panic {
     // r0+(r0<<2) → r0*5 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 2
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)  // r3 = r0+(r0<<2) → r0*5
@@ -15868,7 +15868,7 @@ fn compiler_main_test_ci_shl_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_shl_add_large() -> bool with Mut, Div, Panic {
     // (r0<<3)+r0 → r0*9
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 3
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0<<3)+r0 → r0*9
@@ -15881,7 +15881,7 @@ fn compiler_main_test_ci_shl_add_large() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0<<1)+r1 → no fold (different base)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)  // r3 = r0 << 1
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 1)  // r4 = (r0<<1)+r1
@@ -15893,7 +15893,7 @@ fn compiler_main_test_ci_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_no_fold_rr_shl() -> bool with Mut, Div, Panic {
     // (r0<<r1)+r0 → no fold (non-const shift)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)  // r3 = (r0<<r1)+r0
     let func = cp_make_test_func(instrs, 2)
@@ -15904,7 +15904,7 @@ fn compiler_main_test_ci_no_fold_rr_shl() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ci_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0<<1)-r0 → no fold by CI (sub, not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)  // r2 = r0 << 1
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)  // r3 = (r0<<1)-r0
@@ -15917,7 +15917,7 @@ fn compiler_main_test_ci_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 174 Block CJ: Shift-sub to multiply (T710-T715)
 fn compiler_main_test_cj_shl_sub_basic() -> bool with Mut, Div, Panic {
     // (r0<<1)-r0 → r0*1 (2^1-1=1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<1
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)     // r3 = (r0<<1)-r0
@@ -15930,7 +15930,7 @@ fn compiler_main_test_cj_shl_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_shl_sub_three() -> bool with Mut, Div, Panic {
     // (r0<<2)-r0 → r0*3 (2^2-1=3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<2
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)     // r3 = (r0<<2)-r0
@@ -15943,7 +15943,7 @@ fn compiler_main_test_cj_shl_sub_three() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_sub_shl_reverse() -> bool with Mut, Div, Panic {
     // r0-(r0<<2) → r0*(1-4) = r0*(-3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<2
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)     // r3 = r0-(r0<<2)
@@ -15956,7 +15956,7 @@ fn compiler_main_test_cj_sub_shl_reverse() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0<<1)-r1 → no fold: different base variables
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)     // r3 = r0<<1
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpSub, 1)     // r4 = (r0<<1)-r1
@@ -15967,7 +15967,7 @@ fn compiler_main_test_cj_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_no_fold_rr_shl() -> bool with Mut, Div, Panic {
     // (r0<<r1)-r0 → no fold: shift amount is not constant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)     // r2 = r0<<r1
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)     // r3 = (r0<<r1)-r0
     let func = cp_make_test_func(instrs, 2)
@@ -15977,7 +15977,7 @@ fn compiler_main_test_cj_no_fold_rr_shl() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cj_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0<<1)+r0 → no fold by CJ (add not sub; handled by CI)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)     // add not sub
@@ -15991,7 +15991,7 @@ fn compiler_main_test_cj_no_fold_add() -> bool with Mut, Div, Panic {
 // Sprint 175 Block CK: AND-complement OR (T716-T721)
 fn compiler_main_test_ck_and_comp_or_basic() -> bool with Mut, Div, Panic {
     // (r0 & ~5) | 5 → r0 | 5: AND-complement OR fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                     // r1 = ~5 = -6
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16005,7 +16005,7 @@ fn compiler_main_test_ck_and_comp_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_and_comp_or_comm() -> bool with Mut, Div, Panic {
     // 5 | (r0 & ~5) → r0 | 5: commutative outer
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                     // r1 = ~5 = -6
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)  // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16019,7 +16019,7 @@ fn compiler_main_test_ck_and_comp_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_and_comp_or_val() -> bool with Mut, Div, Panic {
     // (r0 & ~12) | 12 → r0 | 12: different constant C=12
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -13)                    // r1 = ~12 = -13
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1) // r2 = r0 & ~12
     instrs[2 as usize] = ir_load_imm(3, 12)
@@ -16033,7 +16033,7 @@ fn compiler_main_test_ck_and_comp_or_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
     // (r0 & ~5) | 3 → no fold: 3 is not complement of ~5 (3 != 5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                    // r1 = ~5
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1) // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16047,7 +16047,7 @@ fn compiler_main_test_ck_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_no_fold_non_and() -> bool with Mut, Div, Panic {
     // (r0 | ~5) | 5 → no fold by CK (OR not AND in s1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                    // r1 = ~5
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)  // r2 = r0 | ~5 (OR not AND)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16060,7 +16060,7 @@ fn compiler_main_test_ck_no_fold_non_and() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ck_no_fold_and_op() -> bool with Mut, Div, Panic {
     // (r0 & ~5) & 5 → no fold by CK (AND outer not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)                    // r1 = ~5
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1) // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16075,7 +16075,7 @@ fn compiler_main_test_ck_no_fold_and_op() -> bool with Mut, Div, Panic {
 // Sprint 176 Block CL: OR-complement AND (T722-T727)
 fn compiler_main_test_cl_or_comp_and_basic() -> bool with Mut, Div, Panic {
     // (r0|7)&~7 → r0&~7: OR-comp-AND fold; ~7=-8
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, -8)                       // r3 = ~7 = -8
@@ -16089,7 +16089,7 @@ fn compiler_main_test_cl_or_comp_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_or_comp_and_comm() -> bool with Mut, Div, Panic {
     // ~7&(r0|7) → r0&~7: commutative outer
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, -8)                       // r3 = ~7
@@ -16103,7 +16103,7 @@ fn compiler_main_test_cl_or_comp_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_or_comp_and_val() -> bool with Mut, Div, Panic {
     // (r0|0xFF)&~0xFF → r0&~0xFF: larger mask
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 0xFF
     instrs[2 as usize] = ir_load_imm(3, -256)                     // r3 = ~0xFF = -256
@@ -16117,7 +16117,7 @@ fn compiler_main_test_cl_or_comp_and_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
     // (r0|7)&5 → no fold (5 ≠ ~7)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16131,7 +16131,7 @@ fn compiler_main_test_cl_no_fold_wrong_comp() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_no_fold_rr_or() -> bool with Mut, Div, Panic {
     // (r0|r1)&~7 → no fold (no or-const tracking for r0|r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | r1
     instrs[1 as usize] = ir_load_imm(3, -8)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)   // r4 = (r0|r1)&~7
@@ -16142,7 +16142,7 @@ fn compiler_main_test_cl_no_fold_rr_or() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_cl_no_fold_or_op() -> bool with Mut, Div, Panic {
     // (r0|7)|~7 → no fold by CL (OR outer, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, -8)
@@ -16155,7 +16155,7 @@ fn compiler_main_test_cl_no_fold_or_op() -> bool with Mut, Div, Panic {
 // Sprint 177 Block CM: AND complement XOR partition (T728-T733)
 fn compiler_main_test_cm_and_comp_xor_basic() -> bool with Mut, Div, Panic {
     // (r0&5)^(r0&~5) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, -6)                       // ~5
@@ -16167,7 +16167,7 @@ fn compiler_main_test_cm_and_comp_xor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cm_and_comp_xor_comm() -> bool with Mut, Div, Panic {
     // (r0&~5)^(r0&5) → r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & ~5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16179,7 +16179,7 @@ fn compiler_main_test_cm_and_comp_xor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cm_and_comp_xor_val() -> bool with Mut, Div, Panic {
     // (r0&0xFF)^(r0&~0xFF) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -16190,7 +16190,7 @@ fn compiler_main_test_cm_and_comp_xor_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op == IrOpcode::IrCopy && opt.instrs[4 as usize].src1 == 0
 }
 fn compiler_main_test_cm_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -16201,7 +16201,7 @@ fn compiler_main_test_cm_no_fold_diff_base() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op != IrOpcode::IrCopy
 }
 fn compiler_main_test_cm_no_fold_non_comp() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)                        // not ~5
@@ -16212,7 +16212,7 @@ fn compiler_main_test_cm_no_fold_non_comp() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op != IrOpcode::IrCopy
 }
 fn compiler_main_test_cm_no_fold_or_outer() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16226,7 +16226,7 @@ fn compiler_main_test_cm_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 178 Block CN: Add-self to multiply tracking (T734-T739)
 fn compiler_main_test_cn_add_self_tracking() -> bool with Mut, Div, Panic {
     // x+x → tracked as x*2 for downstream passes (CG etc.)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpAdd, 0)      // r1 = r0+r0
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16236,7 +16236,7 @@ fn compiler_main_test_cn_add_self_tracking() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cn_add_self_chain_cg() -> bool with Mut, Div, Panic {
     // (r0+r0)+r0 → should trigger CG: mul_valid(r1)=true, mul_const=2, then +r0 → r0*3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpAdd, 0)      // r1 = r0+r0 (tracked as r0*2)
     instrs[1 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)      // r2 = (r0*2)+r0 → CG → r0*3
     let func = cp_make_test_func(instrs, 2)
@@ -16244,7 +16244,7 @@ fn compiler_main_test_cn_add_self_chain_cg() -> bool with Mut, Div, Panic {
     opt.instrs[1 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cn_add_self_val() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 1)      // r2 = r1+r1
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16252,7 +16252,7 @@ fn compiler_main_test_cn_add_self_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cn_no_track_diff_ops() -> bool with Mut, Div, Panic {
     // r0+r1 → no tracking (different operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16260,7 +16260,7 @@ fn compiler_main_test_cn_no_track_diff_ops() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cn_no_track_sub() -> bool with Mut, Div, Panic {
     // r0-r0 → 0 (Block A), not mul tracking
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpSub, 0)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16269,7 +16269,7 @@ fn compiler_main_test_cn_no_track_sub() -> bool with Mut, Div, Panic {
 fn compiler_main_test_cn_chain_ce() -> bool with Mut, Div, Panic {
     // (r0+r0)*(r0+r0) won't trigger CE directly since both sides are r0*2
     // but (r0+r0)*3 should: mul_valid(r1)=true,cval=2 → CE → r0*6
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(1, 0, BinaryOp::OpAdd, 0)      // r1 = r0+r0 (tracked r0*2)
     instrs[1 as usize] = ir_load_imm(2, 3)
     instrs[2 as usize] = ir_binop(3, 1, BinaryOp::OpMul, 2)      // r3 = (r0*2)*3 → CE → r0*6
@@ -16281,7 +16281,7 @@ fn compiler_main_test_cn_chain_ce() -> bool with Mut, Div, Panic {
 // Sprint 179 Block CO: Neg-add to sub (T740-T745)
 fn compiler_main_test_co_neg_add_basic() -> bool with Mut, Div, Panic {
     // neg(r0)+r1 → r1-r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)        // r2 = neg(r0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 1)      // r3 = neg(r0)+r1
     let func = cp_make_test_func(instrs, 2)
@@ -16292,7 +16292,7 @@ fn compiler_main_test_co_neg_add_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_add_neg_basic() -> bool with Mut, Div, Panic {
     // r0+neg(r1) → r0-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)        // r2 = neg(r1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)      // r3 = r0+neg(r1)
     let func = cp_make_test_func(instrs, 2)
@@ -16303,7 +16303,7 @@ fn compiler_main_test_co_add_neg_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_neg_add_val() -> bool with Mut, Div, Panic {
     // neg(r1)+r0 → r0-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -16313,7 +16313,7 @@ fn compiler_main_test_co_neg_add_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_no_fold_sub() -> bool with Mut, Div, Panic {
     // neg(r0)-r1 → NOT add, so CO doesn't fire (CO only handles add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -16322,7 +16322,7 @@ fn compiler_main_test_co_no_fold_sub() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_no_fold_plain_add() -> bool with Mut, Div, Panic {
     // r0+r1 → no fold (neither is neg)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16330,7 +16330,7 @@ fn compiler_main_test_co_no_fold_plain_add() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_co_no_fold_not() -> bool with Mut, Div, Panic {
     // ~r0+r1 → no fold (NOT is not NEG)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -16341,7 +16341,7 @@ fn compiler_main_test_co_no_fold_not() -> bool with Mut, Div, Panic {
 // Sprint 180 Block CP: Sub-neg to add (T746-T751)
 fn compiler_main_test_cp_sub_neg_basic() -> bool with Mut, Div, Panic {
     // r0-neg(r1) → r0+r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)        // r2 = neg(r1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)      // r3 = r0-neg(r1)
     let func = cp_make_test_func(instrs, 2)
@@ -16352,7 +16352,7 @@ fn compiler_main_test_cp_sub_neg_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_sub_neg_val() -> bool with Mut, Div, Panic {
     // r1-neg(r0) → r1+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -16362,7 +16362,7 @@ fn compiler_main_test_cp_sub_neg_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_sub_neg_chain() -> bool with Mut, Div, Panic {
     // r0-neg(neg(r1)): neg(neg(r1))→r1 (double-neg), then r0-r1 (no CP)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNeg, 2)        // double-neg → r1
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 3)
@@ -16373,7 +16373,7 @@ fn compiler_main_test_cp_sub_neg_chain() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_no_fold_add() -> bool with Mut, Div, Panic {
     // r0+neg(r1) → CO fires (not CP); CP only handles sub
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -16382,7 +16382,7 @@ fn compiler_main_test_cp_no_fold_add() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_no_fold_plain_sub() -> bool with Mut, Div, Panic {
     // r0-r1 → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16390,7 +16390,7 @@ fn compiler_main_test_cp_no_fold_plain_sub() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cp_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // r0-~r1 → no fold (NOT not NEG)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -16401,7 +16401,7 @@ fn compiler_main_test_cp_no_fold_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 181 Block CQ: OR complement XOR → NOT (T752-T757)
 fn compiler_main_test_cq_or_comp_xor_not() -> bool with Mut, Div, Panic {
     // (r0|5)^(r0|~5) → ~r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16415,7 +16415,7 @@ fn compiler_main_test_cq_or_comp_xor_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cq_or_comp_xor_comm() -> bool with Mut, Div, Panic {
     // (r0|~5)^(r0|5) → ~r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16427,7 +16427,7 @@ fn compiler_main_test_cq_or_comp_xor_comm() -> bool with Mut, Div, Panic {
         && opt.instrs[4 as usize].un_op == UnaryOp::OpNot
 }
 fn compiler_main_test_cq_or_comp_xor_val() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -16438,7 +16438,7 @@ fn compiler_main_test_cq_or_comp_xor_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op == IrOpcode::IrUnaryOp
 }
 fn compiler_main_test_cq_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -16449,7 +16449,7 @@ fn compiler_main_test_cq_no_fold_diff_base() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].op != IrOpcode::IrUnaryOp
 }
 fn compiler_main_test_cq_no_fold_non_comp() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16461,7 +16461,7 @@ fn compiler_main_test_cq_no_fold_non_comp() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cq_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|5)&(r0|~5) → Block CA fires (IrCopy), not CQ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16475,7 +16475,7 @@ fn compiler_main_test_cq_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 182 Block CR: AND-XOR complement extraction (T758-T763)
 fn compiler_main_test_cr_and_xor_comp_basic() -> bool with Mut, Div, Panic {
     // (r0&5)^5 → ~r0&5: rewrite to NOT then AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16486,7 +16486,7 @@ fn compiler_main_test_cr_and_xor_comp_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cr_and_xor_comp_comm() -> bool with Mut, Div, Panic {
     // 5^(r0&5) → ~r0&5: commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16496,7 +16496,7 @@ fn compiler_main_test_cr_and_xor_comp_comm() -> bool with Mut, Div, Panic {
     opt.instrs[3 as usize].bin_op == BinaryOp::OpBitAnd
 }
 fn compiler_main_test_cr_and_xor_comp_val() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -16506,7 +16506,7 @@ fn compiler_main_test_cr_and_xor_comp_val() -> bool with Mut, Div, Panic {
     opt.instrs[3 as usize].bin_op == BinaryOp::OpBitAnd
 }
 fn compiler_main_test_cr_no_fold_diff_const() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)                        // different const
@@ -16518,7 +16518,7 @@ fn compiler_main_test_cr_no_fold_diff_const() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cr_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (r0|5)^5 → Block BX handles this, not CR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16530,7 +16530,7 @@ fn compiler_main_test_cr_no_fold_or_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cr_no_fold_plain_xor() -> bool with Mut, Div, Panic {
     // r0^5 → no fold (r0 not and-tracked)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -16541,7 +16541,7 @@ fn compiler_main_test_cr_no_fold_plain_xor() -> bool with Mut, Div, Panic {
 // Sprint 183 Block CS: Sub-add constant chain fold (T764-T769)
 fn compiler_main_test_cs_sub_add_chain_basic() -> bool with Mut, Div, Panic {
     // (r0-3)+5 → r0+2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16554,7 +16554,7 @@ fn compiler_main_test_cs_sub_add_chain_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_sub_add_chain_comm() -> bool with Mut, Div, Panic {
     // 5+(r0-3) → r0+2 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 3
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16567,7 +16567,7 @@ fn compiler_main_test_cs_sub_add_chain_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_sub_add_chain_cancel() -> bool with Mut, Div, Panic {
     // (r0-5)+5 → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 5
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16578,7 +16578,7 @@ fn compiler_main_test_cs_sub_add_chain_cancel() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_sub_add_chain_neg_result() -> bool with Mut, Div, Panic {
     // (r0-7)+2 → r0-5 (negative merged constant)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 7
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16591,7 +16591,7 @@ fn compiler_main_test_cs_sub_add_chain_neg_result() -> bool with Mut, Div, Panic
 }
 fn compiler_main_test_cs_no_fold_rr_sub() -> bool with Mut, Div, Panic {
     // (r0-r1)+5 → no fold (sub is rr, not const-sub)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - r1
     instrs[1 as usize] = ir_load_imm(3, 5)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)   // r4 = (r0-r1)+5
@@ -16601,7 +16601,7 @@ fn compiler_main_test_cs_no_fold_rr_sub() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cs_no_fold_rr_add() -> bool with Mut, Div, Panic {
     // (r0-3)+r1 → no fold (add is rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)   // r2 = r0 - 3
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 1)   // r4 = (r0-3)+r1
@@ -16613,7 +16613,7 @@ fn compiler_main_test_cs_no_fold_rr_add() -> bool with Mut, Div, Panic {
 // Sprint 184 Block CT: Mul-const distributive sub (T770-T775)
 fn compiler_main_test_ct_mul_dist_sub_basic() -> bool with Mut, Div, Panic {
     // r0*5 - r0*3 → r0*2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)      // r2 = r0*5
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16625,7 +16625,7 @@ fn compiler_main_test_ct_mul_dist_sub_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ct_mul_dist_sub_zero() -> bool with Mut, Div, Panic {
     // r0*3 - r0*3 → r0*0 = 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16637,7 +16637,7 @@ fn compiler_main_test_ct_mul_dist_sub_zero() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ct_mul_dist_sub_val() -> bool with Mut, Div, Panic {
     // r0*10 - r0*3 → r0*7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 10)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16648,7 +16648,7 @@ fn compiler_main_test_ct_mul_dist_sub_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_ct_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpMul, 2)      // r0*5
     instrs[2 as usize] = ir_load_imm(4, 3)
@@ -16660,7 +16660,7 @@ fn compiler_main_test_ct_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ct_no_fold_add_op() -> bool with Mut, Div, Panic {
     // r0*5 + r0*3 → CS fires (add), not CT (sub)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpMul, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16671,7 +16671,7 @@ fn compiler_main_test_ct_no_fold_add_op() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_ct_no_fold_plain_sub() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16681,7 +16681,7 @@ fn compiler_main_test_ct_no_fold_plain_sub() -> bool with Mut, Div, Panic {
 // Sprint 185 Block CU: Shift-add factoring (T776-T781)
 fn compiler_main_test_cu_shl_add_factor() -> bool with Mut, Div, Panic {
     // (r0<<1)+(r0<<2) → r0*6 (2+4=6)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)      // r0<<1
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16693,7 +16693,7 @@ fn compiler_main_test_cu_shl_add_factor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cu_shl_add_factor_comm() -> bool with Mut, Div, Panic {
     // (r0<<3)+(r0<<1) → r0*10 (8+2=10)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 1)
@@ -16705,7 +16705,7 @@ fn compiler_main_test_cu_shl_add_factor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cu_shl_add_same() -> bool with Mut, Div, Panic {
     // (r0<<2)+(r0<<2) → r0*8 (4+4=8)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 2)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16716,7 +16716,7 @@ fn compiler_main_test_cu_shl_add_same() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cu_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)      // r0<<1
     instrs[2 as usize] = ir_load_imm(4, 2)
@@ -16727,7 +16727,7 @@ fn compiler_main_test_cu_no_fold_diff_base() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpAdd
 }
 fn compiler_main_test_cu_no_fold_rr_shl() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)      // r0<<r1 (non-const)
     instrs[1 as usize] = ir_load_imm(3, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpShl, 3)      // r0<<2
@@ -16738,7 +16738,7 @@ fn compiler_main_test_cu_no_fold_rr_shl() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cu_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0<<1)-(r0<<2) → CV fires (sub), not CU (add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16752,7 +16752,7 @@ fn compiler_main_test_cu_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 186 Block CV: Shift-sub factoring (T782-T787)
 fn compiler_main_test_cv_shl_sub_factor() -> bool with Mut, Div, Panic {
     // (r0<<3)-(r0<<1) → r0*6 (8-2=6)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 1)
@@ -16764,7 +16764,7 @@ fn compiler_main_test_cv_shl_sub_factor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cv_shl_sub_negative() -> bool with Mut, Div, Panic {
     // (r0<<1)-(r0<<3) → r0*(-6) (2-8=-6)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 1)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16776,7 +16776,7 @@ fn compiler_main_test_cv_shl_sub_negative() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cv_shl_sub_val() -> bool with Mut, Div, Panic {
     // (r0<<4)-(r0<<2) → r0*12 (16-4=12)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 4)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 2)
@@ -16787,7 +16787,7 @@ fn compiler_main_test_cv_shl_sub_val() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cv_no_fold_diff_base() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 3)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpShl, 2)
     instrs[2 as usize] = ir_load_imm(4, 1)
@@ -16799,7 +16799,7 @@ fn compiler_main_test_cv_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cv_no_fold_add() -> bool with Mut, Div, Panic {
     // (r0<<3)+(r0<<1) → CU fires (add), not CV
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 3)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpShl, 1)
     instrs[2 as usize] = ir_load_imm(3, 1)
@@ -16810,7 +16810,7 @@ fn compiler_main_test_cv_no_fold_add() -> bool with Mut, Div, Panic {
     opt.instrs[4 as usize].bin_op == BinaryOp::OpMul
 }
 fn compiler_main_test_cv_no_fold_plain() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 1)
     let opt = opt_cleanup_function(func)
@@ -16820,7 +16820,7 @@ fn compiler_main_test_cv_no_fold_plain() -> bool with Mut, Div, Panic {
 // Sprint 187 Block CW: OR-XOR mask extraction (T788-T793)
 fn compiler_main_test_cw_or_xor_mask_basic() -> bool with Mut, Div, Panic {
     // (r0|7)^7 → r0 & ~7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)   // r2 = r0 | 7
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -16833,7 +16833,7 @@ fn compiler_main_test_cw_or_xor_mask_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_or_xor_mask_comm() -> bool with Mut, Div, Panic {
     // 7^(r0|7) → r0 & ~7 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -16846,7 +16846,7 @@ fn compiler_main_test_cw_or_xor_mask_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_or_xor_mask_val() -> bool with Mut, Div, Panic {
     // (r0|0xFF)^0xFF → r0 & ~0xFF
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 255)
@@ -16859,7 +16859,7 @@ fn compiler_main_test_cw_or_xor_mask_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_no_fold_diff_const() -> bool with Mut, Div, Panic {
     // (r0|7)^3 → no fold (3 != 7)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16870,7 +16870,7 @@ fn compiler_main_test_cw_no_fold_diff_const() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_no_fold_rr_or() -> bool with Mut, Div, Panic {
     // (r0|r1)^7 → no fold (OR is rr not const-or)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_load_imm(3, 7)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -16880,7 +16880,7 @@ fn compiler_main_test_cw_no_fold_rr_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cw_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|7)&7 → no fold by CW (this is CF/Block CF territory, outer is AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_load_imm(3, 7)
@@ -16893,7 +16893,7 @@ fn compiler_main_test_cw_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 188 Block CX: XOR-complement chain to NOT (T794-T799)
 fn compiler_main_test_cx_xor_comp_not_basic() -> bool with Mut, Div, Panic {
     // (r0^5)^~5 → ~r0; ~5 = -6
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^5
     instrs[2 as usize] = ir_load_imm(3, -6)                       // ~5
@@ -16906,7 +16906,7 @@ fn compiler_main_test_cx_xor_comp_not_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_xor_comp_not_comm() -> bool with Mut, Div, Panic {
     // ~5^(r0^5) → ~r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16919,7 +16919,7 @@ fn compiler_main_test_cx_xor_comp_not_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_xor_comp_not_val() -> bool with Mut, Div, Panic {
     // (r0^0xFF)^~0xFF → ~r0; ~0xFF = -256
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -16932,7 +16932,7 @@ fn compiler_main_test_cx_xor_comp_not_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_no_fold_diff_comp() -> bool with Mut, Div, Panic {
     // (r0^5)^3 → no fold (3 is not ~5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -16943,7 +16943,7 @@ fn compiler_main_test_cx_no_fold_diff_comp() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_no_fold_rr_xor() -> bool with Mut, Div, Panic {
     // (r0^r1)^~5 → no fold (inner XOR is rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^r1
     instrs[1 as usize] = ir_load_imm(3, -6)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -16953,7 +16953,7 @@ fn compiler_main_test_cx_no_fold_rr_xor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cx_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0^5)&~5 → no fold by CX (outer is AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16966,7 +16966,7 @@ fn compiler_main_test_cx_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 189 Block CY: AND complement addition (T800-T805)
 fn compiler_main_test_cy_and_comp_add_basic() -> bool with Mut, Div, Panic {
     // (r0&5)+(r0&~5) → r0; ~5=-6
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 5
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -16978,7 +16978,7 @@ fn compiler_main_test_cy_and_comp_add_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_and_comp_add_comm() -> bool with Mut, Div, Panic {
     // (r0&~5)+(r0&5) → r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, -6)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 5)
@@ -16990,7 +16990,7 @@ fn compiler_main_test_cy_and_comp_add_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_and_comp_add_val() -> bool with Mut, Div, Panic {
     // (r0&0xFF)+(r0&~0xFF) → r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -256)
@@ -17002,7 +17002,7 @@ fn compiler_main_test_cy_and_comp_add_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0&5)+(r1&~5) → no fold (diff base)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 5)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_load_imm(4, -6)
@@ -17014,7 +17014,7 @@ fn compiler_main_test_cy_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_no_fold_non_comp() -> bool with Mut, Div, Panic {
     // (r0&5)+(r0&3) → no fold (3 != ~5)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, 3)
@@ -17026,7 +17026,7 @@ fn compiler_main_test_cy_no_fold_non_comp() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cy_no_fold_sub() -> bool with Mut, Div, Panic {
     // (r0&5)-(r0&~5) → no fold (sub not add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 5)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_load_imm(3, -6)
@@ -17040,7 +17040,7 @@ fn compiler_main_test_cy_no_fold_sub() -> bool with Mut, Div, Panic {
 // Sprint 190 Block CZ: XOR-AND mask clear (T806-T811)
 fn compiler_main_test_cz_xor_and_clear_basic() -> bool with Mut, Div, Panic {
     // r0 ^ (r0 & 7) → r0 & ~7
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & 7
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)   // r3 = r0 ^ (r0&7)
@@ -17052,7 +17052,7 @@ fn compiler_main_test_cz_xor_and_clear_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_xor_and_clear_comm() -> bool with Mut, Div, Panic {
     // (r0 & 7) ^ r0 → r0 & ~7 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 0)   // (r0&7) ^ r0
@@ -17064,7 +17064,7 @@ fn compiler_main_test_cz_xor_and_clear_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_xor_and_clear_val() -> bool with Mut, Div, Panic {
     // r0 ^ (r0 & 0xFF) → r0 & ~0xFF
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 255)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
@@ -17076,7 +17076,7 @@ fn compiler_main_test_cz_xor_and_clear_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // r0 ^ (r1 & 7) → no fold (r1 != r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(2, 7)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)   // r3 = r1 & 7
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 3)   // r0 ^ (r1&7)
@@ -17086,7 +17086,7 @@ fn compiler_main_test_cz_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_no_fold_rr_and() -> bool with Mut, Div, Panic {
     // r0 ^ (r0 & r1) → no fold (and is rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0 & r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17095,7 +17095,7 @@ fn compiler_main_test_cz_no_fold_rr_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_cz_no_fold_or() -> bool with Mut, Div, Panic {
     // r0 | (r0 & 7) → no fold by CZ (OR not XOR; handled by Block AO)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(1, 7)
     instrs[1 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
@@ -17107,7 +17107,7 @@ fn compiler_main_test_cz_no_fold_or() -> bool with Mut, Div, Panic {
 // Sprint 191 Block DA: OR-AND XOR identity (T812-T817)
 fn compiler_main_test_da_or_and_xor_basic() -> bool with Mut, Div, Panic {
     // (r0|r1)^(r0&r1) → r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0|r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r3 = r0&r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)   // r4 = (r0|r1)^(r0&r1)
@@ -17120,7 +17120,7 @@ fn compiler_main_test_da_or_and_xor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_or_and_xor_comm() -> bool with Mut, Div, Panic {
     // (r0&r1)^(r0|r1) → r0^r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 2)   // and^or
@@ -17132,7 +17132,7 @@ fn compiler_main_test_da_or_and_xor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_or_and_xor_swapped() -> bool with Mut, Div, Panic {
     // (r1|r0)^(r0&r1) → r1^r0 (operands swapped in OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)    // r1|r0
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r0&r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -17143,7 +17143,7 @@ fn compiler_main_test_da_or_and_xor_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_no_fold_diff_ops() -> bool with Mut, Div, Panic {
     // (r0|r1)^(r0|r1) → 0 via self-xor, not DA; DA requires or+and pair
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)    // also OR
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -17154,7 +17154,7 @@ fn compiler_main_test_da_no_fold_diff_ops() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
     // (r0|r2)^(r0&r1) → no fold (diff operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)    // r0|r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)   // r0&r1
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -17164,7 +17164,7 @@ fn compiler_main_test_da_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_da_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)&(r0^r1) → no fold by DA (AND outer not XOR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)   // AND not XOR outer
@@ -17176,7 +17176,7 @@ fn compiler_main_test_da_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 192 Block DB: XOR-AND to OR (T818-T823)
 fn compiler_main_test_db_xor_and_or_basic() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r1) → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r3 = r0&r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)    // r4 = (r0^r1)|(r0&r1)
@@ -17189,7 +17189,7 @@ fn compiler_main_test_db_xor_and_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_xor_and_or_comm() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0^r1) → r0|r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)    // and|xor
@@ -17200,7 +17200,7 @@ fn compiler_main_test_db_xor_and_or_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_xor_and_or_val() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r1) → r0|r1 runtime check
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 12)                       // r0 = 12 (1100)
     instrs[1 as usize] = ir_load_imm(1, 10)                       // r1 = 10 (1010)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
@@ -17212,7 +17212,7 @@ fn compiler_main_test_db_xor_and_or_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_no_fold_diff_base_xor() -> bool with Mut, Div, Panic {
     // (r0^r2)|(r0&r1) → no fold (different rhs in xor vs and)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)   // r3 = r0^r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)   // r4 = r0&r1
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)    // (r0^r2)|(r0&r1)
@@ -17222,7 +17222,7 @@ fn compiler_main_test_db_no_fold_diff_base_xor() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_no_fold_rr_or() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0&r1) → no fold by DB (first operand is OR not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -17232,7 +17232,7 @@ fn compiler_main_test_db_no_fold_rr_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_db_no_fold_xor_outer() -> bool with Mut, Div, Panic {
     // (r0^r1)^(r0&r1) → no fold by DB (outer is XOR not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)   // XOR not OR outer
@@ -17244,7 +17244,7 @@ fn compiler_main_test_db_no_fold_xor_outer() -> bool with Mut, Div, Panic {
 // Sprint 193 Block DC: AND-XOR to OR (T824-T829)
 fn compiler_main_test_dc_and_xor_or_basic() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0^r1) → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0&r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)   // r3 = r0^r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)    // r4 = (r0&r1)|(r0^r1)
@@ -17257,7 +17257,7 @@ fn compiler_main_test_dc_and_xor_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_and_xor_or_comm() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r1) → r0|r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)    // xor|and
@@ -17269,7 +17269,7 @@ fn compiler_main_test_dc_and_xor_or_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_and_xor_or_swapped() -> bool with Mut, Div, Panic {
     // (r1&r0)|(r0^r1) → r1|r0 (and operands swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)   // r1&r0
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)   // r0^r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -17280,7 +17280,7 @@ fn compiler_main_test_dc_and_xor_or_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0&r2)|(r0^r1) → no fold (diff operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)   // r0&r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 1)   // r0^r1
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -17291,7 +17291,7 @@ fn compiler_main_test_dc_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_no_fold_xor_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)^(r0^r1) → no fold by DC (XOR outer not OR; handled by DA)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)   // XOR not OR
@@ -17301,7 +17301,7 @@ fn compiler_main_test_dc_no_fold_xor_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dc_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)&(r0^r1) → no fold by DC
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)   // AND outer
@@ -17313,7 +17313,7 @@ fn compiler_main_test_dc_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 194 Block DD: OR-NOT-AND to XOR (T830-T835)
 fn compiler_main_test_dd_or_not_and_xor_basic() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0&r1) → r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)    // r2 = r0|r1
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)   // r3 = r0&r1
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)         // r4 = ~r3
@@ -17327,7 +17327,7 @@ fn compiler_main_test_dd_or_not_and_xor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_or_not_and_xor_comm() -> bool with Mut, Div, Panic {
     // ~(r0&r1) & (r0|r1) → r0^r1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -17339,7 +17339,7 @@ fn compiler_main_test_dd_or_not_and_xor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_or_not_and_xor_val() -> bool with Mut, Div, Panic {
     // val check: (6|3)&~(6&3) = 7&~2 = 7&(-3) = 5 = 6^3
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 6)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
@@ -17352,7 +17352,7 @@ fn compiler_main_test_dd_or_not_and_xor_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
     // (r0|r2) & ~(r0&r1) → no fold (OR uses r2, AND uses r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)    // r3 = r0|r2
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)   // r4 = r0&r1
     instrs[2 as usize] = ir_unaryop(5, UnaryOp::OpNot, 4)
@@ -17363,7 +17363,7 @@ fn compiler_main_test_dd_no_fold_diff_base_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_no_fold_not_not_and() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0|r1) → no fold (inner is NOT of OR, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)         // ~(r0|r1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -17373,7 +17373,7 @@ fn compiler_main_test_dd_no_fold_not_not_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dd_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) | ~(r0&r1) → no fold by DD (OR outer not AND outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -17386,7 +17386,7 @@ fn compiler_main_test_dd_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 195 Block DE: XOR self-complement (T836-T841)
 fn compiler_main_test_de_xor_self_comp_basic() -> bool with Mut, Div, Panic {
     // r2 = r0 ^ r1; r3 = ~r2; r4 = r2 ^ r3 → IrLoadImm(-1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -17398,7 +17398,7 @@ fn compiler_main_test_de_xor_self_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_xor_self_comp_comm() -> bool with Mut, Div, Panic {
     // ~r0 ^ r0 → IrLoadImm(-1) (commutative: NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -17409,7 +17409,7 @@ fn compiler_main_test_de_xor_self_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_xor_self_comp_val() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0^r2 → -1; then r4 = r3+1 → const 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_load_imm(4, 1)
@@ -17423,7 +17423,7 @@ fn compiler_main_test_de_xor_self_comp_val() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_no_fold_diff_regs() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r1^r2 → no fold (r1 != r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17433,7 +17433,7 @@ fn compiler_main_test_de_no_fold_diff_regs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 & r2 → no fold by DE (AND not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17443,7 +17443,7 @@ fn compiler_main_test_de_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_de_no_fold_or_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 | r2 → no fold by DE (OR not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17454,7 +17454,7 @@ fn compiler_main_test_de_no_fold_or_op() -> bool with Mut, Div, Panic {
 // Sprint 196 Block DF: OR self-complement (T842-T847)
 fn compiler_main_test_df_or_self_comp_basic() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 | r2 → IrLoadImm(-1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17465,7 +17465,7 @@ fn compiler_main_test_df_or_self_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_or_self_comp_comm() -> bool with Mut, Div, Panic {
     // ~r0 | r0 → IrLoadImm(-1) (commutative: NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -17476,7 +17476,7 @@ fn compiler_main_test_df_or_self_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_or_self_comp_chain() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0|r2 → -1; r4 = r3+1 folds to 0 via const prop
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_load_imm(4, 1)
@@ -17489,7 +17489,7 @@ fn compiler_main_test_df_or_self_comp_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_no_fold_diff_regs() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r1 | r2 → no fold (r1 != r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17499,7 +17499,7 @@ fn compiler_main_test_df_no_fold_diff_regs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_no_fold_xor_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 ^ r2 → no fold by DF (XOR not OR, handled by DE)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17510,7 +17510,7 @@ fn compiler_main_test_df_no_fold_xor_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_df_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r2 = ~r0; r3 = r0 & r2 → 0 (handled by Block DG, not DF)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17523,7 +17523,7 @@ fn compiler_main_test_df_no_fold_and_op() -> bool with Mut, Div, Panic {
 // Sprint 197 Block DG: NOT-XOR-operand unwrapping (T848-T853)
 fn compiler_main_test_dg_not_xor_unwrap_basic() -> bool with Mut, Div, Panic {
     // ~(r0^r1)^r1 → ~r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)   // r2 = r0^r1
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)         // r3 = ~r2
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 1)   // r4 = r3^r1
@@ -17535,7 +17535,7 @@ fn compiler_main_test_dg_not_xor_unwrap_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_not_xor_unwrap_lhs() -> bool with Mut, Div, Panic {
     // ~(r0^r1)^r0 → ~r1 (other operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 0)   // r3^r0 → ~r1
@@ -17547,7 +17547,7 @@ fn compiler_main_test_dg_not_xor_unwrap_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_not_xor_unwrap_comm() -> bool with Mut, Div, Panic {
     // r1^~(r0^r1) → ~r0 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitXor, 3)   // r1^r3
@@ -17558,7 +17558,7 @@ fn compiler_main_test_dg_not_xor_unwrap_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // ~(r0^r1)^r2 → no fold (r2 not in {r0,r1})
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 4, BinaryOp::OpBitXor, 2)
@@ -17568,7 +17568,7 @@ fn compiler_main_test_dg_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_no_fold_not_xor_rr() -> bool with Mut, Div, Panic {
     // ~r1^r1 → -1 (is Block DE, not DG; inner is NOT of scalar not xor-rr)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -17578,7 +17578,7 @@ fn compiler_main_test_dg_no_fold_not_xor_rr() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dg_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // ~(r0^r1)&r1 → no fold by DG (AND outer not XOR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -17590,7 +17590,7 @@ fn compiler_main_test_dg_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 198 Block DH: AND-NOT-OR annihilation (T854-T859)
 fn compiler_main_test_dh_and_not_or_basic() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r0 & r3 → IrLoadImm(0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -17602,7 +17602,7 @@ fn compiler_main_test_dh_and_not_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_and_not_or_rhs() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r1 & r3 → 0 (other operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 3)
@@ -17614,7 +17614,7 @@ fn compiler_main_test_dh_and_not_or_rhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_and_not_or_comm() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r3 & r0 → 0 (NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 0)
@@ -17626,7 +17626,7 @@ fn compiler_main_test_dh_and_not_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r5 & r3 → no fold (r5 not in OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 5, BinaryOp::OpBitAnd, 3)
@@ -17637,7 +17637,7 @@ fn compiler_main_test_dh_no_fold_diff_reg() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_no_fold_or_op() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = ~r2; r4 = r0 | r3 → no fold by DH (OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -17648,7 +17648,7 @@ fn compiler_main_test_dh_no_fold_or_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dh_no_fold_not_and() -> bool with Mut, Div, Panic {
     // r2 = r0&r1; r3 = ~r2; r4 = r0 & r3 → no fold by DH (AND not OR inside NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -17662,7 +17662,7 @@ fn compiler_main_test_dh_no_fold_not_and() -> bool with Mut, Div, Panic {
 // Sprint 199 Block DI: OR-NOT-AND tautology (T860-T865)
 fn compiler_main_test_di_or_not_and_taut_lhs() -> bool with Mut, Div, Panic {
     // r0 | ~(r0&r1) → -1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)   // r2 = r0&r1
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)         // r3 = ~r2
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)    // r4 = r0|r3
@@ -17673,7 +17673,7 @@ fn compiler_main_test_di_or_not_and_taut_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_or_not_and_taut_rhs() -> bool with Mut, Div, Panic {
     // r1 | ~(r0&r1) → -1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 3)    // r1|r3
@@ -17684,7 +17684,7 @@ fn compiler_main_test_di_or_not_and_taut_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_or_not_and_taut_comm() -> bool with Mut, Div, Panic {
     // ~(r0&r1) | r0 → -1 commutative
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 0)    // r3|r0
@@ -17695,7 +17695,7 @@ fn compiler_main_test_di_or_not_and_taut_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r2 | ~(r0&r1) → no fold (r2 not in AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpBitOr, 4)
@@ -17705,7 +17705,7 @@ fn compiler_main_test_di_no_fold_diff_reg() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r0 | ~(r0|r1) → no fold by DI (inner is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -17716,7 +17716,7 @@ fn compiler_main_test_di_no_fold_and_op() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_di_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r0 & ~(r0&r1) → no fold by DI (AND outer not OR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)   // AND not OR outer
@@ -17730,7 +17730,7 @@ fn compiler_main_test_di_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 200 Block DJ: NOT-sub-NOT to reverse-sub (T866-T871)
 fn compiler_main_test_dj_not_sub_not_basic() -> bool with Mut, Div, Panic {
     // ~r0 - ~r1 → r1 - r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)         // r2 = ~r0
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)         // r3 = ~r1
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)       // r4 = r2-r3
@@ -17743,7 +17743,7 @@ fn compiler_main_test_dj_not_sub_not_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_not_sub_not_val() -> bool with Mut, Div, Panic {
     // ~5 - ~3 = 3 - 5 = -2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 5)
     instrs[1 as usize] = ir_load_imm(1, 3)
     instrs[2 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
@@ -17757,7 +17757,7 @@ fn compiler_main_test_dj_not_sub_not_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_not_sub_not_same() -> bool with Mut, Div, Panic {
     // ~r0 - ~r0 → 0 (via this fold: r0 - r0 → 0 from Block A)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 2)       // ~r0 - ~r0 (same reg)
     let func = cp_make_test_func(instrs, 2)
@@ -17768,7 +17768,7 @@ fn compiler_main_test_dj_not_sub_not_same() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_no_fold_only_one_not() -> bool with Mut, Div, Panic {
     // ~r0 - r1 → no fold by DJ (s2 not NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -17778,7 +17778,7 @@ fn compiler_main_test_dj_no_fold_only_one_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_no_fold_not_add() -> bool with Mut, Div, Panic {
     // ~r0 + ~r1 → -2 not via DJ (ADD not SUB; Block BF may fold ~r0+r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)    // OR not SUB
@@ -17788,7 +17788,7 @@ fn compiler_main_test_dj_no_fold_not_add() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dj_no_fold_neg_not() -> bool with Mut, Div, Panic {
     // neg(r0) - ~r1 → no fold by DJ (s1 is neg, not NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17801,7 +17801,7 @@ fn compiler_main_test_dj_no_fold_neg_not() -> bool with Mut, Div, Panic {
 // Sprint 201 Block DK: OR-AND sum factoring (T872-T877)
 fn compiler_main_test_dk_or_and_sum_basic() -> bool with Mut, Div, Panic {
     // r2 = r0|r1; r3 = r0&r1; r4 = r2+r3 → r4 = r0+r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -17815,7 +17815,7 @@ fn compiler_main_test_dk_or_and_sum_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_or_and_sum_comm() -> bool with Mut, Div, Panic {
     // (x&y)+(x|y) → x+y (AND on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 2)
@@ -17827,7 +17827,7 @@ fn compiler_main_test_dk_or_and_sum_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_or_and_sum_swapped() -> bool with Mut, Div, Panic {
     // (y|x) + (x&y) → same result (operand order in OR/AND swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -17839,7 +17839,7 @@ fn compiler_main_test_dk_or_and_sum_swapped() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0|r1) + (r0&r2) → no fold (different second operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -17851,7 +17851,7 @@ fn compiler_main_test_dk_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_no_fold_sub_op() -> bool with Mut, Div, Panic {
     // (r0|r1) - (r0&r1) → no fold by DK (SUB not ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17862,7 +17862,7 @@ fn compiler_main_test_dk_no_fold_sub_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dk_no_fold_or_or() -> bool with Mut, Div, Panic {
     // (r0|r1) + (r0|r1) → no fold by DK (not OR+AND pattern)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -17874,7 +17874,7 @@ fn compiler_main_test_dk_no_fold_or_or() -> bool with Mut, Div, Panic {
 // Sprint 202 Block DL: Transitive subtraction (T878-T883)
 fn compiler_main_test_dl_trans_sub_basic() -> bool with Mut, Div, Panic {
     // r2 = r0-r1; r3 = r1-r4; r5 = r2+r3 → r0-r4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17888,7 +17888,7 @@ fn compiler_main_test_dl_trans_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_trans_sub_comm() -> bool with Mut, Div, Panic {
     // (y-z) + (x-y) → x-z  commutative variant
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpSub, 4)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17902,7 +17902,7 @@ fn compiler_main_test_dl_trans_sub_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_trans_sub_self() -> bool with Mut, Div, Panic {
     // (x-y) + (y-x) → 0 = x-x  (x==z case)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17915,7 +17915,7 @@ fn compiler_main_test_dl_trans_sub_self() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_no_fold_diff_middle() -> bool with Mut, Div, Panic {
     // (r0-r1) + (r2-r3) → no fold (no shared middle term)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17927,7 +17927,7 @@ fn compiler_main_test_dl_no_fold_diff_middle() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (r0-r1) - (r1-r4) → no fold by DL (SUB not ADD outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -17939,7 +17939,7 @@ fn compiler_main_test_dl_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dl_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // (r0+r1) + (r1-r4) → no fold (first is ADD not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -17952,7 +17952,7 @@ fn compiler_main_test_dl_no_fold_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 203 Block DM: OR-AND difference to XOR (T884-T889)
 fn compiler_main_test_dm_or_and_diff_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1; r3=r0&r1; r4=r2-r3 → r4=r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17965,7 +17965,7 @@ fn compiler_main_test_dm_or_and_diff_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_or_and_diff_swapped() -> bool with Mut, Div, Panic {
     // (r1|r0)-(r0&r1) → same (OR operands swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17975,7 +17975,7 @@ fn compiler_main_test_dm_or_and_diff_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_or_and_diff_val() -> bool with Mut, Div, Panic {
     // structural: result is XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -17986,7 +17986,7 @@ fn compiler_main_test_dm_or_and_diff_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_no_fold_diff_ops() -> bool with Mut, Div, Panic {
     // (r0|r1)-(r0|r2) no fold (second is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -17996,7 +17996,7 @@ fn compiler_main_test_dm_no_fold_diff_ops() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0|r1)-(r0&r2) no fold (different operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -18006,7 +18006,7 @@ fn compiler_main_test_dm_no_fold_diff_base() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dm_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)+(r0&r1) no fold by DM (ADD outer, not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -18019,7 +18019,7 @@ fn compiler_main_test_dm_no_fold_add_outer() -> bool with Mut, Div, Panic {
 // Sprint 204 Block DN: Sub-sub identity (T890-T895)
 fn compiler_main_test_dn_sub_sub_basic() -> bool with Mut, Div, Panic {
     // r2 = r0-r1; r3 = r0-r4; r5 = r2-r3 → r4-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18033,7 +18033,7 @@ fn compiler_main_test_dn_sub_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_sub_sub_self() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r1) → z=y, so z-y=0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18045,7 +18045,7 @@ fn compiler_main_test_dn_sub_sub_self() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_sub_sub_reverse() -> bool with Mut, Div, Panic {
     // (r0-r4)-(r0-r1) → r1-r4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 4)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18059,7 +18059,7 @@ fn compiler_main_test_dn_sub_sub_reverse() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r2-r3) → no fold (different x in each sub)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 5, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(6, 2, BinaryOp::OpSub, 3)
@@ -18070,7 +18070,7 @@ fn compiler_main_test_dn_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r0-r4) → DL handles, DN doesn't
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -18083,7 +18083,7 @@ fn compiler_main_test_dn_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dn_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0-r4) → no fold by DN (first inner is ADD not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18095,7 +18095,7 @@ fn compiler_main_test_dn_no_fold_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 205 Block DO: Add-sub common-addend cancel (T896-T901)
 fn compiler_main_test_do_add_sub_cancel_basic() -> bool with Mut, Div, Panic {
     // r2=r0+r1; r3=r1+r4; r5=r2-r3 → r0-r4
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18109,7 +18109,7 @@ fn compiler_main_test_do_add_sub_cancel_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_add_sub_cancel_shared_left() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0+r4) → r1-r4  (shared left operand)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18123,7 +18123,7 @@ fn compiler_main_test_do_add_sub_cancel_shared_left() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_do_add_sub_cancel_self() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0+r1) → 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18135,7 +18135,7 @@ fn compiler_main_test_do_add_sub_cancel_self() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_no_fold_no_common() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r2+r3) → no fold (no shared term)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 5, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(6, 2, BinaryOp::OpSub, 3)
@@ -18146,7 +18146,7 @@ fn compiler_main_test_do_no_fold_no_common() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0+r1)+(r1+r4) → no fold by DO (ADD not SUB outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
@@ -18157,7 +18157,7 @@ fn compiler_main_test_do_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_do_no_fold_not_add() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r1+r4) → no fold by DO (s1 is SUB not ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 4)
     instrs[2 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
@@ -18169,7 +18169,7 @@ fn compiler_main_test_do_no_fold_not_add() -> bool with Mut, Div, Panic {
 // Sprint 206 Block DP: AND-OR XOR identity (T902-T907)
 fn compiler_main_test_dp_and_or_xor_basic() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0|r1) → r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -18183,7 +18183,7 @@ fn compiler_main_test_dp_and_or_xor_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_or_and_xor_comm() -> bool with Mut, Div, Panic {
     // (r0|r1) ^ (r0&r1) → r0^r1 (commutative outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -18195,7 +18195,7 @@ fn compiler_main_test_dp_or_and_xor_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_and_or_xor_swapped() -> bool with Mut, Div, Panic {
     // (r1&r0) ^ (r0|r1) → r1^r0 (inner operand order swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -18207,7 +18207,7 @@ fn compiler_main_test_dp_and_or_xor_swapped() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_no_fold_diff_base() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0|r2) → no fold (different operands)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -18218,7 +18218,7 @@ fn compiler_main_test_dp_no_fold_diff_base() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_no_fold_and_and() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0&r1) → 0 (both AND, not AND^OR — Block A x^x fires)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18229,7 +18229,7 @@ fn compiler_main_test_dp_no_fold_and_and() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dp_no_fold_sub_op() -> bool with Mut, Div, Panic {
     // (r0&r1) - (r0|r1) → no fold by DP (SUB not XOR; DM may fire)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -18241,7 +18241,7 @@ fn compiler_main_test_dp_no_fold_sub_op() -> bool with Mut, Div, Panic {
 // Sprint 207 Block DQ: AND-XNOR to AND (T908-T913)
 fn compiler_main_test_dq_and_xnor_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1; r3=~r2; r4=r0&r3 → r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18254,7 +18254,7 @@ fn compiler_main_test_dq_and_xnor_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_and_xnor_rhs() -> bool with Mut, Div, Panic {
     // r0&~(r0^r1) where r0 matches XOR RHS (swap)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18265,7 +18265,7 @@ fn compiler_main_test_dq_and_xnor_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_and_xnor_comm() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & r0 → r0&r1 (XNOR on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 0)
@@ -18276,7 +18276,7 @@ fn compiler_main_test_dq_and_xnor_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_no_fold_diff_reg() -> bool with Mut, Div, Panic {
     // r2&~(r0^r1) where r2 not in XOR → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 4, BinaryOp::OpBitAnd, 3)
@@ -18286,7 +18286,7 @@ fn compiler_main_test_dq_no_fold_diff_reg() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r0|~(r0^r1) no fold by DQ (OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18296,7 +18296,7 @@ fn compiler_main_test_dq_no_fold_or_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dq_no_fold_not_xor() -> bool with Mut, Div, Panic {
     // r0&~r1 — r1 is plain NOT (not NOT-of-XOR) → no fold by DQ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18307,7 +18307,7 @@ fn compiler_main_test_dq_no_fold_not_xor() -> bool with Mut, Div, Panic {
 // Sprint 208 Block DR: De Morgan NOT-AND (T914-T919)
 fn compiler_main_test_dr_not_and_demorgan() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=~r1; r4=r2&r3; r5=~r4 → r5=r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18321,7 +18321,7 @@ fn compiler_main_test_dr_not_and_demorgan() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_not_and_swapped() -> bool with Mut, Div, Panic {
     // (~r1 & ~r0) negated → r1|r0 (AND operands swapped)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 2)
@@ -18332,7 +18332,7 @@ fn compiler_main_test_dr_not_and_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_not_and_val() -> bool with Mut, Div, Panic {
     // structural: result is IrBinOp (OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18343,7 +18343,7 @@ fn compiler_main_test_dr_not_and_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_no_fold_one_not() -> bool with Mut, Div, Panic {
     // ~(r0 & ~r1) — only one NOT in AND → no DR fold (not both negated)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -18354,7 +18354,7 @@ fn compiler_main_test_dr_no_fold_one_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // ~(~r0 | ~r1) no fold by DR (OR inner, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18367,7 +18367,7 @@ fn compiler_main_test_dr_no_fold_or_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dr_no_fold_not_not_and() -> bool with Mut, Div, Panic {
     // ~(r0&r1) where r0,r1 are not NOTs → no DR fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18380,7 +18380,7 @@ fn compiler_main_test_dr_no_fold_not_not_and() -> bool with Mut, Div, Panic {
 // Sprint 209 Block DS: De Morgan NOT-OR (T920-T925)
 fn compiler_main_test_ds_not_or_demorgan() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=~r1; r4=r2|r3; r5=~r4 → r5=r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18394,7 +18394,7 @@ fn compiler_main_test_ds_not_or_demorgan() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_not_or_swapped() -> bool with Mut, Div, Panic {
     // (~r1 | ~r0) negated → r1&r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18405,7 +18405,7 @@ fn compiler_main_test_ds_not_or_swapped() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_not_or_val() -> bool with Mut, Div, Panic {
     // result is AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18417,7 +18417,7 @@ fn compiler_main_test_ds_not_or_val() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_no_fold_one_not() -> bool with Mut, Div, Panic {
     // ~(r0 | ~r1) — only one NOT in OR → no DS fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -18428,7 +18428,7 @@ fn compiler_main_test_ds_no_fold_one_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // ~(~r0 & ~r1) no fold by DS (AND inner, not OR) — DR fires instead
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18441,7 +18441,7 @@ fn compiler_main_test_ds_no_fold_and_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_ds_no_fold_plain_or() -> bool with Mut, Div, Panic {
     // ~(r0|r1) no fold by DS (r0,r1 not NOTs)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -18453,7 +18453,7 @@ fn compiler_main_test_ds_no_fold_plain_or() -> bool with Mut, Div, Panic {
 // Sprint 210 Block DT: OR-AND complement absorption (T926-T931)
 fn compiler_main_test_dt_or_and_comp_basic() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=r1&r2; r4=r0|r3 → r4=r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18466,7 +18466,7 @@ fn compiler_main_test_dt_or_and_comp_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_or_and_comp_comm_and() -> bool with Mut, Div, Panic {
     // r2=~r0; r3=r2&r1 (AND flipped) → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18477,7 +18477,7 @@ fn compiler_main_test_dt_or_and_comp_comm_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_or_and_comp_comm_or() -> bool with Mut, Div, Panic {
     // (y&~x)|x → x|y (OR outer commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 0)
@@ -18488,7 +18488,7 @@ fn compiler_main_test_dt_or_and_comp_comm_or() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r0|(r1&~r2) no fold (r2 not r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitOr, 4)
@@ -18498,7 +18498,7 @@ fn compiler_main_test_dt_no_fold_diff_var() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_no_fold_no_not() -> bool with Mut, Div, Panic {
     // r0|(r1&r2) no fold (r2 not NOT of r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
     let func = cp_make_test_func(instrs, 2)
@@ -18507,7 +18507,7 @@ fn compiler_main_test_dt_no_fold_no_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dt_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r0&(r1&~r0) no fold by DT (AND outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18520,7 +18520,7 @@ fn compiler_main_test_dt_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 211 Block DU: XOR-AND to OR (T932-T937)
 fn compiler_main_test_du_xor_and_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1; r3=r0&r1; r4=r2|r3 → r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18533,7 +18533,7 @@ fn compiler_main_test_du_xor_and_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
     // r2=r1^r0; r3=r0&r1 (XOR operands swapped) → r1|r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18543,7 +18543,7 @@ fn compiler_main_test_du_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0^r1) → r0|r1 (AND on left, XOR on right)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18555,7 +18555,7 @@ fn compiler_main_test_du_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0&r2) → no fold (AND uses r2 not r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -18565,7 +18565,7 @@ fn compiler_main_test_du_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_no_fold_xor_and_and() -> bool with Mut, Div, Panic {
     // (r0^r1)&(r0&r1) no fold by DU (AND outer, not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18575,7 +18575,7 @@ fn compiler_main_test_du_no_fold_xor_and_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_du_no_fold_xor_or() -> bool with Mut, Div, Panic {
     // (r0^r1)|(r0|r1) no fold by DU (inner is OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18590,7 +18590,7 @@ fn compiler_main_test_du_no_fold_xor_or() -> bool with Mut, Div, Panic {
 // Sprint 212 Block DV: XOR-AND-OR simplify (T938-T943)
 fn compiler_main_test_dv_xor_and_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1; r3=r0|r1; r4=r2&r3 → IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18601,7 +18601,7 @@ fn compiler_main_test_dv_xor_and_or_basic() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) & (r0^r1) → IrCopy(xor_reg) (commutative AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 2)
@@ -18612,7 +18612,7 @@ fn compiler_main_test_dv_xor_and_or_comm_outer() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
     // r2=r1^r0 (swapped); r3=r0|r1 → IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitXor, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18622,7 +18622,7 @@ fn compiler_main_test_dv_xor_and_or_comm_inner() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0|r2) no fold (OR uses r2 not r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -18632,7 +18632,7 @@ fn compiler_main_test_dv_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_no_fold_and_and() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0&r1) no fold by DV (inner AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18643,7 +18643,7 @@ fn compiler_main_test_dv_no_fold_and_and() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dv_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0^r1) | (r0|r1) no fold by DV (outer OR not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18656,7 +18656,7 @@ fn compiler_main_test_dv_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 213 Block DW: AND complement annihilation (T944-T949)
 fn compiler_main_test_dw_and_comp_lhs() -> bool with Mut, Div, Panic {
     // r2=r0&r1; r3=~r0; r4=r2&r3 → 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18667,7 +18667,7 @@ fn compiler_main_test_dw_and_comp_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_and_comp_rhs() -> bool with Mut, Div, Panic {
     // r2=r0&r1; r3=~r1; r4=r2&r3 → 0 (NOT of rhs of AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18678,7 +18678,7 @@ fn compiler_main_test_dw_and_comp_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_and_comp_comm() -> bool with Mut, Div, Panic {
     // ~r0 & (r0&r1) → 0 (NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 2)
@@ -18689,7 +18689,7 @@ fn compiler_main_test_dw_and_comp_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0&r1) & ~r2 no fold (r2 not in AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18700,7 +18700,7 @@ fn compiler_main_test_dw_no_fold_diff_var() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0&r1) & r0 no fold (no NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -18709,7 +18709,7 @@ fn compiler_main_test_dw_no_fold_no_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dw_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0&r1) | ~r0 no fold by DW (OR outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18721,7 +18721,7 @@ fn compiler_main_test_dw_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 214 Block DX: OR complement saturation (T950-T955)
 fn compiler_main_test_dx_or_comp_sat_lhs() -> bool with Mut, Div, Panic {
     // r2=r0|r1; r3=~r0; r4=r2|r3 → -1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18732,7 +18732,7 @@ fn compiler_main_test_dx_or_comp_sat_lhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_or_comp_sat_rhs() -> bool with Mut, Div, Panic {
     // r2=r0|r1; r3=~r1; r4=r2|r3 → -1 (NOT of rhs)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18743,7 +18743,7 @@ fn compiler_main_test_dx_or_comp_sat_rhs() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_or_comp_sat_comm() -> bool with Mut, Div, Panic {
     // ~r0 | (r0|r1) → -1 (NOT on left)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18754,7 +18754,7 @@ fn compiler_main_test_dx_or_comp_sat_comm() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1) | ~r2 no fold (r2 not in OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18765,7 +18765,7 @@ fn compiler_main_test_dx_no_fold_diff_var() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1) | r0 no fold (no NOT) — absorbed by Block AO/AP
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -18774,7 +18774,7 @@ fn compiler_main_test_dx_no_fold_no_not() -> bool with Mut, Div, Panic {
 }
 fn compiler_main_test_dx_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~r0 no fold by DX (AND outer — Block DT fires instead)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18787,7 +18787,7 @@ fn compiler_main_test_dx_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 215 Block DY: AND-OR complement absorption (T956-T961)
 fn compiler_main_test_dy_and_or_comp_basic() -> bool with Mut, Div, Panic {
     // r2 = r1|~r0; r3 = r0&r2 → r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)        // r2 = ~r0
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)    // r3 = r1|~r0
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)   // r4 = r0&r3
@@ -18801,7 +18801,7 @@ fn compiler_main_test_dy_and_or_comp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_and_or_comp_comm() -> bool with Mut, Div, Panic {
     // (r1|~r0) & r0 → r0&r1 (commutative outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 0)
@@ -18813,7 +18813,7 @@ fn compiler_main_test_dy_and_or_comp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_and_or_comp_not_left() -> bool with Mut, Div, Panic {
     // r0 & (~r0|r1) → r0&r1 (~x on left of OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)    // ~r0|r1
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
@@ -18825,7 +18825,7 @@ fn compiler_main_test_dy_and_or_comp_not_left() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r0 & (r1|~r2) → no fold (~r2 != ~r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitAnd, 4)
@@ -18836,7 +18836,7 @@ fn compiler_main_test_dy_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_no_fold_no_not() -> bool with Mut, Div, Panic {
     // r0 & (r1|r2) → no fold (no NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 3)
     let func = cp_make_test_func(instrs, 2)
@@ -18846,7 +18846,7 @@ fn compiler_main_test_dy_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dy_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r0 | (r1|~r0) → DT fires, not DY (OR not AND outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 3)
@@ -18858,7 +18858,7 @@ fn compiler_main_test_dy_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 241 Block EY: OR-XOR subsumption — (x|y)|(x^y) → x|y (T1112-T1117)
 fn compiler_main_test_ey_or_xor_subsume_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2|r3 → r4 becomes IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18870,7 +18870,7 @@ fn compiler_main_test_ey_or_xor_subsume_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_or_xor_subsume_comm() -> bool with Mut, Div, Panic {
     // (x^y)|(x|y) → x|y: commutative outer OR (s1=xor, s2=or)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 2)
@@ -18882,7 +18882,7 @@ fn compiler_main_test_ey_or_xor_subsume_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_or_xor_subsume_inner_comm() -> bool with Mut, Div, Panic {
     // (x|y)|(y^x) → x|y: inner XOR operands commuted
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18894,7 +18894,7 @@ fn compiler_main_test_ey_or_xor_subsume_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ey_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0^r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -18906,7 +18906,7 @@ fn compiler_main_test_ey_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (x|y)|(x&y): inner AND not XOR → Block EF fires (IrCopy(s1)), not EY
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -18919,7 +18919,7 @@ fn compiler_main_test_ey_no_fold_and_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ey_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (x|y)&(x^y): outer AND not OR → no EY fold (Block DD may fire →x^y)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -18937,7 +18937,7 @@ fn compiler_main_test_ey_no_fold_and_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ge_standard_passthrough() -> bool with Mut, Div, Panic {
     // Guard: IR_STRATEGY_STANDARD → epistemic pass returns function unchanged
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_imm(0, 42)
     instrs[1 as usize] = ir_return(0)
     let func = cp_make_test_func(instrs, 2)
@@ -18948,7 +18948,7 @@ fn compiler_main_test_ge_standard_passthrough() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ge_precision_no_crash() -> bool with Mut, Div, Panic {
     // IR_STRATEGY_PRECISION_PRESERVING + canonical Knowledge struct source: pass activates
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 42.0)
     instrs[1 as usize] = ir_load_float(1, 0.25)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -18967,7 +18967,7 @@ fn compiler_main_test_ge_precision_no_crash() -> bool with Mut, Div, Panic {
 fn compiler_main_test_ge_count_guard() -> bool with Mut, Div, Panic {
     // Large non-epistemic bodies still pass through unchanged under the
     // precision-preserving strategy.
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     var i: i64 = 0
     while i < 17 {
         instrs[i as usize] = ir_load_imm(i, i)
@@ -18981,7 +18981,7 @@ fn compiler_main_test_ge_count_guard() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ge_binop_no_crash() -> bool with Mut, Div, Panic {
     // PRECISION_PRESERVING + value extracted from Knowledge struct: binop is processed
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.003)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19020,7 +19020,7 @@ fn compiler_main_test_ge_pythagorean_integration() -> bool with Mut, Div, Panic 
 }
 
 fn compiler_main_test_ge_observation_flow_return_value() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.5)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19039,7 +19039,7 @@ fn compiler_main_test_ge_observation_flow_return_value() -> bool with Mut, Div, 
 }
 
 fn compiler_main_test_ge_observation_flow_unobserved_temp() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.5)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19059,7 +19059,7 @@ fn compiler_main_test_ge_observation_flow_unobserved_temp() -> bool with Mut, Di
 }
 
 fn compiler_main_test_ge_observation_flow_branch() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 10.0)
     instrs[1 as usize] = ir_load_float(1, 0.5)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19081,7 +19081,7 @@ fn compiler_main_test_ge_observation_flow_branch() -> bool with Mut, Div, Panic 
 }
 
 fn compiler_main_test_ge_observed_reassoc_chain() -> bool with Mut, Div, Panic {
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_load_float(0, 1.0)
     instrs[1 as usize] = ir_load_float(1, 0.000000003)
     instrs[2 as usize] = ir_alloc(2, 0)
@@ -19133,7 +19133,7 @@ fn compiler_main_test_ge_observed_reassoc_chain() -> bool with Mut, Div, Panic {
 // Sprint 246 Block FD: XOR decomposition fold — (~x&y)^(x&~y) → x^y (T1142-T1147)
 fn compiler_main_test_fd_xor_decomp_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=~r1, r5=r0&r4, r6=r3^r5 → r6 becomes IrBinOp(r0,XOR,r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19149,7 +19149,7 @@ fn compiler_main_test_fd_xor_decomp_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_xor_decomp_comm() -> bool with Mut, Div, Panic {
     // r2=~r1, r3=r0&r2, r4=~r0, r5=r4&r1, r6=r3^r5 (commuted: (x&~y)^(~x&y)) → x^y
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 0)
@@ -19163,7 +19163,7 @@ fn compiler_main_test_fd_xor_decomp_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_xor_decomp_inner_comm() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r1&r2 (inner: y&~x), r4=~r1, r5=r0&r4, r6=r3^r5 → x^y
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19177,7 +19177,7 @@ fn compiler_main_test_fd_xor_decomp_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=~r2, r5=r0&r4 (s2 AND uses r2 not ~r2) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 2)
@@ -19193,7 +19193,7 @@ fn compiler_main_test_fd_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2|r1 (OR not AND), r4=~r1, r5=r0&r4 → no FD fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19209,7 +19209,7 @@ fn compiler_main_test_fd_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fd_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=~r1, r5=r0&r4, r6=r3&r5 (AND outer not XOR) → no FD fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19224,7 +19224,7 @@ fn compiler_main_test_fd_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 245 Block FC: NOT-XOR-NOT recovery — (~x^y)^~y → x (T1136-T1141)
 fn compiler_main_test_fc_not_xor_not_recovery_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r1, r5=r3^r4 → r5 becomes IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19237,7 +19237,7 @@ fn compiler_main_test_fc_not_xor_not_recovery_basic() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_fc_not_xor_not_recovery_inner_comm() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r1^r2 (inner commuted: y^~x), r4=~r1, r5=r3^r4 → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19250,7 +19250,7 @@ fn compiler_main_test_fc_not_xor_not_recovery_inner_comm() -> bool with Mut, Div
 
 fn compiler_main_test_fc_not_xor_not_recovery_outer_comm() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r1, r5=r4^r3 (outer commuted: ~y^(~x^y)) → IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19263,7 +19263,7 @@ fn compiler_main_test_fc_not_xor_not_recovery_outer_comm() -> bool with Mut, Div
 
 fn compiler_main_test_fc_no_fold_diff_not() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r2 (NOT of ~x not NOT of y) → no FC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 2)
@@ -19276,7 +19276,7 @@ fn compiler_main_test_fc_no_fold_diff_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fc_no_fold_no_not() -> bool with Mut, Div, Panic {
     // r2=r0^r1 (no NOT), r3=r1, r4=r2^r3 (no ~y) → no FC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -19286,7 +19286,7 @@ fn compiler_main_test_fc_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fc_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1, r4=~r1, r5=r3&r4 (AND outer not XOR) → no FC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 1)
@@ -19300,7 +19300,7 @@ fn compiler_main_test_fc_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 244 Block FB: AND-XOR AND annihilation — (x&y)&(x^y) → 0 (T1130-T1135)
 fn compiler_main_test_fb_and_xor_and_zero_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2&r3 → r4 becomes IrLoadImm(0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19312,7 +19312,7 @@ fn compiler_main_test_fb_and_xor_and_zero_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_and_xor_and_zero_comm() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0&r1, r4=r2&r3 → r4 becomes IrLoadImm(0) commutative outer AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19324,7 +19324,7 @@ fn compiler_main_test_fb_and_xor_and_zero_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_and_xor_and_zero_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r1^r0 (inner commuted XOR), r4=r2&r3 → IrLoadImm(0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19336,7 +19336,7 @@ fn compiler_main_test_fb_and_xor_and_zero_inner_comm() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_fb_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r2 (diff var) → no FB fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19348,7 +19348,7 @@ fn compiler_main_test_fb_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // r2=r0|r1 (OR not AND), r3=r0^r1, r4=r2&r3 → FA fires → IrCopy not zero
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19361,7 +19361,7 @@ fn compiler_main_test_fb_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fb_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2|r3 → EZ fires → OR result; not FB
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19375,7 +19375,7 @@ fn compiler_main_test_fb_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 243 Block FA: OR-XOR AND subsumption — (x|y)&(x^y) → x^y (T1124-T1129)
 fn compiler_main_test_fa_or_xor_and_sub_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2&r3 → r4 becomes IrCopy(r3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19387,7 +19387,7 @@ fn compiler_main_test_fa_or_xor_and_sub_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_or_xor_and_sub_comm() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0|r1, r4=r2&r3 → r4 becomes IrCopy(r2) — commutative AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19399,7 +19399,7 @@ fn compiler_main_test_fa_or_xor_and_sub_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_or_xor_and_sub_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r1^r0 (inner commuted XOR), r4=r2&r3 → IrCopy(r3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19411,7 +19411,7 @@ fn compiler_main_test_fa_or_xor_and_sub_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_fa_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r2 (diff var) → no FA fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19423,7 +19423,7 @@ fn compiler_main_test_fa_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2|r3 — outer OR not AND → EY/EZ may fire
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19435,7 +19435,7 @@ fn compiler_main_test_fa_no_fold_or_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_fa_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2&r3 → outer AND but s1 is AND not OR → no FA fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19449,7 +19449,7 @@ fn compiler_main_test_fa_no_fold_and_inner() -> bool with Mut, Div, Panic {
 // Sprint 242 Block EZ: AND-XOR to OR — (x&y)|(x^y) → x|y (T1118-T1123)
 fn compiler_main_test_ez_and_xor_to_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2|r3 → r4 becomes IrBinOp(r0,OpBitOr,r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19463,7 +19463,7 @@ fn compiler_main_test_ez_and_xor_to_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_and_xor_to_or_comm() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0&r1, r4=r2|r3 → r4 becomes IrBinOp(r0,OpBitOr,r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19477,7 +19477,7 @@ fn compiler_main_test_ez_and_xor_to_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_and_xor_to_or_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r1^r0 (inner commuted), r4=r2|r3 → folds to r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19489,7 +19489,7 @@ fn compiler_main_test_ez_and_xor_to_or_inner_comm() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_ez_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r2 (different second var) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19503,7 +19503,7 @@ fn compiler_main_test_ez_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // r2=r0|r1 (OR not AND), r3=r0^r1, r4=r2|r3 → Block EY fires (OR-XOR subsume) not EZ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -19515,7 +19515,7 @@ fn compiler_main_test_ez_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ez_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2&r3 (AND outer not OR) → no EZ fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -19528,7 +19528,7 @@ fn compiler_main_test_ez_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 240 Block EX: OR-complement-AND XOR to copy — (x|y)^(~x&y) → x (T1106-T1111)
 fn compiler_main_test_ex_or_comp_and_xor_copy_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=~r0, r4=r3&r1, r5=r2^r4 → r5 becomes IrCopy(r0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19541,7 +19541,7 @@ fn compiler_main_test_ex_or_comp_and_xor_copy_basic() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_ex_or_comp_and_xor_copy_rhs_x() -> bool with Mut, Div, Panic {
     // (y|x)^(~x&y) → x: x is rhs of OR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitOr, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19554,7 +19554,7 @@ fn compiler_main_test_ex_or_comp_and_xor_copy_rhs_x() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_ex_or_comp_and_xor_copy_comm_xor() -> bool with Mut, Div, Panic {
     // (~x&y)^(x|y) → x: commutative outer XOR
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19567,7 +19567,7 @@ fn compiler_main_test_ex_or_comp_and_xor_copy_comm_xor() -> bool with Mut, Div, 
 
 fn compiler_main_test_ex_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1)^(~r0&r2): y differs → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(5, 4, BinaryOp::OpBitAnd, 2)
@@ -19580,7 +19580,7 @@ fn compiler_main_test_ex_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ex_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1)^(r2&r1): AND has no NOT → no EX fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -19592,7 +19592,7 @@ fn compiler_main_test_ex_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ex_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)&(~r0&r1): outer AND not XOR → no EX fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19606,7 +19606,7 @@ fn compiler_main_test_ex_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 239 Block EW: AND-complement XOR to copy — (x&y)^(~x&y) → y (T1100-T1105)
 fn compiler_main_test_ew_and_comp_xor_copy_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=~r0, r4=r3&r1, r5=r2^r4 → r5 becomes IrCopy(r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19619,7 +19619,7 @@ fn compiler_main_test_ew_and_comp_xor_copy_basic() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_ew_and_comp_xor_copy_comm() -> bool with Mut, Div, Panic {
     // (~x&y)^(x&y) → y (commutative outer XOR: s1=~x&y, s2=x&y)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19632,7 +19632,7 @@ fn compiler_main_test_ew_and_comp_xor_copy_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ew_and_comp_xor_copy_lhs_shared() -> bool with Mut, Div, Panic {
     // (y&x)^(y&~x) → y (same lhs y, rhs x vs ~x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 3)
@@ -19645,7 +19645,7 @@ fn compiler_main_test_ew_and_comp_xor_copy_lhs_shared() -> bool with Mut, Div, P
 
 fn compiler_main_test_ew_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (r0&r1)^(~r0&r2): different rhs (y1≠y2) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(5, 4, BinaryOp::OpBitAnd, 2)
@@ -19658,7 +19658,7 @@ fn compiler_main_test_ew_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ew_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0&r1)^(r2&r1): no NOT involved → no EW fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -19670,7 +19670,7 @@ fn compiler_main_test_ew_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ew_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)|(~r0&r1): outer is OR not XOR → Block EL fires (→r1), not EW
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
@@ -19685,7 +19685,7 @@ fn compiler_main_test_ew_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 238 Block EV: Cross-sub add collapse — (x-y)+(z-x) → z-y (T1094-T1099)
 fn compiler_main_test_ev_cross_sub_add_basic() -> bool with Mut, Div, Panic {
     // r3=r0-r1, r4=r2-r0, r5=r3+r4 → r5 becomes r2-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19699,7 +19699,7 @@ fn compiler_main_test_ev_cross_sub_add_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_cross_sub_add_comm() -> bool with Mut, Div, Panic {
     // (z-x)+(x-y) → z-y (commutative outer ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 0)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19713,7 +19713,7 @@ fn compiler_main_test_ev_cross_sub_add_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_cross_sub_add_self_cancel() -> bool with Mut, Div, Panic {
     // (x-y)+(y-x) = 0 → via Block A (x-x→0) after EV fires: z=y,y=y → y-y→0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19726,7 +19726,7 @@ fn compiler_main_test_ev_cross_sub_add_self_cancel() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ev_no_fold_diff_x() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r2-r3): no shared x → no EV fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
     instrs[2 as usize] = ir_binop(6, 4, BinaryOp::OpAdd, 5)
@@ -19738,7 +19738,7 @@ fn compiler_main_test_ev_no_fold_diff_x() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (x-y)-(z-x): outer SUB not ADD → no EV fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -19751,7 +19751,7 @@ fn compiler_main_test_ev_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ev_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
     // (x-y)+(x+z): s2 is ADD not SUB → no EV fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19764,7 +19764,7 @@ fn compiler_main_test_ev_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 237 Block EU: Add-OR diff to AND — (x+y)-(x|y) → x&y (T1088-T1093)
 fn compiler_main_test_eu_add_or_sub_and_basic() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0|r1, r4=r2-r3 → r4 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19778,7 +19778,7 @@ fn compiler_main_test_eu_add_or_sub_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eu_add_or_sub_and_inner_comm_add() -> bool with Mut, Div, Panic {
     // (y+x)-(x|y) → x&y (inner ADD commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19790,7 +19790,7 @@ fn compiler_main_test_eu_add_or_sub_and_inner_comm_add() -> bool with Mut, Div, 
 
 fn compiler_main_test_eu_add_or_sub_and_inner_comm_or() -> bool with Mut, Div, Panic {
     // (x+y)-(y|x) → x&y (inner OR commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19802,7 +19802,7 @@ fn compiler_main_test_eu_add_or_sub_and_inner_comm_or() -> bool with Mut, Div, P
 
 fn compiler_main_test_eu_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -19814,7 +19814,7 @@ fn compiler_main_test_eu_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eu_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (x+y)+(x|y): outer ADD not SUB → no EU fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19826,7 +19826,7 @@ fn compiler_main_test_eu_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eu_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (x+y)-(x&y): inner is AND not OR → Block DK covers (x|y)+(x&y)→x+y, not this
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19839,7 +19839,7 @@ fn compiler_main_test_eu_no_fold_and_inner() -> bool with Mut, Div, Panic {
 // Sprint 236 Block ET: OR-XOR diff to AND — (x|y)-(x^y) → x&y (T1082-T1087)
 fn compiler_main_test_et_or_xor_sub_and_basic() -> bool with Mut, Div, Panic {
     // r2=r0|r1, r3=r0^r1, r4=r2-r3 → r4 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19853,7 +19853,7 @@ fn compiler_main_test_et_or_xor_sub_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_or_xor_sub_and_inner_comm() -> bool with Mut, Div, Panic {
     // (x|y)-(y^x) → x&y (inner XOR commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19865,7 +19865,7 @@ fn compiler_main_test_et_or_xor_sub_and_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_et_or_xor_sub_and_tracked() -> bool with Mut, Div, Panic {
     // Result of ET is tracked as and_rr for downstream Block AO: (x&y)|(x&y)→IrCopy
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19879,7 +19879,7 @@ fn compiler_main_test_et_or_xor_sub_and_tracked() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0|r1)-(r0^r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -19891,7 +19891,7 @@ fn compiler_main_test_et_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (x|y)+(x^y): outer ADD → Block ES fires not ET
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19904,7 +19904,7 @@ fn compiler_main_test_et_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_et_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (x|y)-(x&y): inner AND not XOR → Block DM fires (→x^y), not ET
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19918,7 +19918,7 @@ fn compiler_main_test_et_no_fold_and_inner() -> bool with Mut, Div, Panic {
 // Sprint 235 Block ES: AND-XOR add to OR — (x&y)+(x^y) → x|y (T1076-T1081)
 fn compiler_main_test_es_and_xor_add_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0&r1, r3=r0^r1, r4=r2+r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19932,7 +19932,7 @@ fn compiler_main_test_es_and_xor_add_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_and_xor_add_or_comm() -> bool with Mut, Div, Panic {
     // (x^y)+(x&y) → x|y (commutative outer ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 2)
@@ -19946,7 +19946,7 @@ fn compiler_main_test_es_and_xor_add_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_and_xor_add_or_inner_comm() -> bool with Mut, Div, Panic {
     // (y&x)+(x^y) → x|y (inner AND commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpBitAnd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19958,7 +19958,7 @@ fn compiler_main_test_es_and_xor_add_or_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_es_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0&r1)+(r0^r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -19970,7 +19970,7 @@ fn compiler_main_test_es_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)-(r0^r1): outer SUB not ADD → no ES fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -19982,7 +19982,7 @@ fn compiler_main_test_es_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_es_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (r0|r1)+(r0^r1): inner is OR not AND → no ES fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -19996,7 +19996,7 @@ fn compiler_main_test_es_no_fold_or_inner() -> bool with Mut, Div, Panic {
 // Sprint 234 Block ER: Complement-AND add to OR — x+(~x&y) → x|y (T1070-T1075)
 fn compiler_main_test_er_comp_and_add_or_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=r0+r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 3)
@@ -20010,7 +20010,7 @@ fn compiler_main_test_er_comp_and_add_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_er_comp_and_add_or_comm_add() -> bool with Mut, Div, Panic {
     // (~x&y)+x → x|y (commutative outer ADD)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpAdd, 0)
@@ -20024,7 +20024,7 @@ fn compiler_main_test_er_comp_and_add_or_comm_add() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_er_comp_and_add_or_inner_comm() -> bool with Mut, Div, Panic {
     // x+(y&~x) → x|y (inner AND commutative: rhs is NOT(x))
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 3)
@@ -20038,7 +20038,7 @@ fn compiler_main_test_er_comp_and_add_or_inner_comm() -> bool with Mut, Div, Pan
 
 fn compiler_main_test_er_no_fold_diff_x() -> bool with Mut, Div, Panic {
     // r0+(~r2&r1): NOT is NOT(r2) not NOT(r0) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[1 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpAdd, 4)
@@ -20050,7 +20050,7 @@ fn compiler_main_test_er_no_fold_diff_x() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_er_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // x-(~x&y): outer is SUB not ADD → no ER fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 3)
@@ -20062,7 +20062,7 @@ fn compiler_main_test_er_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_er_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // x+(~x|y): inner is OR not AND → no ER fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 3)
@@ -20076,7 +20076,7 @@ fn compiler_main_test_er_no_fold_or_inner() -> bool with Mut, Div, Panic {
 // Sprint 233 Block EQ: XOR-AND XOR to OR — (x^y)^(x&y) → x|y (T1064-T1069)
 fn compiler_main_test_eq_xor_and_xor_or_basic() -> bool with Mut, Div, Panic {
     // r2=r0^r1, r3=r0&r1, r4=r2^r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20090,7 +20090,7 @@ fn compiler_main_test_eq_xor_and_xor_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eq_xor_and_xor_or_comm() -> bool with Mut, Div, Panic {
     // (x&y)^(x^y) → x|y (commutative outer XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 3, BinaryOp::OpBitXor, 2)
@@ -20104,7 +20104,7 @@ fn compiler_main_test_eq_xor_and_xor_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eq_xor_and_xor_or_inner_comm() -> bool with Mut, Div, Panic {
     // (x^y)^(y&x) → x|y (inner AND commutative)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20116,7 +20116,7 @@ fn compiler_main_test_eq_xor_and_xor_or_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_eq_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // (r0^r1)^(r0&r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -20129,7 +20129,7 @@ fn compiler_main_test_eq_no_fold_diff_var() -> bool with Mut, Div, Panic {
 fn compiler_main_test_eq_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (x^y)^(x|y): inner is OR not AND → no EQ fold
     // Block DA fires: (x|y)^(x&y)→x^y, but here inner is OR not AND
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20143,7 +20143,7 @@ fn compiler_main_test_eq_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eq_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (x^y)&(x&y): outer is AND not XOR → no EQ fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20157,7 +20157,7 @@ fn compiler_main_test_eq_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 232 Block EP: Sub-swap double — (x-y)-(y-x) → (x-y)+(x-y) (T1058-T1063)
 fn compiler_main_test_ep_sub_swap_double_basic() -> bool with Mut, Div, Panic {
     // r2=r0-r1, r3=r1-r0, r4=r2-r3 → r4 becomes r2+r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -20171,7 +20171,7 @@ fn compiler_main_test_ep_sub_swap_double_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ep_sub_swap_double_uses_s1() -> bool with Mut, Div, Panic {
     // Verify result uses s1 (x-y register) for the doubled add
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -20185,7 +20185,7 @@ fn compiler_main_test_ep_sub_swap_double_uses_s1() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_ep_sub_swap_double_same_sub() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r1): same register → x^x fold happens first (0)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20197,7 +20197,7 @@ fn compiler_main_test_ep_sub_swap_double_same_sub() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_ep_no_fold_not_swap() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r2): rhs differ → no EP fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -20209,7 +20209,7 @@ fn compiler_main_test_ep_no_fold_not_swap() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ep_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r1-r0): outer is ADD not SUB → no EP fold (EO handles this)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpSub, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20224,7 +20224,7 @@ fn compiler_main_test_ep_no_fold_add_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ep_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0+r1): s2 is ADD not SUB → no EP fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -20238,7 +20238,7 @@ fn compiler_main_test_ep_no_fold_one_not_sub() -> bool with Mut, Div, Panic {
 // Sprint 231 Block EO: Add-sub symmetric collapse — (x+y)+(x-y) → x+x (T1052-T1057)
 fn compiler_main_test_eo_add_sub_sym_basic() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0-r1, r4=r2+r3 → r4 becomes r0+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20252,7 +20252,7 @@ fn compiler_main_test_eo_add_sub_sym_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_add_sub_sym_comm_sub() -> bool with Mut, Div, Panic {
     // r2=r0-r1, r3=r0+r1, r4=r2+r3 → (x-y)+(x+y) → r0+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20266,7 +20266,7 @@ fn compiler_main_test_eo_add_sub_sym_comm_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_add_sub_sym_inner_comm() -> bool with Mut, Div, Panic {
     // r2=r1+r0, r3=r0-r1, r4=r2+r3 → (y+x)+(x-y) → r0+r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 1, BinaryOp::OpAdd, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20280,7 +20280,7 @@ fn compiler_main_test_eo_add_sub_sym_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0-r2: subtrahend is r2 not r1 → no EO fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20292,7 +20292,7 @@ fn compiler_main_test_eo_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_no_fold_sub_op() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r0-r1, outer is SUB not ADD → no EO fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 3)
@@ -20305,7 +20305,7 @@ fn compiler_main_test_eo_no_fold_sub_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eo_no_fold_diff_x() -> bool with Mut, Div, Panic {
     // r2=r0+r1, r3=r2-r1: x differs → no EO fold (x+y)+(x'-y) can't simplify to 2x
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 3)
@@ -20318,7 +20318,7 @@ fn compiler_main_test_eo_no_fold_diff_x() -> bool with Mut, Div, Panic {
 // Sprint 230 Block EN: Double-complement XOR — ~x^~y → x^y (T1046-T1051)
 fn compiler_main_test_en_dbl_comp_xor_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r1, r4=r2^r3 → r4 becomes r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20332,7 +20332,7 @@ fn compiler_main_test_en_dbl_comp_xor_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_dbl_comp_xor_same() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r0, r4=r2^r3 → r4 becomes r0^r0 = 0 (via const fold)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20346,7 +20346,7 @@ fn compiler_main_test_en_dbl_comp_xor_same() -> bool with Mut, Div, Panic {
 fn compiler_main_test_en_dbl_comp_xor_chain() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r1, r4=r2^r3 → xor-rr valid for downstream use
     // e.g. Block EK: r4|(r0^r1) → r4|(r0^r1) is just OR since r4=r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20362,7 +20362,7 @@ fn compiler_main_test_en_dbl_comp_xor_chain() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_no_fold_one_not() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2^r1: only one operand is NOT → no EN fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitXor, 1)
     let func = cp_make_test_func(instrs, 2)
@@ -20374,7 +20374,7 @@ fn compiler_main_test_en_no_fold_one_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_no_fold_and_op() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=~r1, r4=r2&r3: AND not XOR → no EN fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20388,7 +20388,7 @@ fn compiler_main_test_en_no_fold_and_op() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_en_no_fold_neg_op() -> bool with Mut, Div, Panic {
     // r2=neg(r0), r3=neg(r1), r4=r2^r3: neg not NOT → no EN fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNeg, 0)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNeg, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -20403,7 +20403,7 @@ fn compiler_main_test_en_no_fold_neg_op() -> bool with Mut, Div, Panic {
 // Sprint 229 Block EM: Complement-OR AND — (~x|y)&(x|y) → y (T1040-T1045)
 fn compiler_main_test_em_comp_or_and_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2|r1, r4=r0|r1, r5=r3&r4 → r5 becomes IrCopy(r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20416,7 +20416,7 @@ fn compiler_main_test_em_comp_or_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_comp_or_and_comm() -> bool with Mut, Div, Panic {
     // (x|y)&(~x|y) → y (outer AND comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 1)
@@ -20429,7 +20429,7 @@ fn compiler_main_test_em_comp_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_comp_or_and_lhs_shared() -> bool with Mut, Div, Panic {
     // (y|~x)&(y|x) → y (same lhs y, rhs are ~x and x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 0)
@@ -20442,7 +20442,7 @@ fn compiler_main_test_em_comp_or_and_lhs_shared() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (~x|y)&(x|z): different rhs (y≠z) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(4, 3, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitOr, 2)
@@ -20455,7 +20455,7 @@ fn compiler_main_test_em_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1)&(r2|r1): no NOT involved → no EM fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -20467,7 +20467,7 @@ fn compiler_main_test_em_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_em_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (~x|y) AND (x&y): second is AND not OR → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20481,7 +20481,7 @@ fn compiler_main_test_em_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 228 Block EL: Complement-AND OR — (~x&y)|(x&y) → y (T1034-T1039)
 fn compiler_main_test_el_comp_and_or_basic() -> bool with Mut, Div, Panic {
     // r2=~r0, r3=r2&r1, r4=r0&r1, r5=r3|r4 → r5 becomes IrCopy(r1)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20494,7 +20494,7 @@ fn compiler_main_test_el_comp_and_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_comp_and_or_comm() -> bool with Mut, Div, Panic {
     // (x&y)|(~x&y) → y (s1 has x, s2 has ~x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
@@ -20507,7 +20507,7 @@ fn compiler_main_test_el_comp_and_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_comp_and_or_lhs_shared() -> bool with Mut, Div, Panic {
     // (y&~x)|(y&x) → y (same lhs y, rhs are ~x and x)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 0)
@@ -20520,7 +20520,7 @@ fn compiler_main_test_el_comp_and_or_lhs_shared() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (~x&y)|(x&z): different rhs (y≠z) → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(3, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(4, 3, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitAnd, 2)
@@ -20533,7 +20533,7 @@ fn compiler_main_test_el_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r2&r1): no NOT involved → no EL fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -20545,7 +20545,7 @@ fn compiler_main_test_el_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_el_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (~x&y) OR (x|y): second operand is OR not AND → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_unaryop(2, UnaryOp::OpNot, 0)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20559,7 +20559,7 @@ fn compiler_main_test_el_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 227 Block EK: OR-XOR simplification — x|(x^y) → x|y (T1028-T1033)
 fn compiler_main_test_ek_or_xor_or_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r0|r2 → r3 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20572,7 +20572,7 @@ fn compiler_main_test_ek_or_xor_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_or_xor_or_comm() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r2|r0 → r3 becomes r0|r1 (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 2, BinaryOp::OpBitOr, 0)
     let func = cp_make_test_func(instrs, 2)
@@ -20585,7 +20585,7 @@ fn compiler_main_test_ek_or_xor_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_or_xor_or_rhs() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r1|r2 → r3 becomes r1|r0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20598,7 +20598,7 @@ fn compiler_main_test_ek_or_xor_or_rhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_no_fold_diff_var() -> bool with Mut, Div, Panic {
     // r3=(r0^r1), r4=r2|r3: r2 not in XOR → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
     let func = cp_make_test_func(instrs, 2)
@@ -20609,7 +20609,7 @@ fn compiler_main_test_ek_no_fold_diff_var() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ek_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=r0&r2: AND outer → no EK fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20620,7 +20620,7 @@ fn compiler_main_test_ek_no_fold_and_outer() -> bool with Mut, Div, Panic {
 fn compiler_main_test_ek_no_fold_no_xor() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=r0|r2: s2 is AND-rr not XOR-rr → EK does not fold to r0|r1 as XOR path
     // Block AO fires: a|(a&b)→a. So result becomes IrCopy(r0).
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 2)
     let func = cp_make_test_func(instrs, 2)
@@ -20632,7 +20632,7 @@ fn compiler_main_test_ek_no_fold_no_xor() -> bool with Mut, Div, Panic {
 // Sprint 226 Block EJ: XNOR-OR to AND — ~(x^y)&(x|y) → x&y (T1022-T1027)
 fn compiler_main_test_ej_xnor_or_and_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=~r2, r4=(r0|r1), r5=r3&r4 → r5 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20647,7 +20647,7 @@ fn compiler_main_test_ej_xnor_or_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_xnor_or_and_comm() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0^r1) → r0&r1 (comm outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20662,7 +20662,7 @@ fn compiler_main_test_ej_xnor_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_xnor_or_and_inner_comm() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & (r1|r0) → r0&r1 (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitOr, 0)
@@ -20675,7 +20675,7 @@ fn compiler_main_test_ej_xnor_or_and_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & (r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitOr, 2)
@@ -20688,7 +20688,7 @@ fn compiler_main_test_ej_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0|r1): no NOT → Block DV fires (IrCopy(x^y)), not EJ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20699,7 +20699,7 @@ fn compiler_main_test_ej_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ej_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r0|r1): OR outer → EI-related, not EJ
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20712,7 +20712,7 @@ fn compiler_main_test_ej_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 225 Block EI: XNOR-AND subsumption — ~(x^y)|(x&y) → ~(x^y) (T1016-T1021)
 fn compiler_main_test_ei_xnor_and_subsume_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=~r2, r4=(r0&r1), r5=r3|r4 → r5 becomes IrCopy(r3)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20725,7 +20725,7 @@ fn compiler_main_test_ei_xnor_and_subsume_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_xnor_and_subsume_comm() -> bool with Mut, Div, Panic {
     // (r0&r1) | ~(r0^r1) → IrCopy(~(r0^r1)) (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20738,7 +20738,7 @@ fn compiler_main_test_ei_xnor_and_subsume_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_xnor_and_subsume_inner_comm() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r1&r0) → IrCopy(~(r0^r1)) (inner comm AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 1, BinaryOp::OpBitAnd, 0)
@@ -20751,7 +20751,7 @@ fn compiler_main_test_ei_xnor_and_subsume_inner_comm() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_ei_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r0&r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
     instrs[2 as usize] = ir_binop(5, 0, BinaryOp::OpBitAnd, 2)
@@ -20763,7 +20763,7 @@ fn compiler_main_test_ei_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // ~(r0^r1) & (r0&r1): AND outer → no EI fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 1)
@@ -20775,7 +20775,7 @@ fn compiler_main_test_ei_no_fold_and_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ei_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // ~(r0^r1) | (r0|r1): s2=OR not AND → no EI fold (EG may fire instead)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_unaryop(3, UnaryOp::OpNot, 2)
     instrs[2 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 1)
@@ -20791,7 +20791,7 @@ fn compiler_main_test_ei_no_fold_or_inner() -> bool with Mut, Div, Panic {
 // Sprint 224 Block EH: XOR-NOR annihilation — (x^y)&~(x|y) → 0 (T1010-T1015)
 fn compiler_main_test_eh_xor_nor_zero_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=(r0|r1), r4=~r3, r5=r2&r4 → r5 becomes 0
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20804,7 +20804,7 @@ fn compiler_main_test_eh_xor_nor_zero_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_xor_nor_zero_comm() -> bool with Mut, Div, Panic {
     // ~(r0|r1) & (r0^r1) → 0 (comm outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20817,7 +20817,7 @@ fn compiler_main_test_eh_xor_nor_zero_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_xor_nor_zero_inner_comm() -> bool with Mut, Div, Panic {
     // (r0^r1) & ~(r1|r0) → 0 (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20830,7 +20830,7 @@ fn compiler_main_test_eh_xor_nor_zero_inner_comm() -> bool with Mut, Div, Panic 
 
 fn compiler_main_test_eh_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1) & ~(r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_unaryop(5, UnaryOp::OpNot, 4)
@@ -20842,7 +20842,7 @@ fn compiler_main_test_eh_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0^r1) & (r0|r1): no NOT → no EH fold (Block DV fires: IrCopy(x^y))
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20854,7 +20854,7 @@ fn compiler_main_test_eh_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eh_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0^r1) | ~(r0|r1): OR outer → no EH fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -20867,7 +20867,7 @@ fn compiler_main_test_eh_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 223 Block EG: AND-OR superset absorption — (x&y)&(x|y) → x&y (T1004-T1009)
 fn compiler_main_test_eg_and_or_absorb_basic() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r0|r1), r4=r2&r3 → r4 becomes IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20879,7 +20879,7 @@ fn compiler_main_test_eg_and_or_absorb_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_and_or_absorb_comm() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0&r1), r4=r2&r3 → r4 becomes IrCopy(r3) (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20891,7 +20891,7 @@ fn compiler_main_test_eg_and_or_absorb_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_and_or_absorb_inner_comm() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r1|r0), r4=r2&r3 → r4 becomes IrCopy(r2) (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20903,7 +20903,7 @@ fn compiler_main_test_eg_and_or_absorb_inner_comm() -> bool with Mut, Div, Panic
 
 fn compiler_main_test_eg_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0&r1)&(r0|r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -20914,7 +20914,7 @@ fn compiler_main_test_eg_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0&r1)|(r0|r1): OR outer → Block EF fires, not EG
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20926,7 +20926,7 @@ fn compiler_main_test_eg_no_fold_or_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eg_no_fold_and_both() -> bool with Mut, Div, Panic {
     // (r0&r1)&(r0&r2): both AND, no OR superset → no EG fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitAnd, 4)
@@ -20938,7 +20938,7 @@ fn compiler_main_test_eg_no_fold_and_both() -> bool with Mut, Div, Panic {
 // Sprint 222 Block EF: OR-AND subsumption — (x|y)|(x&y) → x|y (T998-T1003)
 fn compiler_main_test_ef_or_and_subsume_basic() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0&r1), r4=r2|r3 → r4 becomes IrCopy(r2)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20950,7 +20950,7 @@ fn compiler_main_test_ef_or_and_subsume_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_or_and_subsume_comm() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r0|r1), r4=r2|r3 → r4 becomes IrCopy(r3) (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20962,7 +20962,7 @@ fn compiler_main_test_ef_or_and_subsume_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_or_and_subsume_inner_comm() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r1&r0), r4=r2|r3 → r4 becomes IrCopy(r2) (inner comm AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -20974,7 +20974,7 @@ fn compiler_main_test_ef_or_and_subsume_inner_comm() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ef_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0&r2): different vars → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -20985,7 +20985,7 @@ fn compiler_main_test_ef_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0|r1)&(r0&r1): AND outer not OR → no EF fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -20996,7 +20996,7 @@ fn compiler_main_test_ef_no_fold_and_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ef_no_fold_or_both() -> bool with Mut, Div, Panic {
     // (r0|r1)|(r0|r2): both OR, not AND+OR → no EF fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitOr, 4)
@@ -21008,7 +21008,7 @@ fn compiler_main_test_ef_no_fold_or_both() -> bool with Mut, Div, Panic {
 // Sprint 221 Block EE: Sub-add collapse — (x-y)+(z+y) → x+z (T992-T997)
 fn compiler_main_test_ee_sub_add_collapse_basic() -> bool with Mut, Div, Panic {
     // r3=(r0-r1), r4=(r2+r1), r5=r3+r4 → r5 becomes r0+r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21022,7 +21022,7 @@ fn compiler_main_test_ee_sub_add_collapse_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ee_sub_add_collapse_comm_add() -> bool with Mut, Div, Panic {
     // r3=(r0-r1), r4=(r1+r2), r5=r3+r4 → r5 becomes r0+r2 (y+z form)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpAdd, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21036,7 +21036,7 @@ fn compiler_main_test_ee_sub_add_collapse_comm_add() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_ee_sub_add_collapse_comm_outer() -> bool with Mut, Div, Panic {
     // r3=(r2+r1), r4=(r0-r1), r5=r3+r4 → r5 becomes r0+r2 (comm outer)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 2, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21050,7 +21050,7 @@ fn compiler_main_test_ee_sub_add_collapse_comm_outer() -> bool with Mut, Div, Pa
 
 fn compiler_main_test_ee_no_fold_diff_y() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r2+r3): r3 ≠ r1 → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(5, 2, BinaryOp::OpAdd, 3)
     instrs[2 as usize] = ir_binop(6, 4, BinaryOp::OpAdd, 5)
@@ -21062,7 +21062,7 @@ fn compiler_main_test_ee_no_fold_diff_y() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ee_no_fold_sub_outer() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r2+r1): SUB outer, not ADD → no EE fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpAdd, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21073,7 +21073,7 @@ fn compiler_main_test_ee_no_fold_sub_outer() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ee_no_fold_no_add() -> bool with Mut, Div, Panic {
     // (r0-r1)+(r2-r1): both are subs → EC might fire, not EE
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21086,7 +21086,7 @@ fn compiler_main_test_ee_no_fold_no_add() -> bool with Mut, Div, Panic {
 // Sprint 220 Block ED: Add-sub expand — (x+y)-(x-z) → y+z (T986-T991)
 fn compiler_main_test_ed_add_sub_expand_basic() -> bool with Mut, Div, Panic {
     // r3=(r0+r1), r4=(r0-r2), r5=r3-r4 → r5 becomes r1+r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21100,7 +21100,7 @@ fn compiler_main_test_ed_add_sub_expand_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_add_sub_expand_comm() -> bool with Mut, Div, Panic {
     // r3=(r1+r0), r4=(r0-r2), r5=r3-r4 → r5 becomes r1+r2 (comm add)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 1, BinaryOp::OpAdd, 0)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21114,7 +21114,7 @@ fn compiler_main_test_ed_add_sub_expand_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_add_sub_expand_vals() -> bool with Mut, Div, Panic {
     // (r0+r2)-(r0-r1) → r2+r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21128,7 +21128,7 @@ fn compiler_main_test_ed_add_sub_expand_vals() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
     // (r0+r1)-(r2-r3): no shared var → no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(4, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(5, 2, BinaryOp::OpSub, 3)
     instrs[2 as usize] = ir_binop(6, 4, BinaryOp::OpSub, 5)
@@ -21140,7 +21140,7 @@ fn compiler_main_test_ed_no_fold_diff_lhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_no_fold_sub_s1() -> bool with Mut, Div, Panic {
     // s1 is SUB not ADD: (r0-r1)-(r0-r2) → Block DN fires, not ED
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21152,7 +21152,7 @@ fn compiler_main_test_ed_no_fold_sub_s1() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ed_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0+r1)+(r0-r2) → no fold (ADD outer not SUB)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21165,7 +21165,7 @@ fn compiler_main_test_ed_no_fold_add_outer() -> bool with Mut, Div, Panic {
 // Sprint 219 Block EC: Sub same-RHS cancel — (x-y)-(z-y) → x-z (T980-T985)
 fn compiler_main_test_ec_sub_same_rhs_basic() -> bool with Mut, Div, Panic {
     // r3=(r0-r2), r4=(r1-r2), r5=r3-r4 → r5 becomes r0-r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21179,7 +21179,7 @@ fn compiler_main_test_ec_sub_same_rhs_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_sub_same_rhs_chain() -> bool with Mut, Div, Panic {
     // r3=(r0-r1), r4=(r2-r1), r5=r3-r4 → r5 becomes r0-r2
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 2, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21194,7 +21194,7 @@ fn compiler_main_test_ec_sub_same_rhs_chain() -> bool with Mut, Div, Panic {
 fn compiler_main_test_ec_sub_same_rhs_self_zero() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r1) → IrCopy(0) or IrLoadImm(0) via x-x→0 (Block A after EC)
     // EC only fires when x != z, so same sub: r3=r0-r1, r4=r0-r1 → x==z, no fold by EC
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 1)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21207,7 +21207,7 @@ fn compiler_main_test_ec_sub_same_rhs_self_zero() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_no_fold_diff_rhs() -> bool with Mut, Div, Panic {
     // (r0-r1)-(r0-r2) → Block DN fires (same lhs), not EC
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21220,7 +21220,7 @@ fn compiler_main_test_ec_no_fold_diff_rhs() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_no_fold_not_sub() -> bool with Mut, Div, Panic {
     // r3=(r0+r2), r4=(r1-r2): s1 is ADD not SUB, no fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpAdd, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpSub, 4)
@@ -21232,7 +21232,7 @@ fn compiler_main_test_ec_no_fold_not_sub() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ec_no_fold_add_outer() -> bool with Mut, Div, Panic {
     // (r0-r2)+(r1-r2) → Block DK territory if OR/AND; here ADD outer: no EC fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpSub, 2)
     instrs[1 as usize] = ir_binop(4, 1, BinaryOp::OpSub, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpAdd, 4)
@@ -21244,7 +21244,7 @@ fn compiler_main_test_ec_no_fold_add_outer() -> bool with Mut, Div, Panic {
 // Sprint 218 Block EB: AND-XOR to OR — (x&y) ^ (x^y) → x|y (T974-T979)
 fn compiler_main_test_eb_and_xor_or_basic() -> bool with Mut, Div, Panic {
     // r2=(r0&r1), r3=(r0^r1), r4=r2^r3 → r4 becomes r0|r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21256,7 +21256,7 @@ fn compiler_main_test_eb_and_xor_or_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_and_xor_or_comm() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=(r0&r1), r4=r2^r3 → r4 becomes r0|r1 (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21268,7 +21268,7 @@ fn compiler_main_test_eb_and_xor_or_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_and_xor_or_inner_comm() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r1^r0) → r0|r1 (inner comm XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitXor, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21280,7 +21280,7 @@ fn compiler_main_test_eb_and_xor_or_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0^r2) → no fold (different vars)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitXor, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -21291,7 +21291,7 @@ fn compiler_main_test_eb_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_no_fold_or_inner() -> bool with Mut, Div, Panic {
     // (r0&r1) ^ (r0|r1): EB requires XOR-rr as inner, OR-rr does not match → no EB fold
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21303,7 +21303,7 @@ fn compiler_main_test_eb_no_fold_or_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_eb_no_fold_and_outer() -> bool with Mut, Div, Panic {
     // (r0&r1) & (r0^r1) → no fold (AND outer not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -21315,7 +21315,7 @@ fn compiler_main_test_eb_no_fold_and_outer() -> bool with Mut, Div, Panic {
 // Sprint 217 Block EA: XOR-OR to AND — (x^y) ^ (x|y) → x&y (T968-T973)
 fn compiler_main_test_ea_xor_or_and_basic() -> bool with Mut, Div, Panic {
     // r2=(r0^r1), r3=(r0|r1), r4=r2^r3 → r4 becomes r0&r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21327,7 +21327,7 @@ fn compiler_main_test_ea_xor_or_and_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_xor_or_and_comm() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0^r1), r4=r2^r3 → r4 becomes r0&r1 (comm)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21339,7 +21339,7 @@ fn compiler_main_test_ea_xor_or_and_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_xor_or_and_inner_comm() -> bool with Mut, Div, Panic {
     // (r0^r1) ^ (r1|r0) → r0&r1 (inner comm OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitOr, 0)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21351,7 +21351,7 @@ fn compiler_main_test_ea_xor_or_and_inner_comm() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0^r1) ^ (r0|r2) → no fold (different vars)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitOr, 2)
     instrs[2 as usize] = ir_binop(5, 3, BinaryOp::OpBitXor, 4)
@@ -21362,7 +21362,7 @@ fn compiler_main_test_ea_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_no_fold_and_inner() -> bool with Mut, Div, Panic {
     // (r0^r1) ^ (r0&r1) → no fold (AND not OR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitXor, 3)
@@ -21373,7 +21373,7 @@ fn compiler_main_test_ea_no_fold_and_inner() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_ea_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0^r1) | (r0|r1) → no fold (OR outer not XOR)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitXor, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitOr, 3)
@@ -21385,7 +21385,7 @@ fn compiler_main_test_ea_no_fold_or_outer() -> bool with Mut, Div, Panic {
 // Sprint 216 Block DZ: OR-AND-NOT to XOR — (x|y) & ~(x&y) → x^y (T962-T967)
 fn compiler_main_test_dz_or_and_not_xor_basic() -> bool with Mut, Div, Panic {
     // r2=(r0|r1), r3=(r0&r1), r4=~r3, r5=r2&r4 → r5 becomes r0^r1
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -21398,7 +21398,7 @@ fn compiler_main_test_dz_or_and_not_xor_basic() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dz_or_and_not_xor_comm_outer() -> bool with Mut, Div, Panic {
     // ~(r0&r1) & (r0|r1) → r0^r1 (commutative outer AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -21411,7 +21411,7 @@ fn compiler_main_test_dz_or_and_not_xor_comm_outer() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_dz_or_and_not_xor_comm_inner() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r1&r0) → r0^r1 (commutative inner AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 1, BinaryOp::OpBitAnd, 0)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)
@@ -21424,7 +21424,7 @@ fn compiler_main_test_dz_or_and_not_xor_comm_inner() -> bool with Mut, Div, Pani
 
 fn compiler_main_test_dz_no_fold_diff_vars() -> bool with Mut, Div, Panic {
     // (r0|r1) & ~(r0&r2) → no fold (different vars in AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(3, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(4, 0, BinaryOp::OpBitAnd, 2)
     instrs[2 as usize] = ir_unaryop(5, UnaryOp::OpNot, 4)
@@ -21436,7 +21436,7 @@ fn compiler_main_test_dz_no_fold_diff_vars() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dz_no_fold_no_not() -> bool with Mut, Div, Panic {
     // (r0|r1) & (r0&r1) → no fold (no NOT)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_binop(4, 2, BinaryOp::OpBitAnd, 3)
@@ -21447,7 +21447,7 @@ fn compiler_main_test_dz_no_fold_no_not() -> bool with Mut, Div, Panic {
 
 fn compiler_main_test_dz_no_fold_or_outer() -> bool with Mut, Div, Panic {
     // (r0|r1) | ~(r0&r1) → no fold (OR outer, not AND)
-    var instrs: [IrInstr; 512] = cp_empty_instrs()
+    var instrs: [IrInstr; 1024] = cp_empty_instrs()
     instrs[0 as usize] = ir_binop(2, 0, BinaryOp::OpBitOr, 1)
     instrs[1 as usize] = ir_binop(3, 0, BinaryOp::OpBitAnd, 1)
     instrs[2 as usize] = ir_unaryop(4, UnaryOp::OpNot, 3)

--- a/self-hosted/ir/const_prop.sio
+++ b/self-hosted/ir/const_prop.sio
@@ -1670,7 +1670,7 @@ fn cp_optimize_function(func: IrFunction) -> IrFunction with Mut, Div, Panic {
 // ============================================================================
 
 // Build a test IrFunction from an instruction array and count.
-fn cp_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
+fn cp_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         instrs: instrs,
@@ -1691,8 +1691,8 @@ fn cp_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
 }
 
 // Build an empty instruction array filled with NOPs.
-fn cp_empty_instrs() -> [IrInstr; 512] {
-    [ir_nop(); 512]
+fn cp_empty_instrs() -> [IrInstr; 1024] {
+    [ir_nop(); 1024]
 }
 
 // Check if instruction at position is a specific opcode.

--- a/self-hosted/ir/dce.sio
+++ b/self-hosted/ir/dce.sio
@@ -879,7 +879,7 @@ fn dce_optimize_function(func: IrFunction) -> IrFunction with Mut, Panic, Div {
 // ============================================================================
 
 // Build a test IrFunction from an instruction array and count.
-fn dce_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
+fn dce_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         instrs: instrs,
@@ -919,8 +919,8 @@ fn dce_check_not_nop(func: &IrFunction, pos: i64) -> bool with Div, Panic {
 }
 
 // Build an empty 8192-element instruction array filled with NOPs.
-fn dce_empty_instrs() -> [IrInstr; 512] {
-    [ir_nop(); 512]
+fn dce_empty_instrs() -> [IrInstr; 1024] {
+    [ir_nop(); 1024]
 }
 
 // Make a phi instruction with specified inputs stored in src1/src2.

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -10,7 +10,7 @@ use check::types::{TypeEntry, empty_type_entry}
 // the lowering path can use the capacity that is already physically allocated.
 pub let IR_MAX_FUNCS: i64 = 2048
 pub let IR_MAX_STRINGS: i64 = 4096
-pub let IR_MAX_INSTRS: i64 = 512
+pub let IR_MAX_INSTRS: i64 = 1024
 pub let IR_MAX_PARAMS: i64 = 64
 pub let IR_INVALID_REG: i64 = -1
 pub let IR_INVALID_LABEL: i64 = -1
@@ -704,7 +704,7 @@ pub fn ir_strategy_name(s: i64) -> string {
 
 pub struct IrFunction {
     pub name: Name,
-    pub instrs: [IrInstr; 512],
+    pub instrs: [IrInstr; 1024],
     pub instr_count: i64,
     pub reg_count: i64,
     pub label_count: i64,
@@ -3471,7 +3471,7 @@ fn ir_phi(dst: i64) -> IrInstr {
 pub fn ir_empty_function() -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
-        instrs: [ir_nop(); 512],
+        instrs: [ir_nop(); 1024],
         instr_count: 0,
         reg_count: 0,
         label_count: 0,

--- a/self-hosted/ir/loop_opt.sio
+++ b/self-hosted/ir/loop_opt.sio
@@ -4137,7 +4137,7 @@ fn lopt_ir_count_assigned(assigned: [i64; 128]) -> i64 {
 
 fn lopt_ir_rewrite_function(func: IrFunction, cfg: &LoptIrCfg, assigned: [i64; 128]) -> IrFunction with Mut, Panic, Div {
     var result = func
-    var out_instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var out_instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     var out_count: i64 = 0
 
     var b: i64 = 0

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2018,6 +2018,20 @@ fn lower_cast_type_is_f64(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, D
     }
 }
 
+fn lower_cast_type_is_i64(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *ct {
+        Some(te) => {
+            let seg = (*te).path.segments
+            if seg.head_len != 3 { return false }
+            if seg.head_buf[0] as i64 != 105 { return false }   // 'i'
+            if seg.head_buf[1] as i64 != 54 { return false }    // '6'
+            if seg.head_buf[2] as i64 != 52 { return false }    // '4'
+            true
+        }
+        None => false,
+    }
+}
+
 fn lower_type_expr_is_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
     if (*te).kind != TypeExprKind::TypeNamed { return false }
     let seg = (*te).path.segments
@@ -3596,18 +3610,11 @@ impl Lowerer {
     fn println_dispatch_name(self, args: &Option<Box<ExprList>>) -> Name with Mut, Panic, Div, Alloc {
         match *args {
             Some(list) => {
-                let hk = (*list).head.kind
-                if hk == ExprKind::ExprIntLit {
+                let sk = self.expr_result_scalar_kind_ref(&(*list).head)
+                if sk == 1 {
                     make_name("print_int")
-                } else if self.expr_result_is_float_ref(&(*list).head) {
+                } else if sk == 2 {
                     make_name("print_f64")
-                } else if hk == ExprKind::ExprIdent {
-                    let sk = self.lookup_local_scalar_kind((*list).head.name)
-                    if sk == 1 {
-                        make_name("print_int")
-                    } else {
-                        make_name("print")
-                    }
                 } else {
                     make_name("print")
                 }
@@ -4239,6 +4246,38 @@ impl Lowerer {
             return self.opt_expr_result_is_float_ref(&(*e).left) || self.opt_expr_result_is_float_ref(&(*e).right)
         }
         false
+    }
+
+    fn expr_result_scalar_kind_ref(self, e: &Expr) -> i64 with Mut, Panic, Div, Alloc {
+        if (*e).kind == ExprKind::ExprIntLit {
+            return 1
+        }
+        if (*e).kind == ExprKind::ExprFloatLit {
+            return 2
+        }
+        if (*e).kind == ExprKind::ExprStringLit {
+            return 3
+        }
+        if (*e).kind == ExprKind::ExprIdent {
+            return self.lookup_local_scalar_kind((*e).name)
+        }
+        if (*e).kind == ExprKind::ExprCast {
+            if lower_cast_type_is_f64(&(*e).cast_type) { return 2 }
+            if lower_cast_type_is_i64(&(*e).cast_type) { return 1 }
+            return 0
+        }
+        if (*e).kind == ExprKind::ExprBinary {
+            if lower_binary_op_is_compare((*e).bin_op) {
+                return 1
+            }
+            if self.expr_result_is_float_ref(e) {
+                return 2
+            }
+        }
+        if self.expr_result_is_float_ref(e) {
+            return 2
+        }
+        0
     }
 
     fn ensure_struct_literal_layout_ref(self, type_name: Name, fields: &Option<Box<StructFieldList>>) -> Lowerer with Mut, Panic, Div, Alloc {
@@ -7169,7 +7208,10 @@ impl Lowerer {
             // Redirect bare print(<int literal>) to the print_int builtin: print
             // (=print_str) treats its argument as a char* and would deref the integer
             // value as a pointer. Explicit print_int / print_char are left untouched.
-            let print_builtin_name = if name_eq(callee_name, make_name("print")) && lower_call_first_arg_is_int_literal(&e.args) { make_name("print_int") } else { callee_name }
+            var print_builtin_name = callee_name
+            if name_eq(callee_name, make_name("print")) {
+                print_builtin_name = self.println_dispatch_name(&e.args)
+            }
             var lo_builtin = self
             let fn_id_builtin = lowerer_find_or_add_fn_id_mut(&! lo_builtin, print_builtin_name)
             let pair_args_builtin: LowerExprArgsResult = lo_builtin.lower_expr_args_ref(&e.args)

--- a/self-hosted/ir/opt_strategy.sio
+++ b/self-hosted/ir/opt_strategy.sio
@@ -126,7 +126,7 @@ pub fn ir_opt_clone_instr(
 // Mutating in place avoids copying the entire fixed-size instruction buffer
 // on every append during the dual-path rewrite.
 pub fn ir_opt_append(
-    instrs: &! [IrInstr; 512],
+    instrs: &! [IrInstr; 1024],
     count: i64,
     instr: IrInstr
 ) -> i64 with Mut, Panic {
@@ -138,7 +138,7 @@ pub fn ir_opt_append(
 
 pub fn ir_opt_apply_strategy_instrs_into(
     func: &IrFunction,
-    instrs: &! [IrInstr; 512],
+    instrs: &! [IrInstr; 1024],
     vreg_offset: i64,
     label_offset: i64,
     count: i64,

--- a/self-hosted/ir/optimize.sio
+++ b/self-hosted/ir/optimize.sio
@@ -605,7 +605,7 @@ fn opt_check_load_imm(func: IrFunction, pos: i64, expected_val: i64) -> bool {
 }
 
 // Build a test function with given instruction count.
-fn opt_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
+fn opt_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         instrs: instrs,
@@ -630,7 +630,7 @@ fn opt_make_test_func(instrs: [IrInstr; 512], count: i64) -> IrFunction {
 
 // T01: Constant folding of addition (3 + 5 = 8)
 fn test_const_fold_add() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 3)
     instrs[1] = ir_load_imm(1, 5)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -645,7 +645,7 @@ fn test_const_fold_add() -> bool with Mut, Panic, Div {
 
 // T02: Constant folding of multiplication (7 * 6 = 42)
 fn test_const_fold_mul() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 7)
     instrs[1] = ir_load_imm(1, 6)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)
@@ -659,7 +659,7 @@ fn test_const_fold_mul() -> bool with Mut, Panic, Div {
 
 // T03: Constant folding of subtraction (10 - 3 = 7)
 fn test_const_fold_sub() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 10)
     instrs[1] = ir_load_imm(1, 3)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpSub, 1)
@@ -673,7 +673,7 @@ fn test_const_fold_sub() -> bool with Mut, Panic, Div {
 
 // T04: Constant folding of comparison (5 == 5 -> 1)
 fn test_const_fold_eq() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 5)
     instrs[1] = ir_load_imm(1, 5)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpEq, 1)
@@ -687,7 +687,7 @@ fn test_const_fold_eq() -> bool with Mut, Panic, Div {
 
 // T05: Constant folding of unary negation (neg 42 = -42)
 fn test_const_fold_neg() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 42)
     instrs[1] = ir_unaryop(1, UnaryOp::OpNeg, 0)
     instrs[2] = ir_return(1)
@@ -701,7 +701,7 @@ fn test_const_fold_neg() -> bool with Mut, Panic, Div {
 
 // T06: Constant folding does not fold division by zero
 fn test_const_fold_div_by_zero() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 10)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpDiv, 1)
@@ -716,7 +716,7 @@ fn test_const_fold_div_by_zero() -> bool with Mut, Panic, Div {
 
 // T07: DCE removes a dead instruction
 fn test_dce_removes_dead_instr() -> bool with Mut, Panic, Div, Alloc {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 100)   // used by return
     instrs[1] = ir_load_imm(1, 200)   // dead: r1 never used
     instrs[2] = ir_return(0)
@@ -733,7 +733,7 @@ fn test_dce_removes_dead_instr() -> bool with Mut, Panic, Div, Alloc {
 
 // T08: DCE does not remove instructions with side effects
 fn test_dce_keeps_side_effects() -> bool with Mut, Panic, Div, Alloc {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     // A call whose return value is unused should NOT be eliminated
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
@@ -748,7 +748,7 @@ fn test_dce_keeps_side_effects() -> bool with Mut, Panic, Div, Alloc {
 
 // T09: Strength reduction of x * 2 -> x + x
 fn test_strength_reduce_mul_by_2() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 2)     // const 2
     instrs[1] = ir_load_imm(1, 100)   // this will NOT be recognized as const by SR
                                         // because SR only tracks IrLoadImm
@@ -773,7 +773,7 @@ fn test_strength_reduce_mul_by_2() -> bool with Mut, Panic, Div {
 
 // T10: Strength reduction of x + 0 -> copy x
 fn test_strength_reduce_add_zero() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -792,7 +792,7 @@ fn test_strength_reduce_add_zero() -> bool with Mut, Panic, Div {
 
 // T11: Strength reduction of x * 1 -> copy x
 fn test_strength_reduce_mul_by_1() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 1)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)
@@ -810,7 +810,7 @@ fn test_strength_reduce_mul_by_1() -> bool with Mut, Panic, Div {
 
 // T12: Strength reduction of x * 0 -> load 0
 fn test_strength_reduce_mul_by_0() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)
@@ -824,7 +824,7 @@ fn test_strength_reduce_mul_by_0() -> bool with Mut, Panic, Div {
 
 // T13: Strength reduction of x / 1 -> copy x
 fn test_strength_reduce_div_by_1() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 1)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpDiv, 1)
@@ -842,7 +842,7 @@ fn test_strength_reduce_div_by_1() -> bool with Mut, Panic, Div {
 
 // T14: Strength reduction of x - 0 -> copy x
 fn test_strength_reduce_sub_zero() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_call(0, 0, ir_empty_name(), ir_empty_reg_list(), 0)
     instrs[1] = ir_load_imm(1, 0)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpSub, 1)
@@ -862,7 +862,7 @@ fn test_strength_reduce_sub_zero() -> bool with Mut, Panic, Div {
 fn test_pipeline_combined() -> bool with Mut, Panic, Div, Alloc {
     // Build: r0 = 3, r1 = 5, r2 = r0 + r1 (folds to 8),
     //        r3 = 100 (dead), return r2
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 3)
     instrs[1] = ir_load_imm(1, 5)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
@@ -887,7 +887,7 @@ fn test_pipeline_combined() -> bool with Mut, Panic, Div, Alloc {
 
 // T16: Constant folding through copy propagation
 fn test_const_fold_through_copy() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 10)
     instrs[1] = ir_copy(1, 0)           // r1 = r0 = 10
     instrs[2] = ir_load_imm(2, 20)
@@ -902,7 +902,7 @@ fn test_const_fold_through_copy() -> bool with Mut, Panic, Div {
 
 // T17: Constant folding of chained operations
 fn test_const_fold_chain() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 2)
     instrs[1] = ir_load_imm(1, 3)
     instrs[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)  // r2 = 2 * 3 = 6
@@ -920,7 +920,7 @@ fn test_const_fold_chain() -> bool with Mut, Panic, Div {
 
 // T18: Constant folding with bitwise AND
 fn test_const_fold_bitwise_and() -> bool with Mut, Panic, Div {
-    var instrs: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs[0] = ir_load_imm(0, 255)     // 0xFF
     instrs[1] = ir_load_imm(1, 15)      // 0x0F
     instrs[2] = ir_binop(2, 0, BinaryOp::OpBitAnd, 1)
@@ -934,13 +934,13 @@ fn test_const_fold_bitwise_and() -> bool with Mut, Panic, Div {
 
 // T19: Module-level optimization applies to all functions
 fn test_optimize_module_all_funcs() -> bool with Mut, Panic, Div, Alloc {
-    var instrs_a: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs_a: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs_a[0] = ir_load_imm(0, 10)
     instrs_a[1] = ir_load_imm(1, 20)
     instrs_a[2] = ir_binop(2, 0, BinaryOp::OpAdd, 1)
     instrs_a[3] = ir_return(2)
 
-    var instrs_b: [IrInstr; 512] = [ir_nop(); 512]
+    var instrs_b: [IrInstr; 1024] = [ir_nop(); 1024]
     instrs_b[0] = ir_load_imm(0, 3)
     instrs_b[1] = ir_load_imm(1, 7)
     instrs_b[2] = ir_binop(2, 0, BinaryOp::OpMul, 1)

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -2870,7 +2870,7 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
     var c = nc
 
     // Store 1e6 constant in .rodata
-    c.rodata = data_section_add_f64(c.rodata, 0x4124680000000000)
+    c.rodata = data_section_add_f64(c.rodata, 0x412E848000000000)
     let rodata_1e6_offset = c.rodata.last_offset
 
     c.code = emit_push_rbp(c.code)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -3623,10 +3623,13 @@ fn emit_builtin_str_concat(nc: NativeCompiler) -> NativeCompiler with Mut, Panic
 
 fn native_v2_persist_builtin_emit_into(nc: &! NativeCompiler, updated: NativeCompiler) with Mut, Panic, Div {
     (*nc).code = updated.code
+    (*nc).rodata = updated.rodata
     var ri = 0
     while ri < updated.relocs.count && ri < 4096 {
         let entry = updated.relocs.entries[ri as usize]
-        if entry.kind.kind_code == 3 {
+        if entry.kind.kind_code == 2 {
+            nc_add_rodata_reloc(nc, entry.offset, entry.target.target_index)
+        } else if entry.kind.kind_code == 3 {
             nc_add_data_section_reloc(nc, entry.offset, entry.target.target_index)
         }
         ri = ri + 1
@@ -4274,7 +4277,7 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
     var c = nc
 
     // Store 1e6 constant in .rodata
-    c.rodata = data_section_add_f64(c.rodata, 0x4124680000000000)
+    c.rodata = data_section_add_f64(c.rodata, 0x412E848000000000)
     let rodata_1e6_offset = c.rodata.last_offset
 
     c.code = emit_push_rbp(c.code)
@@ -4576,6 +4579,15 @@ fn native_v2_reloc_is_call_patch(nc: &NativeCompiler, patch_offset: i64) -> bool
 
 fn native_v2_reloc_is_rip_disp_patch(nc: &NativeCompiler, patch_offset: i64) -> bool with Panic, Div {
     if !(patch_offset >= 3 && patch_offset + 4 <= (*nc).code.len) { return false }
+    if patch_offset >= 4
+        && (*nc).code.bytes[(patch_offset - 4) as usize] == (0xf2 as i8)
+        && (*nc).code.bytes[(patch_offset - 3) as usize] == (0x0f as i8)
+        && (*nc).code.bytes[(patch_offset - 2) as usize] == (0x10 as i8) {
+        let sse_modrm = (*nc).code.bytes[(patch_offset - 1) as usize]
+        if sse_modrm == (0x05 as i8) || sse_modrm == (0x0d as i8) {
+            return true
+        }
+    }
     if (*nc).code.bytes[(patch_offset - 3) as usize] != (0x48 as i8) { return false }
     let op = (*nc).code.bytes[(patch_offset - 2) as usize]
     let modrm = (*nc).code.bytes[(patch_offset - 1) as usize]

--- a/self-hosted/native/machine_ir.sio
+++ b/self-hosted/native/machine_ir.sio
@@ -8,7 +8,7 @@ use parser::ast::{Name, BinaryOp, UnaryOp, empty_name}
 use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX}
 
 pub let MIR_MAX_BLOCKS: i64 = 1
-pub let MIR_MAX_INSTRS: i64 = 512
+pub let MIR_MAX_INSTRS: i64 = 1024
 pub let MIR_MAX_CALL_ARGS: i64 = 8
 
 pub let MIR_OPERAND_NONE: i64 = 0
@@ -107,7 +107,7 @@ pub struct MachineInstr {
 }
 
 pub struct MachineBlock {
-    pub instrs: [MachineInstr; 512],
+    pub instrs: [MachineInstr; 1024],
     pub instr_count: i64,
 }
 
@@ -241,7 +241,7 @@ pub fn machine_empty_instr() -> MachineInstr with Mut, Panic, Div {
 
 pub fn machine_block_new() -> MachineBlock with Mut, Panic, Div {
     MachineBlock {
-        instrs: [machine_empty_instr(); 512],
+        instrs: [machine_empty_instr(); 1024],
         instr_count: 0,
     }
 }
@@ -589,7 +589,7 @@ pub fn native_v2_alloc_descriptor_from_tag(tag: i64) -> i64 with Mut, Panic, Div
 // By-value instruction append (avoids JIT &! bug)
 pub fn _emit_legal_byval(func: MachineFunction, instr: MachineInstr) -> MachineFunction with Mut, Panic, Div {
     var f = func
-    if f.blocks[0].instr_count < 512 {
+    if f.blocks[0].instr_count < MIR_MAX_INSTRS {
         var block = f.blocks[0]
         let idx = block.instr_count
         block.instrs[idx as usize] = instr
@@ -602,7 +602,7 @@ pub fn _emit_legal_byval(func: MachineFunction, instr: MachineInstr) -> MachineF
 
 pub fn _add_instr_byval(func: MachineFunction, instr: MachineInstr) -> MachineFunction with Mut, Panic, Div {
     var f = func
-    if f.blocks[0].instr_count < 512 {
+    if f.blocks[0].instr_count < MIR_MAX_INSTRS {
         var block = f.blocks[0]
         let idx = block.instr_count
         block.instrs[idx as usize] = instr


### PR DESCRIPTION
## Summary

Fixes the Madaros `gum-compliance-run` blocker on the default compiler path.

Changes:
- raise fixed IR/MIR instruction capacity from 512 to 1024 to avoid silent truncation of larger lowered functions such as `tests/run-pass/gum_compliance.sio`
- route bare `print(...)`/`println(...)` through scalar-kind dispatch for int/f64 expressions, including casts and float-valued binary expressions
- preserve builtin rodata when persisting emitted builtins and recognize SSE `movsd` RIP-relative rodata relocations
- fix the `print_f64` decimal scaling constant to `1e6`
- refresh `bin/madaros-linux-x86_64` from the rebuilt Madaros binary

## Evidence

Fresh source build:
- `SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/build_modular_madaros.sh /tmp/sounio-gum-madaros-1024`
- result: `Madaros ready: /tmp/sounio-gum-madaros-1024 (103630118 bytes)`

Fresh binary validation:
- `MADAROS_RAW_BIN=/tmp/sounio-gum-madaros-1024 SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/gum_compliance.sio`
- result: exit 0, output contains `All 7 tests match GUM ISO/IEC Guide 98-3`
- `MADAROS_RAW_BIN=/tmp/sounio-gum-madaros-1024 SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/println_f64_literal.sio`
- result: exit 0, output `1.500000`
- `MADAROS_RAW_BIN=/tmp/sounio-gum-madaros-1024 SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/println_f64_var.sio`
- result: exit 0, output `2.250000`
- `SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/sounio-gum-madaros-1024 bash scripts/ci/serious_language_conformance_gate.sh`
- result: `Summary: total=16 passed=16 failed=0`

Default prebuilt validation after refresh:
- prebuilt SHA256: `46f092ba13cdd0c1b582928fee08b23018af317d0590f29580d2e296a5fa887c`
- prebuilt size: `103630118` bytes (`98.83 MiB`; GitHub warned above recommended 50MB, push accepted)
- `SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/gum_compliance.sio`
- result: exit 0, output contains `All 7 tests match GUM ISO/IEC Guide 98-3`
- `SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/println_f64_literal.sio`
- result: exit 0, output `1.500000`
- `SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/println_f64_var.sio`
- result: exit 0, output `2.250000`
- `SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/serious_language_conformance_gate.sh`
- result: `Summary: total=16 passed=16 failed=0`
- `git diff --check`
- result: exit 0

## Notes

The IR/MIR capacity increase is intentionally bounded at 1024, not 2048, because 2048 also passed but produced a 120407334-byte binary, too large for the normal GitHub binary flow. The 1024 build preserved the fix while keeping the prebuilt below 100 MiB.

LLM-offload review: not invoked. This is compiler/backend plumbing and prebuilt refresh, not a math-claim, clinical-pathway, or external-facing artifact change under `.claude/AGENT_OFFLOAD_POLICY.md`.
