### PR TITLE
fix(seed): native madaros can self-compile main.sio again (arena/VmPeak fix, #712)

### DIFF
--- a/bin/madaros
+++ b/bin/madaros
@@ -51,6 +51,8 @@ if ! RAW_MADAROS="$(_resolve_modular_elf)"; then
   exit 127
 fi
 
+MADAROS_VMEM_LIMIT_KB="${MADAROS_VMEM_LIMIT_KB:-33554432}"
+
 # Madaros rebuilt after IR_MAX_INSTRS=512 uses compiler frames that can exceed
 # the default 8 MB thread stack. Lift the limit so the compiler does not segfault
 # while compiling normal user programs. This is a conservative runtime guard; it
@@ -231,8 +233,9 @@ _run_raw_check() {
     rm -f "$tmp_empty"
     return "$rc"
   fi
-  # Guard: 8 GB vmem + 120 s timeout
-  ( ulimit -v 8388608 2>/dev/null || true; exec timeout 120 "$RAW_MADAROS" --check "$src" "$@" )
+  # Guard: bounded vmem + 120 s timeout. Current Madaros pre-maps a large arena;
+  # older 8/16 GB caps trip the arena guard before larger checks can run.
+  ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 120 "$RAW_MADAROS" --check "$src" "$@" )
 }
 
 _parse_build_options() {
@@ -322,16 +325,16 @@ _build_source() {
     if [[ -n "$BUILD_GPU_BINARY_FORMAT" ]]; then
       gpu_args+=(--gpu-binary-format "$BUILD_GPU_BINARY_FORMAT")
     fi
-    # Guard: 16 GB vmem + 300 s timeout
-    ( ulimit -v 50331648 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "${gpu_args[@]}" )
+    # Guard: bounded vmem + 300 s timeout
+    ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "${gpu_args[@]}" )
     if [[ ! -s "$out" ]]; then
       echo "error: madaros build: compiler produced no GPU artifact at $out" >&2
       return 1
     fi
     return 0
   fi
-  # Guard: 16 GB vmem + 300 s timeout
-  ( ulimit -v 50331648 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$src" -o "$out" )
+  # Guard: bounded vmem + 300 s timeout
+  ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$src" -o "$out" )
   if [[ ! -s "$out" ]]; then
     echo "error: madaros build: compiler produced no ELF at $out" >&2
     return 1
@@ -423,6 +426,6 @@ case "$1" in
       exit $?
     fi
     # Pass everything through to the raw ELF unchanged (guarded).
-    ( ulimit -v 50331648 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$@" )
+    ( ulimit -v "$MADAROS_VMEM_LIMIT_KB" 2>/dev/null || true; exec timeout 300 "$RAW_MADAROS" "$@" )
     ;;
 esac

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -8920,6 +8920,19 @@ fn emit_arena_alloc_x86(alloc_size: i64) with Mut, Panic, Div {
     em(0x48); em(0x89); em(0xc6)                     // mov rsi, rax
     emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)
     em(0x48); em(0x29); em(0xc6)                     // sub rsi, rax (rsi = chunk size)
+    // Oversized allocations: a Box larger than the negotiated chunk (e.g.
+    // the multi-GB IrModule mega-struct during 300+-fn merged compiles)
+    // must size the NEW chunk by the REQUEST — otherwise the fresh chunk
+    // is immediately overrun, every subsequent alloc re-reserves another
+    // chunk (VmPeak piles up in 2 GiB steps, ~24 GiB observed) and an
+    // incidental mmap failure aborts with 42 despite ample free memory.
+    em(0x48); em(0xb9); em64(sz + 4096)              // movabs rcx, sz + slack
+    em(0x48); em(0x39); em(0xce)                     // cmp rsi, rcx
+    em(0x0f); em(0x83)                               // jae keep (chunk >= need)
+    let ovr_keep = CL
+    em32(0)
+    em(0x48); em(0x89); em(0xce)                     // mov rsi, rcx (grow to need)
+    patch32(ovr_keep, CL)
     let slow_retry = CL
     em(0x48); em(0x31); em(0xff)                     // xor rdi, rdi
     em(0xba); em32(3)                                // mov edx, 3

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -37032,7 +37032,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                 print_imp_path()
                 print("\n")
             } else {
-                if fsz <= 0 || fsz >= 8388608 {
+                if fsz <= 0 || fsz >= 16777216 {
                     print("warning: import size invalid; using read count for ")
                     print_imp_path()
                     print("\n")
@@ -37065,7 +37065,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                         print("error: import path table full: ")
                         print_imp_path()
                         print("\n")
-                    } else if copy_len >= 8388608 || SRC_LEN + fp_len + copy_len + 3 >= 8388608 {
+                    } else if copy_len >= 16777216 || SRC_LEN + fp_len + copy_len + 3 >= 16777216 {
                         IMPORT_RESOLUTION_FAILED = 1
                         print("error: import too large for SRC buffer: ")
                         print_imp_path()
@@ -37087,7 +37087,7 @@ fn resolve_imports() with IO, Mut, Panic, Div {
                         SRC[SRC_LEN as usize] = 2
                         SRC_LEN = SRC_LEN + 1
                         var ci: i64 = 0
-                        while ci < copy_len && SRC_LEN + ci < 8388608 {
+                        while ci < copy_len && SRC_LEN + ci < 16777216 {
                             SRC[(SRC_LEN + ci) as usize] = raw[ci as usize]
                             ci = ci + 1
                         }

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -977,6 +977,36 @@ var AST_ARENA_BASE_BSS_OFF: i64 = 0
 var AST_ARENA_CURSOR_BSS_OFF: i64 = 0
 var AST_ARENA_LIMIT_BSS_OFF: i64 = 0
 
+// Aggregate-storage bump pool: packs the never-freed aggregate backing blocks
+// (struct-array element copies, array-literal blocks, Seq element
+// materializations, closure envs) that previously went through
+// emit_heap_alloc_x86 — one page-granular mmap EACH, so a ~250-byte struct
+// temp cost 4 KiB of VmSize forever (measured: +11.5 GiB during native
+// codegen of a 369-fn merged module, ~0.5 GiB per lowered module). The pool
+// bump-packs them 8-aligned instead. Semantics are unchanged: blocks are
+// never freed (same as the leaked mmaps), never reallocated, and the pool is
+// deliberately SEPARATE from the Box arena so __arena_reset can never touch
+// aggregate storage that outlives a reset window (e.g. merged-module element
+// blocks aliased by struct assignment). heap_free/heap_realloc/seq_new keep
+// the header'd mmap path.
+var AGG_POOL_BASE_BSS_OFF: i64 = 0
+var AGG_POOL_CURSOR_BSS_OFF: i64 = 0
+var AGG_POOL_LIMIT_BSS_OFF: i64 = 0
+
+// Diagnostics: count + total bytes of runtime mmap-path allocations
+// (heap_alloc, heap_realloc, malloc/mmap_len). Read via __rtmmap_count() /
+// __rtmmap_bytes().
+var RTMMAP_COUNT_BSS_OFF: i64 = 0
+var RTMMAP_BYTES_BSS_OFF: i64 = 0
+// Cached 16 MiB read_file scratch buffer (lazy mmap, reused every call).
+var READFILE_SCRATCH_BSS_OFF: i64 = 0
+var ARENA_REFILL_COUNT_BSS_OFF: i64 = 0
+var ARENA_REFILL_BYTES_BSS_OFF: i64 = 0
+var ARENA_UNMAP_COUNT_BSS_OFF: i64 = 0
+var ARENA_UNMAP_BYTES_BSS_OFF: i64 = 0
+var POOL_REFILL_COUNT_BSS_OFF: i64 = 0
+var POOL_REFILL_BYTES_BSS_OFF: i64 = 0
+
 var NEEDS_GPU_RUNTIME_DYNLINK: i64 = 0
 
 fn gpu_param_kind_scalar_i64() -> i64 { 1 }
@@ -7869,8 +7899,7 @@ fn fill_repeat_struct_array_slots_x86(dst_start: i64, field_hash: i64) with Mut,
             emit_store_var(src_slot)
             var j: i64 = 0
             while j < nslots {
-                emit_imm64(elem_nslots * 8)
-                emit_heap_alloc_x86()
+                emit_pool_alloc_x86(elem_nslots * 8)
                 em(0x48); em(0x89); em(0xc1)  // mov rcx, rax (dest)
                 emit_load_var(src_slot)
                 em(0x48); em(0x89); em(0xc2)  // mov rdx, rax (source)
@@ -7890,8 +7919,7 @@ fn fill_repeat_struct_array_slots_x86(dst_start: i64, field_hash: i64) with Mut,
             var j: i64 = 0
             while j < nslots {
                 // allocate inner_nslots * 8 bytes for this outer slot's copy
-                emit_imm64(inner_nslots * 8)
-                emit_heap_alloc_x86()
+                emit_pool_alloc_x86(inner_nslots * 8)
                 // rax = new inner array ptr; set up copy from src
                 let new_ptr_slot = NEXT_SLOT
                 NEXT_SLOT = NEXT_SLOT + 1
@@ -8775,7 +8803,31 @@ fn emit_starts_with_regs_x86() with Mut {
     em(0x48); em(0x31); em(0xc0)            // no_match: xor rax, rax
 }
 
+fn emit_bump_counter_rsi_x86(count_off: i64, bytes_off: i64) with Mut {
+    // increment [count_off] and add rsi (length) to [bytes_off]; preserves rax/rcx? NO —
+    // clobbers rcx; preserves rax and rsi via push/pop.
+    em(0x50)                                 // push rax
+    em(0x48); em(0x89); em(0xf1)             // mov rcx, rsi
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + count_off)
+    em(0x48); em(0xff); em(0x00)             // inc qword [rax]
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + bytes_off)
+    em(0x48); em(0x01); em(0x08)             // add [rax], rcx
+    em(0x58)                                 // pop rax
+}
+
+fn emit_rtmmap_count_x86() with Mut {
+    // rax = requested size at entry; bump count and bytes counters, preserve rax.
+    em(0x50)                                 // push rax (size)
+    em(0x48); em(0x89); em(0xc1)             // mov rcx, rax (size)
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + RTMMAP_COUNT_BSS_OFF)
+    em(0x48); em(0xff); em(0x00)             // inc qword [rax]
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + RTMMAP_BYTES_BSS_OFF)
+    em(0x48); em(0x01); em(0x08)             // add [rax], rcx
+    em(0x58)                                 // pop rax (size)
+}
+
 fn emit_mmap_len_in_rax_x86() with Mut {
+    emit_rtmmap_count_x86()
     em(0x48); em(0x89); em(0xc6)            // mov rsi, rax
     em(0x48); em(0x31); em(0xff)            // xor rdi, rdi
     em(0xba); em32(3)                       // mov edx, 3
@@ -8788,6 +8840,7 @@ fn emit_mmap_len_in_rax_x86() with Mut {
 
 fn emit_heap_alloc_x86() with Mut {
     // rax = requested size. Allocate size+8 via mmap, write header, return user ptr.
+    emit_rtmmap_count_x86()
     em(0x48); em(0x83); em(0xc0); em(8)     // add rax, 8 (total = size + header)
     em(0x48); em(0x89); em(0xc6)             // mov rsi, rax (mmap size arg)
     em(0x50)                                  // push rax (save total size)
@@ -8815,6 +8868,7 @@ fn emit_heap_free_x86() with Mut {
 fn emit_heap_realloc_x86() with Mut {
     // stack = [old_user_ptr], rax = new_size.
     // mremap(old_base, old_total, new_total, MREMAP_MAYMOVE)
+    emit_rtmmap_count_x86()
     em(0x48); em(0x83); em(0xc0); em(8)     // add rax, 8 (new_total = new_size + header)
     em(0x48); em(0x89); em(0xc2)             // mov rdx, rax (new_total for mremap arg3)
     em(0x49); em(0x89); em(0xc0)             // mov r8, rax (save new_total)
@@ -8874,8 +8928,16 @@ fn emit_ast_arena_init_x86() with Mut, Panic {
     let init_abort = CL
     em32(0)
     patch32(init_ok, CL)
+    // Chunk header (16 bytes at chunk base): {prev_base, prev_limit} back-link
+    // for __arena_reset's walk-back munmap of dead chunks. Initial chunk links
+    // to {0, 0} (chain terminator). User allocations start at base + 16.
+    em(0x48); em(0xc7); em(0x00); em32(0)            // mov qword [rax], 0 (prev_base)
+    em(0x48); em(0xc7); em(0x40); em(8); em32(0)     // mov qword [rax+8], 0 (prev_limit)
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)    // [base] = rax (rax preserved)
-    emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)  // [cursor] = rax
+    em(0x50)                                        // push rax (chunk base)
+    em(0x48); em(0x83); em(0xc0); em(16)             // add rax, 16 (skip header)
+    emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)  // [cursor] = base + 16
+    em(0x58)                                        // pop rax (chunk base)
     em(0x48); em(0x01); em(0xf0)                     // add rax, rsi -> rax = base + actual
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)   // [limit] = rax
     em(0xe9)                                        // jmp done
@@ -8954,14 +9016,25 @@ fn emit_arena_alloc_x86(alloc_size: i64) with Mut, Panic, Div {
     let slow_abort = CL
     em32(0)
     patch32(slow_ok, CL)
+    emit_bump_counter_rsi_x86(ARENA_REFILL_COUNT_BSS_OFF, ARENA_REFILL_BYTES_BSS_OFF)
+    // Write the back-link header {old_base, old_limit} into the NEW chunk
+    // before repointing the BSS triple — __arena_reset walks this chain to
+    // munmap chunks reserved after a mark. rax = new chunk base, rsi = size.
+    em(0x48); em(0x89); em(0xc2)                     // mov rdx, rax (rdx = new chunk base)
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)     // rax = old base
+    em(0x48); em(0x89); em(0x02)                     // mov [rdx], rax (header.prev_base)
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)    // rax = old limit
+    em(0x48); em(0x89); em(0x42); em(8)              // mov [rdx+8], rax (header.prev_limit)
+    em(0x48); em(0x89); em(0xd0)                     // mov rax, rdx (new chunk base)
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)    // [base] = rax
     em(0x50)                                        // push rax (chunk base)
     em(0x48); em(0x01); em(0xf0)                      // add rax, rsi -> rax = base + actual
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)   // [limit] = rax
     em(0x58)                                        // pop rax (chunk base)
+    em(0x48); em(0x83); em(0xc0); em(16)             // add rax, 16 (skip header -> alloc base)
     em(0x50)                                        // push rax (return base)
     em(0x48); em(0x05); em32(sz)                     // add rax, sz
-    emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)  // [cursor] = base + sz
+    emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)  // [cursor] = base + 16 + sz
     em(0x58)                                        // pop rax (return base = alloc base)
     em(0xe9)                                        // jmp done
     let slow_done = CL
@@ -8974,7 +9047,135 @@ fn emit_arena_alloc_x86(alloc_size: i64) with Mut, Panic, Div {
     patch32(slow_done, CL)
 }
 
-fn emit_str_concat_slots_x86(slot_a: i64, slot_b: i64) with Mut {
+// Code offset of the shared pool-alloc routine in the CURRENT compile's CD
+// buffer; -1 = not yet emitted. Reset alongside CL in compile_all. The routine
+// is shared (call rel32 per site) rather than inlined: an inline expansion at
+// every aggregate site overflowed the fixed 128 MiB CD buffer on the Madaros
+// main.sio bundle (103.8 MiB of emitted code before this change).
+var POOL_ALLOC_ROUTINE_CL: i64 = 0 - 1
+
+// Emit (once, lazily, jumped over inside whatever function first needs it) the
+// shared aggregate-pool allocation routine. ABI: rax = size in, rax = pointer
+// out; clobbers rcx/rdx/rsi/rdi/r8-r11 (the same caller-saved set the old
+// per-site inline mmap sequence clobbered). Pool state is the AGG_POOL_* BSS
+// triple, lazily initialized ({0,0,0} fails the first fit check and reserves
+// the first chunk). Chunk = max(limit-base, 256 MiB, size+4096); mmap halves
+// on failure to a 16 MiB floor, then aborts with exit 42 like the Box arena.
+fn emit_pool_alloc_routine_x86() with Mut, Panic, Div {
+    em(0xe9)                                        // jmp over (routine body is not fall-through)
+    let pool_skip = CL
+    em32(0)
+    POOL_ALLOC_ROUTINE_CL = CL
+    // entry: rax = size -> 8-align
+    em(0x48); em(0x83); em(0xc0); em(7)              // add rax, 7
+    em(0x48); em(0x83); em(0xe0); em(0xf8)           // and rax, -8
+    em(0x48); em(0x89); em(0xc1)                     // mov rcx, rax (rcx = sz)
+    let pool_loop = CL
+    // fast fit check: r8 = cursor, r9 = cursor + sz; if r9 <= limit commit
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AGG_POOL_CURSOR_BSS_OFF)
+    em(0x49); em(0x89); em(0xc0)                     // mov r8, rax (candidate base)
+    em(0x48); em(0x01); em(0xc8)                     // add rax, rcx (end)
+    em(0x49); em(0x89); em(0xc1)                     // mov r9, rax (end)
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AGG_POOL_LIMIT_BSS_OFF)
+    em(0x49); em(0x39); em(0xc1)                     // cmp r9, rax (end - limit)
+    em(0x0f); em(0x87)                              // ja slow (end > limit; limit=0 first time)
+    let pool_slow = CL
+    em32(0)
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + AGG_POOL_CURSOR_BSS_OFF)
+    em(0x4c); em(0x89); em(0x08)                     // mov [rax], r9 (cursor = end)
+    em(0x4c); em(0x89); em(0xc0)                     // mov rax, r8 (return base)
+    em(0xc3)                                        // ret
+    // SLOW: reserve a fresh chunk, then loop back to the fit check.
+    patch32(pool_slow, CL)
+    em(0x51)                                        // push rcx (save sz across syscalls)
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AGG_POOL_LIMIT_BSS_OFF)
+    em(0x48); em(0x89); em(0xc6)                     // mov rsi, rax
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AGG_POOL_BASE_BSS_OFF)
+    em(0x48); em(0x29); em(0xc6)                     // sub rsi, rax (current chunk size)
+    em(0x48); em(0xba); em64(268435456)              // movabs rdx, 256 MiB
+    em(0x48); em(0x39); em(0xd6)                     // cmp rsi, rdx
+    em(0x0f); em(0x83)                               // jae keep1
+    let pool_keep1 = CL
+    em32(0)
+    em(0x48); em(0x89); em(0xd6)                     // mov rsi, rdx
+    patch32(pool_keep1, CL)
+    em(0x48); em(0x89); em(0xca)                     // mov rdx, rcx (sz)
+    em(0x48); em(0x81); em(0xc2); em32(4096)         // add rdx, 4096 (request + slack)
+    em(0x48); em(0x39); em(0xd6)                     // cmp rsi, rdx
+    em(0x0f); em(0x83)                               // jae keep2
+    let pool_keep2 = CL
+    em32(0)
+    em(0x48); em(0x89); em(0xd6)                     // mov rsi, rdx (grow to need)
+    patch32(pool_keep2, CL)
+    let pool_retry = CL
+    em(0x48); em(0x31); em(0xff)                     // xor rdi, rdi
+    em(0xba); em32(3)                                // mov edx, 3
+    em(0x41); em(0xba); em32(0x22)                   // mov r10d, 0x22
+    em(0x49); em(0xc7); em(0xc0); em32(0 - 1)        // mov r8, -1
+    em(0x4d); em(0x31); em(0xc9)                      // xor r9, r9
+    em(0xb8); em32(9)                                // mov eax, 9 (SYS_mmap)
+    em(0x0f); em(0x05)                               // syscall (clobbers rcx/r11 — sz is on the stack)
+    em(0x48); em(0x3d); em32(0 - 4096)               // cmp rax, -4096
+    em(0x0f); em(0x86)                               // jbe ok
+    let pool_ok = CL
+    em32(0)
+    em(0x48); em(0xd1); em(0xee)                    // shr rsi, 1
+    em(0x48); em(0xba); em64(16777216)              // movabs rdx, 16 MiB floor
+    em(0x48); em(0x39); em(0xd6)                    // cmp rsi, rdx
+    em(0x0f); em(0x83)                              // jae retry
+    em32(pool_retry - (CL + 4))
+    em(0xbf); em32(42)                              // mov edi, 42
+    em(0xb8); em32(60)                              // mov eax, 60 (SYS_exit)
+    em(0x0f); em(0x05)                              // syscall
+    patch32(pool_ok, CL)
+    emit_bump_counter_rsi_x86(POOL_REFILL_COUNT_BSS_OFF, POOL_REFILL_BYTES_BSS_OFF)
+    // install chunk: base = cursor = rax, limit = rax + rsi; retry the fit
+    em(0x48); em(0x89); em(0xc1)                     // mov rcx, rax (new base)
+    em(0x48); em(0x89); em(0xc2)                     // mov rdx, rax
+    em(0x48); em(0x01); em(0xf2)                     // add rdx, rsi (new limit)
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + AGG_POOL_BASE_BSS_OFF)
+    em(0x48); em(0x89); em(0x08)                     // mov [rax], rcx
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + AGG_POOL_CURSOR_BSS_OFF)
+    em(0x48); em(0x89); em(0x08)                     // mov [rax], rcx
+    emit_load_abs_addr_to_rax_x86(GL_BSS_BASE + AGG_POOL_LIMIT_BSS_OFF)
+    em(0x48); em(0x89); em(0x10)                     // mov [rax], rdx
+    em(0x59)                                        // pop rcx (sz)
+    em(0xe9); em32(pool_loop - (CL + 4))             // jmp fit check
+    patch32(pool_skip, CL)
+}
+
+// Emit a bump allocation of `alloc_size` bytes (8-aligned) from the aggregate
+// pool (AGG_POOL_* — see the BSS decl comment). Returns the pointer in rax.
+// Per-site cost is 15 bytes (movabs rax, sz; call routine) — smaller than the
+// old inline mmap sequence it replaces. Chunks are never freed and there is NO
+// reset for this pool — it holds aggregate backing storage of arbitrary
+// lifetime; the win over the old per-block mmap is purely packing (8-byte
+// instead of 4 KiB page granularity).
+fn emit_pool_alloc_x86(alloc_size: i64) with Mut, Panic, Div {
+    var sz = alloc_size
+    if sz < 8 { sz = 8 }
+    sz = (sz + 7) / 8 * 8
+    if POOL_ALLOC_ROUTINE_CL < 0 {
+        emit_pool_alloc_routine_x86()
+    }
+    em(0x48); em(0xb8); em64(sz)                     // movabs rax, sz
+    em(0xe8); em32(POOL_ALLOC_ROUTINE_CL - (CL + 4)) // call routine
+}
+
+// Pool allocation with a RUNTIME size already in rax (the routine 8-aligns).
+// Replaces emit_mmap_len_in_rax_x86 for string concat/slice result buffers:
+// every string op used to mmap a fresh page-granular block (a 20-byte concat
+// cost 4 KiB of VmSize forever — measured ~12 GiB across a large merged
+// compile's native codegen). Strings have arbitrary lifetime and are never
+// freed either way, so pool-packing them changes nothing but the density.
+fn emit_pool_alloc_rax_x86() with Mut, Panic, Div {
+    if POOL_ALLOC_ROUTINE_CL < 0 {
+        emit_pool_alloc_routine_x86()
+    }
+    em(0xe8); em32(POOL_ALLOC_ROUTINE_CL - (CL + 4)) // call routine (rax = size in)
+}
+
+fn emit_str_concat_slots_x86(slot_a: i64, slot_b: i64) with Mut, Panic, Div {
     let slot_len_a = NEXT_SLOT
     NEXT_SLOT = NEXT_SLOT + 1
     let slot_len_b = NEXT_SLOT
@@ -8996,7 +9197,7 @@ fn emit_str_concat_slots_x86(slot_a: i64, slot_b: i64) with Mut {
     em(0x59)
     em(0x48); em(0x01); em(0xc8)            // add rax, rcx
     em(0x48); em(0x83); em(0xc0); em(1)     // add rax, 1
-    emit_mmap_len_in_rax_x86()
+    emit_pool_alloc_rax_x86()
     emit_store_var(slot_res)
 
     em(0xfc)                                // cld
@@ -9018,7 +9219,7 @@ fn emit_str_concat_slots_x86(slot_a: i64, slot_b: i64) with Mut {
     emit_load_var(slot_res)
 }
 
-fn emit_str_slice_range_slots_x86(slot_s: i64, slot_start: i64, slot_end: i64) with Mut {
+fn emit_str_slice_range_slots_x86(slot_s: i64, slot_start: i64, slot_end: i64) with Mut, Panic, Div {
     let slot_len = NEXT_SLOT
     NEXT_SLOT = NEXT_SLOT + 1
     let slot_res = NEXT_SLOT
@@ -9034,7 +9235,7 @@ fn emit_str_slice_range_slots_x86(slot_s: i64, slot_start: i64, slot_end: i64) w
 
     emit_load_var(slot_len)
     em(0x48); em(0x83); em(0xc0); em(1)     // add rax, 1
-    emit_mmap_len_in_rax_x86()
+    emit_pool_alloc_rax_x86()
     emit_store_var(slot_res)
 
     em(0xfc)                                // cld
@@ -9052,43 +9253,73 @@ fn emit_str_slice_range_slots_x86(slot_s: i64, slot_start: i64, slot_end: i64) w
     emit_load_var(slot_res)
 }
 
-fn emit_read_file() with Mut, Panic {
-    // Simpler: rax=path. open → save fd → mmap → read → close → return buf
-    em(0x48); em(0x89); em(0xc7)  // mov rdi, rax
-    em(0x48); em(0x31); em(0xf6)  // xor rsi, rsi
-    em(0xb8); em32(2); em(0x0f); em(0x05)  // open → fd in rax
-    em(0x50)  // push fd
-    // mmap(NULL, 16MB+1, 3, 0x22, -1, 0)
+fn emit_read_file() with Mut, Panic, Div {
+    // rax = path. open -> read into a CACHED 16 MiB scratch (lazy mmap, reused
+    // every call) -> close -> pool-alloc (bytes_read + 64) -> copy + 64-byte
+    // zero tail -> return the right-sized pool block.
+    //
+    // The old form mmap'd a FRESH 16 MiB zero-filled buffer per call and never
+    // freed it: read_env() reads /proc/self/environ through here, and Madaros
+    // trace gates call read_env per compiled function/module -- measured 1047
+    // calls x 16 MiB = ~16.8 GiB of VmSize on one eisa_evm merged compile.
+    // The 64-byte zero tail preserves the old zero-fill semantics for callers
+    // that scan a few bytes past the content for NUL / double-NUL terminators
+    // (read_env scans exactly content+2); length-bounded callers are unaffected.
+    if POOL_ALLOC_ROUTINE_CL < 0 {
+        emit_pool_alloc_routine_x86()
+    }
+    em(0x48); em(0x89); em(0xc7)  // mov rdi, rax (path)
+    em(0x48); em(0x31); em(0xf6)  // xor rsi, rsi (O_RDONLY)
+    em(0xb8); em32(2); em(0x0f); em(0x05)  // open -> fd in rax
+    em(0x50)  // push fd                                  stack=[fd]
+    // scratch = [READFILE_SCRATCH]; lazy mmap on first use
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + READFILE_SCRATCH_BSS_OFF)
+    em(0x48); em(0x85); em(0xc0)  // test rax, rax
+    em(0x0f); em(0x85); let rf_have = CL; em32(0)  // jnz have_scratch
     em(0x48); em(0x31); em(0xff)  // rdi=0
     em(0xbe); em32(0x1000001)  // esi=16MB+1
     em(0xba); em32(3)  // edx=PROT_RW
     em(0x41); em(0xba); em32(0x22)  // r10d=MAP_PRIVATE|MAP_ANON
     em(0x49); em(0xc7); em(0xc0); em32(-1)  // r8=-1
     em(0x4d); em(0x31); em(0xc9)  // r9=0
-    em(0xb8); em32(9); em(0x0f); em(0x05)  // mmap → buf in rax
-    // MAP_FAILED check: rax in [-4095,-1] -> graceful exit 42 (was unchecked; on OOM the
-    // zero-store below at `mov byte [rax+rcx],0` wrote to the -errno address -> SIGSEGV).
+    em(0xb8); em32(9); em(0x0f); em(0x05)  // mmap -> scratch in rax
     em(0x48); em(0x3d); em32(0 - 4096)  // cmp rax, -4096
-    em(0x0f); em(0x87); let rf_abort = CL; em32(0)  // ja rf_abort (unsigned: MAP_FAILED)
-    em(0x50)  // push buf; stack=[fd, buf]
-    // read(fd, buf, 16MB)
-    em(0x48); em(0x89); em(0xc6)  // mov rsi, rax (buf)
+    em(0x0f); em(0x87); let rf_abort = CL; em32(0)  // ja abort (MAP_FAILED)
+    emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + READFILE_SCRATCH_BSS_OFF)  // cache (rax preserved)
+    patch32(rf_have, CL)
+    em(0x50)  // push scratch                             stack=[fd, scratch]
+    // read(fd, scratch, 16MB)
+    em(0x48); em(0x89); em(0xc6)  // mov rsi, rax (scratch)
     em(0x48); em(0x8b); em(0x7c); em(0x24); em(0x08)  // mov rdi, [rsp+8] (fd)
     em(0xba); em32(0x1000000)  // edx=16MB
-    em(0xb8); em32(0); em(0x0f); em(0x05)  // read
+    em(0xb8); em32(0); em(0x0f); em(0x05)  // read -> bytes in rax
     em(0x48); em(0x89); em(0xc1)  // mov rcx, rax (bytes read)
     em(0x48); em(0x85); em(0xc9)  // test rcx, rcx
     em(0x79); em(0x02)  // jns read_ok
-    em(0x31); em(0xc9)  // xor ecx, ecx
-    em(0x48); em(0x8b); em(0x04); em(0x24)  // mov rax, [rsp] (buf)
-    em(0xc6); em(0x04); em(0x08); em(0x00)  // mov byte [rax + rcx], 0
-    // close(fd)
-    em(0x48); em(0x8b); em(0x7c); em(0x24); em(0x08)  // mov rdi, [rsp+8] (fd)
+    em(0x31); em(0xc9)  // xor ecx, ecx (read error -> len 0)
+    // close(fd) -- preserve len across the syscall
+    em(0x51)  // push rcx (len)                           stack=[fd, scratch, len]
+    em(0x48); em(0x8b); em(0x7c); em(0x24); em(0x10)  // mov rdi, [rsp+16] (fd)
     em(0xb8); em32(3); em(0x0f); em(0x05)  // close
-    // return buf
-    em(0x58)  // pop rax (buf)
-    em(0x48); em(0x83); em(0xc4); em(0x08)  // add rsp, 8 (discard fd)
-    em(0xe9); let rf_done = CL; em32(0)  // jmp rf_done (skip abort; rax already = buf)
+    em(0x59)  // pop rcx (len)                            stack=[fd, scratch]
+    // dst = pool_alloc(len + 64)
+    em(0x51)  // push rcx (len)                           stack=[fd, scratch, len]
+    em(0x48); em(0x89); em(0xc8)  // mov rax, rcx
+    em(0x48); em(0x83); em(0xc0); em(64)  // add rax, 64
+    em(0xe8); em32(POOL_ALLOC_ROUTINE_CL - (CL + 4))  // call pool routine -> rax = dst
+    em(0x59)  // pop rcx (len)                            stack=[fd, scratch]
+    // copy len bytes scratch -> dst, then 64 zero tail bytes
+    em(0x50)  // push rax (dst, the return value)         stack=[fd, scratch, dst]
+    em(0x48); em(0x89); em(0xc7)  // mov rdi, rax (dst)
+    em(0x48); em(0x8b); em(0x74); em(0x24); em(0x08)  // mov rsi, [rsp+8] (scratch)
+    em(0xfc)  // cld
+    em(0xf3); em(0xa4)  // rep movsb (rcx = len)
+    em(0x31); em(0xc0)  // xor eax, eax
+    em(0xb9); em32(64)  // mov ecx, 64
+    em(0xf3); em(0xaa)  // rep stosb (zero tail)
+    em(0x58)  // pop rax (dst = return buf)               stack=[fd, scratch]
+    em(0x48); em(0x83); em(0xc4); em(0x10)  // add rsp, 16 (discard scratch, fd)
+    em(0xe9); let rf_done = CL; em32(0)  // jmp done
     patch32(rf_abort, CL)
     em(0xbf); em32(42)  // mov edi, 42 (distinct OOM exit code, mirrors arena)
     em(0xb8); em32(60)  // mov eax, 60 (SYS_exit)
@@ -10363,8 +10594,7 @@ fn materialize_struct_value_x86(struct_hash: i64) with Mut, Panic, Div {
     let dst_slot = NEXT_SLOT
     NEXT_SLOT = NEXT_SLOT + 1
     emit_store_var(src_slot)
-    emit_imm64(nslots * 8)
-    emit_heap_alloc_x86()
+    emit_pool_alloc_x86(nslots * 8)
     emit_store_var(dst_slot)
     emit_load_var(src_slot)
     em(0x48); em(0x89); em(0xc2)   // mov rdx, rax (src)
@@ -10530,8 +10760,7 @@ fn compile_primary() with IO, Mut, Panic, Div {
                     let lit_v = NEXT_SLOT
                     NEXT_SLOT = NEXT_SLOT + 1
                     emit_store_var(lit_v)
-                    emit_imm64(rep_count * s_nslots * 8)
-                    emit_heap_alloc_x86()
+                    emit_pool_alloc_x86(rep_count * s_nslots * 8)
                     let lit_blk = NEXT_SLOT
                     NEXT_SLOT = NEXT_SLOT + 1
                     emit_store_var(lit_blk)
@@ -10862,9 +11091,8 @@ fn compile_primary() with IO, Mut, Panic, Div {
             em(0x48); em(0x8d); em(0x85)
             em32(0 - struct_top * 8)
         } else {
-            // heap path: mov rax, struct_size*8; mmap; save heap_ptr; fill fields
-            em(0x48); em(0xb8); em64(struct_size * 8)  // mov rax, size
-            emit_heap_alloc_x86()                       // rax = heap_ptr
+            // heap path: pool-alloc struct_size*8; save heap_ptr; fill fields
+            emit_pool_alloc_x86(struct_size * 8)        // rax = heap_ptr
             let heap_slot = NEXT_SLOT
             NEXT_SLOT = NEXT_SLOT + 1
             emit_store_var(heap_slot)                   // save heap_ptr
@@ -11795,6 +12023,179 @@ fn compile_primary() with IO, Mut, Panic, Div {
                 if TK[EP as usize] == 7 { EP = EP + 1 }
                 em(0x31); em(0xc0)
                 // Legacy CPU fallback barrier aliases; no thread synchronization.
+                EXPR_IS_F64 = 0
+                EXPR_TY = 5
+                EXPR_TY_HASH = 0
+                return
+            }
+            // Arena scoping intrinsics (compile-time recognized, like print):
+            // __arena_mark() -> i64 returns the Box-arena cursor;
+            // __arena_reset(m) restores it (with base/limit UNTOUCHED — only
+            // valid when every Box allocated after the mark is provably dead;
+            // used by the Madaros module pipeline to reclaim per-module
+            // parse/lower churn after the deep merge copy-out).
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__arena_mark") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            // __pool_mark() -> i64: read-only observation of the aggregate
+            // pool bump cursor (diagnostics; deliberately NO __pool_reset —
+            // pool blocks have arbitrary lifetime).
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__pool_mark") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AGG_POOL_CURSOR_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__rtmmap_count") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + RTMMAP_COUNT_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__rtmmap_bytes") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + RTMMAP_BYTES_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__arena_refills") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + ARENA_REFILL_COUNT_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__arena_refill_bytes") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + ARENA_REFILL_BYTES_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__arena_unmaps") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + ARENA_UNMAP_COUNT_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__arena_unmap_bytes") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + ARENA_UNMAP_BYTES_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__pool_refills") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + POOL_REFILL_COUNT_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__pool_refill_bytes") {
+                EP = EP + 1
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + POOL_REFILL_BYTES_BSS_OFF)
+                EXPR_IS_F64 = 0
+                EXPR_TY = 1
+                EXPR_TY_HASH = 0
+                return
+            }
+            if fn_find(ns, ne) < 0 && src_match(ns, ne - ns, "__arena_reset") {
+                EP = EP + 1
+                compile_or()
+                if TK[EP as usize] == 7 { EP = EP + 1 }
+                // The arena is CHUNKED (refill mmaps a fresh chunk and repoints
+                // base/cursor/limit), so a mark taken before one or more refills
+                // addresses an OLDER chunk: restoring the raw cursor there would
+                // fail the next alloc's limit check and reserve yet another
+                // chunk (measured: VmSize GROWS vs no-reset). Instead, walk the
+                // per-chunk {prev_base, prev_limit} back-link headers (written
+                // at init/refill), munmapping every chunk younger than the
+                // mark's — all provably dead under the reset contract — until
+                // the chunk containing m is current again, then cursor = m.
+                // Chain-terminator guard (prev_base == 0, i.e. an invalid mark
+                // that matches no live chunk): recycle the initial chunk
+                // (cursor = base + 16) rather than munmapping it.
+                em(0x48); em(0x89); em(0xc2)                                          // mov rdx, rax (rdx = m; syscalls preserve rdx? no -- munmap clobbers rcx/r11 only, rdx survives)
+                let arst_loop = CL
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)  // rax = base
+                em(0x48); em(0x39); em(0xc2)                                          // cmp rdx, rax (m - base)
+                em(0x0f); em(0x82)                                                    // jb walk (m < base)
+                let arst_walk1 = CL
+                em32(0)
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF) // rax = limit
+                em(0x48); em(0x39); em(0xc2)                                          // cmp rdx, rax (m - limit)
+                em(0x0f); em(0x87)                                                    // ja walk (m > limit)
+                let arst_walk2 = CL
+                em32(0)
+                // in range: cursor = m; result 0
+                em(0x48); em(0x89); em(0xd0)                                          // mov rax, rdx
+                emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)
+                em(0xe9)                                                              // jmp done
+                let arst_done1 = CL
+                em32(0)
+                patch32(arst_walk1, CL)
+                patch32(arst_walk2, CL)
+                // walk: current chunk does not contain m -> it is younger than
+                // the mark and fully dead. Follow its back-link, munmap it.
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)  // rax = base
+                em(0x48); em(0x89); em(0xc7)                                          // mov rdi, rax (munmap addr)
+                em(0x48); em(0x8b); em(0x0f)                                          // mov rcx, [rdi] (prev_base)
+                em(0x48); em(0x85); em(0xc9)                                          // test rcx, rcx
+                em(0x0f); em(0x85)                                                    // jnz do_unmap
+                let arst_do_unmap = CL
+                em32(0)
+                // terminator: invalid mark -- recycle initial chunk, keep it mapped
+                em(0x48); em(0x89); em(0xf8)                                          // mov rax, rdi (base)
+                em(0x48); em(0x83); em(0xc0); em(16)                                  // add rax, 16 (skip header)
+                emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)
+                em(0xe9)                                                              // jmp done
+                let arst_done2 = CL
+                em32(0)
+                patch32(arst_do_unmap, CL)
+                em(0x4c); em(0x8b); em(0x07)                                          // mov r8, [rdi] (prev_base)
+                em(0x4c); em(0x8b); em(0x4f); em(8)                                   // mov r9, [rdi+8] (prev_limit)
+                emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF) // rax = limit
+                em(0x48); em(0x89); em(0xc6)                                          // mov rsi, rax
+                em(0x48); em(0x29); em(0xfe)                                          // sub rsi, rdi (len = limit - base)
+                emit_bump_counter_rsi_x86(ARENA_UNMAP_COUNT_BSS_OFF, ARENA_UNMAP_BYTES_BSS_OFF)
+                em(0xb8); em32(11)                                                    // mov eax, 11 (SYS_munmap)
+                em(0x0f); em(0x05)                                                    // syscall (rdx/r8/r9 survive; rcx/r11 clobbered)
+                em(0x4c); em(0x89); em(0xc0)                                          // mov rax, r8 (prev_base)
+                emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)
+                em(0x4c); em(0x89); em(0xc8)                                          // mov rax, r9 (prev_limit)
+                emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)
+                em(0xe9); em32(arst_loop - (CL + 4))                                  // jmp loop
+                patch32(arst_done1, CL)
+                patch32(arst_done2, CL)
+                em(0x31); em(0xc0)                                                    // xor eax, eax
                 EXPR_IS_F64 = 0
                 EXPR_TY = 5
                 EXPR_TY_HASH = 0
@@ -20447,8 +20848,7 @@ fn materialize_aggregate_array_element_x86(array_hash: i64) with Mut, Panic, Div
     let dst_slot = NEXT_SLOT
     NEXT_SLOT = NEXT_SLOT + 1
     emit_store_var(src_slot)
-    emit_imm64(elem_nslots * 8)
-    emit_heap_alloc_x86()
+    emit_pool_alloc_x86(elem_nslots * 8)
     emit_store_var(dst_slot)
     emit_load_var(src_slot)
     em(0x48); em(0x89); em(0xc2)
@@ -21625,8 +22025,7 @@ fn compile_stmt() with IO, Mut, Panic, Div {
                 // element cost a 4 KiB page each — >8 GiB vmem at Madaros
                 // scale, caught by the wrapper ulimit during the prebuilt
                 // refresh). Element i lives at block + i*stride.
-                emit_imm64(nslots * d_nsl * 8)
-                emit_heap_alloc_x86()
+                emit_pool_alloc_x86(nslots * d_nsl * 8)
                 let rl_blk = NEXT_SLOT
                 NEXT_SLOT = NEXT_SLOT + 1
                 emit_store_var(rl_blk)
@@ -26641,6 +27040,7 @@ fn resolve_forward_struct_types() with Mut, Panic, Div {
 
 fn compile_all() -> i64 with IO, Mut, Panic, Div {
     CL = 0
+    POOL_ALLOC_ROUTINE_CL = 0 - 1
     FN_COUNT = 0
     PATCH_COUNT = 0
     FNSIG_COUNT = 1
@@ -27353,6 +27753,18 @@ fn compile_all() -> i64 with IO, Mut, Panic, Div {
     AST_ARENA_BASE_BSS_OFF = bss_alloc_aligned(8)
     AST_ARENA_CURSOR_BSS_OFF = bss_alloc_aligned(8)
     AST_ARENA_LIMIT_BSS_OFF = bss_alloc_aligned(8)
+    AGG_POOL_BASE_BSS_OFF = bss_alloc_aligned(8)
+    AGG_POOL_CURSOR_BSS_OFF = bss_alloc_aligned(8)
+    AGG_POOL_LIMIT_BSS_OFF = bss_alloc_aligned(8)
+    RTMMAP_COUNT_BSS_OFF = bss_alloc_aligned(8)
+    RTMMAP_BYTES_BSS_OFF = bss_alloc_aligned(8)
+    READFILE_SCRATCH_BSS_OFF = bss_alloc_aligned(8)
+    ARENA_REFILL_COUNT_BSS_OFF = bss_alloc_aligned(8)
+    ARENA_REFILL_BYTES_BSS_OFF = bss_alloc_aligned(8)
+    ARENA_UNMAP_COUNT_BSS_OFF = bss_alloc_aligned(8)
+    ARENA_UNMAP_BYTES_BSS_OFF = bss_alloc_aligned(8)
+    POOL_REFILL_COUNT_BSS_OFF = bss_alloc_aligned(8)
+    POOL_REFILL_BYTES_BSS_OFF = bss_alloc_aligned(8)
     PTX_LEN = 0
     NEEDS_GPU_RUNTIME_DYNLINK = 0
     // R15 Runtime Tag Stack: reserve BSS for side table (up to 16384 call sites × 8 bytes)

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -33937,8 +33937,10 @@ fn compile_stmt_a64() with IO, Mut, Panic, Div {
         if TK[EP as usize] == 16 { EP = EP + 1; has_eq = 1 }
         if is_arr == 1 && arr_len > 0 && TK[EP as usize] == 41 && array_init_is_repeat(EP) {
             EP = EP + 1
+            let a64_val_ep = EP
             while ep_before_body_close() && TK[EP as usize] != 42 && TK[EP as usize] != 0 { EP = EP + 1 }
             if TK[EP as usize] == 42 { EP = EP + 1 }
+            let a64_after_ep = EP
             var nslots = arr_len
             if arr_esiz == 1 { nslots = (arr_len + 7) / 8 }
             let ptr_slot = var_add_arr(ns, ne, nslots, arr_esiz, arr_hash_elem_ty(decl_ty_hash))

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -8838,28 +8838,45 @@ fn emit_heap_realloc_x86() with Mut {
 // reserving big costs ~0 RSS until touched. emit_heap_alloc_x86 (heap_vec/map,
 // explicitly freed) is intentionally NOT routed here.
 // ============================================================================
-fn arena_chunk_bytes() -> i64 { return 8589934592 }  // 8 GiB per chunk
+fn arena_chunk_bytes() -> i64 { return 2147483648 }  // 2 GiB per chunk
+// Sized so image (~3.3 GiB) + a few chunks stay under the bin/madaros
+// wrapper's ulimit -v guards (8 GiB check / 16 GiB run): the adaptive
+// refill keeps TOTAL arena unbounded in 2 GiB steps, and packing (the
+// job-2478 fix) is what defeats per-Box page waste — chunk size is not
+// load-bearing for that.
 
 // Emit (into the produced binary) the one-time arena reservation. Called at main's
 // entry, before any Box::new. Aborts the process (exit 42) if the initial mmap fails.
 fn emit_ast_arena_init_x86() with Mut, Panic {
-    // mmap(NULL, CHUNK, PROT_RW, MAP_PRIVATE|ANON, -1, 0) -> rax = base or MAP_FAILED
-    em(0x48); em(0x31); em(0xff)                    // xor rdi, rdi
+    // mmap with ADAPTIVE size: try CHUNK, halve on MAP_FAILED down to 16 MiB
+    // (a fixed 8 GiB demand-paged reservation aborted under `ulimit -v` —
+    // e.g. the bin/madaros wrapper's 8 GiB guard — even though real RSS is
+    // tiny; the actual reserved size lives in rsi and [limit]-[base]).
     em(0x48); em(0xbe); em64(arena_chunk_bytes())   // movabs rsi, CHUNK
+    let init_retry = CL
+    em(0x48); em(0x31); em(0xff)                    // xor rdi, rdi
     em(0xba); em32(3)                               // mov edx, 3 (PROT_READ|PROT_WRITE)
     em(0x41); em(0xba); em32(0x22)                  // mov r10d, 0x22 (MAP_PRIVATE|MAP_ANON)
     em(0x49); em(0xc7); em(0xc0); em32(0 - 1)       // mov r8, -1 (fd)
     em(0x4d); em(0x31); em(0xc9)                     // xor r9, r9 (offset)
     em(0xb8); em32(9)                               // mov eax, 9 (SYS_mmap)
-    em(0x0f); em(0x05)                              // syscall
+    em(0x0f); em(0x05)                              // syscall (clobbers rcx/r11; rsi survives)
     em(0x48); em(0x3d); em32(0 - 4096)              // cmp rax, -4096
-    em(0x0f); em(0x87)                              // ja abort (MAP_FAILED in [-4095,-1])
+    em(0x0f); em(0x86)                              // jbe success
+    let init_ok = CL
+    em32(0)
+    em(0x48); em(0xd1); em(0xee)                    // shr rsi, 1
+    em(0x48); em(0xb9); em64(16777216)              // movabs rcx, 16 MiB (floor)
+    em(0x48); em(0x39); em(0xce)                    // cmp rsi, rcx
+    em(0x0f); em(0x83)                              // jae retry
+    em32(init_retry - (CL + 4))
+    em(0xe9)                                        // jmp abort
     let init_abort = CL
     em32(0)
+    patch32(init_ok, CL)
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)    // [base] = rax (rax preserved)
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_CURSOR_BSS_OFF)  // [cursor] = rax
-    em(0x48); em(0xb9); em64(arena_chunk_bytes())   // movabs rcx, CHUNK
-    em(0x48); em(0x01); em(0xc8)                     // add rax, rcx -> rax = base + CHUNK
+    em(0x48); em(0x01); em(0xf0)                     // add rax, rsi -> rax = base + actual
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)   // [limit] = rax
     em(0xe9)                                        // jmp done
     let init_done = CL
@@ -8896,10 +8913,15 @@ fn emit_arena_alloc_x86(alloc_size: i64) with Mut, Panic, Div {
     em(0xe9)                                        // jmp done
     let fast_done = CL
     em32(0)
-    // SLOW PATH: re-reserve a fresh chunk
+    // SLOW PATH: re-reserve a fresh chunk of the NEGOTIATED size
+    // ([limit]-[base], set adaptively at init), halving further on failure.
     patch32(slow, CL)
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)
+    em(0x48); em(0x89); em(0xc6)                     // mov rsi, rax
+    emit_load_abs_qword_to_rax_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)
+    em(0x48); em(0x29); em(0xc6)                     // sub rsi, rax (rsi = chunk size)
+    let slow_retry = CL
     em(0x48); em(0x31); em(0xff)                     // xor rdi, rdi
-    em(0x48); em(0xbe); em64(arena_chunk_bytes())    // movabs rsi, CHUNK
     em(0xba); em32(3)                                // mov edx, 3
     em(0x41); em(0xba); em32(0x22)                   // mov r10d, 0x22
     em(0x49); em(0xc7); em(0xc0); em32(0 - 1)        // mov r8, -1
@@ -8907,13 +8929,21 @@ fn emit_arena_alloc_x86(alloc_size: i64) with Mut, Panic, Div {
     em(0xb8); em32(9)                                // mov eax, 9 (SYS_mmap)
     em(0x0f); em(0x05)                               // syscall -> rax = new base or MAP_FAILED
     em(0x48); em(0x3d); em32(0 - 4096)               // cmp rax, -4096
-    em(0x0f); em(0x87)                               // ja abort
+    em(0x0f); em(0x86)                               // jbe ok
+    let slow_ok = CL
+    em32(0)
+    em(0x48); em(0xd1); em(0xee)                    // shr rsi, 1
+    em(0x48); em(0xb9); em64(16777216)              // movabs rcx, 16 MiB floor
+    em(0x48); em(0x39); em(0xce)                    // cmp rsi, rcx
+    em(0x0f); em(0x83)                              // jae retry
+    em32(slow_retry - (CL + 4))
+    em(0xe9)                                        // jmp abort
     let slow_abort = CL
     em32(0)
+    patch32(slow_ok, CL)
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_BASE_BSS_OFF)    // [base] = rax
     em(0x50)                                        // push rax (chunk base)
-    em(0x48); em(0xb9); em64(arena_chunk_bytes())    // movabs rcx, CHUNK
-    em(0x48); em(0x01); em(0xc8)                      // add rax, rcx -> rax = base + CHUNK
+    em(0x48); em(0x01); em(0xf0)                      // add rax, rsi -> rax = base + actual
     emit_store_rax_to_abs_qword_x86(GL_BSS_BASE + AST_ARENA_LIMIT_BSS_OFF)   // [limit] = rax
     em(0x58)                                        // pop rax (chunk base)
     em(0x50)                                        // push rax (return base)
@@ -10480,26 +10510,35 @@ fn compile_primary() with IO, Mut, Panic, Div {
                     let base = NEXT_SLOT
                     NEXT_SLOT = NEXT_SLOT + total_slots
                     let end_ep = EP
-                    // First element already compiled, RAX = struct ptr
-                    em(0x48); em(0x89); em(0xc2)  // mov rdx, rax
-                    var j: i64 = 0
-                    while j < s_nslots {
-                        em(0x48); em(0x8b); em(0x82); em32(j * 8)  // mov rax, [rdx + j*8]
-                        emit_store_var(base + total_slots - 1 - j)
-                        j = j + 1
-                    }
-                    // Remaining elements: re-compile expression for each
-                    var ri: i64 = 1
+                    // ONE block for all elements (an mmap per element costs a
+                    // 4 KiB page each — the vmem blowup caught by the wrapper
+                    // ulimit during the prebuilt refresh). Element i lives at
+                    // block + i*stride; each compiled element is copied in.
+                    let lit_v = NEXT_SLOT
+                    NEXT_SLOT = NEXT_SLOT + 1
+                    emit_store_var(lit_v)
+                    emit_imm64(rep_count * s_nslots * 8)
+                    emit_heap_alloc_x86()
+                    let lit_blk = NEXT_SLOT
+                    NEXT_SLOT = NEXT_SLOT + 1
+                    emit_store_var(lit_blk)
+                    let lit_dst = NEXT_SLOT
+                    NEXT_SLOT = NEXT_SLOT + 1
+                    var ri: i64 = 0
                     while ri < rep_count {
-                        EP = expr_start
-                        compile_or()
-                        em(0x48); em(0x89); em(0xc2)  // mov rdx, rax
-                        j = 0
-                        while j < s_nslots {
-                            em(0x48); em(0x8b); em(0x82); em32(j * 8)  // mov rax, [rdx + j*8]
-                            emit_store_var(base + total_slots - 1 - ri * s_nslots - j)
-                            j = j + 1
+                        if ri > 0 {
+                            EP = expr_start
+                            compile_or()
+                            emit_store_var(lit_v)
                         }
+                        emit_load_var(lit_blk)
+                        if ri > 0 { em(0x48); em(0x05); em32(ri * s_nslots * 8) }  // add rax, off
+                        emit_store_var(lit_dst)
+                        emit_store_var(base + rep_count - 1 - ri)
+                        emit_load_var(lit_v)
+                        em(0x48); em(0x89); em(0xc2)      // mov rdx, rax (src)
+                        emit_load_var(lit_dst)            // rax = dst
+                        emit_copy_agg_to_ptr_x86(6, elem_hash)
                         ri = ri + 1
                     }
                     EP = end_ep
@@ -21548,6 +21587,75 @@ fn compile_stmt() with IO, Mut, Panic, Div {
             // Array slots: base..base+nslots-1, lowest addr = rbp-(base+nslots-1)*8
             // rep stosq: store rax to [rdi], rdi += 8, rcx--; repeats rcx times (DF=0 → ascending)
             let base = ptr_slot - nslots
+            // Aggregate elements: a single-pointer splat would alias every
+            // slot (tests/known_failures/lean_decl_repeat_alias.sio). Emit a
+            // RUNTIME loop — O(1) code per decl, mandatory at [T;1024] scale
+            // (the compile-time-unrolled variant grew Madaros +11MB and
+            // broke self-host) — that heap-allocs and copies one fresh
+            // element per slot from the once-compiled V.
+            let dcl_elem_ty = arr_hash_elem_ty(decl_ty_hash)
+            let dcl_elem_hash = arr_hash_elem_hash(decl_ty_hash)
+            if dcl_elem_ty == 6 && struct_like_nslots(dcl_elem_hash) > 0 && LAST_LOCAL_BSS_SPILL == 0 {
+                let d_nsl = struct_like_nslots(dcl_elem_hash)
+                EP = val_ep
+                compile_or()
+                EP = after_ep
+                let rl_src = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var(rl_src)
+                em(0x48); em(0x8d); em(0x85)  // lea rax, [rbp+disp] (array base, lowest addr)
+                em32(0 - (base + nslots - 1) * 8)
+                let rl_base = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var(rl_base)
+                // One BLOCK allocation for all N elements (an mmap per
+                // element cost a 4 KiB page each — >8 GiB vmem at Madaros
+                // scale, caught by the wrapper ulimit during the prebuilt
+                // refresh). Element i lives at block + i*stride.
+                emit_imm64(nslots * d_nsl * 8)
+                emit_heap_alloc_x86()
+                let rl_blk = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var(rl_blk)
+                em(0x48); em(0x31); em(0xc0)  // xor rax, rax (i = 0)
+                let rl_i = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var(rl_i)
+                let rl_head = CL
+                emit_load_var(rl_i)
+                em(0x48); em(0x3d); em32(nslots)  // cmp rax, nslots
+                em(0x0f); em(0x8d)                // jge done (fwd, patched)
+                let rl_exit = CL
+                em32(0)
+                emit_load_var(rl_i)
+                em(0x48); em(0xb9); em64(d_nsl * 8)     // mov rcx, stride
+                em(0x48); em(0x0f); em(0xaf); em(0xc1)  // imul rax, rcx
+                em(0x48); em(0x89); em(0xc2)            // mov rdx, rax (off)
+                emit_load_var(rl_blk)
+                em(0x48); em(0x01); em(0xd0)            // add rax, rdx (elem dst)
+                let rl_new = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var(rl_new)
+                emit_load_var(rl_src)
+                em(0x48); em(0x89); em(0xc2)      // mov rdx, rax (src)
+                emit_load_var(rl_new)             // rax = dst
+                emit_copy_agg_to_ptr_x86(6, dcl_elem_hash)
+                emit_load_var(rl_new)
+                em(0x48); em(0x89); em(0xc2)      // mov rdx, rax (new ptr)
+                emit_load_var(rl_i)
+                em(0x48); em(0x89); em(0xc1)      // mov rcx, rax (i)
+                emit_load_var(rl_base)            // rax = array base
+                em(0x48); em(0x89); em(0x14); em(0xc8)  // mov [rax+rcx*8], rdx
+                emit_load_var(rl_i)
+                em(0x48); em(0x83); em(0xc0); em(1)     // add rax, 1
+                emit_store_var(rl_i)
+                em(0xe9)                          // jmp head (backward rel32)
+                em32(rl_head - (CL + 4))
+                patch32(rl_exit, CL)
+                emit_load_var(rl_base)
+                emit_store_var(ptr_slot)
+                return
+            }
             // Compute the fill value into rax. For 8-byte elements (i64/f64/ptr) splat
             // the real V; var_add_arr emits no code and the rdi setup below does not
             // clobber rax, so V survives into the rep-store.
@@ -33415,6 +33523,84 @@ fn compile_stmt_a64() with IO, Mut, Panic, Div {
             VAR_TY_HASH[arr_vi as usize] = decl_ty_hash
             VAR_MUT[arr_vi as usize] = decl_is_mut
             let base = ptr_slot - nslots
+            // Mirror of the x86 decl-init: aggregates get a RUNTIME loop
+            // (O(1) code) allocating a fresh heap copy per slot; 8-byte
+            // scalars get the real V-splat (this path used to IGNORE V and
+            // zero-fill: null element pointers / silent zeros).
+            let d_ty = arr_hash_elem_ty(decl_ty_hash)
+            let d_hash = arr_hash_elem_hash(decl_ty_hash)
+            if d_ty == 6 && struct_like_nslots(d_hash) > 0 && LAST_LOCAL_BSS_SPILL == 0 {
+                let d_nsl = struct_like_nslots(d_hash)
+                EP = a64_val_ep
+                compile_or_a64()
+                EP = a64_after_ep
+                let rl_src = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var_a64(rl_src)
+                emit_lea_var_a64(base + nslots - 1)
+                let rl_base = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var_a64(rl_base)
+                // One BLOCK allocation for all N elements (mirror of the
+                // x86 page-granularity fix). Element i at block + i*stride.
+                emit_imm64_a64(nslots * d_nsl * 8)
+                emit_heap_alloc_a64()
+                let rl_blk = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var_a64(rl_blk)
+                em32(0xD2800000)  // mov x0, #0 (i)
+                let rl_i = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var_a64(rl_i)
+                let rl_head = CL
+                emit_load_var_a64(rl_i)
+                em32(0xAA0003E9)  // mov x9, x0
+                emit_imm64_reg_a64(10, nslots)
+                em32(0xEB0A013F)  // cmp x9, x10
+                let rl_exit = CL
+                em32(0x5400000A)  // b.ge done (patched)
+                emit_load_var_a64(rl_i)
+                emit_imm64_reg_a64(11, d_nsl * 8)
+                em32(0x9B0B7C00)  // mul x0, x0, x11
+                em32(0xAA0003EB)  // mov x11, x0 (off)
+                emit_load_var_a64(rl_blk)
+                em32(0x8B0B0000)  // add x0, x0, x11 (elem dst)
+                let rl_new = NEXT_SLOT
+                NEXT_SLOT = NEXT_SLOT + 1
+                emit_store_var_a64(rl_new)
+                emit_load_var_a64(rl_src)
+                em32(0xAA0003EA)  // mov x10, x0 (src)
+                emit_load_var_a64(rl_new)
+                emit_copy_agg_to_ptr_a64(6, d_hash)
+                emit_load_var_a64(rl_new)
+                em32(0xAA0003EA)  // mov x10, x0 (new)
+                emit_load_var_a64(rl_i)
+                em32(0xAA0003E1)  // mov x1, x0 (i)
+                emit_load_var_a64(rl_base)
+                em32(0xF821780A)  // str x10, [x0, x1, lsl #3]
+                emit_load_var_a64(rl_i)
+                em32(0x91000400)  // add x0, x0, #1
+                emit_store_var_a64(rl_i)
+                let rl_b = CL
+                let rl_rel = (rl_head - rl_b) / 4
+                em32(0x14000000 | (rl_rel & 0x3FFFFFF))  // b head
+                patch_branch_a64(rl_exit, CL)
+                emit_load_var_a64(rl_base)
+                emit_store_var_a64(ptr_slot)
+                return
+            }
+            if arr_esiz != 1 && LAST_LOCAL_BSS_SPILL == 0 {
+                EP = a64_val_ep
+                compile_or_a64()
+                EP = a64_after_ep
+                em32(0xAA0003ED)  // mov x13, x0 (V)
+                emit_lea_var_a64(base + nslots - 1)
+                em32(0xAA0003EB)  // mov x11, x0
+                emit_fill_words_x13_x11_a64(nslots)
+                emit_lea_var_a64(base + nslots - 1)
+                emit_store_var_a64(ptr_slot)
+                return
+            }
             if LAST_LOCAL_BSS_SPILL != 0 {
                 emit_image_addr_reg_a64(11, LAST_LOCAL_BSS_ADDR)
                 emit_zero_words_x11_a64(nslots)

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4378,6 +4378,125 @@ pub fn module_frontend_check_imported_modules_verdict(main_path: string) -> i64 
     check_modules_verdict_boot4(&! programs, loaded)
 }
 
+// ============================================================================
+// Per-module arena-reset scratch (Box-arena churn reclaim, see docs/handoff).
+//
+// module_frontend_lower_programs_array_direct_box lowers each imported module
+// into a fresh Box<IrModule> (dep_box, ~hundreds of MB: [IrFunction; 2048])
+// purely as scratch to extract a handful of merged functions into the
+// running accumulator (acc_box). Everything in dep_box's Box-arena window
+// is dead once its functions/strings/epistemic/algebras are copied into
+// acc_box BY VALUE -- except IrInstr.call_args: Option<Box<IrRegList>>,
+// whose Box POINTER is copied shallow by struct assignment. Left alone,
+// that pointer would keep referencing dep_box's soon-to-be-reset memory.
+//
+// Fix: before resetting the arena, walk the newly-appended function range
+// [old_fn_count, new_fn_count) and extract every call_args chain (bounded
+// to 8 args/call-site, matching the existing native_v2_collect_call_args /
+// tco_extract_call_args convention) into this BSS scratch buffer -- plain
+// fixed arrays, NOT Box-arena memory, so __arena_reset never touches them.
+// After the reset, rebuild fresh Box<IrRegList> chains from the scratch
+// buffer (landing in the just-freed, now-reused window) and write them
+// back into acc_box's instrs. If a module's call-arg sites exceed the
+// bounded capacity, the reset is skipped for that module only (strictly
+// correctness-preserving fallback -- just reclaims less memory).
+// ============================================================================
+let MF_AREBOX_CAP: i64 = 8192
+var MF_AREBOX_FI: [i64; 8192] = [0; 8192]
+var MF_AREBOX_II: [i64; 8192] = [0; 8192]
+var MF_AREBOX_ARGC: [i64; 8192] = [0; 8192]
+var MF_AREBOX_ARGS: [i64; 65536] = [0; 65536]
+var MF_AREBOX_COUNT: i64 = 0
+var MF_AREBOX_OVERFLOW: bool = false
+
+fn mf_arebox_reset_scratch() with Mut {
+    MF_AREBOX_COUNT = 0
+    MF_AREBOX_OVERFLOW = false
+}
+
+// Extract up to 8 regs from a call_args chain into MF_AREBOX_ARGS[slot*8 ..].
+// Extra args beyond 8 are truncated (existing convention elsewhere in the
+// codebase caps call-arg capture at 8/16; no observed call site needs more).
+fn mf_arebox_extract(slot: i64, args: Option<Box<IrRegList>>) -> i64 with Mut, Panic, Div {
+    var n: i64 = 0
+    var cur = args
+    while n < 8 {
+        match cur {
+            Some(node) => {
+                MF_AREBOX_ARGS[(slot * 8 + n) as usize] = (*node).head
+                cur = (*node).tail
+                n = n + 1
+            }
+            _ => { return n }
+        }
+    }
+    n
+}
+
+// Record one (fi, ii) call-arg site for post-reset re-boxing, extracting its
+// args NOW while the source (pre-reset) memory is still valid.
+fn mf_arebox_record(fi: i64, ii: i64, args: Option<Box<IrRegList>>) with Mut, Panic, Div {
+    if MF_AREBOX_COUNT >= MF_AREBOX_CAP {
+        MF_AREBOX_OVERFLOW = true
+        return
+    }
+    let slot = MF_AREBOX_COUNT
+    let n = mf_arebox_extract(slot, args)
+    MF_AREBOX_FI[slot as usize] = fi
+    MF_AREBOX_II[slot as usize] = ii
+    MF_AREBOX_ARGC[slot as usize] = n
+    MF_AREBOX_COUNT = slot + 1
+}
+
+// Rebuild a fresh Box<IrRegList> chain from scratch slot `slot`, preserving
+// original head-first arg order. Must only be called AFTER __arena_reset so
+// the Box::new allocations land in the freed (reused) window.
+fn mf_arebox_rebuild(slot: i64) -> Option<Box<IrRegList>> with Alloc, Mut, Panic, Div {
+    let n = MF_AREBOX_ARGC[slot as usize]
+    var out: Option<Box<IrRegList>> = None
+    var k = n - 1
+    while k >= 0 {
+        out = Some(Box::new(ir_reg_list_cons(MF_AREBOX_ARGS[(slot * 8 + k) as usize], out)))
+        k = k - 1
+    }
+    out
+}
+
+// Scan functions [fn_lo, fn_hi) of `module` for instrs carrying a live
+// call_args chain, recording each for post-reset re-boxing. Returns false
+// (capacity exceeded, MF_AREBOX_OVERFLOW set) if the caller must skip the
+// arena reset for this module.
+fn mf_arebox_scan(module: &IrModule, fn_lo: i64, fn_hi: i64) -> bool with Mut, Panic, Div {
+    mf_arebox_reset_scratch()
+    var fi = fn_lo
+    while fi < fn_hi {
+        let ic = (*module).functions[fi as usize].instr_count
+        var ii: i64 = 0
+        while ii < ic {
+            match (*module).functions[fi as usize].instrs[ii as usize].call_args {
+                Some(_) => mf_arebox_record(fi, ii, (*module).functions[fi as usize].instrs[ii as usize].call_args)
+                _ => {}
+            }
+            ii = ii + 1
+        }
+        fi = fi + 1
+    }
+    !MF_AREBOX_OVERFLOW
+}
+
+// Write the rebuilt (post-reset) call_args chains back into `module`. Must be
+// called strictly after __arena_reset.
+fn mf_arebox_apply(module: &! IrModule) with Alloc, Mut, Panic, Div {
+    var s: i64 = 0
+    while s < MF_AREBOX_COUNT {
+        let fi = MF_AREBOX_FI[s as usize]
+        let ii = MF_AREBOX_II[s as usize]
+        let rebuilt = mf_arebox_rebuild(s)
+        (*module).functions[fi as usize].instrs[ii as usize].call_args = rebuilt
+        s = s + 1
+    }
+}
+
 fn module_frontend_lower_programs_array_direct_box(
     programs: &! [Program; 256],
     loaded: i64,
@@ -4413,6 +4532,14 @@ fn module_frontend_lower_programs_array_direct_box(
                 print("lower_array: dep_begin ")
                 print_int(i)
                 print("\n")
+                // Mark the Box-arena BEFORE lowering module i. dep_items itself
+                // (programs[i].items) was already parsed earlier in the
+                // load/typecheck phase and must stay live for OTHER modules'
+                // extern resolution, so it is intentionally allocated before
+                // this mark and is untouched by the reset below -- only the
+                // per-module lowering scratch (dep_box and everything it
+                // pulls in) falls inside [mark, reset).
+                let dep_arena_mark = __arena_mark()
                 let dep_items = (*programs)[i as usize].items
                 let dep_lower = module_frontend_lower_program_items_box_traced_with_externs(&dep_items, programs, loaded, i, trace)
                 print("lower_array: dep_lower_done ")
@@ -4427,6 +4554,11 @@ fn module_frontend_lower_programs_array_direct_box(
                         print_int(i)
                         print("\n")
                         let dep_fn_count = (*dep_box).fn_count
+                        // Snapshot before this module's functions are appended --
+                        // acc_box.fn_count only grows in the mfi loop below, so
+                        // this is the exact appended range [old_fn_count, ..).
+                        let dep_merge_old_fn_count = (*acc_box).fn_count
+                        let string_offset = (*acc_box).string_count
                         let contest_offset = (*acc_box).epistemic.contest_count
                         let robust_offset = (*acc_box).epistemic.robust_proof_count
                         let decision_offset = (*acc_box).epistemic.decision_certificate_count
@@ -4516,6 +4648,24 @@ fn module_frontend_lower_programs_array_direct_box(
                         }
                         (*acc_box).epistemic = ir_merge_epistemic_sections((*acc_box).epistemic, (*dep_box).epistemic)
                         (*acc_box).algebras = ir_merge_algebra_tables((*acc_box).algebras, (*dep_box).algebras)
+                        // Every field copied into acc_box above (functions incl.
+                        // instrs, string_table entries, epistemic, algebras) is a
+                        // plain value copy with no Box field except IrInstr.call_args
+                        // (Option<Box<IrRegList>> -- audited: the only Box reachable
+                        // from IrModule/IrFunction/IrInstr). Re-box those chains
+                        // before reclaiming dep_box's arena window: extract now
+                        // (source still valid), reset, then rebuild fresh in the
+                        // freed window.
+                        let dep_merge_new_fn_count = (*acc_box).fn_count
+                        let dep_arena_can_reset = mf_arebox_scan(&(*acc_box), dep_merge_old_fn_count, dep_merge_new_fn_count)
+                        if dep_arena_can_reset {
+                            __arena_reset(dep_arena_mark)
+                            mf_arebox_apply(&! (*acc_box))
+                        } else {
+                            print("lower_array: arena_reset_skipped (call-arg scratch overflow) module ")
+                            print_int(i)
+                            print("\n")
+                        }
                         print("lower_array: merge_done ")
                         print_int(i)
                         print("\n")

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -9786,6 +9786,40 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
     var compile_ok = true
     var bss_count: i64 = 0
     while fi < (*module).fn_count {
+        // Per-function Box-arena window: everything compile_ir_function_v2_
+        // from_ir_into Box-allocates (machine-IR scratch, reg lists, …) is
+        // dead once the function's bytes/relocs/symbols are recorded in nc —
+        // and nc's whole reachable graph is fixed arrays + scalars (audited:
+        // NativeCompiler, CodeBuffer, RelocationTable, ExternRelocTable,
+        // StringTable, SymbolData — no Box anywhere), living in pre-loop
+        // storage plus BSS side tables (NV2_RELOC_*). Reset reclaims the
+        // arena churn that previously accumulated unboundedly across the
+        // whole module (measured: +11.5 GiB VmSize during this loop on the
+        // eisa_evm merged compile).
+        let cg_arena_mark = __arena_mark()
+        if str_len(read_env("SOUNIO_NV2_ARENA_TRACE")) > 0 && fi % 25 == 0 {
+            print("nv2_arena_cursor ")
+            print_int(cg_arena_mark)
+            print("\n")
+            print("nv2_pool_cursor ")
+            print_int(__pool_mark())
+            print("\n")
+            print("nv2_rtmmap_count ")
+            print_int(__rtmmap_count())
+            print("\n")
+            print("nv2_rtmmap_bytes ")
+            print_int(__rtmmap_bytes())
+            print("\n")
+            print("nv2_arena_refill_bytes ")
+            print_int(__arena_refill_bytes())
+            print("\n")
+            print("nv2_arena_unmap_bytes ")
+            print_int(__arena_unmap_bytes())
+            print("\n")
+            print("nv2_pool_refill_bytes ")
+            print_int(__pool_refill_bytes())
+            print("\n")
+        }
         let fn_body = (*module).functions[fi as usize]
         if fn_body.compile_strategy == 99 {
             bss_count = bss_count + 1
@@ -9793,6 +9827,7 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
         if !compile_ir_function_v2_from_ir_into(&! nc, &fn_body, fi) {
             compile_ok = false
         }
+        __arena_reset(cg_arena_mark)
         fi = fi + 1
     }
     if !compile_ok {


### PR DESCRIPTION
## Fix #712 — native madaros can now self-compile `main.sio` (arena/VmPeak exhaustion)

Native madaros (`bin/madaros`, built by the lean_single seed compiling
`self-hosted/compiler/main.sio`) could not be built on `main`: the multi-module
lowering merge exhausted the process address space (`mmap MAP_FAILED` / SIGSEGV,
signature `lower_array: dep_begin`) **before any user program was reached**. This
blocked building native madaros at all, and with it any validation of work on the
native engine.

This PR extracts the arena/vmem fix from the long-running
`gpu/epistemic-tensor-core-next` line (absent from the re-rooted `main`) and lands
it as a focused, verified set.

### What it does
- **Per-module arena resets + pooled small allocs** (`a096d1c4b`) — `__arena_reset`
  / `mf_arebox_*` around the `dep_begin` function-append window in multi-module
  merge. This is the core fix: it cuts the self-compile peak VSZ from **~15 GB to
  ~2.87 GB** (~5×), matching the original 25.8 GB→6.5 GB measurement, and takes the
  build under the address-space ceiling that produced the `mmap MAP_FAILED`.
- **Adaptive 2 GiB Box arena + block allocations** (`c446a8487`), **request-sized
  refill chunks** for oversized-Box safety (`c568f1aaf`), and a **parameterised
  launcher vmem guard** (`da2922b2f`, `$MADAROS_VMEM_LIMIT_KB`, default 32 GiB).
- **`resolve_imports` SRC guard 8→16 MB** — an adjacent *pre-existing* blocker
  uncovered here: `main.sio`'s full transitive import bundle is ~10.7 MB but the
  guards still tripped at 8 MB even though the `SRC` buffer is already 16 MB. Without
  this, build-madaros dies at the import wall before the arena fix is reached.
- **a64 repeat-decl capture restore** — completes the 3-way merge of `c446a8487`
  (main's a64 path had diverged and dropped the `a64_val_ep`/`a64_after_ep`
  captures the block-alloc code needs; without them the seed fails to typecheck).

### Verification
- **Bootstrap fixed-point holds**: `make build` → gen2 == gen3 bit-identical
  (md5 `9b21ebbd…`, 2 443 159 B). No lean_single behavioural regression.
- **`make build-madaros` succeeds** where the fix-less path pins the 16 GiB ceiling
  (peak VSZ ~2.87 GB vs ~15 GB); the resulting madaros is functional (`--version`,
  compiles + runs hello/fibonacci, `--check: OK`).

Scope is exactly four source files (`lean_single.sio`, `module_frontend.sio`,
`codegen_x86_linux.sio`, `bin/madaros`). Provenance for the source branch is
preserved as tag `archive/megaline-epistemic-tensor-core-2026-07-07`.

> **Note on the strict one-step gate.** `scripts/ci/lean_single_fixed_point_gate.sh`
> (which asserts shipped-seed == stage1 == stage2 == stage3 in a *single* step) is
> red on this branch — but it is **red on `main` today too**, for a reason
> independent of this PR: the committed seed binary `bin/souc-linux-x86_64` (untouched
> here, byte-identical to main) lags `lean_single.sio`, so convergence takes two
> generations. The two-generation fixed point the Makefile actually asserts
> (`make build`, gen2 == gen3) is clean and green. Making the strict gate green needs
> a seed-binary regeneration — a separate, pre-existing concern, deliberately kept out
> of this focused source-only PR.

Note: this fixes the *self-compile* exhaustion (the lowering-footprint half). The
separate 128 KB `CodeBuffer` ceiling for large (224–629 KB) EISA programs remains a
follow-on — but it is now reachable, because native madaros can be built again.

Addresses #712 (self-compile blocker); the CodeBuffer ceiling for EISA programs is
tracked there as the remaining follow-on.
