### PR TITLE
[codex] Fall back when compact imported IR emit fails

### DIFF
--- a/self-hosted/compiler/module_native_driver.sio
+++ b/self-hosted/compiler/module_native_driver.sio
@@ -1171,11 +1171,20 @@ pub fn compile_multimodule_native_advanced(
     print("module_native_driver: imported source uses compact modular IR table path\n")
     let imported_ir_status = load_multimodule_imported_simple_ir_global(main_path)
     if imported_ir_status.ok {
-        return native_driver_write_imported_simple_ir_elf(output_path)
+        let simple_rc = native_driver_write_imported_simple_ir_elf(output_path)
+        if simple_rc == 0 {
+            return 0
+        }
+        print("module_native_driver: compact IR ELF write failed; rc=")
+        print_int(simple_rc)
+        print("; falling back to full IR path\n")
     }
-    print("module_native_driver: compact IR load failed: ")
-    print(imported_ir_status.error_msg)
-    print("\n")
+    if !imported_ir_status.ok {
+        print("module_native_driver: compact IR load failed; falling back to full IR path\n")
+        print("module_native_driver: compact IR load error: ")
+        print(imported_ir_status.error_msg)
+        print("\n")
+    }
 
     module_frontend_compile_imported_to_file(main_path, output_path)
 }

--- a/tests/run-pass/tmp_call_handle_repro.sio
+++ b/tests/run-pass/tmp_call_handle_repro.sio
@@ -1,0 +1,83 @@
+module tmp::call_handle_repro
+
+pub struct ExprList {
+    head: i64,
+    tail: Option<Box<ExprList> >,
+}
+
+pub struct FnParamList {
+    head: i64,
+    tail: Option<Box<FnParamList> >,
+}
+
+pub struct ExprListHandle {
+    ptr: *mut ExprList,
+}
+
+pub struct FnParamListHandle {
+    ptr: *mut FnParamList,
+}
+
+fn expr_list_handle(opt: Option<Box<ExprList> >) -> ExprListHandle with Mut, Panic, Div, Alloc {
+    match opt {
+        Some(list) => ExprListHandle { ptr: list as *mut ExprList }
+        None => ExprListHandle { ptr: 0 as *mut ExprList }
+    }
+}
+
+fn expr_list_handle_next(h: ExprListHandle) -> ExprListHandle with Mut, Panic, Div {
+    if h.ptr == 0 as *mut ExprList {
+        ExprListHandle { ptr: 0 as *mut ExprList }
+    } else {
+        match (*h.ptr).tail {
+            Some(next) => ExprListHandle { ptr: next as *mut ExprList }
+            None => ExprListHandle { ptr: 0 as *mut ExprList }
+        }
+    }
+}
+
+fn fn_param_list_handle(opt: Option<Box<FnParamList> >) -> FnParamListHandle with Mut, Panic, Div, Alloc {
+    match opt {
+        Some(list) => FnParamListHandle { ptr: list as *mut FnParamList }
+        None => FnParamListHandle { ptr: 0 as *mut FnParamList }
+    }
+}
+
+fn fn_param_list_handle_get(h: FnParamListHandle, idx: i64) -> i64 with Mut, Panic, Div {
+    var current = h
+    var i = idx
+    while current.ptr != 0 as *mut FnParamList {
+        if i == 0 {
+            return (*current.ptr).head
+        }
+        match (*current.ptr).tail {
+            Some(next) => {
+                current = FnParamListHandle { ptr: next as *mut FnParamList }
+                i = i - 1
+            }
+            None => break
+        }
+    }
+    0
+}
+
+fn checker_check_call_args_inplace(args: ExprListHandle, params: FnParamListHandle, expected_count: i64) -> i64 with Mut, Panic, Div {
+    var current = args
+    var idx: i64 = 0
+    while current.ptr != 0 as *mut ExprList {
+        let _param = fn_param_list_handle_get(params, idx)
+        let _arg = (*current.ptr).head
+        current = expr_list_handle_next(current)
+        idx = idx + 1
+    }
+    if idx != expected_count {
+        return -1
+    }
+    0
+}
+
+fn main() with Mut, Panic, Div, Alloc {
+    let args = None
+    let params = None
+    let _ = checker_check_call_args_inplace(expr_list_handle(args), fn_param_list_handle(params), 0)
+}

--- a/tests/run-pass/tmp_call_path_repro.sio
+++ b/tests/run-pass/tmp_call_path_repro.sio
@@ -1,0 +1,99 @@
+module tmp::call_path_repro
+
+pub struct ExprList {
+    head: i64,
+    tail: Option<Box<ExprList> >,
+}
+
+pub struct FnParamList {
+    head: i64,
+    tail: Option<Box<FnParamList> >,
+}
+
+pub struct ExprListHandle {
+    ptr: *mut ExprList,
+}
+
+pub struct FnParamListHandle {
+    ptr: *mut FnParamList,
+}
+
+fn expr_list_handle(opt: Option<Box<ExprList> >) -> ExprListHandle with Mut, Panic, Div, Alloc {
+    match opt {
+        Some(list) => ExprListHandle { ptr: list as *mut ExprList }
+        None => ExprListHandle { ptr: 0 as *mut ExprList }
+    }
+}
+
+fn expr_list_handle_next(h: ExprListHandle) -> ExprListHandle with Mut, Panic, Div {
+    if h.ptr == 0 as *mut ExprList {
+        ExprListHandle { ptr: 0 as *mut ExprList }
+    } else {
+        match (*h.ptr).tail {
+            Some(next) => ExprListHandle { ptr: next as *mut ExprList }
+            None => ExprListHandle { ptr: 0 as *mut ExprList }
+        }
+    }
+}
+
+fn fn_param_list_handle(opt: Option<Box<FnParamList> >) -> FnParamListHandle with Mut, Panic, Div, Alloc {
+    match opt {
+        Some(list) => FnParamListHandle { ptr: list as *mut FnParamList }
+        None => FnParamListHandle { ptr: 0 as *mut FnParamList }
+    }
+}
+
+fn fn_param_list_handle_get(h: FnParamListHandle, idx: i64) -> i64 with Mut, Panic, Div {
+    var current = h
+    var i = idx
+    while current.ptr != 0 as *mut FnParamList {
+        if i == 0 {
+            return (*current.ptr).head
+        }
+        match (*current.ptr).tail {
+            Some(next) => {
+                current = FnParamListHandle { ptr: next as *mut FnParamList }
+                i = i - 1
+            }
+            None => break
+        }
+    }
+    0
+}
+
+fn checker_check_call_args_inplace(args: ExprListHandle, params: FnParamListHandle, expected_count: i64) -> i64 with Mut, Panic, Div {
+    var current = args
+    var idx: i64 = 0
+    while current.ptr != 0 as *mut ExprList {
+        let _param = fn_param_list_handle_get(params, idx)
+        let _arg = (*current.ptr).head
+        current = expr_list_handle_next(current)
+        idx = idx + 1
+    }
+    if idx != expected_count {
+        return -1
+    }
+    0
+}
+
+fn checker_release_call_arg_borrows_inplace(args: Option<Box<ExprList> >, params: Option<Box<FnParamList> >) -> i64 with Mut, Panic, Div {
+    match args {
+        None => 0
+        Some(list) => {
+            match params {
+                None => 0
+                Some(param_list) => {
+                    let _head = (*param_list).head
+                    checker_release_call_arg_borrows_inplace((*list).tail, (*param_list).tail)
+                }
+            }
+        }
+    }
+}
+
+fn main() with Mut, Panic, Div, Alloc {
+    let args = None
+    let params = None
+    let _ = checker_check_call_args_inplace(expr_list_handle(args), fn_param_list_handle(params), 0)
+    let _ = checker_release_call_arg_borrows_inplace(args, params)
+}

--- a/tests/run-pass/tmp_mono_repro.sio
+++ b/tests/run-pass/tmp_mono_repro.sio
@@ -1,0 +1,53 @@
+module tmp::mono_repro
+
+use parser::ast::{Name, empty_name}
+
+pub struct MiniList {
+    head: Name,
+    tail: Option<Box<MiniList>>,
+}
+
+pub struct MiniBuf {
+    names: [Name; 8],
+    count: i64,
+}
+
+fn mini_clone(list: Option<Box<MiniList>>) -> Option<Box<MiniList>> with Mut, Panic, Div, Alloc {
+    match list {
+        None => None
+        Some(node) => {
+            let head = (*node).head
+            let tail = mini_clone((*node).tail)
+            Some(Box::new(MiniList { head: head, tail: tail }))
+        }
+    }
+}
+
+fn mini_walk(list: Option<Box<MiniList>>, buf: MiniBuf) -> Option<Box<MiniList>> with Mut, Panic, Div, Alloc {
+    match list {
+        None => None
+        Some(node) => {
+            let _first = buf.names[0]
+            let next = mini_walk((*node).tail, buf)
+            Some(Box::new(MiniList { head: (*node).head, tail: next }))
+        }
+    }
+}
+
+fn mini_mono(list: Option<Box<MiniList>>, buf: MiniBuf) -> Option<Box<MiniList>> with Mut, Panic, Div, Alloc {
+    match list {
+        None => None
+        Some(node) => {
+            let cloned = mini_clone((*node).tail)
+            let walked = mini_walk(cloned, buf)
+            Some(Box::new(MiniList { head: (*node).head, tail: walked }))
+        }
+    }
+}
+
+fn main() with Mut, Panic, Div, Alloc {
+    let n0 = empty_name()
+    let buf = MiniBuf { names: [n0; 8], count: 0 }
+    let list = None
+    let _ = mini_mono(list, buf)
+}


### PR DESCRIPTION
## Summary
- fall back to the full imported IR path when compact imported IR ELF emission returns non-zero
- add three focused run-pass repros for the imported-source call/mono paths
- keep the compact path as the fast path when it succeeds

## Evidence
- on current `origin/main` (`17cb849a1`), `bin/madaros build tests/run-pass/tmp_mono_repro.sio` reaches `module_native_driver: imported source uses compact modular IR table path` and then fails with `Native compilation failed: imported_simple_ir_emit_failed`
- on current `origin/main`, `tmp_call_handle_repro` and `tmp_call_path_repro` check/build successfully once their `main` functions declare the required effects
- comparing `self-hosted/compiler/module_native_driver.sio` against the known-good project-spine worktree showed one semantic difference at this failure site: the good lane falls back to `module_frontend_compile_imported_to_file(...)` when compact IR ELF emission fails, while current main returns the failure directly

## Local validation
- passed: `bin/madaros check tests/run-pass/tmp_call_handle_repro.sio`
- passed: `bin/madaros check tests/run-pass/tmp_call_path_repro.sio`
- passed: `bin/madaros check tests/run-pass/tmp_mono_repro.sio`
- passed: `bin/madaros build tests/run-pass/tmp_call_handle_repro.sio -o /tmp/tmp_call_handle_repro_fixed.bin`
- passed: `bin/madaros build tests/run-pass/tmp_call_path_repro.sio -o /tmp/tmp_call_path_repro_fixed.bin`
- reproduced current-main failure before this patch: `bin/madaros build tests/run-pass/tmp_mono_repro.sio -o /tmp/tmp_mono_repro.bin` -> `imported_simple_ir_emit_failed`

## Caveat
A local rebuild of Madaros from source for direct post-patch runtime proof is currently blocked in this workspace by a separate source-build issue in `self-hosted/compiler/module_frontend.sio` (`unknown field access` during seed compilation). That is why this PR is draft and leans on CI for the decisive validation.