### PR TITLE
Fix float unary neg typing in native codegen

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4844,6 +4844,12 @@ impl Lowerer {
             }
             return self.opt_expr_result_is_float_ref(&(*e).left) || self.opt_expr_result_is_float_ref(&(*e).right)
         }
+        if (*e).kind == ExprKind::ExprUnary {
+            if (*e).un_op == UnaryOp::OpNeg {
+                return self.opt_expr_result_is_float_ref(&(*e).left)
+            }
+            return false
+        }
         // An if-expression yields a float if either arm yields a float. Native
         // codegen types the merge register flow-insensitively (last linear write
         // wins), and an f64 literal arm (e.g. `else { 0.0 }`) lowers to IrLoadImm
@@ -8570,13 +8576,21 @@ impl Lowerer {
         let pair_s = self.lower_opt_expr_ref(&e.left)
         let lo1 = pair_s.0
         let src = pair_s.1
+        let src_is_float = if e.un_op == UnaryOp::OpNeg {
+            lo1.opt_expr_result_is_float_ref(&e.left)
+        } else {
+            false
+        }
         let pair_d = lo1.fresh_reg()
         let lo2 = pair_d.0
         let dst = pair_d.1
-        let lo3 = if is_box_deref {
+        var lo3 = if is_box_deref {
             lo2.emit(ir_field_get(dst, src, 0, ir_empty_name()))
         } else {
             lo2.emit(ir_unaryop(dst, e.un_op, src))
+        }
+        if src_is_float {
+            lo3 = lo3.emit(ir_mark_float_reg(dst))
         }
         (lo3, dst)
     }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6457,7 +6457,19 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
             } else if op == IrOpcode::IrLoadImm {
                 def = 2
             } else if op == IrOpcode::IrUnaryOp {
-                def = 2
+                let uop = (*func).instrs[i as usize].un_op
+                if uop == UnaryOp::OpNeg {
+                    let t1 = if s1 >= 0 && s1 < 512 { ty[s1 as usize] } else { 0 }
+                    if t1 == 1 {
+                        def = 1
+                    } else if t1 == 2 {
+                        def = 2
+                    } else {
+                        def = 0
+                    }
+                } else {
+                    def = 2
+                }
             } else if op == IrOpcode::IrCopy {
                 if s1 >= 0 && s1 < 512 { def = ty[s1 as usize] }
             } else if op == IrOpcode::IrCall || op == IrOpcode::IrFieldGet || op == IrOpcode::IrIndexGet {
@@ -6719,10 +6731,24 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             // so fail LOUDLY (codegen error) rather than ship a silent miscompile.
             let uop = (*func).instrs[i as usize].un_op
             if uop == UnaryOp::OpNeg {
-                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
-                nc_emit_neg_rax(nc)
-                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
-                nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
+                let src1 = (*func).instrs[i as usize].src1
+                let src1_marked_float = if src1 >= 0 && src1 < 512 && (*nc).is_float_reg[src1 as usize] == 1 { 1 } else { 0 }
+                let src1_typed_float = if src1 >= 0 && src1 < 512 && (*nc).reg_type[src1 as usize] == 1 { 1 } else { 0 }
+                if src1_marked_float == 1 || src1_typed_float == 1 {
+                    nc_core_load_temp_to_rax(nc, src1)
+                    nc_emit_movq_xmm1_rax(nc)
+                    nc_emit_mov_rax_imm(nc, 0)
+                    nc_emit_movq_xmm0_rax(nc)
+                    nc_emit_subsd_xmm0_xmm1(nc)
+                    nc_emit_movq_rax_xmm0(nc)
+                    nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+                    nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
+                } else {
+                    nc_core_load_temp_to_rax(nc, src1)
+                    nc_emit_neg_rax(nc)
+                    nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+                    nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
+                }
             } else if uop == UnaryOp::OpNot {
                 nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
                 (*nc).code = emit_not_bool_rax((*nc).code)

--- a/tests/run-pass/float_neg_literal_cmp.sio
+++ b/tests/run-pass/float_neg_literal_cmp.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let q = 0.0 - 5.0
+    if q < -6.0 { return 1 }
+    if q < -4.0 { return 0 }
+    return 2
+}


### PR DESCRIPTION
## Summary
- treat unary float negation as a float result in IR lowering and native float-type fixpoint analysis
- emit SSE float negation for `IrUnaryOp(OpNeg)` instead of integer `neg rax` when the operand is float
- add a regression for comparing a negative computed float against negative float literals

## Validation
- `scripts/ci/build_modular_madaros.sh /tmp/madaros-numeric-next`
- `SOUNIO_TEST_SOUC_BIN=/tmp/madaros-numeric-next bash scripts/run_sio_test_suite.sh float_neg_literal_cmp --verbose`
- `SOUNIO_TEST_SOUC_BIN=/tmp/madaros-numeric-next bash scripts/run_sio_test_suite.sh tmp_f64_ --verbose`
- manual repros with `MADAROS_RAW_BIN=/tmp/madaros-numeric-next bin/madaros build ...` for `/workspace/sounio/tests/run-pass/tmp_div_probe.sio`, `tmp_div_probe_neg.sio`, `tmp_div_probe_neg2.sio`, `tmp_div_probe_neg2_noio.sio`, `tmp_div_probe_pos.sio`