### PR TITLE
fix(native): emit builtins referenced only transitively via imported functions

### DIFF
--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -10,7 +10,7 @@ use ir::ir::*
 use io::env::{read_env}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata}
 use ir::lower::{lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
-use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target}
+use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target, native_v2_builtin_id_for_name}
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
 use module_parse::{extract_imports_from_ast, file_exists, file_path_to_module_path, load_module_file}
@@ -1797,6 +1797,54 @@ fn ir_module_promote_canonical_into_stub_slots(module: IrModule) -> IrModule wit
 
 // Materialize merged IR, resolve call targets on an owned IrModule (not through
 // &! Box<IrModule> — lean_single drops those writes), and return the finalized module.
+// Ensure every call to a BUILTIN name (str_char_at, str_len, str_from_bytes, ...)
+// points at a slot bearing that name so codegen emits the builtin body. Builtins
+// carry no IR body (instr_count==0, synthesized at codegen), so the normal name
+// resolver — which only accepts targets with instr_count>0 — never binds them. A
+// builtin referenced ONLY transitively (an imported fn's body calls it, the root
+// module never does) is also absent from the merged module entirely. Append a
+// named stub when missing and rebind the call. Whole-function writeback per A14.
+fn ir_module_ensure_builtin_call_targets(module: IrModule) -> IrModule with Mut, Div, Panic {
+    var out = module
+    var fi: i64 = 0
+    while fi < out.fn_count {
+        var f = out.functions[fi as usize]
+        var changed: bool = false
+        var ii: i64 = 0
+        while ii < f.instr_count {
+            let op = f.instrs[ii as usize].op
+            if op == IrOpcode::IrCall || op == IrOpcode::IrCallSret {
+                let cn = f.instrs[ii as usize].name
+                if cn.len > 0 && native_v2_builtin_id_for_name(cn) != 0 {
+                    let cur = f.instrs[ii as usize].fn_id
+                    var ok: bool = false
+                    if cur >= 0 && cur < out.fn_count {
+                        if ir_name_eq(out.functions[cur as usize].name, cn) { ok = true }
+                    }
+                    if !ok {
+                        var target = ir_merge_find_function_name_index(&out, cn)
+                        if target < 0 && out.fn_count < IR_MAX_FUNCS {
+                            var stub = ir_empty_function()
+                            stub.name = cn
+                            out.functions[out.fn_count as usize] = stub
+                            target = out.fn_count
+                            out.fn_count = out.fn_count + 1
+                        }
+                        if target >= 0 {
+                            f.instrs[ii as usize].fn_id = target
+                            changed = true
+                        }
+                    }
+                }
+            }
+            ii = ii + 1
+        }
+        if changed { out.functions[fi as usize] = f }
+        fi = fi + 1
+    }
+    out
+}
+
 fn ir_module_finalize_merged_calls(module: IrModule) -> IrModule with Mut, Div, Panic {
     var out = module
     ir_module_resolve_named_calls(&! out)
@@ -1836,6 +1884,7 @@ fn ir_module_finalize_merged_calls(module: IrModule) -> IrModule with Mut, Div, 
         }
         pass = pass + 1
     }
+    out = ir_module_ensure_builtin_call_targets(out)
     out
 }
 

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -5636,7 +5636,7 @@ fn native_v2_emit_machine_function_ref_mut(nc: &! NativeCompiler, func: &Machine
     }
 }
 
-fn native_v2_builtin_id_for_name(name: Name) -> i64 with Mut, Panic, Div {
+pub fn native_v2_builtin_id_for_name(name: Name) -> i64 with Mut, Panic, Div {
     if name_is_print_int(name) { return 1 }
     if name_is_print_char(name) { return 2 }
     if name_is_print(name) { return 3 }
@@ -5658,6 +5658,7 @@ fn native_v2_builtin_id_for_name(name: Name) -> i64 with Mut, Panic, Div {
     if name_is_sin(name) { return 18 }
     if name_is_cos(name) { return 19 }
     if name_is_assert(name) { return 21 }
+    if name_is_str_from_bytes(name) { return 22 }
     0
 }
 


### PR DESCRIPTION
## Bug

A builtin (`str_char_at`, `str_from_bytes`, `str_len`, …) that the **root module never calls directly** — reached only through an **imported function's body** — was miscompiled: the call resolved to nothing and dangled, producing garbage output or a SIGSEGV.

Example: `use str::lib::*` then a call whose body internally does `str_from_literal` → `str_char_at`, or `str_to_string` → `str_from_bytes`. The same builtin works if the root module also references it directly (which is why the bug was invisible until now).

## Root causes

1. **Builtins carry no IR body** (`instr_count == 0`; the body is synthesized at codegen from the function name). The merged-module resolver `ir_module_resolve_call_target_fields` only binds a call to a target with `instr_count > 0`, so it **never binds a call to a builtin slot**. And a builtin referenced only *transitively* is often **absent from the merged module entirely** (the root module's lowering never added it).
2. `native_v2_builtin_id_for_name` (name→builtin-id, used for detection) was **missing `str_from_bytes` (id 22)** that its func-ref sibling `native_v2_builtin_id_for_func_ref` already has.

## Fix

- Add `ir_module_ensure_builtin_call_targets`, run at the end of `ir_module_finalize_merged_calls`: for every `IrCall`/`IrCallSret` whose name is a builtin and whose current target isn't a same-named slot, **append a named stub when absent and rebind the call**, so codegen emits the builtin body.
- Add the missing `str_from_bytes` case to `native_v2_builtin_id_for_name` (and make it `pub` for the new pass).

## Verification

- A 2-module reproducer (imported fn calling `str_char_at` that main never references) flips from garbage → correct; imported `str::lib` `str_from_literal` / `str_to_string` round-trip correctly.
- **Byte-identity sweep** over 129 run-pass programs: **127 identical, 2 changed** are pre-existing segfault-both-ways programs (byte-diff only). **Zero regressions.**
- Unblocks the EISA epistemic-ISA suite: `test_eisa_isa` (whose receipt formatter uses these string builtins through an imported module) now prints `ALL PASS: eisa isa P1 P2 P3 P4 P5`.