### PR TITLE
fix(codegen): deref aggregate ref-params; remove lean_single ontology pin

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -18,6 +18,9 @@ struct LowerLocalStack {
     global_bss_offsets: [i64; 4096],
     global_bss_sizes: [i64; 4096],
     is_global: [i64; 4096],
+    // 1 = local/param holds a reference (&P / &[T;N] / &![T;N]) to a heap aggregate,
+    // i.e. its slot stores a raw address of the caller slot, not the handle directly.
+    is_ref: [i64; 4096],
     // 0=other 1=int 2=float; used by println dispatch to avoid routing i64/f64 vars through print_str
     scalar_kind: [i64; 4096],
     // f64 register carrying the GUM variance shadow for scalar locals, or -1 when absent.
@@ -40,6 +43,7 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         global_bss_offsets: [0; 4096],
         global_bss_sizes: [0; 4096],
         is_global: [0; 4096],
+        is_ref: [0; 4096],
         scalar_kind: [0; 4096],
         variance_regs: [-1; 4096],
         closure_fn_id: [-1; 4096],
@@ -1671,12 +1675,31 @@ fn lowerer_bind_local_mut(
         (*locals_box).global_bss_offsets[idx as usize] = 0
         (*locals_box).global_bss_sizes[idx as usize] = 0
         (*locals_box).is_global[idx as usize] = 0
+        (*locals_box).is_ref[idx as usize] = 0
         (*locals_box).scalar_kind[idx as usize] = 0
         (*locals_box).variance_regs[idx as usize] = -1
         (*locals_box).count = idx + 1
         (*lo).locals = locals_box
     } else {
         lowerer_mark_error(lo)
+    }
+}
+
+// *mut analogue: mark a just-bound param/local as a reference-typed binding so
+// field/index lowering can emit the extra dereference for &P / &[T;N] params.
+fn lowerer_mark_local_ref_mut(
+    lo: &! Lowerer,
+    name: Name
+) with Mut, Alloc, Panic, Div {
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).is_ref[i as usize] = 1
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
     }
 }
 
@@ -1786,6 +1809,9 @@ fn lowerer_lower_fn_params_mut(
 
                 lowerer_bind_local_mut(lo, (*list).head.name, preg, (*list).head.is_self_mut)
                 lowerer_bind_local_struct_type_mut(lo, (*list).head.name, lower_param_struct_type_name(&(*list).head.ty))
+                if lower_type_expr_is_ref_like(&(*list).head.ty) {
+                    lowerer_mark_local_ref_mut(lo, (*list).head.name)
+                }
                 if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
                     (*lo) = (*lo).bind_local_array_elem_float((*list).head.name)
                 }
@@ -2160,6 +2186,10 @@ fn lower_param_struct_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
         return lower_opt_type_named_name(&(*ty).inner)
     }
     ir_empty_name()
+}
+
+fn lower_type_expr_is_ref_like(ty: &TypeExpr) -> bool {
+    (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut
 }
 
 fn lower_name_wide_int_bits(n: Name) -> i64 with Panic, Div {
@@ -3624,6 +3654,7 @@ impl Lowerer {
                 stk.array_elem_float[idx as usize] = 0
                 stk.wide_bits[idx as usize] = 0
                 stk.wide_signed[idx as usize] = 0
+                stk.is_ref[idx as usize] = 0
                 stk.variance_regs[idx as usize] = -1
                 stk.count = idx + 1
             lo.locals = Box::new(stk)
@@ -3723,6 +3754,17 @@ impl Lowerer {
         while i >= 0 {
             if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
                 return (*self.locals).is_global[i as usize] == 1
+            }
+            i = i - 1
+        }
+        false
+    }
+
+    fn lookup_local_is_ref(self, name: Name) -> bool with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).is_ref[i as usize] == 1
             }
             i = i - 1
         }
@@ -5649,6 +5691,7 @@ impl Lowerer {
                         locals.array_elem_float[idx as usize] = if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 1 } else { 0 }
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
+                        locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
                         locals.count = idx + 1
                     } else {
                         lo = lo.report_error()
@@ -6533,23 +6576,46 @@ impl Lowerer {
                         let base_opt: Option<Box<Expr>> = (*target_expr).left
                         match base_opt {
                             Some(base_expr) => {
+                                let base_is_ref = if (*base_expr).kind == ExprKind::ExprIdent {
+                                    lo.lookup_local_is_ref((*base_expr).name)
+                                } else {
+                                    false
+                                }
                                 let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
                                 let pair_base = lo.lower_expr_ref(&(*base_expr))
                                 lo = pair_base.0
                                 let base_reg = pair_base.1
-                                lo = lo.emit(ir_field_set(base_reg, fidx, rhs, (*target_expr).name))
+                                var set_instr = ir_field_set(base_reg, fidx, rhs, (*target_expr).name)
+                                if base_is_ref {
+                                    set_instr.label_id = 1
+                                }
+                                lo = lo.emit(set_instr)
                                 (lo, rhs)
                             }
                             _ => (lo.report_error(), rhs),
                         }
                 } else if (*target_expr).kind == ExprKind::ExprIndex {
+                        let target_base_is_ref = match (*target_expr).left {
+                            Some(target_base_expr) => {
+                                if (*target_base_expr).kind == ExprKind::ExprIdent {
+                                    lo.lookup_local_is_ref((*target_base_expr).name)
+                                } else {
+                                    false
+                                }
+                            }
+                            _ => false,
+                        }
                         let pair_base = lo.lower_opt_expr_ref(&(*target_expr).left)
                         lo = pair_base.0
                         let base_reg = pair_base.1
                         let pair_idx = lo.lower_opt_expr_ref(&(*target_expr).right)
                         lo = pair_idx.0
                         let idx_reg = pair_idx.1
-                        lo = lo.emit(ir_index_set(base_reg, idx_reg, rhs))
+                        var index_set_instr = ir_index_set(base_reg, idx_reg, rhs)
+                        if target_base_is_ref {
+                            index_set_instr.label_id = 1
+                        }
+                        lo = lo.emit(index_set_instr)
                         (lo, rhs)
                 } else if (*target_expr).kind == ExprKind::ExprUnary {
                         if (*target_expr).un_op == UnaryOp::OpDeref {
@@ -8176,6 +8242,16 @@ impl Lowerer {
         let fidx = lo1.field_idx_for_base_ref(&e.left, e.name)
         let field_is_float = lo1.field_is_float_for_base_ref(&e.left, e.name) || lo1.field_is_float_by_name_simple(e.name)
         let field_array_elem_is_float = lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name)
+        let base_is_ref = match e.left {
+            Some(base_expr_ref) => {
+                if (*base_expr_ref).kind == ExprKind::ExprIdent {
+                    lo1.lookup_local_is_ref((*base_expr_ref).name)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
         if lower_aggregate_diag_enabled() {
             print("lower_agg: field name=")
             print(str_from_bytes(e.name.buf, e.name.len))
@@ -8219,6 +8295,9 @@ impl Lowerer {
         let lo2 = pair_d.0
         let dst = pair_d.1
         var instr = ir_field_get(dst, base, fidx, e.name)
+        if base_is_ref {
+            instr.label_id = 1
+        }
         if field_is_float || field_array_elem_is_float {
             instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
         }
@@ -8234,6 +8313,16 @@ impl Lowerer {
 
     fn lower_index_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         let index_elem_is_float_pre = self.index_base_elem_is_float_ref(&e.left)
+        let base_is_ref = match e.left {
+            Some(base_expr_ref) => {
+                if (*base_expr_ref).kind == ExprKind::ExprIdent {
+                    self.lookup_local_is_ref((*base_expr_ref).name)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
         let pair_b = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_b.0
         let base = pair_b.1
@@ -8256,6 +8345,9 @@ impl Lowerer {
         let lo3 = pair_d.0
         let dst = pair_d.1
         var instr = ir_index_get(dst, base, idx)
+        if base_is_ref {
+            instr.label_id = 1
+        }
         if index_elem_is_float {
             instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
         }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6451,23 +6451,31 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_add_rodata_reloc(nc, lea_pos + 3, str_offset)
             nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrFieldGet {
-            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-            native_v2_resolve_handle_to_object_base_rax_into(nc)
-            nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
-            nc_emit_mov_rax_mem_rax_rbx8(nc)
-            nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_load_ref_field_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx)
+            } else {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                native_v2_resolve_handle_to_object_base_rax_into(nc)
+                nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
+                nc_emit_mov_rax_mem_rax_rbx8(nc)
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            }
             if (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG || nc_core_field_is_float(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx) {
                 nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
             } else {
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             }
         } else if instr_op == IrOpcode::IrFieldSet {
-            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-            native_v2_resolve_handle_to_object_base_rax_into(nc)
-            nc_emit_mov_rdx_rax(nc)
-            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src2)
-            nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
-            nc_emit_store_rax_mem_rdx_rbx8(nc)
+            if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_store_ref_field_into(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx, (*func).instrs[i as usize].src2)
+            } else {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                native_v2_resolve_handle_to_object_base_rax_into(nc)
+                nc_emit_mov_rdx_rax(nc)
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src2)
+                nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
+                nc_emit_store_rax_mem_rdx_rbx8(nc)
+            }
             if (*func).instrs[i as usize].src2 >= 0 && (*func).instrs[i as usize].src2 < 512 {
                 if (*nc).is_float_reg[(*func).instrs[i as usize].src2 as usize] == 1 {
                     nc_core_mark_float_field(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx)
@@ -6475,7 +6483,21 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrIndexGet {
             let base_reg = (*func).instrs[i as usize].src1
-            if nc_core_func_param_index(func, base_reg) >= 0 {
+            if (*func).instrs[i as usize].label_id == 2 {
+                native_v2_core_emit_raw_array_load_into(
+                    nc,
+                    (*func).instrs[i as usize].dst,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                )
+            } else if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_ref_array_load_into(
+                    nc,
+                    (*func).instrs[i as usize].dst,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                )
+            } else if nc_core_func_param_index(func, base_reg) >= 0 {
                 native_v2_core_emit_param_array_load_into(
                     nc,
                     (*func).instrs[i as usize].dst,
@@ -6498,7 +6520,21 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrIndexSet {
             let base_reg = (*func).instrs[i as usize].src1
-            if nc_core_func_param_index(func, base_reg) >= 0 {
+            if (*func).instrs[i as usize].label_id == 2 {
+                native_v2_core_emit_raw_array_store_into(
+                    nc,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                    (*func).instrs[i as usize].imm_i64,
+                )
+            } else if (*func).instrs[i as usize].label_id == 1 {
+                native_v2_core_emit_ref_array_store_into(
+                    nc,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                    (*func).instrs[i as usize].imm_i64,
+                )
+            } else if nc_core_func_param_index(func, base_reg) >= 0 {
                 native_v2_core_emit_param_array_store_into(
                     nc,
                     base_reg,
@@ -7692,18 +7728,21 @@ pub fn native_v2_core_emit_temp_addr_into(nc: &! NativeCompiler, dst: i64, src: 
 
 pub fn native_v2_core_emit_load_ref_field_into(nc: &! NativeCompiler, dst: i64, base_ref: i64, field_offset_words: i64) with Mut, Panic, Div {
     nc_core_load_temp_to_rax(nc, base_ref)
-    nc_emit_mov_reg_reg(nc, 3, 0)
-    nc_emit_load_rax_mem_rbx_disp32(nc, field_offset_words * 8)
+    nc_emit_load_rax_mem_rax(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_reg_imm(nc, 3, field_offset_words + native_v2_object_header_size() / 8)
+    nc_emit_mov_rax_mem_rax_rbx8(nc)
     nc_core_store_rax_to_temp(nc, dst)
 }
 
 pub fn native_v2_core_emit_store_ref_field_into(nc: &! NativeCompiler, base_ref: i64, field_offset_words: i64, src: i64) with Mut, Panic, Div {
-    nc_core_load_temp_to_rax(nc, src)
-    nc_emit_push_rax(nc)
     nc_core_load_temp_to_rax(nc, base_ref)
-    nc_emit_mov_reg_reg(nc, 3, 0)
-    nc_emit_pop_rax(nc)
-    nc_emit_store_rax_mem_rbx_disp32(nc, field_offset_words * 8)
+    nc_emit_load_rax_mem_rax(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_rdx_rax(nc)
+    nc_core_load_temp_to_rax(nc, src)
+    nc_emit_mov_reg_imm(nc, 3, field_offset_words + native_v2_object_header_size() / 8)
+    nc_emit_store_rax_mem_rdx_rbx8(nc)
 }
 
 pub fn native_v2_driver_state_base_offset() -> i64 { 4096 }
@@ -7782,6 +7821,52 @@ pub fn native_v2_core_emit_param_array_load_into(nc: &! NativeCompiler, dst: i64
 pub fn native_v2_core_emit_param_array_store_into(nc: &! NativeCompiler, base_reg: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
     // Param arrays are passed as handles, same as local and struct-field arrays.
     nc_core_load_temp_to_rax(nc, base_reg)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_emit_mov_reg_imm(nc, 1, native_v2_object_header_size() / 8)
+    nc_emit_add_reg_reg(nc, 3, 1)
+    nc_core_load_temp_to_rax(nc, src)
+    nc_emit_store_rax_mem_rdx_rbx8(nc)
+}
+
+pub fn native_v2_core_emit_raw_array_load_into(nc: &! NativeCompiler, dst: i64, base_reg: i64, idx_reg: i64) with Mut, Panic, Div {
+    nc_core_load_temp_to_rax(nc, base_reg)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_emit_load_rax_mem_rdx_rbx8(nc)
+    nc_core_store_rax_to_temp(nc, dst)
+}
+
+pub fn native_v2_core_emit_raw_array_store_into(nc: &! NativeCompiler, base_reg: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
+    nc_core_load_temp_to_rax(nc, base_reg)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_core_load_temp_to_rax(nc, src)
+    nc_emit_store_rax_mem_rdx_rbx8(nc)
+}
+
+pub fn native_v2_core_emit_ref_array_load_into(nc: &! NativeCompiler, dst: i64, base_ref: i64, idx_reg: i64) with Mut, Panic, Div {
+    // &![T; N] params point at the caller slot that stores the array handle.
+    nc_core_load_temp_to_rax(nc, base_ref)
+    nc_emit_load_rax_mem_rax(nc)
+    native_v2_resolve_handle_to_object_base_rax_into(nc)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_emit_mov_reg_imm(nc, 1, native_v2_object_header_size() / 8)
+    nc_emit_add_reg_reg(nc, 3, 1)
+    nc_emit_load_rax_mem_rdx_rbx8(nc)
+    nc_core_store_rax_to_temp(nc, dst)
+}
+
+pub fn native_v2_core_emit_ref_array_store_into(nc: &! NativeCompiler, base_ref: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
+    // &![T; N] params point at the caller slot that stores the array handle.
+    nc_core_load_temp_to_rax(nc, base_ref)
+    nc_emit_load_rax_mem_rax(nc)
     native_v2_resolve_handle_to_object_base_rax_into(nc)
     nc_emit_mov_reg_reg(nc, 2, 0)
     nc_core_load_temp_to_rax(nc, idx_reg)


### PR DESCRIPTION
## Summary

Two commits that together let the default Madaros engine own ontology validation, removing the long-standing lean_single pin on the ontology gate's compile/run oracle.

1. **fix(codegen): deref aggregate reference params before handle resolution** — fixes a Madaros native_v2 codegen SIGSEGV.
2. **chore(ci): remove lean_single pin from ontology validation oracle** — flips `DEFAULT_FALLBACK_SOUC` to `bin/souc` (Madaros), now safe.

## The codegen bug

Madaros mis-compiled field/index access through **reference params to heap aggregates** (`&P` struct refs, `&[T;N]`/`&![T;N]` array refs). Such a param slot holds a **raw address** pointing at the caller's slot, which holds the heap **handle**. The `IrFieldGet/IrFieldSet/IrIndexGet/IrIndexSet` handlers resolved that raw address *directly as a handle* → wrong address → runtime SIGSEGV. Scalar refs (`&i64`) were fine (plain raw load, no handle resolution).

Minimal repros (all segfaulted before, pass now):
```
fn get(p: &P) -> i64 { p.a }                       // struct-ref field   → was 139
fn first(xs: &[i64;1024]) -> i64 { xs[0] }         // array-ref index    → was 139
fn setf(xs: &![i64;8]) with Mut { xs[0] = 9 }      // mut array-ref store → was 139
```

### Fix
Record per-local `is_ref` in `LowerLocalStack`, set it for reference-typed params; when a field/index base is a reference-typed local, mark the emitted IR instruction `label_id=1`. Codegen routes those through new helpers that **load the handle from the slot (`nc_emit_load_rax_mem_rax`) before resolving it**. Non-ref bases keep `label_id=0` and take the existing path **byte-for-byte** — no behavioral change for any other code. `ir.sio` is untouched (the existing `IrInstr.label_id` is reused as the marker).

This fix was ported in isolation from the `recover/solver-gpu-arc` lineage (where it lives entangled with unrelated solver/struct-layout churn and a separate `assert` regression); only the ref-param pieces were extracted.

## Verification (locally-built Madaros from this branch)

- Ref-param repros: struct-ref, array-ref (const + var index), mut-write, 4-param+assert+bool — **all pass**.
- `tests/run-pass/ontology_subsumption.sio` (`onto_is_a` over `&[i64;1024]`): **exit 0, "all onto_is_a tests passed"** (was SIGSEGV).
- `assert(...)` still works (it works on main; unaffected here).
- Regression: `for_sum`/`var+var`/`lit+lit` unchanged; ontology axioms (E041/E009) still **reject**.
- 120-fixture run-pass crash sweep: **identical to the committed prebuilt** — the 11 pre-existing crashes are unchanged, nothing new.
- **Full ontology validation suite: 57/57 PASS** with the fallback oracle = Madaros (was 56/57, the 1 failure being this segfault).

## Effect

The lean_single pin in `build_ontology_validation_souc.sh` is removed; `bin/souc` (Madaros) is the default fallback oracle, with `SOUNIO_VALIDATION_FALLBACK_SOUC` still overriding. Madaros now both **enforces** the ontology axioms (E041 #439, E009 #475) and **correctly compiles** the fixtures, so it owns ontology validation end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)