### PR TITLE
Fix GPU PTX dataflow lowering

### DIFF
--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1469,46 +1469,101 @@ fn hlir_type_kind_to_gpu(kind: HlirTypeKind) -> GpuType {
     else { GpuType::GpuI64 }
 }
 
-// Map a binary op tag (HlirOpAdd..HlirOpFGe) to a GpuOpcode.
+// Map an HLIR v2 binary op tag (HLIR_BIN_*) to a GpuOpcode.
 fn hlir_bin_op_to_gpu_opcode(bin_op: i64) -> GpuOpcode {
-    if bin_op == HlirOpAdd || bin_op == HlirOpFAdd { GpuOpcode::GpuAdd }
-    else if bin_op == HlirOpSub || bin_op == HlirOpFSub { GpuOpcode::GpuSub }
-    else if bin_op == HlirOpMul || bin_op == HlirOpFMul { GpuOpcode::GpuMul }
-    else if bin_op == HlirOpDiv || bin_op == HlirOpFDiv { GpuOpcode::GpuDiv }
-    else if bin_op == HlirOpLt || bin_op == HlirOpFLt { GpuOpcode::GpuSetpLt }
-    else if bin_op == HlirOpLe || bin_op == HlirOpFLe { GpuOpcode::GpuSetpLe }
-    else if bin_op == HlirOpGt || bin_op == HlirOpFGt { GpuOpcode::GpuSetpGt }
-    else if bin_op == HlirOpGe || bin_op == HlirOpFGe { GpuOpcode::GpuSetpGe }
-    else if bin_op == HlirOpEq || bin_op == HlirOpFEq { GpuOpcode::GpuSetpEq }
-    else if bin_op == HlirOpNe || bin_op == HlirOpFNe { GpuOpcode::GpuSetpNe }
+    if bin_op == HLIR_BIN_ADD || bin_op == HLIR_BIN_FADD { GpuOpcode::GpuAdd }
+    else if bin_op == HLIR_BIN_SUB || bin_op == HLIR_BIN_FSUB { GpuOpcode::GpuSub }
+    else if bin_op == HLIR_BIN_MUL || bin_op == HLIR_BIN_FMUL { GpuOpcode::GpuMul }
+    else if bin_op == HLIR_BIN_SDIV || bin_op == HLIR_BIN_UDIV || bin_op == HLIR_BIN_FDIV { GpuOpcode::GpuDiv }
+    else if bin_op == HLIR_BIN_SLT || bin_op == HLIR_BIN_ULT || bin_op == HLIR_BIN_FOLT { GpuOpcode::GpuSetpLt }
+    else if bin_op == HLIR_BIN_SLE || bin_op == HLIR_BIN_ULE || bin_op == HLIR_BIN_FOLE { GpuOpcode::GpuSetpLe }
+    else if bin_op == HLIR_BIN_SGT || bin_op == HLIR_BIN_UGT || bin_op == HLIR_BIN_FOGT { GpuOpcode::GpuSetpGt }
+    else if bin_op == HLIR_BIN_SGE || bin_op == HLIR_BIN_UGE || bin_op == HLIR_BIN_FOGE { GpuOpcode::GpuSetpGe }
+    else if bin_op == HLIR_BIN_EQ || bin_op == HLIR_BIN_FOEQ { GpuOpcode::GpuSetpEq }
+    else if bin_op == HLIR_BIN_NE || bin_op == HLIR_BIN_FONE { GpuOpcode::GpuSetpNe }
     else { GpuOpcode::GpuAdd }
 }
 
 // Map a binary op tag to a GpuType.
-// IMPORTANT: the op-tag ranges interleave float-arith (7-11), int-logical (12-16),
-// int-compare Eq..Ge (17-22), float-compare FEq..FGe (23-28). The naive guard
-// [FAdd,FGe] swallowed integer comparisons into the float bucket (HlirOpLt=19 is
-// in [7,28]), so `i < n` was emitting setp.lt.f32 over %f. Classify explicitly.
+// IMPORTANT: classify explicit HLIR_BIN_* ranges. The legacy HlirOp* constants
+// are a different tag space and make source-level kernels lose compare width.
 // This is the WIDTH source ONLY for comparisons, where the HlirInstr result type
 // is bool and therefore useless for operand width; arithmetic/logical instrs
 // instead take width from instr.ty.kind at the HLIR_OP_BINARY site below.
 // World A (check.sio: gpu thread/block intrinsics typed i64) ⇒ every integer
 // operand of a comparison in these kernels is i64, so int-compare → GpuI64.
 fn hlir_bin_op_type(bin_op: i64) -> GpuType {
-    if bin_op >= HlirOpFEq && bin_op <= HlirOpFGe { GpuType::GpuF32 }
-    else if bin_op >= HlirOpFAdd && bin_op <= HlirOpFNeg { GpuType::GpuF32 }
-    else if bin_op >= HlirOpEq && bin_op <= HlirOpGe { GpuType::GpuI64 }
+    if bin_op >= HLIR_BIN_FOEQ && bin_op <= HLIR_BIN_FOGE { GpuType::GpuF32 }
+    else if bin_op >= HLIR_BIN_FADD && bin_op <= HLIR_BIN_FREM { GpuType::GpuF32 }
+    else if bin_op >= HLIR_BIN_EQ && bin_op <= HLIR_BIN_UGE { GpuType::GpuI64 }
     else { GpuType::GpuI64 }
+}
+
+fn gpu_kernel_bump_reg(kernel: GpuKernelIr, reg: i64, ty: GpuType) -> GpuKernelIr with Mut {
+    var k = kernel
+    if reg < 0 { return k }
+
+    let next = reg + 1
+    if ty == GpuType::GpuBool {
+        if next > k.max_reg_pred { k.max_reg_pred = next }
+    } else if ty == GpuType::GpuU32 {
+        if next > k.max_reg_u32 { k.max_reg_u32 = next }
+    } else if ty == GpuType::GpuI32 {
+        if next > k.max_reg_i32 { k.max_reg_i32 = next }
+    } else if ty == GpuType::GpuF32 {
+        if next > k.max_reg_f32 { k.max_reg_f32 = next }
+    } else if ty == GpuType::GpuF64 {
+        if next > k.max_reg_f64 { k.max_reg_f64 = next }
+    } else {
+        if next > k.max_reg_u64 { k.max_reg_u64 = next }
+    }
+
+    k
 }
 
 // Append a single GPU op to a GpuKernelIr. Returns the kernel with op appended.
 fn gpu_kernel_append_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic {
     var k = kernel
     if k.op_count < 1024 {
+        if op.opcode == GpuOpcode::GpuCvt {
+            k = gpu_kernel_bump_reg(k, op.dst_reg, op.dst_ty)
+            k = gpu_kernel_bump_reg(k, op.src_reg, op.src_ty)
+        } else if op.opcode == GpuOpcode::GpuSetpLt || op.opcode == GpuOpcode::GpuSetpLe ||
+                  op.opcode == GpuOpcode::GpuSetpEq || op.opcode == GpuOpcode::GpuSetpGe ||
+                  op.opcode == GpuOpcode::GpuSetpGt || op.opcode == GpuOpcode::GpuSetpNe {
+            k = gpu_kernel_bump_reg(k, op.dst_reg, GpuType::GpuBool)
+            k = gpu_kernel_bump_reg(k, op.lhs_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.rhs_reg, op.ty)
+        } else if op.opcode == GpuOpcode::GpuLoadGlobal {
+            k = gpu_kernel_bump_reg(k, op.dst_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.addr_reg, GpuType::GpuU64)
+        } else if op.opcode == GpuOpcode::GpuStoreGlobal {
+            k = gpu_kernel_bump_reg(k, op.src_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.addr_reg, GpuType::GpuU64)
+        } else if op.opcode == GpuOpcode::GpuLoadParam {
+            k = gpu_kernel_bump_reg(k, op.dst_reg, op.ty)
+        } else if op.opcode == GpuOpcode::GpuBra {
+            k = gpu_kernel_bump_reg(k, op.pred_reg, GpuType::GpuBool)
+        } else {
+            k = gpu_kernel_bump_reg(k, op.dst_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.src_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.lhs_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.rhs_reg, op.ty)
+            k = gpu_kernel_bump_reg(k, op.addr_reg, GpuType::GpuU64)
+            k = gpu_kernel_bump_reg(k, op.pred_reg, GpuType::GpuBool)
+        }
         k.ops[k.op_count as usize] = op
         k.op_count = k.op_count + 1
     }
     k
+}
+
+fn hlir_gpu_type_size_bytes(ty: GpuType) -> i64 {
+    if ty == GpuType::GpuF64 || ty == GpuType::GpuI64 || ty == GpuType::GpuU64 || ty == GpuType::GpuPtr {
+        8
+    } else {
+        4
+    }
 }
 
 // Widen a 32-bit thread/block intrinsic result to i64 when the HLIR result type
@@ -1547,7 +1602,7 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
         // vec_add_f64 — fixing the old hardcoded i32/f32). For comparisons the
         // result type is bool, useless for width, so fall back to the op-tag map
         // (int-compare → i64 over %rd, float-compare → f-width).
-        let is_compare = instr.bin_op >= HlirOpEq && instr.bin_op <= HlirOpFGe
+        let is_compare = instr.bin_op >= HLIR_BIN_EQ && instr.bin_op <= HLIR_BIN_FOGE
         if is_compare {
             op.ty = hlir_bin_op_type(instr.bin_op)
         } else {
@@ -1567,15 +1622,40 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
         op.opcode = GpuOpcode::GpuStoreGlobal
         op.addr_reg = instr.store_ptr
         op.src_reg = instr.store_value
-        op.ty = hlir_type_kind_to_gpu(instr.ty.kind)
+        if instr.ty.kind == HlirTypeKind::HlirTypeVoid {
+            op.ty = GpuType::GpuI64
+        } else {
+            op.ty = hlir_type_kind_to_gpu(instr.ty.kind)
+        }
         op.memory_space = GpuMemorySpace::GpuMemGlobal
         k = gpu_kernel_append_op(k, op)
+    } else if op_kind == HLIR_OP_GET_ELEMENT_PTR {
+        let elem_ty = hlir_type_kind_to_gpu(instr.ty.kind)
+        let scale_reg = instr.result + 512
+
+        var scale = gpu_op_new()
+        scale.opcode = GpuOpcode::GpuMulImm
+        scale.dst_reg = scale_reg
+        scale.lhs_reg = instr.index
+        scale.rhs_imm = hlir_gpu_type_size_bytes(elem_ty)
+        scale.ty = GpuType::GpuU64
+        scale.dst_ty = GpuType::GpuU64
+        k = gpu_kernel_append_op(k, scale)
+
+        var addr = gpu_op_new()
+        addr.opcode = GpuOpcode::GpuAdd
+        addr.dst_reg = instr.result
+        addr.lhs_reg = instr.base
+        addr.rhs_reg = scale_reg
+        addr.ty = GpuType::GpuU64
+        addr.dst_ty = GpuType::GpuU64
+        k = gpu_kernel_append_op(k, addr)
     } else if op_kind == HLIR_OP_CONST {
         // Emit constant as immediate load into a virtual register
         var op = gpu_op_new()
         op.opcode = GpuOpcode::GpuAddImm
         op.dst_reg = instr.result
-        op.src_reg = 0
+        op.lhs_reg = 0
         op.rhs_imm = instr.constant.int_val
         op.ty = hlir_type_kind_to_gpu(instr.ty.kind)
         k = gpu_kernel_append_op(k, op)
@@ -1584,7 +1664,7 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
         var op = gpu_op_new()
         op.opcode = GpuOpcode::GpuAddImm
         op.dst_reg = instr.result
-        op.src_reg = instr.src
+        op.lhs_reg = instr.src
         op.rhs_imm = 0
         op.ty = hlir_type_kind_to_gpu(instr.ty.kind)
         k = gpu_kernel_append_op(k, op)
@@ -1695,11 +1775,22 @@ fn hlir_function_to_gpu_kernel(func: HlirFunction) -> GpuKernelIr with Mut, Pani
     while pi < func.param_count {
         if pi < 8 {
             let p = func.params[pi as usize]
+            let param_ty = hlir_type_kind_to_gpu(p.ty.kind)
             kernel.params[pi as usize] = GpuParam {
                 name: hlir_name_to_name(p.name),
-                ty: hlir_type_kind_to_gpu(p.ty.kind),
+                ty: param_ty,
             }
             kernel.param_count = kernel.param_count + 1
+
+            if p.value_id >= 0 {
+                var load_param = gpu_op_new()
+                load_param.opcode = GpuOpcode::GpuLoadParam
+                load_param.dst_reg = p.value_id
+                load_param.param_idx = pi
+                load_param.ty = param_ty
+                load_param.dst_ty = param_ty
+                kernel = gpu_kernel_append_op(kernel, load_param)
+            }
         }
         pi = pi + 1
     }
@@ -1718,7 +1809,14 @@ fn hlir_function_to_gpu_kernel(func: HlirFunction) -> GpuKernelIr with Mut, Pani
         // Lower instructions in this block
         var ii: i64 = 0
         while ii < block.instr_count {
-            kernel = hlir_instr_to_gpu_ops(kernel, block.instrs[ii as usize])
+            var instr = block.instrs[ii as usize]
+            if instr.op_kind == HLIR_OP_STORE {
+                let store_ty = hlir_function_lookup_local_type(func, instr.store_value)
+                if store_ty.kind != HlirTypeKind::HlirTypeVoid {
+                    instr.ty = store_ty
+                }
+            }
+            kernel = hlir_instr_to_gpu_ops(kernel, instr)
             ii = ii + 1
         }
 

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -198,8 +198,24 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
             let cvt_dst = str_concat("cvt.", dst_ty_str)
             let dot_src = str_concat(".", src_ty_str)
             let opcode = str_concat(cvt_dst, dot_src)
-            let dst_str = gpu_reg_u64(op.dst_reg)
-            let src_str = gpu_reg_u32(op.src_reg)
+            let dst_str = match op.dst_ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_u64(op.dst_reg),
+            }
+            let src_str = match op.src_ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.src_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.src_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.src_reg),
+                _ => gpu_reg_u32(op.src_reg),
+            }
 
             ptx_push_binary2(buf, opcode, dst_str, src_str)
         }
@@ -553,21 +569,27 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
                 GpuType::GpuU32 => ptx_opcode_setp_le_u32(),
                 GpuType::GpuU64 => ptx_opcode_setp_le_u64(),
                 GpuType::GpuF32 => ptx_opcode_setp_le_f32(),
+                GpuType::GpuF64 => ptx_opcode_setp_le_f64(),
                 GpuType::GpuI32 => ptx_opcode_setp_le_s32(),
+                GpuType::GpuI64 => ptx_opcode_setp_le_s64(),
                 _ => ptx_opcode_setp_le_u32(),
             }
             let lhs_str = match op.ty {
                 GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
                 GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
                 GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
                 GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
                 _ => gpu_reg_u32(op.lhs_reg),
             }
             let rhs_str = match op.ty {
                 GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
                 GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
                 GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
                 GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
                 _ => gpu_reg_u32(op.rhs_reg),
             }
             ptx_push_setp2(buf, opcode, gpu_pred_reg(op.dst_reg), lhs_str, rhs_str)
@@ -625,21 +647,27 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
                 GpuType::GpuU32 => ptx_opcode_setp_eq_u32(),
                 GpuType::GpuU64 => ptx_opcode_setp_eq_u64(),
                 GpuType::GpuF32 => ptx_opcode_setp_eq_f32(),
+                GpuType::GpuF64 => ptx_opcode_setp_eq_f64(),
                 GpuType::GpuI32 => ptx_opcode_setp_eq_s32(),
+                GpuType::GpuI64 => ptx_opcode_setp_eq_s64(),
                 _ => ptx_opcode_setp_eq_u32(),
             }
             let lhs_str = match op.ty {
                 GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
                 GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
                 GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
                 GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
                 _ => gpu_reg_u32(op.lhs_reg),
             }
             let rhs_str = match op.ty {
                 GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
                 GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
                 GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
                 GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
                 _ => gpu_reg_u32(op.rhs_reg),
             }
             ptx_push_setp2(buf, opcode, gpu_pred_reg(op.dst_reg), lhs_str, rhs_str)

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -466,6 +466,8 @@ pub fn ptx_opcode_setp_le_s32() -> string { "setp.le.s32" }
 
 pub fn ptx_opcode_setp_le_f32() -> string { "setp.le.f32" }
 pub fn ptx_opcode_setp_le_u64() -> string { "setp.le.u64" }
+pub fn ptx_opcode_setp_le_s64() -> string { "setp.le.s64" }
+pub fn ptx_opcode_setp_le_f64() -> string { "setp.le.f64" }
 
 pub fn ptx_opcode_setp_ge_u32() -> string { "setp.ge.u32" }
 
@@ -485,6 +487,8 @@ pub fn ptx_opcode_setp_eq_s32() -> string { "setp.eq.s32" }
 
 pub fn ptx_opcode_setp_eq_f32() -> string { "setp.eq.f32" }
 pub fn ptx_opcode_setp_eq_u64() -> string { "setp.eq.u64" }
+pub fn ptx_opcode_setp_eq_s64() -> string { "setp.eq.s64" }
+pub fn ptx_opcode_setp_eq_f64() -> string { "setp.eq.f64" }
 
 pub fn ptx_opcode_selp_b32() -> string { "selp.b32" }
 

--- a/self-hosted/hlir/lower.sio
+++ b/self-hosted/hlir/lower.sio
@@ -1972,17 +1972,20 @@ pub fn hlir_lower_assign_target(state: HlirLowerState, target: Expr, value_id: i
     if target.kind == ExprKind::ExprFieldAccess {
         let base_pair = hlir_lower_expr_opt(s, target.left)
         s = base_pair.0
+        let base_val = base_pair.1
         let field_idx = hlir_ast_name_hash(target.name) % 16
-        let field_ptr_pair = hlir_lower_get_field_ptr(s, base_pair.1, field_idx, hlir_type_i64())
+        let field_ptr_pair = hlir_lower_get_field_ptr(s, base_val, field_idx, hlir_type_i64())
         s = field_ptr_pair.0
         return hlir_lower_store(s, field_ptr_pair.1, value_id)
     }
     if target.kind == ExprKind::ExprIndex {
         let base_pair = hlir_lower_expr_opt(s, target.left)
         s = base_pair.0
+        let base_val = base_pair.1
         let idx_pair = hlir_lower_expr_opt(s, target.right)
         s = idx_pair.0
-        let elem_ptr_pair = hlir_lower_gep(s, base_pair.1, idx_pair.1, hlir_type_i64())
+        let idx_val = idx_pair.1
+        let elem_ptr_pair = hlir_lower_gep(s, base_val, idx_val, hlir_type_i64())
         s = elem_ptr_pair.0
         return hlir_lower_store(s, elem_ptr_pair.1, value_id)
     }
@@ -2006,10 +2009,42 @@ pub fn hlir_lower_stmt(state: HlirLowerState, stmt: Stmt) -> HlirLowerState with
         return hlir_lower_var(s, name, ty, init_pair.1)
     }
     if stmt.kind == StmtKind::StmtAssign {
-        let rhs_pair = hlir_lower_expr_opt(s, stmt.expr)
-        s = rhs_pair.0
         match stmt.target {
-            Some(t) => hlir_lower_assign_target(s, *t, rhs_pair.1),
+            Some(t) => {
+                let target_expr = *t
+                if target_expr.kind == ExprKind::ExprFieldAccess {
+                    let base_pair = hlir_lower_expr_opt(s, target_expr.left)
+                    s = base_pair.0
+                    let base_val = base_pair.1
+                    let field_idx = hlir_ast_name_hash(target_expr.name) % 16
+                    let field_ptr_pair = hlir_lower_get_field_ptr(s, base_val, field_idx, hlir_type_i64())
+                    s = field_ptr_pair.0
+                    let ptr_val = field_ptr_pair.1
+                    let rhs_pair = hlir_lower_expr_opt(s, stmt.expr)
+                    s = rhs_pair.0
+                    let rhs_val = rhs_pair.1
+                    return hlir_lower_store(s, ptr_val, rhs_val)
+                }
+                if target_expr.kind == ExprKind::ExprIndex {
+                    let base_pair = hlir_lower_expr_opt(s, target_expr.left)
+                    s = base_pair.0
+                    let base_val = base_pair.1
+                    let idx_pair = hlir_lower_expr_opt(s, target_expr.right)
+                    s = idx_pair.0
+                    let idx_val = idx_pair.1
+                    let elem_ptr_pair = hlir_lower_gep(s, base_val, idx_val, hlir_type_i64())
+                    s = elem_ptr_pair.0
+                    let ptr_val = elem_ptr_pair.1
+                    let rhs_pair = hlir_lower_expr_opt(s, stmt.expr)
+                    s = rhs_pair.0
+                    let rhs_val = rhs_pair.1
+                    return hlir_lower_store(s, ptr_val, rhs_val)
+                }
+                let rhs_pair = hlir_lower_expr_opt(s, stmt.expr)
+                s = rhs_pair.0
+                let rhs_val = rhs_pair.1
+                hlir_lower_assign_target(s, target_expr, rhs_val)
+            },
             None => hlir_lower_report_error(s),
         }
     }
@@ -2072,11 +2107,13 @@ pub fn hlir_lower_expr(state: HlirLowerState, expr: Expr) -> (HlirLowerState, i6
     if expr.kind == ExprKind::ExprBinary {
         let lhs_pair = hlir_lower_expr_opt(s, expr.left)
         s = lhs_pair.0
+        let lhs_val = lhs_pair.1
         let rhs_pair = hlir_lower_expr_opt(s, expr.right)
         s = rhs_pair.0
+        let rhs_val = rhs_pair.1
         let op = hlir_ast_binary_to_hlir(expr.bin_op)
         let ty = hlir_ast_binary_result_ty(expr.bin_op)
-        return hlir_lower_binary(s, op, lhs_pair.1, rhs_pair.1, ty)
+        return hlir_lower_binary(s, op, lhs_val, rhs_val, ty)
     }
 
     if expr.kind == ExprKind::ExprUnary {
@@ -2094,16 +2131,19 @@ pub fn hlir_lower_expr(state: HlirLowerState, expr: Expr) -> (HlirLowerState, i6
         }
         let base_pair = hlir_lower_expr_opt(s, expr.left)
         s = base_pair.0
+        let base_val = base_pair.1
         let field_idx = hlir_ast_name_hash(expr.name) % 16
-        return hlir_lower_field_access(s, base_pair.1, field_idx)
+        return hlir_lower_field_access(s, base_val, field_idx)
     }
 
     if expr.kind == ExprKind::ExprIndex {
         let base_pair = hlir_lower_expr_opt(s, expr.left)
         s = base_pair.0
+        let base_val = base_pair.1
         let idx_pair = hlir_lower_expr_opt(s, expr.right)
         s = idx_pair.0
-        return hlir_lower_index(s, base_pair.1, idx_pair.1)
+        let idx_val = idx_pair.1
+        return hlir_lower_index(s, base_val, idx_val)
     }
 
     if expr.kind == ExprKind::ExprCast {
@@ -2183,8 +2223,9 @@ pub fn hlir_lower_expr(state: HlirLowerState, expr: Expr) -> (HlirLowerState, i6
     if expr.kind == ExprKind::ExprMethodCall {
         let base_pair = hlir_lower_expr_opt(s, expr.left)
         s = base_pair.0
+        let base_val = base_pair.1
         var arg_vals: [i64; 64] = [HLIR_INVALID_VALUE; 64]
-        arg_vals[0] = base_pair.1
+        arg_vals[0] = base_val
         let args_pair = hlir_lower_expr_list(s, expr.args, arg_vals, 1)
         s = args_pair.state
         var method_vals: [i64; 64] = args_pair.values
@@ -2280,10 +2321,12 @@ pub fn hlir_lower_expr(state: HlirLowerState, expr: Expr) -> (HlirLowerState, i6
     if expr.kind == ExprKind::ExprRange {
         let lhs_pair = hlir_lower_expr_opt(s, expr.left)
         s = lhs_pair.0
+        let lhs_val = lhs_pair.1
         let rhs_pair = hlir_lower_expr_opt(s, expr.right)
         s = rhs_pair.0
+        let rhs_val = rhs_pair.1
         let op = hlir_ast_binary_to_hlir(expr.bin_op)
-        return hlir_lower_binary(s, op, lhs_pair.1, rhs_pair.1, hlir_type_i64())
+        return hlir_lower_binary(s, op, lhs_val, rhs_val, hlir_type_i64())
     }
 
     if expr.kind == ExprKind::ExprReturn {

--- a/tests/gpu/gate_public_gpu_cfg_build.sh
+++ b/tests/gpu/gate_public_gpu_cfg_build.sh
@@ -39,6 +39,28 @@ require_grep() {
     fi
 }
 
+require_egrep() {
+    local label="$1"
+    local pattern="$2"
+    local file="$3"
+    if grep -Eq "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label" "missing extended pattern $pattern in $file"
+    fi
+}
+
+reject_egrep() {
+    local label="$1"
+    local pattern="$2"
+    local file="$3"
+    if grep -Eq "$pattern" "$file"; then
+        fail "$label" "unexpected extended pattern $pattern in $file"
+    else
+        pass "$label"
+    fi
+}
+
 build_gpu() {
     local label="$1"
     local src="$2"
@@ -93,6 +115,21 @@ build_gpu "gpu_vec_add_e2e_builds" "tests/run-pass/gpu_vec_add_e2e.sio" "$E2E_PT
 require_grep "gpu_vec_add_e2e_entry" "\\.visible \\.entry vec_add" "$E2E_PTX"
 require_grep "gpu_vec_add_e2e_labels" "LBB0_" "$E2E_PTX"
 require_grep "gpu_vec_add_e2e_branches" "bra LBB0_" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_declares_pred_regs" "\\.reg \\.pred %p<[0-9]+>;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_declares_u64_regs" "\\.reg \\.b64 %rd<[0-9]+>;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_loads_n_param" "ld\\.param\\.u64 %rd0, \\[n\\];" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_loads_a_param" "ld\\.param\\.u64 %rd1, \\[a\\];" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_loads_b_param" "ld\\.param\\.u64 %rd2, \\[b\\];" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_loads_c_param" "ld\\.param\\.u64 %rd3, \\[c\\];" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_compares_tid_to_n" "setp\\.lt\\.s64 %p[0-9]+, %rd[0-9]+, %rd0;" "$E2E_PTX"
+reject_egrep "gpu_vec_add_e2e_rejects_degenerate_compare" "setp\\.[a-z]+\\.[a-z0-9]+ %p[0-9]+, %(r|rd)0, %(r|rd)0;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_scales_index" "mul\\.lo\\.u64 %rd[0-9]+, %rd[0-9]+, 8;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_addresses_a" "add\\.u64 %rd[0-9]+, %rd1, %rd[0-9]+;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_addresses_b" "add\\.u64 %rd[0-9]+, %rd2, %rd[0-9]+;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_addresses_c" "add\\.u64 %rd[0-9]+, %rd3, %rd[0-9]+;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_loads_inputs" "ld\\.global\\.s64 %rd[0-9]+, \\[%rd[0-9]+\\];" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_adds_inputs" "add\\.s64 %rd[0-9]+, %rd[0-9]+, %rd[0-9]+;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_stores_output" "st\\.global\\.s64 \\[%rd[0-9]+\\], %rd[0-9]+;" "$E2E_PTX"
 
 echo ""
 echo "Summary: pass=$PASS fail=$FAIL"


### PR DESCRIPTION
## Summary
- lower HLIR v2 binary op tags into the correct GPU op/width space instead of the legacy HlirOp tag space
- materialize GPU parameter loads, register declarations, GEP address math, global loads, input add, and output store for public PTX kernels
- preserve HLIR pair values across expression lowering so indexed assignment lowers the target address before the RHS overwrites transient pair storage
- extend the public GPU CFG build gate to assert structural vec_add dataflow, including rejecting degenerate self-compares

## Evidence
- `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-gpu-ptx-dataflow-20260629-v5` -> Madaros ready
- `MADAROS_RAW_BIN=/tmp/madaros-gpu-ptx-dataflow-20260629-v5 env -u SOUNIO_STDLIB_PATH bash tests/gpu/gate_public_gpu_cfg_build.sh` -> pass=24 fail=0
- `env -u SOUNIO_STDLIB_PATH bash tests/gpu/gate_public_gpu_cfg_build.sh` -> pass=24 fail=0
- `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/gpu/hlir_to_gpu.sio` -> check: OK
- `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/gpu/lower_to_ptx.sio` -> check: OK
- `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/gpu/ptx.sio` -> check: OK
- `env -u SOUNIO_STDLIB_PATH ./bin/souc build tests/run-pass/gpu_vec_add_e2e.sio --backend gpu -o /tmp/default-dataflow-gpu_vec_add_e2e.ptx` -> PTX written
- `env -u SOUNIO_STDLIB_PATH ./bin/souc build examples/kernel_source_level.sio --backend gpu -o /tmp/default-dataflow-kernel_source_level.ptx` -> PTX written
- `git diff --check` -> clean

## Notes / limits
- This is structural PTX dataflow validation, not CUDA assembler validation; `ptxas` was not available in the pod.
- Full f64 slice element typing remains a separate gap: HLIR index/GEP lowering still defaults slice element paths to i64, so this PR does not claim full GPU numeric correctness.
- Direct isolated `./bin/souc check self-hosted/hlir/lower.sio` still reports `syntax appears incomplete after assignment` at the EOF banner, while the imported compiler path and modular build both pass.

## LLM-offload reviews invoked
- None. Scope is compiler GPU/HLIR lowering and gate plumbing; no math claims, clinical-pathway code, or external-facing artifact was touched.