### PR TITLE
feat(cd-seam): widen ZD characterization to the full box (isZD=hasXorAnnih, anti0=¬isZD) + fix overclaim

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2468,3 +2468,8 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - Providers: xai/grok-4.1 = DONE, all 3 claims hold ("P0_neg_general sign algebra correct; a=0 corner provably empty for every distinct nonzero pair; offSeam stays a loHi device, widening sound"). (Grok garbled one line — said the 49 offSeam mismatches are 'inside loHi'; they are off-locus/both-low+both-high, as the manuscript states.) zai = SKIP (unwired).
 - 2nd lens: #print axioms = [propext, Quot.sound] on all three; dim-16 full-box native_decide regression isZD_eq_hasXorAnnih_box_16 passes; Python cross-check isZD==hasXorAnnih 0 mismatches to dim 64.
 - Verdict: pass. Advisor caught the manuscript full-box overclaim + reframed the target to isZD=hasXorAnnih (not isZD=offSeam).
+
+## 2026-07-10 — operator-side widening (anti0_eq_not_isZD_full), M1 note
+- File: formal/lean4/SounioCDConverse.lean (anti0_eq_not_isZD_full)
+- Corollary of already-reviewed pieces (P0_neg_general, isZD_eq_hasXorAnnih_full, anti0_iff) — no new mechanism. Advisor predicted it holds and it does; empirically anti0 == !isZD on the full box = 0 mismatches (bits 4,5,6); #print axioms = [propext, Quot.sound].
+- M1 discharge: covered by the prior full-box review (same P0_neg_general core) + advisor + kernel + empirical. No separate provider round.

--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2461,3 +2461,10 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - Providers: xai/grok-4.1 = DONE, 3/3 checks pass ("both-low a=4+l and both-high a=llo are non-exceptional; six branches + lt/ge symmetry cover every mixed pair in {1..7}; Q_base depends only on [propext, Quot.sound]"). zai = SKIP (unwired).
 - 2nd lens: Lean kernel #print axioms = [propext, Quot.sound] across Q_base/Q_all/seam_coincidence/converse_conjecture_proved — anchor removed, no native_decide in the ∀n chain.
 - Verdict: pass. Advisor also confirmed statement-identical Q_base (zero drift) + caught the stale "only member anchor-free" claim.
+
+## 2026-07-10 — M1 math-review: widen ZD characterization to full box
+- File: formal/lean4/SounioCDConverse.lean (P0_neg_general, hasXorAnnih_complete_full, isZD_eq_hasXorAnnih_full)
+- Task: verify P(0)=−1 sign algebra; a=0-vacuity argument; that offSeam correctly does NOT widen
+- Providers: xai/grok-4.1 = DONE, all 3 claims hold ("P0_neg_general sign algebra correct; a=0 corner provably empty for every distinct nonzero pair; offSeam stays a loHi device, widening sound"). (Grok garbled one line — said the 49 offSeam mismatches are 'inside loHi'; they are off-locus/both-low+both-high, as the manuscript states.) zai = SKIP (unwired).
+- 2nd lens: #print axioms = [propext, Quot.sound] on all three; dim-16 full-box native_decide regression isZD_eq_hasXorAnnih_box_16 passes; Python cross-check isZD==hasXorAnnih 0 mismatches to dim 64.
+- Verdict: pass. Advisor caught the manuscript full-box overclaim + reframed the target to isZD=hasXorAnnih (not isZD=offSeam).

--- a/docs/papers/cd-tower-seam-obstruction.md
+++ b/docs/papers/cd-tower-seam-obstruction.md
@@ -207,10 +207,11 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   via `Q(c)=P(c)`). Axioms `[propext, Quot.sound]` throughout — **fully anchor-free**: the octonion
   base `Q_base` is proved structurally (`both_low_witness_disagree`/`both_high_witness_disagree`), so
   no `native_decide` appears anywhere in the ∀n chain.
-- **Proved (∀n, FULL box — not just loHi):** the zero-divisor characterization `isZD = hasXorAnnih`
-  for *every* distinct nonzero pair (`1≤l,u<2^n`, `l≠u`) — `isZD_eq_hasXorAnnih_full`, via the general
-  `P0_neg_general` (`P(0)=−1` everywhere makes the `a=0` corner vacuous). `[propext, Quot.sound]`. The
-  geometric `isZD = offSeam` reading stays loHi-only (it is *false* off the locus).
+- **Proved (∀n, FULL box — not just loHi):** the two *intrinsic* zero-divisor characterizations for
+  *every* distinct nonzero pair (`1≤l,u<2^n`, `l≠u`) — `isZD = hasXorAnnih` (`isZD_eq_hasXorAnnih_full`)
+  and `anti0 = ¬isZD` (`anti0_eq_not_isZD_full`), both via the general `P0_neg_general` (`P(0)=−1`
+  everywhere kills the `a=0` corner and collapses the `{0,d}` orbit). `[propext, Quot.sound]`. Only the
+  geometric `isZD = offSeam` reading stays loHi-only — it is *false* off the locus.
 - **Decided (fixed n), retained as fast regressions:** `xorAnnih_eq_isZD_16` (necessity n=4, superseded
   ∀n); `coincidence_16/32` (n=4,5,6 — **all three members now superseded ∀n**: `anti0==!offSeam` /
   `anti0==!isZD` via the coincidence theorems, and `anti0==llsqNegI` `{L_l,L_u}=0 ⟺ (L_lL_u)²=−I` via
@@ -286,14 +287,18 @@ is inherently loHi-specific: `offSeam` only tests the seam element `H`, so it re
 both-low / both-high pair, which is **not** the zero-divisor set off the locus (e.g. `e₁+e₂` in the
 sedenions is off-seam by that test but is *not* a ZD — 49 such mismatches at dim 16 alone). So the naive
 "drop the `loHi` bounds" statement is **false** and is not what widens. What *does* extend to the full
-box is the `hasXorAnnih` characterization: **`isZD = hasXorAnnih` for every distinct nonzero pair**
-(`1 ≤ l,u < 2^n`, `l ≠ u`, ∀n) — `isZD_eq_hasXorAnnih_full`, axioms `[propext, Quot.sound]`. It falls out
-because `annih_forces` is already stated for all pairs and the one loHi-dependent step in the necessity
-proof — the `a=0`/`{0,d}` corner — is **vacuous everywhere**: `P0_neg_general` proves `P(0) = −1` for
-*every* distinct nonzero pair (`cdSigma _ 0 = 1` twice, then two cocycles + `cdSigma_cross_neg`), so no
-annihilator can have low index `0`. Cross-checked `isZD == hasXorAnnih` over the entire box to dim 64
-(0 mismatches; dim-16 anchor `isZD_eq_hasXorAnnih_box_16`). The *geometric* `offSeam` reading stays a
-loHi statement — correctly, since it is false elsewhere.
+box are the two *intrinsic* characterizations: **`isZD = hasXorAnnih`** (the XOR-winner test) and
+**`anti0 = ¬isZD`** (the operator test `{L_l,L_u}=0`), each for every distinct nonzero pair
+(`1 ≤ l,u < 2^n`, `l ≠ u`, ∀n) — `isZD_eq_hasXorAnnih_full` and `anti0_eq_not_isZD_full`, both axioms
+`[propext, Quot.sound]`. They fall out because `annih_forces` is already stated for all pairs and the one
+loHi-dependent step in the necessity proof — the `a=0`/`{0,d}` corner — is **vacuous everywhere**:
+`P0_neg_general` proves `P(0) = −1` for *every* distinct nonzero pair (`cdSigma _ 0 = 1` twice, then two
+cocycles + `cdSigma_cross_neg`), so no annihilator can have low index `0`; the same lemma handles the
+`{0,d}` orbit that makes `anti0` (a `∀c` test) collapse onto `¬hasXorAnnih`. Cross-checked
+`isZD == hasXorAnnih` and `anti0 == ¬isZD` over the entire box to dim 64 (0 mismatches; dim-16 anchor
+`isZD_eq_hasXorAnnih_box_16`). **Only the *geometric* `offSeam` predicate stays loHi-bound** — because it
+merely tests the seam element `H`, it is genuinely false off the locus; the operator and winner readings,
+being intrinsic, are not.
 
 What remains is matching this self-contained result to the literature. In rough order of tractability:
 

--- a/docs/papers/cd-tower-seam-obstruction.md
+++ b/docs/papers/cd-tower-seam-obstruction.md
@@ -144,6 +144,9 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   `{0,d}` orbit that `hasXorAnnih` excludes; on-seam it cannot annihilate (`P0_neg_of_onSeam`), off-seam
   `converse_holds` supplies the real winner. `xorAnnih_eq_isZD_all` then gives the full
   `hasXorAnnih == isZD` on loHi for all n (generalizing the n=4 anchor `xorAnnih_eq_isZD_16`).
+  **Widened past loHi:** `isZD = hasXorAnnih` holds for the *entire* distinct-nonzero box
+  (`isZD_eq_hasXorAnnih_full`, any `1≤l,u<2^n`, `l≠u`, ∀n) — the `a=0` corner is vacuous everywhere
+  (`P0_neg_general`: `P(0)=−1` for every pair), so no loHi hypothesis is needed. See §6.
 - **Forward obstruction `¬offSeam ⟹ ¬isZD` — proved ∀n** (`isZD_eq_offSeam`, in fact `isZD = offSeam`
   on loHi ∀ `bits≥4`). On-seam pairs have no XOR-winner (`hasXorAnnih_false_of_onSeam`: every orbit
   loses, via the edge lemmas + `P0_neg_of_onSeam`), composed with `hasXorAnnih_complete`. A purely
@@ -204,6 +207,10 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   via `Q(c)=P(c)`). Axioms `[propext, Quot.sound]` throughout — **fully anchor-free**: the octonion
   base `Q_base` is proved structurally (`both_low_witness_disagree`/`both_high_witness_disagree`), so
   no `native_decide` appears anywhere in the ∀n chain.
+- **Proved (∀n, FULL box — not just loHi):** the zero-divisor characterization `isZD = hasXorAnnih`
+  for *every* distinct nonzero pair (`1≤l,u<2^n`, `l≠u`) — `isZD_eq_hasXorAnnih_full`, via the general
+  `P0_neg_general` (`P(0)=−1` everywhere makes the `a=0` corner vacuous). `[propext, Quot.sound]`. The
+  geometric `isZD = offSeam` reading stays loHi-only (it is *false* off the locus).
 - **Decided (fixed n), retained as fast regressions:** `xorAnnih_eq_isZD_16` (necessity n=4, superseded
   ∀n); `coincidence_16/32` (n=4,5,6 — **all three members now superseded ∀n**: `anti0==!offSeam` /
   `anti0==!isZD` via the coincidence theorems, and `anti0==llsqNegI` `{L_l,L_u}=0 ⟺ (L_lL_u)²=−I` via
@@ -271,27 +278,36 @@ remaining. (This supersedes the provisional "genuinely hard case, cf. Zhilina" n
 
 ### The next formal steps
 
-**Done — the octonion base is now structural** (was step 1 here): `Q_base` is proved by the six-way
-seam split with no `native_decide`, so the *entire* ∀n chain is anchor-free `[propext, Quot.sound]`.
-What remains is matching this self-contained result to the literature and widening its domain. In
-rough order of tractability:
+**Done — the octonion base is now structural**: `Q_base` is proved by the six-way seam split with no
+`native_decide`, so the *entire* ∀n chain is anchor-free `[propext, Quot.sound]`.
 
-1. **Widen past the `loHi` locus.** The coincidence is stated on lower×upper pairs
-   (`1 ≤ l < 2^{n−1} ≤ u < 2^n`). Empirically the ZD ⟺ off-seam correspondence holds across the *full*
-   distinct-nonzero box (probe to dim 1024); formalizing the both-low / both-high / seam-touching
-   remainder as first-class theorems (not just the inherited-witness lemmas they already are internally)
-   would upgrade the headline from a locus statement to an all-pairs one.
-2. **Verify the Moreno seam-index bridge (§4).** Moreno/BDI state their annihilator on
+**Done — the ZD characterization is widened past the `loHi` locus.** The *coincidence* `isZD = offSeam`
+is inherently loHi-specific: `offSeam` only tests the seam element `H`, so it reads `true` for every
+both-low / both-high pair, which is **not** the zero-divisor set off the locus (e.g. `e₁+e₂` in the
+sedenions is off-seam by that test but is *not* a ZD — 49 such mismatches at dim 16 alone). So the naive
+"drop the `loHi` bounds" statement is **false** and is not what widens. What *does* extend to the full
+box is the `hasXorAnnih` characterization: **`isZD = hasXorAnnih` for every distinct nonzero pair**
+(`1 ≤ l,u < 2^n`, `l ≠ u`, ∀n) — `isZD_eq_hasXorAnnih_full`, axioms `[propext, Quot.sound]`. It falls out
+because `annih_forces` is already stated for all pairs and the one loHi-dependent step in the necessity
+proof — the `a=0`/`{0,d}` corner — is **vacuous everywhere**: `P0_neg_general` proves `P(0) = −1` for
+*every* distinct nonzero pair (`cdSigma _ 0 = 1` twice, then two cocycles + `cdSigma_cross_neg`), so no
+annihilator can have low index `0`. Cross-checked `isZD == hasXorAnnih` over the entire box to dim 64
+(0 mismatches; dim-16 anchor `isZD_eq_hasXorAnnih_box_16`). The *geometric* `offSeam` reading stays a
+loHi statement — correctly, since it is false elsewhere.
+
+What remains is matching this self-contained result to the literature. In rough order of tractability:
+
+1. **Verify the Moreno seam-index bridge (§4).** Moreno/BDI state their annihilator on
    `{L_{e_l}, L_{e_{u'}}}` with `u' = u − top` in `A_{n−1}`; ours is on `{L_l, L_u}` at the `A_n`
    indices. Formalizing the doubling correspondence between the two operator pairs would turn our
    "unchecked matching caveat" into a proved identity — and let the Moreno/BDI ∀n result be *cited as a
    consequence* of `seam_coincidence` rather than merely *paralleled by* it.
-3. **Reach the Zhilina closed form (§4).** Whether the off-seam⟺criterion identity in its published,
+2. **Reach the Zhilina closed form (§4).** Whether the off-seam⟺criterion identity in its published,
    framing (doubly-alternative ZDs / hexagons) coincides with ours remains unconfirmed — the sources are
    paywalled. Access + a definitional bridge would settle the literature-priority question the honest
    ledger currently leaves open.
 
-Item 1 is internal formalization (bounded, no discovery risk); 2–3 depend on external sources.
+Both remaining items depend on external sources.
 
 ## References
 

--- a/formal/lean4/SounioCDConverse.lean
+++ b/formal/lean4/SounioCDConverse.lean
@@ -1282,6 +1282,40 @@ theorem annih_forces (bits l u a b : Nat) (s : Int)
     rcases cdSigma_pm bits l b with h3 | h3 <;> rcases cdSigma_pm bits u b with h4 | h4 <;>
     simp only [hs, h1, h2, h3, h4] at e1 e2 ⊢ <;> revert e1 e2 <;> decide
 
+/-- **`P(0) = −1` for EVERY distinct nonzero pair** (`1≤l,u<2^bits`, `l≠u`) — the general form of the
+    `a=0` corner, with no loHi/on-seam hypotheses.  The `{0,d}` orbit *always* disagrees: the four-sign
+    winner product at `a=0` is `−1`, so `a=0` can never be an annihilator's low index.  Proof is a pure
+    σ-identity: `cdSigma _ 0 = 1` (twice), then the two cocycles `σ(l,d)·σ(l,u)=−1`, `σ(u,d)·σ(u,l)=−1`
+    (`d=l⊕u`, so `l⊕d=u`, `u⊕d=l`) combine with `σ(l,u)·σ(u,l)=−1` (`cdSigma_cross_neg`) to force
+    `σ(l,d)·σ(u,d)=−1`.  No loHi, no `native_decide`.  This is what makes the `isZD ⟹ hasXorAnnih`
+    necessity extend to the *full* distinct-nonzero box (not just loHi): the `a=0` branch is vacuous. -/
+theorem P0_neg_general (bits l u : Nat)
+    (hl1 : 1 ≤ l) (hl : l < 2 ^ bits) (hu1 : 1 ≤ u) (hu : u < 2 ^ bits) (hne : l ≠ u) :
+    cdSigma l 0 bits * cdSigma u 0 bits
+      * cdSigma l (l ^^^ u) bits * cdSigma u (l ^^^ u) bits = -1 := by
+  have hbits : 1 ≤ bits := by
+    cases bits with
+    | zero => rw [Nat.pow_zero] at hl; omega
+    | succ _ => omega
+  have hd : l ^^^ u < 2 ^ bits := Nat.xor_lt_two_pow hl hu
+  have hlxd : l ^^^ (l ^^^ u) = u := by rw [← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+  have huxd : u ^^^ (l ^^^ u) = l := by
+    rw [Nat.xor_comm l u, ← Nat.xor_assoc, Nat.xor_self, Nat.zero_xor]
+  have hc1 := cdSigma_cocycle' bits l (l ^^^ u) hl hd (by omega)
+  rw [hlxd] at hc1
+  have hc2 := cdSigma_cocycle' bits u (l ^^^ u) hu hd (by omega)
+  rw [huxd] at hc2
+  have hcn := cdSigma_cross_neg bits l u hl1 hl hu1 hu hne
+  rw [cdSigma_zero_right bits l (by omega), cdSigma_zero_right bits u (by omega)]
+  rcases cdSigma_pm bits l (l ^^^ u) with h1 | h1 <;>
+  rcases cdSigma_pm bits u (l ^^^ u) with h2 | h2 <;>
+  rcases cdSigma_pm bits l u with h3 | h3 <;>
+  rcases cdSigma_pm bits u l with h4 | h4 <;>
+    rw [h1] at hc1 <;> rw [h2] at hc2 <;> rw [h3] at hc1 hcn <;> rw [h4] at hc2 hcn <;>
+    rw [h1, h2] <;>
+    first | decide | exact absurd hc1 (by decide) | exact absurd hc2 (by decide)
+          | exact absurd hcn (by decide)
+
 /-- **On-seam ⟹ `P(0) = −1`** (the `a = 0` corner).  For an on-seam loHi pair (`offSeam = false`),
     the four-sign winner product at `a = 0` is `−1` — so `a = 0` is NOT a `hasXorAnnih` winner.  Two
     subcases (`u = top` / `l⊕u = top`), each computed from the branch lemmas; no cocycle input beyond
@@ -1396,6 +1430,78 @@ theorem xorAnnih_eq_isZD_all (bits : Nat) (hb : 4 ≤ bits) :
     | true =>
       have hsd := hasXorAnnih_sound bits p.1 p.2 hlt hp4 hne hX
       rw [hI] at hsd; exact absurd hsd (by decide)
+
+-- ══════════════════════════════════════════════════════════════════════════════════════════════════
+-- WIDEN PAST loHi: `isZD = hasXorAnnih` on the FULL distinct-nonzero box, ∀ bits (any `1≤l,u<2^bits`,
+--   `l≠u` — NOT just lower×upper).  The geometric `offSeam` predicate is loHi-specific and does NOT
+--   characterize `isZD` off the locus (e.g. `e₁+e₂` in the sedenions is off-seam by that test but not a
+--   ZD); the correct all-pairs characterization is the `hasXorAnnih` one.  The necessity `isZD ⟹
+--   hasXorAnnih` extends here for free: `annih_forces` is already general, and the `a=0` corner (the only
+--   loHi-dependent step) is VACUOUS everywhere — `P0_neg_general` gives `P(0)=−1` for every pair.
+-- ══════════════════════════════════════════════════════════════════════════════════════════════════
+
+/-- **Necessity `isZD ⟹ hasXorAnnih` on the full box, ∀ bits.**  Every 2-term zero divisor is
+    XOR-linked with sign product `+1`, for *any* distinct nonzero pair (not just loHi).  Same argument
+    as `hasXorAnnih_complete` for the `a≥1` witness (which was never loHi-specific); the `a=0` corner is
+    now dispatched by `P0_neg_general` (`P(0)=−1` always) rather than the off-seam detour. -/
+theorem hasXorAnnih_complete_full (bits l u : Nat)
+    (hl1 : 1 ≤ l) (hl : l < 2 ^ bits) (hu1 : 1 ≤ u) (hu : u < 2 ^ bits) (hne : l ≠ u)
+    (hzd : isZD bits l u = true) : hasXorAnnih bits l u = true := by
+  simp only [isZD] at hzd
+  rw [List.any_eq_true] at hzd
+  obtain ⟨a, ha_mem, hzd⟩ := hzd
+  rw [List.any_eq_true] at hzd
+  obtain ⟨b, hb_mem, hzd⟩ := hzd
+  rw [Bool.and_eq_true, decide_eq_true_eq, Bool.or_eq_true] at hzd
+  obtain ⟨hab_lt, hann⟩ := hzd
+  have hltA : a < 2 ^ bits := List.mem_range.mp ha_mem
+  obtain ⟨s, hannih⟩ : ∃ s : Int, annih bits l u a b s = true := by
+    rcases hann with h | h
+    · exact ⟨1, h⟩
+    · exact ⟨-1, h⟩
+  obtain ⟨hbe, hP⟩ :=
+    annih_forces bits l u a b s hl hu hltA hne (Nat.ne_of_lt hab_lt) hannih
+  rcases Nat.eq_zero_or_pos a with ha0 | hapos
+  · -- a = 0 is VACUOUS: annih_forces gives P(0)=+1, but P0_neg_general says P(0)=−1.
+    subst ha0
+    rw [hbe, Nat.zero_xor] at hP
+    have hneg := P0_neg_general bits l u hl1 hl hu1 hu hne
+    rw [hP] at hneg
+    exact absurd hneg (by decide)
+  · -- a ≥ 1: inject a directly as the XOR-linked winner
+    have hane : a ≠ l ^^^ u := by
+      intro h; rw [h, Nat.xor_self] at hbe; omega
+    rw [hbe] at hP
+    unfold hasXorAnnih
+    refine List.any_eq_true.mpr ⟨a, List.mem_range.mpr hltA, ?_⟩
+    rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq, beq_iff_eq]
+    exact ⟨⟨hapos, hane⟩, hP⟩
+
+/-- **The zero-divisor characterization on the FULL box, ∀ bits** — `isZD = hasXorAnnih` for *every*
+    distinct nonzero basis pair `(l,u)` (`1≤l,u<2^bits`, `l≠u`), not just lower×upper.  Soundness (`⟸`)
+    by `hasXorAnnih_sound`, necessity (`⟹`) by `hasXorAnnih_complete_full`.  So `e_l+e_u` is a 2-term
+    zero divisor **iff** it has a non-exceptional XOR-linked agreeing orbit — the honest all-pairs
+    widening of `xorAnnih_eq_isZD_all` (which was confined to loHi).  Axioms `[propext, Quot.sound]`. -/
+theorem isZD_eq_hasXorAnnih_full (bits l u : Nat)
+    (hl1 : 1 ≤ l) (hl : l < 2 ^ bits) (hu1 : 1 ≤ u) (hu : u < 2 ^ bits) (hne : l ≠ u) :
+    isZD bits l u = hasXorAnnih bits l u := by
+  cases hI : isZD bits l u with
+  | true => exact (hasXorAnnih_complete_full bits l u hl1 hl hu1 hu hne hI).symm
+  | false =>
+    cases hX : hasXorAnnih bits l u with
+    | false => rfl
+    | true =>
+      have hsd := hasXorAnnih_sound bits l u hl hu hne hX
+      rw [hI] at hsd; exact absurd hsd (by decide)
+
+/-- **Full-box regression (decided, dim 16):** `isZD == hasXorAnnih` for *every* distinct nonzero pair
+    in `A_4` — a concrete cross-check of `isZD_eq_hasXorAnnih_full` over the whole box (both-low,
+    both-high, and mixed), complementing the loHi-only `xorAnnih_eq_isZD_16`.  `native_decide`, no
+    `sorry`; a fixed-n anchor, outside the ∀n chain. -/
+theorem isZD_eq_hasXorAnnih_box_16 :
+    ((List.range 16).all (fun l => (List.range 16).all (fun u =>
+      (l == 0) || (u == 0) || (l == u) || (isZD 4 l u == hasXorAnnih 4 l u)))) = true := by
+  native_decide
 
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
 -- TARGET 2 (seam coincidence): anti0 == ! offSeam on the loHi locus, ∀ bits ≥ 4.

--- a/formal/lean4/SounioCDConverse.lean
+++ b/formal/lean4/SounioCDConverse.lean
@@ -1752,6 +1752,72 @@ theorem anti0_eq_offSeam_all (bits : Nat) (hb : 4 ≤ bits) :
   rw [beq_iff_eq]
   exact seam_eq_anti0 bits p.1 p.2 hb hp1 hp2 hp3 hp4
 
+/-- **The OPERATOR characterization also widens: `anti0 = ¬isZD` on the full box, ∀ bits.**  For *every*
+    distinct nonzero pair, `{L_l,L_u}=0` ⟺ `e_l+e_u` is not a zero divisor — no loHi hypothesis.  Unlike
+    the *geometric* `offSeam` (which is loHi-specific and false off the locus), the operator predicate
+    `anti0` is an honest all-pairs ZD detector.  Proof: `anti0 ⟺ ∀c P(c)=−1` (`anti0_iff`), while
+    `¬hasXorAnnih ⟺ ∀ non-exceptional a, P(a)=−1`; the two exceptional orbits `{0,d}` are handled by
+    `P0_neg_general` (`P(0)=P(d)=−1`), so `anti0 = ¬hasXorAnnih = ¬isZD` (`isZD_eq_hasXorAnnih_full`). -/
+theorem anti0_eq_not_isZD_full (bits l u : Nat)
+    (hl1 : 1 ≤ l) (hl : l < 2 ^ bits) (hu1 : 1 ≤ u) (hu : u < 2 ^ bits) (hne : l ≠ u) :
+    anti0 bits l u = ! isZD bits l u := by
+  have hbits : 1 ≤ bits := by
+    cases bits with
+    | zero => rw [Nat.pow_zero] at hl; omega
+    | succ _ => omega
+  have hl0 : l ≠ 0 := by omega
+  have hu0 : u ≠ 0 := by omega
+  -- the {0,d} orbit product is -1 (from P0_neg_general, cancelling the two `cdSigma _ 0 = 1` factors)
+  have hddu : cdSigma l (l ^^^ u) bits * cdSigma u (l ^^^ u) bits = -1 := by
+    have h0 := P0_neg_general bits l u hl1 hl hu1 hu hne
+    rw [cdSigma_zero_right bits l hbits, cdSigma_zero_right bits u hbits,
+        Int.one_mul, Int.one_mul] at h0
+    exact h0
+  rw [isZD_eq_hasXorAnnih_full bits l u hl1 hl hu1 hu hne]
+  cases hX : hasXorAnnih bits l u with
+  | true =>
+    rw [Bool.not_true]
+    cases hA : anti0 bits l u with
+    | false => rfl
+    | true =>
+      exfalso
+      have hall := (anti0_iff bits l u hl0 hu0 hl hu).mp hA
+      unfold hasXorAnnih at hX
+      rw [List.any_eq_true] at hX
+      obtain ⟨a, ha_mem, hpred⟩ := hX
+      rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq, beq_iff_eq] at hpred
+      obtain ⟨⟨_, _⟩, hPa⟩ := hpred
+      have hc := hall a (List.mem_range.mp ha_mem)
+      rw [hPa] at hc
+      exact absurd hc (by decide)
+  | false =>
+    rw [Bool.not_false, anti0_iff bits l u hl0 hu0 hl hu]
+    intro c hc
+    by_cases hc0 : c = 0
+    · subst hc0; rw [Nat.zero_xor]
+      exact P0_neg_general bits l u hl1 hl hu1 hu hne
+    · by_cases hcd : c = l ^^^ u
+      · subst hcd
+        rw [Nat.xor_self, cdSigma_zero_right bits l hbits, cdSigma_zero_right bits u hbits,
+            Int.mul_one, Int.mul_one]
+        exact hddu
+      · have hc1 : 1 ≤ c := by omega
+        have hPc : cdSigma l c bits * cdSigma u c bits
+            * cdSigma l (c ^^^ (l ^^^ u)) bits * cdSigma u (c ^^^ (l ^^^ u)) bits ≠ 1 := by
+          intro hP1
+          have hxt : hasXorAnnih bits l u = true := by
+            unfold hasXorAnnih
+            refine List.any_eq_true.mpr ⟨c, List.mem_range.mpr hc, ?_⟩
+            rw [Bool.and_eq_true, Bool.and_eq_true, decide_eq_true_eq, decide_eq_true_eq, beq_iff_eq]
+            exact ⟨⟨hc1, hcd⟩, hP1⟩
+          rw [hX] at hxt; exact absurd hxt (by decide)
+        rcases cdSigma_pm bits l c with h1 | h1 <;>
+        rcases cdSigma_pm bits u c with h2 | h2 <;>
+        rcases cdSigma_pm bits l (c ^^^ (l ^^^ u)) with h3 | h3 <;>
+        rcases cdSigma_pm bits u (c ^^^ (l ^^^ u)) with h4 | h4 <;>
+          rw [h1, h2, h3, h4] at hPc ⊢ <;>
+          first | rfl | exact absurd rfl hPc
+
 -- ══════════════════════════════════════════════════════════════════════════════════════════════════
 -- THE FULL SEAM COINCIDENCE ON loHi, ∀ bits≥4 — every link now a proved ∀n theorem.
 --   offSeam  ⟺  isZD  ⟺  hasXorAnnih  ⟺  ¬anti0


### PR DESCRIPTION
## Widen the ZD characterization past `loHi` — and fix a false full-box claim

Roadmap step (from #732's §6: "widen past the loHi locus"). **The task as literally stated is partly
impossible, and pursuing it surfaced an overclaim already on `main` — please gate the framing below.**

### The reframing (decision point)

The seam coincidence is stated on the lower×upper locus. The naive reading of "widen" — drop the
`loHi` bounds from `isZD = offSeam` — gives a **false** statement. `offSeam` only tests the seam
element `H` (`u=H` or `l⊕u=H`), so it reads `true` for every both-low/both-high pair, which is *not*
the zero-divisor set off the locus. Concretely `e₁+e₂` in the sedenions is off-seam by that test but is
**not** a zero divisor — **49 such mismatches at dim 16 alone**. So the *geometric* predicate genuinely
does not widen.

What *does* widen are the two **intrinsic** characterizations. Both now proved for **every distinct
nonzero pair** (`1 ≤ l,u < 2^n`, `l ≠ u`, ∀n), axioms `[propext, Quot.sound]`:

| Theorem | Statement |
|---|---|
| `isZD_eq_hasXorAnnih_full` | `isZD = hasXorAnnih` — `e_l+e_u` is a 2-term ZD iff it has a non-exceptional XOR-linked agreeing orbit |
| `anti0_eq_not_isZD_full` | `anti0 = ¬isZD` — `{L_l,L_u}=0` iff `e_l+e_u` is not a ZD (the operator test) |

### Why it's cheap (no recursion needed)

The feared both-low/both-high recursion is unnecessary. `annih_forces` was already stated for all
pairs, and the one loHi-dependent step — the `a=0`/`{0,d}` corner — is **vacuous everywhere**:

- **`P0_neg_general`**: `P(0) = −1` for *every* distinct nonzero pair (`cdSigma _ 0 = 1` twice, then two
  cocycles + `cdSigma_cross_neg`). So no annihilator can have low index `0` — the corner that needed
  `offSeam`+`converse_holds` on loHi just disappears.
- The same lemma handles the `{0,d}` orbit that lets the `∀c` operator test `anti0` collapse onto
  `¬hasXorAnnih`.

### The honesty fix (was on `main` via #732)

§6 previously claimed *"the ZD ⟺ off-seam correspondence holds across the full distinct-nonzero box
(probe to dim 1024)."* That is **false** — the probe only ever scanned loHi; off-seam is not a ZD
detector off the locus. The manuscript now states exactly what holds: the two intrinsic
characterizations widen; only the geometric `offSeam` stays loHi-bound (correctly, since it is false
elsewhere).

### Verification
- `#print axioms`: `P0_neg_general`, `hasXorAnnih_complete_full`, `isZD_eq_hasXorAnnih_full`,
  `anti0_eq_not_isZD_full` all `[propext, Quot.sound]`.
- Empirical cross-check (Python oracle): `isZD == hasXorAnnih` and `anti0 == ¬isZD` over the **entire
  box** to dim 64 — 0 mismatches. Dim-16 `native_decide` regression `isZD_eq_hasXorAnnih_box_16`.
- Math-review via `bin/llm-offload` (grok-4.1): all three core claims hold (P(0) sign algebra; a=0
  vacuity; offSeam correctly does not widen). The operator corollary is derived from these + advisor +
  kernel + empirical. Logged in `.claude/llm_offload_log.md`.
- Advisor: reframed the target (isZD=hasXorAnnih, not isZD=offSeam), caught the full-box overclaim, and
  caught that I'd initially skipped the operator side — leading to `anti0_eq_not_isZD_full`.

### Files
- `formal/lean4/SounioCDConverse.lean` — `P0_neg_general`, `hasXorAnnih_complete_full`,
  `isZD_eq_hasXorAnnih_full`, `anti0_eq_not_isZD_full`, `isZD_eq_hasXorAnnih_box_16`
- `docs/papers/cd-tower-seam-obstruction.md` — overclaim fix + widening (body-only, front-matter untouched)

### Verify
```
export PATH="$HOME/.elan/bin:$PATH"; ulimit -v unlimited
(cd formal/lean4 && lake build SounioCDConverse SounioCDTowerSeam SounioCDCocycle)   # green, no sorry
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
