### PR TITLE
fix(gpu): expose spirv driver self check

### DIFF
--- a/self-hosted/gpu/spirv.sio
+++ b/self-hosted/gpu/spirv.sio
@@ -1334,6 +1334,6 @@ fn spirv_self_check() -> bool with Mut, Panic, Div {
     t1 && t2 && t3 && t4 && t5
 }
 
-fn spirv_driver_self_check() -> bool with Mut, Panic, Div {
+pub fn spirv_driver_self_check() -> bool with Mut, Panic, Div {
     spirv_self_check()
 }

--- a/self-hosted/gpu/test_spirv_lower.sio
+++ b/self-hosted/gpu/test_spirv_lower.sio
@@ -1,11 +1,11 @@
 use spirv::*
 fn main() -> i32 with IO, Mut, Panic, Div {
-    let ok = spirv_self_check()
+    let ok = spirv_driver_self_check()
     if ok {
-        print("PASS spirv_self_check\n")
+        print("PASS spirv_driver_self_check\n")
         0
     } else {
-        print("FAIL spirv_self_check\n")
+        print("FAIL spirv_driver_self_check\n")
         1
     }
 }


### PR DESCRIPTION
## Summary
- make `spirv_driver_self_check()` the narrow public SPIR-V smoke-check facade
- update `self-hosted/gpu/test_spirv_lower.sio` to call the public driver facade instead of the private internal `spirv_self_check()`
- keep `spirv_self_check()` and the lower-level `spv_*` emitters private; this avoids turning internal SPIR-V builder details into public API

## Validation
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/test_spirv_lower.sio` -> `check: OK`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/spirv.sio` -> `check: OK`
- `git diff --check` -> pass
- `bash check_sounio.sh --summary` -> pass, summary reported `Checked: 5824 files, Pass: 5803, Errors: 25, Warnings: 0` with existing fixture/archive/legacy errors
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/build_modular_madaros.sh /tmp/madaros-sota-spirv-driver-20260627` -> `Madaros ready: /tmp/madaros-sota-spirv-driver-20260627 (103958906 bytes)`

## Subagent findings
- James confirmed `test_spirv_lower.sio` failed because it called private `spirv_self_check()` across module visibility boundaries, and recommended exposing only `spirv_driver_self_check()`
- Parfit confirmed `self-hosted/gpu/mod.sio` still has larger baseline GPU aggregate blockers: `E137 16`, `E175 567`, `E176 1`, `E177 474`; these are mainly PTX/Metal `i64_to_string`, HLIR bridge wiring/API visibility, and broad constructor visibility issues, not fallout from PR #467

## Non-evidence / remaining blockers
- `self-hosted/gpu/mod.sio` is still not claimed green
- `self-hosted/gpu/kretikos_emit_spirv.sio` still has a larger private-emitter API problem and a separate type error; this PR intentionally does not make every `spv_*` helper public

## LLM-offload reviews invoked
- none; narrow compiler/GPU visibility/test fix, no math claim, clinical-pathway change, or external-facing artifact
