### PR TITLE
test(check): run tuple signature regression

### DIFF
--- a/tests/run-pass/tuple_signature_types.sio
+++ b/tests/run-pass/tuple_signature_types.sio
@@ -1,8 +1,8 @@
-//@ check-only
+//@ run-pass
 
-// Regression for tuple type expressions in function signatures. This is a
-// checker contract: tuple parameters and tuple returns must lower as tuple
-// types instead of falling through to ty_error/E000.
+// Regression for tuple type expressions in function signatures. Tuple
+// parameters and tuple returns must lower as tuple types instead of falling
+// through to ty_error/E000, then run with the expected values.
 
 fn pair_sum(p: (i64, i64)) -> i64 {
     p.0 + p.1


### PR DESCRIPTION
## Summary

- promote `tests/run-pass/tuple_signature_types.sio` from check-only to run-pass
- keep the same tuple-signature checker regression, now also proving the selected runtime/codegen path returns the expected values

## Validation

Using the clean worktree binary from current `origin/main`:

- `SOUNIO_TEST_SOUC_BIN=/tmp/sounio-tuple-runtime-20260629/bin/souc SOUNIO_STDLIB_PATH=/tmp/sounio-tuple-runtime-20260629/stdlib bash scripts/run_sio_test_suite.sh --filter tuple_signature_types --jobs 1` -> pass
- `SOUNIO_TEST_SOUC_BIN=/tmp/sounio-tuple-runtime-20260629/bin/souc SOUNIO_STDLIB_PATH=/tmp/sounio-tuple-runtime-20260629/stdlib bash scripts/run_sio_test_suite.sh --filter tuple_signature_arg_arity --jobs 1` -> pass
- `SOUNIO_TEST_SOUC_BIN=/tmp/sounio-tuple-runtime-20260629/bin/souc SOUNIO_STDLIB_PATH=/tmp/sounio-tuple-runtime-20260629/stdlib bash scripts/run_sio_test_suite.sh --filter tuple_signature_arg_type --jobs 1` -> pass
- `git diff --check` -> pass

## Notes

This does not change compiler behavior. It tightens the regression added in #514 after reducing the suspected runtime/codegen issue on current `main` and confirming the selected tuple-signature fixture runs successfully.

No math claims, clinical-pathway code, or external-facing artifacts touched; LLM offload not required.
