### PR TITLE
chore(hygiene): gitignore tests/test_op*.sio dossier scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,7 @@ docs/audit/g1_wip/mc_g2c.elf
 /test_struct_ret.sio
 /test_probe.asm
 /test_probe.elf
+
+# Dissertation-dossier scratch probes (triaged 2026-07-11; kept on disk, not tracked)
+/tests/test_op.sio
+/tests/test_op_gen.sio


### PR DESCRIPTION
Anchored `.gitignore` entries for `tests/test_op.sio` and `tests/test_op_gen.sio` — dissertation dossier-generator scratch probes surfaced in the 2026-07-11 triage. Kept on disk, removed from `git status` noise.

Anchored to root (`/tests/...`) so other `tests/*.sio` are unaffected, and placed **after** the existing `!*.sio` re-include so the ignore wins (`git check-ignore` confirms both are now ignored).