### PR TITLE
fix(native): print/println don't unwrap &str, print raw pointer (#633)

### DIFF
--- a/docs/audit/LEAN_SINGLE_PRINTLN_STR_REF_2026-07-05.md
+++ b/docs/audit/LEAN_SINGLE_PRINTLN_STR_REF_2026-07-05.md
@@ -1,0 +1,105 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-println-str-ref-2026-07-05
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-println-str-ref-2026-07-05
+-->
+
+# lean_single forensic dispatch — `print`/`println` don't unwrap `&str`
+
+Date: 2026-07-05
+Branch: `main` (post-PR #634, issue #632)
+Class: **type-dispatch gap** (a value's static type wasn't unwrapped before
+choosing how to print it) — closes issue #633
+Status: root-caused, fixed, verified (full test suite 1314 pass / 0 fail /
+124 known failures / 689 skip / 2127 total — exact match to the current
+baseline, zero regressions)
+
+## Symptom
+
+`println(s)` (and `print(s)`) for an `s: &str` value prints a raw pointer
+value instead of the string's contents. A bare `string`-typed value prints
+correctly.
+
+```sio
+fn takes_str(s: &str) -> i64 with IO {
+    println(s)   // prints e.g. "4198732" instead of "hello"
+    0
+}
+fn main() -> i64 with IO { takes_str("hello") }
+```
+
+## Root cause
+
+`&str` and bare `string` are ABI-identical — both a bare byte pointer,
+already established and relied upon by issue #601's Bug E
+(`docs/audit/LEAN_SINGLE_LITERAL_REF_ARG_2026-07-05.md`), which unified them
+for call-argument type-compatibility and `==`/`!=` comparisons. `print()`'s
+and `println()`'s own runtime-type dispatch was never updated to match:
+
+```sio
+if EXPR_IS_F64 == 1 || EXPR_TY == 2 {
+    emit_print_f64()
+} else if EXPR_TY == 3 {
+    emit_print_cstr()
+    emit_print_nl()
+} else {
+    emit_print_int()
+}
+```
+
+`EXPR_TY == 3` is the bare `string` type. A `&str` value has `EXPR_TY == 10`
+(shared reference) with `ref_hash_inner_ty(EXPR_TY_HASH) == 3` — a case this
+dispatch never checked — so it fell into the final `else`, and the pointer
+value already sitting in `rax` was printed as a plain integer via
+`emit_print_int()`.
+
+This exact same gap exists in all four call sites that duplicate this
+dispatch: `print()` and `println()`, each with an x86-64 and an aarch64
+version.
+
+## Fix
+
+Since `&str` and `string` are ABI-identical, the pointer in `rax` at the
+point of dispatch is already exactly what `emit_print_cstr()` expects —
+no codegen change is needed, only the type-check gate:
+
+```sio
+} else if EXPR_TY == 3 || (EXPR_TY == 10 && ref_hash_inner_ty(EXPR_TY_HASH) == 3) {
+    emit_print_cstr()
+    ...
+```
+
+Applied identically to all four sites (`print`/`println` × x86-64/aarch64).
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1314  Fail: 0  Known failures: 124  Skip: 689  Total: 2127
+```
+
+Exact match to the current baseline — zero regressions.
+
+Directly confirmed by output:
+- Issue #633's exact repro: `println(s)` for `s: &str` now prints `hello`
+  (was a raw pointer value).
+- `print(s)` for the same `&str` parameter: also fixed (same gap, same fix).
+- Regression check — all pre-existing print paths unaffected: string
+  literal (`println("literal string")`), a bound `string` local
+  (`println(s)` where `s: string`), `i64` (`println(42)`), and `f64`
+  (`println(3.14)`) all print correctly, unchanged.
+
+## Cross-references
+
+- GitHub issue #633 — closed by this fix.
+- `docs/audit/LEAN_SINGLE_LITERAL_REF_ARG_2026-07-05.md` — issue #601's
+  Bug E, which established `&str`/`string` ABI-identity and unified them for
+  call arguments and comparisons; this dispatch is the same unification
+  applied to the one remaining place (`print`/`println`'s runtime dispatch)
+  that Bug E's own writeup explicitly flagged as a known, not-yet-fixed
+  follow-up.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 859
-- Repo-backed topics: 709
+- Total governed topics: 860
+- Repo-backed topics: 710
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 503
+- Authority count `repo_only`: 504
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 507 topics
+- A2: 508 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -125,6 +125,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.lean-single-multisegment-qualified-call-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_MULTISEGMENT_QUALIFIED_CALL_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-named-use-import-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-nary-tuple-middle-element-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_NARY_TUPLE_MIDDLE_ELEMENT_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-println-str-ref-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_PRINTLN_STR_REF_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-scan-type-qualified-path-2026-07-04 | repo_only | docs/audit/LEAN_SINGLE_SCAN_TYPE_QUALIFIED_PATH_2026-07-04.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-use-as-alias-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_USE_AS_ALIAS_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2347,6 +2347,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-println-str-ref-2026-07-05",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_PRINTLN_STR_REF_2026-07-05.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.lean-single-scalar-ref-deref-store-2026-07-04",
       "collection": "repo",
       "repo_doc_path": "docs/audit/LEAN_SINGLE_SCALAR_REF_DEREF_STORE_2026-07-04.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -11440,9 +11440,12 @@ fn compile_primary() with IO, Mut, Panic, Div {
                     emit_print(EP); EP = EP + 1
                 } else {
                     compile_or()
+                    // See println's identical unwrap just below (issue #633):
+                    // &str and bare string are ABI-identical, unwrap for
+                    // dispatch only, no codegen change.
                     if EXPR_IS_F64 == 1 || EXPR_TY == 2 {
                         emit_print_f64()
-                    } else if EXPR_TY == 3 {
+                    } else if EXPR_TY == 3 || (EXPR_TY == 10 && ref_hash_inner_ty(EXPR_TY_HASH) == 3) {
                         emit_print_cstr()
                     } else {
                         emit_print_int()
@@ -11467,9 +11470,16 @@ fn compile_primary() with IO, Mut, Panic, Div {
                     if ty_is_unobserved(EXPR_TY) && (FN_EFFECTS[CURRENT_FN as usize] & 64) == 0 {
                         tc_observe_boundary(name_tok, "cannot print Unobserved<T> — IO collapses uncertainty")
                     }
+                    // &str and bare string are ABI-identical (both a bare byte
+                    // pointer, per issue #601's Bug E) — unwrap the reference
+                    // for dispatch purposes only; no codegen change, rax
+                    // already holds the same pointer either way. Without this,
+                    // a `&str` parameter fell through to emit_print_int() and
+                    // printed the raw pointer value instead of the string
+                    // (issue #633).
                     if EXPR_IS_F64 == 1 || EXPR_TY == 2 {
                         emit_print_f64()
-                    } else if EXPR_TY == 3 {
+                    } else if EXPR_TY == 3 || (EXPR_TY == 10 && ref_hash_inner_ty(EXPR_TY_HASH) == 3) {
                         emit_print_cstr()
                         emit_print_nl()
                     } else {
@@ -30255,9 +30265,10 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
                 if TK[EP as usize] == 5 && TK[(EP + 1) as usize] == 7 { emit_print_a64(EP); EP = EP + 1 }
                 else {
                     compile_or_a64()
+                    // See print's x86-64 twin for rationale (issue #633).
                     if EXPR_IS_F64 == 1 || EXPR_TY == 2 {
                         emit_print_f64_a64()
-                    } else if EXPR_TY == 3 {
+                    } else if EXPR_TY == 3 || (EXPR_TY == 10 && ref_hash_inner_ty(EXPR_TY_HASH) == 3) {
                         emit_print_cstr_a64()
                     } else {
                         emit_print_int_a64()
@@ -30282,9 +30293,12 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
                     if ty_is_unobserved(EXPR_TY) && (FN_EFFECTS[CURRENT_FN as usize] & 64) == 0 {
                         tc_observe_boundary(name_tok, "cannot print Unobserved<T> — IO collapses uncertainty")
                     }
+                    // See the x86-64 twin (compile_primary()) for the full
+                    // rationale — &str/string are ABI-identical, unwrap the
+                    // reference for dispatch only (issue #633).
                     if EXPR_IS_F64 == 1 || EXPR_TY == 2 {
                         emit_print_f64_a64()
-                    } else if EXPR_TY == 3 {
+                    } else if EXPR_TY == 3 || (EXPR_TY == 10 && ref_hash_inner_ty(EXPR_TY_HASH) == 3) {
                         emit_print_cstr_a64()
                         emit_print_nl_a64()
                     } else {


### PR DESCRIPTION
## Summary

Picked up issue #633 (`println(s)` for `s: &str` prints a raw pointer instead of the string contents). Root cause: `&str` and bare `string` are ABI-identical (both a bare byte pointer, per issue #601's Bug E, `docs/audit/LEAN_SINGLE_LITERAL_REF_ARG_2026-07-05.md`), but `print()`/`println()`'s runtime-type dispatch only ever checked `EXPR_TY == 3` (bare `string`) — a `&str` value (`EXPR_TY == 10`, inner type 3) fell through to `emit_print_int()`, printing the pointer value itself.

This exact gap exists in all four duplicate dispatch sites: `print()` and `println()`, each with an x86-64 and an aarch64 twin. Fixed all four.

Since the two types are ABI-identical, `rax` already holds the exact same pointer either way — this is a pure type-check gate change, no codegen difference: also match `EXPR_TY == 10` with `ref_hash_inner_ty(EXPR_TY_HASH) == 3`.

Full writeup: `docs/audit/LEAN_SINGLE_PRINTLN_STR_REF_2026-07-05.md`.

## Test plan

- [x] Issue #633's exact repro: `println(s)` for `s: &str` now prints `hello` (was a raw pointer value)
- [x] `print(s)` for the same `&str` parameter: also fixed (same gap, same fix)
- [x] Regression check — string literal, bound `string` local, `i64`, `f64` all print correctly, unchanged
- [x] Full regression suite: 1314 pass / 0 fail / 124 known failures / 689 skip / 2127 total — **exact match to baseline, zero regressions**
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass

Closes #633.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>