### PR TITLE
docs(erratum): correct Aut(S) identification + ZD/associator scope note (firewall)

### DIFF
--- a/docs/papers/sedenion-fano-geometry.md
+++ b/docs/papers/sedenion-fano-geometry.md
@@ -28,11 +28,13 @@ element, the octonion→sedenion doubling unit **e₈**:
 - On the **associator side**, the ordered non-associative sedenion basis triples number
   `1848 = 11 × 168`, and by output grade the doubling grade 8 carries one octonion `168` while the
   other 14 grades carry `10 × 168` — so `11 = 10 + 1`.
-- **The unifying theorem**: the `168` is a genuine group — the sedenion signed-automorphism group
-  `Aut(𝕊) ≅ PSL(2,7)`, order 168, sitting in `GL(4,2) ≅ A₈` at index 120 — and it **fixes e₈**. The 7
-  fibers **are the 7 points of the Fano plane `PG(2,2)`**, and `Aut(𝕊)` acts on them as the full Fano
-  collineation group `PGL(3,2)`. So the zero-divisor geometry *is* the Fano plane, decorated by the
-  doubling, with e₈ its unique fixed point.
+- **The unifying theorem**: the `168` is a genuine group — the sedenion **signed-permutation (monomial)
+  automorphism subgroup that fixes e₈**, `≅ PSL(2,7)`, order 168, index 120 in `GL(4,2) ≅ A₈`. It is a
+  finite subgroup of the full `Aut(𝕊) ≅ G₂ × S₃` (Brown's theorem), *not* the full group (**Erratum E1**).
+  The 7 fibers **are the 7 points of the Fano plane `PG(2,2)`**, and this group acts on them as the full
+  Fano collineation group `PGL(3,2)`. So the zero-divisor geometry *is* the Fano plane, decorated by the
+  doubling, with e₈ its unique fixed point. (The fermion-generation structure lives in the *disjoint* `S₃`
+  triality factor, not here — Erratum E1/E2.)
 
 ## 1. Setup
 
@@ -92,12 +94,15 @@ elimination):
 - sedenions `{1..15}`: **168** — of `|GL(4,2)| = 20160 = |A₈|`, at index 120 — the **same** 168;
 - every sedenion automorphism **fixes e₈** (orbit `{8}`); the orbit partition is `{1..7} ∪ {8} ∪ {9..15}`.
 
-Hence the pervasive `168 = |PSL(2,7)|` is the group `Aut(𝕊)`, and because it fixes `e₈` it acts on the
-fiber labels `L = 8 ⊕ t` by `t ↦ M(t)` on `t = L∧7 ∈ F₂³∖{0}`. The seven nonzero vectors of `F₂³` are
-the seven points of the Fano plane `PG(2,2)`; the action is faithful, transitive, and permutes the
-seven Fano lines `{a,b,a⊕b}`. **So the 7 fibers are the 7 Fano points, and `Aut(𝕊)` is the full Fano
-collineation group `PGL(3,2)`.** The number `1848 = 11 × 168` is *not* a group order: `168` is the
-group, `11` is the combinatorial grade factor of §4.
+Hence the pervasive `168 = |PSL(2,7)|` is the **finite signed-permutation (monomial) automorphism
+group that fixes `e₈`** — a finite subgroup of the full `Aut(𝕊)`, **not** the full group (see
+**Erratum E1**; `Aut(𝕊) ≅ G₂ × S₃` by Brown's theorem, and the monomial-168 sits inside the `G₂`
+factor). Because it fixes `e₈` it acts on the fiber labels `L = 8 ⊕ t` by `t ↦ M(t)` on
+`t = L∧7 ∈ F₂³∖{0}`. The seven nonzero vectors of `F₂³` are the seven points of the Fano plane
+`PG(2,2)`; the action is faithful, transitive, and permutes the seven Fano lines `{a,b,a⊕b}`. **So the
+7 fibers are the 7 Fano points, and this monomial-168 acts on them as the full Fano collineation group
+`PGL(3,2)`.** The number `1848 = 11 × 168` is *not* a group order: `168` is the group, `11` is the
+combinatorial grade factor of §4.
 *(`sedenion_automorphism_168.sio`, `docs/research/sedenion_automorphism_168.md`;
 `SounioSedenionFano.lean`, `docs/research/sedenion_fano_fibers.md`.)*
 
@@ -141,4 +146,101 @@ python3 scripts/research/sedenion_associator_1848_oracle.py
 - Per-result notes: `docs/research/sedenion_{e8_boundary, zd_fibers, zd_fiber_identity, zd_quartets,
   quartet_fiber_incidence, associator_1848, automorphism_168, fano_fibers}.md`.
 - Formal layer: `formal/lean4/SounioZeroDivisorBridge.lean`, `SounioCayleyDickson.lean`, and the
-  `SounioSedenion{E8Fibers, FiberIdentity, Quartets, Incidence, Associator1848, Automorphism, Fano}.lean`.
+  `SounioSedenion{E8Fibers, FiberIdentity, Quartets, Incidence, Associator1848, Automorphism, Fano,
+  Clifford8}.lean`.
+
+---
+
+# Erratum and Scope Note (2026-07-07)
+
+**Subject.** Correction of the automorphism-group identification introduced in PR #680, and an
+accompanying scope note delimiting the physical status of the zero-divisor (ZD) census and the
+associator count. Both items are firewall corrections: they narrow claims to what is exactly certified
+and reassign the group-theoretic locus of the generation structure. An independent computational leg is
+appended.
+
+## E1 — Correction of the automorphism-group identification (§5, PR #680)
+
+**As originally stated.** "168 = |PSL(2,7)| is the group Aut(𝕊)."
+
+**Corrected statement.** The signed-permutation (monomial) automorphisms of 𝕊 that fix the doubling
+unit e₈ form a group of order 168, isomorphic to PSL(2,7) ≅ PGL(3,2), acting faithfully and
+transitively on the seven fibres as the Fano collineation group. This group is a **finite subgroup of
+the full automorphism group, and not the full group itself.** By Brown's theorem the automorphism group
+of the sedenions is
+
+  Aut(𝕊) ≅ Aut(𝕆) × S₃ = G₂ × S₃,                                                        (1)
+
+where G₂ = Aut(𝕆) is a 14-dimensional continuous group and the S₃ factor is the triality, absent from
+Aut(𝕆), arising from the triality automorphism of Spin(8) [1–3]. The order-168 group identified in
+PR #680 is the **finite Fano-collineation subgroup of the G₂ factor**; the S₃ (triality) factor is
+disjoint from it.
+
+**Derivation of the null result (why "ZD-168 → generations" must fail).** Because Aut(𝕊) is a *direct*
+product (1), the order-168 monomial subgroup lies wholly within the G₂ (octonion-automorphism) factor,
+whereas the fermion-family structure is carried by the *disjoint* S₃ factor [3,4]. The generation
+symmetry therefore cannot be realised as a signed permutation of basis units. This is corroborated
+independently below (E3): the sedenions admit **exactly one** basis-aligned octonion subalgebra, so the
+three mutually intersecting octonion subalgebras used to build three generations [4] are necessarily the
+non-monomial (rotational, triality) images of the base octonion — precisely the maps invisible to a
+monomial-automorphism census. Consequently the numerical coincidence between the ZD-168 count and
+|PSL(2,7)| reflects a G₂-side Fano combinatorics, not a family-symmetry structure.
+
+## E2 — Scope note on the ZD census and the associator count (Vector 4/3, Part B)
+
+The zero-divisor census (84 → 336 → 168) and the associator count 1848 = 11 × 168 are exact,
+cross-verified algebraic invariants of the multiplicative and associator geometry of 𝕊. They are
+**not** asserted — in this work or in the peer-reviewed literature — to correspond to fermion
+generations or to gauge structure. The generation structure of the complex sedenions arises, per [3,4],
+from the S₃ (triality) factor of (1) and from the enlargement of the left-multiplication algebra
+ℂℓ(6) ↪ ℂℓ(8) (the complexified left-multiplication algebras of, respectively, ℂ⊗𝕆 and ℂ⊗𝕊; executed
+and certified in `sedenion_clifford8.md`). That locus is group-theoretically disjoint from the
+monomial-168 subgroup which the 168/1848 counts inhabit. Any physical interpretation of the
+ZD/associator geometry therefore **remains open** and is flagged as such; the geometry is reported as an
+algebraically real, physically uninterpreted invariant.
+
+## E3 — Supporting computation (independent fourth leg)
+
+An independent reconstruction (NumPy, Cayley–Dickson from first principles; no reuse of `souc`)
+certifies to machine precision (deviation 0.0 on each Clifford and Witt relation), and is reproduced
+in the Sounio/oracle/Lean legs of `sedenion_clifford8.{sio,md}`:
+
+1. **Clifford identification.** dim⟨L_{e₁},…,L_{e₁₅}⟩_assoc = 256 = M₁₆(ℝ), hence the complexified
+   left-multiplication algebra of 𝕊 equals ℂℓ(8,ℂ) ≅ ℂ(16); the octonionic analogue is ℂℓ(6) ≅ ℂ(8).
+2. **Isotropic rank.** Maximal mutually-fermionic ladder rank is 4 (vs 3 for 𝕆) — the maximal isotropic
+   dimension of ℂℓ(8); two independent generations would require rank 6 (ℂℓ(12)). This corroborates the
+   ℂℓ(6) → ℂℓ(8) enlargement of [3,4].
+3. **Non-alternativity fingerprint.** Of the C(15,2)=105 imaginary-unit pairs, 63 anticommute and 42 do
+   not; **all 42 are of lower × upper (doubling-seam) type**, so the octonionic core {e₁,…,e₇} remains
+   Clifford-pure and the failure of {L_i,L_j}=−2δ_ij is confined to the 𝕊 = 𝕆 ⊕ 𝕆ℓ seam.
+4. **Subalgebra census.** Exactly **one** basis-aligned octonion subalgebra exists ({e₁,…,e₇}); of the
+   three F₂-subspaces sharing the quaternion ⟨e₁,e₂,e₃⟩, one is octonionic and two are non-alternative (6
+   and 12 non-anticommuting pairs). Hence the three intersecting octonion subalgebras of [4] are
+   non-monomial.
+5. **Charge operator.** Q₁ = ⅓(N₁+N₂+N₃−3N₄) on the 2⁴ Fock space reproduces one generation's
+   electric-charge spectrum {0,±⅓,±⅔,±1} with colour multiplicities (𝟏,𝟑,𝟑̄,𝟏), and commutes with the
+   colour Weyl-S₃ (deviation 0.0). Invariance under the *generation* triality-S₃ requires the explicit
+   rotated octonion copies and a generalised charge action, and **remains open**; in the order-3
+   realisation of [4] the family symmetry reproduces colour states but not electrocolour states, the full
+   electroweak assignment appearing only in the subsequent construction [5].
+
+## References (Vancouver)
+
+1. Brown RB. On generalized Cayley–Dickson algebras. Pac J Math. 1967;20(3):415–22.
+2. Baez JC. The octonions. Bull Amer Math Soc. 2002;39(2):145–205.
+3. Gresnigt NG. Three generations of coloured fermions with S₃ family symmetry from Cayley–Dickson
+   sedenions. Eur Phys J C. 2023;83:747. arXiv:2306.13098.
+4. Gourlay AS, Gresnigt NG. Three fermion generations and the electroweak sector from the complex
+   sedenions with S₃ family symmetry. Eur Phys J C. 2024;84:1129. doi:10.1140/epjc/s10052-024-13476-0.
+   arXiv:2407.01580. [author/title to be confirmed against the DOI — see note.]
+5. Gresnigt NG. Electroweak structure and three fermion generations in Clifford algebra with S₃ family
+   symmetry. arXiv:2601.07857 (2026).
+6. Furey C. Generations: three prints, in colour. J High Energy Phys. 2014;2014(10):46. arXiv:1405.4601.
+7. Furey C. Standard model physics from an algebra? PhD thesis, University of Cambridge; 2016.
+   arXiv:1611.09182.
+
+*Citation-verification note.* References 1–3, 5–7 are confirmed against primary or archival sources;
+reference 4 is reconciled to the DOI 10.1140/epjc/s10052-024-13476-0 recorded in the deep-research log,
+but its exact author list and title should be confirmed (it may be the published version of
+arXiv:2601.07857 or a distinct paper). Run the standard `protocolo-revisao-agourakis` citation pass
+before deposit.

--- a/docs/research/sedenion_automorphism_168.md
+++ b/docs/research/sedenion_automorphism_168.md
@@ -13,13 +13,23 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.seden
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
 <!-- docs:status-note:end -->
 
-# The 168 IS a group: the sedenion signed-automorphism group ≅ PSL(2,7), fixing e₈ (executed)
+# The 168 IS a group: the sedenion monomial-automorphism subgroup ≅ PSL(2,7), fixing e₈ (executed)
+
+> **Correction (2026-07-07, Erratum E1 of `docs/papers/sedenion-fano-geometry.md`).** This document
+> originally called the order-168 group "`Aut(𝕊)`". That is imprecise: 168 is the **signed-permutation
+> (monomial) automorphism subgroup** that fixes e₈ — a *finite subgroup* of the full automorphism group,
+> which by Brown's theorem is `Aut(𝕊) ≅ Aut(𝕆) × S₃ = G₂ × S₃` (a 14-dim continuous `G₂` times the
+> triality `S₃`). The monomial-168 sits inside the `G₂` factor; the fermion-generation structure lives in
+> the *disjoint* `S₃` (triality) factor, so it cannot be realised as a signed permutation of basis units.
+> Read every "`Aut(𝕊)`" below as "the monomial-automorphism subgroup". The executed facts (order 168,
+> `≅ PSL(2,7)`, fixes e₈, Fano collineations) are unchanged and correct.
 
 **One line.** The `168 = |PSL(2,7)|` that pervades the sedenion geometry (the ZD census, the non-Fano
 count, the 7 fibers, the 42 quartets, the `1848 = 11·168` associator side) **is a genuine group**: the
-sedenion **signed-automorphism group** `Aut(𝕊)`, of order **168**, sitting inside `GL(4,2) ≅ A₈` (order
-20160) at index 120. And it **fixes e₈** — the octonion→sedenion doubling seam is the *unique fixed
-point* of the whole symmetry group. Consequently **`1848 = 11·168` is NOT a group order**: the 168 is a
+sedenion **signed-permutation (monomial) automorphism subgroup** (fixing e₈), of order **168**, sitting
+inside `GL(4,2) ≅ A₈` (order 20160) at index 120 — a finite subgroup of `Aut(𝕊) ≅ G₂ × S₃`, not the full
+group (see the Correction above). And it **fixes e₈** — the octonion→sedenion doubling seam is the
+*unique fixed point* of this group. Consequently **`1848 = 11·168` is NOT a group order**: the 168 is a
 group, but the 11 is combinatorial (the e₈-grade factor), not a group index.
 
 ## Definition


### PR DESCRIPTION
Firewall correction to Paper 2 (`sedenion-fano-geometry.md`) + the automorphism note (#680): the order-168 group is the **monomial-automorphism subgroup** fixing e8 (Fano collineations, inside G2), NOT the full `Aut(S)=G2 x S3` (Brown's thm). Generation structure lives in the disjoint S3/triality factor + the Cl(6)->Cl(8) enlargement — so 'ZD-168 -> generations' must fail (derived, E1). E2: ZD-census/1848 are exact invariants, physically uninterpreted (open). E3: independent numpy leg. Refs updated. Docs only.