### PR TITLE
[madaros] port receipt-gated route to GPU lane

### DIFF
--- a/bin/madaros
+++ b/bin/madaros
@@ -12,7 +12,7 @@
 #   madaros --version
 #   madaros info
 #   madaros check input.sio
-#   madaros build input.sio -o out.elf
+#   madaros build input.sio [-o OUT] [--backend native|gpu]
 #   madaros run input.sio
 #   madaros pkg ...
 #
@@ -31,18 +31,52 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Resolve the underlying modular raw ELF.
 # Resolution order:
 #   1. MADAROS_RAW_BIN / SOUNIO_MADAROS_BIN env var
-#   2. artifacts/self-hosted/madaros (built by make build-madaros)
-#   3. bin/madaros-linux-x86_64 (checked-in prebuilt)
+#   2. artifacts/self-hosted/madaros, only with a matching .gate-receipt
+#      proving the SMT gate was not skipped
+#   3. bin/madaros-relocgate (verified-green fallback)
+#   4. bin/madaros-linux-x86_64 (checked-in prebuilt)
+_is_modular_elf() {
+  [[ -n "${1:-}" && -x "$1" && "$(head -c 2 "$1" 2>/dev/null)" != "#!" ]]
+}
+
+_madaros_receipt_ok() {
+  local elf="$1"
+  local receipt="$elf.gate-receipt"
+  [[ -f "$receipt" ]] || return 1
+  local want
+  want="$(sha256sum "$elf" 2>/dev/null | cut -d' ' -f1)"
+  [[ -n "$want" ]] || return 1
+  grep -Fq "$want" "$receipt" || return 1
+  grep -Fxq "smt_skip=0" "$receipt"
+}
+
 _resolve_modular_elf() {
   local cand
-  for cand in "${MADAROS_RAW_BIN:-}" "${SOUNIO_MADAROS_BIN:-}" "$ROOT_DIR/artifacts/self-hosted/madaros" "$ROOT_DIR/bin/madaros-linux-x86_64"; do
-    if [[ -n "$cand" && -x "$cand" && "$(head -c 2 "$cand" 2>/dev/null)" != "#!" ]]; then
+  for cand in "${MADAROS_RAW_BIN:-}" "${SOUNIO_MADAROS_BIN:-}"; do
+    if _is_modular_elf "$cand"; then
       echo "$cand"
       return 0
     fi
   done
+
+  local artifact="$ROOT_DIR/artifacts/self-hosted/madaros"
+  if _is_modular_elf "$artifact"; then
+    if _madaros_receipt_ok "$artifact"; then
+      echo "$artifact"
+      return 0
+    fi
+    echo "warning: using ungated $artifact skipped; export MADAROS_RAW_BIN=$ROOT_DIR/bin/madaros-relocgate for the verified-green binary" >&2
+  fi
+
+  for cand in "$ROOT_DIR/bin/madaros-relocgate" "$ROOT_DIR/bin/madaros-linux-x86_64"; do
+    if _is_modular_elf "$cand"; then
+      echo "$cand"
+      return 0
+    fi
+  done
+
   echo "error: madaros: no modular compiler raw ELF found" >&2
-  echo "  tried: MADAROS_RAW_BIN, SOUNIO_MADAROS_BIN, $ROOT_DIR/artifacts/self-hosted/madaros, $ROOT_DIR/bin/madaros-linux-x86_64" >&2
+  echo "  tried: MADAROS_RAW_BIN, SOUNIO_MADAROS_BIN, $artifact (receipt-gated), $ROOT_DIR/bin/madaros-relocgate, $ROOT_DIR/bin/madaros-linux-x86_64" >&2
   echo "  run: make build-madaros" >&2
   return 1
 }
@@ -64,10 +98,14 @@ madaros — launcher for the Madaros modular compiler ($RAW_MADAROS)
 Usage:
   madaros --version                     print compiler identity
   madaros info                          print resolution path
-  madaros check <source.sio>            parse, resolve and typecheck
-  madaros build <source.sio> [-o OUT]   compile source to a native ELF
-  madaros compile <source.sio> [-o OUT] alias for build
-  madaros run <source.sio>              compile to a temp ELF and run it
+  madaros check <source.sio|project-dir>
+                                      parse, resolve and typecheck
+  madaros build <source.sio|project-dir> [-o OUT] [--backend native|gpu]
+                                      compile source to native ELF or GPU artifact
+  madaros compile <source.sio|project-dir> [-o OUT]
+                                      alias for build
+  madaros run <source.sio|project-dir>
+                                      compile to a temp ELF and run it
   madaros pkg <subcommand>...           package-manager commands
   madaros <raw-compiler-args>...        pass through to the raw ELF
 
@@ -78,6 +116,12 @@ Common modular-compiler modes:
   madaros --native-v2-emit-scalar N     emit a scalar witness
   madaros --version-json                emit version metadata
   madaros pkg ...                       package manager commands
+
+GPU build options:
+  --backend gpu                         emit PTX via the public GPU build path
+  --gpu-target <target>                 raw GPU target (default: cuda-sm80)
+  --gpu-binary-format <fmt>             raw GPU format/mode selector
+  --gpu-precision <f32|f64>             compatibility alias for GPU mode
 
 Environment:
   SOUNIO_STDLIB_PATH=<dir>     forwarded to raw ELF
@@ -99,6 +143,105 @@ version() {
   local out
   out="$("$RAW_MADAROS" /dev/null /dev/null 2>/dev/null)" || true
   echo "$out" | head -n 1
+}
+
+find_project_root() {
+  local start="${1:-$PWD}"
+  if [[ -f "$start" ]]; then
+    start="$(dirname "$start")"
+  fi
+  if [[ -d "$start" ]]; then
+    start="$(cd "$start" && pwd)"
+  else
+    return 1
+  fi
+  while [[ "$start" != "/" ]]; do
+    if [[ -f "$start/sounio.toml" ]]; then
+      printf '%s\n' "$start"
+      return 0
+    fi
+    start="$(dirname "$start")"
+  done
+  return 1
+}
+
+project_manifest_value() {
+  local root="$1"
+  local key="$2"
+  python3 - "$root/sounio.toml" "$key" <<'PY'
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    raise SystemExit(3)
+path, key = sys.argv[1], sys.argv[2]
+text = open(path, "rb").read().decode("utf-8")
+data = tomllib.loads(text)
+if key == "package.name":
+    print(data.get("package", {}).get("name", "sounio-project"))
+elif key == "entry":
+    bins = data.get("bin", [])
+    if isinstance(bins, list) and bins:
+        value = bins[0].get("path", "")
+        if value:
+            print(value)
+            raise SystemExit(0)
+    value = data.get("project", {}).get("entry", "")
+    if value:
+        print(value)
+        raise SystemExit(0)
+    value = data.get("lib", {}).get("path", "")
+    if value and "[[bin]]" not in text:
+        print(value)
+        raise SystemExit(0)
+    print("src/main.sio")
+else:
+    raise SystemExit(2)
+PY
+}
+
+resolve_source_or_project() {
+  local candidate="${1:-}"
+  if [[ -n "$candidate" && -f "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  local root=""
+  if [[ -n "$candidate" && -d "$candidate" ]]; then
+    root="$(find_project_root "$candidate" || true)"
+  else
+    root="$(find_project_root "$PWD" || true)"
+  fi
+  if [[ -z "$root" ]]; then
+    return 1
+  fi
+
+  local entry
+  entry="$(project_manifest_value "$root" entry)"
+  if [[ ! -f "$root/$entry" ]]; then
+    echo "error: project entry not found: $root/$entry" >&2
+    return 1
+  fi
+  printf '%s\n' "$root/$entry"
+}
+
+project_default_output() {
+  local root="$1"
+  local name
+  name="$(project_manifest_value "$root" package.name)"
+  mkdir -p "$root/target"
+  printf '%s\n' "$root/target/$name"
+}
+
+args_have_output() {
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "-o" || "$arg" == "--output" ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 _check_source_arg() {
@@ -126,10 +269,11 @@ _run_raw_check() {
   ( ulimit -v 8388608 2>/dev/null || true; exec timeout 120 "$RAW_MADAROS" --check "$src" "$@" )
 }
 
-_parse_output_path() {
-  local fallback="$1"
-  shift
-  local out="$fallback"
+_parse_build_options() {
+  BUILD_OUT="a.out"
+  BUILD_BACKEND="native"
+  BUILD_GPU_TARGET="cuda-sm80"
+  BUILD_GPU_BINARY_FORMAT=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -o|--output)
@@ -137,7 +281,46 @@ _parse_output_path() {
           echo "error: madaros build: $1 requires a path" >&2
           return 2
         fi
-        out="$2"
+        BUILD_OUT="$2"
+        shift 2
+        ;;
+      --backend)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --backend requires native or gpu" >&2
+          return 2
+        fi
+        BUILD_BACKEND="$2"
+        shift 2
+        ;;
+      --gpu-target)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --gpu-target requires a target" >&2
+          return 2
+        fi
+        BUILD_GPU_TARGET="$2"
+        shift 2
+        ;;
+      --gpu-binary-format)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --gpu-binary-format requires a format" >&2
+          return 2
+        fi
+        BUILD_GPU_BINARY_FORMAT="$2"
+        shift 2
+        ;;
+      --gpu-precision)
+        if [[ $# -lt 2 ]]; then
+          echo "error: madaros build: --gpu-precision requires f32 or f64" >&2
+          return 2
+        fi
+        case "$2" in
+          f32) BUILD_GPU_BINARY_FORMAT="f32" ;;
+          f64) BUILD_GPU_BINARY_FORMAT="" ;;
+          *)
+            echo "error: madaros build: unsupported --gpu-precision: $2" >&2
+            return 2
+            ;;
+        esac
         shift 2
         ;;
       *)
@@ -146,7 +329,14 @@ _parse_output_path() {
         ;;
     esac
   done
-  echo "$out"
+  case "$BUILD_BACKEND" in
+    native|"") BUILD_BACKEND="native" ;;
+    gpu) ;;
+    *)
+      echo "error: madaros build: unsupported backend: $BUILD_BACKEND" >&2
+      return 2
+      ;;
+  esac
 }
 
 _build_source() {
@@ -157,10 +347,23 @@ _build_source() {
     echo "error: madaros build: source is empty: $src" >&2
     return 1
   fi
-  local out
-  out="$(_parse_output_path a.out "$@")"
+  _parse_build_options "$@"
+  local out="$BUILD_OUT"
   mkdir -p "$(dirname "$out")"
   rm -f "$out"
+  if [[ "$BUILD_BACKEND" == "gpu" ]]; then
+    local gpu_args=("$src" -o "$out" --gpu-target "$BUILD_GPU_TARGET")
+    if [[ -n "$BUILD_GPU_BINARY_FORMAT" ]]; then
+      gpu_args+=(--gpu-binary-format "$BUILD_GPU_BINARY_FORMAT")
+    fi
+    # Guard: 16 GB vmem + 300 s timeout
+    ( ulimit -v 16777216 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "${gpu_args[@]}" )
+    if [[ ! -s "$out" ]]; then
+      echo "error: madaros build: compiler produced no GPU artifact at $out" >&2
+      return 1
+    fi
+    return 0
+  fi
   # Guard: 16 GB vmem + 300 s timeout
   ( ulimit -v 16777216 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$src" -o "$out" )
   if [[ ! -s "$out" ]]; then
@@ -197,25 +400,53 @@ case "$1" in
     info
     ;;
   check)
-    if [[ $# -lt 2 ]]; then
-      echo "error: madaros check: missing source file" >&2
+    shift
+    candidate="${1:-}"
+    if ! src="$(resolve_source_or_project "$candidate")"; then
+      echo "error: madaros check requires <source.sio> or a project with sounio.toml" >&2
       exit 2
     fi
-    _run_raw_check "$2" "${@:3}"
+    if [[ -n "$candidate" ]]; then
+      shift
+    fi
+    _run_raw_check "$src" "$@"
     ;;
   build|compile)
-    if [[ $# -lt 2 ]]; then
-      echo "error: madaros build: missing source file" >&2
+    shift
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || "${1:-}" == "help" ]]; then
+      usage
+      exit 0
+    fi
+    candidate="${1:-}"
+    if [[ -n "$candidate" && "$candidate" != -* ]]; then
+      shift
+    else
+      candidate=""
+    fi
+    if ! src="$(resolve_source_or_project "$candidate")"; then
+      echo "error: madaros build requires <source.sio> or a project with sounio.toml" >&2
       exit 2
     fi
-    _build_source "$2" "${@:3}"
+    project_root=""
+    if [[ -z "$candidate" || -d "$candidate" ]]; then
+      project_root="$(find_project_root "${candidate:-$PWD}" || true)"
+    fi
+    if [[ -n "$project_root" ]] && ! args_have_output "$@"; then
+      set -- "$@" -o "$(project_default_output "$project_root")"
+    fi
+    _build_source "$src" "$@"
     ;;
   run)
-    if [[ $# -lt 2 ]]; then
-      echo "error: madaros run: missing source file" >&2
+    shift
+    candidate="${1:-}"
+    if ! src="$(resolve_source_or_project "$candidate")"; then
+      echo "error: madaros run requires <source.sio> or a project with sounio.toml" >&2
       exit 2
     fi
-    _run_source "$2" "${@:3}"
+    if [[ -n "$candidate" ]]; then
+      shift
+    fi
+    _run_source "$src" "$@"
     ;;
   -h|--help|help)
     usage

--- a/docs/MADAROS_STATUS.md
+++ b/docs/MADAROS_STATUS.md
@@ -80,6 +80,14 @@ as `bin/souc-lean-single-x86_64`.
   `bin/madaros-relocgate`. Verify `bin/madaros` and `scripts/lib/resolve_madaros.sh`
   locally before claiming the safe compiler route on that branch; merge/rebase the
   protected `canon/madaros-greenline` compiler lane before final landing.
+- **Stacked compiler-route port (2026-07-03):** `work/madaros-route-port-codex`
+  ports the protected greenline resolver/full-gate files onto the green GPU/PTX
+  witness branch and refreshes `bin/madaros-linux-x86_64` to the proved artifact
+  hash `0441113419b71ed0fa24348ae8ef0ad0f2a0ff9a38a13ada3409c283984d7d19`.
+  Local proof on that branch: default `bin/madaros run
+  tests/stdlib/theorem/test_smt_solver_basic.sio` exits 0, `scripts/dev/madaros_two_gate.sh
+  bin/madaros-linux-x86_64` reports `two_gate: A=6/6 B=pass`, and
+  `scripts/ci/madaros_full_gate.sh` exits 0 with imported-SMT 6/6.
 
 Do not say "Madaros is production-ready" merely because #356 is closed. Say the
 specific 2026-06-21 blocker cluster is closed, then use the production-ready

--- a/scripts/ci/madaros_full_gate.sh
+++ b/scripts/ci/madaros_full_gate.sh
@@ -7,16 +7,54 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 MADAROS="${MADAROS_BIN:-$ROOT_DIR/bin/madaros}"
-RAW_MADAROS="${MADAROS_RAW_BIN:-}"
-if [[ -z "$RAW_MADAROS" ]]; then
-  if [[ -x "$ROOT_DIR/artifacts/self-hosted/madaros" ]]; then
-    RAW_MADAROS="$ROOT_DIR/artifacts/self-hosted/madaros"
-  else
-    RAW_MADAROS="$ROOT_DIR/bin/madaros-linux-x86_64"
+GATE_STDLIB="${SOUNIO_MADAROS_FULL_GATE_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+is_elf() {
+  [[ -n "${1:-}" && -x "$1" && "$(head -c 2 "$1" 2>/dev/null)" != "#!" ]]
+}
+
+receipt_ok() {
+  local elf="$1"
+  local receipt="${2:-$elf.gate-receipt}"
+  [[ -f "$receipt" ]] || return 1
+  local want
+  want="$(sha256sum "$elf" 2>/dev/null | cut -d' ' -f1)"
+  [[ -n "$want" ]] || return 1
+  grep -Fq "$want" "$receipt" || return 1
+  grep -Fxq "smt_skip=0" "$receipt"
+}
+
+resolve_raw_madaros() {
+  local cand
+  for cand in "${MADAROS_RAW_BIN:-}" "${SOUNIO_MADAROS_BIN:-}"; do
+    if is_elf "$cand"; then
+      echo "$cand"
+      return 0
+    fi
+  done
+
+  local artifact="$ROOT_DIR/artifacts/self-hosted/madaros"
+  if is_elf "$artifact"; then
+    echo "$artifact"
+    return 0
   fi
-fi
+
+  for cand in "$ROOT_DIR/bin/madaros-relocgate" "$ROOT_DIR/bin/madaros-linux-x86_64"; do
+    if is_elf "$cand"; then
+      echo "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
+RAW_MADAROS="$(resolve_raw_madaros)" || {
+  echo "[madaros-full] FAIL: no Madaros raw ELF found" >&2
+  exit 1
+}
 WORK="${SOUNIO_MADAROS_FULL_GATE_DIR:-$(mktemp -d /tmp/sounio-madaros-full.XXXXXX)}"
 KEEP_WORK="${SOUNIO_MADAROS_FULL_GATE_KEEP:-0}"
+SMT_GATE_RAN=0
+SMT_GATE_PASS=0
 
 if [[ "$KEEP_WORK" != "1" ]]; then
   trap 'rm -rf "$WORK"' EXIT
@@ -62,11 +100,87 @@ expect_elf_runs() {
   expect_exit "$expected" "$elf"
 }
 
+run_imported_smt_gate() {
+  if [[ "${SOUNIO_MADAROS_FULL_GATE_SKIP_SMT:-0}" == "1" ]]; then
+    echo "[madaros-full] SKIP: imported-SMT solver gate (SOUNIO_MADAROS_FULL_GATE_SKIP_SMT=1)"
+    fail "imported-SMT solver gate skipped; this gate is non-green without SMT 6/6"
+  fi
+
+  mapfile -t smt_tests < <(find "$ROOT_DIR/tests/stdlib/theorem" -maxdepth 1 -name 'test_smt_*.sio' -print | sort)
+  if [[ "${#smt_tests[@]}" -ne 6 ]]; then
+    fail "expected exactly 6 imported-SMT fixtures, found ${#smt_tests[@]}"
+  fi
+
+  SMT_GATE_RAN=1
+  local pass_count=0
+  local test_path log rc
+  for test_path in "${smt_tests[@]}"; do
+    log="$WORK/smt_$(basename "$test_path").log"
+    set +e
+    env MADAROS_RAW_BIN="$RAW_MADAROS" timeout 120 "$MADAROS" run "$test_path" >"$log" 2>&1
+    rc=$?
+    set -e
+    if [[ "$rc" -ne 0 ]]; then
+      echo "[madaros-full] imported-SMT failure: $(basename "$test_path") rc=$rc" >&2
+      tail -n 40 "$log" >&2 || true
+      fail "imported-SMT solver gate failed"
+    fi
+    pass_count=$((pass_count + 1))
+  done
+
+  if [[ "$pass_count" -ne 6 ]]; then
+    fail "imported-SMT solver gate incomplete: $pass_count/6"
+  fi
+  SMT_GATE_PASS=1
+  pass "imported-SMT solver gate (6/6)"
+}
+
+write_gate_receipt() {
+  if [[ "$SMT_GATE_RAN" != "1" || "$SMT_GATE_PASS" != "1" ]]; then
+    echo "[madaros-full] note: no gate receipt written (SMT gate did not run/pass)"
+    return
+  fi
+
+  local canonical="$ROOT_DIR/artifacts/self-hosted/madaros"
+  local receipt="${SOUNIO_MADAROS_FULL_GATE_RECEIPT_PATH:-}"
+  if [[ -z "$receipt" ]]; then
+    if [[ "$RAW_MADAROS" != "$canonical" ]]; then
+      echo "[madaros-full] note: no gate receipt written for non-canonical raw ELF: $RAW_MADAROS"
+      return
+    fi
+    receipt="$canonical.gate-receipt"
+  fi
+
+  local sha now tmp
+  sha="$(sha256sum "$RAW_MADAROS" | cut -d' ' -f1)"
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  tmp="$receipt.tmp.$$"
+  mkdir -p "$(dirname "$receipt")"
+  {
+    echo "madaros_full_gate_receipt_v1"
+    echo "artifact=$RAW_MADAROS"
+    echo "sha256=$sha"
+    echo "created_utc=$now"
+    echo "gate=madaros_full_gate.sh"
+    echo "smt_tests=6/6"
+    echo "smt_skip=0"
+  } >"$tmp"
+  mv "$tmp" "$receipt"
+  receipt_ok "$RAW_MADAROS" "$receipt" || fail "gate receipt validation failed after write"
+  pass "gate receipt: $receipt"
+}
+
 mkdir -p "$WORK"
 printf '[madaros-full] madaros=%s\n' "$MADAROS"
+printf '[madaros-full] raw_elf=%s\n' "$RAW_MADAROS"
+printf '[madaros-full] stdlib=%s\n' "$GATE_STDLIB"
 printf '[madaros-full] work=%s\n' "$WORK"
 
-"$MADAROS" --version | grep -Fq "Madares v0.80.0" || fail "version banner missing"
+madaros() {
+  env MADAROS_RAW_BIN="$RAW_MADAROS" SOUNIO_STDLIB_PATH="$GATE_STDLIB" "$MADAROS" "$@"
+}
+
+madaros --version | grep -Fq "Madares v0.80.0" || fail "version banner missing"
 pass "version"
 
 : > "$WORK/empty.sio"
@@ -76,63 +190,66 @@ printf 'fn add(a: i64, b: i64) -> i64 { a + b }\nfn main() -> i64 { add(1, 2) }\
 printf 'fn main() -> i64 { 0 }\n' > "$WORK/run0.sio"
 
 for src in "$WORK/empty.sio" "$WORK/nocallargs.sio" "$WORK/localcall.sio" "$WORK/callargs.sio"; do
-  "$MADAROS" check "$src" >"$WORK/check.log" 2>&1
+  madaros check "$src" >"$WORK/check.log" 2>&1
   expect_log_contains "check: OK" "$WORK/check.log"
 done
 pass "public check CLI"
 
 [[ -x "$RAW_MADAROS" ]] || fail "missing raw Madaros ELF for raw check gate: $RAW_MADAROS"
-"$RAW_MADAROS" --check "$WORK/empty.sio" >"$WORK/raw_empty.log" 2>&1
+env SOUNIO_STDLIB_PATH="$GATE_STDLIB" "$RAW_MADAROS" --check "$WORK/empty.sio" >"$WORK/raw_empty.log" 2>&1
 expect_log_contains "check: OK" "$WORK/raw_empty.log"
-expect_exit 1 "$RAW_MADAROS" --check "$WORK/missing.sio" >"$WORK/raw_missing.log" 2>&1
+expect_exit 1 env SOUNIO_STDLIB_PATH="$GATE_STDLIB" "$RAW_MADAROS" --check "$WORK/missing.sio" >"$WORK/raw_missing.log" 2>&1
 expect_log_contains "could not read input file" "$WORK/raw_missing.log"
-expect_exit 1 "$RAW_MADAROS" --check /tmp >"$WORK/raw_tmp_dir.log" 2>&1
+expect_exit 1 env SOUNIO_STDLIB_PATH="$GATE_STDLIB" "$RAW_MADAROS" --check /tmp >"$WORK/raw_tmp_dir.log" 2>&1
 expect_log_contains "could not read input file" "$WORK/raw_tmp_dir.log"
 pass "raw check CLI"
 
-"$MADAROS" check tests/multimodule/visibility_struct_pub_main.sio >"$WORK/visibility_struct_pub.log" 2>&1
+madaros check tests/multimodule/visibility_struct_pub_main.sio >"$WORK/visibility_struct_pub.log" 2>&1
 expect_log_contains "check: OK" "$WORK/visibility_struct_pub.log"
-"$MADAROS" check tests/multimodule/visibility_enum_pub_main.sio >"$WORK/visibility_enum_pub.log" 2>&1
+madaros check tests/multimodule/visibility_enum_pub_main.sio >"$WORK/visibility_enum_pub.log" 2>&1
 expect_log_contains "check: OK" "$WORK/visibility_enum_pub.log"
-"$MADAROS" check tests/multimodule/visibility_same_module_ok.sio >"$WORK/visibility_same_module.log" 2>&1
+madaros check tests/multimodule/visibility_same_module_ok.sio >"$WORK/visibility_same_module.log" 2>&1
 expect_log_contains "check: OK" "$WORK/visibility_same_module.log"
 
-expect_exit 1 "$MADAROS" check tests/multimodule/visibility_struct_private_main.sio >"$WORK/visibility_struct_private.log" 2>&1
+expect_exit 1 madaros check tests/multimodule/visibility_struct_private_main.sio >"$WORK/visibility_struct_private.log" 2>&1
 expect_log_contains "error[E176" "$WORK/visibility_struct_private.log"
-expect_exit 1 "$MADAROS" check tests/multimodule/visibility_fn_private_main.sio >"$WORK/visibility_fn_private.log" 2>&1
+expect_exit 1 madaros check tests/multimodule/visibility_fn_private_main.sio >"$WORK/visibility_fn_private.log" 2>&1
 expect_log_contains "error[E175" "$WORK/visibility_fn_private.log"
-expect_exit 1 "$MADAROS" check tests/multimodule/visibility_enum_private_main.sio >"$WORK/visibility_enum_private.log" 2>&1
+expect_exit 1 madaros check tests/multimodule/visibility_enum_private_main.sio >"$WORK/visibility_enum_private.log" 2>&1
 expect_log_contains "error[E177" "$WORK/visibility_enum_private.log"
 pass "multimodule visibility diagnostics"
 
-expect_exit 1 "$MADAROS" check "$WORK/missing.sio" >"$WORK/missing.log" 2>&1
-expect_log_contains "could not read input file" "$WORK/missing.log"
-expect_exit 1 env MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" check /tmp >"$WORK/wrapper_tmp_dir.log" 2>&1
-expect_log_contains "could not read input file" "$WORK/wrapper_tmp_dir.log"
+expect_exit 2 madaros check "$WORK/missing.sio" >"$WORK/missing.log" 2>&1
+expect_log_contains "requires <source.sio> or a project with sounio.toml" "$WORK/missing.log"
+expect_exit 2 madaros check /tmp >"$WORK/wrapper_tmp_dir.log" 2>&1
+expect_log_contains "requires <source.sio> or a project with sounio.toml" "$WORK/wrapper_tmp_dir.log"
 pass "missing input diagnostic"
 
-"$MADAROS" build "$WORK/run0.sio" -o "$WORK/run0.elf" >"$WORK/build.log" 2>&1
+madaros build "$WORK/run0.sio" -o "$WORK/run0.elf" >"$WORK/build.log" 2>&1
 expect_log_contains "Written to $WORK/run0.elf" "$WORK/build.log"
 expect_elf_runs 0 "$WORK/run0.elf"
 pass "source build to native ELF"
 
-expect_exit 0 "$MADAROS" run "$WORK/run0.sio" >"$WORK/run.log" 2>&1
+expect_exit 0 madaros run "$WORK/run0.sio" >"$WORK/run.log" 2>&1
 pass "source run"
 
-"$MADAROS" --native-v2-emit-scalar 42 "$WORK/scalar42.elf" >"$WORK/scalar42.log" 2>&1
+madaros --native-v2-emit-scalar 42 "$WORK/scalar42.elf" >"$WORK/scalar42.log" 2>&1
 expect_elf_runs 42 "$WORK/scalar42.elf"
-"$MADAROS" --native-v2-emit-call "$WORK/call.elf" >"$WORK/call.log" 2>&1
+madaros --native-v2-emit-call "$WORK/call.elf" >"$WORK/call.log" 2>&1
 expect_elf_runs 6 "$WORK/call.elf"
-"$MADAROS" --native-v2-emit-call5 "$WORK/call5.elf" >"$WORK/call5.log" 2>&1
+madaros --native-v2-emit-call5 "$WORK/call5.elf" >"$WORK/call5.log" 2>&1
 expect_elf_runs 31 "$WORK/call5.elf"
-"$MADAROS" --native-v2-emit-call6 "$WORK/call6.elf" >"$WORK/call6.log" 2>&1
+madaros --native-v2-emit-call6 "$WORK/call6.elf" >"$WORK/call6.log" 2>&1
 expect_elf_runs 63 "$WORK/call6.elf"
-"$MADAROS" --native-v2-emit-sret "$WORK/sret.elf" >"$WORK/sret.log" 2>&1
+madaros --native-v2-emit-sret "$WORK/sret.elf" >"$WORK/sret.log" 2>&1
 expect_elf_runs 14 "$WORK/sret.elf"
 pass "native-v2 ABI/backend witnesses"
 
-"$MADAROS" pkg self-test >"$WORK/pkg_self_test.log" 2>&1
+madaros pkg self-test >"$WORK/pkg_self_test.log" 2>&1
 expect_log_contains "SPM self-tests: ALL PASSED" "$WORK/pkg_self_test.log"
 pass "package manager self-test"
+
+run_imported_smt_gate
+write_gate_receipt
 
 echo "[madaros-full] PASS: public CLI, source ELF path, ABI witnesses, visibility, and pkg self-test"

--- a/scripts/dev/madaros_two_gate.sh
+++ b/scripts/dev/madaros_two_gate.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/dev/madaros_two_gate.sh <madaros-elf> [--gate-b <probe.sio>]
+
+Gate A: the 6 imported-SMT tests under tests/stdlib/theorem/test_smt_*.sio.
+Gate B: a dissertation-facing probe. Defaults to a generated println(f64)
+        probe; pass --gate-b to use a specific .sio probe.
+
+Prints: two_gate: A=<n>/6 B=<pass|fail>
+Exits 0 only when A=6/6 and B=pass.
+
+Env:
+  SOUNIO_MADAROS_TWO_GATE_STDLIB_PATH  stdlib root (default: repo stdlib)
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+ELF="$1"
+shift
+GATE_B=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gate-b)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --gate-b requires a probe path" >&2
+        exit 2
+      fi
+      GATE_B="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MADAROS="$ROOT_DIR/bin/madaros"
+GATE_STDLIB="${SOUNIO_MADAROS_TWO_GATE_STDLIB_PATH:-$ROOT_DIR/stdlib}"
+
+if [[ ! -x "$ELF" ]]; then
+  echo "error: Madaros ELF not executable: $ELF" >&2
+  exit 2
+fi
+if [[ ! -x "$MADAROS" ]]; then
+  echo "error: wrapper not executable: $MADAROS" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/madaros-two-gate.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ -z "$GATE_B" ]]; then
+  GATE_B="$TMP_DIR/gate_b_println_f64.sio"
+  cat > "$GATE_B" <<'EOF'
+fn main() -> i64 {
+    println(0.5)
+    0
+}
+EOF
+fi
+
+mapfile -t SMT_TESTS < <(find "$ROOT_DIR/tests/stdlib/theorem" -maxdepth 1 -name 'test_smt_*.sio' -print | sort)
+if [[ "${#SMT_TESTS[@]}" -ne 6 ]]; then
+  echo "error: expected exactly 6 test_smt fixtures, found ${#SMT_TESTS[@]}" >&2
+  exit 2
+fi
+
+run_probe() {
+  local probe="$1"
+  local log="$2"
+  MADAROS_RAW_BIN="$ELF" SOUNIO_STDLIB_PATH="$GATE_STDLIB" "$MADAROS" run "$probe" >"$log" 2>&1
+}
+
+gate_a_pass=0
+for test_path in "${SMT_TESTS[@]}"; do
+  test_log="$TMP_DIR/$(basename "$test_path").log"
+  run_probe "$test_path" "$test_log"
+  probe_rc=$?
+  if [[ "$probe_rc" -eq 0 ]]; then
+    gate_a_pass=$((gate_a_pass + 1))
+  else
+    echo "gateA FAIL: $(basename "$test_path") (rc=$probe_rc)" >&2
+  fi
+done
+
+echo "gateA=$gate_a_pass/6"
+
+gate_b_log="$TMP_DIR/gate_b.log"
+run_probe "$GATE_B" "$gate_b_log"
+gate_b_rc=$?
+if [[ "$gate_b_rc" -eq 0 ]]; then
+  gate_b_status="pass"
+else
+  gate_b_status="fail"
+  echo "gateB FAIL: $GATE_B (rc=$gate_b_rc)" >&2
+fi
+
+echo "gateB=$gate_b_status"
+echo "two_gate: A=$gate_a_pass/6 B=$gate_b_status"
+
+if [[ "$gate_a_pass" -eq 6 && "$gate_b_status" == "pass" ]]; then
+  exit 0
+fi
+exit 1

--- a/scripts/lib/resolve_madaros.sh
+++ b/scripts/lib/resolve_madaros.sh
@@ -19,7 +19,22 @@ _SOUNIO_RESOLVE_MADAROS_LOADED=1
 _SOUNIO_MADAROS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _SOUNIO_MADAROS_ROOT_DIR="${_SOUNIO_MADAROS_ROOT_DIR:-$(cd "$_SOUNIO_MADAROS_LIB_DIR/../.." && pwd)}"
 
-# Resolve MADAROS_BIN: explicit env → repo wrapper → repo raw ELF → PATH fallback.
+# A raw artifacts/self-hosted/madaros is trusted only when its gate receipt
+# contains the current ELF sha256 and proves the SMT gate was not skipped.
+# Otherwise it is demoted below relocgate.
+_sounio_madaros_receipt_ok() {
+  local elf="$1"
+  local receipt="$elf.gate-receipt"
+  [[ -f "$receipt" ]] || return 1
+  local want
+  want="$(sha256sum "$elf" 2>/dev/null | cut -d' ' -f1)"
+  [[ -n "$want" ]] || return 1
+  grep -Fq "$want" "$receipt" || return 1
+  grep -Fxq "smt_skip=0" "$receipt"
+}
+
+# Resolve MADAROS_BIN: explicit env → repo wrapper → gated raw ELF →
+# relocgate (verified-green) → checked-in prebuilt → explicit PATH opt-in.
 _sounio_resolve_madaros_bin() {
   if [[ -n "${MADAROS_BIN:-}" && -x "$MADAROS_BIN" ]]; then
     echo "$MADAROS_BIN"
@@ -36,7 +51,15 @@ _sounio_resolve_madaros_bin() {
   fi
   local raw_elf="$_SOUNIO_MADAROS_ROOT_DIR/artifacts/self-hosted/madaros"
   if [[ -x "$raw_elf" ]]; then
-    echo "$raw_elf"
+    if _sounio_madaros_receipt_ok "$raw_elf"; then
+      echo "$raw_elf"
+      return 0
+    fi
+    echo "warning: using ungated $raw_elf skipped; export MADAROS_RAW_BIN=$_SOUNIO_MADAROS_ROOT_DIR/bin/madaros-relocgate for the verified-green binary" >&2
+  fi
+  local relocgate="$_SOUNIO_MADAROS_ROOT_DIR/bin/madaros-relocgate"
+  if [[ -x "$relocgate" ]]; then
+    echo "$relocgate"
     return 0
   fi
   local prebuilt="$_SOUNIO_MADAROS_ROOT_DIR/bin/madaros-linux-x86_64"
@@ -44,12 +67,13 @@ _sounio_resolve_madaros_bin() {
     echo "$prebuilt"
     return 0
   fi
-  if command -v madaros >/dev/null 2>&1; then
+  if [[ "${SOUNIO_MADAROS_ALLOW_PATH_FALLBACK:-0}" == "1" ]] && command -v madaros >/dev/null 2>&1; then
+    echo "warning: resolve_madaros using PATH fallback because SOUNIO_MADAROS_ALLOW_PATH_FALLBACK=1" >&2
     command -v madaros
     return 0
   fi
   echo "error: resolve_madaros: no Madaros binary found" >&2
-  echo "  tried: MADAROS_BIN, SOUNIO_MADAROS_BIN, $wrapper, $raw_elf, $prebuilt, PATH" >&2
+  echo "  tried: MADAROS_BIN, SOUNIO_MADAROS_BIN, $wrapper, $raw_elf (receipt-gated), $relocgate, $prebuilt, PATH opt-in" >&2
   echo "  run: make build-madaros" >&2
   return 1
 }


### PR DESCRIPTION
## What changed

- Ports the protected `canon/madaros-greenline` Madaros route files onto the already-green GPU/PTX witness branch:
  - `bin/madaros`
  - `scripts/lib/resolve_madaros.sh`
  - `scripts/ci/madaros_full_gate.sh`
  - `scripts/dev/madaros_two_gate.sh`
- Refreshes `bin/madaros-linux-x86_64` to the proved green artifact hash:
  - `0441113419b71ed0fa24348ae8ef0ad0f2a0ff9a38a13ada3409c283984d7d19`
- Updates `docs/MADAROS_STATUS.md` with the stacked branch proof and the distinction from the base GPU branch caveat.

## Why

PR #611 fixes the GPU/PTX module import combination and is green, but it intentionally does not prove the safe default Madaros compiler route. On the GPU branch, the canonical wrapper logic was absent, and the checked prebuilt still failed the imported-SMT regression with `rc=139`.

This stacked PR keeps the compiler route separate from the GPU/PTX repair while making the default wrapper path actually green on top of that branch.

## Validation

- GitHub CI on PR #612 = all green: Contracts, Native Self-Host Linux/macOS, Source-Bootstrap, Sounio Lint, Lean Proofs, Website, Full Test Suite, Vercel
- `bash -n bin/madaros scripts/lib/resolve_madaros.sh scripts/ci/madaros_full_gate.sh scripts/dev/madaros_two_gate.sh`
- `git diff --check`
- `bash scripts/dev/check_docs_consistency.sh` = PASS
- `bash scripts/dev/check_docs_registry.sh` = PASS
- `env -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN -u MADAROS_BIN -u SOUNIO_STDLIB_PATH ./bin/madaros run tests/stdlib/theorem/test_smt_solver_basic.sio` = `rc=0`
- `env -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN -u MADAROS_BIN -u SOUNIO_STDLIB_PATH scripts/dev/madaros_two_gate.sh bin/madaros-linux-x86_64` = `two_gate: A=6/6 B=pass`
- `env -u MADAROS_RAW_BIN -u SOUNIO_MADAROS_BIN -u MADAROS_BIN -u SOUNIO_STDLIB_PATH bash scripts/ci/madaros_full_gate.sh` = PASS, including imported-SMT solver gate 6/6

## Caveats

- This is a stacked PR on top of #611 (`work/gpu-ptx-combo-fix-codex`), not a direct PR to the GPU base branch.
- `bin/madaros-relocgate` is still not present as a separate checked-in binary; the green fallback here is the refreshed checked prebuilt `bin/madaros-linux-x86_64`.
- `make build-madaros` was not rerun in this branch; the binary refresh came from the already receipt-proved artifact in `/tmp/sounio-madaros-greenline-codex/artifacts/self-hosted/madaros`.

LLM-offload: not invoked; this patch changes compiler routing/gates and an internal status note, not math claims, clinical-pathway code, or external-facing artifacts.