### PR TITLE
feat(exact): general proof step — e_i²=−1 for ALL Cayley–Dickson levels (structural induction)

### DIFF
--- a/docs/research/cd_tower_seam.md
+++ b/docs/research/cd_tower_seam.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.cd-tower-seam
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
@@ -42,7 +43,11 @@ that the two *a-priori-unrelated* sets land on it.)
 
 **The base fact `L_i²=−I`** is the CD cocycle identity `σ(i,j)·σ(i,i⊕j) = −1` (all `i≥1`, all `j`),
 certified here at dim 16/32/64. A Mathlib-free general induction on `bits` would upgrade the forward
-obstruction to a theorem for *all* n; it is **left open**.
+obstruction to a theorem for *all* n. **First step done** (`formal/lean4/SounioCDCocycle.lean`): the CD
+sign is reformulated on explicit bit-lists (structural XOR; verified to agree with the Nat `cdSigma` at
+dim 16/32), and **`e_i²=−1` (diag) is proved for ALL n** by structural induction. The full `L_i²=−I`
+and basis-unit anticommutation close on paper (a simultaneous induction over the sign's four branches)
+but their Mathlib-free formalization is **still open** — they remain certified at n=4,5,6 above.
 
 **Open (all n): the converse.** `off-seam ⟹ e_l+e_u is a ZD` is *verified* at n=4,5,6, not proved — a
 tower-wide conjecture (the sedenion "natural next lemma" of `sedenion_seam_bridge.md`, now at tower

--- a/formal/lean4/SounioCDCocycle.lean
+++ b/formal/lean4/SounioCDCocycle.lean
@@ -1,0 +1,84 @@
+/-
+  SounioCDCocycle — a step toward proving the forward zero-divisor obstruction for ALL Cayley-Dickson
+  levels (not just the dims verified by native_decide in SounioCDTowerSeam). The obstruction reduces to
+  the OPERATOR identity L_i²=−I, i.e. σ(i,j)·σ(i,i⊕j)=−1 ∀j. On paper that closes by a simultaneous
+  induction over the CD sign's four branches, using {L (=L²), R (=R²), antisym (basis units anticommute),
+  diag (e_i²=−1)}. Here the CD sign is reformulated on explicit bit-lists `sgn` (MSB first; XOR is
+  structural `xorL`, no Nat arithmetic), verified to agree with the Nat `cdSigma` at dim 16 and 32.
+  PROVED for ALL n (structural induction): `diag` — e_i² = −1 for every imaginary basis unit. The
+  remaining members (antisym, and hence the full L_i²=−I) close on paper but their Mathlib-free
+  formalization is left open (the equation-compiler lemmas for the branching `sgn` resist `simp`);
+  they remain certified at n=4,5,6 in SounioCDTowerSeam. No sorry. No Mathlib.
+-/
+namespace SounioCDCocycle
+-- bit-list Cayley-Dickson sign, MSB first (head = top bit). Structural XOR, no Nat arithmetic.
+def isZ : List Bool → Bool
+  | [] => true
+  | b :: bs => (!b) && isZ bs
+def sgn : List Bool → List Bool → Int
+  | [], [] => 1
+  | [a], [b] => if a && b then -1 else 1
+  | a :: as, b :: bs =>
+      if isZ (a :: as) || isZ (b :: bs) then 1
+      else
+        match a, b with
+        | false, false => sgn as bs
+        | false, true  => sgn bs as
+        | true,  false => - sgn as bs
+        | true,  true  => if isZ bs then -1 else sgn bs as
+  | _, _ => 0
+termination_by a b => a.length + b.length
+decreasing_by all_goals (simp_wf; omega)
+
+def xorL : List Bool → List Bool → List Bool
+  | a :: as, b :: bs => (xor a b) :: xorL as bs
+  | _, _ => []
+-- zeros of a given length
+def zeros : Nat → List Bool
+  | 0 => []
+  | n+1 => false :: zeros n
+
+-- sanity: matches the Nat cdSigma at small dims? convert Nat->bits (MSB first, fixed width) and compare.
+def bitsOf : Nat → Nat → List Bool     -- width, value
+  | 0, _ => []
+  | w+1, v => (decide (v ≥ 2^w)) :: bitsOf w (v % 2^w)
+def cdSigma (a b : Nat) : Nat → Int
+  | 0 => -1
+  | 1 => if a == 0 || b == 0 then 1 else -1
+  | (n+2) =>
+      if a == 0 || b == 0 then 1
+      else
+        let half := 2 ^ (n+1)
+        if !(a ≥ half) && !(b ≥ half) then cdSigma (a%half) (b%half) (n+1)
+        else if !(a ≥ half) && (b ≥ half) then cdSigma (b%half) (a%half) (n+1)
+        else if (a ≥ half) && !(b ≥ half) then (if b%half == 0 then cdSigma (a%half) 0 (n+1) else - cdSigma (a%half) (b%half) (n+1))
+        else (if b%half == 0 then - cdSigma 0 (a%half) (n+1) else cdSigma (b%half) (a%half) (n+1))
+-- agreement at width 4 (dim 16): sgn on bit-lists == cdSigma on Nats
+theorem agree4 : (List.range 16).all (fun i => (List.range 16).all (fun j =>
+  sgn (bitsOf 4 i) (bitsOf 4 j) == cdSigma i j 4)) = true := by native_decide
+theorem agree5 : (List.range 32).all (fun i => (List.range 32).all (fun j =>
+  sgn (bitsOf 5 i) (bitsOf 5 j) == cdSigma i j 5)) = true := by native_decide
+-- xorL matches Nat xor at width 4
+theorem xor_agree4 : (List.range 16).all (fun i => (List.range 16).all (fun j =>
+  xorL (bitsOf 4 i) (bitsOf 4 j) == bitsOf 4 (i ^^^ j))) = true := by native_decide
+
+-- diag: e_i^2 = -1 for every imaginary basis unit, ALL n (structural induction).
+theorem diag : ∀ i : List Bool, isZ i = false → sgn i i = -1
+  | [], h => by simp [isZ] at h
+  | [a], h => by cases a <;> simp_all [isZ, sgn]
+  | a :: b :: as, h => by
+      have hz : isZ (a :: b :: as) = false := h
+      cases a with
+      | false =>
+        have hb : isZ (b :: as) = false := by simpa [isZ] using hz
+        simp only [sgn, hz, Bool.or_self, if_false]
+        exact diag (b :: as) hb
+      | true =>
+        by_cases hbz : isZ (b :: as) = true
+        · simp [sgn, hz, hbz]
+        · have hb : isZ (b :: as) = false := by simpa using hbz
+          simp only [sgn, hz, Bool.or_self, hb]
+          exact diag (b :: as) hb
+
+
+end SounioCDCocycle

--- a/formal/lean4/lakefile.lean
+++ b/formal/lean4/lakefile.lean
@@ -73,6 +73,9 @@ lean_lib «SounioZeroDivisorBridge» where
 lean_lib «SounioSedenionMeasurement» where
 
 @[default_target]
+lean_lib «SounioCDCocycle» where
+
+@[default_target]
 lean_lib «SounioCDTowerSeam» where
 
 @[default_target]


### PR DESCRIPTION
Toward proving the forward zero-divisor obstruction for **all n** (not just the native_decide dims of the tower brick #717). The obstruction reduces to the operator identity `L_i²=−I` (`σ(i,j)σ(i,i⊕j)=−1`).

`SounioCDCocycle.lean`: the CD sign is reformulated on explicit **bit-lists** (structural XOR, no Nat arithmetic), verified to agree with the Nat `cdSigma` at dim 16/32, and **`e_i²=−1` (diag) is proved for ALL n by structural induction** — a genuine universal theorem, not a per-level check.

**Honest boundary:** the full `L_i²=−I` and basis-unit anticommutation close *on paper* (a simultaneous induction over the sign's four branches, `{L,R,antisym,diag}`), but their Mathlib-free formalization is **left open** (the branching `sgn`'s equation lemmas resist `simp`); they stay certified at n=4,5,6 in #717. One member (diag) is proved universally; the general forward-obstruction proof remains the standing target.