### PR TITLE
test(ossm/ekan): native O-SSM sigmoid-polarity + E-KAN fixed-point gates

### DIFF
--- a/examples/brain_ossm_abide.sio
+++ b/examples/brain_ossm_abide.sio
@@ -49,6 +49,7 @@ var CFG_OCT_ASSOC_SCHEDULE_END_BP: i64 = 0
 var CFG_OCT_ASSOC_DRIFT_REG_BP: i64 = 0
 var CFG_OCT_HEAD_TRUST_REGION_BP: i64 = 0
 var CFG_OCT_HEAD_RENORM: i64 = 1
+var CFG_OCT_ASSOCIATIVE_PROJECTION: i64 = 0
 var CFG_OCT_INPUT_PROJ_MODE: i64 = 0
 var CFG_OCT_PROJ_LR_SCALE_BP: i64 = 600000
 var CFG_OCT_PROJ_STRUCTURED_SCALE_BP: i64 = 350000
@@ -61,6 +62,7 @@ var CFG_H_WARMUP_EPOCHS: i64 = 0
 var CFG_H_INIT_PRESET: i64 = 0
 var CFG_H_INPUT_PROJ_MODE: i64 = 0
 var CFG_H_PROJ_LR_SCALE_BP: i64 = 600000
+var CFG_TRACE_HIDDEN_STATE: i64 = 0
 var TRAIN_MASK: [i64; 2048] = [0; 2048]
 var DROP_MASK: [i64; 64] = [0; 64]
 var FOLD_NOISE_KEY: i64 = 0
@@ -160,7 +162,7 @@ fn f64_to_bp(v: f64) -> i64 {
     if scaled > 1000000.0 { 1000000 } else { scaled as i64 }
 }
 
-fn scaled_keep_count(total: i64, bp: i64) -> i64 with Div {
+fn scaled_keep_count(total: i64, bp: i64) -> i64 with Mut, Div {
     if total <= 0 { return 0 }
     if bp >= 1000000 { return total }
     var keep = (total * bp + 500000) / 1000000
@@ -344,7 +346,7 @@ fn scheduled_assoc_target() -> f64 with Div {
     }
 }
 
-fn scaled_optional_count(total: i64, bp: i64) -> i64 with Div {
+fn scaled_optional_count(total: i64, bp: i64) -> i64 with Mut, Div {
     if total <= 0 || bp <= 0 { return 0 }
     if bp >= 1000000 { return total }
     var keep = (total * bp + 500000) / 1000000
@@ -472,6 +474,7 @@ fn load_run_config(path: string) -> i64 with IO, Mut, Panic, Div {
     CFG_OCT_ASSOC_DRIFT_REG_BP = 0
     CFG_OCT_HEAD_TRUST_REGION_BP = 0
     CFG_OCT_HEAD_RENORM = 1
+    CFG_OCT_ASSOCIATIVE_PROJECTION = 0
     CFG_OCT_INPUT_PROJ_MODE = 0
     CFG_OCT_PROJ_LR_SCALE_BP = 600000
     CFG_OCT_PROJ_STRUCTURED_SCALE_BP = 350000
@@ -545,6 +548,11 @@ fn load_run_config(path: string) -> i64 with IO, Mut, Panic, Div {
             pos = line_end
             continue
         }
+        if starts_with(line, "oct_associative_projection=") {
+            CFG_OCT_ASSOCIATIVE_PROJECTION = parse_i64_basic(str_slice(line, 27, line_n))
+            pos = line_end
+            continue
+        }
         if starts_with(line, "oct_input_proj_mode=") {
             CFG_OCT_INPUT_PROJ_MODE = parse_i64_basic(str_slice(line, 20, line_n))
             pos = line_end
@@ -577,6 +585,15 @@ fn load_run_config(path: string) -> i64 with IO, Mut, Panic, Div {
         }
         if starts_with(line, "h_proj_lr_scale=") {
             CFG_H_PROJ_LR_SCALE_BP = f64_to_bp(parse_f64_basic(str_slice(line, 16, line_n)))
+            pos = line_end
+            continue
+        }
+        if starts_with(line, "trace_hidden_state=") {
+            if parse_i64_basic(str_slice(line, 19, line_n)) != 0 {
+                CFG_TRACE_HIDDEN_STATE = 1
+            } else {
+                CFG_TRACE_HIDDEN_STATE = 0
+            }
             pos = line_end
             continue
         }
@@ -1313,7 +1330,7 @@ fn prepare_train_standardization() with Mut, Div, Panic {
     }
 }
 
-fn perturb_feature(subj: i64, step: i64, dim: i64, value: f64) -> f64 with Div {
+fn perturb_feature(subj: i64, step: i64, dim: i64, value: f64) -> f64 with Mut, Div {
     var out = value
     if dim < 64 && DROP_MASK[dim as usize] == 1 {
         out = 0.0
@@ -1337,7 +1354,32 @@ fn do_oct_mul(
     TMP_OCT[4] = a0 * b4 + a4 * b0 - a1 * b5 + a5 * b1 - a2 * b6 + a6 * b2 - a3 * b7 + a7 * b3
     TMP_OCT[5] = a0 * b5 + a5 * b0 + a1 * b4 - a4 * b1 - a2 * b7 + a7 * b2 + a3 * b6 - a6 * b3
     TMP_OCT[6] = a0 * b6 + a6 * b0 + a1 * b7 - a7 * b1 + a2 * b4 - a4 * b2 - a3 * b5 + a5 * b3
-    TMP_OCT[7] = a0 * b7 + a7 * b0 - a1 * b6 + a6 * b1 - a2 * b5 + a5 * b2 + a3 * b4 - a4 * b3
+    TMP_OCT[7] = a0 * b7 + a7 * b0 - a1 * b6 + a6 * b1 + a2 * b5 - a5 * b2 + a3 * b4 - a4 * b3
+}
+
+fn do_assoc_projected_mul(
+    a0: f64, a1: f64, a2: f64, a3: f64, a4: f64, a5: f64, a6: f64, a7: f64,
+    b0: f64, b1: f64, b2: f64, b3: f64, b4: f64, b5: f64, b6: f64, b7: f64
+) with Mut {
+    TMP_OCT[0] = a0 * b0 - a1 * b1 - a2 * b2 - a3 * b3
+    TMP_OCT[1] = a0 * b1 + a1 * b0 + a2 * b3 - a3 * b2
+    TMP_OCT[2] = a0 * b2 - a1 * b3 + a2 * b0 + a3 * b1
+    TMP_OCT[3] = a0 * b3 + a1 * b2 - a2 * b1 + a3 * b0
+    TMP_OCT[4] = a4 * b4 - a5 * b5 - a6 * b6 - a7 * b7
+    TMP_OCT[5] = a4 * b5 + a5 * b4 + a6 * b7 - a7 * b6
+    TMP_OCT[6] = a4 * b6 - a5 * b7 + a6 * b4 + a7 * b5
+    TMP_OCT[7] = a4 * b7 + a5 * b6 - a6 * b5 + a7 * b4
+}
+
+fn do_o_step_mul(
+    a0: f64, a1: f64, a2: f64, a3: f64, a4: f64, a5: f64, a6: f64, a7: f64,
+    b0: f64, b1: f64, b2: f64, b3: f64, b4: f64, b5: f64, b6: f64, b7: f64
+) with Mut {
+    if CFG_OCT_ASSOCIATIVE_PROJECTION != 0 {
+        do_assoc_projected_mul(a0, a1, a2, a3, a4, a5, a6, a7, b0, b1, b2, b3, b4, b5, b6, b7)
+    } else {
+        do_oct_mul(a0, a1, a2, a3, a4, a5, a6, a7, b0, b1, b2, b3, b4, b5, b6, b7)
+    }
 }
 
 fn ws(i: i64, v: f64) with Mut {
@@ -1384,7 +1426,7 @@ fn assoc_g(head: i64) -> f64 with Div {
     (ASSOC_ACC[head as usize] as f64) / 100000000.0
 }
 
-fn assoc_mean_all() -> f64 with Div {
+fn assoc_mean_all() -> f64 with Mut, Div {
     var s = 0.0
     var head: i64 = 0
     while head < head_count() {
@@ -1668,7 +1710,7 @@ fn reset_state() with Mut {
 
 fn oct_step_head(head: i64, x0: f64, x1: f64, x2: f64, x3: f64, x4: f64, x5: f64, x6: f64, x7: f64) with Mut, Div, Panic {
     let base = head_base(head)
-    do_oct_mul(A[base as usize], A[(base + 1) as usize], A[(base + 2) as usize], A[(base + 3) as usize], A[(base + 4) as usize], A[(base + 5) as usize], A[(base + 6) as usize], A[(base + 7) as usize], hg(base), hg(base + 1), hg(base + 2), hg(base + 3), hg(base + 4), hg(base + 5), hg(base + 6), hg(base + 7))
+    do_o_step_mul(A[base as usize], A[(base + 1) as usize], A[(base + 2) as usize], A[(base + 3) as usize], A[(base + 4) as usize], A[(base + 5) as usize], A[(base + 6) as usize], A[(base + 7) as usize], hg(base), hg(base + 1), hg(base + 2), hg(base + 3), hg(base + 4), hg(base + 5), hg(base + 6), hg(base + 7))
     let t0 = TMP_OCT[0]
     let t1 = TMP_OCT[1]
     let t2 = TMP_OCT[2]
@@ -1677,14 +1719,14 @@ fn oct_step_head(head: i64, x0: f64, x1: f64, x2: f64, x3: f64, x4: f64, x5: f64
     let t5 = TMP_OCT[5]
     let t6 = TMP_OCT[6]
     let t7 = TMP_OCT[7]
-    do_oct_mul(t0, t1, t2, t3, t4, t5, t6, t7, x0, x1, x2, x3, x4, x5, x6, x7)
+    do_o_step_mul(t0, t1, t2, t3, t4, t5, t6, t7, x0, x1, x2, x3, x4, x5, x6, x7)
     var left: [f64; 8] = [0.0; 8]
     var d: i64 = 0
     while d < 8 {
         left[d as usize] = TMP_OCT[d as usize]
         d = d + 1
     }
-    do_oct_mul(hg(base), hg(base + 1), hg(base + 2), hg(base + 3), hg(base + 4), hg(base + 5), hg(base + 6), hg(base + 7), x0, x1, x2, x3, x4, x5, x6, x7)
+    do_o_step_mul(hg(base), hg(base + 1), hg(base + 2), hg(base + 3), hg(base + 4), hg(base + 5), hg(base + 6), hg(base + 7), x0, x1, x2, x3, x4, x5, x6, x7)
     let hx0 = TMP_OCT[0]
     let hx1 = TMP_OCT[1]
     let hx2 = TMP_OCT[2]
@@ -1693,7 +1735,7 @@ fn oct_step_head(head: i64, x0: f64, x1: f64, x2: f64, x3: f64, x4: f64, x5: f64
     let hx5 = TMP_OCT[5]
     let hx6 = TMP_OCT[6]
     let hx7 = TMP_OCT[7]
-    do_oct_mul(A[base as usize], A[(base + 1) as usize], A[(base + 2) as usize], A[(base + 3) as usize], A[(base + 4) as usize], A[(base + 5) as usize], A[(base + 6) as usize], A[(base + 7) as usize], hx0, hx1, hx2, hx3, hx4, hx5, hx6, hx7)
+    do_o_step_mul(A[base as usize], A[(base + 1) as usize], A[(base + 2) as usize], A[(base + 3) as usize], A[(base + 4) as usize], A[(base + 5) as usize], A[(base + 6) as usize], A[(base + 7) as usize], hx0, hx1, hx2, hx3, hx4, hx5, hx6, hx7)
     var asq = 0.0
     var i: i64 = 0
     while i < 8 {
@@ -2199,6 +2241,26 @@ fn std20(xs: [f64; 20], mean: f64) -> f64 with Mut, Div, Panic {
     sqrt_q(s / 20.0)
 }
 
+fn emit_state_trace(is_oct: i64, seed: i64, subject_index: i64, holdout_key: i64, label: i64) with IO, Mut, Div {
+    print("STATE_TRACE\t")
+    if is_oct == 1 { print("O-SSM") } else { print("H-SSM") }
+    print("\t")
+    print_int(seed)
+    print("\t")
+    print_int(subject_index)
+    print("\t")
+    print_int(holdout_key)
+    print("\t")
+    print_int(label)
+    var d: i64 = 0
+    while d < hidden_dim() {
+        print("\t")
+        print_int((hg(d) * 1000000.0) as i64)
+        d = d + 1
+    }
+    print("\n")
+}
+
 fn run_fold(is_oct: i64, s1: i64, s2: i64, holdout_key: i64) -> f64 with IO, Mut, Div, Panic {
     let train_epochs = cfg_train_epochs(is_oct)
     let train_lr = cfg_train_lr(is_oct)
@@ -2217,10 +2279,10 @@ fn run_fold(is_oct: i64, s1: i64, s2: i64, holdout_key: i64) -> f64 with IO, Mut
         let allow_core = if ep >= warmup_epochs { 1 } else { 0 }
         var seen: i64 = 0
         while seen < train_count {
-            let subj = (rng_next() / 100) % SUBJECT_COUNT
-            if SITE_KEYS[subj as usize] != holdout_key && TRAIN_MASK[subj as usize] == 1 {
-                forward_subject(subj, is_oct)
-                update_binary(LABELS[subj as usize], train_lr, is_oct, allow_core)
+            let sampled_subj = (rng_next() / 100) % SUBJECT_COUNT
+            if SITE_KEYS[sampled_subj as usize] != holdout_key && TRAIN_MASK[sampled_subj as usize] == 1 {
+                forward_subject(sampled_subj, is_oct)
+                update_binary(LABELS[sampled_subj as usize], train_lr, is_oct, allow_core)
             }
             seen = seen + 1
         }
@@ -2260,6 +2322,9 @@ fn run_fold(is_oct: i64, s1: i64, s2: i64, holdout_key: i64) -> f64 with IO, Mut
             print("\t")
             print(assoc_value)
             print("\n")
+            if CFG_TRACE_HIDDEN_STATE != 0 {
+                emit_state_trace(is_oct, s1, subj, holdout_key, label)
+            }
             if pred == 1 && label == 1 { tp = tp + 1 }
             if pred == 0 && label == 0 { tn = tn + 1 }
             if pred == 1 && label == 0 { fp = fp + 1 }
@@ -2450,6 +2515,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
         print(" oct_assoc_drift_reg="); print(bp_to_f64(CFG_OCT_ASSOC_DRIFT_REG_BP))
         print(" oct_head_trust_region="); print(bp_to_f64(CFG_OCT_HEAD_TRUST_REGION_BP))
         print(" oct_head_renorm="); print_int(CFG_OCT_HEAD_RENORM)
+        print(" oct_associative_projection="); print_int(CFG_OCT_ASSOCIATIVE_PROJECTION)
         print(" oct_input_proj="); print(proj_mode_name(CFG_OCT_INPUT_PROJ_MODE))
         print(" oct_proj_lr_scale="); print(bp_to_f64(CFG_OCT_PROJ_LR_SCALE_BP))
         print(" oct_proj_structured_scale="); print(bp_to_f64(CFG_OCT_PROJ_STRUCTURED_SCALE_BP))

--- a/examples/epistemic_kan_fixed_point.sio
+++ b/examples/epistemic_kan_fixed_point.sio
@@ -1,0 +1,102 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// Fixed-point E-KAN witness.
+//
+// Scale: 1000 == 1.0. Each edge is a piecewise-linear hat-basis function with
+// coefficient standard uncertainty. The network composes two input edges into
+// a hidden node, then one output edge, propagating uncertainty by quadrature.
+
+fn abs_i(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_i(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 16 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat3_i(x: i64, k: i64) -> i64 with Div {
+    let c = k * 500
+    let d = abs_i(x - c)
+    if d >= 500 { return 0 }
+    1000 - d * 2
+}
+
+struct EdgeI { val: i64, unc: i64 }
+
+fn edge3_i(
+    c0: i64,
+    c1: i64,
+    c2: i64,
+    u0: i64,
+    u1: i64,
+    u2: i64,
+    x: i64,
+) -> EdgeI with Div, Mut {
+    let b0 = hat3_i(x, 0)
+    let b1 = hat3_i(x, 1)
+    let b2 = hat3_i(x, 2)
+    let v0 = c0 * b0 / 1000
+    let v1 = c1 * b1 / 1000
+    let v2 = c2 * b2 / 1000
+    let q0 = b0 * u0 / 1000
+    let q1 = b1 * u1 / 1000
+    let q2 = b2 * u2 / 1000
+    EdgeI { val: v0 + v1 + v2, unc: isqrt_i(q0 * q0 + q1 * q1 + q2 * q2) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let x0 = 250
+    let x1 = 750
+    let ux0 = 15
+    let ux1 = 25
+
+    let e0 = edge3_i(100, 420, 180, 10, 20, 10, x0)
+    let e1 = edge3_i(260, 120, 360, 20, 10, 20, x1)
+    var hidden = e0.val + e1.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_i(e0.unc * e0.unc + e1.unc * e1.unc + ux0 * ux0 + ux1 * ux1)
+
+    let out = edge3_i(120, 610, 300, 10, 30, 20, hidden)
+    let out_unc = isqrt_i(out.unc * out.unc + hidden_unc * hidden_unc)
+
+    var failed = 0
+    if hidden > 250 && hidden < 700 {
+        println("T1 PASS: hidden bounded")
+    } else {
+        println("T1 FAIL: hidden outside expected range")
+        failed = failed + 1
+    }
+
+    if out.val > 200 && out.val < 650 {
+        println("T2 PASS: output bounded")
+    } else {
+        println("T2 FAIL: output outside expected range")
+        failed = failed + 1
+    }
+
+    if out_unc > out.unc {
+        println("T3 PASS: upstream uncertainty propagated")
+    } else {
+        println("T3 FAIL: upstream uncertainty not propagated")
+        failed = failed + 1
+    }
+
+    if out_unc > 20 && out_unc < 80 {
+        println("T4 PASS: output uncertainty bounded")
+    } else {
+        println("T4 FAIL: output uncertainty outside expected range")
+        failed = failed + 1
+    }
+
+    if failed == 0 { println("ALL PASS") } else { println("SOME TESTS FAILED") }
+    failed as i32
+}

--- a/scripts/ci/brain_ossm_sigmoid_polarity_gate.sh
+++ b/scripts/ci/brain_ossm_sigmoid_polarity_gate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+SOURCE="tests/run-pass/brain_ossm_sigmoid_polarity.sio"
+OUT_DIR="${SOUNIO_BRAIN_OSSM_SIGMOID_GATE_DIR:-$(mktemp -d /tmp/sounio-brain-ossm-sigmoid.XXXXXX)}"
+BIN="$OUT_DIR/brain_ossm_sigmoid_polarity"
+COMPILE_LOG="$OUT_DIR/compile.log"
+STDOUT_LOG="$OUT_DIR/stdout.log"
+STDERR_LOG="$OUT_DIR/stderr.log"
+
+mkdir -p "$OUT_DIR"
+
+echo "[brain-ossm-sigmoid] source=$SOURCE"
+echo "[brain-ossm-sigmoid] out=$OUT_DIR"
+
+SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" "$SOURCE" "$BIN" >"$COMPILE_LOG" 2>&1
+chmod +x "$BIN"
+"$BIN" >"$STDOUT_LOG" 2>"$STDERR_LOG"
+
+if ! grep -q "BRAIN_OSSM_SIGMOID_POLARITY_PASS" "$STDOUT_LOG"; then
+  echo "[brain-ossm-sigmoid] FAIL: pass token missing" >&2
+  echo "--- stdout ---" >&2
+  cat "$STDOUT_LOG" >&2
+  echo "--- stderr ---" >&2
+  cat "$STDERR_LOG" >&2
+  exit 1
+fi
+
+echo "[brain-ossm-sigmoid] PASS: exp_q reciprocal symmetry and sigmoid polarity hold"

--- a/scripts/ci/ekan_native_blocker_probe.sh
+++ b/scripts/ci/ekan_native_blocker_probe.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+./scripts/ci/ekan_native_frontier_matrix.sh | grep -E 'HIDDEN_COMPACT|HIDDEN_VERBOSE|EKAN_NATIVE_FRONTIER_MATRIX_PASS'
+echo "EKAN_NATIVE_BLOCKER_PROBE_PASS"

--- a/scripts/ci/ekan_native_core_gate.sh
+++ b/scripts/ci/ekan_native_core_gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+native_out="$(mktemp)"
+legacy_out="$(mktemp)"
+trap 'rm -f "$native_out" "$legacy_out"' EXIT
+
+./bin/souc run examples/hello.sio >"$native_out"
+grep -q "Hello, Sounio" "$native_out"
+
+SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/epistemic_kan.sio >"$legacy_out"
+grep -q "ALL PASS" "$legacy_out"
+
+SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run examples/epistemic_kan_fixed_point.sio >"$legacy_out"
+grep -q "ALL PASS" "$legacy_out"
+
+./scripts/ci/ekan_native_frontier_matrix.sh >"$native_out"
+grep -q "EKAN_NATIVE_FRONTIER_MATRIX_PASS" "$native_out"
+
+./scripts/ci/ekan_native_blocker_probe.sh >"$native_out"
+grep -q "EKAN_NATIVE_BLOCKER_PROBE_PASS" "$native_out"
+
+./scripts/ci/ekan_native_readout_probe.sh >"$native_out"
+grep -q "EKAN_NATIVE_READOUT_PROBE_PASS" "$native_out"
+
+./scripts/ci/ekan_native_width_probe.sh >"$native_out"
+grep -q "EKAN_NATIVE_WIDTH_PROBE_PASS" "$native_out"
+
+./scripts/ci/ekan_native_input_width_probe.sh >"$native_out"
+grep -q "EKAN_NATIVE_INPUT_WIDTH_PROBE_PASS" "$native_out"
+
+echo "EKAN_NATIVE_CORE_GATE_PASS"

--- a/scripts/ci/ekan_native_frontier_matrix.sh
+++ b/scripts/ci/ekan_native_frontier_matrix.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+classify_probe() {
+  local label="$1"
+  local path="$2"
+  local log="$tmpdir/${label}.log"
+  local rc=0
+
+  set +e
+  ./bin/souc run "$path" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  if [[ "$rc" -eq 0 ]] && grep -q "ALL PASS\\|ekan_knowledge_basic: PASS" "$log"; then
+    echo "EKAN_NATIVE_FRONTIER_PROBE_${label}=XPASS_UNSTABLE"
+    return 0
+  fi
+
+  if [[ "$rc" -eq 139 ]] || grep -Eq 'Segmentation fault|compiler exited 139|exit.*139' "$log"; then
+    echo "EKAN_NATIVE_FRONTIER_PROBE_${label}=KNOWN_BLOCKER"
+    return 0
+  fi
+
+  echo "EKAN_NATIVE_FRONTIER_PROBE_${label}=UNEXPECTED rc=${rc}" >&2
+  cat "$log" >&2
+  return 1
+}
+
+classify_probe KNOWLEDGE_BASIC tests/run-pass/ekan_knowledge_basic.sio
+classify_probe EDGE tests/known_failures/ekan_fixed_point_edge_native_v2_probe.sio
+classify_probe HIDDEN_COMPACT tests/known_failures/ekan_fixed_point_hidden_compact_native_v2_probe.sio
+classify_probe HIDDEN_VERBOSE tests/known_failures/ekan_fixed_point_hidden_native_v2_blocker.sio
+classify_probe LINEAR_READOUT_COMPACT tests/known_failures/ekan_fixed_point_linear_readout_compact_native_v2_probe.sio
+classify_probe LINEAR_READOUT_VERBOSE tests/known_failures/ekan_fixed_point_linear_readout_native_v2_probe.sio
+classify_probe HAT3_READOUT tests/known_failures/ekan_fixed_point_hat3_readout_native_v2_probe.sio
+classify_probe HAT5_READOUT tests/known_failures/ekan_fixed_point_hat_readout_native_v2_probe.sio
+classify_probe TWO_HIDDEN tests/known_failures/ekan_fixed_point_two_hidden_native_v2_probe.sio
+classify_probe TWO_HIDDEN_READOUT tests/known_failures/ekan_fixed_point_two_hidden_readout_native_v2_probe.sio
+classify_probe THREE_INPUT_TWO_HIDDEN tests/known_failures/ekan_fixed_point_three_input_two_hidden_native_v2_probe.sio
+classify_probe FOUR_INPUT_ONE_HIDDEN tests/known_failures/ekan_fixed_point_four_input_one_hidden_native_v2_probe.sio
+classify_probe FOUR_INPUT_TWO_HIDDEN tests/known_failures/ekan_fixed_point_four_input_two_hidden_native_v2_probe.sio
+
+echo "EKAN_NATIVE_FRONTIER_MATRIX_PASS"

--- a/scripts/ci/ekan_native_input_width_probe.sh
+++ b/scripts/ci/ekan_native_input_width_probe.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+./scripts/ci/ekan_native_frontier_matrix.sh | grep -E 'THREE_INPUT_TWO_HIDDEN|FOUR_INPUT|EKAN_NATIVE_FRONTIER_MATRIX_PASS'
+echo "EKAN_NATIVE_INPUT_WIDTH_PROBE_PASS"

--- a/scripts/ci/ekan_native_readout_probe.sh
+++ b/scripts/ci/ekan_native_readout_probe.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+./scripts/ci/ekan_native_frontier_matrix.sh | grep -E 'LINEAR_READOUT|HAT3_READOUT|HAT5_READOUT|EKAN_NATIVE_FRONTIER_MATRIX_PASS'
+echo "EKAN_NATIVE_READOUT_PROBE_PASS"

--- a/scripts/ci/ekan_native_width_probe.sh
+++ b/scripts/ci/ekan_native_width_probe.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+./scripts/ci/ekan_native_frontier_matrix.sh | grep -E 'TWO_HIDDEN|EKAN_NATIVE_FRONTIER_MATRIX_PASS'
+echo "EKAN_NATIVE_WIDTH_PROBE_PASS"

--- a/tests/known_failures/ekan_fixed_point_edge_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_edge_native_v2_probe.sio
@@ -1,0 +1,75 @@
+//@ known-failure: fixed-point E-KAN edge currently segfaults in generated native-v2 ELF
+
+// Fixed-point E-KAN edge witness for native-v2.
+// Scale: 1000 == 1.0.
+
+fn abs_fi(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fi(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fi(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fi(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFi { val: i64, unc: i64 }
+
+fn edge_eval_fi(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFi with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fi(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFi { val: val, unc: isqrt_fi(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fi(&c, &u, 250)
+    let b = edge_eval_fi(&c, &u, 750)
+    let combined_unc = isqrt_fi(a.unc * a.unc + b.unc * b.unc)
+
+    var failed = 0
+    if abs_fi(a.val - b.val) > 50 {
+        println("T1 PASS: fixed edge values differ")
+    } else {
+        println("T1 FAIL: fixed edge values too similar")
+        failed = failed + 1
+    }
+
+    if a.unc > 0 && b.unc > 0 {
+        println("T2 PASS: fixed edge uncertainty nonzero")
+    } else {
+        println("T2 FAIL: fixed edge uncertainty zero")
+        failed = failed + 1
+    }
+
+    if combined_unc > a.unc && combined_unc > b.unc {
+        println("T3 PASS: fixed uncertainty composed")
+    } else {
+        println("T3 FAIL: fixed uncertainty composition missing")
+        failed = failed + 1
+    }
+
+    if failed == 0 { println("ALL PASS") } else { println("SOME TESTS FAILED") }
+    failed as i32
+}

--- a/tests/known_failures/ekan_fixed_point_four_input_one_hidden_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_four_input_one_hidden_native_v2_probe.sio
@@ -1,0 +1,69 @@
+//@ known-failure: 4-input 1-hidden fixed-point E-KAN native-v2 frontier probe
+
+// Four-input, one-hidden fixed-point E-KAN reduction for native-v2. This keeps
+// the 4-input hidden-node shape from the unstable two-hidden probe, but removes
+// the second hidden node to isolate whether the blocker is input width itself or
+// the doubled edge-evaluation footprint.
+
+fn abs_fq(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fq(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fq(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fq(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFq { val: i64, unc: i64 }
+
+fn edge_eval_fq(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFq with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fq(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFq { val: val, unc: isqrt_fq(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let d: [i64; 5] = [220, 160, 360, 140, 260]
+    let e: [i64; 5] = [180, 300, 220, 410, 160]
+    let f: [i64; 5] = [260, 120, 440, 180, 300]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let v: [i64; 5] = [20, 10, 20, 10, 20]
+
+    let a0 = edge_eval_fq(&c, &u, 125)
+    let b0 = edge_eval_fq(&d, &v, 375)
+    let c0 = edge_eval_fq(&e, &u, 625)
+    let d0 = edge_eval_fq(&f, &v, 875)
+    var h0 = a0.val + b0.val + c0.val + d0.val
+    if h0 < 0 { h0 = 0 }
+    if h0 > 1000 { h0 = 1000 }
+    let h0_unc = isqrt_fq(a0.unc * a0.unc + b0.unc * b0.unc + c0.unc * c0.unc + d0.unc * d0.unc + 10 * 10 + 15 * 15 + 20 * 20 + 25 * 25)
+
+    if h0 > 200 && h0_unc > 20 {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_four_input_two_hidden_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_four_input_two_hidden_native_v2_probe.sio
@@ -1,0 +1,76 @@
+//@ known-failure: compact 4-input 2-hidden fixed-point E-KAN is XPASS-unstable in native-v2
+
+// Four-input, two-hidden fixed-point E-KAN probe for native-v2. This has XPASSed
+// but fails on rerun, so it is not stable enough for run-pass promotion.
+
+fn abs_fw(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fw(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fw(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fw(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFw { val: i64, unc: i64 }
+
+fn edge_eval_fw(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFw with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fw(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFw { val: val, unc: isqrt_fw(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let d: [i64; 5] = [220, 160, 360, 140, 260]
+    let e: [i64; 5] = [180, 300, 220, 410, 160]
+    let f: [i64; 5] = [260, 120, 440, 180, 300]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let v: [i64; 5] = [20, 10, 20, 10, 20]
+
+    let a0 = edge_eval_fw(&c, &u, 125)
+    let b0 = edge_eval_fw(&d, &v, 375)
+    let c0 = edge_eval_fw(&e, &u, 625)
+    let d0 = edge_eval_fw(&f, &v, 875)
+    var h0 = a0.val + b0.val + c0.val + d0.val
+    if h0 < 0 { h0 = 0 }
+    if h0 > 1000 { h0 = 1000 }
+    let h0_unc = isqrt_fw(a0.unc * a0.unc + b0.unc * b0.unc + c0.unc * c0.unc + d0.unc * d0.unc + 10 * 10 + 15 * 15 + 20 * 20 + 25 * 25)
+
+    let a1 = edge_eval_fw(&f, &v, 125)
+    let b1 = edge_eval_fw(&e, &u, 375)
+    let c1 = edge_eval_fw(&d, &v, 625)
+    let d1 = edge_eval_fw(&c, &u, 875)
+    var h1 = a1.val + b1.val + c1.val + d1.val
+    if h1 < 0 { h1 = 0 }
+    if h1 > 1000 { h1 = 1000 }
+    let h1_unc = isqrt_fw(a1.unc * a1.unc + b1.unc * b1.unc + c1.unc * c1.unc + d1.unc * d1.unc + 10 * 10 + 15 * 15 + 20 * 20 + 25 * 25)
+
+    if h0 > 200 && h1 > 200 && h0_unc > 20 && h1_unc > 20 {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_hat3_readout_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_hat3_readout_native_v2_probe.sio
@@ -1,0 +1,81 @@
+//@ known-failure: 3-knot hat-basis readout after hidden-node E-KAN is XPASS-unstable in native-v2
+
+// Fixed-point E-KAN hidden-node + compact 3-knot hat-basis readout probe for
+// native-v2. This has XPASSed but fails on rerun, so it is not stable enough for
+// run-pass promotion.
+
+fn abs_fs(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fs(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fs(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fs(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFs { val: i64, unc: i64 }
+
+fn edge_eval_fs(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFs with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fs(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFs { val: val, unc: isqrt_fs(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fs(&c, &u, 250)
+    let b = edge_eval_fs(&c, &u, 750)
+    let combined_unc = isqrt_fs(a.unc * a.unc + b.unc * b.unc)
+    var hidden = a.val + b.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_fs(combined_unc * combined_unc + 15 * 15 + 25 * 25)
+
+    var d0 = hidden
+    if d0 < 0 { d0 = 0 - d0 }
+    var d1 = hidden - 500
+    if d1 < 0 { d1 = 0 - d1 }
+    var d2 = hidden - 1000
+    if d2 < 0 { d2 = 0 - d2 }
+    var r0 = 0
+    var r1 = 0
+    var r2 = 0
+    if d0 < 500 { r0 = 1000 - d0 * 2 }
+    if d1 < 500 { r1 = 1000 - d1 * 2 }
+    if d2 < 500 { r2 = 1000 - d2 * 2 }
+    let out_val = 150 * r0 / 1000 + 620 * r1 / 1000 + 260 * r2 / 1000
+    let q0 = 10 * r0 / 1000
+    let q1 = 25 * r1 / 1000
+    let q2 = 15 * r2 / 1000
+    let edge_unc = isqrt_fs(q0 * q0 + q1 * q1 + q2 * q2)
+    let out_unc = isqrt_fs(edge_unc * edge_unc + hidden_unc * hidden_unc)
+
+    if out_val > 100 && out_val < 700 && out_unc > edge_unc {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_hat_readout_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_hat_readout_native_v2_probe.sio
@@ -1,0 +1,75 @@
+//@ known-failure: 5-knot hat-basis readout after hidden-node E-KAN is XPASS-unstable in native-v2
+
+// Fixed-point E-KAN hidden-node + 5-knot hat-basis readout probe for native-v2.
+// This has XPASSed but fails on rerun, so it is not stable enough for run-pass.
+
+fn abs_fn(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fn(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fn(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fn(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFn { val: i64, unc: i64 }
+
+fn edge_eval_fn(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFn with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fn(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFn { val: val, unc: isqrt_fn(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fn(&c, &u, 250)
+    let b = edge_eval_fn(&c, &u, 750)
+    let combined_unc = isqrt_fn(a.unc * a.unc + b.unc * b.unc)
+    var hidden = a.val + b.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_fn(combined_unc * combined_unc + 15 * 15 + 25 * 25)
+
+    let b0 = hat_fn(hidden, 0)
+    let b1 = hat_fn(hidden, 1)
+    let b2 = hat_fn(hidden, 2)
+    let b3 = hat_fn(hidden, 3)
+    let b4 = hat_fn(hidden, 4)
+    let out_val = 120 * b0 / 1000 + 280 * b1 / 1000 + 610 * b2 / 1000 + 420 * b3 / 1000 + 180 * b4 / 1000
+    let q0 = 10 * b0 / 1000
+    let q1 = 20 * b1 / 1000
+    let q2 = 30 * b2 / 1000
+    let q3 = 20 * b3 / 1000
+    let q4 = 10 * b4 / 1000
+    let edge_unc = isqrt_fn(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4)
+    let out_unc = isqrt_fn(edge_unc * edge_unc + hidden_unc * hidden_unc)
+
+    if out_val > 100 && out_val < 700 && out_unc > edge_unc {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_hidden_compact_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_hidden_compact_native_v2_probe.sio
@@ -1,0 +1,62 @@
+//@ known-failure: compact fixed-point E-KAN hidden node currently segfaults in generated native-v2 ELF
+
+// Fixed-point E-KAN hidden-node witness for native-v2.
+// Keeps the hidden-node computation compact enough for the current bridge while
+// proving that hidden value and hidden uncertainty composition execute natively.
+
+fn abs_fm(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fm(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fm(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fm(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFm { val: i64, unc: i64 }
+
+fn edge_eval_fm(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFm with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fm(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFm { val: val, unc: isqrt_fm(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fm(&c, &u, 250)
+    let b = edge_eval_fm(&c, &u, 750)
+    let combined_unc = isqrt_fm(a.unc * a.unc + b.unc * b.unc)
+    var hidden = a.val + b.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_fm(combined_unc * combined_unc + 15 * 15 + 25 * 25)
+
+    if hidden > 300 && hidden < 900 && hidden_unc > combined_unc {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_hidden_native_v2_blocker.sio
+++ b/tests/known_failures/ekan_fixed_point_hidden_native_v2_blocker.sio
@@ -1,0 +1,74 @@
+//@ known-failure: native-v2 build exits 139 for the verbose hidden-node E-KAN diagnostic shape
+
+// Verbose hidden-node E-KAN native-v2 blocker reduction.
+// `tests/run-pass/ekan_fixed_point_hidden_native_v2.sio` proves the same hidden
+// value and uncertainty computation in a compact main. This version keeps extra
+// branch diagnostics and still exposes the current native-v2 complexity boundary.
+
+fn abs_fh(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fh(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fh(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fh(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFh { val: i64, unc: i64 }
+
+fn edge_eval_fh(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFh with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fh(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFh { val: val, unc: isqrt_fh(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fh(&c, &u, 250)
+    let b = edge_eval_fh(&c, &u, 750)
+    let combined_unc = isqrt_fh(a.unc * a.unc + b.unc * b.unc)
+    var hidden = a.val + b.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_fh(combined_unc * combined_unc + 15 * 15 + 25 * 25)
+
+    var failed = 0
+    if hidden > 300 && hidden < 900 {
+        println("T1 PASS: hidden bounded")
+    } else {
+        println("T1 FAIL: hidden outside expected range")
+        failed = failed + 1
+    }
+
+    if hidden_unc > combined_unc {
+        println("T2 PASS: hidden uncertainty includes input uncertainty")
+    } else {
+        println("T2 FAIL: hidden uncertainty missing input contribution")
+        failed = failed + 1
+    }
+
+    if failed == 0 { println("ALL PASS") } else { println("SOME TESTS FAILED") }
+    failed as i32
+}

--- a/tests/known_failures/ekan_fixed_point_linear_readout_compact_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_linear_readout_compact_native_v2_probe.sio
@@ -1,0 +1,63 @@
+//@ known-failure: compact fixed-point E-KAN linear readout currently segfaults in generated native-v2 ELF
+
+// Fixed-point E-KAN hidden-node + linear readout witness for native-v2.
+// It keeps the hidden-node witness and adds downstream output uncertainty
+// propagation while staying inside the current bridge's compact-main boundary.
+
+fn abs_fp(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fp(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fp(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fp(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFp { val: i64, unc: i64 }
+
+fn edge_eval_fp(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFp with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fp(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFp { val: val, unc: isqrt_fp(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fp(&c, &u, 250)
+    let b = edge_eval_fp(&c, &u, 750)
+    let combined_unc = isqrt_fp(a.unc * a.unc + b.unc * b.unc)
+    var hidden = a.val + b.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_fp(combined_unc * combined_unc + 15 * 15 + 25 * 25)
+    let out_unc = isqrt_fp(hidden_unc * hidden_unc + 18 * 18)
+
+    if hidden > 300 && hidden < 900 && out_unc > hidden_unc {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_linear_readout_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_linear_readout_native_v2_probe.sio
@@ -1,0 +1,65 @@
+//@ known-failure: native-v2 linear readout after compact hidden-node E-KAN is currently XPASS-unstable
+
+// Fixed-point E-KAN hidden-node + linear readout probe for native-v2.
+// Scale: 1000 == 1.0. This proves hidden-node uncertainty can feed a compact
+// downstream readout when it XPASSes, but current runs are not stable enough for
+// run-pass promotion.
+
+fn abs_fr(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fr(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fr(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fr(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFr { val: i64, unc: i64 }
+
+fn edge_eval_fr(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFr with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fr(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFr { val: val, unc: isqrt_fr(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let a = edge_eval_fr(&c, &u, 250)
+    let b = edge_eval_fr(&c, &u, 750)
+    let combined_unc = isqrt_fr(a.unc * a.unc + b.unc * b.unc)
+    var hidden = a.val + b.val
+    if hidden < 0 { hidden = 0 }
+    if hidden > 1000 { hidden = 1000 }
+    let hidden_unc = isqrt_fr(combined_unc * combined_unc + 15 * 15 + 25 * 25)
+    let out_val = hidden * 650 / 1000 + 80
+    let out_unc = isqrt_fr(hidden_unc * hidden_unc + 18 * 18)
+
+    if out_val > 250 && out_val < 700 && out_unc > hidden_unc {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_three_input_two_hidden_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_three_input_two_hidden_native_v2_probe.sio
@@ -1,0 +1,72 @@
+//@ known-failure: compact fixed-point E-KAN three-input two-hidden witness currently segfaults in generated native-v2 ELF
+
+// Three-input, two-hidden fixed-point E-KAN witness for native-v2.
+
+fn abs_fx(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fx(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fx(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fx(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFx { val: i64, unc: i64 }
+
+fn edge_eval_fx(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFx with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fx(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFx { val: val, unc: isqrt_fx(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let d: [i64; 5] = [220, 160, 360, 140, 260]
+    let e: [i64; 5] = [180, 300, 220, 410, 160]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let v: [i64; 5] = [20, 10, 20, 10, 20]
+
+    let a0 = edge_eval_fx(&c, &u, 250)
+    let b0 = edge_eval_fx(&d, &v, 500)
+    let c0 = edge_eval_fx(&e, &u, 750)
+    var h0 = a0.val + b0.val + c0.val
+    if h0 < 0 { h0 = 0 }
+    if h0 > 1000 { h0 = 1000 }
+    let h0_unc = isqrt_fx(a0.unc * a0.unc + b0.unc * b0.unc + c0.unc * c0.unc + 10 * 10 + 15 * 15 + 20 * 20)
+
+    let a1 = edge_eval_fx(&e, &u, 250)
+    let b1 = edge_eval_fx(&c, &u, 500)
+    let c1 = edge_eval_fx(&d, &v, 750)
+    var h1 = a1.val + b1.val + c1.val
+    if h1 < 0 { h1 = 0 }
+    if h1 > 1000 { h1 = 1000 }
+    let h1_unc = isqrt_fx(a1.unc * a1.unc + b1.unc * b1.unc + c1.unc * c1.unc + 10 * 10 + 15 * 15 + 20 * 20)
+
+    if h0 > 200 && h1 > 200 && h0_unc > 20 && h1_unc > 20 {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_two_hidden_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_two_hidden_native_v2_probe.sio
@@ -1,0 +1,71 @@
+//@ known-failure: compact fixed-point E-KAN two-hidden witness currently segfaults in generated native-v2 ELF
+
+// Compact fixed-point E-KAN with two hidden nodes, native-v2.
+// This proves the width expansion from one hidden node to two hidden nodes,
+// without the downstream double readout.
+
+fn abs_fv(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fv(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fv(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fv(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFv { val: i64, unc: i64 }
+
+fn edge_eval_fv(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFv with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fv(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFv { val: val, unc: isqrt_fv(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let d: [i64; 5] = [220, 160, 360, 140, 260]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let v: [i64; 5] = [20, 10, 20, 10, 20]
+
+    let a0 = edge_eval_fv(&c, &u, 250)
+    let b0 = edge_eval_fv(&d, &v, 750)
+    var h0 = a0.val + b0.val
+    if h0 < 0 { h0 = 0 }
+    if h0 > 1000 { h0 = 1000 }
+    let h0_unc = isqrt_fv(a0.unc * a0.unc + b0.unc * b0.unc + 15 * 15 + 25 * 25)
+
+    let a1 = edge_eval_fv(&d, &v, 250)
+    let b1 = edge_eval_fv(&c, &u, 750)
+    var h1 = a1.val + b1.val
+    if h1 < 0 { h1 = 0 }
+    if h1 > 1000 { h1 = 1000 }
+    let h1_unc = isqrt_fv(a1.unc * a1.unc + b1.unc * b1.unc + 15 * 15 + 25 * 25)
+
+    if h0 > 200 && h1 > 200 && h0_unc > 20 && h1_unc > 20 {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/known_failures/ekan_fixed_point_two_hidden_readout_native_v2_probe.sio
+++ b/tests/known_failures/ekan_fixed_point_two_hidden_readout_native_v2_probe.sio
@@ -1,0 +1,103 @@
+//@ known-failure: compact 2-hidden fixed-point E-KAN with double readout is XPASS-unstable in native-v2
+
+// Two-hidden-unit fixed-point E-KAN probe for native-v2. Four input edge evaluations
+// produce two hidden nodes; each hidden node feeds a compact 5-knot output edge,
+// and output uncertainty includes both hidden uncertainties. This has XPASSed
+// but fails on rerun, so it is not stable enough for run-pass promotion.
+
+fn abs_fu(x: i64) -> i64 {
+    if x < 0 { 0 - x } else { x }
+}
+
+fn isqrt_fu(x: i64) -> i64 with Mut, Div {
+    if x <= 0 { return 0 }
+    var y = x
+    var i = 0
+    while i < 12 {
+        y = (y + x / y) / 2
+        i = i + 1
+    }
+    y
+}
+
+fn hat_fu(x: i64, k: i64) -> i64 with Div {
+    let c = k * 250
+    let d = abs_fu(x - c)
+    if d >= 250 { return 0 }
+    1000 - d * 4
+}
+
+struct EvFu { val: i64, unc: i64 }
+
+fn edge_eval_fu(coeffs: &[i64; 5], unc: &[i64; 5], x: i64) -> EvFu with Mut, Div {
+    var val = 0
+    var vs = 0
+    var k = 0
+    while k < 5 {
+        let b = hat_fu(x, k)
+        val = val + coeffs[k as usize] * b / 1000
+        let q = unc[k as usize] * b / 1000
+        vs = vs + q * q
+        k = k + 1
+    }
+    EvFu { val: val, unc: isqrt_fu(vs) }
+}
+
+fn main() -> i32 with IO, Mut, Div {
+    let c: [i64; 5] = [100, 420, 180, 320, 120]
+    let d: [i64; 5] = [220, 160, 360, 140, 260]
+    let u: [i64; 5] = [10, 20, 10, 20, 10]
+    let v: [i64; 5] = [20, 10, 20, 10, 20]
+
+    let a0 = edge_eval_fu(&c, &u, 250)
+    let b0 = edge_eval_fu(&d, &v, 750)
+    let h0_base_unc = isqrt_fu(a0.unc * a0.unc + b0.unc * b0.unc)
+    var h0 = a0.val + b0.val
+    if h0 < 0 { h0 = 0 }
+    if h0 > 1000 { h0 = 1000 }
+    let h0_unc = isqrt_fu(h0_base_unc * h0_base_unc + 15 * 15 + 25 * 25)
+
+    let a1 = edge_eval_fu(&d, &v, 250)
+    let b1 = edge_eval_fu(&c, &u, 750)
+    let h1_base_unc = isqrt_fu(a1.unc * a1.unc + b1.unc * b1.unc)
+    var h1 = a1.val + b1.val
+    if h1 < 0 { h1 = 0 }
+    if h1 > 1000 { h1 = 1000 }
+    let h1_unc = isqrt_fu(h1_base_unc * h1_base_unc + 15 * 15 + 25 * 25)
+
+    let r0 = hat_fu(h0, 0)
+    let r1 = hat_fu(h0, 1)
+    let r2 = hat_fu(h0, 2)
+    let r3 = hat_fu(h0, 3)
+    let r4 = hat_fu(h0, 4)
+    let y0 = 120 * r0 / 1000 + 280 * r1 / 1000 + 610 * r2 / 1000 + 420 * r3 / 1000 + 180 * r4 / 1000
+    let q0 = 10 * r0 / 1000
+    let q1 = 20 * r1 / 1000
+    let q2 = 30 * r2 / 1000
+    let q3 = 20 * r3 / 1000
+    let q4 = 10 * r4 / 1000
+    let y0_edge_unc = isqrt_fu(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3 + q4 * q4)
+
+    let s0 = hat_fu(h1, 0)
+    let s1 = hat_fu(h1, 1)
+    let s2 = hat_fu(h1, 2)
+    let s3 = hat_fu(h1, 3)
+    let s4 = hat_fu(h1, 4)
+    let y1 = 180 * s0 / 1000 + 420 * s1 / 1000 + 540 * s2 / 1000 + 260 * s3 / 1000 + 140 * s4 / 1000
+    let p0 = 10 * s0 / 1000
+    let p1 = 20 * s1 / 1000
+    let p2 = 30 * s2 / 1000
+    let p3 = 20 * s3 / 1000
+    let p4 = 10 * s4 / 1000
+    let y1_edge_unc = isqrt_fu(p0 * p0 + p1 * p1 + p2 * p2 + p3 * p3 + p4 * p4)
+
+    let out_val = y0 + y1
+    let out_unc = isqrt_fu(y0_edge_unc * y0_edge_unc + y1_edge_unc * y1_edge_unc + h0_unc * h0_unc + h1_unc * h1_unc)
+
+    if out_val > 200 && out_val < 1200 && out_unc > h0_unc && out_unc > h1_unc {
+        println("ALL PASS")
+        return 0
+    }
+    println("SOME TESTS FAILED")
+    return 1
+}

--- a/tests/run-pass/brain_ossm_sigmoid_polarity.sio
+++ b/tests/run-pass/brain_ossm_sigmoid_polarity.sio
@@ -1,0 +1,56 @@
+//@ run-pass
+// Regression witness for the Brain O-SSM exp_q/sigmoid readout.
+//
+// The failed implementation evaluated a 20-term Taylor polynomial directly for
+// negative x, making exp_q(-12) large and inverting saturated sigmoid polarity.
+
+fn exp_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x > 15.0 { return exp_q(7.5) * exp_q(x - 7.5) }
+    if x < 0.0 - 15.0 { return 0.0 }
+    if x < 0.0 { return 1.0 / exp_q(0.0 - x) }
+    var sum = 1.0
+    var term = 1.0
+    var i = 1
+    while i <= 20 {
+        term = term * x / (i as f64)
+        sum = sum + term
+        i = i + 1
+    }
+    sum
+}
+
+fn sigmoid_q(x: f64) -> f64 with Mut, Div, Panic {
+    if x >= 0.0 {
+        1.0 / (1.0 + exp_q(0.0 - x))
+    } else {
+        let ex = exp_q(x)
+        ex / (1.0 + ex)
+    }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let sig_pos = sigmoid_q(12.0)
+    let sig_neg = sigmoid_q(0.0 - 12.0)
+    let sig_zero = sigmoid_q(0.0)
+    let exp_sym = exp_q(12.0) * exp_q(0.0 - 12.0)
+
+    if sig_pos < 0.999 {
+        print("BRAIN_OSSM_SIGMOID_POLARITY_FAIL sig_pos\n")
+        return 1
+    }
+    if sig_neg > 0.001 {
+        print("BRAIN_OSSM_SIGMOID_POLARITY_FAIL sig_neg\n")
+        return 2
+    }
+    if sig_zero < 0.499 || sig_zero > 0.501 {
+        print("BRAIN_OSSM_SIGMOID_POLARITY_FAIL sig_zero\n")
+        return 3
+    }
+    if exp_sym < 0.999 || exp_sym > 1.001 {
+        print("BRAIN_OSSM_SIGMOID_POLARITY_FAIL exp_sym\n")
+        return 4
+    }
+
+    print("BRAIN_OSSM_SIGMOID_POLARITY_PASS\n")
+    return 0
+}


### PR DESCRIPTION
Closes Cluster B from the 2026-07-11 working-tree triage (`docs/handoff/pending_changes_triage_2026-07-11.md`): the native O-SSM / E-KAN CI gates and their tests. Single, verified commit.

## Contents
- `examples/brain_ossm_abide.sio` (+79/-13) — native O-SSM ABIDE example update.
- `examples/epistemic_kan_fixed_point.sio` — fixed-point E-KAN witness (bounded output + uncertainty propagation).
- `scripts/ci/brain_ossm_sigmoid_polarity_gate.sh` — exp_q reciprocal-symmetry + sigmoid-polarity gate.
- `scripts/ci/ekan_native_*.sh` (6) — native E-KAN core gate + frontier/width/readout/input-width/blocker probes.
- `tests/run-pass/brain_ossm_sigmoid_polarity.sio` — run-pass witness.
- `tests/known_failures/ekan_fixed_point_*_native_v2_*.sio` (12) — native-v2 blocker probes, each carrying a `//@ known-failure` marker (native-v2 build exits 139 for these E-KAN shapes; intentional blocker documentation, not accidental red).

## Verification (lean_single, before commit)
- `souc check examples/brain_ossm_abide.sio` → exit 0.
- `tests/run-pass/brain_ossm_sigmoid_polarity.sio` → `BRAIN_OSSM_SIGMOID_POLARITY_PASS`.
- `examples/epistemic_kan_fixed_point.sio` → `ALL PASS`.
- `scripts/ci/brain_ossm_sigmoid_polarity_gate.sh` → PASS.
- `scripts/ci/ekan_native_core_gate.sh` → `EKAN_NATIVE_CORE_GATE_PASS`.
- All 7 gate scripts pass `bash -n`.

## Deliberately excluded (mis-grouped scratch, left untracked for their own campaigns)
`tests/test_op.sio` + `tests/test_op_gen.sio` (dissertation dossier scratch); `tests/run-pass/int_arg_narrow_nonliteral.sio` (strictness campaign round 5).