### PR TITLE
[codex] sync docs registry after affine audit merge

### DIFF
--- a/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
+++ b/docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13
+-->
+
 # Affine arithmetic over a non-associative algebra: non-associativity as a noise symbol
 
 Status: **frontier opened — core mechanism designed, N=3 case proven (paper + execution), novelty boundary established against prior art.**

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 845
-- Repo-backed topics: 695
+- Total governed topics: 846
+- Repo-backed topics: 696
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 489
+- Authority count `repo_only`: 490
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 493 topics
+- A2: 494 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -72,6 +72,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.archived.roadmap-v0.5.0-part3 | archived | docs/archived/ROADMAP_v0.5.0_PART3.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.strategic-growth-plan | archived | docs/archived/STRATEGIC_GROWTH_PLAN.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.archived.todo-next | archived | docs/archived/TODO_NEXT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13 | repo_only | docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.bucket-d-script-hardening-2026-06-21 | repo_only | docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.chi5-real-axiom-audit-2026-05-30 | repo_only | docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-demo-sweep-2026-06-02 | repo_only | docs/audit/EPISTEMIC_DEMO_SWEEP_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1128,6 +1128,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.affine-nonassoc-uncertainty-2026-06-13",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.bucket-d-script-hardening-2026-06-21",
       "collection": "repo",
       "repo_doc_path": "docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md",


### PR DESCRIPTION
## What changed
- added the docs metadata header for `docs/audit/AFFINE_NONASSOC_UNCERTAINTY_2026-06-13.md`
- resynced `docs/governance/topic-registry.v1.json`, `DOCS_AUTHORITY_MATRIX.md`, and `DOCS_ACCEPTANCE_REPORT.md`

## Why
PR #552 merged a previously forgotten audit doc into `main`, but the generated docs-governance registry files were not resynced afterward. That made the `Contracts` job fail at the `Docs registry` step.

## Validation
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash ./scripts/dev/check_docs_registry.sh`
- `bash ./scripts/dev/check_docs_consistency.sh`
