### PR TITLE
fix(native): a64 two-level chained field assignment (x.f1.f2[i]/x.f1.f2 = v)

### DIFF
--- a/docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md
+++ b/docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md
@@ -1,0 +1,156 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-a64-two-level-field-store-2026-07-05
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-a64-two-level-field-store-2026-07-05
+-->
+
+# lean_single forensic dispatch — aarch64 has no codegen for two-level chained field assignment
+
+Date: 2026-07-05
+Branch: `main` (post-PR #640, a64 struct-literal aggregate-copy fix)
+Class: **missing aarch64 codegen — a whole class of assignment statements had
+no dispatch entry at all**, not a subtle addressing bug like the previous
+dispatch — closes 2 of the 4 aarch64 `native_runtime` failures left
+out-of-scope by that fix
+Status: fixed, verified — aarch64 native_runtime manifest 97/99 pass (up
+from 95/99; the 2 remaining are the separately-diagnosed, unrelated
+`epistemic_ops_42`/`epistemic_propagation` Knowledge<T>-arithmetic
+segfaults), full x86-64 suite 1314/0/124/689 exact baseline (fix is
+aarch64-only)
+
+## Symptom
+
+`s.inner.vals[0] = 10` (two chained field accesses — `inner`, then `vals` —
+followed by an array index) silently does nothing on aarch64: no compile
+error, no crash, the write simply never happens.
+
+```sio
+struct Inner { vals: [i64; 2] }
+struct Outer { inner: Inner }
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    var s = Outer { inner: Inner { vals: [0; 2] } }
+    s.inner.vals[0] = 10
+    s.inner.vals[1] = 32
+    println(s.inner.vals[0])  // pre-fix (aarch64): 0, should be 10
+    println(s.inner.vals[1])  // pre-fix (aarch64): 0, should be 32
+    0
+}
+```
+
+The identical source compiles and runs correctly on x86-64. This affected
+issue tracking as `abi_nested_array_local_only_42` and
+`abi_return_nested_array_42` in the aarch64 `native_runtime` manifest —
+both left explicitly out of scope by the previous dispatch
+(`docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md`)
+pending their own investigation.
+
+## Root cause
+
+`self-hosted/compiler/lean_single.sio`'s statement compiler recognizes
+assignment-statement shapes by their exact token pattern
+(`stmt_is_*_shape()` helpers, shared between backends) and dispatches each
+shape to a dedicated codegen function. x86-64's dispatch chain
+(`compile_stmt()`) has explicit entries for:
+
+- `stmt_is_field_field_array_store_shape` (`x.f1.f2[idx] = expr`) →
+  `compile_value_field_field_array_store_x86()` /
+  `compile_autoderef_field_field_array_store_x86()`
+- `stmt_is_field_field_store_shape` (`x.f1.f2 = expr`, no array) →
+  `compile_value_field_field_store_x86()` /
+  `compile_autoderef_field_field_store_x86()`
+
+aarch64's dispatch chain (`compile_stmt_a64()`) had **no entries for either
+shape at all** — it only handled the single-level cases (`x.field[idx] =
+expr`, `x.field = expr`) and a different two-level shape where the array
+index comes *before* the second field (`x.arr_field[idx].leaf = expr`, via
+`stmt_is_indexed_field_field_array_store`). A statement matching the
+two-plain-fields shape fell through every check in `compile_stmt_a64()` and
+was silently swallowed with no diagnostic.
+
+Confirmed via a minimal repro that this is aarch64-specific (the identical
+source runs correctly on x86-64) and via `grep` that
+`stmt_is_field_field_array_store_shape`/`stmt_is_field_field_store_shape`
+were called only from `compile_stmt()` (x86-64), never from
+`compile_stmt_a64()`, before this fix.
+
+## Fix
+
+Added the aarch64 twins of all four x86-64 functions, ported instruction-
+for-instruction using the already-correct aarch64 encodings from the
+sibling single-level function `compile_field_array_store_a64()` (register
+plan: index in `x1`, value in `x10`, base pointer in `x0`, matching that
+function's proven-working `str x10, [x0, x1, lsl #3]` /
+`strb w10, [x0, x1]` store instructions verbatim) and the existing
+`emit_store_to_pointer_offset_a64()` helper (already used by the
+pointer/ref single-field store path) for the non-array scalar case:
+
+- `compile_value_field_field_array_store_a64()` — `x.f1.f2[idx] = expr`,
+  value-struct root (the struct's own slot holds a pointer to its field
+  data, so the same "load slot, add combined field offset, indexed store"
+  shape as the working single-level function applies directly).
+- `compile_autoderef_field_field_array_store_a64()` — same shape through a
+  `&!T`/pointer-typed root (auto-deref).
+- `compile_value_field_field_store_a64()` / `compile_autoderef_field_field_store_a64()`
+  — the no-array sibling (`x.f1.f2 = expr`), delegating to
+  `emit_store_to_pointer_offset_a64()` for the actual store, exactly as
+  x86-64's twins delegate to `emit_store_to_pointer_offset_x86()`.
+
+Wired all four into `compile_stmt_a64()`'s dispatch, in the same relative
+order x86-64 uses (field-field-array and field-field checked before the
+existing single-level and indexed-field-field-array checks).
+
+**Scope note**: the no-array sibling (`x.f1.f2 = expr`) was not one of the
+4 originally-reported failing tests, but was discovered to have the
+identical "no aarch64 dispatch entry at all" gap while implementing this
+fix — confirmed via its own minimal repro (`s.inner.tag = 99` silently
+no-oped on aarch64, worked on x86-64) — and fixed alongside the array
+variant since it is the same missing-feature class, not a separate defect.
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+
+# Exact CI repros, cross-compiled + run under qemu-aarch64-static:
+/tmp/lean_fixed.elf tests/selfhost/native_runtime/abi_nested_array_local_only_42.sio /tmp/t1.elf --target aarch64-linux
+qemu-aarch64-static /tmp/t1.elf; echo $?   # 42 (was 0)
+/tmp/lean_fixed.elf tests/selfhost/native_runtime/abi_return_nested_array_42.sio /tmp/t2.elf --target aarch64-linux
+qemu-aarch64-static /tmp/t2.elf; echo $?   # 42 (was 0)
+
+# Full aarch64 native_runtime manifest (99 cases) via aarch64-linux + qemu:
+# 97 pass / 2 fail (was 95/4) — both new targets fixed; the 2 remaining are
+# epistemic_ops_42/epistemic_propagation (unrelated, separately diagnosed).
+
+# Full x86-64 suite (fix is aarch64-only, unaffected by construction):
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1314  Fail: 0  Known failures: 124  Skip: 689  Total: 2127 — exact baseline
+```
+
+Also confirmed directly:
+- The no-array sibling (`s.inner.tag = 99`) now correctly prints `99` (was
+  `0`).
+- The autoderef (pointer-root) variant, via a `&!Outer` parameter mutating
+  two chained fields (one array, one scalar) inside a called function:
+  correct on both x86-64 and the aarch64 fix (`55`, `66`, `77`).
+- Single-level (`x.field[idx] = expr`, already-working
+  `compile_field_array_store_a64`) and nested-struct-literal-read
+  (unrelated to assignment) both remain correct — this dispatch is purely
+  additive, it does not modify any existing dispatch branch.
+
+## Cross-references
+
+- `docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md` —
+  the immediately preceding dispatch, which found and fixed a different
+  aarch64 bug (`copy_agg_into_struct_slots_a64`'s off-by-`(nslots-1)`
+  addressing) and left this one, plus `epistemic_ops_42`/
+  `epistemic_propagation`, explicitly out of scope for follow-up.
+- `epistemic_ops_42`/`epistemic_propagation` remain open — both segfault on
+  `Knowledge<f64>` binary arithmetic (`a + b`) on aarch64, confirmed via a
+  minimal repro to be unrelated to field-chain assignment (isolated to the
+  epistemic/uncertainty-propagation operator codegen, not investigated
+  further here).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 861
-- Repo-backed topics: 711
+- Total governed topics: 862
+- Repo-backed topics: 712
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 505
+- Authority count `repo_only`: 506
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 509 topics
+- A2: 510 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -119,6 +119,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-a64-struct-field-aggregate-copy-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-a64-two-level-field-store-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-bugd-already-fixed-by-buga-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_BUGD_ALREADY_FIXED_BY_BUGA_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-bugf-rootcaused-not-fixed-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_BUGF_ROOTCAUSED_NOT_FIXED_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-literal-ref-arg-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_LITERAL_REF_ARG_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2209,6 +2209,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-a64-two-level-field-store-2026-07-05",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.lean-single-bugd-already-fixed-by-buga-2026-07-05",
       "collection": "repo",
       "repo_doc_path": "docs/audit/LEAN_SINGLE_BUGD_ALREADY_FIXED_BY_BUGA_2026-07-05.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -20111,6 +20111,338 @@ fn materialize_aggregate_array_element_a64(array_hash: i64) with Mut, Panic, Div
     emit_copy_agg_to_ptr_a64(6, elem_hash)
 }
 
+// name.f1.f2 = expr — AUTO-DEREF two-level scalar store (pointer root). a64
+// mirror of compile_autoderef_field_field_store_x86.
+fn compile_autoderef_field_field_store_a64() with IO, Mut, Panic, Div {
+    let name_tok = EP + 0
+    let f1_tok = EP + 2
+    let f2_tok = EP + 4
+    if current_fn_allows_mutation() == false {
+        tc_effect_violation(f2_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+    }
+    let ns = TS[name_tok as usize]
+    let ne = TE[name_tok as usize]
+    let fh1 = gl_name_hash(TS[f1_tok as usize], TE[f1_tok as usize])
+    let fh2 = gl_name_hash(TS[f2_tok as usize], TE[f2_tok as usize])
+    EP = EP + 6  // skip name . f1 . f2 =
+    compile_or_a64()  // rhs in x0
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+    let lslot = var_find(ns, ne)
+    if lslot < 0 {
+        tc_undefined_var(name_tok)
+        return
+    }
+    let lvi = var_find_idx(ns, ne)
+    if lvi < 0 || type_is_pointer_like(VAR_TY[lvi as usize], VAR_TY_HASH[lvi as usize]) == false {
+        tc_error(f1_tok, "field access through deref requires ref or pointer binding")
+        return
+    }
+    let inner_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
+    let inner_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
+    if inner_ty != 6 {
+        tc_error(f1_tok, "field access through pointer/ref requires struct pointee")
+        return
+    }
+    let si1 = st_find(inner_hash)
+    if si1 < 0 {
+        tc_error(f1_tok, "unknown field access")
+        return
+    }
+    ST_QUERY_NS = TS[f1_tok as usize]
+    ST_QUERY_NE = TE[f1_tok as usize]
+    let foff1 = st_field_offset(si1, fh1)
+    let fty1 = st_field_ty(si1, fh1)
+    let fhash1 = st_field_hash(si1, fh1)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff1 < 0 || fty1 != 6 {
+        tc_error(f1_tok, "nested field store requires inline struct field")
+        return
+    }
+    let si2 = st_find(fhash1)
+    if si2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        return
+    }
+    ST_QUERY_NS = TS[f2_tok as usize]
+    ST_QUERY_NE = TE[f2_tok as usize]
+    let foff2 = st_field_offset(si2, fh2)
+    let fty2 = st_field_ty(si2, fh2)
+    let fhash2 = st_field_hash(si2, fh2)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        return
+    }
+    if ty_eq(fty2, fhash2, rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    emit_store_to_pointer_offset_a64(lslot, foff1 + foff2, fty2, fhash2)
+}
+
+// name.f1.f2 = expr — VALUE two-level scalar store (value-struct root). a64
+// mirror of compile_value_field_field_store_x86 — see that function's comment
+// for the rationale (a value-struct local's slot holds a pointer to the
+// struct, so emit_store_to_pointer_offset_a64 stores correctly).
+fn compile_value_field_field_store_a64() with IO, Mut, Panic, Div {
+    let name_tok = EP + 0
+    let f1_tok = EP + 2
+    let f2_tok = EP + 4
+    if current_fn_allows_mutation() == false {
+        tc_effect_violation(f2_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+    }
+    let ns = TS[name_tok as usize]
+    let ne = TE[name_tok as usize]
+    let fh1 = gl_name_hash(TS[f1_tok as usize], TE[f1_tok as usize])
+    let fh2 = gl_name_hash(TS[f2_tok as usize], TE[f2_tok as usize])
+    EP = EP + 6  // skip name . f1 . f2 =
+    compile_or_a64()  // rhs in x0
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+    let lslot = var_find(ns, ne)
+    if lslot < 0 {
+        tc_undefined_var(name_tok)
+        return
+    }
+    ST_QUERY_NS = TS[f1_tok as usize]
+    ST_QUERY_NE = TE[f1_tok as usize]
+    let si1 = resolve_field_struct_index(ns, ne, fh1)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if si1 < 0 {
+        tc_error(f1_tok, "unknown field access")
+        return
+    }
+    ST_QUERY_NS = TS[f1_tok as usize]
+    ST_QUERY_NE = TE[f1_tok as usize]
+    let foff1 = st_field_offset(si1, fh1)
+    let fty1 = st_field_ty(si1, fh1)
+    let fhash1 = st_field_hash(si1, fh1)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff1 < 0 || fty1 != 6 {
+        tc_error(f1_tok, "nested field store requires inline struct field")
+        return
+    }
+    let si2 = st_find(fhash1)
+    if si2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        return
+    }
+    ST_QUERY_NS = TS[f2_tok as usize]
+    ST_QUERY_NE = TE[f2_tok as usize]
+    let foff2 = st_field_offset(si2, fh2)
+    let fty2 = st_field_ty(si2, fh2)
+    let fhash2 = st_field_hash(si2, fh2)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        return
+    }
+    if ty_eq(fty2, fhash2, rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    emit_store_to_pointer_offset_a64(lslot, foff1 + foff2, fty2, fhash2)
+}
+
+// name.f1.f2[idx] = expr — AUTO-DEREF two-level array store (pointer root).
+// a64 mirror of compile_autoderef_field_field_array_store_x86.
+fn compile_autoderef_field_field_array_store_a64() with IO, Mut, Panic, Div {
+    let name_tok = EP + 0
+    let ns = TS[name_tok as usize]
+    let ne = TE[name_tok as usize]
+    let f1_tok = EP + 2
+    let f2_tok = EP + 4
+    let fh1 = gl_name_hash(TS[f1_tok as usize], TE[f1_tok as usize])
+    let fh2 = gl_name_hash(TS[f2_tok as usize], TE[f2_tok as usize])
+    if current_fn_allows_mutation() == false {
+        tc_effect_violation(f2_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+    }
+    EP = EP + 6  // skip name . f1 . f2 [
+    compile_or_a64()  // index in x0
+    if TK[EP as usize] == 37 { EP = EP + 1; EP = EP + 1 }  // 'as usize'
+    if TK[EP as usize] == 42 { EP = EP + 1 }  // ]
+    if TK[EP as usize] == 16 { EP = EP + 1 }  // =
+    emit_push_a64()  // push index
+    compile_or_a64()  // value in x0
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+    let lslot = var_find(ns, ne)
+    let lvi = var_find_idx(ns, ne)
+    if lslot < 0 || lvi < 0 || type_is_pointer_like(VAR_TY[lvi as usize], VAR_TY_HASH[lvi as usize]) == false {
+        tc_error(f1_tok, "field access through deref requires ref or pointer binding")
+        emit_pop_x1_a64()
+        return
+    }
+    let inner_ty = ptr_hash_inner_ty(VAR_TY_HASH[lvi as usize])
+    let inner_hash = ptr_hash_inner_hash(VAR_TY_HASH[lvi as usize])
+    if inner_ty != 6 {
+        tc_error(f1_tok, "field access through pointer/ref requires struct pointee")
+        emit_pop_x1_a64()
+        return
+    }
+    let si1 = st_find(inner_hash)
+    if si1 < 0 {
+        tc_error(f1_tok, "unknown field access")
+        emit_pop_x1_a64()
+        return
+    }
+    ST_QUERY_NS = TS[f1_tok as usize]
+    ST_QUERY_NE = TE[f1_tok as usize]
+    let foff1 = st_field_offset(si1, fh1)
+    let fty1 = st_field_ty(si1, fh1)
+    let fhash1 = st_field_hash(si1, fh1)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff1 < 0 || fty1 != 6 {
+        tc_error(f1_tok, "nested field store requires inline struct field")
+        emit_pop_x1_a64()
+        return
+    }
+    let si2 = st_find(fhash1)
+    if si2 < 0 {
+        tc_error(f2_tok, "unknown field access")
+        emit_pop_x1_a64()
+        return
+    }
+    ST_QUERY_NS = TS[f2_tok as usize]
+    ST_QUERY_NE = TE[f2_tok as usize]
+    let foff2 = st_field_offset(si2, fh2)
+    let fty2 = st_field_ty(si2, fh2)
+    let fhash2 = st_field_hash(si2, fh2)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff2 < 0 || fty2 != 8 {
+        tc_error(f2_tok, "indexed field store requires array field")
+        emit_pop_x1_a64()
+        return
+    }
+    if ty_eq(arr_hash_elem_ty(fhash2), arr_hash_elem_hash(fhash2), rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    materialize_aggregate_array_element_a64(fhash2)
+    em32(0xAA0003EA)  // mov x10, x0 (value)
+    emit_pop_x1_a64()  // x1 = index
+    emit_load_var_a64(lslot)  // x0 = base pointer
+    let total_off = foff1 + foff2
+    if total_off != 0 {
+        emit_imm64_reg_a64(11, total_off)
+        em32(0x8B0B0000)  // add x0, x0, x11
+    }
+    if arr_hash_esiz(fhash2) == 8 { em32(0xF821780A) }  // str x10, [x0, x1, lsl #3]
+    else { em32(0x3821680A) }  // strb w10, [x0, x1]
+}
+
+// name.f1.f2[idx] = expr — VALUE two-level array store (value-struct root).
+// a64 mirror of compile_value_field_field_array_store_x86 — see that
+// function's comment for the rationale. Without this handler (and its
+// autoderef/no-array siblings above), a64 had no dispatch entry at all for
+// any two-level field chain assignment (`o.inner.b = v`, `o.inner.vals[i] =
+// v`) — the statement silently fell through every existing shape check and
+// the store never happened, with no diagnostic.
+fn compile_value_field_field_array_store_a64() with IO, Mut, Panic, Div {
+    let name_tok = EP
+    let ns = TS[name_tok as usize]
+    let ne = TE[name_tok as usize]
+    let f1_tok = EP + 2
+    let f2_tok = EP + 4
+    let f1ns = TS[f1_tok as usize]
+    let f1ne = TE[f1_tok as usize]
+    let f2ns = TS[f2_tok as usize]
+    let f2ne = TE[f2_tok as usize]
+    let f1h = gl_name_hash(f1ns, f1ne)
+    let f2h = gl_name_hash(f2ns, f2ne)
+
+    EP = EP + 6
+    compile_or_a64()  // index in x0
+    if TK[EP as usize] == 37 { EP = EP + 1; EP = EP + 1 }
+    if TK[EP as usize] == 42 { EP = EP + 1 }
+    if TK[EP as usize] == 16 { EP = EP + 1 }
+    emit_push_a64()  // push index
+    compile_or_a64()  // value in x0
+    let rhs_ty = EXPR_TY
+    let rhs_ty_hash = EXPR_TY_HASH
+
+    ST_QUERY_NS = f1ns
+    ST_QUERY_NE = f1ne
+    let si1 = resolve_field_struct_index(ns, ne, f1h)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if si1 < 0 {
+        tc_error(f1_tok, "unknown field access")
+        emit_pop_x1_a64()
+        return
+    }
+    if st_private_access_denied(si1, f1_tok) {
+        tc_error_hard(f1_tok, "private struct field access")
+        emit_pop_x1_a64()
+        return
+    }
+    ST_QUERY_NS = f1ns
+    ST_QUERY_NE = f1ne
+    let foff1 = st_field_offset(si1, f1h)
+    let fty1 = st_field_ty(si1, f1h)
+    let fhash1 = st_field_hash(si1, f1h)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff1 < 0 || fty1 != 6 {
+        tc_error(f1_tok, "nested field store requires inline struct field")
+        emit_pop_x1_a64()
+        return
+    }
+    let si2 = st_find(fhash1)
+    if si2 < 0 {
+        tc_error(f1_tok, "nested field store requires known struct field type")
+        emit_pop_x1_a64()
+        return
+    }
+    if st_private_access_denied(si2, f2_tok) {
+        tc_error_hard(f2_tok, "private struct field access")
+        emit_pop_x1_a64()
+        return
+    }
+    ST_QUERY_NS = f2ns
+    ST_QUERY_NE = f2ne
+    let foff2 = st_field_offset(si2, f2h)
+    let fty2 = st_field_ty(si2, f2h)
+    let fhash2 = st_field_hash(si2, f2h)
+    ST_QUERY_NS = -1
+    ST_QUERY_NE = -1
+    if foff2 < 0 || fty2 != 8 {
+        tc_error(f2_tok, "indexed field store requires array field")
+        emit_pop_x1_a64()
+        return
+    }
+    if ty_eq(arr_hash_elem_ty(fhash2), arr_hash_elem_hash(fhash2), rhs_ty, rhs_ty_hash) == false {
+        tc_error(EP - 1, "assignment type mismatch")
+    }
+    materialize_aggregate_array_element_a64(fhash2)
+    em32(0xAA0003EA)  // mov x10, x0 (value)
+    emit_pop_x1_a64()  // x1 = index
+    let slot = var_find(ns, ne)
+    if slot >= 0 {
+        emit_load_var_a64(slot)
+    } else {
+        let gi = gl_find(ns, ne)
+        if gi >= 0 {
+            emit_image_addr_a64(GL_BSS_BASE + GL[(gi * 4 + 1) as usize])
+        } else {
+            tc_undefined_var(name_tok)
+            em32(0xD2800000)
+        }
+    }
+    let total_off = foff1 + foff2
+    if total_off != 0 {
+        emit_imm64_reg_a64(11, total_off)
+        em32(0x8B0B0000)  // add x0, x0, x11
+    }
+    if arr_hash_esiz(fhash2) == 8 { em32(0xF821780A) }  // str x10, [x0, x1, lsl #3]
+    else { em32(0x3821680A) }  // strb w10, [x0, x1]
+}
+
 // ARRAY[idx].field(.field)* = expr — store into a struct element of an array.
 // Array-of-struct slots hold 8-byte pointers to heap-materialized struct copies
 // (see materialize_aggregate_array_element_x86), so the element pointer is
@@ -32628,6 +32960,25 @@ fn compile_stmt_a64() with IO, Mut, Panic, Div {
                 EXPR_CH_SET = 0
                 EXPR_PARAM_USED = 0
             }
+        }
+        return
+    }
+    // x.f1.f2[idx] = expr — two chained field accesses then an array index.
+    if stmt_is_field_field_array_store_shape(EP) {
+        if token_chain_root_is_pointer(EP) {
+            compile_autoderef_field_field_array_store_a64()
+        } else {
+            compile_value_field_field_array_store_a64()
+        }
+        return
+    }
+    // x.f1.f2 = expr — two chained field accesses, no array, through a
+    // pointer var (auto-deref) OR an inline value struct.
+    if stmt_is_field_field_store_shape(EP) {
+        if token_chain_root_is_pointer(EP) {
+            compile_autoderef_field_field_store_a64()
+        } else {
+            compile_value_field_field_store_a64()
         }
         return
     }


### PR DESCRIPTION
## Summary

Picked up the field-chain assignment gap found while investigating the aarch64 native_runtime failures left out of scope by the previous Release Gate fix (#640): `s.inner.vals[0] = 10` (two chained field accesses, then an array index) silently does nothing on aarch64 — no error, no crash, the write just never happens.

**Root cause**: `compile_stmt_a64()` had no dispatch entry at all for the "two chained plain-field accesses" assignment shape, with or without a trailing array index (`x.f1.f2[idx] = expr` / `x.f1.f2 = expr`). X86-64 has dedicated codegen for both shapes (`compile_value_field_field_array_store_x86` and its autoderef + no-array siblings, 4 functions total); aarch64 only had single-level (`x.field[idx] = expr`) and a *different* two-level shape (array index before the second field, `x.arr[idx].leaf = expr`). A statement matching the two-plain-fields shape fell through every existing a64 check and was silently swallowed.

**Fix**: added all four aarch64 twins, ported instruction-for-instruction from the already-correct aarch64 encodings in the working single-level function (register plan: index in `x1`, value in `x10`, base pointer in `x0` — reusing that function's proven `str x10, [x0, x1, lsl #3]` / `strb w10, [x0, x1]` verbatim) and the existing `emit_store_to_pointer_offset_a64()` helper for the non-array case.

**Scope note**: the no-array sibling (`x.f1.f2 = expr`) wasn't one of the originally-reported failures, but turned out to have the identical "no aarch64 dispatch at all" gap — found while implementing the fix, confirmed via its own minimal repro, and fixed alongside the array variant since it's the same missing-feature class.

Full writeup: `docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md`.

## Test plan

- [x] Both CI-reported failures (`abi_nested_array_local_only_42`, `abi_return_nested_array_42`, cross-compiled to `aarch64-linux` + run under `qemu-aarch64-static`): now exit `42` (was `0`)
- [x] No-array sibling (`s.inner.tag = 99`): now correctly prints `99` (was `0`)
- [x] Autoderef (pointer-root) variant, via a `&!Outer` parameter mutating both an array and a scalar field two levels deep: correct on both x86-64 and the aarch64 fix
- [x] Full aarch64 `native_runtime` manifest (99 cases): 97 pass / 2 fail — up from 95/4. Remaining 2 (`epistemic_ops_42`, `epistemic_propagation`) are separately-diagnosed, unrelated `Knowledge<f64>`-arithmetic segfaults, not touched here
- [x] Full x86-64 regression suite: 1314 pass / 0 fail / 124 known failures / 689 skip / 2127 total — **exact match to baseline** (fix is aarch64-only, purely additive)
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>