### PR TITLE
fix(ir): type f64-array-returning call results as float-element locals

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -664,7 +664,7 @@ fn lowerer_preseed_fn_signature_mut(
 
     let strategy = lowerer_compute_strategy_from_ast_ref(return_type, effects)
     (*(*lo).module).functions[fn_id as usize].compile_strategy = strategy
-    (*(*lo).module).functions[fn_id as usize].returns_float = if lower_opt_type_is_f64(return_type) { 1 } else { 0 }
+    (*(*lo).module).functions[fn_id as usize].returns_float = lower_opt_return_float_code(return_type)
     (*(*lo).module).functions[fn_id as usize].return_struct_name = lower_opt_type_named_name(return_type)
     (*(*lo).module).functions[fn_id as usize].param_count = ir_param_list_count_ref(params)
     if strategy == IR_STRATEGY_INSTRUMENTED {
@@ -965,7 +965,7 @@ fn lowerer_preseed_program_items_mut(
                                     var module_box_sig = (*lo).module
                                     var fn_slot_sig = (*module_box_sig).functions[fn_id_sig as usize]
                                     fn_slot_sig.compile_strategy = strategy_sig
-                                    fn_slot_sig.returns_float = if lower_opt_type_is_f64(&(*fd).return_type) { 1 } else { 0 }
+                                    fn_slot_sig.returns_float = lower_opt_return_float_code(&(*fd).return_type)
                                     fn_slot_sig.return_struct_name = lower_opt_type_named_name(&(*fd).return_type)
                                     fn_slot_sig.param_count = ir_param_list_count_ref(&(*fd).params)
                                     if strategy_sig == IR_STRATEGY_INSTRUMENTED {
@@ -1094,7 +1094,7 @@ fn ir_fast_summary_preseed_fn_signature(
     var module_value = (*module)
     let strategy = lowerer_compute_strategy_from_ast_ref(return_type, effects)
     module_value.functions[fn_id as usize].compile_strategy = strategy
-    module_value.functions[fn_id as usize].returns_float = if lower_opt_type_is_f64(return_type) { 1 } else { 0 }
+    module_value.functions[fn_id as usize].returns_float = lower_opt_return_float_code(return_type)
     module_value.functions[fn_id as usize].return_struct_name = lower_opt_type_named_name(return_type)
     module_value.functions[fn_id as usize].param_count = ir_param_list_count_ref(params)
     if strategy == IR_STRATEGY_INSTRUMENTED {
@@ -1218,7 +1218,7 @@ fn ir_fast_summary_preseed_fn_signature_owned(
     }
     let strategy = lowerer_compute_strategy_from_ast_ref(return_type, effects)
     module_value.functions[fn_id as usize].compile_strategy = strategy
-    module_value.functions[fn_id as usize].returns_float = if lower_opt_type_is_f64(return_type) { 1 } else { 0 }
+    module_value.functions[fn_id as usize].returns_float = lower_opt_return_float_code(return_type)
     module_value.functions[fn_id as usize].return_struct_name = lower_opt_type_named_name(return_type)
     module_value.functions[fn_id as usize].param_count = ir_param_list_count_ref(params)
     if strategy == IR_STRATEGY_INSTRUMENTED {
@@ -1523,7 +1523,7 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                             if fn_id >= 0 {
                                 let strategy = lowerer_compute_strategy_from_ast_ref(&(*fd).return_type, &(*fd).effects)
                                 module.functions[fn_id as usize].compile_strategy = strategy
-                                module.functions[fn_id as usize].returns_float = if lower_opt_type_is_f64(&(*fd).return_type) { 1 } else { 0 }
+                                module.functions[fn_id as usize].returns_float = lower_opt_return_float_code(&(*fd).return_type)
                                 module.functions[fn_id as usize].return_struct_name = lower_opt_type_named_name(&(*fd).return_type)
                                 module.functions[fn_id as usize].param_count = ir_param_list_count_ref(&(*fd).params)
                                 if strategy == IR_STRATEGY_INSTRUMENTED {
@@ -1608,7 +1608,7 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                                                     if fn_id >= 0 {
                                                         let strategy = lowerer_compute_strategy_from_ast_ref(&(*fd).return_type, &(*fd).effects)
                                                         module.functions[fn_id as usize].compile_strategy = strategy
-                                                        module.functions[fn_id as usize].returns_float = if lower_opt_type_is_f64(&(*fd).return_type) { 1 } else { 0 }
+                                                        module.functions[fn_id as usize].returns_float = lower_opt_return_float_code(&(*fd).return_type)
                                                         module.functions[fn_id as usize].return_struct_name = lower_opt_type_named_name(&(*fd).return_type)
                                                         module.functions[fn_id as usize].param_count = ir_param_list_count_ref(&(*fd).params)
                                                         if strategy == IR_STRATEGY_INSTRUMENTED {
@@ -1923,7 +1923,7 @@ fn lowerer_lower_fn_item_mut(
     } else {
         (*strategy_func_box).compile_strategy = strategy
     }
-    (*strategy_func_box).returns_float = if lower_opt_type_is_f64(&fd.return_type) { 1 } else { 0 }
+    (*strategy_func_box).returns_float = lower_opt_return_float_code(&fd.return_type)
     (*strategy_func_box).return_struct_name = lower_opt_type_named_name(&fd.return_type)
     (*lo).current_func = strategy_func_box
 
@@ -2176,6 +2176,21 @@ fn lower_opt_type_is_array_of_f64(opt: &Option<Box<TypeExpr>>) -> bool with Mut,
     match *opt {
         Some(te) => lower_type_expr_is_array_of_f64(&(*te)),
         None => false,
+    }
+}
+
+// returns_float classification for a declared return type: 1 = scalar f64, 2 = an
+// f64 array (`[f64; N]`), 0 = other. The `2` lets a caller's `let r = mk()` (mk
+// returning an f64 array) flag `r` as a float-element local, so `r[i]` reads
+// classify as float instead of taking the integer path (cvtsi2sd corruption).
+// All consumers test `== 1`, so the new `2` value is inert for the scalar path.
+fn lower_opt_return_float_code(opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
+    if lower_opt_type_is_f64(opt) {
+        1
+    } else if lower_opt_type_is_array_of_f64(opt) {
+        2
+    } else {
+        0
     }
 }
 
@@ -5352,7 +5367,7 @@ impl Lowerer {
         var func = (*lo.module).functions[fn_id as usize]
         func.name = name
         func.compile_strategy = strategy
-        func.returns_float = if lower_opt_type_is_f64(return_type) { 1 } else { 0 }
+        func.returns_float = lower_opt_return_float_code(return_type)
         func.return_struct_name = lower_opt_type_named_name(return_type)
         func.param_count = ir_param_list_count_ref(params)
         func.param_regs = [IR_INVALID_REG; 64]
@@ -5976,7 +5991,7 @@ impl Lowerer {
         } else {
             (*lo.current_func).compile_strategy = strategy
         }
-        (*lo.current_func).returns_float = if lower_opt_type_is_f64(&fd.return_type) { 1 } else { 0 }
+        (*lo.current_func).returns_float = lower_opt_return_float_code(&fd.return_type)
         (*lo.current_func).return_struct_name = lower_opt_type_named_name(&fd.return_type)
 
         // Sprint 44: allocate profiling counter for instrumented functions
@@ -6150,7 +6165,7 @@ impl Lowerer {
         } else {
             (*lo.current_func).compile_strategy = strategy
         }
-        (*lo.current_func).returns_float = if lower_opt_type_is_f64(&fd.return_type) { 1 } else { 0 }
+        (*lo.current_func).returns_float = lower_opt_return_float_code(&fd.return_type)
         (*lo.current_func).return_struct_name = lower_opt_type_named_name(&fd.return_type)
 
         if strategy == IR_STRATEGY_INSTRUMENTED {
@@ -6429,6 +6444,27 @@ impl Lowerer {
         self.lower_stmt_ref(&s)
     }
 
+    // True iff `e` is a call to a function whose declared return type is an f64 array
+    // (returns_float == 2, set by lower_opt_return_float_code). Used so `let r = mk()`
+    // flags `r` as a float-element local — otherwise `r[i]` reads classify as integer
+    // and get cvtsi2sd-corrupted in arithmetic/comparisons.
+    fn expr_result_is_f64_array_ref(self, e: &Expr) -> bool with Mut, Panic, Div, Alloc {
+        if (*e).kind != ExprKind::ExprCall {
+            return false
+        }
+        match (*e).left {
+            Some(callee_expr) => {
+                let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
+                let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
+                if fn_id >= 0 && fn_id < self.module.fn_count {
+                    return self.module.functions[fn_id as usize].returns_float == 2
+                }
+            }
+            _ => {}
+        }
+        false
+    }
+
     fn lower_let_stmt_ref(self, s: &Stmt, is_mut: bool) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
         var lhs_lo = self
         match s.expr {
@@ -6483,6 +6519,8 @@ impl Lowerer {
             match s.expr {
                 Some(expr_box_arr) => {
                     if lower_expr_is_f64_array_literal_ref(&(*expr_box_arr)) {
+                        lo = lo.bind_local_array_elem_float(s.name)
+                    } else if lo.expr_result_is_f64_array_ref(&(*expr_box_arr)) {
                         lo = lo.bind_local_array_elem_float(s.name)
                     }
                 }

--- a/tests/run-pass/f64_array_return_element.sio
+++ b/tests/run-pass/f64_array_return_element.sio
@@ -1,0 +1,28 @@
+//@ run-pass
+//@ expect-stdout: PASS
+//
+// Regression: an f64 array returned from a function, then indexed inline in an
+// expression, must type the element as float. `let r = mk()` (mk -> [f64;N])
+// previously left `r` untyped, so `r[i]` reads classified as integer and got
+// cvtsi2sd-corrupted in arithmetic/comparisons. The symptom: the 2nd inline read
+// of `r[0]` in `r[0] > a && r[0] < b` returned garbage (first read passed by luck).
+// Fixed by classifying f64-array returns (returns_float == 2) and flagging the
+// let-bound local as a float-element array. lean_single always compiled this.
+
+fn mk() -> [f64; 5] with Mut, Panic, Div {
+    var a: [f64; 5] = [0.0, 0.0, 0.0, 0.0, 0.0]
+    a[0] = 0.8
+    a[1] = 0.64
+    return a
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    let r = mk()
+    let c0 = if r[0] > 0.799 && r[0] < 0.801 { 1 } else { 0 }   // 0.8 in range
+    let c1 = if r[1] > 0.639 && r[1] < 0.641 { 1 } else { 0 }   // 0.64 in range
+    let s = r[0] + r[1]                                          // 1.44 (inline arithmetic)
+    let c2 = if s > 1.439 && s < 1.441 { 1 } else { 0 }
+    if c0 == 1 && c1 == 1 && c2 == 1 { println("PASS") return 0 }
+    println("FAIL")
+    return 1
+}


### PR DESCRIPTION
## Summary

`let r = mk()` where `mk` returns `[f64; N]` left `r` untyped, so `r[i]` read **inline** in an expression classified as integer and was `cvtsi2sd`-corrupted in arithmetic/comparisons. The 2nd inline read of `r[0]` in `r[0] > a && r[0] < b` returned garbage (the 1st passed by luck on positive values). The array return and values were correct — binding `r[0]` to a local, or passing it as an f64 arg, both worked — only the inline float-classification was missing.

Confirmed by disassembly of a minimal repro: `r[0]`'s value loaded then `cvtsi2sd %rax,%xmm0` instead of `movq`.

## Fix (`ir/lower.sio`)
- Classify an f64-array return type as `returns_float == 2` (new `lower_opt_return_float_code` helper applied at all 10 `returns_float` sites). Every consumer tests `== 1`, so the `2` is inert for the scalar-f64 path.
- `lower_let_stmt_ref` flags `let r = <f64-array-returning call>` as a float-element local (new `expr_result_is_f64_array_ref` predicate), so `r[i]` reads classify as float.

## Verification
Sweep over 312 f64 run-pass tests (main vs fix): **0 regressions** (incidental improvement: `gpu_kernel_basic` exits 0 instead of 3). Oracle / arima / slice still pass. Adds `tests/run-pass/f64_array_return_element.sio` (PASS on fix + lean_single, FAIL pre-fix).

Found while investigating the dissertation PBPK failures; note those are a **separate** cluster (multimodule native-emit compile failure for the smoke tests; a runtime struct-of-f64-array segfault for parity_ref) — this fixes a genuine adjacent bug, not those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)