### PR TITLE
fix(gpu): type epistemic spirv byte buffers

### DIFF
--- a/self-hosted/gpu/epistemic_spirv.sio
+++ b/self-hosted/gpu/epistemic_spirv.sio
@@ -26,7 +26,7 @@ fn espv_i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
     }
     if n == 0 { return "0" }
 
-    var digits: [i8; 32] = [0; 32]
+    var digits: [i8; 32] = [0 as i8; 32]
     var rev_len: i64 = 0
     var value: i64 = n
 
@@ -37,7 +37,7 @@ fn espv_i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
         value = value / 10
     }
 
-    var bytes: [i8; 32] = [0; 32]
+    var bytes: [i8; 32] = [0 as i8; 32]
     var i: i64 = 0
     while i < rev_len {
         bytes[i as usize] = digits[(rev_len - i - 1) as usize]


### PR DESCRIPTION
## Summary
- type the two zero-filled byte buffers in `self-hosted/gpu/epistemic_spirv.sio` as `[i8; 32]`
- avoid repeated array literal inference from `[0; 32]` to `[i64; 32]`
- keep this PR scoped to the direct `epistemic_spirv` type-check blocker; it does not claim the aggregate GPU module is green

## Validation
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/epistemic_spirv.sio` -> `check: OK`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-sota-epistemic-spirv-20260627 ./bin/souc check self-hosted/gpu/epistemic_spirv.sio` -> `check: OK`
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/build_modular_madaros.sh /tmp/madaros-sota-epistemic-spirv-20260627` -> `Madaros ready: /tmp/madaros-sota-epistemic-spirv-20260627 (103958906 bytes)`
- `git diff --check` -> pass
- `bash check_sounio.sh --summary` -> pass, summary reported `Checked: 5824 files, Pass: 5803, Errors: 25, Warnings: 0` with existing repository fixture/baseline errors

## Non-evidence / remaining baseline blockers
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/mod.sio` still fails on existing aggregate GPU privacy/import noise
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/test_spirv_lower.sio` still fails on existing private-function visibility noise

## LLM-offload reviews invoked
- none; this is a narrow compiler/GPU implementation fix, not a math claim, clinical-pathway change, or external-facing artifact
