### PR TITLE
fix(gpu): accept public dotted thread axes

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -4925,6 +4925,50 @@ fn checker_check_slice_borrow_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntr
     }
 }
 
+fn checker_expr_is_gpu_axis_root(e: Expr) -> bool with Mut, Panic, Div {
+    e.kind == ExprKind::ExprIdent && name_eq(e.name, make_name("gpu"))
+}
+
+fn checker_expr_gpu_axis_base_kind(e: Expr) -> i64 with Mut, Panic, Div, Alloc, IO {
+    if e.kind == ExprKind::ExprFieldAccess {
+        match e.left {
+            Some(base) => {
+                if checker_expr_is_gpu_axis_root(*base) {
+                    if name_eq(e.name, make_name("thread_id")) { return 1 }
+                    if name_eq(e.name, make_name("block_id")) { return 2 }
+                    if name_eq(e.name, make_name("block_dim")) { return 3 }
+                }
+            }
+            None => {}
+        }
+    } else if e.kind == ExprKind::ExprMethodCall {
+        match e.left {
+            Some(base) => {
+                if checker_expr_is_gpu_axis_root(*base) {
+                    if name_eq(e.name, make_name("thread_id")) { return 1 }
+                    if name_eq(e.name, make_name("block_id")) { return 2 }
+                    if name_eq(e.name, make_name("block_dim")) { return 3 }
+                }
+            }
+            None => {}
+        }
+    }
+    0
+}
+
+fn checker_expr_is_gpu_axis_field(e: Expr) -> bool with Mut, Panic, Div, Alloc, IO {
+    if e.kind != ExprKind::ExprFieldAccess {
+        return false
+    }
+    if !name_eq(e.name, make_name("x")) {
+        return false
+    }
+    match e.left {
+        Some(base) => checker_expr_gpu_axis_base_kind(*base) > 0,
+        None => false,
+    }
+}
+
 // *mut ExprFieldAccess handler — FULL transcription of check_field_access (13528), not a
 // bridge. The ONLY sub-expression is the object (e.left); it is routed through the *mut
 // spine via checker_check_opt_expr_inplace so a nested enum path-expr / binary / etc. in
@@ -4938,6 +4982,9 @@ fn checker_check_slice_borrow_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntr
 // byte-for-byte faithful to the by-value original. No (*c).expr_depth management here (the
 // dispatch owns it).
 fn checker_check_field_access_inplace(c: *mut Checker, e: Expr) -> TypeEntry with Mut, Panic, Div, Alloc, IO {
+    if checker_expr_is_gpu_axis_field(e) {
+        return ty_i64()
+    }
     let base_ty = checker_check_opt_expr_inplace(c, e.left)
     if base_ty.kind == TypeKind::TyNamed {
         let struct_idx = struct_table_find((*c).structs, base_ty.name)
@@ -18513,6 +18560,9 @@ impl Checker {
     // --------------------------------------------------------
 
     fn check_field_access(self, e: Expr) -> (Checker, TypeEntry) with Mut, Panic, Div, Alloc, IO {
+        if checker_expr_is_gpu_axis_field(e) {
+            return (self, ty_i64())
+        }
         let pair = self.check_opt_expr(e.left)
         var c = pair.0
         let base_ty = pair.1

--- a/self-hosted/hlir/lower.sio
+++ b/self-hosted/hlir/lower.sio
@@ -1910,6 +1910,50 @@ pub fn hlir_lower_literal(state: HlirLowerState, lit: Expr) -> (HlirLowerState, 
     hlir_lower_unit(state)
 }
 
+fn hlir_gpu_axis_root(e: Expr) -> bool {
+    e.kind == ExprKind::ExprIdent && hlir_ast_name_to_string(e.name) == "gpu"
+}
+
+fn hlir_gpu_axis_flat_name(e: Expr) -> string with Mut, Panic, Div, Alloc {
+    if e.kind != ExprKind::ExprFieldAccess {
+        return ""
+    }
+    if hlir_ast_name_to_string(e.name) != "x" {
+        return ""
+    }
+    match e.left {
+        Some(base) => {
+            if (*base).kind == ExprKind::ExprFieldAccess {
+                match (*base).left {
+                    Some(root) => {
+                        if hlir_gpu_axis_root(*root) {
+                            let axis_name = hlir_ast_name_to_string((*base).name)
+                            if axis_name == "thread_id" { return "gpu_thread_id_x" }
+                            if axis_name == "block_id" { return "gpu_block_id_x" }
+                            if axis_name == "block_dim" { return "gpu_block_dim_x" }
+                        }
+                    }
+                    None => {}
+                }
+            } else if (*base).kind == ExprKind::ExprMethodCall {
+                match (*base).left {
+                    Some(root2) => {
+                        if hlir_gpu_axis_root(*root2) {
+                            let axis_method = hlir_ast_name_to_string((*base).name)
+                            if axis_method == "thread_id" { return "gpu_thread_id_x" }
+                            if axis_method == "block_id" { return "gpu_block_id_x" }
+                            if axis_method == "block_dim" { return "gpu_block_dim_x" }
+                        }
+                    }
+                    None => {}
+                }
+            }
+        }
+        None => {}
+    }
+    ""
+}
+
 pub fn hlir_lower_match(state: HlirLowerState, scrutinee: i64, arms: Option<Box<MatchArmList>>) -> (HlirLowerState, i64) with Mut, Panic, Div, Alloc {
     // Minimal bridge implementation: lower first arm body if present.
     // Full pattern dispatch is handled by match_begin/match_merge APIs.
@@ -2043,6 +2087,11 @@ pub fn hlir_lower_expr(state: HlirLowerState, expr: Expr) -> (HlirLowerState, i6
     }
 
     if expr.kind == ExprKind::ExprFieldAccess {
+        let gpu_axis_name = hlir_gpu_axis_flat_name(expr)
+        if gpu_axis_name != "" {
+            var no_args: [i64; 64] = [0; 64]
+            return hlir_lower_call(s, gpu_axis_name, no_args, 0, hlir_type_i64())
+        }
         let base_pair = hlir_lower_expr_opt(s, expr.left)
         s = base_pair.0
         let field_idx = hlir_ast_name_hash(expr.name) % 16

--- a/self-hosted/resolve/resolve.sio
+++ b/self-hosted/resolve/resolve.sio
@@ -79,6 +79,50 @@ fn name_is_gpu_builtin(n: Name) -> bool with Mut, Panic, Div {
     false
 }
 
+fn expr_is_gpu_axis_root(e: Expr) -> bool with Mut, Panic, Div {
+    e.kind == ExprKind::ExprIdent && name_eq(e.name, make_name("gpu"))
+}
+
+fn expr_gpu_axis_base_kind(e: Expr) -> i64 with Mut, Panic, Div, Alloc, IO {
+    if e.kind == ExprKind::ExprFieldAccess {
+        match e.left {
+            Some(base) => {
+                if expr_is_gpu_axis_root(*base) {
+                    if name_eq(e.name, make_name("thread_id")) { return 1 }
+                    if name_eq(e.name, make_name("block_id")) { return 2 }
+                    if name_eq(e.name, make_name("block_dim")) { return 3 }
+                }
+            }
+            None => {}
+        }
+    } else if e.kind == ExprKind::ExprMethodCall {
+        match e.left {
+            Some(base) => {
+                if expr_is_gpu_axis_root(*base) {
+                    if name_eq(e.name, make_name("thread_id")) { return 1 }
+                    if name_eq(e.name, make_name("block_id")) { return 2 }
+                    if name_eq(e.name, make_name("block_dim")) { return 3 }
+                }
+            }
+            None => {}
+        }
+    }
+    0
+}
+
+fn expr_is_gpu_axis_field(e: Expr) -> bool with Mut, Panic, Div, Alloc, IO {
+    if e.kind != ExprKind::ExprFieldAccess {
+        return false
+    }
+    if !name_eq(e.name, make_name("x")) {
+        return false
+    }
+    match e.left {
+        Some(base) => expr_gpu_axis_base_kind(*base) > 0,
+        None => false,
+    }
+}
+
 // ============================================================
 // Core operations — define, lookup, scoping, errors
 // ============================================================
@@ -965,6 +1009,9 @@ impl Resolver {
             }
             ExprKind::ExprUnary => self.resolve_opt_expr(e.left)
             ExprKind::ExprFieldAccess => {
+                if expr_is_gpu_axis_field(e) {
+                    return self
+                }
                 // Resolve the base expression; field checked by type checker
                 self.resolve_opt_expr(e.left)
             }

--- a/tests/run-pass/gpu_public_thread_array_params.sio
+++ b/tests/run-pass/gpu_public_thread_array_params.sio
@@ -1,0 +1,32 @@
+//@ run-pass
+//@ check-only
+//@ requires: madaros
+
+kernel fn gpu_public_thread_array_params(
+    a: &[f64; 32],
+    b: &[f64; 32],
+    out: &![f64; 32],
+    n: i64
+) with GPU, Panic {
+    let tid = gpu.thread_id.x
+    let bid = gpu.block_id.x
+    let bdim = gpu.block_dim.x
+    let i = bid * bdim + tid
+    if i < n {
+        (*out)[i] = (*a)[i] + (*b)[i]
+    }
+}
+
+kernel fn gpu_public_thread_method_array_params(
+    out: &![f64; 32],
+    n: i64
+) with GPU, Panic {
+    let i = gpu.thread_id().x
+    if i < n {
+        (*out)[i] = 1.0
+    }
+}
+
+fn main() -> i32 with IO {
+    0
+}


### PR DESCRIPTION
## Summary
- recognize public dotted GPU axis expressions `gpu.thread_id.x`, `gpu.block_id.x`, and `gpu.block_dim.x` during Madaros resolution and checking
- normalize dotted axis expressions, including `gpu.thread_id().x`, to the existing flat GPU builtin names before HLIR field lowering
- add a Madaros-only check-only run-pass covering dotted thread/block axes with fixed array params `&[f64; 32]` and `&![f64; 32]`

## Validation
- `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-gpu-array-patched-20260628` -> OK, produced `/tmp/madaros-gpu-array-patched-20260628` (104023436 bytes)
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-array-patched-20260628 ./bin/souc check tests/run-pass/gpu_public_thread_array_params.sio` -> `check: OK`
- `SOUC_BIN=/tmp/sounio-gpu-array-params-20260628/bin/souc MADAROS_RAW_BIN=/tmp/madaros-gpu-array-patched-20260628 SOUNIO_STDLIB_PATH=/tmp/sounio-gpu-array-params-20260628/stdlib SOUNIO_MADAROS_AVAILABLE=1 bash scripts/run_sio_test_suite.sh gpu_public_thread_array_params --verbose` -> PASS 1/1
- `SOUNIO_TEST_SOUC_BIN=/tmp/pr502-native/souc-stage2 SOUNIO_STDLIB_PATH=/tmp/sounio-gpu-array-params-20260628/stdlib bash scripts/run_sio_test_suite.sh gpu_public_thread_array_params --verbose` -> SKIP 1/1 (`requires:madaros`), matching the current CI Full Test Suite route
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-array-patched-20260628 ./bin/souc check examples/gpu/vec_add.sio` -> `check: OK`
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-array-patched-20260628 ./bin/souc check examples/kretikos/lower_vec_div_f64.sio` -> `check: OK`
- `git diff --check` -> OK

## Baseline evidence
- baseline `origin/main` Madaros `/tmp/madaros-gpu-array-baseline-20260628` accepted `examples/gpu/vec_add.sio` with flat `gpu_thread_id_x()` and array params
- the same baseline rejected `tests/run-pass/gpu_public_thread_array_params.sio` with E137 on `gpu`, confirming this PR fixes the remaining dotted public spelling gap in Madaros

## Notes
- This advances #468 by accepting the documented/probed public `.x` spelling with array params in Madaros. It does not claim full `y/z` axis lowering, lean_single/stage2 dotted-spelling support, or `GPU.launch` closure.
- LLM-offload reviews invoked: none; this is compiler/GPU harness code only, not math claims, clinical-pathway code, or external-facing artifacts.