### PR TITLE
[codex] rescue project-mode launcher slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
          test-knowledge-runtime-guard-native-lowering \
          test-knowledge-context-static \
          test-semantic-knowledge-spine \
-         test-madaros-identity test-real-language-runner \
+         test-madaros-identity test-real-language-runner test-project-spine \
          ops-guardrail-local ops-infra-up ops-strict-up ops-status \
          website-verified-snapshot
 
@@ -76,6 +76,9 @@ test-madaros-identity: ## Verify Madaros identifies as the Stage1 modular Sounio
 
 test-real-language-runner: ## Verify public souc CLI + REPL + Madaros identity
 	@bash scripts/ci/real_language_runner_gate.sh
+
+test-project-spine: ## Verify sounio.toml project mode on souc and Madaros
+	@bash scripts/ci/project_spine_gate.sh
 
 madaros-full-gate: build-madaros ## Build Madaros, then run the Stage1 end-to-end gate
 	@echo "→ Running Madaros full-functioning gate"

--- a/README.md
+++ b/README.md
@@ -248,8 +248,10 @@ export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
 $SOUC --version                              # souc 1.0.0-beta.6
 $SOUC info                                   # selected host artifact + wrapper contract
 $SOUC check examples/hello.sio               # type-check via checked self-hosted lane
+$SOUC init hello_pkg && cd hello_pkg         # create a minimal sounio.toml project
+$SOUC check && $SOUC run && $SOUC build      # project entrypoint -> ELF
+$SOUC run examples/native/hello.sio          # compile to a temp ELF and execute it
 $SOUC compile examples/hello.sio -o /tmp/souc-next
-$SOUC run self-hosted/compiler/native_print_f64_smoke.sio
 $SOUC compile examples/hello.sio -o /tmp/hello-macos --target aarch64-macos
 ```
 
@@ -306,11 +308,11 @@ See [docs/MANIFESTO.md](docs/MANIFESTO.md) for the full philosophy.
 
 **Native startup cost.** Native execution still requires producing a host binary before launch, so there is a small startup cost compared with an in-process executor.
 
-**Launcher contract.** `bin/souc` now provides compatibility commands for `check`, `run`, `compile`, and `build`, but broader omega workflows and JIT-oriented tooling still live outside the checked self-hosted launcher lane.
+**Launcher contract.** `bin/souc` now provides compatibility commands for `check`, `run`, `compile`, `build`, and `init`. When invoked inside a directory with `sounio.toml`, `check`, `run`, and `build` resolve the project entrypoint from `[[bin]].path`, `[project].entry`, or `src/main.sio`. Broader omega workflows and JIT-oriented tooling still live outside the checked self-hosted launcher lane.
 
 **Windows cross-compile.** The PE/COFF backend (3,508 lines) is production-grade. Use `--target x86_64-windows` to emit Windows binaries. No pre-built .exe is shipped in this checkout.
 
-**No REPL yet.** The checked self-hosted launcher does not support `repl`.
+**REPL.** The checked self-hosted launcher supports `souc repl` for a file-backed interactive loop.
 
 **Debug flags.** `--show-ast` and `--show-types` are supported as pass-through flags on the checked self-hosted launcher for `check`, `run`, `compile`, and `build`.
 

--- a/bin/madaros
+++ b/bin/madaros
@@ -64,11 +64,14 @@ madaros — launcher for the Madaros modular compiler ($RAW_MADAROS)
 Usage:
   madaros --version                     print compiler identity
   madaros info                          print resolution path
-  madaros check <source.sio>            parse, resolve and typecheck
-  madaros build <source.sio> [-o OUT] [--backend native|gpu]
+  madaros check <source.sio|project-dir>
+                                      parse, resolve and typecheck
+  madaros build <source.sio|project-dir> [-o OUT] [--backend native|gpu]
                                       compile source to native ELF or GPU artifact
-  madaros compile <source.sio> [-o OUT] alias for build
-  madaros run <source.sio>              compile to a temp ELF and run it
+  madaros compile <source.sio|project-dir> [-o OUT]
+                                      alias for build
+  madaros run <source.sio|project-dir>
+                                      compile to a temp ELF and run it
   madaros pkg <subcommand>...           package-manager commands
   madaros <raw-compiler-args>...        pass through to the raw ELF
 
@@ -106,6 +109,105 @@ version() {
   local out
   out="$("$RAW_MADAROS" /dev/null /dev/null 2>/dev/null)" || true
   echo "$out" | head -n 1
+}
+
+find_project_root() {
+  local start="${1:-$PWD}"
+  if [[ -f "$start" ]]; then
+    start="$(dirname "$start")"
+  fi
+  if [[ -d "$start" ]]; then
+    start="$(cd "$start" && pwd)"
+  else
+    return 1
+  fi
+  while [[ "$start" != "/" ]]; do
+    if [[ -f "$start/sounio.toml" ]]; then
+      printf '%s\n' "$start"
+      return 0
+    fi
+    start="$(dirname "$start")"
+  done
+  return 1
+}
+
+project_manifest_value() {
+  local root="$1"
+  local key="$2"
+  python3 - "$root/sounio.toml" "$key" <<'PY'
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    raise SystemExit(3)
+path, key = sys.argv[1], sys.argv[2]
+text = open(path, "rb").read().decode("utf-8")
+data = tomllib.loads(text)
+if key == "package.name":
+    print(data.get("package", {}).get("name", "sounio-project"))
+elif key == "entry":
+    bins = data.get("bin", [])
+    if isinstance(bins, list) and bins:
+        value = bins[0].get("path", "")
+        if value:
+            print(value)
+            raise SystemExit(0)
+    value = data.get("project", {}).get("entry", "")
+    if value:
+        print(value)
+        raise SystemExit(0)
+    value = data.get("lib", {}).get("path", "")
+    if value and "[[bin]]" not in text:
+        print(value)
+        raise SystemExit(0)
+    print("src/main.sio")
+else:
+    raise SystemExit(2)
+PY
+}
+
+resolve_source_or_project() {
+  local candidate="${1:-}"
+  if [[ -n "$candidate" && -f "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  local root=""
+  if [[ -n "$candidate" && -d "$candidate" ]]; then
+    root="$(find_project_root "$candidate" || true)"
+  else
+    root="$(find_project_root "$PWD" || true)"
+  fi
+  if [[ -z "$root" ]]; then
+    return 1
+  fi
+
+  local entry
+  entry="$(project_manifest_value "$root" entry)"
+  if [[ ! -f "$root/$entry" ]]; then
+    echo "error: project entry not found: $root/$entry" >&2
+    return 1
+  fi
+  printf '%s\n' "$root/$entry"
+}
+
+project_default_output() {
+  local root="$1"
+  local name
+  name="$(project_manifest_value "$root" package.name)"
+  mkdir -p "$root/target"
+  printf '%s\n' "$root/target/$name"
+}
+
+args_have_output() {
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "-o" || "$arg" == "--output" ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 _check_source_arg() {
@@ -264,29 +366,53 @@ case "$1" in
     info
     ;;
   check)
-    if [[ $# -lt 2 ]]; then
-      echo "error: madaros check: missing source file" >&2
+    shift
+    candidate="${1:-}"
+    if ! src="$(resolve_source_or_project "$candidate")"; then
+      echo "error: madaros check requires <source.sio> or a project with sounio.toml" >&2
       exit 2
     fi
-    _run_raw_check "$2" "${@:3}"
+    if [[ -n "$candidate" ]]; then
+      shift
+    fi
+    _run_raw_check "$src" "$@"
     ;;
   build|compile)
-    if [[ $# -lt 2 ]]; then
-      echo "error: madaros build: missing source file" >&2
-      exit 2
-    fi
-    if [[ "${2:-}" == "-h" || "${2:-}" == "--help" || "${2:-}" == "help" ]]; then
+    shift
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
       usage
       exit 0
     fi
-    _build_source "$2" "${@:3}"
-    ;;
-  run)
-    if [[ $# -lt 2 ]]; then
-      echo "error: madaros run: missing source file" >&2
+    candidate="${1:-}"
+    if [[ -n "$candidate" && "$candidate" != -* ]]; then
+      shift
+    else
+      candidate=""
+    fi
+    if ! src="$(resolve_source_or_project "$candidate")"; then
+      echo "error: madaros build requires <source.sio> or a project with sounio.toml" >&2
       exit 2
     fi
-    _run_source "$2" "${@:3}"
+    project_root=""
+    if [[ -z "$candidate" || -d "$candidate" ]]; then
+      project_root="$(find_project_root "${candidate:-$PWD}" || true)"
+    fi
+    if [[ -n "$project_root" ]] && ! args_have_output "$@"; then
+      set -- "$@" -o "$(project_default_output "$project_root")"
+    fi
+    _build_source "$src" "$@"
+    ;;
+  run)
+    shift
+    candidate="${1:-}"
+    if ! src="$(resolve_source_or_project "$candidate")"; then
+      echo "error: madaros run requires <source.sio> or a project with sounio.toml" >&2
+      exit 2
+    fi
+    if [[ -n "$candidate" ]]; then
+      shift
+    fi
+    _run_source "$src" "$@"
     ;;
   -h|--help|help)
     usage

--- a/bin/souc
+++ b/bin/souc
@@ -44,6 +44,44 @@ _resolve_madaros() {
   return 1
 }
 
+cmd_init() {
+  if [[ $# -ne 1 ]]; then
+    echo "souc: init requires <name>" >&2
+    exit 2
+  fi
+  local name="$1"
+  if [[ -e "$name" ]]; then
+    echo "souc: path already exists: $name" >&2
+    exit 1
+  fi
+  mkdir -p "$name/src"
+  cat >"$name/sounio.toml" <<EOF
+[package]
+name = "$name"
+version = "0.1.0"
+edition = "2026"
+
+[[bin]]
+name = "$name"
+path = "src/main.sio"
+EOF
+  cat >"$name/src/greet.sio" <<'EOF'
+pub fn answer() -> i64 {
+    42
+}
+EOF
+  cat >"$name/src/main.sio" <<'EOF'
+use greet::{answer}
+
+fn main() -> i64 with IO {
+    print_int(answer())
+    print_char(10)
+    0
+}
+EOF
+  echo "Created Sounio project: $name"
+}
+
 # souc-flavoured help. The `check|compile|run <file.sio>` tokens are the repo-wide
 # capability-probe contract (scripts grep `souc --help` for `compile <file.sio>` /
 # `run <file.sio>` to decide between the verb CLI and the raw `SRC OUT` form). We
@@ -58,12 +96,15 @@ souc — the Sounio compiler (default engine: Madaros)
 Usage:
   souc --version                      print compiler identity
   souc info                           print compiler status
-  souc check <file.sio>               parse, resolve and typecheck
-  souc compile <file.sio> [-o OUT]    compile <file.sio> to a native ELF
-  souc build <file.sio> [-o OUT]      compile source to native ELF
+  souc check <file.sio|project-dir>   parse, resolve and typecheck
+  souc compile <file.sio|project-dir> [-o OUT]
+                                      compile source to a native ELF
+  souc build <file.sio|project-dir> [-o OUT]
+                                      compile source to a native ELF
   souc build <file.sio> --backend gpu -o OUT
                                       emit a public GPU artifact (PTX by default)
-  souc run <file.sio>                 run <file.sio> (compile to a temp ELF and execute)
+  souc run <file.sio|project-dir>     run source (compile to a temp ELF and execute)
+  souc init <name>                    create a minimal sounio.toml project
   souc format <file.sio>              format Sounio source on stdout
   souc fmt <file.sio>                 alias for format
   souc repl                           start the file-backed Sounio REPL
@@ -79,6 +120,11 @@ USAGE
 # front of engine dispatch so the public `bin/souc` surface is consistent for
 # Madaros and lean_single users alike.
 case "${1:-}" in
+  init)
+    shift
+    cmd_init "$@"
+    exit 0
+    ;;
   format|fmt)
     if [[ $# -lt 2 ]]; then
       echo "souc: usage: souc ${1:-format} <file.sio>" >&2

--- a/examples/projects/bad_missing_import/sounio.toml
+++ b/examples/projects/bad_missing_import/sounio.toml
@@ -1,0 +1,8 @@
+[package]
+name = "bad_missing_import"
+version = "0.1.0"
+edition = "2026"
+
+[[bin]]
+name = "bad_missing_import"
+path = "src/does_not_exist.sio"

--- a/examples/projects/bad_missing_import/src/main.sio
+++ b/examples/projects/bad_missing_import/src/main.sio
@@ -1,0 +1,5 @@
+use does_not_exist::{answer}
+
+fn main() -> i64 {
+    answer()
+}

--- a/examples/projects/hello_pkg/sounio.toml
+++ b/examples/projects/hello_pkg/sounio.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hello_pkg"
+version = "0.1.0"
+edition = "2026"
+
+[[bin]]
+name = "hello_pkg"
+path = "src/main.sio"

--- a/examples/projects/hello_pkg/src/greet.sio
+++ b/examples/projects/hello_pkg/src/greet.sio
@@ -1,0 +1,3 @@
+pub fn answer() -> i64 {
+    42
+}

--- a/examples/projects/hello_pkg/src/main.sio
+++ b/examples/projects/hello_pkg/src/main.sio
@@ -1,0 +1,7 @@
+use greet::{answer}
+
+fn main() -> i64 with IO {
+    print_int(answer())
+    print_char(10)
+    0
+}

--- a/scripts/ci/project_spine_gate.sh
+++ b/scripts/ci/project_spine_gate.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# E2E gate for Sounio project mode: sounio.toml -> local imports -> ELF.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+TMP_DIR="$(mktemp -d /tmp/sounio-project-spine-XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "[project-spine] FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "[project-spine] output for $label:" >&2
+    printf '%s\n' "$haystack" >&2
+    fail "expected '$needle' in $label"
+  fi
+}
+
+echo "[project-spine] 1/7 public runner baseline"
+bash scripts/ci/real_language_runner_gate.sh
+
+echo "[project-spine] 2/7 souc check/run/build on project dir"
+./bin/souc check examples/projects/hello_pkg
+HELLO_RUN_OUT="$(./bin/souc run examples/projects/hello_pkg 2>&1)"
+assert_contains "$HELLO_RUN_OUT" "42" "souc run examples/projects/hello_pkg"
+rm -f examples/projects/hello_pkg/target/hello_pkg
+./bin/souc build examples/projects/hello_pkg
+[[ -x examples/projects/hello_pkg/target/hello_pkg ]] || fail "souc build did not create target/hello_pkg"
+HELLO_ELF_OUT="$(examples/projects/hello_pkg/target/hello_pkg 2>&1)"
+assert_contains "$HELLO_ELF_OUT" "42" "built hello_pkg ELF"
+rm -f examples/projects/hello_pkg/target/hello_pkg
+
+echo "[project-spine] 3/7 souc init project loop"
+(
+  cd "$TMP_DIR"
+  "$ROOT_DIR/bin/souc" init generated_pkg
+  cd generated_pkg
+  "$ROOT_DIR/bin/souc" check
+  GENERATED_RUN_OUT="$("$ROOT_DIR/bin/souc" run 2>&1)"
+  assert_contains "$GENERATED_RUN_OUT" "42" "generated project run"
+  "$ROOT_DIR/bin/souc" build
+  [[ -x target/generated_pkg ]] || fail "generated project build did not create target/generated_pkg"
+  GENERATED_ELF_OUT="$(target/generated_pkg 2>&1)"
+  assert_contains "$GENERATED_ELF_OUT" "42" "generated project built ELF"
+)
+
+echo "[project-spine] 4/7 missing entry negative"
+NEG_LOG="$TMP_DIR/missing_entry.log"
+set +e
+./bin/souc check examples/projects/bad_missing_import >"$NEG_LOG" 2>&1
+NEG_RC=$?
+set -e
+if [[ "$NEG_RC" -eq 0 ]]; then
+  cat "$NEG_LOG" >&2
+  fail "missing entry project unexpectedly passed"
+fi
+if ! grep -q "project entry not found:" "$NEG_LOG"; then
+  cat "$NEG_LOG" >&2
+  fail "missing entry project did not emit a project-entry diagnostic"
+fi
+
+echo "[project-spine] 5/7 Madaros identity"
+bash scripts/gates/g6_madaros_identity.sh
+
+echo "[project-spine] 6/7 Madaros check/run/build on project dir"
+./bin/madaros check examples/projects/hello_pkg
+MADAROS_RUN_OUT="$(./bin/madaros run examples/projects/hello_pkg 2>&1)"
+assert_contains "$MADAROS_RUN_OUT" "42" "madaros run examples/projects/hello_pkg"
+rm -f examples/projects/hello_pkg/target/hello_pkg
+./bin/madaros build examples/projects/hello_pkg
+[[ -x examples/projects/hello_pkg/target/hello_pkg ]] || fail "madaros build did not create target/hello_pkg"
+MADAROS_ELF_OUT="$(examples/projects/hello_pkg/target/hello_pkg 2>&1)"
+assert_contains "$MADAROS_ELF_OUT" "42" "madaros built hello_pkg ELF"
+rm -f examples/projects/hello_pkg/target/hello_pkg
+
+echo "[project-spine] 7/7 cwd project resolution"
+(
+  cd examples/projects/hello_pkg
+  "$ROOT_DIR/bin/souc" check
+  CWD_RUN_OUT="$("$ROOT_DIR/bin/souc" run 2>&1)"
+  assert_contains "$CWD_RUN_OUT" "42" "souc run from project cwd"
+)
+
+echo "PROJECT_SPINE_PASS"


### PR DESCRIPTION
## Summary
- restore `sounio.toml` project mode on the public `souc` and `madaros` launchers
- add `souc init <name>` for a minimal project scaffold
- add focused example projects and a `project_spine_gate` Make target

## Context
This is a narrow slice rescued from the older `codex/project-spine-madaros` lane. The broader lane still bundles a large imported-call and native-v2 stack, but current `main` already has enough compiler support for local imported project entrypoints. The missing piece was launcher resolution plus a focused gate.

## What this slice intentionally does not include
- the larger imported-call stack from `codex/project-spine-madaros`
- solver/checker repro slices stacked on top of that owner branch
- unrelated launcher/history/doc cleanup from older branches

## Validation
- `bash scripts/ci/project_spine_gate.sh`
- `make test-project-spine`

## Notes
- the negative case is a missing project entrypoint path, which is a launcher/project-surface failure class
- the rest of `codex/project-spine-madaros` remains owner-only / stacked work