### PR TITLE
feat(exact): quartet↔fiber incidence — the 42 quartets form 2·K₇ on the 7 fibers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion quartet-fiber incidence cross-verification
+        run: bash scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
       - name: Upload contract artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 880
-- Repo-backed topics: 730
+- Total governed topics: 881
+- Repo-backed topics: 731
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 168
+- Authority count `historical`: 169
 - Authority count `repo_only`: 524
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 217 topics
+- A6: 218 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -667,6 +667,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.runtime-abi-gate-blocker-2026-06-23 | historical | docs/research/runtime-abi-gate-blocker-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.runtime-abi-gate-blocker-query-envelope-2026-06-24 | historical | docs/research/runtime-abi-gate-blocker-query-envelope-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sat-rup-microkernel-2026-06-23 | historical | docs/research/sat-rup-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zero-divisor-geometry-report | historical | docs/research/SEDENION_ZERO_DIVISOR_GEOMETRY_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.self-hosted-hypercomplex | historical | docs/research/self_hosted_hypercomplex.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.smt-farkas-microkernel-2026-06-23 | historical | docs/research/smt-farkas-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14711,6 +14711,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-quartet-fiber-incidence",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_quartet_fiber_incidence.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-zero-divisor-geometry-report",
       "collection": "repo",
       "repo_doc_path": "docs/research/SEDENION_ZERO_DIVISOR_GEOMETRY_REPORT.md",

--- a/docs/research/sedenion_quartet_fiber_incidence.md
+++ b/docs/research/sedenion_quartet_fiber_incidence.md
@@ -1,0 +1,69 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-quartet-fiber-incidence
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-quartet-fiber-incidence
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The quartet↔fiber incidence of the sedenion ZD geometry: 42 quartets = 2·K₇ (executed exactly)
+
+**One line.** The two factorizations of the sedenion zero-divisor `168` — `7 fibers × 24 edges` and
+`42 quartets × 4 pairs` — interlock exactly: each support-quartet's 4 pairs split across exactly **2
+fibers**, and the **42 quartets, viewed as edges on the 7 fibers, form the doubled complete graph
+`2·K₇`** — every one of the `C(7,2) = 21` fiber-pairs is joined by exactly 2 quartets, and every
+fiber has incidence-degree 12. Executed exactly and verified on three independent legs.
+
+## The two factorizations, interlocked
+
+- `sedenion_zd_fibers.md`: the 84 participating primitives split into 7 fibers by `L = lo⊕hi ∈ {9..15}`;
+  annihilation is intra-fiber, `168 = 7 × 24`.
+- `sedenion_zd_quartets.md`: the 168 pairs group by support-union into 42 quartets, `168 = 42 × 4`.
+
+This note is the bridge: a quartet's 4 pairs are **not** all in one fiber — they split `2 + 2` across
+two fibers. Treating each quartet as the edge `{L₁, L₂}` it joins gives a multigraph on the 7 fibers.
+
+## Result
+
+| Quantity | Value |
+|---|---|
+| zero-divisor pairs | 168 |
+| fibers a quartet spans | exactly **2** |
+| distinct fiber-pairs used | **21 = C(7,2)** (all of them) |
+| quartets per fiber-pair | exactly **2** (`2 × 21 = 42`) |
+| incidence-degree of each fiber | **12** |
+
+So the 42 quartets are exactly `2·K₇` on the 7 fibers: the complete graph on the seven fibers, each
+edge doubled. The zero-divisor geometry is a **doubled-K₇ of 12-vertex fibers**, all bounded by the
+`e8` seam.
+
+## Honest scope
+
+The individual factorizations (`7 × 24`, `42 × 4`) are from the Python geometry report. The **`2·K₇`
+incidence** relating them — every fiber-pair joined by exactly 2 quartets — is executed and verified
+here on three legs (souc, Python oracle, Lean `native_decide`). All three transcribe the same sign
+law; Lean is the independent checker.
+
+## Certification
+
+- **Executed in Sounio:** `tests/run-pass/sedenion_quartet_fiber_incidence.sio` (self-contained, no #637).
+  Verdict `INCIDENCE OK` (`PAIRS 168 / FIBERPAIRS 21 / BAD_FIBERS 0 / BAD_PAIRCT 0 / BAD_DEG 0`).
+- **Cross-toolchain:** `scripts/ci/sedenion_quartet_fiber_incidence_gate.sh` — souc vs the Python oracle
+  (which emits the 21 fiber-pair records). Registered in CI (Contracts); under `bin/souc` and stage2.
+- **Lean:** `formal/lean4/SounioSedenionIncidence.lean` `native_decide`-proves `pairs_168`,
+  `each_quartet_spans_2`, `fiberpairs_21`, `two_per_fiberpair`. `lake build` green; Lean Proofs CI job.
+
+## Reproduce
+
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_quartet_fiber_incidence.sio
+python3 scripts/research/sedenion_quartet_fiber_incidence_oracle.py
+bash scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
+(cd formal/lean4 && lake build SounioSedenionIncidence)
+```

--- a/formal/lean4/SounioSedenionIncidence.lean
+++ b/formal/lean4/SounioSedenionIncidence.lean
@@ -1,0 +1,64 @@
+/-
+  SounioSedenionIncidence — independent-spec (Lean native_decide) leg for the quartet<->fiber
+  incidence of the sedenion ZD geometry (Frente B): the 42 support-quartets, as edges on the 7
+  fibers L = lo^hi in {9..15}, form exactly 2*K_7 — every C(7,2)=21 fiber-pair joined by exactly 2
+  quartets, every fiber of incidence-degree 12. Companion to
+  tests/run-pass/sedenion_quartet_fiber_incidence.sio. Mathlib-free, no sorry.
+-/
+namespace SounioSedenionIncidence
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def sedSigma (a b : Nat) : Int := cdSigma a b 4
+def primProd (ulo uhi : Nat) (un : Bool) (vlo vhi : Nat) (vn : Bool) (k : Nat) : Int :=
+  let su : Int := if un then -1 else 1
+  let sv : Int := if vn then -1 else 1
+  (if (ulo ^^^ vlo) == k then sedSigma ulo vlo else 0)
+  + (if (ulo ^^^ vhi) == k then sv * sedSigma ulo vhi else 0)
+  + (if (uhi ^^^ vlo) == k then su * sedSigma uhi vlo else 0)
+  + (if (uhi ^^^ vhi) == k then su * sv * sedSigma uhi vhi else 0)
+def isZeroPair (ulo uhi : Nat) (un : Bool) (vlo vhi : Nat) (vn : Bool) : Bool :=
+  (List.range 16).all (fun k => primProd ulo uhi un vlo vhi vn k == 0)
+abbrev V := Nat × Nat × Bool
+def cands : List V :=
+  (List.range 7).flatMap (fun i => (List.range 8).flatMap (fun j => [(i+1, j+8, false), (i+1, j+8, true)]))
+def adjacent (u v : V) : Bool := isZeroPair u.1 u.2.1 u.2.2 v.1 v.2.1 v.2.2
+def participates (c : V) : Bool := cands.any (fun d => adjacent c d)
+def parts : List V := cands.filter participates
+def qmaskOf (a b : V) : Nat := (2^a.1) ||| (2^a.2.1) ||| (2^b.1) ||| (2^b.2.1)
+
+/-- (mask, fiber-label) for each of the 168 unordered annihilation pairs (intra-fiber: both share L). -/
+def pairData : List (Nat × Nat) :=
+  (List.range parts.length).flatMap (fun i => (List.range parts.length).filterMap (fun j =>
+    if i < j && adjacent parts[i]! parts[j]! then
+      some (qmaskOf parts[i]! parts[j]!, parts[i]!.1 ^^^ parts[i]!.2.1) else none))
+
+def masks : List Nat := (pairData.map (·.1)).eraseDups
+
+/-- the 2 fiber-labels a quartet touches, as (min,max). -/
+def fibersOf (mask : Nat) : Nat × Nat :=
+  let ls := (pairData.filter (·.1 == mask)).map (·.2) |>.eraseDups
+  (ls.foldl Nat.min 99, ls.foldl Nat.max 0)
+
+def fiberPairs : List (Nat × Nat) := (masks.map fibersOf).eraseDups
+
+theorem pairs_168 : pairData.length = 168 := by native_decide
+/-- every quartet spans exactly 2 distinct fibers. -/
+theorem each_quartet_spans_2 :
+    masks.all (fun m => ((pairData.filter (·.1 == m)).map (·.2)).eraseDups.length == 2) = true := by native_decide
+/-- the 42 quartets form 2*K_7 on the 7 fibers: all 21 fiber-pairs, each carrying exactly 2 quartets. -/
+theorem fiberpairs_21 : fiberPairs.length = 21 := by native_decide
+theorem two_per_fiberpair :
+    fiberPairs.all (fun fp => (masks.filter (fun m => fibersOf m == fp)).length == 2) = true := by native_decide
+
+end SounioSedenionIncidence

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -72,6 +72,10 @@ lean_lib «SounioZeroDivisorBridge» where
 @[default_target]
 lean_lib «SounioSedenionMeasurement» where
 
+-- Frente B: quartet<->fiber incidence of the sedenion ZD geometry (42 quartets = 2*K_7 on 7 fibers).
+@[default_target]
+lean_lib «SounioSedenionIncidence» where
+
 @[default_target]
 lean_lib «SounioImpossibilityChain» where
 

--- a/scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
+++ b/scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate for the quartet<->fiber incidence (Frente B): the 42 quartets form 2*K_7 on the
+# 7 fibers. souc executes the incidence; the Python oracle recomputes it (+ emits the 21 fiber-pair
+# records); /usr/bin/diff on the summary. A bare PASS is not proof.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/i.elf" >/dev/null 2>&1; chmod +x "$WORK/i.elf"; "$WORK/i.elf" 2>/dev/null; fi }
+echo "[quartet-fiber-incidence] running souc + oracle ..."
+run_souc tests/run-pass/sedenion_quartet_fiber_incidence.sio > "$WORK/souc.txt"
+python3 scripts/research/sedenion_quartet_fiber_incidence_oracle.py > "$WORK/py.txt"
+field() { grep -m1 "^$1 " "$2" | awk '{print $2}'; }
+fail=0
+for key in PAIRS FIBERPAIRS BAD_FIBERS BAD_PAIRCT BAD_DEG; do
+  s=$(field "$key" "$WORK/souc.txt"); p=$(field "$key" "$WORK/py.txt")
+  [ "$s" = "$p" ] || { echo "MISMATCH $key: souc=$s oracle=$p"; fail=1; }
+done
+[ "$(field PAIRS "$WORK/souc.txt")" = "168" ]      || { echo "souc PAIRS != 168"; fail=1; }
+[ "$(field FIBERPAIRS "$WORK/souc.txt")" = "21" ]  || { echo "souc FIBERPAIRS != 21"; fail=1; }
+[ "$(grep -c '^INCIDENCE OK' "$WORK/souc.txt")" = "1" ] || { echo "souc verdict != INCIDENCE OK"; fail=1; }
+[ "$(grep -c '^FP ' "$WORK/py.txt")" = "21" ]      || { echo "oracle FP count != 21"; fail=1; }
+[ "$(field INCIDENCE "$WORK/py.txt")" = "OK" ]     || { echo "oracle verdict != OK"; fail=1; }
+[ "$fail" -eq 0 ] || { echo "quartet-fiber-incidence gate: FAIL"; exit 1; }
+echo "CROSS-VERIFIED: souc == oracle — the 42 quartets form 2*K_7 on the 7 fibers"
+echo "  (all 21 fiber-pairs, 2 quartets each; every fiber incidence-degree 12; each quartet spans 2 fibers)."
+echo "quartet-fiber-incidence gate: PASS"

--- a/scripts/research/sedenion_quartet_fiber_incidence_oracle.py
+++ b/scripts/research/sedenion_quartet_fiber_incidence_oracle.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Independent oracle for the quartet<->fiber incidence of the sedenion ZD geometry (Frente B):
+the 42 support-quartets, as edges on the 7 fibers L=lo^hi in {9..15}, form exactly 2*K_7 — every one
+of the C(7,2)=21 fiber-pairs joined by exactly 2 quartets, every fiber of incidence degree 12.
+
+Non-souc leg of scripts/ci/sedenion_quartet_fiber_incidence_gate.sh.
+Output:
+  FP <l1> <l2> <n>   per used fiber-pair, count of quartets on it (all 21 pairs, n=2)
+  PAIRS <n>          zero-divisor pairs (168)
+  FIBERPAIRS <n>     distinct fiber-pairs used (21)
+  BAD_FIBERS <n>     quartets not spanning exactly 2 fibers (0)
+  BAD_PAIRCT <n>     fiber-pairs not carrying exactly 2 quartets (0)
+  BAD_DEG <n>        fibers not of incidence-degree 12 (0)
+  INCIDENCE <OK|FAIL>
+"""
+from __future__ import annotations
+from collections import defaultdict
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    a_hi, b_hi = a >= half, b >= half
+    a_lo, b_lo = a & (half - 1), b & (half - 1)
+    if not a_hi and not b_hi:
+        return cd_sigma(a_lo, b_lo, bits - 1)
+    if not a_hi and b_hi:
+        return cd_sigma(b_lo, a_lo, bits - 1)
+    if a_hi and not b_hi:
+        return cd_sigma(a_lo, b_lo, bits - 1) if b_lo == 0 else -cd_sigma(a_lo, b_lo, bits - 1)
+    return -cd_sigma(b_lo, a_lo, bits - 1) if b_lo == 0 else cd_sigma(b_lo, a_lo, bits - 1)
+
+
+def mul(a, b):
+    out = {}
+    for i, ci in a.items():
+        for j, cj in b.items():
+            k = i ^ j
+            out[k] = out.get(k, 0) + cd_sigma(i, j) * ci * cj
+            if out[k] == 0:
+                del out[k]
+    return out
+
+
+def vec(c):
+    lo, hi, neg = c
+    return {lo: 1, hi: (-1 if neg == 1 else 1)}
+
+
+def main() -> None:
+    cands = [(lo, hi, neg) for lo in range(1, 8) for hi in range(8, 16) for neg in (0, 1)]
+    part = [c for c in cands if any(not mul(vec(c), vec(b)) for b in cands)]
+    qfibers = defaultdict(set)
+    npair = 0
+    for i in range(len(part)):
+        for j in range(i + 1, len(part)):
+            if not mul(vec(part[i]), vec(part[j])):
+                a, b = part[i], part[j]
+                q = (1 << a[0]) | (1 << a[1]) | (1 << b[0]) | (1 << b[1])
+                qfibers[q].add(a[0] ^ a[1])
+                qfibers[q].add(b[0] ^ b[1])
+                npair += 1
+    bad_fibers = sum(1 for s in qfibers.values() if len(s) != 2)
+    fp = defaultdict(int)
+    for s in qfibers.values():
+        l1, l2 = sorted(s)[:2] if len(s) >= 2 else (min(s), min(s))
+        fp[(l1, l2)] += 1
+    bad_pairct = sum(1 for c in fp.values() if c != 2)
+    deg = defaultdict(int)
+    for (l1, l2), c in fp.items():
+        deg[l1] += c
+        deg[l2] += c
+    bad_deg = sum(1 for f in range(9, 16) if deg[f] != 12)
+    for (l1, l2) in sorted(fp):
+        print(f"FP {l1} {l2} {fp[(l1, l2)]}")
+    print(f"PAIRS {npair}")
+    print(f"FIBERPAIRS {len(fp)}")
+    print(f"BAD_FIBERS {bad_fibers}")
+    print(f"BAD_PAIRCT {bad_pairct}")
+    print(f"BAD_DEG {bad_deg}")
+    ok = npair == 168 and len(fp) == 21 and bad_fibers == 0 and bad_pairct == 0 and bad_deg == 0
+    print(f"INCIDENCE {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_quartet_fiber_incidence.sio
+++ b/tests/run-pass/sedenion_quartet_fiber_incidence.sio
@@ -1,0 +1,195 @@
+//@ run-pass
+//@ expect-stdout: INCIDENCE OK
+// FRENTE B — the quartet <-> fiber incidence of the sedenion ZD geometry, executed exactly.
+//
+// The two factorizations of the ZD 168 are 7 fibers x 24 edges (sedenion_zd_fibers.sio) and 42
+// quartets x 4 pairs (sedenion_zd_quartets.sio). This proves how they interlock: each support-
+// quartet's 4 pairs split across exactly 2 fibers (2 pairs each), and the 42 quartets, viewed as
+// edges on the 7 fibers {9..15}, form exactly the DOUBLED COMPLETE GRAPH 2*K_7:
+//   * every one of the C(7,2) = 21 fiber-pairs is joined by exactly 2 quartets  (2*21 = 42);
+//   * every fiber has incidence degree 12 (pairs with 6 others x 2 quartets).
+//
+// Decidable integer equality over Z, no float. SELF-CONTAINED (no #637). Cross-verified vs
+// scripts/research/sedenion_quartet_fiber_incidence_oracle.py by the matching gate + Lean file.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+fn sed_sigma(a: i64, b: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, b, 4) }
+fn prim_prod(ulo: i64, uhi: i64, uneg: i64, vlo: i64, vhi: i64, vneg: i64, k: i64) -> i64 with Mut, Panic, Div {
+    let su = if uneg == 1 { 0 - 1 } else { 1 }
+    let sv = if vneg == 1 { 0 - 1 } else { 1 }
+    var acc = 0
+    if (ulo ^ vlo) == k { acc = acc + sed_sigma(ulo, vlo) }
+    if (ulo ^ vhi) == k { acc = acc + sv * sed_sigma(ulo, vhi) }
+    if (uhi ^ vlo) == k { acc = acc + su * sed_sigma(uhi, vlo) }
+    if (uhi ^ vhi) == k { acc = acc + su * sv * sed_sigma(uhi, vhi) }
+    acc
+}
+fn is_zero_pair(ulo: i64, uhi: i64, uneg: i64, vlo: i64, vhi: i64, vneg: i64) -> bool with Mut, Panic, Div {
+    var k = 0
+    while k < 16 {
+        if prim_prod(ulo, uhi, uneg, vlo, vhi, vneg, k) != 0 { return false }
+        k = k + 1
+    }
+    true
+}
+
+fn main() with IO, Mut, Panic, Div {
+    // participating vertices
+    var clo = [0; 112]
+    var chi = [0; 112]
+    var cneg = [0; 112]
+    var n = 0
+    var lo = 1
+    while lo <= 7 {
+        var hi = 8
+        while hi <= 15 {
+            var neg = 0
+            while neg <= 1 {
+                clo[n as usize] = lo
+                chi[n as usize] = hi
+                cneg[n as usize] = neg
+                n = n + 1
+                neg = neg + 1
+            }
+            hi = hi + 1
+        }
+        lo = lo + 1
+    }
+    var plo = [0; 84]
+    var phi = [0; 84]
+    var png = [0; 84]
+    var m = 0
+    var i = 0
+    while i < n {
+        var parti = 0
+        var j = 0
+        while j < n {
+            if is_zero_pair(clo[i as usize], chi[i as usize], cneg[i as usize], clo[j as usize], chi[j as usize], cneg[j as usize]) {
+                parti = 1
+            }
+            j = j + 1
+        }
+        if parti == 1 && m < 84 {
+            plo[m as usize] = clo[i as usize]
+            phi[m as usize] = chi[i as usize]
+            png[m as usize] = cneg[i as usize]
+            m = m + 1
+        }
+        i = i + 1
+    }
+
+    // collect the 168 pairs' quartet mask + fiber label (L = lo^hi; intra-fiber so both endpoints share L)
+    var qmask = [0; 200]
+    var qL = [0; 200]
+    var npair = 0
+    var a = 0
+    while a < m {
+        var b = a + 1
+        while b < m {
+            if is_zero_pair(plo[a as usize], phi[a as usize], png[a as usize], plo[b as usize], phi[b as usize], png[b as usize]) {
+                if npair < 200 {
+                    qmask[npair as usize] = (1 << plo[a as usize]) | (1 << phi[a as usize]) | (1 << plo[b as usize]) | (1 << phi[b as usize])
+                    qL[npair as usize] = plo[a as usize] ^ phi[a as usize]
+                    npair = npair + 1
+                }
+            }
+            b = b + 1
+        }
+        a = a + 1
+    }
+
+    // fiber-pair incidence: for each distinct quartet, find its 2 fiber labels, bump fiberpair[L1*16+L2]
+    var fpcount = [0; 256]
+    var bad_fibers = 0
+    var p = 0
+    while p < npair {
+        var first = 1
+        var q = 0
+        while q < p {
+            if qmask[q as usize] == qmask[p as usize] { first = 0 }
+            q = q + 1
+        }
+        if first == 1 {
+            // distinct fiber labels among this quartet's pairs
+            var lmin = 99
+            var lmax = 0
+            var r = 0
+            while r < npair {
+                if qmask[r as usize] == qmask[p as usize] {
+                    if qL[r as usize] < lmin { lmin = qL[r as usize] }
+                    if qL[r as usize] > lmax { lmax = qL[r as usize] }
+                }
+                r = r + 1
+            }
+            if lmin == lmax { bad_fibers = bad_fibers + 1 }
+            let key = lmin * 16 + lmax
+            fpcount[key as usize] = fpcount[key as usize] + 1
+        }
+        p = p + 1
+    }
+
+    // count distinct fiber-pairs, each hosting exactly 2 quartets; fiber degrees
+    var fiberpairs = 0
+    var bad_pairct = 0
+    var deg = [0; 16]
+    var l1 = 9
+    while l1 <= 15 {
+        var l2 = l1 + 1
+        while l2 <= 15 {
+            let c = fpcount[(l1 * 16 + l2) as usize]
+            if c > 0 {
+                fiberpairs = fiberpairs + 1
+                if c != 2 { bad_pairct = bad_pairct + 1 }
+                deg[l1 as usize] = deg[l1 as usize] + c
+                deg[l2 as usize] = deg[l2 as usize] + c
+            }
+            l2 = l2 + 1
+        }
+        l1 = l1 + 1
+    }
+    var bad_deg = 0
+    var f = 9
+    while f <= 15 {
+        if deg[f as usize] != 12 { bad_deg = bad_deg + 1 }
+        f = f + 1
+    }
+
+    print("PAIRS ")
+    print_int(npair as i64)
+    print("\n")
+    print("FIBERPAIRS ")
+    print_int(fiberpairs as i64)
+    print("\n")
+    print("BAD_FIBERS ")
+    print_int(bad_fibers as i64)
+    print("\n")
+    print("BAD_PAIRCT ")
+    print_int(bad_pairct as i64)
+    print("\n")
+    print("BAD_DEG ")
+    print_int(bad_deg as i64)
+    print("\n")
+    // 168 pairs ; 21 fiber-pairs (all C(7,2)) ; each quartet spans 2 fibers ; each fiber-pair has 2
+    // quartets ; each fiber degree 12  =>  the 42 quartets form 2*K_7 on the 7 fibers.
+    if npair == 168 && fiberpairs == 21 && bad_fibers == 0 && bad_pairct == 0 && bad_deg == 0 {
+        println("INCIDENCE OK")
+    } else {
+        println("INCIDENCE FAIL")
+    }
+}


### PR DESCRIPTION
## Summary
**Frente B.** Bridges the two factorizations of the sedenion ZD `168` (`7 fibers × 24` and `42 quartets × 4`, #660/#670): each quartet's 4 pairs split **2 + 2 across exactly 2 fibers**, and the **42 quartets, as edges on the 7 fibers, form the doubled complete graph `2·K₇`** — all `21 = C(7,2)` fiber-pairs joined by exactly 2 quartets, every fiber of incidence-degree 12.

So the whole zero-divisor geometry is a **doubled-K₇ of 12-vertex fibers**, bounded by the `e8` seam.

## Three legs
- **souc**: `tests/run-pass/sedenion_quartet_fiber_incidence.sio` → `INCIDENCE OK` (`PAIRS 168 / FIBERPAIRS 21 / BAD_FIBERS 0 / BAD_PAIRCT 0 / BAD_DEG 0`).
- **Python oracle**: `scripts/research/sedenion_quartet_fiber_incidence_oracle.py` (emits the 21 fiber-pair records).
- **Lean `native_decide`**: `formal/lean4/SounioSedenionIncidence.lean` → `pairs_168`, `each_quartet_spans_2`, `fiberpairs_21`, `two_per_fiberpair`; `lake build` green.
- **Gate**: `scripts/ci/sedenion_quartet_fiber_incidence_gate.sh`, souc==oracle under `bin/souc` AND stage2; CI-registered.

## Honest scope
The individual factorizations are from the Python geometry report; the `2·K₇` incidence relating them is executed and 3-leg verified here. Self-contained (no #637); independent of #651. Shares ci.yml/lakefile anchors with the other Frente-B PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)