### PR TITLE
docs(madaros): avoid hand-maintained PR ranges

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -23,10 +23,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.madaros-status
 > `madaros_full_gate.sh` passed with imported SMT 6/6 and wrote
 > `artifacts/self-hosted/madaros.gate-receipt`
 > (`sha256=0441113419b71ed0fa24348ae8ef0ad0f2a0ff9a38a13ada3409c283984d7d19`,
-> `smt_skip=0`). Subsequent protected-branch PRs #587-#593 were docs/tooling
-> coordination updates; PR #591 passed the required gate set for the
-> cleanup-planner evidence upgrade, PR #592 passed it for the post-#591 status
-> sync, and PR #593 passed it for stale-tip wording cleanup.
+> `smt_skip=0`). Subsequent protected-branch PRs are docs/tooling coordination
+> updates unless their PR text says otherwise; for the live merge history, run
+> `git log --oneline --merges origin/canon/madaros-greenline`.
 
 ## Madaros is the default compiler (`bin/souc` → Madaros)
 
@@ -164,10 +163,9 @@ full suite, source-bootstrap self-host, both native self-host jobs, contracts,
 lint, and website before the merge.
 GitHub CI for PR #591 passed the same required protection set before merging the
 cleanup-planner evidence upgrade at `3df24a04af6b35e4f710663accb03f9f97825b0a`.
-GitHub CI for PR #592 then passed the same protection set before merging the
-status synchronization at `246cd44e59026b8ca6fecd72336e631036015f07`.
-GitHub CI for PR #593 then passed the same protection set before merging the
-stale-tip wording cleanup at `6f0d9ec8c5289f717d668f773d2e54a8d8d9bbdb`.
+Later status-only PRs continue to advance by the same required protection set;
+use the live merge history command above for the current tip instead of relying
+on a hand-maintained PR range.
 
 Root cause of the previous imported-SMT failure: the compact imported-simple IR
 builder misclassified control/non-call expressions as call thunks. In the

--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -14,7 +14,7 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-
 This ledger is the non-destructive disposition record for the remaining
 Madaros readiness cleanup work after the protected greenline landed.
 
-Completed before this ledger:
+Key completed PRs in this ledger series:
 
 - PR #586 merged into `canon/madaros-greenline` at
   `bf46bda919596ce71b8fc35dc29cb3a31ff01d7b`.
@@ -32,6 +32,9 @@ Completed before this ledger:
   `246cd44e59026b8ca6fecd72336e631036015f07`.
 - PR #593 removed stale live-tip wording from the status docs at
   `6f0d9ec8c5289f717d668f773d2e54a8d8d9bbdb`.
+- Later status-only PRs may advance `canon/madaros-greenline`; use
+  `git log --oneline --merges origin/canon/madaros-greenline` for the live
+  merge list instead of treating this section as exhaustive.
 - `canon/madaros-greenline` is protected, force-push/delete are disabled,
   admins are enforced, strict required checks are enabled, and
   `Madaros Greenline Gate` is required.


### PR DESCRIPTION
## Summary
- removes fragile hand-maintained PR ranges from the Madaros status note
- points readers to live merge history for current `canon/madaros-greenline` tip
- keeps PR #586 and PR #591 as stable semantic anchors while status-only PRs can keep advancing

## Local validation
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `git diff --check`

## LLM-offload
- not invoked: coordination/status docs only; no math, clinical-pathway code, or external-facing artifact changes
