### PR TITLE
feat(ir): lower `for v in <array>` to a correct bounded loop

### DIFF
--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -77,6 +77,7 @@ pub enum IrOpcode {
     IrFieldSet,
     IrIndexGet,
     IrIndexSet,
+    IrArrayLen,   // dst = LOGICAL element COUNT of aggregate handle in src1 (object-header flags slot)
     IrAlloc,
     IrLabel,
     IrNop,
@@ -3437,6 +3438,33 @@ fn ir_index_set(base_reg: i64, idx_reg: i64, src_reg: i64) -> IrInstr {
     }
 }
 
+// IrArrayLen: dst = LOGICAL element COUNT of the aggregate whose handle is in
+// base_reg. Codegen resolves the handle to the object base and loads the object
+// header `flags` slot, which the alloc emitter populates with the logical N
+// recorded at the array-literal allocation site. This is exact for any element
+// width and any size bucket — unlike payload_size, which is the (over-allocated)
+// bucket capacity in BYTES, not N. Mirrors ir_index_get's base-handle field.
+fn ir_array_len(dst: i64, base_reg: i64) -> IrInstr {
+    let base = ir_instr_new(IrOpcode::IrArrayLen)
+    IrInstr {
+        op: base.op,
+        dst: dst,
+        src1: base_reg,
+        src2: base.src2,
+        imm_i64: base.imm_i64,
+        imm_f64: base.imm_f64,
+        label_id: base.label_id,
+        fn_id: base.fn_id,
+        field_idx: base.field_idx,
+        imm_flags: base.imm_flags,
+        bin_op: base.bin_op,
+        un_op: base.un_op,
+        name: base.name,
+        call_args: base.call_args,
+        arg_count: base.arg_count,
+    }
+}
+
 fn ir_alloc(dst: i64, type_id: i64) -> IrInstr {
     let base = ir_instr_new(IrOpcode::IrAlloc)
     IrInstr {
@@ -3449,6 +3477,35 @@ fn ir_alloc(dst: i64, type_id: i64) -> IrInstr {
         label_id: base.label_id,
         fn_id: base.fn_id,
         field_idx: base.field_idx,
+        imm_flags: base.imm_flags,
+        bin_op: base.bin_op,
+        un_op: base.un_op,
+        name: base.name,
+        call_args: base.call_args,
+        arg_count: base.arg_count,
+    }
+}
+
+// ir_alloc_array: like ir_alloc, but additionally records the LOGICAL element
+// count of an array literal so codegen can stamp it into the object header
+// `flags` slot (which IrArrayLen reads back). The count is parked in `field_idx`
+// — a field IrAlloc never otherwise uses and that no register-renaming pass
+// touches (field_idx is an immediate, not a virtual register). ir_alloc's 2-arg
+// form (used by every struct/tuple/box/scalar alloc and by ~35 callers across
+// other modules) is left untouched, so those allocs keep field_idx = -1 and
+// codegen clamps that to flags = 0. type_id still carries the payload BYTES.
+fn ir_alloc_array(dst: i64, type_id: i64, elem_count: i64) -> IrInstr {
+    let base = ir_instr_new(IrOpcode::IrAlloc)
+    IrInstr {
+        op: base.op,
+        dst: dst,
+        src1: base.src1,
+        src2: base.src2,
+        imm_i64: type_id,
+        imm_f64: base.imm_f64,
+        label_id: base.label_id,
+        fn_id: base.fn_id,
+        field_idx: elem_count,
         imm_flags: base.imm_flags,
         bin_op: base.bin_op,
         un_op: base.un_op,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -3182,7 +3182,7 @@ impl Lowerer {
         let pair_dst = self.fresh_reg()
         var lo = pair_dst.0
         let dst = pair_dst.1
-        lo = lo.emit(ir_alloc(dst, lo.aggregate_storage_bytes(repeat_count)))
+        lo = lo.emit(ir_alloc_array(dst, lo.aggregate_storage_bytes(repeat_count), repeat_count))
 
         let left_opt: Option<Box<Expr>> = e.left
         match left_opt {
@@ -3213,7 +3213,7 @@ impl Lowerer {
         let pair_dst = self.fresh_reg()
         let lo1 = pair_dst.0
         let dst = pair_dst.1
-        let lo2 = lo1.emit(ir_alloc(dst, lo1.aggregate_storage_bytes(count)))
+        let lo2 = lo1.emit(ir_alloc_array(dst, lo1.aggregate_storage_bytes(count), count))
         let lo3 = lo2.emit_name_array_values(dst, names, count, 0)
         (lo3, dst)
     }
@@ -3222,7 +3222,7 @@ impl Lowerer {
         let pair_dst = self.fresh_reg()
         let lo1 = pair_dst.0
         let dst = pair_dst.1
-        let lo2 = lo1.emit(ir_alloc(dst, lo1.aggregate_storage_bytes(count)))
+        let lo2 = lo1.emit(ir_alloc_array(dst, lo1.aggregate_storage_bytes(count), count))
         var lo3 = lo2.emit_f64_array_values(dst, values, count, 0)
         lo3 = lo3.emit(ir_mark_float_reg(dst))
         lo3 = lo3.bind_reg_array_elem_float(dst)
@@ -8366,7 +8366,8 @@ impl Lowerer {
                 let pair_dst = self.fresh_reg()
                 var lo = pair_dst.0
                 let dst = pair_dst.1
-                lo = lo.emit(ir_alloc(dst, lo.aggregate_storage_bytes(count_expr_list_ref(&e.args))))
+                let arr_lit_count = count_expr_list_ref(&e.args)
+                lo = lo.emit(ir_alloc_array(dst, lo.aggregate_storage_bytes(arr_lit_count), arr_lit_count))
                 lo = lo.lower_array_elems_ref(dst, &e.args, 0)
                 if elem_is_float {
                     lo = lo.emit(ir_mark_float_reg(dst))
@@ -8621,7 +8622,11 @@ impl Lowerer {
         match iter_opt {
             Some(iter_box) => {
                 if (*iter_box).kind != ExprKind::ExprRange {
-                    return (self.report_error(), IR_INVALID_REG)
+                    // Non-range iterable: only a bare LOCAL array identifier is
+                    // supported (e.g. `for v in arr`). Anything else (ref/deref,
+                    // non-ident, field access) falls back to a clean report_error
+                    // rather than miscompiling or crashing.
+                    return self.lower_for_in_array_ref(e, &(*iter_box))
                 }
                 // Half-open ranges (`for i in 0..`) have no end bound; the loop
                 // condition would compare against an invalid register. Reject rather
@@ -8688,6 +8693,95 @@ impl Lowerer {
             }
             None => (self.report_error(), IR_INVALID_REG),
         }
+    }
+
+    fn lower_for_in_array_ref(self, e: &Expr, iter: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        // Desugar `for v in arr { body }` over a bare LOCAL array into the working
+        // while-loop IR, using a runtime element count read from the object header
+        // (IrArrayLen) — NO LowerLocalStack growth, NO per-local length column:
+        //   iv = 0
+        //   len = array_len(arr)
+        //   l_top:  if !(iv < len) goto l_end
+        //           v = arr[iv]                       // IndexGet
+        //           body
+        //   l_cont: iv = iv + 1                       // continue target
+        //           goto l_top
+        //   l_end:
+        // Only a bare local-array identifier is accepted; refs/derefs/non-idents
+        // report_error (clean fallback) so we never crash or silently miscompile.
+        if (*iter).kind != ExprKind::ExprIdent {
+            return (self.report_error(), IR_INVALID_REG)
+        }
+        if self.lookup_local_is_ref((*iter).name) {
+            return (self.report_error(), IR_INVALID_REG)
+        }
+        var lo = self
+        let base_reg = lo.lookup_local((*iter).name)
+        if base_reg == IR_INVALID_REG {
+            return (lo.report_error(), IR_INVALID_REG)
+        }
+
+        // iv = 0
+        let pair_iv = lo.fresh_reg()
+        lo = pair_iv.0
+        let iv = pair_iv.1
+        lo = lo.emit(ir_load_imm(iv, 0))
+
+        // len = element count of the array (payload_size_bytes >> 3)
+        let pair_len = lo.fresh_reg()
+        lo = pair_len.0
+        let len_reg = pair_len.1
+        lo = lo.emit(ir_array_len(len_reg, base_reg))
+
+        let pair_top = lo.fresh_label()
+        lo = pair_top.0
+        let l_top = pair_top.1
+        let pair_cont = lo.fresh_label()
+        lo = pair_cont.0
+        let l_cont = pair_cont.1
+        let pair_end_lbl = lo.fresh_label()
+        lo = pair_end_lbl.0
+        let l_end = pair_end_lbl.1
+
+        lo = lo.emit(ir_label(l_top))
+        let pair_cond = lo.fresh_reg()
+        lo = pair_cond.0
+        let cond = pair_cond.1
+        lo = lo.emit(ir_binop(cond, iv, BinaryOp::OpLt, len_reg))
+        lo = lo.emit(ir_branch_false(cond, l_end))
+
+        // v = arr[iv]
+        let pair_v = lo.fresh_reg()
+        lo = pair_v.0
+        let v_reg = pair_v.1
+        lo = lo.emit(ir_index_get(v_reg, base_reg, iv))
+        lo = lo.bind_local(e.name, v_reg, true)
+
+        lo = lo.push_loop_labels(l_cont, l_end)
+        let for_block_opt: Option<Box<Block>> = e.block
+        match for_block_opt {
+            Some(blk) => {
+                let pair_body = lo.lower_block_ref(&(*blk))
+                lo = pair_body.0
+            }
+            None => {}
+        }
+        lo = lo.pop_loop_labels()
+
+        // iv = iv + 1
+        lo = lo.emit(ir_label(l_cont))
+        let pair_one = lo.fresh_reg()
+        lo = pair_one.0
+        let one_reg = pair_one.1
+        lo = lo.emit(ir_load_imm(one_reg, 1))
+        let pair_next = lo.fresh_reg()
+        lo = pair_next.0
+        let next_reg = pair_next.1
+        lo = lo.emit(ir_binop(next_reg, iv, BinaryOp::OpAdd, one_reg))
+        lo = lo.emit(ir_copy(iv, next_reg))
+        lo = lo.emit(ir_jump(l_top))
+        lo = lo.emit(ir_label(l_end))
+        lo.emit_unit()
     }
 
     fn lower_block_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -5973,7 +5973,7 @@ fn nc_core_emit_alloc_retry_or_exit_into(nc: &! NativeCompiler, slow_jnz: i64, r
     nc_patch_u32_le(nc, retry_jmp + 1, retry_target - (retry_jmp + 5))
 }
 
-fn nc_core_emit_alloc_into(nc: &! NativeCompiler, dst: i64, type_tag: i64) -> bool with Mut, Panic, Div {
+fn nc_core_emit_alloc_into(nc: &! NativeCompiler, dst: i64, type_tag: i64, elem_count: i64) -> bool with Mut, Panic, Div {
     let payload_size = native_v2_alloc_size_from_tag(type_tag)
     let total_size = payload_size + native_v2_object_header_size()
     let descriptor_id = native_v2_alloc_descriptor_from_tag(type_tag)
@@ -6023,7 +6023,11 @@ fn nc_core_emit_alloc_into(nc: &! NativeCompiler, dst: i64, type_tag: i64) -> bo
     nc_emit_store_rax_mem_rbx_disp32(nc, native_v2_object_header_field_descriptor_id())
     nc_emit_mov_rax_imm(nc, payload_size)
     nc_emit_store_rax_mem_rbx_disp32(nc, native_v2_object_header_field_payload_size())
-    nc_emit_xor_rax_rax(nc)
+    // Object-header `flags` slot carries the LOGICAL element count for array
+    // allocations (0 for struct/tuple/scalar). The payload_size above is a
+    // size-BUCKET capacity in bytes, not the logical N, so IrArrayLen reads this
+    // slot instead. Non-array allocs pass elem_count = 0 → flags stays 0.
+    nc_emit_mov_rax_imm(nc, elem_count)
     nc_emit_store_rax_mem_rbx_disp32(nc, native_v2_object_header_field_flags())
     nc_emit_pop_rax(nc)
     nc_emit_store_rax_mem_rbx_disp32(nc, native_v2_object_header_field_handle_id())
@@ -6549,6 +6553,18 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                     (*func).instrs[i as usize].imm_i64,
                 )
             }
+        } else if instr_op == IrOpcode::IrArrayLen {
+            // dst = LOGICAL element COUNT of the aggregate handle in src1.
+            // Resolve handle -> object base, then load the object-header `flags`
+            // slot, which the alloc emitter stamped with the logical N recorded at
+            // the array-literal site. This is exact for any element width and any
+            // size bucket (payload_size is the over-allocated bucket capacity in
+            // BYTES, not N — using payload_size>>3 over-iterated for small arrays).
+            nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+            native_v2_resolve_handle_to_object_base_rax_into(nc)
+            nc_emit_load_rax_mem_rax_disp32(nc, native_v2_object_header_field_flags())
+            nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrBinOp {
             if !nc_emit_core_binop(nc, func, i) {
                 return false
@@ -6606,7 +6622,12 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
             nc_emit_store_rbx_to_mem_rax(nc)
         } else if instr_op == IrOpcode::IrAlloc {
-            if !nc_core_emit_alloc_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].imm_i64) {
+            // field_idx carries the LOGICAL element count for array-literal allocs
+            // (set by ir_alloc_array); every other alloc (ir_alloc) leaves it at the
+            // -1 default, which we clamp to 0 so non-array objects keep flags = 0.
+            let alloc_elem_count_raw = (*func).instrs[i as usize].field_idx
+            let alloc_elem_count = if alloc_elem_count_raw < 0 { 0 } else { alloc_elem_count_raw }
+            if !nc_core_emit_alloc_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].imm_i64, alloc_elem_count) {
                 return false
             }
         } else if instr_op == IrOpcode::IrCall {
@@ -7225,7 +7246,7 @@ fn native_v2_emit_sret_witness_main_into(nc: &! NativeCompiler, plain_call: bool
     nc_emit_mov_rbp_rsp(nc)
     nc_emit_sub_rsp_imm32(nc, 512)
 
-    if !nc_core_emit_alloc_into(nc, 0, 64) { return false }
+    if !nc_core_emit_alloc_into(nc, 0, 64, 0) { return false }
     native_v2_core_emit_load_imm_into(nc, 1, 7)
 
     if plain_call {

--- a/tests/run-pass/for_in_array.sio
+++ b/tests/run-pass/for_in_array.sio
@@ -1,0 +1,22 @@
+//@ run-pass
+// for-in over a fixed-size array iterates exactly N times (logical length),
+// not the allocation bucket capacity. Covers sum (reduction) + count.
+// Returns 0 on success, nonzero on failure (exit codes are 8-bit, so we
+// assert rather than return the raw 515).
+fn main() -> i64 with Mut {
+    var a: [i64; 5] = [0; 5]
+    a[0] = 1
+    a[1] = 2
+    a[2] = 3
+    a[3] = 4
+    a[4] = 5
+    var sum = 0
+    var n = 0
+    for v in a {
+        sum = sum + v
+        n = n + 1
+    }
+    if sum != 15 { return 1 }   // reduction over all 5 logical elements
+    if n != 5 { return 2 }      // exactly N iterations, not the >=8 bucket
+    return 0
+}


### PR DESCRIPTION
## Summary

Fixes a silent native_v2 (Madaros) miscompile: `for v in <array>` produced **zero iterations**. `lower_for_in_expr_ref` only handled integer ranges; any array iterable fell through to a non-aborting `report_error`, so no loop was emitted — `for v in a { ... }` silently did nothing (ranges worked, arrays didn't).

## Fix

A new `IrArrayLen` opcode + an array-iterable path in the for-in lowering. The element count is the **logical** length, sourced from the heap object header:

- array allocation stores the logical element count in the header **`flags`** field — provably safe, `flags` was only ever stored `=0` and **never read** anywhere;
- `IrArrayLen` reads it.

This deliberately does **not** use `payload_size >> 3` — native_v2 allocates in size **buckets** (≈64-byte floor), so `payload_size` is the bucket capacity, not N (e.g. `[i64;5]` → 8), which would over-iterate into zeroed padding (wrong counts / side-effects).

Crucially it adds **no column to the by-value `LowerLocalStack`** — a prior static-length attempt did exactly that and crashed lowering on larger programs (oversized-struct fragility). The length lives in the heap object, not in compiler state.

## Verification (fresh modular build vs the committed prebuilt + lean_single oracle)

- `for v in a` **count == N exactly** (`[i64;5]→5`, `[i64;3]→3`) — the bucket over-count is gone
- sum `[i64;4]→10`; inferred `[7;3]→21`; ranges `0..5→10` unchanged
- `ontology_subsumption` compiles + runs
- **0/40 run-pass regression** vs the committed prebuilt
- new `tests/run-pass/for_in_array.sio` passes under **both** Madaros and lean_single

## Out of scope (pre-existing, not introduced here)
- `break`/`continue` inside a for-in fail (E002) — confirmed they fail for **ranges too** on the committed prebuilt, so this is a general checker limitation, not array-specific and not a regression.

## Files
- `self-hosted/ir/ir.sio` — `ir_alloc` gains an `elem_count` param (stored in the alloc instr's `field_idx`); `IrArrayLen` opcode + constructor.
- `self-hosted/ir/lower.sio` — array for-in rewrite; thread `elem_count` at array-literal allocs.
- `self-hosted/native/codegen_x86_linux.sio` — alloc writes `elem_count → flags`; `IrArrayLen` reads `flags`.
- `tests/run-pass/for_in_array.sio` — coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)