### PR TITLE
tools(madaros): add cleanup approval manifest

### DIFF
--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -85,6 +85,33 @@ optional `DIR.tar.gz` + sha256. It does **not** push branches, remove worktrees,
 delete files, reset, or clean; it is evidence for the operator decision, not the
 cleanup itself.
 
+After reviewing the packet, create the machine-readable approval template:
+
+```bash
+scripts/dev/madaros_worktree_cleanup_approval.sh template \
+  --plan-tsv /tmp/madaros-cleanup-plan/madaros-cleanup-plan.tsv \
+  --out-dir /tmp/madaros-cleanup-approval
+```
+
+The template defaults every row to `decision=hold`. The operator must edit rows
+to one of `approve_salvage_remove`, `approve_discard_remove`, or
+`approve_remove_clean`, and must fill `approver`, `approved_utc`, and
+`approval_id`. Validate and render the reviewed commands with:
+
+```bash
+scripts/dev/madaros_worktree_cleanup_approval.sh validate \
+  --manifest-tsv /tmp/madaros-cleanup-approval/madaros-cleanup-approval.tsv
+scripts/dev/madaros_worktree_cleanup_approval.sh render \
+  --manifest-tsv /tmp/madaros-cleanup-approval/madaros-cleanup-approval.tsv \
+  --out-dir /tmp/madaros-cleanup-approved
+```
+
+Rendered mutating commands stay commented unless the renderer is invoked with
+`--allow-mutating-output` and
+`SOUNIO_MADAROS_CLEANUP_APPROVAL=I_ACCEPT_PUSH_BEFORE_DELETE`. This preserves
+the explicit approval boundary while making the post-approval command stream
+reviewable and reproducible.
+
 ## Current Blocker To `--strict`
 
 Readiness production proof is green, but the stricter worktree audit still

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -134,6 +134,61 @@ require_salvage_packet_evidence() {
   [[ ! -e "$out_dir.tar.gz" ]] || fail "salvage packet wrote tarball despite --no-tar"
 }
 
+require_cleanup_approval_evidence() {
+  local tmp_dir audit_tsv out_dir manifest approved render_out commands actual_header expected_header validate_out
+  tmp_dir="$(mktemp -d /tmp/madaros-contract-approval.XXXXXX)"
+  audit_tsv="$tmp_dir/worktree-audit.tsv"
+  out_dir="$tmp_dir/template"
+
+  printf 'path\tbranch\thead\tupstream\tstate\tdirty_count\tahead\tbehind\tcritical_dirty\tcritical_vs_base\tpr\n' > "$audit_tsv"
+  printf '%s\tdetached\t%s\t\tdirty\t1\t0\t0\tM scripts/dev/madaros_worktree_cleanup_approval.sh\tscripts/dev/madaros_worktree_cleanup_approval.sh\t\n' \
+    "$ROOT_DIR" "$(git rev-parse --short=12 HEAD 2>/dev/null || printf unknown)" >> "$audit_tsv"
+
+  SOUNIO_MADAROS_CLEANUP_ALLOW_RE='^$' \
+    scripts/dev/madaros_worktree_cleanup_approval.sh template --audit-tsv "$audit_tsv" --out-dir "$out_dir" >/dev/null
+
+  manifest="$out_dir/madaros-cleanup-approval.tsv"
+  require_file "$manifest"
+
+  expected_header='decision	approver	approved_utc	approval_id	category	path	branch	head	state	dirty_count	remote_ref	salvage_ref	disposition	critical_dirty	critical_vs_base	operator_note'
+  IFS= read -r actual_header < "$manifest"
+  [[ "$actual_header" == "$expected_header" ]] ||
+    fail "cleanup approval template header drifted: $actual_header"
+
+  validate_out="$(scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv "$manifest")"
+  grep -Fq 'actionable_rows=0' <<<"$validate_out" ||
+    fail "cleanup approval default template should have zero actionable rows"
+
+  approved="$tmp_dir/approved.tsv"
+  awk -F '\t' 'BEGIN { OFS = "\t" }
+    NR == 1 { print; next }
+    NR == 2 {
+      $1 = "approve_salvage_remove"
+      $2 = "operator"
+      $3 = "2026-07-03T00:00:00Z"
+      $4 = "APPROVAL-fixture"
+      $16 = "fixture approval row"
+    }
+    { print }
+  ' "$manifest" > "$approved"
+
+  validate_out="$(scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv "$approved")"
+  grep -Fq 'actionable_rows=1' <<<"$validate_out" ||
+    fail "cleanup approval approved fixture should have one actionable row"
+
+  render_out="$tmp_dir/render"
+  scripts/dev/madaros_worktree_cleanup_approval.sh render --manifest-tsv "$approved" --out-dir "$render_out" >/dev/null
+  commands="$render_out/madaros-cleanup-approved.commands.sh"
+  require_file "$commands"
+  require_grep '# git push origin' "$commands"
+  require_grep '# git worktree remove' "$commands"
+  require_no_uncommented_mutation "$commands"
+
+  if scripts/dev/madaros_worktree_cleanup_approval.sh render --manifest-tsv "$approved" --out-dir "$tmp_dir/blocked" --allow-mutating-output >/dev/null 2>&1; then
+    fail "cleanup approval render allowed mutating output without confirmation token"
+  fi
+}
+
 require_no_uncommented_mutation() {
   local plan_sh="$1"
   awk '
@@ -159,6 +214,7 @@ require_file scripts/ci/madaros_full_gate.sh
 require_file scripts/ci/madaros_source_to_elf_gate.sh
 require_executable scripts/dev/madaros_two_gate.sh
 require_executable scripts/dev/madaros_worktree_cleanup_plan.sh
+require_executable scripts/dev/madaros_worktree_cleanup_approval.sh
 require_executable scripts/dev/madaros_worktree_salvage_packet.sh
 require_file .github/workflows/ci.yml
 
@@ -226,9 +282,12 @@ require_grep 'unique_commits_origin_main' scripts/dev/madaros_worktree_cleanup_p
 require_grep 'tracked_diff_added' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'critical_vs_base' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep '# evidence=origin_main_unique:' scripts/dev/madaros_worktree_cleanup_plan.sh
+require_grep 'cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_approval.sh' scripts/dev/madaros_readiness_status.sh
+require_grep 'I_ACCEPT_PUSH_BEFORE_DELETE' scripts/dev/madaros_worktree_cleanup_approval.sh
 require_grep 'tracked/staged binary diffs' scripts/dev/madaros_worktree_salvage_packet.sh
 require_grep 'No branches pushed or worktrees removed' scripts/dev/madaros_worktree_salvage_packet.sh
 require_cleanup_planner_evidence
+require_cleanup_approval_evidence
 require_salvage_packet_evidence
 
 echo "[madaros-contract] PASS: status doc, agent contract, default wrapper, and gate wiring are aligned"

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -480,6 +480,7 @@ if [[ "$RUN_AUDIT" == "1" ]]; then
     env SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE:-$audit_allow_default}" \
       scripts/dev/worktree_branch_audit.sh --check "$audit_out"
   echo "cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-plan"
+  echo "cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_approval.sh template --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-approval"
 fi
 
 if [[ "$CHECK_COMPILER_LANE" == "1" ]]; then
@@ -576,6 +577,7 @@ Integration shepherd:
   scripts/ci/madaros_blocker_contract_gate.sh
   scripts/dev/madaros_readiness_status.sh --strict
   scripts/dev/madaros_worktree_cleanup_plan.sh
+  scripts/dev/madaros_worktree_cleanup_approval.sh template --plan-tsv /tmp/madaros-cleanup-plan/madaros-cleanup-plan.tsv --out-dir /tmp/madaros-cleanup-approval
   scripts/dev/madaros_readiness_status.sh --check-compiler-pr-overlap
   scripts/dev/madaros_readiness_status.sh --check-pr-resolution-queue
   scripts/dev/madaros_readiness_status.sh --production-ready

--- a/scripts/dev/madaros_worktree_cleanup_approval.sh
+++ b/scripts/dev/madaros_worktree_cleanup_approval.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MODE="${1:-}"
+if [[ -n "$MODE" ]]; then
+  shift
+fi
+
+OUT_DIR=""
+PLAN_TSV=""
+AUDIT_TSV=""
+MANIFEST_TSV=""
+ALLOW_MUTATING_OUTPUT=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/dev/madaros_worktree_cleanup_approval.sh template [options]
+  scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv FILE
+  scripts/dev/madaros_worktree_cleanup_approval.sh render --manifest-tsv FILE [options]
+
+Create and validate a machine-readable approval manifest for Madaros worktree
+cleanup. This script is non-destructive: it never runs git push, git reset,
+git clean, git branch -D, or git worktree remove. The render mode writes a
+commands file for operator review; mutating commands stay commented unless both
+--allow-mutating-output and SOUNIO_MADAROS_CLEANUP_APPROVAL=I_ACCEPT_PUSH_BEFORE_DELETE
+are set.
+
+Modes:
+  template           write madaros-cleanup-approval.tsv from the cleanup plan
+  validate           validate an edited approval manifest
+  render             validate and render post-approval commands
+
+Options:
+  --out-dir DIR       write outputs under DIR (default: mktemp /tmp dir)
+  --plan-tsv PATH     use an existing madaros-cleanup-plan.tsv
+  --audit-tsv PATH    pass an existing worktree audit TSV through the cleanup
+                      planner before building the approval template
+  --manifest-tsv PATH approval TSV for validate/render
+  --allow-mutating-output
+                      render uncommented mutating commands only with the
+                      SOUNIO_MADAROS_CLEANUP_APPROVAL confirmation token
+  -h, --help          show this help
+
+Manifest decisions:
+  hold                    default; no cleanup action
+  approve_salvage_remove  archive/salvage first, then remove
+  approve_discard_remove  save patch evidence, then discard/remove
+  approve_remove_clean    remove only if the row is clean in the source plan
+USAGE
+}
+
+if [[ -z "$MODE" || "$MODE" == "-h" || "$MODE" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+while (($#)); do
+  case "$1" in
+    --out-dir)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --out-dir requires a directory" >&2
+        exit 2
+      fi
+      OUT_DIR="$1"
+      ;;
+    --plan-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --plan-tsv requires a path" >&2
+        exit 2
+      fi
+      PLAN_TSV="$1"
+      ;;
+    --audit-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --audit-tsv requires a path" >&2
+        exit 2
+      fi
+      AUDIT_TSV="$1"
+      ;;
+    --manifest-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --manifest-tsv requires a path" >&2
+        exit 2
+      fi
+      MANIFEST_TSV="$1"
+      ;;
+    --allow-mutating-output)
+      ALLOW_MUTATING_OUTPUT=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+case "$MODE" in
+  template|validate|render) ;;
+  *)
+    echo "error: unknown mode: $MODE" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="$(mktemp -d /tmp/madaros-cleanup-approval.XXXXXX)"
+fi
+mkdir -p "$OUT_DIR"
+
+approval_header() {
+  printf 'decision\tapprover\tapproved_utc\tapproval_id\tcategory\tpath\tbranch\thead\tstate\tdirty_count\tremote_ref\tsalvage_ref\tdisposition\tcritical_dirty\tcritical_vs_base\toperator_note\n'
+}
+
+expected_approval_header="$(approval_header)"
+
+ensure_plan() {
+  if [[ -n "$PLAN_TSV" && -n "$AUDIT_TSV" ]]; then
+    echo "error: use either --plan-tsv or --audit-tsv, not both" >&2
+    exit 2
+  fi
+
+  if [[ -n "$PLAN_TSV" ]]; then
+    [[ -f "$PLAN_TSV" ]] || {
+      echo "error: plan TSV not found: $PLAN_TSV" >&2
+      exit 2
+    }
+    plan_abs="$(cd "$(dirname "$PLAN_TSV")" && pwd)/$(basename "$PLAN_TSV")"
+    plan_target="$(cd "$OUT_DIR" && pwd)/madaros-cleanup-plan.tsv"
+    if [[ "$plan_abs" != "$plan_target" ]]; then
+      cp "$PLAN_TSV" "$plan_target"
+    fi
+    PLAN_TSV="$plan_target"
+    return 0
+  fi
+
+  cleanup_args=(--out-dir "$OUT_DIR")
+  if [[ -n "$AUDIT_TSV" ]]; then
+    [[ -f "$AUDIT_TSV" ]] || {
+      echo "error: audit TSV not found: $AUDIT_TSV" >&2
+      exit 2
+    }
+    cleanup_args+=(--audit-tsv "$AUDIT_TSV")
+  fi
+  scripts/dev/madaros_worktree_cleanup_plan.sh "${cleanup_args[@]}" \
+    > "$OUT_DIR/cleanup-planner.stdout"
+  PLAN_TSV="$OUT_DIR/madaros-cleanup-plan.tsv"
+}
+
+slug_for_path() {
+  basename "$1" | sed 's/[^A-Za-z0-9._-]\+/-/g; s/^-//; s/-$//'
+}
+
+write_template() {
+  ensure_plan
+  manifest="$OUT_DIR/madaros-cleanup-approval.tsv"
+  {
+    approval_header
+    awk -F '\t' 'BEGIN { OFS = "\t" }
+      NR > 1 {
+        decision = "hold"
+        approver = "TODO"
+        approved_utc = "TODO"
+        approval_id = "TODO"
+        category = $1
+        path = $2
+        branch = $3
+        head = $4
+        state = $6
+        dirty_count = $7
+        remote_ref = $10
+        salvage_ref = $19
+        critical_dirty = $20
+        critical_vs_base = $21
+        disposition = $22
+        operator_note = "TODO"
+        print decision, approver, approved_utc, approval_id, category, path,
+          branch, head, state, dirty_count, remote_ref, salvage_ref, disposition,
+          critical_dirty, critical_vs_base, operator_note
+      }
+    ' "$PLAN_TSV"
+  } > "$manifest"
+  echo "approval_manifest=$manifest"
+  echo "plan_tsv=$PLAN_TSV"
+  echo "edit_decisions=hold|approve_salvage_remove|approve_discard_remove|approve_remove_clean"
+}
+
+validate_manifest() {
+  [[ -n "$MANIFEST_TSV" ]] || {
+    echo "error: --manifest-tsv is required" >&2
+    exit 2
+  }
+  [[ -f "$MANIFEST_TSV" ]] || {
+    echo "error: approval manifest not found: $MANIFEST_TSV" >&2
+    exit 2
+  }
+
+  local actual_header
+  IFS= read -r actual_header < "$MANIFEST_TSV"
+  [[ "$actual_header" == "$expected_approval_header" ]] || {
+    echo "error: approval manifest header drifted: $actual_header" >&2
+    exit 1
+  }
+
+  awk -F '\t' '
+    NR == 1 { next }
+    NF != 16 {
+      printf "error: row %d has %d fields, expected 16\n", NR, NF > "/dev/stderr"
+      failed = 1
+      next
+    }
+    $1 != "hold" &&
+    $1 != "approve_salvage_remove" &&
+    $1 != "approve_discard_remove" &&
+    $1 != "approve_remove_clean" {
+      printf "error: row %d has invalid decision: %s\n", NR, $1 > "/dev/stderr"
+      failed = 1
+    }
+    $6 == "" {
+      printf "error: row %d missing path\n", NR > "/dev/stderr"
+      failed = 1
+    }
+    $1 != "hold" {
+      actionable++
+      if ($2 == "" || $2 == "TODO") {
+        printf "error: row %d approved decision lacks approver\n", NR > "/dev/stderr"
+        failed = 1
+      }
+      if ($3 !~ /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/) {
+        printf "error: row %d approved decision needs approved_utc=YYYY-MM-DDTHH:MM:SSZ\n", NR > "/dev/stderr"
+        failed = 1
+      }
+      if ($4 !~ /^APPROVAL-[A-Za-z0-9._:-]+$/) {
+        printf "error: row %d approved decision needs approval_id=APPROVAL-...\n", NR > "/dev/stderr"
+        failed = 1
+      }
+      if ($1 == "approve_remove_clean" && ($9 != "clean" || $10 != "0")) {
+        printf "error: row %d approve_remove_clean requires state=clean dirty_count=0\n", NR > "/dev/stderr"
+        failed = 1
+      }
+      if ($1 == "approve_salvage_remove" && $12 !~ /^archive\/madaros-/) {
+        printf "error: row %d approve_salvage_remove needs archive/madaros-* salvage_ref\n", NR > "/dev/stderr"
+        failed = 1
+      }
+    }
+    END {
+      if (failed) {
+        exit 1
+      }
+      rows = NR > 0 ? NR - 1 : 0
+      printf "approval_rows=%d\n", rows
+      printf "actionable_rows=%d\n", actionable + 0
+    }
+  ' "$MANIFEST_TSV"
+}
+
+render_line() {
+  local line="$1"
+  local mutating="${2:-0}"
+  if [[ "$mutating" == "1" && "$ALLOW_MUTATING_OUTPUT" != "1" ]]; then
+    printf '# %s\n' "$line"
+  else
+    printf '%s\n' "$line"
+  fi
+}
+
+render_commands() {
+  validate_manifest >/dev/null
+  if [[ "$ALLOW_MUTATING_OUTPUT" == "1" && "${SOUNIO_MADAROS_CLEANUP_APPROVAL:-}" != "I_ACCEPT_PUSH_BEFORE_DELETE" ]]; then
+    echo "error: --allow-mutating-output requires SOUNIO_MADAROS_CLEANUP_APPROVAL=I_ACCEPT_PUSH_BEFORE_DELETE" >&2
+    exit 2
+  fi
+
+  commands="$OUT_DIR/madaros-cleanup-approved.commands.sh"
+  {
+    cat <<'HEADER'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generated by scripts/dev/madaros_worktree_cleanup_approval.sh render.
+# Review before running. Mutating commands are commented unless the renderer was
+# explicitly invoked with --allow-mutating-output and the approval env token.
+
+HEADER
+    awk -F '\t' 'NR > 1 { print }' "$MANIFEST_TSV" | while IFS=$'\t' read -r decision approver approved_utc approval_id category path branch head state dirty_count remote_ref salvage_ref disposition critical_dirty critical_vs_base operator_note; do
+      path_q="$(printf '%q' "$path")"
+      branch_q="$(printf '%q' "$branch")"
+      salvage_q="$(printf '%q' "$salvage_ref")"
+      slug="$(slug_for_path "$path")"
+      patch_q="$(printf '%q' "/tmp/${slug}.approved-cleanup.patch")"
+
+      echo "# path=$path"
+      echo "# decision=$decision approver=$approver approved_utc=$approved_utc approval_id=$approval_id"
+      echo "# category=$category state=$state dirty_count=$dirty_count remote_ref=$remote_ref"
+      echo "# disposition=$disposition"
+      if [[ -n "$operator_note" ]]; then
+        echo "# operator_note=$operator_note"
+      fi
+      render_line "git -C $path_q status --short --branch"
+      render_line "git -C $path_q diff --stat"
+
+      case "$decision" in
+        hold)
+          echo "# no cleanup action approved for this row"
+          ;;
+        approve_salvage_remove)
+          render_line "git -C $path_q diff --binary > $patch_q"
+          if [[ "$branch" == "detached" ]]; then
+            render_line "git -C $path_q switch -c $salvage_q" 1
+            render_line "git push origin $salvage_q" 1
+          else
+            render_line "git push origin HEAD:refs/heads/$salvage_q" 1
+          fi
+          render_line "git worktree remove $path_q" 1
+          if [[ "$branch" != "detached" ]]; then
+            render_line "git branch -D $branch_q" 1
+          fi
+          ;;
+        approve_discard_remove)
+          render_line "git -C $path_q diff --binary > $patch_q"
+          render_line "git worktree remove --force $path_q" 1
+          if [[ "$branch" != "detached" ]]; then
+            render_line "git branch -D $branch_q" 1
+          fi
+          ;;
+        approve_remove_clean)
+          render_line "git worktree remove $path_q" 1
+          if [[ "$branch" != "detached" ]]; then
+            render_line "git branch -d $branch_q" 1
+          fi
+          ;;
+      esac
+      echo
+    done
+  } > "$commands"
+  chmod +x "$commands"
+  echo "approval_commands=$commands"
+  if [[ "$ALLOW_MUTATING_OUTPUT" == "1" ]]; then
+    echo "mutating_output=enabled"
+  else
+    echo "mutating_output=commented"
+  fi
+}
+
+case "$MODE" in
+  template)
+    write_template
+    ;;
+  validate)
+    validate_manifest
+    ;;
+  render)
+    render_commands
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add a non-destructive cleanup approval manifest tool with template/validate/render modes
- wire readiness strict output to emit a cleanup_approval_command after the cleanup_plan_command
- extend the operational contract gate to verify approval template shape, approved-row validation, commented render output, and token-gated mutating render output
- document the plan -> salvage packet -> approval manifest -> rendered commands flow in the cleanup ledger

## Validation
- bash -n scripts/dev/madaros_worktree_cleanup_approval.sh scripts/ci/madaros_operational_contract_gate.sh scripts/dev/madaros_readiness_status.sh
- fixture: template -> validate hold -> edit approve_salvage_remove -> validate -> render -> token refusal
- fixture: token-enabled render writes uncommented commands but does not execute them
- bash scripts/ci/madaros_operational_contract_gate.sh
- bash scripts/dev/check_docs_consistency.sh
- bash scripts/dev/check_docs_registry.sh
- git diff --check
- scripts/dev/madaros_readiness_status.sh --strict still fails only on unallowed_critical_dirty=19 and now prints cleanup_approval_command

## Notes
This PR does not approve cleanup and does not remove, push, reset, clean, or delete any worktree. It makes the post-approval decision machine-readable and reviewable.