### PR TITLE
fix(native): recognize arg_count() as get_arg_count builtin alias

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1100,6 +1100,24 @@ fn native_v2_builtin_id_for_func_ref(func: &IrFunction) -> i64 with Mut, Panic, 
 
 // M4: argv and string builtins
 fn name_is_get_arg_count(n: Name) -> bool with Mut, Panic, Div {
+    // "arg_count" = 9 chars -- the name the typechecker actually registers
+    // as the builtin; "get_arg_count" = 13 chars is an alias some codegen
+    // callers still use. Accept both so a source-level arg_count() call
+    // reaches this emitter instead of falling through to the generic
+    // user-function path (which has no IR body for a builtin and previously
+    // miscompiled into a prologue-without-epilogue crash).
+    if n.len == 9 {
+        if n.buf[0] != 97 as i8 { return false }      // 'a'
+        if n.buf[1] != 114 as i8 { return false }     // 'r'
+        if n.buf[2] != 103 as i8 { return false }     // 'g'
+        if n.buf[3] != 95 as i8 { return false }      // '_'
+        if n.buf[4] != 99 as i8 { return false }      // 'c'
+        if n.buf[5] != 111 as i8 { return false }     // 'o'
+        if n.buf[6] != 117 as i8 { return false }     // 'u'
+        if n.buf[7] != 110 as i8 { return false }     // 'n'
+        if n.buf[8] != 116 as i8 { return false }     // 't'
+        return true
+    }
     // "get_arg_count" = 13 chars
     if n.len != 13 { return false }
     if n.buf[0] != 103 as i8 { return false }     // 'g'


### PR DESCRIPTION
## Summary

Continues #572/#585/#602/#605/#616/#617/#618. `codegen_x86_linux.sio`'s `name_is_get_arg_count`
only matched the 13-char name `"get_arg_count"`, not the 9-char `"arg_count"` that Sounio
source actually calls (e.g. `kretikos_emit_epistemic_wmma.sio`) and that the typechecker
registers as the valid builtin name. Since the name check failed, the builtin dispatch in
`compile_ir_function_v2_mut` fell through to the generic user-function compilation path —
which has no IR body for a builtin — silently producing broken native code: a function
that starts with an rbp-saving prologue but has no matching epilogue, corrupting the stack
on return.

Confirmed via a core dump + gdb backtrace: the crashing frame's RIP had been overwritten
with a stack address (not a code address), consistent with `ret` popping a stray on-stack
value instead of a real return address — exactly what a missing `pop rbp` before `ret`
produces.

Fixed by accepting both `"arg_count"` (9 chars) and `"get_arg_count"` (13 chars),
mirroring the alias already present in `native_compile_driver.sio`'s separate
`V2_BUILTIN_ARG_COUNT` resolution (`name_eq_text(name, "arg_count")` /
`name_eq_text(name, "get_arg_count")`), which this file's name-matcher had drifted out of
sync with.

**Progress note**: after this plus the prior fixes in the chain, a from-source Madaros
rebuild reaches `Merged IR: 206 functions` / `Compilation successful!` for
`kretikos_emit_epistemic_wmma.sio` for the first time this session. A distinct, deeper
crash remains past this point (a null-pointer array access inside `main()`, not yet
root-caused) — not fixed here, still under investigation.

## Test plan

- [x] Verified locally with a freshly-rebuilt Madaros: this exact crash (prologue without
  epilogue, RIP overwritten with a stack address per gdb) reproduced before the fix and
  was gone after it, replaced by a different, later-stage crash.
- [ ] CI on this PR's clean runner — authoritative per the same rationale as #616/#617/#618.

🤖 Generated with [Claude Code](https://claude.com/claude-code)