### PR TITLE
fix(native): a64 Knowledge<T> arithmetic (no codegen at all) + missing .uncertainty read

### DIFF
--- a/docs/audit/LEAN_SINGLE_A64_KNOWLEDGE_ARITHMETIC_2026-07-05.md
+++ b/docs/audit/LEAN_SINGLE_A64_KNOWLEDGE_ARITHMETIC_2026-07-05.md
@@ -1,0 +1,167 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.lean-single-a64-knowledge-arithmetic-2026-07-05
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.lean-single-a64-knowledge-arithmetic-2026-07-05
+-->
+
+# lean_single forensic dispatch — aarch64 had no `Knowledge<T>` arithmetic codegen at all
+
+Date: 2026-07-05
+Branch: `main` (post-PR #642, a64 two-level field-store fix)
+Class: **two missing aarch64 subsystems** — no `Knowledge<T>` binary-operator
+codegen at all (segfault), plus a separate, independently-discovered missing
+`.uncertainty` field-read case (silent wrong value) — closes the last 2 of
+the 4 aarch64 `native_runtime` failures left out of scope by the two
+preceding a64 dispatches
+Status: fixed, verified — aarch64 native_runtime manifest **99/99 pass** (up
+from 97/99 after the previous dispatch; **all four** originally-failing
+tests across this three-dispatch aarch64 arc are now closed), full x86-64
+suite 1314/0/124/689 exact baseline (fix is aarch64-only)
+
+## Symptom
+
+```sio
+let a: Knowledge<f64> = measure(10.0, uncertainty: 0.3, confidence: 0.8)
+let b: Knowledge<f64> = measure(20.0, uncertainty: 0.4, confidence: 0.6)
+let sum = a + b   // segfaults on aarch64
+```
+
+`measure()` and `.value`/`.uncertainty`/`.confidence` field access all work
+correctly on aarch64 in isolation; the crash is isolated to the binary
+arithmetic operators (`+ - * /`) when either operand is `Knowledge<T>`.
+
+## Root cause #1: `compile_additive_a64()`/`compile_multiplicative_a64()` never checked for `Knowledge<T>` at all
+
+x86-64's `compile_additive()`/`compile_multiplicative()` check
+`knowledge_hash_is(left_hash) || knowledge_hash_is(right_hash)` before
+falling into the plain-scalar arithmetic path, dispatching to
+`compile_knowledge_addsub_x86()`/`compile_knowledge_muldiv_x86()` instead.
+`grep` confirmed neither `compile_additive_a64()` nor
+`compile_multiplicative_a64()` contained the string `knowledge_hash_is`
+anywhere, and neither `compile_knowledge_addsub_a64()` nor
+`compile_knowledge_muldiv_a64()` existed. `Knowledge<T>` is represented as a
+pointer to a 3-word struct (`value`@0, `variance`@8, `confidence`@16); with
+no special-casing, `a + b` fell into the plain scalar path and added the two
+**pointers** as if they were f64 bit patterns, producing a garbage result
+that segfaulted on the next `.value`/`.uncertainty`/`.confidence` field
+dereference.
+
+**Fix**: ported `compile_knowledge_addsub_x86()`/`compile_knowledge_muldiv_x86()`
+to aarch64 instruction-for-instruction, along with their primitive
+dependencies (`emit_load_operand_value/variance/confidence_a64`,
+`emit_i64_to_f64_in_x0_a64`, `emit_min_positive_f64_bits_a64` — a
+branch-based min using the same conditional-branch-and-patch pattern already
+proven elsewhere in this file's a64 codegen, avoiding an untested CSEL
+encoding). `emit_f64_binop_a64()` (already existing, parameterized by FP
+opcode) covers add/sub/mul/div uniformly, unlike x86-64's four separate
+named helpers. Wired the `knowledge_hash_is` dispatch into
+`compile_additive_a64()`/`compile_multiplicative_a64()`, adding the missing
+`left_ty`/`left_hash`/`right_ty`/`right_hash`/`op_tok` captures those
+functions never had (only `left_f64` was tracked, since the existing GTT
+sensitivity-shadow-tracking code — a separate, already-ported-to-a64,
+orthogonal feature for plain-f64 automatic differentiation — didn't need
+them). Confirmed via a register-preserving runtime-debug-print technique
+(see "Debugging methodology" below) that every intermediate value (operand
+values, variances, confidence) is bit-for-bit correct through this new
+codegen before removing the instrumentation.
+
+The multiply/divide variance chain-rule math (`Var(a·b) ≈ a²Var(b) +
+b²Var(a)`, `Var(a/b) ≈ Var(a)/b² + a²Var(b)/b⁴`) was ported by mechanically
+translating each `em(0x50)`(push)/`em(0x59)`(pop rcx)/`emit_f64_*_from_rcx_rax_x86()`
+triple to `emit_push_a64()`/`emit_pop_x1_a64()`/`emit_f64_binop_a64(opcode)`
+— x86-64's "rcx OP rax" convention and `emit_f64_binop_a64`'s "x1 OP x0"
+convention are the same shape, so the translation preserves the exact
+operand ordering non-commutative operations (division) depend on. Verified
+independently against the mul/div assertions from the original x86-64 test.
+
+## Root cause #2 (discovered while verifying #1, pre-existing, unrelated to arithmetic): `.uncertainty` field read was never ported to aarch64 either
+
+Fixing root cause #1 alone did not make `epistemic_ops_42` pass: it stopped
+segfaulting, but `sum.uncertainty` read back as `0` instead of `0.5`.
+Isolated with a minimal repro to a **plain `measure()`-created value with no
+arithmetic at all** (`a.uncertainty` on the original `a`, not `a+b`) —
+confirming this is completely independent of root cause #1 and predates
+this dispatch entirely.
+
+`compile_postfix_a64()`'s generic `Knowledge<T>` field-access branch had
+`"value"`, `"variance"`, and `"confidence"`/`"epsilon"` cases, but no
+`"uncertainty"` case — x86-64's equivalent branch has all four. A
+`.uncertainty` access fell through to the final `else { tc_error(...) }`,
+and since `tc_error()` is non-fatal (prints a diagnostic but does not halt
+codegen — see `reference_sounio_visibility_model` in project memory), `x0`
+and `EXPR_IS_F64` were simply left at whatever they were before, silently
+reading as `0`.
+
+**Fix**: added the missing case, `ldr x0,[x0,#8]` (load the raw stored
+`variance`) then `emit_sqrt_builtin_a64()` (new — aarch64 had no `sqrt`
+primitive usable for this either; `fmov d0,x0; fsqrt d0,d0; fmov x0,d0`,
+mirroring `emit_sqrt_builtin_x86`'s `movq`/`sqrtsd`/`movq` shape) —
+`.uncertainty` surfaces `sqrt(variance)`, since `variance` (not the surface
+uncertainty) is what `measure()` actually stores at offset 8.
+
+## Debugging methodology
+
+Both root causes were isolated using the `qemu-aarch64-static` local-repro
+technique established in the two preceding dispatches (cross-compile to
+`--target aarch64-linux`, run under `qemu-aarch64-static`, no macOS hardware
+needed). Root cause #2 specifically required distinguishing "my new
+arithmetic codegen computes the wrong variance" from "the arithmetic is
+right but something downstream misreads it" — resolved by temporarily
+injecting register-preserving runtime print calls
+(`emit_push_a64(); emit_print_int_a64(); emit_pop_x0_a64()`, careful to
+route the actual live register through a named temp slot rather than extra
+unbalanced stack pushes) directly into the generated machine code at each
+intermediate step, confirming the stored variance bit pattern (`0.25`,
+`0.09+0.16`) was correct **before** ever suspecting the field-read side —
+avoiding a wasted re-audit of already-correct arithmetic.
+
+## Verification
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+scripts/dev/souc-build-lock.sh ./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/lean_fixed.elf
+
+# Exact CI repros, cross-compiled + run under qemu-aarch64-static:
+# epistemic_ops_42: exit 42 (was SIGSEGV, then briefly exit 2 mid-fix before root cause #2)
+# epistemic_propagation: exit 0 (was SIGSEGV)
+
+# Full aarch64 native_runtime manifest (99 cases): 99 pass / 0 fail — up
+# from 97/2 after the previous dispatch. All 4 originally-failing tests
+# across this three-PR aarch64 arc (#640, #642, this one) now closed.
+
+bash scripts/run_sio_test_suite.sh --format junit --jobs 8
+# Pass: 1314  Fail: 0  Known failures: 124  Skip: 689  Total: 2127 — exact baseline
+```
+
+Also confirmed directly: the full multiply/divide variance chain-rule
+formulas against the original x86-64 test's exact numeric assertions
+(`prod.value≈200.0`, `prod.uncertainty≈7.211`, `quot.value≈0.5`,
+`quot.uncertainty≈0.018`) — all pass on aarch64.
+
+## Discovered but explicitly out of scope
+
+`compile_knowledge_muldiv_x86`'s own comment (ported verbatim into the a64
+twin) documents a **known, pre-existing limitation shared by both
+backends**: Knowledge<T> multiplication/division does not propagate
+`EXPR_SSHADOW_*`/`EXPR_HSHADOW_*` (the GTT sensitivity/Hessian shadow
+state) — a `hessian_of`/`sensitivity_of` on a direct-Knowledge-arithmetic
+result silently returns zero for those terms. This is Lean-formalised as an
+accepted boundary in `formal/KnowledgeArithmeticSoundness.lean` and
+documented in `docs/compiler/KNOWN_LIMITATIONS.md`; this dispatch preserves
+it identically on both backends rather than attempting to close it (a
+Phase-5 architectural item per the existing comment, unrelated to the
+crash/wrong-value bugs fixed here).
+
+## Cross-references
+
+- `docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md` —
+  first dispatch in this aarch64 arc (Release Gate root cause).
+- `docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md` — second
+  dispatch, fixed 2 of the 4 remaining failures; left these 2 explicitly out
+  of scope pending this dispatch.
+- `reference_a64_codegen_gotchas` (project memory) — this dispatch adds two
+  new entries: the branch-based (not CSEL) min-of-two-positives pattern, and
+  the register-preserving runtime-print debugging technique.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 862
-- Repo-backed topics: 712
+- Total governed topics: 863
+- Repo-backed topics: 713
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 506
+- Authority count `repo_only`: 507
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 510 topics
+- A2: 511 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -118,6 +118,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.g1-wip.verdict-parity-2026-06-02 | repo_only | docs/audit/g1_wip/VERDICT_PARITY_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.lean-single-a64-knowledge-arithmetic-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_KNOWLEDGE_ARITHMETIC_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-a64-struct-field-aggregate-copy-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-a64-two-level-field-store-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_TWO_LEVEL_FIELD_STORE_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-bugd-already-fixed-by-buga-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_BUGD_ALREADY_FIXED_BY_BUGA_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2186,6 +2186,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.lean-single-a64-knowledge-arithmetic-2026-07-05",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/LEAN_SINGLE_A64_KNOWLEDGE_ARITHMETIC_2026-07-05.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.lean-single-a64-struct-field-aggregate-copy-2026-07-05",
       "collection": "repo",
       "repo_doc_path": "docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md",

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -8202,6 +8202,222 @@ fn compile_knowledge_muldiv_x86(op_tok: i64, op: i64, left_ty: i64, left_hash: i
     EXPR_TY_HASH = knowledge_binary_result_hash(op, left_ty, left_hash, right_ty, right_hash)
 }
 
+// ─── aarch64 twins: Knowledge<T> arithmetic (issue: a64 had none of this at
+// all — compile_additive_a64()/compile_multiplicative_a64() never checked
+// knowledge_hash_is and fell into plain scalar add/sub/mul/div on the raw
+// Knowledge<T> POINTER values, producing a garbage "sum" that segfaulted on
+// the next .value/.uncertainty/.confidence field access). Ported
+// instruction-for-instruction from the x86-64 originals above, reusing the
+// already-correct aarch64 primitives from elsewhere in this file
+// (emit_f64_binop_a64 for the SSE2-equivalent ops, the same
+// value@0/variance@8/confidence@16 field layout already used by working
+// Knowledge<T> field access on a64).
+
+fn emit_i64_to_f64_in_x0_a64() with Mut {
+    em32(0x9E620000)  // scvtf d0, x0
+    em32(0x9E660000)  // fmov x0, d0
+}
+
+fn emit_load_operand_value_a64(slot: i64, ty: i64, ty_hash: i64, tok: i64) with IO, Mut, Panic, Div {
+    emit_load_var_a64(slot)
+    if knowledge_hash_is(ty_hash) {
+        em32(0xF9400000)  // ldr x0, [x0] (.value)
+        let inner_ty = knowledge_hash_inner_ty(ty_hash)
+        if inner_ty != 2 {
+            if ty_is_numeric(inner_ty) { emit_i64_to_f64_in_x0_a64() }
+            else {
+                tc_error(tok, "Knowledge arithmetic requires numeric inner type")
+                em32(0xD2800000)  // mov x0, #0
+            }
+        }
+        return
+    }
+    if ty != 2 {
+        if ty_is_numeric(ty) { emit_i64_to_f64_in_x0_a64() }
+        else {
+            tc_error(tok, "Knowledge arithmetic requires numeric operands")
+            em32(0xD2800000)
+        }
+    }
+}
+
+fn emit_load_operand_variance_a64(slot: i64, ty_hash: i64) with Mut, Panic, Div {
+    if knowledge_hash_is(ty_hash) {
+        emit_load_var_a64(slot)
+        em32(0xF9400400)  // ldr x0, [x0, #8] (variance)
+        return
+    }
+    em32(0xD2800000)  // mov x0, #0 (0.0 bit pattern)
+}
+
+fn emit_load_operand_confidence_a64(slot: i64, ty_hash: i64) with Mut, Panic, Div {
+    if knowledge_hash_is(ty_hash) {
+        emit_load_var_a64(slot)
+        em32(0xF9400800)  // ldr x0, [x0, #16] (confidence)
+        return
+    }
+    emit_imm64_reg_a64(0, 4607182418800017408)  // x0 = 1.0 bits
+}
+
+// x1, x0 are two POSITIVE f64 bit patterns — for positive floats, integer
+// comparison of the bit pattern preserves float ordering, so this avoids a
+// real float comparison. Result (min) left in x0. Branch-based rather than
+// CSEL to reuse the already-proven conditional-branch-and-patch pattern used
+// throughout this file's a64 codegen (see aarch64-codegen-authoring-gotchas).
+fn emit_min_positive_f64_bits_a64() with Mut, Panic {
+    em32(0xEB00003F)  // cmp x1, x0
+    let skip_off = CL
+    em32(0x5400000C)  // b.gt skip (cond=gt=0xC): if x1 > x0, x0 already the min
+    em32(0xAA0103E0)  // mov x0, x1
+    patch_branch_a64(skip_off, CL)
+}
+
+// x0 = sqrt(x0), f64 bits in/out. a64 mirror of emit_sqrt_builtin_x86 (used
+// by the .uncertainty field-read accessor below — .uncertainty surfaces
+// sqrt(variance), variance is what's actually stored at offset 8).
+fn emit_sqrt_builtin_a64() with Mut {
+    em32(0x9E670000)  // fmov d0, x0
+    em32(0x1E61C000)  // fsqrt d0, d0
+    em32(0x9E660000)  // fmov x0, d0
+}
+
+fn compile_knowledge_addsub_a64(op_tok: i64, op: i64, left_ty: i64, left_hash: i64, right_ty: i64, right_hash: i64) with IO, Mut, Panic, Div {
+    let rhs_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 1
+    emit_store_var_a64(rhs_slot)
+    let lhs_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 1
+    emit_pop_x0_a64()
+    emit_store_var_a64(lhs_slot)
+    let base_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 3
+
+    emit_load_operand_value_a64(lhs_slot, left_ty, left_hash, op_tok)
+    emit_push_a64()
+    emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+    emit_pop_x1_a64()
+    if op == 17 { emit_f64_binop_a64(0x1E612800) } else { emit_f64_binop_a64(0x1E613800) }
+    emit_store_var_a64(base_slot + 2)
+
+    emit_load_operand_variance_a64(lhs_slot, left_hash)
+    emit_push_a64()
+    emit_load_operand_variance_a64(rhs_slot, right_hash)
+    emit_pop_x1_a64()
+    emit_f64_binop_a64(0x1E612800)
+    emit_store_var_a64(base_slot + 1)
+
+    emit_load_operand_confidence_a64(lhs_slot, left_hash)
+    emit_push_a64()
+    emit_load_operand_confidence_a64(rhs_slot, right_hash)
+    emit_pop_x1_a64()
+    emit_min_positive_f64_bits_a64()
+    emit_store_var_a64(base_slot)
+
+    emit_lea_var_a64(base_slot + 2)
+    EXPR_IS_F64 = 0
+    EXPR_TY = 0
+    EXPR_TY_HASH = knowledge_binary_result_hash(op, left_ty, left_hash, right_ty, right_hash)
+}
+
+fn compile_knowledge_muldiv_a64(op_tok: i64, op: i64, left_ty: i64, left_hash: i64, right_ty: i64, right_hash: i64) with IO, Mut, Panic, Div {
+    let rhs_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 1
+    emit_store_var_a64(rhs_slot)
+    let lhs_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 1
+    emit_pop_x0_a64()
+    emit_store_var_a64(lhs_slot)
+    let base_slot = NEXT_SLOT
+    NEXT_SLOT = NEXT_SLOT + 3
+
+    emit_load_operand_value_a64(lhs_slot, left_ty, left_hash, op_tok)
+    emit_push_a64()
+    emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+    emit_pop_x1_a64()
+    if op == 19 { emit_f64_binop_a64(0x1E610800) } else { emit_f64_binop_a64(0x1E611800) }
+    emit_store_var_a64(base_slot + 2)
+
+    if op == 19 {
+        emit_load_operand_value_a64(lhs_slot, left_ty, left_hash, op_tok)
+        emit_push_a64()
+        emit_load_operand_value_a64(lhs_slot, left_ty, left_hash, op_tok)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_push_a64()
+        emit_load_operand_variance_a64(rhs_slot, right_hash)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_push_a64()
+
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_push_a64()
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_push_a64()
+        emit_load_operand_variance_a64(lhs_slot, left_hash)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E612800)
+    } else {
+        emit_load_operand_variance_a64(lhs_slot, left_hash)
+        emit_push_a64()
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_push_a64()
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E611800)
+        emit_push_a64()
+
+        emit_load_operand_value_a64(lhs_slot, left_ty, left_hash, op_tok)
+        emit_push_a64()
+        emit_load_operand_value_a64(lhs_slot, left_ty, left_hash, op_tok)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_push_a64()
+        emit_load_operand_variance_a64(rhs_slot, right_hash)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_push_a64()
+
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_push_a64()
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_push_a64()
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_push_a64()
+        emit_load_operand_value_a64(rhs_slot, right_ty, right_hash, op_tok)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E610800)
+
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E611800)
+        emit_pop_x1_a64()
+        emit_f64_binop_a64(0x1E612800)
+    }
+    emit_store_var_a64(base_slot + 1)
+
+    emit_load_operand_confidence_a64(lhs_slot, left_hash)
+    emit_push_a64()
+    emit_load_operand_confidence_a64(rhs_slot, right_hash)
+    emit_pop_x1_a64()
+    emit_min_positive_f64_bits_a64()
+    emit_store_var_a64(base_slot)
+
+    emit_lea_var_a64(base_slot + 2)
+    EXPR_IS_F64 = 0
+    EXPR_TY = 0
+    EXPR_TY_HASH = knowledge_binary_result_hash(op, left_ty, left_hash, right_ty, right_hash)
+}
+
 // ─── Built-in function emitters ───
 
 // print_int: rax = value → emit decimal digits + write syscall
@@ -32144,6 +32360,19 @@ fn compile_postfix_tail_a64() with IO, Mut, Panic, Div {
                     EXPR_TY = 2
                     EXPR_TY_HASH = 0
                     EXPR_IS_F64 = 1
+                } else if src_match(fns, fne - fns, "uncertainty") {
+                    // a64 twin of the x86 .uncertainty accessor (compile_postfix())
+                    // — a whole missing case, not previously ported: .uncertainty
+                    // surfaces sqrt(variance); variance is what's actually stored
+                    // at offset 8. Without this, `.uncertainty` fell through to
+                    // the generic "unknown field access" branch below, which
+                    // tc_error()s (non-fatal — see reference_sounio_visibility_model)
+                    // and leaves x0/EXPR_IS_F64 untouched, silently reading as 0.
+                    em32(0xF9400400)
+                    emit_sqrt_builtin_a64()
+                    EXPR_TY = 2
+                    EXPR_TY_HASH = 0
+                    EXPR_IS_F64 = 1
                 } else if src_match(fns, fne - fns, "confidence") || src_match(fns, fne - fns, "epsilon") {
                     em32(0xF9400800)
                     EXPR_TY = 2
@@ -32262,6 +32491,8 @@ fn compile_multiplicative_a64() with IO, Mut, Panic, Div {
             rhs_const_val = TV[(rhs_start + 1) as usize] - TV[(rhs_start + 3) as usize]
         }
         let left_f64 = EXPR_IS_F64
+        let left_ty = EXPR_TY
+        let left_hash = EXPR_TY_HASH
         // β⁴: capture LHS shadow + save LHS f64 value for GUM/AD propagation
         let b4am_left_vshadow = EXPR_VSHADOW
         let b4am_left_sshadow = EXPR_SSHADOW
@@ -32278,9 +32509,41 @@ fn compile_multiplicative_a64() with IO, Mut, Panic, Div {
         EXPR_VSHADOW = -1; EXPR_SSHADOW = -1; EXPR_SSHADOW_1 = -1; EXPR_SSHADOW_2 = -1; EXPR_SSHADOW_3 = -1; EXPR_SSHADOW_4 = -1; EXPR_SSHADOW_5 = -1; EXPR_SSHADOW_6 = -1; EXPR_SSHADOW_7 = -1
         emit_push_a64()
         compile_postfix_a64()
+        let right_ty = EXPR_TY
+        let right_hash = EXPR_TY_HASH
         if (op == 20 || op == 29) && rhs_const_known != 0 && rhs_const_val == 0 {
             if op == 20 { tc_error(op_tok, "division by zero") }
             else { tc_error(op_tok, "modulo by zero") }
+        }
+        let left_has_knowledge = knowledge_hash_is(left_hash)
+        let right_has_knowledge = knowledge_hash_is(right_hash)
+        if left_has_knowledge || right_has_knowledge {
+            // LHS is still on the stack (pushed above) and x0 holds the
+            // freshly-compiled RHS — the stack shape compile_knowledge_muldiv_a64
+            // expects (it does its own pop). See compile_multiplicative() (x86
+            // twin) for the full rationale, including why modulo still calls
+            // through after the diagnostic (mirrors x86 exactly).
+            var left_inner_ty = left_ty
+            var left_inner_hash = left_hash
+            if left_has_knowledge {
+                left_inner_ty = knowledge_hash_inner_ty(left_hash)
+                left_inner_hash = knowledge_hash_inner_hash(left_hash)
+            }
+            var right_inner_ty = right_ty
+            var right_inner_hash = right_hash
+            if right_has_knowledge {
+                right_inner_ty = knowledge_hash_inner_ty(right_hash)
+                right_inner_hash = knowledge_hash_inner_hash(right_hash)
+            }
+            if op == 29 {
+                tc_error(op_tok, "modulo requires integer operands")
+            } else if left_inner_ty != 0 && right_inner_ty != 0 {
+                if ty_is_numeric(left_inner_ty) == false || ty_is_numeric(right_inner_ty) == false || ty_eq(left_inner_ty, left_inner_hash, right_inner_ty, right_inner_hash) == false {
+                    tc_error(op_tok, "Knowledge arithmetic requires matching numeric operands")
+                }
+            }
+            compile_knowledge_muldiv_a64(op_tok, op, left_ty, left_hash, right_ty, right_hash)
+            continue
         }
         // β⁴: capture RHS shadow + save RHS f64 value
         let b4am_right_vshadow = EXPR_VSHADOW
@@ -32416,9 +32679,12 @@ fn compile_multiplicative_a64() with IO, Mut, Panic, Div {
 fn compile_additive_a64() with IO, Mut, Panic, Div {
     compile_multiplicative_a64()
     while TK[EP as usize] == 17 || TK[EP as usize] == 18 {
+        let op_tok = EP
         let op = TK[EP as usize]
         EP = EP + 1
         let left_f64 = EXPR_IS_F64
+        let left_ty = EXPR_TY
+        let left_hash = EXPR_TY_HASH
         // β⁴: capture LHS shadow
         let b4aa_left_vshadow = EXPR_VSHADOW
         let b4aa_left_sshadow = EXPR_SSHADOW
@@ -32428,12 +32694,40 @@ fn compile_additive_a64() with IO, Mut, Panic, Div {
         EXPR_VSHADOW = -1; EXPR_SSHADOW = -1; EXPR_SSHADOW_1 = -1; EXPR_SSHADOW_2 = -1; EXPR_SSHADOW_3 = -1; EXPR_SSHADOW_4 = -1; EXPR_SSHADOW_5 = -1; EXPR_SSHADOW_6 = -1; EXPR_SSHADOW_7 = -1
         emit_push_a64()
         compile_multiplicative_a64()
+        let right_ty = EXPR_TY
+        let right_hash = EXPR_TY_HASH
         // β⁴: capture RHS shadow
         let b4aa_right_vshadow = EXPR_VSHADOW
         let b4aa_right_sshadow = EXPR_SSHADOW
         let b4aa_right_sshadow_1 = EXPR_SSHADOW_1
         let b4aa_right_sshadow_2 = EXPR_SSHADOW_2
         let b4aa_right_sshadow_3 = EXPR_SSHADOW_3
+        let left_has_knowledge = knowledge_hash_is(left_hash)
+        let right_has_knowledge = knowledge_hash_is(right_hash)
+        if left_has_knowledge || right_has_knowledge {
+            // LHS is still on the stack (pushed above, not yet popped) and
+            // x0 holds the freshly-compiled RHS — exactly the stack shape
+            // compile_knowledge_addsub_a64 expects (it does its own pop).
+            var left_inner_ty = left_ty
+            var left_inner_hash = left_hash
+            if left_has_knowledge {
+                left_inner_ty = knowledge_hash_inner_ty(left_hash)
+                left_inner_hash = knowledge_hash_inner_hash(left_hash)
+            }
+            var right_inner_ty = right_ty
+            var right_inner_hash = right_hash
+            if right_has_knowledge {
+                right_inner_ty = knowledge_hash_inner_ty(right_hash)
+                right_inner_hash = knowledge_hash_inner_hash(right_hash)
+            }
+            if left_inner_ty != 0 && right_inner_ty != 0 {
+                if ty_is_numeric(left_inner_ty) == false || ty_is_numeric(right_inner_ty) == false || ty_eq(left_inner_ty, left_inner_hash, right_inner_ty, right_inner_hash) == false {
+                    tc_error(op_tok, "Knowledge arithmetic requires matching numeric operands")
+                }
+            }
+            compile_knowledge_addsub_a64(op_tok, op, left_ty, left_hash, right_ty, right_hash)
+            continue
+        }
         emit_pop_x1_a64()
         if left_f64 == 1 {
             if op == 17 { emit_f64_binop_a64(0x1E612800) }


### PR DESCRIPTION
## Summary

Picked up the last of the four aarch64 `native_runtime` failures left out of scope after the two preceding a64 dispatches (#640, #642): `a + b` on two `Knowledge<f64>` values segfaults on aarch64.

**Root cause #1**: `compile_additive_a64()`/`compile_multiplicative_a64()` never checked `knowledge_hash_is()` at all and had no dispatch to a `Knowledge<T>`-aware codegen path — `a + b` fell into plain scalar addition of the operands' raw **pointers**, producing a garbage result that segfaulted on the next `.value`/`.uncertainty`/`.confidence` access. `compile_knowledge_addsub_x86()`/`compile_knowledge_muldiv_x86()` (x86-64's Knowledge arithmetic codegen) had no aarch64 twins at all.

**Fix**: ported both functions instruction-for-instruction, plus their primitives (`emit_load_operand_value/variance/confidence_a64`, `emit_i64_to_f64_in_x0_a64`, `emit_min_positive_f64_bits_a64` — branch-based, reusing the already-proven conditional-branch-and-patch pattern rather than an untested CSEL encoding). `emit_f64_binop_a64` (already existing) covers add/sub/mul/div uniformly. Wired the dispatch into both caller functions, adding the `left_ty`/`left_hash`/`right_ty`/`right_hash`/`op_tok` captures they never had.

**Root cause #2 (discovered while verifying #1, pre-existing, unrelated)**: fixing #1 alone didn't make the test pass — `sum.uncertainty` read back as `0`. Isolated with a minimal repro to a **plain `measure()`-created value with no arithmetic at all**, confirming this predates and is independent of the arithmetic fix. `compile_postfix_a64()`'s Knowledge<T> field-read branch had `value`/`variance`/`confidence` cases but no `uncertainty` case — it fell through to a non-fatal `tc_error()` that left the result untouched, silently reading as `0`. Added the missing case (`.uncertainty` = `sqrt(variance)`, since variance — not the surface uncertainty — is what's actually stored), plus a new `emit_sqrt_builtin_a64()` primitive.

**Debugging methodology**: both root causes isolated via the `qemu-aarch64-static` local-repro technique from the previous two dispatches. Distinguishing "my new arithmetic is wrong" from "the arithmetic is right but misread downstream" required temporarily injecting register-preserving runtime print calls directly into the generated machine code — confirmed the stored variance bit pattern (0.09+0.16=0.25) was correct before ever suspecting the field-read side.

Full writeup: `docs/audit/LEAN_SINGLE_A64_KNOWLEDGE_ARITHMETIC_2026-07-05.md`.

## Test plan

- [x] Both CI-reported failures (`epistemic_ops_42`, `epistemic_propagation`, cross-compiled to `aarch64-linux` + run under `qemu-aarch64-static`): now pass (exit 42 / exit 0, was SIGSEGV)
- [x] Full multiply/divide variance chain-rule math verified against the original x86-64 test's exact numeric assertions (`prod.value≈200.0`, `prod.uncertainty≈7.211`, `quot.value≈0.5`, `quot.uncertainty≈0.018`) — all pass on aarch64
- [x] `.uncertainty` on a plain `measure()`-created value (no arithmetic): now correct, independent regression check
- [x] Full aarch64 `native_runtime` manifest (99 cases): **99 pass / 0 fail** — up from 97/2. All 4 originally-failing tests across this three-PR aarch64 arc (#640, #642, this one) now closed
- [x] Full x86-64 regression suite: 1314 pass / 0 fail / 124 known failures / 689 skip / 2127 total — **exact match to baseline** (fix is aarch64-only, purely additive)
- [x] `bash scripts/dev/check_docs_registry.sh` / `check_docs_consistency.sh` pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>