### PR TITLE
fix(native): raise CodeBuffer 128KB->256KB (byte-neutral) + seed build prereqs

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -998,7 +998,7 @@ fn local_cap() -> i64 { return 2048 }
 fn global_cap() -> i64 { return 2048 }
 fn max_frame_bytes() -> i64 { return 4194304 }
 fn box_page_bytes() -> i64 { return 4096 }
-fn local_bss_spill_bytes() -> i64 { return 524288 }
+fn local_bss_spill_bytes() -> i64 { return 4194304 }
 fn token_capacity() -> i64 { return 2097152 }
 
 fn note_limit_error(kind: i64) with Mut {
@@ -36419,7 +36419,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                 print_imp_path()
                 print("\n")
             } else {
-                if fsz <= 0 || fsz >= 8388608 {
+                if fsz <= 0 || fsz >= 16777216 {
                     print("warning: import size invalid; using read count for ")
                     print_imp_path()
                     print("\n")
@@ -36452,7 +36452,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                         print("error: import path table full: ")
                         print_imp_path()
                         print("\n")
-                    } else if copy_len >= 8388608 || SRC_LEN + fp_len + copy_len + 3 >= 8388608 {
+                    } else if copy_len >= 16777216 || SRC_LEN + fp_len + copy_len + 3 >= 16777216 {
                         IMPORT_RESOLUTION_FAILED = 1
                         print("error: import too large for SRC buffer: ")
                         print_imp_path()
@@ -36474,7 +36474,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                         SRC[SRC_LEN as usize] = 2
                         SRC_LEN = SRC_LEN + 1
                         var ci: i64 = 0
-                        while ci < copy_len && SRC_LEN + ci < 8388608 {
+                        while ci < copy_len && SRC_LEN + ci < 16777216 {
                             SRC[(SRC_LEN + ci) as usize] = raw[ci as usize]
                             ci = ci + 1
                         }

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -966,7 +966,7 @@ fn compiler_bytes_contains(bytes: [i8; 65536], size: i64, needle: string) -> boo
     false
 }
 
-fn compiler_bytes_contains_seq_i64(bytes: [i8; 131072], size: i64, seq: [i64; 32], seq_len: i64) -> bool with Mut, Panic, Div {
+fn compiler_bytes_contains_seq_i64(bytes: [i8; 262144], size: i64, seq: [i64; 32], seq_len: i64) -> bool with Mut, Panic, Div {
     if seq_len <= 0 {
         return true
     }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1342,7 +1342,7 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    if len >= 0 && len < 131072 {
+    if len >= 0 && len < 262144 {
         (*nc).code.bytes[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
     } else {
@@ -4474,7 +4474,7 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
     // Patch jns displacement
     let neg_block_len = c.code.len - (jns_pos + 2)
-    if jns_pos + 1 < 131072 {
+    if jns_pos + 1 < 262144 {
         c.code.bytes[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
     }
 

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -6,7 +6,7 @@
 module native::encode
 
 pub struct CodeBuffer {
-    pub bytes: [i8; 131072],
+    pub bytes: [i8; 262144],
     pub len: i64,
 }
 
@@ -58,7 +58,7 @@ pub fn wide_copy_from_code_buffer(dst: WideCodeBuffer, src: CodeBuffer) -> WideC
 pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
     var out = buf
     if out.len >= 0 {
-        if out.len < 131072 {
+        if out.len < 262144 {
             out.bytes[out.len as usize] = low8(b) as i8
             out.len = out.len + 1
         }
@@ -68,7 +68,7 @@ pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
 
 pub fn emit_byte_mut(buf: &! CodeBuffer, b: i64) with Mut, Panic, Div {
     if (*buf).len >= 0 {
-        if (*buf).len < 131072 {
+        if (*buf).len < 262144 {
             (*buf).bytes[(*buf).len as usize] = low8(b) as i8
             (*buf).len = (*buf).len + 1
         }

--- a/self-hosted/native/macho.sio
+++ b/self-hosted/native/macho.sio
@@ -1468,7 +1468,7 @@ pub fn macho_compute_layout(
 // entry_off: offset of entry point within __text
 pub fn macho_assemble_executable(
     w: MachoWriter,
-    code_data: [i8; 131072],
+    code_data: [i8; 262144],
     code_len: i64,
     const_data: [i8; 131072],
     const_len: i64,


### PR DESCRIPTION
## What

Doubles the native-v2 machine-code ceiling: `encode::CodeBuffer` **128 KB → 256 KB** (`131072 → 262144`, byte-neutral — both 6 digits), plus the by-value param types that must track it (`macho code_data`, `main compiler_bytes_contains_seq_i64`) and the `nc_emit_byte`/`jns` guards. The ELF-write path is already 262144 (#690); `native_compile_result_ok_elf`'s `1048576` param is the `Elf64Binary` size and is deliberately left untouched.

## Why 256 KB (not more)

`CodeBuffer` lives **by value inside the stack-allocated `NativeCompiler`** (`frame.sio:210`). Enlarging past ~640 KB trips a large-stack-frame miscompile (the ELF-image local's `&!` write stops propagating → `rc=14`). **256 KB is the safe maximum on-stack size.** Going higher requires moving the code buffer off-stack — tracked separately.

## Seed prerequisites (`lean_single.sio`)

So the committed seed can build `main.sio` from source:
- `local_bss_spill_bytes` 512 KB → 4 MB — keeps the ~700 KB `NativeCompiler` on the per-call stack instead of spilling to shared BSS (which corrupts re-entrant multimodule compiles). *(`524288` is also the Causal effect bit elsewhere; only the spill-threshold literal is changed.)*
- import accumulation limit 8 MB → 16 MB — `main.sio`'s transitive closure (~8.4 MB) exceeds the pre-existing 8 MB cliff, so the 8 MB seed could not build main.

## Verification

Built madaros from `origin/main` via the spill+import-patched seed:
- **byte-identity: 22/22 run-pass programs identical to the 128 KB baseline, 0 regressions**
- hello + synthetics compile and run correctly
- synthetic programs with **140–217 KB of code** (which the 128 KB baseline rejects with `rc=19` code-overflow) now **compile and run**

## Scope note

This lifts the buffer ceiling but is **necessary-not-sufficient** for the EISA `isa`/`evm` suites: those are separately blocked by a pre-existing madaros lowering crash (`rc=42`) that fires before codegen. That, and the off-stack rewrite for >256 KB programs, are follow-ups.

## Not included

The rebuilt `artifacts/self-hosted/madaros` binary (~104 MB) is **not** committed here — it must be regenerated (`scripts/ci/build_modular_madaros.sh` via a spill+import-patched seed) for the change to take runtime effect.