### PR TITLE
fix(gpu): add missing setp_le/eq_s64/f64 and ld_param_f32/f64 PTX opcodes

### DIFF
--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -351,6 +351,8 @@ pub fn ptx_opcode_mul_lo_u64() -> string { "mul.lo.u64" }
 
 pub fn ptx_opcode_ld_param_u64() -> string { "ld.param.u64" }
 pub fn ptx_opcode_ld_param_u32() -> string { "ld.param.u32" }
+pub fn ptx_opcode_ld_param_f32() -> string { "ld.param.f32" }
+pub fn ptx_opcode_ld_param_f64() -> string { "ld.param.f64" }
 pub fn ptx_opcode_ld_param_u16() -> string { "ld.param.u16" }
 
 pub fn ptx_opcode_add_u64() -> string { "add.u64" }
@@ -479,6 +481,8 @@ pub fn ptx_opcode_setp_le_s32() -> string { "setp.le.s32" }
 
 pub fn ptx_opcode_setp_le_f32() -> string { "setp.le.f32" }
 pub fn ptx_opcode_setp_le_u64() -> string { "setp.le.u64" }
+pub fn ptx_opcode_setp_le_s64() -> string { "setp.le.s64" }
+pub fn ptx_opcode_setp_le_f64() -> string { "setp.le.f64" }
 
 pub fn ptx_opcode_setp_ge_u32() -> string { "setp.ge.u32" }
 
@@ -498,6 +502,8 @@ pub fn ptx_opcode_setp_eq_s32() -> string { "setp.eq.s32" }
 
 pub fn ptx_opcode_setp_eq_f32() -> string { "setp.eq.f32" }
 pub fn ptx_opcode_setp_eq_u64() -> string { "setp.eq.u64" }
+pub fn ptx_opcode_setp_eq_s64() -> string { "setp.eq.s64" }
+pub fn ptx_opcode_setp_eq_f64() -> string { "setp.eq.f64" }
 
 pub fn ptx_opcode_selp_b32() -> string { "selp.b32" }
 


### PR DESCRIPTION
## Summary

Continues #572/#585/#602/#605/#616/#617. `lower_to_ptx.sio`'s `GpuSetpLe`/`GpuSetpEq`/
`GpuLoadParam` lowering arms call `ptx_opcode_setp_le_s64`, `ptx_opcode_setp_le_f64`,
`ptx_opcode_setp_eq_s64`, `ptx_opcode_setp_eq_f64`, `ptx_opcode_ld_param_f32`, and
`ptx_opcode_ld_param_f64` — none of which existed in `ptx.sio`, despite their
u32/u64/s32/f32 siblings all being present. Pre-existing latent bug (predates this
session), invisible to `souc check`/CI because no CI job rebuilds Madaros from source (see
#617); it only surfaces during `CMV_BOOT4` self-hosted bootstrap typechecking, which
resolves every `match` arm's callee regardless of runtime reachability.

Added the 6 missing opcode functions following the exact pattern of their existing
siblings (e.g. `ptx_opcode_setp_le_u64 -> "setp.le.u64"`).

**Progress note** (not part of this diff, context for the chain): after this fix plus
#617's, a from-source Madaros rebuild gets past typecheck entirely for the first time and
into IR lowering, where it hits the already-documented heap-arena OOM
(`docs/audit/MADAROS_GPU_MODULE_COMPILE_OOM_2026-07-03.md`). Confirmed via a raised
`ulimit -v unlimited` test that this OOM is the compiler's own internal bump-allocator
arena capacity, not an OS-level ulimit — so raising ulimit doesn't help. That's new
information refining the existing audit doc; not fixed in this PR.

## Test plan

- [x] Source-level fix adds functions following an already-correct, proven pattern.
- [ ] CI on this PR's clean runner — authoritative per the same rationale as #616/#617
  (this session's local checkout is under active, concurrent, unrelated automated
  modification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)