### PR TITLE
fix(native): use pkg::mod as alias + single-:: call resolution (#632)

### DIFF
--- a/docs/audit/LEAN_SINGLE_USE_AS_ALIAS_2026-07-05.md
+++ b/docs/audit/LEAN_SINGLE_USE_AS_ALIAS_2026-07-05.md
@@ -1,0 +1,176 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-use-as-alias-2026-07-05
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-use-as-alias-2026-07-05
+-->
+
+# lean_single forensic dispatch — `use pkg::mod as alias` + single-`::` call resolution
+
+Date: 2026-07-05
+Branch: `main` (post-PR #630, Bug G — closing issue #601's full A–H campaign)
+Class: **two independent defects, fixed together because the feature only
+works end-to-end with both fixed** — closes issues #632 and #633's sibling
+(#633 is unrelated, see that issue) — specifically closes **#632**
+Status: root-caused, fixed, verified (full test suite 1314 pass / 0 fail /
+124 known failures / 689 skip / 2127 total — exact match to the current
+baseline, zero regressions)
+
+## Summary
+
+Issue #632 as filed described one defect: `use pkg::mod as alias` silently
+drops spaces during import-path construction, building a garbled filesystem
+path (`pkg/modasalias.sio`) that never exists, so the module never loads.
+That defect is real and is fixed here. But investigation found that fixing
+it alone does not make the feature work: a second, independent, and more
+severe gap exists in how the compiler resolves the resulting `alias::fn()`
+call. This was surfaced to the user before any fix was written (see
+"Design decision" below) and the user chose to fix both together, since
+there is no partial fix that delivers working behavior on its own.
+
+## Defect 1: import-path construction swallows spaces (issue #632 as filed)
+
+`self-hosted/compiler/lean_single.sio`'s `resolve_imports()` builds a `use`
+statement's target filesystem path by scanning bytes until a newline,
+`;`, or `::*`/`::{` marker — nothing else was treated as a path terminator.
+The path-*building* loop right after it explicitly **skipped** spaces
+(`c == 32`) rather than stopping at them, on the assumption a module path
+never contains one. `use pkg::mod as alias` has no `::*`/`::{` marker before
+end-of-line, so the whole line `pkg::mod as alias` was scanned as one path,
+producing `pkg/modasalias.sio` (spaces dropped, `::`→`/`) — a file that
+never exists.
+
+**Fix**: the path-extraction loop now recognizes a literal `" as "` byte
+sequence as an unambiguous path terminator (a module path never legitimately
+contains a space — confirmed by census, see below) and stops there,
+disabling the unrelated Bug C segment-stripping fallback for this case since
+`as`-aliasing always names a whole module, never "the last segment is
+actually an exported symbol." `use pkg::mod as alias` now correctly resolves
+`pkg/mod.sio`.
+
+## Defect 2 (discovered, not originally filed): single-`::` calls never resolve a plain function
+
+Fixing defect 1 alone was not sufficient: `alias::item()` still silently
+returned `0` afterward, with no error. Investigation found this reproduces
+identically for **any** single-`::` call to a plain (non-enum, non-struct)
+module — not alias-specific at all:
+
+```sio
+use pkg::mod            // no alias, bare whole-file import
+fn main() -> i64 { mod::item() }   // returns 0, not item()'s real value
+```
+
+`compile_primary()`'s qualified-call handling has two distinct mechanisms:
+- **2+ `::` chains** (`pkg::sub::fn()`) are flattened to their terminal
+  segment and resolved via an ordinary bare `fn_find()` (the fix for issue
+  #601's Bug A) — Sounio's function namespace is flat, so a multi-segment
+  prefix is purely decorative.
+- **A single `::`** (`X::fn()`) never went through that flatten step. It was
+  always treated as either an `Enum::Variant` reference or a `Type::method()`
+  static method call, keyed by hashing `X` as a type/enum name. When `X`
+  doesn't match any real enum or struct — which is exactly what a module
+  alias is — the code silently emitted a stub `0` and returned, with no
+  fallback to the same "decorative prefix, resolve the bare name" rule the
+  2+-`::` case already uses. There is, and never was, a dedicated
+  module-alias table anywhere in the compiler.
+
+**Design decision** (put to the user before writing this fix, since it
+changes what every single-`::` expression means for an unrecognized prefix):
+should `X::fn()` fall through to a bare `fn_find()` on `fn`, exactly like the
+2+-`::` case, when `X` isn't a real enum/struct? **Approved.** This needed a
+decision rather than a unilateral fix because it is a language-semantics
+change to an existing, exercised code path (every enum-variant and
+static-method call in the language goes through this same function), not a
+narrowly-scoped bug fix.
+
+**Census before fixing** (per the same discipline as issue #601's Bug A —
+verify-before-fixing, not synthetic repros in isolation): `grep -rn "use .*
+as " stdlib/ examples/ tests/ self-hosted/` found exactly **one** real
+`use ... as` usage in the entire codebase —
+`stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio:40:
+use chemistry::ontology as pbpk_chemistry_ontology;`, consumed as
+`pbpk_chemistry_ontology::rapamycin_chebi()` and
+`pbpk_chemistry_ontology::cyp3a4_metabolism_iri()` — both **function calls**,
+the exact shape this fix addresses. That file does not currently compile at
+all (fails on defect 1 first), so nothing today depends on the pre-fix
+behavior of either defect.
+
+**Fix** (`compile_primary()`, x86-64): when the single-`::` static-method
+lookup (`fn_find_method`) fails to find a match, instead of draining the
+call's `()` and stubbing a `0`, treat the prefix as decorative: reassign
+`ns`/`ne` to the already-consumed terminal segment (`EP` is already
+correctly positioned at the call's `(`) and let control fall through to the
+ordinary bare-call resolution code that already exists just below (the same
+code the 2+-`::` flatten path already relies on). A new `mcall_fallthrough`
+flag guards the enclosing block's original "not a method call" stub so it
+still fires, unchanged, for the non-call shape (`X::something` with no `(`
+following) and for the genuine 2+-`::` case (unaffected, already handled
+earlier). The `Type::method()` and `Enum::Variant` success paths are
+untouched.
+
+**aarch64 twin** (`compile_primary_a64()`): a smaller, analogous change.
+Unlike x86, a64's single-`::` handling never had a `Type::method()` branch
+at all — it unconditionally treated any single `::` as an `Enum::Variant`
+lookup, stubbing `0` on a miss regardless of whether a call followed. Added
+the same "if a call follows and it isn't a real enum variant, fall through
+to bare resolution" branch. a64 static-method calls remain entirely
+unsupported — a separate, larger, pre-existing gap not addressed here (this
+only adds the "unrecognized single-`::` prefix in call position resolves
+like the 2+-`::` case" behavior, for parity with x86 on this specific
+shape).
+
+## Incidental effect: a previously-silent bug now surfaces as a compile error
+
+`Point::totally_fake_method()` for a real struct `Point` with no such
+method — previously **silently compiled to a stub returning `0`, with no
+diagnostic at all**. After this fix, the fallthrough reaches ordinary
+bare-call resolution, which fails to find `totally_fake_method` and reports
+a compile error (`error: unknown identifier` — the exact wording references
+the outer name-token span, which reads a little oddly for this repurposed
+path, but the failure is now loud rather than silent). This is a strict
+correctness improvement — a typo'd static method call is no longer a silent
+zero-stub — confirmed not to regress any currently-passing test.
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1314  Fail: 0  Known failures: 124  Skip: 689  Total: 2127
+```
+
+Exact match to the current baseline — zero regressions.
+
+Directly confirmed by runtime value:
+- Issue #632's exact repro (`use pkg::mod as alias; alias::item()`): compiles
+  and returns the real value (was a hard "unreadable import" error).
+- `mod::item()` (single-`::`, no alias, real module): returns the real value
+  (was `0`).
+- `totallybogus::item()` (garbage prefix, real function, no alias at all):
+  now also correctly resolves to the real value — confirming the fallthrough
+  is general, not alias-specific.
+- Real enum-variant matching (`Color::Green` in a `match`) and real
+  static-method calls (`Point::origin()`): unaffected, unchanged codegen
+  path.
+- `stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio`: the
+  `use chemistry::ontology as pbpk_chemistry_ontology;` import and both
+  `pbpk_chemistry_ontology::...()` calls (lines 117–118) no longer error.
+  The file still fails to compile end-to-end due to unrelated,
+  pre-existing defects at lines 315/334 (arity mismatch, type mismatch) —
+  out of scope for this dispatch, not touched.
+
+## Cross-references
+
+- GitHub issue #632 — closed by this fix.
+- `docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md` — Bug C (PR #626),
+  where the `use ... as alias` variant was originally noted as a follow-up
+  and where `is_named_import`'s segment-stripping fallback (left disabled
+  for the `as`-aliased case here) was introduced.
+- `docs/audit/LEAN_SINGLE_MULTISEGMENT_QUALIFIED_CALL_2026-07-04.md` — Bug A
+  (PR #624), the 2+-`::` flatten-to-terminal-segment fix this dispatch
+  extends the same rationale to for the single-`::` case.
+- GitHub issue #633 — the other untracked gap from the same investigation
+  batch (`println(&str)`), unrelated to this fix, not addressed here.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 858
-- Repo-backed topics: 708
+- Total governed topics: 859
+- Repo-backed topics: 709
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 502
+- Authority count `repo_only`: 503
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 506 topics
+- A2: 507 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -127,6 +127,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.lean-single-nary-tuple-middle-element-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_NARY_TUPLE_MIDDLE_ELEMENT_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-use-as-alias-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_USE_AS_ALIAS_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-archive-triage-2026-06-21 | repo_only | docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-boxnew-sigsegv-2026-06-19 | repo_only | docs/audit/MADAROS_BOXNEW_SIGSEGV_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-builtin-emission-2026-06-24 | repo_only | docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2393,6 +2393,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-use-as-alias-2026-07-05",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_USE_AS_ALIAS_2026-07-05.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.madaros-archive-triage-2026-06-21",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_ARCHIVE_TRIAGE_2026-06-21.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -11138,6 +11138,7 @@ fn compile_primary() with IO, Mut, Panic, Div {
             }
             // Check if this looks like a static method call: Type::method()
             let looks_like_method_call = TK[(EP + 2) as usize] == 6
+            var mcall_fallthrough: i64 = 0
             if disc >= 0 {
                 // It's an enum variant
                 EP = EP + 1  // skip ::
@@ -11208,24 +11209,29 @@ fn compile_primary() with IO, Mut, Panic, Div {
                     if EXPR_TY == 2 { EXPR_IS_F64 = 1 } else { EXPR_IS_F64 = 0 }
                     return
                 }
-                // Method not found — drain () to prevent EP stranding at (
-                EP = EP + 1  // skip (
-                var drain_d: i64 = 1
-                while EP < TC && drain_d > 0 {
-                    if TK[EP as usize] == 6 { drain_d = drain_d + 1 }
-                    if TK[EP as usize] == 7 { drain_d = drain_d - 1 }
-                    EP = EP + 1
-                }
+                // Method not found: this single-`::` prefix isn't a real
+                // struct/enum with a matching method — before assuming it's a
+                // broken static-method-call and stubbing 0, treat the prefix as
+                // a decorative module qualifier (exactly like the 2+-`::`
+                // flatten above already does) and fall through to ordinary
+                // bare-name call resolution. EP is already positioned at `(`
+                // (right after consuming `::method_name`), matching what the
+                // bare-call path below expects. Real motivating case: `use
+                // pkg::mod as alias; alias::fn()` (issue #632) — module
+                // aliasing has no dedicated alias table, so any unrecognized
+                // single-`::` prefix in call position falls through instead.
+                ns = method_ns
+                ne = method_ne
+                mcall_fallthrough = 1
+            }
+            if mcall_fallthrough == 0 {
+                // disc < 0, not a method call — unregistered enum variant: consume :: + name to prevent cascade
+                EP = EP + 1  // skip ::
+                EP = EP + 1  // skip variant name
                 em(0x48); em(0xb8); em64(0)
                 EXPR_IS_F64 = 0; EXPR_TY = 0; EXPR_TY_HASH = 0
                 return
             }
-            // disc < 0, not a method call — unregistered enum variant: consume :: + name to prevent cascade
-            EP = EP + 1  // skip ::
-            EP = EP + 1  // skip variant name
-            em(0x48); em(0xb8); em64(0)
-            EXPR_IS_F64 = 0; EXPR_TY = 0; EXPR_TY_HASH = 0
-            return
         }
         // Generic call/struct: IDENT < TYPE > ( or IDENT < TYPE > {
         if TK[EP as usize] == 23 && EP + 2 < TC && TK[(EP + 1) as usize] == 3 && TK[(EP + 2) as usize] == 24 {
@@ -30189,7 +30195,13 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
             ne = TE[EP as usize]
             EP = EP + 1  // skip terminal segment name
         }
-        // Enum::Variant
+        // Enum::Variant (or, when it isn't a real enum and a call follows, a
+        // decorative single-`::` prefix in call position — see the x86-64
+        // twin, compile_primary(), for the full rationale/issue #632. a64 has
+        // no static-method-call support to fall back from in the first place
+        // (a separate, larger, pre-existing a64 gap, not addressed here) —
+        // this only adds the "unrecognized prefix falls through to a bare
+        // call" behavior, mirroring x86's outcome for the same source shape.)
         if TK[EP as usize] == 51 {
             EP = EP + 1
             let vns = TS[EP as usize]
@@ -30198,10 +30210,18 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
             let eh = gl_name_hash(ns, ne)
             let vh = gl_name_hash(vns, vne)
             let disc = en_variant_value(eh, vh)
-            if disc >= 0 { emit_imm64_a64(disc) }
-            else { em32(0xD2800000) }
-            EXPR_IS_F64 = 0
-            return
+            if disc >= 0 {
+                emit_imm64_a64(disc)
+                EXPR_IS_F64 = 0
+                return
+            }
+            if TK[EP as usize] != 6 {
+                em32(0xD2800000)
+                EXPR_IS_F64 = 0
+                return
+            }
+            ns = vns
+            ne = vne
         }
         // Generic resolution
         if TK[EP as usize] == 23 && EP + 2 < TC && TK[(EP + 1) as usize] == 3 && TK[(EP + 2) as usize] == 24 {
@@ -34924,6 +34944,28 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                         is_named_import = 0
                         break
                     }
+                }
+                // `use pkg::mod as alias` — " as " unambiguously ends the module
+                // path (no path segment is ever spelled with embedded spaces in
+                // this codebase; census: zero `use X :: Y` / `use X:: Y` spaced
+                // occurrences). The path-building loop below used to silently
+                // DROP every space instead of treating it as a terminator, so
+                // this built the garbled path `pkg/modasalias.sio` (issue #632).
+                // The alias name itself needs no separate table: the module's
+                // symbols are still resolved by bare name once the file loads
+                // correctly, and a single-`::` call through the alias falls
+                // through to that bare lookup (see the call-site companion fix).
+                if sb(pos) == 32 && pos + 3 < SRC_LEN && sb(pos+1) == 97 && sb(pos+2) == 115 && sb(pos+3) == 32 {
+                    path_end = pos
+                    // Unambiguous: `as alias` always names the whole preceding
+                    // path as a module/file, never "the last segment is really
+                    // an exported symbol" (that ambiguity, is_named_import's
+                    // reason for existing, only applies to a bare trailing
+                    // segment with no `as` at all). Disable the Bug C
+                    // segment-stripping fallback so a genuine load failure here
+                    // reports its real path instead of a further-stripped one.
+                    is_named_import = 0
+                    break
                 }
                 pos = pos + 1
                 path_end = pos


### PR DESCRIPTION
## Summary

Picked up issue #632 (`use pkg::mod as alias` silently drops spaces, building a garbled import path). Fixing that alone doesn't make the feature work — a second, independent gap meant `alias::item()` still silently returned `0` afterward, with no error. Fixed both together, since there's no partial fix that delivers working behavior.

**Defect 1 (issue #632 as filed)**: `resolve_imports()`'s path-extraction loop had no notion of a space as a terminator — the path-building loop right after it just silently *dropped* spaces instead. `use pkg::mod as alias` (no `::*`/`::{` marker before end-of-line) got scanned as one path, producing the garbled, nonexistent `pkg/modasalias.sio`. Fix: recognize a literal `" as "` byte sequence as an unambiguous path terminator (module paths never legitimately contain a space).

**Defect 2 (discovered, not originally filed)**: even with the path fixed and the file loading correctly, `alias::item()` still returned `0`. Reproduces for **any** single-`::` call to a plain module, not just aliases (`mod::item()` after a bare `use pkg::mod`, no alias at all — also returns `0`). Single-`::` calls (`X::fn()`) were only ever resolved as `Enum::Variant` or `Type::method()` static calls; when `X` isn't a real enum/struct, there's no fallback to the "decorative prefix, resolve the bare name" rule the 2+-`::` case already has (from issue #601's Bug A). No alias table exists anywhere in the compiler.

**This needed a design decision, not a unilateral fix** — extending that fallback changes what every single-`::` expression means for an unrecognized prefix, a language-semantics call for the language's author. Before writing any code I censused real usage (`grep -rn "use .* as "` across the whole repo) — found exactly one real occurrence, function-call-shaped (`stdlib/darwin_pbpk/validation/pbpk28_rapamycin_clinical.sio`, currently non-compiling for unrelated reasons too), confirming both fixes are needed together. Put the choice to the user via AskUserQuestion; **approved**: fall through to `fn_find()` on the terminal segment when the static-method lookup misses, mirroring Bug A's existing flatten. Same fallback added to the aarch64 twin (which has no static-method-call support at all — a separate, larger, pre-existing a64 gap, not addressed here).

Full writeup: `docs/audit/LEAN_SINGLE_USE_AS_ALIAS_2026-07-05.md`.

**Incidental improvement**: `Type::nonexistent_method()` for a real struct now surfaces a compile error instead of silently stubbing `0` — confirmed not to regress any currently-passing test.

## Test plan

- [x] Issue #632's exact repro: `use pkg::mod as alias; alias::item()` compiles and returns the real value (was a hard "unreadable import" error)
- [x] `mod::item()` (single-`::`, real module, no alias): returns the real value (was `0`)
- [x] `totallybogus::item()` (garbage prefix, real function): also now resolves correctly, confirming the fallthrough is general
- [x] Real enum-variant matching (`Color::Green`) and real static-method calls (`Point::origin()`): unaffected
- [x] `Type::totally_fake_method()`: now a compile error (was a silent `0` stub) — checked this doesn't regress any passing test
- [x] Real motivating file (`pbpk28_rapamycin_clinical.sio`): the aliased import and both call sites no longer error (file still has unrelated, pre-existing, out-of-scope defects at other lines)
- [x] Full regression suite: 1314 pass / 0 fail / 124 known failures / 689 skip / 2127 total — **exact match to baseline, zero regressions**
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass

Closes #632.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>