### PR TITLE
fix(native): merge print_f64 rodata into flat_rodata on Madaros

### DIFF
--- a/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/epistemic_bmi_f64_println_probe.sio
+++ b/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/epistemic_bmi_f64_println_probe.sio
@@ -1,0 +1,12 @@
+// Bisect: println(f64) after struct field read — exit 0 if no crash.
+struct KnowledgeF64 {
+    value: f64,
+    uncertainty: f64
+}
+
+fn main() with IO {
+    let k = KnowledgeF64 { value: 22.7, uncertainty: 0.1 }
+    println("probe")
+    println(k.value)
+    return 0
+}

--- a/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_div_println_probe.sio
+++ b/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_div_println_probe.sio
@@ -1,0 +1,5 @@
+fn main() with IO {
+    let x = 72.0 / (1.78 * 1.78)
+    println(x)
+    return 0
+}

--- a/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_println_literal_probe.sio
+++ b/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_println_literal_probe.sio
@@ -1,0 +1,5 @@
+fn main() with IO {
+    println("literal_probe")
+    println(22.7)
+    return 0
+}

--- a/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_println_local_probe.sio
+++ b/docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_println_local_probe.sio
@@ -1,0 +1,6 @@
+fn main() with IO {
+    let x = 22.7
+    println("local_probe")
+    println(x)
+    return 0
+}

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -3621,14 +3621,41 @@ fn emit_builtin_str_concat(nc: NativeCompiler) -> NativeCompiler with Mut, Panic
     c
 }
 
+fn native_v2_rodata_append_updated_tail(nc: &! NativeCompiler, updated: NativeCompiler, src_start: i64) -> i64 with Mut, Panic, Div {
+    let append_base = if (*nc).flat_rodata_len > 0 { (*nc).flat_rodata_len } else { (*nc).rodata.len }
+    var src = src_start
+    if (*nc).flat_rodata_len > 0 {
+        var bytes = (*nc).flat_rodata_bytes
+        var len = (*nc).flat_rodata_len
+        while src < updated.rodata.len && len < 8192 {
+            bytes[len as usize] = updated.rodata.bytes[src as usize]
+            len = len + 1
+            src = src + 1
+        }
+        (*nc).flat_rodata_bytes = bytes
+        (*nc).flat_rodata_len = len
+    } else {
+        var t = (*nc).rodata
+        while src < updated.rodata.len && t.len < 8192 {
+            t.bytes[t.len as usize] = updated.rodata.bytes[src as usize]
+            t.len = t.len + 1
+            src = src + 1
+        }
+        (*nc).rodata = t
+    }
+    append_base
+}
+
 fn native_v2_persist_builtin_emit_into(nc: &! NativeCompiler, updated: NativeCompiler) with Mut, Panic, Div {
+    let nc_rodata_len_before = (*nc).rodata.len
     (*nc).code = updated.code
-    (*nc).rodata = updated.rodata
+    let rodata_append_base = native_v2_rodata_append_updated_tail(nc, updated, nc_rodata_len_before)
     var ri = 0
     while ri < updated.relocs.count && ri < 4096 {
         let entry = updated.relocs.entries[ri as usize]
         if entry.kind.kind_code == 2 {
-            nc_add_rodata_reloc(nc, entry.offset, entry.target.target_index)
+            let adjusted = rodata_append_base + (entry.target.target_index - nc_rodata_len_before)
+            nc_add_rodata_reloc(nc, entry.offset, adjusted)
         } else if entry.kind.kind_code == 3 {
             nc_add_data_section_reloc(nc, entry.offset, entry.target.target_index)
         }


### PR DESCRIPTION
## Summary

Fixes `println(f64)` wrong output / SIGSEGV on the default Madaros engine when programs also contain string literals.

**Root cause:** `native_v2_persist_builtin_emit_into` assigned `(*nc).rodata = updated.rodata` after emitting `print_f64`. Programs that already used `flat_rodata_bytes` for string literals never received the `1e6` f64 constant in the ELF rodata section; the `movsd` RIP reloc pointed at code bytes instead, printing truncated values like `22.000000`.

**Fix:** Append new builtin rodata bytes into the active store (`flat_rodata_bytes` when `flat_rodata_len > 0`, else `nc.rodata`) and adjust kind-2 reloc targets.

## Lane coordination

| Lane | Overlap |
|---|---|
| PR #537 `module_frontend` merge finalize | **None** — this PR touches only `codegen_x86_linux.sio` |
| Parser trace (`SOUNIO_PARSER_TRACE`) | **None** — uncommitted on `research/solver-ts3-parallel`, not included |
| GPU worktrees (`/tmp/sounio-gpu-*`) | **Disjoint** per `COORDINATION_2026-06-29_PBOX_LANES.md` |
| Prior PR #449/#454 println dispatch | **Supersedes rodata half only** — dispatch + movsd relocs already on `main@039f3ea6b`; this closes the flat_rodata gap |

**Blocker:** `BLK-20260629-stdlib-epistemic-madaros-sigsegv` — partial closure (println/f64 cluster); remaining 139s (rapamycin, graphics, sret_pbox) are separate.

## Validation

Workspace Madaros rebuild after fix:

```bash
./bin/souc run docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/reference/f64_println_literal_probe.sio
# literal_probe / 22.699999

./bin/souc run tests/run-pass/epistemic_bmi.sio
# BMI value 22.724403 (no SIGSEGV)

./bin/souc run tests/run-pass/epistemic_mcts.sio
# EPISTEMIC_MCTS_PASS
```

Existing on `main`: `tests/run-pass/println_f64_{literal,var,call_return}.sio` should also benefit.

## LLM-offload

Not invoked — compiler codegen plumbing only; no math claims, clinical-pathway code, or external-facing artefacts.