### PR TITLE
[canon] guard GPU PTX module imports on greenline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Run Madaros two-gate harness
         run: |
           bash scripts/dev/madaros_two_gate.sh artifacts/self-hosted/madaros
+      - name: Run Madaros GPU/PTX import witness
+        run: |
+          bash scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
       - name: Upload Madaros receipt
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/madaros-prebuilt-refresh.yml
+++ b/.github/workflows/madaros-prebuilt-refresh.yml
@@ -66,18 +66,21 @@ jobs:
           # build+run enum-variant USE and for/while + break/continue (which the full
           # gate never exercised). The multimodule witness covers import-aware
           # bin/madaros check|run|build, which the full suite can miss when
-          # source and the checked-in prebuilt drift. The source-to-ELF gate
-          # covers the raw --native-v2-compile bridge, so a prebuilt that
-          # regresses the direct source -> native-v2 -> ELF path is not shipped.
+          # source and the checked-in prebuilt drift. The GPU/PTX import witness
+          # guards the kernel_ir + lower_to_ptx + ptx module graph. The
+          # source-to-ELF gate covers the raw --native-v2-compile bridge, so a
+          # prebuilt that regresses the direct source -> native-v2 -> ELF path is
+          # not shipped.
           if bash scripts/ci/madaros_full_gate.sh \
              && bash scripts/ci/madaros_enum_gate.sh \
              && bash scripts/ci/madaros_loop_gate.sh \
              && bash scripts/ci/madaros_multimodule_witness.sh \
+             && bash scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh \
              && bash scripts/ci/madaros_source_to_elf_gate.sh; then
             echo "passed=true" >> "$GITHUB_OUTPUT"
           else
             echo "passed=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::A Madaros gate (full / enum / loop / multimodule witness / source-to-ELF) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
+            echo "::warning::A Madaros gate (full / enum / loop / multimodule witness / GPU-PTX import witness / source-to-ELF) did not pass — keeping the existing prebuilt bin/madaros-linux-x86_64 (no refresh)."
           fi
 
       - name: Install built Madaros as the checked-in prebuilt

--- a/TASK.md
+++ b/TASK.md
@@ -2,13 +2,14 @@
 
 ## Madaros GPU/PTX module-combination guard
 
-- [ ] Track the GPU/PTX module-combination blocker documented in
+- [x] Track the GPU/PTX module-combination blocker documented in
   `docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md`
   and summarized in `docs/MADAROS_STATUS.md`.
-- [ ] Keep a CI-visible regression guard for the normal module graph import
+- [x] Keep a CI-visible regression guard for the normal module graph import
   combination: `gpu::kernel_ir::*` + `gpu::lower_to_ptx::*` + `gpu::ptx::*`.
 - [ ] Follow-up lane: bisect pairwise module combinations and audit `pub`
-  visibility across `self-hosted/gpu/` if the guard regresses.
+  visibility across `self-hosted/gpu/` on `gpu/epistemic-tensor-core-next` if
+  that branch still reproduces the historical error cluster.
 
 # Lane 8c — Regulatory Dossier Generator (dissertation contribution #3 wrapper)
 

--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -113,6 +113,14 @@ as `bin/souc-lean-single-x86_64`.
   for this exact import combination. Cross-reference siblings:
   `docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md` and
   `docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/`.
+- **Canon regression guard now present:** `scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh`
+  checks the pairwise and full import matrix for `gpu::kernel_ir::*`,
+  `gpu::lower_to_ptx::*`, and `gpu::ptx::*`. It runs in `Madaros Greenline Gate`
+  and in the prebuilt-refresh gate chain, so canon/prebuilt publication cannot
+  silently lose this module graph again. If `gpu/epistemic-tensor-core-next`
+  still reproduces the historical E175/E177/E046 cluster, the substantive repair
+  remains branch-local there: compare against canon, then audit `pub`/shape drift
+  across `self-hosted/gpu/`.
 
 Do not say "Madaros is production-ready" merely because #356 is closed. Say the
 specific 2026-06-21 blocker cluster is closed, then use the production-ready

--- a/docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
+++ b/docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
@@ -1,0 +1,203 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02
+-->
+
+# Madaros forensic dispatch — `gpu::kernel_ir` + `gpu::lower_to_ptx` + `gpu::ptx` fail to check together
+
+Date: 2026-07-02
+Branch: `gpu/epistemic-tensor-core-next` (base: `research/solver-ts3-parallel` @ `65f44e60c`,
+merge of PR #572)
+Class: **PRE-EXISTING MODULE-COMBINATION BREAKAGE** (hundreds of typecheck errors,
+independent of any function body or call site — reproducible with an empty `main`)
+Status: root-caused to "this exact 3-module combination is apparently never exercised
+together in CI"; NOT fixed; NOT attempted beyond the diagnosis below
+
+> Found while trying to write a CLI driver
+> (`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio`) to emit PTX for the
+> compiler-generated epistemic WMMA matmul kernel
+> (`self-hosted/gpu/kernel_ir.sio::gpu_build_epistemic_wmma_matmul_16x16_ir`) for
+> hardware verification on the DGX Spark. This dispatch documents why that driver
+> still cannot be built into a native ELF on this branch, so the blocker survives
+> context loss instead of being rediscovered from scratch.
+
+## Symptom
+
+A `.sio` file that does nothing but import three GPU backend modules and return 0 from
+`main` fails `souc check` with **hundreds of errors** — no call into any of the three
+modules is required to trigger it:
+
+```sio
+use gpu::kernel_ir::*
+use gpu::lower_to_ptx::*
+use gpu::ptx::*
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    0
+}
+```
+
+```
+$ ./bin/souc check probe.sio
+run_check_mode: about to check 4 modules
+error[E175] ... : function is private in its defining module     (335 occurrences)
+error[E177] ... : enum constructor is private in its defining module   (18 occurrences)
+error[E046] ... : struct literal has wrong number of fields       (5 occurrences)
+run_check_mode: verdict=1
+```
+
+None of these errors reference anything the probe file itself wrote — `main`'s body is
+just `0`. They come from the transitive resolution of `kernel_ir.sio` + `lower_to_ptx.sio`
++ `ptx.sio` against each other.
+
+## Why this matters
+
+`self-hosted/gpu/mod.sio` — the GPU backend's own orchestrator, which re-exports
+"all GPU code generation and runtime modules" per its header comment — does **not**
+import `gpu::lower_to_ptx`:
+
+```sio
+module gpu::mod
+
+use gpu::kernel_ir::*
+use gpu::hlir_to_gpu::*
+use gpu::epistemic_spirv::*
+use gpu::ptx::*
+use gpu::metal::*
+use gpu::cuda_tile::*
+```
+
+`souc check self-hosted/gpu/mod.sio` passes clean (only pre-existing stack-frame-size
+warnings, `verdict=0`). That's real evidence the rest of the GPU backend is healthy — but
+it also means **nothing in the checked, working surface actually exercises
+`lower_to_ptx.sio` together with `kernel_ir.sio` and `ptx.sio`**, even though
+`lower_to_ptx.sio` is the documented, intended "phase 1" lowering path
+(`GpuKernelIr -> PTX`) and both `self-hosted/test_epistemic_wmma.sio` and
+`self-hosted/gpu/spirv_lower.sio`'s self-checks call `gpu_lower_to_ptx` directly. Those
+test files have no `use` statements themselves and are only ever compiled by
+concatenation into the full bootstrap bundle (`scripts/bootstrap/bootstrap_concat.sh`,
+`BOOTSTRAP_PROFILE=full`), which sidesteps normal module-boundary checking entirely (no
+`use`, no cross-module privacy enforcement) and — separately — currently segfaults during
+native codegen for unrelated reasons. So this 3-module combination, checked as its own
+proper module graph, has apparently never been validated.
+
+## What's actually failing
+
+Not investigated function-by-function (335 + 18 + 5 = 358 errors is not something to
+triage one at a time by hand). The three error classes:
+
+- **E175 "function is private in its defining module"** (335x) and **E177 "enum
+  constructor is private in its defining module"** (18x) — some function/module needed by
+  the `lower_to_ptx.sio` <-> `ptx.sio` call chain lost its `pub` modifier (or was never
+  `pub`) relative to what cross-module resolution now needs. This matches a pattern seen
+  elsewhere on this branch this session: `self-hosted/gpu/kernel_ir.sio`'s `struct Name`
+  and `struct GpuOp` field declarations were observed to have lost their `pub` prefixes at
+  some point in this branch's history (compare: an earlier commit on this same GPU work
+  needed to add `pub` back to `gpu_build_epistemic_wmma_matmul_16x16_ir` for exactly this
+  reason). This looks like **ongoing, uncoordinated privacy-annotation drift** across the
+  GPU module tree, not a one-off.
+- **E046 "struct literal has wrong number of fields"** (5x, at byte offsets 80304, 82284,
+  82895, 83507, 85443 in the 4-module concatenation) — a struct literal somewhere in this
+  combination doesn't match its struct's current field list. Given the E175/E177 pattern
+  above, the likely cause is the same class of drift: a struct gained/lost a field in one
+  file without every literal constructing it (in a different file) being updated to match.
+
+Neither class was root-caused to a specific symbol/line — that requires either a bisection
+across `lower_to_ptx.sio`'s and `ptx.sio`'s own internal `use` graphs (which files, not
+which functions), or fixing the compiler to emit file:line instead of raw byte offsets
+into the concatenated check buffer.
+
+## Reproduction
+
+```bash
+cat > /tmp/probe.sio << 'EOF'
+use gpu::kernel_ir::*
+use gpu::lower_to_ptx::*
+use gpu::ptx::*
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    0
+}
+EOF
+cp /tmp/probe.sio self-hosted/gpu/probe.sio   # must live under self-hosted/gpu/ for `use gpu::*` to resolve
+./bin/souc check self-hosted/gpu/probe.sio
+rm self-hosted/gpu/probe.sio
+```
+
+Expect `verdict=1` with the error counts above. `./bin/souc check self-hosted/gpu/mod.sio`
+in the same tree passes (`verdict=0`) for contrast.
+
+## What was ruled out (not the cause)
+
+- **Not a MY-code issue.** The probe's `main` body is empty; no call into any of the three
+  modules occurs.
+- **Not `IR_MAX_INSTRS` (the sibling `docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md`
+  finding).** That issue is real and separate — three unrelated large functions in
+  `kernel_ir.sio` (`gpu_build_gemm_shared_ir`, `gpu_build_conv2d_ir`,
+  `gpu_build_epistemic_tiled_gemm_ir`) do independently exceed the 1024-instruction cap
+  and block `souc build` (not `souc check`) of anything importing `kernel_ir.sio`
+  wholesale — but fixing that (raising the cap; attempted and reverted this session,
+  touching ~680 call sites across 7 files) does not touch the E175/E177/E046 errors here,
+  which occur at `check` time, before lowering ever starts.
+- **Not the known Madaros native-codegen segfault** (see `docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/`
+  and related) — this dispatch is entirely about `check`/typecheck-time failures, upstream
+  of codegen.
+- **Not a stale pinned binary.** `bin/souc` was rebuilt as of this branch's HEAD; the
+  errors reproduce with the in-tree compiler on the in-tree source, not an old artifact.
+
+## Impact
+
+Any new CLI driver that needs `gpu_lower_to_ptx` (the `GpuKernelIr -> PTX` path) — i.e.
+anything downstream of `self-hosted/gpu/kernel_ir.sio`'s `gpu_build_*_ir()` builder
+functions that isn't reachable through `bin/kretikos`'s existing K-AXI-only dispatch —
+cannot currently be compiled to a native ELF via `souc build`, because `souc check`
+already rejects the module combination before codegen is reached. This blocked
+`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` (added 2026-07-02 to expose
+`gpu_build_epistemic_wmma_matmul_16x16_ir`'s PTX for DGX Spark hardware verification) from
+ever reaching the native-codegen stage on this branch.
+
+## Canon greenline guard
+
+The canonical greenline now carries a cheap import witness for the normal module graph:
+
+```bash
+bash scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
+```
+
+It checks these four combinations:
+
+- `gpu::kernel_ir::*` + `gpu::lower_to_ptx::*`
+- `gpu::lower_to_ptx::*` + `gpu::ptx::*`
+- `gpu::kernel_ir::*` + `gpu::ptx::*`
+- `gpu::kernel_ir::*` + `gpu::lower_to_ptx::*` + `gpu::ptx::*`
+
+This witness is a regression guard for canon. The substantive branch-specific repair,
+if the GPU lane still reproduces the historical error cluster, remains on
+`gpu/epistemic-tensor-core-next`.
+
+## Proposed next step (not attempted here)
+
+1. On the GPU implementation branch, rerun the pairwise import witness and compare it
+   with canon. If only that branch fails, bisect branch-local privacy/shape drift.
+2. Audit `pub`/private-modifier consistency across the whole `self-hosted/gpu/` tree in one
+   pass (grep for struct/fn declarations missing `pub` that are referenced via `::*`
+   imports from outside their own file) rather than patching one symbol at a time as each
+   is hit — the repeated pattern (`Name`, `GpuOp`, and now this) suggests a systemic gap,
+   not isolated typos.
+3. Keep the CI witness for `gpu::kernel_ir` + `gpu::lower_to_ptx` + `gpu::ptx` together so
+   this combination is never silently unvalidated again.
+
+## Cross-references
+
+- `docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md` — separate, orthogonal
+  compile-time cap issue in the same file (`kernel_ir.sio`), hit while chasing this one.
+- `docs/audit/EPISTEMIC_MADAROS_SIGSEGV_2026-06-29/` — separate native-codegen segfault
+  class, downstream of where this dispatch's errors occur.
+- `self-hosted/gpu/kretikos_emit_epistemic_wmma.sio` — the driver whose build is blocked by
+  this; its commit history on `gpu/epistemic-tensor-core-next` records the specific
+  symptoms hit in order (segfault -> `var`-without-initializer typecheck regression, fixed
+  -> this module-combination breakage, not fixed).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 850
-- Repo-backed topics: 700
+- Total governed topics: 851
+- Repo-backed topics: 701
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 494
+- Authority count `repo_only`: 495
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 498 topics
+- A2: 499 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -125,6 +125,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-closures-step2-capture-2026-06-24 | repo_only | docs/audit/MADAROS_CLOSURES_STEP2_CAPTURE_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-enum-variant-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_ENUM_VARIANT_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-for-loop-lowering-2026-06-20 | repo_only | docs/audit/MADAROS_FOR_LOOP_LOWERING_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02 | repo_only | docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-method-two-roots-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-impl-methods-three-layer-fix-2026-06-23 | repo_only | docs/audit/MADAROS_IMPL_METHODS_THREE_LAYER_FIX_2026-06-23.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-match-guards-2026-06-24 | repo_only | docs/audit/MADAROS_MATCH_GUARDS_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2347,6 +2347,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.madaros-gpu-kernel-ir-lower-to-ptx-ptx-module-combination-2026-07-02",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-impl-method-two-roots-2026-06-23",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_IMPL_METHOD_TWO_ROOTS_2026-06-23.md",

--- a/scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
+++ b/scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# madaros_gpu_ptx_pairwise_import_witness.sh — cheap GPU/PTX module import matrix.
+#
+# This guards the normal module graph for the PTX lowering spine:
+#   gpu::kernel_ir::* + gpu::lower_to_ptx::* + gpu::ptx::*
+#
+# The historical failure was a check-time privacy/shape explosion in this exact
+# combination. Keep this witness small: it only typechecks empty check-only
+# probes and does not require CUDA, PTX assembly, or native GPU execution.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ "$(uname -s 2>/dev/null || echo unknown)" != "Linux" ]]; then
+  echo "[madaros-gpu-ptx-import] SKIP: Linux-only gate" >&2
+  exit 0
+fi
+
+case "$(uname -m 2>/dev/null || echo unknown)" in
+  x86_64|amd64) ;;
+  *)
+    echo "[madaros-gpu-ptx-import] SKIP: x86-64 Linux-only gate" >&2
+    exit 0
+    ;;
+esac
+
+source "$ROOT_DIR/scripts/lib/resolve_madaros.sh"
+sounio_require_madaros
+
+OUT_DIR="${SOUNIO_MADAROS_GPU_PTX_IMPORT_DIR:-$(mktemp -d /tmp/sounio-madaros-gpu-ptx-import.XXXXXX)}"
+PROBE_DIR="$OUT_DIR/probes"
+LOG_DIR="$OUT_DIR/logs"
+RESULTS_TSV="$OUT_DIR/results.tsv"
+
+mkdir -p "$PROBE_DIR" "$LOG_DIR"
+
+echo "[madaros-gpu-ptx-import] START"
+echo "[madaros-gpu-ptx-import] madaros=$MADAROS_BIN"
+echo "[madaros-gpu-ptx-import] out=$OUT_DIR"
+
+write_probe() {
+  local case_id="$1"
+  shift
+
+  local probe="$PROBE_DIR/$case_id.sio"
+  {
+    echo '//@ check-only'
+    for module_name in "$@"; do
+      printf 'use gpu::%s::*\n' "$module_name"
+    done
+    echo
+    echo 'fn main() -> i32 {'
+    echo '    0'
+    echo '}'
+  } >"$probe"
+
+  echo "$probe"
+}
+
+run_case() {
+  local case_id="$1"
+  shift
+
+  local probe check_log rc status e175 e177 e046
+  probe="$(write_probe "$case_id" "$@")"
+  check_log="$LOG_DIR/$case_id.check.log"
+
+  set +e
+  "$MADAROS_BIN" check "$probe" >"$check_log" 2>&1
+  rc=$?
+  set -e
+
+  if [[ "$rc" == 0 ]]; then
+    status="check_ok"
+    printf '%s\t%s\t%s\t%s\n' "$case_id" "$probe" "$rc" "$status" >>"$RESULTS_TSV"
+    echo "[madaros-gpu-ptx-import] PASS: $case_id"
+    return 0
+  fi
+
+  status="check_failed"
+  printf '%s\t%s\t%s\t%s\n' "$case_id" "$probe" "$rc" "$status" >>"$RESULTS_TSV"
+  e175="$(grep -c 'error\[E175' "$check_log" || true)"
+  e177="$(grep -c 'error\[E177' "$check_log" || true)"
+  e046="$(grep -c 'error\[E046' "$check_log" || true)"
+  echo "[madaros-gpu-ptx-import] FAIL: $case_id rc=$rc E175=$e175 E177=$e177 E046=$e046" >&2
+  tail -n 60 "$check_log" >&2 || true
+  return 1
+}
+
+printf 'case_id\tprobe\trc\tstatus\n' >"$RESULTS_TSV"
+
+run_case kernel_ir__lower_to_ptx kernel_ir lower_to_ptx
+run_case lower_to_ptx__ptx lower_to_ptx ptx
+run_case kernel_ir__ptx kernel_ir ptx
+run_case kernel_ir__lower_to_ptx__ptx kernel_ir lower_to_ptx ptx
+
+echo "[madaros-gpu-ptx-import] PASS: 4/4 import witnesses"
+echo "[madaros-gpu-ptx-import] results=$RESULTS_TSV"

--- a/scripts/ci/madaros_operational_contract_gate.sh
+++ b/scripts/ci/madaros_operational_contract_gate.sh
@@ -352,6 +352,7 @@ require_madaros_proof_anchor() {
 
 require_file docs/MADAROS_STATUS.md
 require_file docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+require_file docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
 require_file docs/status/madaros_main_proof_17d115.md
 require_file AGENTS.md
 require_file CLAUDE.md
@@ -363,6 +364,7 @@ require_file scripts/lib/resolve_madaros.sh
 require_file scripts/ci/build_modular_madaros.sh
 require_file scripts/ci/madaros_full_gate.sh
 require_file scripts/ci/madaros_source_to_elf_gate.sh
+require_executable scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
 require_executable scripts/dev/madaros_two_gate.sh
 require_executable scripts/dev/madaros_worktree_cleanup_plan.sh
 require_executable scripts/dev/madaros_worktree_cleanup_approval.sh
@@ -385,7 +387,10 @@ require_grep 'ungated' docs/MADAROS_STATUS.md
 require_grep 'artifacts/self-hosted/madaros' docs/MADAROS_STATUS.md
 require_grep 'binary is **not evidence**' docs/MADAROS_STATUS.md
 require_grep 'scripts/ci/madaros_operational_contract_gate.sh' docs/MADAROS_STATUS.md
+require_grep 'scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh' docs/MADAROS_STATUS.md
 require_grep 'scripts/dev/madaros_worktree_cleanup_plan.sh' docs/audit/MADAROS_WORKTREE_CLEANUP_LEDGER_2026-07-03.md
+require_grep 'PRE-EXISTING MODULE-COMBINATION BREAKAGE' docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
+require_grep 'gpu::kernel_ir' docs/audit/MADAROS_GPU_KERNEL_IR_LOWER_TO_PTX_PTX_MODULE_COMBINATION_2026-07-02.md
 
 require_grep 'scripts/lib/resolve_madaros.sh' AGENTS.md
 require_grep 'docs/MADAROS_STATUS.md' AGENTS.md
@@ -410,9 +415,15 @@ require_grep 'receipt_ok' scripts/ci/madaros_full_gate.sh
 require_grep 'SOUNIO_MADAROS_FULL_GATE_SKIP_SMT' scripts/ci/madaros_full_gate.sh
 require_grep 'imported-SMT solver gate' scripts/ci/madaros_full_gate.sh
 require_grep 'write_gate_receipt' scripts/ci/madaros_full_gate.sh
+require_grep 'kernel_ir__lower_to_ptx__ptx' scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
+require_grep 'error\[E175' scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
+require_grep 'error\[E177' scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
+require_grep 'error\[E046' scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh
 require_grep 'Madaros Greenline Gate' .github/workflows/ci.yml
 require_grep 'make madaros-full-gate' .github/workflows/ci.yml
 require_grep 'scripts/dev/madaros_two_gate.sh artifacts/self-hosted/madaros' .github/workflows/ci.yml
+require_grep 'scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh' .github/workflows/ci.yml
+require_grep 'scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh' .github/workflows/madaros-prebuilt-refresh.yml
 require_grep 'madaros_source_to_elf_gate.sh' .github/workflows/madaros-prebuilt-refresh.yml
 require_grep 'source-to-ELF' .github/workflows/madaros-prebuilt-refresh.yml
 


### PR DESCRIPTION
## Summary

- Add the missing GPU/PTX module-combination audit dispatch to the canonical greenline docs and register it in governance metadata.
- Add `scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh`, a cheap check-only matrix for `gpu::kernel_ir::*`, `gpu::lower_to_ptx::*`, and `gpu::ptx::*` pairwise/full imports.
- Wire the witness into `Madaros Greenline Gate`, the prebuilt refresh gate chain, and the Madaros operational contract gate.
- Mark the canon TODO items for blocker tracking and CI-visible regression guarding as complete, leaving the branch-local GPU repair lane open.

## Why

`docs/MADAROS_STATUS.md` and `TASK.md` referenced the GPU/PTX audit dispatch from `gpu/epistemic-tensor-core-next`, but the file was absent on `canon/madaros-greenline`. The canon branch already had a single check-only test for the full import combination; this PR makes the broader pairwise witness explicit and keeps the documented blocker from becoming a dangling reference.

## Validation

- `bash -n scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh scripts/ci/madaros_operational_contract_gate.sh`
- `bash scripts/ci/madaros_gpu_ptx_pairwise_import_witness.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `git diff --check`
- `bash scripts/ci/madaros_operational_contract_gate.sh`

## Notes

This is canon gate/tracking hardening, not the substantive GPU implementation repair. If `gpu/epistemic-tensor-core-next` still reproduces the historical E175/E177/E046 cluster, the follow-up remains branch-local there: compare against canon, then audit `pub`/shape drift across `self-hosted/gpu/`.
