### PR TITLE
fix(stdlib): fix 6/7 qualified-path-cluster tests (issue #567)

### DIFF
--- a/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
+++ b/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
@@ -194,3 +194,69 @@ call chain, not just direct symbol/arity resolution.
 Verified against a freshly rebuilt `lean_single` via `scripts/run_sio_test_suite.sh
 --filter`, no regression on the full set of tests already fixed in this dispatch's
 earlier updates.
+
+## Update 2026-07-02 (continued): closing most of issue #567 (Bug A cluster), plus a Madaros-only regression and a "halt, don't fix" call on stdlib/chemistry/kinetics.sio
+
+Fixed 6 of #567's 7 files (`test_equilibrium_acids`, `test_serialization`,
+`test_thermo_sr_e2e`, `test_viz_core`, `test_particle_physics_core`,
+`test_graphics_core`) the same way as the Bug A/D fixes above: `use pkg::mod::*;` +
+bare calls, plus un-nesting a triple-nested qualified call in `test_graphics_core.sio`
+(same Bug D shape). Two incidental content bugs surfaced and were fixed at the root:
+
+- `stdlib/chemistry/equilibrium.sio` and `stdlib/chemistry/acids.sio` each had an
+  **unused** `use epistemic::knowledge::Epistemic;` (the named-import Bug C shape,
+  documented in issue #568) that was silently dead code — deleted rather than converted,
+  since nothing in either file referenced `Epistemic`.
+- `stdlib/chemistry/equilibrium.sio`, `stdlib/chemistry/kinetics.sio`, and
+  `stdlib/physics/sr.sio` each had `use constants::physical::X as get_R;` /
+  `use constants::physical::speed_of_light_approx;` (Bug C shapes) — converted to
+  `use constants::physical::*;` and renamed the 1-2 call sites per file back to the
+  real name (`get_R()` → `gas_constant_approx()`).
+- `stdlib/chemistry/kinetics.sio` additionally had `use plot::epistemic as epi_plot;`
+  (a *module-alias* variant of Bug C) used as a namespace prefix at 6 call sites —
+  converted to `use plot::epistemic::*;` and stripped the `epi_plot::` prefix at each
+  site — and `use special::caputo;` + `caputo::fn(...)` qualified-via-bare-module-alias
+  calls (4 sites) — converted to `use special::caputo::*;` + bare calls.
+- `stdlib/autodiff/grad.sio`'s `struct Dual { val: f64, dot: f64 }` had neither the
+  struct nor its fields marked `pub` — `stdlib/chemistry/kinetics.sio` constructs `Dual`
+  literals directly once `Dual` became reachable via `use autodiff::grad::*;`, which
+  needs `pub` on both the struct and its fields (same shape as the `stdlib/web`
+  `pub`-visibility fixes from the networking wave). Fixed.
+- `tests/stdlib/viz/test_viz_core.sio` itself asserted `scene.data_count != 0` on a
+  field that **does not exist** on `VizScene` (confirmed via `grep`) — a pre-existing
+  test bug, masked until now by the qualified-call failure occurring first. Replaced
+  with the real field `series_count` (also zero-initialized by `viz_scene_new()`),
+  preserving the test's evident intent (assert a fresh scene has no data yet).
+
+**Madaris-only regression, documented not fixed:** all 6 fixed files now fail standalone
+`souc check` under Madaros (confirmed via `git show HEAD:<file>` that the *originals*
+passed Madaros cleanly before this change) despite passing cleanly under a freshly
+rebuilt `lean_single`. This is the same class of engine divergence as this dispatch's
+original finding (Madaros and lean_single disagree on `use module::*;`-adjacent checker
+behavior) — not investigated further per the same "flag, don't fix Madaros-only checker
+quirks" reasoning as above. No CI gate exercises Madaros for these files.
+
+**Halt call: `stdlib/chemistry/kinetics.sio` is out of scope for a quick fix.** The 7th
+file, `tests/stdlib/chemistry/test_kinetics_core.sio`, remains failing after the same
+import fixes above (which did land real, verified improvements — Bug C's imports now
+resolve, `Dual` literals now construct). Once the qualified-path/import layer was fixed,
+`souc check` under lean_single surfaced roughly 100+ *additional*, independent errors
+throughout kinetics.sio's ~2000 lines: dozens of "arity mismatch" (the Bug D shape,
+recurring at ~28 distinct call sites, not just the 1-2 seen elsewhere), "unknown
+identifier `[`" (a parser/checker issue with array literals, ~35 occurrences),
+"private struct field access [struct=ODESolution]" (another un-`pub`bed struct, same
+shape as `Dual` above but a different type), 6 distinct "tail type mismatch" sites, and
+a **genuinely nonexistent** imported symbol (`use epistemic::ode::{..., 
+ode_system_chem_simple, ...};` — confirmed via `grep -n ode_system_chem_simple
+stdlib/epistemic/ode.sio` returning nothing). This is consistent with kinetics.sio never
+having been fully type-checked by any compiler before — it was always accessed via
+inline fully-qualified calls that never resolved under lean_single at all (Bug A), so no
+one has run the whole file through lean_single's checker until this investigation.
+Fixing kinetics.sio properly is a dedicated stdlib-content triage task, not a follow-on
+to a qualified-path bug fix — filed as a separate issue rather than attempted here.
+
+Verified via `scripts/run_sio_test_suite.sh --filter` against a freshly rebuilt
+`lean_single`: all 6 fixed files pass, no regression on the full set of tests fixed
+earlier this week (`test_net_core`, `test_env_present`, `test_classical_e2e`,
+`test_dataframe_core`, `test_audio_core`, `test_geo_core`, `test_simulation_core`,
+`test_distributed_core`, `test_http_e2e`).

--- a/stdlib/autodiff/grad.sio
+++ b/stdlib/autodiff/grad.sio
@@ -176,9 +176,9 @@ fn tanh_f64(x: f64) -> f64 {
 // ============================================================================
 
 // Dual number: val + dot*epsilon where epsilon^2 = 0
-struct Dual {
-    val: f64,  // Primal (function value)
-    dot: f64   // Tangent (derivative)
+pub struct Dual {
+    pub val: f64,  // Primal (function value)
+    pub dot: f64   // Tangent (derivative)
 }
 
 // Create a constant (derivative = 0)

--- a/stdlib/chemistry/acids.sio
+++ b/stdlib/chemistry/acids.sio
@@ -3,8 +3,6 @@
 
 module chemistry::acids
 
-use epistemic::knowledge::Epistemic;
-
 // FULL ChEBI ontology (real acetic acid CHEBI:15366 etc. for provenance in pH/titration)
 use chemistry::ontology;
 

--- a/stdlib/chemistry/equilibrium.sio
+++ b/stdlib/chemistry/equilibrium.sio
@@ -3,13 +3,12 @@
 
 module chemistry::equilibrium
 
-use constants::physical::gas_constant_approx as get_R;
-use epistemic::knowledge::Epistemic;
+use constants::physical::*;
 
 // FULL ChEBI ontology grounding for equilibrium species/reactions
 use chemistry::ontology;
 
-let R: f64 = get_R();
+let R: f64 = gas_constant_approx();
 
 fn abs_f64(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
 fn check_near(a: f64, b: f64, tol: f64) -> bool { abs_f64(a - b) < tol }

--- a/stdlib/chemistry/kinetics.sio
+++ b/stdlib/chemistry/kinetics.sio
@@ -3,15 +3,15 @@
 
 module chemistry::kinetics
 
-use ode::rk4::rk4_step;
-use constants::physical::gas_constant_approx as get_R;
-use epistemic::knowledge::Epistemic;
+use ode::rk4::*;
+use constants::physical::*;
+use epistemic::knowledge::*;
 use epistemic::ode::{EState, estate_new, estate_set, solve_ode, ode_system_chem_simple, ODEParams, ode_params_new, ode_params_set, solver_options_fixed, solution_get_value, solution_get_variance};
 use linalg::matrix::{mat3_new, mat3_vec_mul}; // for stoich example, adapt to 4x3
-use autodiff::grad::Dual;
+use autodiff::grad::*;
 use linalg::matnm::{matnm_new, matnm_set, matnm_get, matnm_mul, MatNM};
 use chemistry::equilibrium;
-use special::caputo;  // for fractional deep item (Caputo + epistemic)
+use special::caputo::*;  // for fractional deep item (Caputo + epistemic)
 
 // Real ontology integration with ChEBI (Chemical Entities of Biological Interest)
 // Uses the typed bridge for compile-time subsumption + nominal types on species.
@@ -20,11 +20,11 @@ use special::caputo;  // for fractional deep item (Caputo + epistemic)
 use chemistry::ontology;
 
 // Real terminal graphs and statistics (Sounio native, no external libs)
-use plot::epistemic as epi_plot;
+use plot::epistemic::*;
 use plot::line;
 use plot::bar;
 
-let R: f64 = get_R();
+let R: f64 = gas_constant_approx();
 
 fn abs_f64(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
 fn check_near(a: f64, b: f64, tol: f64) -> bool { abs_f64(a - b) < tol }
@@ -810,7 +810,7 @@ pub fn simulate_fractional_structural_ensemble(
         if p > 0.0 {
             let (ov, ou) = simulate_general_epistemic(initv, inits, ks, uks, nus[i], nsp, nrxn, dt, steps);
             // apply fractional on the "product" component (index 2 like M2) using Caputo for order alpha
-            let frac_prod = caputo::fractional_decay_ml(ov[2], 0.05, dt * (steps as f64), alpha);
+            let frac_prod = fractional_decay_ml(ov[2], 0.05, dt * (steps as f64), alpha);
             let frac_u = ou[2] * 1.1; // prop + additional from alpha epistemic
             var j = 0; while j < nsp {
                 if j == 2 {
@@ -865,7 +865,7 @@ pub fn test_fractional_ensemble() -> bool with Mut, Div, Panic {
 // 2. FRACTIONAL-ORDER KINETICS (Caputo from stdlib/special/caputo + epistemic)
 pub fn fractional_crn_decay(c0: f64, uc0: f64, lambda: f64, ul: f64, t: f64, ut: f64, alpha: f64) -> (f64, f64) with Mut, Div, Panic {
     // use caputo fractional + GUM rough on params (real for anomalous kinetics)
-    let nom = caputo::fractional_decay_ml(c0, lambda, t, alpha);
+    let nom = fractional_decay_ml(c0, lambda, t, alpha);
     // simple prop (delta on c0, lambda; alpha epistemic too in full)
     let urel = (uc0 / (if c0>0.0 {c0} else 1.0)) + (ul / (if lambda>0.0 {lambda} else 1.0)) + ut*0.01;
     (nom, abs_f64(nom) * urel)
@@ -888,7 +888,7 @@ pub fn test_fractional_crn_integration() -> bool with Mut, Div, Panic {
         if i < 512 { samples[i] = c; }
         i = i + 1;
     }
-    let dfrac = caputo::caputo_l1_derivative(samples, 30, dt, 0.7); // alpha lit for chem diffusion
+    let dfrac = caputo_l1_derivative(samples, 30, dt, 0.7); // alpha lit for chem diffusion
     dfrac < 0.0 && abs_f64(dfrac) < 1.0  // decay, reasonable
 }
 
@@ -965,7 +965,7 @@ pub fn test_crn_effect_handlers() -> bool with Mut, Div, Panic, Prob, Observe {
 // e.g. midazolam-like or scaled: gut ka~0.5-1 /h fractional, liver met 0.05, renal CL~0.01-0.02
 pub fn simulate_pbpk_gut_liver_kidney(init_d: f64, u_d: f64, t: f64) -> ([f64; 4], [f64; 4]) with Mut, Div, Panic {
     // gut absorption using fractional (from etapa2, alpha~0.8 for anomalous)
-    let gut_v = caputo::fractional_decay_ml(init_d, 0.8, t, 0.8); // ka effective
+    let gut_v = fractional_decay_ml(init_d, 0.8, t, 0.8); // ka effective
     let gut_u = 0.05 * gut_v; // epistemic unc stub + prop
 
     // liver as multi-metabolic using extended + general (from pbpk_full)
@@ -1588,13 +1588,13 @@ pub fn super_chemical_showcase() -> bool with Mut, Div, Panic, IO, Observe, Prob
     println("\n=== GRÁFICOS REAIS (renderizados via stdlib/plot) ===");
 
     // 5a. Error bars for GUM (epistemic)
-    var budget_entries: [epi_plot::ErrorBarEntry; 4] = [
-        epi_plot::error_bar_entry("Epistemic (EState + Knowledge)", ens_u[1]*0.65, ens_u[1]*0.12, 0.91),
-        epi_plot::error_bar_entry("Intrinsic (LNA stochastic)", ens_u[1]*0.22, ens_u[1]*0.08, 0.74),
-        epi_plot::error_bar_entry("Structural (ensemble)", ens_u[1]*0.13, ens_u[1]*0.05, 0.67),
-        epi_plot::error_bar_entry("Other / residual", ens_u[1]*0.05, ens_u[1]*0.03, 0.55)
+    var budget_entries: [ErrorBarEntry; 4] = [
+        error_bar_entry("Epistemic (EState + Knowledge)", ens_u[1]*0.65, ens_u[1]*0.12, 0.91),
+        error_bar_entry("Intrinsic (LNA stochastic)", ens_u[1]*0.22, ens_u[1]*0.08, 0.74),
+        error_bar_entry("Structural (ensemble)", ens_u[1]*0.13, ens_u[1]*0.05, 0.67),
+        error_bar_entry("Other / residual", ens_u[1]*0.05, ens_u[1]*0.03, 0.55)
     ];
-    epi_plot::error_bar_chart(&budget_entries, 4, "GUM Budget Breakdown - M1 (ChEBI H2O)");
+    error_bar_chart(&budget_entries, 4, "GUM Budget Breakdown - M1 (ChEBI H2O)");
 
     // 5b. Line plot for a sample trajectory (nominal decay)
     println("\nTrajectory (line plot renderizado):");

--- a/stdlib/physics/sr.sio
+++ b/stdlib/physics/sr.sio
@@ -14,8 +14,8 @@
 module physics::sr
 
 use units::{quantity_new, dim_length, dim_time, dim_energy, Quantity};
-use constants::physical::speed_of_light_approx;
-use epistemic::knowledge::Epistemic;
+use constants::physical::*;
+use epistemic::knowledge::*;
 
 let C: f64 = speed_of_light_approx();
 let H_PLANCK: f64 = 6.62607015e-34;

--- a/tests/stdlib/chemistry/test_equilibrium_acids.sio
+++ b/tests/stdlib/chemistry/test_equilibrium_acids.sio
@@ -3,20 +3,25 @@
 //
 // Equilibrium, acids, stoichiometry, and thermochemistry harness.
 
+use chemistry::equilibrium::*
+use chemistry::acids::*
+use chemistry::stoichiometry::*
+use chemistry::thermochem::*
+
 fn assert_all() -> i32 with IO, Mut, Div, Panic {
     var fail: i32 = 0
-    if !chemistry::equilibrium::test_k_dg() { fail = fail + 1; println("FAIL k_dg") }
-    if !chemistry::equilibrium::test_nernst() { fail = fail + 1; println("FAIL nernst") }
-    if !chemistry::equilibrium::test_ab_c() { fail = fail + 1; println("FAIL ab_c") }
-    if !chemistry::equilibrium::test_real_delta_g() { fail = fail + 1; println("FAIL real_delta_g") }
-    if !chemistry::equilibrium::test_speciation() { fail = fail + 1; println("FAIL speciation") }
-    if !chemistry::acids::test_ph() { fail = fail + 1; println("FAIL ph") }
-    if !chemistry::acids::test_titration() { fail = fail + 1; println("FAIL titration") }
-    if !chemistry::acids::test_mm() { fail = fail + 1; println("FAIL mm") }
-    if !chemistry::stoichiometry::test_moles_basic() { fail = fail + 1; println("FAIL moles_basic") }
-    if !chemistry::stoichiometry::test_limiting() { fail = fail + 1; println("FAIL limiting") }
-    if !chemistry::thermochem::test_dg() { fail = fail + 1; println("FAIL dg") }
-    if !chemistry::thermochem::test_hess() { fail = fail + 1; println("FAIL hess") }
+    if !test_k_dg() { fail = fail + 1; println("FAIL k_dg") }
+    if !test_nernst() { fail = fail + 1; println("FAIL nernst") }
+    if !test_ab_c() { fail = fail + 1; println("FAIL ab_c") }
+    if !test_real_delta_g() { fail = fail + 1; println("FAIL real_delta_g") }
+    if !test_speciation() { fail = fail + 1; println("FAIL speciation") }
+    if !test_ph() { fail = fail + 1; println("FAIL ph") }
+    if !test_titration() { fail = fail + 1; println("FAIL titration") }
+    if !test_mm() { fail = fail + 1; println("FAIL mm") }
+    if !test_moles_basic() { fail = fail + 1; println("FAIL moles_basic") }
+    if !test_limiting() { fail = fail + 1; println("FAIL limiting") }
+    if !test_dg() { fail = fail + 1; println("FAIL dg") }
+    if !test_hess() { fail = fail + 1; println("FAIL hess") }
     fail
 }
 

--- a/tests/stdlib/chemistry/test_kinetics_core.sio
+++ b/tests/stdlib/chemistry/test_kinetics_core.sio
@@ -3,18 +3,20 @@
 //
 // Core kinetics harness via qualified chemistry module paths.
 
+use chemistry::kinetics::*
+
 fn assert_all() -> i32 with IO, Mut, Div, Panic {
     var fail: i32 = 0
-    if !chemistry::kinetics::test_arrhenius() { fail = fail + 1; println("FAIL arrhenius") }
-    if !chemistry::kinetics::test_real_arrhenius() { fail = fail + 1; println("FAIL real_arrhenius") }
-    if !chemistry::kinetics::test_ode_first_order() { fail = fail + 1; println("FAIL ode_first_order") }
-    if !chemistry::kinetics::test_crn() { fail = fail + 1; println("FAIL crn") }
-    if !chemistry::kinetics::test_crn_epistemic() { fail = fail + 1; println("FAIL crn_epistemic") }
-    if !chemistry::kinetics::test_chem_full() { fail = fail + 1; println("FAIL chem_full") }
-    if !chemistry::kinetics::test_transport_rd() { fail = fail + 1; println("FAIL transport_rd") }
-    if !chemistry::kinetics::test_general_crn() { fail = fail + 1; println("FAIL general_crn") }
-    if !chemistry::kinetics::test_stoich_linalg() { fail = fail + 1; println("FAIL stoich_linalg") }
-    if !chemistry::kinetics::test_stoich_matrix() { fail = fail + 1; println("FAIL stoich_matrix") }
+    if !test_arrhenius() { fail = fail + 1; println("FAIL arrhenius") }
+    if !test_real_arrhenius() { fail = fail + 1; println("FAIL real_arrhenius") }
+    if !test_ode_first_order() { fail = fail + 1; println("FAIL ode_first_order") }
+    if !test_crn() { fail = fail + 1; println("FAIL crn") }
+    if !test_crn_epistemic() { fail = fail + 1; println("FAIL crn_epistemic") }
+    if !test_chem_full() { fail = fail + 1; println("FAIL chem_full") }
+    if !test_transport_rd() { fail = fail + 1; println("FAIL transport_rd") }
+    if !test_general_crn() { fail = fail + 1; println("FAIL general_crn") }
+    if !test_stoich_linalg() { fail = fail + 1; println("FAIL stoich_linalg") }
+    if !test_stoich_matrix() { fail = fail + 1; println("FAIL stoich_matrix") }
     fail
 }
 

--- a/tests/stdlib/graphics/test_graphics_core.sio
+++ b/tests/stdlib/graphics/test_graphics_core.sio
@@ -1,23 +1,27 @@
 //@ check-only
 // tests/stdlib/graphics/test_graphics_core.sio
 
+use graphics::drawing::*
+use graphics::surface::*
+
 fn test_drawing_colors() -> bool with Mut, Div, Panic {
-    let r = graphics::drawing::color_red()
+    let r = color_red()
     if r.r != 255 { return false }
     if r.g != 0 { return false }
     if r.b != 0 { return false }
-    let blended = graphics::drawing::color_blend_over(
-        graphics::drawing::color_white(),
-        graphics::drawing::color_with_alpha(graphics::drawing::color_blue(), 128)
-    )
+    let white = color_white()
+    let blue = color_blue()
+    let blue_alpha = color_with_alpha(blue, 128)
+    let blended = color_blend_over(white, blue_alpha)
     if blended.a != 255 { return false }
     true
 }
 
 fn test_surface_pixel() -> bool with Mut, Panic {
-    var s = graphics::surface::surface_new(8, 8)
-    s = graphics::surface::surface_clear(s, graphics::drawing::color_red())
-    let pr = graphics::surface::surface_get_pixel_r(&s, 3, 3)
+    var s = surface_new(8, 8)
+    let red = color_red()
+    s = surface_clear(s, red)
+    let pr = surface_get_pixel_r(&s, 3, 3)
     if pr != 255 { return false }
     true
 }

--- a/tests/stdlib/particle_physics/test_particle_physics_core.sio
+++ b/tests/stdlib/particle_physics/test_particle_physics_core.sio
@@ -1,15 +1,19 @@
 //@ check-only
 // tests/stdlib/particle_physics/test_particle_physics_core.sio
 
+use particle_physics::bsm_physics::*
+use particle_physics::statistics::*
+use particle_physics::systematics::*
+
 fn assert_all() -> i32 with Mut, Div, Panic {
     var fail: i32 = 0
-    if !particle_physics::bsm_physics::test_mediator_properties() { fail = fail + 1 }
-    if !particle_physics::bsm_physics::test_scalar_mediator() { fail = fail + 1 }
-    if !particle_physics::bsm_physics::test_xs_monojet_positive() { fail = fail + 1 }
-    if !particle_physics::statistics::test_gaussian_pdf() { fail = fail + 1 }
-    if !particle_physics::statistics::test_poisson_pmf() { fail = fail + 1 }
-    if !particle_physics::systematics::test_measurement_new() { fail = fail + 1 }
-    if !particle_physics::systematics::test_pull() { fail = fail + 1 }
+    if !test_mediator_properties() { fail = fail + 1 }
+    if !test_scalar_mediator() { fail = fail + 1 }
+    if !test_xs_monojet_positive() { fail = fail + 1 }
+    if !test_gaussian_pdf() { fail = fail + 1 }
+    if !test_poisson_pmf() { fail = fail + 1 }
+    if !test_measurement_new() { fail = fail + 1 }
+    if !test_pull() { fail = fail + 1 }
     fail
 }
 

--- a/tests/stdlib/physics/test_thermo_sr_e2e.sio
+++ b/tests/stdlib/physics/test_thermo_sr_e2e.sio
@@ -3,28 +3,31 @@
 //
 // Harness for stdlib/physics/thermo.sio and sr.sio public self-tests.
 
+use physics::thermo::*
+use physics::sr::*
+
 fn assert_thermo() -> i32 with IO, Mut, Div, Panic {
     var fail: i32 = 0
-    if !physics::thermo::test_ideal_gas() { fail = fail + 1; println("FAIL ideal_gas") }
-    if !physics::thermo::test_carnot() { fail = fail + 1; println("FAIL carnot") }
-    if !physics::thermo::test_adiabatic() { fail = fail + 1; println("FAIL adiabatic") }
-    if !physics::thermo::test_carnot_cycle() { fail = fail + 1; println("FAIL carnot_cycle") }
-    if !physics::thermo::test_entropy_prod() { fail = fail + 1; println("FAIL entropy_prod") }
+    if !test_ideal_gas() { fail = fail + 1; println("FAIL ideal_gas") }
+    if !test_carnot() { fail = fail + 1; println("FAIL carnot") }
+    if !test_adiabatic() { fail = fail + 1; println("FAIL adiabatic") }
+    if !test_carnot_cycle() { fail = fail + 1; println("FAIL carnot_cycle") }
+    if !test_entropy_prod() { fail = fail + 1; println("FAIL entropy_prod") }
     fail
 }
 
 fn assert_sr() -> i32 with IO, Mut, Div, Panic {
     var fail: i32 = 0
-    if !physics::sr::test_gamma() { fail = fail + 1; println("FAIL gamma") }
-    if !physics::sr::test_energy() { fail = fail + 1; println("FAIL energy") }
-    if !physics::sr::test_invariant() { fail = fail + 1; println("FAIL invariant") }
-    if !physics::sr::test_collision() { fail = fail + 1; println("FAIL collision") }
-    if !physics::sr::test_four_momentum() { fail = fail + 1; println("FAIL four_momentum") }
-    if !physics::sr::test_boost() { fail = fail + 1; println("FAIL boost") }
-    if !physics::sr::test_energy_ep() { fail = fail + 1; println("FAIL energy_ep") }
-    if !physics::sr::test_compton() { fail = fail + 1; println("FAIL compton") }
-    if !physics::sr::test_four_force() { fail = fail + 1; println("FAIL four_force") }
-    if !physics::sr::test_four_force_long() { fail = fail + 1; println("FAIL four_force_long") }
+    if !test_gamma() { fail = fail + 1; println("FAIL gamma") }
+    if !test_energy() { fail = fail + 1; println("FAIL energy") }
+    if !test_invariant() { fail = fail + 1; println("FAIL invariant") }
+    if !test_collision() { fail = fail + 1; println("FAIL collision") }
+    if !test_four_momentum() { fail = fail + 1; println("FAIL four_momentum") }
+    if !test_boost() { fail = fail + 1; println("FAIL boost") }
+    if !test_energy_ep() { fail = fail + 1; println("FAIL energy_ep") }
+    if !test_compton() { fail = fail + 1; println("FAIL compton") }
+    if !test_four_force() { fail = fail + 1; println("FAIL four_force") }
+    if !test_four_force_long() { fail = fail + 1; println("FAIL four_force_long") }
     fail
 }
 

--- a/tests/stdlib/serialization/test_serialization.sio
+++ b/tests/stdlib/serialization/test_serialization.sio
@@ -1,11 +1,15 @@
 //@ check-only
 // tests/stdlib/serialization/test_serialization.sio — format umbrella harness
 
+use toml::parser::*
+use yaml::parser::*
+use json::parser::*
+
 fn assert_self_tests() -> i32 with Mut, Div, Panic {
     var fail: i32 = 0
-    if toml::parser::toml_self_test() != 0 { fail = fail + 1 }
-    if yaml::parser::yaml_self_test() != 0 { fail = fail + 1 }
-    if json::parser::json_self_test() != 0 { fail = fail + 1 }
+    if toml_self_test() != 0 { fail = fail + 1 }
+    if yaml_self_test() != 0 { fail = fail + 1 }
+    if json_self_test() != 0 { fail = fail + 1 }
     fail
 }
 

--- a/tests/stdlib/viz/test_viz_core.sio
+++ b/tests/stdlib/viz/test_viz_core.sio
@@ -1,19 +1,22 @@
 //@ check-only
 // tests/stdlib/viz/test_viz_core.sio
 
+use viz::coord::*
+use viz::ir::*
+
 fn test_coord_mapping() -> bool with Div {
-    let cs = viz::coord::coord_new(0.0, 10.0, 0.0, 100.0, 0, 0, 200, 100)
-    let mx = viz::coord::coord_map_x(&cs, 5.0)
-    let my = viz::coord::coord_map_y(&cs, 50.0)
+    let cs = coord_new(0.0, 10.0, 0.0, 100.0, 0, 0, 200, 100)
+    let mx = coord_map_x(&cs, 5.0)
+    let my = coord_map_y(&cs, 50.0)
     if mx != 100 { return false }
     if my != 50 { return false }
     true
 }
 
 fn test_viz_scene_new() -> bool with Mut {
-    let scene = viz::ir::viz_scene_new()
+    let scene = viz_scene_new()
     if scene.node_count != 0 { return false }
-    if scene.data_count != 0 { return false }
+    if scene.series_count != 0 { return false }
     true
 }
 


### PR DESCRIPTION
## Summary
Fixes 6 of issue #567's 7 files (the "Bug A cluster": 2-segment qualified-path calls failing to resolve under lean_single) via the established `use pkg::mod::*;` workaround:

- `tests/stdlib/chemistry/test_equilibrium_acids.sio`
- `tests/stdlib/serialization/test_serialization.sio`
- `tests/stdlib/physics/test_thermo_sr_e2e.sio`
- `tests/stdlib/viz/test_viz_core.sio`
- `tests/stdlib/particle_physics/test_particle_physics_core.sio`
- `tests/stdlib/graphics/test_graphics_core.sio` (also had a Bug D triple-nested qualified call, un-nested into local `let`s)

Root-caused (not assumed) several incidental content bugs the import switch unmasked — full details in the audit dispatch doc:

- `stdlib/chemistry/equilibrium.sio`/`acids.sio`: each had an **unused** `use epistemic::knowledge::Epistemic;` (dead Bug C import, #568) — deleted.
- `stdlib/chemistry/equilibrium.sio`, `kinetics.sio`, `stdlib/physics/sr.sio`: each had a Bug C aliased/named import (`use constants::physical::X as get_R;` etc.) — converted to glob + renamed call sites back to the real symbol.
- `stdlib/chemistry/kinetics.sio`: a module-alias Bug C variant (`use plot::epistemic as epi_plot;`, used as a namespace prefix at 6 sites) and a bare-module-alias pattern (`use special::caputo; caputo::fn(...)`, 4 sites) — both fixed.
- `stdlib/autodiff/grad.sio`: `struct Dual` needed `pub` (struct + fields) once `kinetics.sio` could reach it via glob import and construct literals directly.
- `tests/stdlib/viz/test_viz_core.sio`: asserted a nonexistent field (`scene.data_count`) — pre-existing test bug, masked until now. Fixed to the real, analogous `series_count`.

## Not fixed here — filed as issue #575
`tests/stdlib/chemistry/test_kinetics_core.sio` (the 7th file) is **not** fixed. The import-layer fixes above genuinely improved `kinetics.sio` (Bug C imports now resolve, `Dual` literals now construct), but once the file is reachable by the checker at all, it surfaces ~100+ *additional*, independent pre-existing errors across its ~2000 lines — recurring arity mismatches, array-literal parser issues, another un-`pub`-ed struct, tail-type mismatches, and one genuinely nonexistent imported symbol. This is consistent with the file never having been fully type-checked by any compiler before. Filed as a dedicated issue (#575) rather than attempted here — full error inventory in that issue and in the audit dispatch doc.

## Notable: Madaros-only regression (documented, not fixed)
Confirmed via `git show HEAD:<file>` that the ORIGINAL versions of all 6 fixed test files passed Madaros cleanly; after the `use`-import conversion they fail under Madaros (but pass under lean_single). Same class of Madaros/lean_single divergence already documented in the audit dispatch from earlier this week — not a lean_single (CI) regression, and Madaros isn't exercised by any CI gate for these files.

## Test plan
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path) and verified all 6 target files pass via `scripts/run_sio_test_suite.sh --filter`.
- [x] No regression on the full set of tests fixed earlier this week (`test_net_core`, `test_env_present`, `test_classical_e2e`, `test_dataframe_core`, `test_audio_core`, `test_geo_core`, `test_simulation_core`, `test_distributed_core`, `test_http_e2e`).

Refs #567 (partial — 6/7). Refs #575 (new, filed for the remaining kinetics.sio work).