### PR TITLE
[codex] Route imported Madaros builds through compact IR

### DIFF
--- a/self-hosted/compiler/module_native_driver.sio
+++ b/self-hosted/compiler/module_native_driver.sio
@@ -1136,6 +1136,15 @@ pub fn compile_multimodule_native_advanced(
         print("module_native_driver: imported source uses modular IR path\n")
     }
 
+    print("module_native_driver: imported source uses compact modular IR table path\n")
+    let imported_ir_status = load_multimodule_imported_simple_ir_global(main_path)
+    if imported_ir_status.ok {
+        return native_driver_write_imported_simple_ir_elf(output_path)
+    }
+    print("module_native_driver: compact IR load failed: ")
+    print(imported_ir_status.error_msg)
+    print("\n")
+
     module_frontend_compile_imported_to_file(main_path, output_path)
 }
 


### PR DESCRIPTION
## Summary

Routes imported `bin/madaros build/run` through the existing compact modular IR table path before falling back to the full imported lowering path.

The failing witness currently reaches `module_frontend_compile_imported_to_file`, then `module_frontend_lower_programs_array_compile_to_file`, and segfaults around `lower_array: seed_begin`. The compact imported-simple path is already used by `module_native_simple_driver.sio`; this change lets the primary `module_native_driver.sio` try the same path for supported imported programs.

## Root Cause

`madaros_multimodule_witness.sh` exercises `bin/madaros check|run|build`. `check` succeeds, but `run/build` invoke raw Madaros through the full imported native driver. For simple imported witnesses like `thin_single`, that driver goes into the fragile full boxed lowering route and exits `139` before producing an ELF.

## Impact

Supported imported-simple programs can compile through `bin/madaros build/run` without entering the crashing full imported lowering route. Unsupported imported shapes still fall back to the existing full path, preserving behavior outside the compact bridge coverage.

## Validation

- `git diff --check` passed.
- Reproduced current failure before the patch with `SOUNIO_MADAROS_MM_WITNESS_DIR=/tmp/sounio-madaros-mm-witness-run timeout 300 bash scripts/ci/madaros_multimodule_witness.sh`: `thin_single expected_exit=7 actual_exit=139`.
- Traced failure boundary with `SOUNIO_MODULE_FRONTEND_LOWER_TRACE=1 timeout 120 bin/madaros run tests/multimodule/thin_single_main.sio`: summary lowering completed and the crash happened after `bodies_begin`.
- `timeout 120 bin/madaros check self-hosted/compiler/module_native_driver.sio` was not useful as source validation with the checked-in raw compiler: it emitted unrelated parse errors later in the large compiler module and segfaulted.
- `timeout 300 bash scripts/ci/native_v2_imported_core_abi_gate.sh` did not complete locally before timeout while in frontend convergence.
- `timeout 300 bash scripts/ci/compiler_stage_contract_gate.sh` failed locally, but its logs show it used `/workspace/sounio/bin/souc` from the dirty primary checkout rather than the isolated worktree compiler, so I am not treating that result as patch evidence.

LLM-offload reviews invoked: none. This touches internal compiler routing only; no math claims, clinical-pathway code, or external-facing artifacts.