### PR TITLE
native-v2: specialize bound captured closure HOF calls

### DIFF
--- a/scripts/ci/native_v2_capturing_closure_unsupported_gate.sh
+++ b/scripts/ci/native_v2_capturing_closure_unsupported_gate.sh
@@ -33,18 +33,20 @@ ARTIFACT_DIR="$OUT_DIR/artifacts"
 ZERO_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_zero_capture_direct_42.sio"
 DIRECT_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_capture_direct_42.sio"
 HOF_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_capture_hof_apply_42.sio"
+BOUND_HOF_CAPTURE="tests/selfhost/native_runtime/native_v2_closure_capture_hof_bound_42.sio"
 LOWER_SOURCE="self-hosted/ir/lower.sio"
 DIAGNOSTIC="native-v2 capturing closure literals are not yet supported"
 ZERO_ELF="$ARTIFACT_DIR/native_v2_closure_zero_capture_direct_42.native"
 DIRECT_ELF="$ARTIFACT_DIR/native_v2_closure_capture_direct_42.native"
 HOF_ELF="$ARTIFACT_DIR/native_v2_closure_capture_hof_apply_42.native"
+BOUND_HOF_ELF="$ARTIFACT_DIR/native_v2_closure_capture_hof_bound_42.native"
 
 mkdir -p "$LOG_DIR" "$ARTIFACT_DIR"
 
 echo "[native-v2-capturing-closure-unsupported] souc=$SOUC_BIN"
 echo "[native-v2-capturing-closure-unsupported] out=$OUT_DIR"
 
-for path in "$ZERO_CAPTURE" "$DIRECT_CAPTURE" "$HOF_CAPTURE" "$LOWER_SOURCE"; do
+for path in "$ZERO_CAPTURE" "$DIRECT_CAPTURE" "$HOF_CAPTURE" "$BOUND_HOF_CAPTURE" "$LOWER_SOURCE"; do
   if [[ ! -f "$path" ]]; then
     echo "[native-v2-capturing-closure-unsupported] FAIL: missing $path" >&2
     exit 1
@@ -76,6 +78,7 @@ run_log() {
 run_log zero_capture_compile "$SOUC_BIN" compile "$ZERO_CAPTURE" -o "$ZERO_ELF"
 run_log direct_capture_compile "$SOUC_BIN" compile "$DIRECT_CAPTURE" -o "$DIRECT_ELF"
 run_log hof_capture_compile "$SOUC_BIN" compile "$HOF_CAPTURE" -o "$HOF_ELF"
+run_log bound_hof_capture_compile "$SOUC_BIN" compile "$BOUND_HOF_CAPTURE" -o "$BOUND_HOF_ELF"
 
 if [[ ! -f "$ZERO_ELF" ]]; then
   echo "[native-v2-capturing-closure-unsupported] FAIL: zero-capture closure did not produce native ELF" >&2
@@ -95,7 +98,13 @@ if [[ ! -f "$HOF_ELF" ]]; then
   exit 1
 fi
 
-chmod +x "$ZERO_ELF" "$DIRECT_ELF" "$HOF_ELF" 2>/dev/null || true
+if [[ ! -f "$BOUND_HOF_ELF" ]]; then
+  echo "[native-v2-capturing-closure-unsupported] FAIL: bound HOF captured closure did not produce native ELF" >&2
+  cat "$LOG_DIR/bound_hof_capture_compile.log" >&2 || true
+  exit 1
+fi
+
+chmod +x "$ZERO_ELF" "$DIRECT_ELF" "$HOF_ELF" "$BOUND_HOF_ELF" 2>/dev/null || true
 
 set +e
 "$ZERO_ELF" >"$LOG_DIR/zero_capture.stdout" 2>"$LOG_DIR/zero_capture.stderr"
@@ -133,4 +142,16 @@ if [[ "$hof_runtime_rc" -ne 42 ]]; then
   exit 1
 fi
 
-echo "[native-v2-capturing-closure-unsupported] PASS: direct and inline-HOF captured closures stay native"
+set +e
+"$BOUND_HOF_ELF" >"$LOG_DIR/bound_hof_capture.stdout" 2>"$LOG_DIR/bound_hof_capture.stderr"
+bound_hof_runtime_rc=$?
+set -e
+
+if [[ "$bound_hof_runtime_rc" -ne 42 ]]; then
+  echo "[native-v2-capturing-closure-unsupported] FAIL: bound HOF captured closure expected exit 42, got $bound_hof_runtime_rc" >&2
+  cat "$LOG_DIR/bound_hof_capture.stdout" >&2 || true
+  cat "$LOG_DIR/bound_hof_capture.stderr" >&2 || true
+  exit 1
+fi
+
+echo "[native-v2-capturing-closure-unsupported] PASS: direct, inline-HOF, and bound-HOF captured closures stay native"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6128,6 +6128,16 @@ impl Lowerer {
         }
     }
 
+    fn first_arg_capturing_closure_local_fn_id_ref(self, opt: &Option<Box<ExprList>>) -> i64 with Mut, Panic, Div, Alloc {
+        match *opt {
+            Some(list) => {
+                if (*list).head.kind != ExprKind::ExprIdent { return -1 }
+                self.lookup_local_closure_fn_id((*list).head.name)
+            }
+            _ => -1,
+        }
+    }
+
     fn lower_function_is_transparent_hof(self, fn_id: i64) -> bool with Mut, Panic, Div, Alloc {
         if fn_id < 0 || fn_id >= (*self.module).fn_count { return false }
         let func = (*self.module).functions[fn_id as usize]
@@ -6167,6 +6177,38 @@ impl Lowerer {
             i = i + 1
         }
         call_count == 1 && saw_return
+    }
+
+    fn lower_hof_captured_closure_local_call(self, closure_fn_id: i64, callee_name: Name, opt: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        match *opt {
+            Some(list) => {
+                var lo = self
+                let pair_tail: LowerExprArgsResult = lo.lower_expr_args_ref(&(*list).tail)
+                lo = pair_tail.lowerer
+                var arglist: Option<Box<IrRegList>> = if pair_tail.count <= 0 { None } else { Some(Box::new(pair_tail.regs)) }
+                var total = pair_tail.count
+                let cidx = lo.find_closure_cap_idx(closure_fn_id)
+                if cidx >= 0 {
+                    let ccount = (*lo.closure_caps).entries[cidx as usize].cap_count
+                    var jc = ccount - 1
+                    while jc >= 0 {
+                        arglist = ir_reg_list_prepend((*lo.closure_caps).entries[cidx as usize].caps[jc as usize], arglist)
+                        jc = jc - 1
+                    }
+                    total = total + ccount
+                }
+
+                let pair_dst = lo.fresh_reg()
+                let lo_dst = pair_dst.0
+                let dst = pair_dst.1
+                let lo_call = lo_dst.emit(ir_call(dst, closure_fn_id, callee_name, arglist, total))
+                (lo_call, dst)
+            }
+            _ => {
+                let loe = self.report_error()
+                loe.emit_unit()
+            }
+        }
     }
 
     fn lower_hof_captured_closure_literal_call(self, callee_name: Name, opt: &Option<Box<ExprList>>) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
@@ -7499,6 +7541,10 @@ impl Lowerer {
         }
         if lo1.first_arg_is_capturing_closure_literal_ref(&e.args) && lo1.lower_function_is_transparent_hof(fn_id) {
             return lo1.lower_hof_captured_closure_literal_call(callee_name, &e.args)
+        }
+        let hof_closure_local_fn = lo1.first_arg_capturing_closure_local_fn_id_ref(&e.args)
+        if hof_closure_local_fn >= 0 && lo1.lower_function_is_transparent_hof(fn_id) {
+            return lo1.lower_hof_captured_closure_local_call(hof_closure_local_fn, callee_name, &e.args)
         }
         let pair_args: LowerExprArgsResult = lo1.lower_expr_args_ref(&e.args)
         let lo2 = pair_args.lowerer

--- a/tests/selfhost/native_runtime/native_v2_closure_capture_hof_bound_42.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_capture_hof_bound_42.sio
@@ -1,0 +1,9 @@
+fn apply(f: fn(i64) -> i64, x: i64) -> i64 {
+    f(x)
+}
+
+fn main() -> i32 {
+    let k: i64 = 7
+    let f = |x: i64| x + k
+    apply(f, 35) as i32
+}


### PR DESCRIPTION
## Summary
- specialize transparent HOF calls whose first argument is a bound captured closure local
- lower `let f = |x| x + k; apply(f, 35)` to the synthetic closure function with captured regs prepended
- add a bound-HOF runtime witness and refresh the checked-in Madaros prebuilt

## Scope
- Supports the transparent bound-local HOF shape only.
- Does not claim general heap closure environments, imports, non-transparent HOFs, or escaping closure values.

## Validation
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/ci/native_v2_capturing_closure_unsupported_gate.sh`
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/ci/madaros_full_gate.sh`
- `env -u SOUC_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib SOUNIO_SELFHOST_HOST_GATE_DIR=/tmp/sounio-closure-bound-hof-source-bootstrap-1 scripts/codex/action-source-bootstrap-host-gate.sh`
- `bash check_sounio.sh --summary` (exit 0; historical summary: 5816 files, 5795 pass, 25 expected legacy errors)
- `git diff --check`
- `bash -n scripts/ci/native_v2_capturing_closure_unsupported_gate.sh`

## Notes
- `native_v2_hof_closure_gate.sh` currently fails through `native_v2_driver_self_compile_gate.sh` with existing check diagnostics in `native_compile_driver.check.log`; not tied to this bound-HOF fixture.
- `native_v2_imported_hof_abi_gate.sh` currently exits 139 during imported IR summary, matching the imported-path segfault class seen in parallel investigation.

## LLM-offload reviews
- Not invoked: compiler lowering/runtime gate only; no math claims, clinical-pathway code, or external-facing artifact touched.
