### PR TITLE
test(run-pass): fix A4 SRET witnesses to rc=0 convention (unbreak main Full Test Suite)

### DIFF
--- a/tests/run-pass/sret_array4_generic_return.sio
+++ b/tests/run-pass/sret_array4_generic_return.sio
@@ -3,7 +3,10 @@ struct G4<F> { c: [F; 4], bits: i64 }
 fn make4g<F>(a: F, b: F, cc: F, d: F, bits: i64) -> G4<F> with Mut, Panic {
     G4 { c: [a, b, cc, d], bits: bits }
 }
-fn main() -> i64 with Mut, Panic {
+fn main() with IO, Mut, Panic {
     let v = make4g::<i64>(1, 2, 3, 4, 9)
-    v.c[3] + v.bits
+    assert(v.c[3] == 4)
+    assert(v.bits == 9)
+    assert(v.c[3] + v.bits == 13)
+    print("sret_array4_generic_return: PASS\n")
 }

--- a/tests/run-pass/sret_array4_return.sio
+++ b/tests/run-pass/sret_array4_return.sio
@@ -3,7 +3,10 @@ struct S4 { c: [i64; 4], bits: i64 }
 fn make4() -> S4 {
     S4 { c: [1, 2, 3, 4], bits: 9 }
 }
-fn main() -> i64 {
+fn main() with IO {
     let v = make4()
-    v.c[3] + v.bits
+    assert(v.c[3] == 4)
+    assert(v.bits == 9)
+    assert(v.c[3] + v.bits == 13)
+    print("sret_array4_return: PASS\n")
 }

--- a/tests/run-pass/sret_array_args_return.sio
+++ b/tests/run-pass/sret_array_args_return.sio
@@ -3,7 +3,10 @@ struct W { c: [i64; 4], bits: i64 }
 fn fw(p: i64, q: i64, r: i64) -> W with Mut, Panic {
     W { c: [p, q, r, p + q + r], bits: q }
 }
-fn main() -> i64 with Mut, Panic {
+fn main() with IO, Mut, Panic {
     let v = fw(3, 5, 7)
-    v.c[3] + v.bits
+    assert(v.c[3] == 15)
+    assert(v.bits == 5)
+    assert(v.c[3] + v.bits == 20)
+    print("sret_array_args_return: PASS\n")
 }


### PR DESCRIPTION
Main's Full Test Suite went red after #659 (A4) because its 3 new SRET witnesses exit with the computed value (13/13/20) instead of rc=0. `tests/run-pass/` requires rc=0. Rewritten to the `assert(...) + print(PASS)` convention (same as sret_8_field_return.sio), still proving array-field SRET round-trips.

Slurm-verified on a fresh main build: sret_array4_return / sret_array4_generic_return / sret_array_args_return all **rc=0 + PASS**; L0 sret_8_field_return and L4 generic_struct_return still green.

Fixes the only 3 new failures ("Fail: 3", the 124 known-failures are pre-existing).