### PR TITLE
fix(gpu): unbreak modular build (tile_buf_print + TileBuf size)

### DIFF
--- a/self-hosted/gpu/cuda_tile.sio
+++ b/self-hosted/gpu/cuda_tile.sio
@@ -5,8 +5,18 @@
 // large aggregate-by-value emitter shape.
 
 pub struct TileBuf {
-    pub data: [i8; 2048],
+    pub data: [i8; 65536],
     pub len: i64,
+}
+
+// Write the CUDA Tile IR buffer to stdout (used when no output file is given).
+// Mirrors ptx_buf_print / metal_buf_print for the other GPU artifact buffers.
+pub fn tile_buf_print(buf: TileBuf) with IO, Mut, Panic, Div {
+    var i: i64 = 0
+    while i < buf.len {
+        print_char(buf.data[i as usize] as i64)
+        i = i + 1
+    }
 }
 
 let CT_GPU_OP_ADD: i64 = 1
@@ -17,12 +27,12 @@ let CT_GPU_OP_MMA: i64 = 33
 let CT_TAG_F32: i64 = 0
 
 pub fn tile_buf_new() -> TileBuf {
-    TileBuf { data: [0; 2048], len: 0 }
+    TileBuf { data: [0; 65536], len: 0 }
 }
 
 fn tile_push_byte(buf: TileBuf, b: i8) -> TileBuf with Mut, Panic {
     var out = buf
-    if out.len >= 0 && out.len < 2048 {
+    if out.len >= 0 && out.len < 65536 {
         out.data[out.len as usize] = b
         out.len = out.len + 1
     }


### PR DESCRIPTION
## Summary

The **modular self-host build was red** — `self-hosted/compiler/main.sio` had two typecheck errors on the CUDA Tile IR output path, introduced by recent **direct (non-PR-CI) GPU preflight commits** and never actually compiled. This blocked every modular build (Native Self-Host / Source-Bootstrap gates) and the Madaros prebuilt refresh.

## The two errors (both in the CUDA Tile path)
1. **`unknown identifier tile_buf_print(tile_buf)`** (main.sio ~27745) — the "print to stdout when no output file" branch called a function that was never defined. The sibling artifact paths have `ptx_buf_print` / `metal_buf_print`; the tile one was missing.
2. **`E001` type mismatch** at `io_write_bytes_to_file(output_path, tile_buf.data, tile_buf.len)` — `TileBuf.data` was `[i8; 2048]`, but `io_write_bytes_to_file` takes `[i8; 65536]` (the size every other GPU artifact buffer uses, e.g. `PtxBuf`).

## Fix (1 file: `self-hosted/gpu/cuda_tile.sio`)
- Define `tile_buf_print(buf: TileBuf)` mirroring `ptx_buf_print`/`metal_buf_print`.
- Size `TileBuf.data` to `[i8; 65536]` (struct + `tile_buf_new` + the `tile_push_byte` bounds guard) so it matches `io_write_bytes_to_file`, consistent with `PtxBuf`.

## Verification
- The modular Madaros compiler **now builds cleanly** (previously a hard typecheck failure — no binary).
- The resulting binary self-compiles and runs: `for i in 0..5 { s+=i }` → 10; `ontology_subsumption` → 0.
- No behavior change outside the CUDA Tile output path.

This unblocks all modular-build CI gates and the prebuilt refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)