### PR TITLE
fix(gpu): localize ptx metal integer formatting

### DIFF
--- a/self-hosted/gpu/metal.sio
+++ b/self-hosted/gpu/metal.sio
@@ -101,7 +101,7 @@ fn metal_buf_contains(buf: MetalBuf, needle: string) -> bool with Mut, Panic, Di
 fn metal_push_i64(buf: MetalBuf, n: i64) -> MetalBuf with Mut, Panic, Div {
     if n == 0 { return metal_push_byte(buf, 48) }
     var value: i64 = if n < 0 { 0 } else { n }
-    var digits: [i8; 20] = [0; 20]
+    var digits: [i8; 20] = [0 as i8; 20]
     var rev_len: i64 = 0
     while value > 0 {
         digits[rev_len as usize] = (48 + value % 10) as i8
@@ -115,6 +115,20 @@ fn metal_push_i64(buf: MetalBuf, n: i64) -> MetalBuf with Mut, Panic, Div {
         k = k - 1
     }
     out
+}
+
+var METAL_I64_TO_STRING_BUF: [i8; 32] = [0 as i8; 32]
+
+fn metal_i64_to_string(n: i64) -> string with Mut, Panic, Div {
+    var tmp = metal_buf_new()
+    tmp = metal_push_i64(tmp, n)
+    var i: i64 = 0
+    while i < tmp.len {
+        METAL_I64_TO_STRING_BUF[i as usize] = tmp.data[i as usize]
+        i = i + 1
+    }
+    METAL_I64_TO_STRING_BUF[tmp.len as usize] = 0
+    str_from_bytes(METAL_I64_TO_STRING_BUF, tmp.len)
 }
 
 fn metal_push_name(buf: MetalBuf, name: Name) -> MetalBuf with Mut, Panic {
@@ -411,18 +425,18 @@ fn metal_emit_var_decls(buf: MetalBuf, kernel: GpuKernelIr) -> MetalBuf with Mut
 
 fn metal_reg_name(ty: GpuType, idx: i64) -> string with Mut, Panic, Div, Alloc {
     match ty {
-        GpuType::GpuU32 => str_concat("r", i64_to_string(idx)),
-        GpuType::GpuU64 => str_concat("rd", i64_to_string(idx)),
-        GpuType::GpuF32 => str_concat("f", i64_to_string(idx)),
-        GpuType::GpuF64 => str_concat("fd", i64_to_string(idx)),
-        GpuType::GpuI32 => str_concat("sr", i64_to_string(idx)),
-        GpuType::GpuI64 => str_concat("srd", i64_to_string(idx)),
-        GpuType::GpuPtr => str_concat("rd", i64_to_string(idx)),
-        GpuType::GpuBool => str_concat("p", i64_to_string(idx)),
-        GpuType::GpuTf32 => str_concat("f", i64_to_string(idx)),
-        GpuType::GpuF16 => str_concat("h", i64_to_string(idx)),
-        GpuType::GpuB32 => str_concat("r", i64_to_string(idx)),
-        GpuType::GpuB64 => str_concat("rd", i64_to_string(idx)),
+        GpuType::GpuU32 => str_concat("r", metal_i64_to_string(idx)),
+        GpuType::GpuU64 => str_concat("rd", metal_i64_to_string(idx)),
+        GpuType::GpuF32 => str_concat("f", metal_i64_to_string(idx)),
+        GpuType::GpuF64 => str_concat("fd", metal_i64_to_string(idx)),
+        GpuType::GpuI32 => str_concat("sr", metal_i64_to_string(idx)),
+        GpuType::GpuI64 => str_concat("srd", metal_i64_to_string(idx)),
+        GpuType::GpuPtr => str_concat("rd", metal_i64_to_string(idx)),
+        GpuType::GpuBool => str_concat("p", metal_i64_to_string(idx)),
+        GpuType::GpuTf32 => str_concat("f", metal_i64_to_string(idx)),
+        GpuType::GpuF16 => str_concat("h", metal_i64_to_string(idx)),
+        GpuType::GpuB32 => str_concat("r", metal_i64_to_string(idx)),
+        GpuType::GpuB64 => str_concat("rd", metal_i64_to_string(idx)),
     }
 }
 
@@ -920,7 +934,7 @@ fn metal_lower_single_op(buf: MetalBuf, op: GpuOp, kernel: GpuKernelIr) -> Metal
     if opc == GpuOpcode::GpuVote || opc == GpuOpcode::GpuBallot {
         var pred_expr = "false"
         if op.pred_reg >= 0 {
-            pred_expr = str_concat("p", i64_to_string(op.pred_reg))
+            pred_expr = str_concat("p", metal_i64_to_string(op.pred_reg))
         } else if op.src_reg >= 0 {
             pred_expr = str_concat(metal_reg_name(op.ty, op.src_reg), " != 0")
         }

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -45,6 +45,25 @@ fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
+fn ptx_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
+    if n == 0 { return ptx_push_byte(buf, 48) }
+    var value: i64 = if n < 0 { 0 } else { n }
+    var digits: [i8; 20] = [0 as i8; 20]
+    var rev_len: i64 = 0
+    while value > 0 {
+        digits[rev_len as usize] = (48 + value % 10) as i8
+        rev_len = rev_len + 1
+        value = value / 10
+    }
+    var out = buf
+    var k: i64 = rev_len - 1
+    while k >= 0 {
+        out = ptx_push_byte(out, digits[k as usize])
+        k = k - 1
+    }
+    out
+}
+
 fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
     let nlen = str_len(needle)
     if nlen == 0 { return true }
@@ -578,7 +597,7 @@ fn ptx_emit_shared_decl(
 ) -> PtxBuf with Mut, Panic, Div, Alloc {
     var out = buf
     out = ptx_push_str(out, "    .shared .align 4 .b8 shared_array[")
-    out = ptx_push_str(out, i64_to_string(bytes))
+    out = ptx_push_i64(out, bytes)
     out = ptx_push_str(out, "];\n")
     out
 }


### PR DESCRIPTION
## Summary
- add local PTX integer-buffer formatting and use it for shared-memory declarations instead of unresolved `i64_to_string`
- add local Metal integer-to-string formatting and use it for register/predicate names instead of unresolved `i64_to_string`
- keep the fix module-local; no new cross-module formatter import or broad GPU API exposure

## Validation
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/ptx.sio` -> `check: OK`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/metal.sio` -> `check: OK`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-sota-gpu-strings-20260627 ./bin/souc check self-hosted/gpu/ptx.sio` -> `check: OK`
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib MADAROS_RAW_BIN=/tmp/madaros-sota-gpu-strings-20260627 ./bin/souc check self-hosted/gpu/metal.sio` -> `check: OK`
- `git diff --check` -> pass
- `bash check_sounio.sh --summary` -> pass, summary reported `Checked: 5824 files, Pass: 5803, Errors: 25, Warnings: 0` with existing fixture/archive/legacy errors
- `env -u SOUC_BIN -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN SOUNIO_STDLIB_PATH=$PWD/stdlib bash scripts/ci/build_modular_madaros.sh /tmp/madaros-sota-gpu-strings-20260627` -> `Madaros ready: /tmp/madaros-sota-gpu-strings-20260627 (103960231 bytes)`

## Aggregate status
- `env SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/mod.sio` still fails: `run_check_mode: verdict=1`
- post-patch aggregate count from `/tmp/sounio-sota-gpu-strings-mod.log`: `E137 16`, `E175 553`, `E176 1`, `E177 474`
- PTX and Metal now pass standalone; the remaining aggregate blockers are the larger HLIR bridge / public API visibility lane identified by subagent analysis

## LLM-offload reviews invoked
- none; narrow compiler/GPU implementation fix, no math claim, clinical-pathway change, or external-facing artifact
