### PR TITLE
feat(lower): string content equality — route == / != on strings to str_eq

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -8503,6 +8503,30 @@ impl Lowerer {
                 return (lo_call, dst)
             }
         }
+        // String equality: `s == t` / `s != t` route to the str_eq builtin (content
+        // compare), instead of an integer compare of the string pointers (which is
+        // always false for distinct literals). `!=` negates via `(str_eq == 0)`.
+        if e.bin_op == BinaryOp::OpEq || e.bin_op == BinaryOp::OpNe {
+            if lo3.opt_expr_result_is_string_ref(&e.left) || lo3.opt_expr_result_is_string_ref(&e.right) {
+                var lo_se = lo3
+                let se_fn = lowerer_find_or_add_fn_id_mut(&! lo_se, make_name("str_eq"))
+                let se_args: Option<Box<IrRegList>> = Some(Box::new(ir_reg_list_cons(lhs, Some(Box::new(ir_reg_list_single(rhs))))))
+                if e.bin_op == BinaryOp::OpEq {
+                    let lo_call = lo_se.emit(ir_call(dst, se_fn, make_name("str_eq"), se_args, 2))
+                    return (lo_call, dst)
+                }
+                let eqp = lo_se.fresh_reg()
+                var lo_e = eqp.0
+                let eq_reg = eqp.1
+                lo_e = lo_e.emit(ir_call(eq_reg, se_fn, make_name("str_eq"), se_args, 2))
+                let zp = lo_e.fresh_reg()
+                var lo_z = zp.0
+                let zero_reg = zp.1
+                lo_z = lo_z.emit(ir_load_imm(zero_reg, 0))
+                let lo_ne = lo_z.emit(ir_binop(dst, eq_reg, BinaryOp::OpEq, zero_reg))
+                return (lo_ne, dst)
+            }
+        }
         if lhs_expr_is_float {
             lo3 = lo3.emit(ir_mark_float_reg(lhs))
         }


### PR DESCRIPTION
## Bug

`==` / `!=` on **string** operands lowered to an integer compare of the string *pointers*. So even `"ok" == "ok"` evaluated to `false` (distinct literals → distinct pointers), and every string comparison silently failed.

## Fix

Mirror the existing string-concat lowering (`s + t` → `str_concat`): in `lower_binary_expr_ref`, when either operand of `==`/`!=` is a string, emit a call to the `str_eq` builtin (content compare) instead of a pointer compare. `!=` negates the result via `(str_eq == 0)`.

The `str_eq` builtin already exists and is used throughout the compiler; this just wires the `==`/`!=` operators to it for string operands, exactly as `+` is already wired to `str_concat`.

## Verification

- `"ok" == "ok"` (literal), `let a = "ok"; a == "ok"` (var), `if c { "ok" } else {..} == "ok"` (if-expr), and dynamic `("o" + "k") == "ok"` — all now compare by **content**.
- `!=` returns the correct negation for both equal and distinct strings.
- **Byte-identity sweep** over 128 run-pass programs: **126 identical, 2 changed** are pre-existing segfault-both-ways programs (byte-diff only, no behavior change). **Zero regressions.**

Found while getting the EISA epistemic-ISA test suite to run — its gate-name checks (`egate_names(c) != "..."`) depend on string content comparison. This clears all 4 of those checks.