### PR TITLE
docs(continuity): phase-2 wrap-up + EISA thin-link hand-off

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 891
-- Repo-backed topics: 741
+- Total governed topics: 892
+- Repo-backed topics: 742
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 176
-- Authority count `repo_only`: 527
+- Authority count `repo_only`: 528
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 531 topics
+- A2: 532 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -350,6 +350,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.continuity.wp-a5 | repo_only | docs/handoff/continuity/WP-A5.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.continuity.wp-b1 | repo_only | docs/handoff/continuity/WP-B1.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.continuity.wp-b2 | repo_only | docs/handoff/continuity/WP-B2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.continuity.wp-eisa-thinlink | repo_only | docs/handoff/continuity/WP-EISA-THINLINK.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.exact-engine-prereqs | repo_only | docs/handoff/exact_engine_prereqs.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-v0800-defects | repo_only | docs/handoff/souc_v0800_defects.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.bootstrap-seed-policy | historical | docs/implementation/BOOTSTRAP_SEED_POLICY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7564,6 +7564,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.continuity.wp-eisa-thinlink",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/continuity/WP-EISA-THINLINK.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.exact-engine-prereqs",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/exact_engine_prereqs.md",

--- a/docs/handoff/continuity/SCOREBOARD.md
+++ b/docs/handoff/continuity/SCOREBOARD.md
@@ -13,6 +13,46 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.contin
 
 Statuses: `TODO` | `CLAIMED(<session>)` | `IN-PROGRESS` | `DONE(<commit/PR>)` | `BLOCKED(<reason>)`
 
+## ★ PHASE 2 FINAL SUMMARY (2026-07-07) — A-track COMPLETE; EISA one native-emit bug away
+
+**A5 ACHIEVED & LANDED + CI-verified:** `cd_exact_generic_i64` runs GREEN on the default Madaros engine
+→ `ZD PROVED` / `SQ PASS` / `NONZERO PASS` / 16× `COMP i 0`, rc=0. `cd_exact_generic_vs_concrete` = real
+`BYTECOMPARE PASS`. Landed on `main` via a stack of PRs (squash commits): A4 `#659`, test-fix `#662`,
+A3 `#658`, **A2+A6+A1 bundle `#667`**, A7 `#669`, A9 `#671`, A8 `#678`, A10 `#679`, A5 `#684`, A14 `#685`.
+
+The original 4-gap framing was incomplete — the Madaros imported/multi-module pipeline had a **layered
+stack of ~10 independent defects**, peeled in order. Several runtime crashes were the SAME lean_single
+by-value-`Box`-copy miscompile family (A8 IrInstr-by-value, A10 nested aggregate store, A14 whole-IrInstr
+fn_id writeback). What looked like an "18 GB memory wall" was a single `ulimit -v` artifact (lean_single
+Box arena reserves 8 GB chunks, never frees → ~24 GB VIRTUAL, ~1.5 GB resident); fixed by raising the
+`bin/madaros` vmem guard 16→48 GB. All builds ran off-pod on Slurm (see reference_slurm_madaros_offload).
+
+| WP | What it closed | Landed |
+|----|----------------|--------|
+| A4 | println `ExprIndex` dispatch (the "SRET rc=139" was really this) | #659 |
+| A3 | multi-module AST specializer (E008) | #658 |
+| A2 | primitive-receiver method dispatch (E019) | #667 |
+| A6 | impl-method effect sig-resolution — empty-name collision (E035) | #667 |
+| A1 | ExactRing trait+Rational-impl effect decls | #667 |
+| A7 | merged-checker i32/i64 int-width coercion (E007/E004) | #669 |
+| A9 | merged-checker struct-ref exact-field lookup (E012/E137) | #671 |
+| A8 | cross-module SRET forwarding SIGSEGV (IrInstr by-value copy) | #678 |
+| A10 | impl-method summary preseed nested-store SIGSEGV | #679 |
+| A5 | transitive cd_sigma → same-module cd_sigma_x + vmem raise | #684 |
+| A14 | transitive cross-module call drop (removes A5 workaround; fixes vs_concrete) | #685 |
+
+**EISA default-lane:** type-checks clean AND lowers fully (`test_eisa_isa`: 142 fns merged) after A7+A9+A14
++ deps + vmem — then fails ONLY at the final native ELF-emit: `Failed to write native binary rc=13` /
+`multimodule native thin-link compilation failed`. B1's original "str_from_bytes ud2/dep-closure" premise
+was FALSIFIED. Remaining EISA work is scoped in **`WP-EISA-THINLINK.md`** (native ELF-emit/thin-link) + B2.
+
+**Open residual gaps (handed off):** (1) EISA native thin-link ELF-write rc=13 — see WP-EISA-THINLINK.
+(2) Octonion multi-module native-lowering / memory wall (`algebra_g2_invariants_import`) — pre-existing.
+(3) A11 `#681` (in-place finalize IrModule refactor) — memory-neutral, correct, zero-regression, UNMERGED
+(optional cleanup). (4) lean_single 4-module generic closure limitation (cross-engine parity via output).
+
+_Rows below are the raw per-WP CLAIM logs (some pre-date the bundle/A14 landing); the summary above is authoritative._
+
 | WP | Title | Model | Deps | Status | Evidence (command → expected) |
 |---|---|---|---|---|---|
 | A0 | Phase-1 PR merge | Haiku | — | DONE(91ee4de77, PR #654) | merged 2026-07-07; A1/A2/A3 unblocked |

--- a/docs/handoff/continuity/WP-EISA-THINLINK.md
+++ b/docs/handoff/continuity/WP-EISA-THINLINK.md
@@ -1,0 +1,71 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.continuity.wp-eisa-thinlink
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.continuity.wp-eisa-thinlink
+-->
+
+# WP-EISA-THINLINK — Madaros multi-module native ELF thin-link write failure (rc=13) [Opus]
+
+## Status of the EISA default-lane track (2026-07-07, post phase-2)
+The checker gaps are CLOSED. `test_eisa_isa` / `test_eisa_evm` now **type-check fully clean** and
+**lower completely** on the default Madaros engine (all imported-lane E004/E012/E137 cleared by
+A7+A9; the transitive cross-module call drop cleared by A14). Verified on a fresh main build with the
+EISA dep closure present and adequate vmem:
+```
+imported_compile: typecheck ok
+lower_array: dep_begin 1..4 ; lower_done ; Merged IR: 142 functions
+Error: Failed to write native binary to /tmp/isa.elf rc=13
+error: multimodule native thin-link compilation failed
+```
+So the ONLY remaining EISA runtime blocker is the **final native ELF-emit / thin-link stage** returning
+**rc=13** for a large (142-fn) merged multi-module program.
+
+## Environment (do this first — a prior agent got a false E137/E004 from a bad env)
+`stdlib/eisa`, `stdlib/math/dd64.sio`, `stdlib/math/qd128.sio` are NOT on main — they live in
+`/workspace/sounio-eisa`. Copy them into your worktree's stdlib (keep OUT of git; compiler/verification
+only). Do NOT copy the eisa worktree's OTHER stdlib files (str::lib etc.) over main's — that reintroduces
+the A7 int-width skew (E004) and is a verification artifact, not a real failure.
+Build with a big-RAM path: the compile reserves ~24 GB VIRTUAL address space (lean_single Box arena
+reserves 8 GB chunks, never frees; RSS ~1.5 GB). Use the RAW binary with `ulimit -v unlimited`:
+`SOUNIO_STDLIB_PATH=<repo>/stdlib "<madaros.elf>" tests/stdlib/eisa/test_eisa_isa.sio -o /tmp/isa.elf`
+(the `bin/madaros` wrapper caps vmem at 48 GB post-A5, which is enough — but the raw path is simplest for
+iteration). All builds go to Slurm (see [[reference_slurm_madaros_offload]]); the 515 GB r740 node is
+intermittently offline, so pin modest `--mem` and retry on scheduling errors.
+
+## Where to look
+The failure is AFTER `imported_compile: lower_done` — in the native ELF write / thin-link path, NOT the
+checker or IR lowering. Candidates: `self-hosted/native/elf.sio`, `elf_bulk.sio`, `reloc.sio`, and the
+`module_native_driver` / thin-link emit in `self-hosted/compiler/module_frontend.sio` (the same file that
+prints `Native compilation failed: imported_simple_ir_emit_failed` on the compact-IR path before falling
+back to the full IR path — trace both paths). `rc=13` is the emit function's return code; find where it
+originates (grep for the `Failed to write native binary` string and the rc plumbing). Likely a size/offset
+or relocation issue that only trips at 142-fn scale, or an unhandled emit case for a specific EISA construct.
+
+## Constraint
+`module_frontend.sio` and the native emit files are in `main.sio`'s import closure; the lean_single SRC
+import buffer is **8 MB** and the closure sits at the cliff. Keep edits BYTE-FRUGAL and confirm the madaros
+build still succeeds (BUILD_RC=0) as your first recipe step (a prior agent overflowed it with +977 comment
+bytes; A11's -113B and A14's +231B both stayed safe).
+
+## Witnesses
+- W1: `test_eisa_isa` (with deps + raw binary + `ulimit -v unlimited`) => BUILD rc=0, ELF produced, RUN =>
+  the test's expected output (see its header/asserts), no SIGILL/SIGSEGV.
+- W2: `test_eisa_evm` => same.
+- W3: minimal repro — a synthetic multi-module program that merges to a comparable fn count and hits the
+  same `Failed to write native binary rc=13`, to bisect the emit path fast.
+- W4 (regression): `cd_exact_generic_i64` still green (`ZD PROVED`… rc=0); madaros BUILD_RC=0; 8-10
+  multi-module run-pass tests byte-identical.
+- Then B2 (gate refresh): conformance 21/21 + 13-test default-lane suite (see WP-B2), once the emit works.
+
+## Done criteria
+`test_eisa_isa`/`test_eisa_evm` build + run PASS on the default lane; no new umbrella reds; PR merged.
+
+## Related residual gaps (not this WP)
+- Octonion multi-module native-lowering / memory wall: `algebra_g2_invariants_import` (uses
+  `algebra::octonion`) rc=1/139; pre-existing, exposed (not caused) by A14.
+- lean_single cannot build 4-module generic closures (`unresolved cd_zero_exact`) — a known lean_single
+  limitation; cross-engine parity for cd_exact is via the proven output + `cd_exact_generic_vs_concrete`
+  (now real BYTECOMPARE PASS after A14), not a line-diff of a lean_single 4-module build.


### PR DESCRIPTION
Campaign phase-2 finalization. **A-track COMPLETE**: cd_exact_generic_i64 runs green on the default Madaros engine (`ZD PROVED / SQ PASS / NONZERO PASS / 16×COMP i 0`), landed via 14 fixes (A1-A10, A13, A14). Adds an authoritative phase-2 summary to SCOREBOARD.md and `WP-EISA-THINLINK.md` scoping the sole remaining EISA runtime blocker — the native ELF-emit/thin-link `rc=13` (EISA already type-checks + lowers 142 fns clean).