### PR TITLE
docs(exact): adopt generic <F> for i64 (==concrete); [struct;N] mul-loop miscompiles (#651)

### DIFF
--- a/docs/EXACT_CORE.md
+++ b/docs/EXACT_CORE.md
@@ -205,10 +205,35 @@ i64-range coefficients; the unbounded-width integration is a compiler-capacity r
   minimal repros in `docs/handoff/souc_v0800_defects.md`; issues #637 (segfault), #638 (`<<`→i64),
   #639 (`match`).
 
-## The `<F>` migration target
+## The `<F>` migration target — UNBLOCKED for scalar `F`, struct-`F` still walled
 
-The generic `stdlib/algebra/cayley_dickson_exact.sio` (`CDElementExact<F: ExactRing>`) is a
-**design skeleton** — it needs four compiler features (generic-struct-return **#1**, bodyless
-trait-method-sig parsing **2a**, `impl Trait for Type` **2b**, trait-bounded dispatch **#3**), all
-commissioned in `docs/handoff/*`. The concrete-i64 engine is exactly what it monomorphizes to, so
-nothing is wasted; the science ships now on `i64`. See `docs/handoff/exact_engine_prereqs.md`.
+The four compiler features the generic engine needed (generic-struct-return **#1**, bodyless
+trait-method-sig parsing **2a**, `impl Trait for Type` **2b**, trait-bounded dispatch **#3**) **all
+landed 2026-07-06** on the fable5 compiler-generic-F lane (PR #650, merge commit `2adb8f061`,
+against the prompt `docs/handoff/compiler_generic_F_engine_unblock_prompt.md`). The generic engine
+`stdlib/algebra/cayley_dickson_exact.sio` (`CDElementExact<F: ExactRing>`) now **compiles and runs**:
+
+- **`F = i64` — adopted and proven equivalent.** `tests/run-pass/cd_exact_generic_i64.sio` proves the
+  canonical ZD pair `(e₃+e₁₀)(e₆−e₁₅)=0` (16× `COMP 0`), and `cd_exact_generic_vs_concrete.sio`
+  shows the generic engine reproduces `cayley_dickson_exact_i64.sio` **byte-for-byte**
+  (`BYTECOMPARE PASS`). The concrete-i64 engine and the generic-at-i64 engine are now
+  cross-certified against each other; the concrete one is retained as the load-bearing i64 path.
+- **`F = Rational` / `F = BigInt` (struct coefficients) — blocked, but NOT by generics (issue #651).**
+  The engine over a *struct* coefficient type compiles and runs but is **wrong**: the `[Rational;N]`
+  multiply-accumulate loop miscompiles — a **deterministic garbage** value at N=16
+  (`c[0]=4206741/1`; correct `1/1`) and a **SIGSEGV** at N=2048. Crucially this reproduces with **no
+  generics at all** (a plain concrete `[Rational;16]` CD-multiply loop is equally wrong), and every
+  sub-operation in isolation is correct (single constant-index RMW, variable-index read, variable-indexed
+  by-value arg, one loop iteration) — only the full nested accumulation loop over array-of-struct
+  temporaries corrupts. So it is a `[struct;N]` **aggregate/struct-temporary codegen bug** (same family
+  as #643/D6 struct value-copy corruption; **distinct** from #637, which is a cross-module
+  arity-mismatch *compiler* SIGSEGV). Scalar arrays (`[i64;N]`) are unaffected. Repro + full isolation:
+  `docs/handoff/repros/d8_generic_struct_F_mul_segv.sio`.
+
+**Net:** the old `<F>` residual (no generics at all) is *closed* — generics work end-to-end for scalar
+`F`. The exact CD product over **unbounded ℚ for all 16 components** — which needs `F = BigInt`/`BigRational`,
+i.e. array-of-struct coefficients — remains open, blocked by the filed non-generic `[struct;N]`
+aggregate-loop codegen bug (#651), not by the math, the parser, or the generics. Until #651 lands,
+unbounded-ℚ work continues via the common-denominator **integer** representation
+(`sedenion_cd_full16_q.sio`, `[i64;N]`, no array-of-struct — unaffected). See
+`docs/handoff/exact_engine_prereqs.md`.

--- a/docs/handoff/repros/d8_generic_struct_F_mul_segv.sio
+++ b/docs/handoff/repros/d8_generic_struct_F_mul_segv.sio
@@ -1,0 +1,60 @@
+// D8 (issue #651) — souc miscompiles the [Rational;N] array-of-struct multiply-accumulate loop.
+// NOT a run-pass test (kept out of tests/run-pass/ so CI never globs it): it prints a WRONG value.
+//
+// This is NOT a generics bug. The generic exact-CD engine works perfectly for scalar F=i64
+// (cd_exact_generic_vs_concrete.sio: byte-identical to the concrete engine), and the SAME generic
+// RMW loop over [i64;16] is correct. The defect is the [Rational;N] (array-of-2-field-struct)
+// Cayley-Dickson accumulation loop below — reproduced here with NO generics at all.
+//
+// Symptom scaling (stage2 souc, post-#650 main):
+//   * N=16   → WRONG value (c[0] ≈ 4.2e6/1, varies run-to-run — corrupted memory; correct is 1/1).
+//   * N=2048 → SIGSEGV (exit 139) — the miscomputed access walks out of bounds.
+// Isolation — every SUB-operation is correct; only the full nested loop corrupts:
+//   * single constant-index RMW on [Rational;2048]           → correct (1/1)
+//   * variable-index READ of a [Rational;16] element         → correct
+//   * variable-indexed struct element as a by-value arg      → correct
+//   * ONE variable-index RMW iteration                       → correct
+//   * the full 16x16 accumulate loop (below)                 → WRONG
+// So it is a struct-temporary / aggregate corruption that accumulates across a nested loop of
+// struct-returning calls writing back into an array-of-struct slot.
+//
+// Relation to other defects: DISTINCT from #637 (that is a *cross-module arity-mismatch* compiler
+// SIGSEGV during lowering; this is single-module, a *runtime* wrong-value that only segfaults at
+// large N). Same family as #643 / D6 (struct value-copy aliasing/corruption). Scalar arrays
+// ([i64;N]) are unaffected — the concrete-i64 engine uses [i64;2048] with this exact loop correctly.
+//
+// Impact: blocks the exact CD product over Rational / BigInt, i.e. all-16-components over unbounded ℚ
+// (the exact-algebra lane's last residual). Unbounded-ℚ meanwhile uses the common-denominator integer
+// representation (sedenion_cd_full16_q.sio), which is [i64;N] — no array-of-struct — and is unaffected.
+use math::rational::{Rational, rat_zero, rat_one, rat_add, rat_mul}
+
+struct SmallR { c: [Rational; 16] }   // array-of-struct; the [i64;16] analogue is correct
+
+// e1*e1 over the sedenion basis, sign dropped for minimality (idx = i XOR j, no cd_sigma).
+fn sr_mul(a: SmallR, b: SmallR) -> SmallR with Mut, Panic, Div {
+    var r = SmallR { c: [rat_zero(); 16] }
+    var i: i32 = 0
+    while i < 16 {
+        var j: i32 = 0
+        while j < 16 {
+            let idx = i ^ j
+            r.c[idx as usize] = rat_add(r.c[idx as usize], rat_mul(a.c[i as usize], b.c[j as usize]))
+            j = j + 1
+        }
+        i = i + 1
+    }
+    r
+}
+
+fn main() with IO, Mut, Panic, Div {
+    var a = SmallR { c: [rat_zero(); 16] }
+    a.c[1] = rat_one()
+    var b = SmallR { c: [rat_zero(); 16] }
+    b.c[1] = rat_one()
+    let p = sr_mul(a, b)                       // e1*e1: only idx=0 accumulates 1*1 = 1
+    print("c0=")
+    print_int(p.c[0 as usize].num)             // observed ~4.2e6 (garbage, varies); correct is 1
+    print("/")
+    print_int(p.c[0 as usize].den)
+    print("\n")
+}

--- a/stdlib/algebra/cayley_dickson_exact.sio
+++ b/stdlib/algebra/cayley_dickson_exact.sio
@@ -15,11 +15,21 @@
 //! (stdlib/math/rational.sio) is only for norm-bearing observables and is a secondary target.
 //!
 //! ─────────────────────────────────────────────────────────────────────────────
-//! STATUS: COMPILES AND RUNS on the lean_single engine (the four compiler
-//! prerequisites — #1 generic-struct-return, 2a bodyless trait-method sigs,
-//! 2b `impl Trait for Type`, #3 trait-bounded dispatch — landed 2026-07-06 on
-//! the fable5 compiler-generic-F lane, plus the mono-mangle separator fix that
+//! STATUS: COMPILES AND RUNS for scalar F (the four compiler prerequisites —
+//! #1 generic-struct-return, 2a bodyless trait-method sigs, 2b `impl Trait for
+//! Type`, #3 trait-bounded dispatch — landed 2026-07-06 on the fable5 compiler-
+//! generic-F lane, PR #650 / `2adb8f061`, plus the mono-mangle separator fix that
 //! lets this file coexist with the hand-monomorphized `*_i64` sibling).
+//!   * F = i64  → WORKS, byte-identical to cayley_dickson_exact_i64.sio (verified).
+//!   * F = Rational / BigInt (struct F) → blocked, but NOT by generics: the
+//!     [Rational;N] multiply-accumulate loop miscompiles (garbage at N=16, SIGSEGV
+//!     at N=2048). Reproduces with NO generics (a plain concrete [Rational;16] CD
+//!     loop is equally wrong); every sub-op works in isolation — only the full
+//!     nested accumulation loop over array-of-struct temporaries corrupts. A
+//!     [struct;N] aggregate codegen bug (#643/D6 family; distinct from #637).
+//!     Filed as issue #651; repro docs/handoff/repros/d8_generic_struct_F_mul_segv.sio.
+//!     Do NOT use this engine over a struct F until #651 lands — use the common-
+//!     denominator integer path (sedenion_cd_full16_q.sio, [i64;N]) for unbounded-ℚ.
 //! Madaros-engine support is a separate pending track (M1-M3).
 //! ─────────────────────────────────────────────────────────────────────────────
 //! Acceptance evidence (all output-verified, cross-checked vs the concrete engine):
@@ -66,6 +76,10 @@ impl ExactRing for i64 {
 }
 
 // F = Rational — secondary field (norm-bearing observables), i64-bounded (no i128/bigint).
+// ⚠ WORKS for construction/dispatch, but cd_mul_exact<Rational> miscompiles (issue #651): the
+// [Rational;N] multiply-accumulate loop corrupts (garbage at N=16, SIGSEGV at N=2048). NOT a generics
+// bug — reproduces with plain concrete [Rational;16] too; it's a [struct;N] aggregate codegen defect
+// (#643/D6 family). Not usable end-to-end until #651 lands. The impl is kept so the shape is ready.
 impl ExactRing for Rational {
     fn er_add(self, o: Self) -> Self { rat_add(self, o) }
     fn er_sub(self, o: Self) -> Self { rat_sub(self, o) }


### PR DESCRIPTION
## Summary
Follow-up to fable5's **#650** (`2adb8f061`), which landed the four generic-`<F>` prereqs against `docs/handoff/compiler_generic_F_engine_unblock_prompt.md` (landed via #649). Records the **empirical adoption** of the generic exact Cayley–Dickson engine and one honest finding (root cause **corrected** after running the size/scalar-vs-struct discriminators — see #651).

## Verified (stage2 souc from a post-#650 `main` run — not the committed `bin/souc`)
- **`F = i64` — adopted, cross-certified.** Generic engine reproduces `cayley_dickson_exact_i64.sio` **byte-for-byte** (`cd_exact_generic_vs_concrete.sio`, `BYTECOMPARE PASS`). The old "no generics at all" residual is **closed** — generics work end-to-end for scalar `F`.
- **`F = Rational` / `BigInt` — blocked, but NOT by generics (#651).** The `[Rational;N]` multiply-accumulate loop miscompiles: **garbage at N=16**, **SIGSEGV at N=2048**. Reproduces with **no generics** (plain concrete `[Rational;16]` loop equally wrong; the `[i64;16]` generic loop is correct). Every sub-op works in isolation — only the full nested accumulate loop over array-of-struct temporaries corrupts. A `[struct;N]` aggregate codegen defect (**#643/D6 family**; **distinct from #637** = cross-module arity-mismatch *compiler* SIGSEGV).

## Changes (docs + repro only — no engine/behavior change)
- `docs/EXACT_CORE.md` — `<F>` migration section set to the real state (generics adopted for scalar F; struct-coeff/unbounded-ℚ waits on the non-generic #651; unbounded-ℚ meanwhile via the common-denominator `[i64;N]` path).
- `stdlib/algebra/cayley_dickson_exact.sio` — status header + `impl ExactRing for Rational` caveat.
- `docs/handoff/repros/d8_generic_struct_F_mul_segv.sio` — non-generic minimal repro + full isolation (filed as **#651**). Not under `tests/run-pass/` (CI globs only that dir), so it never false-fails.

## Net
The exact CD product over **unbounded ℚ for all 16 components** (needs `F=BigInt`/`BigRational` = array-of-struct coeffs) is the one open residual — now blocked by the filed non-generic `[struct;N]` aggregate-loop bug **#651**, not the parser, the math, or the generics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)