### PR TITLE
fix(gpu): lean kernel_ir/lower_to_ptx extraction for the WMMA driver

### DIFF
--- a/self-hosted/gpu/kernel_ir_wmma_lean.sio
+++ b/self-hosted/gpu/kernel_ir_wmma_lean.sio
@@ -1,0 +1,962 @@
+// self-hosted/gpu/kernel_ir_wmma_lean.sio
+// Minimal, standalone extraction of only what
+// gpu_build_epistemic_wmma_matmul_16x16_ir needs, pulled out of
+// self-hosted/gpu/kernel_ir.sio (which has ~130 top-level functions,
+// most unrelated to this kernel -- large GEMM/conv2d/tiled-GEMM builders
+// among them -- that the compiler still fully lowers/codegens for any
+// importer regardless of reachability, per
+// docs/audit/MADAROS_GPU_MODULE_COMPILE_OOM_2026-07-03.md and
+// docs/audit/MADAROS_IR_MAX_INSTRS_1024_TRUNCATION_2026-06-28.md).
+// This file exists purely to give the DGX Spark gate driver
+// (self-hosted/gpu/kretikos_emit_epistemic_wmma.sio) a lean import
+// target instead of the full kernel_ir.sio, to fit inside the
+// compiler's memory/ELF-size envelope. Keep in sync by hand with
+// kernel_ir.sio if the WMMA matmul builder's math or dependencies
+// change -- do not let this drift silently.
+
+pub enum GpuOpcode {
+    GpuGetTid,       // Get thread ID
+    GpuCvt,          // Type conversion
+    GpuMulImm,       // Multiply with immediate
+    GpuAdd,          // Add
+    GpuSub,          // Subtract
+    GpuMul,          // Multiply
+    GpuDiv,          // Divide
+    GpuMax,          // Maximum
+    GpuMin,          // Minimum
+    GpuBarrierSync,  // Barrier synchronization
+    GpuShflDown,     // Warp shuffle down
+    GpuAtomicAdd,    // Atomic add
+    GpuLoadShared,   // Load from shared memory
+    GpuStoreShared,  // Store to shared memory
+    GpuLoadParam,    // Load from kernel parameter
+    GpuLoadGlobal,   // Load from global memory
+    GpuStoreGlobal,  // Store to global memory
+    GpuRet,          // Return
+    GpuFma,          // Phase 4: fused multiply-add (dst = lhs * rhs + src)
+    GpuGetBid,       // Phase 4: block index (blockIdx.x/y/z)
+    GpuGetNtid,      // Phase 4: block dimension (blockDim.x/y/z)
+    GpuAddImm,       // Phase 4: add immediate (for loop offsets)
+    GpuSetpLt,       // Predicate compare less-than: setp.lt
+    GpuSetpLe,       // Predicate compare less-equal: setp.le
+    GpuSetpEq,       // Predicate compare equal: setp.eq
+    GpuSetpGe,       // Predicate compare greater-or-equal: setp.ge
+    GpuSelp,         // Predicate select: selp
+    GpuLoadGlobalPred, // Predicate load from global memory
+    GpuStoreGlobalPred, // Predicate store into global memory
+    GpuLoadSharedPred,  // Predicate load from shared memory
+    GpuStoreSharedPred, // Predicate store into shared memory
+
+    // Phase 5: Warp operations
+    GpuShflUp,          // Warp shuffle up
+    GpuShflBfly,        // Warp shuffle butterfly (XOR)
+    GpuShflIdx,         // Warp shuffle by index
+    GpuVote,            // Warp vote (all/any/ballot)
+    GpuBallot,          // Warp ballot
+
+    // Phase 5: Tensor core
+    GpuWmma,            // Warp matrix multiply-accumulate
+    GpuMma,             // Matrix multiply-accumulate
+    GpuTmaLoad,         // Tensor memory access load (sm_90+)
+    GpuTmaStore,        // Tensor memory access store (sm_90+)
+
+    // Phase 5: Memory (extended)
+    GpuLdGlobalCached,  // Cached global load
+    GpuStGlobalWriteback, // Writeback global store
+    GpuPrefetch,        // Prefetch to cache
+
+    // Phase 5: Math intrinsics
+    GpuSqrt,            // Square root
+    GpuRsqrt,           // Reciprocal square root
+    GpuExp2,            // Base-2 exponential
+    GpuLg2,             // Base-2 logarithm
+    GpuSin,             // Sine
+    GpuCos,             // Cosine
+    GpuAbs,             // Absolute value
+    GpuRcp,             // Reciprocal
+
+    // Phase 5: Predicate (extended)
+    GpuSetpGt,          // Greater-than comparison
+    GpuSetpNe,          // Not-equal comparison
+
+    // Phase 5: Control flow
+    GpuBra,             // Branch (conditional/unconditional)
+    GpuExit,            // Thread exit
+
+    // Phase 5: Special registers
+    GpuGetLaneId,       // Lane ID within warp
+    GpuGetWarpId,       // Warp ID within block
+    GpuGetSmId,         // Streaming multiprocessor ID
+    GpuGetGridDim,      // Grid dimension
+
+    // Phase 6: Async copy (cp.async, sm_80+)
+    GpuCpAsync,              // Async copy global->shared
+    GpuCpAsyncWait,          // Wait for N async copies
+    GpuCpAsyncWaitAll,       // Wait for all async copies
+
+    // Phase 6: Extended atomics
+    GpuAtomicCas,            // Compare-and-swap
+    GpuAtomicExch,           // Exchange
+    GpuAtomicMin,            // Atomic minimum
+    GpuAtomicMax,            // Atomic maximum
+    GpuAtomicAnd,            // Atomic bitwise AND
+    GpuAtomicOr,             // Atomic bitwise OR
+    GpuAtomicXor,            // Atomic bitwise XOR
+
+    // Phase 6: Memory fences
+    GpuFenceAcquire,         // fence.acquire.cta/gl/sys
+    GpuFenceRelease,         // fence.release.cta/gl/sys
+    GpuFenceAcqRel,          // fence.acq_rel
+    GpuMembar,               // membar.cta / membar.gl / membar.sys
+
+    // Phase 6: Mixed precision
+    GpuMmaTf32,              // TF32 tensor core (sm_80+)
+    GpuCvtF32Tf32,           // f32 -> tf32 truncation
+    GpuMmaF16,               // FP16 warp-level mma
+
+    // Phase 6: Bitwise / integer
+    GpuAnd,                  // Bitwise AND
+    GpuOr,                   // Bitwise OR
+    GpuXor,                  // Bitwise XOR
+    GpuNot,                  // Bitwise NOT
+    GpuShl,                  // Shift left
+    GpuShr,                  // Shift right (logical)
+    GpuShra,                 // Shift right (arithmetic)
+    GpuClz,                  // Count leading zeros
+    GpuPopc,                 // Population count (popc.b32)
+
+    // Phase 6: Cooperative groups (sm_90+)
+    GpuCgTiledPartition,     // Cooperative group tiled_partition
+    GpuCgSync,               // Cooperative group sync
+    GpuCgReduce,             // Cooperative group reduce
+}
+
+// GPU memory space (for load/store address space qualification)
+
+pub enum GpuType {
+    GpuU32,
+    GpuU64,
+    GpuF32,
+    GpuF64,
+    GpuI32,
+    GpuI64,
+    GpuPtr,   // .u64 pointer type
+    // Phase 6 types
+    GpuBool,  // Predicate register (.pred)
+    GpuTf32,  // TF32 (19-bit, sm_80+)
+    GpuF16,   // Half precision (.f16)
+    GpuB32,   // Untyped 32-bit (.b32, for bitwise ops)
+    GpuB64,   // Untyped 64-bit (.b64)
+}
+
+// GPU operation opcodes (simple enum, no fields)
+
+pub enum GpuMemorySpace {
+    GpuMemGlobal,
+    GpuMemShared,
+    GpuMemLocal,
+    GpuMemConstant,
+}
+
+// Phase 6: Atomic operation selector (used by GpuAtomicCas, GpuAtomicExch, etc.)
+
+pub enum GpuAtomicOp {
+    GpuAtomAdd,
+    GpuAtomCas,
+    GpuAtomExch,
+    GpuAtomMin,
+    GpuAtomMax,
+    GpuAtomAnd,
+    GpuAtomOr,
+    GpuAtomXor,
+}
+
+// Phase 6: Cache hint for loads/stores (maps to PTX cache operators)
+
+pub enum GpuCacheHint {
+    GpuCacheDefault,  // .ca — cache at all levels (default)
+    GpuCacheCA,       // .ca — cache at all levels
+    GpuCacheCG,       // .cg — cache at L2 only
+    GpuCacheCS,       // .cs — cache streaming (evict-first)
+    GpuCacheWT,       // .wt — write-through
+    GpuCacheCV,       // .cv — volatile (don't cache)
+}
+
+pub enum GpuWorkloadTag {
+    GpuWorkloadGeneral,
+    GpuWorkloadMl,
+    GpuWorkloadOnn,
+    GpuWorkloadQnn,
+    GpuWorkloadSnn,
+    GpuWorkloadSpnn,
+    GpuWorkloadQuantnn,
+    GpuWorkloadHyperMath,
+    GpuWorkloadExceptional,
+}
+
+pub struct Name {
+    pub buf: [i8; 128],
+    pub len: i64,
+}
+
+pub struct GpuOp {
+    pub opcode: GpuOpcode,
+    pub dst_reg: i64,
+    pub src_reg: i64,
+    pub lhs_reg: i64,
+    pub rhs_reg: i64,
+    pub addr_reg: i64,
+    pub rhs_imm: i64,
+    pub param_idx: i64,
+    pub axis: i64,  // 0=x, 1=y, 2=z for GetTid
+    pub shared_addr: i64,  // Shared memory address/offset
+    pub ty: GpuType,
+    pub dst_ty: GpuType,
+    pub src_ty: GpuType,
+    // Phase 5 extensions
+    pub memory_space: GpuMemorySpace,   // Address space for load/store ops
+    pub pred_reg: i64,                  // Predicate register for conditional ops (-1 = none)
+    pub mask: i64,                      // Warp mask for shuffle/vote ops (0xFFFFFFFF = all lanes)
+    // Phase 6 extensions
+    pub atomic_op: GpuAtomicOp,         // Operation selector for atomic ops
+    pub cache_hint: GpuCacheHint,       // Cache policy for loads/stores
+    pub compare_reg: i64,               // CAS compare value register (-1 = none)
+    pub num_regs: i64,                  // Tile register count (tensor core fragments)
+    pub byte_offset: i64,               // Byte offset for cp.async
+    pub scope: i64,                     // Fence scope: 0=cta, 1=gl, 2=sys
+    pub cg_size: i64,                   // Cooperative group size (tiled_partition width)
+}
+
+// GPU kernel parameter (e.g., .param .u64 param_a)
+
+pub struct GpuParam {
+    pub name: Name,
+    pub ty: GpuType,
+}
+
+// GPU kernel IR (represents a single kernel)
+
+pub struct GpuKernelIr {
+    pub kernel_name: Name,
+    pub workload_tag: GpuWorkloadTag,
+    pub params: [GpuParam; 8],
+    pub param_count: i64,
+    // Stage-5 hardening target: allow up to 1024 IR ops per kernel
+    // (large enough for the shared-memory/tiled-family kernels in this phase).
+    pub ops: [GpuOp; 1024],
+    pub op_count: i64,
+
+    // Shared-memory region size (in bytes) used by this kernel.
+    // 0 means no dynamic shared declaration.
+    pub shared_bytes: i64,
+
+    // Register allocation info (simple for now)
+    pub max_reg_u32: i64,
+    pub max_reg_u64: i64,
+    pub max_reg_f32: i64,
+    pub max_reg_f64: i64,
+    pub max_reg_i32: i64,
+    pub max_reg_i64: i64,
+    pub max_reg_pred: i64,
+    // Phase 5 extensions
+    pub shared_mem_bytes: i64,  // Total shared memory allocated (bytes)
+    pub max_threads: i64,       // Maximum threads per block hint (0 = default)
+    // Phase 6 extensions
+    pub num_barriers: i64,      // Named barrier count (bar.sync n)
+    pub cta_size_x: i64,        // Compile-time blockDim.x (0 = dynamic)
+    pub cta_size_y: i64,        // Compile-time blockDim.y (0 = dynamic)
+    pub cta_size_z: i64,        // Compile-time blockDim.z (0 = dynamic)
+    pub cluster_x: i64,         // Thread block cluster dim x (sm_90+, 0 = none)
+    pub cluster_y: i64,         // Thread block cluster dim y (sm_90+, 0 = none)
+}
+
+// Lowered module: collection of kernels post-HLIR-to-GPU lowering, pre-optimization.
+
+pub fn ki_ir_name_from_bytes(a: i8, b: i8, c: i8, d: i8, len: i64) -> Name with Mut, Panic, Div {
+    var n = Name { buf: [0; 128], len: len }
+    if len > 0 { n.buf[0] = a }
+    if len > 1 { n.buf[1] = b }
+    if len > 2 { n.buf[2] = c }
+    if len > 3 { n.buf[3] = d }
+    n
+}
+
+// Build a Name from a string literal (any length up to 128).
+// Uses str_char_at so all bytes are set in one-level ops — avoids the
+// two-level nested-store miscompilation (var.field1.field2[i] = v).
+
+pub fn ki_ir_name_from_str(s: string, len: i64) -> Name with Mut, Panic {
+    var n = Name { buf: [0; 128], len: len }
+    var i: i64 = 0
+    while i < len {
+        n.buf[i as usize] = str_char_at(s, i) as i8
+        i = i + 1
+    }
+    n
+}
+
+// GPU data types (full type coverage for all kernels)
+
+pub fn ki_empty_name() -> Name {
+    Name { buf: [0; 128], len: 0 }
+}
+
+pub fn gpu_op_new() -> GpuOp {
+    GpuOp {
+        opcode: GpuOpcode::GpuRet,
+        dst_reg: -1,
+        src_reg: -1,
+        lhs_reg: -1,
+        rhs_reg: -1,
+        addr_reg: -1,
+        rhs_imm: 0,
+        param_idx: -1,
+        axis: 0,
+        shared_addr: -1,
+        ty: GpuType::GpuU64,
+        dst_ty: GpuType::GpuU64,
+        src_ty: GpuType::GpuU32,
+        memory_space: GpuMemorySpace::GpuMemGlobal,
+        pred_reg: -1,
+        mask: 4294967295,  // 0xFFFFFFFF — all lanes
+        atomic_op: GpuAtomicOp::GpuAtomAdd,
+        cache_hint: GpuCacheHint::GpuCacheDefault,
+        compare_reg: -1,
+        num_regs: 0,
+        byte_offset: 0,
+        scope: 0,
+        cg_size: 0,
+    }
+}
+
+fn gpu_op_default() -> GpuOp {
+    GpuOp {
+        opcode: GpuOpcode::GpuRet,
+        dst_reg: -1,
+        src_reg: -1,
+        lhs_reg: -1,
+        rhs_reg: -1,
+        addr_reg: -1,
+        rhs_imm: 0,
+        param_idx: -1,
+        axis: 0,
+        shared_addr: -1,
+        ty: GpuType::GpuU64,
+        dst_ty: GpuType::GpuU64,
+        src_ty: GpuType::GpuU32,
+        memory_space: GpuMemorySpace::GpuMemGlobal,
+        pred_reg: -1,
+        mask: 4294967295,
+        atomic_op: GpuAtomicOp::GpuAtomAdd,
+        cache_hint: GpuCacheHint::GpuCacheDefault,
+        compare_reg: -1,
+        num_regs: 0,
+        byte_offset: 0,
+        scope: 0,
+        cg_size: 0,
+    }
+}
+
+pub fn gpu_param_new() -> GpuParam {
+    GpuParam {
+        name: ki_empty_name(),
+        ty: GpuType::GpuU64,
+    }
+}
+
+pub fn gpu_kernel_new() -> GpuKernelIr {
+    GpuKernelIr {
+        kernel_name: ki_empty_name(),
+        workload_tag: GpuWorkloadTag::GpuWorkloadGeneral,
+        params: [gpu_param_new(); 8],
+        param_count: 0,
+        ops: [gpu_op_new(); 1024],
+        op_count: 0,
+        shared_bytes: 0,
+        max_reg_u32: 0,
+        max_reg_u64: 0,
+        max_reg_f32: 0,
+        max_reg_f64: 0,
+        max_reg_i32: 0,
+        max_reg_i64: 0,
+        max_reg_pred: 0,
+        shared_mem_bytes: 0,
+        max_threads: 0,
+        num_barriers: 0,
+        cta_size_x: 0,
+        cta_size_y: 0,
+        cta_size_z: 0,
+        cluster_x: 0,
+        cluster_y: 0,
+    }
+}
+
+pub fn gpu_type_to_string(ty: GpuType) -> string {
+    match ty {
+        GpuType::GpuU32  => "u32",
+        GpuType::GpuU64  => "u64",
+        GpuType::GpuF32  => "f32",
+        GpuType::GpuF64  => "f64",
+        GpuType::GpuI32  => "s32",
+        GpuType::GpuI64  => "s64",
+        GpuType::GpuPtr  => "u64",
+        GpuType::GpuBool => "pred",
+        GpuType::GpuTf32 => "tf32",
+        GpuType::GpuF16  => "f16",
+        GpuType::GpuB32  => "b32",
+        GpuType::GpuB64  => "b64",
+    }
+}
+
+pub fn gpu_build_epistemic_wmma_matmul_16x16_ir() -> GpuKernelIr with Mut, Panic, Div {
+    var k = gpu_kernel_new()
+
+    // Kernel name: "epi_wmma_mm16" (13 chars)
+    k.kernel_name = ki_ir_name_from_str("epi_wmma_mm16", 13)
+
+    // ── 8 Parameters (all .u64 pointers) ────────────────────────
+    // 0: param_a_val  1: param_a_eps  2: param_b_val  3: param_b_eps
+    // 4: param_c_val  5: param_c_eps  6: param_c_vld  7: param_c_prv
+
+    let param_names: [i64; 8] = [118, 101, 118, 101, 118, 101, 118, 112]  // v,e,v,e,v,e,v,p
+    let param_suffix: [i64; 8] = [108, 115, 108, 115, 108, 115, 100, 118]  // l,s,l,s,l,s,d,v
+    let param_prefix: [i64; 8] = [97, 97, 98, 98, 99, 99, 99, 99]  // a,a,b,b,c,c,c,c
+
+    var pi: i64 = 0
+    while pi < 8 {
+        var pname = ki_ir_name_from_bytes(112, 95, 0, 95, 6) // "p_?_??" (6 chars)
+        pname.buf[2] = param_prefix[pi as usize] as i8
+        pname.buf[4] = param_names[pi as usize] as i8
+        pname.buf[5] = param_suffix[pi as usize] as i8
+        k.params[pi as usize] = GpuParam { name: pname, ty: GpuType::GpuPtr }
+        pi = pi + 1
+    }
+    k.param_count = 8
+
+    // ── Register layout ─────────────────────────────────────────
+    // u32: %r0=tid.x, %r1=ctaid.x, %r2=ntid.x
+    //      %r3..%r6 (A frags, 4 b32 packed f16)
+    //      %r7..%r8  (B frags, 2 b32 packed f16)
+    // u64: %rd0..%rd1 (tid widen + byte offset)
+    //      %rd2..%rd9 (param ptrs)
+    //      %rd10..%rd13 (A_val, A_eps, B_val, B_eps addrs)
+    //      %rd14..%rd20 (provenance offset, output addrs)
+    // f32: %f0..%f3  (C/D frags — C input = D output for A*B+0 pattern)
+    //      %f4 (eps_A), %f5 (eps_B)
+    //      %f6 (|D[0]| norm_A, then reused as real 0.0 const after %f8/%f9 land)
+    //      %f7 (|D[2]| norm_B)
+    //      %f8 (eps_A*|D[2]|), %f9 (eps_B*|D[0]|)
+    //      %f10 (f8^2), %f11 (f9^2), %f12 (U^2 = f10+f11, RSS quadrature)
+    //      %f13..%f16 (doubling chain: 2*U^2, 4*U^2, 8*U^2, 16*U^2)
+    //      %f17 (eps_out = sqrt(16*U^2))
+    // pred: %p0 (A valid: eps_A>=0), %p1 (B valid: eps_B>=0), %p2 (AND result)
+
+    var idx: i64 = 0
+
+    // ─── Thread / block identification ──────────────────────────
+
+    // %r0 = tid.x
+    var op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuGetTid
+    op.dst_reg = 0
+    op.axis = 0
+    op.ty = GpuType::GpuU32
+    op.dst_ty = GpuType::GpuU32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %r1 = ctaid.x (block ID)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuGetBid
+    op.dst_reg = 1
+    op.axis = 0
+    op.ty = GpuType::GpuU32
+    op.dst_ty = GpuType::GpuU32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %r2 = ntid.x (block dim)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuGetNtid
+    op.dst_reg = 2
+    op.axis = 0
+    op.ty = GpuType::GpuU32
+    op.dst_ty = GpuType::GpuU32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %rd0 = cvt.u64.u32 %r0 (widen tid)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuCvt
+    op.dst_reg = 0
+    op.src_reg = 0
+    op.dst_ty = GpuType::GpuU64
+    op.src_ty = GpuType::GpuU32
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %rd1 = %rd0 * 4 (byte offset for f32 elements)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuMulImm
+    op.dst_reg = 1
+    op.lhs_reg = 0
+    op.rhs_imm = 4
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Load all 8 param pointers (%rd2..%rd9) ────────────────
+
+    var pp: i64 = 0
+    while pp < 8 {
+        op = gpu_op_default()
+        op.opcode = GpuOpcode::GpuLoadParam
+        op.dst_reg = pp + 2   // %rd2..%rd9
+        op.param_idx = pp
+        op.ty = GpuType::GpuU64
+        op.dst_ty = GpuType::GpuU64
+        k.ops[idx] = op
+        idx = idx + 1
+        pp = pp + 1
+    }
+
+    // ─── Address computation for data loads ─────────────────────
+    // %rd10 = rd2 + rd1 (A_val addr)
+    // %rd11 = rd3 + rd1 (A_eps addr)
+    // %rd12 = rd4 + rd1 (B_val addr)
+    // %rd13 = rd5 + rd1 (B_eps addr)
+
+    var ai: i64 = 0
+    while ai < 4 {
+        op = gpu_op_default()
+        op.opcode = GpuOpcode::GpuAdd
+        op.dst_reg = 10 + ai    // %rd10..%rd13
+        op.lhs_reg = 2 + ai     // %rd2..%rd5 (param ptrs)
+        op.rhs_reg = 1           // %rd1 (byte offset)
+        op.ty = GpuType::GpuU64
+        k.ops[idx] = op
+        idx = idx + 1
+        ai = ai + 1
+    }
+
+    // ─── Load A_val fragments into %r3..%r6 (b32 packed f16) ──
+    var li: i64 = 0
+    while li < 4 {
+        op = gpu_op_default()
+        op.opcode = GpuOpcode::GpuLoadGlobal
+        op.dst_reg = 3 + li      // %r3..%r6 (u32 b32 regs)
+        op.addr_reg = 10         // A_val base
+        op.ty = GpuType::GpuU32
+        op.dst_ty = GpuType::GpuU32
+        k.ops[idx] = op
+        idx = idx + 1
+        li = li + 1
+    }
+
+    // ─── Load B_val fragments into %r7..%r8 (b32 packed f16) ──
+    li = 0
+    while li < 2 {
+        op = gpu_op_default()
+        op.opcode = GpuOpcode::GpuLoadGlobal
+        op.dst_reg = 7 + li      // %r7..%r8 (u32 b32 regs)
+        op.addr_reg = 12         // B_val base
+        op.ty = GpuType::GpuU32
+        op.dst_ty = GpuType::GpuU32
+        k.ops[idx] = op
+        idx = idx + 1
+        li = li + 1
+    }
+
+    // ─── Load A_eps and B_eps (scalar per thread) ──────────────
+    // %f4 = A_eps
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuLoadGlobal
+    op.dst_reg = 4
+    op.addr_reg = 11  // A_eps addr
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f5 = B_eps
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuLoadGlobal
+    op.dst_reg = 5
+    op.addr_reg = 13  // B_eps addr
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Barrier before WMMA ───────────────────────────────────
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuBarrierSync
+    op.rhs_imm = 0
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ═══ TENSOR CORE DATA PATH ═════════════════════════════════
+    // mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+    //   {%f0..%f3}, {%r3..%r6}, {%r7..%r8}, {%f0..%f3}
+    // C/D use same regs (A*B+0 pattern; PTX regs zero-init at launch)
+
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuWmma
+    op.dst_reg = 0      // D output: %f0..%f3 (f32)
+    op.lhs_reg = 3      // A frags: %r3..%r6 (u32/b32 packed f16)
+    op.rhs_reg = 7      // B frags: %r7..%r8 (u32/b32 packed f16)
+    op.src_reg = 0      // C accum: %f0..%f3 (same regs, A*B+0)
+    op.num_regs = 4     // 4 fragment registers per matrix (m16n8k16)
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ═══ EPISTEMIC SHADOW PATH (GUM JCGM 100:2008) ════════════
+    //
+    // GUM law of propagation of uncertainty for C = A·B with A, B independent
+    // (no covariance term — v1 does not model input correlation):
+    //   U² = ε_A²·|B|² + ε_B²·|A|²
+    //   ε_C = sqrt(K · U²)   (K=16 identical-variance terms summed in quadrature)
+    //
+    // Previously this computed ε_C = sqrt(K)·(ε_A|B| + ε_B|A|), i.e. it squared
+    // a linear sum instead of summing squares — that carries a spurious cross
+    // term 2·ε_A·ε_B·|A|·|B| that inflates the uncertainty above the true RSS
+    // value for uncorrelated inputs. Fixed below to square each term first.
+    //
+    // Uses D output fragments as norm representatives (as in reference PTX).
+    // Doubling chain: U² → 2·U² → 4·U² → 8·U² → 16·U² → sqrt
+
+    // %f6 = abs(%f0)  — |D[0]| used as norm_A approximation
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAbs
+    op.dst_reg = 6
+    op.src_reg = 0      // D_frag[0]
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f7 = abs(%f2)  — |D[2]| used as norm_B approximation
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAbs
+    op.dst_reg = 7
+    op.src_reg = 2      // D_frag[2]
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f8 = %f4 * %f7  — ε_A · |D[2]| (norm_B)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuMul
+    op.dst_reg = 8
+    op.lhs_reg = 4      // eps_A
+    op.rhs_reg = 7      // norm_B
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f9 = %f5 * %f6  — ε_B · |D[0]| (norm_A)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuMul
+    op.dst_reg = 9
+    op.lhs_reg = 5      // eps_B
+    op.rhs_reg = 6      // norm_A
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // GUM/JCGM 100:2008 quadrature (RSS) combination for independent A, B:
+    //   U² = ε_A²·|B|² + ε_B²·|A|²    (no cross term — A, B assumed uncorrelated;
+    //                                   v1 does not model covariance, see note below)
+    // %f10 = %f8 * %f8  — (ε_A·|B|)²
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuMul
+    op.dst_reg = 10
+    op.lhs_reg = 8
+    op.rhs_reg = 8
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f11 = %f9 * %f9  — (ε_B·|A|)²
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuMul
+    op.dst_reg = 11
+    op.lhs_reg = 9
+    op.rhs_reg = 9
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f12 = %f10 + %f11  — U² = ε_A²|B|² + ε_B²|A|² (true RSS, cross term dropped)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 12
+    op.lhs_reg = 10
+    op.rhs_reg = 11
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // Doubling chain: multiply U² by 16 (tile size K) using 4× add-to-self
+    // %f13 = %f12 + %f12  — 2·U²
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 13
+    op.lhs_reg = 12
+    op.rhs_reg = 12
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f14 = %f13 + %f13  — 4·U²
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 14
+    op.lhs_reg = 13
+    op.rhs_reg = 13
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f15 = %f14 + %f14  — 8·U²
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 15
+    op.lhs_reg = 14
+    op.rhs_reg = 14
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f16 = %f15 + %f15  — 16·U² = K·U² (K=16 independent-term quadrature sum)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 16
+    op.lhs_reg = 15
+    op.rhs_reg = 15
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %f17 = sqrt(%f16) = sqrt(K·U²)
+    // GUM-compliant tile-level uncertainty: ε_C = sqrt(K · (ε_A²|B|² + ε_B²|A|²))
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuSqrt
+    op.dst_reg = 17
+    op.src_reg = 16
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ═══ VALIDITY PATH ═════════════════════════════════════════
+    // %f6 (norm_A) is dead after computing %f8/%f9 above — reuse it to
+    // synthesize a genuine 0.0 f32 constant (self-subtract is exact in IEEE754
+    // for any finite operand; there is no float-immediate-load opcode in this IR).
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuSub
+    op.dst_reg = 6        // %f6 = zero
+    op.lhs_reg = 4         // eps_A
+    op.rhs_reg = 4
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %p0 = (ε_A >= 0)  — A uncertainty is valid (non-negative)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuSetpGe
+    op.dst_reg = 0       // %p0
+    op.lhs_reg = 4       // eps_A (f32 reg %f4)
+    op.rhs_reg = 6       // real 0.0
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %p1 = (ε_B >= 0)  — B uncertainty is valid
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuSetpGe
+    op.dst_reg = 1       // %p1
+    op.lhs_reg = 5       // eps_B (f32 reg %f5)
+    op.rhs_reg = 6       // real 0.0
+    op.ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %p2 = %p0 AND %p1  — both inputs valid
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAnd
+    op.dst_reg = 2       // %p2
+    op.lhs_reg = 0       // %p0
+    op.rhs_reg = 1       // %p1
+    op.ty = GpuType::GpuBool
+    op.dst_ty = GpuType::GpuBool
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ═══ PROVENANCE PATH ═══════════════════════════════════════
+    // %rd14 = %rd1 * 8  (byte offset for u64 provenance arrays)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuMulImm
+    op.dst_reg = 14
+    op.lhs_reg = 0       // tid as u64
+    op.rhs_imm = 8
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %rd15 = rd9 + rd14  (C_prov write addr — param 7)
+    // But first load A_prov and B_prov. We need additional addresses.
+    // Actually, params 6 and 7 are C_vld and C_prv (output only).
+    // We don't load input provenance for this simplified kernel.
+    //
+    // KNOWN LIMITATION (v1, not fixed in this pass): provenance is set to the
+    // bitwise OR of the A/B value pointers, not a real lineage/history merge.
+    // This repo has no established GPU-side provenance-merge convention to
+    // follow yet (tensor_epistemic.sio only allocates a provenance register,
+    // it doesn't define a merge law) — a real fix needs that design decided
+    // first, not a mechanical swap here. Tracked as an open follow-up.
+
+    // %rd16 = %rd2 OR %rd4  — A_val_ptr OR B_val_ptr (KNOWN-LIMITED provenance, see above)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuOr
+    op.dst_reg = 16
+    op.lhs_reg = 2       // A_val ptr
+    op.rhs_reg = 4       // B_val ptr
+    op.ty = GpuType::GpuU64
+    op.dst_ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Output address computation ────────────────────────────
+    // %rd17 = rd6 + rd1  (C_val addr)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 17
+    op.lhs_reg = 6       // param_c_val ptr
+    op.rhs_reg = 1       // byte offset
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %rd18 = rd7 + rd1  (C_eps addr)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 18
+    op.lhs_reg = 7       // param_c_eps ptr
+    op.rhs_reg = 1
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %rd19 = rd8 + rd1  (C_vld addr)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 19
+    op.lhs_reg = 8       // param_c_vld ptr
+    op.rhs_reg = 1
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // %rd20 = rd9 + rd14  (C_prv addr — u64 stride)
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuAdd
+    op.dst_reg = 20
+    op.lhs_reg = 9       // param_c_prv ptr
+    op.rhs_reg = 14      // u64 byte offset
+    op.ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Store C_val (first D fragment %f0) ────────────────────
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuStoreGlobal
+    op.addr_reg = 17     // C_val addr
+    op.src_reg = 0       // %f0 (first mma.sync D output fragment)
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Store C_eps (%f17 = uncertainty) ──────────────────────
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuStoreGlobal
+    op.addr_reg = 18     // C_eps addr
+    op.src_reg = 17      // %f17 (eps_out = sqrt(K·U²), true RSS quadrature)
+    op.ty = GpuType::GpuF32
+    op.dst_ty = GpuType::GpuF32
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Store C_valid (convert pred to u32 and store) ─────────
+    // Simplified: store 1 unconditionally (validity is in %p2)
+    // In a full implementation, we'd use selp to convert pred→u32.
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuStoreGlobalPred
+    op.addr_reg = 19     // C_vld addr
+    op.src_reg = 2       // %p2 (validity predicate)
+    op.ty = GpuType::GpuBool
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Store C_provenance (u64) ──────────────────────────────
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuStoreGlobal
+    op.addr_reg = 20     // C_prv addr
+    op.src_reg = 16      // %rd16 (XOR provenance)
+    op.ty = GpuType::GpuU64
+    op.dst_ty = GpuType::GpuU64
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ─── Return ────────────────────────────────────────────────
+    op = gpu_op_default()
+    op.opcode = GpuOpcode::GpuRet
+    k.ops[idx] = op
+    idx = idx + 1
+
+    // ── Finalize ───────────────────────────────────────────────
+    k.op_count = idx
+
+    // Register allocation counts
+    k.max_reg_u32 = 9    // %r<9>: r0=tid, r1=ctaid, r2=ntid, r3..r6=A frags, r7..r8=B frags
+    k.max_reg_u64 = 21   // %rd<21>: rd0..rd20
+    k.max_reg_f32 = 18   // %f<18>: f0..f17
+    k.max_reg_pred = 3   // %p<3>: p0, p1, p2
+    k.max_reg_f64 = 0
+    k.max_reg_i32 = 0
+    k.max_reg_i64 = 0
+
+    k
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Epistemic Tiled GEMM with Shared Memory + K-loop Uncertainty Accumulation
+//
+// Track A of the Sounio GPU epistemic push: tiled GEMM iterating over K
+// tiles, staging through shared memory, with GUM-compliant (JCGM 100:2008)
+// uncertainty accumulating across K iterations via quadrature:
+//
+//   ε_accum = sqrt( Σ_k  ε_tile_k² )
+//
+// Each tile: load A/B to shared memory → barrier → WMMA → shadow uncertainty
+// After K-loop: store C_val, C_eps, C_vld, C_prv to global.
+//
+// Register layout:
+//   u32: %r0=tid.x, %r1=ctaid.x, %r2=ntid.x, %r3=loop_counter, %r4=K_tiles
+//   u64: %rd0..%rd9 (param ptrs), %rd10..%rd13 (A/B addrs),
+//        %rd14 (u64 stride), %rd15 (tile stride=64),
+//        %rd16 (xor prov), %rd17..%rd20 (output addrs)
+//   f32: %f0..%f7 (A frags), %f8..%f15 (B frags), %f16..%f23 (C accum),
+//        %f24..%f25 (A_eps, B_eps loaded), %f26..%f36 (shadow scratch),
+//        %f37 (eps_accum), %f38 (eps_accum²), %f39 (tile_eps²),
+//        %f40 (sum²)
+//   pred: %p0 (A valid), %p1 (B valid), %p2 (AND result), %p3 (loop cond)
+//
+// Shared memory: 2048 bytes (2 × 16×16×4 for A_tile + B_tile)
+// ═══════════════════════════════════════════════════════════════════════
+

--- a/self-hosted/gpu/kretikos_emit_epistemic_wmma.sio
+++ b/self-hosted/gpu/kretikos_emit_epistemic_wmma.sio
@@ -12,11 +12,20 @@
 // the kernel_ir.sio builder's own output, which carries the corrected GUM
 // quadrature (RSS) epsilon math, not the reference kernel's formula.
 //
+// Imports the *lean* extractions (gpu::kernel_ir_wmma_lean,
+// gpu::lower_to_ptx_wmma_lean) instead of the full gpu::kernel_ir /
+// gpu::lower_to_ptx: the full kernel_ir.sio has ~130 top-level functions
+// (large GEMM/conv2d/tiled-GEMM builders among them) that the compiler
+// fully lowers/codegens for any importer regardless of reachability, which
+// blows past both the Madaros memory ceiling and the ELF staging-buffer cap
+// for a driver this small — see docs/audit/MADAROS_GPU_MODULE_COMPILE_OOM_2026-07-03.md
+// and docs/audit/MADAROS_ELF_STAGING_BUFFER_WIDEN_HANG_2026-07-03.md.
+//
 // Usage: souc build kretikos_emit_epistemic_wmma.sio -o /tmp/kretikos_emit_epistemic_wmma.elf
 //        /tmp/kretikos_emit_epistemic_wmma.elf epi_wmma_mm16 > epi_wmma_mm16.ptx
 
-use gpu::kernel_ir::*
-use gpu::lower_to_ptx::*
+use gpu::kernel_ir_wmma_lean::*
+use gpu::lower_to_ptx_wmma_lean::*
 use gpu::ptx::*
 
 fn main() -> i32 with IO, Mut, Panic, Div, Alloc {

--- a/self-hosted/gpu/lower_to_ptx_wmma_lean.sio
+++ b/self-hosted/gpu/lower_to_ptx_wmma_lean.sio
@@ -1,0 +1,1238 @@
+// self-hosted/gpu/lower_to_ptx_wmma_lean.sio
+// Converts GpuKernelIr to PTX text using the ptx.sio emitter functions.
+// Verbatim copy of self-hosted/gpu/lower_to_ptx.sio with one line changed:
+// imports gpu::kernel_ir_wmma_lean (the lean type-only extraction) instead
+// of the full gpu::kernel_ir, so the DGX Spark gate driver does not have
+// to pull in kernel_ir.sio's other ~130 unrelated functions. Keep this
+// file's logic in sync by hand with lower_to_ptx.sio -- see
+// docs/audit/MADAROS_GPU_MODULE_COMPILE_OOM_2026-07-03.md for why this
+// duplication exists instead of editing the shared file directly (editing
+// lower_to_ptx.sio's own import would risk a duplicate-type conflict for
+// any other caller that also imports the full kernel_ir.sio in the same
+// build).
+
+use gpu::kernel_ir_wmma_lean::*
+use gpu::ptx::*
+
+// Lower a complete GPU kernel IR to PTX
+pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+    var buf = ptx_buf_new()
+
+    // 1. Emit header (.version, .target, .address_size)
+    buf = ptx_emit_header(buf)
+    // gpu_emit_kernel_mode_metadata skipped: calls gpu_legalize_kernel_to_ssa_v2 which
+    // returns GpuKernelSsaV2 by value (~28MB frame) → SIGSEGV in lean_single-compiled binary.
+    // The function only emits cosmetic PTX comment lines; skip it for correctness.
+
+    // 2. Emit kernel signature
+    buf = gpu_emit_kernel_signature(buf, kernel)
+
+    // 3. Emit register declarations
+    buf = gpu_emit_reg_decls(buf, kernel)
+
+    // 4. Lower each operation
+    buf = gpu_lower_ops(buf, kernel)
+
+    // 5. Close kernel body
+    buf = ptx_push_str(buf, "}\n")
+
+    buf
+}
+
+// gpu_emit_kernel_mode_metadata intentionally omitted from this lean file:
+// it is dead code in lower_to_ptx.sio too (never called — see the "skipped"
+// comment above), and its dependency chain (gpu_legalize_kernel_to_ssa_v2's
+// ~28MB by-value GpuKernelSsaV2 return, per that same comment) is exactly
+// the class of thing this lean extraction exists to avoid pulling in.
+
+// Emit kernel signature: .visible .entry kernel_name(params...)
+fn gpu_emit_kernel_signature(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div {
+    var out = buf
+
+    // .visible .entry kernel_name(
+    out = ptx_push_str(out, ".visible .entry ")
+    out = gpu_push_name(out, kernel.kernel_name)
+    out = ptx_push_str(out, "(\n")
+
+    // Emit each parameter
+    var i: i64 = 0
+    while i < kernel.param_count {
+        let param = kernel.params[i as usize]
+
+        out = ptx_push_str(out, "    .param .")
+        out = ptx_push_str(out, gpu_type_to_string(param.ty))
+        out = ptx_push_str(out, " ")
+        out = gpu_push_name(out, param.name)
+
+        if i < (kernel.param_count - 1) {
+            out = ptx_push_str(out, ",\n")
+        } else {
+            out = ptx_push_str(out, "\n")
+        }
+
+        i = i + 1
+    }
+
+    out = ptx_push_str(out, ")\n")
+    out
+}
+
+// Emit register declarations based on kernel.max_reg_*
+fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+    var out = buf
+
+    out = ptx_push_str(out, "{\n")
+
+    // .reg .pred %p<N>
+    if kernel.max_reg_pred > 0 {
+        out = ptx_push_str(out, "    .reg .pred %p<")
+        out = gpu_push_i64(out, kernel.max_reg_pred)
+        out = ptx_push_str(out, ">;\n")
+    }
+
+    // .reg .b32 %r<N> — covers both u32 and i32 (signedness is in opcode, not register)
+    let b32_count = if kernel.max_reg_u32 > kernel.max_reg_i32 { kernel.max_reg_u32 } else { kernel.max_reg_i32 }
+    if b32_count > 0 {
+        out = ptx_push_str(out, "    .reg .b32 %r<")
+        out = gpu_push_i64(out, b32_count)
+        out = ptx_push_str(out, ">;\n")
+    }
+
+    // .reg .b64 %rd<N> — covers both u64 and i64
+    let b64_count = if kernel.max_reg_u64 > kernel.max_reg_i64 { kernel.max_reg_u64 } else { kernel.max_reg_i64 }
+    if b64_count > 0 {
+        out = ptx_push_str(out, "    .reg .b64 %rd<")
+        out = gpu_push_i64(out, b64_count)
+        out = ptx_push_str(out, ">;\n")
+    }
+
+    if kernel.shared_bytes > 0 {
+        out = ptx_emit_shared_decl(out, kernel.shared_bytes)
+    }
+
+    // .reg .f32 %f<N>
+    if kernel.max_reg_f32 > 0 {
+        out = ptx_push_str(out, "    .reg .f32 %f<")
+        out = gpu_push_i64(out, kernel.max_reg_f32)
+        out = ptx_push_str(out, ">;\n")
+    }
+
+    // .reg .f64 %fd<N>
+    if kernel.max_reg_f64 > 0 {
+        out = ptx_push_str(out, "    .reg .f64 %fd<")
+        out = gpu_push_i64(out, kernel.max_reg_f64)
+        out = ptx_push_str(out, ">;\n")
+    }
+
+    out = ptx_push_str(out, "\n")
+    out
+}
+
+// Lower all operations in sequence
+fn gpu_lower_ops(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+    var out = buf
+    var i: i64 = 0
+
+    while i < kernel.op_count {
+        let op = kernel.ops[i as usize]
+        out = gpu_lower_op(out, op, kernel)
+        i = i + 1
+    }
+
+    out
+}
+
+// Lower a single GPU operation to PTX
+fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, Alloc {
+    // Struct-first representation avoids enum field destructuring in the
+    // self-hosted IR; switch on opcode and use struct fields explicitly.
+    let opcode = op.opcode
+    match opcode {
+        GpuOpcode::GpuGetTid => {
+            // mov.u32 %rN, %tid.x
+            let tid_special = if op.axis == 0 { "%tid.x" }
+                             else if op.axis == 1 { "%tid.y" }
+                             else { "%tid.z" }
+            ptx_push_binary2(buf, ptx_opcode_mov_u32(), gpu_reg_u32(op.dst_reg), tid_special)
+        }
+
+        GpuOpcode::GpuCvt => {
+            // cvt.dst_ty.src_ty %rdN, %rM — built dynamically from op.dst_ty / op.src_ty
+            // NOTE: str_concat(str_concat(A,B), str_concat(C,D)) clobbers BUILTIN_SLOT_A/B in
+            // lean_single; break nested calls into sequential variable assignments.
+            let dst_ty_str = gpu_type_to_string(op.dst_ty)
+            let src_ty_str = gpu_type_to_string(op.src_ty)
+            let cvt_dst = str_concat("cvt.", dst_ty_str)
+            let dot_src = str_concat(".", src_ty_str)
+            let opcode = str_concat(cvt_dst, dot_src)
+            let dst_str = match op.dst_ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_u64(op.dst_reg),
+            }
+            let src_str = match op.src_ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.src_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.src_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.src_reg),
+                _ => gpu_reg_u32(op.src_reg),
+            }
+
+            ptx_push_binary2(buf, opcode, dst_str, src_str)
+        }
+
+        GpuOpcode::GpuMulImm => {
+            // mul.lo.u64 %rdN, %rdM, imm  (immediate via gpu_push_i64 — i64_to_string is UAF)
+            let dst_str = if op.ty == GpuType::GpuU64 { gpu_reg_u64(op.dst_reg) } else { gpu_reg_u32(op.dst_reg) }
+            let lhs_str = if op.ty == GpuType::GpuU64 { gpu_reg_u64(op.lhs_reg) } else { gpu_reg_u32(op.lhs_reg) }
+            var mout = buf
+            mout = ptx_push_str(mout, "    ")
+            mout = ptx_push_str(mout, ptx_opcode_mul_lo_u64())
+            mout = ptx_push_str(mout, " ")
+            mout = ptx_push_str(mout, dst_str)
+            mout = ptx_push_str(mout, ", ")
+            mout = ptx_push_str(mout, lhs_str)
+            mout = ptx_push_str(mout, ", ")
+            mout = gpu_push_i64(mout, op.rhs_imm)
+            mout = ptx_push_str(mout, ";\n")
+            mout
+        }
+
+        GpuOpcode::GpuAdd => {
+            // add.ty %dstN, %lhsM, %rhsK
+            let opcode = match op.ty {
+                GpuType::GpuU32 => ptx_opcode_add_u32(),
+                GpuType::GpuU64 => ptx_opcode_add_u64(),
+                GpuType::GpuF32 => ptx_opcode_add_f32(),
+                GpuType::GpuF64 => ptx_opcode_add_f64(),
+                GpuType::GpuI32 => ptx_opcode_add_s32(),
+                GpuType::GpuI64 => ptx_opcode_add_s64(),
+                _ => ptx_opcode_add_u64(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_u64(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_u64(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                _ => gpu_reg_u64(op.rhs_reg),
+            }
+
+            ptx_push_binary3(buf, opcode, dst_str, lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuSub => {
+            // sub.ty %dstN, %lhsM, %rhsK
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_sub_f32(),
+                GpuType::GpuF64 => ptx_opcode_sub_f64(),
+                GpuType::GpuI32 => ptx_opcode_sub_s32(),
+                GpuType::GpuI64 => ptx_opcode_sub_s64(),
+                GpuType::GpuU64 => ptx_opcode_sub_u64(),
+                _ => ptx_opcode_sub_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+
+            ptx_push_binary3(buf, opcode, dst_str, lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuMul => {
+            // mul.lo.ty %dstN, %lhsM, %rhsK (or mul.rn for float)
+            let opcode = match op.ty {
+                GpuType::GpuU32 => ptx_opcode_mul_lo_u32(),
+                GpuType::GpuU64 => ptx_opcode_mul_lo_u64(),
+                GpuType::GpuF32 => ptx_opcode_mul_lo_f32(),
+                GpuType::GpuF64 => ptx_opcode_mul_lo_f64(),
+                GpuType::GpuI32 => ptx_opcode_mul_lo_s32(),
+                GpuType::GpuI64 => ptx_opcode_mul_lo_s64(),
+                _ => ptx_opcode_mul_lo_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+
+            ptx_push_binary3(buf, opcode, dst_str, lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuDiv => {
+            // div.rn.ty %dstN, %lhsM, %rhsK
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_div_f32(),
+                GpuType::GpuF64 => ptx_opcode_div_f64(),
+                GpuType::GpuI32 => ptx_opcode_div_s32(),
+                GpuType::GpuI64 => ptx_opcode_div_s64(),
+                GpuType::GpuU64 => ptx_opcode_div_u64(),
+                _ => ptx_opcode_div_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+
+            ptx_push_binary3(buf, opcode, dst_str, lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuMax => {
+            // max.ty %dstN, %lhsM, %rhsK
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_max_f32(),
+                GpuType::GpuF64 => ptx_opcode_max_f64(),
+                GpuType::GpuI32 => ptx_opcode_max_s32(),
+                GpuType::GpuI64 => ptx_opcode_max_s64(),
+                GpuType::GpuU32 => ptx_opcode_max_u32(),
+                GpuType::GpuU64 => ptx_opcode_max_u64(),
+                _ => ptx_opcode_max_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+
+            ptx_push_binary3(buf, opcode, dst_str, lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuMin => {
+            // min.ty %dstN, %lhsM, %rhsK
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_min_f32(),
+                GpuType::GpuF64 => ptx_opcode_min_f64(),
+                GpuType::GpuI32 => ptx_opcode_min_s32(),
+                GpuType::GpuI64 => ptx_opcode_min_s64(),
+                GpuType::GpuU32 => ptx_opcode_min_u32(),
+                GpuType::GpuU64 => ptx_opcode_min_u64(),
+                _ => ptx_opcode_min_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+
+            ptx_push_binary3(buf, opcode, dst_str, lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuBarrierSync => {
+            // bar.sync 0
+            ptx_push_barrier_sync(buf)
+        }
+
+        GpuOpcode::GpuShflDown => {
+            // Negative rhs_imm => shfl.sync.up (for scan); positive => shfl.sync.down (for reduction)
+            let is_up = op.rhs_imm < 0
+            let actual_offset = if is_up { 0 - op.rhs_imm } else { op.rhs_imm }
+            let opcode = if is_up {
+                match op.ty {
+                    GpuType::GpuF64 => ptx_opcode_shfl_up_b64(),
+                    GpuType::GpuI64 => ptx_opcode_shfl_up_b64(),
+                    GpuType::GpuU64 => ptx_opcode_shfl_up_b64(),
+                    _ => ptx_opcode_shfl_up_b32(),
+                }
+            } else {
+                match op.ty {
+                    GpuType::GpuF64 => ptx_opcode_shfl_down_b64(),
+                    GpuType::GpuI64 => ptx_opcode_shfl_down_b64(),
+                    GpuType::GpuU64 => ptx_opcode_shfl_down_b64(),
+                    _ => ptx_opcode_shfl_down_b32(),
+                }
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let src_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            // Inline shfl emission: i64_to_string(actual_offset) is UAF when passed to a fn
+            var shfl_out = buf
+            shfl_out = ptx_push_str(shfl_out, "    ")
+            shfl_out = ptx_push_str(shfl_out, opcode)
+            shfl_out = ptx_push_str(shfl_out, " ")
+            shfl_out = ptx_push_str(shfl_out, dst_str)
+            shfl_out = ptx_push_str(shfl_out, ", ")
+            shfl_out = ptx_push_str(shfl_out, src_str)
+            shfl_out = ptx_push_str(shfl_out, ", ")
+            shfl_out = gpu_push_i64(shfl_out, actual_offset)
+            shfl_out = ptx_push_str(shfl_out, ", 0xffffffff;\n")
+            shfl_out
+        }
+
+        GpuOpcode::GpuSetpLt => {
+            let opcode = match op.ty {
+                GpuType::GpuU32 => ptx_opcode_setp_lt_u32(),
+                GpuType::GpuU64 => ptx_opcode_setp_lt_u64(),
+                GpuType::GpuF32 => ptx_opcode_setp_lt_f32(),
+                GpuType::GpuF64 => ptx_opcode_setp_lt_f64(),
+                GpuType::GpuI32 => ptx_opcode_setp_lt_s32(),
+                GpuType::GpuI64 => ptx_opcode_setp_lt_s64(),
+                _ => ptx_opcode_setp_lt_u32(),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_u32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                _ => gpu_reg_u32(op.rhs_reg),
+            }
+            ptx_push_setp2(buf, opcode, gpu_pred_reg(op.dst_reg), lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuSetpLe => {
+            let opcode = match op.ty {
+                GpuType::GpuU32 => ptx_opcode_setp_le_u32(),
+                GpuType::GpuU64 => ptx_opcode_setp_le_u64(),
+                GpuType::GpuF32 => ptx_opcode_setp_le_f32(),
+                GpuType::GpuF64 => ptx_opcode_setp_le_f64(),
+                GpuType::GpuI32 => ptx_opcode_setp_le_s32(),
+                GpuType::GpuI64 => ptx_opcode_setp_le_s64(),
+                _ => ptx_opcode_setp_le_u32(),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_u32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                _ => gpu_reg_u32(op.rhs_reg),
+            }
+            ptx_push_setp2(buf, opcode, gpu_pred_reg(op.dst_reg), lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuSetpGe => {
+            let opcode = match op.ty {
+                GpuType::GpuU32 => ptx_opcode_setp_ge_u32(),
+                GpuType::GpuU64 => ptx_opcode_setp_ge_u64(),
+                GpuType::GpuF32 => ptx_opcode_setp_ge_f32(),
+                GpuType::GpuF64 => ptx_opcode_setp_ge_f64(),
+                GpuType::GpuI32 => ptx_opcode_setp_ge_s32(),
+                GpuType::GpuI64 => ptx_opcode_setp_ge_s64(),
+                _ => ptx_opcode_setp_ge_u32(),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_u32(op.lhs_reg),
+            }
+            // If rhs_reg is -1, use immediate value instead of register
+            if op.rhs_reg < 0 {
+                // Inline to avoid i64_to_string UAF when passed through function call boundary
+                var sge_out = buf
+                sge_out = ptx_push_str(sge_out, "    ")
+                sge_out = ptx_push_str(sge_out, opcode)
+                sge_out = ptx_push_str(sge_out, " ")
+                sge_out = ptx_push_str(sge_out, gpu_pred_reg(op.dst_reg))
+                sge_out = ptx_push_str(sge_out, ", ")
+                sge_out = ptx_push_str(sge_out, lhs_str)
+                sge_out = ptx_push_str(sge_out, ", ")
+                sge_out = gpu_push_i64(sge_out, op.rhs_imm)
+                sge_out = ptx_push_str(sge_out, ";\n")
+                sge_out
+            } else {
+                let rhs_str = match op.ty {
+                    GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                    GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                    GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                    GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                    GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                    GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                    _ => gpu_reg_u32(op.rhs_reg),
+                }
+                ptx_push_setp2(buf, opcode, gpu_pred_reg(op.dst_reg), lhs_str, rhs_str)
+            }
+        }
+
+        GpuOpcode::GpuSetpEq => {
+            let opcode = match op.ty {
+                GpuType::GpuU32 => ptx_opcode_setp_eq_u32(),
+                GpuType::GpuU64 => ptx_opcode_setp_eq_u64(),
+                GpuType::GpuF32 => ptx_opcode_setp_eq_f32(),
+                GpuType::GpuF64 => ptx_opcode_setp_eq_f64(),
+                GpuType::GpuI32 => ptx_opcode_setp_eq_s32(),
+                GpuType::GpuI64 => ptx_opcode_setp_eq_s64(),
+                _ => ptx_opcode_setp_eq_u32(),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_u32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                _ => gpu_reg_u32(op.rhs_reg),
+            }
+            ptx_push_setp2(buf, opcode, gpu_pred_reg(op.dst_reg), lhs_str, rhs_str)
+        }
+
+        GpuOpcode::GpuSelp => {
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_selp_f32(),
+                GpuType::GpuI32 => ptx_opcode_selp_s32(),
+                GpuType::GpuI64 => ptx_opcode_selp_b64(),
+                GpuType::GpuU64 => ptx_opcode_selp_b64(),
+                GpuType::GpuF64 => ptx_opcode_selp_f64(),
+                _ => ptx_opcode_selp_b32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.lhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.rhs_reg),
+                GpuType::GpuU64 => gpu_reg_u64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+            ptx_push_selp(buf, opcode, dst_str, lhs_str, rhs_str, gpu_pred_reg(op.src_reg))
+        }
+
+        GpuOpcode::GpuAtomicAdd => {
+            // atom.add.ty %dst, [%addr], %val
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_atom_add_f32(),
+                GpuType::GpuF64 => ptx_opcode_atom_add_f64(),
+                GpuType::GpuI32 => ptx_opcode_atom_add_s32(),
+                GpuType::GpuU32 => ptx_opcode_atom_add_u32(),
+                _ => ptx_opcode_atom_add_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let val_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuU32 => gpu_reg_u32(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            ptx_push_atomic_add(buf, opcode, dst_str, gpu_reg_u64(op.addr_reg), val_str)
+        }
+
+        GpuOpcode::GpuLoadShared => {
+            // ld.shared.ty %dst, [shared_addr]
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_ld_shared_f32(),
+                GpuType::GpuF64 => ptx_opcode_ld_shared_f64(),
+                GpuType::GpuI32 => ptx_opcode_ld_shared_s32(),
+                _ => ptx_opcode_ld_shared_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let shared_addr = gpu_shared_addr_str(op.shared_addr)
+            ptx_push_ld_shared(buf, opcode, dst_str, shared_addr)
+        }
+
+        GpuOpcode::GpuStoreShared => {
+            // st.shared.ty [shared_addr], %src
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_st_shared_f32(),
+                GpuType::GpuF64 => ptx_opcode_st_shared_f64(),
+                GpuType::GpuI32 => ptx_opcode_st_shared_s32(),
+                _ => ptx_opcode_st_shared_f32(),
+            }
+            let src_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            let shared_addr = gpu_shared_addr_str(op.shared_addr)
+            ptx_push_st_shared(buf, opcode, shared_addr, src_str)
+        }
+
+        GpuOpcode::GpuLoadGlobalPred => {
+            // @p dst = ld.global.ty [addr]
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_ld_global_f32(),
+                GpuType::GpuF64 => ptx_opcode_ld_global_f64(),
+                GpuType::GpuI32 => ptx_opcode_ld_global_s32(),
+                GpuType::GpuI64 => ptx_opcode_ld_global_s64(),
+                _ => ptx_opcode_ld_global_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            ptx_push_predicated_mem2(
+                buf,
+                opcode,
+                gpu_pred_reg(op.lhs_reg),
+                dst_str,
+                gpu_reg_u64(op.addr_reg)
+            )
+        }
+
+        GpuOpcode::GpuStoreGlobalPred => {
+            // @p st.global.ty [addr], src
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_st_global_f32(),
+                GpuType::GpuF64 => ptx_opcode_st_global_f64(),
+                GpuType::GpuI32 => ptx_opcode_st_global_s32(),
+                GpuType::GpuI64 => ptx_opcode_st_global_s64(),
+                _ => ptx_opcode_st_global_f32(),
+            }
+            let src_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            ptx_push_predicated_store_mem(
+                buf,
+                opcode,
+                gpu_pred_reg(op.lhs_reg),
+                gpu_reg_u64(op.addr_reg),
+                src_str
+            )
+        }
+
+        GpuOpcode::GpuLoadSharedPred => {
+            // @p dst = ld.shared.ty [shared_addr]
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_ld_shared_f32(),
+                GpuType::GpuF64 => ptx_opcode_ld_shared_f64(),
+                _ => ptx_opcode_ld_shared_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            ptx_push_predicated_mem2(
+                buf,
+                opcode,
+                gpu_pred_reg(op.lhs_reg),
+                dst_str,
+                gpu_shared_addr_str(op.shared_addr)
+            )
+        }
+
+        GpuOpcode::GpuStoreSharedPred => {
+            // @p st.shared.ty [shared_addr], src
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_st_shared_f32(),
+                GpuType::GpuF64 => ptx_opcode_st_shared_f64(),
+                _ => ptx_opcode_st_shared_f32(),
+            }
+            let src_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            ptx_push_predicated_store_mem(
+                buf,
+                opcode,
+                gpu_pred_reg(op.lhs_reg),
+                gpu_shared_addr_str(op.shared_addr),
+                src_str
+            )
+        }
+
+        GpuOpcode::GpuLoadParam => {
+            // ld.param.ty %dst, [param_name]
+            let param_name = kernel.params[op.param_idx as usize].name
+            let opcode = if op.ty == GpuType::GpuU64 {
+                ptx_opcode_ld_param_u64()
+            } else if op.ty == GpuType::GpuU32 {
+                ptx_opcode_ld_param_u32()
+            } else if op.ty == GpuType::GpuF32 {
+                ptx_opcode_ld_param_f32()
+            } else if op.ty == GpuType::GpuF64 {
+                ptx_opcode_ld_param_f64()
+            } else {
+                ptx_opcode_ld_param_u64()
+            }
+            if op.ty == GpuType::GpuF32 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_f32(op.dst_reg), name_to_string(param_name))
+            } else if op.ty == GpuType::GpuF64 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_f64(op.dst_reg), name_to_string(param_name))
+            } else if op.ty == GpuType::GpuU64 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_u64(op.dst_reg), name_to_string(param_name))
+            } else if op.ty == GpuType::GpuU32 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_u32(op.dst_reg), name_to_string(param_name))
+            } else if op.ty == GpuType::GpuI32 {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_i32(op.dst_reg), name_to_string(param_name))
+            } else {
+                ptx_push_binary_mem2(buf, opcode, gpu_reg_u64(op.dst_reg), name_to_string(param_name))
+            }
+        }
+
+        GpuOpcode::GpuLoadGlobal => {
+            // ld.global.ty %regN, [%rdM]
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_ld_global_f32(),
+                GpuType::GpuF64 => ptx_opcode_ld_global_f64(),
+                GpuType::GpuI32 => ptx_opcode_ld_global_s32(),
+                GpuType::GpuI64 => ptx_opcode_ld_global_s64(),
+                _ => ptx_opcode_ld_global_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            ptx_push_binary_mem2(buf, opcode, dst_str, gpu_reg_u64(op.addr_reg))
+        }
+
+        GpuOpcode::GpuStoreGlobal => {
+            // st.global.ty [%rdN], %regM
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_st_global_f32(),
+                GpuType::GpuF64 => ptx_opcode_st_global_f64(),
+                GpuType::GpuI32 => ptx_opcode_st_global_s32(),
+                GpuType::GpuI64 => ptx_opcode_st_global_s64(),
+                _ => ptx_opcode_st_global_f32(),
+            }
+            let src_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            ptx_push_store_mem(buf, opcode, gpu_reg_u64(op.addr_reg), src_str)
+        }
+
+        GpuOpcode::GpuRet => {
+            ptx_push_ret(buf)
+        }
+
+        // Phase 4: Fused multiply-add (dst = lhs * rhs + src)
+        GpuOpcode::GpuFma => {
+            let opcode = match op.ty {
+                GpuType::GpuF32 => ptx_opcode_fma_rn_f32(),
+                GpuType::GpuF64 => ptx_opcode_fma_rn_f64(),
+                GpuType::GpuI32 => ptx_opcode_mad_lo_s32(),
+                GpuType::GpuI64 => ptx_opcode_mad_lo_s64(),
+                _ => ptx_opcode_fma_rn_f32(),
+            }
+            let dst_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.dst_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.dst_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.dst_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.dst_reg),
+                _ => gpu_reg_f32(op.dst_reg),
+            }
+            let lhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.lhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.lhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.lhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.lhs_reg),
+                _ => gpu_reg_f32(op.lhs_reg),
+            }
+            let rhs_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.rhs_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.rhs_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.rhs_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.rhs_reg),
+                _ => gpu_reg_f32(op.rhs_reg),
+            }
+            let acc_str = match op.ty {
+                GpuType::GpuF32 => gpu_reg_f32(op.src_reg),
+                GpuType::GpuF64 => gpu_reg_f64(op.src_reg),
+                GpuType::GpuI32 => gpu_reg_i32(op.src_reg),
+                GpuType::GpuI64 => gpu_reg_i64(op.src_reg),
+                _ => gpu_reg_f32(op.src_reg),
+            }
+            ptx_push_fma(buf, opcode, dst_str, lhs_str, rhs_str, acc_str)
+        }
+
+        // Phase 4: Block index (blockIdx.x/y/z)
+        GpuOpcode::GpuGetBid => {
+            let bid_special = if op.axis == 0 { "%ctaid.x" }
+                             else if op.axis == 1 { "%ctaid.y" }
+                             else { "%ctaid.z" }
+            ptx_push_binary2(buf, ptx_opcode_mov_u32(), gpu_reg_u32(op.dst_reg), bid_special)
+        }
+
+        // Phase 4: Block dimension (blockDim.x/y/z)
+        GpuOpcode::GpuGetNtid => {
+            let ntid_special = if op.axis == 0 { "%ntid.x" }
+                              else if op.axis == 1 { "%ntid.y" }
+                              else { "%ntid.z" }
+            ptx_push_binary2(buf, ptx_opcode_mov_u32(), gpu_reg_u32(op.dst_reg), ntid_special)
+        }
+
+        // Phase 4: Add immediate (like MulImm but for addition)
+        GpuOpcode::GpuAddImm => {
+            let opcode = if op.ty == GpuType::GpuU32 { ptx_opcode_add_u32() } else { ptx_opcode_add_u64() }
+            let dst_str = if op.ty == GpuType::GpuU32 { gpu_reg_u32(op.dst_reg) } else { gpu_reg_u64(op.dst_reg) }
+            let src_str = if op.ty == GpuType::GpuU32 { gpu_reg_u32(op.lhs_reg) } else { gpu_reg_u64(op.lhs_reg) }
+            var aout = buf
+            aout = ptx_push_str(aout, "    ")
+            aout = ptx_push_str(aout, opcode)
+            aout = ptx_push_str(aout, " ")
+            aout = ptx_push_str(aout, dst_str)
+            aout = ptx_push_str(aout, ", ")
+            aout = ptx_push_str(aout, src_str)
+            aout = ptx_push_str(aout, ", ")
+            aout = gpu_push_i64(aout, op.rhs_imm)
+            aout = ptx_push_str(aout, ";\n")
+            aout
+        }
+
+        // ── Phase 5: Tensor Core (mma.sync) ────────────────────────
+        // mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32
+        //   {d0..d3}, {a0..a3}, {b0..b1}, {c0..c3}
+        // A/B: .b32 registers (packed f16 pairs, u32 pool)
+        // C/D: .f32 registers (accumulator/output)
+        // Uses: dst_reg (D, 4 f32), lhs_reg (A, 4 u32),
+        //       rhs_reg (B, 2 u32), src_reg (C, 4 f32)
+        GpuOpcode::GpuWmma => {
+            var out = buf
+
+            out = ptx_push_str(out, "    mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {")
+
+            // D fragments (output f32): dst_reg..dst_reg+3
+            var fi: i64 = 0
+            while fi < 4 {
+                if fi > 0 { out = ptx_push_str(out, ", ") }
+                out = ptx_push_str(out, gpu_reg_f32(op.dst_reg + fi))
+                fi = fi + 1
+            }
+            out = ptx_push_str(out, "}, {")
+
+            // A fragments (b32 u32): lhs_reg..lhs_reg+3
+            fi = 0
+            while fi < 4 {
+                if fi > 0 { out = ptx_push_str(out, ", ") }
+                out = ptx_push_str(out, gpu_reg_u32(op.lhs_reg + fi))
+                fi = fi + 1
+            }
+            out = ptx_push_str(out, "}, {")
+
+            // B fragments (b32 u32): rhs_reg..rhs_reg+1
+            fi = 0
+            while fi < 2 {
+                if fi > 0 { out = ptx_push_str(out, ", ") }
+                out = ptx_push_str(out, gpu_reg_u32(op.rhs_reg + fi))
+                fi = fi + 1
+            }
+            out = ptx_push_str(out, "}, {")
+
+            // C accumulator (f32): src_reg..src_reg+3
+            fi = 0
+            while fi < 4 {
+                if fi > 0 { out = ptx_push_str(out, ", ") }
+                out = ptx_push_str(out, gpu_reg_f32(op.src_reg + fi))
+                fi = fi + 1
+            }
+            out = ptx_push_str(out, "};\n")
+            out
+        }
+
+        // ── Phase 5: Math Intrinsics ───────────────────────────────
+
+        // abs.f32 %fN, %fM
+        GpuOpcode::GpuAbs => {
+            var out = buf
+            out = ptx_push_str(out, "    abs.f32 ")
+            out = ptx_push_str(out, gpu_reg_f32(op.dst_reg))
+            out = ptx_push_str(out, ", ")
+            out = ptx_push_str(out, gpu_reg_f32(op.src_reg))
+            out = ptx_push_str(out, ";\n")
+            out
+        }
+
+        // sqrt.approx.f32 %fN, %fM
+        GpuOpcode::GpuSqrt => {
+            var out = buf
+            out = ptx_push_str(out, "    sqrt.approx.f32 ")
+            out = ptx_push_str(out, gpu_reg_f32(op.dst_reg))
+            out = ptx_push_str(out, ", ")
+            out = ptx_push_str(out, gpu_reg_f32(op.src_reg))
+            out = ptx_push_str(out, ";\n")
+            out
+        }
+
+        // ── Phase 6: Bitwise Operations ────────────────────────────
+
+        // xor.b64 %rdN, %rdM, %rdK  (or xor.b32 for u32)
+        GpuOpcode::GpuXor => {
+            var out = buf
+            if op.ty == GpuType::GpuU64 || op.ty == GpuType::GpuB64 || op.ty == GpuType::GpuI64 {
+                out = ptx_push_str(out, "    xor.b64 ")
+                out = ptx_push_str(out, gpu_reg_u64(op.dst_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u64(op.lhs_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u64(op.rhs_reg))
+            } else {
+                out = ptx_push_str(out, "    xor.b32 ")
+                out = ptx_push_str(out, gpu_reg_u32(op.dst_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u32(op.lhs_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u32(op.rhs_reg))
+            }
+            out = ptx_push_str(out, ";\n")
+            out
+        }
+
+        // ── Phase 6: Async Copy ──────────────────────────────────
+
+        // cp.async.ca.shared.global [shared_addr], [src_addr], 16;
+        GpuOpcode::GpuCpAsync => {
+            var out = buf
+            out = ptx_push_str(out, "    cp.async.ca.shared.global [")
+            out = ptx_push_str(out, gpu_shared_addr_str(op.shared_addr))
+            out = ptx_push_str(out, "], [")
+            out = ptx_push_str(out, gpu_reg_u64(op.addr_reg))
+            out = ptx_push_str(out, "], 16;\n")
+            out
+        }
+
+        // cp.async.wait_all;
+        GpuOpcode::GpuCpAsyncWaitAll => {
+            var out = buf
+            out = ptx_push_str(out, "    cp.async.wait_all;\n")
+            out
+        }
+
+        // ── Phase 5: Branch / Label ─────────────────────────────
+
+        // GpuBra: branch or label definition
+        // src_reg == 1 => label definition: emit "LBB0_N:" where N = rhs_imm
+        // src_reg == 0 => branch: emit "bra LBB0_N;" or "@%pN bra LBB0_N;"
+        GpuOpcode::GpuBra => {
+            var out = buf
+            if op.src_reg == 1 {
+                // Label definition
+                out = ptx_push_str(out, "LBB0_")
+                out = gpu_push_i64(out, op.rhs_imm)
+                out = ptx_push_str(out, ":\n")
+            } else {
+                // Branch instruction
+                if op.pred_reg >= 0 {
+                    out = ptx_push_str(out, "    @")
+                    out = ptx_push_str(out, gpu_pred_reg(op.pred_reg))
+                    out = ptx_push_str(out, " bra LBB0_")
+                } else {
+                    out = ptx_push_str(out, "    bra LBB0_")
+                }
+                out = gpu_push_i64(out, op.rhs_imm)
+                out = ptx_push_str(out, ";\n")
+            }
+            out
+        }
+
+        // and.pred %pN, %pM, %pK  (for bool/pred) or and.b32/b64 (for integers)
+        GpuOpcode::GpuAnd => {
+            var out = buf
+            if op.ty == GpuType::GpuBool {
+                out = ptx_push_str(out, "    and.pred ")
+                out = ptx_push_str(out, gpu_pred_reg(op.dst_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_pred_reg(op.lhs_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_pred_reg(op.rhs_reg))
+            } else if op.ty == GpuType::GpuU64 || op.ty == GpuType::GpuB64 || op.ty == GpuType::GpuI64 {
+                out = ptx_push_str(out, "    and.b64 ")
+                out = ptx_push_str(out, gpu_reg_u64(op.dst_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u64(op.lhs_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u64(op.rhs_reg))
+            } else {
+                out = ptx_push_str(out, "    and.b32 ")
+                out = ptx_push_str(out, gpu_reg_u32(op.dst_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u32(op.lhs_reg))
+                out = ptx_push_str(out, ", ")
+                out = ptx_push_str(out, gpu_reg_u32(op.rhs_reg))
+            }
+            out = ptx_push_str(out, ";\n")
+            out
+        }
+    }
+}
+
+// Helper: Format register names dynamically using str_concat
+fn gpu_reg_u32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r", i64_to_string(reg)) }
+fn gpu_reg_u64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
+fn gpu_reg_f32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%f", i64_to_string(reg)) }
+fn gpu_reg_f64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%fd", i64_to_string(reg)) }
+fn gpu_reg_i32(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%r", i64_to_string(reg)) }
+fn gpu_reg_i64(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%rd", i64_to_string(reg)) }
+
+// Helper: Convert Name to string
+pub fn name_to_string(name: Name) -> string with Mut, Panic, Div, Alloc {
+    str_from_bytes(name.buf, name.len)
+}
+
+fn gpu_pred_reg(reg: i64) -> string with Mut, Panic, Div, Alloc { str_concat("%p", i64_to_string(reg)) }
+
+fn gpu_shared_addr_str(offset: i64) -> string with Mut, Panic, Div, Alloc {
+    if offset <= 0 { "shared_array" } else {
+        var b = ptx_buf_new()
+        b = ptx_push_str(b, "shared_array+")
+        b = gpu_push_i64(b, offset)
+        ptx_to_string(b)
+    }
+}
+
+// Helper: Convert i64 to string
+pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
+    if n < 0 {
+        return "0"
+    }
+    if n == 0 { return "0" }
+
+    var digits: [i8; 32] = [0; 32]
+    var rev_len: i64 = 0
+    var value: i64 = n
+
+    while value > 0 {
+        let digit = value % 10
+        digits[rev_len as usize] = 48 + digit as i8
+        rev_len = rev_len + 1
+        value = value / 10
+    }
+
+    var bytes: [i8; 32] = [0; 32]
+    var i: i64 = 0
+    while i < rev_len {
+        bytes[i as usize] = digits[(rev_len - i - 1) as usize]
+        i = i + 1
+    }
+
+    str_from_bytes(bytes, rev_len)
+}
+
+// Helper: Push Name bytes to buffer
+fn gpu_push_name(buf: PtxBuf, name: Name) -> PtxBuf with Mut, Panic, Div {
+    var out = buf
+    var i: i64 = 0
+    while i < name.len {
+        out = ptx_push_byte(out, name.buf[i as usize])
+        i = i + 1
+    }
+    out
+}
+
+// Helper: Push i64 as ASCII digits directly into PtxBuf (avoids i64_to_string UAF)
+pub fn gpu_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
+    if n == 0 { return ptx_push_byte(buf, 48) }
+    var value: i64 = if n < 0 { 0 } else { n }
+    var digits: [i8; 20] = [0; 20]
+    var rev_len: i64 = 0
+    while value > 0 {
+        digits[rev_len as usize] = (48 + value % 10) as i8
+        rev_len = rev_len + 1
+        value = value / 10
+    }
+    var out = buf
+    var k: i64 = rev_len - 1
+    while k >= 0 {
+        out = ptx_push_byte(out, digits[k as usize])
+        k = k - 1
+    }
+    out
+}


### PR DESCRIPTION
## Summary

Continues the chain from #585 → #602 → #605: the epistemic WMMA PTX-emitter driver
(`self-hosted/gpu/kretikos_emit_epistemic_wmma.sio`) still can't produce a real ELF
because importing the full `kernel_ir.sio` (~130 functions, ~209KB — including large
unrelated GEMM/conv2d/tiled-GEMM builders the compiler fully lowers regardless of
reachability) blows past both the memory ceiling (#602) and the ELF staging buffer (#605).

Instead of touching the compiler (risky, attempted and reverted in prior sessions), this
reduces what the driver actually has to compile: two new files
(`kernel_ir_wmma_lean.sio`, `lower_to_ptx_wmma_lean.sio`) contain only the **computed
transitive dependency closure** of the epistemic WMMA matmul builder — 18 items (4
structs, 6 enums, 8 functions) instead of kernel_ir.sio's ~130. Both are separate files
from the shared `kernel_ir.sio`/`lower_to_ptx.sio` rather than edits to them, to avoid a
duplicate-type conflict for any other caller that needs the full files in the same build.

**Verified result** (reproduced at least once during this session): `souc build` with
this lean driver reaches `Merged IR: 16 functions` (down from ~241–330) and produces a
clean, loud, non-crash error (`Native compilation failed: imported_simple_ir_emit_failed`)
instead of the SIGSEGV from #602. That remaining error is a separate, real bug identified
in `self-hosted/compiler/module_native_driver.sio`'s dispatch logic — it returns a
compact-IR-emitter failure directly instead of falling back to the full merged-IR path
(which it already does correctly for compact-IR *load* failures, just not *emit*
failures). Diagnosed, not fixed here — a fix attempt hit an unexplained typecheck error
under this session's actively-drifting shared checkout and wasn't landed safely.

**Honest caveat**: this repo's checkout was under active, concurrent, unrelated automated
modification throughout this session — `artifacts/self-hosted/madaros` was observed
mid-rebuild/deleted by another process, and `lower_to_ptx.sio`'s own logic changed
functionally (not just cosmetically) within the same session. The 16-function/clean-error
result was reproduced successfully more than once but not on every attempt against a
moving compiler-binary target. Source-level correctness (`souc check` verdict=0 on the
lean files alone) was independently confirmed at a stable point in time. **This PR's CI
run, on a clean isolated runner, is the first fully reliable verification of this change**
— take its result as authoritative over this session's local, contended-checkout results.

## Test plan

- [x] `souc check` on the lean extraction files individually passed clean (verdict=0) at
  time of writing (local, since re-drifted — see caveat).
- [ ] CI `souc check`/build on this PR's clean runner — authoritative, watch for either a
  clean pass or a concrete, reproducible error to act on next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)