### PR TITLE
docs(audit): de-indent §1 gate table (robust GFM rendering)

### DIFF
--- a/docs/audit/PBPK_DISSERTATION_SESSION_NOTES_2026-06-28.md
+++ b/docs/audit/PBPK_DISSERTATION_SESSION_NOTES_2026-06-28.md
@@ -31,13 +31,13 @@ gate result (operating principle R5: intrinsic property vs defect):
 - **lean_single fixed-point engine** (`SOUNIO_SOUC_ENGINE=lean_single`, ELF
   `bin/souc-lean-single-x86_64`) compiles and runs the same sources **clean**:
 
-  | Gate | Result | Markers |
-  |---|---|---|
-  | `dissertation_pbpk28_parity_gate` | PASS | `PBPK28_PARITY_PASS 14/14`, `MASS_CONSERVATION_PASS 12/12`, `TMDD_PARITY_PASS 3/3`, `PD_PARITY_PASS 1/1`, `SEMAGLUTIDE_PARITY_PASS 14/14`, `SEMA_TMDD/SEMA_PD` |
-  | `dissertation_frontend_parity_gate` | PASS | `PARITY_PASS 14/14` |
-  | `dissertation_confidence_gate_gate` | PASS | C4: honest-ceiling compiles, over-claim + non-literal ε rejected |
-  | `dissertation_pbpk_suite_gate` | PASS | 51/53 active; 2 PENDING (clinical, awaiting observed data) |
-  | `dissertation_pbpk_hessian_gate` | science PASS | `HESSIAN_PBPK28_DUAL_RHO_PASS`; CSV byte-identical to golden |
+| Gate | Result | Markers |
+|---|---|---|
+| `dissertation_pbpk28_parity_gate` | PASS | `PBPK28_PARITY_PASS 14/14`, `MASS_CONSERVATION_PASS 12/12`, `TMDD_PARITY_PASS 3/3`, `PD_PARITY_PASS 1/1`, `SEMAGLUTIDE_PARITY_PASS 14/14`, `SEMA_TMDD/SEMA_PD` |
+| `dissertation_frontend_parity_gate` | PASS | `PARITY_PASS 14/14` |
+| `dissertation_confidence_gate_gate` | PASS | C4: honest-ceiling compiles, over-claim + non-literal ε rejected |
+| `dissertation_pbpk_suite_gate` | PASS | 51/53 active; 2 PENDING (clinical, awaiting observed data) |
+| `dissertation_pbpk_hessian_gate` | science PASS | `HESSIAN_PBPK28_DUAL_RHO_PASS`; CSV byte-identical to golden |
 
 **Gotchas**
 - lean_single does **not** `chmod +x` its emitted ELF, so gates guarding with


### PR DESCRIPTION
Pure-formatting follow-up to #497: the §1 "two compiler surfaces" gate table in `docs/audit/PBPK_DISSERTATION_SESSION_NOTES_2026-06-28.md` was indented 2 spaces under the lean_single bullet (renders on GitHub but fragile in stricter Markdown engines). De-indented to the left margin → unambiguous top-level table. No content change; `check_docs_registry.sh` passes; GFM render confirmed (2 tables, 12 rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)