### PR TITLE
Harden imported native-v2 harness paths

### DIFF
--- a/scripts/ci/native_v2_imported_body_lowering_gate.sh
+++ b/scripts/ci/native_v2_imported_body_lowering_gate.sh
@@ -25,7 +25,11 @@ fi
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 
-export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+if [[ -n "${SOUNIO_GATE_STDLIB_PATH:-}" ]]; then
+  export SOUNIO_STDLIB_PATH="$SOUNIO_GATE_STDLIB_PATH"
+elif [[ -z "${SOUNIO_STDLIB_PATH:-}" || "$SOUNIO_STDLIB_PATH" != "$ROOT_DIR"/* ]]; then
+  export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
+fi
 
 OUT_DIR="${SOUNIO_NATIVE_V2_IMPORTED_BODY_LOWERING_DIR:-$(mktemp -d /tmp/sounio-native-v2-imported-body-lowering.XXXXXX)}"
 LOG_DIR="$OUT_DIR/logs"

--- a/scripts/ci/native_v2_imported_captured_closure_boundary_gate.sh
+++ b/scripts/ci/native_v2_imported_captured_closure_boundary_gate.sh
@@ -25,7 +25,11 @@ fi
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 
-export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+if [[ -n "${SOUNIO_GATE_STDLIB_PATH:-}" ]]; then
+  export SOUNIO_STDLIB_PATH="$SOUNIO_GATE_STDLIB_PATH"
+elif [[ -z "${SOUNIO_STDLIB_PATH:-}" || "$SOUNIO_STDLIB_PATH" != "$ROOT_DIR"/* ]]; then
+  export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
+fi
 
 OUT_DIR="${SOUNIO_NATIVE_V2_IMPORTED_CAPTURED_CLOSURE_BOUNDARY_DIR:-$(mktemp -d /tmp/sounio-native-v2-imported-captured-closure-boundary.XXXXXX)}"
 LOG_DIR="$OUT_DIR/logs"

--- a/scripts/ci/native_v2_imported_closure_boundary_gate.sh
+++ b/scripts/ci/native_v2_imported_closure_boundary_gate.sh
@@ -25,7 +25,11 @@ fi
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 
-export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+if [[ -n "${SOUNIO_GATE_STDLIB_PATH:-}" ]]; then
+  export SOUNIO_STDLIB_PATH="$SOUNIO_GATE_STDLIB_PATH"
+elif [[ -z "${SOUNIO_STDLIB_PATH:-}" || "$SOUNIO_STDLIB_PATH" != "$ROOT_DIR"/* ]]; then
+  export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
+fi
 
 OUT_DIR="${SOUNIO_NATIVE_V2_IMPORTED_CLOSURE_BOUNDARY_DIR:-$(mktemp -d /tmp/sounio-native-v2-imported-closure-boundary.XXXXXX)}"
 LOG_DIR="$OUT_DIR/logs"

--- a/scripts/ci/native_v2_imported_core_abi_gate.sh
+++ b/scripts/ci/native_v2_imported_core_abi_gate.sh
@@ -17,10 +17,21 @@ case "$(uname -m 2>/dev/null || echo unknown)" in
     ;;
 esac
 
+if [[ -n "${SOUNIO_GATE_SOUC_BIN:-}" ]]; then
+  export SOUC_BIN="$SOUNIO_GATE_SOUC_BIN"
+elif [[ -n "${SOUC_BIN:-}" && "$SOUC_BIN" != "$ROOT_DIR"/* ]]; then
+  echo "[native-v2-imported-core-abi] ignoring external SOUC_BIN outside this worktree: $SOUC_BIN"
+  unset SOUC_BIN
+fi
+
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 
-export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+if [[ -n "${SOUNIO_GATE_STDLIB_PATH:-}" ]]; then
+  export SOUNIO_STDLIB_PATH="$SOUNIO_GATE_STDLIB_PATH"
+elif [[ -z "${SOUNIO_STDLIB_PATH:-}" || "$SOUNIO_STDLIB_PATH" != "$ROOT_DIR"/* ]]; then
+  export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
+fi
 
 OUT_DIR="${SOUNIO_NATIVE_V2_IMPORTED_CORE_ABI_DIR:-$(mktemp -d /tmp/sounio-native-v2-imported-core-abi.XXXXXX)}"
 LOG_DIR="$OUT_DIR/logs"

--- a/scripts/ci/native_v2_imported_hof_abi_gate.sh
+++ b/scripts/ci/native_v2_imported_hof_abi_gate.sh
@@ -25,7 +25,11 @@ fi
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 
-export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+if [[ -n "${SOUNIO_GATE_STDLIB_PATH:-}" ]]; then
+  export SOUNIO_STDLIB_PATH="$SOUNIO_GATE_STDLIB_PATH"
+elif [[ -z "${SOUNIO_STDLIB_PATH:-}" || "$SOUNIO_STDLIB_PATH" != "$ROOT_DIR"/* ]]; then
+  export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
+fi
 
 OUT_DIR="${SOUNIO_NATIVE_V2_IMPORTED_HOF_ABI_DIR:-$(mktemp -d /tmp/sounio-native-v2-imported-hof-abi.XXXXXX)}"
 LOG_DIR="$OUT_DIR/logs"

--- a/scripts/lib/run_selfhost_fresh.sh
+++ b/scripts/lib/run_selfhost_fresh.sh
@@ -6,12 +6,23 @@ if [ "$#" -lt 2 ]; then
   exit 2
 fi
 
-SOUC_BIN="$1"
+ROOT_DIR="$(pwd)"
+
+SOUC_ARG="$1"
 shift
 ENTRY_PATH="$1"
 shift
 
-ROOT_DIR="$(pwd)"
+case "$SOUC_ARG" in
+  /*) SOUC_BIN="$SOUC_ARG" ;;
+  *) SOUC_BIN="$ROOT_DIR/$SOUC_ARG" ;;
+esac
+
+if [ ! -x "$SOUC_BIN" ]; then
+  echo "souc binary not executable: $SOUC_BIN" >&2
+  exit 2
+fi
+
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sounio-selfhost-fresh.XXXXXX")"
 
 cleanup() {


### PR DESCRIPTION
## Summary
- Normalize `run_selfhost_fresh.sh` compiler paths before it enters the temporary self-host copy, so relative `./bin/souc` works after `cd` into the sandbox.
- Keep imported native-v2 gates on the current worktree compiler/stdlib when inherited env points at another checkout.
- Add explicit `SOUNIO_GATE_SOUC_BIN` / `SOUNIO_GATE_STDLIB_PATH` override support for the core ABI gate, while aligning stdlib handling across the imported gate family.

## Validation
- `bash -n scripts/lib/run_selfhost_fresh.sh scripts/ci/native_v2_imported_core_abi_gate.sh scripts/ci/native_v2_imported_body_lowering_gate.sh scripts/ci/native_v2_imported_hof_abi_gate.sh scripts/ci/native_v2_imported_closure_boundary_gate.sh scripts/ci/native_v2_imported_captured_closure_boundary_gate.sh`
- `git diff --check`
- `env -u SOUC_BIN -u SOUNIO_STDLIB_PATH timeout 20 bash scripts/lib/run_selfhost_fresh.sh ./bin/souc examples/hello.sio`
  - PASS, printed `Hello, Sounio`
- polluted-env smoke:
  - `SOUC_BIN=/workspace/sounio/bin/souc SOUNIO_STDLIB_PATH=/workspace/sounio/stdlib SOUNIO_NATIVE_V2_FRONTEND_RUN_CPU_UMBRELLA=0 ... timeout 8 bash scripts/ci/native_v2_imported_core_abi_gate.sh`
  - Expected timeout while the deeper gate continued, but logs proved it ignored `/workspace/sounio/bin/souc` and used `/tmp/sounio-sota-plus-20260627/bin/souc`.

## Scope note
This is harness hardening only. It does not claim the imported core ABI runtime blocker is fixed; it removes cross-worktree/path contamination so that follow-up ABI/runtime evidence is clean.

## LLM-offload reviews invoked
- None. Scope is CI/harness plumbing only; no math claims, clinical-pathway code, or external-facing artifacts were changed.