### PR TITLE
feat(exact): exact Cayley–Dickson product over unbounded ℚ (all 16 components)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
+      - name: Sedenion exact unbounded-Q CD cross-verification
+        run: bash scripts/ci/sedenion_cd_qbig_gate.sh
       - name: Sedenion e8-seam bridge cross-verification
         run: bash scripts/ci/sedenion_seam_bridge_gate.sh
       - name: Gresnigt G2xS3 cross-verification

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 903
-- Repo-backed topics: 753
+- Total governed topics: 904
+- Repo-backed topics: 754
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 187
+- Authority count `historical`: 188
 - Authority count `repo_only`: 528
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 236 topics
+- A6: 237 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -677,6 +677,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.sat-rup-microkernel-2026-06-23 | historical | docs/research/sat-rup-microkernel-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-associator-1848 | historical | docs/research/sedenion_associator_1848.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-automorphism-168 | historical | docs/research/sedenion_automorphism_168.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.sedenion-cd-qbig | historical | docs/research/sedenion_cd_qbig.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-clifford8 | historical | docs/research/sedenion_clifford8.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-dynamics | historical | docs/research/sedenion_dynamics.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.sedenion-e8-boundary | historical | docs/research/sedenion_e8_boundary.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14935,6 +14935,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.sedenion-cd-qbig",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/sedenion_cd_qbig.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.sedenion-clifford8",
       "collection": "repo",
       "repo_doc_path": "docs/research/sedenion_clifford8.md",

--- a/docs/research/sedenion_cd_qbig.md
+++ b/docs/research/sedenion_cd_qbig.md
@@ -1,0 +1,65 @@
+<!-- docs:meta
+topic_id: repo.docs.research.sedenion-cd-qbig
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.sedenion-cd-qbig
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The exact Cayley–Dickson product over unbounded ℚ (all 16 components)
+
+**One line.** Closes the Paper 1 open item: the full 16-component sedenion product over ℚ with
+**arbitrary-precision** rational coefficients — the i64 version (`sedenion_cd_full16_q.sio`) capped at
+coefficients ~1e8; this reaches magnitudes ~10^80 exactly, via a minimal self-contained signed BigInt.
+
+## What is certified
+Common-denominator reduction: a rational sedenion is 16 integer numerators `A[16]` over one common denom
+`Ad`; then `(A·B)[k] = (Σ_{i⊕j=k} σ(i,j) A[i] B[j]) / (Ad·Bd)` — an **integer** 16-component product of
+numerators. Two cases:
+- **Case 1 — exact annihilation at scale 10^80.** The zero divisor `(e₃+e₁₀)(e₆−e₁₅)`, each coefficient
+  scaled by `10^40`, produces **exactly 0 in all 16 components** at magnitude `10^80`. An i64 product
+  overflows into garbage here; exactness holds.
+- **Case 2 — general unbounded product.** A 16-component product with rational coefficients whose output
+  components reach ~`10^70`, cross-verified component-by-component.
+
+## Why a local BigInt (and the honest boundary on #651)
+The stdlib `math::bignat` full `big_mul(a,b)` **SIGSEGVs** under souc v0.80.0 — a single call, no arrays,
+no loop: a clean minimal `#651`/`#637` struct-copy repro. `[BigInt;16]` also SIGSEGVs (the
+array-of-structs wall). This brick **circumvents — it does not fix — `#651`**, exactly as the i64
+common-denominator circumvented `#637`:
+1. a minimal in-file **signed BigInt** (base-1e9 limbs, `[i64;12]`) built only from primitives that
+   empirically compile — schoolbook `big×big` = `mul_small` + limb-shift + `add`-in-loop (a spike
+   confirmed this exact accumulate-in-loop pattern runs, which is what the stdlib `big_mul` trips on);
+2. the 16 numerators are held in **flat scalar arrays** `[i64;N]`, never `[BigInt;16]`.
+
+Reproducing the full stdlib BigInt path is compiler-team work (`#651`); the math goal is met today.
+
+## Cross-verification (3 independent legs)
+- **souc** (bin/souc AND stage2): `tests/run-pass/sedenion_cd_qbig.sio` → `CDQBIG OK`. Emits each
+  component's **residue mod 1e9+7** (a per-limb *decimal* printer is miscompiled *differently* by the two
+  souc builds — bin/souc breaks print-in-loop, stage2 adds `print_int` newlines — but
+  `print("RES ") print_int(x)` is byte-identical on both), plus the structural annihilation flag.
+- **Python oracle** (exact ℚ): `scripts/research/sedenion_cd_qbig_oracle.py` — emits the exact decimals
+  and the residues; gate `scripts/ci/sedenion_cd_qbig_gate.sh` compares residues in order.
+- **Lean `native_decide`** (native arbitrary-precision `Int`, the digit-exact witness):
+  `formal/lean4/SounioCDqbig.lean` — `case1_annihilates` (all 16 comps 0 at 10^80), `case2_exact`
+  (the 16 exact component values).
+
+## Reproduce
+```bash
+SOUNIO_STDLIB_PATH=$PWD/stdlib ./bin/souc run tests/run-pass/sedenion_cd_qbig.sio
+python3 scripts/research/sedenion_cd_qbig_oracle.py
+bash scripts/ci/sedenion_cd_qbig_gate.sh
+(cd formal/lean4 && lake build SounioCDqbig)
+```
+
+## Relation to the arc
+This is the *infrastructure* frontier opened in Paper 1 (exact algebra over unbounded ℚ), distinct from
+the physics/bridge arc. It makes the exact zero-divisor detection unconditional in coefficient size:
+annihilation is now certifiable at any scale, not just within i64.

--- a/formal/lean4/SounioCDqbig.lean
+++ b/formal/lean4/SounioCDqbig.lean
@@ -1,0 +1,45 @@
+/-
+  SounioCDqbig — exact witness (native Int) for the unbounded-ℚ Cayley-Dickson product brick
+  (tests/run-pass/sedenion_cd_qbig.sio). Lean's Int is arbitrary precision, so this independently
+  confirms, digit-exact: (case 1) a zero divisor scaled by 10^40 annihilates in all 16 components at
+  magnitude 10^80; (case 2) the general 16-component product equals the exact values (also produced by
+  the Python oracle and, mod 1e9+7, by the souc minimal-BigInt leg). Mathlib-free, no sorry.
+-/
+namespace SounioCDqbig
+
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        let aHi := a ≥ half; let bHi := b ≥ half; let aLo := a % half; let bLo := b % half
+        if !aHi && !bHi then cdSigma aLo bLo (n+1)
+        else if !aHi && bHi then cdSigma bLo aLo (n+1)
+        else if aHi && !bHi then (if bLo == 0 then cdSigma aLo 0 (n+1) else - cdSigma aLo bLo (n+1))
+        else (if bLo == 0 then - cdSigma 0 aLo (n+1) else cdSigma bLo aLo (n+1))
+
+def cd16 (A B : List Int) : Nat → Int := fun k =>
+  (List.range 16).foldl (fun acc i =>
+    (List.range 16).foldl (fun acc2 j =>
+      if (i ^^^ j) == k then acc2 + cdSigma i j 4 * A.getD i 0 * B.getD j 0 else acc2) acc) 0
+
+-- Case 1: (e3+e10)(e6-e15), each coefficient scaled by 10^40.
+def A1 : List Int := (List.range 16).map (fun i => if i == 3 || i == 10 then (10:Int)^40 else 0)
+def B1 : List Int := (List.range 16).map (fun i => if i == 6 then (10:Int)^40 else if i == 15 then -(10:Int)^40 else 0)
+/-- Exact annihilation at magnitude 10^80: all 16 components are exactly 0. -/
+theorem case1_annihilates : (List.range 16).all (fun k => cd16 A1 B1 k == 0) = true := by native_decide
+
+-- Case 2: general 16-comp product, unbounded rational numerators.
+def A2 : List Int := (List.range 16).map (fun i =>
+  if i == 1 then (10:Int)^30 else if i == 2 then 3*(10:Int)^28 else if i == 4 then -5*(10:Int)^35
+  else if i == 8 then (10:Int)^33 else if i == 15 then 7*(10:Int)^20 else 0)
+def B2 : List Int := (List.range 16).map (fun i =>
+  if i == 1 then 2*(10:Int)^31 else if i == 5 then -(10:Int)^29 else if i == 7 then 4*(10:Int)^27
+  else if i == 10 then 9*(10:Int)^34 else 0)
+def expected2 : List Int := [-20000000000000000000000000000000000000000000000000000000000000, 50000000000000000000000000000000000000000000000000000000000000000, 90000000000000000000000000000000000000000000000000000000000000000000, -2000600000000000000000000000000000000000000000000000000000000000, 100000000000000000000000000000000000000000000000000000000000, 9999999999817000000000000000000000000000000000000000000000000000000, 4000000000000000000000000000000000000000000000000000000000, -3000000000000000000000000000000000000000000000000000000000, -2699999999999997200000000000000000000000000000000000000000000000, -20000000000000000000000000000000000000000000000000000000000000000, -70000000000000000000000000000000000000000000000000, -90000000000000000000000000000000000000000000000000000000000000000, 0, 100000000000000000000000000000000000000000000000000000000000000, -44999999999999999986000000000000000000000000000000000000000000000000000, -4000000000000000000000000000000000000000000000000000000000000]
+/-- The general product equals the exact values (digit-exact witness, native Int). -/
+theorem case2_exact : (List.range 16).map (cd16 A2 B2) = expected2 := by native_decide
+
+end SounioCDqbig

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -73,6 +73,9 @@ lean_lib «SounioZeroDivisorBridge» where
 lean_lib «SounioSedenionMeasurement» where
 
 @[default_target]
+lean_lib «SounioCDqbig» where
+
+@[default_target]
 lean_lib «SounioSeamBridge» where
 
 @[default_target]

--- a/scripts/ci/sedenion_cd_qbig_gate.sh
+++ b/scripts/ci/sedenion_cd_qbig_gate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Cross-toolchain gate: unbounded-Q Cayley-Dickson product (16 comps) via minimal BigInt.
+# souc emits residues mod 1e9+7 (byte-identical on bin/souc AND stage2); compared IN ORDER vs oracle.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+run_souc() { if [ "$SOUC" = "./bin/souc" ]; then ./bin/souc run "$1" 2>/dev/null; else
+  "$SOUC" "$1" "$WORK/c.elf" >/dev/null 2>&1; chmod +x "$WORK/c.elf"; "$WORK/c.elf" 2>/dev/null; fi }
+OUT="$(run_souc tests/run-pass/sedenion_cd_qbig.sio)"
+echo "$OUT" | grep -aE '^(RES|ANNIHILATION_C1) ' > "$WORK/souc.txt"
+python3 scripts/research/sedenion_cd_qbig_oracle.py | grep -E '^(RES|ANNIHILATION_C1) ' > "$WORK/py.txt"
+diff "$WORK/souc.txt" "$WORK/py.txt" >/dev/null || { echo "MISMATCH:"; diff "$WORK/souc.txt" "$WORK/py.txt" | head; echo "cd-qbig gate: FAIL"; exit 1; }
+echo "$OUT" | grep -qa '^CDQBIG OK' || { echo "verdict != CDQBIG OK"; echo "cd-qbig gate: FAIL"; exit 1; }
+echo "CROSS-VERIFIED: exact unbounded-Q CD product (16 comps). Case 1 annihilates EXACTLY at 10^80"
+echo "  (all 16 comps 0); case 2 residues (mod 1e9+7) match the Python oracle in order. Exact decimals"
+echo "  witnessed by Lean (native Int). #651 circumvented via a minimal working-primitive BigInt."
+echo "cd-qbig gate: PASS"

--- a/scripts/research/sedenion_cd_qbig_oracle.py
+++ b/scripts/research/sedenion_cd_qbig_oracle.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Oracle: unbounded-Q Cayley-Dickson product, ALL 16 components, via the common-denominator reduction
+(16 integer numerators over one common denom -> integer 16-comp product; den = Ad*Bd). Coefficients here
+are UNBOUNDED (numerators ~1e40-1e80) -- far beyond i64 -- so this is the exact-Q CD at arbitrary
+precision. Raw (unreduced) numerators + den emitted so the souc minimal-BigInt leg can match exactly
+without needing gcd. See sedenion_cd_qbig.md."""
+
+
+def cd_sigma(a, b, bits=4):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH, bH, aL, bL = a >= half, b >= half, a & (half - 1), b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def cd16(An, Bn):
+    out = [0] * 16
+    for i in range(16):
+        if An[i] == 0:
+            continue
+        for j in range(16):
+            if Bn[j] == 0:
+                continue
+            out[i ^ j] += cd_sigma(i, j) * An[i] * Bn[j]
+    return out
+
+
+# Case 1: a known ZD pair scaled by 10^40 -> exact annihilation, den 1. (e3+e10)(e6-e15).
+S = 10 ** 40
+A1 = [0] * 16; A1[3] = S; A1[10] = S
+B1 = [0] * 16; B1[6] = S; B1[15] = -S
+# Case 2: general 16-comp product, unbounded rational coeffs over common denoms.
+A2 = [0] * 16; A2[1] = 10 ** 30; A2[2] = 3 * 10 ** 28; A2[4] = -5 * 10 ** 35; A2[8] = 10 ** 33; A2[15] = 7 * 10 ** 20
+Ad2 = 6
+B2 = [0] * 16; B2[1] = 2 * 10 ** 31; B2[5] = -10 ** 29; B2[7] = 4 * 10 ** 27; B2[10] = 9 * 10 ** 34
+Bd2 = 10
+
+cases = [("1", A1, 1, B1, 1), ("2", A2, Ad2, B2, Bd2)]
+P = 1000000007
+allzero1 = True
+for (tag, An, Ad, Bn, Bd) in cases:
+    out = cd16(An, Bn)
+    den = Ad * Bd
+    for k in range(16):
+        print(f"EXACT {tag} {k} {out[k]}")      # exact decimal (record; also witnessed by Lean)
+        print(f"RES {out[k] % P}")              # residue mod 1e9+7 (gated vs souc, same order)
+        if tag == "1" and out[k] != 0:
+            allzero1 = False
+    print(f"EXACT {tag} DEN {den}")
+    print(f"RES {den % P}")
+print(f"ANNIHILATION_C1 {1 if allzero1 else 0}")

--- a/tests/run-pass/sedenion_cd_qbig.sio
+++ b/tests/run-pass/sedenion_cd_qbig.sio
@@ -1,0 +1,320 @@
+//@ run-pass
+//@ expect-stdout: CDQBIG OK
+// FRONTIER (Paper 1 open item) — the exact Cayley-Dickson product over UNBOUNDED ℚ, ALL 16 components.
+//
+// The i64 version (sedenion_cd_full16_q.sio) does the full 16-comp ℚ product via the common-denominator
+// reduction, but caps at coefficients ~1e8 (i64 output). This closes the unbounded case with a minimal,
+// self-contained SIGNED BigInt (base 1e9 limbs) — so numerators/denominators are ARBITRARY precision.
+//
+// WHY A LOCAL BigInt. The stdlib `math::bignat` full big×big `big_mul` SIGSEGVs under souc v0.80.0
+// (a single `big_mul(a,b)`, no arrays, no loop — a clean #651/#637 struct-copy repro), and `[BigInt;16]`
+// SIGSEGVs (the array-of-structs wall). This brick CIRCUMVENTS both — it does NOT fix #651 — exactly as
+// the i64 common-denom circumvented #637: (i) a minimal in-file BigInt built only from primitives that
+// empirically compile (schoolbook big×big = big_mul_small + limb-shift + big_add-in-loop, which the spike
+// confirms runs); (ii) the 16 numerators are held in FLAT scalar arrays [i64;N], never [BigInt;16].
+//
+// Common-denom identity: a rational sedenion = 16 integer numerators A[16] over a common denom Ad;
+//   (A·B)[k] = (Σ_{i⊕j=k} σ(i,j) A[i] B[j]) / (Ad·Bd)  — an INTEGER 16-comp product of numerators.
+// Certified on two cases: (1) a known zero divisor scaled by 10^40 — product EXACTLY 0 in all 16 comps
+// at magnitude 10^80 (i64 would overflow into garbage; exactness holds); (2) a general 16-comp product
+// with unbounded rational coefficients (components up to ~10^70). Each component's residue mod 1e9+7 is
+// emitted (byte-identical across souc builds; a per-limb decimal printer is miscompiled differently by
+// bin/souc vs stage2) and cross-verified vs the Python oracle; the EXACT decimals are witnessed by Lean
+// (native Int, SounioCDqbig.lean) and the oracle (exact ℚ). Case 1's annihilation is checked structurally.
+
+struct SBig { limb: [i64; 12], len: i64, neg: i64 }
+
+fn cd_sigma_c(a: i64, b: i64, bits: i64) -> i64 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma_c(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma_c(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma_c(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma_c(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma_c(0, a_lo, bits - 1) }
+    cd_sigma_c(b_lo, a_lo, bits - 1)
+}
+fn s_is_zero(a: SBig) -> bool with Mut, Panic { a.len == 1 && a.limb[0 as usize] == 0 }
+fn sfrom(x: i64) -> SBig with Mut, Panic, Div {
+    var r = SBig { limb: [0; 12], len: 1, neg: if x < 0 { 1 } else { 0 } }
+    var v = if x < 0 { 0 - x } else { x }
+    var i = 0
+    while v > 0 && i < 12 {
+        r.limb[i as usize] = v % 1000000000
+        v = v / 1000000000
+        i = i + 1
+    }
+    if i > 0 { r.len = i }
+    r
+}
+// magnitude * small (m >= 0), sign dropped
+fn smul_small(a: SBig, m: i64) -> SBig with Mut, Panic, Div {
+    var r = SBig { limb: [0; 12], len: a.len, neg: 0 }
+    var carry = 0
+    var i = 0
+    while i < a.len {
+        let p = a.limb[i as usize] * m + carry
+        r.limb[i as usize] = p % 1000000000
+        carry = p / 1000000000
+        i = i + 1
+    }
+    while carry > 0 && i < 12 {
+        r.limb[i as usize] = carry % 1000000000
+        carry = carry / 1000000000
+        r.len = i + 1
+        i = i + 1
+    }
+    r
+}
+fn sshift(a: SBig, sh: i64) -> SBig with Mut, Panic, Div {
+    if s_is_zero(a) { return a }
+    var r = SBig { limb: [0; 12], len: a.len + sh, neg: 0 }
+    var i = a.len - 1
+    while i >= 0 {
+        if (i + sh) < 12 { r.limb[(i + sh) as usize] = a.limb[i as usize] }
+        i = i - 1
+    }
+    r
+}
+fn spow10(n: i64) -> SBig with Mut, Panic, Div {
+    var r = sfrom(1)
+    var c = 0
+    while c < n { r = smul_small(r, 10)  c = c + 1 }
+    r
+}
+// magnitude compare: 1 if |a|>|b|, -1 if <, 0 eq
+fn ucmp(a: SBig, b: SBig) -> i64 with Mut, Panic, Div {
+    var i = 11
+    while i >= 0 {
+        let av = a.limb[i as usize]
+        let bv = b.limb[i as usize]
+        if av > bv { return 1 }
+        if av < bv { return 0 - 1 }
+        i = i - 1
+    }
+    0
+}
+// magnitude add
+fn uadd(a: SBig, b: SBig) -> SBig with Mut, Panic, Div {
+    var r = SBig { limb: [0; 12], len: if a.len > b.len { a.len } else { b.len }, neg: 0 }
+    var carry = 0
+    var i = 0
+    while i < r.len {
+        let s = a.limb[i as usize] + b.limb[i as usize] + carry
+        r.limb[i as usize] = s % 1000000000
+        carry = s / 1000000000
+        i = i + 1
+    }
+    if carry > 0 && r.len < 12 { r.limb[r.len as usize] = carry  r.len = r.len + 1 }
+    r
+}
+// magnitude sub, requires |a| >= |b|
+fn usub(a: SBig, b: SBig) -> SBig with Mut, Panic, Div {
+    var r = SBig { limb: [0; 12], len: a.len, neg: 0 }
+    var borrow = 0
+    var i = 0
+    while i < a.len {
+        var d = a.limb[i as usize] - b.limb[i as usize] - borrow
+        if d < 0 { d = d + 1000000000  borrow = 1 } else { borrow = 0 }
+        r.limb[i as usize] = d
+        i = i + 1
+    }
+    // trim len
+    var L = a.len
+    while L > 1 && r.limb[(L - 1) as usize] == 0 { L = L - 1 }
+    r.len = L
+    r
+}
+fn sadd(a: SBig, b: SBig) -> SBig with Mut, Panic, Div {
+    if a.neg == b.neg {
+        var r = uadd(a, b)
+        if !s_is_zero(r) { r.neg = a.neg }
+        return r
+    }
+    let c = ucmp(a, b)
+    if c == 0 { return sfrom(0) }
+    if c > 0 {
+        var r = usub(a, b)
+        if !s_is_zero(r) { r.neg = a.neg }
+        return r
+    }
+    var r = usub(b, a)
+    if !s_is_zero(r) { r.neg = b.neg }
+    r
+}
+fn smul(a: SBig, b: SBig) -> SBig with Mut, Panic, Div {
+    var acc = sfrom(0)
+    var i = 0
+    while i < b.len {
+        let part = sshift(smul_small(a, b.limb[i as usize]), i)
+        acc = uadd(acc, part)
+        i = i + 1
+    }
+    if !s_is_zero(acc) {
+        acc.neg = if a.neg == b.neg { 0 } else { 1 }
+    }
+    acc
+}
+fn sneg(a: SBig) -> SBig with Mut, Panic, Div {
+    var r = SBig { limb: [0; 12], len: a.len, neg: 0 }
+    var t = 0
+    while t < 12 { r.limb[t as usize] = a.limb[t as usize]  t = t + 1 }
+    if !s_is_zero(a) { r.neg = 1 - a.neg }
+    r
+}
+// Signed residue of a BigInt modulo a small prime p, normalized to [0, p). We emit residues (not the
+// full decimal) because printing 70-digit numbers via a per-limb helper is miscompiled DIFFERENTLY by
+// the two souc builds (bin/souc vs stage2 diverge on print-in-loop / print_int newline), whereas
+// `print("RES ") print_int(x) print("\n")` is byte-identical on both. A digit error changes the residue
+// with overwhelming probability; the EXACT decimal values are witnessed independently by Lean (native
+// Int) and the Python oracle (exact ℚ). Horner fold: r = (r*base + limb) mod p, high limb to low.
+fn smod_small(a: SBig, p: i64) -> i64 with Mut, Panic, Div {
+    var r = 0
+    var i = 11
+    while i >= 0 {
+        r = (r * 1000000000 + a.limb[i as usize]) % p
+        i = i - 1
+    }
+    if a.neg == 1 && r != 0 { r = p - r }
+    r
+}
+
+// compute (A·B)[k] for all k and print; A,B given as flat limb arrays + nz flags; dens Ad,Bd.
+// returns 1 if all 16 comps are zero (annihilation), else 0.
+fn cd16_emit(tag: i64, alimb: [i64; 192], alen: [i64; 16], aneg: [i64; 16], anz: [i64; 16],
+             blimb: [i64; 192], blen: [i64; 16], bneg: [i64; 16], bnz: [i64; 16],
+             ad: SBig, bd: SBig) -> i64 with IO, Mut, Panic, Div {
+    var allzero = 1
+    var k = 0
+    while k < 16 {
+        var acc = sfrom(0)
+        var i = 0
+        while i < 16 {
+            let j = i ^ k
+            if anz[i as usize] == 1 && bnz[j as usize] == 1 {
+                // reconstruct A[i], B[j]
+                var ai = SBig { limb: [0; 12], len: alen[i as usize], neg: aneg[i as usize] }
+                var bj = SBig { limb: [0; 12], len: blen[j as usize], neg: bneg[j as usize] }
+                var t = 0
+                while t < 12 {
+                    ai.limb[t as usize] = alimb[(i * 12 + t) as usize]
+                    bj.limb[t as usize] = blimb[(j * 12 + t) as usize]
+                    t = t + 1
+                }
+                var term = smul(ai, bj)
+                if cd_sigma_c(i, j, 4) < 0 { term = sneg(term) }
+                acc = sadd(acc, term)
+            }
+            i = i + 1
+        }
+        if !s_is_zero(acc) { allzero = 0 }
+        // emit residue mod (10^9+7); order is (case1 comp0..15, den), (case2 comp0..15, den).
+        print("RES ")
+        print_int(smod_small(acc, 1000000007))
+        print("\n")
+        k = k + 1
+    }
+    let den = smul(ad, bd)
+    print("RES ")
+    print_int(smod_small(den, 1000000007))
+    print("\n")
+    allzero
+}
+
+fn main() with IO, Mut, Panic, Div {
+    // ---- CASE 1: (e3 + e10)(e6 - e15) scaled by 10^40 -> exact annihilation, den 1 ----
+    var A1l = [0; 192]
+    var A1len = [1; 16]
+    var A1neg = [0; 16]
+    var A1nz = [0; 16]
+    var B1l = [0; 192]
+    var B1len = [1; 16]
+    var B1neg = [0; 16]
+    var B1nz = [0; 16]
+    let S = spow10(40)
+    // A1[3] = 10^40, A1[10] = 10^40
+    var idxa = [3, 10]
+    var p = 0
+    while p < 2 {
+        let idx = idxa[p as usize]
+        var t = 0
+        while t < 12 { A1l[(idx * 12 + t) as usize] = S.limb[t as usize]  t = t + 1 }
+        A1len[idx as usize] = S.len
+        A1nz[idx as usize] = 1
+        p = p + 1
+    }
+    // B1[6] = 10^40, B1[15] = -10^40
+    var idxb = [6, 15]
+    var sgnb = [0, 1]
+    p = 0
+    while p < 2 {
+        let idx = idxb[p as usize]
+        var t = 0
+        while t < 12 { B1l[(idx * 12 + t) as usize] = S.limb[t as usize]  t = t + 1 }
+        B1len[idx as usize] = S.len
+        B1neg[idx as usize] = sgnb[p as usize]
+        B1nz[idx as usize] = 1
+        p = p + 1
+    }
+    let c1_zero = cd16_emit(1, A1l, A1len, A1neg, A1nz, B1l, B1len, B1neg, B1nz, sfrom(1), sfrom(1))
+
+    // ---- CASE 2: general 16-comp product, unbounded rational coeffs ----
+    // A2: idx {1,2,4,8,15} = {1e30, 3e28, -5e35, 1e33, 7e20} / 6
+    // B2: idx {1,5,7,10}   = {2e31, -1e29, 4e27, 9e34} / 10
+    var A2l = [0; 192]
+    var A2len = [1; 16]
+    var A2neg = [0; 16]
+    var A2nz = [0; 16]
+    var B2l = [0; 192]
+    var B2len = [1; 16]
+    var B2neg = [0; 16]
+    var B2nz = [0; 16]
+    var pa = [1, 2, 4, 8, 15]
+    var pae = [30, 28, 35, 33, 20]
+    var pam = [1, 3, 5, 1, 7]
+    var pan = [0, 0, 1, 0, 0]
+    p = 0
+    while p < 5 {
+        let idx = pa[p as usize]
+        var v = smul_small(spow10(pae[p as usize]), pam[p as usize])
+        var t = 0
+        while t < 12 { A2l[(idx * 12 + t) as usize] = v.limb[t as usize]  t = t + 1 }
+        A2len[idx as usize] = v.len
+        A2neg[idx as usize] = pan[p as usize]
+        A2nz[idx as usize] = 1
+        p = p + 1
+    }
+    var pb = [1, 5, 7, 10]
+    var pbe = [31, 29, 27, 34]
+    var pbm = [2, 1, 4, 9]
+    var pbn = [0, 1, 0, 0]
+    p = 0
+    while p < 4 {
+        let idx = pb[p as usize]
+        var v = smul_small(spow10(pbe[p as usize]), pbm[p as usize])
+        var t = 0
+        while t < 12 { B2l[(idx * 12 + t) as usize] = v.limb[t as usize]  t = t + 1 }
+        B2len[idx as usize] = v.len
+        B2neg[idx as usize] = pbn[p as usize]
+        B2nz[idx as usize] = 1
+        p = p + 1
+    }
+    let c2_zero = cd16_emit(2, A2l, A2len, A2neg, A2nz, B2l, B2len, B2neg, B2nz, sfrom(6), sfrom(10))
+
+    print("ANNIHILATION_C1 ")
+    print_int(c1_zero)
+    print("\n")
+    // Case 1 annihilates exactly at 10^80; Case 2 general product emitted (cross-checked vs oracle).
+    if c1_zero == 1 && c2_zero == 0 {
+        println("CDQBIG OK")
+    } else {
+        println("CDQBIG FAIL")
+    }
+}


### PR DESCRIPTION
**Closes the Paper 1 infrastructure frontier.** The full 16-component sedenion product over ℚ with **arbitrary-precision** rational coefficients. The i64 version capped at ~1e8; this reaches ~**10^80 exactly** via a minimal self-contained signed BigInt (base-1e9 limbs).

- **Case 1 — exact annihilation at 10^80.** `(e₃+e₁₀)(e₆−e₁₅)` scaled by 10^40 → **all 16 components exactly 0** (i64 would overflow to garbage).
- **Case 2 — general unbounded product**, components to ~10^70, cross-verified.

**Circumvents (does not fix) #651**: stdlib `big_mul(a,b)` SIGSEGVs (single call, no arrays/loop — a clean #651/#637 repro), and `[BigInt;16]` SIGSEGVs. So (i) a minimal in-file BigInt from only-compiling primitives (schoolbook big×big = mul_small + shift + add-in-loop, spike-confirmed), (ii) 16 numerators in **flat scalar arrays**, never `[BigInt;16]`.

**3 legs**: souc (bin/souc AND stage2 — emits residues mod 1e9+7, byte-identical on both; a per-limb decimal printer is miscompiled *differently* by the two builds) + Python oracle (exact ℚ) + Lean native `Int` (digit-exact witness: case1=0, case2 exact values). The souc-build divergence on print-in-loop / print_int-newline is itself documented here.