### PR TITLE
Expose GPU HLIR bridge APIs

### DIFF
--- a/scripts/omega/omega_gpu_opcode_smoke.sh
+++ b/scripts/omega/omega_gpu_opcode_smoke.sh
@@ -35,13 +35,13 @@ emit_sio_decl() {
   awk -v kind="$kind" -v name="$name" '
     function is_target_decl(line) {
       if (kind == "fn") {
-        return line ~ ("^fn " name "\\(")
+        return line ~ ("^(pub )?fn " name "\\(")
       }
-      return line ~ ("^" kind " " name "([ {]|$)")
+      return line ~ ("^(pub )?" kind " " name "([ {]|$)")
     }
 
     function is_top_level_decl(line) {
-      return line ~ /^(fn|struct) /
+      return line ~ /^(pub )?(fn|struct) /
     }
 
     is_target_decl($0) {

--- a/self-hosted/gpu/cuda_tile.sio
+++ b/self-hosted/gpu/cuda_tile.sio
@@ -16,11 +16,11 @@
 // ============================================================================
 
 pub struct TileBuf {
-    data: [i8; 65536],
-    len: i64,
+    pub data: [i8; 65536],
+    pub len: i64,
 }
 
-fn tile_buf_new() -> TileBuf {
+pub fn tile_buf_new() -> TileBuf {
     TileBuf { data: [0; 65536], len: 0 }
 }
 
@@ -612,7 +612,7 @@ fn tile_emit_store_pattern(buf: TileBuf, alloc: TileIdAlloc, param_id: i64, offs
     (b4, a4, tok_id)
 }
 
-fn gpu_lower_to_cuda_tile(
+pub fn gpu_lower_to_cuda_tile(
     kernel_name: string,
     param_count: i64,
     ops_opcodes: [i64; 256],

--- a/self-hosted/gpu/epistemic_spirv.sio
+++ b/self-hosted/gpu/epistemic_spirv.sio
@@ -960,7 +960,7 @@ fn espv_allocate_types(
 // Top-level lowering: gpu_lower_to_epistemic_spirv
 // ============================================================================
 
-fn gpu_lower_to_epistemic_spirv(
+pub fn gpu_lower_to_epistemic_spirv(
     kernel_name: string,
     param_count: i64,
     ops_opcodes: [i64; 256],

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -12,6 +12,13 @@
 // - Counterfactual mode replicates lanes across the warp.
 
 use gpu::lower_to_ptx::*
+use gpu::kernel_ir::*
+use gpu::ptx::*
+use gpu::metal::*
+use gpu::cuda_tile::*
+use gpu::epistemic_spirv::*
+use hlir::ir::*
+use io::trace::{io_write_bytes_to_file}
 use gpu::spirv::*
 use gpu::kaxi_backend::*
 use gpu::opt::fusion::*
@@ -179,20 +186,20 @@ let GpuOpcodeShr: i64 = 37
 // Section 6 — GpuOpEntry
 // ============================================================================
 
-struct GpuOpEntry {
-    opcode: i64,
-    type_tag: i64,
-    dst_idx: i64,
-    src0: i64,
-    src1: i64,
-    src2: i64,
-    imm_int: i64,
-    imm_f32: f32,
-    pred: i64,
-    axis: i64,
+pub struct GpuOpEntry {
+    pub opcode: i64,
+    pub type_tag: i64,
+    pub dst_idx: i64,
+    pub src0: i64,
+    pub src1: i64,
+    pub src2: i64,
+    pub imm_int: i64,
+    pub imm_f32: f32,
+    pub pred: i64,
+    pub axis: i64,
 }
 
-fn gpu_op_entry_default() -> GpuOpEntry {
+pub fn gpu_op_entry_default() -> GpuOpEntry {
     GpuOpEntry {
         opcode: 0,
         type_tag: 0,
@@ -211,17 +218,17 @@ fn gpu_op_entry_default() -> GpuOpEntry {
 // Section 7 — GpuBlockEntry
 // ============================================================================
 
-struct GpuBlockEntry {
-    id: i64,
-    ops: [GpuOpEntry; 4096],
-    op_count: i64,
-    term_tag: i64,
-    term_src: i64,
-    term_target0: i64,
-    term_target1: i64,
+pub struct GpuBlockEntry {
+    pub id: i64,
+    pub ops: [GpuOpEntry; 4096],
+    pub op_count: i64,
+    pub term_tag: i64,
+    pub term_src: i64,
+    pub term_target0: i64,
+    pub term_target1: i64,
 }
 
-fn gpu_block_entry_default() -> GpuBlockEntry {
+pub fn gpu_block_entry_default() -> GpuBlockEntry {
     GpuBlockEntry {
         id: -1,
         ops: [gpu_op_entry_default(); 4096],
@@ -237,14 +244,14 @@ fn gpu_block_entry_default() -> GpuBlockEntry {
 // Section 8 — GpuParamEntry
 // ============================================================================
 
-struct GpuParamEntry {
-    name: [i8; 64],
-    name_len: i64,
-    type_tag: i64,
-    is_restrict: bool,
+pub struct GpuParamEntry {
+    pub name: [i8; 64],
+    pub name_len: i64,
+    pub type_tag: i64,
+    pub is_restrict: bool,
 }
 
-fn gpu_param_entry_default() -> GpuParamEntry {
+pub fn gpu_param_entry_default() -> GpuParamEntry {
     GpuParamEntry {
         name: [0; 64],
         name_len: 0,
@@ -257,17 +264,17 @@ fn gpu_param_entry_default() -> GpuParamEntry {
 // Section 9 — GpuKernelEntry
 // ============================================================================
 
-struct GpuKernelEntry {
-    name: [i8; 256],
-    name_len: i64,
-    is_kernel: bool,
-    params: [GpuParamEntry; 32],
-    param_count: i64,
-    blocks: [GpuBlockEntry; 256],
-    block_count: i64,
+pub struct GpuKernelEntry {
+    pub name: [i8; 256],
+    pub name_len: i64,
+    pub is_kernel: bool,
+    pub params: [GpuParamEntry; 32],
+    pub param_count: i64,
+    pub blocks: [GpuBlockEntry; 256],
+    pub block_count: i64,
 }
 
-fn gpu_kernel_entry_default() -> GpuKernelEntry {
+pub fn gpu_kernel_entry_default() -> GpuKernelEntry {
     GpuKernelEntry {
         name: [0; 256],
         name_len: 0,
@@ -283,23 +290,23 @@ fn gpu_kernel_entry_default() -> GpuKernelEntry {
 // Section 10 — GpuModuleOutput
 // ============================================================================
 
-struct GpuModuleOutput {
-    kernels: [GpuKernelEntry; 64],
-    kernel_count: i64,
-    device_fns: [GpuKernelEntry; 64],
-    device_fn_count: i64,
+pub struct GpuModuleOutput {
+    pub kernels: [GpuKernelEntry; 64],
+    pub kernel_count: i64,
+    pub device_fns: [GpuKernelEntry; 64],
+    pub device_fn_count: i64,
 }
 
 // ============================================================================
 // Section 11 — EpistemicShadowEntry
 // ============================================================================
 
-struct EpistemicShadowEntry {
-    hlir_value: i64,
-    gpu_value: i64,
-    eps_value: i64,
-    valid_value: i64,
-    prov_value: i64,
+pub struct EpistemicShadowEntry {
+    pub hlir_value: i64,
+    pub gpu_value: i64,
+    pub eps_value: i64,
+    pub valid_value: i64,
+    pub prov_value: i64,
 }
 
 fn epistemic_shadow_entry_default() -> EpistemicShadowEntry {
@@ -334,20 +341,20 @@ fn value_map_entry_default() -> ValueMapEntry {
 // Section 13 — HlirToGpuState
 // ============================================================================
 
-struct HlirToGpuState {
-    next_value_id: i64,
-    next_block_id: i64,
-    value_map: [ValueMapEntry; 8192],
-    value_map_count: i64,
-    block_map_src: [i64; 2048],
-    block_map_dst: [i64; 2048],
-    block_map_count: i64,
-    epistemic_shadows: [EpistemicShadowEntry; 8192],
-    shadow_count: i64,
-    epistemic_enabled: bool,
-    counterfactual_enabled: bool,
-    target_sm: i64,
-    fast_math: bool,
+pub struct HlirToGpuState {
+    pub next_value_id: i64,
+    pub next_block_id: i64,
+    pub value_map: [ValueMapEntry; 8192],
+    pub value_map_count: i64,
+    pub block_map_src: [i64; 2048],
+    pub block_map_dst: [i64; 2048],
+    pub block_map_count: i64,
+    pub epistemic_shadows: [EpistemicShadowEntry; 8192],
+    pub shadow_count: i64,
+    pub epistemic_enabled: bool,
+    pub counterfactual_enabled: bool,
+    pub target_sm: i64,
+    pub fast_math: bool,
 }
 
 // ============================================================================

--- a/self-hosted/gpu/kaxi_backend.sio
+++ b/self-hosted/gpu/kaxi_backend.sio
@@ -224,7 +224,7 @@ pub fn kaxi_asm_push_line(buf: KaxiAsmBuf, s: string) -> KaxiAsmBuf with Mut, Pa
     out
 }
 
-fn kaxi_asm_buf_append(a: KaxiAsmBuf, b: KaxiAsmBuf) -> KaxiAsmBuf with Mut, Panic {
+pub fn kaxi_asm_buf_append(a: KaxiAsmBuf, b: KaxiAsmBuf) -> KaxiAsmBuf with Mut, Panic {
     var out = a
     var i: i64 = 0
     while i < b.len && out.len < 2097152 {
@@ -480,7 +480,7 @@ pub fn kaxi_conf_reject_ptx(budget: i64, min_conf: i64) -> string with Mut, Pani
 // GPU IR -> K-AXI lowerer (parallel arrays input, matching cpu_ir_interpreter.sio)
 // ============================================================================
 
-fn gpu_lower_to_kaxi(
+pub fn gpu_lower_to_kaxi(
     ops_opcodes: [i64; 256],
     ops_dst: [i64; 256],
     ops_src_a: [i64; 256],
@@ -1371,7 +1371,7 @@ fn kaxi_asm_append_store_global_i32(buf: KaxiAsmBuf, src: i64, addr_reg: i64, se
 // Typed lowering: same as gpu_lower_to_kaxi but ops_types[i]=1 selects f64 PTX emitters.
 // All existing callers keep using gpu_lower_to_kaxi (u64, unchanged).
 // Only hlir_kernels_to_kaxi uses this path when HLIR types are known.
-fn gpu_lower_to_kaxi_typed(
+pub fn gpu_lower_to_kaxi_typed(
     ops_opcodes: [i64; 256],
     ops_dst: [i64; 256],
     ops_src_a: [i64; 256],

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -11,16 +11,16 @@
 // - Fixed register allocation for now
 // - Struct-based representation (no enum field destructuring - not supported by self-hosted)
 
-struct Name {
-    buf: [i8; 128],
-    len: i64,
+pub struct Name {
+    pub buf: [i8; 128],
+    pub len: i64,
 }
 
-fn ki_empty_name() -> Name {
+pub fn ki_empty_name() -> Name {
     Name { buf: [0; 128], len: 0 }
 }
 
-fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut, Panic, Div {
+pub fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut, Panic, Div {
     var n = Name { buf: [0; 128], len: len }
     if len > 0 { n.buf[0] = a }
     if len > 1 { n.buf[1] = b }
@@ -32,7 +32,7 @@ fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut,
 // Build a Name from a string literal (any length up to 128).
 // Uses str_char_at so all bytes are set in one-level ops — avoids the
 // two-level nested-store miscompilation (var.field1.field2[i] = v).
-fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
+pub fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
     var n = Name { buf: [0; 128], len: len }
     var i: i64 = 0
     while i < len {
@@ -43,7 +43,7 @@ fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
 }
 
 // GPU data types (full type coverage for all kernels)
-enum GpuType {
+pub enum GpuType {
     GpuU32,
     GpuU64,
     GpuF32,
@@ -60,7 +60,7 @@ enum GpuType {
 }
 
 // GPU operation opcodes (simple enum, no fields)
-enum GpuOpcode {
+pub enum GpuOpcode {
     GpuGetTid,       // Get thread ID
     GpuCvt,          // Type conversion
     GpuMulImm,       // Multiply with immediate
@@ -178,7 +178,7 @@ enum GpuOpcode {
 }
 
 // GPU memory space (for load/store address space qualification)
-enum GpuMemorySpace {
+pub enum GpuMemorySpace {
     GpuMemGlobal,
     GpuMemShared,
     GpuMemLocal,
@@ -186,7 +186,7 @@ enum GpuMemorySpace {
 }
 
 // Phase 6: Atomic operation selector (used by GpuAtomicCas, GpuAtomicExch, etc.)
-enum GpuAtomicOp {
+pub enum GpuAtomicOp {
     GpuAtomAdd,
     GpuAtomCas,
     GpuAtomExch,
@@ -198,7 +198,7 @@ enum GpuAtomicOp {
 }
 
 // Phase 6: Cache hint for loads/stores (maps to PTX cache operators)
-enum GpuCacheHint {
+pub enum GpuCacheHint {
     GpuCacheDefault,  // .ca — cache at all levels (default)
     GpuCacheCA,       // .ca — cache at all levels
     GpuCacheCG,       // .cg — cache at L2 only
@@ -207,18 +207,18 @@ enum GpuCacheHint {
     GpuCacheCV,       // .cv — volatile (don't cache)
 }
 
-enum GpuEpistemicMode {
+pub enum GpuEpistemicMode {
     GpuEpistemicStrict,
     GpuEpistemicFast,
 }
 
-enum GpuError {
+pub enum GpuError {
     GpuOk,
     GpuOpBufferOverflow,
 }
 
 // Phase 7: Multi-target profile and legalization contracts.
-enum GpuTargetVendor {
+pub enum GpuTargetVendor {
     GpuVendorCuda,
     GpuVendorRocm,
     GpuVendorSpirv,
@@ -226,21 +226,21 @@ enum GpuTargetVendor {
     GpuVendorUnknown,
 }
 
-enum GpuTargetMemoryModel {
+pub enum GpuTargetMemoryModel {
     GpuMemoryCuda,
     GpuMemoryHsa,
     GpuMemorySpirv,
     GpuMemoryUnknown,
 }
 
-enum GpuBinaryFormat {
+pub enum GpuBinaryFormat {
     GpuBinaryFatbin,
     GpuBinaryCubin,
     GpuBinaryHsaco,
     GpuBinaryMulti,
 }
 
-enum GpuWorkloadTag {
+pub enum GpuWorkloadTag {
     GpuWorkloadGeneral,
     GpuWorkloadMl,
     GpuWorkloadOnn,
@@ -252,7 +252,7 @@ enum GpuWorkloadTag {
     GpuWorkloadExceptional,
 }
 
-enum GpuLegalizationCode {
+pub enum GpuLegalizationCode {
     GpuLegalizationPass,
     GpuLegalizationTensorCoreUnavailable,
     GpuLegalizationAsyncCopyUnavailable,
@@ -261,15 +261,15 @@ enum GpuLegalizationCode {
 }
 
 pub struct GpuTargetProfile {
-    vendor: GpuTargetVendor,
-    arch: Name,
-    warp_width: i64,
-    wave_width: i64,
-    supports_tensor_core: bool,
-    supports_async_copy: bool,
-    supports_tf32: bool,
-    supports_fp16: bool,
-    memory_model: GpuTargetMemoryModel,
+    pub vendor: GpuTargetVendor,
+    pub arch: Name,
+    pub warp_width: i64,
+    pub wave_width: i64,
+    pub supports_tensor_core: bool,
+    pub supports_async_copy: bool,
+    pub supports_tf32: bool,
+    pub supports_fp16: bool,
+    pub memory_model: GpuTargetMemoryModel,
 }
 
 struct GpuOpCapabilityRequirement {
@@ -288,102 +288,102 @@ struct GpuLegalizationDiagnostic {
 }
 
 pub struct GpuKernelSsaV2 {
-    version_major: i64,
-    version_minor: i64,
-    pipeline_id: Name,
-    provenance_tag: Name,
-    workload_tag: GpuWorkloadTag,
-    target_profile: GpuTargetProfile,
-    source_kernel: GpuKernelIr,
-    capability_reqs: [GpuOpCapabilityRequirement; 1024],
-    capability_req_count: i64,
-    diagnostics: [GpuLegalizationDiagnostic; 1024],
-    diagnostic_count: i64,
+    pub version_major: i64,
+    pub version_minor: i64,
+    pub pipeline_id: Name,
+    pub provenance_tag: Name,
+    pub workload_tag: GpuWorkloadTag,
+    pub target_profile: GpuTargetProfile,
+    pub source_kernel: GpuKernelIr,
+    pub capability_reqs: [GpuOpCapabilityRequirement; 1024],
+    pub capability_req_count: i64,
+    pub diagnostics: [GpuLegalizationDiagnostic; 1024],
+    pub diagnostic_count: i64,
 }
 
 // Return value used by checked op append APIs.
 pub struct GpuAppendResult {
-    result_kernel: GpuKernelIr,
-    error: GpuError,
+    pub result_kernel: GpuKernelIr,
+    pub error: GpuError,
 }
 
 // GPU operation (struct with all possible fields, like IrInstr)
 pub struct GpuOp {
-    opcode: GpuOpcode,
-    dst_reg: i64,
-    src_reg: i64,
-    lhs_reg: i64,
-    rhs_reg: i64,
-    addr_reg: i64,
-    rhs_imm: i64,
-    param_idx: i64,
-    axis: i64,  // 0=x, 1=y, 2=z for GetTid
-    shared_addr: i64,  // Shared memory address/offset
-    ty: GpuType,
-    dst_ty: GpuType,
-    src_ty: GpuType,
+    pub opcode: GpuOpcode,
+    pub dst_reg: i64,
+    pub src_reg: i64,
+    pub lhs_reg: i64,
+    pub rhs_reg: i64,
+    pub addr_reg: i64,
+    pub rhs_imm: i64,
+    pub param_idx: i64,
+    pub axis: i64,  // 0=x, 1=y, 2=z for GetTid
+    pub shared_addr: i64,  // Shared memory address/offset
+    pub ty: GpuType,
+    pub dst_ty: GpuType,
+    pub src_ty: GpuType,
     // Phase 5 extensions
-    memory_space: GpuMemorySpace,   // Address space for load/store ops
-    pred_reg: i64,                  // Predicate register for conditional ops (-1 = none)
-    mask: i64,                      // Warp mask for shuffle/vote ops (0xFFFFFFFF = all lanes)
+    pub memory_space: GpuMemorySpace,   // Address space for load/store ops
+    pub pred_reg: i64,                  // Predicate register for conditional ops (-1 = none)
+    pub mask: i64,                      // Warp mask for shuffle/vote ops (0xFFFFFFFF = all lanes)
     // Phase 6 extensions
-    atomic_op: GpuAtomicOp,         // Operation selector for atomic ops
-    cache_hint: GpuCacheHint,       // Cache policy for loads/stores
-    compare_reg: i64,               // CAS compare value register (-1 = none)
-    num_regs: i64,                  // Tile register count (tensor core fragments)
-    byte_offset: i64,               // Byte offset for cp.async
-    scope: i64,                     // Fence scope: 0=cta, 1=gl, 2=sys
-    cg_size: i64,                   // Cooperative group size (tiled_partition width)
+    pub atomic_op: GpuAtomicOp,         // Operation selector for atomic ops
+    pub cache_hint: GpuCacheHint,       // Cache policy for loads/stores
+    pub compare_reg: i64,               // CAS compare value register (-1 = none)
+    pub num_regs: i64,                  // Tile register count (tensor core fragments)
+    pub byte_offset: i64,               // Byte offset for cp.async
+    pub scope: i64,                     // Fence scope: 0=cta, 1=gl, 2=sys
+    pub cg_size: i64,                   // Cooperative group size (tiled_partition width)
 }
 
 // GPU kernel parameter (e.g., .param .u64 param_a)
 pub struct GpuParam {
-    name: Name,
-    ty: GpuType,
+    pub name: Name,
+    pub ty: GpuType,
 }
 
 // GPU kernel IR (represents a single kernel)
 pub struct GpuKernelIr {
-    kernel_name: Name,
-    workload_tag: GpuWorkloadTag,
-    params: [GpuParam; 8],
-    param_count: i64,
+    pub kernel_name: Name,
+    pub workload_tag: GpuWorkloadTag,
+    pub params: [GpuParam; 8],
+    pub param_count: i64,
     // Stage-5 hardening target: allow up to 1024 IR ops per kernel
     // (large enough for the shared-memory/tiled-family kernels in this phase).
-    ops: [GpuOp; 1024],
-    op_count: i64,
+    pub ops: [GpuOp; 1024],
+    pub op_count: i64,
 
     // Shared-memory region size (in bytes) used by this kernel.
     // 0 means no dynamic shared declaration.
-    shared_bytes: i64,
+    pub shared_bytes: i64,
 
     // Register allocation info (simple for now)
-    max_reg_u32: i64,
-    max_reg_u64: i64,
-    max_reg_f32: i64,
-    max_reg_f64: i64,
-    max_reg_i32: i64,
-    max_reg_i64: i64,
-    max_reg_pred: i64,
+    pub max_reg_u32: i64,
+    pub max_reg_u64: i64,
+    pub max_reg_f32: i64,
+    pub max_reg_f64: i64,
+    pub max_reg_i32: i64,
+    pub max_reg_i64: i64,
+    pub max_reg_pred: i64,
     // Phase 5 extensions
-    shared_mem_bytes: i64,  // Total shared memory allocated (bytes)
-    max_threads: i64,       // Maximum threads per block hint (0 = default)
+    pub shared_mem_bytes: i64,  // Total shared memory allocated (bytes)
+    pub max_threads: i64,       // Maximum threads per block hint (0 = default)
     // Phase 6 extensions
-    num_barriers: i64,      // Named barrier count (bar.sync n)
-    cta_size_x: i64,        // Compile-time blockDim.x (0 = dynamic)
-    cta_size_y: i64,        // Compile-time blockDim.y (0 = dynamic)
-    cta_size_z: i64,        // Compile-time blockDim.z (0 = dynamic)
-    cluster_x: i64,         // Thread block cluster dim x (sm_90+, 0 = none)
-    cluster_y: i64,         // Thread block cluster dim y (sm_90+, 0 = none)
+    pub num_barriers: i64,      // Named barrier count (bar.sync n)
+    pub cta_size_x: i64,        // Compile-time blockDim.x (0 = dynamic)
+    pub cta_size_y: i64,        // Compile-time blockDim.y (0 = dynamic)
+    pub cta_size_z: i64,        // Compile-time blockDim.z (0 = dynamic)
+    pub cluster_x: i64,         // Thread block cluster dim x (sm_90+, 0 = none)
+    pub cluster_y: i64,         // Thread block cluster dim y (sm_90+, 0 = none)
 }
 
 // Lowered module: collection of kernels post-HLIR-to-GPU lowering, pre-optimization.
 pub struct HlirGpuLoweredModule {
-    kernels: [GpuKernelIr; 64],
-    kernel_count: i64,
+    pub kernels: [GpuKernelIr; 64],
+    pub kernel_count: i64,
 }
 
-fn hlir_gpu_lowered_module_new() -> HlirGpuLoweredModule {
+pub fn hlir_gpu_lowered_module_new() -> HlirGpuLoweredModule {
     HlirGpuLoweredModule {
         kernels: [gpu_kernel_new(); 64],
         kernel_count: 0,
@@ -392,7 +392,7 @@ fn hlir_gpu_lowered_module_new() -> HlirGpuLoweredModule {
 
 // Constructors and helpers
 
-fn gpu_kernel_new() -> GpuKernelIr {
+pub fn gpu_kernel_new() -> GpuKernelIr {
     GpuKernelIr {
         kernel_name: ki_empty_name(),
         workload_tag: GpuWorkloadTag::GpuWorkloadGeneral,
@@ -419,11 +419,11 @@ fn gpu_kernel_new() -> GpuKernelIr {
     }
 }
 
-fn gpu_kernel_max_ops() -> i64 {
+pub fn gpu_kernel_max_ops() -> i64 {
     1024
 }
 
-fn gpu_append_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
+pub fn gpu_append_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
     if kernel.op_count >= gpu_kernel_max_ops() {
         GpuAppendResult { result_kernel: kernel, error: GpuError::GpuOpBufferOverflow }
     } else {
@@ -434,28 +434,28 @@ fn gpu_append_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with
     }
 }
 
-fn gpu_add_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
+pub fn gpu_add_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
     gpu_append_op_checked(kernel, op)
 }
 
-fn gpu_append_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_append_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
     let out = gpu_append_op_checked(kernel, op)
     out.result_kernel
 }
 
-fn gpu_add_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_add_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
     let out = gpu_add_op_checked(kernel, op)
     out.result_kernel
 }
 
-fn gpu_param_new() -> GpuParam {
+pub fn gpu_param_new() -> GpuParam {
     GpuParam {
         name: ki_empty_name(),
         ty: GpuType::GpuU64,
     }
 }
 
-fn gpu_op_new() -> GpuOp {
+pub fn gpu_op_new() -> GpuOp {
     GpuOp {
         opcode: GpuOpcode::GpuRet,
         dst_reg: -1,
@@ -483,7 +483,7 @@ fn gpu_op_new() -> GpuOp {
     }
 }
 
-fn gpu_target_vendor_to_string(vendor: GpuTargetVendor) -> string {
+pub fn gpu_target_vendor_to_string(vendor: GpuTargetVendor) -> string {
     match vendor {
         GpuTargetVendor::GpuVendorCuda => "cuda"
         GpuTargetVendor::GpuVendorRocm => "rocm"
@@ -502,7 +502,7 @@ fn gpu_binary_format_to_string(fmt: GpuBinaryFormat) -> string {
     }
 }
 
-fn gpu_workload_tag_to_string(tag: GpuWorkloadTag) -> string {
+pub fn gpu_workload_tag_to_string(tag: GpuWorkloadTag) -> string {
     match tag {
         GpuWorkloadTag::GpuWorkloadGeneral => "general"
         GpuWorkloadTag::GpuWorkloadMl => "ml"
@@ -536,7 +536,7 @@ fn gpu_target_profile_unknown() -> GpuTargetProfile {
     }
 }
 
-fn gpu_target_profile_cuda_sm80() -> GpuTargetProfile with Mut, Panic, Div {
+pub fn gpu_target_profile_cuda_sm80() -> GpuTargetProfile with Mut, Panic, Div {
     var arch = ki_ir_name_from_bytes(99, 117, 100, 97, 9)  // "cuda-sm80"
     arch.buf[4] = 45   // '-'
     arch.buf[5] = 115  // 's'
@@ -703,7 +703,7 @@ fn gpu_kernel_ssa_v2_new(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKe
     }
 }
 
-fn gpu_legalize_kernel_to_ssa_v2(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKernelSsaV2 with Mut, Panic, Div {
+pub fn gpu_legalize_kernel_to_ssa_v2(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKernelSsaV2 with Mut, Panic, Div {
     var out = gpu_kernel_ssa_v2_new(kernel, target)
     var i: i64 = 0
     while i < kernel.op_count {
@@ -722,11 +722,11 @@ fn gpu_legalize_kernel_to_ssa_v2(kernel: GpuKernelIr, target: GpuTargetProfile) 
     out
 }
 
-fn gpu_ssa_v2_is_legal(ssa: GpuKernelSsaV2) -> bool {
+pub fn gpu_ssa_v2_is_legal(ssa: GpuKernelSsaV2) -> bool {
     ssa.diagnostic_count == 0
 }
 
-fn gpu_type_to_string(ty: GpuType) -> string {
+pub fn gpu_type_to_string(ty: GpuType) -> string {
     match ty {
         GpuType::GpuU32  => "u32",
         GpuType::GpuU64  => "u64",

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -3,8 +3,11 @@
 // Converts GpuKernelIr to PTX text using the ptx.sio emitter functions.
 // This is "phase 1" of GPU codegen: structured IR-driven lowering.
 
+use gpu::kernel_ir::*
+use gpu::ptx::*
+
 // Lower a complete GPU kernel IR to PTX
-fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     var buf = ptx_buf_new()
 
     // 1. Emit header (.version, .target, .address_size)
@@ -1159,7 +1162,7 @@ fn gpu_reg_i32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r"
 fn gpu_reg_i64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
 
 // Helper: Convert Name to string
-fn name_to_string(name: Name) -> string with Mut, Panic, Div, Alloc {
+pub fn name_to_string(name: Name) -> string with Mut, Panic, Div, Alloc {
     str_from_bytes(name.buf, name.len)
 }
 
@@ -1175,7 +1178,7 @@ fn gpu_shared_addr_str(offset: i64) -> string with Mut, Panic, Div, Alloc {
 }
 
 // Helper: Convert i64 to string
-fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
+pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
     if n < 0 {
         return "0"
     }
@@ -1214,7 +1217,7 @@ fn gpu_push_name(buf: PtxBuf, name: Name) -> PtxBuf with Mut, Panic, Div {
 }
 
 // Helper: Push i64 as ASCII digits directly into PtxBuf (avoids i64_to_string UAF)
-fn gpu_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
+pub fn gpu_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
     if n == 0 { return ptx_push_byte(buf, 48) }
     var value: i64 = if n < 0 { 0 } else { n }
     var digits: [i8; 20] = [0; 20]

--- a/self-hosted/gpu/metal.sio
+++ b/self-hosted/gpu/metal.sio
@@ -21,12 +21,12 @@
 // MetalBuf — text buffer (same pattern as PtxBuf)
 // ============================================================================
 
-struct MetalBuf {
-    data: [i8; 65536],
-    len: i64,
+pub struct MetalBuf {
+    pub data: [i8; 65536],
+    pub len: i64,
 }
 
-fn metal_buf_new() -> MetalBuf {
+pub fn metal_buf_new() -> MetalBuf {
     MetalBuf { data: [0; 65536], len: 0 }
 }
 
@@ -40,7 +40,7 @@ fn metal_push_byte(buf: MetalBuf, b: i8) -> MetalBuf with Mut, Panic {
 }
 
 // Append one MetalBuf to another.
-fn metal_buf_append(dst: MetalBuf, src: MetalBuf) -> MetalBuf with Mut, Panic, Div {
+pub fn metal_buf_append(dst: MetalBuf, src: MetalBuf) -> MetalBuf with Mut, Panic, Div {
     var out = dst
     var i: i64 = 0
     while i < src.len {
@@ -1359,7 +1359,7 @@ fn metal_lower_single_op(buf: MetalBuf, op: GpuOp, kernel: GpuKernelIr) -> Metal
 // Main entry: GpuKernelIr → MetalBuf
 // ============================================================================
 
-fn gpu_lower_to_metal(kernel: GpuKernelIr) -> MetalBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_lower_to_metal(kernel: GpuKernelIr) -> MetalBuf with Mut, Panic, Div, Alloc {
     var buf = metal_buf_new()
     buf = metal_emit_header(buf)
     buf = metal_emit_kernel_signature(buf, kernel)

--- a/self-hosted/gpu/opt/autotune.sio
+++ b/self-hosted/gpu/opt/autotune.sio
@@ -142,10 +142,10 @@ fn gpu_kernel_profile_new() -> GpuKernelProfile {
     }
 }
 
-struct GpuBlockShape {
-    x: i64,
-    y: i64,
-    z: i64,
+pub struct GpuBlockShape {
+    pub x: i64,
+    pub y: i64,
+    pub z: i64,
 }
 
 fn gpu_block_shape_new_1d(x: i64) -> GpuBlockShape {
@@ -160,7 +160,7 @@ fn gpu_block_shape_new_3d(x: i64, y: i64, z: i64) -> GpuBlockShape {
     GpuBlockShape { x: x, y: y, z: z }
 }
 
-fn gpu_block_shape_total_threads(shape: GpuBlockShape) -> i64 {
+pub fn gpu_block_shape_total_threads(shape: GpuBlockShape) -> i64 {
     shape.x * shape.y * shape.z
 }
 
@@ -173,12 +173,12 @@ fn gpu_block_shape_warps(shape: GpuBlockShape) -> i64 with Panic, Div {
     }
 }
 
-struct GpuTileConfig {
-    tile_m: i64,
-    tile_n: i64,
-    tile_k: i64,
-    pipeline_stages: i64,
-    swizzled: bool,
+pub struct GpuTileConfig {
+    pub tile_m: i64,
+    pub tile_n: i64,
+    pub tile_k: i64,
+    pub pipeline_stages: i64,
+    pub swizzled: bool,
 }
 
 fn gpu_tile_config_default() -> GpuTileConfig {
@@ -191,12 +191,12 @@ fn gpu_tile_config_default() -> GpuTileConfig {
     }
 }
 
-struct GpuOccupancyInfo {
-    occupancy_pct: i64,
-    active_warps: i64,
-    max_warps: i64,
-    active_blocks: i64,
-    limiter: i64,
+pub struct GpuOccupancyInfo {
+    pub occupancy_pct: i64,
+    pub active_warps: i64,
+    pub max_warps: i64,
+    pub active_blocks: i64,
+    pub limiter: i64,
 }
 
 fn gpu_occupancy_info_zero() -> GpuOccupancyInfo {
@@ -210,14 +210,14 @@ fn gpu_occupancy_info_zero() -> GpuOccupancyInfo {
 }
 
 pub struct GpuTunedConfig {
-    block_shape: GpuBlockShape,
-    shared_mem_bytes: i64,
-    has_tile_config: bool,
-    tile_config: GpuTileConfig,
-    occupancy: GpuOccupancyInfo,
-    confidence_pct: i64,
-    strategy: i64,
-    rationale: string,
+    pub block_shape: GpuBlockShape,
+    pub shared_mem_bytes: i64,
+    pub has_tile_config: bool,
+    pub tile_config: GpuTileConfig,
+    pub occupancy: GpuOccupancyInfo,
+    pub confidence_pct: i64,
+    pub strategy: i64,
+    pub rationale: string,
 }
 
 fn gpu_tuned_config_default() -> GpuTunedConfig {
@@ -245,16 +245,16 @@ struct GpuArchConstants {
     warp_size: i64,
 }
 
-struct GpuAutoTuneConfig {
-    target: GpuTarget,
-    sm_major: i64,
-    sm_minor: i64,
-    default_strategy: i64,
-    prefer_tensor_cores: bool,
-    min_occupancy_pct: i64,
+pub struct GpuAutoTuneConfig {
+    pub target: GpuTarget,
+    pub sm_major: i64,
+    pub sm_minor: i64,
+    pub default_strategy: i64,
+    pub prefer_tensor_cores: bool,
+    pub min_occupancy_pct: i64,
 }
 
-fn gpu_autotune_config_default() -> GpuAutoTuneConfig {
+pub fn gpu_autotune_config_default() -> GpuAutoTuneConfig {
     GpuAutoTuneConfig {
         target: GpuTarget::GpuTargetPtx,
         sm_major: 8,
@@ -1284,7 +1284,7 @@ fn gpu_autotune_generate_rationale(
 // Top-level tuning API
 // ============================================================================
 
-fn gpu_autotune_tune_kernel(
+pub fn gpu_autotune_tune_kernel(
     kernel: GpuKernelIr,
     cfg: GpuAutoTuneConfig
 ) -> GpuTunedConfig with Mut, Panic, Div, Alloc {
@@ -1368,7 +1368,7 @@ fn gpu_autotune_tune_kernels(
     result.1
 }
 
-fn hlir_gpu_apply_autotune(
+pub fn hlir_gpu_apply_autotune(
     lowered: HlirGpuLoweredModule,
     cfg: GpuAutoTuneConfig
 ) -> HlirGpuLoweredModule with Mut, Panic, Div, Alloc {
@@ -1378,13 +1378,13 @@ fn hlir_gpu_apply_autotune(
     out
 }
 
-fn hlir_gpu_apply_autotune_default(
+pub fn hlir_gpu_apply_autotune_default(
     lowered: HlirGpuLoweredModule
 ) -> HlirGpuLoweredModule with Mut, Panic, Div, Alloc {
     hlir_gpu_apply_autotune(lowered, gpu_autotune_config_default())
 }
 
-fn hlir_gpu_apply_fusion_then_autotune(
+pub fn hlir_gpu_apply_fusion_then_autotune(
     lowered: HlirGpuLoweredModule,
     fusion_cfg: GpuFusionConfig,
     tune_cfg: GpuAutoTuneConfig
@@ -1393,7 +1393,7 @@ fn hlir_gpu_apply_fusion_then_autotune(
     hlir_gpu_apply_autotune(fused, tune_cfg)
 }
 
-fn hlir_gpu_apply_fusion_then_autotune_default(
+pub fn hlir_gpu_apply_fusion_then_autotune_default(
     lowered: HlirGpuLoweredModule
 ) -> HlirGpuLoweredModule with Mut, Panic, Div, Alloc {
     let fused = hlir_gpu_apply_fusion_default(lowered)

--- a/self-hosted/gpu/opt/fusion.sio
+++ b/self-hosted/gpu/opt/fusion.sio
@@ -18,14 +18,14 @@ let GPU_FUSION_MAX_OPS: i64 = 1024
 let GPU_FUSION_MAX_SHARED_BYTES: i64 = 233472
 
 pub struct GpuFusionConfig {
-    max_rounds: i64,
-    max_ops_per_kernel: i64,
-    max_shared_bytes: i64,
-    min_benefit_score: i64,
-    max_register_sum: i64,
+    pub max_rounds: i64,
+    pub max_ops_per_kernel: i64,
+    pub max_shared_bytes: i64,
+    pub min_benefit_score: i64,
+    pub max_register_sum: i64,
 }
 
-fn gpu_fusion_config_default() -> GpuFusionConfig {
+pub fn gpu_fusion_config_default() -> GpuFusionConfig {
     GpuFusionConfig {
         max_rounds: 8,
         max_ops_per_kernel: GPU_FUSION_MAX_OPS,
@@ -134,8 +134,18 @@ fn gpu_fusion_merge_thread_hint(a: GpuKernelIr, b: GpuKernelIr) -> i64 {
     }
 }
 
+fn gpu_name_eq(a: Name, b: Name) -> bool {
+    if a.len != b.len { return false }
+    var i: i64 = 0
+    while i < a.len {
+        if a.buf[i as usize] != b.buf[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
 fn gpu_fusion_param_eq(a: GpuParam, b: GpuParam) -> bool with Mut, Panic, Div {
-    ir_name_eq(a.name, b.name) && a.ty == b.ty
+    gpu_name_eq(a.name, b.name) && a.ty == b.ty
 }
 
 fn gpu_fusion_param_find_index(params: [GpuParam; 8], count: i64, p: GpuParam) -> i64 with Mut, Panic, Div {
@@ -149,7 +159,7 @@ fn gpu_fusion_param_find_index(params: [GpuParam; 8], count: i64, p: GpuParam) -
     -1
 }
 
-fn gpu_fusion_overlap_params(a: GpuKernelIr, b: GpuKernelIr) -> i64 with Mut, Panic, Div {
+pub fn gpu_fusion_overlap_params(a: GpuKernelIr, b: GpuKernelIr) -> i64 with Mut, Panic, Div {
     var overlap: i64 = 0
     var i: i64 = 0
     while i < a.param_count {
@@ -231,7 +241,7 @@ fn gpu_fusion_can_fuse_pair(left: GpuKernelIr, right: GpuKernelIr, cfg: GpuFusio
     true
 }
 
-fn gpu_fusion_score_pair(left: GpuKernelIr, right: GpuKernelIr) -> i64 with Mut, Panic, Div {
+pub fn gpu_fusion_score_pair(left: GpuKernelIr, right: GpuKernelIr) -> i64 with Mut, Panic, Div {
     let rl = gpu_fusion_resource_from_kernel(left)
     let rr = gpu_fusion_resource_from_kernel(right)
 
@@ -549,7 +559,7 @@ fn gpu_fusion_append_ops(
     (out, ok)
 }
 
-fn gpu_fuse_pair(left: GpuKernelIr, right: GpuKernelIr) -> (GpuKernelIr, bool) with Mut, Panic, Div {
+pub fn gpu_fuse_pair(left: GpuKernelIr, right: GpuKernelIr) -> (GpuKernelIr, bool) with Mut, Panic, Div {
     let prepared = gpu_fusion_build_param_map(left, right)
     var fused = prepared.0
     let right_param_map = prepared.1
@@ -688,7 +698,7 @@ fn gpu_fusion_apply_once(
     (out, count - 1)
 }
 
-fn gpu_fusion_run(
+pub fn gpu_fusion_run(
     kernels: [GpuKernelIr; 64],
     count: i64,
     cfg: GpuFusionConfig
@@ -717,7 +727,7 @@ fn gpu_fusion_run_default(
     gpu_fusion_run(kernels, count, gpu_fusion_config_default())
 }
 
-fn hlir_gpu_apply_fusion(
+pub fn hlir_gpu_apply_fusion(
     lowered: HlirGpuLoweredModule,
     cfg: GpuFusionConfig
 ) -> HlirGpuLoweredModule with Mut, Panic, Div {
@@ -728,7 +738,7 @@ fn hlir_gpu_apply_fusion(
     out
 }
 
-fn hlir_gpu_apply_fusion_default(lowered: HlirGpuLoweredModule) -> HlirGpuLoweredModule with Mut, Panic, Div {
+pub fn hlir_gpu_apply_fusion_default(lowered: HlirGpuLoweredModule) -> HlirGpuLoweredModule with Mut, Panic, Div {
     hlir_gpu_apply_fusion(lowered, gpu_fusion_config_default())
 }
 

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -10,17 +10,17 @@
 // - Host-side launch (CUDA Driver API) or static assembly path
 
 pub struct PtxBuf {
-    data: [i8; 65536],
-    len: i64,
+    pub data: [i8; 65536],
+    pub len: i64,
 }
 
 pub var PTX_TO_STRING_BUF: [i8; 65536] = [0; 65536]
 
-fn ptx_buf_new() -> PtxBuf {
+pub fn ptx_buf_new() -> PtxBuf {
     PtxBuf { data: [0; 65536], len: 0 }
 }
 
-fn ptx_push_byte(buf: PtxBuf, b: i8) -> PtxBuf with Mut, Panic {
+pub fn ptx_push_byte(buf: PtxBuf, b: i8) -> PtxBuf with Mut, Panic {
     var out = buf
     if out.len >= 0 {
         if out.len < 65536 {
@@ -31,7 +31,7 @@ fn ptx_push_byte(buf: PtxBuf, b: i8) -> PtxBuf with Mut, Panic {
     out
 }
 
-fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     let n = str_len(s)
     var i: i64 = 0
@@ -45,7 +45,7 @@ fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
     if n == 0 { return ptx_push_byte(buf, 48) }
     var value: i64 = if n < 0 { 0 } else { n }
     var digits: [i8; 20] = [0 as i8; 20]
@@ -64,7 +64,7 @@ fn ptx_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
+pub fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
     let nlen = str_len(needle)
     if nlen == 0 { return true }
     if buf.len < nlen { return false }
@@ -86,7 +86,7 @@ fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
     false
 }
 
-fn ptx_to_string(buf: PtxBuf) -> string with Mut, Panic {
+pub fn ptx_to_string(buf: PtxBuf) -> string with Mut, Panic {
     var i: i64 = 0
     while i < buf.len {
         PTX_TO_STRING_BUF[i as usize] = buf.data[i as usize]
@@ -96,7 +96,7 @@ fn ptx_to_string(buf: PtxBuf) -> string with Mut, Panic {
     str_from_bytes(PTX_TO_STRING_BUF, buf.len)
 }
 
-fn ptx_str_contains(haystack: string, needle: string) -> bool with Mut, Panic, Div {
+pub fn ptx_str_contains(haystack: string, needle: string) -> bool with Mut, Panic, Div {
     // Self-hosted-friendly substring check.
     //
     // NOTE: The VM has a `contains` builtin, but we keep a local implementation
@@ -124,7 +124,7 @@ fn ptx_str_contains(haystack: string, needle: string) -> bool with Mut, Panic, D
     false
 }
 
-fn ptx_trim_leading_spaces(s: string) -> string with Mut, Panic, Div {
+pub fn ptx_trim_leading_spaces(s: string) -> string with Mut, Panic, Div {
     let n = str_len(s)
     var i: i64 = 0
 
@@ -139,7 +139,7 @@ fn ptx_trim_leading_spaces(s: string) -> string with Mut, Panic, Div {
     str_slice(s, i, n)
 }
 
-fn ptx_has_predicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_predicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -171,7 +171,7 @@ fn ptx_has_predicated_opcode(haystack: string, opcode: string) -> bool with Mut,
     false
 }
 
-fn ptx_has_predicated_opcode_with_pred(haystack: string, opcode: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_predicated_opcode_with_pred(haystack: string, opcode: string, pred: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -202,7 +202,7 @@ fn ptx_has_predicated_opcode_with_pred(haystack: string, opcode: string, pred: s
     false
 }
 
-fn ptx_has_predicate_token(line: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_predicate_token(line: string, pred: string) -> bool with Mut, Panic, Div {
     let token_with_space_prefix = " " ++ pred ++ ","
     let token_with_delim = pred ++ ","
     let token_with_space_suffix = ", " ++ pred ++ ","
@@ -228,7 +228,7 @@ fn ptx_has_predicate_token(line: string, pred: string) -> bool with Mut, Panic, 
     false
 }
 
-fn ptx_has_setp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_setp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -259,7 +259,7 @@ fn ptx_has_setp_with_pred(haystack: string, pred: string) -> bool with Mut, Pani
     false
 }
 
-fn ptx_has_selp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_selp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -290,7 +290,7 @@ fn ptx_has_selp_with_pred(haystack: string, pred: string) -> bool with Mut, Pani
     false
 }
 
-fn ptx_has_unpredicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_unpredicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -324,203 +324,203 @@ fn ptx_has_unpredicated_opcode(haystack: string, opcode: string) -> bool with Mu
 // Core PTX emitter pieces used for deterministic text scaffolding.
 // Keeps phase-0 output stable and easy to extend in later PTX-first passes.
 
-fn ptx_header_version() -> string { "7.0" }
+pub fn ptx_header_version() -> string { "7.0" }
 
-fn ptx_header_target() -> string { "sm_50" }
+pub fn ptx_header_target() -> string { "sm_50" }
 
-fn ptx_header_address_size() -> string { ".address_size 64" }
+pub fn ptx_header_address_size() -> string { ".address_size 64" }
 
-fn ptx_opcode_mov_u32() -> string { "mov.u32" }
+pub fn ptx_opcode_mov_u32() -> string { "mov.u32" }
 
-fn ptx_opcode_cvt_u64_u32() -> string { "cvt.u64.u32" }
+pub fn ptx_opcode_cvt_u64_u32() -> string { "cvt.u64.u32" }
 
-fn ptx_opcode_mul_lo_u64() -> string { "mul.lo.u64" }
+pub fn ptx_opcode_mul_lo_u64() -> string { "mul.lo.u64" }
 
-fn ptx_opcode_ld_param_u64() -> string { "ld.param.u64" }
-fn ptx_opcode_ld_param_u32() -> string { "ld.param.u32" }
-fn ptx_opcode_ld_param_u16() -> string { "ld.param.u16" }
+pub fn ptx_opcode_ld_param_u64() -> string { "ld.param.u64" }
+pub fn ptx_opcode_ld_param_u32() -> string { "ld.param.u32" }
+pub fn ptx_opcode_ld_param_u16() -> string { "ld.param.u16" }
 
-fn ptx_opcode_add_u64() -> string { "add.u64" }
+pub fn ptx_opcode_add_u64() -> string { "add.u64" }
 
-fn ptx_opcode_ld_global_f32() -> string { "ld.global.f32" }
+pub fn ptx_opcode_ld_global_f32() -> string { "ld.global.f32" }
 
-fn ptx_opcode_add_f32() -> string { "add.f32" }
+pub fn ptx_opcode_add_f32() -> string { "add.f32" }
 
-fn ptx_opcode_st_global_f32() -> string { "st.global.f32" }
+pub fn ptx_opcode_st_global_f32() -> string { "st.global.f32" }
 
-fn ptx_opcode_ret() -> string { "ret" }
+pub fn ptx_opcode_ret() -> string { "ret" }
 
 // Type-specific opcodes for f64/i32/i64
-fn ptx_opcode_add_f64() -> string { "add.f64" }
+pub fn ptx_opcode_add_f64() -> string { "add.f64" }
 
-fn ptx_opcode_add_s32() -> string { "add.s32" }
+pub fn ptx_opcode_add_s32() -> string { "add.s32" }
 
-fn ptx_opcode_add_s64() -> string { "add.s64" }
+pub fn ptx_opcode_add_s64() -> string { "add.s64" }
 
-fn ptx_opcode_ld_global_f64() -> string { "ld.global.f64" }
+pub fn ptx_opcode_ld_global_f64() -> string { "ld.global.f64" }
 
-fn ptx_opcode_ld_global_s32() -> string { "ld.global.s32" }
+pub fn ptx_opcode_ld_global_s32() -> string { "ld.global.s32" }
 
-fn ptx_opcode_ld_global_s64() -> string { "ld.global.s64" }
+pub fn ptx_opcode_ld_global_s64() -> string { "ld.global.s64" }
 
-fn ptx_opcode_st_global_f64() -> string { "st.global.f64" }
+pub fn ptx_opcode_st_global_f64() -> string { "st.global.f64" }
 
-fn ptx_opcode_st_global_s32() -> string { "st.global.s32" }
+pub fn ptx_opcode_st_global_s32() -> string { "st.global.s32" }
 
-fn ptx_opcode_ld_global_u32() -> string { "ld.global.u32" }
+pub fn ptx_opcode_ld_global_u32() -> string { "ld.global.u32" }
 
-fn ptx_opcode_st_global_u32() -> string { "st.global.u32" }
+pub fn ptx_opcode_st_global_u32() -> string { "st.global.u32" }
 
-fn ptx_opcode_st_global_s64() -> string { "st.global.s64" }
+pub fn ptx_opcode_st_global_s64() -> string { "st.global.s64" }
 
 // Element-wise operation opcodes (sub/mul/div for all types)
-fn ptx_opcode_sub_f32() -> string { "sub.f32" }
+pub fn ptx_opcode_sub_f32() -> string { "sub.f32" }
 
-fn ptx_opcode_sub_f64() -> string { "sub.f64" }
+pub fn ptx_opcode_sub_f64() -> string { "sub.f64" }
 
-fn ptx_opcode_sub_s32() -> string { "sub.s32" }
+pub fn ptx_opcode_sub_s32() -> string { "sub.s32" }
 
-fn ptx_opcode_sub_s64() -> string { "sub.s64" }
+pub fn ptx_opcode_sub_s64() -> string { "sub.s64" }
 
-fn ptx_opcode_sub_u64() -> string { "sub.u64" }
+pub fn ptx_opcode_sub_u64() -> string { "sub.u64" }
 
-fn ptx_opcode_mul_lo_f32() -> string { "mul.rn.f32" }
+pub fn ptx_opcode_mul_lo_f32() -> string { "mul.rn.f32" }
 
-fn ptx_opcode_mul_lo_f64() -> string { "mul.rn.f64" }
+pub fn ptx_opcode_mul_lo_f64() -> string { "mul.rn.f64" }
 
-fn ptx_opcode_mul_lo_s32() -> string { "mul.lo.s32" }
+pub fn ptx_opcode_mul_lo_s32() -> string { "mul.lo.s32" }
 
-fn ptx_opcode_mul_lo_s64() -> string { "mul.lo.s64" }
+pub fn ptx_opcode_mul_lo_s64() -> string { "mul.lo.s64" }
 
-fn ptx_opcode_div_f32() -> string { "div.rn.f32" }
+pub fn ptx_opcode_div_f32() -> string { "div.rn.f32" }
 
-fn ptx_opcode_div_f64() -> string { "div.rn.f64" }
+pub fn ptx_opcode_div_f64() -> string { "div.rn.f64" }
 
-fn ptx_opcode_div_s32() -> string { "div.s32" }
+pub fn ptx_opcode_div_s32() -> string { "div.s32" }
 
-fn ptx_opcode_div_s64() -> string { "div.s64" }
+pub fn ptx_opcode_div_s64() -> string { "div.s64" }
 
-fn ptx_opcode_div_u64() -> string { "div.u64" }
+pub fn ptx_opcode_div_u64() -> string { "div.u64" }
 
 // Reduction operations - max
-fn ptx_opcode_max_f32() -> string { "max.f32" }
+pub fn ptx_opcode_max_f32() -> string { "max.f32" }
 
-fn ptx_opcode_max_f64() -> string { "max.f64" }
+pub fn ptx_opcode_max_f64() -> string { "max.f64" }
 
-fn ptx_opcode_max_s32() -> string { "max.s32" }
+pub fn ptx_opcode_max_s32() -> string { "max.s32" }
 
-fn ptx_opcode_max_s64() -> string { "max.s64" }
+pub fn ptx_opcode_max_s64() -> string { "max.s64" }
 
-fn ptx_opcode_max_u32() -> string { "max.u32" }
+pub fn ptx_opcode_max_u32() -> string { "max.u32" }
 
-fn ptx_opcode_max_u64() -> string { "max.u64" }
+pub fn ptx_opcode_max_u64() -> string { "max.u64" }
 
 // Reduction operations - min
-fn ptx_opcode_min_f32() -> string { "min.f32" }
+pub fn ptx_opcode_min_f32() -> string { "min.f32" }
 
-fn ptx_opcode_min_f64() -> string { "min.f64" }
+pub fn ptx_opcode_min_f64() -> string { "min.f64" }
 
-fn ptx_opcode_min_s32() -> string { "min.s32" }
+pub fn ptx_opcode_min_s32() -> string { "min.s32" }
 
-fn ptx_opcode_min_s64() -> string { "min.s64" }
+pub fn ptx_opcode_min_s64() -> string { "min.s64" }
 
-fn ptx_opcode_min_u32() -> string { "min.u32" }
+pub fn ptx_opcode_min_u32() -> string { "min.u32" }
 
-fn ptx_opcode_min_u64() -> string { "min.u64" }
+pub fn ptx_opcode_min_u64() -> string { "min.u64" }
 
 // Atomic operations
-fn ptx_opcode_atom_add_f32() -> string { "atom.add.f32" }
+pub fn ptx_opcode_atom_add_f32() -> string { "atom.add.f32" }
 
-fn ptx_opcode_atom_add_f64() -> string { "atom.add.f64" }
+pub fn ptx_opcode_atom_add_f64() -> string { "atom.add.f64" }
 
-fn ptx_opcode_atom_add_s32() -> string { "atom.add.s32" }
+pub fn ptx_opcode_atom_add_s32() -> string { "atom.add.s32" }
 
-fn ptx_opcode_atom_add_u32() -> string { "atom.add.u32" }
+pub fn ptx_opcode_atom_add_u32() -> string { "atom.add.u32" }
 
 // Shared memory operations
-fn ptx_opcode_ld_shared_f32() -> string { "ld.shared.f32" }
+pub fn ptx_opcode_ld_shared_f32() -> string { "ld.shared.f32" }
 
-fn ptx_opcode_ld_shared_f64() -> string { "ld.shared.f64" }
+pub fn ptx_opcode_ld_shared_f64() -> string { "ld.shared.f64" }
 
-fn ptx_opcode_st_shared_f32() -> string { "st.shared.f32" }
+pub fn ptx_opcode_st_shared_f32() -> string { "st.shared.f32" }
 
-fn ptx_opcode_st_shared_f64() -> string { "st.shared.f64" }
+pub fn ptx_opcode_st_shared_f64() -> string { "st.shared.f64" }
 
-fn ptx_opcode_ld_shared_s32() -> string { "ld.shared.s32" }
+pub fn ptx_opcode_ld_shared_s32() -> string { "ld.shared.s32" }
 
-fn ptx_opcode_st_shared_s32() -> string { "st.shared.s32" }
+pub fn ptx_opcode_st_shared_s32() -> string { "st.shared.s32" }
 
 // Predicate operations
-fn ptx_opcode_setp_lt_u32() -> string { "setp.lt.u32" }
+pub fn ptx_opcode_setp_lt_u32() -> string { "setp.lt.u32" }
 
-fn ptx_opcode_setp_lt_s32() -> string { "setp.lt.s32" }
+pub fn ptx_opcode_setp_lt_s32() -> string { "setp.lt.s32" }
 
-fn ptx_opcode_setp_lt_f32() -> string { "setp.lt.f32" }
-fn ptx_opcode_setp_lt_u64() -> string { "setp.lt.u64" }
-fn ptx_opcode_setp_lt_s64() -> string { "setp.lt.s64" }
-fn ptx_opcode_setp_lt_f64() -> string { "setp.lt.f64" }
+pub fn ptx_opcode_setp_lt_f32() -> string { "setp.lt.f32" }
+pub fn ptx_opcode_setp_lt_u64() -> string { "setp.lt.u64" }
+pub fn ptx_opcode_setp_lt_s64() -> string { "setp.lt.s64" }
+pub fn ptx_opcode_setp_lt_f64() -> string { "setp.lt.f64" }
 
-fn ptx_opcode_setp_le_u32() -> string { "setp.le.u32" }
+pub fn ptx_opcode_setp_le_u32() -> string { "setp.le.u32" }
 
-fn ptx_opcode_setp_le_s32() -> string { "setp.le.s32" }
+pub fn ptx_opcode_setp_le_s32() -> string { "setp.le.s32" }
 
-fn ptx_opcode_setp_le_f32() -> string { "setp.le.f32" }
-fn ptx_opcode_setp_le_u64() -> string { "setp.le.u64" }
+pub fn ptx_opcode_setp_le_f32() -> string { "setp.le.f32" }
+pub fn ptx_opcode_setp_le_u64() -> string { "setp.le.u64" }
 
-fn ptx_opcode_setp_ge_u32() -> string { "setp.ge.u32" }
+pub fn ptx_opcode_setp_ge_u32() -> string { "setp.ge.u32" }
 
-fn ptx_opcode_setp_ge_s32() -> string { "setp.ge.s32" }
+pub fn ptx_opcode_setp_ge_s32() -> string { "setp.ge.s32" }
 
-fn ptx_opcode_setp_ge_s64() -> string { "setp.ge.s64" }
+pub fn ptx_opcode_setp_ge_s64() -> string { "setp.ge.s64" }
 
-fn ptx_opcode_setp_ge_f32() -> string { "setp.ge.f32" }
+pub fn ptx_opcode_setp_ge_f32() -> string { "setp.ge.f32" }
 
-fn ptx_opcode_setp_ge_f64() -> string { "setp.ge.f64" }
+pub fn ptx_opcode_setp_ge_f64() -> string { "setp.ge.f64" }
 
-fn ptx_opcode_setp_ge_u64() -> string { "setp.ge.u64" }
+pub fn ptx_opcode_setp_ge_u64() -> string { "setp.ge.u64" }
 
-fn ptx_opcode_setp_eq_u32() -> string { "setp.eq.u32" }
+pub fn ptx_opcode_setp_eq_u32() -> string { "setp.eq.u32" }
 
-fn ptx_opcode_setp_eq_s32() -> string { "setp.eq.s32" }
+pub fn ptx_opcode_setp_eq_s32() -> string { "setp.eq.s32" }
 
-fn ptx_opcode_setp_eq_f32() -> string { "setp.eq.f32" }
-fn ptx_opcode_setp_eq_u64() -> string { "setp.eq.u64" }
+pub fn ptx_opcode_setp_eq_f32() -> string { "setp.eq.f32" }
+pub fn ptx_opcode_setp_eq_u64() -> string { "setp.eq.u64" }
 
-fn ptx_opcode_selp_b32() -> string { "selp.b32" }
+pub fn ptx_opcode_selp_b32() -> string { "selp.b32" }
 
-fn ptx_opcode_selp_b64() -> string { "selp.b64" }
+pub fn ptx_opcode_selp_b64() -> string { "selp.b64" }
 
-fn ptx_opcode_selp_s32() -> string { "selp.b32" }
+pub fn ptx_opcode_selp_s32() -> string { "selp.b32" }
 
-fn ptx_opcode_selp_f32() -> string { "selp.f32" }
+pub fn ptx_opcode_selp_f32() -> string { "selp.f32" }
 
-fn ptx_opcode_selp_f64() -> string { "selp.f64" }
+pub fn ptx_opcode_selp_f64() -> string { "selp.f64" }
 
 // Warp shuffle operations
-fn ptx_opcode_shfl_down_b32() -> string { "shfl.sync.down.b32" }
+pub fn ptx_opcode_shfl_down_b32() -> string { "shfl.sync.down.b32" }
 
-fn ptx_opcode_shfl_down_b64() -> string { "shfl.sync.down.b64" }
+pub fn ptx_opcode_shfl_down_b64() -> string { "shfl.sync.down.b64" }
 
 // Phase 7: Warp shuffle up (for inclusive scan)
-fn ptx_opcode_shfl_up_b32() -> string { "shfl.sync.up.b32" }
+pub fn ptx_opcode_shfl_up_b32() -> string { "shfl.sync.up.b32" }
 
-fn ptx_opcode_shfl_up_b64() -> string { "shfl.sync.up.b64" }
+pub fn ptx_opcode_shfl_up_b64() -> string { "shfl.sync.up.b64" }
 
 // Phase 4: U32 arithmetic (for 2D index calculations)
-fn ptx_opcode_add_u32() -> string { "add.u32" }
+pub fn ptx_opcode_add_u32() -> string { "add.u32" }
 
-fn ptx_opcode_mul_lo_u32() -> string { "mul.lo.u32" }
+pub fn ptx_opcode_mul_lo_u32() -> string { "mul.lo.u32" }
 
 // Phase 4: FMA / MAD operations
-fn ptx_opcode_fma_rn_f32() -> string { "fma.rn.f32" }
+pub fn ptx_opcode_fma_rn_f32() -> string { "fma.rn.f32" }
 
-fn ptx_opcode_fma_rn_f64() -> string { "fma.rn.f64" }
+pub fn ptx_opcode_fma_rn_f64() -> string { "fma.rn.f64" }
 
-fn ptx_opcode_mad_lo_s32() -> string { "mad.lo.s32" }
+pub fn ptx_opcode_mad_lo_s32() -> string { "mad.lo.s32" }
 
-fn ptx_opcode_mad_lo_s64() -> string { "mad.lo.s64" }
+pub fn ptx_opcode_mad_lo_s64() -> string { "mad.lo.s64" }
 
-fn ptx_push_binary3(
+pub fn ptx_push_binary3(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -540,7 +540,7 @@ fn ptx_push_binary3(
     out
 }
 
-fn ptx_push_binary2(
+pub fn ptx_push_binary2(
     buf: PtxBuf,
     opcode: string,
     lhs: string,
@@ -557,7 +557,7 @@ fn ptx_push_binary2(
     out
 }
 
-fn ptx_push_binary_mem2(
+pub fn ptx_push_binary_mem2(
     buf: PtxBuf,
     opcode: string,
     dst_or_dst_ptr: string,
@@ -574,7 +574,7 @@ fn ptx_push_binary_mem2(
     out
 }
 
-fn ptx_push_store_mem(
+pub fn ptx_push_store_mem(
     buf: PtxBuf,
     opcode: string,
     dst_ptr: string,
@@ -591,7 +591,7 @@ fn ptx_push_store_mem(
     out
 }
 
-fn ptx_emit_shared_decl(
+pub fn ptx_emit_shared_decl(
     buf: PtxBuf,
     bytes: i64
 ) -> PtxBuf with Mut, Panic, Div, Alloc {
@@ -602,17 +602,17 @@ fn ptx_emit_shared_decl(
     out
 }
 
-fn ptx_push_ret(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_ret(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     ptx_push_str(buf, "    ret;\n")
 }
 
 // Reduction helper functions
 
-fn ptx_push_barrier_sync(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_barrier_sync(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     ptx_push_str(buf, "    bar.sync 0;\n")
 }
 
-fn ptx_push_shfl_down(
+pub fn ptx_push_shfl_down(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -632,7 +632,7 @@ fn ptx_push_shfl_down(
     out
 }
 
-fn ptx_push_setp2(
+pub fn ptx_push_setp2(
     buf: PtxBuf,
     opcode: string,
     dst_pred: string,
@@ -652,7 +652,7 @@ fn ptx_push_setp2(
     out
 }
 
-fn ptx_push_selp(
+pub fn ptx_push_selp(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -675,7 +675,7 @@ fn ptx_push_selp(
     out
 }
 
-fn ptx_push_predicated_mem2(
+pub fn ptx_push_predicated_mem2(
     buf: PtxBuf,
     opcode: string,
     pred: string,
@@ -695,7 +695,7 @@ fn ptx_push_predicated_mem2(
     out
 }
 
-fn ptx_push_predicated_store_mem(
+pub fn ptx_push_predicated_store_mem(
     buf: PtxBuf,
     opcode: string,
     pred: string,
@@ -715,7 +715,7 @@ fn ptx_push_predicated_store_mem(
     out
 }
 
-fn ptx_push_atomic_add(
+pub fn ptx_push_atomic_add(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -735,7 +735,7 @@ fn ptx_push_atomic_add(
     out
 }
 
-fn ptx_push_ld_shared(
+pub fn ptx_push_ld_shared(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -752,7 +752,7 @@ fn ptx_push_ld_shared(
     out
 }
 
-fn ptx_push_st_shared(
+pub fn ptx_push_st_shared(
     buf: PtxBuf,
     opcode: string,
     addr: string,
@@ -770,7 +770,7 @@ fn ptx_push_st_shared(
 }
 
 // Phase 4: FMA emitter (4-operand: dst = a * b + c)
-fn ptx_push_fma(
+pub fn ptx_push_fma(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -794,7 +794,7 @@ fn ptx_push_fma(
 }
 
 // Phase 4: Special register move (ctaid.x, ntid.x, etc.)
-fn ptx_push_mov_special(
+pub fn ptx_push_mov_special(
     buf: PtxBuf,
     special: string,
     axis: string,
@@ -812,7 +812,7 @@ fn ptx_push_mov_special(
 }
 
 // Phase 4: Add immediate (reg + immediate constant)
-fn ptx_push_add_imm(
+pub fn ptx_push_add_imm(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -832,7 +832,7 @@ fn ptx_push_add_imm(
     out
 }
 
-fn ptx_emit_header(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_header(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     out = ptx_push_str(out, ".version ")
     out = ptx_push_str(out, ptx_header_version())
@@ -845,7 +845,7 @@ fn ptx_emit_header(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_emit_vec_add_signature(
+pub fn ptx_emit_vec_add_signature(
     buf: PtxBuf,
     kernel_name: string,
     param_a: string,
@@ -868,7 +868,7 @@ fn ptx_emit_vec_add_signature(
     out
 }
 
-fn ptx_emit_vec_add_reg_decl(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_add_reg_decl(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     out = ptx_push_str(out, "{\n")
     out = ptx_push_str(out, "    .reg .pred %p<2>;\n")
@@ -878,7 +878,7 @@ fn ptx_emit_vec_add_reg_decl(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_emit_vec_add_body(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_add_body(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     out = ptx_push_binary2(out, ptx_opcode_mov_u32(), "%r1", "%tid.x")
     out = ptx_push_binary2(out, ptx_opcode_mov_u32(), "%r2", "%ctaid.x")
@@ -901,7 +901,7 @@ fn ptx_emit_vec_add_body(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_emit_vec3_f32_add(
+pub fn ptx_emit_vec3_f32_add(
     buf: PtxBuf,
     out0: string,
     in0_0: string,
@@ -921,7 +921,7 @@ fn ptx_emit_vec3_f32_add(
 }
 
 // Append one PtxBuf to another. Used to concatenate multiple kernel PTX outputs.
-fn ptx_buf_append(dst: PtxBuf, src: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_buf_append(dst: PtxBuf, src: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = dst
     var i: i64 = 0
     while i < src.len {
@@ -935,7 +935,7 @@ fn ptx_buf_append(dst: PtxBuf, src: PtxBuf) -> PtxBuf with Mut, Panic, Div {
 }
 
 // Print a PtxBuf to stdout.
-fn ptx_buf_print(buf: PtxBuf) with IO, Mut, Panic, Div {
+pub fn ptx_buf_print(buf: PtxBuf) with IO, Mut, Panic, Div {
     var i: i64 = 0
     while i < buf.len {
         print_char(buf.data[i as usize] as i64)
@@ -943,7 +943,7 @@ fn ptx_buf_print(buf: PtxBuf) with IO, Mut, Panic, Div {
     }
 }
 
-fn ptx_emit_demo_vec_add() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_demo_vec_add() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_add", "param_a", "param_b", "param_c")
@@ -952,7 +952,7 @@ fn ptx_emit_demo_vec_add() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_epistemic_dual_output_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_epistemic_dual_output_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry epistemic_dual_output_f32(\n")
@@ -1022,7 +1022,7 @@ fn ptx_emit_epistemic_dual_output_f32() -> PtxBuf with Mut, Panic, Div {
 
 // ── Extended kernel emitters (Phase 2) ──────────────────────────────
 
-fn ptx_emit_vec_sub_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_sub_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_sub", "param_a", "param_b", "param_c")
@@ -1045,7 +1045,7 @@ fn ptx_emit_vec_sub_f32() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_mul_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_mul_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_mul", "param_a", "param_b", "param_c")
@@ -1068,7 +1068,7 @@ fn ptx_emit_vec_mul_f32() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_div_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_div_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_div", "param_a", "param_b", "param_c")
@@ -1091,7 +1091,7 @@ fn ptx_emit_vec_div_f32() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_add_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_add_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_add_f64", "param_a", "param_b", "param_c")
@@ -1118,7 +1118,7 @@ fn ptx_emit_vec_add_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_fma_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_fma_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry fma_f32(\n")
@@ -1155,7 +1155,7 @@ fn ptx_emit_fma_f32() -> PtxBuf with Mut, Panic, Div {
 
 // ── f64 variants ────────────────────────────────────────────────────
 
-fn ptx_emit_vec_sub_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_sub_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_sub_f64", "param_a", "param_b", "param_c")
@@ -1182,7 +1182,7 @@ fn ptx_emit_vec_sub_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_mul_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_mul_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_mul_f64", "param_a", "param_b", "param_c")
@@ -1209,7 +1209,7 @@ fn ptx_emit_vec_mul_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_div_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_div_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_div_f64", "param_a", "param_b", "param_c")
@@ -1236,7 +1236,7 @@ fn ptx_emit_vec_div_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_fma_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_fma_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry fma_f64(\n")
@@ -1273,7 +1273,7 @@ fn ptx_emit_fma_f64() -> PtxBuf with Mut, Panic, Div {
 
 // ── store_u32_const emitter ─────────────────────────────────────────
 
-fn ptx_emit_store_u32_const() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_store_u32_const() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry store_u32_const(\n")

--- a/self-hosted/gpu/spirv.sio
+++ b/self-hosted/gpu/spirv.sio
@@ -133,15 +133,15 @@ let BUILTIN_WORKGROUP_SIZE: i64 = 25
 // ============================================================================
 
 pub struct SpvBuf {
-    words: [i64; 1024],    // SPIR-V words (stored as i64, but only low 32 bits matter)
-    word_count: i64,
+    pub words: [i64; 1024],    // SPIR-V words (stored as i64, but only low 32 bits matter)
+    pub word_count: i64,
 }
 
-fn spv_buf_new() -> SpvBuf {
+pub fn spv_buf_new() -> SpvBuf {
     SpvBuf { words: [0; 1024], word_count: 0 }
 }
 
-fn spv_push_word(buf: SpvBuf, w: i64) -> SpvBuf with Mut, Panic {
+pub fn spv_push_word(buf: SpvBuf, w: i64) -> SpvBuf with Mut, Panic {
     var out = buf
     if out.word_count < 1024 {
         out.words[out.word_count as usize] = w % 4294967296  // mask to 32 bits
@@ -1059,7 +1059,7 @@ fn spv_lower_single_op(state: SpvCompileState, opcode: i64, dst_reg: i64, src_a_
 // 5. gpu_lower_to_spirv — full pipeline entry point
 // ============================================================================
 
-fn gpu_lower_to_spirv(kernel_name: string, param_count: i64, ops_opcodes: [i64; 256], ops_dst: [i64; 256], ops_src_a: [i64; 256], ops_src_b: [i64; 256], ops_type_tags: [i64; 256], ops_imm: [i64; 256], ops_count: i64) -> SpvBuf with Mut, Panic, Div {
+pub fn gpu_lower_to_spirv(kernel_name: string, param_count: i64, ops_opcodes: [i64; 256], ops_dst: [i64; 256], ops_src_a: [i64; 256], ops_src_b: [i64; 256], ops_type_tags: [i64; 256], ops_imm: [i64; 256], ops_count: i64) -> SpvBuf with Mut, Panic, Div {
     var s = spv_compile_state_new()
 
     // We build the module body first, then prepend the header with the final ID bound.

--- a/self-hosted/hlir/ir.sio
+++ b/self-hosted/hlir/ir.sio
@@ -46,8 +46,8 @@ let HLIR_UNIT_VALUE: i64 = 2147483647   // u32::MAX equivalent
 // ============================================================================
 
 pub struct HlirName {
-    buf: [i8; 128],
-    len: i64,
+    pub buf: [i8; 128],
+    pub len: i64,
 }
 
 pub fn hlir_empty_name() -> HlirName {
@@ -90,7 +90,7 @@ pub fn hlir_name_to_string(n: HlirName) -> string with Mut, Panic, Div, Alloc {
 // codegen: aggressive paths for validated data, precision-preserving paths
 // for uncertain data, GPU kernel extraction for GPU-effected functions.
 
-enum CompileStrategy {
+pub enum CompileStrategy {
     StrategyStandard,           // default — standard native compilation
     StrategyAggressive,         // pure + Validated<T> — full inlining, SIMD, no guards
     StrategyPrecisionPreserving,// pure + Knowledge<T> — no float reassociation, interval tracking
@@ -103,7 +103,7 @@ enum CompileStrategy {
 // HLIR Type System
 // ============================================================================
 
-enum HlirTypeKind {
+pub enum HlirTypeKind {
     HlirTypeVoid,
     HlirTypeBool,
     HlirTypeI8,
@@ -158,7 +158,7 @@ enum HlirTypeKind {
 }
 
 // Epistemic mode for Knowledge types
-enum EpistemicMode {
+pub enum EpistemicMode {
     EpistemicDefault,
     EpistemicStrict,
     EpistemicRelaxed,
@@ -167,21 +167,21 @@ enum EpistemicMode {
 // Full type descriptor (flat struct, no recursive Box<HlirType>)
 // For compound types, inner_type_idx points into a type table.
 pub struct HlirType {
-    kind: HlirTypeKind,
+    pub kind: HlirTypeKind,
     // For Ptr: index of pointed-to type in module type table
-    inner_type_idx: i64,
+    pub inner_type_idx: i64,
     // For Array: element count
-    array_len: i64,
+    pub array_len: i64,
     // For Struct: struct name
-    name: HlirName,
+    pub name: HlirName,
     // For Tuple/Function: element type indices stored in type_elems
-    type_elems: [i64; 32],
-    type_elem_count: i64,
+    pub type_elems: [i64; 32],
+    pub type_elem_count: i64,
     // For Function: index of return type (last elem is return)
     // For Knowledge: epistemic metadata
-    epistemic_mode: EpistemicMode,
-    epsilon_bound: f64,         // -1.0 = not set
-    provenance_id: i64,         // -1 = not set
+    pub epistemic_mode: EpistemicMode,
+    pub epsilon_bound: f64,         // -1.0 = not set
+    pub provenance_id: i64,         // -1 = not set
 }
 
 pub fn hlir_type_void() -> HlirType {
@@ -649,7 +649,7 @@ let HLIR_UNARY_NOT: i64 = 2
 // Constants
 // ============================================================================
 
-enum HlirConstKind {
+pub enum HlirConstKind {
     HlirConstUnit,
     HlirConstBool,
     HlirConstInt,
@@ -665,17 +665,17 @@ enum HlirConstKind {
 }
 
 pub struct HlirConstant {
-    kind: HlirConstKind,
-    bool_val: bool,
-    int_val: i64,
-    float_val: f64,
-    string_val: HlirName,
-    ty: HlirType,
+    pub kind: HlirConstKind,
+    pub bool_val: bool,
+    pub int_val: i64,
+    pub float_val: f64,
+    pub string_val: HlirName,
+    pub ty: HlirType,
     // For Array/Struct constants: child constant indices in a const table
-    elem_indices: [i64; 64],
-    elem_count: i64,
+    pub elem_indices: [i64; 64],
+    pub elem_count: i64,
     // For FunctionRef/GlobalRef
-    ref_name: HlirName,
+    pub ref_name: HlirName,
 }
 
 pub fn hlir_const_unit() -> HlirConstant {
@@ -786,7 +786,7 @@ pub fn hlir_const_func_ref(name: HlirName) -> HlirConstant {
 // Instructions (SSA operations)
 // ============================================================================
 
-enum HlirOpKind {
+pub enum HlirOpKind {
     HlirOpConst,
     HlirOpCopy,
     HlirOpBinary,
@@ -813,117 +813,117 @@ enum HlirOpKind {
 }
 
 // Explicit numeric opcode tags used by bootstrap-safe builders.
-let HLIR_OP_CONST: i64 = 0
-let HLIR_OP_COPY: i64 = 1
-let HLIR_OP_BINARY: i64 = 2
-let HLIR_OP_UNARY: i64 = 3
-let HLIR_OP_CALL: i64 = 4
-let HLIR_OP_CALL_DIRECT: i64 = 5
-let HLIR_OP_LOAD: i64 = 6
-let HLIR_OP_STORE: i64 = 7
-let HLIR_OP_GET_FIELD_PTR: i64 = 8
-let HLIR_OP_GET_ELEMENT_PTR: i64 = 9
-let HLIR_OP_ALLOCA: i64 = 10
-let HLIR_OP_CAST: i64 = 11
-let HLIR_OP_PHI: i64 = 12
-let HLIR_OP_EXTRACT_VALUE: i64 = 13
-let HLIR_OP_INSERT_VALUE: i64 = 14
-let HLIR_OP_TUPLE: i64 = 15
-let HLIR_OP_ARRAY: i64 = 16
-let HLIR_OP_STRUCT: i64 = 17
-let HLIR_OP_PERFORM_EFFECT: i64 = 18
-let HLIR_OP_PUSH_HANDLER: i64 = 19
-let HLIR_OP_POP_HANDLER: i64 = 20
-let HLIR_OP_DISPATCH_EFFECT: i64 = 21
-let HLIR_OP_SELECT: i64 = 22
+pub let HLIR_OP_CONST: i64 = 0
+pub let HLIR_OP_COPY: i64 = 1
+pub let HLIR_OP_BINARY: i64 = 2
+pub let HLIR_OP_UNARY: i64 = 3
+pub let HLIR_OP_CALL: i64 = 4
+pub let HLIR_OP_CALL_DIRECT: i64 = 5
+pub let HLIR_OP_LOAD: i64 = 6
+pub let HLIR_OP_STORE: i64 = 7
+pub let HLIR_OP_GET_FIELD_PTR: i64 = 8
+pub let HLIR_OP_GET_ELEMENT_PTR: i64 = 9
+pub let HLIR_OP_ALLOCA: i64 = 10
+pub let HLIR_OP_CAST: i64 = 11
+pub let HLIR_OP_PHI: i64 = 12
+pub let HLIR_OP_EXTRACT_VALUE: i64 = 13
+pub let HLIR_OP_INSERT_VALUE: i64 = 14
+pub let HLIR_OP_TUPLE: i64 = 15
+pub let HLIR_OP_ARRAY: i64 = 16
+pub let HLIR_OP_STRUCT: i64 = 17
+pub let HLIR_OP_PERFORM_EFFECT: i64 = 18
+pub let HLIR_OP_PUSH_HANDLER: i64 = 19
+pub let HLIR_OP_POP_HANDLER: i64 = 20
+pub let HLIR_OP_DISPATCH_EFFECT: i64 = 21
+pub let HLIR_OP_SELECT: i64 = 22
 
 // Flat instruction struct — all fields present, meaning depends on op_kind.
 // This is the self-hosted pattern (no enum field destructuring).
 pub struct HlirInstr {
-    result: i64,              // ValueId (-1 = no result, e.g. Store)
+    pub result: i64,              // ValueId (-1 = no result, e.g. Store)
     // Keep opcode tags as raw i64 for bootstrap compatibility.
-    op_kind: i64,
-    ty: HlirType,             // result type
+    pub op_kind: i64,
+    pub ty: HlirType,             // result type
 
     // For Const
-    constant: HlirConstant,
+    pub constant: HlirConstant,
 
     // For Copy, Load, Unary
-    src: i64,                 // ValueId
+    pub src: i64,                 // ValueId
 
     // For Binary
-    bin_op: i64,
-    lhs: i64,                 // ValueId
-    rhs: i64,                 // ValueId
+    pub bin_op: i64,
+    pub lhs: i64,                 // ValueId
+    pub rhs: i64,                 // ValueId
 
     // For Unary
-    un_op: i64,
+    pub un_op: i64,
 
     // For Call/CallDirect
-    call_func: i64,           // ValueId (for indirect Call)
-    call_name: HlirName,      // function name (for CallDirect)
-    call_args: [i64; 64],     // ValueId array
-    call_arg_count: i64,
+    pub call_func: i64,           // ValueId (for indirect Call)
+    pub call_name: HlirName,      // function name (for CallDirect)
+    pub call_args: [i64; 64],     // ValueId array
+    pub call_arg_count: i64,
 
     // For GetFieldPtr, ExtractValue, InsertValue
-    base: i64,                // ValueId
-    field_index: i64,
+    pub base: i64,                // ValueId
+    pub field_index: i64,
 
     // For GetElementPtr
-    index: i64,               // ValueId
+    pub index: i64,               // ValueId
 
     // For Store
-    store_ptr: i64,           // ValueId
-    store_value: i64,         // ValueId
+    pub store_ptr: i64,           // ValueId
+    pub store_value: i64,         // ValueId
 
     // For Alloca
-    alloca_ty: HlirType,
+    pub alloca_ty: HlirType,
 
     // For Cast
-    cast_value: i64,          // ValueId
-    cast_source: HlirType,
-    cast_target: HlirType,
+    pub cast_value: i64,          // ValueId
+    pub cast_source: HlirType,
+    pub cast_target: HlirType,
 
     // For Phi
-    phi_incoming: [HlirPhiEntry; 64],
-    phi_count: i64,
+    pub phi_incoming: [HlirPhiEntry; 64],
+    pub phi_count: i64,
 
     // For InsertValue
-    insert_value: i64,        // ValueId
+    pub insert_value: i64,        // ValueId
 
     // For Tuple/Array
-    elems: [i64; 64],         // ValueId array
-    elem_count: i64,
+    pub elems: [i64; 64],         // ValueId array
+    pub elem_count: i64,
 
     // For Struct
-    struct_name: HlirName,
-    struct_fields: [HlirStructFieldEntry; 128],
-    struct_field_count: i64,
+    pub struct_name: HlirName,
+    pub struct_fields: [HlirStructFieldEntry; 128],
+    pub struct_field_count: i64,
 
     // For PerformEffect/DispatchEffect
-    effect_name: HlirName,
-    effect_op: HlirName,
-    effect_args: [i64; 16],
-    effect_arg_count: i64,
+    pub effect_name: HlirName,
+    pub effect_op: HlirName,
+    pub effect_args: [i64; 16],
+    pub effect_arg_count: i64,
 
     // For PushHandler
-    handler_name: HlirName,
-    handler_id: i64,
+    pub handler_name: HlirName,
+    pub handler_id: i64,
 
     // For Select
-    select_cond: i64,         // ValueId
-    select_true: i64,         // ValueId
-    select_false: i64,        // ValueId
+    pub select_cond: i64,         // ValueId
+    pub select_true: i64,         // ValueId
+    pub select_false: i64,        // ValueId
 }
 
 pub struct HlirPhiEntry {
-    block_id: i64,
-    value_id: i64,
+    pub block_id: i64,
+    pub value_id: i64,
 }
 
 pub struct HlirStructFieldEntry {
-    name: HlirName,
-    value_id: i64,
+    pub name: HlirName,
+    pub value_id: i64,
 }
 
 pub fn hlir_phi_entry_empty() -> HlirPhiEntry {
@@ -982,7 +982,7 @@ pub fn hlir_instr_new(op: i64) -> HlirInstr {
 // Terminators
 // ============================================================================
 
-enum HlirTermKind {
+pub enum HlirTermKind {
     HlirTermReturn,
     HlirTermBranch,
     HlirTermCondBranch,
@@ -990,15 +990,15 @@ enum HlirTermKind {
     HlirTermUnreachable,
 }
 
-let HLIR_TERM_RETURN: i64 = 0
-let HLIR_TERM_BRANCH: i64 = 1
-let HLIR_TERM_COND_BRANCH: i64 = 2
-let HLIR_TERM_SWITCH: i64 = 3
-let HLIR_TERM_UNREACHABLE: i64 = 4
+pub let HLIR_TERM_RETURN: i64 = 0
+pub let HLIR_TERM_BRANCH: i64 = 1
+pub let HLIR_TERM_COND_BRANCH: i64 = 2
+pub let HLIR_TERM_SWITCH: i64 = 3
+pub let HLIR_TERM_UNREACHABLE: i64 = 4
 
 pub struct HlirSwitchCase {
-    value: i64,
-    target: i64,    // BlockId
+    pub value: i64,
+    pub target: i64,    // BlockId
 }
 
 pub fn hlir_switch_case_empty() -> HlirSwitchCase {
@@ -1007,20 +1007,20 @@ pub fn hlir_switch_case_empty() -> HlirSwitchCase {
 
 pub struct HlirTerminator {
     // Keep terminator kind as raw i64 for bootstrap compatibility.
-    kind: i64,
+    pub kind: i64,
     // Return
-    return_value: i64,       // ValueId (-1 = void return)
+    pub return_value: i64,       // ValueId (-1 = void return)
     // Branch
-    branch_target: i64,      // BlockId
+    pub branch_target: i64,      // BlockId
     // CondBranch
-    cond_value: i64,         // ValueId
-    then_block: i64,         // BlockId
-    else_block: i64,         // BlockId
+    pub cond_value: i64,         // ValueId
+    pub then_block: i64,         // BlockId
+    pub else_block: i64,         // BlockId
     // Switch
-    switch_value: i64,       // ValueId
-    switch_default: i64,     // BlockId
-    switch_cases: [HlirSwitchCase; 256],
-    switch_case_count: i64,
+    pub switch_value: i64,       // ValueId
+    pub switch_default: i64,     // BlockId
+    pub switch_cases: [HlirSwitchCase; 256],
+    pub switch_case_count: i64,
 }
 
 pub fn hlir_term_unreachable() -> HlirTerminator {
@@ -1091,8 +1091,8 @@ pub fn hlir_term_cond_branch(cond: i64, then_blk: i64, else_blk: i64) -> HlirTer
 // ============================================================================
 
 pub struct HlirBlockParam {
-    value_id: i64,
-    ty: HlirType,
+    pub value_id: i64,
+    pub ty: HlirType,
 }
 
 pub fn hlir_block_param_empty() -> HlirBlockParam {
@@ -1100,13 +1100,13 @@ pub fn hlir_block_param_empty() -> HlirBlockParam {
 }
 
 pub struct HlirBlock {
-    id: i64,                  // BlockId
-    label: HlirName,
-    params: [HlirBlockParam; 32],
-    param_count: i64,
-    instrs: [HlirInstr; 16384],
-    instr_count: i64,
-    terminator: HlirTerminator,
+    pub id: i64,                  // BlockId
+    pub label: HlirName,
+    pub params: [HlirBlockParam; 32],
+    pub param_count: i64,
+    pub instrs: [HlirInstr; 16384],
+    pub instr_count: i64,
+    pub terminator: HlirTerminator,
 }
 
 pub fn hlir_block_new(block_id: i64, label: HlirName) -> HlirBlock {
@@ -1125,7 +1125,7 @@ pub fn hlir_block_new(block_id: i64, label: HlirName) -> HlirBlock {
 // ABI
 // ============================================================================
 
-enum HlirAbi {
+pub enum HlirAbi {
     HlirAbiSounio,      // Default Sounio calling convention
     HlirAbiC,           // C calling convention
     HlirAbiSystem,      // Platform default
@@ -1137,9 +1137,9 @@ enum HlirAbi {
 // ============================================================================
 
 pub struct HlirParam {
-    value_id: i64,
-    name: HlirName,
-    ty: HlirType,
+    pub value_id: i64,
+    pub name: HlirName,
+    pub ty: HlirType,
 }
 
 pub fn hlir_param_empty() -> HlirParam {
@@ -1151,8 +1151,8 @@ pub fn hlir_param_empty() -> HlirParam {
 // ============================================================================
 
 pub struct HlirLocalEntry {
-    value_id: i64,
-    ty: HlirType,
+    pub value_id: i64,
+    pub ty: HlirType,
 }
 
 pub fn hlir_local_empty() -> HlirLocalEntry {
@@ -1164,23 +1164,23 @@ pub fn hlir_local_empty() -> HlirLocalEntry {
 // ============================================================================
 
 pub struct HlirFunction {
-    id: i64,                  // FunctionId
-    name: HlirName,
-    link_name: HlirName,     // empty = no link name
-    params: [HlirParam; 64],
-    param_count: i64,
-    return_type: HlirType,
-    effects: [HlirName; 16],
-    effect_count: i64,
-    blocks: [HlirBlock; 4096],
-    block_count: i64,
-    is_kernel: bool,
-    locals: [HlirLocalEntry; 8192],
-    local_count: i64,
-    is_variadic: bool,
-    abi: HlirAbi,
-    is_exported: bool,
-    compile_strategy: CompileStrategy,
+    pub id: i64,                  // FunctionId
+    pub name: HlirName,
+    pub link_name: HlirName,     // empty = no link name
+    pub params: [HlirParam; 64],
+    pub param_count: i64,
+    pub return_type: HlirType,
+    pub effects: [HlirName; 16],
+    pub effect_count: i64,
+    pub blocks: [HlirBlock; 4096],
+    pub block_count: i64,
+    pub is_kernel: bool,
+    pub locals: [HlirLocalEntry; 8192],
+    pub local_count: i64,
+    pub is_variadic: bool,
+    pub abi: HlirAbi,
+    pub is_exported: bool,
+    pub compile_strategy: CompileStrategy,
 }
 
 pub fn hlir_function_new(func_id: i64, name: HlirName) -> HlirFunction {
@@ -1271,12 +1271,12 @@ pub fn hlir_strategy_requires_strict_fp(s: CompileStrategy) -> bool {
 // ============================================================================
 
 pub struct HlirGlobal {
-    id: i64,                  // ValueId
-    name: HlirName,
-    ty: HlirType,
-    init: HlirConstant,      // HlirConstUnit = no initializer
-    has_init: bool,
-    is_const: bool,
+    pub id: i64,                  // ValueId
+    pub name: HlirName,
+    pub ty: HlirType,
+    pub init: HlirConstant,      // HlirConstUnit = no initializer
+    pub has_init: bool,
+    pub is_const: bool,
 }
 
 pub fn hlir_global_new(id: i64, name: HlirName, ty: HlirType) -> HlirGlobal {
@@ -1294,14 +1294,14 @@ pub fn hlir_global_new(id: i64, name: HlirName, ty: HlirType) -> HlirGlobal {
 // Type Definitions
 // ============================================================================
 
-enum HlirTypeDefKind {
+pub enum HlirTypeDefKind {
     HlirTypeDefStruct,
     HlirTypeDefEnum,
 }
 
 pub struct HlirTypeDefField {
-    name: HlirName,
-    ty: HlirType,
+    pub name: HlirName,
+    pub ty: HlirType,
 }
 
 pub fn hlir_typedef_field_empty() -> HlirTypeDefField {
@@ -1309,11 +1309,11 @@ pub fn hlir_typedef_field_empty() -> HlirTypeDefField {
 }
 
 pub struct HlirTypeDef {
-    name: HlirName,
-    kind: HlirTypeDefKind,
+    pub name: HlirName,
+    pub kind: HlirTypeDefKind,
     // Struct fields or enum variants
-    fields: [HlirTypeDefField; 128],
-    field_count: i64,
+    pub fields: [HlirTypeDefField; 128],
+    pub field_count: i64,
 }
 
 pub fn hlir_typedef_struct(name: HlirName) -> HlirTypeDef {
@@ -1330,13 +1330,13 @@ pub fn hlir_typedef_struct(name: HlirName) -> HlirTypeDef {
 // ============================================================================
 
 pub struct HlirModule {
-    name: HlirName,
-    functions: [HlirFunction; 1024],
-    fn_count: i64,
-    globals: [HlirGlobal; 512],
-    global_count: i64,
-    typedefs: [HlirTypeDef; 512],
-    typedef_count: i64,
+    pub name: HlirName,
+    pub functions: [HlirFunction; 1024],
+    pub fn_count: i64,
+    pub globals: [HlirGlobal; 512],
+    pub global_count: i64,
+    pub typedefs: [HlirTypeDef; 512],
+    pub typedef_count: i64,
 }
 
 pub fn hlir_module_new(name: HlirName) -> HlirModule {


### PR DESCRIPTION
## Summary
- expose the HLIR/GPU IR types and backend buffer/emitter helpers required by the self-hosted GPU bridge
- add missing imports for lower_to_ptx so it resolves kernel_ir and ptx APIs directly
- replace stale fusion ir_name_eq usage with a local Name comparator

## Validation
- SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/ptx.sio
- SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/lower_to_ptx.sio
- SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/hlir_to_gpu.sio
- SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc check self-hosted/gpu/mod.sio
- bash check_sounio.sh --summary (baseline: 5824 checked, 5803 pass, 25 errors)
- scripts/ci/build_modular_madaros.sh /tmp/madaros-sota-gpu-hlir-bridge-20260627

LLM-offload reviews invoked: none (compiler/API visibility only; no math claims, clinical-pathway code, or external-facing artifacts).