### PR TITLE
fix(compiler): lean_single emits no store for *n=v through a mutable scalar reference

### DIFF
--- a/docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md
+++ b/docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md
@@ -1,0 +1,151 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04
+-->
+
+# lean_single forensic dispatch — `*n = v` for a mutable scalar reference silently emits no store
+
+Date: 2026-07-04
+Branch: `main` @ `c4d81097e`
+Class: **codegen gap** (valid code compiles clean but the write never happens at
+runtime — worse than a compile error, since nothing signals the defect)
+Status: root-caused, fixed, verified (full test suite 1311/1311, zero regressions)
+
+## Symptom
+
+A dereference-assignment through a mutable reference to a **scalar** (not a struct, not
+an array) compiles without a fatal error but writes nothing at runtime:
+
+```sio
+fn write_only(n: &!i64) with Mut { *n = 999 }
+fn main() -> i64 with IO {
+    var x: i64 = 5
+    write_only(&!x)
+    println(x)   // prints 5, not 999
+    0
+}
+```
+
+Reproduces even as a function's *first statement with no preceding call at all* —
+unrelated to and independent from issue #601's "Bug H" (PR #619), which this was
+originally found while validating. `bin/souc check` on this snippet emits only a
+**non-fatal warning**:
+
+```
+warning: dereference assignment requires raw pointer binding at <main>:2
+```
+
+## Root cause
+
+`self-hosted/compiler/lean_single.sio`'s `*PTR = expr` statement handler (two
+near-identical copies, one per backend: x86-64 and aarch64) only emits the actual store
+instruction when the left-hand variable's type is `VAR_TY == 11` (raw pointer):
+
+```sio
+if lvi >= 0 && VAR_TY[lvi as usize] == 11 && type_is_pointer_like(...) {
+    ...
+    emit_store_to_pointer_offset_x86(lslot, 0, inner_ty, inner_hash)
+} else {
+    tc_error(name_tok, "dereference assignment requires raw pointer binding")
+}
+```
+
+For `n: &!i64`, `VAR_TY[lvi]` is `10` (the "ref" type code), so execution always fell
+into the `else` branch. `tc_error` (as opposed to `tc_error_hard`) only prints a
+non-fatal warning — compilation proceeds to completion, but **no store instruction is
+ever emitted for the statement**. This is not a wrong value; the write does not exist in
+the generated code at all.
+
+This gap predates and is unrelated to issue #601/"Bug H" — bisected by testing the
+statement as a function's *only* statement with zero preceding calls, still reproduces
+identically.
+
+**Refs (`VAR_TY == 10`) and raw pointers (`VAR_TY == 11`) share the same inner-type hash
+encoding and runtime representation** — confirmed directly in the source:
+
+```sio
+fn ptr_hash_inner_ty(h: i64) -> i64 { return ref_hash_inner_ty(h) }
+fn ptr_hash_inner_hash(h: i64) -> i64 { return ref_hash_inner_hash(h) }
+```
+
+`ptr_hash_*` is a pure delegate to `ref_hash_*` — there was never a second, distinct
+encoding to support; the `emit_store_to_pointer_offset_{x86,a64}` codegen function is
+itself fully generic (handles both scalar and aggregate targets identically regardless
+of which "kind" of pointer-like value populated the variable's slot). The only missing
+piece was the `VAR_TY == 11`-only gate in the statement dispatcher.
+
+## Fix
+
+Extend the gate to also accept a *mutable* reference (`VAR_TY == 10` **and**
+`ref_hash_mut(hash) != 0`, using the codebase's existing mutability-check idiom already
+used elsewhere, e.g. `self-hosted/compiler/lean_single.sio:9711`). A **shared** reference
+(`&T`, `ref_hash_mut == 0`) must continue to be rejected — writing through a shared
+reference is a real safety violation, not just a missing feature:
+
+```sio
+let is_raw_ptr = lvar_ty == 11 && type_is_pointer_like(lvar_ty, lvar_hash)
+let is_mut_ref = lvar_ty == 10 && ref_hash_mut(lvar_hash) != 0
+if lvi >= 0 && (is_raw_ptr || is_mut_ref) {
+    ... emit_store_to_pointer_offset_x86(...) ...
+} else {
+    tc_error(name_tok, "dereference assignment requires a raw pointer or a mutable (&!T) reference binding")
+}
+```
+
+Applied to both the x86-64 and aarch64 copies of the handler. Verified the safety
+property is preserved: `*n = 999` for `n: &i64` (shared reference) still produces the
+warning and emits no store.
+
+## Confirmed real-world impact
+
+`stdlib/epistemic/ode.sio` has 4 sites using exactly this pattern
+(`compute_jacobian_state`, `compute_jacobian_params`, `bump_n_evals`,
+`propagate_variance_gum` — lines 688, 744, 834, 1012), all taking a
+`n_evals: &!i64` parameter and incrementing it via `*n_evals = *n_evals + N`. Direct
+before/after test:
+
+```sio
+use epistemic::ode::*
+fn main() -> i64 with IO {
+    var n: i64 = 0
+    bump_n_evals(&!n); bump_n_evals(&!n); bump_n_evals(&!n)
+    println(n)
+    0
+}
+```
+
+Before this fix: prints `0` (4 warnings, one per silently-no-op'd site touched
+transitively). After: prints `3`, zero warnings. This means the ODE solver's function-
+evaluation counters (`ODESolution.n_rhs_evals`, populated via `rk4_step`/`rk45_step`
+calling `bump_n_evals`) have been silently stuck since `bump_n_evals` was introduced in
+PR #599 (the issue #580 fix) — no existing test asserts on this field's value, so this
+was not caught by the regression suite. No stdlib fix needed on top of this compiler
+change; the existing `bump_n_evals` helper now works correctly as originally intended.
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1311  Fail: 0  Known failures: 127  Skip: 689  Total: 2127
+```
+
+Also confirmed: shared-reference rejection preserved; raw-pointer path unaffected;
+`ode.sio`'s `n_evals` counters now increment correctly (shown above). Madaros
+(`self-hosted/compiler/main.sio` + module frontend, a fully separate source tree) is
+untouched by this fix — not independently verified whether it shares this gap.
+
+## Cross-references
+
+- `docs/audit/LEAN_SINGLE_MULTIPLICATIVE_LINE_BOUNDARY_2026-07-04.md` — the "Bug H"
+  parser fix (PR #619) this issue was discovered while validating; independent bugs,
+  same discovery session.
+- GitHub issue #620 — tracks this finding; closed by this fix.
+- `stdlib/epistemic/ode.sio` `bump_n_evals` — the workaround from issue #580's fix
+  (PR #599) that this compiler fix makes *actually effective* rather than merely
+  "compiles without error."

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 850
-- Repo-backed topics: 700
+- Total governed topics: 851
+- Repo-backed topics: 701
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 494
+- Authority count `repo_only`: 495
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 498 topics
+- A2: 499 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -119,6 +119,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-multiplicative-line-boundary-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_MULTIPLICATIVE_LINE_BOUNDARY_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-builtin-emission-2026-06-24 | repo_only | docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2209,6 +2209,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-archive-triage-2026-06-21",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -21415,15 +21415,27 @@ fn compile_stmt() with IO, Mut, Panic, Div {
         let lslot = var_find(ns, ne)
         if lslot >= 0 {
             let lvi = var_find_idx(ns, ne)
-            if lvi >= 0 && VAR_TY[lvi as usize] == 11 && type_is_pointer_like(VAR_TY[lvi as usize], VAR_TY_HASH[lvi as usize]) {
-                let inner_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
-                let inner_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
+            // A raw pointer (VAR_TY 11) always allows the store below. A ref (VAR_TY
+            // 10) shares the identical inner-type hash encoding (ptr_hash_* delegate
+            // straight to ref_hash_*) and the identical runtime representation (an
+            // address value in the variable's slot) — it was previously excluded here
+            // entirely, so `*n = v` for `n: &!T` compiled with only a non-fatal
+            // warning and NO store instruction emitted at all (issue #620). Only a
+            // *mutable* ref (`&!T`, ref_hash_mut != 0) may be written through; a
+            // shared ref (`&T`) must still be rejected.
+            let lvar_ty = VAR_TY[lvi as usize]
+            let lvar_hash = VAR_TY_HASH[lvi as usize]
+            let is_raw_ptr = lvar_ty == 11 && type_is_pointer_like(lvar_ty, lvar_hash)
+            let is_mut_ref = lvar_ty == 10 && ref_hash_mut(lvar_hash) != 0
+            if lvi >= 0 && (is_raw_ptr || is_mut_ref) {
+                let inner_ty = ptr_hash_inner_ty(lvar_hash)
+                let inner_hash = ptr_hash_inner_hash(lvar_hash)
                 if ty_eq(inner_ty, inner_hash, rhs_ty, rhs_ty_hash) == false {
                     tc_error(EP - 1, "assignment type mismatch")
                 }
                 emit_store_to_pointer_offset_x86(lslot, 0, inner_ty, inner_hash)
             } else {
-                tc_error(name_tok, "dereference assignment requires raw pointer binding")
+                tc_error(name_tok, "dereference assignment requires a raw pointer or a mutable (&!T) reference binding")
             }
         } else {
             tc_undefined_var(name_tok)
@@ -32629,15 +32641,23 @@ fn compile_stmt_a64() with IO, Mut, Panic, Div {
         let lslot = var_find(ns, ne)
         if lslot >= 0 {
             let lvi = var_find_idx(ns, ne)
-            if lvi >= 0 && VAR_TY[lvi as usize] == 11 && type_is_pointer_like(VAR_TY[lvi as usize], VAR_TY_HASH[lvi as usize]) {
-                let inner_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
-                let inner_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
+            // See the x86 twin above (compile_deref_store_x86-equivalent) for the
+            // full rationale — issue #620: a mutable ref (VAR_TY 10, &!T) shares the
+            // raw pointer's inner-type hash encoding and runtime representation and
+            // must be allowed to store, not just VAR_TY 11 raw pointers.
+            let lvar_ty = VAR_TY[lvi as usize]
+            let lvar_hash = VAR_TY_HASH[lvi as usize]
+            let is_raw_ptr = lvar_ty == 11 && type_is_pointer_like(lvar_ty, lvar_hash)
+            let is_mut_ref = lvar_ty == 10 && ref_hash_mut(lvar_hash) != 0
+            if lvi >= 0 && (is_raw_ptr || is_mut_ref) {
+                let inner_ty = ptr_hash_inner_ty(lvar_hash)
+                let inner_hash = ptr_hash_inner_hash(lvar_hash)
                 if ty_eq(inner_ty, inner_hash, rhs_ty, rhs_ty_hash) == false {
                     tc_error(EP - 1, "assignment type mismatch")
                 }
                 emit_store_to_pointer_offset_a64(lslot, 0, inner_ty, inner_hash)
             } else {
-                tc_error(name_tok, "dereference assignment requires raw pointer binding")
+                tc_error(name_tok, "dereference assignment requires a raw pointer or a mutable (&!T) reference binding")
             }
         } else {
             tc_undefined_var(name_tok)


### PR DESCRIPTION
## Summary

Closes #620. A dereference-assignment through a mutable reference to a scalar
(`n: &!i64`, `*n = 999`) compiled without a fatal error but **silently wrote nothing at
runtime** — worse than a compile error, since nothing signalled the defect. Reproduces
even as a function's first statement with no preceding call, independent of and found
while validating issue #601's "Bug H" (PR #619).

**Root cause**: the `*PTR = expr` statement handler only emitted the store instruction
when the variable's type was `VAR_TY == 11` (raw pointer). For a mutable reference
(`VAR_TY == 10`), execution fell through to a **non-fatal** `tc_error` warning
("dereference assignment requires raw pointer binding") with no store instruction ever
emitted at all. Refs and raw pointers share the identical inner-type hash encoding
(`ptr_hash_inner_ty`/`ptr_hash_inner_hash` are pure delegates to `ref_hash_inner_ty`/
`ref_hash_inner_hash`) and the identical runtime representation — the codegen function
was already fully generic; only the type-code gate was too narrow.

**Fix**: also accept `VAR_TY == 10` when the reference is mutable
(`ref_hash_mut(hash) != 0`, the codebase's existing mutability-check idiom). A shared
reference (`&T`) must continue to be rejected — writing through a shared reference is a
safety violation, not a missing feature; verified this is preserved. Applied to both the
x86-64 and aarch64 copies of the handler.

## Confirmed real-world impact

`stdlib/epistemic/ode.sio` has 4 sites using exactly this pattern
(`compute_jacobian_state`, `compute_jacobian_params`, `bump_n_evals`,
`propagate_variance_gum`) — all were silently no-op'ing. `bump_n_evals` (added in
PR #599, the issue #580 fix) now correctly increments its counter:

```sio
use epistemic::ode::*
fn main() -> i64 with IO {
    var n: i64 = 0
    bump_n_evals(&!n); bump_n_evals(&!n); bump_n_evals(&!n)
    println(n)   // before: 0 (+4 warnings) — after: 3, zero warnings
    0
}
```

No existing test asserted on this value, so the regression was never caught by the
suite. Full root-cause writeup:
`docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md`.

## Test plan

- [x] Isolated repro from issue #620 now compiles clean and correctly writes at runtime.
- [x] Shared-reference (`&T`) deref-assignment still correctly rejected (safety check).
- [x] `ode.sio`'s `bump_n_evals` verified directly: 3 calls → `n=3` (was stuck at `0`).
- [x] Full test suite: 1311/1311 pass, 0 regressions, against a freshly rebuilt
      `lean_single`.
- [x] Does not touch Madaros (separate source tree; not independently verified whether
      it shares this gap).
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass.

Closes #620.