### PR TITLE
fix(stdlib): full audit fix for ode.sio — closes #580

### DIFF
--- a/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
+++ b/docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md
@@ -467,3 +467,76 @@ untouched, out of this issue's scope.
 Verified against a freshly rebuilt `lean_single`: all 3 kinetics-cluster tests plus the
 other 18 tests fixed this week still pass (21 total, zero regressions). Madaros shows
 the same pre-existing E011 divergence already documented above — not new.
+
+## Update 2026-07-03 (continued): issue #580 (ode.sio audit) — one more severe new bug found, this week's audit chain closed
+
+Picked up issue #580 (`stdlib/epistemic/ode.sio` had ~14 pre-existing, non-fatal
+errors — the last item in this whole audit chain). All fixed; the file now checks with
+zero real errors (only the expected "no main" library-file artifact).
+
+**5 "effect not declared in function signature"** — `estate_set` (mutates `s.values`/
+`s.variances`, needed `Mut`, never declared), `ode_params_set` (same shape), and
+`print_uncertainty_budget` (needed `Mut` alongside its existing `with IO` — the
+"missing" effect wasn't obvious from the error text alone; found by testing `Mut`
+directly, matching this week's most common gap). Ordinary test-authoring omissions
+(#571's shape), not checker bugs.
+
+**Bug H — a `*ref = ...` dereference-assignment lexically following an earlier
+function-call statement in the same function corrupts lean_single's type inference for
+that assignment, even for a pure literal write with no arithmetic.** By far the most
+severe bug found this week — it isn't specific to arithmetic, tuples, qualified paths,
+or literals; it's about control flow shape. Isolated progressively with minimal repros
+outside stdlib:
+```sio
+fn noop() -> i64 { 0 }
+fn write_only(n: &!i64) with Mut {
+    noop()
+    *n = 999          // error: arithmetic operands must have matching numeric types
+}                      // (a LITERAL write, no arithmetic operator anywhere in source)
+```
+`*n = 999` as the function's *first* statement (no preceding call) works fine. Reading
+`*n` into a local *before* any call, then using the local, works fine. A plain `var`
+counter (not a dereferenced reference) increments correctly after any number of
+preceding calls. Only a dereference EXPRESSION (`*ref`, read or write) appearing
+textually after an earlier call statement, in the same function, is corrupted — and the
+call itself needn't touch the reference in question, or take any arguments at all
+(`noop()` takes none). The fix: extract the dereference-assignment into its own tiny
+function, called as an ordinary statement from the outer function:
+```sio
+fn bump_n(n: &!i64) with Mut { *n = *n + 1 }     // safe: this IS its first statement
+fn outer(n: &!i64) with Mut {
+    noop()
+    bump_n(n)        // fine — the deref lives inside bump_n, not here
+}
+```
+Applied this exact pattern to `stdlib/epistemic/ode.sio`'s `rk4_step` and `rk45_step`,
+which call `ode_rhs_dispatch(...)` 4-6 times each, incrementing a `n_evals: &!i64`
+counter inline after every call (`*n_evals = *n_evals + 1`, 10 total sites across both
+functions) — extracted to a shared `bump_n_evals(n: &!i64)` helper, called instead of
+the inline dereference at each site.
+
+**Why this didn't already break `compute_jacobian_state`/`compute_jacobian_params`**,
+which use the identical `*n_evals = *n_evals + 2` pattern and share the same parameter
+name: their increment sites are the *first* dereference of `n_evals` reached inside a
+nested loop body that itself contains the preceding `ode_rhs_dispatch`-family calls —
+still technically "after a call", so this is likely a difference in exactly which
+prior-call/prior-deref sequences trigger the corruption rather than a clean rule; not
+fully characterized. Left untouched since they don't currently error — flagging here so
+a future compiler-side fix attempt knows this pair exists as a "control" case that
+currently passes.
+
+**Result:** `stdlib/epistemic/ode.sio` now checks with zero errors (previously 14, plus
+5 more effect-annotation gaps found once those were fixed first and the arithmetic
+errors could be isolated cleanly). `stdlib/chemistry/kinetics.sio`'s own residual error
+count (tracked separately, non-fatal, unrelated to this issue) is unchanged by this fix.
+
+This closes out the full audit chain opened by issue #575: every file transitively
+reachable from `tests/stdlib/chemistry/test_kinetics_core.sio` now checks clean, and
+`Full Test Suite` CI reached 0 failures for the first time this week (1310 pass) as of
+this issue's merge — `Contracts` (previously failing since before this week's work
+began, via an unrelated specialized ontology-validation driver) also went green,
+apparently as a side effect of `ontology.sio`'s cleanup in the #579 update above.
+
+Verified against a freshly rebuilt `lean_single`: all 21 tests fixed this week still
+pass, zero regressions. Madaros shows the same pre-existing E011 divergence already
+documented above — not new.

--- a/stdlib/epistemic/ode.sio
+++ b/stdlib/epistemic/ode.sio
@@ -83,7 +83,7 @@ fn estate_new(n: i64) -> EState {
     }
 }
 
-fn estate_set(s: &!EState, idx: i64, val: f64, var_: f64) {
+fn estate_set(s: &!EState, idx: i64, val: f64, var_: f64) with Mut {
     if idx >= 0 && idx < 64 {
         s.values[idx] = val
         s.variances[idx] = var_
@@ -147,7 +147,7 @@ fn ode_params_new() -> ODEParams {
     }
 }
 
-fn ode_params_set(p: &!ODEParams, idx: i64, val: f64, var_: f64) {
+fn ode_params_set(p: &!ODEParams, idx: i64, val: f64, var_: f64) with Mut {
     if idx >= 0 && idx < 64 {
         p.params[idx] = val
         p.param_variances[idx] = var_
@@ -823,6 +823,17 @@ fn propagate_variance_gum(
 // General-Purpose RK4 Step
 // ============================================================================
 
+// `*n = *n + 1` written inline after an earlier function-call statement in the
+// same function corrupts lean_single's type inference for that dereference
+// assignment ("arithmetic operands must have matching numeric types", even for
+// a pure literal write with no arithmetic at all — isolated with a minimal
+// repro outside stdlib). Extracting the read-modify-write into its own
+// function sidesteps it: the bump happens as that function's first and only
+// statement, which is unaffected.
+fn bump_n_evals(n: &!i64) with Mut {
+    *n = *n + 1
+}
+
 fn rk4_step(
     sys: &ODESystem,
     t: f64,
@@ -840,22 +851,22 @@ fn rk4_step(
 
     // k1 = f(t, y)
     ode_rhs_dispatch(sys, t, state, p, &!k1)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // k2 = f(t + dt/2, y + dt/2 * k1)
     estate_axpy(&!tmp, state, 0.5 * dt, &k1)
     ode_rhs_dispatch(sys, t + 0.5 * dt, &tmp, p, &!k2)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // k3 = f(t + dt/2, y + dt/2 * k2)
     estate_axpy(&!tmp, state, 0.5 * dt, &k2)
     ode_rhs_dispatch(sys, t + 0.5 * dt, &tmp, p, &!k3)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // k4 = f(t + dt, y + dt * k3)
     estate_axpy(&!tmp, state, dt, &k3)
     ode_rhs_dispatch(sys, t + dt, &tmp, p, &!k4)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // y_{n+1} = y_n + (dt/6) * (k1 + 2*k2 + 2*k3 + k4)
     var i = 0
@@ -902,12 +913,12 @@ fn rk45_step(
 
     // Stage 1
     ode_rhs_dispatch(sys, t, state, p, &!k1)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // Stage 2: t + dt/5, y + dt*(1/5)*k1
     estate_axpy(&!tmp, state, dt * 0.2, &k1)
     ode_rhs_dispatch(sys, t + 0.2 * dt, &tmp, p, &!k2)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // Stage 3: t + 3dt/10, y + dt*(3/40*k1 + 9/40*k2)
     var i = 0
@@ -918,7 +929,7 @@ fn rk45_step(
         i = i + 1
     }
     ode_rhs_dispatch(sys, t + 0.3 * dt, &tmp, p, &!k3)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // Stage 4: t + 4dt/5, y + dt*(44/45*k1 - 56/15*k2 + 32/9*k3)
     i = 0
@@ -931,7 +942,7 @@ fn rk45_step(
         i = i + 1
     }
     ode_rhs_dispatch(sys, t + 0.8 * dt, &tmp, p, &!k4)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // Stage 5: t + 8dt/9
     i = 0
@@ -945,7 +956,7 @@ fn rk45_step(
         i = i + 1
     }
     ode_rhs_dispatch(sys, t + 0.888888888888889 * dt, &tmp, p, &!k5)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // Stage 6: t + dt
     i = 0
@@ -960,7 +971,7 @@ fn rk45_step(
         i = i + 1
     }
     ode_rhs_dispatch(sys, t + dt, &tmp, p, &!k6)
-    *n_evals = *n_evals + 1
+    bump_n_evals(n_evals)
 
     // 5th-order solution (used as the step)
     // b5 = [142/1105, 0, 6570212/46116585, 22482/69174, 8028/28325, -8192/34125]
@@ -1386,7 +1397,7 @@ fn gate_bpr(conf: f64, min_conf: f64) -> EpistemicGate {
 //   ISO 17025:2017 §7.8.2 — "Calibration certificate content"
 // ============================================================================
 
-fn print_uncertainty_budget(budget: &UncertaintyBudget) with IO {
+fn print_uncertainty_budget(budget: &UncertaintyBudget) with IO, Mut {
     println("  === ISO GUM Uncertainty Budget (JCGM 100:2008 §8) ===")
     println("  Dimension | σ_initial | σ_final   | Growth ratio")
     println("  ---------------------------------------------------------")


### PR DESCRIPTION
## Summary
Closes issue #580: `stdlib/epistemic/ode.sio` had 14 pre-existing, non-fatal errors (never fully validated by lean_single) — the last item in this week's audit chain opened by issue #575. All fixed, file now checks with zero real errors.

- **5 "effect not declared in function signature"**: `estate_set`/`ode_params_set` needed `with Mut` (array mutation, never declared); `print_uncertainty_budget` needed `Mut` alongside its existing `IO`. Ordinary test-authoring omissions (#571's shape), not checker bugs.

**New checker bug found and isolated (documented as "Bug H", the most severe found this week):** a `*ref = ...` dereference-assignment lexically following an earlier function-call statement in the same function corrupts lean_single's type inference for that assignment — even for a pure literal write with no arithmetic at all. Not specific to arithmetic, tuples, or literals — a control-flow-shape bug:

```sio
fn noop() -> i64 { 0 }
fn write_only(n: &!i64) with Mut {
    noop()
    *n = 999          // error: arithmetic operands must have matching numeric types
}                      // (a pure literal write, no arithmetic operator anywhere!)
```

`*n = 999` as a function's first statement works; reading `*n` into a local before any call works; a plain `var` counter survives any number of preceding calls. Only a dereference expression appearing after an earlier call in the SAME function is corrupted, regardless of what that call does. Workaround: extract the dereference-assignment into its own tiny function — the deref becomes that function's first statement, which is safe. Applied to `rk4_step`/`rk45_step` (10 sites) via a shared `bump_n_evals(n: &!i64)` helper.

Noted (not investigated further): `compute_jacobian_state`/`compute_jacobian_params` use the identical pattern and share the same parameter name, yet don't currently error — flagged as a "control" case for a future compiler-side fix attempt.

## Milestone
This closes the full audit chain from #575: every file transitively reachable from `test_kinetics_core.sio` now checks clean. Full Test Suite CI reached 0 failures this week as of this chain's merges; `Contracts` (failing since before this week's work) also went green, apparently a side effect of #579's ontology.sio cleanup.

## Test plan
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path).
- [x] All 21 tests fixed this week still pass via `scripts/run_sio_test_suite.sh --filter`, zero regressions.
- [x] Madaros shows the same pre-existing E011 divergence already documented for equilibrium.sio/acids.sio — inherited, not new.

Closes #580.