### PR TITLE
feat(exact): the 168 IS a group — sedenion signed-automorphism group PSL(2,7), fixing e₈

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 888
-- Repo-backed topics: 738
+- Total governed topics: 889
+- Repo-backed topics: 739
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 174
+- Authority count `historical`: 175
 - Authority count `repo_only`: 526
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 223 topics
+- A6: 224 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -670,6 +670,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.runtime-abi-gate-blocker-query-envelope-2026-06-24 | historical | docs/research/runtime-abi-gate-blocker-query-envelope-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sat-rup-microkernel-2026-06-23 | historical | docs/research/sat-rup-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-associator-1848 | historical | docs/research/sedenion_associator_1848.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-automorphism-168 | historical | docs/research/sedenion_automorphism_168.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-e8-boundary | historical | docs/research/sedenion_e8_boundary.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-fiber-identity | historical | docs/research/sedenion_zd_fiber_identity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14779,6 +14779,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-automorphism-168",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_automorphism_168.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-e8-boundary",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_e8_boundary.md",

--- a/docs/research/sedenion_automorphism_168.md
+++ b/docs/research/sedenion_automorphism_168.md
@@ -1,0 +1,73 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-automorphism-168
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-automorphism-168
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The 168 IS a group: the sedenion signed-automorphism group ≅ PSL(2,7), fixing e₈ (executed)
+
+**One line.** The `168 = |PSL(2,7)|` that pervades the sedenion geometry (the ZD census, the non-Fano
+count, the 7 fibers, the 42 quartets, the `1848 = 11·168` associator side) **is a genuine group**: the
+sedenion **signed-automorphism group** `Aut(𝕊)`, of order **168**, sitting inside `GL(4,2) ≅ A₈` (order
+20160) at index 120. And it **fixes e₈** — the octonion→sedenion doubling seam is the *unique fixed
+point* of the whole symmetry group. Consequently **`1848 = 11·168` is NOT a group order**: the 168 is a
+group, but the 11 is combinatorial (the e₈-grade factor), not a group index.
+
+## Definition
+
+A linear map `M ∈ GL(d,2)` acts on the imaginary indices `1..2^d−1` as `F₂^d` vectors (so it preserves
+`⊕`). `M` is a **signed automorphism** iff there are signs `ε: index → ±1` with `φ(e_i) = ε(i) e_{Mi}`
+an algebra automorphism — equivalently iff the sign ratio `σ(Mi,Mj)·σ(i,j)` is a coboundary
+`δε(i,j) = ε(i)ε(j)ε(i⊕j)`. This is a decidable `F₂` linear-consistency check.
+
+## Result
+
+| Tower | signed automorphisms | ambient |
+|---|---|---|
+| octonions `{1..7}` | **168** = `\|GL(3,2)\|` | all of `GL(3,2)` |
+| sedenions `{1..15}` | **168** | index 120 in `\|GL(4,2)\| = 20160 = \|A₈\|` |
+
+- **The sedenion group fixes e₈**: the orbit of index 8 is the singleton `{8}`. The orbit partition of
+  `{1..15}` is `{1..7} ∪ {8} ∪ {9..15}` — the octonionic units, the lone doubling generator e₈, and the
+  doubled units. Every automorphism restricts to an octonion (Fano) automorphism and acts on the doubled
+  copy accordingly; e₈ is untouched.
+- **So the e₈ throughline is group-theoretic**: e₈ bounds the zero-divisor set (`sedenion_e8_boundary.md`)
+  and carries the extra `168` on the associator side (`sedenion_associator_1848.md`) *because* it is the
+  unique fixed point of `Aut(𝕊)`. The group is why 168 recurs — it acts on the 84 ZD vertices, the 168
+  pairs, the 7 fibers, the 42 quartets, and the 1848 associator triples.
+- **`1848 = 11·168` is not a group order.** `Aut(𝕊)` has order 168; the 11 is the combinatorial
+  grade-decomposition factor (`11 = 10 + 1`, the e₈ grade carrying the extra copy). This settles, in the
+  honest negative, the open group-interpretation question of `#668`.
+
+## Honest scope + a caught compiler defect
+
+The order-168 claim is standard for octonions (`Aut ≅ GL(3,2) = PSL(2,7)`); the sedenion count and the
+e₈-fixed-point are computed here. **Cross-verification caught a real compiler defect**: the committed
+`bin/souc` **miscompiles** the `d=4` `GL(4,2)` sweep (returns 17882 / 432, varying with the code) while
+the fresh **stage2** souc, an independent Python oracle (rigorous highest-bit-pivot Gaussian), and Lean
+`native_decide` all agree on **168**. A separate lesson: an order-*dependent* F₂ reduction can give a
+plausible-but-wrong count — the certified computation uses rigorous highest-bit pivoting.
+
+## Certification (3 legs; no `bin/souc` gate — it miscompiles this)
+
+- **Executed in Sounio (stage2):** `tests/run-pass/sedenion_automorphism_168.sio` → `AUT OK`
+  (`OCT_AUTOS 168 / SED_AUTOS 168 / SED_FIX_E8 168`), run by the Full Test Suite (stage2 souc). ~0.35 s.
+- **Python oracle:** `scripts/research/sedenion_automorphism_168_oracle.py` → 168/168/168, orbit of e₈ = `{8}`.
+- **Lean `native_decide`:** `formal/lean4/SounioSedenionAutomorphism.lean` → `oct_168`, `sed_168`,
+  `sed_fix_e8_168`. Non-`default_target` (three GL(4,2) sweeps, ~1 min): `lake build SounioSedenionAutomorphism`.
+
+## Reproduce
+
+```bash
+SOUNIO_TEST_SOUC_BIN=/path/to/souc-stage2  # bin/souc MISCOMPILES this; use a fresh stage2
+python3 scripts/research/sedenion_automorphism_168_oracle.py
+(cd formal/lean4 && lake build SounioSedenionAutomorphism)
+```

--- a/formal/lean4/SounioSedenionAutomorphism.lean
+++ b/formal/lean4/SounioSedenionAutomorphism.lean
@@ -1,0 +1,83 @@
+/-
+  SounioSedenionAutomorphism — the group behind every 168 (Frente B), by Lean native_decide.
+
+  The 168 = |PSL(2,7)| that pervades the sedenion geometry IS a genuine group: the sedenion
+  SIGNED-AUTOMORPHISM group. A linear M in GL(d,2) (acting on indices 1..2^d-1 as F_2^d vectors,
+  preserving xor) is a signed automorphism iff sigma(Mi,Mj)*sigma(i,j) is a coboundary. We count them
+  by rigorous highest-bit-pivot F_2 elimination:
+    * octonions {1..7}: 168 = |GL(3,2)|          (oct_168)
+    * sedenions {1..15}: 168 (of |GL(4,2)|=20160)  (sed_168)  — the SAME 168
+    * ALL sedenion autos FIX e8 (index 8)          (sed_fix_e8_168) — e8 is the unique fixed point.
+  So 168 is Aut ~ PSL(2,7); 1848 = 11*168 is NOT a group order (the 11 is combinatorial).
+
+  NOT a @[default_target]: three native_decide sweeps over GL(4,2)=65536 matrices take ~1 min; build
+  on demand with `lake build SounioSedenionAutomorphism` (mirrors SounioSatK76/DeGreyUnitDistance).
+  Mathlib-free, no sorry. Companion to tests/run-pass/sedenion_automorphism_168.sio.
+-/
+namespace SounioSedenionAutomorphism
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def par (x : Nat) : Nat := (List.range 8).foldl (fun c b => if x &&& (2^b) != 0 then c+1 else c) 0 % 2
+def apply (M : List Nat) (x d : Nat) : Nat :=
+  (List.range d).foldl (fun y r => if par ((M.getD r 0) &&& x) == 1 then y ||| (2^r) else y) 0
+def invertible (M : List Nat) (d : Nat) : Bool := Id.run do
+  let mut rows := M; let mut rank := 0
+  for col in List.range d do
+    match (List.range d).find? (fun r => r ≥ rank && (rows.getD r 0) &&& (2^col) != 0) with
+    | some piv =>
+        let rr := rows.getD rank 0; let rp := rows.getD piv 0
+        rows := (rows.set rank rp).set piv rr
+        for r in List.range d do
+          if r != rank && (rows.getD r 0) &&& (2^col) != 0 then rows := rows.set r ((rows.getD r 0) ^^^ (rows.getD rank 0))
+        rank := rank + 1
+    | none => pure ()
+  return rank == d
+/-- rigorous highest-variable-bit pivoting (order-independent). -/
+def isAuto (M : List Nat) (d : Nat) : Bool := Id.run do
+  let n := 2^d
+  let mut piv : Array Nat := Array.replicate 16 0
+  for i in List.range n do
+    if i ≥ 1 then
+      for j in List.range n do
+        if j > i then
+          let Mi := apply M i d; let Mj := apply M j d; let k := i ^^^ j
+          let s := cdSigma Mi Mj d * cdSigma i j d
+          let mut m := (2^i) ||| (2^j) ||| (2^k) ||| (if s < 0 then 1 else 0)
+          let mut done := false
+          for _ in List.range (n+2) do
+            if !done then
+              let vpart := m >>> 1
+              if vpart == 0 then
+                if m &&& 1 != 0 then return false
+                done := true
+              else
+                let h := Nat.log2 vpart
+                if piv.getD h 0 == 0 then piv := piv.set! h m; done := true
+                else m := m ^^^ (piv.getD h 0)
+  return true
+def matsOf (d : Nat) : List (List Nat) :=
+  let n := 2^d
+  match d with
+  | 3 => (List.range n).flatMap (fun a => (List.range n).flatMap (fun b => (List.range n).map (fun c => [a,b,c])))
+  | _ => (List.range n).flatMap (fun a => (List.range n).flatMap (fun b =>
+           (List.range n).flatMap (fun c => (List.range n).map (fun e => [a,b,c,e]))))
+def octAutos : Nat := ((matsOf 3).filter (fun M => invertible M 3 && isAuto M 3)).length
+def sedAutos : Nat := ((matsOf 4).filter (fun M => invertible M 4 && isAuto M 4)).length
+def sedFixE8 : Nat := ((matsOf 4).filter (fun M => invertible M 4 && isAuto M 4 && apply M 8 4 == 8)).length
+
+theorem oct_168 : octAutos = 168 := by native_decide
+theorem sed_168 : sedAutos = 168 := by native_decide
+theorem sed_fix_e8_168 : sedFixE8 = 168 := by native_decide
+
+end SounioSedenionAutomorphism

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -72,6 +72,10 @@ lean_lib «SounioZeroDivisorBridge» where
 @[default_target]
 lean_lib «SounioSedenionMeasurement» where
 
+-- Frente B: the sedenion signed-automorphism group = 168 = |PSL(2,7)|, fixing e8. NOT a
+-- default_target: 3 native_decide sweeps over GL(4,2)=65536 take ~1 min; `lake build SounioSedenionAutomorphism`.
+lean_lib «SounioSedenionAutomorphism» where
+
 -- Frente B: quartet<->fiber incidence of the sedenion ZD geometry (42 quartets = 2*K_7 on 7 fibers).
 @[default_target]
 lean_lib «SounioSedenionIncidence» where

--- a/scripts/research/sedenion_automorphism_168_oracle.py
+++ b/scripts/research/sedenion_automorphism_168_oracle.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Independent oracle for the sedenion signed-automorphism group (Frente B): the 168 = |PSL(2,7)|
+that pervades the sedenion geometry IS the group Aut(S), and it FIXES e8 (the doubling seam).
+
+A linear map M in GL(d,2) (acting on indices 1..2^d-1 as F_2^d vectors, preserving xor) is a signed
+automorphism iff sigma(Mi,Mj)*sigma(i,j) is a coboundary delta(eps)(i,j)=eps(i)eps(j)eps(i^j). Uses
+RIGOROUS highest-bit-pivot Gaussian elimination over F_2 (order-independent).
+
+Output:
+  OCT_AUTOS <n>    octonions {1..7}: signed autos = 168 = |GL(3,2)|
+  SED_AUTOS <n>    sedenions {1..15}: signed autos = 168 (of |GL(4,2)|=20160)
+  SED_FIX_E8 <n>   sedenion autos fixing e8 (index 8) = 168 (ALL of them)
+  ORBIT8 <...>     orbit of e8 under the group (singleton {8} => e8 is the unique fixed point)
+  ORBITS <...>     orbit partition of {1..15}
+  AUT <OK|FAIL>
+"""
+from __future__ import annotations
+from itertools import product
+
+
+def cd_sigma(a, b, bits):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    a_hi, b_hi = a >= half, b >= half
+    a_lo, b_lo = a & (half - 1), b & (half - 1)
+    if not a_hi and not b_hi:
+        return cd_sigma(a_lo, b_lo, bits - 1)
+    if not a_hi and b_hi:
+        return cd_sigma(b_lo, a_lo, bits - 1)
+    if a_hi and not b_hi:
+        return cd_sigma(a_lo, b_lo, bits - 1) if b_lo == 0 else -cd_sigma(a_lo, b_lo, bits - 1)
+    return -cd_sigma(b_lo, a_lo, bits - 1) if b_lo == 0 else cd_sigma(b_lo, a_lo, bits - 1)
+
+
+def par(x):
+    return bin(x).count("1") & 1
+
+
+def apply(M, x, d):
+    return sum((1 << r) for r in range(d) if par(M[r] & x))
+
+
+def invertible(M, d):
+    rows = list(M)
+    rank = 0
+    for col in range(d):
+        piv = next((r for r in range(rank, d) if rows[r] & (1 << col)), None)
+        if piv is None:
+            continue
+        rows[rank], rows[piv] = rows[piv], rows[rank]
+        for r in range(d):
+            if r != rank and rows[r] & (1 << col):
+                rows[r] ^= rows[rank]
+        rank += 1
+    return rank == d
+
+
+def is_auto(M, d):
+    n = 1 << d
+    piv = {}
+    for i in range(1, n):
+        Mi = apply(M, i, d)
+        for j in range(i + 1, n):
+            Mj = apply(M, j, d)
+            k = i ^ j
+            s = cd_sigma(Mi, Mj, d) * cd_sigma(i, j, d)
+            m = (1 << i) | (1 << j) | (1 << k) | (1 if s < 0 else 0)
+            while True:
+                v = m >> 1
+                if v == 0:
+                    if m & 1:
+                        return False
+                    break
+                h = v.bit_length() - 1
+                if h in piv:
+                    m ^= piv[h]
+                else:
+                    piv[h] = m
+                    break
+    return True
+
+
+def autos(d):
+    n = 1 << d
+    return [list(M) for M in product(range(n), repeat=d) if invertible(M, d) and is_auto(M, d)]
+
+
+def main():
+    oct = autos(3)
+    sed = autos(4)
+    fix8 = [M for M in sed if apply(M, 8, 4) == 8]
+    orb8 = sorted({apply(M, 8, 4) for M in sed})
+    seen, orbits = set(), []
+    for x in range(1, 16):
+        if x in seen:
+            continue
+        o = sorted({apply(M, x, 4) for M in sed})
+        orbits.append(o)
+        seen |= set(o)
+    print(f"OCT_AUTOS {len(oct)}")
+    print(f"SED_AUTOS {len(sed)}")
+    print(f"SED_FIX_E8 {len(fix8)}")
+    print("ORBIT8 " + ",".join(map(str, orb8)))
+    print("ORBITS " + " ".join("{" + ",".join(map(str, o)) + "}" for o in orbits))
+    ok = len(oct) == 168 and len(sed) == 168 and len(fix8) == 168 and orb8 == [8]
+    print(f"AUT {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_automorphism_168.sio
+++ b/tests/run-pass/sedenion_automorphism_168.sio
@@ -1,0 +1,196 @@
+//@ run-pass
+//@ expect-stdout: AUT OK
+// FRENTE B — the automorphism group behind every 168, executed exactly.
+//
+// The 168 = |PSL(2,7)| that pervades the sedenion geometry (ZD census, non-Fano, fibers, quartets)
+// IS a genuine group: the sedenion SIGNED-AUTOMORPHISM group. A linear map M in GL(4,2) (acting on
+// indices 1..15 as F_2^4 vectors, preserving xor) is a signed automorphism iff the sign ratio
+// sigma(Mi,Mj)*sigma(i,j) is a COBOUNDARY delta(eps)(i,j) = eps(i)eps(j)eps(i^j) for some signs eps.
+// This test counts them exactly:
+//   * octonions {1..7}: ALL 168 = |GL(3,2)| linear maps are signed automorphisms;
+//   * sedenions {1..15}: exactly 168 of the |GL(4,2)| = 20160 linear maps are  (= the SAME 168);
+//   * every sedenion automorphism FIXES e8 (index 8) — the doubling seam is the unique fixed point.
+// So 168 is the group Aut ~ PSL(2,7); 1848 = 11*168 is NOT a group order (the 11 is combinatorial).
+//
+// Decidable F_2 linear algebra + integer signs, no float. SELF-CONTAINED. Cross-verified vs
+// scripts/research/sedenion_automorphism_168_oracle.py by the matching gate + Lean file.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+
+// popcount parity of a small int
+fn par(x: i64) -> i64 with Mut, Panic, Div {
+    var c = 0
+    var b = 0
+    while b < 8 {
+        if (x & (1 << b)) != 0 { c = c + 1 }
+        b = b + 1
+    }
+    c & 1
+}
+
+// M is d rows (m0..m3), each a d-bit int. Apply to vector x (d bits): bit r = parity(row_r & x).
+fn apply(m0: i64, m1: i64, m2: i64, m3: i64, x: i64, d: i64) -> i64 with Mut, Panic, Div {
+    var y = 0
+    if par(m0 & x) == 1 { y = y | 1 }
+    if par(m1 & x) == 1 { y = y | 2 }
+    if d >= 3 { if par(m2 & x) == 1 { y = y | 4 } }
+    if d >= 4 { if par(m3 & x) == 1 { y = y | 8 } }
+    y
+}
+
+// F_2 rank of the d rows (d<=4) -> invertible iff rank == d.
+fn invertible(m0: i64, m1: i64, m2: i64, m3: i64, d: i64) -> bool with Mut, Panic, Div {
+    var r = [0; 4]
+    r[0 as usize] = m0
+    r[1 as usize] = m1
+    r[2 as usize] = m2
+    r[3 as usize] = m3
+    var rank = 0
+    var col = 0
+    while col < d {
+        var piv = 0 - 1
+        var i = rank
+        while i < d {
+            if piv < 0 && (r[i as usize] & (1 << col)) != 0 { piv = i }
+            i = i + 1
+        }
+        if piv >= 0 {
+            let tmp = r[rank as usize]
+            r[rank as usize] = r[piv as usize]
+            r[piv as usize] = tmp
+            var k = 0
+            while k < d {
+                if k != rank && (r[k as usize] & (1 << col)) != 0 { r[k as usize] = r[k as usize] ^ r[rank as usize] }
+                k = k + 1
+            }
+            rank = rank + 1
+        }
+        col = col + 1
+    }
+    rank == d
+}
+
+// highest set bit of x>0 (x < 65536); returns 0 if x==0.
+fn highbit(x: i64) -> i64 with Mut, Panic, Div {
+    var h = 0
+    var b = 0
+    while b < 20 {
+        if (x & (1 << b)) != 0 { h = b }
+        b = b + 1
+    }
+    h
+}
+
+// Is M a signed automorphism? Build F_2 system a(i)+a(j)+a(i^j) = b(i,j) over vars 1..n-1,
+// b = 0 if sigma(Mi,Mj)*sigma(i,j)=+1 else 1. RIGOROUS highest-variable-bit pivoting (order-
+// independent): pivot[h] holds a mask whose variable part has highest bit h. Consistent => coboundary.
+fn is_auto(m0: i64, m1: i64, m2: i64, m3: i64, d: i64) -> bool with Mut, Panic, Div {
+    let n = 1 << d
+    var pivmask = [0; 16]   // pivot for each variable-highbit column (var bits shifted: 0..n-2)
+    var haspiv = [0; 16]
+    var i = 1
+    while i < n {
+        let mi = apply(m0, m1, m2, m3, i, d)
+        var j = i + 1
+        while j < n {
+            let mj = apply(m0, m1, m2, m3, j, d)
+            let k = i ^ j
+            let s = cd_sigma_c(mi, mj, d) * cd_sigma_c(i, j, d)
+            var m = (1 << i) | (1 << j) | (1 << k)   // variable bits in positions 1..n-1
+            if s < 0 { m = m | 1 }                    // bit 0 carries rhs (i,j,k >= 1 so bit0 free)
+            // reduce: while the variable part (m>>1) is nonzero, pivot by its highest bit
+            var done = 0
+            var guard = 0
+            while done == 0 && guard < n + 2 {
+                let vpart = (m >> 1)
+                if vpart == 0 {
+                    if (m & 1) != 0 { return false }  // 0 = 1 inconsistent
+                    done = 1
+                } else {
+                    let h = highbit(vpart)
+                    if haspiv[h as usize] == 0 {
+                        pivmask[h as usize] = m
+                        haspiv[h as usize] = 1
+                        done = 1
+                    } else {
+                        m = m ^ pivmask[h as usize]
+                    }
+                }
+                guard = guard + 1
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn count_autos(d: i64, require_fix8: i64) -> i64 with Mut, Panic, Div {
+    let n = 1 << d
+    var cnt = 0
+    var m0 = 0
+    while m0 < n {
+        var m1 = 0
+        while m1 < n {
+            var m2 = 0
+            let m2cap = if d >= 3 { n } else { 1 }
+            while m2 < m2cap {
+                var m3 = 0
+                let m3cap = if d >= 4 { n } else { 1 }
+                while m3 < m3cap {
+                    if invertible(m0, m1, m2, m3, d) {
+                        if is_auto(m0, m1, m2, m3, d) {
+                            var ok = 1
+                            if require_fix8 == 1 {
+                                if apply(m0, m1, m2, m3, 8, d) != 8 { ok = 0 }
+                            }
+                            if ok == 1 { cnt = cnt + 1 }
+                        }
+                    }
+                    m3 = m3 + 1
+                }
+                m2 = m2 + 1
+            }
+            m1 = m1 + 1
+        }
+        m0 = m0 + 1
+    }
+    cnt
+}
+
+fn main() with IO, Mut, Panic, Div {
+    let oct = count_autos(3, 0)
+    let sed = count_autos(4, 0)
+    let sed_fix8 = count_autos(4, 1)
+    print("OCT_AUTOS ")
+    print_int(oct)
+    print("\n")
+    print("SED_AUTOS ")
+    print_int(sed)
+    print("\n")
+    print("SED_FIX_E8 ")
+    print_int(sed_fix8)
+    print("\n")
+    // octonion Aut = 168 = |GL(3,2)| ; sedenion Aut = 168 (same PSL(2,7)) ; ALL fix e8 (168 = 168).
+    if oct == 168 && sed == 168 && sed_fix8 == 168 {
+        println("AUT OK")
+    } else {
+        println("AUT FAIL")
+    }
+}


### PR DESCRIPTION
## Summary
**Frente B, vector 3 (the group interpretation).** The `168 = |PSL(2,7)|` that pervades the sedenion geometry (ZD census, non-Fano, 7 fibers, 42 quartets, the `1848 = 11·168` associator side) **IS a genuine group**: the sedenion **signed-automorphism group** `Aut(𝕊)`, order **168**, index 120 in `GL(4,2) ≅ A₈`. And it **fixes e₈** — the doubling seam is the **unique fixed point** of the symmetry group (orbits `{1..7}`, `{8}`, `{9..15}`).

So the **e₈ throughline is group-theoretic**: e₈ bounds the ZD set (#656) and carries the extra 168 on the associator side (#668) *because* it's the fixed point of `Aut(𝕊)`. And **`1848 = 11·168` is NOT a group order** — 168 is the group, the 11 is combinatorial — settling #668's open question in the honest negative.

## Three legs (no Contracts gate — see below)
- **souc (stage2)**: `tests/run-pass/sedenion_automorphism_168.sio` → `AUT OK` (`OCT_AUTOS 168 / SED_AUTOS 168 / SED_FIX_E8 168`). Runs in the Full Test Suite (stage2), ~0.35 s.
- **Python oracle**: `scripts/research/sedenion_automorphism_168_oracle.py` → 168/168/168, orbit of e₈ = `{8}`.
- **Lean `native_decide`**: `formal/lean4/SounioSedenionAutomorphism.lean` → `oct_168`, `sed_168`, `sed_fix_e8_168`. Non-`default_target` (three GL(4,2) sweeps ~1 min): `lake build SounioSedenionAutomorphism`.

## A caught compiler defect
Cross-verification **caught the committed `bin/souc` miscompiling** the `d=4` GL(4,2) sweep (returns 17882/432, varying with the code) while **stage2 souc + Python + Lean all agree on 168**. This test is therefore Full-Test-Suite-verified (stage2) with **no `bin/souc` Contracts gate**. (Also a lesson recorded: an order-*dependent* F₂ reduction can give a plausible-but-wrong count; the certified computation uses rigorous highest-bit pivoting.)

Self-contained; independent of #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)