### PR TITLE
fix(check): type annotated bindings without init

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -6844,7 +6844,13 @@ fn checker_check_binding_init_expr_inplace(c: *mut Checker, opt: Option<Box<Expr
                 checker_check_expr_inplace(c, *e)
             }
         }
-        None => ty_unit()
+        None => {
+            if ann_ty.kind != TypeKind::TyUnknown {
+                ann_ty
+            } else {
+                ty_unit()
+            }
+        }
     }
 }
 
@@ -17604,7 +17610,13 @@ impl Checker {
                     self.check_expr(*e)
                 }
             }
-            None => (self, ty_unit())
+            None => {
+                if ann_ty.kind != TypeKind::TyUnknown {
+                    (self, ann_ty)
+                } else {
+                    (self, ty_unit())
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Treat missing binding initializers with an explicit type annotation as that annotated type instead of unit in both the in-place and by-value checker paths.
- This preserves source-level zero-init patterns such as `var out: CodeBuffer` without expanding large native structs into huge literals.

## Validation
- `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-varinit-checker-20260627` -> rc=0, built `/tmp/madaros-varinit-checker-20260627` (103912041 bytes).
- `MADAROS_RAW_BIN=/tmp/madaros-varinit-checker-20260627 ./bin/souc check self-hosted/native/encode.sio` -> rc=0, `check: OK`.
- `MADAROS_RAW_BIN=/tmp/madaros-varinit-checker-20260627 ./bin/souc check self-hosted/native/elf.sio` -> rc=0, `check: OK`.
- `MADAROS_RAW_BIN=/tmp/madaros-varinit-checker-20260627 timeout 120 ./bin/souc check self-hosted/compiler/native_compile_driver.sio` -> rc=1; the 3 baseline `E001` diagnostics are gone, remaining diagnostics are unchanged (`E002/E005/E008/E009/E011/E012/E017/E035/E137/E175`).

## Remaining blockers
- This does not close `native_compile_driver.sio`; remaining roots include parser `Box::new`/visibility issues, codegen effect/signature mismatches, relocation/nested zero-init cascades, and `compiler_new` effect fallout.
- No LLM-offload review invoked: compiler checker source only; no math claims, clinical-pathway code, or external-facing artifact changes.
