### PR TITLE
docs+dev: lock in lean_single build path for stdlib/clinical/, audit Madaros multimodule fallback segfault

### DIFF
--- a/docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md
+++ b/docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md
@@ -1,0 +1,116 @@
+# Madaros multi-module native fallback: segfault in `lower_array: seed_begin`
+
+**Date:** 2026-06-30
+**Scope:** `bin/souc` (Madaros v0.80.0) native compilation of multi-module `.sio`
+programs (any `use module::*` import), default `native-v2` engine.
+**Status:** root-caused to two distinct, sequential bugs. First bug fixed by
+rebuild (stale prebuilt binary). Second bug open, minimal repro below.
+
+## Context
+
+`stdlib/clinical/vancomycin_pbpk.sio` (`use epistemic::knightian::*`) and
+`docs/audit/MADAROS_F64_NATIVE_V2_BUGREPORT.md` (this repo, 2026-06-30, commit
+`9626d88a1`) independently reported that Madaros native-v2 fails on f64-heavy
+and multi-module code, with `lean_single` (`SOUNIO_SOUC_ENGINE=lean_single` /
+`bin/souc-lean-single-x86_64`) as the correct-output engine.
+
+## Bug 1 (FIXED — stale prebuilt binary, not a source bug)
+
+`bin/souc-native` (checked-in prebuilt) predates commit
+`fix(madaros): fall back when compact imported IR emit fails`
+(`self-hosted/compiler/module_native_driver.sio`, 2026-06-30T18:04:19Z) by
+~8 hours. The prebuilt binary therefore never reaches the fallback path
+(`module_frontend_compile_imported_to_file`) when the compact "imported
+simple IR" table (`module_native_simple_driver.sio` — a bootstrap-stage
+pattern-matcher over ~20 fixed function "kinds", not a general code
+generator) fails to emit a function shape it doesn't recognize (which
+includes essentially all real f64 arithmetic).
+
+**Verified fix:** rebuilding via
+`bash scripts/ci/build_modular_madaros.sh <out>` (seeded from
+`bin/souc-lean-single-x86_64`, per the script's own seed-resolution order)
+produces a binary that *does* reach the fallback — confirmed by the
+`module_native_driver: compact IR load failed; falling back to full IR path`
+diagnostic, which the stale binary never printed.
+
+## Bug 2 (OPEN — segfault in the fallback's array/box lowering seed step)
+
+The fallback path itself (`module_frontend_lower_programs_array_direct_box`,
+`self-hosted/compiler/module_frontend.sio:4192`) segfaults on the **very
+first** module it lowers, inside
+`module_frontend_lower_program_items_box_traced_with_externs` — after the
+`"lower_array: seed_begin\n"` trace print (line 4204) and before
+`"lower_array: seed_done\n"` (line 4207). No further trace output is
+produced; no panic/error message, just SIGSEGV.
+
+### Minimal repro (2 files, deterministic)
+
+```sounio
+// lib.sio
+pub fn add_one(x: f64) -> f64 { x + 1.0 }
+```
+
+```sounio
+// main.sio
+use lib::*
+pub fn main() -> i32 with IO {
+    println(add_one(4.0))
+    0
+}
+```
+
+```
+$ ./madaros main.sio -o out.elf
+...
+imported_compile: lower_begin
+lower_array: seed_begin
+Segmentation fault
+```
+
+Reproduced with a freshly-rebuilt binary (today's `main`, post-Bug-1-fix), so
+this is not a stale-binary artifact. The crash is upstream of any f64-specific
+logic — even the trivial single-function `lib.sio` triggers it — so this
+looks like a general defect in the imported/multi-module box-lowering seed
+path, not specifically an f64 bug (though it blocks all multi-module f64
+code, including `stdlib/clinical/vancomycin_pbpk.sio`).
+
+### Suggested next step
+
+Bisect inside `module_frontend_lower_program_items_box_traced_with_externs`
+(`self-hosted/compiler/module_frontend.sio`) with additional trace prints, or
+attach a debugger capable of reading the hand-emitted ELF (no DWARF is
+emitted by the self-hosted backend, so `gdb` alone will not resolve symbols —
+a print-statement bisection is the practical path used for Bug 1's sibling
+report). Not attempted here due to unbounded scope within this session; flagged
+for a dedicated follow-up.
+
+## Practical resolution (unblocks the clinical digital-twin work now)
+
+Until Bug 2 is fixed, multi-module and/or f64-heavy `.sio` programs —
+including all of `stdlib/clinical/`, `stdlib/darwin_pbpk/`, and any program
+importing `epistemic::knightian` — **must** be built with the `lean_single`
+engine, not the default Madaros native-v2 path:
+
+```bash
+SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run stdlib/clinical/vancomycin_pbpk.sio
+# or, directly:
+./bin/souc-lean-single-x86_64 stdlib/clinical/vancomycin_pbpk.sio /tmp/out.elf && /tmp/out.elf
+```
+
+This is not a workaround of last resort: `souc-lean-single-x86_64` is the
+verified bootstrap seed compiler (it is literally what `scripts/ci/
+build_modular_madaros.sh` uses to build Madaros itself), and both
+`stdlib/clinical/vancomycin_pbpk.sio` and
+`examples/dissertation_vancomycin_demo.sio` produce hand-verified-correct
+numeric output under it (see `docs/audit/` PBPK session notes and this
+report's companion verification below).
+
+## Verification of the twin under `lean_single` (for the record)
+
+`stdlib/clinical/vancomycin_pbpk.sio :: main()`, three scenarios:
+
+| Scenario | Cmin band (mg/L) | Decision | Hand-check |
+|---|---|---|---|
+| Pre-TDM (0 samples), 78.5 kg, CrCl 65, 1000 mg q12h | [9.052178, 24.298861] | `PRE_REFUSE` | matches closed-form Fréchet corners (Vc_lo,CL_hi)/(Vc_hi,CL_lo) to 6 d.p. |
+| Post-TDM (3 samples), same patient | [12.820636, 17.358234] | `POST_PRESCRIBE` | matches, band ⊂ [10,20] |
+| Contract violation (weight 15 kg) | — | `CONTRACT_BLOCK` | correct refinement-gate refusal |

--- a/scripts/dev/run_clinical_twin.sh
+++ b/scripts/dev/run_clinical_twin.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/dev/run_clinical_twin.sh
+#
+# Build-and-run wrapper for stdlib/clinical/ digital-twin programs.
+#
+# WHY THIS EXISTS: Madaros native-v2 (the default `bin/souc` engine) has an
+# open bug in multi-module native compilation (segfault in
+# module_frontend_lower_programs_array_direct_box's array/box lowering seed
+# step -- see docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md)
+# that blocks ANY program importing another module (`use x::y::*`), which
+# includes every file under stdlib/clinical/. The `lean_single` engine
+# (bin/souc-lean-single-x86_64 -- the verified bootstrap seed compiler used
+# to build Madaros itself) does not have this bug and produces
+# hand-verified-correct output. Use this script, not `souc run`, for clinical
+# / PBPK code until the Madaros bug is fixed.
+#
+# Usage: scripts/dev/run_clinical_twin.sh <file.sio>
+
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="${1:?Usage: $0 <file.sio>}"
+ENGINE="$ROOT_DIR/bin/souc-lean-single-x86_64"
+
+if [[ ! -x "$ENGINE" ]]; then
+    echo "error: $ENGINE not found or not executable" >&2
+    exit 1
+fi
+
+TMP_ELF="$(mktemp /tmp/clinical_twin_run_XXXXXX)"
+trap 'rm -f "$TMP_ELF"' EXIT
+
+"$ENGINE" "$SRC" "$TMP_ELF"
+chmod +x "$TMP_ELF"
+exec "$TMP_ELF"

--- a/stdlib/clinical/README.md
+++ b/stdlib/clinical/README.md
@@ -1,31 +1,29 @@
 # `stdlib/clinical/`
 
-Skeleton for the clinical / neurobiological extension of the Sounio
-platform.  This directory is intentionally minimal: it only hosts
-import-ready placeholders and documentation for the *parallel* plan
-covering the depression-biomarker line of work (EEG + fMRI + Ollivier–
-Ricci curvature).
+Clinical digital-twin modules: pharmacokinetic/dosing-safety pipelines with
+Knightian-uncertainty (p-box) propagation.
 
-## Intended layout
+## Working modules
 
+- `vancomycin_pbpk.sio` — vancomycin trough-screening twin (`predict_cmin_knightian`,
+  `is_safe_dose`). Mirrors `formal/lean4/SounioVancomycinDosingSafety.lean`.
+- `tacrolimus_oral_safety.sio` — tacrolimus C24h dosing-safety twin.
+- `aminoglycoside_pbpk.sio` — aminoglycoside PBPK module.
+- `biomarker.sio` — see `docs/plans/` for the parallel EEG+fMRI+ORC biomarker line.
+
+## IMPORTANT: build engine
+
+These modules import other modules (`use epistemic::knightian::*`), which hits an
+open Madaros native-v2 bug (segfault in multi-module array/box lowering —
+see `docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md`).
+
+**Always run clinical/PBPK code with:**
+
+```bash
+scripts/dev/run_clinical_twin.sh stdlib/clinical/vancomycin_pbpk.sio
 ```
-stdlib/clinical/
-├── README.md                  # this file
-├── eeg.sio                    # EEG ingestion + channel algebra (TBD)
-├── fmri.sio                   # fMRI ROI volumes + motion correction (TBD)
-├── orc.sio                    # Ollivier–Ricci curvature on connectomes (TBD)
-└── biomarker.sio              # pipeline wiring EEG+fMRI+ORC into a single
-                                # epistemic classifier (TBD)
-```
 
-## Why empty now
-
-The surgical-interventions program (G3/G5/G7) and the biomarker program
-are orthogonal contributions that share the same algebraic substrate
-(sedenion ZD).  Keeping them in separate plans lets each program land
-independently, without coupling compiler changes to clinical data
-formats.
-
-Nothing in this directory is imported or compiled in the current
-release.  Touching these files should be the explicit scope of the
-biomarker plan (see `docs/plans/` when it lands).
+Do **not** use the default `bin/souc run` (Madaros native-v2) for anything
+under `stdlib/clinical/` until that bug is fixed — it will either fail to
+compile or, for pure single-file f64 code, silently miscompile (see
+`docs/audit/MADAROS_F64_NATIVE_V2_BUGREPORT.md`).


### PR DESCRIPTION
## Summary
Root-causes the Madaros native-v2 multimodule compilation failure blocking `stdlib/clinical/vancomycin_pbpk.sio` and any program with `use module::*`, fixes what's fixable, documents what isn't yet, and locks in a verified working build path for the clinical digital-twin code.

## Bug 1 — FIXED (stale prebuilt binary, no source change needed)
The checked-in `bin/souc-native` predated commit *"fix(madaros): fall back when compact imported IR emit fails"* by ~8h, so it never reached the intended fallback (`module_frontend_compile_imported_to_file`) when the compact "imported simple IR" table — a bootstrap-stage pattern-matcher over ~20 fixed function shapes, not a general codegen — fails to emit an unrecognized shape (which includes essentially all real `f64` arithmetic). Rebuilding via `scripts/ci/build_modular_madaros.sh` (seeded from `souc-lean-single-x86_64`) produces a binary that correctly reaches the fallback.

## Bug 2 — OPEN, documented with a minimal deterministic repro
The fallback itself (`module_frontend_lower_programs_array_direct_box` → `module_frontend_lower_program_items_box_traced_with_externs`) segfaults during array/box lowering seed, upstream of any f64-specific logic — even a trivial 2-file, non-f64-specific import triggers it. Full write-up + minimal repro + suggested bisection approach: `docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md`.

## What this PR adds
- **`docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md`** — the bug report above.
- **`scripts/dev/run_clinical_twin.sh`** — builds/runs `stdlib/clinical/` programs via the verified `souc-lean-single-x86_64` engine (the bootstrap seed compiler itself, not an ad hoc workaround) until Bug 2 is fixed.
- **`stdlib/clinical/README.md`** — corrected; it predated `vancomycin_pbpk.sio` / `tacrolimus_oral_safety.sio` / `aminoglycoside_pbpk.sio` and still described the directory as an empty skeleton.

## Verification
End-to-end re-verified via the new wrapper: `stdlib/clinical/vancomycin_pbpk.sio` reproduces the hand-checked Cmin bounds exactly — `PRE_REFUSE` [9.052178, 24.298861], `POST_PRESCRIBE` [12.820636, 17.358234], `CONTRACT_BLOCK` for the out-of-contract case.
