### PR TITLE
Tighten vecmat backend import blocker evidence

### DIFF
--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_backend_pack_unpack_probe.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_backend_pack_unpack_probe.v1.json
@@ -29,7 +29,7 @@
     "does_not_claim_imported_compiler_lowering",
     "does_not_claim_cuda_device_runtime_execution"
   ],
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "harness": "self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
   "lean_extract_fallback": {
     "artifacts": {
@@ -40,10 +40,10 @@
         "sha256": "b6c7c688a67876c181fecad7e4516ae2a970480dbb5e958a8aed38b43e7d5afb"
       },
       "log": {
-        "bytes": 355,
+        "bytes": 351,
         "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/lean_extract.log",
         "present": true,
-        "sha256": "85eac450e73e61cb0c563809acb62fcfe6da1fb4200e472a27d37c6d71bb10c7"
+        "sha256": "f9c04d23d591df32a76b28754821ae66e8fb95d866f9ae2dbee80393f54f48b8"
       },
       "ptx": {
         "bytes": 788,
@@ -55,7 +55,7 @@
         "bytes": 1375,
         "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw",
         "present": true,
-        "sha256": "87d7b5e82c7b61bd3fa741e22501e7234acc3100765409e27ef39f413a4aa539"
+        "sha256": "bbce761cb3b58e9da5e90267bd9055a78f2408a3099eda94e63d184c93fb345e"
       }
     },
     "boundaries": [
@@ -70,6 +70,28 @@
     "ptxas_path": "",
     "reason": "run_failed",
     "run_exit_code": 139,
+    "status": "blocked"
+  },
+  "minimal_import_runtime_probe": {
+    "boundaries": [
+      "does_not_claim_backend_ir_to_ptx",
+      "does_not_claim_cuda_device_runtime_execution",
+      "diagnoses_minimal_modular_import_runtime_only"
+    ],
+    "classification": "diagnostic_not_backend_contract",
+    "imported": {
+      "check_exit_code": 0,
+      "run_exit_code": 139,
+      "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/minimal_import_run.log",
+      "run_log_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nrun_check_mode: about to check 2\n modules\nrun_check_mode: verdict=0\n\ncheck: OK\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 2\n items\nMerged IR: 1\n functions\nImported frontend summary: ok\nMain file: 2\n items\nMerged IR: 1\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 1\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 2\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: final_fn_count 4\n\nimported_compile: lower_done\nMerged IR: 4\n functions\nWritten to /tmp/madaros-run.ZKq1EM/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.ZKq1EM/main.elf\n/tmp/sounio-vecmat-backend-pack/bin/madaros: line 342: 4179583 Segmentation fault      \"$out\" \"$@\"\n"
+    },
+    "no_import": {
+      "check_exit_code": 0,
+      "run_exit_code": 0,
+      "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/minimal_no_import_run.log",
+      "run_log_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\ncheck: OK\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 1\n items\nLoaded 1 modules\nResolve skip: single module with no imports\nType checking module 0\nType check complete for module 0\nMerged IR: 2\n functions\nWritten to /tmp/madaros-run.UgtKnn/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.UgtKnn/main.elf\n.version 7.0\n"
+    },
+    "reason": "minimal_imported_elf_segfault_after_compile",
     "status": "blocked"
   },
   "ptxas": {
@@ -88,7 +110,7 @@
     "run_command": "./bin/souc run self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
     "run_exit_code": 139,
     "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/souc_run.log",
-    "run_log_tail": "/tmp/sounio-vecmat-imported-runtime/bin/madaros: line 308: 4152401 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
+    "run_log_tail": "/tmp/sounio-vecmat-backend-pack/bin/madaros: line 308: 4179485 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
   },
   "status": "blocked"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw
@@ -44,6 +44,6 @@ lower_array: final_fn_count 166
 imported_compile: lower_done
 Merged IR: 166
  functions
-Written to /tmp/madaros-run.Scu95x/main.elf
+Written to /tmp/madaros-run.4vDbDd/main.elf
 Compilation successful!
-   Output: /tmp/madaros-run.Scu95x/main.elf
+   Output: /tmp/madaros-run.4vDbDd/main.elf

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_completion_audit.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_completion_audit.v1.json
@@ -55,7 +55,7 @@
     "imported_runtime_fixture"
   ],
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "goal_status": "not_complete",
   "schema": "sounio.gpu-knowledge-vecmat-completion-audit.v1"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_evidence_audit.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_evidence_audit.v1.json
@@ -30,7 +30,7 @@
       "does_not_claim_imported_compiler_lowering",
       "does_not_claim_cuda_device_runtime_execution"
     ],
-    "generated_at_utc": "2026-07-07T16:30:48Z",
+    "generated_at_utc": "2026-07-07T16:51:43Z",
     "harness": "self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
     "lean_extract_fallback": {
       "artifacts": {
@@ -41,10 +41,10 @@
           "sha256": "b6c7c688a67876c181fecad7e4516ae2a970480dbb5e958a8aed38b43e7d5afb"
         },
         "log": {
-          "bytes": 355,
+          "bytes": 351,
           "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/lean_extract.log",
           "present": true,
-          "sha256": "85eac450e73e61cb0c563809acb62fcfe6da1fb4200e472a27d37c6d71bb10c7"
+          "sha256": "f9c04d23d591df32a76b28754821ae66e8fb95d866f9ae2dbee80393f54f48b8"
         },
         "ptx": {
           "bytes": 788,
@@ -56,7 +56,7 @@
           "bytes": 1375,
           "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/gpu_knowledge_vec4_pack_unpack_lean_extract.raw",
           "present": true,
-          "sha256": "87d7b5e82c7b61bd3fa741e22501e7234acc3100765409e27ef39f413a4aa539"
+          "sha256": "bbce761cb3b58e9da5e90267bd9055a78f2408a3099eda94e63d184c93fb345e"
         }
       },
       "boundaries": [
@@ -71,6 +71,28 @@
       "ptxas_path": "",
       "reason": "run_failed",
       "run_exit_code": 139,
+      "status": "blocked"
+    },
+    "minimal_import_runtime_probe": {
+      "boundaries": [
+        "does_not_claim_backend_ir_to_ptx",
+        "does_not_claim_cuda_device_runtime_execution",
+        "diagnoses_minimal_modular_import_runtime_only"
+      ],
+      "classification": "diagnostic_not_backend_contract",
+      "imported": {
+        "check_exit_code": 0,
+        "run_exit_code": 139,
+        "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/minimal_import_run.log",
+        "run_log_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nrun_check_mode: about to check 2\n modules\nrun_check_mode: verdict=0\n\ncheck: OK\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 2\n items\nMerged IR: 1\n functions\nImported frontend summary: ok\nMain file: 2\n items\nMerged IR: 1\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 1\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 2\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: final_fn_count 4\n\nimported_compile: lower_done\nMerged IR: 4\n functions\nWritten to /tmp/madaros-run.ZKq1EM/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.ZKq1EM/main.elf\n/tmp/sounio-vecmat-backend-pack/bin/madaros: line 342: 4179583 Segmentation fault      \"$out\" \"$@\"\n"
+      },
+      "no_import": {
+        "check_exit_code": 0,
+        "run_exit_code": 0,
+        "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/minimal_no_import_run.log",
+        "run_log_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\ncheck: OK\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 1\n items\nLoaded 1 modules\nResolve skip: single module with no imports\nType checking module 0\nType check complete for module 0\nMerged IR: 2\n functions\nWritten to /tmp/madaros-run.UgtKnn/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.UgtKnn/main.elf\n.version 7.0\n"
+      },
+      "reason": "minimal_imported_elf_segfault_after_compile",
       "status": "blocked"
     },
     "ptxas": {
@@ -89,7 +111,7 @@
       "run_command": "./bin/souc run self-hosted/gpu/gpu_knowledge_vec4_pack_unpack_harness.sio",
       "run_exit_code": 139,
       "run_log": "artifacts/gpu/knowledge_vecmat_evidence_audit/backend_pack_unpack_probe/souc_run.log",
-      "run_log_tail": "/tmp/sounio-vecmat-imported-runtime/bin/madaros: line 308: 4152401 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
+      "run_log_tail": "/tmp/sounio-vecmat-backend-pack/bin/madaros: line 308: 4179485 Segmentation fault      ( ulimit -v 50331648 2> /dev/null || true; exec timeout 300 \"$RAW_MADAROS\" \"$src\" -o \"$out\" )\n\n--- stdout ---\nMadares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nMain file: 9\n items\nMerged IR: 22\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 22\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 4\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: dep_begin 2\n\n"
     },
     "status": "blocked"
   },
@@ -103,7 +125,7 @@
     "imported_runtime_fixture"
   ],
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "model_routing_summary": {
     "current-codex": [
       "integration edits",
@@ -145,7 +167,7 @@
       "does_not_claim_automatic_backend_pack_unpack",
       "does_not_claim_imported_runtime_fixture"
     ],
-    "generated_at_utc": "2026-07-07T16:30:35Z",
+    "generated_at_utc": "2026-07-07T16:51:23Z",
     "ptxas": {
       "output": "",
       "path": "/workspace/.home/openvscode-server/.agents/claude-2/.local/lib/python3.12/site-packages/torch/bin/ptxas",

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_open_blockers.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_open_blockers.v1.json
@@ -21,7 +21,7 @@
       "Repro": "scripts/dev/gpu_knowledge_vec4_dgx_runtime_runbook.sh run-dgx",
       "Severity": "B3",
       "Status": "closed",
-      "Worktree": "/tmp/sounio-vecmat-imported-runtime"
+      "Worktree": "/tmp/sounio-vecmat-backend-pack"
     },
     {
       "Acceptance-Gate": "scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh reports status pass plus scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh",
@@ -38,13 +38,13 @@
       "LLM-Offload": "not-required",
       "Lane": "gpu_backend_pack_unpack",
       "Legacy-Kept": "yes",
-      "Next-Action": "Unblock the lean backend harness runtime segfault around GpuKernelIr.ops access, then rerun the Vec4 backend-IR/PTX probe until it emits PTX and passes ptxas.",
-      "Observed": "backend probe status blocked reason souc_runtime_segfault_after_compile; check_exit=0 run_exit=139 ptxas_exit=None; contract=unproved; lean_extract_fallback=blocked:run_failed",
+      "Next-Action": "Transfer the minimal imported-module ELF segfault to the modular compiler/runtime owner, then rerun the Vec4 backend-IR/PTX probe until it emits PTX and passes ptxas.",
+      "Observed": "backend probe status blocked reason souc_runtime_segfault_after_compile; check_exit=0 run_exit=139 ptxas_exit=None; contract=unproved; lean_extract_fallback=blocked:run_failed; minimal_import_runtime=minimal_imported_elf_segfault_after_compile",
       "Owner": "gpu-backend-owner",
       "Repro": "scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh",
       "Severity": "B1",
       "Status": "classified",
-      "Worktree": "/tmp/sounio-vecmat-imported-runtime"
+      "Worktree": "/tmp/sounio-vecmat-backend-pack"
     },
     {
       "Acceptance-Gate": "scripts/dev/gpu_knowledge_vec4_imported_runtime_probe.sh plus scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh",
@@ -67,10 +67,10 @@
       "Repro": "scripts/dev/gpu_knowledge_vecmat_completion_audit.py",
       "Severity": "B1",
       "Status": "classified",
-      "Worktree": "/tmp/sounio-vecmat-imported-runtime"
+      "Worktree": "/tmp/sounio-vecmat-backend-pack"
     }
   ],
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "schema": "sounio.gpu-knowledge-vecmat-open-blockers.v1",
   "source_completion_audit": "artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_completion_audit.v1.json"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_operational_handoff.md
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_operational_handoff.md
@@ -1,8 +1,8 @@
 # GPU Knowledge Vec/Mat Operational Handoff
 
-Current-SHA: 2ae682854059dd38ffc410516297dd60671fcefa
-Current-Branch: work/vecmat-imported-runtime-codex
-Current-Worktree: /tmp/sounio-vecmat-imported-runtime
+Current-SHA: 9d4d4afab13e6bbf9367b4489b9e4e048103717c
+Current-Branch: work/vecmat-backend-pack-codex
+Current-Worktree: /tmp/sounio-vecmat-backend-pack
 Dirty-Status: see `git status --short -- scripts/dev/gpu_knowledge_vec* scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh scripts/dev/dgx_spark_public_gpu_gate.sh artifacts/gpu/knowledge_vecmat_evidence_audit artifacts/gpu/dgx_spark_public_gpu_package artifacts/gpu/dgx_spark_public_gpu_gate.v1.json`
 Current-Goal-Status: not_complete
 Completion-Blockers: automatic_backend_pack_unpack, imported_runtime_fixture

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_swarm_queue.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/gpu_knowledge_vecmat_swarm_queue.v1.json
@@ -1,7 +1,7 @@
 {
   "blocked_or_unproved_lane_count": 2,
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "lane_count": 3,
   "lanes": [
     {

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/gpu_knowledge_vec4_imported_runtime_probe.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/gpu_knowledge_vec4_imported_runtime_probe.v1.json
@@ -16,7 +16,7 @@
       "bytes": 1373,
       "path": "artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/souc_run.stdout",
       "present": true,
-      "sha256": "aa3f329f32080aa6e9926147814df03ee1c4d66f84d4c98fe30ff29c50f8c586"
+      "sha256": "8f8102f4f2c1baf7b7944071c9c0217de0d53371405d4cff5ab60d227ce7923c"
     }
   },
   "boundaries": [
@@ -25,7 +25,7 @@
     "does_not_claim_general_gpu_backend_correctness"
   ],
   "check_log_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nrun_check_mode: about to check 2\n modules\nrun_check_mode: verdict=0\n\ncheck: OK\n",
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "harness": "tests/run-pass/gpu_hlir_vec4_lane_plan_imported.sio",
   "reason": "souc_run_failed_or_missing_pass_marker",
   "runtime_contract": {
@@ -53,5 +53,5 @@
   },
   "status": "blocked",
   "stderr_tail": "",
-  "stdout_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 2\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 2\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: final_fn_count 10\n\nimported_compile: lower_done\nMerged IR: 10\n functions\nWritten to /tmp/madaros-run.BURw3I/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.BURw3I/main.elf\n"
+  "stdout_tail": "Madares v0.80.0 -- the Sounio self-hosted compiler\nthe bare highland that does not negotiate with ill-formed code -- Sfakia, Crete\nHorizon 3: self-hosted primary compiler.\n\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nMain file: 2\n items\nMerged IR: 2\n functions\nImported frontend summary: ok\nNative dispatch: requested=native resolved=x86_64-linux matrix=auto source=fallback fallback=unresolved_default_x86_64_linux gpu_strict_parity=false\nmodule_native_driver: imported source uses modular IR path\nmodule_native_driver: imported source uses compact modular IR table path\nMerged IR: 2\n functions\nNative compilation failed: imported_simple_ir_emit_failed\nmodule_native_driver: compact IR ELF write failed; rc=1\n; falling back to full IR path\nimported_compile: begin\nimported_compile: load_begin\nimported_compile: load_done\nimported_compile: loaded 2\n modules\nimported_compile: typecheck_begin\nimported_compile: typecheck_done\nimported_compile: typecheck ok\nimported_compile: lower_begin\nlower_array: seed_begin\nlower_array: seed_done\nlower_array: dep_begin 1\n\nlower_array: dep_lower_done 1\n\nlower_array: merge_begin 1\n\nlower_array: merge_done 1\n\nlower_array: final_fn_count 10\n\nimported_compile: lower_done\nMerged IR: 10\n functions\nWritten to /tmp/madaros-run.gWDYoi/main.elf\nCompilation successful!\n   Output: /tmp/madaros-run.gWDYoi/main.elf\n"
 }

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/souc_run.stdout
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/imported_runtime_probe/souc_run.stdout
@@ -44,6 +44,6 @@ lower_array: final_fn_count 10
 imported_compile: lower_done
 Merged IR: 10
  functions
-Written to /tmp/madaros-run.BURw3I/main.elf
+Written to /tmp/madaros-run.gWDYoi/main.elf
 Compilation successful!
-   Output: /tmp/madaros-run.BURw3I/main.elf
+   Output: /tmp/madaros-run.gWDYoi/main.elf

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/ptxas_probe/gpu_knowledge_vec4_ptxas_probe.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/ptxas_probe/gpu_knowledge_vec4_ptxas_probe.v1.json
@@ -27,7 +27,7 @@
     "does_not_claim_automatic_backend_pack_unpack",
     "does_not_claim_imported_runtime_fixture"
   ],
-  "generated_at_utc": "2026-07-07T16:30:35Z",
+  "generated_at_utc": "2026-07-07T16:51:23Z",
   "ptxas": {
     "output": "",
     "path": "/workspace/.home/openvscode-server/.agents/claude-2/.local/lib/python3.12/site-packages/torch/bin/ptxas",

--- a/artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/manifest.v1.json
+++ b/artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "completion_ready": false,
-  "generated_at_utc": "2026-07-07T16:30:48Z",
+  "generated_at_utc": "2026-07-07T16:51:43Z",
   "handoffs": [
     "artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/gpu_backend_pack_unpack.handoff.md",
     "artifacts/gpu/knowledge_vecmat_evidence_audit/swarm_dispatch/cuda_runtime_vecmat_artifact.handoff.md",

--- a/scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh
+++ b/scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh
@@ -158,6 +158,15 @@ if backend_probe.get("status") == "blocked":
         require(compiled_before_failure in {True, False}, "backend segfault blocker missing compile-before-failure classification")
         if compiled_before_failure is False:
             require("imported_compile:" in run_log_tail or "Native compilation failed" in run_log_tail, "backend compile-path segfault missing imported-lower evidence")
+        min_import = backend_probe.get("minimal_import_runtime_probe", {})
+        require(min_import.get("classification") == "diagnostic_not_backend_contract", "backend segfault missing minimal import diagnostic classification")
+        require("diagnoses_minimal_modular_import_runtime_only" in min_import.get("boundaries", []), "minimal import diagnostic missing boundary")
+        require(min_import.get("reason") == "minimal_imported_elf_segfault_after_compile", "minimal import diagnostic reason mismatch")
+        require(min_import.get("no_import", {}).get("check_exit_code") == 0, "minimal no-import check must pass")
+        require(min_import.get("no_import", {}).get("run_exit_code") == 0, "minimal no-import run must pass")
+        require(min_import.get("imported", {}).get("check_exit_code") == 0, "minimal imported check must pass")
+        require(min_import.get("imported", {}).get("run_exit_code") == 139, "minimal imported run must segfault")
+        require("Compilation successful!" in min_import.get("imported", {}).get("run_log_tail", ""), "minimal imported diagnostic missing compile-success evidence")
 else:
     require(backend_contract.get("status") == "proved", "backend pass did not prove contract")
     require(backend_probe.get("artifacts", {}).get("ptx", {}).get("present") is True, "backend pass missing PTX")

--- a/scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh
+++ b/scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh
@@ -19,6 +19,8 @@ EXTRACT_RAW="$OUT_DIR/gpu_knowledge_vec4_pack_unpack_lean_extract.raw"
 EXTRACT_PTX="$OUT_DIR/gpu_knowledge_vec4_pack_unpack_lean_extract.ptx"
 EXTRACT_CUBIN="$OUT_DIR/gpu_knowledge_vec4_pack_unpack_lean_extract.cubin"
 EXTRACT_LOG="$OUT_DIR/lean_extract.log"
+MIN_NO_IMPORT_LOG="$OUT_DIR/minimal_no_import_run.log"
+MIN_IMPORT_LOG="$OUT_DIR/minimal_import_run.log"
 LOG="$OUT_DIR/souc_run.log"
 CHECK_LOG="$OUT_DIR/souc_check.log"
 STDOUT_LOG="$OUT_DIR/souc_stdout.log"
@@ -138,6 +140,28 @@ payload = {
             "does_not_claim_cuda_device_runtime_execution",
         ],
     },
+    "minimal_import_runtime_probe": {
+        "classification": "diagnostic_not_backend_contract",
+        "status": os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_STATUS", "not_run"),
+        "reason": os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_REASON", "not_run"),
+        "no_import": {
+            "check_exit_code": int(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_CHECK_EXIT", "-1")),
+            "run_exit_code": int(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_RUN_EXIT", "-1")),
+            "run_log": rel(pathlib.Path(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_LOG", ""))),
+            "run_log_tail": pathlib.Path(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_LOG", "")).read_text(encoding="utf-8", errors="replace")[-2000:] if os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_LOG") and pathlib.Path(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_LOG", "")).exists() else "",
+        },
+        "imported": {
+            "check_exit_code": int(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_CHECK_EXIT", "-1")),
+            "run_exit_code": int(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_RUN_EXIT", "-1")),
+            "run_log": rel(pathlib.Path(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_LOG", ""))),
+            "run_log_tail": pathlib.Path(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_LOG", "")).read_text(encoding="utf-8", errors="replace")[-2000:] if os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_LOG") and pathlib.Path(os.environ.get("SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_LOG", "")).exists() else "",
+        },
+        "boundaries": [
+            "does_not_claim_backend_ir_to_ptx",
+            "does_not_claim_cuda_device_runtime_execution",
+            "diagnoses_minimal_modular_import_runtime_only",
+        ],
+    },
     "backend_ir_contract": {
         "kernel": "gpu_vec4_pack_unpack",
         "source_param": "in_ptr",
@@ -251,6 +275,64 @@ run_lean_extract_fallback() {
   export SOUNIO_GPU_KNOWLEDGE_LEAN_EXTRACT_REASON="lean_extract_ptxas_pass"
 }
 
+run_minimal_import_runtime_probe() {
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_STATUS="blocked"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_REASON="not_run"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_CHECK_EXIT="-1"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_RUN_EXIT="-1"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_CHECK_EXIT="-1"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_RUN_EXIT="-1"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_LOG="$MIN_NO_IMPORT_LOG"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_LOG="$MIN_IMPORT_LOG"
+
+  local tmpdir
+  tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/sounio-gpu-min-import.XXXXXX")"
+  cat >"$tmpdir/no_import.sio" <<'SIO'
+fn main() -> i32 with IO {
+    print(".version 7.0\n")
+    0
+}
+SIO
+  cat >"$tmpdir/import_leaf.sio" <<'SIO'
+pub fn emit_marker() with IO {
+    print(".version 7.0\n")
+}
+SIO
+  cat >"$tmpdir/import_harness.sio" <<'SIO'
+use import_leaf::*
+
+fn main() -> i32 with IO {
+    emit_marker()
+    0
+}
+SIO
+
+  : >"$MIN_NO_IMPORT_LOG"
+  : >"$MIN_IMPORT_LOG"
+
+  set +e
+  ./bin/souc check "$tmpdir/no_import.sio" >>"$MIN_NO_IMPORT_LOG" 2>&1
+  local no_import_check=$?
+  ./bin/souc run "$tmpdir/no_import.sio" >>"$MIN_NO_IMPORT_LOG" 2>&1
+  local no_import_run=$?
+  ./bin/souc check "$tmpdir/import_harness.sio" >>"$MIN_IMPORT_LOG" 2>&1
+  local import_check=$?
+  ./bin/souc run "$tmpdir/import_harness.sio" >>"$MIN_IMPORT_LOG" 2>&1
+  local import_run=$?
+  set -e
+
+  export SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_CHECK_EXIT="$no_import_check"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_NO_IMPORT_RUN_EXIT="$no_import_run"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_CHECK_EXIT="$import_check"
+  export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_RUN_EXIT="$import_run"
+
+  if [ "$no_import_check" -eq 0 ] && [ "$no_import_run" -eq 0 ] && [ "$import_check" -eq 0 ] && [ "$import_run" -eq 139 ]; then
+    export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_REASON="minimal_imported_elf_segfault_after_compile"
+  else
+    export SOUNIO_GPU_KNOWLEDGE_MIN_IMPORT_REASON="minimal_import_probe_unexpected_result"
+  fi
+}
+
 set +e
 ./bin/souc check "$HARNESS" >"$CHECK_LOG" 2>&1
 souc_check_exit=$?
@@ -278,6 +360,7 @@ if [ "$souc_run_exit" -ne 0 ]; then
   elif [ "$souc_run_exit" -eq 139 ] || grep -qi "Segmentation fault" "$LOG"; then
     reason="souc_runtime_segfault_after_compile"
   fi
+  run_minimal_import_runtime_probe
   run_lean_extract_fallback
   write_json "blocked" "$reason" "$souc_run_exit" "$souc_check_exit"
   echo "gpu_knowledge_vec4_backend_pack_unpack_probe: BLOCKED $reason report=${OUT_JSON#$ROOT_DIR/}"

--- a/scripts/dev/gpu_knowledge_vecmat_completion_audit.py
+++ b/scripts/dev/gpu_knowledge_vecmat_completion_audit.py
@@ -187,7 +187,7 @@ def main() -> int:
                 "Files-Read-Only": "self-hosted/gpu/kernel_ir.sio; self-hosted/gpu/lower_to_ptx.sio; self-hosted/gpu/ptx.sio; scripts/dev/gpu_knowledge_vec4_ptxas_probe.sh",
                 "Do-Not-Touch": "self-hosted/compiler/module_frontend.sio; self-hosted/ir/lower.sio",
                 "Repro": "scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh",
-                "Observed": f"backend probe status {backend_probe.get('status', 'missing')} reason {backend_probe.get('reason', 'missing')}; check_exit={backend_probe.get('souc', {}).get('check_exit_code', 'n/a')} run_exit={backend_probe.get('souc', {}).get('run_exit_code', 'n/a')} ptxas_exit={backend_probe.get('ptxas', {}).get('exit_code', 'n/a')}; contract={backend_probe.get('backend_ir_contract', {}).get('status', 'n/a')}; lean_extract_fallback={backend_probe.get('lean_extract_fallback', {}).get('status', 'n/a')}:{backend_probe.get('lean_extract_fallback', {}).get('reason', 'n/a')}",
+                "Observed": f"backend probe status {backend_probe.get('status', 'missing')} reason {backend_probe.get('reason', 'missing')}; check_exit={backend_probe.get('souc', {}).get('check_exit_code', 'n/a')} run_exit={backend_probe.get('souc', {}).get('run_exit_code', 'n/a')} ptxas_exit={backend_probe.get('ptxas', {}).get('exit_code', 'n/a')}; contract={backend_probe.get('backend_ir_contract', {}).get('status', 'n/a')}; lean_extract_fallback={backend_probe.get('lean_extract_fallback', {}).get('status', 'n/a')}:{backend_probe.get('lean_extract_fallback', {}).get('reason', 'n/a')}; minimal_import_runtime={backend_probe.get('minimal_import_runtime_probe', {}).get('reason', 'n/a')}",
                 "Expected": "automatic Vec/Mat aggregate backend pack/unpack proof across relevant emitters without imported-lower fallback",
                 "Acceptance-Gate": "scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh reports status pass plus scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh",
                 "Evidence-Level": "E3" if backend_closed else "E2",
@@ -195,7 +195,7 @@ def main() -> int:
                 "Fallback-Path": "direct backend Vec4 emitter; lean extract retained as reference fallback" if backend_closed else "local ptxas/package witness only",
                 "Legacy-Kept": "yes",
                 "LLM-Offload": "not-required",
-                "Next-Action": "Closed for the direct backend Vec4 emitter; keep the GpuKernelIr.ops modular ABI issue as a separate compiler/runtime hardening note." if backend_closed else "Unblock the lean backend harness runtime segfault around GpuKernelIr.ops access, then rerun the Vec4 backend-IR/PTX probe until it emits PTX and passes ptxas.",
+                "Next-Action": "Closed for the direct backend Vec4 emitter; keep the GpuKernelIr.ops modular ABI issue as a separate compiler/runtime hardening note." if backend_closed else "Transfer the minimal imported-module ELF segfault to the modular compiler/runtime owner, then rerun the Vec4 backend-IR/PTX probe until it emits PTX and passes ptxas.",
             },
             {
                 "Blocker-ID": "BLK-20260706-gpu-knowledge-vecmat-imported-runtime",


### PR DESCRIPTION
## Summary
- add a minimal modular-import diagnostic to the Vec/Mat backend pack/unpack probe
- require that diagnostic in the evidence gate when the backend harness is blocked by segfault
- refresh the completion audit/blocker artifacts so the next action points at the minimal imported-module ELF segfault

## Evidence
- `bash scripts/dev/gpu_knowledge_vec4_backend_pack_unpack_probe.sh` -> `BLOCKED souc_runtime_segfault_after_compile`
- minimal diagnostic in the backend probe JSON: no-import check/run `0/0`, imported check/run `0/139`, reason `minimal_imported_elf_segfault_after_compile`
- `scripts/dev/gpu_knowledge_vecmat_completion_audit.py` -> `not_complete`
- `bash scripts/ci/gpu_knowledge_vecmat_evidence_gate.sh` -> `PASS`
- `git diff --check` -> pass

## Boundaries
- does not claim automatic backend pack/unpack is closed
- does not claim CUDA device runtime execution
- does not edit compiler-owned files
- LLM-offload not required: no math claims, clinical-pathway code, or external-facing artifact changes
