### PR TITLE
feat(exact): substrate dynamics — spanning-tree complexity of the ZD-geometry graphs (vector 4/2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion dynamics cross-verification
+        run: bash scripts/ci/sedenion_dynamics_gate.sh
       - name: Sedenion spectra cross-verification
         run: bash scripts/ci/sedenion_spectra_gate.sh
       - name: Sedenion quartet-fiber incidence cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 892
-- Repo-backed topics: 742
+- Total governed topics: 893
+- Repo-backed topics: 743
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 177
+- Authority count `historical`: 178
 - Authority count `repo_only`: 527
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 226 topics
+- A6: 227 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -672,6 +672,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sat-rup-microkernel-2026-06-23 | historical | docs/research/sat-rup-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-associator-1848 | historical | docs/research/sedenion_associator_1848.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-automorphism-168 | historical | docs/research/sedenion_automorphism_168.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-dynamics | historical | docs/research/sedenion_dynamics.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-e8-boundary | historical | docs/research/sedenion_e8_boundary.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-fano-fibers | historical | docs/research/sedenion_fano_fibers.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14824,6 +14824,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-dynamics",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_dynamics.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-e8-boundary",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_e8_boundary.md",

--- a/docs/research/sedenion_dynamics.md
+++ b/docs/research/sedenion_dynamics.md
@@ -1,0 +1,98 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-dynamics
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-dynamics
+-->
+
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The substrate dynamics: spanning-tree complexity of the ZD-geometry graphs (executed)
+
+**One line.** Frente B, vector 4 (the pre-geometric jump), second step: the Laplacian `L = D − A` is the
+generator of the substrate **dynamics** (heat flow `e^{−tL}`, random walk). Two of its exact,
+integer-certified invariants — the **spanning-tree complexity** `τ` (Matrix-Tree theorem) and the
+**random-walk return counts** `(A^k)_{ii}` — are computed over ℤ, fraction-free, and cross-verified on
+three independent legs. Headline: `τ(fiber) = 393216`, `τ(2·K₇) = 1075648`.
+
+## From the spectrum to the dynamics
+
+Vector 4/1 (`sedenion_spectra.md`) proved the ZD-geometry graphs have **integral** Laplacian spectra:
+the fiber `K_{6,6}−3·K_{2,2}` (12 vertices, degree 4) has `L`-spectrum `{0, 2², 4⁶, 6², 8}`; the `2·K₇`
+fiber-incidence graph (7 vertices, off-diagonal 2, degree 12) has `L`-spectrum `{0, 14⁶}`. The spectrum
+*is* the dynamics: `e^{−tL}` is heat flow, the walk operator governs diffusion, and the number of
+**spanning trees** is the graph's global connectivity/complexity — the normalization constant of the
+uniform-spanning-tree measure and (via Matrix-Tree/Kirchhoff) a determinant of the Laplacian.
+
+### 1. Spanning-tree complexity `τ` (Matrix-Tree, exact over ℤ)
+
+Kirchhoff's Matrix-Tree theorem: `τ` = the determinant of **any** principal `(n−1)×(n−1)` cofactor of
+`L` (delete one row and its column). We compute that determinant by **fraction-free (Bareiss) integer
+Gaussian elimination** — no rationals, no float; every intermediate is an exact `i64` (the Bareiss
+identity guarantees each division is exact, and for these connected graphs the reduced Laplacian is
+positive-definite, so no pivot is ever zero).
+
+| Graph | `L`-spectrum | `τ = (1/n)·∏(nonzero eigenvalues)` | Bareiss `det` |
+|---|---|---|---|
+| fiber `K_{6,6}−3K_{2,2}` (12 v) | `{0, 2², 4⁶, 6², 8}` | `(2²·4⁶·6²·8)/12` | **393216** |
+| `2·K₇` incidence (7 v) | `{0, 14⁶}` | `14⁶/7` | **1075648** |
+
+The right two columns are computed **independently** — the middle from the integral spectrum of
+vector 4/1, the right by exact integer elimination on the Laplacian cofactor — and they agree. This ties
+the dynamics directly back to the metric: `τ = ∏(nonzero Laplacian eigenvalues)/n`.
+
+### 2. Random-walk return counts `(A^k)_{ii}` (secondary)
+
+`(A^k)_{ii}` is the number of closed walks of length `k` from vertex `i`. Both graphs are
+vertex-transitive, so these return counts are the same at every vertex:
+
+- fiber: `(A²)_{00} = 4 = degree`, `(A⁴)_{00} = 48`.
+- `2·K₇`: `(A²)_{00} = 24 = 2²·6`, `(A⁴)_{00} = 2976`.
+
+**A subtlety worth flagging.** For a simple `0/1` graph, `(A²)_{ii}` equals the degree — this is why the
+fiber gives `4 = degree`. For `2·K₇` the adjacency entries are `2`, so `(A²)_{00} = Σ_j A_{0j}² = 6·2² =
+24`, which is **not** the degree (`12 = Σ_j A_{0j}`). The closed-2-walk count and the degree coincide only
+in the `0/1` case; we certify the true return count `24`.
+
+## Certification (exact, over ℤ — three independent legs)
+
+- **souc**: `tests/run-pass/sedenion_dynamics.sio` → `DYNAMICS OK`. Self-contained (the Cayley–Dickson
+  sign `cd_sigma`, `prim_prod`, `is_zero_pair` copied verbatim from `sedenion_zd_fibers.sio`, avoiding
+  the stdlib-engine import defect #637). Runs correctly under **both** `bin/souc` and the fresh stage2.
+- **Python oracle**: `scripts/research/sedenion_dynamics_oracle.py` (same Bareiss + matrix-power values);
+  CI gate `scripts/ci/sedenion_dynamics_gate.sh` diffs the souc value lines against the oracle.
+- **Lean `native_decide`**: `formal/lean4/SounioSedenionDynamics.lean` → `fiber_spantree`,
+  `k7_spantree`, `fiber_walk2/walk4`, `k7_walk2`, `fiber_verts` (Mathlib-free, no `sorry`; Bareiss with
+  structural fuel recursion). `lake build SounioSedenionDynamics` in <4 s.
+
+### A compiler note (recorded for lineage)
+
+A single monolithic `main()` computing **both** graphs SIGSEGVs under `bin/souc` (a codegen defect: the
+values are all computed correctly, the crash is during output; the fiber and `2·K₇` halves each run clean
+in isolation, and it is not a stack-size issue). Splitting the two graphs into separate functions (so
+`main` stays tiny) sidesteps it entirely, and the brick then runs correctly under **both** `bin/souc` and
+stage2 — so no stage2-only carve-out is needed here (unlike `sedenion_automorphism_168`, where `bin/souc`
+genuinely miscompiles the value). This is a concrete instance of the standing rule: never trust a bare
+souc pass; every number here is cross-checked against the Python oracle and the Lean kernel.
+
+## Toward the jump (vectors 4/3)
+
+Spanning-tree complexity and the walk operator are the *dynamical* data of the substrate; the integral
+spectrum (`sedenion_spectra.md`) is its *metric* data; the Fano/`PSL(2,7)` symmetry
+(`sedenion_fano_fibers.md`) is its *algebraic* data. A spinor/spacetime construction (vector 4/3,
+Dixon/Furey-style) would build on all three. This note delivers the exact dynamical datum.
+
+## Reproduce
+
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_dynamics.sio
+python3 scripts/research/sedenion_dynamics_oracle.py
+bash scripts/ci/sedenion_dynamics_gate.sh
+(cd formal/lean4 && lake build SounioSedenionDynamics)
+```

--- a/formal/lean4/SounioSedenionDynamics.lean
+++ b/formal/lean4/SounioSedenionDynamics.lean
@@ -1,0 +1,97 @@
+/-
+  SounioSedenionDynamics — the substrate DYNAMICS (Frente B, vector 4/2): the sedenion ZD-geometry
+  graphs carry an exact spanning-tree complexity (Matrix-Tree theorem) and random-walk return structure.
+  tau = det of a principal (n-1)x(n-1) Laplacian cofactor, computed by fraction-free (Bareiss) integer
+  Gaussian elimination. fiber K_{6,6}-3K_{2,2}: tau=393216; 2*K_7: tau=1075648. Mathlib-free, no sorry.
+-/
+namespace SounioSedenionDynamics
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def sedSigma (a b : Nat) : Int := cdSigma a b 4
+def primProd (ulo uhi : Nat) (un : Bool) (vlo vhi : Nat) (vn : Bool) (k : Nat) : Int :=
+  let su : Int := if un then -1 else 1
+  let sv : Int := if vn then -1 else 1
+  (if (ulo ^^^ vlo) == k then sedSigma ulo vlo else 0)
+  + (if (ulo ^^^ vhi) == k then sv * sedSigma ulo vhi else 0)
+  + (if (uhi ^^^ vlo) == k then su * sedSigma uhi vlo else 0)
+  + (if (uhi ^^^ vhi) == k then su * sv * sedSigma uhi vhi else 0)
+def isZeroPair (ulo uhi : Nat) (un : Bool) (vlo vhi : Nat) (vn : Bool) : Bool :=
+  (List.range 16).all (fun k => primProd ulo uhi un vlo vhi vn k == 0)
+abbrev V := Nat × Nat × Bool
+-- fiber L=9 vertices: mixed-half primitives with lo^hi=9 and hi != 8
+def fiber : List V :=
+  ((List.range 7).flatMap (fun i => (List.range 8).flatMap (fun j =>
+     let lo := i+1; let hi := j+8
+     if (lo ^^^ hi) == 9 && hi != 8 then [(lo,hi,false),(lo,hi,true)] else []))).eraseDups
+-- integer adjacency matrix (row-major over `fiber`)
+def adjMat : List (List Int) :=
+  fiber.map (fun v => fiber.map (fun w =>
+    if v == w then 0
+    else if isZeroPair v.1 v.2.1 v.2.2 w.1 w.2.1 w.2.2 then 1 else 0))
+-- 2*K_7: 0 on diagonal, 2 off-diagonal
+def k7 : List (List Int) := (List.range 7).map (fun i => (List.range 7).map (fun j => if i == j then 0 else 2))
+
+-- ── random walk: (A^k)_{00} via integer matrix powers ─────────────────────────
+def matmul (A B : List (List Int)) : List (List Int) :=
+  let n := A.length
+  A.map (fun row => (List.range n).map (fun j =>
+    (List.range n).foldl (fun s t => s + (row.getD t 0) * ((B.getD t []).getD j 0)) 0))
+def power (A : List (List Int)) : Nat → List (List Int)
+  | 0 => (List.range A.length).map (fun i => (List.range A.length).map (fun j => if i == j then (1:Int) else 0))
+  | (k+1) => matmul (power A k) A
+def walk (A : List (List Int)) (k : Nat) : Int := ((power A k).getD 0 []).getD 0 0
+
+-- ── Matrix-Tree: tau = det of a principal (n-1)x(n-1) Laplacian cofactor ───────
+def degOf (A : List (List Int)) (i : Nat) : Int := (A.getD i []).foldl (·+·) 0
+-- Laplacian L = D - A, then delete row/col 0 (rows/cols 1..n-1).
+def lapCofactor (A : List (List Int)) : List (List Int) :=
+  let n := A.length
+  (List.range (n-1)).map (fun r => (List.range (n-1)).map (fun c =>
+    let gr := r+1; let gc := c+1
+    (if gr == gc then degOf A gr else 0) - (A.getD gr []).getD gc 0))
+-- element access / update on List (List Int)
+def getE (M : List (List Int)) (i j : Nat) : Int := (M.getD i []).getD j 0
+def setE (M : List (List Int)) (i j : Nat) (v : Int) : List (List Int) :=
+  M.set i ((M.getD i []).set j v)
+-- Fraction-free (Bareiss) integer Gaussian elimination. The reduced Laplacian of a connected graph is
+-- positive-definite, so no pivot is ever zero; we run pivot-free.
+def bareissStep (M : List (List Int)) (k n : Nat) (prev : Int) : List (List Int) :=
+  (List.range n).foldl (fun M1 i =>
+    if i ≤ k then M1 else
+    (List.range n).foldl (fun M2 j =>
+      if j ≤ k then M2 else
+      setE M2 i j ((getE M2 i j * getE M2 k k - getE M2 i k * getE M2 k j) / prev)) M1) M
+-- structural recursion on `fuel` (fuel = n suffices: at most n-1 elimination steps).
+def bareissGo (M : List (List Int)) (k n : Nat) (prev : Int) : Nat → Int
+  | 0 => getE M (n-1) (n-1)
+  | (fuel+1) =>
+      if k + 1 ≥ n then getE M (n-1) (n-1)
+      else
+        let M' := bareissStep M k n prev
+        bareissGo M' (k+1) n (getE M' k k) fuel
+def bareissDet (M : List (List Int)) : Int :=
+  let n := M.length
+  bareissGo M 0 n 1 n
+def spanningTrees (A : List (List Int)) : Int := bareissDet (lapCofactor A)
+
+theorem fiber_verts : fiber.length = 12 := by native_decide
+-- spanning-tree counts (headline)
+theorem fiber_spantree : spanningTrees adjMat = 393216 := by native_decide
+theorem k7_spantree : spanningTrees k7 = 1075648 := by native_decide
+-- random-walk return counts (secondary)
+theorem fiber_walk2 : walk adjMat 2 = 4 := by native_decide
+theorem fiber_walk4 : walk adjMat 4 = 48 := by native_decide
+theorem k7_walk2 : walk k7 2 = 24 := by native_decide
+
+end SounioSedenionDynamics

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -76,6 +76,11 @@ lean_lib «SounioSedenionMeasurement» where
 @[default_target]
 lean_lib «SounioSedenionSpectra» where
 
+-- Frente B vector 4/2: substrate dynamics — spanning-tree complexity (Matrix-Tree, exact Bareiss
+-- integer det) + random-walk return counts of the ZD-geometry graphs. Mathlib-free, native_decide.
+@[default_target]
+lean_lib «SounioSedenionDynamics» where
+
 -- Frente B: the sedenion signed-automorphism group = 168 = |PSL(2,7)|, fixing e8. NOT a
 -- default_target: 3 native_decide sweeps over GL(4,2)=65536 take ~1 min; `lake build SounioSedenionAutomorphism`.
 lean_lib «SounioSedenionAutomorphism» where

--- a/scripts/ci/sedenion_dynamics_gate.sh
+++ b/scripts/ci/sedenion_dynamics_gate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: the substrate DYNAMICS of the ZD-geometry graphs (Frente B, vector 4/2) —
+# spanning-tree complexity tau (Matrix-Tree, exact Bareiss integer det) + random-walk return counts.
+# souc vs Python oracle; /usr/bin/diff on the value lines.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/s.elf" >/dev/null 2>&1; chmod +x "$WORK/s.elf"; "$WORK/s.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/sedenion_dynamics.sio | grep -E '^(SPANTREE|FIB_|K7_|VERTS|DYNAMICS)' | sort > "$WORK/souc.txt"
+python3 scripts/research/sedenion_dynamics_oracle.py | grep -E '^(SPANTREE|FIB_|K7_|VERTS|DYNAMICS)' | sort > "$WORK/py.txt"
+if diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null && grep -q '^DYNAMICS OK' "$WORK/souc.txt"; then
+  echo "CROSS-VERIFIED: substrate dynamics — spanning trees tau(fiber)=393216, tau(2*K_7)=1075648"
+  echo "  (Matrix-Tree via exact Bareiss integer det = prod(nonzero Laplacian eigenvalues)/n); walk counts agree."
+  echo "dynamics gate: PASS"
+else echo "dynamics gate: FAIL"; diff "$WORK/souc.txt" "$WORK/py.txt"; exit 1; fi

--- a/scripts/research/sedenion_dynamics_oracle.py
+++ b/scripts/research/sedenion_dynamics_oracle.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Oracle: the substrate DYNAMICS of the sedenion ZD geometry (Frente B, vector 4/2).
+
+The Laplacian L = D - A is the generator of the substrate dynamics. Two exact, integer-certified
+invariants of the ZD-geometry graphs:
+
+  1. SPANNING-TREE COMPLEXITY tau (Matrix-Tree theorem): tau = det of any principal (n-1)x(n-1)
+     cofactor of L, computed by FRACTION-FREE (Bareiss) integer Gaussian elimination — exact ints.
+       * fiber K_{6,6}-3K_{2,2} (12 v, deg 4):  tau = 393216 = (2^2*4^6*6^2*8)/12.
+       * 2*K_7 fiber-incidence (7 v, off-diag 2, deg 12): tau = 1075648 = 14^6/7.
+  2. RANDOM-WALK RETURN COUNTS (A^k)_{00}: fiber (A^2)=4=deg, (A^4)=48; 2*K_7 (A^2)=24=2^2*6, (A^4)=2976.
+
+Output lines: SPANTREE_FIB, SPANTREE_K7, FIB_A2, FIB_A4, K7_A2, K7_A4, VERTS, DYNAMICS <OK|FAIL>.
+Cross-verified vs tests/run-pass/sedenion_dynamics.sio by scripts/ci/sedenion_dynamics_gate.sh.
+"""
+from collections import defaultdict
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0: return 1
+    if bits <= 1: return -1
+    half = 1 << (bits - 1); aH = a >= half; bH = b >= half; aL = a & (half - 1); bL = b & (half - 1)
+    if not aH and not bH: return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH: return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH: return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def mul(a, b):
+    o = {}
+    for i, ci in a.items():
+        for j, cj in b.items():
+            k = i ^ j; o[k] = o.get(k, 0) + cd_sigma(i, j) * ci * cj
+            if o[k] == 0: del o[k]
+    return o
+
+
+def vec(c):
+    lo, hi, neg = c; return {lo: 1, hi: (-1 if neg else 1)}
+
+
+def bareiss_det(M):
+    """Fraction-free (Bareiss) integer determinant — exact, no rationals."""
+    M = [row[:] for row in M]; n = len(M); sign = 1; prev = 1
+    for k in range(n - 1):
+        if M[k][k] == 0:
+            sw = next((r for r in range(k + 1, n) if M[r][k] != 0), None)
+            if sw is None: return 0
+            M[k], M[sw] = M[sw], M[k]; sign = -sign
+        for i in range(k + 1, n):
+            for j in range(k + 1, n):
+                M[i][j] = (M[i][j] * M[k][k] - M[i][k] * M[k][j]) // prev
+        prev = M[k][k]
+    return sign * M[n - 1][n - 1]
+
+
+def spanning_trees(A):
+    """Matrix-Tree: tau = det of the (n-1)x(n-1) Laplacian cofactor (delete row/col 0)."""
+    n = len(A)
+    deg = [sum(A[i]) for i in range(n)]
+    L = [[(deg[i] if i == j else 0) - A[i][j] for j in range(n)] for i in range(n)]
+    cof = [[L[i][j] for j in range(1, n)] for i in range(1, n)]
+    return bareiss_det(cof)
+
+
+def matpow_diag0(A, k):
+    """(A^k)_{00} via repeated integer matmul."""
+    n = len(A); P = [[1 if i == j else 0 for j in range(n)] for i in range(n)]
+    for _ in range(k):
+        P = [[sum(P[i][t] * A[t][j] for t in range(n)) for j in range(n)] for i in range(n)]
+    return P[0][0]
+
+
+def main():
+    cands = [(lo, hi, neg) for lo in range(1, 8) for hi in range(8, 16) for neg in (0, 1)]
+    part = [c for c in cands if any(not mul(vec(c), vec(b)) for b in cands)]
+    adj = defaultdict(set)
+    for i in range(len(part)):
+        for j in range(len(part)):
+            if i != j and not mul(vec(part[i]), vec(part[j])): adj[part[i]].add(part[j])
+    fib = [v for v in part if (v[0] ^ v[1]) == 9]
+    idx = {v: i for i, v in enumerate(fib)}
+    Af = [[0] * len(fib) for _ in fib]
+    for v in fib:
+        for w in adj[v]:
+            if w in idx: Af[idx[v]][idx[w]] = 1
+    A7 = [[0 if i == j else 2 for j in range(7)] for i in range(7)]
+
+    tau_fib = spanning_trees(Af)
+    tau_k7 = spanning_trees(A7)
+    fib_a2 = matpow_diag0(Af, 2)
+    fib_a4 = matpow_diag0(Af, 4)
+    k7_a2 = matpow_diag0(A7, 2)
+    k7_a4 = matpow_diag0(A7, 4)
+    verts = len(fib)
+
+    print(f"SPANTREE_FIB {tau_fib}")
+    print(f"SPANTREE_K7 {tau_k7}")
+    print(f"FIB_A2 {fib_a2}")
+    print(f"FIB_A4 {fib_a4}")
+    print(f"K7_A2 {k7_a2}")
+    print(f"K7_A4 {k7_a4}")
+    print(f"VERTS {verts}")
+    ok = (tau_fib == 393216 and tau_k7 == 1075648 and fib_a2 == 4 and fib_a4 == 48
+          and k7_a2 == 24 and k7_a4 == 2976 and verts == 12)
+    print(f"DYNAMICS {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_dynamics.sio
+++ b/tests/run-pass/sedenion_dynamics.sio
@@ -1,0 +1,375 @@
+//@ run-pass
+//@ expect-stdout: DYNAMICS OK
+// FRENTE B, vector 4(2) — the substrate DYNAMICS of the sedenion ZD geometry, executed exactly.
+//
+// Vector 4/1 (sedenion_spectra.sio) proved the ZD-geometry graphs have INTEGRAL spectra. The Laplacian
+// L = D - A is the generator of the substrate dynamics (heat flow e^{-tL}, random walk). Two exact,
+// integer-certified invariants of that dynamics:
+//
+//   1. SPANNING-TREE COMPLEXITY tau (Matrix-Tree theorem): tau = det of ANY principal (n-1)x(n-1)
+//      cofactor of L, an exact positive integer. Computed by FRACTION-FREE (Bareiss) integer Gaussian
+//      elimination — no rationals, no float, every intermediate an exact i64.
+//        * fiber graph K_{6,6}-3K_{2,2} (12 vertices, degree 4): tau = 393216.
+//        * 2*K_7 fiber-incidence graph (7 vertices, off-diag 2, degree 12): tau = 1075648.
+//      Cross-check vs the integral spectra: tau = (1/n)*prod(nonzero Laplacian eigenvalues), i.e.
+//        fiber (2^2 * 4^6 * 6^2 * 8)/12 = 393216 ; 2*K_7  14^6/7 = 1075648.
+//
+//   2. RANDOM-WALK RETURN COUNTS (A^k)_{ii} = number of closed walks of length k from vertex i. These
+//      graphs are vertex-transitive: the return counts are the same at every vertex.
+//        * fiber (A^2)_{00} = 4 = degree, (A^4)_{00} = 48.
+//        * 2*K_7 (A^2)_{00} = 24 = 2^2*6 (NB: the DEGREE is 12; for the entries-2 matrix the closed
+//          2-walk count is sum_j A_{0j}^2 = 6*2^2 = 24, not the degree), (A^4)_{00} = 2976.
+//
+// Decidable integer arithmetic, no float. SELF-CONTAINED (Lean-bridge prim_prod idiom, avoids #637).
+// Cross-verified vs scripts/research/sedenion_dynamics_oracle.py by scripts/ci/sedenion_dynamics_gate.sh
+// and by formal/lean4/SounioSedenionDynamics.lean (native_decide).
+//
+// NB: bin/souc SIGSEGVs on a single monolithic main() computing BOTH graphs (a codegen defect — the
+// values are all computed correctly, the crash is during output; the fiber and 2*K_7 halves each run
+// clean in isolation). Splitting the two graphs into separate functions (main stays tiny) sidesteps it,
+// so this brick runs correctly under BOTH bin/souc AND the fresh stage2 compiler.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+
+fn sed_sigma(a: i64, b: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, b, 4) }
+
+fn prim_prod(ulo: i64, uhi: i64, uneg: i64, vlo: i64, vhi: i64, vneg: i64, k: i64) -> i64 with Mut, Panic, Div {
+    let su = if uneg == 1 { 0 - 1 } else { 1 }
+    let sv = if vneg == 1 { 0 - 1 } else { 1 }
+    var acc = 0
+    if (ulo ^ vlo) == k { acc = acc + sed_sigma(ulo, vlo) }
+    if (ulo ^ vhi) == k { acc = acc + sv * sed_sigma(ulo, vhi) }
+    if (uhi ^ vlo) == k { acc = acc + su * sed_sigma(uhi, vlo) }
+    if (uhi ^ vhi) == k { acc = acc + su * sv * sed_sigma(uhi, vhi) }
+    acc
+}
+
+fn is_zero_pair(ulo: i64, uhi: i64, uneg: i64, vlo: i64, vhi: i64, vneg: i64) -> bool with Mut, Panic, Div {
+    var k = 0
+    while k < 16 {
+        if prim_prod(ulo, uhi, uneg, vlo, vhi, vneg, k) != 0 { return false }
+        k = k + 1
+    }
+    true
+}
+
+// tau of the fiber via Matrix-Tree + Bareiss integer Gaussian elimination.
+fn fiber_tau() -> i64 with Mut, Panic, Div {
+    var flo = [0; 12]
+    var fhi = [0; 12]
+    var fng = [0; 12]
+    var m = 0
+    var lo = 1
+    while lo <= 7 {
+        var hi = 8
+        while hi <= 15 {
+            if (lo ^ hi) == 9 && hi != 8 {
+                var neg = 0
+                while neg <= 1 {
+                    if m < 12 {
+                        flo[m as usize] = lo
+                        fhi[m as usize] = hi
+                        fng[m as usize] = neg
+                        m = m + 1
+                    }
+                    neg = neg + 1
+                }
+            }
+            hi = hi + 1
+        }
+        lo = lo + 1
+    }
+    var A = [0; 144]
+    var i = 0
+    while i < 12 {
+        var j = 0
+        while j < 12 {
+            if i != j {
+                if is_zero_pair(flo[i as usize], fhi[i as usize], fng[i as usize],
+                                flo[j as usize], fhi[j as usize], fng[j as usize]) {
+                    A[(i * 12 + j) as usize] = 1
+                }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    var fdeg = [0; 12]
+    var di = 0
+    while di < 12 {
+        var s = 0
+        var dj = 0
+        while dj < 12 {
+            s = s + A[(di * 12 + dj) as usize]
+            dj = dj + 1
+        }
+        fdeg[di as usize] = s
+        di = di + 1
+    }
+    // Laplacian cofactor: reduced 11x11 (delete vertex 0); rows/cols map to graph vertices 1..11.
+    var Wf = [0; 121]
+    var rr = 0
+    while rr < 11 {
+        var cc = 0
+        while cc < 11 {
+            let gr = rr + 1
+            let gc = cc + 1
+            var v = 0 - A[(gr * 12 + gc) as usize]
+            if gr == gc {
+                v = fdeg[gr as usize] - A[(gr * 12 + gc) as usize]
+            }
+            Wf[(rr * 11 + cc) as usize] = v
+            cc = cc + 1
+        }
+        rr = rr + 1
+    }
+    // Fraction-free (Bareiss) integer Gaussian elimination on the 11x11 cofactor.
+    var prevf = 1
+    var kf = 0
+    while kf < 10 {
+        var if2 = kf + 1
+        while if2 < 11 {
+            var jf2 = kf + 1
+            while jf2 < 11 {
+                let nv = (Wf[(if2 * 11 + jf2) as usize] * Wf[(kf * 11 + kf) as usize]
+                          - Wf[(if2 * 11 + kf) as usize] * Wf[(kf * 11 + jf2) as usize]) / prevf
+                Wf[(if2 * 11 + jf2) as usize] = nv
+                jf2 = jf2 + 1
+            }
+            if2 = if2 + 1
+        }
+        prevf = Wf[(kf * 11 + kf) as usize]
+        kf = kf + 1
+    }
+    Wf[(10 * 11 + 10) as usize]
+}
+
+// fiber vertex count (must be 12).
+fn fiber_verts() -> i64 with Mut, Panic, Div {
+    var m = 0
+    var lo = 1
+    while lo <= 7 {
+        var hi = 8
+        while hi <= 15 {
+            if (lo ^ hi) == 9 && hi != 8 { m = m + 2 }
+            hi = hi + 1
+        }
+        lo = lo + 1
+    }
+    m
+}
+
+// fiber closed-walk return counts at vertex 0: kk=2 -> (A^2)_00, kk=4 -> (A^4)_00.
+fn fiber_walk(kk: i64) -> i64 with Mut, Panic, Div {
+    var flo = [0; 12]
+    var fhi = [0; 12]
+    var fng = [0; 12]
+    var m = 0
+    var lo = 1
+    while lo <= 7 {
+        var hi = 8
+        while hi <= 15 {
+            if (lo ^ hi) == 9 && hi != 8 {
+                var neg = 0
+                while neg <= 1 {
+                    if m < 12 {
+                        flo[m as usize] = lo
+                        fhi[m as usize] = hi
+                        fng[m as usize] = neg
+                        m = m + 1
+                    }
+                    neg = neg + 1
+                }
+            }
+            hi = hi + 1
+        }
+        lo = lo + 1
+    }
+    var A = [0; 144]
+    var i = 0
+    while i < 12 {
+        var j = 0
+        while j < 12 {
+            if i != j {
+                if is_zero_pair(flo[i as usize], fhi[i as usize], fng[i as usize],
+                                flo[j as usize], fhi[j as usize], fng[j as usize]) {
+                    A[(i * 12 + j) as usize] = 1
+                }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    // row 0 of A^2 (A symmetric): row0[c] = sum_s A[0][s]*A[s][c].
+    var row0 = [0; 12]
+    var c = 0
+    while c < 12 {
+        var s2 = 0
+        var s = 0
+        while s < 12 {
+            s2 = s2 + A[(0 * 12 + s) as usize] * A[(s * 12 + c) as usize]
+            s = s + 1
+        }
+        row0[c as usize] = s2
+        c = c + 1
+    }
+    if kk == 2 { return row0[0 as usize] }
+    // (A^4)_00 = sum_t (A^2)_{0t}*(A^2)_{t0} = sum_t row0[t]^2 (symmetry).
+    var acc = 0
+    var tt = 0
+    while tt < 12 {
+        acc = acc + row0[tt as usize] * row0[tt as usize]
+        tt = tt + 1
+    }
+    acc
+}
+
+// tau of 2*K_7 via Matrix-Tree + Bareiss on the reduced 6x6 Laplacian cofactor.
+fn k7_tau() -> i64 with Mut, Panic, Div {
+    var B = [0; 49]
+    var bi = 0
+    while bi < 7 {
+        var bj = 0
+        while bj < 7 {
+            if bi != bj { B[(bi * 7 + bj) as usize] = 2 }
+            bj = bj + 1
+        }
+        bi = bi + 1
+    }
+    var bdeg = [0; 7]
+    var ki = 0
+    while ki < 7 {
+        var sk = 0
+        var kj = 0
+        while kj < 7 {
+            sk = sk + B[(ki * 7 + kj) as usize]
+            kj = kj + 1
+        }
+        bdeg[ki as usize] = sk
+        ki = ki + 1
+    }
+    var Wk = [0; 36]
+    var kr = 0
+    while kr < 6 {
+        var kc = 0
+        while kc < 6 {
+            let gr = kr + 1
+            let gc = kc + 1
+            var v = 0 - B[(gr * 7 + gc) as usize]
+            if gr == gc {
+                v = bdeg[gr as usize] - B[(gr * 7 + gc) as usize]
+            }
+            Wk[(kr * 6 + kc) as usize] = v
+            kc = kc + 1
+        }
+        kr = kr + 1
+    }
+    var prevk = 1
+    var kk = 0
+    while kk < 5 {
+        var ik2 = kk + 1
+        while ik2 < 6 {
+            var jk2 = kk + 1
+            while jk2 < 6 {
+                let nv = (Wk[(ik2 * 6 + jk2) as usize] * Wk[(kk * 6 + kk) as usize]
+                          - Wk[(ik2 * 6 + kk) as usize] * Wk[(kk * 6 + jk2) as usize]) / prevk
+                Wk[(ik2 * 6 + jk2) as usize] = nv
+                jk2 = jk2 + 1
+            }
+            ik2 = ik2 + 1
+        }
+        prevk = Wk[(kk * 6 + kk) as usize]
+        kk = kk + 1
+    }
+    Wk[(5 * 6 + 5) as usize]
+}
+
+// 2*K_7 closed-walk return counts at vertex 0: kk=2 -> (A^2)_00 = 24, kk=4 -> (A^4)_00 = 2976.
+fn k7_walk(kk: i64) -> i64 with Mut, Panic, Div {
+    var B = [0; 49]
+    var bi = 0
+    while bi < 7 {
+        var bj = 0
+        while bj < 7 {
+            if bi != bj { B[(bi * 7 + bj) as usize] = 2 }
+            bj = bj + 1
+        }
+        bi = bi + 1
+    }
+    var row0 = [0; 7]
+    var c = 0
+    while c < 7 {
+        var sb = 0
+        var bt = 0
+        while bt < 7 {
+            sb = sb + B[(0 * 7 + bt) as usize] * B[(bt * 7 + c) as usize]
+            bt = bt + 1
+        }
+        row0[c as usize] = sb
+        c = c + 1
+    }
+    if kk == 2 { return row0[0 as usize] }
+    var acc = 0
+    var tt = 0
+    while tt < 7 {
+        acc = acc + row0[tt as usize] * row0[tt as usize]
+        tt = tt + 1
+    }
+    acc
+}
+
+fn main() with IO, Mut, Panic, Div {
+    let tau_fib = fiber_tau()
+    let tau_k7 = k7_tau()
+    let fib_a2 = fiber_walk(2)
+    let fib_a4 = fiber_walk(4)
+    let k7_a2 = k7_walk(2)
+    let k7_a4 = k7_walk(4)
+    let verts = fiber_verts()
+
+    // one value per line (single print_int + explicit newline) — portable across souc builds.
+    print("SPANTREE_FIB ")
+    print_int(tau_fib)
+    print("\n")
+    print("SPANTREE_K7 ")
+    print_int(tau_k7)
+    print("\n")
+    print("FIB_A2 ")
+    print_int(fib_a2)
+    print("\n")
+    print("FIB_A4 ")
+    print_int(fib_a4)
+    print("\n")
+    print("K7_A2 ")
+    print_int(k7_a2)
+    print("\n")
+    print("K7_A4 ")
+    print_int(k7_a4)
+    print("\n")
+    print("VERTS ")
+    print_int(verts)
+    print("\n")
+    // single load-bearing verdict.
+    if tau_fib == 393216 && tau_k7 == 1075648 && fib_a2 == 4 && fib_a4 == 48
+       && k7_a2 == 24 && k7_a4 == 2976 && verts == 12 {
+        println("DYNAMICS OK")
+    } else {
+        println("DYNAMICS FAIL")
+    }
+}


### PR DESCRIPTION
## Frente B, vector 4/2 — the substrate dynamics of the sedenion ZD geometry

The Laplacian `L = D − A` generates the substrate dynamics (heat flow `e^{−tL}`, random walk). This brick computes and certifies, exactly over ℤ, two of its invariants for the ZD-geometry graphs — headline being the **spanning-tree complexity** `τ` (Matrix-Tree theorem).

### Result

**1. Spanning-tree counts `τ`** (Matrix-Tree: `τ = det` of a principal `(n−1)×(n−1)` Laplacian cofactor), via fraction-free **Bareiss** integer Gaussian elimination — no rationals, no float, every intermediate an exact `i64`:

| Graph | `τ = ∏(nonzero L-eigenvalues)/n` | Bareiss `det` |
|---|---|---|
| fiber `K_{6,6}−3K_{2,2}` (12 v, deg 4) | `(2²·4⁶·6²·8)/12` | **393216** |
| `2·K₇` incidence (7 v, deg 12) | `14⁶/7` | **1075648** |

The two forms (integral spectrum from vector 4/1 vs Bareiss det) are computed **independently** and agree, tying the dynamics back to the metric: `τ = ∏(nonzero eigenvalues)/n`.

**2. Random-walk return counts** `(A^k)_{00}` (vertex-transitive graphs): fiber `(A²)=4=deg`, `(A⁴)=48`; `2·K₇` `(A²)=24=2²·6`, `(A⁴)=2976`. NB: for the entries-`2` matrix the closed-2-walk count `24` is **not** the degree `12` (they coincide only for a `0/1` adjacency); the true return count is certified.

### Three independent legs (cross-verified)

- **souc** — `tests/run-pass/sedenion_dynamics.sio` → `DYNAMICS OK`. Self-contained (`cd_sigma`/`prim_prod`/`is_zero_pair` copied verbatim from `sedenion_zd_fibers.sio`, avoids stdlib-engine defect #637).
- **Python oracle** — `scripts/research/sedenion_dynamics_oracle.py`; CI gate `scripts/ci/sedenion_dynamics_gate.sh` (registered in `.github/workflows/ci.yml`) diffs the souc value lines against the oracle.
- **Lean `native_decide`** — `formal/lean4/SounioSedenionDynamics.lean` (Mathlib-free, no `sorry`; Bareiss via structural fuel recursion; `lake build` < 4 s), registered in `lakefile.lean`.

### Compiler cross-check (bin/souc vs stage2)

Verified under **both** `./bin/souc` and the fresh stage2 — they **agree** (`DYNAMICS OK`, gate PASS under both). A monolithic `main()` computing both graphs SIGSEGVs `bin/souc` during output (a codegen defect — values computed correctly, not a stack-size issue; each half runs clean alone). Splitting the two graphs into separate functions sidesteps it entirely, so no stage2-only carve-out is needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)