### PR TITLE
fix(ir): stop forcing int locals to float scalar_kind (#478)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6385,7 +6385,17 @@ impl Lowerer {
                     lo = var_pair.0
                     if var_pair.1 >= 0 {
                         lo = lo.bind_local_variance_reg(s.name, var_pair.1)
-                        lo = lo.bind_local_scalar_kind(s.name, 2)
+                        // Do NOT force scalar_kind=2 (float) here. A variance reg is
+                        // produced for every tracked value, including INT locals
+                        // (variance 0); the value's scalar_kind was already set
+                        // authoritatively above (int/bool->1, float->2, string->3).
+                        // Clobbering it to float made `int_local + literal` (and the
+                        // for_sum loop accumulator `var s=3; s=s+5`) lower as a float
+                        // add, yielding 0 instead of 8 (#478). Re-assert float only
+                        // when the value is genuinely float, mirroring the if-branch.
+                        if lo.expr_result_is_float_ref(&(*expr_box_var)) {
+                            lo = lo.bind_local_scalar_kind(s.name, 2)
+                        }
                     }
                 }
             }
@@ -6457,11 +6467,13 @@ impl Lowerer {
         var lo = pair_rhs.0
         var rhs = pair_rhs.1
         var rhs_variance: i64 = -1
+        var rhs_is_float: bool = false
         match s.expr {
             Some(rhs_expr_var) => {
                 let rhs_var_pair = lo.lower_expr_variance_ref(&(*rhs_expr_var))
                 lo = rhs_var_pair.0
                 rhs_variance = rhs_var_pair.1
+                rhs_is_float = lo.expr_result_is_float_ref(&(*rhs_expr_var))
             }
             _ => {}
         }
@@ -6505,7 +6517,12 @@ impl Lowerer {
                             lo = lo.emit(ir_copy(dst, rhs))
                             if rhs_variance >= 0 {
                                 lo = lo.bind_local_variance_reg((*target_expr).name, rhs_variance)
-                                lo = lo.bind_local_scalar_kind((*target_expr).name, 2)
+                                // Re-assert float scalar_kind only when the RHS is
+                                // genuinely float; an int RHS that merely carries a
+                                // variance reg must not flip the local to float (#478).
+                                if rhs_is_float {
+                                    lo = lo.bind_local_scalar_kind((*target_expr).name, 2)
+                                }
                             }
                             (lo, dst)
                         }


### PR DESCRIPTION
## Summary

Fixes #478 — the Madaros `for_sum` miscompile where `var s = 3; s = s + 5; s` returned **0 instead of 8**.

## Root cause

In `Lowerer` var/let lowering (`self-hosted/ir/lower.sio`), two code paths unconditionally recorded `scalar_kind = 2` (float) whenever a value produced a **variance register**:

1. the `else`-branch of the var-declaration variance binding, and
2. the `=` assignment path.

A variance reg is produced for **every** tracked value — including integer locals (variance 0). So `var s = 3` was recorded as *float*. The subsequent `s + 5` then consulted `expr_result_is_float_ref(ident)` → `lookup_local_scalar_kind == 2` → emitted a **float add**, corrupting the integer accumulator. The for_sum loop accumulator hit the same path.

The sibling if-branch already gated its `scalar_kind = 2` write on actual float-ness via `expr_result_is_float_ref`; these two paths simply weren't gated the same way.

## Fix

Gate both `scalar_kind = 2` writes on genuine float-ness (`expr_result_is_float_ref`), mirroring the already-correct if-branch. The authoritative scalar_kind set earlier from the value's type (int/bool→1, float→2, string→3) is preserved. Variance-register binding is untouched.

## Verification (locally-built Madaros from this branch)

- `for_sum` → **8** (was 0) ✓
- b-series: var+var→7, param+lit→8, lit+lit→8, **chain (`s=s+5; s+1`)→9** (exercises assignment path), **float (`1.5+2.5>3.9`)→1** (no float regression) ✓
- `scripts/ci/madaros_loop_gate.sh` — all 8 loop/break/continue fixtures **PASS** ✓
- 4 ontology compile-fail axioms (E041 weakening, E009 subclass/superclass, disjoint) still **REJECT** ✓
- run-pass ontology typecheck output **byte-identical** to the committed prebuilt baseline (`check` never invokes lowering) ✓

Once this lands, the Madaros prebuilt refresh can commit a new binary, taking the previously-merged E009 (#475) and E041 (#439) ontology fixes **live in the committed prebuilt** (the loop gate had been blocking the refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)