### PR TITLE
[codex] Fix public GPU CFG PTX build segfault

### DIFF
--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1709,6 +1709,12 @@ fn hlir_function_to_gpu_kernel(func: HlirFunction) -> GpuKernelIr with Mut, Pani
     while bi < func.block_count {
         let block = func.blocks[bi as usize]
 
+        var label_op = gpu_op_new()
+        label_op.opcode = GpuOpcode::GpuBra
+        label_op.src_reg = 1
+        label_op.rhs_imm = block.id
+        kernel = gpu_kernel_append_op(kernel, label_op)
+
         // Lower instructions in this block
         var ii: i64 = 0
         while ii < block.instr_count {
@@ -1725,27 +1731,21 @@ fn hlir_function_to_gpu_kernel(func: HlirFunction) -> GpuKernelIr with Mut, Pani
         } else if term.kind == HLIR_TERM_BRANCH {
             var bra_op = gpu_op_new()
             bra_op.opcode = GpuOpcode::GpuBra
+            bra_op.src_reg = 0
             bra_op.rhs_imm = term.branch_target
             bra_op.pred_reg = 0 - 1
             kernel = gpu_kernel_append_op(kernel, bra_op)
         } else if term.kind == HLIR_TERM_COND_BRANCH {
-            // Conditional branch: setp on condition, then predicated branch
-            var setp_op = gpu_op_new()
-            setp_op.opcode = GpuOpcode::GpuSetpNe
-            setp_op.dst_reg = 0
-            setp_op.lhs_reg = term.cond_value
-            setp_op.rhs_imm = 0
-            setp_op.ty = GpuType::GpuI32
-            kernel = gpu_kernel_append_op(kernel, setp_op)
-
             var bra_then = gpu_op_new()
             bra_then.opcode = GpuOpcode::GpuBra
+            bra_then.src_reg = 0
             bra_then.rhs_imm = term.then_block
-            bra_then.pred_reg = 0
+            bra_then.pred_reg = term.cond_value
             kernel = gpu_kernel_append_op(kernel, bra_then)
 
             var bra_else = gpu_op_new()
             bra_else.opcode = GpuOpcode::GpuBra
+            bra_else.src_reg = 0
             bra_else.rhs_imm = term.else_block
             bra_else.pred_reg = 0 - 1
             kernel = gpu_kernel_append_op(kernel, bra_else)

--- a/tests/gpu/gate_public_gpu_cfg_build.sh
+++ b/tests/gpu/gate_public_gpu_cfg_build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Gate for public GPU backend CFG lowering through `souc build --backend gpu`.
+#
+# This intentionally checks structural PTX emission only. It does not claim
+# CUDA/PTX assembler validation or full kernel semantic correctness.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+SOUC="${SOUC:-./bin/souc}"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+    PASS=$((PASS + 1))
+    echo "PASS  $1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    echo "FAIL  $1: $2"
+}
+
+require_grep() {
+    local label="$1"
+    local pattern="$2"
+    local file="$3"
+    if grep -q "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label" "missing pattern $pattern in $file"
+    fi
+}
+
+build_gpu() {
+    local label="$1"
+    local src="$2"
+    local out="$3"
+    local log="$TMP_DIR/${label}.log"
+    local rc=0
+
+    timeout 30 "$SOUC" build "$src" --backend gpu -o "$out" >"$log" 2>&1 || rc=$?
+    if [ "$rc" -eq 124 ]; then
+        fail "$label" "timeout"
+        return
+    fi
+    if [ "$rc" -ne 0 ]; then
+        fail "$label" "exit $rc: $(tail -5 "$log" | tr '\n' ' ')"
+        return
+    fi
+    if [ ! -s "$out" ]; then
+        fail "$label" "empty PTX output"
+        return
+    fi
+    pass "$label"
+}
+
+if [ ! -x "$SOUC" ]; then
+    echo "FATAL: souc binary not executable: $SOUC"
+    exit 1
+fi
+
+cat > "$TMP_DIR/cfg_if_kernel.sio" <<'EOF'
+kernel fn k(n: i64) {
+  let tid = gpu_thread_id_x()
+  if tid < n {
+    let next = tid + 1
+  }
+}
+EOF
+
+echo "=== Public GPU CFG Build Gate ==="
+echo "SOUC:               $SOUC"
+echo "SOUNIO_STDLIB_PATH: $SOUNIO_STDLIB_PATH"
+echo ""
+
+MIN_PTX="$TMP_DIR/cfg_if_kernel.ptx"
+build_gpu "cfg_if_kernel_builds" "$TMP_DIR/cfg_if_kernel.sio" "$MIN_PTX"
+require_grep "cfg_if_kernel_entry" "\\.visible \\.entry k" "$MIN_PTX"
+require_grep "cfg_if_kernel_labels" "LBB0_" "$MIN_PTX"
+require_grep "cfg_if_kernel_branches" "bra LBB0_" "$MIN_PTX"
+require_grep "cfg_if_kernel_ret" "ret;" "$MIN_PTX"
+
+E2E_PTX="$TMP_DIR/gpu_vec_add_e2e.ptx"
+build_gpu "gpu_vec_add_e2e_builds" "tests/run-pass/gpu_vec_add_e2e.sio" "$E2E_PTX"
+require_grep "gpu_vec_add_e2e_entry" "\\.visible \\.entry vec_add" "$E2E_PTX"
+require_grep "gpu_vec_add_e2e_labels" "LBB0_" "$E2E_PTX"
+require_grep "gpu_vec_add_e2e_branches" "bra LBB0_" "$E2E_PTX"
+
+echo ""
+echo "Summary: pass=$PASS fail=$FAIL"
+
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- emit block labels while linearizing HLIR basic blocks into public GPU IR
- branch to those labels explicitly for unconditional and conditional terminators
- predicate conditional branches directly with the HLIR condition value instead of synthesizing an extra compare into register 0
- add a public GPU CFG build gate covering an `if` kernel and `gpu_vec_add_e2e` through `souc build --backend gpu`

## Why
Public GPU builds for kernels with CFG lowered through HLIR could segfault after kernel discovery. The PTX backend already treats `GpuBra` with `src_reg == 1` as a label definition, but the HLIR-to-GPU path was emitting branches without the corresponding block labels and was also rewriting conditional branches through a fragile synthetic `setp.ne` path.

This PR fixes that crash path and keeps the claim narrow: it validates structural PTX emission for CFG kernels, not full CUDA/PTX assembler acceptance or complete kernel semantic correctness.

Refs #468.

## Validation
- `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-gpu-rich-kernel-segfault-20260629-v1`
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-rich-kernel-segfault-20260629-v1 bash tests/gpu/gate_public_gpu_cfg_build.sh`
- `bash tests/gpu/gate_public_gpu_cfg_build.sh`
- `env -u SOUNIO_STDLIB_PATH bash tests/gpu/gate_public_gpu_cfg_build.sh`
- `env -u SOUNIO_STDLIB_PATH ./bin/souc build examples/kernel_source_level.sio --backend gpu -o /tmp/default-v3-kernel_source_level.ptx`
- `env -u SOUNIO_STDLIB_PATH ./bin/souc build tests/run-pass/gpu_vec_add_e2e.sio --backend gpu -o /tmp/default-v3-gpu_vec_add_e2e.ptx`
- `./bin/souc build examples/kernel_vec_add.sio --backend gpu -o /tmp/default-v2-kernel_vec_add.ptx`
- `./bin/souc check self-hosted/gpu/hlir_to_gpu.sio`
- `./bin/souc check tests/run-pass/gpu_public_launch_check.sio`
- `git diff --check`
- `git diff --cached --check`

## Remaining limits
- `ptxas` is not installed in this pod, so no assembler validation was run locally.
- Generated PTX still has known semantic gaps in richer kernel dataflow; this PR should be treated as crash/CFG containment, not full #468 closure.
- LLM-offload was not invoked because this touches compiler GPU plumbing, not math claims, clinical-pathway code, or external-facing artifacts.
