### PR TITLE
ci(release-gate): run Apple native typecheck proof against lean.sio, not lean_single

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -111,11 +111,23 @@ jobs:
           "$SOUC_STAGE2" self-hosted/compiler/lean_single.sio "$MACOS_OUT" --target aarch64-macos
           chmod +x "$MACOS_OUT"
           file "$MACOS_OUT" | grep -F "Mach-O 64-bit arm64 executable"
+          # Typecheck-proof compiler: the native typecheck proof harness invokes
+          # `<compiler> --check <fixture>` and greps for E-code diagnostics (E137, ...).
+          # The minimal lean_single seed provides neither `--check` nor E-codes, so the
+          # proof must run against lean.sio — exactly as the x86 source-bootstrap proof
+          # does (ci.yml builds lean.sio -> CHECK_OUT for the same harness). Cross-build
+          # it here and wire it in via SOUC_TYPECHECK_NATIVE below.
+          MACOS_CHECK_OUT=/tmp/souc-lean-check-arm64-macos
+          "$SOUC_STAGE2" self-hosted/compiler/lean.sio "$MACOS_CHECK_OUT" --target aarch64-macos
+          chmod +x "$MACOS_CHECK_OUT"
+          file "$MACOS_CHECK_OUT" | grep -F "Mach-O 64-bit arm64 executable"
       - name: Upload source-bootstrap macOS compiler artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-source-bootstrap-native-compiler-macos-arm64
-          path: /tmp/souc-self-hosted-arm64-macos
+          path: |
+            /tmp/souc-self-hosted-arm64-macos
+            /tmp/souc-lean-check-arm64-macos
           retention-days: 7
       - name: Upload source-bootstrap release artifacts
         if: always()
@@ -144,9 +156,14 @@ jobs:
         run: |
           cp /tmp/source-bootstrap-macos/souc-self-hosted-arm64-macos artifacts/self-hosted/souc-self-hosted-arm64-macos
           chmod +x artifacts/self-hosted/souc-self-hosted-arm64-macos
+          cp /tmp/source-bootstrap-macos/souc-lean-check-arm64-macos artifacts/self-hosted/souc-lean-check-arm64-macos
+          chmod +x artifacts/self-hosted/souc-lean-check-arm64-macos
       - name: Native acceptance gate
         env:
           SOUC_NATIVE: artifacts/self-hosted/souc-self-hosted-arm64-macos
+          # The proof harness needs lean.sio's --check + E-code diagnostics; the
+          # lean_single seed under test (SOUC_NATIVE) has neither. Mirror x86.
+          SOUC_TYPECHECK_NATIVE: artifacts/self-hosted/souc-lean-check-arm64-macos
           WORK_DIR: /tmp/sounio-native-acceptance-macos-arm64
           SOUNIO_MACOS_CRASH_DIAG: "1"
         run: bash scripts/selfhost/selfhost_native_acceptance_gate.sh


### PR DESCRIPTION
## Problem

The **Release Gate → Apple Self-Host → Native acceptance gate** step (native typecheck proof) has been red on every daily run since **2026-05-28**. Current signature:

```
FAIL [undefined_var] missing expected diagnostic  (expected: E137)
selfhost_native_typecheck_proof.sh: line 28: Segmentation fault: 11
```

Investigation showed this is (at least partly) a **CI misconfiguration**, not a compiler defect. The proof harness invokes `<compiler> --check <fixture>` and greps for E-code diagnostics (`E137`, …). The job passed the **lean_single**-derived arm64 binary as the typecheck compiler — via the acceptance gate default `SOUC_TYPECHECK_NATIVE:-$SOUC_NATIVE` — but the minimal `lean_single` seed:

- has **no `--check` flag** → it reads the literal string `--check` as the source path and never opens the fixture (`source: --check` → `no main`), and
- **never emits E-codes** (`grep E137 lean_single.sio` = 0 hits; its undefined-var error is prose).

So the proof could not pass by construction. The **x86 source-bootstrap proof already runs the harness against `lean.sio`** (which supports `--check` and emits `E137`); arm64 simply never got the same wiring, despite `SOUC_TYPECHECK_NATIVE` existing as the intended override.

## Fix

Mirror the x86 proof on arm64:
1. Cross-build `lean.sio` → `souc-lean-check-arm64-macos` alongside the existing `lean_single` → arm64 build.
2. Upload / install it.
3. Set `SOUC_TYPECHECK_NATIVE` to it in the Native acceptance gate step.

`lean_single` stays as `SOUC_NATIVE` (the compile target under test); only the **typecheck-proof** compiler changes to `lean.sio`.

## Verification (x86, local)

- `lean.sio --check undefined_var.sio` → `error[E137: use of undeclared variable` ✓
- `lean_single --check …` → `source: --check` + `no main` (never reads the fixture)
- The seed cross-targets `aarch64-macos` (Mach-O arm64) via the same `macho_arm64` path CI uses.
- YAML validated (`yaml.safe_load`).

The arm64 runtime behavior is only observable on the Apple CI runner — this PR exists so that job can exercise it.

## Caveat (scope)

This fixes the **`--check`/E137 wiring**. A **separate** finding is that the aarch64-macOS codegen SIGSEGVs on `lean_single` (same source runs clean on x86-linux) — if that crash also affects `lean.sio` at runtime, the Apple job may still fail and a distinct backend fix is needed. Full diagnosis + repro recipe: `docs/handoff/apple_selfhost_release_gate_sigsegv_2026-07-10.md`. This PR is necessary and correct regardless; CI on the Apple runner is the arbiter for whether it is sufficient alone.

## Notes

- Pre-existing failure since 2026-05-28 (`b65cd4788` last green → `a32348c94` first red); independent of recent native-backend work (#724).
- Touches only `.github/workflows/release-gate.yml` (+18/−1).
