### PR TITLE
fix(gpu): expose public backend build path

### DIFF
--- a/bin/madaros
+++ b/bin/madaros
@@ -12,7 +12,7 @@
 #   madaros --version
 #   madaros info
 #   madaros check input.sio
-#   madaros build input.sio -o out.elf
+#   madaros build input.sio [-o OUT] [--backend native|gpu]
 #   madaros run input.sio
 #   madaros pkg ...
 #
@@ -65,7 +65,8 @@ Usage:
   madaros --version                     print compiler identity
   madaros info                          print resolution path
   madaros check <source.sio>            parse, resolve and typecheck
-  madaros build <source.sio> [-o OUT]   compile source to a native ELF
+  madaros build <source.sio> [-o OUT] [--backend native|gpu]
+                                      compile source to native ELF or GPU artifact
   madaros compile <source.sio> [-o OUT] alias for build
   madaros run <source.sio>              compile to a temp ELF and run it
   madaros pkg <subcommand>...           package-manager commands
@@ -78,6 +79,12 @@ Common modular-compiler modes:
   madaros --native-v2-emit-scalar N     emit a scalar witness
   madaros --version-json                emit version metadata
   madaros pkg ...                       package manager commands
+
+GPU build options:
+  --backend gpu                         emit PTX via the public GPU build path
+  --gpu-target <target>                 raw GPU target (default: cuda-sm80)
+  --gpu-binary-format <fmt>             raw GPU format/mode selector
+  --gpu-precision <f32|f64>             compatibility alias for GPU mode
 
 Environment:
   SOUNIO_STDLIB_PATH=<dir>     forwarded to raw ELF
@@ -126,10 +133,11 @@ _run_raw_check() {
   ( ulimit -v 8388608 2>/dev/null || true; exec timeout 120 "$RAW_MADAROS" --check "$src" "$@" )
 }
 
-_parse_output_path() {
-  local fallback="$1"
-  shift
-  local out="$fallback"
+_parse_build_options() {
+  BUILD_OUT="a.out"
+  BUILD_BACKEND="native"
+  BUILD_GPU_TARGET="cuda-sm80"
+  BUILD_GPU_BINARY_FORMAT=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -o|--output)
@@ -137,7 +145,46 @@ _parse_output_path() {
           echo "error: madaros build: $1 requires a path" >&2
           return 2
         fi
-        out="$2"
+        BUILD_OUT="$2"
+        shift 2
+        ;;
+      --backend)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --backend requires native or gpu" >&2
+          return 2
+        fi
+        BUILD_BACKEND="$2"
+        shift 2
+        ;;
+      --gpu-target)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --gpu-target requires a target" >&2
+          return 2
+        fi
+        BUILD_GPU_TARGET="$2"
+        shift 2
+        ;;
+      --gpu-binary-format)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --gpu-binary-format requires a format" >&2
+          return 2
+        fi
+        BUILD_GPU_BINARY_FORMAT="$2"
+        shift 2
+        ;;
+      --gpu-precision)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --gpu-precision requires f32 or f64" >&2
+          return 2
+        fi
+        case "$2" in
+          f32) BUILD_GPU_BINARY_FORMAT="f32" ;;
+          f64) BUILD_GPU_BINARY_FORMAT="" ;;
+          *)
+            echo "error: madaros build: unsupported --gpu-precision: $2" >&2
+            return 2
+            ;;
+        esac
         shift 2
         ;;
       *)
@@ -146,7 +193,14 @@ _parse_output_path() {
         ;;
     esac
   done
-  echo "$out"
+  case "$BUILD_BACKEND" in
+    native|"") BUILD_BACKEND="native" ;;
+    gpu) ;;
+    *)
+      echo "error: madaros build: unsupported backend: $BUILD_BACKEND" >&2
+      return 2
+      ;;
+  esac
 }
 
 _build_source() {
@@ -157,10 +211,23 @@ _build_source() {
     echo "error: madaros build: source is empty: $src" >&2
     return 1
   fi
-  local out
-  out="$(_parse_output_path a.out "$@")"
+  _parse_build_options "$@"
+  local out="$BUILD_OUT"
   mkdir -p "$(dirname "$out")"
   rm -f "$out"
+  if [[ "$BUILD_BACKEND" == "gpu" ]]; then
+    local gpu_args=("$src" -o "$out" --gpu-target "$BUILD_GPU_TARGET")
+    if [[ -n "$BUILD_GPU_BINARY_FORMAT" ]]; then
+      gpu_args+=(--gpu-binary-format "$BUILD_GPU_BINARY_FORMAT")
+    fi
+    # Guard: 16 GB vmem + 300 s timeout
+    ( ulimit -v 16777216 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "${gpu_args[@]}" )
+    if [[ ! -s "$out" ]]; then
+      echo "error: madaros build: compiler produced no GPU artifact at $out" >&2
+      return 1
+    fi
+    return 0
+  fi
   # Guard: 16 GB vmem + 300 s timeout
   ( ulimit -v 16777216 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$src" -o "$out" )
   if [[ ! -s "$out" ]]; then
@@ -207,6 +274,10 @@ case "$1" in
     if [[ $# -lt 2 ]]; then
       echo "error: madaros build: missing source file" >&2
       exit 2
+    fi
+    if [[ "${2:-}" == "-h" || "${2:-}" == "--help" || "${2:-}" == "help" ]]; then
+      usage
+      exit 0
     fi
     _build_source "$2" "${@:3}"
     ;;

--- a/bin/souc
+++ b/bin/souc
@@ -60,6 +60,9 @@ Usage:
   souc info                           print compiler status
   souc check <file.sio>               parse, resolve and typecheck
   souc compile <file.sio> [-o OUT]    compile <file.sio> to a native ELF
+  souc build <file.sio> [-o OUT]      compile source to native ELF
+  souc build <file.sio> --backend gpu -o OUT
+                                      emit a public GPU artifact (PTX by default)
   souc run <file.sio>                 run <file.sio> (compile to a temp ELF and execute)
   souc format <file.sio>              format Sounio source on stdout
   souc fmt <file.sio>                 alias for format

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -27467,6 +27467,56 @@ fn gpu_emit_host_glue(
 }
 
 
+fn compiler_hlir_name_matches_ast_name(hn: HlirName, an: Name) -> bool with Mut, Panic, Div {
+    if hn.len != an.len {
+        return false
+    }
+    var i: i64 = 0
+    while i < hn.len {
+        if hn.buf[i as usize] != an.buf[i as usize] {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn compiler_mark_hlir_kernel_name(module: HlirModule, name: Name) -> HlirModule with Mut, Panic, Div {
+    var out = module
+    var i: i64 = 0
+    while i < out.fn_count {
+        if compiler_hlir_name_matches_ast_name(out.functions[i as usize].name, name) {
+            var f = out.functions[i as usize]
+            f.is_kernel = true
+            out.functions[i as usize] = f
+        }
+        i = i + 1
+    }
+    out
+}
+
+fn compiler_mark_hlir_kernels_from_items(module: HlirModule, items: Option<Box<ItemList>>) -> HlirModule with Mut, Panic, Div {
+    match items {
+        Some(list) => {
+            var out = module
+            let item = (*list).head
+            if item.kind == ItemKind::ItemFn {
+                match item.fn_def {
+                    Some(fd) => {
+                        if (*fd).is_kernel {
+                            out = compiler_mark_hlir_kernel_name(out, (*fd).name)
+                        }
+                    }
+                    None => {}
+                }
+            }
+            compiler_mark_hlir_kernels_from_items(out, (*list).tail)
+        }
+        None => module,
+    }
+}
+
+
 // ============================================================================
 // GPU COMPILE PIPELINE
 // ============================================================================
@@ -27513,8 +27563,13 @@ fn run_gpu_compile_pipeline(
         return 1
     }
 
-    // Lower AST to HLIR SSA
-    let hlir_module = hlir_lower_module(main_prog)
+    // module_frontend_check_items_with_source_context consumes the item list on
+    // the self-hosted value path. Reload before HLIR lowering so kernel fn
+    // declarations remain visible to the GPU extraction pass.
+    let lower_prog = load_module_file(input_path)
+    var hlir_module = hlir_lower_module(lower_prog)
+    let kernel_mark_prog = load_module_file(input_path)
+    hlir_module = compiler_mark_hlir_kernels_from_items(hlir_module, kernel_mark_prog.items)
 
     // Count GPU-annotated kernels
     let kcount = hlir_extract_kernel_count(hlir_module)

--- a/self-hosted/hlir/lower.sio
+++ b/self-hosted/hlir/lower.sio
@@ -2366,7 +2366,10 @@ pub fn hlir_lower_items(state: HlirLowerState, items: Option<Box<ItemList>>) -> 
             let item = (*list).head
             if item.kind == ItemKind::ItemFn {
                 match item.fn_def {
-                    Some(fn_def) => { s = hlir_lower_function(s, *fn_def, (*fn_def).is_kernel) }
+                    Some(fn_def) => {
+                        let is_kernel = (*fn_def).is_kernel
+                        s = hlir_lower_function(s, *fn_def, is_kernel)
+                    }
                     None => { s = hlir_lower_report_error(s) }
                 }
             }


### PR DESCRIPTION
## Summary
- add public `madaros/souc build --backend gpu` handling with GPU target/format options
- fix the GPU compile pipeline so frontend checking does not consume kernel declarations before HLIR lowering
- refresh `bin/madaros-linux-x86_64` from the rebuilt modular compiler (`sha256: 8332c414b2f39e831c70bfe9c82b97bb53c132b2a76f229a508586c4dc44eec0`)

## Validation
- `git diff --check`
- `./bin/souc check tests/run-pass/gpu_public_launch_check.sio`
- `./bin/souc check examples/kernel_vec_add.sio`
- `./bin/souc build --help | rg -n -- '--backend gpu|GPU artifact|gpu-target'`\n- `./bin/souc build examples/kernel_vec_add.sio --backend gpu -o /tmp/default-kernel_vec_add.ptx` -> `GPU: 2 kernel(s) found`, PTX entries `vec_add`, `vec_scale`\n- `./bin/souc build examples/kernel_matmul.sio --backend gpu -o /tmp/default-kernel_matmul.ptx` -> `GPU: 2 kernel(s) found`, PTX entries `matmul`, `matmul_transpose`\n- `./bin/souc build tests/run-pass/kernel_ptx_emit.sio --backend gpu -o /tmp/default-kernel_ptx_emit.ptx` -> `GPU: 2 kernel(s) found`, PTX entries `matrix_add`, `scale_vector`\n\n## Remaining blockers\n- `./bin/souc build examples/kernel_source_level.sio --backend gpu -o /tmp/default-kernel_source_level.ptx` still exits `rc=139` after `GPU: 2 kernel(s) found`\n- `./bin/souc build tests/run-pass/gpu_vec_add_e2e.sio --backend gpu -o /tmp/default-gpu_vec_add_e2e.ptx` still exits `rc=139` after `GPU: 1 kernel(s) found`\n\nThis improves issue #468 by making simple public GPU PTX emission reachable, but it does not fully close #468 because richer solver-style kernel lowering still crashes.\n\n## LLM-offload\n- Not invoked; this is compiler/wrapper/backend plumbing, not math claims, clinical-pathway code, or external-facing artifact work.\n