### PR TITLE
feat(exact): Gresnigt's 3 generation-octonions + a G2 (color-side) automorphism (source cross-check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion Gresnigt-octonions cross-verification
+        run: bash scripts/ci/sedenion_gresnigt_octonions_gate.sh
       - name: Sedenion octonion-census cross-verification
         run: bash scripts/ci/sedenion_octonion_census_gate.sh
       - name: Sedenion Clifford-8 cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 898
-- Repo-backed topics: 748
+- Total governed topics: 899
+- Repo-backed topics: 749
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 182
+- Authority count `historical`: 183
 - Authority count `repo_only`: 528
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 231 topics
+- A6: 232 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -678,6 +678,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sedenion-dynamics | historical | docs/research/sedenion_dynamics.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-e8-boundary | historical | docs/research/sedenion_e8_boundary.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-fano-fibers | historical | docs/research/sedenion_fano_fibers.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-gresnigt-octonions | historical | docs/research/sedenion_gresnigt_octonions.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-ladder-extension | historical | docs/research/sedenion_ladder_extension.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-octonion-census | historical | docs/research/sedenion_octonion_census.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14957,6 +14957,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-gresnigt-octonions",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_gresnigt_octonions.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-ladder-extension",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_ladder_extension.md",

--- a/docs/research/sedenion_gresnigt_octonions.md
+++ b/docs/research/sedenion_gresnigt_octonions.md
@@ -1,0 +1,72 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-gresnigt-octonions
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-gresnigt-octonions
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Gresnigt's three generation-octonions + a G₂ (color-side) automorphism — executed against the source
+
+**One line.** Reproduced, in this repo's Cayley–Dickson convention, the three octonion subalgebras
+Gresnigt uses to build three fermion generations (arXiv:2306.13098), and exhibited an **explicit order-3
+monomial automorphism** of 𝕊 that cyclically permutes them. That automorphism lies in **G₂** (it is a
+color-sector map); it is **not** Gresnigt's family `S₃` (the Brown direct factor, non-monomial), and this
+is **not** a bridge from the zero-divisor monomial-168 to fermion generations. **Erratum E1 stands.**
+
+## What was reproduced (primary-source cross-check)
+
+Gresnigt (EPJC 2019/2024; arXiv:2306.13098) builds three generations from three octonion subalgebras of
+𝕊 sharing a common quaternion, cyclically related by the family `S₃`. The paper's copies (its basis) are
+the index sets `𝕆₁={1,4,5,8,9,12,13}`, `𝕆₂={2,4,6,8,10,12,14}`, `𝕆₃={3,4,7,8,11,12,15}` with intersection
+`ℍ = ⟨e₄,e₈,e₁₂⟩`. Certified here, in this repo's convention:
+
+- each `𝕆_i` is a **genuine (zero-divisor-free) octonion**, and all three are **ambient-equivalent** — each
+  has exactly 6 non-anticommuting internal left-mult pairs in the 16-dim `Cℓ(8)` (`sedenion_clifford8.md`);
+  `𝕆₁∩𝕆₂∩𝕆₃ = {4,8,12}`.
+- the pure 3-cycle `φ = (e₁e₂e₃)(e₅e₆e₇)(e₉e₁₀e₁₁)(e₁₃e₁₄e₁₅)` (all signs `+1`, fixing `e₀,e₄,e₈,e₁₂`) is a
+  **genuine algebra automorphism** of 𝕊 (verified on all 256 products), of **order 3**, cyclically
+  permuting `𝕆₁→𝕆₂→𝕆₃` and fixing `ℍ` and `e₈`;
+- `φ = g ⊕ g` is **diagonal** under `𝕊 = 𝕆 ⊕ 𝕆·e₈`, with `g = (e₁e₂e₃)(e₅e₆e₇)` an automorphism of the base
+  octonion `{e₁..e₇}`. So **`φ ∈ G₂ = Aut(𝕆)`** — proved directly (diagonal + `g ∈ Aut(𝕆)`), not via any
+  simplicity argument.
+
+## Honest boundary — this is NOT a physics bridge
+
+An adversarial review corrected an over-correction here; the boundary is sharp:
+
+- **`φ ∈ G₂`, and `G₂ ⊃ SU(3)_color`**, so `φ` is a **color-sector** operation. Permuting the three
+  octonions **as sets** is something a G₂ element can do; it does **not** make `φ` the family symmetry.
+- Gresnigt's **family `S₃`** is, by Brown's theorem `Aut(𝕊)=G₂×S₃`, the direct factor **disjoint from
+  G₂** — used *precisely because* it is outside G₂, so that **family ≠ color**. Identifying `φ` with the
+  family `S₃` would conflate the two sectors the construction keeps separate (a category error).
+- Therefore this **does not** connect the zero-divisor monomial-168 to fermion generations, and **does not
+  amend Erratum E1**, which correctly places the monomial-168 inside G₂ (`docs/papers/sedenion-fano-geometry.md`).
+- A genuine bridge would require building the fermion ideals `T_i` and showing Brown's `S₃` acts on those
+  **states** as a monomial-168 element. The ideals are not built here; the 3-set permutation match is
+  necessary but nowhere near sufficient. Open.
+
+What this brick *is*: a clean, triple-legged reproduction of the paper's octonion triple, plus the
+explicit G₂/color realization of their 3-set permutation.
+
+## Certification (3 legs)
+- **souc**: `tests/run-pass/sedenion_gresnigt_octonions.sio` → `GRESNIGT OK` (bin/souc AND stage2 agree).
+- **Python oracle**: `scripts/research/sedenion_gresnigt_octonions_oracle.py`; gate
+  `scripts/ci/sedenion_gresnigt_octonions_gate.sh`.
+- **Lean `native_decide`**: `formal/lean4/SounioSedenionGresnigtOctonions.lean` — `phi_automorphism`,
+  `phi_order_3`, `phi_fixes_quaternion_e8`, `phi_in_G2`, `phi_cycles_octonions`.
+
+## Reproduce
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_gresnigt_octonions.sio
+python3 scripts/research/sedenion_gresnigt_octonions_oracle.py
+bash scripts/ci/sedenion_gresnigt_octonions_gate.sh
+(cd formal/lean4 && lake build SounioSedenionGresnigtOctonions)
+```
+Source: Gresnigt NG, arXiv:2306.13098 (EPJC 2023); octonion triple + shared quaternion from §4 / App. A.

--- a/formal/lean4/SounioSedenionGresnigtOctonions.lean
+++ b/formal/lean4/SounioSedenionGresnigtOctonions.lean
@@ -1,0 +1,48 @@
+/-
+  SounioSedenionGresnigtOctonions — cross-check of Gresnigt's three generation-octonions (arXiv:2306.13098)
+  and an explicit G₂ (color-side) monomial automorphism permuting them, by Lean native_decide.
+  φ = (e₁e₂e₃)(e₅e₆e₇)(e₉e₁₀e₁₁)(e₁₃e₁₄e₁₅) [all signs +1] is a genuine order-3 automorphism of 𝕊
+  cycling 𝕆₁→𝕆₂→𝕆₃, fixing the shared quaternion {4,8,12} and e₈; and φ ∈ G₂ (its restriction to the
+  base octonion {1..7} is an octonion automorphism). This is NOT Gresnigt's family S₃ (Brown factor,
+  non-monomial, disjoint from G₂); it is a color-sector map. Not a physics bridge. Mathlib-free, no sorry.
+-/
+namespace SounioSedenionGresnigtOctonions
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def sg (a b : Nat) : Int := cdSigma a b 4
+
+def piL : List Nat := [0,2,3,1,4,6,7,5,8,10,11,9,12,14,15,13]
+def pi (i : Nat) : Nat := piL.getD i 0
+
+/-- φ is a genuine algebra automorphism of 𝕊: all 256 products (sign-free monomial condition). -/
+theorem phi_automorphism :
+    (List.range 16).all (fun i => (List.range 16).all (fun j =>
+      sg (pi i) (pi j) == sg i j && pi (i ^^^ j) == (pi i) ^^^ (pi j))) = true := by native_decide
+/-- φ has order 3 and moves something. -/
+theorem phi_order_3 :
+    (List.range 16).all (fun i => pi (pi (pi i)) == i) && (List.range 16).any (fun i => pi i != i) = true := by
+  native_decide
+/-- φ fixes the shared quaternion {4,8,12} and e₈. -/
+theorem phi_fixes_quaternion_e8 : (pi 4, pi 8, pi 12) = (4, 8, 12) := by native_decide
+/-- φ ∈ G₂: it preserves the base octonion {1..7} and restricts there to an octonion automorphism. -/
+theorem phi_in_G2 :
+    (List.range 7).all (fun i => 1 ≤ pi (i+1) && pi (i+1) ≤ 7)
+    && (List.range 8).all (fun i => (List.range 8).all (fun j => cdSigma (pi i) (pi j) 3 == cdSigma i j 3)) = true := by
+  native_decide
+/-- φ cyclically permutes Gresnigt's three octonions 𝕆₁→𝕆₂→𝕆₃. -/
+theorem phi_cycles_octonions :
+    (([1,4,5,8,9,12,13].map pi).all (fun x => x ∈ [2,4,6,8,10,12,14])
+     && ([2,4,6,8,10,12,14].map pi).all (fun x => x ∈ [3,4,7,8,11,12,15])) = true := by native_decide
+
+end SounioSedenionGresnigtOctonions

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -73,6 +73,9 @@ lean_lib «SounioZeroDivisorBridge» where
 lean_lib «SounioSedenionMeasurement» where
 
 @[default_target]
+lean_lib «SounioSedenionGresnigtOctonions» where
+
+@[default_target]
 lean_lib «SounioSedenionOctonionCensus» where
 
 -- Frente B vector 4/3: sedenion left-mult algebra = Cℓ(8) (peer-reviewed; Gresnigt).

--- a/scripts/ci/sedenion_gresnigt_octonions_gate.sh
+++ b/scripts/ci/sedenion_gresnigt_octonions_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: Gresnigt octonion triple + G2 (color-side) automorphism (Frente B vector 4/3).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/c.elf" >/dev/null 2>&1; chmod +x "$WORK/c.elf"; "$WORK/c.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/sedenion_gresnigt_octonions.sio | grep -E '^(AUT_OK|ORD3|FIX_|G2_|OCTS_|CYCLE_|GRESNIGT)' | sort > "$WORK/souc.txt"
+python3 scripts/research/sedenion_gresnigt_octonions_oracle.py | grep -E '^(AUT_OK|ORD3|FIX_|G2_|OCTS_|CYCLE_|GRESNIGT)' | sort > "$WORK/py.txt"
+diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt"; echo "gresnigt gate: FAIL"; exit 1; }
+grep -q '^GRESNIGT OK' "$WORK/souc.txt" || { echo "verdict != GRESNIGT OK"; echo "gresnigt gate: FAIL"; exit 1; }
+echo "CROSS-VERIFIED: Gresnigt's 3 octonions (ZD-free, ambient-equiv, shared quaternion {4,8,12})"
+echo "  cyclically permuted by an explicit G2 (color-side) monomial automorphism. NOT the family S3."
+echo "gresnigt gate: PASS"

--- a/scripts/research/sedenion_gresnigt_octonions_oracle.py
+++ b/scripts/research/sedenion_gresnigt_octonions_oracle.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Oracle: cross-check of Gresnigt's three generation-octonions + the G2 (color-side) monomial
+automorphism permuting them (Frente B, vector 4/3). NOT the family S3 (Brown factor); NOT a physics
+bridge. See docs/research/sedenion_gresnigt_octonions.md. Ref: Gresnigt arXiv:2306.13098."""
+from itertools import combinations
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH, bH, aL, bL = a >= half, b >= half, a & (half - 1), b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def antiL(i, j):
+    return all(cd_sigma(i, j ^ c) * cd_sigma(j, c) + cd_sigma(j, i ^ c) * cd_sigma(i, c) == 0
+               for c in range(16))
+
+
+def pprod(ul, uh, us, vl, vh, vs, k):
+    a = 0
+    if (ul ^ vl) == k: a += cd_sigma(ul, vl)
+    if (ul ^ vh) == k: a += vs * cd_sigma(ul, vh)
+    if (uh ^ vl) == k: a += us * cd_sigma(uh, vl)
+    if (uh ^ vh) == k: a += us * vs * cd_sigma(uh, vh)
+    return a
+
+
+def has_zd(S):
+    U = sorted(S)
+    prims = [(a, b, s) for a, b in combinations(U, 2) for s in (1, -1)]
+    for (ul, uh, us), (vl, vh, vs) in combinations(prims, 2):
+        if all(pprod(ul, uh, us, vl, vh, vs, k) == 0 for k in range(16)):
+            return True
+    return False
+
+
+def nonanti(S):
+    return sum(1 for i, j in combinations(sorted(S), 2) if not antiL(i, j))
+
+
+PI = [0, 2, 3, 1, 4, 6, 7, 5, 8, 10, 11, 9, 12, 14, 15, 13]
+O1 = {1, 4, 5, 8, 9, 12, 13}
+O2 = {2, 4, 6, 8, 10, 12, 14}
+O3 = {3, 4, 7, 8, 11, 12, 15}
+
+
+def main():
+    aut = 1 if all(cd_sigma(PI[i], PI[j]) == cd_sigma(i, j) and PI[i ^ j] == PI[i] ^ PI[j]
+                   for i in range(16) for j in range(16)) else 0
+    ord3 = 1 if (all(PI[PI[PI[i]]] == i for i in range(16)) and any(PI[i] != i for i in range(16))) else 0
+    fixes = 1 if (PI[8] == 8 and PI[4] == 4 and PI[12] == 12) else 0
+    g2 = 1 if (all(1 <= PI[i] <= 7 for i in range(1, 8))
+               and all(cd_sigma(PI[i], PI[j], 3) == cd_sigma(i, j, 3) for i in range(8) for j in range(8))) else 0
+    octs = 1 if all(not has_zd(S) and nonanti(S) == 6 for S in (O1, O2, O3)) else 0
+    img = lambda S: set(PI[x] for x in S)
+    cyc = 1 if (img(O1) == O2 and img(O2) == O3) else 0
+    print(f"AUT_OK {aut}")
+    print(f"ORD3 {ord3}")
+    print(f"FIX_QH_E8 {fixes}")
+    print(f"G2_DIAGONAL {g2}")
+    print(f"OCTS_ZDFREE_NA6 {octs}")
+    print(f"CYCLE_O1O2O3 {cyc}")
+    print(f"GRESNIGT {'OK' if aut and ord3 and fixes and g2 and octs and cyc else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_gresnigt_octonions.sio
+++ b/tests/run-pass/sedenion_gresnigt_octonions.sio
@@ -1,0 +1,243 @@
+//@ run-pass
+//@ expect-stdout: GRESNIGT OK
+// FRENTE B, vector 4/3 — cross-check of Gresnigt's three generation-octonions + an explicit G₂
+// (COLOR-side) monomial automorphism permuting them. Executed against the primary source.
+//
+// Gresnigt (EPJC 2019/2024; arXiv:2306.13098) builds three fermion generations from three octonion
+// subalgebras of the sedenions 𝕊 sharing a common quaternion, cyclically related by the family S₃.
+// The paper's three copies (its basis, App. A) are, as index sets:
+//   𝕆₁ = {1,4,5,8,9,12,13},  𝕆₂ = {2,4,6,8,10,12,14},  𝕆₃ = {3,4,7,8,11,12,15},
+//   sharing the quaternion ℍ = ⟨e₄,e₈,e₁₂⟩ = {4,8,12}.
+// This test certifies, in this repo's Cayley-Dickson convention:
+//   (a) each 𝕆_i is a genuine (zero-divisor-free) octonion, all three ambient-equivalent (each has 6
+//       non-anticommuting internal left-mult pairs in the 16-dim Cℓ(8));  ℍ = 𝕆₁∩𝕆₂∩𝕆₃ = {4,8,12};
+//   (b) the pure 3-cycle φ = (e₁e₂e₃)(e₅e₆e₇)(e₉e₁₀e₁₁)(e₁₃e₁₄e₁₅) [all signs +1, fixing e₀,e₄,e₈,e₁₂]
+//       is a genuine algebra automorphism of 𝕊 (all 256 products), of order 3, cyclically permuting
+//       𝕆₁→𝕆₂→𝕆₃ and fixing ℍ and e₈;
+//   (c) φ = g ⊕ g is DIAGONAL under 𝕊 = 𝕆 ⊕ 𝕆·e₈ with g = (e₁e₂e₃)(e₅e₆e₇) an automorphism of the base
+//       octonion {e₁..e₇} — so φ ∈ G₂ = Aut(𝕆).
+//
+// HONEST BOUNDARY (this is NOT a physics bridge). Because φ ∈ G₂ and G₂ ⊃ SU(3)_color, φ is a
+// COLOR-sector operation. It is NOT Gresnigt's family S₃: by Brown's theorem Aut(𝕊)=G₂×S₃, and the
+// family S₃ is precisely the direct factor DISJOINT from G₂ (non-monomial) — used exactly so that
+// family ≠ color. This brick therefore does NOT connect the zero-divisor monomial-168 to fermion
+// generations, and does NOT amend Erratum E1 (which correctly places the monomial-168 inside G₂). It
+// reproduces the paper's octonion triple and exhibits the G₂/color realization of their 3-set
+// permutation — nothing more. A genuine bridge would require building the fermion ideals and showing
+// Brown's S₃ acts on those states as a monomial-168 element; that is not done here.
+//
+// Decidable integer arithmetic, no float. SELF-CONTAINED. Cross-verified vs the oracle by the gate + Lean.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+fn sg(a: i64, b: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, b, 4) }
+fn antiL(i: i64, j: i64) -> bool with Mut, Panic, Div {
+    var c = 0
+    while c < 16 {
+        if sg(i, j ^ c) * sg(j, c) + sg(j, i ^ c) * sg(i, c) != 0 { return false }
+        c = c + 1
+    }
+    true
+}
+fn pprod(ulo: i64, uhi: i64, us: i64, vlo: i64, vhi: i64, vs: i64, k: i64) -> i64 with Mut, Panic, Div {
+    var acc = 0
+    if (ulo ^ vlo) == k { acc = acc + sg(ulo, vlo) }
+    if (ulo ^ vhi) == k { acc = acc + vs * sg(ulo, vhi) }
+    if (uhi ^ vlo) == k { acc = acc + us * sg(uhi, vlo) }
+    if (uhi ^ vhi) == k { acc = acc + us * vs * sg(uhi, vhi) }
+    acc
+}
+fn zero_pair(ulo: i64, uhi: i64, us: i64, vlo: i64, vhi: i64, vs: i64) -> bool with Mut, Panic, Div {
+    var k = 0
+    while k < 16 {
+        if pprod(ulo, uhi, us, vlo, vhi, vs, k) != 0 { return false }
+        k = k + 1
+    }
+    true
+}
+fn oct_zdfree_and_nonanti6(u0: i64, u1: i64, u2: i64, u3: i64, u4: i64, u5: i64, u6: i64) -> bool with Mut, Panic, Div {
+    var u = [0; 7]
+    u[0 as usize] = u0
+    u[1 as usize] = u1
+    u[2 as usize] = u2
+    u[3 as usize] = u3
+    u[4 as usize] = u4
+    u[5 as usize] = u5
+    u[6 as usize] = u6
+    // ZD-free: no annihilating primitive pair
+    var a = 0
+    while a < 7 {
+        var b = a + 1
+        while b < 7 {
+            var us = 0 - 1
+            while us <= 1 {
+                if us != 0 {
+                    var cc = 0
+                    while cc < 7 {
+                        var dd = cc + 1
+                        while dd < 7 {
+                            var vs = 0 - 1
+                            while vs <= 1 {
+                                if vs != 0 {
+                                    if zero_pair(u[a as usize], u[b as usize], us, u[cc as usize], u[dd as usize], vs) {
+                                        return false
+                                    }
+                                }
+                                vs = vs + 1
+                            }
+                            dd = dd + 1
+                        }
+                        cc = cc + 1
+                    }
+                }
+                us = us + 1
+            }
+            b = b + 1
+        }
+        a = a + 1
+    }
+    // nonanti == 6
+    var non = 0
+    a = 0
+    while a < 7 {
+        var b = a + 1
+        while b < 7 {
+            if !antiL(u[a as usize], u[b as usize]) { non = non + 1 }
+            b = b + 1
+        }
+        a = a + 1
+    }
+    non == 6
+}
+
+fn main() with IO, Mut, Panic, Div {
+    // the 3-cycle phi (all signs +1): index permutation
+    var pi = [0; 16]
+    pi[0 as usize] = 0
+    pi[1 as usize] = 2
+    pi[2 as usize] = 3
+    pi[3 as usize] = 1
+    pi[4 as usize] = 4
+    pi[5 as usize] = 6
+    pi[6 as usize] = 7
+    pi[7 as usize] = 5
+    pi[8 as usize] = 8
+    pi[9 as usize] = 10
+    pi[10 as usize] = 11
+    pi[11 as usize] = 9
+    pi[12 as usize] = 12
+    pi[13 as usize] = 14
+    pi[14 as usize] = 15
+    pi[15 as usize] = 13
+
+    // (b) phi is an algebra automorphism (all 256 products): sign-free monomial condition
+    //     sg(pi i, pi j) == sg(i,j)  AND  pi(i^j) == pi(i)^pi(j).
+    var aut_ok = 1
+    var i = 0
+    while i < 16 {
+        var j = 0
+        while j < 16 {
+            if sg(pi[i as usize], pi[j as usize]) != sg(i, j) { aut_ok = 0 }
+            if pi[(i ^ j) as usize] != (pi[i as usize] ^ pi[j as usize]) { aut_ok = 0 }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    // order 3
+    var ord3 = 1
+    var moved = 0
+    i = 0
+    while i < 16 {
+        if pi[pi[pi[i as usize] as usize] as usize] != i { ord3 = 0 }
+        if pi[i as usize] != i { moved = 1 }
+        i = i + 1
+    }
+    // fixes e8 and the quaternion {4,8,12}
+    var fixes = 1
+    if pi[8 as usize] != 8 { fixes = 0 }
+    if pi[4 as usize] != 4 { fixes = 0 }
+    if pi[12 as usize] != 12 { fixes = 0 }
+    // (c) g in G2: phi preserves the base octonion {1..7}, and there g is an octonion automorphism.
+    var g2 = 1
+    i = 1
+    while i <= 7 {
+        if pi[i as usize] < 1 || pi[i as usize] > 7 { g2 = 0 }
+        i = i + 1
+    }
+    // g = phi|{1..7} is an automorphism of O (octonion sigma bits=3)
+    i = 0
+    while i < 8 {
+        var j = 0
+        while j < 8 {
+            if cd_sigma_c(pi[i as usize], pi[j as usize], 3) != cd_sigma_c(i, j, 3) { g2 = 0 }
+            j = j + 1
+        }
+        i = i + 1
+    }
+
+    // (a) each O_i is a ZD-free octonion with nonanti==6
+    let o1 = oct_zdfree_and_nonanti6(1, 4, 5, 8, 9, 12, 13)
+    let o2 = oct_zdfree_and_nonanti6(2, 4, 6, 8, 10, 12, 14)
+    let o3 = oct_zdfree_and_nonanti6(3, 4, 7, 8, 11, 12, 15)
+    var octs_ok = 0
+    if o1 && o2 && o3 { octs_ok = 1 }
+    // phi cycles O1 -> O2 -> O3 (setwise, via membership masks)
+    var m1 = 0
+    var m2 = 0
+    var m3 = 0
+    m1 = (1<<1)|(1<<4)|(1<<5)|(1<<8)|(1<<9)|(1<<12)|(1<<13)
+    m2 = (1<<2)|(1<<4)|(1<<6)|(1<<8)|(1<<10)|(1<<12)|(1<<14)
+    m3 = (1<<3)|(1<<4)|(1<<7)|(1<<8)|(1<<11)|(1<<12)|(1<<15)
+    // image of a mask under pi
+    var im1 = 0
+    var im2 = 0
+    var b = 1
+    while b <= 15 {
+        if (m1 & (1 << b)) != 0 { im1 = im1 | (1 << pi[b as usize]) }
+        if (m2 & (1 << b)) != 0 { im2 = im2 | (1 << pi[b as usize]) }
+        b = b + 1
+    }
+    var cyc_ok = 0
+    if im1 == m2 && im2 == m3 { cyc_ok = 1 }
+
+    print("AUT_OK ")
+    print_int(aut_ok as i64)
+    print("\n")
+    print("ORD3 ")
+    print_int((ord3 & moved) as i64)
+    print("\n")
+    print("FIX_QH_E8 ")
+    print_int(fixes as i64)
+    print("\n")
+    print("G2_DIAGONAL ")
+    print_int(g2 as i64)
+    print("\n")
+    print("OCTS_ZDFREE_NA6 ")
+    print_int(octs_ok as i64)
+    print("\n")
+    print("CYCLE_O1O2O3 ")
+    print_int(cyc_ok as i64)
+    print("\n")
+    // Gresnigt's octonion triple reproduced; phi is a G₂ (color-side) monomial automorphism cycling
+    // them. NOT the family S₃ (Brown factor, non-monomial). NOT a bridge. E1 stands.
+    if aut_ok == 1 && ord3 == 1 && moved == 1 && fixes == 1 && g2 == 1 && octs_ok == 1 && cyc_ok == 1 {
+        println("GRESNIGT OK")
+    } else {
+        println("GRESNIGT FAIL")
+    }
+}


### PR DESCRIPTION
Fetched the primary source (Gresnigt arXiv:2306.13098) and reproduced its three generation-octonions in this repo's convention: **O1/O2/O3** (ZD-free, ambient-equivalent nonanti=6, shared quaternion {4,8,12}), plus the explicit order-3 monomial automorphism φ=(e1e2e3)(e5e6e7)(e9e10e11)(e13e14e15) cycling them (verified on 256 products), with φ=g⊕g diagonal ⟹ **φ ∈ G2**.

**Honest boundary (adversarial review caught an over-correction):** φ ∈ G2 ⊃ SU(3)_color, so φ is a **color-sector** map — NOT Gresnigt's family S3 (Brown factor, non-monomial, disjoint from G2). This is **not** a bridge from the ZD monomial-168 to generations and does **not** amend Erratum E1 (which correctly places the monomial-168 in G2). A real bridge needs the fermion ideals + Brown's S3 acting on states as a monomial-168 element — not done. 3 legs (souc bin+stage2 / Python oracle / Lean native_decide, 5 theorems).