### PR TITLE
docs(governance): resync stale registry

### DIFF
--- a/docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md
+++ b/docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-multimodule-fallback-segfault-2026-06-30
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-multimodule-fallback-segfault-2026-06-30
+-->
+
 # Madaros multi-module native fallback: segfault in `lower_array: seed_begin`
 
 **Date:** 2026-06-30

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 847
-- Repo-backed topics: 697
+- Total governed topics: 848
+- Repo-backed topics: 698
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 491
+- Authority count `repo_only`: 492
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 495 topics
+- A2: 496 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -129,6 +129,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-match-guards-2026-06-24 | repo_only | docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-method-call-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-multimodule-fallback-segfault-2026-06-30 | repo_only | docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-multimodule-native-seed-segfault-2026-06-22 | repo_only | docs/audit/MADAROS_MULTIMODULE_NATIVE_SEED_SEGFAULT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-native-v2-codegen-census-2026-06-19 | repo_only | docs/audit/MADAROS_NATIVE_V2_CODEGEN_CENSUS_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-open-pr-worktree-disposition-2026-06-21 | repo_only | docs/audit/MADAROS_OPEN_PR_WORKTREE_DISPOSITION_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2439,6 +2439,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-multimodule-fallback-segfault-2026-06-30",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-multimodule-native-seed-segfault-2026-06-22",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_MULTIMODULE_NATIVE_SEED_SEGFAULT_2026-06-22.md",


### PR DESCRIPTION
## What

Contracts / Docs registry has been red on \`main\` since PR #558 (and #557
before it): \`docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md\`
was committed without running the sync script, so it's missing its
\`docs:meta\` block and isn't registered in
\`docs/governance/topic-registry.v1.json\`.

## Fix

Ran \`node scripts/docs/sync_governance_metadata.mjs\`, which:
- adds the missing \`docs:meta\` header to the untracked audit doc
- registers it in \`topic-registry.v1.json\`
- refreshes the derived \`DOCS_ACCEPTANCE_REPORT.md\` / \`DOCS_AUTHORITY_MATRIX.md\`

\`bash scripts/dev/check_docs_registry.sh\` now passes locally (previously
failing the same way CI does on main).

Unrelated to #559 (str_from_bytes native-v2 fix) — that PR's one red check
(Contracts) is this same pre-existing main-inherited failure, not caused by
that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)