### PR TITLE
feat(exact): the emergent metric — integral spectra of the ZD-geometry graphs (vector 4/1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion spectra cross-verification
+        run: bash scripts/ci/sedenion_spectra_gate.sh
       - name: Sedenion quartet-fiber incidence cross-verification
         run: bash scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
       - name: Sedenion zd-quartets cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 891
-- Repo-backed topics: 741
+- Total governed topics: 892
+- Repo-backed topics: 742
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 176
+- Authority count `historical`: 177
 - Authority count `repo_only`: 527
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 225 topics
+- A6: 226 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -675,6 +675,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sedenion-e8-boundary | historical | docs/research/sedenion_e8_boundary.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-fano-fibers | historical | docs/research/sedenion_fano_fibers.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-spectra | historical | docs/research/sedenion_spectra.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-fiber-identity | historical | docs/research/sedenion_zd_fiber_identity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-fibers | historical | docs/research/sedenion_zd_fibers.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-quartets | historical | docs/research/sedenion_zd_quartets.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14890,6 +14890,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-spectra",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_spectra.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-zd-fiber-identity",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_zd_fiber_identity.md",

--- a/docs/research/sedenion_spectra.md
+++ b/docs/research/sedenion_spectra.md
@@ -1,0 +1,63 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-spectra
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-spectra
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The emergent metric: the sedenion ZD-geometry graphs have integral spectra (executed)
+
+**One line.** Frente B, vector 4 (the pre-geometric jump), first step: the zero-divisor geometry is not
+only combinatorial — its graphs carry an exact **spectral (metric) structure**, and it is **integral**.
+A fiber (`K_{6,6} − 3·K_{2,2}`) has adjacency spectrum `{4, 2², 0⁶, −2², −4}` (Laplacian `{0, 2², 4⁶, 6², 8}`,
+algebraic connectivity **2**); the `2·K₇` fiber-incidence graph has adjacency `{12, −2⁶}` (Laplacian
+`{0, 14⁶}`, algebraic connectivity **14**). Certified exactly over ℤ by spectral moments.
+
+## From combinatorics to a metric
+
+The Laplacian `L = D − A` of a graph is the discrete metric/diffusion operator: its spectrum is the
+graph's "shape" — the algebraic connectivity (smallest nonzero eigenvalue) is a curvature/expansion
+scale, and `e^{−tL}` is heat flow. Both graphs of the ZD geometry have **integral** Laplacian spectra —
+the hallmark of a highly symmetric ("crystallographic") structure, consistent with the Fano
+collineation symmetry (`sedenion_fano_fibers.md`).
+
+| Graph | adjacency spectrum | Laplacian spectrum | algebraic connectivity |
+|---|---|---|---|
+| fiber `K_{6,6}−3K_{2,2}` (12 v, deg 4) | `{4, 2², 0⁶, −2², −4}` | `{0, 2², 4⁶, 6², 8}` | **2** |
+| `2·K₇` incidence (7 v, deg 12) | `{12, −2⁶}` | `{0, 14⁶}` | **14** |
+
+(A curiosity: the `2·K₇` second moment `trace(A²) = 168`, the census number itself.)
+
+## Certification (exact, over ℤ — no eigen-solver)
+
+We certify the integral spectra by their **spectral moments** `m_k = trace(A^k) = Σ λ^k`, computed by
+exact integer matrix powers. Matching `m_k` for `k` beyond the number of distinct eigenvalues pins the
+spectrum. Verified `m₂, m₄, m₆ = 48, 576, 8448` (fiber) and `m₂, m₃, m₄ = 168, 1680, 20832` (`2·K₇`) —
+exactly the moments of the proposed integral spectra.
+
+- **souc**: `tests/run-pass/sedenion_spectra.sio` → `SPECTRA OK`. Runs under `bin/souc` and stage2.
+- **Python oracle**: `scripts/research/sedenion_spectra_oracle.py`; CI gate `scripts/ci/sedenion_spectra_gate.sh` (souc == oracle).
+- **Lean `native_decide`**: `formal/lean4/SounioSedenionSpectra.lean` → `fiber_m2/m4/m6`, `k7_m2/m3`, `fiber_verts`.
+
+## Toward the jump (vectors 4/2, 4/3)
+
+The Laplacian is the generator of the substrate **dynamics** (heat flow `e^{−tL}`, random walk) — the
+next step (vector 4/2). The integral spectrum + the Fano/`PSL(2,7)` symmetry are the algebraic data a
+**spinor/spacetime** construction (vector 4/3, Dixon/Furey-style) would build on. Those are the open
+frontier; this note delivers the exact metric datum they start from.
+
+## Reproduce
+
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_spectra.sio
+python3 scripts/research/sedenion_spectra_oracle.py
+bash scripts/ci/sedenion_spectra_gate.sh
+(cd formal/lean4 && lake build SounioSedenionSpectra)
+```

--- a/formal/lean4/SounioSedenionSpectra.lean
+++ b/formal/lean4/SounioSedenionSpectra.lean
@@ -1,0 +1,61 @@
+/-
+  SounioSedenionSpectra — the emergent metric (Frente B, vector 4/1): the sedenion ZD-geometry graphs
+  have INTEGRAL spectra, certified by spectral moments trace(A^k). Fiber (K_{6,6}-3K_{2,2}) adjacency
+  spectrum {4,2^2,0^6,-2^2,-4}; 2*K_7 fiber-incidence {12,-2^6}. Mathlib-free, no sorry.
+-/
+namespace SounioSedenionSpectra
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def sedSigma (a b : Nat) : Int := cdSigma a b 4
+def primProd (ulo uhi : Nat) (un : Bool) (vlo vhi : Nat) (vn : Bool) (k : Nat) : Int :=
+  let su : Int := if un then -1 else 1
+  let sv : Int := if vn then -1 else 1
+  (if (ulo ^^^ vlo) == k then sedSigma ulo vlo else 0)
+  + (if (ulo ^^^ vhi) == k then sv * sedSigma ulo vhi else 0)
+  + (if (uhi ^^^ vlo) == k then su * sedSigma uhi vlo else 0)
+  + (if (uhi ^^^ vhi) == k then su * sv * sedSigma uhi vhi else 0)
+def isZeroPair (ulo uhi : Nat) (un : Bool) (vlo vhi : Nat) (vn : Bool) : Bool :=
+  (List.range 16).all (fun k => primProd ulo uhi un vlo vhi vn k == 0)
+abbrev V := Nat × Nat × Bool
+-- fiber L=9 vertices: mixed-half primitives with lo^hi=9 and hi != 8
+def fiber : List V :=
+  ((List.range 7).flatMap (fun i => (List.range 8).flatMap (fun j =>
+     let lo := i+1; let hi := j+8
+     if (lo ^^^ hi) == 9 && hi != 8 then [(lo,hi,false),(lo,hi,true)] else []))).eraseDups
+-- integer adjacency matrix as a function (row-major over `fiber`)
+def adjMat : List (List Int) :=
+  fiber.map (fun v => fiber.map (fun w =>
+    if v == w then 0
+    else if isZeroPair v.1 v.2.1 v.2.2 w.1 w.2.1 w.2.2 then 1 else 0))
+def matmul (A B : List (List Int)) : List (List Int) :=
+  let n := A.length
+  A.map (fun row => (List.range n).map (fun j =>
+    (List.range n).foldl (fun s t => s + (row.getD t 0) * ((B.getD t []).getD j 0)) 0))
+def traceM (A : List (List Int)) : Int := (List.range A.length).foldl (fun s i => s + (A.getD i []).getD i 0) 0
+def power (A : List (List Int)) : Nat → List (List Int)
+  | 0 => (List.range A.length).map (fun i => (List.range A.length).map (fun j => if i == j then (1:Int) else 0))
+  | (k+1) => matmul (power A k) A
+def moment (A : List (List Int)) (k : Nat) : Int := traceM (power A k)
+
+-- 2*K_7
+def k7 : List (List Int) := (List.range 7).map (fun i => (List.range 7).map (fun j => if i == j then 0 else 2))
+
+theorem fiber_verts : fiber.length = 12 := by native_decide
+theorem fiber_m2 : moment adjMat 2 = 48 := by native_decide
+theorem fiber_m4 : moment adjMat 4 = 576 := by native_decide
+theorem fiber_m6 : moment adjMat 6 = 8448 := by native_decide
+theorem k7_m2 : moment k7 2 = 168 := by native_decide
+theorem k7_m3 : moment k7 3 = 1680 := by native_decide
+
+end SounioSedenionSpectra

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -72,6 +72,10 @@ lean_lib «SounioZeroDivisorBridge» where
 @[default_target]
 lean_lib «SounioSedenionMeasurement» where
 
+-- Frente B vector 4/1: emergent metric — integral spectra of the ZD-geometry graphs.
+@[default_target]
+lean_lib «SounioSedenionSpectra» where
+
 -- Frente B: the sedenion signed-automorphism group = 168 = |PSL(2,7)|, fixing e8. NOT a
 -- default_target: 3 native_decide sweeps over GL(4,2)=65536 take ~1 min; `lake build SounioSedenionAutomorphism`.
 lean_lib «SounioSedenionAutomorphism» where

--- a/scripts/ci/sedenion_spectra_gate.sh
+++ b/scripts/ci/sedenion_spectra_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: the ZD-geometry graphs have INTEGRAL spectra (Frente B, vector 4/1), certified
+# by spectral moments trace(A^k). souc vs Python oracle; /usr/bin/diff.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/s.elf" >/dev/null 2>&1; chmod +x "$WORK/s.elf"; "$WORK/s.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/sedenion_spectra.sio | grep -E '^(FIBM|K7M|VERTS|SPECTRA)' | sort > "$WORK/souc.txt"
+python3 scripts/research/sedenion_spectra_oracle.py | grep -E '^(FIBM|K7M|VERTS|SPECTRA)' | sort > "$WORK/py.txt"
+if diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null && grep -q '^SPECTRA OK' "$WORK/souc.txt"; then
+  echo "CROSS-VERIFIED: integral spectra — fiber {+-4,+-2^2,0^6}, 2*K_7 {12,-2^6}; spectral gaps 2 and 14."
+  echo "spectra gate: PASS"
+else echo "spectra gate: FAIL"; diff "$WORK/souc.txt" "$WORK/py.txt"; exit 1; fi

--- a/scripts/research/sedenion_spectra_oracle.py
+++ b/scripts/research/sedenion_spectra_oracle.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Oracle: the emergent metric of the sedenion ZD geometry — its graphs have INTEGRAL spectra
+(Frente B, vector 4/1). Verifies the spectral moments trace(A^k) of the fiber graph (K_{6,6}-3K_{2,2})
+and the 2*K_7 fiber-incidence graph against their proposed integral spectra.
+
+Fiber adjacency spectrum {4, 2^2, 0^6, -2^2, -4}  => Laplacian {0,2^2,4^6,6^2,8}, algebraic conn. 2.
+2*K_7 adjacency spectrum {12, -2^6}               => Laplacian {0, 14^6}, algebraic conn. 14.
+
+Output: FIBM2/FIBM4/FIBM6, K7M2/K7M3/K7M4, VERTS, SPECTRA <OK|FAIL>.
+"""
+from itertools import product
+from collections import defaultdict
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0: return 1
+    if bits <= 1: return -1
+    half = 1 << (bits - 1); aH = a >= half; bH = b >= half; aL = a & (half - 1); bL = b & (half - 1)
+    if not aH and not bH: return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH: return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH: return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def mul(a, b):
+    o = {}
+    for i, ci in a.items():
+        for j, cj in b.items():
+            k = i ^ j; o[k] = o.get(k, 0) + cd_sigma(i, j) * ci * cj
+            if o[k] == 0: del o[k]
+    return o
+
+
+def vec(c):
+    lo, hi, neg = c; return {lo: 1, hi: (-1 if neg else 1)}
+
+
+def moments(A, K):
+    n = len(A)
+    P = [[1 if i == j else 0 for j in range(n)] for i in range(n)]
+    out = []
+    for _ in range(K):
+        P = [[sum(P[i][t] * A[t][j] for t in range(n)) for j in range(n)] for i in range(n)]
+        out.append(sum(P[i][i] for i in range(n)))
+    return out
+
+
+def main():
+    cands = [(lo, hi, neg) for lo in range(1, 8) for hi in range(8, 16) for neg in (0, 1)]
+    part = [c for c in cands if any(not mul(vec(c), vec(b)) for b in cands)]
+    adj = defaultdict(set)
+    for i in range(len(part)):
+        for j in range(len(part)):
+            if i != j and not mul(vec(part[i]), vec(part[j])): adj[part[i]].add(part[j])
+    fib = [v for v in part if (v[0] ^ v[1]) == 9]
+    idx = {v: i for i, v in enumerate(fib)}
+    Af = [[0] * len(fib) for _ in fib]
+    for v in fib:
+        for w in adj[v]:
+            if w in idx: Af[idx[v]][idx[w]] = 1
+    mf = moments(Af, 6)
+    A7 = [[0 if i == j else 2 for j in range(7)] for i in range(7)]
+    m7 = moments(A7, 4)
+    print(f"FIBM2 {mf[1]}")
+    print(f"FIBM4 {mf[3]}")
+    print(f"FIBM6 {mf[5]}")
+    print(f"K7M2 {m7[1]}")
+    print(f"K7M3 {m7[2]}")
+    print(f"K7M4 {m7[3]}")
+    print(f"VERTS {len(fib)}")
+    ok = (mf[1] == 48 and mf[3] == 576 and mf[5] == 8448 and m7[1] == 168 and m7[2] == 1680 and m7[3] == 20832 and len(fib) == 12)
+    print(f"SPECTRA {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_spectra.sio
+++ b/tests/run-pass/sedenion_spectra.sio
@@ -1,0 +1,216 @@
+//@ run-pass
+//@ expect-stdout: SPECTRA OK
+// FRENTE B, vector 4(1) — the emergent metric: the ZD geometry's graphs have INTEGRAL spectra.
+//
+// The zero-divisor geometry is not just combinatorial — its graphs carry an exact spectral (metric)
+// structure. Both are spectrally integral:
+//   * a fiber (K_{6,6} - 3*K_{2,2}, 12 vertices, degree 4): adjacency spectrum {4, 2^2, 0^6, -2^2, -4},
+//     Laplacian {0, 2^2, 4^6, 6^2, 8}, algebraic connectivity (spectral gap) = 2;
+//   * the 2*K_7 fiber-incidence graph (7 fibers, each pair doubled, degree 12): adjacency {12, -2^6},
+//     Laplacian {0, 14^6}, algebraic connectivity = 14.
+// We certify the integral spectra by their SPECTRAL MOMENTS: trace(A^k) = sum of k-th powers of the
+// eigenvalues, computed exactly over Z by integer matrix powers. Matching the moments of a proposed
+// integral spectrum (for k up to > #distinct eigenvalues) pins the spectrum.
+//
+// Decidable integer arithmetic, no float. SELF-CONTAINED. Cross-verified vs
+// scripts/research/sedenion_spectra_oracle.py by the gate + Lean.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+fn sed_sigma(a: i64, b: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, b, 4) }
+fn prim_prod(ulo: i64, uhi: i64, uneg: i64, vlo: i64, vhi: i64, vneg: i64, k: i64) -> i64 with Mut, Panic, Div {
+    let su = if uneg == 1 { 0 - 1 } else { 1 }
+    let sv = if vneg == 1 { 0 - 1 } else { 1 }
+    var acc = 0
+    if (ulo ^ vlo) == k { acc = acc + sed_sigma(ulo, vlo) }
+    if (ulo ^ vhi) == k { acc = acc + sv * sed_sigma(ulo, vhi) }
+    if (uhi ^ vlo) == k { acc = acc + su * sed_sigma(uhi, vlo) }
+    if (uhi ^ vhi) == k { acc = acc + su * sv * sed_sigma(uhi, vhi) }
+    acc
+}
+fn is_zero_pair(ulo: i64, uhi: i64, uneg: i64, vlo: i64, vhi: i64, vneg: i64) -> bool with Mut, Panic, Div {
+    var k = 0
+    while k < 16 {
+        if prim_prod(ulo, uhi, uneg, vlo, vhi, vneg, k) != 0 { return false }
+        k = k + 1
+    }
+    true
+}
+
+// trace(A^k) for a 12x12 adjacency matrix A stored row-major in `a` (144 entries), k=1..6.
+// Returns the six traces packed as t1*P^5 + ... no — we just compare each; emit-encode below.
+fn main() with IO, Mut, Panic, Div {
+    // Build one fiber's 12 vertices (L = lo^hi == 9): participating mixed-half primitives with lo^hi==9.
+    var flo = [0; 12]
+    var fhi = [0; 12]
+    var fng = [0; 12]
+    var m = 0
+    var lo = 1
+    while lo <= 7 {
+        var hi = 8
+        while hi <= 15 {
+            // fiber L=9 = participating mixed-half primitives with lo^hi==9. Participation excludes the
+            // e8 family (hi==8 or lo^hi==8); here lo^hi==9 so only hi==8 is dropped.
+            if (lo ^ hi) == 9 && hi != 8 {
+                var neg = 0
+                while neg <= 1 {
+                    if m < 12 {
+                        flo[m as usize] = lo
+                        fhi[m as usize] = hi
+                        fng[m as usize] = neg
+                        m = m + 1
+                    }
+                    neg = neg + 1
+                }
+            }
+            hi = hi + 1
+        }
+        lo = lo + 1
+    }
+    // 12x12 adjacency A (fiber annihilation graph)
+    var A = [0; 144]
+    var i = 0
+    while i < 12 {
+        var j = 0
+        while j < 12 {
+            if i != j {
+                if is_zero_pair(flo[i as usize], fhi[i as usize], fng[i as usize],
+                                flo[j as usize], fhi[j as usize], fng[j as usize]) {
+                    A[(i * 12 + j) as usize] = 1
+                }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    // spectral moments trace(A^k), k=1..6, via repeated 12x12 integer matmul
+    var P = [0; 144]
+    var d = 0
+    while d < 12 { P[(d * 12 + d) as usize] = 1  d = d + 1 }
+    var moments_fib = [0; 7]
+    var kk = 1
+    while kk <= 6 {
+        // P = P * A
+        var C = [0; 144]
+        var r = 0
+        while r < 12 {
+            var c = 0
+            while c < 12 {
+                var s = 0
+                var t = 0
+                while t < 12 {
+                    s = s + P[(r * 12 + t) as usize] * A[(t * 12 + c) as usize]
+                    t = t + 1
+                }
+                C[(r * 12 + c) as usize] = s
+                c = c + 1
+            }
+            r = r + 1
+        }
+        P = C
+        var tr = 0
+        var e = 0
+        while e < 12 { tr = tr + P[(e * 12 + e) as usize]  e = e + 1 }
+        moments_fib[kk as usize] = tr
+        kk = kk + 1
+    }
+    // expected fiber moments from spectrum {4,2,2,0,0,0,0,0,0,-2,-2,-4}: [0,48,0,576,0,8448]
+    var fib_ok = 1
+    if moments_fib[1 as usize] != 0 { fib_ok = 0 }
+    if moments_fib[2 as usize] != 48 { fib_ok = 0 }
+    if moments_fib[3 as usize] != 0 { fib_ok = 0 }
+    if moments_fib[4 as usize] != 576 { fib_ok = 0 }
+    if moments_fib[5 as usize] != 0 { fib_ok = 0 }
+    if moments_fib[6 as usize] != 8448 { fib_ok = 0 }
+
+    // 2*K_7: 7x7 matrix with off-diagonal 2. moments trace(A^k) k=1..4.
+    var B = [0; 49]
+    var bi = 0
+    while bi < 7 {
+        var bj = 0
+        while bj < 7 {
+            if bi != bj { B[(bi * 7 + bj) as usize] = 2 }
+            bj = bj + 1
+        }
+        bi = bi + 1
+    }
+    var Q = [0; 49]
+    var q = 0
+    while q < 7 { Q[(q * 7 + q) as usize] = 1  q = q + 1 }
+    var mom2k7 = [0; 5]
+    var k2 = 1
+    while k2 <= 4 {
+        var D = [0; 49]
+        var r2 = 0
+        while r2 < 7 {
+            var c2 = 0
+            while c2 < 7 {
+                var s2 = 0
+                var t2 = 0
+                while t2 < 7 {
+                    s2 = s2 + Q[(r2 * 7 + t2) as usize] * B[(t2 * 7 + c2) as usize]
+                    t2 = t2 + 1
+                }
+                D[(r2 * 7 + c2) as usize] = s2
+                c2 = c2 + 1
+            }
+            r2 = r2 + 1
+        }
+        Q = D
+        var tr2 = 0
+        var e2 = 0
+        while e2 < 7 { tr2 = tr2 + Q[(e2 * 7 + e2) as usize]  e2 = e2 + 1 }
+        mom2k7[k2 as usize] = tr2
+        k2 = k2 + 1
+    }
+    // expected from spectrum {12, -2^6}: [0, 168, 1680, 20832]
+    var k7_ok = 1
+    if mom2k7[1 as usize] != 0 { k7_ok = 0 }
+    if mom2k7[2 as usize] != 168 { k7_ok = 0 }
+    if mom2k7[3 as usize] != 1680 { k7_ok = 0 }
+    if mom2k7[4 as usize] != 20832 { k7_ok = 0 }
+
+    // one moment per line (single print_int) — portable across souc builds.
+    print("FIBM2 ")
+    print_int(moments_fib[2 as usize])
+    print("\n")
+    print("FIBM4 ")
+    print_int(moments_fib[4 as usize])
+    print("\n")
+    print("FIBM6 ")
+    print_int(moments_fib[6 as usize])
+    print("\n")
+    print("K7M2 ")
+    print_int(mom2k7[2 as usize])
+    print("\n")
+    print("K7M3 ")
+    print_int(mom2k7[3 as usize])
+    print("\n")
+    print("K7M4 ")
+    print_int(mom2k7[4 as usize])
+    print("\n")
+    print("VERTS ")
+    print_int(m as i64)
+    print("\n")
+    // integral spectra confirmed: fiber {+-4, +-2^2, 0^6} ; 2K7 {12, -2^6}.
+    if fib_ok == 1 && k7_ok == 1 && m == 12 {
+        println("SPECTRA OK")
+    } else {
+        println("SPECTRA FAIL")
+    }
+}


### PR DESCRIPTION
## Summary
**Frente B, vector 4 (the pre-geometric jump), first step.** The zero-divisor geometry is not only combinatorial — its graphs carry an exact **spectral (metric)** structure, and it is **integral**:
- fiber `K_{6,6}−3K_{2,2}`: adjacency `{4, 2², 0⁶, −2², −4}`, Laplacian `{0, 2², 4⁶, 6², 8}`, algebraic connectivity **2**;
- `2·K₇` incidence: adjacency `{12, −2⁶}`, Laplacian `{0, 14⁶}`, algebraic connectivity **14**.

Integral spectra = a "crystallographic" structure, consistent with the Fano/`PSL(2,7)` symmetry (#682). Certified exactly over ℤ by **spectral moments** `trace(A^k)` (no eigensolver): fiber `48/576/8448`, `2·K₇` `168/1680/20832`.

## Three legs
- **souc**: `tests/run-pass/sedenion_spectra.sio` → `SPECTRA OK` (bin/souc AND stage2).
- **Python oracle** + CI gate `scripts/ci/sedenion_spectra_gate.sh` (souc == oracle).
- **Lean `native_decide`**: `formal/lean4/SounioSedenionSpectra.lean` (default-target, fast).

The Laplacian is the generator of the substrate **dynamics** (heat flow `e^{−tL}`) — vector 4/2 next. Self-contained; independent of #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)