### PR TITLE
docs(solver): Blackwell GPU runtime receipt — Sounio epistemic kernel verified on GB10

### DIFF
--- a/benchmarks/solver/gpu/run_epistemic_mma_jit.c
+++ b/benchmarks/solver/gpu/run_epistemic_mma_jit.c
@@ -1,0 +1,65 @@
+// Driver-API launcher: JIT-load Sounio epistemic-MMA PTX, run on the GPU, verify.
+// Verifiable case: A=0 => D = A*B + C = C ; shadow eps_C = sqrt(4*(|D0|*epsB + |D2|*epsA)).
+// With C=[1,2,3,4], epsA=0.5, epsB=0.25 -> D=[1,2,3,4], eps_C = sqrt(4*(1*0.25+3*0.5)) = sqrt(7) ~ 2.6458.
+#include <cuda.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+static void chk(CUresult r, const char* w){ if(r!=CUDA_SUCCESS){ const char* m; cuGetErrorString(r,&m); fprintf(stderr,"ERR %s: %s\n",w,m); exit(1);} }
+
+int main(int argc, char** argv){
+    const char* ptxpath = argc>1? argv[1] : "/tmp/epi_ascii.ptx";
+    FILE* f=fopen(ptxpath,"rb"); if(!f){perror("ptx");return 1;}
+    fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
+    char* ptx=malloc(n+1); fread(ptx,1,n,f); ptx[n]=0; fclose(f);
+
+    chk(cuInit(0),"init");
+    CUdevice dev; chk(cuDeviceGet(&dev,0),"devget");
+    char name[128]; cuDeviceGetName(name,sizeof name,dev);
+    int ccM=0,ccm=0; cuDeviceGetAttribute(&ccM,CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,dev);
+    cuDeviceGetAttribute(&ccm,CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,dev);
+    printf("device: %s  sm_%d%d\n",name,ccM,ccm);
+    CUcontext ctx; chk(cuDevicePrimaryCtxRetain(&ctx,dev),"ctxRetain"); chk(cuCtxSetCurrent(ctx),"ctxset");
+
+    // JIT-load PTX (proves forward-compat PTX->this-arch SASS at load time)
+    CUmodule mod; CUjit_option o[1]={CU_JIT_TARGET_FROM_CUCONTEXT}; void* ov[1]={0};
+    chk(cuModuleLoadDataEx(&mod, ptx, 1, o, ov),"loadPTX(JIT)");
+    CUfunction fn; chk(cuModuleGetFunction(&fn,mod,"epistemic_mma_kernel"),"getfn");
+    printf("JIT-loaded epistemic_mma_kernel from PTX\n");
+
+    // device buffers
+    CUdeviceptr dAv,dAe,dBv,dBe,dCv,dCe,dVl,dPr;
+    chk(cuMemAlloc(&dAv,16),"aAv"); chk(cuMemAlloc(&dAe,4),"aAe");
+    chk(cuMemAlloc(&dBv,8),"aBv");  chk(cuMemAlloc(&dBe,4),"aBe");
+    chk(cuMemAlloc(&dCv,16),"aCv"); chk(cuMemAlloc(&dCe,4),"aCe");
+    chk(cuMemAlloc(&dVl,8),"aVl");  chk(cuMemAlloc(&dPr,8),"aPr");
+
+    unsigned char zA[16]={0}, zB[8]={0};               // A=0 (f16 zeros), B=0
+    float Cv[4]={1.f,2.f,3.f,4.f}, epsA=0.5f, epsB=0.25f, Ce=-1.f;
+    unsigned long long vld=1ULL, prv=0x5ULL;
+    chk(cuMemcpyHtoD(dAv,zA,16),"hAv"); chk(cuMemcpyHtoD(dAe,&epsA,4),"hAe");
+    chk(cuMemcpyHtoD(dBv,zB,8),"hBv");  chk(cuMemcpyHtoD(dBe,&epsB,4),"hBe");
+    chk(cuMemcpyHtoD(dCv,Cv,16),"hCv"); chk(cuMemcpyHtoD(dCe,&Ce,4),"hCe");
+    chk(cuMemcpyHtoD(dVl,&vld,8),"hVl"); chk(cuMemcpyHtoD(dPr,&prv,8),"hPr");
+
+    void* args[8]={&dAv,&dAe,&dBv,&dBe,&dCv,&dCe,&dVl,&dPr};
+    chk(cuLaunchKernel(fn, 1,1,1, 32,1,1, 0,0, args, 0),"launch");
+    chk(cuCtxSynchronize(),"sync");
+
+    float Dout[4]; float Ceout; unsigned long long prout;
+    chk(cuMemcpyDtoH(Dout,dCv,16),"dCv"); chk(cuMemcpyDtoH(&Ceout,dCe,4),"dCe");
+    chk(cuMemcpyDtoH(&prout,dPr,8),"dPr");
+
+    printf("D (expect 1,2,3,4): %.4f %.4f %.4f %.4f\n",Dout[0],Dout[1],Dout[2],Dout[3]);
+    printf("eps_C (expect sqrt(7)=%.5f): %.5f\n", sqrtf(7.f), Ceout);
+    printf("prov (expect 0x5): 0x%llx\n", prout);
+
+    int okD = (Dout[0]==1.f&&Dout[1]==2.f&&Dout[2]==3.f&&Dout[3]==4.f);
+    int okE = fabsf(Ceout - sqrtf(7.f)) < 1e-3f;
+    int okP = (prout==0x5ULL);
+    printf("RESULT: dataPath=%s epistemicShadow=%s provenance=%s\n",
+           okD?"PASS":"FAIL", okE?"PASS":"FAIL", okP?"PASS":"FAIL");
+    return (okD&&okE&&okP)?0:2;
+}

--- a/benchmarks/solver/gpu/run_epistemic_mma_native_sm121.c
+++ b/benchmarks/solver/gpu/run_epistemic_mma_native_sm121.c
@@ -1,0 +1,100 @@
+// Driver-API launcher: load a NATIVE sm_121 cubin via cuModuleLoad (no JIT).
+// Identical A=0 verification to run_epistemic_mma.c:
+//   A=0 => D = A*B + C = C = [1,2,3,4], eps_C = sqrt(7) ~ 2.64575, prov = 0x5
+//
+// Usage:
+//   gcc -O2 run_native_sm121.c -o run_native_sm121 -lcuda -lm
+//   ./run_native_sm121 /path/to/epistemic_mma.cubin
+//
+// cuModuleLoad(CUmodule*, const char* path) reads a fatbin/cubin directly from
+// disk; no JIT step, no PTX intermediary — pure SASS for sm_121 executes as-is.
+// The .cubin must have been compiled with -arch=sm_121 (or a compatible fatbin).
+#include <cuda.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+static void chk(CUresult r, const char* w){
+    if(r != CUDA_SUCCESS){
+        const char* m; cuGetErrorString(r, &m);
+        fprintf(stderr, "ERR %s: %s\n", w, m); exit(1);
+    }
+}
+
+int main(int argc, char** argv){
+    const char* cubinpath = argc > 1 ? argv[1] : "/tmp/epistemic_mma.cubin";
+
+    chk(cuInit(0), "init");
+    CUdevice dev; chk(cuDeviceGet(&dev, 0), "devget");
+    char name[128]; cuDeviceGetName(name, sizeof name, dev);
+    int ccM = 0, ccm = 0;
+    cuDeviceGetAttribute(&ccM, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, dev);
+    cuDeviceGetAttribute(&ccm, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, dev);
+    printf("device: %s  sm_%d%d\n", name, ccM, ccm);
+
+    CUcontext ctx;
+    chk(cuDevicePrimaryCtxRetain(&ctx, dev), "ctxRetain");
+    chk(cuCtxSetCurrent(ctx), "ctxset");
+
+    // Load native cubin directly from disk — no JIT, no PTX.
+    // cuModuleLoad(CUmodule*, const char*) signature is stable through CUDA 13.
+    CUmodule mod;
+    chk(cuModuleLoad(&mod, cubinpath), "cuModuleLoad(cubin)");
+    CUfunction fn;
+    chk(cuModuleGetFunction(&fn, mod, "epistemic_mma_kernel"), "getfn");
+    printf("Loaded native cubin from: %s\n", cubinpath);
+
+    // Device buffers matching kernel signature:
+    //   A_val[16B f16], A_eps[f32], B_val[8B f16], B_eps[f32],
+    //   C_val[16B 4xf32 in/out], C_eps[f32 out], C_vld[u64], C_prv[u64]
+    CUdeviceptr dAv, dAe, dBv, dBe, dCv, dCe, dVl, dPr;
+    chk(cuMemAlloc(&dAv, 16), "aAv"); chk(cuMemAlloc(&dAe, 4), "aAe");
+    chk(cuMemAlloc(&dBv,  8), "aBv"); chk(cuMemAlloc(&dBe, 4), "aBe");
+    chk(cuMemAlloc(&dCv, 16), "aCv"); chk(cuMemAlloc(&dCe, 4), "aCe");
+    chk(cuMemAlloc(&dVl,  8), "aVl"); chk(cuMemAlloc(&dPr, 8), "aPr");
+
+    // A=0 (f16 zeros, 8 half-precision values packed into 16 bytes)
+    // B=0 (f16 zeros, 4 half-precision values packed into 8 bytes)
+    unsigned char zA[16] = {0};
+    unsigned char zB[8]  = {0};
+    float  Cv[4]  = {1.f, 2.f, 3.f, 4.f};
+    float  epsA   = 0.5f;
+    float  epsB   = 0.25f;
+    float  Ce     = -1.f;           // output slot; kernel overwrites
+    unsigned long long vld = 1ULL;
+    unsigned long long prv = 0x5ULL;
+
+    chk(cuMemcpyHtoD(dAv, zA, 16),  "hAv");
+    chk(cuMemcpyHtoD(dAe, &epsA, 4),"hAe");
+    chk(cuMemcpyHtoD(dBv, zB, 8),   "hBv");
+    chk(cuMemcpyHtoD(dBe, &epsB, 4),"hBe");
+    chk(cuMemcpyHtoD(dCv, Cv, 16),  "hCv");
+    chk(cuMemcpyHtoD(dCe, &Ce, 4),  "hCe");
+    chk(cuMemcpyHtoD(dVl, &vld, 8), "hVl");
+    chk(cuMemcpyHtoD(dPr, &prv, 8), "hPr");
+
+    void* args[8] = {&dAv, &dAe, &dBv, &dBe, &dCv, &dCe, &dVl, &dPr};
+    chk(cuLaunchKernel(fn, 1,1,1, 32,1,1, 0, 0, args, 0), "launch");
+    chk(cuCtxSynchronize(), "sync");
+
+    float Dout[4]; float Ceout; unsigned long long prout;
+    chk(cuMemcpyDtoH(Dout,  dCv, 16), "dCv");
+    chk(cuMemcpyDtoH(&Ceout, dCe, 4), "dCe");
+    chk(cuMemcpyDtoH(&prout, dPr, 8), "dPr");
+
+    printf("D (expect 1,2,3,4): %.4f %.4f %.4f %.4f\n",
+           Dout[0], Dout[1], Dout[2], Dout[3]);
+    printf("eps_C (expect sqrt(7)=%.5f): %.5f\n", sqrtf(7.f), Ceout);
+    printf("prov  (expect 0x5): 0x%llx\n", prout);
+
+    int okD = (Dout[0]==1.f && Dout[1]==2.f && Dout[2]==3.f && Dout[3]==4.f);
+    int okE = fabsf(Ceout - sqrtf(7.f)) < 1e-3f;
+    int okP = (prout == 0x5ULL);
+    printf("RESULT: dataPath=%s epistemicShadow=%s provenance=%s\n",
+           okD?"PASS":"FAIL", okE?"PASS":"FAIL", okP?"PASS":"FAIL");
+
+    cuModuleUnload(mod);
+    cuDevicePrimaryCtxRelease(dev);
+    return (okD && okE && okP) ? 0 : 2;
+}

--- a/benchmarks/solver/gpu/run_epistemic_mma_nonzero.c
+++ b/benchmarks/solver/gpu/run_epistemic_mma_nonzero.c
@@ -1,0 +1,140 @@
+// Driver-API launcher: exercise the tensor-core mma.sync path with non-zero A and B.
+//
+// IMPORTANT CAVEAT (read before interpreting output):
+//   The reference epistemic_mma_kernel loads the SAME fragment tile into every
+//   warp lane — it does not offset per-lane within the 16x16 fragment.  The
+//   mma.sync instruction therefore computes a rank-1 (or constant-tile)
+//   multiply, NOT a general A*B of distinct 16x16 matrices.
+//   This launcher proves:
+//     (a) the tensor-core multiply EXECUTES with non-zero operands, and
+//     (b) D and eps_C are deterministic across runs.
+//   It does NOT validate a full 16x16 row-major A*B result.
+//   For that, a per-lane-offset kernel would be required.
+//
+// A = all f16 1.0 (0x3C00) packed into 16 bytes (8 half values per fragment)
+// B = all f16 1.0 (0x3C00) packed into  8 bytes (4 half values per fragment)
+// C = all f32 0.0
+// epsA = 0.5, epsB = 0.25, vld = 1, prv = 0x5
+//
+// The launcher prints D[0..3] and eps_C without asserting specific values.
+//
+// Usage:
+//   # PTX path (JIT):
+//   gcc -O2 run_matmul_verify.c -o run_matmul_verify -lcuda -lm
+//   ./run_matmul_verify /path/to/epistemic_mma.ptx
+//
+//   # Native cubin path: change cuModuleLoadDataEx -> cuModuleLoad (see run_native_sm121.c)
+#include <cuda.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+static void chk(CUresult r, const char* w){
+    if(r != CUDA_SUCCESS){
+        const char* m; cuGetErrorString(r, &m);
+        fprintf(stderr, "ERR %s: %s\n", w, m); exit(1);
+    }
+}
+
+// Fill a byte buffer with the f16 bit pattern for 1.0 (IEEE 754 half: 0x3C00).
+// Little-endian layout: low byte = 0x00, high byte = 0x3C.
+static void fill_f16_ones(unsigned char* buf, size_t nbytes){
+    for(size_t i = 0; i < nbytes; i += 2){
+        buf[i]   = 0x00;   // low byte of 0x3C00
+        buf[i+1] = 0x3C;   // high byte of 0x3C00
+    }
+}
+
+int main(int argc, char** argv){
+    const char* ptxpath = argc > 1 ? argv[1] : "/tmp/epi_ascii.ptx";
+    FILE* fh = fopen(ptxpath, "rb");
+    if(!fh){ perror("ptx"); return 1; }
+    fseek(fh, 0, SEEK_END); long n = ftell(fh); fseek(fh, 0, SEEK_SET);
+    char* ptx = malloc(n + 1); fread(ptx, 1, n, fh); ptx[n] = 0; fclose(fh);
+
+    chk(cuInit(0), "init");
+    CUdevice dev; chk(cuDeviceGet(&dev, 0), "devget");
+    char name[128]; cuDeviceGetName(name, sizeof name, dev);
+    int ccM = 0, ccm = 0;
+    cuDeviceGetAttribute(&ccM, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, dev);
+    cuDeviceGetAttribute(&ccm, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, dev);
+    printf("device: %s  sm_%d%d\n", name, ccM, ccm);
+
+    CUcontext ctx;
+    chk(cuDevicePrimaryCtxRetain(&ctx, dev), "ctxRetain");
+    chk(cuCtxSetCurrent(ctx), "ctxset");
+
+    // JIT-load PTX (replace these two lines with cuModuleLoad for native cubin)
+    CUmodule mod;
+    CUjit_option o[1] = {CU_JIT_TARGET_FROM_CUCONTEXT}; void* ov[1] = {0};
+    chk(cuModuleLoadDataEx(&mod, ptx, 1, o, ov), "loadPTX(JIT)");
+    free(ptx);
+
+    CUfunction fn;
+    chk(cuModuleGetFunction(&fn, mod, "epistemic_mma_kernel"), "getfn");
+    printf("Loaded epistemic_mma_kernel\n");
+
+    // Device buffers
+    CUdeviceptr dAv, dAe, dBv, dBe, dCv, dCe, dVl, dPr;
+    chk(cuMemAlloc(&dAv, 16), "aAv"); chk(cuMemAlloc(&dAe, 4), "aAe");
+    chk(cuMemAlloc(&dBv,  8), "aBv"); chk(cuMemAlloc(&dBe, 4), "aBe");
+    chk(cuMemAlloc(&dCv, 16), "aCv"); chk(cuMemAlloc(&dCe, 4), "aCe");
+    chk(cuMemAlloc(&dVl,  8), "aVl"); chk(cuMemAlloc(&dPr, 8), "aPr");
+
+    // A = all f16 1.0 (16 bytes = 8 half-precision values)
+    unsigned char Av[16]; fill_f16_ones(Av, 16);
+    // B = all f16 1.0 (8 bytes = 4 half-precision values)
+    unsigned char Bv[8];  fill_f16_ones(Bv,  8);
+    // C = all f32 0.0  (D = A*B + C = A*B; mma result is unbiased by accumulator)
+    float  Cv[4]  = {0.f, 0.f, 0.f, 0.f};
+    float  epsA   = 0.5f;
+    float  epsB   = 0.25f;
+    float  Ce     = -1.f;   // output slot; kernel overwrites
+    unsigned long long vld = 1ULL;
+    unsigned long long prv = 0x5ULL;
+
+    chk(cuMemcpyHtoD(dAv, Av, 16),   "hAv");
+    chk(cuMemcpyHtoD(dAe, &epsA, 4), "hAe");
+    chk(cuMemcpyHtoD(dBv, Bv,  8),   "hBv");
+    chk(cuMemcpyHtoD(dBe, &epsB, 4), "hBe");
+    chk(cuMemcpyHtoD(dCv, Cv, 16),   "hCv");
+    chk(cuMemcpyHtoD(dCe, &Ce,  4),  "hCe");
+    chk(cuMemcpyHtoD(dVl, &vld, 8),  "hVl");
+    chk(cuMemcpyHtoD(dPr, &prv, 8),  "hPr");
+
+    void* args[8] = {&dAv, &dAe, &dBv, &dBe, &dCv, &dCe, &dVl, &dPr};
+    chk(cuLaunchKernel(fn, 1,1,1, 32,1,1, 0, 0, args, 0), "launch");
+    chk(cuCtxSynchronize(), "sync");
+
+    float Dout[4]; float Ceout; unsigned long long prout;
+    chk(cuMemcpyDtoH(Dout,   dCv, 16), "dCv");
+    chk(cuMemcpyDtoH(&Ceout, dCe,  4), "dCe");
+    chk(cuMemcpyDtoH(&prout, dPr,  8), "dPr");
+
+    // Print without asserting: the mma result depends on per-lane tile layout.
+    printf("--- NON-ZERO OPERAND mma.sync RESULTS ---\n");
+    printf("A = all f16 1.0 (0x3C00), B = all f16 1.0 (0x3C00), C = all f32 0.0\n");
+    printf("D[0..3] (measured): %.6f  %.6f  %.6f  %.6f\n",
+           Dout[0], Dout[1], Dout[2], Dout[3]);
+    printf("eps_C   (measured): %.6f   (sqrt(7) ref = %.6f)\n",
+           Ceout, sqrtf(7.f));
+    printf("prov    (measured): 0x%llx\n", prout);
+    printf("\n");
+    printf("NOTE: D values above confirm the tensor-core executed with non-zero\n");
+    printf("      operands and produced a deterministic result.  They are NOT the\n");
+    printf("      expected result of a general 16x16 A*B because the kernel\n");
+    printf("      broadcasts the same tile to every warp lane.\n");
+
+    // Soft sanity: D should be finite and non-negative (all-ones * all-ones + 0)
+    int finite_ok = 1;
+    for(int i = 0; i < 4; i++){
+        if(!(Dout[i] == Dout[i]) /* NaN check */ || Dout[i] < 0.f) finite_ok = 0;
+    }
+    printf("RESULT: finite_nonneg_D=%s  provenance=0x%llx\n",
+           finite_ok ? "PASS" : "FAIL", prout);
+
+    cuModuleUnload(mod);
+    cuDevicePrimaryCtxRelease(dev);
+    return finite_ok ? 0 : 2;
+}

--- a/benchmarks/solver/gpu_epistemic_scoring.sio
+++ b/benchmarks/solver/gpu_epistemic_scoring.sio
@@ -1,0 +1,47 @@
+// Boundary demonstrator: the CEILING of the checked public GPU kernel subset.
+//
+// These bodies mirror the per-variable scoring formulas in
+// `stdlib/theorem/smt.sio`, but they are NOT a GPU scorer: the inputs are
+// scalar and loop-invariant, the result is accumulated into a discarded local,
+// and there is no thread index, no array I/O, and no output. They emit
+// non-trivial PTX only because they stay inside the verified subset
+// (loops + scalar f64 arithmetic).
+//
+// A real per-variable GPU scorer needs `gpu.thread_id`/`gpu.block_id` and array
+// params, which are NOT in the checked public surface (check fails with
+// "Undefined variable: gpu"; thread-indexed/array kernels fail emission rc=1).
+// See docs/research/solver-gpu-native-path-2026-06-27.md for the boundary map.
+//
+//   souc-linux-x86_64-gpu check benchmarks/solver/gpu_epistemic_scoring.sio
+//   souc-linux-x86_64-gpu build benchmarks/solver/gpu_epistemic_scoring.sio \
+//       --backend gpu -o /tmp/gpu_epistemic_scoring.ptx
+
+// UCB-style epistemic score: act_mean + beta * sqrt(act_var)
+// (smt.sio: "Score = act_mean[v] + 0.5*sqrt(act_var[v])" — exploit + explore).
+kernel fn epistemic_ucb_score(n: i64, act_mean: f64, act_var: f64, beta: f64) with GPU, Div, Mut {
+    var i: i64 = 0
+    var acc: f64 = 0.0
+    while i < n {
+        let spread = beta * sqrt(act_var)
+        let score = act_mean + spread
+        acc = acc + score
+        i = i + 1
+    }
+}
+
+// Beta-Bernoulli polarity posterior: phase_alpha / (phase_alpha + phase_beta)
+// (smt.sio: "posterior P(true is good for v)").
+kernel fn epistemic_beta_polarity(n: i64, phase_alpha: f64, phase_beta: f64) with GPU, Div, Mut, Panic {
+    var i: i64 = 0
+    var acc: f64 = 0.0
+    while i < n {
+        let denom = phase_alpha + phase_beta
+        let posterior = phase_alpha / denom
+        acc = acc + posterior
+        i = i + 1
+    }
+}
+
+fn main() -> i32 with IO {
+    0
+}

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 845
-- Repo-backed topics: 695
+- Total governed topics: 846
+- Repo-backed topics: 696
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 170
+- Authority count `historical`: 171
 - Authority count `repo_only`: 487
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 219 topics
+- A6: 220 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -633,6 +633,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sedenion-zero-divisor-geometry-report | historical | docs/research/SEDENION_ZERO_DIVISOR_GEOMETRY_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.self-hosted-hypercomplex | historical | docs/research/self_hosted_hypercomplex.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.smt-farkas-microkernel-2026-06-23 | historical | docs/research/smt-farkas-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.solver-gpu-native-path-2026-06-27 | historical | docs/research/solver-gpu-native-path-2026-06-27.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.solver-heuristic-literature-matrix-2026-06-25 | historical | docs/research/solver-heuristic-literature-matrix-2026-06-25.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.solver-lorenz-v175-lane-state-2026-06-24 | historical | docs/research/solver-lorenz-v175-lane-state-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.solver-novelty-readiness-2026-06-25 | historical | docs/research/solver-novelty-readiness-2026-06-25.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13926,6 +13926,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.solver-gpu-native-path-2026-06-27",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/solver-gpu-native-path-2026-06-27.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.solver-heuristic-literature-matrix-2026-06-25",
       "collection": "repo",
       "repo_doc_path": "docs/research/solver-heuristic-literature-matrix-2026-06-25.md",

--- a/docs/research/solver-gpu-native-path-2026-06-27.md
+++ b/docs/research/solver-gpu-native-path-2026-06-27.md
@@ -1,0 +1,101 @@
+<!-- docs:meta
+topic_id: repo.docs.research.solver-gpu-native-path-2026-06-27
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.solver-gpu-native-path-2026-06-27
+-->
+
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Solver lane on Sounio's native GPU path — Blackwell runtime VERIFIED (2026-06-27)
+
+Toward the lane's target (showcase Sounio's native GPU + machine-code control). The
+headline result: **a Sounio-emitted epistemic tensor-core kernel executes on a real
+NVIDIA Blackwell GB10 (sm_121), with GUM uncertainty propagated through the tensor
+cores and verified exact.** This supersedes an earlier intermediate note on this page
+that concluded "the GPU surface can't express a solver kernel" — that was true only of
+the *narrow checked `kernel fn` surface*; the internal K-AXI/Kretikos engine underneath
+has thread/block intrinsics, array access, CUBIN emission, and multi-arch targeting.
+
+Evidence tags per `docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md`: **MEASURED**
+(re-runnable artifact) / **BOUNDED** / **SOURCE-ONLY**. No claim rests on a projection.
+
+## The two GPU surfaces
+
+- **Narrow public `kernel fn` surface** (the `souc-linux-x86_64-gpu --backend gpu`
+  path): loops + scalar f64 only; no thread index, no array I/O. `benchmarks/solver/
+  gpu_epistemic_scoring.sio` is a boundary demonstrator of that *ceiling* — it mirrors
+  the smt.sio UCB/Beta formulas and emits non-trivial PTX, but is loop-invariant scalar
+  with a discarded result, i.e. NOT a scorer.
+- **Internal K-AXI / Kretikos engine** (`self-hosted/gpu/`, driver `bin/kretikos`): full
+  thread/block intrinsics (`get_tid`/`get_bid`/`get_ntid`/`get_nctaid` + `getvar`
+  array access), an audited K-AXI→PTX emitter (53 patterns × 6 modes, 0/318 static
+  violations, f64 register banks), and **real CUBIN emission** (`kretikos_emit_cubin`,
+  pure-Sounio CUBIN validator) — i.e. below PTX, bypassing nvcc. This is where a real
+  per-variable GPU solver scorer becomes expressible (next-work).
+
+## MEASURED on real Blackwell GB10 (sm_121, CUDA 13, 2026-06-27)
+
+Hardware: NVIDIA **GB10** (Grace-Blackwell, compute_cap **12.1 = sm_121**), driver 580,
+CUDA 13.0. Kernel: `self-hosted/gpu/epistemic_mma_reference.ptx` (epistemic
+`mma.sync.m16n8k16` with GUM shadow propagation, `ε_C = sqrt(K)·(|A|·ε_B + |B|·ε_A)`).
+
+1. **ptxas → Blackwell SASS/CUBIN** (closes the KAXI audit's open "ptxas needs a GPU"):
+   ```
+   epistemic_mma_reference.ptx  → ptxas -arch=sm_121 → 6648-byte CUBIN (real ELF)
+   FIXED kretikos emitter output → ptxas -arch=sm_121 → 5048-byte CUBIN   (PR #483)
+   ```
+2. **Runtime, verifiable case A=0 ⇒ D = A·B + C = C** (layout-independent), via the CUDA
+   Driver API (`benchmarks/solver/gpu/run_epistemic_mma_*.c`):
+   ```
+   device: NVIDIA GB10  sm_121
+   D     (expect 1,2,3,4): 1.0000 2.0000 3.0000 4.0000        ← tensor-core data path PASS
+   eps_C (expect sqrt(7)=2.64575): 2.64575                    ← GUM epistemic shadow PASS (exact)
+   prov  (expect 0x5): 0x5                                    ← provenance union PASS
+   ```
+   Done both as **JIT** (sm_80 PTX → sm_121 at load, `cuModuleLoadDataEx`) and as
+   **native sm_121 SASS** (`ptxas -arch=sm_121` → cubin → `cuModuleLoad`, no JIT).
+3. **Non-zero operands** (A=B=f16 1.0, C=0): `D = [16,16,16,16]` — the K=16 contraction
+   executed deterministically on the tensor cores.
+
+This validates the "compiler-integrated GUM standard uncertainty through GPU tensor
+cores" claim **on real hardware**, not in a fixture.
+
+## Reproducible receipt
+
+```bash
+# On the workspace (x86): the PTX is checked in at
+#   self-hosted/gpu/epistemic_mma_reference.ptx   (strip non-ASCII comments first; see #476)
+# On a Blackwell host (CUDA 13):
+P=/usr/local/cuda-13.0/bin
+$P/ptxas -arch=sm_121 epistemic_mma_reference.ptx -o epi_sm121.cubin
+nvcc -O2 benchmarks/solver/gpu/run_epistemic_mma_native_sm121.c -lcuda -o run_native
+./run_native epi_sm121.cubin            # expect D=[1,2,3,4], eps_C=2.64575, all PASS
+```
+Note CUDA-13 specifics: use `cuDevicePrimaryCtxRetain` (the `cuCtxCreate` macro maps to
+`cuCtxCreate_v4`); ptxas/nvcc are not on the default non-interactive SSH PATH.
+
+## Honest caveats (held to the doc's evidence bar)
+
+- The runtime used the hand-authored **reference** PTX. The emitter *pipeline* now also
+  produces ptxas-valid Blackwell CUBINs after PR #483 (non-ASCII fix); the second emitter
+  finding (`retval` illegal state space, #477) is a **stale-artifact non-issue** — it came
+  from the removed old `souc-linux-x86_64-gpu` binary's cached PTX, not the live emitter.
+- `A=0 ⇒ D=C` is a valid but specific verification; the kernel's per-lane *broadcast* load
+  means it is NOT a general 16×16 A·B (the `mma.sync` instruction executed on Blackwell
+  tensor cores; a correct fragment-loading kernel is the next step for true matmul verify).
+- This is **not** Level 3 by itself; it is a measured capability + runtime receipt.
+
+## Next work
+
+Author a real **per-variable parallel epistemic solver scorer** via the K-AXI thread-index
+path (`get_tid` + `getvar` array access; f64 banks), mirroring smt.sio's UCB
+`act_mean + β·sqrt(act_var)` + Beta polarity, with real array I/O and verified output on
+the GB10 — the genuine GPU-solver showcase, now that both the path and Blackwell execution
+are proven.


### PR DESCRIPTION
## Summary
Consolidates the **verified Blackwell-GPU runtime** milestone into the repo as a durable, reproducible receipt — so the result lives in version control, not just in `/tmp` + notes.

**Headline (MEASURED on real hardware):** a Sounio epistemic tensor-core kernel runs on a real **NVIDIA Blackwell GB10 (sm_121, CUDA 13)** with **GUM uncertainty propagated through the tensor cores, verified exact**:
```
D     (A=0 ⇒ D=C): 1,2,3,4        ← tensor-core data path PASS
eps_C (= sqrt(7)):  2.64575        ← GUM epistemic shadow PASS (exact)
prov:               0x5            ← provenance union PASS
```
Done both **JIT** (sm_80 PTX → sm_121) and **native sm_121 SASS** (`ptxas -arch=sm_121` → cubin → `cuModuleLoad`). Closes the KAXI audit's open "ptxas needs a GPU" gap.

## Contents
- `docs/research/solver-gpu-native-path-2026-06-27.md` — **corrected** from an earlier intermediate "the GPU surface can't express a solver kernel" framing (true only of the narrow public `kernel fn` surface; the internal K-AXI/Kretikos engine has thread intrinsics + array access + CUBIN emission). Strict MEASURED tags + honest caveats.
- `benchmarks/solver/gpu/*.c` — the 3 CUDA Driver-API launchers (JIT, native sm_121, non-zero operands) as a reproducible receipt.
- `benchmarks/solver/gpu_epistemic_scoring.sio` — retained as the narrow-surface *ceiling* demonstrator.

## Honest caveats (in the doc)
Reference PTX used (the live emitter now also assembles on Blackwell after #483); `A=0 ⇒ D=C` is layout-independent but not a general A·B (the reference kernel broadcasts the same fragment per lane). Emitter findings: #483 (non-ASCII, merged), #477 (`retval`, stale-artifact non-issue).

## Next
A real per-variable parallel epistemic solver scorer via the K-AXI thread-index path (the genuine GPU-solver showcase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
