### PR TITLE
[codex] resync docs registry after preprint merge

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 846
-- Repo-backed topics: 696
+- Total governed topics: 847
+- Repo-backed topics: 697
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 490
+- Authority count `repo_only`: 491
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 494 topics
+- A2: 495 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -489,6 +489,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.ppcr.claims-ledger | repo_only | docs/ppcr/CLAIMS_LEDGER.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ppcr.one-pager | repo_only | docs/ppcr/ONE_PAGER.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.ppcr.sounio-ppcr-map | repo_only | docs/ppcr/SOUNIO_PPCR_MAP.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.preprint.rapamycin-des-combo-outline | repo_only | docs/preprint/rapamycin_des_combo_outline.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.epistemic-meta-analysis | repo_only | docs/proposals/epistemic-meta-analysis.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.epistemic-workflows | repo_only | docs/proposals/epistemic-workflows.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.nma-nonassociative-algebra-note | repo_only | docs/proposals/nma_nonassociative_algebra_note.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -10741,6 +10741,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.preprint.rapamycin-des-combo-outline",
+      "collection": "repo",
+      "repo_doc_path": "docs/preprint/rapamycin_des_combo_outline.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.proposals.epistemic-meta-analysis",
       "collection": "repo",
       "repo_doc_path": "docs/proposals/epistemic-meta-analysis.md",

--- a/docs/preprint/rapamycin_des_combo_outline.md
+++ b/docs/preprint/rapamycin_des_combo_outline.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.preprint.rapamycin-des-combo-outline
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.preprint.rapamycin-des-combo-outline
+-->
+
 # Cross-domain epistemic uncertainty quantification for drug-eluting stents
 
 **Working title**  


### PR DESCRIPTION
## What changed
- added the docs metadata header for `docs/preprint/rapamycin_des_combo_outline.md`
- resynced `docs/governance/topic-registry.v1.json`, `DOCS_AUTHORITY_MATRIX.md`, and `DOCS_ACCEPTANCE_REPORT.md`

## Why
`main` stayed red in the `Contracts` job after a subsequent preprint merge introduced a new governed repo doc without rerunning the docs-governance sync. This PR just brings the generated registry artifacts back in line with the current tree.

## Validation
- `node scripts/docs/sync_governance_metadata.mjs`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
