### PR TITLE
fix(native): resolve named use imports (issue #601 Bug C)

### DIFF
--- a/docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md
+++ b/docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md
@@ -1,0 +1,157 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-named-use-import-2026-07-05
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-named-use-import-2026-07-05
+-->
+
+# lean_single forensic dispatch — a named (non-glob) `use` import treats the imported symbol as a path segment
+
+Date: 2026-07-05
+Branch: `main` (post-PR #625, Bug B)
+Class: **module-loader gap** (a syntactically valid, commonly-used `use` form
+was resolved against the wrong filesystem path and failed to load at all) —
+root-causes and closes issue #601's "Bug C"
+Status: root-caused, fixed, verified (full test suite 1314 pass / 0 fail / 124
+known failures / 689 skip — 3 net additional genuine passes, 0 regressions)
+
+## Symptom
+
+`use package::file::specific_symbol` (no trailing `::*`, no `::{...}`) fails
+to load the target file at all, reporting the *symbol* name as if it were an
+additional directory/file segment:
+
+```sio
+// stdlib/pkg/thing.sio
+module pkg::thing
+pub fn item() -> i64 { 1 }
+
+// main.sio
+use pkg::thing::item
+fn main() -> i64 { item() }
+// error: unreadable import: stdlib/pkg/thing/item.sio
+```
+
+The glob form (`use pkg::thing::*`) loads the same file correctly. Matches
+issue #601's original Bug C repro exactly. Real-world impact: three tracked,
+value-checked (`//@ expect-stdout: ALL PASS`) acceptance tests for the
+octonion/uncertainty-propagation stdlib were carried as known failures purely
+because of this — `tests/run-pass/uncertain_octonion_auto.sio`,
+`tests/run-pass/propagate_nonassoc_variance.sio`, and
+`tests/run-pass/perturbation_graph_order_safe.sio`, all of which import via
+`use algebra::octonion::oct_basis` or similar named forms.
+
+## Root cause
+
+`self-hosted/compiler/lean_single.sio`'s `resolve_imports()` extracts a `use`
+statement's module path with a single scan (originally at line 34744) that
+recognises exactly two path-terminating markers:
+
+```sio
+while pos < SRC_LEN && sb(pos) != 10 && sb(pos) != 59 && sb(pos) != 13 {
+    if sb(pos) == 58 && pos + 1 < SRC_LEN && sb(pos+1) == 58 {
+        if pos + 2 < SRC_LEN && sb(pos+2) == 42 { /* ::* */ path_end = pos; break }
+        if pos + 2 < SRC_LEN && sb(pos+2) == 123 { /* ::{ */ path_end = pos; break }
+    }
+    pos = pos + 1
+    path_end = pos
+}
+```
+
+`::*` and `::{...}` are unambiguous: everything before them is the file path,
+everything from the marker onward is glob/brace syntax, not more path. A
+**bare named import has no such marker** — `use pkg::thing::item` is
+token-for-token indistinguishable from a (legitimate, and already-working)
+whole-file import like `use database::pure::types` where every segment really
+is a directory/file component. The scan has no way to know, from the tokens
+alone, whether the *last* segment is "the file" or "a specific symbol
+exported by the second-to-last segment's file" — so it always treated it as
+the former, converting every `::` (including the one before the actual
+symbol) into a `/` and appending `.sio`, producing `pkg/thing/item.sio` —
+a path that never exists.
+
+There was no fallback that ever tried the *other* interpretation (drop the
+last segment, treat it as a symbol name, load the parent as the file) — every
+existing fallback in this function (`mod.sio`, `lib.sio`,
+`packages/<pkg>/src/`, `stdlib/`-prefix, `self-hosted/`-prefix) only varies
+*where* the fully-joined path is rooted, never *how many trailing segments*
+belong to the file path.
+
+## Fix
+
+The two are genuinely ambiguous from syntax alone (this is not decidable
+without a filesystem probe — real code uses both `use pkg::mod::file` and
+`use pkg::mod::file::symbol` identically shaped otherwise), so the fix adds a
+**last-resort fallback**, tried only after every existing whole-path attempt
+has failed and only for a bare (non-glob, non-brace) import — tracked via a
+new `is_named_import` flag set during path extraction: strip the last
+`/`-segment of the already-`.sio`-suffixed raw path and retry across the same
+path roots (`BASE_DIR`-relative, `stdlib/`-prefixed, `self-hosted/`-prefixed,
+and the raw path itself) the primary attempts already tried:
+
+```sio
+if copy_len <= 0 && is_named_import == 1 {
+    // find the last '/' before ".sio" in the raw joined path
+    // if found, truncate there + re-append ".sio", retry read_file()
+    // across BASE_DIR/, stdlib/, self-hosted/, and the bare raw path
+}
+```
+
+Because this only activates when the naive full-path read has *already
+failed*, the existing `use pkg::mod::file` (bare whole-file, no trailing
+symbol) idiom is completely unaffected — it keeps succeeding on the first,
+unshortened attempt, exactly as before. Verified directly: `use
+database::pure::types` (no glob, no symbol — the same shape a resolver-only
+fix could have broken) still loads `database/pure/types.sio` on the first
+attempt, not the shortened fallback.
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1314  Fail: 0  Known failures: 124  Skip: 689  Total: 2127
+```
+
+Baseline was 1311 pass / 0 fail / 127 known failures / 689 skip — net +3 pass,
+-3 known failures, 0 regressions. The three newly-passing tests
+(`uncertain_octonion_auto.sio`, `propagate_nonassoc_variance.sio`,
+`perturbation_graph_order_safe.sio`) are removed from
+`tests/known_failures/hardened_diagnostics_full_suite.txt`; all three are
+`//@ run-pass` + `//@ expect-stdout: ALL PASS` tests (exact-stdout-match, not
+merely "compiles"), so this is a genuine correctness fix, not a masked
+compile-clean regression.
+
+Also confirmed directly:
+- The exact issue #601 repro (`use pkg::thing::item; item()`) now loads
+  correctly and returns `1` as defined.
+- The glob form (`use pkg::thing::*`) is unaffected (still works).
+- The bare whole-file-import idiom (`use database::pure::types`, no trailing
+  symbol) is unaffected — succeeds on the unshortened first attempt.
+
+## Known follow-up not fixed here
+
+Issue #601's Bug C entry also notes a **module-alias variant**
+(`use pkg::mod as alias;` then `alias::fn()`) "behaves the same way." That
+form hits a different code path in the same extraction loop — the ` as
+alias` suffix is not a `::`-segment at all; spaces are silently dropped
+during path construction (`c == 32` is skipped, not treated as a
+terminator), so `use pkg::mod as alias` currently builds the garbled path
+`pkg/modasalias.sio` rather than `pkg/mod/alias.sio`. This is a related but
+mechanically distinct defect (space-handling in path construction, not
+`::`-segment ambiguity) and is not addressed by this fix. Left for a
+dedicated follow-up.
+
+## Cross-references
+
+- `docs/audit/LEAN_SINGLE_MULTISEGMENT_QUALIFIED_CALL_2026-07-04.md` — Bug A
+  (PR #624), the call-site sibling: a different `::`-ambiguity, in call
+  position rather than the `use` statement's own path.
+- `docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md` — Bug B
+  (PR #625), the type-annotation sibling.
+- GitHub issue #601 — tracks Bug C (closed by this fix). Bugs D–G remain
+  open; the `use ... as alias` variant noted above is a newly-identified,
+  not-yet-tracked follow-up.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 853
-- Repo-backed topics: 703
+- Total governed topics: 854
+- Repo-backed topics: 704
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 497
+- Authority count `repo_only`: 498
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 501 topics
+- A2: 502 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -120,6 +120,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-multiplicative-line-boundary-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_MULTIPLICATIVE_LINE_BOUNDARY_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-multisegment-qualified-call-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_MULTISEGMENT_QUALIFIED_CALL_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-named-use-import-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2232,6 +2232,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-named-use-import-2026-07-05",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04",
       "collection": "repo",
       "repo_doc_path": "docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -34743,11 +34743,20 @@ fn resolve_imports() with IO, Mut, Panic, Div {
             // Extract module path until newline, semicolon, or ::*
             var path_start: i64 = pos
             var path_end: i64 = pos
+            // Bug C: a glob (`::*`) or braced (`::{...}`) import unambiguously
+            // marks where the file path ends. A bare named import
+            // (`use pkg::mod::symbol`) has no such marker — `symbol` is
+            // syntactically indistinguishable from another path segment here.
+            // Track that ambiguity so the fallback below (after the naive
+            // whole-path read fails) can retry with the last segment treated
+            // as an imported symbol name rather than part of the file path.
+            var is_named_import: i64 = 1
             while pos < SRC_LEN && sb(pos) != 10 && sb(pos) != 59 && sb(pos) != 13 {
                 if sb(pos) == 58 && pos + 1 < SRC_LEN && sb(pos+1) == 58 {
                     if pos + 2 < SRC_LEN && sb(pos+2) == 42 {
                         path_end = pos
                         pos = pos + 3  // skip ::*
+                        is_named_import = 0
                         break
                     }
                     if pos + 2 < SRC_LEN && sb(pos+2) == 123 {
@@ -34755,6 +34764,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                         // Skip ::{...} until }
                         while pos < SRC_LEN && sb(pos) != 125 && sb(pos) != 10 { pos = pos + 1 }
                         if pos < SRC_LEN && sb(pos) == 125 { pos = pos + 1 }
+                        is_named_import = 0
                         break
                     }
                 }
@@ -35131,6 +35141,75 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                             fp_len = mfp
                             IMP_PATH[fp_len as usize] = 0
                         }
+                    }
+                }
+            }
+            // Bug C fallback: every attempt above treated the whole `use`
+            // path as a file path. For a bare named import with no glob/brace
+            // marker, the last segment may instead be the specific symbol
+            // being imported (e.g. `use pkg::mod::item` means "load
+            // pkg/mod.sio, bring `item` into scope", not "load
+            // pkg/mod/item.sio") — retry once with that last `/`-segment
+            // dropped, across the same path roots the primary attempts used.
+            if copy_len <= 0 && is_named_import == 1 {
+                var bc_strip: i64 = raw_len - 4  // drop ".sio"
+                var bc_slash: i64 = -1
+                var bc_si: i64 = bc_strip - 1
+                while bc_si >= 0 {
+                    if IMP_RAW_PATH[bc_si as usize] == 47 { bc_slash = bc_si; bc_si = -1 } else { bc_si = bc_si - 1 }
+                }
+                if bc_slash > 0 {
+                    var bc_len: i64 = bc_slash
+                    IMP_RAW_PATH[bc_len as usize] = 46; bc_len = bc_len + 1   // .
+                    IMP_RAW_PATH[bc_len as usize] = 115; bc_len = bc_len + 1  // s
+                    IMP_RAW_PATH[bc_len as usize] = 105; bc_len = bc_len + 1  // i
+                    IMP_RAW_PATH[bc_len as usize] = 111; bc_len = bc_len + 1  // o
+                    IMP_RAW_PATH[bc_len as usize] = 0
+                    if needs_base_dir == 1 && BASE_DIR_LEN > 0 {
+                        var bc_bj: i64 = 0
+                        while bc_bj < BASE_DIR_LEN { IMP_PATH[bc_bj as usize] = BASE_DIR[bc_bj as usize]; bc_bj = bc_bj + 1 }
+                        IMP_PATH[BASE_DIR_LEN as usize] = 47
+                        var bc_rj: i64 = 0
+                        while bc_rj < bc_len { IMP_PATH[(BASE_DIR_LEN + 1 + bc_rj) as usize] = IMP_RAW_PATH[bc_rj as usize]; bc_rj = bc_rj + 1 }
+                        fp_len = BASE_DIR_LEN + 1 + bc_len
+                        IMP_PATH[fp_len as usize] = 0
+                        raw = read_file(IMP_PATH)
+                        copy_len = str_len(raw)
+                        fsz = file_size(IMP_PATH)
+                    }
+                    if copy_len <= 0 {
+                        IMP_PATH[0 as usize] = 115; IMP_PATH[1 as usize] = 116; IMP_PATH[2 as usize] = 100
+                        IMP_PATH[3 as usize] = 108; IMP_PATH[4 as usize] = 105; IMP_PATH[5 as usize] = 98
+                        IMP_PATH[6 as usize] = 47
+                        var bc_rj2: i64 = 0
+                        while bc_rj2 < bc_len { IMP_PATH[(7 + bc_rj2) as usize] = IMP_RAW_PATH[bc_rj2 as usize]; bc_rj2 = bc_rj2 + 1 }
+                        fp_len = 7 + bc_len
+                        IMP_PATH[fp_len as usize] = 0
+                        raw = read_file(IMP_PATH)
+                        copy_len = str_len(raw)
+                        fsz = file_size(IMP_PATH)
+                    }
+                    if copy_len <= 0 {
+                        IMP_PATH[0 as usize] = 115; IMP_PATH[1 as usize] = 101; IMP_PATH[2 as usize] = 108
+                        IMP_PATH[3 as usize] = 102; IMP_PATH[4 as usize] = 45; IMP_PATH[5 as usize] = 104
+                        IMP_PATH[6 as usize] = 111; IMP_PATH[7 as usize] = 115; IMP_PATH[8 as usize] = 116
+                        IMP_PATH[9 as usize] = 101; IMP_PATH[10 as usize] = 100; IMP_PATH[11 as usize] = 47
+                        var bc_rj3: i64 = 0
+                        while bc_rj3 < bc_len { IMP_PATH[(12 + bc_rj3) as usize] = IMP_RAW_PATH[bc_rj3 as usize]; bc_rj3 = bc_rj3 + 1 }
+                        fp_len = 12 + bc_len
+                        IMP_PATH[fp_len as usize] = 0
+                        raw = read_file(IMP_PATH)
+                        copy_len = str_len(raw)
+                        fsz = file_size(IMP_PATH)
+                    }
+                    if copy_len <= 0 {
+                        var bc_rj4: i64 = 0
+                        while bc_rj4 < bc_len { IMP_PATH[bc_rj4 as usize] = IMP_RAW_PATH[bc_rj4 as usize]; bc_rj4 = bc_rj4 + 1 }
+                        fp_len = bc_len
+                        IMP_PATH[fp_len as usize] = 0
+                        raw = read_file(IMP_PATH)
+                        copy_len = str_len(raw)
+                        fsz = file_size(IMP_PATH)
                     }
                 }
             }

--- a/tests/known_failures/hardened_diagnostics_full_suite.txt
+++ b/tests/known_failures/hardened_diagnostics_full_suite.txt
@@ -38,8 +38,6 @@ tests/run-pass/pbpk28_deriv_zero.sio
 tests/run-pass/pbpk28_extract_only.sio
 tests/run-pass/pbpk28_m5_gum_4th_order.sio
 tests/run-pass/pbpk28_struct_return.sio
-tests/run-pass/perturbation_graph_order_safe.sio
-tests/run-pass/propagate_nonassoc_variance.sio
 tests/run-pass/rapamycin_iso_budget.sio
 tests/run-pass/rapamycin_rk4_budget.sio
 tests/run-pass/sample_uniform_native.sio
@@ -50,7 +48,6 @@ tests/run-pass/sample_uniform_native.sio
 # binary (af4db4e6): g2==g3 md5=80c5d14210c552b46ba3d03b1b496a61. a64 Seq out of scope.
 tests/run-pass/spearman_holm_bca.sio
 tests/run-pass/str_index_of.sio
-tests/run-pass/uncertain_octonion_auto.sio
 tests/stdlib/autodiff/test_dual_e2e.sio
 tests/stdlib/bayes/test_mcmc_e2e.sio
 tests/stdlib/bayes/test_prior_e2e.sio


### PR DESCRIPTION
## Summary

Root-causes and fixes issue #601's "Bug C" — `use package::file::specific_symbol` (a named, non-glob import) failed to load at all, misresolving the imported symbol as an additional path segment.

Full forensic writeup: `docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md`.

**Root cause**: `resolve_imports()` converts every `::` in a `use` path to `/` unconditionally when building the file path. The glob (`::*`) and brace (`::{...}`) forms have unambiguous terminator markers telling the scanner where the file path ends. A bare named import (`use pkg::mod::symbol`) has no such marker — it's token-for-token identical to a legitimate whole-file import (`use pkg::mod::file`), so the last segment was always folded into the path, producing `pkg/mod/symbol.sio` (which never exists) instead of loading `pkg/mod.sio`.

**Fix**: since the two forms are genuinely ambiguous from syntax alone (both shapes are real, existing idioms in the codebase), add a last-resort fallback — tried only after every existing path-root attempt (`BASE_DIR`-relative, `stdlib/`, `self-hosted/`, raw) has already failed, and only for a non-glob/non-brace import: strip the last segment and retry across the same roots. The unshortened whole-file idiom (`use pkg::mod::file`) keeps succeeding on its first, unshortened attempt — completely unaffected.

**Real-world impact**: 3 stdlib acceptance tests for octonion/uncertainty-propagation (`tests/run-pass/uncertain_octonion_auto.sio`, `propagate_nonassoc_variance.sio`, `perturbation_graph_order_safe.sio`) were carried as known failures purely because of this bug — all import via `use algebra::octonion::oct_basis` or similar. All three are `//@ expect-stdout: ALL PASS` (exact-match, not merely "compiles") and now genuinely pass; removed from `tests/known_failures/hardened_diagnostics_full_suite.txt`.

**Known follow-up, not fixed here**: issue #601 also mentions a module-alias variant (`use pkg::mod as alias;`) "behaving the same way" — investigation shows this is a mechanically distinct defect (space-handling in path construction, not `::`-segment ambiguity) and is left for a dedicated follow-up.

## Test plan

- [x] Full regression suite: 1314 pass / 0 fail / 124 known failures / 689 skip / 2127 total (baseline 1311/0/127/689 — net +3 genuine pass, -3 known-failure, 0 regressions)
- [x] Exact issue #601 repro (`use pkg::thing::item; item()`) now loads and returns the correct value
- [x] Regression check: glob form (`use pkg::thing::*`) unaffected
- [x] Regression check: bare whole-file import idiom (`use database::pure::types`, no trailing symbol) unaffected — succeeds on first unshortened attempt
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass

Closes #601.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>