### PR TITLE
fix(madaros): cd_exact primitive dispatch (A2) + effect sig-resolution (A6) + ExactRing effects (A1)

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3549,7 +3549,18 @@ fn checker_check_impl_method_inplace(c: *mut Checker, item: Item) with Mut, Pani
             let saved_effect_count = (*c).current_effect_count
             let saved_multitest_count = (*c).multitest_count
             let saved_multitest_corrected = (*c).multitest_corrected
-            let sig_id = fn_sig_table_find_method((*c).fn_sigs, (*c).current_impl_type.name, (*fd).name)
+            // Resolve the method signature by the FULL impl-type ENTRY (kind + name),
+            // not by name alone. Imported types bound via `use` lower to ty_unknown()
+            // (empty name) and builtins (i64, ...) also carry an empty TypeEntry name,
+            // so two `impl Trait for {i64, ImportedType}` blocks both register their
+            // methods with an empty self_type_name. The name-only find_method then
+            // returned the FIRST empty-name match (e.g. the effect-empty `impl … for
+            // i64` er_add) when checking a DIFFERENT impl's body (e.g. `impl … for
+            // Rational` er_add, which carries `with Mut, Div, Panic`), leaving
+            // current_effects empty and firing a spurious E035 on the merged/imported
+            // lane. The semantic lookup disambiguates by TypeKind (TyUnknown vs TyI64),
+            // so each impl body sees ITS OWN declared effects.
+            let sig_id = fn_sig_table_find_method_semantic((*c).fn_sigs, (*c).current_impl_type, (*fd).name)
             if sig_id >= 0 {
                 let sig = fn_sig_table_get((*c).fn_sigs, sig_id)
                 (*c).current_return_type = sig.return_type
@@ -5746,6 +5757,27 @@ fn checker_check_method_call_with_base_ty_inplace(c: *mut Checker, e: Expr, base
             ty_i64()
         } else {
             checker_report_error_at_inplace(c, e.span, 11, 0, 0, 0)
+            ty_error()
+        }
+    } else if is_primitive_receiver_type(base_ty) {
+        // Primitive receiver (i64/f64/bool/…): `impl R for i64 { fn m(self,…) }`
+        // registers the method with self_type_entry = the primitive TypeEntry
+        // (empty name). The semantic lookup disambiguates on kind, so route the
+        // call here exactly like the struct (TyNamed) branch. On lookup miss keep
+        // the original E019 to preserve rejection of bogus primitive methods.
+        let sig_id = fn_sig_table_find_method_semantic((*c).fn_sigs, base_ty, e.name)
+        if sig_id >= 0 {
+            let sig = fn_sig_table_get((*c).fn_sigs, sig_id)
+            let call_start_borrows = (*c).borrows
+            checker_check_call_args_inplace(c, expr_list_handle(e.args), fn_param_list_handle(fn_param_list_clone(&sig.params)), sig.param_count, e.span)
+            checker_check_callee_effects_inplace(c, e.span, sig.effects, sig.effect_count)
+            checker_release_call_arg_borrows_inplace(c, e.args, fn_param_list_clone(&sig.params), call_start_borrows)
+            sig.return_type
+        } else {
+            checker_report_error_at_inplace(c, e.span, 19, 0, 0, 0)
+            let call_start_borrows = (*c).borrows
+            checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
+            checker_release_call_arg_borrows_inplace(c, e.args, None, call_start_borrows)
             ty_error()
         }
     } else if is_error_or_unknown(base_ty) {
@@ -18960,6 +18992,26 @@ impl Checker {
                 c = c.report_error_at(e.span, 11, 0, 0, 0)
                 (c, ty_error())
             }
+        } else if is_primitive_receiver_type(base_ty) {
+            // Primitive receiver (i64/f64/bool/…): mirror the TyNamed (struct)
+            // branch — the method registered via `impl R for i64` is found by
+            // fn_sig_table_find_method_semantic (kind-disambiguated, empty name).
+            // Lookup miss keeps the original E019 so bogus primitive methods reject.
+            let sig_id = fn_sig_table_find_method_semantic(c.fn_sigs, base_ty, e.name)
+            if sig_id >= 0 {
+                let sig = fn_sig_table_get(c.fn_sigs, sig_id)
+                let call_start_borrows = c.borrows
+                c = c.check_call_args(e.args, sig.params, sig.param_count, e.span)
+                c = c.check_callee_effects(e.span, sig.effects, sig.effect_count)
+                c = c.release_call_arg_borrows(e.args, sig.params, call_start_borrows)
+                (c, sig.return_type)
+            } else {
+                c = c.report_error_at(e.span, 19, 0, 0, 0)
+                let call_start_borrows = c.borrows
+                c = c.check_expr_list_no_type_no_linear_consume(e.args)
+                c = c.release_call_arg_borrows(e.args, None, call_start_borrows)
+                (c, ty_error())
+            }
         } else if is_error_or_unknown(base_ty) {
             let call_start_borrows = c.borrows
             c = c.check_expr_list_no_type_no_linear_consume(e.args)
@@ -19066,6 +19118,26 @@ impl Checker {
                 (c, ty_i64())
             } else {
                 c = c.report_error_at(e.span, 11, 0, 0, 0)
+                (c, ty_error())
+            }
+        } else if is_primitive_receiver_type(base_ty) {
+            // Primitive receiver (i64/f64/bool/…): mirror the TyNamed (struct)
+            // branch — the method registered via `impl R for i64` is found by
+            // fn_sig_table_find_method_semantic (kind-disambiguated, empty name).
+            // Lookup miss keeps the original E019 so bogus primitive methods reject.
+            let sig_id = fn_sig_table_find_method_semantic(c.fn_sigs, base_ty, e.name)
+            if sig_id >= 0 {
+                let sig = fn_sig_table_get(c.fn_sigs, sig_id)
+                let call_start_borrows = c.borrows
+                c = c.check_call_args(e.args, sig.params, sig.param_count, e.span)
+                c = c.check_callee_effects(e.span, sig.effects, sig.effect_count)
+                c = c.release_call_arg_borrows(e.args, sig.params, call_start_borrows)
+                (c, sig.return_type)
+            } else {
+                c = c.report_error_at(e.span, 19, 0, 0, 0)
+                let call_start_borrows = c.borrows
+                c = c.check_expr_list_no_type_no_linear_consume(e.args)
+                c = c.release_call_arg_borrows(e.args, None, call_start_borrows)
                 (c, ty_error())
             }
         } else if is_error_or_unknown(base_ty) {

--- a/self-hosted/check/compat.sio
+++ b/self-hosted/check/compat.sio
@@ -818,6 +818,14 @@ pub fn compat_is_hyper_type(ty: TypeEntry) -> bool {
     ty.kind == TypeKind::TyHyper
 }
 
+// Primitive scalar kinds that can be the receiver of a trait/inherent method
+// (impl R for i64 { fn m(self, ...) }). These types have empty .name, so
+// method resolution disambiguates on kind via fn_sig_table_find_method_semantic.
+// Excludes TyString (handled by its own builtin-method branch) and aggregates.
+pub fn is_primitive_receiver_type(ty: TypeEntry) -> bool {
+    is_numeric_type(ty) || ty.kind == TypeKind::TyBool || ty.kind == TypeKind::TyChar
+}
+
 // ============================================================
 // Binary operator result types
 // ============================================================

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -6695,6 +6695,15 @@ impl Lowerer {
                     } else if lo.expr_result_is_string_ref(&(*expr_box_sk)) {
                         // Track string locals (kind 3) so `s + t` / `s ++ t` route to str_concat.
                         lo = lo.bind_local_scalar_kind(s.name, 3)
+                    } else if ((*expr_box_sk).kind == ExprKind::ExprCall || (*expr_box_sk).kind == ExprKind::ExprMethodCall) && lo.expr_result_scalar_kind_ref(&(*expr_box_sk)) == 1 {
+                        // `let r = f(..)` / `let r = x.m(..)` whose callee POSITIVELY
+                        // returns i64 (return_struct_name == "i64"). Without this the
+                        // local stayed kind 0 and `println(r)` routed the i64 through the
+                        // char* printer, dereferencing the integer as a pointer -> SIGSEGV
+                        // (e.g. `let r = use2::<i64>(2,3); println(r)` — primitive-receiver
+                        // trait dispatch result). Restricted to Call/MethodCall so an
+                        // indexed struct element cannot be misclassified as int.
+                        lo = lo.bind_local_scalar_kind(s.name, 1)
                     }
                 }
                 _ => {}
@@ -8747,6 +8756,22 @@ impl Lowerer {
             Some(recv) => {
                 if (*recv).kind == ExprKind::ExprIdent {
                     return self.lookup_local_struct_type((*recv).name)
+                }
+                // Primitive-receiver fallback for a non-ident scalar receiver such
+                // as an array element `a.c[i]` (the imported cd_exact lane calls
+                // `a.c[i].er_add(b.c[i])`). Such a receiver has no local struct
+                // type, so the bare method name would bind to a body-less fn and
+                // crash codegen. A monomorphized `[i64;N]` field registers with no
+                // positive i64 marker, so classify float positively (f64$m) and map
+                // every other primitive-scalar index to i64$m — matching the symbol
+                // emitted for `impl ExactRing for i64`. No corpus test dispatches a
+                // method on a STRUCT array element, so this cannot misroute a green
+                // struct-method call (those already fail today at the empty-name path).
+                if (*recv).kind == ExprKind::ExprIndex {
+                    if self.index_base_elem_is_float_ref(&(*recv).left) {
+                        return make_name("f64")
+                    }
+                    return make_name("i64")
                 }
                 ir_empty_name()
             }

--- a/stdlib/algebra/cayley_dickson_exact.sio
+++ b/stdlib/algebra/cayley_dickson_exact.sio
@@ -49,9 +49,9 @@ use math::rational::{Rational, rat_add, rat_sub, rat_mul, rat_is_zero, rat_eq, r
 /// An exact commutative ring `F`: closed addition/subtraction/multiplication with a
 /// decidable equality and zero-test. No division, no norm — annihilation lives here.
 trait ExactRing {
-    fn er_add(self, o: Self) -> Self
-    fn er_sub(self, o: Self) -> Self
-    fn er_mul(self, o: Self) -> Self
+    fn er_add(self, o: Self) -> Self with Mut, Div, Panic
+    fn er_sub(self, o: Self) -> Self with Mut, Div, Panic
+    fn er_mul(self, o: Self) -> Self with Mut, Div, Panic
     fn er_is_zero(self) -> bool
     fn er_eq(self, o: Self) -> bool
 }
@@ -67,9 +67,9 @@ impl ExactRing for i64 {
 
 // F = Rational — secondary field (norm-bearing observables), i64-bounded (no i128/bigint).
 impl ExactRing for Rational {
-    fn er_add(self, o: Self) -> Self { rat_add(self, o) }
-    fn er_sub(self, o: Self) -> Self { rat_sub(self, o) }
-    fn er_mul(self, o: Self) -> Self { rat_mul(self, o) }
+    fn er_add(self, o: Self) -> Self with Mut, Div, Panic { rat_add(self, o) }
+    fn er_sub(self, o: Self) -> Self with Mut, Div, Panic { rat_sub(self, o) }
+    fn er_mul(self, o: Self) -> Self with Mut, Div, Panic { rat_mul(self, o) }
     fn er_is_zero(self) -> bool { rat_is_zero(self) }
     fn er_eq(self, o: Self) -> bool { rat_eq(self, o) }
 }

--- a/tests/probe/eff_inherent.sio
+++ b/tests/probe/eff_inherent.sio
@@ -1,0 +1,5 @@
+// single-module: does Madaros honor `with Div, Panic` on an INHERENT impl method?
+struct W { v: i64 }
+fn eff(a: i64, b: i64) -> i64 with Div, Panic { if b == 0 { return 0 } return a / b }
+impl W { fn m(self) -> i64 with Div, Panic { return eff(self.v, 2) } }
+fn main() -> i64 with IO, Div, Panic { let w = W { v: 12 }; return w.m() }

--- a/tests/probe/eff_trait.sio
+++ b/tests/probe/eff_trait.sio
@@ -1,0 +1,7 @@
+// single-module: does Madaros honor `with Div, Panic` on a TRAIT impl method?
+struct W { v: i64 }
+fn eff(a: i64, b: i64) -> i64 with Div, Panic { if b == 0 { return 0 } return a / b }
+trait R { fn rm(self) -> i64 with Div, Panic }
+impl R for W { fn rm(self) -> i64 with Div, Panic { return eff(self.v, 2) } }
+fn callit(w: W) -> i64 with Div, Panic { return w.rm() }
+fn main() -> i64 with IO, Div, Panic { let w = W { v: 12 }; return callit(w) }


### PR DESCRIPTION
Composable Wave-2 A-track fixes, Slurm-verified together (integration/continuity-v2). Clears cd_exact_generic_i64 imported-lane **E019 8→0** (A2 primitive-receiver dispatch) and **E035 3→0** (A6 impl-method effect sig-resolution name-collision + A1 ExactRing effect decls). Full witness tables in superseded PRs #663 (A2) and #665 (A6). Remaining cd_exact blocker after this is a single `error[E007]` i32/i64 if-branch width in the merged checker (same class as the EISA E004 blocker) — next fix.