### PR TITLE
fix(arm64): enum-variant path typing (EXPR_TY=7) — #740 factor 3

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -31734,7 +31734,18 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
             let disc = en_variant_value(eh, vh)
             if disc >= 0 {
                 emit_imm64_a64(disc)
+                // Consume trailing () if present (unit variants written E::A())
+                if TK[EP as usize] == 6 {
+                    EP = EP + 1
+                    if TK[EP as usize] == 7 { EP = EP + 1 }
+                }
+                // Parity with the x86-64 twin (~11749): an enum-variant path has
+                // enum type (EXPR_TY=7, hash=eh). The arm64 handler left EXPR_TY
+                // stale, so a variant arg inherited the previous arg's type (e.g. a
+                // preceding &! ref) -> E001 (want enum, got ref).
                 EXPR_IS_F64 = 0
+                EXPR_TY = 7
+                EXPR_TY_HASH = eh
                 return
             }
             if TK[EP as usize] != 6 {


### PR DESCRIPTION
## arm64 enum-variant path typing (#740 factor 3)

The arm64 enum-variant handler (`compile_primary_a64`, the `::` path) emitted the variant discriminant and set `EXPR_IS_F64=0` but **never set `EXPR_TY`/`EXPR_TY_HASH`** — so an enum-variant path (`E::A`) inherited the *previous* expression's type. Passing it as an argument after a ref arg (e.g. `own_add_error(ctx: &!OwnContext, kind, ...)`) made the enum arg inherit the ref type → E001 (want enum(7), got ref(10)).

Same class as the string-literal fix (#744): a value-producing handler that forgot to set its own `EXPR_TY`, leaking the prior expression's type. The x86-64 twin (~11749) sets `EXPR_TY=7, EXPR_TY_HASH=eh`; mirrored it (plus the trailing-`()` consumption for unit variants written `E::A()`).

## Verification
- Minimal repro `take2(&!ctx, E::A)` (ref arg before the enum-variant arg) now compiles clean on aarch64 (was E001).
- **x86-64 program output byte-identical** (arm64-only delta).
- **5-generation self-host fixed point preserved.**
- Enum-by-value calls still clean (no regression).
- lean.sio arm64 errors **914 → 642** (same-timeout apples-to-apples, **−272**).

## Scope
Third factor toward the #740 cascade (after #744's field-borrow + string-literal). Progression: 1439 (baseline) → 914 (#744) → **642** (this). Remaining is further enum/generic type-hash parity, tracked in #740.
