### PR TITLE
fix(stdlib): fix test_mesh_core.sio and test_serial_core.sio — closes #570

### DIFF
--- a/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
+++ b/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
@@ -292,3 +292,33 @@ established Bug C workaround:
 Verified via `scripts/run_sio_test_suite.sh --filter`: `test_em_e2e` passes;
 `test_lib_surface` still fails (expected, tracked against #575); no regression on the
 full set of tests fixed earlier this week.
+
+## Update 2026-07-03: issue #570 (unknown-field-access / type-mismatch cluster) — real bug, not stdlib content, same shape as Bug A/D's return-type-tracking gap
+
+Issue #570 was filed at low confidence — it was unclear whether `test_mesh_core.sio` and
+`test_serial_core.sio` had genuine content bugs or were hitting a checker issue.
+Confirmed **checker issue**, not content: `stdlib/mesh/pure/types.sio` (`Mesh`) and
+`stdlib/serial/pure/types.sio` (`SerialConfig`/`SerialBuffer`) all already had every
+field correctly `pub`, and `mesh_get_vertex` already correctly returns `[f64; 3]`. Both
+test files call their target module functions via *3-segment* fully-qualified paths
+(`mesh::pure::types::mesh_get_vertex(...)`, `serial::pure::types::serial_config_new(...)`)
+— already known to *resolve* fine per Bug A (3+ segments), so this isn't Bug A. Instead:
+the checker fails to track the **return type** of a 3-segment fully-qualified call
+correctly for later use — indexing the result (`v[0]` on a `mesh_get_vertex(...)`
+result) or field-accessing it (`cfg.baud_rate` on a `serial_config_new(...)` result)
+then fails with a type/field error, even though the value's real type is completely
+correct.
+
+This is the same underlying gap already noted for `tests/stdlib/simulation/
+test_simulation_core.sio`'s `ts.n_points` fix two updates ago in this dispatch ("Bug
+A/D also disrupting return-type tracking through a qualified call chain, not just direct
+symbol/arity resolution") — confirmed here to also apply at 3 segments, not just 2, and
+to indexing as well as field access. Fixed both files the same way: `use pkg::mod::*;`
++ bare calls (binding the qualified call's result to a `let`/`var` first, then indexing/
+field-accessing the *locally-typed* value, resolves cleanly). No stdlib source files
+needed changes this time — `mesh/pure/types.sio` and `serial/pure/types.sio` were
+already correct.
+
+Verified against both Madaros and a freshly rebuilt `lean_single`: both files pass
+cleanly on both engines (no Madaros-only regression this time, unlike the #567/#568
+fixes). No regression on the full set of tests fixed earlier this week.

--- a/tests/stdlib/mesh/test_mesh_core.sio
+++ b/tests/stdlib/mesh/test_mesh_core.sio
@@ -1,6 +1,9 @@
 //@ check-only
 // tests/stdlib/mesh/test_mesh_core.sio
 
+use mesh::pure::types::*
+use mesh::ffi::bindings::*
+
 fn near(a: f64, b: f64) -> bool {
     let d = a - b
     let ad = if d < 0.0 { 0.0 - d } else { d }
@@ -8,24 +11,24 @@ fn near(a: f64, b: f64) -> bool {
 }
 
 fn assert_mesh_ops() -> bool with Mut, Div {
-    var m = mesh::pure::types::mesh_new()
-    mesh::pure::types::mesh_add_vertex(&!m, 0.0, 0.0, 0.0)
-    mesh::pure::types::mesh_add_vertex(&!m, 1.0, 0.0, 0.0)
-    mesh::pure::types::mesh_add_vertex(&!m, 0.0, 1.0, 0.0)
-    mesh::pure::types::mesh_add_face(&!m, 0, 1, 2)
-    if mesh::pure::types::mesh_vertex_count(&m) != 3 { return false }
-    if mesh::pure::types::mesh_face_count(&m) != 1 { return false }
-    let v = mesh::pure::types::mesh_get_vertex(&m, 1)
+    var m = mesh_new()
+    mesh_add_vertex(&!m, 0.0, 0.0, 0.0)
+    mesh_add_vertex(&!m, 1.0, 0.0, 0.0)
+    mesh_add_vertex(&!m, 0.0, 1.0, 0.0)
+    mesh_add_face(&!m, 0, 1, 2)
+    if mesh_vertex_count(&m) != 3 { return false }
+    if mesh_face_count(&m) != 1 { return false }
+    let v = mesh_get_vertex(&m, 1)
     if !near(v[0], 1.0) { return false }
     if !near(v[1], 0.0) { return false }
     if !near(v[2], 0.0) { return false }
-    let area = mesh::pure::types::mesh_triangle_area(&m, 0)
+    let area = mesh_triangle_area(&m, 0)
     if !near(area, 0.5) { return false }
     true
 }
 
 fn main() -> i32 with Mut, Div {
     if !assert_mesh_ops() { return 1 }
-    if mesh::ffi::bindings::opengl_available() { return 1 }
+    if opengl_available() { return 1 }
     0
 }

--- a/tests/stdlib/serial/test_serial_core.sio
+++ b/tests/stdlib/serial/test_serial_core.sio
@@ -1,13 +1,16 @@
 //@ check-only
 // tests/stdlib/serial/test_serial_core.sio
 
+use serial::pure::types::*
+use serial::ffi::bindings::*
+
 fn assert_serial_buffer() -> bool with Mut {
-    var cfg = serial::pure::types::serial_config_new(9600)
+    var cfg = serial_config_new(9600)
     if cfg.baud_rate != 9600 { return false }
     if cfg.data_bits != 8 { return false }
-    var buf = serial::pure::types::serial_buffer_new()
-    serial::pure::types::serial_buffer_push_rx(&!buf, 0x42)
-    serial::pure::types::serial_buffer_push_rx(&!buf, 0xFF)
+    var buf = serial_buffer_new()
+    serial_buffer_push_rx(&!buf, 0x42)
+    serial_buffer_push_rx(&!buf, 0xFF)
     if buf.rx_len != 2 { return false }
     if buf.rx_buf[0] != 0x42 { return false }
     if buf.rx_buf[1] != 0xFF { return false }
@@ -16,6 +19,6 @@ fn assert_serial_buffer() -> bool with Mut {
 
 fn main() -> i32 with Mut {
     if !assert_serial_buffer() { return 1 }
-    if serial::ffi::bindings::libftdi_available() { return 1 }
+    if libftdi_available() { return 1 }
     0
 }


### PR DESCRIPTION
## Summary
Fixes issue #570 (filed at low confidence — it was unclear whether this was a real stdlib content bug or a checker issue).

**Confirmed: checker issue, not content.** `stdlib/mesh/pure/types.sio`'s `Mesh` struct and `stdlib/serial/pure/types.sio`'s `SerialConfig`/`SerialBuffer` structs already had every field correctly `pub`, and `mesh_get_vertex` already correctly returns `[f64; 3]`. Both test files call their target functions via *3-segment* fully-qualified paths (`mesh::pure::types::mesh_get_vertex(...)`, `serial::pure::types::serial_config_new(...)`) — already known to resolve fine at 3+ segments per Bug A. The actual gap: the checker fails to track the **return type** of a 3-segment qualified call correctly for later use — indexing the result (`v[0]`) or field-accessing it (`cfg.baud_rate`) then fails with a type/field error despite the value's real type being correct.

This is the same underlying gap as `tests/stdlib/simulation/test_simulation_core.sio`'s `ts.n_points` fix from issue #569's PR — confirmed here to also apply at 3 segments (not just 2) and to array indexing (not just field access). Fixed both files with `use pkg::mod::*;` + bare calls. No stdlib source files needed changes — the underlying modules were already correct.

## Test plan
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path).
- [x] Both files pass on both Madaros and lean_single (no Madaros-only regression this time, unlike the #567/#568 fixes).
- [x] No regression on the full set of tests fixed this week.

Closes #570.