### PR TITLE
fix(gpu): explicit i8 cast on zero-repeat array literals in i64-to-string helpers

### DIFF
--- a/self-hosted/gpu/lower_to_ptx_wmma_lean.sio
+++ b/self-hosted/gpu/lower_to_ptx_wmma_lean.sio
@@ -1185,7 +1185,7 @@ pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
     }
     if n == 0 { return "0" }
 
-    var digits: [i8; 32] = [0; 32]
+    var digits: [i8; 32] = [0 as i8; 32]
     var rev_len: i64 = 0
     var value: i64 = n
 
@@ -1196,7 +1196,7 @@ pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
         value = value / 10
     }
 
-    var bytes: [i8; 32] = [0; 32]
+    var bytes: [i8; 32] = [0 as i8; 32]
     var i: i64 = 0
     while i < rev_len {
         bytes[i as usize] = digits[(rev_len - i - 1) as usize]
@@ -1221,7 +1221,7 @@ fn gpu_push_name(buf: PtxBuf, name: Name) -> PtxBuf with Mut, Panic, Div {
 pub fn gpu_push_i64(buf: PtxBuf, n: i64) -> PtxBuf with Mut, Panic, Div {
     if n == 0 { return ptx_push_byte(buf, 48) }
     var value: i64 = if n < 0 { 0 } else { n }
-    var digits: [i8; 20] = [0; 20]
+    var digits: [i8; 20] = [0 as i8; 20]
     var rev_len: i64 = 0
     while value > 0 {
         digits[rev_len as usize] = (48 + value % 10) as i8

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -56,7 +56,7 @@ pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
     }
     if n == 0 { return "0" }
 
-    var digits: [i8; 32] = [0; 32]
+    var digits: [i8; 32] = [0 as i8; 32]
     var rev_len: i64 = 0
     var value: i64 = n
 
@@ -67,7 +67,7 @@ pub fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
         value = value / 10
     }
 
-    var bytes: [i8; 32] = [0; 32]
+    var bytes: [i8; 32] = [0 as i8; 32]
     var i2: i64 = 0
     while i2 < rev_len {
         bytes[i2 as usize] = digits[(rev_len - i2 - 1) as usize]


### PR DESCRIPTION
## Summary

Continues the chain from #572/#585/#602/#605/#616. The epistemic WMMA driver
(`kretikos_emit_epistemic_wmma.sio`) still doesn't produce a native ELF via the standard
Madaros toolchain. Investigating why led here: a **from-source rebuild of Madaros**
(`scripts/ci/build_modular_madaros.sh` — confirmed via grep that **no CI job currently
runs this script**, so this path is genuinely untested by CI) rejects
`self-hosted/gpu/ptx.sio`'s and `lower_to_ptx_wmma_lean.sio`'s `i64_to_string`/
`gpu_push_i64` helpers with:

```
error[E001]: this binding expects a different type
  expected [i8; 32]
  found [i64; 32]
```

Both declared `var digits: [i8; N] = [0; N]` — a bare-literal repeat-array initializer
with no explicit cast, relying on the `[i8; N]` type annotation to coerce the element
type. That works against the checked-in pinned Madaros binaries, but not against a
freshly self-hosted-rebuilt one — untyped integer literals apparently default to i64 in a
repeat-array literal in this build regardless of the surrounding annotation.

Fix: explicit `as i8` cast on the repeated element (`[0 as i8; N]`), matching the pattern
already used elsewhere in the same file (`ptx_push_i64`) and already proven correct there.

This bug has been latent and undetected through every prior PR in this chain (#585, #602,
#605, #616), all of which passed CI, because CI never rebuilds Madaros from source — it
only runs `souc check`/tests against the pre-built, checked-in toolchain.

## Test plan

- [x] Source-level fix mirrors an already-correct, proven pattern in the same file.
- [ ] CI on this PR's clean runner — same strategy as #616: this session's local checkout
  is under active, concurrent, unrelated automated modification (confirmed directly:
  this exact file was reverted mid-edit by another process twice while investigating),
  so CI is the authoritative verification here, not local results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)