### PR TITLE
fix(check): type Box::new path calls

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -5888,6 +5888,47 @@ fn call_expr_enum_variant_ctor_enum_idx(c: *mut Checker, opt: Option<Box<Expr> >
     }
 }
 
+fn call_expr_is_box_new(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprPath {
+                return false
+            }
+            if (*expr).path.seg_count != 2 {
+                return false
+            }
+            let head_name = checker_copy_string_list_to_name((*expr).path.segments)
+            let tail_name = checker_copy_string_list_tail_to_name((*expr).path.segments)
+            let head_ok = name_matches_str3(head_name, 66, 111, 120)
+            let tail_ok = name_matches_str3(tail_name, 110, 101, 119)
+            head_ok && tail_ok
+        }
+        None => false
+    }
+}
+
+fn checker_check_box_new_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    let first_arg = expr_list_head(e.args)
+    let second_arg = expr_list_second(e.args)
+    let call_start_borrows = (*c).borrows
+    let arg_ty = checker_check_opt_expr_inplace(c, first_arg)
+    match first_arg {
+        None => checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        Some(_) => {}
+    }
+    match second_arg {
+        Some(extra) => {
+            let _extra_ty = checker_check_expr_inplace(c, *extra)
+            checker_report_error_at_inplace(c, e.span, 10, 0, 0, 0)
+        }
+        None => {}
+    }
+    checker_release_call_arg_borrows_inplace(c, e.args, None, call_start_borrows)
+    var box_ty = ty_named(make_name("Box"))
+    box_ty.inner = Some(Box::new(arg_ty))
+    box_ty
+}
+
 fn checker_fn_sigs_find_inplace(c: *mut Checker, name: Name) -> i64 with Mut, Panic, Div, Alloc, IO {
     fn_sig_table_find((*c).fn_sigs, name)
 }
@@ -6010,6 +6051,9 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
     // %ntid.x, etc.); see hlir_to_gpu.sio / lower_to_ptx.sio.
     if call_expr_is_gpu_builtin(e.left) {
         return ty_u32()
+    }
+    if call_expr_is_box_new(e.left) {
+        return checker_check_box_new_expr_inplace(c, e)
     }
     if call_expr_should_bridge_by_value(e) {
         return checker_check_expr_mut(c, e)
@@ -18634,6 +18678,31 @@ impl Checker {
         (c, ty_unit())
     }
 
+    fn check_box_new_expr(self, e: Expr) -> (Checker, TypeEntry) with Mut, Panic, Div, Alloc, IO {
+        let first_arg = expr_list_head(e.args)
+        let second_arg = expr_list_second(e.args)
+        let call_start_borrows = self.borrows
+        let first_pair = self.check_opt_expr(first_arg)
+        var c = first_pair.0
+        let arg_ty = first_pair.1
+        match first_arg {
+            None => c = c.report_error_at(e.span, 10, 0, 0, 0)
+            Some(_) => {}
+        }
+        match second_arg {
+            Some(extra) => {
+                let extra_pair = c.check_expr(*extra)
+                c = extra_pair.0
+                c = c.report_error_at(e.span, 10, 0, 0, 0)
+            }
+            None => {}
+        }
+        c = c.release_call_arg_borrows(e.args, None, call_start_borrows)
+        var box_ty = ty_named(make_name("Box"))
+        box_ty.inner = Some(Box::new(arg_ty))
+        (c, box_ty)
+    }
+
     fn check_call_expr(self, e: Expr) -> (Checker, TypeEntry) with Mut, Panic, Div, Alloc, IO {
         // Safety guard: ExprIndex nodes (e.right=Some) are occasionally dispatched here
         // due to a VM-level kind mismatch. ExprCall never sets e.right; ExprIndex always does.
@@ -18709,6 +18778,9 @@ impl Checker {
         }
         if call_expr_is_builtin_slice_len(e.left) {
             return self.check_slice_len_call_expr(e)
+        }
+        if call_expr_is_box_new(e.left) {
+            return self.check_box_new_expr(e)
         }
         if call_expr_is_builtin_print_int(e.left) {
             return self.check_print_i64_builtin_expr(e)


### PR DESCRIPTION
## Summary

- Recognize `Box::new(...)` when the callee is parsed as an `ExprPath` instead of a bare function identifier.
- Type the intrinsic as `Box<T>` by preserving the checked argument type in `TypeEntry.inner`.
- Apply the same behavior in both the in-place and by-value call checker paths.
- Preserve existing arity rejection: `Box::new()` and `Box::new(a, b)` report E010, not E017.

## Validation

All validation below used a clean Madaros candidate built from this branch only:

```sh
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
  SOUNIO_STDLIB_PATH=$PWD/stdlib \
  bash scripts/ci/build_modular_madaros.sh /tmp/madaros-boxnew-checkonly-20260627
```

Result:

```text
Madaros ready: /tmp/madaros-boxnew-checkonly-20260627 (103919908 bytes)
```

Focused checks:

```sh
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-boxnew-checkonly-20260627 \
  ./bin/souc check tests/run-pass/door1_box_new_array_65536.sio
# rc=0, check: OK
```

```sh
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-boxnew-checkonly-20260627 \
  ./bin/souc check /tmp/sounio_boxnew_noargs.sio
# rc=1, E010 wrong number of arguments
```

```sh
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-boxnew-checkonly-20260627 \
  ./bin/souc check /tmp/sounio_boxnew_twoargs.sio
# rc=1, E010 wrong number of arguments
```

Parser probes with the same candidate:

```sh
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-boxnew-checkonly-20260627 \
  ./bin/souc check self-hosted/parser/stmts.sio
# rc=1; E017 count = 0; remaining: E137/E011 import/visibility blockers
```

```sh
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-boxnew-checkonly-20260627 \
  ./bin/souc check self-hosted/parser/mod.sio
# rc=1; E017 count = 0; remaining: E035/E011/E175/E009 parser effect/visibility/type blockers
```

```sh
git diff --check
# clean
```

## Remaining blockers

This PR only removes the `Box::new` path-callee E017 family. It does not claim parser closure. Current parser probes still expose separate blockers:

- `parser/stmts.sio`: E137 missing import and E011 private/method visibility issues.
- `parser/mod.sio`: E035 missing `Alloc`, E011 private/method visibility, E175 private functions, and E009 visibility argument mismatches.

LLM-offload reviews invoked: none. This change is compiler checker plumbing only; it does not touch math claims, clinical-pathway code, or external-facing artifacts.
