### PR TITLE
Fix imported Madaros runtime lowering

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -48,7 +48,7 @@ use resolve::scope::*
 
 use resolve::mod::{resolve_modules, resolve_program, ResolveBatchResult}
 use module_native_driver::{compile_multimodule_native, compile_multimodule_native_advanced, compile_multimodule_native_with_ir, compile_multimodule_native_maybe_streaming_for_target, compile_multimodule_llvm}
-use module_frontend::{load_multimodule_ir, load_multimodule_ir_traced, load_multimodule_ir_into, load_multimodule_ir_fn_count_traced, load_multimodule_ir_probe_summary, load_multimodule_ir_probe_summary_traced, empty_load_multimodule_ir_trace}
+use module_frontend::{load_multimodule_ir, load_multimodule_ir_traced, load_multimodule_ir_into, load_multimodule_ir_fn_count_traced, load_multimodule_ir_probe_summary, load_multimodule_ir_probe_summary_traced, empty_load_multimodule_ir_trace, module_frontend_compile_imported_to_file}
 use module_frontend::{preflight_multimodule_frontend, load_multimodule_epistemic_into, MultiModuleIrResult, MultiModuleFrontendResult, LoadMultimoduleIrTrace, empty_multimodule_ir_result, bridge_lower_single_module_box, ModuleFrontendLowerBoxResult, module_frontend_import_files_from_source, ImportPathList}
 use module_parse::{ImportList, load_module_file, extract_imports_from_ast, file_exists}
 use frontend_callsite_probe::{run_frontend_callsite_probe}
@@ -2879,12 +2879,58 @@ fn run_native_v2_emit_wide(args: ArgList, flag_index: i64, kind: i64) with IO, M
 // lost on SIGSEGV). Content is irrelevant — file existence is the signal. Uses a
 // zero-fill init ([0;N] is the codegen-safe array-fill form).
 var NV2_MARKER_BUF: [i8; 4] = [0; 4]
+var NV2_RUN_ARGV: [i64; 32] = [0; 32]
+var NV2_RUN_ENVP: [i64; 1] = [0; 1]
+
+fn native_v2_wait_exit_code(status: i64) -> i64 {
+    if (status & 127) == 0 {
+        return (status >> 8) & 255
+    }
+    128 + (status & 127)
+}
+
+fn native_v2_run_elf_and_exit(path: string, args: ArgList, flag_index: i64) with IO, Mut, Panic, Div {
+    syscall6(90, path, 493, 0, 0, 0, 0)
+    NV2_RUN_ARGV[0] = path as i64
+    var argv_len: i64 = 1
+    var passthrough: bool = false
+    var i: i64 = flag_index + 1
+    while i < args.len && argv_len < 31 {
+        let arg = arg_list_get(args, i)
+        if passthrough {
+            NV2_RUN_ARGV[argv_len as usize] = arg as i64
+            argv_len = argv_len + 1
+        } else if arg == "--" {
+            passthrough = true
+        }
+        i = i + 1
+    }
+    NV2_RUN_ARGV[argv_len as usize] = 0
+    NV2_RUN_ENVP[0] = 0
+
+    let pid = syscall6(57, 0, 0, 0, 0, 0, 0)
+    if pid < 0 {
+        print("native_v2_compile: run fork failed\n")
+        syscall6(60, 127, 0, 0, 0, 0, 0)
+        return
+    }
+    if pid == 0 {
+        syscall6(59, path as i64, &! NV2_RUN_ARGV, &! NV2_RUN_ENVP, 0, 0, 0)
+        syscall6(60, 127, 0, 0, 0, 0, 0)
+        return
+    }
+
+    var status: i64 = 0
+    syscall6(61, pid, &! status, 0, 0, 0, 0)
+    syscall6(60, native_v2_wait_exit_code(status), 0, 0, 0, 0, 0)
+}
 
 // Bridge: real .sio SOURCE -> multimodule front-half -> IrModule -> native-v2 -> ELF.
 // Keep this on load_multimodule_ir_traced, the same front-half exercised by
 // --probe-load-ir-trace. The older boxed single-module bridge is fragile in
 // native-built Madaros before the first crash marker on trivial programs.
 fn run_native_v2_compile_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Alloc {
+    let execute_after_compile = arg_list_get(args, flag_index) == "run"
     let source_path = compiler_mode_source_arg(args, flag_index, "--native-v2-compile")
     // Output path resolution: `-o <out>` wins; otherwise honor a second
     // positional argument (`mc --native-v2-compile src.sio out.elf`); else a.out.
@@ -2894,6 +2940,20 @@ fn run_native_v2_compile_mode(args: ArgList, flag_index: i64) with IO, Mut, Pani
     let out_path = compiler_mode_output_path(args, out_positional)
     if !compiler_preflight_source_input(source_path) {
         panic("native-v2-compile failed: source not readable")
+    }
+    if module_frontend_file_maybe_has_use(source_path) {
+        let imported_rc = module_frontend_compile_imported_to_file(source_path, out_path)
+        if imported_rc != 0 {
+            print("native_v2_compile: front-half failed: imported_compile\n")
+            panic("native-v2-compile failed: imported front-half errors")
+        }
+        print("native_v2_compile: emitted path=")
+        print(out_path)
+        print("\n")
+        if execute_after_compile {
+            native_v2_run_elf_and_exit(out_path, args, flag_index)
+        }
+        return
     }
     var trace = empty_load_multimodule_ir_trace()
     let ir_result = load_multimodule_ir_traced(source_path, &! trace)
@@ -2920,6 +2980,9 @@ fn run_native_v2_compile_mode(args: ArgList, flag_index: i64) with IO, Mut, Pani
     print("native_v2_compile: emitted path=")
     print(out_path)
     print("\n")
+    if execute_after_compile {
+        native_v2_run_elf_and_exit(out_path, args, flag_index)
+    }
 }
 
 fn compiler_try_default_native_v2_single(opts: CompilerOptions) -> bool with IO, Mut, Panic, Div, Alloc {

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -3234,6 +3234,10 @@ fn module_frontend_lower_box_ok(module: Box<IrModule>, patch_stats: IrValidatedP
     }
 }
 
+fn module_frontend_ir_module_fn_count(module: &IrModule) -> i64 {
+    module.fn_count
+}
+
 fn module_frontend_param_count(params: &Option<Box<ParamList>>) -> i64 with Alloc {
     match *params {
         Some(list) => {
@@ -3474,25 +3478,24 @@ fn module_frontend_lower_programs_array_boxed(
     if !seed_lower.ok {
         return seed_lower
     }
-    var merged_box = seed_lower.module
-    trace.merged_modules = 1
+    match seed_lower.module {
+        Some(acc_box) => {
+            trace.merged_modules = 1
 
-    var i: i64 = 1
-    while i < loaded {
-        trace.last_module_index = i
-        print("lower_array: dep_begin ")
-        print_int(i)
-        print("\n")
-        let dep_prog_copy = (*programs)[i as usize]
-        let dep_lower = module_frontend_lower_program_box_traced(&dep_prog_copy, i, trace)
-        print("lower_array: dep_lower_done ")
-        print_int(i)
-        print("\n")
-        if !dep_lower.ok {
-            return dep_lower
-        }
-        match merged_box {
-            Some(acc_box) => {
+            var i: i64 = 1
+            while i < loaded {
+                trace.last_module_index = i
+                print("lower_array: dep_begin ")
+                print_int(i)
+                print("\n")
+                let dep_prog_copy = (*programs)[i as usize]
+                let dep_lower = module_frontend_lower_program_box_traced(&dep_prog_copy, i, trace)
+                print("lower_array: dep_lower_done ")
+                print_int(i)
+                print("\n")
+                if !dep_lower.ok {
+                    return dep_lower
+                }
                 match dep_lower.module {
                     Some(dep_box) => {
                         print("lower_array: merge_begin ")
@@ -3533,19 +3536,126 @@ fn module_frontend_lower_programs_array_boxed(
                     }
                     None => return module_frontend_lower_box_error("ir_lowering_failed")
                 }
+                trace.merged_modules = trace.merged_modules + 1
+                i = i + 1
             }
-            None => return module_frontend_lower_box_error("ir_lowering_failed")
-        }
-        trace.merged_modules = trace.merged_modules + 1
-        i = i + 1
-    }
-
-    match merged_box {
-        Some(final_box) => {
             trace.last_stage = "done"
-            module_frontend_lower_box_ok(final_box, ir_empty_validated_patch_stats())
+            module_frontend_lower_box_ok(acc_box, ir_empty_validated_patch_stats())
         }
         None => module_frontend_lower_box_error("ir_lowering_failed")
+    }
+}
+
+fn module_frontend_lower_programs_array_compile_to_file(
+    programs: &! [Program; 256],
+    loaded: i64,
+    trace: &! LoadMultimoduleIrTrace,
+    output_path: string
+) -> i64 with IO, Mut, Panic, Div, Alloc {
+    if loaded <= 0 {
+        return 1
+    }
+
+    trace.last_stage = "lower_summary"
+    trace.last_module_index = 0
+    print("lower_array: seed_begin\n")
+    let seed_prog_copy = (*programs)[0]
+    let seed_lower = module_frontend_lower_program_box_traced_with_externs(&seed_prog_copy, programs, loaded, 0, trace)
+    print("lower_array: seed_done\n")
+    if !seed_lower.ok {
+        return 1
+    }
+
+    match seed_lower.module {
+        Some(acc_box) => {
+            trace.merged_modules = 1
+
+            var i: i64 = 1
+            while i < loaded {
+                trace.last_module_index = i
+                print("lower_array: dep_begin ")
+                print_int(i)
+                print("\n")
+                let dep_prog_copy = (*programs)[i as usize]
+                let dep_lower = module_frontend_lower_program_box_traced(&dep_prog_copy, i, trace)
+                print("lower_array: dep_lower_done ")
+                print_int(i)
+                print("\n")
+                if !dep_lower.ok {
+                    return 1
+                }
+                match dep_lower.module {
+                    Some(dep_box) => {
+                        print("lower_array: merge_begin ")
+                        print_int(i)
+                        print("\n")
+                        var mfi: i64 = 0
+                        while mfi < (*dep_box).fn_count && (*acc_box).fn_count < IR_MAX_FUNCS {
+                            let dep_ic = (*dep_box).functions[mfi as usize].instr_count
+                            var stub_idx: i64 = 0 - 1
+                            var sfi: i64 = 0
+                            while sfi < (*acc_box).fn_count {
+                                if ir_name_eq(
+                                    (*acc_box).functions[sfi as usize].name,
+                                    (*dep_box).functions[mfi as usize].name
+                                ) && (*acc_box).functions[sfi as usize].instr_count <= 0 {
+                                    stub_idx = sfi
+                                }
+                                sfi = sfi + 1
+                            }
+                            if stub_idx >= 0 && dep_ic > 0 {
+                                (*acc_box).functions[stub_idx as usize] = (*dep_box).functions[mfi as usize]
+                            } else {
+                                ir_merge_append_function_into_box(&! (*acc_box), &(*dep_box), mfi)
+                            }
+                            mfi = mfi + 1
+                        }
+                        var si: i64 = 0
+                        while si < (*dep_box).string_count && (*acc_box).string_count < IR_MAX_STRINGS {
+                            (*acc_box).string_table[(*acc_box).string_count as usize] = (*dep_box).string_table[si as usize]
+                            (*acc_box).string_count = (*acc_box).string_count + 1
+                            si = si + 1
+                        }
+                        (*acc_box).epistemic = ir_merge_epistemic_sections((*acc_box).epistemic, (*dep_box).epistemic)
+                        (*acc_box).algebras = ir_merge_algebra_tables((*acc_box).algebras, (*dep_box).algebras)
+                        print("lower_array: merge_done ")
+                        print_int(i)
+                        print("\n")
+                    }
+                    None => return 1
+                }
+                trace.merged_modules = trace.merged_modules + 1
+                i = i + 1
+            }
+            trace.last_stage = "done"
+            let fn_count = module_frontend_ir_module_fn_count(&(*acc_box))
+            trace.last_module_index = loaded - 1
+            trace.merged_modules = loaded
+            print("Merged IR: ")
+            print_int(fn_count)
+            print(" functions\n")
+            if fn_count <= 0 {
+                print("IR lowering produced empty module\n")
+                return 1
+            }
+            ir_module_resolve_named_calls(&! (*acc_box))
+            parser_reset_last_errors()
+            let target_spec = native_resolve_target("native", "auto", false)
+            let write_rc = compile_native_v2_preview_to_file(&(*acc_box), target_spec, output_path)
+            if write_rc != 0 {
+                print("Error: Failed to write native binary to ")
+                print(output_path)
+                print(" rc=")
+                print_int(write_rc)
+                print("\n")
+                return 1
+            }
+            print("Written to ")
+            print(output_path)
+            print("\n")
+            0
+        }
+        None => 1
     }
 }
 
@@ -3764,55 +3874,13 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
 
     trace.last_stage = "lower_merge"
     print("imported_compile: lower_begin\n")
-    let lowered = module_frontend_lower_programs_array_boxed(&! programs, loaded, &! trace)
+    let lower_rc = module_frontend_lower_programs_array_compile_to_file(&! programs, loaded, &! trace, output_path)
     print("imported_compile: lower_done\n")
-    if !lowered.ok {
-        print("IR lowering failed during merge: ")
-        print(lowered.error_msg)
-        print("\n")
+    if lower_rc != 0 {
+        print("IR lowering failed during merge\n")
         return 1
     }
-
-    match lowered.module {
-        Some(module_box) => {
-            let fn_count = (*module_box).fn_count
-            trace.last_stage = "done"
-            trace.last_module_index = loaded - 1
-            trace.merged_modules = loaded
-            print("Merged IR: ")
-            print_int(fn_count)
-            print(" functions\n")
-            if fn_count <= 0 {
-                print("IR lowering produced empty module\n")
-                return 1
-            }
-            // Use the &!IrModule variant (not _box). The Box-wrapped variant
-            // suffers from a lean_single codegen issue where (*module_box).field
-            // for module_box: &! Box<IrModule> reads garbage (observed: fn_count
-            // 1→29795 across the call boundary). Dereferencing the Box at the
-            // call site materializes a clean &!IrModule and bypasses the bug.
-            ir_module_resolve_named_calls(&! (*module_box))
-            parser_reset_last_errors()
-            let target_spec = native_resolve_target("native", "auto", false)
-            let write_rc = compile_native_v2_preview_to_file(&(*module_box), target_spec, output_path)
-            if write_rc != 0 {
-                print("Error: Failed to write native binary to ")
-                print(output_path)
-                print(" rc=")
-                print_int(write_rc)
-                print("\n")
-                return 1
-            }
-            print("Written to ")
-            print(output_path)
-            print("\n")
-            0
-        }
-        None => {
-            print("IR lowering failed during merge\n")
-            1
-        }
-    }
+    0
 }
 
 fn load_multimodule_lower_program_traced(

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -9127,14 +9127,25 @@ fn ir_reg_list_prepend(reg: i64, args: Option<Box<IrRegList>>) -> Option<Box<IrR
 
 fn ir_call_needs_validated_patch(
     fn_count: i64,
-    callee_strategies: [i64; 2048],
-    callee_param_counts: [i64; 2048],
+    callee_strategies: &[i64; 2048],
+    callee_param_counts: &[i64; 2048],
     instr: IrInstr
 ) -> bool with Mut, Panic, Div {
     if instr.op != IrOpcode::IrCall { return false }
     if instr.fn_id < 0 || instr.fn_id >= fn_count { return false }
     callee_strategies[instr.fn_id as usize] == IR_STRATEGY_INSTRUMENTED &&
     instr.arg_count + 1 == callee_param_counts[instr.fn_id as usize]
+}
+
+fn ir_module_has_instrumented_strategy(module: &IrModule) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < module.fn_count {
+        if module.functions[i as usize].compile_strategy == IR_STRATEGY_INSTRUMENTED {
+            return true
+        }
+        i = i + 1
+    }
+    false
 }
 
 fn ir_function_has_opcode(func: IrFunction, op: IrOpcode) -> bool with Mut, Panic, Div {
@@ -9184,8 +9195,8 @@ fn ir_patch_validated_call_instr(instr: &! IrInstr, validated_reg: i64) with Mut
 
 fn ir_patch_validated_calls_in_function(
     fn_count: i64,
-    callee_strategies: [i64; 2048],
-    callee_param_counts: [i64; 2048],
+    callee_strategies: &[i64; 2048],
+    callee_param_counts: &[i64; 2048],
     func: &! IrFunction,
     stats: &! IrValidatedPatchStats
 ) with Mut, Panic, Div, Alloc {
@@ -9241,9 +9252,13 @@ fn ir_patch_validated_calls_in_function(
 }
 
 fn ir_patch_validated_calls(module: &! IrModule) -> IrValidatedPatchStats with Mut, Panic, Div, Alloc {
+    var stats = ir_empty_validated_patch_stats()
+    if !ir_module_has_instrumented_strategy(module) {
+        return stats
+    }
+
     var callee_strategies: [i64; 2048] = [IR_STRATEGY_STANDARD; 2048]
     var callee_param_counts: [i64; 2048] = [0; 2048]
-    var stats = ir_empty_validated_patch_stats()
     var i: i64 = 0
     while i < module.fn_count {
         callee_strategies[i as usize] = module.functions[i as usize].compile_strategy
@@ -9253,7 +9268,7 @@ fn ir_patch_validated_calls(module: &! IrModule) -> IrValidatedPatchStats with M
 
     i = 0
     while i < module.fn_count {
-        ir_patch_validated_calls_in_function(module.fn_count, callee_strategies, callee_param_counts, &! module.functions[i as usize], &! stats)
+        ir_patch_validated_calls_in_function(module.fn_count, &callee_strategies, &callee_param_counts, &! module.functions[i as usize], &! stats)
         i = i + 1
     }
     stats
@@ -9611,7 +9626,9 @@ fn lower_program_bodies_from_summary_with_epistemic_boxed_ref(
     var lo2 = lo.lower_program_bodies_ref(&prog.items)
     var patch_stats = ir_empty_validated_patch_stats()
     if !lo2.had_error {
-        patch_stats = ir_patch_validated_calls(&! lo2.module)
+        var module_box = lo2.module
+        patch_stats = ir_patch_validated_calls(&! (*module_box))
+        lo2.module = module_box
     }
     IrLowerBoxResult {
         module: lo2.module,


### PR DESCRIPTION
## Summary
- avoid by-value 2048-element strategy/count arrays in validated-call patching, and skip that patch when a module has no instrumented functions
- compile imported merged IR while the accumulator box is still in scope, avoiding the observed fn_count loss across the large module return boundary
- route imported native-v2 compile/run through the direct compile-to-file path and propagate generated ELF exit status for run witnesses

## Validation
- git diff --check
- bash scripts/ci/build_modular_madaros.sh /tmp/sounio-import-runtime-20260627/madaros-import-runtime-final
  - PASS, produced 103974755-byte Madaros ELF
- env MADAROS_BIN=/tmp/sounio-import-runtime-20260627/madaros-import-runtime-final SOUNIO_STDLIB_PATH=/tmp/sounio-import-runtime-20260627/stdlib bash scripts/ci/madaros_multimodule_witness.sh
  - PASS: 5/5 witnesses
- env MADAROS_BIN=/tmp/sounio-import-runtime-20260627/madaros-import-runtime-final SOUNIO_STDLIB_PATH=/tmp/sounio-import-runtime-20260627/stdlib SOUNIO_MADAROS_MM_WITNESS_MANIFEST=tests/madaros/ocssm_imported/manifest.tsv bash scripts/ci/madaros_multimodule_witness.sh
  - PASS: 5/5 OCSSM imported check witnesses

## Remaining known limits
- This does not claim the P1 imported core ABI runtime gate is fixed; direct imported core ABI ELF execution was still a separate runtime segfault during triage.
- The self-host fresh path for native_v2_imported_core_abi_gate still fails earlier in the imported self-host/lean compile path and remains separate from this lower_array crash fix.

## LLM-offload reviews invoked
- None. Scope is compiler/runtime plumbing only; no math claims, clinical-pathway code, or external-facing artifacts were changed.