### PR TITLE
tools(madaros): enrich cleanup planner evidence

### DIFF
--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -38,7 +38,10 @@ scripts/dev/madaros_worktree_cleanup_plan.sh
 It writes:
 
 - `worktree-audit.tsv` — raw `scripts/dev/worktree_branch_audit.sh` inventory.
-- `madaros-cleanup-plan.tsv` — classified unallowed critical dirty worktrees.
+- `madaros-cleanup-plan.tsv` — classified unallowed critical dirty worktrees,
+  including `unique_commits_origin_main`, `unique_commits_upstream`,
+  tracked/untracked dirty file counts, tracked diff numstat,
+  `critical_vs_base`, and a suggested `salvage_ref`.
 - `madaros-cleanup-plan.commands.sh` — inspection and salvage commands, with
   mutating push/remove commands commented out.
 

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -29,6 +29,82 @@ require_grep() {
   grep -Fq -- "$pattern" "$file" || fail "missing marker in $file: $pattern"
 }
 
+require_cleanup_planner_evidence() {
+  local tmp_dir audit_tsv out_dir plan_tsv plan_sh real_out real_plan real_sh head actual_header expected_header row_count evidence_count
+  tmp_dir="$(mktemp -d /tmp/madaros-contract-cleanup.XXXXXX)"
+  audit_tsv="$tmp_dir/worktree-audit.tsv"
+  out_dir="$tmp_dir/out"
+  head="$(git rev-parse --short=12 HEAD 2>/dev/null || printf 'unknown')"
+
+  printf 'path\tbranch\thead\tupstream\tstate\tdirty_count\tahead\tbehind\tcritical_dirty\tcritical_vs_base\tpr\n' > "$audit_tsv"
+  printf '%s\tdetached\t%s\t\tdirty\t1\t0\t0\tM scripts/dev/madaros_worktree_cleanup_plan.sh\tscripts/dev/madaros_worktree_cleanup_plan.sh\t\n' \
+    "$ROOT_DIR" "$head" >> "$audit_tsv"
+
+  SOUNIO_MADAROS_CLEANUP_ALLOW_RE='^$' \
+    scripts/dev/madaros_worktree_cleanup_plan.sh --audit-tsv "$audit_tsv" --out-dir "$out_dir" >/dev/null
+
+  plan_tsv="$out_dir/madaros-cleanup-plan.tsv"
+  plan_sh="$out_dir/madaros-cleanup-plan.commands.sh"
+  require_file "$plan_tsv"
+  require_file "$plan_sh"
+
+  expected_header='category	path	branch	head	upstream	state	dirty_count	ahead	behind	remote_ref	prs	unique_commits_origin_main	unique_commits_upstream	tracked_dirty_files	untracked_dirty_files	tracked_diff_files	tracked_diff_added	tracked_diff_deleted	salvage_ref	critical_dirty	critical_vs_base	disposition'
+  IFS= read -r actual_header < "$plan_tsv"
+  [[ "$actual_header" == "$expected_header" ]] ||
+    fail "cleanup planner header drifted: $actual_header"
+
+  awk -F '\t' '
+    NR == 2 {
+      if (NF != 22) {
+        exit 1
+      }
+      if ($12 == "" || $14 == "" || $15 == "" || $16 == "" || $17 == "" || $18 == "") {
+        exit 1
+      }
+      if ($19 !~ /^archive\/madaros-/ || $21 == "") {
+        exit 1
+      }
+      found = 1
+    }
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$plan_tsv" || fail "cleanup planner evidence row missing or malformed"
+
+  grep -Eq '^# evidence=origin_main_unique:[^ ]+ upstream_unique:[^ ]+ tracked_dirty:[0-9]+ untracked_dirty:[0-9]+ tracked_diff:[0-9]+ files \+[0-9]+ -[0-9]+ critical_vs_base:' "$plan_sh" ||
+    fail "cleanup planner command evidence comment missing"
+
+  require_no_uncommented_mutation "$plan_sh"
+
+  # Live audit validates row shape and non-destructive output; cleanup counts may drift.
+  real_out="$tmp_dir/real"
+  scripts/dev/madaros_worktree_cleanup_plan.sh --out-dir "$real_out" >/dev/null
+  real_plan="$real_out/madaros-cleanup-plan.tsv"
+  real_sh="$real_out/madaros-cleanup-plan.commands.sh"
+  require_file "$real_plan"
+  require_file "$real_sh"
+  IFS= read -r actual_header < "$real_plan"
+  [[ "$actual_header" == "$expected_header" ]] ||
+    fail "real cleanup planner header drifted: $actual_header"
+  awk -F '\t' 'NR > 1 && NF != 22 { exit 1 }' "$real_plan" ||
+    fail "real cleanup planner emitted a malformed row"
+  row_count="$(awk 'NR > 1 { rows++ } END { print rows + 0 }' "$real_plan")"
+  evidence_count="$(grep -c '^# evidence=origin_main_unique:' "$real_sh" || true)"
+  [[ "$row_count" == "$evidence_count" ]] ||
+    fail "real cleanup planner evidence comments do not match rows: rows=$row_count evidence=$evidence_count"
+  require_no_uncommented_mutation "$real_sh"
+}
+
+require_no_uncommented_mutation() {
+  local plan_sh="$1"
+  awk '
+    /^[[:space:]]*git[[:space:]]+push([[:space:]]|$)/ { exit 1 }
+    /^[[:space:]]*git[[:space:]]+worktree[[:space:]]+remove([[:space:]]|$)/ { exit 1 }
+    /^[[:space:]]*git[[:space:]]+branch[[:space:]]+-[dD]([[:space:]]|$)/ { exit 1 }
+    /^[[:space:]]*git[[:space:]]+-C[[:space:]][^[:space:]]+[[:space:]]+(reset|clean)([[:space:]]|$)/ { exit 1 }
+  ' "$plan_sh" || fail "cleanup planner emitted an uncommented mutating command: $plan_sh"
+}
+
 require_file docs/MADAROS_STATUS.md
 require_file docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
 require_file docs/status/madaros_main_proof_17d115.md
@@ -104,7 +180,12 @@ require_grep 'bin/madaros-linux-x86_64' bin/souc
 require_grep 'exec env MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros"' bin/souc
 require_grep 'artifacts/self-hosted/madaros.gate-receipt' .gitignore
 require_grep 'cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh' scripts/dev/madaros_readiness_status.sh
-require_grep 'It never runs git push, git reset, git clean, git branch -D, or' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep 'git push, git reset, git clean, git branch -D' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'owner confirmation required before any archive, push, or removal' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep 'unique_commits_origin_main' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep 'tracked_diff_added' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep 'critical_vs_base' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep '# evidence=origin_main_unique:' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_cleanup_planner_evidence
 
 echo "[madaros-contract] PASS: status doc, agent contract, default wrapper, and gate wiring are aligned"

--- a/scripts/dev/madaros_worktree_cleanup_plan.sh
+++ b/scripts/dev/madaros_worktree_cleanup_plan.sh
@@ -15,7 +15,9 @@ Usage: scripts/dev/madaros_worktree_cleanup_plan.sh [options]
 
 Build a non-destructive cleanup plan for Madaros critical dirty worktrees.
 The script writes an audit TSV, a classified cleanup TSV, and a commented shell
-plan. It never runs git push, git reset, git clean, git branch -D, or
+plan. The cleanup TSV includes unique-commit counts, dirty tracked/untracked
+file counts, tracked diff numstat, critical-vs-base paths, and a suggested
+salvage ref. It never runs git push, git reset, git clean, git branch -D, or
 git worktree remove.
 
 Options:
@@ -171,6 +173,36 @@ slug_for_path() {
   basename "$1" | sed 's/[^A-Za-z0-9._-]\+/-/g; s/^-//; s/-$//'
 }
 
+archive_branch_for_path() {
+  printf 'archive/madaros-%s' "$(slug_for_path "$1")"
+}
+
+count_commits() {
+  local wt_path="$1" rev_range="$2"
+  git -C "$wt_path" rev-list --count "$rev_range" 2>/dev/null || printf '?'
+}
+
+dirty_file_counts() {
+  local wt_path="$1"
+  git -C "$wt_path" status --porcelain 2>/dev/null | awk '
+    /^\?\?/ { untracked++; next }
+    { tracked++ }
+    END { printf "%d %d", tracked, untracked }
+  '
+}
+
+tracked_diff_numstat() {
+  local wt_path="$1"
+  git -C "$wt_path" diff --numstat 2>/dev/null | awk '
+    {
+      files++
+      if ($1 ~ /^[0-9]+$/) added += $1
+      if ($2 ~ /^[0-9]+$/) deleted += $2
+    }
+    END { printf "%d %d %d", files, added, deleted }
+  '
+}
+
 emit_unallowed_rows() {
   awk -F '\t' -v allow_re="$ALLOW_RE" -v OFS=$'\034' '
     NR > 1 && $9 != "" {
@@ -185,22 +217,34 @@ emit_unallowed_rows() {
 emit_plan_rows() {
   awk -F '\t' -v OFS=$'\034' '
     NR > 1 {
-      print $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+      print $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+        $14, $15, $16, $17, $18, $19, $20, $21, $22
     }
   ' "$PLAN_TSV"
 }
 
 {
-  printf 'category\tpath\tbranch\thead\tupstream\tstate\tdirty_count\tahead\tbehind\tremote_ref\tprs\tcritical_dirty\tdisposition\n'
+  printf 'category\tpath\tbranch\thead\tupstream\tstate\tdirty_count\tahead\tbehind\tremote_ref\tprs\tunique_commits_origin_main\tunique_commits_upstream\ttracked_dirty_files\tuntracked_dirty_files\ttracked_diff_files\ttracked_diff_added\ttracked_diff_deleted\tsalvage_ref\tcritical_dirty\tcritical_vs_base\tdisposition\n'
 
-  emit_unallowed_rows | while IFS=$'\034' read -r path branch head upstream state dirty_count ahead behind critical_dirty critical_vs pr; do
+  emit_unallowed_rows | while IFS=$'\034' read -r path branch head upstream state dirty_count ahead behind critical_dirty critical_vs _audit_pr; do
     remote_ref="$(remote_ref_for_branch "$branch")"
     prs="$(prs_for_branch "$branch")"
     category="$(category_for_row "$path" "$branch")"
     disposition="$(disposition_for_category "$category" "$remote_ref" "$prs")"
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    unique_origin_main="$(count_commits "$path" "origin/main..HEAD")"
+    if [[ -n "$upstream" ]]; then
+      unique_upstream="$(count_commits "$path" "$upstream..HEAD")"
+    else
+      unique_upstream=""
+    fi
+    read -r tracked_dirty untracked_dirty <<<"$(dirty_file_counts "$path")"
+    read -r tracked_diff_files tracked_diff_added tracked_diff_deleted <<<"$(tracked_diff_numstat "$path")"
+    salvage_ref="$(archive_branch_for_path "$path")"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
       "$category" "$path" "$branch" "$head" "$upstream" "$state" "$dirty_count" \
-      "$ahead" "$behind" "$remote_ref" "$prs" "$critical_dirty" "$disposition"
+      "$ahead" "$behind" "$remote_ref" "$prs" "$unique_origin_main" "$unique_upstream" \
+      "$tracked_dirty" "$untracked_dirty" "$tracked_diff_files" "$tracked_diff_added" \
+      "$tracked_diff_deleted" "$salvage_ref" "$critical_dirty" "$critical_vs" "$disposition"
   done
 } > "$PLAN_TSV"
 
@@ -216,15 +260,16 @@ set -euo pipefail
 
 HEADER
 
-  emit_plan_rows | while IFS=$'\034' read -r category path branch head upstream state dirty_count ahead behind remote_ref prs critical_dirty disposition; do
+  emit_plan_rows | while IFS=$'\034' read -r category path branch head upstream state dirty_count ahead behind remote_ref prs unique_origin_main unique_upstream tracked_dirty untracked_dirty tracked_diff_files tracked_diff_added tracked_diff_deleted salvage_ref critical_dirty critical_vs_base disposition; do
     path_q="$(quote_sh "$path")"
-    archive_branch="archive/madaros-$(slug_for_path "$path")"
-    archive_q="$(quote_sh "$archive_branch")"
+    archive_q="$(quote_sh "$salvage_ref")"
+    patch_q="$(quote_sh "/tmp/$(basename "$path").dirty.patch")"
     echo "# category=$category branch=$branch head=$head remote_ref=$remote_ref"
     echo "# disposition=$disposition"
+    echo "# evidence=origin_main_unique:$unique_origin_main upstream_unique:${unique_upstream:-n/a} tracked_dirty:$tracked_dirty untracked_dirty:$untracked_dirty tracked_diff:$tracked_diff_files files +$tracked_diff_added -$tracked_diff_deleted critical_vs_base:${critical_vs_base:-none}"
     echo "git -C $path_q status --short --branch"
     echo "git -C $path_q diff --stat"
-    echo "git -C $path_q diff > /tmp/$(basename "$path").dirty.patch"
+    echo "git -C $path_q diff > $patch_q"
     if [[ "$category" == "active_other_lane_wip" || "$category" == "unclassified" ]]; then
       echo "# owner confirmation required before any archive, push, or removal"
       echo


### PR DESCRIPTION
## Summary

- enrich `madaros_worktree_cleanup_plan.sh` with cleanup evidence columns: unique commits, tracked/untracked dirty counts, tracked diff numstat, `critical_vs_base`, and `salvage_ref`
- carry evidence into generated cleanup commands while keeping mutating push/remove/delete commands commented
- upgrade `madaros_operational_contract_gate.sh` from marker-only checks to deterministic fixture coverage plus live-audit shape validation
- update the cleanup ledger to describe the expanded planner output

## Validation

- `bash -n scripts/dev/madaros_worktree_cleanup_plan.sh scripts/dev/madaros_readiness_status.sh scripts/ci/madaros_operational_contract_gate.sh`
- `git diff --check`
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `SOUNIO_MADAROS_CLEANUP_ALLOW_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|/tmp/sounio-madaros-cleanup-evidence)$' scripts/dev/madaros_worktree_cleanup_plan.sh --out-dir /tmp/madaros-cleanup-evidence-plan-test`
- verified generated plan has 22 TSV fields, 19 rows, 19 evidence comments, and no uncommented mutating commands
- `bash scripts/dev/check_docs_consistency.sh && bash scripts/dev/check_docs_registry.sh`

## Review

Used read-only subagents for speed/cost routing:

- planner review: previous patch quoting and evidence-flow findings resolved; no new blockers
- gate/ledger review: previous marker-only gate finding resolved by live-audit shape validation; no new blockers

## Notes

The live-audit gate intentionally validates structure and non-destructive output, not exact cleanup counts. Counts are expected to drift as operator-approved cleanup proceeds.
