### PR TITLE
docs(handoff): continuity WP briefs — Madaros <F> phase 2 + EISA (Opus/Haiku campaign)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 870
-- Repo-backed topics: 720
+- Total governed topics: 880
+- Repo-backed topics: 730
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 168
-- Authority count `repo_only`: 514
+- Authority count `repo_only`: 524
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 518 topics
+- A2: 528 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -338,6 +338,16 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.compiler-generic-struct-return-fix-prompt | repo_only | docs/handoff/compiler_generic_struct_return_fix_prompt.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-impl-trait-for-type-fix-prompt | repo_only | docs/handoff/compiler_impl_trait_for_type_fix_prompt.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-trait-bounded-dispatch-fix-prompt | repo_only | docs/handoff/compiler_trait_bounded_dispatch_fix_prompt.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.bootstrap | repo_only | docs/handoff/continuity/BOOTSTRAP.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.scoreboard | repo_only | docs/handoff/continuity/SCOREBOARD.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-a0 | repo_only | docs/handoff/continuity/WP-A0.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-a1 | repo_only | docs/handoff/continuity/WP-A1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-a2 | repo_only | docs/handoff/continuity/WP-A2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-a3 | repo_only | docs/handoff/continuity/WP-A3.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-a4 | repo_only | docs/handoff/continuity/WP-A4.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-a5 | repo_only | docs/handoff/continuity/WP-A5.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-b1 | repo_only | docs/handoff/continuity/WP-B1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-b2 | repo_only | docs/handoff/continuity/WP-B2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.exact-engine-prereqs | repo_only | docs/handoff/exact_engine_prereqs.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-v0800-defects | repo_only | docs/handoff/souc_v0800_defects.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.bootstrap-seed-policy | historical | docs/implementation/BOOTSTRAP_SEED_POLICY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7288,6 +7288,236 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.continuity.bootstrap",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/BOOTSTRAP.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.scoreboard",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/SCOREBOARD.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-a0",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-A0.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-a1",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-A1.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-a2",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-A2.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-a3",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-A3.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-a4",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-A4.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-a5",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-A5.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-b1",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-B1.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.handoff.continuity.wp-b2",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-B2.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.exact-engine-prereqs",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/exact_engine_prereqs.md",

--- a/docs/handoff/continuity/BOOTSTRAP.md
+++ b/docs/handoff/continuity/BOOTSTRAP.md
@@ -1,0 +1,35 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.bootstrap
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.bootstrap
+-->
+
+# BOOTSTRAP — paste this into a fresh Opus or Haiku session
+
+> You are executing one work packet of the fable5 continuity campaign (Madaros generic-`<F>` phase 2 + EISA default-lane parity) in the Sounio repo at `/workspace/sounio`.
+>
+> 1. Read `docs/handoff/continuity/SCOREBOARD.md`. Pick the FIRST work packet with status TODO whose `Model` column matches you and whose `Deps` are all DONE.
+> 2. Post a CLAIM entry in `artifacts/omega/agent_handoff.log.md` (append; agent/lane/time_utc/files/intent/status fields, matching the log's existing format). Check first that no other agent holds a live CLAIM on the same files.
+> 3. Read your `docs/handoff/continuity/WP-<id>.md` brief and execute it TO THE LETTER. The brief contains the diagnosis, exact file anchors, witnesses, and gates — do not re-derive, do not expand scope.
+> 4. Any NEW defect you find: add a row to the scoreboard's new-gap ledger and move on. Never chase it inside your WP.
+> 5. When done (or blocked): update your scoreboard row (status + evidence + commit sha), append a RELEASE entry to the handoff log, commit both files together with your work.
+
+## Global guardrails (they cost the previous sessions hours — respect them)
+
+- **FALSE GREEN**: the compiler's exit code lies (exit 0 on failure; silent miscompiles with clean rc). ALWAYS run the produced ELF and verify its actual stdout/exit code against the expected values in your brief.
+- **No `println` of computed locals in Madaros witnesses** (`let y: i64 = x+11; println(y)` segfaults — pre-existing). Use `fn main() -> i64` + exit code, or `print_int`.
+- **Serialized surfaces**: `self-hosted/compiler/lean_single.sio` and the `bin/souc*` binaries are Lane-4-token surfaces — do not edit them in any WP here. Never `git add -A`. Print `git branch --show-current` after every checkout.
+- **LoRA/Contracts gate**: if you edit any file mirrored in `datasets/sounio-code-examples/train.jsonl`, resync that entry (completion must byte-equal the file) and run `bash scripts/ci/lora_assets_gate.sh`.
+- **Builds**: Madaros modular build = `bash scripts/ci/build_modular_madaros.sh /tmp/<name>` (~2-4 min, raw ELF). Compile+run = `MADAROS_RAW_BIN=/tmp/<name> ./bin/madaros compile <t.sio> -o /tmp/out.elf && chmod +x /tmp/out.elf && /tmp/out.elf`. lean_single build = `./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/stage1` (interface `<src> <out>`), then self-compile to stage2/stage3 and `cmp` stage2 stage3.
+- **CI parity** (what actually gates a PR): `SOUNIO_FORCE_SOURCE_BOOTSTRAP=1 bash scripts/ci/selfhost_host_gate.sh`, then `cp <gate-dir>/artifacts/souc-stage2 /tmp/final_boot4.elf && bash scripts/ci/souc_v2_gate.sh`, then `SOUC_NATIVE=<stage2> bash scripts/selfhost/selfhost_native_runtime_proof.sh`. The local `lean_single_fixed_point_gate.sh` is red even on clean main via the wrapper — it is NOT the CI gate; ignore it.
+- **Umbrella** (Madaros regression matrix): `bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh` (~100s-8m). Run BEFORE and AFTER your change; pre-existing reds are listed in the scoreboard; any NEW red is yours to fix before finishing.
+- **4-cell bisect**: if two changes are in flight and a gate breaks, test all 4 combinations before assigning blame.
+- If you spawn subagents and one stops "waiting for a build notification", resume it with: "poll your build result directly; do not wait for notifications".
+
+## Commit/PR conventions
+- No `Co-Authored-By` trailers. Commit messages follow the repo style (`feat(madaros): ...`, `fix(native): ...`).
+- PR bodies list: what changed, witness table with ACTUAL outputs, gates before/after, known residuals.
+- Squash-merge on green CI. If a Contracts/LoRA failure appears, see the LoRA guardrail above.

--- a/docs/handoff/continuity/SCOREBOARD.md
+++ b/docs/handoff/continuity/SCOREBOARD.md
@@ -1,0 +1,39 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.scoreboard
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.scoreboard
+-->
+
+# Continuity Scoreboard — Madaros M-track phase 2 + EISA default-lane
+
+**Single source of truth for the Opus/Haiku continuity campaign.** Every session MUST update its row when it finishes (status + evidence + commit). Protocol: read this file → claim the first TODO work packet compatible with your model → post a CLAIM entry in `artifacts/omega/agent_handoff.log.md` → execute the WP brief to the letter → update this table → RELEASE in the handoff log. See `BOOTSTRAP.md`.
+
+Statuses: `TODO` | `CLAIMED(<session>)` | `IN-PROGRESS` | `DONE(<commit/PR>)` | `BLOCKED(<reason>)`
+
+| WP | Title | Model | Deps | Status | Evidence (command → expected) |
+|---|---|---|---|---|---|
+| A0 | Phase-1 PR merge | Haiku | — | IN-PROGRESS (PR #654 open) | `gh pr checks 654` all green → squash-merge |
+| A1 | Skeleton E035 effects | Haiku | A0 | TODO | Madaros compile of cd_exact: E035×3 gone; lean_single BYTECOMPARE PASS intact |
+| A2 | Primitive-receiver dispatch (E019/E011) | Opus | A0 | TODO | dispatch witnesses rc=23/74 and rc=23/60; `trait_bounded_dispatch{,_multi_call}.sio` green on Madaros |
+| A3 | Specializer in multi-module lane | Opus | A0 | TODO | cd_exact compile: no `E008 ... CDElementExact__T` |
+| A4 | SRET struct-by-value return | Opus | — (own branch/PR) | TODO | bisect ladder L1–L4 green; `generic_struct_return.sio` runs rc=0 "6"/"spike PASS" |
+| A5 | Convergence + phase-2 PR | Opus+Haiku | A1–A4 | TODO | cd_exact on Madaros: ZD PROVED + SQ PASS + NONZERO PASS + 16×COMP 0 |
+| B1 | EISA `str_from_bytes` dep-closure (ud2/SIGILL) | Opus | — | TODO | `test_eisa_isa` + `test_eisa_evm` PASS on default lane, no SIGILL |
+| B2 | EISA gate refresh + suite | Haiku | B1 | TODO | conformance gate 21/21; 13-test suite green on default lane |
+
+## New-gap ledger (candidates for new WPs — do NOT chase inside an existing WP)
+
+| Found by | Description | Evidence |
+|---|---|---|
+| fable5 | `println(<annotated computed local>)` segfaults on Madaros (e.g. `let y: i64 = x+11; println(y)`) — pre-existing, distinct from the fixed call/field cases | rc=139 on baseline madaros-m0 too |
+| fable5 | `method_receiver_correct.sio` + `generic_struct_instantiate.sio` rc=139 on baseline — families per `docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md` / `MADAROS_BOXNEW_SIGSEGV_2026-06-19.md` | pre-existing |
+
+## Fixed reference state (do not re-derive)
+
+- lean_single generic `<F>` engine: MERGED main PR #650 (`2adb8f061`). Gold-standard outputs for cd_exact live in `tests/run-pass/cd_exact_generic_i64.sio` header.
+- Madaros phase 1: branch `coord/fable5-madaros-generic-f` @ `d15915f58`, PR #654.
+- EISA: 12/12 lean-lane GREEN; `test_eisax_format` v0 fixed (`639094a00`); evm arena fixed (`a096d1c4b`, 25.8→6.5GB). Lane worktree `/workspace/sounio-eisa` (branch `gpu/epistemic-tensor-core-next`, owner cursor/grok, lock-open); its bundled `bin/madaros-linux-x86_64` is STALE — pair with `/workspace/sounio/bin/madaros-linux-x86_64`.
+- Pre-existing umbrella-gate reds (row-identical across phase 1; not yours to fix): driver_self_compile, science_spine, f64_ladder, gum_primitives, semantic_hardening, lean_single_fixed_point, imported_closure×2 (rc=139), struct_orchestrator, phase_j_conf_gate, kretikos_kaxi_meta, dissertation_pbpk_suite.

--- a/docs/handoff/continuity/WP-A0.md
+++ b/docs/handoff/continuity/WP-A0.md
@@ -1,0 +1,22 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-a0
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-a0
+-->
+
+# WP-A0 — Land the Madaros phase-1 PR [Haiku]
+
+**Status at authoring:** PR #654 already OPEN (base `main`, head `coord/fable5-madaros-generic-f` @ `d15915f58`).
+
+## Steps
+1. `gh pr checks 654 --repo Sounio-lang/sounio` — wait for all checks. Expected all-green: the diff touches only Madaros-side files (`parser/items.sio`, `check/{specializer,compat}.sio`, `compiler/{main,module_frontend}.sio`, `ir/lower.sio`); the CI Full Test Suite runs on the lean_single stage2 and is unaffected; no LoRA-mirrored file is in the diff.
+2. If the Contracts job fails on "LoRA dataset assets": run `bash scripts/ci/lora_assets_gate.sh` locally, resync the offending `datasets/sounio-code-examples/train.jsonl` entry (completion must byte-equal the source file), commit to the same branch, push.
+3. If any other check fails: capture the failing job log (`gh run view --job <id> --log`), record it in the scoreboard as BLOCKED with the log excerpt, and STOP (do not improvise fixes to compiler code in this WP).
+4. On green: `gh pr merge 654 --repo Sounio-lang/sounio --squash --subject "feat(madaros): generic <F> M-track phase 1 — trait/impl grammar, AST specializer, println i64 fix, #638 (#654)"`.
+5. Update `SCOREBOARD.md`: A0 → DONE(merge sha). Append RELEASE to `artifacts/omega/agent_handoff.log.md`.
+
+## Done criteria
+PR #654 merged to main; scoreboard + handoff log updated.

--- a/docs/handoff/continuity/WP-A1.md
+++ b/docs/handoff/continuity/WP-A1.md
@@ -1,0 +1,25 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-a1
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-a1
+-->
+
+# WP-A1 — Skeleton E035 effect annotations [Haiku] (dep: WP-A0 merged)
+
+## Problem
+Under Madaros, compiling `tests/run-pass/cd_exact_generic_i64.sio` (which imports `stdlib/algebra/cayley_dickson_exact.sio`) emits `error[E035] effect not declared in function signature (missing: Mut, Div, Panic)` ×3, at source spans ~4329/4387/4445 of the imported module. Three fns in the skeleton perform Mut/Div/Panic work without declaring those effects. lean_single does not enforce this; Madaros does.
+
+## Steps
+1. Fresh worktree/branch off post-A0 main: `fix/cd-exact-skeleton-effects`.
+2. Build Madaros: `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-a1`.
+3. Reproduce: `MADAROS_RAW_BIN=/tmp/madaros-a1 ./bin/madaros compile tests/run-pass/cd_exact_generic_i64.sio -o /tmp/x.elf` → see the 3 E035 spans. Map spans to fns by opening `stdlib/algebra/cayley_dickson_exact.sio` (byte offsets ≈ spans; candidates are among `cd_basis_exact`/`cd_associator_exact`/`zd_exact`-family fns whose `with ...` clause is missing `Mut`/`Div`/`Panic`).
+4. Add the missing effects to exactly those fn signatures (e.g. `with Mut, Panic` → `with Mut, Panic, Div`). Touch NOTHING else in the file.
+5. Validate Madaros: recompile cd_exact — the 3 E035 must be gone (other error classes like E008/E011 may remain; they belong to WP-A2/A3, ignore).
+6. Validate lean_single unaffected (the skeleton is shared): build stage2 (`./bin/souc-lean-single-x86_64 self-hosted/compiler/lean_single.sio /tmp/ls1; chmod +x /tmp/ls1; /tmp/ls1 self-hosted/compiler/lean_single.sio /tmp/ls2; chmod +x /tmp/ls2`), then compile+RUN with `/tmp/ls2` (interface `<src> <out>`): `tests/run-pass/cd_exact_generic_i64.sio` (expect ZD PROVED + SQ PASS + NONZERO PASS + 16× `COMP <i> 0`) and `tests/run-pass/cd_exact_generic_vs_concrete.sio` (expect 3× MATCH + BYTECOMPARE PASS). VERIFY ACTUAL STDOUT.
+7. Commit, push, PR (small, docs-style body with the witness outputs), squash-merge on green. Update scoreboard + handoff log.
+
+## Done criteria
+E035×3 gone under Madaros; both lean_single cd_exact tests still output-verified green; PR merged.

--- a/docs/handoff/continuity/WP-A2.md
+++ b/docs/handoff/continuity/WP-A2.md
@@ -1,0 +1,51 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-a2
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-a2
+-->
+
+# WP-A2 — Madaros: trait-method dispatch on PRIMITIVE receivers [Opus] (dep: WP-A0; parallel with A1/A3)
+
+## Problem
+After the phase-1 AST specializer, a generic fn `fn use2<F: R>(a: F, b: F) -> F { a.radd(b) }` instantiated at `<i64>` leaves a method call `a.radd(b)` with `a: i64`. `impl R for i64 { fn radd(self, o: Self) -> Self { self + o } }` parses (phase-1 grammar) and its method registers, but the checker rejects the CALL: `error[E019]: method calls are not supported for this type` (bare primitive receiver), and `trait_bounded_dispatch_multi_call.sio` also shows `E011 no method named for this type` / `E009 argument type mismatch`. Struct receivers work (`trait_bounded_dispatch_struct.sio` is GREEN) — the gap is primitives only.
+
+This mirrors the lean_single fix that landed in PR #650 (there: primitive receiver hash fallback at the method-lookup site + bare `self` typed with the primitive VAR_TY instead of struct). Madaros needs the same semantics in its own architecture.
+
+## Where to look (verified anchors, post-phase-1 tree)
+- Checker method-call path: `self-hosted/check/check.sio` — method resolution around `checker_check_call_inplace`/method lookup; E019/E011/E009 message sites via `print_error_message` (`check.sio:~11314-11488`; E011 = "no method named for this type"). Find the branch that gates method calls on the receiver being a struct (`TyNamed` + `struct_table_find`) and extend it: when the receiver type is a primitive (i64/i32/f64/bool), look the method up against impls registered for that primitive's type NAME (how `impl ExactRing for i64` registers is visible in the phase-1 parser work: `parser/items.sio` `parse_impl_item` — receiver name flows like an inherent impl; `ImplDef.trait_name` at `parser/ast.sio:1153`).
+- `Self` in impl bodies resolves via `current_impl_type` (`check.sio:1681, 14031`) — verify it also resolves when the impl target is a primitive name (`impl R for i64` → `Self` = i64), and that bare `self` params get the primitive type, not a struct type.
+- IR lowering method mangling: `self-hosted/ir/lower.sio` — `lower_method_recv_type` + `ir_mangle_method_name` (see also the phase-1 println fix nearby at `expr_result_scalar_kind_ref`, `lower.sio:~4893`). Ensure a method on an i64 receiver lowers to the same mangled symbol the impl's fn was emitted under.
+
+## Witnesses (exit-code, NOT println — see BOOTSTRAP guardrail)
+W1 (asymmetric — catches operand swaps):
+```
+trait R { fn rmix(self, o: Self) -> Self }
+impl R for i64 { fn rmix(self, o: Self) -> Self { self * 10 + o } }
+fn use2<F: R>(a: F, b: F) -> F { a.rmix(b) }
+fn main() -> i64 with IO { return use2::<i64>(2, 3) }   // rc MUST be 23
+```
+and a variant returning `use2::<i64>(7, 4)` → rc 74.
+W2 (two impls of one trait — disambiguation):
+```
+trait E { fn ea(self, o: Self) -> Self }
+impl E for i64 { fn ea(self, o: Self) -> Self { self + o } }
+struct Wrap { v: i64 }
+impl E for Wrap { fn ea(self, o: Self) -> Self { Wrap { v: self.v * o.v } } }
+fn g<F: E>(a: F, b: F) -> F { a.ea(b) }
+// main #1: return g::<i64>(20, 3)                        → rc 23
+// main #2: return g::<Wrap>(Wrap{v:20}, Wrap{v:3}).v     → rc 60
+```
+W3: `tests/run-pass/trait_bounded_dispatch.sio` → prints `5` / `spike PASS`, rc=0 (this one may use println of a call result — that path was fixed in phase 1 and is allowed).
+W4: `tests/run-pass/trait_bounded_dispatch_multi_call.sio` → `11`/`5`/`6`/`multi_call PASS`.
+
+## Validation battery
+- Build cycle: `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-a2`; run witnesses with actual rc/stdout checks.
+- Still green: `trait_bounded_dispatch_struct.sio` (10/struct PASS), `impl_trait_for_type{,_multi}.sio`, `turbofish.sio` 3/3, `generic_struct_basic.sio`, compile-fail `tests/compile-fail/turbofish_type_arg_arity.sio` still REJECTED (E010).
+- Umbrella before/after: `bash scripts/ci/native_v2_cpu_compiler_umbrella_gate.sh` — pre-existing reds per SCOREBOARD.md; zero NEW reds.
+- 10-test diverse regression sample vs your pre-change build, byte-identical.
+
+## Done criteria
+W1–W4 pass output-verified; battery green; PR merged; scoreboard + handoff updated.

--- a/docs/handoff/continuity/WP-A3.md
+++ b/docs/handoff/continuity/WP-A3.md
@@ -1,0 +1,33 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-a3
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-a3
+-->
+
+# WP-A3 — Madaros: AST specializer in the MULTI-module lane [Opus] (dep: WP-A0; parallel with A1/A2)
+
+## Problem
+The phase-1 specializer (`self-hosted/check/specializer.sio`, hooked in `compiler/{main,module_frontend}.sio`) runs ONLY in single-module lanes, by name-safety design. `tests/run-pass/cd_exact_generic_i64.sio` imports the generic engine via `use algebra::cayley_dickson_exact::{...}` — the imported-compile path never specializes, so the checker still sees `CDElementExact<F>` templates and fails: `error[E008] expected CDElementExact / found CDElementExact__T` (+ E011s on `er_*` methods, which are WP-A2's).
+
+## Design constraints (READ FIRST)
+- `self-hosted/check/specializer.sio` header documents: the structural type-param recovery heuristic (single-uppercase-letter `TypeNamed` in params/return that isn't a locally declared struct/enum — parser drops `<T>` headers, so params are recovered structurally), the same-name single-instantiation replacement scheme (a 2nd distinct instantiation of one template POISONS it back to baseline — this preserves the E010 compile-fail guard), and FOUR backend miscompile classes the pass's own code must avoid (global aggregate arrays; global Option<Box<T>>; whole-struct stores through *mut; large-struct SRET self-assignment). Respect all of it — the pass compiles under the lean_single-built bundle and these are real.
+- The multi-module hazard the single-module restriction was guarding: imported type NAMES (e.g. a real imported struct named `F` or `T`) could be misread as type params. Two acceptable designs — pick ONE and justify in the PR:
+  (a) run the pass AFTER module merge (where the full item list including imported structs/enums is available) so the "locally declared struct/enum" exclusion covers imported names too;
+  (b) restrict specialization to fns whose own declaring module marks them generic (recover the param list in the module where the fn is declared, then specialize at the merged level).
+- Hook points: `compiler/module_frontend.sio` — the phase-1 hooks sit in `preflight_multimodule_frontend` (~5492/5508) and `load_multimodule_ir_traced` (~5548/5581) single-module branches; the multi-module path runs `imported_compile` / `module_frontend_check_items_with_source_context` over the merged item list. Find where the merged list exists before type checking and insert `specialize_generics(items)` there.
+
+## Witnesses
+W1: `MADAROS_RAW_BIN=<build> ./bin/madaros compile tests/run-pass/cd_exact_generic_i64.sio -o /tmp/x.elf` → NO `E008 ... CDElementExact__T` and no other mono-class errors. (E011 on `er_*` methods may remain until WP-A2 lands — that is OK for this WP; E035 may remain until WP-A1 — also OK. Record residual classes verbatim in the scoreboard.)
+W2: a small 2-module witness you author: module `m1.sio` with `fn wrap<T>(v: T) -> W<T>` + `struct W<T>{val: T}`, main file `use`s it and calls `wrap::<i64>(9)` → compiles, runs, rc=9 via `.val`.
+W3 (no-misfire guard): a 2-module witness where the IMPORTED module declares a real `struct F { x: i64 }` used by the main file — must compile and run unchanged (proves imported single-letter type names aren't eaten as type params).
+
+## Validation battery
+- Single-module witnesses stay green: `turbofish.sio` 3/3, `generic_struct_return.sio` compile-clean, `generic_struct_basic/instantiate` unchanged, compile-fail `turbofish_type_arg_arity.sio` still rejected.
+- Multi-module smoke: 8-10 existing run-pass tests that `use` stdlib modules and are green on your pre-change build — byte-identical after.
+- Umbrella before/after — zero new reds.
+
+## Done criteria
+W1–W3 verified; battery green; PR merged; scoreboard + handoff updated.

--- a/docs/handoff/continuity/WP-A4.md
+++ b/docs/handoff/continuity/WP-A4.md
@@ -1,0 +1,39 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-a4
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-a4
+-->
+
+# WP-A4 — Madaros: wire real SRET for struct-by-value returns [Opus] (independent; own branch `fix/madaros-struct-return-runtime` off main; own PR)
+
+## Problem (the critical-path gap)
+Functions returning a struct BY VALUE segfault at runtime (rc=139) on the default Madaros engine when the struct contains an ARRAY field (e.g. `struct S { c: [i64;4], bits: i64 }` + `fn make() -> S` + field read → rc=139 even non-generic). This blocks `tests/run-pass/generic_struct_return.sio` (typechecks clean since phase 1, dies at runtime) and ultimately `cd_exact_generic_i64` (cd_* fns return structs with `[F;2048]` ≈ 16KB).
+
+## Root cause (verified by read-only exploration — trust these anchors)
+Two mechanisms exist; the real pipeline uses the weak one:
+- `ir/lower.sio` never emits SRET: it lowers every `fn -> S` to plain `IrCall` + `IrReturn`. Default `IrReturn` codegen (`native/codegen_x86_linux.sio:6988-6992`) returns ONE register; `native_v2_core_emit_return_struct_into` (`:7301-7310`) handles at most 2 slots (rax/rdx). Anything wider is mis-returned → caller reads a bad aggregate address → rc=139.
+- The full SysV-SRET machinery ALREADY EXISTS in codegen and is consumed correctly, but has NO producer in real lowering: `ir/ir.sio:719-720` (`is_sret`, `sret_dest_reg` fields); prologue param-shift `codegen_x86_linux.sio:5782-5801`; `IrCallSret` handler `:6955-6987` (hidden dest in rdi, args shift to rsi+); `IrReturnSret` `:6993-6997`; caller stack-args helper `:6511`; instruction builders `native_v2_ir_return_sret` `:7440` / `native_v2_ir_call_sret` `:7461`. Today its only exerciser is the hand-built witness `native_v2_fill_sret_*` (`:7502-7522`).
+- NOTE the boundary: scalar multi-field returns already work by a different path — `tests/run-pass/sret_8_field_return.sio` (8×i64 fields) is GREEN (`docs/compiler/KNOWN_LIMITATIONS.md:95` records that fix). The broken axis is the ARRAY FIELD inside the returned struct, not raw size. Do not regress the scalar path.
+
+## Implementation
+In `self-hosted/ir/lower.sio`: for any fn whose return struct layout exceeds 2 i64 slots OR contains an array field — (1) mark the fn `is_sret=1` + `sret_dest_reg`; (2) at each call site allocate a caller-side destination slot and emit `IrCallSret` instead of `IrCall`; (3) in the fn body emit `IrReturnSret` instead of `IrReturn`; (4) make the callee's return expression write into the hidden-dest. Reuse `return_struct_name` metadata (`lower.sio:4285,4292` helpers) to identify affected fns; derive slot width from the struct layout the lowerer already computes for locals. Related prior art (layout derivation only, NOT wiring): commit `c4934c558` "S5 generic aggregate SRET layouts" (+119 in lower.sio, gate `scripts/dev/madaros_v2_s5_program_mir_abi_gate.sh`); `341b9be14` f128 SRET arg boundary.
+
+## Bisect ladder (each rung exit-code-verified; green control first)
+L0 control: `tests/run-pass/sret_8_field_return.sio` must be GREEN before AND after.
+L1: non-generic `struct{c:[i64;2], x:i64}` returned by value, read `c[1]` + `x` → exact expected rc.
+L2: non-generic `struct{c:[i64;4], bits:i64}` (the witness shape) → expected rc.
+L3: same shape generic `<F>` instantiated `<i64>` (specializer makes it concrete pre-lowering, so if L2 passes L3 should too — if not, the residual is in the specializer's output shape; record, don't chase).
+L4: `tests/run-pass/generic_struct_return.sio` → runs rc=0 printing `6` / `spike PASS`.
+Stretch (record result either way): does `[F;2048]`-scale survive (16KB SRET)? Author a `struct{c:[i64;256], bits}` rung before trying cd_exact scale.
+
+## Validation battery
+- Ladder L0–L4 + a callee-with-args case (SRET shifts explicit args to rsi+ — verify a 3-arg fn returning a wide struct computes all args correctly; asymmetric arg values to catch shifts).
+- Umbrella before/after (`native_v2_cpu_compiler_umbrella_gate.sh`): zero new reds. CHECK whether `imported_closure_boundary`/`imported_captured_closure_boundary` (pre-existing rc=139 reds) change — if they go green, record it (bonus, same family); if they stay red, that is fine (different family per `docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md` / `MADAROS_BOXNEW_SIGSEGV_2026-06-19.md`).
+- 12-15 diverse run-pass regression sample vs pre-change build, byte-identical — INCLUDE struct-heavy tests (`mc_struct_basic`, `array_elem_field_store`, `impl_inherent_method`, `linear_return_value`, `sret_8_field_return`).
+- Canonical background doc: `docs/audit/MADAROS_SELFHOST_TYPEENV_SRET_2026-06-25.md` ("by-value large-struct copy/return (SRET) is the systemic" miscompile).
+
+## Done criteria
+Ladder green; battery green; PR merged; `docs/compiler/KNOWN_LIMITATIONS.md` updated (remove/annotate the array-field SRET limitation); scoreboard + handoff updated.

--- a/docs/handoff/continuity/WP-A5.md
+++ b/docs/handoff/continuity/WP-A5.md
@@ -1,0 +1,25 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-a5
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-a5
+-->
+
+# WP-A5 — Convergence: cd_exact green on BOTH engines + phase-2 PR [Opus, Haiku for sweeps] (dep: A1+A2+A3+A4 all DONE)
+
+## Goal
+The master-prompt acceptance (docs/handoff/compiler_generic_F_engine_unblock_prompt.md §2) on the Madaros engine: `cd_exact_generic_i64` runs correctly, matching the lean_single gold standard that merged in PR #650.
+
+## Steps
+1. Fresh branch off main (which now has A1–A4 merged). Build: `bash scripts/ci/build_modular_madaros.sh /tmp/madaros-a5`.
+2. THE TEST: `MADAROS_RAW_BIN=/tmp/madaros-a5 ./bin/madaros compile tests/run-pass/cd_exact_generic_i64.sio -o /tmp/cd.elf && chmod +x /tmp/cd.elf && /tmp/cd.elf` → stdout MUST be exactly: `ZD PROVED`, `SQ PASS`, `NONZERO PASS`, then 16 lines `COMP <i> 0` (i=0..15). Any deviation = a residual gap: classify verbatim, add to the new-gap ledger, status BLOCKED — do not improvise.
+3. Cross-engine check: run the same test with a fresh lean_single stage2 — outputs must be identical line-for-line. Also run `tests/run-pass/cd_exact_generic_vs_concrete.sio` under Madaros (expect 3× MATCH + BYTECOMPARE PASS) — note it may hit the [F;2048]-scale SRET stretch goal from WP-A4; record honestly.
+4. Full battery under the integrated Madaros: the 10 generic/trait run-pass tests (turbofish, generic_struct_return{,_structf}, impl_trait_for_type{,_multi}, trait_bounded_dispatch{,_struct,_multi_call}, trait_decl_bodyless_methods, cd_exact_generic_i64), compile-fail E010 still rejected, umbrella zero new reds.
+5. [Haiku] Run-pass sweep vs the recorded baseline (see SCOREBOARD.md baseline row): zero regressions.
+6. Phase-2 PR with the full witness table; squash-merge on green.
+7. Wrap-up: RELEASE all M-track claims in `artifacts/omega/agent_handoff.log.md`; ping the exact-algebra consumer (engine parity achieved — `CDElementExact<F>` is now default-engine-safe; F=Rational next); leave a note in SCOREBOARD.md for fable5 to refresh its memory file (`project_fable5_generic_f.md`) on return.
+
+## Done criteria
+cd_exact output-verified identical on both engines; suite + umbrella + sweep green; phase-2 PR merged; claims released.

--- a/docs/handoff/continuity/WP-B1.md
+++ b/docs/handoff/continuity/WP-B1.md
@@ -1,0 +1,39 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-b1
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-b1
+-->
+
+# WP-B1 — EISA: dependency-closure `str_from_bytes` (ud2 → SIGILL) [Opus] (no deps)
+
+## Ownership protocol (FIRST)
+This item was assigned to **Codex** in `artifacts/omega/agent_handoff.log.md` ("YOURS: str_from_bytes absent from the test's dep closure"). Before claiming: `grep -n -i 'str_from_bytes\|closure' artifacts/omega/agent_handoff.log.md | tail` — if Codex has a live CLAIM or landed a fix, coordinate/skip. If free, post a CLAIM citing the user's reassignment to the continuity campaign.
+
+## Problem
+The LAST open technical blocker of EISA default-lane parity. `tests/stdlib/eisa/test_eisa_isa.sio` imports `use eisa::core::*` + `use eisa::isa::*` but NOT `str::lib`. `stdlib/eisa/isa.sio:5` does `use str::lib::*` and calls `str_to_string` → the builtin wrapper `str_from_bytes` (`stdlib/str/lib.sio:87`). The compiler's module dependency-closure pulls the test's DIRECT imports but does not transitively pull `str::lib` definitions that `eisa::isa` itself needs → the missing body is emitted as a deliberate `ud2` → SIGILL at runtime. The SAME defect kills the runtime of `tests/stdlib/eisa/test_eisa_evm.sio` (its former ~24GB compile-vmem problem was already fixed on main by `a096d1c4b` — 25.8→6.5GB; no `MADAROS_VMEM_LIMIT_KB` juggling needed anymore).
+
+## Where
+`self-hosted/compiler/module_loader.sio` + `self-hosted/compiler/module_frontend.sio` — the module merge/closure sites (commit `a5e19cd8a` "imported struct chains fn_id merge" touched them; read that diff first: `git show a5e19cd8a -- self-hosted/compiler/`). The fix: when module M is pulled into the closure, M's OWN `use` deps (and their fn bodies) must be pulled transitively — or at minimum, fns of M that are reachable from the compiled program must have their callee closure satisfied instead of emitting ud2 stubs. Prefer the general transitive-closure fix; if the general fix explodes compile footprint, measure and report (the arena work in `a096d1c4b` should absorb it — verify with `/usr/bin/time -v`).
+
+## Environment
+Work in the EISA lane worktree `/workspace/sounio-eisa` (branch `gpu/epistemic-tensor-core-next`) BUT note its bundled `bin/madaros-linux-x86_64` is STALE. Two options: (a) implement the compiler fix on a fresh branch off MAIN (in a new worktree) where the compiler sources are current, and test EISA by copying the two test files + stdlib/eisa from the EISA worktree if they don't exist on main; (b) if stdlib/eisa exists on main, work entirely on main. Check `ls /workspace/sounio/stdlib/eisa/` first. Default-lane run command pattern:
+```
+SOUNIO_MADAROS_BIN=<your fresh madaros build> ./bin/souc run tests/stdlib/eisa/test_eisa_isa.sio
+```
+
+## Witnesses
+W1: minimal 3-module repro you author FIRST (before touching the compiler): `mod_a.sio` uses `mod_b`; `mod_b.sio` uses `str::lib` and calls `str_to_string`; main imports only `mod_a`. Baseline → SIGILL/ud2; after fix → correct output. Keep it as a run-pass test.
+W2: `test_eisa_isa.sio` on the default lane → PASS, no SIGILL (exact expected output: see the test's header/asserts).
+W3: `test_eisa_evm.sio` on the default lane → compiles within default vmem guards, runs, PASS, no SIGILL.
+
+## Validation battery
+- Umbrella gate before/after: zero new reds (12/12 sub-gates unchanged or better).
+- lean-lane EISA unaffected: `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tests/stdlib/eisa/test_eisa_core.sio` (and isa) still PASS.
+- Multi-module smoke: 8-10 run-pass tests with `use` chains, byte-identical vs pre-change build.
+- CI-parity battery (the fix touches compiler files): selfhost_host_gate + souc_v2_gate + runtime proof.
+
+## Done criteria
+W1–W3 verified; battery green; PR merged to main; scoreboard + handoff (incl. the EISA lane scoreboard entry) updated.

--- a/docs/handoff/continuity/WP-B2.md
+++ b/docs/handoff/continuity/WP-B2.md
@@ -1,0 +1,26 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-b2
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-b2
+-->
+
+# WP-B2 — EISA: gate refresh + full-suite verification [Haiku] (dep: WP-B1 merged)
+
+## Goal
+Prove EISA default-lane parity end-to-end and refresh the conformance artifacts. NO compiler edits in this WP.
+
+## Environment
+EISA lane worktree: `/workspace/sounio-eisa` (branch `gpu/epistemic-tensor-core-next`, owner cursor/grok — read its CLAIM state in `artifacts/omega/agent_handoff.log.md` before writing anything there). Its bundled `bin/madaros-linux-x86_64` is STALE — always pair the default lane with the canonical main binary: `SOUNIO_MADAROS_BIN=/workspace/sounio/bin/madaros-linux-x86_64` (or a fresh build from post-B1 main).
+
+## Steps
+1. Regenerate the conformance artifacts (only 16 of the gate's 21 `.eisax.elf` programs exist in `artifacts/eisa/`): `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tools/eisa/eisa_bridge_emit.sio`, then `bash scripts/ci/eisa_bridge_conformance_gate.sh` → expect 21/21 (differential EVM-vs-native + tamper + anti-vacuity lanes).
+2. Full EISA suite on the LEAN lane (control): all 13 tests in `tests/stdlib/eisa/` via `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run <t>` → record per-test PASS/FAIL + key output lines.
+3. Full EISA suite on the DEFAULT lane (the parity target): same 13 tests via `SOUNIO_MADAROS_BIN=<canonical> ./bin/souc run <t>` → expect 13/13 PASS after WP-B1. Any failure: verbatim error → new-gap ledger, status per-test in your report.
+4. Do NOT attempt to merge `gpu/epistemic-tensor-core-next` into main (~90 conflicts; that integration belongs to Lane 6 / cursor-grok). Instead: document in SCOREBOARD.md exactly which EISA-worktree commits are not yet on main (`git cherry -v origin/main` in the worktree, annotated).
+5. Update the EISA scoreboard entry in `artifacts/omega/agent_handoff.log.md` (append a fresh entry with the 13-test table + gate result + lane state) and SCOREBOARD.md.
+
+## Done criteria
+Conformance 21/21; 13/13 default-lane table published in the handoff log; unmerged-commit inventory documented; scoreboard updated.


### PR DESCRIPTION
Docs-only (pattern of #649). Execution kit at `docs/handoff/continuity/` so Opus/Haiku sessions can carry the two lanes autonomously:

- **SCOREBOARD.md** — single source of truth (WP × status × evidence + new-gap ledger + fixed reference state).
- **BOOTSTRAP.md** — paste-into-session prompt + global guardrails (false-green discipline, serialized surfaces, LoRA resync, real CI gates, 4-cell bisect).
- **WP-A0..A5** — Madaros M-track phase 2 (land #654 → E035 effects → primitive-receiver dispatch → multi-module specializer → SRET wiring → convergence to cd_exact on both engines). Each brief carries verified anchors, witnesses (exit-code-based) and gate batteries.
- **WP-B1..B2** — EISA default-lane: the last open blocker (`str_from_bytes` dep-closure ud2/SIGILL) + conformance refresh (state corrected: format-v0 and evm-arena already fixed on main).

Governance registry regenerated; Docs registry check passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)