### PR TITLE
native-v2: structurally reject captured closure escapes

### DIFF
--- a/scripts/ci/native_v2_capturing_closure_unsupported_gate.sh
+++ b/scripts/ci/native_v2_capturing_closure_unsupported_gate.sh
@@ -39,6 +39,9 @@ ALIAS_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_alias_fail.s
 RETURN_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_return_fail.sio"
 IGNORE_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_ignore_fail.sio"
 INLINE_NONTRANSPARENT_HOF_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_inline_nontransparent_hof_fail.sio"
+NONTRANSPARENT_HOF_GENERIC_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_nontransparent_hof_generic_fail.sio"
+ALIAS_GENERIC_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_alias_generic_fail.sio"
+RETURN_GENERIC_FAIL="tests/selfhost/native_runtime/native_v2_closure_capture_return_generic_fail.sio"
 LOWER_SOURCE="self-hosted/ir/lower.sio"
 DIAGNOSTIC="native-v2 capturing closure literals are not yet supported"
 ZERO_ELF="$ARTIFACT_DIR/native_v2_closure_zero_capture_direct_42.native"
@@ -61,6 +64,9 @@ for path in \
   "$RETURN_FAIL" \
   "$IGNORE_FAIL" \
   "$INLINE_NONTRANSPARENT_HOF_FAIL" \
+  "$NONTRANSPARENT_HOF_GENERIC_FAIL" \
+  "$ALIAS_GENERIC_FAIL" \
+  "$RETURN_GENERIC_FAIL" \
   "$LOWER_SOURCE"; do
   if [[ ! -f "$path" ]]; then
     echo "[native-v2-capturing-closure-unsupported] FAIL: missing $path" >&2
@@ -199,5 +205,8 @@ expect_compile_fail alias_fail "$ALIAS_FAIL"
 expect_compile_fail return_fail "$RETURN_FAIL"
 expect_compile_fail ignore_fail "$IGNORE_FAIL"
 expect_compile_fail inline_nontransparent_hof_fail "$INLINE_NONTRANSPARENT_HOF_FAIL"
+expect_compile_fail nontransparent_hof_generic_fail "$NONTRANSPARENT_HOF_GENERIC_FAIL"
+expect_compile_fail alias_generic_fail "$ALIAS_GENERIC_FAIL"
+expect_compile_fail return_generic_fail "$RETURN_GENERIC_FAIL"
 
 echo "[native-v2-capturing-closure-unsupported] PASS: transparent direct/HOF captured closures stay native; escaping/nontransparent captured closure value use fails closed"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -9,7 +9,7 @@ use parser::parser::{parser_last_error_count, parser_reset_last_errors}
 use ir::ir::*
 use io::env::{read_env}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata}
-use ir::lower::{lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
+use ir::lower::{lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref, lower_program_has_captured_closure_value_misuse_ref}
 use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target}
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
@@ -294,31 +294,6 @@ fn module_frontend_source_contains_pattern(path: string, pattern: string) -> boo
         return false
     }
     module_frontend_loaded_contains_pattern(size, pattern)
-}
-
-fn module_frontend_source_has_captured_closure_value_misuse(path: string) -> bool with IO, Mut, Panic, Div {
-    if !module_frontend_source_contains_pattern(path, "|x: i64| x + k") {
-        return false
-    }
-    if module_frontend_source_contains_pattern(path, "let g = f") {
-        return true
-    }
-    if module_frontend_source_contains_pattern(path, "ignore_fn(f") {
-        return true
-    }
-    if module_frontend_source_contains_pattern(path, "apply_plus_one(f") {
-        return true
-    }
-    if module_frontend_source_contains_pattern(path, "apply_plus_one(|") {
-        return true
-    }
-    if module_frontend_source_contains_pattern(path, "apply_twice(f") {
-        return true
-    }
-    if module_frontend_source_contains_pattern(path, "-> fn(i64) -> i64") {
-        return true
-    }
-    false
 }
 
 fn module_frontend_check_items_with_source_context(items: Option<Box<ItemList>>, source_path: string) -> i64 with IO, Mut, Div, Panic, Alloc {
@@ -4369,7 +4344,7 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
             print("Type check failed during IR lowering for module 0\n")
             return multimodule_ir_error("type_check_failed")
         }
-        if module_frontend_source_has_captured_closure_value_misuse(main_path) {
+        if lower_program_has_captured_closure_value_misuse_ref(&main_prog) {
             print("error: capturing closure cannot be used as a value (escaping closures are not yet supported); only a direct call of the closure is allowed\n")
             return multimodule_ir_error("ir_lowering_failed")
         }
@@ -4405,7 +4380,7 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
             print("Type check failed during IR lowering for module 0\n")
             return multimodule_ir_error("type_check_failed")
         }
-        if module_frontend_source_has_captured_closure_value_misuse(main_path) {
+        if lower_program_has_captured_closure_value_misuse_ref(&main_prog) {
             print("error: capturing closure cannot be used as a value (escaping closures are not yet supported); only a direct call of the closure is allowed\n")
             return multimodule_ir_error("ir_lowering_failed")
         }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2235,6 +2235,425 @@ fn lower_struct_field_float_kind_ref(e: &Expr) -> i64 with Mut, Panic, Div {
     0
 }
 
+struct CapturedClosureValueScan {
+    locals: [Name; 256],
+    local_count: i64,
+    captured_closures: [Name; 256],
+    captured_closure_count: i64,
+    transparent_hofs: [Name; 256],
+    transparent_hof_count: i64,
+}
+
+fn captured_closure_value_scan_empty() -> CapturedClosureValueScan {
+    CapturedClosureValueScan {
+        locals: [ir_empty_name(); 256],
+        local_count: 0,
+        captured_closures: [ir_empty_name(); 256],
+        captured_closure_count: 0,
+        transparent_hofs: [ir_empty_name(); 256],
+        transparent_hof_count: 0,
+    }
+}
+
+fn captured_scan_has_local(scan: CapturedClosureValueScan, name: Name) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < scan.local_count {
+        if ir_name_eq(scan.locals[i as usize], name) { return true }
+        i = i + 1
+    }
+    false
+}
+
+fn captured_scan_has_closure(scan: CapturedClosureValueScan, name: Name) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < scan.captured_closure_count {
+        if ir_name_eq(scan.captured_closures[i as usize], name) { return true }
+        i = i + 1
+    }
+    false
+}
+
+fn captured_scan_has_transparent_hof(scan: CapturedClosureValueScan, name: Name) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < scan.transparent_hof_count {
+        if ir_name_eq(scan.transparent_hofs[i as usize], name) { return true }
+        i = i + 1
+    }
+    false
+}
+
+fn captured_scan_add_local(scan: CapturedClosureValueScan, name: Name) -> CapturedClosureValueScan with Mut, Panic, Div {
+    var out = scan
+    if captured_scan_has_local(out, name) { return out }
+    if out.local_count < 256 {
+        out.locals[out.local_count as usize] = name
+        out.local_count = out.local_count + 1
+    }
+    out
+}
+
+fn captured_scan_add_closure(scan: CapturedClosureValueScan, name: Name) -> CapturedClosureValueScan with Mut, Panic, Div {
+    var out = scan
+    if captured_scan_has_closure(out, name) { return out }
+    if out.captured_closure_count < 256 {
+        out.captured_closures[out.captured_closure_count as usize] = name
+        out.captured_closure_count = out.captured_closure_count + 1
+    }
+    out
+}
+
+fn captured_scan_add_transparent_hof(scan: CapturedClosureValueScan, name: Name) -> CapturedClosureValueScan with Mut, Panic, Div {
+    var out = scan
+    if captured_scan_has_transparent_hof(out, name) { return out }
+    if out.transparent_hof_count < 256 {
+        out.transparent_hofs[out.transparent_hof_count as usize] = name
+        out.transparent_hof_count = out.transparent_hof_count + 1
+    }
+    out
+}
+
+fn captured_closure_param_has_name(params: &Option<Box<ClosureParamList>>, name: Name) -> bool with Mut, Panic, Div {
+    var cur = params
+    while true {
+        match *cur {
+            Some(node) => {
+                if ir_name_eq((*node).head.name, name) { return true }
+                cur = &(*node).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn captured_expr_references_enclosing_local(e: &Expr, params: &Option<Box<ClosureParamList>>, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    if (*e).kind == ExprKind::ExprIdent {
+        if captured_scan_has_local(scan, (*e).name) && !captured_closure_param_has_name(params, (*e).name) {
+            return true
+        }
+    }
+    match (*e).left {
+        Some(l) => { if captured_expr_references_enclosing_local(&(*l), params, scan) { return true } }
+        _ => {}
+    }
+    match (*e).right {
+        Some(r) => { if captured_expr_references_enclosing_local(&(*r), params, scan) { return true } }
+        _ => {}
+    }
+    match (*e).else_expr {
+        Some(el) => { if captured_expr_references_enclosing_local(&(*el), params, scan) { return true } }
+        _ => {}
+    }
+    match (*e).block {
+        Some(b) => { if captured_block_references_enclosing_local(&(*b), params, scan) { return true } }
+        _ => {}
+    }
+    var args = &(*e).args
+    while true {
+        match *args {
+            Some(node) => {
+                if captured_expr_references_enclosing_local(&(*node).head, params, scan) { return true }
+                args = &(*node).tail
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
+fn captured_block_references_enclosing_local(block: &Block, params: &Option<Box<ClosureParamList>>, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    var cur = &(*block).stmts
+    while true {
+        match *cur {
+            Some(node) => {
+                match (*node).head.expr {
+                    Some(e) => {
+                        if captured_expr_references_enclosing_local(&(*e), params, scan) { return true }
+                    }
+                    _ => {}
+                }
+                cur = &(*node).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn captured_expr_is_capturing_closure_literal(e: &Expr, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    if (*e).kind != ExprKind::ExprClosure { return false }
+    match (*e).closure_body {
+        Some(body) => captured_expr_references_enclosing_local(&(*body), &(*e).closure_params, scan),
+        _ => false,
+    }
+}
+
+fn captured_expr_is_captured_closure_value(e: &Expr, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    if (*e).kind == ExprKind::ExprIdent {
+        return captured_scan_has_closure(scan, (*e).name)
+    }
+    captured_expr_is_capturing_closure_literal(e, scan)
+}
+
+fn captured_call_first_arg_is_captured_value(args: &Option<Box<ExprList>>, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    match *args {
+        Some(node) => captured_expr_is_captured_closure_value(&(*node).head, scan),
+        _ => false,
+    }
+}
+
+fn captured_expr_callee_name(e: &Expr) -> Name with Mut, Panic, Div {
+    if (*e).kind == ExprKind::ExprIdent {
+        return (*e).name
+    }
+    if (*e).kind == ExprKind::ExprPath {
+        return ir_path_first_name((*e).path)
+    }
+    ir_empty_name()
+}
+
+fn captured_expr_misuses_value(e: &Expr, scan: CapturedClosureValueScan, in_callee: bool) -> bool with Mut, Panic, Div, Alloc {
+    if (*e).kind == ExprKind::ExprIdent {
+        return !in_callee && captured_scan_has_closure(scan, (*e).name)
+    }
+    if (*e).kind == ExprKind::ExprClosure {
+        return !in_callee && captured_expr_is_capturing_closure_literal(e, scan)
+    }
+    if (*e).kind == ExprKind::ExprReturn {
+        match (*e).left {
+            Some(ret) => { return captured_expr_misuses_value(&(*ret), scan, false) }
+            _ => return false,
+        }
+    }
+    if (*e).kind == ExprKind::ExprCall {
+        var callee_name = ir_empty_name()
+        var direct_captured_call = false
+        match (*e).left {
+            Some(callee) => {
+                callee_name = captured_expr_callee_name(&(*callee))
+                if callee_name.len > 0 {
+                    direct_captured_call = captured_scan_has_closure(scan, callee_name)
+                } else if captured_expr_misuses_value(&(*callee), scan, true) {
+                    return true
+                }
+            }
+            _ => {}
+        }
+        let captured_first_arg = captured_call_first_arg_is_captured_value(&(*e).args, scan)
+        let transparent_hof_call = captured_first_arg && captured_scan_has_transparent_hof(scan, callee_name)
+        if captured_first_arg && !transparent_hof_call { return true }
+        var args = &(*e).args
+        var idx: i64 = 0
+        while true {
+            match *args {
+                Some(node) => {
+                    if !((direct_captured_call || transparent_hof_call) && idx == 0) {
+                        if captured_expr_misuses_value(&(*node).head, scan, false) { return true }
+                    }
+                    args = &(*node).tail
+                    idx = idx + 1
+                }
+                _ => break,
+            }
+        }
+        return false
+    }
+    match (*e).left {
+        Some(l) => { if captured_expr_misuses_value(&(*l), scan, false) { return true } }
+        _ => {}
+    }
+    match (*e).right {
+        Some(r) => { if captured_expr_misuses_value(&(*r), scan, false) { return true } }
+        _ => {}
+    }
+    match (*e).else_expr {
+        Some(el) => { if captured_expr_misuses_value(&(*el), scan, false) { return true } }
+        _ => {}
+    }
+    match (*e).block {
+        Some(b) => { if captured_block_misuses_value(&(*b), scan) { return true } }
+        _ => {}
+    }
+    var args2 = &(*e).args
+    while true {
+        match *args2 {
+            Some(node2) => {
+                if captured_expr_misuses_value(&(*node2).head, scan, false) { return true }
+                args2 = &(*node2).tail
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
+fn captured_block_misuses_value(block: &Block, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    var state = scan
+    var cur = &(*block).stmts
+    while true {
+        match *cur {
+            Some(node) => {
+                let stmt = &(*node).head
+                if stmt.kind == StmtKind::StmtLet || stmt.kind == StmtKind::StmtVar {
+                    match (*stmt).expr {
+                        Some(e) => {
+                            if captured_expr_is_capturing_closure_literal(&(*e), state) {
+                                state = captured_scan_add_closure(state, (*stmt).name)
+                            } else {
+                                if captured_expr_misuses_value(&(*e), state, false) { return true }
+                            }
+                        }
+                        _ => {}
+                    }
+                    state = captured_scan_add_local(state, (*stmt).name)
+                } else {
+                    match (*stmt).expr {
+                        Some(e2) => {
+                            if captured_expr_misuses_value(&(*e2), state, false) { return true }
+                        }
+                        _ => {}
+                    }
+                }
+                cur = &(*node).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn captured_param_count(params: &Option<Box<ParamList>>) -> i64 with Alloc, Mut, Div {
+    var n: i64 = 0
+    var cur = params
+    while true {
+        match *cur {
+            Some(node) => {
+                n = n + 1
+                cur = &(*node).tail
+            }
+            _ => return n,
+        }
+    }
+    0
+}
+
+fn captured_first_param_name(params: &Option<Box<ParamList>>) -> Name with Alloc, Mut, Div {
+    match *params {
+        Some(node) => (*node).head.name,
+        _ => ir_empty_name(),
+    }
+}
+
+fn captured_expr_is_transparent_hof_body(e: &Expr, first_param: Name) -> bool with Mut, Panic, Div {
+    if (*e).kind == ExprKind::ExprReturn {
+        match (*e).left {
+            Some(ret) => return captured_expr_is_transparent_hof_body(&(*ret), first_param),
+            _ => return false,
+        }
+    }
+    if (*e).kind == ExprKind::ExprBinary {
+        return false
+    }
+    if (*e).kind != ExprKind::ExprCall { return false }
+    match (*e).left {
+        Some(callee) => {
+            ir_name_eq(captured_expr_callee_name(&(*callee)), first_param)
+        }
+        _ => false,
+    }
+}
+
+fn captured_stmt_list_has_transparent_hof_body(stmts: &Option<Box<StmtList>>, first_param: Name) -> bool with Mut, Panic, Div {
+    var cur = stmts
+    while true {
+        match *cur {
+            Some(node) => {
+                match (*node).head.expr {
+                    Some(e) => {
+                        if captured_expr_is_transparent_hof_body(&(*e), first_param) {
+                            return true
+                        }
+                    }
+                    _ => {}
+                }
+                cur = &(*node).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn captured_fn_is_transparent_hof(fd: &FnDef) -> bool with Mut, Panic, Div, Alloc {
+    if captured_param_count(&(*fd).params) < 2 { return false }
+    let first_param = captured_first_param_name(&(*fd).params)
+    captured_stmt_list_has_transparent_hof_body(&(*fd).body.stmts, first_param)
+}
+
+fn captured_collect_transparent_hofs(items: &Option<Box<ItemList>>, scan: CapturedClosureValueScan) -> CapturedClosureValueScan with Mut, Panic, Div, Alloc {
+    var state = scan
+    var cur = items
+    while true {
+        match *cur {
+            Some(node) => {
+                let item = &(*node).head
+                if (*item).kind == ItemKind::ItemFn {
+                    match (*item).fn_def {
+                        Some(fd) => {
+                            if captured_fn_is_transparent_hof(&(*fd)) {
+                                state = captured_scan_add_transparent_hof(state, (*item).name)
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                cur = &(*node).tail
+            }
+            _ => return state,
+        }
+    }
+    state
+}
+
+fn captured_fn_has_value_misuse(fd: &FnDef, scan: CapturedClosureValueScan) -> bool with Mut, Panic, Div, Alloc {
+    var state = scan
+    var params = &(*fd).params
+    while true {
+        match *params {
+            Some(node) => {
+                state = captured_scan_add_local(state, (*node).head.name)
+                params = &(*node).tail
+            }
+            _ => break,
+        }
+    }
+    captured_block_misuses_value(&(*fd).body, state)
+}
+
+pub fn lower_program_has_captured_closure_value_misuse_ref(prog: &Program) -> bool with Mut, Panic, Div, Alloc {
+    var scan = captured_closure_value_scan_empty()
+    scan = captured_collect_transparent_hofs(&(*prog).items, scan)
+    var cur = &(*prog).items
+    while true {
+        match *cur {
+            Some(node) => {
+                let item = &(*node).head
+                if (*item).kind == ItemKind::ItemFn {
+                    match (*item).fn_def {
+                        Some(fd) => {
+                            if captured_fn_has_value_misuse(&(*fd), scan) { return true }
+                        }
+                        _ => {}
+                    }
+                }
+                cur = &(*node).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
 
 impl Lowerer {
     fn current_fn_compile_strategy(self) -> i64 with Mut, Panic, Div {

--- a/tests/selfhost/native_runtime/native_v2_closure_capture_alias_generic_fail.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_capture_alias_generic_fail.sio
@@ -1,0 +1,6 @@
+fn main() -> i32 {
+    let delta: i64 = 7
+    let captured = |x: i64| x + delta
+    let other = captured
+    other(35) as i32
+}

--- a/tests/selfhost/native_runtime/native_v2_closure_capture_nontransparent_hof_generic_fail.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_capture_nontransparent_hof_generic_fail.sio
@@ -1,0 +1,9 @@
+fn call_and_bump(cb: fn(i64) -> i64, value: i64) -> i64 {
+    cb(value) + 1
+}
+
+fn main() -> i32 {
+    let delta: i64 = 7
+    let captured = |x: i64| x + delta
+    call_and_bump(captured, 35) as i32
+}

--- a/tests/selfhost/native_runtime/native_v2_closure_capture_return_generic_fail.sio
+++ b/tests/selfhost/native_runtime/native_v2_closure_capture_return_generic_fail.sio
@@ -1,0 +1,9 @@
+fn make(delta: i64) -> fn(i64) -> i64 {
+    let captured = |x: i64| x + delta
+    captured
+}
+
+fn main() -> i32 {
+    let cb = make(7)
+    cb(35) as i32
+}


### PR DESCRIPTION
## Summary
- replace the narrow source-text captured-closure escape guard with an AST-level detector over the checked main program
- preserve direct captured closure calls and transparent first-argument HOF calls while failing closed on alias, return, ignored, and non-transparent HOF value use
- add generic-name negative fixtures so the gate covers cases that bypassed the previous textual pattern checks
- refresh `bin/madaros-linux-x86_64` from the rebuilt self-hosted compiler

## Validation
- `bash -n scripts/ci/native_v2_capturing_closure_unsupported_gate.sh`
- `git diff --check`
- `make build-madaros`
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/ci/native_v2_capturing_closure_unsupported_gate.sh`
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/ci/madaros_full_gate.sh`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/ci/build_native_souc.sh /tmp/sounio-lowerer-error-propagation-souc.elf`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib scripts/dev/check_sounio.sh --summary` (exit 0; 25 known baseline dialect/archive errors)

## LLM-offload reviews
- not invoked: compiler containment only; no math claims, clinical-pathway code, or external-facing artifacts touched
