### PR TITLE
[codex] Gate Madaros prebuilt refresh on multimodule witness

### DIFF
--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -64,17 +64,20 @@ jobs:
           # commit; keep the last-good prebuilt. Only a green gate refreshes.
           # The full gate is the broad contract; the enum + loop gates additionally
           # build+run enum-variant USE and for/while + break/continue (which the full
-          # gate never exercised). The source-to-ELF gate covers the raw
-          # --native-v2-compile bridge, so a prebuilt that regresses the direct
-          # source -> native-v2 -> ELF path is not shipped.
+          # gate never exercised). The multimodule witness covers import-aware
+          # bin/madaros check|run|build, which the full suite can miss when
+          # source and the checked-in prebuilt drift. The source-to-ELF gate
+          # covers the raw --native-v2-compile bridge, so a prebuilt that
+          # regresses the direct source -> native-v2 -> ELF path is not shipped.
           if bash scripts/ci/madaros_full_gate.sh \
              && bash scripts/ci/madaros_enum_gate.sh \
              && bash scripts/ci/madaros_loop_gate.sh \
+             && bash scripts/ci/madaros_multimodule_witness.sh \
              && bash scripts/ci/madaros_source_to_elf_gate.sh; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
           else
             echo "passed=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::A Madaros gate (full / enum / loop / source-to-ELF) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
+            echo "::warning::A Madaros gate (full / enum / loop / multimodule witness / source-to-ELF) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
           fi
 
       - name: Install built Madaros as the checked-in prebuilt
@@ -100,7 +103,7 @@ jobs:
           git commit -m "build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]
 
           Auto-rebuilt from ${SRC_REF} (make build-madaros) and passed the
-          Madaros full, enum, loop, and source-to-ELF gates. Keeps the
+          Madaros full, enum, loop, multimodule witness, and source-to-ELF gates. Keeps the
           out-of-box Madaros default current with self-hosted/compiler/main.sio.
           Binary size: ${BYTES} bytes."
 


### PR DESCRIPTION
## Summary

Adds `scripts/ci/madaros_multimodule_witness.sh` to the `Madaros Prebuilt Refresh` gate stack before the workflow installs and commits a refreshed `bin/madaros-linux-x86_64`.

## Why

After #490, `origin/main` source contains the compact imported modular IR route for `module_native_driver.sio`, and main CI is green. However, a clean worktree from `origin/main@e7463318` still resolves `bin/madaros` to the checked-in `bin/madaros-linux-x86_64`, and that stale prebuilt still fails the multimodule witness:

```text
[madaros-mm-witness] FAIL: thin_single expected_exit=7 actual_exit=139
module_native_driver: imported source uses modular IR path
imported_compile: lower_begin
lower_array: seed_begin
Segmentation fault
```

The refresh workflow already gates full, enum, loop, and source-to-ELF behavior before shipping a new checked-in prebuilt. This PR adds the import-aware `bin/madaros check|run|build` witness to that same ship/no-ship decision so source/prebuilt drift like this is caught at the artifact boundary.

## Validation

- `git diff --check` passed.
- Verified the workflow file now references each refresh gate once: `madaros_full_gate.sh`, `madaros_enum_gate.sh`, `madaros_loop_gate.sh`, `madaros_multimodule_witness.sh`, and `madaros_source_to_elf_gate.sh`.
- Reproduced the current checked-in prebuilt failure in a clean `origin/main@e7463318` worktree with `SOUNIO_MADAROS_MM_WITNESS_DIR=/tmp/sounio-full-lowerer-mm-witness timeout 300 bash scripts/ci/madaros_multimodule_witness.sh`.

LLM-offload reviews invoked: none. This is CI/artifact gating only; it does not touch math claims, clinical-pathway code, or external-facing artifacts.