### PR TITLE
tools(madaros): allow approved active cleanup lanes

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -169,6 +169,13 @@ Later status-only PRs continue to advance by the same required protection set;
 use the live merge history command above for the current tip instead of relying
 on a hand-maintained PR range.
 
+For worktree hygiene, `scripts/dev/madaros_worktree_cleanup_approval.sh`
+supports `approve_keep_active_allowlist` rows in reviewed approval manifests.
+Those rows require the normal approver fields, render no cleanup commands, and
+can be passed to `scripts/dev/madaros_readiness_status.sh --strict` via
+`SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST=<manifest.tsv>` so active owned
+lanes are explicit instead of hidden inside a broad regex.
+
 Root cause of the previous imported-SMT failure: the compact imported-simple IR
 builder misclassified control/non-call expressions as call thunks. In the
 minimal `use theorem::smt::*` repro, it first emitted a `kind=1` call target for

--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -94,9 +94,13 @@ scripts/dev/madaros_worktree_cleanup_approval.sh template \
 ```
 
 The template defaults every row to `decision=hold`. The operator must edit rows
-to one of `approve_salvage_remove`, `approve_discard_remove`, or
-`approve_remove_clean`, and must fill `approver`, `approved_utc`, and
-`approval_id`. Validate and render the reviewed commands with:
+to one of `approve_salvage_remove`, `approve_discard_remove`,
+`approve_remove_clean`, or `approve_keep_active_allowlist`, and must fill
+`approver`, `approved_utc`, and `approval_id`. `approve_keep_active_allowlist`
+means "this dirty worktree remains a live owned lane"; it is valid approval
+metadata for readiness/audit allowlisting, but the renderer emits only
+inspection commands and no cleanup/push/remove commands for that row. Validate
+and render the reviewed commands with:
 
 ```bash
 scripts/dev/madaros_worktree_cleanup_approval.sh validate \
@@ -111,6 +115,20 @@ Rendered mutating commands stay commented unless the renderer is invoked with
 `SOUNIO_MADAROS_CLEANUP_APPROVAL=I_ACCEPT_PUSH_BEFORE_DELETE`. This preserves
 the explicit approval boundary while making the post-approval command stream
 reviewable and reproducible.
+
+To make approved active lanes count as allowed in the strict readiness audit,
+reuse the same reviewed manifest:
+
+```bash
+SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST=/tmp/madaros-cleanup-approval/madaros-cleanup-approval.tsv \
+  scripts/dev/madaros_readiness_status.sh --strict
+```
+
+Rows are allowed by exact worktree path only when their decision is
+`approve_keep_active_allowlist` and the approval manifest validates. The legacy
+regex allowlist (`SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE`, or
+`SOUNIO_MADAROS_CLEANUP_ALLOW_RE` through readiness) remains a union fallback
+for operator-controlled anchored path patterns.
 
 ## Current Blocker To `--strict`
 

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -168,13 +168,19 @@ require_cleanup_approval_evidence() {
       $3 = "2026-07-03T00:00:00Z"
       $4 = "APPROVAL-fixture"
       $16 = "fixture approval row"
+      print
+      $1 = "approve_keep_active_allowlist"
+      $4 = "APPROVAL-fixture-keep-active"
+      $16 = "fixture keep-active allowlist row"
+      print
+      next
     }
     { print }
   ' "$manifest" > "$approved"
 
   validate_out="$(scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv "$approved")"
-  grep -Fq 'actionable_rows=1' <<<"$validate_out" ||
-    fail "cleanup approval approved fixture should have one actionable row"
+  grep -Fq 'actionable_rows=2' <<<"$validate_out" ||
+    fail "cleanup approval approved fixture should have two actionable rows"
 
   render_out="$tmp_dir/render"
   scripts/dev/madaros_worktree_cleanup_approval.sh render --manifest-tsv "$approved" --out-dir "$render_out" >/dev/null
@@ -182,6 +188,8 @@ require_cleanup_approval_evidence() {
   require_file "$commands"
   require_grep '# git push origin' "$commands"
   require_grep '# git worktree remove' "$commands"
+  require_grep 'decision=approve_keep_active_allowlist' "$commands"
+  require_grep 'keep-active allowlist approved; no cleanup action rendered' "$commands"
   require_no_uncommented_mutation "$commands"
 
   if scripts/dev/madaros_worktree_cleanup_approval.sh render --manifest-tsv "$approved" --out-dir "$tmp_dir/blocked" --allow-mutating-output >/dev/null 2>&1; then
@@ -276,6 +284,7 @@ require_grep 'bin/madaros-linux-x86_64' bin/souc
 require_grep 'exec env MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros"' bin/souc
 require_grep 'artifacts/self-hosted/madaros.gate-receipt' .gitignore
 require_grep 'cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh' scripts/dev/madaros_readiness_status.sh
+require_grep 'audit_allow_manifest_decision=approve_keep_active_allowlist' scripts/dev/madaros_readiness_status.sh
 require_grep 'git push, git reset, git clean, git branch -D' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'owner confirmation required before any archive, push, or removal' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'unique_commits_origin_main' scripts/dev/madaros_worktree_cleanup_plan.sh
@@ -284,6 +293,8 @@ require_grep 'critical_vs_base' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep '# evidence=origin_main_unique:' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_approval.sh' scripts/dev/madaros_readiness_status.sh
 require_grep 'I_ACCEPT_PUSH_BEFORE_DELETE' scripts/dev/madaros_worktree_cleanup_approval.sh
+require_grep 'approve_keep_active_allowlist' scripts/dev/madaros_worktree_cleanup_approval.sh
+require_grep 'SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST' scripts/dev/worktree_branch_audit.sh
 require_grep 'tracked/staged binary diffs' scripts/dev/madaros_worktree_salvage_packet.sh
 require_grep 'No branches pushed or worktrees removed' scripts/dev/madaros_worktree_salvage_packet.sh
 require_cleanup_planner_evidence

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -475,10 +475,22 @@ fi
 if [[ "$RUN_AUDIT" == "1" ]]; then
   section "Worktree Audit"
   audit_allow_default="^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b|$ROOT_DIR)$"
+  audit_allow_re="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE:-${SOUNIO_MADAROS_CLEANUP_ALLOW_RE:-$audit_allow_default}}"
+  audit_allow_manifest="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST:-}"
   audit_out="${SOUNIO_MADAROS_READINESS_AUDIT_OUT:-$(mktemp /tmp/sounio-madaros-readiness-audit.XXXXXX.tsv)}"
+  echo "audit_allow_regex=$audit_allow_re"
+  if [[ -n "$audit_allow_manifest" ]]; then
+    echo "audit_allow_manifest=$audit_allow_manifest"
+    echo "audit_allow_manifest_decision=approve_keep_active_allowlist"
+  else
+    echo "audit_allow_manifest=<unset>"
+  fi
+  audit_env=(env "SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE=$audit_allow_re")
+  if [[ -n "$audit_allow_manifest" ]]; then
+    audit_env+=("SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST=$audit_allow_manifest")
+  fi
   run_status_command audit \
-    env SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE:-$audit_allow_default}" \
-      scripts/dev/worktree_branch_audit.sh --check "$audit_out"
+    "${audit_env[@]}" scripts/dev/worktree_branch_audit.sh --check "$audit_out"
   echo "cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-plan"
   echo "cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_approval.sh template --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-approval"
 fi

--- a/scripts/dev/madaros_worktree_cleanup_approval.sh
+++ b/scripts/dev/madaros_worktree_cleanup_approval.sh
@@ -50,6 +50,9 @@ Manifest decisions:
   approve_salvage_remove  archive/salvage first, then remove
   approve_discard_remove  save patch evidence, then discard/remove
   approve_remove_clean    remove only if the row is clean in the source plan
+  approve_keep_active_allowlist
+                          keep active under operator-approved audit allowlist;
+                          render emits inspection only, never cleanup commands
 USAGE
 }
 
@@ -196,7 +199,7 @@ write_template() {
   } > "$manifest"
   echo "approval_manifest=$manifest"
   echo "plan_tsv=$PLAN_TSV"
-  echo "edit_decisions=hold|approve_salvage_remove|approve_discard_remove|approve_remove_clean"
+  echo "edit_decisions=hold|approve_salvage_remove|approve_discard_remove|approve_remove_clean|approve_keep_active_allowlist"
 }
 
 validate_manifest() {
@@ -226,7 +229,8 @@ validate_manifest() {
     $1 != "hold" &&
     $1 != "approve_salvage_remove" &&
     $1 != "approve_discard_remove" &&
-    $1 != "approve_remove_clean" {
+    $1 != "approve_remove_clean" &&
+    $1 != "approve_keep_active_allowlist" {
       printf "error: row %d has invalid decision: %s\n", NR, $1 > "/dev/stderr"
       failed = 1
     }
@@ -342,6 +346,10 @@ HEADER
           if [[ "$branch" != "detached" ]]; then
             render_line "git branch -d $branch_q" 1
           fi
+          ;;
+        approve_keep_active_allowlist)
+          echo "# keep-active allowlist approved; no cleanup action rendered for this row"
+          echo "# pass this manifest via SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST to readiness/audit gates"
           ;;
       esac
       echo

--- a/scripts/dev/worktree_branch_audit.sh
+++ b/scripts/dev/worktree_branch_audit.sh
@@ -6,6 +6,7 @@ cd "$ROOT_DIR"
 
 BASE_REF="${SOUNIO_AUDIT_BASE_REF:-origin/main}"
 INCLUDE_PRS="${SOUNIO_AUDIT_INCLUDE_PRS:-0}"
+ALLOW_MANIFEST="${SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST:-}"
 CHECK_MODE=0
 OUT=""
 
@@ -25,6 +26,10 @@ Check-mode environment:
   SOUNIO_AUDIT_MAX_DIRTY                 optional
   SOUNIO_AUDIT_MAX_OPEN_PR               optional
   SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE   optional awk regex for allowed paths
+  SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST
+                                             optional cleanup approval TSV;
+                                             approve_keep_active_allowlist rows
+                                             allow exact worktree paths
 USAGE
 }
 
@@ -56,6 +61,15 @@ done
 
 if [[ -z "$OUT" ]]; then
   OUT="$(mktemp /tmp/sounio-worktree-audit.XXXXXX.tsv)"
+fi
+
+if [[ -n "$ALLOW_MANIFEST" ]]; then
+  [[ -f "$ALLOW_MANIFEST" ]] || {
+    echo "error: allow manifest not found: $ALLOW_MANIFEST" >&2
+    exit 2
+  }
+  scripts/dev/madaros_worktree_cleanup_approval.sh validate \
+    --manifest-tsv "$ALLOW_MANIFEST" >/dev/null
 fi
 
 CRITICAL_PATHS=(
@@ -161,10 +175,49 @@ write_rows() {
 } > "$OUT"
 
 echo "audit_tsv=$OUT"
+if [[ -n "$ALLOW_MANIFEST" ]]; then
+  echo "allow_manifest=$ALLOW_MANIFEST"
+  echo "allow_manifest_decision=approve_keep_active_allowlist"
+fi
 summary="$(
   awk -F '\t' '
+    function strip_cr(value) {
+      sub(/\r$/, "", value)
+      return value
+    }
+    function load_allow_manifest(manifest, line, fields, n, header_seen) {
+      if (manifest == "") {
+        return
+      }
+      while ((getline line < manifest) > 0) {
+        line = strip_cr(line)
+        if (line == "" || line ~ /^#/) {
+          continue
+        }
+        if (!header_seen) {
+          header_seen = 1
+          continue
+        }
+        n = split(line, fields, "\t")
+        if (n >= 6 && fields[1] == "approve_keep_active_allowlist" && fields[6] != "") {
+          allow_manifest_path[fields[6]] = 1
+        }
+      }
+      close(manifest)
+    }
+    function path_allowed(path) {
+      if (allow_critical_dirty_re != "" && path ~ allow_critical_dirty_re) {
+        return 1
+      }
+      if (path in allow_manifest_path) {
+        return 1
+      }
+      return 0
+    }
     BEGIN {
       allow_critical_dirty_re = ENVIRON["SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE"]
+      allow_critical_dirty_manifest = ENVIRON["SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST"]
+      load_allow_manifest(allow_critical_dirty_manifest)
     }
     NR > 1 {
       total++
@@ -172,7 +225,7 @@ summary="$(
       if ($5 ~ /^PRUNABLE/) prunable++
       if ($9 != "") {
         critical_dirty++
-        if (allow_critical_dirty_re == "" || $1 !~ allow_critical_dirty_re) {
+        if (!path_allowed($1)) {
           unallowed_critical_dirty++
         }
       }
@@ -203,13 +256,48 @@ check_threshold() {
 
 echo "critical_dirty_worktrees:"
 awk -F '\t' '
+  function strip_cr(value) {
+    sub(/\r$/, "", value)
+    return value
+  }
+  function load_allow_manifest(manifest, line, fields, n, header_seen) {
+    if (manifest == "") {
+      return
+    }
+    while ((getline line < manifest) > 0) {
+      line = strip_cr(line)
+      if (line == "" || line ~ /^#/) {
+        continue
+      }
+      if (!header_seen) {
+        header_seen = 1
+        continue
+      }
+      n = split(line, fields, "\t")
+      if (n >= 6 && fields[1] == "approve_keep_active_allowlist" && fields[6] != "") {
+        allow_manifest_path[fields[6]] = 1
+      }
+    }
+    close(manifest)
+  }
+  function path_allowed(path) {
+    if (allow_critical_dirty_re != "" && path ~ allow_critical_dirty_re) {
+      return 1
+    }
+    if (path in allow_manifest_path) {
+      return 1
+    }
+    return 0
+  }
   BEGIN {
     allow_critical_dirty_re = ENVIRON["SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE"]
+    allow_critical_dirty_manifest = ENVIRON["SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST"]
+    load_allow_manifest(allow_critical_dirty_manifest)
   }
   NR > 1 {
     if ($9 != "") {
       prefix = "unallowed"
-      if (allow_critical_dirty_re != "" && $1 ~ allow_critical_dirty_re) {
+      if (path_allowed($1)) {
         prefix = "allowed"
       }
       print "- [" prefix "] " $1 " | " $2 " | " $9


### PR DESCRIPTION
## Summary

- add `approve_keep_active_allowlist` to the Madaros cleanup approval manifest flow
- let `worktree_branch_audit.sh` consume a validated approval manifest via `SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST` and allow exact keep-active paths
- show regex/manifest allowlist inputs in readiness output and document the operator workflow
- extend the cheap operational contract gate for the new decision

## Validation

- `for f in scripts/dev/madaros_worktree_cleanup_approval.sh scripts/dev/worktree_branch_audit.sh scripts/dev/madaros_readiness_status.sh scripts/ci/madaros_operational_contract_gate.sh; do bash -n "$f" || exit 1; done`
- real probe: `/tmp/sounio-active-lowerfix` changes from `[unallowed]` to `[allowed]` when listed in a validated `approve_keep_active_allowlist` manifest
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`

## Offload

Not invoked: this is operational cleanup tooling/status documentation, not math claims, clinical-pathway code, or external-facing artifacts.
