### PR TITLE
feat(madaros): generic <F> M-track phase 1 — trait/impl grammar, AST specializer, println i64 fix, #638

### DIFF
--- a/self-hosted/check/compat.sio
+++ b/self-hosted/check/compat.sio
@@ -953,38 +953,42 @@ pub fn binary_result_type(op: BinaryOp, left: TypeEntry, right: TypeEntry) -> Ty
             }
         }
 
-        // Bitwise: both i64, result = i64
+        // Bitwise: both integer, result = LEFT operand type (#638: the old always-i64
+        // result poisoned every i32 shift/mask context, e.g. `let half = 1 << (bits-1)`
+        // with bits: i32 — the whole f64 Cayley-Dickson layer failed to import).
+        // Acceptance domain unchanged (both integer, mixed widths still accepted);
+        // only the RESULT type follows the left operand, mirroring the arithmetic arms.
         BinaryOp::OpBitAnd => {
             if is_integer_type(left) && is_integer_type(right) {
-                ty_i64()
+                left
             } else {
                 ty_error()
             }
         }
         BinaryOp::OpBitOr => {
             if is_integer_type(left) && is_integer_type(right) {
-                ty_i64()
+                left
             } else {
                 ty_error()
             }
         }
         BinaryOp::OpBitXor => {
             if is_integer_type(left) && is_integer_type(right) {
-                ty_i64()
+                left
             } else {
                 ty_error()
             }
         }
         BinaryOp::OpShl => {
             if is_integer_type(left) && is_integer_type(right) {
-                ty_i64()
+                left
             } else {
                 ty_error()
             }
         }
         BinaryOp::OpShr => {
             if is_integer_type(left) && is_integer_type(right) {
-                ty_i64()
+                left
             } else {
                 ty_error()
             }

--- a/self-hosted/check/specializer.sio
+++ b/self-hosted/check/specializer.sio
@@ -1,0 +1,1196 @@
+// AST-level generic-fn specializer (monomorphizer).
+//
+// Runs AFTER parsing, BEFORE type checking. The parser currently discards a
+// fn's `<T, U>` type-param header (parse_type_param_header consumes the
+// tokens without storing them on FnDef — FnDef has no type_params field).
+// So "is this fn generic" is recovered structurally: any single-segment,
+// single-UPPERCASE-letter TypeNamed in a fn's params/return type that is not
+// a locally declared struct/enum name is treated as a free type variable
+// (a conservative variant of check.sio's
+// type_is_unresolved_type_param_in_tables/collect_fn_generic_names_*).
+// The pass is only hooked into the single-module (no imports) pipeline
+// lanes, so imported type names can never be misread as type variables.
+//
+// Algorithm (SAME-NAME single-instantiation scheme):
+//   1. Collect every top-level ItemFn with >=1 free type var into a table;
+//      collect generic struct templates (StructDef has real type_params).
+//   2. READ-ONLY scan of all non-generic fn bodies for Call exprs carrying
+//      turbofish type_args whose callee matches a collected generic fn AND
+//      whose arg count matches the fn's free-var count. Count mismatches
+//      leave the call site untouched and pin the template so the checker's
+//      own E010 still fires.
+//   3. First matching instantiation of a template: clone + substitute the
+//      FnDef, KEEPING THE TEMPLATE'S OWN NAME, and scan the clone's body
+//      (transitive turbofish calls, incl. self-recursion; the per-slot
+//      instantiation hash guarantees termination). A SECOND instantiation
+//      with different type args POISONS the template back to baseline
+//      behavior. Call sites are NEVER rewritten: the checker ignores
+//      turbofish on non-generic signatures (generic_names comes out empty
+//      at its call-check), and the lowering has no generics concept.
+//   4. Finalize: replace each single-instantiation template item with its
+//      concrete same-name clone; keep poisoned/still-referenced templates
+//      verbatim; drop never-referenced templates. Generic-struct instances
+//      (CDExact<i64> -> struct CDExact__i64 items) referenced from clone
+//      signatures/bodies are appended, with type annotations and struct
+//      literals inside clones rewritten to the mangled concrete names
+//      (the checker's signature lowering erases generic struct args, and
+//      its literal inference is TyNamed-only, so only concrete names
+//      survive both).
+//
+// Backend-safety notes (this file runs inside the lean_single-compiled
+// Madaros binary, so it must stay inside the proven-safe subset):
+//   - No Name/struct-typed GLOBAL arrays: global aggregate array elements
+//     read back corrupted (witnessed on this exact pass).
+//   - No Option<Box<...>> globals either: a global Option<Box<Node>> does
+//     not round-trip (store-then-load returns garbage; witnessed with a
+//     standalone probe). The ONLY safe global state is flat i64/bool
+//     arrays + scalars (check/mod.sio sidecar precedent).
+//   - Heap state therefore lives behind raw pointers from heap_alloc,
+//     accessed via *mut field reads/writes and parked in i64 globals —
+//     the check/mod.sio *mut-Checker-spine pattern (probe-validated for
+//     both scalar and big-aggregate fields, including Option<Box<T>>
+//     fields THROUGH the *mut node).
+//   - Type-param and dedup lookups compare ast_name_hash i64 values, the
+//     module_frontend hash-table pattern.
+
+module check::specializer
+
+use parser::ast::*
+use parser::parser::{dummy_type_expr}
+use io::env::{read_env}
+
+// ============================================================
+// Small fixed-capacity LOCAL helper structs (never stored in globals)
+// ============================================================
+
+struct SpecKnownNames { names: [Name; 32], count: i64 }
+struct SpecNameBuf { names: [Name; 4], count: i64 }
+
+// ============================================================
+// Generic-fn table: heap_alloc'd all-scalar nodes reached through raw
+// pointers parked in a flat i64 global array (*mut spine pattern).
+// ============================================================
+
+struct SpecGfNode {
+    name_hash: i64,
+    tp_count: i64,
+    tp_h0: i64,
+    tp_h1: i64,
+    tp_h2: i64,
+    tp_h3: i64,
+    fd: Option<Box<FnDef>>,
+}
+
+// Generic STRUCT template node (StructDef carries real type_params, so no
+// heuristic recovery is needed for structs).
+struct SpecStNode {
+    name_hash: i64,
+    tp_count: i64,
+    tp_h0: i64,
+    tp_h1: i64,
+    tp_h2: i64,
+    tp_h3: i64,
+    sd: Option<Box<StructDef>>,
+}
+
+// Substitution context: the ACTIVE type-param set during one clone's
+// substitution (either a generic fn's recovered params or a generic
+// struct's declared params). Reached via raw pointer like the table nodes.
+struct SpecCtxNode {
+    tp_count: i64,
+    h0: i64,
+    h1: i64,
+    h2: i64,
+    h3: i64,
+}
+
+// Chain node for freshly instantiated items (Item stored inline in the
+// heap node; `next` is a raw pointer, 0 = end of chain).
+struct SpecItemNode {
+    it: Item,
+    next: i64,
+}
+
+// Staging wrappers: WHOLE-struct stores through *mut ((*q) = v) are
+// miscompiled (probe-witnessed: destination stays zeroed), while FIELD
+// stores through *mut ((*q).e = v) work. All big AST values are therefore
+// staged inside single-field wrapper nodes.
+struct SpecExprStage { e: Expr }
+struct SpecStmtStage { s: Stmt }
+struct SpecFnDefStage { fd: FnDef }
+struct SpecStructDefStage { sd: StructDef }
+
+// Mutable driver state. Reset unconditionally at the top of every
+// specialize_generics() call — this pass may run more than once per
+// process (preflight + IR-lowering both invoke it on independently
+// re-parsed item lists), so no state may leak across invocations.
+var SPEC_GF_COUNT: i64 = 0
+var SPEC_GF_PTRS: [i64; 16] = [0; 16]
+var SPEC_GF_NEEDED: [bool; 16] = [false; 16]
+var SPEC_GF_INST_HASH: [i64; 16] = [0; 16]
+var SPEC_GF_POISONED: [bool; 16] = [false; 16]
+var SPEC_GF_CLONE_PTR: [i64; 16] = [0; 16]
+var SPEC_ST_COUNT: i64 = 0
+var SPEC_ST_PTRS: [i64; 16] = [0; 16]
+var SPEC_EMITTED_HASHES: [i64; 64] = [0; 64]
+var SPEC_EMITTED_COUNT: i64 = 0
+var SPEC_EXTRA_HEAD: i64 = 0
+
+fn spec_reset_state() with Mut {
+    SPEC_EMITTED_COUNT = 0
+    SPEC_EXTRA_HEAD = 0
+    var i: i64 = 0
+    while i < 16 {
+        SPEC_GF_PTRS[i as usize] = 0
+        SPEC_GF_NEEDED[i as usize] = false
+        SPEC_GF_INST_HASH[i as usize] = 0
+        SPEC_GF_POISONED[i as usize] = false
+        SPEC_GF_CLONE_PTR[i as usize] = 0
+        SPEC_ST_PTRS[i as usize] = 0
+        i = i + 1
+    }
+    SPEC_GF_COUNT = 0
+    SPEC_ST_COUNT = 0
+}
+
+// ============================================================
+// Name / string helpers
+// ============================================================
+
+fn spec_name_to_string(name: Name) -> string with Mut, Panic, Div {
+    var buf: [i8; 128] = name.buf
+    str_from_bytes(buf, name.len)
+}
+
+fn spec_path_single_name(path: AstPath) -> Name {
+    if path.seg_count != 1 { return empty_name() }
+    Name { buf: path.segments.head_buf, len: path.segments.head_len }
+}
+
+// ============================================================
+// Known type names (structs/enums declared in this item list)
+// ============================================================
+
+fn spec_known_names_has(kn: SpecKnownNames, n: Name) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < kn.count {
+        if name_eq(kn.names[i as usize], n) { return true }
+        i = i + 1
+    }
+    false
+}
+
+fn spec_known_names_push(kn: SpecKnownNames, n: Name) -> SpecKnownNames with Mut, Panic, Div {
+    var out = kn
+    if out.count < 32 && !spec_known_names_has(out, n) {
+        out.names[out.count as usize] = n
+        out.count = out.count + 1
+    }
+    out
+}
+
+fn spec_collect_known_names(items: Option<Box<ItemList>>, acc: SpecKnownNames) -> SpecKnownNames with Mut, Panic, Div {
+    match items {
+        None => acc
+        Some(list) => {
+            var out = acc
+            let it = (*list).head
+            if it.kind == ItemKind::ItemStruct || it.kind == ItemKind::ItemEnum {
+                out = spec_known_names_push(out, it.name)
+            }
+            spec_collect_known_names((*list).tail, out)
+        }
+    }
+}
+
+// ============================================================
+// Free-type-variable detection
+// ============================================================
+
+// A candidate type parameter must be a single UPPERCASE letter (T, U, F, K,
+// V, ...). The single-letter restriction keeps stdlib named types (Option,
+// Box, ...) from being misread as free type variables; generic fns with
+// multi-character param names simply stay on the baseline checker path.
+fn spec_type_is_free_var(te: TypeExpr, known: SpecKnownNames) -> bool with Mut, Panic, Div {
+    if te.kind != TypeExprKind::TypeNamed { return false }
+    if te.path.seg_count != 1 { return false }
+    let seg = spec_path_single_name(te.path)
+    if seg.len != 1 { return false }
+    let c0 = seg.buf[0] as i64
+    if c0 < 65 || c0 > 90 { return false }
+    if spec_known_names_has(known, seg) { return false }
+    true
+}
+
+fn spec_name_buf_has(buf: SpecNameBuf, n: Name) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < buf.count {
+        if name_eq(buf.names[i as usize], n) { return true }
+        i = i + 1
+    }
+    false
+}
+
+fn spec_name_buf_push(buf: SpecNameBuf, n: Name) -> SpecNameBuf with Mut, Panic, Div {
+    var out = buf
+    if out.count < 4 && !spec_name_buf_has(out, n) {
+        out.names[out.count as usize] = n
+        out.count = out.count + 1
+    }
+    out
+}
+
+fn spec_collect_free_vars_from_type(te: TypeExpr, known: SpecKnownNames, buf: SpecNameBuf) -> SpecNameBuf with Mut, Panic, Div {
+    var out = buf
+    if spec_type_is_free_var(te, known) {
+        out = spec_name_buf_push(out, spec_path_single_name(te.path))
+    }
+    match te.inner {
+        Some(inner) => out = spec_collect_free_vars_from_type(*inner, known, out)
+        None => {}
+    }
+    match te.type_args {
+        Some(list) => out = spec_collect_free_vars_from_type_list(*list, known, out)
+        None => {}
+    }
+    out
+}
+
+fn spec_collect_free_vars_from_type_list(list: TypeExprList, known: SpecKnownNames, buf: SpecNameBuf) -> SpecNameBuf with Mut, Panic, Div {
+    let with_head = spec_collect_free_vars_from_type(list.head, known, buf)
+    match list.tail {
+        Some(rest) => spec_collect_free_vars_from_type_list(*rest, known, with_head)
+        None => with_head
+    }
+}
+
+fn spec_collect_free_vars_from_params(opt: Option<Box<ParamList>>, known: SpecKnownNames, buf: SpecNameBuf) -> SpecNameBuf with Mut, Panic, Div {
+    match opt {
+        None => buf
+        Some(list) => {
+            let with_head = spec_collect_free_vars_from_type((*list).head.ty, known, buf)
+            spec_collect_free_vars_from_params((*list).tail, known, with_head)
+        }
+    }
+}
+
+fn spec_collect_free_vars_from_fndef(fd: FnDef, known: SpecKnownNames) -> SpecNameBuf with Mut, Panic, Div {
+    var buf = spec_collect_free_vars_from_params(fd.params, known, SpecNameBuf { names: [empty_name(); 4], count: 0 })
+    match fd.return_type {
+        Some(rt) => buf = spec_collect_free_vars_from_type(*rt, known, buf)
+        None => {}
+    }
+    buf
+}
+
+// ============================================================
+// Generic-fn table operations (hash-keyed *mut arena)
+// ============================================================
+
+fn spec_generic_table_find(name: Name) -> i64 with Mut, Panic, Div {
+    let h = ast_name_hash(name)
+    var i: i64 = 0
+    while i < SPEC_GF_COUNT {
+        let p = SPEC_GF_PTRS[i as usize] as *mut SpecGfNode
+        if (*p).name_hash == h {
+            return i
+        }
+        i = i + 1
+    }
+    0 - 1
+}
+
+fn spec_generic_table_tp_count(slot: i64) -> i64 with Mut, Panic, Div {
+    if slot < 0 || slot >= SPEC_GF_COUNT { return 0 - 1 }
+    let p = SPEC_GF_PTRS[slot as usize] as *mut SpecGfNode
+    (*p).tp_count
+}
+
+// The template FnDef box for a slot (shared pointer, read-only use).
+fn spec_generic_table_fd(slot: i64) -> Option<Box<FnDef>> with Mut, Panic, Div {
+    if slot < 0 || slot >= SPEC_GF_COUNT { return None }
+    let p = SPEC_GF_PTRS[slot as usize] as *mut SpecGfNode
+    (*p).fd
+}
+
+fn spec_tp_hash_at(buf: SpecNameBuf, i: i64) -> i64 with Mut, Panic, Div {
+    if i < buf.count && i < 4 {
+        return ast_name_hash(buf.names[i as usize])
+    }
+    0 - 1
+}
+
+// ============================================================
+// Substitution contexts
+// ============================================================
+
+fn spec_ctx_new(count: i64, h0: i64, h1: i64, h2: i64, h3: i64) -> i64 with Mut, Panic, Div, Alloc {
+    let p = heap_alloc(256) as *mut SpecCtxNode
+    (*p).tp_count = count
+    (*p).h0 = h0
+    (*p).h1 = h1
+    (*p).h2 = h2
+    (*p).h3 = h3
+    p as i64
+}
+
+fn spec_ctx_tp_index(ctx: i64, h: i64) -> i64 with Mut, Panic, Div {
+    if ctx == 0 { return 0 - 1 }
+    let p = ctx as *mut SpecCtxNode
+    if (*p).tp_count > 0 && (*p).h0 == h { return 0 }
+    if (*p).tp_count > 1 && (*p).h1 == h { return 1 }
+    if (*p).tp_count > 2 && (*p).h2 == h { return 2 }
+    if (*p).tp_count > 3 && (*p).h3 == h { return 3 }
+    0 - 1
+}
+
+fn spec_ctx_from_fn_slot(slot: i64) -> i64 with Mut, Panic, Div, Alloc {
+    if slot < 0 || slot >= SPEC_GF_COUNT { return 0 }
+    let p = SPEC_GF_PTRS[slot as usize] as *mut SpecGfNode
+    spec_ctx_new((*p).tp_count, (*p).tp_h0, (*p).tp_h1, (*p).tp_h2, (*p).tp_h3)
+}
+
+fn spec_ctx_from_struct_slot(slot: i64) -> i64 with Mut, Panic, Div, Alloc {
+    if slot < 0 || slot >= SPEC_ST_COUNT { return 0 }
+    let p = SPEC_ST_PTRS[slot as usize] as *mut SpecStNode
+    spec_ctx_new((*p).tp_count, (*p).tp_h0, (*p).tp_h1, (*p).tp_h2, (*p).tp_h3)
+}
+
+// ============================================================
+// Generic-struct template table (*mut arena)
+// ============================================================
+
+fn spec_struct_table_find(name: Name) -> i64 with Mut, Panic, Div {
+    let h = ast_name_hash(name)
+    var i: i64 = 0
+    while i < SPEC_ST_COUNT {
+        let p = SPEC_ST_PTRS[i as usize] as *mut SpecStNode
+        if (*p).name_hash == h {
+            return i
+        }
+        i = i + 1
+    }
+    0 - 1
+}
+
+fn spec_struct_table_tp_count(slot: i64) -> i64 with Mut, Panic, Div {
+    if slot < 0 || slot >= SPEC_ST_COUNT { return 0 - 1 }
+    let p = SPEC_ST_PTRS[slot as usize] as *mut SpecStNode
+    (*p).tp_count
+}
+
+fn spec_struct_table_tp_hash(slot: i64, k: i64) -> i64 with Mut, Panic, Div {
+    if slot < 0 || slot >= SPEC_ST_COUNT { return 0 - 1 }
+    let p = SPEC_ST_PTRS[slot as usize] as *mut SpecStNode
+    if k == 0 { return (*p).tp_h0 }
+    if k == 1 { return (*p).tp_h1 }
+    if k == 2 { return (*p).tp_h2 }
+    if k == 3 { return (*p).tp_h3 }
+    0 - 1
+}
+
+fn spec_struct_table_sd(slot: i64) -> Option<Box<StructDef>> with Mut, Panic, Div {
+    if slot < 0 || slot >= SPEC_ST_COUNT { return None }
+    let p = SPEC_ST_PTRS[slot as usize] as *mut SpecStNode
+    (*p).sd
+}
+
+fn spec_struct_tp_count_of(opt: Option<Box<TypeParamDefList>>) -> i64 with Mut, Panic, Div {
+    match opt {
+        None => 0
+        Some(list) => 1 + spec_struct_tp_count_of((*list).tail)
+    }
+}
+
+fn spec_struct_tp_hash_of(opt: Option<Box<TypeParamDefList>>, n: i64) -> i64 with Mut, Panic, Div {
+    match opt {
+        None => 0 - 1
+        Some(list) => {
+            if n <= 0 {
+                ast_name_hash((*list).head.name)
+            } else {
+                spec_struct_tp_hash_of((*list).tail, n - 1)
+            }
+        }
+    }
+}
+
+fn spec_collect_generic_structs(items: Option<Box<ItemList>>) with Mut, Panic, Div, Alloc {
+    match items {
+        None => {}
+        Some(list) => {
+            let it = (*list).head
+            if it.kind == ItemKind::ItemStruct {
+                match it.struct_def {
+                    Some(sd_box) => {
+                        let tp_count = spec_struct_tp_count_of((*sd_box).type_params)
+                        if tp_count > 0 && tp_count <= 4 && SPEC_ST_COUNT < 16 && spec_struct_table_find(it.name) < 0 {
+                            let slot = SPEC_ST_COUNT
+                            let p = heap_alloc(4096) as *mut SpecStNode
+                            (*p).name_hash = ast_name_hash(it.name)
+                            (*p).tp_count = tp_count
+                            (*p).tp_h0 = spec_struct_tp_hash_of((*sd_box).type_params, 0)
+                            (*p).tp_h1 = spec_struct_tp_hash_of((*sd_box).type_params, 1)
+                            (*p).tp_h2 = spec_struct_tp_hash_of((*sd_box).type_params, 2)
+                            (*p).tp_h3 = spec_struct_tp_hash_of((*sd_box).type_params, 3)
+                            (*p).sd = it.struct_def
+                            SPEC_ST_PTRS[slot as usize] = p as i64
+                            SPEC_ST_COUNT = SPEC_ST_COUNT + 1
+                        }
+                    }
+                    None => {}
+                }
+            }
+            spec_collect_generic_structs((*list).tail)
+        }
+    }
+}
+
+fn spec_collect_generic_fns(items: Option<Box<ItemList>>, known: SpecKnownNames) with IO, Mut, Panic, Div, Alloc {
+    match items {
+        None => {}
+        Some(list) => {
+            let it = (*list).head
+            if it.kind == ItemKind::ItemFn {
+                match it.fn_def {
+                    Some(fd_box) => {
+                        let tp = spec_collect_free_vars_from_fndef((*fd_box), known)
+                        if tp.count > 0 && SPEC_GF_COUNT < 16 && spec_generic_table_find(it.name) < 0 {
+                            let slot = SPEC_GF_COUNT
+                            let p = heap_alloc(4096) as *mut SpecGfNode
+                            (*p).name_hash = ast_name_hash(it.name)
+                            (*p).tp_count = tp.count
+                            (*p).tp_h0 = spec_tp_hash_at(tp, 0)
+                            (*p).tp_h1 = spec_tp_hash_at(tp, 1)
+                            (*p).tp_h2 = spec_tp_hash_at(tp, 2)
+                            (*p).tp_h3 = spec_tp_hash_at(tp, 3)
+                            (*p).fd = it.fn_def
+                            SPEC_GF_PTRS[slot as usize] = p as i64
+                            SPEC_GF_NEEDED[slot as usize] = false
+                            SPEC_GF_COUNT = SPEC_GF_COUNT + 1
+                            if spec_trace_enabled() {
+                                print("specializer: registered=")
+                                print(spec_name_to_string(it.name))
+                                print(" slot=")
+                                print_int(spec_generic_table_find(it.name))
+                                print(" tp=")
+                                print_int(spec_generic_table_tp_count(slot))
+                                print("\n")
+                            }
+                        }
+                    }
+                    None => {}
+                }
+            }
+            spec_collect_generic_fns((*list).tail, known)
+        }
+    }
+}
+
+// ============================================================
+// Turbofish type-arg list helpers (work on the parsed list in place;
+// no array-of-TypeExpr copies)
+// ============================================================
+
+fn spec_type_args_count(opt: Option<Box<TypeExprList>>) -> i64 with Mut, Panic, Div {
+    match opt {
+        None => 0
+        Some(list) => 1 + spec_type_args_count((*list).tail)
+    }
+}
+
+fn spec_type_args_nth(opt: Option<Box<TypeExprList>>, n: i64) -> TypeExpr with Mut, Panic, Div, Alloc {
+    match opt {
+        None => dummy_type_expr()
+        Some(list) => {
+            if n <= 0 {
+                (*list).head
+            } else {
+                spec_type_args_nth((*list).tail, n - 1)
+            }
+        }
+    }
+}
+
+fn spec_render_type_name(te: TypeExpr) -> Name with Mut, Panic, Div {
+    if te.kind == TypeExprKind::TypeNamed && te.path.seg_count == 1 {
+        return spec_path_single_name(te.path)
+    }
+    make_name("T")
+}
+
+fn spec_mangle_name(base: Name, targs: Option<Box<TypeExprList>>) -> Name with Mut, Panic, Div {
+    var s = spec_name_to_string(base)
+    var cur = targs
+    var going = true
+    while going {
+        match cur {
+            None => { going = false }
+            Some(list) => {
+                s = str_concat(str_concat(s, "__"), spec_name_to_string(spec_render_type_name((*list).head)))
+                cur = (*list).tail
+            }
+        }
+    }
+    make_name(s)
+}
+
+// ============================================================
+// Type-substitution visitor. Context = (ctx, targs): a type param is any
+// single-segment TypeNamed whose name-hash matches one of the ctx's
+// registered params; it is replaced by the corresponding turbofish arg.
+// Recurses into every TypeExpr-bearing AST slot, including nested turbofish
+// `type_args` on calls inside the body — that is what makes generic-to-
+// generic chaining (the transitive case) resolve correctly.
+// After substitution, a reference to a LOCAL generic struct with concrete
+// args (e.g. Wrapper<i64>) is rewritten to the checker's mangled instance
+// name (Wrapper__i64) and the concrete struct item is emitted — the
+// checker's fn-signature lowering erases generic struct args, so only
+// plain concrete names survive it.
+// ============================================================
+
+fn spec_name_to_path(n: Name) -> AstPath {
+    AstPath {
+        segments: StringList { head_buf: n.buf, head_len: n.len, tail: None },
+        seg_count: 1,
+    }
+}
+
+fn spec_subst_type(te: TypeExpr, ctx: i64, targs: Option<Box<TypeExprList>>) -> TypeExpr with Mut, Panic, Div, Alloc {
+    if te.kind == TypeExprKind::TypeNamed && te.path.seg_count == 1 {
+        let idx = spec_ctx_tp_index(ctx, ast_name_hash(spec_path_single_name(te.path)))
+        if idx >= 0 {
+            return spec_type_args_nth(targs, idx)
+        }
+    }
+    var out = te
+    out.inner = spec_subst_type_opt(te.inner, ctx, targs)
+    out.type_args = spec_subst_type_list_opt(te.type_args, ctx, targs)
+
+    // Local generic struct with (now concrete) args -> mangled instance name.
+    if out.kind == TypeExprKind::TypeNamed && out.path.seg_count == 1 {
+        match out.type_args {
+            Some(al) => {
+                let base = spec_path_single_name(out.path)
+                let st_idx = spec_struct_table_find(base)
+                if st_idx >= 0 && spec_type_args_count(Some(al)) == spec_struct_table_tp_count(st_idx) {
+                    let mangled = spec_get_or_create_struct_instance(st_idx, base, Some(al))
+                    out.path = spec_name_to_path(mangled)
+                    out.type_args = None
+                }
+            }
+            None => {}
+        }
+    }
+    out
+}
+
+fn spec_subst_type_opt(opt: Option<Box<TypeExpr>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<TypeExpr>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(t) => Some(Box::new(spec_subst_type(*t, ctx, targs)))
+    }
+}
+
+fn spec_subst_type_list_opt(opt: Option<Box<TypeExprList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<TypeExprList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => Some(Box::new(TypeExprList { head: spec_subst_type((*list).head, ctx, targs), tail: spec_subst_type_list_opt((*list).tail, ctx, targs) }))
+    }
+}
+
+// In-place substitution over an Expr staged in a heap buffer. Every write
+// goes through the *mut node: direct field writes on big Expr LOCALS are
+// silently dropped by the bundle backend (witnessed via trace), while
+// *mut field writes are its proven-safe path (check/mod.sio spine).
+fn spec_subst_expr_mut(p: *mut SpecExprStage, ctx: i64, targs: Option<Box<TypeExprList>>) with Mut, Panic, Div, Alloc {
+    (*p).e.left = spec_subst_expr_opt((*p).e.left, ctx, targs)
+    (*p).e.right = spec_subst_expr_opt((*p).e.right, ctx, targs)
+    (*p).e.block = spec_subst_block_opt((*p).e.block, ctx, targs)
+    (*p).e.else_expr = spec_subst_expr_opt((*p).e.else_expr, ctx, targs)
+    (*p).e.args = spec_subst_expr_list_opt((*p).e.args, ctx, targs)
+    (*p).e.arms = spec_subst_match_arm_list_opt((*p).e.arms, ctx, targs)
+    (*p).e.fields = spec_subst_struct_field_list_opt((*p).e.fields, ctx, targs)
+    (*p).e.cast_type = spec_subst_type_opt((*p).e.cast_type, ctx, targs)
+    (*p).e.handler_block = spec_subst_block_opt((*p).e.handler_block, ctx, targs)
+    (*p).e.closure_return = spec_subst_type_opt((*p).e.closure_return, ctx, targs)
+    (*p).e.closure_body = spec_subst_expr_opt((*p).e.closure_body, ctx, targs)
+    (*p).e.closure_params = spec_subst_closure_param_list_opt((*p).e.closure_params, ctx, targs)
+    (*p).e.type_args = spec_subst_type_list_opt((*p).e.type_args, ctx, targs)
+
+    // Struct literal of a LOCAL generic struct template inside a substituted
+    // body: `CDExact { ... }` written in a fn generic over F names the
+    // instantiation CDExact<F> — resolvable only when the struct's param
+    // names appear in the active ctx (the common same-name convention).
+    // When every struct param resolves through ctx, rewrite the literal to
+    // the concrete instance name; otherwise leave it for the checker's own
+    // literal-inference path (baseline behavior).
+    if (*p).e.kind == ExprKind::ExprStructLit && (*p).e.path.seg_count == 1 {
+        let base = spec_path_single_name((*p).e.path)
+        let st_idx = spec_struct_table_find(base)
+        if st_idx >= 0 {
+            let st_count = spec_struct_table_tp_count(st_idx)
+            var all_resolved = true
+            var k: i64 = 0
+            while k < st_count {
+                if spec_ctx_tp_index(ctx, spec_struct_table_tp_hash(st_idx, k)) < 0 {
+                    all_resolved = false
+                }
+                k = k + 1
+            }
+            if all_resolved && st_count > 0 {
+                // Build the concrete arg list in param order.
+                var args_list: Option<Box<TypeExprList>> = None
+                var r: i64 = st_count - 1
+                while r >= 0 {
+                    let pick = spec_ctx_tp_index(ctx, spec_struct_table_tp_hash(st_idx, r))
+                    args_list = Some(Box::new(TypeExprList { head: spec_type_args_nth(targs, pick), tail: args_list }))
+                    r = r - 1
+                }
+                spec_get_or_create_struct_instance(st_idx, base, args_list)
+                // Recompute the mangled name AFTER the deep instantiation
+                // call (Name values held across deep calls arrive corrupted).
+                var args_list2: Option<Box<TypeExprList>> = None
+                var r2 = spec_struct_table_tp_count(st_idx) - 1
+                while r2 >= 0 {
+                    let pick2 = spec_ctx_tp_index(ctx, spec_struct_table_tp_hash(st_idx, r2))
+                    args_list2 = Some(Box::new(TypeExprList { head: spec_type_args_nth(targs, pick2), tail: args_list2 }))
+                    r2 = r2 - 1
+                }
+                let base2 = spec_path_single_name((*p).e.path)
+                (*p).e.path = spec_name_to_path(spec_mangle_name(base2, args_list2))
+            }
+        }
+    }
+}
+
+fn spec_subst_expr_opt(opt: Option<Box<Expr>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<Expr>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(b) => {
+            let q = heap_alloc(32768) as *mut SpecExprStage
+            let tmp = *b
+            (*q).e = tmp
+            spec_subst_expr_mut(q, ctx, targs)
+            Some(Box::new((*q).e))
+        }
+    }
+}
+
+fn spec_subst_block(b: Block, ctx: i64, targs: Option<Box<TypeExprList>>) -> Block with Mut, Panic, Div, Alloc {
+    Block { stmts: spec_subst_stmt_list_opt(b.stmts, ctx, targs), span: b.span }
+}
+
+fn spec_subst_block_opt(opt: Option<Box<Block>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<Block>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(b) => Some(Box::new(spec_subst_block(*b, ctx, targs)))
+    }
+}
+
+fn spec_subst_stmt_list_opt(opt: Option<Box<StmtList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<StmtList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => {
+            let sp = heap_alloc(16384) as *mut SpecStmtStage
+            let tmp = (*list).head
+            (*sp).s = tmp
+            (*sp).s.ty = spec_subst_type_opt((*sp).s.ty, ctx, targs)
+            (*sp).s.expr = spec_subst_expr_opt((*sp).s.expr, ctx, targs)
+            (*sp).s.target = spec_subst_expr_opt((*sp).s.target, ctx, targs)
+            Some(Box::new(StmtList { head: (*sp).s, tail: spec_subst_stmt_list_opt((*list).tail, ctx, targs) }))
+        }
+    }
+}
+
+fn spec_subst_expr_list_opt(opt: Option<Box<ExprList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<ExprList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => {
+            let q = heap_alloc(32768) as *mut SpecExprStage
+            let tmp = (*list).head
+            (*q).e = tmp
+            spec_subst_expr_mut(q, ctx, targs)
+            Some(Box::new(ExprList { label: (*list).label, head: (*q).e, tail: spec_subst_expr_list_opt((*list).tail, ctx, targs) }))
+        }
+    }
+}
+
+fn spec_subst_match_arm_list_opt(opt: Option<Box<MatchArmList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<MatchArmList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => {
+            let q = heap_alloc(32768) as *mut SpecExprStage
+            let tmp = (*list).head.body
+            (*q).e = tmp
+            spec_subst_expr_mut(q, ctx, targs)
+            let new_arm = MatchArm {
+                pattern: (*list).head.pattern,
+                guard: spec_subst_expr_opt((*list).head.guard, ctx, targs),
+                body: (*q).e,
+                span: (*list).head.span,
+            }
+            Some(Box::new(MatchArmList { head: new_arm, tail: spec_subst_match_arm_list_opt((*list).tail, ctx, targs) }))
+        }
+    }
+}
+
+fn spec_subst_struct_field_list_opt(opt: Option<Box<StructFieldList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<StructFieldList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => {
+            let q = heap_alloc(32768) as *mut SpecExprStage
+            let tmp = (*list).head.value
+            (*q).e = tmp
+            spec_subst_expr_mut(q, ctx, targs)
+            let new_init = StructFieldInit { name: (*list).head.name, value: (*q).e }
+            Some(Box::new(StructFieldList { head: new_init, tail: spec_subst_struct_field_list_opt((*list).tail, ctx, targs) }))
+        }
+    }
+}
+
+fn spec_subst_closure_param(cp: ClosureParam, ctx: i64, targs: Option<Box<TypeExprList>>) -> ClosureParam with Mut, Panic, Div, Alloc {
+    ClosureParam { name: cp.name, ty: spec_subst_type(cp.ty, ctx, targs), span: cp.span }
+}
+
+fn spec_subst_closure_param_list_opt(opt: Option<Box<ClosureParamList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<ClosureParamList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => Some(Box::new(ClosureParamList { head: spec_subst_closure_param((*list).head, ctx, targs), tail: spec_subst_closure_param_list_opt((*list).tail, ctx, targs) }))
+    }
+}
+
+fn spec_subst_param(p: Param, ctx: i64, targs: Option<Box<TypeExprList>>) -> Param with Mut, Panic, Div, Alloc {
+    Param { name: p.name, ty: spec_subst_type(p.ty, ctx, targs), is_self: p.is_self, is_self_mut: p.is_self_mut, span: p.span }
+}
+
+fn spec_subst_param_list_opt(opt: Option<Box<ParamList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<ParamList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => Some(Box::new(ParamList { head: spec_subst_param((*list).head, ctx, targs), tail: spec_subst_param_list_opt((*list).tail, ctx, targs) }))
+    }
+}
+
+
+// ============================================================
+// Struct monomorphization: emit `struct S__i64 { ... }` items so the
+// checker only ever sees concrete named structs in signatures.
+// ============================================================
+
+fn spec_subst_field_list_opt(opt: Option<Box<FieldDefList>>, ctx: i64, targs: Option<Box<TypeExprList>>) -> Option<Box<FieldDefList>> with Mut, Panic, Div, Alloc {
+    match opt {
+        None => None
+        Some(list) => {
+            let f = (*list).head
+            let new_f = FieldDef { name: f.name, ty: spec_subst_type(f.ty, ctx, targs), span: f.span }
+            Some(Box::new(FieldDefList { head: new_f, tail: spec_subst_field_list_opt((*list).tail, ctx, targs) }))
+        }
+    }
+}
+
+fn spec_make_struct_item(name: Name, sd: StructDef) -> Item with Mut, Panic, Div, Alloc {
+    Item {
+        kind: ItemKind::ItemStruct, span: sd.span, visibility: visibility_private(), name: name, fn_def: None,
+        struct_def: Some(Box::new(sd)), enum_def: None, impl_def: None, type_alias_ty: None, policy_def: None,
+        acquisition_policy_def: None, recourse_policy_def: None, decision_policy_def: None, deferral_policy_def: None,
+        transition_policy_def: None, transition_protocol_def: None, monitoring_policy_def: None, alternative_policy_def: None,
+        alternative_frontier_def: None, models_def: None, validation_def: None, audit_def: None, use_path: empty_path(),
+        use_glob: false, use_items: None, effect_def: None, session_decl: None, trait_def: None, algebra_def: None,
+        study_def: None, ontology_def: None,
+    }
+}
+
+fn spec_extra_push_item(it: Item) with Mut, Panic, Div, Alloc {
+    let np = heap_alloc(16384) as *mut SpecItemNode
+    (*np).it = it
+    (*np).next = SPEC_EXTRA_HEAD
+    SPEC_EXTRA_HEAD = np as i64
+}
+
+// Get-or-create a monomorphized struct instance `S__Args` for struct
+// template slot st_idx. Dedup shares the emitted-hash cache; nested
+// generic-struct fields recurse through spec_subst_type (terminating via
+// the same cache).
+fn spec_get_or_create_struct_instance(st_idx: i64, base: Name, targs: Option<Box<TypeExprList>>) -> Name with Mut, Panic, Div, Alloc {
+    let mangled = spec_mangle_name(base, targs)
+    if spec_emitted_has(mangled) { return mangled }
+    spec_emitted_push(mangled)
+
+    match spec_struct_table_sd(st_idx) {
+        None => {}
+        Some(sd_box) => {
+            // Stage the struct clone in a *mut heap node; write the mangled
+            // name before the deep field-substitution call (see fn-instance
+            // note about Name locals across deep calls).
+            let sp = heap_alloc(16384) as *mut SpecStructDefStage
+            let tmp_sd = (*sd_box)
+            (*sp).sd = tmp_sd
+            (*sp).sd.name = mangled
+            (*sp).sd.type_params = None
+            let st_ctx = spec_ctx_from_struct_slot(st_idx)
+            (*sp).sd.fields = spec_subst_field_list_opt((*sp).sd.fields, st_ctx, targs)
+            spec_extra_push_item(spec_make_struct_item((*sp).sd.name, (*sp).sd))
+        }
+    }
+    mangled
+}
+
+// ============================================================
+// Dedup / instantiation cache (name-hash keyed)
+// ============================================================
+
+fn spec_emitted_has(n: Name) -> bool with Mut, Panic, Div {
+    let h = ast_name_hash(n)
+    var i: i64 = 0
+    while i < SPEC_EMITTED_COUNT {
+        if SPEC_EMITTED_HASHES[i as usize] == h { return true }
+        i = i + 1
+    }
+    false
+}
+
+fn spec_emitted_push(n: Name) with Mut, Panic, Div {
+    if SPEC_EMITTED_COUNT < 64 {
+        SPEC_EMITTED_HASHES[SPEC_EMITTED_COUNT as usize] = ast_name_hash(n)
+        SPEC_EMITTED_COUNT = SPEC_EMITTED_COUNT + 1
+    }
+}
+
+fn spec_make_fn_item(name: Name, fd: FnDef) -> Item with Mut, Panic, Div, Alloc {
+    Item {
+        kind: ItemKind::ItemFn, span: fd.span, visibility: visibility_private(), name: name, fn_def: Some(Box::new(fd)),
+        struct_def: None, enum_def: None, impl_def: None, type_alias_ty: None, policy_def: None,
+        acquisition_policy_def: None, recourse_policy_def: None, decision_policy_def: None, deferral_policy_def: None,
+        transition_policy_def: None, transition_protocol_def: None, monitoring_policy_def: None, alternative_policy_def: None,
+        alternative_frontier_def: None, models_def: None, validation_def: None, audit_def: None, use_path: empty_path(),
+        use_glob: false, use_items: None, effect_def: None, session_decl: None, trait_def: None, algebra_def: None,
+        study_def: None, ontology_def: None,
+    }
+}
+
+// Ensure a monomorphized clone of template `base_name` for `targs` exists.
+//
+// SAME-NAME SCHEME: the clone keeps the TEMPLATE\'S OWN NAME and at finalize
+// time REPLACES the template item, so call sites need no rewriting at all
+// (the checker ignores turbofish on non-generic signatures — generic_names
+// comes out empty at check.sio:6323 — and the lowering has no generics
+// concept). This sidesteps the callee-rename Expr-field write that the
+// bundle backend silently drops. A template instantiated with TWO OR MORE
+// distinct type-arg lists is POISONED back to baseline behavior (template
+// kept verbatim, calls untouched).
+//
+// Reserves the instantiation hash BEFORE processing the clone\'s own body so
+// a self-recursive generic fn terminates.
+fn spec_ensure_instance(base_name: Name, targs: Option<Box<TypeExprList>>) with IO, Mut, Panic, Div, Alloc {
+    let gt_idx = spec_generic_table_find(base_name)
+    if gt_idx < 0 { return }
+    if spec_type_args_count(targs) != spec_generic_table_tp_count(gt_idx) { return }
+
+    let inst_hash = ast_name_hash(spec_mangle_name(base_name, targs))
+    if SPEC_GF_INST_HASH[gt_idx as usize] != 0 {
+        if SPEC_GF_INST_HASH[gt_idx as usize] != inst_hash {
+            SPEC_GF_POISONED[gt_idx as usize] = true
+            if spec_trace_enabled() { print("specializer: poisoned (second distinct instantiation)\n") }
+        }
+        return
+    }
+    SPEC_GF_INST_HASH[gt_idx as usize] = inst_hash
+
+    match spec_generic_table_fd(gt_idx) {
+        None => {}
+        Some(fd_box) => {
+            let fp = heap_alloc(32768) as *mut SpecFnDefStage
+            let tmp_fd = (*fd_box)
+            (*fp).fd = tmp_fd
+            let fn_ctx = spec_ctx_from_fn_slot(gt_idx)
+            (*fp).fd.params = spec_subst_param_list_opt((*fp).fd.params, fn_ctx, targs)
+            (*fp).fd.return_type = spec_subst_type_opt((*fp).fd.return_type, fn_ctx, targs)
+            (*fp).fd.body = spec_subst_block((*fp).fd.body, fn_ctx, targs)
+            // Scan the clone body for transitive turbofish instantiations
+            // (read-only walk; no tree mutation).
+            spec_scan_block((*fp).fd.body)
+            let np = heap_alloc(16384) as *mut SpecItemNode
+            (*np).it = spec_make_fn_item((*fp).fd.name, (*fp).fd)
+            (*np).next = 0
+            SPEC_GF_CLONE_PTR[gt_idx as usize] = np as i64
+            if spec_trace_enabled() {
+                print("specializer: clone_ready=")
+                print(spec_name_to_string((*fp).fd.name))
+                print("\n")
+            }
+        }
+    }
+}
+
+// ============================================================
+// Call-site rewriting visitor: finds turbofish Call exprs targeting a
+// collected generic fn and rewrites callee+type_args in place. Mirrors
+// check.sio's call_expr_type_args lookup (type_args lives on the call node
+// itself OR on its callee ident — the parser stamps both).
+// ============================================================
+
+fn spec_call_expr_type_args(e: Expr) -> Option<Box<TypeExprList>> with Mut, Panic, Div {
+    match e.type_args {
+        Some(args) => Some(args)
+        None => {
+            match e.left {
+                Some(callee) => (*callee).type_args
+                None => None
+            }
+        }
+    }
+}
+
+fn spec_call_expr_callee_name(e: Expr) -> Name with Mut, Panic, Div {
+    match e.left {
+        None => empty_name()
+        Some(callee) => {
+            let c = *callee
+            if c.kind == ExprKind::ExprIdent {
+                c.name
+            } else if c.kind == ExprKind::ExprPath && c.path.seg_count == 1 {
+                spec_path_single_name(c.path)
+            } else {
+                empty_name()
+            }
+        }
+    }
+}
+
+// Rewrite a call's callee to the mangled instance name, returning the new
+// callee box. IMPORTANT: this deliberately returns only the small
+// Option<Box<Expr>> — an earlier version returned the whole rewritten Expr
+// and the caller's `out = rewrite(out, ...)` self-assignment silently lost
+// the update (the large-struct SRET self-by-value hazard documented in
+// compiler/main.sio). Callers assign the returned box into out.left and
+// clear out.type_args themselves.
+// Read-only scanner: walks fn bodies looking for turbofish calls that
+// target a collected generic template, instantiating clones as a side
+// effect. NO tree mutation happens here (call sites are deliberately left
+// untouched — see spec_ensure_instance's same-name scheme).
+fn spec_scan_expr_opt(opt: Option<Box<Expr>>) with IO, Mut, Panic, Div, Alloc {
+    match opt {
+        None => {}
+        Some(b) => spec_scan_expr((*b))
+    }
+}
+
+fn spec_scan_expr(e: Expr) with IO, Mut, Panic, Div, Alloc {
+    spec_scan_expr_opt(e.left)
+    spec_scan_expr_opt(e.right)
+    spec_scan_block_opt(e.block)
+    spec_scan_expr_opt(e.else_expr)
+    spec_scan_expr_list_opt(e.args)
+    spec_scan_match_arm_list_opt(e.arms)
+    spec_scan_struct_field_list_opt(e.fields)
+    spec_scan_block_opt(e.handler_block)
+    spec_scan_expr_opt(e.closure_body)
+
+    if e.kind == ExprKind::ExprCall {
+        let callee_name = spec_call_expr_callee_name(e)
+        if !name_is_empty(callee_name) {
+            let gt_idx = spec_generic_table_find(callee_name)
+            if gt_idx >= 0 {
+                var specialized = false
+                match spec_call_expr_type_args(e) {
+                    Some(targs) => {
+                        let provided = spec_type_args_count(Some(targs))
+                        if spec_trace_enabled() {
+                            print("specializer: call=")
+                            print(spec_name_to_string(callee_name))
+                            print(" gt=")
+                            print_int(gt_idx)
+                            print(" targs=")
+                            print_int(provided)
+                            print(" want=")
+                            print_int(spec_generic_table_tp_count(gt_idx))
+                            print("\n")
+                        }
+                        if provided == spec_generic_table_tp_count(gt_idx) {
+                            spec_ensure_instance(callee_name, Some(targs))
+                            specialized = true
+                        }
+                    }
+                    None => {}
+                }
+                if !specialized {
+                    SPEC_GF_NEEDED[gt_idx as usize] = true
+                }
+            }
+        }
+    }
+}
+
+fn spec_scan_block(b: Block) with IO, Mut, Panic, Div, Alloc {
+    spec_scan_stmt_list_opt(b.stmts)
+}
+
+fn spec_scan_block_opt(opt: Option<Box<Block>>) with IO, Mut, Panic, Div, Alloc {
+    match opt {
+        None => {}
+        Some(b) => spec_scan_stmt_list_opt((*b).stmts)
+    }
+}
+
+fn spec_scan_stmt_list_opt(opt: Option<Box<StmtList>>) with IO, Mut, Panic, Div, Alloc {
+    match opt {
+        None => {}
+        Some(list) => {
+            spec_scan_expr_opt((*list).head.expr)
+            spec_scan_expr_opt((*list).head.target)
+            spec_scan_stmt_list_opt((*list).tail)
+        }
+    }
+}
+
+fn spec_scan_expr_list_opt(opt: Option<Box<ExprList>>) with IO, Mut, Panic, Div, Alloc {
+    match opt {
+        None => {}
+        Some(list) => {
+            spec_scan_expr((*list).head)
+            spec_scan_expr_list_opt((*list).tail)
+        }
+    }
+}
+
+fn spec_scan_match_arm_list_opt(opt: Option<Box<MatchArmList>>) with IO, Mut, Panic, Div, Alloc {
+    match opt {
+        None => {}
+        Some(list) => {
+            spec_scan_expr_opt((*list).head.guard)
+            spec_scan_expr((*list).head.body)
+            spec_scan_match_arm_list_opt((*list).tail)
+        }
+    }
+}
+
+fn spec_scan_struct_field_list_opt(opt: Option<Box<StructFieldList>>) with IO, Mut, Panic, Div, Alloc {
+    match opt {
+        None => {}
+        Some(list) => {
+            spec_scan_expr((*list).head.value)
+            spec_scan_struct_field_list_opt((*list).tail)
+        }
+    }
+}
+
+fn spec_scan_items(items: Option<Box<ItemList>>) with IO, Mut, Panic, Div, Alloc {
+    match items {
+        None => {}
+        Some(list) => {
+            let it = (*list).head
+            if it.kind == ItemKind::ItemFn && spec_generic_table_find(it.name) < 0 {
+                match it.fn_def {
+                    Some(fd_box) => spec_scan_block((*fd_box).body)
+                    None => {}
+                }
+            }
+            spec_scan_items((*list).tail)
+        }
+    }
+}
+
+// ============================================================
+// Top-level driver
+// ============================================================
+
+fn spec_append_items(a: Option<Box<ItemList>>, b: Option<Box<ItemList>>) -> Option<Box<ItemList>> with Mut, Alloc {
+    match a {
+        None => b
+        Some(list) => Some(Box::new(ItemList { head: (*list).head, tail: spec_append_items((*list).tail, b) }))
+    }
+}
+
+// Materialize the *mut chain of freshly instantiated items into a real
+// Option<Box<ItemList>> (order does not matter for top-level fns).
+fn spec_extra_items_to_list() -> Option<Box<ItemList>> with Mut, Panic, Div, Alloc {
+    var out: Option<Box<ItemList>> = None
+    var cur = SPEC_EXTRA_HEAD
+    while cur != 0 {
+        let p = cur as *mut SpecItemNode
+        out = Some(Box::new(ItemList { head: (*p).it, tail: out }))
+        cur = (*p).next
+    }
+    out
+}
+
+// Finalize phase (runs after ALL bodies have been scanned, so every call
+// site has voted): for each generic template item —
+//   - poisoned (2+ distinct instantiations) or still referenced by a
+//     turbofish-less/arity-mismatched call: keep the template verbatim so
+//     the checker\'s existing diagnostics (e.g. E010) keep firing;
+//   - exactly one instantiation: REPLACE the template with its concrete
+//     same-name clone;
+//   - never referenced: drop it so the checker never sees a body with free
+//     type vars.
+fn spec_finalize_items(items: Option<Box<ItemList>>) -> Option<Box<ItemList>> with Mut, Panic, Div, Alloc {
+    match items {
+        None => None
+        Some(list) => {
+            let it = (*list).head
+            let rest = spec_finalize_items((*list).tail)
+            if it.kind == ItemKind::ItemFn {
+                let gt_idx = spec_generic_table_find(it.name)
+                if gt_idx >= 0 {
+                    if SPEC_GF_POISONED[gt_idx as usize] || SPEC_GF_NEEDED[gt_idx as usize] {
+                        return Some(Box::new(ItemList { head: it, tail: rest }))
+                    }
+                    if SPEC_GF_CLONE_PTR[gt_idx as usize] != 0 {
+                        let np = SPEC_GF_CLONE_PTR[gt_idx as usize] as *mut SpecItemNode
+                        return Some(Box::new(ItemList { head: (*np).it, tail: rest }))
+                    }
+                    return rest
+                }
+            }
+            Some(Box::new(ItemList { head: it, tail: rest }))
+        }
+    }
+}
+
+fn spec_trace_enabled() -> bool with IO, Mut, Panic, Div {
+    str_eq(read_env("SOUNIO_SPEC_TRACE"), "1")
+}
+
+fn spec_trace_out_items(items: Option<Box<ItemList>>) with IO, Mut, Panic, Div {
+    match items {
+        None => {}
+        Some(list) => {
+            let it = (*list).head
+            if it.kind == ItemKind::ItemFn {
+                print("specializer: out_fn ")
+                print(spec_name_to_string(it.name))
+                print("\n")
+            } else if it.kind == ItemKind::ItemStruct {
+                print("specializer: out_struct ")
+                print(spec_name_to_string(it.name))
+                print("\n")
+            }
+            spec_trace_out_items((*list).tail)
+        }
+    }
+}
+
+pub fn specialize_generics(items: Option<Box<ItemList>>) -> Option<Box<ItemList>> with IO, Mut, Panic, Div, Alloc {
+    spec_reset_state()
+    let known = spec_collect_known_names(items, SpecKnownNames { names: [empty_name(); 32], count: 0 })
+    spec_collect_generic_fns(items, known)
+    spec_collect_generic_structs(items)
+    if spec_trace_enabled() {
+        print("specializer: generic_fns=")
+        print_int(SPEC_GF_COUNT)
+        print("\n")
+    }
+    if SPEC_GF_COUNT == 0 {
+        return items
+    }
+    spec_scan_items(items)
+    let finalized = spec_finalize_items(items)
+    let out = spec_append_items(finalized, spec_extra_items_to_list())
+    if spec_trace_enabled() {
+        print("specializer: instances=")
+        print_int(SPEC_EMITTED_COUNT)
+        print("\n")
+        spec_trace_out_items(out)
+    }
+    out
+}

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -23,6 +23,7 @@ use check::units::*
 use check::env::*
 use check::traits::*
 use check::mod::{check_program, check_program_epistemic_into, check_modules_verdict_boot4_with_visibility}
+use check::specializer::{specialize_generics}
 use check::ownership::*
 use check::lint::*
 use check::layout::*
@@ -1257,17 +1258,17 @@ fn compiler_is_render_fixture(path: string) -> bool with Mut, Panic, Div {
 }
 
 fn compiler_try_single_module_check(path: string) -> i64 with IO, Mut, Panic, Div, Alloc {
-    let program = load_module_file(path)
+    var program = load_module_file(path)
     let parse_errors = parser_last_error_count()
     if parse_errors > 0 {
         println("error: parser reported " + int_to_string(parse_errors) + " syntax errors")
         return 0 - 1
     }
-
     let imports = extract_imports_from_ast(program)
     if imports.count > 0 {
         return 0
     }
+    program.items = specialize_generics(program.items)
 
     let resolve_result = resolve_program(program)
     if resolve_result.had_error {
@@ -1882,10 +1883,11 @@ fn run_check_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Allo
 
     if !module_frontend_file_maybe_has_use(source_path) {
         // Single-module real typecheck.
-        let main_prog = load_module_file(source_path)
+        var main_prog = load_module_file(source_path)
         if parser_last_error_count() > 0 {
             panic("check failed")
         }
+        main_prog.items = specialize_generics(main_prog.items)
         let verdict = module_frontend_check_items_with_source_context(main_prog.items, source_path)
         if verdict == 0 {
             println(compiler_check_ok_message())

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -14,6 +14,7 @@ use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolv
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
 use module_parse::{extract_imports_from_ast, file_exists, file_path_to_module_path, load_module_file}
+use check::specializer::{specialize_generics}
 
 fn module_frontend_lower_trace_enabled() -> bool with IO, Mut, Panic, Div {
     str_eq(read_env("SOUNIO_MODULE_FRONTEND_LOWER_TRACE"), "1")
@@ -5470,7 +5471,7 @@ pub fn module_frontend_file_maybe_has_use(path: string) -> bool with IO, Mut, Pa
 }
 
 pub fn preflight_multimodule_frontend(main_path: string) -> MultiModuleFrontendResult with IO, Mut, Div, Panic, Alloc {
-    let main_prog = load_module_file(main_path)
+    var main_prog = load_module_file(main_path)
     let main_parse_errors = parser_last_error_count()
     if main_parse_errors > 0 {
         print("Parse failed for module 0: ")
@@ -5488,6 +5489,7 @@ pub fn preflight_multimodule_frontend(main_path: string) -> MultiModuleFrontendR
         print("Loaded 1 modules\n")
         print("Resolve skip: single module with no imports\n")
         print("Type checking module 0\n")
+        main_prog.items = specialize_generics(main_prog.items)
         let single_verdict_no_use = module_frontend_check_items_with_source_context(main_prog.items, main_path)
         if single_verdict_no_use != 0 {
             print("Type check failed for module 0\n")
@@ -5502,6 +5504,7 @@ pub fn preflight_multimodule_frontend(main_path: string) -> MultiModuleFrontendR
         print("Loaded 1 modules\n")
         print("Resolve skip: single module with no imports\n")
         print("Type checking module 0\n")
+        main_prog.items = specialize_generics(main_prog.items)
         let single_verdict = module_frontend_check_items_with_source_context(main_prog.items, main_path)
         if single_verdict != 0 {
             print("Type check failed for module 0\n")
@@ -5524,7 +5527,7 @@ pub fn preflight_multimodule_frontend(main_path: string) -> MultiModuleFrontendR
 
 pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIrTrace) -> MultiModuleIrResult with IO, Mut, Div, Panic, Alloc {
     parser_reset_last_errors()
-    let main_prog = load_module_file(main_path)
+    var main_prog = load_module_file(main_path)
     let main_parse_errors = parser_last_error_count()
     if main_parse_errors > 0 {
         print("Parse failed during IR lowering for module 0: ")
@@ -5542,6 +5545,7 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         var single_epistemic_no_use = ir_empty_epistemic_section()
         trace.last_stage = "typecheck"
         if module_frontend_lower_trace_enabled() { print("module_frontend_lower: typecheck_begin\n") }
+        main_prog.items = specialize_generics(main_prog.items)
         let single_verdict_no_use = module_frontend_check_items_with_source_context(main_prog.items, main_path)
         if module_frontend_lower_trace_enabled() { print("module_frontend_lower: typecheck_done\n") }
         if single_verdict_no_use != 0 {
@@ -5574,6 +5578,7 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         var single_epistemic = ir_empty_epistemic_section()
         trace.last_stage = "typecheck"
         if module_frontend_lower_trace_enabled() { print("module_frontend_lower: typecheck_begin\n") }
+        main_prog.items = specialize_generics(main_prog.items)
         let single_verdict = module_frontend_check_items_with_source_context(main_prog.items, main_path)
         if module_frontend_lower_trace_enabled() { print("module_frontend_lower: typecheck_done\n") }
         if single_verdict != 0 {

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -824,7 +824,12 @@ fn lowerer_register_struct_fields_direct_mut(
                 entry.fields[fc as usize] = StructFieldEntry {
                     name: (*flist).head.name,
                     index: fc,
-                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else { 0 },
+                    // println i64-segfault fix: keep in sync with register_struct_fields_ref's
+                    // `3` = scalar-i64 marker (this is a separate early-pass registration path
+                    // over the same struct_layouts table; a mismatch here would leave the
+                    // FIRST-registered field entry — the one actually found by name lookup —
+                    // without the i64 marker).
+                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_i64(&(*flist).head.ty) { 3 } else { 0 },
                 }
                 fc = fc + 1
                 fcur = &(*flist).tail
@@ -876,7 +881,8 @@ fn lowerer_register_struct_fields_mut(
                     (*(*lo).struct_layouts).entries[layout_idx as usize].fields[fc as usize] = StructFieldEntry {
                         name: (*list).head.name,
                         index: field_idx,
-                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else { 0 },
+                        // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
+                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
                     }
                     (*(*lo).struct_layouts).entries[layout_idx as usize].field_count = fc + 1
                 } else {
@@ -1376,7 +1382,8 @@ fn ir_fast_summary_register_struct_fields_owned(
                 lay_entry.fields[fc as usize] = StructFieldEntry {
                     name: (*list).head.name,
                     index: idx,
-                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else { 0 },
+                    // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
+                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
                 }
                 lay_entry.field_count = fc + 1
                 table_value.entries[layout_idx as usize] = lay_entry
@@ -2142,6 +2149,31 @@ fn lower_type_expr_is_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
     if seg.head_buf[1] as i64 != 54 { return false }    // '6'
     if seg.head_buf[2] as i64 != 52 { return false }    // '4'
     true
+}
+
+// println i64-segfault fix: mirror lower_type_expr_is_f64 for i64 so a struct
+// field's declared type can be positively classified as scalar-i64 (as opposed
+// to merely "not float", which is also true of string/bool/struct fields).
+fn lower_type_expr_is_i64(te: &TypeExpr) -> bool with Mut, Panic, Div {
+    if (*te).kind != TypeExprKind::TypeNamed { return false }
+    let seg = (*te).path.segments
+    if seg.head_len != 3 { return false }
+    if seg.head_buf[0] as i64 != 105 { return false }   // 'i'
+    if seg.head_buf[1] as i64 != 54 { return false }    // '6'
+    if seg.head_buf[2] as i64 != 52 { return false }    // '4'
+    true
+}
+
+// println i64-segfault fix: a callee's return type name (module.functions[..].
+// return_struct_name, populated for ANY TypeNamed return type via
+// lower_opt_type_named_name — not only actual structs) positively identifies a
+// scalar i64 return, as opposed to returns_float==0 which is also true for
+// string/bool/void/unresolved returns.
+fn lower_name_is_i64_type(n: Name) -> bool with Div {
+    n.len == 3
+    && n.buf[0] == 105 as i8   // 'i'
+    && n.buf[1] == 54 as i8    // '6'
+    && n.buf[2] == 52 as i8    // '4'
 }
 
 fn lower_type_expr_is_array_of_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
@@ -4668,6 +4700,60 @@ impl Lowerer {
         false
     }
 
+    // println i64-segfault fix: field analogue of field_is_float_by_name_simple,
+    // testing the `is_float == 3` scalar-i64 marker set in register_struct_fields_ref.
+    fn field_is_int_by_name_simple(self, n: Name) -> bool with Mut, Panic, Div {
+        var si: i64 = 0
+        while si < (*self.struct_layouts).count {
+            var fi: i64 = 0
+            while fi < (*self.struct_layouts).entries[si as usize].field_count {
+                if ir_name_eq((*self.struct_layouts).entries[si as usize].fields[fi as usize].name, n) {
+                    return (*self.struct_layouts).entries[si as usize].fields[fi as usize].is_float == 3
+                }
+                fi = fi + 1
+            }
+            si = si + 1
+        }
+        false
+    }
+
+    // println i64-segfault fix: field analogue of field_is_float_for_struct.
+    fn field_is_int_for_struct(self, type_name: Name, field_name: Name) -> bool with Mut, Panic, Div {
+        if type_name.len <= 0 {
+            return false
+        }
+        var si: i64 = 0
+        while si < (*self.struct_layouts).count {
+            if ir_name_eq((*self.struct_layouts).entries[si as usize].type_name, type_name) {
+                var fi: i64 = 0
+                while fi < (*self.struct_layouts).entries[si as usize].field_count {
+                    if ir_name_eq((*self.struct_layouts).entries[si as usize].fields[fi as usize].name, field_name) {
+                        return (*self.struct_layouts).entries[si as usize].fields[fi as usize].is_float == 3
+                    }
+                    fi = fi + 1
+                }
+            }
+            si = si + 1
+        }
+        false
+    }
+
+    // println i64-segfault fix: field analogue of field_is_float_for_base_ref.
+    fn field_is_int_for_base_ref(self, base_opt: &Option<Box<Expr>>, field_name: Name) -> bool with Mut, Panic, Div, Alloc {
+        match *base_opt {
+            Some(base_expr) => {
+                if (*base_expr).kind == ExprKind::ExprIdent {
+                    let type_name = self.lookup_local_struct_type((*base_expr).name)
+                    if self.field_is_int_for_struct(type_name, field_name) {
+                        return true
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
     fn field_array_elem_is_float_for_struct(self, type_name: Name, field_name: Name) -> bool with Mut, Panic, Div {
         if type_name.len <= 0 {
             return false
@@ -4908,6 +4994,43 @@ impl Lowerer {
             if lower_cast_type_is_i64(&(*e).cast_type) { return 1 }
             return 0
         }
+        // println i64-segfault fix: resolve a call's/field's return type to the
+        // scalar-int kind when it is POSITIVELY known to be i64 (not merely "not
+        // float") — mirrors the float resolution in expr_result_is_float_ref
+        // (module.functions[fn_id].returns_float), using return_struct_name
+        // instead, since that field carries the return type's name for ANY
+        // TypeNamed return (see lower_opt_type_named_name), not only structs.
+        // When the type can't be resolved this way, fall through unchanged so
+        // string/bool/void/unresolved results keep routing to the char* printer.
+        if (*e).kind == ExprKind::ExprCall {
+            match (*e).left {
+                Some(callee_expr) => {
+                    let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
+                    let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
+                    if fn_id >= 0 && fn_id < self.module.fn_count {
+                        if lower_name_is_i64_type(self.module.functions[fn_id as usize].return_struct_name) {
+                            return 1
+                        }
+                    }
+                }
+                None => {}
+            }
+        }
+        if (*e).kind == ExprKind::ExprMethodCall {
+            let recv_type = self.lower_method_recv_type(&(*e).left)
+            let call_name = if recv_type.len > 0 { ir_mangle_method_name(recv_type, (*e).name) } else { (*e).name }
+            let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, call_name)
+            if fn_id >= 0 && fn_id < self.module.fn_count {
+                if lower_name_is_i64_type(self.module.functions[fn_id as usize].return_struct_name) {
+                    return 1
+                }
+            }
+        }
+        if (*e).kind == ExprKind::ExprFieldAccess {
+            if self.field_is_int_for_base_ref(&(*e).left, (*e).name) || self.field_is_int_by_name_simple((*e).name) {
+                return 1
+            }
+        }
         if (*e).kind == ExprKind::ExprBinary {
             if lower_binary_op_is_compare((*e).bin_op) {
                 return 1
@@ -5078,7 +5201,11 @@ impl Lowerer {
                         lay_entry.fields[fc as usize] = StructFieldEntry {
                             name: (*list).head.name,
                             index: field_idx,
-                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else { 0 },
+                            // println i64-segfault fix: reuse the `is_float` numeric-kind slot
+                            // with a new `3` marker for scalar-i64 fields (2 is already taken by
+                            // f64-array). Existing consumers only test `== 1` / `== 2`, so this
+                            // is inert for them; field_is_int_* below tests `== 3`.
+                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
                         }
                         lay_entry.field_count = fc + 1
                         (*lo.struct_layouts).entries[layout_idx as usize] = lay_entry

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -881,7 +881,19 @@ impl Parser {
 
         let pair = p.parse_type()
         p = pair.0
-        let target_ty = pair.1
+        var target_ty = pair.1
+        var trait_name = empty_name()
+
+        // `impl TraitName for Type { ... }` — the first type parsed above is
+        // actually the trait name; re-parse the real target type after `for`.
+        if parser_peek(p) == TokenKind::For {
+            p = p.advance()  // skip 'for'
+            trait_name = extract_impl_name(target_ty)
+            let pair_target = p.parse_type()
+            p = pair_target.0
+            target_ty = pair_target.1
+        }
+
         p = p.expect(TokenKind::LBrace)
 
         // Build methods in reverse for O(1) cons, reverse once at the end.
@@ -919,7 +931,7 @@ impl Parser {
         // Extract name from target type path
         let impl_name = extract_impl_name(target_ty)
 
-        let idef = ImplDef { target_type: target_ty, methods: methods_opt, span: span, trait_name: empty_name() }
+        let idef = ImplDef { target_type: target_ty, methods: methods_opt, span: span, trait_name: trait_name }
 
         (p, Item {
             kind: ItemKind::ItemImpl,
@@ -966,14 +978,30 @@ impl Parser {
         let name = p.current_name()
         p = p.advance()  // skip name
 
-        // Parse trait body: { fn m1(); fn m2(x: i64) -> i64; ... }
+        // Parse trait body: { fn m1(self, o: Self) -> Self  fn m2(x: i64) -> i64 { ... } ... }
+        // Trait methods may be bodyless signatures (no `{ ... }`) or carry a default
+        // implementation body; parse_trait_method_sig handles both.
         p = p.expect(TokenKind::LBrace)
         var rev_methods_opt: Option<Box<ItemList>> = None
         while parser_peek(p) != TokenKind::RBrace && !parser_at_eof(p) {
-            let method_pair = p.parse_item()
-            p = method_pair.0
-            let method_item = method_pair.1
-            rev_methods_opt = Some(Box::new(ItemList { head: method_item, tail: rev_methods_opt }))
+            // Ignore trivia and doc comments between method signatures.
+            while parser_peek(p) == TokenKind::Newline || parser_peek(p) == TokenKind::Semi || tk_is_doc_comment(parser_peek(p)) {
+                p = p.advance()
+            }
+            if parser_peek(p) == TokenKind::RBrace || parser_at_eof(p) {
+                break
+            }
+            if parser_peek(p) == TokenKind::Fn {
+                let method_pair = p.parse_trait_method_sig()
+                p = method_pair.0
+                let method_item = method_pair.1
+                rev_methods_opt = Some(Box::new(ItemList { head: method_item, tail: rev_methods_opt }))
+            } else {
+                // Recovery: consume one unexpected token inside trait body.
+                p.had_error = true
+                p.error_count = p.error_count + 1
+                p = p.advance()
+            }
         }
         p = p.expect(TokenKind::RBrace)
         let methods_opt = items_reverse_item_list_opt(rev_methods_opt)
@@ -1013,6 +1041,83 @@ impl Parser {
             study_def: None,
             ontology_def: None,
             trait_def: Some(Box::new(tdef)),
+        })
+    }
+
+    // Trait method signature: `fn name(self, o: Self) -> Self` optionally followed
+    // by a `{ ... }` default body. When no body follows, an empty Block is stored
+    // (v1: bodyless signatures are parsed and carried, not semantically dispatched).
+    fn parse_trait_method_sig(self) -> (Parser, Item) with Mut, IO, Panic, Div, Alloc {
+        let start = self.current_span()
+        var p = self.advance()  // skip 'fn'
+        let name = p.current_name()
+        p = p.expect_ident()
+        if parser_peek(p) == TokenKind::Lt {
+            p = p.parse_type_param_header()
+        }
+        p = p.expect(TokenKind::LParen)
+        let pair = p.parse_param_list()
+        p = pair.0
+        let params_opt = pair.1
+        p = p.expect(TokenKind::RParen)
+        let pair2 = p.parse_optional_return_type()
+        p = pair2.0
+        let ret_ty = pair2.1
+        var effects_opt: Option<Box<EffectList>> = None
+        if parser_peek(p) == TokenKind::With {
+            let pair3 = p.parse_effect_list()
+            p = pair3.0
+            effects_opt = Some(Box::new(pair3.1))
+        }
+        var body = Block { stmts: None, span: p.current_span() }
+        if parser_peek(p) == TokenKind::LBrace {
+            let pair4 = p.parse_block()
+            p = pair4.0
+            body = pair4.1
+        }
+        let span = p.span_from(start)
+        let fn_def = FnDef {
+            name: name,
+            params: params_opt,
+            return_type: ret_ty,
+            effects: effects_opt,
+            body: body,
+            span: span,
+            is_kernel: false,
+        }
+
+        (p, Item {
+            kind: ItemKind::ItemFn,
+            span: span,
+            visibility: visibility_private(),
+            name: name,
+            fn_def: Some(Box::new(fn_def)),
+            struct_def: None,
+            enum_def: None,
+            impl_def: None,
+            type_alias_ty: None,
+            policy_def: None,
+            acquisition_policy_def: None,
+            recourse_policy_def: None,
+            decision_policy_def: None,
+            deferral_policy_def: None,
+            transition_policy_def: None,
+            transition_protocol_def: None,
+            monitoring_policy_def: None,
+            alternative_policy_def: None,
+            alternative_frontier_def: None,
+            models_def: None,
+            validation_def: None,
+            audit_def: None,
+            use_path: empty_path(),
+            use_glob: false,
+            use_items: None,
+            effect_def: None,
+            session_decl: None,
+            trait_def: None,
+            algebra_def: None,
+            study_def: None,
+            ontology_def: None,
         })
     }
 


### PR DESCRIPTION
Phase 1 of Madaros parity with the lean_single generic `<F>` engine (#650). Four coordinated changes:

1. **parser/items.sio** — trait/impl grammar: bodyless trait method signatures (`parse_trait_method_sig`), `impl Trait for Type` headers (receiver flows through the inherent-impl path; trait name recorded in pre-existing `ImplDef.trait_name`), `<F: Bound>` already parsed.
2. **check/specializer.sio (NEW)** — pre-check AST generic-fn specializer hooked in the single-module lanes of `compiler/{main,module_frontend}.sio`: structural type-param recovery, same-name single-instantiation replacement (2nd distinct instantiation poisons back to baseline — E010 compile-fail preserved), syntactic TypeExpr substitution incl. AST-level generic-struct monomorphization, transitive worklist. `ir/lower.sio` untouched. Backend-safety notes in the file header.
3. **ir/lower.sio** — pre-existing `println(<i64-valued call/method/field>)` segfault: `expr_result_scalar_kind_ref` now positively resolves integer results (`return_struct_name=="i64"`; new `is_float==3` scalar-i64 field marker at all 4 registration sites). Conservative fallback preserved.
4. **check/compat.sio** — #638: bitwise/shift result type follows the LEFT operand (was always-i64, poisoning i32 shift/mask contexts). Witnessed via exit-code (rc=20).

## Madaros scoreboard (integrated build, output-verified)
GREEN now (was red): `turbofish.sio` 3/3; `impl_trait_for_type` (3/spike PASS); `impl_trait_for_type_multi` (7/9/10/multi PASS); `trait_decl_bodyless_methods`; `trait_bounded_dispatch_struct` (10/struct PASS). Preserved: `generic_struct_basic`, E010 compile-fail regression guard.

## Safety
- 10-test regression sample byte-identical to baseline; umbrella gate (`native_v2_cpu_compiler_umbrella_gate.sh`) row-for-row identical (zero new reds; all reds pre-existing and documented).
- lean_single engine untouched (`lean_single.sio` not in the diff); CI Full Test Suite runs on the fresh lean_single stage2, unaffected.
- Remaining for full `cd_exact_generic_i64` parity (phase 2, tracked in docs/handoff/continuity/): primitive-receiver method dispatch (E019/E011), specializer in the multi-module lane, skeleton E035 effect annotations, and the pre-existing native-v2 struct-by-value-return runtime segfault (orthogonal; own lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)