### PR TITLE
Capture imported f64 return blocker

### DIFF
--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_backend_pack_unpack_probe.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_backend_pack_unpack_probe.v1.json
@@ -29,7 +29,7 @@
     "does_not_claim_imported_compiler_lowering",
     "does_not_claim_cuda_device_runtime_execution"
   ],
-  "generated_at_utc": "2026-07-07T15:14:32Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "harness": "self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
   "lean_extract_fallback": {
     "artifacts": {
@@ -40,10 +40,10 @@
         "sha256": "b6c7c688a67876c181fecad7e4516ae2a970480dbb5e958a8aed38b43e7d5afb"
       },
       "log": {
-        "bytes": 343,
+        "bytes": 355,
         "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/lean_extract.log",
         "present": true,
-        "sha256": "358c5f55e8908e7aa5172d207c50530a1be241cd984d4bda8cf6c5da01ac6a4f"
+        "sha256": "85eac450e73e61cb0c563809acb62fcfe6da1fb4200e472a27d37c6d71bb10c7"
       },
       "ptx": {
         "bytes": 788,
@@ -55,7 +55,7 @@
         "bytes": 1375,
         "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw",
         "present": true,
-        "sha256": "b4f4bc71b74e218c3c0699475b7fee68f1db2b5e1fcaa3c92b054acf41f2918a"
+        "sha256": "87d7b5e82c7b61bd3fa741e22501e7234acc3100765409e27ef39f413a4aa539"
       }
     },
     "boundaries": [
@@ -88,7 +88,7 @@
     "run_command": "./bin/souc run self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
     "run_exit_code": 139,
     "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/souc_run.log",
-    "run_log_tail": "/tmp/sounio-pr691-merge/bin/madaros: line 308: 4065815 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
+    "run_log_tail": "/tmp/sounio-vecmat-imported-runtime/bin/madaros: line 308: 4152401 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
   },
   "status": "blocked"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw
@@ -44,6 +44,6 @@ lower_array: final_fn_count 166
 imported_compile: lower_done
 Merged IR: 166
  functions
-Written to /tmp/madaros-run.vVyvCd/main.elf
+Written to /tmp/madaros-run.Scu95x/main.elf
 Compilation successful!
-   Output: /tmp/madaros-run.vVyvCd/main.elf
+   Output: /tmp/madaros-run.Scu95x/main.elf

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_completion_audit.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_completion_audit.v1.json
@@ -55,7 +55,7 @@
     "imported_runtime_fixture"
   ],
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T15:14:33Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "goal_status": "not_complete",
   "schema": "sounio.gpu-knowledge-vecmat-completion-audit.v1"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_evidence_audit.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_evidence_audit.v1.json
@@ -30,7 +30,7 @@
       "does_not_claim_imported_compiler_lowering",
       "does_not_claim_cuda_device_runtime_execution"
     ],
-    "generated_at_utc": "2026-07-07T15:14:32Z",
+    "generated_at_utc": "2026-07-07T16:30:48Z",
     "harness": "self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
     "lean_extract_fallback": {
       "artifacts": {
@@ -41,10 +41,10 @@
           "sha256": "b6c7c688a67876c181fecad7e4516ae2a970480dbb5e958a8aed38b43e7d5afb"
         },
         "log": {
-          "bytes": 343,
+          "bytes": 355,
           "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/lean_extract.log",
           "present": true,
-          "sha256": "358c5f55e8908e7aa5172d207c50530a1be241cd984d4bda8cf6c5da01ac6a4f"
+          "sha256": "85eac450e73e61cb0c563809acb62fcfe6da1fb4200e472a27d37c6d71bb10c7"
         },
         "ptx": {
           "bytes": 788,
@@ -56,7 +56,7 @@
           "bytes": 1375,
           "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw",
           "present": true,
-          "sha256": "b4f4bc71b74e218c3c0699475b7fee68f1db2b5e1fcaa3c92b054acf41f2918a"
+          "sha256": "87d7b5e82c7b61bd3fa741e22501e7234acc3100765409e27ef39f413a4aa539"
         }
       },
       "boundaries": [
@@ -89,7 +89,7 @@
       "run_command": "./bin/souc run self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
       "run_exit_code": 139,
       "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/souc_run.log",
-      "run_log_tail": "/tmp/sounio-pr691-merge/bin/madaros: line 308: 4065815 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
+      "run_log_tail": "/tmp/sounio-vecmat-imported-runtime/bin/madaros: line 308: 4152401 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
     },
     "status": "blocked"
   },
@@ -103,7 +103,7 @@
     "imported_runtime_fixture"
   ],
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T15:14:33Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "model_routing_summary": {
     "current-codex": [
       "integration edits",
@@ -145,7 +145,7 @@
       "does_not_claim_automatic_backend_pack_unpack",
       "does_not_claim_imported_runtime_fixture"
     ],
-    "generated_at_utc": "2026-07-07T15:14:20Z",
+    "generated_at_utc": "2026-07-07T16:30:35Z",
     "ptxas": {
       "output": "",
       "path": "/workspace/.home/openvscode-server/.agents/claude-2/.local/lib/python3.12/site-packages/torch/bin/ptxas",

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_open_blockers.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_open_blockers.v1.json
@@ -21,7 +21,7 @@
       "Repro": "scripts/dev/gpu_knowledge_vec4_dgx_runtime_runbook.sh run-dgx",
       "Severity": "B3",
       "Status": "closed",
-      "Worktree": "/tmp/sounio-pr691-merge"
+      "Worktree": "/tmp/sounio-vecmat-imported-runtime"
     },
     {
       "Acceptance-Gate": "scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh reports status pass plus scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh",
@@ -44,7 +44,7 @@
       "Repro": "scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh",
       "Severity": "B1",
       "Status": "classified",
-      "Worktree": "/tmp/sounio-pr691-merge"
+      "Worktree": "/tmp/sounio-vecmat-imported-runtime"
     },
     {
       "Acceptance-Gate": "scripts/dev/gpu_knowledge_vec4_imported_runtime_probe.sh plus scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh",
@@ -67,10 +67,10 @@
       "Repro": "scripts/dev/gpu_knowledge_vecmat_completion_audit.py",
       "Severity": "B1",
       "Status": "classified",
-      "Worktree": "/tmp/sounio-pr691-merge"
+      "Worktree": "/tmp/sounio-vecmat-imported-runtime"
     }
   ],
-  "generated_at_utc": "2026-07-07T15:14:33Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "schema": "sounio.gpu-knowledge-vecmat-open-blockers.v1",
   "source_completion_audit": "artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_completion_audit.v1.json"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_operational_handoff.md
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_operational_handoff.md
@@ -1,8 +1,8 @@
 # GPU Knowledge Vec/Mat Operational Handoff
 
-Current-SHA: 42dea4082b003a48162d39f8bee54843a33b9cb7
-Current-Branch: <detached>
-Current-Worktree: /tmp/sounio-pr691-merge
+Current-SHA: 2ae682854059dd38ffc410516297dd60671fcefa
+Current-Branch: work/vecmat-imported-runtime-codex
+Current-Worktree: /tmp/sounio-vecmat-imported-runtime
 Dirty-Status: see `git status --short -- scripts/dev/gpu_knowledge_vec* scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh scripts/dev/dgx_spark_public_gpu_gate.sh artifacts/gpu/knowledge_vecmat_evidence_audit artifacts/gpu/dgx_spark_public_gpu_package artifacts/gpu/dgx_spark_public_gpu_gate.v1.json`
 Current-Goal-Status: not_complete
 Completion-Blockers: automatic_backend_pack_unpack, imported_runtime_fixture

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_swarm_queue.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_swarm_queue.v1.json
@@ -1,7 +1,7 @@
 {
   "blocked_or_unproved_lane_count": 2,
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T15:14:33Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "lane_count": 3,
   "lanes": [
     {

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/gpu_knowledge_vec4_imported_runtime_probe.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/gpu_knowledge_vec4_imported_runtime_probe.v1.json
@@ -16,7 +16,7 @@
       "bytes": 1373,
       "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/souc_run.stdout",
       "present": true,
-      "sha256": "a713f58a12bdee2cd37dcb19f9092e64bc75a5fcefd2345ce9e8606dd35c3b6d"
+      "sha256": "aa3f329f32080aa6e9926147814df03ee1c4d66f84d4c98fe30ff29c50f8c586"
     }
   },
   "boundaries": [
@@ -25,7 +25,7 @@
     "does_not_claim_general_gpu_backend_correctness"
   ],
   "check_log_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nrun_check_mode: about to check 2\n modules\nrun_check_mode: verdict=0\n\ncheck: OK\n",
-  "generated_at_utc": "2026-07-07T15:14:33Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "harness": "tests/run-pass/gpu_hlir_vec4_lane_plan_imported.sio",
   "reason": "souc_run_failed_or_missing_pass_marker",
   "runtime_contract": {
@@ -53,5 +53,5 @@
   },
   "status": "blocked",
   "stderr_tail": "",
-  "stdout_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 2\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 2\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: final_fn_count 10\n\nimported_compile: lower_done\nMerged IR: 10\n functions\nWritten to /tmp/madaros-run.wlnDbO/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.wlnDbO/main.elf\n"
+  "stdout_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 2\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 2\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: final_fn_count 10\n\nimported_compile: lower_done\nMerged IR: 10\n functions\nWritten to /tmp/madaros-run.BURw3I/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.BURw3I/main.elf\n"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/souc_run.stdout
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/souc_run.stdout
@@ -44,6 +44,6 @@ lower_array: final_fn_count 10
 imported_compile: lower_done
 Merged IR: 10
  functions
-Written to /tmp/madaros-run.wlnDbO/main.elf
+Written to /tmp/madaros-run.BURw3I/main.elf
 Compilation successful!
-   Output: /tmp/madaros-run.wlnDbO/main.elf
+   Output: /tmp/madaros-run.BURw3I/main.elf

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/ptxas_probe/gpu_knowledge_vec4_ptxas_probe.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/ptxas_probe/gpu_knowledge_vec4_ptxas_probe.v1.json
@@ -27,7 +27,7 @@
     "does_not_claim_automatic_backend_pack_unpack",
     "does_not_claim_imported_runtime_fixture"
   ],
-  "generated_at_utc": "2026-07-07T15:14:20Z",
+  "generated_at_utc": "2026-07-07T16:30:35Z",
   "ptxas": {
     "output": "",
     "path": "/workspace/.home/openvscode-server/.agents/claude-2/.local/lib/python3.12/site-packages/torch/bin/ptxas",

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/manifest.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T15:14:33Z",
+  "generated_at_utc": "2026-07-07T16:30:48Z",
   "handoffs": [
     "artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/gpu_backend_pack_unpack.handoff.md",
     "artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/cuda_runtime_vecmat_artifact.handoff.md",

--- a/tests/run-pass/imported_f64_return.sio
+++ b/tests/run-pass/imported_f64_return.sio
@@ -1,0 +1,20 @@
+//@ run-pass
+//@ known-failure: Madaros imported/native full-IR path misclassifies cross-module f64 call results as integer values; lean_single passes.
+//@ description: Documents the scalar f64 return half of the imported runtime blocker.
+
+use imported_f64_return_leaf::{
+    imported_f64_return_value,
+    imported_i64_return_value,
+    imported_f64_internal_check,
+}
+
+fn main() -> i32 with IO {
+    if imported_i64_return_value() != 10 { return 1 }
+    if imported_f64_internal_check() != 1 { return 2 }
+
+    let x = imported_f64_return_value()
+    if !(x > 9.999 && x < 10.001) { return 3 }
+
+    println("PASS imported_f64_return")
+    return 0
+}

--- a/tests/run-pass/imported_f64_return_leaf.sio
+++ b/tests/run-pass/imported_f64_return_leaf.sio
@@ -1,0 +1,13 @@
+pub fn imported_f64_return_value() -> f64 {
+    return 10.0
+}
+
+pub fn imported_i64_return_value() -> i64 {
+    return 10
+}
+
+pub fn imported_f64_internal_check() -> i64 {
+    let x = 10.0
+    if !(x > 9.999 && x < 10.001) { return 0 }
+    return 1
+}


### PR DESCRIPTION
## Summary
- adds a focused known-failure fixture for imported scalar `f64` returns
- records the current imported-runtime blocker receipts on latest `origin/main`
- refreshes the GPU Knowledge Vec/Mat evidence/audit artifacts without claiming completion

## Evidence
- `./sounio-whereami --quick` -> branch `work/vecmat-imported-runtime-codex`, commit base `2ae682854`, isolated worktree
- `./bin/souc check tests/run-pass/imported_f64_return.sio` -> `check: OK`
- `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tests/run-pass/imported_f64_return.sio` -> `PASS imported_f64_return`
- `./bin/souc run tests/run-pass/imported_f64_return.sio` -> `exit=3` on default Madaros imported/native path
- `bash scripts/dev/run_sio_test_suite_v2.sh --filter imported_f64_return --jobs 1` -> 1 known-failure, all tests passed
- `bash scripts/dev/gpu_knowledge_vec4_imported_runtime_probe.sh` -> `BLOCKED souc_run_failed_or_missing_pass_marker`
- `scripts/dev/gpu_knowledge_vecmat_completion_audit.py` -> `not_complete`
- `bash scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh` -> `PASS`
- `git diff --check` -> clean

## Boundaries
- does not edit compiler-owned files
- does not claim the imported runtime fixture is fixed
- Madaros rebuild experiment was attempted in `/tmp` and stopped at the current seed import-buffer limit (`import too large for SRC buffer: self-hosted/parser/patterns.sio`); no speculative compiler patch is included

LLM-offload reviews invoked: none; this change does not touch math claims, clinical-pathway code, or external-facing artifacts.
