### PR TITLE
docs(madaros): sync greenline status after cleanup evidence

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -16,13 +16,16 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.madaros-status
 > The proof path is `make madaros-full-gate`; that gate now includes the
 > imported-SMT solver gate (6/6) regression suite and writes a `.gate-receipt`
 > only after a non-skipped SMT pass.
-> **Canonical greenline (2026-07-03):** PR #586 landed on protected
-> `canon/madaros-greenline` at merge commit
-> `bf46bda919596ce71b8fc35dc29cb3a31ff01d7b`. The branch is proof-green:
-> `madaros_full_gate.sh` passed with imported SMT 6/6 and wrote
+> **Canonical greenline (2026-07-03):** protected `canon/madaros-greenline`
+> currently points at PR #591 merge commit
+> `3df24a04af6b35e4f710663accb03f9f97825b0a`. Its compiler proof base is PR
+> #586 (`bf46bda919596ce71b8fc35dc29cb3a31ff01d7b`): `madaros_full_gate.sh`
+> passed with imported SMT 6/6 and wrote
 > `artifacts/self-hosted/madaros.gate-receipt`
 > (`sha256=0441113419b71ed0fa24348ae8ef0ad0f2a0ff9a38a13ada3409c283984d7d19`,
-> `smt_skip=0`), and GitHub required checks include `Madaros Greenline Gate`.
+> `smt_skip=0`). Subsequent protected-branch PRs #587-#591 were docs/tooling
+> coordination updates, and PR #591 passed `Madaros Greenline Gate`, `Full Test
+> Suite`, `Lean Proofs`, `Contracts`, self-host checks, lint, website, and Vercel.
 
 ## Madaros is the default compiler (`bin/souc` → Madaros)
 
@@ -76,10 +79,12 @@ as `bin/souc-lean-single-x86_64`.
   or the checked prebuilt with a loud warning. This prevents default routing
   from silently selecting a stale raw artifact.
 - **2026-07-03 canonical greenline lock (landed):** remote branch
-  `canon/madaros-greenline` points at PR #586 merge commit
-  `bf46bda919596ce71b8fc35dc29cb3a31ff01d7b` and is protected: PR flow
-  required, stale reviews dismissed, admins enforced, force-push disabled,
-  deletion disabled, and strict required status checks enabled. Required checks:
+  `canon/madaros-greenline` is protected and currently points at PR #591 merge
+  commit `3df24a04af6b35e4f710663accb03f9f97825b0a`; the initial compiler-proof
+  landing remains PR #586 at `bf46bda919596ce71b8fc35dc29cb3a31ff01d7b`. The
+  branch requires PR flow; stale reviews are dismissed, admins are enforced,
+  force-push is disabled, deletion is disabled, and strict required status
+  checks are enabled. Required checks:
   `Contracts`, `Full Test Suite`, `Lean Proofs`, `Native Self-Host (Linux x86_64)`,
   `Native Self-Host (macOS arm64)`, `Sounio Lint`,
   `Source-Bootstrap Self-Host (Linux x86_64)`, `Website`, and
@@ -145,7 +150,7 @@ When the imported-SMT section passes without
 `smt_skip=0`. A skipped SMT section is non-green and never writes that receipt.
 
 Canonical `canon/madaros-greenline` status: **proof-green and merged via PR
-#586**. On 2026-07-03, a fresh source rebuild produced
+#586; current protected head is PR #591**. On 2026-07-03, a fresh source rebuild produced
 `artifacts/self-hosted/madaros` with sha256
 `0441113419b71ed0fa24348ae8ef0ad0f2a0ff9a38a13ada3409c283984d7d19`; the six
 `tests/stdlib/theorem/test_smt_*.sio` fixtures all passed, and
@@ -153,6 +158,8 @@ Canonical `canon/madaros-greenline` status: **proof-green and merged via PR
 `smt_skip=0`. GitHub CI for PR #586 also passed `Madaros Greenline Gate`, Lean,
 full suite, source-bootstrap self-host, both native self-host jobs, contracts,
 lint, and website before the merge.
+GitHub CI for PR #591 passed the same required protection set before merging the
+cleanup-planner evidence upgrade at `3df24a04af6b35e4f710663accb03f9f97825b0a`.
 
 Root cause of the previous imported-SMT failure: the compact imported-simple IR
 builder misclassified control/non-call expressions as call thunks. In the

--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -20,6 +20,14 @@ Completed before this ledger:
   `bf46bda919596ce71b8fc35dc29cb3a31ff01d7b`.
 - PR #587 merged into `canon/madaros-greenline` at
   `4419f2097913de65e36665d442a65c6f64d5f3ca`.
+- PR #588 merged the first cleanup ledger at
+  `2bfe06b4cea88e86c0875e4c9069526c2292e9fc`.
+- PR #589 merged the non-destructive cleanup planner at
+  `95d689462126b34f57fc25d83b45dc8dbf3c01cc`.
+- PR #590 merged readiness handoff wiring at
+  `0fdaa2b1c740c6e04b533eee0b90e335b3bf728f`.
+- PR #591 merged planner evidence columns plus live-audit shape validation at
+  `3df24a04af6b35e4f710663accb03f9f97825b0a`.
 - `canon/madaros-greenline` is protected, force-push/delete are disabled,
   admins are enforced, strict required checks are enabled, and
   `Madaros Greenline Gate` is required.
@@ -47,6 +55,10 @@ It writes:
 
 The planner is intentionally non-destructive. It never runs `git push`,
 `git reset`, `git clean`, `git branch -D`, or `git worktree remove`.
+As of PR #591, `scripts/ci/madaros_operational_contract_gate.sh` also exercises
+the planner on a deterministic fixture and on the live worktree audit stream,
+checking the 22-column TSV shape, evidence-comment coverage, and absence of
+uncommented mutating commands.
 
 `scripts/dev/madaros_readiness_status.sh --strict` prints a
 `cleanup_plan_command=...` line after the worktree audit section, using the


### PR DESCRIPTION
## Summary

- updates `docs/MADAROS_STATUS.md` so the protected canonical greenline now points at PR #591 / `3df24a04a`, while preserving PR #586 as the compiler proof base
- updates the cleanup ledger with PR #588-#591 merge evidence
- records that the operational contract gate now validates cleanup-planner evidence on both a deterministic fixture and the live audit stream

## Validation

- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `scripts/dev/madaros_readiness_status.sh --production-ready`
- `git diff --check`

## Notes

No cleanup/removal was performed. `scripts/dev/madaros_readiness_status.sh --strict` remains intentionally blocked by the existing approval-gated worktree cleanup blocker (`unallowed_critical_dirty=19`).

Also verified/restored the cross-lane GPU/PTX remote branch mentioned in the status doc:
`origin/gpu/epistemic-tensor-core-next` now points at `8ea996fe327e299cc5710a3b7deb251fa0e9433d`.
