### PR TITLE
fix(stdlib): fix test_em_e2e.sio (issue #568); test_lib_surface.sio partially improved

### DIFF
--- a/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
+++ b/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
@@ -260,3 +260,35 @@ Verified via `scripts/run_sio_test_suite.sh --filter` against a freshly rebuilt
 earlier this week (`test_net_core`, `test_env_present`, `test_classical_e2e`,
 `test_dataframe_core`, `test_audio_core`, `test_geo_core`, `test_simulation_core`,
 `test_distributed_core`, `test_http_e2e`).
+
+## Update 2026-07-02 (continued): issue #566 closed as a kinetics.sio duplicate; issue #568's two files split — one fixed, one also blocked by kinetics.sio
+
+**Issue #566** (`test_pbpk_ontology.sio` failing both CI jobs) was investigated next.
+Converting its inline fully-qualified calls to `use chemistry::kinetics::*;` (the
+standard Bug A fix) immediately surfaced ~274 of the same pre-existing errors already
+inventoried in issue #575 — this is the identical `stdlib/chemistry/kinetics.sio`
+content debt, reached through a different test file that happens to call a different
+(also-broken) subset of the module's functions. Reverted the test-file edit (trading 4
+clear "unknown identifier" errors for 274 confusing ones fixes nothing) and closed #566
+as a duplicate of #575 rather than tracking the same root cause twice.
+
+**Issue #568**'s two files split into one real fix and one partial, both via the
+established Bug C workaround:
+
+- `tests/stdlib/physics/test_em_e2e.sio`: root cause was in `stdlib/physics/em.sio`
+  itself (`use constants::physical::speed_of_light_approx;`, 1 usage site) — converted
+  to `use constants::physical::*;`. Unlike kinetics.sio, `em.sio` is a normal-sized
+  (419-line) file with no other latent debt — fixed cleanly, verified passing.
+- `tests/stdlib/chemistry/test_lib_surface.sio` imports one named symbol each from THREE
+  modules (`chemistry::kinetics::test_arrhenius`, `chemistry::equilibrium::test_k_dg`,
+  `chemistry::acids::test_ph`) but never calls any of them — it's a pure "does this
+  import surface resolve" smoke test. The `equilibrium`/`acids` imports fixed cleanly
+  (glob, matching the already-verified #567 fixes to those two files). The `kinetics`
+  import hits the exact same #575 wall as #566 — reverted to its original (still Bug-C-
+  broken) form rather than glob-importing and drowning the signal in 274 unrelated
+  errors. Net effect: this file's own error count dropped from 3 to 1, but it does
+  **not** flip to passing — it remains blocked on #575, same as #566 was.
+
+Verified via `scripts/run_sio_test_suite.sh --filter`: `test_em_e2e` passes;
+`test_lib_surface` still fails (expected, tracked against #575); no regression on the
+full set of tests fixed earlier this week.

--- a/stdlib/physics/em.sio
+++ b/stdlib/physics/em.sio
@@ -20,7 +20,7 @@ module physics::em
 
 use units::{quantity_new, dim_energy, dim_force, dim_length, Quantity, UnitDim, dim_add_exp, dim_mass, dim_acceleration};
 use constants::lib::{MU_0, EPSILON_0};
-use constants::physical::speed_of_light_approx;
+use constants::physical::*;
 let C: f64 = speed_of_light_approx();
 
 struct Vec3 { x: f64, y: f64, z: f64 }

--- a/tests/stdlib/chemistry/test_lib_surface.sio
+++ b/tests/stdlib/chemistry/test_lib_surface.sio
@@ -4,8 +4,8 @@
 // Import-surface gate for stdlib/chemistry/lib.sio bundle (runner compiles as one unit).
 
 use chemistry::kinetics::test_arrhenius
-use chemistry::equilibrium::test_k_dg
-use chemistry::acids::test_ph
+use chemistry::equilibrium::*
+use chemistry::acids::*
 
 fn main() -> i32 with IO {
     0


### PR DESCRIPTION
## Summary
Issue #568 listed 2 files. One is fully fixed; the other only partially, blocked by #575.

- `tests/stdlib/physics/test_em_e2e.sio`: **fully fixed**. Root cause was in `stdlib/physics/em.sio` itself (`use constants::physical::speed_of_light_approx;`, Bug C named-import shape, 1 usage site) — converted to `use constants::physical::*;`. em.sio is a normal 419-line file with no other latent debt, so this fix is clean — verified passing.
- `tests/stdlib/chemistry/test_lib_surface.sio`: **partially improved, still failing**. It names one symbol each from `chemistry::kinetics`, `chemistry::equilibrium`, `chemistry::acids` without calling any of them (pure import-surface smoke test). The `equilibrium`/`acids` imports now resolve cleanly. The `kinetics` import hits the same ~274-error `kinetics.sio` wall as issue #566 — reverted to its original (still Bug-C-broken) form rather than drowning the real signal in unrelated errors. Net: error count dropped 3→1, but the file still fails overall — blocked on #575.

## Also: issue #566 closed as a duplicate of #575
Investigated separately: `test_pbpk_ontology.sio` hits the identical `kinetics.sio` wall (~274 errors) once its Bug A calls are fixed — same root cause as #575, different subset of broken functions. No independent fix exists; closed as duplicate with a comment pointing to #575.

## Test plan
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path).
- [x] `test_em_e2e` passes via `scripts/run_sio_test_suite.sh --filter`.
- [x] `test_lib_surface` still fails (expected — tracked against #575), but its own error signature is cleaner (1 vs 3 errors) and correctly points at the real blocker.
- [x] No regression on the full set of tests fixed earlier this week.

Refs #568 (partial — 1 of 2 files fixed, other blocked by #575). Closes duplicate #566.