### PR TITLE
fix(tests): sret_pbox_clinical_known_failure.sio import for lean_single

### DIFF
--- a/tests/run-pass/sret_pbox_clinical_known_failure.sio
+++ b/tests/run-pass/sret_pbox_clinical_known_failure.sio
@@ -8,7 +8,10 @@
 // Vacuous contract path (weight 15 kg): predict_cmin_knightian → pb_confidence consumption.
 
 use clinical::vancomycin_pbpk::*
-use epistemic::knightian::pb_confidence
+// Named (non-glob) `use pkg::file::symbol` is misresolved by lean_single as if
+// `symbol` were itself a nested file (checker Bug C, tracked in issue #601) — use
+// the glob form instead.
+use epistemic::knightian::*
 
 fn main() -> i32 with Mut, Div, Panic {
     let bad = predict_cmin_knightian(15.0, 65.0, 1000.0, 12.0, 0)


### PR DESCRIPTION
## Summary

Closes #614. Fixes the sole failure in `research/solver-ts3-parallel`'s `Full Test
Suite` job (confirmed deterministic across two PR #604 CI runs, not flaky).

This test is a regression pin for a previously-fixed SIGSEGV
(`docs/audit/MADAROS_SRET_PBOX_CLINICAL_2026-06-29/DISPATCH.md`, closed 2026-06-29),
originally validated against Madaros. CI's `Full Test Suite` job runs against a
freshly-bootstrapped `lean_single` instead — a different engine that was never checked
against this specific file's import statement.

Root cause: `use epistemic::knightian::pb_confidence` (a named, non-glob import of a
single symbol) is checker **Bug C**, tracked in the consolidated checker-bug issue #601.
`lean_single` misresolves it as if `pb_confidence` were itself a nested file
(`self-hosted/epistemic/knightian/pb_confidence.sio`) rather than a `pub fn` exported by
`knightian.sio`. Converted to the glob form (`use epistemic::knightian::*`) — the
established workaround for every other Bug-C site fixed this week (issues #567/#568/#575).

## Test plan
- [x] Rebuilt `lean_single` from source (matching CI's `souc-stage2` build path).
- [x] `sret_pbox_clinical_known_failure.sio` now passes, prints the expected
      `SRET_PBOX_CLINICAL_OK`.
- [x] No regression on `vancomycin`/`clinical` filtered suites.
- [x] `test_stiff_ode_knightian_mc.sio` still fails both before and after this change
      (confirmed via `git stash`) — pre-existing, unrelated, not touched here.
- [x] Verified clean under Madaros too (`souc check`: `verdict=0`), matching this file's
      original validation engine.

Closes #614.