### PR TITLE
[codex] audit and merge low-risk forgotten branches

### DIFF
--- a/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
+++ b/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
@@ -1,7 +1,7 @@
 # Affine arithmetic over a non-associative algebra: non-associativity as a noise symbol
 
 Status: **frontier opened — core mechanism designed, N=3 case proven (paper + execution), novelty boundary established against prior art.**
-Branch: `feat/affine-nonassoc-uncertainty`. Demonstrator: `examples/epistemic/affine_nonassoc_demo.sio` (self-contained, builds + runs, all claims green 2026-06-13).
+Branch: `feat/affine-nonassoc-uncertainty`. Demonstrator: `examples/epistemic/affine_nonassoc_demo.sio` (self-contained; verified green via `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run ...` on 2026-06-30).
 
 ## The frontier target
 
@@ -33,7 +33,7 @@ We are on **Path 2**.
 
 ## Verified result (N=3)
 
-`examples/epistemic/affine_nonassoc_demo.sio` implements octonion-coefficient affine forms with a first-order product rule `∂/∂ε_k = a0·d_k(b) + d_k(a)·b0` (octonion order preserved, hence non-associativity preserved). It asserts three claims numerically and **runs green**:
+`examples/epistemic/affine_nonassoc_demo.sio` implements octonion-coefficient affine forms with a first-order product rule `∂/∂ε_k = a0·d_k(b) + d_k(a)·b0` (octonion order preserved, hence non-associativity preserved). It asserts three claims numerically and **runs green on the verified lean_single lane**:
 
 1. **Exact conditioning = zero covariance.** `x − x` → affine `Var = 0`; the independence-assuming scalar model is forced to report `2·Var(x) = 0.08`. (Realizes the exact-conditioning/zero-covariance lead, arXiv:2312.17141, as the canonical AA cancellation.)
 2. **Correlation honesty.** `Var(x+y)` = `4‖d‖²` when `x,y` share a symbol vs `2‖d‖²` when independent — tracked, not assumed.
@@ -58,7 +58,7 @@ A focused prior-art sweep (9 queries) places the boundary precisely:
 
 ## Roadmap
 
-1. **[done]** Self-contained N=3 demonstrator, runs green.
+1. **[done]** Self-contained N=3 demonstrator, runs green on `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run ...`.
 2. **Promote to a stdlib module** `stdlib/epistemic/affine_octonion.sio` — arena-backed (mirror `perturbation_graph.sio`'s flat-arena, bare-`&!`-deref discipline to avoid the large-boxed-struct codegen hazard), `NSYM` symbols, second-order remainder lumped into a fresh roundoff symbol with a documented magnitude bound.
 3. **Upgrade `PerturbGraph` to correlation-honest** — replace scalar `pvar[n]` with a noise-symbol row; the current independent combination becomes the special case of disjoint symbol sets. This retires the leaf-independence assumption in the live substrate.
 4. **[done 2026-06-15]** N≥4 spread — `examples/epistemic/affine_nonassoc_n4_demo.sio` wires the ε0-coefficient rows of all 5 affine parenthesizations of w·x·y·z into `pentagon_variance`. Claim 4: max component-wise diff (affine coeff row vs plain pentagon on w1,x0,y0,z0) = 0 machine-exact; variance = 0.96 (×1e6, genuinely non-associative non-Fano quad e1,e2,e4,e1). Claim 5: all-real quad → variance = 0 (reals associate). ALL CLAIMS VERIFIED by live run on 2026-06-15. `pentagon_variance` is the correct path-independent order-ambiguity measure when N>3.
@@ -66,4 +66,4 @@ A focused prior-art sweep (9 queries) places the boundary precisely:
 
 ## Why this is the right "big step"
 
-It advances the telos (uncertainty-as-default-substrate, "my mind and the world") rather than the toolchain that serves it, it is falsifiable and already falsified-green at N=3, and the prior-art sweep shows the narrow mechanization is unworked. It does **not** block on the arm64 self-host (it runs today on `bin/souc`), so it proceeds in parallel with closing that out.
+It advances the telos (uncertainty-as-default-substrate, "my mind and the world") rather than the toolchain that serves it, it is falsifiable and already falsified-green at N=3 on the verified lean_single lane, and the prior-art sweep shows the narrow mechanization is unworked. It does **not** block on the arm64 self-host, so it proceeds in parallel with closing that out.

--- a/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
+++ b/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
@@ -61,7 +61,7 @@ A focused prior-art sweep (9 queries) places the boundary precisely:
 1. **[done]** Self-contained N=3 demonstrator, runs green.
 2. **Promote to a stdlib module** `stdlib/epistemic/affine_octonion.sio` — arena-backed (mirror `perturbation_graph.sio`'s flat-arena, bare-`&!`-deref discipline to avoid the large-boxed-struct codegen hazard), `NSYM` symbols, second-order remainder lumped into a fresh roundoff symbol with a documented magnitude bound.
 3. **Upgrade `PerturbGraph` to correlation-honest** — replace scalar `pvar[n]` with a noise-symbol row; the current independent combination becomes the special case of disjoint symbol sets. This retires the leaf-independence assumption in the live substrate.
-4. **N≥4 spread** — wire the associahedron/`pentagon_variance` work into the coefficient-spread term (the 5-association Catalan-C₃ enclosure).
+4. **[done 2026-06-15]** N≥4 spread — `examples/epistemic/affine_nonassoc_n4_demo.sio` wires the ε0-coefficient rows of all 5 affine parenthesizations of w·x·y·z into `pentagon_variance`. Claim 4: max component-wise diff (affine coeff row vs plain pentagon on w1,x0,y0,z0) = 0 machine-exact; variance = 0.96 (×1e6, genuinely non-associative non-Fano quad e1,e2,e4,e1). Claim 5: all-real quad → variance = 0 (reals associate). ALL CLAIMS VERIFIED by live run on 2026-06-15. `pentagon_variance` is the correct path-independent order-ambiguity measure when N>3.
 5. **Type-system framing** — surface `NonAssoc` (already an effect) as the carrier: a non-associative product *is* a variance-producing effect, and the affine form is its propagated witness. This is the PL-novel half.
 
 ## Why this is the right "big step"

--- a/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
+++ b/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
@@ -1,0 +1,69 @@
+# Affine arithmetic over a non-associative algebra: non-associativity as a noise symbol
+
+Status: **frontier opened — core mechanism designed, N=3 case proven (paper + execution), novelty boundary established against prior art.**
+Branch: `feat/affine-nonassoc-uncertainty`. Demonstrator: `examples/epistemic/affine_nonassoc_demo.sio` (self-contained, builds + runs, all claims green 2026-06-13).
+
+## The frontier target
+
+The reject-defaults map named the next default to reject: **"independence is a lie" generalized from the perturbation-DAG to every `+` and `*`.** The existing uncertainty substrate already folds non-associativity into a *scalar* variance budget — `UncertainOct.mul3` and `PerturbGraph.pg_mul` add `κ·‖[a,b,c]‖²`. But both assume **leaf independence**: `pg_mul` combines operands as `‖j‖²·Var(i) + ‖i‖²·Var(j)`, with no representation of shared error sources. That independence assumption is exactly the default to reject.
+
+**Affine arithmetic (AA)** is the correct substrate for that rejection. A value is
+```
+x = x0 + Σ_k  d_k · ε_k
+```
+where `ε_k ∈ [−1,1]` are shared scalar noise symbols and the coefficients `x0, d_k` are octonion-valued (`[f64;8]`). Two values that share a symbol are *correlated through it*; a symbol with equal-and-opposite coefficients cancels exactly. Correlation is structural, not a separate covariance matrix. The one budget is `Var(x) = Σ_k ‖d_k‖²`.
+
+## The crux that forks the design (resolved)
+
+The naive pitch — "a non-associative product injects one scalar structural symbol `κ‖[a,b,c]‖²`" — is **false**, and the falsity is the whole point. Take `a = a0 + a1·ε`, `b = b0`, `c = c0` (b, c exact):
+
+| association | ε-coefficient |
+|---|---|
+| `(a·b)·c` | `(a1·b0)·c0` |
+| `a·(b·c)` | `a1·(b0·c0)` |
+| **difference** | **`[a1, b0, c0]`** (the associator) |
+
+Non-associativity perturbs **every shared symbol's coefficient**, and the perturbation stays *correlated* with whatever owns that symbol. The order-ambiguity does not live in a separate independent scalar add-on — it is distributed across the symbol row. The scalar `κ‖[a,b,c]‖²` model is a lossy projection of this onto an independent budget.
+
+This forked two designs:
+- **Path 1 (leaf-correlation only):** shared symbols at leaves for additive correlation; keep the norm-rule + scalar structural term for products. Correct and shippable, but this is *textbook AA applied* — not frontier.
+- **Path 2 (octonion-coefficient affine forms propagated through products):** confronts the per-symbol associator spread. **This is the research and the novelty.** N=3 is closed and buildable (matches the already-proven "DAG order-safe IFF N≤3"); N≥4 needs the associahedron machinery (`pentagon_variance`, commit `73fa72b91`) because there the spread is over 5 associations (Catalan C₃).
+
+We are on **Path 2**.
+
+## Verified result (N=3)
+
+`examples/epistemic/affine_nonassoc_demo.sio` implements octonion-coefficient affine forms with a first-order product rule `∂/∂ε_k = a0·d_k(b) + d_k(a)·b0` (octonion order preserved, hence non-associativity preserved). It asserts three claims numerically and **runs green**:
+
+1. **Exact conditioning = zero covariance.** `x − x` → affine `Var = 0`; the independence-assuming scalar model is forced to report `2·Var(x) = 0.08`. (Realizes the exact-conditioning/zero-covariance lead, arXiv:2312.17141, as the canonical AA cancellation.)
+2. **Correlation honesty.** `Var(x+y)` = `4‖d‖²` when `x,y` share a symbol vs `2‖d‖²` when independent — tracked, not assumed.
+3. **Non-associativity is a noise-symbol perturbation.** For `[e1,e2,e4]` (non-Fano, `‖associator‖² = 4`), the ε-coefficient spread between `((ab)c)` and `(a(bc))` equals `[a1,b0,c0]` to machine zero. The order-ambiguity rides the *same symbol* as `a`'s input uncertainty.
+
+The N=3 hand-calc is therefore proven both on paper and by execution.
+
+## Novelty boundary (honest — do not round up)
+
+A focused prior-art sweep (9 queries) places the boundary precisely:
+- **Fusing roundoff + epistemic/input uncertainty in one affine form is textbook** — Stolfi & de Figueiredo. The fresh-symbol-per-nonlinear-op *is* the roundoff term. Not novel.
+- **"Associator as uncertainty" exists as a concept** in non-associative quantum mechanics (arXiv:1411.3710; PRL 121.201602) — but as a *bound on simultaneous measurability of observables*, not a propagated variance carried inside a value representation. Adjacent, different direction.
+- **No prior art** for: AA operating *over a non-associative algebra*, with the associator `[a,b,c]` injected as a *first-class affine noise symbol* so product order-ambiguity becomes propagated variance, fused with roundoff and epistemic symbols — nor for the **PL/type-system framing** of it. The closest computational analog (ZC502 Isaac-Sim physical-consistency plugin, Feb 2026) independently mechanizes the octonion associator as a numerical-drift diagnostic but makes the *opposite* modeling choice (structural signal, explicitly *not* noise, no AA).
+
+**The novel residue is the narrow fused mechanization + its language framing, not any single ingredient.** Claims must be scoped to that.
+
+### Key references
+- Stolfi & de Figueiredo, *Affine Arithmetic: Concepts and Applications* — roundoff + input uncertainty fused via shared noise symbols.
+- arXiv:1411.3710 / PRL 121.201602 — associator bounds an uncertainty (concept-level prior art, different sense).
+- ZC502, *Isaac-Sim Physical-consistency plugin* v0.4.2 (2026) — associator as drift diagnostic, opposite choice, no AA.
+- Goubault & Putot, perturbed affine arithmetic / zonotopes (arXiv:0807.2961) — AA-as-error-tracking over ℝ (associative), the machinery this extends.
+
+## Roadmap
+
+1. **[done]** Self-contained N=3 demonstrator, runs green.
+2. **Promote to a stdlib module** `stdlib/epistemic/affine_octonion.sio` — arena-backed (mirror `perturbation_graph.sio`'s flat-arena, bare-`&!`-deref discipline to avoid the large-boxed-struct codegen hazard), `NSYM` symbols, second-order remainder lumped into a fresh roundoff symbol with a documented magnitude bound.
+3. **Upgrade `PerturbGraph` to correlation-honest** — replace scalar `pvar[n]` with a noise-symbol row; the current independent combination becomes the special case of disjoint symbol sets. This retires the leaf-independence assumption in the live substrate.
+4. **N≥4 spread** — wire the associahedron/`pentagon_variance` work into the coefficient-spread term (the 5-association Catalan-C₃ enclosure).
+5. **Type-system framing** — surface `NonAssoc` (already an effect) as the carrier: a non-associative product *is* a variance-producing effect, and the affine form is its propagated witness. This is the PL-novel half.
+
+## Why this is the right "big step"
+
+It advances the telos (uncertainty-as-default-substrate, "my mind and the world") rather than the toolchain that serves it, it is falsifiable and already falsified-green at N=3, and the prior-art sweep shows the narrow mechanization is unworked. It does **not** block on the arm64 self-host (it runs today on `bin/souc`), so it proceeds in parallel with closing that out.

--- a/examples/epistemic/affine_nonassoc_demo.sio
+++ b/examples/epistemic/affine_nonassoc_demo.sio
@@ -4,9 +4,10 @@
 // with non-associativity carried as a noise symbol in the SAME affine budget
 // as correlated input uncertainty.
 //
-// Self-contained (no imports) so it builds + RUNS with a single
-//   bin/souc affine_nonassoc_demo.sio out && chmod +x out && ./out
-// per the project rule that the --check harness lies but the emitted ELF runs.
+// Self-contained (no imports) so it builds + RUNS via the verified lean_single lane:
+//   SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/epistemic/affine_nonassoc_demo.sio
+// The current Madaros default path still segfaults on this demo, so keep the
+// executable claim scoped to the lean_single engine until that lane catches up.
 //
 // An affine octonion is   x = x0 + Σ_k  d_k · ε_k     (k = 0..NSYM-1)
 // where ε_k are shared scalar noise symbols (unit variance) and the

--- a/examples/epistemic/affine_nonassoc_demo.sio
+++ b/examples/epistemic/affine_nonassoc_demo.sio
@@ -1,0 +1,302 @@
+// examples/epistemic/affine_nonassoc_demo.sio
+//
+// FRONTIER DEMONSTRATOR — affine arithmetic over a non-associative algebra,
+// with non-associativity carried as a noise symbol in the SAME affine budget
+// as correlated input uncertainty.
+//
+// Self-contained (no imports) so it builds + RUNS with a single
+//   bin/souc affine_nonassoc_demo.sio out && chmod +x out && ./out
+// per the project rule that the --check harness lies but the emitted ELF runs.
+//
+// An affine octonion is   x = x0 + Σ_k  d_k · ε_k     (k = 0..NSYM-1)
+// where ε_k are shared scalar noise symbols (unit variance) and the
+// coefficients x0, d_k are OCTONION-valued ([f64;8]). Two values that share a
+// symbol ε_k are CORRELATED through it; a symbol that appears with equal and
+// opposite coefficients cancels exactly (zero covariance). Variance is the one
+// budget   Var(x) = Σ_k ‖d_k‖².
+//
+// Three claims, each asserted numerically:
+//   (1) EXACT CONDITIONING = ZERO COVARIANCE. x − x carries variance 0 in the
+//       affine model; the independence-assuming scalar model reports 2·Var(x).
+//   (2) CORRELATION HONESTY. Sharing a symbol changes the sum's variance versus
+//       treating the two operands as independent — the affine form tracks it,
+//       a scalar variance budget cannot.
+//   (3) NON-ASSOCIATIVITY IS A NOISE-SYMBOL PERTURBATION. For a triple product
+//       a·b·c where a carries a noise symbol, the ε-coefficient of ((a·b)·c)
+//       and of (a·(b·c)) DIFFER by exactly the associator [a1,b0,c0]. The
+//       order-ambiguity does not live in a separate scalar add-on — it is
+//       distributed across the symbol row and stays correlated with the input
+//       that owns the symbol. (This is the N=3 hand-calc, verified by running.)
+
+// ───────────────────────── octonion primitives (inlined) ─────────────────────
+
+fn oct_mul(a: &[f64; 8], b: &[f64; 8], out: &![f64; 8]) with Mut, Div, NonAssoc {
+    var r0 = a[0] * b[0]
+    r0 = r0 - a[1] * b[1] - a[2] * b[2] - a[3] * b[3]
+    r0 = r0 - a[4] * b[4] - a[5] * b[5] - a[6] * b[6] - a[7] * b[7]
+    out[0] = r0
+    var r1 = a[0] * b[1] + a[1] * b[0]
+    r1 = r1 + a[2] * b[3] - a[3] * b[2]
+    r1 = r1 + a[4] * b[5] - a[5] * b[4]
+    r1 = r1 - a[6] * b[7] + a[7] * b[6]
+    out[1] = r1
+    var r2 = a[0] * b[2] + a[2] * b[0]
+    r2 = r2 - a[1] * b[3] + a[3] * b[1]
+    r2 = r2 + a[4] * b[6] - a[6] * b[4]
+    r2 = r2 + a[5] * b[7] - a[7] * b[5]
+    out[2] = r2
+    var r3 = a[0] * b[3] + a[3] * b[0]
+    r3 = r3 + a[1] * b[2] - a[2] * b[1]
+    r3 = r3 + a[4] * b[7] - a[7] * b[4]
+    r3 = r3 - a[5] * b[6] + a[6] * b[5]
+    out[3] = r3
+    var r4 = a[0] * b[4] + a[4] * b[0]
+    r4 = r4 - a[1] * b[5] + a[5] * b[1]
+    r4 = r4 - a[2] * b[6] + a[6] * b[2]
+    r4 = r4 - a[3] * b[7] + a[7] * b[3]
+    out[4] = r4
+    var r5 = a[0] * b[5] + a[5] * b[0]
+    r5 = r5 + a[1] * b[4] - a[4] * b[1]
+    r5 = r5 - a[2] * b[7] + a[7] * b[2]
+    r5 = r5 + a[3] * b[6] - a[6] * b[3]
+    out[5] = r5
+    var r6 = a[0] * b[6] + a[6] * b[0]
+    r6 = r6 + a[1] * b[7] - a[7] * b[1]
+    r6 = r6 + a[2] * b[4] - a[4] * b[2]
+    r6 = r6 - a[3] * b[5] + a[5] * b[3]
+    out[6] = r6
+    var r7 = a[0] * b[7] + a[7] * b[0]
+    r7 = r7 - a[1] * b[6] + a[6] * b[1]
+    r7 = r7 + a[2] * b[5] - a[5] * b[2]
+    r7 = r7 + a[3] * b[4] - a[4] * b[3]
+    out[7] = r7
+}
+
+fn oct_norm_sq(a: &[f64; 8]) -> f64 with Mut {
+    var sum: f64 = 0.0
+    var i: i64 = 0
+    while i < 8 { sum = sum + a[i] * a[i]; i = i + 1 }
+    sum
+}
+
+fn oct_associator(a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], out: &![f64; 8])
+    with Mut, Div, NonAssoc {
+    var ab: [f64; 8] = [0.0; 8]
+    oct_mul(a, b, &!ab)
+    var ab_c: [f64; 8] = [0.0; 8]
+    oct_mul(&ab, c, &!ab_c)
+    var bc: [f64; 8] = [0.0; 8]
+    oct_mul(b, c, &!bc)
+    var a_bc: [f64; 8] = [0.0; 8]
+    oct_mul(a, &bc, &!a_bc)
+    var i: i64 = 0
+    while i < 8 { out[i] = ab_c[i] - a_bc[i]; i = i + 1 }
+}
+
+// ───────────────────────── affine octonion form ──────────────────────────────
+// NSYM noise symbols; coefficient of symbol k lives at co[k*8 + c].
+
+struct AffOct {
+    c0: [f64; 8],    // central octonion value
+    co: [f64; 32],   // 4 symbols × 8 components
+}
+
+fn aff_zero() -> AffOct {
+    AffOct { c0: [0.0; 8], co: [0.0; 32] }
+}
+
+fn aff_set_central(a: &!AffOct, v: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { a.c0[c] = v[c]; c = c + 1 }
+}
+
+fn aff_set_sym(a: &!AffOct, k: i64, coeff: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { a.co[k * 8 + c] = coeff[c]; c = c + 1 }
+}
+
+fn aff_get_sym(a: &AffOct, k: i64, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = a.co[k * 8 + c]; c = c + 1 }
+}
+
+// A leaf: central value v, perturbed along octonion direction `coeff` by symbol k.
+fn aff_leaf(v: &[f64; 8], k: i64, coeff: &[f64; 8]) -> AffOct with Mut {
+    var a = aff_zero()
+    aff_set_central(&!a, v)
+    aff_set_sym(&!a, k, coeff)
+    a
+}
+
+// One variance budget: Σ_k ‖d_k‖² over all noise symbols.
+fn aff_variance(a: &AffOct) -> f64 with Mut {
+    var total: f64 = 0.0
+    var k: i64 = 0
+    while k < 4 {
+        var d: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!d)
+        total = total + oct_norm_sq(&d)
+        k = k + 1
+    }
+    total
+}
+
+fn aff_sub(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = a.c0[c] - b.c0[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 32 { out.co[i] = a.co[i] - b.co[i]; i = i + 1 }
+}
+
+fn aff_add(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut {
+    var c: i64 = 0
+    while c < 8 { out.c0[c] = a.c0[c] + b.c0[c]; c = c + 1 }
+    var i: i64 = 0
+    while i < 32 { out.co[i] = a.co[i] + b.co[i]; i = i + 1 }
+}
+
+// First-order affine octonion product (preserves octonion ORDER, hence
+// non-associativity).  central = a0·b0 ; ∂/∂ε_k = a0·d_k(b) + d_k(a)·b0.
+fn aff_mul(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut, Div, NonAssoc {
+    var a0: [f64; 8] = [0.0; 8]
+    var b0: [f64; 8] = [0.0; 8]
+    var c: i64 = 0
+    while c < 8 { a0[c] = a.c0[c]; b0[c] = b.c0[c]; c = c + 1 }
+
+    var prod: [f64; 8] = [0.0; 8]
+    oct_mul(&a0, &b0, &!prod)
+    aff_set_central(out, &prod)
+
+    var k: i64 = 0
+    while k < 4 {
+        var da: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!da)
+        var db: [f64; 8] = [0.0; 8]
+        aff_get_sym(b, k, &!db)
+        // a0 · db  +  da · b0
+        var t1: [f64; 8] = [0.0; 8]
+        oct_mul(&a0, &db, &!t1)
+        var t2: [f64; 8] = [0.0; 8]
+        oct_mul(&da, &b0, &!t2)
+        var sum: [f64; 8] = [0.0; 8]
+        var c2: i64 = 0
+        while c2 < 8 { sum[c2] = t1[c2] + t2[c2]; c2 = c2 + 1 }
+        aff_set_sym(out, k, &sum)
+        k = k + 1
+    }
+}
+
+fn f_abs(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
+fn scaled(x: f64) -> i64 { (x * 1000000.0) as i64 }
+
+// ───────────────────────────────── demo ─────────────────────────────────────
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    var fails: i64 = 0
+
+    // ── Claim 1: exact conditioning = zero covariance ──
+    // x = v + d·ε0 .   x − x  must have variance 0 (symbol cancels), whereas the
+    // independence-assuming scalar model would report Var(x)+Var(x) = 2‖d‖².
+    var v: [f64; 8] = [0.0; 8]
+    v[0] = 3.0
+    v[1] = 1.0
+    var d: [f64; 8] = [0.0; 8]
+    d[1] = 0.2          // noise direction along e1, ‖d‖² = 0.04
+    let x = aff_leaf(&v, 0, &d)
+    let var_x = aff_variance(&x)
+
+    var xmx = aff_zero()
+    aff_sub(&x, &x, &!xmx)
+    let var_xmx = aff_variance(&xmx)
+    let scalar_indep_model = var_x + var_x   // what a scalar budget is forced to say
+
+    println("── Claim 1: exact conditioning = zero covariance ──")
+    print(scaled(var_x))      ; println("   = Var(x)  (×1e6)")
+    print(scaled(scalar_indep_model)); println("   = scalar-model Var(x−x), independence assumed")
+    print(scaled(var_xmx))    ; println("   = affine    Var(x−x)  → exact zero")
+    if f_abs(var_xmx) < 0.000000001 { println("  PASS: affine collapses correlated difference to 0") }
+    else { println("  FAIL"); fails = fails + 1 }
+    if scalar_indep_model > 0.0000001 { println("  (scalar model overstates by 2·Var(x) — the lie)") }
+
+    // ── Claim 2: correlation honesty ──
+    // Same magnitude budget on two leaves, combined two ways:
+    //   shared symbol  (correlated)   vs   distinct symbols (independent).
+    var w: [f64; 8] = [0.0; 8]
+    w[0] = 2.0
+    w[2] = 1.0
+    let y_shared = aff_leaf(&w, 0, &d)   // shares ε0 with x
+    let y_indep  = aff_leaf(&w, 1, &d)   // own symbol ε1
+
+    var sum_corr = aff_zero()
+    aff_add(&x, &y_shared, &!sum_corr)
+    var sum_ind = aff_zero()
+    aff_add(&x, &y_indep, &!sum_ind)
+    let var_corr = aff_variance(&sum_corr)   // ‖d+d‖² = 4‖d‖²
+    let var_ind  = aff_variance(&sum_ind)    // ‖d‖²+‖d‖² = 2‖d‖²
+
+    println("")
+    println("── Claim 2: correlation honesty (Var of x+y) ──")
+    print(scaled(var_corr)); println("   = correlated  (shared ε0): 4‖d‖²")
+    print(scaled(var_ind)) ; println("   = independent (own ε1):   2‖d‖²")
+    if var_corr > var_ind + 0.0000001 { println("  PASS: shared-symbol correlation raises variance — tracked, not assumed") }
+    else { println("  FAIL"); fails = fails + 1 }
+
+    // ── Claim 3: non-associativity is a noise-symbol perturbation ──
+    // a = a0 + a1·ε0 ;  b, c exact (no symbols).
+    // ε0-coefficient of ((a·b)·c) is (a1·b0)·c0 ; of (a·(b·c)) is a1·(b0·c0).
+    // Their difference must equal the associator [a1, b0, c0].
+    var a0: [f64; 8] = [0.0; 8]
+    a0[0] = 1.0                 // a central = 1
+    var a1: [f64; 8] = [0.0; 8]
+    a1[1] = 1.0                 // a noise direction = e1
+    var b0: [f64; 8] = [0.0; 8]
+    b0[2] = 1.0                 // b = e2
+    var c0: [f64; 8] = [0.0; 8]
+    c0[4] = 1.0                 // c = e4   ([e1,e2,e4] is non-Fano → associator ≠ 0)
+
+    let a = aff_leaf(&a0, 0, &a1)
+    var b = aff_zero(); aff_set_central(&!b, &b0)
+    var cc = aff_zero(); aff_set_central(&!cc, &c0)
+
+    var ab = aff_zero(); aff_mul(&a, &b, &!ab)
+    var ab_c = aff_zero(); aff_mul(&ab, &cc, &!ab_c)       // ((a·b)·c)
+    var bc = aff_zero(); aff_mul(&b, &cc, &!bc)
+    var a_bc = aff_zero(); aff_mul(&a, &bc, &!a_bc)        // (a·(b·c))
+
+    var coeff_left: [f64; 8] = [0.0; 8]
+    aff_get_sym(&ab_c, 0, &!coeff_left)
+    var coeff_right: [f64; 8] = [0.0; 8]
+    aff_get_sym(&a_bc, 0, &!coeff_right)
+
+    // measured spread between associations, on the noise coefficient
+    var spread: [f64; 8] = [0.0; 8]
+    var c3: i64 = 0
+    while c3 < 8 { spread[c3] = coeff_left[c3] - coeff_right[c3]; c3 = c3 + 1 }
+
+    // the algebra's own associator [a1, b0, c0]
+    var assoc: [f64; 8] = [0.0; 8]
+    oct_associator(&a1, &b0, &c0, &!assoc)
+
+    var max_diff: f64 = 0.0
+    var c4: i64 = 0
+    while c4 < 8 {
+        let dd = f_abs(spread[c4] - assoc[c4])
+        if dd > max_diff { max_diff = dd }
+        c4 = c4 + 1
+    }
+    let assoc_mag = oct_norm_sq(&assoc)
+
+    println("")
+    println("── Claim 3: non-associativity perturbs the noise symbol ──")
+    print(scaled(assoc_mag)); println("   = ‖associator‖²  (>0 ⇒ genuinely non-associative triple)")
+    print(scaled(max_diff)) ; println("   = max |coeff-spread − associator| over components (→0)")
+    if assoc_mag > 0.0000001 && max_diff < 0.000000001 {
+        println("  PASS: ε0-coefficient spread between ((ab)c) and (a(bc)) == [a1,b0,c0]")
+        println("        the order-ambiguity rides the SAME symbol as a's input uncertainty")
+    } else { println("  FAIL"); fails = fails + 1 }
+
+    println("")
+    if fails == 0 { println("ALL CLAIMS VERIFIED"); return 0 }
+    print(fails); println(" claim(s) FAILED")
+    return 1
+}

--- a/examples/epistemic/affine_nonassoc_n4_demo.sio
+++ b/examples/epistemic/affine_nonassoc_n4_demo.sio
@@ -1,0 +1,356 @@
+// examples/epistemic/affine_nonassoc_n4_demo.sio
+//
+// N=4 AFFINE NOISE-SYMBOL PENTAGON CLAIM
+//
+// At N=3 (proven in affine_nonassoc_demo.sio), the ε0-coefficient spread
+// between the 2 parenthesizations equals [a1, b0, c0] — one associator
+// captures the full ambiguity. That is the N≤3 order-safety claim.
+//
+// At N=4, Catalan C₃ = 5 parenthesizations. No single pairwise difference
+// captures the ambiguity. The correct path-independent measure is the
+// POPULATION VARIANCE of all 5 vertices — pentagon_variance on [f64;40].
+//
+// CLAIM: for w = w0 + w1·ε0  (x, y, z exact, one symbol on one factor),
+// the affine first-order product rule is EXACT (no ε² cross-terms),
+// so the ε0-coefficient of P_k(w,x,y,z) is exactly P_k(w1, x0, y0, z0).
+// Therefore: pentagon_variance(aff_coeffs) == pentagon_variance(P(w1,x0,y0,z0)).
+//
+// This is the N=4 generalization of the noise-symbol perturbation claim.
+// The order-ambiguity rides the noise symbol, and pentagon_variance is the
+// correct path-independent measure when N>3.
+//
+// Self-contained. No imports. Build and run:
+//   cd /workspace/sounio-affine && \
+//   bin/souc examples/epistemic/affine_nonassoc_n4_demo.sio /tmp/affine_n4_out \
+//     && chmod +x /tmp/affine_n4_out && /tmp/affine_n4_out
+
+// ── octonion primitives (inlined from affine_nonassoc_demo.sio) ──────────────
+
+fn oct_mul(a: &[f64; 8], b: &[f64; 8], out: &![f64; 8]) with Mut, Div, NonAssoc {
+    var r0 = a[0] * b[0]
+    r0 = r0 - a[1] * b[1] - a[2] * b[2] - a[3] * b[3]
+    r0 = r0 - a[4] * b[4] - a[5] * b[5] - a[6] * b[6] - a[7] * b[7]
+    out[0] = r0
+    var r1 = a[0] * b[1] + a[1] * b[0]
+    r1 = r1 + a[2] * b[3] - a[3] * b[2]
+    r1 = r1 + a[4] * b[5] - a[5] * b[4]
+    r1 = r1 - a[6] * b[7] + a[7] * b[6]
+    out[1] = r1
+    var r2 = a[0] * b[2] + a[2] * b[0]
+    r2 = r2 - a[1] * b[3] + a[3] * b[1]
+    r2 = r2 + a[4] * b[6] - a[6] * b[4]
+    r2 = r2 + a[5] * b[7] - a[7] * b[5]
+    out[2] = r2
+    var r3 = a[0] * b[3] + a[3] * b[0]
+    r3 = r3 + a[1] * b[2] - a[2] * b[1]
+    r3 = r3 + a[4] * b[7] - a[7] * b[4]
+    r3 = r3 - a[5] * b[6] + a[6] * b[5]
+    out[3] = r3
+    var r4 = a[0] * b[4] + a[4] * b[0]
+    r4 = r4 - a[1] * b[5] + a[5] * b[1]
+    r4 = r4 - a[2] * b[6] + a[6] * b[2]
+    r4 = r4 - a[3] * b[7] + a[7] * b[3]
+    out[4] = r4
+    var r5 = a[0] * b[5] + a[5] * b[0]
+    r5 = r5 + a[1] * b[4] - a[4] * b[1]
+    r5 = r5 - a[2] * b[7] + a[7] * b[2]
+    r5 = r5 + a[3] * b[6] - a[6] * b[3]
+    out[5] = r5
+    var r6 = a[0] * b[6] + a[6] * b[0]
+    r6 = r6 + a[1] * b[7] - a[7] * b[1]
+    r6 = r6 + a[2] * b[4] - a[4] * b[2]
+    r6 = r6 - a[3] * b[5] + a[5] * b[3]
+    out[6] = r6
+    var r7 = a[0] * b[7] + a[7] * b[0]
+    r7 = r7 - a[1] * b[6] + a[6] * b[1]
+    r7 = r7 + a[2] * b[5] - a[5] * b[2]
+    r7 = r7 + a[3] * b[4] - a[4] * b[3]
+    out[7] = r7
+}
+
+fn oct_norm_sq(a: &[f64; 8]) -> f64 with Mut {
+    var sum: f64 = 0.0
+    var i: i64 = 0
+    while i < 8 { sum = sum + a[i] * a[i]; i = i + 1 }
+    sum
+}
+
+fn af_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y
+}
+
+fn f_abs(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
+fn scaled(x: f64) -> i64 { (x * 1000000.0) as i64 }
+
+// ── affine octonion form (same as N=3 demo, NSYM=4 symbols) ─────────────────
+
+struct AffOct {
+    c0: [f64; 8],    // central value
+    co: [f64; 32],   // 4 symbols × 8 components
+}
+
+fn aff_zero() -> AffOct {
+    AffOct { c0: [0.0; 8], co: [0.0; 32] }
+}
+
+fn aff_set_central(a: &!AffOct, v: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { a.c0[c] = v[c]; c = c + 1 }
+}
+
+fn aff_set_sym(a: &!AffOct, k: i64, coeff: &[f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { a.co[k * 8 + c] = coeff[c]; c = c + 1 }
+}
+
+fn aff_get_sym(a: &AffOct, k: i64, out: &![f64; 8]) with Mut {
+    var c: i64 = 0
+    while c < 8 { out[c] = a.co[k * 8 + c]; c = c + 1 }
+}
+
+fn aff_leaf(v: &[f64; 8], k: i64, coeff: &[f64; 8]) -> AffOct with Mut {
+    var a = aff_zero()
+    aff_set_central(&!a, v)
+    aff_set_sym(&!a, k, coeff)
+    a
+}
+
+fn aff_mul(a: &AffOct, b: &AffOct, out: &!AffOct) with Mut, Div, NonAssoc {
+    var a0: [f64; 8] = [0.0; 8]
+    var b0: [f64; 8] = [0.0; 8]
+    var c: i64 = 0
+    while c < 8 { a0[c] = a.c0[c]; b0[c] = b.c0[c]; c = c + 1 }
+    var prod: [f64; 8] = [0.0; 8]
+    oct_mul(&a0, &b0, &!prod)
+    aff_set_central(out, &prod)
+    var k: i64 = 0
+    while k < 4 {
+        var da: [f64; 8] = [0.0; 8]
+        aff_get_sym(a, k, &!da)
+        var db: [f64; 8] = [0.0; 8]
+        aff_get_sym(b, k, &!db)
+        var t1: [f64; 8] = [0.0; 8]
+        oct_mul(&a0, &db, &!t1)
+        var t2: [f64; 8] = [0.0; 8]
+        oct_mul(&da, &b0, &!t2)
+        var sum: [f64; 8] = [0.0; 8]
+        var c2: i64 = 0
+        while c2 < 8 { sum[c2] = t1[c2] + t2[c2]; c2 = c2 + 1 }
+        aff_set_sym(out, k, &sum)
+        k = k + 1
+    }
+}
+
+// ── pentagon on plain octonions (inlined from associator_field.sio) ──────────
+// P0=((wx)y)z  P1=(w(xy))z  P2=(wx)(yz)  P3=w((xy)z)  P4=w(x(yz))
+fn pentagon_products(
+    w: &[f64; 8], x: &[f64; 8], y: &[f64; 8], z: &[f64; 8], ps: &![f64; 40]
+) with Mut, Div, NonAssoc {
+    var t1: [f64; 8] = [0.0; 8]
+    var t2: [f64; 8] = [0.0; 8]
+    var p0: [f64; 8] = [0.0; 8]
+    var p1: [f64; 8] = [0.0; 8]
+    var p2: [f64; 8] = [0.0; 8]
+    var p3: [f64; 8] = [0.0; 8]
+    var p4: [f64; 8] = [0.0; 8]
+    oct_mul(w, x, &!t1);  oct_mul(&t1, y, &!t2);  oct_mul(&t2, z, &!p0)
+    oct_mul(x, y, &!t1);  oct_mul(w, &t1, &!t2);  oct_mul(&t2, z, &!p1)
+    oct_mul(w, x, &!t1);  oct_mul(y, z, &!t2);    oct_mul(&t1, &t2, &!p2)
+    oct_mul(x, y, &!t1);  oct_mul(&t1, z, &!t2);  oct_mul(w, &t2, &!p3)
+    oct_mul(y, z, &!t1);  oct_mul(x, &t1, &!t2);  oct_mul(w, &t2, &!p4)
+    var c: i64 = 0
+    while c < 8 {
+        ps[c] = p0[c]; ps[8 + c] = p1[c]; ps[16 + c] = p2[c]
+        ps[24 + c] = p3[c]; ps[32 + c] = p4[c]
+        c = c + 1
+    }
+}
+
+fn pentagon_variance(ps: &[f64; 40]) -> f64 with Mut, Div {
+    var mean: [f64; 8] = [0.0; 8]
+    var c: i64 = 0
+    while c < 8 {
+        var s: f64 = 0.0
+        var k: i64 = 0
+        while k < 5 { s = s + ps[k * 8 + c]; k = k + 1 }
+        mean[c] = s / 5.0
+        c = c + 1
+    }
+    var v: f64 = 0.0
+    var k: i64 = 0
+    while k < 5 {
+        var d2: f64 = 0.0
+        var cc: i64 = 0
+        while cc < 8 {
+            let d = ps[k * 8 + cc] - mean[cc]
+            d2 = d2 + d * d
+            cc = cc + 1
+        }
+        v = v + d2
+        k = k + 1
+    }
+    v / 5.0
+}
+
+// ── main: N=4 claims ─────────────────────────────────────────────────────────
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    var fails: i64 = 0
+
+    // Setup: w = w0 + w1·ε0 ; x, y, z = exact (no symbols).
+    // Use the non-Fano basis triple that gave assoc≠0 in N=3:
+    //   w1=e1, x0=e2, y0=e4  → nonzero triple associator.
+    // For z0 we pick e1 (mirrors associator_field_pentagon.sio's verified test).
+    var w0: [f64; 8] = [0.0; 8]; w0[0] = 1.0  // w central = 1 (real part)
+    var w1: [f64; 8] = [0.0; 8]; w1[1] = 1.0  // w noise direction = e1
+    var x0: [f64; 8] = [0.0; 8]; x0[2] = 1.0  // x = e2
+    var y0: [f64; 8] = [0.0; 8]; y0[4] = 1.0  // y = e4
+    var z0: [f64; 8] = [0.0; 8]; z0[1] = 1.0  // z = e1
+
+    // Build affine forms: w carries ε0; x,y,z are exact (zero co).
+    let aw = aff_leaf(&w0, 0, &w1)
+    var ax = aff_zero(); aff_set_central(&!ax, &x0)
+    var ay = aff_zero(); aff_set_central(&!ay, &y0)
+    var az = aff_zero(); aff_set_central(&!az, &z0)
+
+    // ── Claim 4: N=4 ε0-coefficients == P(w1, x0, y0, z0) ──────────────────
+    // Compute all 5 affine parenthesizations and extract the ε0-coefficient row.
+    // P0 = ((aw·ax)·ay)·az
+    var t1 = aff_zero()
+    var t2 = aff_zero()
+    var ap0 = aff_zero()
+    aff_mul(&aw, &ax, &!t1); aff_mul(&t1, &ay, &!t2); aff_mul(&t2, &az, &!ap0)
+
+    // P1 = (aw·(ax·ay))·az
+    var s1 = aff_zero()
+    var s2 = aff_zero()
+    var ap1 = aff_zero()
+    aff_mul(&ax, &ay, &!s1); aff_mul(&aw, &s1, &!s2); aff_mul(&s2, &az, &!ap1)
+
+    // P2 = (aw·ax)·(ay·az)
+    var u1 = aff_zero()
+    var u2 = aff_zero()
+    var ap2 = aff_zero()
+    aff_mul(&aw, &ax, &!u1); aff_mul(&ay, &az, &!u2); aff_mul(&u1, &u2, &!ap2)
+
+    // P3 = aw·((ax·ay)·az)
+    var q1 = aff_zero()
+    var q2 = aff_zero()
+    var ap3 = aff_zero()
+    aff_mul(&ax, &ay, &!q1); aff_mul(&q1, &az, &!q2); aff_mul(&aw, &q2, &!ap3)
+
+    // P4 = aw·(ax·(ay·az))
+    var r1 = aff_zero()
+    var r2 = aff_zero()
+    var ap4 = aff_zero()
+    aff_mul(&ay, &az, &!r1); aff_mul(&ax, &r1, &!r2); aff_mul(&aw, &r2, &!ap4)
+
+    // Extract ε0-coefficient from each affine parenthesization → aff_coeffs[k*8+c]
+    var aff_coeffs: [f64; 40] = [0.0; 40]
+    var c0: [f64; 8] = [0.0; 8]; aff_get_sym(&ap0, 0, &!c0)
+    var c1: [f64; 8] = [0.0; 8]; aff_get_sym(&ap1, 0, &!c1)
+    var c2: [f64; 8] = [0.0; 8]; aff_get_sym(&ap2, 0, &!c2)
+    var c3: [f64; 8] = [0.0; 8]; aff_get_sym(&ap3, 0, &!c3)
+    var c4: [f64; 8] = [0.0; 8]; aff_get_sym(&ap4, 0, &!c4)
+    var ci: i64 = 0
+    while ci < 8 {
+        aff_coeffs[ci]      = c0[ci]
+        aff_coeffs[8  + ci] = c1[ci]
+        aff_coeffs[16 + ci] = c2[ci]
+        aff_coeffs[24 + ci] = c3[ci]
+        aff_coeffs[32 + ci] = c4[ci]
+        ci = ci + 1
+    }
+
+    // Direct pentagon products on (w1, x0, y0, z0) — the claimed identity.
+    var plain_ps: [f64; 40] = [0.0; 40]
+    pentagon_products(&w1, &x0, &y0, &z0, &!plain_ps)
+
+    // Compare: max component-wise absolute difference should be zero.
+    var max_diff: f64 = 0.0
+    var j: i64 = 0
+    while j < 40 {
+        let dd = f_abs(aff_coeffs[j] - plain_ps[j])
+        if dd > max_diff { max_diff = dd }
+        j = j + 1
+    }
+
+    let var_aff   = pentagon_variance(&aff_coeffs)
+    let var_plain = pentagon_variance(&plain_ps)
+
+    println("── Claim 4: N=4 noise-symbol coefficients == P(w1,x0,y0,z0) ──")
+    print(scaled(max_diff));  println("   = max component-wise |aff_coeff - plain| (→0)")
+    print(scaled(var_aff));   println("   = pentagon_variance of affine ε0-coeff row (×1e6)")
+    print(scaled(var_plain)); println("   = pentagon_variance of plain pentagon     (×1e6)")
+    if max_diff < 0.000000001 {
+        println("  PASS: ε0-coefficient row of all 5 affine products == P(w1,x0,y0,z0)")
+        println("        order-ambiguity rides the noise symbol exactly at N=4")
+    } else { println("  FAIL: coefficient mismatch"); fails = fails + 1 }
+    if var_aff > 0.0000001 {
+        println("  PASS: pentagon_variance > 0 (genuinely non-associative N=4 quad)")
+    } else { println("  FAIL: variance zero — associative case leaked in"); fails = fails + 1 }
+
+    // ── Claim 5: vanishing case — all-real quad collapses pentagon variance ─
+    var rw0: [f64; 8] = [0.0; 8]; rw0[0] = 2.0
+    var rw1: [f64; 8] = [0.0; 8]; rw1[0] = 0.1   // small real perturbation on ε0
+    var rx0: [f64; 8] = [0.0; 8]; rx0[0] = 3.0
+    var ry0: [f64; 8] = [0.0; 8]; ry0[0] = 5.0
+    var rz0: [f64; 8] = [0.0; 8]; rz0[0] = 7.0
+
+    let arw = aff_leaf(&rw0, 0, &rw1)
+    var arx = aff_zero(); aff_set_central(&!arx, &rx0)
+    var ary = aff_zero(); aff_set_central(&!ary, &ry0)
+    var arz = aff_zero(); aff_set_central(&!arz, &rz0)
+
+    var rt1 = aff_zero(); var rt2 = aff_zero(); var rap0 = aff_zero()
+    aff_mul(&arw, &arx, &!rt1); aff_mul(&rt1, &ary, &!rt2); aff_mul(&rt2, &arz, &!rap0)
+    var rs1 = aff_zero(); var rs2 = aff_zero(); var rap1 = aff_zero()
+    aff_mul(&arx, &ary, &!rs1); aff_mul(&arw, &rs1, &!rs2); aff_mul(&rs2, &arz, &!rap1)
+    var ru1 = aff_zero(); var ru2 = aff_zero(); var rap2 = aff_zero()
+    aff_mul(&arw, &arx, &!ru1); aff_mul(&ary, &arz, &!ru2); aff_mul(&ru1, &ru2, &!rap2)
+    var rq1 = aff_zero(); var rq2 = aff_zero(); var rap3 = aff_zero()
+    aff_mul(&arx, &ary, &!rq1); aff_mul(&rq1, &arz, &!rq2); aff_mul(&arw, &rq2, &!rap3)
+    var rr1 = aff_zero(); var rr2 = aff_zero(); var rap4 = aff_zero()
+    aff_mul(&ary, &arz, &!rr1); aff_mul(&arx, &rr1, &!rr2); aff_mul(&arw, &rr2, &!rap4)
+
+    var raff: [f64; 40] = [0.0; 40]
+    var rc0: [f64; 8] = [0.0; 8]; aff_get_sym(&rap0, 0, &!rc0)
+    var rc1: [f64; 8] = [0.0; 8]; aff_get_sym(&rap1, 0, &!rc1)
+    var rc2: [f64; 8] = [0.0; 8]; aff_get_sym(&rap2, 0, &!rc2)
+    var rc3: [f64; 8] = [0.0; 8]; aff_get_sym(&rap3, 0, &!rc3)
+    var rc4: [f64; 8] = [0.0; 8]; aff_get_sym(&rap4, 0, &!rc4)
+    var rci: i64 = 0
+    while rci < 8 {
+        raff[rci]      = rc0[rci]
+        raff[8  + rci] = rc1[rci]
+        raff[16 + rci] = rc2[rci]
+        raff[24 + rci] = rc3[rci]
+        raff[32 + rci] = rc4[rci]
+        rci = rci + 1
+    }
+    let var_real = pentagon_variance(&raff)
+
+    println("")
+    println("── Claim 5: all-real quad → pentagon variance == 0 (associative) ──")
+    print(scaled(var_real)); println("   = pentagon_variance of ε0-coeff row for real quad (→0 ×1e6)")
+    if f_abs(var_real) < 0.000000001 {
+        println("  PASS: real numbers associate → zero spread across 5 parenthesizations")
+    } else { println("  FAIL"); fails = fails + 1 }
+
+    println("")
+    if fails == 0 { println("ALL CLAIMS VERIFIED"); return 0 }
+    print(fails); println(" claim(s) FAILED")
+    return 1
+}

--- a/examples/epistemic/affine_nonassoc_n4_demo.sio
+++ b/examples/epistemic/affine_nonassoc_n4_demo.sio
@@ -4,20 +4,22 @@
 //
 // At N=3 (proven in affine_nonassoc_demo.sio), the ε0-coefficient spread
 // between the 2 parenthesizations equals [a1, b0, c0] — one associator
-// captures the full ambiguity. That is the N≤3 order-safety claim.
+// captures the full ambiguity (Claim 3 there). That is the N≤3 order-safety
+// claim.
 //
-// At N=4, Catalan C₃ = 5 parenthesizations. No single pairwise difference
-// captures the ambiguity. The correct path-independent measure is the
-// POPULATION VARIANCE of all 5 vertices — pentagon_variance on [f64;40].
+// At N=4, Catalan C₃ = 5 parenthesizations. No single pairwise vertex
+// difference captures the full spread: picking any two of the 5 vertices
+// gives a norm² that differs from pentagon_variance (the 5-vertex population
+// variance). This is the genuine N=3→N=4 distinction.
 //
-// CLAIM: for w = w0 + w1·ε0  (x, y, z exact, one symbol on one factor),
-// the affine first-order product rule is EXACT (no ε² cross-terms),
-// so the ε0-coefficient of P_k(w,x,y,z) is exactly P_k(w1, x0, y0, z0).
-// Therefore: pentagon_variance(aff_coeffs) == pentagon_variance(P(w1,x0,y0,z0)).
-//
-// This is the N=4 generalization of the noise-symbol perturbation claim.
-// The order-ambiguity rides the noise symbol, and pentagon_variance is the
-// correct path-independent measure when N>3.
+// Claims here:
+//  4. Leibniz/implementation check: ε0-coefficient of P_k(w,x,y,z) equals
+//     P_k(w1,x0,y0,z0) machine-exactly (forced by first-order linearity when
+//     ε0 sits on exactly one factor). Confirms aff_mul correctness.
+//  5. Vanishing case: all-real quad → pentagon_variance = 0.
+//  6. No single pairwise edge recovers the 5-vertex variance for the
+//     non-Fano quad — demonstrating that N=4 requires pentagon_variance (all 5
+//     vertices) while N=3 needed only one associator.
 //
 // Self-contained. No imports. Build and run:
 //   cd /workspace/sounio-affine && \
@@ -176,6 +178,18 @@ fn pentagon_products(
         ps[24 + c] = p3[c]; ps[32 + c] = p4[c]
         c = c + 1
     }
+}
+
+// norm² of the difference between two rows k and j in the 5×8 pentagon array.
+fn pentagon_edge_normsq(ps: &[f64; 40], k: i64, j: i64) -> f64 with Mut {
+    var sum: f64 = 0.0
+    var c: i64 = 0
+    while c < 8 {
+        let d = ps[k * 8 + c] - ps[j * 8 + c]
+        sum = sum + d * d
+        c = c + 1
+    }
+    sum
 }
 
 fn pentagon_variance(ps: &[f64; 40]) -> f64 with Mut, Div {
@@ -348,6 +362,42 @@ fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
     if f_abs(var_real) < 0.000000001 {
         println("  PASS: real numbers associate → zero spread across 5 parenthesizations")
     } else { println("  FAIL"); fails = fails + 1 }
+
+    // ── Claim 6: no single pairwise edge recovers the 5-vertex variance ─────
+    // At N=3, one pairwise difference (left minus right bracket) exactly equals
+    // the associator — a single edge captures the full spread. At N=4 the
+    // pentagon has 5 vertices; the "edge variance" (norm²/2 of two vertices,
+    // which is what a single pairwise check measures) differs from the 5-vertex
+    // population variance for every choice of pair.
+    //
+    // We check all C(5,2)=10 pairs against pentagon_variance.  If ANY pair
+    // gives edge_normsq/2 == var_aff (within tolerance), a single pairwise
+    // diff would be sufficient — that would mean N=4 reduces to N=3. The
+    // claim is that NONE do.
+    //
+    // (edge_normsq/2 is the "two-point variance" of the two vertices,
+    // which is how a pairwise Δ maps to a variance budget.)
+    let pvar = pentagon_variance(&plain_ps)
+    var any_pair_matches: i64 = 0
+    var i6: i64 = 0
+    while i6 < 5 {
+        var j6: i64 = i6 + 1
+        while j6 < 5 {
+            let en = pentagon_edge_normsq(&plain_ps, i6, j6)
+            let pair_var = en / 2.0   // two-point population variance
+            if f_abs(pair_var - pvar) < 0.000001 { any_pair_matches = any_pair_matches + 1 }
+            j6 = j6 + 1
+        }
+        i6 = i6 + 1
+    }
+    println("")
+    println("── Claim 6: no pairwise edge recovers the 5-vertex pentagon_variance ──")
+    print(scaled(pvar)); println("   = pentagon_variance (×1e6)")
+    print(any_pair_matches); println("   = #pairs whose two-point variance matches pentagon_variance (→0)")
+    if any_pair_matches == 0 {
+        println("  PASS: N=4 needs all 5 vertices — no single pairwise diff suffices")
+        println("        (this is the genuine N=3→N=4 distinction)")
+    } else { println("  FAIL: a single pair recovered the full variance — N=4 reduces to N=3"); fails = fails + 1 }
 
     println("")
     if fails == 0 { println("ALL CLAIMS VERIFIED"); return 0 }

--- a/scripts/dev/run_sio_test_suite_v2.sh
+++ b/scripts/dev/run_sio_test_suite_v2.sh
@@ -66,6 +66,18 @@ fi
 source "$ROOT_DIR/scripts/lib/resolve_souc.sh"
 sounio_require_souc
 
+# If SOUC_BIN resolved to a raw ELF (not a shell script), route through the
+# subcommand wrapper so the harness can call `check`/`run`/`compile` correctly.
+if [[ "$(head -c 2 "$SOUC_BIN" 2>/dev/null)" != "#!" ]]; then
+    _NATIVE_WRAPPER="$ROOT_DIR/scripts/ci/souc-native-wrapper.sh"
+    if [[ -f "$_NATIVE_WRAPPER" ]]; then
+        export SOUNIO_SOUC_BIN="$SOUC_BIN"
+        SOUC_BIN="$_NATIVE_WRAPPER"
+        chmod +x "$_NATIVE_WRAPPER"
+    fi
+    unset _NATIVE_WRAPPER
+fi
+
 export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
 
 # Parse arguments


### PR DESCRIPTION
## What changed
- merged the low-risk content from `feat/affine-nonassoc-uncertainty` into `main`
- merged the raw-ELF harness fix from `claude/ir-heap-indirect`
- narrowed the affine demo runtime wording to the verified `lean_single` lane after local audit found the current Madaros default path still segfaults on those demos

## Why
Several forgotten branches no longer had live WIP but still carried useful, mergeable content. This PR integrates the small survivors and leaves the larger or already-absorbed branches for separate disposition.

## Impact
- adds the affine non-associativity audit note and two runnable example programs
- makes `scripts/dev/run_sio_test_suite_v2.sh` route raw ELF `SOUC_BIN` resolutions through the native wrapper instead of assuming a shell launcher
- avoids overclaiming that the affine demos run on the current default `bin/souc` path

## Audit notes
- `integrate/kw-demote-landing` was audited and found to be substantially absorbed by newer `main` changes (`&[T]` lowering, literal narrowing, `local_cap=2048`, section-copy helper), so it was not merged as-is
- larger branches like `codex/real-language-runner` and `codex/semcall-hof-main` remain separate because they need a dedicated integration pass, not housekeeping treatment

## Validation
- `bash -n scripts/dev/run_sio_test_suite_v2.sh`
- `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/epistemic/affine_nonassoc_demo.sio`
- `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/epistemic/affine_nonassoc_n4_demo.sio`
- `bin/llm-offload -t math-review -p xai` on the affine audit/examples content: `NO BLOCKING MATH ISSUES FOUND`

