### PR TITLE
feat(exact): Sounio reproduces Furey's octonion → one SM generation (vector 4/3 A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Furey octonion generation cross-verification
+        run: bash scripts/ci/furey_octonion_gate.sh
       - name: Sedenion dynamics cross-verification
         run: bash scripts/ci/sedenion_dynamics_gate.sh
       - name: Sedenion spectra cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 893
-- Repo-backed topics: 743
+- Total governed topics: 894
+- Repo-backed topics: 744
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 178
+- Authority count `historical`: 179
 - Authority count `repo_only`: 527
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 227 topics
+- A6: 228 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -571,6 +571,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.erdos-sat-smt-unsat-scope-2026-06-23 | historical | docs/research/erdos-sat-smt-unsat-scope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.fano-arcs-blocking-sounio-note | historical | docs/research/fano-arcs-blocking-sounio-note.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.fisher-matrix-fix | historical | docs/research/FISHER_MATRIX_FIX.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.furey-octonion-generation | historical | docs/research/furey_octonion_generation.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.gradual-epistemic-positioning | historical | docs/research/gradual_epistemic_positioning.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.hyper-uncertainty-parenthesization-report | historical | docs/research/HYPER_UNCERTAINTY_PARENTHESIZATION_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.hyperbolic-semantic-networks-run | historical | docs/research/hyperbolic_semantic_networks_run.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -12601,6 +12601,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.furey-octonion-generation",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/furey_octonion_generation.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.gradual-epistemic-positioning",
       "collection": "repo",
       "repo_doc_path": "docs/research/gradual_epistemic_positioning.md",

--- a/docs/research/furey_octonion_generation.md
+++ b/docs/research/furey_octonion_generation.md
@@ -1,0 +1,100 @@
+<!-- docs:meta
+topic_id: repo.docs.research.furey-octonion-generation
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.furey-octonion-generation
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Sounio reproduces Furey's octonion → one Standard-Model generation (executed, exact)
+
+**One line.** Frente B, vector 4/3 Part A: the complex octonions ℂ⊗𝕆 carry a fermionic ladder algebra of
+three modes whose number operator gives the electric charges of exactly **one generation** of quarks and
+leptons, with the ×3 multiplicities of **SU(3) colour**. Sounio **executes** this established result
+**exactly over the Gaussian integers ℤ[i]** — no float — and it is cross-verified on three independent
+legs (souc, a Python oracle, and a Lean `native_decide` kernel proof).
+
+## Established result, not a new claim
+
+This is the *textbook / "trivial" end* of the octonion–Standard-Model program (C. Furey, *"Standard model
+physics from an algebra?"*, and the broader Dixon/Furey ℂ⊗𝕆 line of work). We claim **no new physics**.
+The point is that Sounio's exact-algebra substrate can carry a real particle-physics construction end to
+end and certify every integer, reproducing the known one-generation charge spectrum on the nose.
+
+## The construction (over Sounio's `cd_sigma` convention)
+
+Work with left-multiplication operators. For the octonion unit `e_a` (`e_0 = 1`, `e_1..e_7`), the
+**left-multiplication matrix** `L_a` is the 8×8 integer matrix with `L_a[a^b][b] = cd_sigma(a,b,3)` in
+column `b`, because `e_a · e_b = cd_sigma(a,b,3) · e_{a^b}` (`cd_sigma` = the standard Cayley–Dickson sign,
+here at `bits = 3`, the *same* recursion used at `bits = 4` for the sedenion bricks).
+
+Furey's ladder operators over ℂ⊗𝕆 are
+
+```
+alpha_i = 1/2 ( -L_{a_i} + i · L_{b_i} ),   (a_1,b_1),(a_2,b_2),(a_3,b_3) = (1,2),(3,4),(5,6)
+```
+
+**relative to Sounio's `cd_sigma` sign convention** (the specific index pairs are convention-dependent;
+these three pairs are the ones that close the algebra here). To stay in exact integers we scale by 2 and
+work with `A_i = 2·alpha_i`, the complex 8×8 matrix with **real part `−L_{a_i}`** and **imaginary part
+`L_{b_i}`** — Gaussian-integer entries. A complex matrix is represented as **two** integer arrays
+`(Re, Im)`; the adjoint is the conjugate-transpose `A† = (Reᵀ, −Imᵀ)`, and the complex product is
+`(Xr+iXi)(Yr+iYi) = (XrYr − XiYi) + i(XrYi + XiYr)`.
+
+### Claim 1 — the fermionic ladder algebra closes, exactly over ℤ[i]
+
+For all `i, j ∈ {1,2,3}` (18 anticommutator relations):
+
+| relation | value |
+|---|---|
+| `{A_i, A_j} = A_iA_j + A_jA_i` | `0` (both Re and Im all-zero) |
+| `{A_i, A_j†} = A_iA_j† + A_j†A_i` | `4·δ_ij·I` (Re = `4·I` iff `i=j`, else 0; Im all-zero) |
+
+The factor **4** appears because `A = 2·alpha`; the physical `alpha_i` satisfy `{alpha_i, alpha_j†} =
+δ_ij` — the canonical anticommutation relations of three fermionic creation/annihilation modes. Every
+entry is computed by exact integer complex matrix multiplication; there is no rounding anywhere.
+
+### Claim 2 — the charge spectrum of one generation
+
+Given Claim 1, the rest is combinatorics. The fermionic Fock space of the three modes has occupation
+number `n ∈ {0,1,2,3}` with multiplicities `C(3,n) = {0:1, 1:3, 2:3, 3:1}`. The **electric charge** is
+`Q = N/3`, so it takes the values
+
+```
+Q ∈ { 0,  1/3,  2/3,  1 }   with multiplicities { 1, 3, 3, 1 }.
+```
+
+The `×3` multiplicities on `Q = 1/3` and `Q = 2/3` are exactly the **SU(3) colour triplets** — the three
+colours of the down-type and up-type quarks. `Q = 0` is the neutrino, `Q = 1` the positron (or, in the
+conjugate ideal, `Q = −1` the electron). The conjugate minimal ideal supplies
+`{0, −1/3, −2/3, −1}` with the same `{1,3,3,1}`, completing the **full 16-state generation** (8 particles +
+8 anti-particles). The brick emits `Q×3 → multiplicity`, i.e. `CHARGE3_0 1`, `CHARGE3_1 3`, `CHARGE3_2 3`,
+`CHARGE3_3 1`.
+
+## Certification (exact, over ℤ[i] — three independent legs)
+
+- **souc**: `tests/run-pass/furey_octonion_generation.sio` → `FUREY OK`. Self-contained (the
+  Cayley–Dickson sign `cd_sigma` copied verbatim; no stdlib import). `main` stays tiny (the 8×8 complex
+  matmul lives in helper functions), and the brick runs with **identical values** under **both**
+  `bin/souc` and the fresh stage2 compiler — no bin/souc miscompile here.
+- **Python oracle**: `scripts/research/furey_octonion_oracle.py` (independent implementation of the same
+  `L_a`, complex matmul, adjoint, and Fock counting). CI gate
+  `scripts/ci/furey_octonion_gate.sh` diffs the souc value lines against the oracle.
+- **Lean `native_decide`**: `formal/lean4/SounioFureyOctonion.lean` → `ladder_closes` (Claim 1, all 18
+  relations over ℤ[i]) and `charge_multiplicities` (Claim 2, `C(3,n) = [1,3,3,1]`). Mathlib-free, no
+  `sorry`; `lake build SounioFureyOctonion` in <4 s.
+
+## Reproduce
+
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/furey_octonion_generation.sio
+python3 scripts/research/furey_octonion_oracle.py
+bash scripts/ci/furey_octonion_gate.sh
+(cd formal/lean4 && lake build SounioFureyOctonion)
+```

--- a/formal/lean4/SounioFureyOctonion.lean
+++ b/formal/lean4/SounioFureyOctonion.lean
@@ -1,0 +1,90 @@
+/-
+  SounioFureyOctonion — Sounio reproduces Furey's octonion -> one Standard-Model generation
+  (Frente B, vector 4/3 Part A). Left-multiplication operators L_a (8x8 integer matrices) over Sounio's
+  octonion convention (Cayley-Dickson sign cdSigma at bits=3). Furey's ladder operators
+  alpha_i = 1/2(-L_{a_i} + i L_{b_i}) for pairs (a_i,b_i) = (1,2),(3,4),(5,6); to stay exact over Z[i]
+  we use A_i = 2*alpha_i = (Re,Im) = (-L_{a_i}, L_{b_i}).
+
+  CLAIM 1 (native_decide): the three modes close a fermionic ladder algebra over Z[i]:
+    {A_i, A_j} = 0  and  {A_i, A_j^dag} = 4*delta_ij*I   for all i,j in {1,2,3}.
+  CLAIM 2 (decide): the fermionic Fock-space occupation multiplicities C(3,n) = [1,3,3,1] -> one
+  generation of electric charges Q=N/3 in {0,1/3,2/3,1}, the x3 being SU(3) colour.
+
+  Mathlib-free, no sorry.
+-/
+namespace SounioFureyOctonion
+
+-- Cayley-Dickson sign, recursion on `bits`; octonions at bits=3.
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def octSigma (a b : Nat) : Int := cdSigma a b 3
+
+-- L_a entry: e_a * e_c = octSigma(a,c) * e_{a^c}; nonzero only when r = a^c.
+def lentry (a r c : Nat) : Int := if r == (a ^^^ c) then octSigma a c else 0
+
+-- 8x8 integer matrices as List (List Int).
+def mk (f : Nat → Nat → Int) : List (List Int) :=
+  (List.range 8).map (fun r => (List.range 8).map (fun c => f r c))
+
+-- A_i = 2*alpha_i, pairs (a_i,b_i) = (2i-1, 2i); Re = -L_{a_i}, Im = L_{b_i}.
+def Are (i : Nat) : List (List Int) := mk (fun r c => - lentry (2*i - 1) r c)
+def Aim (i : Nat) : List (List Int) := mk (fun r c => lentry (2*i) r c)
+
+def matmul (A B : List (List Int)) : List (List Int) :=
+  let n := A.length
+  A.map (fun row => (List.range n).map (fun j =>
+    (List.range n).foldl (fun s t => s + (row.getD t 0) * ((B.getD t []).getD j 0)) 0))
+def madd (A B : List (List Int)) : List (List Int) :=
+  (List.range A.length).map (fun i =>
+    (List.range ((A.getD i []).length)).map (fun j => (A.getD i []).getD j 0 + (B.getD i []).getD j 0))
+def smul (s : Int) (A : List (List Int)) : List (List Int) :=
+  A.map (fun row => row.map (fun x => s * x))
+def tpose (A : List (List Int)) : List (List Int) :=
+  (List.range 8).map (fun i => (List.range 8).map (fun j => (A.getD j []).getD i 0))
+
+-- complex 8x8 product (Xr+iXi)(Yr+iYi) = (XrYr - XiYi) + i(XrYi + XiYr).
+def prodRe (Xr Xi Yr Yi : List (List Int)) : List (List Int) := madd (matmul Xr Yr) (smul (-1) (matmul Xi Yi))
+def prodIm (Xr Xi Yr Yi : List (List Int)) : List (List Int) := madd (matmul Xr Yi) (matmul Xi Yr)
+def anticommRe (Xr Xi Yr Yi : List (List Int)) : List (List Int) :=
+  madd (prodRe Xr Xi Yr Yi) (prodRe Yr Yi Xr Xi)
+def anticommIm (Xr Xi Yr Yi : List (List Int)) : List (List Int) :=
+  madd (prodIm Xr Xi Yr Yi) (prodIm Yr Yi Xr Xi)
+
+def isZero (M : List (List Int)) : Bool := M.all (fun row => row.all (fun x => x == 0))
+def isScalar (M : List (List Int)) (v : Int) : Bool :=
+  (List.range 8).all (fun r => (List.range 8).all (fun c =>
+    (M.getD r []).getD c 0 == (if r == c then v else 0)))
+
+-- {A_i,A_j}=0 and {A_i,A_j^dag}=4 delta_ij I.
+def checkPair (i j : Nat) : Bool :=
+  let Xr := Are i; let Xi := Aim i
+  let Yr := Are j; let Yi := Aim j
+  let acR := anticommRe Xr Xi Yr Yi; let acI := anticommIm Xr Xi Yr Yi
+  let YrD := tpose (Are j); let YiD := smul (-1) (tpose (Aim j))
+  let adR := anticommRe Xr Xi YrD YiD; let adI := anticommIm Xr Xi YrD YiD
+  let want : Int := if i == j then 4 else 0
+  isZero acR && isZero acI && isScalar adR want && isZero adI
+def checkAll : Bool :=
+  ((List.range 3).map (· + 1)).all (fun i => ((List.range 3).map (· + 1)).all (fun j => checkPair i j))
+
+-- CLAIM 1: the fermionic ladder algebra closes exactly over Z[i].
+theorem ladder_closes : checkAll = true := by native_decide
+
+-- CLAIM 2: Fock-space occupation multiplicities C(3,n) = one generation {1,3,3,1}.
+def fact : Nat → Nat
+  | 0 => 1
+  | (n+1) => (n+1) * fact n
+def binom (n k : Nat) : Nat := fact n / (fact k * fact (n - k))
+theorem charge_multiplicities : ((List.range 4).map (fun n => binom 3 n)) = [1, 3, 3, 1] := by decide
+
+end SounioFureyOctonion

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -72,6 +72,12 @@ lean_lib «SounioZeroDivisorBridge» where
 @[default_target]
 lean_lib «SounioSedenionMeasurement» where
 
+-- Frente B vector 4/3 Part A: Sounio reproduces Furey's octonion -> one Standard-Model generation.
+-- Fermionic ladder algebra {A_i,A_j}=0, {A_i,A_j^dag}=4 delta_ij I over Z[i] (native_decide) + the
+-- one-generation charge multiplicities C(3,n)=[1,3,3,1]. Mathlib-free, no sorry.
+@[default_target]
+lean_lib «SounioFureyOctonion» where
+
 -- Frente B vector 4/1: emergent metric — integral spectra of the ZD-geometry graphs.
 @[default_target]
 lean_lib «SounioSedenionSpectra» where

--- a/scripts/ci/furey_octonion_gate.sh
+++ b/scripts/ci/furey_octonion_gate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: Sounio reproduces Furey's octonion -> one SM generation (Frente B, vector 4/3 A).
+# Fermionic ladder algebra {A_i,A_j}=0, {A_i,A_j^dag}=4 delta_ij I over Z[i] + one-generation charge
+# multiplicities {1,3,3,1}. souc vs Python oracle; /usr/bin/diff on the value lines.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/s.elf" >/dev/null 2>&1; chmod +x "$WORK/s.elf"; "$WORK/s.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/furey_octonion_generation.sio | grep -E '^(LADDER_OK|CHARGE3_|FUREY)' | sort > "$WORK/souc.txt"
+python3 scripts/research/furey_octonion_oracle.py | grep -E '^(LADDER_OK|CHARGE3_|FUREY)' | sort > "$WORK/py.txt"
+if diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null && grep -q '^FUREY OK' "$WORK/souc.txt"; then
+  echo "CROSS-VERIFIED: Furey octonion -> one SM generation — fermionic ladder {A_i,A_j}=0,"
+  echo "  {A_i,A_j^dag}=4 delta_ij I over Z[i]; charge multiplicities Q*3 -> {0:1,1:3,2:3,3:1} (SU(3) colour)."
+  echo "furey octonion gate: PASS"
+else echo "furey octonion gate: FAIL"; diff "$WORK/souc.txt" "$WORK/py.txt"; exit 1; fi

--- a/scripts/research/furey_octonion_oracle.py
+++ b/scripts/research/furey_octonion_oracle.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Oracle: Sounio reproduces Furey's octonion -> one Standard-Model generation (Frente B, vector 4/3 A).
+
+Established result (C. Furey, "Standard model physics from an algebra?"; the Dixon/Furey C(x)O program):
+the complex octonions carry a fermionic ladder algebra of three modes whose number operator gives the
+electric charges of exactly one generation, with the x3 multiplicities of SU(3) colour. Executed EXACTLY
+over the Gaussian integers Z[i] on Sounio's octonion convention (Cayley-Dickson sign cd_sigma at bits=3).
+
+Left-multiplication operators (8x8 int matrices): L_a[a^b][b] = cd_sigma(a,b,3) in column b.
+Furey ladder ops alpha_i = 1/2(-L_{a_i} + i L_{b_i}), pairs (a_i,b_i) = (1,2),(3,4),(5,6). To keep exact
+integers we use A_i = 2*alpha_i = (Re,Im) = (-L_{a_i}, L_{b_i}). Adjoint = (Re^T, -Im^T). Complex matmul
+(Xr+iXi)(Yr+iYi) = (XrYr - XiYi) + i(XrYi + XiYr).
+
+CLAIM 1: {A_i,A_j} = 0 and {A_i,A_j^dag} = 4*delta_ij*I for all i,j in {1,2,3} (18 relations).
+CLAIM 2: Fock-space occupation multiplicities C(3,n) = {0:1,1:3,2:3,3:1} -> charges Q=N/3 in
+{0,1/3,2/3,1} with the x3 = SU(3) colour; the conjugate ideal completes the 16-state generation.
+
+Output lines: LADDER_OK, CHARGE3_0..CHARGE3_3, FUREY <OK|FAIL>.
+Cross-verified vs tests/run-pass/furey_octonion_generation.sio by scripts/ci/furey_octonion_gate.sh.
+"""
+from math import comb
+
+
+def cd_sigma(a, b, bits=3):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH = a >= half
+    bH = b >= half
+    aL = a & (half - 1)
+    bL = b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def lmat(a):
+    """Left-multiplication matrix of e_a: column b -> cd_sigma(a,b,3)*e_{a^b}."""
+    M = [[0] * 8 for _ in range(8)]
+    for b in range(8):
+        M[a ^ b][b] = cd_sigma(a, b, 3)
+    return M
+
+
+def smul(s, A):
+    return [[s * A[i][j] for j in range(8)] for i in range(8)]
+
+
+def tpose(A):
+    return [[A[j][i] for j in range(8)] for i in range(8)]
+
+
+def madd(A, B):
+    return [[A[i][j] + B[i][j] for j in range(8)] for i in range(8)]
+
+
+def mm(A, B):
+    return [[sum(A[i][k] * B[k][j] for k in range(8)) for j in range(8)] for i in range(8)]
+
+
+def cprod(X, Y):
+    """Complex 8x8 product (Xr+iXi)(Yr+iYi)."""
+    (xr, xi), (yr, yi) = X, Y
+    return (madd(mm(xr, yr), smul(-1, mm(xi, yi))), madd(mm(xr, yi), mm(xi, yr)))
+
+
+def anticomm(X, Y):
+    p = cprod(X, Y)
+    q = cprod(Y, X)
+    return (madd(p[0], q[0]), madd(p[1], q[1]))
+
+
+def adj(X):
+    xr, xi = X
+    return (tpose(xr), smul(-1, tpose(xi)))
+
+
+def A(i):
+    """A_i = 2*alpha_i = -L_{a_i} + i L_{b_i}, pairs (2i-1, 2i)."""
+    a_i, b_i = 2 * i - 1, 2 * i
+    return (smul(-1, lmat(a_i)), lmat(b_i))
+
+
+def is_scalar(M, val):
+    return all(M[i][j] == (val if i == j else 0) for i in range(8) for j in range(8))
+
+
+def is_zero(M):
+    return all(M[i][j] == 0 for i in range(8) for j in range(8))
+
+
+def ladder_ok():
+    ops = {i: A(i) for i in (1, 2, 3)}
+    for i in (1, 2, 3):
+        for j in (1, 2, 3):
+            ac = anticomm(ops[i], ops[j])
+            if not (is_zero(ac[0]) and is_zero(ac[1])):
+                return 0
+            acd = anticomm(ops[i], adj(ops[j]))
+            want = 4 if i == j else 0
+            if not (is_scalar(acd[0], want) and is_zero(acd[1])):
+                return 0
+    return 1
+
+
+def main():
+    lad = ladder_ok()
+    mult = {n: comb(3, n) for n in range(4)}
+    print(f"LADDER_OK {lad}")
+    for n in range(4):
+        print(f"CHARGE3_{n} {mult[n]}")
+    ok = lad == 1 and mult == {0: 1, 1: 3, 2: 3, 3: 1}
+    print(f"FUREY {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/furey_octonion_generation.sio
+++ b/tests/run-pass/furey_octonion_generation.sio
@@ -1,0 +1,191 @@
+//@ run-pass
+//@ expect-stdout: FUREY OK
+// FRENTE B, vector 4/3 Part A — Sounio reproduces Furey's octonion -> one Standard-Model generation.
+//
+// This EXECUTES an established result (C. Furey, "Standard model physics from an algebra?", and the
+// Dixon/Furey C(x)O program): the complex octonions C(x)O carry a fermionic ladder algebra of three
+// modes whose number operator gives the electric charges of exactly one generation of quarks + leptons,
+// with the x3 multiplicities of SU(3) colour. We build it EXACTLY over the Gaussian integers Z[i].
+//
+// Left-multiplication operators (8x8 integer matrices) over Sounio's octonion convention (cd_sigma at
+// bits=3): for the unit e_a, L_a has L_a[a^b][b] = cd_sigma(a,b,3) in column b (e_a * e_b = sign*e_{a^b}).
+// Furey's ladder operators are alpha_i = 1/2(-L_{a_i} + i L_{b_i}) for the pairs
+//   (a_1,b_1),(a_2,b_2),(a_3,b_3) = (1,2),(3,4),(5,6)   [relative to Sounio's cd_sigma sign convention].
+// To stay in exact integers we use A_i = 2*alpha_i, the complex 8x8 matrix with real part -L_{a_i} and
+// imaginary part L_{b_i}. A complex matrix is TWO int arrays (Re, Im), 64 entries row-major each.
+// Adjoint A^dag = conjugate-transpose = (Re^T, -Im^T). Complex matmul
+//   (Xr+iXi)(Yr+iYi) = (XrYr - XiYi) + i(XrYi + XiYr).
+//
+// CLAIM 1 (the headline, exact over Z[i]): the three A_i close a fermionic ladder algebra —
+//   {A_i, A_j}      = 0                (all 9 pairs, both Re and Im zero)
+//   {A_i, A_j^dag}  = 4*delta_ij * I   (Re = 4*I if i==j else 0; Im zero)
+// (the factor 4 is because A = 2*alpha; alpha itself gives delta_ij). 18 anticommutator relations.
+//
+// CLAIM 2 (charge spectrum, combinatorial given Claim 1): the fermionic Fock space of the 3 modes has
+// occupation-number multiplicities C(3,n) = {0:1, 1:3, 2:3, 3:1}, so the electric charge Q = N/3 takes
+// the values {0, 1/3, 2/3, 1} with those multiplicities (the x3 = SU(3) colour triplets). The conjugate
+// ideal supplies {0, -1/3, -2/3, -1} -> the full 16-state generation. We emit Q*3 -> multiplicity.
+//
+// Decidable integer arithmetic, no float. SELF-CONTAINED (cd_sigma copied verbatim; no stdlib import).
+// Cross-verified vs scripts/research/furey_octonion_oracle.py by scripts/ci/furey_octonion_gate.sh and
+// by formal/lean4/SounioFureyOctonion.lean (native_decide).
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+
+// L_a entry at (row r, col c): e_a * e_c = cd_sigma(a,c,3) * e_{a^c}, so nonzero only when r == a^c.
+fn l_entry(a: i64, r: i64, c: i64) -> i64 with Mut, Panic, Div {
+    if r == (a ^ c) { return cd_sigma_c(a, c, 3) }
+    0
+}
+
+// Verify one anticommutator relation for modes i,j in {1,2,3}:
+//   dag==0 -> {A_i, A_j}      must be 0 (Re and Im).
+//   dag==1 -> {A_i, A_j^dag}  must be 4*delta_ij*I (Re = 4 on diagonal iff i==j; Im 0).
+// A_k = 2*alpha_k has real part -L_{a_k}, imaginary part L_{b_k}, with (a_k,b_k)=(2k-1, 2k).
+// Returns 1 if the relation holds exactly over Z[i], else 0.
+fn check_anti(i: i64, j: i64, dag: i64) -> i64 with Mut, Panic, Div {
+    let ai = 2 * i - 1
+    let bi = 2 * i
+    let aj = 2 * j - 1
+    let bj = 2 * j
+    var xr = [0; 64]
+    var xi = [0; 64]
+    var yr = [0; 64]
+    var yi = [0; 64]
+    var rr = 0
+    while rr < 8 {
+        var cc = 0
+        while cc < 8 {
+            // X = A_i
+            xr[(rr * 8 + cc) as usize] = 0 - l_entry(ai, rr, cc)
+            xi[(rr * 8 + cc) as usize] = l_entry(bi, rr, cc)
+            if dag == 0 {
+                // Y = A_j
+                yr[(rr * 8 + cc) as usize] = 0 - l_entry(aj, rr, cc)
+                yi[(rr * 8 + cc) as usize] = l_entry(bj, rr, cc)
+            } else {
+                // Y = A_j^dag = (Re(A_j)^T, -Im(A_j)^T); Re(A_j)=-L_{aj}, Im(A_j)=L_{bj}.
+                yr[(rr * 8 + cc) as usize] = 0 - l_entry(aj, cc, rr)
+                yi[(rr * 8 + cc) as usize] = 0 - l_entry(bj, cc, rr)
+            }
+            cc = cc + 1
+        }
+        rr = rr + 1
+    }
+    // anti = X*Y + Y*X, complex; check each entry against the expected value.
+    var ok = 1
+    var r = 0
+    while r < 8 {
+        var c = 0
+        while c < 8 {
+            var pr = 0
+            var pi = 0
+            var qr = 0
+            var qi = 0
+            var k = 0
+            while k < 8 {
+                let xrk = xr[(r * 8 + k) as usize]
+                let xik = xi[(r * 8 + k) as usize]
+                let yrk = yr[(r * 8 + k) as usize]
+                let yik = yi[(r * 8 + k) as usize]
+                let xkc = xr[(k * 8 + c) as usize]
+                let xikc = xi[(k * 8 + c) as usize]
+                let ykc = yr[(k * 8 + c) as usize]
+                let yikc = yi[(k * 8 + c) as usize]
+                // P = X*Y
+                pr = pr + xrk * ykc - xik * yikc
+                pi = pi + xrk * yikc + xik * ykc
+                // Q = Y*X
+                qr = qr + yrk * xkc - yik * xikc
+                qi = qi + yrk * xikc + yik * xkc
+                k = k + 1
+            }
+            let a_re = pr + qr
+            let a_im = pi + qi
+            var e_re = 0
+            if dag == 1 && i == j && r == c { e_re = 4 }
+            if a_re != e_re { ok = 0 }
+            if a_im != 0 { ok = 0 }
+            c = c + 1
+        }
+        r = r + 1
+    }
+    ok
+}
+
+// All 18 relations: for i,j in {1,2,3}, both {A_i,A_j}=0 and {A_i,A_j^dag}=4 delta_ij I.
+fn ladder_ok() -> i64 with Mut, Panic, Div {
+    var ok = 1
+    var i = 1
+    while i <= 3 {
+        var j = 1
+        while j <= 3 {
+            if check_anti(i, j, 0) == 0 { ok = 0 }
+            if check_anti(i, j, 1) == 0 { ok = 0 }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    ok
+}
+
+// Fock-space occupation multiplicity of n filled modes among 3 = binomial(3, n).
+fn binom3(n: i64) -> i64 with Mut, Panic, Div {
+    var num = 1
+    var den = 1
+    var t = 0
+    while t < n {
+        num = num * (3 - t)
+        den = den * (t + 1)
+        t = t + 1
+    }
+    num / den
+}
+
+fn main() with IO, Mut, Panic, Div {
+    let lad = ladder_ok()
+    let m0 = binom3(0)
+    let m1 = binom3(1)
+    let m2 = binom3(2)
+    let m3 = binom3(3)
+
+    // one value per line (single print_int + explicit newline) — portable across souc builds.
+    print("LADDER_OK ")
+    print_int(lad)
+    print("\n")
+    // Q*3 -> multiplicity (Q in {0, 1/3, 2/3, 1}; the x3 factors are SU(3) colour).
+    print("CHARGE3_0 ")
+    print_int(m0)
+    print("\n")
+    print("CHARGE3_1 ")
+    print_int(m1)
+    print("\n")
+    print("CHARGE3_2 ")
+    print_int(m2)
+    print("\n")
+    print("CHARGE3_3 ")
+    print_int(m3)
+    print("\n")
+    // single load-bearing verdict: ladder closes AND generation multiplicities {1,3,3,1}.
+    if lad == 1 && m0 == 1 && m1 == 3 && m2 == 3 && m3 == 1 {
+        println("FUREY OK")
+    } else {
+        println("FUREY FAIL")
+    }
+}


### PR DESCRIPTION
## Frente B, vector 4/3 Part A — Sounio reproduces Furey's octonion → one Standard-Model generation, exactly

Reproduces an **established** result (C. Furey, *"Standard model physics from an algebra?"*; the Dixon/Furey ℂ⊗𝕆 program) — the textbook end — showing Sounio executes real particle physics **exactly over the Gaussian integers ℤ[i]**, no float. No new physics claimed.

### The construction
Left-multiplication matrices `L_a` (8×8 integer) over Sounio's octonion convention (Cayley–Dickson sign `cd_sigma` at **bits=3**): `L_a[a^b][b] = cd_sigma(a,b,3)`. Furey's ladder operators `alpha_i = ½(−L_{a_i} + i·L_{b_i})` for pairs `(a_i,b_i) = (1,2),(3,4),(5,6)` (relative to Sounio's `cd_sigma` sign convention). To stay in exact integers we use `A_i = 2·alpha_i = (Re, Im) = (−L_{a_i}, L_{b_i})`; adjoint `A† = (Reᵀ, −Imᵀ)`.

**Claim 1 (native_decide + souc + oracle):** for all `i,j ∈ {1,2,3}` (18 relations, exact over ℤ[i])
- `{A_i, A_j} = 0`
- `{A_i, A_j†} = 4·δ_ij·I`  (factor 4 because `A = 2·alpha`)

**Claim 2:** fermionic Fock occupation multiplicities `C(3,n) = {1,3,3,1}` → electric charges `Q = N/3 ∈ {0, 1/3, 2/3, 1}` (the ×3 = SU(3) colour triplets); the conjugate ideal completes the 16-state generation. Emitted as `CHARGE3_0 1`, `CHARGE3_1 3`, `CHARGE3_2 3`, `CHARGE3_3 1`.

### Three independent legs
- `tests/run-pass/furey_octonion_generation.sio` → `FUREY OK`, self-contained. **bin/souc and stage2 agree** on every value (`LADDER_OK 1`, charges `{1,3,3,1}`).
- `scripts/research/furey_octonion_oracle.py` — independent Python reference (same lines).
- `scripts/ci/furey_octonion_gate.sh` — souc vs oracle diff; registered in `.github/workflows/ci.yml` after the sedenion-zd168 step. Passes under both `bin/souc` and stage2.
- `formal/lean4/SounioFureyOctonion.lean` — `ladder_closes` (Claim 1) + `charge_multiplicities` (Claim 2). Mathlib-free, no `sorry`; `lake build` < 4 s.
- Docs: `docs/research/furey_octonion_generation.md` (+ governance registry entry).

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)