### PR TITLE
feat(examples): octonion mass-delta / J3(O) / triality physics examples + connectomics repros

### DIFF
--- a/examples/physics/j3o_mass_spectrum.sio
+++ b/examples/physics/j3o_mass_spectrum.sio
@@ -1,0 +1,67 @@
+// J3(O) diagonal vacuum -> mass spectrum + Koide bridge, native Sounio.
+//
+// The Jordan vacuum diag(a,b,c) carries the arithmetic spectrum (q-δ, q, q+δ) with the
+// algebra-fixed δ²=3/8. This verifies the §4.2/§4.9 Koide bridge natively:
+//   Koide Q = (Σ λ²)/(Σ λ)²  = 2/3  exactly at center q = 1/2 with δ²=3/8.
+// (The edge-ratio ladders use charge-centered q = 1 and 2/3; both shown.)
+//
+// Scalar δ-analysis + cross-sector held-out: examples/physics/octonion_mass_delta.sio
+// Run: SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/physics/j3o_mass_spectrum.sio
+//
+// OPEN STEP (NOT implemented — research-level, not derivable by re-encoding):
+//   the E6 Dynkin-Z2 realisation of the down->lepton ladder factor (δ±1/3) and the full
+//   Jordan-eigenvalue -> physical-mass assignment. Foundation (octonions -> J3(O) ->
+//   triality -> 3 generations) is verified (jordan_j3o.sio, triality_check.sio,
+//   scripts/triality_principle.py); this last realisation link is left open and honest.
+
+fn sqrt_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var g = x; var i = 0
+    while i < 40 { g = 0.5 * (g + x / g); i = i + 1 }
+    g
+}
+
+fn fp_string(v: f64) -> string with Mut, Div, Panic {
+    var x = v; var neg = false
+    if x < 0.0 { neg = true; x = 0.0 - x }
+    let n = (x * 1000000.0 + 0.5) as i64
+    var whole = n / 1000000; let frac = n % 1000000
+    var buf: [i8; 64] = [0; 64]
+    var wrev: [i8; 32] = [0; 32]; var wlen: i64 = 0
+    if whole == 0 { wrev[0] = 48 as i8; wlen = 1 }
+    while whole > 0 && wlen < 31 { wrev[wlen as usize] = (48 + whole % 10) as i8; wlen = wlen + 1; whole = whole / 10 }
+    var pos: i64 = 0
+    if neg { buf[pos as usize] = 45 as i8; pos = pos + 1 }
+    var i = wlen - 1
+    while i >= 0 { buf[pos as usize] = wrev[i as usize]; pos = pos + 1; if i == 0 { break }; i = i - 1 }
+    buf[pos as usize] = 46 as i8; pos = pos + 1
+    var div = 100000
+    while div >= 1 { buf[pos as usize] = (48 + (frac / div) % 10) as i8; pos = pos + 1; div = div / 10 }
+    str_from_bytes(buf, pos)
+}
+
+fn koide_q(center: f64, delta: f64) -> f64 with Mut, Div, Panic {
+    let l0 = center - delta
+    let l1 = center
+    let l2 = center + delta
+    let sumsq = l0*l0 + l1*l1 + l2*l2
+    let sum = l0 + l1 + l2
+    sumsq / (sum * sum)
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    println("=== J3(O) diagonal vacuum -> Koide bridge (native Sounio) ===")
+    let delta = sqrt_q(3.0 / 8.0)
+    println("delta = sqrt(3/8) = " ++ fp_string(delta))
+
+    // diagonal Koide center q = 1/2  -> Q = 2/3 exactly
+    let q_half = 0.5
+    println("center q=1/2 spectrum: (" ++ fp_string(q_half - delta) ++ ", " ++ fp_string(q_half) ++ ", " ++ fp_string(q_half + delta) ++ ")")
+    println("  Koide Q = " ++ fp_string(koide_q(q_half, delta)) ++ "  (expect 0.666667)")
+
+    // charge-centered ladders
+    println("center q=1   (lepton/down charge) Koide Q = " ++ fp_string(koide_q(1.0, delta)))
+    println("center q=2/3 (up charge)          Koide Q = " ++ fp_string(koide_q(0.6666666667, delta)))
+    println("DONE  (E6 Dynkin-Z2 mass realisation = OPEN; see header)")
+    0
+}

--- a/examples/physics/jordan_j3o.sio
+++ b/examples/physics/jordan_j3o.sio
@@ -1,0 +1,116 @@
+// J3(O) — exceptional Jordan (Albert) algebra: Freudenthal cubic norm, native Sounio.
+//
+// Verifies, on the Fano-checked `algebra::octonion` product (with the NonAssoc effect
+// tracked by the compiler), the foundation for the E6/triality program:
+//   det(a,b,c; x,y,z) = a*b*c - a*N(x) - b*N(y) - c*N(z) + 2*Re((z*x)*y)
+//   [1] well-defined: Re((z*x)*y) - Re(z*(x*y)) = 0   (the real part associates)
+//   [2] cyclic slot (generation) symmetry: det(a,b,c;x,y,z) - det(b,c,a;y,z,x) = 0
+//   [3] G2 automorphism phi (negate components e4..e7) preserves det
+//
+// Python/sympy cross-check: experiments/non_assoc_connectomics/scripts/j3o_foundation.py
+// Run: SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/physics/jordan_j3o.sio
+
+use algebra::octonion::*;
+
+fn sqrt_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x != x { return 0.0 }
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    var i = 0
+    while i < 40 { g = 0.5 * (g + x / g); i = i + 1 }
+    g
+}
+
+fn fp_string(v: f64) -> string with Mut, Div, Panic {
+    var x = v
+    var neg = false
+    if x < 0.0 { neg = true; x = 0.0 - x }
+    let n = (x * 1000000.0 + 0.5) as i64
+    var whole = n / 1000000
+    let frac = n % 1000000
+    var buf: [i8; 64] = [0; 64]
+    var wrev: [i8; 32] = [0; 32]
+    var wlen: i64 = 0
+    if whole == 0 { wrev[0] = 48 as i8; wlen = 1 }
+    while whole > 0 && wlen < 31 {
+        wrev[wlen as usize] = (48 + whole % 10) as i8
+        wlen = wlen + 1
+        whole = whole / 10
+    }
+    var pos: i64 = 0
+    if neg { buf[pos as usize] = 45 as i8; pos = pos + 1 }
+    var i = wlen - 1
+    while i >= 0 {
+        buf[pos as usize] = wrev[i as usize]; pos = pos + 1
+        if i == 0 { break }
+        i = i - 1
+    }
+    buf[pos as usize] = 46 as i8; pos = pos + 1
+    var div = 100000
+    while div >= 1 {
+        buf[pos as usize] = (48 + (frac / div) % 10) as i8; pos = pos + 1
+        div = div / 10
+    }
+    str_from_bytes(buf, pos)
+}
+
+fn re_mul2(p: &[f64; 8], q: &[f64; 8]) -> f64 with Mut, Div, Panic, NonAssoc {
+    // Re(p*q) = component 0 of p*q
+    var out: [f64; 8] = [0.0; 8]
+    oct_mul(p, q, &!out)
+    out[0]
+}
+
+// Re((z*x)*y)
+fn tri_term(x: &[f64; 8], y: &[f64; 8], z: &[f64; 8]) -> f64 with Mut, Div, Panic, NonAssoc {
+    var zx: [f64; 8] = [0.0; 8]
+    oct_mul(z, x, &!zx)
+    re_mul2(&zx, y)
+}
+
+fn det_j3o(a: f64, b: f64, c: f64, x: &[f64; 8], y: &[f64; 8], z: &[f64; 8]) -> f64
+    with Mut, Div, Panic, NonAssoc {
+    a*b*c - a*oct_norm_sq(x) - b*oct_norm_sq(y) - c*oct_norm_sq(z) + 2.0*tri_term(x, y, z)
+}
+
+fn phi(v: &[f64; 8], out: &![f64; 8]) with Mut {
+    // G2 automorphism: negate components 4..7, fix 0..3
+    var i: i64 = 0
+    while i < 8 {
+        if i >= 4 { out[i as usize] = 0.0 - v[i as usize] } else { out[i as usize] = v[i as usize] }
+        i = i + 1
+    }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    println("=== J3(O) Freudenthal cubic norm (native Sounio / algebra::octonion) ===")
+    // sample octonions (non-trivial, mixed components)
+    var x: [f64; 8] = [0.3, 0.5, 0.0, 0.2, 0.1, 0.0, 0.4, 0.0]
+    var y: [f64; 8] = [0.1, 0.0, 0.6, 0.0, 0.2, 0.3, 0.0, 0.1]
+    var z: [f64; 8] = [0.2, 0.1, 0.0, 0.5, 0.0, 0.2, 0.0, 0.4]
+    let a = 1.0
+    let b = 0.6666666667
+    let c = 0.5
+
+    println("det(a,b,c; x,y,z) = " ++ fp_string(det_j3o(a, b, c, &x, &y, &z)))
+
+    // [1] well-defined: Re((zx)y) - Re(z(xy))
+    var xy: [f64; 8] = [0.0; 8]
+    oct_mul(&x, &y, &!xy)
+    let well = tri_term(&x, &y, &z) - re_mul2(&z, &xy)
+    println("[1] well-defined  Re((zx)y)-Re(z(xy)) = " ++ fp_string(well) ++ "  (expect 0)")
+
+    // [2] cyclic slot symmetry: det(a,b,c;x,y,z) - det(b,c,a;y,z,x)
+    let cyc = det_j3o(a, b, c, &x, &y, &z) - det_j3o(b, c, a, &y, &z, &x)
+    println("[2] cyclic slot symmetry diff      = " ++ fp_string(cyc) ++ "  (expect 0)")
+
+    // [3] G2 automorphism preserves det
+    var px: [f64; 8] = [0.0; 8]
+    var py: [f64; 8] = [0.0; 8]
+    var pz: [f64; 8] = [0.0; 8]
+    phi(&x, &!px); phi(&y, &!py); phi(&z, &!pz)
+    let autodiff = det_j3o(a, b, c, &x, &y, &z) - det_j3o(a, b, c, &px, &py, &pz)
+    println("[3] G2 automorphism det diff       = " ++ fp_string(autodiff) ++ "  (expect 0)")
+    println("DONE")
+    0
+}

--- a/examples/physics/octonion_mass_delta.sio
+++ b/examples/physics/octonion_mass_delta.sio
@@ -1,0 +1,263 @@
+// Octonion exceptional-Jordan fermion-mass delta-consistency + cross-sector held-out test.
+// Native Sounio port of the analysis (Python ref: scratchpad/delta_consistency.py,
+// heldout_crosssector.py). The exceptional Jordan algebra J3(O_C) FIXES delta^2 = 3/8;
+// this program checks whether real PDG fermion masses select that value, and whether a
+// delta fit on the QUARK sector predicts the LEPTON sector held-out (zero lepton input).
+//
+// All f64 values are printed as fixed-point integers (value * 1e6) — lean_single idiom.
+//
+// Stage 2 ties the analysis to the REAL octonion algebra (math::octonion) and the
+// formal obligation in formal/OctonionAssociator.lean: the associator [a,b,c] vanishes
+// on Fano-line (associative) triples and is nonzero off them (genuine non-associativity).
+
+use algebra::octonion::*;
+
+fn sqrt_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x != x { return 0.0 }
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    var i = 0
+    while i < 40 {
+        g = 0.5 * (g + x / g)
+        i = i + 1
+    }
+    g
+}
+
+fn abs_f(x: f64) -> f64 { if x < 0.0 { 0.0 - x } else { x } }
+
+// relative standard uncertainty of R = sqrt(ma/mb), from GUM propagation:
+//   u_rel(R) = (1/2) * sqrt( (ua/ma)^2 + (ub/mb)^2 )
+fn u_rel_ratio(ma: f64, ua: f64, mb: f64, ub: f64) -> f64 with Mut, Div, Panic {
+    let ra = ua / ma
+    let rb = ub / mb
+    0.5 * sqrt_q(ra*ra + rb*rb)
+}
+
+fn i64_to_string(v: i64) -> string with Mut, Panic, Div {
+    if v == 0 { return "0" }
+    var n = v
+    var neg = false
+    if n < 0 { neg = true; n = 0 - n }
+    var rev: [i8; 32] = [0; 32]
+    var rev_len: i64 = 0
+    while n > 0 && rev_len < 31 {
+        rev[rev_len as usize] = (48 + n % 10) as i8
+        rev_len = rev_len + 1
+        n = n / 10
+    }
+    var out: [i8; 64] = [0; 64]
+    var out_len: i64 = 0
+    if neg { out[out_len as usize] = 45 as i8; out_len = out_len + 1 }
+    var i = rev_len - 1
+    while i >= 0 {
+        out[out_len as usize] = rev[i as usize]
+        out_len = out_len + 1
+        if i == 0 { break }
+        i = i - 1
+    }
+    str_from_bytes(out, out_len)
+}
+
+fn fp_string(v: f64) -> string with Mut, Div, Panic {
+    // build "W.dddddd" (6 dp, fixed point) into ONE buffer, single str_from_bytes
+    // (avoids str_from_bytes buffer-reuse when concatenating multiple converted ints)
+    var x = v
+    var neg = false
+    if x < 0.0 { neg = true; x = 0.0 - x }
+    let n = (x * 1000000.0 + 0.5) as i64
+    var whole = n / 1000000
+    let frac = n % 1000000
+    var buf: [i8; 64] = [0; 64]
+    // whole part digits (reversed) into wrev
+    var wrev: [i8; 32] = [0; 32]
+    var wlen: i64 = 0
+    if whole == 0 { wrev[0] = 48 as i8; wlen = 1 }
+    while whole > 0 && wlen < 31 {
+        wrev[wlen as usize] = (48 + whole % 10) as i8
+        wlen = wlen + 1
+        whole = whole / 10
+    }
+    var pos: i64 = 0
+    if neg { buf[pos as usize] = 45 as i8; pos = pos + 1 }
+    var i = wlen - 1
+    while i >= 0 {
+        buf[pos as usize] = wrev[i as usize]; pos = pos + 1
+        if i == 0 { break }
+        i = i - 1
+    }
+    buf[pos as usize] = 46 as i8; pos = pos + 1   // '.'
+    // 6 fractional digits, zero-padded, most-significant first
+    var div = 100000
+    while div >= 1 {
+        buf[pos as usize] = (48 + (frac / div) % 10) as i8; pos = pos + 1
+        div = div / 10
+    }
+    str_from_bytes(buf, pos)
+}
+
+fn print_fp(label: string, v: f64) with IO, Mut, Div, Panic {
+    println(label ++ fp_string(v))
+}
+
+// inverse closed forms: implied delta from an observed sqrt-mass-ratio R
+fn inv_A(r: f64)  -> f64 with Div { (r - 1.0) / (r + 1.0) }              // R=(1+d)/(1-d)
+fn inv_C1(r: f64) -> f64 with Div { (2.0/3.0) * (r - 1.0) / (r + 1.0) }  // R=(2/3+d)/(2/3-d)
+fn inv_C2(r: f64) -> f64 with Div { (2.0/3.0) * (1.0 - 1.0/r) }          // R=(2/3)/(2/3-d)
+
+fn form_A(d: f64)   -> f64 with Div { (1.0 + d) / (1.0 - d) }
+fn form_Asq(d: f64) -> f64 with Div { (1.0 + d) * (1.0 + d) / (1.0 - d) }
+fn form_C1(d: f64)  -> f64 with Div { (2.0/3.0 + d) / (2.0/3.0 - d) }
+fn form_C2(d: f64)  -> f64 with Div { (2.0/3.0) / (2.0/3.0 - d) }
+
+fn ln_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    // atanh series: ln(x) = 2*atanh((x-1)/(x+1))
+    let y = (x - 1.0) / (x + 1.0)
+    var term = y
+    var sum = 0.0
+    var k = 0
+    let y2 = y * y
+    while k < 60 {
+        let denom = (2 * k + 1) as f64
+        sum = sum + term / denom
+        term = term * y2
+        k = k + 1
+    }
+    2.0 * sum
+}
+
+fn set_basis(v: &![f64; 8], j: i64) with Mut {
+    var i: i64 = 0
+    while i < 8 { v[i as usize] = 0.0; i = i + 1 }
+    v[j as usize] = 1.0
+}
+
+// associator norm |[e_i, e_j, e_k]| via the verified algebra::octonion product
+fn assoc_norm(i: i64, j: i64, k: i64) -> f64 with Mut, Div, Panic, NonAssoc {
+    var a: [f64; 8] = [0.0; 8]
+    var b: [f64; 8] = [0.0; 8]
+    var c: [f64; 8] = [0.0; 8]
+    set_basis(&!a, i); set_basis(&!b, j); set_basis(&!c, k)
+    var out: [f64; 8] = [0.0; 8]
+    oct_associator(&a, &b, &c, &!out)
+    sqrt_q(oct_norm_sq(&out))
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    println("=== Octonion exceptional-Jordan fermion-mass delta test (Sounio/lean_single) ===")
+    let delta_th = sqrt_q(3.0 / 8.0)
+    print_fp("delta_theory = sqrt(3/8) = ", delta_th)
+
+    // PDG pole-ish masses (MeV)
+    let me  = 0.51099895
+    let mmu = 105.6583755
+    let mtau = 1776.86
+    let mu_ = 2.16
+    let md = 4.67
+    let ms = 93.4
+    let mc = 1270.0
+    let mb = 4180.0
+    let mt = 172570.0
+
+    println("")
+    println("(1) implied delta per ratio (3 functional forms, 3 sectors):")
+    print_fp("  tau/mu  (A)   -> ", inv_A(sqrt_q(mtau/mmu)))
+    print_fp("  s/d     (A)   -> ", inv_A(sqrt_q(ms/md)))
+    print_fp("  c/u     (C1)  -> ", inv_C1(sqrt_q(mc/mu_)))
+    print_fp("  t/c     (C2)  -> ", inv_C2(sqrt_q(mt/mc)))
+    // b/s uses Asq -> numeric solve below
+
+    // grid-fit delta on QUARK sector (s/d:A, b/s:Asq, c/u:C1, t/c:C2), least-squares in log
+    let r_sd = sqrt_q(ms/md)
+    let r_bs = sqrt_q(mb/ms)
+    let r_cu = sqrt_q(mc/mu_)
+    let r_tc = sqrt_q(mt/mc)
+    var best_d = 0.0
+    var best_err = 1.0e30
+    var d = 0.334
+    while d < 0.666 {
+        let e1 = ln_q(form_A(d))   - ln_q(r_sd)
+        let e2 = ln_q(form_Asq(d)) - ln_q(r_bs)
+        let e3 = ln_q(form_C1(d))  - ln_q(r_cu)
+        let e4 = ln_q(form_C2(d))  - ln_q(r_tc)
+        let err = e1*e1 + e2*e2 + e3*e3 + e4*e4
+        if err < best_err { best_err = err; best_d = d }
+        d = d + 0.0001
+    }
+    println("")
+    println("(2) cross-sector HELD-OUT: delta fit on QUARKS only ->")
+    print_fp("  delta_quark = ", best_d)
+    println("  predict LEPTONS (zero lepton data):")
+    print_fp("    sqrt(m_tau/m_mu) pred = ", form_A(best_d))
+    print_fp("    sqrt(m_tau/m_mu) obs  = ", sqrt_q(mtau/mmu))
+    let pred_mue = form_A(best_d) * (best_d + 1.0/3.0) / (best_d - 1.0/3.0)
+    print_fp("    sqrt(m_mu/m_e)   pred = ", pred_mue)
+    print_fp("    sqrt(m_mu/m_e)   obs  = ", sqrt_q(mmu/me))
+
+    println("")
+    println("(3) group-forced equalities (zero delta):")
+    print_fp("    Dynkin swap sqrt(m_tau/m_mu) = ", sqrt_q(mtau/mmu))
+    print_fp("                sqrt(m_s/m_d)    = ", sqrt_q(ms/md))
+    print_fp("    trace split sqrt(m_u/m_e)    = ", sqrt_q(mu_/me))
+    print_fp("                sqrt(m_d/m_e)    = ", sqrt_q(md/me))
+
+    println("")
+    println("(4) octonion non-associativity (real algebra, ties to OctonionAssociator.lean):")
+    print_fp("    |[e1,e2,e4]| (non-Fano, NON-assoc) = ", assoc_norm(1, 2, 4))
+    print_fp("    |[e1,e2,e3]| (Fano line, assoc)    = ", assoc_norm(1, 2, 3))
+    println("    forward theorem: Fano triple => associator 0; off-Fano => |assoc|=2")
+
+    // ---- (5) ISO GUM uncertainty (JCGM 100:2008) on implied delta -------------
+    // PDG 1-sigma mass uncertainties (MeV)
+    let ue = 0.0000001
+    let umu = 0.000002
+    let utau = 0.12
+    let uu = 0.49
+    let ud = 0.48
+    let us = 3.4
+    let uc = 20.0
+    let ut = 290.0
+    let dth = delta_th
+    println("")
+    println("(5) ISO GUM combined uncertainty on implied delta (k=1); z=(delta-sqrt(3/8))/u_c:")
+
+    // tau/mu, form A: delta=(R-1)/(R+1), ddelta/dR = 2/(R+1)^2
+    let R1 = sqrt_q(mtau/mmu)
+    let uR1 = R1 * u_rel_ratio(mtau, utau, mmu, umu)
+    let s1 = 2.0 / ((R1 + 1.0) * (R1 + 1.0))
+    let d1 = inv_A(R1); let ud1 = abs_f(s1) * uR1
+    print_fp("  tau/mu : delta = ", d1)
+    print_fp("           u_c   = ", ud1)
+    print_fp("           z     = ", (d1 - dth) / ud1)
+
+    // s/d, form A
+    let R2 = sqrt_q(ms/md)
+    let uR2 = R2 * u_rel_ratio(ms, us, md, ud)
+    let s2 = 2.0 / ((R2 + 1.0) * (R2 + 1.0))
+    let d2 = inv_A(R2); let ud2 = abs_f(s2) * uR2
+    print_fp("  s/d    : delta = ", d2)
+    print_fp("           u_c   = ", ud2)
+    print_fp("           z     = ", (d2 - dth) / ud2)
+
+    // c/u, form C1: delta=(2/3)(R-1)/(R+1), ddelta/dR = (4/3)/(R+1)^2
+    let R3 = sqrt_q(mc/mu_)
+    let uR3 = R3 * u_rel_ratio(mc, uc, mu_, uu)
+    let s3 = (4.0/3.0) / ((R3 + 1.0) * (R3 + 1.0))
+    let d3 = inv_C1(R3); let ud3 = abs_f(s3) * uR3
+    print_fp("  c/u    : delta = ", d3)
+    print_fp("           u_c   = ", ud3)
+    print_fp("           z     = ", (d3 - dth) / ud3)
+
+    // t/c, form C2: delta=(2/3)(1-1/R), ddelta/dR = (2/3)/R^2
+    let R4 = sqrt_q(mt/mc)
+    let uR4 = R4 * u_rel_ratio(mt, ut, mc, uc)
+    let s4 = (2.0/3.0) / (R4 * R4)
+    let d4 = inv_C2(R4); let ud4 = abs_f(s4) * uR4
+    print_fp("  t/c    : delta = ", d4)
+    print_fp("           u_c   = ", ud4)
+    print_fp("           z     = ", (d4 - dth) / ud4)
+    println("  (|z|<=1 => sqrt(3/8) within 1 combined standard uncertainty of that ratio)")
+    println("DONE")
+    0
+}

--- a/examples/physics/triality_check.sio
+++ b/examples/physics/triality_check.sio
@@ -1,0 +1,79 @@
+// Triality core checks, native Sounio (algebra::octonion).
+//
+// The full Spin(8) local-triality solve (∀A∈so(8) ∃! (B,C); dim g2 = 14) is a 56-var
+// linear solve — done & verified in python:
+//   experiments/non_assoc_connectomics/scripts/triality_principle.py (residual 1e-13, dim 14)
+// Here we verify the lean_single-feasible algebraic CORE that underpins it, on the
+// Fano-checked octonion product:
+//   [1] trilinear t(x,y,z)=Re((x*y)*z) is CYCLIC: t(x,y,z)-t(y,z,x) = 0
+//   [2] but NOT fully symmetric: t(x,y,z)-t(x,z,y) ≠ 0   (the genuine octonionic signature)
+//   [3] left-alternative  [a,a,b] = 0   (defining law; g2=derivations rests on alternativity)
+//   [4] right-alternative [a,b,b] = 0
+//   [5] genuine non-associativity off-Fano: |[e1,e2,e4]| = 2 (test is not vacuous)
+//
+// Run: SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/physics/triality_check.sio
+
+use algebra::octonion::*;
+
+fn sqrt_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var g = x; var i = 0
+    while i < 40 { g = 0.5 * (g + x / g); i = i + 1 }
+    g
+}
+
+fn fp_string(v: f64) -> string with Mut, Div, Panic {
+    var x = v; var neg = false
+    if x < 0.0 { neg = true; x = 0.0 - x }
+    let n = (x * 1000000.0 + 0.5) as i64
+    var whole = n / 1000000; let frac = n % 1000000
+    var buf: [i8; 64] = [0; 64]
+    var wrev: [i8; 32] = [0; 32]; var wlen: i64 = 0
+    if whole == 0 { wrev[0] = 48 as i8; wlen = 1 }
+    while whole > 0 && wlen < 31 { wrev[wlen as usize] = (48 + whole % 10) as i8; wlen = wlen + 1; whole = whole / 10 }
+    var pos: i64 = 0
+    if neg { buf[pos as usize] = 45 as i8; pos = pos + 1 }
+    var i = wlen - 1
+    while i >= 0 { buf[pos as usize] = wrev[i as usize]; pos = pos + 1; if i == 0 { break }; i = i - 1 }
+    buf[pos as usize] = 46 as i8; pos = pos + 1
+    var div = 100000
+    while div >= 1 { buf[pos as usize] = (48 + (frac / div) % 10) as i8; pos = pos + 1; div = div / 10 }
+    str_from_bytes(buf, pos)
+}
+
+// t(x,y,z) = Re((x*y)*z)
+fn t3(x: &[f64; 8], y: &[f64; 8], z: &[f64; 8]) -> f64 with Mut, Div, Panic, NonAssoc {
+    var xy: [f64; 8] = [0.0; 8]
+    oct_mul(x, y, &!xy)
+    var xyz: [f64; 8] = [0.0; 8]
+    oct_mul(&xy, z, &!xyz)
+    xyz[0]
+}
+
+fn assoc_norm3(a: &[f64; 8], b: &[f64; 8], c: &[f64; 8]) -> f64 with Mut, Div, Panic, NonAssoc {
+    var out: [f64; 8] = [0.0; 8]
+    oct_associator(a, b, c, &!out)
+    sqrt_q(oct_norm_sq(&out))
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    println("=== Triality core checks (native Sounio / algebra::octonion) ===")
+    var x: [f64; 8] = [0.3, 0.5, 0.0, 0.2, 0.1, 0.0, 0.4, 0.0]
+    var y: [f64; 8] = [0.1, 0.0, 0.6, 0.0, 0.2, 0.3, 0.0, 0.1]
+    var z: [f64; 8] = [0.2, 0.1, 0.0, 0.5, 0.0, 0.2, 0.0, 0.4]
+
+    println("[1] cyclic  t(x,y,z)-t(y,z,x) = " ++ fp_string(t3(&x,&y,&z) - t3(&y,&z,&x)) ++ "  (expect 0)")
+    println("[2] not-sym t(x,y,z)-t(x,z,y) = " ++ fp_string(t3(&x,&y,&z) - t3(&x,&z,&y)) ++ "  (expect != 0)")
+
+    // alternativity on the sample elements (defining octonion laws)
+    println("[3] left-alt  |[x,x,y]| = " ++ fp_string(assoc_norm3(&x,&x,&y)) ++ "  (expect 0)")
+    println("[4] right-alt |[x,y,y]| = " ++ fp_string(assoc_norm3(&x,&y,&y)) ++ "  (expect 0)")
+
+    // non-vacuity: genuine off-Fano non-associativity
+    var e1: [f64; 8] = [0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0]
+    var e2: [f64; 8] = [0.0,0.0,1.0,0.0,0.0,0.0,0.0,0.0]
+    var e4: [f64; 8] = [0.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0]
+    println("[5] off-Fano |[e1,e2,e4]| = " ++ fp_string(assoc_norm3(&e1,&e2,&e4)) ++ "  (expect 2)")
+    println("DONE  (full 56-var triality solve + dim g2=14: scripts/triality_principle.py)")
+    0
+}

--- a/experiments/non_assoc_connectomics/MADAROS_F64_NATIVE_V2_BUGREPORT.md
+++ b/experiments/non_assoc_connectomics/MADAROS_F64_NATIVE_V2_BUGREPORT.md
@@ -1,0 +1,267 @@
+# Madaros native-v2 backend: f64 + str_from_bytes miscompilation (minimal repros)
+
+Found 2026-06-30 while porting the octonion mass-δ artifact
+(`examples/physics/octonion_mass_delta.sio`) from `lean_single` to Madaros (v0.80.0,
+default `bin/souc`).
+
+## Good news first
+Madaros has advanced a lot vs the prior "segfault during octonion lowering" state:
+frontend, merged-IR, type-check, and **integer** native-v2 codegen all work and emit a
+running ELF. Integer programs (println + print_int) run correctly.
+
+## The boundary (3 distinct native-v2 defects)
+All three **compile** ("Compilation successful!", ELF written) but produce wrong results
+or crash **at runtime**. The identical files run correctly under `lean_single`
+(`SOUNIO_SOUC_ENGINE=lean_single`), so these are Madaros-native-v2-specific.
+
+| repro | program | lean_single | Madaros native-v2 |
+|---|---|---|---|
+| m2 | `let x:f64=3.0/8.0; print_int((x*1e6) as i64)` | `375000` | **`0`** |
+| m3 | f64 Newton sqrt loop (`g=0.5*(g+0.375/g)`) | `612372` | **SIGFPE (floating point exception)** |
+| m4 | `str_from_bytes(buf,2)` on `[i8;8]` | `Hi` | **Segmentation fault** |
+
+### Repro m2 — f64→i64 cast yields 0 (f64 arithmetic likely lowered as integer)
+```sounio
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let x: f64 = 3.0 / 8.0
+    print_int((x * 1000000.0) as i64); print("\n"); 0
+}
+```
+Expected `375000`; Madaros prints `0`. Suggests f64 `/` and `*` (or the f64→i64 `as`
+cast) are being emitted as integer ops, so `3/8 → 0`.
+
+### Repro m3 — f64 division SIGFPEs at runtime
+```sounio
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var g: f64 = 1.0; var i: i64 = 0
+    while i < 30 { g = 0.5*(g + 0.375/g); i = i+1 }
+    print_int((g*1000000.0) as i64); print("\n"); 0
+}
+```
+Expected `612372` (√(3/8)); Madaros raises a hardware **floating-point exception** —
+consistent with an integer `idiv` being emitted where an f64 `divsd` is required.
+
+### Repro m4 — str_from_bytes segfaults at runtime
+```sounio
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var b: [i8; 8] = [0; 8]
+    b[0]=72 as i8; b[1]=105 as i8
+    println(str_from_bytes(b, 2)); 0
+}
+```
+Expected `Hi`; Madaros segfaults — likely a bad pointer/length to the str_from_bytes
+builtin in native-v2.
+
+## Impact
+The octonion mass-δ scientific artifact is f64- and string-heavy, so it cannot run
+correctly on Madaros until m2/m3 (f64 ALU lowering) and m4 (str_from_bytes) are fixed.
+`lean_single` remains the engine that emits correct numeric binaries.
+Multimodule note: the full artifact (with `use algebra::octonion`) fails earlier at
+`multimodule native thin-link compilation failed` / `imported_simple_ir_emit_failed`
+— a separate imported-IR emit path, also worth a look, but the f64 ALU bug is upstream
+of it.
+
+## Suggested first fix (SUPERSEDED — see corrected root cause below)
+~~Audit the native-v2 instruction selection for f64~~ — this framing was wrong.
+
+## CORRECTED ROOT CAUSE (2026-06-30, after disassembling the emitted ELF)
+Scanned the m2 ELF for opcodes: **zero** `divsd/mulsd/addsd/subsd` (no SSE float ops at
+all), but `idiv`+`imul` present. The program isn't being generally compiled on the modular
+path at all:
+
+- Madaros (Horizon 3) routes these files through the **"compact modular IR table" path**
+  (`module_native_driver.sio` → `native_driver_write_imported_simple_ir_elf`).
+- That path's emitter, `module_native_simple_driver.sio::simple_driver_emit_fn`, is a
+  **bootstrap template stub**: it pattern-matches a fixed set of function "kinds"
+  (kind 1=tail-call, kind 2 = `mov eax,imm32; ret` = *return a constant*, kind 3=print, …)
+  and writes hand-crafted bytes. It is **not a general code generator**. m2 returned `0`
+  because it matched a "return constant" template; arbitrary f64/general code is unhandled.
+- The **f64-correct backend already exists**: `lower_ir.sio::lower_ir_binop` →
+  `emit_float_binop_code` → `emit_divsd_xmm0_xmm1` (encode.sio:1825, opcode 0x5E), with
+  `is_float_reg` tracking. It is reached only by `main.sio`'s direct path (`lower_instr`,
+  main.sio:5590), which the modular path bypasses.
+
+So the real gap is **backend routing**, not f64 instruction selection.
+
+### Correct fix (architectural, not a localized patch)
+Translate the compact modular IR records into `IrInstr` and drive `lower_instr` (the full
+`lower_ir.sio` lowering + regalloc + encode pipeline, already f64-correct) instead of
+`simple_driver_emit_fn`'s templates. Then `make build-madaros` (bootstrap rebuild) and
+re-test m2/m3/m4 (expect 375000 / 612372 / "Hi") + the multimodule octonion artifact.
+Substantial integration with bootstrap-fixed-point risk. Until then, f64-heavy code runs
+correctly on `lean_single` (which uses the full backend).
+
+---
+
+## REBUILD VERIFIED (2026-06-30): f64 fix WORKS; two separate blocks remain
+
+Rebuilt Madaros with the routing fix (lean_single seed) and tested:
+
+| repro | before | after fix |
+|---|---|---|
+| m2 `(f64 3.0/8.0)*1e6 as i64` | 0 | **375000** ✓ FIXED |
+| m3 f64 Newton division | SIGFPE | **612372** ✓ FIXED |
+| m4 `str_from_bytes` | segfault | empty output, no crash (string still wrong) — separate builtin bug |
+| `octonion_mass_delta.sio` (multimodule, octonion intrinsics) | thin-link failed | takes the full merged-IR path (fix active) but the v2 backend SIGSEGVs (139) on octonion intrinsics |
+
+**Verdict:** the routing fix RESOLVES the f64 codegen bug for general code on Madaros
+(m2/m3 correct, verified). Two independent blockers remain before the full octonion
+artifact runs on Madaros, both in the full v2 backend (not the routing):
+1. `str_from_bytes` returns empty in the v2 backend (no longer segfaults).
+2. The v2 backend segfaults compiling the octonion intrinsics (`oct_mul`/`oct_associator`
+   lowering, `IrHyperMulO`/`IrAssociator` paths in lower_ir.sio).
+Both are out of scope of the f64 routing fix. f64-heavy *scalar* programs now compile and
+run correctly on Madaros; the octonion artifact stays on lean_single until (1)+(2) land.
+No regression: integer + f64 programs compile and run correctly with the fixed binary.
+
+---
+
+## (a) str_from_bytes — ROOT CAUSE LOCATED (2026-06-30)
+
+`str_from_bytes` is **missing from the v2 backend's builtin table**. In
+`self-hosted/native/codegen_x86_linux.sio`, `native_v2_builtin_id_for_func_ref`
+(lines ~1065-1088) maps ~21 builtins (str_len=6, str_char_at=20, str_eq=7,
+str_slice=8, starts_with=9, str_concat=10, read_file=11, …) but has **no entry for
+str_from_bytes**. So a call to it returns id 0 (not-a-builtin) → treated as a call to a
+bodiless function → returns garbage/empty (matches m4: empty output, no crash).
+
+VM string representation (from `emit_builtin_str_concat`): null-terminated `char*` on a
+bump heap (`RuntimeContext.heap_cursor`).
+
+### Fix recipe (NOT applied — needs a working rebuild loop to verify; writing raw
+machine-code emitters blind is unsafe, doubly so now the binary is shared/promoted):
+1. Add recognizer `name_is_str_from_bytes(n)` ("str_from_bytes" = 14 bytes), mirroring
+   `name_is_str_concat`.
+2. Register an id (e.g. 22) in `native_v2_builtin_id_for_func_ref` and in the name-based
+   dispatch near line 4752 (`if name_is_str_from_bytes(func.name) { return emit_builtin_str_from_bytes(c) }`).
+3. Add to the id dispatch near line 5570:
+   `if builtin_id == 22 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_from_bytes((*nc))); return }`.
+4. Write `emit_builtin_str_from_bytes`: args rdi=buf, rsi=len → bump-allocate len+1 from
+   heap_cursor, copy len bytes (rep movsb or a byte loop like starts_with), store NUL at
+   end, return pointer in rax. Mirror `emit_builtin_str_concat`'s heap-alloc/copy/advance
+   sequence exactly (it is the canonical string-producing builtin).
+Verify: rebuild + m4 → "Hi".
+
+## (b) octonion-intrinsic SIGSEGV in v2 — NOT yet localized
+The full octonion artifact takes the (now-default) full merged-IR path but the v2 backend
+SIGSEGVs (exit 139) compiling the octonion intrinsics (`oct_mul`/`oct_associator` →
+`IrHyperMulO`/`IrAssociator`). Next step: determine whether the v2 path (`compile_ir_function_v2`)
+handles these IR opcodes at all (lower_ir.sio has `lower_hyper_mul_o_fano`/`lower_associator`,
+but the v2 machine-IR path may not route to them). Needs investigation + rebuild to verify.
+
+---
+
+## (a) str_from_bytes — wired into v2, but runtime ABI segfault (2026-06-30, NOT promoted)
+
+Added `name_is_str_from_bytes` + builtin id 22 + dispatch + `emit_builtin_str_from_bytes`
+(`mov rax, rdi; ret` — return the buffer pointer, matching lean_single's
+"returns the address of the byte buffer" semantics). Rebuilt (scratch madaros-fix-a):
+- m2/m3 still correct (375000 / 612372) — no f64 regression.
+- m4 now **compiles** (builtin recognized; previously returned empty) but **SIGSEGVs at
+  runtime** (exit 139).
+
+So the missing-builtin was real but not the whole story: with the builtin wired, the fault
+moves to the **array-argument / builtin-call ABI**. `str_from_bytes(b, 2)` passes an array
+`[i8;8]` as arg0; the emitter assumes rdi = &b (as str_slice does for a string pointer), but
+the runtime segfault indicates the array address is not arriving in rdi the way a string
+pointer does (array-arg passing differs from pointer-arg passing in the v2 call path), or the
+returned stack-array pointer is mishandled by the caller. Needs: disassemble the m4 call site
+to confirm what's in rdi at the call, and/or inspect how the v2 backend lowers array
+arguments to a call. **fix-a was NOT promoted** — it would regress str_from_bytes from
+empty-output to crash. The promoted binary remains the f64-only fix (str_from_bytes returns
+empty, no crash).
+
+---
+
+## (a) EXACT root cause found via disassembly (2026-06-30)
+
+Disassembled the m4 ELF (raw binary code segment fed to `objdump -b binary -m i386:x86-64`,
+since the ELF has no section headers). Found the call site:
+
+```
+mov rdi, [rbp-0x8]     ; rdi = local var "b" ([i8;8] array)
+mov rsi, [rbp-0x38]    ; rsi = 2 (len)
+call 0x40141b          ; str_from_bytes(rdi, rsi)   <- my new emitter: mov rax,rdi; ret
+```
+
+And the array-store code (for `b[0]=72; b[1]=105;`) reveals arrays in the v2 backend are
+**boxed/indirect, not raw byte buffers**:
+
+```
+mov rax, [rbp-8]              ; rax = "b" = a SLOT INDEX (small int), NOT a pointer
+imul rbx, rax, 0x30           ; rbx = slot_index * 48   (descriptor stride)
+mov rax, [RuntimeContext+0x18]; rax = array-descriptor-table base
+add rax, rbx
+mov rax, [rax]                ; DEREFERENCE -> rax = the REAL data pointer (descriptor field 0)
+...
+mov [rax + (i+4)*8], value    ; element i stored at data_ptr + 32 (4-qword header) + i*8
+                               ; (8 bytes PER i8 ELEMENT — uniform boxed representation)
+```
+
+So `rdi` at the `str_from_bytes` call site is a **slot index into an array-descriptor
+table**, not a byte-buffer address. My emitter (`mov rax,rdi; ret`, mirroring how
+`str_slice`/`str_concat` treat their args as raw `char*`) just echoes the slot index back —
+the caller (`println`) then dereferences that small integer as if it were a string pointer
+→ SIGSEGV. `str_slice`/`str_concat` never hit this because they only ever receive **strings**
+(already raw null-terminated `char*`, from literals/heap), never a stack-declared `[i8;N]`
+array — so this ABI mismatch was latent until `str_from_bytes` (the only builtin that takes
+an array argument) was wired up.
+
+### What a correct fix requires
+`emit_builtin_str_from_bytes` must, given `rdi`=slot index and `rsi`=len:
+1. Resolve the descriptor: `descriptor_ptr = [RuntimeContext+0x18] + rdi*48`.
+2. Load the real data pointer: `data_ptr = [descriptor_ptr]`.
+3. Bump-allocate `rsi+1` bytes from `RuntimeContext.heap_cursor` (mirror
+   `emit_builtin_str_concat`'s allocation phase) for a **packed** result buffer.
+4. Copy `rsi` bytes, reading each source byte from `[data_ptr + 32 + i*8]` (low byte of the
+   8-byte boxed element) and writing packed to `[result + i]`.
+5. NUL-terminate, return `result` in rax.
+This is a real fix (not a one-liner) requiring the exact descriptor stride (0x30) and header
+size (32 bytes / 4 qwords) confirmed above, plus a copy loop. Not applied this session —
+needs a dedicated rebuild-test cycle to get the encoding right; the promoted shared binary
+must not regress. Current promoted binary keeps the safe (non-crashing, wrong-output)
+str_from_bytes state; `madaros-fix-a` (the crashing version) stays unpromoted.
+
+---
+
+## (a) Complete fix recipe — all pieces identified, NOT hand-assembled (2026-06-30)
+
+Traced every constant and helper needed, all already exist and are used elsewhere (so
+they are trustworthy, tested code paths):
+
+- `native_v2_resolve_handle_to_object_base_rax(nc) -> nc` (codegen_x86_linux.sio:2691):
+  takes a handle in `rax`, returns the object's data pointer in `rax`. This is the exact
+  function `native_v2_core_emit_local_array_load_into` (line 7991, used for ordinary
+  `arr[i]` reads) calls — confirms it's the right, tested primitive.
+- `native_v2_handle_entry_size() = 48` (gc.sio:35) — matches the `imul rbx,rbx,0x30` seen
+  in the disassembly.
+- `native_v2_object_header_size() = 32` (gc.sio:27) — matches the `+4` qword offset (`(i+4)*8`)
+  seen for element access.
+- `nc_emit_load_rax_mem_rdx_rbx8` / `nc_emit_store_rax_mem_rdx_rbx8` (codegen_x86_linux.sio:1501):
+  raw `mov rax,[rdx+rbx*8]` / `mov [rdx+rbx*8],rax` — the exact element-read/write instruction,
+  confirmed byte-identical to the disassembled array-store code.
+
+So `emit_builtin_str_from_bytes(nc)` [rdi=handle, rsi=len] should:
+1. `rax=rdi; c = native_v2_resolve_handle_to_object_base_rax(c)` → `rax` = object_base.
+2. Bump-allocate `len+1` bytes from `heap_cursor` (mirror `emit_builtin_str_concat`'s Phase 3)
+   → result pointer.
+3. Loop `i` in `0..len`: read element via `object_base`, index `(i + 32/8)`, using
+   `nc_emit_load_rax_mem_rdx_rbx8` (rdx=object_base, rbx=i+4) → low byte is the packed byte;
+   write to `[result+i]`.
+4. NUL-terminate at `[result+len]`; return `result` in `rax`.
+
+### Why this was NOT hand-assembled and shipped
+Steps 3's loop requires a conditional branch (`jz`/`jnz` to a "done" label) whose relative
+displacement must be the exact byte count of the intervening instructions — this codebase's
+raw-builtin style (`emit_builtin_str_concat`, `emit_builtin_starts_with`) computes these by
+**manual byte-counting** (see e.g. `starts_with`'s comments `// jz match (skip 2+2+3+3+2=12)`),
+with no assembler/two-pass relocation available at this level (unlike full IR-compiled
+functions, which get real label/reloc support — see `IrIndexGet`/`IrIndexSet`'s clean
+label-based lowering at codegen_x86_linux.sio:6676, a SAFER model this builtin could follow
+in a future rewrite: expand `str_from_bytes` as small generated IR code with `IrIndexGet` +
+`IrBranchTrue`/`IrJump`, not a hand-written raw-bytes leaf function). A single miscounted
+byte here produces a silently wrong jump target (crash or, worse, silent memory
+corruption) that only surfaces after another ~10min rebuild — on a currently
+contended shared build box, and on a binary that gets promoted to shared use. Per this
+session's discipline (verify before promote, no blind machine-code), this is deliberately
+left as a precise, actionable spec rather than shipped code.

--- a/experiments/non_assoc_connectomics/brain_structure_verdict.md
+++ b/experiments/non_assoc_connectomics/brain_structure_verdict.md
@@ -1,0 +1,93 @@
+# Non-associative / exceptional algebra in the brain — honest verdict
+
+Synthesis of a deep, adversarially-verified literature sweep (19 claims, 3-vote
+verification; the automated synthesis step failed on quota, so this is the hand-merge).
+Companion to the ABIDE FC null (`octonion_arc_findings.md` §2). Goal: separate real
+signal from analogy from hype on whether non-associative/hypercomplex/exceptional
+structure lives in the brain, and name the best falsifiable next test.
+
+## Verdict by front
+
+### Octonionic / exceptional algebra in neural *tissue*: no evidence, and actively bounded out
+The best-characterized neural geometry — grid cells — is rigorously a **2D twisted-torus
+manifold** that is a representation of a **compact connected *Abelian* (commutative) Lie
+group** (Gardner et al. 2022, Nature; Xu et al. arXiv:2210.02684; arXiv:2510.02853, all
+3-0). Abelian + toroidal is **incompatible with non-associative/octonionic** structure.
+So in the one place neural symmetry is nailed down, it is the *opposite* of exceptional.
+No peer-reviewed work ties G2/E6/E8/triality/Jordan algebras to neural data (hypercomplex
+DL reviews cover remote sensing/medical imaging/robotics — **zero** neuroimaging). Octonion
+non-associativity appears in the literature only as an *engineering* concern in octonion
+nets, not an emergent brain property.
+
+### Hypercomplex nets on brain data: efficiency, not structure
+Quaternion EEG/neuroimaging nets claim ~4× parameter efficiency, justified by an informal
+"naturalness" argument — **not** a demonstrated quaternionic/non-associative property of
+neural signals (3-0). On ABIDE specifically, simple baselines are competitive, i.e. fancy
+inductive biases yield little (3-0) — consistent with our FC null.
+
+### The TWO real, non-woo open doors
+
+1. **Directed / effective connectivity carries asymmetric structure symmetric FC cannot
+   represent** (3-0, multiple: sparse-DCM irreversible component, biorxiv 2025.11.16.688716;
+   asymmetric-diffusion prediction, PMC7888488). This is exactly the modality our null did
+   NOT test. **But the demonstrated structure is non-commutativity / irreversibility, not
+   Cayley-Dickson non-associativity.** The honest test is whether the *composition* of
+   directed influences is non-associative, not merely asymmetric (see next section).
+
+2. **Non-associative binding earns its keep in sequence / working memory.** A VSA /
+   hyperdimensional model with Cayley-Dickson-style binding where left- vs right-associative
+   bundling give distinct states (L-state recency, R-state primacy) **reproduces the human
+   Serial Position Curve** (arXiv:2506.13768, 2-1 — single line, weaker). This is the one
+   place the "(A then B) then C ≠ A then (B then C)" intuition is literally realized and
+   makes a falsifiable behavioral prediction. It is a *cognitive/computational* model, not
+   a claim about tissue.
+
+## Best falsifiable next experiment (ranked)
+
+1. **Non-associativity of directed-connectivity composition.** Estimate directed effective
+   connectivity (transfer entropy / sparse DCM) → form the path-composition operator → test
+   whether (A∘B)∘C ≠ A∘(B∘C) *beyond* what non-commutativity alone forces, with a
+   pre-registered associator-style statistic and a phase-randomized / commutativity-matched
+   null. This targets the one modality with proven asymmetric structure, and distinguishes
+   genuine non-associativity from mere asymmetry. **Prior: most likely reveals
+   non-commutativity but associative composition — but it is the honest, untested case.**
+2. **Serial-position / sequence-memory associativity probe.** Behavioral + neural (sequence
+   replay) test of whether order-binding is left- or right-associative, per the VSA model —
+   the one place non-associativity already has explanatory traction.
+3. **(Bounded out, do not pursue):** octonionic/exceptional signatures in symmetric FC or in
+   grid-cell-like manifolds — the geometry is Abelian/toroidal; the detector is calibrated
+   and reads null.
+
+## Bottom line (to dissolve the fear, honestly)
+"The brain uses octonions/exceptional algebra" has **no support** and is **bounded out** of
+the best-characterized neural geometry. But the broader instinct is not dead: **directed
+connectivity has real asymmetric structure left untested**, and **non-associativity has a
+genuine, falsifiable home in sequence/working-memory composition**. The honest path is to
+test *those* — with the same calibrated-detector + pre-registered-null discipline — not to
+keep probing symmetric FC for octonions that the geometry rules out.
+
+Sources: Nature s41586-021-04268-7; arXiv 2210.02684, 2510.02853, 2506.13768;
+PMC3040354, PMC7888488, PMC11625415, PMC12513225; biorxiv 2025.11.16.688716;
+mdpi 15/21/11526.
+
+## Track C result (2026-06-30): directed connectivity TESTED — real but weak for ASD
+
+Ran the directed-connectivity probe (`scripts/directed_connectivity_test.py`) on ABIDE
+CC200 (N=988, LOSO 20 sites). Lag-1 cross-correlation M_ij=corr(x_i(t),x_j(t+1));
+directed part K=(M−Mᵀ)/2.
+
+- **Directed structure is REAL:** asymmetry ‖K‖/‖M‖ = **0.291** (substantial, not noise) —
+  lead-lag directionality genuinely exists, as the verdict predicted.
+- **But its ASD signal is weak:** directed part alone = **53.5%** balanced acc (vs symmetric
+  FC **65.9%**), and FC+directed = **62.7%** (worse than FC — the 19 900 weak directed
+  features overfit in LOSO).
+
+**Honest read:** the directed/lead-lag modality the verdict flagged is real but, at this
+(lag-1 cross-correlation) operationalization, carries only marginal autism-classification
+signal and does **not** add to symmetric FC. Caveat: one directed measure, naive
+high-dim features, simple linear LOSO — a dimensionality-reduced or model-based (sparse-DCM)
+directed estimate could differ. And note: composition of directed connectivity as matrices
+is associative, so this does not bear on *non-associativity* — it tests whether directed
+*structure* carries signal (it does, but weakly). Door 1 is now tested, not assumed; the
+remaining non-associativity home is sequence/working-memory composition (door 2), behavioral
+and outside this dataset.

--- a/experiments/non_assoc_connectomics/madaros_repros/m2_f64_cast.sio
+++ b/experiments/non_assoc_connectomics/madaros_repros/m2_f64_cast.sio
@@ -1,0 +1,5 @@
+// Madaros native-v2: prints 0 (expected 375000). lean_single: 375000.
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let x: f64 = 3.0 / 8.0
+    print_int((x * 1000000.0) as i64); print("\n"); 0
+}

--- a/experiments/non_assoc_connectomics/madaros_repros/m3_f64_newton.sio
+++ b/experiments/non_assoc_connectomics/madaros_repros/m3_f64_newton.sio
@@ -1,0 +1,6 @@
+// Madaros native-v2: SIGFPE (expected 612372). lean_single: 612372.
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var g: f64 = 1.0; var i: i64 = 0
+    while i < 30 { g = 0.5*(g + 0.375/g); i = i+1 }
+    print_int((g*1000000.0) as i64); print("\n"); 0
+}

--- a/experiments/non_assoc_connectomics/madaros_repros/m4_str_from_bytes.sio
+++ b/experiments/non_assoc_connectomics/madaros_repros/m4_str_from_bytes.sio
@@ -1,0 +1,6 @@
+// Madaros native-v2: segfault (expected Hi). lean_single: Hi.
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var b: [i8; 8] = [0; 8]
+    b[0]=72 as i8; b[1]=105 as i8
+    println(str_from_bytes(b, 2)); 0
+}

--- a/experiments/non_assoc_connectomics/octonion_arc_findings.md
+++ b/experiments/non_assoc_connectomics/octonion_arc_findings.md
@@ -1,0 +1,322 @@
+# Octonions, non-associativity, and where "something more" actually lives
+
+**A consolidated, adversarially-checked findings document.**
+Scope: a multi-stage investigation testing the hypothesis that octonionic non-associativity
+is a meaningful structure — in brain connectomics, as a machine-learning inductive bias,
+and in fundamental physics. Every quantitative claim below was produced by a runnable
+script (paths in §7) and, where central, cross-checked against an independent baseline,
+a pre-committed decision rule, or a null model.
+
+Date: 2026-06-30. Engine for Sounio artifacts: `souc-lean-single-x86_64`.
+
+> **ERRATUM (2026-06-30, self-reported).** The explicit 8-component octonion product
+> used in the numpy synthetic/brain scripts (§2–§3) is **not a genuine octonion
+> algebra** — it fails composition, alternativity, and Re(associator)=0 (verified
+> symbolically). It matched correct octonions on the basis triples originally
+> spot-checked but differs on 5/35 basis triples and on general elements. **Impact:**
+> (1) the **mass result (§4) is unaffected** — it is pure scalar arithmetic with no
+> octonion multiplication; (2) the **Sounio artifact's associator is unaffected** — it
+> uses the Fano-verified stdlib `algebra::octonion` (2.0/0.0); (3) the **§3
+> inductive-bias result re-verifies with correct Cayley–Dickson octonions** — the fair
+> ablation gives octonion−associative = **+40.0** on the octonionic task (vs the
+> reported +35.4) and −3.2 on the associative task, so the double-dissociation
+> conclusion *holds for genuine octonions*; (4) the **brain null (§2) survives** (a
+> non-associative detector found nothing; recalibrated to +40). Verified octonions and
+> the re-check: `scripts/octonion_cd_correct.py`. The §2–§3 numeric tables were
+> computed with the flawed table; their *conclusions* are confirmed, their exact
+> figures should be read as "computed with a non-alternative near-octonion, conclusion
+> re-verified with true octonions."
+
+---
+
+## 0. One-paragraph verdict
+
+Octonionic non-associativity is **real and decisive as a representational tool when the data
+carries matching structure** (a fair, pre-committed, matched-capacity ablation gives a +35-point
+balanced-accuracy gap over an associative control). It is **absent from brain functional
+connectivity** (ABIDE rs-fMRI): three converging, fairly-powered tests — including an
+end-to-end learned embedding that had every chance to find it — return null, while the *same*
+machinery scores +35 on genuinely octonionic data. Its one suggestive anchor is in
+**fermion masses**: **given the electric-charge center assignment** of the exceptional Jordan
+algebra J₃(O_C), real PDG mass ratios are **consistent with** δ²=3/8 (the up sector's
+spread/center ratio = √(3/8)/(2/3) to 0.1%; given charge-centers the 5-ratio cluster is
+p < 10⁻⁵ vs random; the centers≈charges match is selective — 0/20000 scrambled spectra reproduce
+it). **Important conditioning (identifiability audit, §4.10):** with the sector centers left
+free, δ is *not* identified by the masses alone — χ²(δ) is flat; only fixing centers = electric
+charges pins δ to √(3/8). So the honest claim is conditional: *charges ⇒ δ²=3/8*, not *masses
+select δ²=3/8*. This is a genuine, quantified, conditional regularity — **not** a confirmed
+predictive theory (δ is unidentified without the charge input; some relations miss by ~10%; the
+source is a single-author program). Net: the octonion has "something more," but in physics,
+not the brain — and as suggestive, properly-conditioned structure, not established law.
+
+---
+
+## 1. The question
+
+Does octonionic non-associativity — the associator `[a,b,c] = (ab)c − a(bc)`, nonzero off the
+Fano lines — encode something real? Three fronts were tested in sequence, each forcing the
+next. The investigation began as a "correction run" for a claimed octonionic O-SSM autism
+biomarker and ended in the fermion mass spectrum.
+
+---
+
+## 2. Front A — Brain connectomics: a robust null
+
+### 2.1 The ROI biomarker screen is a clean, well-powered NULL
+Model-free octonionic-associator ROI screen on real ABIDE CC200 (N=505 ASD / 518 control):
+**0/200 ROIs survive Holm–Bonferroni**, both mean and max pooling; max |Cliff's δ| = 0.072;
+feature non-degenerate (between-subject CV 0.287). No biomarker. The much-publicized
+"O-SSM 58.7%" claim is unsupported: every repository result shows ~49.5%, octonion training
+was disabled, and no trained checkpoint was ever written (the pipeline never serializes a model).
+
+### 2.2 The chance-level results were feature engineering, not the model
+Every architecture sits at chance on the project's 8×8 manifest (200 ROIs pooled → 8 groups,
+time → 8 steps = 64 numbers): gru 49.4, lstm 50.3, tcn 50.3, **transformer 50.8**, O-SSM raw
+49.95, H-SSM 49.91. A transformer at chance on the same features ⇒ the signal is destroyed
+upstream. Restoring it: full CC200 functional connectivity (Pearson upper-triangle,
+19 900 features) + a plain linear classifier → **65.93% balanced accuracy** (LOSO, 20 sites,
+N=988). The 200→8 averaging discards the pairwise-connectivity structure where ABIDE signal lives.
+
+### 2.3 The octonion recurrence destroys linearly-separable signal
+At matched 64-dim input (per-fold PCA-64 of FC): linear **65.00%**, O-SSM (octonion) **49.72%**,
+H-SSM (quaternion) **51.21%**. The 64-dim bottleneck is not the problem (PCA-64 linear ≈ full-FC
+linear); the frozen-random-A octonion recurrence + tiny readout is an untuned Echo State Network
+that scrambles separability.
+
+### 2.4 Three converging brain tests; the tool is calibrated
+A *fair* octonion-vs-associative ablation (identical recipe — both bracketings L=(o_i o_j)o_k,
+R=o_i(o_j o_k) + quadratic readout; toggle only the product) on ABIDE FC:
+
+| Test | octonion − associative |
+|---|---|
+| Frozen ESN (weak) | ~0 (chance) |
+| Fixed PCA-64, fair ablation | **−1.78** |
+| Learned end-to-end embedding (max power) | **+0.28** |
+| *(reference: genuinely octonionic data)* | *+35.4* |
+
+The same machinery reads +35 where structure exists and ≤0 on the brain across fixed *and*
+learned embeddings. **Conclusion: brain FC carries no octonionic non-associative structure**
+(bounded honestly to FC representations; a directed/effective-connectivity modality remains
+formally untested). "Connectomics is non-associative by definition" conflates nonlinearity /
+higher-order interactions (hypergraph, TDA — formally orthogonal, over associative groups)
+with Cayley–Dickson non-associativity.
+
+---
+
+## 3. Front B — Octonion as a machine-learning inductive bias: vindicated, fairly
+
+### 3.1 Double dissociation on synthetic data
+Label = octonion associator-norm `‖[a,b,c]‖ > median` (genuinely octonionic) vs an
+associative/linear label. Same 24-real inputs.
+
+| Model | Octonionic target | Associative target |
+|---|---|---|
+| linear | 49.8 | 98.2 |
+| real reservoir (generic nonlinearity, matched cap.) | 55.7 | 95.1 |
+| octonion (associator feature) | **99.5** | 51.2 |
+
+### 3.2 Not a degree artifact, not a capacity artifact
+Real random-polynomial features matched to the target degree: deg-3 56.6, deg-4 59.5, deg-6 58.1.
+A trained MLP up to **537 k parameters**: ~60%. None approach the octonion's 99.5% — the
+associator is a specific, hard-to-learn target generic models miss.
+
+### 3.3 The clean test: matched-capacity, both trained, toggle only associativity
+*Pre-committed rule:* non-associativity helps ⟺ on the non-associative task octonion − associative ≥ 10,
+AND on associative/neutral tasks |difference| ≤ 3.
+- Weak readout (linear, final state): NA-task **+4.1** → fails the bar (architecture too weak to
+  express the degree-6 norm).
+- **Fair readout (both bracketings + quadratic, neither handed the associator):**
+  NA **90.3 vs 54.9 = +35.4 (≫10 ✓)**, neutral −0.2 (✓), associative −4.1 (octonion slightly
+  *worse* — reinforces the dissociation). **Rule passed.**
+
+**Conclusion: octonionic non-associativity is a real, decisive, learnable inductive bias when
+the data carries matching structure.** Bounded claim: this is representational capability given
+matching structure, not evidence any real domain has it. (Design note: providing both
+bracketings is a symmetric architecture choice that exposes non-associativity; fair because the
+advantage is intrinsic to L≠R, but a choice worth stating.)
+
+---
+
+## 4. Front C — Physics: the real anchor
+
+### 4.1 Literature state (deep, adversarially-verified survey)
+No rigorously demonstrated, matched-capacity, cross-validated advantage for octonion / non-associative
+algebras in ML. Quaternions (associative): no significant accuracy gain over real baselines at
+matched parameters; benefit is parameter efficiency only. Octonion-positive results
+(Deep Octonion Networks) are single-paper, unreplicated, never isolate non-associativity; a 2025
+review calls octonion nets empirically unvalidated. The most-cited modern work (PHM/PHNN, ICLR'21)
+*learns* the multiplication rule from data, treating the fixed algebra as a restriction. Octonions
+appear rigorously by construction in the Standard-Model C⊗O programs (Furey, Todorov), the
+exceptional Jordan algebra J₃(O_C)→E₆ (Singh), and G₂=Aut(O) lattice gauge theory (which shows
+*no* exceptional thermodynamic signature vs SU(N)).
+
+### 4.2 The Koide diamond
+Koide Q = (Σm)/(Σ√m)² for charged leptons = **0.666661** vs 2/3 = 0.666667 (φ = 44.9997° vs 45°),
+agreeing to ~5 significant figures. Derived bridge: the J₃(O_C) spectrum (q−δ, q, q+δ) with
+**δ²=3/8 is exactly the Koide 2/3 point** (φ=45°). Quarks miss: up Q=0.849, down Q=0.731.
+Caveat: Koide (1981) predates the octonion derivation — a retrofit, not a forward prediction.
+
+### 4.3 Singh Table I (parameter-free √mass-ratio closed forms, δ²=3/8)
+√(mτ/mμ) +1.0%; √(m_d/m_e) gen-1 −0.7%; √(mμ/me) −3%; √(mc/mu) +5%; √(ms/md) −7%;
+√(mb/ms) −9%; **√(mt/mc) −26% (miss)**; gen-1 √(mu/me) +26% @MZ. "Few-to-tens of percent,"
+as the paper itself states; precision agreement not claimed.
+
+### 4.4 δ-consistency — the strongest pro-octonion result
+Inverting each ratio (three functional forms, three sectors) for the δ it implies:
+τμ→0.608, sd→0.635, bs→0.612, cu→0.614, tc→0.610. Cluster **0.6155 ± 0.0099** (std/mean 1.6%),
+on top of √(3/8)=0.6124 (0.5% away). **Null model** (200 k random mass ratios, same fixed formulas):
+P(cluster this tight)=10⁻⁴; P(mean this close to √(3/8))=0.036; **P(both) < 1/200 000 (<5×10⁻⁶)**.
+Real fermion masses are *not* random with respect to these octonion formulas.
+
+### 4.5 Cross-sector held-out prediction
+Fit the single δ on the **quark sector only** → δ = **0.6124 ± 0.003 = √(3/8)**. Predict the
+**lepton sector held-out** (zero lepton data): √(mτ/mμ) +1.4%, √(mμ/me) −2.0%. Reverse
+(leptons→quarks): √(mt/mc) −0.4%, √(mc/mu) −10%. Pure group-forced equalities (zero δ):
+Dynkin swap √(mτ/mμ)=√(ms/md) → **8.7% off** (a real miss); trace split √m_e:√m_u:√m_d = 1:2:3
+→ observed 1:2.04:3.02 (good).
+
+### 4.6 Neutrinos — the one surviving forward prediction
+Singh predicts leptonic Jarlskog J_ℓ=0 ⇒ δ_CP ∈ {0, π}. NuFit-6.0 (2024): for **normal
+ordering**, the global fit is consistent with CP conservation within 1σ → **prediction survives**;
+for inverted ordering, δ_CP≈270° is favored at >3.6σ → would refute. Majorana nature untested
+(0νββ only limits). Lightest-ν ≈ massless: consistent with tight cosmological Σm_ν bounds.
+Decisive future arbiter: DUNE / Hyper-Kamiokande.
+
+### 4.7 The residual confound
+The δ-consistency null randomizes the *data*, not Singh's *formula-assignment* (which functional
+form maps to which ratio). That assignment is derived from group theory in the paper but was not
+independently re-derived mass-blind here. The cross-functional-form consistency (one δ across
+three forms) is harder to reverse-engineer than per-ratio fitting, but a full kill requires a
+mass-blind derivation of the assignment + a truly held-out sector.
+
+**Enumeration bound on the assignment freedom (`assignment_enumeration.py`).** Triality forces
+each single-edge adjacent-generation ratio to be one of three ascending edge types
+(`b/a`, `c/a`, `c/b`) on the Sym³(3) triangle, with eigenvalues (c_s−δ, c_s, c_s+δ). Enumerating
+*all* 3⁴ edge assignments for the four single-edge ratios (τ/μ, s/d, c/u, t/c) and demanding a
+single cross-sector δ: only **16 of 81** are even valid (`c/b` always gives δ > c_s); the
+lepton and down ratios are **forced to `c/a`** (the `b/a` alternative implies δ ≈ 0.76, grossly
+inconsistent); and only **two** assignments have δ-spread ≤ 0.02, both landing at δ ≈ √(3/8)
+(0.616, 0.623). The genuine residual freedom is a mild **two-fold (`b/a` vs `c/a`) ambiguity in
+the up sector**, moving δ by ~±0.02 around √(3/8). So the assignment freedom on the single-edge
+ratios is **small and funnels to √(3/8)**, not free to fit arbitrary δ.
+
+### 4.8 The sector centers are the electric charges (recovered mass-blind)
+The remaining structural inputs flagged in §4.7 — the per-sector eigenvalue centers c_s — are
+**not free parameters fit to masses**. Fixing only the single algebraic constant δ=√(3/8) (zero
+mass input for the center) and inverting each single-edge form for the c_s it implies
+(`centers_from_charges.py`):
+
+| ratio | sector | implied c_s | electric charge | dev |
+|---|---|---|---|---|
+| τ/μ | lepton | 1.0073 | 1 | +0.7% |
+| s/d | down | 0.9651 | 1 (electron, via Dynkin swap) | −3.5% |
+| c/u | up | 0.6651 | 2/3 | −0.2% |
+| t/c | up | 0.6698 | 2/3 | +0.5% |
+
+Given δ=√(3/8), the implied centers match electric charges for **two of three** sectors — lepton
+1.007 vs 1 (+0.7%) and up 0.665/0.670 vs 2/3 (~0.1–0.5%). The down sector comes out ≈1, the
+**electron** charge (via the Dynkin swap), **not** its own 1/3 — and partly because center 1/3 < δ
+makes the form invalid, so this is forced by validity, not an independent charge recovery.
+*(And see §4.10: this recovery is conditional on δ being fixed; with δ free the centers and δ are
+co-determined.)* The δ inferred here is δ²≈0.379, **consistent with** 3/8=0.375 at the ~1% level,
+not exactly selected. **Compound (two-edge) ratios** match
+*forward* (δ and centers fixed, zero free parameter): b/s = (c/a)(c/b)|_{c=1} = 6.707 vs 6.690
+(+0.3%); μ/e = (c/a)·(δ+⅓)/(δ−⅓) = 14.10 vs 14.38 (−2.0%) — the (δ±⅓) factor is the Dynkin-swap
+1↔⅓ image (consistent; not independently re-derived here).
+
+**Net after §4.7–4.8:** δ is the algebraic √(3/8); the centers are the electric charges
+(recovered mass-blind to ~1%); the edge assignment is bounded and funnels to √(3/8); compound
+ratios match forward to a few %. The selection confound is now **substantially closed** — the
+free knobs that would have made this "numerology" are pinned to {√(3/8), electric charges}. What
+remains for a full first-principles claim: an independent derivation of the Dynkin-swap (δ±⅓)
+action and a genuinely held-out sector (neutrinos), neither computable today.
+
+### 4.9 Formal obligation and the two-center reconciliation
+`formal/DynkinSwapMassLadder.lean` separates what is **proved** (pure-ℝ algebra) from the one
+**representation-theory obligation** left open. Every algebraic identity is verified symbolically
+in `scripts/dynkin_swap_symbolic.py` (7/7 PASS):
+- Koide closed form `Q(c,δ) = 2δ²/(9c²) + 1/3`, and `Q = 2/3 ⟺ δ² = (3/2)c²`, so **δ² = 3/8 at
+  the diagonal center c = 1/2**.
+- The μ/e swap factor `(δ+⅓)/(δ−⅓)` is exactly the `c/a` edge with **center and spread exchanged**
+  (`caEdge δ ⅓`) — the algebraic signature of the Dynkin Z₂.
+- μ/e and b/s expand to the Table-I closed forms.
+
+**The two-center reconciliation (not a contradiction).** δ²=3/8 appears in two places with
+*different* centers — the diagonal Koide spectrum (center **1/2**) and the edge-ratio ladders
+(centers **1** and **2/3** = charges). These are consistent: the **same** δ = √6/4 simultaneously
+makes the center-1 edge `(1+δ)/(1−δ) = 4.16` match √(mτ/mμ) **and** makes the center-1/2 diagonal
+spectrum Koide-exact (Q = 2/3). One constant, two manifestations, linked through δ — verified
+symbolically. The genuinely open step (stated, not encoded as an axiom): deriving that triality
+*realises* the center↔spread exchange. This is the boundary between strong quantified regularity
+and first-principles law.
+
+### 4.10 Identifiability audit (adversarial — what survives, what doesn't)
+Two break-it tests (`identifiability_audit.py`):
+
+1. **δ is not identified by the masses alone.** §4.8 fixed δ=√(3/8) and then "recovered" the
+   centers — near-circular. Profiling the fit χ²(δ) with the sector centers left **free**: χ²(δ)
+   is **flat** across δ∈[0.40, 0.65] (max/min = 1.0). The lepton and down sectors (one ratio,
+   one free center each) fit *any* δ exactly; the up sector pins only the scale-free ratio
+   **δ/c_U = 0.918 = √(3/8)/(2/3) to 0.1%**, not δ itself. So δ=√(3/8) emerges **only** once the
+   centers are fixed to the electric charges. The honest statement is conditional:
+   *charge-centers ⇒ δ²=3/8*, **not** *masses select δ²=3/8*.
+2. **The charge-center match is selective (not manufactured).** Real masses give centers within
+   1.2% of {1, 1, 2/3}; over 20 000 scrambled mass spectra, **0** land that close. And the
+   5-ratio δ-cluster (given charge-centers) sits at p < 10⁻⁵ vs random (§4.4). So conditional on
+   the charge assignment, the agreement is real and unlikely by chance.
+
+**Reconciled honest claim:** the load-bearing input is the **electric-charge center assignment**
+(physically motivated, external). *Given* it, the fermion masses are consistent with the single
+algebraic constant δ²=3/8, selectively (p<10⁻⁵) and cross-sector-predictively (~2%). Without it,
+δ is unidentified. The remaining first-principles step (deriving the charge↔center and swap
+structure from E₆ triality) is exactly where the content lives — not in the algebra we can already
+prove.
+
+---
+
+## 5. Sounio artifact (reproducibility + formal anchoring)
+
+`examples/physics/octonion_mass_delta.sio` — native Sounio (lean_single) port:
+- §4.4–4.5 reproduced **bit-identically** to the Python reference (δ_quark=0.612100; lepton
+  held-out predictions +1.3% / −2.0%; Dynkin swap 8.3%).
+- Stage-2 uses the verified `algebra::octonion` product (the `NonAssoc` effect tracked by the
+  compiler): |[e1,e2,e4]| = 2.000000 (off-Fano), |[e1,e2,e3]| = 0.000000 (Fano) — the forward
+  direction of `formal/OctonionAssociator.lean`.
+
+Running in Sounio **reproduces, does not improve** the numbers — confirming the throughline of
+the whole arc: the binding constraint was never the tool. Sounio's value here is provenance,
+a formally-verified non-associative algebra, and (next) ISO-GUM uncertainty propagation.
+
+---
+
+## 6. Honest verdict
+
+| Domain | "Octonion has something more"? |
+|---|---|
+| Brain (ABIDE FC) | **No** — robust null (3 tests; tool calibrated at +35) |
+| Octonion as inductive bias | **Yes** — decisive (+35) when data carries the structure |
+| Fermion masses | **Conditional** — *given charge-centers*, masses are consistent with δ²=3/8 (selective, p<10⁻⁵; cross-sector ~2%). δ is **unidentified** without the charge input (§4.10). |
+| Confirmed predictive theory | **Not yet** — assignment not re-derived mass-blind; ~10% misses; single-author |
+
+The honest lesson, repeated at every front: a different tool, algebra, or language does not
+rescue a limit that lives in the data/structure. The 8×8 manifest destroyed the brain signal
+(not the model); the octonion is null on the brain across all embeddings (not a tool failure);
+Sounio reproduces bit-identically (the language changes nothing). Where the octonion genuinely
+has "something more" is where octonions provably live — the fermion mass spectrum — and even
+there the status is *strong, quantified regularity*, not established law.
+
+---
+
+## 7. Methods / code (scratchpad) and key sources
+
+Scripts (numpy/torch reference): `fc_baseline.py`, `fc_vs_octonion.py`, `octonion_positive_control.py`,
+`degree_matched_control.py`, `mlp_baseline.py`, `assoc_ablation.py`, `assoc_ablation_fair.py`,
+`assoc_ablation_fc.py`, `learned_embedding_fc.py`, `koide_jordan_test.py`, `singh_tableI_test.py`,
+`delta_consistency.py`, `heldout_crosssector.py`. Sounio: `examples/physics/octonion_mass_delta.sio`.
+
+Sources: Furey arXiv:1611.09182; Todorov arXiv:2206.06912 (Universe 2023); Singh arXiv:2508.10131;
+G₂ lattice arXiv:1409.8305 (JHEP 03(2015)057); PHM arXiv:2102.08597 (ICLR 2021); quaternion null
+arXiv:2409.00140; NuFit-6.0 arXiv:2410.05380 (JHEP 12(2024)216); Baez "The Octonions" (Bull. AMS 2002).
+
+Pre-registered decision rules were fixed *before* running each ablation; results are reported
+against those rules including where they failed (§3.3 weak readout; §4.3 mt/mc; §4.5 Dynkin swap).


### PR DESCRIPTION
Net-new Sounio physics examples + research write-ups extracted from the `octonion-mass-delta` line — additive, no `self-hosted/` changes.

- **`examples/physics/`**: `jordan_j3o.sio`, `triality_check.sio`, `j3o_mass_spectrum.sio`, `octonion_mass_delta.sio` — all pass `souc check`.
- **`experiments/non_assoc_connectomics/madaros_repros/`**: `m2_f64_cast`, `m3_f64_newton`, `m4_str_from_bytes` (madaros f64 repros) — pass `souc check`.
- **Docs**: `MADAROS_F64_NATIVE_V2_BUGREPORT.md`, `brain_structure_verdict.md`, `octonion_arc_findings.md`.

**Deliberately excluded** (honesty over completeness): the branch's Lean notes (`JordanJ3O`/`Triality` are prose-only with no theorems and self-declare "not machine-checked"; `DynkinSwapMassLadder` imports Mathlib, which the on-main Lean projects don't provide, so it can't be CI-verified), and all 20 Python probes (NumPy/PyTorch/SymPy — Sounio-only science-path policy, CLAUDE.md §4). Provenance of the source branch is preserved via the archive tag created during branch pruning.