### PR TITLE
fix(stdlib): fix arity-mismatch cluster — closes #569

### DIFF
--- a/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
+++ b/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
@@ -143,3 +143,54 @@ visible fallback notice, while CI's authoritative gate uses a freshly-bootstrapp
 performance). Before trusting a local `souc check` result as CI-equivalent, confirm which
 engine `bin/souc info` (or `_resolve_madaros`) actually resolved to, or rebuild
 `lean_single` from source and test against that directly.
+
+## Update 2026-07-02 (continued): Bug D — qualified call nested as an argument miscounts the outer call's arity
+
+Found while fixing issue #569 (the "arity mismatch" cluster: `tests/stdlib/dataframe/
+test_dataframe_core.sio`, `tests/stdlib/audio/test_audio_core.sio`, `tests/stdlib/geo/
+test_geo_core.sio`, `tests/stdlib/simulation/test_simulation_core.sio`). Issue #569 had
+speculated this cluster might share Bug B's root cause (qualified-path parameter type +
+co-scope glob import) — checked and **ruled out**: none of the 4 files' failing calls
+have a qualified-path parameter type anywhere in scope. The real, distinct trigger,
+isolated with a minimal 2-file repro outside stdlib:
+
+```sio
+// stdlib/pkg/sub/inner.sio
+module pkg::sub::inner
+pub fn two_args(a: i64, b: i64) -> i64 { a + b }
+
+// main.sio
+fn outer(x: i64, y: i64) -> bool { x == y }
+
+fn main() -> i64 {
+    let r1 = outer(pkg::sub::inner::two_args(1, 2), 3)   // error: arity mismatch (on outer!)
+    let r2 = pkg::sub::inner::two_args(1, 2)              // fine — same call, standalone
+    0
+}
+```
+
+A fully-qualified call (`pkg::subdir::file::symbol(...)`, 3+ segments — already known to
+resolve per Bug A) used as an **argument expression nested inside another call**
+(`outer(qualified_call(...), other_arg)`) produces a false `arity mismatch` on the
+*outer* call, even though both calls individually have the correct argument count. The
+identical call used as its own standalone statement (not nested) does not trigger it.
+Madaros does not reproduce this (checks OK); confirmed lean_single-only, same as Bugs A
+and B.
+
+All 4 affected files had the exact same shape: `near(pkg::pure::types::fn(args), literal)`
+— a qualified accessor call nested directly inside a `near()` (approx-equality) helper
+call. Fixed by rewriting to `use pkg::pure::types::*;` (matching the established Bug A
+workaround) *and* binding each nested call's result to a local `let` first, e.g.
+`let v = fn(args); if !near(v, literal) { ... }` — the local-binding step was kept even
+though `use` already de-qualifies the call, since Bug D was isolated for *qualified*
+nested calls specifically and a bare nested call was not independently verified safe;
+binding first avoids the ambiguity regardless. `tests/stdlib/simulation/
+test_simulation_core.sio` also had a separate `error: unknown field access` on
+`ts.n_points` (a `pub` field, so not a visibility issue) that resolved once `ts` was
+constructed via the `use`-imported bare `timeseries_new()` instead of a fully-qualified
+call — consistent with Bug A/D also disrupting return-type tracking through a qualified
+call chain, not just direct symbol/arity resolution.
+
+Verified against a freshly rebuilt `lean_single` via `scripts/run_sio_test_suite.sh
+--filter`, no regression on the full set of tests already fixed in this dispatch's
+earlier updates.

--- a/tests/stdlib/audio/test_audio_core.sio
+++ b/tests/stdlib/audio/test_audio_core.sio
@@ -1,6 +1,9 @@
 //@ check-only
 // tests/stdlib/audio/test_audio_core.sio
 
+use audio::pure::types::*
+use audio::ffi::bindings::*
+
 fn near(a: f32, b: f32) -> bool {
     let d = a - b
     let ad = if d < 0.0 as f32 { 0.0 as f32 - d } else { d }
@@ -8,18 +11,20 @@ fn near(a: f32, b: f32) -> bool {
 }
 
 fn assert_buffer() -> bool with Mut {
-    var buf = audio::pure::types::audio_buffer_new(44100)
-    if audio::pure::types::audio_buffer_sample_rate(&buf) != 44100 { return false }
-    audio::pure::types::audio_buffer_push(&!buf, 0.5 as f32)
-    audio::pure::types::audio_buffer_push(&!buf, 0.25 as f32)
-    if audio::pure::types::audio_buffer_size(&buf) != 2 { return false }
-    if !near(audio::pure::types::audio_buffer_get(&buf, 0), 0.5 as f32) { return false }
-    if !near(audio::pure::types::audio_buffer_get(&buf, 1), 0.25 as f32) { return false }
+    var buf = audio_buffer_new(44100)
+    if audio_buffer_sample_rate(&buf) != 44100 { return false }
+    audio_buffer_push(&!buf, 0.5 as f32)
+    audio_buffer_push(&!buf, 0.25 as f32)
+    if audio_buffer_size(&buf) != 2 { return false }
+    let g0 = audio_buffer_get(&buf, 0)
+    if !near(g0, 0.5 as f32) { return false }
+    let g1 = audio_buffer_get(&buf, 1)
+    if !near(g1, 0.25 as f32) { return false }
     true
 }
 
 fn main() -> i32 with Mut {
     if !assert_buffer() { return 1 }
-    if audio::ffi::bindings::alsa_available() { return 1 }
+    if alsa_available() { return 1 }
     0
 }

--- a/tests/stdlib/dataframe/test_dataframe_core.sio
+++ b/tests/stdlib/dataframe/test_dataframe_core.sio
@@ -1,6 +1,9 @@
 //@ check-only
 // tests/stdlib/dataframe/test_dataframe_core.sio
 
+use dataframe::pure::core::*
+use dataframe::lib::*
+
 fn near(a: f64, b: f64) -> bool with Mut, Div {
     let d = a - b
     let ad = if d < 0.0 { 0.0 - d } else { d }
@@ -14,19 +17,22 @@ fn assert_stats() -> bool with Mut, Div {
     col[2] = 3.0
     col[3] = 4.0
     col[4] = 5.0
-    if !near(dataframe::pure::core::col_mean(&col, 5), 3.0) { return false }
-    if !near(dataframe::pure::core::col_std(&col, 5), 1.4142135624) { return false }
-    var df = dataframe::pure::core::df_new()
-    dataframe::pure::core::df_set(&!df, 0, 0, 10.0)
-    dataframe::pure::core::df_set(&!df, 0, 1, 20.0)
+    let mean = col_mean(&col, 5)
+    if !near(mean, 3.0) { return false }
+    let std = col_std(&col, 5)
+    if !near(std, 1.4142135624) { return false }
+    var df = df_new()
+    df_set(&!df, 0, 0, 10.0)
+    df_set(&!df, 0, 1, 20.0)
     df.n_cols = 1
     df.n_rows = 2
-    if !near(dataframe::pure::core::df_get(&df, 0, 1), 20.0) { return false }
+    let got = df_get(&df, 0, 1)
+    if !near(got, 20.0) { return false }
     true
 }
 
 fn main() -> i32 with Mut, Div {
     if !assert_stats() { return 1 }
-    if dataframe::lib::arrow_available() { return 1 }
+    if arrow_available() { return 1 }
     0
 }

--- a/tests/stdlib/geo/test_geo_core.sio
+++ b/tests/stdlib/geo/test_geo_core.sio
@@ -1,6 +1,9 @@
 //@ check-only
 // tests/stdlib/geo/test_geo_core.sio
 
+use geo::pure::types::*
+use geo::ffi::bindings::*
+
 fn near(a: f64, b: f64) -> bool with Div {
     let d = a - b
     let ad = if d < 0.0 { 0.0 - d } else { d }
@@ -8,17 +11,20 @@ fn near(a: f64, b: f64) -> bool with Div {
 }
 
 fn assert_geometry() -> bool with Div {
-    let p1 = geo::pure::types::point2d_new(0.0, 0.0)
-    let p2 = geo::pure::types::point2d_new(3.0, 4.0)
-    let p3 = geo::pure::types::point2d_new(1.0, 2.0)
-    if !near(geo::pure::types::point2d_distance(&p1, &p2), 5.0) { return false }
-    if !near(geo::pure::types::point2d_dot(&p2, &p2), 25.0) { return false }
-    if !near(geo::pure::types::point2d_cross(&p2, &p3), 2.0) { return false }
+    let p1 = point2d_new(0.0, 0.0)
+    let p2 = point2d_new(3.0, 4.0)
+    let p3 = point2d_new(1.0, 2.0)
+    let dist = point2d_distance(&p1, &p2)
+    if !near(dist, 5.0) { return false }
+    let dot = point2d_dot(&p2, &p2)
+    if !near(dot, 25.0) { return false }
+    let cross = point2d_cross(&p2, &p3)
+    if !near(cross, 2.0) { return false }
     true
 }
 
 fn main() -> i32 with Div {
     if !assert_geometry() { return 1 }
-    if geo::ffi::bindings::gdal_available() { return 1 }
+    if gdal_available() { return 1 }
     0
 }

--- a/tests/stdlib/simulation/test_simulation_core.sio
+++ b/tests/stdlib/simulation/test_simulation_core.sio
@@ -1,6 +1,9 @@
 //@ check-only
 // tests/stdlib/simulation/test_simulation_core.sio
 
+use simulation::pure::types::*
+use simulation::ffi::bindings::*
+
 fn near(a: f64, b: f64) -> bool {
     let d = a - b
     let ad = if d < 0.0 { 0.0 - d } else { d }
@@ -8,17 +11,18 @@ fn near(a: f64, b: f64) -> bool {
 }
 
 fn assert_timeseries() -> bool with Mut, Div {
-    var ts = simulation::pure::types::timeseries_new()
-    simulation::pure::types::timeseries_push(&!ts, 0.0, 10.0)
-    simulation::pure::types::timeseries_push(&!ts, 1.0, 20.0)
-    simulation::pure::types::timeseries_push(&!ts, 2.0, 30.0)
+    var ts = timeseries_new()
+    timeseries_push(&!ts, 0.0, 10.0)
+    timeseries_push(&!ts, 1.0, 20.0)
+    timeseries_push(&!ts, 2.0, 30.0)
     if ts.n_points != 3 { return false }
-    if !near(simulation::pure::types::timeseries_mean(&ts), 20.0) { return false }
+    let mean = timeseries_mean(&ts)
+    if !near(mean, 20.0) { return false }
     true
 }
 
 fn main() -> i32 with Mut, Div {
     if !assert_timeseries() { return 1 }
-    if simulation::ffi::bindings::monte_carlo_gpu_available() { return 1 }
+    if monte_carlo_gpu_available() { return 1 }
     0
 }


### PR DESCRIPTION
## Summary
Fixes issue #569 (4 of the pre-existing `Full Test Suite` failures found while investigating PR #565).

Issue #569 speculated this cluster might share Bug B's root cause (qualified-path parameter type + co-scope glob import). Checked and **ruled out** — none of the 4 files have that shape. Root-caused separately, isolated with a minimal 2-file repro outside stdlib (documented as "Bug D" in the audit dispatch doc): a fully-qualified call (`pkg::subdir::file::symbol(...)`) used as an **argument nested inside another call** produces a false `arity mismatch` on the outer call, even though both calls individually have the correct argument count. The same call as its own standalone statement does not trigger it. Madaros doesn't reproduce this — lean_single only.

All 4 files had the identical shape: `near(pkg::pure::types::fn(args), literal)` — a qualified accessor nested inside a `near()` approx-equality helper. Fixed via `use pkg::pure::types::*;` (the established Bug A workaround) plus binding each nested call's result to a local `let` first:

- `tests/stdlib/dataframe/test_dataframe_core.sio`
- `tests/stdlib/audio/test_audio_core.sio`
- `tests/stdlib/geo/test_geo_core.sio`
- `tests/stdlib/simulation/test_simulation_core.sio` (also had a separate "unknown field access" on `ts.n_points` — a `pub` field, not a visibility issue — resolved once `ts` came from the `use`-imported bare `timeseries_new()` instead of a fully-qualified call)

## Test plan
- [x] `souc check` (Madaros) on all 4 touched test files passes.
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path) and verified all 4 pass via `scripts/run_sio_test_suite.sh --filter`.
- [x] No regression on `test_net_core`/`test_env_present`/`test_classical_e2e`/`test_distributed_core`/`test_http_e2e` (prior fixes this week).

Closes #569.