### PR TITLE
fix(ir): type if-expression result as float JOIN of its arms

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4795,7 +4795,44 @@ impl Lowerer {
             }
             return self.opt_expr_result_is_float_ref(&(*e).left) || self.opt_expr_result_is_float_ref(&(*e).right)
         }
+        // An if-expression yields a float if either arm yields a float. Native
+        // codegen types the merge register flow-insensitively (last linear write
+        // wins), and an f64 literal arm (e.g. `else { 0.0 }`) lowers to IrLoadImm
+        // (int-flagged), so without this case `let k = if c { a/b } else { 0.0 }`
+        // leaves `k` untyped and a downstream `acc + k` cvtsi2sd-corrupts the bits.
+        if (*e).kind == ExprKind::ExprIf {
+            return self.opt_block_tail_is_float_ref(&(*e).block) || self.opt_expr_result_is_float_ref(&(*e).else_expr)
+        }
         false
+    }
+
+    // True iff the block's value (its trailing expression statement) yields a
+    // float. A block whose last statement is a let/var/assign yields unit → false.
+    fn opt_block_tail_is_float_ref(self, blk_opt: &Option<Box<Block>>) -> bool with Mut, Panic, Div, Alloc {
+        match *blk_opt {
+            Some(blk) => self.block_tail_is_float_ref(&(*blk)),
+            _ => false,
+        }
+    }
+
+    fn block_tail_is_float_ref(self, blk: &Block) -> bool with Mut, Panic, Div, Alloc {
+        var current = &(*blk).stmts
+        var result = false
+        while true {
+            match *current {
+                Some(list) => {
+                    let stmt_ref = &(*list).head
+                    if stmt_ref.kind == StmtKind::StmtExpr {
+                        result = self.opt_expr_result_is_float_ref(&stmt_ref.expr)
+                    } else {
+                        result = false
+                    }
+                    current = &(*list).tail
+                }
+                _ => break
+            }
+        }
+        result
     }
 
     fn expr_result_scalar_kind_ref(self, e: &Expr) -> i64 with Mut, Panic, Div, Alloc {
@@ -8501,6 +8538,12 @@ impl Lowerer {
     }
 
     fn lower_if_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        // Type the merge register as a true JOIN of the two arms. Native codegen
+        // is flow-insensitive (the if-merge res inherits whichever ir_copy is last
+        // in linear order — the else arm), so an f64 if-expr whose else arm is an
+        // int-flagged value (e.g. an f64 literal via IrLoadImm) would otherwise
+        // leave res untyped and a downstream float consumer cvtsi2sd-corrupts it.
+        let res_is_float = self.expr_result_is_float_ref(e)
         let pair_cond = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_cond.0
         let cond = pair_cond.1
@@ -8537,6 +8580,9 @@ impl Lowerer {
         let else_reg = pair_else.1
         lo = lo.emit(ir_copy(res, else_reg))
         lo = lo.emit(ir_label(l_end))
+        if res_is_float {
+            lo = lo.emit(ir_mark_float_reg(res))
+        }
         (lo, res)
     }
 

--- a/tests/run-pass/f64_if_expr_merge_typing.sio
+++ b/tests/run-pass/f64_if_expr_merge_typing.sio
@@ -1,0 +1,49 @@
+//@ run-pass
+//@ expect-stdout: PASS
+//
+// Regression: an if-expression whose arms are f64 must type its merge register
+// as a float, so a downstream float consumer (`acc_in + k`) does not run the
+// f64 bit-pattern through cvtsi2sd.
+//
+// Bug (native-v2 / Madaros codegen): the if-merge register was typed
+// flow-insensitively — the last linear ir_copy won — and an f64-literal else arm
+// (`else { 0.0 }`) lowers to IrLoadImm (int-flagged), so the merge result was
+// left untyped. A subsequent `acc_in + k` then took the SSE add (acc_in is a
+// genuine f64 param) but loaded the *unflagged* `k` operand via cvtsi2sd,
+// reinterpreting its IEEE-754 bits as an integer → garbage.
+//
+// Fixed in self-hosted/ir/lower.sio: expr_result_is_float_ref now has an ExprIf
+// case (arms join), and lower_if_expr_ref marks the merge register float when the
+// if-expression is float. lean_single always compiled this correctly.
+//
+// Both arms reachable: float condition (step_fcond) and int condition
+// (step_icond) — the latter proves the defect is the float *result* merge, not
+// the condition.
+
+fn step_fcond(acc_in: f64, numer: f64) -> f64 with Mut, Panic, Div {
+    var sigma_sq = 1.0
+    var j = 0
+    while j < 3 { sigma_sq = sigma_sq - 0.2; j = j + 1 }
+    let k = if sigma_sq > 1.0e-15 { numer / sigma_sq } else { 0.0 }
+    acc_in + k
+}
+
+fn step_icond(acc_in: f64, numer: f64) -> f64 with Mut, Panic, Div {
+    var sigma_sq = 1.0
+    var j = 0
+    while j < 3 { sigma_sq = sigma_sq - 0.2; j = j + 1 }
+    let k = if j == 3 { numer / sigma_sq } else { 0.0 }
+    acc_in + k
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    // sigma_sq = 1.0 - 0.2*3 = 0.4 ; k = 0.8 / 0.4 = 2.0 ; acc_in + k = 2.0
+    let r1 = step_fcond(0.0, 0.8)
+    let r2 = step_icond(0.0, 0.8)
+    if r1 > 1.9 && r1 < 2.1 && r2 > 1.9 && r2 < 2.1 {
+        println("PASS")
+        return 0
+    }
+    println("FAIL")
+    return 1
+}


### PR DESCRIPTION
## Problem

A `let k = if c { a/b } else { 0.0 }` over `f64` yields a merge register the native-v2 (Madaros) backend left typed as **integer**. Codegen types the if-merge register flow-insensitively (last linear `ir_copy` wins) and an f64-literal arm lowers to `IrLoadImm` (int-flagged via `emit_f64_const`), so the merge inherited int. A downstream `acc + k` then took the SSE add (because `acc` is a genuine f64 param) but loaded the **unflagged** `k` operand via `cvtsi2sd`, reinterpreting its IEEE-754 bits as an integer → garbage. `lean_single` always compiled this correctly.

Confirmed by disassembly: the failing binary ran `k` through `cvtsi2sd`; the fixed binary loads it with `movq` (1→0 `cvtsi2sd` at the add site).

## Fix (`self-hosted/ir/lower.sio`)

- `expr_result_is_float_ref` gains an `ExprIf` case (+ `block_tail_is_float_ref` / `opt_block_tail_is_float_ref` helpers) so a float if-expression types its `let` binding and binop operands as float.
- `lower_if_expr_ref` marks the merge register float when the if-expression is float (a true JOIN of the arms), instead of relying on the last linear copy.

Codegen already honors the float-marker `IrNop` unconditionally, so no codegen change is needed.

## Verification (f64-param-fixpoint baseline Madaros build)

- Repros `ret_if_add` / `if_intcond` now pass (were `F`); controls `if_flt_nok` / `ret_acc_add` still pass.
- **fcmp comparison oracle byte-identical** baseline vs fix — this change is fully independent of the f64 compare path-selection bug.
- **311-test f64 run-pass sweep: zero regressions.** Every diff was an improvement — `arima`/Levinson `LEV_FAIL`→`PASS`, `bayesian_observe` & `epistemic_mcts_full` `FAIL`→`PASS`, `plot3d`/`svg` corrupted-floats→correct. (`gum_h1_native` times out identically on both — pre-existing.)

Adds `tests/run-pass/f64_if_expr_merge_typing.sio` regression fixture (self-checking, passes under `lean_single` and the fixed Madaros).

## Out of scope
f64 comparison path-selection (oracle cases 20–23, 56) and `match`-expression result typing (same shape) — noted as separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)