### PR TITLE
fix(lower): preseed imported free-function signatures (returns_float / return_struct_name)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -792,6 +792,19 @@ fn lowerer_preseed_external_struct_items_mut(
                         _ => {}
                     }
                 }
+                // Also preseed imported FREE functions' signatures (returns_float /
+                // return_struct_name), so the caller recognizes an imported fn's f64
+                // return instead of treating the call result as int (cvtsi2sd). The
+                // struct-only preseed above left free-function returns unclassified.
+                if head_owned.kind == ItemKind::ItemFn {
+                    let fn_def_opt_ref: &Option<Box<FnDef>> = &head_owned.fn_def
+                    match *fn_def_opt_ref {
+                        Some(fd) => {
+                            lowerer_preseed_fn_signature_mut(lo, head_owned.name, &(*fd).params, &(*fd).return_type, &(*fd).effects)
+                        }
+                        _ => {}
+                    }
+                }
                 current = &(*list).tail
             }
             _ => break


### PR DESCRIPTION
## Bug

The cross-module external-items preseed (`lowerer_preseed_external_struct_items_mut`) registered imported **struct** layouts but not imported free **functions**. So when a caller referenced an imported function, its `returns_float` was unknown, and any use of the call result in a float context (comparison, arithmetic) treated the f64 return as an **integer** — emitting `cvtsi2sd` and corrupting the value.

Concretely, an imported `fn f(x: Dd64) -> f64` used as `f(d) == k` compiled `f(d)`'s result with `cvtsi2sd xmm0, rax` (int→double reinterpret) instead of a direct f64 load. The same function defined **locally** was fine.

## Fix

Add an `ItemFn` branch to `lowerer_preseed_external_struct_items_mut` that calls `lowerer_preseed_fn_signature_mut` for each imported free function — mirroring the existing impl-method preseed (`lowerer_preseed_impl_method_summaries_mut`). This registers the callee's `returns_float` and `return_struct_name` **before** the caller's own items are lowered, so cross-module f64 (and struct) returns classify correctly.

## Verification

- A 2-module reproducer (imported `first(p:P)->f64`, `sum2(p:P)->f64`) flips from wrong → correct.
- **Byte-identity sweep** over 128 run-pass programs: **110 identical, 18 changed** — 2 improved (PBPK/PD models now compute correctly), 16 behavior-preserving (byte-diff only from correct float classification). **Zero regressions.**

Completes the cross-module type-metadata propagation series (imported struct field classes, string equality, and now free-function return types). With this, the EISA epistemic-arithmetic test suite's `core` module prints `ALL PASS` end-to-end.