### PR TITLE
tools(madaros): surface cleanup planner in readiness

### DIFF
--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -45,6 +45,11 @@ It writes:
 The planner is intentionally non-destructive. It never runs `git push`,
 `git reset`, `git clean`, `git branch -D`, or `git worktree remove`.
 
+`scripts/dev/madaros_readiness_status.sh --strict` prints a
+`cleanup_plan_command=...` line after the worktree audit section, using the
+exact audit TSV path from that run. That is the operator handoff from red
+strict-audit output to this cleanup planner.
+
 ## Current Blocker To `--strict`
 
 Readiness production proof is green, but the stricter worktree audit still

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -30,6 +30,7 @@ require_grep() {
 }
 
 require_file docs/MADAROS_STATUS.md
+require_file docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
 require_file docs/status/madaros_main_proof_17d115.md
 require_file AGENTS.md
 require_file CLAUDE.md
@@ -42,6 +43,7 @@ require_file scripts/ci/build_modular_madaros.sh
 require_file scripts/ci/madaros_full_gate.sh
 require_file scripts/ci/madaros_source_to_elf_gate.sh
 require_executable scripts/dev/madaros_two_gate.sh
+require_executable scripts/dev/madaros_worktree_cleanup_plan.sh
 require_file .github/workflows/ci.yml
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -60,6 +62,7 @@ require_grep 'ungated' docs/MADAROS_STATUS.md
 require_grep 'artifacts/self-hosted/madaros' docs/MADAROS_STATUS.md
 require_grep 'binary is **not evidence**' docs/MADAROS_STATUS.md
 require_grep 'scripts/ci/madaros_operational_contract_gate.sh' docs/MADAROS_STATUS.md
+require_grep 'scripts/dev/madaros_worktree_cleanup_plan.sh' docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
 
 require_grep 'scripts/lib/resolve_madaros.sh' AGENTS.md
 require_grep 'docs/MADAROS_STATUS.md' AGENTS.md
@@ -100,5 +103,8 @@ require_grep 'bin/madaros-relocgate' scripts/lib/resolve_madaros.sh
 require_grep 'bin/madaros-linux-x86_64' bin/souc
 require_grep 'exec env MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros"' bin/souc
 require_grep 'artifacts/self-hosted/madaros.gate-receipt' .gitignore
+require_grep 'cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh' scripts/dev/madaros_readiness_status.sh
+require_grep 'It never runs git push, git reset, git clean, git branch -D, or' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep 'owner confirmation required before any archive, push, or removal' scripts/dev/madaros_worktree_cleanup_plan.sh
 
 echo "[madaros-contract] PASS: status doc, agent contract, default wrapper, and gate wiring are aligned"

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -15,6 +15,7 @@ IN_PRODUCTION_READY_CHECK=0
 COMPILER_LANE_PATH="${SOUNIO_MADAROS_COMPILER_LANE:-/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b}"
 REFRESH_GH=0
 STRICT=0
+STRICT_FAILED=0
 PRODUCTION_READY=0
 PRODUCTION_READY_FAILED=0
 COMPILER_PR_OVERLAP_FAILED=0
@@ -127,14 +128,14 @@ run_status_command() {
   if "$@"; then
     echo "status[$label]=pass"
     return 0
+  else
+    local rc=$?
+    echo "status[$label]=fail rc=$rc"
+    if [[ "$STRICT" == "1" ]]; then
+      STRICT_FAILED=1
+    fi
+    return 0
   fi
-
-  local rc=$?
-  echo "status[$label]=fail rc=$rc"
-  if [[ "$STRICT" == "1" ]]; then
-    return "$rc"
-  fi
-  return 0
 }
 
 summarize_check_log() {
@@ -478,6 +479,7 @@ if [[ "$RUN_AUDIT" == "1" ]]; then
   run_status_command audit \
     env SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE:-$audit_allow_default}" \
       scripts/dev/worktree_branch_audit.sh --check "$audit_out"
+  echo "cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-plan"
 fi
 
 if [[ "$CHECK_COMPILER_LANE" == "1" ]]; then
@@ -573,6 +575,7 @@ Production readiness still also requires:
 Integration shepherd:
   scripts/ci/madaros_blocker_contract_gate.sh
   scripts/dev/madaros_readiness_status.sh --strict
+  scripts/dev/madaros_worktree_cleanup_plan.sh
   scripts/dev/madaros_readiness_status.sh --check-compiler-pr-overlap
   scripts/dev/madaros_readiness_status.sh --check-pr-resolution-queue
   scripts/dev/madaros_readiness_status.sh --production-ready
@@ -591,5 +594,9 @@ if [[ "$RUN_SOURCE_TO_ELF" == "1" ]]; then
 fi
 
 if [[ "$PRODUCTION_READY" == "1" && "$PRODUCTION_READY_FAILED" != "0" ]]; then
+  exit 1
+fi
+
+if [[ "$STRICT" == "1" && "$PRODUCTION_READY" != "1" && "$STRICT_FAILED" != "0" ]]; then
   exit 1
 fi


### PR DESCRIPTION
## Summary
- makes `madaros_readiness_status.sh --strict` print the exact `cleanup_plan_command=...` using the audit TSV from that run
- fixes `run_status_command` so strict audit failures report the real rc and make `--strict` exit nonzero after printing Next Gates
- preserves `--production-ready` as the existing narrow blocker/main-CI verdict
- guards the cleanup planner wiring in `madaros_operational_contract_gate.sh`

## Validation
- `bash -n scripts/dev/madaros_readiness_status.sh scripts/ci/madaros_operational_contract_gate.sh scripts/dev/madaros_worktree_cleanup_plan.sh`
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `scripts/dev/madaros_readiness_status.sh --strict` -> rc 1, prints `cleanup_plan_command=...`
- `scripts/dev/madaros_readiness_status.sh --production-ready` -> rc 0, production_ready pass
- `scripts/dev/madaros_worktree_cleanup_plan.sh` with current worktree allowlisted -> `planned_worktrees=19`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `git diff --check`