### PR TITLE
ci(release-gate): run the Apple arm64 native typecheck proof against lean.sio, not lean_single

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -111,11 +111,23 @@ jobs:
           "$SOUC_STAGE2" self-hosted/compiler/lean_single.sio "$MACOS_OUT" --target aarch64-macos
           chmod +x "$MACOS_OUT"
           file "$MACOS_OUT" | grep -F "Mach-O 64-bit arm64 executable"
+          # Typecheck-proof compiler: the native typecheck proof harness invokes
+          # `<compiler> --check <fixture>` and greps for E-code diagnostics (E137, ...).
+          # The minimal lean_single seed provides neither `--check` nor E-codes, so the
+          # proof must run against lean.sio — exactly as the x86 source-bootstrap proof
+          # does (ci.yml builds lean.sio -> CHECK_OUT for the same harness). Cross-build
+          # it here and wire it in via SOUC_TYPECHECK_NATIVE below.
+          MACOS_CHECK_OUT=/tmp/souc-lean-check-arm64-macos
+          "$SOUC_STAGE2" self-hosted/compiler/lean.sio "$MACOS_CHECK_OUT" --target aarch64-macos
+          chmod +x "$MACOS_CHECK_OUT"
+          file "$MACOS_CHECK_OUT" | grep -F "Mach-O 64-bit arm64 executable"
       - name: Upload source-bootstrap macOS compiler artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-source-bootstrap-native-compiler-macos-arm64
-          path: /tmp/souc-self-hosted-arm64-macos
+          path: |
+            /tmp/souc-self-hosted-arm64-macos
+            /tmp/souc-lean-check-arm64-macos
           retention-days: 7
       - name: Upload source-bootstrap release artifacts
         if: always()
@@ -144,9 +156,14 @@ jobs:
         run: |
           cp /tmp/source-bootstrap-macos/souc-self-hosted-arm64-macos artifacts/self-hosted/souc-self-hosted-arm64-macos
           chmod +x artifacts/self-hosted/souc-self-hosted-arm64-macos
+          cp /tmp/source-bootstrap-macos/souc-lean-check-arm64-macos artifacts/self-hosted/souc-lean-check-arm64-macos
+          chmod +x artifacts/self-hosted/souc-lean-check-arm64-macos
       - name: Native acceptance gate
         env:
           SOUC_NATIVE: artifacts/self-hosted/souc-self-hosted-arm64-macos
+          # The proof harness needs lean.sio's --check + E-code diagnostics; the
+          # lean_single seed under test (SOUC_NATIVE) has neither. Mirror x86.
+          SOUC_TYPECHECK_NATIVE: artifacts/self-hosted/souc-lean-check-arm64-macos
           WORK_DIR: /tmp/sounio-native-acceptance-macos-arm64
           SOUNIO_MACOS_CRASH_DIAG: "1"
         run: bash scripts/selfhost/selfhost_native_acceptance_gate.sh


### PR DESCRIPTION
The Apple Self-Host job's native typecheck proof invokes `<compiler> --check <fixture>` and greps for E-code diagnostics (E137, …). It was passing the lean_single-derived arm64 binary as the typecheck compiler — but lean_single is the minimal seed: it has **no `--check` flag** (it reads the literal `--check` as a source path) and **never emits E-codes** (`E137` grep in lean_single.sio = 0 hits; its undefined-var error is prose). So the proof could not pass by construction ("missing expected diagnostic").

This mirrors the x86 source-bootstrap proof (ci.yml, which already runs the harness against lean.sio): cross-build `lean.sio → aarch64-macos` and wire it in as `SOUC_TYPECHECK_NATIVE`, keeping lean_single as the `SOUC_NATIVE` compile target under test. Single-file CI change (`.github/workflows/release-gate.yml`, +18/−1), cherry-picked from the audited `fix/apple-selfhost-typecheck-compiler` branch. (Fixes only the `--check`/E137 wiring; a separate arm64 codegen SIGSEGV, if it affects lean.sio at runtime, remains a distinct backend concern.)