### PR TITLE
fix(native): move code + ELF buffers off-stack (2MB/4MB) — lift .text ceiling to 2MB

### DIFF
--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -1178,8 +1178,8 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    if len >= 0 && len < 65536 {
-        (*nc).code.bytes[len as usize] = low8(b) as i8
+    if len >= 0 && len < 2097152 {
+        NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
     }
 }
@@ -1331,10 +1331,10 @@ fn nc_emit_jnz_rel32(nc: &! NativeCompiler) with Mut, Panic, Div {
 
 fn nc_patch_u32_le(nc: &! NativeCompiler, offset: i64, val: i64) with Mut, Panic, Div {
     if offset >= 0 && offset + 4 <= (*nc).code.len {
-        (*nc).code.bytes[offset as usize] = low8(val) as i8
-        (*nc).code.bytes[(offset + 1) as usize] = low8(val >> 8) as i8
-        (*nc).code.bytes[(offset + 2) as usize] = low8(val >> 16) as i8
-        (*nc).code.bytes[(offset + 3) as usize] = low8(val >> 24) as i8
+        NC_BIG_CODE[offset as usize] = low8(val) as i8
+        NC_BIG_CODE[(offset + 1) as usize] = low8(val >> 8) as i8
+        NC_BIG_CODE[(offset + 2) as usize] = low8(val >> 16) as i8
+        NC_BIG_CODE[(offset + 3) as usize] = low8(val >> 24) as i8
     }
 }
 
@@ -2912,8 +2912,8 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
     // Patch jns displacement
     let neg_block_len = c.code.len - (jns_pos + 2)
-    if jns_pos + 1 < 65536 {
-        c.code.bytes[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
+    if jns_pos + 1 < 2097152 {
+        NC_BIG_CODE[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
     }
 
     // Integer part: cvttsd2si
@@ -6215,7 +6215,7 @@ fn finalize_elf64_relocatable(
     // .text
     let text_offset = bin.len
     var ti = 0
-    while ti < code.len { elf_emit_byte_ref(&! bin, code.bytes[ti as usize] as i64); ti = ti + 1 }
+    while ti < code.len { elf_emit_byte_ref(&! bin, NC_BIG_CODE[ti as usize] as i64); ti = ti + 1 }
 
     // .rodata
     let rodata_file_offset = bin.len
@@ -6441,7 +6441,7 @@ fn finalize_elf64_shared(code: CodeBuffer, symbols: SymbolData, fn_offsets: [i64
     while bin.len < 4096 { elf_emit_byte_ref(&! bin, 0) }
     let text_offset = bin.len
     var ti = 0
-    while ti < code.len { elf_emit_byte_ref(&! bin, code.bytes[ti as usize] as i64); ti = ti + 1 }
+    while ti < code.len { elf_emit_byte_ref(&! bin, NC_BIG_CODE[ti as usize] as i64); ti = ti + 1 }
     while bin.len % 8 != 0 { elf_emit_byte_ref(&! bin, 0) }
     let dynsym_offset = bin.len
     emit_symtab_entry_ref(&! bin, 0, 0, 0, 0, 0, 0)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -40,6 +40,12 @@ use io::env::{read_env}
 var NATIVE_ELF_BUF: [i8; 16777216] = [0; 16777216]
 // Write cursor — module-scope avoids &! i64 ref mutation issues in helper fns.
 var NATIVE_ELF_OFF: i64 = 0
+// Off-stack ELF-image output buffer for native_v2_write_min_elf64_to_file. Its
+// image used to be built into a `var bytes: [i8; 262144]` STACK local — too small
+// for large programs (isa ELF ~700KB, evm ~2.1MB) and itself a large-stack-frame
+// hazard. This module-global BSS array (demand-paged, ~0 RSS until touched) holds
+// the assembled ELF image. Written INLINE only (direct NC_BIG_ELF[i]).
+var NC_BIG_ELF: [i8; 4194304] = [0; 4194304]
 // Scratch IR functions for the sret witness. These are module-scope to avoid
 // putting IrFunction-sized temporaries on the Madaros runtime stack.
 var NV2_SRET_MAIN_FN: IrFunction = ir_empty_function()
@@ -1342,8 +1348,8 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    if len >= 0 && len < 262144 {
-        (*nc).code.bytes[len as usize] = low8(b) as i8
+    if len >= 0 && len < 2097152 {
+        NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
     } else {
         (*nc).code_overflow = true
@@ -1590,10 +1596,10 @@ fn nc_emit_jnz_rel32(nc: &! NativeCompiler) with Mut, Panic, Div {
 
 fn nc_patch_u32_le(nc: &! NativeCompiler, offset: i64, val: i64) with Mut, Panic, Div {
     if offset >= 0 && offset + 4 <= (*nc).code.len {
-        (*nc).code.bytes[offset as usize] = low8(val) as i8
-        (*nc).code.bytes[(offset + 1) as usize] = low8(val >> 8) as i8
-        (*nc).code.bytes[(offset + 2) as usize] = low8(val >> 16) as i8
-        (*nc).code.bytes[(offset + 3) as usize] = low8(val >> 24) as i8
+        NC_BIG_CODE[offset as usize] = low8(val) as i8
+        NC_BIG_CODE[(offset + 1) as usize] = low8(val >> 8) as i8
+        NC_BIG_CODE[(offset + 2) as usize] = low8(val >> 16) as i8
+        NC_BIG_CODE[(offset + 3) as usize] = low8(val >> 24) as i8
     }
 }
 
@@ -4474,8 +4480,8 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
     // Patch jns displacement
     let neg_block_len = c.code.len - (jns_pos + 2)
-    if jns_pos + 1 < 262144 {
-        c.code.bytes[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
+    if jns_pos + 1 < 2097152 {
+        NC_BIG_CODE[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
     }
 
     // Integer part: cvttsd2si
@@ -4729,23 +4735,23 @@ pub fn compile_module_streaming_finish_into(nc: &! NativeCompiler, module: &IrMo
 
 fn native_v2_reloc_is_call_patch(nc: &NativeCompiler, patch_offset: i64) -> bool with Panic, Div {
     patch_offset > 0 && patch_offset + 4 <= (*nc).code.len
-        && (*nc).code.bytes[(patch_offset - 1) as usize] == (0xe8 as i8)
+        && NC_BIG_CODE[(patch_offset - 1) as usize] == (0xe8 as i8)
 }
 
 fn native_v2_reloc_is_rip_disp_patch(nc: &NativeCompiler, patch_offset: i64) -> bool with Panic, Div {
     if !(patch_offset >= 3 && patch_offset + 4 <= (*nc).code.len) { return false }
     if patch_offset >= 4
-        && (*nc).code.bytes[(patch_offset - 4) as usize] == (0xf2 as i8)
-        && (*nc).code.bytes[(patch_offset - 3) as usize] == (0x0f as i8)
-        && (*nc).code.bytes[(patch_offset - 2) as usize] == (0x10 as i8) {
-        let sse_modrm = (*nc).code.bytes[(patch_offset - 1) as usize]
+        && NC_BIG_CODE[(patch_offset - 4) as usize] == (0xf2 as i8)
+        && NC_BIG_CODE[(patch_offset - 3) as usize] == (0x0f as i8)
+        && NC_BIG_CODE[(patch_offset - 2) as usize] == (0x10 as i8) {
+        let sse_modrm = NC_BIG_CODE[(patch_offset - 1) as usize]
         if sse_modrm == (0x05 as i8) || sse_modrm == (0x0d as i8) {
             return true
         }
     }
-    if (*nc).code.bytes[(patch_offset - 3) as usize] != (0x48 as i8) { return false }
-    let op = (*nc).code.bytes[(patch_offset - 2) as usize]
-    let modrm = (*nc).code.bytes[(patch_offset - 1) as usize]
+    if NC_BIG_CODE[(patch_offset - 3) as usize] != (0x48 as i8) { return false }
+    let op = NC_BIG_CODE[(patch_offset - 2) as usize]
+    let modrm = NC_BIG_CODE[(patch_offset - 1) as usize]
     (op == (0x8d as i8) && modrm == (0x05 as i8))
         || (op == (0x8b as i8) && modrm == (0x1d as i8))
         || (op == (0x89 as i8) && modrm == (0x05 as i8))
@@ -9557,42 +9563,41 @@ fn compile_to_elf_v2(module: &IrModule, base_addr: i64) -> NativeCompileResult w
     native_compile_result_ok_elf(elf.bytes, elf.len, FORMAT_ELF64())
 }
 
-fn native_v2_file_put_u8(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic {
-    if pos >= 0 && pos < 262144 {
-        (*buf)[pos as usize] = (val & 255) as i8
+fn native_v2_file_put_u8(pos: i64, val: i64) with Mut, Panic {
+    if pos >= 0 && pos < 4194304 {
+        NC_BIG_ELF[pos as usize] = (val & 255) as i8
     }
 }
 
-fn native_v2_file_put_u16(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
-    native_v2_file_put_u8(buf, pos, val)
-    native_v2_file_put_u8(buf, pos + 1, val >> 8)
+fn native_v2_file_put_u16(pos: i64, val: i64) with Mut, Panic, Div {
+    native_v2_file_put_u8(pos, val)
+    native_v2_file_put_u8(pos + 1, val >> 8)
 }
 
-fn native_v2_file_put_u32(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
-    native_v2_file_put_u8(buf, pos, val)
-    native_v2_file_put_u8(buf, pos + 1, val >> 8)
-    native_v2_file_put_u8(buf, pos + 2, val >> 16)
-    native_v2_file_put_u8(buf, pos + 3, val >> 24)
+fn native_v2_file_put_u32(pos: i64, val: i64) with Mut, Panic, Div {
+    native_v2_file_put_u8(pos, val)
+    native_v2_file_put_u8(pos + 1, val >> 8)
+    native_v2_file_put_u8(pos + 2, val >> 16)
+    native_v2_file_put_u8(pos + 3, val >> 24)
 }
 
-fn native_v2_file_put_u64(buf: &![i8; 262144], pos: i64, val: i64) with Mut, Panic, Div {
-    native_v2_file_put_u32(buf, pos, val)
-    native_v2_file_put_u32(buf, pos + 4, val >> 32)
+fn native_v2_file_put_u64(pos: i64, val: i64) with Mut, Panic, Div {
+    native_v2_file_put_u32(pos, val)
+    native_v2_file_put_u32(pos + 4, val >> 32)
 }
 
-fn native_v2_file_emit_phdr(buf: &![i8; 262144], pos: i64, p_type: i64, flags: i64, offset: i64, vaddr: i64, filesz: i64, memsz: i64, align: i64) with Mut, Panic, Div {
-    native_v2_file_put_u32(buf, pos, p_type)
-    native_v2_file_put_u32(buf, pos + 4, flags)
-    native_v2_file_put_u64(buf, pos + 8, offset)
-    native_v2_file_put_u64(buf, pos + 16, vaddr)
-    native_v2_file_put_u64(buf, pos + 24, vaddr)
-    native_v2_file_put_u64(buf, pos + 32, filesz)
-    native_v2_file_put_u64(buf, pos + 40, memsz)
-    native_v2_file_put_u64(buf, pos + 48, align)
+fn native_v2_file_emit_phdr(pos: i64, p_type: i64, flags: i64, offset: i64, vaddr: i64, filesz: i64, memsz: i64, align: i64) with Mut, Panic, Div {
+    native_v2_file_put_u32(pos, p_type)
+    native_v2_file_put_u32(pos + 4, flags)
+    native_v2_file_put_u64(pos + 8, offset)
+    native_v2_file_put_u64(pos + 16, vaddr)
+    native_v2_file_put_u64(pos + 24, vaddr)
+    native_v2_file_put_u64(pos + 32, filesz)
+    native_v2_file_put_u64(pos + 40, memsz)
+    native_v2_file_put_u64(pos + 48, align)
 }
 
 fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler, entry_offset: i64, base_addr: i64) -> i32 with IO, Mut, Panic, Div {
-    var bytes: [i8; 262144] = [0; 262144]
     let text_offset: i64 = 4096
     let code_len = (*nc).code.len
     let rodata_len = if (*nc).flat_rodata_len > 0 { (*nc).flat_rodata_len } else { (*nc).rodata.len }
@@ -9617,81 +9622,91 @@ fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler,
     if data_len > 0 {
         file_len = data_offset + data_len
     }
-    if file_len <= 64 || file_len > 262144 { return 13 }
+    if file_len <= 64 || file_len > 4194304 { return 13 }
 
-    // Build the ELF header + program headers + segment payloads into `bytes`
+    // Zero the used region of the off-stack ELF image buffer (NC_BIG_ELF is a BSS
+    // global — zero at process start, but re-zero here so page-alignment padding
+    // gaps stay zero across repeat compiles in one process). Matches the old
+    // `var bytes: [i8; 262144] = [0; 262144]` stack-local semantics.
+    var zi: i64 = 0
+    while zi < file_len {
+        NC_BIG_ELF[zi as usize] = 0 as i8
+        zi = zi + 1
+    }
+
+    // Build the ELF header + program headers + segment payloads into NC_BIG_ELF
     // via a dedicated small helper. Splitting this out of the (large) caller
     // keeps the conditional `if rodata_len>0`/`if data_len>0` forward jumps
     // inside a short function so their branch offsets stay small — working
     // around a c634b38f branch-target miscompile that otherwise skipped this
     // whole block and fell through to `return 0` (file never written).
-    native_v2_build_elf_image_into(&! bytes, nc, base_addr, entry_offset, text_offset, code_len, rodata_offset, rodata_len, rodata_vaddr, text_vaddr, data_offset, data_len, data_vaddr, phnum)
+    native_v2_build_elf_image_into(nc, base_addr, entry_offset, text_offset, code_len, rodata_offset, rodata_len, rodata_vaddr, text_vaddr, data_offset, data_len, data_vaddr, phnum)
 
-    if bytes[0 as usize] != (0x7f as i8) { return 14 }
-    if bytes[1 as usize] != (0x45 as i8) { return 15 }
-    if bytes[2 as usize] != (0x4c as i8) { return 16 }
-    if bytes[3 as usize] != (0x46 as i8) { return 17 }
-    if write_file(output_path, bytes, file_len) < 0 { return 18 }
+    if NC_BIG_ELF[0 as usize] != (0x7f as i8) { return 14 }
+    if NC_BIG_ELF[1 as usize] != (0x45 as i8) { return 15 }
+    if NC_BIG_ELF[2 as usize] != (0x4c as i8) { return 16 }
+    if NC_BIG_ELF[3 as usize] != (0x46 as i8) { return 17 }
+    if write_file(output_path, NC_BIG_ELF, file_len) < 0 { return 18 }
     0
 }
 
 // Helper extracted from native_v2_write_min_elf64_to_file (c634b38f branch-offset
 // workaround — see caller). Writes the full ELF image into `bytes`.
-fn native_v2_build_elf_image_into(bytes: &! [i8; 262144], nc: &! NativeCompiler, base_addr: i64, entry_offset: i64, text_offset: i64, code_len: i64, rodata_offset: i64, rodata_len: i64, rodata_vaddr: i64, text_vaddr: i64, data_offset: i64, data_len: i64, data_vaddr: i64, phnum: i64) with Mut, Panic, Div {
-    native_v2_file_put_u8(bytes, 0, 127)
-    native_v2_file_put_u8(bytes, 1, 69)
-    native_v2_file_put_u8(bytes, 2, 76)
-    native_v2_file_put_u8(bytes, 3, 70)
-    native_v2_file_put_u8(bytes, 4, 2)
-    native_v2_file_put_u8(bytes, 5, 1)
-    native_v2_file_put_u8(bytes, 6, 1)
-    native_v2_file_put_u16(bytes, 16, 2)
-    native_v2_file_put_u16(bytes, 18, 62)
-    native_v2_file_put_u32(bytes, 20, 1)
-    native_v2_file_put_u64(bytes, 24, base_addr + text_offset + entry_offset)
-    native_v2_file_put_u64(bytes, 32, 64)
-    native_v2_file_put_u64(bytes, 40, 0)
-    native_v2_file_put_u32(bytes, 48, 0)
-    native_v2_file_put_u16(bytes, 52, 64)
-    native_v2_file_put_u16(bytes, 54, 56)
-    native_v2_file_put_u16(bytes, 56, phnum)
-    native_v2_file_put_u16(bytes, 58, 64)
-    native_v2_file_put_u16(bytes, 60, 0)
-    native_v2_file_put_u16(bytes, 62, 0)
+fn native_v2_build_elf_image_into(nc: &! NativeCompiler, base_addr: i64, entry_offset: i64, text_offset: i64, code_len: i64, rodata_offset: i64, rodata_len: i64, rodata_vaddr: i64, text_vaddr: i64, data_offset: i64, data_len: i64, data_vaddr: i64, phnum: i64) with Mut, Panic, Div {
+    native_v2_file_put_u8(0, 127)
+    native_v2_file_put_u8(1, 69)
+    native_v2_file_put_u8(2, 76)
+    native_v2_file_put_u8(3, 70)
+    native_v2_file_put_u8(4, 2)
+    native_v2_file_put_u8(5, 1)
+    native_v2_file_put_u8(6, 1)
+    native_v2_file_put_u16(16, 2)
+    native_v2_file_put_u16(18, 62)
+    native_v2_file_put_u32(20, 1)
+    native_v2_file_put_u64(24, base_addr + text_offset + entry_offset)
+    native_v2_file_put_u64(32, 64)
+    native_v2_file_put_u64(40, 0)
+    native_v2_file_put_u32(48, 0)
+    native_v2_file_put_u16(52, 64)
+    native_v2_file_put_u16(54, 56)
+    native_v2_file_put_u16(56, phnum)
+    native_v2_file_put_u16(58, 64)
+    native_v2_file_put_u16(60, 0)
+    native_v2_file_put_u16(62, 0)
 
     var phoff: i64 = 64
-    native_v2_file_emit_phdr(bytes, phoff, 1, 5, text_offset, text_vaddr, code_len, code_len, 4096)
+    native_v2_file_emit_phdr(phoff, 1, 5, text_offset, text_vaddr, code_len, code_len, 4096)
     phoff = phoff + 56
     if rodata_len > 0 {
-        native_v2_file_emit_phdr(bytes, phoff, 1, 4, rodata_offset, rodata_vaddr, rodata_len, rodata_len, 4096)
+        native_v2_file_emit_phdr(phoff, 1, 4, rodata_offset, rodata_vaddr, rodata_len, rodata_len, 4096)
         phoff = phoff + 56
     }
     if data_len > 0 {
-        native_v2_file_emit_phdr(bytes, phoff, 1, 6, data_offset, data_vaddr, data_len, data_len, 4096)
+        native_v2_file_emit_phdr(phoff, 1, 6, data_offset, data_vaddr, data_len, data_len, 4096)
         phoff = phoff + 56
     }
     if (*nc).bss_total_size > 0 {
-        native_v2_file_emit_phdr(bytes, phoff, 1, 6, 0, 268435456, 0, (*nc).bss_total_size, 4096)
+        native_v2_file_emit_phdr(phoff, 1, 6, 0, 268435456, 0, (*nc).bss_total_size, 4096)
         phoff = phoff + 56
     }
-    native_v2_file_emit_phdr(bytes, phoff, 0x6474e551, 6, 0, 0, 0, 0, 16)
+    native_v2_file_emit_phdr(phoff, 0x6474e551, 6, 0, 0, 0, 0, 16)
 
     var i: i64 = 0
-    while i < code_len && (text_offset + i) < 262144 {
-        (*bytes)[(text_offset + i) as usize] = (*nc).code.bytes[i as usize]
+    while i < code_len && (text_offset + i) < 4194304 {
+        NC_BIG_ELF[(text_offset + i) as usize] = NC_BIG_CODE[i as usize]
         i = i + 1
     }
 
     if (*nc).flat_rodata_len > 0 {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 262144 {
-            (*bytes)[(rodata_offset + i) as usize] = (*nc).flat_rodata_bytes[i as usize]
+        while i < rodata_len && (rodata_offset + i) < 4194304 {
+            NC_BIG_ELF[(rodata_offset + i) as usize] = (*nc).flat_rodata_bytes[i as usize]
             i = i + 1
         }
     } else {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 262144 {
-            (*bytes)[(rodata_offset + i) as usize] = (*nc).rodata.bytes[i as usize]
+        while i < rodata_len && (rodata_offset + i) < 4194304 {
+            NC_BIG_ELF[(rodata_offset + i) as usize] = (*nc).rodata.bytes[i as usize]
             i = i + 1
         }
     }
@@ -10106,7 +10121,7 @@ fn compile_native_finalize_and_write_ref(nc: &! NativeCompiler, base_addr: i64, 
     // Copy code bytes — direct BSS write + struct-ref read (both work)
     var ci: i64 = 0
     while ci < code_len {
-        NATIVE_ELF_BUF[NATIVE_ELF_OFF as usize] = (*nc).code.bytes[ci as usize]
+        NATIVE_ELF_BUF[NATIVE_ELF_OFF as usize] = NC_BIG_CODE[ci as usize]
         NATIVE_ELF_OFF = NATIVE_ELF_OFF + 1
         ci = ci + 1
     }

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -10,6 +10,20 @@ pub struct CodeBuffer {
     pub len: i64,
 }
 
+// Off-stack machine-code buffer for the native_v2 x86 Linux path. The .text bytes
+// used to live inline in CodeBuffer.bytes (embedded by value in NativeCompiler on
+// the 8MB stack); growing that past ~640KB miscompiles (large stack frame). This
+// module-global BSS array holds the emitted code so NativeCompiler stays small on
+// the stack, while `.len` (a scalar, threaded through BOTH the by-ref nc_emit_byte
+// path and the by-value emit_byte path) stays the authoritative length. Both emit
+// paths write NC_BIG_CODE[.len]; the struct .bytes field is now vestigial for the
+// Linux path (kept only for the macho/pe by-value readers). Because .len is threaded
+// consistently, the by-value builtin emitters (which emit into a copy of nc) append
+// to the same global at the shared offset, so no persist/call-site changes are
+// needed. Accessed INLINE only — never via a returning helper (miscompiles under
+// the seed). NOT used by the aarch64/suite scratch-buffer paths (those keep .bytes).
+pub var NC_BIG_CODE: [i8; 2097152] = [0; 2097152]
+
 pub fn code_buffer_new() -> CodeBuffer {
     var out: CodeBuffer
     out.len = 0
@@ -58,8 +72,8 @@ pub fn wide_copy_from_code_buffer(dst: WideCodeBuffer, src: CodeBuffer) -> WideC
 pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
     var out = buf
     if out.len >= 0 {
-        if out.len < 262144 {
-            out.bytes[out.len as usize] = low8(b) as i8
+        if out.len < 2097152 {
+            NC_BIG_CODE[out.len as usize] = low8(b) as i8
             out.len = out.len + 1
         }
     }
@@ -68,8 +82,8 @@ pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
 
 pub fn emit_byte_mut(buf: &! CodeBuffer, b: i64) with Mut, Panic, Div {
     if (*buf).len >= 0 {
-        if (*buf).len < 262144 {
-            (*buf).bytes[(*buf).len as usize] = low8(b) as i8
+        if (*buf).len < 2097152 {
+            NC_BIG_CODE[(*buf).len as usize] = low8(b) as i8
             (*buf).len = (*buf).len + 1
         }
     }

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -463,10 +463,13 @@ pub fn patch_return_jumps_mut(nc: &! NativeCompiler, epilogue_offset: i64) with 
     while i < (*nc).return_jump_count && i < 16 {
         let imm_offset = (*nc).return_jumps[i as usize]
         if imm_offset > 0 && imm_offset + 4 <= (*nc).code.len
-            && (*nc).code.bytes[(imm_offset - 1) as usize] == (0xe9 as i8) {
+            && NC_BIG_CODE[(imm_offset - 1) as usize] == (0xe9 as i8) {
             let next_ip = imm_offset + 4
             let rel = epilogue_offset - next_ip
-            (*nc).code = patch_u32_le((*nc).code, imm_offset, rel)
+            NC_BIG_CODE[imm_offset as usize] = low8(rel) as i8
+            NC_BIG_CODE[(imm_offset + 1) as usize] = low8(rel >> 8) as i8
+            NC_BIG_CODE[(imm_offset + 2) as usize] = low8(rel >> 16) as i8
+            NC_BIG_CODE[(imm_offset + 3) as usize] = low8(rel >> 24) as i8
         }
         i = i + 1
     }
@@ -501,12 +504,12 @@ pub fn record_label_patch_mut(nc: &! NativeCompiler, label_id: i64, rel32_offset
 
 fn label_patch_is_rel32_branch(nc: &NativeCompiler, patch_off: i64) -> bool with Panic, Div {
     if patch_off > 0 && patch_off + 4 <= (*nc).code.len
-        && (*nc).code.bytes[(patch_off - 1) as usize] == (0xe9 as i8) {
+        && NC_BIG_CODE[(patch_off - 1) as usize] == (0xe9 as i8) {
         return true
     }
     if patch_off >= 2 && patch_off + 4 <= (*nc).code.len
-        && (*nc).code.bytes[(patch_off - 2) as usize] == (0x0f as i8) {
-        let op = (*nc).code.bytes[(patch_off - 1) as usize]
+        && NC_BIG_CODE[(patch_off - 2) as usize] == (0x0f as i8) {
+        let op = NC_BIG_CODE[(patch_off - 1) as usize]
         return op == (0x84 as i8) || op == (0x85 as i8)
     }
     false
@@ -524,10 +527,10 @@ pub fn patch_label_forwards_mut(nc: &! NativeCompiler) with Mut, Panic, Div {
         let target = NC_V2_LABEL_OFFSETS[patch_lid as usize]
         if target >= 0 && patch_off >= 0 && label_patch_is_rel32_branch(nc, patch_off) {
             let rel = target - (patch_off + 4)
-            (*nc).code.bytes[patch_off as usize] = low8(rel) as i8
-            (*nc).code.bytes[(patch_off + 1) as usize] = low8(rel >> 8) as i8
-            (*nc).code.bytes[(patch_off + 2) as usize] = low8(rel >> 16) as i8
-            (*nc).code.bytes[(patch_off + 3) as usize] = low8(rel >> 24) as i8
+            NC_BIG_CODE[patch_off as usize] = low8(rel) as i8
+            NC_BIG_CODE[(patch_off + 1) as usize] = low8(rel >> 8) as i8
+            NC_BIG_CODE[(patch_off + 2) as usize] = low8(rel >> 16) as i8
+            NC_BIG_CODE[(patch_off + 3) as usize] = low8(rel >> 24) as i8
         }
         i = i + 1
     }

--- a/self-hosted/native/reloc.sio
+++ b/self-hosted/native/reloc.sio
@@ -4,7 +4,7 @@
 
 module native::reloc
 
-use native::encode::{CodeBuffer, low8}
+use native::encode::{CodeBuffer, low8, NC_BIG_CODE}
 
 // Relocation kinds
 pub struct RelocKind {
@@ -267,10 +267,10 @@ pub fn collect_rela_section(
 pub fn patch_u32_le(buf: CodeBuffer, offset: i64, val: i64) -> CodeBuffer with Mut, Panic, Div {
     var b = buf
     if offset >= 0 && offset + 4 <= b.len {
-        b.bytes[offset as usize] = low8(val) as i8
-        b.bytes[(offset + 1) as usize] = low8(val >> 8) as i8
-        b.bytes[(offset + 2) as usize] = low8(val >> 16) as i8
-        b.bytes[(offset + 3) as usize] = low8(val >> 24) as i8
+        NC_BIG_CODE[offset as usize] = low8(val) as i8
+        NC_BIG_CODE[(offset + 1) as usize] = low8(val >> 8) as i8
+        NC_BIG_CODE[(offset + 2) as usize] = low8(val >> 16) as i8
+        NC_BIG_CODE[(offset + 3) as usize] = low8(val >> 24) as i8
     }
     b
 }


### PR DESCRIPTION
**Stacked on #715** (base = `fix/native-codebuffer-256k`). Merge #715 first; this shows only the off-stack diff.

## What

Moves the two machine-code buffers off the stack into module-global BSS arrays, lifting the `.text` ceiling **256 KB → 2 MB** without touching `NativeCompiler`'s stack frame:
- `NC_BIG_CODE [i8; 2097152]` (encode.sio) — the emitted `.text`
- `NC_BIG_ELF [i8; 4194304]` (codegen_x86_linux.sio) — the assembled ELF image

Both are demand-paged BSS (~0 RSS until touched).

## Why this works where on-stack didn't

Growing the inline buffer past ~640 KB miscompiles (large stack frame → `rc=14`). Off-stack sidesteps that. The key trick for the code buffer: route **both** the by-ref `nc_emit_byte` **and** the by-value `emit_byte`/`emit_byte_mut` to write `NC_BIG_CODE[.len]`, keyed by the threaded `.len` scalar. Because `.len` stays consistent across the by-ref/by-value transition, the by-value builtin emitters (`emit_builtin_X((*nc))` → `persist`) append to the same global automatically — **no persist/call-site changes**. Every access is inlined (never a returning helper — that pattern miscompiles under the seed). The struct `CodeBuffer.bytes[262144]` stays vestigial (kept for the macho/pe readers), so the stack frame is unchanged.

ELF buffer: the `native_v2_file_put_*` helpers + `native_v2_build_elf_image_into` drop their `bytes: &![i8;262144]` param and write `NC_BIG_ELF` directly (mirrors the existing `nc_elf_put_u8`/`NATIVE_ELF_BUF` pattern).

## Verification (madaros rebuilt from source)

- **Byte-identical to the 256 KB build for every previously-emittable program; 0 real regressions.** `clifford_spacetime`/`constrained_opt_test` differ in ELF layout only — **identical, deterministic runtime output** (the documented benign f64 diff class).
- Integer synthetics: 147 KB matches exactly; **400 KB+ / 800 KB+ `.text`** (which the 256 KB build rejects with `rc=19`) now **compile and run correctly**.
- Programs the 256 KB build rejected now compile: `bdf64_test` (1.4 MB ELF), `darwin_compartments` (590 KB), `darwin_pbpk28` (266 KB), and the **EISA `isa` suite (688 KB `.text`, 467 fns — previously impossible to emit at any on-stack size)**.
- `eisa core` still `ALL PASS`.

## Scope note

`isa` and the f64-heavy large programs **emit correctly but still SIGSEGV at runtime** — a **separate, pre-existing** deep bug (cross-module large-struct SRET / f64 codegen), **not** the buffer: integer programs of the same code size run correctly. This PR solves the compile-size blocker; the runtime bug is a distinct follow-up. (`evm`'s 2.1 MB `.text` will need `NC_BIG_CODE` bumped to 4 MB.)

## Not included

The rebuilt `artifacts/self-hosted/madaros` binary is not committed — regenerate via `scripts/ci/build_modular_madaros.sh` with a spill+import-patched seed.