### PR TITLE
Fix imported core ABI function and struct layout merge

### DIFF
--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1159,6 +1159,37 @@ fn ir_merge_append_function_into_box(dst: &! IrModule, src: &IrModule, src_fi: i
     (*dst).fn_count = (*dst).fn_count + 1
 }
 
+fn ir_merge_find_function_name_index(module: &IrModule, name: Name) -> i64 with Mut, Div, Panic {
+    var fi: i64 = 0
+    var found: i64 = 0 - 1
+    while fi < (*module).fn_count {
+        if ir_name_eq((*module).functions[fi as usize].name, name) {
+            found = fi
+        }
+        fi = fi + 1
+    }
+    found
+}
+
+fn ir_merge_remap_existing_call_targets(func: IrFunction, src: &IrModule, dst: &IrModule) -> IrFunction with Mut, Panic, Div {
+    var out = func
+    var ii: i64 = 0
+    while ii < out.instr_count {
+        if out.instrs[ii as usize].op == IrOpcode::IrCall || out.instrs[ii as usize].op == IrOpcode::IrCallSret {
+            let old_id = out.instrs[ii as usize].fn_id
+            if old_id >= 0 && old_id < (*src).fn_count {
+                let target_name = (*src).functions[old_id as usize].name
+                let new_id = ir_merge_find_function_name_index(dst, target_name)
+                if new_id >= 0 {
+                    out.instrs[ii as usize].fn_id = new_id
+                }
+            }
+        }
+        ii = ii + 1
+    }
+    out
+}
+
 // Resolve fn_id=-1 named calls (cross-module calls emitted by module_frontend_ir_named_call)
 // to their position in the merged module. Operates through &! to avoid large-local JIT writes.
 fn ir_module_resolve_named_calls(module: &! IrModule) with Mut, Div, Panic {
@@ -3489,7 +3520,7 @@ fn module_frontend_lower_programs_array_boxed(
                 print_int(i)
                 print("\n")
                 let dep_prog_copy = (*programs)[i as usize]
-                let dep_lower = module_frontend_lower_program_box_traced(&dep_prog_copy, i, trace)
+                let dep_lower = module_frontend_lower_program_box_traced_with_externs(&dep_prog_copy, programs, loaded, i, trace)
                 print("lower_array: dep_lower_done ")
                 print_int(i)
                 print("\n")
@@ -3516,7 +3547,12 @@ fn module_frontend_lower_programs_array_boxed(
                                 sfi = sfi + 1
                             }
                             if stub_idx >= 0 && dep_ic > 0 {
-                                (*acc_box).functions[stub_idx as usize] = (*dep_box).functions[mfi as usize]
+                                let remapped_func = ir_merge_remap_existing_call_targets(
+                                    (*dep_box).functions[mfi as usize],
+                                    &(*dep_box),
+                                    &(*acc_box)
+                                )
+                                (*acc_box).functions[stub_idx as usize] = remapped_func
                             } else {
                                 ir_merge_append_function_into_box(&! (*acc_box), &(*dep_box), mfi)
                             }
@@ -3577,7 +3613,7 @@ fn module_frontend_lower_programs_array_compile_to_file(
                 print_int(i)
                 print("\n")
                 let dep_prog_copy = (*programs)[i as usize]
-                let dep_lower = module_frontend_lower_program_box_traced(&dep_prog_copy, i, trace)
+                let dep_lower = module_frontend_lower_program_box_traced_with_externs(&dep_prog_copy, programs, loaded, i, trace)
                 print("lower_array: dep_lower_done ")
                 print_int(i)
                 print("\n")
@@ -3604,7 +3640,12 @@ fn module_frontend_lower_programs_array_compile_to_file(
                                 sfi = sfi + 1
                             }
                             if stub_idx >= 0 && dep_ic > 0 {
-                                (*acc_box).functions[stub_idx as usize] = (*dep_box).functions[mfi as usize]
+                                let remapped_func = ir_merge_remap_existing_call_targets(
+                                    (*dep_box).functions[mfi as usize],
+                                    &(*dep_box),
+                                    &(*acc_box)
+                                )
+                                (*acc_box).functions[stub_idx as usize] = remapped_func
                             } else {
                                 ir_merge_append_function_into_box(&! (*acc_box), &(*dep_box), mfi)
                             }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -784,6 +784,55 @@ fn lowerer_preseed_external_struct_items_mut(
     }
 }
 
+fn lowerer_register_struct_fields_direct_mut(
+    lo: &! Lowerer,
+    type_name: Name,
+    fields: &Option<Box<FieldDefList>>
+) with Mut, Panic, Div, Alloc {
+    var sl_box = (*lo).struct_layouts
+    var layout_idx: i64 = -1
+    var si: i64 = 0
+    while si < (*sl_box).count {
+        if ir_name_eq((*sl_box).entries[si as usize].type_name, type_name) {
+            layout_idx = si
+        }
+        si = si + 1
+    }
+    if layout_idx < 0 {
+        let pre_count = (*sl_box).count
+        if pre_count >= 256 {
+            lo.error_count = lo.error_count + 1
+            lo.had_error = true
+            return
+        }
+        layout_idx = pre_count
+        (*sl_box).count = pre_count + 1
+    }
+
+    var entry = empty_struct_layout_entry()
+    entry.type_name = type_name
+    var fc: i64 = 0
+    var fcur = fields
+    var keep_going = true
+    while keep_going && fc < 64 {
+        match *fcur {
+            Some(flist) => {
+                entry.fields[fc as usize] = StructFieldEntry {
+                    name: (*flist).head.name,
+                    index: fc,
+                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else { 0 },
+                }
+                fc = fc + 1
+                fcur = &(*flist).tail
+            }
+            _ => { keep_going = false }
+        }
+    }
+    entry.field_count = fc
+    (*sl_box).entries[layout_idx as usize] = entry
+    (*lo).struct_layouts = sl_box
+}
+
 fn lowerer_register_struct_fields_mut(
     lo: &! Lowerer,
     type_name: Name,
@@ -978,7 +1027,7 @@ fn lowerer_preseed_program_items_mut(
                     let struct_def_opt_ref: &Option<Box<StructDef>> = &head.struct_def
                     match *struct_def_opt_ref {
                         Some(sd) => {
-                            lowerer_register_struct_fields_mut(lo, name, &(*sd).fields, 0)
+                            lowerer_register_struct_fields_direct_mut(lo, name, &(*sd).fields)
                         }
                         _ => {}
                     }
@@ -4472,6 +4521,27 @@ impl Lowerer {
         }
     }
 
+    fn field_idx_from_struct_literal_name(self, struct_name: Name, field_name: Name, default_idx: i64) -> i64 with Mut, Panic, Div {
+        if struct_name.len <= 0 {
+            return self.field_idx_from_name_simple(field_name)
+        }
+        var si: i64 = 0
+        while si < (*self.struct_layouts).count {
+            if ir_name_eq((*self.struct_layouts).entries[si as usize].type_name, struct_name) {
+                var fi: i64 = 0
+                while fi < (*self.struct_layouts).entries[si as usize].field_count {
+                    if ir_name_eq((*self.struct_layouts).entries[si as usize].fields[fi as usize].name, field_name) {
+                        return (*self.struct_layouts).entries[si as usize].fields[fi as usize].index
+                    }
+                    fi = fi + 1
+                }
+                return default_idx
+            }
+            si = si + 1
+        }
+        default_idx
+    }
+
     fn field_is_float_by_name_simple(self, n: Name) -> bool with Mut, Panic, Div {
         var si: i64 = 0
         while si < (*self.struct_layouts).count {
@@ -6847,7 +6917,7 @@ impl Lowerer {
                     }
                     let named_field_idx = if (*list).head.name.len > 0 {
                         if struct_name.len > 0 {
-                            lo.field_idx_from_name(struct_name, (*list).head.name)
+                            lo.field_idx_from_struct_literal_name(struct_name, (*list).head.name, field_idx)
                         } else {
                             lo.field_idx_from_name_simple((*list).head.name)
                         }
@@ -8072,9 +8142,12 @@ impl Lowerer {
     }
 
     fn lower_field_access_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
-        let fidx = self.field_idx_for_base_ref(&e.left, e.name)
-        let field_is_float = self.field_is_float_for_base_ref(&e.left, e.name) || self.field_is_float_by_name_simple(e.name)
-        let field_array_elem_is_float = self.field_array_elem_is_float_for_base_ref(&e.left, e.name)
+        let pair_b = self.lower_opt_expr_ref(&e.left)
+        let lo1 = pair_b.0
+        let base = pair_b.1
+        let fidx = lo1.field_idx_for_base_ref(&e.left, e.name)
+        let field_is_float = lo1.field_is_float_for_base_ref(&e.left, e.name) || lo1.field_is_float_by_name_simple(e.name)
+        let field_array_elem_is_float = lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name)
         if lower_aggregate_diag_enabled() {
             print("lower_agg: field name=")
             print(str_from_bytes(e.name.buf, e.name.len))
@@ -8092,31 +8165,28 @@ impl Lowerer {
             print(" idx=")
             print_int(fidx)
             print(" layouts.count=")
-            print_int((*self.struct_layouts).count)
+            print_int((*lo1.struct_layouts).count)
             print("\n")
             var di: i64 = 0
-            while di < (*self.struct_layouts).count {
+            while di < (*lo1.struct_layouts).count {
                 print("  [")
                 print_int(di)
                 print("] ")
-                print(str_from_bytes((*self.struct_layouts).entries[di as usize].type_name.buf, (*self.struct_layouts).entries[di as usize].type_name.len))
+                print(str_from_bytes((*lo1.struct_layouts).entries[di as usize].type_name.buf, (*lo1.struct_layouts).entries[di as usize].type_name.len))
                 print(" fc=")
-                print_int((*self.struct_layouts).entries[di as usize].field_count)
+                print_int((*lo1.struct_layouts).entries[di as usize].field_count)
                 var dj: i64 = 0
-                while dj < (*self.struct_layouts).entries[di as usize].field_count {
+                while dj < (*lo1.struct_layouts).entries[di as usize].field_count {
                     print(" ")
-                    print(str_from_bytes((*self.struct_layouts).entries[di as usize].fields[dj as usize].name.buf, (*self.struct_layouts).entries[di as usize].fields[dj as usize].name.len))
+                    print(str_from_bytes((*lo1.struct_layouts).entries[di as usize].fields[dj as usize].name.buf, (*lo1.struct_layouts).entries[di as usize].fields[dj as usize].name.len))
                     print(":")
-                    print_int((*self.struct_layouts).entries[di as usize].fields[dj as usize].index)
+                    print_int((*lo1.struct_layouts).entries[di as usize].fields[dj as usize].index)
                     dj = dj + 1
                 }
                 print("\n")
                 di = di + 1
             }
         }
-        let pair_b = self.lower_opt_expr_ref(&e.left)
-        let lo1 = pair_b.0
-        let base = pair_b.1
         let pair_d = lo1.fresh_reg()
         let lo2 = pair_d.0
         let dst = pair_d.1


### PR DESCRIPTION
## Summary

- remap imported dependency call targets by function name when replacing import stubs in merged IR, including `IrCallSret`
- lower imported dependencies with the full extern/module context so cross-module references are present during dependency lowering
- preserve imported struct layouts through direct mut preseed and use named literal positions plus base-first field lookup for imported struct field lowering

## Validation

Local worktree: `/tmp/sounio-sota-plus-20260627`, branch `codex/sota-plus-runtime-abi-20260627`.

- `git diff --check` -> pass
- patched raw artifact: `/tmp/sounio-sota-plus-madaros-directstruct-patched`
- `import_core_abi_42.sio` with patched raw:
  - compile: `compile_rc=0`
  - native execution: `run_rc=42`
  - compile log includes `Merged IR: 6`, `module_native_driver: imported source uses modular IR path`, `imported_compile: typecheck ok`, `Compilation successful!`
- layout dump with `SOUNIO_DUMP_LAYOUTS=1`:
  - `CorePair fc=2 left:0 right:1`
  - `CoreTriple fc=3 a:0 c:2`
  - field accesses observed as `a idx=0`, `c idx=2`, `left idx=0`, `right idx=1`

Baseline evidence from current `origin/main` raw before this patch:

- `import_core_abi_42.sio` compiled but native execution segfaulted: `compile_rc=0`, `run_rc=139`

## Not fixed in this PR

- `import_hof_abi_42.sio` still fails at typecheck with `E009`: expected `fn#4`, found `fn#7`
- `import_body_lowering_42.sio` still fails at typecheck with `E009`: expected `fn#5`, found `fn#8`
- focused imported runtime gate scripts still hit the pre-existing `run_selfhost_fresh` / `self-hosted/compiler/lean.sio` raw segfault path (`rc=139`), also reproduced on the current `origin/main` raw, so this PR uses the direct imported core canary as the scoped runtime proof

## LLM offload

Not invoked: compiler runtime/ABI implementation only; no math claims, clinical-pathway code, or external-facing artifacts touched.
