### PR TITLE
ci(madaros): run greenline checks after canon merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, canon/madaros-greenline]
   workflow_dispatch:
 
 jobs:

--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -93,7 +93,9 @@ as `bin/souc-lean-single-x86_64`.
   `Source-Bootstrap Self-Host (Linux x86_64)`, `Website`, and
   `Madaros Greenline Gate`. Review approvals are set to `0` because the repo
   currently exposes only the PR author as collaborator; the enforced lock is
-  PR+checks.
+  PR+checks. The `CI` workflow also runs on pushes to
+  `canon/madaros-greenline`, so the protected branch tip gets the same named
+  status contexts after merge instead of relying only on the pre-merge PR run.
 
 ## Cross-lane TODOs
 


### PR DESCRIPTION
## Summary
- run the main CI workflow on pushes to `canon/madaros-greenline`, not only `main`
- document that the protected canon branch tip receives the same named status contexts after merge

## Verification
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `git diff --check`

## Notes
This is a control-plane hardening patch only. No compiler semantics, math/GUM claims, or cleanup removals are changed.