### PR TITLE
fix(parser): close modular parser effect/import gaps

### DIFF
--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -1208,7 +1208,7 @@ pub struct StudyDef {
     n_outcomes: i32,
 }
 
-fn empty_study_hypothesis() -> StudyHypothesis {
+pub fn empty_study_hypothesis() -> StudyHypothesis {
     StudyHypothesis {
         name: Name { buf: [0; 128], len: 0 },
         outcome: Name { buf: [0; 128], len: 0 },
@@ -1217,7 +1217,7 @@ fn empty_study_hypothesis() -> StudyHypothesis {
     }
 }
 
-fn empty_study_outcome() -> StudyOutcome {
+pub fn empty_study_outcome() -> StudyOutcome {
     StudyOutcome {
         name: Name { buf: [0; 128], len: 0 },
         is_primary: false,
@@ -1249,7 +1249,7 @@ pub struct OntologyClassDecl {
     span: Span,
 }
 
-fn empty_ontology_property_decl() -> OntologyPropertyDecl {
+pub fn empty_ontology_property_decl() -> OntologyPropertyDecl {
     OntologyPropertyDecl {
         name: Name { buf: [0; 128], len: 0 },
         type_name: Name { buf: [0; 128], len: 0 },

--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -751,7 +751,7 @@ impl Parser {
     }
 
     // Parse single closure param: name: Type
-    fn parse_closure_param(self) -> (Parser, ClosureParam) with Mut, IO, Panic, Div {
+    fn parse_closure_param(self) -> (Parser, ClosureParam) with Mut, IO, Panic, Div, Alloc {
         let span = self.current_span()
         let name = self.current_name()
         var p = self.advance()  // skip param name

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -9,6 +9,24 @@ use parser::types::*
 use parser::exprs::*
 use parser::stmts::*
 
+fn items_reverse_item_list_opt(items: Option<Box<ItemList>>) -> Option<Box<ItemList>> with Mut, Alloc {
+    items_reverse_item_list_loop(items, None)
+}
+
+fn items_reverse_item_list_loop(
+    current: Option<Box<ItemList>>,
+    acc: Option<Box<ItemList>>,
+) -> Option<Box<ItemList>> with Mut, Alloc {
+    match current {
+        None => acc,
+        Some(node) => {
+            let next = (*node).tail
+            let rev_node = ItemList { head: (*node).head, tail: acc }
+            items_reverse_item_list_loop(next, Some(Box::new(rev_node)))
+        },
+    }
+}
+
 impl Parser {
     // ============================================================
     // Parse a single item
@@ -146,11 +164,11 @@ impl Parser {
         } else if item_kind == TokenKind::Trait {
             p.parse_trait_item(visibility)
         } else if item_kind == TokenKind::Algebra {
-            p.parse_algebra_item(visibility)
+            parse_algebra_item(p, visibility)
         } else if item_kind == TokenKind::Study {
-            p.parse_study_item(visibility)
+            parse_study_item(p, visibility)
         } else if item_kind == TokenKind::Ontology {
-            p.parse_ontology_item(visibility)
+            parse_ontology_item(p, visibility)
         } else if item_kind == TokenKind::Extern {
             p.parse_extern_fn_item(visibility)
         } else if item_kind == TokenKind::Export {
@@ -896,7 +914,7 @@ impl Parser {
 
         p = p.expect(TokenKind::RBrace)
         let span = p.span_from(start)
-        let methods_opt = reverse_item_list_opt(rev_methods_opt)
+        let methods_opt = items_reverse_item_list_opt(rev_methods_opt)
 
         // Extract name from target type path
         let impl_name = extract_impl_name(target_ty)
@@ -958,7 +976,7 @@ impl Parser {
             rev_methods_opt = Some(Box::new(ItemList { head: method_item, tail: rev_methods_opt }))
         }
         p = p.expect(TokenKind::RBrace)
-        let methods_opt = reverse_item_list_opt(rev_methods_opt)
+        let methods_opt = items_reverse_item_list_opt(rev_methods_opt)
 
         let span = p.span_from(start)
         let tdef = TraitItemDef { name: name, methods: methods_opt, supertraits: None, span: span }
@@ -3135,15 +3153,15 @@ impl Parser {
     fn parse_export_fn_item(self, visibility: Visibility) -> (Parser, Item) with Mut, IO, Panic, Div, Alloc {
         var p = self.advance()  // skip 'export'
         if parser_peek(p) == TokenKind::Extern {
-            return p.parse_extern_fn_item(true)
+            return p.parse_extern_fn_item(visibility)
         }
         if parser_peek(p) == TokenKind::StringLit {
             p = p.advance()
             if parser_peek(p) == TokenKind::Extern {
-                return p.parse_extern_fn_item(true)
+                return p.parse_extern_fn_item(visibility)
             }
         }
-        p.parse_fn_item(true, false)
+        p.parse_fn_item(visibility, false)
     }
 
 }

--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -6,6 +6,10 @@
 use parser::ast::*
 use lexer::token::*
 use parser::parser::{parser_peek, parser_at_eof, pt_read_kind, parser_take_expr_box, parser_advance, parser_assign_op_code, error_expr, mk_expr}
+use parser::types::*
+use parser::exprs::{parse_expr_entry}
+use parser::exprs::*
+use parser::patterns::*
 
 // Lean compiler safety: keep assignment targets out of the local frame while
 // recursively parsing the RHS. Holding both Boxes locally corrupts some nested

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -13,7 +13,7 @@ impl Parser {
     // Type expression entry point
     // ============================================================
 
-    fn parse_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div {
+    fn parse_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div, Alloc {
         let k = self.peek()
 
         if k == TokenKind::Star {
@@ -205,7 +205,7 @@ impl Parser {
     // Named type: Foo, Foo::Bar, Option<Box<T>>
     // ============================================================
 
-    fn parse_option_shorthand_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div {
+    fn parse_option_shorthand_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div, Alloc {
         let start = self.current_span()
         var p = self.advance()  // skip ?
         let pair = p.parse_type()
@@ -236,7 +236,7 @@ impl Parser {
         })
     }
 
-    fn parse_named_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div {
+    fn parse_named_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div, Alloc {
         let start = self.current_span()
         let pair = self.parse_type_path()
         let p1 = pair.0
@@ -351,7 +351,7 @@ impl Parser {
     // Reference type: &T
     // ============================================================
 
-    fn parse_ref_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div {
+    fn parse_ref_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div, Alloc {
         let start = self.current_span()
         var p = self.advance()  // skip &
         let pair = p.parse_type()
@@ -375,7 +375,7 @@ impl Parser {
     // Exclusive reference type: &!T
     // ============================================================
 
-    fn parse_ref_mut_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div {
+    fn parse_ref_mut_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div, Alloc {
         let start = self.current_span()
         var p = self.advance()  // skip &!
         let pair = p.parse_type()
@@ -704,7 +704,7 @@ impl Parser {
     // Optional type annotation: ': Type'
     // ============================================================
 
-    fn parse_optional_type(self) -> (Parser, Option<Box<TypeExpr>>) with Mut, IO, Panic, Div {
+    fn parse_optional_type(self) -> (Parser, Option<Box<TypeExpr>>) with Mut, IO, Panic, Div, Alloc {
         if self.peek() == TokenKind::Colon {
             var p = self.advance()  // skip :
             let pair = p.parse_type()
@@ -721,7 +721,7 @@ impl Parser {
     // Optional return type: '-> Type'
     // ============================================================
 
-    fn parse_optional_return_type(self) -> (Parser, Option<Box<TypeExpr>>) with Mut, IO, Panic, Div {
+    fn parse_optional_return_type(self) -> (Parser, Option<Box<TypeExpr>>) with Mut, IO, Panic, Div, Alloc {
         if self.peek() == TokenKind::Arrow {
             var p = self.advance()  // skip ->
             let pair = p.parse_type()


### PR DESCRIPTION
## Summary

- declares `Alloc` on parser type/closure helpers that allocate boxed AST nodes or call `Alloc`-annotated type parsers
- imports the parser extension modules needed by `stmts.sio` so Parser methods/free entrypoints resolve under modular checking
- fixes stale `Visibility` call sites in `export fn` parsing and localizes item-list reversal for `items.sio`
- publishes the AST empty constructors that `items.sio` already uses across the parser submodule boundary

## Validation

Built patched Madaros from source:

```sh
env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN \
  SOUNIO_STDLIB_PATH=$PWD/stdlib \
  bash scripts/ci/build_modular_madaros.sh /tmp/madaros-parser-alloc-patched-20260627
```

Result:

```text
Madaros ready: /tmp/madaros-parser-alloc-patched-20260627 (103921963 bytes)
```

Focused parser checks with the patched candidate all passed:

```sh
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 ./bin/souc check self-hosted/parser/types.sio
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 ./bin/souc check self-hosted/parser/stmts.sio
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 ./bin/souc check self-hosted/parser/exprs.sio
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 ./bin/souc check self-hosted/parser/items.sio
env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 ./bin/souc check self-hosted/parser/mod.sio
```

Each reported `check: OK`.

Focused suite checks:

```sh
SOUNIO_TEST_SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/dev/run_sio_test_suite_v2.sh --filter hello --verbose
SOUNIO_TEST_SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/dev/run_sio_test_suite_v2.sh --filter tuple_signature --verbose
SOUNIO_TEST_SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/dev/run_sio_test_suite_v2.sh --filter box_new --verbose
SOUNIO_TEST_SOUC_BIN=$PWD/bin/souc MADAROS_RAW_BIN=/tmp/madaros-parser-alloc-patched-20260627 SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/dev/run_sio_test_suite_v2.sh --filter ontology_basic --verbose
```

Results:

- `hello`: Pass 2 / Fail 0
- `tuple_signature`: Pass 5 / Fail 0
- `box_new`: Pass 1 / Fail 0
- `ontology_basic`: Pass 1 / Fail 0

Baseline comparisons, not introduced by this PR:

- `--filter parser_card`: patched and base candidate both had Pass 1 / Fail 4
- `--filter study`: patched and base candidate both had Pass 1 / Fail 2 / Skip 1

Also ran `git diff --check` successfully.

## Subagents

Used three read-only subagents:

- E035/Alloc triage: identified parser type helpers missing `Alloc`
- `stmts.sio` E011/E137 triage: identified missing imports for parser extension modules and `parse_expr_entry`
- `items.sio` E175/E009 triage: identified stale `Visibility` bool calls and cross-module private helper/constructor usage

## LLM-offload

Not invoked. This patch is compiler/parser plumbing only; it does not touch math claims, clinical-pathway code, or external-facing artifacts.
