### PR TITLE
feat(exact): the sedenion extension of the Furey ladder — rank 3→4, interpretation open (vector 4/3 B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion ladder extension cross-verification
+        run: bash scripts/ci/sedenion_ladder_extension_gate.sh
       - name: Sedenion dynamics cross-verification
         run: bash scripts/ci/sedenion_dynamics_gate.sh
       - name: Sedenion spectra cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 893
-- Repo-backed topics: 743
+- Total governed topics: 894
+- Repo-backed topics: 744
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 178
+- Authority count `historical`: 179
 - Authority count `repo_only`: 527
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 227 topics
+- A6: 228 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -675,6 +675,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sedenion-dynamics | historical | docs/research/sedenion_dynamics.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-e8-boundary | historical | docs/research/sedenion_e8_boundary.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-fano-fibers | historical | docs/research/sedenion_fano_fibers.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-ladder-extension | historical | docs/research/sedenion_ladder_extension.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-spectra | historical | docs/research/sedenion_spectra.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-fiber-identity | historical | docs/research/sedenion_zd_fiber_identity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14890,6 +14890,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-ladder-extension",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_ladder_extension.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-quartet-fiber-incidence",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_quartet_fiber_incidence.md",

--- a/docs/research/sedenion_ladder_extension.md
+++ b/docs/research/sedenion_ladder_extension.md
@@ -1,0 +1,123 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-ladder-extension
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-ladder-extension
+-->
+
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The sedenion extension of the Furey ladder: rank 3 → 4 (interpretation OPEN)
+
+**One line.** Frente B, vector 4/3 Part B — the *novelty* end, executed exactly. Under the
+octonion → **sedenion** doubling, the octonion Standard-Model generation **persists** (B1) and the
+doubling adds **exactly one** more fermionic mode (greedy maximal rank `3 → 4`, B2). This is **not** a
+clean second generation (which would need `6`), and the sedenion zero-divisor geometry is a **separate**
+state-level structure (B3). Every number is exact integer arithmetic, cross-verified on three
+independent legs. The particle-physics **interpretation is explicitly OPEN**.
+
+## Setup (the same ladder, one dimension up)
+
+Part A (`docs/research/furey_octonion.md`, the sibling brick) shows Sounio reproduces Furey's
+`ℂ ⊗ 𝕆 → one Standard-Model generation`. Over the octonion **left-multiplication** matrices `L_a`
+(`8×8`, `L_a[a^b][b] = cd_sigma(a,b,3)`), a single-pair ladder op is the complex `8×8` matrix
+`A = α(a,b) = (−L_a, L_b)` (real, imaginary parts). This is Furey's `A = 2α`, so the fermionic
+normalisation carries a factor `4`. The three ops from the disjoint pairs `(1,2), (3,4), (5,6)` satisfy
+
+```
+{A_i, A_j} = 0            {A_i, A_j†} = 4·δ_ij·I ,
+```
+
+i.e. a fermionic creation/annihilation ladder of **three** modes → one generation (occupation
+`n ∈ {0,1,2,3}`, the `C(3,n) = 1,3,3,1` multiplicities are `SU(3)` color).
+
+This note applies the exact same construction to the **sedenion** left-multiplication matrices
+(`cd_sigma` at `bits = 4`, `16×16`): `A = α(a,b) = (−L_a, L_b)`, adjoint `= (Reᵀ, −Imᵀ)`, anticommutator
+`{X,Y} = XY + YX`, all over ℤ.
+
+## B1 — the octonion generation persists inside the sedenion
+
+The three octonion ladder ops `(1,2), (3,4), (5,6)`, now realised as `16×16` complex matrices, **still**
+satisfy the full fermionic algebra:
+
+```
+{A_i, A_j} = 0    and    {A_i, A_j†} = 4·δ_ij·I₁₆      for all i,j ∈ {1,2,3}.
+```
+
+So the entire Standard-Model generation of Part A **survives intact** inside the sedenion — the doubling
+does not spoil it. Executed value: `B1_OK 1`.
+
+## B2 — the maximal fermionic rank is 4, not 6
+
+The natural hope is that doubling `𝕆 → 𝕊` doubles the ladder into a **second** generation (rank
+`3 → 6`). It does **not**. We compute the maximal set of mutually-fermionic single-pair ladder ops by a
+deterministic **greedy** sweep: iterate pairs `(a,b)` with `1 ≤ a < b ≤ N−1` in order, keep a `chosen`
+list, and add `α(a,b)` iff it is **self-fermionic** (`{X,X†} = 4·I`, `{X,X} = 0`) **and** cross-fermionic
+with every already-chosen `Y` (`{X,Y} = 0` **and** `{X,Y†} = 0` — distinct, independent modes).
+
+| algebra | index range | greedy maximal fermionic rank |
+|---|---|---|
+| octonion (`𝕆`, `8`-dim) | `1..7` | **3**  → one generation |
+| sedenion (`𝕊`, `16`-dim) | `1..15` | **4** |
+
+Executed values: `OCT_RANK 3`, `SED_RANK 4`. **The doubling adds exactly ONE fermionic mode**, `3 → 4`.
+One extra creation/annihilation mode is *not* a second `SU(3)` generation (that would be `6`, two disjoint
+triples). The naive "second generation" reading fails; the exact answer is a single additional mode.
+
+## B3 — honest scope: the zero divisors live at the state level, not here
+
+The sedenion is famous for its **zero divisors**, and the sibling ZD-geometry bricks
+(`docs/research/sedenion_e8_boundary.md`, `sedenion_zd_fibers.md`, `sedenion_zd_quartets.md`,
+`sedenion_automorphism_168.md`) map the `84 / 168 / E8`-boundary combinatorics of that structure. It is
+important to state where that structure does — and does **not** — touch the present ladder:
+
+> The basis **units** `e_i` never multiply to zero; a sedenion zero divisor is a **2-support** element
+> (e.g. `e_i ± e_j`). The ladder generators here are built from single units, so the zero-divisor
+> geometry enters at the **STATE / spinor** level, **not** at the ladder-generator level.
+
+So B1/B2 (this note) and the ZD-geometry bricks describe **two different layers**: the fermionic ladder of
+generators, and the zero-divisor geometry of states. They are complementary, not the same object.
+
+## Interpretation: OPEN
+
+The facts above are exact and certified. Their **physical** reading is **not** settled and is presented
+here as speculative/open:
+
+- B1 is a clean, positive result: the octonion → SM generation is a genuine sub-structure of the sedenion.
+- B2 is a *negative* result against the most naive hope: doubling does **not** give two generations; it
+  gives `3 → 4`, one extra mode. Whether that single mode carries any Standard-Model meaning (a sterile
+  mode? an artifact of the greedy single-pair restriction? something visible only once state-level ZD
+  structure is included, per B3?) is **an open question** — this brick does not claim an answer.
+
+This is the whole point of the brick: Sounio spans, **exactly**, from the *established* (octonion/SM,
+reproduced) to the *genuinely unexplored* (the sedenion ladder), and reports the unexplored end
+honestly — the exact algebra, and an interpretation flagged open.
+
+## Certification (exact, over ℤ — three independent legs)
+
+- **souc**: `tests/run-pass/sedenion_ladder_extension.sio` → `SEDEXT OK`. Self-contained (`cd_sigma`
+  copied verbatim, avoiding the stdlib-import defect #637); `main()` kept tiny (the `16×16` matrices live
+  inside helper functions) to sidestep the monolithic-`main` codegen SIGSEGV. Runs correctly and
+  **identically** under **both** `bin/souc` and the fresh stage2 compiler.
+- **Python oracle**: `scripts/research/sedenion_ladder_extension_oracle.py` — a clean re-implementation of
+  the Part B facts; CI gate `scripts/ci/sedenion_ladder_extension_gate.sh` diffs the souc value lines
+  against the oracle (`B1_OK`, `OCT_RANK`, `SED_RANK`, `SEDEXT OK`).
+- **Lean `native_decide`**: `formal/lean4/SounioSedenionLadderExtension.lean` → `b1_persists`,
+  `oct_rank_3`, `sed_rank_4` (Mathlib-free, no `sorry`; the `16×16` complex greedy over indices `1..15`
+  checks in ~10 s, so kept a `@[default_target]`). All three facts — including `SED_RANK = 4` — are pinned
+  by the Lean kernel, not only by souc + oracle.
+
+## Reproduce
+
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_ladder_extension.sio
+python3 scripts/research/sedenion_ladder_extension_oracle.py
+bash scripts/ci/sedenion_ladder_extension_gate.sh
+(cd formal/lean4 && lake build SounioSedenionLadderExtension)
+```

--- a/formal/lean4/SounioSedenionLadderExtension.lean
+++ b/formal/lean4/SounioSedenionLadderExtension.lean
@@ -1,0 +1,121 @@
+/-
+  SounioSedenionLadderExtension — the SEDENION EXTENSION of the Furey ladder (Frente B, vector 4/3 B),
+  by Lean native_decide. Mathlib-free, no sorry.
+
+  Over the sedenion LEFT-multiplication matrices L_a (16x16, L_a[a^b][b] = cd_sigma(a,b,4)), a single-pair
+  ladder op is the complex 16x16 matrix A = alpha(a,b) = (-L_a, L_b) (Re, Im) — Furey's A = 2*alpha, hence
+  the factor 4. adjoint(Re,Im) = (Re^T, -Im^T); anticommutator {X,Y} = XY + YX.
+
+    B1 (octonion generation persists): the three octonion ladder ops (1,2),(3,4),(5,6), now 16x16, still
+       satisfy {A_i,A_j}=0 and {A_i,A_j†}=4*delta_ij*I_16.                             (b1_persists)
+    B2 (maximal fermionic rank 3 -> 4): greedy max mutually-fermionic single-pair ladder ops is 3 for the
+       octonion (indices 1..7) and 4 for the sedenion (indices 1..15).       (oct_rank_3 / sed_rank_4)
+
+  The doubling adds EXACTLY ONE fermionic mode — NOT a clean second generation (which needs 6).
+
+  All three native_decide sweeps (the 16x16 complex greedy over indices 1..15) build in ~10s, so this is
+  a @[default_target]. Companion to tests/run-pass/sedenion_ladder_extension.sio.
+-/
+namespace SounioSedenionLadderExtension
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def sedSigma (a b : Nat) : Int := cdSigma a b 4
+
+-- a 16x16 integer matrix is a flat List Int of length 256, row-major.
+abbrev Mat := List Int
+
+-- sign * L_a : L_a[a^j][j] = cd_sigma(a,j,4).
+def signedL (a : Nat) (sign : Int) : Mat :=
+  (List.range 256).map (fun idx =>
+    let i := idx / 16; let j := idx % 16
+    if i == (a ^^^ j) then sign * sedSigma a j else 0)
+
+-- complex ladder op alpha(a,b) = (-L_a, L_b) as a pair (Re, Im).
+def alphaRe (a : Nat) : Mat := signedL a (-1)
+def alphaIm (b : Nat) : Mat := signedL b 1
+
+def transp (A : Mat) : Mat :=
+  (List.range 256).map (fun idx => let i := idx / 16; let j := idx % 16; A.getD (j * 16 + i) 0)
+def negTransp (A : Mat) : Mat :=
+  (List.range 256).map (fun idx => let i := idx / 16; let j := idx % 16; - A.getD (j * 16 + i) 0)
+
+-- 16x16 integer matmul (flat).
+def mm (A B : Mat) : Mat :=
+  (List.range 256).map (fun idx =>
+    let i := idx / 16; let j := idx % 16
+    (List.range 16).foldl (fun s k => s + A.getD (i * 16 + k) 0 * B.getD (k * 16 + j) 0) 0)
+def madd (A B : Mat) : Mat := (List.range 256).map (fun idx => A.getD idx 0 + B.getD idx 0)
+def msub (A B : Mat) : Mat := (List.range 256).map (fun idx => A.getD idx 0 - B.getD idx 0)
+
+-- {X,Y} = XY + YX for complex X=(xr,xi), Y=(yr,yi); returns (Re, Im).
+--   re = xr yr - xi yi + yr xr - yi xi ;  im = xr yi + xi yr + yr xi + yi xr
+def acRe (xr xi yr yi : Mat) : Mat :=
+  msub (madd (mm xr yr) (mm yr xr)) (madd (mm xi yi) (mm yi xi))
+def acIm (xr xi yr yi : Mat) : Mat :=
+  madd (madd (mm xr yi) (mm xi yr)) (madd (mm yr xi) (mm yi xr))
+
+def isZero (M : Mat) : Bool := M.all (· == 0)
+def isScalar (M : Mat) (v : Int) : Bool :=
+  (List.range 256).all (fun idx => let i := idx / 16; let j := idx % 16;
+    M.getD idx 0 == (if i == j then v else 0))
+
+-- {alpha(a,b), alpha(c,d)} == 0 ?
+def pairAnticommZero (a b c d : Nat) : Bool :=
+  let xr := alphaRe a; let xi := alphaIm b; let yr := alphaRe c; let yi := alphaIm d
+  isZero (acRe xr xi yr yi) && isZero (acIm xr xi yr yi)
+
+-- {alpha(a,b), alpha(c,d)†} : adj(c,d) = (Re^T, -Im^T) with Re=-L_c, Im=L_d.
+-- returns 1 if 4*I, 0 if zero, 2 otherwise.
+def adjAnticommKind (a b c d : Nat) : Nat :=
+  let xr := alphaRe a; let xi := alphaIm b
+  let yr := transp (alphaRe c); let yi := negTransp (alphaIm d)
+  let re := acRe xr xi yr yi; let im := acIm xr xi yr yi
+  if !isZero im then 2
+  else if isScalar re 4 then 1
+  else if isZero re then 0
+  else 2
+
+def selfFermionic (a b : Nat) : Bool :=
+  adjAnticommKind a b a b == 1 && pairAnticommZero a b a b
+def crossFermionic (a b c d : Nat) : Bool :=
+  pairAnticommZero a b c d && adjAnticommKind a b c d == 0
+
+-- greedy over pairs (a<b) in 1..hi; store chosen pairs; count.
+def greedyRank (hi : Nat) : Nat := Id.run do
+  let mut chosen : List (Nat × Nat) := []
+  for a in List.range (hi + 1) do
+    if a ≥ 1 then
+      for b in List.range (hi + 1) do
+        if b > a then
+          if selfFermionic a b && chosen.all (fun p => crossFermionic a b p.1 p.2) then
+            chosen := chosen ++ [(a, b)]
+  return chosen.length
+
+-- B1: the three octonion ladder ops (1,2),(3,4),(5,6) still fermionic as 16x16 matrices.
+def b1Persists : Bool := Id.run do
+  let pa := [1, 3, 5]; let pb := [2, 4, 6]
+  for i in List.range 3 do
+    for j in List.range 3 do
+      let ai := pa.getD i 0; let bi := pb.getD i 0
+      let aj := pa.getD j 0; let bj := pb.getD j 0
+      if !pairAnticommZero ai bi aj bj then return false
+      let want := if i == j then 1 else 0
+      if adjAnticommKind ai bi aj bj != want then return false
+  return true
+
+theorem b1_persists : b1Persists = true := by native_decide
+theorem oct_rank_3 : greedyRank 7 = 3 := by native_decide
+theorem sed_rank_4 : greedyRank 15 = 4 := by native_decide
+
+end SounioSedenionLadderExtension

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -85,6 +85,12 @@ lean_lib «SounioSedenionDynamics» where
 -- default_target: 3 native_decide sweeps over GL(4,2)=65536 take ~1 min; `lake build SounioSedenionAutomorphism`.
 lean_lib «SounioSedenionAutomorphism» where
 
+-- Frente B vector 4/3 B: the sedenion extension of the Furey ladder — octonion SM generation persists
+-- (B1) and the doubling adds exactly one fermionic mode (greedy rank 3 -> 4). All three native_decide
+-- sweeps (16x16 complex greedy over 1..15) build in ~10s, so kept as a default_target.
+@[default_target]
+lean_lib «SounioSedenionLadderExtension» where
+
 -- Frente B vector 1: the 7 fibers = Fano plane PG(2,2), Aut = PGL(3,2). Corollary of the
 -- automorphism sweep; NON-default_target (~1 min): `lake build SounioSedenionFano`.
 lean_lib «SounioSedenionFano» where

--- a/scripts/ci/sedenion_ladder_extension_gate.sh
+++ b/scripts/ci/sedenion_ladder_extension_gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: the SEDENION EXTENSION of the Furey ladder (Frente B, vector 4/3 Part B) —
+# the octonion SM generation persists (B1) and the doubling adds exactly ONE more fermionic mode
+# (greedy rank 3 -> 4), NOT a clean second generation. souc vs Python oracle; /usr/bin/diff on the
+# value lines.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/s.elf" >/dev/null 2>&1; chmod +x "$WORK/s.elf"; "$WORK/s.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/sedenion_ladder_extension.sio | grep -E '^(B1_OK|OCT_RANK|SED_RANK|SEDEXT)' | sort > "$WORK/souc.txt"
+python3 scripts/research/sedenion_ladder_extension_oracle.py | grep -E '^(B1_OK|OCT_RANK|SED_RANK|SEDEXT)' | sort > "$WORK/py.txt"
+if diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null && grep -q '^SEDEXT OK' "$WORK/souc.txt"; then
+  echo "CROSS-VERIFIED: sedenion ladder extension — octonion SM generation persists (B1_OK=1),"
+  echo "  greedy max fermionic rank 3 (octonion) -> 4 (sedenion): the doubling adds exactly ONE mode,"
+  echo "  NOT a clean second generation. Particle-physics interpretation OPEN."
+  echo "sedenion ladder extension gate: PASS"
+else echo "sedenion ladder extension gate: FAIL"; diff "$WORK/souc.txt" "$WORK/py.txt"; exit 1; fi

--- a/scripts/research/sedenion_ladder_extension_oracle.py
+++ b/scripts/research/sedenion_ladder_extension_oracle.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Oracle: the SEDENION EXTENSION of the Furey ladder (Frente B, vector 4/3 Part B).
+
+Clean re-implementation of the Part B facts. Over the sedenion LEFT-multiplication matrices
+L_a (16x16, L_a[a^b][b] = cd_sigma(a,b,4)), a single-pair ladder op is the complex 16x16 matrix
+A = alpha(a,b) = (-L_a, L_b) (Re, Im) — this is Furey's A = 2*alpha, hence the factor 4. adjoint of
+(Re,Im) is (Re^T, -Im^T); anticommutator {X,Y} = XY + YX.
+
+  B1 (octonion generation persists): the three octonion ladder ops from the disjoint pairs
+     (1,2),(3,4),(5,6), now as 16x16 matrices, still satisfy {A_i,A_j}=0 and {A_i,A_j†}=4*delta_ij*I.
+  B2 (maximal fermionic rank is 4, not 6): the greedy maximal set of mutually-fermionic single-pair
+     ladder ops is 3 in the octonion (indices 1..7) and 4 in the sedenion (indices 1..15). The doubling
+     adds EXACTLY ONE more fermionic mode (rank 3->4) — NOT a clean second generation (which needs 6).
+  B3 (honest scope): the basis UNITS never multiply to zero; the sedenion zero divisors are 2-support
+     elements, so the ZD geometry lives at the STATE/spinor level, not the ladder-generator level.
+
+Output lines: B1_OK, OCT_RANK, SED_RANK, SEDEXT <OK|FAIL>.
+Cross-verified vs tests/run-pass/sedenion_ladder_extension.sio by scripts/ci/sedenion_ladder_extension_gate.sh.
+"""
+
+N = 16
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH = a >= half; bH = b >= half; aL = a & (half - 1); bL = b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def Lmat(a):
+    M = [[0] * N for _ in range(N)]
+    for b in range(N):
+        M[a ^ b][b] = cd_sigma(a, b, 4)
+    return M
+
+
+def mm(A, B):
+    return [[sum(A[i][k] * B[k][j] for k in range(N)) for j in range(N)] for i in range(N)]
+
+
+def madd(A, B):
+    return [[A[i][j] + B[i][j] for j in range(N)] for i in range(N)]
+
+
+def smul(s, A):
+    return [[s * A[i][j] for j in range(N)] for i in range(N)]
+
+
+def tpose(A):
+    return [[A[j][i] for j in range(N)] for i in range(N)]
+
+
+def alpha(a, b):
+    return (smul(-1, Lmat(a)), Lmat(b))  # A = (-L_a, L_b)
+
+
+def adj(X):
+    xr, xi = X
+    return (tpose(xr), smul(-1, tpose(xi)))
+
+
+def anticomm(X, Y):
+    (xr, xi), (yr, yi) = X, Y
+
+    def prod(P):
+        (ar, ai), (br, bi) = P
+        return (madd(mm(ar, br), smul(-1, mm(ai, bi))), madd(mm(ar, bi), mm(ai, br)))
+
+    pr = prod((X, Y)); pl = prod((Y, X))
+    return (madd(pr[0], pl[0]), madd(pr[1], pl[1]))
+
+
+def is_zero(M):
+    return all(M[i][j] == 0 for i in range(N) for j in range(N))
+
+
+def is_scalar(M, v):
+    return all(M[i][j] == (v if i == j else 0) for i in range(N) for j in range(N))
+
+
+def self_fermionic(a, b):
+    X = alpha(a, b)
+    s = anticomm(X, adj(X)); s2 = anticomm(X, X)
+    return is_scalar(s[0], 4) and is_zero(s[1]) and is_zero(s2[0]) and is_zero(s2[1])
+
+
+def cross_fermionic(a, b, c, d):
+    X = alpha(a, b); Y = alpha(c, d)
+    ac = anticomm(X, Y); acd = anticomm(X, adj(Y))
+    return is_zero(ac[0]) and is_zero(ac[1]) and is_zero(acd[0]) and is_zero(acd[1])
+
+
+def greedy_rank(hi):
+    chosen = []
+    for a in range(1, hi + 1):
+        for b in range(a + 1, hi + 1):
+            if not self_fermionic(a, b):
+                continue
+            if all(cross_fermionic(a, b, c, d) for (c, d) in chosen):
+                chosen.append((a, b))
+    return len(chosen)
+
+
+def b1_octonion_persists():
+    tri = [(1, 2), (3, 4), (5, 6)]
+    A = [alpha(a, b) for (a, b) in tri]
+    for i in range(3):
+        for j in range(3):
+            ac = anticomm(A[i], A[j])
+            if not (is_zero(ac[0]) and is_zero(ac[1])):
+                return 0
+            acd = anticomm(A[i], adj(A[j]))
+            want = 4 if i == j else 0
+            if not (is_scalar(acd[0], want) and is_zero(acd[1])):
+                return 0
+    return 1
+
+
+def main():
+    b1 = b1_octonion_persists()
+    oct_rank = greedy_rank(7)
+    sed_rank = greedy_rank(15)
+    print(f"B1_OK {b1}")
+    print(f"OCT_RANK {oct_rank}")
+    print(f"SED_RANK {sed_rank}")
+    ok = (b1 == 1 and oct_rank == 3 and sed_rank == 4)
+    print(f"SEDEXT {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_ladder_extension.sio
+++ b/tests/run-pass/sedenion_ladder_extension.sio
@@ -1,0 +1,301 @@
+//@ run-pass
+//@ expect-stdout: SEDEXT OK
+// FRENTE B, vector 4/3 Part B — the SEDENION EXTENSION of the Furey ladder, executed exactly.
+//
+// Part A (the octonion side) shows Sounio reproduces Furey's C x O -> one Standard Model generation:
+// over the octonion LEFT-multiplication matrices L_a (8x8, L_a[a^b][b] = cd_sigma(a,b,3)), the three
+// ladder ops from the disjoint pairs (1,2),(3,4),(5,6) — complex A = (-L_a, L_b), scaled A = 2*alpha —
+// satisfy the fermionic algebra {A_i,A_j} = 0 and {A_i,A_j†} = 4*delta_ij*I. Three modes -> one
+// generation (occupation n in 0..3, SU(3) color = the C(3,n) multiplicities).
+//
+// This brick asks what survives the octonion -> SEDENION DOUBLING (cd_sigma bits=4, 16x16 left-mult).
+// Everything below is EXACT integer arithmetic, cross-verified vs the Python oracle and Lean.
+//
+//   B1 (the octonion generation PERSISTS): the same three ladder ops (1,2),(3,4),(5,6), now as 16x16
+//      matrices, STILL satisfy {A_i,A_j} = 0 and {A_i,A_j†} = 4*delta_ij*I_16 for all i,j in {1,2,3}.
+//      => the Standard-Model generation survives intact inside the sedenion.  Emits B1_OK 1.
+//
+//   B2 (the maximal fermionic rank is 4, NOT 6): the greedy maximal set of mutually-fermionic single-
+//      pair ladder ops is exactly 3 in the octonion (indices 1..7) and 4 in the sedenion (indices
+//      1..15). So the doubling adds EXACTLY ONE more fermionic mode — it is NOT a clean second
+//      generation (which would need 6, i.e. rank 3->6). Emits OCT_RANK 3, SED_RANK 4.
+//
+//   B3 (honest scope): the basis UNITS never multiply to zero (a sedenion zero divisor is a 2-support
+//      element like e_i +- e_j), so the sedenion zero-divisor geometry (the 84/168/E8 boundary of the
+//      other bricks) lives at the STATE/spinor level, NOT at the ladder-generator level. (Documented in
+//      the companion .md; nothing to compute here.)
+//
+// Complex 16x16 as two flat [i64;256] arrays (Re, Im). adjoint(Re,Im) = (Re^T, -Im^T). anticommutator
+// {X,Y} = XY + YX. All matrices are exact integer signed structures; no float, no division in the
+// linear algebra. SELF-CONTAINED (cd_sigma copied verbatim, avoids the stdlib-import defect #637).
+// main() stays tiny (helpers own the 256-arrays) to sidestep the monolithic-main codegen SIGSEGV.
+// Cross-verified vs scripts/research/sedenion_ladder_extension_oracle.py by
+// scripts/ci/sedenion_ladder_extension_gate.sh and by formal/lean4/SounioSedenionLadderExtension.lean.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+
+fn sed_sigma(a: i64, b: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, b, 4) }
+
+// zero a 16x16 flat matrix.
+fn zero256(M: &![i64; 256]) with Mut, Panic, Div {
+    var i = 0
+    while i < 256 {
+        M[i as usize] = 0
+        i = i + 1
+    }
+}
+
+// M = sign * L_a  (left-multiplication by e_a, 16x16): L_a[a^j][j] = cd_sigma(a,j,4).
+fn build_signed_L(a: i64, sign: i64, M: &![i64; 256]) with Mut, Panic, Div {
+    zero256(M)
+    var j = 0
+    while j < 16 {
+        let row = a ^ j
+        M[(row * 16 + j) as usize] = sign * sed_sigma(a, j)
+        j = j + 1
+    }
+}
+
+// alpha(a,b) = A = (-L_a, L_b): re = -L_a, im = L_b.  (This is Furey's A = 2*alpha, hence the factor 4.)
+fn build_alpha(a: i64, b: i64, re: &![i64; 256], im: &![i64; 256]) with Mut, Panic, Div {
+    build_signed_L(a, 0 - 1, re)
+    build_signed_L(b, 1, im)
+}
+
+// T = A^T
+fn transpose(A: &[i64; 256], T: &![i64; 256]) with Mut, Panic, Div {
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            T[(j * 16 + i) as usize] = A[(i * 16 + j) as usize]
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+// T = -A^T
+fn transpose_neg(A: &[i64; 256], T: &![i64; 256]) with Mut, Panic, Div {
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            T[(j * 16 + i) as usize] = 0 - A[(i * 16 + j) as usize]
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+// adjoint of alpha(a,b) = (Re^T, -Im^T) with Re=-L_a, Im=L_b.
+fn build_adj(a: i64, b: i64, are: &![i64; 256], aim: &![i64; 256]) with Mut, Panic, Div {
+    var tr = [0; 256]
+    var ti = [0; 256]
+    build_alpha(a, b, &!tr, &!ti)
+    transpose(&tr, are)
+    transpose_neg(&ti, aim)
+}
+
+// C += sgn * (A * B)  (16x16 integer matmul, accumulated).
+fn acc_mm(A: &[i64; 256], B: &[i64; 256], sgn: i64, C: &![i64; 256]) with Mut, Panic, Div {
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            var s = 0
+            var k = 0
+            while k < 16 {
+                s = s + A[(i * 16 + k) as usize] * B[(k * 16 + j) as usize]
+                k = k + 1
+            }
+            C[(i * 16 + j) as usize] = C[(i * 16 + j) as usize] + sgn * s
+            j = j + 1
+        }
+        i = i + 1
+    }
+}
+
+// {X,Y} = XY + YX for complex X=(xr,xi), Y=(yr,yi); result (ore,oim).
+//   re = xr*yr - xi*yi + yr*xr - yi*xi ;  im = xr*yi + xi*yr + yr*xi + yi*xr
+fn anticomm(xr: &[i64; 256], xi: &[i64; 256], yr: &[i64; 256], yi: &[i64; 256],
+            ore: &![i64; 256], oim: &![i64; 256]) with Mut, Panic, Div {
+    zero256(ore)
+    zero256(oim)
+    acc_mm(xr, yr, 1, ore)
+    acc_mm(xi, yi, 0 - 1, ore)
+    acc_mm(yr, xr, 1, ore)
+    acc_mm(yi, xi, 0 - 1, ore)
+    acc_mm(xr, yi, 1, oim)
+    acc_mm(xi, yr, 1, oim)
+    acc_mm(yr, xi, 1, oim)
+    acc_mm(yi, xr, 1, oim)
+}
+
+fn is_zero(M: &[i64; 256]) -> bool with Mut, Panic, Div {
+    var i = 0
+    while i < 256 {
+        if M[i as usize] != 0 { return false }
+        i = i + 1
+    }
+    true
+}
+
+// M == v * I_16 ?
+fn is_scalar(M: &[i64; 256], v: i64) -> bool with Mut, Panic, Div {
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            let want = if i == j { v } else { 0 }
+            if M[(i * 16 + j) as usize] != want { return false }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    true
+}
+
+// {alpha(a,b), alpha(c,d)} == 0 (both parts) ?
+fn anticomm_pair_zero(a: i64, b: i64, c: i64, d: i64) -> bool with Mut, Panic, Div {
+    var xr = [0; 256]
+    var xi = [0; 256]
+    var yr = [0; 256]
+    var yi = [0; 256]
+    build_alpha(a, b, &!xr, &!xi)
+    build_alpha(c, d, &!yr, &!yi)
+    var ore = [0; 256]
+    var oim = [0; 256]
+    anticomm(&xr, &xi, &yr, &yi, &!ore, &!oim)
+    is_zero(&ore) && is_zero(&oim)
+}
+
+// {alpha(a,b), alpha(c,d)†} : returns 1 if == 4*I, 0 if == 0, -1 otherwise.
+fn anticomm_adj_kind(a: i64, b: i64, c: i64, d: i64) -> i64 with Mut, Panic, Div {
+    var xr = [0; 256]
+    var xi = [0; 256]
+    var yr = [0; 256]
+    var yi = [0; 256]
+    build_alpha(a, b, &!xr, &!xi)
+    build_adj(c, d, &!yr, &!yi)
+    var ore = [0; 256]
+    var oim = [0; 256]
+    anticomm(&xr, &xi, &yr, &yi, &!ore, &!oim)
+    if !is_zero(&oim) { return 0 - 1 }
+    if is_scalar(&ore, 4) { return 1 }
+    if is_zero(&ore) { return 0 }
+    0 - 1
+}
+
+// self-fermionic: {X,X†} = 4*I  and  {X,X} = 0.
+fn self_fermionic(a: i64, b: i64) -> bool with Mut, Panic, Div {
+    if anticomm_adj_kind(a, b, a, b) != 1 { return false }
+    if !anticomm_pair_zero(a, b, a, b) { return false }
+    true
+}
+
+// distinct-mode compatible with Y=alpha(c,d): {X,Y} = 0  and  {X,Y†} = 0.
+fn cross_fermionic(a: i64, b: i64, c: i64, d: i64) -> bool with Mut, Panic, Div {
+    if !anticomm_pair_zero(a, b, c, d) { return false }
+    if anticomm_adj_kind(a, b, c, d) != 0 { return false }
+    true
+}
+
+// candidate alpha(a,b) admissible given the already-chosen pairs?
+fn candidate_ok(a: i64, b: i64, ca: &[i64; 16], cb: &[i64; 16], nc: i64) -> bool with Mut, Panic, Div {
+    if !self_fermionic(a, b) { return false }
+    var t = 0
+    while t < nc {
+        if !cross_fermionic(a, b, ca[t as usize], cb[t as usize]) { return false }
+        t = t + 1
+    }
+    true
+}
+
+// greedy maximal mutually-fermionic single-pair ladder ops over pairs (a<b) in 1..hi.
+fn greedy_rank(hi: i64) -> i64 with Mut, Panic, Div {
+    var ca = [0; 16]
+    var cb = [0; 16]
+    var nc = 0
+    var a = 1
+    while a <= hi {
+        var b = a + 1
+        while b <= hi {
+            if nc < 16 {
+                if candidate_ok(a, b, &ca, &cb, nc) {
+                    ca[nc as usize] = a
+                    cb[nc as usize] = b
+                    nc = nc + 1
+                }
+            }
+            b = b + 1
+        }
+        a = a + 1
+    }
+    nc
+}
+
+// B1: the three octonion ladder ops (1,2),(3,4),(5,6) still fermionic as 16x16 matrices.
+fn b1_octonion_persists() -> i64 with Mut, Panic, Div {
+    var pa = [1, 3, 5]
+    var pb = [2, 4, 6]
+    var i = 0
+    while i < 3 {
+        var j = 0
+        while j < 3 {
+            let ai = pa[i as usize]
+            let bi = pb[i as usize]
+            let aj = pa[j as usize]
+            let bj = pb[j as usize]
+            // {A_i, A_j} = 0 for all i,j
+            if !anticomm_pair_zero(ai, bi, aj, bj) { return 0 }
+            // {A_i, A_j†} = 4*delta_ij*I
+            let k = anticomm_adj_kind(ai, bi, aj, bj)
+            let want = if i == j { 1 } else { 0 }
+            if k != want { return 0 }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    1
+}
+
+fn main() with IO, Mut, Panic, Div {
+    let b1 = b1_octonion_persists()
+    let oct_rank = greedy_rank(7)
+    let sed_rank = greedy_rank(15)
+
+    // one value per record (single print_int + explicit newline) — portable across souc builds.
+    print("B1_OK ")
+    print_int(b1)
+    print("\n")
+    print("OCT_RANK ")
+    print_int(oct_rank)
+    print("\n")
+    print("SED_RANK ")
+    print_int(sed_rank)
+    print("\n")
+    // single load-bearing verdict: the octonion SM generation persists (B1), and the sedenion doubling
+    // adds exactly ONE fermionic mode (rank 3 -> 4), NOT a clean second generation (which needs 6).
+    if b1 == 1 && oct_rank == 3 && sed_rank == 4 {
+        println("SEDEXT OK")
+    } else {
+        println("SEDEXT FAIL")
+    }
+}


### PR DESCRIPTION
## Frente B, vector 4/3 Part B — the sedenion extension of the Furey ladder (novelty end, executed exactly)

Sibling of Part A (the octonion → one Standard-Model generation brick, #separate PR). This applies the exact same Furey ladder construction to the **sedenion** 16×16 left-multiplication matrices `L_a` (`cd_sigma` at `bits=4`), complex ladder op `A = α(a,b) = (−L_a, L_b)`, adjoint `(Reᵀ, −Imᵀ)`, anticommutator `{X,Y}=XY+YX`. All exact integer arithmetic.

### Verified facts (all three legs agree)

- **B1 — the octonion generation persists.** The three octonion ladder ops `(1,2),(3,4),(5,6)`, now as 16×16 matrices, still satisfy `{A_i,A_j}=0` and `{A_i,A_j†}=4·δ_ij·I₁₆`. The Standard-Model generation survives intact inside the sedenion. → `B1_OK 1`
- **B2 — maximal fermionic rank 3 → 4, not 6.** The greedy maximal set of mutually-fermionic single-pair ladder ops is exactly **3** (octonion, indices 1..7) and **4** (sedenion, indices 1..15). The doubling adds **exactly one** more fermionic mode — **NOT** a clean second generation (which would need 6). → `OCT_RANK 3`, `SED_RANK 4`
- **B3 — honest scope.** The basis units never multiply to zero; sedenion zero divisors are 2-support elements, so the ZD geometry (the 84/168/E8-boundary of the sibling bricks) lives at the **state/spinor** level, not the ladder-generator level.

The particle-physics **interpretation is explicitly flagged OPEN** — the doc leads with the honest framing (persistence + one extra mode, not two generations) and marks the physical reading speculative.

### Certification — three independent legs, over ℤ

- **souc**: `tests/run-pass/sedenion_ladder_extension.sio` → `SEDEXT OK`, **identical under both `bin/souc` and the fresh stage2 compiler** (self-contained; `main` kept tiny to avoid the monolithic-main SIGSEGV).
- **Python oracle**: `scripts/research/sedenion_ladder_extension_oracle.py`, gated by `scripts/ci/sedenion_ladder_extension_gate.sh` (registered in `ci.yml` after the zd168 step).
- **Lean `native_decide`**: `formal/lean4/SounioSedenionLadderExtension.lean` — `b1_persists`, `oct_rank_3`, `sed_rank_4` (Mathlib-free, no `sorry`; the 16×16 complex greedy checks in ~10s, kept `@[default_target]`). All three facts including `SED_RANK=4` are pinned by the Lean kernel.

Doc: `docs/research/sedenion_ladder_extension.md` (governance synced; registry + consistency checks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)