### PR TITLE
feat(dissertation): midazolam CYP3A DDI canonical parity (fifth drug, cases 17-19)

### DIFF
--- a/docs/dissertation/results/pbpk14_midazolam_ddi_canonical_v1.md
+++ b/docs/dissertation/results/pbpk14_midazolam_ddi_canonical_v1.md
@@ -1,0 +1,124 @@
+<!-- docs:meta
+topic_id: repo.docs.dissertation.results.pbpk14-midazolam-ddi-canonical-v1
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.dissertation.results.pbpk14-midazolam-ddi-canonical-v1
+-->
+
+# PBPK14 Midazolam — CYP3A Drug–Drug Interaction (Fifth Canonical Drug)
+
+## Scope
+
+Midazolam is the **fifth canonical drug** of the PBPK dissertation suite and the
+**first to model a drug–drug interaction (DDI)**. The four prior drugs each added
+a distinct modeling surface — rapamycin (PBPK28 + TMDD + neointima PD),
+semaglutide (PBPK28 + TMDD + Bergman PD), venlafaxine (parent + ODV + matrix
+release), haloperidol (PBPK14 + BBB Kpuu + D2 occupancy). None modeled enzyme
+inhibition. Midazolam adds it: **oral midazolam co-administered with
+ketoconazole**, the textbook CYP3A victim/perpetrator pair, whose iconic readout
+is oral AUC rising ~15× under a strong CYP3A inhibitor (Olkkola 1994).
+
+As with the prior four drugs, the contribution is a **Sounio↔Node 0.0000% parity
+surface**: a self-contained Sounio reference and the pure-JS engine the
+dissertation viewer runs produce byte-identical trajectories under a fixed-step
+RK4 integrator. Parity gate cases **17–19** were added; the full gate (cases
+1–19) is green with no regression.
+
+## The mechanism (and the honesty it required)
+
+The DDI is modeled with the **standard well-stirred oral first-pass** formulation,
+parameterized by *intrinsic* clearances rather than lumped quantities:
+
+| Quantity | Expression |
+|---|---|
+| Gut-wall survival | `FG  = Qg / (Qg + fu_g·CLint_g)` |
+| Hepatic first-pass survival | `FH  = Qh / (Qh + fu·CLint_h)` |
+| Systemic clearance | `CL_h = Qh·fu·CLint_h / (Qh + fu·CLint_h)` |
+| Oral bioavailability | `F = Fa · FG · FH` |
+| Oral exposure | `AUC = F·Dose / CL_h` |
+| Competitive inhibition | `CLint → CLint / (1 + I/Ki)` (gut and hepatic, same enzyme) |
+
+**The avoided trap.** A naïve implementation would scale a lumped `F` *up* and a
+separate lumped `CL` *down* under inhibition — double-counting hepatic CYP3A and
+**fabricating** the 15×. Parity cannot catch this (both sides compute the same
+wrong number). The fix is that a **single** hepatic intrinsic clearance `CLint_h`
+drives *both* `FH` and `CL_h`; inhibiting that one quantity raises `FH` and lowers
+`CL_h` consistently, so the ~15× emerges with **no double-count**. This is the
+well-stirred model's correct closed form, not an approximation, and required no
+portal-vein topology change.
+
+**Gut matters.** With the gut term, the model lands AUCR = **14.99×** at
+`I/Ki = 8`; hepatic-only inhibition reaches only **9.0×**. The gut-wall CYP3A
+contribution (`FG'/FG = 1.67×`) is exactly why oral midazolam is *the* CYP3A
+probe (Thummel 1996). This is asserted in `validation/midazolam_ddi.sio` TEST 4.
+
+## Parity surface (gate cases 17–19)
+
+| Case | Series | Result |
+|---|---|---|
+| 17 | Solo oral PK (5 mg), 12 samples | `MIDAZOLAM_SOLO_PK_PARITY_PASS` — 0.0000% RMSE |
+| 18 | Ketoconazole-inhibited oral PK, 12 samples | `MIDAZOLAM_DDI_PK_PARITY_PASS` — 0.0000% RMSE |
+| 19 | DDI inhibition curve (F, CL_h, AUCR across I/Ki), 8 points | `MIDAZOLAM_AUCR_PARITY_PASS` — 0.0000% RMSE |
+
+All three series are **byte-identical** between the Sounio reference
+(`tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio`) and the Node
+runner (`scripts/dissertation/run_midazolam_node.mjs`, consuming
+`website/src/lib/pbpk28_core.mjs runMidazolamScenario`).
+
+## Locked parameters
+
+```
+Qh = 90 L/h   Qg = 18 L/h (Qgut model)   fu = 0.03   fu_g = 1.0   Fa = 0.95
+CLint_h = 1090 L/h   CLint_g = 14.7 L/h     ka = 3.0 /h   tlag = 0
+Ketoconazole: Ki = 0.008 mg/L, I_ss(unbound) = 0.064 mg/L  -> I/Ki = 8, R = 9
+=> solo: FH 0.733, FG 0.551, CL_h 23.99 L/h, F 0.384  (oral F in Heizmann 1984 range)
+=> +keto: FH 0.961, FG 0.917, CL_h 3.49 L/h, F 0.837   -> AUCR 14.99×
+```
+
+Pharmacogenomics (`pgx/cyp3a45_midazolam.sio`): CYP3A5*3 expresser vs
+non-expresser and CYP3A4*22 carrier scale `CLint_h` (and hence `CL_h`); validated
+ordering — expresser CL_h 28.6 > non-expresser 23.99 > *22 carrier.
+
+## Honest framing (what this does and does not claim)
+
+- **Parity proves Sounio == Node to f64**, not ground-truth accuracy. The ~15× is
+  a **model output**, validated against literature (Olkkola 1994; band 12–18×) in
+  `validation/midazolam_ddi.sio`, not asserted as a measured constant.
+- **Well-stirred first-pass** is assumed; the gut `Qgut` is the Yang 2007 hybrid
+  villous flow, distinct from splanchnic perfusion.
+- **Static inhibitor.** Ketoconazole is held at its steady-state unbound
+  concentration (as clinical DDI studies pre-dose the perpetrator) — this is *not*
+  a dynamic two-drug PK simulation.
+- **Fixed-step RK4 (parity) vs adaptive Tsit5 (production).** Bit-for-bit parity
+  on an adaptive controller is intractable, so both the reference and the JS
+  engine use a fixed-step RK4 — parity validates exactly what the viewer runs. The
+  production scenario (`scenarios/oral_midazolam_ddi.sio`) uses Tsit5 and
+  independently reproduces AUCR ≈ 15.2× as a cross-check.
+- **Nominal distribution Kp.** Systemic tissue partition coefficients are
+  midazolam-plausible (Vss ≈ 1.4 L/kg) but nominal; the *validated* DDI quantities
+  (F, CL_h, AUCR) are distribution-independent.
+
+## Artifacts
+
+- `tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio` — Sounio parity ref
+- `scripts/dissertation/run_midazolam_node.mjs` — Node runner
+- `website/src/lib/pbpk28_core.mjs` — `runMidazolamScenario` / `runMidazolamDDIResponse`
+- `stdlib/darwin_pbpk/ddi/cyp3a_competitive.sio` — competitive-inhibition + first-pass primitive
+- `stdlib/darwin_pbpk/drugs/midazolam.sio` — drug module
+- `stdlib/darwin_pbpk/pgx/cyp3a45_midazolam.sio` — CYP3A5 / CYP3A4*22 PGx
+- `stdlib/darwin_pbpk/scenarios/oral_midazolam_ddi.sio` — production Tsit5 scenario
+- `stdlib/darwin_pbpk/validation/midazolam_ddi.sio` — literature-anchored validation (6/6)
+- `scripts/ci/dissertation_pbpk28_parity_gate.sh` — gate cases 17–19
+
+## References
+
+- Olkkola KT et al. (1994) *Clin Pharmacol Ther* 55:481 — oral midazolam +
+  ketoconazole AUC ~15×.
+- Heizmann P et al. (1984) *Br J Anaesth* 56:1215 — oral midazolam bioavailability.
+- Thummel KE et al. (1996) *Clin Pharmacol Ther* 59:491 — gut + hepatic first-pass.
+- Gorski JC et al. (1998) *Clin Pharmacol Ther* 64:133 — CYP3A inhibition.
+- Yang J et al. (2007) *Curr Drug Metab* 8:676 — Qgut model.
+- Kuehl P et al. (2001) *Nat Genet* 27:383 — CYP3A5*3; Wang D et al. (2011)
+  *Pharmacogenomics J* 11:274 — CYP3A4*22.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 843
-- Repo-backed topics: 693
+- Total governed topics: 844
+- Repo-backed topics: 694
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 487
+- Authority count `repo_only`: 488
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 491 topics
+- A2: 492 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -277,6 +277,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.dissertation.results.mc-prior-family-sweep-v1 | repo_only | docs/dissertation/results/mc_prior_family_sweep_v1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.results.mc-prior-family-sweep-v2 | repo_only | docs/dissertation/results/mc_prior_family_sweep_v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.results.ml-negz-fix-v1 | repo_only | docs/dissertation/results/ml_negz_fix_v1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.dissertation.results.pbpk14-midazolam-ddi-canonical-v1 | repo_only | docs/dissertation/results/pbpk14_midazolam_ddi_canonical_v1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.results.pbpk28-epistemic-v1 | repo_only | docs/dissertation/results/pbpk28_epistemic_v1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.results.prior-evolution-sprint-summary-v1 | repo_only | docs/dissertation/results/prior_evolution_sprint_summary_v1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.dissertation.results.prior-evolution-sprint-summary-v2 | repo_only | docs/dissertation/results/prior_evolution_sprint_summary_v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -5871,6 +5871,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.dissertation.results.pbpk14-midazolam-ddi-canonical-v1",
+      "collection": "repo",
+      "repo_doc_path": "docs/dissertation/results/pbpk14_midazolam_ddi_canonical_v1.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.dissertation.results.pbpk28-epistemic-v1",
       "collection": "repo",
       "repo_doc_path": "docs/dissertation/results/pbpk28_epistemic_v1.md",

--- a/scripts/ci/dissertation_pbpk28_parity_gate.sh
+++ b/scripts/ci/dissertation_pbpk28_parity_gate.sh
@@ -860,3 +860,60 @@ halo_series_rmse d2occ "D2 occupancy" "HALOPERIDOL_D2_OCCUPANCY_PARITY_PASS" "HA
 
 echo
 echo "[pbpk28-parity] haloperidol CASO II canonical: plasma + BBB Kpuu + D2 occupancy all within ${RMSE_THRESHOLD_PCT}% RMSE (4th canonical drug)"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Cases 17-19: Midazolam — fifth canonical drug, the suite's first CYP3A
+# drug–drug interaction (DDI). PBPK14 well-stirred + mechanistic oral first-pass
+# (F = Fa·FG·FH) + competitive CYP3A inhibition by ketoconazole.
+#   17  solo oral PK                         Node ↔ Sounio, <1% RMSE
+#   18  ketoconazole-inhibited oral PK       Node ↔ Sounio, <1% RMSE
+#   19  DDI inhibition curve (AUCR vs I/Ki)  Node ↔ Sounio, <1% RMSE
+# A single hepatic CLint_h drives BOTH first-pass survival FH and systemic CL_h
+# (well-stirred closed form), so inhibition raises FH and lowers CL_h
+# consistently — no double-count — and the iconic oral midazolam+ketoconazole AUC
+# rise (~15×) emerges honestly (validated in validation/midazolam_ddi.sio). The
+# inhibitor is held static at steady state; both sides use a FIXED-STEP RK4
+# systemic integrator (the production scenario uses adaptive Tsit5 — an
+# intractable bit-for-bit parity target; gap disclosed in the gist).
+# ════════════════════════════════════════════════════════════════════════════
+echo
+echo "[pbpk28-parity] Cases 17-19: Sounio ↔ Node midazolam (solo PK + ketoconazole DDI + AUCR curve)"
+
+MDZ_NODE_RUNNER="$ROOT_DIR/scripts/dissertation/run_midazolam_node.mjs"
+MDZ_SIO_LOG="$OUT_DIR/mdz_sounio.txt"
+MDZ_NODE_LOG="$OUT_DIR/mdz_node.txt"
+
+"$SOUC_BIN" run tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio > "$MDZ_SIO_LOG" 2>&1 || {
+  echo "[pbpk28-parity:case17] FAIL: Sounio midazolam ref returned non-zero" >&2
+  tail -n 20 "$MDZ_SIO_LOG" >&2; exit 1; }
+if ! grep -q '^DISSERTATION_PBPK28_MIDAZOLAM_PARITY_DONE$' "$MDZ_SIO_LOG"; then
+  echo "[pbpk28-parity:case17] FAIL: Sounio midazolam ref did not emit DONE" >&2; exit 1; fi
+node "$MDZ_NODE_RUNNER" > "$MDZ_NODE_LOG" 2>&1 || {
+  echo "[pbpk28-parity:case17] FAIL: Node midazolam runner returned non-zero" >&2
+  tail -n 20 "$MDZ_NODE_LOG" >&2; exit 1; }
+if ! grep -q '^DISSERTATION_PBPK28_MIDAZOLAM_PARITY_DONE$' "$MDZ_NODE_LOG"; then
+  echo "[pbpk28-parity:case17] FAIL: Node midazolam runner did not emit DONE" >&2; exit 1; fi
+
+# RMSE over one MDZ|<series> (both logs emit them in the same order).
+mdz_series_rmse() {  # $1=series $2=expected-n $3=label $4=pass-marker $5=fail-marker
+  paste <(grep "^MDZ|$1=" "$MDZ_SIO_LOG"  | sed "s/^MDZ|$1=//") \
+        <(grep "^MDZ|$1=" "$MDZ_NODE_LOG" | sed "s/^MDZ|$1=//") \
+  | awk -v THR="$RMSE_THRESHOLD_PCT" -v EXP="$2" -v PASS="$4" -v FAILM="$5" -v LAB="$3" '
+      {d=($1+0)-($2+0); ss+=d*d; n++; a=($1<0?-($1+0):($1+0)); if(a>pk)pk=a}
+      END{ if(n!=EXP+0){printf "%s row count %d != %d\n",FAILM,n,EXP; exit 1}
+        rmse=sqrt(ss/n); pct=(pk>0)?100*rmse/pk:0;
+        if(pct<THR+0) printf "%s %d/%d within %s%% RMSE (%s, peak=%.4g)\n",PASS,n,EXP,THR,LAB,pk;
+        else { printf "%s %.4f%% RMSE (%s)\n",FAILM,pct,LAB; exit 1 } }'
+}
+
+echo "[pbpk28-parity:case17] midazolam solo oral PK (5 mg)"
+mdz_series_rmse plasma_solo 12 "plasma mg/L (solo)" "MIDAZOLAM_SOLO_PK_PARITY_PASS" "MIDAZOLAM_SOLO_PK_PARITY_FAIL"
+
+echo "[pbpk28-parity:case18] midazolam + ketoconazole inhibited oral PK (CYP3A DDI)"
+mdz_series_rmse plasma_inh 12 "plasma mg/L (+keto)" "MIDAZOLAM_DDI_PK_PARITY_PASS" "MIDAZOLAM_DDI_PK_PARITY_FAIL"
+
+echo "[pbpk28-parity:case19] midazolam DDI inhibition curve (AUCR across I/Ki, oral ~15× at I/Ki=8)"
+mdz_series_rmse aucr 8 "AUC ratio" "MIDAZOLAM_AUCR_PARITY_PASS" "MIDAZOLAM_AUCR_PARITY_FAIL"
+
+echo
+echo "[pbpk28-parity] midazolam CYP3A DDI canonical: solo PK + ketoconazole-inhibited PK + AUCR curve all within ${RMSE_THRESHOLD_PCT}% RMSE (5th canonical drug)"

--- a/scripts/dissertation/run_midazolam_node.mjs
+++ b/scripts/dissertation/run_midazolam_node.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Node-side reference runner for midazolam — fifth canonical drug, the suite's
+// first CYP3A drug–drug interaction (DDI). Consumes the SAME pure-JS core
+// (website/src/lib/pbpk28_core.mjs, runMidazolamScenario / runMidazolamDDIResponse)
+// and emits prefixed records bit-compatible with
+// tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio:
+//
+//   MDZ|t / MDZ|plasma_solo / MDZ|plasma_inh           (time-series, 12 samples)
+//   MDZ|igrid / MDZ|F / MDZ|clh / MDZ|aucr             (DDI dose-response, 8 points)
+//
+// Parity surface (gate cases 17-19): solo oral PK · ketoconazole-inhibited oral PK
+// · DDI inhibition curve (oral F, systemic CL_h, AUC ratio across I/Ki). Both sides
+// use a FIXED-STEP RK4 systemic integrator at the same dt (the production scenario
+// uses adaptive Tsit5 — an intractable bit-for-bit parity target); the inhibitor is
+// held STATIC at its steady-state unbound concentration.
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CORE_PATH = resolve(__dirname, '../../website/src/lib/pbpk28_core.mjs');
+const core = await import(CORE_PATH);
+const { runMidazolamScenario, runMidazolamDDIResponse, MDZ_KETO } = core;
+
+const DT = 0.002;
+const DOSE = 5.0;
+const SAMPLES = [0.25, 0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 18.0, 24.0, 36.0];
+const IGRID = [0.0, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0];
+
+function fmt(x) {
+  if (Math.abs(x) >= 1e-6 || x === 0) return Number(x).toFixed(6);
+  return Number(x).toExponential(6);
+}
+
+const solo = runMidazolamScenario(SAMPLES, { dt: DT, doseMg: DOSE, I: 0.0 });
+const inh  = runMidazolamScenario(SAMPLES, { dt: DT, doseMg: DOSE, I: MDZ_KETO.iSteadyState });
+const dd   = runMidazolamDDIResponse(IGRID);
+
+const out = [];
+out.push('DISSERTATION_PBPK28_MIDAZOLAM_PARITY_NODE v1');
+out.push('model=pbpk14_wellstirred+mechanistic_firstpass+cyp3a_competitive_ddi');
+out.push('integrator=fixed_step_rk4');
+out.push('dt=0.002');
+out.push('dose_mg=5.0');
+out.push('inhibitor=ketoconazole_static_steady_state');
+out.push('drug=midazolam');
+out.push(`samples=${SAMPLES.length}`);
+out.push(`igrid=${IGRID.length}`);
+
+for (let i = 0; i < solo.length; i++) {
+  out.push(`MDZ|t=${Number(solo[i].t).toFixed(6)}`);
+  out.push(`MDZ|plasma_solo=${fmt(solo[i].plasma)}`);
+  out.push(`MDZ|plasma_inh=${fmt(inh[i].plasma)}`);
+}
+
+for (const d of dd) {
+  out.push(`MDZ|igrid=${Number(d.iOverKi).toFixed(6)}`);
+  out.push(`MDZ|F=${fmt(d.F)}`);
+  out.push(`MDZ|clh=${fmt(d.clH)}`);
+  out.push(`MDZ|aucr=${fmt(d.aucr)}`);
+}
+
+out.push('DISSERTATION_PBPK28_MIDAZOLAM_PARITY_DONE');
+process.stdout.write(out.join('\n') + '\n');

--- a/stdlib/darwin_pbpk/ddi/cyp3a_competitive.sio
+++ b/stdlib/darwin_pbpk/ddi/cyp3a_competitive.sio
@@ -1,0 +1,113 @@
+// cyp3a_competitive.sio — Darwin PBPK CYP3A competitive (reversible) DDI module.
+//
+// The suite's first drug–drug interaction primitive. Models a CYP3A victim's oral
+// disposition under a reversible competitive inhibitor (e.g. ketoconazole) using
+// the standard well-stirred oral first-pass formulation.
+//
+// A SINGLE hepatic intrinsic clearance CLint_h yields BOTH:
+//   first-pass survival   FH   = Qh / (Qh + fu·CLint_h)
+//   systemic clearance    CL_h = Qh·fu·CLint_h / (Qh + fu·CLint_h)
+// A separate gut intrinsic clearance CLint_g yields the gut-wall survival
+//   FG = Qg / (Qg + fu_g·CLint_g).
+// Oral bioavailability F = Fa·FG·FH; AUC = F·Dose / CL_h.
+//
+// Competitive inhibition divides the INTRINSIC clearances by (1 + I/Ki) (same
+// enzyme, same factor for gut and liver). Because FH and CL_h derive from one
+// CLint_h, inhibition raises FH and lowers CL_h consistently — NO double-count —
+// so the oral AUC ratio (AUCR) emerges honestly (the iconic midazolam +
+// ketoconazole ~15× — see drugs/midazolam.sio, validation/midazolam_ddi.sio).
+//
+// All concentrations/clearances in mg/L and L/h (NOT ng/mL — unlike the ng/mL
+// tacrolimus_sirolimus_ddi module). `factor` is the inhibition factor in (0,1];
+// factor = 1.0 means no inhibition (baseline).
+//
+// Sources: Rowland & Matin 1973 / Pang & Rowland 1977 (well-stirred first-pass),
+// Ito 1998 (competitive I/Ki), Yang 2007 (Qgut model).
+
+pub struct Cyp3aSubstrate {
+    qh: f64,        // hepatic blood flow (L/h)
+    qg: f64,        // gut (villous) blood flow (L/h) — Qgut model
+    fu: f64,        // fraction unbound in blood
+    fu_gut: f64,    // enterocyte unbound fraction (convention 1.0)
+    fa: f64,        // fraction absorbed across apical membrane
+    clint_h: f64,   // hepatic intrinsic clearance (L/h) -> FH and CL_h
+    clint_g: f64,   // gut intrinsic clearance (L/h) -> FG
+}
+
+pub struct Cyp3aInhibitor {
+    ki: f64,         // competitive inhibition constant (mg/L, unbound)
+    i_unbound: f64,  // steady-state unbound inhibitor concentration (mg/L)
+}
+
+// Competitive inhibition factor 1/(1 + I/Ki) in (0,1].
+pub fn cyp3a_inhibition_factor(i_unbound: f64, ki: f64) -> f64 with Div {
+    return 1.0 / (1.0 + i_unbound / ki)
+}
+
+// Inhibition factor for a given inhibitor (i_unbound = 0 -> factor = 1.0).
+pub fn cyp3a_factor_of(inh: Cyp3aInhibitor) -> f64 with Div {
+    return cyp3a_inhibition_factor(inh.i_unbound, inh.ki)
+}
+
+// Gut-wall survival FG = Qg / (Qg + fu_g·CLint_g·factor).
+pub fn cyp3a_fg(s: Cyp3aSubstrate, factor: f64) -> f64 with Div {
+    let b = s.fu_gut * s.clint_g * factor
+    return s.qg / (s.qg + b)
+}
+
+// Hepatic first-pass survival FH = Qh / (Qh + fu·CLint_h·factor).
+pub fn cyp3a_fh(s: Cyp3aSubstrate, factor: f64) -> f64 with Div {
+    let a = s.fu * s.clint_h * factor
+    return s.qh / (s.qh + a)
+}
+
+// Systemic well-stirred hepatic clearance CL_h = Qh·fu·CLint_h·factor / (Qh + fu·CLint_h·factor).
+pub fn cyp3a_clh(s: Cyp3aSubstrate, factor: f64) -> f64 with Div {
+    let a = s.fu * s.clint_h * factor
+    return s.qh * a / (s.qh + a)
+}
+
+// Oral bioavailability F = Fa·FG·FH.
+pub fn cyp3a_f_oral(s: Cyp3aSubstrate, factor: f64) -> f64 with Div {
+    return s.fa * cyp3a_fg(s, factor) * cyp3a_fh(s, factor)
+}
+
+// Oral AUC ratio vs baseline: AUCR = (F/F0)·(CL_h0/CL_h). Linear-system exact.
+pub fn cyp3a_aucr(s: Cyp3aSubstrate, factor: f64) -> f64 with Div {
+    let f0 = cyp3a_f_oral(s, 1.0)
+    let clh0 = cyp3a_clh(s, 1.0)
+    let f = cyp3a_f_oral(s, factor)
+    let cl = cyp3a_clh(s, factor)
+    return (f / f0) * (clh0 / cl)
+}
+
+// ─── Smoke tests ─────────────────────────────────────────────────────────────
+fn cyp3a_test_substrate() -> Cyp3aSubstrate {
+    Cyp3aSubstrate { qh: 90.0, qg: 18.0, fu: 0.03, fu_gut: 1.0, fa: 0.95, clint_h: 1090.0, clint_g: 14.7 }
+}
+
+// No inhibition -> factor 1, AUCR exactly 1.
+fn test_cyp3a_baseline_aucr_unity() -> bool with Div {
+    let r = cyp3a_aucr(cyp3a_test_substrate(), 1.0)
+    return r > 0.999999 && r < 1.000001
+}
+
+// Strong inhibition (I/Ki = 8 -> factor 1/9) reproduces the oral ~15× AUCR band.
+fn test_cyp3a_strong_inhibition_15x() -> bool with Div {
+    let factor = cyp3a_inhibition_factor(0.064, 0.008)
+    let r = cyp3a_aucr(cyp3a_test_substrate(), factor)
+    return r > 12.0 && r < 18.0
+}
+
+// Gut contributes: full (gut+hepatic) AUCR exceeds the hepatic-only AUCR.
+fn test_cyp3a_gut_contributes() -> bool with Div {
+    let s = cyp3a_test_substrate()
+    let factor = cyp3a_inhibition_factor(0.064, 0.008)
+    let full = cyp3a_aucr(s, factor)
+    // hepatic-only: same Qh/fu/CLint_h, but gut not inhibited (clint_g unchanged).
+    let f0 = cyp3a_f_oral(s, 1.0)
+    let clh0 = cyp3a_clh(s, 1.0)
+    let fh_only = s.fa * cyp3a_fg(s, 1.0) * cyp3a_fh(s, factor)
+    let hep_only = (fh_only / f0) * (clh0 / cyp3a_clh(s, factor))
+    return full > hep_only
+}

--- a/stdlib/darwin_pbpk/drugs/midazolam.sio
+++ b/stdlib/darwin_pbpk/drugs/midazolam.sio
@@ -1,0 +1,99 @@
+// midazolam.sio — Midazolam systemic PBPK14 parameters + CYP3A DDI wiring.
+//
+// Fifth canonical drug; the suite's CYP3A drug–drug-interaction (DDI) probe.
+// Midazolam is the textbook CYP3A victim: oral bioavailability is gated by gut +
+// hepatic first-pass, and a strong CYP3A inhibitor (ketoconazole) raises oral AUC
+// ~15× (Olkkola 1994). The mechanism lives in ddi/cyp3a_competitive.sio: a single
+// hepatic intrinsic clearance CLint_h yields BOTH first-pass survival FH and the
+// systemic well-stirred clearance CL_h, so inhibition is consistent (no
+// double-count). This module exposes midazolam's substrate parameters and builds
+// PBPKParams14 / AbsorptionParams with the (optionally inhibited / PGx-adjusted)
+// CL_h and oral F derived from that mechanism.
+//
+// Systemic distribution Kp are nominal midazolam-plausible values (Vss ~1.4 L/kg,
+// moderate lipophilicity); the validated DDI quantities are F, CL_h and AUCR,
+// which are distribution-independent (see validation/midazolam_ddi.sio). Units:
+// L, L/h, mg/L. Renal clearance of unchanged drug is negligible (<1%).
+//
+// Sources: Heizmann 1984 (oral F~0.4), Thummel 1996 (gut+hepatic first-pass),
+// Gorski 1998 / Olkkola 1994,1996 (ketoconazole DDI ~15×), Yang 2007 (Qgut),
+// Smith 1981 (fu ~0.03).
+
+use darwin_pbpk::absorption::{AbsorptionParams}
+use darwin_pbpk::tsit5_pbpk14::{PBPKParams14}
+use darwin_pbpk::ddi::cyp3a_competitive::{Cyp3aSubstrate, Cyp3aInhibitor, cyp3a_clh, cyp3a_f_oral, cyp3a_factor_of}
+use darwin_pbpk::pgx::cyp3a45_midazolam::{mdz_cyp3a_adjusted_clint}
+
+// Midazolam CYP3A substrate parameters (drive FG/FH/CL_h in cyp3a_competitive).
+pub fn midazolam_cyp3a_substrate() -> Cyp3aSubstrate {
+    Cyp3aSubstrate { qh: 90.0, qg: 18.0, fu: 0.03, fu_gut: 1.0, fa: 0.95, clint_h: 1090.0, clint_g: 14.7 }
+}
+
+// Ketoconazole perpetrator: static steady-state unbound conc (mg/L); I/Ki = 8.
+pub fn ketoconazole_inhibitor() -> Cyp3aInhibitor {
+    Cyp3aInhibitor { ki: 0.008, i_unbound: 0.064 }
+}
+
+// PBPK14 systemic distribution template with a supplied (mechanism-derived)
+// effective plasma clearance cl_h_eff. The stdlib pbpk_ode applies cl_hepatic on
+// UNBOUND drug (cl_hepatic·fu·c_plasma), so we store the intrinsic-on-unbound
+// value CL_h/fu to realise cl_h_eff as the plasma clearance. (The fixed-step
+// parity ref applies CL_h on plasma directly — same effective clearance,
+// identical trajectory; the conventions agree on the observable plasma curve.)
+fn midazolam_params_with_clh(cl_h_eff: f64) -> PBPKParams14 with Div {
+    let fu: f64 = 0.03
+    PBPKParams14 {
+        // Volumes (L) — 70 kg reference
+        v_blood: 5.2, v_liver: 1.69, v_kidney: 0.31, v_brain: 1.37,
+        v_heart: 0.31, v_lung: 1.17, v_muscle: 29.0, v_adipose: 18.2,
+        v_gut: 1.65, v_skin: 7.8, v_bone: 10.5, v_spleen: 0.19,
+        v_pancreas: 0.14, v_other: 4.5,
+        // Blood flows (L/h)
+        q_liver: 90.0, q_kidney: 72.0, q_brain: 44.0, q_heart: 14.4,
+        q_lung: 0.0, q_muscle: 73.8, q_adipose: 18.0, q_gut: 57.6,
+        q_skin: 18.0, q_bone: 21.6, q_spleen: 10.8, q_pancreas: 4.5,
+        q_other: 18.0,
+        // Partition coefficients (midazolam, nominal)
+        kp_liver: 2.0, kp_kidney: 1.5, kp_brain: 1.5, kp_heart: 1.2,
+        kp_lung: 1.5, kp_muscle: 1.0, kp_adipose: 2.0, kp_gut: 1.5,
+        kp_skin: 1.2, kp_bone: 0.6, kp_spleen: 1.2, kp_pancreas: 1.2,
+        kp_other: 1.0,
+        // Clearance — intrinsic-on-unbound = CL_h/fu (stdlib multiplies by fu);
+        // renal negligible (<1%)
+        cl_hepatic: cl_h_eff / fu, cl_renal: 0.0,
+        // Blood binding
+        fu_plasma: fu, rb_ratio: 1.0
+    }
+}
+
+// Baseline (no inhibitor) PBPK14 parameters.
+pub fn midazolam_pbpk_params() -> PBPKParams14 with Mut, Div {
+    return midazolam_params_with_clh(cyp3a_clh(midazolam_cyp3a_substrate(), 1.0))
+}
+
+// PBPK14 parameters under a CYP3A inhibition factor in (0,1] (1.0 = no inhibition).
+pub fn midazolam_pbpk_params_ddi(factor: f64) -> PBPKParams14 with Mut, Div {
+    return midazolam_params_with_clh(cyp3a_clh(midazolam_cyp3a_substrate(), factor))
+}
+
+// PBPK14 parameters under a ketoconazole co-administration (static steady state).
+pub fn midazolam_pbpk_params_keto() -> PBPKParams14 with Mut, Div {
+    return midazolam_pbpk_params_ddi(cyp3a_factor_of(ketoconazole_inhibitor()))
+}
+
+// PGx-adjusted PBPK14 parameters: CYP3A5 expresser + CYP3A4*22 scale CLint_h.
+pub fn midazolam_pbpk_params_pgx(cyp3a5_geno: i32, cyp3a4_22: i32) -> PBPKParams14 with Mut, Div, Panic {
+    var sub = midazolam_cyp3a_substrate()
+    sub.clint_h = mdz_cyp3a_adjusted_clint(sub.clint_h, cyp3a5_geno, cyp3a4_22)
+    return midazolam_params_with_clh(cyp3a_clh(sub, 1.0))
+}
+
+// Absorption: rapid oral (ka 3/h, Tmax ~0.9 h), negligible lag. f_bio = Fa·FG·FH.
+pub fn midazolam_absorption_params() -> AbsorptionParams with Div {
+    AbsorptionParams { ka: 3.0, f_bio: cyp3a_f_oral(midazolam_cyp3a_substrate(), 1.0), tlag: 0.0 }
+}
+
+// Absorption under a CYP3A inhibition factor (gut+hepatic first-pass recover).
+pub fn midazolam_absorption_params_ddi(factor: f64) -> AbsorptionParams with Div {
+    AbsorptionParams { ka: 3.0, f_bio: cyp3a_f_oral(midazolam_cyp3a_substrate(), factor), tlag: 0.0 }
+}

--- a/stdlib/darwin_pbpk/pgx/cyp3a45_midazolam.sio
+++ b/stdlib/darwin_pbpk/pgx/cyp3a45_midazolam.sio
@@ -1,0 +1,84 @@
+// cyp3a45_midazolam.sio — CYP3A4/5 pharmacogenomics for midazolam.
+//
+// Midazolam is ~95% CYP3A-cleared (CYP3A4 + CYP3A5). Two pharmacogenes scale the
+// CYP3A intrinsic clearance CLint_h (which then flows through the well-stirred
+// first-pass and systemic clearance in ddi/cyp3a_competitive.sio):
+//
+//   CYP3A5*3 (rs776746): non-expressers (*3/*3) lack functional CYP3A5; *1
+//     carriers ("expressers") have higher total CYP3A activity.
+//       geno 0 = non-expresser (*3/*3, reference)   1 = expresser (*1 carrier)
+//   CYP3A4*22 (rs35599367): carriers have reduced CYP3A4 expression -> lower CL.
+//       carrier 0 = non-carrier (reference)          1 = *22 carrier
+//
+// Mirrors the pgx/cyp2d6_haloperidol.sio pattern (scale · prior_conf · cv · freq).
+// Sources: Kuehl 2001 (CYP3A5*3), Wang 2011/2014 (CYP3A4*22), Klein 2013
+// (frequencies), Shih 2013 (midazolam CYP3A5 effect).
+
+// CYP3A5 expresser status -> multiplicative scale on the CYP3A clearance fraction.
+pub fn mdz_cyp3a5_cl_scale(geno: i32) -> f64 {
+    if geno == 1 { return 1.30 }   // expresser: ~30% higher CYP3A clearance
+    return 1.0                      // non-expresser (reference)
+}
+
+// CYP3A4*22 carrier status -> multiplicative scale on the CYP3A clearance fraction.
+pub fn mdz_cyp3a4_22_cl_scale(carrier: i32) -> f64 {
+    if carrier == 1 { return 0.75 }  // *22 carrier: ~25% lower CYP3A4 clearance
+    return 1.0                        // non-carrier (reference)
+}
+
+// Adjust an intrinsic clearance for both CYP3A genes (CYP3A = fm of total).
+pub fn mdz_cyp3a_adjusted_clint(base_clint: f64, cyp3a5_geno: i32, cyp3a4_22: i32) -> f64 with Div, Panic {
+    let fm: f64 = 0.95
+    let scale = mdz_cyp3a5_cl_scale(cyp3a5_geno) * mdz_cyp3a4_22_cl_scale(cyp3a4_22)
+    let cl_other = base_clint * (1.0 - fm)
+    let cl_3a    = base_clint * fm * scale
+    return cl_other + cl_3a
+}
+
+// Prior confidence per CYP3A5 genotype (epistemic; well-characterised reference).
+pub fn mdz_cyp3a5_prior_conf(geno: i32) -> f64 {
+    if geno == 1 { return 0.60 }   // expresser: moderate data, more variability
+    return 0.75                     // non-expresser: well-characterised reference
+}
+
+// Coefficient of variation for the CYP3A clearance scale (GUM variance).
+pub fn mdz_cyp3a5_cl_cv(geno: i32) -> f64 {
+    if geno == 1 { return 0.35 }
+    return 0.25
+}
+
+// European allele/phenotype frequencies (CYP3A5 non-expresser dominant).
+pub fn mdz_cyp3a5_freq_european(geno: i32) -> f64 {
+    if geno == 0 { return 0.85 }   // non-expresser (*3/*3)
+    if geno == 1 { return 0.15 }   // expresser (*1 carrier)
+    return 0.0
+}
+
+// Sample a CYP3A5 genotype from a uniform draw u in [0,1).
+pub fn mdz_cyp3a5_sample(u: f64) -> i32 {
+    if u < 0.85 { return 0 }
+    return 1
+}
+
+// ─── Smoke tests ─────────────────────────────────────────────────────────────
+// Expresser raises CLint above the non-expresser reference.
+fn test_mdz_cyp3a5_expresser_higher() -> bool with Div, Panic {
+    let base = 1090.0
+    let non = mdz_cyp3a_adjusted_clint(base, 0, 0)
+    let exp = mdz_cyp3a_adjusted_clint(base, 1, 0)
+    return exp > non
+}
+
+// CYP3A4*22 carrier lowers CLint below reference.
+fn test_mdz_cyp3a4_22_lower() -> bool with Div, Panic {
+    let base = 1090.0
+    let non = mdz_cyp3a_adjusted_clint(base, 0, 0)
+    let car = mdz_cyp3a_adjusted_clint(base, 0, 1)
+    return car < non
+}
+
+// European frequencies sum to ~1.
+fn test_mdz_cyp3a5_freq_sum() -> bool {
+    let s = mdz_cyp3a5_freq_european(0) + mdz_cyp3a5_freq_european(1)
+    return s > 0.999 && s < 1.001
+}

--- a/stdlib/darwin_pbpk/scenarios/oral_midazolam_ddi.sio
+++ b/stdlib/darwin_pbpk/scenarios/oral_midazolam_ddi.sio
@@ -1,0 +1,153 @@
+// oral_midazolam_ddi.sio — production scenario: oral midazolam ± ketoconazole.
+//
+// Couples first-order oral absorption with the adaptive Tsit5 PBPK14 systemic
+// solver (the production integrator — the parity gate instead uses a fixed-step
+// RK4 in tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio, since
+// bit-for-bit parity on an adaptive controller is intractable).
+//
+// The CYP3A drug–drug interaction enters mechanistically and WITHOUT extending
+// absorption.sio: drugs/midazolam.sio derives, from a single CYP3A intrinsic
+// clearance CLint_h, both the systemic CL_h (-> PBPKParams14.cl_hepatic) and the
+// oral bioavailability F = Fa·FG·FH (-> AbsorptionParams.f_bio). A ketoconazole
+// inhibition factor lowers CL_h and raises F consistently (no double-count), so
+// the oral AUC ratio reproduces the iconic ~15× (Olkkola 1994).
+//
+// Inhibitor held static at steady state. Units: mg, L, L/h, h, mg/L.
+
+use darwin_pbpk::absorption::*
+use darwin_pbpk::tsit5_pbpk14::*
+use darwin_pbpk::drugs::midazolam::*
+use darwin_pbpk::ddi::cyp3a_competitive::*
+
+pub struct OralMidazolamTrace {
+    n_points:     i32,
+    times_h:      [f64; 32],
+    c_plasma:     [f64; 32],   // total blood concentration (mg/L)
+    a_gut:        [f64; 32],   // gut-depot mass remaining (mg)
+    released_cum: [f64; 32],   // cumulative mass delivered to blood (mg)
+    auc_plasma:   f64,         // trapezoidal plasma AUC (mg·h/L)
+    success:      bool,
+}
+
+pub fn oral_midazolam_trace_zero() -> OralMidazolamTrace {
+    OralMidazolamTrace {
+        n_points: 0,
+        times_h:      [0.0; 32],
+        c_plasma:     [0.0; 32],
+        a_gut:        [0.0; 32],
+        released_cum: [0.0; 32],
+        auc_plasma:   0.0,
+        success:      false,
+    }
+}
+
+// Single oral dose, adaptive Tsit5 systemic integration under supplied params
+// (sys_prm carries the inhibited CL_h; abs_prm carries the inhibited F).
+pub fn oral_midazolam_run(
+    sys_prm:     PBPKParams14,
+    abs_prm:     AbsorptionParams,
+    dose_mg:     f64,
+    checkpoints: [f64; 32],
+    n_points:    i32
+) -> OralMidazolamTrace with Mut, Div, Panic {
+    let cfg = tight_ode_config()
+
+    var trace = oral_midazolam_trace_zero()
+    trace.n_points = n_points
+
+    var sys_st = pbpk_state_zero()
+    var abs_st = absorption_state_with_dose(dose_mg)
+
+    trace.times_h[0]      = 0.0
+    trace.c_plasma[0]     = sys_st.blood
+    trace.a_gut[0]        = abs_st.a_gut
+    trace.released_cum[0] = 0.0
+
+    var t: f64       = 0.0
+    var dt_sys       = cfg.dt_init
+    var point_i: i32 = 1
+
+    while point_i < n_points {
+        let idx    = point_i as usize
+        let target = checkpoints[idx]
+
+        var nsteps:  i64 = 0
+        var nreject: i64 = 0
+
+        while t < target && nsteps < cfg.max_steps {
+            let dt_use = if t + dt_sys > target { target - t } else { dt_sys }
+
+            let released_before = abs_st.released_cum
+            let abs_next = absorption_step(abs_st, t, dt_use, abs_prm)
+            let rel_mg = abs_next.released_cum - released_before
+
+            var st_in = sys_st
+            if rel_mg > 0.0 {
+                st_in.blood = st_in.blood + absorption_mass_to_blood_delta(rel_mg, sys_prm.v_blood)
+            }
+
+            let result   = tsit5_step_pbpk(st_in, t, dt_use, sys_prm)
+            let err_norm = compute_error_norm_14(result.err, st_in, result.state_new, cfg.rtol, cfg.atol)
+
+            if err_norm <= 1.0 {
+                sys_st = result.state_new
+                abs_st = abs_next
+                t      = t + dt_use
+                nsteps = nsteps + 1
+                dt_sys = optimal_step_14(dt_use, err_norm, cfg.safety, cfg.max_growth, cfg.min_shrink)
+            } else {
+                nreject = nreject + 1
+                dt_sys  = optimal_step_14(dt_use, err_norm, cfg.safety, cfg.max_growth, cfg.min_shrink)
+            }
+            if dt_sys < cfg.dt_min { dt_sys = cfg.dt_min }
+            if dt_sys > cfg.dt_max { dt_sys = cfg.dt_max }
+            if nreject > 10000 { return trace }
+        }
+
+        trace.times_h[idx]      = target
+        trace.c_plasma[idx]     = sys_st.blood
+        trace.a_gut[idx]        = abs_st.a_gut
+        trace.released_cum[idx] = abs_st.released_cum
+
+        point_i = point_i + 1
+    }
+
+    var auc_p: f64 = 0.0
+    var k: i32 = 0
+    while k < n_points - 1 {
+        let ka = k as usize
+        let kb = (k + 1) as usize
+        let h  = trace.times_h[kb] - trace.times_h[ka]
+        auc_p  = auc_p + 0.5 * h * (trace.c_plasma[ka] + trace.c_plasma[kb])
+        k = k + 1
+    }
+    trace.auc_plasma = auc_p
+    trace.success    = true
+    trace
+}
+
+// Oral solo run (no inhibitor).
+pub fn oral_midazolam_solo(dose_mg: f64, checkpoints: [f64; 32], n_points: i32)
+    -> OralMidazolamTrace with Mut, Div, Panic
+{
+    return oral_midazolam_run(midazolam_pbpk_params(), midazolam_absorption_params(), dose_mg, checkpoints, n_points)
+}
+
+// Oral + ketoconazole run (static steady-state inhibition).
+pub fn oral_midazolam_keto(dose_mg: f64, checkpoints: [f64; 32], n_points: i32)
+    -> OralMidazolamTrace with Mut, Div, Panic
+{
+    let factor = cyp3a_factor_of(ketoconazole_inhibitor())
+    return oral_midazolam_run(midazolam_pbpk_params_ddi(factor), midazolam_absorption_params_ddi(factor), dose_mg, checkpoints, n_points)
+}
+
+// Tsit5-path AUC ratio (solo vs ketoconazole) — production cross-check of the
+// closed-form ~15× (the parity gate validates the fixed-step path to f64).
+pub fn oral_midazolam_aucr(dose_mg: f64, checkpoints: [f64; 32], n_points: i32)
+    -> f64 with Mut, Div, Panic
+{
+    let solo = oral_midazolam_solo(dose_mg, checkpoints, n_points)
+    let keto = oral_midazolam_keto(dose_mg, checkpoints, n_points)
+    if solo.auc_plasma > 0.0 { return keto.auc_plasma / solo.auc_plasma }
+    return 0.0
+}

--- a/stdlib/darwin_pbpk/validation/midazolam_ddi.sio
+++ b/stdlib/darwin_pbpk/validation/midazolam_ddi.sio
@@ -1,0 +1,114 @@
+// midazolam_ddi.sio — validation of the midazolam CYP3A drug–drug interaction.
+//
+// Anchors the mechanistic well-stirred first-pass + competitive-inhibition model
+// (ddi/cyp3a_competitive.sio, drugs/midazolam.sio) against the clinical literature
+// and checks internal consistency. These are MODEL-property assertions: the parity
+// gate proves Sounio==Node to f64; this file checks the model lands on the
+// documented pharmacology.
+//
+//   Olkkola 1994 (Clin Pharmacol Ther 55:481): oral midazolam + ketoconazole
+//     raises AUC ~15× (range ~10-16× across studies).
+//   Heizmann 1984 (Br J Anaesth 56:1215): oral midazolam F ~0.3-0.44.
+//   Thummel 1996 (Clin Pharmacol Ther 59:491): both gut-wall and hepatic CYP3A
+//     contribute to first-pass — gut is essential to the magnitude.
+//   Shih 2013 / Kuehl 2001: CYP3A5 expressers clear midazolam faster.
+
+use darwin_pbpk::drugs::midazolam::{midazolam_cyp3a_substrate, ketoconazole_inhibitor, midazolam_pbpk_params_pgx}
+use darwin_pbpk::ddi::cyp3a_competitive::{cyp3a_factor_of, cyp3a_aucr, cyp3a_f_oral, cyp3a_clh, cyp3a_fg, cyp3a_fh, cyp3a_inhibition_factor}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    println("======================================================================")
+    println("  Midazolam CYP3A Drug-Drug Interaction — Validation")
+    println("======================================================================")
+    println("")
+
+    var passed = 0
+    var failed = 0
+
+    let sub = midazolam_cyp3a_substrate()
+    let keto = ketoconazole_inhibitor()
+    let factor = cyp3a_factor_of(keto)
+
+    // TEST 1: solo oral bioavailability in the documented range (Heizmann 1984).
+    println("TEST 1: oral F in [0.30, 0.45] (Heizmann 1984)")
+    let f_solo = cyp3a_f_oral(sub, 1.0)
+    print("  F=");  println(f_solo); println("")
+    if f_solo > 0.30 && f_solo < 0.45 {
+        println("  [PASS] oral F within documented range")
+        passed = passed + 1
+    } else { println("  FAIL: oral F out of range"); failed = failed + 1 }
+    println("")
+
+    // TEST 2: ketoconazole AUCR ~15× (Olkkola 1994; band 12-18).
+    println("TEST 2: ketoconazole oral AUCR in [12, 18] (~15x, Olkkola 1994)")
+    let aucr = cyp3a_aucr(sub, factor)
+    print("  AUCR="); println(aucr); println("")
+    if aucr > 12.0 && aucr < 18.0 {
+        println("  [PASS] AUCR reproduces the iconic ~15x")
+        passed = passed + 1
+    } else { println("  FAIL: AUCR out of band"); failed = failed + 1 }
+    println("")
+
+    // TEST 3: monotonicity — stronger inhibition (smaller factor) -> larger AUCR.
+    println("TEST 3: AUCR monotonic increasing with inhibition strength")
+    let aucr_weak = cyp3a_aucr(sub, cyp3a_inhibition_factor(0.008, 0.008))   // I/Ki=1
+    let aucr_mid  = cyp3a_aucr(sub, cyp3a_inhibition_factor(0.032, 0.008))   // I/Ki=4
+    let aucr_strong = aucr                                                   // I/Ki=8
+    if aucr_strong > aucr_mid && aucr_mid > aucr_weak && aucr_weak > 1.0 {
+        println("  [PASS] AUCR(I/Ki=1) < AUCR(4) < AUCR(8)")
+        passed = passed + 1
+    } else { println("  FAIL: AUCR not monotonic"); failed = failed + 1 }
+    println("")
+
+    // TEST 4: gut contributes — full (gut+hepatic) AUCR exceeds hepatic-only.
+    println("TEST 4: gut-wall CYP3A is essential to the magnitude (Thummel 1996)")
+    let f0 = cyp3a_f_oral(sub, 1.0)
+    let clh0 = cyp3a_clh(sub, 1.0)
+    let f_hep_only = sub.fa * cyp3a_fg(sub, 1.0) * cyp3a_fh(sub, factor)
+    let aucr_hep_only = (f_hep_only / f0) * (clh0 / cyp3a_clh(sub, factor))
+    print("  AUCR_full="); println(aucr); println("")
+    print("  AUCR_hepatic_only="); println(aucr_hep_only); println("")
+    if aucr > aucr_hep_only && aucr_hep_only > 1.0 {
+        println("  [PASS] hepatic-only cannot reach the full AUCR without gut")
+        passed = passed + 1
+    } else { println("  FAIL: gut contribution not demonstrated"); failed = failed + 1 }
+    println("")
+
+    // TEST 5: CYP3A5 expresser clears faster than non-expresser (higher CL_h).
+    println("TEST 5: CYP3A5 expresser CL_h > non-expresser (Shih 2013)")
+    let p_exp = midazolam_pbpk_params_pgx(1, 0)
+    let p_non = midazolam_pbpk_params_pgx(0, 0)
+    let clh_exp = p_exp.cl_hepatic * p_exp.fu_plasma   // effective plasma CL_h
+    let clh_non = p_non.cl_hepatic * p_non.fu_plasma
+    print("  CL_h expresser="); println(clh_exp); println("")
+    print("  CL_h non-expresser="); println(clh_non); println("")
+    if clh_exp > clh_non {
+        println("  [PASS] expresser clears midazolam faster")
+        passed = passed + 1
+    } else { println("  FAIL: CYP3A5 ordering wrong"); failed = failed + 1 }
+    println("")
+
+    // TEST 6: CYP3A4*22 carrier clears slower than non-carrier (lower CL_h).
+    println("TEST 6: CYP3A4*22 carrier CL_h < non-carrier (Wang 2011)")
+    let p_22 = midazolam_pbpk_params_pgx(0, 1)
+    let clh_22 = p_22.cl_hepatic * p_22.fu_plasma
+    if clh_22 < clh_non {
+        println("  [PASS] *22 carrier clears midazolam slower")
+        passed = passed + 1
+    } else { println("  FAIL: CYP3A4*22 ordering wrong"); failed = failed + 1 }
+    println("")
+
+    println("======================================================================")
+    println("  MIDAZOLAM DDI VALIDATION — SUMMARY")
+    println("======================================================================")
+    print("  Passed: "); println(passed)
+    print("  Failed: "); println(failed)
+    println("")
+    if failed == 0 {
+        println("  ALL 6 TESTS PASSED")
+    } else {
+        println("  SOME TESTS FAILED — see diagnostics above")
+    }
+    println("======================================================================")
+    return 0
+}

--- a/tests/run-pass/dissertation_midazolam_scenario_smoke.sio
+++ b/tests/run-pass/dissertation_midazolam_scenario_smoke.sio
@@ -1,0 +1,28 @@
+//@ run-pass
+//@ timeout: 120
+use darwin_pbpk::scenarios::oral_midazolam_ddi::{oral_midazolam_solo, oral_midazolam_keto, oral_midazolam_aucr}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // Checkpoints out to 150 h (capture the long ketoconazole-inhibited tail).
+    let cp: [f64; 32] = [
+        0.0, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0,
+        10.0, 12.0, 16.0, 20.0, 24.0, 30.0, 36.0, 48.0, 60.0, 72.0, 84.0,
+        96.0, 108.0, 120.0, 132.0, 144.0, 150.0, 150.0, 150.0, 150.0
+    ]
+    let n: i32 = 29
+
+    let solo = oral_midazolam_solo(5.0, cp, n)
+    let keto = oral_midazolam_keto(5.0, cp, n)
+    let aucr = oral_midazolam_aucr(5.0, cp, n)
+
+    print("auc_solo="); println(solo.auc_plasma); println("")
+    print("auc_keto="); println(keto.auc_plasma); println("")
+    print("tsit5_aucr="); println(aucr); println("")
+
+    if solo.success && keto.success && aucr > 12.0 && aucr < 18.0 {
+        println("MDZ_SCENARIO_SMOKE_PASS")
+    } else {
+        println("MDZ_SCENARIO_SMOKE_FAIL")
+    }
+    return 0
+}

--- a/tests/run-pass/dissertation_midazolam_stdlib_smoke.sio
+++ b/tests/run-pass/dissertation_midazolam_stdlib_smoke.sio
@@ -1,0 +1,36 @@
+//@ run-pass
+use darwin_pbpk::drugs::midazolam::{midazolam_cyp3a_substrate, ketoconazole_inhibitor, midazolam_pbpk_params, midazolam_pbpk_params_keto, midazolam_pbpk_params_pgx, midazolam_absorption_params}
+use darwin_pbpk::ddi::cyp3a_competitive::{cyp3a_factor_of, cyp3a_aucr, cyp3a_f_oral, cyp3a_clh}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let sub = midazolam_cyp3a_substrate()
+    let keto = ketoconazole_inhibitor()
+    let factor = cyp3a_factor_of(keto)
+
+    let f0 = cyp3a_f_oral(sub, 1.0)
+    let aucr = cyp3a_aucr(sub, factor)
+    print("solo_F="); println(f0); println("")
+    print("aucr_keto="); println(aucr); println("")
+
+    let p0 = midazolam_pbpk_params()
+    let pk = midazolam_pbpk_params_keto()
+    // effective plasma CL_h = cl_hepatic (intrinsic-on-unbound) · fu_plasma
+    print("clh_solo="); println(p0.cl_hepatic * p0.fu_plasma); println("")
+    print("clh_keto="); println(pk.cl_hepatic * pk.fu_plasma); println("")
+
+    let p_exp = midazolam_pbpk_params_pgx(1, 0)
+    let p_non = midazolam_pbpk_params_pgx(0, 0)
+    print("clh_expresser="); println(p_exp.cl_hepatic * p_exp.fu_plasma); println("")
+    print("clh_nonexpresser="); println(p_non.cl_hepatic * p_non.fu_plasma); println("")
+
+    let abs = midazolam_absorption_params()
+    print("ka="); println(abs.ka); println("")
+
+    // basic sanity: AUCR ~15, inhibited CL_h < solo, expresser CL_h > non-expresser
+    if aucr > 12.0 && aucr < 18.0 && pk.cl_hepatic < p0.cl_hepatic && p_exp.cl_hepatic > p_non.cl_hepatic {
+        println("MDZ_STDLIB_SMOKE_PASS")
+    } else {
+        println("MDZ_STDLIB_SMOKE_FAIL")
+    }
+    return 0
+}

--- a/tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio
+++ b/tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio
@@ -1,0 +1,304 @@
+//@ run-pass
+//@ timeout: 90
+// ============================================================================
+// DISSERTATION PARITY REFERENCE — MIDAZOLAM (CYP3A drug–drug interaction)
+//
+// Fifth canonical drug, and the suite's FIRST drug–drug interaction (DDI). Novel
+// surface (none of rapamycin/semaglutide/venlafaxine/haloperidol model enzyme
+// inhibition): mechanistic well-stirred oral first-pass + competitive CYP3A
+// inhibition by ketoconazole.
+//
+//   Oral bioavailability   F     = Fa · FG · FH
+//   gut-wall survival      FG    = Qg / (Qg + fu_g·CLint_g)
+//   hepatic first-pass     FH    = Qh / (Qh + fu·CLint_h)
+//   systemic clearance     CL_h  = Qh·fu·CLint_h / (Qh + fu·CLint_h)
+//   competitive inhibition CLint -> CLint / (1 + I/Ki)   (gut & hepatic, same enzyme)
+//
+// A SINGLE hepatic intrinsic clearance CLint_h drives BOTH FH and CL_h, so
+// inhibition raises FH and lowers CL_h consistently — NO double-count — and the
+// iconic oral midazolam+ketoconazole AUC rise (~15×) emerges honestly
+// (AUC = F·Dose/CL_h). The inhibitor is held STATIC at its steady-state unbound
+// concentration (as in clinical DDI studies). Systemic distribution Kp are
+// nominal midazolam-plausible values; the validated DDI quantities are F, CL_h
+// and AUCR (distribution-independent).
+//
+// Both this ref and the JS engine (pbpk28_core.mjs runMidazolamScenario /
+// runMidazolamDDIResponse) use a FIXED-STEP RK4 systemic integrator at the same
+// dt — the production scenario (scenarios/oral_midazolam_ddi.sio) uses adaptive
+// Tsit5, an intractable bit-for-bit parity target; the fidelity gap is disclosed
+// in the gist. Self-contained (no imports — lean_single blocks cross-module
+// private fields); all constants verbatim from drugs/midazolam.sio +
+// ddi/cyp3a_competitive.sio.
+//
+// Parity surface (gate cases 17-19): solo oral PK · ketoconazole-inhibited oral
+// PK · DDI inhibition curve (F, CL_h, AUCR across I/Ki).
+//
+// Sources: Heizmann 1984 (oral F~0.4), Thummel 1996 (gut+hepatic first-pass),
+// Gorski 1998 / Olkkola 1994,1996 (ketoconazole DDI ~15×), Yang 2007 (Qgut).
+// ============================================================================
+
+// Systemic well-stirred state: 0=blood,1=liver,2=kidney,3=brain,4=heart,5=lung,
+// 6=muscle,7=adipose,8=gut,9=skin,10=bone,11=spleen,12=pancreas,13=other.
+struct Sys14 { c: [f64; 14] }
+struct MdzState { sys: Sys14, a_gut: f64 }
+
+fn sys_zero() -> Sys14 { Sys14 { c: [0.0; 14] } }
+
+// ─── PBPK14 physiology (volumes L, flows L/h) + midazolam Kp ──────────────────
+fn v_at(i: i64) -> f64 {
+    if i ==  0 { return 5.2 }
+    if i ==  1 { return 1.69 }
+    if i ==  2 { return 0.31 }
+    if i ==  3 { return 1.37 }
+    if i ==  4 { return 0.31 }
+    if i ==  5 { return 1.17 }
+    if i ==  6 { return 29.0 }
+    if i ==  7 { return 18.2 }
+    if i ==  8 { return 1.65 }
+    if i ==  9 { return 7.8 }
+    if i == 10 { return 10.5 }
+    if i == 11 { return 0.19 }
+    if i == 12 { return 0.14 }
+    return 4.5
+}
+fn q_at(i: i64) -> f64 {
+    if i ==  1 { return 90.0 }
+    if i ==  2 { return 72.0 }
+    if i ==  3 { return 44.0 }
+    if i ==  4 { return 14.4 }
+    if i ==  5 { return 0.0 }
+    if i ==  6 { return 73.8 }
+    if i ==  7 { return 18.0 }
+    if i ==  8 { return 57.6 }
+    if i ==  9 { return 18.0 }
+    if i == 10 { return 21.6 }
+    if i == 11 { return 10.8 }
+    if i == 12 { return 4.5 }
+    if i == 13 { return 18.0 }
+    return 0.0
+}
+fn kp_at(i: i64) -> f64 {
+    if i ==  1 { return 2.0 }
+    if i ==  2 { return 1.5 }
+    if i ==  3 { return 1.5 }
+    if i ==  4 { return 1.2 }
+    if i ==  5 { return 1.5 }
+    if i ==  6 { return 1.0 }
+    if i ==  7 { return 2.0 }
+    if i ==  8 { return 1.5 }
+    if i ==  9 { return 1.2 }
+    if i == 10 { return 0.6 }
+    if i == 11 { return 1.2 }
+    if i == 12 { return 1.2 }
+    if i == 13 { return 1.0 }
+    return 1.0
+}
+fn fu_plasma() -> f64 { return 0.03 }
+fn rb_ratio() -> f64 { return 1.0 }
+fn cl_renal() -> f64 { return 0.0 }
+
+// First-pass + CYP3A metabolism (one CLint_h -> {FH, CL_h}; CLint_g -> FG).
+fn fp_qh() -> f64 { return 90.0 }
+fn fp_qg() -> f64 { return 18.0 }
+fn fp_fu() -> f64 { return 0.03 }
+fn fp_fu_gut() -> f64 { return 1.0 }
+fn fp_fa() -> f64 { return 0.95 }
+fn fp_clint_h() -> f64 { return 1090.0 }
+fn fp_clint_g() -> f64 { return 14.7 }
+
+// Ketoconazole perpetrator (static steady-state unbound, mg/L): I/Ki = 8 -> R = 9.
+fn keto_ki() -> f64 { return 0.008 }
+fn keto_i() -> f64 { return 0.064 }
+
+// Absorption (rapid oral, negligible lag).
+fn abs_ka() -> f64 { return 3.0 }
+fn abs_tlag() -> f64 { return 0.0 }
+
+// ─── Absorption exp(-x) — verbatim port of absorption.sio abs_exp_neg ─────────
+fn abs_exp_neg(x: f64) -> f64 with Div, Mut {
+    if x <= 0.0 { return 1.0 }
+    if x > 0.5 {
+        let half = abs_exp_neg(x * 0.5)
+        return half * half
+    }
+    var term = 1.0
+    var sum = 1.0
+    var k: i32 = 1
+    while k < 16 {
+        term = term * (0.0 - x) / (k as f64)
+        sum = sum + term
+        k = k + 1
+    }
+    return sum
+}
+
+// ─── Competitive CYP3A inhibition + well-stirred first-pass closed forms ──────
+fn inh_factor(i_conc: f64) -> f64 with Div { return 1.0 / (1.0 + i_conc / keto_ki()) }
+fn fg(i_conc: f64) -> f64 with Div {
+    let b = fp_fu_gut() * fp_clint_g() * inh_factor(i_conc)
+    return fp_qg() / (fp_qg() + b)
+}
+fn fh(i_conc: f64) -> f64 with Div {
+    let a = fp_fu() * fp_clint_h() * inh_factor(i_conc)
+    return fp_qh() / (fp_qh() + a)
+}
+fn clh(i_conc: f64) -> f64 with Div {
+    let a = fp_fu() * fp_clint_h() * inh_factor(i_conc)
+    return fp_qh() * a / (fp_qh() + a)
+}
+fn f_oral(i_conc: f64) -> f64 with Div { return fp_fa() * fg(i_conc) * fh(i_conc) }
+
+// ─── PBPK14 well-stirred RHS; cl_h is the inhibitor-dependent systemic hepatic
+// clearance on plasma (already embeds fu via the well-stirred form). ──────────
+fn sys_ode(st: Sys14, cl_h: f64) -> Sys14 with Mut, Div {
+    let c_blood = st.c[0]
+    let c_plasma = c_blood / rb_ratio()
+    var d = Sys14 { c: [0.0; 14] }
+    var d_blood = 0.0
+    var i = 1
+    while i < 14 {
+        let flux = (q_at(i) / v_at(i)) * (c_plasma - st.c[i] / kp_at(i))
+        d.c[i] = flux
+        d_blood = d_blood - (q_at(i) / v_at(0)) * rb_ratio() * (c_plasma - st.c[i] / kp_at(i))
+        i = i + 1
+    }
+    d_blood = d_blood - (cl_h / v_at(0)) * c_plasma * rb_ratio()
+    d_blood = d_blood - (cl_renal() / v_at(0)) * c_plasma * rb_ratio()
+    d.c[0] = d_blood
+    return d
+}
+
+fn sys_axpy(y: Sys14, k: Sys14, a: f64) -> Sys14 with Mut {
+    var r = Sys14 { c: [0.0; 14] }
+    var i = 0
+    while i < 14 { r.c[i] = y.c[i] + a * k.c[i]; i = i + 1 }
+    return r
+}
+
+fn sys_rk4(st: Sys14, dt: f64, cl_h: f64) -> Sys14 with Mut, Div {
+    let k1 = sys_ode(st, cl_h)
+    let k2 = sys_ode(sys_axpy(st, k1, 0.5 * dt), cl_h)
+    let k3 = sys_ode(sys_axpy(st, k2, 0.5 * dt), cl_h)
+    let k4 = sys_ode(sys_axpy(st, k3, dt), cl_h)
+    var r = Sys14 { c: [0.0; 14] }
+    let sixth = dt / 6.0
+    let third = dt / 3.0
+    var i = 0
+    while i < 14 {
+        r.c[i] = st.c[i] + sixth * k1.c[i] + third * k2.c[i] + third * k3.c[i] + sixth * k4.c[i]
+        i = i + 1
+    }
+    return r
+}
+
+// One fixed step: operator-split oral absorption (delivers Fa·FG·FH of the
+// released mass to blood) → systemic RK4. cl_h, f_or constant (static inhibitor).
+fn mdz_step(st: MdzState, t: f64, dt: f64, cl_h: f64, f_or: f64) -> MdzState with Mut, Div {
+    var a_gut = st.a_gut
+    var s0 = st.sys
+    if t + dt > abs_tlag() {
+        let t_active_start = if t < abs_tlag() { abs_tlag() } else { t }
+        let dt_active = (t + dt) - t_active_start
+        if dt_active > 0.0 {
+            let decay = abs_exp_neg(abs_ka() * dt_active)
+            let a_after = a_gut * decay
+            let to_blood = f_or * (a_gut - a_after)
+            a_gut = a_after
+            s0.c[0] = s0.c[0] + to_blood / v_at(0)
+        }
+    }
+    let s1 = sys_rk4(s0, dt, cl_h)
+    return MdzState { sys: s1, a_gut: a_gut }
+}
+
+fn integrate_to(st: MdzState, t_start: f64, t_end: f64, dt: f64, cl_h: f64, f_or: f64) -> MdzState with Mut, Div {
+    var s = st
+    var t = t_start
+    while t + 0.5 * dt < t_end {
+        s = mdz_step(s, t, dt, cl_h, f_or)
+        t = t + dt
+    }
+    return s
+}
+
+// Sample times (h) and DDI inhibition-curve grid (I/Ki).
+fn sample_at(idx: i32) -> f64 {
+    if idx == 0 { return 0.25 }
+    if idx == 1 { return 0.5 }
+    if idx == 2 { return 1.0 }
+    if idx == 3 { return 2.0 }
+    if idx == 4 { return 3.0 }
+    if idx == 5 { return 4.0 }
+    if idx == 6 { return 6.0 }
+    if idx == 7 { return 8.0 }
+    if idx == 8 { return 12.0 }
+    if idx == 9 { return 18.0 }
+    if idx == 10 { return 24.0 }
+    return 36.0
+}
+fn igrid_at(idx: i32) -> f64 {
+    if idx == 0 { return 0.0 }
+    if idx == 1 { return 0.25 }
+    if idx == 2 { return 0.5 }
+    if idx == 3 { return 1.0 }
+    if idx == 4 { return 2.0 }
+    if idx == 5 { return 4.0 }
+    if idx == 6 { return 8.0 }
+    return 16.0
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    println("DISSERTATION_PBPK28_MIDAZOLAM_PARITY_REF v1")
+    println("model=pbpk14_wellstirred+mechanistic_firstpass+cyp3a_competitive_ddi")
+    println("integrator=fixed_step_rk4")
+    println("dt=0.002")
+    println("dose_mg=5.0")
+    println("inhibitor=ketoconazole_static_steady_state")
+    println("drug=midazolam")
+    println("samples=12")
+    println("igrid=8")
+
+    let dt = 0.002
+    let cl_h_solo = clh(0.0)
+    let f_solo = f_oral(0.0)
+    let cl_h_inh = clh(keto_i())
+    let f_inh = f_oral(keto_i())
+
+    // Cases 17-18: solo vs ketoconazole-inhibited oral PK, lockstep on a 5 mg dose.
+    var st_solo = MdzState { sys: sys_zero(), a_gut: 5.0 }
+    var st_inh  = MdzState { sys: sys_zero(), a_gut: 5.0 }
+    var prev = 0.0
+    var i: i32 = 0
+    while i < 12 {
+        let target = sample_at(i)
+        st_solo = integrate_to(st_solo, prev, target, dt, cl_h_solo, f_solo)
+        st_inh  = integrate_to(st_inh,  prev, target, dt, cl_h_inh,  f_inh)
+        let p_solo = st_solo.sys.c[0] / rb_ratio()
+        let p_inh  = st_inh.sys.c[0] / rb_ratio()
+        print("MDZ|t=");           println(target); println("")
+        print("MDZ|plasma_solo="); println(p_solo); println("")
+        print("MDZ|plasma_inh=");  println(p_inh);  println("")
+        prev = target
+        i = i + 1
+    }
+
+    // Case 19: DDI inhibition curve — F, CL_h, AUCR across I/Ki (closed form).
+    let f0 = f_oral(0.0)
+    let clh0 = clh(0.0)
+    var j: i32 = 0
+    while j < 8 {
+        let r = igrid_at(j)
+        let i_conc = r * keto_ki()
+        let ff = f_oral(i_conc)
+        let cc = clh(i_conc)
+        let aucr = (ff / f0) * (clh0 / cc)
+        print("MDZ|igrid="); println(r);    println("")
+        print("MDZ|F=");     println(ff);   println("")
+        print("MDZ|clh=");   println(cc);   println("")
+        print("MDZ|aucr=");  println(aucr); println("")
+        j = j + 1
+    }
+
+    println("DISSERTATION_PBPK28_MIDAZOLAM_PARITY_DONE")
+    return 0
+}

--- a/website/src/lib/pbpk28_core.mjs
+++ b/website/src/lib/pbpk28_core.mjs
@@ -960,3 +960,139 @@ export function runHaloperidolScenario(sampleTimes, { dt = 0.002, doseMg = 5.0 }
   }
   return out;
 }
+
+// ============================================================================
+// MIDAZOLAM — fifth canonical drug: oral CYP3A drug–drug interaction (DDI).
+//
+// Novel surface (none of the four prior drugs model enzyme inhibition):
+// mechanistic well-stirred oral first-pass (F = Fa·FG·FH) + competitive CYP3A
+// inhibition. A SINGLE hepatic intrinsic clearance CLint_h drives BOTH the
+// first-pass survival FH = Qh/(Qh+fu·CLint_h) AND the systemic well-stirred
+// clearance CL_h = Qh·fu·CLint_h/(Qh+fu·CLint_h). A separate gut CLint_g drives
+// FG = Qg/(Qg+fu_g·CLint_g). Competitive inhibition divides the INTRINSIC
+// clearances by (1 + I/Ki). Because FH and CL_h come from one CLint_h,
+// inhibition raises FH and lowers CL_h *consistently* — no double-count — so the
+// iconic oral midazolam+ketoconazole AUC rise (~15×) emerges honestly
+// (AUC = F·Dose/CL_h; validated in stdlib/darwin_pbpk/validation/midazolam_ddi.sio).
+//
+// Inhibitor is held STATIC at its steady-state unbound concentration (matches how
+// clinical DDI studies pre-dose the perpetrator). Systemic distribution Kp are
+// nominal midazolam-plausible values (Vss ~1.4 L/kg); the *validated* DDI
+// quantities are F, CL_h and AUCR, which are distribution-independent.
+// Units: mg, L, L/h, h, mg/L throughout.
+//
+// Sources: Heizmann 1984 (oral F~0.4), Thummel 1996 (gut+hepatic first-pass),
+// Gorski 1998 / Olkkola 1994,1996 (ketoconazole DDI ~15×), Yang 2007 (Qgut model).
+// ============================================================================
+
+// Generic 70 kg human physiology (volumes L, flows L/h) — reused; Kp are midazolam.
+export const MDZ_V  = Object.freeze([5.2, 1.69, 0.31, 1.37, 0.31, 1.17, 29.0, 18.2, 1.65, 7.8, 10.5, 0.19, 0.14, 4.5]);
+export const MDZ_Q  = Object.freeze([0.0, 90.0, 72.0, 44.0, 14.4, 0.0, 73.8, 18.0, 57.6, 18.0, 21.6, 10.8, 4.5, 18.0]);
+export const MDZ_KP = Object.freeze([1.0, 2.0, 1.5, 1.5, 1.2, 1.5, 1.0, 2.0, 1.5, 1.2, 0.6, 1.2, 1.2, 1.0]);
+export const MDZ_FU_PLASMA = 0.03, MDZ_RB = 1.0;
+export const MDZ_CL_RENAL = 0.0;  // midazolam: <1% renal — elimination is CYP3A-hepatic.
+// First-pass + CYP3A metabolism: one CLint_h -> {FH, CL_h}; CLint_g -> FG.
+export const MDZ_FP = Object.freeze({ qh: 90.0, qg: 18.0, fu: 0.03, fuGut: 1.0, fa: 0.95, clintH: 1090.0, clintG: 14.7 });
+// Absorption: rapid oral (Tmax ~0.9 h), negligible lag.
+export const MDZ_ABS = Object.freeze({ ka: 3.0, tlag: 0.0 });
+// Ketoconazole perpetrator, static steady-state UNBOUND conc (mg/L): I/Ki = 8 -> R = 9.
+export const MDZ_KETO = Object.freeze({ ki: 0.008, iSteadyState: 0.064 });
+
+// exp(-x) — verbatim port of absorption.sio abs_exp_neg (shared low-accuracy arithmetic).
+function mdzAbsExpNeg(x) {
+  if (x <= 0.0) return 1.0;
+  if (x > 0.5) { const half = mdzAbsExpNeg(x * 0.5); return half * half; }
+  let term = 1.0, sum = 1.0;
+  for (let k = 1; k < 16; k++) { term = term * (-x) / k; sum = sum + term; }
+  return sum;
+}
+
+// Competitive inhibition on CYP3A intrinsic clearance: factor in [0,1].
+function mdzInhFactor(I) { return 1.0 / (1.0 + I / MDZ_KETO.ki); }
+// Gut-wall survival FG, hepatic first-pass survival FH, systemic CL_h — each from
+// a single (inhibited) intrinsic clearance. Same enzyme/inhibitor -> same factor.
+function mdzFG(I)  { const b = MDZ_FP.fuGut * MDZ_FP.clintG * mdzInhFactor(I); return MDZ_FP.qg / (MDZ_FP.qg + b); }
+function mdzFH(I)  { const a = MDZ_FP.fu   * MDZ_FP.clintH * mdzInhFactor(I); return MDZ_FP.qh / (MDZ_FP.qh + a); }
+function mdzCLh(I) { const a = MDZ_FP.fu   * MDZ_FP.clintH * mdzInhFactor(I); return MDZ_FP.qh * a / (MDZ_FP.qh + a); }
+function mdzF(I)   { return MDZ_FP.fa * mdzFG(I) * mdzFH(I); }
+
+// PBPK14 well-stirred RHS; clH is the (inhibitor-dependent) systemic hepatic
+// clearance acting on plasma — it already embeds fu via the well-stirred form,
+// so it is NOT multiplied by fu again here.
+function mdzSysOde(c, clH) {
+  const cPlasma = c[0] / MDZ_RB;
+  const d = new Float64Array(14);
+  let dBlood = 0.0;
+  for (let i = 1; i < 14; i++) {
+    const flux = (MDZ_Q[i] / MDZ_V[i]) * (cPlasma - c[i] / MDZ_KP[i]);
+    d[i] = flux;
+    dBlood = dBlood - (MDZ_Q[i] / MDZ_V[0]) * MDZ_RB * (cPlasma - c[i] / MDZ_KP[i]);
+  }
+  dBlood = dBlood - (clH / MDZ_V[0]) * cPlasma * MDZ_RB;
+  dBlood = dBlood - (MDZ_CL_RENAL / MDZ_V[0]) * cPlasma * MDZ_RB;
+  d[0] = dBlood;
+  return d;
+}
+function mdzSysRk4(c, dt, clH) {
+  const axpy = (y, k, a) => { const r = new Float64Array(14); for (let i = 0; i < 14; i++) r[i] = y[i] + a * k[i]; return r; };
+  const k1 = mdzSysOde(c, clH);
+  const k2 = mdzSysOde(axpy(c, k1, 0.5 * dt), clH);
+  const k3 = mdzSysOde(axpy(c, k2, 0.5 * dt), clH);
+  const k4 = mdzSysOde(axpy(c, k3, dt), clH);
+  const r = new Float64Array(14);
+  const sixth = dt / 6.0, third = dt / 3.0;
+  for (let i = 0; i < 14; i++) r[i] = c[i] + sixth * k1[i] + third * k2[i] + third * k3[i] + sixth * k4[i];
+  return r;
+}
+
+// One fixed step: operator-split oral absorption (delivers Fa·FG·FH of the released
+// mass to blood) -> systemic RK4. clH, Foral are constant (static inhibitor).
+function mdzStep(st, t, dt, clH, Foral) {
+  let aGut = st.aGut;
+  let c = st.sys;
+  if (t + dt > MDZ_ABS.tlag) {
+    const tActiveStart = t < MDZ_ABS.tlag ? MDZ_ABS.tlag : t;
+    const dtActive = (t + dt) - tActiveStart;
+    if (dtActive > 0.0) {
+      const decay = mdzAbsExpNeg(MDZ_ABS.ka * dtActive);
+      const aAfter = aGut * decay;
+      const toBlood = Foral * (aGut - aAfter);
+      aGut = aAfter;
+      c = Float64Array.from(c);
+      c[0] = c[0] + toBlood / MDZ_V[0];
+    }
+  }
+  return { sys: mdzSysRk4(c, dt, clH), aGut };
+}
+
+/**
+ * Integrate the oral midazolam scenario (single dose, fixed-step RK4) under a
+ * static unbound inhibitor concentration `I` (mg/L; 0 = solo). Samples plasma
+ * (mg/L) at the given times. dt default 0.002 h, dose 5 mg — matches the ref.
+ */
+export function runMidazolamScenario(sampleTimes, { dt = 0.002, doseMg = 5.0, I = 0.0 } = {}) {
+  const clH = mdzCLh(I);
+  const Foral = mdzF(I);
+  let st = { sys: new Float64Array(14), aGut: doseMg };
+  const out = [];
+  let t = 0.0;
+  for (const target of sampleTimes) {
+    while (t + 0.5 * dt < target) { st = mdzStep(st, t, dt, clH, Foral); t += dt; }
+    out.push({ t: target, plasma: st.sys[0] / MDZ_RB });
+  }
+  return out;
+}
+
+/**
+ * Analytic DDI dose-response across a grid of I/Ki ratios: per point returns oral
+ * F, systemic CL_h, and AUC ratio vs solo (AUCR = (F/F0)·(CL_h0/CL_h)). This is
+ * the inhibition-curve parity series (case 19) — closed form, no integration.
+ */
+export function runMidazolamDDIResponse(iOverKiGrid) {
+  const F0 = mdzF(0.0), clH0 = mdzCLh(0.0);
+  return iOverKiGrid.map((r) => {
+    const I = r * MDZ_KETO.ki;
+    const F = mdzF(I), clH = mdzCLh(I);
+    return { iOverKi: r, F, clH, aucr: (F / F0) * (clH0 / clH) };
+  });
+}


### PR DESCRIPTION
## Summary

**Midazolam** — the **fifth canonical drug**, and the suite's **first drug–drug interaction (DDI)**. Oral midazolam co-administered with ketoconazole, the textbook CYP3A victim/perpetrator pair (iconic oral AUC ~15×; Olkkola 1994). The four prior drugs each added a distinct surface (rapamycin TMDD+PD, semaglutide TMDD+Bergman, venlafaxine parent+metabolite, haloperidol BBB+D2); none modeled enzyme inhibition — this does.

As with the prior four, the deliverable is a **Sounio↔Node 0.0000% parity surface** under a fixed-step RK4 integrator (what the dissertation viewer runs). Parity gate **cases 17–19** added; **full gate 1–19 green, no regression** (verified under `lean_single`).

## The mechanism (and the honesty it required)

Standard well-stirred oral first-pass, parameterized by **intrinsic** clearances:

| | |
|---|---|
| `FG  = Qg/(Qg + fu_g·CLint_g)` | gut-wall survival |
| `FH  = Qh/(Qh + fu·CLint_h)` | hepatic first-pass survival |
| `CL_h = Qh·fu·CLint_h/(Qh + fu·CLint_h)` | systemic clearance |
| `F = Fa·FG·FH`,  `AUC = F·Dose/CL_h` | oral exposure |
| `CLint → CLint/(1 + I/Ki)` | competitive inhibition |

**Avoided trap:** scaling a lumped `F` up *and* a separate lumped `CL` down under inhibition double-counts hepatic CYP3A and fabricates the 15× (invisible to parity — both sides compute the same wrong number). The fix: a **single** `CLint_h` drives *both* `FH` and `CL_h`, so inhibition raises `FH` and lowers `CL_h` consistently — **no double-count**. Result: **AUCR 14.99×** with gut; **9.0×** hepatic-only — the gut term is exactly why oral midazolam is *the* CYP3A probe (Thummel 1996; asserted in validation TEST 4).

## Parity cases (Sounio↔Node byte-identical, 0.0000% RMSE)

- **17** solo oral PK (5 mg) · **18** ketoconazole-inhibited oral PK · **19** DDI inhibition curve (F, CL_h, AUCR across I/Ki)

## Five layers + validation + docs

- `website/src/lib/pbpk28_core.mjs` — `runMidazolamScenario` / `runMidazolamDDIResponse` (append-only)
- `scripts/dissertation/run_midazolam_node.mjs` — Node runner
- `tests/run-pass/dissertation_pbpk28_parity_ref_midazolam.sio` — self-contained Sounio ref
- `stdlib/darwin_pbpk/ddi/cyp3a_competitive.sio` — **new** competitive-inhibition + first-pass primitive
- `stdlib/darwin_pbpk/drugs/midazolam.sio` · `pgx/cyp3a45_midazolam.sio` (CYP3A5*3 / CYP3A4*22)
- `stdlib/darwin_pbpk/scenarios/oral_midazolam_ddi.sio` — production Tsit5 scenario (AUCR ≈ 15.2× cross-check)
- `stdlib/darwin_pbpk/validation/midazolam_ddi.sio` — literature-anchored, **6/6** (Olkkola/Heizmann/Thummel/Kuehl/Wang)
- `tests/run-pass/dissertation_midazolam_{stdlib,scenario}_smoke.sio` — stdlib + Tsit5 smokes (matches the `darwin_*_smoke` convention)
- `scripts/ci/dissertation_pbpk28_parity_gate.sh` — cases 17–19
- `docs/dissertation/results/pbpk14_midazolam_ddi_canonical_v1.md` (+ governance registered)

## Honest framing

Parity proves **Sounio == Node to f64**, not ground-truth accuracy. The ~15× is a **model output** validated vs literature (band 12–18×), not asserted as a measured constant. Well-stirred first-pass; **static** steady-state inhibitor (not a dynamic two-drug PK sim); fixed-step RK4 (parity) vs adaptive Tsit5 (production) gap disclosed; nominal distribution Kp (the validated DDI quantities F/CL_h/AUCR are distribution-independent). Case 19 is closed-form on both sides (f64 arithmetic identity), not independent algorithm parity like the time-series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)