### PR TITLE
[codex] Expose strict-check parser and IR helpers

### DIFF
--- a/self-hosted/check/types.sio
+++ b/self-hosted/check/types.sio
@@ -155,7 +155,7 @@ pub struct TypeEntryList {
 // Default / empty type entry
 // ============================================================
 
-fn empty_type_entry() -> TypeEntry {
+pub fn empty_type_entry() -> TypeEntry {
     TypeEntry {
         kind: TypeKind::TyError,
         name: Name { buf: [0; 128], len: 0 },

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -2082,7 +2082,7 @@ fn ir_mangle_method_name(type_name: Name, method_name: Name) -> Name with Mut, P
     result
 }
 
-fn ir_empty_name() -> Name {
+pub fn ir_empty_name() -> Name {
     Name { buf: [0; 128], len: 0 }
 }
 
@@ -3574,7 +3574,7 @@ pub fn ir_call_indirect(dst: i64, fn_ref_reg: i64, args: Option<Box<IrRegList>>,
     instr
 }
 
-fn ir_module_add_export(module: IrModule, name: Name) -> IrModule with Mut, Panic {
+pub fn ir_module_add_export(module: IrModule, name: Name) -> IrModule with Mut, Panic {
     var m = module
     if m.export_count < 64 {
         m.export_names[m.export_count as usize] = name

--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -1376,7 +1376,7 @@ pub fn ast_reset_global_var_inits() with Mut {
     GLOBAL_VAR_INIT_COUNT = 0
 }
 
-pub fn ast_record_global_var_init(name: Name, value: i64) with Mut {
+pub fn ast_record_global_var_init(name: Name, value: i64) with Mut, Div {
     if GLOBAL_VAR_INIT_COUNT < 128 {
         GLOBAL_VAR_INIT_HASHES[GLOBAL_VAR_INIT_COUNT as usize] = ast_name_hash(name)
         GLOBAL_VAR_INIT_VALUES[GLOBAL_VAR_INIT_COUNT as usize] = value

--- a/self-hosted/parser/mod.sio
+++ b/self-hosted/parser/mod.sio
@@ -7,7 +7,7 @@ module parser::mod
 
 use parser::ast::*
 use lexer::token::*
-use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_new, parser_reset_last_errors, parser_set_last_errors}
+use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_new, parser_reset_last_errors, parser_set_last_errors, parser_set_tokens}
 use parser::types::*
 use parser::exprs::*
 use parser::stmts::*

--- a/self-hosted/parser/parser.sio
+++ b/self-hosted/parser/parser.sio
@@ -29,7 +29,7 @@ pub fn parser_store_expr_box(b: Box<Expr>) with Mut {
     LAST_EXPR = Some(b)
 }
 
-pub fn parser_take_expr_box() -> Box<Expr> with Mut, Alloc {
+pub fn parser_take_expr_box() -> Box<Expr> with Mut, Panic, Alloc {
     match LAST_EXPR {
         Some(b) => {
             LAST_EXPR = None
@@ -37,7 +37,7 @@ pub fn parser_take_expr_box() -> Box<Expr> with Mut, Alloc {
         },
         None => {
             LAST_EXPR = None
-            Box::new(error_expr(Span { file_id: 0, start: 0, end: 0 }))
+            panic("parser_take_expr_box: missing expr")
         },
     }
 }
@@ -86,7 +86,7 @@ pub fn parser_new() -> Parser {
     }
 }
 
-fn parser_set_tokens(tokens: [Token; 2097152], token_count: i64) with Mut, Panic, Div {
+pub fn parser_set_tokens(tokens: [Token; 2097152], token_count: i64) with Mut, Panic, Div {
     var i: i64 = 0
     while i < token_count && i < 2097152 {
         // Write to parallel scalar arrays (boot4-compatible)
@@ -1052,7 +1052,7 @@ impl Parser {
         }
     }
 
-    fn at(self: Parser, kind: TokenKind) -> bool with Panic, Div {
+    fn at(self: Parser, kind: TokenKind) -> bool with Mut, Panic, Div {
         self.peek() == kind
     }
 
@@ -1267,7 +1267,7 @@ impl Parser {
     // Utility: check if current token starts an item
     // ============================================================
 
-    fn at_item_start(self: Parser) -> bool with Panic, Div {
+    fn at_item_start(self: Parser) -> bool with Mut, Panic, Div {
         let k = self.peek()
         k == TokenKind::Fn
             || k == TokenKind::Struct


### PR DESCRIPTION
## Summary

- expose `empty_type_entry`, `ir_empty_name`, and `ir_module_add_export` for strict multimodule check paths that already import/call them across module boundaries
- expose `parser_set_tokens` through `parser::mod` because `parse_program` calls it from `parser::parser`
- add missing parser/AST effects discovered by strict checks (`Div` for global var init hashing, `Mut` for `Parser.at`/`Parser.at_item_start`)
- make `parser_take_expr_box` panic on missing stored expression instead of fabricating an error expression through a fallback path that fails strict checking

## Root Cause

Current strict Madaros check paths reject several helpers that are private or under-declared even though split self-hosted modules use them across module boundaries. These are incremental API/effect corrections; they do not claim to close the full native-v2 serious track.

## Validation

Passed:

```sh
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/check/types.sio
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/ir/ir.sio
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/parser/ast.sio
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/parser/parser.sio
git diff --check
```

Still failing, not fixed by this PR:

```sh
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/compiler/native_compile_driver.sio
# rc=1; remaining cascade includes native constructor strictness, parser/mod callable resolution, and downstream privacy/effect diagnostics.
```
