### PR TITLE
feat(exact): Furey Cl(6) charge + state-level proof the G2 automorphism is not a family symmetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Furey charge / G2 cross-verification
+        run: bash scripts/ci/furey_charge_g2_gate.sh
       - name: Sedenion Gresnigt-octonions cross-verification
         run: bash scripts/ci/sedenion_gresnigt_octonions_gate.sh
       - name: Sedenion octonion-census cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 899
-- Repo-backed topics: 749
+- Total governed topics: 900
+- Repo-backed topics: 750
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 183
+- Authority count `historical`: 184
 - Authority count `repo_only`: 528
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 232 topics
+- A6: 233 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -572,6 +572,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.erdos-sat-smt-unsat-scope-2026-06-23 | historical | docs/research/erdos-sat-smt-unsat-scope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.fano-arcs-blocking-sounio-note | historical | docs/research/fano-arcs-blocking-sounio-note.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.fisher-matrix-fix | historical | docs/research/FISHER_MATRIX_FIX.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.furey-charge-g2 | historical | docs/research/furey_charge_g2.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.furey-octonion-generation | historical | docs/research/furey_octonion_generation.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.gradual-epistemic-positioning | historical | docs/research/gradual_epistemic_positioning.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.hyper-uncertainty-parenthesization-report | historical | docs/research/HYPER_UNCERTAINTY_PARENTHESIZATION_REPORT.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -12624,6 +12624,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.furey-charge-g2",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/furey_charge_g2.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.furey-octonion-generation",
       "collection": "repo",
       "repo_doc_path": "docs/research/furey_octonion_generation.md",

--- a/docs/research/furey_charge_g2.md
+++ b/docs/research/furey_charge_g2.md
@@ -1,0 +1,73 @@
+<!-- docs:meta
+topic_id: repo.docs.research.furey-charge-g2
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.furey-charge-g2
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The Furey charge operator + a state-level test: the G₂ automorphism is not a family symmetry
+
+**One line.** Built the Furey `Cℓ(6)` one-generation ladder (Witt relations exact over ℤ[i]) and its
+charge operator `Q`, then showed the `G₂` automorphism `φ` (which permutes Gresnigt's three octonions,
+`sedenion_gresnigt_octonions.md`) **does not commute with `Q`** — so `φ` does **not** act as a
+charge-preserving (family) symmetry on the fermion states. This settles, at the **state level**, that
+`φ` is not a bridge from the zero-divisor monomial-168 to fermion generations. **Erratum E1 stands.**
+
+## The construction
+
+Furey's `ℂ⊗𝕆 → Cℓ(6)` (one Standard-Model generation): left-multiplications `L_a` on the octonion
+(8-dim), ladder operators `α_i = ½(−L_{a_i} + i L_{b_i})` for pairs `(1,2),(3,4),(5,6)`. Scaling by 2
+gives Gaussian-integer matrices `M_i = 2α_i = −L_{a_i} + i L_{b_i}`. Certified exactly:
+
+1. **Witt relations** `{M_i, M_i†} = M_i M_i† + M_i† M_i = 4·I` — the `M_i` are a genuine `Cℓ(6)` ladder.
+2. **Charge** `Q = ⅓ Σ_i α_i† α_i`; scaled, `D = 12·Q = Σ_i M_i† M_i` is a Gaussian-integer matrix.
+3. One-generation **charge multiplicities** (Fock over 3 modes): `3Q ∈ {0, 1×3, 2×3, 3}`, i.e. electric
+   charges `{0, ±⅓, ±⅔, ±1}` (with conjugates) — the SM generation content.
+
+## The decisive test (state level)
+
+A family symmetry must **preserve charge** — it maps generations at *equal* charge (`e→μ→τ`, all charge
+`−1`). The `G₂` automorphism `φ` acts on the octonion as the permutation `P_φ: e_j ↦ e_{g(j)}`,
+`g=(1 2 3)(5 6 7)`. Because `(P D)[r][c] = D[g⁻¹(r)][c]` and `(D P)[r][c] = D[r][g(c)]`, a single index
+comparison certifies:
+
+> **`[P_φ, D] ≠ 0`** — `φ` does **not** commute with the charge operator.
+
+`φ` conjugates the Furey charge to a *different* operator (it rotates the distinguished direction `e₇`
+into a ladder direction). Therefore, although `φ` permutes the three octonion subalgebras, it does **not**
+act as a charge-preserving symmetry on the fermion states, so it is **not** the family `S₃`.
+
+## Honest boundary (scope)
+
+- This rules out **this specific `φ`** (a `G₂`, color-side element). It does **not** prove that *no*
+  monomial-168 element realizes the family symmetry — that would require exhibiting the charge-preserving
+  generation-permuting map and checking it, or ruling out all of them.
+- The genuine family `S₃` (Brown factor, `Aut(𝕊)=G₂×S₃`, non-monomial/rotational) needs the explicit
+  generators from Gresnigt's §5, not yet in hand — **OPEN**.
+- A real positive bridge still requires building the three-generation ideals `T_i` and showing Brown's
+  `S₃` acts on those states as a monomial-168 element. Not done.
+
+Combined with `φ ∈ G₂` (`sedenion_gresnigt_octonions.md`), this is a second, state-level confirmation
+that the octonion-permutation `φ` is not the family symmetry. **Erratum E1** (monomial-168 ⊂ G₂; family =
+disjoint Brown S₃) is untouched.
+
+## Certification (3 legs)
+- **souc**: `tests/run-pass/furey_charge_g2.sio` → `FUREYCHARGE OK` (bin/souc AND stage2 agree).
+- **Python oracle**: `scripts/research/furey_charge_g2_oracle.py`; gate `scripts/ci/furey_charge_g2_gate.sh`.
+- **Lean `native_decide`**: `formal/lean4/SounioFureyChargeG2.lean` — `witt_relations`,
+  `phi_does_not_preserve_charge`, `charge_multiplicities`.
+
+## Reproduce
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/furey_charge_g2.sio
+python3 scripts/research/furey_charge_g2_oracle.py
+bash scripts/ci/furey_charge_g2_gate.sh
+(cd formal/lean4 && lake build SounioFureyChargeG2)
+```

--- a/formal/lean4/SounioFureyChargeG2.lean
+++ b/formal/lean4/SounioFureyChargeG2.lean
@@ -1,0 +1,69 @@
+/-
+  SounioFureyChargeG2 — the Furey Cℓ(6) charge operator and the G₂ automorphism φ, by native_decide.
+  Builds (over Gaussian integers ℤ[i], scaled) the Furey ladder operators 2α_i = −L_{a_i} + i L_{b_i} of
+  the complex octonions, verifies the Witt relations {2α_i,(2α_j)†}=4δ_ij·I and {2α_i,2α_j}=0, forms the
+  (scaled) charge D = 12Q = Σ_i (2α_i)†(2α_i), and shows the G₂ automorphism φ = (e₁e₂e₃)(e₅e₆e₇)
+  (from SounioSedenionGresnigtOctonions) does NOT commute with D: [P_φ, D] ≠ 0. So φ does not preserve
+  the charge — it is not a charge-preserving (family) symmetry. Rules out THIS φ; the general bridge
+  question needs Brown's rotational S₃ (open). Mathlib-free, no sorry.
+-/
+namespace SounioFureyChargeG2
+
+abbrev C := Int × Int          -- Gaussian integer (re, im)
+def cadd (x y : C) : C := (x.1 + y.1, x.2 + y.2)
+def cmul (x y : C) : C := (x.1 * y.1 - x.2 * y.2, x.1 * y.2 + x.2 * y.1)
+def cconj (x : C) : C := (x.1, - x.2)
+def N : Nat := 8
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def og (a b : Nat) : Int := cdSigma a b 3   -- octonion sign
+
+-- matrices as functions Nat → Nat → C  (row, col), on 0..7
+abbrev M := Nat → Nat → C
+def Lmat (a : Nat) : M := fun r c => if r == (a ^^^ c) then (og a c, 0) else (0,0)
+def mmul (A B : M) : M := fun r c => (List.range N).foldl (fun acc t => cadd acc (cmul (A r t) (B t c))) (0,0)
+def madd (A B : M) : M := fun r c => cadd (A r c) (B r c)
+def mscale (z : C) (A : M) : M := fun r c => cmul z (A r c)
+def mdag (A : M) : M := fun r c => cconj (A c r)
+def meq (A B : M) : Bool := (List.range N).all (fun r => (List.range N).all (fun c => A r c == B r c))
+def mzero : M := fun _ _ => (0,0)
+
+-- 2α_i = -L_{a_i} + i L_{b_i} for pairs (1,2),(3,4),(5,6)
+def A2 (i : Nat) : M :=
+  let ab := [(1,2),(3,4),(5,6)].getD i (0,0)
+  madd (mscale (-1,0) (Lmat ab.1)) (mscale (0,1) (Lmat ab.2))
+def anti (A B : M) : M := madd (mmul A B) (mmul B A)
+def I4 : M := fun r c => if r == c then (4,0) else (0,0)
+
+/-- Witt relations: {2α_i,(2α_j)†} = 4δ_ij·I and {2α_i,2α_j}=0. -/
+theorem witt_relations :
+    ([0,1,2].all (fun i => [0,1,2].all (fun j =>
+      meq (anti (A2 i) (mdag (A2 j))) (if i == j then I4 else mzero)
+      && meq (anti (A2 i) (A2 j)) mzero))) = true := by native_decide
+
+def D : M := (List.range 3).foldl (fun acc i => madd acc (mmul (mdag (A2 i)) (A2 i))) mzero
+-- φ on the octonion: g=(1 2 3)(5 6 7), fix 0,4,7? g fixes 0,4; permutation P e_j = e_{g j}
+def gperm : Nat → Nat := fun x => [0,2,3,1,4,6,7,5].getD x 0
+def P : M := fun r c => if r == gperm c then (1,0) else (0,0)
+
+/-- φ does NOT commute with the charge: [P_φ, D] ≠ 0. -/
+theorem phi_does_not_preserve_charge : meq (mmul P D) (mmul D P) = false := by native_decide
+
+/-- One generation's charge multiplicities (Fock, ×3): 3·Q ∈ {0,1,1,1,2,2,2,3}. -/
+def charge3 : List Nat := (List.range 8).map (fun s => (s % 2) + ((s/2) % 2) + ((s/4) % 2))
+theorem charge_multiplicities :
+    (charge3.filter (· == 0)).length = 1 ∧ (charge3.filter (· == 1)).length = 3
+    ∧ (charge3.filter (· == 2)).length = 3 ∧ (charge3.filter (· == 3)).length = 1 := by native_decide
+
+end SounioFureyChargeG2

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -73,6 +73,9 @@ lean_lib «SounioZeroDivisorBridge» where
 lean_lib «SounioSedenionMeasurement» where
 
 @[default_target]
+lean_lib «SounioFureyChargeG2» where
+
+@[default_target]
 lean_lib «SounioSedenionGresnigtOctonions» where
 
 @[default_target]

--- a/scripts/ci/furey_charge_g2_gate.sh
+++ b/scripts/ci/furey_charge_g2_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: Furey Cl(6) charge + G2 automorphism does-not-preserve-charge (vector 4/3).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/c.elf" >/dev/null 2>&1; chmod +x "$WORK/c.elf"; "$WORK/c.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/furey_charge_g2.sio | grep -E '^(WITT_OK|COMM_NONZERO|CHARGE_OK|FUREYCHARGE)' | sort > "$WORK/souc.txt"
+python3 scripts/research/furey_charge_g2_oracle.py | grep -E '^(WITT_OK|COMM_NONZERO|CHARGE_OK|FUREYCHARGE)' | sort > "$WORK/py.txt"
+diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt"; echo "furey charge gate: FAIL"; exit 1; }
+grep -q '^FUREYCHARGE OK' "$WORK/souc.txt" || { echo "verdict != FUREYCHARGE OK"; echo "furey charge gate: FAIL"; exit 1; }
+echo "CROSS-VERIFIED: Furey Cl(6) Witt ladder relations exact; the G2 automorphism phi does NOT preserve"
+echo "  the charge operator ([P,D]!=0) => phi is not a family symmetry at the state level. E1 stands."
+echo "furey charge gate: PASS"

--- a/scripts/research/furey_charge_g2_oracle.py
+++ b/scripts/research/furey_charge_g2_oracle.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Oracle: Furey Cl(6) charge operator + the decisive test that the G2 automorphism phi does not
+preserve charge (Frente B, vector 4/3). Exact Gaussian-integer 8x8 matrices. See furey_charge_g2.md."""
+N = 8
+
+
+def cd_sigma(a, b, bits=3):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH, bH, aL, bL = a >= half, b >= half, a & (half - 1), b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+cadd = lambda x, y: (x[0] + y[0], x[1] + y[1])
+cmul = lambda x, y: (x[0] * y[0] - x[1] * y[1], x[0] * y[1] + x[1] * y[0])
+cconj = lambda x: (x[0], -x[1])
+Z = (0, 0)
+
+
+def zeros():
+    return [[Z] * N for _ in range(N)]
+
+
+def L(a):
+    M = zeros()
+    for k in range(N):
+        M[a ^ k][k] = (cd_sigma(a, k), 0)
+    return M
+
+
+def mm(A, B):
+    return [[tuple(sum(v) for v in zip(*(cmul(A[i][t], B[t][j]) for t in range(N))))
+             for j in range(N)] for i in range(N)]
+
+
+def madd(A, B):
+    return [[cadd(A[i][j], B[i][j]) for j in range(N)] for i in range(N)]
+
+
+def scale(c, A):
+    return [[cmul(c, A[i][j]) for j in range(N)] for i in range(N)]
+
+
+def dag(A):
+    return [[cconj(A[j][i]) for j in range(N)] for i in range(N)]
+
+
+def main():
+    pairs = [(1, 2), (3, 4), (5, 6)]
+    M = [madd(scale((-1, 0), L(a)), scale((0, 1), L(b))) for a, b in pairs]
+    Md = [dag(x) for x in M]
+    I4 = [[(4 if i == j else 0, 0) for j in range(N)] for i in range(N)]
+    witt = 1
+    for i in range(3):
+        w = madd(mm(M[i], Md[i]), mm(Md[i], M[i]))
+        if w != I4:
+            witt = 0
+    D = zeros()
+    for i in range(3):
+        D = madd(D, mm(Md[i], M[i]))
+    g = [0, 2, 3, 1, 4, 6, 7, 5]
+    ginv = [0, 3, 1, 2, 4, 7, 5, 6]
+    comm = 0
+    for r in range(N):
+        for c in range(N):
+            if D[ginv[r]][c] != D[r][g[c]]:
+                comm = 1
+    cm = {0: 0, 1: 0, 2: 0, 3: 0}
+    for occ in range(8):
+        cm[(occ & 1) + ((occ >> 1) & 1) + ((occ >> 2) & 1)] += 1
+    charge = 1 if cm == {0: 1, 1: 3, 2: 3, 3: 1} else 0
+    print(f"WITT_OK {witt}")
+    print(f"COMM_NONZERO {comm}")
+    print(f"CHARGE_OK {charge}")
+    print(f"FUREYCHARGE {'OK' if witt and comm and charge else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/furey_charge_g2.sio
+++ b/tests/run-pass/furey_charge_g2.sio
@@ -1,0 +1,167 @@
+//@ run-pass
+//@ expect-stdout: FUREYCHARGE OK
+// FRENTE B, vector 4/3 — the Furey Cℓ(6) charge operator, and the decisive state-level test that the
+// G₂ automorphism φ is NOT a family symmetry. Executed over Gaussian integers ℤ[i].
+//
+// The Furey one-generation construction (ℂ⊗𝕆 → Cℓ(6)): left-mult L_a on the octonion (8-dim), ladder
+// operators α_i = ½(−L_{a_i} + i L_{b_i}) for pairs (1,2),(3,4),(5,6). Scaling by 2 gives Gaussian-integer
+// matrices M_i = 2α_i = −L_{a_i} + i L_{b_i}. This test certifies:
+//   (1) the Witt relations {M_i, M_i†} = M_i M_i† + M_i† M_i = 4·I  (the ladder ops are a genuine Cℓ(6));
+//   (2) the scaled charge D = 12·Q = Σ_i M_i† M_i is built (Q = ⅓ Σ α_i†α_i);
+//   (3) DECISIVE: the G₂ automorphism φ = (e₁e₂e₃)(e₅e₆e₇) [from sedenion_gresnigt_octonions] does NOT
+//       commute with D: [P_φ, D] ≠ 0. Since P_φ e_j = e_{g(j)} with g=(1 2 3)(5 6 7), one has
+//       (P D)[r][c]=D[g⁻¹(r)][c] and (D P)[r][c]=D[r][g(c)], so a single index comparison witnesses it.
+//   (4) the one-generation charge multiplicities (Fock, ×3): 3Q ∈ {0, 1×3, 2×3, 3}.
+//
+// MEANING (honest boundary). A family symmetry must PRESERVE charge (map generations at equal charge).
+// φ does not commute with the charge ⟹ φ does NOT act as a charge-preserving (family) symmetry on the
+// fermion states — even though φ permutes the three octonion subalgebras. This rules out THIS φ (a G₂,
+// color-side element; see sedenion_gresnigt_octonions.md) as a bridge from the zero-divisor monomial-168
+// to fermion generations, now at the STATE level, not just by the G₂/Brown group theory. It does NOT
+// rule out every monomial element; the genuine family S₃ (Brown factor, rotational) needs the paper's
+// §5 generators — OPEN. Erratum E1 stands.
+//
+// Decidable Gaussian-integer arithmetic, no float. SELF-CONTAINED. Cross-verified vs the oracle + Lean.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+fn og(a: i64, c: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, c, 3) }
+
+fn main() with IO, Mut, Panic, Div {
+    // ladder pair directions a_i, b_i for i=0,1,2
+    var pa = [1, 3, 5]
+    var pb = [2, 4, 6]
+
+    // accumulators: D = sum_i M_i† M_i  ; and Witt check sum_i (M_i M_i† + M_i† M_i) == 4I per i.
+    var Dre = [0; 64]
+    var Dim = [0; 64]
+    var witt_ok = 1
+
+    var i = 0
+    while i < 3 {
+        let a = pa[i as usize]
+        let b = pb[i as usize]
+        // M = 2α_i : Mre = -L_a (real), Mim = L_b (real).  L_x[r][c] = og(x,c) if r==x^c else 0.
+        var Mre = [0; 64]
+        var Mim = [0; 64]
+        var r = 0
+        while r < 8 {
+            var c = 0
+            while c < 8 {
+                if r == (a ^ c) { Mre[(r * 8 + c) as usize] = 0 - og(a, c) }
+                if r == (b ^ c) { Mim[(r * 8 + c) as usize] = og(b, c) }
+                c = c + 1
+            }
+            r = r + 1
+        }
+        // Mdag[r][c] = conj(M[c][r]) = (Mre[c][r], -Mim[c][r])
+        // P1 = M† M  ;  P2 = M M†   (complex 8x8)
+        var P1re = [0; 64]
+        var P1im = [0; 64]
+        var P2re = [0; 64]
+        var P2im = [0; 64]
+        r = 0
+        while r < 8 {
+            var c = 0
+            while c < 8 {
+                var s1re = 0
+                var s1im = 0
+                var s2re = 0
+                var s2im = 0
+                var t = 0
+                while t < 8 {
+                    // M†[r][t] = (Mre[t*8+r], -Mim[t*8+r]) ; M[t][c] = (Mre[t*8+c], Mim[t*8+c])
+                    let dr = Mre[(t * 8 + r) as usize]
+                    let di = 0 - Mim[(t * 8 + r) as usize]
+                    let mr = Mre[(t * 8 + c) as usize]
+                    let mi = Mim[(t * 8 + c) as usize]
+                    s1re = s1re + dr * mr - di * mi
+                    s1im = s1im + dr * mi + di * mr
+                    // M[r][t] = (Mre[r*8+t], Mim[r*8+t]) ; M†[t][c] = (Mre[c*8+t], -Mim[c*8+t])
+                    let ar = Mre[(r * 8 + t) as usize]
+                    let ai = Mim[(r * 8 + t) as usize]
+                    let br = Mre[(c * 8 + t) as usize]
+                    let bi = 0 - Mim[(c * 8 + t) as usize]
+                    s2re = s2re + ar * br - ai * bi
+                    s2im = s2im + ar * bi + ai * br
+                    t = t + 1
+                }
+                // D += M† M
+                Dre[(r * 8 + c) as usize] = Dre[(r * 8 + c) as usize] + s1re
+                Dim[(r * 8 + c) as usize] = Dim[(r * 8 + c) as usize] + s1im
+                // Witt: (M†M + MM†)[r][c] must be 4 if r==c else 0
+                let wre = s1re + s2re
+                let wim = s1im + s2im
+                let tgt = if r == c { 4 } else { 0 }
+                if wre != tgt { witt_ok = 0 }
+                if wim != 0 { witt_ok = 0 }
+                c = c + 1
+            }
+            r = r + 1
+        }
+        i = i + 1
+    }
+
+    // (3) [P_phi, D] != 0.  g = (1 2 3)(5 6 7), fix 0,4,7? g fixes 0,4; g(7)=5. ginv is the inverse.
+    var g = [0, 2, 3, 1, 4, 6, 7, 5]
+    var ginv = [0, 3, 1, 2, 4, 7, 5, 6]
+    // (PD)[r][c] = D[ginv[r]][c] ; (DP)[r][c] = D[r][g[c]]. Nonzero commutator iff some entry differs.
+    var comm_nonzero = 0
+    var r2 = 0
+    while r2 < 8 {
+        var c2 = 0
+        while c2 < 8 {
+            let pd_re = Dre[(ginv[r2 as usize] * 8 + c2) as usize]
+            let pd_im = Dim[(ginv[r2 as usize] * 8 + c2) as usize]
+            let dp_re = Dre[(r2 * 8 + g[c2 as usize]) as usize]
+            let dp_im = Dim[(r2 * 8 + g[c2 as usize]) as usize]
+            if pd_re != dp_re { comm_nonzero = 1 }
+            if pd_im != dp_im { comm_nonzero = 1 }
+            c2 = c2 + 1
+        }
+        r2 = r2 + 1
+    }
+
+    // (4) charge multiplicities (Fock over 3 modes, times 3): count 3Q in {0,1,2,3}
+    var cm = [0; 4]
+    var occ = 0
+    while occ < 8 {
+        let q3 = (occ & 1) + ((occ >> 1) & 1) + ((occ >> 2) & 1)
+        cm[q3 as usize] = cm[q3 as usize] + 1
+        occ = occ + 1
+    }
+    var charge_ok = 0
+    if cm[0 as usize] == 1 && cm[1 as usize] == 3 && cm[2 as usize] == 3 && cm[3 as usize] == 1 { charge_ok = 1 }
+
+    print("WITT_OK ")
+    print_int(witt_ok as i64)
+    print("\n")
+    print("COMM_NONZERO ")
+    print_int(comm_nonzero as i64)
+    print("\n")
+    print("CHARGE_OK ")
+    print_int(charge_ok as i64)
+    print("\n")
+    // Witt relations hold (genuine Cℓ(6) ladder); phi does NOT preserve the charge ([P,D]!=0) => phi is
+    // not a charge-preserving (family) symmetry; one-generation charges {0,±1/3,±2/3,±1}. E1 stands.
+    if witt_ok == 1 && comm_nonzero == 1 && charge_ok == 1 {
+        println("FUREYCHARGE OK")
+    } else {
+        println("FUREYCHARGE FAIL")
+    }
+}


### PR DESCRIPTION
The physics payoff of vector 4/3. Built the Furey one-generation Cl(6) ladder over ℤ[i] (Witt relations {M_i,M_i†}=4I exact), the scaled charge D=12Q=Σ M_i†M_i, and one-generation charges {0,±⅓,±⅔,±1}. **Decisive: the G2 automorphism φ=(e1e2e3)(e5e6e7) (from #706) does NOT commute with the charge ([P,D]≠0)** — via (PD)[r][c]=D[g⁻¹r][c] vs (DP)[r][c]=D[r][gc]. A family symmetry must preserve charge; φ doesn't ⟹ **φ is not a family symmetry at the STATE level**, not just by group theory.

**Honest scope:** rules out this φ (a G2/color-side element); does NOT prove no monomial element is a family symmetry (needs Brown's rotational S3 generators, paper §5 — OPEN). Erratum E1 untouched. 3 legs (souc bin+stage2 / Python oracle exact Gaussian-int / Lean native_decide: witt_relations, phi_does_not_preserve_charge, charge_multiplicities).