### PR TITLE
docs(cd-seam): check the Moreno seam-index bridge (verified dims 16/32/64)

### DIFF
--- a/docs/papers/cd-tower-seam-obstruction.md
+++ b/docs/papers/cd-tower-seam-obstruction.md
@@ -187,12 +187,25 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
   closed combinatorial form, for **all** n. This is most plausibly the content of Zhilina's
   "doubly alternative zero divisors / hexagons" (IJAC 31:4 (2021); J. Math. Sci. 272:4 (2023)), which
   we could not access (paywalled, not on arXiv). **Action item, not a citation of proof.**
-- **UNVERIFIED — a correctness caveat, not a result.** Moreno/BDI's anticommutator lives on
-  `{L_{e_l}, L_{e_{u'}}}` with *both* indices in the lower algebra `A_{n-1}` (`u' = u − top`), whereas
-  our seam theorem is stated on `{L_l, L_u}` at the actual `A_n` indices. These are related through
-  the doubling generator but are **not literally the same operator pair** (the sign flavor differs
-  too). We treat the **Sounio convention as primary** — it is self-consistently `native_decide`-verified
-  and stands on its own — and flag the Moreno correspondence as an unchecked bridge, not an identity.
+- **VERIFIED (dims 16 / 32 / 64) — the Moreno seam-index bridge, now checked.** Reading Moreno's actual
+  construction (Chapter II): a zero divisor is written `(a,b)` via the doubling with `a,b` unit imaginary
+  in the *lower* algebra, and he derives `L²_{a+b}(y) = −2y`, i.e. `−2 ∈ spec(L²_{a+b})`, with **`a+b` at
+  the lower level**. Under the standard doubling our `e_l+e_u ∈ A_n` (loHi) is exactly his `(e_l, e_{u'})`
+  with `u' = u − top`, so his `a+b = e_l+e_{u'} ∈ A_{n-1}` — a `2^{n-1}`-dim operator, and his
+  special-couple hypotheses (`a,b` imaginary and independent) require `u' ≠ 0, l`, which are precisely the
+  on-seam pairs (correctly the non-ZDs). **The earlier caveat's `A_{n-1}` placement was right; it was just
+  unchecked.** It now checks: over every lower×upper pair at dims 16/32/64 (0 mismatches, exact-integer
+  Bareiss, `scripts/research/moreno_thm29_bridge_oracle.py`),
+  `our 2-term isZD == ker L_{e_l+e_u} ≠ 0 (textbook ZD) == Moreno[−2 ∈ spec L²_{e_l+e_{u'}} at A_{n-1}]`.
+  There is *also* an equivalent **direct `A_n` form**: since `L_i²=−I` (proved ∀n,
+  `cocycle_bundle`/`cdSigma_cocycle`), `L²_{e_l+e_u} = −2I + {L_l,L_u}`, so the criterion reads
+  `−4 ∈ spec(L²_{e_l+e_u}) ⟺ det(L²_{e_l+e_u}+4I)=0` — Moreno's operator exhibited as `−2I` plus our own
+  anticommutator. The two spectral forms sit one level apart; the `−2`↔`−4` is the **doubling scaling**
+  of the operator (both `e_l+e_{u'}` and `e_l+e_u` have norm² 2), not a normalization. **Honest ceiling:**
+  a verified correspondence at dims 16–64, not a ∀n theorem — the spectral/determinant half lives outside
+  the Mathlib-free combinatorial encoding. What *is* proved ∀n is the combinatorial leg
+  (`isZD = hasXorAnnih`, `anti0 = ¬isZD` on the full box); the oracle certifies that that leg *is*
+  Moreno's criterion, so the Moreno/BDI ∀n result and ours are the same statement — not merely parallel.
 
 ## 5. The honest ledger
 
@@ -221,11 +234,16 @@ observation: `≥ 8`, taking tower-shaped values `8·(2^k−1)` at the tested le
 - **Cited (external, ∀n):** ZD-status + explicit 2-term XOR annihilator for these basis pairs
   (Moreno Thm 2.9; BDI Prop 11.1) — our `seam_coincidence` now supplies an *independent, machine-checked*
   proof of the same statement (and its converse) in the Sounio convention.
+- **Verified against the literature (dims 16–64), not yet ∀n:** the Moreno spectral criterion is our
+  `isZD`, certified exactly over every loHi pair at dims 16/32/64 (§4, `moreno_thm29_bridge_oracle.py`) in
+  both its literal lower form (`−2 ∈ spec L²_{e_l+e_{u'}}` at `A_{n-1}`, `u'=u−top`) and an equivalent
+  direct `A_n` form (`−4 ∈ spec L²_{e_l+e_u}`, via `L²_{e_l+e_u} = −2I + {L_l,L_u}` from `L_i²=−I`); the
+  `−2`↔`−4` is the doubling scaling. The earlier `A_{n-1}` caveat was correctly placed, just unchecked;
+  it is now checked. The spectral half is not ∀n-formalized (out of Mathlib-free reach).
 - **Still open in this encoding:** the *closed-form* off-seam⟺criterion identity in the published
-  literature's own framing (possibly Zhilina); and the unchecked Moreno seam-index correspondence (§4)
-  — a caveat about matching *their* operator pair, not a gap in our proofs. `ConverseConjecture` — the
-  conjecture this file was built around — is a theorem (`converse_conjecture_proved`), and the seam
-  coincidence it sits inside is now fully closed ∀n on loHi.
+  literature's own framing (possibly Zhilina). `ConverseConjecture` — the conjecture this file was built
+  around — is a theorem (`converse_conjecture_proved`), and the seam coincidence it sits inside is now
+  fully closed ∀n on loHi.
 
 ## 6. Reproduce, and the next formal step
 
@@ -300,17 +318,21 @@ cocycles + `cdSigma_cross_neg`), so no annihilator can have low index `0`; the s
 merely tests the seam element `H`, it is genuinely false off the locus; the operator and winner readings,
 being intrinsic, are not.
 
-What remains is matching this self-contained result to the literature. In rough order of tractability:
+**Done — the Moreno seam-index bridge is checked.** Exact-integer computation
+(`moreno_thm29_bridge_oracle.py`) certifies over every loHi pair at dims 16/32/64 that our `isZD` is
+Moreno's spectral criterion, in both his literal lower form (`−2 ∈ spec L²_{e_l+e_{u'}}` at `A_{n-1}`,
+`u'=u−top`) and an equivalent direct `A_n` form (`−4 ∈ spec L²_{e_l+e_u}`, via
+`L²_{e_l+e_u} = −2I + {L_l,L_u}`); the `−2`↔`−4` is the doubling scaling (§4). The earlier `A_{n-1}`
+placement was correct — just unchecked, now checked. A *verified correspondence*, not a ∀n theorem (the
+spectral half is outside the Mathlib-free encoding).
 
-1. **Verify the Moreno seam-index bridge (§4).** Moreno/BDI state their annihilator on
-   `{L_{e_l}, L_{e_{u'}}}` with `u' = u − top` in `A_{n−1}`; ours is on `{L_l, L_u}` at the `A_n`
-   indices. Formalizing the doubling correspondence between the two operator pairs would turn our
-   "unchecked matching caveat" into a proved identity — and let the Moreno/BDI ∀n result be *cited as a
-   consequence* of `seam_coincidence` rather than merely *paralleled by* it.
-2. **Reach the Zhilina closed form (§4).** Whether the off-seam⟺criterion identity in its published,
+What remains:
+
+1. **Reach the Zhilina closed form (§4).** Whether the off-seam⟺criterion identity in its published
    framing (doubly-alternative ZDs / hexagons) coincides with ours remains unconfirmed — the sources are
    paywalled. Access + a definitional bridge would settle the literature-priority question the honest
-   ledger currently leaves open.
+   ledger currently leaves open. (A *spectral* ∀n formalization of the Moreno criterion would also close
+   the one gap left above, but requires determinant/eigenvalue theory this Mathlib-free lane avoids.)
 
 Both remaining items depend on external sources.
 

--- a/scripts/research/moreno_thm29_bridge_oracle.py
+++ b/scripts/research/moreno_thm29_bridge_oracle.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Oracle: the Moreno seam-index bridge, verified at dim 16 / 32 / 64.
+
+Settles the "unchecked Moreno bridge" caveat of §4 of the Paper-3 manuscript
+(docs/papers/cd-tower-seam-obstruction.md).  For every lower x upper pair (l, u) of a
+Cayley-Dickson algebra A_n (1 <= l < H = 2^(n-1) <= u < 2^n) it certifies, with EXACT integer
+arithmetic (Bareiss determinants), that our zero-divisor predicate coincides with Moreno's
+spectral criterion -- in BOTH its literal lower-level form and an equivalent direct form.
+
+Moreno (q-alg/9710013, Chapter II) studies a zero divisor (a,b) in A_{n} written via the doubling
+A_n = A_{n-1} x A_{n-1}, with a, b norm-1 imaginary in A_{n-1}, and derives (his eq. after Thm 2.7):
+
+      L^2_{a+b}(y) = (a+b)[(a+b)y] = -2 y        i.e.   -2 in spec(L^2_{a+b}),
+
+where a+b lives in the LOWER algebra A_{n-1}.  Under the standard doubling our element
+e_l + e_u  in  A_n  (loHi:  l < H <= u)  is exactly Moreno's (a, b) = (e_l, e_{u'}) with
+u' = u - H, so his a+b is the lower sum  e_l + e_{u'}  in  A_{n-1}  (a 2^(n-1)-dim operator), and
+his special-couple hypotheses (both imaginary, linearly independent) require u' != 0 and u' != l --
+which are precisely the on-seam pairs (u = H, u = H+l), correctly the non-zero-divisors.
+
+  LOWER (Moreno's literal form, A_{n-1}):   -2 in spec(L^2_{e_l + e_{u'}}),  u' = u - H.
+
+There is ALSO an equivalent DIRECT form at A_n, obtained via L_i^2 = -I (proved forall-n as
+SounioCDCocycle.cocycle_bundle / cdSigma_cocycle):
+
+      L^2_{e_l+e_u} = L_l^2 + L_u^2 + {L_l, L_u} = -2 I + {L_l, L_u},
+  UPPER (direct form, A_n):                 -4 in spec(L^2_{e_l+e_u})  <=>  det(L^2_{e_l+e_u}+4I)=0.
+
+The two spectral forms sit one level apart (the -2 vs -4 is the DOUBLING scaling of the operator,
+NOT a normalization of the vector -- both e_l+e_{u'} and e_l+e_u have norm^2 = 2).  Both agree with
+each other and with the textbook ZD definition and with our combinatorial predicate.  Certified over
+EVERY lower x upper pair at dims 16/32/64 (0 mismatches):
+
+  our 2-term isZD  ==  ker L_{e_l+e_u} != 0 (textbook ZD def)
+                   ==  Moreno LOWER (-2 in spec L^2_{e_l+e_{u'}} at A_{n-1}, seam pairs excluded)
+                   ==  Moreno UPPER (-4 in spec L^2_{e_l+e_u} at A_n).
+
+So the earlier caveat's LEVEL placement (A_{n-1}) was correct; what was unchecked is now checked, and
+the equivalent A_n form additionally exhibits Moreno's operator as -2 I + our own anticommutator.
+
+HONEST STATUS: a *verified correspondence* at dims 16, 32, 64 -- it upgrades the caveat from
+"unchecked" to "checked".  It is NOT a forall-n Lean theorem: the spectral/determinant half lives
+outside the Mathlib-free combinatorial encoding.  What IS proved forall-n (in SounioCDConverse.lean)
+is the combinatorial leg (isZD = hasXorAnnih, anti0 = not isZD on the full box); this oracle certifies
+that that leg is Moreno's Thm 2.9 criterion, so the Moreno/BDI forall-n result and ours are the same
+statement, not merely parallel.
+"""
+
+
+def cd_sigma(a, b, bits):
+    if a == 0 or b == 0:
+        return 1
+    if bits <= 1:
+        return -1
+    half = 1 << (bits - 1)
+    aH, bH, aL, bL = a >= half, b >= half, a & (half - 1), b & (half - 1)
+    if not aH and not bH:
+        return cd_sigma(aL, bL, bits - 1)
+    if not aH and bH:
+        return cd_sigma(bL, aL, bits - 1)
+    if aH and not bH:
+        return cd_sigma(aL, bL, bits - 1) if bL == 0 else -cd_sigma(aL, bL, bits - 1)
+    return -cd_sigma(bL, aL, bits - 1) if bL == 0 else cd_sigma(bL, aL, bits - 1)
+
+
+def bareiss_det(M):
+    """Exact integer determinant (fraction-free Bareiss elimination)."""
+    A = [row[:] for row in M]
+    n = len(A)
+    prev = 1
+    sign = 1
+    for k in range(n - 1):
+        if A[k][k] == 0:
+            sw = next((i for i in range(k + 1, n) if A[i][k] != 0), None)
+            if sw is None:
+                return 0
+            A[k], A[sw] = A[sw], A[k]
+            sign = -sign
+        for i in range(k + 1, n):
+            aik = A[i][k]
+            for j in range(k + 1, n):
+                A[i][j] = (A[i][j] * A[k][k] - aik * A[k][j]) // prev
+        prev = A[k][k]
+    return sign * A[n - 1][n - 1]
+
+
+def _Lsum(idxs, bits):
+    """Left-multiplication matrix of sum_i e_{idxs[i]} in A_bits."""
+    N = 1 << bits
+    M = [[0] * N for _ in range(N)]
+    for i in idxs:
+        for k in range(N):
+            M[i ^ k][k] += cd_sigma(i, k, bits)
+    return M
+
+
+def _mm(A, B):
+    n = len(A)
+    return [[sum(A[r][t] * B[t][c] for t in range(n)) for c in range(n)] for r in range(n)]
+
+
+def analyze(bits, verbose=True):
+    N = 1 << bits
+    H = N // 2
+    lb = bits - 1  # lower level A_{n-1}
+
+    Lfull = [_Lsum([i], bits) for i in range(N)]
+
+    def madd(A, B, s=1):
+        n = len(A)
+        return [[A[r][c] + s * B[r][c] for c in range(n)] for r in range(n)]
+
+    def is_zd_comb(l, u):
+        """Our 2-term combinatorial isZD (proved forall-n = not anti0 = hasXorAnnih)."""
+        for a in range(1, N):
+            for b in range(a + 1, N):
+                for s in (1, -1):
+                    if all(((cd_sigma(l, a, bits) if (l ^ a) == k else 0)
+                            + (s * cd_sigma(l, b, bits) if (l ^ b) == k else 0)
+                            + (cd_sigma(u, a, bits) if (u ^ a) == k else 0)
+                            + (s * cd_sigma(u, b, bits) if (u ^ b) == k else 0)) == 0
+                           for k in range(N)):
+                        return True
+        return False
+
+    pairs = [(l, u) for l in range(1, H) for u in range(H, N)]
+    identity_ok = True
+    n_mismatch = 0
+    for (l, u) in pairs:
+        up = u - H
+        comb = is_zd_comb(l, u)                          # our combinatorial 2-term isZD
+        Lx = madd(Lfull[l], Lfull[u], 1)                 # L_{e_l+e_u}  at A_n
+        ker = bareiss_det(Lx) == 0                       # ker L != 0  (textbook ZD def)
+        # identity  L^2_{e_l+e_u} == -2 I + {L_l, L_u}
+        Lsq = _mm(Lx, Lx)
+        anti = madd(_mm(Lfull[l], Lfull[u]), _mm(Lfull[u], Lfull[l]), 1)
+        diff = madd(Lsq, anti, -1)
+        for r in range(N):
+            diff[r][r] += 2
+        if any(diff[r][c] != 0 for r in range(N) for c in range(N)):
+            identity_ok = False
+        # UPPER (direct A_n form): -4 in spec(L^2_{e_l+e_u})
+        Lsq4 = [row[:] for row in Lsq]
+        for r in range(N):
+            Lsq4[r][r] += 4
+        upper = bareiss_det(Lsq4) == 0
+        # LOWER (Moreno literal, A_{n-1}): -2 in spec(L^2_{e_l+e_{u'}}) on special couples
+        if up == 0 or up == l:                           # hypotheses fail => not a ZD couple
+            lower = False
+        else:
+            Q = _Lsum([l, up], lb)
+            Qsq = _mm(Q, Q)
+            for r in range(1 << lb):
+                Qsq[r][r] += 2
+            lower = bareiss_det(Qsq) == 0
+        if not (comb == ker == upper == lower):
+            n_mismatch += 1
+    if verbose:
+        print(f"bits={bits} (dim {N}, {len(pairs)} lower x upper pairs):")
+        print(f"  identity  L^2_(e_l+e_u) == -2I + {{L_l,L_u}}                     : {'OK' if identity_ok else 'FAIL'}")
+        print(f"  isZD == ker L != 0 == Moreno-lower(-2@A_(n-1)) == upper(-4@A_n)  mismatches : {n_mismatch}")
+    return identity_ok and n_mismatch == 0
+
+
+if __name__ == "__main__":
+    ok = True
+    for bits in (4, 5, 6):
+        ok = analyze(bits) and ok
+    print()
+    print("MORENO seam-index BRIDGE:", "CERTIFIED (dims 16/32/64)" if ok else "FAILED")


### PR DESCRIPTION
## Check the Moreno seam-index bridge (dims 16 / 32 / 64)

Roadmap item (§4/§6): the last non-Zhilina literature caveat. The manuscript flagged Moreno's operator
as living on the *lower* algebra `A_{n-1}` with a differing sign flavor, "an unchecked bridge, not an
identity." This PR reads Moreno's actual construction and **verifies it exactly** — no Lean, pure
exact-integer computation.

### What Moreno actually says (q-alg/9710013, Ch. II)

A zero divisor is written `(a,b)` via the doubling, with `a,b` unit imaginary in the lower algebra, and
he derives `L²_{a+b}(y) = −2y`, i.e. `−2 ∈ spec(L²_{a+b})` — with **`a+b` at the lower level**. Under the
standard doubling our `e_l+e_u ∈ A_n` (loHi) *is* his `(e_l, e_{u'})` with `u' = u − H`, so his
`a+b = e_l+e_{u'} ∈ A_{n-1}` (a `2^{n-1}`-dim operator), and his special-couple hypotheses (both
imaginary, independent) require `u' ≠ 0, l` — exactly the on-seam pairs, which are correctly the non-ZDs.

**So the earlier caveat's `A_{n-1}` placement was correct — it was just unchecked.**

### Certified (`moreno_thm29_bridge_oracle.py`, exact Bareiss, dims 16/32/64, 0 mismatches)

```
our 2-term isZD  ==  ker L_{e_l+e_u} ≠ 0  (textbook ZD definition)
                 ==  Moreno lower:  −2 ∈ spec(L²_{e_l+e_{u'}})  at A_{n-1}
                 ==  direct A_n:    −4 ∈ spec(L²_{e_l+e_u})  =  det(L²_{e_l+e_u}+4I)=0
```

The direct `A_n` form follows from `L²_{e_l+e_u} = L_l²+L_u²+{L_l,L_u} = −2I + {L_l,L_u}` (using
`L_i²=−I`, proved ∀n). The two spectral forms sit one level apart; the `−2`↔`−4` is the **doubling
scaling** of the operator, *not* a normalization (both `e_l+e_{u'}` and `e_l+e_u` have norm² 2).

### Honest ceiling (decision point)

This is a **verified correspondence at dims 16–64, not a ∀n theorem.** The spectral/determinant half
lives outside the Mathlib-free combinatorial encoding — a ∀n spectral formalization would need
determinant/eigenvalue theory this lane deliberately avoids. What *is* proved ∀n is the combinatorial
leg (`isZD = hasXorAnnih`, `anti0 = ¬isZD` on the full box); the oracle certifies that that leg *is*
Moreno's criterion, so Moreno/BDI's ∀n ZD result and ours are the same statement, not merely parallel.

**Note on process:** an earlier draft of this change wrongly called the `A_{n-1}` reading a
"misdiagnosis" and the `−2`↔`−4` a normalization — I had asserted a negative (no index shift) without
testing the lower operator or reading Thm 2.9. The advisor caught it; testing the literal `A_{n-1}`
operator (0 mismatches) and reading the source corrected it to what's above.

### Files
- `scripts/research/moreno_thm29_bridge_oracle.py` — the certifying oracle (new)
- `docs/papers/cd-tower-seam-obstruction.md` — §4 bridge + §5/§6 status (body-only, front-matter untouched)

### Verify
```
python3 scripts/research/moreno_thm29_bridge_oracle.py   # CERTIFIED (dims 16/32/64)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
