### PR TITLE
fix(stdlib): full audit fix for ontology.sio — closes #579

### DIFF
--- a/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
+++ b/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
@@ -405,3 +405,65 @@ this week (21 tests total, all pass). Also verified Madaros: the 3 kinetics-clus
 tests show the same pre-existing "no method named for this type" (E011) Madaros-only
 divergence already documented for `equilibrium.sio`/`acids.sio` in the #567 update — not
 a new regression, inherited from those two modules.
+
+## Update 2026-07-03 (continued): issue #579 (ontology.sio audit) — one more new bug found, file down to zero errors
+
+Picked up issue #579 (`stdlib/chemistry/ontology.sio` had ~24 pre-existing, non-fatal
+errors). All 24 fixed; the file now checks with zero errors. Breakdown:
+
+**16 "comparison operands must have the same type"** — all the same root cause as the
+string-literal-argument issue from #575's PR, but for `==` comparisons instead of call
+arguments: `mechanism == "big_crn"` (comparing a `&str` parameter against a bare string
+literal, which infers as `string` not `&str`) fails. Same workaround: bind the literal
+to a local `string` first, compare against its reference (`let lit: string = "big_crn";
+mechanism == &lit`). Fixed at every comparison site across `species_to_chebi_iri` (12
+distinct literals) and `attach_chebi_to_crn_output` (4 literals, reused from the first
+function's set since both take a `mechanism: &str` parameter with the same literal
+vocabulary).
+
+**4 E001 + 2 "unknown identifier `[`" + 1 arity mismatch** — the already-known Bug E
+(inline array/string literal as a call argument) recurring in this file's own test
+functions (`species_to_chebi_iri(5, "big_crn")`, `attach_chebi_to_crn_output(&[...],
+&[...], "big_crn")`) — same fix, bind to locals first.
+
+**3 "effect not declared in function signature"** — `attach_chebi_to_crn_output` (array
+mutation via `iris[i] = ...`, needed `with Mut`, never declared) and its 2 transitive
+callers needed the same effect propagated up their own signatures — ordinary
+test-authoring omissions, same shape as issue #571's fix, not checker bugs.
+
+**Bug G — a struct type in the LAST position of a 3-tuple confuses lean_single's type
+inference for the tuple's *middle* element.** Isolated with a minimal repro outside
+stdlib:
+```sio
+struct Foo { id: i64 }
+fn f(val: f64, u: f64) -> (f64, f64, Foo) { (val, u, Foo { id: 1 }) }
+fn main() -> bool {
+    let (v, u, iri) = f(0.18, 0.02);
+    u > 0.0   // error: ordered comparison requires matching numeric operands
+}
+```
+Isolated further: `(f64, f64, f64)` (all-numeric) works fine; `(Foo, f64, f64)` (struct
+*first*) works fine; only a struct in position 2-of-2 (i.e. last, with something before
+it) corrupts the *middle* f64's inferred type — `let u2: f64 = u;` in the repro above
+reports `expected f64, got i64`, i.e. the checker doesn't just lose the type, it assigns
+the wrong concrete one. Access via `.1` field syntax instead of destructuring hits the
+identical error, so this isn't specific to `let (a, b, c) = ...` pattern-matching syntax
+— it's the tuple type's own internal element-type bookkeeping. `stdlib/chemistry/
+ontology.sio`'s `epistemic_water_conc(val, u) -> (f64, f64, IRI)` matched this exact
+shape (struct last, 2 f64s before it) and had exactly 2 real call sites (one in this
+file's own test, one in `stdlib/chemistry/kinetics.sio`). Fixed by reordering the
+return tuple to `(IRI, f64, f64)` (struct first) and updating both call sites'
+destructuring order to match — this is a public-API change to `epistemic_water_conc`,
+justified as a workaround for a confirmed checker bug with a fully enumerated, tiny
+blast radius (grepped for all callers before changing).
+
+**Result:** `stdlib/chemistry/ontology.sio` now checks with zero errors (previously 24).
+`stdlib/chemistry/kinetics.sio`'s own remaining error count also dropped by one (the
+`epistemic_water_conc` tail-type-mismatch this file had been carrying) — its residual
+14 errors (separately tracked, non-fatal, same file this whole dispatch update-chain has
+been about) are otherwise unchanged; `stdlib/epistemic/ode.sio`'s 14 (issue #580) are
+untouched, out of this issue's scope.
+
+Verified against a freshly rebuilt `lean_single`: all 3 kinetics-cluster tests plus the
+other 18 tests fixed this week still pass (21 total, zero regressions). Madaros shows
+the same pre-existing E011 divergence already documented above — not new.

--- a/stdlib/chemistry/kinetics.sio
+++ b/stdlib/chemistry/kinetics.sio
@@ -89,7 +89,7 @@ pub fn chebi_water() -> CHEBI_15377 {
 }
 
 pub fn ontology_linked_water_conc(val: f64, u: f64) -> (f64, f64) {
-    let (v, uv, _) = epistemic_water_conc(val, u);
+    let (_, v, uv) = epistemic_water_conc(val, u);
     (v, uv)
 }
 

--- a/stdlib/chemistry/ontology.sio
+++ b/stdlib/chemistry/ontology.sio
@@ -146,7 +146,25 @@ pub fn full_big_crn_chebi_map() -> [IRI; 6] {
 
 pub fn species_to_chebi_iri(species_idx: i64, mechanism: &str) -> IRI {
     // Delegate to FULL per-compound for consistency
-    if mechanism == "big_crn" || mechanism == "h2o2" {
+    //
+    // Bare string literals compared against a `&str` parameter fail lean_single's
+    // checker ("comparison operands must have the same type" — a bare literal
+    // infers as `string`, not `&str`); bind each to a local `string` first and
+    // compare against its reference, matching the workaround already used
+    // elsewhere in this stdlib wave for the same class of bug.
+    let mech_big_crn: string = "big_crn";
+    let mech_h2o2: string = "h2o2";
+    let mech_metabolic: string = "metabolic";
+    let mech_pbpk: string = "pbpk";
+    let mech_pbpk28: string = "pbpk28";
+    let mech_cyp: string = "cyp";
+    let mech_cyp3a4: string = "cyp3a4";
+    let mech_pgp: string = "pgp";
+    let mech_transport: string = "transport";
+    let mech_proteolytic: string = "proteolytic";
+    let mech_peptide: string = "peptide";
+    let mech_enzyme: string = "enzyme";
+    if mechanism == &mech_big_crn || mechanism == &mech_h2o2 {
         match species_idx {
             0 => h_atom_chebi(),
             1 => o2_chebi(),
@@ -156,7 +174,7 @@ pub fn species_to_chebi_iri(species_idx: i64, mechanism: &str) -> IRI {
             5 => h2o_chebi(),
             _ => iri_new(0),
         }
-    } else if mechanism == "metabolic" || mechanism == "pbpk" || mechanism == "pbpk28" {
+    } else if mechanism == &mech_metabolic || mechanism == &mech_pbpk || mechanism == &mech_pbpk28 {
         match species_idx {
             0 => water_iri(),
             1 => drug_chebi(),
@@ -168,25 +186,25 @@ pub fn species_to_chebi_iri(species_idx: i64, mechanism: &str) -> IRI {
             7 => semaglutide_chebi(),
             _ => iri_new(100000 + species_idx),
         }
-    } else if mechanism == "cyp" || mechanism == "cyp3a4" {
+    } else if mechanism == &mech_cyp || mechanism == &mech_cyp3a4 {
         match species_idx {
             0 => cyp3a4_enzyme_chebi(),
             1 => midazolam_chebi(), // probe substrate
             2 => tacrolimus_chebi(),
             _ => iri_new(6805), // fall to xeno GO id
         }
-    } else if mechanism == "pgp" || mechanism == "transport" {
+    } else if mechanism == &mech_pgp || mechanism == &mech_transport {
         match species_idx {
             0 => digoxin_chebi(),
             1 => rapamycin_chebi(),
             _ => pgp_transport_iri(),
         }
-    } else if mechanism == "proteolytic" || mechanism == "peptide" {
+    } else if mechanism == &mech_proteolytic || mechanism == &mech_peptide {
         match species_idx {
             0 => semaglutide_chebi(),
             _ => proteolysis_process_iri(),
         }
-    } else if mechanism == "enzyme" {
+    } else if mechanism == &mech_enzyme {
         match species_idx {
             0 => enzyme_chebi(),
             1 => substrate_chebi(),
@@ -214,22 +232,33 @@ fn check_near(a: f64, b: f64, tol: f64) -> bool { abs_f64(a - b) <= tol }
 // ============================================================================
 
 // Example: epistemic concentration of water with full ChEBI provenance
-pub fn epistemic_water_conc(val: f64, u: f64) -> (f64, f64, IRI) {
+//
+// Returns (IRI, value, uncertainty) rather than (value, uncertainty, IRI): a struct
+// type in the LAST position of a 3-tuple confuses lean_single's type inference for
+// the tuple's middle numeric element (isolated with a minimal repro outside stdlib;
+// `f64` first/middle positions are fine, `f64` last next to a struct is fine too —
+// only a non-numeric type strictly in position 2 of 3 breaks it). Reordering avoids
+// the bug entirely; both of this function's 2 call sites were updated to match.
+pub fn epistemic_water_conc(val: f64, u: f64) -> (IRI, f64, f64) {
     let chebi = water_iri();
     // In full system: this would feed Knowledge[CHEBI_15377] { value, variance, ontology: chebi, ... }
-    (val, u, chebi)
+    (chebi, val, u)
 }
 
 // Used in CRN outputs to attach ontology grounding (for audit, reports)
 // Supports pbpk/pbpk28 for PBPK28 drug mappings (extended)
-pub fn attach_chebi_to_crn_output(vals: &[f64; 8], us: &[f64; 8], mechanism: &str) -> ([f64; 8], [f64; 8], [IRI; 8]) {
+pub fn attach_chebi_to_crn_output(vals: &[f64; 8], us: &[f64; 8], mechanism: &str) -> ([f64; 8], [f64; 8], [IRI; 8]) with Mut {
     var iris: [IRI; 8] = [iri_new(0); 8];
-    var n = if mechanism == "pbpk" || mechanism == "pbpk28" || mechanism == "cyp" || mechanism == "pgp" { 8 } else { 6 };
+    let acco_pbpk: string = "pbpk";
+    let acco_pbpk28: string = "pbpk28";
+    let acco_cyp: string = "cyp";
+    let acco_pgp: string = "pgp";
+    var n = if mechanism == &acco_pbpk || mechanism == &acco_pbpk28 || mechanism == &acco_cyp || mechanism == &acco_pgp { 8 } else { 6 };
     var i = 0; while i < n && i < 8 {
         iris[i] = species_to_chebi_iri(i as i64, mechanism);
         i = i + 1;
     }
-    (vals, us, iris)
+    (*vals, *us, iris)
 }
 
 // PBPK28 drug/enzyme map (ChEBI for compounds + enzymes)
@@ -265,19 +294,27 @@ pub fn test_chebi_water_nominal() -> bool {
 }
 
 pub fn test_chebi_crn_species_mapping() -> bool {
-    let h2o = species_to_chebi_iri(5, "big_crn");
-    let o2 = species_to_chebi_iri(1, "big_crn");
+    let mech_test_big_crn: string = "big_crn";
+    let h2o = species_to_chebi_iri(5, &mech_test_big_crn);
+    let o2 = species_to_chebi_iri(1, &mech_test_big_crn);
     // Water uses real, others documented standard
     h2o.id == CHEBI_15377_ID && o2.id == 15379
 }
 
-pub fn test_epistemic_ontology_linked() -> bool {
-    let (v, u, iri) = epistemic_water_conc(0.18, 0.02);  // from BigCRN lit H2O
-    let (v2, u2, _) = attach_chebi_to_crn_output(&[0.5,0.5,0.0,0.0,0.5,0.18,0.0,0.0], &[0.0;8], "big_crn");
-    check_near(v, 0.18, 0.05) && u > 0.0 && iri.id == CHEBI_15377_ID && v2[5] == 0.18
+pub fn test_epistemic_ontology_linked() -> bool with Mut {
+    let (iri, v, u) = epistemic_water_conc(0.18, 0.02);  // from BigCRN lit H2O
+    let test_vals: [f64; 8] = [0.5,0.5,0.0,0.0,0.5,0.18,0.0,0.0];
+    let test_us: [f64; 8] = [0.0;8];
+    let mech_test_big_crn2: string = "big_crn";
+    let (v2, u2, _) = attach_chebi_to_crn_output(&test_vals, &test_us, &mech_test_big_crn2);
+    let near_ok = check_near(v, 0.18, 0.05);
+    let u_ok = u > 0.0;
+    let iri_ok = iri.id == CHEBI_15377_ID;
+    let v2_ok = v2[5] == 0.18;
+    near_ok && u_ok && iri_ok && v2_ok
 }
 
-pub fn test_chemistry_full_ontology() -> bool with IO {
+pub fn test_chemistry_full_ontology() -> bool with IO, Mut {
     let ok1 = test_chebi_water_nominal();
     let ok2 = test_chebi_crn_species_mapping();
     let ok3 = test_epistemic_ontology_linked();


### PR DESCRIPTION
## Summary
Closes issue #579: `stdlib/chemistry/ontology.sio` had 24 pre-existing, non-fatal type errors (never fully validated by lean_single). All fixed — the file now checks clean.

- **16 "comparison operands must have the same type"**: `mechanism == "literal"` (comparing a `&str` parameter against a bare string literal, which infers as `string` not `&str`) across `species_to_chebi_iri` (12 distinct literals) and `attach_chebi_to_crn_output` (4 literals). Same workaround as #575's string-literal-argument fix, applied to `==` comparisons: bind the literal to a local `string` first, compare against its reference.
- **4 E001 + 2 "unknown identifier `[`" + 1 arity mismatch**: #575's Bug E (inline array/string literal as a call argument) recurring in this file's own test functions.
- **3 "effect not declared in function signature"**: `attach_chebi_to_crn_output` needed `with Mut` (array mutation, never declared) and its 2 transitive callers needed the effect propagated up — ordinary test-authoring omissions (#571's shape), not checker bugs.

**New checker bug found and isolated (documented as "Bug G"):** a struct type in the LAST position of a 3-tuple corrupts lean_single's type inference for the tuple's MIDDLE f64 element — not just loses the type, assigns the *wrong concrete one* (confirmed via a minimal repro outside stdlib). `(f64, f64, f64)` and `(Struct, f64, f64)` both work; only `(f64, f64, Struct)` breaks. Not specific to destructuring — `.1` field access hits the same error. `epistemic_water_conc(val, u) -> (f64, f64, IRI)` matched this shape with exactly 2 real call sites (grepped before changing). Fixed by reordering to `(IRI, f64, f64)` and updating both call sites (`stdlib/chemistry/kinetics.sio` and this file's own test) — a small, justified public-API change to work around a confirmed checker bug.

## Test plan
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path).
- [x] All 21 tests fixed this week still pass via `scripts/run_sio_test_suite.sh --filter`, zero regressions.
- [x] Madaros shows the same pre-existing "no method named for this type" divergence already documented for `equilibrium.sio`/`acids.sio` — inherited, not new.

Closes #579.