### PR TITLE
fix(native): multimodule ELF emit — raise 128KB output ceiling + guard code overflow

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -9556,30 +9556,30 @@ fn compile_to_elf_v2(module: &IrModule, base_addr: i64) -> NativeCompileResult w
     native_compile_result_ok_elf(elf.bytes, elf.len, FORMAT_ELF64())
 }
 
-fn native_v2_file_put_u8(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic {
-    if pos >= 0 && pos < 131072 {
+fn native_v2_file_put_u8(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic {
+    if pos >= 0 && pos < 262144 {
         (*buf)[pos as usize] = (val & 255) as i8
     }
 }
 
-fn native_v2_file_put_u16(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic, Div {
+fn native_v2_file_put_u16(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
     native_v2_file_put_u8(buf, pos, val)
     native_v2_file_put_u8(buf, pos + 1, val >> 8)
 }
 
-fn native_v2_file_put_u32(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic, Div {
+fn native_v2_file_put_u32(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
     native_v2_file_put_u8(buf, pos, val)
     native_v2_file_put_u8(buf, pos + 1, val >> 8)
     native_v2_file_put_u8(buf, pos + 2, val >> 16)
     native_v2_file_put_u8(buf, pos + 3, val >> 24)
 }
 
-fn native_v2_file_put_u64(buf: &![i8; 131072], pos: i64, val: i64) with Mut, Panic, Div {
+fn native_v2_file_put_u64(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
     native_v2_file_put_u32(buf, pos, val)
     native_v2_file_put_u32(buf, pos + 4, val >> 32)
 }
 
-fn native_v2_file_emit_phdr(buf: &![i8; 131072], pos: i64, p_type: i64, flags: i64, offset: i64, vaddr: i64, filesz: i64, memsz: i64, align: i64) with Mut, Panic, Div {
+fn native_v2_file_emit_phdr(buf: &![i8; 262144], pos: i64, p_type: i64, flags: i64, offset: i64, vaddr: i64, filesz: i64, memsz: i64, align: i64) with Mut, Panic, Div {
     native_v2_file_put_u32(buf, pos, p_type)
     native_v2_file_put_u32(buf, pos + 4, flags)
     native_v2_file_put_u64(buf, pos + 8, offset)
@@ -9591,7 +9591,7 @@ fn native_v2_file_emit_phdr(buf: &![i8; 131072], pos: i64, p_type: i64, flags: i
 }
 
 fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler, entry_offset: i64, base_addr: i64) -> i32 with IO, Mut, Panic, Div {
-    var bytes: [i8; 131072] = [0; 131072]
+    var bytes: [i8; 262144] = [0; 262144]
     let text_offset: i64 = 4096
     let code_len = (*nc).code.len
     let rodata_len = if (*nc).flat_rodata_len > 0 { (*nc).flat_rodata_len } else { (*nc).rodata.len }
@@ -9616,7 +9616,7 @@ fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler,
     if data_len > 0 {
         file_len = data_offset + data_len
     }
-    if file_len <= 64 || file_len > 131072 { return 13 }
+    if file_len <= 64 || file_len > 262144 { return 13 }
 
     // Build the ELF header + program headers + segment payloads into `bytes`
     // via a dedicated small helper. Splitting this out of the (large) caller
@@ -9636,7 +9636,7 @@ fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler,
 
 // Helper extracted from native_v2_write_min_elf64_to_file (c634b38f branch-offset
 // workaround — see caller). Writes the full ELF image into `bytes`.
-fn native_v2_build_elf_image_into(bytes: &! [i8; 131072], nc: &! NativeCompiler, base_addr: i64, entry_offset: i64, text_offset: i64, code_len: i64, rodata_offset: i64, rodata_len: i64, rodata_vaddr: i64, text_vaddr: i64, data_offset: i64, data_len: i64, data_vaddr: i64, phnum: i64) with Mut, Panic, Div {
+fn native_v2_build_elf_image_into(bytes: &! [i8; 262144], nc: &! NativeCompiler, base_addr: i64, entry_offset: i64, text_offset: i64, code_len: i64, rodata_offset: i64, rodata_len: i64, rodata_vaddr: i64, text_vaddr: i64, data_offset: i64, data_len: i64, data_vaddr: i64, phnum: i64) with Mut, Panic, Div {
     native_v2_file_put_u8(bytes, 0, 127)
     native_v2_file_put_u8(bytes, 1, 69)
     native_v2_file_put_u8(bytes, 2, 76)
@@ -9676,20 +9676,20 @@ fn native_v2_build_elf_image_into(bytes: &! [i8; 131072], nc: &! NativeCompiler,
     native_v2_file_emit_phdr(bytes, phoff, 0x6474e551, 6, 0, 0, 0, 0, 16)
 
     var i: i64 = 0
-    while i < code_len && (text_offset + i) < 131072 {
+    while i < code_len && (text_offset + i) < 262144 {
         (*bytes)[(text_offset + i) as usize] = (*nc).code.bytes[i as usize]
         i = i + 1
     }
 
     if (*nc).flat_rodata_len > 0 {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 131072 {
+        while i < rodata_len && (rodata_offset + i) < 262144 {
             (*bytes)[(rodata_offset + i) as usize] = (*nc).flat_rodata_bytes[i as usize]
             i = i + 1
         }
     } else {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 131072 {
+        while i < rodata_len && (rodata_offset + i) < 262144 {
             (*bytes)[(rodata_offset + i) as usize] = (*nc).rodata.bytes[i as usize]
             i = i + 1
         }
@@ -9814,6 +9814,13 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
     let entry = trampoline_offset(nc)
     nc.bss_total_size = (*module).bss_total_size
     if nc.bss_total_size < 8 { nc.bss_total_size = 8 }
+    // Machine code exceeded the 128KB CodeBuffer: nc_emit_byte drops bytes past
+    // 131072 and sets code_overflow. .text is truncated and the entry trampoline
+    // lands out of bounds -> SIGSEGV at runtime. Fail with a distinct rc so the
+    // caller reports it instead of writing a broken ELF.
+    if nc.code_overflow {
+        return 19
+    }
     native_v2_write_min_elf64_to_file(output_path, &! nc, entry, 4194304)
 }
 


### PR DESCRIPTION
## Summary

Fixes the EISA default-lane **rc=13** native thin-link ELF-write failure (WP-EISA-THINLINK) and removes the silent-SIGSEGV footgun it was masking.

### Root cause (rc=13)
`native_v2_write_min_elf64_to_file` (codegen_x86_linux.sio) builds the entire ELF image into a fixed **`[i8; 131072]` (128KB)** stack buffer and returns `rc=13` when `file_len > 131072`. A 142-function merged program (`test_eisa_isa`) emits a ~139KB image and overflows it. The 128KB output buffer was also *smaller* than the max content a 128KB CodeBuffer + 8KB rodata + 8KB data can legitimately produce (~152KB), so it could reject valid programs.

### Changes
1. **Raise the write-path buffer `131072 → 262144`** (the whole `native_v2_write_min_elf64_to_file` / `native_v2_build_elf_image_into` / `native_v2_file_*` cluster). **Byte-neutral** — both are 6 digits, so no growth of `main.sio`'s import closure (which sits at the lean_single 8MB SRC-import cliff). 256KB ≥ max possible content, so the output buffer is never the bottleneck.
2. **Guard `nc.code_overflow` before writing.** When machine code exceeds the 128KB `CodeBuffer`, `nc_emit_byte` silently drops bytes past 131072, `.text` is truncated, and the entry trampoline lands out of bounds → **SIGSEGV** at runtime. Return a distinct **`rc=19`** so the caller reports it instead of writing a broken, crashing ELF.

### Verification
Built a madaros from this branch (via an expanded lean seed) and ran on the default Madaros engine:

| Witness | Result |
|---|---|
| `test_eisa_isa` / `test_eisa_evm` | **clean rc=19**, no ELF (was rc=13; silently SIGSEGV'd without the guard) |
| madaros multimodule witness (11 cases) | **11/11 PASS** (exit 7/0 as expected) — emit path unchanged |
| `hello` + small multimodule programs | compile & run unchanged |

Before the guard was added, an interim build confirmed the output-buffer fix alone lets the emitter **write a 139272-byte ELF** (`COMPILE_RC=0`, "Written to") that the old 128KB ceiling rejected — proving the rc=13 fix.

### Not in this PR (scoped separately)
The **deeper blocker**: the 128KB `encode::CodeBuffer` itself overflows for programs with >128KB of machine code (both EISA tests). Enlarging it is not a buffer bump — `encode::CodeBuffer` is copied **by-value across 563+ `emit_byte` call sites** (x86-v2, arm64-macho, wasm, legacy) and appears in fixed-size signatures, so it needs a dedicated large-code path. This PR converts that case from a silent miscompile into a clean, diagnosed `rc=19` error and leaves the buffer enlargement as follow-up work.