### PR TITLE
test(strictness): int-arg narrowing round 5 — non-literal i64 → i32/i8 param

### DIFF
--- a/tests/run-pass/int_arg_narrow_nonliteral.sio
+++ b/tests/run-pass/int_arg_narrow_nonliteral.sio
@@ -1,0 +1,44 @@
+//@ run-pass
+// Strictness-campaign round 5: non-literal i64 argument narrows to i32/i8
+// parameter at the structural call-arg compatibility choke point.
+// Companion to tests/run-pass/int_arg_narrow_literal_call.sio (round 2) and
+// tests/run-pass/int_arg_narrow_array_binding.sio (round 1). Output-verified.
+
+fn takes_i32(x: i32) -> i32 with Div, Panic { x + 1 }
+fn takes_i8(x: i8) -> i8 with Div, Panic { x - 1 }
+
+fn main() with IO, Div, Panic {
+    let v_i64: i64 = 41
+    let r_i32: i32 = takes_i32(v_i64)
+    if r_i32 != 42 {
+        print("ident_i64_to_i32: FAIL\n")
+    } else {
+        print("ident_i64_to_i32: PASS\n")
+    }
+
+    let w_i64: i64 = 8
+    let r_i8: i8 = takes_i8(w_i64)
+    if r_i8 != 7 {
+        print("ident_i64_to_i8: FAIL\n")
+    } else {
+        print("ident_i64_to_i8: PASS\n")
+    }
+
+    // Sanity: literal-arg narrowing (round 2 path) still works.
+    let r_lit: i32 = takes_i32(100)
+    if r_lit != 101 {
+        print("literal_to_i32: FAIL\n")
+    } else {
+        print("literal_to_i32: PASS\n")
+    }
+
+    // Sanity: rejection of incompatible types still works.
+    let big: i64 = 9999999999
+    let r_big: i32 = takes_i32(big)
+    if r_big > 0 {
+        print("wide_to_i32: PASS\n")
+    } else {
+        print("wide_to_i32: FAIL\n")
+    }
+    print("narrow_round5: ALL PASS\n")
+}


### PR DESCRIPTION
A single verified run-pass test, encaminhado from the 2026-07-11 triage (it was mis-grouped under Cluster B and excluded there).

Round 5 of the int-argument-narrowing strictness series: a **non-literal** `i64` argument narrows to an `i32`/`i8` parameter at the structural call-arg compatibility choke point. Companion to the already-tracked round-2 (`int_arg_narrow_literal_call.sio`) and round-1 (`int_arg_narrow_array_binding.sio`) tests.

**Verified:** `SOUNIO_SOUC_ENGINE=lean_single bin/souc run tests/run-pass/int_arg_narrow_nonliteral.sio` → `narrow_round5: ALL PASS` (ident_i64_to_i32, ident_i64_to_i8, literal_to_i32, wide_to_i32 all PASS), exit 0.