### PR TITLE
[codex] extend thin import witness coverage

### DIFF
--- a/tests/madaros/multimodule_witness/manifest.tsv
+++ b/tests/madaros/multimodule_witness/manifest.tsv
@@ -1,7 +1,9 @@
 # case_id	program_path	expected_exit	gate_mode
 # gate_mode: run = check + madaros run; compile = check + compile -o only (run not gated)
 thin_single	tests/multimodule/thin_single_main.sio	7	run
+thin_expr_args	tests/multimodule/thin_expr_args_main.sio	7	run
 thin_four_locals	tests/multimodule/thin_four_locals_main.sio	7	run
+thin_locals	tests/multimodule/thin_locals_main.sio	7	run
 thin_parenthesized_local_args	tests/multimodule/thin_parenthesized_local_args_main.sio	7	run
 thin_return_call	tests/multimodule/thin_return_call_main.sio	7	run
 thin_typed_var_args	tests/multimodule/thin_typed_var_args_main.sio	7	run

--- a/tests/multimodule/thin_expr_args_main.sio
+++ b/tests/multimodule/thin_expr_args_main.sio
@@ -1,0 +1,9 @@
+//@ run-pass
+
+use thin_single_lib::{add_public}
+
+fn main() -> i64 {
+    let base = 2
+    let y = base + 2
+    add_public(base + 1, y)
+}

--- a/tests/multimodule/thin_locals_main.sio
+++ b/tests/multimodule/thin_locals_main.sio
@@ -1,0 +1,9 @@
+//@ run-pass
+
+use thin_single_lib::{add_public}
+
+fn main() -> i64 {
+    let x = 3
+    let y = x + 1
+    add_public(x, y)
+}


### PR DESCRIPTION
## Summary
- extract the last clean witness-only residue from `codex/project-spine-slice-20260630`
- add `thin_expr_args_main` and `thin_locals_main` multimodule witnesses
- extend the Madaros multimodule manifest from 9 cases to 11

## Validation
- `bash scripts/ci/madaros_multimodule_witness.sh`
- direct `./bin/madaros run` on both new witnesses

## Context
The rest of commit `87751fdde` conflicts with launcher/project-dir work already absorbed by `#558` and `#562`. This PR keeps only the text-only witness delta that still applies cleanly to current `main`.