### PR TITLE
[codex] Fix GPU f64 slice PTX typing

### DIFF
--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -2082,6 +2082,28 @@ fn hlir_function_to_epistemic_gpu_kernel(func: HlirFunction) -> GpuKernelIr with
 // Section 26 — End-to-end pipeline orchestrators (Sprint 28)
 // ============================================================================
 
+fn hlir_ptx_append_kernel_module(dst: PtxBuf, src: PtxBuf, include_header: bool) -> PtxBuf with Mut, Panic {
+    var out = dst
+    var i: i64 = 0
+    if !include_header {
+        var newline_count: i64 = 0
+        while i < src.len && newline_count < 4 {
+            if src.data[i as usize] == 10 as i8 {
+                newline_count = newline_count + 1
+            }
+            i = i + 1
+        }
+    }
+    while i < src.len {
+        if out.len < 65536 {
+            out.data[out.len as usize] = src.data[i as usize]
+            out.len = out.len + 1
+        }
+        i = i + 1
+    }
+    out
+}
+
 // Extract all kernel functions from an HlirModule, lower each to GpuKernelIr,
 // then lower each to PTX and concatenate into a single PtxBuf.
 fn hlir_kernels_to_ptx(module: HlirModule) -> PtxBuf with Mut, Panic, Div, Alloc {
@@ -2097,7 +2119,7 @@ fn hlir_kernels_to_ptx(module: HlirModule) -> PtxBuf with Mut, Panic, Div, Alloc
             let func = module.functions[fidx as usize]
             let gpu_kernel = hlir_function_to_gpu_kernel(func)
             let ptx = gpu_lower_to_ptx(gpu_kernel)
-            combined = ptx_buf_append(combined, ptx)
+            combined = hlir_ptx_append_kernel_module(combined, ptx, ki == 0)
         }
         ki = ki + 1
     }
@@ -2129,7 +2151,7 @@ fn hlir_kernels_to_tuned_ptx(module: HlirModule) -> PtxBuf with Mut, Panic, Div,
                 gpu_kernel.shared_mem_bytes = tuned.shared_mem_bytes
             }
             let ptx = gpu_lower_to_ptx(gpu_kernel)
-            combined = ptx_buf_append(combined, ptx)
+            combined = hlir_ptx_append_kernel_module(combined, ptx, ki == 0)
         }
         ki = ki + 1
     }
@@ -2187,7 +2209,7 @@ fn hlir_kernels_to_fused_ptx(module: HlirModule) -> PtxBuf with Mut, Panic, Div,
     var pi: i64 = 0
     while pi < fused_count {
         let ptx = gpu_lower_to_ptx(fused_kernels[pi as usize])
-        combined = ptx_buf_append(combined, ptx)
+        combined = hlir_ptx_append_kernel_module(combined, ptx, pi == 0)
         pi = pi + 1
     }
     combined
@@ -2208,7 +2230,7 @@ fn hlir_kernels_to_epistemic_ptx(module: HlirModule) -> PtxBuf with Mut, Panic, 
             let func = module.functions[fidx as usize]
             let gpu_kernel = hlir_function_to_epistemic_gpu_kernel(func)
             let ptx = gpu_lower_to_ptx(gpu_kernel)
-            combined = ptx_buf_append(combined, ptx)
+            combined = hlir_ptx_append_kernel_module(combined, ptx, ki == 0)
         }
         ki = ki + 1
     }
@@ -2676,7 +2698,7 @@ fn hlir_kernels_to_epistemic_fused_ptx(module: HlirModule) -> PtxBuf with Mut, P
     var pi: i64 = 0
     while pi < fused_count {
         let ptx = gpu_lower_to_ptx(fused_kernels[pi as usize])
-        combined = ptx_buf_append(combined, ptx)
+        combined = hlir_ptx_append_kernel_module(combined, ptx, pi == 0)
         pi = pi + 1
     }
 
@@ -2738,7 +2760,7 @@ fn hlir_kernels_to_speculative_ptx(module: HlirModule) -> PtxBuf with Mut, Panic
             combined = ptx_push_str(combined, "\n")
         }
         let ptx = gpu_lower_to_ptx(kernels[si as usize])
-        combined = ptx_buf_append(combined, ptx)
+        combined = hlir_ptx_append_kernel_module(combined, ptx, si == 0)
         si = si + 1
     }
 
@@ -2918,6 +2940,7 @@ fn hlir_kernels_to_dag_scheduled_ptx(module: HlirModule) -> PtxBuf with Mut, Pan
 
     // Phase 7: Lower each kernel in topological order to PTX
     var loi: i64 = 0
+    var emitted_count: i64 = 0
     while loi < topo_count {
         // Find node at this topo position
         var node: i64 = -1
@@ -2932,7 +2955,8 @@ fn hlir_kernels_to_dag_scheduled_ptx(module: HlirModule) -> PtxBuf with Mut, Pan
 
         if node >= 0 {
             let ptx = gpu_lower_to_ptx(kernels[node as usize])
-            combined = ptx_buf_append(combined, ptx)
+            combined = hlir_ptx_append_kernel_module(combined, ptx, emitted_count == 0)
+            emitted_count = emitted_count + 1
         }
 
         loi = loi + 1

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -873,11 +873,17 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
                 ptx_opcode_ld_param_u64()
             } else if op.ty == GpuType::GpuU32 {
                 ptx_opcode_ld_param_u32()
+            } else if op.ty == GpuType::GpuF32 {
+                ptx_opcode_ld_param_f32()
+            } else if op.ty == GpuType::GpuF64 {
+                ptx_opcode_ld_param_f64()
             } else {
                 ptx_opcode_ld_param_u64()
             }
-            if op.ty == GpuType::GpuF64 {
-                ptx_push_binary_mem2(buf, ptx_opcode_ld_param_u64(), gpu_reg_f64(op.dst_reg), name_to_string(param_name))
+            if op.ty == GpuType::GpuF32 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_f32(op.dst_reg), name_to_string(param_name))
+            } else if op.ty == GpuType::GpuF64 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_f64(op.dst_reg), name_to_string(param_name))
             } else if op.ty == GpuType::GpuU64 {
                 ptx_push_binary_mem2(buf, opcode, gpu_reg_u64(op.dst_reg), name_to_string(param_name))
             } else if op.ty == GpuType::GpuU32 {

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -339,6 +339,8 @@ pub fn ptx_opcode_mul_lo_u64() -> string { "mul.lo.u64" }
 pub fn ptx_opcode_ld_param_u64() -> string { "ld.param.u64" }
 pub fn ptx_opcode_ld_param_u32() -> string { "ld.param.u32" }
 pub fn ptx_opcode_ld_param_u16() -> string { "ld.param.u16" }
+pub fn ptx_opcode_ld_param_f32() -> string { "ld.param.f32" }
+pub fn ptx_opcode_ld_param_f64() -> string { "ld.param.f64" }
 
 pub fn ptx_opcode_add_u64() -> string { "add.u64" }
 

--- a/self-hosted/hlir/lower.sio
+++ b/self-hosted/hlir/lower.sio
@@ -23,6 +23,19 @@ let HLIR_LOWER_MAX_SCOPES: i64 = 256
 let HLIR_LOWER_MAX_LOOP_DEPTH: i64 = 128
 let HLIR_LOWER_NO_LOOP: i64 = -1
 
+let HLIR_TYPE_CODE_NONE: i64 = 0
+let HLIR_TYPE_CODE_BOOL: i64 = 1
+let HLIR_TYPE_CODE_I8: i64 = 2
+let HLIR_TYPE_CODE_I16: i64 = 3
+let HLIR_TYPE_CODE_I32: i64 = 4
+let HLIR_TYPE_CODE_I64: i64 = 5
+let HLIR_TYPE_CODE_U8: i64 = 6
+let HLIR_TYPE_CODE_U16: i64 = 7
+let HLIR_TYPE_CODE_U32: i64 = 8
+let HLIR_TYPE_CODE_U64: i64 = 9
+let HLIR_TYPE_CODE_F32: i64 = 10
+let HLIR_TYPE_CODE_F64: i64 = 11
+
 pub fn hlir_i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
     if n < 0 {
         return "0"
@@ -1748,6 +1761,61 @@ pub fn hlir_ast_path_head_to_string(path: AstPath) -> string with Mut, Panic, Di
     str_from_bytes(path.segments.head_buf, path.segments.head_len)
 }
 
+fn hlir_type_code_from_type(ty: HlirType) -> i64 {
+    if ty.kind == HlirTypeKind::HlirTypeBool { return HLIR_TYPE_CODE_BOOL }
+    if ty.kind == HlirTypeKind::HlirTypeI8 { return HLIR_TYPE_CODE_I8 }
+    if ty.kind == HlirTypeKind::HlirTypeI16 { return HLIR_TYPE_CODE_I16 }
+    if ty.kind == HlirTypeKind::HlirTypeI32 { return HLIR_TYPE_CODE_I32 }
+    if ty.kind == HlirTypeKind::HlirTypeI64 { return HLIR_TYPE_CODE_I64 }
+    if ty.kind == HlirTypeKind::HlirTypeU8 { return HLIR_TYPE_CODE_U8 }
+    if ty.kind == HlirTypeKind::HlirTypeU16 { return HLIR_TYPE_CODE_U16 }
+    if ty.kind == HlirTypeKind::HlirTypeU32 { return HLIR_TYPE_CODE_U32 }
+    if ty.kind == HlirTypeKind::HlirTypeU64 { return HLIR_TYPE_CODE_U64 }
+    if ty.kind == HlirTypeKind::HlirTypeF32 { return HLIR_TYPE_CODE_F32 }
+    if ty.kind == HlirTypeKind::HlirTypeF64 { return HLIR_TYPE_CODE_F64 }
+    HLIR_TYPE_CODE_NONE
+}
+
+fn hlir_type_from_code(code: i64) -> HlirType {
+    if code == HLIR_TYPE_CODE_BOOL { return hlir_type_bool() }
+    if code == HLIR_TYPE_CODE_I8 { return hlir_type_i8() }
+    if code == HLIR_TYPE_CODE_I16 { return hlir_type_i16() }
+    if code == HLIR_TYPE_CODE_I32 { return hlir_type_i32() }
+    if code == HLIR_TYPE_CODE_I64 { return hlir_type_i64() }
+    if code == HLIR_TYPE_CODE_U8 { return hlir_type_u8() }
+    if code == HLIR_TYPE_CODE_U16 { return hlir_type_u16() }
+    if code == HLIR_TYPE_CODE_U32 { return hlir_type_u32() }
+    if code == HLIR_TYPE_CODE_U64 { return hlir_type_u64() }
+    if code == HLIR_TYPE_CODE_F32 { return hlir_type_f32() }
+    if code == HLIR_TYPE_CODE_F64 { return hlir_type_f64() }
+    hlir_type_void()
+}
+
+fn hlir_type_with_element(base: HlirType, elem: HlirType) -> HlirType with Mut {
+    var out = base
+    let code = hlir_type_code_from_type(elem)
+    if code != HLIR_TYPE_CODE_NONE {
+        out.type_elem_count = 1
+        out.type_elems[0] = code
+    }
+    out
+}
+
+fn hlir_type_element_or_void(ty: HlirType) -> HlirType {
+    if ty.type_elem_count > 0 {
+        return hlir_type_from_code(ty.type_elems[0])
+    }
+    hlir_type_void()
+}
+
+fn hlir_type_element_or_i64(ty: HlirType) -> HlirType {
+    let elem = hlir_type_element_or_void(ty)
+    if elem.kind != HlirTypeKind::HlirTypeVoid {
+        return elem
+    }
+    hlir_type_i64()
+}
+
 pub fn hlir_type_from_ast(ty: TypeExpr) -> HlirType with Mut, Panic, Div, Alloc {
     if ty.kind == TypeExprKind::TypeUnit {
         return hlir_type_void()
@@ -1779,8 +1847,31 @@ pub fn hlir_type_from_ast(ty: TypeExpr) -> HlirType with Mut, Panic, Div, Alloc 
         if tname == "bool" { return hlir_type_bool() }
         if tname == "unit" { return hlir_type_void() }
     }
+    if ty.kind == TypeExprKind::TypeArray {
+        match ty.inner {
+            Some(elem) => {
+                let elem_ty = hlir_type_from_ast(*elem)
+                return hlir_type_with_element(hlir_type_array(-1, 0), elem_ty)
+            }
+            None => return hlir_type_array(-1, 0),
+        }
+    }
     if ty.kind == TypeExprKind::TypeReference || ty.kind == TypeExprKind::TypeRefMut {
-        return hlir_type_ptr(-1)
+        match ty.inner {
+            Some(inner) => {
+                let inner_ty = *inner
+                let elem_ty = if inner_ty.kind == TypeExprKind::TypeArray {
+                    match inner_ty.inner {
+                        Some(elem) => hlir_type_from_ast(*elem),
+                        None => hlir_type_i64(),
+                    }
+                } else {
+                    hlir_type_from_ast(inner_ty)
+                }
+                return hlir_type_with_element(hlir_type_ptr(-1), elem_ty)
+            }
+            None => return hlir_type_ptr(-1),
+        }
     }
     // Conservative fallback for unsupported/unknown AST types.
     hlir_type_i64()
@@ -1818,6 +1909,25 @@ pub fn hlir_ast_binary_to_hlir(op: BinaryOp) -> i64 {
     }
 }
 
+pub fn hlir_ast_binary_to_hlir_typed(op: BinaryOp, lhs_ty: HlirType, rhs_ty: HlirType) -> i64 {
+    let is_float = lhs_ty.kind == HlirTypeKind::HlirTypeF32 || lhs_ty.kind == HlirTypeKind::HlirTypeF64 ||
+                   rhs_ty.kind == HlirTypeKind::HlirTypeF32 || rhs_ty.kind == HlirTypeKind::HlirTypeF64
+    if is_float {
+        if op == BinaryOp::OpAdd { return HLIR_BIN_FADD }
+        if op == BinaryOp::OpSub { return HLIR_BIN_FSUB }
+        if op == BinaryOp::OpMul { return HLIR_BIN_FMUL }
+        if op == BinaryOp::OpDiv { return HLIR_BIN_FDIV }
+        if op == BinaryOp::OpRem { return HLIR_BIN_FREM }
+        if op == BinaryOp::OpEq { return HLIR_BIN_FOEQ }
+        if op == BinaryOp::OpNe { return HLIR_BIN_FONE }
+        if op == BinaryOp::OpLt { return HLIR_BIN_FOLT }
+        if op == BinaryOp::OpLe { return HLIR_BIN_FOLE }
+        if op == BinaryOp::OpGt { return HLIR_BIN_FOGT }
+        if op == BinaryOp::OpGe { return HLIR_BIN_FOGE }
+    }
+    hlir_ast_binary_to_hlir(op)
+}
+
 pub fn hlir_ast_binary_result_ty(op: BinaryOp) -> HlirType {
     if op == BinaryOp::OpEq
     || op == BinaryOp::OpNe
@@ -1830,6 +1940,26 @@ pub fn hlir_ast_binary_result_ty(op: BinaryOp) -> HlirType {
         return hlir_type_bool()
     }
     hlir_type_i64()
+}
+
+pub fn hlir_ast_binary_result_ty_typed(op: BinaryOp, lhs_ty: HlirType, rhs_ty: HlirType) -> HlirType {
+    if op == BinaryOp::OpEq
+    || op == BinaryOp::OpNe
+    || op == BinaryOp::OpLt
+    || op == BinaryOp::OpLe
+    || op == BinaryOp::OpGt
+    || op == BinaryOp::OpGe
+    || op == BinaryOp::OpAnd
+    || op == BinaryOp::OpOr {
+        return hlir_type_bool()
+    }
+    if lhs_ty.kind == HlirTypeKind::HlirTypeF64 || rhs_ty.kind == HlirTypeKind::HlirTypeF64 {
+        return hlir_type_f64()
+    }
+    if lhs_ty.kind == HlirTypeKind::HlirTypeF32 || rhs_ty.kind == HlirTypeKind::HlirTypeF32 {
+        return hlir_type_f32()
+    }
+    hlir_ast_binary_result_ty(op)
 }
 
 pub fn hlir_ast_unary_to_hlir(op: UnaryOp) -> i64 {
@@ -1883,9 +2013,32 @@ pub fn hlir_lower_field_access(state: HlirLowerState, base: i64, field: i64) -> 
     hlir_lower_load(ptr_pair.0, ptr_pair.1, hlir_type_i64())
 }
 
+fn hlir_lower_value_type(state: HlirLowerState, value_id: i64) -> HlirType {
+    hlir_function_lookup_local_type(state.builder.func, value_id)
+}
+
+fn hlir_lower_index_elem_type(state: HlirLowerState, base: i64) -> HlirType {
+    let base_ty = hlir_lower_value_type(state, base)
+    hlir_type_element_or_i64(base_ty)
+}
+
+fn hlir_lower_store_index_elem_type(state: HlirLowerState, base: i64, value_id: i64) -> HlirType {
+    let base_ty = hlir_lower_value_type(state, base)
+    let elem_ty = hlir_type_element_or_void(base_ty)
+    if elem_ty.kind != HlirTypeKind::HlirTypeVoid {
+        return elem_ty
+    }
+    let value_ty = hlir_lower_value_type(state, value_id)
+    if value_ty.kind != HlirTypeKind::HlirTypeVoid {
+        return value_ty
+    }
+    hlir_type_i64()
+}
+
 pub fn hlir_lower_index(state: HlirLowerState, base: i64, index: i64) -> (HlirLowerState, i64) with Mut, Panic {
-    let ptr_pair = hlir_lower_gep(state, base, index, hlir_type_i64())
-    hlir_lower_load(ptr_pair.0, ptr_pair.1, hlir_type_i64())
+    let elem_ty = hlir_lower_index_elem_type(state, base)
+    let ptr_pair = hlir_lower_gep(state, base, index, elem_ty)
+    hlir_lower_load(ptr_pair.0, ptr_pair.1, elem_ty)
 }
 
 pub fn hlir_lower_literal(state: HlirLowerState, lit: Expr) -> (HlirLowerState, i64) with Mut, Panic, Div, Alloc {
@@ -1985,7 +2138,8 @@ pub fn hlir_lower_assign_target(state: HlirLowerState, target: Expr, value_id: i
         let idx_pair = hlir_lower_expr_opt(s, target.right)
         s = idx_pair.0
         let idx_val = idx_pair.1
-        let elem_ptr_pair = hlir_lower_gep(s, base_val, idx_val, hlir_type_i64())
+        let elem_ty = hlir_lower_store_index_elem_type(s, base_val, value_id)
+        let elem_ptr_pair = hlir_lower_gep(s, base_val, idx_val, elem_ty)
         s = elem_ptr_pair.0
         return hlir_lower_store(s, elem_ptr_pair.1, value_id)
     }
@@ -2032,7 +2186,8 @@ pub fn hlir_lower_stmt(state: HlirLowerState, stmt: Stmt) -> HlirLowerState with
                     let idx_pair = hlir_lower_expr_opt(s, target_expr.right)
                     s = idx_pair.0
                     let idx_val = idx_pair.1
-                    let elem_ptr_pair = hlir_lower_gep(s, base_val, idx_val, hlir_type_i64())
+                    let elem_ty = hlir_lower_index_elem_type(s, base_val)
+                    let elem_ptr_pair = hlir_lower_gep(s, base_val, idx_val, elem_ty)
                     s = elem_ptr_pair.0
                     let ptr_val = elem_ptr_pair.1
                     let rhs_pair = hlir_lower_expr_opt(s, stmt.expr)
@@ -2111,8 +2266,10 @@ pub fn hlir_lower_expr(state: HlirLowerState, expr: Expr) -> (HlirLowerState, i6
         let rhs_pair = hlir_lower_expr_opt(s, expr.right)
         s = rhs_pair.0
         let rhs_val = rhs_pair.1
-        let op = hlir_ast_binary_to_hlir(expr.bin_op)
-        let ty = hlir_ast_binary_result_ty(expr.bin_op)
+        let lhs_ty = hlir_lower_value_type(s, lhs_val)
+        let rhs_ty = hlir_lower_value_type(s, rhs_val)
+        let op = hlir_ast_binary_to_hlir_typed(expr.bin_op, lhs_ty, rhs_ty)
+        let ty = hlir_ast_binary_result_ty_typed(expr.bin_op, lhs_ty, rhs_ty)
         return hlir_lower_binary(s, op, lhs_val, rhs_val, ty)
     }
 

--- a/tests/gpu/gate_public_gpu_cfg_build.sh
+++ b/tests/gpu/gate_public_gpu_cfg_build.sh
@@ -61,6 +61,20 @@ reject_egrep() {
     fi
 }
 
+require_egrep_count() {
+    local label="$1"
+    local pattern="$2"
+    local expected="$3"
+    local file="$4"
+    local count
+    count="$(grep -Ec "$pattern" "$file" || true)"
+    if [ "$count" -eq "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label" "expected $expected matches for $pattern in $file, got $count"
+    fi
+}
+
 build_gpu() {
     local label="$1"
     local src="$2"
@@ -127,9 +141,22 @@ require_egrep "gpu_vec_add_e2e_scales_index" "mul\\.lo\\.u64 %rd[0-9]+, %rd[0-9]
 require_egrep "gpu_vec_add_e2e_addresses_a" "add\\.u64 %rd[0-9]+, %rd1, %rd[0-9]+;" "$E2E_PTX"
 require_egrep "gpu_vec_add_e2e_addresses_b" "add\\.u64 %rd[0-9]+, %rd2, %rd[0-9]+;" "$E2E_PTX"
 require_egrep "gpu_vec_add_e2e_addresses_c" "add\\.u64 %rd[0-9]+, %rd3, %rd[0-9]+;" "$E2E_PTX"
-require_egrep "gpu_vec_add_e2e_loads_inputs" "ld\\.global\\.s64 %rd[0-9]+, \\[%rd[0-9]+\\];" "$E2E_PTX"
-require_egrep "gpu_vec_add_e2e_adds_inputs" "add\\.s64 %rd[0-9]+, %rd[0-9]+, %rd[0-9]+;" "$E2E_PTX"
-require_egrep "gpu_vec_add_e2e_stores_output" "st\\.global\\.s64 \\[%rd[0-9]+\\], %rd[0-9]+;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_declares_f64_regs" "\\.reg \\.f64 %fd<[0-9]+>;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_loads_f64_inputs" "ld\\.global\\.f64 %fd[0-9]+, \\[%rd[0-9]+\\];" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_adds_f64_inputs" "add\\.f64 %fd[0-9]+, %fd[0-9]+, %fd[0-9]+;" "$E2E_PTX"
+require_egrep "gpu_vec_add_e2e_stores_f64_output" "st\\.global\\.f64 \\[%rd[0-9]+\\], %fd[0-9]+;" "$E2E_PTX"
+reject_egrep "gpu_vec_add_e2e_rejects_s64_value_loads" "ld\\.global\\.s64 %rd[0-9]+, \\[%rd[0-9]+\\];" "$E2E_PTX"
+reject_egrep "gpu_vec_add_e2e_rejects_s64_value_stores" "st\\.global\\.s64 \\[%rd[0-9]+\\], %rd[0-9]+;" "$E2E_PTX"
+
+SLICES_PTX="$TMP_DIR/gpu_launch_vec_slices.ptx"
+build_gpu "gpu_launch_vec_slices_builds" "tests/run-pass/gpu_launch_vec_slices.sio" "$SLICES_PTX"
+require_egrep_count "gpu_launch_vec_slices_single_ptx_version" "^\\.version " 1 "$SLICES_PTX"
+require_egrep_count "gpu_launch_vec_slices_single_ptx_target" "^\\.target " 1 "$SLICES_PTX"
+require_egrep_count "gpu_launch_vec_slices_single_ptx_address_size" "^\\.address_size " 1 "$SLICES_PTX"
+require_egrep "gpu_launch_vec_slices_loads_f64_scalar_params" "ld\\.param\\.f64 %fd[0-9]+, \\[(factor|bias)\\];" "$SLICES_PTX"
+reject_egrep "gpu_launch_vec_slices_rejects_u64_load_to_f64_param" "ld\\.param\\.u64 %fd[0-9]+, \\[(factor|bias)\\];" "$SLICES_PTX"
+require_egrep "gpu_launch_vec_slices_multiplies_f64" "mul\\.rn\\.f64 %fd[0-9]+, %fd[0-9]+, %fd[0-9]+;" "$SLICES_PTX"
+require_egrep "gpu_launch_vec_slices_divides_f64" "div\\.rn\\.f64 %fd[0-9]+, %fd[0-9]+, %fd[0-9]+;" "$SLICES_PTX"
 
 echo ""
 echo "Summary: pass=$PASS fail=$FAIL"


### PR DESCRIPTION
## Summary
- Preserve array/reference element type metadata in HLIR lowering so GPU slice indexing lowers `&[f64]` loads/stores as f64 instead of s64.
- Use typed HLIR binary lowering for float arithmetic, including f64 add/mul/div paths used by public GPU kernels.
- Emit a single PTX header for multi-kernel GPU outputs and use `ld.param.f32/f64` for float scalar parameters.
- Extend `tests/gpu/gate_public_gpu_cfg_build.sh` to reject s64 value loads/stores for `gpu_vec_add_e2e` and to guard multi-kernel headers plus f64 scalar param loads.
- Rebuilt `bin/madaros-linux-x86_64` from this branch.

## Root Cause
The HLIR public GPU path collapsed indexed array element values to i64, so `gpu_vec_add_e2e.sio` with `&[f64]` emitted `ld.global.s64`, `add.s64`, and `st.global.s64`. Real DGX Spark validation then exposed two adjacent PTX assembly blockers: repeated `.version/.target/.address_size` headers in multi-kernel PTX, and `ld.param.u64` into `%fd` registers for `.param .f64` scalar parameters.

## Validation
- `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-gpu-f64-index-20260629-v3` -> PASS, produced 104112812-byte Madaros.
- `env -u SOUNIO_STDLIB_PATH bash tests/gpu/gate_public_gpu_cfg_build.sh` -> PASS, 35/35.
- `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/gpu/hlir_to_gpu.sio` -> PASS.
- `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/gpu/lower_to_ptx.sio` -> PASS.
- `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/gpu/ptx.sio` -> PASS.
- `env -u SOUNIO_STDLIB_PATH ./bin/souc build tests/run-pass/gpu_vec_add_e2e.sio --backend gpu -o /tmp/f64-index-v3.ptx` -> emitted `.reg .f64`, `ld.global.f64`, `add.f64`, `st.global.f64`.
- `env -u SOUNIO_STDLIB_PATH ./bin/souc build tests/run-pass/gpu_launch_vec_slices.sio --backend gpu -o /tmp/f64-index-v3-launch-slices.ptx` -> emitted one PTX header, `ld.param.f64`, `mul.rn.f64`, `div.rn.f64`.
- DGX Spark `192.168.3.43` (`spark-8e54`, NVIDIA GB10 cc 12.1, CUDA 13.0 ptxas V13.0.88): `/usr/local/cuda-13.0/bin/ptxas -arch=sm_121 launch_slices_v3.ptx -o launch_slices_v3.cubin` -> PASS, produced 25K cubin.
- DGX Spark runtime harness for generated `vec_add_v3.ptx` -> PASS: `c[0]=4`, `c[1]=3`, `c[2]=3`, `c[3]=10.125`.
- `git diff --check` -> PASS.

## Known Limitation
- Direct standalone `env -u SOUNIO_STDLIB_PATH ./bin/souc check self-hosted/hlir/lower.sio` still fails with the pre-existing isolated-file parse issue: `syntax appears incomplete after assignment` at `self-hosted/hlir/lower.sio:2596:79`. The imported module path and rebuilt compiler path passed.

## LLM-offload reviews invoked
- None. This change touches compiler/GPU lowering and tests only; it does not touch math claims, clinical-pathway code, or external-facing artifacts under `.claude/AGENT_OFFLOAD_POLICY.md`.
