### PR TITLE
fix(algebra): declare missing Div effect on cd_exact skeleton functions

### DIFF
--- a/stdlib/algebra/cayley_dickson_exact.sio
+++ b/stdlib/algebra/cayley_dickson_exact.sio
@@ -101,19 +101,19 @@ pub struct CDElementExact<F: ExactRing> {
 
 /// Zero element. `zero` is the ring's additive identity, supplied by the caller
 /// (methods-only trait → no `F::er_zero()`).
-pub fn cd_zero_exact<F: ExactRing>(k: i32, zero: F) -> CDElementExact<F> with Mut, Panic {
+pub fn cd_zero_exact<F: ExactRing>(k: i32, zero: F) -> CDElementExact<F> with Mut, Panic, Div {
     CDElementExact { c: [zero; 2048], bits: k }
 }
 
 /// Real unit e_0 = 1.
-pub fn cd_one_exact<F: ExactRing>(k: i32, zero: F, one: F) -> CDElementExact<F> with Mut, Panic {
+pub fn cd_one_exact<F: ExactRing>(k: i32, zero: F, one: F) -> CDElementExact<F> with Mut, Panic, Div {
     var r = cd_zero_exact::<F>(k, zero)
     r.c[0] = one
     r
 }
 
 /// Basis element e_idx.
-pub fn cd_basis_exact<F: ExactRing>(k: i32, idx: i32, zero: F, one: F) -> CDElementExact<F> with Mut, Panic {
+pub fn cd_basis_exact<F: ExactRing>(k: i32, idx: i32, zero: F, one: F) -> CDElementExact<F> with Mut, Panic, Div {
     var r = cd_zero_exact::<F>(k, zero)
     if idx >= 0 && idx < (1 << k) {
         r.c[idx as usize] = one


### PR DESCRIPTION
Three CD-exact algebra skeleton functions in `stdlib/algebra/cayley_dickson_exact.sio` perform Div-effect operations (`[zero; 2048]` array repetition / struct init) but did not declare `Div`: `cd_zero_exact`, and `cd_one_exact`/`cd_basis_exact` which call it (Div propagation). This declares the effect they genuinely have — needed for certain generic-F instantiations. Absent from main (verified); `souc check` passes on the file. 3-line effect annotation, cherry-picked from the audited `fix/cd-exact-skeleton-effects` branch.