### PR TITLE
tools(madaros): generate suggested cleanup manifests

### DIFF
--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -99,8 +99,22 @@ to one of `approve_salvage_remove`, `approve_discard_remove`,
 `approver`, `approved_utc`, and `approval_id`. `approve_keep_active_allowlist`
 means "this dirty worktree remains a live owned lane"; it is valid approval
 metadata for readiness/audit allowlisting, but the renderer emits only
-inspection commands and no cleanup/push/remove commands for that row. Validate
-and render the reviewed commands with:
+inspection commands and no cleanup/push/remove commands for that row.
+
+If a reviewed recommendations file exists, generate an operator-review manifest
+without manually copying decisions:
+
+```bash
+scripts/dev/madaros_cleanup_suggested_manifest.sh \
+  --manifest-tsv /tmp/madaros-cleanup-approval/madaros-cleanup-approval.tsv \
+  --decisions-tsv /tmp/madaros-cleanup-decision-packet/suggested-cleanup-decisions.tsv \
+  --out-tsv /tmp/madaros-cleanup-approval/madaros-cleanup-approval.suggested-unapproved.tsv
+```
+
+The suggested manifest is intentionally **not approval**: every actionable row
+uses `TODO_REQUIRED` approval fields, so validation must fail until the operator
+fills `approver`, `approved_utc`, and `approval_id`. Validate and render the
+reviewed commands with:
 
 ```bash
 scripts/dev/madaros_worktree_cleanup_approval.sh validate \

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -197,6 +197,72 @@ require_cleanup_approval_evidence() {
   fi
 }
 
+require_cleanup_suggested_manifest_evidence() {
+  local tmp_dir manifest decisions suggested approved validate_out render_out commands
+  tmp_dir="$(mktemp -d /tmp/madaros-contract-suggested-manifest.XXXXXX)"
+  manifest="$tmp_dir/approval-template.tsv"
+  decisions="$tmp_dir/suggested-cleanup-decisions.tsv"
+  suggested="$tmp_dir/suggested-unapproved.tsv"
+  approved="$tmp_dir/approved.tsv"
+
+  printf 'decision\tapprover\tapproved_utc\tapproval_id\tcategory\tpath\tbranch\thead\tstate\tdirty_count\tremote_ref\tsalvage_ref\tdisposition\tcritical_dirty\tcritical_vs_base\toperator_note\n' > "$manifest"
+  printf 'hold\tTODO\tTODO\tTODO\tactive_other_lane_wip\t/tmp/active-lane\twork/active\t%s\tdirty\t1\tnone\tarchive/madaros-active-lane\tdo not remove; confirm owner\tM self-hosted/ir/lower.sio\tself-hosted/ir/lower.sio\tTODO\n' \
+    "$(git rev-parse --short=12 HEAD 2>/dev/null || printf unknown)" >> "$manifest"
+  printf 'hold\tTODO\tTODO\tTODO\tstale_local_temp\t/tmp/salvage-lane\twork/salvage\t%s\tdirty\t1\tnone\tarchive/madaros-salvage-lane\tcheck unique commits; push archive/salvage before removal\tM self-hosted/compiler/module_native_driver.sio\tself-hosted/compiler/module_native_driver.sio\tTODO\n' \
+    "$(git rev-parse --short=12 HEAD 2>/dev/null || printf unknown)" >> "$manifest"
+
+  printf 'path\tsuggested_action\tmanifest_decision_if_operator_approves\trequires_approver_fields\tnote\n' > "$decisions"
+  printf '/tmp/active-lane\tkeep_active_allowlist\thold_or_allowlist\toperator_owner_ack\tfixture active lane stays alive\n' >> "$decisions"
+  printf '/tmp/salvage-lane\tapprove_salvage_remove\tapprove_salvage_remove\tyes\tfixture salvage before remove\n' >> "$decisions"
+
+  scripts/dev/madaros_cleanup_suggested_manifest.sh \
+    --manifest-tsv "$manifest" \
+    --decisions-tsv "$decisions" \
+    --out-tsv "$suggested" >/dev/null
+  require_file "$suggested"
+  awk -F '\t' '
+    NR > 1 && $6 == "/tmp/active-lane" {
+      found_active = ($1 == "approve_keep_active_allowlist" &&
+        $2 == "TODO_REQUIRED" && $3 == "TODO_REQUIRED" &&
+        $4 == "APPROVAL-TODO_REQUIRED")
+    }
+    NR > 1 && $6 == "/tmp/salvage-lane" {
+      found_salvage = ($1 == "approve_salvage_remove" &&
+        $2 == "TODO_REQUIRED" && $3 == "TODO_REQUIRED" &&
+        $4 == "APPROVAL-TODO_REQUIRED")
+    }
+    END {
+      exit (found_active && found_salvage) ? 0 : 1
+    }
+  ' "$suggested" || fail "suggested manifest did not mark active/salvage rows correctly"
+
+  if scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv "$suggested" >/dev/null 2>&1; then
+    fail "suggested unapproved manifest validated before operator approval fields were filled"
+  fi
+
+  awk -F '\t' 'BEGIN { OFS = "\t" }
+    NR == 1 { print; next }
+    $1 != "hold" {
+      $2 = "operator"
+      $3 = "2026-07-03T00:00:00Z"
+      $4 = "APPROVAL-fixture-" NR
+    }
+    { print }
+  ' "$suggested" > "$approved"
+
+  validate_out="$(scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv "$approved")"
+  grep -Fq 'actionable_rows=2' <<<"$validate_out" ||
+    fail "approved suggested manifest should have two actionable rows"
+
+  render_out="$tmp_dir/render"
+  scripts/dev/madaros_worktree_cleanup_approval.sh render --manifest-tsv "$approved" --out-dir "$render_out" >/dev/null
+  commands="$render_out/madaros-cleanup-approved.commands.sh"
+  require_file "$commands"
+  require_grep 'decision=approve_keep_active_allowlist' "$commands"
+  require_grep 'keep-active allowlist approved; no cleanup action rendered' "$commands"
+  require_no_uncommented_mutation "$commands"
+}
+
 require_no_uncommented_mutation() {
   local plan_sh="$1"
   awk '
@@ -223,6 +289,7 @@ require_file scripts/ci/madaros_source_to_elf_gate.sh
 require_executable scripts/dev/madaros_two_gate.sh
 require_executable scripts/dev/madaros_worktree_cleanup_plan.sh
 require_executable scripts/dev/madaros_worktree_cleanup_approval.sh
+require_executable scripts/dev/madaros_cleanup_suggested_manifest.sh
 require_executable scripts/dev/madaros_worktree_salvage_packet.sh
 require_file .github/workflows/ci.yml
 
@@ -294,11 +361,14 @@ require_grep '# evidence=origin_main_unique:' scripts/dev/madaros_worktree_clean
 require_grep 'cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_approval.sh' scripts/dev/madaros_readiness_status.sh
 require_grep 'I_ACCEPT_PUSH_BEFORE_DELETE' scripts/dev/madaros_worktree_cleanup_approval.sh
 require_grep 'approve_keep_active_allowlist' scripts/dev/madaros_worktree_cleanup_approval.sh
+require_grep 'madaros_cleanup_suggested_manifest.sh' docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+require_grep 'keep_active_allowlist  -> approve_keep_active_allowlist' scripts/dev/madaros_cleanup_suggested_manifest.sh
 require_grep 'SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST' scripts/dev/worktree_branch_audit.sh
 require_grep 'tracked/staged binary diffs' scripts/dev/madaros_worktree_salvage_packet.sh
 require_grep 'No branches pushed or worktrees removed' scripts/dev/madaros_worktree_salvage_packet.sh
 require_cleanup_planner_evidence
 require_cleanup_approval_evidence
+require_cleanup_suggested_manifest_evidence
 require_salvage_packet_evidence
 
 echo "[madaros-contract] PASS: status doc, agent contract, default wrapper, and gate wiring are aligned"

--- a/scripts/dev/madaros_cleanup_suggested_manifest.sh
+++ b/scripts/dev/madaros_cleanup_suggested_manifest.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MANIFEST_TSV=""
+DECISIONS_TSV=""
+OUT_TSV=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/dev/madaros_cleanup_suggested_manifest.sh \
+    --manifest-tsv FILE \
+    --decisions-tsv FILE \
+    --out-tsv FILE
+
+Create an operator-review manifest from a cleanup approval template plus a
+reviewed recommendations TSV. This helper is non-destructive and does not
+approve anything: actionable rows are emitted with TODO_REQUIRED approval
+fields, so validation intentionally fails until the operator fills them.
+
+Inputs:
+  --manifest-tsv FILE   madaros-cleanup-approval.tsv template or manifest
+  --decisions-tsv FILE  TSV with columns:
+                        path, suggested_action,
+                        manifest_decision_if_operator_approves,
+                        requires_approver_fields, note
+  --out-tsv FILE        output suggested approval manifest
+  -h, --help            show this help
+
+Supported suggested_action values:
+  approve_salvage_remove
+  approve_discard_remove
+  approve_remove_clean
+  keep_active_allowlist  -> approve_keep_active_allowlist
+  needs_owner_review     -> hold
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --manifest-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --manifest-tsv requires a path" >&2
+        exit 2
+      fi
+      MANIFEST_TSV="$1"
+      ;;
+    --decisions-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --decisions-tsv requires a path" >&2
+        exit 2
+      fi
+      DECISIONS_TSV="$1"
+      ;;
+    --out-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --out-tsv requires a path" >&2
+        exit 2
+      fi
+      OUT_TSV="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+[[ -n "$MANIFEST_TSV" ]] || { echo "error: --manifest-tsv is required" >&2; exit 2; }
+[[ -n "$DECISIONS_TSV" ]] || { echo "error: --decisions-tsv is required" >&2; exit 2; }
+[[ -n "$OUT_TSV" ]] || { echo "error: --out-tsv is required" >&2; exit 2; }
+[[ -f "$MANIFEST_TSV" ]] || { echo "error: manifest TSV not found: $MANIFEST_TSV" >&2; exit 2; }
+[[ -f "$DECISIONS_TSV" ]] || { echo "error: decisions TSV not found: $DECISIONS_TSV" >&2; exit 2; }
+
+expected_manifest_header='decision	approver	approved_utc	approval_id	category	path	branch	head	state	dirty_count	remote_ref	salvage_ref	disposition	critical_dirty	critical_vs_base	operator_note'
+expected_decisions_header='path	suggested_action	manifest_decision_if_operator_approves	requires_approver_fields	note'
+
+IFS= read -r actual_manifest_header < "$MANIFEST_TSV"
+[[ "$actual_manifest_header" == "$expected_manifest_header" ]] || {
+  echo "error: manifest header drifted: $actual_manifest_header" >&2
+  exit 1
+}
+
+IFS= read -r actual_decisions_header < "$DECISIONS_TSV"
+[[ "$actual_decisions_header" == "$expected_decisions_header" ]] || {
+  echo "error: decisions header drifted: $actual_decisions_header" >&2
+  exit 1
+}
+
+mkdir -p "$(dirname "$OUT_TSV")"
+
+awk -F '\t' -v OFS='\t' -v decisions="$DECISIONS_TSV" '
+  function strip_cr(value) {
+    sub(/\r$/, "", value)
+    return value
+  }
+  function decision_for(action, manifest_decision) {
+    if (action == "approve_salvage_remove" ||
+        action == "approve_discard_remove" ||
+        action == "approve_remove_clean") {
+      return action
+    }
+    if (action == "keep_active_allowlist" ||
+        manifest_decision == "approve_keep_active_allowlist") {
+      return "approve_keep_active_allowlist"
+    }
+    if (action == "needs_owner_review" || action == "hold" ||
+        manifest_decision == "hold") {
+      return "hold"
+    }
+    printf "error: unsupported suggested_action for %s: %s\n", current_path, action > "/dev/stderr"
+    failed = 1
+    return "hold"
+  }
+  BEGIN {
+    while ((getline line < decisions) > 0) {
+      line = strip_cr(line)
+      if (line == "" || line ~ /^#/) {
+        continue
+      }
+      if (!header_seen) {
+        header_seen = 1
+        continue
+      }
+      n = split(line, fields, "\t")
+      if (n != 5) {
+        printf "error: decisions row has %d fields, expected 5: %s\n", n, line > "/dev/stderr"
+        failed = 1
+        continue
+      }
+      current_path = fields[1]
+      suggested_action[current_path] = fields[2]
+      manifest_decision[current_path] = fields[3]
+      note[current_path] = fields[5]
+    }
+    close(decisions)
+    if (failed) {
+      exit 1
+    }
+  }
+  NR == 1 {
+    print
+    next
+  }
+  NF != 16 {
+    printf "error: manifest row %d has %d fields, expected 16\n", NR, NF > "/dev/stderr"
+    failed = 1
+    next
+  }
+  {
+    path = $6
+    if (path in suggested_action) {
+      current_path = path
+      next_decision = decision_for(suggested_action[path], manifest_decision[path])
+      if (next_decision == "hold") {
+        $1 = "hold"
+        $2 = "TODO"
+        $3 = "TODO"
+        $4 = "TODO"
+      } else {
+        $1 = next_decision
+        $2 = "TODO_REQUIRED"
+        $3 = "TODO_REQUIRED"
+        $4 = "APPROVAL-TODO_REQUIRED"
+      }
+      if (note[path] != "") {
+        $16 = note[path]
+      }
+    }
+    print
+  }
+  END {
+    if (failed) {
+      exit 1
+    }
+  }
+' "$MANIFEST_TSV" > "$OUT_TSV"
+
+approval_rows="$(awk 'NR > 1 { rows++ } END { print rows + 0 }' "$OUT_TSV")"
+actionable_rows="$(awk -F '\t' 'NR > 1 && $1 != "hold" { rows++ } END { print rows + 0 }' "$OUT_TSV")"
+keep_active_rows="$(awk -F '\t' 'NR > 1 && $1 == "approve_keep_active_allowlist" { rows++ } END { print rows + 0 }' "$OUT_TSV")"
+
+echo "suggested_manifest=$OUT_TSV"
+echo "approval_rows=$approval_rows"
+echo "actionable_rows=$actionable_rows"
+echo "approve_keep_active_allowlist_rows=$keep_active_rows"

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -590,6 +590,10 @@ Integration shepherd:
   scripts/dev/madaros_readiness_status.sh --strict
   scripts/dev/madaros_worktree_cleanup_plan.sh
   scripts/dev/madaros_worktree_cleanup_approval.sh template --plan-tsv /tmp/madaros-cleanup-plan/madaros-cleanup-plan.tsv --out-dir /tmp/madaros-cleanup-approval
+  scripts/dev/madaros_cleanup_suggested_manifest.sh \
+    --manifest-tsv /tmp/madaros-cleanup-approval/madaros-cleanup-approval.tsv \
+    --decisions-tsv /tmp/madaros-cleanup-decision-packet/suggested-cleanup-decisions.tsv \
+    --out-tsv /tmp/madaros-cleanup-approval/madaros-cleanup-approval.suggested-unapproved.tsv
   scripts/dev/madaros_readiness_status.sh --check-compiler-pr-overlap
   scripts/dev/madaros_readiness_status.sh --check-pr-resolution-queue
   scripts/dev/madaros_readiness_status.sh --production-ready


### PR DESCRIPTION
## Summary

- add a non-destructive helper that turns reviewed cleanup recommendations into an operator-review approval manifest
- map `keep_active_allowlist` recommendations to `approve_keep_active_allowlist` with `TODO_REQUIRED` approval fields
- extend the operational contract gate to prove suggested manifests fail before operator approval and pass/render after fixture approval
- document the helper in the cleanup ledger and readiness next-gates output

## Validation

- `for f in scripts/dev/madaros_cleanup_suggested_manifest.sh scripts/dev/madaros_readiness_status.sh scripts/ci/madaros_operational_contract_gate.sh; do bash -n "$f" || exit 1; done`
- real stale-packet probe: generated 19 approval rows / 14 actionable rows / 5 `approve_keep_active_allowlist` rows; validation correctly fails until approver fields are filled
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_outpath_invariant.sh`
- `git diff --check`

## Safety

This helper does not approve, push, remove, delete, reset, or clean anything. It only generates an unapproved TSV with `TODO_REQUIRED` approval fields for operator review.

## Offload

Not invoked: this is internal operational cleanup tooling/docs, not math claims, clinical-pathway code, or external-facing artifacts.
