### PR TITLE
Fix modular Madaros source rebuild user-main restore

### DIFF
--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1753,7 +1753,6 @@ fn ir_module_restore_user_main_calls(module: IrModule, user_main: IrFunction) ->
     slot.is_sret = user_main.is_sret
     slot.sret_dest_reg = user_main.sret_dest_reg
     slot.bss_size = user_main.bss_size
-    slot.had_overflow = user_main.had_overflow
     var pi: i64 = 0
     while pi < user_main.param_count && pi < IR_MAX_PARAMS {
         slot.param_regs[pi as usize] = user_main.param_regs[pi as usize]


### PR DESCRIPTION
## Summary
- remove the stale `had_overflow` field copy from `ir_module_restore_user_main_calls`
- unblock canonical `scripts/ci/build_modular_madaros.sh` rebuilds on current `origin/main`
- verify the rebuilt compiler with a hello smoke and `tmp_mono_repro`

## Validation
- `scripts/ci/build_modular_madaros.sh /tmp/madaros-main-rebuild-test`
- `MADAROS_RAW_BIN=/tmp/madaros-main-rebuild-test bin/madaros build examples/hello.sio -o /tmp/hello_main_rebuild.bin && /tmp/hello_main_rebuild.bin`
- `MADAROS_RAW_BIN=/tmp/madaros-main-rebuild-test bin/madaros build tests/run-pass/tmp_mono_repro.sio -o /tmp/tmp_mono_repro.bin && /tmp/tmp_mono_repro.bin`