### PR TITLE
docs(madaros): record post-593 cleanup status

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -23,9 +23,10 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.madaros-status
 > `madaros_full_gate.sh` passed with imported SMT 6/6 and wrote
 > `artifacts/self-hosted/madaros.gate-receipt`
 > (`sha256=0441113419b71ed0fa24348ae8ef0ad0f2a0ff9a38a13ada3409c283984d7d19`,
-> `smt_skip=0`). Subsequent protected-branch PRs #587-#592 were docs/tooling
+> `smt_skip=0`). Subsequent protected-branch PRs #587-#593 were docs/tooling
 > coordination updates; PR #591 passed the required gate set for the
-> cleanup-planner evidence upgrade, and PR #592 passed it for this status sync.
+> cleanup-planner evidence upgrade, PR #592 passed it for the post-#591 status
+> sync, and PR #593 passed it for stale-tip wording cleanup.
 
 ## Madaros is the default compiler (`bin/souc` → Madaros)
 
@@ -165,6 +166,8 @@ GitHub CI for PR #591 passed the same required protection set before merging the
 cleanup-planner evidence upgrade at `3df24a04af6b35e4f710663accb03f9f97825b0a`.
 GitHub CI for PR #592 then passed the same protection set before merging the
 status synchronization at `246cd44e59026b8ca6fecd72336e631036015f07`.
+GitHub CI for PR #593 then passed the same protection set before merging the
+stale-tip wording cleanup at `6f0d9ec8c5289f717d668f773d2e54a8d8d9bbdb`.
 
 Root cause of the previous imported-SMT failure: the compact imported-simple IR
 builder misclassified control/non-call expressions as call thunks. In the

--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -30,6 +30,8 @@ Completed before this ledger:
   `3df24a04af6b35e4f710663accb03f9f97825b0a`.
 - PR #592 synchronized the status docs after PR #591 at
   `246cd44e59026b8ca6fecd72336e631036015f07`.
+- PR #593 removed stale live-tip wording from the status docs at
+  `6f0d9ec8c5289f717d668f773d2e54a8d8d9bbdb`.
 - `canon/madaros-greenline` is protected, force-push/delete are disabled,
   admins are enforced, strict required checks are enabled, and
   `Madaros Greenline Gate` is required.
@@ -70,13 +72,19 @@ strict-audit output to this cleanup planner.
 ## Current Blocker To `--strict`
 
 Readiness production proof is green, but the stricter worktree audit still
-reports dirty critical worktrees:
+reports dirty critical worktrees. The exact `total` and `critical_vs_base`
+counts drift as clean coordination worktrees are created or removed; the live
+authority is the repro command below. The stable blocker is still
+`unallowed_critical_dirty=19`.
+
+Sample observed after PR #593:
 
 ```text
-total=56
-dirty=36
+total=62
+dirty=37
 critical_dirty=21
 unallowed_critical_dirty=19
+critical_vs_base=48
 ```
 
 Repro command:


### PR DESCRIPTION
## Summary
- records PR #593 in the canonical Madaros status docs
- marks the cleanup-audit counts as a live snapshot instead of fixed truth
- keeps `unallowed_critical_dirty=19` as the active strict-cleanup blocker

## Local validation
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `git diff --check`

## LLM-offload
- not invoked: coordination/status docs only; no math, clinical-pathway code, or external-facing artifact changes
