### PR TITLE
tools(madaros): generate cleanup decision packets

### DIFF
--- a/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+++ b/docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
@@ -85,6 +85,20 @@ optional `DIR.tar.gz` + sha256. It does **not** push branches, remove worktrees,
 delete files, reset, or clean; it is evidence for the operator decision, not the
 cleanup itself.
 
+For the full operator decision packet in one command, run:
+
+```bash
+scripts/dev/madaros_cleanup_decision_packet.sh --tarball
+```
+
+This writes a timestamped `/tmp/madaros-cleanup-decision-packet-*` directory and
+updates `/tmp/madaros-latest-decision-packet.path`. The packet includes the
+current audit TSV, cleanup plan, approval template, suggested unapproved
+manifest, hold-only rendered commands, salvage evidence packet, README, and
+operator draft. It never fills operator approval fields; suggested non-`hold`
+rows keep `TODO_REQUIRED` approval fields, so validation must fail until the
+operator fills them.
+
 After reviewing the packet, create the machine-readable approval template:
 
 ```bash

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -264,6 +264,62 @@ require_cleanup_suggested_manifest_evidence() {
   require_no_uncommented_mutation "$commands"
 }
 
+require_cleanup_decision_packet_evidence() {
+  local tmp_dir audit_tsv decisions out_dir latest_pointer stdout_path suggested commands pointer_value
+  tmp_dir="$(mktemp -d /tmp/madaros-contract-decision-packet.XXXXXX)"
+  audit_tsv="$tmp_dir/worktree-audit.tsv"
+  decisions="$tmp_dir/suggested-cleanup-decisions.tsv"
+  out_dir="$tmp_dir/packet"
+  latest_pointer="$tmp_dir/latest.path"
+  stdout_path="$tmp_dir/stdout.txt"
+
+  printf 'path\tbranch\thead\tupstream\tstate\tdirty_count\tahead\tbehind\tcritical_dirty\tcritical_vs_base\tpr\n' > "$audit_tsv"
+  printf '%s\tdetached\t%s\t\tdirty\t1\t0\t0\tM scripts/dev/madaros_cleanup_decision_packet.sh\tscripts/dev/madaros_cleanup_decision_packet.sh\t\n' \
+    "$ROOT_DIR" "$(git rev-parse --short=12 HEAD 2>/dev/null || printf unknown)" >> "$audit_tsv"
+
+  printf 'path\tsuggested_action\tmanifest_decision_if_operator_approves\trequires_approver_fields\tnote\n' > "$decisions"
+  printf '%s\tapprove_salvage_remove\tapprove_salvage_remove\tyes\tfixture suggested salvage remains unapproved\n' "$ROOT_DIR" >> "$decisions"
+
+  SOUNIO_MADAROS_CLEANUP_ALLOW_RE='^$' \
+    scripts/dev/madaros_cleanup_decision_packet.sh \
+      --audit-tsv "$audit_tsv" \
+      --decisions-tsv "$decisions" \
+      --out-dir "$out_dir" \
+      --latest-pointer "$latest_pointer" \
+      --no-tar > "$stdout_path"
+
+  require_file "$out_dir/README.txt"
+  require_file "$out_dir/operator-approval-draft.md"
+  require_file "$out_dir/worktree-audit.tsv"
+  require_file "$out_dir/cleanup-plan/madaros-cleanup-plan.tsv"
+  require_file "$out_dir/approval-template/madaros-cleanup-approval.tsv"
+  require_file "$out_dir/suggested-cleanup-decisions.tsv"
+  require_file "$out_dir/madaros-cleanup-approval.suggested-unapproved.tsv"
+  require_file "$out_dir/salvage-packet/README.txt"
+  require_file "$latest_pointer"
+
+  pointer_value="$(cat "$latest_pointer")"
+  [[ "$pointer_value" == "$out_dir" ]] ||
+    fail "decision packet latest pointer drifted: $pointer_value"
+
+  require_grep 'suggested_manifest_validate_rc=1' "$out_dir/README.txt"
+  require_grep 'expected_fail_until_operator_fills_approver_fields' "$out_dir/README.txt"
+  require_grep 'Agents must' "$out_dir/operator-approval-draft.md"
+  require_grep 'packet_root=' "$stdout_path"
+  require_grep 'latest_pointer=' "$stdout_path"
+
+  suggested="$out_dir/madaros-cleanup-approval.suggested-unapproved.tsv"
+  if scripts/dev/madaros_worktree_cleanup_approval.sh validate --manifest-tsv "$suggested" >/dev/null 2>&1; then
+    fail "decision packet suggested manifest validated before operator approval fields were filled"
+  fi
+
+  commands="$out_dir/approval-rendered/madaros-cleanup-approved.commands.sh"
+  require_file "$commands"
+  require_no_uncommented_mutation "$commands"
+  [[ ! -e "$out_dir/salvage-packet.tar.gz" ]] ||
+    fail "decision packet wrote salvage tarball despite --no-tar"
+}
+
 require_no_uncommented_mutation() {
   local plan_sh="$1"
   awk '
@@ -371,7 +427,9 @@ require_grep 'bin/madaros-linux-x86_64' bin/souc
 require_grep 'exec env MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros"' bin/souc
 require_grep 'artifacts/self-hosted/madaros.gate-receipt' .gitignore
 require_grep 'cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh' scripts/dev/madaros_readiness_status.sh
+require_grep 'decision_packet_command=scripts/dev/madaros_cleanup_decision_packet.sh' scripts/dev/madaros_readiness_status.sh
 require_grep 'audit_allow_manifest_decision=approve_keep_active_allowlist' scripts/dev/madaros_readiness_status.sh
+require_grep 'scripts/dev/madaros_cleanup_decision_packet.sh --tarball' scripts/dev/madaros_readiness_status.sh
 require_grep 'git push, git reset, git clean, git branch -D' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'owner confirmation required before any archive, push, or removal' scripts/dev/madaros_worktree_cleanup_plan.sh
 require_grep 'unique_commits_origin_main' scripts/dev/madaros_worktree_cleanup_plan.sh
@@ -382,6 +440,7 @@ require_grep 'cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_appr
 require_grep 'I_ACCEPT_PUSH_BEFORE_DELETE' scripts/dev/madaros_worktree_cleanup_approval.sh
 require_grep 'approve_keep_active_allowlist' scripts/dev/madaros_worktree_cleanup_approval.sh
 require_grep 'madaros_cleanup_suggested_manifest.sh' docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+require_grep 'madaros_cleanup_decision_packet.sh --tarball' docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
 require_grep 'keep_active_allowlist  -> approve_keep_active_allowlist' scripts/dev/madaros_cleanup_suggested_manifest.sh
 require_grep 'SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST' scripts/dev/worktree_branch_audit.sh
 require_grep 'tracked/staged binary diffs' scripts/dev/madaros_worktree_salvage_packet.sh
@@ -389,6 +448,7 @@ require_grep 'No branches pushed or worktrees removed' scripts/dev/madaros_workt
 require_cleanup_planner_evidence
 require_cleanup_approval_evidence
 require_cleanup_suggested_manifest_evidence
+require_cleanup_decision_packet_evidence
 require_salvage_packet_evidence
 
 echo "[madaros-contract] PASS: status doc, agent contract, default wrapper, and gate wiring are aligned"

--- a/scripts/dev/madaros_cleanup_decision_packet.sh
+++ b/scripts/dev/madaros_cleanup_decision_packet.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+BASE_REF="${SOUNIO_MADAROS_CLEANUP_BASE_REF:-origin/canon/madaros-greenline}"
+DEFAULT_ALLOW_RE='^(/workspace/sounio|/workspace/sounio-effects|/workspace/sounio/.claude/worktrees/agent-adc1cd8b9d52ba53b)$'
+ALLOW_RE="${SOUNIO_MADAROS_CLEANUP_ALLOW_RE:-$DEFAULT_ALLOW_RE}"
+OUT_DIR=""
+AUDIT_TSV=""
+DECISIONS_TSV=""
+LATEST_POINTER="${SOUNIO_MADAROS_CLEANUP_LATEST_POINTER:-/tmp/madaros-latest-decision-packet.path}"
+MAKE_TARBALL=0
+UPDATE_LATEST=1
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/madaros_cleanup_decision_packet.sh [options]
+
+Create a fresh non-destructive Madaros cleanup decision packet. The packet
+bundles the live worktree audit, cleanup plan, approval template, suggested
+operator-review manifest, salvage evidence packet, and README/draft handoff.
+It never fills operator approval fields, pushes branches, removes worktrees,
+deletes files, resets, or cleans.
+
+Options:
+  --out-dir DIR       write packet under DIR (default: /tmp timestamped dir)
+  --audit-tsv PATH    use an existing worktree_branch_audit TSV instead of
+                      generating a fresh one
+  --base-ref REF      base ref for fresh worktree audit
+                      (default: origin/canon/madaros-greenline)
+  --allow-re REGEX    allowed critical-dirty path regex for audit/planner
+  --decisions-tsv PATH
+                      reviewed recommendation TSV for suggested manifest;
+                      when omitted, a conservative seed file is generated
+  --latest-pointer PATH
+                      write PATH with the packet dir (default:
+                      /tmp/madaros-latest-decision-packet.path)
+  --no-latest-pointer do not update the latest-pointer file
+  --tarball           include salvage-packet.tar.gz and sha256
+  --no-tar            do not include a salvage tarball (default)
+  -h, --help          show this help
+
+Environment:
+  SOUNIO_MADAROS_CLEANUP_BASE_REF        default --base-ref
+  SOUNIO_MADAROS_CLEANUP_ALLOW_RE        default --allow-re
+  SOUNIO_MADAROS_CLEANUP_LATEST_POINTER  default --latest-pointer
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --out-dir)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --out-dir requires a directory" >&2
+        exit 2
+      fi
+      OUT_DIR="$1"
+      ;;
+    --audit-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --audit-tsv requires a path" >&2
+        exit 2
+      fi
+      AUDIT_TSV="$1"
+      ;;
+    --base-ref)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --base-ref requires a ref" >&2
+        exit 2
+      fi
+      BASE_REF="$1"
+      ;;
+    --allow-re)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --allow-re requires a regex" >&2
+        exit 2
+      fi
+      ALLOW_RE="$1"
+      ;;
+    --decisions-tsv)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --decisions-tsv requires a path" >&2
+        exit 2
+      fi
+      DECISIONS_TSV="$1"
+      ;;
+    --latest-pointer)
+      shift
+      if [[ $# -eq 0 || -z "${1:-}" ]]; then
+        echo "error: --latest-pointer requires a path" >&2
+        exit 2
+      fi
+      LATEST_POINTER="$1"
+      ;;
+    --no-latest-pointer)
+      UPDATE_LATEST=0
+      ;;
+    --tarball)
+      MAKE_TARBALL=1
+      ;;
+    --no-tar)
+      MAKE_TARBALL=0
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+timestamp_utc="$(date -u +%Y%m%dT%H%M%SZ)"
+if [[ -z "$OUT_DIR" ]]; then
+  OUT_DIR="/tmp/madaros-cleanup-decision-packet-$timestamp_utc"
+fi
+
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+
+packet_path() {
+  printf '%s/%s\n' "$OUT_DIR" "$1"
+}
+
+copy_input() {
+  local src="$1" dest="$2"
+  [[ -f "$src" ]] || {
+    echo "error: file not found: $src" >&2
+    exit 2
+  }
+  local src_abs dest_abs
+  src_abs="$(cd "$(dirname "$src")" && pwd)/$(basename "$src")"
+  dest_abs="$(cd "$(dirname "$dest")" && pwd)/$(basename "$dest")"
+  if [[ "$src_abs" != "$dest_abs" ]]; then
+    cp "$src" "$dest"
+  fi
+}
+
+write_seed_decisions() {
+  local plan_tsv="$1" decisions_tsv="$2"
+  {
+    printf 'path\tsuggested_action\tmanifest_decision_if_operator_approves\trequires_approver_fields\tnote\n'
+    awk -F '\t' 'BEGIN { OFS = "\t" }
+      NR == 1 { next }
+      {
+        action = "needs_owner_review"
+        manifest_decision = "hold"
+        required = "owner_review"
+        note = "operator must classify this row before cleanup"
+        if ($1 == "active_other_lane_wip") {
+          action = "keep_active_allowlist"
+          manifest_decision = "hold_or_allowlist"
+          required = "operator_owner_ack"
+          note = "active lane candidate; keep only with explicit operator allowlist approval"
+        }
+        print $2, action, manifest_decision, required, note
+      }
+    ' "$plan_tsv"
+  } > "$decisions_tsv"
+}
+
+validate_expected_maybe_fails() {
+  local manifest="$1" out="$2"
+  set +e
+  scripts/dev/madaros_worktree_cleanup_approval.sh validate \
+    --manifest-tsv "$manifest" >"$out" 2>&1
+  local rc=$?
+  set -e
+  printf '%s' "$rc"
+}
+
+audit_out="$(packet_path worktree-audit.tsv)"
+audit_log="$(packet_path worktree-audit.log)"
+
+if [[ -n "$AUDIT_TSV" ]]; then
+  copy_input "$AUDIT_TSV" "$audit_out"
+  audit_rc=0
+  {
+    echo "audit_source=$AUDIT_TSV"
+    echo "audit_mode=copied"
+  } > "$audit_log"
+else
+  set +e
+  env \
+    "SOUNIO_AUDIT_BASE_REF=$BASE_REF" \
+    "SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_RE=$ALLOW_RE" \
+    scripts/dev/worktree_branch_audit.sh --check "$audit_out" >"$audit_log" 2>&1
+  audit_rc=$?
+  set -e
+fi
+
+cleanup_plan_dir="$(packet_path cleanup-plan)"
+approval_template_dir="$(packet_path approval-template)"
+approval_render_dir="$(packet_path approval-rendered)"
+salvage_dir="$(packet_path salvage-packet)"
+mkdir -p "$cleanup_plan_dir" "$approval_template_dir" "$approval_render_dir" "$salvage_dir"
+
+env "SOUNIO_MADAROS_CLEANUP_ALLOW_RE=$ALLOW_RE" \
+  scripts/dev/madaros_worktree_cleanup_plan.sh \
+  --audit-tsv "$audit_out" \
+  --out-dir "$cleanup_plan_dir" \
+  > "$(packet_path cleanup-plan.stdout)"
+
+plan_tsv="$cleanup_plan_dir/madaros-cleanup-plan.tsv"
+
+scripts/dev/madaros_worktree_cleanup_approval.sh template \
+  --plan-tsv "$plan_tsv" \
+  --out-dir "$approval_template_dir" \
+  > "$(packet_path approval-template.stdout)"
+
+approval_manifest="$approval_template_dir/madaros-cleanup-approval.tsv"
+scripts/dev/madaros_worktree_cleanup_approval.sh validate \
+  --manifest-tsv "$approval_manifest" \
+  > "$(packet_path approval-validate.stdout)"
+
+scripts/dev/madaros_worktree_cleanup_approval.sh render \
+  --manifest-tsv "$approval_manifest" \
+  --out-dir "$approval_render_dir" \
+  > "$(packet_path approval-rendered.stdout)"
+
+if [[ -n "$DECISIONS_TSV" ]]; then
+  copy_input "$DECISIONS_TSV" "$(packet_path suggested-cleanup-decisions.tsv)"
+else
+  write_seed_decisions "$plan_tsv" "$(packet_path suggested-cleanup-decisions.tsv)"
+fi
+
+suggested_manifest="$(packet_path madaros-cleanup-approval.suggested-unapproved.tsv)"
+scripts/dev/madaros_cleanup_suggested_manifest.sh \
+  --manifest-tsv "$approval_manifest" \
+  --decisions-tsv "$(packet_path suggested-cleanup-decisions.tsv)" \
+  --out-tsv "$suggested_manifest" \
+  > "$(packet_path suggested-manifest.stdout)"
+
+suggested_validate_rc="$(
+  validate_expected_maybe_fails \
+    "$suggested_manifest" \
+    "$(packet_path suggested-unapproved-validate.stdout)"
+)"
+
+salvage_args=(--plan-tsv "$plan_tsv" --out-dir "$salvage_dir")
+if [[ "$MAKE_TARBALL" == "1" ]]; then
+  salvage_args+=(--tarball)
+else
+  salvage_args+=(--no-tar)
+fi
+scripts/dev/madaros_worktree_salvage_packet.sh "${salvage_args[@]}" \
+  > "$(packet_path salvage-packet.stdout)"
+
+{
+  cat <<EOF
+# Madaros Cleanup Decision Packet
+
+Generated: $timestamp_utc
+
+This packet is non-destructive and not an approval. It bundles the current
+audit, cleanup plan, approval template, suggested operator-review manifest,
+and salvage evidence so an operator can decide what stays active and what can
+be salvaged/removed later.
+
+## Key Files
+
+- README: \`README.txt\`
+- audit TSV: \`worktree-audit.tsv\`
+- cleanup plan: \`cleanup-plan/madaros-cleanup-plan.tsv\`
+- cleanup commands draft: \`cleanup-plan/madaros-cleanup-plan.commands.sh\`
+- approval template: \`approval-template/madaros-cleanup-approval.tsv\`
+- suggested decisions: \`suggested-cleanup-decisions.tsv\`
+- suggested unapproved manifest: \`madaros-cleanup-approval.suggested-unapproved.tsv\`
+- rendered hold-only commands: \`approval-rendered/madaros-cleanup-approved.commands.sh\`
+- salvage evidence: \`salvage-packet/\`
+
+## Operator Boundary
+
+Any non-\`hold\` decision must be edited by the operator to fill:
+
+- \`approver\`
+- \`approved_utc\`
+- \`approval_id\`
+- \`operator_note\`
+
+The suggested manifest intentionally uses \`TODO_REQUIRED\` for those fields.
+That means validation may fail until the operator fills the fields. Agents must
+not fill them.
+
+## Recheck After Approval
+
+\`\`\`bash
+scripts/dev/madaros_worktree_cleanup_approval.sh validate \\
+  --manifest-tsv $approval_manifest
+
+SOUNIO_AUDIT_ALLOW_CRITICAL_DIRTY_MANIFEST=$approval_manifest \\
+  scripts/dev/madaros_readiness_status.sh --strict
+\`\`\`
+
+## Render Commands After Approval
+
+\`\`\`bash
+scripts/dev/madaros_worktree_cleanup_approval.sh render \\
+  --manifest-tsv $approval_manifest \\
+  --out-dir /tmp/madaros-cleanup-approved
+\`\`\`
+
+Rendered mutating commands remain commented unless the explicit
+\`SOUNIO_MADAROS_CLEANUP_APPROVAL=I_ACCEPT_PUSH_BEFORE_DELETE\` token is set
+with \`--allow-mutating-output\`.
+EOF
+} > "$(packet_path operator-approval-draft.md)"
+
+summary_line="$(grep -E '^total=' "$audit_log" | tail -n 1 || true)"
+planner_counts="$(grep -E '^(planned_worktrees=|category\[)' "$(packet_path cleanup-plan.stdout)" || true)"
+approval_validate="$(cat "$(packet_path approval-validate.stdout)")"
+suggested_counts="$(cat "$(packet_path suggested-manifest.stdout)")"
+greenline_tip="$(git rev-parse --verify "$BASE_REF" 2>/dev/null || git rev-parse HEAD 2>/dev/null || true)"
+
+{
+  printf 'packet_root=%s\n' "$OUT_DIR"
+  printf 'generated_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'base_ref=%s\n' "$BASE_REF"
+  printf 'greenline_tip=%s\n' "$greenline_tip"
+  printf 'allow_re=%s\n' "$ALLOW_RE"
+  printf 'audit_rc=%s\n' "$audit_rc"
+  [[ -z "$summary_line" ]] || printf '%s\n' "$summary_line"
+  grep -E '^gate_violation:' "$audit_log" || true
+  printf '\nplanner_counts:\n'
+  [[ -z "$planner_counts" ]] || printf '%s\n' "$planner_counts"
+  printf '\napproval_validate:\n%s\n' "$approval_validate"
+  printf '\nsuggested_manifest_validate_rc=%s\n' "$suggested_validate_rc"
+  printf 'suggested_unapproved_manifest_validate=%s\n' \
+    "$(if [[ "$suggested_validate_rc" == "0" ]]; then echo pass_no_actionable_or_already_approved; else echo expected_fail_until_operator_fills_approver_fields; fi)"
+  printf '\nsuggested_counts:\n%s\n' "$suggested_counts"
+  if [[ -f "$salvage_dir.tar.gz.sha256" ]]; then
+    printf '\nsalvage_tarball_sha256:\n'
+    cat "$salvage_dir.tar.gz.sha256"
+  fi
+  printf '\noperator_approval_draft=%s\n' "$(packet_path operator-approval-draft.md)"
+  printf 'suggested_cleanup_decisions=%s\n' "$(packet_path suggested-cleanup-decisions.tsv)"
+  printf 'suggested_unapproved_manifest=%s\n' "$suggested_manifest"
+} > "$(packet_path README.txt)"
+
+if [[ "$UPDATE_LATEST" == "1" ]]; then
+  mkdir -p "$(dirname "$LATEST_POINTER")"
+  printf '%s\n' "$OUT_DIR" > "$LATEST_POINTER"
+fi
+
+echo "packet_root=$OUT_DIR"
+echo "readme=$OUT_DIR/README.txt"
+echo "audit_rc=$audit_rc"
+[[ -z "$summary_line" ]] || echo "$summary_line"
+echo "approval_manifest=$approval_manifest"
+echo "suggested_unapproved_manifest=$suggested_manifest"
+echo "suggested_manifest_validate_rc=$suggested_validate_rc"
+if [[ "$UPDATE_LATEST" == "1" ]]; then
+  echo "latest_pointer=$LATEST_POINTER"
+fi

--- a/scripts/dev/madaros_readiness_status.sh
+++ b/scripts/dev/madaros_readiness_status.sh
@@ -491,6 +491,7 @@ if [[ "$RUN_AUDIT" == "1" ]]; then
   fi
   run_status_command audit \
     "${audit_env[@]}" scripts/dev/worktree_branch_audit.sh --check "$audit_out"
+  echo "decision_packet_command=scripts/dev/madaros_cleanup_decision_packet.sh --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-decision-packet"
   echo "cleanup_plan_command=scripts/dev/madaros_worktree_cleanup_plan.sh --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-plan"
   echo "cleanup_approval_command=scripts/dev/madaros_worktree_cleanup_approval.sh template --audit-tsv $audit_out --out-dir /tmp/madaros-cleanup-approval"
 fi
@@ -588,6 +589,7 @@ Production readiness still also requires:
 Integration shepherd:
   scripts/ci/madaros_blocker_contract_gate.sh
   scripts/dev/madaros_readiness_status.sh --strict
+  scripts/dev/madaros_cleanup_decision_packet.sh --tarball
   scripts/dev/madaros_worktree_cleanup_plan.sh
   scripts/dev/madaros_worktree_cleanup_approval.sh template --plan-tsv /tmp/madaros-cleanup-plan/madaros-cleanup-plan.tsv --out-dir /tmp/madaros-cleanup-approval
   scripts/dev/madaros_cleanup_suggested_manifest.sh \


### PR DESCRIPTION
## Summary

- add `scripts/dev/madaros_cleanup_decision_packet.sh`, a non-destructive one-command workflow that bundles live worktree audit, cleanup plan, approval template, suggested unapproved manifest, hold-only rendered commands, salvage evidence, README, and operator draft
- surface the decision packet command from `madaros_readiness_status.sh --strict`
- extend the operational contract gate with a fixture proving the packet remains non-destructive and does not auto-approve suggested rows
- document the new packet workflow in the cleanup ledger

## Fresh packet generated

Generated from this branch against `origin/canon/madaros-greenline`:

```text
packet_root=/tmp/madaros-cleanup-decision-packet-20260703T174242Z
greenline_tip=b73c50a7a94ad298524640bdb21ee818985c22d1
audit_rc=1
total=74 dirty=38 prunable=0 critical_dirty=21 unallowed_critical_dirty=20 critical_vs_base=35 open_pr=0
approval_rows=20 actionable_rows=0
suggested_manifest_validate_rc=1
```

`/tmp/madaros-latest-decision-packet.path` now points at that fresh packet. The suggested manifest intentionally fails validation until the operator fills approval fields.

## Validation

- `bash -n scripts/dev/madaros_cleanup_decision_packet.sh scripts/dev/madaros_readiness_status.sh scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `git diff --check`
- `bash scripts/dev/madaros_readiness_status.sh --strict` expected fail on worktree governance, now printing `decision_packet_command=...`
- official packet manifest validates with `actionable_rows=0`; suggested unapproved manifest fails as expected with missing operator approval fields

## LLM-offload

Not invoked: this is internal workflow/governance tooling, no math/clinical semantics or external-facing artifact changes.
