### PR TITLE
feat(cd-seam): drop the native_decide octonion base — ∀n chain now fully anchor-free

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2454,3 +2454,10 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - File: docs/papers/cd-tower-seam-obstruction.md (§6 "The next formal steps" block)
 - Providers: xai/grok-4.1 = DONE, no issues ("internal/external split exact; no mischaracterization of dropping the native_decide base or widening past loHi; no overclaims; technically precise"). Other legs infra-degraded (SKIP).
 - Verdict: pass. Docs-only, no theorem claims changed.
+
+## 2026-07-10 — M1 math-review: drop native_decide octonion base (Q_base structural)
+- File: formal/lean4/SounioCDConverse.lean (Q_base + cdSigma_cross_neg, both_low_witness_disagree, both_high_witness_disagree)
+- Task: verify the structural octonion base (witness existence sufficiency; both witnesses non-exceptional; 6-case exhaustiveness)
+- Providers: xai/grok-4.1 = DONE, 3/3 checks pass ("both-low a=4+l and both-high a=llo are non-exceptional; six branches + lt/ge symmetry cover every mixed pair in {1..7}; Q_base depends only on [propext, Quot.sound]"). zai = SKIP (unwired).
+- 2nd lens: Lean kernel #print axioms = [propext, Quot.sound] across Q_base/Q_all/seam_coincidence/converse_conjecture_proved — anchor removed, no native_decide in the ∀n chain.
+- Verdict: pass. Advisor also confirmed statement-identical Q_base (zero drift) + caught the stale "only member anchor-free" claim.

--- a/docs/papers/cd-tower-seam-obstruction.md
+++ b/docs/papers/cd-tower-seam-obstruction.md
@@ -21,7 +21,8 @@ coincidence** `off-seam ⟺ 2-term zero divisor ⟺ XOR-winner ⟺ {L_l,L_u} ≠
 σ-form** (`seam_coincidence`: `isZD = offSeam ∧ hasXorAnnih = offSeam ∧ anti0 = ¬offSeam`, ∀ `bits≥4`
 on loHi) — both the converse (`off-seam ⟹ ZD`, an ordinary induction over the tower with an octonion
 base) and its forward obstruction (`on-seam ⟹ not a ZD`), plus the operator bridge, all with kernel
-axioms `[propext, Quot.sound]` plus a single `native_decide` octonion-base anchor; (ii) an `O(N)`
+axioms `[propext, Quot.sound]` and **no `native_decide` anywhere in the ∀n chain** (the octonion base
+is proved structurally); (ii) an `O(N)`
 decision reduction that pushes the cross-check to dimension `1024`; and (iii) a primary-source
 cross-check against Moreno's original annihilator. The σ-recursion machinery gives a *combinatorial*
 form of the Moreno/BDI statement — its own, self-contained proof in the Sounio convention, not a
@@ -57,14 +58,16 @@ The content is the coincidence `offSeam ⟺ hasXorAnnih ⟺ isZD ⟺ ¬anti0`. *
 
 | Link | Direction | Status |
 |---|---|---|
-| `offSeam ⟹ hasXorAnnih` | the converse proper | **proved ∀n** (`converse_holds`) — ordinary induction (`Q_all`; octonion base by `native_decide`; six exhaustive seam cases) + the BDI doubling recursion `converse_recursion'`; discharges `ConverseConjecture` (`converse_conjecture_proved`). Empirically verified n≤10 (§2); matches Moreno/BDI (§4) |
+| `offSeam ⟹ hasXorAnnih` | the converse proper | **proved ∀n** (`converse_holds`) — ordinary induction (`Q_all`; octonion base `Q_base` proved structurally, no `native_decide`; six exhaustive seam cases) + the BDI doubling recursion `converse_recursion'`; discharges `ConverseConjecture` (`converse_conjecture_proved`). Empirically verified n≤10 (§2); matches Moreno/BDI (§4) |
 | `hasXorAnnih ⟹ isZD` | reduction (sufficiency) | **proved ∀n** (`hasXorAnnih_sound`, on `l,u < 2^bits`, `l ≠ u`) |
 | `isZD ⟹ hasXorAnnih` | reduction (necessity) | **proved ∀n** (`hasXorAnnih_complete`) — the reverse reduction `annih_forces` (any 2-term annihilator forces `b=a⊕(l⊕u)` and the four-sign winner, axioms `[propext, Quot.sound]`), with the `a=0`/`{0,d}`-orbit corner (`P0_neg_of_onSeam`) routed through `converse_holds`. Upgrades the old n=4 anchor; `xorAnnih_eq_isZD_all` gives the full `hasXorAnnih == isZD` on loHi ∀n |
 | `¬offSeam ⟹ ¬isZD` | forward obstruction | **proved ∀n** (`isZD_eq_offSeam`) — on-seam pairs have no XOR-winner (`hasXorAnnih_false_of_onSeam`, every orbit loses via the edge lemmas) composed with `hasXorAnnih_complete`. A purely combinatorial route (no operator/`anti0` detour needed) |
 | `anti0 ⟺ ¬offSeam` | operator bridge | **proved ∀n** (`seam_eq_anti0`) — via the identity `Q(c)=P(c)` (the anticommutator four-sign product equals the converse winner product, two `cdSigma_cocycle` rewrites), so the operator condition reduces to the same `P`-analysis. Generalizes the `anti0==!offSeam` member of `coincidence_16/32` to all n (`anti0_eq_offSeam_all`) |
 
-All links carry axioms `[propext, Quot.sound]` plus the single inherited k=3 octonion `native_decide`
-base anchor. `seam_coincidence` states the four-way identity as one theorem: `isZD = offSeam ∧
+All links carry axioms `[propext, Quot.sound]` — **fully anchor-free**, with no `native_decide`
+anywhere in the ∀n chain (the octonion base `Q_base` is proved structurally; the only `native_decide`
+uses in the file are the fixed-n regression anchors of §3, outside the ∀n chain).
+`seam_coincidence` states the four-way identity as one theorem: `isZD = offSeam ∧
 hasXorAnnih = offSeam ∧ anti0 = ¬offSeam`, ∀ bits≥4 on loHi. The one overclaim we still avoid: **no**
 claim about zero divisors with annihilators of length `> 2` — every predicate here is about 2-term
 factors by definition (Grok-verified exhaustive for 2-term factors, §2).
@@ -121,10 +124,13 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   all hold on loHi.)
 - **The converse proper `offSeam ⟹ hasXorAnnih` — proved ∀n** (`converse_holds`, `∀ bits≥4` on loHi;
   and `converse_conjecture_proved : ConverseConjecture` composing it with `hasXorAnnih_sound`).
-  Mathlib-free, axioms `[propext, Quot.sound]` + the single k=3 octonion-base `native_decide` anchor.
+  Mathlib-free, axioms `[propext, Quot.sound]` — anchor-free (no `native_decide`).
   The engine is `Q_all`: *every distinct-nonzero pair in `A_k` (`k≥3`) has a non-exceptional
   disagreeing orbit* (`P=−1`), by **ordinary** induction on the level. Base = octonions `A_3` (a
-  division algebra; `native_decide`). Step = six exhaustive cases on the seam position `H=2^k`: three
+  division algebra; `Q_base`, proved **structurally** by the same six-way seam split as the step, with
+  the two doubling cases discharged without an IH — both-low via the high witness `a=2²+l`, both-high
+  via the low witness `a=l_lo`; `both_low_witness_disagree`/`both_high_witness_disagree`, no
+  `native_decide`). Step = six exhaustive cases on the seam position `H=2^k`: three
   seam-element **edges** collapse to the cocycle/antisym/diagonal identities (`edge_m_eq_H`,
   `edge_m_eq_H_plus_l`, `edge_l_eq_H`); **both-low** and **both-high** pairs *inherit* their witness
   from the level below via sign-stability (`P_stable_low`, `fVal_high_stable`); **mixed** pairs use the
@@ -147,7 +153,7 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   winner product `P(c)` (two `cdSigma_cocycle` rewrites), so `{L_l,L_u}=0 ⟺ ∀c P(c)=−1 ⟺ ¬offSeam`
   reuses the converse `P`-analysis wholesale. Generalizes the `anti0==!offSeam` member of `coincidence_16/32` to all n.
 - **The full coincidence — `seam_coincidence`:** `isZD = offSeam ∧ hasXorAnnih = offSeam ∧
-  anti0 = ¬offSeam`, one theorem, ∀ `bits≥4` on loHi, axioms `[propext, Quot.sound]` + the single k=3 base.
+  anti0 = ¬offSeam`, one theorem, ∀ `bits≥4` on loHi, axioms `[propext, Quot.sound]` — anchor-free.
 - **Converse anchors — decided:** `converse_16` (brute), `converse_sharp_16/32/64` (sharp σ-form),
   `xorAnnih_eq_isZD_16`, `coincidence_16/32` (**now fully superseded ∀n** — all three members proved:
   `anti0==!offSeam` and `anti0==!isZD` by the theorems above, and the `anti0==llsqNegI` member —
@@ -156,9 +162,11 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
 - **Operator identity `anti0 ⟺ llsqNegI` — proved ∀n** (`anti0_eq_llsqNegI`, and `anti0_eq_llsqNegI_all`
   over `loHi`). The two operator conditions `{L_l,L_u}=0` and `(L_lL_u)²=−I` coincide for **all** `l,u≠0`
   (not just loHi). Key identity `llsq_QP`: the `(L_lL_u)²=−I` four-sign product `R(c)` equals the same
-  `P(c)`, so both reduce to `∀c P(c)=−1`. Notably this member carries axioms `[propext, Quot.sound]`
-  with **no `native_decide` anchor at all** — it rests on the cocycle identity alone, not the octonion
-  base — the last member of `coincidence_16/32` to close, and the only one proved anchor-free.
+  `P(c)`, so both reduce to `∀c P(c)=−1`. This was the last member of `coincidence_16/32` to close;
+  it rests on the cocycle identity alone and was the first link proved without routing through the
+  octonion base at all. (Since the octonion base is now itself structural — see the converse engine
+  above — the *whole* ∀n chain is anchor-free `[propext, Quot.sound]`; anchor-free is the norm here,
+  not this member's distinction.)
 - **Primary-source regression — decided:** `moreno_e1_e10` — Moreno's own example, `e₁+e₁₀`
   annihilated by `e₁₅−e₄`, discharged via `annih` (`l=1,u=10,a=15,b=4,s=−1`; note `4 = 15⊕11`,
   i.e. `b=a⊕d` — the XOR link appears literally in the 1998 source).
@@ -193,12 +201,13 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   `ConverseConjecture`), sufficiency `hasXorAnnih ⟹ isZD` (`hasXorAnnih_sound`), necessity
   `isZD ⟹ hasXorAnnih` (`hasXorAnnih_complete`, via `annih_forces`), the forward obstruction
   `¬offSeam ⟹ ¬isZD` (`isZD_eq_offSeam`), and the operator bridge `anti0 ⟺ ¬offSeam` (`seam_eq_anti0`,
-  via `Q(c)=P(c)`). Axioms `[propext, Quot.sound]` throughout, plus the single k=3 octonion
-  `native_decide` base anchor (inherited from the converse's octonion base).
+  via `Q(c)=P(c)`). Axioms `[propext, Quot.sound]` throughout — **fully anchor-free**: the octonion
+  base `Q_base` is proved structurally (`both_low_witness_disagree`/`both_high_witness_disagree`), so
+  no `native_decide` appears anywhere in the ∀n chain.
 - **Decided (fixed n), retained as fast regressions:** `xorAnnih_eq_isZD_16` (necessity n=4, superseded
   ∀n); `coincidence_16/32` (n=4,5,6 — **all three members now superseded ∀n**: `anti0==!offSeam` /
   `anti0==!isZD` via the coincidence theorems, and `anti0==llsqNegI` `{L_l,L_u}=0 ⟺ (L_lL_u)²=−I` via
-  `anti0_eq_llsqNegI`, the latter anchor-free `[propext, Quot.sound]`); Moreno's example.
+  `anti0_eq_llsqNegI`, `[propext, Quot.sound]`); Moreno's example.
 - **Computed:** brute==fast reduction n=4,5,6; the converse frontier n=7..10 (dim ≤1024) — now a
   cross-check of proved theorems, not the evidence base.
 - **Cited (external, ∀n):** ZD-status + explicit 2-term XOR annihilator for these basis pairs
@@ -226,20 +235,25 @@ antisym` proved ∀n (`cocycle_bundle`) on both `sgn` and canonical `cdSigma`; t
 via the reverse reduction `annih_forces`); the forward obstruction `¬offSeam ⟹ ¬isZD`
 (`isZD_eq_offSeam`); the operator bridge `anti0 ⟺ ¬offSeam` (`seam_eq_anti0`, via `Q(c)=P(c)`); and
 the two-operator identity `anti0 ⟺ llsqNegI` (`{L_l,L_u}=0 ⟺ (L_lL_u)²=−I`, `anti0_eq_llsqNegI`, via
-`R(c)=P(c)` — the **only** member proved *anchor-free*, `[propext, Quot.sound]` with no `native_decide`).
-Every "single remaining open theorem" of the earlier drafts is now closed, and `coincidence_16/32` are
-fully superseded ∀n on all three members.
+`R(c)=P(c)`). Every "single remaining open theorem" of the earlier drafts is now closed;
+`coincidence_16/32` are fully superseded ∀n on all three members; and — with the octonion base now
+proved structurally (`Q_base`) — the **entire ∀n chain is anchor-free `[propext, Quot.sound]`**, no
+`native_decide` anywhere in it (the only `native_decide` uses left are the fixed-n regression anchors).
 
 The engine is the counting statement `Q` on the sign cocycle
 (`scripts/research/cd_tower_converse_counting.py`), now a **theorem** (`Q_all`): *every
 distinct-nonzero pair `(l,m)` in `A_k` (`k≥3`) has a non-exceptional disagreeing orbit* (`P=−1`),
 where an orbit is `{a, a⊕d}`, `d=l⊕m`, `P` is constant on orbits, and the two exceptional orbits are
-`{0,d}` and `{l,m}`. Proved by **ordinary induction on the level** (`native_decide` octonion base,
+`{0,d}` and `{l,m}`. Proved by **ordinary induction on the level** (structural octonion base,
 six exhaustive seam cases), then lifted through the doubling recursion `P_(l,u)(a) = −P_(l,u_lo)(a)`.
 
 The proof levers, all now formal:
-- **Base:** octonions `A_3` are a division algebra — *every* orbit disagrees (`oct_all_disagree` /
-  `Q_base_bool`, `native_decide`; the sole native anchor).
+- **Base (`Q_base`, structural — no `native_decide`):** octonions `A_3` close by the *same* six-way
+  seam split as the step, but with the two doubling cases discharged **without an IH** — a both-low pair
+  takes the high witness `a=2²+l` (orbit `{2²+l, 2²+m}`, reduced by `cdSigma_lo_hi`+diag), a both-high
+  pair takes the low witness `a=l_lo` (orbit `{l_lo,m_lo}`, reduced by `fVal_high_stable`+diag), both
+  bottoming out on the core identity `cdSigma a b · cdSigma b a = −1` (`cdSigma_cross_neg`, one
+  antisymmetry). Lemmas `both_low_witness_disagree` / `both_high_witness_disagree`.
 - **Doubling / stability:** `P_stable_low` (both-low, low block) and `fVal_high_stable` (both-high, low
   block) — the sign is level-invariant on the low block, so these pairs **inherit** a disagreeing
   witness from the level below.
@@ -257,30 +271,27 @@ remaining. (This supersedes the provisional "genuinely hard case, cf. Zhilina" n
 
 ### The next formal steps
 
-With every internal predicate now equated ∀n, the open frontier is entirely *external* — matching this
-self-contained result to the literature and widening its domain. In rough order of tractability:
+**Done — the octonion base is now structural** (was step 1 here): `Q_base` is proved by the six-way
+seam split with no `native_decide`, so the *entire* ∀n chain is anchor-free `[propext, Quot.sound]`.
+What remains is matching this self-contained result to the literature and widening its domain. In
+rough order of tractability:
 
-1. **Drop the single `native_decide` octonion base** (`Q_base_bool`). The whole coincidence rests on one
-   `k=3` anchor: that `A_3` is a division algebra, so every orbit disagrees. A structural proof of this
-   base — e.g. from the octonion norm being multiplicative, or a direct `cdSigma`-combinatorial argument
-   over the 8 units — would make `seam_coincidence` axiom-clean `[propext, Quot.sound]` throughout, the
-   status `anti0_eq_llsqNegI` already enjoys. Purely internal; no new mathematics, only formalization.
-2. **Widen past the `loHi` locus.** The coincidence is stated on lower×upper pairs
+1. **Widen past the `loHi` locus.** The coincidence is stated on lower×upper pairs
    (`1 ≤ l < 2^{n−1} ≤ u < 2^n`). Empirically the ZD ⟺ off-seam correspondence holds across the *full*
    distinct-nonzero box (probe to dim 1024); formalizing the both-low / both-high / seam-touching
    remainder as first-class theorems (not just the inherited-witness lemmas they already are internally)
    would upgrade the headline from a locus statement to an all-pairs one.
-3. **Verify the Moreno seam-index bridge (§4).** Moreno/BDI state their annihilator on
+2. **Verify the Moreno seam-index bridge (§4).** Moreno/BDI state their annihilator on
    `{L_{e_l}, L_{e_{u'}}}` with `u' = u − top` in `A_{n−1}`; ours is on `{L_l, L_u}` at the `A_n`
    indices. Formalizing the doubling correspondence between the two operator pairs would turn our
    "unchecked matching caveat" into a proved identity — and let the Moreno/BDI ∀n result be *cited as a
    consequence* of `seam_coincidence` rather than merely *paralleled by* it.
-4. **Reach the Zhilina closed form (§4).** Whether the off-seam⟺criterion identity in its published,
+3. **Reach the Zhilina closed form (§4).** Whether the off-seam⟺criterion identity in its published,
    framing (doubly-alternative ZDs / hexagons) coincides with ours remains unconfirmed — the sources are
    paywalled. Access + a definitional bridge would settle the literature-priority question the honest
    ledger currently leaves open.
 
-Items 1–2 are internal formalization (bounded, no discovery risk); 3–4 depend on external sources.
+Item 1 is internal formalization (bounded, no discovery risk); 2–3 depend on external sources.
 
 ## References
 

--- a/formal/lean4/SounioCDConverse.lean
+++ b/formal/lean4/SounioCDConverse.lean
@@ -582,17 +582,18 @@ theorem converse_recursion' (n l uL a : Nat)
       `S := Σ_a P(a) = 4·#agree − 2^bits` (each orbit counted twice) reduces it to a lower bound on
       the number of AGREEING orbits; empirically `#agree` is large (winner sets of size `8·(2^k−1)`),
       but a dimension-independent lower bound `#agree ≥ 2` (one nontrivial) is not yet formalized.
-      A clean base case `A_3` (octonions, `n = 1`) is finite (`converse_16`-style native_decide),
-      so an induction on `n` closes the whole tower ONCE (2) has a dimension-free witness.
+      A clean base case `A_3` (octonions, `n = 1`) is now proved structurally (`Q_base`, no
+      `native_decide`), so an induction on `n` closes the whole tower ONCE (2) has a dimension-free witness.
 
   In short: `converse_recursion` reduces the tower-wide converse to {the sgn=cdSigma bridge} ∧ {a
   dimension-free downstairs-loser witness}.  The sign-flip half is now fully mechanized here.
 -/
 
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
--- BOUNDED LEVERS OF THE CONVERSE COUNTING ARGUMENT (all ∀n except the octonion base case)
--- Three self-contained lemmas that formalize the concretely-provable steps of the converse counting
--- argument (`scripts/research/cd_tower_converse_counting.py`).  Mathlib-free, no `sorry`.
+-- BOUNDED LEVERS OF THE CONVERSE COUNTING ARGUMENT (ALL ∀n — the octonion base is now structural too)
+-- Self-contained lemmas that formalize the concretely-provable steps of the converse counting
+-- argument (`scripts/research/cd_tower_converse_counting.py`).  Mathlib-free, no `sorry`,
+-- no `native_decide` anywhere in the ∀n chain (the octonion base `Q_base` is proved structurally).
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
 
 /-- **CD diagonal sign** `cdSigma x x k = -1` for every nonzero basis unit (`1 ≤ x < 2^k`).  This is
@@ -607,15 +608,6 @@ theorem cdSigma_diag (k x : Nat) (h1 : 1 ≤ x) (hx : x < 2 ^ k) : cdSigma x x k
   rw [← cdSigma_defeq k x x, ← SounioCDCocycle.sgn_eq_cdSigma k x x hk hx hx]
   exact SounioCDCocycle.diag _ (SounioCDCocycle.isZ_bitsOf_false k x hx hx0)
 
-/-- **Lemma 1 (octonion base case).**  The octonions `A_3` are a division algebra: for every mixed
-    (distinct, nonzero) index pair `(l, m)` and every `a`, the four-sign winner product is `-1` — i.e.
-    *every* orbit disagrees, so there is no zero divisor.  A fixed finite claim, discharged by
-    `native_decide` (a legitimate base-case anchor; the general lemmas below avoid it). -/
-theorem oct_all_disagree :
-    (List.range 8).all (fun l => (List.range 8).all (fun m =>
-      (List.range 8).all (fun a =>
-        (! ((! (l == 0)) && (! (m == 0)) && (l != m)))
-          || (fVal l m a 3 * fVal l m (a ^^^ (l ^^^ m)) 3 == -1)))) = true := by native_decide
 
 /-- **Lemma 2 (the main σ-identity, ∀n): explicit disagreeing witness for a mixed pair.**  For a mixed
     pair `(l, 2^k + m_lo)` with `1 ≤ l, m_lo < 2^k` and `m_lo ≠ l`, the orbit anchored at `a = m_lo`
@@ -790,6 +782,59 @@ theorem edge_l_eq_H (k m_lo a : Nat)
     rcases cdSigma_pm (j+1) m_lo (m_lo ^^^ a) with hB|hB <;>
       rw [hA, hB] at hcoc ⊢ <;> first | decide | exact absurd hcoc (by decide)
 
+/-- **Core disagreement identity.**  The transposed product of a distinct nonzero basis pair is `-1`:
+    `cdSigma a b · cdSigma b a = -1`.  One antisymmetry (`cdSigma b a = -cdSigma a b`) then `(±1)²=1`.
+    No `native_decide`. -/
+theorem cdSigma_cross_neg (k a b : Nat)
+    (ha1 : 1 ≤ a) (ha : a < 2 ^ k) (hb1 : 1 ≤ b) (hb : b < 2 ^ k) (hab : a ≠ b) :
+    cdSigma a b k * cdSigma b a k = -1 := by
+  rw [cdAntisym_all k b a hb1 hb ha1 ha (fun h => hab h.symm)]
+  rcases cdSigma_pm k a b with h | h <;> rw [h] <;> decide
+
+/-- **Both-low witness (base-case, no IH).**  For a both-low mixed pair `(l,m)` (`1≤l,m<2^(n+1)`,
+    `l≠m`) the high orbit anchored at `a = 2^(n+1)+l` — i.e. `{2^(n+1)+l, 2^(n+1)+m}` — DISAGREES:
+    the four-sign product is `-1`.  Each factor collapses through `cdSigma_lo_hi` (nonzero low part)
+    plus `cdSigma_diag`, and the residue is the core identity `cdSigma_cross_neg`.  No `native_decide`,
+    no induction hypothesis. -/
+theorem both_low_witness_disagree (n l m : Nat)
+    (hl1 : 1 ≤ l) (hl : l < 2 ^ (n+1)) (hm1 : 1 ≤ m) (hm : m < 2 ^ (n+1)) (hlm : l ≠ m) :
+    fVal l m (2 ^ (n+1) + l) (n+2)
+      * fVal l m ((2 ^ (n+1) + l) ^^^ (l ^^^ m)) (n+2) = -1 := by
+  have hidx : (2 ^ (n+1) + l) ^^^ (l ^^^ m) = 2 ^ (n+1) + m := by
+    rw [← two_pow_xor_eq_add (n+1) l hl, ← two_pow_xor_eq_add (n+1) m hm,
+        Nat.xor_assoc, ← Nat.xor_assoc l l m, Nat.xor_self, Nat.zero_xor]
+  rw [hidx]
+  unfold fVal
+  rw [cdSigma_lo_hi n l l hl hl1 hl, cdSigma_lo_hi n l m hl hm1 hm,
+      cdSigma_lo_hi n m l hm hl1 hl, cdSigma_lo_hi n m m hm hm1 hm,
+      cdSigma_diag (n+1) l hl1 hl, cdSigma_diag (n+1) m hm1 hm]
+  have hcn := cdSigma_cross_neg (n+1) l m hl1 hl hm1 hm hlm
+  rcases cdSigma_pm (n+1) l m with h | h <;> rcases cdSigma_pm (n+1) m l with h2 | h2 <;>
+    rw [h, h2] at hcn ⊢ <;> first | decide | exact absurd hcn (by decide)
+
+/-- **Both-high witness (base-case, no IH).**  For a both-high mixed pair
+    `(2^(n+1)+llo, 2^(n+1)+mlo)` (`llo≠mlo`, both `1≤·<2^(n+1)`) the low orbit `{llo, mlo}` DISAGREES.
+    `fVal_high_stable` collapses both factors to level `n+1`, leaving the `{llo,mlo}` orbit which is
+    `-1` by `cdSigma_diag` + `cdSigma_cross_neg`.  No `native_decide`, no induction hypothesis. -/
+theorem both_high_witness_disagree (n llo mlo : Nat)
+    (hl1 : 1 ≤ llo) (hl : llo < 2 ^ (n+1)) (hm1 : 1 ≤ mlo) (hm : mlo < 2 ^ (n+1)) (hlm : llo ≠ mlo) :
+    fVal (2 ^ (n+1) + llo) (2 ^ (n+1) + mlo) llo (n+2)
+      * fVal (2 ^ (n+1) + llo) (2 ^ (n+1) + mlo)
+          (llo ^^^ ((2 ^ (n+1) + llo) ^^^ (2 ^ (n+1) + mlo))) (n+2) = -1 := by
+  have hd : (2 ^ (n+1) + llo) ^^^ (2 ^ (n+1) + mlo) = llo ^^^ mlo := by
+    rw [← two_pow_xor_eq_add (n+1) llo hl, ← two_pow_xor_eq_add (n+1) mlo hm,
+        Nat.xor_assoc, xor_left_comm llo (2 ^ (n+1)) mlo, ← Nat.xor_assoc,
+        Nat.xor_self, Nat.zero_xor]
+  have hidx : llo ^^^ ((2 ^ (n+1) + llo) ^^^ (2 ^ (n+1) + mlo)) = mlo := by
+    rw [hd, ← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+  rw [hidx, fVal_high_stable (n+1) llo mlo llo hl hm hl,
+      fVal_high_stable (n+1) llo mlo mlo hl hm hm]
+  unfold fVal
+  rw [cdSigma_diag (n+1) llo hl1 hl, cdSigma_diag (n+1) mlo hm1 hm]
+  have hcn := cdSigma_cross_neg (n+1) mlo llo hm1 hm hl1 hl (fun h => hlm h.symm)
+  rcases cdSigma_pm (n+1) mlo llo with h | h <;> rcases cdSigma_pm (n+1) llo mlo with h2 | h2 <;>
+    rw [h, h2] at hcn ⊢ <;> first | decide | exact absurd hcn (by decide)
+
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
 -- Q: a non-exceptional disagreeing witness exists for EVERY mixed pair (ORDINARY induction on level).
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
@@ -817,25 +862,105 @@ theorem exists_witness_symm (k l m : Nat)
   · rw [Nat.xor_comm m l]; exact h3
   · rw [Nat.xor_comm m l, fVal_comm m l, fVal_comm m l]; exact h6
 
-/-- **Base `Qstmt 3` (octonions)** as a finite decidable Bool over `range 8` — the ONE legitimate
-    `native_decide` anchor. -/
-theorem Q_base_bool : ∀ l, l < 2 ^ 3 → ∀ m, m < 2 ^ 3 → 1 ≤ l → 1 ≤ m → l ≠ m →
-    (List.range (2 ^ 3)).any (fun a =>
-      (a != 0) && (a != l ^^^ m) && (a != l) && (a != m)
-        && (fVal l m a 3 * fVal l m (a ^^^ (l ^^^ m)) 3 == -1)) = true := by
-  native_decide
-
-/-- Base case `Qstmt 3`, extracting the `∃`-witness from the decidable Bool anchor. -/
+/-- **Base case `Qstmt 3` (octonions) — structural, NO `native_decide`.**  Every mixed pair in `A_3`
+    has a non-exceptional disagreeing orbit, by the SAME six-way seam split as the inductive step but
+    with the two doubling cases discharged *without* an IH: both-low takes the high witness
+    `a = 2^2+l` (`both_low_witness_disagree`), both-high takes the low witness `a = llo`
+    (`both_high_witness_disagree`), and the edges/mixed-non-edge reuse L2/L3/L4/`mixed_witness_disagree`
+    at `W = 2`.  This removes the last `native_decide` from the ∀n coincidence chain — every downstream
+    theorem is now `[propext, Quot.sound]`. -/
 theorem Q_base : Qstmt 3 := by
+  have h4 : (2 : Nat) ^ 2 = 4 := by decide
+  have h8 : (2 : Nat) ^ 3 = 8 := by decide
+  have core : ∀ l m, 1 ≤ l → l < m → m < 2 ^ 3 →
+      ∃ a, a < 2 ^ 3 ∧ a ≠ 0 ∧ a ≠ l ^^^ m ∧ a ≠ l ∧ a ≠ m ∧
+           fVal l m a 3 * fVal l m (a ^^^ (l ^^^ m)) 3 = -1 := by
+    intro l m hl1 hlm hm8
+    have hm1 : 1 ≤ m := by omega
+    by_cases hmlt : m < 2 ^ 2
+    · -- CASE 4: both low — high witness a = 2^2 + l
+      have hl4 : l < 2 ^ 2 := by omega
+      have hdlt : l ^^^ m < 2 ^ 2 := Nat.xor_lt_two_pow hl4 hmlt
+      refine ⟨2 ^ 2 + l, by omega, by omega, by omega, by omega, by omega, ?_⟩
+      exact both_low_witness_disagree 1 l m hl1 hl4 hm1 hmlt (by omega)
+    · by_cases hllt : l < 2 ^ 2
+      · by_cases hmH : m = 2 ^ 2
+        · -- CASE 1: m = 2^2
+          subst hmH
+          obtain ⟨a, ha1, haH, hal⟩ : ∃ a, 1 ≤ a ∧ a < 2 ^ 2 ∧ a ≠ l := by
+            by_cases hle : l = 1
+            · exact ⟨2, by omega, by omega, by omega⟩
+            · exact ⟨1, by omega, by omega, by omega⟩
+          have hlmv : l ^^^ 2 ^ 2 = 2 ^ 2 + l := by
+            rw [Nat.xor_comm l (2 ^ 2), two_pow_xor_eq_add 2 l hllt]
+          refine ⟨a, by omega, by omega, ?_, hal, by omega, ?_⟩
+          · rw [hlmv]; omega
+          · exact edge_m_eq_H 2 l a hl1 hllt ha1 haH hal
+        · -- m > 2^2
+          obtain ⟨mlo, rfl⟩ : ∃ mlo, m = 2 ^ 2 + mlo := ⟨m - 2 ^ 2, by omega⟩
+          have hmloH : mlo < 2 ^ 2 := by omega
+          have hmlo1 : 1 ≤ mlo := by omega
+          by_cases hmlol : mlo = l
+          · -- CASE 2: m = 2^2 + l
+            obtain ⟨a, ha1, haH, hal⟩ : ∃ a, 1 ≤ a ∧ a < 2 ^ 2 ∧ a ≠ l := by
+              by_cases hle : l = 1
+              · exact ⟨2, by omega, by omega, by omega⟩
+              · exact ⟨1, by omega, by omega, by omega⟩
+            have hlmv : l ^^^ (2 ^ 2 + mlo) = 2 ^ 2 := by
+              rw [hmlol, ← two_pow_xor_eq_add 2 l hllt, xor_left_comm, Nat.xor_self, Nat.xor_zero]
+            refine ⟨a, by omega, by omega, ?_, hal, by omega, ?_⟩
+            · rw [hlmv]; omega
+            · rw [hmlol]; exact edge_m_eq_H_plus_l 2 l a hl1 hllt ha1 haH
+          · -- CASE 5: mixed non-edge
+            have hlmv : l ^^^ (2 ^ 2 + mlo) = 2 ^ 2 + (l ^^^ mlo) := by
+              rw [← two_pow_xor_eq_add 2 mlo hmloH, xor_left_comm,
+                  two_pow_xor_eq_add 2 (l ^^^ mlo) (Nat.xor_lt_two_pow hllt hmloH)]
+            refine ⟨mlo, by omega, by omega, ?_, hmlol, by omega, ?_⟩
+            · rw [hlmv]; omega
+            · exact mixed_witness_disagree 2 l mlo hl1 hllt hmlo1 hmloH hmlol
+      · -- l ≥ 2^2, both high (l < m ⟹ m ≥ 2^2)
+        by_cases hlH : l = 2 ^ 2
+        · -- CASE 3: l = 2^2
+          subst hlH
+          obtain ⟨mlo, rfl⟩ : ∃ mlo, m = 2 ^ 2 + mlo := ⟨m - 2 ^ 2, by omega⟩
+          have hmloH : mlo < 2 ^ 2 := by omega
+          have hmlo1 : 1 ≤ mlo := by omega
+          obtain ⟨a, ha1, haH, ham⟩ : ∃ a, 1 ≤ a ∧ a < 2 ^ 2 ∧ a ≠ mlo := by
+            by_cases hle : mlo = 1
+            · exact ⟨2, by omega, by omega, by omega⟩
+            · exact ⟨1, by omega, by omega, by omega⟩
+          have hlmv : (2 ^ 2) ^^^ (2 ^ 2 + mlo) = mlo := by
+            rw [← two_pow_xor_eq_add 2 mlo hmloH, ← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+          refine ⟨a, by omega, by omega, ?_, ?_, by omega, ?_⟩
+          · rw [hlmv]; exact ham
+          · omega
+          · exact edge_l_eq_H 2 mlo a hmlo1 hmloH ha1 haH ham
+        · -- CASE 6: both high, l ≠ 2^2 — low witness a = llo
+          obtain ⟨llo, rfl⟩ : ∃ llo, l = 2 ^ 2 + llo := ⟨l - 2 ^ 2, by omega⟩
+          obtain ⟨mlo, rfl⟩ : ∃ mlo, m = 2 ^ 2 + mlo := ⟨m - 2 ^ 2, by omega⟩
+          have hlloH : llo < 2 ^ 2 := by omega
+          have hmloH : mlo < 2 ^ 2 := by omega
+          have hllo1 : 1 ≤ llo := by omega
+          have hmlo1 : 1 ≤ mlo := by omega
+          have hlomlo : llo ≠ mlo := by omega
+          have hd : (2 ^ 2 + llo) ^^^ (2 ^ 2 + mlo) = llo ^^^ mlo := by
+            rw [← two_pow_xor_eq_add 2 llo hlloH, ← two_pow_xor_eq_add 2 mlo hmloH,
+                Nat.xor_assoc, xor_left_comm llo (2 ^ 2) mlo, ← Nat.xor_assoc,
+                Nat.xor_self, Nat.zero_xor]
+          have hguard : llo ≠ (2 ^ 2 + llo) ^^^ (2 ^ 2 + mlo) := by
+            rw [hd]; intro h
+            have : mlo = 0 := by
+              calc mlo = llo ^^^ (llo ^^^ mlo) := by
+                        rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+                _ = llo ^^^ llo := by rw [← h]
+                _ = 0 := Nat.xor_self llo
+            omega
+          refine ⟨llo, by omega, by omega, hguard, by omega, by omega, ?_⟩
+          exact both_high_witness_disagree 1 llo mlo hllo1 hlloH hmlo1 hmloH hlomlo
   intro l m hl1 hl hm1 hm hlm
-  have hb := Q_base_bool l hl m hm hl1 hm1 hlm
-  rw [List.any_eq_true] at hb
-  obtain ⟨a, hmem, hpred⟩ := hb
-  rw [List.mem_range] at hmem
-  rw [Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true, Bool.and_eq_true,
-      bne_iff_ne, bne_iff_ne, bne_iff_ne, bne_iff_ne, beq_iff_eq] at hpred
-  obtain ⟨⟨⟨⟨g0, gd⟩, gl⟩, gm⟩, gP⟩ := hpred
-  exact ⟨a, hmem, g0, gd, gl, gm, gP⟩
+  rcases Nat.lt_or_ge l m with hlt | hge
+  · exact core l m hl1 hlt hm
+  · exact exists_witness_symm 3 m l (core m l hm1 (by omega) hl)
 
 /-- **The inductive step `Qstmt W → Qstmt (W+1)`** (ORDINARY induction, `W ≥ 3`).  Six-case split on
     the seam position of the pair; edges by L2/L3/L4, both-low by `P_stable_low`+IH, mixed non-edge by
@@ -1013,8 +1138,8 @@ theorem loHi_mem (bits : Nat) (hb : 1 ≤ bits) (p : Nat × Nat) (hp : p ∈ loH
 /-- **THE TOWER-WIDE CONVERSE, DISCHARGED** — `ConverseConjecture` is now a theorem: for every level
     `bits ≥ 4`, every off-seam lower×upper pair is a zero divisor.  Composition of `converse_holds`
     (off-seam ⟹ `hasXorAnnih`, ∀n, proved by the octonion-base induction) with `hasXorAnnih_sound`
-    (`hasXorAnnih` ⟹ `isZD`, ∀n).  Kernel axioms `[propext, Quot.sound]` + the single k=3 base
-    `native_decide` anchor. -/
+    (`hasXorAnnih` ⟹ `isZD`, ∀n).  Kernel axioms `[propext, Quot.sound]` — fully anchor-free (the
+    octonion base `Q_base` is now structural, no `native_decide`). -/
 theorem converse_conjecture_proved : ConverseConjecture := by
   intro bits hb
   unfold converseHolds
@@ -1253,7 +1378,7 @@ theorem hasXorAnnih_complete (bits l u : Nat) (hb : 4 ≤ bits)
 
 /-- **`hasXorAnnih == isZD` on the loHi locus, ∀ bits ≥ 4** — the ∀n generalization of
     `xorAnnih_eq_isZD_16`.  Soundness (`⟹`) by `hasXorAnnih_sound`, completeness (`⟸`) by
-    `hasXorAnnih_complete`.  Kernel axioms `[propext, Quot.sound]` + the single inherited k=3 anchor. -/
+    `hasXorAnnih_complete`.  Kernel axioms `[propext, Quot.sound]` — anchor-free. -/
 theorem xorAnnih_eq_isZD_all (bits : Nat) (hb : 4 ≤ bits) :
     (loHi bits).all (fun p => hasXorAnnih bits p.1 p.2 == isZD bits p.1 p.2) = true := by
   rw [List.all_eq_true]
@@ -1478,7 +1603,7 @@ theorem on_seam_P_neg (bits l u : Nat) (hb : 4 ≤ bits)
     operator/anti-commutator member: `{L_l,L_u}=0 ⟺ NOT off-seam`.  Off-seam ⟹ the converse winner
     exists (`converse_holds`), so some `P(a)=+1` breaks the anti0 test (`anti0=false`); on-seam ⟹
     `∀c P(c)=-1` (`on_seam_P_neg`), so anti0 holds.  Via the `Q=P` bridge (`anti0_iff`).  Kernel axioms
-    `[propext, Quot.sound]` + the single inherited k=3 base anchor. -/
+    `[propext, Quot.sound]` — anchor-free (the octonion base is structural). -/
 theorem seam_eq_anti0 (bits l u : Nat) (hb : 4 ≤ bits)
     (hl1 : 1 ≤ l) (hl : l < 2 ^ (bits-1)) (hu1 : 2 ^ (bits-1) ≤ u) (hu : u < 2 ^ bits) :
     anti0 bits l u = ! offSeam bits l u := by
@@ -1524,7 +1649,8 @@ theorem anti0_eq_offSeam_all (bits : Nat) (hb : 4 ≤ bits) :
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
 -- THE FULL SEAM COINCIDENCE ON loHi, ∀ bits≥4 — every link now a proved ∀n theorem.
 --   offSeam  ⟺  isZD  ⟺  hasXorAnnih  ⟺  ¬anti0
--- (forward obstruction `¬offSeam ⟹ ¬isZD` included; no `native_decide` beyond the inherited k=3 base).
+-- (forward obstruction `¬offSeam ⟹ ¬isZD` included; NO `native_decide` in the ∀n chain — fully
+--  anchor-free; the 7 fixed-n regression anchors near the top of the file retain `native_decide`).
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
 
 /-- **On-seam loHi pairs have NO XOR-winner** (`hasXorAnnih = false`): every orbit loses (`on_seam_P_neg`),
@@ -1548,7 +1674,8 @@ theorem hasXorAnnih_false_of_onSeam (bits l u : Nat) (hb : 4 ≤ bits)
 /-- **Forward obstruction + converse, unified**: on the loHi locus (`∀ bits≥4`) a lower×upper pair is a
     2-term zero divisor **iff** it is off-seam.  `isZD = offSeam`.  Off-seam ⟹ `isZD` is the converse
     (`converse_holds`+`hasXorAnnih_sound`); on-seam ⟹ `¬isZD` is the forward obstruction
-    (`hasXorAnnih_false_of_onSeam`+`hasXorAnnih_complete`). Kernel-clean (inherited k=3 base only). -/
+    (`hasXorAnnih_false_of_onSeam`+`hasXorAnnih_complete`). Kernel-clean `[propext, Quot.sound]`,
+    anchor-free. -/
 theorem isZD_eq_offSeam (bits l u : Nat) (hb : 4 ≤ bits)
     (hl1 : 1 ≤ l) (hl : l < 2 ^ (bits-1)) (hu1 : 2 ^ (bits-1) ≤ u) (hu : u < 2 ^ bits) :
     isZD bits l u = offSeam bits l u := by


### PR DESCRIPTION
## Drop the `native_decide` octonion base — the ∀n chain is now fully anchor-free

Roadmap step 1 (from #732's §6). The seam coincidence had exactly **one** `native_decide` anchor left
in its ∀n proof: `Q_base_bool`, the octonion base of the converse induction (`A_3` is a division
algebra ⟹ every mixed pair has a disagreeing orbit). This PR replaces it with a **structural** proof
of `Q_base : Qstmt 3`, so every downstream theorem is `[propext, Quot.sound]` with **no `native_decide`
anywhere in the chain**.

### How the base closes without `native_decide` (and without an IH)

`Q_base` uses the *same* six-way seam split as the inductive step `Qstep`, but the two doubling cases
— which `Qstep` discharges via the induction hypothesis — close here with explicit witnesses:

| Case | Witness `a` | Orbit | Reduces via |
|---|---|---|---|
| both-low `(l,m)`, `l,m<4` | `2²+l` | `{2²+l, 2²+m}` (high) | `cdSigma_lo_hi` (nonzero low part) + `cdSigma_diag` |
| both-high `(4+l_lo, 4+m_lo)` | `l_lo` | `{l_lo, m_lo}` (low) | `fVal_high_stable` + `cdSigma_diag` |
| edges (`m=4`, `m=4+l`, `l=4`), mixed non-edge | existing | — | `edge_m_eq_H` / `edge_m_eq_H_plus_l` / `edge_l_eq_H` / `mixed_witness_disagree` at `W=2` |

Both doubling witnesses bottom out on one core identity, `cdSigma a b · cdSigma b a = −1`
(`cdSigma_cross_neg`, a single antisymmetry then `(±1)²=1`). Each chosen witness is verified
non-exceptional (`a ∉ {0, l⊕m, l, m}`): the high witnesses exceed `4`, and `l_lo` differs from `0`,
`l_lo⊕m_lo`, and both high indices.

New lemmas (all `[propext, Quot.sound]`): `cdSigma_cross_neg`, `both_low_witness_disagree`,
`both_high_witness_disagree`. Dead code `oct_all_disagree` removed.

### Acceptance test — `#print axioms` (the real deliverable)

`Q_base` is **statement-identical** to the old version (only the proof term changed), so there is zero
statement-drift risk and a `sorry` would surface as `sorryAx`. Verified clean:

```
Q_base                     : [propext, Quot.sound]
Q_all                      : [propext, Quot.sound]
converse_conjecture_proved : [propext, Quot.sound]
seam_coincidence           : [propext, Quot.sound]
hasXorAnnih_complete / isZD_eq_offSeam / seam_eq_anti0 / xorAnnih_eq_isZD_all
anti0_eq_offSeam_all / anti0_eq_llsqNegI_all : all [propext, Quot.sound]
```

The 7 remaining `native_decide` uses in the file are the **fixed-n regression anchors**
(`converse_16`, `converse_sharp_16/32/64`, `converse_sharp_agrees_16`, `moreno_e1_e10`) — outside the
∀n chain, retained as fast regressions.

### Verification & provenance
- Math-review via `bin/llm-offload` (grok-4.1): **3/3 checks pass** — witness existence is sufficient,
  both witnesses are non-exceptional, the six cases + `lt`/`ge` symmetry cover every mixed pair in
  `{1..7}`. `zai` leg unwired (SKIP); Lean kernel `#print axioms` = second lens. Logged in
  `.claude/llm_offload_log.md`.
- Advisor: confirmed the statement-identical swap (zero drift) and caught a now-stale honesty claim —
  `anti0_eq_llsqNegI` was documented as "the only member proved anchor-free"; that's false now that the
  whole chain is anchor-free, so the manuscript + memory drop the uniqueness framing (see below).

### Docs (body-only, no front-matter / no registry sync)
`docs/papers/cd-tower-seam-obstruction.md`: flips every "single k=3 base anchor" claim to
anchor-free, rewrites the §6 base lever to the structural split, moves step 1 into "Done", and removes
the false "only member anchor-free" uniqueness framing. Front-matter untouched.

### Verify
```
export PATH="$HOME/.elan/bin:$PATH"; ulimit -v unlimited
(cd formal/lean4 && lake build SounioCDConverse SounioCDTowerSeam SounioCDCocycle)   # green, no sorry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
