### PR TITLE
[codex] rescue real-runner compatibility slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
          test-knowledge-runtime-guard-native-lowering \
          test-knowledge-context-static \
          test-semantic-knowledge-spine \
+         test-madaros-identity test-real-language-runner \
          ops-guardrail-local ops-infra-up ops-strict-up ops-status \
          website-verified-snapshot
 
@@ -69,6 +70,12 @@ test-stdlib:         ## Run stdlib integration tests (subset)
 build-madaros:       ## Build the Stage1 modular compiler (Madaros)
 	@echo "→ Building Madaros (Stage1 modular compiler)"
 	bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
+
+test-madaros-identity: ## Verify Madaros identifies as the Stage1 modular Sounio compiler
+	@bash scripts/gates/g6_madaros_identity.sh
+
+test-real-language-runner: ## Verify public souc CLI + REPL + Madaros identity
+	@bash scripts/ci/real_language_runner_gate.sh
 
 madaros-full-gate: build-madaros ## Build Madaros, then run the Stage1 end-to-end gate
 	@echo "→ Running Madaros full-functioning gate"

--- a/bin/souc
+++ b/bin/souc
@@ -104,6 +104,18 @@ if _is_elf "${SOUNIO_SOUC_BIN:-}"; then
   exec "$SOUNIO_SOUC_BIN" "$@"
 fi
 
+# Historical raw positional compile form: `souc <src.sio> <out> [flags]`.
+# Keep routing this through the lean_single bootstrap ELF even though Madaros is
+# the default verb-oriented engine; the modular launcher does not implement the
+# raw `SRC OUT` ABI.
+if [[ $# -ge 2 && "${1:-}" == *.sio ]]; then
+  if [[ -x "$LEAN_SINGLE" ]]; then
+    exec "$LEAN_SINGLE" "$@"
+  fi
+  echo "souc: raw positional form '<src.sio> <out>' requires a lean_single ELF at $LEAN_SINGLE" >&2
+  exit 127
+fi
+
 # 2) Forced legacy engine.
 case "${SOUNIO_SOUC_ENGINE:-madaros}" in
   lean_single|lean-single|leansingle)

--- a/scripts/ci/real_language_runner_gate.sh
+++ b/scripts/ci/real_language_runner_gate.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# E2E gate for the public Sounio developer loop.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+TMP_HOME="$(mktemp -d /tmp/sounio-real-runner-home-XXXXXX)"
+TMP_ELF="$(mktemp /tmp/sounio-real-runner-XXXXXX.elf)"
+TMP_RAW="$(mktemp /tmp/sounio-real-runner-raw-XXXXXX.elf)"
+TMP_MADAROS_SRC="$(mktemp /tmp/sounio-madaros-XXXXXX.sio)"
+TMP_MADAROS_ELF="$(mktemp /tmp/sounio-madaros-XXXXXX.elf)"
+trap 'rm -rf "$TMP_HOME" "$TMP_ELF" "$TMP_RAW" "$TMP_MADAROS_SRC" "$TMP_MADAROS_ELF"' EXIT
+
+fail() {
+  echo "[real-runner] FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "[real-runner] output for $label:" >&2
+    printf '%s\n' "$haystack" >&2
+    fail "expected '$needle' in $label"
+  fi
+}
+
+echo "[real-runner] 1/7 souc --version"
+VERSION_OUT="$(./bin/souc --version 2>&1)"
+assert_contains "$VERSION_OUT" "Madar" "souc --version"
+assert_contains "$VERSION_OUT" "Sounio self-hosted compiler" "souc --version"
+
+echo "[real-runner] 2/7 souc info"
+INFO_OUT="$(./bin/souc info 2>&1)"
+assert_contains "$INFO_OUT" "wrapper:" "souc info"
+assert_contains "$INFO_OUT" "raw_elf:" "souc info"
+assert_contains "$INFO_OUT" "identity:" "souc info"
+
+echo "[real-runner] 3/7 souc check"
+./bin/souc check examples/hello.sio >/tmp/sounio-real-runner-check.log 2>&1 || {
+  cat /tmp/sounio-real-runner-check.log >&2
+  fail "souc check examples/hello.sio"
+}
+
+echo "[real-runner] 4/7 souc run stdout"
+RUN_OUT="$(./bin/souc run examples/native/hello.sio 2>&1)"
+assert_contains "$RUN_OUT" "Hello from self-hosted Sounio!" "souc run examples/native/hello.sio"
+assert_contains "$RUN_OUT" "42" "souc run examples/native/hello.sio"
+
+echo "[real-runner] 5/7 souc compile + execute ELF"
+./bin/souc compile examples/native/hof_closure_literal.sio -o "$TMP_ELF" >/tmp/sounio-real-runner-compile.log 2>&1 || {
+  cat /tmp/sounio-real-runner-compile.log >&2
+  fail "souc compile examples/native/hof_closure_literal.sio"
+}
+[[ -x "$TMP_ELF" ]] || fail "compiled ELF is not executable: $TMP_ELF"
+ELF_OUT="$("$TMP_ELF" 2>&1)"
+assert_contains "$ELF_OUT" "42" "compiled ELF"
+
+echo "[real-runner] 6/7 raw positional passthrough"
+./bin/souc examples/hello.sio "$TMP_RAW" >/tmp/sounio-real-runner-raw.log 2>&1 || {
+  cat /tmp/sounio-real-runner-raw.log >&2
+  fail "souc raw positional passthrough"
+}
+[[ -s "$TMP_RAW" ]] || fail "raw passthrough produced no ELF"
+
+echo "[real-runner] 7/7 REPL declaration + expression"
+REPL_OUT="$(printf '%s\n' \
+  'fn dbl(x: i64) -> i64 { x + x }' \
+  'dbl(21)' \
+  ':quit' \
+  | env HOME="$TMP_HOME" timeout 120 ./bin/souc repl 2>&1)"
+assert_contains "$REPL_OUT" "(defined)" "souc repl"
+assert_contains "$REPL_OUT" "42" "souc repl"
+
+echo "[real-runner] Madaros identity + native-v2 compile"
+bash scripts/gates/g6_madaros_identity.sh
+
+cat >"$TMP_MADAROS_SRC" <<'SRC'
+fn main() -> i64 {
+    42
+}
+SRC
+
+./bin/madaros compile "$TMP_MADAROS_SRC" -o "$TMP_MADAROS_ELF" >/tmp/sounio-real-runner-madaros.log 2>&1 || {
+  cat /tmp/sounio-real-runner-madaros.log >&2
+  fail "madaros compile"
+}
+chmod +x "$TMP_MADAROS_ELF"
+set +e
+"$TMP_MADAROS_ELF"
+MADAROS_RC=$?
+set -e
+[[ "$MADAROS_RC" -eq 42 ]] || fail "expected Madaros-compiled ELF exit 42, got $MADAROS_RC"
+
+echo "REAL_LANGUAGE_RUNNER_PASS"

--- a/scripts/gates/g6_madaros_identity.sh
+++ b/scripts/gates/g6_madaros_identity.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# g6_madaros_identity.sh - Madaros Stage1 identity gate.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# shellcheck source=/dev/null
+source "$ROOT_DIR/scripts/lib/resolve_madaros.sh"
+sounio_require_madaros
+
+VERSION_OUTPUT="$("$MADAROS_BIN" --version 2>&1 || true)"
+IDENTITY="$(printf '%s\n' "$VERSION_OUTPUT" | sed -n '1p')"
+
+if [[ -z "$IDENTITY" ]]; then
+  echo "[g6] FAIL: Madaros produced no --version output" >&2
+  exit 1
+fi
+
+if [[ "$VERSION_OUTPUT" != *"Madaros"* && "$VERSION_OUTPUT" != *"Madares"* ]]; then
+  echo "[g6] FAIL: expected Madaros/Madares identity, got:" >&2
+  printf '%s\n' "$VERSION_OUTPUT" >&2
+  exit 1
+fi
+
+if [[ "$VERSION_OUTPUT" != *"Sounio self-hosted compiler"* ]]; then
+  echo "[g6] FAIL: expected 'Sounio self-hosted compiler' in identity, got:" >&2
+  printf '%s\n' "$VERSION_OUTPUT" >&2
+  exit 1
+fi
+
+echo "[g6] PASS: Madaros identity OK: $IDENTITY"


### PR DESCRIPTION
## Summary
- add a current-main gate for the public `bin/souc` developer loop and Madaros identity
- restore the historical raw positional `souc <src.sio> <out>` ABI under the default Madaros launcher
- wire both checks into `Makefile`

## Context
This is a mergeable slice rescued from the stale `codex/real-language-runner` branch. The full branch is not suitable for direct merge because it bundles older wrappers and unrelated arm64 fixes, but this slice still closes a live compatibility gap on current `main`.

## Validation
- `bash scripts/gates/g6_madaros_identity.sh`
- `bash scripts/ci/real_language_runner_gate.sh`
- `make test-madaros-identity`
- `make test-real-language-runner`