### PR TITLE
research(neurodyn): NeuroDyn/Brain-O-SSM campaign harness (Cluster C)

### DIFF
--- a/scripts/gpu/prepare_abide_campaign_snapshot.sh
+++ b/scripts/gpu/prepare_abide_campaign_snapshot.sh
@@ -13,11 +13,13 @@ mkdir -p \
 _copy() { cp -a "$1" "$2"; }
 _copy "${SRC_ROOT}/bin/souc" "${OUT_ROOT}/bin/"
 _copy "${SRC_ROOT}/bin/souc-native" "${OUT_ROOT}/bin/"
+_copy "${SRC_ROOT}/bin/souc-linux-x86_64" "${OUT_ROOT}/bin/"
 _copy "${SRC_ROOT}/artifacts/self-hosted/souc-self-hosted-x86_64" "${OUT_ROOT}/artifacts/self-hosted/"
 _copy "${SRC_ROOT}/examples/brain_ossm_abide.sio" "${OUT_ROOT}/examples/"
 _copy "${SRC_ROOT}/scripts/research/abide_campaign_lib.py" "${OUT_ROOT}/scripts/research/"
 _copy "${SRC_ROOT}/scripts/research/build_abide_temporal_manifest.py" "${OUT_ROOT}/scripts/research/"
 _copy "${SRC_ROOT}/scripts/research/normalize_abide_manifest.py" "${OUT_ROOT}/scripts/research/"
+_copy "${SRC_ROOT}/scripts/research/abide_manifest_quality_gate.py" "${OUT_ROOT}/scripts/research/"
 _copy "${SRC_ROOT}/scripts/research/parse_brain_ossm_abide_output.py" "${OUT_ROOT}/scripts/research/"
 _copy "${SRC_ROOT}/scripts/research/abide_external_baselines.py" "${OUT_ROOT}/scripts/research/"
 _copy "${SRC_ROOT}/scripts/research/aggregate_brain_ossm_campaign.py" "${OUT_ROOT}/scripts/research/"

--- a/scripts/research/README.md
+++ b/scripts/research/README.md
@@ -1,0 +1,53 @@
+# `scripts/research/` — campaign harness (NOT the Sounio science path)
+
+**Boundary (read first).** Everything in this directory is the **research-campaign
+harness**: Python/shell tooling that *prepares manifests, gates data quality,
+orchestrates runs, parses model output, computes decision verdicts, and stamps
+provenance*. It is **not** the Sounio science path.
+
+The actual scientific model — the octonionic O-SSM dynamics, uncertainty
+propagation, associator geometry — is implemented in Sounio and runs through
+`bin/souc` on `.sio` sources (e.g. `examples/brain_ossm_abide.sio`,
+`examples/cognitive_ossm/`). Per CLAUDE.md Principle 4, the science stays in
+Sounio; these drivers only build the scaffolding around it and read the
+`STATE_TRACE` / benchmark output the compiled `.sio` model emits.
+
+Do not migrate numerical *science* into this directory. If a computation is a
+scientific result, it belongs in `.sio`.
+
+## What lives here
+
+A NeuroDyn / Brain-O-SSM computational-psychiatry campaign:
+
+- **Manifest & null generators** — synthetic paired non-associative trajectories,
+  temporal-arrow / Fano-line / permutation-null manifests, with `SHA256SUMS`.
+- **Diagnostics** — hidden-state separability, orientation / associator-vector
+  readouts, Fano-orbit geometry, temporal-arrow polarity, all with permutation
+  null envelopes.
+- **Campaign gates** — ABIDE dynamic-FC (`abide_dynamic_fc_switching_*`) and
+  ADHD-200 dimensional (`adhd200_*`) target → gate → decision chains, each
+  emitting a bounded, no-promotion verdict.
+
+Convention across drivers: `argparse` CLIs with `__main__`, deterministic
+JSON + Markdown + `SHA256SUMS` outputs, and explicit **no-clinical-claim**
+boundaries in the decision gates.
+
+## Data & reproducibility
+
+- **Public data only.** ADHD-200 access (`adhd200_s3_bootstrap.py`,
+  `adhd200_data_access_audit.py`) uses the **anonymous public** `s3://fcp-indi`
+  bucket / PCP mirrors over unauthenticated HTTPS. No credentials, no PHI, no
+  private buckets are used or stored.
+- **External inputs are not versioned here.** Drivers consume `STATE_TRACE`
+  CSVs, ROI `.1D` timeseries, and manifests produced elsewhere; reproducibility
+  depends on that upstream data provenance.
+- **Cluster-coupled outliers.** A few scripts (`neurodyn_scale14x14_missing_roi_rerun.py`,
+  `neurodyn_orangefs_not_required_gate.py`, the Slurm smokes) hardwire this pod's
+  k8s / CephFS / partition defaults and invoke `kubectl` / `singularity` / `srun`;
+  they are recorded for provenance but will not run off this cluster.
+
+## Dependencies
+
+Mostly Python standard library. Third-party: see [`requirements.txt`](requirements.txt)
+(`numpy`, `scipy`). Install into a throwaway venv; nothing here is part of the
+Sounio toolchain build.

--- a/scripts/research/abide_checkpoint_persist.py
+++ b/scripts/research/abide_checkpoint_persist.py
@@ -1,0 +1,1210 @@
+#!/usr/bin/env python3
+"""Persist and verify Brain O-SSM ABIDE fold checkpoints from benchmark stdout."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from abide_campaign_lib import load_manifest
+
+
+SCALE = 100_000_000.0
+INTERNAL_CV_SITE_1 = 177622
+INTERNAL_CV_SITE_2 = 177623
+INTERNAL_CV_KEYS = {INTERNAL_CV_SITE_1, INTERNAL_CV_SITE_2}
+I64_STATE_ARRAYS = ("W", "MOM", "A_MOM", "PROJ_W", "PROJ_B", "PROJ_W_MOM", "PROJ_B_MOM", "DROP_MASK")
+F64_STATE_ARRAYS = ("A", "TRAIN_FEATURE_MEAN", "TRAIN_FEATURE_STD")
+I64_MASK = (1 << 64) - 1
+I64_SIGN = 1 << 63
+DECIMAL_FRAGMENT_RE = re.compile(r"^\.\d+$")
+
+
+def fixed_to_float(value: int) -> float:
+    return value / SCALE
+
+
+def exact_int(value: str | int | float) -> int:
+    """Parse native integer metadata without losing large i64 precision."""
+
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise ValueError(f"expected integer metadata, got {value!r}")
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        raise ValueError("empty integer metadata")
+    if any(ch in text for ch in ".eE"):
+        parsed = float(text)
+        if not parsed.is_integer():
+            raise ValueError(f"expected integer metadata, got {value!r}")
+        return int(parsed)
+    return int(text)
+
+
+def i64(value: int) -> int:
+    value &= I64_MASK
+    if value >= I64_SIGN:
+        value -= 1 << 64
+    return value
+
+
+def abs_i64(value: int) -> int:
+    return -value if value < 0 else value
+
+
+def parse_blocks(raw_output: Path) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    lines = raw_output.read_text(encoding="utf-8", errors="replace").splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if line == "CKPT_BEGIN":
+            current = {"meta": {}, "arrays": {}}
+            idx += 1
+            continue
+        if line == "CKPT_END":
+            if current is not None:
+                blocks.append(current)
+            current = None
+            idx += 1
+            continue
+        if current is None:
+            idx += 1
+            continue
+        parts = line.split("\t")
+        if len(parts) >= 3 and parts[0] == "CKPT_META":
+            value = parts[2]
+            next_idx = idx + 1
+            if next_idx < len(lines) and DECIMAL_FRAGMENT_RE.match(lines[next_idx].strip()):
+                value = f"{value}{lines[next_idx].strip()}"
+                next_idx += 1
+            current["meta"][parts[1]] = value
+            idx = next_idx
+            continue
+        elif len(parts) >= 4 and parts[0] == "CKPT_ARRAY":
+            name, dtype, count_raw = parts[1], parts[2], int(parts[3])
+            values_raw = parts[4 : 4 + count_raw]
+            next_idx = idx + 1
+            while len(values_raw) < count_raw and next_idx < len(lines):
+                next_line = lines[next_idx]
+                if next_line.startswith(("CKPT_META", "CKPT_ARRAY", "CKPT_END")):
+                    break
+                stripped = next_line.strip()
+                if not stripped:
+                    next_idx += 1
+                    continue
+                if DECIMAL_FRAGMENT_RE.match(stripped) and values_raw:
+                    values_raw[-1] = f"{values_raw[-1]}{stripped}"
+                else:
+                    values_raw.extend(part for part in next_line.split("\t") if part)
+                next_idx += 1
+            if len(values_raw) != count_raw:
+                raise ValueError(f"checkpoint array {name} expected {count_raw} values, got {len(values_raw)}")
+            if dtype == "i64":
+                values = [int(v) for v in values_raw]
+            elif dtype == "f64":
+                values = [float(v) for v in values_raw]
+            else:
+                raise ValueError(f"unsupported checkpoint dtype {dtype!r} for {name}")
+            current["arrays"][name] = {"dtype": dtype, "values": values}
+            idx = next_idx
+            continue
+        idx += 1
+    for block in blocks:
+        arrays = block.get("arrays", {})
+        if "A_FIXED" in arrays:
+            arrays["A"] = {
+                "dtype": "f64",
+                "values": [fixed_to_float(int(value)) for value in arrays["A_FIXED"]["values"]],
+            }
+    return blocks
+
+
+def merge_tab_continuation_records(lines: list[str], prefixes: tuple[str, ...]) -> list[str]:
+    merged: list[str] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if line.startswith(prefixes):
+            parts = [part for part in line.split("\t") if part]
+            next_idx = idx + 1
+            while next_idx < len(lines) and lines[next_idx].startswith("\t"):
+                parts.extend(part for part in lines[next_idx].split("\t") if part)
+                next_idx += 1
+            merged.append("\t".join(parts))
+            idx = next_idx
+            continue
+        merged.append(line)
+        idx += 1
+    return merged
+
+
+def array_has_signal(block: dict[str, Any], name: str) -> bool:
+    values = block.get("arrays", {}).get(name, {}).get("values", [])
+    return any(abs(float(v)) > 1.0e-12 for v in values)
+
+
+def parse_run_config(path: Path | None) -> dict[str, str]:
+    if path is None or not path.exists():
+        return {}
+    config: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        config[key.strip()] = value.strip()
+    return config
+
+
+def int_config(config: dict[str, str], key: str) -> int | None:
+    value = config.get(key)
+    if value is None or value == "":
+        return None
+    try:
+        return exact_int(value)
+    except ValueError:
+        return None
+
+
+def expected_meta_from_config(config: dict[str, str]) -> dict[str, int]:
+    mapping = {
+        "oct_profile_id": "cfg_oct_profile_id",
+        "oct_train_mode": "cfg_oct_train_mode",
+        "oct_input_proj_mode": "cfg_oct_input_proj_mode",
+    }
+    expected: dict[str, int] = {}
+    for config_key, meta_key in mapping.items():
+        value = int_config(config, config_key)
+        if value is not None:
+            expected[meta_key] = value
+    return expected
+
+
+def block_matches_expected(block: dict[str, Any], expected_meta: dict[str, int]) -> bool:
+    meta = block.get("meta", {})
+    if meta.get("model") != "O-SSM":
+        return False
+    for key, expected in expected_meta.items():
+        if key not in meta:
+            return False
+        try:
+            actual = exact_int(meta[key])
+        except ValueError:
+            return False
+        if actual != expected:
+            return False
+    return True
+
+
+def best_block(blocks: list[dict[str, Any]], expected_meta: dict[str, int] | None = None) -> dict[str, Any]:
+    if not blocks:
+        raise ValueError("no CKPT blocks found in raw benchmark output")
+    expected_meta = expected_meta or {}
+    candidates = [
+        block
+        for block in blocks
+        if block_matches_expected(block, expected_meta) and array_has_signal(block, "A")
+    ]
+    if not candidates:
+        profile_hint = ", ".join(f"{k}={v}" for k, v in sorted(expected_meta.items())) or "no config filter"
+        raise ValueError(
+            "no valid O-SSM CKPT blocks found with nonzero A tensor "
+            f"({profile_hint}); refusing to persist an incomplete checkpoint"
+        )
+    return max(candidates, key=lambda block: float(block["meta"]["balanced_accuracy_pct"]))
+
+
+def site_hash(site: str) -> int:
+    h = 5381
+    for ch in site:
+        h = i64(i64(h * 33) + ord(ch))
+    return abs_i64(h)
+
+
+def unique_site_key_count(records: list[Any]) -> int:
+    return len({site_hash(record.site) for record in records})
+
+
+def single_site_internal_cv_enabled(
+    config: dict[str, str] | None,
+    records: list[Any],
+    holdout_key: int | None = None,
+) -> bool:
+    if config and int_config(config, "single_site_internal_cv") == 1:
+        return True
+    return holdout_key in INTERNAL_CV_KEYS and unique_site_key_count(records) < 2
+
+
+def materialize_single_site_internal_cv_keys(records: list[Any]) -> list[int]:
+    site_keys: list[int] = []
+    pos_seen = 0
+    neg_seen = 0
+    for record in records:
+        if int(record.label) == 1:
+            site_keys.append(INTERNAL_CV_SITE_1 if pos_seen % 2 == 0 else INTERNAL_CV_SITE_2)
+            pos_seen += 1
+        else:
+            site_keys.append(INTERNAL_CV_SITE_1 if neg_seen % 2 == 0 else INTERNAL_CV_SITE_2)
+            neg_seen += 1
+    return site_keys
+
+
+def int_meta(meta: dict[str, str], key: str) -> int:
+    return exact_int(meta[key])
+
+
+def exp_q(x: float) -> float:
+    if x > 15.0:
+        return exp_q(7.5) * exp_q(x - 7.5)
+    if x < -15.0:
+        return 0.0
+    if x < 0.0:
+        return 1.0 / exp_q(-x)
+    total = 1.0
+    term = 1.0
+    for i in range(1, 21):
+        term = term * x / float(i)
+        total += term
+    return total
+
+
+def sqrt_q(x: float) -> float:
+    if math.isnan(x) or x <= 0.0:
+        return 0.0
+    g = x
+    for _ in range(16):
+        g = 0.5 * (g + x / g)
+    return 0.0 if math.isnan(g) else g
+
+
+def sigmoid_q(x: float) -> float:
+    if x >= 0.0:
+        return 1.0 / (1.0 + exp_q(-x))
+    ex = exp_q(x)
+    return ex / (1.0 + ex)
+
+
+def clip(x: float, lo: float, hi: float) -> float:
+    return lo if x < lo else hi if x > hi else x
+
+
+def squash_pos(x: float) -> float:
+    return 0.0 if x <= 0.0 else x / (1.0 + x)
+
+
+def md2_squash(v: float) -> float:
+    return v / (1.0 + v) if v >= 0.0 else v / (1.0 + -v)
+
+
+def mandelbrot_d2_feature(seed: float, delta: float) -> float:
+    z = clip(0.55 * seed + 0.20 * delta, -2.0, 2.0)
+    c = clip(0.35 * seed + 0.25 * delta, -2.0, 2.0)
+    dz = 1.0 + 0.10 * delta
+    ddz = 0.0
+    for _ in range(3):
+        ddz = 2.0 * (dz * dz + z * ddz)
+        dz = 2.0 * z * dz + 1.0 + 0.15 * delta
+        z = clip(z * z + c, -4.0, 4.0)
+        dz = clip(dz, -6.0, 6.0)
+        ddz = clip(ddz, -8.0, 8.0)
+    return clip(md2_squash(ddz), -1.5, 1.5)
+
+
+def oct_mul(a: list[float], b: list[float]) -> list[float]:
+    a0, a1, a2, a3, a4, a5, a6, a7 = a
+    b0, b1, b2, b3, b4, b5, b6, b7 = b
+    return [
+        a0 * b0 - a1 * b1 - a2 * b2 - a3 * b3 - a4 * b4 - a5 * b5 - a6 * b6 - a7 * b7,
+        a0 * b1 + a1 * b0 + a2 * b3 - a3 * b2 + a4 * b5 - a5 * b4 - a6 * b7 + a7 * b6,
+        a0 * b2 + a2 * b0 - a1 * b3 + a3 * b1 + a4 * b6 - a6 * b4 + a5 * b7 - a7 * b5,
+        a0 * b3 + a3 * b0 + a1 * b2 - a2 * b1 + a4 * b7 - a7 * b4 - a5 * b6 + a6 * b5,
+        a0 * b4 + a4 * b0 - a1 * b5 + a5 * b1 - a2 * b6 + a6 * b2 - a3 * b7 + a7 * b3,
+        a0 * b5 + a5 * b0 + a1 * b4 - a4 * b1 - a2 * b7 + a7 * b2 + a3 * b6 - a6 * b3,
+        a0 * b6 + a6 * b0 + a1 * b7 - a7 * b1 + a2 * b4 - a4 * b2 - a3 * b5 + a5 * b3,
+        a0 * b7 + a7 * b0 - a1 * b6 + a6 * b1 - a2 * b5 + a5 * b2 + a3 * b4 - a4 * b3,
+    ]
+
+
+class CheckpointForward:
+    def __init__(self, ckpt: dict[str, Any]) -> None:
+        self.meta = ckpt["meta"]
+        arrays = ckpt["arrays"]
+        self.w = arrays["W"]["values"]
+        self.a = arrays["A"]["values"]
+        self.proj_w = arrays["PROJ_W"]["values"]
+        self.proj_b = arrays["PROJ_B"]["values"]
+        self.mean = arrays["TRAIN_FEATURE_MEAN"]["values"]
+        self.std = arrays["TRAIN_FEATURE_STD"]["values"]
+        self.drop_mask = arrays["DROP_MASK"]["values"]
+        self.seq_len = int_meta(self.meta, "manifest_seq_len")
+        self.feature_count = int_meta(self.meta, "manifest_feature_count")
+        self.proj_mode = int_meta(self.meta, "cfg_oct_input_proj_mode")
+        self.noise_std = int_meta(self.meta, "cfg_noise_std_bp") / 1_000_000.0
+        self.fold_noise_key = int_meta(self.meta, "fold_noise_key")
+        self.proj_structured_scale = int_meta(self.meta, "cfg_oct_proj_structured_scale_bp") / 1_000_000.0
+        self.proj_delta_scale = int_meta(self.meta, "cfg_oct_proj_delta_scale_bp") / 1_000_000.0
+        self.proj_hybrid_scale = int_meta(self.meta, "cfg_oct_proj_hybrid_scale_bp") / 1_000_000.0
+        self.h = [0] * 16
+        self.assoc = [0] * 2
+
+    def wg(self, idx: int) -> float:
+        return fixed_to_float(self.w[idx])
+
+    def proj_wg(self, out_dim: int, in_dim: int) -> float:
+        return fixed_to_float(self.proj_w[out_dim * 8 + in_dim])
+
+    def proj_bg(self, out_dim: int) -> float:
+        return fixed_to_float(self.proj_b[out_dim])
+
+    def hg(self, idx: int) -> float:
+        return fixed_to_float(self.h[idx])
+
+    def hs(self, idx: int, value: float) -> None:
+        self.h[idx] = int(value * SCALE)
+
+    def assoc_g(self, head: int) -> float:
+        return fixed_to_float(self.assoc[head])
+
+    def assoc_s(self, head: int, value: float) -> None:
+        self.assoc[head] = int(value * SCALE)
+
+    def reset_state(self) -> None:
+        self.h = [0] * 16
+        self.assoc = [0] * 2
+        self.hs(0, 1.0)
+        self.hs(8, 1.0)
+
+    def perturb(self, subj_idx: int, step: int, dim: int, value: float) -> float:
+        out = value
+        if dim < len(self.drop_mask) and self.drop_mask[dim] == 1:
+            out = 0.0
+        if self.noise_std > 0.0:
+            raw = abs((((subj_idx + 1) * 1103515245) ^ ((step + 1) * 12345) ^ ((dim + 1) * 2654435761) ^ self.fold_noise_key) % 20001)
+            out += ((float(raw) - 10000.0) / 10000.0) * self.noise_std
+        return out
+
+    def project_step(self, grad: list[float], delta: list[float]) -> list[float]:
+        if self.proj_mode == 1:
+            return [clip(self.proj_bg(o) + sum(grad[i] * self.proj_wg(o, i) for i in range(8)), -4.0, 4.0) for o in range(8)]
+        if self.proj_mode == 2:
+            out = []
+            for o in range(8):
+                s = self.proj_bg(o) + sum(grad[i] * self.proj_wg(o, i) for i in range(8))
+                out.append(clip(grad[o] + 0.25 * (s - grad[o]), -4.0, 4.0))
+            return out
+        if self.proj_mode in {3, 4}:
+            out = []
+            for o in range(8):
+                base = grad[o]
+                struct_gate = clip(0.55 + 0.45 * self.proj_bg(o), -1.5, 1.5)
+                delta_gate = clip(self.proj_wg(o, o), -1.5, 1.5)
+                s = base + self.proj_structured_scale * struct_gate * mandelbrot_d2_feature(base, delta[o])
+                s += self.proj_delta_scale * delta_gate * delta[o]
+                if self.proj_mode == 4:
+                    corr = self.proj_bg(o) + sum(grad[i] * self.proj_wg(o, i) for i in range(8))
+                    s += self.proj_hybrid_scale * 0.20 * (corr - base)
+                out.append(clip(s, -4.0, 4.0))
+            return out
+        return list(grad)
+
+    def oct_step_head(self, head: int, x: list[float]) -> None:
+        base = head * 8
+        avec = self.a[base : base + 8]
+        hvec = [self.hg(base + i) for i in range(8)]
+        left = oct_mul(oct_mul(avec, hvec), x)
+        right = oct_mul(avec, oct_mul(hvec, x))
+        asq = sum((left[i] - right[i]) ** 2 for i in range(8))
+        assoc_step = sqrt_q(asq)
+        self.assoc_s(head, self.assoc_g(head) + squash_pos(assoc_step))
+        for i in range(8):
+            self.hs(base + i, clip(left[i] + 0.2 * right[i], -5.0, 5.0))
+
+    def forward(self, subj_idx: int, sequence: list[list[float]]) -> tuple[float, float]:
+        self.reset_state()
+        raw_mean = [0.0] * 8
+        last_mean = [0.0] * 8
+        first_step = [0.0] * 8
+        last_step = [0.0] * 8
+        last_flat = [0.0] * max(512, self.feature_count)
+        prev_raw = [0.0] * 8
+        for step in range(self.seq_len):
+            raw = []
+            delta = []
+            grad = []
+            for dim in range(8):
+                flat = step * 8 + dim
+                value = (sequence[step][dim] - self.mean[flat]) / self.std[flat]
+                value = self.perturb(subj_idx, step, dim, value)
+                raw.append(value)
+                d = value - prev_raw[dim] if step > 0 else 0.0
+                delta.append(d)
+                grad.append(clip(value * self.wg(554 + dim) + d * self.wg(34 + dim) + self.wg(562 + dim), -4.0, 4.0))
+            x = self.project_step(grad, delta)
+            prev_raw = raw
+            for dim in range(8):
+                raw_mean[dim] += raw[dim]
+                last_mean[dim] += x[dim]
+                last_flat[step * 8 + dim] = x[dim]
+            if step == 0:
+                first_step = list(x)
+            last_step = list(x)
+            self.oct_step_head(0, x)
+            self.oct_step_head(1, x)
+        for dim in range(8):
+            raw_mean[dim] /= float(self.seq_len)
+            last_mean[dim] /= float(self.seq_len)
+        score = self.wg(570)
+        for dim in range(16):
+            score += self.hg(dim) * self.wg(dim)
+        for head in range(2):
+            assoc_raw = self.assoc_g(head) / float(self.seq_len)
+            self.assoc_s(head, assoc_raw)
+            score += squash_pos(assoc_raw) * self.wg(16 + head)
+        for dim in range(8):
+            score += last_mean[dim] * self.wg(18 + dim)
+            score += (last_step[dim] - first_step[dim]) * self.wg(26 + dim)
+        for flat in range(self.feature_count):
+            score += last_flat[flat] * self.wg(42 + flat)
+        prob = sigmoid_q(clip(score, -12.0, 12.0))
+        assoc = sum(self.assoc_g(head) for head in range(2)) / 2.0
+        return prob, assoc
+
+
+def balanced_accuracy(labels: list[int], probs: list[float]) -> float:
+    tp = tn = fp = fn = 0
+    for label, prob in zip(labels, probs, strict=True):
+        pred = 1 if prob >= 0.5 else 0
+        if pred == 1 and label == 1:
+            tp += 1
+        elif pred == 0 and label == 0:
+            tn += 1
+        elif pred == 1 and label == 0:
+            fp += 1
+        elif pred == 0 and label == 1:
+            fn += 1
+    tpr = tp / (tp + fn) if tp + fn > 0 else 0.0
+    tnr = tn / (tn + fp) if tn + fp > 0 else 0.0
+    return 50.0 * (tpr + tnr)
+
+
+def flatten_sequence(sequence: list[list[float]], feature_count: int) -> list[float]:
+    flat: list[float] = []
+    for step in sequence:
+        flat.extend(step)
+    if len(flat) < feature_count:
+        flat.extend([0.0] * (feature_count - len(flat)))
+    return flat[:feature_count]
+
+
+def arrays_need_standardization_rebuild(ckpt: dict[str, Any]) -> bool:
+    arrays = ckpt["arrays"]
+    feature_count = int_meta(ckpt["meta"], "manifest_feature_count")
+    mean = arrays.get("TRAIN_FEATURE_MEAN", {}).get("values", [])
+    std = arrays.get("TRAIN_FEATURE_STD", {}).get("values", [])
+    if len(mean) < feature_count or len(std) < feature_count:
+        return True
+    return any((not math.isfinite(value)) or value < 1.0e-6 for value in std[:feature_count])
+
+
+def rebuild_standardization_from_manifest(ckpt: dict[str, Any], records: list[Any]) -> bool:
+    """Recover deterministic train-fold mean/std when native f64 serialization is zeroed."""
+
+    if not arrays_need_standardization_rebuild(ckpt):
+        return False
+    meta = ckpt["meta"]
+    holdout_key = int_meta(meta, "holdout_key")
+    train_fraction_bp = int_meta(meta, "cfg_train_fraction_bp")
+    if train_fraction_bp < 1_000_000:
+        raise ValueError(
+            "checkpoint has zero TRAIN_FEATURE_STD and train_fraction < 1.0; "
+            "manifest-side reconstruction for subsampled folds is not implemented"
+        )
+    feature_count = int_meta(meta, "manifest_feature_count")
+    train_flats = [
+        flatten_sequence(record.sequence, feature_count)
+        for record in records
+        if site_hash(record.site) != holdout_key
+    ]
+    if not train_flats:
+        raise ValueError(f"cannot rebuild standardization: no train records for holdout_key={holdout_key}")
+    train_n = float(len(train_flats))
+    mean = [0.0] * feature_count
+    for flat in train_flats:
+        for idx, value in enumerate(flat):
+            mean[idx] += value
+    mean = [value / train_n for value in mean]
+    var = [0.0] * feature_count
+    for flat in train_flats:
+        for idx, value in enumerate(flat):
+            diff = value - mean[idx]
+            var[idx] += diff * diff
+    std = []
+    for value in var:
+        current = sqrt_q(value / train_n)
+        if not math.isfinite(current) or current < 1.0e-6:
+            current = 1.0
+        std.append(current)
+    ckpt["arrays"]["TRAIN_FEATURE_MEAN"] = {"dtype": "f64", "values": mean}
+    ckpt["arrays"]["TRAIN_FEATURE_STD"] = {"dtype": "f64", "values": std}
+    ckpt.setdefault("repairs", {})["standardization"] = "recomputed_from_manifest_train_fold"
+    return True
+
+
+def sio_string_literal(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def sio_decimal_literal(value: float) -> str:
+    if not math.isfinite(value):
+        return "0.0"
+    text = f"{float(value):.17f}".rstrip("0").rstrip(".")
+    if text in {"", "-0"}:
+        return "0.0"
+    if "." not in text:
+        text += ".0"
+    return text
+
+
+def write_native_state_sequence(ckpt: dict[str, Any], state_path: Path) -> list[tuple[str, str, int, int]]:
+    arrays = ckpt["arrays"]
+    offsets: list[tuple[str, str, int, int]] = []
+    cursor = 0
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with state_path.open("w", encoding="utf-8") as handle:
+        for name in I64_STATE_ARRAYS:
+            values = [int(value) for value in arrays[name]["values"]]
+            start = cursor
+            for value in values:
+                handle.write(f"{value}\n")
+                cursor += 1
+            offsets.append((name, "i64", start, cursor))
+        for name in F64_STATE_ARRAYS:
+            values = [float(value) for value in arrays[name]["values"]]
+            start = cursor
+            for value in values:
+                handle.write(f"{sio_decimal_literal(value)}\n")
+                cursor += 1
+            offsets.append((name, "f64", start, cursor))
+    return offsets
+
+
+def chunked_i64_loader(name: str, values: list[int], chunk_size: int = 192) -> str:
+    pieces: list[str] = []
+    loaders: list[str] = []
+    lname = name.lower()
+    for chunk_idx, start in enumerate(range(0, len(values), chunk_size)):
+        fn_name = f"load_{lname}_{chunk_idx}"
+        loaders.append(fn_name)
+        pieces.append(f"fn {fn_name}() with Mut {{")
+        for offset, value in enumerate(values[start : start + chunk_size], start):
+            pieces.append(f"    {name}[{offset}] = {value}")
+        pieces.append("}")
+    pieces.append(f"fn load_{lname}() with Mut {{")
+    for fn_name in loaders:
+        pieces.append(f"    {fn_name}()")
+    pieces.append("}")
+    return "\n".join(pieces)
+
+
+def chunked_f64_loader(name: str, values: list[float], chunk_size: int = 192) -> str:
+    pieces: list[str] = []
+    loaders: list[str] = []
+    lname = name.lower()
+    for chunk_idx, start in enumerate(range(0, len(values), chunk_size)):
+        fn_name = f"load_{lname}_{chunk_idx}"
+        loaders.append(fn_name)
+        pieces.append(f"fn {fn_name}() with Mut {{")
+        for offset, value in enumerate(values[start : start + chunk_size], start):
+            pieces.append(f"    {name}[{offset}] = {float(value):.12g}")
+        pieces.append("}")
+    pieces.append(f"fn load_{lname}() with Mut {{")
+    for fn_name in loaders:
+        pieces.append(f"    {fn_name}()")
+    pieces.append("}")
+    return "\n".join(pieces)
+
+
+def generate_native_verifier_source(ckpt: dict[str, Any], manifest_path: Path, repo_root: Path) -> str:
+    source_path = repo_root / "examples" / "brain_ossm_abide.sio"
+    source = source_path.read_text(encoding="utf-8")
+    marker = "fn main() -> i32"
+    if marker not in source:
+        raise RuntimeError(f"cannot locate main marker in {source_path}")
+    prefix = source.split(marker, 1)[0]
+    ckpt_emit_start = "fn ckpt_i64_value("
+    ckpt_emit_end = "fn project_current_step("
+    if ckpt_emit_start in prefix and ckpt_emit_end in prefix:
+        before_emit, rest = prefix.split(ckpt_emit_start, 1)
+        _, after_emit = rest.split(ckpt_emit_end, 1)
+        # The verifier loads an already-persisted checkpoint, so native CKPT
+        # emission helpers are dead code here. Dropping them avoids a Madares
+        # backend crash in the unused checkpoint dispatch path.
+        prefix = before_emit + ckpt_emit_end + after_emit
+    ckpt_print_start = "fn print_i64_array("
+    ckpt_print_end = "fn project_current_step("
+    if ckpt_print_start in prefix and ckpt_print_end in prefix:
+        before_print, rest = prefix.split(ckpt_print_start, 1)
+        _, after_print = rest.split(ckpt_print_end, 1)
+        prefix = before_print + ckpt_print_end + after_print
+    train_update_start = "fn update_hidden_weights("
+    if train_update_start in prefix:
+        prefix = prefix.split(train_update_start, 1)[0]
+    def strip_prefix_block(current: str, start: str, end: str) -> str:
+        if start not in current or end not in current:
+            return current
+        before, rest = current.split(start, 1)
+        _, after = rest.split(end, 1)
+        return before + end + after
+
+    prefix = strip_prefix_block(prefix, "fn apply_run_config_oct_schedule_line(", "fn parse_decimal_digit(")
+    prefix = strip_prefix_block(prefix, "fn parse_decimal_digit(", "fn clear_subject_site_slot(")
+    prefix = strip_prefix_block(prefix, "fn site_name_for_key(", "fn parse_f64_span(")
+    prefix = strip_prefix_block(prefix, "fn load_local_manifest(", "fn discover_sites(")
+    prefix = strip_prefix_block(prefix, "fn debug_class_f64(", "fn abs_i64(")
+    prefix = strip_prefix_block(prefix, "fn discover_sites(", "fn perturb_feature(")
+    prefix = strip_prefix_block(prefix, "fn assoc_mean_all(", "fn print_fixed6_from_micros(")
+    prefix = strip_prefix_block(prefix, "fn print_f64_fixed6(", "fn project_current_step(")
+    train_prep_start = "fn build_train_mask("
+    train_prep_end = "fn perturb_feature("
+    if train_prep_start in prefix and train_prep_end in prefix:
+        before_train_prep, rest = prefix.split(train_prep_start, 1)
+        _, after_train_prep = rest.split(train_prep_end, 1)
+        prefix = before_train_prep + train_prep_end + after_train_prep
+    init_start = "fn normalize_head("
+    init_end = "fn reset_state("
+    if init_start in prefix and init_end in prefix:
+        before_init, rest = prefix.split(init_start, 1)
+        _, after_init = rest.split(init_end, 1)
+        prefix = before_init + init_end + after_init
+    arrays = ckpt["arrays"]
+    meta = ckpt["meta"]
+    if int_meta(meta, "cfg_oct_input_proj_mode") == 0:
+        project_start = "fn project_current_step("
+        project_end = "fn normalize_head("
+        if project_start in prefix and project_end in prefix:
+            before_project, rest = prefix.split(project_start, 1)
+            _, after_project = rest.split(project_end, 1)
+            prefix = before_project + project_end + after_project
+        prefix = prefix.replace(
+            "    project_current_step(proj_mode)",
+            """    var project_out_dim: i64 = 0
+    while project_out_dim < 8 {
+        TMP_OCT[project_out_dim as usize] = TMP_GRAD[project_out_dim as usize]
+        project_out_dim = project_out_dim + 1
+    }""",
+        )
+    parts = [prefix]
+    for name in ("W", "MOM", "A_MOM", "PROJ_W", "PROJ_B", "PROJ_W_MOM", "PROJ_B_MOM", "DROP_MASK"):
+        parts.append(chunked_i64_loader(name, arrays[name]["values"]))
+    parts.append(chunked_f64_loader("A", arrays["A"]["values"]))
+    parts.append(chunked_f64_loader("TRAIN_FEATURE_MEAN", arrays["TRAIN_FEATURE_MEAN"]["values"]))
+    parts.append(chunked_f64_loader("TRAIN_FEATURE_STD", arrays["TRAIN_FEATURE_STD"]["values"]))
+    config_keys = [
+        ("CFG_TRAIN_FRACTION_BP", "cfg_train_fraction_bp"),
+        ("CFG_DROP_CHANNEL_FRAC_BP", "cfg_drop_channel_frac_bp"),
+        ("CFG_NOISE_STD_BP", "cfg_noise_std_bp"),
+        ("CFG_GLOBAL_TRAIN_EPOCHS", "cfg_global_train_epochs"),
+        ("CFG_GLOBAL_TRAIN_LR_BP", "cfg_global_train_lr_bp"),
+        ("CFG_GLOBAL_CORE_LR_SCALE_BP", "cfg_global_core_lr_scale_bp"),
+        ("CFG_OCT_PROFILE_ID", "cfg_oct_profile_id"),
+        ("CFG_OCT_TRAIN_MODE", "cfg_oct_train_mode"),
+        ("CFG_OCT_INIT_PRESET", "cfg_oct_init_preset"),
+        ("CFG_OCT_ASSOC_REG_BP", "cfg_oct_assoc_reg_bp"),
+        ("CFG_OCT_ASSOC_TARGET_BP", "cfg_oct_assoc_target_bp"),
+        ("CFG_OCT_ASSOCIATOR_SIGN_AUX_BP", "cfg_oct_associator_sign_aux_bp"),
+        ("CFG_OCT_TRAIN_NOISE_STD_BP", "cfg_oct_train_noise_std_bp"),
+        ("CFG_OCT_RELATION_PRESERVE_AUX_BP", "cfg_oct_relation_preserve_aux_bp"),
+        ("CFG_OCT_RELATION_TARGET_AUX_BP", "cfg_oct_relation_target_aux_bp"),
+        ("CFG_OCT_RELATION_MARGIN_AUX_BP", "cfg_oct_relation_margin_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_AUX_BP", "cfg_oct_relation_identity_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_SRC_AUX_BP", "cfg_oct_relation_identity_src_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_DST_AUX_BP", "cfg_oct_relation_identity_dst_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_START_EPOCH", "cfg_oct_relation_identity_start_epoch"),
+        ("CFG_OCT_RELATION_IDENTITY_RAMP_EPOCHS", "cfg_oct_relation_identity_ramp_epochs"),
+        ("CFG_OCT_RELATION_IDENTITY_TIE_MARGIN_BP", "cfg_oct_relation_identity_tie_margin_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_GATE_MARGIN_BP", "cfg_oct_relation_identity_gate_margin_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_GATE_FLOOR_BP", "cfg_oct_relation_identity_gate_floor_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_TASK_GUARD", "cfg_oct_relation_identity_task_guard"),
+        ("CFG_OCT_RELATION_IDENTITY_TASK_GUARD_TOL_BP", "cfg_oct_relation_identity_task_guard_tol_bp"),
+        ("CFG_OCT_RELATION_READOUT_CORRECT_STEPS", "cfg_oct_relation_readout_correct_steps"),
+        ("CFG_OCT_RELATION_READOUT_CORRECT_LR_SCALE_BP", "cfg_oct_relation_readout_correct_lr_scale_bp"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_CORRECT_STEPS", "cfg_oct_associator_readout_correct_steps"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_CORRECT_LR_SCALE_BP", "cfg_oct_associator_readout_correct_lr_scale_bp"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_ALIGN_EPOCHS", "cfg_oct_associator_readout_align_epochs"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_ALIGN_LR_SCALE_BP", "cfg_oct_associator_readout_align_lr_scale_bp"),
+        ("CFG_OCT_RELATION_MARGIN_GATE_CAP_BP", "cfg_oct_relation_margin_gate_cap_bp"),
+        ("CFG_OCT_RELATION_MARGIN_START_EPOCH", "cfg_oct_relation_margin_start_epoch"),
+        ("CFG_OCT_RELATION_MARGIN_RAMP_EPOCHS", "cfg_oct_relation_margin_ramp_epochs"),
+        ("CFG_OCT_RELATION_FREEZE_AFTER_EPOCH", "cfg_oct_relation_freeze_after_epoch"),
+        ("CFG_OCT_RELATION_POST_FREEZE_SCALE_BP", "cfg_oct_relation_post_freeze_scale_bp"),
+        ("CFG_OCT_BINARY_LR_SCALE_AFTER_EPOCH", "cfg_oct_binary_lr_scale_after_epoch"),
+        ("CFG_OCT_BINARY_LR_POST_SCALE_BP", "cfg_oct_binary_lr_post_scale_bp"),
+        ("CFG_OCT_RELATION_TASK_GUARD", "cfg_oct_relation_task_guard"),
+        ("CFG_OCT_RELATION_TASK_GUARD_TOL_BP", "cfg_oct_relation_task_guard_tol_bp"),
+        ("CFG_OCT_RELATION_TARGET_SRC_POS", "cfg_oct_relation_target_src_pos"),
+        ("CFG_OCT_RELATION_TARGET_DST_POS", "cfg_oct_relation_target_dst_pos"),
+        ("CFG_OCT_INPUT_PROJ_MODE", "cfg_oct_input_proj_mode"),
+        ("CFG_OCT_PROJ_LR_SCALE_BP", "cfg_oct_proj_lr_scale_bp"),
+        ("CFG_OCT_PROJ_STRUCTURED_SCALE_BP", "cfg_oct_proj_structured_scale_bp"),
+        ("CFG_OCT_PROJ_DELTA_SCALE_BP", "cfg_oct_proj_delta_scale_bp"),
+        ("CFG_OCT_PROJ_HYBRID_SCALE_BP", "cfg_oct_proj_hybrid_scale_bp"),
+    ]
+    config_lines = ["fn load_ckpt_config() with Mut {"]
+    for var_name, meta_key in config_keys:
+        if meta_key in meta:
+            config_lines.append(f"    {var_name} = {int_meta(meta, meta_key)}")
+    config_lines.append("}")
+    parts.append("\n".join(config_lines))
+    manifest_literal = sio_string_literal(str(manifest_path.resolve()))
+    holdout_key = int_meta(meta, "holdout_key")
+    seed_a = int_meta(meta, "seed_a")
+    seed_b = int_meta(meta, "seed_b")
+    fold_noise_key = int_meta(meta, "fold_noise_key")
+    parts.append(
+        f"""
+fn load_ckpt_state() with Mut {{
+    load_w()
+    load_mom()
+    load_a()
+    load_a_mom()
+    load_proj_w()
+    load_proj_b()
+    load_proj_w_mom()
+    load_proj_b_mom()
+    load_drop_mask()
+    load_train_feature_mean()
+    load_train_feature_std()
+}}
+
+fn verify_holdout_only(holdout_key: i64) -> f64 with IO, Mut, Div, Panic {{
+    var tp: i64 = 0
+    var tn: i64 = 0
+    var fp: i64 = 0
+    var fnn: i64 = 0
+    var test_n: i64 = 0
+    var pos_n: i64 = 0
+    var neg_n: i64 = 0
+    var subj: i64 = 0
+    while subj < SUBJECT_COUNT {{
+        if SITE_KEYS[subj as usize] == holdout_key {{
+            forward_subject(subj, 1)
+            let prob = sigmoid_q(LOGIT)
+            let pred = if prob >= 0.5 {{ 1 }} else {{ 0 }}
+            let label = LABELS[subj as usize]
+            print("VERIFY_PRED\\t")
+            print_int(subj); print("\\t"); print_int(label); print("\\t")
+            print_int((prob * 1000000.0) as i64); print("\\t")
+            if LOGIT > 0.0 {{ print_int(1) }} else if LOGIT < 0.0 {{ print_int(0 - 1) }} else {{ print_int(0) }}
+            print("\\t"); print_int(pred); print("\\n")
+            if pred == 1 && label == 1 {{ tp = tp + 1 }}
+            if pred == 0 && label == 0 {{ tn = tn + 1 }}
+            if pred == 1 && label == 0 {{ fp = fp + 1 }}
+            if pred == 0 && label == 1 {{ fnn = fnn + 1 }}
+            if label == 1 {{ pos_n = pos_n + 1 }} else {{ neg_n = neg_n + 1 }}
+            test_n = test_n + 1
+        }}
+        subj = subj + 1
+    }}
+    if pos_n == 0 || neg_n == 0 || test_n == 0 {{ return 0.0 }}
+    var tpr = 0.0
+    if tp + fnn > 0 {{ tpr = (tp as f64) / ((tp + fnn) as f64) }}
+    var tnr = 0.0
+    if tn + fp > 0 {{ tnr = (tn as f64) / ((tn + fp) as f64) }}
+    let bal = 50.0 * (tpr + tnr)
+    print("VERIFY_COUNTS\\t")
+    print_int(tp); print("\\t"); print_int(tn); print("\\t"); print_int(fp); print("\\t"); print_int(fnn); print("\\t"); print_int(test_n); print("\\n")
+    bal
+}}
+
+fn main() -> i32 with IO, Mut, Div, Panic {{
+    reset_run_config_defaults()
+    load_ckpt_config()
+    let loaded = load_manifest({manifest_literal})
+    if loaded == 0 {{ print("VERIFY_FAIL\\tmanifest\\n"); return 2 }}
+    let holdout_key: i64 = {holdout_key}
+    let seed_a: i64 = {seed_a}
+    let seed_b: i64 = {seed_b}
+    FOLD_NOISE_KEY = {fold_noise_key}
+    load_ckpt_state()
+    let bal = verify_holdout_only(holdout_key)
+    print("VERIFY_BAL\\t")
+    print_fixed6_from_micros((bal * 1000000.0) as i64)
+    print("\\n")
+    return 0
+}}
+"""
+    )
+    return "\n".join(parts)
+
+
+def run_native_verifier(
+    checkpoint_path: Path,
+    ckpt: dict[str, Any],
+    manifest_path: Path,
+    tolerance_pp: float,
+    repo_root: Path | None = None,
+    compile_timeout_sec: float = 300.0,
+    run_timeout_sec: float = 180.0,
+    souc_engine: str | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root or Path(os.environ.get("SOUNIO_CHECKPOINT_REPO_ROOT", "") or Path(__file__).resolve().parents[2])
+    repo_root = repo_root.resolve()
+    checkpoint_path = checkpoint_path.resolve()
+    manifest_path = manifest_path.resolve()
+    short_digest = hashlib.sha256(str(manifest_path).encode("utf-8")).hexdigest()[:12]
+    native_manifest_path = Path("/tmp") / f"brain_ossm_verify_manifest_{os.getpid()}_{short_digest}.tsv"
+    native_manifest_path.write_text(manifest_path.read_text(encoding="utf-8", errors="replace"), encoding="utf-8")
+    verify_dir = checkpoint_path.parent / f".{checkpoint_path.stem}.native-verify"
+    verify_dir.mkdir(parents=True, exist_ok=True)
+    verifier_source = verify_dir / "verify_checkpoint.sio"
+    verifier_binary = verify_dir / "verify_checkpoint.elf"
+    verifier_source.write_text(generate_native_verifier_source(ckpt, native_manifest_path, repo_root), encoding="utf-8")
+
+    env = dict(os.environ)
+    env.setdefault("SOUNIO_STDLIB_PATH", str(repo_root / "stdlib"))
+    if souc_engine:
+        env["SOUNIO_SOUC_ENGINE"] = souc_engine
+    compiler = repo_root / "bin" / "souc"
+    compile_proc = subprocess.run(
+        [str(compiler), "compile", str(verifier_source), "-o", str(verifier_binary)],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=compile_timeout_sec,
+    )
+    compile_output = compile_proc.stdout + compile_proc.stderr
+    if compile_proc.returncode != 0 or "exceeds IR_MAX_INSTRS" in compile_output:
+        raise RuntimeError(
+            "native checkpoint verifier compile failed\n"
+            f"returncode={compile_proc.returncode}\n{compile_output}"
+        )
+    verifier_binary.chmod(verifier_binary.stat().st_mode | 0o111)
+
+    run_proc = subprocess.run(
+        [str(verifier_binary)],
+        cwd=verify_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=run_timeout_sec,
+    )
+    run_output = run_proc.stdout + run_proc.stderr
+    if run_proc.returncode != 0:
+        raise RuntimeError(
+            "native checkpoint verifier run failed\n"
+            f"returncode={run_proc.returncode}\n{run_output}"
+        )
+
+    actual: float | None = None
+    counts: dict[str, int] | None = None
+    sample: dict[str, Any] | None = None
+    heldout = 0
+    for line in merge_tab_continuation_records(run_proc.stdout.splitlines(), ("VERIFY_PRED", "VERIFY_COUNTS", "VERIFY_BAL")):
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0] == "VERIFY_BAL":
+            actual = float(parts[1])
+        elif len(parts) >= 6 and parts[0] == "VERIFY_COUNTS":
+            counts = {
+                "tp": int(parts[1]),
+                "tn": int(parts[2]),
+                "fp": int(parts[3]),
+                "fn": int(parts[4]),
+                "test_n": int(parts[5]),
+            }
+            heldout = counts["test_n"]
+        elif len(parts) >= 6 and parts[0] == "VERIFY_PRED":
+            heldout += 1 if counts is None else 0
+            if sample is None:
+                sample = {
+                    "subject_index": int(parts[1]),
+                    "label": int(parts[2]),
+                    "prob_micros": int(parts[3]),
+                    "logit_sign": int(parts[4]),
+                    "pred": int(parts[5]),
+                }
+    if actual is None:
+        raise RuntimeError(f"native checkpoint verifier did not emit VERIFY_BAL\n{run_output}")
+
+    expected = float(ckpt["meta"]["balanced_accuracy_pct"])
+    delta = abs(actual - expected)
+    result = {
+        "status": "pass" if delta <= tolerance_pp else "fail",
+        "method": "sounio_native_fresh_process",
+        "expected_balanced_accuracy_pct": expected,
+        "actual_balanced_accuracy_pct": actual,
+        "delta_pp": delta,
+        "tolerance_pp": tolerance_pp,
+        "heldout_subjects": heldout,
+        "counts": counts,
+        "sample_forward": sample,
+        "verifier_source": str(verifier_source),
+        "verifier_binary": str(verifier_binary),
+        "native_souc_engine": souc_engine or env.get("SOUNIO_SOUC_ENGINE", ""),
+        "native_manifest_path": str(native_manifest_path),
+        "source_manifest_path": str(manifest_path),
+    }
+    if result["status"] != "pass":
+        raise AssertionError(json.dumps(result, indent=2, sort_keys=True))
+    return result
+
+
+def site_keys_for_records(records: list[Any], holdout_key: int, config: dict[str, str] | None = None) -> list[int]:
+    if single_site_internal_cv_enabled(config, records, holdout_key):
+        return materialize_single_site_internal_cv_keys(records)
+    return [site_hash(record.site) for record in records]
+
+
+def run_python_verifier(
+    checkpoint_path: Path,
+    ckpt: dict[str, Any],
+    manifest_path: Path,
+    tolerance_pp: float,
+    run_config: dict[str, str] | None = None,
+    native_failure: str | None = None,
+) -> dict[str, Any]:
+    _, records = load_manifest(manifest_path)
+    rebuild_standardization_from_manifest(ckpt, records)
+    holdout_key = int_meta(ckpt["meta"], "holdout_key")
+    site_keys = site_keys_for_records(records, holdout_key, run_config)
+    forward = CheckpointForward(ckpt)
+    labels: list[int] = []
+    probs: list[float] = []
+    sample: dict[str, Any] | None = None
+    tp = tn = fp = fn = 0
+    heldout = 0
+    for subj_idx, (record, site_key) in enumerate(zip(records, site_keys, strict=True)):
+        if site_key != holdout_key:
+            continue
+        prob, assoc = forward.forward(subj_idx, record.sequence)
+        label = int(record.label)
+        pred = 1 if prob >= 0.5 else 0
+        labels.append(label)
+        probs.append(prob)
+        heldout += 1
+        if pred == 1 and label == 1:
+            tp += 1
+        elif pred == 0 and label == 0:
+            tn += 1
+        elif pred == 1 and label == 0:
+            fp += 1
+        elif pred == 0 and label == 1:
+            fn += 1
+        if sample is None:
+            sample = {
+                "subject_index": subj_idx,
+                "subject_id": record.subject_id,
+                "site": record.site,
+                "site_key": site_key,
+                "label": label,
+                "prob": prob,
+                "pred": pred,
+                "assoc": assoc,
+            }
+    if heldout == 0:
+        raise AssertionError(f"python checkpoint verifier found no holdout records for holdout_key={holdout_key}")
+
+    actual = balanced_accuracy(labels, probs)
+    expected = float(ckpt["meta"]["balanced_accuracy_pct"])
+    delta = abs(actual - expected)
+    result = {
+        "status": "pass" if delta <= tolerance_pp else "fail",
+        "method": "python_fresh_process",
+        "expected_balanced_accuracy_pct": expected,
+        "actual_balanced_accuracy_pct": actual,
+        "delta_pp": delta,
+        "tolerance_pp": tolerance_pp,
+        "heldout_subjects": heldout,
+        "holdout_key": holdout_key,
+        "counts": {"tp": tp, "tn": tn, "fp": fp, "fn": fn, "test_n": heldout},
+        "sample_forward": sample,
+        "checkpoint_path": str(checkpoint_path.resolve()),
+        "source_manifest_path": str(manifest_path.resolve()),
+    }
+    if native_failure:
+        result["native_verifier_status"] = "blocked"
+        result["native_verifier_failure"] = native_failure[-4000:]
+    if result["status"] != "pass":
+        raise AssertionError(json.dumps(result, indent=2, sort_keys=True))
+    return result
+
+
+def verify_checkpoint(
+    checkpoint_path: Path,
+    manifest_path: Path,
+    tolerance_pp: float,
+    repo_root: Path | None = None,
+    verification_mode: str = "auto",
+    run_config: dict[str, str] | None = None,
+    native_compile_timeout_sec: float = 300.0,
+    native_run_timeout_sec: float = 180.0,
+    native_souc_engine: str | None = None,
+) -> dict[str, Any]:
+    ckpt = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    if not array_has_signal(ckpt, "A"):
+        raise AssertionError("checkpoint A tensor is empty/all-zero; refusing verification without octonionic state")
+    _, records = load_manifest(manifest_path)
+    rebuild_standardization_from_manifest(ckpt, records)
+    if verification_mode == "python":
+        return run_python_verifier(checkpoint_path, ckpt, manifest_path, tolerance_pp, run_config)
+    if verification_mode == "native":
+        return run_native_verifier(
+            checkpoint_path,
+            ckpt,
+            manifest_path,
+            tolerance_pp,
+            repo_root,
+            native_compile_timeout_sec,
+            native_run_timeout_sec,
+            native_souc_engine,
+        )
+    if verification_mode != "auto":
+        raise ValueError(f"unsupported verification mode: {verification_mode!r}")
+    try:
+        return run_native_verifier(
+            checkpoint_path,
+            ckpt,
+            manifest_path,
+            tolerance_pp,
+            repo_root,
+            native_compile_timeout_sec,
+            native_run_timeout_sec,
+            native_souc_engine,
+        )
+    except Exception as exc:  # noqa: BLE001 - auto mode records native blockage, then verifies independently.
+        return run_python_verifier(
+            checkpoint_path,
+            ckpt,
+            manifest_path,
+            tolerance_pp,
+            run_config,
+            native_failure=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def persist(args: argparse.Namespace) -> int:
+    blocks = parse_blocks(Path(args.raw_output))
+    run_config = parse_run_config(Path(args.run_config) if args.run_config else None)
+    block = best_block(blocks, expected_meta_from_config(run_config))
+    ckpt = {
+        "schema": "brain_ossm_abide_model_checkpoint_container.v1",
+        "run_id": args.run_id,
+        "selection": {
+            "strategy": "max_o_ssm_fold_balanced_accuracy",
+            "candidate_count": len(blocks),
+        },
+        **block,
+    }
+    _, records = load_manifest(args.manifest)
+    rebuild_standardization_from_manifest(ckpt, records)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(ckpt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--verify-only",
+            "--checkpoint",
+            str(output),
+            "--manifest",
+            str(Path(args.manifest)),
+            *(["--run-config", str(Path(args.run_config))] if args.run_config else []),
+            "--tolerance-pp",
+            str(args.tolerance_pp),
+            "--verification-mode",
+            args.verification_mode,
+            "--native-compile-timeout-sec",
+            str(args.native_compile_timeout_sec),
+            "--native-run-timeout-sec",
+            str(args.native_run_timeout_sec),
+            *(["--native-souc-engine", args.native_souc_engine] if args.native_souc_engine else []),
+            *(["--repo-root", str(args.repo_root)] if args.repo_root else []),
+        ],
+        check=True,
+    )
+    verified = json.loads(output.read_text(encoding="utf-8"))
+    print(
+        "checkpoint persisted and verified: "
+        f"{output} expected={verified['verification']['expected_balanced_accuracy_pct']:.6f} "
+        f"actual={verified['verification']['actual_balanced_accuracy_pct']:.6f} "
+        f"delta={verified['verification']['delta_pp']:.6f}pp"
+    )
+    return 0
+
+
+def verify_only(args: argparse.Namespace) -> int:
+    checkpoint = Path(args.checkpoint)
+    payload = json.loads(checkpoint.read_text(encoding="utf-8"))
+    _, records = load_manifest(args.manifest)
+    rebuild_standardization_from_manifest(payload, records)
+    checkpoint.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    result = verify_checkpoint(
+        checkpoint,
+        Path(args.manifest),
+        args.tolerance_pp,
+        Path(args.repo_root) if args.repo_root else None,
+        args.verification_mode,
+        parse_run_config(Path(args.run_config) if args.run_config else None),
+        args.native_compile_timeout_sec,
+        args.native_run_timeout_sec,
+        args.native_souc_engine,
+    )
+    payload["verification"] = result
+    checkpoint.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        "checkpoint reload sanity check PASS: "
+        f"expected={result['expected_balanced_accuracy_pct']:.6f} "
+        f"actual={result['actual_balanced_accuracy_pct']:.6f} "
+        f"delta={result['delta_pp']:.6f}pp "
+        f"sample_subject={result['sample_forward'].get('subject_id', result['sample_forward'].get('subject_index'))}"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--raw-output")
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output")
+    parser.add_argument("--checkpoint")
+    parser.add_argument("--run-config")
+    parser.add_argument("--run-id", default="manual")
+    parser.add_argument("--tolerance-pp", type=float, default=0.5)
+    parser.add_argument("--repo-root", help="Optional repo/compiler root for native verifier replay")
+    parser.add_argument(
+        "--verification-mode",
+        choices=["auto", "native", "python"],
+        default="auto",
+        help="Checkpoint replay mode. auto records native verifier failure and falls back to Python fresh-process replay.",
+    )
+    parser.add_argument("--native-compile-timeout-sec", type=float, default=300.0)
+    parser.add_argument("--native-run-timeout-sec", type=float, default=180.0)
+    parser.add_argument("--native-souc-engine", default="", help="Optional SOUNIO_SOUC_ENGINE for native verifier compilation")
+    args = parser.parse_args()
+    if args.verify_only:
+        if not args.checkpoint:
+            parser.error("--verify-only requires --checkpoint")
+        return verify_only(args)
+    if not args.raw_output or not args.output:
+        parser.error("persist mode requires --raw-output and --output")
+    return persist(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/abide_dynamic_fc_switching_decision_gate.py
+++ b/scripts/research/abide_dynamic_fc_switching_decision_gate.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Decision gate for ABIDE dynamic-FC switch-event artifacts.
+
+This gate combines the target-builder audit with switch-event model metrics.
+It emits a bounded follow-up verdict only. It does not authorize clinical,
+diagnostic, biomarker, mechanism, ASD-detection, or O-SSM superiority claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.abide_dynamic_fc_switching_decision.v1"
+CLAIM_BOUNDARY = (
+    "Dynamic-FC switching decision gate only; no diagnostic, biomarker, "
+    "mechanism, ASD-detection, clinical-decision, or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-audit-json", required=True, type=Path)
+    parser.add_argument("--gate-json", required=True, type=Path)
+    parser.add_argument("--gate-summary", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--min-decision-subjects", type=int, default=50)
+    parser.add_argument("--min-decision-sites", type=int, default=5)
+    parser.add_argument("--min-decision-null-permutations", type=int, default=20)
+    parser.add_argument("--min-ap-gap", type=float, default=0.03)
+    parser.add_argument("--min-proper-score-gap", type=float, default=0.002)
+    parser.add_argument("--alpha", type=float, default=0.10)
+    parser.add_argument("--require-split-policy", default="leave_one_site_out")
+    parser.add_argument("--require-full-sounio-ossm", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def parse_float(value: Any, default: float = 0.0) -> float:
+    try:
+        out = float(str(value))
+    except (TypeError, ValueError):
+        return default
+    return out if math.isfinite(out) else default
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def by_model(rows: list[dict[str, str]]) -> dict[str, dict[str, str]]:
+    out: dict[str, dict[str, str]] = {}
+    for row in rows:
+        model = row.get("model", "")
+        if model:
+            out[model] = row
+    return out
+
+
+def score(row: dict[str, str], field: str, default: float = 0.0) -> float:
+    return parse_float(row.get(field, ""), default=default)
+
+
+def lower_is_better_gain(ossm: dict[str, str], controls: list[dict[str, str]], field: str) -> tuple[float, str]:
+    if not controls:
+        return 0.0, "missing"
+    best = min(controls, key=lambda row: score(row, field, default=float("inf")))
+    return score(best, field, default=float("inf")) - score(ossm, field, default=float("inf")), best.get("model", "")
+
+
+def higher_is_better_gain(ossm: dict[str, str], controls: list[dict[str, str]], field: str) -> tuple[float, str]:
+    if not controls:
+        return 0.0, "missing"
+    best = max(controls, key=lambda row: score(row, field, default=float("-inf")))
+    return score(ossm, field, default=float("-inf")) - score(best, field, default=float("-inf")), best.get("model", "")
+
+
+def low_power_reasons(target: dict[str, Any], gate: dict[str, Any], summary: dict[str, dict[str, str]], args: argparse.Namespace) -> list[str]:
+    reasons: list[str] = []
+    subject_count = int(parse_float(target.get("subject_count", 0)))
+    site_count = int(parse_float(target.get("site_count", 0)))
+    split_policy = str(target.get("parameters", {}).get("split_policy", ""))
+    if subject_count < args.min_decision_subjects:
+        reasons.append(f"subject_count {subject_count} < min_decision_subjects {args.min_decision_subjects}")
+    if site_count < args.min_decision_sites:
+        reasons.append(f"site_count {site_count} < min_decision_sites {args.min_decision_sites}")
+    if split_policy != args.require_split_policy:
+        reasons.append(f"split_policy {split_policy!r} != required {args.require_split_policy!r}")
+    null_counts = [
+        score(row, "null_permutations_mean", default=0.0)
+        for row in summary.values()
+        if row.get("null_permutations_mean") not in {"", None}
+    ]
+    max_nulls = max(null_counts) if null_counts else 0.0
+    if max_nulls < args.min_decision_null_permutations:
+        reasons.append(
+            f"max null_permutations_mean {max_nulls:g} < min_decision_null_permutations {args.min_decision_null_permutations}"
+        )
+    if gate.get("verdict") not in {
+        "O_SSM_RESERVOIR_GATE_EXECUTED_NO_PROMOTION",
+        "TRAINED_O_SSM_GATE_EXECUTED_NO_PROMOTION",
+        "FULL_O_SSM_GATE_EXECUTED",
+    }:
+        reasons.append(f"model gate verdict is {gate.get('verdict')!r}")
+    return reasons
+
+
+def missing_control_reasons(summary: dict[str, dict[str, str]]) -> list[str]:
+    required = {
+        "base_rate",
+        "persistence",
+        "logistic",
+        "gru_reservoir",
+        "hssm_reservoir",
+        "ossm_reservoir",
+        "trained_hssm",
+        "trained_ossm",
+    }
+    return [f"missing required model surface: {model}" for model in sorted(required - set(summary))]
+
+
+def decide(target: dict[str, Any], gate: dict[str, Any], summary_rows: list[dict[str, str]], args: argparse.Namespace) -> tuple[str, list[str], dict[str, Any]]:
+    summary = by_model(summary_rows)
+    reasons: list[str] = []
+    diagnostics: dict[str, Any] = {}
+
+    if target.get("status") != "pass":
+        return "BLOCKED_TARGET_AUDIT_FAILED", list(target.get("failures", [])), diagnostics
+
+    missing = missing_control_reasons(summary)
+    if missing:
+        return "UNDERCONTROLLED_MISSING_SURFACES", missing, diagnostics
+
+    ossm_model = "trained_ossm" if "trained_ossm" in summary else "ossm_reservoir"
+    ossm = summary[ossm_model]
+    controls = [row for model, row in summary.items() if model != ossm_model]
+    ap_gain, best_ap_control = higher_is_better_gain(ossm, controls, "average_precision_mean")
+    brier_gain, best_brier_control = lower_is_better_gain(ossm, controls, "brier_mean")
+    log_loss_gain, best_log_loss_control = lower_is_better_gain(ossm, controls, "log_loss_mean")
+    null_p = score(ossm, "null_average_precision_p_ge_mean", default=1.0)
+    diagnostics.update(
+        {
+            "ossm_model_surface": ossm_model,
+            "ap_gain_over_best_control": ap_gain,
+            "best_ap_control": best_ap_control,
+            "brier_gain_over_best_control": brier_gain,
+            "best_brier_control": best_brier_control,
+            "log_loss_gain_over_best_control": log_loss_gain,
+            "best_log_loss_control": best_log_loss_control,
+            "ossm_null_average_precision_p_ge": null_p,
+        }
+    )
+
+    low_power = low_power_reasons(target, gate, summary, args)
+    if low_power:
+        reasons.extend(low_power)
+        return "UNDERCONTROLLED_LOW_POWER_OR_SMOKE_SPLIT", reasons, diagnostics
+
+    if args.require_full_sounio_ossm and "full_sounio_ossm" not in summary:
+        reasons.append("full_sounio_ossm surface missing")
+        return "UNDERCONTROLLED_RESERVOIR_ONLY", reasons, diagnostics
+
+    reasons.extend(gate.get("reasons", []))
+    if "reservoir_o_ssm_surface_only_not_full_trained_sio_model" in reasons:
+        return "NO_PROMOTION_RESERVOIR_ONLY", reasons, diagnostics
+    if "trained_python_o_ssm_surface_not_full_sounio_model" in reasons:
+        return "NO_PROMOTION_PYTHON_TRAINED_ONLY", reasons, diagnostics
+
+    proper_score_pass = brier_gain >= args.min_proper_score_gap or log_loss_gain >= args.min_proper_score_gap
+    if ap_gain >= args.min_ap_gap and proper_score_pass and null_p <= args.alpha:
+        return "EXPLORATORY_O_SSM_SWITCHING_SIGNAL", ["passes exploratory metric thresholds"], diagnostics
+    if ap_gain < args.min_ap_gap:
+        reasons.append(f"AP gain {ap_gain:.6f} < min_ap_gap {args.min_ap_gap:.6f}")
+    if not proper_score_pass:
+        reasons.append(
+            "O-SSM does not improve Brier or log-loss over the best control by "
+            f"{args.min_proper_score_gap:.6f}"
+        )
+    if null_p > args.alpha:
+        reasons.append(f"O-SSM null AP p_ge {null_p:.6f} > alpha {args.alpha:.6f}")
+    return "NEGATIVE_OR_UNDERCONTROLLED_NO_ROBUST_O_SSM_SIGNAL", reasons, diagnostics
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    diagnostics = payload["diagnostics"]
+    lines = [
+        "# ABIDE Dynamic-FC Switching Decision",
+        "",
+        CLAIM_BOUNDARY,
+        "",
+        f"- Overall verdict: `{payload['overall_verdict']}`",
+        f"- Target audit status: `{payload['target_status']}`",
+        f"- Model gate verdict: `{payload['gate_verdict']}`",
+        "",
+        "## Diagnostics",
+        "",
+        f"- O-SSM surface: `{diagnostics.get('ossm_model_surface', 'missing')}`",
+        f"- AP gain over best control: `{diagnostics.get('ap_gain_over_best_control', '')}`",
+        f"- Brier gain over best control: `{diagnostics.get('brier_gain_over_best_control', '')}`",
+        f"- Log-loss gain over best control: `{diagnostics.get('log_loss_gain_over_best_control', '')}`",
+        f"- O-SSM null AP p>=: `{diagnostics.get('ossm_null_average_precision_p_ge', '')}`",
+        "",
+        "## Reasons",
+        "",
+    ]
+    lines.extend(f"- {reason}" for reason in payload["reasons"])
+    if not payload["reasons"]:
+        lines.append("- no blocking reason recorded")
+    lines.extend(
+        [
+            "",
+            "Interpretation: this gate decides whether the dynamic-FC switching artifacts can support a follow-up decision.",
+            "A positive exploratory verdict is not a clinical, biomarker, mechanism, ASD-detection, or O-SSM superiority claim.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.output_dir.exists() and any(args.output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    target = read_json(args.target_audit_json)
+    gate = read_json(args.gate_json)
+    summary_rows = read_tsv(args.gate_summary)
+    verdict, reasons, diagnostics = decide(target, gate, summary_rows, args)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "target_audit_json": str(args.target_audit_json.resolve()),
+        "gate_json": str(args.gate_json.resolve()),
+        "gate_summary": str(args.gate_summary.resolve()),
+        "target_status": target.get("status", "missing"),
+        "target_failures": target.get("failures", []),
+        "gate_verdict": gate.get("verdict", "missing"),
+        "gate_reasons": gate.get("reasons", []),
+        "parameters": {
+            "min_decision_subjects": args.min_decision_subjects,
+            "min_decision_sites": args.min_decision_sites,
+            "min_decision_null_permutations": args.min_decision_null_permutations,
+            "min_ap_gap": args.min_ap_gap,
+            "min_proper_score_gap": args.min_proper_score_gap,
+            "alpha": args.alpha,
+            "require_split_policy": args.require_split_policy,
+            "require_full_sounio_ossm": args.require_full_sounio_ossm,
+        },
+        "target_summary": {
+            "subject_count": target.get("subject_count"),
+            "site_count": target.get("site_count"),
+            "split_policy": target.get("parameters", {}).get("split_policy"),
+            "primary_switch_event_frac": target.get("primary_test_switch_event_frac"),
+            "primary_window_switch_corr": target.get("primary_switching_rate_window_count_corr"),
+        },
+        "model_summary": summary_rows,
+        "diagnostics": diagnostics,
+        "overall_verdict": verdict,
+        "reasons": reasons,
+    }
+    (args.output_dir / "dynamic_fc_switching_decision.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (args.output_dir / "dynamic_fc_switching_decision.md").write_text(markdown(payload), encoding="utf-8")
+    print(f"verdict={verdict}")
+    print(f"outputs={args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/abide_dynamic_fc_switching_gate.py
+++ b/scripts/research/abide_dynamic_fc_switching_gate.py
@@ -1,0 +1,823 @@
+#!/usr/bin/env python3
+"""Evaluate temporal switch-event baselines on ABIDE dynamic-FC targets.
+
+This consumes ``dynamic_fc_window_table.tsv`` from
+``abide_dynamic_fc_switching_target.py`` and predicts whether the current
+dynamic-FC state differs from the previous window's state. Features are built
+only from history available before the target window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+SCHEMA = "neurodyn.abide_dynamic_fc_switching_gate.v1"
+CLAIM_BOUNDARY = (
+    "Switch-event temporal prediction gate only; no diagnostic, biomarker, "
+    "mechanism, ASD-detection, clinical-decision, or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-table", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument(
+        "--models",
+        default="base_rate,persistence,logistic,gru_reservoir,hssm_reservoir,ossm_reservoir,trained_hssm,trained_ossm",
+        help=(
+            "Comma-separated models: base_rate,persistence,logistic,"
+            "gru_reservoir,hssm_reservoir,ossm_reservoir,trained_hssm,trained_ossm."
+        ),
+    )
+    parser.add_argument("--epochs", type=int, default=800)
+    parser.add_argument("--lr", type=float, default=0.05)
+    parser.add_argument("--l2", type=float, default=0.01)
+    parser.add_argument("--reservoir-hidden", type=int, default=24)
+    parser.add_argument("--reservoir-seed", type=int, default=20260708)
+    parser.add_argument("--trained-candidates", type=int, default=5)
+    parser.add_argument("--null-permutations", type=int, default=0)
+    parser.add_argument("--min-test-events", type=int, default=20)
+    parser.add_argument("--min-test-positive-events", type=int, default=2)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def oct_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Normed octonion multiplication with Fano line (2,5,7) positive."""
+    r = np.zeros(8, dtype=np.float64)
+    r[0] = a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3] - a[4] * b[4] - a[5] * b[5] - a[6] * b[6] - a[7] * b[7]
+    r[1] = a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2] + a[4] * b[5] - a[5] * b[4] - a[6] * b[7] + a[7] * b[6]
+    r[2] = a[0] * b[2] + a[2] * b[0] - a[1] * b[3] + a[3] * b[1] + a[4] * b[6] - a[6] * b[4] + a[5] * b[7] - a[7] * b[5]
+    r[3] = a[0] * b[3] + a[3] * b[0] + a[1] * b[2] - a[2] * b[1] + a[4] * b[7] - a[7] * b[4] - a[5] * b[6] + a[6] * b[5]
+    r[4] = a[0] * b[4] + a[4] * b[0] - a[1] * b[5] + a[5] * b[1] - a[2] * b[6] + a[6] * b[2] - a[3] * b[7] + a[7] * b[3]
+    r[5] = a[0] * b[5] + a[5] * b[0] + a[1] * b[4] - a[4] * b[1] - a[2] * b[7] + a[7] * b[2] + a[3] * b[6] - a[6] * b[3]
+    r[6] = a[0] * b[6] + a[6] * b[0] + a[1] * b[7] - a[7] * b[1] + a[2] * b[4] - a[4] * b[2] - a[3] * b[5] + a[5] * b[3]
+    r[7] = a[0] * b[7] + a[7] * b[0] - a[1] * b[6] + a[6] * b[1] + a[2] * b[5] - a[5] * b[2] + a[3] * b[4] - a[4] * b[3]
+    return r
+
+
+def quat_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    r = np.zeros(4, dtype=np.float64)
+    r[0] = a[0] * b[0] - a[1] * b[1] - a[2] * b[2] - a[3] * b[3]
+    r[1] = a[0] * b[1] + a[1] * b[0] + a[2] * b[3] - a[3] * b[2]
+    r[2] = a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1]
+    r[3] = a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0]
+    return r
+
+
+def octonion_self_check() -> dict[str, float | int]:
+    e2 = np.zeros(8, dtype=np.float64)
+    e5 = np.zeros(8, dtype=np.float64)
+    e2[2] = 1.0
+    e5[5] = 1.0
+    prod = oct_mul(e2, e5)
+    rng = np.random.default_rng(424242)
+    max_composition_err = 0.0
+    max_alternative_err = 0.0
+    for _ in range(32):
+        a = rng.normal(0.0, 1.0, size=8)
+        b = rng.normal(0.0, 1.0, size=8)
+        ab = oct_mul(a, b)
+        max_composition_err = max(
+            max_composition_err,
+            abs(float(ab @ ab) - float(a @ a) * float(b @ b)),
+        )
+        alt = oct_mul(oct_mul(a, a), b) - oct_mul(a, oct_mul(a, b))
+        max_alternative_err = max(max_alternative_err, float(np.linalg.norm(alt)))
+    return {
+        "e2_times_e5_dominant_dim": int(np.argmax(np.abs(prod))),
+        "e2_times_e5_dim7_value": float(prod[7]),
+        "composition_err_max": max_composition_err,
+        "alternative_err_max": max_alternative_err,
+    }
+
+
+def sigmoid_array(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(x, -40.0, 40.0)))
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def event_rows(rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, int, str], list[dict[str, str]]] = defaultdict(list)
+    for row in rows:
+        if not row.get("fold_id") or not row.get("subject_id") or not row.get("k"):
+            continue
+        grouped[(row["fold_id"], int(row["k"]), row["subject_id"])].append(row)
+
+    out: list[dict[str, Any]] = []
+    for (fold_id, k, subject_id), chunk in sorted(grouped.items()):
+        ordered = sorted(chunk, key=lambda row: int(row["window_index"]))
+        previous_state: int | None = None
+        previous_switch = 0
+        run_length = 0
+        for row in ordered:
+            state = int(row["state"])
+            window_index = int(row["window_index"])
+            window_count = max(1, int(row["window_count"]))
+            if previous_state is not None and str(row.get("switch_event", "")) in {"0", "1"}:
+                features = [0.0] * (k + 4)
+                if 0 <= previous_state < k:
+                    features[previous_state] = 1.0
+                features[k] = float(previous_switch)
+                features[k + 1] = min(run_length, 20) / 20.0
+                features[k + 2] = window_index / max(1, window_count - 1)
+                features[k + 3] = math.log1p(window_count)
+                out.append(
+                    {
+                        "fold_id": fold_id,
+                        "holdout_site": row.get("holdout_site", ""),
+                        "k": k,
+                        "subject_id": subject_id,
+                        "site": row.get("site", ""),
+                        "label": row.get("label", ""),
+                        "split": row.get("split", ""),
+                        "window_index": window_index,
+                        "window_count": window_count,
+                        "previous_state": previous_state,
+                        "previous_switch": previous_switch,
+                        "run_length_before_event": run_length,
+                        "target": int(row["switch_event"]),
+                        "features": features,
+                    }
+                )
+            if previous_state is None or state != previous_state:
+                run_length = 1
+            else:
+                run_length += 1
+            previous_switch = 0 if previous_state is None else int(state != previous_state)
+            previous_state = state
+    return out
+
+
+def split_fold(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    train = [row for row in rows if row["split"] == "train"]
+    test = [row for row in rows if row["split"] == "test"]
+    return train, test
+
+
+def standardize(train_x: np.ndarray, x: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    mu = train_x.mean(axis=0)
+    sigma = train_x.std(axis=0)
+    sigma = np.where(sigma > 1.0e-8, sigma, 1.0)
+    return (x - mu) / sigma, mu, sigma
+
+
+def train_logistic(
+    train_x: np.ndarray,
+    train_y: np.ndarray,
+    *,
+    epochs: int,
+    lr: float,
+    l2: float,
+) -> tuple[np.ndarray, float, np.ndarray, np.ndarray]:
+    x, mu, sigma = standardize(train_x, train_x)
+    y = train_y.astype(np.float64)
+    w = np.zeros(x.shape[1], dtype=np.float64)
+    pos = float(np.clip(y.mean(), 1.0e-6, 1.0 - 1.0e-6))
+    b = math.log(pos / (1.0 - pos))
+    for _ in range(max(1, epochs)):
+        p = sigmoid_array(x @ w + b)
+        err = p - y
+        grad_w = (x.T @ err) / x.shape[0] + l2 * w
+        grad_b = float(err.mean())
+        w -= lr * grad_w
+        b -= lr * grad_b
+    return w, b, mu, sigma
+
+
+def predict_logistic(w: np.ndarray, b: float, mu: np.ndarray, sigma: np.ndarray, x: np.ndarray) -> np.ndarray:
+    zx = (x - mu) / sigma
+    return sigmoid_array(zx @ w + b)
+
+
+def reservoir_features(rows: list[dict[str, Any]], *, hidden_dim: int, seed: int) -> np.ndarray:
+    if not rows:
+        return np.zeros((0, hidden_dim), dtype=np.float64)
+    dim = len(rows[0]["features"])
+    rng = np.random.default_rng(seed)
+    wxz = rng.normal(0.0, 0.35 / math.sqrt(dim), size=(dim, hidden_dim))
+    whz = rng.normal(0.0, 0.35 / math.sqrt(hidden_dim), size=(hidden_dim, hidden_dim))
+    wxr = rng.normal(0.0, 0.35 / math.sqrt(dim), size=(dim, hidden_dim))
+    whr = rng.normal(0.0, 0.35 / math.sqrt(hidden_dim), size=(hidden_dim, hidden_dim))
+    wxh = rng.normal(0.0, 0.35 / math.sqrt(dim), size=(dim, hidden_dim))
+    whh = rng.normal(0.0, 0.35 / math.sqrt(hidden_dim), size=(hidden_dim, hidden_dim))
+    bz = rng.normal(0.0, 0.02, size=hidden_dim)
+    br = rng.normal(0.0, 0.02, size=hidden_dim)
+    bh = rng.normal(0.0, 0.02, size=hidden_dim)
+
+    ordered_indices = sorted(
+        range(len(rows)),
+        key=lambda idx: (rows[idx]["fold_id"], rows[idx]["subject_id"], int(rows[idx]["window_index"])),
+    )
+    h_by_subject: dict[tuple[str, str], np.ndarray] = defaultdict(lambda: np.zeros(hidden_dim, dtype=np.float64))
+    out = np.zeros((len(rows), hidden_dim), dtype=np.float64)
+    for idx in ordered_indices:
+        row = rows[idx]
+        key = (row["fold_id"], row["subject_id"])
+        h = h_by_subject[key]
+        x = np.asarray(row["features"], dtype=np.float64)
+        z = sigmoid_array(x @ wxz + h @ whz + bz)
+        r = sigmoid_array(x @ wxr + h @ whr + br)
+        h_tilde = np.tanh(x @ wxh + (r * h) @ whh + bh)
+        h_new = (1.0 - z) * h + z * h_tilde
+        h_by_subject[key] = h_new
+        out[idx] = h_new
+    return out
+
+
+def to_oct_inputs(rows: list[dict[str, Any]], train_rows: list[dict[str, Any]]) -> dict[int, np.ndarray]:
+    train_x = np.asarray([row["features"] for row in train_rows], dtype=np.float64)
+    all_x = np.asarray([row["features"] for row in rows], dtype=np.float64)
+    zx, _, _ = standardize(train_x, all_x)
+    zx = np.clip(zx, -5.0, 5.0)
+    if zx.shape[1] < 8:
+        padded = np.zeros((zx.shape[0], 8), dtype=np.float64)
+        padded[:, : zx.shape[1]] = zx
+        zx = padded
+    elif zx.shape[1] > 8:
+        zx = zx[:, :8]
+    return {id(row): zx[idx] for idx, row in enumerate(rows)}
+
+
+def algebraic_reservoir_features(
+    rows: list[dict[str, Any]],
+    train_rows: list[dict[str, Any]],
+    *,
+    algebra: str,
+    seed: int,
+    a_override: np.ndarray | None = None,
+) -> np.ndarray:
+    if not rows:
+        return np.zeros((0, 9), dtype=np.float64)
+    if a_override is None:
+        rng = np.random.default_rng(seed)
+        a = rng.normal(0.0, 1.0, size=8)
+    else:
+        a = np.asarray(a_override, dtype=np.float64).copy()
+    a = normalize_algebra_parameter(a, algebra)
+
+    x_by_id = to_oct_inputs(rows, train_rows)
+    ordered_indices = sorted(
+        range(len(rows)),
+        key=lambda idx: (rows[idx]["fold_id"], rows[idx]["subject_id"], int(rows[idx]["window_index"])),
+    )
+    h0 = np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    h_by_subject: dict[tuple[str, str], np.ndarray] = defaultdict(lambda: h0.copy())
+    assoc_by_subject: dict[tuple[str, str], float] = defaultdict(float)
+    count_by_subject: dict[tuple[str, str], int] = defaultdict(int)
+    out = np.zeros((len(rows), 9), dtype=np.float64)
+    for idx in ordered_indices:
+        row = rows[idx]
+        key = (row["fold_id"], row["subject_id"])
+        h = h_by_subject[key]
+        x = x_by_id[id(row)]
+        if algebra == "ossm":
+            ah = oct_mul(a, h)
+            left = oct_mul(ah, x)
+            right = oct_mul(a, oct_mul(h, x))
+            diff = left - right
+            assoc_step = min(math.sqrt(max(float(diff @ diff), 0.0)), 1000.0)
+            h_new = np.clip(left + 0.2 * right, -5.0, 5.0)
+            h_new = np.where(np.isfinite(h_new), h_new, 0.0)
+        elif algebra == "hssm":
+            left0 = quat_mul(quat_mul(a[:4], h[:4]), x[:4])
+            left1 = quat_mul(quat_mul(a[4:], h[4:]), x[4:])
+            h_new = np.zeros(8, dtype=np.float64)
+            h_new[:4] = np.clip(1.2 * left0, -5.0, 5.0)
+            h_new[4:] = np.clip(1.2 * left1, -5.0, 5.0)
+            assoc_step = 0.0
+        else:
+            raise ValueError(f"unknown algebra: {algebra}")
+        h_by_subject[key] = h_new
+        assoc_by_subject[key] += assoc_step
+        count_by_subject[key] += 1
+        out[idx, :8] = h_new
+        out[idx, 8] = assoc_by_subject[key] / max(1, count_by_subject[key]) if algebra == "ossm" else 0.0
+    return out
+
+
+def normalize_algebra_parameter(a: np.ndarray, algebra: str) -> np.ndarray:
+    out = np.asarray(a, dtype=np.float64).copy()
+    norm = float(np.linalg.norm(out))
+    if norm <= 1.0e-12:
+        out = np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+    else:
+        out = out / norm
+    if algebra == "hssm":
+        n0 = float(np.linalg.norm(out[:4]))
+        n1 = float(np.linalg.norm(out[4:]))
+        out[:4] = out[:4] / n0 if n0 > 1.0e-12 else np.asarray([1.0, 0.0, 0.0, 0.0])
+        out[4:] = out[4:] / n1 if n1 > 1.0e-12 else np.asarray([1.0, 0.0, 0.0, 0.0])
+    return out
+
+
+def trained_algebraic_features(
+    rows: list[dict[str, Any]],
+    train_rows: list[dict[str, Any]],
+    train_y: np.ndarray,
+    *,
+    algebra: str,
+    seed: int,
+    candidates: int,
+    args: argparse.Namespace,
+) -> tuple[np.ndarray, dict[str, Any]]:
+    train_mask = np.asarray([row["split"] == "train" for row in rows], dtype=bool)
+    rng = np.random.default_rng(seed)
+    best_loss = float("inf")
+    best_states: np.ndarray | None = None
+    best_a: np.ndarray | None = None
+    tried = max(1, candidates)
+    for idx in range(tried):
+        if idx == 0:
+            raw_a = np.asarray([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64)
+        else:
+            raw_a = rng.normal(0.0, 1.0, size=8)
+        a = normalize_algebra_parameter(raw_a, algebra)
+        states = algebraic_reservoir_features(rows, train_rows, algebra=algebra, seed=seed + idx, a_override=a)
+        w, b, mu, sigma = train_logistic(states[train_mask], train_y, epochs=args.epochs, lr=args.lr, l2=args.l2)
+        train_probs = predict_logistic(w, b, mu, sigma, states[train_mask]).tolist()
+        train_labels = [int(value) for value in train_y.tolist()]
+        loss = log_loss(train_labels, train_probs)
+        if loss < best_loss:
+            best_loss = loss
+            best_states = states
+            best_a = a
+    if best_states is None or best_a is None:
+        raise RuntimeError("trained algebraic surface failed to select a candidate")
+    return best_states, {
+        "trained_candidate_count": tried,
+        "selected_train_log_loss": best_loss,
+        "selected_a_norm": float(np.linalg.norm(best_a)),
+    }
+
+
+def brier(labels: list[int], probs: list[float]) -> float:
+    return sum((p - y) * (p - y) for y, p in zip(labels, probs, strict=True)) / len(labels)
+
+
+def log_loss(labels: list[int], probs: list[float]) -> float:
+    total = 0.0
+    for y, p in zip(labels, probs, strict=True):
+        q = min(1.0 - 1.0e-12, max(1.0e-12, p))
+        total += -(y * math.log(q) + (1 - y) * math.log(1.0 - q))
+    return total / len(labels)
+
+
+def auroc(labels: list[int], probs: list[float]) -> float | None:
+    pos = [p for y, p in zip(labels, probs, strict=True) if y == 1]
+    neg = [p for y, p in zip(labels, probs, strict=True) if y == 0]
+    if not pos or not neg:
+        return None
+    wins = 0.0
+    total = 0
+    for ps in pos:
+        for ns in neg:
+            wins += 1.0 if ps > ns else 0.5 if ps == ns else 0.0
+            total += 1
+    return wins / total
+
+
+def average_precision(labels: list[int], probs: list[float]) -> float | None:
+    positive_count = sum(labels)
+    if positive_count == 0:
+        return None
+    ordered = sorted(zip(probs, labels, strict=True), key=lambda item: item[0], reverse=True)
+    tp = 0
+    fp = 0
+    prev_recall = 0.0
+    ap = 0.0
+    for _, label in ordered:
+        if label == 1:
+            tp += 1
+        else:
+            fp += 1
+        recall = tp / positive_count
+        precision = tp / max(1, tp + fp)
+        if label == 1:
+            ap += (recall - prev_recall) * precision
+            prev_recall = recall
+    return ap
+
+
+def metric_row(model: str, fold_id: str, k: int, rows: list[dict[str, Any]], probs: list[float]) -> dict[str, Any]:
+    labels = [int(row["target"]) for row in rows]
+    positives = sum(labels)
+    auc = auroc(labels, probs)
+    ap = average_precision(labels, probs)
+    return {
+        "model": model,
+        "fold_id": fold_id,
+        "k": k,
+        "test_events": len(labels),
+        "test_positive_events": positives,
+        "test_prevalence": positives / len(labels) if labels else 0.0,
+        "brier": brier(labels, probs),
+        "log_loss": log_loss(labels, probs),
+        "auroc": "" if auc is None else auc,
+        "average_precision": "" if ap is None else ap,
+        "mean_predicted_prob": sum(probs) / len(probs) if probs else 0.0,
+        "null_permutations": 0,
+        "null_average_precision_mean": "",
+        "null_average_precision_p_ge": "",
+        "null_brier_mean": "",
+        "null_log_loss_mean": "",
+        "trained_candidate_count": "",
+        "selected_train_log_loss": "",
+    }
+
+
+def add_readout_nulls(
+    row: dict[str, Any],
+    train_x: np.ndarray,
+    train_y: np.ndarray,
+    test_x: np.ndarray,
+    test_rows: list[dict[str, Any]],
+    observed_probs: list[float],
+    args: argparse.Namespace,
+    *,
+    seed: int,
+) -> None:
+    if args.null_permutations <= 0:
+        return
+    labels = [int(test_row["target"]) for test_row in test_rows]
+    observed_ap = average_precision(labels, observed_probs)
+    rng = np.random.default_rng(seed)
+    aps: list[float] = []
+    briers: list[float] = []
+    losses: list[float] = []
+    for _ in range(args.null_permutations):
+        perm_y = np.asarray(train_y, dtype=np.float64).copy()
+        rng.shuffle(perm_y)
+        w, b, mu, sigma = train_logistic(train_x, perm_y, epochs=args.epochs, lr=args.lr, l2=args.l2)
+        probs = predict_logistic(w, b, mu, sigma, test_x).tolist()
+        ap = average_precision(labels, probs)
+        if ap is not None:
+            aps.append(ap)
+        briers.append(brier(labels, probs))
+        losses.append(log_loss(labels, probs))
+    row["null_permutations"] = args.null_permutations
+    row["null_average_precision_mean"] = sum(aps) / len(aps) if aps else ""
+    if observed_ap is not None and aps:
+        row["null_average_precision_p_ge"] = (1 + sum(1 for value in aps if value >= observed_ap)) / (len(aps) + 1)
+    row["null_brier_mean"] = sum(briers) / len(briers) if briers else ""
+    row["null_log_loss_mean"] = sum(losses) / len(losses) if losses else ""
+
+
+def mean_numeric(rows: list[dict[str, Any]], field: str) -> float | None:
+    values = [float(row[field]) for row in rows if row.get(field) != ""]
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def run_gate(rows: list[dict[str, Any]], models: set[str], args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    predictions: list[dict[str, Any]] = []
+    detail: list[dict[str, Any]] = []
+    failures: list[str] = []
+    by_fold_k: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_fold_k[(row["fold_id"], int(row["k"]))].append(row)
+
+    for (fold_id, k), fold_rows in sorted(by_fold_k.items()):
+        train_rows, test_rows = split_fold(fold_rows)
+        if len(test_rows) < args.min_test_events:
+            failures.append(f"{fold_id}:test_events_below_minimum")
+        if sum(int(row["target"]) for row in test_rows) < args.min_test_positive_events:
+            failures.append(f"{fold_id}:test_positive_events_below_minimum")
+        if not train_rows or not test_rows:
+            continue
+        train_x = np.asarray([row["features"] for row in train_rows], dtype=np.float64)
+        train_y = np.asarray([row["target"] for row in train_rows], dtype=np.float64)
+        test_x = np.asarray([row["features"] for row in test_rows], dtype=np.float64)
+        train_rate = float(np.clip(train_y.mean(), 1.0e-6, 1.0 - 1.0e-6))
+
+        fold_probs: dict[str, list[float]] = {}
+        null_features: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        if "base_rate" in models:
+            fold_probs["base_rate"] = [train_rate] * len(test_rows)
+        if "persistence" in models:
+            fold_probs["persistence"] = [
+                0.95 if int(row["previous_switch"]) == 1 else 0.05 for row in test_rows
+            ]
+        if "logistic" in models:
+            w, b, mu, sigma = train_logistic(train_x, train_y, epochs=args.epochs, lr=args.lr, l2=args.l2)
+            fold_probs["logistic"] = predict_logistic(w, b, mu, sigma, test_x).tolist()
+            null_features["logistic"] = (train_x, test_x)
+        if "gru_reservoir" in models:
+            reservoir = reservoir_features(fold_rows, hidden_dim=args.reservoir_hidden, seed=args.reservoir_seed + k)
+            train_mask = np.asarray([row["split"] == "train" for row in fold_rows], dtype=bool)
+            test_mask = np.asarray([row["split"] == "test" for row in fold_rows], dtype=bool)
+            y_all = np.asarray([row["target"] for row in fold_rows], dtype=np.float64)
+            w, b, mu, sigma = train_logistic(
+                reservoir[train_mask],
+                y_all[train_mask],
+                epochs=args.epochs,
+                lr=args.lr,
+                l2=args.l2,
+            )
+            fold_probs["gru_reservoir"] = predict_logistic(w, b, mu, sigma, reservoir[test_mask]).tolist()
+            null_features["gru_reservoir"] = (reservoir[train_mask], reservoir[test_mask])
+        training_meta: dict[str, dict[str, Any]] = {}
+        for model, algebra in [("hssm_reservoir", "hssm"), ("ossm_reservoir", "ossm")]:
+            if model not in models:
+                continue
+            states = algebraic_reservoir_features(
+                fold_rows,
+                train_rows,
+                algebra=algebra,
+                seed=args.reservoir_seed + k + (104729 if algebra == "ossm" else 524287),
+            )
+            train_mask = np.asarray([row["split"] == "train" for row in fold_rows], dtype=bool)
+            test_mask = np.asarray([row["split"] == "test" for row in fold_rows], dtype=bool)
+            y_all = np.asarray([row["target"] for row in fold_rows], dtype=np.float64)
+            w, b, mu, sigma = train_logistic(
+                states[train_mask],
+                y_all[train_mask],
+                epochs=args.epochs,
+                lr=args.lr,
+                l2=args.l2,
+            )
+            fold_probs[model] = predict_logistic(w, b, mu, sigma, states[test_mask]).tolist()
+            null_features[model] = (states[train_mask], states[test_mask])
+        for model, algebra in [("trained_hssm", "hssm"), ("trained_ossm", "ossm")]:
+            if model not in models:
+                continue
+            train_mask = np.asarray([row["split"] == "train" for row in fold_rows], dtype=bool)
+            test_mask = np.asarray([row["split"] == "test" for row in fold_rows], dtype=bool)
+            y_all = np.asarray([row["target"] for row in fold_rows], dtype=np.float64)
+            states, meta = trained_algebraic_features(
+                fold_rows,
+                train_rows,
+                y_all[train_mask],
+                algebra=algebra,
+                seed=args.reservoir_seed + k + (130363 if algebra == "ossm" else 99991),
+                candidates=args.trained_candidates,
+                args=args,
+            )
+            w, b, mu, sigma = train_logistic(
+                states[train_mask],
+                y_all[train_mask],
+                epochs=args.epochs,
+                lr=args.lr,
+                l2=args.l2,
+            )
+            fold_probs[model] = predict_logistic(w, b, mu, sigma, states[test_mask]).tolist()
+            null_features[model] = (states[train_mask], states[test_mask])
+            training_meta[model] = meta
+
+        for model, probs in sorted(fold_probs.items()):
+            detail_row = metric_row(model, fold_id, k, test_rows, probs)
+            if model in training_meta:
+                detail_row.update(training_meta[model])
+            if model in null_features:
+                null_train_x, null_test_x = null_features[model]
+                add_readout_nulls(
+                    detail_row,
+                    null_train_x,
+                    train_y,
+                    null_test_x,
+                    test_rows,
+                    probs,
+                    args,
+                    seed=args.reservoir_seed + k + sum(ord(ch) for ch in model),
+                )
+            detail.append(detail_row)
+            for row, prob in zip(test_rows, probs, strict=True):
+                predictions.append(
+                    {
+                        "model": model,
+                        "fold_id": fold_id,
+                        "k": k,
+                        "subject_id": row["subject_id"],
+                        "site": row["site"],
+                        "label": row["label"],
+                        "window_index": row["window_index"],
+                        "target": row["target"],
+                        "predicted_prob": f"{prob:.10f}",
+                        "previous_state": row["previous_state"],
+                        "previous_switch": row["previous_switch"],
+                        "run_length_before_event": row["run_length_before_event"],
+                    }
+                )
+    summary: list[dict[str, Any]] = []
+    for model in sorted({row["model"] for row in detail}):
+        model_rows = [row for row in detail if row["model"] == model]
+        summary.append(
+            {
+                "model": model,
+                "fold_count": len(model_rows),
+                "test_events": sum(int(row["test_events"]) for row in model_rows),
+                "test_positive_events": sum(int(row["test_positive_events"]) for row in model_rows),
+                "test_prevalence_mean": mean_numeric(model_rows, "test_prevalence"),
+                "brier_mean": mean_numeric(model_rows, "brier"),
+                "log_loss_mean": mean_numeric(model_rows, "log_loss"),
+                "auroc_mean": mean_numeric(model_rows, "auroc"),
+                "average_precision_mean": mean_numeric(model_rows, "average_precision"),
+                "mean_predicted_prob": mean_numeric(model_rows, "mean_predicted_prob"),
+                "null_permutations_mean": mean_numeric(model_rows, "null_permutations"),
+                "null_average_precision_mean": mean_numeric(model_rows, "null_average_precision_mean"),
+                "null_average_precision_p_ge_mean": mean_numeric(model_rows, "null_average_precision_p_ge"),
+                "null_brier_mean": mean_numeric(model_rows, "null_brier_mean"),
+                "null_log_loss_mean": mean_numeric(model_rows, "null_log_loss_mean"),
+                "trained_candidate_count_mean": mean_numeric(model_rows, "trained_candidate_count"),
+                "selected_train_log_loss_mean": mean_numeric(model_rows, "selected_train_log_loss"),
+            }
+        )
+    return predictions, summary, failures
+
+
+def decide(summary: list[dict[str, Any]], failures: list[str], models: set[str]) -> tuple[str, list[str]]:
+    reasons = list(failures)
+    if not summary:
+        return "BLOCKED_NO_EVALUABLE_FOLDS", reasons or ["no summary rows"]
+    if failures:
+        return "UNDERCONTROLLED_LOW_EVENT_SUPPORT", reasons
+    if "gru_reservoir" not in models:
+        reasons.append("generic_recurrent_control_missing")
+        return "UNDERCONTROLLED_NO_GENERIC_RECURRENT_CONTROL", reasons
+    if "base_rate" not in models:
+        reasons.append("base_rate_control_missing")
+        return "UNDERCONTROLLED_BASELINE_MISSING", reasons
+    if "ossm_reservoir" not in models:
+        reasons.append("no_o_ssm_surface_in_this_gate")
+        return "BASELINE_GATE_READY_NO_O_SSM_CLAIM", reasons
+    if "hssm_reservoir" not in models:
+        reasons.append("associative_hssm_control_missing")
+        return "UNDERCONTROLLED_O_SSM_WITHOUT_ASSOCIATIVE_CONTROL", reasons
+    if "trained_ossm" in models and "trained_hssm" in models:
+        reasons.append("trained_python_o_ssm_surface_not_full_sounio_model")
+        reasons.append("no_promotion_without_full_sounio_campaign_and_retrained_nulls")
+        return "TRAINED_O_SSM_GATE_EXECUTED_NO_PROMOTION", reasons
+    reasons.append("reservoir_o_ssm_surface_only_not_full_trained_sio_model")
+    reasons.append("no_promotion_without_grouped_site_gate_and_retrained_nulls")
+    return "O_SSM_RESERVOIR_GATE_EXECUTED_NO_PROMOTION", reasons
+
+
+def main() -> int:
+    args = parse_args()
+    if args.output_dir.exists() and any(args.output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    models = {value.strip() for value in args.models.split(",") if value.strip()}
+    allowed = {
+        "base_rate",
+        "persistence",
+        "logistic",
+        "gru_reservoir",
+        "hssm_reservoir",
+        "ossm_reservoir",
+        "trained_hssm",
+        "trained_ossm",
+    }
+    unknown = sorted(models - allowed)
+    if unknown:
+        raise SystemExit(f"unknown model(s): {', '.join(unknown)}")
+
+    source_rows = read_tsv(args.window_table)
+    rows = event_rows(source_rows)
+    predictions, summary, failures = run_gate(rows, models, args)
+    verdict, reasons = decide(summary, failures, models)
+    oct_check = octonion_self_check()
+    if (
+        oct_check["e2_times_e5_dominant_dim"] != 7
+        or abs(float(oct_check["e2_times_e5_dim7_value"]) - 1.0) > 1.0e-12
+        or float(oct_check["composition_err_max"]) > 1.0e-10
+        or float(oct_check["alternative_err_max"]) > 1.0e-10
+    ):
+        raise SystemExit(f"octonion self-check failed: {oct_check}")
+
+    pred_fields = [
+        "model",
+        "fold_id",
+        "k",
+        "subject_id",
+        "site",
+        "label",
+        "window_index",
+        "target",
+        "predicted_prob",
+        "previous_state",
+        "previous_switch",
+        "run_length_before_event",
+    ]
+    summary_fields = [
+        "model",
+        "fold_count",
+        "test_events",
+        "test_positive_events",
+        "test_prevalence_mean",
+        "brier_mean",
+        "log_loss_mean",
+        "auroc_mean",
+        "average_precision_mean",
+        "mean_predicted_prob",
+        "null_permutations_mean",
+        "null_average_precision_mean",
+        "null_average_precision_p_ge_mean",
+        "null_brier_mean",
+        "null_log_loss_mean",
+        "trained_candidate_count_mean",
+        "selected_train_log_loss_mean",
+    ]
+    if predictions:
+        write_tsv(args.output_dir / "dynamic_fc_switching_gate_predictions.tsv", predictions, pred_fields)
+    else:
+        write_tsv(args.output_dir / "dynamic_fc_switching_gate_predictions.tsv", [], pred_fields)
+    write_tsv(args.output_dir / "dynamic_fc_switching_gate_summary.tsv", summary, summary_fields)
+    counts = Counter((row["split"], row["target"]) for row in rows)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "window_table": str(args.window_table),
+        "verdict": verdict,
+        "reasons": reasons,
+        "models": sorted(models),
+        "octonion_self_check": oct_check,
+        "parameters": {
+            "epochs": args.epochs,
+            "lr": args.lr,
+            "l2": args.l2,
+            "reservoir_hidden": args.reservoir_hidden,
+            "reservoir_seed": args.reservoir_seed,
+            "trained_candidates": args.trained_candidates,
+            "null_permutations": args.null_permutations,
+            "min_test_events": args.min_test_events,
+            "min_test_positive_events": args.min_test_positive_events,
+        },
+        "event_rows": len(rows),
+        "event_counts": {f"{split}:{target}": count for (split, target), count in sorted(counts.items())},
+        "summary": summary,
+    }
+    (args.output_dir / "dynamic_fc_switching_gate.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    md_lines = [
+        "# ABIDE Dynamic-FC Switching Gate",
+        "",
+        CLAIM_BOUNDARY,
+        "",
+        f"- Verdict: `{verdict}`",
+        f"- Event rows: {len(rows)}",
+        f"- Models: {', '.join(sorted(models))}",
+        "",
+        "## Summary",
+        "",
+        "| model | test events | positives | Brier | log loss | AUROC | AUPRC | null AP p>= |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in summary:
+        md_lines.append(
+            "| {model} | {test_events} | {test_positive_events} | {brier_mean:.6f} | "
+            "{log_loss_mean:.6f} | {auroc_mean} | {average_precision_mean} | {null_p} |".format(
+                **{
+                    **row,
+                    "brier_mean": float(row["brier_mean"] or 0.0),
+                    "log_loss_mean": float(row["log_loss_mean"] or 0.0),
+                    "auroc_mean": ""
+                    if row["auroc_mean"] is None
+                    else f"{float(row['auroc_mean']):.6f}",
+                    "average_precision_mean": ""
+                    if row["average_precision_mean"] is None
+                    else f"{float(row['average_precision_mean']):.6f}",
+                    "null_p": ""
+                    if row["null_average_precision_p_ge_mean"] is None
+                    else f"{float(row['null_average_precision_p_ge_mean']):.6f}",
+                }
+            )
+        )
+    if reasons:
+        md_lines.extend(["", "## Reasons", ""])
+        md_lines.extend(f"- {reason}" for reason in reasons)
+    (args.output_dir / "dynamic_fc_switching_gate.md").write_text(
+        "\n".join(md_lines) + "\n",
+        encoding="utf-8",
+    )
+    print(f"verdict={verdict}")
+    print(f"outputs={args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/abide_dynamic_fc_switching_loso_runner.sh
+++ b/scripts/research/abide_dynamic_fc_switching_loso_runner.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_ROOT="${OUT_ROOT:-$(mktemp -d /tmp/abide-dynamic-fc-loso.XXXXXX)}"
+CACHE_DIR="${CACHE_DIR:-${ROOT}/artifacts/research/abide}"
+RESULT_DIR="${OUT_ROOT}/results"
+
+MAX_SUBJECTS="${MAX_SUBJECTS:-60}"
+ROI_LIMIT="${ROI_LIMIT:-40}"
+WINDOW_TR="${WINDOW_TR:-30}"
+STEP_TR="${STEP_TR:-6}"
+MIN_TIMEPOINTS="${MIN_TIMEPOINTS:-90}"
+MIN_WINDOWS="${MIN_WINDOWS:-10}"
+PCA_COMPONENTS="${PCA_COMPONENTS:-8}"
+K="${K:-4}"
+SENSITIVITY_K="${SENSITIVITY_K:-3,5}"
+TARGET_MIN_SUBJECTS="${TARGET_MIN_SUBJECTS:-50}"
+TARGET_MIN_SITES="${TARGET_MIN_SITES:-5}"
+TARGET_MIN_STATE_OCCUPANCY="${TARGET_MIN_STATE_OCCUPANCY:-0.005}"
+TARGET_MIN_SWITCH_FRAC="${TARGET_MIN_SWITCH_FRAC:-0.001}"
+TARGET_MAX_ZERO_SWITCH_FRAC="${TARGET_MAX_ZERO_SWITCH_FRAC:-1.0}"
+TARGET_MAX_WINDOW_SWITCH_CORR="${TARGET_MAX_WINDOW_SWITCH_CORR:-1.0}"
+
+GATE_EPOCHS="${GATE_EPOCHS:-80}"
+GATE_LR="${GATE_LR:-0.04}"
+GATE_L2="${GATE_L2:-0.01}"
+GATE_NULL_PERMUTATIONS="${GATE_NULL_PERMUTATIONS:-20}"
+GATE_MIN_TEST_EVENTS="${GATE_MIN_TEST_EVENTS:-2}"
+GATE_MIN_TEST_POSITIVE_EVENTS="${GATE_MIN_TEST_POSITIVE_EVENTS:-0}"
+
+DECISION_MIN_SUBJECTS="${DECISION_MIN_SUBJECTS:-50}"
+DECISION_MIN_SITES="${DECISION_MIN_SITES:-5}"
+DECISION_MIN_NULL_PERMUTATIONS="${DECISION_MIN_NULL_PERMUTATIONS:-20}"
+
+RUN_SOUNIO_SMOKE="${RUN_SOUNIO_SMOKE:-0}"
+SOUNIO_SMOKE_MAX_EVENTS="${SOUNIO_SMOKE_MAX_EVENTS:-96}"
+SOUNIO_SMOKE_GLOBAL_EPOCHS="${SOUNIO_SMOKE_GLOBAL_EPOCHS:-1}"
+SOUNIO_SMOKE_OCT_EPOCHS="${SOUNIO_SMOKE_OCT_EPOCHS:-1}"
+SOUNIO_SMOKE_H_EPOCHS="${SOUNIO_SMOKE_H_EPOCHS:-1}"
+
+python3 "${ROOT}/scripts/research/abide_dynamic_fc_switching_target.py" \
+  --cache-dir "${CACHE_DIR}" \
+  --output-dir "${RESULT_DIR}" \
+  --max-subjects "${MAX_SUBJECTS}" \
+  --roi-limit "${ROI_LIMIT}" \
+  --split-policy leave_one_site_out \
+  --window-tr "${WINDOW_TR}" \
+  --step-tr "${STEP_TR}" \
+  --min-timepoints "${MIN_TIMEPOINTS}" \
+  --min-windows "${MIN_WINDOWS}" \
+  --pca-components "${PCA_COMPONENTS}" \
+  --k "${K}" \
+  --sensitivity-k "${SENSITIVITY_K}" \
+  --min-subjects "${TARGET_MIN_SUBJECTS}" \
+  --min-sites "${TARGET_MIN_SITES}" \
+  --min-state-occupancy-frac "${TARGET_MIN_STATE_OCCUPANCY}" \
+  --min-switch-event-frac "${TARGET_MIN_SWITCH_FRAC}" \
+  --max-zero-switch-subject-frac "${TARGET_MAX_ZERO_SWITCH_FRAC}" \
+  --max-window-switch-abs-corr "${TARGET_MAX_WINDOW_SWITCH_CORR}"
+
+python3 "${ROOT}/scripts/research/abide_dynamic_fc_switching_gate.py" \
+  --window-table "${RESULT_DIR}/dynamic_fc_window_table.tsv" \
+  --output-dir "${RESULT_DIR}/switching_gate" \
+  --epochs "${GATE_EPOCHS}" \
+  --lr "${GATE_LR}" \
+  --l2 "${GATE_L2}" \
+  --null-permutations "${GATE_NULL_PERMUTATIONS}" \
+  --min-test-events "${GATE_MIN_TEST_EVENTS}" \
+  --min-test-positive-events "${GATE_MIN_TEST_POSITIVE_EVENTS}"
+
+python3 "${ROOT}/scripts/research/abide_dynamic_fc_switching_decision_gate.py" \
+  --target-audit-json "${RESULT_DIR}/dynamic_fc_target_audit.json" \
+  --gate-json "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate.json" \
+  --gate-summary "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate_summary.tsv" \
+  --output-dir "${RESULT_DIR}/switching_decision" \
+  --min-decision-subjects "${DECISION_MIN_SUBJECTS}" \
+  --min-decision-sites "${DECISION_MIN_SITES}" \
+  --min-decision-null-permutations "${DECISION_MIN_NULL_PERMUTATIONS}"
+
+python3 - "${RESULT_DIR}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+result = Path(sys.argv[1])
+target = json.loads((result / "dynamic_fc_target_audit.json").read_text(encoding="utf-8"))
+gate = json.loads((result / "switching_gate" / "dynamic_fc_switching_gate.json").read_text(encoding="utf-8"))
+decision = json.loads((result / "switching_decision" / "dynamic_fc_switching_decision.json").read_text(encoding="utf-8"))
+assert target["status"] == "pass", target
+assert target["parameters"]["split_policy"] == "leave_one_site_out", target
+assert gate["verdict"] == "TRAINED_O_SSM_GATE_EXECUTED_NO_PROMOTION", gate
+assert decision["overall_verdict"] in {
+    "NO_PROMOTION_RESERVOIR_ONLY",
+    "NO_PROMOTION_PYTHON_TRAINED_ONLY",
+    "NEGATIVE_OR_UNDERCONTROLLED_NO_ROBUST_O_SSM_SIGNAL",
+    "EXPLORATORY_O_SSM_SWITCHING_SIGNAL",
+}, decision
+print("ABIDE_DYNAMIC_FC_SWITCHING_LOSO_RUNNER_PASS")
+print("target_subjects=", target["subject_count"], "sites=", target["site_count"])
+print("decision=", decision["overall_verdict"])
+PY
+
+if [[ "${RUN_SOUNIO_SMOKE}" == "1" ]]; then
+  WINDOW_TABLE="${RESULT_DIR}/dynamic_fc_window_table.tsv" \
+  OUT_ROOT="${RESULT_DIR}/sounio_smoke" \
+  MAX_EVENTS="${SOUNIO_SMOKE_MAX_EVENTS}" \
+  GLOBAL_TRAIN_EPOCHS="${SOUNIO_SMOKE_GLOBAL_EPOCHS}" \
+  OCT_TRAIN_EPOCHS="${SOUNIO_SMOKE_OCT_EPOCHS}" \
+  H_TRAIN_EPOCHS="${SOUNIO_SMOKE_H_EPOCHS}" \
+  SOUNIO_SOUC_ENGINE="${SOUNIO_SOUC_ENGINE:-lean_single}" \
+    bash "${ROOT}/scripts/research/abide_dynamic_fc_switching_sounio_smoke.sh"
+fi
+
+echo "outputs: ${RESULT_DIR}"

--- a/scripts/research/abide_dynamic_fc_switching_smoke.sh
+++ b/scripts/research/abide_dynamic_fc_switching_smoke.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_ROOT="${OUT_ROOT:-$(mktemp -d /tmp/abide-dynamic-fc-smoke.XXXXXX)}"
+CACHE_DIR="${OUT_ROOT}/cache"
+RESULT_DIR="${OUT_ROOT}/results"
+
+mkdir -p "${CACHE_DIR}"
+
+python3 - "${CACHE_DIR}" <<'PY'
+import csv
+import math
+import sys
+from pathlib import Path
+
+cache = Path(sys.argv[1])
+subjects = []
+sites = ["SITE_A", "SITE_B", "SITE_C"]
+for site_idx, site in enumerate(sites):
+    for local_idx in range(2):
+        global_idx = site_idx * 2 + local_idx
+        sub_id = f"{50000 + global_idx}"
+        file_id = f"{site}_{sub_id}"
+        dx = "1" if local_idx == 0 else "2"
+        subjects.append({"SUB_ID": sub_id, "FILE_ID": file_id, "SITE_ID": site, "DX_GROUP": dx})
+        rows = []
+        for t in range(80):
+            phase = (t // 20) % 2
+            values = []
+            for roi in range(8):
+                base = math.sin(0.17 * t + 0.31 * roi + 0.13 * global_idx)
+                if phase == 0:
+                    coupled = base + 0.25 * math.sin(0.11 * t + site_idx)
+                else:
+                    coupled = ((-1) ** roi) * base + 0.25 * math.cos(0.07 * t + local_idx)
+                values.append(coupled + 0.01 * (global_idx + 1) * (roi + 1))
+            rows.append(values)
+        with (cache / f"{file_id}_rois_cc200.1D").open("w", encoding="utf-8") as handle:
+            for row in rows:
+                handle.write(" ".join(f"{value:.8f}" for value in row) + "\n")
+
+with (cache / "phenotypic.csv").open("w", encoding="utf-8", newline="") as handle:
+    writer = csv.DictWriter(handle, fieldnames=["SUB_ID", "FILE_ID", "SITE_ID", "DX_GROUP"])
+    writer.writeheader()
+    for row in subjects:
+        writer.writerow(row)
+PY
+
+python3 "${ROOT}/scripts/research/abide_dynamic_fc_switching_target.py" \
+  --cache-dir "${CACHE_DIR}" \
+  --output-dir "${RESULT_DIR}" \
+  --window-tr 20 \
+  --step-tr 5 \
+  --min-timepoints 60 \
+  --min-windows 10 \
+  --pca-components 4 \
+  --k 3 \
+  --sensitivity-k 2,4 \
+  --min-subjects 6 \
+  --min-sites 3 \
+  --min-state-occupancy-frac 0.01 \
+  --min-switch-event-frac 0.01 \
+  --max-zero-switch-subject-frac 1.0 \
+  --max-window-switch-abs-corr 1.0
+
+python3 "${ROOT}/scripts/research/abide_dynamic_fc_switching_gate.py" \
+  --window-table "${RESULT_DIR}/dynamic_fc_window_table.tsv" \
+  --output-dir "${RESULT_DIR}/switching_gate" \
+  --epochs 120 \
+  --lr 0.04 \
+  --l2 0.01 \
+  --null-permutations 3 \
+  --min-test-events 6 \
+  --min-test-positive-events 1
+
+python3 "${ROOT}/scripts/research/abide_dynamic_fc_switching_decision_gate.py" \
+  --target-audit-json "${RESULT_DIR}/dynamic_fc_target_audit.json" \
+  --gate-json "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate.json" \
+  --gate-summary "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate_summary.tsv" \
+  --output-dir "${RESULT_DIR}/switching_decision" \
+  --min-decision-subjects 50 \
+  --min-decision-null-permutations 20
+
+test -s "${RESULT_DIR}/dynamic_fc_window_table.tsv"
+test -s "${RESULT_DIR}/dynamic_fc_subject_summary.tsv"
+test -s "${RESULT_DIR}/dynamic_fc_target_audit.json"
+test -s "${RESULT_DIR}/dynamic_fc_target_audit.md"
+test -s "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate.json"
+test -s "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate_summary.tsv"
+test -s "${RESULT_DIR}/switching_decision/dynamic_fc_switching_decision.json"
+
+python3 - "${RESULT_DIR}/dynamic_fc_target_audit.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["status"] == "pass", payload
+assert payload["subject_count"] == 6, payload
+assert payload["site_count"] == 3, payload
+assert payload["primary_test_switch_event_denominator"] > 0, payload
+print("ABIDE_DYNAMIC_FC_SWITCHING_SMOKE_PASS")
+PY
+
+python3 - "${RESULT_DIR}/switching_gate/dynamic_fc_switching_gate.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["verdict"] == "TRAINED_O_SSM_GATE_EXECUTED_NO_PROMOTION", payload
+assert payload["event_rows"] > 0, payload
+assert payload["summary"], payload
+models = {row["model"] for row in payload["summary"]}
+assert {"base_rate", "gru_reservoir", "hssm_reservoir", "ossm_reservoir", "trained_hssm", "trained_ossm"} <= models, payload
+ossm = next(row for row in payload["summary"] if row["model"] == "ossm_reservoir")
+assert float(ossm["null_permutations_mean"]) == 3.0, payload
+print("ABIDE_DYNAMIC_FC_SWITCHING_GATE_SMOKE_PASS")
+PY
+
+python3 - "${RESULT_DIR}/switching_decision/dynamic_fc_switching_decision.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["overall_verdict"] == "UNDERCONTROLLED_LOW_POWER_OR_SMOKE_SPLIT", payload
+assert any("subject_count" in reason for reason in payload["reasons"]), payload
+assert payload["target_summary"]["split_policy"] == "leave_one_site_out", payload
+assert any("null_permutations" in reason for reason in payload["reasons"]), payload
+print("ABIDE_DYNAMIC_FC_SWITCHING_DECISION_SMOKE_PASS")
+PY
+
+echo "outputs: ${RESULT_DIR}"

--- a/scripts/research/abide_dynamic_fc_switching_sounio_manifest.py
+++ b/scripts/research/abide_dynamic_fc_switching_sounio_manifest.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Export dynamic-FC switching events to the Brain O-SSM ABIDE manifest format.
+
+The exported manifest is a bridge artifact for the existing compiled Sounio
+`examples/brain_ossm_abide.sio` benchmark. Each row is a switch-event example,
+not an ASD diagnostic subject. Features are built only from dynamic-state
+history available before the target transition.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SEQ_LEN = 8
+INPUT_DIM = 8
+FEATURE_COUNT = SEQ_LEN * INPUT_DIM
+DEFAULT_CONFIG = {
+    "global_train_epochs": "8",
+    "global_train_lr": "0.015",
+    "global_core_lr_scale": "0.25",
+    "oct_train_epochs": "8",
+    "oct_train_lr": "0.015",
+    "oct_core_lr_scale": "0.25",
+    "oct_warmup_epochs": "2",
+    "h_train_epochs": "8",
+    "h_train_lr": "0.015",
+    "h_core_lr_scale": "0.25",
+    "h_warmup_epochs": "2",
+    "trace_hidden_state": "0",
+}
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]], fields: list[str]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, delimiter="\t", fieldnames=fields, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_int(value: str, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    return int(float(value))
+
+
+def parse_binary(value: str) -> int | None:
+    if value == "":
+        return None
+    parsed = int(float(value))
+    if parsed not in (0, 1):
+        raise ValueError(f"switch_event must be binary, got {value!r}")
+    return parsed
+
+
+def event_sort_key(row: dict[str, str]) -> tuple[str, str, int]:
+    return (row["fold_id"], row["subject_id"], parse_int(row["window_index"]))
+
+
+def compute_history_vectors(rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+    by_subject: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
+    for row in sorted(rows, key=event_sort_key):
+        by_subject[(row["fold_id"], row["subject_id"])].append(row)
+
+    events: list[dict[str, Any]] = []
+    for (fold_id, subject_id), subject_rows in by_subject.items():
+        subject_rows.sort(key=lambda row: parse_int(row["window_index"]))
+        run_lengths: list[int] = []
+        current_run = 0
+        previous_state: int | None = None
+        for row in subject_rows:
+            state = parse_int(row["state"])
+            if previous_state is None or state != previous_state:
+                current_run = 1
+            else:
+                current_run += 1
+            run_lengths.append(current_run)
+            previous_state = state
+
+        window_count = max(parse_int(subject_rows[0].get("window_count", "0")), len(subject_rows))
+        n_timepoints = parse_int(subject_rows[0].get("n_timepoints", "0"))
+        for idx, row in enumerate(subject_rows):
+            target = parse_binary(row.get("switch_event", ""))
+            if target is None:
+                continue
+            features: list[float] = []
+            for step in range(SEQ_LEN):
+                hist_idx = idx - SEQ_LEN + step
+                vec = [0.0] * INPUT_DIM
+                if hist_idx >= 0:
+                    hist_row = subject_rows[hist_idx]
+                    state = parse_int(hist_row["state"])
+                    if 0 <= state < 4:
+                        vec[state] = 1.0
+                    else:
+                        vec[state % 4] = 0.5
+                    previous_switch = parse_binary(hist_row.get("switch_event", "")) or 0
+                    vec[4] = float(previous_switch)
+                    vec[5] = min(run_lengths[hist_idx], SEQ_LEN) / float(SEQ_LEN)
+                    vec[6] = parse_int(hist_row["window_index"]) / max(window_count - 1, 1)
+                    vec[7] = min(math.log1p(max(n_timepoints, 1)) / 6.0, 1.0)
+                features.extend(vec)
+            if len(features) != FEATURE_COUNT:
+                raise AssertionError(f"expected {FEATURE_COUNT} features, got {len(features)}")
+            event_id = f"dynfc_{fold_id}_{subject_id}_{parse_int(row['window_index']):03d}"
+            events.append(
+                {
+                    "event_id": event_id,
+                    "manifest_subject_id": event_id,
+                    "label": str(target),
+                    "site": row["site"],
+                    "fold_id": fold_id,
+                    "holdout_site": row["holdout_site"],
+                    "subject_id": subject_id,
+                    "source_label": row.get("label", ""),
+                    "window_index": parse_int(row["window_index"]),
+                    "target_switch_event": target,
+                    "features": features,
+                }
+            )
+    return events
+
+
+def balanced_sample(events: list[dict[str, Any]], max_events: int) -> list[dict[str, Any]]:
+    if max_events <= 0 or len(events) <= max_events:
+        return events
+    selected: list[dict[str, Any]] = []
+    by_label = {
+        0: [event for event in events if event["target_switch_event"] == 0],
+        1: [event for event in events if event["target_switch_event"] == 1],
+    }
+    first_quota = max_events // 2
+    quotas = {1: first_quota, 0: max_events - first_quota}
+    for label in (1, 0):
+        selected.extend(by_label[label][: quotas[label]])
+    if len(selected) < max_events:
+        used = {event["event_id"] for event in selected}
+        for event in events:
+            if event["event_id"] not in used:
+                selected.append(event)
+                if len(selected) >= max_events:
+                    break
+    return sorted(selected, key=lambda event: event["event_id"])
+
+
+def write_manifest(path: Path, events: list[dict[str, Any]], source: Path) -> None:
+    header = ["subject_id", "label", "site"] + [f"f{i}" for i in range(FEATURE_COUNT)]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write("# schema=abide_dynamic_fc_switching_sounio_manifest.v1\n")
+        handle.write("# target=switch_event; labels are dynamic-FC switching events, not ASD/control diagnoses\n")
+        handle.write("# features=8x8 prior-state-history; no current-window state or clinical label is encoded\n")
+        handle.write(f"# source={source}\n")
+        writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+        writer.writerow(header)
+        for event in events:
+            writer.writerow(
+                [event["manifest_subject_id"], event["label"], event["site"]]
+                + [f"{value:.8f}" for value in event["features"]]
+            )
+
+
+def write_config(path: Path, overrides: list[str]) -> dict[str, str]:
+    config = dict(DEFAULT_CONFIG)
+    for override in overrides:
+        if "=" not in override:
+            raise ValueError(f"config override must be key=value, got {override!r}")
+        key, value = override.split("=", 1)
+        config[key] = value
+    with path.open("w", encoding="utf-8") as handle:
+        for key, value in config.items():
+            handle.write(f"{key}={value}\n")
+    return config
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--window-table", required=True, help="dynamic_fc_window_table.tsv")
+    parser.add_argument("--output-dir", required=True, help="Directory for Sounio manifest/config outputs")
+    parser.add_argument("--split", default="test", help="Window-table split to export")
+    parser.add_argument("--max-events", type=int, default=320, help="Deterministic cap for compiled smoke runs")
+    parser.add_argument("--min-events", type=int, default=20)
+    parser.add_argument("--min-sites", type=int, default=2)
+    parser.add_argument("--config", action="append", default=[], help="Extra abide_run_config.tsv key=value line")
+    args = parser.parse_args()
+
+    window_table = Path(args.window_table)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        row
+        for row in read_tsv(window_table)
+        if row.get("split") == args.split and row.get("switch_event", "") != ""
+    ]
+    if not rows:
+        raise SystemExit(f"no rows with split={args.split!r} and binary switch_event in {window_table}")
+
+    events = compute_history_vectors(rows)
+    events = balanced_sample(events, args.max_events)
+    label_counts = Counter(event["target_switch_event"] for event in events)
+    site_counts = Counter(event["site"] for event in events)
+    if len(events) < args.min_events:
+        raise SystemExit(f"too few exported events: {len(events)} < {args.min_events}")
+    if len(site_counts) < args.min_sites:
+        raise SystemExit(f"too few exported sites: {len(site_counts)} < {args.min_sites}")
+    if min(label_counts.values()) <= 0 or len(label_counts) < 2:
+        raise SystemExit(f"manifest needs both switch classes, got {dict(label_counts)}")
+
+    manifest_path = output_dir / "abide_roi_manifest.tsv"
+    config_path = output_dir / "abide_run_config.tsv"
+    event_map_path = output_dir / "dynamic_fc_sounio_event_map.tsv"
+    audit_path = output_dir / "dynamic_fc_sounio_manifest_audit.json"
+    audit_md_path = output_dir / "dynamic_fc_sounio_manifest_audit.md"
+
+    write_manifest(manifest_path, events, window_table)
+    config = write_config(config_path, args.config)
+    write_tsv(
+        event_map_path,
+        [
+            {
+                key: event[key]
+                for key in (
+                    "event_id",
+                    "manifest_subject_id",
+                    "label",
+                    "site",
+                    "fold_id",
+                    "holdout_site",
+                    "subject_id",
+                    "source_label",
+                    "window_index",
+                    "target_switch_event",
+                )
+            }
+            for event in events
+        ],
+        [
+            "event_id",
+            "manifest_subject_id",
+            "label",
+            "site",
+            "fold_id",
+            "holdout_site",
+            "subject_id",
+            "source_label",
+            "window_index",
+            "target_switch_event",
+        ],
+    )
+    audit = {
+        "schema": "abide_dynamic_fc_switching_sounio_manifest_audit.v1",
+        "verdict": "PASS",
+        "source_window_table": str(window_table),
+        "split": args.split,
+        "event_count": len(events),
+        "site_count": len(site_counts),
+        "label_counts": {str(key): value for key, value in sorted(label_counts.items())},
+        "feature_shape": {"seq_len": SEQ_LEN, "input_dim": INPUT_DIM, "feature_count": FEATURE_COUNT},
+        "manifest_path": str(manifest_path),
+        "config_path": str(config_path),
+        "event_map_path": str(event_map_path),
+        "claim_boundary": (
+            "Switch-event labels are dynamic-FC temporal events, not ASD/control diagnoses; "
+            "this bridge does not establish a clinical, biomarker, mechanism, or O-SSM superiority claim."
+        ),
+        "config": config,
+    }
+    audit_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    audit_md_path.write_text(
+        "\n".join(
+            [
+                "# Dynamic-FC Sounio Manifest Audit",
+                "",
+                f"- Verdict: `{audit['verdict']}`",
+                f"- Events: `{len(events)}`",
+                f"- Sites: `{len(site_counts)}`",
+                f"- Label counts: `{dict(label_counts)}`",
+                f"- Feature shape: `{SEQ_LEN}x{INPUT_DIM}`",
+                "",
+                "The exported labels are dynamic-FC switch events. They are not ASD/control diagnoses, biomarkers,",
+                "clinical-decision outputs, biological mechanisms, or evidence of O-SSM superiority.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    print(f"ABIDE_DYNAMIC_FC_SOUNIO_MANIFEST_PASS output_dir={output_dir} events={len(events)} sites={len(site_counts)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/abide_dynamic_fc_switching_sounio_smoke.sh
+++ b/scripts/research/abide_dynamic_fc_switching_sounio_smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Run the existing compiled Brain O-SSM ABIDE benchmark on dynamic-FC switch events.
+#
+# This is a bridge smoke for execution only. Labels are temporal switch events,
+# not ASD/control diagnoses, and the output must not be promoted as a clinical
+# or O-SSM superiority claim.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WINDOW_TABLE="${WINDOW_TABLE:-}"
+OUT_ROOT="${OUT_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/abide-dynamic-fc-sounio.XXXXXX")}"
+MAX_EVENTS="${MAX_EVENTS:-96}"
+ENGINE="${SOUNIO_SOUC_ENGINE:-lean_single}"
+
+if [[ -z "$WINDOW_TABLE" ]]; then
+  echo "WINDOW_TABLE is required; pass dynamic_fc_window_table.tsv" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_ROOT"
+MANIFEST_DIR="$OUT_ROOT/sounio_manifest"
+RAW_OUT="$OUT_ROOT/brain_ossm_dynamic_fc_switching.raw.txt"
+PARSED_DIR="$OUT_ROOT/brain_ossm_dynamic_fc_switching_parsed"
+
+python3 "$ROOT_DIR/scripts/research/abide_dynamic_fc_switching_sounio_manifest.py" \
+  --window-table "$WINDOW_TABLE" \
+  --output-dir "$MANIFEST_DIR" \
+  --max-events "$MAX_EVENTS" \
+  --config global_train_epochs="${GLOBAL_TRAIN_EPOCHS:-3}" \
+  --config oct_train_epochs="${OCT_TRAIN_EPOCHS:-3}" \
+  --config h_train_epochs="${H_TRAIN_EPOCHS:-3}" \
+  --config oct_warmup_epochs="${OCT_WARMUP_EPOCHS:-1}" \
+  --config h_warmup_epochs="${H_WARMUP_EPOCHS:-1}" \
+  --config trace_hidden_state="${TRACE_HIDDEN_STATE:-0}"
+
+(
+  cd "$MANIFEST_DIR"
+  SOUNIO_SOUC_ENGINE="$ENGINE" "$ROOT_DIR/bin/souc" run "$ROOT_DIR/examples/brain_ossm_abide.sio"
+) >"$RAW_OUT" 2>&1
+
+python3 "$ROOT_DIR/scripts/research/parse_brain_ossm_abide_output.py" \
+  --input "$RAW_OUT" \
+  --output-dir "$PARSED_DIR"
+
+python3 - "$MANIFEST_DIR/dynamic_fc_sounio_manifest_audit.json" "$PARSED_DIR/overall_metrics.json" <<'PY'
+import json
+import sys
+
+audit = json.load(open(sys.argv[1], encoding="utf-8"))
+metrics = json.load(open(sys.argv[2], encoding="utf-8"))
+models = {row["model"] for row in metrics.get("overall", [])}
+if audit.get("verdict") != "PASS":
+    raise SystemExit(f"manifest audit did not pass: {audit.get('verdict')}")
+missing = {"O-SSM", "H-SSM"} - models
+if missing:
+    raise SystemExit(f"missing parsed Sounio models: {sorted(missing)}")
+print(
+    "ABIDE_DYNAMIC_FC_SOUNIO_SMOKE_PASS "
+    f"events={audit['event_count']} sites={audit['site_count']} models={','.join(sorted(models))}"
+)
+PY
+
+echo "output_root=$OUT_ROOT"

--- a/scripts/research/abide_dynamic_fc_switching_target.py
+++ b/scripts/research/abide_dynamic_fc_switching_target.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python3
+"""Build ABIDE dynamic-FC state-switching targets.
+
+This is a target-builder and audit surface, not a model evaluation. It turns
+cached ABIDE CC200 ROI time series into fold-local dynamic functional
+connectivity states and switching events. PCA and k-means are fit on training
+windows only inside each split, then applied to held-out windows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+SCHEMA = "neurodyn.abide_dynamic_fc_switching_target.v1"
+CLAIM_BOUNDARY = (
+    "Target-builder and readiness audit only; no diagnostic, biomarker, "
+    "mechanism, treatment, ASD-detection, or O-SSM superiority claim."
+)
+
+MISSING_TOKENS = {"", "na", "n/a", "nan", "none", "null", "-999", "-9999"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phenotypic-csv",
+        type=Path,
+        default=None,
+        help="ABIDE phenotypic CSV. Defaults to <cache-dir>/phenotypic.csv.",
+    )
+    parser.add_argument(
+        "--roi-dir",
+        type=Path,
+        default=None,
+        help="Directory containing *_rois_cc200.1D files. Defaults to <cache-dir>.",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("artifacts/research/abide"),
+        help="Fallback directory containing phenotypic.csv and ROI files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/research/abide_dynamic_fc_switching"),
+        help="Output artifact directory.",
+    )
+    parser.add_argument("--window-tr", type=int, default=30)
+    parser.add_argument("--step-tr", type=int, default=3)
+    parser.add_argument("--min-timepoints", type=int, default=90)
+    parser.add_argument("--min-windows", type=int, default=20)
+    parser.add_argument("--pca-components", type=int, default=16)
+    parser.add_argument("--k", type=int, default=4)
+    parser.add_argument("--sensitivity-k", default="3,5,6,7")
+    parser.add_argument("--seed", type=int, default=20260708)
+    parser.add_argument(
+        "--split-policy",
+        choices=["leave_one_site_out", "stratified_smoke"],
+        default="leave_one_site_out",
+    )
+    parser.add_argument(
+        "--smoke-test-frac",
+        type=float,
+        default=0.25,
+        help="Held-out subject fraction for --split-policy=stratified_smoke.",
+    )
+    parser.add_argument(
+        "--max-subjects",
+        type=int,
+        default=0,
+        help="Optional deterministic cap for local smoke runs.",
+    )
+    parser.add_argument(
+        "--roi-limit",
+        type=int,
+        default=0,
+        help="Optional leading-ROI cap for smoke tests; 0 uses all columns.",
+    )
+    parser.add_argument("--min-subjects", type=int, default=50)
+    parser.add_argument("--min-sites", type=int, default=5)
+    parser.add_argument("--min-state-occupancy-frac", type=float, default=0.05)
+    parser.add_argument("--min-switch-event-frac", type=float, default=0.02)
+    parser.add_argument("--max-switch-event-frac", type=float, default=0.80)
+    parser.add_argument("--max-zero-switch-subject-frac", type=float, default=0.25)
+    parser.add_argument("--max-low-window-subject-frac", type=float, default=0.20)
+    parser.add_argument("--max-window-switch-abs-corr", type=float, default=0.50)
+    return parser.parse_args()
+
+
+def is_missing(value: str | None) -> bool:
+    if value is None:
+        return True
+    return value.strip().lower() in MISSING_TOKENS
+
+
+def label_from_dx(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    value = raw.strip()
+    if value == "1":
+        return "ASD"
+    if value == "2":
+        return "CONTROL"
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(out):
+        return None
+    return out
+
+
+def read_pheno(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def load_timeseries(path: Path, roi_limit: int = 0) -> np.ndarray | None:
+    rows: list[list[float]] = []
+    width_counts: Counter[int] = Counter()
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            values = [safe_float(value) for value in line.split()]
+            if any(value is None for value in values):
+                continue
+            row = [float(value) for value in values if value is not None]
+            if roi_limit > 0:
+                row = row[:roi_limit]
+            if row:
+                width_counts[len(row)] += 1
+                rows.append(row)
+    if not rows:
+        return None
+    target_width = width_counts.most_common(1)[0][0]
+    clean: list[list[float]] = []
+    for row in rows:
+        if len(row) >= target_width:
+            clean.append(row[:target_width])
+        else:
+            clean.append(row + [0.0] * (target_width - len(row)))
+    arr = np.asarray(clean, dtype=np.float64)
+    if arr.ndim != 2 or arr.shape[1] < 2:
+        return None
+    return np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def window_slices(n_timepoints: int, window_tr: int, step_tr: int) -> list[tuple[int, int]]:
+    if window_tr <= 1 or step_tr <= 0:
+        raise ValueError("window_tr must be >1 and step_tr must be positive")
+    if n_timepoints < window_tr:
+        return []
+    return [(start, start + window_tr) for start in range(0, n_timepoints - window_tr + 1, step_tr)]
+
+
+def window_fc_vectors(ts: np.ndarray, slices: list[tuple[int, int]]) -> np.ndarray:
+    vectors: list[np.ndarray] = []
+    tri = np.triu_indices(ts.shape[1], k=1)
+    for start, end in slices:
+        window = ts[start:end, :]
+        mu = window.mean(axis=0, keepdims=True)
+        sigma = window.std(axis=0, keepdims=True, ddof=1)
+        sigma = np.where(sigma > 1.0e-8, sigma, 1.0)
+        z = (window - mu) / sigma
+        corr = (z.T @ z) / max(1, z.shape[0] - 1)
+        corr = np.clip(corr, -0.999999, 0.999999)
+        fish = np.arctanh(corr)
+        vectors.append(fish[tri].astype(np.float64))
+    if not vectors:
+        return np.zeros((0, 0), dtype=np.float64)
+    return np.vstack(vectors)
+
+
+def pearson(xs: list[float], ys: list[float]) -> float | None:
+    if len(xs) != len(ys) or len(xs) < 3:
+        return None
+    mx = sum(xs) / len(xs)
+    my = sum(ys) / len(ys)
+    vx = sum((x - mx) * (x - mx) for x in xs)
+    vy = sum((y - my) * (y - my) for y in ys)
+    if vx <= 1.0e-12 or vy <= 1.0e-12:
+        return None
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    return cov / math.sqrt(vx * vy)
+
+
+def fit_pca(train_x: np.ndarray, components: int) -> tuple[np.ndarray, np.ndarray, list[float]]:
+    mean = train_x.mean(axis=0)
+    centered = train_x - mean
+    max_components = max(1, min(components, centered.shape[0] - 1, centered.shape[1]))
+    if centered.shape[0] < centered.shape[1]:
+        gram = centered @ centered.T
+        eigvals, eigvecs = np.linalg.eigh(gram)
+        order = np.argsort(eigvals)[::-1]
+        eigvals = np.maximum(eigvals[order], 0.0)
+        eigvecs = eigvecs[:, order]
+        nonzero = eigvals > 1.0e-12
+        eigvals = eigvals[nonzero]
+        eigvecs = eigvecs[:, nonzero]
+        take = min(max_components, eigvals.shape[0])
+        if take <= 0:
+            basis = np.zeros((centered.shape[1], 1), dtype=np.float64)
+            variances = np.zeros(1, dtype=np.float64)
+        else:
+            svals = np.sqrt(eigvals[:take])
+            basis = centered.T @ (eigvecs[:, :take] / svals[None, :])
+            variances = eigvals / max(1, centered.shape[0] - 1)
+    else:
+        cov = (centered.T @ centered) / max(1, centered.shape[0] - 1)
+        eigvals, eigvecs = np.linalg.eigh(cov)
+        order = np.argsort(eigvals)[::-1]
+        eigvals = np.maximum(eigvals[order], 0.0)
+        eigvecs = eigvecs[:, order]
+        basis = eigvecs[:, :max_components]
+        variances = eigvals
+    total = float(variances.sum())
+    explained = [float(value / total) if total > 0 else 0.0 for value in variances[: basis.shape[1]]]
+    return mean, basis, explained
+
+
+def project_pca(x: np.ndarray, mean: np.ndarray, basis: np.ndarray) -> np.ndarray:
+    return (x - mean) @ basis
+
+
+def fit_kmeans(x: np.ndarray, k: int, seed: int, max_iter: int = 100) -> np.ndarray:
+    if k <= 1:
+        raise ValueError("k must be greater than one")
+    if x.shape[0] < k:
+        raise ValueError(f"cannot fit k={k} with only {x.shape[0]} rows")
+    rng = np.random.default_rng(seed)
+    first_idx = int(rng.integers(0, x.shape[0]))
+    centers = [x[first_idx]]
+    min_dist = np.sum((x - centers[0]) ** 2, axis=1)
+    for _ in range(1, k):
+        total = float(min_dist.sum())
+        if total <= 1.0e-12:
+            idx = len(centers) % x.shape[0]
+        else:
+            idx = int(rng.choice(x.shape[0], p=min_dist / total))
+        centers.append(x[idx])
+        min_dist = np.minimum(min_dist, np.sum((x - centers[-1]) ** 2, axis=1))
+    centroids = np.vstack(centers)
+    labels = np.zeros(x.shape[0], dtype=np.int64)
+    for _ in range(max_iter):
+        new_labels = assign_kmeans(x, centroids)
+        if np.array_equal(new_labels, labels):
+            break
+        labels = new_labels
+        for cluster in range(k):
+            mask = labels == cluster
+            if mask.any():
+                centroids[cluster] = x[mask].mean(axis=0)
+            else:
+                centroids[cluster] = x[int(rng.integers(0, x.shape[0]))]
+    return centroids
+
+
+def assign_kmeans(x: np.ndarray, centroids: np.ndarray) -> np.ndarray:
+    dist = ((x[:, None, :] - centroids[None, :, :]) ** 2).sum(axis=2)
+    return np.argmin(dist, axis=1).astype(np.int64)
+
+
+def build_subjects(args: argparse.Namespace) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    pheno_path = args.phenotypic_csv or (args.cache_dir / "phenotypic.csv")
+    roi_dir = args.roi_dir or args.cache_dir
+    if not pheno_path.exists():
+        raise SystemExit(f"missing phenotypic CSV: {pheno_path}")
+    if not roi_dir.exists():
+        raise SystemExit(f"missing ROI directory: {roi_dir}")
+
+    specs: list[dict[str, str]] = []
+    skipped = Counter()
+    for row in read_pheno(pheno_path):
+        subject_id = (row.get("SUB_ID") or row.get("subject_id") or "").strip()
+        file_id = (row.get("FILE_ID") or "").strip()
+        site = (row.get("SITE_ID") or row.get("site") or "").strip()
+        label = label_from_dx(row.get("DX_GROUP"))
+        if is_missing(file_id) or file_id == "no_filename":
+            skipped["missing_file_id"] += 1
+            continue
+        if not subject_id or not site or label is None:
+            skipped["missing_metadata"] += 1
+            continue
+        ts_path = roi_dir / f"{file_id}_rois_cc200.1D"
+        if not ts_path.exists():
+            skipped["missing_roi"] += 1
+            continue
+        specs.append(
+            {
+                "subject_id": subject_id,
+                "file_id": file_id,
+                "site": site,
+                "label": label,
+                "ts_path": str(ts_path),
+            }
+        )
+
+    if args.max_subjects > 0 and len(specs) > args.max_subjects:
+        specs = select_balanced_specs(specs, args.max_subjects)
+
+    subjects: list[dict[str, Any]] = []
+    for spec in specs:
+        ts_path = Path(spec["ts_path"])
+        ts = load_timeseries(ts_path, roi_limit=args.roi_limit)
+        if ts is None:
+            skipped["bad_roi"] += 1
+            continue
+        if ts.shape[0] < args.min_timepoints:
+            skipped["short_time_series"] += 1
+            continue
+        slices = window_slices(ts.shape[0], args.window_tr, args.step_tr)
+        if len(slices) < args.min_windows:
+            skipped["few_windows"] += 1
+            continue
+        fc = window_fc_vectors(ts, slices)
+        if fc.shape[0] != len(slices) or fc.shape[1] <= 0:
+            skipped["bad_fc"] += 1
+            continue
+        subjects.append(
+            {
+                "subject_id": spec["subject_id"],
+                "file_id": spec["file_id"],
+                "site": spec["site"],
+                "label": spec["label"],
+                "n_timepoints": int(ts.shape[0]),
+                "roi_dim": int(ts.shape[1]),
+                "slices": slices,
+                "fc": fc,
+            }
+        )
+
+    source = {
+        "phenotypic_csv": str(pheno_path),
+        "roi_dir": str(roi_dir),
+        "skipped": dict(sorted(skipped.items())),
+    }
+    return subjects, source
+
+
+def select_balanced_specs(specs: list[dict[str, str]], limit: int) -> list[dict[str, str]]:
+    """Deterministically cap subjects without collapsing to one site/label."""
+    by_bucket: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
+    for spec in specs:
+        by_bucket[(spec["site"], spec["label"])].append(spec)
+    buckets = sorted(by_bucket)
+    selected: list[dict[str, str]] = []
+    index = 0
+    while len(selected) < limit:
+        progressed = False
+        for bucket in buckets:
+            rows = by_bucket[bucket]
+            if index < len(rows):
+                selected.append(rows[index])
+                progressed = True
+                if len(selected) >= limit:
+                    break
+        if not progressed:
+            break
+        index += 1
+    return selected
+
+
+def make_folds(subjects: list[dict[str, Any]], args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.split_policy == "leave_one_site_out":
+        return [
+            {
+                "fold_id": f"loso_{site}",
+                "holdout_site": site,
+                "test_subject_ids": {s["subject_id"] for s in subjects if s["site"] == site},
+            }
+            for site in sorted({s["site"] for s in subjects})
+        ]
+
+    rng = np.random.default_rng(args.seed)
+    by_group: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for subject in subjects:
+        by_group[subject["label"]].append(subject)
+    test_ids: set[str] = set()
+    for group_subjects in by_group.values():
+        shuffled = list(group_subjects)
+        rng.shuffle(shuffled)
+        n_test = max(1, int(round(len(shuffled) * args.smoke_test_frac)))
+        if n_test >= len(shuffled) and len(shuffled) > 1:
+            n_test = len(shuffled) - 1
+        test_ids.update(subject["subject_id"] for subject in shuffled[:n_test])
+    return [{"fold_id": "stratified_smoke_0", "holdout_site": "STRATIFIED_SMOKE", "test_subject_ids": test_ids}]
+
+
+def subject_window_rows(subjects: list[dict[str, Any]], fold: dict[str, Any]) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    vectors: list[np.ndarray] = []
+    rows: list[dict[str, Any]] = []
+    test_ids = fold["test_subject_ids"]
+    for subject in subjects:
+        split = "test" if subject["subject_id"] in test_ids else "train"
+        for window_idx, (start, end) in enumerate(subject["slices"]):
+            vectors.append(subject["fc"][window_idx])
+            rows.append(
+                {
+                    "subject_id": subject["subject_id"],
+                    "file_id": subject["file_id"],
+                    "site": subject["site"],
+                    "label": subject["label"],
+                    "split": split,
+                    "window_index": window_idx,
+                    "window_start": start,
+                    "window_end": end,
+                    "n_timepoints": subject["n_timepoints"],
+                    "roi_dim": subject["roi_dim"],
+                    "window_count": len(subject["slices"]),
+                }
+            )
+    return np.vstack(vectors), rows
+
+
+def summarize_fold(rows: list[dict[str, Any]], k: int) -> dict[str, Any]:
+    split_counts = Counter(row["split"] for row in rows)
+    train_state_counts = Counter(row["state"] for row in rows if row["split"] == "train")
+    test_state_counts = Counter(row["state"] for row in rows if row["split"] == "test")
+    test_switch_values = [
+        int(row["switch_event"])
+        for row in rows
+        if row["split"] == "test" and str(row["switch_event"]) in {"0", "1"}
+    ]
+    train_total = sum(train_state_counts.values())
+    min_train_occ = (
+        min(train_state_counts.get(state, 0) / train_total for state in range(k))
+        if train_total
+        else 0.0
+    )
+    return {
+        "split_window_counts": dict(sorted(split_counts.items())),
+        "train_state_counts": dict(sorted(train_state_counts.items())),
+        "test_state_counts": dict(sorted(test_state_counts.items())),
+        "min_train_state_occupancy_frac": min_train_occ,
+        "test_switch_event_count": sum(test_switch_values),
+        "test_switch_event_denominator": len(test_switch_values),
+        "test_switch_event_frac": sum(test_switch_values) / len(test_switch_values)
+        if test_switch_values
+        else 0.0,
+    }
+
+
+def assign_states_for_k(
+    subjects: list[dict[str, Any]],
+    folds: list[dict[str, Any]],
+    k: int,
+    pca_components: int,
+    seed: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    all_rows: list[dict[str, Any]] = []
+    fold_summaries: list[dict[str, Any]] = []
+    for fold_idx, fold in enumerate(folds):
+        x, rows = subject_window_rows(subjects, fold)
+        train_mask = np.array([row["split"] == "train" for row in rows], dtype=bool)
+        if int(train_mask.sum()) < max(k, 3):
+            continue
+        mean, basis, explained = fit_pca(x[train_mask], pca_components)
+        z = project_pca(x, mean, basis)
+        centroids = fit_kmeans(z[train_mask], k=k, seed=seed + 7919 * fold_idx + k)
+        states = assign_kmeans(z, centroids)
+        previous_by_subject: dict[str, int] = {}
+        for row, state in zip(rows, states.tolist(), strict=True):
+            subject_id = row["subject_id"]
+            prev = previous_by_subject.get(subject_id)
+            switch_event: str | int = "" if prev is None else int(state != prev)
+            previous_by_subject[subject_id] = state
+            all_rows.append(
+                {
+                    "fold_id": fold["fold_id"],
+                    "holdout_site": fold["holdout_site"],
+                    "k": k,
+                    "pca_components": int(basis.shape[1]),
+                    "pca_explained_variance": f"{sum(explained):.10f}",
+                    **row,
+                    "state": int(state),
+                    "switch_event": switch_event,
+                }
+            )
+        fold_rows = [row for row in all_rows if row["fold_id"] == fold["fold_id"] and row["k"] == k]
+        fold_summaries.append(
+            {
+                "fold_id": fold["fold_id"],
+                "holdout_site": fold["holdout_site"],
+                "k": k,
+                "train_subject_count": len({row["subject_id"] for row in fold_rows if row["split"] == "train"}),
+                "test_subject_count": len({row["subject_id"] for row in fold_rows if row["split"] == "test"}),
+                "pca_components": int(basis.shape[1]),
+                "pca_explained_variance": sum(explained),
+                **summarize_fold(fold_rows, k),
+            }
+        )
+    return all_rows, fold_summaries
+
+
+def summarize_subjects(window_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in window_rows:
+        if row["split"] == "test":
+            grouped[(row["fold_id"], row["subject_id"], int(row["k"]), row["holdout_site"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (fold_id, subject_id, k, holdout_site), rows in sorted(grouped.items()):
+        rows = sorted(rows, key=lambda row: int(row["window_index"]))
+        switches = [int(row["switch_event"]) for row in rows if str(row["switch_event"]) in {"0", "1"}]
+        state_counts = Counter(int(row["state"]) for row in rows)
+        dwell: list[int] = []
+        current_state = None
+        current_len = 0
+        for row in rows:
+            state = int(row["state"])
+            if current_state is None or state == current_state:
+                current_state = state
+                current_len += 1
+            else:
+                dwell.append(current_len)
+                current_state = state
+                current_len = 1
+        if current_len:
+            dwell.append(current_len)
+        total = len(rows)
+        occupancy = {f"state_{state}_occupancy": state_counts.get(state, 0) / total for state in range(k)}
+        out.append(
+            {
+                "fold_id": fold_id,
+                "holdout_site": holdout_site,
+                "k": k,
+                "subject_id": subject_id,
+                "file_id": rows[0]["file_id"],
+                "site": rows[0]["site"],
+                "label": rows[0]["label"],
+                "window_count": total,
+                "n_timepoints": rows[0]["n_timepoints"],
+                "roi_dim": rows[0]["roi_dim"],
+                "switch_count": sum(switches),
+                "switch_denominator": len(switches),
+                "switching_rate": sum(switches) / len(switches) if switches else 0.0,
+                "zero_switch": int(sum(switches) == 0),
+                "mean_dwell": sum(dwell) / len(dwell) if dwell else 0.0,
+                "max_dwell": max(dwell) if dwell else 0,
+                **occupancy,
+            }
+        )
+    return out
+
+
+def audit_payload(
+    args: argparse.Namespace,
+    subjects: list[dict[str, Any]],
+    source: dict[str, Any],
+    window_rows: list[dict[str, Any]],
+    subject_summary: list[dict[str, Any]],
+    fold_summaries: list[dict[str, Any]],
+    sensitivity: list[dict[str, Any]],
+) -> dict[str, Any]:
+    site_counts = Counter(subject["site"] for subject in subjects)
+    label_counts = Counter(subject["label"] for subject in subjects)
+    windows = [len(subject["slices"]) for subject in subjects]
+    low_window_count = sum(1 for value in windows if value < args.min_windows)
+    primary_subject_rows = [row for row in subject_summary if int(row["k"]) == args.k]
+    switch_rates = [float(row["switching_rate"]) for row in primary_subject_rows]
+    window_counts = [float(row["window_count"]) for row in primary_subject_rows]
+    zero_switch_frac = (
+        sum(int(row["zero_switch"]) for row in primary_subject_rows) / len(primary_subject_rows)
+        if primary_subject_rows
+        else 1.0
+    )
+    switch_values = [
+        int(row["switch_event"])
+        for row in window_rows
+        if int(row["k"]) == args.k and row["split"] == "test" and str(row["switch_event"]) in {"0", "1"}
+    ]
+    switch_frac = sum(switch_values) / len(switch_values) if switch_values else 0.0
+    window_switch_corr = pearson(window_counts, switch_rates)
+    min_train_occ = min(
+        (float(summary["min_train_state_occupancy_frac"]) for summary in fold_summaries if int(summary["k"]) == args.k),
+        default=0.0,
+    )
+    failures: list[str] = []
+    if len(subjects) < args.min_subjects:
+        failures.append("subject_count_below_minimum")
+    if len(site_counts) < args.min_sites:
+        failures.append("site_count_below_minimum")
+    if windows and low_window_count / len(windows) > args.max_low_window_subject_frac:
+        failures.append("low_window_subject_fraction_above_threshold")
+    if min_train_occ < args.min_state_occupancy_frac:
+        failures.append("state_occupancy_below_minimum")
+    if switch_frac < args.min_switch_event_frac:
+        failures.append("switch_event_prevalence_below_minimum")
+    if switch_frac > args.max_switch_event_frac:
+        failures.append("switch_event_prevalence_above_maximum")
+    if zero_switch_frac > args.max_zero_switch_subject_frac:
+        failures.append("zero_switch_subject_fraction_above_threshold")
+    if window_switch_corr is not None and abs(window_switch_corr) > args.max_window_switch_abs_corr:
+        failures.append("switching_rate_window_count_correlation_above_threshold")
+
+    return {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "status": "fail" if failures else "pass",
+        "failures": failures,
+        "source": source,
+        "parameters": {
+            "window_tr": args.window_tr,
+            "step_tr": args.step_tr,
+            "min_timepoints": args.min_timepoints,
+            "min_windows": args.min_windows,
+            "pca_components": args.pca_components,
+            "k": args.k,
+            "sensitivity_k": args.sensitivity_k,
+            "split_policy": args.split_policy,
+            "seed": args.seed,
+            "roi_limit": args.roi_limit,
+        },
+        "thresholds": {
+            "min_subjects": args.min_subjects,
+            "min_sites": args.min_sites,
+            "min_state_occupancy_frac": args.min_state_occupancy_frac,
+            "min_switch_event_frac": args.min_switch_event_frac,
+            "max_switch_event_frac": args.max_switch_event_frac,
+            "max_zero_switch_subject_frac": args.max_zero_switch_subject_frac,
+            "max_low_window_subject_frac": args.max_low_window_subject_frac,
+            "max_window_switch_abs_corr": args.max_window_switch_abs_corr,
+        },
+        "subject_count": len(subjects),
+        "site_count": len(site_counts),
+        "site_counts": dict(sorted(site_counts.items())),
+        "label_counts": dict(sorted(label_counts.items())),
+        "window_count_min": min(windows) if windows else 0,
+        "window_count_max": max(windows) if windows else 0,
+        "window_count_mean": sum(windows) / len(windows) if windows else 0.0,
+        "low_window_subject_count": low_window_count,
+        "primary_k": args.k,
+        "primary_test_switch_event_frac": switch_frac,
+        "primary_test_switch_event_count": sum(switch_values),
+        "primary_test_switch_event_denominator": len(switch_values),
+        "primary_zero_switch_subject_frac": zero_switch_frac,
+        "primary_min_train_state_occupancy_frac": min_train_occ,
+        "primary_switching_rate_window_count_corr": window_switch_corr,
+        "fold_summaries": fold_summaries,
+        "sensitivity": sensitivity,
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def write_markdown(path: Path, audit: dict[str, Any]) -> None:
+    lines = [
+        "# ABIDE Dynamic-FC Switching Target Audit",
+        "",
+        f"Schema: `{audit['schema']}`",
+        "",
+        f"Status: `{audit['status']}`",
+        "",
+        f"Claim boundary: {audit['claim_boundary']}",
+        "",
+        "## Summary",
+        "",
+        f"- Subjects: {audit['subject_count']}",
+        f"- Sites: {audit['site_count']}",
+        f"- Primary k: {audit['primary_k']}",
+        f"- Test switch-event fraction: {audit['primary_test_switch_event_frac']:.6f}",
+        f"- Zero-switch subject fraction: {audit['primary_zero_switch_subject_frac']:.6f}",
+        f"- Min train state occupancy fraction: {audit['primary_min_train_state_occupancy_frac']:.6f}",
+        f"- Switching-rate/window-count correlation: {audit['primary_switching_rate_window_count_corr']}",
+        "",
+        "## Failures",
+        "",
+    ]
+    if audit["failures"]:
+        lines.extend(f"- `{failure}`" for failure in audit["failures"])
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Site Counts", ""])
+    for site, count in audit["site_counts"].items():
+        lines.append(f"- `{site}`: {count}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    subjects, source = build_subjects(args)
+    if not subjects:
+        raise SystemExit("no usable subjects for dynamic-FC switching target")
+    folds = make_folds(subjects, args)
+    sensitivity_ks = [int(value) for value in args.sensitivity_k.split(",") if value.strip()]
+    all_ks = [args.k] + [value for value in sensitivity_ks if value != args.k]
+
+    rows_by_k: dict[int, list[dict[str, Any]]] = {}
+    fold_summaries_all: list[dict[str, Any]] = []
+    sensitivity: list[dict[str, Any]] = []
+    for k in all_ks:
+        rows, fold_summaries = assign_states_for_k(subjects, folds, k, args.pca_components, args.seed)
+        rows_by_k[k] = rows
+        fold_summaries_all.extend(fold_summaries)
+        switch_values = [
+            int(row["switch_event"])
+            for row in rows
+            if row["split"] == "test" and str(row["switch_event"]) in {"0", "1"}
+        ]
+        min_occ = min((float(item["min_train_state_occupancy_frac"]) for item in fold_summaries), default=0.0)
+        sensitivity.append(
+            {
+                "k": k,
+                "fold_count": len(fold_summaries),
+                "test_switch_event_frac": sum(switch_values) / len(switch_values) if switch_values else 0.0,
+                "test_switch_event_denominator": len(switch_values),
+                "min_train_state_occupancy_frac": min_occ,
+            }
+        )
+
+    primary_rows = rows_by_k[args.k]
+    subject_summary = summarize_subjects(primary_rows)
+    audit = audit_payload(args, subjects, source, primary_rows, subject_summary, fold_summaries_all, sensitivity)
+
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    window_fields = [
+        "fold_id",
+        "holdout_site",
+        "k",
+        "subject_id",
+        "file_id",
+        "site",
+        "label",
+        "split",
+        "window_index",
+        "window_start",
+        "window_end",
+        "state",
+        "switch_event",
+        "window_count",
+        "n_timepoints",
+        "roi_dim",
+        "pca_components",
+        "pca_explained_variance",
+    ]
+    summary_fields = [
+        "fold_id",
+        "holdout_site",
+        "k",
+        "subject_id",
+        "file_id",
+        "site",
+        "label",
+        "window_count",
+        "n_timepoints",
+        "roi_dim",
+        "switch_count",
+        "switch_denominator",
+        "switching_rate",
+        "zero_switch",
+        "mean_dwell",
+        "max_dwell",
+    ] + [f"state_{state}_occupancy" for state in range(args.k)]
+    write_tsv(out / "dynamic_fc_window_table.tsv", primary_rows, window_fields)
+    write_tsv(out / "dynamic_fc_subject_summary.tsv", subject_summary, summary_fields)
+    with (out / "dynamic_fc_target_audit.json").open("w", encoding="utf-8") as handle:
+        json.dump(audit, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    write_markdown(out / "dynamic_fc_target_audit.md", audit)
+
+    print(json.dumps({"status": audit["status"], "failures": audit["failures"], "output_dir": str(out)}, sort_keys=True))
+    if audit["failures"]:
+        raise SystemExit("ABIDE dynamic-FC target audit failed: " + ",".join(audit["failures"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/abide_manifest_quality_gate.py
+++ b/scripts/research/abide_manifest_quality_gate.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Fail fast when a Brain O-SSM ABIDE manifest has no usable feature signal."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from abide_campaign_lib import load_manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--min-nonzero-frac", type=float, default=0.01)
+    parser.add_argument("--min-variance", type=float, default=1.0e-10)
+    parser.add_argument("--min-class-count", type=int, default=1)
+    args = parser.parse_args()
+
+    meta, records = load_manifest(args.manifest)
+    values: list[float] = []
+    label_counts = {0: 0, 1: 0}
+    site_counts: dict[str, int] = {}
+    for record in records:
+        label_counts[record.label] = label_counts.get(record.label, 0) + 1
+        site_counts[record.site] = site_counts.get(record.site, 0) + 1
+        for step in record.sequence:
+            values.extend(step)
+
+    total = len(values)
+    finite_values = [value for value in values if math.isfinite(value)]
+    finite_count = len(finite_values)
+    nonzero_count = sum(1 for value in finite_values if abs(value) > 1.0e-12)
+    nonzero_frac = nonzero_count / finite_count if finite_count else 0.0
+    mean = sum(finite_values) / finite_count if finite_count else 0.0
+    variance = (
+        sum((value - mean) * (value - mean) for value in finite_values) / finite_count
+        if finite_count
+        else 0.0
+    )
+
+    result = {
+        "schema": "brain_ossm.abide_manifest_quality_gate.v1",
+        "manifest": str(Path(args.manifest).resolve()),
+        "subject_count": len(records),
+        "site_count": len(site_counts),
+        "seq_len": meta.seq_len,
+        "input_dim": meta.input_dim,
+        "feature_value_count": total,
+        "finite_feature_value_count": finite_count,
+        "nonzero_feature_value_count": nonzero_count,
+        "nonzero_feature_frac": nonzero_frac,
+        "feature_mean": mean,
+        "feature_variance": variance,
+        "label_counts": label_counts,
+        "thresholds": {
+            "min_nonzero_frac": args.min_nonzero_frac,
+            "min_variance": args.min_variance,
+            "min_class_count": args.min_class_count,
+        },
+    }
+
+    failures: list[str] = []
+    if not records:
+        failures.append("no_subjects")
+    if finite_count != total:
+        failures.append("non_finite_features")
+    if nonzero_frac < args.min_nonzero_frac:
+        failures.append("low_nonzero_fraction")
+    if variance < args.min_variance:
+        failures.append("low_feature_variance")
+    if label_counts.get(0, 0) < args.min_class_count or label_counts.get(1, 0) < args.min_class_count:
+        failures.append("class_count_below_minimum")
+
+    result["status"] = "fail" if failures else "pass"
+    result["failures"] = failures
+    print(json.dumps(result, sort_keys=True))
+    if failures:
+        raise SystemExit("ABIDE manifest quality gate failed: " + ",".join(failures))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/abide_trained_roi_associator.py
+++ b/scripts/research/abide_trained_roi_associator.py
@@ -1,0 +1,927 @@
+#!/usr/bin/env python3
+"""Extract ROI-level associator features from a verified trained Brain O-SSM checkpoint."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from abide_campaign_lib import load_manifest, write_json, write_tsv
+from abide_checkpoint_persist import (
+    CheckpointForward,
+    F64_STATE_ARRAYS,
+    I64_STATE_ARRAYS,
+    balanced_accuracy,
+    chunked_f64_loader,
+    chunked_i64_loader,
+    int_meta,
+    materialize_single_site_internal_cv_keys,
+    merge_tab_continuation_records,
+    rebuild_standardization_from_manifest,
+    site_hash,
+    single_site_internal_cv_enabled,
+    sio_string_literal,
+    write_native_state_sequence,
+)
+
+
+METRIC_LABELS = {
+    "assoc_delta_abs": "trained_assoc_occlusion_delta_abs",
+    "prob_delta_abs": "trained_prob_occlusion_delta_abs",
+    "logit_delta_abs": "trained_logit_occlusion_delta_abs",
+    "hidden_delta_abs": "trained_hidden_occlusion_delta_abs",
+}
+
+
+def manifest_label_names(manifest_extra: dict[str, str]) -> tuple[str, str]:
+    label_space = manifest_extra.get("label_space", "").lower()
+    if "adhd" in label_space:
+        default_positive = "ADHD"
+    elif "mdd" in label_space or "depress" in label_space:
+        default_positive = "MDD"
+    elif "asd" in label_space or "autism" in label_space:
+        default_positive = "ASD"
+    else:
+        default_positive = "CASE"
+    positive = (
+        manifest_extra.get("label_positive_name")
+        or manifest_extra.get("positive_label_name")
+        or manifest_extra.get("case_label_name")
+        or default_positive
+    )
+    negative = (
+        manifest_extra.get("label_negative_name")
+        or manifest_extra.get("negative_label_name")
+        or manifest_extra.get("control_label_name")
+        or "CONTROL"
+    )
+    return positive, negative
+
+
+def label_name_for(label: int, positive_name: str, negative_name: str) -> str:
+    return positive_name if label == 1 else negative_name
+
+
+def _norm_cdf_complement(z: float) -> float:
+    return 0.5 * math.erfc(z / math.sqrt(2.0))
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return ordered[mid]
+    return 0.5 * (ordered[mid - 1] + ordered[mid])
+
+
+def mann_whitney_cliff(asd: list[float], control: list[float]) -> dict[str, float]:
+    n1 = len(asd)
+    n2 = len(control)
+    if n1 == 0 or n2 == 0:
+        return {"u": 0.0, "p": 1.0, "z": 0.0, "cliff_delta": 0.0}
+
+    merged = [(value, 0) for value in asd] + [(value, 1) for value in control]
+    merged.sort(key=lambda item: item[0])
+    ranks = [0.0] * len(merged)
+    tie_terms = 0.0
+    i = 0
+    while i < len(merged):
+        j = i + 1
+        while j < len(merged) and merged[j][0] == merged[i][0]:
+            j += 1
+        avg_rank = 0.5 * ((i + 1) + j)
+        for idx in range(i, j):
+            ranks[idx] = avg_rank
+        tie = j - i
+        if tie > 1:
+            tie_terms += float(tie * tie * tie - tie)
+        i = j
+
+    rank_asd = sum(rank for rank, (_, group) in zip(ranks, merged, strict=True) if group == 0)
+    u1 = rank_asd - (n1 * (n1 + 1) / 2.0)
+    mean_u = n1 * n2 / 2.0
+    n = n1 + n2
+    if n > 1:
+        variance = n1 * n2 / 12.0 * ((n + 1.0) - tie_terms / (n * (n - 1.0)))
+    else:
+        variance = 0.0
+    if variance <= 0.0:
+        z = 0.0
+        p = 1.0
+    else:
+        z = (u1 - mean_u) / math.sqrt(variance)
+        p = min(1.0, max(0.0, 2.0 * _norm_cdf_complement(abs(z))))
+
+    greater = less = 0
+    for x in asd:
+        for y in control:
+            if x > y:
+                greater += 1
+            elif x < y:
+                less += 1
+    cliff = (greater - less) / float(n1 * n2)
+    return {"u": u1, "p": p, "z": z, "cliff_delta": cliff}
+
+
+def holm_adjust(p_values: list[float]) -> list[float]:
+    order = sorted(range(len(p_values)), key=lambda idx: p_values[idx])
+    adjusted = [1.0] * len(p_values)
+    running = 0.0
+    m = len(p_values)
+    for rank, idx in enumerate(order):
+        candidate = min(1.0, p_values[idx] * (m - rank))
+        running = max(running, candidate)
+        adjusted[idx] = running
+    return adjusted
+
+
+def require_verified_checkpoint(ckpt: dict[str, Any], min_balanced_accuracy: float) -> None:
+    verification = ckpt.get("verification")
+    if not isinstance(verification, dict):
+        raise SystemExit("checkpoint has no verification block; refusing model-free associator extraction")
+    if verification.get("status") != "pass":
+        raise SystemExit(f"checkpoint verification status is not pass: {verification.get('status')!r}")
+    actual = float(verification.get("actual_balanced_accuracy_pct", 0.0))
+    delta = float(verification.get("delta_pp", 999.0))
+    if actual <= min_balanced_accuracy:
+        raise SystemExit(
+            f"checkpoint verification balanced accuracy {actual:.6f}% <= required {min_balanced_accuracy:.6f}%"
+        )
+    if delta > float(verification.get("tolerance_pp", 0.5)):
+        raise SystemExit(f"checkpoint verification delta {delta:.6f}pp exceeds tolerance")
+    a_values = [float(value) for value in ckpt.get("arrays", {}).get("A", {}).get("values", [])]
+    if not a_values or not any(abs(value) > 1.0e-12 for value in a_values):
+        raise SystemExit("checkpoint A tensor is empty/all-zero; refusing associator extraction without octonionic state")
+
+
+def generate_native_extractor_source(
+    ckpt: dict[str, Any],
+    manifest_path: Path,
+    repo_root: Path,
+    scope: str,
+    state_path: Path,
+    state_offsets: list[tuple[str, str, int, int]],
+    use_single_site_internal_cv: bool,
+) -> str:
+    source_path = repo_root / "examples" / "brain_ossm_abide.sio"
+    source = source_path.read_text(encoding="utf-8")
+    marker = "fn main() -> i32"
+    if marker not in source:
+        raise RuntimeError(f"cannot locate main marker in {source_path}")
+    prefix = source.split(marker, 1)[0]
+    meta = ckpt["meta"]
+    # Do not add new Sounio globals here. A prior dedicated ROI hidden buffer
+    # changed the native ABIDE forward result for Mandelbrot checkpoints by
+    # perturbing global layout. Reuse A_MOM as a temporary hidden-state buffer
+    # instead; A_MOM is loaded for checkpoint completeness but is not read by
+    # forward_subject.
+    parts = [prefix]
+    config_keys = [
+        ("CFG_TRAIN_FRACTION_BP", "cfg_train_fraction_bp"),
+        ("CFG_DROP_CHANNEL_FRAC_BP", "cfg_drop_channel_frac_bp"),
+        ("CFG_NOISE_STD_BP", "cfg_noise_std_bp"),
+        ("CFG_GLOBAL_TRAIN_EPOCHS", "cfg_global_train_epochs"),
+        ("CFG_GLOBAL_TRAIN_LR_BP", "cfg_global_train_lr_bp"),
+        ("CFG_GLOBAL_CORE_LR_SCALE_BP", "cfg_global_core_lr_scale_bp"),
+        ("CFG_OCT_PROFILE_ID", "cfg_oct_profile_id"),
+        ("CFG_OCT_TRAIN_MODE", "cfg_oct_train_mode"),
+        ("CFG_OCT_INIT_PRESET", "cfg_oct_init_preset"),
+        ("CFG_OCT_ASSOC_REG_BP", "cfg_oct_assoc_reg_bp"),
+        ("CFG_OCT_ASSOC_TARGET_BP", "cfg_oct_assoc_target_bp"),
+        ("CFG_OCT_ASSOCIATOR_SIGN_AUX_BP", "cfg_oct_associator_sign_aux_bp"),
+        ("CFG_OCT_TRAIN_NOISE_STD_BP", "cfg_oct_train_noise_std_bp"),
+        ("CFG_OCT_RELATION_PRESERVE_AUX_BP", "cfg_oct_relation_preserve_aux_bp"),
+        ("CFG_OCT_RELATION_TARGET_AUX_BP", "cfg_oct_relation_target_aux_bp"),
+        ("CFG_OCT_RELATION_MARGIN_AUX_BP", "cfg_oct_relation_margin_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_AUX_BP", "cfg_oct_relation_identity_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_SRC_AUX_BP", "cfg_oct_relation_identity_src_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_DST_AUX_BP", "cfg_oct_relation_identity_dst_aux_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_START_EPOCH", "cfg_oct_relation_identity_start_epoch"),
+        ("CFG_OCT_RELATION_IDENTITY_RAMP_EPOCHS", "cfg_oct_relation_identity_ramp_epochs"),
+        ("CFG_OCT_RELATION_IDENTITY_TIE_MARGIN_BP", "cfg_oct_relation_identity_tie_margin_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_GATE_MARGIN_BP", "cfg_oct_relation_identity_gate_margin_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_GATE_FLOOR_BP", "cfg_oct_relation_identity_gate_floor_bp"),
+        ("CFG_OCT_RELATION_IDENTITY_TASK_GUARD", "cfg_oct_relation_identity_task_guard"),
+        ("CFG_OCT_RELATION_IDENTITY_TASK_GUARD_TOL_BP", "cfg_oct_relation_identity_task_guard_tol_bp"),
+        ("CFG_OCT_RELATION_READOUT_CORRECT_STEPS", "cfg_oct_relation_readout_correct_steps"),
+        ("CFG_OCT_RELATION_READOUT_CORRECT_LR_SCALE_BP", "cfg_oct_relation_readout_correct_lr_scale_bp"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_CORRECT_STEPS", "cfg_oct_associator_readout_correct_steps"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_CORRECT_LR_SCALE_BP", "cfg_oct_associator_readout_correct_lr_scale_bp"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_ALIGN_EPOCHS", "cfg_oct_associator_readout_align_epochs"),
+        ("CFG_OCT_ASSOCIATOR_READOUT_ALIGN_LR_SCALE_BP", "cfg_oct_associator_readout_align_lr_scale_bp"),
+        ("CFG_OCT_RELATION_MARGIN_GATE_CAP_BP", "cfg_oct_relation_margin_gate_cap_bp"),
+        ("CFG_OCT_RELATION_MARGIN_START_EPOCH", "cfg_oct_relation_margin_start_epoch"),
+        ("CFG_OCT_RELATION_MARGIN_RAMP_EPOCHS", "cfg_oct_relation_margin_ramp_epochs"),
+        ("CFG_OCT_RELATION_FREEZE_AFTER_EPOCH", "cfg_oct_relation_freeze_after_epoch"),
+        ("CFG_OCT_RELATION_POST_FREEZE_SCALE_BP", "cfg_oct_relation_post_freeze_scale_bp"),
+        ("CFG_OCT_BINARY_LR_SCALE_AFTER_EPOCH", "cfg_oct_binary_lr_scale_after_epoch"),
+        ("CFG_OCT_BINARY_LR_POST_SCALE_BP", "cfg_oct_binary_lr_post_scale_bp"),
+        ("CFG_OCT_RELATION_TASK_GUARD", "cfg_oct_relation_task_guard"),
+        ("CFG_OCT_RELATION_TASK_GUARD_TOL_BP", "cfg_oct_relation_task_guard_tol_bp"),
+        ("CFG_OCT_RELATION_TARGET_SRC_POS", "cfg_oct_relation_target_src_pos"),
+        ("CFG_OCT_RELATION_TARGET_DST_POS", "cfg_oct_relation_target_dst_pos"),
+        ("CFG_OCT_INPUT_PROJ_MODE", "cfg_oct_input_proj_mode"),
+        ("CFG_OCT_PROJ_LR_SCALE_BP", "cfg_oct_proj_lr_scale_bp"),
+        ("CFG_OCT_PROJ_STRUCTURED_SCALE_BP", "cfg_oct_proj_structured_scale_bp"),
+        ("CFG_OCT_PROJ_DELTA_SCALE_BP", "cfg_oct_proj_delta_scale_bp"),
+        ("CFG_OCT_PROJ_HYBRID_SCALE_BP", "cfg_oct_proj_hybrid_scale_bp"),
+    ]
+    config_lines = ["fn load_ckpt_config() with Mut {"]
+    for var_name, meta_key in config_keys:
+        if meta_key in meta:
+            config_lines.append(f"    {var_name} = {int(float(meta[meta_key]))}")
+    config_lines.append("}")
+    parts.append("\n".join(config_lines))
+    manifest_literal = sio_string_literal(str(manifest_path.resolve()))
+    state_literal = sio_string_literal(state_path.name)
+    holdout_key = int_meta(meta, "holdout_key")
+    seed_a = int_meta(meta, "seed_a")
+    seed_b = int_meta(meta, "seed_b")
+    fold_noise_key = int_meta(meta, "fold_noise_key")
+    require_holdout_scope = "1" if scope == "holdout" else "0"
+    internal_cv_block = (
+        "    materialize_single_site_internal_cv_folds()\n"
+        if use_single_site_internal_cv
+        else ""
+    )
+    arrays = ckpt["arrays"]
+    for name in I64_STATE_ARRAYS:
+        parts.append(chunked_i64_loader(name, arrays[name]["values"]))
+    parts.append(chunked_f64_loader("A", arrays["A"]["values"]))
+    parts.append(
+        f"""
+fn load_ckpt_state() with Mut {{
+    load_w()
+    load_mom()
+    load_a()
+    load_a_mom()
+    load_proj_w()
+    load_proj_b()
+    load_proj_w_mom()
+    load_proj_b_mom()
+    load_drop_mask()
+}}
+
+fn roi_verify_holdout(holdout_key: i64) -> f64 with IO, Mut, Div, Panic {{
+    var tp: i64 = 0
+    var tn: i64 = 0
+    var fp: i64 = 0
+    var fnn: i64 = 0
+    var test_n: i64 = 0
+    var pos_n: i64 = 0
+    var neg_n: i64 = 0
+    var subj: i64 = 0
+    while subj < SUBJECT_COUNT {{
+        if SITE_KEYS[subj as usize] == holdout_key {{
+            forward_subject(subj, 1)
+            let prob = sigmoid_q(LOGIT)
+            let pred = if prob >= 0.5 {{ 1 }} else {{ 0 }}
+            let label = LABELS[subj as usize]
+            if pred == 1 && label == 1 {{ tp = tp + 1 }}
+            if pred == 0 && label == 0 {{ tn = tn + 1 }}
+            if pred == 1 && label == 0 {{ fp = fp + 1 }}
+            if pred == 0 && label == 1 {{ fnn = fnn + 1 }}
+            if label == 1 {{ pos_n = pos_n + 1 }} else {{ neg_n = neg_n + 1 }}
+            test_n = test_n + 1
+        }}
+        subj = subj + 1
+    }}
+    if pos_n == 0 || neg_n == 0 || test_n == 0 {{ return 0.0 }}
+    var tpr = 0.0
+    if tp + fnn > 0 {{ tpr = (tp as f64) / ((tp + fnn) as f64) }}
+    var tnr = 0.0
+    if tn + fp > 0 {{ tnr = (tn as f64) / ((tn + fp) as f64) }}
+    let bal = 50.0 * (tpr + tnr)
+    print("ROI_VERIFY_COUNTS\\t")
+    print_int(tp); print("\\t"); print_int(tn); print("\\t"); print_int(fp); print("\\t"); print_int(fnn); print("\\t"); print_int(test_n); print("\\n")
+    print("ROI_VERIFY_BAL\\t"); print_fixed6_from_micros((bal * 1000000.0) as i64); print("\\n")
+    bal
+}}
+
+fn emit_roi_features(scope_holdout_only: i64, holdout_key: i64) with IO, Mut, Div, Panic {{
+    var subj: i64 = 0
+    while subj < SUBJECT_COUNT {{
+        if scope_holdout_only == 0 || SITE_KEYS[subj as usize] == holdout_key {{
+            forward_subject(subj, 1)
+            var base_logit = LOGIT
+            if base_logit != base_logit {{ base_logit = 0.0 }}
+            if base_logit > 12.0 {{ base_logit = 12.0 }}
+            if base_logit < 0.0 - 12.0 {{ base_logit = 0.0 - 12.0 }}
+            let base_prob = sigmoid_q(LOGIT)
+            let base_assoc = assoc_mean_all()
+            var hd: i64 = 0
+            while hd < hidden_dim() {{
+                A_MOM[hd as usize] = H[hd as usize]
+                hd = hd + 1
+            }}
+            var roi: i64 = 0
+            while roi < MANIFEST_FEATURE_COUNT {{
+                let offset = subj * feature_cap() + roi
+                let old_value = FEATURES[offset as usize]
+                FEATURES[offset as usize] = TRAIN_FEATURE_MEAN[roi as usize]
+                forward_subject(subj, 1)
+                var masked_logit = LOGIT
+                if masked_logit != masked_logit {{ masked_logit = 0.0 }}
+                if masked_logit > 12.0 {{ masked_logit = 12.0 }}
+                if masked_logit < 0.0 - 12.0 {{ masked_logit = 0.0 - 12.0 }}
+                let masked_prob = sigmoid_q(LOGIT)
+                let masked_assoc = assoc_mean_all()
+                FEATURES[offset as usize] = old_value
+                let assoc_delta = base_assoc - masked_assoc
+                let prob_delta = base_prob - masked_prob
+                let logit_delta = base_logit - masked_logit
+                var hidden_sq = 0.0
+                hd = 0
+                while hd < hidden_dim() {{
+                    let base_h = (A_MOM[hd as usize] as f64) / 100000000.0
+                    let masked_h = hg(hd)
+                    let diff_h = base_h - masked_h
+                    hidden_sq = hidden_sq + diff_h * diff_h
+                    hd = hd + 1
+                }}
+                let hidden_delta = sqrt_q(hidden_sq)
+                var assoc_abs = assoc_delta
+                if assoc_abs < 0.0 {{ assoc_abs = 0.0 - assoc_abs }}
+                var prob_abs = prob_delta
+                if prob_abs < 0.0 {{ prob_abs = 0.0 - prob_abs }}
+                var logit_abs = logit_delta
+                if logit_abs < 0.0 {{ logit_abs = 0.0 - logit_abs }}
+                print("ROI_FEATURE\\t")
+                print_int(subj); print("\\t")
+                print_int(LABELS[subj as usize]); print("\\t")
+                print(site_name_dynamic_for_key(SITE_KEYS[subj as usize])); print("\\t")
+                print_int(roi); print("\\t")
+                print_int((base_prob * 1000000.0) as i64); print("\\t")
+                print_int((masked_prob * 1000000.0) as i64); print("\\t")
+                print_int((base_assoc * 1000000.0) as i64); print("\\t")
+                print_int((masked_assoc * 1000000.0) as i64); print("\\t")
+                print_int((assoc_delta * 1000000.0) as i64); print("\\t")
+                print_int((assoc_abs * 1000000.0) as i64); print("\\t")
+                print_int((prob_delta * 1000000.0) as i64); print("\\t")
+                print_int((prob_abs * 1000000.0) as i64); print("\\t")
+                print_int((base_logit * 1000000.0) as i64); print("\\t")
+                print_int((masked_logit * 1000000.0) as i64); print("\\t")
+                print_int((logit_delta * 1000000.0) as i64); print("\\t")
+                print_int((logit_abs * 1000000.0) as i64); print("\\t")
+                print_int((hidden_delta * 1000000.0) as i64); print("\\n")
+                roi = roi + 1
+            }}
+        }}
+        subj = subj + 1
+    }}
+}}
+
+fn main() -> i32 with IO, Mut, Div, Panic {{
+    reset_run_config_defaults()
+    load_ckpt_config()
+    let loaded = load_manifest({manifest_literal})
+    if loaded == 0 {{ print("ROI_FAIL\\tmanifest\\n"); return 2 }}
+    discover_sites()
+{internal_cv_block}    let holdout_key: i64 = {holdout_key}
+    let seed_a: i64 = {seed_a}
+    let seed_b: i64 = {seed_b}
+    build_train_mask(holdout_key, seed_a, seed_b)
+    prepare_train_standardization()
+    FOLD_NOISE_KEY = {fold_noise_key}
+    load_ckpt_state()
+    let bal = roi_verify_holdout(holdout_key)
+    if bal <= 51.0 {{ print("ROI_FAIL\\tcheckpoint_balanced_accuracy\\n"); return 3 }}
+    emit_roi_features({require_holdout_scope}, holdout_key)
+    return 0
+}}
+"""
+    )
+    return "\n".join(parts)
+
+
+def run_native_extractor(
+    ckpt: dict[str, Any],
+    checkpoint_path: Path,
+    manifest_path: Path,
+    output_dir: Path,
+    scope: str,
+    repo_root: Path | None = None,
+    native_souc_engine: str = "",
+) -> tuple[Path, Path, Path]:
+    repo_root = (repo_root or Path(__file__).resolve().parents[2]).resolve()
+    native_dir = output_dir / ".native"
+    native_dir.mkdir(parents=True, exist_ok=True)
+    source_path = native_dir / "extract_trained_roi_associator.sio"
+    binary_path = native_dir / "extract_trained_roi_associator.elf"
+    stdout_path = native_dir / "extract_trained_roi_associator.out"
+    state_path = native_dir / "model.state.seq"
+    state_offsets = write_native_state_sequence(ckpt, state_path)
+    _, records = load_manifest(manifest_path)
+    use_single_site_internal_cv = single_site_internal_cv_enabled(None, records, int_meta(ckpt["meta"], "holdout_key"))
+    source_path.write_text(
+        generate_native_extractor_source(
+            ckpt,
+            manifest_path,
+            repo_root,
+            scope,
+            state_path,
+            state_offsets,
+            use_single_site_internal_cv,
+        ),
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    env.setdefault("SOUNIO_STDLIB_PATH", str(repo_root / "stdlib"))
+    if native_souc_engine:
+        env["SOUNIO_SOUC_ENGINE"] = native_souc_engine
+    compiler = repo_root / "bin" / "souc"
+    compile_proc = subprocess.run(
+        [str(compiler), "compile", str(source_path), "-o", str(binary_path)],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=300,
+    )
+    compile_output = compile_proc.stdout + compile_proc.stderr
+    if compile_proc.returncode != 0 or (
+        "exceeds IR_MAX_INSTRS" in compile_output and not binary_path.is_file()
+    ):
+        raise RuntimeError(
+            "trained ROI associator native compile failed\n"
+            f"checkpoint={checkpoint_path}\n"
+            f"returncode={compile_proc.returncode}\n{compile_output}"
+        )
+    binary_path.chmod(0o755)
+
+    run_proc = subprocess.run(
+        [str(binary_path)],
+        cwd=native_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=600,
+    )
+    stdout_path.write_text(run_proc.stdout + run_proc.stderr, encoding="utf-8", errors="replace")
+    if run_proc.returncode != 0:
+        raise RuntimeError(
+            "trained ROI associator native run failed\n"
+            f"returncode={run_proc.returncode}\n"
+            f"stdout_path={stdout_path}\n"
+            f"{(run_proc.stdout + run_proc.stderr)[-4000:]}"
+        )
+    return source_path, binary_path, stdout_path
+
+
+def parse_native_rows(stdout_path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    verification: dict[str, Any] = {}
+    rows: list[dict[str, Any]] = []
+    lines = merge_tab_continuation_records(
+        stdout_path.read_text(encoding="utf-8", errors="replace").splitlines(),
+        ("ROI_VERIFY_COUNTS", "ROI_FEATURE"),
+    )
+    for line in lines:
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0] == "ROI_VERIFY_BAL":
+            verification["actual_balanced_accuracy_pct"] = float(parts[1])
+        elif len(parts) >= 6 and parts[0] == "ROI_VERIFY_COUNTS":
+            verification["counts"] = {
+                "tp": int(parts[1]),
+                "tn": int(parts[2]),
+                "fp": int(parts[3]),
+                "fn": int(parts[4]),
+                "test_n": int(parts[5]),
+            }
+        elif len(parts) >= 13 and parts[0] == "ROI_FEATURE":
+            extra = parts + ["0"] * max(0, 18 - len(parts))
+            rows.append(
+                {
+                    "subject_index": int(parts[1]),
+                    "label": int(parts[2]),
+                    "site": parts[3],
+                    "roi_index": int(parts[4]),
+                    "base_prob": int(parts[5]) / 1_000_000.0,
+                    "masked_prob": int(parts[6]) / 1_000_000.0,
+                    "base_assoc": int(parts[7]) / 1_000_000.0,
+                    "masked_assoc": int(parts[8]) / 1_000_000.0,
+                    "assoc_delta_signed": int(parts[9]) / 1_000_000.0,
+                    "assoc_delta_abs": int(parts[10]) / 1_000_000.0,
+                    "prob_delta_signed": int(parts[11]) / 1_000_000.0,
+                    "prob_delta_abs": int(parts[12]) / 1_000_000.0,
+                    "base_logit": int(extra[13]) / 1_000_000.0,
+                    "masked_logit": int(extra[14]) / 1_000_000.0,
+                    "logit_delta_signed": int(extra[15]) / 1_000_000.0,
+                    "logit_delta_abs": int(extra[16]) / 1_000_000.0,
+                    "hidden_delta_abs": int(extra[17]) / 1_000_000.0,
+                }
+            )
+    if "actual_balanced_accuracy_pct" not in verification:
+        raise RuntimeError(f"native extractor did not emit ROI_VERIFY_BAL: {stdout_path}")
+    if not rows:
+        raise RuntimeError(f"native extractor emitted no ROI_FEATURE rows: {stdout_path}")
+    return verification, rows
+
+
+def prob_to_logit(prob: float) -> float:
+    prob = min(1.0 - 1.0e-12, max(1.0e-12, prob))
+    return math.log(prob / (1.0 - prob))
+
+
+def mutable_sequence(sequence: list[list[float]], feature_count: int) -> list[list[float]]:
+    out = [list(step) for step in sequence]
+    while len(out) * 8 < feature_count:
+        out.append([0.0] * 8)
+    return out
+
+
+def run_python_extractor(
+    ckpt: dict[str, Any],
+    records: list[Any],
+    scope: str,
+) -> tuple[dict[str, Any], tuple[Path, Path, Path], list[dict[str, Any]]]:
+    model = CheckpointForward(ckpt)
+    holdout_key = int_meta(ckpt["meta"], "holdout_key")
+    feature_count = int_meta(ckpt["meta"], "manifest_feature_count")
+    use_single_site_internal_cv = single_site_internal_cv_enabled(None, records, holdout_key)
+    site_keys = (
+        materialize_single_site_internal_cv_keys(records)
+        if use_single_site_internal_cv
+        else [site_hash(record.site) for record in records]
+    )
+    labels: list[int] = []
+    probs: list[float] = []
+    tp = tn = fp = fnn = 0
+
+    for subj_idx, record in enumerate(records):
+        if site_keys[subj_idx] != holdout_key:
+            continue
+        prob, _assoc = model.forward(subj_idx, record.sequence)
+        pred = 1 if prob >= 0.5 else 0
+        label = int(record.label)
+        labels.append(label)
+        probs.append(prob)
+        if pred == 1 and label == 1:
+            tp += 1
+        elif pred == 0 and label == 0:
+            tn += 1
+        elif pred == 1 and label == 0:
+            fp += 1
+        elif pred == 0 and label == 1:
+            fnn += 1
+
+    verification = {
+        "actual_balanced_accuracy_pct": balanced_accuracy(labels, probs),
+        "counts": {"tp": tp, "tn": tn, "fp": fp, "fn": fnn, "test_n": len(labels)},
+        "executor": "python_checkpoint_forward_roi_occlusion",
+        "single_site_internal_cv": use_single_site_internal_cv,
+    }
+    rows: list[dict[str, Any]] = []
+    for subj_idx, record in enumerate(records):
+        if scope == "holdout" and site_keys[subj_idx] != holdout_key:
+            continue
+        base_prob, base_assoc = model.forward(subj_idx, record.sequence)
+        base_h = [model.hg(dim) for dim in range(16)]
+        base_logit = prob_to_logit(base_prob)
+        for roi in range(feature_count):
+            masked = mutable_sequence(record.sequence, feature_count)
+            masked[roi // 8][roi % 8] = float(model.mean[roi])
+            masked_prob, masked_assoc = model.forward(subj_idx, masked)
+            masked_h = [model.hg(dim) for dim in range(16)]
+            masked_logit = prob_to_logit(masked_prob)
+            assoc_delta = base_assoc - masked_assoc
+            prob_delta = base_prob - masked_prob
+            logit_delta = base_logit - masked_logit
+            hidden_delta = math.sqrt(sum((base_h[idx] - masked_h[idx]) ** 2 for idx in range(16)))
+            rows.append(
+                {
+                    "subject_index": subj_idx,
+                    "label": int(record.label),
+                    "site": f"SITE_{1 if site_keys[subj_idx] == 177622 else 2}" if use_single_site_internal_cv else record.site,
+                    "roi_index": roi,
+                    "base_prob": base_prob,
+                    "masked_prob": masked_prob,
+                    "base_assoc": base_assoc,
+                    "masked_assoc": masked_assoc,
+                    "assoc_delta_signed": assoc_delta,
+                    "assoc_delta_abs": abs(assoc_delta),
+                    "prob_delta_signed": prob_delta,
+                    "prob_delta_abs": abs(prob_delta),
+                    "base_logit": base_logit,
+                    "masked_logit": masked_logit,
+                    "logit_delta_signed": logit_delta,
+                    "logit_delta_abs": abs(logit_delta),
+                    "hidden_delta_abs": hidden_delta,
+                }
+            )
+    marker = Path("python_checkpoint_forward")
+    return verification, (marker, marker, marker), rows
+
+
+def summarize_roi_rows(
+    rows: list[dict[str, Any]],
+    alpha: float,
+    metric: str,
+    positive_name: str,
+    negative_name: str,
+) -> list[dict[str, Any]]:
+    by_roi: dict[int, dict[int, list[float]]] = {}
+    for row in rows:
+        roi = int(row["roi_index"])
+        label = int(row["label"])
+        by_roi.setdefault(roi, {0: [], 1: []})[label].append(float(row[metric]))
+
+    out: list[dict[str, Any]] = []
+    for roi in sorted(by_roi):
+        negative = by_roi[roi][0]
+        positive = by_roi[roi][1]
+        stats = mann_whitney_cliff(positive, negative)
+        out.append(
+            {
+                "roi_index": roi,
+                "roi_label": f"f{roi}",
+                "metric": METRIC_LABELS[metric],
+                "positive_label": positive_name,
+                "negative_label": negative_name,
+                "n_positive": len(positive),
+                "n_negative": len(negative),
+                "mean_positive": round(sum(positive) / len(positive), 9) if positive else 0.0,
+                "mean_negative": round(sum(negative) / len(negative), 9) if negative else 0.0,
+                "median_positive": round(_median(positive), 9),
+                "median_negative": round(_median(negative), 9),
+                "u_stat": round(stats["u"], 6),
+                "z": round(stats["z"], 6),
+                "p_raw": stats["p"],
+                "cliffs_delta": round(stats["cliff_delta"], 9),
+            }
+        )
+
+    adjusted = holm_adjust([float(row["p_raw"]) for row in out])
+    for row, p_holm in zip(out, adjusted, strict=True):
+        row["p_holm"] = p_holm
+        row["significant_holm_0_05"] = p_holm < alpha
+        row["abs_cliffs_delta"] = abs(float(row["cliffs_delta"]))
+    out.sort(key=lambda row: (float(row["p_holm"]), -float(row["abs_cliffs_delta"]), int(row["roi_index"])))
+    for rank, row in enumerate(out, start=1):
+        row["rank"] = rank
+    return out
+
+
+def enrich_subject_rows(
+    rows: list[dict[str, Any]],
+    records: list[Any],
+    positive_name: str,
+    negative_name: str,
+) -> list[dict[str, Any]]:
+    enriched: list[dict[str, Any]] = []
+    for row in rows:
+        record = records[int(row["subject_index"])]
+        label = int(row["label"])
+        enriched.append(
+            {
+                "subject_index": row["subject_index"],
+                "subject_id": record.subject_id,
+                "label": row["label"],
+                "label_name": label_name_for(label, positive_name, negative_name),
+                "site": row["site"],
+                "roi_index": row["roi_index"],
+                "roi_label": f"f{row['roi_index']}",
+                "base_prob": row["base_prob"],
+                "masked_prob": row["masked_prob"],
+                "base_assoc": row["base_assoc"],
+                "masked_assoc": row["masked_assoc"],
+                "assoc_delta_signed": row["assoc_delta_signed"],
+                "assoc_delta_abs": row["assoc_delta_abs"],
+                "prob_delta_signed": row["prob_delta_signed"],
+                "prob_delta_abs": row["prob_delta_abs"],
+                "base_logit": row["base_logit"],
+                "masked_logit": row["masked_logit"],
+                "logit_delta_signed": row["logit_delta_signed"],
+                "logit_delta_abs": row["logit_delta_abs"],
+                "hidden_delta_abs": row["hidden_delta_abs"],
+            }
+        )
+    return enriched
+
+
+def write_outputs(
+    output_dir: Path,
+    ckpt: dict[str, Any],
+    checkpoint_path: Path,
+    manifest_path: Path,
+    manifest_meta: Any,
+    records: list[Any],
+    native_verification: dict[str, Any],
+    native_paths: tuple[Path, Path, Path],
+    rows: list[dict[str, Any]],
+    roi_stats: list[dict[str, Any]],
+    scope: str,
+    alpha: float,
+    metric: str,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    positive_name, negative_name = manifest_label_names(manifest_meta.extra)
+    subject_rows = enrich_subject_rows(rows, records, positive_name, negative_name)
+    roi_stat_fields = [
+        "rank",
+        "roi_index",
+        "roi_label",
+        "metric",
+        "positive_label",
+        "negative_label",
+        "n_positive",
+        "n_negative",
+        "mean_positive",
+        "mean_negative",
+        "median_positive",
+        "median_negative",
+        "u_stat",
+        "z",
+        "p_raw",
+        "p_holm",
+        "cliffs_delta",
+        "abs_cliffs_delta",
+        "significant_holm_0_05",
+    ]
+    write_tsv(
+        output_dir / "subject_roi_assoc_features.tsv",
+        subject_rows,
+        [
+            "subject_index",
+            "subject_id",
+            "label",
+            "label_name",
+            "site",
+            "roi_index",
+            "roi_label",
+            "base_prob",
+            "masked_prob",
+            "base_assoc",
+            "masked_assoc",
+            "assoc_delta_signed",
+            "assoc_delta_abs",
+            "prob_delta_signed",
+            "prob_delta_abs",
+            "base_logit",
+            "masked_logit",
+            "logit_delta_signed",
+            "logit_delta_abs",
+            "hidden_delta_abs",
+        ],
+    )
+    write_tsv(
+        output_dir / "associator_by_roi.csv",
+        roi_stats,
+        roi_stat_fields,
+    )
+    write_tsv(
+        output_dir / "top10_roi_biomarkers.csv",
+        roi_stats[:10],
+        roi_stat_fields,
+    )
+    source_path, binary_path, stdout_path = native_paths
+    atlas = manifest_meta.extra.get("atlas") or f"manifest_f0_f{max(0, manifest_meta.seq_len * manifest_meta.input_dim - 1)}"
+    summary = {
+        "schema": "brain_ossm.trained_roi_associator.v1",
+        "method": native_verification.get("executor", "trained_checkpoint_native_forward_roi_occlusion"),
+        "ranking_metric": METRIC_LABELS[metric],
+        "scope": scope,
+        "alpha": alpha,
+        "checkpoint_path": str(checkpoint_path),
+        "manifest_path": str(manifest_path),
+        "manifest_schema": manifest_meta.schema,
+        "dataset_id": manifest_meta.extra.get("dataset_id", "abide"),
+        "label_space": manifest_meta.label_space,
+        "positive_label_name": positive_name,
+        "negative_label_name": negative_name,
+        "atlas": atlas,
+        "run_id": ckpt.get("run_id"),
+        "checkpoint_selection": ckpt.get("selection"),
+        "checkpoint_meta": ckpt.get("meta"),
+        "checkpoint_verification": ckpt.get("verification"),
+        "extractor_verification": native_verification,
+        "native_extractor_verification": native_verification,
+        "native_extractor_source": str(source_path),
+        "native_extractor_binary": str(binary_path),
+        "native_extractor_stdout": str(stdout_path),
+        "subject_count": len({row["subject_index"] for row in rows}),
+        "roi_count": len({row["roi_index"] for row in rows}),
+        "feature_rows": len(rows),
+        "holm_survivors": sum(1 for row in roi_stats if row["significant_holm_0_05"]),
+        "top_roi": roi_stats[0] if roi_stats else None,
+    }
+    write_json(output_dir / "run_summary.json", summary)
+    write_json(
+        output_dir / "associator_map.json",
+        {
+            "schema": "brain_ossm.trained_roi_associator.map.v1",
+            "dataset_id": manifest_meta.extra.get("dataset_id", "abide"),
+            "label_space": manifest_meta.label_space,
+            "positive_label_name": positive_name,
+            "negative_label_name": negative_name,
+            "atlas": atlas,
+            "metric": METRIC_LABELS[metric],
+            "roi_count": len(roi_stats),
+            "rois": roi_stats,
+        },
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--scope", choices=["all", "holdout"], default="all")
+    parser.add_argument("--alpha", type=float, default=0.05)
+    parser.add_argument("--min-balanced-accuracy", type=float, default=51.0)
+    parser.add_argument("--executor", choices=["python", "native"], default="native")
+    parser.add_argument("--native-souc-engine", default="", help="Optional SOUNIO_SOUC_ENGINE for native extraction.")
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[2]))
+    parser.add_argument(
+        "--metric",
+        choices=sorted(METRIC_LABELS),
+        default="hidden_delta_abs",
+        help="ROI statistic used for Mann-Whitney/Holm ranking; default uses trained hidden-state occlusion.",
+    )
+    args = parser.parse_args()
+
+    checkpoint_path = Path(args.checkpoint).resolve()
+    manifest_path = Path(args.manifest).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    ckpt = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    require_verified_checkpoint(ckpt, args.min_balanced_accuracy)
+    manifest_meta, records = load_manifest(manifest_path)
+    positive_name, negative_name = manifest_label_names(manifest_meta.extra)
+    rebuild_standardization_from_manifest(ckpt, records)
+    require_verified_checkpoint(ckpt, args.min_balanced_accuracy)
+
+    repaired_checkpoint = output_dir / "model.with_rebuilt_standardization.ckpt"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    repaired_checkpoint.write_text(json.dumps(ckpt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.executor == "native":
+        native_paths = run_native_extractor(
+            ckpt,
+            checkpoint_path,
+            manifest_path,
+            output_dir,
+            args.scope,
+            Path(args.repo_root),
+            args.native_souc_engine,
+        )
+        native_verification, rows = parse_native_rows(native_paths[2])
+    else:
+        native_verification, native_paths, rows = run_python_extractor(ckpt, records, args.scope)
+    expected = float(ckpt["verification"]["actual_balanced_accuracy_pct"])
+    actual = float(native_verification["actual_balanced_accuracy_pct"])
+    delta = abs(actual - expected)
+    if delta > 0.5:
+        raise SystemExit(f"extractor verification mismatch: expected={expected:.6f} actual={actual:.6f} delta={delta:.6f}pp")
+    if actual <= args.min_balanced_accuracy:
+        raise SystemExit(f"extractor verification below threshold: actual={actual:.6f}")
+
+    roi_stats = summarize_roi_rows(rows, args.alpha, args.metric, positive_name, negative_name)
+    if args.scope == "holdout":
+        holdout_key = int_meta(ckpt["meta"], "holdout_key")
+        expected_site_keys = (
+            materialize_single_site_internal_cv_keys(records)
+            if single_site_internal_cv_enabled(None, records, holdout_key)
+            else [site_hash(record.site) for record in records]
+        )
+        expected_subjects = sum(1 for site_key in expected_site_keys if site_key == holdout_key)
+    else:
+        expected_subjects = len(records)
+    expected_rows = expected_subjects * int_meta(ckpt["meta"], "manifest_feature_count")
+    if len(rows) != expected_rows:
+        raise SystemExit(f"extractor row count mismatch: expected={expected_rows} actual={len(rows)}")
+    write_outputs(
+        output_dir,
+        ckpt,
+        checkpoint_path,
+        manifest_path,
+        manifest_meta,
+        records,
+        {**native_verification, "expected_balanced_accuracy_pct": expected, "delta_pp": delta},
+        native_paths,
+        rows,
+        roi_stats,
+        args.scope,
+        args.alpha,
+        args.metric,
+    )
+    print(
+        "trained ROI associator extraction complete: "
+        f"rows={len(rows)} rois={len(roi_stats)} "
+        f"verify_expected={expected:.6f} verify_actual={actual:.6f} delta={delta:.6f}pp "
+        f"top10={output_dir / 'top10_roi_biomarkers.csv'}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/adhd200_data_access_audit.py
+++ b/scripts/research/adhd200_data_access_audit.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Audit ADHD-200 data access before running the dimensional O-SSM pilot.
+
+This script is intentionally conservative: it does not download large
+derivatives, does not treat ABIDE files as ADHD-200, and does not convert a
+missing dataset into a synthetic smoke. Its job is to make the next executable
+step explicit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.adhd200_data_access_audit.v1"
+CLAIM_BOUNDARY = (
+    "Data-access/readiness audit only; no diagnostic, biomarker, mechanism, "
+    "treatment, or O-SSM superiority claim."
+)
+
+SOURCE_URLS = [
+    "https://fcon_1000.projects.nitrc.org/indi/adhd200/",
+    "https://preprocessed-connectomes-project.org/adhd200/",
+    "https://preprocessed-connectomes-project.org/adhd200/download.html",
+    "https://raw.githubusercontent.com/preprocessed-connectomes-project/adhd200/gh-pages/download.html",
+]
+
+PHENO_NAME_RE = re.compile(r"(adhd|phenotypic|phenotype|participants).*\.(csv|tsv|txt)$", re.I)
+ROI_NAME_RE = re.compile(r"(adhd|nyu|pitt|peking|washu|ohsu|neuro|kki|brown|kennedy|sub[-_]?|^[A-Za-z0-9_.-]+)(_rois_cc200)?\.(1D|tsv|txt|csv)$", re.I)
+ABIDE_NAME_RE = re.compile(r"abide|autism|asd", re.I)
+ADHD_CONTEXT_RE = re.compile(r"adhd[-_ ]?200|adhd", re.I)
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    "__pycache__",
+    "node_modules",
+    "target",
+    "vendor",
+}
+
+REQUIRED_HINTS = {
+    "subject": ["subject_id", "sub_id", "subject", "participant_id", "scan_dir_id", "scandirid", "scan_dir id", "ScanDir ID", "scanid", "id"],
+    "site": ["site", "site_id", "siteid", "scan_site", "data_set", "dataset"],
+    "diagnosis": ["dx", "dx_group", "diagnosis", "adhd", "adhd_diagnosis", "diagnostic_status"],
+}
+PRIMARY_HINTS = {
+    "inattention": ["inattention", "inattentive", "adhd_rs_iv_inattention", "conners_inattention"],
+    "hyperactivity_impulsivity": [
+        "hyperactivity_impulsivity",
+        "hyper_impulsive",
+        "Hyper/Impulsive",
+        "hyperactivity",
+        "impulsivity",
+        "adhd_rs_iv_hyperactivity_impulsivity",
+        "conners_hyperactivity",
+    ],
+    "adhd_total": ["adhd_total", "adhd_index", "adhd_rs_iv_total", "conners_adhd_index"],
+}
+
+
+def normalize_name(value: str) -> str:
+    return "".join(ch.lower() for ch in value if ch.isalnum())
+
+
+def header_hits(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "path": str(path),
+        "size_bytes": path.stat().st_size if path.exists() else 0,
+        "readable": False,
+        "required_hits": {},
+        "primary_hits": {},
+        "field_count": 0,
+    }
+    try:
+        with path.open(newline="", encoding="utf-8-sig") as handle:
+            sample = handle.read(8192)
+            handle.seek(0)
+            try:
+                dialect = csv.Sniffer().sniff(sample, delimiters=",\t")
+            except csv.Error:
+                dialect = csv.excel_tab if path.suffix.lower() in {".tsv", ".txt"} else csv.excel
+            reader = csv.DictReader(handle, dialect=dialect)
+            fields = list(reader.fieldnames or [])
+    except Exception as exc:
+        result["error"] = str(exc)
+        return result
+
+    result["readable"] = bool(fields)
+    result["field_count"] = len(fields)
+    by_norm = {normalize_name(field): field for field in fields}
+    for logical, aliases in REQUIRED_HINTS.items():
+        result["required_hits"][logical] = next(
+            (by_norm[normalize_name(alias)] for alias in aliases if normalize_name(alias) in by_norm),
+            "",
+        )
+    for logical, aliases in PRIMARY_HINTS.items():
+        result["primary_hits"][logical] = next(
+            (by_norm[normalize_name(alias)] for alias in aliases if normalize_name(alias) in by_norm),
+            "",
+        )
+    return result
+
+
+def has_adhd_context(path: Path) -> bool:
+    return bool(ADHD_CONTEXT_RE.search(str(path)))
+
+
+def looks_like_roi(path: Path, require_adhd_context: bool) -> bool:
+    if require_adhd_context and not has_adhd_context(path):
+        return False
+    name = path.name
+    if ABIDE_NAME_RE.search(str(path)):
+        return False
+    if not ROI_NAME_RE.search(name):
+        return False
+    if path.stat().st_size < 256:
+        return False
+    return True
+
+
+def scan_tree(root: Path, max_files: int, require_adhd_context: bool) -> tuple[list[Path], list[Path], int, bool]:
+    phenotypic: list[Path] = []
+    roi: list[Path] = []
+    visited = 0
+    truncated = False
+    if not root.exists():
+        return phenotypic, roi, visited, truncated
+    if root.is_file():
+        visited = 1
+        if PHENO_NAME_RE.search(root.name) and (not require_adhd_context or has_adhd_context(root)):
+            phenotypic.append(root)
+        if looks_like_roi(root, require_adhd_context):
+            roi.append(root)
+        return phenotypic, roi, visited, truncated
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in SKIP_DIRS]
+        for filename in filenames:
+            path = Path(dirpath) / filename
+            visited += 1
+            if visited > max_files:
+                truncated = True
+                return phenotypic, roi, visited, truncated
+            if (
+                PHENO_NAME_RE.search(filename)
+                and not ABIDE_NAME_RE.search(str(path))
+                and (not require_adhd_context or has_adhd_context(path))
+            ):
+                phenotypic.append(path)
+            if looks_like_roi(path, require_adhd_context):
+                roi.append(path)
+    return phenotypic, roi, visited, truncated
+
+
+def summarize_roi_dirs(paths: list[Path]) -> list[dict[str, Any]]:
+    by_dir: dict[Path, int] = {}
+    examples: dict[Path, list[str]] = {}
+    for path in paths:
+        by_dir[path.parent] = by_dir.get(path.parent, 0) + 1
+        examples.setdefault(path.parent, [])
+        if len(examples[path.parent]) < 5:
+            examples[path.parent].append(path.name)
+    rows = [
+        {"roi_dir": str(directory), "candidate_file_count": count, "examples": examples.get(directory, [])}
+        for directory, count in sorted(by_dir.items(), key=lambda item: (-item[1], str(item[0])))
+    ]
+    return rows
+
+
+def probe_url(url: str, timeout: float) -> dict[str, Any]:
+    request = urllib.request.Request(url, headers={"User-Agent": "sounio-adhd200-access-audit/1.0"})
+    result: dict[str, Any] = {"url": url, "ok": False}
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read(4096)
+            result.update(
+                {
+                    "ok": 200 <= int(response.status) < 400,
+                    "status": int(response.status),
+                    "content_type": response.headers.get("content-type", ""),
+                    "sample_bytes": len(body),
+                }
+            )
+    except Exception as exc:  # pragma: no cover - network environment dependent
+        result["error"] = str(exc)
+    return result
+
+
+def shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def build_command(pheno: str, roi_dir: str, output_dir: str) -> str:
+    return (
+        f"PHENOTYPIC_CSV={shell_quote(pheno)} "
+        f"ROI_DIR={shell_quote(roi_dir)} "
+        f"OUTPUT_DIR={shell_quote(output_dir)} "
+        "SOUNIO_SOUC_ENGINE=lean_single "
+        "scripts/research/adhd200_dimensional_pilot_smoke.sh"
+    )
+
+
+def write_markdown(path: Path, audit: dict[str, Any]) -> None:
+    lines = [
+        "# ADHD-200 Data Access Audit",
+        "",
+        f"Status: `{audit['status']}`",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Inputs",
+        "",
+        f"- Explicit phenotypic CSV: `{audit['explicit_inputs'].get('phenotypic_csv') or ''}`",
+        f"- Explicit ROI dir: `{audit['explicit_inputs'].get('roi_dir') or ''}`",
+        f"- Search roots: {', '.join('`' + root + '`' for root in audit['search_roots'])}",
+        "",
+        "## Local Findings",
+        "",
+        f"- Phenotypic candidates: {audit['local']['phenotypic_candidate_count']}",
+        f"- ROI candidate files: {audit['local']['roi_candidate_file_count']}",
+    ]
+    if audit["local"]["phenotypic_candidates"]:
+        lines.append("")
+        lines.append("Phenotypic candidates:")
+        for row in audit["local"]["phenotypic_candidates"][:10]:
+            required = ",".join(k for k, v in row.get("required_hits", {}).items() if v) or "none"
+            primary = ",".join(k for k, v in row.get("primary_hits", {}).items() if v) or "none"
+            lines.append(f"- `{row['path']}` required={required} primary={primary}")
+    if audit["local"]["roi_dirs"]:
+        lines.append("")
+        lines.append("ROI candidate directories:")
+        for row in audit["local"]["roi_dirs"][:10]:
+            lines.append(f"- `{row['roi_dir']}` files={row['candidate_file_count']}")
+    lines.extend(["", "## Next Action", ""])
+    if audit.get("next_command"):
+        lines.append("Run:")
+        lines.append("")
+        lines.append("```bash")
+        lines.append(audit["next_command"])
+        lines.append("```")
+    else:
+        lines.append(audit["next_action"])
+    if audit.get("source_probes"):
+        lines.extend(["", "## Source Probes", ""])
+        for row in audit["source_probes"]:
+            state = "ok" if row.get("ok") else "blocked"
+            detail = row.get("status", row.get("error", ""))
+            lines.append(f"- `{state}` {row['url']} {detail}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--phenotypic-csv", type=Path, default=None)
+    parser.add_argument("--roi-dir", type=Path, default=None)
+    parser.add_argument(
+        "--search-root",
+        action="append",
+        type=Path,
+        default=[],
+        help="Local root to scan. Defaults to artifacts/research and data if present.",
+    )
+    parser.add_argument("--max-files", type=int, default=25000)
+    parser.add_argument("--probe-network", action="store_true")
+    parser.add_argument("--network-timeout", type=float, default=12.0)
+    parser.add_argument("--pilot-output-dir", default="/tmp/adhd200_dimensional_pilot_real")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = args.output_dir / "adhd200_data_access_audit.json"
+    md_path = args.output_dir / "adhd200_data_access_audit.md"
+    if not args.overwrite and (json_path.exists() or md_path.exists()):
+        raise SystemExit(f"refusing to overwrite existing audit outputs in {args.output_dir}; pass --overwrite")
+
+    default_roots = [Path("artifacts/research"), Path("data"), Path("datasets")]
+    roots = args.search_root or [root for root in default_roots if root.exists()] or [Path(".")]
+    roots = [root.resolve() for root in roots]
+
+    phenotypic_paths: list[Path] = []
+    roi_paths: list[Path] = []
+    scans = []
+    for root in roots:
+        pheno, roi, visited, truncated = scan_tree(root, args.max_files, require_adhd_context=True)
+        phenotypic_paths.extend(pheno)
+        roi_paths.extend(roi)
+        scans.append({"root": str(root), "visited_files": visited, "truncated": truncated})
+
+    if args.phenotypic_csv:
+        phenotypic_paths.insert(0, args.phenotypic_csv.resolve())
+    if args.roi_dir and args.roi_dir.exists():
+        _, explicit_roi, visited, truncated = scan_tree(args.roi_dir.resolve(), args.max_files, require_adhd_context=False)
+        roi_paths = explicit_roi + roi_paths
+        scans.append({"root": str(args.roi_dir.resolve()), "visited_files": visited, "truncated": truncated})
+
+    seen_pheno: set[str] = set()
+    pheno_summaries = []
+    for path in phenotypic_paths:
+        key = str(path)
+        if key in seen_pheno or not path.exists() or not path.is_file():
+            continue
+        seen_pheno.add(key)
+        pheno_summaries.append(header_hits(path))
+
+    seen_roi: set[str] = set()
+    unique_roi_paths: list[Path] = []
+    for path in roi_paths:
+        key = str(path)
+        if key not in seen_roi:
+            seen_roi.add(key)
+            unique_roi_paths.append(path)
+    roi_dirs = summarize_roi_dirs(unique_roi_paths)
+
+    explicit_pheno_ok = bool(args.phenotypic_csv and args.phenotypic_csv.exists())
+    explicit_roi_ok = bool(args.roi_dir and args.roi_dir.exists() and roi_dirs)
+    usable_pheno = [
+        row
+        for row in pheno_summaries
+        if row.get("readable")
+        and all(row.get("required_hits", {}).get(key) for key in ["subject", "site", "diagnosis"])
+    ]
+    primary_complete = [
+        row
+        for row in usable_pheno
+        if all(row.get("primary_hits", {}).get(key) for key in PRIMARY_HINTS)
+    ]
+    explicit_primary_complete = bool(
+        args.phenotypic_csv
+        and primary_complete
+        and Path(primary_complete[0]["path"]).resolve() == args.phenotypic_csv.resolve()
+    )
+
+    next_command = ""
+    if explicit_pheno_ok and explicit_roi_ok and explicit_primary_complete:
+        status = "ready"
+        next_command = build_command(str(args.phenotypic_csv), str(args.roi_dir), args.pilot_output_dir)
+        next_action = "Explicit ADHD-200 phenotypic and ROI inputs are present; run the pilot command."
+    elif explicit_pheno_ok and explicit_roi_ok:
+        status = "partial"
+        next_action = (
+            "Explicit phenotypic and ROI paths exist, but the phenotypic table is not confirmatory-ready. "
+            "Check required ADHD dimensional subscale columns before running the pilot."
+        )
+    elif primary_complete and roi_dirs:
+        status = "partial"
+        next_command = build_command(primary_complete[0]["path"], roi_dirs[0]["roi_dir"], args.pilot_output_dir)
+        next_action = "Candidate ADHD-200 inputs were found locally; inspect them, then run the pilot command if they are the intended dataset."
+    elif usable_pheno or roi_dirs:
+        status = "partial"
+        next_action = (
+            "Only part of the ADHD-200 input pair was found. Provide both PHENOTYPIC_CSV and ROI_DIR, "
+            "or pass explicit --phenotypic-csv/--roi-dir to this audit."
+        )
+    else:
+        status = "blocked"
+        next_action = (
+            "No usable local ADHD-200 phenotypic/ROI input pair was found. Acquire ADHD-200 phenotypic metadata "
+            "and PCP ROI time-series derivatives manually or via the official PCP/NITRC access path, then rerun this audit."
+        )
+
+    source_probes = [probe_url(url, args.network_timeout) for url in SOURCE_URLS] if args.probe_network else []
+
+    audit: dict[str, Any] = {
+        "schema": SCHEMA,
+        "status": status,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "explicit_inputs": {
+            "phenotypic_csv": str(args.phenotypic_csv) if args.phenotypic_csv else "",
+            "roi_dir": str(args.roi_dir) if args.roi_dir else "",
+        },
+        "search_roots": [str(root) for root in roots],
+        "scans": scans,
+        "local": {
+            "phenotypic_candidate_count": len(pheno_summaries),
+            "usable_phenotypic_candidate_count": len(usable_pheno),
+            "primary_complete_phenotypic_candidate_count": len(primary_complete),
+            "phenotypic_candidates": pheno_summaries[:50],
+            "roi_candidate_file_count": len(unique_roi_paths),
+            "roi_dirs": roi_dirs[:50],
+        },
+        "source_probes": source_probes,
+        "next_action": next_action,
+        "next_command": next_command,
+    }
+    json_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(md_path, audit)
+    print(json.dumps({"status": status, "json": str(json_path), "markdown": str(md_path)}, sort_keys=True))
+    return 0 if status in {"ready", "partial", "blocked"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/adhd200_dimensional_pilot_decision_gate.py
+++ b/scripts/research/adhd200_dimensional_pilot_decision_gate.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Decision gate for ADHD-200 dimensional O-SSM pilot artifacts.
+
+The gate compares O-SSM hidden-state dimensional probes against associative,
+generic recurrent, covariate, and static-input controls. It emits an honest
+pilot verdict only; it does not promote diagnostic, biomarker, mechanism, or
+O-SSM superiority claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.adhd200_dimensional_pilot_decision.v1"
+CLAIM_BOUNDARY = (
+    "Pilot decision gate only. No diagnostic, biomarker, treatment-response, "
+    "biological-mechanism, or O-SSM superiority claim."
+)
+
+
+def parse_float(value: Any, default: float = 0.0) -> float:
+    try:
+        out = float(str(value))
+    except (TypeError, ValueError):
+        return default
+    return out if math.isfinite(out) else default
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"missing": str(path)}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    if not path.exists() or path.stat().st_size == 0:
+        return []
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def row_score(row: dict[str, str]) -> float:
+    return parse_float(row.get("spearman_mean", "0"))
+
+
+def row_null_p(row: dict[str, str]) -> float:
+    return parse_float(row.get("null_spearman_p_ge_mean", "1"), default=1.0)
+
+
+def row_null_count(row: dict[str, str]) -> float:
+    return parse_float(row.get("null_permutations_mean", "0"), default=0.0)
+
+
+def best(rows: list[dict[str, str]], phenotype: str, surface: str | None = None, models: set[str] | None = None) -> dict[str, Any] | None:
+    candidates = [row for row in rows if row.get("phenotype") == phenotype]
+    if surface is not None:
+        candidates = [row for row in candidates if row.get("surface") == surface]
+    if models is not None:
+        candidates = [row for row in candidates if row.get("model") in models]
+    if not candidates:
+        return None
+    return max(candidates, key=row_score)
+
+
+def summarize_phenotype(
+    phenotype: str,
+    rows: list[dict[str, str]],
+    min_gap: float,
+    alpha: float,
+) -> dict[str, Any]:
+    o_hidden = best(rows, phenotype, surface="hidden", models={"O-SSM"})
+    h_hidden = best(rows, phenotype, surface="hidden", models={"H-SSM"})
+    generic = best(
+        rows,
+        phenotype,
+        models={"gru_reservoir", "gru_reservoir_wide", "trained_rnn", "trained_rnn_wide"},
+    )
+    generic_hidden = best(rows, phenotype, surface="hidden", models={"gru_reservoir", "gru_reservoir_wide"})
+    generic_trained = best(rows, phenotype, surface="trained_recurrent_prediction", models={"trained_rnn", "trained_rnn_wide"})
+    covariates = best(rows, phenotype, surface="covariates")
+    static = best(rows, phenotype, surface="static_input_summary")
+
+    controls = [row for row in [h_hidden, generic, covariates, static] if row is not None]
+    best_control = max(controls, key=row_score) if controls else None
+    result: dict[str, Any] = {
+        "phenotype": phenotype,
+        "o_ssm_hidden": o_hidden,
+        "h_ssm_hidden": h_hidden,
+        "generic_best": generic,
+        "generic_hidden_best": generic_hidden,
+        "generic_trained_best": generic_trained,
+        "covariates_best": covariates,
+        "static_input_best": static,
+        "best_control": best_control,
+        "min_gap": min_gap,
+        "alpha": alpha,
+    }
+    if o_hidden is None:
+        result["verdict"] = "BLOCKED_MISSING_O_SSM_HIDDEN"
+        result["reason"] = "No O-SSM hidden-state summary row was found."
+        return result
+    if h_hidden is None:
+        result["verdict"] = "BLOCKED_MISSING_ASSOCIATIVE_CONTROL"
+        result["reason"] = "No H-SSM hidden-state control row was found."
+        return result
+    if generic is None:
+        result["verdict"] = "UNDERCONTROLLED_MISSING_GENERIC_CONTROL"
+        result["reason"] = "No generic recurrent baseline row was found."
+        return result
+
+    o_score = row_score(o_hidden)
+    o_null_p = row_null_p(o_hidden)
+    best_control_score = row_score(best_control) if best_control is not None else float("-inf")
+    gap = o_score - best_control_score
+    result["o_score"] = o_score
+    result["o_null_p"] = o_null_p
+    result["best_control_score"] = best_control_score
+    result["o_minus_best_control"] = gap
+
+    if best_control is not None and best_control.get("surface") in {"covariates", "static_input_summary"} and row_score(best_control) >= o_score - min_gap:
+        result["verdict"] = "NEGATIVE_NUISANCE_OR_STATIC_COMPETITIVE"
+        result["reason"] = "Covariate or static-input surface matches or exceeds the O-SSM hidden score within the preregistered margin."
+    elif generic is not None and row_score(generic) >= o_score - min_gap:
+        result["verdict"] = "NEGATIVE_GENERIC_RECURRENT_COMPETITIVE"
+        result["reason"] = "Generic recurrent baseline matches or exceeds the O-SSM hidden score within the preregistered margin."
+    elif h_hidden is not None and row_score(h_hidden) >= o_score - min_gap:
+        result["verdict"] = "NEGATIVE_ASSOCIATIVE_CONTROL_COMPETITIVE"
+        result["reason"] = "Associative H-SSM hidden state matches or exceeds the O-SSM hidden score within the preregistered margin."
+    elif gap >= min_gap and o_null_p <= alpha:
+        result["verdict"] = "EXPLORATORY_O_SSM_SIGNAL"
+        result["reason"] = "O-SSM hidden state exceeds the available controls and passes the pilot null threshold."
+    else:
+        result["verdict"] = "NO_ROBUST_PILOT_SIGNAL"
+        result["reason"] = "O-SSM hidden state does not clear both the control margin and null threshold."
+    return result
+
+
+def overall_verdict(phenotype_rows: list[dict[str, Any]]) -> str:
+    verdicts = [row["verdict"] for row in phenotype_rows]
+    if any(value.startswith("BLOCKED") for value in verdicts):
+        return "BLOCKED"
+    if any(value.startswith("UNDERCONTROLLED") for value in verdicts):
+        return "UNDERCONTROLLED"
+    if any(value == "EXPLORATORY_O_SSM_SIGNAL" for value in verdicts):
+        if all(value == "EXPLORATORY_O_SSM_SIGNAL" for value in verdicts):
+            return "PILOT_EXPLORATORY_O_SSM_SIGNAL_ALL_PRIMARY"
+        return "PILOT_MIXED_EXPLORATORY"
+    if all(value.startswith("NEGATIVE") for value in verdicts):
+        return "PILOT_NEGATIVE_CONTROLS_SUFFICE"
+    return "PILOT_NO_ROBUST_SIGNAL"
+
+
+def low_power_reasons(readiness: dict[str, Any], rows: list[dict[str, str]], min_subjects: int, min_null_permutations: int) -> list[str]:
+    reasons = []
+    row_count = int(parse_float(readiness.get("row_count", 0), default=0.0))
+    if row_count < min_subjects:
+        reasons.append(f"row_count {row_count} < min_decision_subjects {min_subjects}")
+    null_counts = [row_null_count(row) for row in rows if row.get("null_permutations_mean") not in {None, ""}]
+    min_observed_nulls = min(null_counts) if null_counts else 0.0
+    if min_observed_nulls < min_null_permutations:
+        reasons.append(
+            f"min null_permutations_mean {min_observed_nulls:g} < min_decision_null_permutations {min_null_permutations}"
+        )
+    return reasons
+
+
+def downgrade_low_power(phenotype_rows: list[dict[str, Any]], reasons: list[str]) -> None:
+    reason_text = "; ".join(reasons)
+    for row in phenotype_rows:
+        if row["verdict"].startswith("BLOCKED") or row["verdict"].startswith("UNDERCONTROLLED"):
+            continue
+        row["pilot_metric_verdict"] = row["verdict"]
+        row["verdict"] = "UNDERCONTROLLED_LOW_POWER"
+        row["reason"] = (
+            "Pilot scores were computed, but the run is underpowered for a negative or positive decision: "
+            + reason_text
+            + "."
+        )
+
+
+def compact_row(row: dict[str, Any] | None) -> str:
+    if not row:
+        return "missing"
+    model = row.get("model", "")
+    surface = row.get("surface", "")
+    score = row_score(row)
+    null_p = row_null_p(row)
+    return f"{model}/{surface} spearman={score:.6f} null_p_ge={null_p:.6f}"
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# ADHD-200 Dimensional Pilot Decision",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        f"Overall verdict: `{payload['overall_verdict']}`",
+        "",
+        "| phenotype | verdict | O-SSM hidden | best control | reason |",
+        "|---|---|---|---|---|",
+    ]
+    for row in payload["phenotype_decisions"]:
+        lines.append(
+            "| {phenotype} | {verdict} | {ossm} | {control} | {reason} |".format(
+                phenotype=row["phenotype"],
+                verdict=row["verdict"],
+                ossm=compact_row(row.get("o_ssm_hidden")),
+                control=compact_row(row.get("best_control")),
+                reason=row["reason"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "Interpretation: this gate decides only whether the pilot artifacts are worth deeper follow-up.",
+            "A positive pilot verdict remains exploratory until a larger independently reviewed cohort, trained generic baselines, leakage audits, and external review all pass.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--readiness-json", required=True, type=Path)
+    parser.add_argument("--state-summary", required=True, type=Path)
+    parser.add_argument("--generic-summary", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--primary-phenotypes", default="inattention,hyperactivity_impulsivity,adhd_total")
+    parser.add_argument("--min-gap", type=float, default=0.05)
+    parser.add_argument("--alpha", type=float, default=0.10)
+    parser.add_argument("--min-decision-subjects", type=int, default=50)
+    parser.add_argument("--min-decision-null-permutations", type=int, default=20)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    readiness = read_json(args.readiness_json)
+    state_rows = read_tsv(args.state_summary)
+    generic_rows = read_tsv(args.generic_summary)
+    rows = state_rows + generic_rows
+    phenotypes = [item.strip() for item in args.primary_phenotypes.split(",") if item.strip()]
+    phenotype_decisions = [summarize_phenotype(name, rows, args.min_gap, args.alpha) for name in phenotypes]
+    power_reasons = low_power_reasons(readiness, rows, args.min_decision_subjects, args.min_decision_null_permutations)
+    if power_reasons:
+        downgrade_low_power(phenotype_decisions, power_reasons)
+    if readiness.get("status") != "pass":
+        overall = "BLOCKED_READINESS_GATE_FAILED"
+    elif power_reasons:
+        overall = "UNDERCONTROLLED_LOW_POWER"
+    else:
+        overall = overall_verdict(phenotype_decisions)
+
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "readiness_json": str(args.readiness_json.resolve()),
+        "state_summary": str(args.state_summary.resolve()),
+        "generic_summary": str(args.generic_summary.resolve()),
+        "readiness_status": readiness.get("status", "missing"),
+        "readiness_failures": readiness.get("failures", []),
+        "primary_phenotypes": phenotypes,
+        "min_gap": args.min_gap,
+        "alpha": args.alpha,
+        "min_decision_subjects": args.min_decision_subjects,
+        "min_decision_null_permutations": args.min_decision_null_permutations,
+        "low_power_reasons": power_reasons,
+        "overall_verdict": overall,
+        "phenotype_decisions": phenotype_decisions,
+    }
+    (output_dir / "adhd_dimensional_pilot_decision.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (output_dir / "adhd_dimensional_pilot_decision.md").write_text(markdown(payload), encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/adhd200_dimensional_pilot_smoke.sh
+++ b/scripts/research/adhd200_dimensional_pilot_smoke.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage:
+  PHENOTYPIC_CSV=/path/phenotypic.csv ROI_DIR=/path/roi OUTPUT_DIR=/path/out \
+    scripts/research/adhd200_dimensional_pilot_smoke.sh
+
+Required environment:
+  PHENOTYPIC_CSV   ADHD-200 phenotypic CSV/TSV with dimensional subscales.
+  ROI_DIR          Directory containing subject ROI time-series files.
+  OUTPUT_DIR       Output directory for all pilot artifacts.
+
+Preflight:
+  Use scripts/research/adhd200_s3_bootstrap.py to create a bounded public
+  PCP/FCP-INDI cache when local ADHD-200 inputs are absent.
+  Use scripts/research/adhd200_data_access_audit.py before a real-data run to
+  prove the local PHENOTYPIC_CSV/ROI_DIR pair is present. This smoke does not
+  download ADHD-200 data and must not be run on ABIDE files as a substitute.
+
+Optional environment:
+  MAX_SUBJECTS             Default: 0 (all eligible).
+  NULL_PERMUTATIONS        Default: 20.
+  RUN_GENERIC_BASELINE     Default: 1.
+  GENERIC_BASELINE_MODELS  Default: gru_reservoir,gru_reservoir_wide.
+  GENERIC_BASELINE_SEEDS   Default: Sounio 20-seed schedule.
+  GENERIC_TRAINED_EPOCHS   Default: 80.
+  GENERIC_TRAINED_LR       Default: 0.01.
+  PILOT_DECISION_MIN_GAP   Default: 0.05.
+  PILOT_DECISION_ALPHA     Default: 0.10.
+  GLOBAL_TRAIN_EPOCHS      Default: 6.
+  OCT_TRAIN_EPOCHS         Default: 6.
+  H_TRAIN_EPOCHS           Default: 6.
+  TRAIN_FRACTION           Default: 1.0.
+  FEATURE_MODE             Default: temporal_roi_block.
+  PRIMARY_PHENOTYPES       Default: inattention,hyperactivity_impulsivity,adhd_total.
+  SOUNIO_SOUC_ENGINE       Default: lean_single.
+  SOUNIO_DIR               Default: current repository root.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOUNIO_DIR="${SOUNIO_DIR:-$repo_root}"
+
+: "${PHENOTYPIC_CSV:?PHENOTYPIC_CSV is required}"
+: "${ROI_DIR:?ROI_DIR is required}"
+: "${OUTPUT_DIR:?OUTPUT_DIR is required}"
+
+MAX_SUBJECTS="${MAX_SUBJECTS:-0}"
+NULL_PERMUTATIONS="${NULL_PERMUTATIONS:-20}"
+RUN_GENERIC_BASELINE="${RUN_GENERIC_BASELINE:-1}"
+GENERIC_BASELINE_MODELS="${GENERIC_BASELINE_MODELS:-gru_reservoir,gru_reservoir_wide}"
+GENERIC_BASELINE_SEEDS="${GENERIC_BASELINE_SEEDS:-55555,11111,99887,22222,44444,66666,77777,88888,33333,12321,24680,13579,54321,67890,11223,44567,77889,99001,31415,27182}"
+GENERIC_TRAINED_EPOCHS="${GENERIC_TRAINED_EPOCHS:-80}"
+GENERIC_TRAINED_LR="${GENERIC_TRAINED_LR:-0.01}"
+PILOT_DECISION_MIN_GAP="${PILOT_DECISION_MIN_GAP:-0.05}"
+PILOT_DECISION_ALPHA="${PILOT_DECISION_ALPHA:-0.10}"
+GLOBAL_TRAIN_EPOCHS="${GLOBAL_TRAIN_EPOCHS:-6}"
+OCT_TRAIN_EPOCHS="${OCT_TRAIN_EPOCHS:-6}"
+H_TRAIN_EPOCHS="${H_TRAIN_EPOCHS:-6}"
+TRAIN_FRACTION="${TRAIN_FRACTION:-1.0}"
+FEATURE_MODE="${FEATURE_MODE:-temporal_roi_block}"
+PRIMARY_PHENOTYPES="${PRIMARY_PHENOTYPES:-inattention,hyperactivity_impulsivity,adhd_total}"
+export SOUNIO_SOUC_ENGINE="${SOUNIO_SOUC_ENGINE:-lean_single}"
+
+output_dir="$(mkdir -p "$OUTPUT_DIR" && cd "$OUTPUT_DIR" && pwd)"
+manifest_dir="$output_dir/manifest"
+run_dir="$output_dir/ossm_run"
+probe_dir="$output_dir/dimensional_probe"
+generic_dir="$output_dir/generic_recurrent_baseline"
+decision_dir="$output_dir/pilot_decision"
+align_dir="$output_dir/readout_alignment"
+mkdir -p "$manifest_dir" "$run_dir" "$probe_dir" "$generic_dir" "$decision_dir" "$align_dir"
+
+prepare_args=(
+  "$SOUNIO_DIR/scripts/research/adhd200_prepare_manifest.py"
+  --output-dir "$manifest_dir"
+  --phenotypic-csv "$PHENOTYPIC_CSV"
+  --roi-dir "$ROI_DIR"
+  --write-ossm-view
+  --feature-mode "$FEATURE_MODE"
+  --primary-phenotypes "$PRIMARY_PHENOTYPES"
+)
+if [[ "$MAX_SUBJECTS" != "0" ]]; then
+  prepare_args+=(--max-subjects "$MAX_SUBJECTS")
+fi
+
+python3 "${prepare_args[@]}" >"$manifest_dir/prepare.stdout.json"
+
+python3 "$SOUNIO_DIR/scripts/research/adhd200_manifest_readiness_gate.py" \
+  --manifest "$manifest_dir/adhd200_roi_manifest.tsv" \
+  --primary-phenotypes "$PRIMARY_PHENOTYPES" \
+  >"$manifest_dir/readiness_gate.json"
+
+cp "$manifest_dir/adhd200_ossm_manifest.tsv" "$run_dir/abide_roi_manifest.tsv"
+cat >"$run_dir/abide_run_config.tsv" <<CONFIG
+train_fraction=$TRAIN_FRACTION
+global_train_epochs=$GLOBAL_TRAIN_EPOCHS
+oct_train_epochs=$OCT_TRAIN_EPOCHS
+h_train_epochs=$H_TRAIN_EPOCHS
+trace_hidden_state=1
+CONFIG
+
+(
+  cd "$run_dir"
+  "$SOUNIO_DIR/bin/souc" compile "$SOUNIO_DIR/examples/brain_ossm_abide.sio" -o brain_ossm_abide.elf \
+    >compile.stdout.txt 2>compile.stderr.txt
+  chmod +x brain_ossm_abide.elf
+  set +e
+  ./brain_ossm_abide.elf >brain_ossm_abide.raw.txt 2>brain_ossm_abide.stderr.txt
+  rc=$?
+  set -e
+  printf '%s\n' "$rc" >brain_ossm_abide.rc
+  if [[ "$rc" -ne 0 ]]; then
+    tail -n 80 brain_ossm_abide.raw.txt >&2 || true
+    tail -n 80 brain_ossm_abide.stderr.txt >&2 || true
+    exit "$rc"
+  fi
+)
+
+python3 "$SOUNIO_DIR/scripts/research/neurodyn_adhd_dimensional_state_probe.py" \
+  --raw-output "$run_dir/brain_ossm_abide.raw.txt" \
+  --manifest "$manifest_dir/adhd200_roi_manifest.tsv" \
+  --ossm-manifest "$manifest_dir/adhd200_ossm_manifest.tsv" \
+  --output-dir "$probe_dir" \
+  --primary-phenotypes "$PRIMARY_PHENOTYPES" \
+  --null-permutations "$NULL_PERMUTATIONS" \
+  --overwrite \
+  >"$probe_dir/state_probe.stdout.json"
+
+if [[ "$RUN_GENERIC_BASELINE" != "0" ]]; then
+  python3 "$SOUNIO_DIR/scripts/research/adhd200_generic_recurrent_baseline.py" \
+    --manifest "$manifest_dir/adhd200_roi_manifest.tsv" \
+    --output-dir "$generic_dir" \
+    --models "$GENERIC_BASELINE_MODELS" \
+    --seeds "$GENERIC_BASELINE_SEEDS" \
+    --trained-epochs "$GENERIC_TRAINED_EPOCHS" \
+    --trained-lr "$GENERIC_TRAINED_LR" \
+    --primary-phenotypes "$PRIMARY_PHENOTYPES" \
+    --null-permutations "$NULL_PERMUTATIONS" \
+    --overwrite \
+    >"$generic_dir/generic_recurrent_baseline.stdout.json"
+else
+  cat >"$generic_dir/generic_recurrent_baseline.SKIPPED.txt" <<'SKIPPED'
+RUN_GENERIC_BASELINE=0; generic recurrent baseline was intentionally skipped.
+Skipping this control keeps the artifact exploratory and undercontrolled.
+SKIPPED
+fi
+
+python3 "$SOUNIO_DIR/scripts/research/adhd200_dimensional_pilot_decision_gate.py" \
+  --readiness-json "$manifest_dir/readiness_gate.json" \
+  --state-summary "$probe_dir/adhd_dimensional_state_probe_summary.tsv" \
+  --generic-summary "$generic_dir/adhd_generic_recurrent_baseline_summary.tsv" \
+  --output-dir "$decision_dir" \
+  --primary-phenotypes "$PRIMARY_PHENOTYPES" \
+  --min-gap "$PILOT_DECISION_MIN_GAP" \
+  --alpha "$PILOT_DECISION_ALPHA" \
+  --overwrite \
+  >"$decision_dir/pilot_decision.stdout.json"
+
+if grep -q '^READOUT_ALIGN_TRACE' "$run_dir/brain_ossm_abide.raw.txt"; then
+  python3 "$SOUNIO_DIR/scripts/research/neurodyn_readout_alignment_trace_summary.py" \
+    --raw-output "$run_dir/brain_ossm_abide.raw.txt" \
+    --output-dir "$align_dir" \
+    --overwrite \
+    >"$align_dir/readout_alignment.stdout.json"
+else
+  cat >"$align_dir/readout_alignment_trace_summary.SKIPPED.txt" <<'SKIPPED'
+READOUT_ALIGN_TRACE rows were not present in this pilot output.
+The dimensional pilot only requires STATE_TRACE; readout alignment remains a separate optional audit.
+SKIPPED
+fi
+
+(
+  cd "$output_dir"
+  find manifest ossm_run dimensional_probe generic_recurrent_baseline pilot_decision readout_alignment -type f -print0 \
+    | sort -z \
+    | xargs -0 sha256sum >SHA256SUMS
+)
+
+cat >"$output_dir/PILOT_SUMMARY.md" <<SUMMARY
+# ADHD-200 Dimensional O-SSM Pilot Smoke
+
+Claim boundary: instrumentation and site-aware pilot only; no diagnostic, biomarker, treatment, mechanism, or O-SSM superiority claim.
+
+- Phenotypic source: $PHENOTYPIC_CSV
+- ROI source: $ROI_DIR
+- Feature mode: $FEATURE_MODE
+- Primary phenotypes: $PRIMARY_PHENOTYPES
+- Sounio engine: $SOUNIO_SOUC_ENGINE
+- O-SSM compatibility labels: 1=ADHD, 0=TD
+- Manifest: manifest/adhd200_roi_manifest.tsv
+- O-SSM compatibility view: manifest/adhd200_ossm_manifest.tsv
+- Raw O-SSM output: ossm_run/brain_ossm_abide.raw.txt
+- Dynamic state features: dimensional_probe/adhd_dimensional_dynamic_features.tsv
+- Probe report: dimensional_probe/adhd_dimensional_state_probe.md
+- Generic recurrent baseline: generic_recurrent_baseline/adhd_generic_recurrent_baseline.md
+- Pilot decision gate: pilot_decision/adhd_dimensional_pilot_decision.md
+
+This smoke uses the legacy ABIDE runner as an O-SSM execution surface. The rich ADHD manifest is the semantic source of truth.
+The generic recurrent baseline defaults to GRU-style reservoir controls for pilot readiness. Include trained_rnn or trained_rnn_wide in GENERIC_BASELINE_MODELS to run the small NumPy-trained recurrent controls. A full S4/Transformer suite remains required before promotion-scale claims.
+The pilot decision gate is an honesty filter only; it classifies whether controls suffice, whether the result is mixed, or whether a deeper real-data follow-up is justified.
+SUMMARY
+
+printf 'ADHD-200 dimensional pilot smoke complete: %s\n' "$output_dir"

--- a/scripts/research/adhd200_generic_recurrent_baseline.py
+++ b/scripts/research/adhd200_generic_recurrent_baseline.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""Generic recurrent dimensional baselines for ADHD-200 manifests.
+
+This is a lightweight non-hypercomplex control surface for pilot runs. It uses
+deterministic GRU-style recurrent reservoirs plus site-held-out ridge readouts
+over dimensional phenotypes, and can optionally run small trained Elman-RNN
+regressors. It is not a full S4/Transformer suite; it is the small reproducible
+generic-control layer that should be present before interpreting O-SSM hidden
+states.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from neurodyn_adhd_dimensional_state_probe import (
+    CLAIM_BOUNDARY as STATE_PROBE_CLAIM_BOUNDARY,
+    covariate_vector,
+    parse_float,
+    pearson,
+    pstdev,
+    r2_score,
+    ridge_fit_predict,
+    spearman,
+    subject_universe_sha256,
+    vector_from_columns,
+)
+
+
+SCHEMA = "neurodyn.adhd200_generic_recurrent_baseline.v1"
+CLAIM_BOUNDARY = (
+    "Generic recurrent baseline only. This is not a diagnostic, "
+    "biomarker, treatment-response, biological-mechanism, or O-SSM superiority claim."
+)
+
+
+def sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(x, -40.0, 40.0)))
+
+
+def read_manifest(path: Path) -> tuple[dict[str, str], list[dict[str, str]]]:
+    meta: dict[str, str] = {}
+    data_lines: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        if raw.startswith("#"):
+            body = raw[1:].strip()
+            if "=" in body:
+                key, value = body.split("=", 1)
+                meta[key.strip()] = value.strip()
+            continue
+        data_lines.append(raw)
+    if not data_lines:
+        raise SystemExit(f"manifest has no rows: {path}")
+    return meta, list(csv.DictReader(data_lines, delimiter="\t"))
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def feature_matrix(rows: list[dict[str, str]], seq_len: int, input_dim: int) -> np.ndarray:
+    feature_cols = [f"f{i}" for i in range(seq_len * input_dim)]
+    matrix: list[list[float]] = []
+    for idx, row in enumerate(rows):
+        values = vector_from_columns(row, feature_cols)
+        if values is None:
+            raise SystemExit(f"manifest row {idx} has nonnumeric recurrent feature")
+        matrix.append(values)
+    x = np.array(matrix, dtype=float).reshape(len(rows), seq_len, input_dim)
+    mu = x.mean(axis=(0, 1), keepdims=True)
+    sigma = x.std(axis=(0, 1), keepdims=True)
+    sigma = np.where(sigma > 1.0e-12, sigma, 1.0)
+    return (x - mu) / sigma
+
+
+def model_hidden_dim(model: str) -> int:
+    if model in {"gru_reservoir", "trained_rnn"}:
+        return 16
+    if model in {"gru_reservoir_wide", "trained_rnn_wide"}:
+        return 32
+    raise SystemExit(f"unknown generic recurrent baseline model: {model}")
+
+
+def is_reservoir_model(model: str) -> bool:
+    return model in {"gru_reservoir", "gru_reservoir_wide"}
+
+
+def is_trained_model(model: str) -> bool:
+    return model in {"trained_rnn", "trained_rnn_wide"}
+
+
+def init_weights(seed: int, input_dim: int, hidden_dim: int) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    in_scale = 1.0 / math.sqrt(max(1, input_dim))
+    hid_scale = 0.75 / math.sqrt(max(1, hidden_dim))
+    return {
+        "wz": rng.normal(0.0, in_scale, size=(input_dim, hidden_dim)),
+        "wr": rng.normal(0.0, in_scale, size=(input_dim, hidden_dim)),
+        "wn": rng.normal(0.0, in_scale, size=(input_dim, hidden_dim)),
+        "uz": rng.normal(0.0, hid_scale, size=(hidden_dim, hidden_dim)),
+        "ur": rng.normal(0.0, hid_scale, size=(hidden_dim, hidden_dim)),
+        "un": rng.normal(0.0, hid_scale, size=(hidden_dim, hidden_dim)),
+        "bz": rng.normal(0.0, 0.05, size=(hidden_dim,)),
+        "br": rng.normal(0.0, 0.05, size=(hidden_dim,)),
+        "bn": rng.normal(0.0, 0.05, size=(hidden_dim,)),
+    }
+
+
+def run_gru_reservoir(x: np.ndarray, seed: int, model: str) -> np.ndarray:
+    hidden_dim = model_hidden_dim(model)
+    weights = init_weights(seed, x.shape[2], hidden_dim)
+    h = np.zeros((x.shape[0], hidden_dim), dtype=float)
+    for step in range(x.shape[1]):
+        xt = x[:, step, :]
+        z = sigmoid(xt @ weights["wz"] + h @ weights["uz"] + weights["bz"])
+        r = sigmoid(xt @ weights["wr"] + h @ weights["ur"] + weights["br"])
+        n = np.tanh(xt @ weights["wn"] + (r * h) @ weights["un"] + weights["bn"])
+        h = (1.0 - z) * n + z * h
+    return h
+
+
+def init_rnn_params(seed: int, input_dim: int, hidden_dim: int) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    return {
+        "wxh": rng.normal(0.0, 1.0 / math.sqrt(max(1, input_dim)), size=(input_dim, hidden_dim)),
+        "whh": rng.normal(0.0, 0.45 / math.sqrt(max(1, hidden_dim)), size=(hidden_dim, hidden_dim)),
+        "b": np.zeros(hidden_dim, dtype=float),
+        "wo": rng.normal(0.0, 0.15 / math.sqrt(max(1, hidden_dim)), size=(hidden_dim,)),
+        "bo": np.zeros(1, dtype=float),
+    }
+
+
+def rnn_forward(x: np.ndarray, params: dict[str, np.ndarray]) -> tuple[np.ndarray, list[np.ndarray]]:
+    h = np.zeros((x.shape[0], params["b"].shape[0]), dtype=float)
+    states: list[np.ndarray] = []
+    for step in range(x.shape[1]):
+        h = np.tanh(x[:, step, :] @ params["wxh"] + h @ params["whh"] + params["b"])
+        states.append(h)
+    pred = states[-1] @ params["wo"] + float(params["bo"][0])
+    return pred, states
+
+
+def train_rnn_regressor(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    seed: int,
+    model: str,
+    epochs: int,
+    lr: float,
+    l2: float,
+) -> dict[str, np.ndarray]:
+    params = init_rnn_params(seed, x_train.shape[2], model_hidden_dim(model))
+    n = max(1, x_train.shape[0])
+    for _ in range(epochs):
+        pred, states = rnn_forward(x_train, params)
+        dy = (2.0 / n) * (pred - y_train)
+        grads = {
+            "wxh": np.zeros_like(params["wxh"]),
+            "whh": np.zeros_like(params["whh"]),
+            "b": np.zeros_like(params["b"]),
+            "wo": states[-1].T @ dy + l2 * params["wo"],
+            "bo": np.array([dy.sum()]),
+        }
+        dh = dy[:, None] * params["wo"][None, :]
+        for step in range(x_train.shape[1] - 1, -1, -1):
+            h = states[step]
+            h_prev = states[step - 1] if step > 0 else np.zeros_like(h)
+            da = dh * (1.0 - h * h)
+            grads["wxh"] += x_train[:, step, :].T @ da + l2 * params["wxh"]
+            grads["whh"] += h_prev.T @ da + l2 * params["whh"]
+            grads["b"] += da.sum(axis=0)
+            dh = da @ params["whh"].T
+        total_norm = math.sqrt(sum(float((grad * grad).sum()) for grad in grads.values()))
+        scale = 1.0 if total_norm <= 5.0 else 5.0 / total_norm
+        for key in params:
+            params[key] = params[key] - lr * scale * grads[key]
+    return params
+
+
+def trained_rnn_predictions(
+    manifest_rows: list[dict[str, str]],
+    x: np.ndarray,
+    models: list[str],
+    seeds: list[int],
+    phenotypes: list[str],
+    epochs: int,
+    lr: float,
+    l2: float,
+    null_permutations: int,
+    min_test_variance: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    summary: list[dict[str, Any]] = []
+    sites = sorted({row.get("site", "") for row in manifest_rows})
+    labels = [row.get("label", "") for row in manifest_rows]
+    subject_ids = [row.get("subject_id", str(idx)) for idx, row in enumerate(manifest_rows)]
+    for model in models:
+        for phenotype in phenotypes:
+            pooled_rows: list[dict[str, Any]] = []
+            for seed in seeds:
+                y_all: list[float] = []
+                pred_all: list[float] = []
+                seed_detail: list[dict[str, Any]] = []
+                null_spearman: list[float] = []
+                for site in sites:
+                    train_idx = [
+                        idx
+                        for idx, row in enumerate(manifest_rows)
+                        if row.get("site", "") != site and parse_float(row.get(phenotype, "")) is not None
+                    ]
+                    test_idx = [
+                        idx
+                        for idx, row in enumerate(manifest_rows)
+                        if row.get("site", "") == site and parse_float(row.get(phenotype, "")) is not None
+                    ]
+                    if len(train_idx) < 3 or not test_idx:
+                        continue
+                    y_train_raw = np.array([float(parse_float(manifest_rows[idx].get(phenotype, ""))) for idx in train_idx], dtype=float)
+                    y_test = [float(parse_float(manifest_rows[idx].get(phenotype, ""))) for idx in test_idx]
+                    if len(y_test) > 1 and statistics.pvariance(y_test) < min_test_variance:
+                        continue
+                    y_mu = float(y_train_raw.mean())
+                    y_sigma = float(y_train_raw.std())
+                    if y_sigma <= 1.0e-12:
+                        y_sigma = 1.0
+                    y_train = (y_train_raw - y_mu) / y_sigma
+                    params = train_rnn_regressor(x[train_idx], y_train, seed, model, epochs, lr, l2)
+                    pred_z, hidden_states = rnn_forward(x[test_idx], params)
+                    preds = (pred_z * y_sigma + y_mu).tolist()
+                    y_all.extend(y_test)
+                    pred_all.extend(float(value) for value in preds)
+                    for local_idx, subject_idx in enumerate(test_idx):
+                        seed_detail.append(
+                            {
+                                "model": model,
+                                "seed": seed,
+                                "phenotype": phenotype,
+                                "holdout_site": site,
+                                "subject_index": subject_idx,
+                                "subject_id": subject_ids[subject_idx],
+                                "site": site,
+                                "label": labels[subject_idx],
+                                "target": y_test[local_idx],
+                                "prediction": float(preds[local_idx]),
+                                "h_norm": float(np.linalg.norm(hidden_states[-1][local_idx])),
+                            }
+                        )
+                    if null_permutations > 0:
+                        rng = np.random.default_rng(seed * 4001 + len(phenotype) * 331 + len(site))
+                        for _ in range(null_permutations):
+                            shuffled = y_train.copy()
+                            rng.shuffle(shuffled)
+                            null_params = train_rnn_regressor(
+                                x[train_idx],
+                                shuffled,
+                                seed + 17017,
+                                model,
+                                max(1, epochs // 2),
+                                lr,
+                                l2,
+                            )
+                            null_pred_z, _ = rnn_forward(x[test_idx], null_params)
+                            null_preds = (null_pred_z * y_sigma + y_mu).tolist()
+                            null_spearman.append(spearman(y_test, [float(value) for value in null_preds]))
+                detail.extend(seed_detail)
+                if y_all:
+                    observed = spearman(y_all, pred_all)
+                    if null_spearman:
+                        ge = sum(1 for value in null_spearman if value >= observed)
+                        null_p_ge = (ge + 1.0) / (len(null_spearman) + 1.0)
+                        null_mean = mean(null_spearman)
+                        null_std = pstdev(null_spearman)
+                    else:
+                        null_p_ge = 1.0
+                        null_mean = 0.0
+                        null_std = 0.0
+                    pooled_rows.append(
+                        {
+                            "model": model,
+                            "seed": seed,
+                            "phenotype": phenotype,
+                            "surface": "trained_recurrent_prediction",
+                            "sites_evaluated": len({row["holdout_site"] for row in seed_detail}),
+                            "pooled_n": len(y_all),
+                            "pearson": pearson(y_all, pred_all),
+                            "spearman": observed,
+                            "r2": r2_score(y_all, pred_all),
+                            "null_permutations": len(null_spearman),
+                            "null_spearman_mean": null_mean,
+                            "null_spearman_std": null_std,
+                            "null_spearman_p_ge": null_p_ge,
+                            "null_mode": "phenotype_permutation_retrained_generic_recurrent_regressor",
+                        }
+                    )
+            for row in pooled_rows:
+                detail.append(row | {"holdout_site": "__pooled__"})
+            summary.append(
+                {
+                    "model": model,
+                    "phenotype": phenotype,
+                    "surface": "trained_recurrent_prediction",
+                    "seed_count": len(pooled_rows),
+                    "sites_evaluated_mean": mean([float(row["sites_evaluated"]) for row in pooled_rows]),
+                    "pooled_n_mean": mean([float(row["pooled_n"]) for row in pooled_rows]),
+                    "pearson_mean": mean([float(row["pearson"]) for row in pooled_rows]),
+                    "pearson_std": pstdev([float(row["pearson"]) for row in pooled_rows]),
+                    "spearman_mean": mean([float(row["spearman"]) for row in pooled_rows]),
+                    "spearman_std": pstdev([float(row["spearman"]) for row in pooled_rows]),
+                    "r2_mean": mean([float(row["r2"]) for row in pooled_rows]),
+                    "null_permutations_mean": mean([float(row["null_permutations"]) for row in pooled_rows]),
+                    "null_spearman_mean": mean([float(row["null_spearman_mean"]) for row in pooled_rows]),
+                    "null_spearman_p_ge_mean": mean([float(row["null_spearman_p_ge"]) for row in pooled_rows]),
+                    "canonical_metric": "pooled_per_seed_spearman_mean",
+                }
+            )
+    return summary, detail
+
+
+def build_rows(
+    manifest_rows: list[dict[str, str]],
+    x: np.ndarray,
+    models: list[str],
+    seeds: list[int],
+    phenotypes: list[str],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    feature_cols = [f"f{i}" for i in range(x.shape[1] * x.shape[2])]
+    for model in models:
+        for seed in seeds:
+            hidden = run_gru_reservoir(x, seed, model)
+            for idx, row in enumerate(manifest_rows):
+                out.append(
+                    {
+                        "model": model,
+                        "seed": seed,
+                        "subject_index": idx,
+                        "subject_id": row.get("subject_id", str(idx)),
+                        "site": row.get("site", ""),
+                        "label": row.get("label", ""),
+                        "h": hidden[idx].tolist(),
+                        "raw_features": vector_from_columns(row, feature_cols),
+                        "covariates": covariate_vector(row),
+                        "phenotypes": {name: parse_float(row.get(name, "")) for name in phenotypes},
+                    }
+                )
+    return out
+
+
+def run_probe(
+    rows: list[dict[str, Any]],
+    phenotypes: list[str],
+    surfaces: list[str],
+    l2: float,
+    null_permutations: int,
+    min_test_variance: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    summary: list[dict[str, Any]] = []
+    for model in sorted({row["model"] for row in rows}):
+        model_rows = [row for row in rows if row["model"] == model]
+        seeds = sorted({int(row["seed"]) for row in model_rows})
+        for phenotype in phenotypes:
+            for surface in surfaces:
+                fold_metrics: list[dict[str, Any]] = []
+                for seed in seeds:
+                    seed_rows = [row for row in model_rows if int(row["seed"]) == seed]
+                    sites = sorted({row["site"] for row in seed_rows})
+                    y_all: list[float] = []
+                    pred_all: list[float] = []
+                    for site in sites:
+                        train = [row for row in seed_rows if row["site"] != site and row["phenotypes"].get(phenotype) is not None]
+                        test = [row for row in seed_rows if row["site"] == site and row["phenotypes"].get(phenotype) is not None]
+                        if surface == "hidden":
+                            x_train_list = [row["h"] for row in train]
+                            x_test_list = [row["h"] for row in test]
+                        elif surface == "static_input_summary":
+                            train = [row for row in train if row["raw_features"] is not None]
+                            test = [row for row in test if row["raw_features"] is not None]
+                            x_train_list = [row["raw_features"] for row in train]
+                            x_test_list = [row["raw_features"] for row in test]
+                        elif surface == "covariates":
+                            train = [row for row in train if row["covariates"] is not None]
+                            test = [row for row in test if row["covariates"] is not None]
+                            x_train_list = [row["covariates"] for row in train]
+                            x_test_list = [row["covariates"] for row in test]
+                        else:
+                            raise SystemExit(f"unknown surface: {surface}")
+                        if len(train) < 3 or not test:
+                            continue
+                        y_train = np.array([float(row["phenotypes"][phenotype]) for row in train], dtype=float)
+                        y_test = [float(row["phenotypes"][phenotype]) for row in test]
+                        if len(y_test) > 1 and statistics.pvariance(y_test) < min_test_variance:
+                            continue
+                        preds = ridge_fit_predict(
+                            np.array(x_train_list, dtype=float),
+                            y_train,
+                            np.array(x_test_list, dtype=float),
+                            l2=l2,
+                        ).tolist()
+                        y_all.extend(y_test)
+                        pred_all.extend(float(value) for value in preds)
+                        fold_metrics.append(
+                            {
+                                "model": model,
+                                "seed": seed,
+                                "phenotype": phenotype,
+                                "surface": surface,
+                                "holdout_site": site,
+                                "train_n": len(train),
+                                "holdout_n": len(test),
+                                "pearson": pearson(y_test, preds),
+                                "spearman": spearman(y_test, preds),
+                                "r2": r2_score(y_test, preds),
+                            }
+                        )
+                    if y_all:
+                        observed_spearman = spearman(y_all, pred_all)
+                        null_spearman: list[float] = []
+                        if null_permutations > 0:
+                            rng = np.random.default_rng(seed * 1009 + len(phenotype) * 9176 + len(surface) * 131)
+                            for _ in range(null_permutations):
+                                null_y_all: list[float] = []
+                                null_pred_all: list[float] = []
+                                for site in sites:
+                                    train = [
+                                        row
+                                        for row in seed_rows
+                                        if row["site"] != site and row["phenotypes"].get(phenotype) is not None
+                                    ]
+                                    test = [
+                                        row
+                                        for row in seed_rows
+                                        if row["site"] == site and row["phenotypes"].get(phenotype) is not None
+                                    ]
+                                    if surface == "hidden":
+                                        x_train_list = [row["h"] for row in train]
+                                        x_test_list = [row["h"] for row in test]
+                                    elif surface == "static_input_summary":
+                                        train = [row for row in train if row["raw_features"] is not None]
+                                        test = [row for row in test if row["raw_features"] is not None]
+                                        x_train_list = [row["raw_features"] for row in train]
+                                        x_test_list = [row["raw_features"] for row in test]
+                                    elif surface == "covariates":
+                                        train = [row for row in train if row["covariates"] is not None]
+                                        test = [row for row in test if row["covariates"] is not None]
+                                        x_train_list = [row["covariates"] for row in train]
+                                        x_test_list = [row["covariates"] for row in test]
+                                    else:
+                                        raise SystemExit(f"unknown surface: {surface}")
+                                    if len(train) < 3 or not test:
+                                        continue
+                                    y_test = [float(row["phenotypes"][phenotype]) for row in test]
+                                    if len(y_test) > 1 and statistics.pvariance(y_test) < min_test_variance:
+                                        continue
+                                    y_train_values = np.array([float(row["phenotypes"][phenotype]) for row in train], dtype=float)
+                                    rng.shuffle(y_train_values)
+                                    preds = ridge_fit_predict(
+                                        np.array(x_train_list, dtype=float),
+                                        y_train_values,
+                                        np.array(x_test_list, dtype=float),
+                                        l2=l2,
+                                    ).tolist()
+                                    null_y_all.extend(y_test)
+                                    null_pred_all.extend(float(value) for value in preds)
+                                if null_y_all:
+                                    null_spearman.append(spearman(null_y_all, null_pred_all))
+                        if null_spearman:
+                            ge = sum(1 for value in null_spearman if value >= observed_spearman)
+                            null_p_ge = (ge + 1.0) / (len(null_spearman) + 1.0)
+                            null_mean = mean(null_spearman)
+                            null_std = pstdev(null_spearman)
+                        else:
+                            null_p_ge = 1.0
+                            null_mean = 0.0
+                            null_std = 0.0
+                        fold_metrics.append(
+                            {
+                                "model": model,
+                                "seed": seed,
+                                "phenotype": phenotype,
+                                "surface": surface,
+                                "holdout_site": "__pooled__",
+                                "train_n": 0,
+                                "holdout_n": len(y_all),
+                                "pearson": pearson(y_all, pred_all),
+                                "spearman": observed_spearman,
+                                "r2": r2_score(y_all, pred_all),
+                                "null_permutations": len(null_spearman),
+                                "null_spearman_mean": null_mean,
+                                "null_spearman_std": null_std,
+                                "null_spearman_p_ge": null_p_ge,
+                                "null_mode": "phenotype_permutation_train_only_frozen_generic_recurrent_state",
+                            }
+                        )
+                detail.extend(fold_metrics)
+                pooled = [row for row in fold_metrics if row["holdout_site"] == "__pooled__"]
+                site_rows = [row for row in fold_metrics if row["holdout_site"] != "__pooled__"]
+                summary.append(
+                    {
+                        "model": model,
+                        "phenotype": phenotype,
+                        "surface": surface,
+                        "seed_count": len(pooled),
+                        "sites_evaluated_mean": mean(
+                            [len({row["holdout_site"] for row in site_rows if row["seed"] == pooled_row["seed"]}) for pooled_row in pooled]
+                        ),
+                        "pooled_n_mean": mean([float(row["holdout_n"]) for row in pooled]),
+                        "pearson_mean": mean([float(row["pearson"]) for row in pooled]),
+                        "pearson_std": pstdev([float(row["pearson"]) for row in pooled]),
+                        "spearman_mean": mean([float(row["spearman"]) for row in pooled]),
+                        "spearman_std": pstdev([float(row["spearman"]) for row in pooled]),
+                        "r2_mean": mean([float(row["r2"]) for row in pooled]),
+                        "null_permutations_mean": mean([float(row.get("null_permutations", 0)) for row in pooled]),
+                        "null_spearman_mean": mean([float(row.get("null_spearman_mean", 0.0)) for row in pooled]),
+                        "null_spearman_p_ge_mean": mean([float(row.get("null_spearman_p_ge", 1.0)) for row in pooled]),
+                        "canonical_metric": "pooled_per_seed_spearman_mean",
+                    }
+                )
+    return summary, detail
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def export_dynamic_features(path: Path, rows: list[dict[str, Any]], phenotypes: list[str]) -> None:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        record: dict[str, Any] = {
+            "model": row["model"],
+            "seed": row["seed"],
+            "subject_index": row["subject_index"],
+            "subject_id": row["subject_id"],
+            "site": row["site"],
+            "label": row["label"],
+        }
+        for phenotype in phenotypes:
+            value = row["phenotypes"].get(phenotype)
+            record[phenotype] = "" if value is None else value
+        for idx, value in enumerate(row["h"]):
+            record[f"h{idx}"] = value
+        out.append(record)
+    write_tsv(path, out)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# ADHD-200 Generic Recurrent Baseline",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "This pilot baseline uses deterministic GRU-style recurrent reservoirs plus ridge readouts and optional small trained Elman-RNN regressors.",
+        "It is a generic non-hypercomplex control surface, not a full S4/Transformer baseline suite.",
+        "",
+        "| model | phenotype | surface | seeds | sites eval mean | pooled n mean | Spearman mean | null p>= mean | Pearson mean | R2 mean |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {model} | {phenotype} | {surface} | {seed_count} | {sites:.3f} | {pooled_n:.3f} | {spearman:.6f} | {null_p:.6f} | {pearson:.6f} | {r2:.6f} |".format(
+                model=row["model"],
+                phenotype=row["phenotype"],
+                surface=row["surface"],
+                seed_count=row["seed_count"],
+                sites=row["sites_evaluated_mean"],
+                pooled_n=row["pooled_n_mean"],
+                spearman=row["spearman_mean"],
+                null_p=row["null_spearman_p_ge_mean"],
+                pearson=row["pearson_mean"],
+                r2=row["r2_mean"],
+            )
+        )
+    lines.extend(["", f"State-probe claim boundary inherited for comparison: {STATE_PROBE_CLAIM_BOUNDARY}", ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--models", default="gru_reservoir,gru_reservoir_wide")
+    parser.add_argument("--seeds", default="55555,11111,99887,22222,44444,66666,77777,88888,33333,12321,24680,13579,54321,67890,11223,44567,77889,99001,31415,27182")
+    parser.add_argument("--primary-phenotypes", default="inattention,hyperactivity_impulsivity,adhd_total")
+    parser.add_argument("--surfaces", default="hidden,covariates,static_input_summary")
+    parser.add_argument("--trained-epochs", type=int, default=80)
+    parser.add_argument("--trained-lr", type=float, default=0.01)
+    parser.add_argument("--trained-l2", type=float, default=1.0e-4)
+    parser.add_argument("--l2", type=float, default=1.0)
+    parser.add_argument("--null-permutations", type=int, default=20)
+    parser.add_argument("--min-test-variance", type=float, default=1.0e-12)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    meta, manifest_rows = read_manifest(args.manifest)
+    seq_len = int(meta.get("seq_len", "8"))
+    input_dim = int(meta.get("input_dim", "8"))
+    phenotypes = [value.strip() for value in args.primary_phenotypes.split(",") if value.strip()]
+    surfaces = [value.strip() for value in args.surfaces.split(",") if value.strip()]
+    models = [value.strip() for value in args.models.split(",") if value.strip()]
+    seeds = [int(value.strip()) for value in args.seeds.split(",") if value.strip()]
+
+    unknown_models = [model for model in models if not (is_reservoir_model(model) or is_trained_model(model))]
+    if unknown_models:
+        raise SystemExit(f"unknown model(s): {','.join(unknown_models)}")
+
+    x = feature_matrix(manifest_rows, seq_len, input_dim)
+    reservoir_models = [model for model in models if is_reservoir_model(model)]
+    trained_models = [model for model in models if is_trained_model(model)]
+    rows: list[dict[str, Any]] = []
+    summary: list[dict[str, Any]] = []
+    detail: list[dict[str, Any]] = []
+    trained_summary: list[dict[str, Any]] = []
+    trained_detail: list[dict[str, Any]] = []
+    if reservoir_models:
+        rows = build_rows(manifest_rows, x, reservoir_models, seeds, phenotypes)
+        summary, detail = run_probe(rows, phenotypes, surfaces, args.l2, args.null_permutations, args.min_test_variance)
+        export_dynamic_features(output_dir / "adhd_generic_recurrent_dynamic_features.tsv", rows, phenotypes)
+    else:
+        (output_dir / "adhd_generic_recurrent_dynamic_features.tsv").write_text("", encoding="utf-8")
+    if trained_models:
+        trained_summary, trained_detail = trained_rnn_predictions(
+            manifest_rows,
+            x,
+            trained_models,
+            seeds,
+            phenotypes,
+            args.trained_epochs,
+            args.trained_lr,
+            args.trained_l2,
+            args.null_permutations,
+            args.min_test_variance,
+        )
+    write_tsv(output_dir / "adhd_generic_recurrent_baseline_summary.tsv", summary + trained_summary)
+    write_tsv(output_dir / "adhd_generic_recurrent_baseline_detail.tsv", detail)
+    write_tsv(output_dir / "adhd_trained_generic_recurrent_predictions.tsv", trained_detail)
+
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "manifest": str(args.manifest.resolve()),
+        "manifest_sha256": sha256(args.manifest),
+        "manifest_metadata": meta,
+        "subject_universe_sha256": meta.get("subject_universe_sha256", subject_universe_sha256(manifest_rows)),
+        "row_count": len(manifest_rows),
+        "seq_len": seq_len,
+        "input_dim": input_dim,
+        "models": models,
+        "reservoir_models": reservoir_models,
+        "trained_models": trained_models,
+        "seeds": seeds,
+        "primary_phenotypes": phenotypes,
+        "surfaces": surfaces,
+        "ridge_l2": args.l2,
+        "trained_epochs": args.trained_epochs,
+        "trained_lr": args.trained_lr,
+        "trained_l2": args.trained_l2,
+        "null_permutations_requested": args.null_permutations,
+        "null_modes": [
+            "phenotype_permutation_train_only_frozen_generic_recurrent_state",
+            "phenotype_permutation_retrained_generic_recurrent_regressor",
+        ],
+        "baseline_boundary": "Reservoir plus small trained RNN baselines; full S4/Transformer suite remains required before promotion-scale claims.",
+        "summary": summary + trained_summary,
+    }
+    (output_dir / "adhd_generic_recurrent_baseline.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (output_dir / "adhd_generic_recurrent_baseline.md").write_text(markdown(payload), encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/adhd200_manifest_readiness_gate.py
+++ b/scripts/research/adhd200_manifest_readiness_gate.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Readiness gate for rich ADHD-200 O-SSM manifests.
+
+This gate checks data support and feature sanity. It is not a model evaluation
+and makes no clinical claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.adhd200_manifest_readiness_gate.v1"
+CLAIM_BOUNDARY = (
+    "Dataset readiness only; no diagnostic, biomarker, mechanism, treatment, "
+    "or O-SSM superiority claim."
+)
+
+
+MISSING_TOKENS = {"", "na", "n/a", "nan", "none", "null", "-999", "-9999"}
+
+
+def is_missing(value: str) -> bool:
+    return value.strip().lower() in MISSING_TOKENS
+
+
+def parse_float(value: str) -> float | None:
+    if is_missing(value):
+        return None
+    try:
+        result = float(value)
+    except ValueError:
+        return None
+    if not math.isfinite(result):
+        return None
+    return result
+
+
+def read_manifest(path: Path) -> tuple[dict[str, str], list[dict[str, str]]]:
+    meta: dict[str, str] = {}
+    data_lines: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        if raw.startswith("#"):
+            body = raw[1:].strip()
+            if "=" in body:
+                key, value = body.split("=", 1)
+                meta[key.strip()] = value.strip()
+            continue
+        data_lines.append(raw)
+    if not data_lines:
+        raise SystemExit(f"manifest has no tabular rows: {path}")
+    reader = csv.DictReader(data_lines, delimiter="\t")
+    rows = list(reader)
+    return meta, rows
+
+
+def summarize_numeric(rows: list[dict[str, str]], column: str) -> dict[str, Any]:
+    values = [parse_float(row.get(column, "")) for row in rows]
+    valid = [value for value in values if value is not None]
+    distinct = len({round(value, 12) for value in valid})
+    missing = len(values) - len(valid)
+    if valid:
+        mean = sum(valid) / len(valid)
+        variance = sum((value - mean) * (value - mean) for value in valid) / len(valid)
+        min_value = min(valid)
+        max_value = max(valid)
+    else:
+        mean = variance = min_value = max_value = None
+    return {
+        "column": column,
+        "row_count": len(rows),
+        "valid_count": len(valid),
+        "missing_count": missing,
+        "missing_frac": missing / len(rows) if rows else 1.0,
+        "distinct_count": distinct,
+        "mean": mean,
+        "variance": variance,
+        "min": min_value,
+        "max": max_value,
+    }
+
+
+def summarize_numeric_by_site(rows: list[dict[str, str]], column: str) -> list[dict[str, Any]]:
+    by_site: dict[str, list[dict[str, str]]] = {}
+    for row in rows:
+        by_site.setdefault(row.get("site", ""), []).append(row)
+    return [summarize_numeric(site_rows, column) | {"site": site} for site, site_rows in sorted(by_site.items())]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument(
+        "--primary-phenotypes",
+        default="inattention,hyperactivity_impulsivity,adhd_total",
+        help="Comma-separated phenotype columns required for confirmatory readiness.",
+    )
+    parser.add_argument("--min-sites", type=int, default=2)
+    parser.add_argument("--min-class-count", type=int, default=1)
+    parser.add_argument("--max-primary-missing-frac", type=float, default=0.35)
+    parser.add_argument("--min-primary-distinct", type=int, default=3)
+    parser.add_argument("--min-feature-variance", type=float, default=1.0e-10)
+    parser.add_argument("--min-feature-nonzero-frac", type=float, default=0.01)
+    args = parser.parse_args()
+
+    meta, rows = read_manifest(args.manifest)
+    fieldnames = list(rows[0].keys()) if rows else []
+    required_base = ["subject_id", "label", "site"]
+    primary = [value.strip() for value in args.primary_phenotypes.split(",") if value.strip()]
+    feature_cols = [name for name in fieldnames if name.startswith("f") and name[1:].isdigit()]
+
+    failures: list[str] = []
+    for column in required_base:
+        if column not in fieldnames:
+            failures.append(f"missing_required_column:{column}")
+    if len(feature_cols) != 64:
+        failures.append(f"feature_column_count:{len(feature_cols)}")
+
+    label_counts = Counter(row.get("label", "") for row in rows)
+    site_counts = Counter(row.get("site", "") for row in rows)
+    if len(site_counts) < args.min_sites:
+        failures.append("site_count_below_minimum")
+    if label_counts.get("ADHD", 0) < args.min_class_count:
+        failures.append("adhd_count_below_minimum")
+    if label_counts.get("TD", 0) < args.min_class_count:
+        failures.append("td_count_below_minimum")
+
+    phenotype_summary = []
+    for column in primary:
+        if column not in fieldnames:
+            failures.append(f"missing_primary_phenotype:{column}")
+            phenotype_summary.append({"column": column, "present": False})
+            continue
+        summary = summarize_numeric(rows, column)
+        summary["present"] = True
+        summary["by_site"] = summarize_numeric_by_site(rows, column)
+        phenotype_summary.append(summary)
+        if summary["missing_frac"] > args.max_primary_missing_frac:
+            failures.append(f"primary_missingness_above_threshold:{column}")
+        if summary["distinct_count"] < args.min_primary_distinct:
+            failures.append(f"primary_distinct_below_minimum:{column}")
+        if summary["variance"] is None or summary["variance"] <= 0.0:
+            failures.append(f"primary_nonvarying:{column}")
+        for site_summary in summary["by_site"]:
+            if site_summary["valid_count"] == 0:
+                failures.append(f"primary_absent_in_site:{column}:{site_summary['site']}")
+            elif site_summary["distinct_count"] < 2:
+                failures.append(f"primary_nonvarying_in_site:{column}:{site_summary['site']}")
+
+    feature_values: list[float] = []
+    nonfinite_features = 0
+    for row in rows:
+        for column in feature_cols:
+            value = parse_float(row.get(column, ""))
+            if value is None:
+                nonfinite_features += 1
+            else:
+                feature_values.append(value)
+    if feature_values:
+        feature_mean = sum(feature_values) / len(feature_values)
+        feature_variance = sum((value - feature_mean) * (value - feature_mean) for value in feature_values) / len(feature_values)
+        feature_nonzero_frac = sum(1 for value in feature_values if abs(value) > 1.0e-12) / len(feature_values)
+    else:
+        feature_mean = 0.0
+        feature_variance = 0.0
+        feature_nonzero_frac = 0.0
+    if nonfinite_features:
+        failures.append("nonfinite_features")
+    if feature_variance < args.min_feature_variance:
+        failures.append("feature_variance_below_minimum")
+    if feature_nonzero_frac < args.min_feature_nonzero_frac:
+        failures.append("feature_nonzero_fraction_below_minimum")
+
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "manifest": str(args.manifest.resolve()),
+        "status": "fail" if failures else "pass",
+        "failures": failures,
+        "metadata": meta,
+        "row_count": len(rows),
+        "field_count": len(fieldnames),
+        "site_count": len(site_counts),
+        "site_counts": dict(sorted(site_counts.items())),
+        "label_counts": dict(sorted(label_counts.items())),
+        "primary_phenotypes": primary,
+        "phenotype_summary": phenotype_summary,
+        "feature_column_count": len(feature_cols),
+        "feature_value_count": len(feature_values) + nonfinite_features,
+        "finite_feature_value_count": len(feature_values),
+        "nonfinite_feature_value_count": nonfinite_features,
+        "feature_mean": feature_mean,
+        "feature_variance": feature_variance,
+        "feature_nonzero_frac": feature_nonzero_frac,
+        "thresholds": {
+            "min_sites": args.min_sites,
+            "min_class_count": args.min_class_count,
+            "max_primary_missing_frac": args.max_primary_missing_frac,
+            "min_primary_distinct": args.min_primary_distinct,
+            "min_feature_variance": args.min_feature_variance,
+            "min_feature_nonzero_frac": args.min_feature_nonzero_frac,
+        },
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if failures:
+        raise SystemExit("ADHD-200 manifest readiness gate failed: " + ",".join(failures))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/adhd200_pcp_pilot24_reproduce.sh
+++ b/scripts/research/adhd200_pcp_pilot24_reproduce.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage:
+  OUTPUT_ROOT=/tmp/adhd200_pcp_pilot24_bootstrap scripts/research/adhd200_pcp_pilot24_reproduce.sh
+
+This reproduces the bounded ADHD-200 PCP pilot-24 smoke used by the
+computational-psychiatry framework handoff. It is intentionally small and
+underpowered: its purpose is executable framework proof, not clinical evidence.
+
+Optional environment:
+  OUTPUT_ROOT              Default: /tmp/adhd200_pcp_pilot24_bootstrap
+  MAX_SUBJECTS             Default: 24
+  NULL_PERMUTATIONS        Default: 1
+  GENERIC_BASELINE_MODELS  Default: gru_reservoir,trained_rnn
+  GENERIC_BASELINE_SEEDS   Default: 55555,11111
+  GENERIC_TRAINED_EPOCHS   Default: 4
+  GLOBAL_TRAIN_EPOCHS      Default: 2
+  OCT_TRAIN_EPOCHS         Default: 2
+  H_TRAIN_EPOCHS           Default: 2
+  SOUNIO_SOUC_ENGINE       Default: lean_single
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/tmp/adhd200_pcp_pilot24_bootstrap}"
+MAX_SUBJECTS="${MAX_SUBJECTS:-24}"
+NULL_PERMUTATIONS="${NULL_PERMUTATIONS:-1}"
+GENERIC_BASELINE_MODELS="${GENERIC_BASELINE_MODELS:-gru_reservoir,trained_rnn}"
+GENERIC_BASELINE_SEEDS="${GENERIC_BASELINE_SEEDS:-55555,11111}"
+GENERIC_TRAINED_EPOCHS="${GENERIC_TRAINED_EPOCHS:-4}"
+GLOBAL_TRAIN_EPOCHS="${GLOBAL_TRAIN_EPOCHS:-2}"
+OCT_TRAIN_EPOCHS="${OCT_TRAIN_EPOCHS:-2}"
+H_TRAIN_EPOCHS="${H_TRAIN_EPOCHS:-2}"
+export SOUNIO_SOUC_ENGINE="${SOUNIO_SOUC_ENGINE:-lean_single}"
+
+python3 "$repo_root/scripts/research/adhd200_s3_bootstrap.py" \
+  --output-dir "$OUTPUT_ROOT" \
+  --max-subjects "$MAX_SUBJECTS" \
+  --overwrite
+
+python3 "$repo_root/scripts/research/adhd200_data_access_audit.py" \
+  --phenotypic-csv "$OUTPUT_ROOT/adhd200_phenotypic.csv" \
+  --roi-dir "$OUTPUT_ROOT/rois" \
+  --output-dir "$OUTPUT_ROOT/access_audit" \
+  --overwrite
+
+PHENOTYPIC_CSV="$OUTPUT_ROOT/adhd200_phenotypic.csv" \
+ROI_DIR="$OUTPUT_ROOT/rois" \
+OUTPUT_DIR="$OUTPUT_ROOT/pilot_real24" \
+NULL_PERMUTATIONS="$NULL_PERMUTATIONS" \
+GENERIC_BASELINE_MODELS="$GENERIC_BASELINE_MODELS" \
+GENERIC_BASELINE_SEEDS="$GENERIC_BASELINE_SEEDS" \
+GENERIC_TRAINED_EPOCHS="$GENERIC_TRAINED_EPOCHS" \
+GLOBAL_TRAIN_EPOCHS="$GLOBAL_TRAIN_EPOCHS" \
+OCT_TRAIN_EPOCHS="$OCT_TRAIN_EPOCHS" \
+H_TRAIN_EPOCHS="$H_TRAIN_EPOCHS" \
+SOUNIO_SOUC_ENGINE="$SOUNIO_SOUC_ENGINE" \
+"$repo_root/scripts/research/adhd200_dimensional_pilot_smoke.sh"
+
+printf 'ADHD-200 PCP pilot-24 reproduction complete: %s\n' "$OUTPUT_ROOT/pilot_real24"

--- a/scripts/research/adhd200_prepare_manifest.py
+++ b/scripts/research/adhd200_prepare_manifest.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""Prepare an ADHD-200 dimensional O-SSM manifest from phenotypic and ROI data.
+
+The rich manifest is the phenotype/readiness source of truth. The optional
+O-SSM compatibility view intentionally drops dimensional phenotype columns so
+current Sounio model readers can consume the same feature rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import os
+import sys
+import urllib.request
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy import linalg
+
+
+SCHEMA = "neurodyn.adhd200_dimensional_manifest.v1"
+OSSM_VIEW_SCHEMA = "neurodyn.adhd200_ossm_compat_manifest.v1"
+CLAIM_BOUNDARY = (
+    "Dataset preparation only; no diagnostic, biomarker, mechanism, treatment, "
+    "or O-SSM superiority claim."
+)
+
+N_EIGVECS = 7
+N_ROIS_TARGET = 200
+N_STEPS = 8
+N_DIMS = 8
+N_FEATURES = 64
+MISSING_TOKENS = {"", "na", "n/a", "nan", "none", "null", "-999", "-9999"}
+
+
+COLUMN_ALIASES = {
+    "subject_id": [
+        "subject_id",
+        "sub_id",
+        "subject",
+        "participant_id",
+        "scan_dir_id",
+        "scandirid",
+        "scan_dir id",
+        "ScanDir ID",
+        "scanid",
+        "id",
+    ],
+    "file_id": [
+        "file_id",
+        "fileid",
+        "filename",
+        "scan_dir_id",
+        "scandirid",
+        "scan_dir id",
+        "ScanDir ID",
+        "scanid",
+        "subject_id",
+        "participant_id",
+    ],
+    "site": [
+        "site",
+        "site_id",
+        "siteid",
+        "scan_site",
+        "data_set",
+        "dataset",
+    ],
+    "diagnosis": [
+        "dx",
+        "dx_group",
+        "diagnosis",
+        "adhd",
+        "adhd_diagnosis",
+        "diagnostic_status",
+    ],
+    "inattention": [
+        "inattention",
+        "inattentive",
+        "adhd_inattentive",
+        "adhd_inattention",
+        "adhd_rs_inattention",
+        "adhd_rs_iv_inattention",
+        "adhd_inattentive_score",
+        "conners_inattention",
+    ],
+    "hyperactivity_impulsivity": [
+        "hyperactivity_impulsivity",
+        "hyper_impulsive",
+        "hyperactive_impulsive",
+        "hyperactivity",
+        "impulsivity",
+        "adhd_hyperactivity",
+        "adhd_hyper_impulsive",
+        "adhd_rs_hyperactivity_impulsivity",
+        "adhd_rs_iv_hyperactivity_impulsivity",
+        "conners_hyperactivity",
+    ],
+    "adhd_total": [
+        "adhd_total",
+        "adhd_index",
+        "adhd index",
+        "adhd_index_score",
+        "adhd_rs_total",
+        "adhd_rs_iv_total",
+        "conners_adhd_index",
+        "total",
+    ],
+    "age": ["age", "age_at_scan", "age_years"],
+    "sex": ["sex", "gender"],
+    "iq": ["iq", "fiq", "full_scale_iq", "fullscale_iq", "full2_iq", "full4_iq", "Full2 IQ", "Full4 IQ"],
+    "medication_status": [
+        "medication_status",
+        "med_status",
+        "current_med_status",
+        "medicated",
+        "lifetime_med_status",
+    ],
+    "qc_status": [
+        "qc_status",
+        "qc",
+        "quality_control",
+        "qc_rater",
+        "func_quality",
+    ],
+    "mean_fd": [
+        "mean_fd",
+        "func_mean_fd",
+        "motion_mean_fd",
+        "fd",
+    ],
+}
+
+
+def normalize_name(name: str) -> str:
+    return "".join(ch.lower() for ch in name.strip() if ch.isalnum())
+
+
+def is_missing(value: Any) -> bool:
+    return str(value).strip().lower() in MISSING_TOKENS
+
+
+def parse_float(value: Any) -> float | None:
+    if is_missing(value):
+        return None
+    try:
+        result = float(str(value).strip())
+    except ValueError:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def discover_columns(fieldnames: list[str]) -> dict[str, str | None]:
+    by_norm = {normalize_name(name): name for name in fieldnames}
+    result: dict[str, str | None] = {}
+    for logical, aliases in COLUMN_ALIASES.items():
+        result[logical] = None
+        for alias in aliases:
+            found = by_norm.get(normalize_name(alias))
+            if found:
+                result[logical] = found
+                break
+    return result
+
+
+def read_csv_rows(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        sample = handle.read(4096)
+        handle.seek(0)
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=",\t")
+        except csv.Error:
+            dialect = csv.excel
+        reader = csv.DictReader(handle, dialect=dialect)
+        if not reader.fieldnames:
+            raise SystemExit(f"phenotypic CSV has no header: {path}")
+        return list(reader.fieldnames), list(reader)
+
+
+def diagnosis_label(value: Any) -> str | None:
+    text = str(value).strip()
+    low = text.lower()
+    if is_missing(text):
+        return None
+    if low in {"td", "tdc", "control", "typically developing", "healthy", "0", "2"}:
+        return "TD"
+    if low in {"adhd", "adhd-c", "adhd-i", "adhd-h", "combined", "inattentive", "hyperactive", "1", "3"}:
+        return "ADHD"
+    numeric = parse_float(text)
+    if numeric is not None:
+        if int(numeric) == 0 or int(numeric) == 2:
+            return "TD"
+        if int(numeric) in {1, 3}:
+            return "ADHD"
+    return None
+
+
+def ossm_label(label: str) -> str:
+    if label == "ADHD":
+        return "1"
+    if label == "TD":
+        return "0"
+    raise SystemExit(f"unsupported O-SSM compatibility label: {label}")
+
+
+def download_file(url: str, path: Path) -> bool:
+    if path.exists() and path.stat().st_size > 0:
+        return True
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        urllib.request.urlretrieve(url, path)
+        return True
+    except Exception as exc:  # pragma: no cover - network failure path
+        print(f"download failed: {url}: {exc}", file=sys.stderr)
+        return False
+
+
+def candidate_roi_paths(roi_dir: Path, file_id: str, subject_id: str) -> list[Path]:
+    candidates = []
+    names = []
+    for stem in [file_id, subject_id, f"sub-{subject_id}", f"sub_{subject_id}"]:
+        if stem and stem not in names:
+            names.append(stem)
+    suffixes = [
+        "",
+        "_rois_cc200.1D",
+        "_rois_aal.1D",
+        ".1D",
+        "_timeseries.tsv",
+        "_timeseries.txt",
+        ".tsv",
+        ".txt",
+        ".csv",
+    ]
+    for stem in names:
+        for suffix in suffixes:
+            path = roi_dir / f"{stem}{suffix}"
+            if path.exists() and path.is_file():
+                candidates.append(path)
+    return candidates
+
+
+def load_timeseries(path: Path) -> np.ndarray | None:
+    try:
+        delimiter = "," if path.suffix.lower() == ".csv" else None
+        data = np.loadtxt(path, delimiter=delimiter, comments="#")
+    except Exception:
+        return None
+    if data.ndim != 2 or data.shape[0] < 20 or data.shape[1] < 8:
+        return None
+    return data
+
+
+def extract_eigenvectors(ts: np.ndarray) -> tuple[np.ndarray, int, int] | None:
+    try:
+        n_rois = ts.shape[1]
+        n_timepoints = ts.shape[0]
+        with np.errstate(divide="ignore", invalid="ignore"):
+            corr = np.corrcoef(ts.T)
+        corr = np.nan_to_num(corr, nan=0.0, posinf=0.0, neginf=0.0)
+        np.fill_diagonal(corr, 0.0)
+        adj = np.maximum(corr, 0.0)
+        deg = adj.sum(axis=1)
+        laplacian = np.diag(deg) - adj
+        eigenvalues, eigenvectors = linalg.eigh(laplacian)
+        if len(eigenvalues) < N_EIGVECS + 1:
+            return None
+        return eigenvectors[:, 1 : N_EIGVECS + 1].T, n_rois, n_timepoints
+    except Exception:
+        return None
+
+
+def eigvecs_to_features(evecs: np.ndarray, n_rois: int) -> np.ndarray:
+    if evecs.shape[0] < N_STEPS:
+        padded = np.zeros((N_STEPS, evecs.shape[1]))
+        padded[: evecs.shape[0], :] = evecs
+        evecs = padded
+    if n_rois < N_ROIS_TARGET:
+        padded = np.zeros((N_STEPS, N_ROIS_TARGET))
+        padded[:, :n_rois] = evecs[:, :n_rois]
+        evecs = padded
+    elif n_rois > N_ROIS_TARGET:
+        evecs = evecs[:, :N_ROIS_TARGET]
+    block_size = N_ROIS_TARGET // N_DIMS
+    features = np.zeros((N_STEPS, N_DIMS))
+    for dim in range(N_DIMS):
+        start = dim * block_size
+        end = start + block_size
+        features[:, dim] = evecs[:, start:end].mean(axis=1)
+    max_abs = np.abs(features).max()
+    if max_abs > 1.0e-12:
+        features = features / max_abs
+    return features.flatten()
+
+
+def timeseries_to_temporal_block_features(ts: np.ndarray) -> np.ndarray:
+    n_timepoints, n_rois = ts.shape
+    if n_rois < N_ROIS_TARGET:
+        padded = np.zeros((n_timepoints, N_ROIS_TARGET))
+        padded[:, :n_rois] = ts[:, :n_rois]
+        ts = padded
+    elif n_rois > N_ROIS_TARGET:
+        ts = ts[:, :N_ROIS_TARGET]
+
+    means = ts.mean(axis=0, keepdims=True)
+    stds = ts.std(axis=0, keepdims=True)
+    stds = np.where(stds > 1.0e-12, stds, 1.0)
+    zts = (ts - means) / stds
+
+    block_size = N_ROIS_TARGET // N_DIMS
+    features = np.zeros((N_STEPS, N_DIMS))
+    edges = np.linspace(0, n_timepoints, N_STEPS + 1, dtype=int)
+    for step in range(N_STEPS):
+        start = int(edges[step])
+        end = int(edges[step + 1])
+        if end <= start:
+            end = min(n_timepoints, start + 1)
+        window = zts[start:end, :]
+        for dim in range(N_DIMS):
+            roi_start = dim * block_size
+            roi_end = roi_start + block_size
+            features[step, dim] = float(window[:, roi_start:roi_end].mean())
+
+    max_abs = np.abs(features).max()
+    if max_abs > 1.0e-12:
+        features = features / max_abs
+    return features.flatten()
+
+
+def canonical_value(row: dict[str, str], columns: dict[str, str | None], logical: str) -> str:
+    column = columns.get(logical)
+    if not column:
+        return ""
+    value = row.get(column, "")
+    return "" if is_missing(value) else str(value).strip()
+
+
+def numeric_text(row: dict[str, str], columns: dict[str, str | None], logical: str) -> str:
+    value = parse_float(canonical_value(row, columns, logical))
+    return "" if value is None else f"{value:.8g}"
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str], meta: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        for key, value in meta.items():
+            handle.write(f"# {key}={value}\n")
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def subject_universe_sha256(rows: list[dict[str, Any]]) -> str:
+    """Hash ordered subject_id/label/site rows; keep in sync with the probe."""
+    h = hashlib.sha256()
+    for row in rows:
+        h.update(str(row["subject_id"]).encode("utf-8"))
+        h.update(b"\t")
+        h.update(str(row["label"]).encode("utf-8"))
+        h.update(b"\t")
+        h.update(str(row["site"]).encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--phenotypic-csv", type=Path, default=None)
+    parser.add_argument("--phenotypic-url", default="")
+    parser.add_argument("--roi-dir", type=Path, default=None)
+    parser.add_argument("--download-derivatives", action="store_true")
+    parser.add_argument(
+        "--derivative-url-template",
+        default="",
+        help="Template containing {file_id} and/or {subject_id}; required with --download-derivatives.",
+    )
+    parser.add_argument("--max-subjects", type=int, default=0)
+    parser.add_argument("--skip-download", action="store_true")
+    parser.add_argument("--write-ossm-view", action="store_true")
+    parser.add_argument("--allow-missing-primary", action="store_true")
+    parser.add_argument("--sampling-mode", choices=["ordered", "site_balanced"], default="site_balanced")
+    parser.add_argument(
+        "--feature-mode",
+        choices=["temporal_roi_block", "laplacian_eigenblock"],
+        default="temporal_roi_block",
+        help="Default preserves an 8-step temporal sequence; laplacian mode is a static-summary ablation.",
+    )
+    parser.add_argument("--primary-phenotypes", default="inattention,hyperactivity_impulsivity,adhd_total")
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir = args.output_dir / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.phenotypic_csv:
+        pheno_path = args.phenotypic_csv
+        if not pheno_path.exists():
+            raise SystemExit(f"phenotypic CSV not found: {pheno_path}")
+        phenotypic_source = str(pheno_path)
+    else:
+        pheno_path = cache_dir / "phenotypic.csv"
+        phenotypic_source = args.phenotypic_url or "manual_required"
+        if args.skip_download:
+            raise SystemExit("no --phenotypic-csv supplied and --skip-download is set")
+        if not args.phenotypic_url:
+            raise SystemExit("no public ADHD-200 phenotypic URL configured; pass --phenotypic-csv")
+        if not download_file(args.phenotypic_url, pheno_path):
+            raise SystemExit("failed to download phenotypic CSV; pass --phenotypic-csv after manual access")
+
+    roi_dir = args.roi_dir if args.roi_dir else cache_dir
+    if args.download_derivatives and not args.derivative_url_template:
+        raise SystemExit("--download-derivatives requires --derivative-url-template")
+
+    fieldnames, pheno_rows = read_csv_rows(pheno_path)
+    columns = discover_columns(fieldnames)
+    for logical in ["subject_id", "site", "diagnosis"]:
+        if not columns.get(logical):
+            raise SystemExit(f"could not identify required phenotypic column: {logical}")
+
+    primary = [value.strip() for value in args.primary_phenotypes.split(",") if value.strip()]
+    missing_primary = [logical for logical in primary if not columns.get(logical)]
+    if missing_primary and not args.allow_missing_primary:
+        raise SystemExit(
+            "missing primary phenotype columns: "
+            + ",".join(missing_primary)
+            + " (use --allow-missing-primary for readiness-only manifests)"
+        )
+
+    prepared: list[dict[str, Any]] = []
+    skipped = Counter()
+    for row in pheno_rows:
+        subject_id = canonical_value(row, columns, "subject_id")
+        file_id = canonical_value(row, columns, "file_id") or subject_id
+        site = canonical_value(row, columns, "site") or "UNKNOWN_SITE"
+        label = diagnosis_label(canonical_value(row, columns, "diagnosis"))
+        if not subject_id:
+            skipped["missing_subject_id"] += 1
+            continue
+        if label not in {"ADHD", "TD"}:
+            skipped["missing_or_unknown_label"] += 1
+            continue
+
+        paths = candidate_roi_paths(roi_dir, file_id, subject_id)
+        if not paths and args.download_derivatives:
+            target = roi_dir / f"{file_id}_rois_cc200.1D"
+            url = args.derivative_url_template.format(file_id=file_id, subject_id=subject_id)
+            if download_file(url, target):
+                paths = [target]
+        if not paths:
+            skipped["missing_roi"] += 1
+            continue
+
+        ts = None
+        ts_path = None
+        for candidate in paths:
+            ts = load_timeseries(candidate)
+            if ts is not None:
+                ts_path = candidate
+                break
+        if ts is None or ts_path is None:
+            skipped["unreadable_roi"] += 1
+            continue
+        n_rois = int(ts.shape[1])
+        n_timepoints = int(ts.shape[0])
+        if args.feature_mode == "laplacian_eigenblock":
+            extracted = extract_eigenvectors(ts)
+            if extracted is None:
+                skipped["feature_extraction_failed"] += 1
+                continue
+            evecs, n_rois, n_timepoints = extracted
+            features = eigvecs_to_features(evecs, n_rois)
+            feature_layout = "8x8_laplacian_eigenblock"
+        else:
+            features = timeseries_to_temporal_block_features(ts)
+            feature_layout = "8x8_temporal_roi_block"
+        record: dict[str, Any] = {
+            "subject_id": subject_id,
+            "label": label,
+            "site": site,
+            "inattention": numeric_text(row, columns, "inattention"),
+            "hyperactivity_impulsivity": numeric_text(row, columns, "hyperactivity_impulsivity"),
+            "adhd_total": numeric_text(row, columns, "adhd_total"),
+            "age": numeric_text(row, columns, "age"),
+            "sex": canonical_value(row, columns, "sex"),
+            "iq": numeric_text(row, columns, "iq"),
+            "medication_status": canonical_value(row, columns, "medication_status"),
+            "qc_status": canonical_value(row, columns, "qc_status"),
+            "mean_fd": numeric_text(row, columns, "mean_fd"),
+            "source_file_id": file_id,
+            "roi_path": str(ts_path),
+            "n_rois": n_rois,
+            "n_timepoints": n_timepoints,
+        }
+        for idx, value in enumerate(features):
+            record[f"f{idx}"] = f"{value:.8f}"
+        prepared.append(record)
+        if args.max_subjects > 0 and len(prepared) >= args.max_subjects:
+            break
+
+    if args.sampling_mode == "site_balanced":
+        by_site_label: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for record in prepared:
+            by_site_label[(str(record["site"]), str(record["label"]))].append(record)
+        selected: list[dict[str, Any]] = []
+        for site in sorted({str(record["site"]) for record in prepared}):
+            n = min(len(by_site_label[(site, "ADHD")]), len(by_site_label[(site, "TD")]))
+            selected.extend(by_site_label[(site, "ADHD")][:n])
+            selected.extend(by_site_label[(site, "TD")][:n])
+        prepared = selected
+
+    if not prepared:
+        raise SystemExit("no subjects processed; check phenotypic fields, ROI cache, and access settings")
+    universe_hash = subject_universe_sha256(prepared)
+
+    rich_fields = [
+        "subject_id",
+        "label",
+        "site",
+        "inattention",
+        "hyperactivity_impulsivity",
+        "adhd_total",
+        "age",
+        "sex",
+        "iq",
+        "medication_status",
+        "qc_status",
+        "mean_fd",
+        "source_file_id",
+        "roi_path",
+        "n_rois",
+        "n_timepoints",
+    ] + [f"f{i}" for i in range(N_FEATURES)]
+    meta = {
+        "schema": SCHEMA,
+        "seq_len": str(N_STEPS),
+        "input_dim": str(N_DIMS),
+        "feature_layout": feature_layout,
+        "feature_mode": args.feature_mode,
+        "label_space": "adhd_vs_td_for_stratification_only",
+        "primary_phenotypes": ",".join(primary),
+        "split_policy": "leave_one_site_out",
+        "sampling_mode": args.sampling_mode,
+        "phenotypic_source": phenotypic_source,
+        "subject_universe_sha256": universe_hash,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    manifest_path = args.output_dir / "adhd200_roi_manifest.tsv"
+    write_tsv(manifest_path, prepared, rich_fields, meta)
+
+    ossm_view_path = None
+    if args.write_ossm_view:
+        ossm_fields = ["subject_id", "label", "site"] + [f"f{i}" for i in range(N_FEATURES)]
+        ossm_rows = []
+        for row in prepared:
+            view_row = dict(row)
+            view_row["label"] = ossm_label(str(row["label"]))
+            ossm_rows.append(view_row)
+        ossm_meta = {
+            "schema": OSSM_VIEW_SCHEMA,
+            "seq_len": str(N_STEPS),
+            "input_dim": str(N_DIMS),
+            "feature_layout": feature_layout,
+            "feature_mode": args.feature_mode,
+            "label_space": "1_ADHD_0_TD_for_model_smoke_only",
+            "label_encoding": "1=ADHD;0=TD",
+            "split_policy": "leave_one_site_out",
+            "source_manifest": str(manifest_path),
+            "subject_universe_sha256": universe_hash,
+            "claim_boundary": CLAIM_BOUNDARY,
+        }
+        ossm_view_path = args.output_dir / "adhd200_ossm_manifest.tsv"
+        write_tsv(ossm_view_path, ossm_rows, ossm_fields, ossm_meta)
+
+    summary = {
+        "schema": "neurodyn.adhd200_prepare_manifest.summary.v1",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "manifest": str(manifest_path),
+        "ossm_view": str(ossm_view_path) if ossm_view_path else None,
+        "phenotypic_source": phenotypic_source,
+        "roi_dir": str(roi_dir),
+        "column_mapping": columns,
+        "missing_primary_columns": missing_primary,
+        "processed_subjects": len(prepared),
+        "subject_universe_sha256": universe_hash,
+        "site_counts": dict(sorted(Counter(str(row["site"]) for row in prepared).items())),
+        "label_counts": dict(sorted(Counter(str(row["label"]) for row in prepared).items())),
+        "skipped": dict(sorted(skipped.items())),
+    }
+    summary_path = args.output_dir / "adhd200_prepare_manifest_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/adhd200_s3_bootstrap.py
+++ b/scripts/research/adhd200_s3_bootstrap.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Bootstrap a bounded ADHD-200 PCP/S3 pilot cache.
+
+The public FCP-INDI bucket exposes ADHD-200 phenotypic CSVs and C-PAC ROI
+timeseries. This helper downloads small phenotypic tables plus a deliberately
+bounded CC200 ROI subset and rewrites the ROI filenames into the local
+`<ScanDir ID>_rois_cc200.1D` convention consumed by adhd200_prepare_manifest.py.
+
+It is not a full cohort downloader unless --allow-full-download is explicit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.adhd200_s3_bootstrap.v1"
+CLAIM_BOUNDARY = (
+    "Data acquisition bootstrap only; no diagnostic, biomarker, mechanism, "
+    "treatment, or O-SSM superiority claim."
+)
+S3_BUCKET_URL = "https://s3.amazonaws.com/fcp-indi"
+S3_XML_NS = {"s": "http://s3.amazonaws.com/doc/2006-03-01/"}
+PHENO_PREFIX = "data/Projects/ADHD200/RawData/"
+DEFAULT_PIPELINE = "pipeline_adhd200-benchmark__freq-filter"
+DEFAULT_REGRESSOR = "_compcor_ncomponents_5_selector_pc10.linear1.wm0.global0.motion1.quadratic1.gm0.compcor1.csf0"
+DEFAULT_BANDPASS = "_bandpass_freqs_0.01.0.1"
+
+
+def s3_url(key: str) -> str:
+    return f"{S3_BUCKET_URL}/{urllib.parse.quote(key)}"
+
+
+def list_s3(prefix: str, max_keys: int = 1000) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode({"list-type": "2", "prefix": prefix, "max-keys": str(max_keys)})
+    request = urllib.request.Request(
+        f"{S3_BUCKET_URL}?{query}",
+        headers={"User-Agent": "sounio-adhd200-s3-bootstrap/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        root = ET.fromstring(response.read())
+    rows = []
+    for item in root.findall("s:Contents", S3_XML_NS):
+        key = item.findtext("s:Key", default="", namespaces=S3_XML_NS)
+        size = int(item.findtext("s:Size", default="0", namespaces=S3_XML_NS) or 0)
+        if key:
+            rows.append({"key": key, "size": size})
+    return rows
+
+
+def list_s3_prefixes(prefix: str, max_keys: int = 1000) -> list[str]:
+    query = urllib.parse.urlencode(
+        {"list-type": "2", "prefix": prefix, "delimiter": "/", "max-keys": str(max_keys)}
+    )
+    request = urllib.request.Request(
+        f"{S3_BUCKET_URL}?{query}",
+        headers={"User-Agent": "sounio-adhd200-s3-bootstrap/1.0"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        root = ET.fromstring(response.read())
+    return [
+        item.findtext("s:Prefix", default="", namespaces=S3_XML_NS)
+        for item in root.findall("s:CommonPrefixes", S3_XML_NS)
+        if item.findtext("s:Prefix", default="", namespaces=S3_XML_NS)
+    ]
+
+
+def download_file(key: str, path: Path) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.stat().st_size > 0:
+        data = path.read_bytes()
+        return {"key": key, "path": str(path), "bytes": len(data), "sha256": hashlib.sha256(data).hexdigest(), "cached": True}
+    request = urllib.request.Request(s3_url(key), headers={"User-Agent": "sounio-adhd200-s3-bootstrap/1.0"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        data = response.read()
+    path.write_bytes(data)
+    return {"key": key, "path": str(path), "bytes": len(data), "sha256": hashlib.sha256(data).hexdigest(), "cached": False}
+
+
+def is_missing(value: Any) -> bool:
+    return str(value).strip().lower() in {"", "na", "n/a", "nan", "none", "null", "-999", "-9999"}
+
+
+def diagnosis_label(value: Any) -> str:
+    text = str(value).strip()
+    if text in {"0", "2"}:
+        return "TD"
+    if text in {"1", "3"}:
+        return "ADHD"
+    return ""
+
+
+def read_phenotypic(path: Path, source_key: str) -> list[dict[str, str]]:
+    rows = []
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            scan_id = str(row.get("ScanDir ID", "")).strip()
+            label = diagnosis_label(row.get("DX", ""))
+            if not scan_id or not label:
+                continue
+            row = dict(row)
+            row["source_phenotypic_key"] = source_key
+            row["source_site_name"] = Path(source_key).name.replace("_phenotypic.csv", "")
+            rows.append(row)
+    return rows
+
+
+def has_primary(row: dict[str, str]) -> bool:
+    return not any(is_missing(row.get(name, "")) for name in ["Inattentive", "Hyper/Impulsive", "ADHD Index"])
+
+
+def select_rows(rows: list[dict[str, str]], max_subjects: int, available_scan_ids: set[str]) -> list[dict[str, str]]:
+    by_site_label: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
+    for row in rows:
+        if not has_primary(row):
+            continue
+        scan_id = str(row.get("ScanDir ID", "")).strip()
+        if available_scan_ids and scan_id not in available_scan_ids:
+            continue
+        label = diagnosis_label(row.get("DX", ""))
+        site = row.get("source_site_name", row.get("Site", "UNKNOWN_SITE"))
+        by_site_label[(site, label)].append(row)
+    selected = []
+    target = max_subjects if max_subjects > 0 else sum(len(v) for v in by_site_label.values())
+    while len(selected) < target:
+        progressed = False
+        for site in sorted({key[0] for key in by_site_label}):
+            for label in ["ADHD", "TD"]:
+                bucket = by_site_label[(site, label)]
+                if bucket:
+                    selected.append(bucket.pop(0))
+                    progressed = True
+                    if len(selected) >= target:
+                        break
+            if len(selected) >= target:
+                break
+        if not progressed:
+            break
+    return selected
+
+
+def available_subjects_for_pipeline(pipeline: str) -> set[str]:
+    prefix = f"data/Projects/ADHD200/Outputs/cpac/raw_outputs/{pipeline}/"
+    subjects = set()
+    for item in list_s3_prefixes(prefix, max_keys=1000):
+        leaf = item.rstrip("/").split("/")[-1]
+        if leaf.endswith("_session_1"):
+            subjects.add(leaf[: -len("_session_1")])
+    return subjects
+
+
+def roi_key_for(scan_id: str, pipeline: str, regressor: str, bandpass: str) -> str:
+    parts = [
+        "data/Projects/ADHD200/Outputs/cpac/raw_outputs",
+        pipeline,
+        f"{scan_id}_session_1",
+        "roi_timeseries",
+        "_scan_rest_1",
+        "_csf_threshold_0.96",
+        "_gm_threshold_0.7",
+        "_wm_threshold_0.96",
+        regressor,
+    ]
+    if bandpass:
+        parts.append(bandpass)
+    parts.extend(["_mask_CC200", "roi_CC200.1D"])
+    return "/".join(parts)
+
+
+def write_merged_phenotypic(path: Path, rows: list[dict[str, str]]) -> None:
+    fields = [
+        "ScanDir ID",
+        "Site",
+        "Gender",
+        "Age",
+        "DX",
+        "ADHD Index",
+        "Inattentive",
+        "Hyper/Impulsive",
+        "Full2 IQ",
+        "Full4 IQ",
+        "Med Status",
+        "QC_Rest_1",
+        "source_site_name",
+        "source_phenotypic_key",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_readme(path: Path, summary: dict[str, Any]) -> None:
+    lines = [
+        "# ADHD-200 S3 Bootstrap",
+        "",
+        f"Status: `{summary['status']}`",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Outputs",
+        "",
+        f"- Phenotypic CSV: `{summary['outputs']['phenotypic_csv']}`",
+        f"- ROI dir: `{summary['outputs']['roi_dir']}`",
+        f"- Downloaded ROI files: {summary['downloaded_roi_count']}",
+        "",
+        "## Next Command",
+        "",
+        "```bash",
+        summary.get("next_command", ""),
+        "```",
+        "",
+        "## Notes",
+        "",
+        "- Source bucket: `s3://fcp-indi/data/Projects/ADHD200/`.",
+        "- Default derivative: C-PAC benchmark with frequency filter, CC200 ROI timeseries, no global signal regression.",
+        "- This is a bounded cache bootstrap, not a clinical or mechanistic result.",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--max-subjects", type=int, default=24)
+    parser.add_argument("--allow-full-download", action="store_true")
+    parser.add_argument("--pipeline", default=DEFAULT_PIPELINE)
+    parser.add_argument("--regressor", default=DEFAULT_REGRESSOR)
+    parser.add_argument("--bandpass", default=DEFAULT_BANDPASS)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    if args.max_subjects <= 0 and not args.allow_full_download:
+        raise SystemExit("--max-subjects must be positive unless --allow-full-download is set")
+    if args.max_subjects > 64 and not args.allow_full_download:
+        raise SystemExit("--max-subjects >64 requires --allow-full-download")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    pheno_dir = args.output_dir / "phenotypic_sources"
+    roi_dir = args.output_dir / "rois"
+    summary_path = args.output_dir / "adhd200_s3_bootstrap_summary.json"
+    readme_path = args.output_dir / "ADHD200_S3_BOOTSTRAP.md"
+    if not args.overwrite and (summary_path.exists() or readme_path.exists()):
+        raise SystemExit(f"refusing to overwrite existing outputs in {args.output_dir}; pass --overwrite")
+
+    pheno_keys = [
+        item["key"]
+        for item in list_s3(PHENO_PREFIX)
+        if item["key"].endswith("_phenotypic.csv") and "TestRelease" not in item["key"]
+    ]
+    pheno_downloads = []
+    all_rows: list[dict[str, str]] = []
+    for key in sorted(pheno_keys):
+        path = pheno_dir / Path(key).name
+        receipt = download_file(key, path)
+        pheno_downloads.append(receipt)
+        all_rows.extend(read_phenotypic(path, key))
+
+    available_scan_ids = available_subjects_for_pipeline(args.pipeline)
+    selected = select_rows(all_rows, args.max_subjects, available_scan_ids)
+    if not selected:
+        raise SystemExit(
+            "no ADHD-200 phenotypic rows with primary dimensional endpoints and available C-PAC ROI subjects were selected"
+        )
+
+    merged_pheno = args.output_dir / "adhd200_phenotypic.csv"
+    write_merged_phenotypic(merged_pheno, selected)
+
+    roi_receipts = []
+    missing = []
+    for row in selected:
+        scan_id = str(row["ScanDir ID"]).strip()
+        key = roi_key_for(scan_id, args.pipeline, args.regressor, args.bandpass)
+        target = roi_dir / f"{scan_id}_rois_cc200.1D"
+        if args.dry_run:
+            roi_receipts.append({"key": key, "path": str(target), "dry_run": True})
+            continue
+        try:
+            roi_receipts.append(download_file(key, target))
+        except Exception as exc:
+            missing.append({"scan_id": scan_id, "key": key, "error": str(exc)})
+
+    status = "ready" if not missing and not args.dry_run else ("dry_run" if args.dry_run else "partial")
+    next_command = (
+        f"PHENOTYPIC_CSV='{merged_pheno}' ROI_DIR='{roi_dir}' "
+        f"OUTPUT_DIR='{args.output_dir / 'pilot'}' SOUNIO_SOUC_ENGINE=lean_single "
+        "scripts/research/adhd200_dimensional_pilot_smoke.sh"
+    )
+    counts = Counter(row.get("source_site_name", "UNKNOWN_SITE") for row in selected)
+    label_counts = Counter(diagnosis_label(row.get("DX", "")) for row in selected)
+    summary = {
+        "schema": SCHEMA,
+        "status": status,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "source_bucket": "s3://fcp-indi/data/Projects/ADHD200/",
+        "pipeline": args.pipeline,
+        "available_cpac_subject_count": len(available_scan_ids),
+        "regressor": args.regressor,
+        "bandpass": args.bandpass,
+        "selected_subject_count": len(selected),
+        "site_counts": dict(sorted(counts.items())),
+        "label_counts": dict(sorted(label_counts.items())),
+        "phenotypic_downloads": pheno_downloads,
+        "downloaded_roi_count": sum(1 for receipt in roi_receipts if not receipt.get("dry_run")),
+        "missing_roi": missing,
+        "outputs": {"phenotypic_csv": str(merged_pheno), "roi_dir": str(roi_dir)},
+        "next_command": "" if status == "partial" else next_command,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_readme(readme_path, summary)
+    print(json.dumps({"status": status, "summary": str(summary_path), "readme": str(readme_path)}, sort_keys=True))
+    return 0 if status in {"ready", "dry_run"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_adhd_dimensional_state_probe.py
+++ b/scripts/research/neurodyn_adhd_dimensional_state_probe.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""Site-aware dimensional probes for ADHD-200 O-SSM STATE_TRACE features.
+
+This script joins traced hidden states from brain_ossm_abide output to the rich
+ADHD-200 manifest. It exports dynamic state features and evaluates simple
+leave-one-site-out ridge probes for dimensional ADHD subscales. It is a
+diagnostic instrument, not a clinical model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from neurodyn_hidden_state_separability import parse_state_rows
+
+
+SCHEMA = "neurodyn.adhd_dimensional_state_probe.v1"
+CLAIM_BOUNDARY = (
+    "Dimensional hidden-state diagnostic only. This is not a diagnostic, "
+    "biomarker, treatment-response, biological-mechanism, or O-SSM superiority claim."
+)
+
+MISSING_TOKENS = {"", "na", "n/a", "nan", "none", "null", "-999", "-9999"}
+
+
+def is_missing(value: str) -> bool:
+    return value.strip().lower() in MISSING_TOKENS
+
+
+def parse_float(value: str) -> float | None:
+    if is_missing(value):
+        return None
+    try:
+        out = float(value)
+    except ValueError:
+        return None
+    return out if math.isfinite(out) else None
+
+
+def canonical_label_code(value: Any) -> int | None:
+    text = str(value).strip().lower()
+    if text in {"1", "adhd", "asd", "aut"}:
+        return 1
+    if text in {"0", "td", "hc", "control", "typically developing"}:
+        return 0
+    return None
+
+
+def canonical_label_text(value: Any) -> str:
+    code = canonical_label_code(value)
+    if code == 1:
+        return "ADHD"
+    if code == 0:
+        return "TD"
+    return str(value).strip()
+
+
+def site_hash(value: str) -> int:
+    h = 5381
+    for byte in value.encode("utf-8"):
+        h = h * 33 + byte
+    return abs(h)
+
+
+def trace_site_matches(trace_site: Any, manifest_site: str) -> bool:
+    trace_text = str(trace_site)
+    if trace_text == manifest_site:
+        return True
+    try:
+        return int(trace_text) == site_hash(manifest_site)
+    except ValueError:
+        return False
+
+
+def read_manifest(path: Path) -> tuple[dict[str, str], list[dict[str, str]]]:
+    meta: dict[str, str] = {}
+    data_lines: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        if raw.startswith("#"):
+            body = raw[1:].strip()
+            if "=" in body:
+                key, value = body.split("=", 1)
+                meta[key.strip()] = value.strip()
+            continue
+        data_lines.append(raw)
+    if not data_lines:
+        raise SystemExit(f"manifest has no rows: {path}")
+    reader = csv.DictReader(data_lines, delimiter="\t")
+    return meta, list(reader)
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def subject_universe_sha256(rows: list[dict[str, str]]) -> str:
+    """Hash ordered subject_id/label/site rows; keep in sync with the preparer."""
+    h = hashlib.sha256()
+    for row in rows:
+        h.update(row.get("subject_id", "").encode("utf-8"))
+        h.update(b"\t")
+        h.update(canonical_label_text(row.get("label", "")).encode("utf-8"))
+        h.update(b"\t")
+        h.update(row.get("site", "").encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def pearson(x: list[float], y: list[float]) -> float:
+    if len(x) < 2 or len(x) != len(y):
+        return 0.0
+    mx = mean(x)
+    my = mean(y)
+    vx = sum((v - mx) * (v - mx) for v in x)
+    vy = sum((v - my) * (v - my) for v in y)
+    if vx <= 1.0e-20 or vy <= 1.0e-20:
+        return 0.0
+    cov = sum((a - mx) * (b - my) for a, b in zip(x, y, strict=True))
+    return cov / math.sqrt(vx * vy)
+
+
+def rankdata(values: list[float]) -> list[float]:
+    order = sorted(range(len(values)), key=lambda idx: values[idx])
+    ranks = [0.0] * len(values)
+    idx = 0
+    while idx < len(order):
+        j = idx + 1
+        while j < len(order) and values[order[j]] == values[order[idx]]:
+            j += 1
+        rank = (idx + 1 + j) / 2.0
+        for k in range(idx, j):
+            ranks[order[k]] = rank
+        idx = j
+    return ranks
+
+
+def spearman(x: list[float], y: list[float]) -> float:
+    if len(x) < 2:
+        return 0.0
+    return pearson(rankdata(x), rankdata(y))
+
+
+def r2_score(y: list[float], pred: list[float]) -> float:
+    if len(y) < 2:
+        return 0.0
+    y_mean = mean(y)
+    ss_tot = sum((value - y_mean) * (value - y_mean) for value in y)
+    if ss_tot <= 1.0e-20:
+        return 0.0
+    ss_res = sum((a - b) * (a - b) for a, b in zip(y, pred, strict=True))
+    return 1.0 - ss_res / ss_tot
+
+
+def mae(y: list[float], pred: list[float]) -> float:
+    return mean([abs(a - b) for a, b in zip(y, pred, strict=True)])
+
+
+def zscore_train_apply(x_train: np.ndarray, x_test: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    mu = x_train.mean(axis=0)
+    sigma = x_train.std(axis=0)
+    sigma = np.where(sigma > 1.0e-12, sigma, 1.0)
+    return (x_train - mu) / sigma, (x_test - mu) / sigma
+
+
+def ridge_fit_predict(x_train: np.ndarray, y_train: np.ndarray, x_test: np.ndarray, l2: float) -> np.ndarray:
+    x_train_z, x_test_z = zscore_train_apply(x_train, x_test)
+    design_train = np.column_stack([np.ones(x_train_z.shape[0]), x_train_z])
+    design_test = np.column_stack([np.ones(x_test_z.shape[0]), x_test_z])
+    penalty = np.eye(design_train.shape[1]) * l2
+    penalty[0, 0] = 0.0
+    weights = np.linalg.pinv(design_train.T @ design_train + penalty) @ design_train.T @ y_train
+    return design_test @ weights
+
+
+def metric_value(name: str, y: list[float], pred: list[float]) -> float:
+    if name == "spearman":
+        return spearman(y, pred)
+    if name == "pearson":
+        return pearson(y, pred)
+    if name == "r2":
+        return r2_score(y, pred)
+    if name == "mae":
+        return mae(y, pred)
+    raise SystemExit(f"unknown metric: {name}")
+
+
+def vector_from_columns(row: dict[str, str], cols: list[str]) -> list[float] | None:
+    values: list[float] = []
+    for col in cols:
+        value = parse_float(row.get(col, ""))
+        if value is None:
+            return None
+        values.append(value)
+    return values
+
+
+def covariate_vector(row: dict[str, str]) -> list[float] | None:
+    values: list[float] = []
+    for col in ["age", "iq", "mean_fd"]:
+        value = parse_float(row.get(col, ""))
+        values.append(0.0 if value is None else value)
+    sex = row.get("sex", "").strip().lower()
+    if sex in {"1", "m", "male"}:
+        values.append(1.0)
+    elif sex in {"2", "f", "female"}:
+        values.append(0.0)
+    else:
+        values.append(0.5)
+    med = row.get("medication_status", "").strip().lower()
+    if med in {"1", "yes", "y", "true", "medicated", "on"}:
+        values.append(1.0)
+    elif med in {"0", "no", "n", "false", "unmedicated", "off"}:
+        values.append(0.0)
+    else:
+        values.append(0.5)
+    return values
+
+
+def joined_rows(
+    raw_output: Path,
+    manifest_rows: list[dict[str, str]],
+    ossm_rows: list[dict[str, str]] | None,
+    phenotypes: list[str],
+) -> list[dict[str, Any]]:
+    state_rows = parse_state_rows(raw_output)
+    trace_subjects = {(int(row["seed"]), int(row["subject_index"])) for row in state_rows}
+    if ossm_rows is not None and len(ossm_rows) != len(manifest_rows):
+        raise SystemExit(f"rich manifest/view row count mismatch: {len(manifest_rows)} vs {len(ossm_rows)}")
+    if ossm_rows is not None:
+        for idx, (rich, view) in enumerate(zip(manifest_rows, ossm_rows, strict=True)):
+            for column in ["subject_id", "site"]:
+                if rich.get(column, "") != view.get(column, ""):
+                    raise SystemExit(f"rich manifest/view mismatch at row {idx} column {column}")
+            if canonical_label_code(rich.get("label", "")) != canonical_label_code(view.get("label", "")):
+                raise SystemExit(f"rich manifest/view mismatch at row {idx} column label")
+    out: list[dict[str, Any]] = []
+    for row in state_rows:
+        idx = int(row["subject_index"])
+        if idx < 0 or idx >= len(manifest_rows):
+            raise SystemExit(f"STATE_TRACE subject_index out of bounds: {idx}")
+        manifest = manifest_rows[idx]
+        view = ossm_rows[idx] if ossm_rows is not None else manifest
+        if not manifest.get("subject_id", ""):
+            raise SystemExit(f"manifest row {idx} has no subject_id")
+        if not manifest.get("site", ""):
+            raise SystemExit(f"manifest row {idx} has no site")
+        expected_label = canonical_label_code(manifest.get("label", ""))
+        if expected_label is None:
+            raise SystemExit(f"manifest row {idx} has unsupported label: {manifest.get('label', '')}")
+        if not trace_site_matches(row["site"], str(view.get("site", ""))):
+            raise SystemExit(f"STATE_TRACE site mismatch at row {idx}: trace={row['site']} manifest={view.get('site', '')}")
+        if int(row["label"]) != expected_label:
+            raise SystemExit(f"STATE_TRACE label mismatch at row {idx}: trace={row['label']} manifest={manifest.get('label', '')}")
+        phenotype_values = {name: parse_float(manifest.get(name, "")) for name in phenotypes}
+        feature_cols = [f"f{i}" for i in range(64)]
+        raw_features = vector_from_columns(manifest, feature_cols)
+        covariates = covariate_vector(manifest)
+        out.append(
+            {
+                "model": row["model"],
+                "seed": int(row["seed"]),
+                "subject_index": idx,
+                "subject_id": manifest.get("subject_id", str(idx)),
+                "site": manifest.get("site", row["site"]),
+                "label": manifest.get("label", str(row["label"])),
+                "h": row["h"],
+                "raw_features": raw_features,
+                "covariates": covariates,
+                "phenotypes": phenotype_values,
+            }
+        )
+    if not out:
+        raise SystemExit("no STATE_TRACE rows joined to manifest")
+    expected_trace_count = len({int(row["seed"]) for row in state_rows}) * len(manifest_rows)
+    if len(trace_subjects) != expected_trace_count:
+        raise SystemExit(f"STATE_TRACE subject coverage mismatch: got {len(trace_subjects)}, expected {expected_trace_count}")
+    return out
+
+
+def run_probe(
+    rows: list[dict[str, Any]],
+    phenotypes: list[str],
+    surfaces: list[str],
+    l2: float,
+    null_permutations: int,
+    min_test_variance: float,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    summary: list[dict[str, Any]] = []
+    models = sorted({row["model"] for row in rows})
+    if len(models) > 1:
+        reference_model = models[0]
+        reference_set = {(int(row["seed"]), str(row["subject_id"])) for row in rows if row["model"] == reference_model}
+        for model in models[1:]:
+            model_set = {(int(row["seed"]), str(row["subject_id"])) for row in rows if row["model"] == model}
+            if model_set != reference_set:
+                missing = sorted(reference_set - model_set)[:5]
+                extra = sorted(model_set - reference_set)[:5]
+                raise SystemExit(
+                    f"cross-model subject/seed mismatch for {model} vs {reference_model}; "
+                    f"missing_examples={missing}; extra_examples={extra}"
+                )
+    for model in models:
+        model_rows = [row for row in rows if row["model"] == model]
+        seeds = sorted({int(row["seed"]) for row in model_rows})
+        for phenotype in phenotypes:
+            for surface in surfaces:
+                fold_metrics: list[dict[str, Any]] = []
+                for seed in seeds:
+                    seed_rows = [row for row in model_rows if int(row["seed"]) == seed]
+                    sites = sorted({row["site"] for row in seed_rows})
+                    y_all: list[float] = []
+                    pred_all: list[float] = []
+                    for site in sites:
+                        train = [row for row in seed_rows if row["site"] != site and row["phenotypes"].get(phenotype) is not None]
+                        test = [row for row in seed_rows if row["site"] == site and row["phenotypes"].get(phenotype) is not None]
+                        if len(train) < 3 or not test:
+                            continue
+                        if surface == "hidden":
+                            x_train_list = [row["h"] for row in train]
+                            x_test_list = [row["h"] for row in test]
+                        elif surface in {"static_input_summary", "raw_features"}:
+                            train = [row for row in train if row["raw_features"] is not None]
+                            test = [row for row in test if row["raw_features"] is not None]
+                            x_train_list = [row["raw_features"] for row in train]
+                            x_test_list = [row["raw_features"] for row in test]
+                        elif surface == "covariates":
+                            train = [row for row in train if row["covariates"] is not None]
+                            test = [row for row in test if row["covariates"] is not None]
+                            x_train_list = [row["covariates"] for row in train]
+                            x_test_list = [row["covariates"] for row in test]
+                        else:
+                            raise SystemExit(f"unknown surface: {surface}")
+                        if len(train) < 3 or not test:
+                            continue
+                        y_train = np.array([float(row["phenotypes"][phenotype]) for row in train], dtype=float)
+                        y_test = [float(row["phenotypes"][phenotype]) for row in test]
+                        if len(y_test) > 1 and statistics.pvariance(y_test) < min_test_variance:
+                            continue
+                        x_train = np.array(x_train_list, dtype=float)
+                        x_test = np.array(x_test_list, dtype=float)
+                        preds = ridge_fit_predict(x_train, y_train, x_test, l2=l2).tolist()
+                        y_all.extend(y_test)
+                        pred_all.extend(float(value) for value in preds)
+                        fold_metrics.append(
+                            {
+                                "model": model,
+                                "seed": seed,
+                                "phenotype": phenotype,
+                                "surface": surface,
+                                "holdout_site": site,
+                                "train_n": len(train),
+                                "holdout_n": len(test),
+                                "pearson": pearson(y_test, preds),
+                                "spearman": spearman(y_test, preds),
+                                "r2": r2_score(y_test, preds),
+                                "mae": mae(y_test, preds),
+                            }
+                        )
+                    if y_all:
+                        observed_spearman = spearman(y_all, pred_all)
+                        null_spearman: list[float] = []
+                        if null_permutations > 0:
+                            rng = np.random.default_rng(seed * 1009 + len(phenotype) * 9176 + len(surface) * 131)
+                            for _ in range(null_permutations):
+                                null_y_all: list[float] = []
+                                null_pred_all: list[float] = []
+                                for site in sites:
+                                    train = [row for row in seed_rows if row["site"] != site and row["phenotypes"].get(phenotype) is not None]
+                                    test = [row for row in seed_rows if row["site"] == site and row["phenotypes"].get(phenotype) is not None]
+                                    if surface == "hidden":
+                                        x_train_list = [row["h"] for row in train]
+                                        x_test_list = [row["h"] for row in test]
+                                    elif surface in {"static_input_summary", "raw_features"}:
+                                        train = [row for row in train if row["raw_features"] is not None]
+                                        test = [row for row in test if row["raw_features"] is not None]
+                                        x_train_list = [row["raw_features"] for row in train]
+                                        x_test_list = [row["raw_features"] for row in test]
+                                    elif surface == "covariates":
+                                        train = [row for row in train if row["covariates"] is not None]
+                                        test = [row for row in test if row["covariates"] is not None]
+                                        x_train_list = [row["covariates"] for row in train]
+                                        x_test_list = [row["covariates"] for row in test]
+                                    else:
+                                        raise SystemExit(f"unknown surface: {surface}")
+                                    if len(train) < 3 or not test:
+                                        continue
+                                    y_test = [float(row["phenotypes"][phenotype]) for row in test]
+                                    if len(y_test) > 1 and statistics.pvariance(y_test) < min_test_variance:
+                                        continue
+                                    y_train_values = np.array([float(row["phenotypes"][phenotype]) for row in train], dtype=float)
+                                    rng.shuffle(y_train_values)
+                                    x_train = np.array(x_train_list, dtype=float)
+                                    x_test = np.array(x_test_list, dtype=float)
+                                    preds = ridge_fit_predict(x_train, y_train_values, x_test, l2=l2).tolist()
+                                    null_y_all.extend(y_test)
+                                    null_pred_all.extend(float(value) for value in preds)
+                                if null_y_all:
+                                    null_spearman.append(spearman(null_y_all, null_pred_all))
+                        if null_spearman:
+                            ge = sum(1 for value in null_spearman if value >= observed_spearman)
+                            null_p_ge = (ge + 1.0) / (len(null_spearman) + 1.0)
+                            null_mean = mean(null_spearman)
+                            null_std = pstdev(null_spearman)
+                        else:
+                            null_p_ge = 1.0
+                            null_mean = 0.0
+                            null_std = 0.0
+                        fold_metrics.append(
+                            {
+                                "model": model,
+                                "seed": seed,
+                                "phenotype": phenotype,
+                                "surface": surface,
+                                "holdout_site": "__pooled__",
+                                "train_n": 0,
+                                "holdout_n": len(y_all),
+                                "pearson": pearson(y_all, pred_all),
+                                "spearman": observed_spearman,
+                                "r2": r2_score(y_all, pred_all),
+                                "mae": mae(y_all, pred_all),
+                                "null_permutations": len(null_spearman),
+                                "null_spearman_mean": null_mean,
+                                "null_spearman_std": null_std,
+                                "null_spearman_p_ge": null_p_ge,
+                                "null_mode": "phenotype_permutation_train_only_frozen_recurrent_state",
+                            }
+                        )
+                detail.extend(fold_metrics)
+                pooled = [row for row in fold_metrics if row["holdout_site"] == "__pooled__"]
+                site_rows = [row for row in fold_metrics if row["holdout_site"] != "__pooled__"]
+                summary.append(
+                    {
+                        "model": model,
+                        "phenotype": phenotype,
+                        "surface": surface,
+                        "seed_count": len(pooled),
+                        "sites_evaluated_mean": mean([len({row["holdout_site"] for row in site_rows if row["seed"] == pooled_row["seed"]}) for pooled_row in pooled]),
+                        "pooled_n_mean": mean([float(row["holdout_n"]) for row in pooled]),
+                        "pearson_mean": mean([float(row["pearson"]) for row in pooled]),
+                        "pearson_std": pstdev([float(row["pearson"]) for row in pooled]),
+                        "spearman_mean": mean([float(row["spearman"]) for row in pooled]),
+                        "spearman_std": pstdev([float(row["spearman"]) for row in pooled]),
+                        "r2_mean": mean([float(row["r2"]) for row in pooled]),
+                        "mae_mean": mean([float(row["mae"]) for row in pooled]),
+                        "null_permutations_mean": mean([float(row.get("null_permutations", 0)) for row in pooled]),
+                        "null_spearman_mean": mean([float(row.get("null_spearman_mean", 0.0)) for row in pooled]),
+                        "null_spearman_p_ge_mean": mean([float(row.get("null_spearman_p_ge", 1.0)) for row in pooled]),
+                        "canonical_metric": "pooled_per_seed_spearman_mean",
+                    }
+                )
+    return summary, detail
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def export_dynamic_features(path: Path, rows: list[dict[str, Any]], phenotypes: list[str]) -> None:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        record: dict[str, Any] = {
+            "model": row["model"],
+            "seed": row["seed"],
+            "subject_index": row["subject_index"],
+            "subject_id": row["subject_id"],
+            "site": row["site"],
+            "label": row["label"],
+        }
+        for phenotype in phenotypes:
+            value = row["phenotypes"].get(phenotype)
+            record[phenotype] = "" if value is None else value
+        for idx, value in enumerate(row["h"]):
+            record[f"h{idx}"] = value
+        out.append(record)
+    write_tsv(path, out)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# ADHD Dimensional O-SSM State Probe",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "| model | phenotype | surface | seeds | sites eval mean | pooled n mean | Spearman mean | null p>= mean | Pearson mean | R2 mean | MAE mean |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {model} | {phenotype} | {surface} | {seed_count} | {sites:.3f} | {pooled_n:.3f} | {spearman:.6f} | {null_p:.6f} | {pearson:.6f} | {r2:.6f} | {mae:.6f} |".format(
+                model=row["model"],
+                phenotype=row["phenotype"],
+                surface=row["surface"],
+                seed_count=row["seed_count"],
+                sites=row["sites_evaluated_mean"],
+                pooled_n=row["pooled_n_mean"],
+                spearman=row["spearman_mean"],
+                null_p=row["null_spearman_p_ge_mean"],
+                pearson=row["pearson_mean"],
+                r2=row["r2_mean"],
+                mae=row["mae_mean"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "Interpretation: this is a site-held-out dimensional diagnostic over traced hidden states.",
+            "The canonical metric is the pooled-per-seed Spearman summary, not a naive average of per-site rows.",
+            "A positive value is only a hypothesis-generating representation result unless matched baselines, nulls, and leakage audits also pass.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-output", required=True, type=Path)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--ossm-manifest", type=Path, default=None, help="Compatibility view consumed by the O-SSM runner.")
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--primary-phenotypes", default="inattention,hyperactivity_impulsivity,adhd_total")
+    parser.add_argument("--surfaces", default="hidden,covariates,static_input_summary")
+    parser.add_argument("--l2", type=float, default=1.0)
+    parser.add_argument("--null-permutations", type=int, default=20)
+    parser.add_argument("--min-test-variance", type=float, default=1.0e-12)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir.resolve()
+    if output_dir.exists() and any(output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    phenotypes = [value.strip() for value in args.primary_phenotypes.split(",") if value.strip()]
+    surfaces = [value.strip() for value in args.surfaces.split(",") if value.strip()]
+    manifest_meta, manifest_rows = read_manifest(args.manifest)
+    ossm_meta: dict[str, str] = {}
+    ossm_rows: list[dict[str, str]] | None = None
+    if args.ossm_manifest is not None:
+        ossm_meta, ossm_rows = read_manifest(args.ossm_manifest)
+        rich_universe = manifest_meta.get("subject_universe_sha256", subject_universe_sha256(manifest_rows))
+        ossm_universe = ossm_meta.get("subject_universe_sha256", subject_universe_sha256(ossm_rows))
+        if rich_universe != ossm_universe:
+            raise SystemExit(f"subject universe mismatch: rich={rich_universe} ossm={ossm_universe}")
+    rows = joined_rows(args.raw_output, manifest_rows, ossm_rows, phenotypes)
+    summary, detail = run_probe(rows, phenotypes, surfaces, args.l2, args.null_permutations, args.min_test_variance)
+    export_dynamic_features(output_dir / "adhd_dimensional_dynamic_features.tsv", rows, phenotypes)
+    write_tsv(output_dir / "adhd_dimensional_state_probe_summary.tsv", summary)
+    write_tsv(output_dir / "adhd_dimensional_state_probe_detail.tsv", detail)
+
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "raw_output": str(args.raw_output.resolve()),
+        "raw_output_sha256": sha256(args.raw_output),
+        "manifest": str(args.manifest.resolve()),
+        "manifest_sha256": sha256(args.manifest),
+        "manifest_metadata": manifest_meta,
+        "ossm_manifest": str(args.ossm_manifest.resolve()) if args.ossm_manifest is not None else "",
+        "ossm_manifest_sha256": sha256(args.ossm_manifest) if args.ossm_manifest is not None else "",
+        "ossm_manifest_metadata": ossm_meta,
+        "subject_universe_sha256": manifest_meta.get("subject_universe_sha256", subject_universe_sha256(manifest_rows)),
+        "joined_state_rows": len(rows),
+        "primary_phenotypes": phenotypes,
+        "surfaces": surfaces,
+        "ridge_l2": args.l2,
+        "null_permutations_requested": args.null_permutations,
+        "null_mode": "phenotype_permutation_train_only_frozen_recurrent_state",
+        "state_trace_provenance": "STATE_TRACE final hidden state from brain_ossm_abide; recurrent model is not retrained by this probe.",
+        "summary": summary,
+    }
+    (output_dir / "adhd_dimensional_state_probe.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (output_dir / "adhd_dimensional_state_probe.md").write_text(markdown(payload), encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_algebra_b_decision_gate.py
+++ b/scripts/research/neurodyn_algebra_b_decision_gate.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Apply the preregistered Algebra-B attribution decision table.
+
+The top-level gate has exactly four scientific routes:
+
+1. O-SSM crosses threshold, A8 does not, projection collapses.
+2. O-SSM crosses threshold, A8 also crosses threshold.
+3. O-SSM is subthreshold and reformulation attempts remain.
+4. Reformulation attempts are exhausted while subthreshold.
+
+Null expansion is allowed only after route 1 is reached.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.algebra_b_decision_gate.v1"
+OSS_THRESHOLD = 55.0
+A8_THRESHOLD = 55.0
+PROJECTION_COLLAPSE_THRESHOLD = 55.0
+MAX_REFORMULATIONS_DEFAULT = 2
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prereg", required=True, type=Path)
+    parser.add_argument("--audit", required=True, type=Path, help="data_audit/associator_data_audit.json")
+    parser.add_argument("--true-run", required=True, type=Path, help="O/H true Slurm run directory")
+    parser.add_argument("--null-run", action="append", default=[], type=Path)
+    parser.add_argument("--a8-true-run", type=Path)
+    parser.add_argument("--a8-null-run", action="append", default=[], type=Path)
+    parser.add_argument("--projection-true-run", type=Path)
+    parser.add_argument("--projection-null-run", action="append", default=[], type=Path)
+    parser.add_argument("--a8-model", default="A8-SSM")
+    parser.add_argument("--projection-model", default="O-SSM")
+    parser.add_argument("--attempt-count", type=int, default=0)
+    parser.add_argument("--max-reformulations", type=int, default=MAX_REFORMULATIONS_DEFAULT)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def model_metric(run: Path, model: str) -> dict[str, float]:
+    rows = read_tsv(run / "results" / "overall_metrics.tsv")
+    for row in rows:
+        if row["model"] == model:
+            return {
+                "balanced_accuracy_pct": float(row["balanced_accuracy_pct_mean"]),
+                "auroc_pct": float(row["auroc_pct_mean"]),
+                "brier": float(row["brier_mean"]),
+                "ece_pct": float(row["ece_pct_mean"]),
+            }
+    raise SystemExit(f"model={model} not found in {run / 'results' / 'overall_metrics.tsv'}")
+
+
+def hidden_probe_metric(run: Path, model: str) -> float | None:
+    path = run / "hidden_state_separability" / "hidden_state_separability_summary.tsv"
+    if not path.exists():
+        return None
+    rows = read_tsv(path)
+    for row in rows:
+        if row.get("model") == model:
+            key = "nearest_centroid_balanced_accuracy_mean"
+            if key in row:
+                return float(row[key])
+    return None
+
+
+def envelope(true_value: float, null_values: list[float]) -> dict[str, Any]:
+    return {
+        "true": true_value,
+        "null_count": len(null_values),
+        "null_min": min(null_values) if null_values else None,
+        "null_max": max(null_values) if null_values else None,
+        "null_mean": statistics.fmean(null_values) if null_values else None,
+        "null_ge_true": sum(1 for value in null_values if value >= true_value),
+        "plus_one_p_ge_true": (1 + sum(1 for value in null_values if value >= true_value)) / (len(null_values) + 1)
+        if null_values
+        else None,
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    a8_ba = payload["attribution"]["a8_balanced_accuracy_pct"]
+    projection_ba = payload["attribution"]["projection_balanced_accuracy_pct"]
+    a8_ba_text = "NA" if a8_ba is None else f"{a8_ba:.6f}"
+    projection_ba_text = "NA" if projection_ba is None else f"{projection_ba:.6f}"
+    lines = [
+        "# Algebra-B Decision Gate",
+        "",
+        "Claim boundary: synthetic non-clinical algebra-necessity gate only.",
+        "",
+        f"Decision: `{payload['decision']}`",
+        f"Route: `{payload['route_id']}`",
+        "",
+        payload["interpretation"],
+        "",
+        "## Four-Route Contract",
+        "",
+        "- `1`: O-SSM >= 55%, A8 < 55%, associative projection < 55%; algebraic necessity candidate. Only this route permits 99 nulls.",
+        "- `2`: O-SSM >= 55%, A8 >= 55%; dimensionality/capacity effect, not octonionic necessity.",
+        "- `3`: O-SSM < 55% and reformulation attempts remain; one new preregistered reformulation is allowed.",
+        "- `4`: O-SSM < 55% and reformulation attempts are exhausted; terminal negative for fixed-dim6 design.",
+        "",
+        "## Core Metrics",
+        "",
+        "| metric | true | null max | null >= true | plus-one p |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for metric, env in payload["envelopes"].items():
+        null_max = "NA" if env["null_max"] is None else f"{env['null_max']:.6f}"
+        pval = "NA" if env["plus_one_p_ge_true"] is None else f"{env['plus_one_p_ge_true']:.6f}"
+        lines.append(
+            f"| {metric} | {env['true']:.6f} | {null_max} | {env['null_ge_true']}/{env['null_count']} | {pval} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Attribution Controls",
+            "",
+            f"- O-SSM BA: `{payload['attribution']['o_balanced_accuracy_pct']:.6f}`",
+            f"- H-SSM BA: `{payload['attribution']['h_balanced_accuracy_pct']:.6f}`",
+            f"- A8 BA: `{a8_ba_text}`",
+            f"- associative projection BA: `{projection_ba_text}`",
+            f"- attempt count/max reformulations: `{payload['attempt_count']}` / `{payload['max_reformulations']}`",
+            "",
+            "## Missing Controls",
+            "",
+            *[f"- {item}" for item in payload["missing_controls"]],
+            "",
+            "## Shortcut Audit",
+            "",
+            f"- raw-flat leave-site BA: `{payload['shortcut_audit']['raw_flat_leave_site_ba']:.6f}`",
+            f"- fail shortcut threshold: `55.000000`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    prereg = json.loads(args.prereg.read_text(encoding="utf-8"))
+    audit = json.loads(args.audit.read_text(encoding="utf-8"))
+    raw_flat_ba = float(audit["leave_site_raw_flat_nearest_centroid"]["balanced_accuracy"])
+
+    true_o = model_metric(args.true_run, "O-SSM")
+    true_h = model_metric(args.true_run, "H-SSM")
+    true_a8 = model_metric(args.a8_true_run, args.a8_model) if args.a8_true_run is not None else None
+    true_projection = (
+        model_metric(args.projection_true_run, args.projection_model)
+        if args.projection_true_run is not None
+        else None
+    )
+    null_o = [model_metric(path, "O-SSM") for path in args.null_run]
+    hidden_true = hidden_probe_metric(args.true_run, "O-SSM")
+    hidden_null = [value for path in args.null_run if (value := hidden_probe_metric(path, "O-SSM")) is not None]
+
+    envelopes = {
+        "o_balanced_accuracy_pct": envelope(
+            true_o["balanced_accuracy_pct"], [row["balanced_accuracy_pct"] for row in null_o]
+        ),
+        "o_auroc_pct": envelope(true_o["auroc_pct"], [row["auroc_pct"] for row in null_o]),
+    }
+    if hidden_true is not None:
+        envelopes["o_hidden_centroid_ba_pct"] = envelope(hidden_true, hidden_null)
+
+    missing_controls: list[str] = []
+    if len(args.null_run) < int(prereg.get("null_count", 99)):
+        missing_controls.append(f"99 null runs required; found {len(args.null_run)}")
+    if args.a8_true_run is None:
+        missing_controls.append("A8-SSM direct-sum associative 8-D true run missing")
+    if len(args.a8_null_run) < int(prereg.get("null_count", 99)):
+        missing_controls.append(f"A8-SSM null runs incomplete; found {len(args.a8_null_run)}")
+    if args.projection_true_run is None:
+        missing_controls.append("associative-projection O-SSM true run missing")
+    if len(args.projection_null_run) < int(prereg.get("null_count", 99)):
+        missing_controls.append(f"associative-projection null runs incomplete; found {len(args.projection_null_run)}")
+    if hidden_true is None:
+        missing_controls.append("O-SSM hidden-state probe missing")
+
+    fail_shortcut = raw_flat_ba >= OSS_THRESHOLD
+    oss_subthreshold = true_o["balanced_accuracy_pct"] < OSS_THRESHOLD
+    attempts_exhausted = args.attempt_count >= args.max_reformulations
+    o_clears_nulls = (
+        len(args.null_run) >= int(prereg.get("null_count", 99))
+        and envelopes["o_balanced_accuracy_pct"]["null_ge_true"] == 0
+        and envelopes["o_auroc_pct"]["null_ge_true"] == 0
+        and envelopes["o_balanced_accuracy_pct"]["plus_one_p_ge_true"] is not None
+        and envelopes["o_balanced_accuracy_pct"]["plus_one_p_ge_true"] <= 0.01
+    )
+    h_gap = true_o["balanced_accuracy_pct"] - true_h["balanced_accuracy_pct"]
+
+    if fail_shortcut:
+        route_id = "3" if not attempts_exhausted else "4"
+        decision = "ALGEBRA_B_FAIL_SHORTCUT"
+        interpretation = (
+            "The raw-flat audit crosses the shortcut threshold. Treat this as subthreshold/invalid for the "
+            "four-route contract; only a preregistered reformulation may proceed if attempts remain."
+        )
+    elif oss_subthreshold and attempts_exhausted:
+        route_id = "4"
+        decision = "ALGEBRA_B_ROUTE4_TERMINAL_FIXEDDIM6_NEGATIVE"
+        interpretation = (
+            "O-SSM is below 55% and the preregistered reformulation budget is exhausted. "
+            "Terminate this fixed-dim6 algebraic-necessity design."
+        )
+    elif oss_subthreshold:
+        route_id = "3"
+        decision = "ALGEBRA_B_ROUTE3_SUBTHRESHOLD_REFORMULATION_ALLOWED"
+        interpretation = (
+            "O-SSM is below 55%. Do not expand nulls. One preregistered reformulation is allowed only "
+            "if it increments the attempt counter and fixes seed/threshold before running."
+        )
+    elif true_a8 is None:
+        route_id = "NEEDS_ATTRIBUTION_CONTROLS"
+        decision = "ALGEBRA_B_NEEDS_A8_AND_PROJECTION_BEFORE_ROUTE_ASSIGNMENT"
+        interpretation = (
+            "O-SSM crosses 55%, but route 1 versus route 2 cannot be assigned until A8 and associative "
+            "projection controls are present. Do not run 99 nulls yet."
+        )
+    elif true_projection is None:
+        route_id = "NEEDS_PROJECTION_CONTROL"
+        decision = "ALGEBRA_B_NEEDS_ASSOCIATIVE_PROJECTION_BEFORE_ROUTE_ASSIGNMENT"
+        interpretation = (
+            "O-SSM crosses 55% and A8 is below 55%, but route 1 cannot be assigned until the "
+            "associative-projection O-SSM true control is present. Do not run 99 nulls yet."
+        )
+    elif true_a8["balanced_accuracy_pct"] >= A8_THRESHOLD:
+        route_id = "2"
+        decision = "ALGEBRA_B_ROUTE2_DIMENSIONALITY_NOT_ALGEBRA"
+        interpretation = (
+            "O-SSM crosses 55%, but the paired associative 8-D A8 control also crosses 55%. "
+            "Attribute the effect to dimensionality/capacity, not octonionic necessity."
+        )
+    elif true_projection["balanced_accuracy_pct"] >= PROJECTION_COLLAPSE_THRESHOLD:
+        route_id = "2"
+        decision = "ALGEBRA_B_ROUTE2_ASSOCIATIVE_PROJECTION_DOES_NOT_COLLAPSE"
+        interpretation = (
+            "O-SSM crosses 55% and A8 is below threshold, but the associative projection does not collapse. "
+            "The octonionic product is not necessary under this assay."
+        )
+    elif h_gap < 3.0:
+        route_id = "2"
+        decision = "ALGEBRA_B_ROUTE2_HSSM_MATCHES_CAPACITY_NOT_ALGEBRA"
+        interpretation = "O-SSM crosses 55%, but H-SSM is within the preregistered 3.0 pp margin."
+    elif len(args.null_run) == 0:
+        route_id = "1"
+        decision = "ALGEBRA_B_ROUTE1_ATTRIBUTION_READY_FOR_99_NULLS"
+        interpretation = (
+            "O-SSM crosses 55%, A8 is below 55%, associative projection collapses, and H-SSM is below the margin. "
+            "This is the only route that permits the 99-null expansion."
+        )
+    elif not o_clears_nulls:
+        route_id = "1"
+        decision = "ALGEBRA_B_ROUTE1_ATTRIBUTION_POSITIVE_BUT_NULLS_FAIL"
+        interpretation = "Attribution controls pass, but the full null envelope does not. Do not promote."
+    else:
+        route_id = "1"
+        decision = "ALGEBRA_B_ROUTE1_NULL_VALIDATED_METHOD_READY"
+        interpretation = (
+            "O-SSM crosses 55%, A8 is below 55%, associative projection collapses, H-SSM is below the margin, "
+            "and 99 nulls collapse. A method piece may be drafted under the synthetic-only claim boundary."
+        )
+
+    rows = [
+        {"condition": "true", "model": "O-SSM", "run": str(args.true_run), **true_o},
+        {"condition": "true", "model": "H-SSM", "run": str(args.true_run), **true_h},
+    ]
+    if true_a8 is not None:
+        rows.append({"condition": "true", "model": args.a8_model, "run": str(args.a8_true_run), **true_a8})
+    if true_projection is not None:
+        rows.append(
+            {
+                "condition": "true",
+                "model": f"projection:{args.projection_model}",
+                "run": str(args.projection_true_run),
+                **true_projection,
+            }
+        )
+    rows.extend({"condition": "null", "model": "O-SSM", "run": str(path), **metric} for path, metric in zip(args.null_run, null_o))
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "prereg": str(args.prereg),
+        "audit": str(args.audit),
+        "true_run": str(args.true_run),
+        "null_runs": [str(path) for path in args.null_run],
+        "shortcut_audit": {"raw_flat_leave_site_ba": raw_flat_ba},
+        "o_minus_h_ba_pp": h_gap,
+        "attempt_count": args.attempt_count,
+        "max_reformulations": args.max_reformulations,
+        "attribution": {
+            "o_balanced_accuracy_pct": true_o["balanced_accuracy_pct"],
+            "h_balanced_accuracy_pct": true_h["balanced_accuracy_pct"],
+            "a8_balanced_accuracy_pct": None if true_a8 is None else true_a8["balanced_accuracy_pct"],
+            "projection_balanced_accuracy_pct": None
+            if true_projection is None
+            else true_projection["balanced_accuracy_pct"],
+        },
+        "envelopes": envelopes,
+        "missing_controls": missing_controls,
+        "route_id": route_id,
+        "decision": decision,
+        "interpretation": interpretation,
+    }
+    write_tsv(out / "algebra_b_decision_runs.tsv", rows)
+    (out / "algebra_b_decision_gate.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (out / "algebra_b_decision_gate.md").write_text(markdown(payload), encoding="utf-8")
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(out.iterdir()):
+            if path.is_file() and path.name != "SHA256SUMS":
+                handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_algebra_b_prereg.py
+++ b/scripts/research/neurodyn_algebra_b_prereg.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Build the preregistered Algebra-B synthetic non-associativity package.
+
+The package is intentionally synthetic and non-clinical. It freezes the next
+scientific question before any larger run: does octonionic non-associativity do
+work that an associative 8-D, parameter-matched control cannot do?
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.algebra_b_prereg.v1"
+DECISION_TABLE = {
+    "route_1_algebraic_necessity": (
+        "O-SSM >=55%, A8-SSM <55%, associative projection <55%, and H-SSM is "
+        "outside the 3.0 pp matching margin. Only this route permits 99 nulls."
+    ),
+    "route_2_dimensionality_not_algebra": (
+        "O-SSM >=55% and A8-SSM >=55%, or associative projection >=55%, or H-SSM "
+        "matches within 3.0 pp. Reframe as dimensionality/capacity, not octonionic necessity."
+    ),
+    "route_3_subthreshold_reformulation": (
+        "O-SSM <55% before the reformulation budget is exhausted. A new objective/training "
+        "reformulation is allowed only under a new preregistration with fixed seed/threshold."
+    ),
+    "route_4_terminal_negative": (
+        "Two reformulations are exhausted while O-SSM remains <55%. Terminate this fixed-dim6 design."
+    ),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--seed", type=int, default=2026070801)
+    parser.add_argument("--pairs", type=int, default=28)
+    parser.add_argument("--sites", type=int, default=7)
+    parser.add_argument("--seq-len", type=int, default=32)
+    parser.add_argument("--null-count", type=int, default=99)
+    parser.add_argument("--max-reformulations", type=int, default=2)
+    parser.add_argument("--target-assoc-dim", type=int, default=6)
+    parser.add_argument("--target-assoc-sign", type=int, choices=(-1, 1), default=1)
+    parser.add_argument("--triple-source", choices=("scaled_unit", "continuous", "unit"), default="scaled_unit")
+    parser.add_argument("--scale-jitter", type=float, default=0.12)
+    parser.add_argument("--noise-std", type=float, default=0.0)
+    parser.add_argument("--manifest-script", type=Path, default=Path("scripts/research/neurodyn_octonionic_associator_manifest.py"))
+    parser.add_argument("--audit-script", type=Path, default=Path("scripts/research/neurodyn_octonionic_associator_data_audit.py"))
+    parser.add_argument("--balance-script", type=Path, default=Path("scripts/research/neurodyn_associator_manifest_balance_gate.py"))
+    parser.add_argument("--null-script", type=Path, default=Path("scripts/research/neurodyn_pair_label_permutation_manifest.py"))
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_cmd(argv: list[str]) -> None:
+    subprocess.run(argv, check=True)
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Algebra-B Preregistration: Necessity of Non-Associativity",
+        "",
+        "Claim boundary: synthetic non-clinical algebra-necessity assay only. "
+        "No clinical, biomarker, biological mechanism, treatment-response, or broad O-SSM superiority claim.",
+        "",
+        "## Locked Question",
+        "",
+        "Does octonionic non-associative composition carry a third-order signal that a "
+        "parameter-matched associative 8-D control cannot recover under the same shortcuts-off training surface?",
+        "",
+        "## Design",
+        "",
+        f"- True manifest pairs/sites/seq_len: `{payload['pairs']}` / `{payload['sites']}` / `{payload['seq_len']}`",
+        f"- Triple source: `{payload['triple_source']}`",
+        f"- Target associator component/sign: `{payload['target_assoc_dim']}` / `{payload['target_assoc_sign']}`",
+        f"- Null count: `{payload['null_count']}` pair-label permutations",
+        "- Required shortcuts-off config: `READOUT_MEAN_SCALE=0`, `READOUT_DELTA_SCALE=0`, `READOUT_FLAT_SCALE=0`",
+        "- Required baselines before null expansion: O-SSM, H-SSM, A8-SSM (`H+H` direct-sum associative 8-D), associative-projection O-SSM.",
+        f"- Reformulation budget for this fixed-dim6 line: `{payload['max_reformulations']}`.",
+        "",
+        "## Decision Table",
+        "",
+    ]
+    for key, value in DECISION_TABLE.items():
+        lines.append(f"- `{key}`: {value}")
+    lines.extend(
+        [
+            "",
+            "## Artifacts",
+            "",
+            f"- True manifest package: `{payload['true_manifest_dir']}`",
+            f"- Data audit: `{payload['audit_dir']}`",
+            f"- Balance gate: `{payload['balance_dir']}`",
+            f"- Null manifest root: `{payload['null_manifest_root']}`",
+            f"- Runbook: `{payload['runbook']}`",
+            "",
+            "## Stop Rule",
+            "",
+            "Run the O/H/A8/projection attribution smoke before nulls. If O-SSM is below 55%, stop and consume one "
+            "reformulation attempt. If A8 or projection crosses 55%, stop and reframe as non-octonionic. "
+            "Only route 1 may run 99 nulls.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def runbook(payload: dict[str, Any]) -> str:
+    manifest = Path(payload["true_manifest_dir"]) / "octonionic_associator_manifest.tsv"
+    lines = [
+        "# Algebra-B Slurm Runbook",
+        "",
+        "This runbook is executable guidance, not evidence. Evidence begins only after SHA-checked Slurm outputs exist.",
+        "",
+        "## True Smoke",
+        "",
+        "```bash",
+        "RUN_ID=neurodyn-algebra-b-true-smoke \\",
+        f"MANIFEST_PATH={manifest} \\",
+        "OUTPUT_DIR=artifacts/research/neurodyn/synthetic/algebra_b_true_smoke_$(date -u +%Y%m%dT%H%M%SZ) \\",
+        "PAIRS_EXPECTED=" + str(payload["pairs"]) + " \\",
+        "NODE=gpuorangefs-5860-proxmox \\",
+        "READOUT_MEAN_SCALE=0 READOUT_DELTA_SCALE=0 READOUT_FLAT_SCALE=0 \\",
+        "TRACE_HIDDEN_STATE=1 TRACE_READOUT_ALL_FOLDS=1 \\",
+        "bash scripts/research/neurodyn_direct_slurm_smoke.sh",
+        "```",
+        "",
+        "## Bridge Nulls",
+        "",
+        "Run null seeds 1..5 first using the manifests under `null_manifests/`. Do not run nulls 6..99 until the gate clears.",
+        "",
+        "## Required Missing Baselines",
+        "",
+        "The decision gate requires A8-SSM and associative-projection O-SSM outputs. Until those model surfaces are wired, "
+        "the final gate must report `ALGEBRA_B_NOT_READY_MISSING_ASSOCIATIVE_CONTROLS`, even if O-SSM beats H-SSM/nulls.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    true_dir = out / "true_manifest"
+    audit_dir = out / "data_audit"
+    balance_dir = out / "balance_gate"
+    null_root = out / "null_manifests"
+    null_root.mkdir(parents=True, exist_ok=True)
+
+    manifest_cmd = [
+        sys.executable,
+        str(args.manifest_script),
+        "--output-dir",
+        str(true_dir),
+        "--pairs",
+        str(args.pairs),
+        "--sites",
+        str(args.sites),
+        "--seq-len",
+        str(args.seq_len),
+        "--seed",
+        str(args.seed),
+        "--noise-std",
+        str(args.noise_std),
+        "--site-mode",
+        "round_robin",
+        "--triple-selection",
+        "seeded_shuffle",
+        "--triple-source",
+        args.triple_source,
+        "--target-assoc-dim",
+        str(args.target_assoc_dim),
+        "--target-assoc-sign",
+        str(args.target_assoc_sign),
+        "--scale-jitter",
+        str(args.scale_jitter),
+        "--overwrite",
+    ]
+    run_cmd(manifest_cmd)
+
+    manifest = true_dir / "octonionic_associator_manifest.tsv"
+    triples = true_dir / "associator_triples.tsv"
+    run_cmd([sys.executable, str(args.audit_script), "--manifest", str(manifest), "--output-dir", str(audit_dir), "--overwrite"])
+    run_cmd(
+        [
+            sys.executable,
+            str(args.balance_script),
+            "--manifest",
+            str(manifest),
+            "--associator-triples",
+            str(triples),
+            "--output-dir",
+            str(balance_dir),
+            "--overwrite",
+        ]
+    )
+
+    null_dirs: list[str] = []
+    for idx in range(1, args.null_count + 1):
+        null_seed = args.seed + 10_000 + idx
+        null_dir = null_root / f"pairpermnull_{idx:03d}_seed{null_seed}"
+        run_cmd(
+            [
+                sys.executable,
+                str(args.null_script),
+                "--input",
+                str(manifest),
+                "--output-dir",
+                str(null_dir),
+                "--seed",
+                str(null_seed),
+                "--overwrite",
+            ]
+        )
+        null_dirs.append(rel(null_dir))
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "created_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "seed": args.seed,
+        "pairs": args.pairs,
+        "sites": args.sites,
+        "seq_len": args.seq_len,
+        "null_count": args.null_count,
+        "triple_source": args.triple_source,
+        "target_assoc_dim": args.target_assoc_dim,
+        "target_assoc_sign": args.target_assoc_sign,
+        "claim_boundary": "Synthetic non-clinical algebra-necessity assay only.",
+        "decision_table": DECISION_TABLE,
+        "true_manifest_dir": rel(true_dir),
+        "audit_dir": rel(audit_dir),
+        "balance_dir": rel(balance_dir),
+        "null_manifest_root": rel(null_root),
+        "null_manifest_dirs": null_dirs,
+        "runbook": rel(out / "runbook.md"),
+        "required_controls": [
+            "O-SSM true and null outputs",
+            "H-SSM true and null outputs",
+            "A8-SSM direct-sum associative 8-D true and null outputs",
+            "associative-projection O-SSM true and null outputs",
+        ],
+        "max_reformulations": args.max_reformulations,
+        "stop_rule": DECISION_TABLE["route_3_subthreshold_reformulation"],
+    }
+    write_json(out / "algebra_b_prereg.json", payload)
+    (out / "algebra_b_prereg.md").write_text(markdown(payload), encoding="utf-8")
+    (out / "runbook.md").write_text(runbook(payload), encoding="utf-8")
+
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(out.iterdir()):
+            if path.is_file() and path.name != "SHA256SUMS":
+                handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_algebra_c_decision_gate.py
+++ b/scripts/research/neurodyn_algebra_c_decision_gate.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Apply the Algebra-C continuous associator fidelity decision contract."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.algebra_c.decision_gate.v1"
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--prereg", required=True, type=Path)
+    ap.add_argument("--target-audit", required=True, type=Path)
+    ap.add_argument("--fidelity-summary", required=True, type=Path, help="fidelity_summary.tsv")
+    ap.add_argument("--external-summary", required=True, type=Path, help="GRU overall_metrics.tsv")
+    ap.add_argument("--null-summary", action="append", default=[], type=Path, help="null fidelity_summary.tsv")
+    ap.add_argument(
+        "--trajectory-null-summary",
+        action="append",
+        default=[],
+        type=Path,
+        help="trajectory-preserving continuous-target permutation null fidelity_summary.tsv",
+    )
+    ap.add_argument("--o-condition", default="octonion")
+    ap.add_argument("--a8-condition", default="a8")
+    ap.add_argument("--h-condition", default="h")
+    ap.add_argument("--projection-condition", default="projection")
+    ap.add_argument("--o-model", default="O-SSM")
+    ap.add_argument("--a8-model", default="A8-SSM")
+    ap.add_argument("--h-model", default="H-SSM")
+    ap.add_argument("--projection-model", default="O-SSM")
+    ap.add_argument("--generic-model", default="gru")
+    ap.add_argument("--higher-capacity-generic-model", default="gru_wide")
+    ap.add_argument("--spearman-margin", type=float, default=0.10)
+    ap.add_argument("--r2-margin", type=float, default=0.05)
+    ap.add_argument("--null-count-required", type=int, default=99)
+    ap.add_argument("--trajectory-null-count-required", type=int, default=20)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def find_fidelity(rows: list[dict[str, str]], condition: str, model: str) -> dict[str, float] | None:
+    for row in rows:
+        if row.get("condition") == condition and row.get("model") == model:
+            return {
+                "spearman": float(row["spearman_mean"]),
+                "r2": float(row["r2_mean"]),
+                "sign_auc": float(row["sign_auc_mean"]) if row.get("sign_auc_mean") not in {"", None} else 0.0,
+            }
+    return None
+
+
+def find_external(rows: list[dict[str, str]], model: str) -> dict[str, float] | None:
+    for row in rows:
+        if row.get("model") == model:
+            return {
+                "spearman": float(row["spearman_mean"]),
+                "r2": float(row["r2_mean"]),
+                "sign_auc": float(row["sign_auc_mean"]) if row.get("sign_auc_mean") not in {"", None} else 0.0,
+                "parameter_count": float(row.get("parameter_count", 0.0)),
+            }
+    return None
+
+
+def envelope(true_value: float, null_values: list[float]) -> dict[str, Any]:
+    return {
+        "true": true_value,
+        "null_count": len(null_values),
+        "null_min": min(null_values) if null_values else None,
+        "null_max": max(null_values) if null_values else None,
+        "null_mean": statistics.fmean(null_values) if null_values else None,
+        "null_ge_true": sum(1 for value in null_values if value >= true_value),
+        "plus_one_p_ge_true": (1 + sum(1 for value in null_values if value >= true_value)) / (len(null_values) + 1)
+        if null_values
+        else None,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    target_audit = json.loads(args.target_audit.read_text(encoding="utf-8"))
+    fidelity_rows = read_tsv(args.fidelity_summary)
+    external_rows = read_tsv(args.external_summary)
+    failures: list[str] = []
+    if target_audit.get("decision") != "ALGEBRA_C_TARGET_AUDIT_PASS":
+        failures.append("target audit did not pass")
+
+    o = find_fidelity(fidelity_rows, args.o_condition, args.o_model)
+    a8 = find_fidelity(fidelity_rows, args.a8_condition, args.a8_model)
+    h = find_fidelity(fidelity_rows, args.h_condition, args.h_model)
+    projection = find_fidelity(fidelity_rows, args.projection_condition, args.projection_model)
+    generic = find_external(external_rows, args.generic_model)
+    higher_capacity_generic = find_external(external_rows, args.higher_capacity_generic_model)
+    metrics = {
+        "o": o,
+        "a8": a8,
+        "h": h,
+        "projection": projection,
+        "generic": generic,
+        "higher_capacity_generic": higher_capacity_generic,
+    }
+    for name, value in metrics.items():
+        if name == "higher_capacity_generic":
+            continue
+        if value is None:
+            failures.append(f"missing required surface: {name}")
+    warnings: list[str] = []
+    if higher_capacity_generic is None:
+        warnings.append(
+            "WARN_UNDERCONTROLLED: higher-capacity generic control missing; run external baseline model=gru_wide"
+        )
+    null_spearman: list[float] = []
+    null_r2: list[float] = []
+    for path in args.null_summary:
+        null_rows = read_tsv(path)
+        row = find_fidelity(null_rows, args.o_condition, args.o_model)
+        if row is None:
+            failures.append(f"missing O-SSM null metric in {path}")
+            continue
+        null_spearman.append(row["spearman"])
+        null_r2.append(row["r2"])
+    trajectory_null_spearman: list[float] = []
+    trajectory_null_r2: list[float] = []
+    for path in args.trajectory_null_summary:
+        null_rows = read_tsv(path)
+        row = find_fidelity(null_rows, args.o_condition, args.o_model)
+        if row is None:
+            failures.append(f"missing O-SSM trajectory-preserving null metric in {path}")
+            continue
+        trajectory_null_spearman.append(row["spearman"])
+        trajectory_null_r2.append(row["r2"])
+
+    envelopes: dict[str, Any] = {}
+    if o is not None:
+        control_values = [value for key, value in metrics.items() if key != "o" and value is not None]
+        if o["spearman"] <= 0.0:
+            failures.append("O-SSM Spearman is not positive")
+        if control_values:
+            best_control_spearman = max(value["spearman"] for value in control_values)
+            best_control_r2 = max(value["r2"] for value in control_values)
+            if o["spearman"] - best_control_spearman < args.spearman_margin:
+                failures.append("O-SSM Spearman margin over best control is insufficient")
+            if o["r2"] - best_control_r2 < args.r2_margin:
+                failures.append("O-SSM R2 margin over best control is insufficient")
+        if projection is not None and o["spearman"] - projection["spearman"] < args.spearman_margin:
+            failures.append("associative projection did not collapse below O-SSM margin")
+        envelopes = {
+            "spearman": envelope(o["spearman"], null_spearman),
+            "r2": envelope(o["r2"], null_r2),
+            "trajectory_preserving_spearman": envelope(o["spearman"], trajectory_null_spearman),
+            "trajectory_preserving_r2": envelope(o["r2"], trajectory_null_r2),
+        }
+        if len(trajectory_null_spearman) < args.trajectory_null_count_required:
+            failures.append(
+                "trajectory-preserving continuous-target retrain nulls required; "
+                f"found {len(trajectory_null_spearman)}"
+            )
+        if len(null_spearman) < args.null_count_required:
+            failures.append(f"99 retrain nulls required; found {len(null_spearman)}")
+        if len(trajectory_null_spearman) >= args.trajectory_null_count_required:
+            if envelopes["trajectory_preserving_spearman"]["null_ge_true"] != 0:
+                failures.append("trajectory-preserving null Spearman envelope reaches/exceeds true O-SSM")
+            if envelopes["trajectory_preserving_r2"]["null_ge_true"] != 0:
+                failures.append("trajectory-preserving null R2 envelope reaches/exceeds true O-SSM")
+        if len(null_spearman) >= args.null_count_required:
+            if envelopes["spearman"]["null_ge_true"] != 0:
+                failures.append("null Spearman envelope reaches/exceeds true O-SSM")
+            if envelopes["r2"]["null_ge_true"] != 0:
+                failures.append("null R2 envelope reaches/exceeds true O-SSM")
+
+    if failures:
+        decision = "ALGEBRA_C_BLOCKED_OR_NEGATIVE"
+    elif warnings:
+        decision = "ALGEBRA_C_WARN_UNDERCONTROLLED"
+    else:
+        decision = "ALGEBRA_C_CONTINUOUS_ASSOCIATOR_FIDELITY_CANDIDATE"
+    payload = {
+        "schema": SCHEMA,
+        "decision": decision,
+        "claim_boundary": (
+            "Synthetic generator-matched inductive-bias result only; no clinical, biomarker, "
+            "biological-mechanism, MDD/ADHD, or broad O-SSM superiority claim."
+        ),
+        "inputs": {
+            "prereg": str(args.prereg),
+            "prereg_sha256": sha256_file(args.prereg),
+            "target_audit": str(args.target_audit),
+            "target_audit_sha256": sha256_file(args.target_audit),
+            "fidelity_summary": str(args.fidelity_summary),
+            "fidelity_summary_sha256": sha256_file(args.fidelity_summary),
+            "external_summary": str(args.external_summary),
+            "external_summary_sha256": sha256_file(args.external_summary),
+            "null_summaries": [str(path) for path in args.null_summary],
+        },
+        "thresholds": {
+            "spearman_margin": args.spearman_margin,
+            "r2_margin": args.r2_margin,
+            "null_count_required": args.null_count_required,
+            "trajectory_null_count_required": args.trajectory_null_count_required,
+        },
+        "metrics": metrics,
+        "null_envelopes": envelopes,
+        "warnings": warnings,
+        "failures": failures,
+    }
+    (out / "algebra_c_decision_gate.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_algebra_c_external_baselines.py
+++ b/scripts/research/neurodyn_algebra_c_external_baselines.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Run generic non-hypercomplex Algebra-C fidelity baselines.
+
+The first required generic capacity control is a small real-valued GRU.  The
+`gru_wide` option doubles the hidden width as an under-control warning check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import random
+import statistics
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from abide_campaign_lib import (
+    SubjectRecord,
+    grouped_leave_one_site_out,
+    limit_subjects,
+    load_manifest,
+    seed_schedule,
+)
+
+
+SCHEMA = "neurodyn.algebra_c.external_baselines.v1"
+
+
+def _require_torch():
+    try:
+        import torch
+        import torch.nn as nn
+    except ModuleNotFoundError as exc:
+        raise SystemExit("torch is required for Algebra-C external baselines; use --dry-run for config checks") from exc
+    return torch, nn
+
+
+def read_targets(path: Path) -> dict[str, float]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return {row["subject_id"]: float(row["target_scalar"]) for row in csv.DictReader(handle, delimiter="\t")}
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def ranks(values: list[float]) -> list[float]:
+    indexed = sorted(enumerate(values), key=lambda item: item[1])
+    out = [0.0] * len(values)
+    i = 0
+    while i < len(indexed):
+        j = i + 1
+        while j < len(indexed) and indexed[j][1] == indexed[i][1]:
+            j += 1
+        rank = (i + 1 + j) / 2.0
+        for k in range(i, j):
+            out[indexed[k][0]] = rank
+        i = j
+    return out
+
+
+def pearson(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b) or len(a) < 2:
+        return 0.0
+    ma = mean(a)
+    mb = mean(b)
+    va = sum((x - ma) * (x - ma) for x in a)
+    vb = sum((y - mb) * (y - mb) for y in b)
+    if va <= 0.0 or vb <= 0.0:
+        return 0.0
+    return sum((x - ma) * (y - mb) for x, y in zip(a, b, strict=True)) / math.sqrt(va * vb)
+
+
+def spearman(a: list[float], b: list[float]) -> float:
+    return pearson(ranks(a), ranks(b))
+
+
+def r2_score(y: list[float], pred: list[float]) -> float:
+    if not y:
+        return 0.0
+    mu = mean(y)
+    ss_tot = sum((value - mu) * (value - mu) for value in y)
+    if ss_tot <= 0.0:
+        return 0.0
+    ss_res = sum((value - estimate) * (value - estimate) for value, estimate in zip(y, pred, strict=True))
+    return 1.0 - ss_res / ss_tot
+
+
+def sign_auc(y: list[float], scores: list[float]) -> float | None:
+    pos = [score for value, score in zip(y, scores, strict=True) if value > 0.0]
+    neg = [score for value, score in zip(y, scores, strict=True) if value < 0.0]
+    if not pos or not neg:
+        return None
+    wins = 0.0
+    total = 0
+    for p in pos:
+        for n in neg:
+            total += 1
+            if p > n:
+                wins += 1.0
+            elif p == n:
+                wins += 0.5
+    return wins / total if total else None
+
+
+def calibration_slope(y: list[float], pred: list[float]) -> float:
+    mp = mean(pred)
+    my = mean(y)
+    denom = sum((p - mp) * (p - mp) for p in pred)
+    if denom <= 0.0:
+        return 0.0
+    return sum((p - mp) * (value - my) for value, p in zip(y, pred, strict=True)) / denom
+
+
+def _site_seed(site: str, seed: int) -> int:
+    h = 5381
+    for ch in site:
+        h = (h * 33 + ord(ch)) % 2_147_483_647
+    return (seed * 1315423911 + h) % 2_147_483_647
+
+
+def _set_seed(torch, seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def _pick_device(torch, requested: str):
+    if requested == "cpu":
+        return torch.device("cpu")
+    if requested == "cuda":
+        if not torch.cuda.is_available():
+            raise SystemExit("requested --device cuda but torch.cuda.is_available() is false")
+        return torch.device("cuda")
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _records_to_tensor(torch, records: list[SubjectRecord], targets: dict[str, float], indices: list[int]):
+    x = torch.tensor([records[idx].sequence for idx in indices], dtype=torch.float32)
+    y = torch.tensor([targets[records[idx].subject_id] for idx in indices], dtype=torch.float32)
+    return x, y
+
+
+def _standardize(train_x, test_x):
+    mu = train_x.mean(dim=0, keepdim=True)
+    sd = train_x.std(dim=0, keepdim=True, unbiased=False).clamp_min(1e-6)
+    return (train_x - mu) / sd, (test_x - mu) / sd
+
+
+def _iter_batches(torch, x, y, batch_size: int, seed: int):
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    indices = torch.randperm(x.shape[0], generator=generator)
+    for start in range(0, x.shape[0], batch_size):
+        batch_idx = indices[start : start + batch_size]
+        yield x[batch_idx], y[batch_idx]
+
+
+def _build_model(torch, nn, model_name: str, seq_len: int, input_dim: int, hidden_dim: int):
+    actual_hidden_dim = hidden_dim * 2 if model_name == "gru_wide" else hidden_dim
+
+    class GRURegressor(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rnn = nn.GRU(input_dim, actual_hidden_dim, batch_first=True)
+            self.head = nn.Linear(actual_hidden_dim, 1)
+
+        def forward(self, batch):
+            _, hidden = self.rnn(batch)
+            return self.head(hidden[-1]).squeeze(-1)
+
+    class TransformerRegressor(nn.Module):
+        def __init__(self):
+            super().__init__()
+            d_model = actual_hidden_dim
+            self.proj = nn.Linear(input_dim, d_model)
+            self.pos = nn.Parameter(torch.zeros(1, seq_len, d_model))
+            layer = nn.TransformerEncoderLayer(
+                d_model=d_model,
+                nhead=4,
+                dim_feedforward=max(64, hidden_dim * 2),
+                dropout=0.1,
+                batch_first=True,
+                activation="gelu",
+            )
+            self.encoder = nn.TransformerEncoder(layer, num_layers=1)
+            self.head = nn.Linear(d_model, 1)
+
+        def forward(self, batch):
+            encoded = self.encoder(self.proj(batch) + self.pos)
+            return self.head(encoded.mean(dim=1)).squeeze(-1)
+
+    model_map = {
+        "gru": GRURegressor,
+        "gru_wide": GRURegressor,
+        "transformer": TransformerRegressor,
+    }
+    if model_name not in model_map:
+        raise ValueError(f"unsupported model: {model_name}")
+    return model_map[model_name]()
+
+
+def parameter_count(model) -> int:
+    return sum(param.numel() for param in model.parameters() if param.requires_grad)
+
+
+def _train_model(torch, nn, model, x_train, y_train, epochs: int, batch_size: int, lr: float, device):
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1.0e-4)
+    loss_fn = nn.MSELoss()
+    x_train = x_train.to(device)
+    y_train = y_train.to(device)
+    model.train()
+    for epoch in range(epochs):
+        for batch_x, batch_y in _iter_batches(torch, x_train, y_train, batch_size, epoch + 17):
+            batch_x = batch_x.to(device)
+            batch_y = batch_y.to(device)
+            optimizer.zero_grad(set_to_none=True)
+            pred = model(batch_x)
+            loss = loss_fn(pred, batch_y)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            optimizer.step()
+    return model
+
+
+def run_one_model(torch, nn, records, targets, model_name: str, seed: int, epochs: int, batch_size: int, lr: float, hidden_dim: int, device):
+    rows: list[dict[str, Any]] = []
+    param_count = None
+    for holdout_site in grouped_leave_one_site_out(records):
+        train_indices = [idx for idx, record in enumerate(records) if record.site != holdout_site]
+        test_indices = [idx for idx, record in enumerate(records) if record.site == holdout_site]
+        x_train, y_train = _records_to_tensor(torch, records, targets, train_indices)
+        x_test, y_test = _records_to_tensor(torch, records, targets, test_indices)
+        x_train, x_test = _standardize(x_train, x_test)
+        _set_seed(torch, _site_seed(holdout_site, seed))
+        model = _build_model(torch, nn, model_name, x_train.shape[1], x_train.shape[2], hidden_dim).to(device)
+        param_count = parameter_count(model)
+        _train_model(torch, nn, model, x_train, y_train, epochs, batch_size, lr, device)
+        model.eval()
+        with torch.no_grad():
+            pred = model(x_test.to(device)).detach().cpu().tolist()
+        for idx, target, estimate in zip(test_indices, y_test.tolist(), pred, strict=True):
+            rows.append(
+                {
+                    "model": model_name,
+                    "seed": seed,
+                    "site": holdout_site,
+                    "subject_id": records[idx].subject_id,
+                    "target_scalar": float(target),
+                    "prediction": float(estimate),
+                    "parameter_count": param_count,
+                }
+            )
+    return rows
+
+
+def summarize_prediction_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    per_seed: list[dict[str, Any]] = []
+    groups: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    for row in rows:
+        groups.setdefault((str(row["model"]), int(row["seed"])), []).append(row)
+    for (model, seed), chunk in sorted(groups.items()):
+        y = [float(row["target_scalar"]) for row in chunk]
+        pred = [float(row["prediction"]) for row in chunk]
+        auc = sign_auc(y, pred)
+        per_seed.append(
+            {
+                "model": model,
+                "seed": seed,
+                "site_count": len({row["site"] for row in chunk}),
+                "subject_count": len(chunk),
+                "parameter_count": int(chunk[0]["parameter_count"]),
+                "spearman": spearman(y, pred),
+                "r2": r2_score(y, pred),
+                "sign_auc": "" if auc is None else auc,
+                "calibration_slope": calibration_slope(y, pred),
+            }
+        )
+    overall: list[dict[str, Any]] = []
+    by_model: dict[str, list[dict[str, Any]]] = {}
+    for row in per_seed:
+        by_model.setdefault(str(row["model"]), []).append(row)
+    for model, chunk in sorted(by_model.items()):
+        overall_row: dict[str, Any] = {
+            "model": model,
+            "seed_count": len(chunk),
+            "parameter_count": int(chunk[0]["parameter_count"]),
+            "subject_count_mean": mean([float(row["subject_count"]) for row in chunk]),
+        }
+        for key in ("spearman", "r2", "calibration_slope"):
+            vals = [float(row[key]) for row in chunk]
+            overall_row[f"{key}_mean"] = mean(vals)
+            overall_row[f"{key}_std"] = pstdev(vals)
+        auc_vals = [float(row["sign_auc"]) for row in chunk if row["sign_auc"] != ""]
+        overall_row["sign_auc_mean"] = "" if not auc_vals else mean(auc_vals)
+        overall_row["sign_auc_std"] = "" if not auc_vals else pstdev(auc_vals)
+        overall.append(overall_row)
+    return overall, per_seed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--targets", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--models", default="gru")
+    parser.add_argument("--seeds", type=int, default=5)
+    parser.add_argument("--epochs", type=int, default=40)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--lr", type=float, default=3.0e-3)
+    parser.add_argument("--hidden-dim", type=int, default=32)
+    parser.add_argument("--device", choices=["auto", "cpu", "cuda"], default="auto")
+    parser.add_argument("--limit-subjects", type=int, default=0)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    meta, records = load_manifest(args.manifest)
+    records = limit_subjects(records, args.limit_subjects or None)
+    targets = read_targets(args.targets)
+    missing = [record.subject_id for record in records if record.subject_id not in targets]
+    if missing:
+        raise SystemExit(f"targets missing {len(missing)} manifest subjects; first={missing[0]}")
+    model_list = [item.strip() for item in args.models.split(",") if item.strip()]
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+    config = {
+        "schema": SCHEMA,
+        "manifest": asdict(meta),
+        "targets": str(args.targets),
+        "run_config": {
+            "models": model_list,
+            "seeds": args.seeds,
+            "epochs": args.epochs,
+            "batch_size": args.batch_size,
+            "lr": args.lr,
+            "hidden_dim": args.hidden_dim,
+            "device": args.device,
+            "limit_subjects": args.limit_subjects,
+        },
+        "subjects_after_filter": len(records),
+        "sites_after_filter": len(grouped_leave_one_site_out(records)),
+    }
+    (out / "baseline_config.json").write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.dry_run:
+        print(json.dumps(config, indent=2, sort_keys=True))
+        return 0
+    torch, nn = _require_torch()
+    device = _pick_device(torch, args.device)
+    all_rows: list[dict[str, Any]] = []
+    seed_list = seed_schedule(args.seeds)
+    total = len(model_list) * len(seed_list)
+    run_idx = 0
+    for model_name in model_list:
+        for seed in seed_list:
+            run_idx += 1
+            started = time.perf_counter()
+            print(f"[algebra-c-external] start model={model_name} seed={seed} run={run_idx}/{total}", flush=True)
+            rows = run_one_model(torch, nn, records, targets, model_name, seed, args.epochs, args.batch_size, args.lr, args.hidden_dim, device)
+            all_rows.extend(rows)
+            print(f"[algebra-c-external] done model={model_name} seed={seed} elapsed_s={time.perf_counter() - started:.2f}", flush=True)
+    overall, per_seed = summarize_prediction_rows(all_rows)
+    write_tsv(out / "prediction_rows.tsv", all_rows)
+    write_tsv(out / "per_seed_metrics.tsv", per_seed)
+    write_tsv(out / "overall_metrics.tsv", overall)
+    payload = {**config, "overall": overall}
+    (out / "overall_metrics.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_algebra_c_fidelity_probe.py
+++ b/scripts/research/neurodyn_algebra_c_fidelity_probe.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Fold-local Algebra-C continuous associator fidelity probe.
+
+This reads trained hidden-state traces and asks whether a linear readout fitted
+on training sites predicts the held-out per-sequence associator scalar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_orientation_topk_prototype import read_manifest
+
+
+SCHEMA = "neurodyn.algebra_c.fidelity_probe.v1"
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--targets", required=True, type=Path, help="associator_targets.tsv")
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--ridge", type=float, default=1.0)
+    ap.add_argument("--top-frac", type=float, default=0.20)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def ranks(values: list[float]) -> list[float]:
+    indexed = sorted(enumerate(values), key=lambda item: item[1])
+    out = [0.0] * len(values)
+    i = 0
+    while i < len(indexed):
+        j = i + 1
+        while j < len(indexed) and indexed[j][1] == indexed[i][1]:
+            j += 1
+        rank = (i + 1 + j) / 2.0
+        for k in range(i, j):
+            out[indexed[k][0]] = rank
+        i = j
+    return out
+
+
+def pearson(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b) or len(a) < 2:
+        return 0.0
+    ma = mean(a)
+    mb = mean(b)
+    va = sum((x - ma) * (x - ma) for x in a)
+    vb = sum((y - mb) * (y - mb) for y in b)
+    if va <= 0.0 or vb <= 0.0:
+        return 0.0
+    return sum((x - ma) * (y - mb) for x, y in zip(a, b, strict=True)) / math.sqrt(va * vb)
+
+
+def spearman(a: list[float], b: list[float]) -> float:
+    return pearson(ranks(a), ranks(b))
+
+
+def r2_score(y: list[float], pred: list[float]) -> float:
+    if not y:
+        return 0.0
+    mu = mean(y)
+    ss_tot = sum((value - mu) * (value - mu) for value in y)
+    if ss_tot <= 0.0:
+        return 0.0
+    ss_res = sum((value - estimate) * (value - estimate) for value, estimate in zip(y, pred, strict=True))
+    return 1.0 - ss_res / ss_tot
+
+
+def sign_auc(y: list[float], scores: list[float]) -> float | None:
+    pos = [score for value, score in zip(y, scores, strict=True) if value > 0.0]
+    neg = [score for value, score in zip(y, scores, strict=True) if value < 0.0]
+    if not pos or not neg:
+        return None
+    wins = 0.0
+    total = 0
+    for p in pos:
+        for n in neg:
+            total += 1
+            if p > n:
+                wins += 1.0
+            elif p == n:
+                wins += 0.5
+    return wins / total if total else None
+
+
+def calibration_slope(y: list[float], pred: list[float]) -> float:
+    mp = mean(pred)
+    my = mean(y)
+    denom = sum((p - mp) * (p - mp) for p in pred)
+    if denom <= 0.0:
+        return 0.0
+    return sum((p - mp) * (value - my) for value, p in zip(y, pred, strict=True)) / denom
+
+
+def topk_enrichment(y: list[float], pred: list[float], frac: float) -> float:
+    if not y:
+        return 0.0
+    k = max(1, int(round(len(y) * frac)))
+    global_mean = mean([abs(value) for value in y])
+    if global_mean <= 0.0:
+        return 0.0
+    picked = sorted(range(len(pred)), key=lambda idx: abs(pred[idx]), reverse=True)[:k]
+    return mean([abs(y[idx]) for idx in picked]) / global_mean
+
+
+def standardize(train_x: list[list[float]], rows_x: list[list[float]]) -> list[list[float]]:
+    dim = len(train_x[0]) if train_x else 0
+    mu = [mean([row[d] for row in train_x]) for d in range(dim)]
+    sd: list[float] = []
+    for d in range(dim):
+        var = mean([(row[d] - mu[d]) * (row[d] - mu[d]) for row in train_x])
+        sd.append(math.sqrt(var) if var > 1.0e-18 else 1.0)
+    return [[(row[d] - mu[d]) / sd[d] for d in range(dim)] for row in rows_x]
+
+
+def solve_linear(a: list[list[float]], b: list[float]) -> list[float]:
+    n = len(a)
+    aug = [list(a[i]) + [b[i]] for i in range(n)]
+    for col in range(n):
+        pivot = max(range(col, n), key=lambda r: abs(aug[r][col]))
+        if abs(aug[pivot][col]) < 1.0e-12:
+            continue
+        if pivot != col:
+            aug[col], aug[pivot] = aug[pivot], aug[col]
+        div = aug[col][col]
+        for j in range(col, n + 1):
+            aug[col][j] /= div
+        for r in range(n):
+            if r == col:
+                continue
+            factor = aug[r][col]
+            if abs(factor) <= 1.0e-18:
+                continue
+            for j in range(col, n + 1):
+                aug[r][j] -= factor * aug[col][j]
+    return [aug[i][n] for i in range(n)]
+
+
+def fit_ridge(train_x: list[list[float]], train_y: list[float], ridge: float) -> list[float]:
+    if not train_x:
+        return []
+    p = len(train_x[0]) + 1
+    xtx = [[0.0 for _ in range(p)] for _ in range(p)]
+    xty = [0.0 for _ in range(p)]
+    for x, y in zip(train_x, train_y, strict=True):
+        xb = [1.0] + x
+        for i in range(p):
+            xty[i] += xb[i] * y
+            for j in range(p):
+                xtx[i][j] += xb[i] * xb[j]
+    for i in range(1, p):
+        xtx[i][i] += ridge
+    return solve_linear(xtx, xty)
+
+
+def predict(weights: list[float], x: list[float]) -> float:
+    return weights[0] + sum(w * value for w, value in zip(weights[1:], x, strict=True))
+
+
+def subject_meta(reference_manifest: Path, targets: Path) -> dict[int, dict[str, Any]]:
+    manifest_rows = read_manifest(reference_manifest)
+    target_rows = {row["subject_id"]: row for row in read_tsv(targets)}
+    out: dict[int, dict[str, Any]] = {}
+    for idx, row in enumerate(manifest_rows):
+        target = target_rows.get(row["subject_id"])
+        if target is None:
+            raise SystemExit(f"missing associator target for {row['subject_id']}")
+        out[idx] = {
+            "subject_id": row["subject_id"],
+            "site": row["site"],
+            "target_scalar": float(target["target_scalar"]),
+            "target_sign": int(target["target_sign"]),
+            "target_component": int(target["target_component"]),
+        }
+    return out
+
+
+def collect_rows(run: Path, condition: str, meta: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+    state_rows = parse_state_rows(run / "brain_ossm_abide.raw.txt")
+    out: list[dict[str, Any]] = []
+    for row in state_rows:
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        out.append(
+            {
+                "condition": condition,
+                "model": row["model"],
+                "seed": int(row["seed"]),
+                "subject_id": m["subject_id"],
+                "site": m["site"],
+                "x": list(row["h"]),
+                "y": float(m["target_scalar"]),
+                "target_sign": int(m["target_sign"]),
+                "target_component": int(m["target_component"]),
+            }
+        )
+    return out
+
+
+def evaluate(rows: list[dict[str, Any]], ridge: float, top_frac: float) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    seed_rows: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        y_all: list[float] = []
+        pred_all: list[float] = []
+        for site in sites:
+            train = [row for row in chunk if row["site"] != site]
+            test = [row for row in chunk if row["site"] == site]
+            if not train or not test:
+                continue
+            train_x_raw = [row["x"] for row in train]
+            train_x = standardize(train_x_raw, train_x_raw)
+            weights = fit_ridge(train_x, [row["y"] for row in train], ridge)
+            test_x = standardize(train_x_raw, [row["x"] for row in test])
+            for row, x in zip(test, test_x, strict=True):
+                pred = predict(weights, x)
+                y_all.append(row["y"])
+                pred_all.append(pred)
+                detail.append(
+                    {
+                        "condition": condition,
+                        "model": model,
+                        "seed": seed,
+                        "holdout_site": site,
+                        "subject_id": row["subject_id"],
+                        "target_scalar": row["y"],
+                        "prediction": pred,
+                        "target_sign": row["target_sign"],
+                        "target_component": row["target_component"],
+                    }
+                )
+        auc = sign_auc(y_all, pred_all)
+        seed_rows.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed": seed,
+                "subject_count": len(y_all),
+                "site_count": len(sites),
+                "spearman": spearman(y_all, pred_all),
+                "r2": r2_score(y_all, pred_all),
+                "sign_auc": "" if auc is None else auc,
+                "calibration_slope": calibration_slope(y_all, pred_all),
+                "topk_enrichment": topk_enrichment(y_all, pred_all, top_frac),
+            }
+        )
+    return detail, seed_rows
+
+
+def summarize(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        groups[(row["condition"], row["model"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model), chunk in sorted(groups.items()):
+        numeric_keys = ["spearman", "r2", "calibration_slope", "topk_enrichment"]
+        row: dict[str, Any] = {
+            "condition": condition,
+            "model": model,
+            "seed_count": len(chunk),
+            "subject_count_mean": mean([float(item["subject_count"]) for item in chunk]),
+        }
+        for key in numeric_keys:
+            vals = [float(item[key]) for item in chunk]
+            row[f"{key}_mean"] = mean(vals)
+            row[f"{key}_std"] = pstdev(vals)
+        auc_vals = [float(item["sign_auc"]) for item in chunk if item["sign_auc"] != ""]
+        row["sign_auc_mean"] = "" if not auc_vals else mean(auc_vals)
+        row["sign_auc_std"] = "" if not auc_vals else pstdev(auc_vals)
+        out.append(row)
+    return out
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts must match")
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+    meta = subject_meta(args.reference_manifest, args.targets)
+    rows: list[dict[str, Any]] = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        rows.extend(collect_rows(run, condition, meta))
+    detail, seed_rows = evaluate(rows, args.ridge, args.top_frac)
+    summary_rows = summarize(seed_rows)
+    write_tsv(out / "fidelity_predictions.tsv", detail)
+    write_tsv(out / "fidelity_per_seed.tsv", seed_rows)
+    write_tsv(out / "fidelity_summary.tsv", summary_rows)
+    payload = {
+        "schema": SCHEMA,
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "targets": str(args.targets),
+        "targets_sha256": sha256_file(args.targets),
+        "ridge": args.ridge,
+        "top_frac": args.top_frac,
+        "runs": [
+            {"condition": condition, "path": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")}
+            for run, condition in zip(args.run, args.condition, strict=True)
+        ],
+        "summary": summary_rows,
+    }
+    (out / "fidelity_probe.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_algebra_c_target_audit.py
+++ b/scripts/research/neurodyn_algebra_c_target_audit.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Audit Algebra-C associator targets before any model smoke.
+
+The gate is deliberately about target quality, not model performance.  It
+rejects categorical or one-sided targets before they can masquerade as a
+continuous associator-fidelity endpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.algebra_c.target_audit.v1"
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--targets", required=True, type=Path, help="associator_targets.tsv")
+    ap.add_argument("--manifest", type=Path, help="optional manifest used for hashing/provenance")
+    ap.add_argument("--min-distinct-ratio", type=float, default=0.80)
+    ap.add_argument("--max-tie-fraction", type=float, default=0.20)
+    ap.add_argument("--require-both-signs", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--require-site-both-signs", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def summarize(rows: list[dict[str, str]]) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    if not rows:
+        return {}, [], ["target table is empty"]
+    errors: list[str] = []
+    values = [float(row["target_scalar"]) for row in rows]
+    rounded = [round(value, 10) for value in values]
+    distinct_counts = Counter(rounded)
+    tied_rows = sum(count for count in distinct_counts.values() if count > 1)
+    tie_sensitivity: dict[str, dict[str, float]] = {}
+    for digits in (8, 10, 12):
+        counts = Counter(round(value, digits) for value in values)
+        tied = sum(count for count in counts.values() if count > 1)
+        tie_sensitivity[str(digits)] = {
+            "distinct_target_values": len(counts),
+            "distinct_ratio": len(counts) / len(rows),
+            "tie_fraction": tied / len(rows),
+        }
+    signs = Counter(int(row["target_sign"]) for row in rows)
+    sites: dict[str, list[dict[str, str]]] = defaultdict(list)
+    components = Counter(int(row["target_component"]) for row in rows)
+    for row in rows:
+        sites[row["site"]].append(row)
+    site_rows: list[dict[str, Any]] = []
+    for site, chunk in sorted(sites.items()):
+        site_values = [float(row["target_scalar"]) for row in chunk]
+        site_signs = Counter(int(row["target_sign"]) for row in chunk)
+        site_distinct = len({round(value, 10) for value in site_values})
+        site_rows.append(
+            {
+                "site": site,
+                "rows": len(chunk),
+                "distinct_target_values": site_distinct,
+                "sign_neg": site_signs[-1],
+                "sign_pos": site_signs[1],
+                "target_min": min(site_values),
+                "target_max": max(site_values),
+            }
+        )
+    summary = {
+        "row_count": len(rows),
+        "site_count": len(sites),
+        "target_min": min(values),
+        "target_max": max(values),
+        "target_mean": statistics.fmean(values),
+        "target_std": statistics.pstdev(values) if len(values) > 1 else 0.0,
+        "distinct_target_values": len(distinct_counts),
+        "distinct_ratio": len(distinct_counts) / len(rows),
+        "tie_fraction": tied_rows / len(rows),
+        "sign_counts": {str(key): signs[key] for key in sorted(signs)},
+        "target_components": {str(key): components[key] for key in sorted(components)},
+        "tie_sensitivity_decimal_places": tie_sensitivity,
+    }
+    if summary["target_min"] == summary["target_max"]:
+        errors.append("target is constant")
+    return summary, site_rows, errors
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+    rows = read_rows(args.targets)
+    summary, site_rows, errors = summarize(rows)
+    sign_counts = {int(key): value for key, value in summary.get("sign_counts", {}).items()}
+    if summary.get("distinct_ratio", 0.0) < args.min_distinct_ratio:
+        errors.append(
+            f"distinct ratio {summary.get('distinct_ratio', 0.0):.6f} < {args.min_distinct_ratio:.6f}"
+        )
+    if summary.get("tie_fraction", 1.0) > args.max_tie_fraction:
+        errors.append(
+            f"tie fraction {summary.get('tie_fraction', 1.0):.6f} > {args.max_tie_fraction:.6f}"
+        )
+    if args.require_both_signs and (sign_counts.get(-1, 0) == 0 or sign_counts.get(1, 0) == 0):
+        errors.append("target must contain both negative and positive signs")
+    if args.require_site_both_signs:
+        for row in site_rows:
+            if int(row["sign_neg"]) == 0 or int(row["sign_pos"]) == 0:
+                errors.append(f"site {row['site']} lacks both target signs")
+    decision = "ALGEBRA_C_TARGET_AUDIT_PASS" if not errors else "ALGEBRA_C_TARGET_AUDIT_FAIL"
+    payload = {
+        "schema": SCHEMA,
+        "decision": decision,
+        "targets": str(args.targets),
+        "targets_sha256": sha256_file(args.targets),
+        "manifest": str(args.manifest) if args.manifest else None,
+        "manifest_sha256": sha256_file(args.manifest) if args.manifest else None,
+        "thresholds": {
+            "min_distinct_ratio": args.min_distinct_ratio,
+            "max_tie_fraction": args.max_tie_fraction,
+            "require_both_signs": args.require_both_signs,
+            "require_site_both_signs": args.require_site_both_signs,
+        },
+        "summary": summary,
+        "errors": errors,
+    }
+    (out / "target_audit.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_tsv(out / "target_audit_by_site.tsv", site_rows)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_associator_manifest_balance_gate.py
+++ b/scripts/research/neurodyn_associator_manifest_balance_gate.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Gate site/label/associator-dimension balance for associator manifests."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.associator_manifest_balance_gate.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def pair_id(subject_id: str) -> str:
+    return subject_id.split("__", 1)[0]
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader((line for line in handle if not line.startswith("#")), delimiter="\t"))
+
+
+def read_triples(path: Path) -> dict[str, dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    return {f"assoc_pair_{int(row['pair_id']):04d}": row for row in rows}
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--associator-triples", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "associator_manifest_balance_gate.json").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+
+    manifest_rows = read_manifest(args.manifest)
+    triples = read_triples(args.associator_triples)
+    pair_site: dict[str, str] = {}
+    label_by_site: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in manifest_rows:
+        pid = pair_id(row["subject_id"])
+        pair_site.setdefault(pid, row["site"])
+        if pair_site[pid] != row["site"]:
+            raise SystemExit(f"pair split across sites: {pid}")
+        label_by_site[row["site"]][row["label"]] += 1
+
+    site_dim_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    dim_site_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    sign_site_counts: dict[str, Counter[str]] = defaultdict(Counter)
+    for pid, site in sorted(pair_site.items()):
+        meta = triples.get(pid)
+        if meta is None:
+            raise SystemExit(f"missing triple metadata for {pid}")
+        dim = str(meta["assoc_dim"])
+        sign = "positive" if float(meta["positive_assoc_value"]) > 0.0 else "negative"
+        site_dim_counts[site][dim] += 1
+        dim_site_counts[dim][site] += 1
+        sign_site_counts[site][sign] += 1
+
+    site_rows: list[dict[str, Any]] = []
+    all_dims = sorted({dim for counts in site_dim_counts.values() for dim in counts}, key=int)
+    for site in sorted(site_dim_counts):
+        row: dict[str, Any] = {
+            "site": site,
+            "pair_count": sum(site_dim_counts[site].values()),
+            "label_0": label_by_site[site].get("0", 0),
+            "label_1": label_by_site[site].get("1", 0),
+            "assoc_sign_positive": sign_site_counts[site].get("positive", 0),
+            "assoc_sign_negative": sign_site_counts[site].get("negative", 0),
+            "assoc_dim_nonzero_count": sum(1 for dim in all_dims if site_dim_counts[site].get(dim, 0) > 0),
+        }
+        for dim in all_dims:
+            row[f"assoc_dim_{int(dim):02d}"] = site_dim_counts[site].get(dim, 0)
+        site_rows.append(row)
+
+    dim_rows: list[dict[str, Any]] = []
+    for dim in all_dims:
+        counts = dim_site_counts[dim]
+        dim_rows.append(
+            {
+                "assoc_dim": dim,
+                "site_nonzero_count": sum(1 for site in counts if counts[site] > 0),
+                "pair_count": sum(counts.values()),
+                "min_pairs_per_nonzero_site": min(counts.values()) if counts else 0,
+                "max_pairs_per_site": max(counts.values()) if counts else 0,
+            }
+        )
+
+    label_balanced = all(counts.get("0", 0) == counts.get("1", 0) for counts in label_by_site.values())
+    site_dim_nonzero_min = min(row["assoc_dim_nonzero_count"] for row in site_rows) if site_rows else 0
+    dim_site_nonzero_min = min(row["site_nonzero_count"] for row in dim_rows) if dim_rows else 0
+    deterministic_site_dim = any(row["assoc_dim_nonzero_count"] == 1 for row in site_rows)
+    decision = (
+        "ASSOCIATOR_MANIFEST_SITE_DIM_DECOUPLED_READY"
+        if label_balanced and site_dim_nonzero_min >= 4 and dim_site_nonzero_min >= 4 and not deterministic_site_dim
+        else "ASSOCIATOR_MANIFEST_BALANCE_GATE_NOT_READY"
+    )
+    payload = {
+        "schema": SCHEMA,
+        "manifest": str(args.manifest),
+        "manifest_sha256": sha256_file(args.manifest),
+        "associator_triples": str(args.associator_triples),
+        "associator_triples_sha256": sha256_file(args.associator_triples),
+        "site_count": len(site_rows),
+        "pair_count": len(pair_site),
+        "assoc_dim_count": len(all_dims),
+        "label_balanced_by_site": label_balanced,
+        "site_dim_nonzero_min": site_dim_nonzero_min,
+        "dim_site_nonzero_min": dim_site_nonzero_min,
+        "deterministic_site_dim": deterministic_site_dim,
+        "decision": decision,
+    }
+    write_tsv(out / "site_assoc_dim_balance.tsv", site_rows)
+    write_tsv(out / "assoc_dim_site_balance.tsv", dim_rows)
+    (out / "associator_manifest_balance_gate.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = [
+        "# Associator Manifest Balance Gate",
+        "",
+        f"Decision: `{decision}`",
+        "",
+        f"- pairs: `{payload['pair_count']}`",
+        f"- sites: `{payload['site_count']}`",
+        f"- assoc dims: `{payload['assoc_dim_count']}`",
+        f"- label balanced by site: `{label_balanced}`",
+        f"- min assoc dims per site: `{site_dim_nonzero_min}`",
+        f"- min sites per assoc dim: `{dim_site_nonzero_min}`",
+        f"- deterministic site->dim coupling: `{deterministic_site_dim}`",
+        "",
+    ]
+    (out / "associator_manifest_balance_gate.md").write_text("\n".join(md), encoding="utf-8")
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in out.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_associator_orientation_hidden_contrast.py
+++ b/scripts/research/neurodyn_associator_orientation_hidden_contrast.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Fixed-orientation hidden-state contrast for octonionic associator runs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_frozen_hidden_linear_readout import (
+    auroc,
+    balanced_accuracy,
+    predict,
+    train_logistic,
+    zscore,
+)
+
+
+SCHEMA = "neurodyn.associator_orientation_hidden_contrast.v1"
+CLAIM_BOUNDARY = (
+    "Synthetic associator orientation hidden-state diagnostic only. This is not a "
+    "clinical, biomarker, mechanistic, null-validated, or broad O-SSM claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True, type=Path, help="Original true-orientation manifest.")
+    ap.add_argument("--run", action="append", required=True, type=Path, help="Run directory with brain_ossm_abide.raw.txt.")
+    ap.add_argument("--condition", action="append", required=True, help="Condition label for matching --run.")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--fixed-l2", type=float, default=0.01)
+    ap.add_argument("--epochs", type=int, default=800)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")]
+    if not lines:
+        raise SystemExit(f"manifest has no rows: {path}")
+    return list(csv.DictReader(lines, delimiter="\t"))
+
+
+def orientation_label(subject_id: str) -> int:
+    if subject_id.endswith("__positive"):
+        return 1
+    if subject_id.endswith("__negative"):
+        return 0
+    raise SystemExit(f"subject id lacks associator orientation suffix: {subject_id}")
+
+
+def pair_id(subject_id: str) -> str:
+    if "__" not in subject_id:
+        raise SystemExit(f"subject id lacks pair suffix: {subject_id}")
+    return subject_id.split("__", 1)[0]
+
+
+def attach_orientation(rows: list[dict[str, Any]], manifest_rows: list[dict[str, str]], condition: str, run: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        idx = int(row["subject_index"])
+        if idx < 0 or idx >= len(manifest_rows):
+            raise SystemExit(f"subject index out of range: {idx}")
+        subject_id = manifest_rows[idx]["subject_id"]
+        item = dict(row)
+        item["condition"] = condition
+        item["run"] = str(run)
+        item["subject_id"] = subject_id
+        item["pair_id"] = pair_id(subject_id)
+        item["orientation_label"] = orientation_label(subject_id)
+        out.append(item)
+    return out
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def centroid(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    return [sum(vec[d] for vec in vectors) / len(vectors) for d in range(dim)]
+
+
+def dist2(a: list[float], b: list[float]) -> float:
+    return sum((x - y) * (x - y) for x, y in zip(a, b, strict=True))
+
+
+def centroid_probe(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        for holdout_site in sorted({row["site"] for row in chunk}):
+            train = [row for row in chunk if row["site"] != holdout_site]
+            test = [row for row in chunk if row["site"] == holdout_site]
+            pos = centroid([row["h"] for row in train if row["orientation_label"] == 1])
+            neg = centroid([row["h"] for row in train if row["orientation_label"] == 0])
+            if not pos or not neg:
+                continue
+            labels: list[int] = []
+            preds: list[int] = []
+            scores: list[float] = []
+            for row in test:
+                dpos = dist2(row["h"], pos)
+                dneg = dist2(row["h"], neg)
+                score = dneg - dpos
+                labels.append(int(row["orientation_label"]))
+                preds.append(1 if score >= 0.0 else 0)
+                scores.append(score)
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "holdout_site": holdout_site,
+                    "probe": "centroid",
+                    "rows": len(test),
+                    "balanced_accuracy": balanced_accuracy(labels, preds),
+                    "auroc": auroc(labels, scores),
+                    "score_mean": mean(scores),
+                    "score_std": pstdev(scores),
+                }
+            )
+    return out
+
+
+def logistic_probe(rows: list[dict[str, Any]], *, fixed_l2: float, epochs: int, lr: float) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        for holdout_site in sorted({row["site"] for row in chunk}):
+            train = [row for row in chunk if row["site"] != holdout_site]
+            test = [row for row in chunk if row["site"] == holdout_site]
+            if not train or not test:
+                continue
+            x_train_raw = [row["h"] for row in train]
+            x_test_raw = [row["h"] for row in test]
+            x_train, _, _ = zscore(x_train_raw, x_train_raw)
+            x_test, _, _ = zscore(x_train_raw, x_test_raw)
+            y_train = [int(row["orientation_label"]) for row in train]
+            y_test = [int(row["orientation_label"]) for row in test]
+            w, b = train_logistic(x_train, y_train, l2=fixed_l2, epochs=epochs, lr=lr)
+            preds, scores = predict(w, b, x_test)
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "holdout_site": holdout_site,
+                    "probe": "frozen_logistic",
+                    "rows": len(test),
+                    "balanced_accuracy": balanced_accuracy(y_test, preds),
+                    "auroc": auroc(y_test, scores),
+                    "score_mean": mean(scores),
+                    "score_std": pstdev(scores),
+                    "weight_norm": math.sqrt(sum(v * v for v in w)),
+                }
+            )
+    return out
+
+
+def summarize(details: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in details:
+        grouped[(row["condition"], row["model"], row["probe"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model, probe), chunk in sorted(grouped.items()):
+        bas = [float(row["balanced_accuracy"]) for row in chunk]
+        aucs = [float(row["auroc"]) for row in chunk]
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "probe": probe,
+                "fold_count": len(chunk),
+                "balanced_accuracy_mean": mean(bas),
+                "balanced_accuracy_std": pstdev(bas),
+                "auroc_mean": mean(aucs),
+                "auroc_std": pstdev(aucs),
+                "score_mean": mean([float(row["score_mean"]) for row in chunk]),
+            }
+        )
+    return out
+
+
+def null_envelope(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    keys = sorted({(row["model"], row["probe"]) for row in summary})
+    for model, probe in keys:
+        true = [row for row in summary if row["condition"] == "true" and row["model"] == model and row["probe"] == probe]
+        nulls = [row for row in summary if row["condition"].startswith("null") and row["model"] == model and row["probe"] == probe]
+        if not true or not nulls:
+            continue
+        t = true[0]
+        null_ba = [float(row["balanced_accuracy_mean"]) for row in nulls]
+        null_auc = [float(row["auroc_mean"]) for row in nulls]
+        true_ba = float(t["balanced_accuracy_mean"])
+        true_auc = float(t["auroc_mean"])
+        ba_ge = sum(1 for value in null_ba if value >= true_ba)
+        auc_ge = sum(1 for value in null_auc if value >= true_auc)
+        out.append(
+            {
+                "model": model,
+                "probe": probe,
+                "true_balanced_accuracy_mean": true_ba,
+                "null_balanced_accuracy_mean": mean(null_ba),
+                "null_balanced_accuracy_max": max(null_ba),
+                "null_ba_ge_true_count": ba_ge,
+                "empirical_ba_p_ge_true": (1.0 + ba_ge) / (1.0 + len(nulls)),
+                "true_auroc_mean": true_auc,
+                "null_auroc_mean": mean(null_auc),
+                "null_auroc_max": max(null_auc),
+                "null_auroc_ge_true_count": auc_ge,
+                "empirical_auroc_p_ge_true": (1.0 + auc_ge) / (1.0 + len(nulls)),
+            }
+        )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fieldnames: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in fieldnames:
+                fieldnames.append(key)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t", lineterminator="\n", extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Associator Orientation Hidden Contrast",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Summary",
+        "",
+        "| condition | model | probe | BA | AUROC |",
+        "|---|---|---|---:|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {condition} | {model} | {probe} | {ba:.6f} | {auc:.6f} |".format(
+                condition=row["condition"],
+                model=row["model"],
+                probe=row["probe"],
+                ba=row["balanced_accuracy_mean"],
+                auc=row["auroc_mean"],
+            )
+        )
+    lines.extend(["", "## Null Envelope", "", "| model | probe | true BA | null max BA | p BA | true AUROC | null max AUROC | p AUROC |", "|---|---|---:|---:|---:|---:|---:|---:|"])
+    for row in payload["null_envelope"]:
+        lines.append(
+            "| {model} | {probe} | {tba:.6f} | {nba:.6f} | {pba:.6f} | {tauc:.6f} | {nauc:.6f} | {pauc:.6f} |".format(
+                model=row["model"],
+                probe=row["probe"],
+                tba=row["true_balanced_accuracy_mean"],
+                nba=row["null_balanced_accuracy_max"],
+                pba=row["empirical_ba_p_ge_true"],
+                tauc=row["true_auroc_mean"],
+                nauc=row["null_auroc_max"],
+                pauc=row["empirical_auroc_p_ge_true"],
+            )
+        )
+    lines.extend(["", "## Interpretation", "", payload["interpretation"], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts must match")
+    if args.output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_rows = read_manifest(args.manifest)
+    rows: list[dict[str, Any]] = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        rows.extend(attach_orientation(parse_state_rows(run / "brain_ossm_abide.raw.txt"), manifest_rows, condition, run))
+    details = centroid_probe(rows) + logistic_probe(rows, fixed_l2=args.fixed_l2, epochs=args.epochs, lr=args.lr)
+    summary = summarize(details)
+    envelope = null_envelope(summary)
+    interpretation = (
+        "This diagnostic uses the original manifest orientation as the fixed target, "
+        "even for pair-label null runs. Centroid probes test geometry directly; frozen "
+        "logistic probes ask whether a simple fold-local readout can recover orientation "
+        "from hidden states when the integrated readout is not fixed-target selective."
+    )
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "manifest": str(args.manifest),
+        "manifest_sha256": sha256_file(args.manifest),
+        "runs": [{"condition": c, "run": str(r)} for r, c in zip(args.run, args.condition, strict=True)],
+        "fixed_l2": args.fixed_l2,
+        "epochs": args.epochs,
+        "lr": args.lr,
+        "detail_rows": len(details),
+        "summary": summary,
+        "null_envelope": envelope,
+        "interpretation": interpretation,
+    }
+    (args.output_dir / "associator_orientation_hidden_contrast.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_tsv(args.output_dir / "associator_orientation_hidden_detail.tsv", details)
+    write_tsv(args.output_dir / "associator_orientation_hidden_summary.tsv", summary)
+    write_tsv(args.output_dir / "associator_orientation_hidden_null_envelope.tsv", envelope)
+    (args.output_dir / "associator_orientation_hidden_contrast.md").write_text(markdown(payload), encoding="utf-8")
+    with (args.output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in args.output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_associator_orientation_readout_contrast.py
+++ b/scripts/research/neurodyn_associator_orientation_readout_contrast.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Contrast trained readout scores on original associator pair orientation.
+
+For pair-label null runs, the evaluated labels are permuted but subject IDs keep
+their original ``__positive`` / ``__negative`` suffixes. This probe asks a fixed
+target question: does the trained model assign a higher score to the original
+associator-positive member of each pair than to its swapped-sign mate?
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.associator_orientation_readout_contrast.v1"
+CLAIM_BOUNDARY = (
+    "Synthetic associator orientation readout diagnostic only. This is not a "
+    "clinical, biomarker, mechanistic, null-validated, or broad O-SSM claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True, type=Path, help="Original true-orientation manifest.")
+    ap.add_argument("--run", action="append", required=True, type=Path, help="Run directory with brain_ossm_abide.raw.txt.")
+    ap.add_argument("--condition", action="append", required=True, help="Condition label for matching --run.")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")]
+    if not lines:
+        raise SystemExit(f"manifest has no rows: {path}")
+    return list(csv.DictReader(lines, delimiter="\t"))
+
+
+def pair_id(subject_id: str) -> str:
+    if "__" not in subject_id:
+        raise SystemExit(f"subject id lacks pair suffix: {subject_id}")
+    return subject_id.split("__", 1)[0]
+
+
+def orientation(subject_id: str) -> str:
+    if subject_id.endswith("__positive"):
+        return "positive"
+    if subject_id.endswith("__negative"):
+        return "negative"
+    raise SystemExit(f"subject id lacks associator orientation suffix: {subject_id}")
+
+
+def parse_pred_rows(raw_output: Path, manifest_rows: list[dict[str, str]], condition: str, run: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    lines = raw_output.read_text(encoding="utf-8").splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.startswith("PRED\t"):
+            idx += 1
+            continue
+        parts = [part for part in line.split("\t") if part]
+        line_no = idx + 1
+        next_idx = idx + 1
+        while len(parts) < 9 and next_idx < len(lines) and lines[next_idx].startswith("\t"):
+            parts.extend(part for part in lines[next_idx].split("\t") if part)
+            next_idx += 1
+        if len(parts) != 9:
+            raise SystemExit(f"malformed PRED at {raw_output}:{line_no}: expected 9 fields got {len(parts)}")
+        _, model, seed, subj_raw, site, label, prob_micros, pred, assoc_micros = parts
+        subj = int(subj_raw)
+        if subj < 0 or subj >= len(manifest_rows):
+            raise SystemExit(f"subject index out of range at {raw_output}:{idx}: {subj}")
+        subject_id = manifest_rows[subj]["subject_id"]
+        rows.append(
+            {
+                "condition": condition,
+                "run": str(run),
+                "model": model,
+                "seed": int(seed),
+                "subject_index": subj,
+                "subject_id": subject_id,
+                "pair_id": pair_id(subject_id),
+                "orientation": orientation(subject_id),
+                "site": site,
+                "eval_label": int(label),
+                "prob": int(prob_micros) / 1_000_000.0,
+                "pred": int(pred),
+                "assoc": int(assoc_micros) / 1_000_000.0,
+            }
+        )
+        idx = next_idx
+    if not rows:
+        raise SystemExit(f"no PRED rows found in {raw_output}")
+    return rows
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def pair_contrasts(pred_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_key: dict[tuple[str, str, int, str], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in pred_rows:
+        key = (row["condition"], row["model"], row["seed"], row["pair_id"])
+        by_key[key][row["orientation"]] = row
+
+    out: list[dict[str, Any]] = []
+    for (condition, model, seed, pid), parts in sorted(by_key.items()):
+        if "positive" not in parts or "negative" not in parts:
+            continue
+        pos = parts["positive"]
+        neg = parts["negative"]
+        margin = float(pos["prob"]) - float(neg["prob"])
+        if margin > 0.0:
+            acc = 1.0
+        elif margin < 0.0:
+            acc = 0.0
+        else:
+            acc = 0.5
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed": seed,
+                "pair_id": pid,
+                "site": pos["site"],
+                "positive_prob": pos["prob"],
+                "negative_prob": neg["prob"],
+                "orientation_margin": margin,
+                "orientation_correct": acc,
+                "positive_eval_label": pos["eval_label"],
+                "negative_eval_label": neg["eval_label"],
+            }
+        )
+    if not out:
+        raise SystemExit("no complete positive/negative prediction pairs found")
+    return out
+
+
+def summarize_pairs(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    by_seed: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_seed[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    seed_rows: list[dict[str, Any]] = []
+    for (condition, model, seed), chunk in sorted(by_seed.items()):
+        seed_rows.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed": seed,
+                "pair_count": len(chunk),
+                "orientation_accuracy_pct": 100.0 * mean([float(row["orientation_correct"]) for row in chunk]),
+                "orientation_margin_mean": mean([float(row["orientation_margin"]) for row in chunk]),
+                "orientation_margin_std": pstdev([float(row["orientation_margin"]) for row in chunk]),
+            }
+        )
+
+    by_model: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        by_model[(row["condition"], row["model"])].append(row)
+
+    summary_rows: list[dict[str, Any]] = []
+    for (condition, model), chunk in sorted(by_model.items()):
+        accs = [float(row["orientation_accuracy_pct"]) for row in chunk]
+        margins = [float(row["orientation_margin_mean"]) for row in chunk]
+        summary_rows.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed_count": len(chunk),
+                "pair_count_per_seed": int(chunk[0]["pair_count"]) if chunk else 0,
+                "orientation_accuracy_pct_mean": mean(accs),
+                "orientation_accuracy_pct_std": pstdev(accs),
+                "orientation_margin_mean": mean(margins),
+                "orientation_margin_std": pstdev(margins),
+            }
+        )
+    return seed_rows, summary_rows
+
+
+def null_envelope(summary_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    true_rows = [row for row in summary_rows if row["condition"] == "true" and row["model"] == "O-SSM"]
+    null_rows = [row for row in summary_rows if row["condition"].startswith("null") and row["model"] == "O-SSM"]
+    if not true_rows or not null_rows:
+        return {}
+    true = true_rows[0]
+    null_acc = [float(row["orientation_accuracy_pct_mean"]) for row in null_rows]
+    null_margin = [float(row["orientation_margin_mean"]) for row in null_rows]
+    true_acc = float(true["orientation_accuracy_pct_mean"])
+    true_margin = float(true["orientation_margin_mean"])
+    acc_ge = sum(1 for value in null_acc if value >= true_acc)
+    margin_ge = sum(1 for value in null_margin if value >= true_margin)
+    return {
+        "true_o_orientation_accuracy_pct": true_acc,
+        "true_o_orientation_margin_mean": true_margin,
+        "null_count": len(null_rows),
+        "null_o_orientation_accuracy_pct_mean": mean(null_acc),
+        "null_o_orientation_accuracy_pct_max": max(null_acc),
+        "null_o_orientation_margin_mean": mean(null_margin),
+        "null_o_orientation_margin_max": max(null_margin),
+        "null_accuracy_ge_true_count": acc_ge,
+        "null_margin_ge_true_count": margin_ge,
+        "empirical_accuracy_p_ge_true": (1.0 + acc_ge) / (1.0 + len(null_rows)),
+        "empirical_margin_p_ge_true": (1.0 + margin_ge) / (1.0 + len(null_rows)),
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Associator Orientation Readout Contrast",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Summary",
+        "",
+        "| condition | model | orientation accuracy | margin mean |",
+        "|---|---|---:|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {condition} | {model} | {acc:.6f} | {margin:.9f} |".format(
+                condition=row["condition"],
+                model=row["model"],
+                acc=row["orientation_accuracy_pct_mean"],
+                margin=row["orientation_margin_mean"],
+            )
+        )
+    if payload["null_envelope"]:
+        env = payload["null_envelope"]
+        lines.extend(
+            [
+                "",
+                "## Null Envelope",
+                "",
+                f"- true O orientation accuracy: `{env['true_o_orientation_accuracy_pct']:.6f}`",
+                f"- null O orientation accuracy mean: `{env['null_o_orientation_accuracy_pct_mean']:.6f}`",
+                f"- null O orientation accuracy max: `{env['null_o_orientation_accuracy_pct_max']:.6f}`",
+                f"- accuracy plus-one p_ge_true: `{env['empirical_accuracy_p_ge_true']:.6f}`",
+                f"- true O orientation margin: `{env['true_o_orientation_margin_mean']:.9f}`",
+                f"- null O orientation margin mean: `{env['null_o_orientation_margin_mean']:.9f}`",
+                f"- null O orientation margin max: `{env['null_o_orientation_margin_max']:.9f}`",
+                f"- margin plus-one p_ge_true: `{env['empirical_margin_p_ge_true']:.6f}`",
+            ]
+        )
+    lines.extend(["", "## Interpretation", "", payload["interpretation"], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts must match")
+    if args.output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_rows = read_manifest(args.manifest)
+    pred_rows: list[dict[str, Any]] = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        pred_rows.extend(parse_pred_rows(run / "brain_ossm_abide.raw.txt", manifest_rows, condition, run))
+    pair_rows = pair_contrasts(pred_rows)
+    seed_rows, summary_rows = summarize_pairs(pair_rows)
+    envelope = null_envelope(summary_rows)
+    interpretation = (
+        "This fixed-orientation contrast asks whether trained readout probabilities rank "
+        "the original associator-positive member of each pair above the swapped-sign member. "
+        "For pair-label null runs, evaluation labels are ignored here; the target remains the "
+        "original manifest orientation. This is an associator-specific diagnostic, not a "
+        "standalone superiority claim."
+    )
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "manifest": str(args.manifest),
+        "manifest_sha256": sha256_file(args.manifest),
+        "runs": [{"condition": c, "run": str(r)} for r, c in zip(args.run, args.condition, strict=True)],
+        "pair_rows": len(pair_rows),
+        "seed_rows": len(seed_rows),
+        "summary": summary_rows,
+        "null_envelope": envelope,
+        "interpretation": interpretation,
+    }
+    (args.output_dir / "associator_orientation_readout_contrast.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_tsv(args.output_dir / "associator_orientation_readout_pair_detail.tsv", pair_rows)
+    write_tsv(args.output_dir / "associator_orientation_readout_seed_summary.tsv", seed_rows)
+    write_tsv(args.output_dir / "associator_orientation_readout_summary.tsv", summary_rows)
+    if envelope:
+        write_tsv(args.output_dir / "associator_orientation_readout_null_envelope.tsv", [envelope])
+    (args.output_dir / "associator_orientation_readout_contrast.md").write_text(markdown(payload), encoding="utf-8")
+    with (args.output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in args.output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_associator_vector_head_probe.py
+++ b/scripts/research/neurodyn_associator_vector_head_probe.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Train an explicit fold-local associator-vector head on hidden pair deltas."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import random
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_associator_vector_probe import read_triple_meta
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_orientation_topk_prototype import orientation, pair_id, read_manifest
+
+
+SCHEMA = "neurodyn.associator_vector_head_probe.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--associator-triples", required=True, type=Path)
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--epochs", type=int, default=300)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--l2", type=float, default=0.001)
+    ap.add_argument("--feature-mode", choices=("linear", "poly2"), default="poly2")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def subject_meta(reference_manifest: Path, triples: Path) -> dict[int, dict[str, Any]]:
+    rows = read_manifest(reference_manifest)
+    triple_meta = read_triple_meta(triples)
+    out: dict[int, dict[str, Any]] = {}
+    for idx, row in enumerate(rows):
+        pid = pair_id(row["subject_id"])
+        tm = triple_meta.get(pid)
+        if tm is None:
+            raise SystemExit(f"missing associator triple metadata for {pid}")
+        assoc_value = float(tm["positive_assoc_value"])
+        assoc_dim = int(tm["assoc_dim"])
+        assoc_sign = 1 if assoc_value > 0.0 else -1
+        out[idx] = {
+            "subject_id": row["subject_id"],
+            "pair_id": pid,
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+            "assoc_dim": assoc_dim,
+            "assoc_sign": assoc_sign,
+            "signed_class": assoc_dim if assoc_sign > 0 else 8 + assoc_dim,
+        }
+    return out
+
+
+def collect_pair_rows(run: Path, condition: str, meta: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+    state_rows = parse_state_rows(run / "brain_ossm_abide.raw.txt")
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in state_rows:
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        grouped[(row["model"], int(row["seed"]))][f"{m['pair_id']}::{m['orientation']}"] = {**row, **m}
+
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        for pid in sorted({v["pair_id"] for v in chunk.values()}):
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "assoc_dim": int(pos["assoc_dim"]),
+                    "assoc_sign": int(pos["assoc_sign"]),
+                    "signed_class": int(pos["signed_class"]),
+                    "x": [a - b for a, b in zip(pos["h"], neg["h"], strict=True)],
+                }
+            )
+    return out
+
+
+def featurize(x: list[float], mode: str) -> list[float]:
+    if mode == "linear":
+        return list(x)
+    return list(x) + [abs(v) for v in x] + [v * v for v in x]
+
+
+def standardize(train_x: list[list[float]], rows_x: list[list[float]]) -> list[list[float]]:
+    dim = len(train_x[0]) if train_x else 0
+    mu = [mean([row[d] for row in train_x]) for d in range(dim)]
+    sd: list[float] = []
+    for d in range(dim):
+        var = mean([(row[d] - mu[d]) * (row[d] - mu[d]) for row in train_x])
+        s = math.sqrt(var)
+        sd.append(s if s > 1.0e-9 else 1.0)
+    return [[(row[d] - mu[d]) / sd[d] for d in range(dim)] for row in rows_x]
+
+
+def softmax(logits: list[float]) -> list[float]:
+    m = max(logits)
+    exps = [math.exp(max(-60.0, min(60.0, v - m))) for v in logits]
+    s = sum(exps)
+    return [v / s for v in exps]
+
+
+def train_softmax(
+    xs: list[list[float]],
+    ys: list[int],
+    class_count: int,
+    *,
+    epochs: int,
+    lr: float,
+    l2: float,
+    seed: int,
+) -> list[list[float]]:
+    if not xs:
+        return []
+    p = len(xs[0]) + 1
+    rng = random.Random(seed)
+    weights = [[rng.uniform(-0.01, 0.01) for _ in range(p)] for _ in range(class_count)]
+    n = float(len(xs))
+    for _ in range(epochs):
+        grad = [[0.0 for _ in range(p)] for _ in range(class_count)]
+        for x, y in zip(xs, ys, strict=True):
+            xb = [1.0] + x
+            probs = softmax([sum(weights[k][i] * xb[i] for i in range(p)) for k in range(class_count)])
+            for k in range(class_count):
+                err = probs[k] - (1.0 if k == y else 0.0)
+                for i in range(p):
+                    grad[k][i] += err * xb[i]
+        for k in range(class_count):
+            for i in range(p):
+                reg = 0.0 if i == 0 else l2 * weights[k][i]
+                weights[k][i] -= lr * ((grad[k][i] / n) + reg)
+    return weights
+
+
+def predict(weights: list[list[float]], x: list[float]) -> tuple[int, float]:
+    xb = [1.0] + x
+    logits = [sum(w[i] * xb[i] for i in range(len(xb))) for w in weights]
+    probs = softmax(logits)
+    pred = max(range(len(probs)), key=lambda k: probs[k])
+    sorted_probs = sorted(probs, reverse=True)
+    margin = sorted_probs[0] - (sorted_probs[1] if len(sorted_probs) > 1 else 0.0)
+    return pred, margin
+
+
+def signed_to_dim_sign(cls: int) -> tuple[int, int]:
+    if cls >= 8:
+        return cls - 8, -1
+    return cls, 1
+
+
+def evaluate(rows: list[dict[str, Any]], args: argparse.Namespace) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    seed_rows: list[dict[str, Any]] = []
+    detail: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        dim_ok = 0
+        signed_ok = 0
+        sign_ok = 0
+        total = 0
+        dim_margins: list[float] = []
+        signed_margins: list[float] = []
+        for site in sites:
+            train = [row for row in chunk if row["site"] != site]
+            test = [row for row in chunk if row["site"] == site]
+            train_raw = [featurize(row["x"], args.feature_mode) for row in train]
+            test_raw = [featurize(row["x"], args.feature_mode) for row in test]
+            train_x = standardize(train_raw, train_raw)
+            test_x = standardize(train_raw, test_raw)
+            dim_w = train_softmax(
+                train_x,
+                [int(row["assoc_dim"]) for row in train],
+                8,
+                epochs=args.epochs,
+                lr=args.lr,
+                l2=args.l2,
+                seed=int(seed) + 11,
+            )
+            signed_w = train_softmax(
+                train_x,
+                [int(row["signed_class"]) for row in train],
+                16,
+                epochs=args.epochs,
+                lr=args.lr,
+                l2=args.l2,
+                seed=int(seed) + 29,
+            )
+            for row, x in zip(test, test_x, strict=True):
+                pred_dim, dim_margin = predict(dim_w, x)
+                pred_signed, signed_margin = predict(signed_w, x)
+                signed_dim, signed_sign = signed_to_dim_sign(pred_signed)
+                true_dim = int(row["assoc_dim"])
+                true_sign = int(row["assoc_sign"])
+                dim_hit = int(pred_dim == true_dim)
+                signed_hit = int(pred_signed == int(row["signed_class"]))
+                sign_hit = int(signed_sign == true_sign)
+                dim_ok += dim_hit
+                signed_ok += signed_hit
+                sign_ok += sign_hit
+                total += 1
+                dim_margins.append(dim_margin)
+                signed_margins.append(signed_margin)
+                detail.append(
+                    {
+                        "condition": condition,
+                        "model": model,
+                        "seed": seed,
+                        "holdout_site": site,
+                        "pair_id": row["pair_id"],
+                        "assoc_dim": true_dim,
+                        "assoc_sign": true_sign,
+                        "pred_dim": pred_dim,
+                        "pred_signed_class": pred_signed,
+                        "pred_signed_dim": signed_dim,
+                        "pred_signed_sign": signed_sign,
+                        "dim_correct": dim_hit,
+                        "signed_correct": signed_hit,
+                        "sign_correct": sign_hit,
+                        "dim_margin": dim_margin,
+                        "signed_margin": signed_margin,
+                    }
+                )
+        seed_rows.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed": seed,
+                "pair_count": total,
+                "dim_accuracy": 100.0 * dim_ok / total if total else 0.0,
+                "signed_accuracy": 100.0 * signed_ok / total if total else 0.0,
+                "sign_accuracy": 100.0 * sign_ok / total if total else 0.0,
+                "dim_margin_mean": mean(dim_margins),
+                "signed_margin_mean": mean(signed_margins),
+            }
+        )
+    return seed_rows, detail
+
+
+def summarize(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        groups[(row["condition"], row["model"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model), rows in sorted(groups.items()):
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed_count": len(rows),
+                "pair_count_mean": mean([float(r["pair_count"]) for r in rows]),
+                "dim_accuracy_mean": mean([float(r["dim_accuracy"]) for r in rows]),
+                "dim_accuracy_std": pstdev([float(r["dim_accuracy"]) for r in rows]),
+                "signed_accuracy_mean": mean([float(r["signed_accuracy"]) for r in rows]),
+                "signed_accuracy_std": pstdev([float(r["signed_accuracy"]) for r in rows]),
+                "sign_accuracy_mean": mean([float(r["sign_accuracy"]) for r in rows]),
+                "sign_accuracy_std": pstdev([float(r["sign_accuracy"]) for r in rows]),
+                "dim_margin_mean": mean([float(r["dim_margin_mean"]) for r in rows]),
+                "signed_margin_mean": mean([float(r["signed_margin_mean"]) for r in rows]),
+            }
+        )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "associator_vector_head_probe_summary.tsv").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+    meta = subject_meta(args.reference_manifest, args.associator_triples)
+    all_rows: list[dict[str, Any]] = []
+    runs = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        all_rows.extend(collect_pair_rows(run, condition, meta))
+        runs.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")})
+    seed_rows, detail = evaluate(all_rows, args)
+    summary = summarize(seed_rows)
+    write_tsv(out / "associator_vector_head_probe_seed_detail.tsv", seed_rows)
+    write_tsv(out / "associator_vector_head_probe_pair_detail.tsv", detail)
+    write_tsv(out / "associator_vector_head_probe_summary.tsv", summary)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic posthoc explicit associator-vector head diagnostic only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "associator_triples": str(args.associator_triples),
+        "associator_triples_sha256": sha256_file(args.associator_triples),
+        "epochs": args.epochs,
+        "lr": args.lr,
+        "l2": args.l2,
+        "feature_mode": args.feature_mode,
+        "runs": runs,
+        "summary": summary,
+    }
+    (out / "associator_vector_head_probe.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = ["# Associator Vector Head Probe", "", payload["claim_boundary"], ""]
+    for row in summary:
+        md.append(
+            f"- `{row['condition']}` `{row['model']}` dim `{float(row['dim_accuracy_mean']):.6f}`, "
+            f"signed `{float(row['signed_accuracy_mean']):.6f}`, sign `{float(row['sign_accuracy_mean']):.6f}`"
+        )
+    md.append("")
+    (out / "associator_vector_head_probe.md").write_text("\n".join(md), encoding="utf-8")
+    sums = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_associator_vector_probe.py
+++ b/scripts/research/neurodyn_associator_vector_probe.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Fit a fold-local associator-vector readout from hidden pair deltas.
+
+This is a posthoc diagnostic, not a training change.  It asks whether the
+trained hidden states contain a linearly readable signed associator vector:
+target[assoc_dim] = sign(positive_assoc_value), all other components zero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_orientation_topk_prototype import orientation, pair_id, read_manifest
+
+
+SCHEMA = "neurodyn.associator_vector_probe.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--associator-triples", required=True, type=Path)
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--ridge", type=float, default=1.0)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def read_triple_meta(path: Path) -> dict[str, dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    out: dict[str, dict[str, str]] = {}
+    for row in rows:
+        out[f"assoc_pair_{int(row['pair_id']):04d}"] = row
+    return out
+
+
+def subject_meta(reference_manifest: Path, triples: Path) -> dict[int, dict[str, Any]]:
+    rows = read_manifest(reference_manifest)
+    triple_meta = read_triple_meta(triples)
+    out: dict[int, dict[str, Any]] = {}
+    for idx, row in enumerate(rows):
+        pid = pair_id(row["subject_id"])
+        tm = triple_meta.get(pid)
+        if tm is None:
+            raise SystemExit(f"missing associator triple metadata for {pid}")
+        assoc_value = float(tm["positive_assoc_value"])
+        assoc_dim = int(tm["assoc_dim"])
+        out[idx] = {
+            "subject_id": row["subject_id"],
+            "pair_id": pid,
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+            "assoc_dim": assoc_dim,
+            "assoc_sign": 1 if assoc_value > 0.0 else -1,
+            "target": [1.0 if d == assoc_dim and assoc_value > 0.0 else -1.0 if d == assoc_dim else 0.0 for d in range(8)],
+        }
+    return out
+
+
+def collect_pair_rows(run: Path, condition: str, meta: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+    state_rows = parse_state_rows(run / "brain_ossm_abide.raw.txt")
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in state_rows:
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        grouped[(row["model"], int(row["seed"]))][f"{m['pair_id']}::{m['orientation']}"] = {**row, **m}
+
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        for pid in sorted({v["pair_id"] for v in chunk.values()}):
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "assoc_dim": int(pos["assoc_dim"]),
+                    "assoc_sign": int(pos["assoc_sign"]),
+                    "x": [a - b for a, b in zip(pos["h"], neg["h"], strict=True)],
+                    "y": list(pos["target"]),
+                }
+            )
+    return out
+
+
+def standardize(train_x: list[list[float]], rows_x: list[list[float]]) -> tuple[list[list[float]], list[float], list[float]]:
+    dim = len(train_x[0]) if train_x else 0
+    mu = [mean([row[d] for row in train_x]) for d in range(dim)]
+    sd: list[float] = []
+    for d in range(dim):
+        var = mean([(row[d] - mu[d]) * (row[d] - mu[d]) for row in train_x])
+        s = math.sqrt(var)
+        sd.append(s if s > 1.0e-9 else 1.0)
+    out = [[(row[d] - mu[d]) / sd[d] for d in range(dim)] for row in rows_x]
+    return out, mu, sd
+
+
+def solve_linear(a: list[list[float]], b: list[float]) -> list[float]:
+    n = len(a)
+    aug = [list(a[i]) + [b[i]] for i in range(n)]
+    for col in range(n):
+        pivot = max(range(col, n), key=lambda r: abs(aug[r][col]))
+        if abs(aug[pivot][col]) < 1.0e-12:
+            continue
+        if pivot != col:
+            aug[col], aug[pivot] = aug[pivot], aug[col]
+        div = aug[col][col]
+        for j in range(col, n + 1):
+            aug[col][j] /= div
+        for r in range(n):
+            if r == col:
+                continue
+            factor = aug[r][col]
+            if abs(factor) <= 1.0e-18:
+                continue
+            for j in range(col, n + 1):
+                aug[r][j] -= factor * aug[col][j]
+    return [aug[i][n] for i in range(n)]
+
+
+def fit_ridge(train_x: list[list[float]], train_y: list[list[float]], ridge: float) -> list[list[float]]:
+    if not train_x:
+        return []
+    p = len(train_x[0]) + 1
+    ydim = len(train_y[0])
+    xtx = [[0.0 for _ in range(p)] for _ in range(p)]
+    xty = [[0.0 for _ in range(ydim)] for _ in range(p)]
+    for x, y in zip(train_x, train_y, strict=True):
+        xb = [1.0] + x
+        for i in range(p):
+            for j in range(p):
+                xtx[i][j] += xb[i] * xb[j]
+            for k in range(ydim):
+                xty[i][k] += xb[i] * y[k]
+    for i in range(1, p):
+        xtx[i][i] += ridge
+    weights: list[list[float]] = []
+    for k in range(ydim):
+        weights.append(solve_linear(xtx, [xty[i][k] for i in range(p)]))
+    return weights
+
+
+def predict(weights: list[list[float]], x: list[float]) -> list[float]:
+    xb = [1.0] + x
+    return [sum(w[i] * xb[i] for i in range(len(xb))) for w in weights]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    na = math.sqrt(sum(v * v for v in a))
+    nb = math.sqrt(sum(v * v for v in b))
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return sum(x * y for x, y in zip(a, b, strict=True)) / (na * nb)
+
+
+def evaluate(rows: list[dict[str, Any]], ridge: float) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    seed_rows: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        correct_dim = 0
+        correct_sign = 0
+        correct_both = 0
+        total = 0
+        cosines: list[float] = []
+        margins: list[float] = []
+        for site in sites:
+            train = [row for row in chunk if row["site"] != site]
+            test = [row for row in chunk if row["site"] == site]
+            if not train or not test:
+                continue
+            train_x_raw = [row["x"] for row in train]
+            train_x, _, _ = standardize(train_x_raw, train_x_raw)
+            weights = fit_ridge(train_x, [row["y"] for row in train], ridge)
+            test_x, _, _ = standardize(train_x_raw, [row["x"] for row in test])
+            for row, x in zip(test, test_x, strict=True):
+                pred = predict(weights, x)
+                pred_dim = max(range(len(pred)), key=lambda d: abs(pred[d]))
+                pred_sign = 1 if pred[pred_dim] >= 0.0 else -1
+                true_dim = int(row["assoc_dim"])
+                true_sign = int(row["assoc_sign"])
+                dim_ok = int(pred_dim == true_dim)
+                sign_ok = int((1 if pred[true_dim] >= 0.0 else -1) == true_sign)
+                both_ok = int(dim_ok == 1 and pred_sign == true_sign)
+                sorted_abs = sorted((abs(v) for v in pred), reverse=True)
+                margin = sorted_abs[0] - (sorted_abs[1] if len(sorted_abs) > 1 else 0.0)
+                c = cosine(pred, row["y"])
+                correct_dim += dim_ok
+                correct_sign += sign_ok
+                correct_both += both_ok
+                total += 1
+                cosines.append(c)
+                margins.append(margin)
+                detail.append(
+                    {
+                        "condition": condition,
+                        "model": model,
+                        "seed": seed,
+                        "holdout_site": site,
+                        "pair_id": row["pair_id"],
+                        "assoc_dim": true_dim,
+                        "assoc_sign": true_sign,
+                        "pred_dim": pred_dim,
+                        "pred_sign": pred_sign,
+                        "dim_correct": dim_ok,
+                        "sign_correct": sign_ok,
+                        "both_correct": both_ok,
+                        "cosine": c,
+                        "margin": margin,
+                        "pred_vector": ",".join(f"{v:.8f}" for v in pred),
+                    }
+                )
+        seed_rows.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed": seed,
+                "pair_count": total,
+                "dim_accuracy": 100.0 * correct_dim / total if total else 0.0,
+                "sign_accuracy": 100.0 * correct_sign / total if total else 0.0,
+                "both_accuracy": 100.0 * correct_both / total if total else 0.0,
+                "cosine_mean": mean(cosines),
+                "cosine_std": pstdev(cosines),
+                "margin_mean": mean(margins),
+            }
+        )
+    return seed_rows, detail
+
+
+def summarize(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        groups[(row["condition"], row["model"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model), rows in sorted(groups.items()):
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed_count": len(rows),
+                "pair_count_mean": mean([float(r["pair_count"]) for r in rows]),
+                "dim_accuracy_mean": mean([float(r["dim_accuracy"]) for r in rows]),
+                "dim_accuracy_std": pstdev([float(r["dim_accuracy"]) for r in rows]),
+                "sign_accuracy_mean": mean([float(r["sign_accuracy"]) for r in rows]),
+                "sign_accuracy_std": pstdev([float(r["sign_accuracy"]) for r in rows]),
+                "both_accuracy_mean": mean([float(r["both_accuracy"]) for r in rows]),
+                "both_accuracy_std": pstdev([float(r["both_accuracy"]) for r in rows]),
+                "cosine_mean": mean([float(r["cosine_mean"]) for r in rows]),
+                "cosine_std": pstdev([float(r["cosine_mean"]) for r in rows]),
+                "margin_mean": mean([float(r["margin_mean"]) for r in rows]),
+            }
+        )
+    return out
+
+
+def null_envelope(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for model in sorted({row["model"] for row in summary}):
+        true = [row for row in summary if row["condition"] == "true" and row["model"] == model]
+        nulls = [row for row in summary if row["condition"].startswith("null") and row["model"] == model]
+        if not true or not nulls:
+            continue
+        t = true[0]
+        for metric in ("dim_accuracy_mean", "sign_accuracy_mean", "both_accuracy_mean", "cosine_mean", "margin_mean"):
+            tv = float(t[metric])
+            vals = [float(row[metric]) for row in nulls]
+            ge = sum(1 for v in vals if v >= tv)
+            out.append(
+                {
+                    "model": model,
+                    "metric": metric,
+                    "true": tv,
+                    "null_count": len(vals),
+                    "null_min": min(vals),
+                    "null_max": max(vals),
+                    "null_mean": mean(vals),
+                    "null_ge_true": ge,
+                    "plus_one_p_ge_true": (ge + 1.0) / (len(vals) + 1.0),
+                }
+            )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "associator_vector_probe_summary.tsv").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+
+    meta = subject_meta(args.reference_manifest, args.associator_triples)
+    all_rows: list[dict[str, Any]] = []
+    runs = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        all_rows.extend(collect_pair_rows(run, condition, meta))
+        runs.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")})
+
+    seed_rows, detail = evaluate(all_rows, args.ridge)
+    summary = summarize(seed_rows)
+    envelope = null_envelope(summary)
+
+    write_tsv(out / "associator_vector_probe_seed_detail.tsv", seed_rows)
+    write_tsv(out / "associator_vector_probe_pair_detail.tsv", detail)
+    write_tsv(out / "associator_vector_probe_summary.tsv", summary)
+    write_tsv(out / "associator_vector_probe_null_envelope.tsv", envelope)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic posthoc associator-vector hidden readout diagnostic only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "associator_triples": str(args.associator_triples),
+        "associator_triples_sha256": sha256_file(args.associator_triples),
+        "ridge": args.ridge,
+        "runs": runs,
+        "summary": summary,
+        "null_envelope": envelope,
+    }
+    (out / "associator_vector_probe.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = ["# Associator Vector Probe", "", payload["claim_boundary"], ""]
+    for row in summary:
+        md.append(
+            f"- `{row['condition']}` `{row['model']}` dim `{float(row['dim_accuracy_mean']):.6f}`, "
+            f"sign `{float(row['sign_accuracy_mean']):.6f}`, both `{float(row['both_accuracy_mean']):.6f}`, "
+            f"cosine `{float(row['cosine_mean']):.6f}`"
+        )
+    for row in envelope:
+        md.append(
+            f"- envelope `{row['model']}` `{row['metric']}` true `{float(row['true']):.6f}`, "
+            f"null max `{float(row['null_max']):.6f}`, null_ge `{row['null_ge_true']}/{row['null_count']}`"
+        )
+    md.append("")
+    (out / "associator_vector_probe.md").write_text("\n".join(md), encoding="utf-8")
+    sums = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_direct_slurm_smoke.sh
+++ b/scripts/research/neurodyn_direct_slurm_smoke.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run one Brain O-SSM synthetic smoke directly through Slurm.
+#
+# This intentionally executes from worker-local /tmp and streams the result
+# bundle back over stdout in a second srun call. OrangeFS is not used as the
+# canonical result path because this lane observed zero-prefixed tgz writes
+# during a prior smoke.
+
+RUN_ID="${RUN_ID:?set RUN_ID}"
+MANIFEST_PATH="${MANIFEST_PATH:?set MANIFEST_PATH}"
+OUTPUT_DIR="${OUTPUT_DIR:?set OUTPUT_DIR}"
+SOUNIO_DIR="${SOUNIO_DIR:-/workspace/sounio}"
+NODE="${NODE:-gpuorangefs-r770-proxmox}"
+PARTITION="${PARTITION:-all}"
+CPUS="${CPUS:-4}"
+MEM="${MEM:-8G}"
+TIME_LIMIT="${TIME_LIMIT:-01:00:00}"
+PAIRS_EXPECTED="${PAIRS_EXPECTED:-}"
+
+TRAIN_FRACTION="${TRAIN_FRACTION:-1.0}"
+DROP_CHANNEL_FRAC="${DROP_CHANNEL_FRAC:-0.0}"
+NOISE_STD="${NOISE_STD:-0.0}"
+GLOBAL_TRAIN_EPOCHS="${GLOBAL_TRAIN_EPOCHS:-24}"
+GLOBAL_TRAIN_LR="${GLOBAL_TRAIN_LR:-0.010}"
+GLOBAL_CORE_LR_SCALE="${GLOBAL_CORE_LR_SCALE:-0.50}"
+OCT_PROFILE_ID="${OCT_PROFILE_ID:-4}"
+OCT_TRAIN_MODE="${OCT_TRAIN_MODE:-4}"
+OCT_TRAIN_EPOCHS="${OCT_TRAIN_EPOCHS:-36}"
+OCT_TRAIN_LR="${OCT_TRAIN_LR:-0.012}"
+OCT_CORE_LR_SCALE="${OCT_CORE_LR_SCALE:-0.65}"
+OCT_WARMUP_EPOCHS="${OCT_WARMUP_EPOCHS:-6}"
+OCT_INIT_PRESET="${OCT_INIT_PRESET:-1}"
+OCT_ASSOC_REG="${OCT_ASSOC_REG:-0.04}"
+OCT_ASSOC_TARGET="${OCT_ASSOC_TARGET:-0.86}"
+OCT_ASSOC_SCHEDULE_MODE="${OCT_ASSOC_SCHEDULE_MODE:-1}"
+OCT_ASSOC_SCHEDULE_START="${OCT_ASSOC_SCHEDULE_START:-1.10}"
+OCT_ASSOC_SCHEDULE_MID="${OCT_ASSOC_SCHEDULE_MID:-0.86}"
+OCT_ASSOC_SCHEDULE_END="${OCT_ASSOC_SCHEDULE_END:-0.74}"
+OCT_ASSOC_DRIFT_REG="${OCT_ASSOC_DRIFT_REG:-0.03}"
+OCT_HEAD_TRUST_REGION="${OCT_HEAD_TRUST_REGION:-0.05}"
+OCT_HEAD_RENORM="${OCT_HEAD_RENORM:-1}"
+OCT_ASSOCIATIVE_PROJECTION="${OCT_ASSOCIATIVE_PROJECTION:-0}"
+OCT_STATE_ORDER_AUX="${OCT_STATE_ORDER_AUX:-0.0}"
+OCT_ASSOCIATOR_SIGN_AUX="${OCT_ASSOCIATOR_SIGN_AUX:-0.0}"
+OCT_ASSOCIATOR_FIXED_DIM_AUX="${OCT_ASSOCIATOR_FIXED_DIM_AUX:-0.0}"
+OCT_ASSOCIATOR_FIXED_DIM_READOUT_AUX="${OCT_ASSOCIATOR_FIXED_DIM_READOUT_AUX:-0.0}"
+OCT_ASSOCIATOR_FIXED_ORIENTATION_AUX="${OCT_ASSOCIATOR_FIXED_ORIENTATION_AUX:-0.0}"
+OCT_ASSOCIATOR_FIXED_ORIENTATION_READOUT_AUX="${OCT_ASSOCIATOR_FIXED_ORIENTATION_READOUT_AUX:-0.0}"
+OCT_ASSOCIATOR_FIXED_ORIENTATION_ALIGN_READOUT_AUX="${OCT_ASSOCIATOR_FIXED_ORIENTATION_ALIGN_READOUT_AUX:-0.0}"
+OCT_ASSOCIATOR_ORIENTATION_HEAD_AUX="${OCT_ASSOCIATOR_ORIENTATION_HEAD_AUX:-0.0}"
+OCT_ASSOCIATOR_ORIENTATION_HEAD_EPOCHS="${OCT_ASSOCIATOR_ORIENTATION_HEAD_EPOCHS:-0}"
+OCT_ASSOCIATOR_FIXED_ORIENTATION_RAMP_EPOCHS="${OCT_ASSOCIATOR_FIXED_ORIENTATION_RAMP_EPOCHS:-0}"
+OCT_ASSOCIATOR_FIXED_DIM="${OCT_ASSOCIATOR_FIXED_DIM:-4}"
+OCT_ASSOCIATOR_VECTOR_PAIR_AUX="${OCT_ASSOCIATOR_VECTOR_PAIR_AUX:-0.0}"
+OCT_PAIR_CONTRAST_AUX="${OCT_PAIR_CONTRAST_AUX:-0.08}"
+OCT_TRAIN_NOISE_STD="${OCT_TRAIN_NOISE_STD:-0.0}"
+OCT_RELATION_PRESERVE_AUX="${OCT_RELATION_PRESERVE_AUX:-0.0}"
+OCT_RELATION_TARGET_AUX="${OCT_RELATION_TARGET_AUX:-0.0}"
+OCT_RELATION_MARGIN_AUX="${OCT_RELATION_MARGIN_AUX:-0.0}"
+OCT_RELATION_IDENTITY_AUX="${OCT_RELATION_IDENTITY_AUX:-0.0}"
+OCT_RELATION_IDENTITY_SRC_AUX="${OCT_RELATION_IDENTITY_SRC_AUX:--1.0}"
+OCT_RELATION_IDENTITY_DST_AUX="${OCT_RELATION_IDENTITY_DST_AUX:--1.0}"
+OCT_RELATION_IDENTITY_START_EPOCH="${OCT_RELATION_IDENTITY_START_EPOCH:-0}"
+OCT_RELATION_IDENTITY_RAMP_EPOCHS="${OCT_RELATION_IDENTITY_RAMP_EPOCHS:-0}"
+OCT_RELATION_IDENTITY_TIE_MARGIN="${OCT_RELATION_IDENTITY_TIE_MARGIN:-0.0}"
+OCT_RELATION_IDENTITY_GATE_MARGIN="${OCT_RELATION_IDENTITY_GATE_MARGIN:-0.0}"
+OCT_RELATION_IDENTITY_GATE_FLOOR="${OCT_RELATION_IDENTITY_GATE_FLOOR:-1.0}"
+OCT_RELATION_IDENTITY_TASK_GUARD="${OCT_RELATION_IDENTITY_TASK_GUARD:-0}"
+OCT_RELATION_IDENTITY_TASK_GUARD_TOL="${OCT_RELATION_IDENTITY_TASK_GUARD_TOL:-0.0}"
+OCT_RELATION_READOUT_CORRECT_STEPS="${OCT_RELATION_READOUT_CORRECT_STEPS:-0}"
+OCT_RELATION_READOUT_CORRECT_LR_SCALE="${OCT_RELATION_READOUT_CORRECT_LR_SCALE:-1.0}"
+OCT_ASSOCIATOR_READOUT_CORRECT_STEPS="${OCT_ASSOCIATOR_READOUT_CORRECT_STEPS:-0}"
+OCT_ASSOCIATOR_READOUT_CORRECT_LR_SCALE="${OCT_ASSOCIATOR_READOUT_CORRECT_LR_SCALE:-1.0}"
+OCT_ASSOCIATOR_READOUT_ALIGN_EPOCHS="${OCT_ASSOCIATOR_READOUT_ALIGN_EPOCHS:-0}"
+OCT_ASSOCIATOR_READOUT_ALIGN_LR_SCALE="${OCT_ASSOCIATOR_READOUT_ALIGN_LR_SCALE:-1.0}"
+OCT_RELATION_MARGIN_GATE_CAP="${OCT_RELATION_MARGIN_GATE_CAP:-2.0}"
+OCT_RELATION_MARGIN_START_EPOCH="${OCT_RELATION_MARGIN_START_EPOCH:-0}"
+OCT_RELATION_MARGIN_RAMP_EPOCHS="${OCT_RELATION_MARGIN_RAMP_EPOCHS:-0}"
+OCT_RELATION_FREEZE_AFTER_EPOCH="${OCT_RELATION_FREEZE_AFTER_EPOCH:--1}"
+OCT_RELATION_POST_FREEZE_SCALE="${OCT_RELATION_POST_FREEZE_SCALE:-0.0}"
+OCT_BINARY_LR_SCALE_AFTER_EPOCH="${OCT_BINARY_LR_SCALE_AFTER_EPOCH:--1}"
+OCT_BINARY_LR_POST_SCALE="${OCT_BINARY_LR_POST_SCALE:-1.0}"
+OCT_RELATION_TASK_GUARD="${OCT_RELATION_TASK_GUARD:-0}"
+OCT_RELATION_TASK_GUARD_TOL="${OCT_RELATION_TASK_GUARD_TOL:-0.0}"
+OCT_RELATION_TARGET_SRC_POS="${OCT_RELATION_TARGET_SRC_POS:-2}"
+OCT_RELATION_TARGET_DST_POS="${OCT_RELATION_TARGET_DST_POS:-0}"
+OCT_INPUT_PROJ_MODE="${OCT_INPUT_PROJ_MODE:-4}"
+OCT_PROJ_LR_SCALE="${OCT_PROJ_LR_SCALE:-0.6}"
+OCT_PROJ_STRUCTURED_SCALE="${OCT_PROJ_STRUCTURED_SCALE:-0.35}"
+OCT_PROJ_DELTA_SCALE="${OCT_PROJ_DELTA_SCALE:-0.18}"
+OCT_PROJ_HYBRID_SCALE="${OCT_PROJ_HYBRID_SCALE:-0.12}"
+H_TRAIN_EPOCHS="${H_TRAIN_EPOCHS:-24}"
+H_TRAIN_LR="${H_TRAIN_LR:-0.010}"
+H_CORE_LR_SCALE="${H_CORE_LR_SCALE:-0.50}"
+H_WARMUP_EPOCHS="${H_WARMUP_EPOCHS:-4}"
+H_INIT_PRESET="${H_INIT_PRESET:-1}"
+H_INPUT_PROJ_MODE="${H_INPUT_PROJ_MODE:-0}"
+H_PROJ_LR_SCALE="${H_PROJ_LR_SCALE:-0.6}"
+READOUT_ASSOC_SCALE="${READOUT_ASSOC_SCALE:-0.0}"
+READOUT_MEAN_SCALE="${READOUT_MEAN_SCALE:-0.0}"
+READOUT_DELTA_SCALE="${READOUT_DELTA_SCALE:-0.0}"
+READOUT_FLAT_SCALE="${READOUT_FLAT_SCALE:-0.0}"
+TRACE_HIDDEN_STATE="${TRACE_HIDDEN_STATE:-1}"
+TRACE_READOUT_ALL_FOLDS="${TRACE_READOUT_ALL_FOLDS:-1}"
+MIN_SUBJECTS="${MIN_SUBJECTS:-112}"
+
+SNAPSHOT_DIR="${SNAPSHOT_DIR:-/tmp/${RUN_ID}-snapshot}"
+PAYLOAD_TGZ="${PAYLOAD_TGZ:-/tmp/${RUN_ID}.tgz}"
+RESULT_TGZ="${RESULT_TGZ:-/tmp/${RUN_ID}-results.tgz}"
+
+rm -rf "${SNAPSHOT_DIR}" "${PAYLOAD_TGZ}" "${RESULT_TGZ}" "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+OUT_ROOT="${SNAPSHOT_DIR}" SOUNIO_DIR="${SOUNIO_DIR}" ABIDE_MANIFEST_PATH="${MANIFEST_PATH}" \
+  bash "${SOUNIO_DIR}/scripts/gpu/prepare_abide_campaign_snapshot.sh" >/dev/null
+tar -C "${SNAPSHOT_DIR}" -czf "${PAYLOAD_TGZ}" .
+tar -tzf "${PAYLOAD_TGZ}" >/dev/null
+
+base64 -w0 "${PAYLOAD_TGZ}" | srun \
+  --chdir=/tmp \
+  -p "${PARTITION}" \
+  -w "${NODE}" \
+  -N1 -n1 -c "${CPUS}" \
+  --mem="${MEM}" \
+  --time="${TIME_LIMIT}" \
+  bash -lc "
+set -euo pipefail
+RUN_ID='${RUN_ID}'
+ROOT=\"/tmp/\${RUN_ID}\"
+rm -rf \"\${ROOT}\"
+mkdir -p \"\${ROOT}\"
+base64 -d > \"\${ROOT}/payload.tgz\"
+tar -xzf \"\${ROOT}/payload.tgz\" -C \"\${ROOT}\"
+cd \"\${ROOT}\"
+python3 -c 'from pathlib import Path; p=Path(\"scripts/research/abide_campaign_lib.py\"); data=p.read_bytes(); assert data.startswith(b\"#!/usr/bin/env python3\") and b\"\\0\" not in data[:200], data[:40]'
+cat > abide_run_config.tsv <<'CFG'
+train_fraction=${TRAIN_FRACTION}
+drop_channel_frac=${DROP_CHANNEL_FRAC}
+noise_std=${NOISE_STD}
+global_train_epochs=${GLOBAL_TRAIN_EPOCHS}
+global_train_lr=${GLOBAL_TRAIN_LR}
+global_core_lr_scale=${GLOBAL_CORE_LR_SCALE}
+oct_profile_id=${OCT_PROFILE_ID}
+oct_train_mode=${OCT_TRAIN_MODE}
+oct_train_epochs=${OCT_TRAIN_EPOCHS}
+oct_train_lr=${OCT_TRAIN_LR}
+oct_core_lr_scale=${OCT_CORE_LR_SCALE}
+oct_warmup_epochs=${OCT_WARMUP_EPOCHS}
+oct_init_preset=${OCT_INIT_PRESET}
+oct_assoc_reg=${OCT_ASSOC_REG}
+oct_assoc_target=${OCT_ASSOC_TARGET}
+oct_assoc_schedule_mode=${OCT_ASSOC_SCHEDULE_MODE}
+oct_assoc_schedule_start=${OCT_ASSOC_SCHEDULE_START}
+oct_assoc_schedule_mid=${OCT_ASSOC_SCHEDULE_MID}
+oct_assoc_schedule_end=${OCT_ASSOC_SCHEDULE_END}
+oct_assoc_drift_reg=${OCT_ASSOC_DRIFT_REG}
+oct_head_trust_region=${OCT_HEAD_TRUST_REGION}
+oct_head_renorm=${OCT_HEAD_RENORM}
+oct_associative_projection=${OCT_ASSOCIATIVE_PROJECTION}
+oct_state_order_aux=${OCT_STATE_ORDER_AUX}
+oct_associator_sign_aux=${OCT_ASSOCIATOR_SIGN_AUX}
+oct_associator_fixed_dim_aux=${OCT_ASSOCIATOR_FIXED_DIM_AUX}
+oct_associator_fixed_dim_readout_aux=${OCT_ASSOCIATOR_FIXED_DIM_READOUT_AUX}
+oct_associator_fixed_orientation_aux=${OCT_ASSOCIATOR_FIXED_ORIENTATION_AUX}
+oct_associator_fixed_orientation_readout_aux=${OCT_ASSOCIATOR_FIXED_ORIENTATION_READOUT_AUX}
+oct_associator_fixed_orientation_align_readout_aux=${OCT_ASSOCIATOR_FIXED_ORIENTATION_ALIGN_READOUT_AUX}
+oct_associator_orientation_head_aux=${OCT_ASSOCIATOR_ORIENTATION_HEAD_AUX}
+oct_associator_orientation_head_epochs=${OCT_ASSOCIATOR_ORIENTATION_HEAD_EPOCHS}
+oct_associator_fixed_orientation_ramp_epochs=${OCT_ASSOCIATOR_FIXED_ORIENTATION_RAMP_EPOCHS}
+oct_associator_fixed_dim=${OCT_ASSOCIATOR_FIXED_DIM}
+oct_associator_vector_pair_aux=${OCT_ASSOCIATOR_VECTOR_PAIR_AUX}
+oct_pair_contrast_aux=${OCT_PAIR_CONTRAST_AUX}
+oct_train_noise_std=${OCT_TRAIN_NOISE_STD}
+oct_relation_preserve_aux=${OCT_RELATION_PRESERVE_AUX}
+oct_relation_target_aux=${OCT_RELATION_TARGET_AUX}
+oct_relation_margin_aux=${OCT_RELATION_MARGIN_AUX}
+oct_relation_identity_aux=${OCT_RELATION_IDENTITY_AUX}
+oct_relation_identity_src_aux=${OCT_RELATION_IDENTITY_SRC_AUX}
+oct_relation_identity_dst_aux=${OCT_RELATION_IDENTITY_DST_AUX}
+oct_relation_identity_start_epoch=${OCT_RELATION_IDENTITY_START_EPOCH}
+oct_relation_identity_ramp_epochs=${OCT_RELATION_IDENTITY_RAMP_EPOCHS}
+oct_relation_identity_tie_margin=${OCT_RELATION_IDENTITY_TIE_MARGIN}
+oct_relation_identity_gate_margin=${OCT_RELATION_IDENTITY_GATE_MARGIN}
+oct_relation_identity_gate_floor=${OCT_RELATION_IDENTITY_GATE_FLOOR}
+oct_relation_identity_task_guard=${OCT_RELATION_IDENTITY_TASK_GUARD}
+oct_relation_identity_task_guard_tol=${OCT_RELATION_IDENTITY_TASK_GUARD_TOL}
+oct_relation_readout_correct_steps=${OCT_RELATION_READOUT_CORRECT_STEPS}
+oct_relation_readout_correct_lr_scale=${OCT_RELATION_READOUT_CORRECT_LR_SCALE}
+oct_associator_readout_correct_steps=${OCT_ASSOCIATOR_READOUT_CORRECT_STEPS}
+oct_associator_readout_correct_lr_scale=${OCT_ASSOCIATOR_READOUT_CORRECT_LR_SCALE}
+oct_associator_readout_align_epochs=${OCT_ASSOCIATOR_READOUT_ALIGN_EPOCHS}
+oct_associator_readout_align_lr_scale=${OCT_ASSOCIATOR_READOUT_ALIGN_LR_SCALE}
+oct_relation_margin_gate_cap=${OCT_RELATION_MARGIN_GATE_CAP}
+oct_relation_margin_start_epoch=${OCT_RELATION_MARGIN_START_EPOCH}
+oct_relation_margin_ramp_epochs=${OCT_RELATION_MARGIN_RAMP_EPOCHS}
+oct_relation_freeze_after_epoch=${OCT_RELATION_FREEZE_AFTER_EPOCH}
+oct_relation_post_freeze_scale=${OCT_RELATION_POST_FREEZE_SCALE}
+oct_binary_lr_scale_after_epoch=${OCT_BINARY_LR_SCALE_AFTER_EPOCH}
+oct_binary_lr_post_scale=${OCT_BINARY_LR_POST_SCALE}
+oct_relation_task_guard=${OCT_RELATION_TASK_GUARD}
+oct_relation_task_guard_tol=${OCT_RELATION_TASK_GUARD_TOL}
+oct_relation_target_src_pos=${OCT_RELATION_TARGET_SRC_POS}
+oct_relation_target_dst_pos=${OCT_RELATION_TARGET_DST_POS}
+oct_input_proj_mode=${OCT_INPUT_PROJ_MODE}
+oct_proj_lr_scale=${OCT_PROJ_LR_SCALE}
+oct_proj_structured_scale=${OCT_PROJ_STRUCTURED_SCALE}
+oct_proj_delta_scale=${OCT_PROJ_DELTA_SCALE}
+oct_proj_hybrid_scale=${OCT_PROJ_HYBRID_SCALE}
+h_train_epochs=${H_TRAIN_EPOCHS}
+h_train_lr=${H_TRAIN_LR}
+h_core_lr_scale=${H_CORE_LR_SCALE}
+h_warmup_epochs=${H_WARMUP_EPOCHS}
+h_init_preset=${H_INIT_PRESET}
+h_input_proj_mode=${H_INPUT_PROJ_MODE}
+h_proj_lr_scale=${H_PROJ_LR_SCALE}
+readout_assoc_scale=${READOUT_ASSOC_SCALE}
+readout_mean_scale=${READOUT_MEAN_SCALE}
+readout_delta_scale=${READOUT_DELTA_SCALE}
+readout_flat_scale=${READOUT_FLAT_SCALE}
+trace_hidden_state=${TRACE_HIDDEN_STATE}
+trace_readout_all_folds=${TRACE_READOUT_ALL_FOLDS}
+min_subjects=${MIN_SUBJECTS}
+CFG
+python3 scripts/research/normalize_abide_manifest.py --input abide_source_manifest.tsv --output abide_roi_manifest.tsv --layout flat
+if [[ -n '${PAIRS_EXPECTED}' ]]; then
+  export PAIRS_EXPECTED_VALUE='${PAIRS_EXPECTED}'
+  python3 - <<'PY'
+import csv, os
+expected = int(os.environ.get('PAIRS_EXPECTED_VALUE', '0'))
+with open('abide_roi_manifest.tsv', newline='') as f:
+    rows = list(csv.DictReader((line for line in f if not line.startswith('#')), delimiter='\t'))
+pairs = {row['subject_id'].split('__', 1)[0] for row in rows}
+if len(pairs) != expected:
+    raise SystemExit(f'expected {expected} pairs, got {len(pairs)}')
+PY
+fi
+python3 scripts/research/abide_manifest_quality_gate.py --manifest abide_roi_manifest.tsv --min-nonzero-frac 0.01 --min-variance 1e-10 > manifest_quality_gate.log
+export SOUNIO_SOUC_ENGINE=lean_single
+./bin/souc compile examples/brain_ossm_abide.sio -o brain_ossm_abide.elf > compile.log 2>&1
+chmod +x brain_ossm_abide.elf
+set +e
+./brain_ossm_abide.elf > brain_ossm_abide.raw.txt 2>&1
+rc=\$?
+set -e
+printf '%s\n' \"\${rc}\" > run.rc
+if [[ \"\${rc}\" -ne 0 ]]; then
+  tail -80 brain_ossm_abide.raw.txt >&2
+  exit \"\${rc}\"
+fi
+python3 scripts/research/parse_brain_ossm_abide_output.py --input brain_ossm_abide.raw.txt --output-dir results > parse.log
+sha256sum abide_source_manifest.tsv abide_roi_manifest.tsv abide_run_config.tsv brain_ossm_abide.raw.txt run.rc results/overall_metrics.tsv > SHA256SUMS.output
+cat results/overall_metrics.tsv
+"
+
+srun \
+  --chdir=/tmp \
+  -p "${PARTITION}" \
+  -w "${NODE}" \
+  -N1 -n1 -c1 \
+  --mem=1G \
+  --time=00:05:00 \
+  tar -C "/tmp/${RUN_ID}" -czf - \
+    abide_source_manifest.tsv abide_roi_manifest.tsv abide_run_config.tsv \
+    manifest_quality_gate.log compile.log brain_ossm_abide.raw.txt run.rc \
+    parse.log results SHA256SUMS.output > "${RESULT_TGZ}"
+
+tar -tzf "${RESULT_TGZ}" >/dev/null
+tar -xzf "${RESULT_TGZ}" -C "${OUTPUT_DIR}"
+printf 'output_dir=%s\n' "${OUTPUT_DIR}"

--- a/scripts/research/neurodyn_ds006731_p3_manifest.py
+++ b/scripts/research/neurodyn_ds006731_p3_manifest.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Build a durable ds006731 NeuroDyn P3 balanced manifest package.
+
+This is a plumbing helper for the P3 MDD ROI lane. It takes two already
+materialized ROI stores:
+
+* a survivor directory containing ``roi/sub-*.1D`` files
+* a rerun directory containing ``roi/sub-*.1D`` plus rerun receipts
+
+and emits the ``balanced_manifest`` artifact class consumed by
+``neurodyn_evidence_bundle.py`` and ``neurodyn_orangefs_not_required_gate.py``.
+
+It intentionally does not run fMRIPrep, train O-SSM, or make any clinical claim.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import json
+import math
+import random
+import shutil
+from pathlib import Path
+
+
+DEFAULT_SUBJECTS: tuple[tuple[str, int, str], ...] = (
+    ("HVS1", 0, "survivor"),
+    ("HVS10", 0, "survivor"),
+    ("HVS11", 0, "survivor"),
+    ("HVS12", 0, "survivor"),
+    ("HVS13", 0, "rerun"),
+    ("HVS14", 0, "rerun"),
+    ("HVS15", 0, "rerun"),
+    ("HVS17", 0, "rerun"),
+    ("T006", 1, "survivor"),
+    ("T007", 1, "survivor"),
+    ("T008", 1, "survivor"),
+    ("T009", 1, "survivor"),
+    ("T010", 1, "rerun"),
+    ("T012", 1, "rerun"),
+    ("T013", 1, "rerun"),
+    ("T014", 1, "rerun"),
+)
+
+CLAIM_BOUNDARY = (
+    "ROI/manifest persistence only. No positive, clinical, mechanistic, "
+    "biomarker, or replicated O-SSM claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--survivor-root", default="", help="Directory containing survivor roi/sub-*.1D files")
+    parser.add_argument("--rerun-root", default="", help="Directory containing rerun roi/sub-*.1D files")
+    parser.add_argument(
+        "--roster-tsv",
+        default="",
+        help="Optional readiness roster with subject_id, label, and primary_roi_path columns.",
+    )
+    parser.add_argument("--out-root", required=True, help="Durable output root for the balanced_manifest package")
+    parser.add_argument("--tag", default="", help="Optional output tag; defaults to UTC timestamp")
+    parser.add_argument("--manifest-prefix", default="", help="Optional output package prefix; defaults to 8x8 or 14x14.")
+    parser.add_argument(
+        "--roi-buckets",
+        type=int,
+        default=200,
+        help="Number of contiguous ROI buckets to emit per time window; use 8 for current O-SSM runner.",
+    )
+    parser.add_argument(
+        "--site-policy",
+        choices=["openneuro", "pseudo_fold4", "pseudo_balanced"],
+        default="openneuro",
+        help="Site labels for O-SSM grouped holdout; pseudo_balanced creates balanced internal folds.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Replace the target directory if it exists")
+    return parser.parse_args()
+
+
+def read_roi(path: Path) -> list[list[float]]:
+    data: list[list[float]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                data.append([float(item) for item in line.split()])
+    if len(data) < 32:
+        raise SystemExit(f"short ROI {path}: {len(data)} rows")
+    width = len(data[0])
+    if width != 200:
+        raise SystemExit(f"unexpected ROI width {path}: {width}")
+    if any(len(row) != width for row in data):
+        raise SystemExit(f"ragged ROI {path}")
+    return data
+
+
+def window_features(data: list[list[float]], roi_buckets: int, mode: str = "none") -> list[float]:
+    n_rows = len(data)
+    n_roi = len(data[0])
+    if roi_buckets <= 0 or roi_buckets > n_roi:
+        raise SystemExit(f"invalid roi_buckets={roi_buckets}; ROI width is {n_roi}")
+    columns: list[list[float]] = []
+    for col_idx in range(n_roi):
+        col = [data[row_idx][col_idx] for row_idx in range(n_rows)]
+        mean = sum(col) / n_rows
+        var = sum((value - mean) * (value - mean) for value in col) / max(1, n_rows - 1)
+        sd = math.sqrt(var) if var > 1e-12 else 1.0
+        columns.append([(value - mean) / sd for value in col])
+
+    z_rows = [[columns[col_idx][row_idx] for col_idx in range(n_roi)] for row_idx in range(n_rows)]
+    order = list(range(n_rows))
+    if mode == "reverse":
+        order = list(reversed(order))
+    elif mode == "shuffle":
+        rnd = random.Random(60731 + n_rows + n_roi)
+        rnd.shuffle(order)
+
+    values: list[float] = []
+    for window in range(32):
+        start = (window * n_rows) // 32
+        end = ((window + 1) * n_rows) // 32
+        idx = order[start:end] or [order[min(start, n_rows - 1)]]
+        for bucket in range(roi_buckets):
+            roi_start = (bucket * n_roi) // roi_buckets
+            roi_end = ((bucket + 1) * n_roi) // roi_buckets
+            denom = len(idx) * max(1, roi_end - roi_start)
+            acc = 0.0
+            for row_idx in idx:
+                for col_idx in range(roi_start, roi_end):
+                    acc += z_rows[row_idx][col_idx]
+            values.append(acc / denom)
+    return values
+
+
+def site_for_row(row: dict[str, str], site_policy: str) -> str:
+    if site_policy == "openneuro":
+        return "openneuro"
+    return row["SITE_ID"]
+
+
+def write_manifest(
+    path: Path,
+    rows: list[dict[str, str]],
+    out_dir: Path,
+    site_policy: str,
+    roi_buckets: int,
+    temporal: str = "none",
+    label_shuffle: bool = False,
+) -> None:
+    labels = {row["subject_id"]: int(row["diagnosis"]) for row in rows}
+    if label_shuffle:
+        ordered = [row["subject_id"] for row in rows]
+        labels = dict(zip(ordered, list(reversed([labels[subject] for subject in ordered]))))
+    label_control = "within_site_shuffle" if label_shuffle else "none"
+
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(
+            "# schema=brain_ossm.neurodyn.v1\n"
+            "# dataset_id=ds006731\n"
+            "# seq_len=32\n"
+            f"# input_dim={roi_buckets}\n"
+            "# feature_layout=flat\n"
+            "# label_space=ds006731_mdd_vs_control\n"
+            "# label_positive_name=MDD\n"
+            "# label_negative_name=CONTROL\n"
+            "# split_policy=leave_one_site_out\n"
+            "# atlas=Schaefer2018_200Parcels_7Networks\n"
+            f"# feature_recipe=zscore_window_contiguous_roi_mean_bucket{roi_buckets}\n"
+            f"# site_policy={site_policy}\n"
+            f"# temporal_control={temporal}\n"
+            f"# label_control={label_control}\n"
+            f"# source_phenotypic={out_dir / 'mdd_phenotypic.csv'}\n"
+            f"# source_roi_dir={out_dir / 'rois'}\n"
+            f"# subject_count={len(rows)}\n"
+            f"# site_count={len(set(site_for_row(row, site_policy) for row in rows))}\n"
+        )
+        header = ["subject_id", "label", "site"] + [f"f{i}" for i in range(32 * roi_buckets)]
+        handle.write("\t".join(header) + "\n")
+        for row in rows:
+            roi_path = out_dir / "rois" / (row["subject_id"] + ".1D")
+            values = window_features(read_roi(roi_path), roi_buckets, temporal)
+            fields = [row["subject_id"], str(labels[row["subject_id"]]), site_for_row(row, site_policy)]
+            fields.extend(f"{value:.10f}" for value in values)
+            handle.write("\t".join(fields) + "\n")
+
+
+def pseudo_fold(subject: str) -> str:
+    # Four folds, each with two controls and two MDD subjects in DEFAULT_SUBJECTS order.
+    fold_map = {
+        "HVS1": 0,
+        "HVS13": 0,
+        "T006": 0,
+        "T010": 0,
+        "HVS10": 1,
+        "HVS14": 1,
+        "T007": 1,
+        "T012": 1,
+        "HVS11": 2,
+        "HVS15": 2,
+        "T008": 2,
+        "T013": 2,
+        "HVS12": 3,
+        "HVS17": 3,
+        "T009": 3,
+        "T014": 3,
+    }
+    return f"pseudo_fold_{fold_map[subject]:02d}"
+
+
+def apply_balanced_pseudo_folds(rows: list[dict[str, str]], per_label_per_fold: int = 2) -> None:
+    by_label: dict[str, list[dict[str, str]]] = {"0": [], "1": []}
+    for row in rows:
+        by_label.setdefault(row["diagnosis"], []).append(row)
+    if len(by_label.get("0", [])) != len(by_label.get("1", [])):
+        raise SystemExit("pseudo_balanced requires equal class counts")
+    if not by_label.get("0"):
+        raise SystemExit("pseudo_balanced requires at least one subject per class")
+    for label_rows in by_label.values():
+        for idx, row in enumerate(label_rows):
+            row["SITE_ID"] = f"pseudo_fold_{idx // per_label_per_fold:02d}"
+
+
+def read_roster_rows(roster_tsv: Path) -> list[dict[str, str]]:
+    with roster_tsv.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    required = {"subject_id", "label", "primary_roi_path"}
+    missing = required.difference(rows[0] if rows else {})
+    if missing:
+        raise SystemExit(f"roster missing columns: {','.join(sorted(missing))}")
+    return rows
+
+
+def copy_rois_from_roster(roster_tsv: Path, out_dir: Path, site_policy: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    (out_dir / "rois").mkdir(parents=True, exist_ok=True)
+    for item in read_roster_rows(roster_tsv):
+        subject_id = item["subject_id"]
+        label = str(item["label"])
+        source = Path(item["primary_roi_path"])
+        if label not in {"0", "1"}:
+            raise SystemExit(f"bad label for {subject_id}: {label}")
+        if not source.exists() or source.stat().st_size == 0:
+            raise SystemExit(f"missing ROI {subject_id}: {source}")
+        roi = read_roi(source)
+        target = out_dir / "rois" / f"{subject_id}.1D"
+        shutil.copy2(source, target)
+        rows.append(
+            {
+                "subject_id": subject_id,
+                "FILE_ID": subject_id,
+                "SITE_ID": "openneuro",
+                "diagnosis": label,
+                "source_roi_path": str(source),
+                "timepoints": str(len(roi)),
+                "roi_dim": str(len(roi[0])),
+                "provenance": item.get("primary_roi_path", ""),
+            }
+        )
+    if site_policy == "pseudo_balanced":
+        apply_balanced_pseudo_folds(rows)
+    return rows
+
+
+def copy_rois(survivor_root: Path, rerun_root: Path, out_dir: Path, site_policy: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    (out_dir / "rois").mkdir(parents=True, exist_ok=True)
+    for subject, label, provenance in DEFAULT_SUBJECTS:
+        source_root = survivor_root if provenance == "survivor" else rerun_root
+        roi_path = source_root / "roi" / f"sub-{subject}.1D"
+        if not roi_path.exists() or roi_path.stat().st_size == 0:
+            raise SystemExit(f"missing ROI {subject}: {roi_path}")
+        target = out_dir / "rois" / f"sub-{subject}.1D"
+        shutil.copy2(roi_path, target)
+        site = "openneuro" if site_policy == "openneuro" else pseudo_fold(subject)
+        rows.append(
+            {
+                "subject_id": f"sub-{subject}",
+                "FILE_ID": f"sub-{subject}",
+                "SITE_ID": site,
+                "diagnosis": str(label),
+                "source_roi_path": str(target),
+                "timepoints": "200",
+                "roi_dim": "200",
+                "provenance": provenance,
+            }
+        )
+    if site_policy == "pseudo_balanced":
+        apply_balanced_pseudo_folds(rows)
+    return rows
+
+
+def write_summary(
+    out_dir: Path,
+    rows: list[dict[str, str]],
+    rerun_root: Path,
+    site_policy: str,
+    roi_buckets: int,
+    source_descriptor: str,
+) -> None:
+    site_label_counts: dict[str, dict[str, int]] = {}
+    label_counts = {"0": 0, "1": 0}
+    for row in rows:
+        site_counts = site_label_counts.setdefault(row["SITE_ID"], {"0": 0, "1": 0})
+        site_counts[row["diagnosis"]] += 1
+        label_counts[row["diagnosis"]] = label_counts.get(row["diagnosis"], 0) + 1
+    summary = {
+        "schema": "brain_ossm.mdd_neurodyn_prepare.v1",
+        "dataset_id": "ds006731",
+        "atlas": "Schaefer2018_200Parcels_7Networks",
+        "seq_len": 32,
+        "input_dim": roi_buckets,
+        "selected_subject_count": len(rows),
+        "selected_negative_count": label_counts.get("0", 0),
+        "selected_positive_count": label_counts.get("1", 0),
+        "selected_site_label_counts": site_label_counts,
+        "eligible_subject_count": len(rows),
+        "eligible_negative_count": label_counts.get("0", 0),
+        "eligible_positive_count": label_counts.get("1", 0),
+        "site_policy": site_policy,
+        "source_descriptor": source_descriptor,
+        "source_phenotypic": str(out_dir / "mdd_phenotypic.csv"),
+        "phenotypic_output": str(out_dir / "mdd_phenotypic.csv"),
+        "source_roi_dir": str(out_dir / "rois"),
+        "roi_cache_dir": str(out_dir / "rois"),
+        "manifests": {
+            "original": str(out_dir / "mdd_neurodyn_manifest.tsv"),
+            "temporal_shuffle": str(out_dir / "mdd_neurodyn_temporal_shuffle_manifest.tsv"),
+            "temporal_reverse": str(out_dir / "mdd_neurodyn_temporal_reverse_manifest.tsv"),
+            "label_within_site_shuffle": str(out_dir / "mdd_neurodyn_label_within_site_shuffle_manifest.tsv"),
+        },
+        "candidate_stats": {
+            "rows_seen": len(rows),
+            "skipped_bad_label": 0,
+            "skipped_missing_path": 0,
+            "skipped_short": 0,
+            "skipped_site_limit": 0,
+        },
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    (out_dir / "mdd_neurodyn_prepare_summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
+    (out_dir / "mdd_neurodyn_inventory.tsv").write_text(
+        "subject_id\tlabel\tsite\tprovenance\n"
+        + "".join(
+            f"{row['subject_id']}\t{row['diagnosis']}\t{row['SITE_ID']}\t{row['provenance']}\n"
+            for row in rows
+        ),
+        encoding="utf-8",
+    )
+    if str(rerun_root) != ".":
+        receipt = rerun_root / "rerun_receipt.env"
+        if receipt.exists():
+            shutil.copy2(receipt, out_dir / "rerun_receipt.env")
+        (out_dir / "RERUN_SOURCE_DIR.txt").write_text(str(rerun_root) + "\n", encoding="utf-8")
+    (out_dir / "claim_boundary.txt").write_text(CLAIM_BOUNDARY + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    survivor_root = Path(args.survivor_root).resolve() if args.survivor_root else Path()
+    rerun_root = Path(args.rerun_root).resolve() if args.rerun_root else Path()
+    roster_tsv = Path(args.roster_tsv).resolve() if args.roster_tsv else Path()
+    out_root = Path(args.out_root).resolve()
+    tag = args.tag or dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    if roster_tsv:
+        package_prefix = args.manifest_prefix or "14x14"
+    else:
+        package_prefix = args.manifest_prefix or "8x8"
+    out_dir = out_root / f"manifest_{package_prefix}_rerun_{args.site_policy}_bucket{args.roi_buckets}_{tag}"
+    if out_dir.exists():
+        if not args.overwrite:
+            raise SystemExit(f"output exists; pass --overwrite to replace: {out_dir}")
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    if roster_tsv:
+        rows = copy_rois_from_roster(roster_tsv, out_dir, args.site_policy)
+        source_descriptor = str(roster_tsv)
+    else:
+        if not args.survivor_root or not args.rerun_root:
+            raise SystemExit("either --roster-tsv or both --survivor-root/--rerun-root are required")
+        rows = copy_rois(survivor_root, rerun_root, out_dir, args.site_policy)
+        source_descriptor = f"survivor_root={survivor_root};rerun_root={rerun_root}"
+
+    with (out_dir / "mdd_phenotypic.csv").open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    write_manifest(out_dir / "mdd_neurodyn_manifest.tsv", rows, out_dir, args.site_policy, args.roi_buckets)
+    write_manifest(
+        out_dir / "mdd_neurodyn_temporal_shuffle_manifest.tsv",
+        rows,
+        out_dir,
+        args.site_policy,
+        args.roi_buckets,
+        temporal="shuffle",
+    )
+    write_manifest(
+        out_dir / "mdd_neurodyn_temporal_reverse_manifest.tsv",
+        rows,
+        out_dir,
+        args.site_policy,
+        args.roi_buckets,
+        temporal="reverse",
+    )
+    write_manifest(
+        out_dir / "mdd_neurodyn_label_within_site_shuffle_manifest.tsv",
+        rows,
+        out_dir,
+        args.site_policy,
+        args.roi_buckets,
+        label_shuffle=True,
+    )
+    write_summary(out_dir, rows, rerun_root, args.site_policy, args.roi_buckets, source_descriptor)
+    with (out_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in out_dir.rglob("*") if item.is_file() and item.name != "SHA256SUMS"):
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            handle.write(f"{digest}  {path}\n")
+    print(out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_evidence_bundle.py
+++ b/scripts/research/neurodyn_evidence_bundle.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+neurodyn_evidence_bundle — camada de integridade (hash) para o manifest P3 NeuroDyn.
+
+Motivação: os artefatos NeuroDyn (mdd_neurodyn_manifest.tsv, null-models
+temporal_shuffle/temporal_reverse/label_within_site_shuffle, phenotypic, ROIs,
+prepare_summary.json) hoje são referenciados só por PATH — sem integridade de
+conteúdo. Sem hash, não há atestado cirúrgico de reprodutibilidade, e o gate
+orangefs_not_required_for_p3_roi_manifest não consegue provar o check 3.
+
+Este script emite/verifica um evidence bundle com sha256 por artefato e uma raiz
+determinística (bundle_sha256), casando com o check 3 do gate.
+
+Uso:
+  build:   neurodyn_evidence_bundle.py build  <ARTIFACT_ROOT> [--summary NAME] [--dry]
+  verify:  neurodyn_evidence_bundle.py verify <ARTIFACT_ROOT> [--bundle NAME]
+
+  <ARTIFACT_ROOT> = dir que contém o prepare_summary.json (ex.:
+    .../ds002748/bounded_sub01_05_ctrl52_56/manifest_balanced_fmriprep)
+    ou um pacote de smoke O-SSM com neurodyn_bucket8_smoke_summary.json.
+
+Saídas (no ARTIFACT_ROOT, ou stdout com --dry):
+  neurodyn_evidence_bundle_manifest.json   (schema brain_ossm.neurodyn_evidence_bundle.v1)
+  neurodyn_evidence_bundle_verify.json     (schema ...verify.v1, no verify)
+
+Exit: 0 ok, 1 falha (build: artefato faltando; verify: hash divergente).
+"""
+from __future__ import annotations
+import argparse, hashlib, json, os, sys, datetime
+
+BUNDLE_NAME = "neurodyn_evidence_bundle_manifest.json"
+VERIFY_NAME = "neurodyn_evidence_bundle_verify.json"
+SUMMARY_DEFAULT = "mdd_neurodyn_prepare_summary.json"
+CLAIM = ("Content-integrity manifest only. Fixa hashes de artefatos P3; "
+         "não autoriza nenhuma afirmação científica, clínica ou de biomarcador.")
+
+
+def sha256_file(path: str, buf: int = 1 << 20) -> tuple[str, int]:
+    h = hashlib.sha256(); n = 0
+    with open(path, "rb") as f:
+        while True:
+            b = f.read(buf)
+            if not b:
+                break
+            h.update(b); n += len(b)
+    return h.hexdigest(), n
+
+
+def resolve(root: str, ref: str) -> str | None:
+    """Resolve um artefato referenciado (path absoluto do summary OU relativo)
+    contra o ARTIFACT_ROOT local, por basename — portável entre hosts."""
+    for cand in (ref, os.path.join(root, ref), os.path.join(root, os.path.basename(ref))):
+        if cand and os.path.isfile(cand):
+            return cand
+    return None
+
+
+def collect_smoke(root: str) -> tuple[list[dict], list[str]]:
+    required = [
+        "neurodyn_bucket8_smoke_summary.json",
+        "neurodyn_bucket8_smoke_summary.tsv",
+        "checkpoint_python_fresh_replay.json",
+        "single_site_cv_test_results/checkpoints/neurodyn-ds006731-bucket8-original-precompiled-20260705T173500Z/model.ckpt",
+    ]
+    missing = [name for name in required if not os.path.isfile(os.path.join(root, name))]
+    if missing:
+        return [], missing
+    artifacts = []
+    skip = {
+        "SHA256SUMS",
+        BUNDLE_NAME,
+        VERIFY_NAME,
+        "neurodyn_orangefs_not_required_gate.json",
+        "neurodyn_orangefs_not_required_gate.md",
+    }
+    for dirpath, _, filenames in os.walk(root):
+        for filename in sorted(filenames):
+            if filename in skip:
+                continue
+            abs_path = os.path.join(dirpath, filename)
+            rel = os.path.relpath(abs_path, root)
+            digest, size = sha256_file(abs_path)
+            role = "ossm_smoke"
+            if rel.endswith("model.ckpt"):
+                role = "checkpoint"
+            elif rel == "checkpoint_python_fresh_replay.json":
+                role = "checkpoint_replay"
+            elif rel.startswith("single_site_cv_test_results/"):
+                role = "original_run_output"
+            elif rel.startswith("temporal_shuffle_results/"):
+                role = "null_output.temporal_shuffle"
+            elif rel.startswith("temporal_reverse_results/"):
+                role = "null_output.temporal_reverse"
+            elif rel.startswith("label_within_site_shuffle_results/"):
+                role = "null_output.label_within_site_shuffle"
+            artifacts.append({
+                "role": role,
+                "path": rel,
+                "sha256": digest,
+                "bytes": size,
+            })
+    return artifacts, []
+
+
+def collect(root: str, summary_name: str) -> tuple[list[dict], list[str]]:
+    """Coleta (role, path_rel, abs) de todo artefato científico a hashear."""
+    if os.path.isfile(os.path.join(root, "neurodyn_bucket8_smoke_summary.json")):
+        return collect_smoke(root)
+
+    spath = os.path.join(root, summary_name)
+    missing: list[str] = []
+    if not os.path.isfile(spath):
+        return [], [summary_name]
+    with open(spath) as f:
+        summ = json.load(f)
+
+    wanted: list[tuple[str, str]] = [("summary", spath)]
+    man = summ.get("manifests", {})
+    for role_key in ("original", "temporal_shuffle", "temporal_reverse",
+                     "label_within_site_shuffle"):
+        ref = man.get(role_key)
+        if ref:
+            role = "roi_manifest" if role_key == "original" else f"null_manifest.{role_key}"
+            a = resolve(root, ref)
+            wanted.append((role, a)) if a else missing.append(os.path.basename(ref))
+    for key, role in (("phenotypic_output", "phenotypic"),):
+        ref = summ.get(key)
+        if ref:
+            a = resolve(root, ref)
+            wanted.append((role, a)) if a else missing.append(os.path.basename(ref))
+    # ROIs no roi_cache_dir
+    roidir_ref = summ.get("roi_cache_dir")
+    roidir = None
+    if roidir_ref:
+        for cand in (roidir_ref, os.path.join(root, os.path.basename(roidir_ref))):
+            if os.path.isdir(cand):
+                roidir = cand; break
+    if roidir:
+        for fn in sorted(os.listdir(roidir)):
+            if fn.endswith(".1D"):
+                wanted.append(("roi", os.path.join(roidir, fn)))
+    else:
+        missing.append("roi_cache_dir")
+    # inventory opcional
+    inv = os.path.join(root, "mdd_neurodyn_inventory.tsv")
+    if os.path.isfile(inv):
+        wanted.append(("inventory", inv))
+
+    artifacts = []
+    for role, abs_ in wanted:
+        digest, size = sha256_file(abs_)
+        artifacts.append({
+            "role": role,
+            "path": os.path.relpath(abs_, root),
+            "sha256": digest,
+            "bytes": size,
+        })
+    return artifacts, missing
+
+
+def bundle_root(artifacts: list[dict]) -> str:
+    """Raiz determinística: sha256 sobre linhas 'sha256␠path\\n' ordenadas por path."""
+    lines = "".join(f"{a['sha256']}  {a['path']}\n"
+                    for a in sorted(artifacts, key=lambda x: x["path"]))
+    return hashlib.sha256(lines.encode()).hexdigest()
+
+
+def now_utc() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def cmd_build(args) -> int:
+    root = os.path.abspath(args.artifact_root)
+    artifacts, missing = collect(root, args.summary)
+    if missing:
+        sys.stderr.write(f"[build] FALHA — artefatos faltando: {missing}\n")
+        return 1
+    dataset_id = "unknown"
+    try:
+        with open(os.path.join(root, args.summary)) as f:
+            dataset_id = json.load(f).get("dataset_id", "unknown")
+    except Exception:
+        pass
+    bundle = {
+        "schema": "brain_ossm.neurodyn_evidence_bundle.v1",
+        "claim_boundary": CLAIM,
+        "created_at_utc": now_utc(),
+        "dataset_id": dataset_id,
+        "source_summary": args.summary,
+        "artifact_count": len(artifacts),
+        "total_bytes": sum(a["bytes"] for a in artifacts),
+        "artifacts": sorted(artifacts, key=lambda x: x["path"]),
+        "bundle_sha256": bundle_root(artifacts),
+    }
+    out = json.dumps(bundle, indent=2, ensure_ascii=False)
+    if args.dry:
+        print(out)
+    else:
+        with open(os.path.join(root, BUNDLE_NAME), "w") as f:
+            f.write(out + "\n")
+        sys.stderr.write(f"[build] OK — {len(artifacts)} artefatos, "
+                         f"bundle_sha256={bundle['bundle_sha256'][:16]}… → {BUNDLE_NAME}\n")
+    return 0
+
+
+def cmd_verify(args) -> int:
+    root = os.path.abspath(args.artifact_root)
+    bpath = os.path.join(root, args.bundle)
+    if not os.path.isfile(bpath):
+        sys.stderr.write(f"[verify] FALHA — bundle ausente: {bpath}\n"); return 1
+    with open(bpath) as f:
+        bundle = json.load(f)
+    mism = []
+    for a in bundle.get("artifacts", []):
+        abs_ = os.path.join(root, a["path"])
+        if not os.path.isfile(abs_):
+            mism.append({"path": a["path"], "reason": "arquivo ausente"}); continue
+        got, size = sha256_file(abs_)
+        if got != a["sha256"]:
+            mism.append({"path": a["path"], "reason": "sha256 divergente",
+                         "expected": a["sha256"], "got": got})
+    recomputed = bundle_root([{"path": a["path"], "sha256": a["sha256"]}
+                              for a in bundle.get("artifacts", [])])
+    root_ok = recomputed == bundle.get("bundle_sha256")
+    all_ok = not mism and root_ok
+    result = {
+        "schema": "brain_ossm.neurodyn_evidence_bundle_verify.v1",
+        "created_at_utc": now_utc(),
+        "bundle": args.bundle,
+        "bundle_sha256_expected": bundle.get("bundle_sha256"),
+        "bundle_sha256_recomputed": recomputed,
+        "bundle_root_match": root_ok,
+        "artifact_count": len(bundle.get("artifacts", [])),
+        "all_match": all_ok,
+        "mismatches": mism,
+    }
+    out = json.dumps(result, indent=2, ensure_ascii=False)
+    if args.dry:
+        print(out)
+    else:
+        with open(os.path.join(root, VERIFY_NAME), "w") as f:
+            f.write(out + "\n")
+    sys.stderr.write(f"[verify] {'OK ✓' if all_ok else 'FALHA ✗'} — "
+                     f"{len(mism)} divergência(s), root_match={root_ok}\n")
+    return 0 if all_ok else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="NeuroDyn P3 evidence bundle (hash layer)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    b = sub.add_parser("build"); b.add_argument("artifact_root")
+    b.add_argument("--summary", default=SUMMARY_DEFAULT); b.add_argument("--dry", action="store_true")
+    b.set_defaults(fn=cmd_build)
+    v = sub.add_parser("verify"); v.add_argument("artifact_root")
+    v.add_argument("--bundle", default=BUNDLE_NAME); v.add_argument("--dry", action="store_true")
+    v.set_defaults(fn=cmd_verify)
+    args = p.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fano_orbit_diagnostic.py
+++ b/scripts/research/neurodyn_fano_orbit_diagnostic.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Diagnose Fano-line orbit geometry from Brain O-SSM STATE_TRACE output."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, pstdev
+from typing import Any
+
+
+PAIR_RE = re.compile(r"synthetic_pair_(\d+)__(oriented|swapped)$")
+FANO_SITE_RE = re.compile(r"fano_line_\d+_(\d+)-(\d+)-(\d+)$")
+
+
+def read_manifest(path: Path) -> tuple[list[dict[str, Any]], int]:
+    rows: list[dict[str, Any]] = []
+    with path.open(newline="") as f:
+        reader = csv.reader((line for line in f if not line.startswith("#")), delimiter="\t")
+        header = next(reader)
+        idx = {name: i for i, name in enumerate(header)}
+        for subject_idx, row in enumerate(reader):
+            sid = row[idx["subject_id"]]
+            m = PAIR_RE.match(sid)
+            if not m:
+                raise SystemExit(f"manifest subject_id does not match synthetic pair pattern: {sid}")
+            pair_idx = int(m.group(1))
+            orientation = m.group(2)
+            label_raw = row[idx["label"]]
+            try:
+                label = int(label_raw)
+            except ValueError:
+                if orientation == "oriented":
+                    label = 1
+                elif orientation == "swapped":
+                    label = 0
+                else:
+                    raise
+            rows.append(
+                {
+                    "subject_idx": subject_idx,
+                    "subject_id": sid,
+                    "label": label,
+                    "label_raw": label_raw,
+                    "site": row[idx["site"]],
+                    "pair_id": f"synthetic_pair_{pair_idx:04d}",
+                    "pair_idx": pair_idx,
+                    "orientation": orientation,
+                }
+            )
+    site_count = len({r["site"] for r in rows})
+    if site_count <= 0:
+        raise SystemExit("manifest has no sites")
+    for r in rows:
+        r["line_idx"] = r["pair_idx"] % site_count
+        r["orbit_idx"] = r["pair_idx"] // site_count
+    return rows, site_count
+
+
+def collect_parts(lines: list[str], i: int, expected: int) -> tuple[list[str], int]:
+    parts = [part for part in lines[i].split("\t") if part]
+    j = i + 1
+    while len(parts) < expected and j < len(lines) and lines[j].startswith("\t"):
+        parts.extend(part for part in lines[j].split("\t") if part)
+        j += 1
+    return parts, j
+
+
+def parse_raw(path: Path) -> tuple[dict[tuple[str, int, int], list[float]], dict[tuple[str, int, int], int]]:
+    states: dict[tuple[str, int, int], list[float]] = {}
+    preds: dict[tuple[str, int, int], int] = {}
+    lines = path.read_text().splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("STATE_TRACE\t"):
+            parts, next_i = collect_parts(lines, i, 22)
+            if len(parts) != 22:
+                raise SystemExit(f"malformed STATE_TRACE near line {i + 1}: expected 22 fields, got {len(parts)}")
+            _, model, seed_s, subject_s, _site, _label, *raw_values = parts
+            seed = int(seed_s)
+            subject_idx = int(subject_s)
+            values = [int(value) / 1_000_000.0 for value in raw_values]
+            states[(model, seed, subject_idx)] = values
+            i = next_i
+            continue
+        if line.startswith("PRED\t"):
+            parts, next_i = collect_parts(lines, i, 9)
+            if len(parts) == 8:
+                _, model, seed_s, _site, _label, _prob, pred_s, _assoc = parts
+                subject_idx = -1
+            elif len(parts) == 9:
+                _, model, seed_s, subject_s, _site, _label, _prob, pred_s, _assoc = parts
+                subject_idx = int(subject_s)
+            else:
+                raise SystemExit(f"malformed PRED near line {i + 1}: expected 8 or 9 fields, got {len(parts)}")
+            seed = int(seed_s)
+            pred = int(pred_s)
+            if subject_idx >= 0:
+                preds[(model, seed, subject_idx)] = pred
+            i = next_i
+            continue
+        i += 1
+    return states, preds
+
+
+def dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def norm(a: list[float]) -> float:
+    return math.sqrt(dot(a, a))
+
+
+def sub(a: list[float], b: list[float]) -> list[float]:
+    return [x - y for x, y in zip(a, b)]
+
+
+def add_into(dst: list[float], src: list[float]) -> None:
+    for i, v in enumerate(src):
+        dst[i] += v
+
+
+def scale(a: list[float], s: float) -> list[float]:
+    return [x * s for x in a]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    denom = norm(a) * norm(b)
+    if denom <= 1e-12:
+        return 0.0
+    return dot(a, b) / denom
+
+
+def balanced_accuracy(items: list[tuple[int, int]]) -> float:
+    tp = tn = fp = fn = 0
+    for label, pred in items:
+        if label == 1 and pred == 1:
+            tp += 1
+        elif label == 0 and pred == 0:
+            tn += 1
+        elif label == 0 and pred == 1:
+            fp += 1
+        elif label == 1 and pred == 0:
+            fn += 1
+    tpr = tp / (tp + fn) if tp + fn else 0.0
+    tnr = tn / (tn + fp) if tn + fp else 0.0
+    return 50.0 * (tpr + tnr)
+
+
+def build_pair_rows(
+    manifest_rows: list[dict[str, Any]],
+    states: dict[tuple[str, int, int], list[float]],
+    preds: dict[tuple[str, int, int], int],
+) -> list[dict[str, Any]]:
+    by_pair: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in manifest_rows:
+        by_pair[r["pair_id"]].append(r)
+
+    out: list[dict[str, Any]] = []
+    model_seeds = sorted({(m, s) for (m, s, _) in states})
+    for model, seed in model_seeds:
+        for pair_id, members in sorted(by_pair.items()):
+            pos = next((r for r in members if r["label"] == 1), None)
+            neg = next((r for r in members if r["label"] == 0), None)
+            if pos is None or neg is None:
+                continue
+            pos_state = states.get((model, seed, pos["subject_idx"]))
+            neg_state = states.get((model, seed, neg["subject_idx"]))
+            if pos_state is None or neg_state is None:
+                continue
+            pos_pred = preds.get((model, seed, pos["subject_idx"]))
+            neg_pred = preds.get((model, seed, neg["subject_idx"]))
+            pred_items = []
+            if pos_pred is not None:
+                pred_items.append((1, pos_pred))
+            if neg_pred is not None:
+                pred_items.append((0, neg_pred))
+            delta = sub(pos_state, neg_state)
+            out.append(
+                {
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pair_id,
+                    "pair_idx": pos["pair_idx"],
+                    "orbit_idx": pos["orbit_idx"],
+                    "line_idx": pos["line_idx"],
+                    "site": pos["site"],
+                    "delta": delta,
+                    "delta_norm": norm(delta),
+                    "pair_balanced_accuracy": balanced_accuracy(pred_items) if pred_items else None,
+                }
+            )
+    return out
+
+
+def enrich_orbit_alignment(pair_rows: list[dict[str, Any]]) -> None:
+    groups: dict[tuple[str, int, int], list[dict[str, Any]]] = defaultdict(list)
+    for r in pair_rows:
+        groups[(r["model"], r["seed"], r["orbit_idx"])].append(r)
+    for group_rows in groups.values():
+        if not group_rows:
+            continue
+        center = [0.0] * len(group_rows[0]["delta"])
+        for r in group_rows:
+            add_into(center, r["delta"])
+        center = scale(center, 1.0 / len(group_rows))
+        for r in group_rows:
+            leave_center = [0.0] * len(r["delta"])
+            leave_n = 0
+            for other in group_rows:
+                if other is r:
+                    continue
+                add_into(leave_center, other["delta"])
+                leave_n += 1
+            if leave_n:
+                leave_center = scale(leave_center, 1.0 / leave_n)
+            else:
+                leave_center = center
+            r["orbit_center_cosine"] = cosine(r["delta"], center)
+            r["orbit_leave_one_cosine"] = cosine(r["delta"], leave_center)
+            r["orbit_center_distance"] = norm(sub(r["delta"], center))
+
+
+def aggregate(rows: list[dict[str, Any]], keys: list[str]) -> list[dict[str, Any]]:
+    groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        groups[tuple(r[k] for k in keys)].append(r)
+    out: list[dict[str, Any]] = []
+    for key, group in sorted(groups.items()):
+        rec = {k: v for k, v in zip(keys, key)}
+        for field in ["delta_norm", "orbit_center_cosine", "orbit_leave_one_cosine", "orbit_center_distance"]:
+            vals = [float(r[field]) for r in group if field in r]
+            rec[f"{field}_mean"] = mean(vals) if vals else 0.0
+            rec[f"{field}_std"] = pstdev(vals) if len(vals) > 1 else 0.0
+        ba_vals = [float(r["pair_balanced_accuracy"]) for r in group if r.get("pair_balanced_accuracy") is not None]
+        rec["pair_balanced_accuracy_mean"] = mean(ba_vals) if ba_vals else 0.0
+        rec["row_count"] = len(group)
+        out.append(rec)
+    return out
+
+
+def line_transfer_rows(pair_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_model_seed_line: dict[tuple[str, int, int], list[dict[str, Any]]] = defaultdict(list)
+    for r in pair_rows:
+        by_model_seed_line[(r["model"], r["seed"], r["line_idx"])].append(r)
+
+    centers: dict[tuple[str, int, int], list[float]] = {}
+    for key, rows in by_model_seed_line.items():
+        if not rows:
+            continue
+        center = [0.0] * len(rows[0]["delta"])
+        for r in rows:
+            add_into(center, r["delta"])
+        centers[key] = scale(center, 1.0 / len(rows))
+
+    out: list[dict[str, Any]] = []
+    model_seeds = sorted({(r["model"], r["seed"]) for r in pair_rows})
+    line_indices = sorted({int(r["line_idx"]) for r in pair_rows})
+    site_by_line = {int(r["line_idx"]): r["site"] for r in pair_rows}
+    for model, seed in model_seeds:
+        for source_line in line_indices:
+            center = centers.get((model, seed, source_line))
+            if center is None:
+                continue
+            center_norm = norm(center)
+            for target_line in line_indices:
+                target_rows = by_model_seed_line.get((model, seed, target_line), [])
+                if not target_rows:
+                    continue
+                correct = 0
+                total = 0
+                score_values: list[float] = []
+                cos_values: list[float] = []
+                for r in target_rows:
+                    score = dot(r["delta"], center)
+                    score_values.append(score)
+                    cos_values.append(cosine(r["delta"], center))
+                    if score >= 0.0:
+                        correct += 1
+                    total += 1
+                out.append(
+                    {
+                        "model": model,
+                        "seed": seed,
+                        "source_line_idx": source_line,
+                        "source_site": site_by_line.get(source_line, ""),
+                        "target_line_idx": target_line,
+                        "target_site": site_by_line.get(target_line, ""),
+                        "source_center_norm": center_norm,
+                        "transfer_accuracy": 100.0 * correct / total if total else 0.0,
+                        "score_mean": mean(score_values),
+                        "cosine_mean": mean(cos_values),
+                        "pair_count": total,
+                    }
+                )
+    return out
+
+
+def aggregate_line_transfer(rows: list[dict[str, Any]], condition: str) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, int, str, int, str], list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        groups[
+            (
+                r["model"],
+                int(r["source_line_idx"]),
+                str(r["source_site"]),
+                int(r["target_line_idx"]),
+                str(r["target_site"]),
+            )
+        ].append(r)
+    out: list[dict[str, Any]] = []
+    for (model, source_line, source_site, target_line, target_site), group in sorted(groups.items()):
+        acc = [float(r["transfer_accuracy"]) for r in group]
+        score = [float(r["score_mean"]) for r in group]
+        cos = [float(r["cosine_mean"]) for r in group]
+        diag = 1 if source_line == target_line else 0
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "source_line_idx": source_line,
+                "source_site": source_site,
+                "target_line_idx": target_line,
+                "target_site": target_site,
+                "is_diagonal": diag,
+                "transfer_accuracy_mean": mean(acc),
+                "transfer_accuracy_std": pstdev(acc) if len(acc) > 1 else 0.0,
+                "score_mean": mean(score),
+                "cosine_mean": mean(cos),
+                "seed_count": len(group),
+            }
+        )
+    return out
+
+
+def summarize_line_transfer(rows: list[dict[str, Any]], condition: str) -> list[dict[str, Any]]:
+    by_model: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        by_model[str(r["model"])].append(r)
+    out: list[dict[str, Any]] = []
+    for model, model_rows in sorted(by_model.items()):
+        diag = [float(r["transfer_accuracy_mean"]) for r in model_rows if int(r["is_diagonal"]) == 1]
+        off = [float(r["transfer_accuracy_mean"]) for r in model_rows if int(r["is_diagonal"]) == 0]
+        anti = [r for r in model_rows if int(r["is_diagonal"]) == 0 and float(r["transfer_accuracy_mean"]) < 50.0]
+        strong = [r for r in model_rows if int(r["is_diagonal"]) == 0 and float(r["transfer_accuracy_mean"]) > 55.0]
+        best = max((r for r in model_rows if int(r["is_diagonal"]) == 0), key=lambda r: float(r["transfer_accuracy_mean"]), default=None)
+        worst = min((r for r in model_rows if int(r["is_diagonal"]) == 0), key=lambda r: float(r["transfer_accuracy_mean"]), default=None)
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "diagonal_transfer_accuracy_mean": mean(diag),
+                "offdiag_transfer_accuracy_mean": mean(off),
+                "offdiag_transfer_accuracy_std": pstdev(off) if len(off) > 1 else 0.0,
+                "strong_offdiag_count": len(strong),
+                "anti_transfer_offdiag_count": len(anti),
+                "best_offdiag": f"{best['source_site']}->{best['target_site']}" if best else "",
+                "best_offdiag_accuracy": float(best["transfer_accuracy_mean"]) if best else 0.0,
+                "worst_offdiag": f"{worst['source_site']}->{worst['target_site']}" if worst else "",
+                "worst_offdiag_accuracy": float(worst["transfer_accuracy_mean"]) if worst else 0.0,
+            }
+        )
+    return out
+
+
+def fano_units(site: str) -> tuple[int, int, int]:
+    m = FANO_SITE_RE.match(site)
+    if not m:
+        return (-1, -1, -1)
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def annotate_fano_relation(rows: list[dict[str, Any]]) -> None:
+    for r in rows:
+        source_units = fano_units(str(r["source_site"]))
+        target_units = fano_units(str(r["target_site"]))
+        shared = sorted(set(source_units) & set(target_units))
+        if int(r["is_diagonal"]) == 1:
+            r["shared_unit"] = "diag"
+            r["source_shared_pos"] = -1
+            r["target_shared_pos"] = -1
+            r["shared_pos_pair"] = "diag"
+            continue
+        if len(shared) != 1:
+            r["shared_unit"] = "none"
+            r["source_shared_pos"] = -1
+            r["target_shared_pos"] = -1
+            r["shared_pos_pair"] = "none"
+            continue
+        unit = shared[0]
+        source_pos = source_units.index(unit)
+        target_pos = target_units.index(unit)
+        r["shared_unit"] = unit
+        r["source_shared_pos"] = source_pos
+        r["target_shared_pos"] = target_pos
+        r["shared_pos_pair"] = f"{source_pos}->{target_pos}"
+
+
+def aggregate_relation_transfer(rows: list[dict[str, Any]], condition: str) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        if int(r["is_diagonal"]) == 1:
+            continue
+        groups[(str(r["model"]), str(r["shared_pos_pair"]))].append(r)
+    out: list[dict[str, Any]] = []
+    for (model, relation), group in sorted(groups.items()):
+        acc = [float(r["transfer_accuracy_mean"]) for r in group]
+        cos = [float(r["cosine_mean"]) for r in group]
+        scores = [float(r["score_mean"]) for r in group]
+        strong = [r for r in group if float(r["transfer_accuracy_mean"]) > 55.0]
+        anti = [r for r in group if float(r["transfer_accuracy_mean"]) < 50.0]
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "shared_pos_pair": relation,
+                "transfer_accuracy_mean": mean(acc),
+                "transfer_accuracy_std": pstdev(acc) if len(acc) > 1 else 0.0,
+                "cosine_mean": mean(cos),
+                "score_mean": mean(scores),
+                "strong_edge_count": len(strong),
+                "anti_transfer_edge_count": len(anti),
+                "edge_count": len(group),
+            }
+        )
+    return out
+
+
+def read_edge_plan(path: Path) -> set[tuple[str, str]]:
+    selected: set[tuple[str, str]] = set()
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        required = {"source_site", "target_site"}
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise SystemExit(f"edge plan missing columns {sorted(missing)}: {path}")
+        for row in reader:
+            flag = row.get("selected", "1").strip()
+            if flag in {"", "0", "false", "False", "FALSE", "no", "No", "NO"}:
+                continue
+            source = row["source_site"]
+            target = row["target_site"]
+            if source == target:
+                continue
+            selected.add((source, target))
+    if not selected:
+        raise SystemExit(f"edge plan selected no off-diagonal edges: {path}")
+    return selected
+
+
+def filter_transfer_matrix(rows: list[dict[str, Any]], selected_edges: set[tuple[str, str]]) -> list[dict[str, Any]]:
+    out = []
+    for r in rows:
+        edge = (str(r["source_site"]), str(r["target_site"]))
+        if edge in selected_edges:
+            out.append(r)
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]], drop_delta: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("")
+        return
+    fieldnames = [k for k in rows[0].keys() if not (drop_delta and k == "delta")]
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t", extrasaction="ignore")
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw-output", type=Path, required=True)
+    ap.add_argument("--manifest", type=Path, required=True)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--condition", required=True)
+    ap.add_argument(
+        "--edge-plan",
+        type=Path,
+        default=None,
+        help="Optional TSV with source_site/target_site/selected columns for balanced directed-edge diagnostics.",
+    )
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    if args.output_dir.exists() and any(args.output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_rows, site_count = read_manifest(args.manifest)
+    states, preds = parse_raw(args.raw_output)
+    pair_rows = build_pair_rows(manifest_rows, states, preds)
+    enrich_orbit_alignment(pair_rows)
+    for r in pair_rows:
+        r["condition"] = args.condition
+
+    pair_out = []
+    for r in pair_rows:
+        pair_out.append({k: v for k, v in r.items() if k != "delta"})
+    summary = aggregate(pair_rows, ["condition", "model"])
+    site_summary = aggregate(pair_rows, ["condition", "model", "site", "line_idx"])
+    orbit_summary = aggregate(pair_rows, ["condition", "model", "orbit_idx"])
+    transfer_detail = line_transfer_rows(pair_rows)
+    transfer_matrix = aggregate_line_transfer(transfer_detail, args.condition)
+    annotate_fano_relation(transfer_matrix)
+    transfer_summary = summarize_line_transfer(transfer_matrix, args.condition)
+    relation_summary = aggregate_relation_transfer(transfer_matrix, args.condition)
+    edge_plan_filtered_matrix: list[dict[str, Any]] = []
+    edge_plan_relation_summary: list[dict[str, Any]] = []
+    selected_edges: set[tuple[str, str]] | None = None
+    if args.edge_plan is not None:
+        selected_edges = read_edge_plan(args.edge_plan)
+        edge_plan_filtered_matrix = filter_transfer_matrix(transfer_matrix, selected_edges)
+        if not edge_plan_filtered_matrix:
+            raise SystemExit(f"edge plan matched no transfer-matrix rows: {args.edge_plan}")
+        edge_plan_relation_summary = aggregate_relation_transfer(edge_plan_filtered_matrix, args.condition)
+
+    write_tsv(args.output_dir / "fano_orbit_pair_detail.tsv", pair_out)
+    write_tsv(args.output_dir / "fano_orbit_summary.tsv", summary)
+    write_tsv(args.output_dir / "fano_orbit_site_summary.tsv", site_summary)
+    write_tsv(args.output_dir / "fano_orbit_orbit_summary.tsv", orbit_summary)
+    write_tsv(args.output_dir / "fano_line_transfer_seed_detail.tsv", transfer_detail)
+    write_tsv(args.output_dir / "fano_line_transfer_matrix.tsv", transfer_matrix)
+    write_tsv(args.output_dir / "fano_line_transfer_summary.tsv", transfer_summary)
+    write_tsv(args.output_dir / "fano_line_transfer_relation_summary.tsv", relation_summary)
+    if selected_edges is not None:
+        write_tsv(args.output_dir / "fano_line_transfer_matrix_edge_plan_filtered.tsv", edge_plan_filtered_matrix)
+        write_tsv(args.output_dir / "fano_line_transfer_relation_summary_edge_plan_filtered.tsv", edge_plan_relation_summary)
+
+    payload = {
+        "schema": "neurodyn.fano_orbit_diagnostic.v1",
+        "condition": args.condition,
+        "raw_output": str(args.raw_output),
+        "manifest": str(args.manifest),
+        "site_count": site_count,
+        "state_count": len(states),
+        "prediction_count": len(preds),
+        "pair_row_count": len(pair_rows),
+        "summary": summary,
+        "line_transfer_summary": transfer_summary,
+        "line_transfer_relation_summary": relation_summary,
+        "edge_plan": str(args.edge_plan) if args.edge_plan is not None else "",
+        "edge_plan_selected_edges": len(selected_edges) if selected_edges is not None else 0,
+        "edge_plan_line_transfer_relation_summary": edge_plan_relation_summary,
+    }
+    (args.output_dir / "fano_orbit_diagnostic.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fano_relation_counterbalanced_assay.py
+++ b/scripts/research/neurodyn_fano_relation_counterbalanced_assay.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Build a relation-counterbalanced Fano-line NeuroDyn assay package.
+
+This packages the temporal manifest and the directed-edge relation plan at
+generation time. The model still trains on subjects whose observations live on
+Fano lines; the edge plan defines the pre-registered transfer diagnostic over
+directed source-line -> target-line relations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CLAIM_BOUNDARY = (
+    "Synthetic non-clinical relation-counterbalanced Fano transfer assay only. "
+    "No clinical, biomarker, biological mechanism, solved-transfer, or broad "
+    "O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--pairs", type=int, default=280)
+    ap.add_argument("--seq-len", type=int, default=32)
+    ap.add_argument("--noise-std", type=float, default=0.015)
+    ap.add_argument("--magnitude", type=float, default=3.0)
+    ap.add_argument("--seed", type=int, default=2026070710)
+    ap.add_argument("--edge-seed", type=int, default=2026070711)
+    ap.add_argument("--edges-per-relation", type=int, default=2)
+    ap.add_argument(
+        "--target-relation",
+        default="",
+        help="Optional pre-registered relation such as 2->0 for fixed-target diagnostics.",
+    )
+    ap.add_argument("--anchor", choices=("zero", "unit_real"), default="unit_real")
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f))
+
+
+def fail_if(condition: bool, message: str) -> None:
+    if condition:
+        raise SystemExit(message)
+
+
+def write_markdown(path: Path, summary: dict[str, Any]) -> None:
+    rel_counts = summary["selected_relation_counts"]
+    source_counts = summary["selected_source_counts"]
+    target_counts = summary["selected_target_counts"]
+    lines = [
+        "# NeuroDyn Fano Relation-Counterbalanced Assay",
+        "",
+        f"Generated: {summary['created_at_utc']}",
+        "",
+        "## Scope",
+        "",
+        CLAIM_BOUNDARY,
+        "",
+        "## Manifest",
+        "",
+        f"- Manifest: `{summary['manifest']}`",
+        f"- Pairs: `{summary['pairs']}`",
+        f"- Records: `{summary['records']}`",
+        f"- Sites: `{summary['sites']}`",
+        f"- Sequence length: `{summary['seq_len']}`",
+        f"- Magnitude: `{summary['magnitude']}`",
+        f"- Noise std: `{summary['noise_std']}`",
+        f"- Anchor: `{summary['anchor']}`",
+        "",
+        "## Invariant Gate",
+        "",
+        f"- mean max abs diff: `{summary['invariant_max']['mean_max_abs_diff']}`",
+        f"- delta max abs diff: `{summary['invariant_max']['delta_max_abs_diff']}`",
+        f"- start max abs diff: `{summary['invariant_max']['start_max_abs_diff']}`",
+        f"- end max abs diff: `{summary['invariant_max']['end_max_abs_diff']}`",
+        f"- energy abs diff: `{summary['invariant_max']['energy_abs_diff']}`",
+        f"- same unordered multiset min: `{summary['invariant_max']['same_unordered_multiset_min']}`",
+        "",
+        "## Relation Edge Plan",
+        "",
+        f"- Edge plan: `{summary['edge_plan']}`",
+        f"- Directed off-diagonal edges: `{summary['directed_offdiag_edges']}`",
+        f"- Selected edges: `{summary['selected_edges']}`",
+        f"- Edges per relation: `{summary['edges_per_relation']}`",
+        f"- Target relation: `{summary['target_relation'] or 'none'}`",
+        f"- Target selected edges: `{summary['target_edges_selected']}`",
+        "",
+        "| relation | selected_edges |",
+        "| --- | ---: |",
+    ]
+    for rel, count in sorted(rel_counts.items()):
+        lines.append(f"| {rel} | {count} |")
+    lines.extend(
+        [
+            "",
+            "## Source Counts",
+            "",
+            "| source_site | selected_edges |",
+            "| --- | ---: |",
+        ]
+    )
+    for site, count in sorted(source_counts.items()):
+        lines.append(f"| {site} | {count} |")
+    lines.extend(
+        [
+            "",
+            "## Target Counts",
+            "",
+            "| target_site | selected_edges |",
+            "| --- | ---: |",
+        ]
+    )
+    for site, count in sorted(target_counts.items()):
+        lines.append(f"| {site} | {count} |")
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            f"`{summary['decision']}`",
+            "",
+            "This package is ready for a single true-label run plus one matched pair-label null smoke. "
+            "Do not use it as clinical or mechanistic evidence without the trained run, null envelope, "
+            "checkpoint replay, and hidden-state diagnostics.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    script_dir = Path(__file__).resolve().parent
+    out = args.output_dir.resolve()
+    fail_if(out.exists() and any(out.iterdir()) and not args.overwrite, f"output exists: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    manifest_script = script_dir / "neurodyn_noncommutative_temporal_manifest.py"
+    edge_plan_script = script_dir / "neurodyn_fano_relation_edge_plan.py"
+    manifest_cmd = [
+        sys.executable,
+        str(manifest_script),
+        "--output-dir",
+        str(out),
+        "--pairs",
+        str(args.pairs),
+        "--sites",
+        "7",
+        "--seq-len",
+        str(args.seq_len),
+        "--noise-std",
+        str(args.noise_std),
+        "--magnitude",
+        str(args.magnitude),
+        "--seed",
+        str(args.seed),
+        "--line-mode",
+        "fano_cycle",
+        "--site-mode",
+        "fano_line",
+        "--anchor",
+        args.anchor,
+    ]
+    if args.overwrite:
+        manifest_cmd.append("--overwrite")
+    run(manifest_cmd)
+
+    manifest = out / "noncommutative_temporal_manifest.tsv"
+    edge_dir = out / "relation_edge_plan"
+    edge_cmd = [
+        sys.executable,
+        str(edge_plan_script),
+        "--manifest",
+        str(manifest),
+        "--output-dir",
+        str(edge_dir),
+        "--seed",
+        str(args.edge_seed),
+        "--edges-per-relation",
+        str(args.edges_per_relation),
+    ]
+    if args.target_relation:
+        edge_cmd.extend(["--target-relation", args.target_relation])
+    if args.overwrite:
+        edge_cmd.append("--overwrite")
+    run(edge_cmd)
+
+    manifest_summary = read_json(out / "noncommutative_temporal_prepare_summary.json")
+    edge_summary = read_json(edge_dir / "fano_relation_balanced_edge_plan_summary.json")
+    invariant_max = manifest_summary["invariant_max"]
+    fail_if(manifest_summary["sites"] != 7, "expected 7 Fano-line sites")
+    fail_if(manifest_summary["line_mode"] != "fano_cycle", "expected fano_cycle line mode")
+    fail_if(manifest_summary["site_mode"] != "fano_line", "expected fano_line site mode")
+    fail_if(manifest_summary["label_counts"] != {"0": args.pairs, "1": args.pairs}, "label counts are not pair-balanced")
+    for site, counts in manifest_summary["site_label_counts"].items():
+        fail_if(counts["0"] != counts["1"], f"site labels not balanced for {site}: {counts}")
+    for key, value in invariant_max.items():
+        if key == "same_unordered_multiset_min":
+            fail_if(int(value) != 1, "paired unordered multiset invariant failed")
+        else:
+            fail_if(float(value) > 1e-9, f"paired invariant failed for {key}: {value}")
+    rel_counts = edge_summary["selected_relation_counts"]
+    fail_if(len(set(rel_counts.values())) != 1, f"selected relation counts are not balanced: {rel_counts}")
+    fail_if(edge_summary["selected_edges"] != args.edges_per_relation * 9, "unexpected selected edge count")
+    if args.target_relation:
+        fail_if(edge_summary["target_relation"] != args.target_relation, "edge summary target relation mismatch")
+        fail_if(
+            edge_summary["target_edges_selected"] != args.edges_per_relation,
+            f"target selected edge count mismatch: {edge_summary['target_edges_selected']}",
+        )
+
+    selected_rows = read_csv_rows(edge_dir / "fano_relation_balanced_edge_plan_selected.tsv")
+    target_rows = []
+    if args.target_relation:
+        target_rows = read_csv_rows(edge_dir / "fano_relation_fixed_target_edge_plan_selected.tsv")
+    summary = {
+        "schema": (
+            "neurodyn.fano_relation_fixed_target_assay.v1"
+            if args.target_relation
+            else "neurodyn.fano_relation_counterbalanced_assay.v1"
+        ),
+        "created_at_utc": manifest_summary["created_at_utc"],
+        "claim_boundary": CLAIM_BOUNDARY,
+        "output_dir": str(out),
+        "manifest": str(manifest),
+        "edge_plan": str(edge_dir / "fano_relation_balanced_edge_plan.tsv"),
+        "selected_edge_plan": str(edge_dir / "fano_relation_balanced_edge_plan_selected.tsv"),
+        "target_selected_edge_plan": edge_summary["target_selected_edge_plan"],
+        "pairs": manifest_summary["pairs"],
+        "records": manifest_summary["records"],
+        "sites": manifest_summary["sites"],
+        "seq_len": manifest_summary["seq_len"],
+        "noise_std": manifest_summary["noise_std"],
+        "magnitude": manifest_summary["magnitude"],
+        "anchor": manifest_summary["anchor"],
+        "seed": args.seed,
+        "edge_seed": args.edge_seed,
+        "label_counts": manifest_summary["label_counts"],
+        "site_label_counts": manifest_summary["site_label_counts"],
+        "invariant_max": invariant_max,
+        "directed_offdiag_edges": edge_summary["directed_offdiag_edges"],
+        "selected_edges": edge_summary["selected_edges"],
+        "edges_per_relation": edge_summary["edges_per_relation"],
+        "selected_relation_counts": edge_summary["selected_relation_counts"],
+        "selected_source_counts": edge_summary["selected_source_counts"],
+        "selected_target_counts": edge_summary["selected_target_counts"],
+        "selected_edge_rows": len(selected_rows),
+        "target_relation": args.target_relation,
+        "target_edges_available": edge_summary["target_edges_available"],
+        "target_edges_selected": edge_summary["target_edges_selected"],
+        "target_edge_rows": len(target_rows),
+        "decision": (
+            "RELATION_FIXED_TARGET_ASSAY_READY_FOR_SINGLE_SLURM_TRUE_PLUS_NULL_SMOKE"
+            if args.target_relation
+            else "RELATION_COUNTERBALANCED_ASSAY_READY_FOR_SINGLE_SLURM_TRUE_PLUS_NULL_SMOKE"
+        ),
+        "next_gate": (
+            "Run one true-label hidden-only O-SSM job plus one matched pair-label null, "
+            "then replay diagnostics with --edge-plan and the pre-registered target relation "
+            "before expanding to five nulls."
+        ),
+    }
+    (out / "relation_counterbalanced_assay_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_markdown(out / "relation_counterbalanced_assay_summary.md", summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fano_relation_edge_plan.py
+++ b/scripts/research/neurodyn_fano_relation_edge_plan.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Build a relation-balanced directed Fano-line edge plan.
+
+The Fano-line transfer diagnostic has uneven directed-edge counts per shared
+position relation. This helper selects an equal number of off-diagonal
+source->target edges for every relation so follow-up diagnostics can test
+whether a relation-level effect survives edge-count balancing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import re
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+
+FANO_SITE_RE = re.compile(r"fano_line_(\d+)_(\d+)-(\d+)-(\d+)$")
+RELATION_RE = re.compile(r"^[0-2]->[0-2]$")
+
+
+def read_sites(manifest: Path) -> list[dict[str, Any]]:
+    rows = []
+    with manifest.open(newline="") as f:
+        reader = csv.reader((line for line in f if not line.startswith("#")), delimiter="\t")
+        header = next(reader)
+        idx = {name: i for i, name in enumerate(header)}
+        if "site" not in idx:
+            raise SystemExit(f"manifest missing site column: {manifest}")
+        seen: dict[str, dict[str, Any]] = {}
+        for row in reader:
+            site = row[idx["site"]]
+            if site in seen:
+                continue
+            m = FANO_SITE_RE.match(site)
+            if not m:
+                raise SystemExit(f"site is not a fano_line site: {site}")
+            seen[site] = {
+                "site": site,
+                "line_idx": int(m.group(1)),
+                "units": (int(m.group(2)), int(m.group(3)), int(m.group(4))),
+            }
+    rows = sorted(seen.values(), key=lambda r: int(r["line_idx"]))
+    if len(rows) != 7:
+        raise SystemExit(f"expected 7 Fano-line sites, got {len(rows)}")
+    return rows
+
+
+def relation(source_units: tuple[int, int, int], target_units: tuple[int, int, int]) -> tuple[str, int]:
+    shared = sorted(set(source_units) & set(target_units))
+    if len(shared) != 1:
+        return ("none", -1)
+    unit = shared[0]
+    return (f"{source_units.index(unit)}->{target_units.index(unit)}", unit)
+
+
+def build_edges(sites: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out = []
+    for source in sites:
+        for target in sites:
+            if source["site"] == target["site"]:
+                continue
+            rel, shared_unit = relation(source["units"], target["units"])
+            out.append(
+                {
+                    "source_line_idx": source["line_idx"],
+                    "source_site": source["site"],
+                    "target_line_idx": target["line_idx"],
+                    "target_site": target["site"],
+                    "shared_pos_pair": rel,
+                    "shared_unit": shared_unit,
+                    "selected": 0,
+                }
+            )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", type=Path, required=True)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--seed", type=int, default=2026070607)
+    ap.add_argument(
+        "--edges-per-relation",
+        type=int,
+        default=0,
+        help="0 means use the minimum available count across relations.",
+    )
+    ap.add_argument(
+        "--target-relation",
+        default="",
+        help="Optional pre-registered relation such as 2->0. Emits a selected target-only plan.",
+    )
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+    if args.target_relation and not RELATION_RE.match(args.target_relation):
+        raise SystemExit(f"--target-relation must look like 0->2, got {args.target_relation!r}")
+
+    if args.output_dir.exists() and any(args.output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    sites = read_sites(args.manifest)
+    edges = build_edges(sites)
+    by_relation: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for edge in edges:
+        if edge["shared_pos_pair"] == "none":
+            raise SystemExit("Fano edge without unique shared unit")
+        by_relation[str(edge["shared_pos_pair"])].append(edge)
+
+    available_counts = {rel: len(items) for rel, items in sorted(by_relation.items())}
+    if args.edges_per_relation > 0:
+        edges_per_relation = args.edges_per_relation
+    else:
+        edges_per_relation = min(available_counts.values())
+    too_small = {rel: n for rel, n in available_counts.items() if n < edges_per_relation}
+    if too_small:
+        raise SystemExit(f"not enough edges for requested balance: {too_small}")
+
+    rng = random.Random(args.seed)
+    selected_keys: set[tuple[str, str]] = set()
+    for rel, rel_edges in sorted(by_relation.items()):
+        candidates = list(rel_edges)
+        rng.shuffle(candidates)
+        for edge in sorted(candidates[:edges_per_relation], key=lambda r: (r["source_site"], r["target_site"])):
+            selected_keys.add((str(edge["source_site"]), str(edge["target_site"])))
+
+    for edge in edges:
+        key = (str(edge["source_site"]), str(edge["target_site"]))
+        edge["selected"] = 1 if key in selected_keys else 0
+
+    selected = [edge for edge in edges if int(edge["selected"]) == 1]
+    target_selected = []
+    if args.target_relation:
+        target_available = by_relation.get(args.target_relation, [])
+        if not target_available:
+            raise SystemExit(f"target relation is not available: {args.target_relation}")
+        target_selected = [edge for edge in selected if str(edge["shared_pos_pair"]) == args.target_relation]
+        if len(target_selected) != edges_per_relation:
+            raise SystemExit(
+                "target relation did not survive balanced selection: "
+                f"{args.target_relation} selected={len(target_selected)} expected={edges_per_relation}"
+            )
+    selected_counts: dict[str, int] = defaultdict(int)
+    for edge in selected:
+        selected_counts[str(edge["shared_pos_pair"])] += 1
+    source_counts: dict[str, int] = defaultdict(int)
+    target_counts: dict[str, int] = defaultdict(int)
+    for edge in selected:
+        source_counts[str(edge["source_site"])] += 1
+        target_counts[str(edge["target_site"])] += 1
+
+    write_tsv(args.output_dir / "fano_relation_balanced_edge_plan.tsv", edges)
+    write_tsv(args.output_dir / "fano_relation_balanced_edge_plan_selected.tsv", selected)
+    if args.target_relation:
+        write_tsv(args.output_dir / "fano_relation_fixed_target_edge_plan_selected.tsv", target_selected)
+    summary = {
+        "schema": "neurodyn.fano_relation_edge_plan.v1",
+        "manifest": str(args.manifest),
+        "seed": args.seed,
+        "site_count": len(sites),
+        "directed_offdiag_edges": len(edges),
+        "available_relation_counts": available_counts,
+        "edges_per_relation": edges_per_relation,
+        "selected_edges": len(selected),
+        "selected_relation_counts": dict(sorted(selected_counts.items())),
+        "selected_source_counts": dict(sorted(source_counts.items())),
+        "selected_target_counts": dict(sorted(target_counts.items())),
+        "selected_source_count_mean": mean(source_counts.values()) if source_counts else 0.0,
+        "selected_target_count_mean": mean(target_counts.values()) if target_counts else 0.0,
+        "target_relation": args.target_relation,
+        "target_edges_available": len(by_relation.get(args.target_relation, [])) if args.target_relation else 0,
+        "target_edges_selected": len(target_selected),
+        "target_selected_edge_plan": (
+            str(args.output_dir / "fano_relation_fixed_target_edge_plan_selected.tsv")
+            if args.target_relation
+            else ""
+        ),
+        "decision": (
+            "RELATION_FIXED_TARGET_EDGE_PLAN_READY"
+            if args.target_relation
+            else "RELATION_COUNTERBALANCED_EDGE_PLAN_READY"
+        ),
+        "claim_boundary": (
+            "Synthetic Fano relation counterbalance plan only; no clinical, "
+            "biomarker, mechanistic, solved-transfer, or superiority claim."
+        ),
+    }
+    (args.output_dir / "fano_relation_balanced_edge_plan_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fano_relation_peak_geometry_audit.py
+++ b/scripts/research/neurodyn_fano_relation_peak_geometry_audit.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Audit relation-peak geometry across Fano transfer diagnostics.
+
+This is deliberately a descriptive assay gate, not a significance test. It
+compares pre-registered true/null groups on the shape of the best directed
+relation: transfer, margin to the runner-up, hidden-state cosine/score, and
+strong/anti edge counts. If null runs look as peaky as true runs, the relation
+winner is treated as non-selective.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, pstdev
+from typing import Any
+
+
+SCHEMA = "neurodyn.fano_relation_peak_geometry_audit.v1"
+CLAIM_BOUNDARY = (
+    "Synthetic Fano relation geometry diagnostic only. No clinical, biomarker, "
+    "biological mechanism, solved-transfer, global classifier, fixed-relation "
+    "replication, or broad O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        help="GROUP:LABEL:PATH to fano_line_transfer_relation_summary.tsv",
+    )
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--model", default="O-SSM")
+    ap.add_argument("--target-relation", default="2->0")
+    ap.add_argument("--true-group", default="true")
+    ap.add_argument("--null-group", default="null")
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_input(spec: str) -> tuple[str, str, Path]:
+    parts = spec.split(":", 2)
+    if len(parts) != 3:
+        raise SystemExit(f"expected GROUP:LABEL:PATH input, got: {spec}")
+    group, label, raw_path = parts
+    if not group or not label or not raw_path:
+        raise SystemExit(f"group, label, and path must be non-empty: {spec}")
+    path = Path(raw_path)
+    if not path.exists():
+        raise SystemExit(f"input path does not exist: {path}")
+    return group, label, path
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def fnum(row: dict[str, str], key: str) -> float:
+    try:
+        return float(row[key])
+    except KeyError as exc:
+        raise SystemExit(f"missing column {key!r}") from exc
+
+
+def inum(row: dict[str, str], key: str) -> int:
+    return int(round(fnum(row, key)))
+
+
+def relation_summary(group: str, label: str, path: Path, model: str, target: str) -> dict[str, Any]:
+    rows = [row for row in read_rows(path) if row.get("model") == model]
+    if not rows:
+        raise SystemExit(f"no rows for model={model} in {path}")
+    rows.sort(key=lambda row: fnum(row, "transfer_accuracy_mean"), reverse=True)
+    top = rows[0]
+    second = rows[1] if len(rows) > 1 else rows[0]
+    target_rows = [row for row in rows if row.get("shared_pos_pair") == target]
+    if len(target_rows) != 1:
+        raise SystemExit(f"{label}: expected exactly one target row {target}, got {len(target_rows)}")
+    target_row = target_rows[0]
+    top_transfer = fnum(top, "transfer_accuracy_mean")
+    second_transfer = fnum(second, "transfer_accuracy_mean")
+    target_transfer = fnum(target_row, "transfer_accuracy_mean")
+    target_rank = next(
+        idx for idx, row in enumerate(rows, start=1) if row.get("shared_pos_pair") == target
+    )
+    return {
+        "group": group,
+        "label": label,
+        "model": model,
+        "path": str(path),
+        "target_relation": target,
+        "top_relation": top["shared_pos_pair"],
+        "top_transfer": top_transfer,
+        "second_relation": second["shared_pos_pair"],
+        "second_transfer": second_transfer,
+        "top_margin": top_transfer - second_transfer,
+        "top_cosine": fnum(top, "cosine_mean"),
+        "top_abs_cosine": abs(fnum(top, "cosine_mean")),
+        "top_score": fnum(top, "score_mean"),
+        "top_abs_score": abs(fnum(top, "score_mean")),
+        "top_strong_edge_count": inum(top, "strong_edge_count"),
+        "top_anti_transfer_edge_count": inum(top, "anti_transfer_edge_count"),
+        "top_edge_count": inum(top, "edge_count"),
+        "target_transfer": target_transfer,
+        "target_rank": target_rank,
+        "target_margin_to_top": target_transfer - top_transfer,
+        "target_cosine": fnum(target_row, "cosine_mean"),
+        "target_abs_cosine": abs(fnum(target_row, "cosine_mean")),
+        "target_score": fnum(target_row, "score_mean"),
+        "target_abs_score": abs(fnum(target_row, "score_mean")),
+        "target_strong_edge_count": inum(target_row, "strong_edge_count"),
+        "target_anti_transfer_edge_count": inum(target_row, "anti_transfer_edge_count"),
+        "target_edge_count": inum(target_row, "edge_count"),
+        "target_gate_pass": target_transfer > 50.0 and target_rank == 1,
+        "relation_count": len(rows),
+    }
+
+
+def summarize_group(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return {"run_count": 0}
+    fields = [
+        "top_transfer",
+        "top_margin",
+        "top_abs_cosine",
+        "top_abs_score",
+        "top_strong_edge_count",
+        "top_anti_transfer_edge_count",
+        "target_transfer",
+        "target_abs_cosine",
+        "target_abs_score",
+        "target_strong_edge_count",
+        "target_anti_transfer_edge_count",
+    ]
+    out: dict[str, Any] = {"run_count": len(rows)}
+    for field in fields:
+        vals = [float(row[field]) for row in rows]
+        out[f"mean_{field}"] = mean(vals)
+        out[f"std_{field}"] = pstdev(vals) if len(vals) > 1 else 0.0
+        out[f"max_{field}"] = max(vals)
+        out[f"min_{field}"] = min(vals)
+    out["target_gate_pass_count"] = sum(1 for row in rows if row["target_gate_pass"])
+    out["top_relation_counts"] = {
+        rel: sum(1 for row in rows if row["top_relation"] == rel)
+        for rel in sorted({row["top_relation"] for row in rows})
+    }
+    return out
+
+
+def group_summaries(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_group: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_group[str(row["group"])].append(row)
+    return {group: summarize_group(group_rows) for group, group_rows in sorted(by_group.items())}
+
+
+def selectivity_decision(payload: dict[str, Any], true_group: str, null_group: str) -> dict[str, Any]:
+    groups = payload["group_summary"]
+    true = groups.get(true_group, {})
+    null = groups.get(null_group, {})
+    if not true:
+        return {"decision": "PEAK_GEOMETRY_TRUE_GROUP_MISSING", "reason": f"missing group {true_group!r}"}
+    if not null:
+        return {"decision": "PEAK_GEOMETRY_NULL_GROUP_MISSING", "reason": f"missing group {null_group!r}"}
+
+    true_mean_margin = float(true["mean_top_margin"])
+    null_max_margin = float(null["max_top_margin"])
+    true_mean_abs_cos = float(true["mean_top_abs_cosine"])
+    null_max_abs_cos = float(null["max_top_abs_cosine"])
+    true_mean_transfer = float(true["mean_top_transfer"])
+    null_max_transfer = float(null["max_top_transfer"])
+    target_gate_pass = int(true.get("target_gate_pass_count", 0))
+    true_runs = int(true.get("run_count", 0))
+
+    if target_gate_pass < true_runs:
+        return {
+            "decision": "PEAK_GEOMETRY_NOT_PROMOTED_TARGET_GATE_FAILS",
+            "reason": "not all true runs preserve the pre-registered target relation",
+            "true_target_gate_pass_count": target_gate_pass,
+            "true_run_count": true_runs,
+        }
+    if true_mean_margin <= null_max_margin or true_mean_transfer <= null_max_transfer:
+        return {
+            "decision": "PEAK_GEOMETRY_NOT_SELECTIVE_VS_NULL",
+            "reason": "null peak transfer or margin reaches/exceeds true mean peak geometry",
+            "true_mean_top_transfer": true_mean_transfer,
+            "null_max_top_transfer": null_max_transfer,
+            "true_mean_top_margin": true_mean_margin,
+            "null_max_top_margin": null_max_margin,
+            "true_mean_top_abs_cosine": true_mean_abs_cos,
+            "null_max_top_abs_cosine": null_max_abs_cos,
+        }
+    return {
+        "decision": "PEAK_GEOMETRY_CANDIDATE_REQUIRES_LARGER_NULL",
+        "reason": "true peaks exceed current null envelope on transfer and margin, but this is descriptive only",
+        "true_mean_top_transfer": true_mean_transfer,
+        "null_max_top_transfer": null_max_transfer,
+        "true_mean_top_margin": true_mean_margin,
+        "null_max_top_margin": null_max_margin,
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Fano Relation Peak Geometry Audit",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        f"Model: `{payload['model']}`",
+        f"Target relation: `{payload['target_relation']}`",
+        f"Decision: `{payload['decision']['decision']}`",
+        "",
+        "## Runs",
+        "",
+        "| group | label | top | top transfer | margin | abs cosine | abs score | strong/anti | target transfer | target rank | target gate |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {group} | {label} | `{top_relation}` | {top_transfer:.6f} | {top_margin:.6f} | {top_abs_cosine:.6f} | {top_abs_score:.6f} | {top_strong_edge_count}/{top_anti_transfer_edge_count} | {target_transfer:.6f} | {target_rank} | {gate} |".format(
+                group=row["group"],
+                label=row["label"],
+                top_relation=row["top_relation"],
+                top_transfer=row["top_transfer"],
+                top_margin=row["top_margin"],
+                top_abs_cosine=row["top_abs_cosine"],
+                top_abs_score=row["top_abs_score"],
+                top_strong_edge_count=row["top_strong_edge_count"],
+                top_anti_transfer_edge_count=row["top_anti_transfer_edge_count"],
+                target_transfer=row["target_transfer"],
+                target_rank=row["target_rank"],
+                gate="PASS" if row["target_gate_pass"] else "FAIL",
+            )
+        )
+    lines.extend(["", "## Group Summary", ""])
+    lines.append(
+        "| group | runs | mean top transfer | max top transfer | mean margin | max margin | mean abs cosine | target gate pass | top relation counts |"
+    )
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |")
+    for group, item in payload["group_summary"].items():
+        counts = ", ".join(f"{rel}:{count}" for rel, count in item.get("top_relation_counts", {}).items())
+        lines.append(
+            "| {group} | {run_count} | {mean_top_transfer:.6f} | {max_top_transfer:.6f} | {mean_top_margin:.6f} | {max_top_margin:.6f} | {mean_top_abs_cosine:.6f} | {target_gate_pass_count}/{run_count} | {counts} |".format(
+                group=group,
+                run_count=item["run_count"],
+                mean_top_transfer=item["mean_top_transfer"],
+                max_top_transfer=item["max_top_transfer"],
+                mean_top_margin=item["mean_top_margin"],
+                max_top_margin=item["max_top_margin"],
+                mean_top_abs_cosine=item["mean_top_abs_cosine"],
+                target_gate_pass_count=item["target_gate_pass_count"],
+                counts=counts,
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            payload["decision"]["reason"],
+            "",
+            "A peak-geometry signal is not considered useful if pair-label nulls produce comparable or stronger peak transfer/margin, or if true runs fail the pre-registered target gate. This audit is descriptive and should not be used as clinical, mechanistic, or superiority evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir.resolve()
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        relation_summary(group, label, path, args.model, args.target_relation)
+        for group, label, path in map(parse_input, args.input)
+    ]
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "model": args.model,
+        "target_relation": args.target_relation,
+        "true_group": args.true_group,
+        "null_group": args.null_group,
+        "rows": rows,
+        "group_summary": group_summaries(rows),
+    }
+    payload["decision"] = selectivity_decision(payload, args.true_group, args.null_group)
+
+    (out / "fano_relation_peak_geometry_audit.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_tsv(out / "fano_relation_peak_geometry_rows.tsv", rows)
+    (out / "fano_relation_peak_geometry_audit.md").write_text(markdown(payload), encoding="utf-8")
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in out.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fano_relation_stability_summary.py
+++ b/scripts/research/neurodyn_fano_relation_stability_summary.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Summarize top-relation stability across Fano relation diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.fano_relation_stability_summary.v1"
+CLAIM_BOUNDARY = (
+    "Synthetic Fano relation diagnostic only. No clinical, biomarker, "
+    "biological mechanism, solved-transfer, fixed-relation replication, "
+    "global classifier, or broad O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        help="GROUP:LABEL:PATH to fano_line_transfer_relation_summary.tsv",
+    )
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--model", default="O-SSM")
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def parse_input(spec: str) -> tuple[str, str, Path]:
+    parts = spec.split(":", 2)
+    if len(parts) != 3:
+        raise SystemExit(f"expected GROUP:LABEL:PATH input, got: {spec}")
+    group, label, path = parts
+    if not group or not label:
+        raise SystemExit(f"group and label must be non-empty: {spec}")
+    return group, label, Path(path)
+
+
+def relation_row(group: str, label: str, path: Path, model: str) -> dict[str, Any]:
+    rows = [row for row in read_tsv(path) if row.get("model") == model]
+    if not rows:
+        raise SystemExit(f"no rows for model={model} in {path}")
+    rows.sort(key=lambda row: float(row["transfer_accuracy_mean"]), reverse=True)
+    top = rows[0]
+    second = rows[1] if len(rows) > 1 else rows[0]
+    top_transfer = float(top["transfer_accuracy_mean"])
+    second_transfer = float(second["transfer_accuracy_mean"])
+    top_margin = top_transfer - second_transfer
+    return {
+        "group": group,
+        "label": label,
+        "model": model,
+        "path": str(path),
+        "top_relation": top["shared_pos_pair"],
+        "top_transfer": top_transfer,
+        "second_relation": second["shared_pos_pair"],
+        "second_transfer": second_transfer,
+        "top_margin": top_margin,
+        "top_above_chance": top_transfer > 50.0,
+        "top_gate_pass": top_transfer > 50.0 and top_margin > 0.0,
+        "relation_count": len(rows),
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_group: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_group[row["group"]].append(row)
+    groups: dict[str, Any] = {}
+    for group, group_rows in sorted(by_group.items()):
+        relation_counts = Counter(str(row["top_relation"]) for row in group_rows)
+        gate_pass_rows = [row for row in group_rows if row["top_gate_pass"]]
+        groups[group] = {
+            "run_count": len(group_rows),
+            "top_relation_counts": dict(sorted(relation_counts.items())),
+            "top_gate_pass_count": len(gate_pass_rows),
+            "top_gate_pass_fraction": len(gate_pass_rows) / len(group_rows) if group_rows else 0.0,
+            "mean_top_transfer": sum(float(row["top_transfer"]) for row in group_rows) / len(group_rows),
+            "mean_top_margin": sum(float(row["top_margin"]) for row in group_rows) / len(group_rows),
+        }
+    return groups
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Fano Relation Stability Summary",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "| group | label | top relation | top transfer | second relation | second transfer | margin | gate |",
+        "| --- | --- | --- | ---: | --- | ---: | ---: | --- |",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {group} | {label} | `{top_relation}` | {top_transfer:.6f} | `{second_relation}` | {second_transfer:.6f} | {top_margin:.6f} | {gate} |".format(
+                group=row["group"],
+                label=row["label"],
+                top_relation=row["top_relation"],
+                top_transfer=row["top_transfer"],
+                second_relation=row["second_relation"],
+                second_transfer=row["second_transfer"],
+                top_margin=row["top_margin"],
+                gate="PASS" if row["top_gate_pass"] else "FAIL",
+            )
+        )
+    lines.extend(["", "## Group Summary", ""])
+    lines.extend(["| group | runs | top gate pass | mean top transfer | mean top margin | top relation counts |"])
+    lines.extend(["| --- | ---: | ---: | ---: | ---: | --- |"])
+    for group, item in payload["group_summary"].items():
+        counts = ", ".join(f"{rel}:{count}" for rel, count in item["top_relation_counts"].items())
+        lines.append(
+            "| {group} | {run_count} | {top_gate_pass_count}/{run_count} | {mean_top_transfer:.6f} | {mean_top_margin:.6f} | {counts} |".format(
+                group=group,
+                run_count=item["run_count"],
+                top_gate_pass_count=item["top_gate_pass_count"],
+                mean_top_transfer=item["mean_top_transfer"],
+                mean_top_margin=item["mean_top_margin"],
+                counts=counts,
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation Boundary",
+            "",
+            "This report is relation-agnostic: it asks which directed relation is top in each run. It does not show fixed-relation replication unless the same top relation recurs across independent true manifests under a predeclared rule.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = [relation_row(group, label, path, args.model) for group, label, path in map(parse_input, args.input)]
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "model": args.model,
+        "rows": rows,
+        "group_summary": summarize(rows),
+    }
+    (out / "fano_relation_stability_summary.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_tsv(out / "fano_relation_stability_rows.tsv", rows)
+    (out / "fano_relation_stability_summary.md").write_text(markdown(payload), encoding="utf-8")
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in out.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fano_relation_target_contrast.py
+++ b/scripts/research/neurodyn_fano_relation_target_contrast.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Summarize a target Fano relation against non-target relation drift.
+
+The Fano diagnostics emit one row per model/relation. This helper turns those
+rows into a compact target-vs-distractor table so a follow-up auxiliary can be
+designed around the relation that actually failed, rather than around generic
+clean/noisy invariance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+CLAIM_BOUNDARY = (
+    "Synthetic Fano relation diagnostic only; no clinical, biomarker, "
+    "biological mechanism, solved-transfer, or broad O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        metavar="LABEL:PATH",
+        help="Condition label plus relation summary TSV path.",
+    )
+    ap.add_argument("--target-relation", default="2->0")
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f, delimiter="\t"))
+
+
+def parse_input(spec: str) -> tuple[str, Path]:
+    if ":" not in spec:
+        raise SystemExit(f"--input must be LABEL:PATH, got {spec!r}")
+    label, raw_path = spec.split(":", 1)
+    label = label.strip()
+    if not label:
+        raise SystemExit(f"empty label in --input {spec!r}")
+    path = Path(raw_path)
+    if not path.exists():
+        raise SystemExit(f"missing input path for {label}: {path}")
+    return label, path
+
+
+def fnum(row: dict[str, str], key: str) -> float:
+    try:
+        return float(row[key])
+    except KeyError as exc:
+        raise SystemExit(f"missing column {key!r}") from exc
+
+
+def summarize_condition(label: str, path: Path, target: str) -> list[dict[str, Any]]:
+    rows = read_rows(path)
+    by_model: dict[str, list[dict[str, str]]] = {}
+    for row in rows:
+        model = row.get("model", "")
+        relation = row.get("shared_pos_pair", "")
+        if not model or not relation:
+            raise SystemExit(f"malformed row in {path}: {row}")
+        by_model.setdefault(model, []).append(row)
+
+    out: list[dict[str, Any]] = []
+    for model, model_rows in sorted(by_model.items()):
+        target_rows = [row for row in model_rows if row["shared_pos_pair"] == target]
+        if len(target_rows) != 1:
+            raise SystemExit(f"{label} {model}: expected one target {target}, got {len(target_rows)}")
+        target_row = target_rows[0]
+        target_transfer = fnum(target_row, "transfer_accuracy_mean")
+        sorted_rows = sorted(model_rows, key=lambda row: fnum(row, "transfer_accuracy_mean"), reverse=True)
+        target_rank = 1
+        for idx, row in enumerate(sorted_rows, start=1):
+            if row["shared_pos_pair"] == target:
+                target_rank = idx
+                break
+        non_target = [row for row in sorted_rows if row["shared_pos_pair"] != target]
+        best = non_target[0]
+        worst = sorted_rows[-1]
+        best_transfer = fnum(best, "transfer_accuracy_mean")
+        out.append(
+            {
+                "condition": label,
+                "input_path": str(path),
+                "model": model,
+                "target_relation": target,
+                "target_transfer": target_transfer,
+                "target_rank": target_rank,
+                "target_strong_edges": int(float(target_row.get("strong_edge_count", "0"))),
+                "target_anti_edges": int(float(target_row.get("anti_transfer_edge_count", "0"))),
+                "best_non_target_relation": best["shared_pos_pair"],
+                "best_non_target_transfer": best_transfer,
+                "target_minus_best_non_target": target_transfer - best_transfer,
+                "worst_relation": worst["shared_pos_pair"],
+                "worst_transfer": fnum(worst, "transfer_accuracy_mean"),
+                "relation_count": len(model_rows),
+            }
+        )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    cols = [
+        "condition",
+        "model",
+        "target_relation",
+        "target_transfer",
+        "target_rank",
+        "target_strong_edges",
+        "target_anti_edges",
+        "best_non_target_relation",
+        "best_non_target_transfer",
+        "target_minus_best_non_target",
+        "worst_relation",
+        "worst_transfer",
+        "relation_count",
+        "input_path",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=cols, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: row.get(col, "") for col in cols})
+
+
+def write_markdown(path: Path, rows: list[dict[str, Any]], target: str) -> None:
+    lines = [
+        "# NeuroDyn Fano Relation Target Contrast",
+        "",
+        f"Target relation: `{target}`",
+        "",
+        CLAIM_BOUNDARY,
+        "",
+        "| condition | model | target transfer | target rank | best non-target | best non-target transfer | margin |",
+        "| --- | --- | ---: | ---: | --- | ---: | ---: |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {condition} | {model} | {target_transfer:.6f} | {target_rank} | `{best_non_target_relation}` | {best_non_target_transfer:.6f} | {target_minus_best_non_target:.6f} |".format(
+                **row
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation Gate",
+            "",
+            "A target relation is not considered preserved unless its transfer is above chance, "
+            "its target rank is `1`, and its margin over the best non-target relation is positive. "
+            "Rows failing this gate indicate relation drift and should not trigger null expansion.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir.resolve()
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output exists: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, Any]] = []
+    inputs: list[dict[str, str]] = []
+    for spec in args.input:
+        label, path = parse_input(spec)
+        inputs.append({"label": label, "path": str(path)})
+        rows.extend(summarize_condition(label, path, args.target_relation))
+
+    summary = {
+        "schema": "neurodyn.fano_relation_target_contrast.v1",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "target_relation": args.target_relation,
+        "inputs": inputs,
+        "rows": rows,
+        "decision": "RELATION_TARGET_CONTRAST_READY",
+    }
+    (out / "fano_relation_target_contrast.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_tsv(out / "fano_relation_target_contrast.tsv", rows)
+    write_markdown(out / "fano_relation_target_contrast.md", rows, args.target_relation)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_fixedtarget_null_envelope.py
+++ b/scripts/research/neurodyn_fixedtarget_null_envelope.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Aggregate true-vs-null fixed-target associator smoke metrics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.fixedtarget_null_envelope.v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--true-run", required=True, type=Path)
+    parser.add_argument("--null-run", action="append", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def read_tsv_one(path: Path, predicate: dict[str, str] | None = None) -> dict[str, str]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    if predicate:
+        for row in rows:
+            if all(row.get(key) == value for key, value in predicate.items()):
+                return row
+        raise SystemExit(f"no row matching {predicate} in {path}")
+    if len(rows) != 1:
+        raise SystemExit(f"expected one row in {path}, got {len(rows)}")
+    return rows[0]
+
+
+def f(row: dict[str, str], key: str) -> float:
+    return float(row[key])
+
+
+def run_id(path: Path) -> str:
+    return path.name
+
+
+def load_run(path: Path, condition: str) -> dict[str, Any]:
+    overall = read_tsv_one(path / "results" / "overall_metrics.tsv", {"model": "O-SSM"})
+    hidden = read_tsv_one(
+        path / "hidden_state_separability" / "hidden_state_separability_summary.tsv",
+        {"model": "O-SSM"},
+    )
+    paired = read_tsv_one(
+        path / "paired_hidden_contrast" / "paired_hidden_contrast_summary.tsv",
+        {"model": "O-SSM"},
+    )
+    replay = read_tsv_one(
+        path / "trained_hidden_readout" / "trained_hidden_readout_probe_summary.tsv",
+        {"model": "O-SSM"},
+    )
+    return {
+        "condition": condition,
+        "run_id": run_id(path),
+        "path": str(path),
+        "o_balanced_accuracy_pct": f(overall, "balanced_accuracy_pct_mean"),
+        "o_auroc_pct": f(overall, "auroc_pct_mean"),
+        "o_brier": f(overall, "brier_mean"),
+        "o_ece_pct": f(overall, "ece_pct_mean"),
+        "o_hidden_centroid_ba_pct": f(hidden, "nearest_centroid_balanced_accuracy_mean"),
+        "o_hidden_centroid_margin": f(hidden, "centroid_margin_mean"),
+        "o_paired_hidden_direction_pct": f(paired, "leave_site_pair_direction_accuracy_mean"),
+        "o_hidden_pair_distance_mean": f(paired, "hidden_pair_distance_mean"),
+        "o_trained_hidden_readout_ba_pct": f(replay, "trained_hidden_readout_balanced_accuracy_mean"),
+    }
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def metric_envelope(true_value: float, null_values: list[float]) -> dict[str, Any]:
+    return {
+        "true": true_value,
+        "null_count": len(null_values),
+        "null_mean": statistics.fmean(null_values) if null_values else 0.0,
+        "null_std": statistics.pstdev(null_values) if len(null_values) > 1 else 0.0,
+        "null_min": min(null_values) if null_values else 0.0,
+        "null_max": max(null_values) if null_values else 0.0,
+        "null_ge_true_count": sum(1 for value in null_values if value >= true_value),
+        "empirical_p_ge_true_plus_one": (1 + sum(1 for value in null_values if value >= true_value)) / (len(null_values) + 1),
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def markdown(summary: dict[str, Any]) -> str:
+    metric_names = {
+        "o_balanced_accuracy_pct": "O-SSM BA",
+        "o_auroc_pct": "O-SSM AUROC",
+        "o_hidden_centroid_ba_pct": "O hidden centroid BA",
+        "o_paired_hidden_direction_pct": "O paired hidden direction",
+    }
+    lines = [
+        "# Fixed-Target Null Envelope",
+        "",
+        "Claim boundary: synthetic non-clinical null-envelope diagnostic only. No clinical, biomarker, biological mechanism, solved-associator, scaled-transfer, or broad O-SSM superiority claim.",
+        "",
+        f"- True run: `{summary['true_run']}`",
+        f"- Null runs: `{summary['null_count']}`",
+        "",
+        "## Envelope",
+        "",
+        "| metric | true | null max | null mean | null >= true | plus-one p |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for key, label in metric_names.items():
+        env = summary["metrics"][key]
+        lines.append(
+            f"| {label} | {env['true']:.6f} | {env['null_max']:.6f} | {env['null_mean']:.6f} | "
+            f"{env['null_ge_true_count']}/{env['null_count']} | {env['empirical_p_ge_true_plus_one']:.6f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            f"`{summary['decision']}`",
+            "",
+            summary["interpretation"],
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    true_row = load_run(args.true_run, "true")
+    null_rows = [load_run(path, "null") for path in args.null_run]
+    all_rows = [true_row, *null_rows]
+    metric_keys = [
+        "o_balanced_accuracy_pct",
+        "o_auroc_pct",
+        "o_hidden_centroid_ba_pct",
+        "o_paired_hidden_direction_pct",
+    ]
+    metrics = {
+        key: metric_envelope(true_row[key], [row[key] for row in null_rows])
+        for key in metric_keys
+    }
+    ba_ok = metrics["o_balanced_accuracy_pct"]["null_ge_true_count"] == 0
+    auroc_ok = metrics["o_auroc_pct"]["null_ge_true_count"] == 0
+    centroid_ok = metrics["o_hidden_centroid_ba_pct"]["null_ge_true_count"] == 0
+    paired_ok = metrics["o_paired_hidden_direction_pct"]["null_ge_true_count"] == 0
+    if ba_ok and auroc_ok and centroid_ok and paired_ok:
+        decision = "FIXEDTARGET_MAIN_READOUT_NULL_ENVELOPE_PASSES_MICRO_GATE"
+        interpretation = (
+            "The true fixed-target micro-run exceeds the five-null envelope on global and hidden-state metrics. "
+            "This supports only a bounded synthetic micro-assay result and still requires larger controlled variants."
+        )
+    elif ba_ok and (centroid_ok or paired_ok):
+        decision = "FIXEDTARGET_MAIN_READOUT_GLOBAL_PARTIAL_HIDDEN_NOT_NULL_SAFE"
+        interpretation = (
+            "The true run exceeds the null envelope on balanced accuracy and at least one hidden-state probe, "
+            "but one or more nulls match or exceed another hidden/ranking metric. Do not promote; the next step is assay/objective repair or more stringent hidden target alignment."
+        )
+    else:
+        decision = "FIXEDTARGET_MAIN_READOUT_NOT_NULL_SAFE"
+        interpretation = (
+            "At least one pair-label null matches or exceeds the true run on the required global or hidden-state gates. "
+            "The micro-positive result is not null-safe and must not be promoted."
+        )
+
+    summary: dict[str, Any] = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic non-clinical null-envelope diagnostic only.",
+        "true_run": str(args.true_run),
+        "null_runs": [str(path) for path in args.null_run],
+        "null_count": len(null_rows),
+        "metrics": metrics,
+        "decision": decision,
+        "interpretation": interpretation,
+    }
+    write_tsv(out / "fixedtarget_null_envelope_runs.tsv", all_rows)
+    write_tsv(
+        out / "fixedtarget_null_envelope_metrics.tsv",
+        [
+            {"metric": key, **value}
+            for key, value in metrics.items()
+        ],
+    )
+    (out / "fixedtarget_null_envelope.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "fixedtarget_null_envelope.md").write_text(markdown(summary), encoding="utf-8")
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(out.iterdir()):
+            if path.is_file() and path.name != "SHA256SUMS":
+                handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_frozen_hidden_linear_readout.py
+++ b/scripts/research/neurodyn_frozen_hidden_linear_readout.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Train a small linear readout on frozen Brain O-SSM STATE_TRACE hidden states.
+
+This probe answers whether hidden states contain linearly recoverable signal
+when the integrated model readout fails. It trains only on traced hidden states
+within each seed and leave-site split; it does not retrain the recurrent model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+
+
+SCHEMA = "neurodyn.frozen_hidden_linear_readout.v1"
+CLAIM_BOUNDARY = (
+    "Frozen hidden-state linear readout diagnostic only. This is not a clinical, "
+    "mechanistic, biomarker, solved-associator, or O-SSM superiority claim."
+)
+
+
+def sigmoid(x: float) -> float:
+    if x >= 0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    z = math.exp(x)
+    return z / (1.0 + z)
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def balanced_accuracy(labels: list[int], preds: list[int]) -> float:
+    pos = [i for i, label in enumerate(labels) if label == 1]
+    neg = [i for i, label in enumerate(labels) if label == 0]
+    if not pos or not neg:
+        return 0.0
+    tpr = sum(1 for i in pos if preds[i] == 1) / len(pos)
+    tnr = sum(1 for i in neg if preds[i] == 0) / len(neg)
+    return 100.0 * (tpr + tnr) / 2.0
+
+
+def auroc(labels: list[int], scores: list[float]) -> float:
+    pos = [score for label, score in zip(labels, scores, strict=True) if label == 1]
+    neg = [score for label, score in zip(labels, scores, strict=True) if label == 0]
+    if not pos or not neg:
+        return 50.0
+    wins = 0.0
+    total = 0
+    for ps in pos:
+        for ns in neg:
+            if ps > ns:
+                wins += 1.0
+            elif ps == ns:
+                wins += 0.5
+            total += 1
+    return 100.0 * wins / total
+
+
+def zscore(train_x: list[list[float]], values: list[list[float]]) -> tuple[list[list[float]], list[float], list[float]]:
+    dim = len(train_x[0])
+    means = [sum(row[d] for row in train_x) / len(train_x) for d in range(dim)]
+    stds: list[float] = []
+    for d, m in enumerate(means):
+        var = sum((row[d] - m) ** 2 for row in train_x) / len(train_x)
+        stds.append(math.sqrt(var) if var > 1.0e-12 else 1.0)
+    return [[(row[d] - means[d]) / stds[d] for d in range(dim)] for row in values], means, stds
+
+
+def train_logistic(
+    x: list[list[float]],
+    y: list[int],
+    *,
+    l2: float,
+    epochs: int,
+    lr: float,
+) -> tuple[list[float], float]:
+    dim = len(x[0])
+    w = [0.0] * dim
+    pos_frac = max(1.0e-6, min(1.0 - 1.0e-6, sum(y) / len(y)))
+    b = math.log(pos_frac / (1.0 - pos_frac))
+    n = len(x)
+    for _ in range(epochs):
+        gw = [0.0] * dim
+        gb = 0.0
+        for row, label in zip(x, y, strict=True):
+            p = sigmoid(b + sum(wi * xi for wi, xi in zip(w, row, strict=True)))
+            err = p - label
+            gb += err
+            for d, xi in enumerate(row):
+                gw[d] += err * xi
+        for d in range(dim):
+            grad = gw[d] / n + l2 * w[d]
+            w[d] -= lr * grad
+        b -= lr * (gb / n)
+    return w, b
+
+
+def predict(w: list[float], b: float, x: list[list[float]]) -> tuple[list[int], list[float]]:
+    scores = [b + sum(wi * xi for wi, xi in zip(w, row, strict=True)) for row in x]
+    return [1 if score >= 0.0 else 0 for score in scores], scores
+
+
+def fit_select_lambda(train_rows: list[dict[str, Any]], l2_values: list[float], epochs: int, lr: float) -> tuple[float, list[float], float]:
+    sites = sorted({row["site"] for row in train_rows})
+    best_l2 = l2_values[0]
+    best_ba = -1.0
+    for l2 in l2_values:
+        labels_all: list[int] = []
+        preds_all: list[int] = []
+        for site in sites:
+            inner_train = [row for row in train_rows if row["site"] != site]
+            inner_val = [row for row in train_rows if row["site"] == site]
+            if not inner_train or not inner_val:
+                continue
+            x_train_raw = [row["h"] for row in inner_train]
+            x_val_raw = [row["h"] for row in inner_val]
+            x_train, _, _ = zscore(x_train_raw, x_train_raw)
+            x_val, _, _ = zscore(x_train_raw, x_val_raw)
+            y_train = [int(row["label"]) for row in inner_train]
+            w, b = train_logistic(x_train, y_train, l2=l2, epochs=epochs, lr=lr)
+            preds, _ = predict(w, b, x_val)
+            labels_all.extend(int(row["label"]) for row in inner_val)
+            preds_all.extend(preds)
+        ba = balanced_accuracy(labels_all, preds_all)
+        if ba > best_ba:
+            best_ba = ba
+            best_l2 = l2
+    x_train_raw = [row["h"] for row in train_rows]
+    x_train, _, _ = zscore(x_train_raw, x_train_raw)
+    y_train = [int(row["label"]) for row in train_rows]
+    w, b = train_logistic(x_train, y_train, l2=best_l2, epochs=epochs, lr=lr)
+    return best_l2, w, b
+
+
+def run_probe(rows: list[dict[str, Any]], l2_values: list[float], epochs: int, lr: float, fixed_l2: float | None) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    groups: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["model"], int(row["seed"]))].append(row)
+
+    for (model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        for holdout_site in sites:
+            train_rows = [row for row in chunk if row["site"] != holdout_site]
+            test_rows = [row for row in chunk if row["site"] == holdout_site]
+            if not train_rows or not test_rows:
+                continue
+            if fixed_l2 is None:
+                selected_l2, w, b = fit_select_lambda(train_rows, l2_values, epochs, lr)
+            else:
+                selected_l2 = fixed_l2
+            x_train_raw = [row["h"] for row in train_rows]
+            x_test_raw = [row["h"] for row in test_rows]
+            x_train, _, _ = zscore(x_train_raw, x_train_raw)
+            # Refit on fold train after selection, then apply train statistics to holdout.
+            y_train = [int(row["label"]) for row in train_rows]
+            w, b = train_logistic(x_train, y_train, l2=selected_l2, epochs=epochs, lr=lr)
+            x_test, _, _ = zscore(x_train_raw, x_test_raw)
+            labels = [int(row["label"]) for row in test_rows]
+            preds, scores = predict(w, b, x_test)
+            detail.append(
+                {
+                    "model": model,
+                    "seed": seed,
+                    "holdout_site": holdout_site,
+                    "rows": len(test_rows),
+                    "selected_l2": selected_l2,
+                    "balanced_accuracy": balanced_accuracy(labels, preds),
+                    "auroc": auroc(labels, scores),
+                    "score_mean": mean(scores),
+                    "score_std": pstdev(scores),
+                    "positive_pred_frac": mean([1.0 if pred == 1 else 0.0 for pred in preds]),
+                    "weight_norm": math.sqrt(sum(value * value for value in w)),
+                }
+            )
+
+    summary: list[dict[str, Any]] = []
+    by_model: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in detail:
+        by_model[str(row["model"])].append(row)
+    for model, model_rows in sorted(by_model.items()):
+        bas = [float(row["balanced_accuracy"]) for row in model_rows]
+        aucs = [float(row["auroc"]) for row in model_rows]
+        summary.append(
+            {
+                "model": model,
+                "fold_count": len(model_rows),
+                "balanced_accuracy_mean": mean(bas),
+                "balanced_accuracy_std": pstdev(bas),
+                "auroc_mean": mean(aucs),
+                "auroc_std": pstdev(aucs),
+                "weight_norm_mean": mean([float(row["weight_norm"]) for row in model_rows]),
+            }
+        )
+    return detail, summary
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--raw-output", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--l2", default="0.0,0.001,0.01,0.1,1.0")
+    ap.add_argument("--epochs", type=int, default=800)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--models", default="", help="Optional comma-separated model filter, e.g. O-SSM")
+    ap.add_argument("--fixed-l2", type=float, default=None, help="Skip inner model selection and use this L2 value")
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    if args.output_dir.exists() and any(args.output_dir.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    l2_values = [float(value) for value in args.l2.split(",") if value.strip()]
+
+    rows = parse_state_rows(args.raw_output)
+    if args.models.strip():
+        keep = {value.strip() for value in args.models.split(",") if value.strip()}
+        rows = [row for row in rows if row["model"] in keep]
+        if not rows:
+            raise SystemExit(f"no STATE_TRACE rows left after --models={args.models!r}")
+    detail, summary = run_probe(rows, l2_values, args.epochs, args.lr, args.fixed_l2)
+    if not detail:
+        raise SystemExit("no probe rows generated")
+
+    write_tsv(args.output_dir / "frozen_hidden_linear_readout_detail.tsv", detail)
+    write_tsv(args.output_dir / "frozen_hidden_linear_readout_summary.tsv", summary)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "raw_output": str(args.raw_output),
+        "l2_values": l2_values,
+        "fixed_l2": args.fixed_l2,
+        "epochs": args.epochs,
+        "lr": args.lr,
+        "state_trace_rows": len(rows),
+        "summary": summary,
+    }
+    (args.output_dir / "frozen_hidden_linear_readout.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = [
+        "# Frozen Hidden Linear Readout",
+        "",
+        CLAIM_BOUNDARY,
+        "",
+        f"- Raw output: `{args.raw_output}`",
+        f"- STATE_TRACE rows: `{len(rows)}`",
+        f"- L2 grid: `{','.join(str(v) for v in l2_values)}`",
+        f"- Epochs: `{args.epochs}`",
+        f"- LR: `{args.lr}`",
+        "",
+        "| Model | folds | BA mean | BA std | AUROC mean | AUROC std | weight norm mean |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in summary:
+        md.append(
+            "| {model} | {fold_count} | {ba:.6f} | {ba_std:.6f} | {auc:.6f} | {auc_std:.6f} | {wn:.6f} |".format(
+                model=row["model"],
+                fold_count=row["fold_count"],
+                ba=float(row["balanced_accuracy_mean"]),
+                ba_std=float(row["balanced_accuracy_std"]),
+                auc=float(row["auroc_mean"]),
+                auc_std=float(row["auroc_std"]),
+                wn=float(row["weight_norm_mean"]),
+            )
+        )
+    (args.output_dir / "frozen_hidden_linear_readout.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+    sha_rows = []
+    for path in sorted(args.output_dir.iterdir()):
+        if path.name == "SHA256SUMS":
+            continue
+        sha_rows.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
+    (args.output_dir / "SHA256SUMS").write_text("\n".join(sha_rows) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_hidden_state_separability.py
+++ b/scripts/research/neurodyn_hidden_state_separability.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Analyze Brain O-SSM STATE_TRACE hidden-state separability."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.hidden_state_separability.v1"
+CLAIM_BOUNDARY = (
+    "Hidden-state separability diagnostic only. This is not a clinical, "
+    "mechanistic, biomarker, or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-output", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def parse_state_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.startswith("STATE_TRACE"):
+            idx += 1
+            continue
+        line_no = idx + 1
+        parts = [part for part in line.split("\t") if part]
+        next_idx = idx + 1
+        while len(parts) < 22 and next_idx < len(lines) and lines[next_idx].startswith("\t"):
+            parts.extend(part for part in lines[next_idx].split("\t") if part)
+            next_idx += 1
+        if len(parts) != 22:
+            raise SystemExit(f"malformed STATE_TRACE at line {line_no}: expected 22 fields, got {len(parts)}")
+        _, model, seed, subject_index, site, label, *raw_values = parts
+        rows.append(
+            {
+                "model": model,
+                "seed": int(seed),
+                "subject_index": int(subject_index),
+                "site": site,
+                "label": int(label),
+                "h": [int(value) / 1_000_000.0 for value in raw_values],
+            }
+        )
+        idx = next_idx
+    if not rows:
+        raise SystemExit("no STATE_TRACE rows found; run with trace_hidden_state=1")
+    return rows
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def pstdev(values: list[float]) -> float:
+    return statistics.pstdev(values) if len(values) > 1 else 0.0
+
+
+def centroid(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    return [sum(vec[idx] for vec in vectors) / len(vectors) for idx in range(dim)]
+
+
+def dist2(a: list[float], b: list[float]) -> float:
+    return sum((x - y) * (x - y) for x, y in zip(a, b, strict=True))
+
+
+def balanced_accuracy(labels: list[int], preds: list[int]) -> float:
+    pos = [idx for idx, label in enumerate(labels) if label == 1]
+    neg = [idx for idx, label in enumerate(labels) if label == 0]
+    if not pos or not neg:
+        return 0.0
+    tpr = sum(1 for idx in pos if preds[idx] == 1) / len(pos)
+    tnr = sum(1 for idx in neg if preds[idx] == 0) / len(neg)
+    return 100.0 * (tpr + tnr) / 2.0
+
+
+def norm(vec: list[float]) -> float:
+    return math.sqrt(sum(value * value for value in vec))
+
+
+def summarize(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    groups: dict[tuple[str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["model"], row["seed"])].append(row)
+
+    for (model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        labels_all: list[int] = []
+        preds_all: list[int] = []
+        for site in sites:
+            train = [row for row in chunk if row["site"] != site]
+            test = [row for row in chunk if row["site"] == site]
+            pos_centroid = centroid([row["h"] for row in train if row["label"] == 1])
+            neg_centroid = centroid([row["h"] for row in train if row["label"] == 0])
+            if not pos_centroid or not neg_centroid:
+                continue
+            for row in test:
+                pred = 1 if dist2(row["h"], pos_centroid) <= dist2(row["h"], neg_centroid) else 0
+                labels_all.append(int(row["label"]))
+                preds_all.append(pred)
+        pos_centroid_all = centroid([row["h"] for row in chunk if row["label"] == 1])
+        neg_centroid_all = centroid([row["h"] for row in chunk if row["label"] == 0])
+        margin = norm([a - b for a, b in zip(pos_centroid_all, neg_centroid_all, strict=True)])
+        within: list[float] = []
+        for row in chunk:
+            center = pos_centroid_all if row["label"] == 1 else neg_centroid_all
+            within.append(math.sqrt(dist2(row["h"], center)))
+        detail.append(
+            {
+                "model": model,
+                "seed": seed,
+                "site_count": len(sites),
+                "rows": len(chunk),
+                "nearest_centroid_balanced_accuracy": balanced_accuracy(labels_all, preds_all),
+                "centroid_margin": margin,
+                "within_class_radius_mean": mean(within),
+                "margin_radius_ratio": margin / mean(within) if mean(within) > 1e-12 else 0.0,
+            }
+        )
+
+    summary_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in detail:
+        summary_groups[row["model"]].append(row)
+
+    summary: list[dict[str, Any]] = []
+    for model, chunk in sorted(summary_groups.items()):
+        ba = [float(row["nearest_centroid_balanced_accuracy"]) for row in chunk]
+        margin = [float(row["centroid_margin"]) for row in chunk]
+        ratio = [float(row["margin_radius_ratio"]) for row in chunk]
+        summary.append(
+            {
+                "model": model,
+                "seed_count": len(chunk),
+                "nearest_centroid_balanced_accuracy_mean": mean(ba),
+                "nearest_centroid_balanced_accuracy_std": pstdev(ba),
+                "centroid_margin_mean": mean(margin),
+                "margin_radius_ratio_mean": mean(ratio),
+            }
+        )
+    return summary, detail
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_hashes(output_dir: Path) -> None:
+    with (output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n")
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Hidden-State Separability Diagnostic",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "| model | seeds | nearest-centroid BA mean | BA std | centroid margin mean | margin/radius mean |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {model} | {seed_count} | {ba:.6f} | {ba_std:.6f} | {margin:.6f} | {ratio:.6f} |".format(
+                model=row["model"],
+                seed_count=row["seed_count"],
+                ba=row["nearest_centroid_balanced_accuracy_mean"],
+                ba_std=row["nearest_centroid_balanced_accuracy_std"],
+                margin=row["centroid_margin_mean"],
+                ratio=row["margin_radius_ratio_mean"],
+            )
+        )
+    lines.extend(["", "## Interpretation", "", payload["interpretation"], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rows = parse_state_rows(Path(args.raw_output))
+    summary, detail = summarize(rows)
+    interpretation = (
+        "Nearest-centroid balanced accuracy on traced final hidden states asks whether "
+        "the state representation itself contains class/order information before the "
+        "trained classifier readout. Chance-level values imply the current recurrent "
+        "state/update path is not separating this assay; above-chance values with a "
+        "chance classifier would point to readout/training failure instead."
+    )
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "raw_output": str(Path(args.raw_output).resolve()),
+        "state_trace_rows": len(rows),
+        "summary": summary,
+        "detail": detail,
+        "interpretation": interpretation,
+    }
+    write_json(output_dir / "hidden_state_separability.json", payload)
+    write_tsv(output_dir / "hidden_state_separability_summary.tsv", summary)
+    write_tsv(output_dir / "hidden_state_separability_detail.tsv", detail)
+    (output_dir / "hidden_state_separability.md").write_text(markdown(payload), encoding="utf-8")
+    write_hashes(output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_noncommutative_temporal_manifest.py
+++ b/scripts/research/neurodyn_noncommutative_temporal_manifest.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Build a synthetic noncommutative temporal-composition manifest.
+
+The assay is deliberately non-clinical. It creates paired sequences from
+oriented octonion/Fano triples. Each pair has the same endpoints, same mean,
+same energy, and same unordered vector multiset; only the internal temporal
+order differs. It is meant to test whether the Brain O-SSM path can use
+order/composition after direct delta/flat readouts are disabled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import json
+import math
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "brain_ossm.neurodyn_noncommutative_temporal_prepare.v1"
+CLAIM_BOUNDARY = (
+    "Synthetic non-clinical temporal-composition diagnostic only. No clinical, "
+    "biomarker, mechanistic, or O-SSM superiority claim."
+)
+
+# Oriented Fano lines for the common octonion convention over e1..e7.
+FANO_LINES = (
+    (1, 2, 3),
+    (1, 4, 5),
+    (1, 7, 6),
+    (2, 4, 6),
+    (2, 5, 7),
+    (3, 4, 7),
+    (3, 6, 5),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--pairs", type=int, default=280)
+    parser.add_argument("--sites", type=int, default=7)
+    parser.add_argument("--seq-len", type=int, default=32)
+    parser.add_argument("--noise-std", type=float, default=0.015)
+    parser.add_argument("--magnitude", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=20260705)
+    parser.add_argument(
+        "--line-mode",
+        choices=("fano_cycle", "fixed_pair"),
+        default="fano_cycle",
+        help="Use all oriented Fano lines, or a single fixed e1/e2/e3 sanity pair.",
+    )
+    parser.add_argument(
+        "--anchor",
+        choices=("zero", "unit_real"),
+        default="zero",
+        help="Common first/last vector. unit_real avoids zero-step state erasure in Brain O-SSM.",
+    )
+    parser.add_argument(
+        "--site-mode",
+        choices=("round_robin", "fano_line"),
+        default="round_robin",
+        help=(
+            "Pseudo-site assignment. round_robin preserves the original mixed-line "
+            "holdouts; fano_line makes leave-one-site-out CV a leave-one-Fano-line-out "
+            "transfer assay."
+        ),
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def basis(index: int, sign: float = 1.0) -> list[float]:
+    if index < 0 or index > 7:
+        raise ValueError(index)
+    out = [0.0] * 8
+    out[index] = sign
+    return out
+
+
+def zero() -> list[float]:
+    return [0.0] * 8
+
+
+def neg(vec: list[float]) -> list[float]:
+    return [-value for value in vec]
+
+
+def add_noise(vec: list[float], rng: random.Random, noise_std: float) -> list[float]:
+    if noise_std <= 0.0:
+        return list(vec)
+    return [value + rng.gauss(0.0, noise_std) for value in vec]
+
+
+def vector_key(vec: list[float]) -> tuple[int, ...]:
+    return tuple(int(round(value * 1000000.0)) for value in vec)
+
+
+def make_core(line: tuple[int, int, int], positive: bool, variant: int, anchor: str, magnitude: float) -> list[list[float]]:
+    a, b, c = line
+    va = basis(a, magnitude)
+    vb = basis(b, magnitude)
+    vc = basis(c, magnitude)
+    if anchor == "zero":
+        endpoint = zero()
+    elif anchor == "unit_real":
+        endpoint = basis(0)
+    else:
+        raise ValueError(anchor)
+    # Positive uses the oriented Fano order. Negative swaps the first two
+    # elements. Both retain the same signed multiset after the balancing tail.
+    if positive:
+        first = [va, vb, vc]
+    else:
+        first = [vb, va, vc]
+    if variant % 2 == 0:
+        tail = [neg(first[0]), neg(first[1]), neg(first[2])]
+    else:
+        tail = [neg(first[2]), neg(first[1]), neg(first[0])]
+    return [endpoint, *first, *tail, endpoint]
+
+
+def stretch_to_seq(core: list[list[float]], seq_len: int, rng: random.Random, noise_std: float) -> list[list[float]]:
+    if seq_len < len(core):
+        raise ValueError(f"seq_len={seq_len} < core_len={len(core)}")
+    out: list[list[float]] = []
+    for idx in range(seq_len):
+        source = (idx * len(core)) // seq_len
+        out.append(add_noise(core[source], rng, noise_std))
+    return out
+
+
+def flatten(seq: list[list[float]]) -> list[float]:
+    return [value for row in seq for value in row]
+
+
+def stats(seq: list[list[float]]) -> dict[str, Any]:
+    dim = len(seq[0])
+    mean = [sum(row[d] for row in seq) / len(seq) for d in range(dim)]
+    delta = [seq[-1][d] - seq[0][d] for d in range(dim)]
+    energy = sum(value * value for row in seq for value in row)
+    return {
+        "mean": mean,
+        "delta": delta,
+        "energy": energy,
+        "start": seq[0],
+        "end": seq[-1],
+        "multiset": Counter(vector_key(row) for row in seq),
+    }
+
+
+def max_abs(values: list[float]) -> float:
+    return max((abs(value) for value in values), default=0.0)
+
+
+def paired_invariant_rows(pairs: list[tuple[dict[str, Any], dict[str, Any]]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for pos, neg_record in pairs:
+        pos_stats = stats(pos["sequence_noiseless"])
+        neg_stats = stats(neg_record["sequence_noiseless"])
+        rows.append(
+            {
+                "pair_id": pos["pair_id"],
+                "line": pos["line"],
+                "variant": pos["variant"],
+                "mean_max_abs_diff": max_abs([a - b for a, b in zip(pos_stats["mean"], neg_stats["mean"], strict=True)]),
+                "delta_max_abs_diff": max_abs([a - b for a, b in zip(pos_stats["delta"], neg_stats["delta"], strict=True)]),
+                "start_max_abs_diff": max_abs([a - b for a, b in zip(pos_stats["start"], neg_stats["start"], strict=True)]),
+                "end_max_abs_diff": max_abs([a - b for a, b in zip(pos_stats["end"], neg_stats["end"], strict=True)]),
+                "energy_abs_diff": abs(pos_stats["energy"] - neg_stats["energy"]),
+                "same_unordered_multiset": int(pos_stats["multiset"] == neg_stats["multiset"]),
+            }
+        )
+    return rows
+
+
+def write_tsv(path: Path, records: list[dict[str, Any]], seq_len: int) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(
+            "# schema=brain_ossm.neurodyn.synthetic.v1\n"
+            "# dataset_id=synthetic_noncommutative_temporal\n"
+            f"# seq_len={seq_len}\n"
+            "# input_dim=8\n"
+            "# feature_layout=flat\n"
+            "# label_space=fano_oriented_order_vs_swapped_order\n"
+            "# label_positive_name=FANO_ORIENTED_ORDER\n"
+            "# label_negative_name=SWAPPED_ORDER\n"
+            "# split_policy=pseudo_site_holdout_pair_balanced\n"
+            "# feature_recipe=paired_fano_triple_same_mean_delta_energy_multiset\n"
+            "# task=noncommutative_temporal_composition\n"
+            f"# subject_count={len(records)}\n"
+            f"# site_count={len({record['site'] for record in records})}\n"
+            f"# claim_boundary={CLAIM_BOUNDARY}\n"
+        )
+        header = ["subject_id", "label", "site"] + [f"f{i}" for i in range(seq_len * 8)]
+        handle.write("\t".join(header) + "\n")
+        for record in records:
+            fields = [record["subject_id"], str(record["label"]), record["site"]]
+            fields.extend(f"{value:.10f}" for value in flatten(record["sequence"]))
+            handle.write("\t".join(fields) + "\n")
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if args.pairs < args.sites:
+        raise SystemExit("--pairs must be >= --sites")
+    if args.sites < 2:
+        raise SystemExit("--sites must be >= 2")
+
+    rng = random.Random(args.seed)
+    records: list[dict[str, Any]] = []
+    pair_records: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for pair_id in range(args.pairs):
+        if args.line_mode == "fixed_pair":
+            line = FANO_LINES[0]
+            variant = pair_id
+            line_idx = 0
+        else:
+            line_idx = pair_id % len(FANO_LINES)
+            line = FANO_LINES[line_idx]
+            variant = pair_id // len(FANO_LINES)
+        if args.site_mode == "fano_line":
+            if args.line_mode != "fano_cycle":
+                raise SystemExit("--site-mode=fano_line requires --line-mode=fano_cycle")
+            if args.sites != len(FANO_LINES):
+                raise SystemExit(f"--site-mode=fano_line requires --sites={len(FANO_LINES)}")
+            site = f"fano_line_{line_idx:02d}_{'-'.join(str(item) for item in line)}"
+        else:
+            site = f"pseudo_site_{pair_id % args.sites:02d}"
+        pair_seed = rng.randrange(1 << 30)
+        pos_rng = random.Random(pair_seed)
+        neg_rng = random.Random(pair_seed)
+        pos_core = make_core(line, True, variant, args.anchor, args.magnitude)
+        neg_core = make_core(line, False, variant, args.anchor, args.magnitude)
+        pos_record = {
+            "subject_id": f"synthetic_pair_{pair_id:04d}__oriented",
+            "pair_id": pair_id,
+            "label": 1,
+            "site": site,
+            "line": "-".join(str(item) for item in line),
+            "variant": variant,
+            "sequence_noiseless": stretch_to_seq(pos_core, args.seq_len, random.Random(0), 0.0),
+            "sequence": stretch_to_seq(pos_core, args.seq_len, pos_rng, args.noise_std),
+        }
+        neg_record = {
+            "subject_id": f"synthetic_pair_{pair_id:04d}__swapped",
+            "pair_id": pair_id,
+            "label": 0,
+            "site": site,
+            "line": "-".join(str(item) for item in line),
+            "variant": variant,
+            "sequence_noiseless": stretch_to_seq(neg_core, args.seq_len, random.Random(0), 0.0),
+            "sequence": stretch_to_seq(neg_core, args.seq_len, neg_rng, args.noise_std),
+        }
+        records.extend([pos_record, neg_record])
+        pair_records.append((pos_record, neg_record))
+
+    manifest = output_dir / "noncommutative_temporal_manifest.tsv"
+    write_tsv(manifest, records, args.seq_len)
+    invariant_rows = paired_invariant_rows(pair_records)
+    write_csv(output_dir / "paired_invariant_audit.csv", invariant_rows)
+    by_site: dict[str, Counter[int]] = defaultdict(Counter)
+    for record in records:
+        by_site[record["site"]][int(record["label"])] += 1
+    summary = {
+        "schema": SCHEMA,
+        "created_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "manifest": str(manifest),
+        "pairs": args.pairs,
+        "records": len(records),
+        "sites": args.sites,
+        "seq_len": args.seq_len,
+        "input_dim": 8,
+        "noise_std": args.noise_std,
+        "magnitude": args.magnitude,
+        "seed": args.seed,
+        "line_mode": args.line_mode,
+        "site_mode": args.site_mode,
+        "anchor": args.anchor,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "fano_lines": FANO_LINES,
+        "label_counts": {
+            "0": sum(1 for record in records if record["label"] == 0),
+            "1": sum(1 for record in records if record["label"] == 1),
+        },
+        "site_label_counts": {
+            site: {"0": counts[0], "1": counts[1]} for site, counts in sorted(by_site.items())
+        },
+        "invariant_max": {
+            "mean_max_abs_diff": max(row["mean_max_abs_diff"] for row in invariant_rows),
+            "delta_max_abs_diff": max(row["delta_max_abs_diff"] for row in invariant_rows),
+            "start_max_abs_diff": max(row["start_max_abs_diff"] for row in invariant_rows),
+            "end_max_abs_diff": max(row["end_max_abs_diff"] for row in invariant_rows),
+            "energy_abs_diff": max(row["energy_abs_diff"] for row in invariant_rows),
+            "same_unordered_multiset_min": min(row["same_unordered_multiset"] for row in invariant_rows),
+        },
+    }
+    write_json(output_dir / "noncommutative_temporal_prepare_summary.json", summary)
+    with (output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(f"manifest={manifest}")
+    print(f"records={len(records)}")
+    print(f"output_dir={output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_octonionic_associator_data_audit.py
+++ b/scripts/research/neurodyn_octonionic_associator_data_audit.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Audit whether the octonionic associator manifest itself carries the target.
+
+This is intentionally model-free, but not a substitute for model evidence. It
+answers a narrower question: before training O-SSM, do the raw and normalized
+input trajectories expose the intended associator sign under leave-site splits?
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.octonionic_associator_data_audit.v1"
+
+
+def oct_mul(a: list[float], b: list[float]) -> list[float]:
+    a0, a1, a2, a3, a4, a5, a6, a7 = a
+    b0, b1, b2, b3, b4, b5, b6, b7 = b
+    return [
+        a0 * b0 - a1 * b1 - a2 * b2 - a3 * b3 - a4 * b4 - a5 * b5 - a6 * b6 - a7 * b7,
+        a0 * b1 + a1 * b0 + a2 * b3 - a3 * b2 + a4 * b5 - a5 * b4 - a6 * b7 + a7 * b6,
+        a0 * b2 + a2 * b0 - a1 * b3 + a3 * b1 + a4 * b6 - a6 * b4 + a5 * b7 - a7 * b5,
+        a0 * b3 + a3 * b0 + a1 * b2 - a2 * b1 + a4 * b7 - a7 * b4 - a5 * b6 + a6 * b5,
+        a0 * b4 + a4 * b0 - a1 * b5 + a5 * b1 - a2 * b6 + a6 * b2 - a3 * b7 + a7 * b3,
+        a0 * b5 + a5 * b0 + a1 * b4 - a4 * b1 - a2 * b7 + a7 * b2 + a3 * b6 - a6 * b3,
+        a0 * b6 + a6 * b0 + a1 * b7 - a7 * b1 + a2 * b4 - a4 * b2 - a3 * b5 + a5 * b3,
+        a0 * b7 + a7 * b0 - a1 * b6 + a6 * b1 - a2 * b5 + a5 * b2 + a3 * b4 - a4 * b3,
+    ]
+
+
+def associator(a: list[float], b: list[float], c: list[float]) -> list[float]:
+    left = oct_mul(oct_mul(a, b), c)
+    right = oct_mul(a, oct_mul(b, c))
+    return [left[i] - right[i] for i in range(8)]
+
+
+def trajectory_assoc_signal(flat: list[float], normalize_len: bool = True) -> list[float]:
+    seq_len = len(flat) // 8
+    signal = [0.0] * 8
+    for step in range(seq_len - 2):
+        av = associator(
+            flat[step * 8 : (step + 1) * 8],
+            flat[(step + 1) * 8 : (step + 2) * 8],
+            flat[(step + 2) * 8 : (step + 3) * 8],
+        )
+        for i, value in enumerate(av):
+            signal[i] += value
+    if normalize_len and seq_len:
+        signal = [value / seq_len for value in signal]
+    return signal
+
+
+def block_mean(flat: list[float], block_idx: int, block_count: int = 8) -> list[float]:
+    seq_len = len(flat) // 8
+    start = (block_idx * seq_len) // block_count
+    end = ((block_idx + 1) * seq_len) // block_count
+    if end <= start:
+        end = start + 1
+    out = [0.0] * 8
+    for step in range(start, end):
+        for i, value in enumerate(flat[step * 8 : (step + 1) * 8]):
+            out[i] += value
+    return [value / (end - start) for value in out]
+
+
+def core_block_assoc_signal(flat: list[float]) -> list[float]:
+    """Associator over the stretched manifest core blocks 1, 2, and 3."""
+    return associator(block_mean(flat, 1), block_mean(flat, 2), block_mean(flat, 3))
+
+
+def read_manifest(path: Path) -> list[dict[str, Any]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader((line for line in handle if not line.startswith("#")), delimiter="\t")
+        rows: list[dict[str, Any]] = []
+        for row in reader:
+            features = [float(row[f"f{i}"]) for i in range(256)]
+            rows.append(
+                {
+                    "subject_id": row["subject_id"],
+                    "pair_id": row["subject_id"].split("__", 1)[0],
+                    "label": int(row["label"]),
+                    "sign": 1 if int(row["label"]) == 1 else -1,
+                    "site": row["site"],
+                    "features": features,
+                }
+            )
+    return rows
+
+
+def mean_vector(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    out = [0.0] * len(vectors[0])
+    for vec in vectors:
+        for i, value in enumerate(vec):
+            out[i] += value
+    return [value / len(vectors) for value in out]
+
+
+def dist2(a: list[float], b: list[float]) -> float:
+    return sum((x - y) * (x - y) for x, y in zip(a, b))
+
+
+def balanced_accuracy(y_true: list[int], y_pred: list[int]) -> float:
+    tp = sum(1 for y, p in zip(y_true, y_pred) if y == 1 and p == 1)
+    tn = sum(1 for y, p in zip(y_true, y_pred) if y == 0 and p == 0)
+    fp = sum(1 for y, p in zip(y_true, y_pred) if y == 0 and p == 1)
+    fn = sum(1 for y, p in zip(y_true, y_pred) if y == 1 and p == 0)
+    sens = tp / (tp + fn) if tp + fn else 0.0
+    spec = tn / (tn + fp) if tn + fp else 0.0
+    return 50.0 * (sens + spec)
+
+
+def zscore_by_train(train: list[list[float]], values: list[list[float]]) -> list[list[float]]:
+    means = mean_vector(train)
+    stds: list[float] = []
+    for i, mean in enumerate(means):
+        var = sum((row[i] - mean) ** 2 for row in train) / max(1, len(train))
+        stds.append(math.sqrt(var) if var > 1.0e-12 else 1.0)
+    return [[(row[i] - means[i]) / stds[i] for i in range(len(row))] for row in values]
+
+
+def leave_site_nearest_centroid(rows: list[dict[str, Any]], feature_key: str) -> dict[str, Any]:
+    sites = sorted({row["site"] for row in rows})
+    detail = []
+    all_y: list[int] = []
+    all_pred: list[int] = []
+    for site in sites:
+        train = [row for row in rows if row["site"] != site]
+        test = [row for row in rows if row["site"] == site]
+        pos = mean_vector([row[feature_key] for row in train if row["label"] == 1])
+        neg = mean_vector([row[feature_key] for row in train if row["label"] == 0])
+        y_true = [row["label"] for row in test]
+        y_pred = [1 if dist2(row[feature_key], pos) <= dist2(row[feature_key], neg) else 0 for row in test]
+        all_y.extend(y_true)
+        all_pred.extend(y_pred)
+        detail.append({"site": site, "n": len(test), "balanced_accuracy": balanced_accuracy(y_true, y_pred)})
+    return {"balanced_accuracy": balanced_accuracy(all_y, all_pred), "detail": detail}
+
+
+def leave_site_normalized_assoc(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    sites = sorted({row["site"] for row in rows})
+    audit_rows: list[dict[str, Any]] = []
+    detail = []
+    all_y: list[int] = []
+    all_pred: list[int] = []
+    for site in sites:
+        train = [row for row in rows if row["site"] != site]
+        test = [row for row in rows if row["site"] == site]
+        train_norm = zscore_by_train([row["features"] for row in train], [row["features"] for row in train])
+        test_norm = zscore_by_train([row["features"] for row in train], [row["features"] for row in test])
+        train_features = [trajectory_assoc_signal(vec) for vec in train_norm]
+        test_features = [trajectory_assoc_signal(vec) for vec in test_norm]
+        train_aug = [dict(row, norm_assoc=vec) for row, vec in zip(train, train_features)]
+        test_aug = [dict(row, norm_assoc=vec) for row, vec in zip(test, test_features)]
+        pos = mean_vector([row["norm_assoc"] for row in train_aug if row["label"] == 1])
+        neg = mean_vector([row["norm_assoc"] for row in train_aug if row["label"] == 0])
+        y_true = [row["label"] for row in test_aug]
+        y_pred = [1 if dist2(row["norm_assoc"], pos) <= dist2(row["norm_assoc"], neg) else 0 for row in test_aug]
+        all_y.extend(y_true)
+        all_pred.extend(y_pred)
+        detail.append({"site": site, "n": len(test), "balanced_accuracy": balanced_accuracy(y_true, y_pred)})
+        audit_rows.extend(test_aug)
+    signed_norms = []
+    for row in audit_rows:
+        vec = row["norm_assoc"]
+        dominant = max(range(8), key=lambda i: abs(vec[i]))
+        signed_norms.append(row["sign"] * vec[dominant])
+    return {
+        "balanced_accuracy": balanced_accuracy(all_y, all_pred),
+        "detail": detail,
+        "signed_dominant_mean": sum(signed_norms) / len(signed_norms) if signed_norms else 0.0,
+        "signed_dominant_min": min(signed_norms) if signed_norms else 0.0,
+    }
+
+
+def leave_site_normalized_core_assoc(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    sites = sorted({row["site"] for row in rows})
+    detail = []
+    all_y: list[int] = []
+    all_pred: list[int] = []
+    signed_norms = []
+    for site in sites:
+        train = [row for row in rows if row["site"] != site]
+        test = [row for row in rows if row["site"] == site]
+        train_norm = zscore_by_train([row["features"] for row in train], [row["features"] for row in train])
+        test_norm = zscore_by_train([row["features"] for row in train], [row["features"] for row in test])
+        train_features = [core_block_assoc_signal(vec) for vec in train_norm]
+        test_features = [core_block_assoc_signal(vec) for vec in test_norm]
+        train_aug = [dict(row, norm_core_assoc=vec) for row, vec in zip(train, train_features)]
+        test_aug = [dict(row, norm_core_assoc=vec) for row, vec in zip(test, test_features)]
+        pos = mean_vector([row["norm_core_assoc"] for row in train_aug if row["label"] == 1])
+        neg = mean_vector([row["norm_core_assoc"] for row in train_aug if row["label"] == 0])
+        y_true = [row["label"] for row in test_aug]
+        y_pred = [1 if dist2(row["norm_core_assoc"], pos) <= dist2(row["norm_core_assoc"], neg) else 0 for row in test_aug]
+        all_y.extend(y_true)
+        all_pred.extend(y_pred)
+        detail.append({"site": site, "n": len(test), "balanced_accuracy": balanced_accuracy(y_true, y_pred)})
+        for row in test_aug:
+            vec = row["norm_core_assoc"]
+            dominant = max(range(8), key=lambda i: abs(vec[i]))
+            signed_norms.append(row["sign"] * vec[dominant])
+    return {
+        "balanced_accuracy": balanced_accuracy(all_y, all_pred),
+        "detail": detail,
+        "signed_dominant_mean": sum(signed_norms) / len(signed_norms) if signed_norms else 0.0,
+        "signed_dominant_min": min(signed_norms) if signed_norms else 0.0,
+    }
+
+
+def pair_audit(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    by_pair: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_pair[row["pair_id"]].append(row)
+    residuals = []
+    core_residuals = []
+    raw_distances = []
+    assoc_distances = []
+    core_assoc_distances = []
+    bad_pairs = []
+    for pair_id, pair_rows in by_pair.items():
+        if len(pair_rows) != 2 or {row["label"] for row in pair_rows} != {0, 1}:
+            bad_pairs.append(pair_id)
+            continue
+        pos = next(row for row in pair_rows if row["label"] == 1)
+        neg = next(row for row in pair_rows if row["label"] == 0)
+        residuals.append(max(abs(pos["raw_assoc"][i] + neg["raw_assoc"][i]) for i in range(8)))
+        if "raw_core_assoc" in pos:
+            core_residuals.append(max(abs(pos["raw_core_assoc"][i] + neg["raw_core_assoc"][i]) for i in range(8)))
+            core_assoc_distances.append(math.sqrt(dist2(pos["raw_core_assoc"], neg["raw_core_assoc"])))
+        raw_distances.append(math.sqrt(dist2(pos["features"], neg["features"])))
+        assoc_distances.append(math.sqrt(dist2(pos["raw_assoc"], neg["raw_assoc"])))
+    return {
+        "pair_count": len(by_pair),
+        "bad_pair_count": len(bad_pairs),
+        "assoc_sign_flip_residual_max": max(residuals) if residuals else None,
+        "core_assoc_sign_flip_residual_max": max(core_residuals) if core_residuals else None,
+        "raw_pair_distance_mean": sum(raw_distances) / len(raw_distances) if raw_distances else None,
+        "assoc_pair_distance_mean": sum(assoc_distances) / len(assoc_distances) if assoc_distances else None,
+        "core_assoc_pair_distance_mean": sum(core_assoc_distances) / len(core_assoc_distances) if core_assoc_distances else None,
+    }
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    out = args.output_dir
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output dir exists and is non-empty: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = read_manifest(args.manifest)
+    for row in rows:
+        row["raw_assoc"] = trajectory_assoc_signal(row["features"])
+        row["raw_core_assoc"] = core_block_assoc_signal(row["features"])
+        row["raw_assoc_norm"] = math.sqrt(sum(value * value for value in row["raw_assoc"]))
+        row["raw_core_assoc_norm"] = math.sqrt(sum(value * value for value in row["raw_core_assoc"]))
+        row["raw_assoc_dominant_dim"] = max(range(8), key=lambda i: abs(row["raw_assoc"][i]))
+        row["raw_core_assoc_dominant_dim"] = max(range(8), key=lambda i: abs(row["raw_core_assoc"][i]))
+        row["raw_assoc_signed_dominant"] = row["sign"] * row["raw_assoc"][row["raw_assoc_dominant_dim"]]
+        row["raw_core_assoc_signed_dominant"] = row["sign"] * row["raw_core_assoc"][row["raw_core_assoc_dominant_dim"]]
+
+    raw_flat = leave_site_nearest_centroid(rows, "features")
+    raw_assoc = leave_site_nearest_centroid(rows, "raw_assoc")
+    raw_core_assoc = leave_site_nearest_centroid(rows, "raw_core_assoc")
+    norm_assoc = leave_site_normalized_assoc(rows)
+    norm_core_assoc = leave_site_normalized_core_assoc(rows)
+    pairs = pair_audit(rows)
+
+    signed = [row["raw_assoc_signed_dominant"] for row in rows]
+    core_signed = [row["raw_core_assoc_signed_dominant"] for row in rows]
+    site_counts = defaultdict(lambda: {"n": 0, "label_0": 0, "label_1": 0})
+    for row in rows:
+        site_counts[row["site"]]["n"] += 1
+        site_counts[row["site"]][f"label_{row['label']}"] += 1
+
+    summary = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic manifest/input audit only. This is not model, clinical, biomarker, or mechanistic evidence.",
+        "manifest": str(args.manifest),
+        "row_count": len(rows),
+        "site_count": len(site_counts),
+        "pair_audit": pairs,
+        "site_counts": dict(sorted(site_counts.items())),
+        "raw_assoc_signed_dominant_mean": sum(signed) / len(signed) if signed else 0.0,
+        "raw_assoc_signed_dominant_min": min(signed) if signed else 0.0,
+        "raw_core_assoc_signed_dominant_mean": sum(core_signed) / len(core_signed) if core_signed else 0.0,
+        "raw_core_assoc_signed_dominant_min": min(core_signed) if core_signed else 0.0,
+        "leave_site_raw_flat_nearest_centroid": raw_flat,
+        "leave_site_raw_assoc_nearest_centroid": raw_assoc,
+        "leave_site_raw_core_assoc_nearest_centroid": raw_core_assoc,
+        "leave_site_train_zscored_assoc_nearest_centroid": norm_assoc,
+        "leave_site_train_zscored_core_assoc_nearest_centroid": norm_core_assoc,
+    }
+
+    detail = [
+        {
+            "subject_id": row["subject_id"],
+            "pair_id": row["pair_id"],
+            "site": row["site"],
+            "label": row["label"],
+            "raw_assoc_norm": row["raw_assoc_norm"],
+            "raw_core_assoc_norm": row["raw_core_assoc_norm"],
+            "raw_assoc_dominant_dim": row["raw_assoc_dominant_dim"],
+            "raw_core_assoc_dominant_dim": row["raw_core_assoc_dominant_dim"],
+            "raw_assoc_signed_dominant": row["raw_assoc_signed_dominant"],
+            "raw_core_assoc_signed_dominant": row["raw_core_assoc_signed_dominant"],
+            **{f"raw_assoc_{i}": row["raw_assoc"][i] for i in range(8)},
+            **{f"raw_core_assoc_{i}": row["raw_core_assoc"][i] for i in range(8)},
+        }
+        for row in rows
+    ]
+    write_tsv(out / "associator_data_audit_detail.tsv", detail)
+    write_tsv(
+        out / "associator_data_audit_summary.tsv",
+        [
+            {
+                "row_count": summary["row_count"],
+                "site_count": summary["site_count"],
+                "pair_count": pairs["pair_count"],
+                "bad_pair_count": pairs["bad_pair_count"],
+                "assoc_sign_flip_residual_max": pairs["assoc_sign_flip_residual_max"],
+                "core_assoc_sign_flip_residual_max": pairs["core_assoc_sign_flip_residual_max"],
+                "raw_flat_leave_site_ba": raw_flat["balanced_accuracy"],
+                "raw_assoc_leave_site_ba": raw_assoc["balanced_accuracy"],
+                "raw_core_assoc_leave_site_ba": raw_core_assoc["balanced_accuracy"],
+                "train_zscored_assoc_leave_site_ba": norm_assoc["balanced_accuracy"],
+                "train_zscored_core_assoc_leave_site_ba": norm_core_assoc["balanced_accuracy"],
+                "raw_assoc_signed_dominant_mean": summary["raw_assoc_signed_dominant_mean"],
+                "raw_core_assoc_signed_dominant_mean": summary["raw_core_assoc_signed_dominant_mean"],
+                "train_zscored_assoc_signed_dominant_mean": norm_assoc["signed_dominant_mean"],
+                "train_zscored_core_assoc_signed_dominant_mean": norm_core_assoc["signed_dominant_mean"],
+            }
+        ],
+    )
+    md = [
+        "# Octonionic Associator Data Audit",
+        "",
+        summary["claim_boundary"],
+        "",
+        f"- Rows: `{summary['row_count']}`",
+        f"- Sites: `{summary['site_count']}`",
+        f"- Pairs: `{pairs['pair_count']}`",
+        f"- Bad pairs: `{pairs['bad_pair_count']}`",
+        f"- Raw associator sign-flip residual max: `{pairs['assoc_sign_flip_residual_max']}`",
+        f"- Raw core-block associator sign-flip residual max: `{pairs['core_assoc_sign_flip_residual_max']}`",
+        f"- Raw flat leave-site nearest-centroid BA: `{raw_flat['balanced_accuracy']:.6f}`",
+        f"- Raw associator leave-site nearest-centroid BA: `{raw_assoc['balanced_accuracy']:.6f}`",
+        f"- Raw core-block associator leave-site nearest-centroid BA: `{raw_core_assoc['balanced_accuracy']:.6f}`",
+        f"- Train-zscored associator leave-site nearest-centroid BA: `{norm_assoc['balanced_accuracy']:.6f}`",
+        f"- Train-zscored core-block associator leave-site nearest-centroid BA: `{norm_core_assoc['balanced_accuracy']:.6f}`",
+        f"- Raw signed dominant associator mean: `{summary['raw_assoc_signed_dominant_mean']:.6f}`",
+        f"- Raw signed dominant core-block associator mean: `{summary['raw_core_assoc_signed_dominant_mean']:.6f}`",
+        f"- Train-zscored signed dominant associator mean: `{norm_assoc['signed_dominant_mean']:.6f}`",
+        f"- Train-zscored signed dominant core-block associator mean: `{norm_core_assoc['signed_dominant_mean']:.6f}`",
+        "",
+        "## Interpretation",
+        "",
+        "If raw associator separability is high but train-zscored associator separability collapses, the manifest is not necessarily wrong, but the current preprocessing/model input is erasing or distorting the constructed nonassociative target. If both raw and normalized associator separability are high while O-SSM remains near chance, the problem is more likely in the training/readout path.",
+    ]
+    (out / "associator_data_audit.md").write_text("\n".join(md) + "\n", encoding="utf-8")
+    (out / "associator_data_audit.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    sha_rows = []
+    for path in sorted(out.iterdir()):
+        if path.name == "SHA256SUMS":
+            continue
+        sha_rows.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sha_rows) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_octonionic_associator_manifest.py
+++ b/scripts/research/neurodyn_octonionic_associator_manifest.py
@@ -1,0 +1,812 @@
+#!/usr/bin/env python3
+"""Build a synthetic octonionic associator trajectory manifest.
+
+This generator avoids the quaternionic/Fano-line trap: triples that lie on one
+Fano line are associative, so they are weak tests of an octonionic state-space
+model. Here every pair uses an imaginary-unit triple with nonzero associator.
+The paired labels keep the same endpoints, mean, energy, and unordered vector
+multiset; only the temporal order flips the associator sign.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import json
+import math
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.octonionic_associator_manifest.v1"
+UNIT_TOL = 1.0e-9
+CONTINUOUS_TOL = 1.0e-7
+CLAIM_BOUNDARY = (
+    "Synthetic non-clinical octonionic associator trajectory assay only. "
+    "No clinical, biomarker, biological mechanism, solved-transfer, global "
+    "classifier, or broad O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--pairs", type=int, default=56)
+    ap.add_argument("--sites", type=int, default=7)
+    ap.add_argument("--seq-len", type=int, default=32)
+    ap.add_argument("--magnitude", type=float, default=3.0)
+    ap.add_argument("--noise-std", type=float, default=0.0)
+    ap.add_argument("--seed", type=int, default=2026071010)
+    ap.add_argument("--anchor", choices=("zero", "unit_real"), default="unit_real")
+    ap.add_argument("--site-mode", choices=("assoc_dim", "round_robin"), default="assoc_dim")
+    ap.add_argument("--triple-selection", choices=("ordered", "seeded_shuffle"), default="ordered")
+    ap.add_argument(
+        "--triple-source",
+        choices=("unit", "continuous", "scaled_unit"),
+        default="unit",
+        help="Use unit triples, scaled unit triples, or continuous imaginary vectors around fixed-target unit triples.",
+    )
+    ap.add_argument(
+        "--scale-jitter",
+        type=float,
+        default=0.12,
+        help="Uniform relative scale jitter for --triple-source=scaled_unit.",
+    )
+    ap.add_argument(
+        "--continuous-jitter",
+        type=float,
+        default=0.18,
+        help="Gaussian jitter scale for --triple-source=continuous before renormalizing each imaginary vector.",
+    )
+    ap.add_argument(
+        "--continuous-max-attempts",
+        type=int,
+        default=200000,
+        help="Maximum rejection-sampling attempts for continuous fixed-target triples.",
+    )
+    ap.add_argument(
+        "--target-assoc-dim",
+        type=int,
+        default=-1,
+        help="Restrict pairs to a fixed dominant associator component 0..7; -1 keeps all components.",
+    )
+    ap.add_argument(
+        "--target-assoc-sign",
+        type=int,
+        choices=(-1, 0, 1),
+        default=0,
+        help="Dominant associator sign for the positive-order member when --target-assoc-dim is set; 0 keeps both signs.",
+    )
+    ap.add_argument(
+        "--exclude-assoc-dims",
+        default="",
+        help="Comma-separated associator components to exclude before pair selection, e.g. 0.",
+    )
+    ap.add_argument(
+        "--assoc-sign-filter",
+        type=int,
+        choices=(-1, 0, 1),
+        default=0,
+        help="Keep only triples whose positive-order dominant associator sign is -1 or 1; 0 keeps both signs.",
+    )
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def basis(index: int, value: float = 1.0) -> list[float]:
+    out = [0.0] * 8
+    out[index] = value
+    return out
+
+
+def neg(vec: list[float]) -> list[float]:
+    return [-value for value in vec]
+
+
+def add_vec(a: list[float], b: list[float]) -> list[float]:
+    return [x + y for x, y in zip(a, b, strict=True)]
+
+
+def sub_vec(a: list[float], b: list[float]) -> list[float]:
+    return [x - y for x, y in zip(a, b, strict=True)]
+
+
+def scale_vec(vec: list[float], scale: float) -> list[float]:
+    return [scale * value for value in vec]
+
+
+def oct_mul(a: list[float], b: list[float]) -> list[float]:
+    a0, a1, a2, a3, a4, a5, a6, a7 = a
+    b0, b1, b2, b3, b4, b5, b6, b7 = b
+    return [
+        a0 * b0 - a1 * b1 - a2 * b2 - a3 * b3 - a4 * b4 - a5 * b5 - a6 * b6 - a7 * b7,
+        a0 * b1 + a1 * b0 + a2 * b3 - a3 * b2 + a4 * b5 - a5 * b4 - a6 * b7 + a7 * b6,
+        a0 * b2 + a2 * b0 - a1 * b3 + a3 * b1 + a4 * b6 - a6 * b4 + a5 * b7 - a7 * b5,
+        a0 * b3 + a3 * b0 + a1 * b2 - a2 * b1 + a4 * b7 - a7 * b4 - a5 * b6 + a6 * b5,
+        a0 * b4 + a4 * b0 - a1 * b5 + a5 * b1 - a2 * b6 + a6 * b2 - a3 * b7 + a7 * b3,
+        a0 * b5 + a5 * b0 + a1 * b4 - a4 * b1 - a2 * b7 + a7 * b2 + a3 * b6 - a6 * b3,
+        a0 * b6 + a6 * b0 + a1 * b7 - a7 * b1 + a2 * b4 - a4 * b2 - a3 * b5 + a5 * b3,
+        a0 * b7 + a7 * b0 - a1 * b6 + a6 * b1 + a2 * b5 - a5 * b2 + a3 * b4 - a4 * b3,
+    ]
+
+
+def associator(a: list[float], b: list[float], c: list[float]) -> list[float]:
+    left = oct_mul(oct_mul(a, b), c)
+    right = oct_mul(a, oct_mul(b, c))
+    return [x - y for x, y in zip(left, right, strict=True)]
+
+
+def norm(vec: list[float]) -> float:
+    return math.sqrt(sum(value * value for value in vec))
+
+
+def dominant_component(vec: list[float]) -> tuple[int, float]:
+    idx, value = max(enumerate(vec), key=lambda item: abs(item[1]))
+    return idx, value
+
+
+def nonassociative_triples(magnitude: float) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for a in range(1, 8):
+        for b in range(1, 8):
+            for c in range(1, 8):
+                if len({a, b, c}) != 3:
+                    continue
+                av = associator(basis(a, magnitude), basis(b, magnitude), basis(c, magnitude))
+                assoc_norm = norm(av)
+                if assoc_norm <= 1.0e-9:
+                    continue
+                swapped = associator(basis(b, magnitude), basis(a, magnitude), basis(c, magnitude))
+                dim, value = dominant_component(av)
+                swapped_dim, swapped_value = dominant_component(swapped)
+                if dim != swapped_dim or abs(value + swapped_value) > 1.0e-9:
+                    continue
+                rows.append(
+                    {
+                        "triple": (a, b, c),
+                        "assoc_vector": av,
+                        "assoc_norm": assoc_norm,
+                        "assoc_dim": dim,
+                        "assoc_sign": 1 if value > 0.0 else -1,
+                        "assoc_value": value,
+                    }
+                )
+    rows.sort(key=lambda row: (row["assoc_dim"], -row["assoc_sign"], row["triple"]))
+    return rows
+
+
+def imaginary_norm(vec: list[float]) -> float:
+    return math.sqrt(sum(value * value for value in vec[1:]))
+
+
+def normalize_imaginary(vec: list[float], magnitude: float) -> list[float]:
+    out = list(vec)
+    out[0] = 0.0
+    n = imaginary_norm(out)
+    if n <= 1.0e-12:
+        raise ValueError("cannot normalize zero imaginary vector")
+    scale = magnitude / n
+    return [0.0, *[value * scale for value in out[1:]]]
+
+
+def jitter_basis(index: int, magnitude: float, rng: random.Random, jitter: float) -> list[float]:
+    vec = basis(index, magnitude)
+    if jitter <= 0.0:
+        return vec
+    for dim in range(1, 8):
+        vec[dim] += rng.gauss(0.0, jitter * magnitude)
+    return normalize_imaginary(vec, magnitude)
+
+
+def continuous_triples(
+    base_triples: list[dict[str, Any]],
+    pairs: int,
+    magnitude: float,
+    rng: random.Random,
+    target_assoc_dim: int,
+    target_assoc_sign: int,
+    jitter: float,
+    max_attempts: int,
+) -> list[dict[str, Any]]:
+    if target_assoc_dim < 0 or target_assoc_dim > 7:
+        raise SystemExit("--triple-source=continuous currently requires --target-assoc-dim 0..7")
+    if not base_triples:
+        raise SystemExit("--triple-source=continuous has no fixed-target base triples after filtering")
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[int, ...]] = set()
+    attempts = 0
+    while len(rows) < pairs and attempts < max_attempts:
+        attempts += 1
+        base = rng.choice(base_triples)
+        a_idx, b_idx, c_idx = base["triple"]
+        va = jitter_basis(a_idx, magnitude, rng, jitter)
+        vb = jitter_basis(b_idx, magnitude, rng, jitter)
+        vc = jitter_basis(c_idx, magnitude, rng, jitter)
+        av = associator(va, vb, vc)
+        assoc_norm = norm(av)
+        if assoc_norm <= 1.0e-9:
+            continue
+        swapped = associator(vb, va, vc)
+        dim, value = dominant_component(av)
+        swapped_dim, swapped_value = dominant_component(swapped)
+        sign = 1 if value > 0.0 else -1
+        if dim != target_assoc_dim or (target_assoc_sign != 0 and sign != target_assoc_sign):
+            continue
+        if swapped_dim != dim or abs(value + swapped_value) > CONTINUOUS_TOL:
+            continue
+        # Avoid exact duplicate continuous samples after rounding; this keeps
+        # scaled packages from silently replaying the same jitter realization.
+        key = tuple(vector_key(va) + vector_key(vb) + vector_key(vc))
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(
+            {
+                "triple": base["triple"],
+                "vectors": (va, vb, vc),
+                "assoc_vector": av,
+                "assoc_norm": assoc_norm,
+                "assoc_dim": dim,
+                "assoc_sign": sign,
+                "assoc_value": value,
+                "base_triple": base["triple"],
+                "continuous_attempt": attempts,
+            }
+        )
+    if len(rows) < pairs:
+        raise SystemExit(
+            "not enough continuous fixed-target triples: "
+            f"target_dim={target_assoc_dim} target_sign={target_assoc_sign} "
+            f"generated={len(rows)} requested_pairs={pairs} attempts={attempts}"
+        )
+    return rows
+
+
+def endpoint(anchor: str) -> list[float]:
+    if anchor == "zero":
+        return [0.0] * 8
+    if anchor == "unit_real":
+        return basis(0)
+    raise ValueError(anchor)
+
+
+def make_core(triple: tuple[int, int, int], label: int, anchor: str, magnitude: float) -> list[list[float]]:
+    a, b, c = triple
+    va = basis(a, magnitude)
+    vb = basis(b, magnitude)
+    vc = basis(c, magnitude)
+    return make_core_from_vectors(va, vb, vc, label, anchor)
+
+
+def make_core_from_vectors(
+    va: list[float],
+    vb: list[float],
+    vc: list[float],
+    label: int,
+    anchor: str,
+) -> list[list[float]]:
+    first = [va, vb, vc] if label == 1 else [vb, va, vc]
+    tail = [neg(first[0]), neg(first[1]), neg(first[2])]
+    return [endpoint(anchor), *first, *tail, endpoint(anchor)]
+
+
+def add_noise(vec: list[float], rng: random.Random, noise_std: float) -> list[float]:
+    if noise_std <= 0.0:
+        return list(vec)
+    return [value + rng.gauss(0.0, noise_std) for value in vec]
+
+
+def stretch(core: list[list[float]], seq_len: int, rng: random.Random, noise_std: float) -> list[list[float]]:
+    if seq_len < len(core):
+        raise ValueError(f"seq_len={seq_len} < core_len={len(core)}")
+    return [add_noise(core[(idx * len(core)) // seq_len], rng, noise_std) for idx in range(seq_len)]
+
+
+def stretched_core_indices(seq_len: int, core_len: int = 8) -> dict[int, int]:
+    indices: dict[int, int] = {}
+    for idx in range(seq_len):
+        core_idx = (idx * core_len) // seq_len
+        indices.setdefault(core_idx, idx)
+    missing = [core_idx for core_idx in (1, 2, 3) if core_idx not in indices]
+    if missing:
+        raise ValueError(f"seq_len={seq_len} does not expose associator event core indices: {missing}")
+    return indices
+
+
+def realized_associator_target(
+    sequence: list[list[float]],
+    component: int,
+    event_indices: dict[int, int],
+) -> dict[str, Any]:
+    av = associator(
+        sequence[event_indices[1]],
+        sequence[event_indices[2]],
+        sequence[event_indices[3]],
+    )
+    dim, dominant_value = dominant_component(av)
+    if component < 0:
+        target_component = dim
+    elif component < len(av):
+        target_component = component
+    else:
+        raise ValueError(f"target component out of range: {component}")
+    value = av[target_component]
+    return {
+        "target_component": target_component,
+        "target_scalar": value,
+        "target_sign": 1 if value >= 0.0 else -1,
+        "dominant_component": dim,
+        "dominant_value": dominant_value,
+        "assoc_norm": norm(av),
+        "assoc_vector": av,
+    }
+
+
+def flatten(seq: list[list[float]]) -> list[float]:
+    return [value for row in seq for value in row]
+
+
+def vector_key(vec: list[float]) -> tuple[int, ...]:
+    return tuple(int(round(value * 1_000_000.0)) for value in vec)
+
+
+def stats(seq: list[list[float]]) -> dict[str, Any]:
+    dim = len(seq[0])
+    mean = [sum(row[d] for row in seq) / len(seq) for d in range(dim)]
+    delta = [seq[-1][d] - seq[0][d] for d in range(dim)]
+    energy = sum(value * value for row in seq for value in row)
+    return {
+        "mean": mean,
+        "delta": delta,
+        "energy": energy,
+        "start": seq[0],
+        "end": seq[-1],
+        "multiset": Counter(vector_key(row) for row in seq),
+    }
+
+
+def max_abs(values: list[float]) -> float:
+    return max((abs(value) for value in values), default=0.0)
+
+
+def pair_invariants(pairs: list[tuple[dict[str, Any], dict[str, Any]]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for pos, neg_record in pairs:
+        ps = stats(pos["sequence_noiseless"])
+        ns = stats(neg_record["sequence_noiseless"])
+        rows.append(
+            {
+                "pair_id": pos["pair_id"],
+                "triple": pos["triple"],
+                "assoc_dim": pos["assoc_dim"],
+                "positive_assoc_value": pos["assoc_value"],
+                "negative_assoc_value": neg_record["assoc_value"],
+                "assoc_sum_abs": abs(pos["assoc_value"] + neg_record["assoc_value"]),
+                "mean_max_abs_diff": max_abs([a - b for a, b in zip(ps["mean"], ns["mean"], strict=True)]),
+                "delta_max_abs_diff": max_abs([a - b for a, b in zip(ps["delta"], ns["delta"], strict=True)]),
+                "start_max_abs_diff": max_abs([a - b for a, b in zip(ps["start"], ns["start"], strict=True)]),
+                "end_max_abs_diff": max_abs([a - b for a, b in zip(ps["end"], ns["end"], strict=True)]),
+                "energy_abs_diff": abs(ps["energy"] - ns["energy"]),
+                "same_unordered_multiset": int(ps["multiset"] == ns["multiset"]),
+            }
+        )
+    return rows
+
+
+def write_manifest(path: Path, records: list[dict[str, Any]], seq_len: int) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(
+            "# schema=neurodyn.octonionic_associator_manifest.v1\n"
+            "# dataset_id=synthetic_octonionic_associator_trajectory\n"
+            f"# seq_len={seq_len}\n"
+            "# input_dim=8\n"
+            "# feature_layout=flat\n"
+            "# label_space=associator_positive_vs_swapped_sign\n"
+            "# label_positive_name=ASSOCIATOR_POSITIVE_ORDER\n"
+            "# label_negative_name=ASSOCIATOR_SWAPPED_SIGN\n"
+            "# split_policy=pseudo_site_holdout_pair_balanced\n"
+            "# feature_recipe=paired_nonassociative_triple_same_mean_delta_energy_multiset\n"
+            "# task=octonionic_nonassociative_temporal_trajectory\n"
+            f"# subject_count={len(records)}\n"
+            f"# site_count={len({record['site'] for record in records})}\n"
+            f"# claim_boundary={CLAIM_BOUNDARY}\n"
+        )
+        header = ["subject_id", "label", "site"] + [f"f{i}" for i in range(seq_len * 8)]
+        handle.write("\t".join(header) + "\n")
+        for record in records:
+            fields = [record["subject_id"], str(record["label"]), record["site"]]
+            fields.extend(f"{value:.10f}" for value in flatten(record["sequence"]))
+            handle.write("\t".join(fields) + "\n")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def target_support_summary(target_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    values = [float(row["target_scalar"]) for row in target_rows]
+    rounded = [round(value, 10) for value in values]
+    counts = Counter(rounded)
+    tied_rows = sum(count for count in counts.values() if count > 1)
+    sign_counts = Counter(int(row["target_sign"]) for row in target_rows)
+    by_site: dict[str, Counter[int]] = defaultdict(Counter)
+    for row in target_rows:
+        by_site[str(row["site"])][int(row["target_sign"])] += 1
+    return {
+        "target_row_count": len(target_rows),
+        "distinct_target_values": len(counts),
+        "tie_fraction": tied_rows / len(target_rows) if target_rows else 1.0,
+        "target_min": min(values) if values else None,
+        "target_max": max(values) if values else None,
+        "target_sign_counts": {str(key): sign_counts[key] for key in sorted(sign_counts)},
+        "site_target_sign_counts": {
+            site: {str(key): counts[key] for key in sorted(counts)}
+            for site, counts in sorted(by_site.items())
+        },
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Octonionic Associator Trajectory Manifest",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Package",
+        "",
+        f"- Manifest: `{summary['manifest']}`",
+        f"- Pairs: `{summary['pairs']}`",
+        f"- Records: `{summary['records']}`",
+        f"- Sites: `{summary['sites']}`",
+        f"- Sequence length: `{summary['seq_len']}`",
+        f"- Magnitude: `{summary['magnitude']}`",
+        f"- Noise std: `{summary['noise_std']}`",
+        f"- Anchor: `{summary['anchor']}`",
+        "",
+        "## Algebraic Gate",
+        "",
+        f"- Nonassociative triples available: `{summary['nonassociative_triples_available']}`",
+        f"- Target associator dim: `{summary['target_assoc_dim']}`",
+        f"- Target associator sign: `{summary['target_assoc_sign']}`",
+        f"- Associator norm min: `{summary['associator_norm_min']}`",
+        f"- Associator norm max: `{summary['associator_norm_max']}`",
+        f"- Pair sign-flip max residual: `{summary['invariant_max']['assoc_sum_abs']}`",
+        "",
+        "## Pair Invariants",
+        "",
+    ]
+    for key, value in summary["invariant_max"].items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(
+        [
+            "",
+            "## Decision",
+            "",
+            f"`{summary['decision']}`",
+            "",
+            "This package is ready for one hidden-state trace smoke only. Do not expand to nulls or clinical data unless the trained model passes global, hidden-state, checkpoint replay, and associator-specific gates.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    out = args.output_dir.resolve()
+    if out.exists() and any(out.iterdir()) and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+    out.mkdir(parents=True, exist_ok=True)
+    if args.site_mode == "assoc_dim" and args.sites != 7:
+        raise SystemExit("--site-mode=assoc_dim requires --sites=7")
+    if args.target_assoc_dim != -1:
+        if args.target_assoc_dim < 0 or args.target_assoc_dim > 7:
+            raise SystemExit("--target-assoc-dim must be -1 or an octonion associator component 0..7")
+        if args.site_mode == "assoc_dim":
+            raise SystemExit("--target-assoc-dim requires --site-mode=round_robin so held-out sites do not equal the target component")
+    if args.pairs < args.sites:
+        raise SystemExit("--pairs must be >= --sites")
+
+    triples = nonassociative_triples(args.magnitude)
+    if not triples:
+        raise SystemExit("no nonassociative triples found")
+    total_nonassociative_triples = len(triples)
+    excluded_dims = {int(part.strip()) for part in args.exclude_assoc_dims.split(",") if part.strip()}
+    if excluded_dims:
+        triples = [row for row in triples if int(row["assoc_dim"]) not in excluded_dims]
+        if not triples:
+            raise SystemExit(f"--exclude-assoc-dims removed all triples: {sorted(excluded_dims)}")
+    if args.assoc_sign_filter != 0:
+        triples = [row for row in triples if int(row["assoc_sign"]) == args.assoc_sign_filter]
+        if not triples:
+            raise SystemExit(f"--assoc-sign-filter={args.assoc_sign_filter} removed all triples")
+    if args.triple_source in {"continuous", "scaled_unit"} and args.target_assoc_dim == -1:
+        raise SystemExit(f"--triple-source={args.triple_source} requires --target-assoc-dim")
+    if args.target_assoc_dim != -1:
+        triples = [
+            row
+            for row in triples
+            if int(row["assoc_dim"]) == args.target_assoc_dim
+            and (args.target_assoc_sign == 0 or int(row["assoc_sign"]) == args.target_assoc_sign)
+        ]
+        if args.triple_source == "unit" and len(triples) < args.pairs:
+            raise SystemExit(
+                "not enough fixed-target nonassociative triples: "
+                f"target_dim={args.target_assoc_dim} target_sign={args.target_assoc_sign} "
+                f"available={len(triples)} requested_pairs={args.pairs}"
+            )
+    rng = random.Random(args.seed)
+    if args.triple_selection == "seeded_shuffle":
+        rng.shuffle(triples)
+    if args.triple_source == "continuous":
+        triples = continuous_triples(
+            triples,
+            args.pairs,
+            args.magnitude,
+            rng,
+            args.target_assoc_dim,
+            args.target_assoc_sign,
+            args.continuous_jitter,
+            args.continuous_max_attempts,
+        )
+    elif args.triple_source == "scaled_unit":
+        base_triples = list(triples)
+        triples = []
+        if not base_triples:
+            raise SystemExit("--triple-source=scaled_unit has no fixed-target base triples after filtering")
+        for pair_id in range(args.pairs):
+            base = base_triples[pair_id % len(base_triples)]
+            rel = 1.0
+            if args.scale_jitter > 0.0:
+                rel += rng.uniform(-args.scale_jitter, args.scale_jitter)
+            if rel <= 0.0:
+                raise SystemExit("--scale-jitter produced non-positive pair scale")
+            pair_magnitude = args.magnitude * rel
+            a, b, c = base["triple"]
+            va = basis(a, pair_magnitude)
+            vb = basis(b, pair_magnitude)
+            vc = basis(c, pair_magnitude)
+            av = associator(va, vb, vc)
+            dim, value = dominant_component(av)
+            triples.append(
+                {
+                    **base,
+                    "vectors": (va, vb, vc),
+                    "assoc_vector": av,
+                    "assoc_norm": norm(av),
+                    "assoc_dim": dim,
+                    "assoc_sign": 1 if value > 0.0 else -1,
+                    "assoc_value": value,
+                    "base_triple": base["triple"],
+                    "scale": pair_magnitude,
+                }
+            )
+    triples_by_dim: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for triple in triples:
+        triples_by_dim[int(triple["assoc_dim"])].append(triple)
+    if args.triple_selection == "seeded_shuffle":
+        for dim_rows in triples_by_dim.values():
+            rng.shuffle(dim_rows)
+    dims = sorted(triples_by_dim)
+    if args.site_mode == "assoc_dim" and len(dims) != args.sites:
+        raise SystemExit(f"--site-mode=assoc_dim expected {args.sites} associator dims, got {len(dims)}")
+    records: list[dict[str, Any]] = []
+    pair_records: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    triple_rows: list[dict[str, Any]] = []
+    target_rows: list[dict[str, Any]] = []
+    event_indices = stretched_core_indices(args.seq_len)
+
+    for pair_id in range(args.pairs):
+        if args.site_mode == "assoc_dim":
+            dim = dims[pair_id % len(dims)]
+            dim_rows = triples_by_dim[dim]
+            triple_meta = dim_rows[(pair_id // len(dims)) % len(dim_rows)]
+        else:
+            triple_meta = triples[pair_id % len(triples)]
+        triple = tuple(triple_meta["triple"])
+        va, vb, vc = (
+            tuple(triple_meta["vectors"])
+            if args.triple_source in {"continuous", "scaled_unit"}
+            else (basis(triple[0], args.magnitude), basis(triple[1], args.magnitude), basis(triple[2], args.magnitude))
+        )
+        assoc_dim = int(triple_meta["assoc_dim"])
+        if args.site_mode == "assoc_dim":
+            site = f"assoc_dim_{assoc_dim:02d}"
+        else:
+            site = f"pseudo_site_{pair_id % args.sites:02d}"
+        pair_seed = rng.randrange(1 << 30)
+        pos_core = make_core_from_vectors(list(va), list(vb), list(vc), 1, args.anchor)
+        neg_core = make_core_from_vectors(list(va), list(vb), list(vc), 0, args.anchor)
+        pos_assoc = associator(pos_core[1], pos_core[2], pos_core[3])
+        neg_assoc = associator(neg_core[1], neg_core[2], neg_core[3])
+        pos_dim, pos_value = dominant_component(pos_assoc)
+        neg_dim, neg_value = dominant_component(neg_assoc)
+        tolerance = CONTINUOUS_TOL if args.triple_source == "continuous" else UNIT_TOL
+        if pos_dim != neg_dim or abs(pos_value + neg_value) > tolerance:
+            raise SystemExit(f"associator sign-flip invariant failed for pair {pair_id}: {triple}")
+        pos_sequence_noiseless = stretch(pos_core, args.seq_len, random.Random(0), 0.0)
+        neg_sequence_noiseless = stretch(neg_core, args.seq_len, random.Random(0), 0.0)
+        pos_sequence = stretch(pos_core, args.seq_len, random.Random(pair_seed), args.noise_std)
+        neg_sequence = stretch(neg_core, args.seq_len, random.Random(pair_seed), args.noise_std)
+        target_component = args.target_assoc_dim if args.target_assoc_dim != -1 else pos_dim
+        pos_target = realized_associator_target(pos_sequence, target_component, event_indices)
+        neg_target = realized_associator_target(neg_sequence, target_component, event_indices)
+        pos_record = {
+            "subject_id": f"assoc_pair_{pair_id:04d}__positive",
+            "pair_id": pair_id,
+            "label": 1,
+            "site": site,
+            "triple": "-".join(str(item) for item in triple),
+            "assoc_dim": pos_dim,
+            "assoc_value": pos_value,
+            "target_scalar": pos_target["target_scalar"],
+            "target_sign": pos_target["target_sign"],
+            "target_component": pos_target["target_component"],
+            "sequence_noiseless": pos_sequence_noiseless,
+            "sequence": pos_sequence,
+        }
+        neg_record = {
+            "subject_id": f"assoc_pair_{pair_id:04d}__negative",
+            "pair_id": pair_id,
+            "label": 0,
+            "site": site,
+            "triple": "-".join(str(item) for item in triple),
+            "assoc_dim": neg_dim,
+            "assoc_value": neg_value,
+            "target_scalar": neg_target["target_scalar"],
+            "target_sign": neg_target["target_sign"],
+            "target_component": neg_target["target_component"],
+            "sequence_noiseless": neg_sequence_noiseless,
+            "sequence": neg_sequence,
+        }
+        records.extend([pos_record, neg_record])
+        pair_records.append((pos_record, neg_record))
+        for orientation, record, target in (
+            ("positive", pos_record, pos_target),
+            ("negative", neg_record, neg_target),
+        ):
+            target_rows.append(
+                {
+                    "subject_id": record["subject_id"],
+                    "pair_id": pair_id,
+                    "orientation": orientation,
+                    "site": site,
+                    "label": record["label"],
+                    "target_component": target["target_component"],
+                    "target_scalar": f"{target['target_scalar']:.12f}",
+                    "target_sign": target["target_sign"],
+                    "dominant_component": target["dominant_component"],
+                    "dominant_value": f"{target['dominant_value']:.12f}",
+                    "assoc_norm": f"{target['assoc_norm']:.12f}",
+                    "assoc_vector": ",".join(f"{value:.12f}" for value in target["assoc_vector"]),
+                    "target_source": "realized_stretched_sequence",
+                }
+            )
+        triple_rows.append(
+            {
+                "pair_id": pair_id,
+                "triple": pos_record["triple"],
+                "triple_source": args.triple_source,
+                "base_triple": "-".join(str(item) for item in triple_meta.get("base_triple", triple)),
+                "continuous_attempt": triple_meta.get("continuous_attempt", 0),
+                "scale": triple_meta.get("scale", args.magnitude),
+                "site": site,
+                "assoc_dim": pos_dim,
+                "positive_assoc_value": pos_value,
+                "negative_assoc_value": neg_value,
+                "positive_assoc_norm": norm(pos_assoc),
+                "negative_assoc_norm": norm(neg_assoc),
+            }
+        )
+
+    manifest = out / "octonionic_associator_manifest.tsv"
+    write_manifest(manifest, records, args.seq_len)
+    invariant_rows = pair_invariants(pair_records)
+    write_csv(out / "paired_associator_invariant_audit.csv", invariant_rows)
+    write_tsv(out / "associator_triples.tsv", triple_rows)
+    target_path = out / "associator_targets.tsv"
+    write_tsv(target_path, target_rows)
+    support_summary = target_support_summary(target_rows)
+    by_site: dict[str, Counter[int]] = defaultdict(Counter)
+    for record in records:
+        by_site[record["site"]][int(record["label"])] += 1
+    invariant_max = {
+        "assoc_sum_abs": max(row["assoc_sum_abs"] for row in invariant_rows),
+        "mean_max_abs_diff": max(row["mean_max_abs_diff"] for row in invariant_rows),
+        "delta_max_abs_diff": max(row["delta_max_abs_diff"] for row in invariant_rows),
+        "start_max_abs_diff": max(row["start_max_abs_diff"] for row in invariant_rows),
+        "end_max_abs_diff": max(row["end_max_abs_diff"] for row in invariant_rows),
+        "energy_abs_diff": max(row["energy_abs_diff"] for row in invariant_rows),
+        "same_unordered_multiset_min": min(row["same_unordered_multiset"] for row in invariant_rows),
+    }
+    for key, value in invariant_max.items():
+        if key == "same_unordered_multiset_min":
+            if int(value) != 1:
+                raise SystemExit("paired unordered multiset invariant failed")
+        elif float(value) > (CONTINUOUS_TOL if args.triple_source == "continuous" else UNIT_TOL):
+            raise SystemExit(f"paired invariant failed for {key}: {value}")
+    assoc_norms = [row["positive_assoc_norm"] for row in triple_rows] + [row["negative_assoc_norm"] for row in triple_rows]
+    summary = {
+        "schema": SCHEMA,
+        "created_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "claim_boundary": CLAIM_BOUNDARY,
+        "output_dir": str(out),
+        "manifest": str(manifest),
+        "pairs": args.pairs,
+        "records": len(records),
+        "sites": args.sites,
+        "seq_len": args.seq_len,
+        "input_dim": 8,
+        "magnitude": args.magnitude,
+        "noise_std": args.noise_std,
+        "seed": args.seed,
+        "anchor": args.anchor,
+        "site_mode": args.site_mode,
+        "triple_selection": args.triple_selection,
+        "triple_source": args.triple_source,
+        "continuous_jitter": args.continuous_jitter if args.triple_source == "continuous" else 0.0,
+        "continuous_max_attempts": args.continuous_max_attempts if args.triple_source == "continuous" else 0,
+        "scale_jitter": args.scale_jitter if args.triple_source == "scaled_unit" else 0.0,
+        "target_assoc_dim": args.target_assoc_dim,
+        "target_assoc_sign": args.target_assoc_sign if args.target_assoc_dim != -1 else 0,
+        "associator_targets": str(target_path),
+        "target_source": "realized_stretched_sequence",
+        "target_support": support_summary,
+        "excluded_assoc_dims": sorted(excluded_dims),
+        "assoc_sign_filter": args.assoc_sign_filter,
+        "nonassociative_triples_available": total_nonassociative_triples,
+        "selected_triples_available": len(triples),
+        "associator_norm_min": min(assoc_norms),
+        "associator_norm_max": max(assoc_norms),
+        "label_counts": {
+            "0": sum(1 for record in records if record["label"] == 0),
+            "1": sum(1 for record in records if record["label"] == 1),
+        },
+        "site_label_counts": {
+            site: {"0": counts[0], "1": counts[1]} for site, counts in sorted(by_site.items())
+        },
+        "invariant_max": invariant_max,
+        "decision": "OCTONIONIC_ASSOCIATOR_TRAJECTORY_MANIFEST_READY_FOR_SINGLE_TRACE_SMOKE",
+    }
+    (out / "octonionic_associator_manifest_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "octonionic_associator_manifest_summary.md").write_text(markdown(summary), encoding="utf-8")
+    with (out / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in out.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_octonionic_dynamics_diagnostic.py
+++ b/scripts/research/neurodyn_octonionic_dynamics_diagnostic.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Diagnose octonionic state-space activity from a verified NeuroDyn O-SSM run.
+
+The goal is not to make a clinical claim. It is to keep the O-SSM evaluation
+honest as an octonionic state-space model by separating:
+
+* replayable, nonzero octonionic state
+* associator/hidden-state activity
+* saturated classifier readout artifacts
+* label/fold summaries that need scale before interpretation
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.octonionic_dynamics_diagnostic.v1"
+CLAIM_BOUNDARY = (
+    "Diagnostic only. Nonzero octonionic state and associator activity are "
+    "necessary but not sufficient for a clinical, mechanistic, or biomarker claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--features", required=True, help="subject_roi_assoc_features.tsv from trained associator.")
+    parser.add_argument("--run-summary", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--prob-saturation-threshold", type=float, default=0.99)
+    parser.add_argument("--logit-saturation-threshold", type=float, default=11.999)
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fields = list(rows[0])
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def values(ckpt: dict[str, Any], name: str) -> list[float]:
+    return [float(value) for value in ckpt.get("arrays", {}).get(name, {}).get("values", [])]
+
+
+def fixed_to_float(values_in: list[float]) -> list[float]:
+    return [value / 100_000_000.0 for value in values_in]
+
+
+def vector_summary(raw: list[float], scale: float = 1.0) -> dict[str, Any]:
+    vals = [value * scale for value in raw]
+    if not vals:
+        return {
+            "count": 0,
+            "nonzero_count": 0,
+            "mean": 0.0,
+            "mean_abs": 0.0,
+            "l1": 0.0,
+            "l2": 0.0,
+            "linf": 0.0,
+            "positive_count": 0,
+            "negative_count": 0,
+        }
+    abs_vals = [abs(value) for value in vals]
+    return {
+        "count": len(vals),
+        "nonzero_count": sum(1 for value in abs_vals if value > 1.0e-12),
+        "mean": sum(vals) / len(vals),
+        "mean_abs": sum(abs_vals) / len(abs_vals),
+        "l1": sum(abs_vals),
+        "l2": math.sqrt(sum(value * value for value in vals)),
+        "linf": max(abs_vals),
+        "positive_count": sum(1 for value in vals if value > 1.0e-12),
+        "negative_count": sum(1 for value in vals if value < -1.0e-12),
+    }
+
+
+def read_feature_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for row in reader:
+            rows.append(
+                {
+                    "subject_index": int(row["subject_index"]),
+                    "subject_id": row["subject_id"],
+                    "label": int(row["label"]),
+                    "label_name": row["label_name"],
+                    "site": row["site"],
+                    "roi_index": int(row["roi_index"]),
+                    "base_prob": float(row["base_prob"]),
+                    "masked_prob": float(row["masked_prob"]),
+                    "base_assoc": float(row["base_assoc"]),
+                    "masked_assoc": float(row["masked_assoc"]),
+                    "assoc_delta_abs": float(row["assoc_delta_abs"]),
+                    "prob_delta_abs": float(row["prob_delta_abs"]),
+                    "base_logit": float(row["base_logit"]),
+                    "masked_logit": float(row["masked_logit"]),
+                    "logit_delta_abs": float(row["logit_delta_abs"]),
+                    "hidden_delta_abs": float(row["hidden_delta_abs"]),
+                }
+            )
+    return rows
+
+
+def mean(values_in: list[float]) -> float:
+    return sum(values_in) / len(values_in) if values_in else 0.0
+
+
+def stdev(values_in: list[float]) -> float:
+    return statistics.pstdev(values_in) if len(values_in) > 1 else 0.0
+
+
+def summarize_group(rows: list[dict[str, Any]], group_key: str) -> list[dict[str, Any]]:
+    grouped: dict[Any, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[row[group_key]].append(row)
+    out: list[dict[str, Any]] = []
+    for key in sorted(grouped, key=str):
+        chunk = grouped[key]
+        out.append(
+            {
+                group_key: key,
+                "feature_rows": len(chunk),
+                "subject_count": len({row["subject_index"] for row in chunk}),
+                "base_prob_mean": mean([row["base_prob"] for row in chunk]),
+                "base_assoc_mean": mean([row["base_assoc"] for row in chunk]),
+                "assoc_delta_abs_mean": mean([row["assoc_delta_abs"] for row in chunk]),
+                "prob_delta_abs_mean": mean([row["prob_delta_abs"] for row in chunk]),
+                "logit_delta_abs_mean": mean([row["logit_delta_abs"] for row in chunk]),
+                "hidden_delta_abs_mean": mean([row["hidden_delta_abs"] for row in chunk]),
+            }
+        )
+    return out
+
+
+def subject_level(rows: list[dict[str, Any]], prob_threshold: float, logit_threshold: float) -> list[dict[str, Any]]:
+    grouped: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[row["subject_index"]].append(row)
+    out: list[dict[str, Any]] = []
+    for subject_index in sorted(grouped):
+        chunk = grouped[subject_index]
+        first = chunk[0]
+        base_prob = first["base_prob"]
+        base_logit = first["base_logit"]
+        out.append(
+            {
+                "subject_index": subject_index,
+                "subject_id": first["subject_id"],
+                "label": first["label"],
+                "label_name": first["label_name"],
+                "site": first["site"],
+                "roi_count": len(chunk),
+                "base_prob": base_prob,
+                "base_assoc": first["base_assoc"],
+                "base_logit": base_logit,
+                "prob_saturated": int(base_prob >= prob_threshold or base_prob <= 1.0 - prob_threshold),
+                "logit_saturated": int(abs(base_logit) >= logit_threshold),
+                "assoc_delta_abs_mean": mean([row["assoc_delta_abs"] for row in chunk]),
+                "assoc_delta_abs_std": stdev([row["assoc_delta_abs"] for row in chunk]),
+                "hidden_delta_abs_mean": mean([row["hidden_delta_abs"] for row in chunk]),
+                "hidden_delta_abs_std": stdev([row["hidden_delta_abs"] for row in chunk]),
+                "prob_delta_abs_mean": mean([row["prob_delta_abs"] for row in chunk]),
+                "logit_delta_abs_mean": mean([row["logit_delta_abs"] for row in chunk]),
+            }
+        )
+    return out
+
+
+def top_subjects(rows: list[dict[str, Any]], field: str, limit: int = 10) -> list[dict[str, Any]]:
+    return sorted(rows, key=lambda row: float(row[field]), reverse=True)[:limit]
+
+
+def markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Octonionic Dynamics Diagnostic",
+        "",
+        f"- schema: `{summary['schema']}`",
+        f"- run_id: `{summary['run_id']}`",
+        f"- checkpoint_replay_status: `{summary['checkpoint_verification'].get('status')}`",
+        f"- checkpoint_replay_delta_pp: `{summary['checkpoint_verification'].get('delta_pp')}`",
+        f"- claim_boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## State Activity",
+        "",
+        f"- A_nonzero: `{summary['state']['A']['nonzero_count']}` / `{summary['state']['A']['count']}`",
+        f"- A_l2: `{summary['state']['A']['l2']}`",
+        f"- LAST_H_nonzero: `{summary['state']['LAST_H_fixed']['nonzero_count']}` / `{summary['state']['LAST_H_fixed']['count']}`",
+        f"- LAST_ASSOC_ACC_nonzero: `{summary['state']['LAST_ASSOC_ACC_fixed']['nonzero_count']}` / `{summary['state']['LAST_ASSOC_ACC_fixed']['count']}`",
+        "",
+        "## Readout Saturation",
+        "",
+        f"- subject_count: `{summary['subject_count']}`",
+        f"- prob_saturated_subjects: `{summary['saturation']['prob_saturated_subjects']}`",
+        f"- logit_saturated_subjects: `{summary['saturation']['logit_saturated_subjects']}`",
+        f"- mean_base_prob: `{summary['saturation']['mean_base_prob']}`",
+        f"- mean_base_assoc: `{summary['saturation']['mean_base_assoc']}`",
+        "",
+        "## Interpretation",
+        "",
+        summary["interpretation"],
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    checkpoint_path = Path(args.checkpoint).resolve()
+    features_path = Path(args.features).resolve()
+    run_summary_path = Path(args.run_summary).resolve()
+    output_dir = Path(args.output_dir).resolve()
+
+    checkpoint = read_json(checkpoint_path)
+    run_summary = read_json(run_summary_path)
+    rows = read_feature_rows(features_path)
+    subjects = subject_level(rows, args.prob_saturation_threshold, args.logit_saturation_threshold)
+
+    state = {
+        "A": vector_summary(values(checkpoint, "A")),
+        "A_FIXED_as_float": vector_summary(fixed_to_float(values(checkpoint, "A_FIXED"))),
+        "LAST_H_fixed": vector_summary(fixed_to_float(values(checkpoint, "LAST_H"))),
+        "LAST_ASSOC_ACC_fixed": vector_summary(fixed_to_float(values(checkpoint, "LAST_ASSOC_ACC"))),
+        "W_fixed": vector_summary(fixed_to_float(values(checkpoint, "W"))),
+        "PROJ_W_fixed": vector_summary(fixed_to_float(values(checkpoint, "PROJ_W"))),
+    }
+    prob_saturated = sum(row["prob_saturated"] for row in subjects)
+    logit_saturated = sum(row["logit_saturated"] for row in subjects)
+    interpretation = (
+        "The checkpoint contains nonzero replayable octonionic state and nonzero associator activity. "
+        "However, the current subject-level readout is saturated for most or all subjects, so probability/logit "
+        "perturbation metrics are weak evidence for octonionic structure. Treat hidden/associator diagnostics as "
+        "necessary instrumentation for the scaled run, not as a standalone positive claim."
+    )
+
+    summary = {
+        "schema": SCHEMA,
+        "checkpoint_path": str(checkpoint_path),
+        "features_path": str(features_path),
+        "run_summary_path": str(run_summary_path),
+        "run_id": checkpoint.get("run_id"),
+        "checkpoint_verification": checkpoint.get("verification", {}),
+        "extractor_verification": run_summary.get("extractor_verification", {}),
+        "state": state,
+        "feature_rows": len(rows),
+        "subject_count": len(subjects),
+        "roi_count": len({row["roi_index"] for row in rows}),
+        "saturation": {
+            "prob_threshold": args.prob_saturation_threshold,
+            "logit_threshold": args.logit_saturation_threshold,
+            "prob_saturated_subjects": prob_saturated,
+            "logit_saturated_subjects": logit_saturated,
+            "prob_saturated_fraction": prob_saturated / len(subjects) if subjects else 0.0,
+            "logit_saturated_fraction": logit_saturated / len(subjects) if subjects else 0.0,
+            "mean_base_prob": mean([row["base_prob"] for row in subjects]),
+            "mean_base_assoc": mean([row["base_assoc"] for row in subjects]),
+            "mean_hidden_delta_abs": mean([row["hidden_delta_abs_mean"] for row in subjects]),
+            "mean_assoc_delta_abs": mean([row["assoc_delta_abs_mean"] for row in subjects]),
+        },
+        "by_label": summarize_group(rows, "label_name"),
+        "by_site": summarize_group(rows, "site"),
+        "top_subjects_by_hidden_delta_abs_mean": top_subjects(subjects, "hidden_delta_abs_mean"),
+        "top_subjects_by_assoc_delta_abs_mean": top_subjects(subjects, "assoc_delta_abs_mean"),
+        "interpretation": interpretation,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "octonionic_dynamics_diagnostic.json", summary)
+    write_tsv(output_dir / "subject_octonionic_dynamics.tsv", subjects)
+    write_tsv(output_dir / "label_octonionic_dynamics.tsv", summary["by_label"])
+    write_tsv(output_dir / "site_octonionic_dynamics.tsv", summary["by_site"])
+    (output_dir / "octonionic_dynamics_diagnostic.md").write_text(markdown(summary), encoding="utf-8")
+
+    print(f"summary={output_dir / 'octonionic_dynamics_diagnostic.json'}")
+    print(f"subjects={output_dir / 'subject_octonionic_dynamics.tsv'}")
+    print(f"claim_boundary={CLAIM_BOUNDARY}")
+    print(f"prob_saturated_subjects={prob_saturated}/{len(subjects)}")
+    print(f"logit_saturated_subjects={logit_saturated}/{len(subjects)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_octonionic_order_witness.py
+++ b/scripts/research/neurodyn_octonionic_order_witness.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Deterministic order-sensitivity witness for the Brain O-SSM update path."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.octonionic_order_witness.v1"
+CLAIM_BOUNDARY = (
+    "Deterministic synthetic update-path diagnostic only. This is not a "
+    "clinical, biomarker, mechanistic, or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def clip(x: float, lo: float, hi: float) -> float:
+    return lo if x < lo else hi if x > hi else x
+
+
+def norm(v: list[float]) -> float:
+    return math.sqrt(sum(x * x for x in v))
+
+
+def normalize(v: list[float]) -> list[float]:
+    n = norm(v)
+    if n <= 1e-12:
+        return [1.0] + [0.0] * 7
+    return [x / n for x in v]
+
+
+def dist(a: list[float], b: list[float]) -> float:
+    return norm([x - y for x, y in zip(a, b, strict=True)])
+
+
+def oct_mul(a: list[float], b: list[float]) -> list[float]:
+    a0, a1, a2, a3, a4, a5, a6, a7 = a
+    b0, b1, b2, b3, b4, b5, b6, b7 = b
+    return [
+        a0 * b0 - a1 * b1 - a2 * b2 - a3 * b3 - a4 * b4 - a5 * b5 - a6 * b6 - a7 * b7,
+        a0 * b1 + a1 * b0 + a2 * b3 - a3 * b2 + a4 * b5 - a5 * b4 - a6 * b7 + a7 * b6,
+        a0 * b2 + a2 * b0 - a1 * b3 + a3 * b1 + a4 * b6 - a6 * b4 + a5 * b7 - a7 * b5,
+        a0 * b3 + a3 * b0 + a1 * b2 - a2 * b1 + a4 * b7 - a7 * b4 - a5 * b6 + a6 * b5,
+        a0 * b4 + a4 * b0 - a1 * b5 + a5 * b1 - a2 * b6 + a6 * b2 - a3 * b7 + a7 * b3,
+        a0 * b5 + a5 * b0 + a1 * b4 - a4 * b1 - a2 * b7 + a7 * b2 + a3 * b6 - a6 * b3,
+        a0 * b6 + a6 * b0 + a1 * b7 - a7 * b1 + a2 * b4 - a4 * b2 - a3 * b5 + a5 * b3,
+        a0 * b7 + a7 * b0 - a1 * b6 + a6 * b1 - a2 * b5 + a5 * b2 + a3 * b4 - a4 * b3,
+    ]
+
+
+def basis(index: int, sign: float = 1.0) -> list[float]:
+    out = [0.0] * 8
+    out[index] = sign
+    return out
+
+
+def md2_squash(v: float) -> float:
+    if v >= 0.0:
+        return v / (1.0 + v)
+    return v / (1.0 + (-v))
+
+
+def mandelbrot_d2_feature(seed: float, delta: float) -> float:
+    z = clip(0.55 * seed + 0.20 * delta, -2.0, 2.0)
+    c = clip(0.35 * seed + 0.25 * delta, -2.0, 2.0)
+    dz = 1.0 + 0.10 * delta
+    ddz = 0.0
+    for _ in range(3):
+        ddz = 2.0 * (dz * dz + z * ddz)
+        dz = 2.0 * z * dz + 1.0 + 0.15 * delta
+        z = clip(z * z + c, -4.0, 4.0)
+        dz = clip(dz, -6.0, 6.0)
+        ddz = clip(ddz, -8.0, 8.0)
+    return clip(md2_squash(ddz), -1.5, 1.5)
+
+
+def project_identity(x: list[float], prev_raw: list[float] | None) -> tuple[list[float], list[float]]:
+    delta = [0.0] * 8 if prev_raw is None else [x[i] - prev_raw[i] for i in range(8)]
+    return list(x), delta
+
+
+def project_mandel_hybrid(x: list[float], prev_raw: list[float] | None) -> tuple[list[float], list[float]]:
+    delta = [0.0] * 8 if prev_raw is None else [x[i] - prev_raw[i] for i in range(8)]
+    out: list[float] = []
+    for d in range(8):
+        base = x[d]
+        md2 = mandelbrot_d2_feature(base, delta[d])
+        # Mirrors the benchmark's preset-ish projection defaults: structured and
+        # delta terms are active; learned correlation starts close to identity.
+        struct_gate = clip(0.55 + 0.45 * 0.65, -1.5, 1.5)
+        delta_gate = clip(0.75, -1.5, 1.5)
+        corr = base
+        s = base + 0.35 * struct_gate * md2 + 0.18 * delta_gate * delta[d] + 0.12 * 0.20 * (corr - base)
+        out.append(clip(s, -4.0, 4.0))
+    return out, delta
+
+
+def brain_g2_preset_a() -> list[float]:
+    return normalize([1.0, 0.62, 0.62, 0.0, 0.62, 0.0, 0.0, 0.0])
+
+
+def brain_step(h: list[float], x: list[float], a: list[float], clip_state: bool = True) -> tuple[list[float], float]:
+    ah = oct_mul(a, h)
+    left = oct_mul(ah, x)
+    hx = oct_mul(h, x)
+    right = oct_mul(a, hx)
+    assoc = dist(left, right)
+    next_h = [left[i] + 0.2 * right[i] for i in range(8)]
+    if clip_state:
+        next_h = [clip(v, -5.0, 5.0) for v in next_h]
+    return next_h, assoc
+
+
+def stable_sigmoid_step(h: list[float], x: list[float]) -> tuple[list[float], float]:
+    a = [0.82, 0.06, 0.03, 0.02, 0.03, 0.02, 0.01, 0.01]
+    b = [0.44, 0.09, 0.06, 0.04, 0.05, 0.03, 0.02, 0.02]
+    ah = oct_mul(a, h)
+    bx = oct_mul(b, x)
+    raw = [ah[i] + bx[i] + 0.18 * h[i] for i in range(8)]
+    next_h = [1.0 / (1.0 + math.exp(-clip(v, -15.0, 15.0))) for v in raw]
+    assoc = dist(oct_mul(oct_mul(h, x), next_h), oct_mul(h, oct_mul(x, next_h)))
+    return next_h, assoc
+
+
+def fixed_pair_core(oriented: bool, anchor: str) -> list[list[float]]:
+    e1, e2, e3 = basis(1), basis(2), basis(3)
+    if anchor == "zero":
+        endpoint = [0.0] * 8
+    elif anchor == "unit_real":
+        endpoint = basis(0)
+    else:
+        raise ValueError(anchor)
+    first = [e1, e2, e3] if oriented else [e2, e1, e3]
+    tail = [[-v for v in first[0]], [-v for v in first[1]], [-v for v in first[2]]]
+    return [endpoint, *first, *tail, endpoint]
+
+
+def stretch(core: list[list[float]], seq_len: int = 32) -> list[list[float]]:
+    return [core[(idx * len(core)) // seq_len] for idx in range(seq_len)]
+
+
+def run_sequence(
+    seq: list[list[float]],
+    projection: str,
+    update: str,
+    clip_state: bool = True,
+) -> dict[str, Any]:
+    h = basis(0)
+    a = brain_g2_preset_a()
+    prev_raw: list[float] | None = None
+    assoc_values: list[float] = []
+    states: list[list[float]] = []
+    for raw in seq:
+        if projection == "identity":
+            x, _ = project_identity(raw, prev_raw)
+        elif projection == "mandel_hybrid":
+            x, _ = project_mandel_hybrid(raw, prev_raw)
+        else:
+            raise ValueError(projection)
+        if update == "brain":
+            h, assoc = brain_step(h, x, a, clip_state=clip_state)
+        elif update == "stable_sigmoid":
+            h, assoc = stable_sigmoid_step(h, x)
+        else:
+            raise ValueError(update)
+        assoc_values.append(assoc)
+        states.append(list(h))
+        prev_raw = raw
+    return {
+        "final_h": h,
+        "final_norm": norm(h),
+        "assoc_mean": sum(assoc_values) / len(assoc_values),
+        "assoc_max": max(assoc_values),
+        "states": states,
+    }
+
+
+def compare_regime(anchor: str, projection: str, update: str, clip_state: bool = True) -> dict[str, Any]:
+    pos = run_sequence(stretch(fixed_pair_core(True, anchor)), projection, update, clip_state)
+    neg = run_sequence(stretch(fixed_pair_core(False, anchor)), projection, update, clip_state)
+    step_distances = [dist(a, b) for a, b in zip(pos["states"], neg["states"], strict=True)]
+    return {
+        "anchor": anchor,
+        "projection": projection,
+        "update": update,
+        "clip_state": clip_state,
+        "final_distance": dist(pos["final_h"], neg["final_h"]),
+        "max_step_distance": max(step_distances),
+        "mean_step_distance": sum(step_distances) / len(step_distances),
+        "positive_final_norm": pos["final_norm"],
+        "negative_final_norm": neg["final_norm"],
+        "positive_assoc_mean": pos["assoc_mean"],
+        "negative_assoc_mean": neg["assoc_mean"],
+        "positive_assoc_max": pos["assoc_max"],
+        "negative_assoc_max": neg["assoc_max"],
+        "positive_final_h": pos["final_h"],
+        "negative_final_h": neg["final_h"],
+    }
+
+
+def write_hashes(output_dir: Path) -> None:
+    with (output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n")
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Octonionic Order Witness",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "| anchor | projection | update | clip | final distance | max step distance | pos assoc mean | neg assoc mean |",
+        "|---|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["regimes"]:
+        lines.append(
+            "| {anchor} | {projection} | {update} | {clip_state} | {final_distance:.9f} | {max_step_distance:.9f} | {positive_assoc_mean:.9f} | {negative_assoc_mean:.9f} |".format(
+                **row
+            )
+        )
+    lines.extend(["", "## Interpretation", "", payload["interpretation"], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    regimes = [
+        compare_regime("zero", "identity", "brain", True),
+        compare_regime("zero", "mandel_hybrid", "brain", True),
+        compare_regime("zero", "identity", "stable_sigmoid", True),
+        compare_regime("unit_real", "identity", "brain", True),
+        compare_regime("unit_real", "mandel_hybrid", "brain", True),
+        compare_regime("unit_real", "identity", "stable_sigmoid", True),
+    ]
+    interpretation = (
+        "The deterministic update-path witness checks whether order reversal changes final "
+        "state before any classifier. If identity+brain is order-sensitive but "
+        "mandel_hybrid+brain is weak, the projection/encoding path is suspect. If both are "
+        "order-sensitive while trained hidden traces are chance, optimization/readout-to-state "
+        "coupling is suspect. If identity+brain is not order-sensitive, the recurrent update "
+        "itself needs redesign."
+    )
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "assay": "fixed_pair_e1_e2_e3_oriented_vs_swapped",
+        "regimes": regimes,
+        "interpretation": interpretation,
+    }
+    (output_dir / "octonionic_order_witness.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_dir / "octonionic_order_witness.md").write_text(markdown(payload), encoding="utf-8")
+    write_hashes(output_dir)
+    print(json.dumps({"output_dir": str(output_dir), "regimes": regimes}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orangefs_not_required_gate.py
+++ b/scripts/research/neurodyn_orangefs_not_required_gate.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+neurodyn_orangefs_not_required_gate — gate P3 NeuroDyn (Python, generalizado).
+
+Prova (não afirma) que o OrangeFS NÃO é requisito para a persistência científica
+do P3, para DUAS classes de artefato:
+  - pilot            (ds006731: p3_fmriprep_pilot_receipt.json, pilot_*/roi/*.1D)
+  - balanced_manifest(ds002748: mdd_neurodyn_prepare_summary.json, mdd_neurodyn_manifest.tsv, rois/*.1D)
+  - ossm_smoke       (ds006731: pacote O-SSM smoke com checkpoint/replay/controles)
+
+Armadilha central que o gate mata: um artifact root pode começar com "/tmp/..."
+mesmo estando em Ceph RBD/CephFS persistente. O gate resolve o BACKING REAL
+(findmnt), nunca confia no nome do path.
+
+4 CHECKS (todos precisam passar):
+  1. artifact_landing_path      — artefatos da classe presentes, FORA do worker scratch
+  2. stable_backing_filesystem  — backing = /dev/rbd* ou ceph/ceph-fuse; nunca overlay/tmpfs
+  3. bundle_inclusion_hash      — evidence bundle presente; sha256 de cada artefato bate; bundle_sha256 raiz bate
+  4. worker_loss_survivability  — nada aponta pro worker scratch; artefatos são arquivos reais legíveis
+
+Uso:
+  neurodyn_orangefs_not_required_gate.py <ARTIFACT_ROOT> [--worker-scratch PATH] [--emit-md] [--out-dir DIR]
+
+Saída: JSON (schema brain_ossm.neurodyn_orangefs_not_required_gate.v1) no stdout;
+       MD opcional em <out-dir> ou <ARTIFACT_ROOT>. Exit 0 = orangefs_not_required, 1 = still_required.
+"""
+from __future__ import annotations
+import argparse, hashlib, json, os, subprocess, sys, datetime, glob
+
+BUNDLE_NAME = "neurodyn_evidence_bundle_manifest.json"
+GATE_SCHEMA = "brain_ossm.neurodyn_orangefs_not_required_gate.v1"
+DEFAULT_WORKER_SCRATCH = "/tmp/neurodyn-ds006731-pilot"
+DECISION_PASS = "orangefs_not_required_for_p3_roi_manifest"
+DECISION_FAIL = "orangefs_still_required_for_p3"
+CLAIM = ("Storage/reproducibility gate only. Atesta persistência durável+íntegra "
+         "de ROI/manifest/receipts; não autoriza afirmação científica, clínica ou de biomarcador.")
+
+
+def now_utc() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for b in iter(lambda: f.read(1 << 20), b""):
+            h.update(b)
+    return h.hexdigest()
+
+
+def within(child: str, parent: str) -> bool:
+    child, parent = os.path.realpath(child), os.path.realpath(parent)
+    return child == parent or child.startswith(parent.rstrip("/") + "/")
+
+
+def detect_class(root: str) -> str | None:
+    if os.path.isfile(os.path.join(root, "mdd_neurodyn_prepare_summary.json")):
+        return "balanced_manifest"
+    if os.path.isfile(os.path.join(root, "p3_fmriprep_pilot_receipt.json")):
+        return "pilot"
+    if os.path.isfile(os.path.join(root, "neurodyn_bucket8_smoke_summary.json")):
+        return "ossm_smoke"
+    return None
+
+
+# ---- CHECK 1 --------------------------------------------------------------
+def check_artifact_landing(root: str, cls: str, worker: str) -> tuple[bool, str]:
+    if not os.path.isdir(root):
+        return False, f"artifact_root não existe: {root}"
+    if within(root, worker):
+        return False, f"artifact_root está DENTRO do worker scratch ({worker}) — persistência ilusória"
+    missing: list[str] = []
+    if cls == "balanced_manifest":
+        req = ["mdd_neurodyn_prepare_summary.json", "mdd_neurodyn_manifest.tsv",
+               "mdd_neurodyn_temporal_shuffle_manifest.tsv",
+               "mdd_neurodyn_temporal_reverse_manifest.tsv",
+               "mdd_neurodyn_label_within_site_shuffle_manifest.tsv", "mdd_phenotypic.csv"]
+        for f in req:
+            if not os.path.isfile(os.path.join(root, f)):
+                missing.append(f)
+        if not glob.glob(os.path.join(root, "rois", "*.1D")):
+            missing.append("rois/*.1D")
+    elif cls == "pilot":
+        req = ["p3_fmriprep_pilot_receipt.json", "p3_storage_preprocessing_gate.json"]
+        for f in req:
+            if not os.path.isfile(os.path.join(root, f)):
+                missing.append(f)
+        subs = glob.glob(os.path.join(root, "pilot_*"))
+        if not subs:
+            missing.append("pilot_*")
+        for s in subs:
+            if not glob.glob(os.path.join(s, "roi", "*.1D")):
+                missing.append(f"{os.path.basename(s)}/roi/*.1D")
+            if not os.path.isfile(os.path.join(s, "roi_phenotypic.csv")):
+                missing.append(f"{os.path.basename(s)}/roi_phenotypic.csv")
+    elif cls == "ossm_smoke":
+        req = [
+            "neurodyn_bucket8_smoke_summary.json",
+            "neurodyn_bucket8_smoke_summary.tsv",
+            "checkpoint_python_fresh_replay.json",
+            "single_site_cv_test_results/sounio_structured/overall_metrics.json",
+            "temporal_shuffle_results/sounio_structured/overall_metrics.json",
+            "temporal_reverse_results/sounio_structured/overall_metrics.json",
+            "label_within_site_shuffle_results/sounio_structured/overall_metrics.json",
+        ]
+        for f in req:
+            if not os.path.isfile(os.path.join(root, f)):
+                missing.append(f)
+        if not glob.glob(os.path.join(root, "single_site_cv_test_results", "checkpoints", "*", "model.ckpt")):
+            missing.append("single_site_cv_test_results/checkpoints/*/model.ckpt")
+    else:
+        return False, "classe de artefato não reconhecida (nem pilot, balanced_manifest, nem ossm_smoke)"
+    if missing:
+        return False, f"faltando: {missing}"
+    return True, f"artefatos da classe '{cls}' presentes, fora do worker scratch"
+
+
+# ---- CHECK 2 --------------------------------------------------------------
+def check_stable_backing(root: str) -> tuple[bool, dict]:
+    def fm(field: str) -> str:
+        try:
+            return subprocess.run(["findmnt", "-n", "-o", field, "--target", root],
+                                  capture_output=True, text=True, timeout=10).stdout.strip()
+        except Exception:
+            return ""
+    src, fstype, mnt = fm("SOURCE"), fm("FSTYPE"), fm("TARGET")
+    info = {"device": src, "fstype": fstype, "mountpoint": mnt}
+    if fstype in ("overlay", "tmpfs", "ramfs"):
+        return False, {**info, "why": f"fstype '{fstype}' é EFÊMERO — não sobrevive ao pod/host"}
+    if src.startswith("/dev/rbd"):
+        return True, {**info, "why": f"Ceph RBD ({src}) — persistente/replicado"}
+    if fstype in ("ceph", "fuse.ceph-fuse"):
+        return True, {**info, "why": f"CephFS ({fstype}) — persistente/replicado"}
+    return False, {**info, "why": f"backing '{src}'/'{fstype}' não reconhecido como persistente"}
+
+
+# ---- CHECK 3 --------------------------------------------------------------
+def check_bundle_hash(root: str) -> tuple[bool, str]:
+    bpath = os.path.join(root, BUNDLE_NAME)
+    if not os.path.isfile(bpath):
+        return False, f"evidence bundle ausente ({BUNDLE_NAME}) — rode neurodyn_evidence_bundle.py build"
+    try:
+        bundle = json.load(open(bpath))
+    except Exception as e:
+        return False, f"bundle ilegível: {e}"
+    arts = bundle.get("artifacts", [])
+    if not arts:
+        return False, "bundle sem artefatos"
+    mism = []
+    for a in arts:
+        abs_ = os.path.join(root, a["path"])
+        if not os.path.isfile(abs_):
+            mism.append(f"{a['path']}(ausente)"); continue
+        if sha256_file(abs_) != a["sha256"]:
+            mism.append(f"{a['path']}(sha256)")
+    # raiz determinística
+    lines = "".join(f"{a['sha256']}  {a['path']}\n"
+                    for a in sorted(arts, key=lambda x: x["path"]))
+    root_ok = hashlib.sha256(lines.encode()).hexdigest() == bundle.get("bundle_sha256")
+    if mism:
+        return False, f"hash divergente: {mism}"
+    if not root_ok:
+        return False, "bundle_sha256 raiz não bate (bundle adulterado/inconsistente)"
+    return True, f"{len(arts)} artefatos hash-verificados; bundle_sha256 raiz OK ({bundle.get('bundle_sha256','')[:16]}…)"
+
+
+# ---- CHECK 4 --------------------------------------------------------------
+def check_worker_survivability(root: str, worker: str) -> tuple[bool, str]:
+    escapes = []
+    for dp, _, fns in os.walk(root):
+        for fn in fns:
+            p = os.path.join(dp, fn)
+            if os.path.islink(p):
+                tgt = os.path.realpath(p)
+                if within(tgt, worker) or tgt.startswith("/tmp/neurodyn-"):
+                    escapes.append(f"{os.path.relpath(p, root)} -> {tgt}")
+    if escapes:
+        return False, f"symlink(s) dependem do worker scratch: {escapes}"
+    # artefatos-chave são arquivos regulares legíveis
+    keys = glob.glob(os.path.join(root, "rois", "*.1D")) + \
+           glob.glob(os.path.join(root, "pilot_*", "roi", "*.1D")) + \
+           glob.glob(os.path.join(root, "single_site_cv_test_results", "checkpoints", "*", "model.ckpt")) + \
+           [os.path.join(root, BUNDLE_NAME)]
+    for k in keys:
+        if os.path.exists(k) and not (os.path.isfile(k) and os.access(k, os.R_OK)):
+            return False, f"não legível como arquivo real: {os.path.relpath(k, root)}"
+    return True, "sem dependência de symlink no worker scratch; artefatos são arquivos reais legíveis"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Gate P3: orangefs_not_required_for_p3_roi_manifest")
+    ap.add_argument("artifact_root")
+    ap.add_argument("--worker-scratch", default=DEFAULT_WORKER_SCRATCH)
+    ap.add_argument("--emit-md", action="store_true")
+    ap.add_argument("--out-dir", default=None)
+    a = ap.parse_args()
+    root = os.path.abspath(a.artifact_root)
+    cls = detect_class(root)
+
+    c1p, c1d = check_artifact_landing(root, cls, a.worker_scratch)
+    c2p, c2i = check_stable_backing(root)
+    c3p, c3d = check_bundle_hash(root)
+    c4p, c4d = check_worker_survivability(root, a.worker_scratch)
+    all_pass = all([c1p, c2p, c3p, c4p])
+    decision = DECISION_PASS if all_pass else DECISION_FAIL
+
+    result = {
+        "schema": GATE_SCHEMA, "claim_boundary": CLAIM, "created_at_utc": now_utc(),
+        "artifact_root": root, "artifact_class": cls, "worker_scratch": a.worker_scratch,
+        "backing": {k: c2i.get(k) for k in ("device", "fstype", "mountpoint")},
+        "checks": {
+            "artifact_landing_path": {"pass": c1p, "detail": c1d},
+            "stable_backing_filesystem": {"pass": c2p, "detail": c2i.get("why")},
+            "bundle_inclusion_hash": {"pass": c3p, "detail": c3d},
+            "worker_loss_survivability": {"pass": c4p, "detail": c4d},
+        },
+        "all_pass": all_pass, "decision": decision,
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+    if a.emit_md:
+        od = a.out_dir or root
+        mark = lambda b: "✅" if b else "❌"
+        md = [f"# Gate: {DECISION_PASS}", "",
+              f"- **decisão:** `{decision}`  (`all_pass={all_pass}`)",
+              f"- **artifact_root:** `{root}`  (classe: `{cls}`)",
+              f"- **backing:** `{result['backing']['device']}` / `{result['backing']['fstype']}`",
+              f"- **claim boundary:** {CLAIM}", "", "| check | pass | detalhe |", "|---|---|---|"]
+        for k, v in result["checks"].items():
+            md.append(f"| {k} | {mark(v['pass'])} | {v['detail']} |")
+        try:
+            open(os.path.join(od, "neurodyn_orangefs_not_required_gate.md"), "w").write("\n".join(md) + "\n")
+        except Exception as e:
+            sys.stderr.write(f"[md] falha ao escrever: {e}\n")
+
+    sys.stderr.write(f"[gate] {decision}  (all_pass={all_pass}, classe={cls})\n")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orientation_cosine_margin_probe.py
+++ b/scripts/research/neurodyn_orientation_cosine_margin_probe.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Evaluate cosine-margin readouts over associator-sign-aligned hidden deltas."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_frozen_hidden_linear_readout import auroc, balanced_accuracy
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_orientation_topk_prototype import orientation, pair_id, parse_k_values, read_manifest
+
+
+SCHEMA = "neurodyn.orientation_cosine_margin_probe.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def unit(vec: list[float]) -> list[float]:
+    n = math.sqrt(sum(value * value for value in vec))
+    if n <= 1.0e-12:
+        return [0.0 for _ in vec]
+    return [value / n for value in vec]
+
+
+def masked_unit(vec: list[float], dims: list[int]) -> list[float]:
+    out = [0.0 for _ in vec]
+    for dim in dims:
+        out[dim] = vec[dim]
+    return unit(out)
+
+
+def dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b, strict=True))
+
+
+def mean_vec(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    return [sum(row[d] for row in vectors) / len(vectors) for d in range(dim)]
+
+
+def read_triple_meta(path: Path) -> dict[str, dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    return {f"assoc_pair_{int(row['pair_id']):04d}": row for row in rows}
+
+
+def subject_meta(reference_manifest: Path, triples: Path) -> dict[int, dict[str, str]]:
+    rows = read_manifest(reference_manifest)
+    triple_meta = read_triple_meta(triples)
+    out: dict[int, dict[str, str]] = {}
+    for idx, row in enumerate(rows):
+        pid = pair_id(row["subject_id"])
+        tm = triple_meta.get(pid)
+        if tm is None:
+            raise SystemExit(f"missing triple metadata for {pid}")
+        out[idx] = {
+            "subject_id": row["subject_id"],
+            "pair_id": pid,
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+            "assoc_dim": tm["assoc_dim"],
+            "assoc_sign": "1" if float(tm["positive_assoc_value"]) > 0.0 else "-1",
+            "triple": tm["triple"],
+        }
+    return out
+
+
+def collect_deltas(run: Path, condition: str, meta: dict[int, dict[str, str]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in parse_state_rows(run / "brain_ossm_abide.raw.txt"):
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        grouped[(row["model"], int(row["seed"]))][f"{m['pair_id']}::{m['orientation']}"] = {**row, **m}
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        for pid in sorted({v["pair_id"] for v in chunk.values()}):
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            assoc_sign = float(pos["assoc_sign"])
+            raw_delta = [a - b for a, b in zip(pos["h"], neg["h"], strict=True)]
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "assoc_dim": pos["assoc_dim"],
+                    "assoc_sign": pos["assoc_sign"],
+                    "triple": pos["triple"],
+                    "x": [assoc_sign * value for value in raw_delta],
+                }
+            )
+    return out
+
+
+def pair_number(pair_id_value: str) -> int:
+    return int(pair_id_value.rsplit("_", 1)[1])
+
+
+def train_threshold(scores: list[float]) -> float:
+    if not scores:
+        return 0.0
+    sorted_scores = sorted(scores)
+    candidates = [sorted_scores[0] - 1.0e-9, sorted_scores[-1] + 1.0e-9]
+    candidates.extend((a + b) / 2.0 for a, b in zip(sorted_scores, sorted_scores[1:]))
+    best = 0.0
+    best_acc = -1.0
+    for cand in candidates:
+        acc = sum(1 for score in scores if score >= cand) / len(scores)
+        if acc > best_acc:
+            best_acc = acc
+            best = cand
+    return best
+
+
+def fold_result(train: list[dict[str, Any]], test: list[dict[str, Any]], *, k: int, threshold_mode: str) -> dict[str, Any] | None:
+    if not train or not test:
+        return None
+    proto_full = unit(mean_vec([unit(row["x"]) for row in train]))
+    if not proto_full:
+        return None
+    dims = sorted(range(len(proto_full)), key=lambda idx: abs(proto_full[idx]), reverse=True)[: min(k, len(proto_full))]
+    proto = masked_unit(proto_full, dims)
+    train_scores = [dot(masked_unit(row["x"], dims), proto) for row in train]
+    test_scores = [dot(masked_unit(row["x"], dims), proto) for row in test]
+    threshold = train_threshold(train_scores) if threshold_mode == "train_max_acc" else 0.0
+    labels = [1 for _ in test_scores]
+    preds = [1 if score >= threshold else 0 for score in test_scores]
+    # A one-class aligned target has no balanced accuracy. Report aligned-hit rate
+    # as accuracy and use mean margin for continuous null envelopes.
+    hit = 100.0 * sum(preds) / len(preds) if preds else 0.0
+    return {
+        "rows": len(test_scores),
+        "aligned_hit_rate": hit,
+        "score_mean": mean(test_scores),
+        "score_std": pstdev(test_scores),
+        "threshold": threshold,
+        "train_score_mean": mean(train_scores),
+        "train_score_std": pstdev(train_scores),
+        "dims": ",".join(str(dim) for dim in dims),
+    }
+
+
+def evaluate(rows: list[dict[str, Any]], *, k_values: list[int], threshold_modes: list[str]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        for threshold_mode in threshold_modes:
+            for k in k_values:
+                for mode in ("global_pair_group_holdout", "leave_dim_global"):
+                    folds: list[tuple[str, list[dict[str, Any]], list[dict[str, Any]]]] = []
+                    if mode == "global_pair_group_holdout":
+                        for fold in range(7):
+                            folds.append(
+                                (
+                                    f"group_{fold}",
+                                    [row for row in chunk if pair_number(row["pair_id"]) % 7 != fold],
+                                    [row for row in chunk if pair_number(row["pair_id"]) % 7 == fold],
+                                )
+                            )
+                    else:
+                        for dim in sorted({row["assoc_dim"] for row in chunk}):
+                            folds.append(
+                                (
+                                    f"dim_{dim}",
+                                    [row for row in chunk if row["assoc_dim"] != dim],
+                                    [row for row in chunk if row["assoc_dim"] == dim],
+                                )
+                            )
+                    for fold_id, train, test in folds:
+                        result = fold_result(train, test, k=k, threshold_mode=threshold_mode)
+                        if result is None:
+                            continue
+                        detail.append(
+                            {
+                                "condition": condition,
+                                "model": model,
+                                "seed": seed,
+                                "threshold_mode": threshold_mode,
+                                "mode": mode,
+                                "k": k,
+                                "fold_id": fold_id,
+                                **result,
+                            }
+                        )
+    summary: list[dict[str, Any]] = []
+    by_key: dict[tuple[str, str, str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in detail:
+        by_key[(row["condition"], row["model"], row["threshold_mode"], row["mode"], int(row["k"]))].append(row)
+    for (condition, model, threshold_mode, mode, k), rows_for_key in sorted(by_key.items()):
+        summary.append(
+            {
+                "condition": condition,
+                "model": model,
+                "threshold_mode": threshold_mode,
+                "mode": mode,
+                "k": k,
+                "fold_count": len(rows_for_key),
+                "aligned_hit_rate_mean": mean([float(row["aligned_hit_rate"]) for row in rows_for_key]),
+                "aligned_hit_rate_std": pstdev([float(row["aligned_hit_rate"]) for row in rows_for_key]),
+                "score_mean": mean([float(row["score_mean"]) for row in rows_for_key]),
+                "score_std": pstdev([float(row["score_mean"]) for row in rows_for_key]),
+                "threshold_mean": mean([float(row["threshold"]) for row in rows_for_key]),
+            }
+        )
+    return detail, summary
+
+
+def null_envelope(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    keys = sorted({(row["model"], row["threshold_mode"], row["mode"], int(row["k"])) for row in summary})
+    for model, threshold_mode, mode, k in keys:
+        true = [
+            row for row in summary
+            if row["condition"] == "true"
+            and row["model"] == model
+            and row["threshold_mode"] == threshold_mode
+            and row["mode"] == mode
+            and int(row["k"]) == k
+        ]
+        nulls = [
+            row for row in summary
+            if row["condition"].startswith("null")
+            and row["model"] == model
+            and row["threshold_mode"] == threshold_mode
+            and row["mode"] == mode
+            and int(row["k"]) == k
+        ]
+        if not true or not nulls:
+            continue
+        for metric in ("aligned_hit_rate_mean", "score_mean"):
+            tv = float(true[0][metric])
+            vals = [float(row[metric]) for row in nulls]
+            ge = sum(1 for value in vals if value >= tv)
+            out.append(
+                {
+                    "model": model,
+                    "threshold_mode": threshold_mode,
+                    "mode": mode,
+                    "k": k,
+                    "metric": metric,
+                    "true": tv,
+                    "null_count": len(vals),
+                    "null_min": min(vals),
+                    "null_max": max(vals),
+                    "null_mean": mean(vals),
+                    "null_ge_true": ge,
+                    "plus_one_p_ge_true": (ge + 1.0) / (len(vals) + 1.0),
+                }
+            )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--associator-triples", required=True, type=Path)
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--models", default="O-SSM")
+    ap.add_argument("--k-values", default="1,2,4,8,16")
+    ap.add_argument("--threshold-modes", default="zero,train_max_acc")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "orientation_cosine_margin_summary.tsv").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+    meta = subject_meta(args.reference_manifest, args.associator_triples)
+    rows: list[dict[str, Any]] = []
+    runs = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        rows.extend(collect_deltas(run, condition, meta))
+        runs.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")})
+    if args.models.strip():
+        keep = {value.strip() for value in args.models.split(",") if value.strip()}
+        rows = [row for row in rows if row["model"] in keep]
+    k_values = parse_k_values(args.k_values)
+    threshold_modes = [value.strip() for value in args.threshold_modes.split(",") if value.strip()]
+    detail, summary = evaluate(rows, k_values=k_values, threshold_modes=threshold_modes)
+    envelope = null_envelope(summary)
+    write_tsv(out / "orientation_cosine_margin_detail.tsv", detail)
+    write_tsv(out / "orientation_cosine_margin_summary.tsv", summary)
+    write_tsv(out / "orientation_cosine_margin_null_envelope.tsv", envelope)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic sign-aligned cosine-margin probe only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "associator_triples": str(args.associator_triples),
+        "associator_triples_sha256": sha256_file(args.associator_triples),
+        "k_values": k_values,
+        "threshold_modes": threshold_modes,
+        "models": args.models,
+        "runs": runs,
+        "summary": summary,
+        "null_envelope": envelope,
+    }
+    (out / "orientation_cosine_margin.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = ["# Orientation Cosine Margin Probe", "", payload["claim_boundary"], ""]
+    for row in envelope:
+        md.append(
+            f"- `{row['model']}` `{row['threshold_mode']}` `{row['mode']}` k=`{row['k']}` `{row['metric']}`: "
+            f"true `{float(row['true']):.6f}`, null max `{float(row['null_max']):.6f}`, "
+            f"null_ge `{row['null_ge_true']}/{row['null_count']}`, p+1 `{float(row['plus_one_p_ge_true']):.6f}`"
+        )
+    md.append("")
+    (out / "orientation_cosine_margin.md").write_text("\n".join(md), encoding="utf-8")
+    sums = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orientation_delta_stability.py
+++ b/scripts/research/neurodyn_orientation_delta_stability.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Audit leave-site stability of original positive-negative hidden deltas."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+
+
+SCHEMA = "neurodyn.orientation_delta_stability.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")]
+    if not lines:
+        raise SystemExit(f"manifest has no rows: {path}")
+    return list(csv.DictReader(lines, delimiter="\t"))
+
+
+def pair_id(subject_id: str) -> str:
+    if "__" not in subject_id:
+        raise SystemExit(f"subject id lacks orientation suffix: {subject_id}")
+    return subject_id.split("__", 1)[0]
+
+
+def orientation(subject_id: str) -> str:
+    if subject_id.endswith("__positive"):
+        return "positive"
+    if subject_id.endswith("__negative"):
+        return "negative"
+    raise SystemExit(f"subject id lacks fixed-target suffix: {subject_id}")
+
+
+def dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b, strict=True))
+
+
+def norm(a: list[float]) -> float:
+    return math.sqrt(dot(a, a))
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    na = norm(a)
+    nb = norm(b)
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot(a, b) / (na * nb)
+
+
+def mean_vec(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    return [sum(v[d] for v in vectors) / len(vectors) for d in range(dim)]
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path, help="True fixed-orientation manifest.")
+    ap.add_argument("--run", action="append", required=True, type=Path, help="Run directory with brain_ossm_abide.raw.txt.")
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def build_subject_meta(reference_manifest: Path) -> dict[int, dict[str, str]]:
+    rows = read_manifest(reference_manifest)
+    return {
+        idx: {
+            "subject_id": row["subject_id"],
+            "pair_id": pair_id(row["subject_id"]),
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+        }
+        for idx, row in enumerate(rows)
+    }
+
+
+def collect_pair_deltas(run: Path, condition: str, subject_meta: dict[int, dict[str, str]]) -> list[dict[str, Any]]:
+    raw = run / "brain_ossm_abide.raw.txt"
+    state_rows = parse_state_rows(raw)
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in state_rows:
+        meta = subject_meta.get(int(row["subject_index"]))
+        if meta is None:
+            continue
+        key = (row["model"], int(row["seed"]))
+        grouped[key][f"{meta['pair_id']}::{meta['orientation']}"] = {**row, **meta}
+
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        pair_ids = sorted({value["pair_id"] for value in chunk.values()})
+        for pid in pair_ids:
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            delta = [a - b for a, b in zip(pos["h"], neg["h"], strict=True)]
+            out.append(
+                {
+                    "condition": condition,
+                    "run": str(run),
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "delta": delta,
+                    "delta_norm": norm(delta),
+                }
+            )
+    return out
+
+
+def summarize_condition(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    summary: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        correct = 0
+        total = 0
+        holdout_cosines: list[float] = []
+        for site in sites:
+            train = [row["delta"] for row in chunk if row["site"] != site]
+            test = [row for row in chunk if row["site"] == site]
+            direction = mean_vec(train)
+            if not direction:
+                continue
+            for row in test:
+                c = cosine(row["delta"], direction)
+                holdout_cosines.append(c)
+                if c > 0.0:
+                    correct += 1
+                total += 1
+        mean_delta = mean_vec([row["delta"] for row in chunk])
+        pairwise_cosines: list[float] = []
+        for i, left in enumerate(chunk):
+            for right in chunk[i + 1 :]:
+                pairwise_cosines.append(cosine(left["delta"], right["delta"]))
+        delta_norms = [float(row["delta_norm"]) for row in chunk]
+        seed_summary = {
+            "condition": condition,
+            "model": model,
+            "seed": seed,
+            "pair_count": len(chunk),
+            "delta_norm_mean": mean(delta_norms),
+            "mean_delta_norm": norm(mean_delta),
+            "mean_delta_norm_over_delta_norm": norm(mean_delta) / mean(delta_norms) if mean(delta_norms) > 0 else 0.0,
+            "pairwise_cosine_mean": mean(pairwise_cosines),
+            "pairwise_cosine_std": pstdev(pairwise_cosines),
+            "leave_site_delta_accuracy": 100.0 * correct / total if total else 0.0,
+            "leave_site_delta_cosine_mean": mean(holdout_cosines),
+            "leave_site_delta_cosine_std": pstdev(holdout_cosines),
+        }
+        summary.append(seed_summary)
+        for row in chunk:
+            detail.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": row["pair_id"],
+                    "site": row["site"],
+                    "delta_norm": row["delta_norm"],
+                }
+            )
+    return summary, detail
+
+
+def summarize_model(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        groups[(row["condition"], row["model"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model), rows in sorted(groups.items()):
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed_count": len(rows),
+                "leave_site_delta_accuracy_mean": mean([float(r["leave_site_delta_accuracy"]) for r in rows]),
+                "leave_site_delta_accuracy_std": pstdev([float(r["leave_site_delta_accuracy"]) for r in rows]),
+                "leave_site_delta_cosine_mean": mean([float(r["leave_site_delta_cosine_mean"]) for r in rows]),
+                "leave_site_delta_cosine_std": pstdev([float(r["leave_site_delta_cosine_mean"]) for r in rows]),
+                "pairwise_cosine_mean": mean([float(r["pairwise_cosine_mean"]) for r in rows]),
+                "mean_delta_norm_over_delta_norm_mean": mean([float(r["mean_delta_norm_over_delta_norm"]) for r in rows]),
+                "delta_norm_mean": mean([float(r["delta_norm_mean"]) for r in rows]),
+            }
+        )
+    return out
+
+
+def null_envelope(model_summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for model in sorted({row["model"] for row in model_summary}):
+        true_rows = [row for row in model_summary if row["condition"] == "true" and row["model"] == model]
+        null_rows = [row for row in model_summary if row["condition"].startswith("null") and row["model"] == model]
+        if not true_rows or not null_rows:
+            continue
+        true = true_rows[0]
+        for metric in ("leave_site_delta_accuracy_mean", "leave_site_delta_cosine_mean", "pairwise_cosine_mean", "mean_delta_norm_over_delta_norm_mean"):
+            t = float(true[metric])
+            vals = [float(row[metric]) for row in null_rows]
+            ge = sum(1 for v in vals if v >= t)
+            out.append(
+                {
+                    "model": model,
+                    "metric": metric,
+                    "true": t,
+                    "null_count": len(vals),
+                    "null_min": min(vals),
+                    "null_max": max(vals),
+                    "null_mean": mean(vals),
+                    "null_ge_true": ge,
+                    "plus_one_p_ge_true": (ge + 1.0) / (len(vals) + 1.0),
+                }
+            )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "orientation_delta_stability_summary.tsv"
+    if summary_path.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+
+    subject_meta = build_subject_meta(args.reference_manifest)
+    all_pair_rows: list[dict[str, Any]] = []
+    run_meta = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        all_pair_rows.extend(collect_pair_deltas(run, condition, subject_meta))
+        raw = run / "brain_ossm_abide.raw.txt"
+        run_meta.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(raw)})
+    seed_rows, detail_rows = summarize_condition(all_pair_rows)
+    model_summary = summarize_model(seed_rows)
+    envelope = null_envelope(model_summary)
+
+    write_tsv(summary_path, model_summary)
+    write_tsv(args.output_dir / "orientation_delta_stability_seed_detail.tsv", seed_rows)
+    write_tsv(args.output_dir / "orientation_delta_stability_pair_detail.tsv", detail_rows)
+    write_tsv(args.output_dir / "orientation_delta_stability_null_envelope.tsv", envelope)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic original-orientation hidden-delta stability diagnostic only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "runs": run_meta,
+        "model_summary": model_summary,
+        "null_envelope": envelope,
+    }
+    (args.output_dir / "orientation_delta_stability.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = ["# Orientation Delta Stability", "", payload["claim_boundary"], ""]
+    for row in model_summary:
+        md.append(
+            f"- `{row['condition']}` `{row['model']}` leave-site delta accuracy: "
+            f"`{float(row['leave_site_delta_accuracy_mean']):.6f}`; cosine: "
+            f"`{float(row['leave_site_delta_cosine_mean']):.6f}`"
+        )
+    md.append("")
+    for row in envelope:
+        md.append(
+            f"- envelope `{row['model']}` `{row['metric']}`: true `{float(row['true']):.6f}`, "
+            f"null max `{float(row['null_max']):.6f}`, null_ge `{row['null_ge_true']}/{row['null_count']}`, "
+            f"p+1 `{float(row['plus_one_p_ge_true']):.6f}`"
+        )
+    md.append("")
+    (args.output_dir / "orientation_delta_stability.md").write_text("\n".join(md), encoding="utf-8")
+    sums = []
+    for path in sorted(args.output_dir.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (args.output_dir / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orientation_dim_prototype.py
+++ b/scripts/research/neurodyn_orientation_dim_prototype.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Evaluate associator-dimension conditioned prototype orientation readouts."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_orientation_topk_prototype import (
+    cosine_masked,
+    mean_vec,
+    orientation,
+    pair_id,
+    parse_k_values,
+    read_manifest,
+)
+
+
+SCHEMA = "neurodyn.orientation_dim_prototype.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--associator-triples", required=True, type=Path)
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--k-values", default="1,2,4,8,16")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def read_triple_meta(path: Path) -> dict[str, dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    out: dict[str, dict[str, str]] = {}
+    for row in rows:
+        key = f"assoc_pair_{int(row['pair_id']):04d}"
+        out[key] = row
+    return out
+
+
+def subject_meta(reference_manifest: Path, triples: Path) -> dict[int, dict[str, str]]:
+    rows = read_manifest(reference_manifest)
+    triple_meta = read_triple_meta(triples)
+    out: dict[int, dict[str, str]] = {}
+    for idx, row in enumerate(rows):
+        pid = pair_id(row["subject_id"])
+        tm = triple_meta.get(pid)
+        if tm is None:
+            raise SystemExit(f"missing associator triple metadata for {pid}")
+        out[idx] = {
+            "subject_id": row["subject_id"],
+            "pair_id": pid,
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+            "assoc_dim": tm["assoc_dim"],
+            "assoc_sign": "1" if float(tm["positive_assoc_value"]) > 0.0 else "-1",
+            "triple": tm["triple"],
+        }
+    return out
+
+
+def collect_deltas(run: Path, condition: str, meta: dict[int, dict[str, str]]) -> list[dict[str, Any]]:
+    raw = run / "brain_ossm_abide.raw.txt"
+    state_rows = parse_state_rows(raw)
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in state_rows:
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        grouped[(row["model"], int(row["seed"]))][f"{m['pair_id']}::{m['orientation']}"] = {**row, **m}
+
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        for pid in sorted({v["pair_id"] for v in chunk.values()}):
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            raw_delta = [a - b for a, b in zip(pos["h"], neg["h"], strict=True)]
+            assoc_sign = float(pos["assoc_sign"])
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "assoc_dim": pos["assoc_dim"],
+                    "assoc_sign": pos["assoc_sign"],
+                    "triple": pos["triple"],
+                    "raw_delta": raw_delta,
+                    "aligned_delta": [assoc_sign * value for value in raw_delta],
+                }
+            )
+    return out
+
+
+def score_rows(
+    *,
+    chunk: list[dict[str, Any]],
+    k: int,
+    mode: str,
+    basis: str,
+    condition: str,
+    model: str,
+    seed: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    correct = 0
+    total = 0
+    scores: list[float] = []
+    detail: list[dict[str, Any]] = []
+    dims_all = sorted({row["assoc_dim"] for row in chunk})
+
+    for row in chunk:
+        delta_key = "aligned_delta" if basis == "assoc_sign_aligned" else "raw_delta"
+        if mode == "global_pair_holdout":
+            train = [r[delta_key] for r in chunk if r["pair_id"] != row["pair_id"]]
+            family = "global"
+        elif mode == "within_dim_pair_holdout":
+            train = [
+                r[delta_key]
+                for r in chunk
+                if r["assoc_dim"] == row["assoc_dim"] and r["pair_id"] != row["pair_id"]
+            ]
+            family = f"dim_{row['assoc_dim']}"
+        elif mode == "leave_dim_global":
+            train = [r[delta_key] for r in chunk if r["assoc_dim"] != row["assoc_dim"]]
+            family = "not_" + f"dim_{row['assoc_dim']}"
+        else:
+            raise ValueError(mode)
+        proto = mean_vec(train)
+        if not proto:
+            continue
+        top_dims = sorted(range(len(proto)), key=lambda d: abs(proto[d]), reverse=True)[: min(k, len(proto))]
+        score = cosine_masked(row[delta_key], proto, top_dims)
+        scores.append(score)
+        if score > 0.0:
+            correct += 1
+        total += 1
+        detail.append(
+            {
+                "condition": condition,
+                "model": model,
+                "seed": seed,
+                "mode": mode,
+                "basis": basis,
+                "k": k,
+                "pair_id": row["pair_id"],
+                "assoc_dim": row["assoc_dim"],
+                "assoc_sign": row["assoc_sign"],
+                "prototype_family": family,
+                "score": score,
+                "correct": 1 if score > 0.0 else 0,
+                "dims": ",".join(str(d) for d in top_dims),
+            }
+        )
+
+    return (
+        {
+            "condition": condition,
+            "model": model,
+            "seed": seed,
+            "mode": mode,
+            "basis": basis,
+            "k": k,
+            "pair_count": total,
+            "assoc_dim_count": len(dims_all),
+            "accuracy": 100.0 * correct / total if total else 0.0,
+            "score_mean": mean(scores),
+            "score_std": pstdev(scores),
+        },
+        detail,
+    )
+
+
+def evaluate(rows: list[dict[str, Any]], k_values: list[int]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    seed_rows: list[dict[str, Any]] = []
+    detail: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    modes = ["global_pair_holdout", "within_dim_pair_holdout", "leave_dim_global"]
+    bases = ["raw_orientation", "assoc_sign_aligned"]
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        for basis in bases:
+            for mode in modes:
+                for k in k_values:
+                    seed_row, seed_detail = score_rows(
+                        chunk=chunk,
+                        k=k,
+                        mode=mode,
+                        basis=basis,
+                        condition=condition,
+                        model=model,
+                        seed=seed,
+                    )
+                    seed_rows.append(seed_row)
+                    detail.extend(seed_detail)
+    return seed_rows, detail
+
+
+def summarize(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str, str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        groups[(row["condition"], row["model"], row["basis"], row["mode"], int(row["k"]))].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model, basis, mode, k), rows in sorted(groups.items()):
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "basis": basis,
+                "mode": mode,
+                "k": k,
+                "seed_count": len(rows),
+                "pair_count_mean": mean([float(r["pair_count"]) for r in rows]),
+                "accuracy_mean": mean([float(r["accuracy"]) for r in rows]),
+                "accuracy_std": pstdev([float(r["accuracy"]) for r in rows]),
+                "score_mean": mean([float(r["score_mean"]) for r in rows]),
+                "score_std": pstdev([float(r["score_mean"]) for r in rows]),
+            }
+        )
+    return out
+
+
+def null_envelope(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    models = sorted({row["model"] for row in summary})
+    bases = sorted({row["basis"] for row in summary})
+    modes = sorted({row["mode"] for row in summary})
+    ks = sorted({int(row["k"]) for row in summary})
+    for model in models:
+        for basis in bases:
+            for mode in modes:
+                for k in ks:
+                    true = [
+                        row
+                        for row in summary
+                        if row["condition"] == "true"
+                        and row["model"] == model
+                        and row["basis"] == basis
+                        and row["mode"] == mode
+                        and int(row["k"]) == k
+                    ]
+                    nulls = [
+                        row
+                        for row in summary
+                        if row["condition"].startswith("null")
+                        and row["model"] == model
+                        and row["basis"] == basis
+                        and row["mode"] == mode
+                        and int(row["k"]) == k
+                    ]
+                    if not true or not nulls:
+                        continue
+                    t = true[0]
+                    for metric in ("accuracy_mean", "score_mean"):
+                        tv = float(t[metric])
+                        vals = [float(row[metric]) for row in nulls]
+                        ge = sum(1 for v in vals if v >= tv)
+                        out.append(
+                            {
+                                "model": model,
+                                "basis": basis,
+                                "mode": mode,
+                                "k": k,
+                                "metric": metric,
+                                "true": tv,
+                                "null_count": len(vals),
+                                "null_min": min(vals),
+                                "null_max": max(vals),
+                                "null_mean": mean(vals),
+                                "null_ge_true": ge,
+                                "plus_one_p_ge_true": (ge + 1.0) / (len(vals) + 1.0),
+                            }
+                        )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "orientation_dim_prototype_summary.tsv").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+
+    meta = subject_meta(args.reference_manifest, args.associator_triples)
+    k_values = parse_k_values(args.k_values)
+    all_rows: list[dict[str, Any]] = []
+    runs = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        all_rows.extend(collect_deltas(run, condition, meta))
+        runs.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")})
+
+    seed_rows, detail = evaluate(all_rows, k_values)
+    summary = summarize(seed_rows)
+    envelope = null_envelope(summary)
+
+    write_tsv(out / "orientation_dim_prototype_seed_detail.tsv", seed_rows)
+    write_tsv(out / "orientation_dim_prototype_pair_detail.tsv", detail)
+    write_tsv(out / "orientation_dim_prototype_summary.tsv", summary)
+    write_tsv(out / "orientation_dim_prototype_null_envelope.tsv", envelope)
+
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic associator-dimension prototype diagnostic only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "associator_triples": str(args.associator_triples),
+        "associator_triples_sha256": sha256_file(args.associator_triples),
+        "k_values": k_values,
+        "runs": runs,
+        "summary": summary,
+        "null_envelope": envelope,
+    }
+    (out / "orientation_dim_prototype.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    md = ["# Orientation Dimension Prototype", "", payload["claim_boundary"], ""]
+    for row in envelope:
+        md.append(
+            f"- `{row['model']}` `{row['basis']}` `{row['mode']}` k=`{row['k']}` `{row['metric']}`: "
+            f"true `{float(row['true']):.6f}`, null max `{float(row['null_max']):.6f}`, "
+            f"null_ge `{row['null_ge_true']}/{row['null_count']}`, "
+            f"p+1 `{float(row['plus_one_p_ge_true']):.6f}`"
+        )
+    md.append("")
+    (out / "orientation_dim_prototype.md").write_text("\n".join(md), encoding="utf-8")
+
+    sums = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orientation_head_trace_summary.py
+++ b/scripts/research/neurodyn_orientation_head_trace_summary.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Summarize ORIENT_HEAD_TRACE rows from Brain O-SSM synthetic runs."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from pathlib import Path
+
+
+def bp_to_pct(v: str) -> float:
+    return int(v) / 10000.0
+
+
+def bp_to_unit(v: str) -> float:
+    return int(v) / 1_000_000.0
+
+
+def mean(values: list[float]) -> float:
+    return statistics.fmean(values) if values else 0.0
+
+
+def stdev(values: list[float]) -> float:
+    return statistics.pstdev(values) if len(values) > 1 else 0.0
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_rows(raw_output: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    current: list[str] | None = None
+
+    def flush(parts: list[str] | None) -> None:
+        if not parts or len(parts) != 12:
+            return
+        rows.append(
+            {
+                "model": parts[1],
+                "seed_a": int(parts[2]),
+                "seed_b": int(parts[3]),
+                "holdout_key": int(parts[4]),
+                "holdout_site": parts[5],
+                "train_pairs": int(parts[6]),
+                "train_orientation_accuracy_pct": bp_to_pct(parts[7]),
+                "train_orientation_margin": bp_to_unit(parts[8]),
+                "holdout_pairs": int(parts[9]),
+                "holdout_orientation_accuracy_pct": bp_to_pct(parts[10]),
+                "holdout_orientation_margin": bp_to_unit(parts[11]),
+            }
+        )
+
+    with raw_output.open("r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line.startswith("ORIENT_HEAD_TRACE\t"):
+                flush(current)
+                current = line.split("\t")
+                continue
+            if current is not None and line.startswith("\t"):
+                current.extend(line.lstrip("\t").split("\t"))
+                continue
+            flush(current)
+            current = None
+    flush(current)
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--raw-output", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    if args.output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = parse_rows(args.raw_output)
+    if not rows:
+        raise SystemExit("no ORIENT_HEAD_TRACE rows found")
+
+    summary = {
+        "schema": "neurodyn.orientation_head_trace_summary.v1",
+        "raw_output": str(args.raw_output),
+        "raw_output_sha256": sha256_file(args.raw_output),
+        "row_count": len(rows),
+        "seed_fold_count": len(rows),
+        "train_orientation_accuracy_pct_mean": mean([float(r["train_orientation_accuracy_pct"]) for r in rows]),
+        "train_orientation_accuracy_pct_std": stdev([float(r["train_orientation_accuracy_pct"]) for r in rows]),
+        "train_orientation_margin_mean": mean([float(r["train_orientation_margin"]) for r in rows]),
+        "train_orientation_margin_std": stdev([float(r["train_orientation_margin"]) for r in rows]),
+        "holdout_orientation_accuracy_pct_mean": mean([float(r["holdout_orientation_accuracy_pct"]) for r in rows]),
+        "holdout_orientation_accuracy_pct_std": stdev([float(r["holdout_orientation_accuracy_pct"]) for r in rows]),
+        "holdout_orientation_margin_mean": mean([float(r["holdout_orientation_margin"]) for r in rows]),
+        "holdout_orientation_margin_std": stdev([float(r["holdout_orientation_margin"]) for r in rows]),
+    }
+
+    detail_path = args.output_dir / "orientation_head_trace_detail.tsv"
+    with detail_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    summary_path = args.output_dir / "orientation_head_trace_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    md = [
+        "# Orientation Head Trace Summary",
+        "",
+        "Claim boundary: synthetic orientation-head diagnostic only. This is not clinical, biomarker, mechanistic, null-validated, or broad O-SSM evidence.",
+        "",
+        f"- rows: `{summary['row_count']}`",
+        f"- train orientation accuracy mean: `{summary['train_orientation_accuracy_pct_mean']:.6f}`",
+        f"- train orientation margin mean: `{summary['train_orientation_margin_mean']:.6f}`",
+        f"- holdout orientation accuracy mean: `{summary['holdout_orientation_accuracy_pct_mean']:.6f}`",
+        f"- holdout orientation margin mean: `{summary['holdout_orientation_margin_mean']:.6f}`",
+        "",
+    ]
+    (args.output_dir / "orientation_head_trace_summary.md").write_text("\n".join(md), encoding="utf-8")
+
+    sums = []
+    for path in (summary_path, detail_path, args.output_dir / "orientation_head_trace_summary.md"):
+        sums.append(f"{sha256_file(path)}  {path.name}")
+    (args.output_dir / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orientation_sign_readout_probe.py
+++ b/scripts/research/neurodyn_orientation_sign_readout_probe.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Probe hidden pair deltas with a sign-aligned logistic readout."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_frozen_hidden_linear_readout import auroc, balanced_accuracy, predict, train_logistic, zscore
+from neurodyn_hidden_state_separability import parse_state_rows
+from neurodyn_orientation_topk_prototype import orientation, pair_id, read_manifest
+
+
+SCHEMA = "neurodyn.orientation_sign_readout_probe.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def read_triple_meta(path: Path) -> dict[str, dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, delimiter="\t"))
+    return {f"assoc_pair_{int(row['pair_id']):04d}": row for row in rows}
+
+
+def subject_meta(reference_manifest: Path, triples: Path) -> dict[int, dict[str, str]]:
+    rows = read_manifest(reference_manifest)
+    triple_meta = read_triple_meta(triples)
+    out: dict[int, dict[str, str]] = {}
+    for idx, row in enumerate(rows):
+        pid = pair_id(row["subject_id"])
+        tm = triple_meta.get(pid)
+        if tm is None:
+            raise SystemExit(f"missing triple metadata for {pid}")
+        out[idx] = {
+            "subject_id": row["subject_id"],
+            "pair_id": pid,
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+            "assoc_dim": tm["assoc_dim"],
+            "assoc_sign_label": "1" if float(tm["positive_assoc_value"]) > 0.0 else "0",
+            "triple": tm["triple"],
+        }
+    return out
+
+
+def collect_pair_deltas(run: Path, condition: str, meta: dict[int, dict[str, str]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in parse_state_rows(run / "brain_ossm_abide.raw.txt"):
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        grouped[(row["model"], int(row["seed"]))][f"{m['pair_id']}::{m['orientation']}"] = {**row, **m}
+
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        for pid in sorted({v["pair_id"] for v in chunk.values()}):
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "assoc_dim": pos["assoc_dim"],
+                    "triple": pos["triple"],
+                    "label": int(pos["assoc_sign_label"]),
+                    "x": [a - b for a, b in zip(pos["h"], neg["h"], strict=True)],
+                }
+            )
+    return out
+
+
+def fit_predict(train: list[dict[str, Any]], test: list[dict[str, Any]], *, l2: float, epochs: int, lr: float) -> dict[str, Any] | None:
+    y_train = [int(row["label"]) for row in train]
+    y_test = [int(row["label"]) for row in test]
+    if len(set(y_train)) < 2 or len(set(y_test)) < 2:
+        return None
+    x_train_raw = [row["x"] for row in train]
+    x_test_raw = [row["x"] for row in test]
+    x_train, _, _ = zscore(x_train_raw, x_train_raw)
+    x_test, _, _ = zscore(x_train_raw, x_test_raw)
+    w, b = train_logistic(x_train, y_train, l2=l2, epochs=epochs, lr=lr)
+    preds, scores = predict(w, b, x_test)
+    return {
+        "rows": len(test),
+        "balanced_accuracy": balanced_accuracy(y_test, preds),
+        "accuracy": 100.0 * sum(1 for a, p in zip(y_test, preds, strict=True) if a == p) / len(y_test),
+        "auroc": auroc(y_test, scores),
+        "score_mean": mean(scores),
+        "score_std": pstdev(scores),
+        "positive_pred_frac": mean([1.0 if pred == 1 else 0.0 for pred in preds]),
+        "weight_norm": math.sqrt(sum(value * value for value in w)),
+    }
+
+
+def pair_number(pair_id_value: str) -> int:
+    return int(pair_id_value.rsplit("_", 1)[1])
+
+
+def evaluate(
+    rows: list[dict[str, Any]],
+    *,
+    l2_values: list[float],
+    epochs: int,
+    lr: float,
+    global_folds: int,
+    within_dim_folds: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        for l2 in l2_values:
+            for mode in ("global_pair_group_holdout", "within_dim_group_holdout", "leave_dim_global"):
+                folds: list[tuple[str, list[dict[str, Any]], list[dict[str, Any]]]] = []
+                if mode == "global_pair_group_holdout":
+                    for fold in range(global_folds):
+                        test = [row for row in chunk if pair_number(row["pair_id"]) % global_folds == fold]
+                        train = [row for row in chunk if pair_number(row["pair_id"]) % global_folds != fold]
+                        folds.append((f"group_{fold}", train, test))
+                elif mode == "within_dim_group_holdout":
+                    for dim in sorted({row["assoc_dim"] for row in chunk}):
+                        dim_rows = [row for row in chunk if row["assoc_dim"] == dim]
+                        for fold in range(within_dim_folds):
+                            test = [row for row in dim_rows if (pair_number(row["pair_id"]) // 7) % within_dim_folds == fold]
+                            train = [row for row in dim_rows if (pair_number(row["pair_id"]) // 7) % within_dim_folds != fold]
+                            if train and test:
+                                folds.append((f"dim_{dim}_group_{fold}", train, test))
+                elif mode == "leave_dim_global":
+                    for dim in sorted({row["assoc_dim"] for row in chunk}):
+                        folds.append((f"dim_{dim}", [row for row in chunk if row["assoc_dim"] != dim], [row for row in chunk if row["assoc_dim"] == dim]))
+                for fold_id, train, test in folds:
+                    result = fit_predict(train, test, l2=l2, epochs=epochs, lr=lr)
+                    if result is None:
+                        continue
+                    detail.append(
+                        {
+                            "condition": condition,
+                            "model": model,
+                            "seed": seed,
+                            "l2": l2,
+                            "mode": mode,
+                            "fold_id": fold_id,
+                            **result,
+                        }
+                    )
+
+    summary: list[dict[str, Any]] = []
+    by_key: dict[tuple[str, str, float, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in detail:
+        by_key[(row["condition"], row["model"], float(row["l2"]), row["mode"])].append(row)
+    for (condition, model, l2, mode), rows_for_key in sorted(by_key.items()):
+        summary.append(
+            {
+                "condition": condition,
+                "model": model,
+                "l2": l2,
+                "mode": mode,
+                "fold_count": len(rows_for_key),
+                "balanced_accuracy_mean": mean([float(row["balanced_accuracy"]) for row in rows_for_key]),
+                "balanced_accuracy_std": pstdev([float(row["balanced_accuracy"]) for row in rows_for_key]),
+                "accuracy_mean": mean([float(row["accuracy"]) for row in rows_for_key]),
+                "accuracy_std": pstdev([float(row["accuracy"]) for row in rows_for_key]),
+                "auroc_mean": mean([float(row["auroc"]) for row in rows_for_key]),
+                "auroc_std": pstdev([float(row["auroc"]) for row in rows_for_key]),
+                "weight_norm_mean": mean([float(row["weight_norm"]) for row in rows_for_key]),
+            }
+        )
+    return detail, summary
+
+
+def null_envelope(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    keys = sorted({(row["model"], float(row["l2"]), row["mode"]) for row in summary})
+    for model, l2, mode in keys:
+        true = [row for row in summary if row["condition"] == "true" and row["model"] == model and float(row["l2"]) == l2 and row["mode"] == mode]
+        nulls = [row for row in summary if row["condition"].startswith("null") and row["model"] == model and float(row["l2"]) == l2 and row["mode"] == mode]
+        if not true or not nulls:
+            continue
+        for metric in ("balanced_accuracy_mean", "accuracy_mean", "auroc_mean"):
+            tv = float(true[0][metric])
+            vals = [float(row[metric]) for row in nulls]
+            ge = sum(1 for value in vals if value >= tv)
+            out.append(
+                {
+                    "model": model,
+                    "l2": l2,
+                    "mode": mode,
+                    "metric": metric,
+                    "true": tv,
+                    "null_count": len(vals),
+                    "null_min": min(vals),
+                    "null_max": max(vals),
+                    "null_mean": mean(vals),
+                    "null_ge_true": ge,
+                    "plus_one_p_ge_true": (ge + 1.0) / (len(vals) + 1.0),
+                }
+            )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--associator-triples", required=True, type=Path)
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--l2", default="0.01,0.1,1.0,10.0")
+    ap.add_argument("--epochs", type=int, default=600)
+    ap.add_argument("--lr", type=float, default=0.05)
+    ap.add_argument("--global-folds", type=int, default=7)
+    ap.add_argument("--within-dim-folds", type=int, default=4)
+    ap.add_argument("--models", default="", help="Optional comma-separated model filter, e.g. O-SSM")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "orientation_sign_readout_summary.tsv").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+
+    meta = subject_meta(args.reference_manifest, args.associator_triples)
+    rows: list[dict[str, Any]] = []
+    runs = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        rows.extend(collect_pair_deltas(run, condition, meta))
+        runs.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")})
+    if args.models.strip():
+        keep = {value.strip() for value in args.models.split(",") if value.strip()}
+        rows = [row for row in rows if row["model"] in keep]
+        if not rows:
+            raise SystemExit(f"no rows left after --models={args.models!r}")
+    l2_values = [float(value) for value in args.l2.split(",") if value.strip()]
+    detail, summary = evaluate(
+        rows,
+        l2_values=l2_values,
+        epochs=args.epochs,
+        lr=args.lr,
+        global_folds=args.global_folds,
+        within_dim_folds=args.within_dim_folds,
+    )
+    envelope = null_envelope(summary)
+
+    write_tsv(out / "orientation_sign_readout_detail.tsv", detail)
+    write_tsv(out / "orientation_sign_readout_summary.tsv", summary)
+    write_tsv(out / "orientation_sign_readout_null_envelope.tsv", envelope)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic sign-aligned hidden-delta readout probe only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "associator_triples": str(args.associator_triples),
+        "associator_triples_sha256": sha256_file(args.associator_triples),
+        "l2_values": l2_values,
+        "epochs": args.epochs,
+        "lr": args.lr,
+        "global_folds": args.global_folds,
+        "within_dim_folds": args.within_dim_folds,
+        "models": args.models,
+        "runs": runs,
+        "summary": summary,
+        "null_envelope": envelope,
+    }
+    (out / "orientation_sign_readout.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = ["# Orientation Sign Readout Probe", "", payload["claim_boundary"], ""]
+    for row in envelope:
+        md.append(
+            f"- `{row['model']}` `{row['mode']}` l2=`{row['l2']}` `{row['metric']}`: "
+            f"true `{float(row['true']):.6f}`, null max `{float(row['null_max']):.6f}`, "
+            f"null_ge `{row['null_ge_true']}/{row['null_count']}`, p+1 `{float(row['plus_one_p_ge_true']):.6f}`"
+        )
+    md.append("")
+    (out / "orientation_sign_readout.md").write_text("\n".join(md), encoding="utf-8")
+    sums = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_orientation_topk_prototype.py
+++ b/scripts/research/neurodyn_orientation_topk_prototype.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Evaluate top-k prototype orientation decisions from hidden pair deltas."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+
+
+SCHEMA = "neurodyn.orientation_topk_prototype.v1"
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line and not line.startswith("#")]
+    if not lines:
+        raise SystemExit(f"manifest has no rows: {path}")
+    return list(csv.DictReader(lines, delimiter="\t"))
+
+
+def pair_id(subject_id: str) -> str:
+    if "__" not in subject_id:
+        raise SystemExit(f"subject id lacks pair suffix: {subject_id}")
+    return subject_id.split("__", 1)[0]
+
+
+def orientation(subject_id: str) -> str:
+    if subject_id.endswith("__positive"):
+        return "positive"
+    if subject_id.endswith("__negative"):
+        return "negative"
+    raise SystemExit(f"subject id lacks orientation suffix: {subject_id}")
+
+
+def dot_masked(a: list[float], b: list[float], dims: list[int]) -> float:
+    return sum(a[d] * b[d] for d in dims)
+
+
+def norm_masked(a: list[float], dims: list[int]) -> float:
+    return math.sqrt(sum(a[d] * a[d] for d in dims))
+
+
+def cosine_masked(a: list[float], b: list[float], dims: list[int]) -> float:
+    na = norm_masked(a, dims)
+    nb = norm_masked(b, dims)
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return dot_masked(a, b, dims) / (na * nb)
+
+
+def mean_vec(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    return [sum(v[d] for v in vectors) / len(vectors) for d in range(dim)]
+
+
+def mean(xs: list[float]) -> float:
+    return statistics.fmean(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def parse_k_values(text: str) -> list[int]:
+    vals = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        vals.append(int(part))
+    return vals
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--reference-manifest", required=True, type=Path)
+    ap.add_argument("--run", action="append", required=True, type=Path)
+    ap.add_argument("--condition", action="append", required=True)
+    ap.add_argument("--k-values", default="1,2,4,8,16")
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    return ap.parse_args()
+
+
+def subject_meta(reference_manifest: Path) -> dict[int, dict[str, str]]:
+    rows = read_manifest(reference_manifest)
+    return {
+        idx: {
+            "subject_id": row["subject_id"],
+            "pair_id": pair_id(row["subject_id"]),
+            "orientation": orientation(row["subject_id"]),
+            "site": row["site"],
+        }
+        for idx, row in enumerate(rows)
+    }
+
+
+def collect_deltas(run: Path, condition: str, meta: dict[int, dict[str, str]]) -> list[dict[str, Any]]:
+    raw = run / "brain_ossm_abide.raw.txt"
+    state_rows = parse_state_rows(raw)
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in state_rows:
+        m = meta.get(int(row["subject_index"]))
+        if m is None:
+            continue
+        grouped[(row["model"], int(row["seed"]))][f"{m['pair_id']}::{m['orientation']}"] = {**row, **m}
+
+    out: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        for pid in sorted({v["pair_id"] for v in chunk.values()}):
+            pos = chunk.get(f"{pid}::positive")
+            neg = chunk.get(f"{pid}::negative")
+            if pos is None or neg is None:
+                continue
+            out.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": pos["site"],
+                    "delta": [a - b for a, b in zip(pos["h"], neg["h"], strict=True)],
+                }
+            )
+    return out
+
+
+def evaluate(rows: list[dict[str, Any]], k_values: list[int]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    seed_rows: list[dict[str, Any]] = []
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        groups[(row["condition"], row["model"], int(row["seed"]))].append(row)
+
+    for (condition, model, seed), chunk in sorted(groups.items()):
+        sites = sorted({row["site"] for row in chunk})
+        for k in k_values:
+            correct = 0
+            total = 0
+            scores: list[float] = []
+            for site in sites:
+                train = [row["delta"] for row in chunk if row["site"] != site]
+                test = [row for row in chunk if row["site"] == site]
+                proto = mean_vec(train)
+                if not proto:
+                    continue
+                dims = sorted(range(len(proto)), key=lambda d: abs(proto[d]), reverse=True)[: min(k, len(proto))]
+                for row in test:
+                    score = cosine_masked(row["delta"], proto, dims)
+                    scores.append(score)
+                    if score > 0.0:
+                        correct += 1
+                    total += 1
+                    detail.append(
+                        {
+                            "condition": condition,
+                            "model": model,
+                            "seed": seed,
+                            "k": k,
+                            "holdout_site": site,
+                            "pair_id": row["pair_id"],
+                            "score": score,
+                            "correct": 1 if score > 0.0 else 0,
+                            "dims": ",".join(str(d) for d in dims),
+                        }
+                    )
+            seed_rows.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "k": k,
+                    "pair_count": total,
+                    "accuracy": 100.0 * correct / total if total else 0.0,
+                    "score_mean": mean(scores),
+                    "score_std": pstdev(scores),
+                }
+            )
+    return seed_rows, detail
+
+
+def model_summary(seed_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in seed_rows:
+        groups[(row["condition"], row["model"], int(row["k"]))].append(row)
+    out: list[dict[str, Any]] = []
+    for (condition, model, k), rows in sorted(groups.items()):
+        out.append(
+            {
+                "condition": condition,
+                "model": model,
+                "k": k,
+                "seed_count": len(rows),
+                "accuracy_mean": mean([float(r["accuracy"]) for r in rows]),
+                "accuracy_std": pstdev([float(r["accuracy"]) for r in rows]),
+                "score_mean": mean([float(r["score_mean"]) for r in rows]),
+                "score_std": pstdev([float(r["score_mean"]) for r in rows]),
+            }
+        )
+    return out
+
+
+def null_envelope(summary: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for model in sorted({row["model"] for row in summary}):
+        for k in sorted({int(row["k"]) for row in summary}):
+            true = [row for row in summary if row["condition"] == "true" and row["model"] == model and int(row["k"]) == k]
+            nulls = [row for row in summary if row["condition"].startswith("null") and row["model"] == model and int(row["k"]) == k]
+            if not true or not nulls:
+                continue
+            t = true[0]
+            for metric in ("accuracy_mean", "score_mean"):
+                tv = float(t[metric])
+                vals = [float(row[metric]) for row in nulls]
+                ge = sum(1 for v in vals if v >= tv)
+                out.append(
+                    {
+                        "model": model,
+                        "k": k,
+                        "metric": metric,
+                        "true": tv,
+                        "null_count": len(vals),
+                        "null_min": min(vals),
+                        "null_max": max(vals),
+                        "null_mean": mean(vals),
+                        "null_ge_true": ge,
+                        "plus_one_p_ge_true": (ge + 1.0) / (len(vals) + 1.0),
+                    }
+                )
+    return out
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.run) != len(args.condition):
+        raise SystemExit("--run and --condition counts differ")
+    out = args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if (out / "orientation_topk_prototype_summary.tsv").exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {out}")
+    k_values = parse_k_values(args.k_values)
+    meta = subject_meta(args.reference_manifest)
+    all_rows: list[dict[str, Any]] = []
+    runs = []
+    for run, condition in zip(args.run, args.condition, strict=True):
+        all_rows.extend(collect_deltas(run, condition, meta))
+        runs.append({"condition": condition, "run": str(run), "raw_sha256": sha256_file(run / "brain_ossm_abide.raw.txt")})
+    seed_rows, detail = evaluate(all_rows, k_values)
+    summary = model_summary(seed_rows)
+    envelope = null_envelope(summary)
+
+    write_tsv(out / "orientation_topk_prototype_summary.tsv", summary)
+    write_tsv(out / "orientation_topk_prototype_seed_detail.tsv", seed_rows)
+    write_tsv(out / "orientation_topk_prototype_pair_detail.tsv", detail)
+    write_tsv(out / "orientation_topk_prototype_null_envelope.tsv", envelope)
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": "Synthetic top-k prototype orientation diagnostic only.",
+        "reference_manifest": str(args.reference_manifest),
+        "reference_manifest_sha256": sha256_file(args.reference_manifest),
+        "k_values": k_values,
+        "runs": runs,
+        "model_summary": summary,
+        "null_envelope": envelope,
+    }
+    (out / "orientation_topk_prototype.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md = ["# Orientation Top-K Prototype", "", payload["claim_boundary"], ""]
+    for row in envelope:
+        md.append(
+            f"- `{row['model']}` k=`{row['k']}` `{row['metric']}`: true `{float(row['true']):.6f}`, "
+            f"null max `{float(row['null_max']):.6f}`, null_ge `{row['null_ge_true']}/{row['null_count']}`, "
+            f"p+1 `{float(row['plus_one_p_ge_true']):.6f}`"
+        )
+    md.append("")
+    (out / "orientation_topk_prototype.md").write_text("\n".join(md), encoding="utf-8")
+    sums = []
+    for path in sorted(out.iterdir()):
+        if path.is_file() and path.name != "SHA256SUMS":
+            sums.append(f"{sha256_file(path)}  {path.name}")
+    (out / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_pair_label_permutation_manifest.py
+++ b/scripts/research/neurodyn_pair_label_permutation_manifest.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Build a pair-preserving label-permutation null manifest.
+
+This is for synthetic paired manifests with subject ids like
+`synthetic_pair_0000__oriented` and `synthetic_pair_0000__swapped`.
+For each pair, a seeded coin flip either keeps or swaps the two labels.
+Features, sites, row order, and one-positive/one-negative pair balance are
+preserved. The global relationship between orientation and label is broken.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.pair_label_permutation_manifest.v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--seed", type=int, default=20260706)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def pair_id(subject_id: str) -> str:
+    marker = "__"
+    if marker not in subject_id:
+        raise ValueError(f"subject_id lacks pair suffix: {subject_id}")
+    return subject_id.split(marker, 1)[0]
+
+
+def read_manifest(path: Path) -> tuple[list[str], list[str], list[dict[str, str]]]:
+    comments: list[str] = []
+    header: list[str] | None = None
+    rows: list[dict[str, str]] = []
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        for raw in handle:
+            if raw.startswith("#"):
+                comments.append(raw.rstrip("\n"))
+                continue
+            if not raw.strip():
+                continue
+            header = raw.rstrip("\n").split("\t")
+            break
+        if header is None:
+            raise SystemExit(f"manifest header not found: {path}")
+        reader = csv.DictReader(handle, fieldnames=header, delimiter="\t")
+        rows = [dict(row) for row in reader if row.get("subject_id")]
+    required = {"subject_id", "label", "site"}
+    missing = required.difference(header)
+    if missing:
+        raise SystemExit(f"manifest missing required columns: {sorted(missing)}")
+    return comments, header, rows
+
+
+def write_manifest(path: Path, comments: list[str], header: list[str], rows: list[dict[str, str]], seed: int) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        for comment in comments:
+            if comment.startswith("# label_space="):
+                handle.write("# label_space=pair_label_permutation_null\n")
+            elif comment.startswith("# label_positive_name="):
+                handle.write("# label_positive_name=PERMUTED_POSITIVE\n")
+            elif comment.startswith("# label_negative_name="):
+                handle.write("# label_negative_name=PERMUTED_NEGATIVE\n")
+            elif comment.startswith("# task="):
+                handle.write("# task=pair_label_permutation_null_control\n")
+            else:
+                handle.write(comment + "\n")
+        handle.write(f"# null_control=pair_label_permutation\n")
+        handle.write(f"# permutation_seed={seed}\n")
+        handle.write("# claim_boundary=Synthetic non-clinical null control only. No clinical, biomarker, mechanistic, or O-SSM superiority claim.\n")
+        writer = csv.DictWriter(handle, fieldnames=header, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    comments, header, rows = read_manifest(args.input)
+    groups: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for row in rows:
+        groups[pair_id(row["subject_id"])].append(row)
+    bad = {key: value for key, value in groups.items() if len(value) != 2}
+    if bad:
+        raise SystemExit(f"expected exactly two rows per pair; bad pairs={sorted(bad)[:5]}")
+
+    rng = random.Random(args.seed)
+    flip_by_pair: dict[str, int] = {}
+    output_rows = [dict(row) for row in rows]
+    by_subject = {row["subject_id"]: row for row in output_rows}
+    for key in sorted(groups):
+        pair_rows = groups[key]
+        labels = sorted(int(row["label"]) for row in pair_rows)
+        if labels != [0, 1]:
+            raise SystemExit(f"expected one label 0 and one label 1 for {key}: {labels}")
+        flip = rng.randrange(2)
+        flip_by_pair[key] = flip
+        if flip:
+            for row in pair_rows:
+                by_subject[row["subject_id"]]["label"] = "0" if row["label"] == "1" else "1"
+
+    manifest = args.output_dir / "pair_label_permutation_manifest.tsv"
+    write_manifest(manifest, comments, header, output_rows, args.seed)
+
+    site_label_counts = {
+        site: dict(Counter(row["label"] for row in output_rows if row["site"] == site))
+        for site in sorted({row["site"] for row in output_rows})
+    }
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "input": str(args.input),
+        "manifest": str(manifest),
+        "seed": args.seed,
+        "pair_count": len(groups),
+        "row_count": len(output_rows),
+        "flipped_pair_count": sum(flip_by_pair.values()),
+        "kept_pair_count": len(groups) - sum(flip_by_pair.values()),
+        "label_counts": dict(Counter(row["label"] for row in output_rows)),
+        "site_label_counts": site_label_counts,
+        "input_sha256": sha256_file(args.input),
+        "manifest_sha256": sha256_file(manifest),
+    }
+    (args.output_dir / "pair_label_permutation_summary.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with (args.output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(args.output_dir.iterdir()):
+            if path.is_file() and path.name != "SHA256SUMS":
+                handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_pair_order_signal_audit.py
+++ b/scripts/research/neurodyn_pair_order_signal_audit.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Audit paired temporal-order signals in NeuroDyn synthetic manifests."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, pstdev
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    lines = [line for line in path.read_text().splitlines() if line and not line.startswith("#")]
+    if not lines:
+        raise SystemExit(f"manifest has no data rows: {path}")
+    return list(csv.DictReader(lines, delimiter="\t"))
+
+
+def pair_id(subject_id: str) -> str:
+    if "__" in subject_id:
+        return subject_id.split("__", 1)[0]
+    return subject_id
+
+
+def variant(subject_id: str, label: str) -> str:
+    if subject_id.endswith("__oriented"):
+        return "oriented"
+    if subject_id.endswith("__swapped"):
+        return "swapped"
+    return f"label_{label}"
+
+
+def feature_matrix(row: dict[str, str], seq_len: int, input_dim: int) -> list[list[float]]:
+    xs: list[list[float]] = []
+    for step in range(seq_len):
+        cur = []
+        for dim in range(input_dim):
+            cur.append(float(row[f"f{step * input_dim + dim}"]))
+        xs.append(cur)
+    return xs
+
+
+def wedge_signal(xs: list[list[float]]) -> list[float]:
+    input_dim = len(xs[0])
+    seq_len = len(xs)
+    out = []
+    for dim in range(input_dim):
+        nxt = (dim + 1) % input_dim
+        acc = 0.0
+        for step in range(seq_len - 1):
+            acc += xs[step][dim] * xs[step + 1][nxt] - xs[step][nxt] * xs[step + 1][dim]
+        out.append(acc / seq_len)
+    return out
+
+
+def l2(v: list[float]) -> float:
+    return math.sqrt(sum(x * x for x in v))
+
+
+def dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    den = l2(a) * l2(b)
+    if den <= 0:
+        return 0.0
+    return dot(a, b) / den
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--seq-len", type=int, default=32)
+    ap.add_argument("--input-dim", type=int, default=8)
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "pair_order_signal_summary.json"
+    pairs_path = args.output_dir / "pair_order_signal_pairs.tsv"
+    if not args.overwrite and (summary_path.exists() or pairs_path.exists()):
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+
+    rows = read_manifest(args.manifest)
+    grouped: dict[str, dict[str, dict[str, object]]] = defaultdict(dict)
+    for row in rows:
+        sid = row["subject_id"]
+        lab = row["label"]
+        xs = feature_matrix(row, args.seq_len, args.input_dim)
+        sig = wedge_signal(xs)
+        grouped[pair_id(sid)][variant(sid, lab)] = {
+            "subject_id": sid,
+            "label": int(lab),
+            "site": row["site"],
+            "signal": sig,
+            "norm": l2(sig),
+        }
+
+    pair_rows = []
+    for pid in sorted(grouped):
+        item = grouped[pid]
+        if "oriented" not in item or "swapped" not in item:
+            continue
+        oriented = item["oriented"]
+        swapped = item["swapped"]
+        osig = oriented["signal"]  # type: ignore[assignment]
+        ssig = swapped["signal"]  # type: ignore[assignment]
+        assert isinstance(osig, list)
+        assert isinstance(ssig, list)
+        diff = [a - b for a, b in zip(osig, ssig)]
+        pair_rows.append(
+            {
+                "pair_id": pid,
+                "site": oriented["site"],
+                "oriented_subject": oriented["subject_id"],
+                "swapped_subject": swapped["subject_id"],
+                "oriented_norm": float(oriented["norm"]),
+                "swapped_norm": float(swapped["norm"]),
+                "diff_norm": l2(diff),
+                "cosine": cosine(osig, ssig),
+                "dot": dot(osig, ssig),
+                **{f"diff_d{i}": diff[i] for i in range(args.input_dim)},
+            }
+        )
+
+    if not pair_rows:
+        raise SystemExit("no complete oriented/swapped pairs found")
+
+    diff_norms = [float(r["diff_norm"]) for r in pair_rows]
+    cosines = [float(r["cosine"]) for r in pair_rows]
+    oriented_norms = [float(r["oriented_norm"]) for r in pair_rows]
+    swapped_norms = [float(r["swapped_norm"]) for r in pair_rows]
+    summary = {
+        "schema": "neurodyn_pair_order_signal_audit.v1",
+        "manifest": str(args.manifest),
+        "pairs": len(pair_rows),
+        "seq_len": args.seq_len,
+        "input_dim": args.input_dim,
+        "diff_norm_mean": mean(diff_norms),
+        "diff_norm_std": pstdev(diff_norms),
+        "diff_norm_min": min(diff_norms),
+        "diff_norm_max": max(diff_norms),
+        "cosine_mean": mean(cosines),
+        "cosine_std": pstdev(cosines),
+        "oriented_norm_mean": mean(oriented_norms),
+        "swapped_norm_mean": mean(swapped_norms),
+    }
+
+    with pairs_path.open("w", newline="") as f:
+        fieldnames = list(pair_rows[0].keys())
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(pair_rows)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_paired_hidden_contrast.py
+++ b/scripts/research/neurodyn_paired_hidden_contrast.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Paired oriented-vs-swapped hidden-state contrast audit."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+
+
+SCHEMA = "neurodyn.paired_hidden_contrast.v1"
+
+
+def read_manifest(path: Path) -> list[dict[str, str]]:
+    lines = [line for line in path.read_text().splitlines() if line and not line.startswith("#")]
+    if not lines:
+        raise SystemExit(f"manifest has no data rows: {path}")
+    return list(csv.DictReader(lines, delimiter="\t"))
+
+
+def pair_id(subject_id: str) -> str:
+    if "__" in subject_id:
+        return subject_id.split("__", 1)[0]
+    return subject_id
+
+
+def variant(subject_id: str, label: int) -> str:
+    if subject_id.endswith("__oriented"):
+        return "oriented"
+    if subject_id.endswith("__swapped"):
+        return "swapped"
+    return "oriented" if label == 1 else "swapped"
+
+
+def dot(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def norm(a: list[float]) -> float:
+    return math.sqrt(dot(a, a))
+
+
+def dist(a: list[float], b: list[float]) -> float:
+    return norm([x - y for x, y in zip(a, b)])
+
+
+def mean_vec(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    return [sum(v[i] for v in vectors) / len(vectors) for i in range(dim)]
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--raw-output", required=True, type=Path)
+    ap.add_argument("--manifest", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "paired_hidden_contrast_summary.tsv"
+    if summary_path.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+
+    manifest_rows = read_manifest(args.manifest)
+    subject_meta = {
+        idx: {
+            "subject_id": row["subject_id"],
+            "pair_id": pair_id(row["subject_id"]),
+            "variant": variant(row["subject_id"], int(row["label"])),
+            "label": int(row["label"]),
+            "site": row["site"],
+        }
+        for idx, row in enumerate(manifest_rows)
+    }
+    state_rows = parse_state_rows(args.raw_output)
+    grouped: dict[tuple[str, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in state_rows:
+        meta = subject_meta.get(row["subject_index"])
+        if meta is None:
+            continue
+        key = (row["model"], row["seed"])
+        grouped[key][f"{meta['pair_id']}::{meta['variant']}"] = {
+            **row,
+            **meta,
+        }
+
+    detail_rows: list[dict[str, Any]] = []
+    summary_rows: list[dict[str, Any]] = []
+    for (model, seed), chunk in sorted(grouped.items()):
+        pair_ids = sorted({value["pair_id"] for value in chunk.values()})
+        pair_diffs: list[dict[str, Any]] = []
+        for pid in pair_ids:
+            o = chunk.get(f"{pid}::oriented")
+            s = chunk.get(f"{pid}::swapped")
+            if o is None or s is None:
+                continue
+            diff = [a - b for a, b in zip(o["h"], s["h"])]
+            pair_diffs.append(
+                {
+                    "model": model,
+                    "seed": seed,
+                    "pair_id": pid,
+                    "site": o["site"],
+                    "hidden_pair_distance": dist(o["h"], s["h"]),
+                    "diff": diff,
+                }
+            )
+        if not pair_diffs:
+            continue
+        sites = sorted({row["site"] for row in pair_diffs})
+        correct = 0
+        total = 0
+        for site in sites:
+            train = [row for row in pair_diffs if row["site"] != site]
+            test = [row for row in pair_diffs if row["site"] == site]
+            direction = mean_vec([row["diff"] for row in train])
+            if not direction:
+                continue
+            for row in test:
+                if dot(row["diff"], direction) > 0.0:
+                    correct += 1
+                total += 1
+        diffs = [row["diff"] for row in pair_diffs]
+        mean_direction = mean_vec(diffs)
+        distances = [float(row["hidden_pair_distance"]) for row in pair_diffs]
+        direction_norm = norm(mean_direction)
+        detail_rows.extend(
+            {
+                "model": row["model"],
+                "seed": row["seed"],
+                "pair_id": row["pair_id"],
+                "site": row["site"],
+                "hidden_pair_distance": row["hidden_pair_distance"],
+                "diff_alignment_with_seed_mean": dot(row["diff"], mean_direction) / (norm(row["diff"]) * direction_norm)
+                if norm(row["diff"]) > 0 and direction_norm > 0
+                else 0.0,
+            }
+            for row in pair_diffs
+        )
+        summary_rows.append(
+            {
+                "model": model,
+                "seed": seed,
+                "pairs": len(pair_diffs),
+                "hidden_pair_distance_mean": mean(distances),
+                "hidden_pair_distance_std": pstdev(distances),
+                "mean_direction_norm": direction_norm,
+                "direction_norm_over_pair_distance": direction_norm / mean(distances) if mean(distances) > 0 else 0.0,
+                "leave_site_pair_direction_accuracy": 100.0 * correct / total if total else 0.0,
+            }
+        )
+
+    model_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in summary_rows:
+        model_groups[row["model"]].append(row)
+    model_summary = []
+    for model, rows in sorted(model_groups.items()):
+        acc = [float(r["leave_site_pair_direction_accuracy"]) for r in rows]
+        dist_mean = [float(r["hidden_pair_distance_mean"]) for r in rows]
+        ratio = [float(r["direction_norm_over_pair_distance"]) for r in rows]
+        model_summary.append(
+            {
+                "model": model,
+                "seed_count": len(rows),
+                "leave_site_pair_direction_accuracy_mean": mean(acc),
+                "leave_site_pair_direction_accuracy_std": pstdev(acc),
+                "hidden_pair_distance_mean": mean(dist_mean),
+                "direction_norm_over_pair_distance_mean": mean(ratio),
+            }
+        )
+
+    def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+        with path.open("w", newline="") as f:
+            if not rows:
+                return
+            writer = csv.DictWriter(f, fieldnames=list(rows[0]), delimiter="\t")
+            writer.writeheader()
+            writer.writerows(rows)
+
+    write_tsv(args.output_dir / "paired_hidden_contrast_summary.tsv", model_summary)
+    write_tsv(args.output_dir / "paired_hidden_contrast_seed_detail.tsv", summary_rows)
+    write_tsv(args.output_dir / "paired_hidden_contrast_pair_detail.tsv", detail_rows)
+    payload = {
+        "schema": SCHEMA,
+        "raw_output": str(args.raw_output),
+        "manifest": str(args.manifest),
+        "state_trace_rows": len(state_rows),
+        "model_summary": model_summary,
+    }
+    (args.output_dir / "paired_hidden_contrast.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_permutation_null_summary.py
+++ b/scripts/research/neurodyn_permutation_null_summary.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Aggregate true-label and permutation-null NeuroDyn benchmark summaries."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.permutation_null_summary.v1"
+CLAIM_BOUNDARY = (
+    "Synthetic non-clinical null-summary diagnostic only. No clinical, "
+    "biomarker, mechanistic, or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--true-run", required=True, type=Path)
+    parser.add_argument("--null-run", required=True, action="append", type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def model_row(run: Path, model: str) -> dict[str, str]:
+    rows = read_tsv(run / "results" / "overall_metrics.tsv")
+    for row in rows:
+        if row["model"] == model:
+            return row
+    raise SystemExit(f"model {model} not found in {run}")
+
+
+def read_seed(run: Path) -> int | None:
+    for candidate in (run / "pair_label_permutation_summary.json", run.parent / "pair_label_permutation_summary.json"):
+        if candidate.exists():
+            return int(json.loads(candidate.read_text(encoding="utf-8"))["seed"])
+    name = run.name
+    for token in name.split("_"):
+        if token.startswith("202607") and token.isdigit():
+            return int(token)
+    match = re.search(r"(202607\d+)", name)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def pstdev(values: list[float]) -> float:
+    if len(values) <= 1:
+        return 0.0
+    m = mean(values)
+    return math.sqrt(sum((value - m) * (value - m) for value in values) / len(values))
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Pair-Label Permutation Null Summary",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "| condition | seed | O-SSM BA | H-SSM BA | O-SSM AUROC |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {condition} | {seed} | {o_ba:.6f} | {h_ba:.6f} | {o_auroc:.6f} |".format(
+                condition=row["condition"],
+                seed=row["seed"] if row["seed"] is not None else -1,
+                o_ba=row["o_balanced_accuracy_pct"],
+                h_ba=row["h_balanced_accuracy_pct"],
+                o_auroc=row["o_auroc_pct"],
+            )
+        )
+    s = payload["summary"]
+    lines.extend(
+        [
+            "",
+            "## Summary",
+            "",
+            f"- true O-SSM BA: `{s['true_o_balanced_accuracy_pct']:.6f}`",
+            f"- null O-SSM BA mean: `{s['null_o_balanced_accuracy_pct_mean']:.6f}`",
+            f"- null O-SSM BA std: `{s['null_o_balanced_accuracy_pct_std']:.6f}`",
+            f"- null O-SSM BA max: `{s['null_o_balanced_accuracy_pct_max']:.6f}`",
+            f"- true-minus-null-mean gap: `{s['true_minus_null_mean_pp']:.6f}` pp",
+            f"- empirical p_ge_true: `{s['empirical_p_ge_true']:.6f}`",
+            "",
+            "The empirical p-value uses plus-one smoothing: "
+            "`(1 + count(null >= true)) / (1 + null_count)`. This is a small "
+            "synthetic null sample, not a final inferential claim.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, Any]] = []
+    for condition, run in [("true", args.true_run), *[("null", path) for path in args.null_run]]:
+        o = model_row(run, "O-SSM")
+        h = model_row(run, "H-SSM")
+        rows.append(
+            {
+                "condition": condition,
+                "seed": None if condition == "true" else read_seed(run),
+                "run": str(run),
+                "o_balanced_accuracy_pct": float(o["balanced_accuracy_pct_mean"]),
+                "h_balanced_accuracy_pct": float(h["balanced_accuracy_pct_mean"]),
+                "o_auroc_pct": float(o["auroc_pct_mean"]),
+                "h_auroc_pct": float(h["auroc_pct_mean"]),
+                "o_seed_count": int(o["seed_count"]),
+                "site_count": int(o["site_count"]),
+                "subjects": int(o["subjects"]),
+            }
+        )
+
+    true_row = [row for row in rows if row["condition"] == "true"][0]
+    null_rows = [row for row in rows if row["condition"] == "null"]
+    null_o = [float(row["o_balanced_accuracy_pct"]) for row in null_rows]
+    null_o_auroc = [float(row["o_auroc_pct"]) for row in null_rows]
+    true_o = float(true_row["o_balanced_accuracy_pct"])
+    true_o_auroc = float(true_row["o_auroc_pct"])
+    exceed = sum(1 for value in null_o if value >= true_o)
+    exceed_auroc = sum(1 for value in null_o_auroc if value >= true_o_auroc)
+    summary = {
+        "true_o_balanced_accuracy_pct": true_o,
+        "true_h_balanced_accuracy_pct": float(true_row["h_balanced_accuracy_pct"]),
+        "true_o_auroc_pct": true_o_auroc,
+        "true_h_auroc_pct": float(true_row["h_auroc_pct"]),
+        "null_count": len(null_rows),
+        "null_o_balanced_accuracy_pct_mean": mean(null_o),
+        "null_o_balanced_accuracy_pct_std": pstdev(null_o),
+        "null_o_balanced_accuracy_pct_min": min(null_o) if null_o else 0.0,
+        "null_o_balanced_accuracy_pct_max": max(null_o) if null_o else 0.0,
+        "null_o_auroc_pct_mean": mean(null_o_auroc),
+        "null_o_auroc_pct_std": pstdev(null_o_auroc),
+        "null_o_auroc_pct_min": min(null_o_auroc) if null_o_auroc else 0.0,
+        "null_o_auroc_pct_max": max(null_o_auroc) if null_o_auroc else 0.0,
+        "true_minus_null_mean_pp": true_o - mean(null_o),
+        "true_auroc_minus_null_mean_pp": true_o_auroc - mean(null_o_auroc),
+        "null_ge_true_count": exceed,
+        "null_auroc_ge_true_count": exceed_auroc,
+        "empirical_p_ge_true": (1.0 + exceed) / (1.0 + len(null_o)) if null_o else 1.0,
+        "empirical_auroc_p_ge_true": (1.0 + exceed_auroc) / (1.0 + len(null_o_auroc)) if null_o_auroc else 1.0,
+    }
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "rows": rows,
+        "summary": summary,
+    }
+    (args.output_dir / "permutation_null_summary.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_tsv(args.output_dir / "permutation_null_rows.tsv", rows)
+    write_tsv(args.output_dir / "permutation_null_summary.tsv", [summary])
+    (args.output_dir / "permutation_null_summary.md").write_text(markdown(payload), encoding="utf-8")
+    with (args.output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in args.output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path.name}\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_postcampaign_trained_associator_gate.py
+++ b/scripts/research/neurodyn_postcampaign_trained_associator_gate.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Gate trained ROI associator extraction after an O-SSM campaign.
+
+The previous model-free associator failure mode was: no trained checkpoint was
+loaded, yet ROI statistics were still produced.  This gate refuses to proceed
+unless it can select a verified, nonzero O-SSM checkpoint with balanced accuracy
+above threshold.  It is dry-run by default; pass --execute-associator to run the
+native trained ROI associator extractor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "brain_ossm.neurodyn_postcampaign_trained_associator_gate.v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--checkpoint", action="append", default=[])
+    parser.add_argument("--checkpoint-root", action="append", default=[])
+    parser.add_argument("--run-config", default="", help="Optional run config to replay checkpoint split settings.")
+    parser.add_argument("--run-id", default="", help="Optional exact checkpoint run_id filter.")
+    parser.add_argument("--min-balanced-accuracy", type=float, default=51.0)
+    parser.add_argument("--tolerance-pp", type=float, default=0.5)
+    parser.add_argument("--scope", choices=["all", "holdout"], default="all")
+    parser.add_argument("--metric", default="hidden_delta_abs")
+    parser.add_argument("--alpha", type=float, default=0.05)
+    parser.add_argument("--associator-executor", choices=["native", "python"], default="native")
+    parser.add_argument("--native-souc-engine", default="", help="Optional SOUNIO_SOUC_ENGINE for native verifier/extractor.")
+    parser.add_argument("--verify-checkpoint", action="store_true")
+    parser.add_argument("--execute-associator", action="store_true")
+    parser.add_argument("--repo-root", default=str(Path(__file__).resolve().parents[2]))
+    return parser.parse_args()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def candidate_paths(args: argparse.Namespace) -> list[Path]:
+    paths: dict[Path, None] = {}
+    for raw in args.checkpoint:
+        path = Path(raw).expanduser().resolve()
+        if path.exists():
+            paths[path] = None
+    for raw_root in args.checkpoint_root:
+        root = Path(raw_root).expanduser().resolve()
+        if not root.exists():
+            continue
+        for pattern in ["model.ckpt", "*.ckpt"]:
+            for path in root.rglob(pattern):
+                if path.is_file():
+                    paths[path.resolve()] = None
+    return sorted(paths)
+
+
+def load_checkpoint(path: Path) -> tuple[dict[str, Any] | None, str]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - diagnostic gate
+        return None, f"json_load_failed:{type(exc).__name__}:{exc}"
+    return payload, ""
+
+
+def checkpoint_signal(payload: dict[str, Any]) -> bool:
+    values = payload.get("arrays", {}).get("A", {}).get("values", [])
+    return bool(values) and any(abs(float(value)) > 1.0e-12 for value in values)
+
+
+def float_field(payload: dict[str, Any], key: str, default: float) -> float:
+    value = payload.get(key)
+    if value is None or value == "":
+        return default
+    return float(value)
+
+
+def inspect_checkpoint(path: Path, args: argparse.Namespace) -> dict[str, Any]:
+    payload, error = load_checkpoint(path)
+    row: dict[str, Any] = {
+        "path": str(path),
+        "status": "fail",
+        "failures": [],
+        "run_id": "",
+        "balanced_accuracy_pct": 0.0,
+        "delta_pp": 999.0,
+        "verification_status": "",
+        "has_nonzero_a_tensor": False,
+    }
+    if payload is None:
+        row["failures"].append(error)
+        return row
+
+    row["run_id"] = str(payload.get("run_id") or "")
+    meta = payload.get("meta") or {}
+    if meta.get("model") != "O-SSM":
+        row["failures"].append(f"model is not O-SSM: {meta.get('model')!r}")
+    if args.run_id and row["run_id"] != args.run_id:
+        row["failures"].append(f"run_id mismatch: {row['run_id']} != {args.run_id}")
+
+    verification = payload.get("verification")
+    if not isinstance(verification, dict):
+        row["failures"].append("missing verification block")
+    else:
+        row["verification_status"] = str(verification.get("status") or "")
+        row["balanced_accuracy_pct"] = float_field(verification, "actual_balanced_accuracy_pct", 0.0)
+        row["delta_pp"] = float_field(verification, "delta_pp", 999.0)
+        tolerance = float_field(verification, "tolerance_pp", args.tolerance_pp)
+        if verification.get("status") != "pass":
+            row["failures"].append(f"verification status is {verification.get('status')!r}")
+        if row["balanced_accuracy_pct"] <= args.min_balanced_accuracy:
+            row["failures"].append(
+                f"balanced accuracy {row['balanced_accuracy_pct']:.6f} <= {args.min_balanced_accuracy:.6f}"
+            )
+        if row["delta_pp"] > tolerance:
+            row["failures"].append(f"verification delta {row['delta_pp']:.6f}pp > {tolerance:.6f}pp")
+
+    row["has_nonzero_a_tensor"] = checkpoint_signal(payload)
+    if not row["has_nonzero_a_tensor"]:
+        row["failures"].append("A tensor missing or all-zero")
+
+    if not row["failures"]:
+        row["status"] = "pass"
+    return row
+
+
+def select_checkpoint(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    passing = [row for row in rows if row.get("status") == "pass"]
+    if not passing:
+        return None
+    return max(passing, key=lambda row: (float(row.get("balanced_accuracy_pct") or 0.0), str(row.get("path") or "")))
+
+
+def run_command(command: list[str], cwd: Path) -> dict[str, Any]:
+    proc = subprocess.run(
+        command,
+        cwd=str(cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "command": command,
+        "returncode": proc.returncode,
+        "stdout": proc.stdout[-20000:],
+        "stderr": proc.stderr[-20000:],
+    }
+
+
+def load_json_file(path: Path) -> tuple[dict[str, Any] | None, str]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), ""
+    except Exception as exc:  # noqa: BLE001 - diagnostic gate
+        return None, f"json_load_failed:{type(exc).__name__}:{exc}"
+
+
+def validate_associator_summary(path: Path, args: argparse.Namespace) -> tuple[dict[str, Any] | None, list[str]]:
+    failures: list[str] = []
+    payload, error = load_json_file(path)
+    if payload is None:
+        return None, [f"associator summary unreadable: {error}"]
+    verification = payload.get("extractor_verification") or payload.get("native_extractor_verification")
+    if not isinstance(verification, dict):
+        failures.append("associator summary missing extractor verification")
+        return payload, failures
+    actual = float_field(verification, "actual_balanced_accuracy_pct", 0.0)
+    expected = float_field(verification, "expected_balanced_accuracy_pct", 0.0)
+    delta = float_field(verification, "delta_pp", abs(actual - expected))
+    if actual <= args.min_balanced_accuracy:
+        failures.append(f"associator verifier balanced accuracy {actual:.6f} <= {args.min_balanced_accuracy:.6f}")
+    if delta > args.tolerance_pp:
+        failures.append(f"associator verifier delta {delta:.6f}pp > {args.tolerance_pp:.6f}pp")
+    feature_rows = int(float_field(payload, "feature_rows", 0.0))
+    roi_count = int(float_field(payload, "roi_count", 0.0))
+    if feature_rows <= 0:
+        failures.append("associator emitted no feature rows")
+    if roi_count <= 0:
+        failures.append("associator emitted no ROI stats")
+    top10 = path.parent / "top10_roi_biomarkers.csv"
+    if not top10.is_file() or top10.stat().st_size <= 0:
+        failures.append(f"associator top10 missing or empty: {top10}")
+    method = str(payload.get("method") or "")
+    if args.associator_executor == "native" and "native" not in method:
+        failures.append(f"associator method is not native: {method!r}")
+    return payload, failures
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    manifest = Path(args.manifest).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    initial_failures: list[str] = []
+    if not manifest.is_file():
+        initial_failures.append(f"manifest missing: {manifest}")
+
+    candidates = candidate_paths(args)
+    rows = [inspect_checkpoint(path, args) for path in candidates]
+    selected = select_checkpoint(rows)
+    failures: list[str] = list(initial_failures)
+    commands: dict[str, Any] = {}
+    selected_copy = output_dir / "selected_model.ckpt"
+    staged_manifest = manifest
+    staged_checkpoint = selected_copy
+    staged_run_config = Path(args.run_config).expanduser().resolve() if args.run_config else None
+
+    if not candidates:
+        failures.append("no checkpoint candidates found")
+    if selected is None:
+        failures.append("no verified trained checkpoint passed the gate")
+    else:
+        shutil.copy2(Path(selected["path"]), selected_copy)
+
+    with tempfile.TemporaryDirectory(prefix="neurodyn-assoc-gate-") as stage_raw:
+        stage_dir = Path(stage_raw)
+        if manifest.is_file():
+            staged_manifest = stage_dir / "manifest.tsv"
+            shutil.copy2(manifest, staged_manifest)
+        if selected_copy.exists():
+            staged_checkpoint = stage_dir / "model.ckpt"
+            shutil.copy2(selected_copy, staged_checkpoint)
+        if staged_run_config is not None and staged_run_config.is_file():
+            staged_run_config_copy = stage_dir / "run_config.tsv"
+            shutil.copy2(staged_run_config, staged_run_config_copy)
+            staged_run_config = staged_run_config_copy
+
+        if selected is not None and args.verify_checkpoint:
+            verify_cmd = [
+                sys.executable,
+                str(repo_root / "scripts/research/abide_checkpoint_persist.py"),
+                "--verify-only",
+                "--checkpoint",
+                str(staged_checkpoint),
+                "--manifest",
+                str(staged_manifest),
+                "--tolerance-pp",
+                str(args.tolerance_pp),
+            ]
+            if staged_run_config is not None:
+                verify_cmd.extend(["--run-config", str(staged_run_config)])
+            if args.native_souc_engine:
+                verify_cmd.extend(["--native-souc-engine", args.native_souc_engine])
+            commands["verify_checkpoint"] = run_command(verify_cmd, repo_root)
+            if commands["verify_checkpoint"]["returncode"] != 0:
+                failures.append(f"checkpoint reverify failed rc={commands['verify_checkpoint']['returncode']}")
+            else:
+                shutil.copy2(staged_checkpoint, selected_copy)
+                selected = inspect_checkpoint(selected_copy, args)
+                if selected.get("status") != "pass":
+                    failures.append("checkpoint failed after reverify")
+
+        associator_output = output_dir / "trained_roi_associator"
+        if args.execute_associator and selected is not None and not failures:
+            associator_cmd = [
+                sys.executable,
+                str(repo_root / "scripts/research/abide_trained_roi_associator.py"),
+                "--checkpoint",
+                str(staged_checkpoint),
+                "--manifest",
+                str(staged_manifest),
+                "--output-dir",
+                str(associator_output),
+                "--scope",
+                args.scope,
+                "--metric",
+                args.metric,
+                "--alpha",
+                str(args.alpha),
+                "--min-balanced-accuracy",
+                str(args.min_balanced_accuracy),
+                "--executor",
+                args.associator_executor,
+                "--repo-root",
+                str(repo_root),
+            ]
+            if args.native_souc_engine:
+                associator_cmd.extend(["--native-souc-engine", args.native_souc_engine])
+            commands["trained_roi_associator"] = run_command(associator_cmd, repo_root)
+            if commands["trained_roi_associator"]["returncode"] != 0:
+                failures.append(f"trained ROI associator failed rc={commands['trained_roi_associator']['returncode']}")
+            else:
+                associator_summary, associator_failures = validate_associator_summary(
+                    associator_output / "run_summary.json",
+                    args,
+                )
+                commands["trained_roi_associator"]["summary"] = associator_summary
+                failures.extend(associator_failures)
+        elif args.execute_associator and failures:
+            failures.append("refusing to execute associator because gate failed")
+
+    decision = "ready_for_trained_associator" if selected is not None and not failures else "blocked"
+    if args.execute_associator and decision == "ready_for_trained_associator":
+        decision = "associator_complete"
+
+    summary = {
+        "schema": SCHEMA,
+        "created_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "decision": decision,
+        "failures": failures,
+        "manifest": str(manifest),
+        "output_dir": str(output_dir),
+        "candidate_count": len(candidates),
+        "candidates": rows,
+        "selected_checkpoint": selected,
+        "selected_checkpoint_copy": str(selected_copy) if selected_copy.exists() else "",
+        "execute_associator": bool(args.execute_associator),
+        "associator_executor": args.associator_executor,
+        "native_souc_engine": args.native_souc_engine,
+        "associator_output_dir": str(associator_output),
+        "commands": commands,
+        "claim_boundary": (
+            "This gate permits trained associator extraction from verified checkpoints; "
+            "it does not certify a scientific result by itself."
+        ),
+    }
+    write_json(output_dir / "postcampaign_trained_associator_gate.json", summary)
+
+    print(f"decision={decision}")
+    print(f"candidate_count={len(candidates)}")
+    if selected:
+        print(f"selected_checkpoint={selected.get('path')}")
+        print(f"selected_balanced_accuracy={float(selected.get('balanced_accuracy_pct') or 0.0):.6f}")
+    print(f"summary={output_dir / 'postcampaign_trained_associator_gate.json'}")
+    for failure in failures:
+        print(f"BLOCKED: {failure}", file=sys.stderr)
+    return 0 if decision in {"ready_for_trained_associator", "associator_complete"} else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/research/neurodyn_readout_alignment_trace_summary.py
+++ b/scripts/research/neurodyn_readout_alignment_trace_summary.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Summarize O-SSM READOUT_ALIGN_TRACE rows from brain_ossm_abide output."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.readout_alignment_trace_summary.v1"
+
+
+FIELDS = [
+    "tag",
+    "model",
+    "seed",
+    "seed_b",
+    "holdout_key",
+    "holdout_site",
+    "phase",
+    "align_epochs",
+    "align_lr_scale_bp",
+    "train_n",
+    "train_balanced_accuracy_pct",
+    "train_accuracy_pct",
+    "train_brier",
+    "train_margin",
+    "holdout_n",
+    "holdout_balanced_accuracy_pct",
+    "holdout_accuracy_pct",
+    "holdout_brier",
+    "holdout_margin",
+]
+
+
+def bp(value: str) -> float:
+    return int(value) / 1_000_000.0
+
+
+def parse_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.startswith("READOUT_ALIGN_TRACE\t"):
+            idx += 1
+            continue
+        parts = [part for part in line.split("\t") if part]
+        line_no = idx + 1
+        next_idx = idx + 1
+        while len(parts) < len(FIELDS) and next_idx < len(lines) and lines[next_idx].startswith("\t"):
+            parts.extend(part for part in lines[next_idx].split("\t") if part)
+            next_idx += 1
+        if len(parts) != len(FIELDS):
+            raise SystemExit(f"malformed READOUT_ALIGN_TRACE at line {line_no}: expected {len(FIELDS)} fields, got {len(parts)}")
+        raw = dict(zip(FIELDS, parts, strict=True))
+        rows.append(
+            {
+                "model": raw["model"],
+                "seed": int(raw["seed"]),
+                "seed_b": int(raw["seed_b"]),
+                "holdout_key": int(raw["holdout_key"]),
+                "holdout_site": raw["holdout_site"],
+                "phase": raw["phase"],
+                "align_epochs": int(raw["align_epochs"]),
+                "align_lr_scale": bp(raw["align_lr_scale_bp"]),
+                "train_n": int(raw["train_n"]),
+                "train_balanced_accuracy_pct": bp(raw["train_balanced_accuracy_pct"]),
+                "train_accuracy_pct": bp(raw["train_accuracy_pct"]),
+                "train_brier": bp(raw["train_brier"]),
+                "train_margin": bp(raw["train_margin"]),
+                "holdout_n": int(raw["holdout_n"]),
+                "holdout_balanced_accuracy_pct": bp(raw["holdout_balanced_accuracy_pct"]),
+                "holdout_accuracy_pct": bp(raw["holdout_accuracy_pct"]),
+                "holdout_brier": bp(raw["holdout_brier"]),
+                "holdout_margin": bp(raw["holdout_margin"]),
+            }
+        )
+        idx = next_idx
+    if not rows:
+        raise SystemExit("no READOUT_ALIGN_TRACE rows found")
+    return rows
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def summarize_phase(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for phase in ["pre", "post"]:
+        phase_rows = [row for row in rows if row["phase"] == phase]
+        if not phase_rows:
+            continue
+        out.append(
+            {
+                "phase": phase,
+                "fold_count": len(phase_rows),
+                "train_balanced_accuracy_pct_mean": mean([row["train_balanced_accuracy_pct"] for row in phase_rows]),
+                "train_balanced_accuracy_pct_std": pstdev([row["train_balanced_accuracy_pct"] for row in phase_rows]),
+                "train_brier_mean": mean([row["train_brier"] for row in phase_rows]),
+                "train_margin_mean": mean([row["train_margin"] for row in phase_rows]),
+                "holdout_balanced_accuracy_pct_mean": mean([row["holdout_balanced_accuracy_pct"] for row in phase_rows]),
+                "holdout_balanced_accuracy_pct_std": pstdev([row["holdout_balanced_accuracy_pct"] for row in phase_rows]),
+                "holdout_brier_mean": mean([row["holdout_brier"] for row in phase_rows]),
+                "holdout_margin_mean": mean([row["holdout_margin"] for row in phase_rows]),
+            }
+        )
+    return out
+
+
+def summarize_delta(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_fold: dict[tuple[int, int, str], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for row in rows:
+        by_fold[(row["seed"], row["holdout_key"], row["holdout_site"])][row["phase"]] = row
+    deltas: list[dict[str, Any]] = []
+    for (seed, holdout_key, holdout_site), phases in sorted(by_fold.items()):
+        if "pre" not in phases or "post" not in phases:
+            continue
+        pre = phases["pre"]
+        post = phases["post"]
+        deltas.append(
+            {
+                "seed": seed,
+                "holdout_key": holdout_key,
+                "holdout_site": holdout_site,
+                "train_balanced_accuracy_delta": post["train_balanced_accuracy_pct"] - pre["train_balanced_accuracy_pct"],
+                "train_brier_delta": post["train_brier"] - pre["train_brier"],
+                "train_margin_delta": post["train_margin"] - pre["train_margin"],
+                "holdout_balanced_accuracy_delta": post["holdout_balanced_accuracy_pct"] - pre["holdout_balanced_accuracy_pct"],
+                "holdout_brier_delta": post["holdout_brier"] - pre["holdout_brier"],
+                "holdout_margin_delta": post["holdout_margin"] - pre["holdout_margin"],
+            }
+        )
+    if not deltas:
+        raise SystemExit("no matched pre/post fold traces found")
+    return deltas
+
+
+def summarize_delta_overall(deltas: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "fold_count": len(deltas),
+            "train_balanced_accuracy_delta_mean": mean([row["train_balanced_accuracy_delta"] for row in deltas]),
+            "train_brier_delta_mean": mean([row["train_brier_delta"] for row in deltas]),
+            "train_margin_delta_mean": mean([row["train_margin_delta"] for row in deltas]),
+            "holdout_balanced_accuracy_delta_mean": mean([row["holdout_balanced_accuracy_delta"] for row in deltas]),
+            "holdout_brier_delta_mean": mean([row["holdout_brier_delta"] for row in deltas]),
+            "holdout_margin_delta_mean": mean([row["holdout_margin_delta"] for row in deltas]),
+        }
+    ]
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0]), delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--raw-output", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "readout_alignment_trace_summary.tsv"
+    if summary_path.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+
+    rows = parse_rows(args.raw_output)
+    phase_summary = summarize_phase(rows)
+    deltas = summarize_delta(rows)
+    delta_summary = summarize_delta_overall(deltas)
+
+    write_tsv(summary_path, phase_summary)
+    write_tsv(args.output_dir / "readout_alignment_trace_delta_summary.tsv", delta_summary)
+    write_tsv(args.output_dir / "readout_alignment_trace_delta_detail.tsv", deltas)
+
+    payload = {
+        "schema": SCHEMA,
+        "raw_output": str(args.raw_output),
+        "trace_rows": len(rows),
+        "phase_summary": phase_summary,
+        "delta_summary": delta_summary,
+    }
+    (args.output_dir / "readout_alignment_trace_summary.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_scale14x14_missing_roi_rerun.py
+++ b/scripts/research/neurodyn_scale14x14_missing_roi_rerun.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Rerun the ds006731 14x14 missing ROI subjects on the r740 worker.
+
+This is orchestration plumbing only.  It keeps the scientific preprocessing
+profile used by the existing P3 receipts, but fixes the durability gap by
+copying each successful ROI artifact to CephFS before moving to the next
+subject.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_NAMESPACE = "slurm-pilot"
+DEFAULT_POD = "slurm-pilot-worker-gpuorangefs-multi-mpttj"
+DEFAULT_CONTAINER = "slurmd"
+DEFAULT_REMOTE_ROOT = "/tmp/neurodyn-ds006731-r740"
+DEFAULT_DURABLE_BASE = "/mnt/cephfs/neurodyn/derivatives/ds006731"
+DEFAULT_SELECTED_TSV = (
+    "artifacts/research/neurodyn/p3_candidates/"
+    "ds006731_p3_contract_20260705T102500Z/"
+    "balanced_8x8_worker_20260705T113600Z/selected_subjects.tsv"
+)
+DEFAULT_SUBJECTS = ["HVS7", "T011", "T015", "T016", "T017", "T018", "T019"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--namespace", default=DEFAULT_NAMESPACE)
+    parser.add_argument("--pod", default=DEFAULT_POD)
+    parser.add_argument("--container", default=DEFAULT_CONTAINER)
+    parser.add_argument("--remote-root", default=DEFAULT_REMOTE_ROOT)
+    parser.add_argument("--durable-base", default=DEFAULT_DURABLE_BASE)
+    parser.add_argument("--durable-dir", default="")
+    parser.add_argument("--selected-tsv", default=DEFAULT_SELECTED_TSV)
+    parser.add_argument("--subject", action="append", default=[])
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--skip-fmriprep", action="store_true")
+    return parser.parse_args()
+
+
+def now_stamp() -> str:
+    return dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def normalize_subject(subject: str) -> str:
+    subject = subject.strip()
+    if not subject:
+        raise ValueError("empty subject")
+    return subject if subject.startswith("sub-") else f"sub-{subject}"
+
+
+def task_from_bold_path(path: str) -> str:
+    match = re.search(r"_task-([^_]+)_bold\.nii\.gz$", path)
+    if not match:
+        raise ValueError(f"cannot infer task from BOLD path: {path}")
+    return match.group(1)
+
+
+def read_subject_rows(path: Path) -> dict[str, dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        rows = {}
+        for row in reader:
+            subject = normalize_subject(row["subject_id"])
+            row["subject_id"] = subject
+            row["task"] = task_from_bold_path(row["bold_path"])
+            rows[subject] = row
+        return rows
+
+
+def run(cmd: list[str], *, dry_run: bool, check: bool = True) -> subprocess.CompletedProcess[str]:
+    print("+", " ".join(shlex.quote(part) for part in cmd), flush=True)
+    if dry_run:
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    proc = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+    if proc.stdout:
+        print(proc.stdout, end="" if proc.stdout.endswith("\n") else "\n", flush=True)
+    if check and proc.returncode != 0:
+        raise SystemExit(proc.returncode)
+    return proc
+
+
+def kubectl(args: argparse.Namespace, remote_command: str, *, dry_run: bool, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(
+        [
+            "kubectl",
+            "-n",
+            args.namespace,
+            "exec",
+            args.pod,
+            "-c",
+            args.container,
+            "--",
+            "sh",
+            "-lc",
+            remote_command,
+        ],
+        dry_run=dry_run,
+        check=check,
+    )
+
+
+def remote_python_download_script(root: str, row: dict[str, str]) -> str:
+    files = []
+    for key in ("bold_path", "anat_path"):
+        rel = row[key]
+        files.append(rel)
+        if rel.endswith(".nii.gz"):
+            files.append(rel.removesuffix(".nii.gz") + ".json")
+    payload = json.dumps({"root": root, "files": files})
+    return rf"""python3 - <<'PY'
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+payload = json.loads({payload!r})
+root = Path(payload["root"])
+base = "https://s3.amazonaws.com/openneuro.org/ds006731"
+for rel in payload["files"]:
+    target = root / "bids" / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists() and target.stat().st_size > 0:
+        print(f"download_skip existing {{target}}")
+        continue
+    url = f"{{base}}/{{rel}}"
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    req = urllib.request.Request(url, headers={{"User-Agent": "sounio-neurodyn-scale14x14/1.0"}})
+    with urllib.request.urlopen(req, timeout=120) as response, tmp.open("wb") as handle:
+        while True:
+            chunk = response.read(1024 * 1024)
+            if not chunk:
+                break
+            handle.write(chunk)
+    os.replace(tmp, target)
+    print(f"downloaded {{target}} bytes={{target.stat().st_size}}")
+PY"""
+
+
+def remote_participants_script(root: str, rows: list[dict[str, str]]) -> str:
+    participants = [
+        {
+            "participant_id": row["subject_id"],
+            "group": "MDD" if row["label"] == "1" else "HV",
+            "site": "ds006731",
+        }
+        for row in rows
+    ]
+    payload = json.dumps({"root": root, "participants": participants})
+    return rf"""python3 - <<'PY'
+import csv
+import json
+from pathlib import Path
+
+payload = json.loads({payload!r})
+path = Path(payload["root"]) / "bids" / "participants.tsv"
+path.parent.mkdir(parents=True, exist_ok=True)
+existing = {{}}
+if path.exists():
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        for row in csv.DictReader(handle, delimiter="\t"):
+            existing[row["participant_id"]] = row
+for row in payload["participants"]:
+    existing[row["participant_id"]] = row
+with path.open("w", encoding="utf-8", newline="") as handle:
+    writer = csv.DictWriter(handle, fieldnames=["participant_id", "group", "site"], delimiter="\t")
+    writer.writeheader()
+    for subject in sorted(existing):
+        row = existing[subject]
+        writer.writerow({{
+            "participant_id": subject,
+            "group": row.get("group", ""),
+            "site": row.get("site", "") or "ds006731",
+        }})
+print(f"participants_tsv={{path}} rows={{len(existing)}}")
+PY"""
+
+
+def fmriprep_command(root: str, subject: str) -> str:
+    label = subject.removeprefix("sub-")
+    log = f"{root}/fmriprep_{subject}_full_sloppy.log"
+    rc = f"{root}/fmriprep_{subject}_full_sloppy.rc"
+    return " ".join(
+        [
+            "set -u;",
+            f"cd {shlex.quote(root)};",
+            "mkdir -p out work singularity-cache;",
+            "export SINGULARITY_CACHEDIR=./singularity-cache;",
+            "export TEMPLATEFLOW_HOME=/templateflow;",
+            "singularity run --cleanenv",
+            f"-B {shlex.quote(root + '/bids')}:/data:ro",
+            f"-B {shlex.quote(root + '/out')}:/out",
+            f"-B {shlex.quote(root + '/work')}:/work",
+            f"-B {shlex.quote(root + '/license')}:/license:ro",
+            f"-B {shlex.quote(root + '/templateflow')}:/templateflow",
+            f"{shlex.quote(root + '/fmriprep-24.1.1.sif')}",
+            "/data /out participant",
+            f"--participant-label {shlex.quote(label)}",
+            "--skip-bids-validation",
+            "--fs-license-file /license/license.txt",
+            "--fs-no-reconall --sloppy",
+            "--nthreads 12 --omp-nthreads 4 --mem-mb 48000",
+            "--notrack",
+            "--output-spaces MNI152NLin2009cAsym:res-2",
+            "-w /work",
+            f"> {shlex.quote(log)} 2>&1;",
+            "run_rc=$?;",
+            f"echo $run_rc > {shlex.quote(rc)};",
+            "exit $run_rc",
+        ]
+    )
+
+
+def roi_extract_command(root: str, durable_dir: str, row: dict[str, str]) -> str:
+    subject = row["subject_id"]
+    task = row["task"]
+    group = "MDD" if row["label"] == "1" else "HV"
+    participant_file = f"{root}/participants_{subject}.tsv"
+    return " ".join(
+        [
+            "set -u;",
+            f"printf 'participant_id\\tgroup\\tsite\\n{subject}\\t{group}\\tds006731\\n' > {shlex.quote(participant_file)};",
+            f"singularity exec -B {shlex.quote(root + '/out')}:/fmriprep:ro",
+            f"-B {shlex.quote(root + '/atlas')}:/atlas:ro",
+            f"-B {shlex.quote(root)}:/pilot",
+            f"-B {shlex.quote(root + '/roi')}:/roi",
+            f"{shlex.quote(root + '/fmriprep-24.1.1.sif')}",
+            "python /pilot/extract_fmriprep_roi_timeseries.py",
+            "--fmriprep-dir /fmriprep",
+            f"--participants-tsv /pilot/{Path(participant_file).name}",
+            "--atlas-image /atlas/schaefer_2018/Schaefer2018_200Parcels_7Networks_order_FSLMNI152_2mm.nii.gz",
+            "--output-roi-dir /roi",
+            f"--phenotypic-output /pilot/roi_{subject}_phenotypic.csv",
+            f"--subject-id {shlex.quote(subject)}",
+            f"--task {shlex.quote(task)}",
+            "--confounds-mode motion",
+            "--standardize",
+            "--detrend",
+            "--fail-on-empty",
+            f"> {shlex.quote(root + f'/roi_extract_{subject}.log')} 2>&1;",
+            "roi_rc=$?;",
+            f"echo $roi_rc > {shlex.quote(root + f'/roi_extract_{subject}.rc')};",
+            "test \"$roi_rc\" = 0;",
+            f"test \"$(cat {shlex.quote(root + f'/roi_extract_{subject}.rc')})\" = 0;",
+            f"mkdir -p {shlex.quote(durable_dir + '/roi')} {shlex.quote(durable_dir + '/logs')} {shlex.quote(durable_dir + '/rc')};",
+            f"cp {shlex.quote(root + f'/roi/{subject}.1D')} {shlex.quote(durable_dir + f'/roi/{subject}.1D')};",
+            f"cp {shlex.quote(root + f'/roi_{subject}_phenotypic.csv')} {shlex.quote(durable_dir + '/')};",
+            f"cp {shlex.quote(root + f'/roi_extract_{subject}.rc')} {shlex.quote(durable_dir + f'/rc/')};",
+            f"cp {shlex.quote(root + f'/roi_extract_{subject}.log')} {shlex.quote(durable_dir + f'/logs/')};",
+            f"cp {shlex.quote(root + f'/fmriprep_{subject}_full_sloppy.rc')} {shlex.quote(durable_dir + f'/rc/')} 2>/dev/null || true;",
+            f"cp {shlex.quote(root + f'/fmriprep_{subject}_full_sloppy.log')} {shlex.quote(durable_dir + f'/logs/')} 2>/dev/null || true;",
+            f"sha256sum {shlex.quote(durable_dir + f'/roi/{subject}.1D')} > {shlex.quote(durable_dir + f'/roi/{subject}.1D.sha256')};",
+        ]
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    selected = read_subject_rows(Path(args.selected_tsv))
+    subjects = [normalize_subject(item) for item in (args.subject or DEFAULT_SUBJECTS)]
+    rows = []
+    for subject in subjects:
+        if subject not in selected:
+            raise SystemExit(f"subject not found in selected TSV: {subject}")
+        rows.append(selected[subject])
+    durable_dir = args.durable_dir or f"{args.durable_base}/scale14x14_missing_{now_stamp()}"
+
+    manifest = {
+        "schema": "brain_ossm.neurodyn.scale14x14_missing_roi_rerun.v1",
+        "created_at_utc": now_stamp(),
+        "namespace": args.namespace,
+        "pod": args.pod,
+        "container": args.container,
+        "remote_root": args.remote_root,
+        "durable_dir": durable_dir,
+        "subjects": [{"subject_id": row["subject_id"], "label": row["label"], "task": row["task"]} for row in rows],
+        "claim_boundary": "ROI preprocessing only. No clinical, mechanistic, or replicated O-SSM claim.",
+    }
+    print(json.dumps(manifest, indent=2), flush=True)
+
+    kubectl(args, f"mkdir -p {shlex.quote(durable_dir)}", dry_run=args.dry_run)
+    kubectl(args, remote_participants_script(args.remote_root, rows), dry_run=args.dry_run)
+
+    for row in rows:
+        subject = row["subject_id"]
+        print(f"== subject {subject} task={row['task']} ==", flush=True)
+        kubectl(args, remote_python_download_script(args.remote_root, row), dry_run=args.dry_run)
+        if not args.skip_fmriprep:
+            kubectl(args, f"test -s {shlex.quote(args.remote_root + f'/out/{subject}.html')} && echo fmriprep_skip_existing || ({fmriprep_command(args.remote_root, subject)})", dry_run=args.dry_run)
+        kubectl(args, roi_extract_command(args.remote_root, durable_dir, row), dry_run=args.dry_run)
+
+    manifest_json = json.dumps(manifest, indent=2, sort_keys=True)
+    kubectl(
+        args,
+        f"cat > {shlex.quote(durable_dir + '/rerun_manifest.json')} <<'JSON'\n{manifest_json}\nJSON\n"
+        f"find {shlex.quote(durable_dir)} -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > {shlex.quote(durable_dir + '/SHA256SUMS')}",
+        dry_run=args.dry_run,
+    )
+    print(f"durable_dir={durable_dir}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/research/neurodyn_scale_roi_readiness.py
+++ b/scripts/research/neurodyn_scale_roi_readiness.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Inventory durable ROI availability for a scaled NeuroDyn ds006731 cohort."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.scale_roi_readiness.v1"
+CLAIM_BOUNDARY = "Operational ROI readiness only; no O-SSM, clinical, or biomarker claim."
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--selected-subjects", required=True)
+    parser.add_argument("--roi-root", action="append", default=[], help="Root to search for roi/sub-*.1D files.")
+    parser.add_argument(
+        "--roi-index",
+        action="append",
+        default=[],
+        help="Optional TSV with subject and path columns for ROIs discovered outside this filesystem.",
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--target-per-class", type=int, default=14)
+    return parser.parse_args()
+
+
+def read_selected(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def read_roi_index(path: Path) -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    if not path.exists():
+        return found
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for row in reader:
+            subject = (row.get("subject") or row.get("subject_id") or "").removeprefix("sub-")
+            roi_path = row.get("path") or row.get("roi_path") or row.get("primary_roi_path") or ""
+            if subject and roi_path:
+                found.setdefault(subject, []).append(roi_path)
+    return found
+
+
+def find_roi_files(roots: list[Path], roi_indexes: list[Path]) -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("sub-*.1D")):
+            if path.parent.name not in {"roi", "rois"}:
+                continue
+            subject = path.name.removeprefix("sub-").removesuffix(".1D")
+            found.setdefault(subject, []).append(str(path.resolve()))
+    for index_path in roi_indexes:
+        for subject, paths in read_roi_index(index_path).items():
+            found.setdefault(subject, []).extend(paths)
+    return {subject: sorted(paths) for subject, paths in sorted(found.items())}
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fields = list(rows[0])
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def label_name(label: str) -> str:
+    return "MDD" if str(label) == "1" else "CONTROL"
+
+
+def main() -> int:
+    args = parse_args()
+    selected_path = Path(args.selected_subjects).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    roots = [Path(raw).resolve() for raw in args.roi_root]
+    roi_indexes = [Path(raw).resolve() for raw in args.roi_index]
+
+    selected = read_selected(selected_path)
+    roi_files = find_roi_files(roots, roi_indexes)
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(selected):
+        subject_id = row["subject_id"]
+        subject = subject_id.removeprefix("sub-")
+        paths = roi_files.get(subject, [])
+        rows.append(
+            {
+                "candidate_order": index,
+                "subject": subject,
+                "subject_id": subject_id,
+                "label": row["label"],
+                "label_name": label_name(row["label"]),
+                "raw_label": row.get("raw_label", ""),
+                "has_roi": bool(paths),
+                "roi_path_count": len(paths),
+                "primary_roi_path": paths[0] if paths else "",
+                "bold_s3_uri": row.get("bold_s3_uri", ""),
+                "anat_s3_uri": row.get("anat_s3_uri", ""),
+            }
+        )
+
+    selected_for_target: list[dict[str, Any]] = []
+    missing_for_target: list[dict[str, Any]] = []
+    counts = {"0": 0, "1": 0}
+    available_counts = {"0": 0, "1": 0}
+    for row in rows:
+        label = str(row["label"])
+        if row["has_roi"]:
+            available_counts[label] = available_counts.get(label, 0) + 1
+        if counts.get(label, 0) >= args.target_per_class:
+            continue
+        counts[label] = counts.get(label, 0) + 1
+        selected_for_target.append(row)
+        if not row["has_roi"]:
+            missing_for_target.append(row)
+
+    summary = {
+        "schema": SCHEMA,
+        "created_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "selected_subjects": str(selected_path),
+        "roi_roots": [str(root) for root in roots],
+        "roi_indexes": [str(path) for path in roi_indexes],
+        "target_per_class": args.target_per_class,
+        "candidate_count": len(rows),
+        "candidate_label_counts": {
+            "0": sum(1 for row in rows if str(row["label"]) == "0"),
+            "1": sum(1 for row in rows if str(row["label"]) == "1"),
+        },
+        "available_roi_label_counts": available_counts,
+        "target_selected_count": len(selected_for_target),
+        "target_selected_label_counts": counts,
+        "target_available_label_counts": {
+            "0": sum(1 for row in selected_for_target if str(row["label"]) == "0" and row["has_roi"]),
+            "1": sum(1 for row in selected_for_target if str(row["label"]) == "1" and row["has_roi"]),
+        },
+        "target_missing_count": len(missing_for_target),
+        "target_missing_subjects": [row["subject"] for row in missing_for_target],
+        "decision": "ready_for_scaled_manifest" if not missing_for_target else "blocked_missing_roi",
+        "next_action": "build scaled manifest" if not missing_for_target else "run fMRIPrep/ROI extraction for target_missing_subjects",
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "scale_roi_readiness.json", summary)
+    write_tsv(output_dir / "scale_roi_inventory.tsv", rows)
+    write_tsv(output_dir / "scale_target_selected.tsv", selected_for_target)
+    write_tsv(output_dir / "scale_target_missing.tsv", missing_for_target)
+    print(f"decision={summary['decision']}")
+    print(f"available_roi_label_counts={summary['available_roi_label_counts']}")
+    print(f"target_available_label_counts={summary['target_available_label_counts']}")
+    print(f"target_missing_subjects={','.join(summary['target_missing_subjects'])}")
+    print(f"summary={output_dir / 'scale_roi_readiness.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_scaled_eval_plan.py
+++ b/scripts/research/neurodyn_scaled_eval_plan.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Create a claim-safe next-wave evaluation plan for NeuroDyn O-SSM.
+
+This script does not submit jobs. It turns the current P3 receipts into an
+auditable scale plan with concrete gates for a larger MDD/ADHD-style evaluation:
+manifest quality, O-SSM vs baselines, label/temporal controls, checkpoint replay,
+trained associator extraction, and promotion boundaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+from abide_campaign_lib import load_manifest
+
+
+SCHEMA = "neurodyn.scaled_eval_plan.v1"
+CLAIM_BOUNDARY = (
+    "Planning/operations only. No positive clinical, mechanistic, biomarker, "
+    "or replicated O-SSM claim is authorized by this plan."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True, help="Current manifest used by the verified smoke.")
+    parser.add_argument("--checkpoint", required=True, help="Verified trained checkpoint from the smoke.")
+    parser.add_argument("--metric-matrix-dir", required=True, help="Trained associator metric matrix receipt directory.")
+    parser.add_argument("--output-dir", required=True, help="Directory to write the scale plan receipt.")
+    parser.add_argument("--dataset-id", default="ds006731")
+    parser.add_argument("--label-space", default="mdd_vs_control")
+    parser.add_argument("--target-subjects", type=int, default=28)
+    parser.add_argument("--target-per-class", type=int, default=14)
+    parser.add_argument("--target-min-sites", type=int, default=4)
+    parser.add_argument("--native-souc-engine", default="lean_single")
+    parser.add_argument("--cluster-worker", default="slurm-pilot-worker-gpuorangefs-multi-mpttj")
+    parser.add_argument("--durable-root", default="/mnt/cephfs/neurodyn/derivatives/ds006731")
+    return parser.parse_args()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def read_metric_summary(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    fields = list(rows[0])
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def manifest_summary(manifest: Path) -> dict[str, Any]:
+    meta, records = load_manifest(manifest)
+    label_counts: dict[str, int] = {}
+    site_counts: dict[str, int] = {}
+    site_label_counts: dict[str, dict[str, int]] = {}
+    for record in records:
+        label = str(record.label)
+        label_counts[label] = label_counts.get(label, 0) + 1
+        site_counts[record.site] = site_counts.get(record.site, 0) + 1
+        site_label_counts.setdefault(record.site, {"0": 0, "1": 0})
+        site_label_counts[record.site][label] = site_label_counts[record.site].get(label, 0) + 1
+    return {
+        "path": str(manifest.resolve()),
+        "schema": meta.schema,
+        "subject_count": len(records),
+        "label_counts": label_counts,
+        "site_count": len(site_counts),
+        "site_counts": site_counts,
+        "site_label_counts": site_label_counts,
+        "seq_len": meta.seq_len,
+        "input_dim": meta.input_dim,
+        "feature_count": meta.seq_len * meta.input_dim,
+        "label_space": meta.label_space,
+        "extra": meta.extra,
+    }
+
+
+def _array_values(checkpoint: dict[str, Any], name: str) -> list[float]:
+    raw = checkpoint.get("arrays", {}).get(name, {}).get("values", [])
+    return [float(value) for value in raw]
+
+
+def _abs_summary(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"count": 0, "nonzero_count": 0, "l1": 0.0, "linf": 0.0, "mean_abs": 0.0}
+    abs_values = [abs(value) for value in values]
+    return {
+        "count": len(values),
+        "nonzero_count": sum(1 for value in abs_values if value > 1.0e-12),
+        "l1": sum(abs_values),
+        "linf": max(abs_values),
+        "mean_abs": sum(abs_values) / len(abs_values),
+    }
+
+
+def octonionic_nontriviality(checkpoint: dict[str, Any], metric_rows: list[dict[str, str]]) -> dict[str, Any]:
+    arrays = checkpoint.get("arrays", {})
+    a = _array_values(checkpoint, "A")
+    a_fixed = _array_values(checkpoint, "A_FIXED")
+    last_assoc = _array_values(checkpoint, "LAST_ASSOC_ACC")
+    last_h = _array_values(checkpoint, "LAST_H")
+    top_rows = []
+    for row in metric_rows:
+        top_rows.append(
+            {
+                "metric": row.get("metric", ""),
+                "top1_roi": row.get("top1_roi", ""),
+                "top1_p_raw": row.get("top1_p_raw", ""),
+                "top1_p_holm": row.get("top1_p_holm", ""),
+                "top1_cliffs_delta": row.get("top1_cliffs_delta", ""),
+                "holm_survivors": row.get("holm_survivors", ""),
+            }
+        )
+    return {
+        "arrays_present": sorted(arrays),
+        "a_summary": _abs_summary(a),
+        "a_fixed_summary": _abs_summary(a_fixed),
+        "last_assoc_acc_summary": _abs_summary(last_assoc),
+        "last_h_summary": _abs_summary(last_h),
+        "metric_top1": top_rows,
+        "nontrivial_result_definition": [
+            "trained octonionic state is nonzero and replayable in a fresh process",
+            "associator/hidden trajectory signal is stable across folds/seeds, not only a single saturated readout",
+            "effect survives comparative baselines and disappears or changes appropriately under label/temporal controls",
+            "ROI or mechanistic interpretation is corrected for multiplicity and robust across preregistered metric family",
+        ],
+    }
+
+
+def gate_rows(current: dict[str, Any], checkpoint: dict[str, Any], metric_rows: list[dict[str, str]], args: argparse.Namespace) -> list[dict[str, Any]]:
+    label_counts = current["label_counts"]
+    min_class = min(int(label_counts.get("0", 0)), int(label_counts.get("1", 0)))
+    holm_survivors = sum(int(float(row.get("holm_survivors") or 0)) for row in metric_rows)
+    verification = checkpoint.get("verification") or {}
+    octo = octonionic_nontriviality(checkpoint, metric_rows)
+    a_signal = octo["a_summary"]["nonzero_count"] > 0 or octo["a_fixed_summary"]["nonzero_count"] > 0
+    assoc_signal = octo["last_assoc_acc_summary"]["nonzero_count"] > 0
+    hidden_signal = octo["last_h_summary"]["nonzero_count"] > 0
+    return [
+        {
+            "gate": "manifest_scale",
+            "current_status": "blocked" if current["subject_count"] < args.target_subjects else "pass",
+            "current_value": current["subject_count"],
+            "target": args.target_subjects,
+            "why": "Avoid interpreting n=16 smoke as replicated clinical evidence.",
+        },
+        {
+            "gate": "class_balance",
+            "current_status": "blocked" if min_class < args.target_per_class else "pass",
+            "current_value": min_class,
+            "target": args.target_per_class,
+            "why": "Nested folds need enough positives and controls after holdout.",
+        },
+        {
+            "gate": "site_or_pseudofold_balance",
+            "current_status": "pass" if current["site_count"] >= args.target_min_sites else "blocked",
+            "current_value": current["site_count"],
+            "target": args.target_min_sites,
+            "why": "Grouped CV requires at least four balanced folds/sites.",
+        },
+        {
+            "gate": "checkpoint_replay",
+            "current_status": "pass" if verification.get("status") == "pass" else "blocked",
+            "current_value": f"{verification.get('actual_balanced_accuracy_pct')} delta={verification.get('delta_pp')}",
+            "target": "status=pass and delta<=0.5pp for every promoted fold",
+            "why": "No associator extraction from model-free or non-replayable state.",
+        },
+        {
+            "gate": "octonionic_state_nonzero",
+            "current_status": "pass" if a_signal and hidden_signal else "blocked",
+            "current_value": f"A_nonzero={octo['a_summary']['nonzero_count']} H_nonzero={octo['last_h_summary']['nonzero_count']}",
+            "target": "trained A/H state nonzero for every promoted checkpoint",
+            "why": "An octonionic state-space result must use trained octonionic state, not model-free scaffolding.",
+        },
+        {
+            "gate": "associator_activity",
+            "current_status": "pass" if assoc_signal else "blocked",
+            "current_value": f"LAST_ASSOC_ACC_nonzero={octo['last_assoc_acc_summary']['nonzero_count']}",
+            "target": "nonzero associator activity plus control-specific behavior at scale",
+            "why": "Non-associative dynamics are the point of O-SSM; BA alone is not enough.",
+        },
+        {
+            "gate": "metric_robustness",
+            "current_status": "negative_control_pass",
+            "current_value": f"holm_survivors={holm_survivors}",
+            "target": "no biomarker claim unless corrected and robust across preregistered metric family",
+            "why": "Current smoke has no Holm-corrected ROI survivor.",
+        },
+        {
+            "gate": "baseline_superiority",
+            "current_status": "missing_at_scale",
+            "current_value": "H-SSM exceeded O-SSM in current smoke",
+            "target": "O-SSM improvement over H-SSM and external baselines with controls",
+            "why": "Utility claim must be comparative, not a solo accuracy number.",
+        },
+        {
+            "gate": "null_controls",
+            "current_status": "planned",
+            "current_value": "label_shuffle + temporal_shuffle/reverse required",
+            "target": "positive result must collapse under label shuffle and behave specifically under temporal controls",
+            "why": "Separates real dynamics from leakage or arbitrary separability.",
+        },
+        {
+            "gate": "octonionic_nontriviality_at_scale",
+            "current_status": "planned",
+            "current_value": "requires fold/seed distribution of associator and hidden trajectory diagnostics",
+            "target": "nontrivial O-SSM effect is algebraically active, replayable, control-specific, and comparatively useful",
+            "why": "Prevents missing a real octonionic state-space effect or overclaiming a trivial classifier artifact.",
+        },
+    ]
+
+
+def shell_plan(args: argparse.Namespace) -> list[str]:
+    root = args.durable_root.rstrip("/")
+    return [
+        "# 1. Expand durable ROI manifest, then build pseudo-fold and control manifests.",
+        f"python3 scripts/research/neurodyn_ds006731_p3_manifest.py --survivor-root {root}/p3_candidates --rerun-root {root}/rerun_YYYYMMDDTHHMMSSZ --out-root {root}/p3_candidates --site-policy pseudo_fold4 --roi-buckets 8",
+        "# 2. Run manifest quality gate before any training.",
+        "python3 scripts/research/abide_manifest_quality_gate.py --manifest ${RUN_MANIFEST}",
+        "# 3. Run O-SSM campaign profile only; require checkpoint persistence and replay.",
+        "RUN_ID=neurodyn-ds006731-scaled-o-assoc-stable-${STAMP} SKIP_EXTERNAL_BASELINES=1 STOP_AFTER_CHECKPOINT=0 ABIDE_MANIFEST_PATH=${RUN_MANIFEST} bash slurm-jobs/brain-ossm/submit-abide-campaign-gpu.sh",
+        "# 4. Run external baselines on the same manifest and folds.",
+        "ABIDE_MANIFEST_PATH=${RUN_MANIFEST} bash slurm-jobs/brain-ossm/submit-abide-external-baselines-gpu.sh",
+        "# 5. Gate trained associator only after checkpoint replay passes.",
+        f"python3 scripts/research/neurodyn_postcampaign_trained_associator_gate.py --manifest ${{RUN_MANIFEST}} --checkpoint ${{MODEL_CKPT}} --output-dir ${{ASSOC_OUT}} --native-souc-engine {args.native_souc_engine} --execute-associator",
+    ]
+
+
+def markdown(plan: dict[str, Any], gates: list[dict[str, Any]]) -> str:
+    lines = [
+        "# NeuroDyn Scaled Evaluation Plan",
+        "",
+        f"- created_at_utc: `{plan['created_at_utc']}`",
+        f"- dataset_id: `{plan['dataset_id']}`",
+        f"- label_space: `{plan['label_space']}`",
+        f"- current_manifest_subjects: `{plan['current_manifest']['subject_count']}`",
+        f"- current_label_counts: `{plan['current_manifest']['label_counts']}`",
+        f"- current_site_count: `{plan['current_manifest']['site_count']}`",
+        f"- checkpoint_run_id: `{plan['checkpoint'].get('run_id')}`",
+        f"- checkpoint_replay_status: `{plan['checkpoint'].get('verification', {}).get('status')}`",
+        f"- claim_boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Octonionic Nontriviality",
+        "",
+        f"- A_nonzero_count: `{plan['octonionic_nontriviality']['a_summary']['nonzero_count']}`",
+        f"- A_linf: `{plan['octonionic_nontriviality']['a_summary']['linf']}`",
+        f"- A_FIXED_nonzero_count: `{plan['octonionic_nontriviality']['a_fixed_summary']['nonzero_count']}`",
+        f"- LAST_H_nonzero_count: `{plan['octonionic_nontriviality']['last_h_summary']['nonzero_count']}`",
+        f"- LAST_ASSOC_ACC_nonzero_count: `{plan['octonionic_nontriviality']['last_assoc_acc_summary']['nonzero_count']}`",
+        "- nontrivial_result_definition:",
+    ]
+    lines.extend(f"  - {item}" for item in plan["octonionic_nontriviality"]["nontrivial_result_definition"])
+    lines.extend(
+        [
+            "",
+        "## Gates",
+        "",
+        "| gate | status | current | target |",
+        "|---|---|---:|---|",
+        ]
+    )
+    for row in gates:
+        lines.append(f"| `{row['gate']}` | `{row['current_status']}` | `{row['current_value']}` | {row['target']} |")
+    lines.extend(
+        [
+            "",
+            "## Execution Sketch",
+            "",
+        ]
+    )
+    lines.extend(f"```bash\n{cmd}\n```" for cmd in plan["shell_plan"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    manifest = Path(args.manifest).resolve()
+    checkpoint_path = Path(args.checkpoint).resolve()
+    metric_matrix_dir = Path(args.metric_matrix_dir).resolve()
+
+    checkpoint = read_json(checkpoint_path)
+    metric_summary = read_metric_summary(metric_matrix_dir / "metric_matrix_summary.tsv")
+    current = manifest_summary(manifest)
+    gates = gate_rows(current, checkpoint, metric_summary, args)
+    plan = {
+        "schema": SCHEMA,
+        "created_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "dataset_id": args.dataset_id,
+        "label_space": args.label_space,
+        "current_manifest": current,
+        "checkpoint_path": str(checkpoint_path),
+        "checkpoint": {
+            "run_id": checkpoint.get("run_id"),
+            "meta": checkpoint.get("meta"),
+            "verification": checkpoint.get("verification"),
+        },
+        "metric_matrix_dir": str(metric_matrix_dir),
+        "metric_summary": metric_summary,
+        "octonionic_nontriviality": octonionic_nontriviality(checkpoint, metric_summary),
+        "target": {
+            "subjects": args.target_subjects,
+            "per_class": args.target_per_class,
+            "min_sites": args.target_min_sites,
+            "native_souc_engine": args.native_souc_engine,
+            "cluster_worker": args.cluster_worker,
+            "durable_root": args.durable_root,
+        },
+        "promotion_rule": {
+            "required": [
+                "scaled manifest meets target subject/class/site gates",
+                "O-SSM checkpoint replay delta <= 0.5pp for every promoted fold",
+                "O-SSM compared against H-SSM and external baselines on identical manifest/folds",
+                "label shuffle fails to reproduce the positive effect",
+                "temporal controls behave specifically for the claimed dynamic effect",
+                "trained associator uses verified checkpoints only",
+                "octonionic state/associator diagnostics are nonzero, replayable, and control-specific",
+            ],
+            "disallowed": [
+                "positive clinical claim from n=16 smoke",
+                "ROI biomarker claim without Holm-corrected and robust evidence",
+                "associator extraction from untrained or non-replayable state",
+                "calling a plain classification delta an octonionic result without A/H/associator diagnostics",
+            ],
+        },
+        "shell_plan": shell_plan(args),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    write_json(output_dir / "scaled_eval_plan.json", plan)
+    write_tsv(output_dir / "scaled_eval_gates.tsv", gates)
+    (output_dir / "scaled_eval_plan.md").write_text(markdown(plan, gates), encoding="utf-8")
+    print(f"plan={output_dir / 'scaled_eval_plan.json'}")
+    print(f"gates={output_dir / 'scaled_eval_gates.tsv'}")
+    print(f"markdown={output_dir / 'scaled_eval_plan.md'}")
+    blocked = [row["gate"] for row in gates if row["current_status"] in {"blocked", "missing_at_scale"}]
+    print("blocked_gates=" + ",".join(blocked))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_temporal_arrow_logit_part_ablation.py
+++ b/scripts/research/neurodyn_temporal_arrow_logit_part_ablation.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Post-hoc ablations for temporal-arrow Brain O-SSM logit part traces."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Callable
+
+
+SCHEMA = "neurodyn.temporal_arrow_logit_part_ablation.v1"
+CLAIM_BOUNDARY = (
+    "Temporal-arrow logit-channel diagnostic only. This post-hoc readout "
+    "ablation is not a clinical, diagnostic, mechanistic, or O-SSM superiority "
+    "claim; trained ablations are still required for causal readout claims."
+)
+
+PARTS = ("bias", "hidden", "assoc", "mean", "delta", "flat")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        help="Input as CONDITION=path/to/temporal_arrow_logit_parts_rows.tsv. May repeat.",
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def read_tsv(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        rows = [dict(row) for row in reader]
+    for row in rows:
+        row["seed"] = int(row["seed"])
+        row["label"] = int(row["label"])
+        for part in (*PARTS, "total", "logit"):
+            row[part] = float(row[part])
+    return rows
+
+
+def parse_inputs(raw_inputs: list[str]) -> list[tuple[str, Path]]:
+    parsed: list[tuple[str, Path]] = []
+    for raw in raw_inputs:
+        if "=" not in raw:
+            raise SystemExit(f"input must be CONDITION=path: {raw}")
+        condition, path_raw = raw.split("=", 1)
+        condition = condition.strip()
+        path = Path(path_raw).resolve()
+        if not condition:
+            raise SystemExit(f"empty condition for input: {raw}")
+        if not path.exists():
+            raise SystemExit(f"missing input: {path}")
+        parsed.append((condition, path))
+    return parsed
+
+
+def score_full(row: dict[str, Any]) -> float:
+    return float(row["logit"])
+
+
+def score_total_unclipped(row: dict[str, Any]) -> float:
+    return float(row["total"])
+
+
+def score_no_flat(row: dict[str, Any]) -> float:
+    return row["bias"] + row["hidden"] + row["assoc"] + row["mean"] + row["delta"]
+
+
+def score_no_delta(row: dict[str, Any]) -> float:
+    return row["bias"] + row["hidden"] + row["assoc"] + row["mean"] + row["flat"]
+
+
+def score_no_delta_flat(row: dict[str, Any]) -> float:
+    return row["bias"] + row["hidden"] + row["assoc"] + row["mean"]
+
+
+def score_state_only(row: dict[str, Any]) -> float:
+    return row["bias"] + row["hidden"] + row["assoc"]
+
+
+def score_hidden_only(row: dict[str, Any]) -> float:
+    return row["bias"] + row["hidden"]
+
+
+def score_assoc_only(row: dict[str, Any]) -> float:
+    return row["bias"] + row["assoc"]
+
+
+def score_summary_only(row: dict[str, Any]) -> float:
+    return row["bias"] + row["mean"] + row["delta"]
+
+
+def score_delta_flat_only(row: dict[str, Any]) -> float:
+    return row["bias"] + row["delta"] + row["flat"]
+
+
+ABLATIONS: dict[str, Callable[[dict[str, Any]], float]] = {
+    "full_clipped": score_full,
+    "full_unclipped": score_total_unclipped,
+    "no_flat": score_no_flat,
+    "no_delta": score_no_delta,
+    "no_delta_flat": score_no_delta_flat,
+    "state_only": score_state_only,
+    "hidden_only": score_hidden_only,
+    "assoc_only": score_assoc_only,
+    "summary_only": score_summary_only,
+    "delta_flat_only": score_delta_flat_only,
+}
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def pstdev(values: list[float]) -> float:
+    return statistics.pstdev(values) if len(values) > 1 else 0.0
+
+
+def balanced_accuracy(labels: list[int], preds: list[int]) -> float:
+    positives = [idx for idx, label in enumerate(labels) if label == 1]
+    negatives = [idx for idx, label in enumerate(labels) if label == 0]
+    if not positives or not negatives:
+        return 0.0
+    tpr = sum(1 for idx in positives if preds[idx] == 1) / len(positives)
+    tnr = sum(1 for idx in negatives if preds[idx] == 0) / len(negatives)
+    return 100.0 * (tpr + tnr) / 2.0
+
+
+def accuracy(labels: list[int], preds: list[int]) -> float:
+    if not labels:
+        return 0.0
+    return 100.0 * sum(1 for label, pred in zip(labels, preds, strict=True) if label == pred) / len(labels)
+
+
+def summarize(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    detail: list[dict[str, Any]] = []
+    grouped: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(row["condition"], row["model"], row["seed"])].append(row)
+
+    for (condition, model, seed), chunk in sorted(grouped.items()):
+        labels = [int(row["label"]) for row in chunk]
+        for ablation, score_fn in ABLATIONS.items():
+            scores = [score_fn(row) for row in chunk]
+            preds = [1 if score >= 0.0 else 0 for score in scores]
+            detail.append(
+                {
+                    "condition": condition,
+                    "model": model,
+                    "seed": seed,
+                    "ablation": ablation,
+                    "rows": len(chunk),
+                    "accuracy": accuracy(labels, preds),
+                    "balanced_accuracy": balanced_accuracy(labels, preds),
+                    "positive_score_frac": mean([1.0 if score >= 0.0 else 0.0 for score in scores]),
+                    "score_mean": mean(scores),
+                    "score_std": pstdev(scores),
+                }
+            )
+
+    summary_groups: dict[tuple[str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in detail:
+        summary_groups[(row["condition"], row["model"], row["ablation"])].append(row)
+
+    summary: list[dict[str, Any]] = []
+    for (condition, model, ablation), chunk in sorted(summary_groups.items()):
+        ba_values = [float(row["balanced_accuracy"]) for row in chunk]
+        acc_values = [float(row["accuracy"]) for row in chunk]
+        pos_values = [float(row["positive_score_frac"]) for row in chunk]
+        score_values = [float(row["score_mean"]) for row in chunk]
+        summary.append(
+            {
+                "condition": condition,
+                "model": model,
+                "ablation": ablation,
+                "seed_count": len(chunk),
+                "balanced_accuracy_mean": mean(ba_values),
+                "balanced_accuracy_std": pstdev(ba_values),
+                "accuracy_mean": mean(acc_values),
+                "accuracy_std": pstdev(acc_values),
+                "positive_score_frac_mean": mean(pos_values),
+                "score_mean_mean": mean(score_values),
+            }
+        )
+    return summary, detail
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_hashes(output_dir: Path) -> None:
+    with (output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n")
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Temporal-Arrow Logit Part Ablation",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        "## Summary",
+        "",
+        "| condition | model | ablation | balanced accuracy mean | ba std | positive score frac |",
+        "|---|---|---|---:|---:|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {condition} | {model} | {ablation} | {ba:.6f} | {ba_std:.6f} | {pos:.6f} |".format(
+                condition=row["condition"],
+                model=row["model"],
+                ablation=row["ablation"],
+                ba=row["balanced_accuracy_mean"],
+                ba_std=row["balanced_accuracy_std"],
+                pos=row["positive_score_frac_mean"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation",
+            "",
+            payload["interpretation"],
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    input_paths = parse_inputs(args.input)
+    all_rows: list[dict[str, Any]] = []
+    sources: dict[str, str] = {}
+    for condition, path in input_paths:
+        rows = read_tsv(path)
+        for row in rows:
+            row["condition"] = condition
+        all_rows.extend(rows)
+        sources[condition] = str(path)
+
+    summary, detail = summarize(all_rows)
+    by_key = {(row["condition"], row["model"], row["ablation"]): row for row in summary}
+    interpretation = (
+        "If full_clipped remains high while no_delta_flat, state_only, or assoc_only collapse, "
+        "the temporal-arrow separability is being carried mainly by direct summary/readout terms. "
+        "If state_only remains high, the corrected O-SSM hidden dynamics deserve a trained "
+        "readout ablation and a stricter non-clinical temporal-dynamics benchmark."
+    )
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "sources": sources,
+        "row_count": len(all_rows),
+        "summary": summary,
+        "detail": detail,
+        "interpretation": interpretation,
+        "state_signal_candidates": [
+            row
+            for key, row in sorted(by_key.items())
+            if key[2] in {"no_delta_flat", "state_only", "assoc_only"}
+            and float(row["balanced_accuracy_mean"]) >= 60.0
+        ],
+    }
+
+    write_json(output_dir / "temporal_arrow_logit_part_ablation.json", payload)
+    write_tsv(output_dir / "temporal_arrow_logit_part_ablation_summary.tsv", summary)
+    write_tsv(output_dir / "temporal_arrow_logit_part_ablation_detail.tsv", detail)
+    (output_dir / "temporal_arrow_logit_part_ablation.md").write_text(markdown(payload), encoding="utf-8")
+    write_hashes(output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_temporal_arrow_logit_parts_audit.py
+++ b/scripts/research/neurodyn_temporal_arrow_logit_parts_audit.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Summarize temporal-arrow logit contribution traces from Brain O-SSM output."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from abide_campaign_lib import load_manifest
+
+
+SCHEMA = "neurodyn.temporal_arrow_logit_parts_audit.v1"
+PART_FIELDS = ["bias", "hidden", "assoc", "mean", "delta", "flat", "total", "logit"]
+CLAIM_BOUNDARY = (
+    "Temporal-arrow diagnostic only. Channel-level readout tracing is not a "
+    "clinical, diagnostic, mechanistic, or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-output", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--condition", default="")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def direction(subject_id: str) -> str:
+    if subject_id.endswith("__forward"):
+        return "forward"
+    if subject_id.endswith("__reverse"):
+        return "reverse"
+    return "unknown"
+
+
+def read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def collect_parts(lines: list[str], records: list[Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.startswith("LOGIT_PARTS"):
+            idx += 1
+            continue
+        parts = [part for part in line.split("\t") if part]
+        next_idx = idx + 1
+        while len(parts) < 14 and next_idx < len(lines) and lines[next_idx].startswith("\t"):
+            parts.extend(part for part in lines[next_idx].split("\t") if part)
+            next_idx += 1
+        if len(parts) != 14:
+            raise ValueError(f"malformed LOGIT_PARTS line at {idx + 1}: {line}")
+        _, model, seed, subject_index_raw, site, label, *raw_values = parts
+        subject_index = int(subject_index_raw)
+        subject_id = records[subject_index].subject_id if 0 <= subject_index < len(records) else ""
+        values = {field: int(raw) / 1_000_000.0 for field, raw in zip(PART_FIELDS, raw_values, strict=True)}
+        dominant = max(PART_FIELDS[:-2], key=lambda field: abs(values[field]))
+        rows.append(
+            {
+                "model": model,
+                "seed": int(seed),
+                "subject_index": subject_index,
+                "subject_id": subject_id,
+                "direction": direction(subject_id),
+                "site": site,
+                "label": int(label),
+                "dominant_part": dominant,
+                **values,
+            }
+        )
+        idx = next_idx
+    return rows
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def pstdev(values: list[float]) -> float:
+    return statistics.pstdev(values) if len(values) > 1 else 0.0
+
+
+def summarize(rows: list[dict[str, Any]], condition: str) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(row["model"], row["direction"])].append(row)
+    out: list[dict[str, Any]] = []
+    for (model, dir_name) in sorted(grouped):
+        chunk = grouped[(model, dir_name)]
+        dominant_counts = Counter(str(row["dominant_part"]) for row in chunk)
+        top_part, top_count = dominant_counts.most_common(1)[0]
+        summary: dict[str, Any] = {
+            "condition": condition,
+            "model": model,
+            "direction": dir_name,
+            "rows": len(chunk),
+            "seed_count": len({row["seed"] for row in chunk}),
+            "label_mean": mean([float(row["label"]) for row in chunk]),
+            "dominant_part_mode": top_part,
+            "dominant_part_mode_frac": top_count / len(chunk),
+            "positive_logit_frac": mean([1.0 if float(row["logit"]) > 0 else 0.0 for row in chunk]),
+        }
+        for field in PART_FIELDS:
+            values = [float(row[field]) for row in chunk]
+            summary[f"{field}_mean"] = mean(values)
+            summary[f"{field}_std"] = pstdev(values)
+        out.append(summary)
+    return out
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_hashes(output_dir: Path) -> None:
+    with (output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n")
+
+
+def markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Temporal-Arrow Logit Parts Audit",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+        f"- condition: `{payload['condition']}`",
+        f"- RUN_ID: `{payload['run_id']}`",
+        f"- row_count: `{payload['row_count']}`",
+        "",
+        "## Direction Summary",
+        "",
+        "| model | direction | logit mean | hidden mean | assoc mean | mean-term | delta mean | flat mean | dominant mode | positive logit frac |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---|---:|",
+    ]
+    for row in payload["summary"]:
+        lines.append(
+            "| {model} | {direction} | {logit:.6f} | {hidden:.6f} | {assoc:.6f} | {mean:.6f} | {delta:.6f} | {flat:.6f} | {dom} | {pos:.6f} |".format(
+                model=row["model"],
+                direction=row["direction"],
+                logit=row["logit_mean"],
+                hidden=row["hidden_mean"],
+                assoc=row["assoc_mean"],
+                mean=row["mean_mean"],
+                delta=row["delta_mean"],
+                flat=row["flat_mean"],
+                dom=row["dominant_part_mode"],
+                pos=row["positive_logit_frac"],
+            )
+        )
+    lines.extend(["", "## Interpretation", "", payload["interpretation"], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _, records = load_manifest(args.manifest)
+    rows = collect_parts(read_lines(Path(args.raw_output)), records)
+    if not rows:
+        raise SystemExit("no LOGIT_PARTS rows found; rebuild Brain O-SSM with logit trace instrumentation")
+    summary = summarize(rows, args.condition)
+    dominant_modes = sorted({row["dominant_part_mode"] for row in summary})
+    interpretation = (
+        "The trace identifies which readout term dominates signed temporal-arrow logits. "
+        "Use this as a localization diagnostic for the observed anti-polarity, not as a "
+        "claim that the channel is mechanistic."
+    )
+    payload = {
+        "schema": SCHEMA,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "run_id": args.run_id,
+        "condition": args.condition,
+        "raw_output": str(Path(args.raw_output).resolve()),
+        "manifest": str(Path(args.manifest).resolve()),
+        "row_count": len(rows),
+        "dominant_modes": dominant_modes,
+        "summary": summary,
+        "interpretation": interpretation,
+    }
+    write_json(output_dir / "temporal_arrow_logit_parts_audit.json", payload)
+    write_tsv(output_dir / "temporal_arrow_logit_parts_summary.tsv", summary)
+    write_tsv(output_dir / "temporal_arrow_logit_parts_rows.tsv", rows)
+    (output_dir / "temporal_arrow_logit_parts_audit.md").write_text(markdown(payload), encoding="utf-8")
+    write_hashes(output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_temporal_arrow_manifest.py
+++ b/scripts/research/neurodyn_temporal_arrow_manifest.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Build a paired temporal-arrow manifest from durable NeuroDyn ROI files.
+
+This is a clinical-claim-free task.  Each subject contributes two records:
+
+* forward: the ROI sequence in its observed order, label 1
+* reverse: the same ROI sequence reversed in time, label 0
+
+Both records inherit the same site/fold, preventing subject leakage across
+leave-one-site-out folds.  The goal is to test whether the state-space model
+uses temporal direction structure rather than disease labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "brain_ossm.neurodyn_temporal_arrow_prepare.v1"
+CLAIM_BOUNDARY = (
+    "Temporal-arrow diagnostic only. No clinical, mechanistic, biomarker, "
+    "or replicated claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory", required=True, help="TSV with subject_id, site, and provenance/path columns.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--roi-buckets", type=int, default=8)
+    parser.add_argument("--tag", default="")
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument(
+        "--swap-labels",
+        action="store_true",
+        help="Emit the paired control with forward=0 and reverse=1 for polarity auditing.",
+    )
+    return parser.parse_args()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def read_roi(path: Path) -> list[list[float]]:
+    data: list[list[float]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                data.append([float(item) for item in line.split()])
+    if len(data) < 32:
+        raise SystemExit(f"short ROI {path}: {len(data)} rows")
+    width = len(data[0])
+    if width != 200:
+        raise SystemExit(f"unexpected ROI width {path}: {width}")
+    if any(len(row) != width for row in data):
+        raise SystemExit(f"ragged ROI {path}")
+    return data
+
+
+def zscore_columns(data: list[list[float]]) -> list[list[float]]:
+    n_rows = len(data)
+    n_roi = len(data[0])
+    columns: list[list[float]] = []
+    for col_idx in range(n_roi):
+        col = [data[row_idx][col_idx] for row_idx in range(n_rows)]
+        mean = sum(col) / n_rows
+        var = sum((value - mean) * (value - mean) for value in col) / max(1, n_rows - 1)
+        sd = math.sqrt(var) if var > 1e-12 else 1.0
+        columns.append([(value - mean) / sd for value in col])
+    return [[columns[col_idx][row_idx] for col_idx in range(n_roi)] for row_idx in range(n_rows)]
+
+
+def window_features(data: list[list[float]], roi_buckets: int, reverse: bool) -> list[float]:
+    z_rows = zscore_columns(data)
+    n_rows = len(z_rows)
+    n_roi = len(z_rows[0])
+    if roi_buckets <= 0 or roi_buckets > n_roi:
+        raise SystemExit(f"invalid roi_buckets={roi_buckets}; ROI width is {n_roi}")
+    order = list(range(n_rows))
+    if reverse:
+        order = list(reversed(order))
+    values: list[float] = []
+    for window in range(32):
+        start = (window * n_rows) // 32
+        end = ((window + 1) * n_rows) // 32
+        idx = order[start:end] or [order[min(start, n_rows - 1)]]
+        for bucket in range(roi_buckets):
+            roi_start = (bucket * n_roi) // roi_buckets
+            roi_end = ((bucket + 1) * n_roi) // roi_buckets
+            denom = len(idx) * max(1, roi_end - roi_start)
+            acc = 0.0
+            for row_idx in idx:
+                for col_idx in range(roi_start, roi_end):
+                    acc += z_rows[row_idx][col_idx]
+            values.append(acc / denom)
+    return values
+
+
+def roi_path_for(row: dict[str, str]) -> Path:
+    raw = row.get("provenance") or row.get("primary_roi_path") or row.get("source_roi_path") or ""
+    if not raw:
+        raise SystemExit(f"missing ROI path for {row.get('subject_id')}")
+    return Path(raw)
+
+
+def write_manifest(path: Path, records: list[dict[str, Any]], roi_buckets: int, swap_labels: bool) -> None:
+    label_space = "ds006731_temporal_arrow_reverse_vs_forward" if swap_labels else "ds006731_temporal_arrow_forward_vs_reverse"
+    positive_name = "REVERSE" if swap_labels else "FORWARD"
+    negative_name = "FORWARD" if swap_labels else "REVERSE"
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(
+            "# schema=brain_ossm.neurodyn.v1\n"
+            "# dataset_id=ds006731\n"
+            "# seq_len=32\n"
+            f"# input_dim={roi_buckets}\n"
+            "# feature_layout=flat\n"
+            f"# label_space={label_space}\n"
+            f"# label_positive_name={positive_name}\n"
+            f"# label_negative_name={negative_name}\n"
+            "# split_policy=leave_one_site_out_subject_paired\n"
+            "# atlas=Schaefer2018_200Parcels_7Networks\n"
+            f"# feature_recipe=zscore_window_contiguous_roi_mean_bucket{roi_buckets}\n"
+            "# task=temporal_arrow\n"
+            f"# subject_count={len({record['source_subject_id'] for record in records})}\n"
+            f"# record_count={len(records)}\n"
+            f"# site_count={len({record['site'] for record in records})}\n"
+        )
+        header = ["subject_id", "label", "site"] + [f"f{i}" for i in range(32 * roi_buckets)]
+        handle.write("\t".join(header) + "\n")
+        for record in records:
+            fields = [record["record_id"], str(record["label"]), record["site"]]
+            fields.extend(f"{value:.10f}" for value in record["features"])
+            handle.write("\t".join(fields) + "\n")
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    args = parse_args()
+    inventory_path = Path(args.inventory).resolve()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    inventory = read_tsv(inventory_path)
+    records: list[dict[str, Any]] = []
+    phenotypic: list[dict[str, Any]] = []
+    for row in inventory:
+        subject_id = row["subject_id"]
+        site = row["site"]
+        source_label = row.get("label", "")
+        roi_path = roi_path_for(row)
+        data = read_roi(roi_path)
+        for direction, base_label, reverse in (("forward", 1, False), ("reverse", 0, True)):
+            label = 1 - base_label if args.swap_labels else base_label
+            record_id = f"{subject_id}__{direction}"
+            features = window_features(data, args.roi_buckets, reverse)
+            records.append(
+                {
+                    "record_id": record_id,
+                    "source_subject_id": subject_id,
+                    "direction": direction,
+                    "label": label,
+                    "site": site,
+                    "source_clinical_label": source_label,
+                    "source_roi_path": str(roi_path),
+                    "timepoints": len(data),
+                    "roi_dim": len(data[0]),
+                    "features": features,
+                }
+            )
+            phenotypic.append(
+                {
+                    "subject_id": record_id,
+                    "source_subject_id": subject_id,
+                    "direction": direction,
+                    "diagnosis": label,
+                    "SITE_ID": site,
+                    "source_clinical_label": source_label,
+                    "source_roi_path": str(roi_path),
+                    "timepoints": len(data),
+                    "roi_dim": len(data[0]),
+                }
+            )
+
+    manifest = output_dir / "temporal_arrow_manifest.tsv"
+    write_manifest(manifest, records, args.roi_buckets, args.swap_labels)
+    write_csv(output_dir / "temporal_arrow_phenotypic.csv", phenotypic)
+    write_json(
+        output_dir / "temporal_arrow_prepare_summary.json",
+        {
+            "schema": SCHEMA,
+            "created_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "dataset_id": "ds006731",
+            "source_inventory": str(inventory_path),
+            "manifest": str(manifest),
+            "seq_len": 32,
+            "input_dim": args.roi_buckets,
+            "source_subject_count": len(inventory),
+            "record_count": len(records),
+            "swap_labels": bool(args.swap_labels),
+            "label_positive_name": "REVERSE" if args.swap_labels else "FORWARD",
+            "label_negative_name": "FORWARD" if args.swap_labels else "REVERSE",
+            "label_counts": {
+                "0": sum(1 for record in records if record["label"] == 0),
+                "1": sum(1 for record in records if record["label"] == 1),
+            },
+            "site_label_counts": {
+                site: {
+                    "0": sum(1 for record in records if record["site"] == site and record["label"] == 0),
+                    "1": sum(1 for record in records if record["site"] == site and record["label"] == 1),
+                }
+                for site in sorted({record["site"] for record in records})
+            },
+            "claim_boundary": CLAIM_BOUNDARY,
+        },
+    )
+    with (output_dir / "SHA256SUMS").open("w", encoding="utf-8") as handle:
+        for path in sorted(item for item in output_dir.rglob("*") if item.is_file() and item.name != "SHA256SUMS"):
+            handle.write(f"{sha256_file(path)}  {path}\n")
+    print(f"manifest={manifest}")
+    print(f"records={len(records)}")
+    print(f"output_dir={output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_temporal_arrow_polarity_audit.py
+++ b/scripts/research/neurodyn_temporal_arrow_polarity_audit.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Audit temporal-arrow label/readout polarity from prediction receipts.
+
+This is deliberately clinical-claim-free.  The goal is to distinguish absent
+temporal signal from anti-aligned readout polarity in paired forward/reverse
+benchmarks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import statistics
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "neurodyn.temporal_arrow_polarity_audit.v1"
+CLAIM_BOUNDARY = (
+    "Temporal-arrow diagnostic only. No clinical, diagnostic, mechanistic, "
+    "or O-SSM superiority claim."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--predictions", required=True, help="prediction_rows.tsv from O-SSM/H-SSM.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--checkpoint-replay", default="")
+    parser.add_argument("--external-overall", default="", help="Optional external baseline overall_metrics.tsv.")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def read_tsv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]), delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def pstdev(values: list[float]) -> float:
+    return statistics.pstdev(values) if len(values) > 1 else 0.0
+
+
+def subject_direction(subject_id: str) -> str:
+    if subject_id.endswith("__forward"):
+        return "forward"
+    if subject_id.endswith("__reverse"):
+        return "reverse"
+    return "unknown"
+
+
+def summarize_predictions(rows: list[dict[str, str]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for model in sorted({row["model"] for row in rows}):
+        model_rows = [row for row in rows if row["model"] == model]
+        by_seed: dict[str, list[dict[str, str]]] = defaultdict(list)
+        for row in model_rows:
+            by_seed[row["seed"]].append(row)
+
+        raw_acc: list[float] = []
+        inv_acc: list[float] = []
+        forward_raw: list[float] = []
+        reverse_raw: list[float] = []
+        prob_forward: list[float] = []
+        prob_reverse: list[float] = []
+        confusion: Counter[tuple[int, int]] = Counter()
+        per_site_seed: dict[tuple[str, str], list[dict[str, str]]] = defaultdict(list)
+
+        for row in model_rows:
+            per_site_seed[(row["seed"], row["site"])].append(row)
+            y = int(row["label"])
+            pred = int(row["pred"])
+            confusion[(y, pred)] += 1
+            direction = subject_direction(row.get("subject_id") or "")
+            if direction == "forward":
+                prob_forward.append(float(row["prob"]))
+            elif direction == "reverse":
+                prob_reverse.append(float(row["prob"]))
+
+        for seed_rows in by_seed.values():
+            raw_acc.append(100.0 * mean([1.0 if int(row["pred"]) == int(row["label"]) else 0.0 for row in seed_rows]))
+            inv_acc.append(100.0 * mean([1.0 if (1 - int(row["pred"])) == int(row["label"]) else 0.0 for row in seed_rows]))
+            fw = [row for row in seed_rows if subject_direction(row.get("subject_id") or "") == "forward"]
+            rv = [row for row in seed_rows if subject_direction(row.get("subject_id") or "") == "reverse"]
+            forward_raw.append(100.0 * mean([1.0 if int(row["pred"]) == int(row["label"]) else 0.0 for row in fw]))
+            reverse_raw.append(100.0 * mean([1.0 if int(row["pred"]) == int(row["label"]) else 0.0 for row in rv]))
+
+        site_raw_values: list[float] = []
+        site_inv_values: list[float] = []
+        for site_rows in per_site_seed.values():
+            site_raw_values.append(100.0 * mean([1.0 if int(row["pred"]) == int(row["label"]) else 0.0 for row in site_rows]))
+            site_inv_values.append(100.0 * mean([1.0 if (1 - int(row["pred"])) == int(row["label"]) else 0.0 for row in site_rows]))
+
+        out.append(
+            {
+                "model": model,
+                "prediction_rows": len(model_rows),
+                "seed_count": len(by_seed),
+                "raw_accuracy_pct_mean": mean(raw_acc),
+                "raw_accuracy_pct_std": pstdev(raw_acc),
+                "inverted_accuracy_pct_mean": mean(inv_acc),
+                "inverted_accuracy_pct_std": pstdev(inv_acc),
+                "raw_minus_inverted_pct": mean(raw_acc) - mean(inv_acc),
+                "forward_raw_accuracy_pct_mean": mean(forward_raw),
+                "reverse_raw_accuracy_pct_mean": mean(reverse_raw),
+                "forward_prob_mean": mean(prob_forward),
+                "reverse_prob_mean": mean(prob_reverse),
+                "site_seed_raw_accuracy_pct_min": min(site_raw_values) if site_raw_values else 0.0,
+                "site_seed_inverted_accuracy_pct_max": max(site_inv_values) if site_inv_values else 0.0,
+                "confusion_y0_p0": confusion[(0, 0)],
+                "confusion_y0_p1": confusion[(0, 1)],
+                "confusion_y1_p0": confusion[(1, 0)],
+                "confusion_y1_p1": confusion[(1, 1)],
+            }
+        )
+    return out
+
+
+def write_hashes(output_dir: Path) -> None:
+    rows: list[str] = []
+    for path in sorted(item for item in output_dir.iterdir() if item.is_file() and item.name != "SHA256SUMS"):
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        rows.append(f"{digest}  {path.name}\n")
+    (output_dir / "SHA256SUMS").write_text("".join(rows), encoding="utf-8")
+
+
+def markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# NeuroDyn Temporal-Arrow Polarity Audit",
+        "",
+        f"Claim boundary: {CLAIM_BOUNDARY}",
+        "",
+    ]
+    if summary.get("run_id"):
+        lines.append(f"- RUN_ID: `{summary['run_id']}`")
+    if summary.get("checkpoint_replay"):
+        lines.append(f"- checkpoint replay: {summary['checkpoint_replay']}")
+    lines.extend(
+        [
+            "",
+            "## Polarity",
+            "",
+            "| model | raw acc % | inverted acc % | forward prob mean | reverse prob mean |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    for row in summary["polarity"]:
+        lines.append(
+            "| {model} | {raw:.6f} | {inv:.6f} | {pf:.6f} | {pr:.6f} |".format(
+                model=row["model"],
+                raw=row["raw_accuracy_pct_mean"],
+                inv=row["inverted_accuracy_pct_mean"],
+                pf=row["forward_prob_mean"],
+                pr=row["reverse_prob_mean"],
+            )
+        )
+    if summary["external_baselines"]:
+        lines.extend(["", "## External Baselines", "", "| model | balanced accuracy % | AUROC % |", "|---|---:|---:|"])
+        for row in summary["external_baselines"]:
+            lines.append(
+                f"| {row['model']} | {float(row['balanced_accuracy_pct_mean']):.6f} | {float(row['auroc_pct_mean']):.6f} |"
+            )
+    lines.extend(["", "## Interpretation", "", summary["interpretation"], ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    predictions_path = Path(args.predictions).resolve()
+    rows = read_tsv(predictions_path)
+    if not rows:
+        raise SystemExit(f"no prediction rows: {predictions_path}")
+    polarity = summarize_predictions(rows)
+    external_baselines = read_tsv(Path(args.external_overall).resolve()) if args.external_overall else []
+    best_raw = max(float(row["raw_accuracy_pct_mean"]) for row in polarity)
+    best_inv = max(float(row["inverted_accuracy_pct_mean"]) for row in polarity)
+    if best_inv > best_raw + 20.0:
+        decision = "anti_aligned_temporal_signal"
+        interpretation = (
+            "Predictions are strongly anti-aligned with manifest labels. This is evidence "
+            "against absent temporal signal, but it is a readout/label-polarity blocker "
+            "until checked with swapped labels and native state decoding."
+        )
+    else:
+        decision = "no_strong_polarity_inversion"
+        interpretation = (
+            "The raw and inverted scores do not show a large polarity gap. Treat any "
+            "temporal-arrow signal as ordinary benchmark performance until deeper state "
+            "diagnostics are available."
+        )
+
+    summary = {
+        "schema": SCHEMA,
+        "run_id": args.run_id,
+        "checkpoint_replay": args.checkpoint_replay,
+        "predictions": str(predictions_path),
+        "external_overall": str(Path(args.external_overall).resolve()) if args.external_overall else "",
+        "decision": decision,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "polarity": polarity,
+        "external_baselines": external_baselines,
+        "interpretation": interpretation,
+    }
+    write_json(output_dir / "temporal_arrow_polarity_audit.json", summary)
+    write_tsv(output_dir / "temporal_arrow_polarity_audit.tsv", polarity)
+    (output_dir / "temporal_arrow_polarity_audit.md").write_text(markdown(summary), encoding="utf-8")
+    write_hashes(output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/neurodyn_trained_hidden_readout_probe.py
+++ b/scripts/research/neurodyn_trained_hidden_readout_probe.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Probe STATE_TRACE rows with the trained hidden readout vector from CKPT blocks."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from neurodyn_hidden_state_separability import parse_state_rows
+
+
+SCHEMA = "neurodyn.trained_hidden_readout_probe.v1"
+
+
+def parse_ckpts(path: Path) -> list[dict[str, Any]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    ckpts: list[dict[str, Any]] = []
+    idx = 0
+    while idx < len(lines):
+        if lines[idx] != "CKPT_BEGIN":
+            idx += 1
+            continue
+        meta: dict[str, str] = {}
+        arrays: dict[str, list[int]] = {}
+        idx += 1
+        while idx < len(lines) and lines[idx] != "CKPT_END":
+            line = lines[idx]
+            if line.startswith("CKPT_META\t"):
+                parts = line.split("\t")
+                if len(parts) >= 3:
+                    meta[parts[1]] = parts[2]
+                idx += 1
+                continue
+            if line.startswith("CKPT_ARRAY\t"):
+                parts = line.split("\t")
+                if len(parts) < 4:
+                    raise SystemExit(f"malformed CKPT_ARRAY at line {idx + 1}: {line}")
+                name = parts[1]
+                count = int(parts[3])
+                values: list[int] = []
+                idx += 1
+                while idx < len(lines) and len(values) < count:
+                    raw = lines[idx].strip()
+                    if raw and name == "W":
+                        values.append(int(raw))
+                    idx += 1
+                if name == "W" and len(values) != count:
+                    raise SystemExit(f"short CKPT_ARRAY {name}: expected {count}, got {len(values)}")
+                if name == "W":
+                    arrays[name] = values
+                continue
+            idx += 1
+        if "W" in arrays and meta.get("model") == "O-SSM":
+            w = arrays["W"]
+            ckpts.append(
+                {
+                    "seed": int(meta["seed_a"]),
+                    "holdout_site": meta["holdout_site"],
+                    "holdout_key": meta.get("holdout_key", ""),
+                    "balanced_accuracy_pct": float(meta.get("balanced_accuracy_pct", "0")),
+                    "hidden_w": [value / 100_000_000.0 for value in w[:16]],
+                    "bias": w[570] / 100_000_000.0 if len(w) > 570 else 0.0,
+                }
+            )
+        idx += 1
+    if not ckpts:
+        raise SystemExit("no O-SSM CKPT W arrays found")
+    return ckpts
+
+
+def parse_readout_traces(path: Path) -> list[dict[str, Any]]:
+    traces: list[dict[str, Any]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not line.startswith("READOUT_TRACE\t"):
+            idx += 1
+            continue
+        parts = [part for part in line.split("\t") if part]
+        line_no = idx + 1
+        next_idx = idx + 1
+        while len(parts) < 26 and next_idx < len(lines) and lines[next_idx].startswith("\t"):
+            parts.extend(part for part in lines[next_idx].split("\t") if part)
+            next_idx += 1
+        if len(parts) != 26:
+            raise SystemExit(f"malformed READOUT_TRACE at line {line_no}: expected 26 fields, got {len(parts)}")
+        (
+            _,
+            model,
+            seed,
+            seed_b,
+            holdout_key,
+            holdout_site,
+            bal_bp,
+            acc_bp,
+            test_n,
+            bias,
+            *raw_w,
+        ) = parts
+        if model != "O-SSM":
+            continue
+        traces.append(
+            {
+                "seed": int(seed),
+                "seed_b": int(seed_b),
+                "holdout_key": holdout_key,
+                "holdout_site": holdout_site,
+                "balanced_accuracy_pct": int(bal_bp) / 1_000_000.0,
+                "accuracy_pct": int(acc_bp) / 1_000_000.0,
+                "test_n": int(test_n),
+                "hidden_w": [int(value) / 100_000_000.0 for value in raw_w],
+                "bias": int(bias) / 100_000_000.0,
+                "source": "READOUT_TRACE",
+            }
+        )
+        idx = next_idx
+    return traces
+
+
+def balanced_accuracy(labels: list[int], preds: list[int]) -> float:
+    pos = [i for i, label in enumerate(labels) if label == 1]
+    neg = [i for i, label in enumerate(labels) if label == 0]
+    if not pos or not neg:
+        return 0.0
+    tpr = sum(1 for i in pos if preds[i] == 1) / len(pos)
+    tnr = sum(1 for i in neg if preds[i] == 0) / len(neg)
+    return 100.0 * (tpr + tnr) / 2.0
+
+
+def mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def pstdev(xs: list[float]) -> float:
+    return statistics.pstdev(xs) if len(xs) > 1 else 0.0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--raw-output", required=True, type=Path)
+    ap.add_argument("--output-dir", required=True, type=Path)
+    ap.add_argument("--overwrite", action="store_true")
+    args = ap.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = args.output_dir / "trained_hidden_readout_probe_summary.tsv"
+    if summary_path.exists() and not args.overwrite:
+        raise SystemExit(f"output exists; pass --overwrite: {args.output_dir}")
+
+    ckpts = parse_readout_traces(args.raw_output)
+    source = "READOUT_TRACE"
+    if not ckpts:
+        ckpts = parse_ckpts(args.raw_output)
+        source = "CKPT_ARRAY_W"
+    state_rows = parse_state_rows(args.raw_output)
+    by_seed_site: dict[tuple[int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in state_rows:
+        if row["model"] == "O-SSM":
+            by_seed_site[(row["seed"], row["site"])].append(row)
+
+    detail = []
+    for ckpt in ckpts:
+        rows = by_seed_site.get((ckpt["seed"], ckpt["holdout_site"]), [])
+        if not rows:
+            continue
+        labels: list[int] = []
+        preds: list[int] = []
+        scores: list[float] = []
+        for row in rows:
+            score = ckpt["bias"] + sum(h * w for h, w in zip(row["h"], ckpt["hidden_w"], strict=True))
+            labels.append(int(row["label"]))
+            preds.append(1 if score >= 0.0 else 0)
+            scores.append(score)
+        detail.append(
+            {
+                "seed": ckpt["seed"],
+                "holdout_site": ckpt["holdout_site"],
+                "rows": len(rows),
+                "ckpt_balanced_accuracy_pct": ckpt["balanced_accuracy_pct"],
+                "trained_hidden_readout_balanced_accuracy": balanced_accuracy(labels, preds),
+                "score_mean": mean(scores),
+                "score_std": pstdev(scores),
+                "positive_score_frac": mean([1.0 if score >= 0.0 else 0.0 for score in scores]),
+            }
+        )
+
+    if not detail:
+        raise SystemExit("no checkpoint/state rows matched by seed and holdout site")
+
+    ba = [float(row["trained_hidden_readout_balanced_accuracy"]) for row in detail]
+    ckpt_ba = [float(row["ckpt_balanced_accuracy_pct"]) for row in detail]
+    summary = [
+        {
+            "model": "O-SSM",
+            "fold_count": len(detail),
+            "trained_hidden_readout_balanced_accuracy_mean": mean(ba),
+            "trained_hidden_readout_balanced_accuracy_std": pstdev(ba),
+            "ckpt_balanced_accuracy_pct_mean": mean(ckpt_ba),
+            "ckpt_balanced_accuracy_pct_std": pstdev(ckpt_ba),
+        }
+    ]
+
+    def write_tsv(path: Path, rows: list[dict[str, Any]]) -> None:
+        with path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0]), delimiter="\t")
+            writer.writeheader()
+            writer.writerows(rows)
+
+    write_tsv(summary_path, summary)
+    write_tsv(args.output_dir / "trained_hidden_readout_probe_detail.tsv", detail)
+    payload = {
+        "schema": SCHEMA,
+        "raw_output": str(args.raw_output),
+        "readout_source": source,
+        "checkpoint_count": len(ckpts),
+        "matched_fold_count": len(detail),
+        "summary": summary,
+    }
+    (args.output_dir / "trained_hidden_readout_probe.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/research/requirements.txt
+++ b/scripts/research/requirements.txt
@@ -1,0 +1,9 @@
+# Third-party Python deps for the scripts/research/ campaign harness.
+# This is research tooling, NOT part of the Sounio compiler/toolchain build
+# (see README.md). Install into a throwaway venv.
+#
+# Most drivers are standard-library only; only a handful need these:
+#   numpy — dynamic-FC / dimensional gates, ADHD/ABIDE feature builders (~5 files)
+#   scipy — adhd200_prepare_manifest.py (scipy.linalg)
+numpy
+scipy


### PR DESCRIPTION
Closes **Cluster C** from the 2026-07-11 working-tree triage (`docs/handoff/pending_changes_triage_2026-07-11.md`): 69 NeuroDyn / Brain-O-SSM campaign-harness drivers + a directory README and `requirements.txt`. Single commit.

## Audit (3 parallel read-only passes, before commit)
- **0 scratch / throwaway** — all 69 are complete drivers or shared libraries.
- **No credentials / secrets / PHI.** ADHD-200 access (`adhd200_s3_bootstrap.py`, `adhd200_data_access_audit.py`) uses the **anonymous public** `s3://fcp-indi` bucket / PCP mirrors over unauthenticated HTTPS — no boto3, no keys, no private buckets.
- **Import graph self-closed** — every local import resolves within these 69 plus already-tracked libs (`abide_campaign_lib`, `abide_cohort_orc_sweep`, `abide_epistemic_orc_slice`). Committed together so nothing is import-broken.
- **Deps pinned** in `scripts/research/requirements.txt`: `numpy` (~5 files), `scipy` (`adhd200_prepare_manifest.py`). No pandas/torch/boto3.

## Principle 4 boundary
`scripts/research/README.md` marks this directory as the campaign **harness** (manifest generation, data gating, output parsing, decision verdicts, provenance) — **not** the Sounio science path. The O-SSM science stays in `.sio` and runs via `bin/souc`; these drivers only scaffold around it. This extends the Python research harness **already tracked** in `scripts/research/`.

## What it is
One coherent campaign: manifest/null generators → hidden-state / orientation / associator / Fano-line / temporal-arrow diagnostics with permutation nulls and `SHA256SUMS` provenance → ABIDE dynamic-FC and ADHD-200 dimensional target→gate→decision chains, all with explicit no-clinical-claim boundaries.

## Known non-portable outliers (recorded for provenance)
`neurodyn_scale14x14_missing_roi_rerun.py` and `neurodyn_orangefs_not_required_gate.py` hardwire this pod's k8s / CephFS / partition defaults and invoke `kubectl` / `singularity`; they will not run off this cluster.