### PR TITLE
fix(native-v2): preserve float binop typing for f64 expr casts

### DIFF
--- a/self-hosted/native/machine_ir.sio
+++ b/self-hosted/native/machine_ir.sio
@@ -5,7 +5,7 @@
 module native::machine_ir
 
 use parser::ast::{Name, BinaryOp, UnaryOp, empty_name}
-use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX}
+use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX, IR_FLOAT_REG_MARKER_FLAG}
 
 pub let MIR_MAX_BLOCKS: i64 = 1
 pub let MIR_MAX_INSTRS: i64 = 1024
@@ -970,6 +970,9 @@ pub fn native_v2_legalize_ir_summary_ref(func: &IrFunction) -> NativeV2LegalizeS
     while i < (*func).instr_count {
         let instr = (*func).instrs[i as usize]
         if instr.op == IrOpcode::IrNop {
+            if instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && instr.dst >= 0 && instr.dst < 256 {
+                is_float_slot[instr.dst as usize] = 1
+            }
             i = i + 1
             continue
         }
@@ -1001,7 +1004,9 @@ pub fn native_v2_legalize_ir_summary_ref(func: &IrFunction) -> NativeV2LegalizeS
             let s2 = instr.src2
             let s1f = if s1 >= 0 && s1 < 256 { is_float_slot[s1 as usize] } else { 0 }
             let s2f = if s2 >= 0 && s2 < 256 { is_float_slot[s2 as usize] } else { 0 }
-            if s1f == 1 || s2f == 1 {
+            let s1f_marked = (instr.imm_flags / 2) & 1
+            let s2f_marked = (instr.imm_flags / 4) & 1
+            if s1f == 1 || s2f == 1 || s1f_marked == 1 || s2f_marked == 1 {
                 out.legal_instr_count = out.legal_instr_count + 1
                 if instr.dst >= 0 && instr.dst < 256 {
                     if instr.bin_op == BinaryOp::OpAdd || instr.bin_op == BinaryOp::OpSub || instr.bin_op == BinaryOp::OpMul || instr.bin_op == BinaryOp::OpDiv {
@@ -1104,6 +1109,9 @@ pub fn native_v2_lower_legal_function_from_ir_ref(func: &IrFunction, out: &! Mac
     while i < (*func).instr_count {
         let ir_instr = (*func).instrs[i as usize]
         if ir_instr.op == IrOpcode::IrNop {
+            if ir_instr.imm_flags == IR_FLOAT_REG_MARKER_FLAG && ir_instr.dst >= 0 && ir_instr.dst < 256 {
+                (*out).is_float_slot[ir_instr.dst as usize] = 1
+            }
             i = i + 1
             continue
         }
@@ -1145,8 +1153,12 @@ pub fn native_v2_lower_legal_function_from_ir_ref(func: &IrFunction, out: &! Mac
             let s2 = machine_instr_src2_value(instr)
             let s1f = if s1 >= 0 && s1 < 256 { (*out).is_float_slot[s1 as usize] } else { 0 }
             let s2f = if s2 >= 0 && s2 < 256 { (*out).is_float_slot[s2 as usize] } else { 0 }
-            if s1f == 1 || s2f == 1 {
-                native_v2_emit_legal_instr_mut(out, native_v2_make_float_binop(machine_instr_dst_value(instr), s1, s2, machine_instr_bin_op(instr), s1f, s2f))
+            let s1f_marked = ((*func).instrs[i as usize].imm_flags / 2) & 1
+            let s2f_marked = ((*func).instrs[i as usize].imm_flags / 4) & 1
+            let lhs_float = if s1f == 1 || s1f_marked == 1 { 1 } else { 0 }
+            let rhs_float = if s2f == 1 || s2f_marked == 1 { 1 } else { 0 }
+            if lhs_float == 1 || rhs_float == 1 {
+                native_v2_emit_legal_instr_mut(out, native_v2_make_float_binop(machine_instr_dst_value(instr), s1, s2, machine_instr_bin_op(instr), lhs_float, rhs_float))
                 let dslot = machine_instr_dst_value(instr)
                 if dslot >= 0 && dslot < 256 {
                     if machine_instr_bin_op(instr) == BinaryOp::OpAdd || machine_instr_bin_op(instr) == BinaryOp::OpSub || machine_instr_bin_op(instr) == BinaryOp::OpMul || machine_instr_bin_op(instr) == BinaryOp::OpDiv {

--- a/tests/run-pass/tmp_float_to_int_literal_witness.sio
+++ b/tests/run-pass/tmp_float_to_int_literal_witness.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+fn main() -> i64 with Mut, Div, Panic {
+    let k = 10.0 as i64
+    if k < 9 { return 1 }
+    if k < 11 { return 0 }
+    return 2
+}

--- a/tests/run-pass/tmp_float_to_int_mulexpr_witness.sio
+++ b/tests/run-pass/tmp_float_to_int_mulexpr_witness.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+fn main() -> i64 with Mut, Div, Panic {
+    let k = (0.5 * 1000.0) as i64
+    if k < 400 { return 1 }
+    if k < 600 { return 0 }
+    return 2
+}

--- a/tests/run-pass/tmp_float_to_int_negexpr_witness.sio
+++ b/tests/run-pass/tmp_float_to_int_negexpr_witness.sio
@@ -1,0 +1,7 @@
+//@ run-pass
+fn main() -> i64 with Mut, Div, Panic {
+    let k = (0.0 - 10.0) as i64
+    if k < -11 { return 1 }
+    if k < -9 { return 0 }
+    return 2
+}


### PR DESCRIPTION
## Summary
- preserve float-typed literal markers and `IrBinOp` float flags in the native-v2 machine-IR legalization path
- add three run-pass witnesses covering direct literal cast, float multiply expression cast, and float neg/sub expression cast to `i64`
- refresh `bin/madaros-linux-x86_64` so the default wrapper path picks up the fix

## Validation
- `env -u SOUC_BIN SOUNIO_STDLIB_PATH=/tmp/sounio-f64-arith-20260630/stdlib ./bin/souc compile tests/run-pass/tmp_float_to_int_literal_witness.sio -o /tmp/lit.head.bin && /tmp/lit.head.bin` -> `0`
- `env -u SOUC_BIN SOUNIO_STDLIB_PATH=/tmp/sounio-f64-arith-20260630/stdlib ./bin/souc compile tests/run-pass/tmp_float_to_int_mulexpr_witness.sio -o /tmp/mul.head.bin && /tmp/mul.head.bin` -> `0`
- `env -u SOUC_BIN SOUNIO_STDLIB_PATH=/tmp/sounio-f64-arith-20260630/stdlib ./bin/souc compile tests/run-pass/tmp_float_to_int_negexpr_witness.sio -o /tmp/neg.head.bin && /tmp/neg.head.bin` -> `0`
- disassembly receipt for the multiply witness now shows `mulsd` instead of `imul` on the float-expression path