### PR TITLE
[codex] native-v2: reject capturing closure literals

### DIFF
--- a/scripts/ci/native_v2_capturing_closure_unsupported_gate.sh
+++ b/scripts/ci/native_v2_capturing_closure_unsupported_gate.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ "$(uname -s 2>/dev/null || echo unknown)" != "Linux" ]]; then
+  echo "[native-v2-capturing-closure-unsupported] SKIP: Linux-only gate" >&2
+  exit 0
+fi
+
+case "$(uname -m 2>/dev/null || echo unknown)" in
+  x86_64|amd64) ;;
+  *)
+    echo "[native-v2-capturing-closure-unsupported] SKIP: x86-64 Linux-only gate" >&2
+    exit 0
+    ;;
+esac
+
+if [[ -n "${SOUC_BIN:-}" && "$SOUC_BIN" != "$ROOT_DIR"/* ]]; then
+  echo "[native-v2-capturing-closure-unsupported] ignoring external SOUC_BIN outside this worktree: $SOUC_BIN"
+  unset SOUC_BIN
+fi
+
+source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
+sounio_require_souc
+
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+OUT_DIR="${SOUNIO_NATIVE_V2_CAPTURING_CLOSURE_UNSUPPORTED_DIR:-$(mktemp -d /tmp/sounio-native-v2-capturing-closure-unsupported.XXXXXX)}"
+LOG_DIR="$OUT_DIR/logs"
+ARTIFACT_DIR="$OUT_DIR/artifacts"
+ZERO_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_zero_capture_direct_42.sio"
+DIRECT_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_capture_direct_unsupported.sio"
+ESCAPE_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_capture_escape_unsupported.sio"
+LOWER_SOURCE="self-hosted/ir/lower.sio"
+DIAGNOSTIC="native-v2 capturing closure literals are not yet supported"
+ZERO_ELF="$ARTIFACT_DIR/native_v2_closure_zero_capture_direct_42.native"
+
+mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
+
+echo "[native-v2-capturing-closure-unsupported] souc=$SOUC_BIN"
+echo "[native-v2-capturing-closure-unsupported] out=$OUT_DIR"
+
+for path in "$ZERO_CAPTURE" "$DIRECT_CAPTURE" "$ESCAPE_CAPTURE" "$LOWER_SOURCE"; do
+  if [[ ! -f "$path" ]]; then
+    echo "[native-v2-capturing-closure-unsupported] FAIL: missing $path" >&2
+    exit 1
+  fi
+done
+
+if ! grep -q "$DIAGNOSTIC" "$LOWER_SOURCE"; then
+  echo "[native-v2-capturing-closure-unsupported] FAIL: missing native-v2 capture rejection diagnostic in $LOWER_SOURCE" >&2
+  exit 1
+fi
+
+if ! grep -q 'if captures.count > 0' "$LOWER_SOURCE"; then
+  echo "[native-v2-capturing-closure-unsupported] FAIL: missing native-v2 capture count guard in $LOWER_SOURCE" >&2
+  exit 1
+fi
+
+run_log() {
+  local name="$1"
+  shift
+  echo "[native-v2-capturing-closure-unsupported] running $name"
+  "$@" >"$LOG_DIR/$name.log" 2>&1
+}
+
+run_log zero_capture_compile "$SOUC_BIN" compile "$ZERO_CAPTURE" -o "$ZERO_ELF"
+
+if [[ ! -f "$ZERO_ELF" ]]; then
+  echo "[native-v2-capturing-closure-unsupported] FAIL: zero-capture closure did not produce native ELF" >&2
+  cat "$LOG_DIR/zero_capture_compile.log" >&2 || true
+  exit 1
+fi
+
+chmod +x "$ZERO_ELF" 2>/dev/null || true
+
+set +e
+"$ZERO_ELF" >"$LOG_DIR/zero_capture.stdout" 2>"$LOG_DIR/zero_capture.stderr"
+runtime_rc=$?
+set -e
+
+if [[ "$runtime_rc" -ne 42 ]]; then
+  echo "[native-v2-capturing-closure-unsupported] FAIL: zero-capture closure expected exit 42, got $runtime_rc" >&2
+  cat "$LOG_DIR/zero_capture.stdout" >&2 || true
+  cat "$LOG_DIR/zero_capture.stderr" >&2 || true
+  exit 1
+fi
+
+echo "[native-v2-capturing-closure-unsupported] PASS: source rejects capturing closures; zero-capture native closure still exits 42"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -8384,6 +8384,11 @@ impl Lowerer {
         // params on the synthetic fn and are injected at the (direct) call site.
         var captures = empty_capture_list()
         captures = lo.scan_captures_opt(&e.closure_body, &e.closure_params, captures)
+        if captures.count > 0 {
+            print("error: native-v2 capturing closure literals are not yet supported; use a named function or a noncapturing closure\n")
+            let loe = lo.report_error()
+            return loe.emit_unit()
+        }
 
         // 3. Switch to the closure function context. current_func_loaded MUST be true so
         // the functional lowering (current_fn_validated_reg / param resolution) reads from

--- a/tests/selfhost/native_runtime/native_v2_closure_capture_direct_unsupported.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_capture_direct_unsupported.sio
@@ -1,0 +1,5 @@
+fn main() -> i32 {
+    let k: i64 = 7
+    let f = |x: i64| x + k
+    f(35) as i32
+}

--- a/tests/selfhost/native_runtime/native_v2_closure_capture_escape_unsupported.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_capture_escape_unsupported.sio
@@ -1,0 +1,8 @@
+fn apply(f: fn(i64) -> i64, x: i64) -> i64 {
+    f(x)
+}
+
+fn main() -> i32 {
+    let k: i64 = 7
+    apply(|x: i64| x + k, 35) as i32
+}

--- a/tests/selfhost/native_runtime/native_v2_closure_zero_capture_direct_42.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_zero_capture_direct_42.sio
@@ -1,0 +1,4 @@
+fn main() -> i32 {
+    let f = |x: i64| x + 1
+    f(41) as i32
+}


### PR DESCRIPTION
## Summary
- reject capturing closure literals during native-v2 IR lowering instead of emitting an invalid bare function reference
- add focused native-runtime fixtures for zero-capture, direct captured, and escaping captured closure cases
- add a containment gate that verifies the source guard and keeps zero-capture native closure execution at exit 42

## Root Cause
Native-v2 lowers closure literals to synthetic functions and bare function references. Captured closures need an environment ABI, but the current path records captures only for a direct-call island; escaping or value-position captured closures can still compile into invalid native artifacts.

## Validation
- `git diff --check`
- `bash -n scripts/ci/native_v2_capturing_closure_unsupported_gate.sh`
- `env -u SOUC_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/ci/native_v2_capturing_closure_unsupported_gate.sh`

## Notes
- This is containment, not full captured-closure environment support.
- `env -u SOUC_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/ir/lower.sio` is not a clean signal here; isolated checking of this source already reports broad pre-existing privacy/effect/field errors.