### PR TITLE
test(check): cover tuple signature types

### DIFF
--- a/tests/run-pass/tuple_signature_types.sio
+++ b/tests/run-pass/tuple_signature_types.sio
@@ -1,0 +1,24 @@
+//@ check-only
+
+// Regression for tuple type expressions in function signatures. This is a
+// checker contract: tuple parameters and tuple returns must lower as tuple
+// types instead of falling through to ty_error/E000.
+
+fn pair_sum(p: (i64, i64)) -> i64 {
+    p.0 + p.1
+}
+
+fn make_pair(a: i64, b: i64) -> (i64, i64) {
+    (a, b)
+}
+
+fn main() -> i64 {
+    let direct = pair_sum((20, 22))
+    let p = make_pair(40, 2)
+    let returned = p.0 + p.1
+    if direct == 42 && returned == 42 {
+        0
+    } else {
+        1
+    }
+}

--- a/tests/ui/type/tuple_signature_arg_arity.sio
+++ b/tests/ui/type/tuple_signature_arg_arity.sio
@@ -1,0 +1,12 @@
+//@ compile-fail
+//@ error-pattern: argument type does not match parameter
+//@ error-pattern: expected (i64, i64)
+//@ error-pattern: found (i64, i64, i64)
+
+fn pair_sum(p: (i64, i64)) -> i64 {
+    p.0 + p.1
+}
+
+fn main() -> i64 {
+    pair_sum((1, 2, 3))
+}

--- a/tests/ui/type/tuple_signature_arg_type.sio
+++ b/tests/ui/type/tuple_signature_arg_type.sio
@@ -1,0 +1,12 @@
+//@ compile-fail
+//@ error-pattern: argument type does not match parameter
+//@ error-pattern: expected (i64, i64)
+//@ error-pattern: found (i64, bool)
+
+fn pair_sum(p: (i64, i64)) -> i64 {
+    p.0 + p.1
+}
+
+fn main() -> i64 {
+    pair_sum((1, true))
+}


### PR DESCRIPTION
## Summary

- add a check-only regression for tuple type expressions in function signatures
- add compile-fail coverage for tuple signature argument arity mismatch
- add compile-fail coverage for tuple signature argument element type mismatch

## Validation

Using the clean worktree binary from current `origin/main`:

- `./bin/souc check tests/run-pass/tuple_signature_types.sio` -> `check: OK`
- `./bin/souc check tests/ui/type/tuple_signature_arg_arity.sio` -> expected failure with `E009`, `expected (i64, i64)`, `found (i64, i64, i64)`
- `./bin/souc check tests/ui/type/tuple_signature_arg_type.sio` -> expected failure with `E009`, `expected (i64, i64)`, `found (i64, bool)`
- `SOUNIO_TEST_SOUC_BIN=/tmp/sounio-tuple-signature-check-20260629/bin/souc SOUNIO_STDLIB_PATH=/tmp/sounio-tuple-signature-check-20260629/stdlib bash scripts/run_sio_test_suite.sh --filter tuple_signature_types --jobs 1` -> pass
- `SOUNIO_TEST_SOUC_BIN=/tmp/sounio-tuple-signature-check-20260629/bin/souc SOUNIO_STDLIB_PATH=/tmp/sounio-tuple-signature-check-20260629/stdlib bash scripts/run_sio_test_suite.sh --filter tuple_signature_arg_arity --jobs 1` -> pass
- `SOUNIO_TEST_SOUC_BIN=/tmp/sounio-tuple-signature-check-20260629/bin/souc SOUNIO_STDLIB_PATH=/tmp/sounio-tuple-signature-check-20260629/stdlib bash scripts/run_sio_test_suite.sh --filter tuple_signature_arg_type --jobs 1` -> pass
- `git diff --check` -> pass

## Notes

The original checker E000 blocker appears fixed on current `origin/main`: tuple parameters and tuple returns lower as tuple types. This PR makes that contract durable.

The active `/workspace/sounio/bin/souc` still reports `error[E000]: type checking failed` for the positive fixture, but that checkout is dirty/stale and not evidence against current `origin/main`.

No math claims, clinical-pathway code, or external-facing artifacts touched; LLM offload not required.
