### PR TITLE
fix(codegen): correct f64 comparisons + array-element & var-alias typing

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1703,6 +1703,28 @@ fn lowerer_mark_local_ref_mut(
     }
 }
 
+// *mut analogue of bind_local_array_elem_float: record that a local/param array has
+// f64 elements, so `arr[i]` reads classify as float in arithmetic/comparisons. Single-
+// level store through the Box (safe under the by-value-aggregate miscompile). The
+// value-returning `(*lo) = (*lo).bind_local_array_elem_float(name)` form silently
+// dropped this update for f64 ARRAY PARAMS (local arrays thread `lo` by value and were
+// unaffected) — so `acf[i] + acf[j]` over an f64 array param fell to the integer path.
+fn lowerer_mark_local_array_elem_float_mut(
+    lo: &! Lowerer,
+    name: Name
+) with Mut, Alloc, Panic, Div {
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).array_elem_float[i as usize] = 1
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
+    }
+}
+
 // *mut analogue of bind_local_struct_type: record a local/param's struct type so
 // `recv.method()` and `recv.field` resolve the receiver type. Single-level store through
 // the Box (safe under the by-value-aggregate miscompile). No-op for non-struct types.
@@ -1813,7 +1835,7 @@ fn lowerer_lower_fn_params_mut(
                     lowerer_mark_local_ref_mut(lo, (*list).head.name)
                 }
                 if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
-                    (*lo) = (*lo).bind_local_array_elem_float((*list).head.name)
+                    lowerer_mark_local_array_elem_float_mut(lo, (*list).head.name)
                 }
                 current = &(*list).tail
             }
@@ -2120,6 +2142,15 @@ fn lower_type_expr_is_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
 }
 
 fn lower_type_expr_is_array_of_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
+    // Unwrap a single reference layer: `&[f64; N]` / `&![f64; N]` params (arrays passed
+    // by reference — slice/linalg/matvec helpers) are arrays-of-f64 for element float
+    // typing. Without this, `a[i] * b[i]` over such params fell to the integer path.
+    if (*te).kind == TypeExprKind::TypeReference || (*te).kind == TypeExprKind::TypeRefMut {
+        match (*te).inner {
+            Some(inner_ty) => return lower_type_expr_is_array_of_f64(&(*inner_ty)),
+            None => return false,
+        }
+    }
     if (*te).kind != TypeExprKind::TypeArray { return false }
     match (*te).inner {
         Some(inner_ty) => lower_type_expr_is_f64(&(*inner_ty)),
@@ -6412,7 +6443,30 @@ impl Lowerer {
         var lo = pair.0
         lo.allow_direct_capturing_closure_literal = false
         let reg = pair.1
-        lo = lo.bind_local(s.name, reg, is_mut)
+        // A `var` initialized from a bare identifier must own its storage. An ident
+        // lowers to the SOURCE local's register (lookup_local returns it directly), so
+        // binding the var to `reg` aliases them onto the same vreg/stack slot — a later
+        // `y = ...` then clobbers the source `x`, and reads of `x` return y's value.
+        // This corrupted `var y = x; ... y = f(y, x)` patterns (e.g. Newton's method
+        // `y = 0.5*(y + x/y)`, which drifted to sqrt(garbage) once x was overwritten).
+        // Computed initializers already yield a fresh dst reg, so only the bare-ident
+        // case needs an explicit copy into a fresh register.
+        var bind_reg = reg
+        if is_mut {
+            match s.expr {
+                Some(rhs_ident) => {
+                    if (*rhs_ident).kind == ExprKind::ExprIdent {
+                        let copy_pair = lo.fresh_reg()
+                        lo = copy_pair.0
+                        let copy_reg = copy_pair.1
+                        lo = lo.emit(ir_copy(copy_reg, reg))
+                        bind_reg = copy_reg
+                    }
+                }
+                _ => {}
+            }
+        }
+        lo = lo.bind_local(s.name, bind_reg, is_mut)
         // Closures step 2: if the RHS was a capturing closure, mark this local so a later
         // `name(args)` call injects the captured regs (direct call to the synthetic fn).
         if lo.pending_closure_fn_id >= 0 {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6142,15 +6142,19 @@ fn nc_emit_core_binop(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64
     let rhs_float_marked = (flags / 4) & 1
     let lhs_known_int = if lhs >= 0 && lhs < 512 && (*nc).is_float_reg[lhs as usize] == 2 { 1 } else { 0 }
     let rhs_known_int = if rhs >= 0 && rhs < 512 && (*nc).is_float_reg[rhs as usize] == 2 { 1 } else { 0 }
-    // Path-sound float override: for arithmetic ops, also count an operand as float
-    // when the fixpoint typing (nc_compute_float_types) proved its register is a
-    // pure FLOAT — every reaching definition is float. This rescues f64 params /
-    // f64-derived intermediates that the lowering imm_flags bits miss (their idents
-    // classify via scalar_kind, unset for f64 params). Bitwise/shift/compare never
-    // override; they stay on the old marker-only path.
+    // Path-sound float override: for arithmetic AND comparison ops, also count an
+    // operand as float when the fixpoint typing (nc_compute_float_types) proved its
+    // register is a pure FLOAT — every reaching definition is float. This rescues
+    // f64 params / f64-derived intermediates that the lowering imm_flags bits miss
+    // (their idents classify via scalar_kind, unset for f64 params). Comparisons
+    // MUST be included: an f64 compare left on the integer path mis-orders negatives
+    // (the sign bit makes -2.0's bits compare ABOVE -1.0's) and mishandles
+    // `param == literal`. Bitwise/shift never override; they stay marker-only.
     let op_is_arith = if op == BinaryOp::OpAdd || op == BinaryOp::OpSub || op == BinaryOp::OpMul || op == BinaryOp::OpDiv { 1 } else { 0 }
-    let lhs_typed_float = if op_is_arith == 1 && lhs >= 0 && lhs < 512 && (*nc).reg_type[lhs as usize] == 1 { 1 } else { 0 }
-    let rhs_typed_float = if op_is_arith == 1 && rhs >= 0 && rhs < 512 && (*nc).reg_type[rhs as usize] == 1 { 1 } else { 0 }
+    let op_is_compare = if op == BinaryOp::OpLt || op == BinaryOp::OpLe || op == BinaryOp::OpGt || op == BinaryOp::OpGe || op == BinaryOp::OpEq || op == BinaryOp::OpNe { 1 } else { 0 }
+    let op_wants_float_typing = if op_is_arith == 1 || op_is_compare == 1 { 1 } else { 0 }
+    let lhs_typed_float = if op_wants_float_typing == 1 && lhs >= 0 && lhs < 512 && (*nc).reg_type[lhs as usize] == 1 { 1 } else { 0 }
+    let rhs_typed_float = if op_wants_float_typing == 1 && rhs >= 0 && rhs < 512 && (*nc).reg_type[rhs as usize] == 1 { 1 } else { 0 }
     let lhs_is_float = if (lhs_float_marked == 1 || lhs_typed_float == 1) && lhs_known_int == 0 { 1 } else { 0 }
     let rhs_is_float = if (rhs_float_marked == 1 || rhs_typed_float == 1) && rhs_known_int == 0 { 1 } else { 0 }
     if lhs_is_float == 1 || rhs_is_float == 1 {

--- a/tests/run-pass/fcmp_f64_oracle_matrix.sio
+++ b/tests/run-pass/fcmp_f64_oracle_matrix.sio
@@ -1,0 +1,112 @@
+//@ run-pass
+//@ expect-stdout: FCMP_ORACLE_PASS
+
+// Oracle matrix for f64 comparison codegen.
+//
+// Pins the correct behavior of the six f64 comparison operators and is the
+// validation target for the native float comparison emit fix. The known native bug
+// is that an f64 comparison whose float path is taken can load a float operand with
+// cvtsi2sd instead of movq, corrupting the test; the result path is entangled with
+// that load. Every comparison here runs over f64 params across three operand sources
+// param vs param, param vs literal, and computed subtraction results over equal,
+// positive, negative, mixed sign, zero and fractional values, each asserted against
+// the mathematically correct answer. Correct under lean_single; the run-pass harness
+// requires the FCMP_ORACLE_PASS sentinel.
+
+fn lt(a: f64, b: f64) -> bool { a < b }
+fn le(a: f64, b: f64) -> bool { a <= b }
+fn gt(a: f64, b: f64) -> bool { a > b }
+fn ge(a: f64, b: f64) -> bool { a >= b }
+fn eq(a: f64, b: f64) -> bool { a == b }
+fn ne(a: f64, b: f64) -> bool { a != b }
+
+// param-vs-literal forms (the abs_f64 `x < 0.0` shape)
+fn lt0(x: f64) -> bool { x < 0.0 }
+fn le0(x: f64) -> bool { x <= 0.0 }
+fn gt0(x: f64) -> bool { x > 0.0 }
+fn ge0(x: f64) -> bool { x >= 0.0 }
+fn eq1(x: f64) -> bool { x == 1.0 }
+fn ne1(x: f64) -> bool { x != 1.0 }
+
+fn fsub(a: f64, b: f64) -> f64 { a - b }
+fn fabs(x: f64) -> f64 { if x < 0.0 { return 0.0 - x } return x }
+
+// Records one assertion: returns 1 on match, else prints "FAIL <id>" and returns 0.
+fn rec(got: bool, want: bool, id: i64) -> i64 with IO {
+    if got == want { return 1 }
+    print("FAIL ")
+    print_int(id)
+    print("\n")
+    return 0
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    var pass = 0
+    var total = 0
+
+    // --- param/param, all six operators, both outcomes ---
+    // equal operands (where an integer-bit hack can pass by luck)
+    total = total + 1; pass = pass + rec(lt(1.0, 1.0), false, 1)
+    total = total + 1; pass = pass + rec(le(1.0, 1.0), true, 2)
+    total = total + 1; pass = pass + rec(gt(1.0, 1.0), false, 3)
+    total = total + 1; pass = pass + rec(ge(1.0, 1.0), true, 4)
+    total = total + 1; pass = pass + rec(eq(1.0, 1.0), true, 5)
+    total = total + 1; pass = pass + rec(ne(1.0, 1.0), false, 6)
+
+    // positive ordering
+    total = total + 1; pass = pass + rec(lt(1.0, 2.0), true, 10)
+    total = total + 1; pass = pass + rec(gt(1.0, 2.0), false, 11)
+    total = total + 1; pass = pass + rec(le(2.0, 1.0), false, 12)
+    total = total + 1; pass = pass + rec(ge(2.0, 1.0), true, 13)
+
+    // negative ordering (bit pattern reversed vs magnitude)
+    total = total + 1; pass = pass + rec(lt(0.0 - 2.0, 0.0 - 1.0), true, 20)
+    total = total + 1; pass = pass + rec(gt(0.0 - 2.0, 0.0 - 1.0), false, 21)
+    total = total + 1; pass = pass + rec(le(0.0 - 1.0, 0.0 - 2.0), false, 22)
+    total = total + 1; pass = pass + rec(ge(0.0 - 1.0, 0.0 - 2.0), true, 23)
+
+    // mixed sign
+    total = total + 1; pass = pass + rec(gt(1.0, 0.0 - 1.0), true, 30)
+    total = total + 1; pass = pass + rec(lt(0.0 - 1.0, 1.0), true, 31)
+    total = total + 1; pass = pass + rec(eq(1.0, 0.0 - 1.0), false, 32)
+    total = total + 1; pass = pass + rec(ne(1.0, 0.0 - 1.0), true, 33)
+
+    // fractional
+    total = total + 1; pass = pass + rec(lt(0.1, 0.2), true, 40)
+    total = total + 1; pass = pass + rec(gt(0.3, 0.2), true, 41)
+    total = total + 1; pass = pass + rec(eq(0.3, 0.3), true, 42)
+
+    // --- param/literal (the `x < 0.0` shape) ---
+    total = total + 1; pass = pass + rec(lt0(0.0 - 2.0), true, 50)
+    total = total + 1; pass = pass + rec(lt0(2.0), false, 51)
+    total = total + 1; pass = pass + rec(gt0(2.0), true, 52)
+    total = total + 1; pass = pass + rec(gt0(0.0 - 2.0), false, 53)
+    total = total + 1; pass = pass + rec(le0(0.0), true, 54)
+    total = total + 1; pass = pass + rec(ge0(0.0), true, 55)
+    total = total + 1; pass = pass + rec(eq1(1.0), true, 56)
+    total = total + 1; pass = pass + rec(eq1(2.0), false, 57)
+    total = total + 1; pass = pass + rec(ne1(2.0), true, 58)
+
+    // --- computed operands (subtraction results fed into comparisons) ---
+    total = total + 1; pass = pass + rec(lt(fsub(3.0, 1.0), fsub(1.0, 3.0)), false, 60)
+    total = total + 1; pass = pass + rec(gt(fsub(3.0, 1.0), fsub(1.0, 3.0)), true, 61)
+    total = total + 1; pass = pass + rec(eq(fsub(2.0, 2.0), 0.0), true, 62)
+    total = total + 1; pass = pass + rec(lt(fsub(1.0, 1.0), 0.0), false, 63)
+
+    // --- abs pattern (the concrete regressing shape) ---
+    total = total + 1; pass = pass + rec(eq(fabs(0.0 - 2.0), 2.0), true, 70)
+    total = total + 1; pass = pass + rec(eq(fabs(2.0), 2.0), true, 71)
+    total = total + 1; pass = pass + rec(lt(fabs(fsub(1.0, 1.0)), 0.0001), true, 72)
+    total = total + 1; pass = pass + rec(lt(fabs(fsub(1.0, 2.0)), 0.0001), false, 73)
+
+    if pass == total {
+        println("FCMP_ORACLE_PASS")
+        return 0
+    }
+    print("FCMP_ORACLE_FAIL ")
+    print_int(pass)
+    print("/")
+    print_int(total)
+    print("\n")
+    return 1
+}


### PR DESCRIPTION
## Summary

Four related f64 codegen fixes (Madaros backend) that together unblock a cascade of tolerance-checked numerical tests a broken f64 comparison had been masking. `lean_single` was always correct; these fix the modular Madaros build.

1. **f64 comparison path-selection** (`native/codegen_x86_linux.sio`, `nc_emit_core_binop`): extend the `reg_type` float-typing gate from arithmetic-only to also cover comparison ops. f64 comparisons were left on the integer-bit path, which mis-orders negatives (the sign bit makes `-2.0`'s bits compare *above* `-1.0`'s) and mishandles `param == literal`. Now they take the SSE `ucomisd` path. **Oracle 33/38 → 38/38.**
2. **f64 array-PARAM element typing** (`ir/lower.sio`): the param summary path set the float-element flag via the value-return-through-`&!` form `(*lo) = (*lo).bind_local_array_elem_float(name)`, which the by-value-aggregate miscompile silently drops. Added `lowerer_mark_local_array_elem_float_mut` (in-place store through the Box). `acf[i]*acf[j]` over `[f64;N]` params now uses SSE instead of `idiv`.
3. **`&[f64;N]` ref-array params** (`ir/lower.sio`, `lower_type_expr_is_array_of_f64`): unwrap one reference layer so by-ref array params (slice/linalg helpers) are recognized as float-element arrays.
4. **var-alias** (`ir/lower.sio`, `lower_let_stmt_ref`): `var y = x` bound `y` to the *source* local's register (an ident lowers to its bound reg), aliasing them onto one stack slot — a later `y = ...` then clobbered `x`. Copy bare-ident `var` initializers into a fresh register. Fixed Newton's method `y = 0.5*(y + x/y)` drifting to `sqrt(garbage)`.

## Verification

**Sweep over 312 f64 run-pass tests (main vs fix): +13 improved, 0 regressions.** Improvements include the `fcmp` oracle, **`cranelift_geo_product_min`** and **`arima_levinson_ar2`** (both prior-session blockers), `slice_linalg_and_perms` (8/8), `autodiff_forward_basic`, `ode_rk4_harmonic`, `embed_octonion`, `matnm_test`, `wavelet_haar_roundtrip`, `special_functions`, `theorem_epistemic_monotonicity`.

Instruction-level confirmed (oracle: 6 integer `cmp` → `ucomisd`, `cvtsi2sd` corruptions removed; minimal repros disassembled to pin each bug). This **resolves the prior session's "comparison fix regresses arima" blocker** — that was the separate array-typing bug surfacing, not a compare miscompile.

Builds on the merged if-expr-merge fix (#539). Adds `tests/run-pass/fcmp_f64_oracle_matrix.sio` (38-case f64 comparison oracle).

## Out of scope (separate pre-existing Madaros f64 bugs, unmasked but not introduced)
Dissertation/PBPK heavy tests still fail/segfault on Madaros independent of this change (they don't pass on main either); a mixed `(f64, i32)` param ABI quirk was noted. Filed for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)