### PR TITLE
Fix raw Madaros harness mode and add f64 regressions

### DIFF
--- a/scripts/ci/souc-native-wrapper.sh
+++ b/scripts/ci/souc-native-wrapper.sh
@@ -84,6 +84,28 @@ if ! RAW_SOUC="$(_resolve_raw_elf)"; then
   exit 127
 fi
 
+_detect_raw_mode() {
+  if [[ -n "${SOUNIO_SOUC_RAW_MODE:-}" ]]; then
+    echo "$SOUNIO_SOUC_RAW_MODE"
+    return 0
+  fi
+  local base
+  base="$(basename "$RAW_SOUC")"
+  if [[ "$base" == *madaros* ]]; then
+    echo "modular"
+    return 0
+  fi
+  local ident
+  ident="$("$RAW_SOUC" /dev/null /dev/null 2>/dev/null | head -n 1 || true)"
+  if grep -q "Madares v" <<<"$ident"; then
+    echo "modular"
+    return 0
+  fi
+  echo "legacy"
+}
+
+RAW_MODE="$(_detect_raw_mode)"
+
 usage() {
   cat <<USAGE
 souc-native-wrapper.sh — subcommand wrapper around $RAW_SOUC
@@ -105,6 +127,7 @@ USAGE
 info() {
   echo "wrapper:   $0"
   echo "raw_elf:   $RAW_SOUC"
+  echo "raw_mode:  $RAW_MODE"
   echo "stdlib:    ${SOUNIO_STDLIB_PATH:-<unset>}"
 }
 
@@ -121,6 +144,15 @@ souc_compile() {
   local src="$1"
   local out="$2"
   local log
+  if [[ "$RAW_MODE" == "modular" ]]; then
+    log="$("$RAW_SOUC" "$src" -o "$out" 2>&1)" || true
+    if [[ ! -s "$out" ]]; then
+      printf '%s\ntypecheck: failed\n' "$log"
+      return 1
+    fi
+    printf '%s' "$log"
+    return 0
+  fi
   log="$("$RAW_SOUC" "$src" "$out" 2>&1)" || true
   if [[ ! -s "$out" ]] || ! grep -qF "compile: fns=" <<<"$log"; then
     printf '%s\ntypecheck: failed\n' "$log"
@@ -139,6 +171,13 @@ case "${1:-}" in
       echo "error: check takes exactly 1 argument (file.sio)" >&2
       usage >&2
       exit 2
+    fi
+    if [[ "$RAW_MODE" == "modular" ]]; then
+      set +e
+      "$RAW_SOUC" --check "$1"
+      rc=$?
+      set -e
+      exit "$rc"
     fi
     tmp="$(mktemp /tmp/sounio-check-XXXXXX.elf)"
     trap 'rm -f "$tmp"' EXIT

--- a/tests/run-pass/tmp_f64_branch_return_neg_expr.sio
+++ b/tests/run-pass/tmp_f64_branch_return_neg_expr.sio
@@ -1,0 +1,10 @@
+//@ run-pass
+fn probe(x: f64) -> f64 {
+    if x < (0.0 - 700.0) { return 0.0 }
+    1.0
+}
+
+fn main() -> i64 with IO, Mut, Div {
+    println(probe(0.0))
+    0
+}

--- a/tests/run-pass/tmp_f64_branch_return_neg_literal.sio
+++ b/tests/run-pass/tmp_f64_branch_return_neg_literal.sio
@@ -1,0 +1,10 @@
+//@ run-pass
+fn probe(x: f64) -> f64 {
+    if x < -700.0 { return 0.0 }
+    1.0
+}
+
+fn main() -> i64 with IO {
+    println(probe(0.0))
+    0
+}

--- a/tests/run-pass/tmp_f64_range_probe.sio
+++ b/tests/run-pass/tmp_f64_range_probe.sio
@@ -1,0 +1,16 @@
+//@ run-pass
+fn classify(v: f64, lo: f64, hi: f64) -> i64 with Mut, Div {
+    if v < lo { return 1 }
+    if v < hi { return 0 }
+    return 2
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let a = 0.5 * 1000.0
+    let b = 0.69 * 1000.0
+    let c = 0.6931471805599453 * 1000.0
+    let ra = classify(a, 100.0, 1000.0)
+    let rb = classify(b, 600.0, 800.0)
+    let rc = classify(c, 600.0, 800.0)
+    return ra + (rb * 10) + (rc * 100)
+}


### PR DESCRIPTION
## Summary
- teach `scripts/ci/souc-native-wrapper.sh` to detect modular raw Madaros binaries and use the correct compile/check interface
- preserve the legacy raw `souc` positional interface path
- add missing `f64` regression witnesses for negative-branch and range-classification cases

## Validation
- `scripts/ci/build_modular_madaros.sh /tmp/madaros-f64-param-main`
- `MADAROS_RAW_BIN=/tmp/madaros-f64-param-main bin/madaros build /workspace/sounio/tests/run-pass/tmp_f64_param_mul_witness.sio -o /tmp/f64_param_mul_witness_main.bin && /tmp/f64_param_mul_witness_main.bin`
- `MADAROS_RAW_BIN=/tmp/madaros-f64-param-main bin/madaros build /workspace/sounio/tests/run-pass/tmp_f64_branch_return_hi_value_witness.sio -o /tmp/f64_branch_return_hi_value_witness_main.bin && /tmp/f64_branch_return_hi_value_witness_main.bin`
- `MADAROS_RAW_BIN=/tmp/madaros-f64-param-main bin/madaros build /workspace/sounio/tests/run-pass/tmp_f64_range_probe.sio -o /tmp/f64_range_probe_main.bin && /tmp/f64_range_probe_main.bin`
- `SOUNIO_TEST_SOUC_BIN=/tmp/madaros-f64-param-main bash scripts/run_sio_test_suite.sh tmp_f64_ --verbose`
- `bash scripts/run_sio_test_suite.sh tmp_f64_ --verbose`