### PR TITLE
fix(check): E009 ontology subsumption — accept subclass→parent call args in default Madaros

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -267,6 +267,13 @@ pub struct Checker {
     refine_violations: i64,       // predicates definitely violated (compile error)
     // Condition-narrowing guard stack: up to 8 nested if-conditions.
     refine_cond_env: RefineStaticEnv,
+    // Program items pointer, stored once during the in-place collect spine, so the
+    // deep expression-checking compat path can walk ontology class declarations
+    // for E009 subclass→parent subsumption. A single Option<Box<…>> field (one
+    // shallow write that persists, unlike deep ontology_kernel mutation) avoids
+    // both the un-writable kernel and threading the list through the call chain.
+    // Placed at struct end to keep all existing field offsets unchanged.
+    ontology_items: Option<Box<ItemList> >,
 }
 
 // Wrapper for inferred type arguments (avoids &![T;N] JIT bug)
@@ -899,6 +906,7 @@ fn checker_new() -> Checker with Mut, Panic, Div, Alloc {
         refine_runtime_checked: 0,
         refine_violations: 0,
         refine_cond_env: refine_static_env_new(),
+        ontology_items: None,
     }
 }
 
@@ -999,6 +1007,7 @@ fn checker_init_in_place(raw: *mut Checker) with Mut, Panic, Div, Alloc {
     (*raw).refine_runtime_checked = 0
     (*raw).refine_violations = 0
     (*raw).refine_cond_env = refine_static_env_new()
+    (*raw).ontology_items = None
 }
 
 fn checker_store_from_value(dst: *mut Checker, src: Checker) with Mut, Panic, Div, Alloc {
@@ -1094,6 +1103,7 @@ fn checker_store_from_value(dst: *mut Checker, src: Checker) with Mut, Panic, Di
     (*dst).refine_runtime_checked = src.refine_runtime_checked
     (*dst).refine_violations = src.refine_violations
     (*dst).refine_cond_env = src.refine_cond_env
+    (*dst).ontology_items = src.ontology_items
 }
 
 fn checker_note_type_error_mut(c: *mut Checker) with Mut {
@@ -3266,6 +3276,10 @@ fn checker_collect_type_alias_inplace(c: *mut Checker, name: Name, ty_opt: Optio
 }
 
 fn checker_collect_items_inplace(c: *mut Checker, items: Option<Box<ItemList> >) with Mut, Panic, Div, Alloc, IO {
+    // Stash the program items so the deep call-arg compat path can resolve
+    // ontology subclass relations by name (E009 subsumption). Single shallow
+    // pointer write — persists where deep ontology_kernel mutation does not.
+    (*c).ontology_items = items
     checker_collect_runtime_builtins_inplace(c)
     var cursor = items
     while true {
@@ -12776,6 +12790,56 @@ fn checker_types_compatible_inplace(c: *mut Checker, a: TypeEntry, b: TypeEntry)
     checker_fn_types_structurally_compatible_inplace(c, a, b)
 }
 
+// E009 ontology subsumption by name: walk the stored program items for child_name's
+// class declaration and recurse up its superclasses; true if parent_name is reached
+// (reflexive + transitive). Pure read-walk — works in the *mut spine where deep
+// ontology_kernel mutation does not. Depth-bounded against pathological cycles.
+fn checker_onto_name_subclass_walk(items: Option<Box<ItemList> >, child_name: Name, parent_name: Name, depth: i64) -> bool with Mut, Panic, Div, Alloc {
+    if name_eq(child_name, parent_name) {
+        return true
+    }
+    if depth > 64 {
+        return false
+    }
+    var cur = items
+    while true {
+        match cur {
+            Some(list) => {
+                let item = (*list).head
+                if item.kind == ItemKind::ItemOntology {
+                    match item.ontology_def {
+                        Some(odef) => {
+                            var ci = (*odef).classes
+                            while true {
+                                match ci {
+                                    Some(clist) => {
+                                        if name_eq((*clist).head.name, child_name) {
+                                            var s: i64 = 0
+                                            while s < (*clist).head.superclass_count && s < 8 {
+                                                let sname = (*clist).head.superclass_names[s as usize]
+                                                if checker_onto_name_subclass_walk(items, sname, parent_name, depth + 1) {
+                                                    return true
+                                                }
+                                                s = s + 1
+                                            }
+                                        }
+                                        ci = (*clist).tail
+                                    }
+                                    None => break
+                                }
+                            }
+                        }
+                        None => {}
+                    }
+                }
+                cur = (*list).tail
+            }
+            None => break
+        }
+    }
+    false
+}
+
 fn checker_call_arg_types_compatible_inplace(c: *mut Checker, arg_expr: Expr, arg_ty: TypeEntry, param_ty: TypeEntry) -> bool with Mut, Panic, Div, Alloc, IO {
     if checker_types_compatible_inplace(c, arg_ty, param_ty) {
         return true
@@ -12795,6 +12859,14 @@ fn checker_call_arg_types_compatible_inplace(c: *mut Checker, arg_expr: Expr, ar
     if arg_expr.kind == ExprKind::ExprIdent &&
        (param_ty.kind == TypeKind::TyRef || param_ty.kind == TypeKind::TyRefMut) {
         return checker_types_compatible_inplace(c, arg_ty, call_ref_inner_or_self(param_ty))
+    }
+    // Ontology subsumption: a subclass argument satisfies a parent-class parameter.
+    let exp_ty = call_ref_inner_or_self(param_ty)
+    let got_ty = call_ref_inner_or_self(arg_ty)
+    if !name_is_empty(got_ty.name) && !name_is_empty(exp_ty.name) && !name_eq(got_ty.name, exp_ty.name) {
+        if checker_onto_name_subclass_walk((*c).ontology_items, got_ty.name, exp_ty.name, 0) {
+            return true
+        }
     }
     false
 }


### PR DESCRIPTION
## Summary

Resolves **E009 ontology subsumption** in the default Madaros engine: a subclass argument passed where a parent ontology class is expected (incl. transitively) now type-checks, instead of being false-rejected. This is the completeness half of the ontology gap (#417); E041 weakening — the soundness half — was already fixed (#439).

## Why the obvious fix didn't work (and what does)

The `*mut` checking spine never collected `ItemOntology`, so the kernel subclass matrix was empty and no type carried an `ontology_id`. The natural fix — populate `(*c).ontology_kernel` in place — is **impossible**: verified via instrumented builds that deep-nested `*mut` struct mutation does not persist (`classes.count` stayed 0 immediately after the write; the `OntologyKernel` is too large to round-trip through the pointer, and the by-value kernel ops / 8MB-Checker SRET bridge are equally lossy).

Resolution that sidesteps the kernel entirely:
1. Store the program **items pointer** on the Checker (`ontology_items: Option<Box<ItemList>>`, placed at struct end so existing field offsets are unchanged) during the in-place collect spine — a single **shallow** field write, which *does* persist.
2. In `checker_call_arg_types_compatible_inplace`, resolve subclass relations **by name** via a depth-bounded transitive walk of the stored ontology class declarations (`checker_onto_name_subclass_walk`) — pure reads, which work in the `*mut` spine.

No kernel mutation, no large-struct stores, no new arrays.

## Verification (rebuilt Madaros, run 28291228725)

- subclass→parent run-pass fixtures **now ACCEPT**: ontology_subclass_accept, ontology_role_domain_accept, ontology_transitive, ontology_subsumption, ontology_complex_hierarchy, ontology_type_bridge (6/6 core; 21/31 of all `tests/run-pass/ontology*`).
- **Sound (no false-accept):** an unrelated/disjoint class passed where another is expected is still rejected with E009 (verified directly).
- **No regression:** the 4 ontology compile-fail axioms (E156/E157/E158/E159 + E041) still reject.
- madaros-full / enum / loop gates pass; typecheck parity vs origin/main baseline (17 == 17, no new errors).

The remaining `tests/run-pass/ontology*` failures are **separate pre-existing gaps, not regressions**: `ontology_typed_bridge_*` now fail with E137 (external-ontology import / unknown identifier — previously masked by the E009 failure) and `ontology_axiom_conjunction` with E001. Those are distinct features; the lean_single pin for them stays until addressed.

Closes the subsumption half of #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)