### PR TITLE
test(gpu): guard PTX module import combination

### DIFF
--- a/TASK.md
+++ b/TASK.md
@@ -1,3 +1,15 @@
+# Active TODOs
+
+## Madaros GPU/PTX module-combination guard
+
+- [ ] Track the GPU/PTX module-combination blocker documented in
+  `docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md`
+  and summarized in `docs/MADAROS_STATUS.md`.
+- [ ] Keep a CI-visible regression guard for the normal module graph import
+  combination: `gpu::kernel_ir::*` + `gpu::lower_to_ptx::*` + `gpu::ptx::*`.
+- [ ] Follow-up lane: bisect pairwise module combinations and audit `pub`
+  visibility across `self-hosted/gpu/` if the guard regresses.
+
 # Lane 8c — Regulatory Dossier Generator (dissertation contribution #3 wrapper)
 
 **Owner:** Kimi 2.5 (offload). Reviewer: Claude B.

--- a/tests/gpu/test_madaros_kernel_ir_lower_to_ptx_ptx_import_gate.sio
+++ b/tests/gpu/test_madaros_kernel_ir_lower_to_ptx_ptx_import_gate.sio
@@ -1,0 +1,8 @@
+//@ check-only
+use gpu::kernel_ir::*
+use gpu::lower_to_ptx::*
+use gpu::ptx::*
+
+fn main() -> i32 {
+    0
+}


### PR DESCRIPTION
## Summary
- add a check-only GPU regression fixture for the normal module graph import combination: kernel_ir + lower_to_ptx + ptx
- record the GPU/PTX module-combination blocker in TASK.md with the follow-up pairwise bisect/pub-audit action

## Validation
- env -u SOUC_BIN -u SOUNIO_SOUC_BIN ./bin/souc check tests/gpu/test_madaros_kernel_ir_lower_to_ptx_ptx_import_gate.sio
- env -u SOUC_BIN -u SOUNIO_SOUC_BIN bash scripts/run_sio_test_suite.sh --filter-exact test_madaros_kernel_ir_lower_to_ptx_ptx_import_gate.sio --verbose
- bash scripts/dev/check_docs_consistency.sh
- bash scripts/dev/check_docs_registry.sh
- bash scripts/dev/check_outpath_invariant.sh
- git diff --check

## Notes
- This is a regression guard; the triple import passes on canon today.
- I did not run or alter destructive cleanup/approval flows.
- LLM-offload not invoked: this touches only an internal compiler test/TODO, not math claims, clinical-pathway code, or external-facing artifacts.