### PR TITLE
fix(arm64): str_len/str_char_at EXPR_TY — close EXPR_TY-leak class (#740 factor 4)

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -32220,7 +32220,7 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
             if src_match(ns, ne - ns, "str_len") {
                 EP = EP + 1; compile_or_a64()
                 if TK[EP as usize] == 7 { EP = EP + 1 }
-                emit_str_len_a64(); EXPR_IS_F64 = 0; return
+                emit_str_len_a64(); EXPR_IS_F64 = 0; EXPR_TY = 1; return
             }
             if src_match(ns, ne - ns, "slice_len") {
                 EP = EP + 1; compile_or_a64()
@@ -32236,7 +32236,7 @@ fn compile_primary_a64() with IO, Mut, Panic, Div {
                 emit_pop_x1_a64()
                 em32(0x38A06820)  // ldrsb x0, [x1, x0]
                 if TK[EP as usize] == 7 { EP = EP + 1 }
-                EXPR_IS_F64 = 0; return
+                EXPR_IS_F64 = 0; EXPR_TY = 1; return
             }
             if src_match(ns, ne - ns, "sqrt") || src_match(ns, ne - ns, "sin") || src_match(ns, ne - ns, "cos") || src_match(ns, ne - ns, "exp") || src_match(ns, ne - ns, "ln") || src_match(ns, ne - ns, "log") {
                 EP = EP + 1


### PR DESCRIPTION
## Close the `EXPR_TY`-leak class in the arm64 walker (#740 factor 4)

Systematic sweep of `compile_primary_a64` for the bug pattern behind #744 (string literal) and #746 (enum variant): a **value-producing handler that returns without setting `EXPR_TY`**, so its result silently inherits the previous expression's type — which, in an argument position after a differently-typed arg, causes a spurious E001.

Found the remaining two: **`str_len`** and **`str_char_at`** both emit an integer result and set `EXPR_IS_F64=0` but never `EXPR_TY`. The x86 twins set `EXPR_TY=1`; mirrored.

Swept the rest and confirmed the class is closed:
- All literals set their type (int=1, bool=4, float=2), plus enum-variant (#746) and string-literal (#744).
- The other value builtins (`heap_*`, `read/write_*`, `sqrt/sin/cos`, `parse_*`, `slice_len`) **match the x86 twin** — neither sets `EXPR_TY`, both rely on `EXPR_IS_F64` — so no divergence.

## Verification
- lean.sio arm64 **642 → 633** (same-timeout apples-to-apples).
- **x86-64 program output byte-identical.**
- **5-generation self-host fixed point preserved.**

## Scope
Fourth factor toward #740, and the last of the `EXPR_TY`-leak class (which accounted for the two biggest drops: string −467, enum −272). Progression: 1439 → 914 (#744) → 642 (#746) → **633** (this). The remaining ~633 are a different class ('requires' + non-leak type mismatches), tracked in #740.
