### PR TITLE
ci(madaros): accept greenline proof anchor

### DIFF
--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -133,6 +133,10 @@ bash scripts/ci/madaros_operational_contract_gate.sh
 It does not replace the compiler proof. It prevents drift in the committed agent
 instructions, `bin/souc` default-wrapper contract, `scripts/dev/e2e_gate.sh`, and
 `scripts/ci/madaros_full_gate.sh` coverage.
+The gate accepts either of two proof anchors: the canonical protected greenline
+proof landing PR #586 (`bf46bda919596ce71b8fc35dc29cb3a31ff01d7b`) or the
+historical `origin/main` proof baseline `17d1157be540d32bb583dd03ca7072a6026e2027`.
+Do not treat the historical baseline as a reset target for the current greenline.
 
 Historical baseline at `17d1157be` (fresh build from source, **not** a
 prebuilt artifact) covered the broad full-gate shape:

--- a/docs/status/madaros_main_proof_17d115.md
+++ b/docs/status/madaros_main_proof_17d115.md
@@ -84,6 +84,12 @@ No SIGSEGV was observed.
 
 These exact cases are now covered by `make madaros-full-gate`.
 
-## Coordination Rule
+## Historical Coordination Rule
 
-Madaros is green on `origin/main@17d1157be`. Agents must fetch/rebase or reset to that commit, rebuild `artifacts/self-hosted/madaros`, and run `make madaros-full-gate` before treating checker/Madaros failures as current evidence. Dirty worktrees and stale raw binaries are not evidence against the current Madaros state.
+Madaros was proven green on `origin/main@17d1157be` on 2026-06-14. This record is
+a historical proof anchor for the broad full-gate shape, not a current reset
+target. For current work, use the live branch named in `docs/MADAROS_STATUS.md`
+and verify with `make madaros-full-gate` (or the protected-branch
+`Madaros Greenline Gate`) before treating checker/Madaros failures as current
+evidence. Dirty worktrees and stale raw binaries are not evidence against the
+current Madaros state.

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
-GREEN_BASE="17d1157be540d32bb583dd03ca7072a6026e2027"
+HISTORICAL_MAIN_GREEN_BASE="17d1157be540d32bb583dd03ca7072a6026e2027"
+CANONICAL_GREENLINE_PROOF_BASE="bf46bda919596ce71b8fc35dc29cb3a31ff01d7b"
 
 fail() {
   echo "[madaros-contract] FAIL: $*" >&2
@@ -273,6 +274,26 @@ require_no_uncommented_mutation() {
   ' "$plan_sh" || fail "cleanup planner emitted an uncommented mutating command: $plan_sh"
 }
 
+require_madaros_proof_anchor() {
+  local -a accepted_anchors=(
+    "$CANONICAL_GREENLINE_PROOF_BASE"
+    "$HISTORICAL_MAIN_GREEN_BASE"
+  )
+  local anchor
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for anchor in "${accepted_anchors[@]}"; do
+    if git merge-base --is-ancestor "$anchor" HEAD; then
+      return 0
+    fi
+  done
+
+  fail "HEAD does not contain an accepted Madaros proof anchor: canonical greenline $CANONICAL_GREENLINE_PROOF_BASE or historical main $HISTORICAL_MAIN_GREEN_BASE"
+}
+
 require_file docs/MADAROS_STATUS.md
 require_file docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
 require_file docs/status/madaros_main_proof_17d115.md
@@ -293,12 +314,11 @@ require_executable scripts/dev/madaros_cleanup_suggested_manifest.sh
 require_executable scripts/dev/madaros_worktree_salvage_packet.sh
 require_file .github/workflows/ci.yml
 
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  git merge-base --is-ancestor "$GREEN_BASE" HEAD ||
-    fail "HEAD does not contain Madaros green base $GREEN_BASE"
-fi
+require_madaros_proof_anchor
 
 require_grep 'bin/souc` routes to Madaros' docs/MADAROS_STATUS.md
+require_grep 'bf46bda919596ce71b8fc35dc29cb3a31ff01d7b' docs/MADAROS_STATUS.md
+require_grep '17d1157be' docs/MADAROS_STATUS.md
 require_grep 'receipt-gated' docs/MADAROS_STATUS.md
 require_grep 'bin/madaros-relocgate' docs/MADAROS_STATUS.md
 require_grep 'artifacts/self-hosted/madaros.gate-receipt' docs/MADAROS_STATUS.md


### PR DESCRIPTION
## Summary
- update the standalone Madaros operational contract gate to accept the canonical greenline proof anchor from PR #586 as well as the historical origin/main proof anchor
- document that `17d1157be` is a historical proof baseline, not a reset target for current greenline work
- align `docs/MADAROS_STATUS.md` with the accepted proof-anchor semantics

## Validation
- bash -n scripts/ci/madaros_operational_contract_gate.sh
- bash scripts/ci/madaros_operational_contract_gate.sh
- bash scripts/dev/check_docs_consistency.sh
- bash scripts/dev/check_docs_registry.sh
- git diff --check
- bash scripts/dev/check_outpath_invariant.sh
- bash scripts/ci/claude_operational_contract_gate.sh

## Notes
- CI workflows do not currently invoke `madaros_operational_contract_gate.sh`; this fixes the standalone gate used by local/full operational checks.
- LLM-offload not invoked: this is internal CI/governance plumbing, not math claims, clinical-pathway code, or external-facing artifacts.