### PR TITLE
feat(exact): the e₈-seam bridge — zero-division and operator non-alternativity are one locus in 𝕊

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion e8-seam bridge cross-verification
+        run: bash scripts/ci/sedenion_seam_bridge_gate.sh
       - name: Gresnigt G2xS3 cross-verification
         run: bash scripts/ci/gresnigt_g2s3_gate.sh
       - name: Gresnigt family-S3 cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 902
-- Repo-backed topics: 752
+- Total governed topics: 903
+- Repo-backed topics: 753
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 186
+- Authority count `historical`: 187
 - Authority count `repo_only`: 528
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 235 topics
+- A6: 236 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -685,6 +685,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sedenion-ladder-extension | historical | docs/research/sedenion_ladder_extension.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-octonion-census | historical | docs/research/sedenion_octonion_census.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-quartet-fiber-incidence | historical | docs/research/sedenion_quartet_fiber_incidence.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-seam-bridge | historical | docs/research/sedenion_seam_bridge.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-spectra | historical | docs/research/sedenion_spectra.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-fiber-identity | historical | docs/research/sedenion_zd_fiber_identity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-zd-fibers | historical | docs/research/sedenion_zd_fibers.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -15111,6 +15111,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-seam-bridge",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_seam_bridge.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-spectra",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_spectra.md",

--- a/docs/research/sedenion_seam_bridge.md
+++ b/docs/research/sedenion_seam_bridge.md
@@ -1,0 +1,92 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-seam-bridge
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-seam-bridge
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The e₈-seam bridge — zero-division and operator non-alternativity are one locus in 𝕊
+
+**One line.** Two *a priori* independent structures of the sedenions — the state-level zero-divisor
+census (the e₈-boundary geometry of Paper 1/2) and the operator-level failure of the left-multiplications
+to anticommute (the Cℓ(6)→Cℓ(8) fingerprint) — are shown to be **the same off-seam locus**, and the
+anticommutator is the **exact obstruction** to zero-division. This closes the previously disconnected
+state-level and operator-level strata of Vector 4/3.
+
+## The theorem (seam trichotomy)
+
+Let `𝕊 = 𝕆 ⊕ 𝕆·e₈`, lower indices `L={1..7}`, upper `U={8..15}`, `L_i` = left multiplication by `e_i`
+(`L_i²=−I`). The **e₈ seam** is `{(l,u) : u=8 or l⊕u=8}` (14 pairs); its complement in the 56 lower×upper
+pairs is the **off-seam** set (42 pairs). For every lower×upper pair `(l,u)` the following are equivalent:
+
+1. `{L_l, L_u} ≠ 0`  (the left-multiplications fail to anticommute);
+2. `(L_l L_u)² ≠ −I`;
+3. `+1 ∈ spec(L_l L_u)`;
+4. `L_l + L_u` is singular;
+5. `e_l + e_u` is a (left) zero divisor of 𝕊;
+6. `(l,u)` is off the e₈ seam.
+
+Consequently the three independently defined 42-element sets — **non-anticommuting operator-pairs**,
+**zero-divisor-participating directions**, and **off-seam index-pairs** — coincide.
+
+### Mechanism (forward implication, proved)
+
+`e_l + e_u` is a left zero divisor iff `L_l + L_u` is singular, i.e. iff some `w ≠ 0` has `L_l w = −L_u w`;
+applying `L_l` and using `L_l²=−I` gives `L_l L_u w = w`, so `w` is a `+1`-eigenvector of `L_l L_u`. If
+`{L_l,L_u}=0`, then
+
+```
+(L_l L_u)² = L_l (L_u L_l) L_u = −L_l² L_u² = −(−I)(−I) = −I,
+```
+
+so `spec(L_l L_u) ⊆ {±i}`, `+1` is excluded, `L_l+L_u` is nonsingular, and `e_l+e_u` is **not** a zero
+divisor. **Anticommutation obstructs zero-division.** The converse holds for all 42 off-seam pairs by
+direct computation.
+
+## Quartet incidence (resolution of the "42 = 42")
+
+The 84 participating primitives (42 off-seam directions × 2 signs) carry 168 unordered zero-divisor edges,
+grouping by support-union into 42 quartets `{l₁,l₂,u₁,u₂}` of four edges each (`168 = 42×4`, the Paper 1
+census). Certified: **every quartet contains exactly four off-seam cross sub-pairs, and every off-seam
+pair lies in exactly four quartets.** The coincidence `|operator-pairs| = |quartets| = 42` is therefore
+not a bijection but a **4-regular, self-paired incidence** with 168 incidences — both sides being the
+off-seam locus, joined by the 168 zero-divisor edges.
+
+## Significance
+
+The zero-divisor geometry (a property of the multiplication on *states*) and the non-alternativity of the
+left-adjoint action (a property of *operators*) are two faces of the same off-seam locus, with the
+anticommutator as the precise obstruction. The 42 non-anticommuting pairs, the 42 ZD-quartets, and the
+84↔84 dagger structure are one object viewed along three axes. Intrinsic to 𝕊; independent of any
+particle-physics interpretation.
+
+## Certification (3 legs)
+- **souc** (sparse core, ℤ): `tests/run-pass/sedenion_seam_bridge.sio` → `BRIDGE OK` (bin/souc AND stage2):
+  `{L_l,L_u}=0 ⟺ (L_lL_u)²=−I ⟺ not-ZD ⟺ on-seam`, all 56 pairs; the three 42-sets.
+- **Python oracle** (full six-way incl. the det/spec formulations via exact integer Bareiss determinants,
+  + the 4-regular quartet incidence): `scripts/research/sedenion_seam_bridge_oracle.py`; gate
+  `scripts/ci/sedenion_seam_bridge_gate.sh` (asserts `SIXWAY_OK` and `INCIDENCE_OK`).
+- **Lean `native_decide`**: `formal/lean4/SounioSeamBridge.lean` — `seam_equivalence`, `three_42_sets`.
+
+The sparse identities used (no matrix products): `{L_l,L_u}=0 ⟺ σ(l,u⊕c)σ(u,c)+σ(u,l⊕c)σ(l,c)=0 ∀c`;
+`(L_lL_u)²=−I ⟺ σ(l,l⊕c)σ(u,l⊕u⊕c)σ(l,u⊕c)σ(u,c)=−1 ∀c`.
+
+## Reproduce
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_seam_bridge.sio
+python3 scripts/research/sedenion_seam_bridge_oracle.py
+bash scripts/ci/sedenion_seam_bridge_gate.sh
+(cd formal/lean4 && lake build SounioSeamBridge)
+```
+
+## References
+- Paper 1 (`docs/papers/exact-168-executable.md`), Paper 2 (`docs/papers/sedenion-fano-geometry.md`).
+- Moreno G, Bol Soc Mat Mexicana 4 (1998) 13; Cawagas RE, Discuss. Math. 24 (2004) 251; Biss/Dugger/
+  Isaksen, Commun. Algebra 36 (2008) 632.

--- a/formal/lean4/SounioSeamBridge.lean
+++ b/formal/lean4/SounioSeamBridge.lean
@@ -1,0 +1,54 @@
+/-
+  SounioSeamBridge — the e₈-seam bridge (Frente B), by native_decide. For every lower×upper index-pair
+  (l,u) of 𝕊 the sparse equivalences hold: {L_l,L_u}=0 ⟺ (L_lL_u)²=−I ⟺ e_l+e_u is NOT a zero divisor
+  ⟺ (l,u) is on the e₈ seam. Hence operator non-alternativity and state-level zero-division are ONE
+  locus (the 42 off-seam pairs). The anticommutator is the exact obstruction to zero-division (forward
+  proof: {L_l,L_u}=0 ⟹ (L_lL_u)²=−I ⟹ +1 ∉ spec ⟹ not a ZD). Mathlib-free, no sorry.
+-/
+namespace SounioSeamBridge
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+def sg (a b : Nat) : Int := cdSigma a b 4
+
+def anti0 (l u : Nat) : Bool :=
+  (List.range 16).all (fun c => sg l (u ^^^ c) * sg u c + sg u (l ^^^ c) * sg l c == 0)
+def llsqNegI (l u : Nat) : Bool :=
+  (List.range 16).all (fun c => sg l (l ^^^ c) * sg u (l ^^^ u ^^^ c) * sg l (u ^^^ c) * sg u c == -1)
+def annih (l u a b : Nat) (s : Int) : Bool :=
+  (List.range 16).all (fun k =>
+    (if (l ^^^ a) == k then sg l a else 0) + (if (l ^^^ b) == k then s * sg l b else 0)
+    + (if (u ^^^ a) == k then sg u a else 0) + (if (u ^^^ b) == k then s * sg u b else 0) == 0)
+def isZD (l u : Nat) : Bool :=
+  (List.range 16).any (fun a => (List.range 16).any (fun b =>
+    a < b && (annih l u a b 1 || annih l u a b (-1))))
+def offSeam (l u : Nat) : Bool := ! (u == 8 || (l ^^^ u) == 8)
+
+def loHi : List (Nat × Nat) :=
+  (List.range 7).flatMap (fun l => (List.range 8).map (fun u => (l+1, u+8)))
+
+/-- The four sparse conditions are equivalent for all 56 lower×upper pairs:
+    {L_l,L_u}=0 ⟺ (L_lL_u)²=−I ⟺ (l,u) NOT off-seam ⟺ e_l+e_u NOT a zero divisor. -/
+theorem seam_equivalence :
+    loHi.all (fun p =>
+      (anti0 p.1 p.2 == llsqNegI p.1 p.2)
+      && (anti0 p.1 p.2 == ! offSeam p.1 p.2)
+      && (anti0 p.1 p.2 == ! isZD p.1 p.2)) = true := by native_decide
+
+/-- The three 42-element sets coincide: non-anticommuting pairs = off-seam pairs = zero-divisor directions. -/
+theorem three_42_sets :
+    ((loHi.filter (fun p => ! anti0 p.1 p.2)).length = 42)
+    ∧ ((loHi.filter (fun p => offSeam p.1 p.2)).length = 42)
+    ∧ ((loHi.filter (fun p => isZD p.1 p.2)).length = 42) := by native_decide
+
+end SounioSeamBridge

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -73,6 +73,9 @@ lean_lib «SounioZeroDivisorBridge» where
 lean_lib «SounioSedenionMeasurement» where
 
 @[default_target]
+lean_lib «SounioSeamBridge» where
+
+@[default_target]
 lean_lib «SounioGresnigtG2S3» where
 
 @[default_target]

--- a/scripts/ci/sedenion_seam_bridge_gate.sh
+++ b/scripts/ci/sedenion_seam_bridge_gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: the e8-seam bridge (Frente B). souc (sparse core) vs oracle (full six-way + incidence).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/c.elf" >/dev/null 2>&1; chmod +x "$WORK/c.elf"; "$WORK/c.elf" 2>/dev/null; fi }
+run_souc tests/run-pass/sedenion_seam_bridge.sio | grep -E '^(EQUIV_OK|N_|BRIDGE)' | sort > "$WORK/souc.txt"
+python3 scripts/research/sedenion_seam_bridge_oracle.py > "$WORK/py_all.txt"
+grep -E '^(EQUIV_OK|N_|BRIDGE)' "$WORK/py_all.txt" | sort > "$WORK/py.txt"
+fail=0
+diff -q "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt"; fail=1; }
+grep -q '^BRIDGE OK' "$WORK/souc.txt" || { echo "verdict != BRIDGE OK"; fail=1; }
+[ "$(grep '^SIXWAY_OK ' "$WORK/py_all.txt" | awk '{print $2}')" = "1" ] || { echo "full six-way equivalence failed"; fail=1; }
+[ "$(grep '^INCIDENCE_OK ' "$WORK/py_all.txt" | awk '{print $2}')" = "1" ] || { echo "4-regular incidence failed"; fail=1; }
+[ "$fail" -eq 0 ] || { echo "seam bridge gate: FAIL"; exit 1; }
+echo "CROSS-VERIFIED: operator non-anticommutation = state zero-division = off the e8 seam (42=42=42);"
+echo "  full six-way equivalence (incl. det/spec) + 4-regular self-paired quartet incidence (168)."
+echo "seam bridge gate: PASS"

--- a/scripts/research/sedenion_seam_bridge_oracle.py
+++ b/scripts/research/sedenion_seam_bridge_oracle.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Oracle: the e8-seam bridge (Frente B). Certifies the FULL six-way equivalence (including the
+determinant/eigenvalue formulations via exact integer Bareiss determinants) and the 4-regular quartet
+incidence, over all 56 lower x upper pairs of S. See sedenion_seam_bridge.md."""
+from collections import Counter
+
+DIM = 16
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH, bH, aL, bL = a >= half, b >= half, a & (half - 1), b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def Lm(i):
+    M = [[0] * DIM for _ in range(DIM)]
+    for k in range(DIM):
+        M[i ^ k][k] = cd_sigma(i, k)
+    return M
+
+
+L = [Lm(i) for i in range(DIM)]
+mm = lambda A, B: [[sum(A[r][t] * B[t][c] for t in range(DIM)) for c in range(DIM)] for r in range(DIM)]
+madd = lambda A, B, s=1: [[A[r][c] + s * B[r][c] for c in range(DIM)] for r in range(DIM)]
+isnegI = lambda A: all(A[r][c] == (-1 if r == c else 0) for r in range(DIM) for c in range(DIM))
+I16 = [[1 if r == c else 0 for c in range(DIM)] for r in range(DIM)]
+
+
+def anticomm0(i, j):
+    P, Q = mm(L[i], L[j]), mm(L[j], L[i])
+    return all(P[r][c] + Q[r][c] == 0 for r in range(DIM) for c in range(DIM))
+
+
+def bareiss_det(M):
+    A = [row[:] for row in M]
+    n = len(A)
+    prev = 1
+    sign = 1
+    for k in range(n - 1):
+        if A[k][k] == 0:
+            sw = next((i for i in range(k + 1, n) if A[i][k] != 0), None)
+            if sw is None:
+                return 0
+            A[k], A[sw] = A[sw], A[k]
+            sign = -sign
+        for i in range(k + 1, n):
+            for j in range(k + 1, n):
+                A[i][j] = (A[i][j] * A[k][k] - A[i][k] * A[k][j]) // prev
+        prev = A[k][k]
+    return sign * A[n - 1][n - 1]
+
+
+LO = range(1, 8)
+HI = range(8, 16)
+allpairs = {(l, u) for l in LO for u in HI}
+seam = {(l, u) for (l, u) in allpairs if u == 8 or u == (l ^ 8)}
+offseam = allpairs - seam
+
+
+def qprod0(l, u, a, b, s):
+    def comp(k):
+        acc = 0
+        if (l ^ a) == k: acc += cd_sigma(l, a)
+        if (l ^ b) == k: acc += s * cd_sigma(l, b)
+        if (u ^ a) == k: acc += cd_sigma(u, a)
+        if (u ^ b) == k: acc += s * cd_sigma(u, b)
+        return acc
+    return all(comp(k) == 0 for k in range(16))
+
+
+def is_zd(l, u):
+    return any(qprod0(l, u, a, b, s) for a in range(1, 16) for b in range(a + 1, 16) for s in (1, -1))
+
+
+def main():
+    # sparse core (matches souc)
+    equiv_ok = 1
+    n_nonanti = n_offseam = n_zd = 0
+    for (l, u) in allpairs:
+        ac = anticomm0(l, u)
+        sq = isnegI(mm(mm(L[l], L[u]), mm(L[l], L[u])))
+        off = (l, u) in offseam
+        zd = is_zd(l, u)
+        if not (ac == sq and ac != off and ac != zd):
+            equiv_ok = 0
+        if not ac: n_nonanti += 1
+        if off: n_offseam += 1
+        if zd: n_zd += 1
+    # FULL six-way including det/spec formulations
+    sixway = 1
+    for (l, u) in allpairs:
+        ac = anticomm0(l, u)
+        sq = isnegI(mm(mm(L[l], L[u]), mm(L[l], L[u])))
+        LL = mm(L[l], L[u])
+        p1 = bareiss_det(madd(LL, I16, -1)) == 0            # +1 in spec
+        sing = bareiss_det(madd(L[l], L[u], 1)) == 0 or bareiss_det(madd(L[l], L[u], -1)) == 0
+        zd = is_zd(l, u)
+        off = (l, u) in offseam
+        # all six 'off-seam' conditions equal: (not ac),(not sq),p1,sing,zd,off
+        row = [(not ac), (not sq), p1, sing, zd, off]
+        if not all(x == row[0] for x in row):
+            sixway = 0
+    # 4-regular quartet incidence
+    P = [(l, u, s) for (l, u) in offseam for s in (1, -1)]
+
+    def pv0(p, q):
+        l1, u1, s1 = p
+        l2, u2, s2 = q
+
+        def comp(k):
+            acc = 0
+            if (l1 ^ l2) == k: acc += cd_sigma(l1, l2)
+            if (l1 ^ u2) == k: acc += s2 * cd_sigma(l1, u2)
+            if (u1 ^ l2) == k: acc += s1 * cd_sigma(u1, l2)
+            if (u1 ^ u2) == k: acc += s1 * s2 * cd_sigma(u1, u2)
+            return acc
+        return all(comp(k) == 0 for k in range(16))
+    edges = set()
+    for i in range(len(P)):
+        for j in range(i + 1, len(P)):
+            if pv0(P[i], P[j]) or pv0(P[j], P[i]):
+                edges.add((P[i], P[j]))
+    quart = {}
+    for (a, b) in edges:
+        supp = frozenset([a[0], a[1], b[0], b[1]])
+        if len(supp) == 4:
+            quart[supp] = quart.get(supp, 0) + 1
+    q4 = list(quart)
+    persub = Counter()
+    deg = {p: 0 for p in offseam}
+    for q in q4:
+        los = [x for x in q if x in LO]
+        his = [x for x in q if x in HI]
+        persub[sum(1 for l in los for u in his if (l, u) in offseam)] += 1
+        for l in los:
+            for u in his:
+                if (l, u) in deg:
+                    deg[(l, u)] += 1
+    incidence_ok = 1 if (len(q4) == 42 and set(persub) == {4} and set(deg.values()) == {4}
+                         and len(edges) == 168) else 0
+    print(f"EQUIV_OK {equiv_ok}")
+    print(f"N_NONANTI {n_nonanti}")
+    print(f"N_OFFSEAM {n_offseam}")
+    print(f"N_ZD {n_zd}")
+    print(f"SIXWAY_OK {sixway}")
+    print(f"INCIDENCE_OK {incidence_ok}")
+    ok = equiv_ok and n_nonanti == 42 and n_offseam == 42 and n_zd == 42
+    print(f"BRIDGE {'OK' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run-pass/sedenion_seam_bridge.sio
+++ b/tests/run-pass/sedenion_seam_bridge.sio
@@ -1,0 +1,145 @@
+//@ run-pass
+//@ expect-stdout: BRIDGE OK
+// FRENTE B — the e₈-seam bridge: zero-division (state level) and operator non-alternativity are ONE locus.
+//
+// This closes the previously disconnected state-level (§1 e₈-boundary, Paper 1/2) and operator-level
+// (Cℓ(6)→Cℓ(8) fingerprint, this vector) strata of 𝕊. For a lower×upper index-pair (l,u) with l∈{1..7},
+// u∈{8..15}, the following are equivalent (proved analytically for the forward direction; certified for
+// all 56 pairs):
+//   • {L_l, L_u} ≠ 0          (the left-multiplications fail to anticommute);
+//   • (L_l L_u)² ≠ −I;
+//   • e_l + e_u is a left zero divisor of 𝕊;
+//   • (l,u) is OFF the e₈ seam  (seam = {u=8 or l⊕u=8}).
+// The anticommutator is the exact OBSTRUCTION to zero-division: if {L_l,L_u}=0 then, using L_l²=L_u²=−I,
+//   (L_l L_u)² = L_l(L_u L_l)L_u = −L_l² L_u² = −(−I)(−I) = −I,
+// so spec(L_l L_u) ⊆ {±i}; +1 is excluded, L_l+L_u is nonsingular, and e_l+e_u is NOT a zero divisor.
+// (The determinant/eigenvalue formulations of the theorem and the 4-regular quartet incidence are in the
+// oracle; here we certify the sparse-checkable equivalences over ℤ.)
+//
+// Sparse identities (no matrix products): with e_i e_j = σ(i,j) e_{i⊕j},
+//   {L_l,L_u}=0        ⟺  σ(l,u⊕c)σ(u,c) + σ(u,l⊕c)σ(l,c) = 0        ∀c
+//   (L_l L_u)²=−I      ⟺  σ(l,l⊕c)σ(u,l⊕u⊕c)σ(l,u⊕c)σ(u,c) = −1      ∀c
+//   e_l+e_u is a ZD    ⟺  ∃ primitive e_a±e_b annihilated by (e_l+e_u)
+// Then: {L_l,L_u}=0  ⟺  (L_lL_u)²=−I  ⟺  NOT ZD  ⟺  on the e₈ seam, for all 56 pairs; and the three
+// 42-element sets (non-anticommuting pairs, ZD-participating directions, off-seam pairs) coincide.
+//
+// Decidable integer arithmetic, no float. SELF-CONTAINED. Cross-verified vs the oracle + Lean.
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+fn sg(a: i64, b: i64) -> i64 with Mut, Panic, Div { cd_sigma_c(a, b, 4) }
+// {L_l, L_u} == 0 ?
+fn anti0(l: i64, u: i64) -> bool with Mut, Panic, Div {
+    var c = 0
+    while c < 16 {
+        if sg(l, u ^ c) * sg(u, c) + sg(u, l ^ c) * sg(l, c) != 0 { return false }
+        c = c + 1
+    }
+    true
+}
+// (L_l L_u)^2 == -I ?
+fn llsq_negI(l: i64, u: i64) -> bool with Mut, Panic, Div {
+    var c = 0
+    while c < 16 {
+        if sg(l, l ^ c) * sg(u, l ^ u ^ c) * sg(l, u ^ c) * sg(u, c) != (0 - 1) { return false }
+        c = c + 1
+    }
+    true
+}
+// (e_l + e_u)(e_a + s*e_b) component on e_k
+fn qprod(l: i64, u: i64, a: i64, b: i64, s: i64, k: i64) -> i64 with Mut, Panic, Div {
+    var acc = 0
+    if (l ^ a) == k { acc = acc + sg(l, a) }
+    if (l ^ b) == k { acc = acc + s * sg(l, b) }
+    if (u ^ a) == k { acc = acc + sg(u, a) }
+    if (u ^ b) == k { acc = acc + s * sg(u, b) }
+    acc
+}
+fn annihilates(l: i64, u: i64, a: i64, b: i64, s: i64) -> bool with Mut, Panic, Div {
+    var k = 0
+    while k < 16 {
+        if qprod(l, u, a, b, s, k) != 0 { return false }
+        k = k + 1
+    }
+    true
+}
+// e_l + e_u is a left zero divisor (annihilates some primitive e_a (+/-) e_b) ?
+fn is_zd(l: i64, u: i64) -> bool with Mut, Panic, Div {
+    var a = 1
+    while a < 16 {
+        var b = a + 1
+        while b < 16 {
+            if annihilates(l, u, a, b, 1) { return true }
+            if annihilates(l, u, a, b, 0 - 1) { return true }
+            b = b + 1
+        }
+        a = a + 1
+    }
+    false
+}
+fn off_seam(l: i64, u: i64) -> bool with Mut, Panic, Div {
+    if u == 8 { return false }
+    if (l ^ u) == 8 { return false }
+    true
+}
+
+fn main() with IO, Mut, Panic, Div {
+    var equiv_ok = 1
+    var n_nonanti = 0
+    var n_offseam = 0
+    var n_zd = 0
+    var l = 1
+    while l <= 7 {
+        var u = 8
+        while u <= 15 {
+            let ac = anti0(l, u)            // {L_l,L_u}=0
+            let sq = llsq_negI(l, u)        // (L_lL_u)^2=-I
+            let off = off_seam(l, u)
+            let zd = is_zd(l, u)
+            // equivalence: ac ⟺ sq ⟺ (not off) ⟺ (not zd)
+            if ac != sq { equiv_ok = 0 }
+            if ac == off { equiv_ok = 0 }       // ac true ⟺ off false
+            if ac == zd { equiv_ok = 0 }        // ac true ⟺ zd false
+            if !ac { n_nonanti = n_nonanti + 1 }
+            if off { n_offseam = n_offseam + 1 }
+            if zd { n_zd = n_zd + 1 }
+            u = u + 1
+        }
+        l = l + 1
+    }
+
+    print("EQUIV_OK ")
+    print_int(equiv_ok as i64)
+    print("\n")
+    print("N_NONANTI ")
+    print_int(n_nonanti as i64)
+    print("\n")
+    print("N_OFFSEAM ")
+    print_int(n_offseam as i64)
+    print("\n")
+    print("N_ZD ")
+    print_int(n_zd as i64)
+    print("\n")
+    // The six-way equivalence (sparse core) holds for all 56 pairs; the three 42-sets coincide:
+    // operator non-anticommutation = state zero-division = off the e₈ seam. The bridge.
+    if equiv_ok == 1 && n_nonanti == 42 && n_offseam == 42 && n_zd == 42 {
+        println("BRIDGE OK")
+    } else {
+        println("BRIDGE FAIL")
+    }
+}


### PR DESCRIPTION
Certifies an **internal correspondence** in the sedenions between two *a priori* independent strata: the state-level zero-divisor census (e₈-boundary, Paper 1/2) and the operator-level failure of the left-multiplications to anticommute (Cℓ(6)→Cℓ(8) fingerprint).

For every lower×upper pair (l,u): the **six-way equivalence** {L_l,L_u}≠0 ⟺ (L_lL_u)²≠−I ⟺ +1∈spec ⟺ L_l+L_u singular ⟺ e_l+e_u is a ZD ⟺ off the e₈ seam — all 56 pairs. The **anticommutator is the exact obstruction** to zero-division (proof: {L_l,L_u}=0 ⟹ (L_lL_u)²=−L_l²L_u²=−I ⟹ +1∉spec ⟹ not a ZD). The three 42-element sets (non-anticommuting pairs, ZD directions, off-seam pairs) **coincide**; the 42 operator-pairs and 42 ZD-quartets form a **4-regular self-paired incidence** (168).

Intrinsic to 𝕊, independent of physics. 3 legs: souc (bin+stage2, sparse core over ℤ) + Python oracle (full six-way via exact Bareiss determinants + quartet incidence) + Lean native_decide (2 theorems). Result note + numpy reference by the operator; the sparse (L_lL_u)² identity derived here for the souc leg.