### PR TITLE
fix(gpu): accept public thread intrinsics in Madaros

### DIFF
--- a/examples/kretikos/gpu_pid_population.sio
+++ b/examples/kretikos/gpu_pid_population.sio
@@ -1,0 +1,10 @@
+kernel fn pid_compute(n: i64) with GPU, Panic {
+    let tid = gpu_thread_id_x()
+    let bid = gpu_block_id_x()
+    let bdim = gpu_block_dim_x()
+    let pid = bid * bdim + tid
+    if pid < n {
+        gpu_sync_threads()
+    }
+}
+fn main() -> i32 with IO { 0 }

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -2867,7 +2867,10 @@ fn checker_collect_fn_def_inplace(c: *mut Checker, opt: Option<Box<FnDef> >, vis
                     }
                     ri = ri + 1
                 }
-                if ret_ty.kind != TypeKind::TyUnit {
+                // E072: a missing return annotation lowers to TyUnknown and is
+                // implicitly unit for a void kernel — accept it; only an EXPLICIT
+                // non-unit return type is an error. (Mirrors the collect_fn_def site.)
+                if ret_ty.kind != TypeKind::TyUnit && ret_ty.kind != TypeKind::TyUnknown {
                     checker_report_error_at_inplace(c, (*fd).span, 72, 0, 0, 0)
                 }
             }
@@ -4087,6 +4090,13 @@ fn checker_check_stmts_inplace(c: *mut Checker, opt: Option<Box<StmtList> >) -> 
     while true {
         match cursor {
             Some(list) => {
+                // Reset the int-literal flag before each stmt so that after the
+                // loop (*c).last_literal_kind reflects ONLY the block's tail
+                // statement — a bare `0` leaves it set, a non-literal tail (call,
+                // ident, binary) leaves it clear, never stale from an earlier
+                // statement's literal. The E008 return-narrow (checker_collect_fn_
+                // def_inplace) depends on this being the tail's literalness.
+                (*c).last_literal_kind = 0
                 last_ty = checker_check_stmt_inplace(c, (*list).head)
                 // Capture the escape provenance of the block's TAIL expression
                 // (the value the block/function yields) while the AST is still live;
@@ -4152,6 +4162,7 @@ fn checker_check_opt_expr_inplace(c: *mut Checker, opt: Option<Box<Expr> >) -> T
 }
 
 fn checker_check_return_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    (*c).last_literal_kind = 0  // so the flag reflects ONLY this return value expr
     let val_ty = checker_check_opt_expr_inplace(c, e.left)
     match e.left {
         Some(val_expr) => {
@@ -6174,7 +6185,20 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
     // The GPU backend lowers these by name to PTX sregs (%tid.x / %ctaid.x /
     // %ntid.x, etc.); see hlir_to_gpu.sio / lower_to_ptx.sio.
     if call_expr_is_gpu_builtin(e.left) {
-        return ty_u32()
+        // Barriers (gpu_barrier, gpu_barrier_sync, gpu_sync_threads) are void
+        // side-effects; the thread-index/dim intrinsics return a u32 coordinate.
+        if call_expr_is_gpu_barrier(e.left) {
+            return ty_unit()
+        }
+        // E004: thread/block coordinate intrinsics return the language's native
+        // index type i64 (not u32), so cast-free witness kernels typecheck as
+        // written — `let i = bid*bdim + tid; if i < n` where `n: i64` no longer
+        // reports a u32/i64 mismatch. The GPU backend lowers GpuGetTid/Bid/Ntid
+        // by NAME to 32-bit PTX sregs (%tid.x etc.) independent of this checker
+        // type (hlir_to_gpu.sio hardcodes GpuU32 for the read; all integer binops
+        // lower as i32), so widening the checker type to i64 keeps strict integer
+        // typing intact without changing the emitted register width.
+        return ty_i64()
     }
     if call_expr_is_box_new(e.left) {
         return checker_check_box_new_expr_inplace(c, e)
@@ -12261,11 +12285,29 @@ fn call_expr_is_builtin_uncertainty_of(opt: Option<Box<Expr> >) -> bool with Mut
 
 // Read-only GPU thread/block coordinate intrinsics. These are implicit
 // kernel-scope builtins with no user-declared signature, so the call checker
-// must recognise them by name and assign their result type (u32) directly —
+// must recognise them by name and assign their result type directly —
 // otherwise the callee ident falls through to the unbound-identifier check
 // (E137) just as the name resolver would reject it without its allowlist.
 // MUST stay in sync with name_is_gpu_builtin() in self-hosted/resolve/resolve.sio
 // and token_is_gpu_builtin_name() in self-hosted/compiler/lean_single.sio.
+// The subset of call_expr_is_gpu_builtin names that are void barriers (return
+// unit), as opposed to the thread-index/dim coordinate reads (return i64).
+fn call_expr_is_gpu_barrier(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
+    match opt {
+        Some(expr) => {
+            if (*expr).kind != ExprKind::ExprIdent {
+                return false
+            }
+            let n = (*expr).name
+            if name_eq(n, make_name("gpu_barrier")) { return true }
+            if name_eq(n, make_name("gpu_barrier_sync")) { return true }
+            if name_eq(n, make_name("gpu_sync_threads")) { return true }
+            false
+        }
+        None => false
+    }
+}
+
 fn call_expr_is_gpu_builtin(opt: Option<Box<Expr> >) -> bool with Mut, Panic, Div, Alloc, IO {
     match opt {
         Some(expr) => {
@@ -16299,8 +16341,11 @@ impl Checker {
                         ri = ri + 1
                     }
 
-                    // E072: Kernel must return unit type
-                    if ret_ty.kind != TypeKind::TyUnit {
+                    // E072: Kernel must return unit type. A missing return
+                    // annotation lowers to TyUnknown (lower_opt_return_type's
+                    // None case), which is implicitly unit for a void kernel —
+                    // accept it; only an EXPLICIT non-unit return type is an error.
+                    if ret_ty.kind != TypeKind::TyUnit && ret_ty.kind != TypeKind::TyUnknown {
                         c = c.report_error_at((*fd).span, 72, 0, 0, 0)
                     }
                 }

--- a/self-hosted/gpu/ptx_width_harness.sio
+++ b/self-hosted/gpu/ptx_width_harness.sio
@@ -1,0 +1,86 @@
+// Isolated verification of the gap-C register-width fix via the omega Rust
+// interpreter (which does NOT have the lean_single seed's large-by-value-struct
+// native miscompile). Builds a complete i64 index-bounds kernel and emits PTX
+// through the PRODUCTION gpu_lower_to_ptx (lower_to_ptx.sio, with gap C).
+// Run: souc run self-hosted/gpu/ptx_width_harness.sio
+// Signals: cvt.u64.u32 after each sreg read; setp.lt.s64 over %rd.
+
+use kernel_ir::*
+use ptx::*
+use lower_to_ptx::*
+
+fn append(k0: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
+    var k = k0
+    let c = k.op_count
+    if c < 1024 {
+        k.ops[c as usize] = op
+        k.op_count = c + 1
+    }
+    k
+}
+
+fn mk(oc: GpuOpcode, dst: i64, lhs: i64, rhs: i64, t: GpuType) -> GpuOp with Mut, Panic, Div {
+    var o = gpu_op_new()
+    o.opcode = oc
+    o.dst_reg = dst
+    o.lhs_reg = lhs
+    o.rhs_reg = rhs
+    o.ty = t
+    o
+}
+
+fn mk_intrin(oc: GpuOpcode, reg: i64) -> GpuOp with Mut, Panic, Div {
+    var o = gpu_op_new()
+    o.opcode = oc
+    o.dst_reg = reg
+    o.axis = 0
+    o.ty = GpuType::GpuU32
+    o
+}
+
+fn mk_cvt(reg: i64) -> GpuOp with Mut, Panic, Div {
+    var c = gpu_op_new()
+    c.opcode = GpuOpcode::GpuCvt
+    c.dst_reg = reg
+    c.src_reg = reg
+    c.dst_ty = GpuType::GpuU64
+    c.src_ty = GpuType::GpuU32
+    c.ty = GpuType::GpuU64
+    c
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    var k = gpu_kernel_new()
+    k.kernel_name = ki_ir_name_from_bytes(118, 97, 100, 100, 4)  // "vadd"
+    var p = gpu_param_new()
+    p.name = ki_ir_name_from_bytes(110, 0, 0, 0, 1)  // "n"
+    p.ty = GpuType::GpuU64
+    k.params[0] = p
+    k.param_count = 1
+    k.max_reg_u32 = 4
+    k.max_reg_u64 = 8
+    k.max_reg_pred = 2
+
+    k = append(k, mk_intrin(GpuOpcode::GpuGetTid, 1))
+    k = append(k, mk_cvt(1))
+    k = append(k, mk_intrin(GpuOpcode::GpuGetBid, 2))
+    k = append(k, mk_cvt(2))
+    k = append(k, mk_intrin(GpuOpcode::GpuGetNtid, 3))
+    k = append(k, mk_cvt(3))
+    k = append(k, mk(GpuOpcode::GpuMul, 4, 2, 3, GpuType::GpuI64))
+    k = append(k, mk(GpuOpcode::GpuAdd, 5, 4, 1, GpuType::GpuI64))
+    var lp = gpu_op_new()
+    lp.opcode = GpuOpcode::GpuLoadParam
+    lp.dst_reg = 6
+    lp.param_idx = 0
+    lp.ty = GpuType::GpuU64
+    k = append(k, lp)
+    k = append(k, mk(GpuOpcode::GpuSetpLt, 1, 5, 6, GpuType::GpuI64))
+    var r = gpu_op_new()
+    r.opcode = GpuOpcode::GpuRet
+    k = append(k, r)
+
+    let buf = gpu_lower_to_ptx(k)
+    ptx_buf_print(buf)
+    0
+}


### PR DESCRIPTION
## Summary
- accept public GPU thread/block coordinate intrinsics in Madaros checking as `i64` values
- treat GPU barrier builtins as unit-returning calls and allow void kernels without explicit return annotations
- add a public kernel repro plus a PTX width harness for thread/block sreg widening

## Validation
- `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-gpu-thread-intrinsics-final-20260628` -> OK, produced `/tmp/madaros-gpu-thread-intrinsics-final-20260628` (104006406 bytes)
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-thread-intrinsics-final-20260628 ./bin/souc check examples/kretikos/gpu_pid_population.sio` -> `check: OK`
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-thread-intrinsics-final-20260628 ./bin/souc check self-hosted/gpu/ptx_width_harness.sio` -> `check: OK`
- `git diff --check origin/main..HEAD` -> OK

## Notes
- This addresses the public thread/block intrinsic side of #468. It does not claim full solver-kernel array-param closure yet.
- LLM-offload reviews invoked: none; this is compiler/GPU harness code only, not math claims, clinical-pathway code, or external-facing artifacts.