### PR TITLE
formal: remove false IEEE-754 mul_assoc; split it to an explicit hypothesis

### DIFF
--- a/formal/CliffordGradeExact.lean
+++ b/formal/CliffordGradeExact.lean
@@ -110,13 +110,11 @@ theorem grade_product_upper_bound (r s k max_grade : Grade)
 theorem same_grade_includes_scalar (r max_grade : Grade)
     (hr : r ≤ max_grade) :
     IsOutputGrade r r 0 max_grade := by
+  -- lo = |r-r| = 0; hi = min(2r, max_grade) ≥ 0; (0-0) % 2 = 0.
+  -- `omega` is unusable on `Grade`-typed atoms in this toolchain, so the
+  -- three conjuncts are discharged structurally.
   unfold IsOutputGrade
-  constructor
-  · simp
-  constructor
-  · simp
-    exact Nat.le_of_dvd (by omega) (by omega)
-  · simp
+  refine ⟨by simp, Nat.zero_le _, by simp⟩
 
 -- ---------------------------------------------------------------------------
 -- §4. Scalar multiplication — Case 2 lowering
@@ -129,17 +127,25 @@ theorem same_grade_includes_scalar (r max_grade : Grade)
 theorem scalar_mul_preserves_grades (k s max_grade : Grade)
     (hs : s ≤ max_grade) :
     IsOutputGrade 0 s k max_grade ↔ (k = s ∧ k ≤ max_grade) := by
+  -- For r = 0: lo = |0 - s| = s and hi = min(0+s, max_grade) = s (since
+  -- s ≤ max_grade), so `IsOutputGrade 0 s k` collapses to s ≤ k ∧ k ≤ s,
+  -- i.e. k = s.  `omega` is unusable on `Grade`-typed atoms here, so the
+  -- bounds are reduced explicitly and the equivalence proved structurally.
   unfold IsOutputGrade
-  simp [Nat.zero_sub]
+  have e1 : (if (0 : Grade) ≥ s then (0 : Grade) - s else s - 0) = s := by
+    rcases Nat.eq_zero_or_pos s with h | h
+    · subst h; decide
+    · rw [if_neg (Nat.not_le.mpr h)]; exact Nat.sub_zero s
+  have e2 : Nat.min (0 + s) max_grade = s := by
+    rw [Nat.zero_add]; exact Nat.min_eq_left hs
+  rw [e1, e2]
   constructor
-  · intro ⟨h1, h2, h3⟩
-    constructor
-    · omega
-    · exact Nat.le_of_lt_succ (Nat.lt_of_le_of_lt h2 (by omega))
-  · intro ⟨h1, h2⟩
-    refine ⟨by omega, ?_, by omega⟩
-    simp [h1, Nat.min_def]
-    exact if_pos h2
+  · rintro ⟨h1, h2, _⟩
+    have hk : k = s := Nat.le_antisymm h2 h1
+    exact ⟨hk, hk ▸ hs⟩
+  · rintro ⟨hk, _⟩
+    subst hk
+    exact ⟨Nat.le_refl k, Nat.le_refl k, by simp⟩
 
 -- ---------------------------------------------------------------------------
 -- §5. Summary

--- a/formal/Epistemic.lean
+++ b/formal/Epistemic.lean
@@ -18,9 +18,12 @@ References:
 
 `Float` in Lean 4 (leanc) is an opaque IEEE-754 double backed by C `double`.
 The Lean 4 core does **not** export a complete algebraic hierarchy for `Float`
-(no `Ring`, `LinearOrder`, etc.).  Where ordering inequalities cannot be
-closed by `ring` or `native_decide`, we declare them as `axiom` (valid
-IEEE-754 facts for finite non-NaN values, documented in §11).
+(no `Ring`, `LinearOrder`, etc.).  Where ordering/sign inequalities cannot be
+closed by `ring` or `native_decide`, we declare them as `axiom`. These are
+restricted to facts that DO hold for finite non-NaN binary64 (monotonicity,
+non-negativity, and the *exact* identities x+0, x*1, x/1, x-x). Associativity
+and distributivity are NOT among them — they are false for IEEE-754 and are
+deliberately absent (see §12).
 
 All non-inequality theorems are proved via `ring` or structural induction.
 -/
@@ -285,14 +288,12 @@ axiom float_le_trans (a b c : Float) : a ≤ b → b ≤ c → a ≤ c
 /-- Float addition is commutative. -/
 axiom float_add_comm (a b : Float) : a + b = b + a
 
-/-- Float addition is associative. -/
-axiom float_add_assoc (a b c : Float) : a + b + c = a + (b + c)
+-- [audit-removed] float_add_assoc: FALSE for IEEE-754 ((a+b)+c ≠ a+(b+c)).
 
 /-- Float multiplication is commutative. -/
 axiom float_mul_comm (a b : Float) : a * b = b * a
 
-/-- Float multiplication is associative. -/
-axiom float_mul_assoc (a b c : Float) : (a * b) * c = a * (b * c)
+-- [audit-removed] float_mul_assoc: FALSE for IEEE-754 (overflow breaks assoc).
 
 /-- Float addition right identity. -/
 axiom float_add_zero (a : Float) : a + 0.0 = a
@@ -312,8 +313,7 @@ axiom float_mul_zero (a : Float) : a * 0.0 = 0.0
 /-- Float multiplication left zero. -/
 axiom float_zero_mul (a : Float) : 0.0 * a = 0.0
 
-/-- Float left distributivity. -/
-axiom float_mul_add (a b c : Float) : a * (b + c) = a * b + a * c
+-- [audit-removed] float_mul_add: FALSE for IEEE-754 (rounding breaks distrib).
 
 /-- Float absolute value of one. -/
 axiom float_abs_one : Float.abs 1.0 = 1.0
@@ -414,31 +414,21 @@ theorem gemm_row_eps_nonneg (aVals aEps bVals bEps : List Float)
 -- §12. Concrete Float instance
 -- ---------------------------------------------------------------------------
 
-noncomputable instance : EpistemicField Float where
-  zero       := 0.0
-  one        := 1.0
-  abs        := Float.abs
-  le_refl    := float_le_refl
-  le_trans   := float_le_trans
-  le_antisymm := float_le_antisymm
-  add_nonneg := float_add_nonneg
-  add_le_add := float_add_le_add
-  mul_nonneg := float_mul_nonneg
-  mul_le_mul_of_nonneg_left := float_mul_le_mul_left
-  abs_nonneg := float_abs_nonneg
-  add_comm   := float_add_comm
-  add_assoc  := float_add_assoc
-  mul_comm   := float_mul_comm
-  mul_assoc  := float_mul_assoc
-  add_zero   := float_add_zero
-  zero_add   := float_zero_add
-  mul_one    := float_mul_one
-  one_mul    := float_one_mul
-  mul_zero   := float_mul_zero
-  zero_mul   := float_zero_mul
-  mul_add    := float_mul_add
-  abs_one    := float_abs_one
-  zero_nonneg := float_zero_nonneg
+-- §12. Concrete instances
+--
+-- NOTE (audit fix, 2026): there is intentionally NO `EpistemicField Float`
+-- instance. `EpistemicField` demands *exact* associativity/distributivity,
+-- which IEEE-754 binary64 does NOT satisfy (e.g. (a+b)+c ≠ a+(b+c) for
+-- a=1.0,b=1e16,c=-1e16; overflow breaks (a*b)*c = a*(b*c)). The former
+-- instance discharged these via axioms `float_add_assoc`/`float_mul_assoc`/
+-- `float_mul_add` that are FALSE of the intended model. They have been removed.
+--
+-- For exact reasoning, instantiate the abstract theorems at an exact ordered
+-- field (ℚ/ℝ). For Float runtime arithmetic, use the round-to-nearest-even
+-- bounded model in `SounioIEEE754Spec` (`Float.mul_rne_bound` /
+-- `Float.add_rne_bound`) and the `BoundedOrderedCarrier` interface in
+-- `SounioFloatInstance`, where the rounding error is carried as an explicit
+-- `eps_inf` budget (Higham 2002 §2.1) rather than wished away.
 
 -- ---------------------------------------------------------------------------
 -- §13. Summary: key correctness properties

--- a/formal/FreeConvolveRTransform.lean
+++ b/formal/FreeConvolveRTransform.lean
@@ -108,21 +108,23 @@ def gaussianM4 (sigma_sq : Float) : Float :=
     Proof: 2σ⁴ ≠ 3σ⁴ iff σ⁴ ≠ 0 iff σ² ≠ 0.
     This shows the dist_class annotation is not redundant — the two distribution
     classes produce DIFFERENT 4th moments even though their R-transforms coincide. -/
-theorem m4_wigner_vs_gaussian (sigma_sq : Float) (h : sigma_sq ≠ 0.0) :
-    wignerM4 sigma_sq ≠ gaussianM4 sigma_sq := by
-  unfold wignerM4 gaussianM4
-  intro h_eq
-  -- 2σ⁴ = 3σ⁴ → σ⁴ = 0 → σ² = 0 → contradiction
-  have : (2.0 : Float) * sigma_sq * sigma_sq = 3.0 * sigma_sq * sigma_sq := h_eq
-  simp at this
+theorem m4_wigner_vs_gaussian : (wignerM4 2.0 == gaussianM4 2.0) = false := by
+  -- Distinguishing witness at the canonical test vector σ²=2: 8 ≠ 12,
+  -- established by IEEE-754 value computation.
+  -- NOTE: the unrestricted ∀ σ²≠0 statement is FALSE over `Float` — under
+  -- overflow both 4th moments saturate to +∞ and compare equal — so the
+  -- claim is a finite decidable witness, not a universally quantified law.
+  -- A general (overflow-free) proof belongs to the RNE-bounded real model.
+  native_decide
 
 /-- **Concrete computation.**  For σ² = 2.0 (free convolution of two σ²=1 semicircles):
     Wigner m₄ = 8.0, Gaussian m₄ = 12.0, overestimate = 4.0.
     This matches the science spine test `free_probability_rtr.sio`. -/
 theorem m4_at_sigma_sq_2 :
-    wignerM4 2.0 = 8.0 ∧ gaussianM4 2.0 = 12.0 := by
-  unfold wignerM4 gaussianM4
-  simp [Float.mul_def]
+    (wignerM4 2.0 == 8.0) = true ∧ (gaussianM4 2.0 == 12.0) = true :=
+  -- IEEE-754 value equality (`==`); opaque `Float` has no `DecidableEq`, so
+  -- the concrete test vector is stated via Bool `==` and closed by native eval.
+  ⟨by native_decide, by native_decide⟩
 
 -- ---------------------------------------------------------------------------
 -- §4. Commutativity of free convolution (for semicircle class)
@@ -134,8 +136,11 @@ theorem m4_at_sigma_sq_2 :
 theorem free_convolve_comm (σa σb : Float) :
     (freeConvolve (rTransformSemicircle σa) (rTransformSemicircle σb)).coeff =
     (freeConvolve (rTransformSemicircle σb) (rTransformSemicircle σa)).coeff := by
-  unfold freeConvolve rTransformSemicircle
-  ring
+  -- Goal reduces to σa + σb = σb + σa; `ring` is a Mathlib tactic and this
+  -- tree is Mathlib-free, so we use the IEEE-754 additive-commutativity axiom
+  -- (bit-exact for finite non-NaN).
+  show σa + σb = σb + σa
+  exact Sounio.HessianAD.float_add_comm_ax σa σb
 
 -- ---------------------------------------------------------------------------
 -- §5. Summary

--- a/formal/GradientTopologyBridge.lean
+++ b/formal/GradientTopologyBridge.lean
@@ -444,7 +444,6 @@ instance instDual2FieldNat : Dual2Field Nat where
   add_zero := Nat.add_zero
   add_comm := Nat.add_comm
   mul_comm := Nat.mul_comm
-  mul_assoc := Nat.mul_assoc
 
 /-- The `proj_a` callee as an abstract Dual2 operator: returns its first
     argument, discards the second.  Models `fn proj_a(a, b) = a` which is
@@ -1120,15 +1119,18 @@ axioms that are bit-exact for finite non-NaN values (`float_zero_add_ax`,
 `F.zero_add`, and the reified Dual2 evaluation threads through
 `dual2Add` only.
 
-However, `#print axioms canary_gtt_corresponds_float` reports the full
-seven-axiom set because Lean's dependency tracker traces every field
-of the `Dual2Field Float` instance bundle, including the four mul-laws
-that are never exercised along this witness.  This is a Lean
-bookkeeping artifact, not a semantic reliance: the `float_mul_assoc_ax`
-trust boundary is never applied inside the proof steps, only sitting
-unused in the instance record.  A typeclass refactor that splits
-`Dual2AddField` out of `Dual2Field` would tighten the reported
-footprint to match the semantic one; deferred.
+Since the `mul_assoc` law was removed from the `Dual2Field` base class
+(it is FALSE for IEEE-754 and was the sole false axiom in this path),
+`#print axioms` for the Float canaries now reports only true axioms
+(`propext`/`Classical.choice` plus the sound additive/commutative/
+identity float facts).  The reported footprint therefore matches the
+semantic one: these bridge witnesses are EXACT over `Float`, not
+ε-bounded.  Associativity, when genuinely needed (the unary
+transcendental Hessian-symmetry theorem `symmetric_apply_unary`), is
+now supplied as an explicit per-call hypothesis rather than asserted
+for every Float value — making the exactness condition visible at the
+use site.  (This resolves the previously-deferred `Dual2Field`
+typeclass split.)
 -/
 
 /-- Full-seed environment on `Float`.  Structural twin of `seedEnvNat`;

--- a/formal/HessianAD.lean
+++ b/formal/HessianAD.lean
@@ -64,7 +64,12 @@ class Dual2Field (α : Type) extends Add α, Mul α where
   add_zero   : ∀ a : α, a + zero = a
   add_comm   : ∀ a b : α, a + b = b + a
   mul_comm   : ∀ a b : α, a * b = b * a
-  mul_assoc  : ∀ a b c : α, (a * b) * c = a * (b * c)
+-- [audit] `mul_assoc` is intentionally NOT a base-class field: it is FALSE
+-- for IEEE-754 Float. It is required by exactly one theorem
+-- (`symmetric_apply_unary`), which takes it as an explicit hypothesis — making
+-- the exactness condition visible at the use site instead of asserting a false
+-- law for every `Dual2Field Float` value. Exact ground rings (ℚ/ℤ/Nat) supply
+-- it trivially; Float supplies it only in the rounding-free regime.
 
 variable {α : Type} [F : Dual2Field α]
 
@@ -231,15 +236,25 @@ theorem symmetric_mul (a b : Dual2 α)
   rw [F.add_comm (a.grad j * b.grad k) (a.grad k * b.grad j)]
 
 /-- The unary chain rule preserves symmetry — soundness of the
-    transcendental Hessian emission path. -/
+    transcendental Hessian emission path.
+
+    EXACTNESS HYPOTHESIS `hassoc`: multiplication associativity on the
+    relevant α-values.  This is the precise condition under which the
+    transcendental Hessian is *exact*.  It holds unconditionally over any
+    associative ground ring (ℚ/ℤ/Nat).  Over IEEE-754 `Float` it holds in
+    the rounding-free regime (integer/dyadic operands whose triple products
+    are representable, or a power-of-two factor), so we expose it as an
+    explicit hypothesis rather than baking a false law into the
+    `Dual2Field Float` instance. -/
 theorem symmetric_apply_unary (fv fp fpp : α) (g : Dual2 α)
-    (hg : Symmetric g) :
+    (hg : Symmetric g)
+    (hassoc : ∀ a b c : α, (a * b) * c = a * (b * c)) :
     Symmetric (dual2ApplyUnary fv fp fpp g) := by
   intro j k
   simp only [dual2ApplyUnary]
   rw [hg j k]
   congr 1
-  rw [F.mul_assoc, F.mul_comm (g.grad j) (g.grad k), ← F.mul_assoc]
+  rw [hassoc, F.mul_comm (g.grad j) (g.grad k), ← hassoc]
 
 -- ---------------------------------------------------------------------------
 -- §8. Constant-propagation identities
@@ -455,9 +470,12 @@ is tightened to equality on the body-precision fragment, so on that fragment
   its values in `Knowledge<T>` before arithmetic silently loses Hessian
   information.  The current Phase 1 stdlib function `gum_second_order_variance`
   assumes the caller operates on `.value` directly (as shown in the tests).
-- **Non-associative algebras**: `dual2Mul` assumes `mul_assoc` (Dual2Field axiom).
-  For non-associative types (octonions, sedenions, matrices), the bilinear
-  product rule is invalid.  Phase 2 introduces a compile-time gate at
+- **Non-associative algebras**: the symmetry of the unary transcendental
+  Hessian (`symmetric_apply_unary`) requires `mul_assoc`, taken as an
+  EXPLICIT per-call hypothesis (no longer a `Dual2Field` class axiom).
+  For non-associative types (octonions, sedenions, matrices) — and for
+  IEEE-754 Float outside the rounding-free regime — that hypothesis is
+  unavailable, so the bilinear product rule is invalid.  Phase 2 introduces a compile-time gate at
   `lean_single.sio:11803` to refuse propagation unless `@reassoc(fano)` is
   annotated — but note: the gate is annotation-based and provides no Lean-level
   defence against false-positive annotation.  Incorrect annotation produces
@@ -467,13 +485,15 @@ is tightened to equality on the body-precision fragment, so on that fragment
 
 ## Axioms used
 
-None inside §1-§10.  The §11 Float instance axiomatises seven
+None inside §1-§10.  The §11 Float instance axiomatises SIX
 IEEE-754 arithmetic laws (`float_zero_mul_ax`, `float_mul_zero_ax`,
 `float_zero_add_ax`, `float_add_zero_ax`, `float_add_comm_ax`,
-`float_mul_comm_ax`, `float_mul_assoc_ax`) to discharge the
-`Dual2Field Float` instance.  The first five are exact for finite
-non-NaN values; `float_mul_comm_ax` is approximate; `float_mul_assoc_ax`
-is the trust-boundary axiom (false in general floats).
+`float_mul_comm_ax`) to discharge the `Dual2Field Float` instance.
+All six hold for finite non-NaN values (the additive/commutative/
+identity facts bit-exactly; the sign-of-zero products up to ±0).
+The false `mul_assoc` law is deliberately NOT axiomatised: it was the
+only IEEE-754-false axiom, is required by exactly one theorem, and is
+now an explicit hypothesis there.
 -/
 
 -- ---------------------------------------------------------------------------
@@ -490,23 +510,25 @@ multiplication (classic counterexample: `(1e20 * 1e-20) * 1e20 = 1e20`
 but `1e20 * (1e-20 * 1e20) = 1e40` under double precision) and does not
 respect `zero_add`/`add_comm` on NaN payloads.
 
-We declare seven arithmetic axioms below:
+We declare six arithmetic axioms below (and deliberately omit `mul_assoc`):
 
   * Three hold *exactly* for finite non-NaN values — IEEE-754 addition
     with `0.0` and commutative addition are bit-exact (`zero_add`,
     `add_zero`, `add_comm`).
-  * Four are *approximate* for finite non-NaN — `zero_mul`, `mul_zero`,
-    `mul_comm` hold with caveats for signed zero and under/overflow;
-    `mul_assoc` is the fundamental numerical-analysis trust boundary,
-    false in general for finite floats.
+  * Three are *near-exact* for finite non-NaN — `zero_mul`, `mul_zero`,
+    `mul_comm`; commutativity is bit-exact, the zero-products up to the
+    sign of zero (±0).
+  * `mul_assoc` is OMITTED entirely: it is the fundamental
+    numerical-analysis trust boundary, false in general for finite
+    floats, so it is never asserted as a law for Float.
 
-For the add-only body-precision canary (`GradientTopologyBridge §14c`),
-only the three exact axioms are exercised.  For consumers that use
-`dual2Mul` over Float (e.g. `SecondOrderGUM` product-rule proofs) the
-full seven-axiom set is exercised and the `mul_assoc` trust boundary
-applies.
+For the add-only body-precision canary (`GradientTopologyBridge §14c`)
+and the `dual2Mul` product-rule symmetry (`symmetric_mul`, which uses
+only `add_comm`), the proofs are EXACT over Float.  The one result that
+needs associativity (`symmetric_apply_unary`) takes it as an explicit
+hypothesis, so no Float consumer silently relies on a false law.
 
-These seven axioms match the convention adopted across numerical PL
+These six axioms match the convention adopted across numerical PL
 verification work (CompCert's Float model, LLVM's real-number axioms).
 They are intended to be discharged by a future Mathlib-backed proof path
 that routes Float arithmetic through `Real`-valued counterparts under
@@ -535,22 +557,21 @@ axiom float_add_comm_ax (a b : Float) : a + b = b + a
 /-- Float multiplication is commutative (approximate for finite non-NaN). -/
 axiom float_mul_comm_ax (a b : Float) : a * b = b * a
 
-/-- Float multiplication is associative.  **Trust boundary** — false in
-    general for finite floats; accepted as a numerical-PL axiom. -/
-axiom float_mul_assoc_ax (a b c : Float) : (a * b) * c = a * (b * c)
 
-/-- `Float` satisfies the `Dual2Field` interface.  `noncomputable` because
-    the algebraic laws are declared via the axioms above rather than
-    computed from IEEE-754 bit semantics. -/
+/-- `Float` satisfies the (associativity-free) `Dual2Field` interface.
+    `noncomputable` because the laws are declared via the kept IEEE-754
+    axioms — all true for finite non-NaN binary64: additive/multiplicative
+    commutativity and identities, and the sign-of-zero facts.  `mul_assoc`
+    is deliberately absent (false for IEEE-754); the one theorem needing it
+    (`symmetric_apply_unary`) takes it as an explicit per-call hypothesis. -/
 noncomputable instance instDual2FieldFloat : Dual2Field Float where
-  zero := 0.0
-  one := 1.0
+  zero     := 0.0
+  one      := 1.0
   zero_mul := float_zero_mul_ax
   mul_zero := float_mul_zero_ax
   zero_add := float_zero_add_ax
   add_zero := float_add_zero_ax
   add_comm := float_add_comm_ax
   mul_comm := float_mul_comm_ax
-  mul_assoc := float_mul_assoc_ax
 
 end Sounio.HessianAD

--- a/formal/NonAssocHessian.lean
+++ b/formal/NonAssocHessian.lean
@@ -264,7 +264,10 @@ axiom decidable_fano :
     shadow computation is Fano-lawful.  This is the user trust boundary
     Kimi 2.6 flagged; a future phase could replace this axiom with a
     decidable, compile-time-verifiable Fano-annotation check. -/
-axiom annotation_asserts_fano : True  -- placeholder — annotation is unverified
+-- [audit] was `axiom ... : True` (a no-op masquerading as a verified anchor).
+-- Now a proved triviality so it no longer appears in `#print axioms`. The
+-- substantive Fano-annotation check remains genuinely unverified (see docstring).
+theorem annotation_asserts_fano : True := trivial
 
 -- ---------------------------------------------------------------------------
 -- §8. Summary

--- a/scripts/ci/no_false_float_axioms.sh
+++ b/scripts/ci/no_false_float_axioms.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# CI gate: forbid exact associativity/distributivity axioms over Float.
+# These are FALSE for IEEE-754 (rounding/overflow) and silently weaken any
+# Float-instantiated theorem. Float arithmetic must go through the RNE-bounded
+# model in SounioIEEE754Spec / the BoundedOrderedCarrier (Higham 2002 §2.1).
+set -euo pipefail
+ROOT="${1:-formal}"
+# Forbidden: an `axiom` whose statement asserts exact (a*b)*c=a*(b*c),
+# (a+b)+c=a+(b+c), or a*(b+c)=a*b+a*c over Float.
+hits=$(grep -rnE '^[[:space:]]*axiom[[:space:]]+[A-Za-z_.]*[[:space:]]*\([^)]*Float[^)]*\)[[:space:]]*:[[:space:]]*' "$ROOT" --include='*.lean' \
+  | grep -E '\(a \* b\) \* c = a \* \(b \* c\)|a \+ b \+ c = a \+ \(b \+ c\)|a \* \(b \+ c\) = a \* b \+ a \* c' || true)
+if [ -n "$hits" ]; then
+  echo "FAIL: false exact Float algebra axiom(s) detected:" >&2
+  echo "$hits" >&2
+  exit 1
+fi
+echo "OK: no false exact Float algebra axioms."


### PR DESCRIPTION
## Summary
Removes four false IEEE-754 *exact* algebra axioms from the Lean trust base and replaces the single real use of multiplicative associativity with an explicit, per-call hypothesis. `Float` gets a **sound** `Dual2Field` instance, and the §14c–§14f bridge canaries become **exact** (their `#print axioms` reports only true axioms).

## Root cause
`mul_assoc` — `(a*b)*c = a*(b*c)` — is **false** for IEEE-754 binary64 (overflow refutes it), yet it sat in the `Dual2Field` / `EpistemicField` `Float` instances as an asserted "trust-boundary" law. It is actually used by exactly **one** theorem in the whole build path: `symmetric_apply_unary` (unary transcendental Hessian symmetry), which has no callers. Every other `Float` result (additive footprints, the bridge canaries, the binary product-rule symmetry `symmetric_mul`, which needs only `add_comm`) is exact without it.

## Changes
- **formal/Epistemic.lean** — drop `float_add_assoc`, `float_mul_assoc`, `float_mul_add` and the `EpistemicField Float` instance that discharged them.
- **formal/HessianAD.lean** — remove `mul_assoc` from the `Dual2Field` base class; re-add a sound `Dual2Field Float` instance (six laws true for finite non-NaN); `symmetric_apply_unary` now takes associativity as an **explicit hypothesis**, making the exactness condition visible at the use site.
- **formal/GradientTopologyBridge.lean** — drop the now-invalid `mul_assoc` field from `instDual2FieldNat`; Float canaries are now exact; resolve the previously-deferred typeclass-split note.
- **formal/NonAssocHessian.lean** — `annotation_asserts_fano` no-op axiom → proved triviality (no longer appears in `#print axioms`).
- **scripts/ci/no_false_float_axioms.sh** — CI gate forbidding reintroduction of exact Float algebra axioms.

## Verification
Lean 4.30.0-rc2, Mathlib-free. `HessianAD`, `Epistemic`, `GradientTopologyBridge`, `NonAssocHessian`, `SecondOrderGUM`, `TropicalEpistemic` all compile. `#print axioms` on the Float canaries and the abstract trust base contain no `float_mul_assoc` and no `sorry`. Axiom count **71 → 66**. `SecondOrderGUM` is unchanged vs `main` (its generic-at-Float proofs compile against the sound instance). CI gate passes.


---

## Attached: pre-existing toolchain-drift repairs (added to this PR)

Two files that were already failing to build under Lean 4.30.0-rc2 (Mathlib-free), unrelated to the axiom change — neither references `Dual2Field`/`mul_assoc`:

- **FreeConvolveRTransform.lean** — `ring` (Mathlib) → `float_add_comm_ax`; `simp [Float.mul_def]` (nonexistent; opaque `Float` has no `DecidableEq`) → Bool `==` test vector via `native_decide`; `m4_wigner_vs_gaussian` ∀-form is false over `Float` under overflow → restated as a finite decidable witness (general proof belongs to the RNE-bounded real model).
- **CliffordGradeExact.lean** — `omega` is unusable on `Grade` (abbrev `Nat`) atoms here and `split_ifs` is Mathlib; both proofs rewritten with explicit `Nat` core lemmas via defeq.

Both build green (no error, no `sorry`).