### PR TITLE
fix(madaros): provide relocgate alias to green prebuilt

### DIFF
--- a/bin/madaros-relocgate
+++ b/bin/madaros-relocgate
@@ -1,0 +1,1 @@
+madaros-linux-x86_64


### PR DESCRIPTION
## What changed

Adds `bin/madaros-relocgate` as a symlink to the checked-in green `bin/madaros-linux-x86_64` prebuilt on `gpu/epistemic-tensor-core-next`.

## Why

PR #612/Phase 0 routes Madaros through a receipt-gated chain that tries `bin/madaros-relocgate` before the checked-in prebuilt. The route was correct and the prebuilt is green, but the relocgate path itself was absent, leaving the warning/action text pointing at a missing file.

This provides the relocgate path without duplicating a 100MB ELF in git.

## Validation

- `./bin/madaros info` resolves `raw_elf` to `bin/madaros-relocgate`
- `scripts/dev/madaros_two_gate.sh bin/madaros-relocgate` -> `gateA=6/6`, `gateB=pass`, `two_gate: A=6/6 B=pass`
- `MADAROS_RAW_BIN=$PWD/bin/madaros-relocgate bash scripts/ci/madaros_full_gate.sh` -> PASS, including imported-SMT solver gate 6/6

## Notes

This is deliberately a symlink to the already verified green prebuilt, not a second binary blob.
