### PR TITLE
chore(website): disable Vercel git auto-deploy

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,5 +3,8 @@
   "framework": "astro",
   "buildCommand": "npm run build",
   "installCommand": "npm ci",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": false
+  }
 }


### PR DESCRIPTION
## Summary
- Sets `git.deploymentEnabled: false` in `website/vercel.json` to stop Vercel from automatically building/deploying a preview on every push and PR.
- Manual deployment via `.github/workflows/vercel-website.yml` (workflow_dispatch, or `website-v*` tags) is unaffected.

## Why
Repo-wide cost control — every PR currently triggers an automatic Vercel preview build/deploy regardless of whether the website changed.

## Test plan
- [x] JSON is valid, matches Vercel's documented `git.deploymentEnabled` config key
- [ ] Confirm on Vercel's side that auto-deploys stop firing on the next PR after merge

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>