### PR TITLE
fix(native): move flat_reloc off-stack (65536) — EISA isa now compiles AND runs (ALL PASS)

### DIFF
--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1605,19 +1605,11 @@ fn nc_patch_u32_le(nc: &! NativeCompiler, offset: i64, val: i64) with Mut, Panic
 
 fn nc_add_flat_reloc(nc: &! NativeCompiler, patch_offset: i64, kind_code: i64, is_function: i64, target_index: i64) with Mut, Panic, Div {
     let idx = (*nc).flat_reloc_count
-    if idx >= 0 && idx < 4096 {
-        var offsets = (*nc).flat_reloc_offsets
-        var kinds = (*nc).flat_reloc_kind_codes
-        var flags = (*nc).flat_reloc_is_functions
-        var targets = (*nc).flat_reloc_target_indices
-        offsets[idx as usize] = patch_offset
-        kinds[idx as usize] = kind_code
-        flags[idx as usize] = is_function
-        targets[idx as usize] = target_index
-        (*nc).flat_reloc_offsets = offsets
-        (*nc).flat_reloc_kind_codes = kinds
-        (*nc).flat_reloc_is_functions = flags
-        (*nc).flat_reloc_target_indices = targets
+    if idx >= 0 && idx < 65536 {
+        NC_FLAT_RELOC_OFFSETS[idx as usize] = patch_offset
+        NC_FLAT_RELOC_KIND_CODES[idx as usize] = kind_code
+        NC_FLAT_RELOC_IS_FUNCTIONS[idx as usize] = is_function
+        NC_FLAT_RELOC_TARGET_INDICES[idx as usize] = target_index
         (*nc).flat_reloc_count = idx + 1
     }
 }
@@ -4759,11 +4751,11 @@ fn native_v2_reloc_is_rip_disp_patch(nc: &NativeCompiler, patch_offset: i64) -> 
 
 fn apply_relocations_into(nc: &! NativeCompiler, rodata_file_offset: i64, data_file_offset: i64) with Mut, Panic, Div {
     var i = 0
-    while i < (*nc).flat_reloc_count && i < 4096 {
-        let patch_offset = (*nc).flat_reloc_offsets[i as usize]
-        let kind_code = (*nc).flat_reloc_kind_codes[i as usize]
-        let is_function = (*nc).flat_reloc_is_functions[i as usize]
-        let target_index = (*nc).flat_reloc_target_indices[i as usize]
+    while i < (*nc).flat_reloc_count && i < 65536 {
+        let patch_offset = NC_FLAT_RELOC_OFFSETS[i as usize]
+        let kind_code = NC_FLAT_RELOC_KIND_CODES[i as usize]
+        let is_function = NC_FLAT_RELOC_IS_FUNCTIONS[i as usize]
+        let target_index = NC_FLAT_RELOC_TARGET_INDICES[i as usize]
 
         if kind_code == 1 && native_v2_reloc_is_call_patch(nc, patch_offset) {
             if is_function == 1 {

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -202,6 +202,22 @@ pub var NC_V2_LABEL_PATCH_IDS: [i64; 256] = [0; 256]
 pub var NC_V2_LABEL_PATCH_COUNT: i64 = 0
 pub var NC_V2_NEXT_CMP_LABEL: i64 = 210
 
+// Off-stack flat relocation table for the native_v2 x86 Linux path. This is
+// module-WIDE (accumulates across ALL functions of a compile, reset via
+// flat_reloc_count=0 in compiler_new). It used to be four [i64; 4096] arrays
+// inline in NativeCompiler — but a large multi-function program overflows 4096
+// (e.g. the EISA isa suite emits ~9700 relocations across its 467 functions),
+// silently dropping every reloc past 4096, so calls/rodata refs (incl. the entry
+// trampoline's call to main) stay unpatched → jump to garbage → SIGSEGV. Raising
+// the inline arrays would add ~2MB to NativeCompiler's stack frame (rc=14 zone),
+// so they live off-stack here (BSS, demand-paged). flat_reloc_count stays a scalar
+// in NativeCompiler and indexes these. Accessed INLINE only (never a returning
+// helper — that miscompiles under the seed).
+pub var NC_FLAT_RELOC_OFFSETS: [i64; 65536] = [0; 65536]
+pub var NC_FLAT_RELOC_KIND_CODES: [i64; 65536] = [0; 65536]
+pub var NC_FLAT_RELOC_IS_FUNCTIONS: [i64; 65536] = [0; 65536]
+pub var NC_FLAT_RELOC_TARGET_INDICES: [i64; 65536] = [0; 65536]
+
 // ============================================================================
 // Compiler state
 // ============================================================================
@@ -210,10 +226,8 @@ pub struct NativeCompiler {
     pub code: CodeBuffer,
     pub code_overflow: bool,
     pub relocs: RelocationTable,
-    pub flat_reloc_offsets: [i64; 4096],
-    pub flat_reloc_kind_codes: [i64; 4096],
-    pub flat_reloc_is_functions: [i64; 4096],
-    pub flat_reloc_target_indices: [i64; 4096],
+    // flat_reloc storage moved off-stack to module globals NC_FLAT_RELOC_* (above);
+    // only the count remains here (module-wide, indexes the globals).
     pub flat_reloc_count: i64,
     pub flat_rodata_bytes: [i8; 8192],
     pub flat_rodata_len: i64,


### PR DESCRIPTION
**Stacked on #721** (base = `fix/native-codebuffer-offstack`). Merge #715 and #721 first; this shows only the reloc diff.

## The headline

**EISA `isa` now compiles AND runs: `ALL PASS: eisa isa P1 P2 P3 P4 P5`, rc=0.** It was a SIGSEGV before — impossible to run at any prior config.

## Root cause

The native_v2 flat relocation table is **module-wide** — it accumulates every call/rodata/data relocation across *all* functions of a compile (reset only in `compiler_new`), stored as four `[i64; 4096]` arrays inline in `NativeCompiler`.

isa (467 functions, f64/string-heavy) emits **~9703 relocations**. `nc_add_flat_reloc`'s `idx < 4096` guard silently **drops the ~5607 past the cap**. Those calls and rodata references — including the **entry trampoline's call to `main`** — stay unpatched (`rel32 = 0`), so the program jumps to garbage and SIGSEGVs *before main runs* (it crashes even with `main { 0 }`).

The tell that isolated it: 459 *integer* functions + `main{0}` run fine, but 459 *EISA* functions + `main{0}` crash — integer programs emit **zero** relocations. Confirmed with a counter: isa=9703, eisa core=1894 (<4096, works).

## Fix

Move the four arrays off-stack into module globals (`NC_FLAT_RELOC_*` in frame.sio, `[i64; 65536]`; `nc_add_flat_reloc` + `apply_relocations_into` access them inline; guards 4096→65536). Raising them in the struct would add ~2 MB to `NativeCompiler`'s stack frame (the >640 KB miscompile zone); off-stack BSS avoids that **and removes 128 KB from the struct**. `flat_reloc_count` stays a scalar indexing the globals. Same off-stack pattern as #721's code and ELF buffers.

## Verification

- `isa`: `ALL PASS: eisa isa P1..P5`, rc=0.
- `eisa core`: still `ALL PASS`.
- **Byte-identical** to the prior build for every program under 4096 relocations (the storage move is logic-neutral). The only diffs are large programs already broken by the dropped relocs — not regressions.

## Follow-up

`evm` (2048 functions, ~2.1 MB code) still overflows the 2 MB code buffer (`rc=19`) — needs `NC_BIG_CODE` bumped to 4 MB, separate.