### PR TITLE
fix(gpu): driver typecheck workaround + module-combination audit dispatch

### DIFF
--- a/docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
+++ b/docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
@@ -1,0 +1,187 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02
+-->
+
+# Madaros forensic dispatch — `gpu::kernel_ir` + `gpu::lower_to_ptx` + `gpu::ptx` fail to check together
+
+Date: 2026-07-02
+Branch: `gpu/epistemic-tensor-core-next` (base: `research/solver-ts3-parallel` @ `65f44e60c`,
+merge of PR #572)
+Class: **PRE-EXISTING MODULE-COMBINATION BREAKAGE** (hundreds of typecheck errors,
+independent of any function body or call site — reproducible with an empty `main`)
+Status: root-caused to "this exact 3-module combination is apparently never exercised
+together in CI"; NOT fixed; NOT attempted beyond the diagnosis below
+
+> Found while trying to write a CLI driver
+> (`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio`) to emit PTX for the
+> compiler-generated epistemic WMMA matmul kernel
+> (`self-hosted/gpu/kernel_ir.sio::gpu_build_epistemic_wmma_matmul_16x16_ir`) for
+> hardware verification on the DGX Spark. This dispatch documents why that driver
+> still cannot be built into a native ELF on this branch, so the blocker survives
+> context loss instead of being rediscovered from scratch.
+
+## Symptom
+
+A `.sio` file that does nothing but import three GPU backend modules and return 0 from
+`main` fails `souc check` with **hundreds of errors** — no call into any of the three
+modules is required to trigger it:
+
+```sio
+use gpu::kernel_ir::*
+use gpu::lower_to_ptx::*
+use gpu::ptx::*
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    0
+}
+```
+
+```
+$ ./bin/souc check probe.sio
+run_check_mode: about to check 4 modules
+error[E175] ... : function is private in its defining module     (335 occurrences)
+error[E177] ... : enum constructor is private in its defining module   (18 occurrences)
+error[E046] ... : struct literal has wrong number of fields       (5 occurrences)
+run_check_mode: verdict=1
+```
+
+None of these errors reference anything the probe file itself wrote — `main`'s body is
+just `0`. They come from the transitive resolution of `kernel_ir.sio` + `lower_to_ptx.sio`
++ `ptx.sio` against each other.
+
+## Why this matters
+
+`self-hosted/gpu/mod.sio` — the GPU backend's own orchestrator, which re-exports
+"all GPU code generation and runtime modules" per its header comment — does **not**
+import `gpu::lower_to_ptx`:
+
+```sio
+module gpu::mod
+
+use gpu::kernel_ir::*
+use gpu::hlir_to_gpu::*
+use gpu::epistemic_spirv::*
+use gpu::ptx::*
+use gpu::metal::*
+use gpu::cuda_tile::*
+```
+
+`souc check self-hosted/gpu/mod.sio` passes clean (only pre-existing stack-frame-size
+warnings, `verdict=0`). That's real evidence the rest of the GPU backend is healthy — but
+it also means **nothing in the checked, working surface actually exercises
+`lower_to_ptx.sio` together with `kernel_ir.sio` and `ptx.sio`**, even though
+`lower_to_ptx.sio` is the documented, intended "phase 1" lowering path
+(`GpuKernelIr → PTX`) and both `self-hosted/test_epistemic_wmma.sio` and
+`self-hosted/gpu/spirv_lower.sio`'s self-checks call `gpu_lower_to_ptx` directly. Those
+test files have no `use` statements themselves and are only ever compiled by
+concatenation into the full bootstrap bundle (`scripts/bootstrap/bootstrap_concat.sh`,
+`BOOTSTRAP_PROFILE=full`), which sidesteps normal module-boundary checking entirely (no
+`use`, no cross-module privacy enforcement) and — separately — currently segfaults during
+native codegen for unrelated reasons. So this 3-module combination, checked as its own
+proper module graph, has apparently never been validated.
+
+## What's actually failing
+
+Not investigated function-by-function (335 + 18 + 5 = 358 errors is not something to
+triage one at a time by hand). The three error classes:
+
+- **E175 "function is private in its defining module"** (335×) and **E177 "enum
+  constructor is private in its defining module"** (18×) — some function/module needed by
+  the `lower_to_ptx.sio` ⟷ `ptx.sio` call chain lost its `pub` modifier (or was never
+  `pub`) relative to what cross-module resolution now needs. This matches a pattern seen
+  elsewhere on this branch this session: `self-hosted/gpu/kernel_ir.sio`'s `struct Name`
+  and `struct GpuOp` field declarations were observed to have lost their `pub` prefixes at
+  some point in this branch's history (compare: an earlier commit on this same GPU work
+  needed to add `pub` back to `gpu_build_epistemic_wmma_matmul_16x16_ir` for exactly this
+  reason). This looks like **ongoing, uncoordinated privacy-annotation drift** across the
+  GPU module tree, not a one-off.
+- **E046 "struct literal has wrong number of fields"** (5×, at byte offsets 80304, 82284,
+  82895, 83507, 85443 in the 4-module concatenation) — a struct literal somewhere in this
+  combination doesn't match its struct's current field list. Given the E175/E177 pattern
+  above, the likely cause is the same class of drift: a struct gained/lost a field in one
+  file without every literal constructing it (in a different file) being updated to match.
+
+Neither class was root-caused to a specific symbol/line — that requires either a bisection
+across `lower_to_ptx.sio`'s and `ptx.sio`'s own internal `use` graphs (which files, not
+which functions), or fixing the compiler to emit file:line instead of raw byte offsets
+into the concatenated check buffer.
+
+## Reproduction
+
+```bash
+cat > /tmp/probe.sio << 'EOF'
+use gpu::kernel_ir::*
+use gpu::lower_to_ptx::*
+use gpu::ptx::*
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    0
+}
+EOF
+cp /tmp/probe.sio self-hosted/gpu/probe.sio   # must live under self-hosted/gpu/ for `use gpu::*` to resolve
+./bin/souc check self-hosted/gpu/probe.sio
+rm self-hosted/gpu/probe.sio
+```
+
+Expect `verdict=1` with the error counts above. `./bin/souc check self-hosted/gpu/mod.sio`
+in the same tree passes (`verdict=0`) for contrast.
+
+## What was ruled out (not the cause)
+
+- **Not a MY-code issue.** The probe's `main` body is empty; no call into any of the three
+  modules occurs.
+- **Not `IR_MAX_INSTRS` (the sibling `docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md`
+  finding).** That issue is real and separate — three unrelated large functions in
+  `kernel_ir.sio` (`gpu_build_gemm_shared_ir`, `gpu_build_conv2d_ir`,
+  `gpu_build_epistemic_tiled_gemm_ir`) do independently exceed the 1024-instruction cap
+  and block `souc build` (not `souc check`) of anything importing `kernel_ir.sio`
+  wholesale — but fixing that (raising the cap; attempted and reverted this session,
+  touching ~680 call sites across 7 files) does not touch the E175/E177/E046 errors here,
+  which occur at `check` time, before lowering ever starts.
+- **Not the known Madaros native-codegen segfault** (see `docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/`
+  and related) — this dispatch is entirely about `check`/typecheck-time failures, upstream
+  of codegen.
+- **Not a stale pinned binary.** `bin/souc` was rebuilt as of this branch's HEAD; the
+  errors reproduce with the in-tree compiler on the in-tree source, not an old artifact.
+
+## Impact
+
+Any new CLI driver that needs `gpu_lower_to_ptx` (the `GpuKernelIr → PTX` path) — i.e.
+anything downstream of `self-hosted/gpu/kernel_ir.sio`'s `gpu_build_*_ir()` builder
+functions that isn't reachable through `bin/kretikos`'s existing K-AXI-only dispatch —
+cannot currently be compiled to a native ELF via `souc build`, because `souc check`
+already rejects the module combination before codegen is reached. This blocked
+`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` (added 2026-07-02 to expose
+`gpu_build_epistemic_wmma_matmul_16x16_ir`'s PTX for DGX Spark hardware verification) from
+ever reaching the native-codegen stage on this branch.
+
+## Proposed next step (not attempted here)
+
+1. Bisect by importing `gpu::lower_to_ptx` and `gpu::ptx` alone (no `kernel_ir`) and vice
+   versa, to narrow which pairwise combination first breaks — this dispatch only
+   established that all three together break, not which pair.
+2. Audit `pub`/private-modifier consistency across the whole `self-hosted/gpu/` tree in one
+   pass (grep for struct/fn declarations missing `pub` that are referenced via `::*`
+   imports from outside their own file) rather than patching one symbol at a time as each
+   is hit — the repeated pattern (`Name`, `GpuOp`, and now this) suggests a systemic gap,
+   not isolated typos.
+3. Add a CI check that runs `souc check` on `gpu::kernel_ir` + `gpu::lower_to_ptx` +
+   `gpu::ptx` together (e.g. via `mod.sio` gaining a `use gpu::lower_to_ptx::*` line, if
+   that's semantically correct for the orchestrator to own) so this combination is never
+   silently unvalidated again.
+
+## Cross-references
+
+- `docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md` — separate, orthogonal
+  compile-time cap issue in the same file (`kernel_ir.sio`), hit while chasing this one.
+- `docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/` — separate native-codegen segfault
+  class, downstream of where this dispatch's errors occur.
+- `self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` — the driver whose build is blocked by
+  this; its commit history on `gpu/epistemic-tensor-core-next` records the specific
+  symptoms hit in order (segfault → `var`-without-initializer typecheck regression, fixed
+  → this module-combination breakage, not fixed).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 861
-- Repo-backed topics: 711
+- Total governed topics: 860
+- Repo-backed topics: 710
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 174
-- Authority count `repo_only`: 499
+- Authority count `repo_only`: 498
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 503 topics
+- A2: 502 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 859
-- Repo-backed topics: 709
+- Total governed topics: 861
+- Repo-backed topics: 711
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 174
-- Authority count `repo_only`: 497
+- Authority count `repo_only`: 499
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 501 topics
+- A2: 503 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -128,6 +128,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-closures-step2-capture-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02 | repo_only | docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-ir-max-instrs-1024-truncation-2026-06-28 | repo_only | docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -138,6 +139,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-open-pr-worktree-disposition-2026-06-21 | repo_only | docs/audit/MADAROS_OPEN_PR_WORKTREE_DISPOSITION_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-operational-handoff-2026-06-21 | repo_only | docs/audit/MADAROS_OPERATIONAL_HANDOFF_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-option-box-deref-2026-06-24 | repo_only | docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-phase03-step5-validation-2026-07-02 | repo_only | docs/audit/MADAROS_PHASE03_STEP5_VALIDATION_2026-07-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-post-merge-closeout-2026-06-22 | repo_only | docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-production-readiness-plan-2026-06-21 | repo_only | docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -139,7 +139,6 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-open-pr-worktree-disposition-2026-06-21 | repo_only | docs/audit/MADAROS_OPEN_PR_WORKTREE_DISPOSITION_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-operational-handoff-2026-06-21 | repo_only | docs/audit/MADAROS_OPERATIONAL_HANDOFF_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-option-box-deref-2026-06-24 | repo_only | docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.audit.madaros-phase03-step5-validation-2026-07-02 | repo_only | docs/audit/MADAROS_PHASE03_STEP5_VALIDATION_2026-07-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-post-merge-closeout-2026-06-22 | repo_only | docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-print-int-dispatch-2026-06-20 | repo_only | docs/audit/MADAROS_PRINT_INT_DISPATCH_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-production-readiness-plan-2026-06-21 | repo_only | docs/audit/MADAROS_PRODUCTION_READINESS_PLAN_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2416,6 +2416,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-impl-method-two-roots-2026-06-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md",
@@ -2626,6 +2649,29 @@
       "topic_id": "repo.docs.audit.madaros-option-box-deref-2026-06-24",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_OPTION_BOX_DEREF_2026-06-24.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.madaros-phase03-step5-validation-2026-07-02",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_PHASE03_STEP5_VALIDATION_2026-07-02.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2669,29 +2669,6 @@
       "related_artifacts": []
     },
     {
-      "topic_id": "repo.docs.audit.madaros-phase03-step5-validation-2026-07-02",
-      "collection": "repo",
-      "repo_doc_path": "docs/audit/MADAROS_PHASE03_STEP5_VALIDATION_2026-07-02.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "users",
-      "authority": "repo_only",
-      "owner_agent": "A2",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh",
-        "bash scripts/check_docs_consistency.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
       "topic_id": "repo.docs.audit.madaros-post-merge-closeout-2026-06-22",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_POST_MERGE_CLOSEOUT_2026-06-22.md",

--- a/docs/research/act-var-redefinition-prototype-2026-06-28.md
+++ b/docs/research/act-var-redefinition-prototype-2026-06-28.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.act-var-redefinition-prototype-2026-06-28
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/solver-novelty-boundary-verified-2026-06-28.md
+++ b/docs/research/solver-novelty-boundary-verified-2026-06-28.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.solver-novelty-boundary-verified-2026-06-28
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/self-hosted/gpu/kretikos_emit_epistemic_wmma.sio
+++ b/self-hosted/gpu/kretikos_emit_epistemic_wmma.sio
@@ -31,17 +31,15 @@ fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
 
     let pattern = get_arg(0)
 
-    var buf: PtxBuf
-    if str_eq(pattern, "epi_wmma_mm16") {
-        let ir = gpu_build_epistemic_wmma_matmul_16x16_ir()
-        buf = gpu_lower_to_ptx(ir)
-    } else {
+    if !str_eq(pattern, "epi_wmma_mm16") {
         print("kretikos_emit_epistemic_wmma: error - unknown pattern '")
         print(pattern)
         println("'")
         return 1
     }
 
+    let ir = gpu_build_epistemic_wmma_matmul_16x16_ir()
+    let buf = gpu_lower_to_ptx(ir)
     ptx_buf_print(buf)
     0
 }


### PR DESCRIPTION
## Summary

Follow-up to #572 (epistemic WMMA GUM math fix). While trying to get the compiler-generated
epistemic WMMA matmul kernel's PTX onto the DGX Spark for hardware verification, hit a chain
of pre-existing, unrelated compiler issues. This PR contains the one real code fix plus a
forensic writeup of the blocker that remains open:

- `self-hosted/gpu/kretikos_emit_epistemic_wmma.sio`: rewrite the `var buf: PtxBuf` (declare,
  assign in an if/else branch) idiom as an early-return guard + straight-line `let` bindings.
  The original idiom — also used by the pre-existing, previously-working
  `kretikos_emit_ptx.sio` — now fails typecheck on this branch with `expected PtxBuf, found
  ()` (E001), confirmed to reproduce on the untouched `kretikos_emit_ptx.sio` too, so it's a
  branch-wide regression, not specific to this file.
- `docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md`: new
  forensic dispatch documenting a deeper, still-unfixed blocker found after the above fix —
  importing `gpu::kernel_ir` + `gpu::lower_to_ptx` + `gpu::ptx` together fails `souc check`
  with 335 `E175` + 18 `E177` + 5 `E046` errors, reproducible with an empty `main()` (no code
  of mine involved). `gpu::mod` (the GPU backend's own orchestrator) doesn't import
  `lower_to_ptx`, so this exact module combination has apparently never been exercised
  together in CI. Root-caused as far as reproduction/classification; NOT fixed — documented
  so the blocker survives context loss instead of being rediscovered from scratch.

Ruled out as the cause of the module-combination breakage: `IR_MAX_INSTRS` (separate, already
documented in a sibling audit doc — raising it was attempted and reverted this session since
it didn't touch these errors), the known native-codegen segfault (separate, downstream of
where these errors occur), and stale binaries.

## Test plan

- [x] `souc check self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` no longer hits the E001
  regression after the rewrite (still blocked by the separate module-combination issue
  documented in the new audit doc).
- [x] Reproduction in the audit doc verified against `souc check self-hosted/gpu/mod.sio`
  passing clean for contrast.
- [ ] Actually emitting PTX from this driver and running the DGX Spark gate
  (`scripts/dev/dgx_spark_epistemic_wmma_matmul_gate.sh`, from #572) remains blocked pending
  a fix for the module-combination issue — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)