### PR TITLE
fix(arm64): add missing print_char builtin to the aarch64 backend

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -29789,6 +29789,22 @@ fn emit_print_char_lit_a64(ch: i64) with Mut {
     em32(0x910043FF)  // add sp, sp, #16
 }
 
+fn emit_print_char_a64() with Mut {
+    // x0 = char value (from compile_or_a64); write its low byte to stdout.
+    em32(0xD1000000 | (16 << 10) | (31 << 5) | 31)  // sub sp, sp, #16
+    em32(0x390003E0)                                 // strb w0, [sp]   (store char byte first)
+    em32(0xD2800020)                                 // movz x0, #1     (fd = stdout)
+    em32(0x910003E1)                                 // mov x1, sp      (buf)
+    em32(0xD2800022)                                 // movz x2, #1     (len = 1)
+    if TARGET_OS == 2 {
+        emit_imm64_reg_a64(16, 4)                    // x16 = 4 (macOS write)
+    } else {
+        em32(0xD2800000 | ((64 & 0xFFFF) << 5) | 8)  // movz x8, #64 (Linux write)
+    }
+    emit_syscall_a64()
+    em32(0x910043FF)  // add sp, sp, #16
+}
+
 fn emit_assert_fail_a64() with Mut {
     em32(0xD2800020)  // movz x0, #1
     if TARGET_OS == 2 {
@@ -31736,6 +31752,22 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
                 if TK[EP as usize] == 7 { EP = EP + 1 }
                 emit_print_int_a64()
                 em32(0xD2800000); EXPR_IS_F64 = 0; EXPR_TY = 5; return
+            }
+            if src_match(ns, ne - ns, "print_char") {
+                if (FN_EFFECTS[CURRENT_FN as usize] & 1) == 0 { tc_effect_violation(name_tok, 1, FN_EFFECTS[CURRENT_FN as usize]) }
+                EP = EP + 1
+                if TK[EP as usize] == 7 {
+                    tc_wrong_arity(name_tok, 1, 0)
+                    EP = EP + 1
+                    em32(0xD2800000)
+                } else {
+                    compile_or_a64()
+                    if EXPR_TY != 0 && EXPR_TY != 1 { tc_error(name_tok, "print_char requires integer argument") }
+                    if TK[EP as usize] == 7 { EP = EP + 1 }
+                    emit_print_char_a64()
+                    em32(0xD2800000)
+                }
+                EXPR_IS_F64 = 0; EXPR_TY = 5; return
             }
             if src_match(ns, ne - ns, "print_f64") {
                 EP = EP + 1; compile_or_a64()


### PR DESCRIPTION
## Root cause

The **aarch64-macOS backend** of `lean_single.sio` implements `print`, `println`, `print_int`, `print_f64`, `print_f64_n` — but **`print_char` is missing entirely**. The x86-64 backend has it (`compile_primary` → `emit_print_char_x86`); the arm64 twin (`compile_primary_a64` dispatcher, ~line 31731) never got it.

On an arm64 build, `print_char` therefore fell through to the unknown-call path:
- `print_char(constant)` → **blank output** (nothing emitted)
- `print_char(array[i])` → **SIGSEGV**

This is the root cause of two long-standing arm64-macOS symptoms:
1. The self-hosted compiler's **"blank identifier name"** — `` E200 `` `` instead of `` E200 `x` `` — because diagnostics print the offending identifier via a `while i<ne { print_char(SRC[i]); i++ }` loop. (Telemetry survived because it uses `print`/`print_int`, which the arm64 backend does implement.)
2. The Release Gate **Apple Self-Host native typecheck-proof SIGSEGV** on the `macos-15` runner.

## Isolation (minimal reproducers, run on Apple Silicon — macOS 27, M-series)

Built via the x86 seed (valid Mach-O), run on-device under SHA-verified transfer:

| probe | pattern | before | after |
|---|---|---|---|
| P4 | `print_int(i)` in loop | `0 1 2` | `0 1 2` |
| P6 | `id(array[i])` sum, exit code | `21` | `21` |
| **P5** | `print_char(65)` in loop | **blank** | **`AAA`** |
| **P3** | `print_char(array[i])` in loop | **SIGSEGV (139)** | **`xyz`** |

P4/P6 passing isolated the fault away from loops, calls, and array-arg passing — leaving `print_char` itself.

## Fix

- Add `emit_print_char_a64()`: single-byte `write(1, &byte, 1)` syscall (macOS `x16=4` / Linux `x8=64`), mirroring `emit_print_char_lit_a64` / `emit_print_nl_a64`, storing `w0` (the `compile_or_a64` result) before clobbering `x0` for the fd.
- Wire a `print_char` handler into the aarch64 dispatcher next to `print_int` (effect + arity + integer-type checks mirroring the x86 twin).

## Verification

- **On-device (Apple Silicon):** P5 blank→`AAA`, P3 SIGSEGV→`xyz`; the full arm64 `lean_single` compiler now prints the identifier name in diagnostics.
- **x86-64:** program output **byte-identical** with/without the change (delta is arm64-only).
- **Self-host:** 5-generation fixed point preserved (`gen2 == gen3`).

## Scope

This fixes the arm64 `print_char` codegen defect (the crash + blank-name). It is independent of, and complementary to, #729 (which wires the Apple typecheck proof to `lean.sio`). A separate arm64 issue remains — the seed cannot yet cross-compile the larger `lean.sio` to aarch64 (unrelated "unknown identifier" resolution failures) — tracked in `docs/handoff/apple_selfhost_release_gate_sigsegv_2026-07-10.md`.
