### PR TITLE
fix(runtime): raise native handle-table capacity 4096 -> 1048576

### DIFF
--- a/self-hosted/native/gc.sio
+++ b/self-hosted/native/gc.sio
@@ -33,7 +33,7 @@ pub fn native_v2_handle_entry_field_pin_count() -> i64 { 24 }
 pub fn native_v2_handle_entry_field_flags() -> i64 { 32 }
 pub fn native_v2_handle_entry_field_epoch() -> i64 { 40 }
 pub fn native_v2_handle_entry_size() -> i64 { 48 }
-pub fn native_v2_handle_table_capacity_default() -> i64 { 4096 }
+pub fn native_v2_handle_table_capacity_default() -> i64 { 1048576 }
 pub fn native_v2_handle_table_bytes() -> i64 { native_v2_handle_entry_size() * native_v2_handle_table_capacity_default() }
 
 pub fn native_v2_descriptor_magic() -> i64 { 0x32445353 } // "SSD2"


### PR DESCRIPTION
## Problem

The native-v2 (Madaros) runtime allocates one heap **handle** per struct/array object and reclaims them only via a crude "empty-frame" bump-reset that fires when the handle table fills. A real scientific simulation (the dissertation PBPK parity tests) allocates thousands of intermediate state-vector structs across its integration loop, exhausting the **4096-entry** handle table within a few outer iterations.

When it fills, the reset wipes the heap (`heap_cursor = heap_base`, `handle_count = 0`) **while a live `MdzState` is still held** across the integrate loop. The next allocation then overwrites that struct's nested struct-of-array field — its `sys` handle becomes an f64 bit-pattern — and the following `st.sys.c[i]` dereferences a non-pointer → **SIGSEGV (rc=139)**.

## Diagnosis

ptrace-traced the fault (no gdb available) to a two-level handle deref reading a garbage nested-struct handle; then trapped the GC reset and classified its trigger as **handle-table exhaustion** (ruled out heap-full and `heap_cursor` corruption via in-codegen classifiers).

## Fix

Raise the default handle-table capacity to **1,048,576** (256×; ~48 MB table, lazily backed via `MAP_ANONYMOUS`, leaving ~1.95 GB heap). Bounded simulations now run without ever triggering the unsafe reset.

## Verification

- `dissertation_pbpk28_parity_ref_midazolam`: **rc=139 (segfault) → rc=0**, output matches `lean_single` (`...PARITY_DONE`).
- `epistemic_pbpk_native`: rc=6 → rc=0 (incidental improvement).
- **313-test f64 run-pass sweep (main vs fix): 0 regressions** (only improvements + two unchanged pre-existing `gum_h1` timeouts).

## Known limitation

Integration-heavier parity tests (`haloperidol`, `qss`, `frontend`) allocate beyond any fixed capacity that fits the 2 GB heap and still hit the unsafe reset — a correct fix for those requires real GC reclamation (liveness-aware collection), tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)