### PR TITLE
fix(gpu): resolve gpu::kernel_ir+lower_to_ptx+ptx module-combination breakage

### DIFF
--- a/docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
+++ b/docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
@@ -9,13 +9,16 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-
 
 # Madaros forensic dispatch — `gpu::kernel_ir` + `gpu::lower_to_ptx` + `gpu::ptx` fail to check together
 
-Date: 2026-07-02
+Date: 2026-07-02, resolved 2026-07-03
 Branch: `gpu/epistemic-tensor-core-next` (base: `research/solver-ts3-parallel` @ `65f44e60c`,
-merge of PR #572)
+merge of PR #572); fix landed on `fix/gpu-lower-to-ptx-module-combo`
 Class: **PRE-EXISTING MODULE-COMBINATION BREAKAGE** (hundreds of typecheck errors,
 independent of any function body or call site — reproducible with an empty `main`)
-Status: root-caused to "this exact 3-module combination is apparently never exercised
-together in CI"; NOT fixed; NOT attempted beyond the diagnosis below
+Status: **FIXED** (`souc check` verdict=0 on all three files together, and on the
+`kretikos_emit_epistemic_wmma.sio` driver this was blocking). See "Resolution" below.
+The three root causes were NOT what the diagnosis section originally guessed
+(the diagnosis correctly named privacy-annotation drift as one factor, but there were
+two more independent bugs stacked underneath it — see Resolution).
 
 > Found while trying to write a CLI driver
 > (`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio`) to emit PTX for the
@@ -174,6 +177,51 @@ ever reaching the native-codegen stage on this branch.
    `gpu::ptx` together (e.g. via `mod.sio` gaining a `use gpu::lower_to_ptx::*` line, if
    that's semantically correct for the orchestrator to own) so this combination is never
    silently unvalidated again.
+
+## Resolution (2026-07-03)
+
+Bisected pairwise as step 1 above suggested: `kernel_ir + lower_to_ptx` alone reproduced
+357 of the 358 errors; `lower_to_ptx` alone (which has its own internal `use` of both
+other modules) reproduced 334 as **E137 "use of undeclared variable"** instead of
+E175/E177/E046 — a different error class, which turned out to be the first real clue.
+Three independent, stacked bugs, found in this order:
+
+1. **`lower_to_ptx.sio` had lost its own `use gpu::kernel_ir::*` / `use gpu::ptx::*`
+   lines** (and `gpu_lower_to_ptx`'s `pub`) at some point in this branch's churn — every
+   reference inside it to `GpuKernelIr`, `PtxBuf`, `ptx_buf_new()`, etc. was genuinely
+   undeclared in that file's own scope. `use` in Sounio is **not transitive** — a
+   dependency's own `use` lines only resolve symbols for that dependency's own body; they
+   don't extend the importer's visible symbol set. Restored both `use` lines.
+2. **`kernel_ir.sio` had 5 struct literals with a duplicated field key** (`rhs_reg` or
+   `lhs_reg` given two different `key: value` entries in the same `GpuOp { ... }`
+   literal — 24 pairs for a 23-field struct). This is what E046 ("wrong number of fields")
+   actually meant; the count check runs before any duplicate-key check. All 5 were
+   address-computation ops (`GpuAdd`/`GpuSetpLt`/`GpuStoreSharedPred`) built from a copied
+   template that kept both the template's placeholder value and the real one. Removed the
+   redundant copy in each, keeping the meaningful value.
+3. **`ptx.sio` called `i64_to_string`, which it never defined or imported** (it only exists
+   in `lower_to_ptx.sio` and `opt/warp_vote_fastpath.sio` — importing either from `ptx.sio`
+   would be circular, since `lower_to_ptx.sio` imports `gpu::ptx`). Added a local copy.
+4. **Privacy-annotation drift, confirmed as real and widespread, not a one-off**: in
+   `kernel_ir.sio`, the `Name`/`GpuOp`/`GpuParam`/`GpuKernelIr` structs and their fields,
+   all 12 top-level enums, and 131/132 top-level functions were missing `pub`. In
+   `ptx.sio`, `PtxBuf` and all 147 of its top-level functions were missing `pub`. Both
+   files exist specifically to be shared libraries for the rest of the GPU backend, so
+   blanket `pub` (not selective) is the correct fix, applied via a scripted pass rather
+   than fixing one symbol at a time as each was hit by a different caller.
+
+**Verified:** `souc check` now passes (`verdict=0`, no errors) on `kernel_ir.sio`,
+`ptx.sio`, `lower_to_ptx.sio` individually and together, and on
+`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` (the driver this was blocking).
+`souc build` of that driver now gets past typecheck and IR merge — down to a 1-function
+merged IR from the ~240–330 seen before this fix — and reaches native codegen, where it
+hits the **separate**, already-tracked, open Madaros SIGSEGV cluster
+(`docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/`). That is out of scope for this
+dispatch; getting a real native ELF (and from there, PTX for DGX Spark hardware
+verification) still depends on that separate bug being fixed.
+
+Fix commit: `fix(gpu): resolve gpu::kernel_ir+lower_to_ptx+ptx module-combination
+breakage` on `fix/gpu-lower-to-ptx-module-combo`.
 
 ## Cross-references
 

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -11,16 +11,16 @@
 // - Fixed register allocation for now
 // - Struct-based representation (no enum field destructuring - not supported by self-hosted)
 
-struct Name {
-    buf: [i8; 128],
-    len: i64,
+pub struct Name {
+    pub buf: [i8; 128],
+    pub len: i64,
 }
 
-fn ki_empty_name() -> Name {
+pub fn ki_empty_name() -> Name {
     Name { buf: [0; 128], len: 0 }
 }
 
-fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut, Panic, Div {
+pub fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut, Panic, Div {
     var n = Name { buf: [0; 128], len: len }
     if len > 0 { n.buf[0] = a }
     if len > 1 { n.buf[1] = b }
@@ -32,7 +32,7 @@ fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut,
 // Build a Name from a string literal (any length up to 128).
 // Uses str_char_at so all bytes are set in one-level ops — avoids the
 // two-level nested-store miscompilation (var.field1.field2[i] = v).
-fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
+pub fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
     var n = Name { buf: [0; 128], len: len }
     var i: i64 = 0
     while i < len {
@@ -43,7 +43,7 @@ fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
 }
 
 // GPU data types (full type coverage for all kernels)
-enum GpuType {
+pub enum GpuType {
     GpuU32,
     GpuU64,
     GpuF32,
@@ -60,7 +60,7 @@ enum GpuType {
 }
 
 // GPU operation opcodes (simple enum, no fields)
-enum GpuOpcode {
+pub enum GpuOpcode {
     GpuGetTid,       // Get thread ID
     GpuCvt,          // Type conversion
     GpuMulImm,       // Multiply with immediate
@@ -178,7 +178,7 @@ enum GpuOpcode {
 }
 
 // GPU memory space (for load/store address space qualification)
-enum GpuMemorySpace {
+pub enum GpuMemorySpace {
     GpuMemGlobal,
     GpuMemShared,
     GpuMemLocal,
@@ -186,7 +186,7 @@ enum GpuMemorySpace {
 }
 
 // Phase 6: Atomic operation selector (used by GpuAtomicCas, GpuAtomicExch, etc.)
-enum GpuAtomicOp {
+pub enum GpuAtomicOp {
     GpuAtomAdd,
     GpuAtomCas,
     GpuAtomExch,
@@ -198,7 +198,7 @@ enum GpuAtomicOp {
 }
 
 // Phase 6: Cache hint for loads/stores (maps to PTX cache operators)
-enum GpuCacheHint {
+pub enum GpuCacheHint {
     GpuCacheDefault,  // .ca — cache at all levels (default)
     GpuCacheCA,       // .ca — cache at all levels
     GpuCacheCG,       // .cg — cache at L2 only
@@ -207,18 +207,18 @@ enum GpuCacheHint {
     GpuCacheCV,       // .cv — volatile (don't cache)
 }
 
-enum GpuEpistemicMode {
+pub enum GpuEpistemicMode {
     GpuEpistemicStrict,
     GpuEpistemicFast,
 }
 
-enum GpuError {
+pub enum GpuError {
     GpuOk,
     GpuOpBufferOverflow,
 }
 
 // Phase 7: Multi-target profile and legalization contracts.
-enum GpuTargetVendor {
+pub enum GpuTargetVendor {
     GpuVendorCuda,
     GpuVendorRocm,
     GpuVendorSpirv,
@@ -226,21 +226,21 @@ enum GpuTargetVendor {
     GpuVendorUnknown,
 }
 
-enum GpuTargetMemoryModel {
+pub enum GpuTargetMemoryModel {
     GpuMemoryCuda,
     GpuMemoryHsa,
     GpuMemorySpirv,
     GpuMemoryUnknown,
 }
 
-enum GpuBinaryFormat {
+pub enum GpuBinaryFormat {
     GpuBinaryFatbin,
     GpuBinaryCubin,
     GpuBinaryHsaco,
     GpuBinaryMulti,
 }
 
-enum GpuWorkloadTag {
+pub enum GpuWorkloadTag {
     GpuWorkloadGeneral,
     GpuWorkloadMl,
     GpuWorkloadOnn,
@@ -252,7 +252,7 @@ enum GpuWorkloadTag {
     GpuWorkloadExceptional,
 }
 
-enum GpuLegalizationCode {
+pub enum GpuLegalizationCode {
     GpuLegalizationPass,
     GpuLegalizationTensorCoreUnavailable,
     GpuLegalizationAsyncCopyUnavailable,
@@ -309,72 +309,72 @@ pub struct GpuAppendResult {
 
 // GPU operation (struct with all possible fields, like IrInstr)
 pub struct GpuOp {
-    opcode: GpuOpcode,
-    dst_reg: i64,
-    src_reg: i64,
-    lhs_reg: i64,
-    rhs_reg: i64,
-    addr_reg: i64,
-    rhs_imm: i64,
-    param_idx: i64,
-    axis: i64,  // 0=x, 1=y, 2=z for GetTid
-    shared_addr: i64,  // Shared memory address/offset
-    ty: GpuType,
-    dst_ty: GpuType,
-    src_ty: GpuType,
+    pub opcode: GpuOpcode,
+    pub dst_reg: i64,
+    pub src_reg: i64,
+    pub lhs_reg: i64,
+    pub rhs_reg: i64,
+    pub addr_reg: i64,
+    pub rhs_imm: i64,
+    pub param_idx: i64,
+    pub axis: i64,  // 0=x, 1=y, 2=z for GetTid
+    pub shared_addr: i64,  // Shared memory address/offset
+    pub ty: GpuType,
+    pub dst_ty: GpuType,
+    pub src_ty: GpuType,
     // Phase 5 extensions
-    memory_space: GpuMemorySpace,   // Address space for load/store ops
-    pred_reg: i64,                  // Predicate register for conditional ops (-1 = none)
-    mask: i64,                      // Warp mask for shuffle/vote ops (0xFFFFFFFF = all lanes)
+    pub memory_space: GpuMemorySpace,   // Address space for load/store ops
+    pub pred_reg: i64,                  // Predicate register for conditional ops (-1 = none)
+    pub mask: i64,                      // Warp mask for shuffle/vote ops (0xFFFFFFFF = all lanes)
     // Phase 6 extensions
-    atomic_op: GpuAtomicOp,         // Operation selector for atomic ops
-    cache_hint: GpuCacheHint,       // Cache policy for loads/stores
-    compare_reg: i64,               // CAS compare value register (-1 = none)
-    num_regs: i64,                  // Tile register count (tensor core fragments)
-    byte_offset: i64,               // Byte offset for cp.async
-    scope: i64,                     // Fence scope: 0=cta, 1=gl, 2=sys
-    cg_size: i64,                   // Cooperative group size (tiled_partition width)
+    pub atomic_op: GpuAtomicOp,         // Operation selector for atomic ops
+    pub cache_hint: GpuCacheHint,       // Cache policy for loads/stores
+    pub compare_reg: i64,               // CAS compare value register (-1 = none)
+    pub num_regs: i64,                  // Tile register count (tensor core fragments)
+    pub byte_offset: i64,               // Byte offset for cp.async
+    pub scope: i64,                     // Fence scope: 0=cta, 1=gl, 2=sys
+    pub cg_size: i64,                   // Cooperative group size (tiled_partition width)
 }
 
 // GPU kernel parameter (e.g., .param .u64 param_a)
 pub struct GpuParam {
-    name: Name,
-    ty: GpuType,
+    pub name: Name,
+    pub ty: GpuType,
 }
 
 // GPU kernel IR (represents a single kernel)
 pub struct GpuKernelIr {
-    kernel_name: Name,
-    workload_tag: GpuWorkloadTag,
-    params: [GpuParam; 8],
-    param_count: i64,
+    pub kernel_name: Name,
+    pub workload_tag: GpuWorkloadTag,
+    pub params: [GpuParam; 8],
+    pub param_count: i64,
     // Stage-5 hardening target: allow up to 1024 IR ops per kernel
     // (large enough for the shared-memory/tiled-family kernels in this phase).
-    ops: [GpuOp; 1024],
-    op_count: i64,
+    pub ops: [GpuOp; 1024],
+    pub op_count: i64,
 
     // Shared-memory region size (in bytes) used by this kernel.
     // 0 means no dynamic shared declaration.
-    shared_bytes: i64,
+    pub shared_bytes: i64,
 
     // Register allocation info (simple for now)
-    max_reg_u32: i64,
-    max_reg_u64: i64,
-    max_reg_f32: i64,
-    max_reg_f64: i64,
-    max_reg_i32: i64,
-    max_reg_i64: i64,
-    max_reg_pred: i64,
+    pub max_reg_u32: i64,
+    pub max_reg_u64: i64,
+    pub max_reg_f32: i64,
+    pub max_reg_f64: i64,
+    pub max_reg_i32: i64,
+    pub max_reg_i64: i64,
+    pub max_reg_pred: i64,
     // Phase 5 extensions
-    shared_mem_bytes: i64,  // Total shared memory allocated (bytes)
-    max_threads: i64,       // Maximum threads per block hint (0 = default)
+    pub shared_mem_bytes: i64,  // Total shared memory allocated (bytes)
+    pub max_threads: i64,       // Maximum threads per block hint (0 = default)
     // Phase 6 extensions
-    num_barriers: i64,      // Named barrier count (bar.sync n)
-    cta_size_x: i64,        // Compile-time blockDim.x (0 = dynamic)
-    cta_size_y: i64,        // Compile-time blockDim.y (0 = dynamic)
-    cta_size_z: i64,        // Compile-time blockDim.z (0 = dynamic)
-    cluster_x: i64,         // Thread block cluster dim x (sm_90+, 0 = none)
-    cluster_y: i64,         // Thread block cluster dim y (sm_90+, 0 = none)
+    pub num_barriers: i64,      // Named barrier count (bar.sync n)
+    pub cta_size_x: i64,        // Compile-time blockDim.x (0 = dynamic)
+    pub cta_size_y: i64,        // Compile-time blockDim.y (0 = dynamic)
+    pub cta_size_z: i64,        // Compile-time blockDim.z (0 = dynamic)
+    pub cluster_x: i64,         // Thread block cluster dim x (sm_90+, 0 = none)
+    pub cluster_y: i64,         // Thread block cluster dim y (sm_90+, 0 = none)
 }
 
 // Lowered module: collection of kernels post-HLIR-to-GPU lowering, pre-optimization.
@@ -383,7 +383,7 @@ pub struct HlirGpuLoweredModule {
     kernel_count: i64,
 }
 
-fn hlir_gpu_lowered_module_new() -> HlirGpuLoweredModule {
+pub fn hlir_gpu_lowered_module_new() -> HlirGpuLoweredModule {
     HlirGpuLoweredModule {
         kernels: [gpu_kernel_new(); 64],
         kernel_count: 0,
@@ -392,7 +392,7 @@ fn hlir_gpu_lowered_module_new() -> HlirGpuLoweredModule {
 
 // Constructors and helpers
 
-fn gpu_kernel_new() -> GpuKernelIr {
+pub fn gpu_kernel_new() -> GpuKernelIr {
     GpuKernelIr {
         kernel_name: ki_empty_name(),
         workload_tag: GpuWorkloadTag::GpuWorkloadGeneral,
@@ -419,11 +419,11 @@ fn gpu_kernel_new() -> GpuKernelIr {
     }
 }
 
-fn gpu_kernel_max_ops() -> i64 {
+pub fn gpu_kernel_max_ops() -> i64 {
     1024
 }
 
-fn gpu_append_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
+pub fn gpu_append_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
     if kernel.op_count >= gpu_kernel_max_ops() {
         GpuAppendResult { result_kernel: kernel, error: GpuError::GpuOpBufferOverflow }
     } else {
@@ -434,28 +434,28 @@ fn gpu_append_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with
     }
 }
 
-fn gpu_add_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
+pub fn gpu_add_op_checked(kernel: GpuKernelIr, op: GpuOp) -> GpuAppendResult with Mut, Panic, Div {
     gpu_append_op_checked(kernel, op)
 }
 
-fn gpu_append_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_append_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
     let out = gpu_append_op_checked(kernel, op)
     out.result_kernel
 }
 
-fn gpu_add_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_add_op(kernel: GpuKernelIr, op: GpuOp) -> GpuKernelIr with Mut, Panic, Div {
     let out = gpu_add_op_checked(kernel, op)
     out.result_kernel
 }
 
-fn gpu_param_new() -> GpuParam {
+pub fn gpu_param_new() -> GpuParam {
     GpuParam {
         name: ki_empty_name(),
         ty: GpuType::GpuU64,
     }
 }
 
-fn gpu_op_new() -> GpuOp {
+pub fn gpu_op_new() -> GpuOp {
     GpuOp {
         opcode: GpuOpcode::GpuRet,
         dst_reg: -1,
@@ -483,7 +483,7 @@ fn gpu_op_new() -> GpuOp {
     }
 }
 
-fn gpu_target_vendor_to_string(vendor: GpuTargetVendor) -> string {
+pub fn gpu_target_vendor_to_string(vendor: GpuTargetVendor) -> string {
     match vendor {
         GpuTargetVendor::GpuVendorCuda => "cuda"
         GpuTargetVendor::GpuVendorRocm => "rocm"
@@ -493,7 +493,7 @@ fn gpu_target_vendor_to_string(vendor: GpuTargetVendor) -> string {
     }
 }
 
-fn gpu_binary_format_to_string(fmt: GpuBinaryFormat) -> string {
+pub fn gpu_binary_format_to_string(fmt: GpuBinaryFormat) -> string {
     match fmt {
         GpuBinaryFormat::GpuBinaryFatbin => "fatbin"
         GpuBinaryFormat::GpuBinaryCubin => "cubin"
@@ -502,7 +502,7 @@ fn gpu_binary_format_to_string(fmt: GpuBinaryFormat) -> string {
     }
 }
 
-fn gpu_workload_tag_to_string(tag: GpuWorkloadTag) -> string {
+pub fn gpu_workload_tag_to_string(tag: GpuWorkloadTag) -> string {
     match tag {
         GpuWorkloadTag::GpuWorkloadGeneral => "general"
         GpuWorkloadTag::GpuWorkloadMl => "ml"
@@ -516,13 +516,13 @@ fn gpu_workload_tag_to_string(tag: GpuWorkloadTag) -> string {
     }
 }
 
-fn gpu_kernel_set_workload_tag(kernel: GpuKernelIr, tag: GpuWorkloadTag) -> GpuKernelIr with Mut {
+pub fn gpu_kernel_set_workload_tag(kernel: GpuKernelIr, tag: GpuWorkloadTag) -> GpuKernelIr with Mut {
     var out = kernel
     out.workload_tag = tag
     out
 }
 
-fn gpu_target_profile_unknown() -> GpuTargetProfile {
+pub fn gpu_target_profile_unknown() -> GpuTargetProfile {
     GpuTargetProfile {
         vendor: GpuTargetVendor::GpuVendorUnknown,
         arch: ki_empty_name(),
@@ -536,7 +536,7 @@ fn gpu_target_profile_unknown() -> GpuTargetProfile {
     }
 }
 
-fn gpu_target_profile_cuda_sm80() -> GpuTargetProfile with Mut, Panic, Div {
+pub fn gpu_target_profile_cuda_sm80() -> GpuTargetProfile with Mut, Panic, Div {
     var arch = ki_ir_name_from_bytes(99, 117, 100, 97, 9)  // "cuda-sm80"
     arch.buf[4] = 45   // '-'
     arch.buf[5] = 115  // 's'
@@ -556,7 +556,7 @@ fn gpu_target_profile_cuda_sm80() -> GpuTargetProfile with Mut, Panic, Div {
     }
 }
 
-fn gpu_target_profile_rocm_gfx942() -> GpuTargetProfile with Mut, Panic, Div {
+pub fn gpu_target_profile_rocm_gfx942() -> GpuTargetProfile with Mut, Panic, Div {
     var arch = ki_ir_name_from_bytes(114, 111, 99, 109, 11)  // "rocm-gfx942"
     arch.buf[4] = 45   // '-'
     arch.buf[5] = 103  // 'g'
@@ -578,11 +578,11 @@ fn gpu_target_profile_rocm_gfx942() -> GpuTargetProfile with Mut, Panic, Div {
     }
 }
 
-fn gpu_target_profile_arch_string(profile: GpuTargetProfile) -> string with Mut, Panic, Div {
+pub fn gpu_target_profile_arch_string(profile: GpuTargetProfile) -> string with Mut, Panic, Div {
     str_from_bytes(profile.arch.buf, profile.arch.len)
 }
 
-fn gpu_op_capability_requirement_new() -> GpuOpCapabilityRequirement {
+pub fn gpu_op_capability_requirement_new() -> GpuOpCapabilityRequirement {
     GpuOpCapabilityRequirement {
         opcode: GpuOpcode::GpuRet,
         requires_tensor_core: false,
@@ -592,7 +592,7 @@ fn gpu_op_capability_requirement_new() -> GpuOpCapabilityRequirement {
     }
 }
 
-fn gpu_capability_requirement_from_op(op: GpuOp) -> GpuOpCapabilityRequirement with Mut {
+pub fn gpu_capability_requirement_from_op(op: GpuOp) -> GpuOpCapabilityRequirement with Mut {
     var req = gpu_op_capability_requirement_new()
     req.opcode = op.opcode
 
@@ -612,7 +612,7 @@ fn gpu_capability_requirement_from_op(op: GpuOp) -> GpuOpCapabilityRequirement w
     req
 }
 
-fn gpu_target_supports_requirement(profile: GpuTargetProfile, req: GpuOpCapabilityRequirement) -> bool {
+pub fn gpu_target_supports_requirement(profile: GpuTargetProfile, req: GpuOpCapabilityRequirement) -> bool {
     if req.requires_tensor_core && !profile.supports_tensor_core {
         return false
     }
@@ -628,7 +628,7 @@ fn gpu_target_supports_requirement(profile: GpuTargetProfile, req: GpuOpCapabili
     true
 }
 
-fn gpu_first_unmet_legalization_code(profile: GpuTargetProfile, req: GpuOpCapabilityRequirement) -> GpuLegalizationCode {
+pub fn gpu_first_unmet_legalization_code(profile: GpuTargetProfile, req: GpuOpCapabilityRequirement) -> GpuLegalizationCode {
     if req.requires_tensor_core && !profile.supports_tensor_core {
         return GpuLegalizationCode::GpuLegalizationTensorCoreUnavailable
     }
@@ -644,7 +644,7 @@ fn gpu_first_unmet_legalization_code(profile: GpuTargetProfile, req: GpuOpCapabi
     GpuLegalizationCode::GpuLegalizationPass
 }
 
-fn gpu_legalization_diag_default() -> GpuLegalizationDiagnostic {
+pub fn gpu_legalization_diag_default() -> GpuLegalizationDiagnostic {
     GpuLegalizationDiagnostic {
         op_index: -1,
         opcode: GpuOpcode::GpuRet,
@@ -653,7 +653,7 @@ fn gpu_legalization_diag_default() -> GpuLegalizationDiagnostic {
     }
 }
 
-fn gpu_legalization_diagnostic_new(op_index: i64, opcode: GpuOpcode, code: GpuLegalizationCode) -> GpuLegalizationDiagnostic {
+pub fn gpu_legalization_diagnostic_new(op_index: i64, opcode: GpuOpcode, code: GpuLegalizationCode) -> GpuLegalizationDiagnostic {
     GpuLegalizationDiagnostic {
         op_index: op_index,
         opcode: opcode,
@@ -662,7 +662,7 @@ fn gpu_legalization_diagnostic_new(op_index: i64, opcode: GpuOpcode, code: GpuLe
     }
 }
 
-fn gpu_ssa_v2_pipeline_id() -> Name with Mut, Panic, Div {
+pub fn gpu_ssa_v2_pipeline_id() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(103, 112, 117, 95, 10)  // "gpu_ssa_v2"
     n.buf[4] = 115  // 's'
     n.buf[5] = 115  // 's'
@@ -673,7 +673,7 @@ fn gpu_ssa_v2_pipeline_id() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_ssa_v2_provenance_tag() -> Name with Mut, Panic, Div {
+pub fn gpu_ssa_v2_provenance_tag() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(110, 97, 116, 105, 13)  // "native_shadow"
     n.buf[4] = 118   // 'v'
     n.buf[5] = 101   // 'e'
@@ -687,7 +687,7 @@ fn gpu_ssa_v2_provenance_tag() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_kernel_ssa_v2_new(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKernelSsaV2 with Mut, Panic, Div {
+pub fn gpu_kernel_ssa_v2_new(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKernelSsaV2 with Mut, Panic, Div {
     GpuKernelSsaV2 {
         version_major: 2,
         version_minor: 0,
@@ -703,7 +703,7 @@ fn gpu_kernel_ssa_v2_new(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKe
     }
 }
 
-fn gpu_legalize_kernel_to_ssa_v2(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKernelSsaV2 with Mut, Panic, Div {
+pub fn gpu_legalize_kernel_to_ssa_v2(kernel: GpuKernelIr, target: GpuTargetProfile) -> GpuKernelSsaV2 with Mut, Panic, Div {
     var out = gpu_kernel_ssa_v2_new(kernel, target)
     var i: i64 = 0
     while i < kernel.op_count {
@@ -722,11 +722,11 @@ fn gpu_legalize_kernel_to_ssa_v2(kernel: GpuKernelIr, target: GpuTargetProfile) 
     out
 }
 
-fn gpu_ssa_v2_is_legal(ssa: GpuKernelSsaV2) -> bool {
+pub fn gpu_ssa_v2_is_legal(ssa: GpuKernelSsaV2) -> bool {
     ssa.diagnostic_count == 0
 }
 
-fn gpu_type_to_string(ty: GpuType) -> string {
+pub fn gpu_type_to_string(ty: GpuType) -> string {
     match ty {
         GpuType::GpuU32  => "u32",
         GpuType::GpuU64  => "u64",
@@ -743,7 +743,7 @@ fn gpu_type_to_string(ty: GpuType) -> string {
     }
 }
 
-fn gpu_type_sizeof(ty: GpuType) -> i64 {
+pub fn gpu_type_sizeof(ty: GpuType) -> i64 {
     match ty {
         GpuType::GpuU32  => 4,
         GpuType::GpuU64  => 8,
@@ -761,7 +761,7 @@ fn gpu_type_sizeof(ty: GpuType) -> i64 {
 }
 
 // Build a vec_add kernel IR (canonical example, kept for backward compat with T10)
-fn gpu_build_vec_add_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_add_ir() -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
 
     // Kernel name: "vec_add"
@@ -1194,7 +1194,7 @@ fn gpu_build_vec_add_ir() -> GpuKernelIr with Mut, Panic, Div {
 //   - i32 elements: %r2, %r3, %r4 (share with tid %r1, start at 2)
 //   - i64 elements: %rd1, %rd2, %rd3 (reuse dead address-calc regs)
 
-fn gpu_build_vec_binop_ir(
+pub fn gpu_build_vec_binop_ir(
     kernel_name: Name,
     binop: GpuOpcode,
     elem_ty: GpuType,
@@ -1521,7 +1521,7 @@ fn gpu_build_vec_binop_ir(
 
 // ===== Name builders for kernel variants =====
 
-fn gpu_name_vec_add_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_add_f64() -> Name with Mut, Panic, Div {
     // "vec_add_f64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)  // "vec_"
     n.buf[4] = 97    // 'a'
@@ -1534,7 +1534,7 @@ fn gpu_name_vec_add_f64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_add_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_add_i32() -> Name with Mut, Panic, Div {
     // "vec_add_i32" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 97    // 'a'
@@ -1547,7 +1547,7 @@ fn gpu_name_vec_add_i32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_add_i64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_add_i64() -> Name with Mut, Panic, Div {
     // "vec_add_i64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 97    // 'a'
@@ -1560,7 +1560,7 @@ fn gpu_name_vec_add_i64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_sub() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sub() -> Name with Mut, Panic, Div {
     // "vec_sub" (7 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 7)
     n.buf[4] = 115   // 's'
@@ -1569,7 +1569,7 @@ fn gpu_name_vec_sub() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_sub_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sub_f64() -> Name with Mut, Panic, Div {
     // "vec_sub_f64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 115   // 's'
@@ -1582,7 +1582,7 @@ fn gpu_name_vec_sub_f64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_sub_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sub_i32() -> Name with Mut, Panic, Div {
     // "vec_sub_i32" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 115   // 's'
@@ -1595,7 +1595,7 @@ fn gpu_name_vec_sub_i32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_sub_i64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sub_i64() -> Name with Mut, Panic, Div {
     // "vec_sub_i64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 115   // 's'
@@ -1608,7 +1608,7 @@ fn gpu_name_vec_sub_i64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_mul() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_mul() -> Name with Mut, Panic, Div {
     // "vec_mul" (7 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 7)
     n.buf[4] = 109   // 'm'
@@ -1617,7 +1617,7 @@ fn gpu_name_vec_mul() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_mul_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_mul_f64() -> Name with Mut, Panic, Div {
     // "vec_mul_f64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 109   // 'm'
@@ -1630,7 +1630,7 @@ fn gpu_name_vec_mul_f64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_mul_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_mul_i32() -> Name with Mut, Panic, Div {
     // "vec_mul_i32" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 109   // 'm'
@@ -1643,7 +1643,7 @@ fn gpu_name_vec_mul_i32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_mul_i64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_mul_i64() -> Name with Mut, Panic, Div {
     // "vec_mul_i64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 109   // 'm'
@@ -1656,7 +1656,7 @@ fn gpu_name_vec_mul_i64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_div() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_div() -> Name with Mut, Panic, Div {
     // "vec_div" (7 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 7)
     n.buf[4] = 100   // 'd'
@@ -1665,7 +1665,7 @@ fn gpu_name_vec_div() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_div_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_div_f64() -> Name with Mut, Panic, Div {
     // "vec_div_f64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 100   // 'd'
@@ -1678,7 +1678,7 @@ fn gpu_name_vec_div_f64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_div_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_div_i32() -> Name with Mut, Panic, Div {
     // "vec_div_i32" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 100   // 'd'
@@ -1691,7 +1691,7 @@ fn gpu_name_vec_div_i32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_vec_div_i64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_div_i64() -> Name with Mut, Panic, Div {
     // "vec_div_i64" (11 chars)
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 100   // 'd'
@@ -1708,121 +1708,121 @@ fn gpu_name_vec_div_i64() -> Name with Mut, Panic, Div {
 
 // --- vec_add variants ---
 
-fn gpu_build_vec_add_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_add_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_add_f64(), GpuOpcode::GpuAdd, GpuType::GpuF64)
 }
 
-fn gpu_build_vec_add_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_add_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_add_i32(), GpuOpcode::GpuAdd, GpuType::GpuI32)
 }
 
-fn gpu_build_vec_add_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_add_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_add_i64(), GpuOpcode::GpuAdd, GpuType::GpuI64)
 }
 
 // --- vec_sub variants ---
 
-fn gpu_build_vec_sub_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sub_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_sub(), GpuOpcode::GpuSub, GpuType::GpuF32)
 }
 
-fn gpu_build_vec_sub_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sub_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_sub_f64(), GpuOpcode::GpuSub, GpuType::GpuF64)
 }
 
-fn gpu_build_vec_sub_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sub_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_sub_i32(), GpuOpcode::GpuSub, GpuType::GpuI32)
 }
 
-fn gpu_build_vec_sub_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sub_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_sub_i64(), GpuOpcode::GpuSub, GpuType::GpuI64)
 }
 
 // --- vec_mul variants ---
 
-fn gpu_build_vec_mul_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_mul_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_mul(), GpuOpcode::GpuMul, GpuType::GpuF32)
 }
 
-fn gpu_build_vec_mul_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_mul_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_mul_f64(), GpuOpcode::GpuMul, GpuType::GpuF64)
 }
 
-fn gpu_build_vec_mul_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_mul_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_mul_i32(), GpuOpcode::GpuMul, GpuType::GpuI32)
 }
 
-fn gpu_build_vec_mul_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_mul_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_mul_i64(), GpuOpcode::GpuMul, GpuType::GpuI64)
 }
 
 // --- vec_div variants ---
 
-fn gpu_build_vec_div_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_div_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_div(), GpuOpcode::GpuDiv, GpuType::GpuF32)
 }
 
-fn gpu_build_vec_div_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_div_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_div_f64(), GpuOpcode::GpuDiv, GpuType::GpuF64)
 }
 
-fn gpu_build_vec_div_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_div_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_div_i32(), GpuOpcode::GpuDiv, GpuType::GpuI32)
 }
 
-fn gpu_build_vec_div_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_div_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_vec_binop_ir(gpu_name_vec_div_i64(), GpuOpcode::GpuDiv, GpuType::GpuI64)
 }
 
 // --- Phase 3: Reduction kernel name helpers ---
 
-fn gpu_name_vec_sum() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sum() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 7)
     n.buf[4] = 115; n.buf[5] = 117; n.buf[6] = 109
     n
 }
 
-fn gpu_name_vec_sum_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sum_f64() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 115; n.buf[5] = 117; n.buf[6] = 109
     n.buf[7] = 95; n.buf[8] = 102; n.buf[9] = 54; n.buf[10] = 52
     n
 }
 
-fn gpu_name_vec_sum_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sum_i32() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 115; n.buf[5] = 117; n.buf[6] = 109
     n.buf[7] = 95; n.buf[8] = 105; n.buf[9] = 51; n.buf[10] = 50
     n
 }
 
-fn gpu_name_vec_sum_i64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_sum_i64() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 115; n.buf[5] = 117; n.buf[6] = 109
     n.buf[7] = 95; n.buf[8] = 105; n.buf[9] = 54; n.buf[10] = 52
     n
 }
 
-fn gpu_name_vec_max() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_max() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 7)
     n.buf[4] = 109; n.buf[5] = 97; n.buf[6] = 120
     n
 }
 
-fn gpu_name_vec_max_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_max_i32() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 109; n.buf[5] = 97; n.buf[6] = 120
     n.buf[7] = 95; n.buf[8] = 105; n.buf[9] = 51; n.buf[10] = 50
     n
 }
 
-fn gpu_name_vec_min() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_min() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 7)
     n.buf[4] = 109; n.buf[5] = 105; n.buf[6] = 110
     n
 }
 
-fn gpu_name_vec_min_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_vec_min_i32() -> Name with Mut, Panic, Div {
     var n = ki_ir_name_from_bytes(118, 101, 99, 95, 11)
     n.buf[4] = 109; n.buf[5] = 105; n.buf[6] = 110
     n.buf[7] = 95; n.buf[8] = 105; n.buf[9] = 51; n.buf[10] = 50
@@ -1835,7 +1835,7 @@ fn gpu_name_vec_min_i32() -> Name with Mut, Panic, Div {
 // data_ty: type of data being reduced
 // sizeof_ty: 4 for 32-bit, 8 for 64-bit
 // use_atomic: true for sum (atom.add), false for max/min (st.global)
-fn gpu_build_reduction_ir(
+pub fn gpu_build_reduction_ir(
     name: Name,
     reduction_op: GpuOpcode,
     data_ty: GpuType,
@@ -1956,69 +1956,69 @@ fn gpu_build_reduction_ir(
 
 // --- Phase 3: 8 Reduction kernel builders ---
 
-fn gpu_build_vec_sum_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sum_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_sum(), GpuOpcode::GpuAdd, GpuType::GpuF32, 4, true)
 }
 
-fn gpu_build_vec_sum_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sum_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_sum_f64(), GpuOpcode::GpuAdd, GpuType::GpuF64, 8, true)
 }
 
-fn gpu_build_vec_sum_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sum_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_sum_i32(), GpuOpcode::GpuAdd, GpuType::GpuI32, 4, true)
 }
 
-fn gpu_build_vec_sum_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_sum_i64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_sum_i64(), GpuOpcode::GpuAdd, GpuType::GpuI64, 8, false)
 }
 
-fn gpu_build_vec_max_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_max_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_max(), GpuOpcode::GpuMax, GpuType::GpuF32, 4, false)
 }
 
-fn gpu_build_vec_max_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_max_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_max_i32(), GpuOpcode::GpuMax, GpuType::GpuI32, 4, false)
 }
 
-fn gpu_build_vec_min_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_min_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_min(), GpuOpcode::GpuMin, GpuType::GpuF32, 4, false)
 }
 
-fn gpu_build_vec_min_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_vec_min_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_reduction_ir(gpu_name_vec_min_i32(), GpuOpcode::GpuMin, GpuType::GpuI32, 4, false)
 }
 
 // ===== Phase 4: Matrix operation kernel name helpers =====
 
-fn gpu_name_fma_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_fma_f32() -> Name with Mut, Panic, Div {
     // "fma_f32" (7 chars)
     var n = ki_ir_name_from_bytes(102, 109, 97, 95, 7)  // "fma_"
     n.buf[4] = 102; n.buf[5] = 51; n.buf[6] = 50    // "f32"
     n
 }
 
-fn gpu_name_fma_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_fma_f64() -> Name with Mut, Panic, Div {
     // "fma_f64" (7 chars)
     var n = ki_ir_name_from_bytes(102, 109, 97, 95, 7)  // "fma_"
     n.buf[4] = 102; n.buf[5] = 54; n.buf[6] = 52    // "f64"
     n
 }
 
-fn gpu_name_gemm_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_gemm_f32() -> Name with Mut, Panic, Div {
     // "gemm_f32" (8 chars)
     var n = ki_ir_name_from_bytes(103, 101, 109, 109, 8)  // "gemm"
     n.buf[4] = 95; n.buf[5] = 102; n.buf[6] = 51; n.buf[7] = 50  // "_f32"
     n
 }
 
-fn gpu_name_gemm_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_gemm_f64() -> Name with Mut, Panic, Div {
     // "gemm_f64" (8 chars)
     var n = ki_ir_name_from_bytes(103, 101, 109, 109, 8)  // "gemm"
     n.buf[4] = 95; n.buf[5] = 102; n.buf[6] = 54; n.buf[7] = 52  // "_f64"
     n
 }
 
-fn gpu_name_gemm_shared_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_gemm_shared_f32() -> Name with Mut, Panic, Div {
     // "gemm_shared_f32" (15 chars)
     var n = ki_ir_name_from_bytes(103, 101, 109, 109, 15)  // "gemm"
     n.buf[4] = 95; n.buf[5] = 115; n.buf[6] = 104; n.buf[7] = 97  // "_sha"
@@ -2028,7 +2028,7 @@ fn gpu_name_gemm_shared_f32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_gemm_shared_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_gemm_shared_f64() -> Name with Mut, Panic, Div {
     // "gemm_shared_f64" (15 chars)
     var n = ki_ir_name_from_bytes(103, 101, 109, 109, 15)  // "gemm"
     n.buf[4] = 95; n.buf[5] = 115; n.buf[6] = 104; n.buf[7] = 97  // "_sha"
@@ -2038,14 +2038,14 @@ fn gpu_name_gemm_shared_f64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_grid_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_grid_f32() -> Name with Mut, Panic, Div {
     // "grid_f32" (8 chars)
     var n = ki_ir_name_from_bytes(103, 114, 105, 100, 8)  // "grid"
     n.buf[4] = 95; n.buf[5] = 102; n.buf[6] = 51; n.buf[7] = 50  // "_f32"
     n
 }
 
-fn gpu_name_grid_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_grid_f64() -> Name with Mut, Panic, Div {
     // "grid_f64" (8 chars)
     var n = ki_ir_name_from_bytes(103, 114, 105, 100, 8)  // "grid"
     n.buf[4] = 95; n.buf[5] = 102; n.buf[6] = 54; n.buf[7] = 52  // "_f64"
@@ -2054,7 +2054,7 @@ fn gpu_name_grid_f64() -> Name with Mut, Panic, Div {
 
 // ===== Phase 4: FMA kernel builder =====
 // c[i] = a[i] * b[i] + c[i]  (element-wise fused multiply-add)
-fn gpu_build_fma_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_fma_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     let elem_sizeof = gpu_type_sizeof(elem_ty)
     k.kernel_name = kernel_name
@@ -2162,7 +2162,7 @@ fn gpu_build_fma_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut
 
 // ===== Phase 4: GEMM-like kernel builder =====
 // row = bid.x * 16 + tid.x, c[row] = a[row] * b[row] + c[row]
-fn gpu_build_gemm_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_gemm_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     let elem_sizeof = gpu_type_sizeof(elem_ty)
     k.kernel_name = kernel_name
@@ -2289,7 +2289,7 @@ fn gpu_build_gemm_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mu
 }
 
 // ===== Phase 5: Shared-memory tiled-ish GEMM-style kernel =====
-fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     let elem_sizeof = gpu_type_sizeof(elem_ty)
     k.kernel_name = kernel_name
@@ -2508,7 +2508,7 @@ fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr 
         opcode: GpuOpcode::GpuSetpLt,
         dst_reg: 0, lhs_reg: 1, rhs_reg: 6,
         ty: GpuType::GpuU32, dst_ty: GpuType::GpuU32, src_ty: GpuType::GpuU32,
-        src_reg: -1, rhs_imm: 0, rhs_reg: -1, addr_reg: -1,
+        src_reg: -1, rhs_imm: 0, addr_reg: -1,
         param_idx: -1, axis: 0, shared_addr: -1,
         memory_space: GpuMemorySpace::GpuMemGlobal,
         pred_reg: -1,
@@ -2568,7 +2568,7 @@ fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr 
     k.ops[idx] = GpuOp {
         opcode: GpuOpcode::GpuAdd, dst_reg: 9, lhs_reg: 3, rhs_reg: 2,
         ty: GpuType::GpuU64, dst_ty: GpuType::GpuU64, src_ty: GpuType::GpuU64,
-        src_reg: -1, rhs_reg: 2, addr_reg: -1,
+        src_reg: -1, addr_reg: -1,
         rhs_imm: 0, param_idx: -1, axis: 0, shared_addr: -1,
         memory_space: GpuMemorySpace::GpuMemGlobal,
         pred_reg: -1,
@@ -2586,7 +2586,7 @@ fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr 
     k.ops[idx] = GpuOp {
         opcode: GpuOpcode::GpuAdd, dst_reg: 10, lhs_reg: 4, rhs_reg: 2,
         ty: GpuType::GpuU64, dst_ty: GpuType::GpuU64, src_ty: GpuType::GpuU64,
-        src_reg: -1, rhs_reg: 2, addr_reg: -1,
+        src_reg: -1, addr_reg: -1,
         rhs_imm: 0, param_idx: -1, axis: 0, shared_addr: -1,
         memory_space: GpuMemorySpace::GpuMemGlobal,
         pred_reg: -1,
@@ -2604,7 +2604,7 @@ fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr 
     k.ops[idx] = GpuOp {
         opcode: GpuOpcode::GpuAdd, dst_reg: 11, lhs_reg: 5, rhs_reg: 2,
         ty: GpuType::GpuU64, dst_ty: GpuType::GpuU64, src_ty: GpuType::GpuU64,
-        src_reg: -1, rhs_reg: 2, addr_reg: -1,
+        src_reg: -1, addr_reg: -1,
         rhs_imm: 0, param_idx: -1, axis: 0, shared_addr: -1,
         memory_space: GpuMemorySpace::GpuMemGlobal,
         pred_reg: -1,
@@ -2656,7 +2656,7 @@ fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr 
         k.ops[idx] = GpuOp {
             opcode: GpuOpcode::GpuStoreSharedPred, src_reg: 1, shared_addr: 0, lhs_reg: 0,
             ty: GpuType::GpuF32, dst_ty: GpuType::GpuF32, src_ty: GpuType::GpuF32,
-            dst_reg: -1, lhs_reg: 0, rhs_reg: -1, rhs_imm: 0, param_idx: -1, axis: 0, addr_reg: -1,
+            dst_reg: -1, rhs_reg: -1, rhs_imm: 0, param_idx: -1, axis: 0, addr_reg: -1,
         memory_space: GpuMemorySpace::GpuMemGlobal,
         pred_reg: -1,
         mask: 4294967295,
@@ -2951,7 +2951,7 @@ fn gpu_build_gemm_shared_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr 
 
 // ===== Phase 4: Grid-aware kernel builder =====
 // Uses ntid.x for stride computation: stride = ntid.x * sizeof
-fn gpu_build_grid_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_grid_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     let elem_sizeof = gpu_type_sizeof(elem_ty)
     k.kernel_name = kernel_name
@@ -3052,35 +3052,35 @@ fn gpu_build_grid_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mu
 
 // ===== Phase 4: Kernel wrapper builders =====
 
-fn gpu_build_fma_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_fma_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_fma_ir(gpu_name_fma_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_fma_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_fma_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_fma_ir(gpu_name_fma_f64(), GpuType::GpuF64)
 }
 
-fn gpu_build_gemm_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_gemm_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_gemm_ir(gpu_name_gemm_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_gemm_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_gemm_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_gemm_ir(gpu_name_gemm_f64(), GpuType::GpuF64)
 }
 
-fn gpu_build_gemm_shared_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_gemm_shared_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_gemm_shared_ir(gpu_name_gemm_shared_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_gemm_shared_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_gemm_shared_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_gemm_shared_ir(gpu_name_gemm_shared_f64(), GpuType::GpuF64)
 }
 
-fn gpu_build_grid_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_grid_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_grid_ir(gpu_name_grid_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_grid_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_grid_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_grid_ir(gpu_name_grid_f64(), GpuType::GpuF64)
 }
 
@@ -3097,7 +3097,7 @@ fn gpu_build_grid_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
 //   barrier
 //   out[gid] = shared_tile[tid]*w[0] + shared_tile[tid+1]*w[1] + shared_tile[tid+2]*w[2]
 
-fn gpu_name_conv1d_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_conv1d_f32() -> Name with Mut, Panic, Div {
     // "conv1d_f32" (10 chars)
     // c=99 o=111 n=110 v=118 1=49 d=100 _=95 f=102 3=51 2=50
     var n = ki_ir_name_from_bytes(99, 111, 110, 118, 10)
@@ -3106,7 +3106,7 @@ fn gpu_name_conv1d_f32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_conv1d_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_conv1d_f64() -> Name with Mut, Panic, Div {
     // "conv1d_f64" (10 chars)
     var n = ki_ir_name_from_bytes(99, 111, 110, 118, 10)
     n.buf[4] = 49; n.buf[5] = 100; n.buf[6] = 95
@@ -3114,7 +3114,7 @@ fn gpu_name_conv1d_f64() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_conv1d_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_conv1d_i32() -> Name with Mut, Panic, Div {
     // "conv1d_i32" (10 chars)
     var n = ki_ir_name_from_bytes(99, 111, 110, 118, 10)
     n.buf[4] = 49; n.buf[5] = 100; n.buf[6] = 95
@@ -3125,7 +3125,7 @@ fn gpu_name_conv1d_i32() -> Name with Mut, Panic, Div {
 // Generic conv1d stencil builder
 // 3-point stencil: out[i] = in[i-1]*w0 + in[i]*w1 + in[i+1]*w2
 // Uses shared memory to cache the input tile + 2 halo elements
-fn gpu_build_conv1d_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv1d_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     let elem_sizeof = gpu_type_sizeof(elem_ty)
     k.kernel_name = kernel_name
@@ -3328,15 +3328,15 @@ fn gpu_build_conv1d_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with 
     k
 }
 
-fn gpu_build_conv1d_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv1d_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_conv1d_ir(gpu_name_conv1d_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_conv1d_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv1d_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_conv1d_ir(gpu_name_conv1d_f64(), GpuType::GpuF64)
 }
 
-fn gpu_build_conv1d_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv1d_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_conv1d_ir(gpu_name_conv1d_i32(), GpuType::GpuI32)
 }
 
@@ -3357,7 +3357,7 @@ fn gpu_build_conv1d_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
 //   result = mul(s0, w0) + fma chain for remaining 8 terms
 //   Store result
 
-fn gpu_name_conv2d_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_conv2d_f32() -> Name with Mut, Panic, Div {
     // "conv2d_f32" (10 chars)
     // c=99 o=111 n=110 v=118 2=50 d=100 _=95 f=102 3=51 2=50
     var n = ki_ir_name_from_bytes(99, 111, 110, 118, 10)
@@ -3366,7 +3366,7 @@ fn gpu_name_conv2d_f32() -> Name with Mut, Panic, Div {
     n
 }
 
-fn gpu_name_conv2d_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_conv2d_f64() -> Name with Mut, Panic, Div {
     // "conv2d_f64" (10 chars)
     var n = ki_ir_name_from_bytes(99, 111, 110, 118, 10)
     n.buf[4] = 50; n.buf[5] = 100; n.buf[6] = 95
@@ -3376,7 +3376,7 @@ fn gpu_name_conv2d_f64() -> Name with Mut, Panic, Div {
 
 // Generic conv2d 3x3 stencil builder
 // Uses TILE=16, shared memory = (16+2)*(16+2)*sizeof = 1296 for f32
-fn gpu_build_conv2d_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv2d_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     let elem_sizeof = gpu_type_sizeof(elem_ty)
     k.kernel_name = kernel_name
@@ -3732,11 +3732,11 @@ fn gpu_build_conv2d_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with 
     k
 }
 
-fn gpu_build_conv2d_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv2d_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_conv2d_ir(gpu_name_conv2d_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_conv2d_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_conv2d_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_conv2d_ir(gpu_name_conv2d_f64(), GpuType::GpuF64)
 }
 
@@ -3754,21 +3754,21 @@ fn gpu_build_conv2d_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
 //   store(output[tid], val)
 
 // Name helpers for scan kernels
-fn gpu_name_scan_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_scan_f32() -> Name with Mut, Panic, Div {
     // "scan_f32" (8 chars)
     var n = ki_ir_name_from_bytes(115, 99, 97, 110, 8)
     n.buf[4] = 95; n.buf[5] = 102; n.buf[6] = 51; n.buf[7] = 50
     n
 }
 
-fn gpu_name_scan_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_scan_f64() -> Name with Mut, Panic, Div {
     // "scan_f64" (8 chars)
     var n = ki_ir_name_from_bytes(115, 99, 97, 110, 8)
     n.buf[4] = 95; n.buf[5] = 102; n.buf[6] = 54; n.buf[7] = 52
     n
 }
 
-fn gpu_name_scan_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_scan_i32() -> Name with Mut, Panic, Div {
     // "scan_i32" (8 chars)
     var n = ki_ir_name_from_bytes(115, 99, 97, 110, 8)
     n.buf[4] = 95; n.buf[5] = 105; n.buf[6] = 51; n.buf[7] = 50
@@ -3777,7 +3777,7 @@ fn gpu_name_scan_i32() -> Name with Mut, Panic, Div {
 
 // Generic inclusive scan builder (warp-level Hillis-Steele)
 // Uses shfl.sync.up for the scan, setp.ge for conditional add
-fn gpu_build_scan_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_scan_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     k.kernel_name = kernel_name
     let sizeof_ty = gpu_type_sizeof(elem_ty)
@@ -3905,15 +3905,15 @@ fn gpu_build_scan_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mu
     k
 }
 
-fn gpu_build_scan_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_scan_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_scan_ir(gpu_name_scan_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_scan_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_scan_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_scan_ir(gpu_name_scan_f64(), GpuType::GpuF64)
 }
 
-fn gpu_build_scan_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_scan_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_scan_ir(gpu_name_scan_i32(), GpuType::GpuI32)
 }
 
@@ -3927,21 +3927,21 @@ fn gpu_build_scan_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
 //
 // Thread indexing: tid.x, tid.y for intra-tile; bid.x, bid.y for tile position.
 
-fn gpu_name_transpose_f32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_transpose_f32() -> Name with Mut, Panic, Div {
     // "xpose_f32" (9 chars) — "transpose" is 9 but we use "xpose" to fit
     var n = ki_ir_name_from_bytes(120, 112, 111, 115, 9)
     n.buf[4] = 101; n.buf[5] = 95; n.buf[6] = 102; n.buf[7] = 51; n.buf[8] = 50
     n
 }
 
-fn gpu_name_transpose_f64() -> Name with Mut, Panic, Div {
+pub fn gpu_name_transpose_f64() -> Name with Mut, Panic, Div {
     // "xpose_f64" (9 chars)
     var n = ki_ir_name_from_bytes(120, 112, 111, 115, 9)
     n.buf[4] = 101; n.buf[5] = 95; n.buf[6] = 102; n.buf[7] = 54; n.buf[8] = 52
     n
 }
 
-fn gpu_name_transpose_i32() -> Name with Mut, Panic, Div {
+pub fn gpu_name_transpose_i32() -> Name with Mut, Panic, Div {
     // "xpose_i32" (9 chars)
     var n = ki_ir_name_from_bytes(120, 112, 111, 115, 9)
     n.buf[4] = 101; n.buf[5] = 95; n.buf[6] = 105; n.buf[7] = 51; n.buf[8] = 50
@@ -3951,7 +3951,7 @@ fn gpu_name_transpose_i32() -> Name with Mut, Panic, Div {
 // Generic transpose builder
 // TILE = 32. Each thread loads one element, stores one element after barrier.
 // Params: param_in (src matrix), param_out (dst matrix), param_rows (u32), param_cols (u32)
-fn gpu_build_transpose_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_transpose_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
     k.kernel_name = kernel_name
     let sizeof_ty = gpu_type_sizeof(elem_ty)
@@ -4168,15 +4168,15 @@ fn gpu_build_transpose_ir(kernel_name: Name, elem_ty: GpuType) -> GpuKernelIr wi
     k
 }
 
-fn gpu_build_transpose_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_transpose_f32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_transpose_ir(gpu_name_transpose_f32(), GpuType::GpuF32)
 }
 
-fn gpu_build_transpose_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_transpose_f64_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_transpose_ir(gpu_name_transpose_f64(), GpuType::GpuF64)
 }
 
-fn gpu_build_transpose_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_transpose_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
     gpu_build_transpose_ir(gpu_name_transpose_i32(), GpuType::GpuI32)
 }
 
@@ -4200,7 +4200,7 @@ fn gpu_build_transpose_i32_ir() -> GpuKernelIr with Mut, Panic, Div {
 // ═════════════════════════════════════════════════════════════════════
 
 // Helper: make a GpuOp with common defaults pre-filled
-fn gpu_op_default() -> GpuOp {
+pub fn gpu_op_default() -> GpuOp {
     GpuOp {
         opcode: GpuOpcode::GpuRet,
         dst_reg: -1,
@@ -4780,7 +4780,7 @@ pub fn gpu_build_epistemic_wmma_matmul_16x16_ir() -> GpuKernelIr with Mut, Panic
 // Shared memory: 2048 bytes (2 × 16×16×4 for A_tile + B_tile)
 // ═══════════════════════════════════════════════════════════════════════
 
-fn gpu_build_epistemic_tiled_gemm_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_epistemic_tiled_gemm_ir() -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
 
     // Kernel name: "epi_tgemm" (9 chars)
@@ -5520,7 +5520,7 @@ fn gpu_build_epistemic_tiled_gemm_ir() -> GpuKernelIr with Mut, Panic, Div {
 //   pred: %p0 (grad_c_eps valid), %p1 (eps_grad_A non-negative)
 // ═══════════════════════════════════════════════════════════════════════
 
-fn gpu_build_epistemic_wmma_backward_ir() -> GpuKernelIr with Mut, Panic, Div {
+pub fn gpu_build_epistemic_wmma_backward_ir() -> GpuKernelIr with Mut, Panic, Div {
     var k = gpu_kernel_new()
 
     // Kernel name: "epi_wmma_bwd" (12 chars)

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -3,8 +3,11 @@
 // Converts GpuKernelIr to PTX text using the ptx.sio emitter functions.
 // This is "phase 1" of GPU codegen: structured IR-driven lowering.
 
+use gpu::kernel_ir::*
+use gpu::ptx::*
+
 // Lower a complete GPU kernel IR to PTX
-fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     var buf = ptx_buf_new()
 
     // 1. Emit header (.version, .target, .address_size)
@@ -28,7 +31,7 @@ fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     buf
 }
 
-fn gpu_emit_kernel_mode_metadata(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_emit_kernel_mode_metadata(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     var out = buf
     let target_profile = gpu_target_profile_cuda_sm80()
     let legalized = gpu_legalize_kernel_to_ssa_v2(kernel, target_profile)
@@ -76,7 +79,7 @@ fn gpu_emit_kernel_mode_metadata(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf wit
 }
 
 // Emit kernel signature: .visible .entry kernel_name(params...)
-fn gpu_emit_kernel_signature(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div {
+pub fn gpu_emit_kernel_signature(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div {
     var out = buf
 
     // .visible .entry kernel_name(
@@ -108,7 +111,7 @@ fn gpu_emit_kernel_signature(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mu
 }
 
 // Emit register declarations based on kernel.max_reg_*
-fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     var out = buf
 
     out = ptx_push_str(out, "{\n")
@@ -159,7 +162,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
 }
 
 // Lower all operations in sequence
-fn gpu_lower_ops(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_lower_ops(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     var out = buf
     var i: i64 = 0
 
@@ -173,7 +176,7 @@ fn gpu_lower_ops(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Di
 }
 
 // Lower a single GPU operation to PTX
-fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+pub fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
     // Struct-first representation avoids enum field destructuring in the
     // self-hosted IR; switch on opcode and use struct fields explicitly.
     let opcode = op.opcode
@@ -1151,21 +1154,21 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
 }
 
 // Helper: Format register names dynamically using str_concat
-fn gpu_reg_u32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r", i64_to_string(reg)) }
-fn gpu_reg_u64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
-fn gpu_reg_f32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%f", i64_to_string(reg)) }
-fn gpu_reg_f64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%fd", i64_to_string(reg)) }
-fn gpu_reg_i32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r", i64_to_string(reg)) }
-fn gpu_reg_i64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
+pub fn gpu_reg_u32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r", i64_to_string(reg)) }
+pub fn gpu_reg_u64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
+pub fn gpu_reg_f32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%f", i64_to_string(reg)) }
+pub fn gpu_reg_f64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%fd", i64_to_string(reg)) }
+pub fn gpu_reg_i32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r", i64_to_string(reg)) }
+pub fn gpu_reg_i64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
 
 // Helper: Convert Name to string
-fn name_to_string(name: Name) -> string with Mut, Panic, Div, Alloc {
+pub fn name_to_string(name: Name) -> string with Mut, Panic, Div, Alloc {
     str_from_bytes(name.buf, name.len)
 }
 
-fn gpu_pred_reg(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%p", i64_to_string(reg)) }
+pub fn gpu_pred_reg(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%p", i64_to_string(reg)) }
 
-fn gpu_shared_addr_str(offset: i64) -> string with Mut, Panic, Div, Alloc {
+pub fn gpu_shared_addr_str(offset: i64) -> string with Mut, Panic, Div, Alloc {
     if offset <= 0 { "shared_array" } else {
         var b = ptx_buf_new()
         b = ptx_push_str(b, "shared_array+")
@@ -1175,7 +1178,7 @@ fn gpu_shared_addr_str(offset: i64) -> string with Mut, Panic, Div, Alloc {
 }
 
 // Helper: Convert i64 to string
-fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
+pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
     if n < 0 {
         return "0"
     }
@@ -1203,7 +1206,7 @@ fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
 }
 
 // Helper: Push Name bytes to buffer
-fn gpu_push_name(buf: PtxBuf, name: Name) -> PtxBuf with Mut, Panic, Div {
+pub fn gpu_push_name(buf: PtxBuf, name: Name) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     var i: i64 = 0
     while i < name.len {
@@ -1214,7 +1217,7 @@ fn gpu_push_name(buf: PtxBuf, name: Name) -> PtxBuf with Mut, Panic, Div {
 }
 
 // Helper: Push i64 as ASCII digits directly into PtxBuf (avoids i64_to_string UAF)
-fn gpu_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
+pub fn gpu_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
     if n == 0 { return ptx_push_byte(buf, 48) }
     var value: i64 = if n < 0 { 0 } else { n }
     var digits: [i8; 20] = [0; 20]

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -10,17 +10,17 @@
 // - Host-side launch (CUDA Driver API) or static assembly path
 
 pub struct PtxBuf {
-    data: [i8; 65536],
-    len: i64,
+    pub data: [i8; 65536],
+    pub len: i64,
 }
 
 pub var PTX_TO_STRING_BUF: [i8; 65536] = [0; 65536]
 
-fn ptx_buf_new() -> PtxBuf {
+pub fn ptx_buf_new() -> PtxBuf {
     PtxBuf { data: [0; 65536], len: 0 }
 }
 
-fn ptx_push_byte(buf: PtxBuf, b: i8) -> PtxBuf with Mut, Panic {
+pub fn ptx_push_byte(buf: PtxBuf, b: i8) -> PtxBuf with Mut, Panic {
     var out = buf
     if out.len >= 0 {
         if out.len < 65536 {
@@ -31,7 +31,7 @@ fn ptx_push_byte(buf: PtxBuf, b: i8) -> PtxBuf with Mut, Panic {
     out
 }
 
-fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     let n = str_len(s)
     var i: i64 = 0
@@ -45,7 +45,39 @@ fn ptx_push_str(buf: PtxBuf, s: string) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
+// Local copy of i64_to_string (also defined in lower_to_ptx.sio and
+// opt/warp_vote_fastpath.sio): ptx.sio cannot `use gpu::lower_to_ptx::*`
+// for this, since lower_to_ptx.sio itself imports gpu::ptx — that would be
+// circular. Kept in sync by hand; small enough that duplication is cheaper
+// than restructuring the module graph.
+pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
+    if n < 0 {
+        return "0"
+    }
+    if n == 0 { return "0" }
+
+    var digits: [i8; 32] = [0; 32]
+    var rev_len: i64 = 0
+    var value: i64 = n
+
+    while value > 0 {
+        let digit = value % 10
+        digits[rev_len as usize] = 48 + digit as i8
+        rev_len = rev_len + 1
+        value = value / 10
+    }
+
+    var bytes: [i8; 32] = [0; 32]
+    var i2: i64 = 0
+    while i2 < rev_len {
+        bytes[i2 as usize] = digits[(rev_len - i2 - 1) as usize]
+        i2 = i2 + 1
+    }
+
+    str_from_bytes(bytes, rev_len)
+}
+
+pub fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
     let nlen = str_len(needle)
     if nlen == 0 { return true }
     if buf.len < nlen { return false }
@@ -67,7 +99,7 @@ fn ptx_buf_contains(buf: PtxBuf, needle: string) -> bool with Mut, Panic, Div {
     false
 }
 
-fn ptx_to_string(buf: PtxBuf) -> string with Mut, Panic {
+pub fn ptx_to_string(buf: PtxBuf) -> string with Mut, Panic {
     var i: i64 = 0
     while i < buf.len {
         PTX_TO_STRING_BUF[i as usize] = buf.data[i as usize]
@@ -77,7 +109,7 @@ fn ptx_to_string(buf: PtxBuf) -> string with Mut, Panic {
     str_from_bytes(PTX_TO_STRING_BUF, buf.len)
 }
 
-fn ptx_str_contains(haystack: string, needle: string) -> bool with Mut, Panic, Div {
+pub fn ptx_str_contains(haystack: string, needle: string) -> bool with Mut, Panic, Div {
     // Self-hosted-friendly substring check.
     //
     // NOTE: The VM has a `contains` builtin, but we keep a local implementation
@@ -105,7 +137,7 @@ fn ptx_str_contains(haystack: string, needle: string) -> bool with Mut, Panic, D
     false
 }
 
-fn ptx_trim_leading_spaces(s: string) -> string with Mut, Panic, Div {
+pub fn ptx_trim_leading_spaces(s: string) -> string with Mut, Panic, Div {
     let n = str_len(s)
     var i: i64 = 0
 
@@ -120,7 +152,7 @@ fn ptx_trim_leading_spaces(s: string) -> string with Mut, Panic, Div {
     str_slice(s, i, n)
 }
 
-fn ptx_has_predicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_predicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -152,7 +184,7 @@ fn ptx_has_predicated_opcode(haystack: string, opcode: string) -> bool with Mut,
     false
 }
 
-fn ptx_has_predicated_opcode_with_pred(haystack: string, opcode: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_predicated_opcode_with_pred(haystack: string, opcode: string, pred: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -183,7 +215,7 @@ fn ptx_has_predicated_opcode_with_pred(haystack: string, opcode: string, pred: s
     false
 }
 
-fn ptx_has_predicate_token(line: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_predicate_token(line: string, pred: string) -> bool with Mut, Panic, Div {
     let token_with_space_prefix = " " ++ pred ++ ","
     let token_with_delim = pred ++ ","
     let token_with_space_suffix = ", " ++ pred ++ ","
@@ -209,7 +241,7 @@ fn ptx_has_predicate_token(line: string, pred: string) -> bool with Mut, Panic, 
     false
 }
 
-fn ptx_has_setp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_setp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -240,7 +272,7 @@ fn ptx_has_setp_with_pred(haystack: string, pred: string) -> bool with Mut, Pani
     false
 }
 
-fn ptx_has_selp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_selp_with_pred(haystack: string, pred: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -271,7 +303,7 @@ fn ptx_has_selp_with_pred(haystack: string, pred: string) -> bool with Mut, Pani
     false
 }
 
-fn ptx_has_unpredicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
+pub fn ptx_has_unpredicated_opcode(haystack: string, opcode: string) -> bool with Mut, Panic, Div {
     let n = str_len(haystack)
     if n == 0 { return false }
 
@@ -305,203 +337,203 @@ fn ptx_has_unpredicated_opcode(haystack: string, opcode: string) -> bool with Mu
 // Core PTX emitter pieces used for deterministic text scaffolding.
 // Keeps phase-0 output stable and easy to extend in later PTX-first passes.
 
-fn ptx_header_version() -> string { "7.0" }
+pub fn ptx_header_version() -> string { "7.0" }
 
-fn ptx_header_target() -> string { "sm_50" }
+pub fn ptx_header_target() -> string { "sm_50" }
 
-fn ptx_header_address_size() -> string { ".address_size 64" }
+pub fn ptx_header_address_size() -> string { ".address_size 64" }
 
-fn ptx_opcode_mov_u32() -> string { "mov.u32" }
+pub fn ptx_opcode_mov_u32() -> string { "mov.u32" }
 
-fn ptx_opcode_cvt_u64_u32() -> string { "cvt.u64.u32" }
+pub fn ptx_opcode_cvt_u64_u32() -> string { "cvt.u64.u32" }
 
-fn ptx_opcode_mul_lo_u64() -> string { "mul.lo.u64" }
+pub fn ptx_opcode_mul_lo_u64() -> string { "mul.lo.u64" }
 
-fn ptx_opcode_ld_param_u64() -> string { "ld.param.u64" }
-fn ptx_opcode_ld_param_u32() -> string { "ld.param.u32" }
-fn ptx_opcode_ld_param_u16() -> string { "ld.param.u16" }
+pub fn ptx_opcode_ld_param_u64() -> string { "ld.param.u64" }
+pub fn ptx_opcode_ld_param_u32() -> string { "ld.param.u32" }
+pub fn ptx_opcode_ld_param_u16() -> string { "ld.param.u16" }
 
-fn ptx_opcode_add_u64() -> string { "add.u64" }
+pub fn ptx_opcode_add_u64() -> string { "add.u64" }
 
-fn ptx_opcode_ld_global_f32() -> string { "ld.global.f32" }
+pub fn ptx_opcode_ld_global_f32() -> string { "ld.global.f32" }
 
-fn ptx_opcode_add_f32() -> string { "add.f32" }
+pub fn ptx_opcode_add_f32() -> string { "add.f32" }
 
-fn ptx_opcode_st_global_f32() -> string { "st.global.f32" }
+pub fn ptx_opcode_st_global_f32() -> string { "st.global.f32" }
 
-fn ptx_opcode_ret() -> string { "ret" }
+pub fn ptx_opcode_ret() -> string { "ret" }
 
 // Type-specific opcodes for f64/i32/i64
-fn ptx_opcode_add_f64() -> string { "add.f64" }
+pub fn ptx_opcode_add_f64() -> string { "add.f64" }
 
-fn ptx_opcode_add_s32() -> string { "add.s32" }
+pub fn ptx_opcode_add_s32() -> string { "add.s32" }
 
-fn ptx_opcode_add_s64() -> string { "add.s64" }
+pub fn ptx_opcode_add_s64() -> string { "add.s64" }
 
-fn ptx_opcode_ld_global_f64() -> string { "ld.global.f64" }
+pub fn ptx_opcode_ld_global_f64() -> string { "ld.global.f64" }
 
-fn ptx_opcode_ld_global_s32() -> string { "ld.global.s32" }
+pub fn ptx_opcode_ld_global_s32() -> string { "ld.global.s32" }
 
-fn ptx_opcode_ld_global_s64() -> string { "ld.global.s64" }
+pub fn ptx_opcode_ld_global_s64() -> string { "ld.global.s64" }
 
-fn ptx_opcode_st_global_f64() -> string { "st.global.f64" }
+pub fn ptx_opcode_st_global_f64() -> string { "st.global.f64" }
 
-fn ptx_opcode_st_global_s32() -> string { "st.global.s32" }
+pub fn ptx_opcode_st_global_s32() -> string { "st.global.s32" }
 
-fn ptx_opcode_ld_global_u32() -> string { "ld.global.u32" }
+pub fn ptx_opcode_ld_global_u32() -> string { "ld.global.u32" }
 
-fn ptx_opcode_st_global_u32() -> string { "st.global.u32" }
+pub fn ptx_opcode_st_global_u32() -> string { "st.global.u32" }
 
-fn ptx_opcode_st_global_s64() -> string { "st.global.s64" }
+pub fn ptx_opcode_st_global_s64() -> string { "st.global.s64" }
 
 // Element-wise operation opcodes (sub/mul/div for all types)
-fn ptx_opcode_sub_f32() -> string { "sub.f32" }
+pub fn ptx_opcode_sub_f32() -> string { "sub.f32" }
 
-fn ptx_opcode_sub_f64() -> string { "sub.f64" }
+pub fn ptx_opcode_sub_f64() -> string { "sub.f64" }
 
-fn ptx_opcode_sub_s32() -> string { "sub.s32" }
+pub fn ptx_opcode_sub_s32() -> string { "sub.s32" }
 
-fn ptx_opcode_sub_s64() -> string { "sub.s64" }
+pub fn ptx_opcode_sub_s64() -> string { "sub.s64" }
 
-fn ptx_opcode_sub_u64() -> string { "sub.u64" }
+pub fn ptx_opcode_sub_u64() -> string { "sub.u64" }
 
-fn ptx_opcode_mul_lo_f32() -> string { "mul.rn.f32" }
+pub fn ptx_opcode_mul_lo_f32() -> string { "mul.rn.f32" }
 
-fn ptx_opcode_mul_lo_f64() -> string { "mul.rn.f64" }
+pub fn ptx_opcode_mul_lo_f64() -> string { "mul.rn.f64" }
 
-fn ptx_opcode_mul_lo_s32() -> string { "mul.lo.s32" }
+pub fn ptx_opcode_mul_lo_s32() -> string { "mul.lo.s32" }
 
-fn ptx_opcode_mul_lo_s64() -> string { "mul.lo.s64" }
+pub fn ptx_opcode_mul_lo_s64() -> string { "mul.lo.s64" }
 
-fn ptx_opcode_div_f32() -> string { "div.rn.f32" }
+pub fn ptx_opcode_div_f32() -> string { "div.rn.f32" }
 
-fn ptx_opcode_div_f64() -> string { "div.rn.f64" }
+pub fn ptx_opcode_div_f64() -> string { "div.rn.f64" }
 
-fn ptx_opcode_div_s32() -> string { "div.s32" }
+pub fn ptx_opcode_div_s32() -> string { "div.s32" }
 
-fn ptx_opcode_div_s64() -> string { "div.s64" }
+pub fn ptx_opcode_div_s64() -> string { "div.s64" }
 
-fn ptx_opcode_div_u64() -> string { "div.u64" }
+pub fn ptx_opcode_div_u64() -> string { "div.u64" }
 
 // Reduction operations - max
-fn ptx_opcode_max_f32() -> string { "max.f32" }
+pub fn ptx_opcode_max_f32() -> string { "max.f32" }
 
-fn ptx_opcode_max_f64() -> string { "max.f64" }
+pub fn ptx_opcode_max_f64() -> string { "max.f64" }
 
-fn ptx_opcode_max_s32() -> string { "max.s32" }
+pub fn ptx_opcode_max_s32() -> string { "max.s32" }
 
-fn ptx_opcode_max_s64() -> string { "max.s64" }
+pub fn ptx_opcode_max_s64() -> string { "max.s64" }
 
-fn ptx_opcode_max_u32() -> string { "max.u32" }
+pub fn ptx_opcode_max_u32() -> string { "max.u32" }
 
-fn ptx_opcode_max_u64() -> string { "max.u64" }
+pub fn ptx_opcode_max_u64() -> string { "max.u64" }
 
 // Reduction operations - min
-fn ptx_opcode_min_f32() -> string { "min.f32" }
+pub fn ptx_opcode_min_f32() -> string { "min.f32" }
 
-fn ptx_opcode_min_f64() -> string { "min.f64" }
+pub fn ptx_opcode_min_f64() -> string { "min.f64" }
 
-fn ptx_opcode_min_s32() -> string { "min.s32" }
+pub fn ptx_opcode_min_s32() -> string { "min.s32" }
 
-fn ptx_opcode_min_s64() -> string { "min.s64" }
+pub fn ptx_opcode_min_s64() -> string { "min.s64" }
 
-fn ptx_opcode_min_u32() -> string { "min.u32" }
+pub fn ptx_opcode_min_u32() -> string { "min.u32" }
 
-fn ptx_opcode_min_u64() -> string { "min.u64" }
+pub fn ptx_opcode_min_u64() -> string { "min.u64" }
 
 // Atomic operations
-fn ptx_opcode_atom_add_f32() -> string { "atom.add.f32" }
+pub fn ptx_opcode_atom_add_f32() -> string { "atom.add.f32" }
 
-fn ptx_opcode_atom_add_f64() -> string { "atom.add.f64" }
+pub fn ptx_opcode_atom_add_f64() -> string { "atom.add.f64" }
 
-fn ptx_opcode_atom_add_s32() -> string { "atom.add.s32" }
+pub fn ptx_opcode_atom_add_s32() -> string { "atom.add.s32" }
 
-fn ptx_opcode_atom_add_u32() -> string { "atom.add.u32" }
+pub fn ptx_opcode_atom_add_u32() -> string { "atom.add.u32" }
 
 // Shared memory operations
-fn ptx_opcode_ld_shared_f32() -> string { "ld.shared.f32" }
+pub fn ptx_opcode_ld_shared_f32() -> string { "ld.shared.f32" }
 
-fn ptx_opcode_ld_shared_f64() -> string { "ld.shared.f64" }
+pub fn ptx_opcode_ld_shared_f64() -> string { "ld.shared.f64" }
 
-fn ptx_opcode_st_shared_f32() -> string { "st.shared.f32" }
+pub fn ptx_opcode_st_shared_f32() -> string { "st.shared.f32" }
 
-fn ptx_opcode_st_shared_f64() -> string { "st.shared.f64" }
+pub fn ptx_opcode_st_shared_f64() -> string { "st.shared.f64" }
 
-fn ptx_opcode_ld_shared_s32() -> string { "ld.shared.s32" }
+pub fn ptx_opcode_ld_shared_s32() -> string { "ld.shared.s32" }
 
-fn ptx_opcode_st_shared_s32() -> string { "st.shared.s32" }
+pub fn ptx_opcode_st_shared_s32() -> string { "st.shared.s32" }
 
 // Predicate operations
-fn ptx_opcode_setp_lt_u32() -> string { "setp.lt.u32" }
+pub fn ptx_opcode_setp_lt_u32() -> string { "setp.lt.u32" }
 
-fn ptx_opcode_setp_lt_s32() -> string { "setp.lt.s32" }
+pub fn ptx_opcode_setp_lt_s32() -> string { "setp.lt.s32" }
 
-fn ptx_opcode_setp_lt_f32() -> string { "setp.lt.f32" }
-fn ptx_opcode_setp_lt_u64() -> string { "setp.lt.u64" }
-fn ptx_opcode_setp_lt_s64() -> string { "setp.lt.s64" }
-fn ptx_opcode_setp_lt_f64() -> string { "setp.lt.f64" }
+pub fn ptx_opcode_setp_lt_f32() -> string { "setp.lt.f32" }
+pub fn ptx_opcode_setp_lt_u64() -> string { "setp.lt.u64" }
+pub fn ptx_opcode_setp_lt_s64() -> string { "setp.lt.s64" }
+pub fn ptx_opcode_setp_lt_f64() -> string { "setp.lt.f64" }
 
-fn ptx_opcode_setp_le_u32() -> string { "setp.le.u32" }
+pub fn ptx_opcode_setp_le_u32() -> string { "setp.le.u32" }
 
-fn ptx_opcode_setp_le_s32() -> string { "setp.le.s32" }
+pub fn ptx_opcode_setp_le_s32() -> string { "setp.le.s32" }
 
-fn ptx_opcode_setp_le_f32() -> string { "setp.le.f32" }
-fn ptx_opcode_setp_le_u64() -> string { "setp.le.u64" }
+pub fn ptx_opcode_setp_le_f32() -> string { "setp.le.f32" }
+pub fn ptx_opcode_setp_le_u64() -> string { "setp.le.u64" }
 
-fn ptx_opcode_setp_ge_u32() -> string { "setp.ge.u32" }
+pub fn ptx_opcode_setp_ge_u32() -> string { "setp.ge.u32" }
 
-fn ptx_opcode_setp_ge_s32() -> string { "setp.ge.s32" }
+pub fn ptx_opcode_setp_ge_s32() -> string { "setp.ge.s32" }
 
-fn ptx_opcode_setp_ge_s64() -> string { "setp.ge.s64" }
+pub fn ptx_opcode_setp_ge_s64() -> string { "setp.ge.s64" }
 
-fn ptx_opcode_setp_ge_f32() -> string { "setp.ge.f32" }
+pub fn ptx_opcode_setp_ge_f32() -> string { "setp.ge.f32" }
 
-fn ptx_opcode_setp_ge_f64() -> string { "setp.ge.f64" }
+pub fn ptx_opcode_setp_ge_f64() -> string { "setp.ge.f64" }
 
-fn ptx_opcode_setp_ge_u64() -> string { "setp.ge.u64" }
+pub fn ptx_opcode_setp_ge_u64() -> string { "setp.ge.u64" }
 
-fn ptx_opcode_setp_eq_u32() -> string { "setp.eq.u32" }
+pub fn ptx_opcode_setp_eq_u32() -> string { "setp.eq.u32" }
 
-fn ptx_opcode_setp_eq_s32() -> string { "setp.eq.s32" }
+pub fn ptx_opcode_setp_eq_s32() -> string { "setp.eq.s32" }
 
-fn ptx_opcode_setp_eq_f32() -> string { "setp.eq.f32" }
-fn ptx_opcode_setp_eq_u64() -> string { "setp.eq.u64" }
+pub fn ptx_opcode_setp_eq_f32() -> string { "setp.eq.f32" }
+pub fn ptx_opcode_setp_eq_u64() -> string { "setp.eq.u64" }
 
-fn ptx_opcode_selp_b32() -> string { "selp.b32" }
+pub fn ptx_opcode_selp_b32() -> string { "selp.b32" }
 
-fn ptx_opcode_selp_b64() -> string { "selp.b64" }
+pub fn ptx_opcode_selp_b64() -> string { "selp.b64" }
 
-fn ptx_opcode_selp_s32() -> string { "selp.b32" }
+pub fn ptx_opcode_selp_s32() -> string { "selp.b32" }
 
-fn ptx_opcode_selp_f32() -> string { "selp.f32" }
+pub fn ptx_opcode_selp_f32() -> string { "selp.f32" }
 
-fn ptx_opcode_selp_f64() -> string { "selp.f64" }
+pub fn ptx_opcode_selp_f64() -> string { "selp.f64" }
 
 // Warp shuffle operations
-fn ptx_opcode_shfl_down_b32() -> string { "shfl.sync.down.b32" }
+pub fn ptx_opcode_shfl_down_b32() -> string { "shfl.sync.down.b32" }
 
-fn ptx_opcode_shfl_down_b64() -> string { "shfl.sync.down.b64" }
+pub fn ptx_opcode_shfl_down_b64() -> string { "shfl.sync.down.b64" }
 
 // Phase 7: Warp shuffle up (for inclusive scan)
-fn ptx_opcode_shfl_up_b32() -> string { "shfl.sync.up.b32" }
+pub fn ptx_opcode_shfl_up_b32() -> string { "shfl.sync.up.b32" }
 
-fn ptx_opcode_shfl_up_b64() -> string { "shfl.sync.up.b64" }
+pub fn ptx_opcode_shfl_up_b64() -> string { "shfl.sync.up.b64" }
 
 // Phase 4: U32 arithmetic (for 2D index calculations)
-fn ptx_opcode_add_u32() -> string { "add.u32" }
+pub fn ptx_opcode_add_u32() -> string { "add.u32" }
 
-fn ptx_opcode_mul_lo_u32() -> string { "mul.lo.u32" }
+pub fn ptx_opcode_mul_lo_u32() -> string { "mul.lo.u32" }
 
 // Phase 4: FMA / MAD operations
-fn ptx_opcode_fma_rn_f32() -> string { "fma.rn.f32" }
+pub fn ptx_opcode_fma_rn_f32() -> string { "fma.rn.f32" }
 
-fn ptx_opcode_fma_rn_f64() -> string { "fma.rn.f64" }
+pub fn ptx_opcode_fma_rn_f64() -> string { "fma.rn.f64" }
 
-fn ptx_opcode_mad_lo_s32() -> string { "mad.lo.s32" }
+pub fn ptx_opcode_mad_lo_s32() -> string { "mad.lo.s32" }
 
-fn ptx_opcode_mad_lo_s64() -> string { "mad.lo.s64" }
+pub fn ptx_opcode_mad_lo_s64() -> string { "mad.lo.s64" }
 
-fn ptx_push_binary3(
+pub fn ptx_push_binary3(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -521,7 +553,7 @@ fn ptx_push_binary3(
     out
 }
 
-fn ptx_push_binary2(
+pub fn ptx_push_binary2(
     buf: PtxBuf,
     opcode: string,
     lhs: string,
@@ -538,7 +570,7 @@ fn ptx_push_binary2(
     out
 }
 
-fn ptx_push_binary_mem2(
+pub fn ptx_push_binary_mem2(
     buf: PtxBuf,
     opcode: string,
     dst_or_dst_ptr: string,
@@ -555,7 +587,7 @@ fn ptx_push_binary_mem2(
     out
 }
 
-fn ptx_push_store_mem(
+pub fn ptx_push_store_mem(
     buf: PtxBuf,
     opcode: string,
     dst_ptr: string,
@@ -572,7 +604,7 @@ fn ptx_push_store_mem(
     out
 }
 
-fn ptx_emit_shared_decl(
+pub fn ptx_emit_shared_decl(
     buf: PtxBuf,
     bytes: i64
 ) -> PtxBuf with Mut, Panic, Div, Alloc {
@@ -583,17 +615,17 @@ fn ptx_emit_shared_decl(
     out
 }
 
-fn ptx_push_ret(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_ret(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     ptx_push_str(buf, "    ret;\n")
 }
 
 // Reduction helper functions
 
-fn ptx_push_barrier_sync(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_push_barrier_sync(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     ptx_push_str(buf, "    bar.sync 0;\n")
 }
 
-fn ptx_push_shfl_down(
+pub fn ptx_push_shfl_down(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -613,7 +645,7 @@ fn ptx_push_shfl_down(
     out
 }
 
-fn ptx_push_setp2(
+pub fn ptx_push_setp2(
     buf: PtxBuf,
     opcode: string,
     dst_pred: string,
@@ -633,7 +665,7 @@ fn ptx_push_setp2(
     out
 }
 
-fn ptx_push_selp(
+pub fn ptx_push_selp(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -656,7 +688,7 @@ fn ptx_push_selp(
     out
 }
 
-fn ptx_push_predicated_mem2(
+pub fn ptx_push_predicated_mem2(
     buf: PtxBuf,
     opcode: string,
     pred: string,
@@ -676,7 +708,7 @@ fn ptx_push_predicated_mem2(
     out
 }
 
-fn ptx_push_predicated_store_mem(
+pub fn ptx_push_predicated_store_mem(
     buf: PtxBuf,
     opcode: string,
     pred: string,
@@ -696,7 +728,7 @@ fn ptx_push_predicated_store_mem(
     out
 }
 
-fn ptx_push_atomic_add(
+pub fn ptx_push_atomic_add(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -716,7 +748,7 @@ fn ptx_push_atomic_add(
     out
 }
 
-fn ptx_push_ld_shared(
+pub fn ptx_push_ld_shared(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -733,7 +765,7 @@ fn ptx_push_ld_shared(
     out
 }
 
-fn ptx_push_st_shared(
+pub fn ptx_push_st_shared(
     buf: PtxBuf,
     opcode: string,
     addr: string,
@@ -751,7 +783,7 @@ fn ptx_push_st_shared(
 }
 
 // Phase 4: FMA emitter (4-operand: dst = a * b + c)
-fn ptx_push_fma(
+pub fn ptx_push_fma(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -775,7 +807,7 @@ fn ptx_push_fma(
 }
 
 // Phase 4: Special register move (ctaid.x, ntid.x, etc.)
-fn ptx_push_mov_special(
+pub fn ptx_push_mov_special(
     buf: PtxBuf,
     special: string,
     axis: string,
@@ -793,7 +825,7 @@ fn ptx_push_mov_special(
 }
 
 // Phase 4: Add immediate (reg + immediate constant)
-fn ptx_push_add_imm(
+pub fn ptx_push_add_imm(
     buf: PtxBuf,
     opcode: string,
     dst: string,
@@ -813,7 +845,7 @@ fn ptx_push_add_imm(
     out
 }
 
-fn ptx_emit_header(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_header(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     out = ptx_push_str(out, ".version ")
     out = ptx_push_str(out, ptx_header_version())
@@ -826,7 +858,7 @@ fn ptx_emit_header(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_emit_vec_add_signature(
+pub fn ptx_emit_vec_add_signature(
     buf: PtxBuf,
     kernel_name: string,
     param_a: string,
@@ -849,7 +881,7 @@ fn ptx_emit_vec_add_signature(
     out
 }
 
-fn ptx_emit_vec_add_reg_decl(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_add_reg_decl(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     out = ptx_push_str(out, "{\n")
     out = ptx_push_str(out, "    .reg .pred %p<2>;\n")
@@ -859,7 +891,7 @@ fn ptx_emit_vec_add_reg_decl(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_emit_vec_add_body(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_add_body(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = buf
     out = ptx_push_binary2(out, ptx_opcode_mov_u32(), "%r1", "%tid.x")
     out = ptx_push_binary2(out, ptx_opcode_mov_u32(), "%r2", "%ctaid.x")
@@ -882,7 +914,7 @@ fn ptx_emit_vec_add_body(buf: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     out
 }
 
-fn ptx_emit_vec3_f32_add(
+pub fn ptx_emit_vec3_f32_add(
     buf: PtxBuf,
     out0: string,
     in0_0: string,
@@ -902,7 +934,7 @@ fn ptx_emit_vec3_f32_add(
 }
 
 // Append one PtxBuf to another. Used to concatenate multiple kernel PTX outputs.
-fn ptx_buf_append(dst: PtxBuf, src: PtxBuf) -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_buf_append(dst: PtxBuf, src: PtxBuf) -> PtxBuf with Mut, Panic, Div {
     var out = dst
     var i: i64 = 0
     while i < src.len {
@@ -916,7 +948,7 @@ fn ptx_buf_append(dst: PtxBuf, src: PtxBuf) -> PtxBuf with Mut, Panic, Div {
 }
 
 // Print a PtxBuf to stdout.
-fn ptx_buf_print(buf: PtxBuf) with IO, Mut, Panic, Div {
+pub fn ptx_buf_print(buf: PtxBuf) with IO, Mut, Panic, Div {
     var i: i64 = 0
     while i < buf.len {
         print_char(buf.data[i as usize] as i64)
@@ -924,7 +956,7 @@ fn ptx_buf_print(buf: PtxBuf) with IO, Mut, Panic, Div {
     }
 }
 
-fn ptx_emit_demo_vec_add() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_demo_vec_add() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_add", "param_a", "param_b", "param_c")
@@ -933,7 +965,7 @@ fn ptx_emit_demo_vec_add() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_epistemic_dual_output_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_epistemic_dual_output_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry epistemic_dual_output_f32(\n")
@@ -1003,7 +1035,7 @@ fn ptx_emit_epistemic_dual_output_f32() -> PtxBuf with Mut, Panic, Div {
 
 // ── Extended kernel emitters (Phase 2) ──────────────────────────────
 
-fn ptx_emit_vec_sub_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_sub_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_sub", "param_a", "param_b", "param_c")
@@ -1026,7 +1058,7 @@ fn ptx_emit_vec_sub_f32() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_mul_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_mul_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_mul", "param_a", "param_b", "param_c")
@@ -1049,7 +1081,7 @@ fn ptx_emit_vec_mul_f32() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_div_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_div_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_div", "param_a", "param_b", "param_c")
@@ -1072,7 +1104,7 @@ fn ptx_emit_vec_div_f32() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_add_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_add_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_add_f64", "param_a", "param_b", "param_c")
@@ -1099,7 +1131,7 @@ fn ptx_emit_vec_add_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_fma_f32() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_fma_f32() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry fma_f32(\n")
@@ -1136,7 +1168,7 @@ fn ptx_emit_fma_f32() -> PtxBuf with Mut, Panic, Div {
 
 // ── f64 variants ────────────────────────────────────────────────────
 
-fn ptx_emit_vec_sub_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_sub_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_sub_f64", "param_a", "param_b", "param_c")
@@ -1163,7 +1195,7 @@ fn ptx_emit_vec_sub_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_mul_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_mul_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_mul_f64", "param_a", "param_b", "param_c")
@@ -1190,7 +1222,7 @@ fn ptx_emit_vec_mul_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_vec_div_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_vec_div_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_emit_vec_add_signature(b, "vec_div_f64", "param_a", "param_b", "param_c")
@@ -1217,7 +1249,7 @@ fn ptx_emit_vec_div_f64() -> PtxBuf with Mut, Panic, Div {
     b
 }
 
-fn ptx_emit_fma_f64() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_fma_f64() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry fma_f64(\n")
@@ -1254,7 +1286,7 @@ fn ptx_emit_fma_f64() -> PtxBuf with Mut, Panic, Div {
 
 // ── store_u32_const emitter ─────────────────────────────────────────
 
-fn ptx_emit_store_u32_const() -> PtxBuf with Mut, Panic, Div {
+pub fn ptx_emit_store_u32_const() -> PtxBuf with Mut, Panic, Div {
     var b = ptx_buf_new()
     b = ptx_emit_header(b)
     b = ptx_push_str(b, ".visible .entry store_u32_const(\n")


### PR DESCRIPTION
## Summary

Fixes the blocker documented in `docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md`
(from #582): `use gpu::kernel_ir::*; use gpu::lower_to_ptx::*; use gpu::ptx::*` together
failed `souc check` with 335 E175 + 18 E177 + 5 E046 errors, blocking any driver (like
`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio`) that needs the `GpuKernelIr -> PTX`
lowering path outside the K-AXI-only `bin/kretikos` dispatch.

Bisection found three independent, stacked bugs, not one:

1. **`lower_to_ptx.sio` had lost its own `use gpu::kernel_ir::*` / `use gpu::ptx::*`**
   (and `gpu_lower_to_ptx`'s `pub`). `use` in Sounio is not transitive — a dependency's
   own imports don't extend the importer's symbol set. Restored both lines.
2. **`kernel_ir.sio` had 5 struct literals with a duplicated field key** (`rhs_reg` or
   `lhs_reg` given two different values in the same `GpuOp { ... }` literal — 24 pairs for
   a 23-field struct). This is what "wrong number of fields" (E046) actually meant.
   Removed the redundant duplicate in each, kept the meaningful value.
3. **`ptx.sio` called `i64_to_string`, which it never defined or imported** (only exists in
   `lower_to_ptx.sio`/`opt/warp_vote_fastpath.sio`, and importing either would be circular
   since `lower_to_ptx.sio` imports `gpu::ptx`). Added a local copy.
4. **Privacy-annotation drift, confirmed widespread**: `kernel_ir.sio`'s structs/enums/131
   of 132 top-level functions, and `ptx.sio`'s struct/all 147 top-level functions, were
   missing `pub`. Both files exist to be shared libraries for the rest of the GPU backend,
   so blanket `pub` is correct, applied via a scripted pass.

Full root-cause writeup and reproduction steps in the audit doc (updated in this PR).

## Test plan

- [x] `souc check` passes clean (`verdict=0`) on `kernel_ir.sio`, `ptx.sio`,
  `lower_to_ptx.sio` individually and together.
- [x] `souc check self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` (the driver this was
  blocking) passes clean.
- [x] `souc check self-hosted/gpu/mod.sio` (the GPU orchestrator) still passes with only
  the one pre-existing, unrelated error it already had before this change (confirmed via
  baseline diff — not touched by this PR).
- [x] `souc build` of the driver now gets past typecheck and IR merge (down to a
  1-function merged IR from ~240–330 before this fix) and reaches native codegen, where it
  hits the **separate**, already-tracked, open Madaros SIGSEGV cluster
  (`docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/`) — out of scope for this PR. Getting
  a real ELF (and PTX for DGX Spark hardware verification) still depends on that separate
  bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)