### PR TITLE
fix(codegen): honor explicit f64 float-marker so literal multiply uses SSE

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6405,9 +6405,15 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
         let instr_op = (*func).instrs[i as usize].op
         if instr_op == IrOpcode::IrNop && (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG {
             let mark_reg = (*func).instrs[i as usize].dst
-            if !(mark_reg >= 0 && mark_reg < 512 && (*nc).is_float_reg[mark_reg as usize] == 2) {
-                nc_core_mark_float_reg(nc, mark_reg)
-            }
+            // Always honor an explicit float-marker IrNop. The previous guard
+            // skipped marking when is_float_reg[mark_reg]==2 (int), but a preceding
+            // IrLoadImm sets =2 on f64 literals, so the guard vetoed the float mark
+            // for `0.1 * 0.1` etc. → the literal kept int regs and took integer imul
+            // on the IEEE bit-patterns (result 0). The guard was a stale #478
+            // neutralizer; #478 is now fixed at source in lower.sio, so this marker
+            // is only emitted for genuinely-float values. nc_core_mark_float_reg
+            // bounds-checks internally.
+            nc_core_mark_float_reg(nc, mark_reg)
         } else if instr_op == IrOpcode::IrLoadImm {
             let imm_value = (*func).instrs[i as usize].imm_i64
             if imm_value == (0 - 4242) {

--- a/tests/run-pass/f64_literal_mul.sio
+++ b/tests/run-pass/f64_literal_mul.sio
@@ -1,0 +1,12 @@
+//@ run-pass
+// f64 literal/local multiplication must use SSE (mulsd), not integer imul on the
+// IEEE bit patterns. Regression test for the IrNop float-marker guard that vetoed
+// float-marking f64 literals (result was 0).
+fn abs_f64(x: f64) -> f64 { if x < 0.0 { return 0.0 - x } return x }
+fn main() -> i64 with Mut {
+    let a = 0.1 * 0.1 + 0.1 * 0.1     // 0.02
+    let b = 0.5 * 0.5                 // 0.25
+    if abs_f64(a - 0.02) > 0.0001 { return 1 }
+    if abs_f64(b - 0.25) > 0.0001 { return 2 }
+    return 0
+}


### PR DESCRIPTION
## Summary

f64 literal multiply (`0.1 * 0.1`) returned **0** under native_v2 (Madaros) — codegen emitted an integer `imul` on the IEEE bit patterns instead of `mulsd`. lean_single was correct; the committed prebuilt had the bug too (pre-existing).

## Root cause

The `IrNop` float-marker handler was guarded by `!(mark_reg in-bounds && is_float_reg[mark_reg] == 2)`. A preceding `IrLoadImm` sets `is_float_reg = 2` (int) on the literal's register, so the guard **vetoed the float mark for f64 literals** — they kept integer registers and took the integer multiply path. The guard was a stale leftover from neutralizing #478; #478 is now fixed at its source in `lower.sio`, so this marker is only emitted for genuinely-float values. It is now honored unconditionally (`nc_core_mark_float_reg` bounds-checks internally).

## Verification

Apples-to-apples vs a **pure-current-main rebuild** (correct baseline — the committed prebuilt is built differently and isn't a valid local baseline), 100 run-pass fixtures: **0 regressions**.

- `0.1*0.1+0.1*0.1 → 0.02`, `0.5*0.5 → 0.25`
- f64 add, integer multiply, `#478` (`var s=3; s=s+5 → 8`), `for v in array` (#515) all unchanged
- new `tests/run-pass/f64_literal_mul.sio` passes under **both** Madaros and lean_single

## Scope / follow-up

This fixes f64 **literal/local** multiply. f64 arithmetic over function **parameters** (`fn(x:f64)->f64{x*x}`) is a **separate, deeper** f64-calling-convention / register-allocation issue — marking f64 params float fixes the arithmetic but hangs mixed-param functions in loops — and is left to a dedicated backend pass.

## Files
- `self-hosted/native/codegen_x86_linux.sio` — honor the f64 float-marker IrNop unconditionally.
- `tests/run-pass/f64_literal_mul.sio` — coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)