### PR TITLE
fix(native): resolve multi-segment qualified type paths (issue #601 Bug B)

### DIFF
--- a/docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md
+++ b/docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md
@@ -1,0 +1,161 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04
+-->
+
+# lean_single forensic dispatch — `scan_type` drops trailing `::segment`s of a qualified type path, corrupting the enclosing arity scan
+
+Date: 2026-07-04
+Branch: `main` (post-PR #624, Bug A)
+Class: **checker gap** (a qualified type name in a parameter/field annotation is
+silently truncated to its first path segment, and the unconsumed remainder is
+misread as extra parameters by whatever scan called it) — root-causes and
+closes issue #601's "Bug B"
+Status: root-caused, fixed, verified (full test suite 1311 pass / 0 fail / 127
+known failures / 689 skip — back to the pre-existing baseline, zero deltas)
+
+## Symptom
+
+A function parameter (or any type position) annotated with a `::`-qualified
+type path produces a false `arity mismatch` at every call site, even when the
+call passes the exact correct number of arguments:
+
+```sio
+// pkg/addr.sio
+module pkg::addr
+pub struct Thing { x: i64 }
+pub fn thing_new(x: i64) -> Thing { Thing { x: x } }
+
+// pkg/sub/wrapper.sio
+module pkg::sub::wrapper
+pub fn take_thing(target: &pkg::addr::Thing) -> i32 { 0 }
+
+// main.sio
+use pkg::addr::*
+use pkg::sub::wrapper::*
+fn main() -> i32 {
+    let t = thing_new(5)
+    take_thing(&t)   // error: arity mismatch
+}
+```
+
+Matches issue #601's original Bug B repro exactly. Real-world instance:
+`stdlib/database/pure/engine.sio`'s `engine_create_table(db: &!database::pure::types::InMemoryDB, name: string)`
+— every call to any function in `engine.sio` failed with "arity mismatch"
+regardless of argument count, forcing `tests/stdlib/database/test_database_core.sio`
+into a `//@ known-failure` marker as of PR #624 (the Bug A fix), since fixing
+Bug A let these calls reach arity-checking for the first time and exposed
+this independent, pre-existing defect.
+
+## Root cause
+
+`self-hosted/compiler/lean_single.sio`'s `scan_type()` (line 5094, shared by
+both the x86-64 and aarch64 backends — it does no codegen, only token
+bookkeeping) resolves a plain-identifier type name by reading exactly **one**
+token as the type name:
+
+```sio
+if TK[p as usize] == 3 {
+    let ns = TS[p as usize]
+    let ne = TE[p as usize]
+    ...  // ~300 lines of primitive-name / Option<T> / Box<T> / Knowledge<T> / struct+enum lookup
+    p = p + 1
+    if TK[p as usize] == 23 { ... }  // generic <T> args
+    ...
+}
+SCAN_TY_NEXT = p
+```
+
+For `pkg::addr::Thing`, `ns`/`ne` capture only `"pkg"`. None of the primitive
+names match; `st_find(gl_name_hash("pkg"))` and `en_find(...)` both fail
+(there is no struct or enum literally named `pkg`), so the type resolves to
+`SCAN_TY = 0` (unknown) with `SCAN_TY_HASH = hash("pkg")`. `p` advances past
+`pkg` only, and since the next token is `::` (not `<`), the generic-args
+check is skipped. `SCAN_TY_NEXT` is set to `p`, pointing at the *first* `::`
+— the rest of the path (`::addr::Thing`) is left completely unconsumed in the
+token stream.
+
+The caller that exposes this — the function-signature arity pre-pass
+(`self-hosted/compiler/lean_single.sio` ~line 26368) — advances its own
+scan cursor `q = SCAN_TY_NEXT` after each parameter's type and then resumes
+its `while TK[q] != ')'` loop looking for the next parameter. With
+`SCAN_TY_NEXT` stranded mid-path, the loop walks the leftover tokens one at a
+time: `::` is not an identifier (falls through, `q += 1`), then `addr` **is**
+an identifier — the loop's `if TK[q] == 3 { FN_ARITY += 1; ... }` branch fires,
+counting it as a *second* parameter. The same happens again for `Thing`. A
+function with one real qualified-type parameter ends up with `FN_ARITY == 3`
+(the real parameter plus two phantom ones peeled off its own type
+annotation), so every correctly-arity'd call site fails arity-checking.
+
+This is structurally the same class of defect as Bug A (PR #624) — a `::`
+chain silently truncated to its first segment, corrupting whatever comes
+after — but in type-annotation position (`scan_type`) rather than call
+position (`compile_primary`).
+
+## Fix
+
+Flatten a `::`-separated identifier chain down to its terminal segment
+*before* any of `scan_type`'s existing type-name resolution runs, exactly
+mirroring the Bug A fix's approach:
+
+```sio
+if TK[p as usize] == 3 {
+    while TK[p as usize] == 3 && TK[(p + 1) as usize] == 51 && TK[(p + 2) as usize] == 3 {
+        p = p + 2  // skip segment + ::
+    }
+    let ns = TS[p as usize]
+    let ne = TE[p as usize]
+    ...  // unchanged below — now resolves "Thing", not "pkg"
+```
+
+The loop condition requires the *next* token after the `::` to also be an
+identifier, so it only fires on a genuine qualified chain and naturally stops
+at the terminal segment (nothing follows `Thing` with another `::ident`
+pair). All of the existing struct/enum/primitive/generic resolution below
+runs unchanged on the now-correct terminal name — `st_find(hash("Thing"))`
+succeeds, `SCAN_TY`/`SCAN_TY_HASH` are set correctly, and `SCAN_TY_NEXT`
+lands past the whole qualified path rather than mid-chain. Single shared
+function; no separate aarch64 twin exists for `scan_type` (unlike
+`compile_primary`), so one edit covers both backends.
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1311  Fail: 0  Known failures: 127  Skip: 689  Total: 2127
+```
+
+Exactly the pre-existing baseline (the same numbers as before PR #624's Bug A
+fix) — zero regressions, and `tests/stdlib/database/test_database_core.sio`'s
+`//@ known-failure` marker (added in PR #624 to document this exact bug) is
+removed since it now genuinely passes.
+
+Also confirmed directly with instrumented `println` output against the real
+`stdlib/database/pure/engine.sio` API (not just "compiles without error"):
+
+```
+engine_create_table (1st)  → 1   (expected: created)
+engine_create_table (2nd)  → 0   (expected: already exists)
+engine_insert_row x2       → 1, 1
+engine_table_row_count     → 2
+engine_get_cell            → 42
+engine_drop_table          → 1
+engine_table_row_count     → -1  (expected: table gone)
+```
+
+All eight values match `test_database_core.sio`'s own hand-written
+assertions exactly.
+
+## Cross-references
+
+- `docs/audit/LEAN_SINGLE_MULTISEGMENT_QUALIFIED_CALL_2026-07-04.md` — Bug A
+  (PR #624), the call-site sibling of this fix; this dispatch's "Symptom"
+  section documents how fixing Bug A unmasked Bug B.
+- GitHub issue #601 — tracks Bug B (closed by this fix). Bugs C–G remain
+  open.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 852
-- Repo-backed topics: 702
+- Total governed topics: 853
+- Repo-backed topics: 703
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 496
+- Authority count `repo_only`: 497
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 500 topics
+- A2: 501 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -121,6 +121,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.lean-single-multiplicative-line-boundary-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_MULTIPLICATIVE_LINE_BOUNDARY_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-multisegment-qualified-call-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_MULTISEGMENT_QUALIFIED_CALL_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-builtin-emission-2026-06-24 | repo_only | docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2255,6 +2255,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-archive-triage-2026-06-21",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -5372,6 +5372,19 @@ fn scan_type(p0: i64) with IO, Mut, Panic, Div {
         return
     }
     if TK[p as usize] == 3 {
+        // Multi-segment qualified type path (pkg::mod::Type) — same rationale
+        // as the Bug A call-site fix (see compile_primary()): flatten a chain
+        // of `::`-separated segments down to its terminal identifier before
+        // any of the type-name resolution below, which only ever understands
+        // a single bare identifier. Without this, the leading module-path
+        // segments were treated as "the type name" (an unknown-type hash),
+        // and the trailing `::segment`s were left unconsumed in the token
+        // stream — which the function-signature arity scanner then misread
+        // as extra phantom parameters, producing false arity mismatches at
+        // every call site (issue #601 Bug B).
+        while TK[p as usize] == 3 && TK[(p + 1) as usize] == 51 && TK[(p + 2) as usize] == 3 {
+            p = p + 2  // skip segment + ::
+        }
         let ns = TS[p as usize]
         let ne = TE[p as usize]
         var saw_generic: i64 = 0

--- a/tests/stdlib/database/test_database_core.sio
+++ b/tests/stdlib/database/test_database_core.sio
@@ -1,5 +1,4 @@
 //@ check-only
-//@ known-failure: issue #601 Bug B (qualified-path param type + glob import causes false arity mismatch on engine_create_table) — unmasked by the Bug A fix, independent pre-existing bug
 // tests/stdlib/database/test_database_core.sio
 
 use database::pure::types::*


### PR DESCRIPTION
## Summary

Root-causes and fixes issue #601's "Bug B" — a qualified-path parameter/field type (`&pkg::mod::Type`) produced a false `arity mismatch` at every call site, regardless of argument count.

Full forensic writeup: `docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md`.

**Root cause**: `scan_type()` in `self-hosted/compiler/lean_single.sio` (a single function shared by both backends — pure token bookkeeping, no codegen) resolves a plain-identifier type name by reading exactly one token. For `pkg::mod::Type` it captured only `pkg` as "the type" (an unknown-type hash), left `::mod::Type` unconsumed, and returned `SCAN_TY_NEXT` pointing mid-path. The function-signature arity pre-pass that calls `scan_type` per parameter then walked the leftover `::segment` identifiers as if they were additional parameters — `mod` and `Type` each got counted as phantom extra parameters, inflating `FN_ARITY` for any function with a qualified-type parameter.

This is the same class of defect as Bug A (PR #624, merged earlier today) — a `::` chain truncated to its first segment — but in type-annotation position rather than call position.

**Fix**: flatten a genuine `::`-chain down to its terminal segment before any of `scan_type`'s existing resolution logic runs, mirroring the Bug A approach. All the existing struct/enum/primitive/generic-type resolution then runs unchanged on the correct terminal name.

**Byproduct**: this was exactly the bug PR #624 unmasked and marked `//@ known-failure` in `test_database_core.sio` (pending this fix). That marker is now removed — verified with instrumented output that all 8 `engine_*`/table operations return the exact values the test's own assertions expect (not just "compiles clean").

## Test plan

- [x] Full regression suite: 1311 pass / 0 fail / 127 known failures / 689 skip / 2127 total — exactly the pre-existing baseline (same numbers as before PR #624), zero regressions
- [x] Controlled repro from issue #601 (`take_thing(&t)` with a qualified-path parameter) now compiles and runs correctly, was `error: arity mismatch`
- [x] Real stdlib repro (`database::pure::engine::engine_create_table` et al.) verified via instrumented println: all 8 values match `test_database_core.sio`'s hand-written assertions exactly
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass

Closes #601.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>