### PR TITLE
fix(wasm): resolve module-path collision shadowing the self-hosted WASM emitter

### DIFF
--- a/scripts/bootstrap/bootstrap_concat.sh
+++ b/scripts/bootstrap/bootstrap_concat.sh
@@ -281,7 +281,7 @@ FILES=(
   self-hosted/compiler/codegen/hardware/kaxi_emitter.sio
 
   # ── 22. WebAssembly backend ─────────────────────────────────────
-  self-hosted/wasm/mod.sio
+  self-hosted/wasm/emitter.sio
   self-hosted/wasm/encode.sio
   self-hosted/wasm/lower.sio
 
@@ -506,7 +506,7 @@ if [ "$BOOTSTRAP_PROFILE" != "full" ]; then
     self-hosted/native/hyper_lower.sio
 
     # 8. WebAssembly backend
-    self-hosted/wasm/mod.sio
+    self-hosted/wasm/emitter.sio
     self-hosted/wasm/encode.sio
     self-hosted/wasm/lower.sio
 

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -39,6 +39,7 @@ use native::runtime_context::*
 use native::stack_maps::*
 use native::target_policy::*
 use wasm::core::*
+use wasm::emitter::*
 use wasm::encode::*
 use wasm::lower::*
 use native::codegen_x86_linux::*

--- a/self-hosted/run_wasm_tests.sio
+++ b/self-hosted/run_wasm_tests.sio
@@ -1,12 +1,12 @@
 // self-hosted::run_wasm_tests — WASM backend test runner
 //
-// Entry point at self-hosted/ level so that `use wasm::mod::*` resolves
+// Entry point at self-hosted/ level so that `use wasm::emitter::*` resolves
 // to self-hosted/wasm/mod.sio correctly.
 //
 // Run with:  souc build --backend=selfhosted-native self-hosted/run_wasm_tests.sio
 
 module wasm::run_tests
-use wasm::mod::*
+use wasm::emitter::*
 use wasm::encode::*
 
 fn run_mod_tests() -> i64 with Mut, Panic, Div {

--- a/self-hosted/wasm/core.sio
+++ b/self-hosted/wasm/core.sio
@@ -23,7 +23,7 @@
 module wasm::core
 
 use wasm::types::*
-use wasm::mod::*
+use wasm::emitter::*
 use wasm::opcodes::*
 use wasm::buf::*
 

--- a/self-hosted/wasm/emitter.sio
+++ b/self-hosted/wasm/emitter.sio
@@ -14,7 +14,7 @@
 //
 // LEB128 encoding is required for all integer fields in WASM.
 
-module wasm::mod
+module wasm::emitter
 
 // ============================================================================
 // WASM value type constants
@@ -55,13 +55,13 @@ pub struct WasmBuf {
     len: i64,
 }
 
-fn wasm_buf_new() -> WasmBuf {
+pub fn wasm_buf_new() -> WasmBuf {
     var out: WasmBuf
     out.len = 0
     out
 }
 
-fn wasm_push_byte(buf: WasmBuf, b: i64) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_push_byte(buf: WasmBuf, b: i64) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if out.len >= 0 {
         if out.len < 262144 {
@@ -75,7 +75,7 @@ fn wasm_push_byte(buf: WasmBuf, b: i64) -> WasmBuf with Mut, Panic, Div {
     out
 }
 
-fn wasm_push_str(buf: WasmBuf, s: string) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_push_str(buf: WasmBuf, s: string) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     let n = str_len(s)
     var i: i64 = 0
@@ -95,7 +95,7 @@ fn wasm_push_str(buf: WasmBuf, s: string) -> WasmBuf with Mut, Panic, Div {
 
 // Encode an unsigned 32-bit integer in LEB128 format.
 // Each output byte carries 7 data bits; the high bit indicates continuation.
-fn wasm_push_u32_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_push_u32_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     var v = val
     // Mask to 32 bits to handle negative i64 representations of u32 values
@@ -115,7 +115,7 @@ fn wasm_push_u32_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div 
 }
 
 // Encode a signed 32-bit integer in LEB128 format.
-fn wasm_push_i32_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_push_i32_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     var v = val
     var done = false
@@ -147,7 +147,7 @@ fn wasm_push_i32_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div 
 }
 
 // Encode a signed 64-bit integer in LEB128 format (for i64.const).
-fn wasm_push_i64_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_push_i64_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     var v = val
     var done = false
@@ -174,7 +174,7 @@ fn wasm_push_i64_leb128(buf: WasmBuf, val: i64) -> WasmBuf with Mut, Panic, Div 
 // Helper: compute LEB128 byte length of a u32 value (for size calculations)
 // ============================================================================
 
-fn wasm_u32_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
+pub fn wasm_u32_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
     var v = val
     if v < 0 { v = v + 4294967296 }
     var count: i64 = 0
@@ -189,7 +189,7 @@ fn wasm_u32_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
     count
 }
 
-fn wasm_i32_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
+pub fn wasm_i32_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
     var v = val
     var count: i64 = 0
     var done = false
@@ -209,7 +209,7 @@ fn wasm_i32_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
     count
 }
 
-fn wasm_i64_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
+pub fn wasm_i64_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
     // Signed LEB128 byte length for i64 (mirrors wasm_push_i64_leb128 counting logic)
     var v = val
     var count: i64 = 0
@@ -235,21 +235,21 @@ fn wasm_i64_leb128_len(val: i64) -> i64 with Mut, Panic, Div {
 // ============================================================================
 
 // A single function type: (params...) -> (results...)
-struct WasmFuncType {
+pub struct WasmFuncType {
     params: [i64; 16],
     param_count: i64,
     results: [i64; 4],
     result_count: i64,
 }
 
-fn wasm_func_type_new() -> WasmFuncType {
+pub fn wasm_func_type_new() -> WasmFuncType {
     var out: WasmFuncType
     out.param_count = 0
     out.result_count = 0
     out
 }
 
-fn wasm_func_type_add_param(ft: WasmFuncType, val_type: i64) -> WasmFuncType with Mut, Panic {
+pub fn wasm_func_type_add_param(ft: WasmFuncType, val_type: i64) -> WasmFuncType with Mut, Panic {
     var out = ft
     if out.param_count < 16 {
         out.params[out.param_count as usize] = val_type
@@ -258,7 +258,7 @@ fn wasm_func_type_add_param(ft: WasmFuncType, val_type: i64) -> WasmFuncType wit
     out
 }
 
-fn wasm_func_type_add_result(ft: WasmFuncType, val_type: i64) -> WasmFuncType with Mut, Panic {
+pub fn wasm_func_type_add_result(ft: WasmFuncType, val_type: i64) -> WasmFuncType with Mut, Panic {
     var out = ft
     if out.result_count < 4 {
         out.results[out.result_count as usize] = val_type
@@ -268,18 +268,18 @@ fn wasm_func_type_add_result(ft: WasmFuncType, val_type: i64) -> WasmFuncType wi
 }
 
 // Type section: vector of function types
-struct WasmTypeSection {
+pub struct WasmTypeSection {
     types: [WasmFuncType; 256],
     count: i64,
 }
 
-fn wasm_type_section_new() -> WasmTypeSection {
+pub fn wasm_type_section_new() -> WasmTypeSection {
     var out: WasmTypeSection
     out.count = 0
     out
 }
 
-fn wasm_type_section_add(ts: WasmTypeSection, ft: WasmFuncType) -> WasmTypeSection with Mut, Panic {
+pub fn wasm_type_section_add(ts: WasmTypeSection, ft: WasmFuncType) -> WasmTypeSection with Mut, Panic {
     var out = ts
     if out.count < 256 {
         out.types[out.count as usize] = ft
@@ -289,18 +289,18 @@ fn wasm_type_section_add(ts: WasmTypeSection, ft: WasmFuncType) -> WasmTypeSecti
 }
 
 // Function section: maps function index to type index
-struct WasmFuncSection {
+pub struct WasmFuncSection {
     type_indices: [i64; 256],
     count: i64,
 }
 
-fn wasm_func_section_new() -> WasmFuncSection {
+pub fn wasm_func_section_new() -> WasmFuncSection {
     var out: WasmFuncSection
     out.count = 0
     out
 }
 
-fn wasm_func_section_add(fs: WasmFuncSection, type_idx: i64) -> WasmFuncSection with Mut, Panic {
+pub fn wasm_func_section_add(fs: WasmFuncSection, type_idx: i64) -> WasmFuncSection with Mut, Panic {
     var out = fs
     if out.count < 256 {
         out.type_indices[out.count as usize] = type_idx
@@ -317,7 +317,7 @@ pub struct WasmExport {
     index: i64,
 }
 
-fn wasm_export_new() -> WasmExport {
+pub fn wasm_export_new() -> WasmExport {
     var out: WasmExport
     out.name_len = 0
     out.kind = 0
@@ -325,7 +325,7 @@ fn wasm_export_new() -> WasmExport {
     out
 }
 
-fn wasm_export_set_name(exp: WasmExport, name: string) -> WasmExport with Mut, Panic, Div {
+pub fn wasm_export_set_name(exp: WasmExport, name: string) -> WasmExport with Mut, Panic, Div {
     var out = exp
     let n = str_len(name)
     var i: i64 = 0
@@ -340,7 +340,7 @@ fn wasm_export_set_name(exp: WasmExport, name: string) -> WasmExport with Mut, P
     out
 }
 
-fn wasm_export_func(name: string, func_idx: i64) -> WasmExport with Mut, Panic, Div {
+pub fn wasm_export_func(name: string, func_idx: i64) -> WasmExport with Mut, Panic, Div {
     var exp = wasm_export_new()
     exp = wasm_export_set_name(exp, name)
     exp.kind = WASM_EXPORT_FUNC
@@ -348,7 +348,7 @@ fn wasm_export_func(name: string, func_idx: i64) -> WasmExport with Mut, Panic, 
     exp
 }
 
-fn wasm_export_memory(name: string, mem_idx: i64) -> WasmExport with Mut, Panic, Div {
+pub fn wasm_export_memory(name: string, mem_idx: i64) -> WasmExport with Mut, Panic, Div {
     var exp = wasm_export_new()
     exp = wasm_export_set_name(exp, name)
     exp.kind = WASM_EXPORT_MEMORY
@@ -357,18 +357,18 @@ fn wasm_export_memory(name: string, mem_idx: i64) -> WasmExport with Mut, Panic,
 }
 
 // Export section
-struct WasmExportSection {
+pub struct WasmExportSection {
     exports: [WasmExport; 64],
     count: i64,
 }
 
-fn wasm_export_section_new() -> WasmExportSection {
+pub fn wasm_export_section_new() -> WasmExportSection {
     var out: WasmExportSection
     out.count = 0
     out
 }
 
-fn wasm_export_section_add(es: WasmExportSection, exp: WasmExport) -> WasmExportSection with Mut, Panic {
+pub fn wasm_export_section_add(es: WasmExportSection, exp: WasmExport) -> WasmExportSection with Mut, Panic {
     var out = es
     if out.count < 64 {
         out.exports[out.count as usize] = exp
@@ -401,12 +401,12 @@ pub struct WasmImport {
     type_index: i64,
 }
 
-struct WasmImportSection {
+pub struct WasmImportSection {
     imports: [WasmImport; 64],
     count:   i64,
 }
 
-fn wasm_import_new() -> WasmImport {
+pub fn wasm_import_new() -> WasmImport {
     var out: WasmImport
     out.module_len = 0
     out.name_len = 0
@@ -414,13 +414,13 @@ fn wasm_import_new() -> WasmImport {
     out
 }
 
-fn wasm_import_section_new() -> WasmImportSection {
+pub fn wasm_import_section_new() -> WasmImportSection {
     var out: WasmImportSection
     out.count = 0
     out
 }
 
-fn wasm_import_section_add(sec: WasmImportSection, imp: WasmImport) -> WasmImportSection with Mut, Panic {
+pub fn wasm_import_section_add(sec: WasmImportSection, imp: WasmImport) -> WasmImportSection with Mut, Panic {
     var out = sec
     if out.count < WASM_IMPORT_MAX {
         out.imports[out.count as usize] = imp
@@ -429,7 +429,7 @@ fn wasm_import_section_add(sec: WasmImportSection, imp: WasmImport) -> WasmImpor
     out
 }
 
-fn wasm_import_byte_size(imp: WasmImport) -> i64 with Mut, Panic, Div {
+pub fn wasm_import_byte_size(imp: WasmImport) -> i64 with Mut, Panic, Div {
     // module_len(LEB128) + module_bytes + name_len(LEB128) + name_bytes + kind(1) + type_idx(LEB128)
     wasm_u32_leb128_len(imp.module_len) + imp.module_len
         + wasm_u32_leb128_len(imp.name_len) + imp.name_len
@@ -437,7 +437,7 @@ fn wasm_import_byte_size(imp: WasmImport) -> i64 with Mut, Panic, Div {
         + wasm_u32_leb128_len(imp.type_index)
 }
 
-fn wasm_import_section_payload_size(sec: WasmImportSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_import_section_payload_size(sec: WasmImportSection) -> i64 with Mut, Panic, Div {
     var size = wasm_u32_leb128_len(sec.count)
     var i: i64 = 0
     while i < sec.count {
@@ -447,7 +447,7 @@ fn wasm_import_section_payload_size(sec: WasmImportSection) -> i64 with Mut, Pan
     size
 }
 
-fn wasm_emit_import_section(buf: WasmBuf, sec: WasmImportSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_import_section(buf: WasmBuf, sec: WasmImportSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if sec.count == 0 { return out }
 
@@ -487,7 +487,7 @@ pub struct WasmLocal {
     val_type: i64,
 }
 
-fn wasm_local_new(count: i64, val_type: i64) -> WasmLocal {
+pub fn wasm_local_new(count: i64, val_type: i64) -> WasmLocal {
     WasmLocal { count: count, val_type: val_type }
 }
 
@@ -499,7 +499,7 @@ pub struct WasmFuncBody {
     local_count: i64,
 }
 
-fn wasm_func_body_new() -> WasmFuncBody {
+pub fn wasm_func_body_new() -> WasmFuncBody {
     var out: WasmFuncBody
     out.code_len = 0
     out.local_count = 0
@@ -507,18 +507,18 @@ fn wasm_func_body_new() -> WasmFuncBody {
 }
 
 // Code section: vector of function bodies
-struct WasmCodeSection {
+pub struct WasmCodeSection {
     bodies: [WasmFuncBody; 256],
     count: i64,
 }
 
-fn wasm_code_section_new() -> WasmCodeSection {
+pub fn wasm_code_section_new() -> WasmCodeSection {
     var out: WasmCodeSection
     out.count = 0
     out
 }
 
-fn wasm_code_section_add(cs: WasmCodeSection, body: WasmFuncBody) -> WasmCodeSection with Mut, Panic {
+pub fn wasm_code_section_add(cs: WasmCodeSection, body: WasmFuncBody) -> WasmCodeSection with Mut, Panic {
     var out = cs
     if out.count < 256 {
         out.bodies[out.count as usize] = body
@@ -531,7 +531,7 @@ fn wasm_code_section_add(cs: WasmCodeSection, body: WasmFuncBody) -> WasmCodeSec
 // Magic + Version header
 // ============================================================================
 
-fn wasm_emit_magic(buf: WasmBuf) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_magic(buf: WasmBuf) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     // \0asm = 0x00 0x61 0x73 0x6D
     out = wasm_push_byte(out, 0x00)
@@ -550,7 +550,7 @@ fn wasm_emit_magic(buf: WasmBuf) -> WasmBuf with Mut, Panic, Div {
 // Section header: section_id(1 byte) + payload_len(LEB128)
 // ============================================================================
 
-fn wasm_emit_section_header(buf: WasmBuf, section_id: i64, payload_len: i64) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_section_header(buf: WasmBuf, section_id: i64, payload_len: i64) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     out = wasm_push_byte(out, section_id)
     out = wasm_push_u32_leb128(out, payload_len)
@@ -568,7 +568,7 @@ fn wasm_emit_section_header(buf: WasmBuf, section_id: i64, payload_len: i64) -> 
 // ============================================================================
 
 // Compute the byte size of a single func type encoding
-fn wasm_func_type_byte_size(ft: WasmFuncType) -> i64 with Mut, Panic, Div {
+pub fn wasm_func_type_byte_size(ft: WasmFuncType) -> i64 with Mut, Panic, Div {
     // 1 byte for 0x60 marker
     var size: i64 = 1
     // param count (LEB128)
@@ -583,7 +583,7 @@ fn wasm_func_type_byte_size(ft: WasmFuncType) -> i64 with Mut, Panic, Div {
 }
 
 // Compute total payload size for the type section
-fn wasm_type_section_payload_size(ts: WasmTypeSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_type_section_payload_size(ts: WasmTypeSection) -> i64 with Mut, Panic, Div {
     // count(LEB128)
     var size = wasm_u32_leb128_len(ts.count)
     var i: i64 = 0
@@ -594,7 +594,7 @@ fn wasm_type_section_payload_size(ts: WasmTypeSection) -> i64 with Mut, Panic, D
     size
 }
 
-fn wasm_emit_type_section(buf: WasmBuf, types: WasmTypeSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_type_section(buf: WasmBuf, types: WasmTypeSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if types.count == 0 { return out }
 
@@ -638,7 +638,7 @@ fn wasm_emit_type_section(buf: WasmBuf, types: WasmTypeSection) -> WasmBuf with 
 //   for each function: type_index(LEB128)
 // ============================================================================
 
-fn wasm_func_section_payload_size(fs: WasmFuncSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_func_section_payload_size(fs: WasmFuncSection) -> i64 with Mut, Panic, Div {
     var size = wasm_u32_leb128_len(fs.count)
     var i: i64 = 0
     while i < fs.count {
@@ -648,7 +648,7 @@ fn wasm_func_section_payload_size(fs: WasmFuncSection) -> i64 with Mut, Panic, D
     size
 }
 
-fn wasm_emit_function_section(buf: WasmBuf, funcs: WasmFuncSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_function_section(buf: WasmBuf, funcs: WasmFuncSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if funcs.count == 0 { return out }
 
@@ -675,7 +675,7 @@ fn wasm_emit_function_section(buf: WasmBuf, funcs: WasmFuncSection) -> WasmBuf w
 //   [max_pages(LEB128)]  if flag == 1
 // ============================================================================
 
-fn wasm_memory_payload_size(min_pages: i64, max_pages: i64) -> i64 with Mut, Panic, Div {
+pub fn wasm_memory_payload_size(min_pages: i64, max_pages: i64) -> i64 with Mut, Panic, Div {
     // count = 1 (LEB128 len)
     var size = wasm_u32_leb128_len(1)
     if max_pages > 0 {
@@ -688,7 +688,7 @@ fn wasm_memory_payload_size(min_pages: i64, max_pages: i64) -> i64 with Mut, Pan
     size
 }
 
-fn wasm_emit_memory_section(buf: WasmBuf, min_pages: i64, max_pages: i64) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_memory_section(buf: WasmBuf, min_pages: i64, max_pages: i64) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     let payload_size = wasm_memory_payload_size(min_pages, max_pages)
     out = wasm_emit_section_header(out, WASM_SECTION_MEMORY, payload_size)
@@ -719,7 +719,7 @@ fn wasm_emit_memory_section(buf: WasmBuf, min_pages: i64, max_pages: i64) -> Was
 //     name_len(LEB128) | name(bytes) | kind(1 byte) | index(LEB128)
 // ============================================================================
 
-fn wasm_export_byte_size(exp: WasmExport) -> i64 with Mut, Panic, Div {
+pub fn wasm_export_byte_size(exp: WasmExport) -> i64 with Mut, Panic, Div {
     // name_len(LEB128) + name_bytes + kind(1) + index(LEB128)
     var size = wasm_u32_leb128_len(exp.name_len)
     size = size + exp.name_len
@@ -728,7 +728,7 @@ fn wasm_export_byte_size(exp: WasmExport) -> i64 with Mut, Panic, Div {
     size
 }
 
-fn wasm_export_section_payload_size(es: WasmExportSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_export_section_payload_size(es: WasmExportSection) -> i64 with Mut, Panic, Div {
     var size = wasm_u32_leb128_len(es.count)
     var i: i64 = 0
     while i < es.count {
@@ -738,7 +738,7 @@ fn wasm_export_section_payload_size(es: WasmExportSection) -> i64 with Mut, Pani
     size
 }
 
-fn wasm_emit_export_section(buf: WasmBuf, exports: WasmExportSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_export_section(buf: WasmBuf, exports: WasmExportSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if exports.count == 0 { return out }
 
@@ -779,7 +779,7 @@ fn wasm_emit_export_section(buf: WasmBuf, exports: WasmExportSection) -> WasmBuf
 // ============================================================================
 
 // Compute byte size of a single function body entry (locals + code)
-fn wasm_func_body_inner_size(body: WasmFuncBody) -> i64 with Mut, Panic, Div {
+pub fn wasm_func_body_inner_size(body: WasmFuncBody) -> i64 with Mut, Panic, Div {
     // local_decl_count(LEB128)
     var size = wasm_u32_leb128_len(body.local_count)
     // each local decl: count(LEB128) + type(1 byte)
@@ -794,7 +794,7 @@ fn wasm_func_body_inner_size(body: WasmFuncBody) -> i64 with Mut, Panic, Div {
     size
 }
 
-fn wasm_code_section_payload_size(cs: WasmCodeSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_code_section_payload_size(cs: WasmCodeSection) -> i64 with Mut, Panic, Div {
     // count(LEB128)
     var size = wasm_u32_leb128_len(cs.count)
     var i: i64 = 0
@@ -807,7 +807,7 @@ fn wasm_code_section_payload_size(cs: WasmCodeSection) -> i64 with Mut, Panic, D
     size
 }
 
-fn wasm_emit_code_section(buf: WasmBuf, bodies: WasmCodeSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_code_section(buf: WasmBuf, bodies: WasmCodeSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if bodies.count == 0 { return out }
 
@@ -864,22 +864,22 @@ fn wasm_emit_code_section(buf: WasmBuf, bodies: WasmCodeSection) -> WasmBuf with
 let WASM_GLOBAL_MUTABLE: i64 = 1
 
 // A single i64 mutable global with a known initial value.
-struct WasmGlobal {
+pub struct WasmGlobal {
     init_val: i64,
 }
 
-struct WasmGlobalSection {
+pub struct WasmGlobalSection {
     globals: [WasmGlobal; 8],
     count:   i64,
 }
 
-fn wasm_global_section_new() -> WasmGlobalSection {
+pub fn wasm_global_section_new() -> WasmGlobalSection {
     var out: WasmGlobalSection
     out.count = 0
     out
 }
 
-fn wasm_global_section_add(sec: WasmGlobalSection, init_val: i64) -> WasmGlobalSection with Mut, Panic {
+pub fn wasm_global_section_add(sec: WasmGlobalSection, init_val: i64) -> WasmGlobalSection with Mut, Panic {
     var out = sec
     if out.count < 8 {
         out.globals[out.count as usize] = WasmGlobal { init_val: init_val }
@@ -888,12 +888,12 @@ fn wasm_global_section_add(sec: WasmGlobalSection, init_val: i64) -> WasmGlobalS
     out
 }
 
-fn wasm_global_entry_byte_size(g: WasmGlobal) -> i64 with Mut, Panic, Div {
+pub fn wasm_global_entry_byte_size(g: WasmGlobal) -> i64 with Mut, Panic, Div {
     // val_type(1) + mutability(1) + i64.const(1) + val(LEB128) + end(1)
     4 + wasm_i64_leb128_len(g.init_val)
 }
 
-fn wasm_global_section_payload_size(sec: WasmGlobalSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_global_section_payload_size(sec: WasmGlobalSection) -> i64 with Mut, Panic, Div {
     var size = wasm_u32_leb128_len(sec.count)
     var i: i64 = 0
     while i < sec.count {
@@ -903,7 +903,7 @@ fn wasm_global_section_payload_size(sec: WasmGlobalSection) -> i64 with Mut, Pan
     size
 }
 
-fn wasm_emit_global_section(buf: WasmBuf, sec: WasmGlobalSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_global_section(buf: WasmBuf, sec: WasmGlobalSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if sec.count == 0 { return out }
 
@@ -950,7 +950,7 @@ pub struct WasmDataSection {
     seg_len:    [i64; 512],   // seg_len[i]    = byte count of segment i
 }
 
-fn wasm_data_section_new() -> WasmDataSection {
+pub fn wasm_data_section_new() -> WasmDataSection {
     var out: WasmDataSection
     out.data_len = 0
     out.seg_count = 0
@@ -959,7 +959,7 @@ fn wasm_data_section_new() -> WasmDataSection {
 
 // Add a Name's bytes as a new data segment at the current offset.
 // Returns updated section.  The segment is null-terminated.
-fn wasm_data_section_add_name(sec: WasmDataSection, name: Name) -> WasmDataSection with Mut, Panic, Div {
+pub fn wasm_data_section_add_name(sec: WasmDataSection, name: Name) -> WasmDataSection with Mut, Panic, Div {
     var out = sec
     if out.seg_count >= 512 { return out }
     let seg_idx = out.seg_count
@@ -980,12 +980,12 @@ fn wasm_data_section_add_name(sec: WasmDataSection, name: Name) -> WasmDataSecti
     out
 }
 
-fn wasm_data_segment_header_size(seg_offset: i64, seg_len: i64) -> i64 with Mut, Panic, Div {
+pub fn wasm_data_segment_header_size(seg_offset: i64, seg_len: i64) -> i64 with Mut, Panic, Div {
     // kind(1) + i32.const(1) + offset(LEB128) + end(1) + byte_count(LEB128)
     1 + 1 + wasm_u32_leb128_len(seg_offset) + 1 + wasm_u32_leb128_len(seg_len)
 }
 
-fn wasm_data_section_payload_size(sec: WasmDataSection) -> i64 with Mut, Panic, Div {
+pub fn wasm_data_section_payload_size(sec: WasmDataSection) -> i64 with Mut, Panic, Div {
     var size = wasm_u32_leb128_len(sec.seg_count)
     var i: i64 = 0
     while i < sec.seg_count {
@@ -997,7 +997,7 @@ fn wasm_data_section_payload_size(sec: WasmDataSection) -> i64 with Mut, Panic, 
     size
 }
 
-fn wasm_emit_data_section(buf: WasmBuf, sec: WasmDataSection) -> WasmBuf with Mut, Panic, Div {
+pub fn wasm_emit_data_section(buf: WasmBuf, sec: WasmDataSection) -> WasmBuf with Mut, Panic, Div {
     var out = buf
     if sec.seg_count == 0 { return out }
 
@@ -1032,7 +1032,7 @@ fn wasm_emit_data_section(buf: WasmBuf, sec: WasmDataSection) -> WasmBuf with Mu
 // Full module assembly
 // ============================================================================
 
-fn wasm_emit_full_module(
+pub fn wasm_emit_full_module(
     types: WasmTypeSection,
     imports: WasmImportSection,
     funcs: WasmFuncSection,
@@ -1081,7 +1081,7 @@ fn wasm_emit_full_module(
 // Buffer inspection helpers (for testing)
 // ============================================================================
 
-fn wasm_buf_byte_at(buf: WasmBuf, idx: i64) -> i64 with Mut, Panic {
+pub fn wasm_buf_byte_at(buf: WasmBuf, idx: i64) -> i64 with Mut, Panic {
     if idx < 0 { return 0 }
     if idx >= buf.len { return 0 }
     let raw = buf.data[idx as usize] as i64
@@ -1090,7 +1090,7 @@ fn wasm_buf_byte_at(buf: WasmBuf, idx: i64) -> i64 with Mut, Panic {
     raw
 }
 
-fn wasm_buf_contains_bytes(buf: WasmBuf, offset: i64, expected: [i64; 16], expected_len: i64) -> bool with Mut, Panic, Div {
+pub fn wasm_buf_contains_bytes(buf: WasmBuf, offset: i64, expected: [i64; 16], expected_len: i64) -> bool with Mut, Panic, Div {
     if offset + expected_len > buf.len { return false }
     var i: i64 = 0
     while i < expected_len {
@@ -1107,35 +1107,35 @@ fn wasm_buf_contains_bytes(buf: WasmBuf, offset: i64, expected: [i64; 16], expec
 // Inline tests
 // ============================================================================
 
-fn test_wasm_leb128_zero() -> bool with Mut, Panic, Div {
+pub fn test_wasm_leb128_zero() -> bool with Mut, Panic, Div {
     // LEB128 of 0 should be a single byte: 0x00
     var buf = wasm_buf_new()
     buf = wasm_push_u32_leb128(buf, 0)
     buf.len == 1 && wasm_buf_byte_at(buf, 0) == 0
 }
 
-fn test_wasm_leb128_small() -> bool with Mut, Panic, Div {
+pub fn test_wasm_leb128_small() -> bool with Mut, Panic, Div {
     // LEB128 of 42 fits in one byte: 0x2A
     var buf = wasm_buf_new()
     buf = wasm_push_u32_leb128(buf, 42)
     buf.len == 1 && wasm_buf_byte_at(buf, 0) == 42
 }
 
-fn test_wasm_leb128_127() -> bool with Mut, Panic, Div {
+pub fn test_wasm_leb128_127() -> bool with Mut, Panic, Div {
     // LEB128 of 127 fits in one byte: 0x7F
     var buf = wasm_buf_new()
     buf = wasm_push_u32_leb128(buf, 127)
     buf.len == 1 && wasm_buf_byte_at(buf, 0) == 127
 }
 
-fn test_wasm_leb128_128() -> bool with Mut, Panic, Div {
+pub fn test_wasm_leb128_128() -> bool with Mut, Panic, Div {
     // LEB128 of 128 requires two bytes: 0x80 0x01
     var buf = wasm_buf_new()
     buf = wasm_push_u32_leb128(buf, 128)
     buf.len == 2 && wasm_buf_byte_at(buf, 0) == 128 && wasm_buf_byte_at(buf, 1) == 1
 }
 
-fn test_wasm_leb128_624485() -> bool with Mut, Panic, Div {
+pub fn test_wasm_leb128_624485() -> bool with Mut, Panic, Div {
     // Classic test: 624485 -> 0xE5 0x8E 0x26
     var buf = wasm_buf_new()
     buf = wasm_push_u32_leb128(buf, 624485)
@@ -1145,14 +1145,14 @@ fn test_wasm_leb128_624485() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 2) == 0x26
 }
 
-fn test_wasm_signed_leb128_neg1() -> bool with Mut, Panic, Div {
+pub fn test_wasm_signed_leb128_neg1() -> bool with Mut, Panic, Div {
     // Signed LEB128 of -1 should be a single byte: 0x7F
     var buf = wasm_buf_new()
     buf = wasm_push_i32_leb128(buf, 0 - 1)
     buf.len == 1 && wasm_buf_byte_at(buf, 0) == 0x7F
 }
 
-fn test_wasm_signed_leb128_neg128() -> bool with Mut, Panic, Div {
+pub fn test_wasm_signed_leb128_neg128() -> bool with Mut, Panic, Div {
     // Signed LEB128 of -128 should be: 0x80 0x7F
     var buf = wasm_buf_new()
     buf = wasm_push_i32_leb128(buf, 0 - 128)
@@ -1161,7 +1161,7 @@ fn test_wasm_signed_leb128_neg128() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 1) == 0x7F
 }
 
-fn test_wasm_magic_header() -> bool with Mut, Panic, Div {
+pub fn test_wasm_magic_header() -> bool with Mut, Panic, Div {
     // WASM magic: 00 61 73 6D 01 00 00 00
     var buf = wasm_buf_new()
     buf = wasm_emit_magic(buf)
@@ -1176,7 +1176,7 @@ fn test_wasm_magic_header() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 7) == 0x00
 }
 
-fn test_wasm_type_section_single() -> bool with Mut, Panic, Div {
+pub fn test_wasm_type_section_single() -> bool with Mut, Panic, Div {
     // Type section with one func type: (i32, i32) -> i32
     var ft = wasm_func_type_new()
     ft = wasm_func_type_add_param(ft, WASM_TYPE_I32)
@@ -1205,7 +1205,7 @@ fn test_wasm_type_section_single() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 8) == 0x7F       // i32
 }
 
-fn test_wasm_memory_section_min_only() -> bool with Mut, Panic, Div {
+pub fn test_wasm_memory_section_min_only() -> bool with Mut, Panic, Div {
     // Memory section with min=1, no max
     var buf = wasm_buf_new()
     buf = wasm_emit_memory_section(buf, 1, 0)
@@ -1222,7 +1222,7 @@ fn test_wasm_memory_section_min_only() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 4) == 1          // min pages
 }
 
-fn test_wasm_memory_section_min_max() -> bool with Mut, Panic, Div {
+pub fn test_wasm_memory_section_min_max() -> bool with Mut, Panic, Div {
     // Memory section with min=1, max=10
     var buf = wasm_buf_new()
     buf = wasm_emit_memory_section(buf, 1, 10)
@@ -1239,7 +1239,7 @@ fn test_wasm_memory_section_min_max() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 5) == 10          // max
 }
 
-fn test_wasm_export_section_func() -> bool with Mut, Panic, Div {
+pub fn test_wasm_export_section_func() -> bool with Mut, Panic, Div {
     // Export "add" as function index 0
     var es = wasm_export_section_new()
     let exp = wasm_export_func("add", 0)
@@ -1263,7 +1263,7 @@ fn test_wasm_export_section_func() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 8) == 0x00        // index = 0
 }
 
-fn test_wasm_function_section() -> bool with Mut, Panic, Div {
+pub fn test_wasm_function_section() -> bool with Mut, Panic, Div {
     // Function section: two functions, both using type index 0
     var fs = wasm_func_section_new()
     fs = wasm_func_section_add(fs, 0)
@@ -1282,7 +1282,7 @@ fn test_wasm_function_section() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(buf, 4) == 0           // type index 0
 }
 
-fn test_wasm_full_module_header() -> bool with Mut, Panic, Div {
+pub fn test_wasm_full_module_header() -> bool with Mut, Panic, Div {
     // Build a minimal module: one function (i32, i32) -> i32 that does i32.add
     var ft = wasm_func_type_new()
     ft = wasm_func_type_add_param(ft, WASM_TYPE_I32)
@@ -1323,7 +1323,7 @@ fn test_wasm_full_module_header() -> bool with Mut, Panic, Div {
         && wasm_buf_byte_at(module, 4) == 0x01
 }
 
-fn test_wasm_leb128_len_helper() -> bool with Mut, Panic, Div {
+pub fn test_wasm_leb128_len_helper() -> bool with Mut, Panic, Div {
     // Verify the u32_leb128_len helper
     wasm_u32_leb128_len(0) == 1
         && wasm_u32_leb128_len(1) == 1
@@ -1333,7 +1333,7 @@ fn test_wasm_leb128_len_helper() -> bool with Mut, Panic, Div {
         && wasm_u32_leb128_len(16384) == 3
 }
 
-fn test_wasm_signed_leb128_positive() -> bool with Mut, Panic, Div {
+pub fn test_wasm_signed_leb128_positive() -> bool with Mut, Panic, Div {
     // Signed LEB128 of 63 fits in one byte: 0x3F
     // Signed LEB128 of 64 requires two bytes: 0xC0 0x00
     var buf1 = wasm_buf_new()
@@ -1346,7 +1346,7 @@ fn test_wasm_signed_leb128_positive() -> bool with Mut, Panic, Div {
         && buf2.len == 2 && wasm_buf_byte_at(buf2, 0) == 0xC0 && wasm_buf_byte_at(buf2, 1) == 0x00
 }
 
-fn test_wasm_code_section_simple() -> bool with Mut, Panic, Div {
+pub fn test_wasm_code_section_simple() -> bool with Mut, Panic, Div {
     // A function body with no locals, just [i32.const 42, end]
     var body = wasm_func_body_new()
     body.code[0 as usize] = 0x41 as i8  // i32.const

--- a/self-hosted/wasm/encode.sio
+++ b/self-hosted/wasm/encode.sio
@@ -16,6 +16,7 @@
 
 module wasm::encode
 use wasm::core::*
+use wasm::emitter::*
 
 // ============================================================================
 // WASM opcode constants

--- a/self-hosted/wasm/lower.sio
+++ b/self-hosted/wasm/lower.sio
@@ -16,6 +16,7 @@
 
 module wasm::lower
 use wasm::core::*
+use wasm::emitter::*
 use wasm::encode::*
 use ir::ir::*
 use parser::ast::{Name, StringList, AstPath, BinaryOp, UnaryOp}

--- a/self-hosted/wasm/test_mod.sio
+++ b/self-hosted/wasm/test_mod.sio
@@ -4,7 +4,7 @@
 // Run with:  souc run self-hosted/wasm/test_mod.sio
 
 module wasm::test_mod
-use wasm::mod::*
+use wasm::emitter::*
 use wasm::encode::*
 
 fn run_mod_tests() -> i64 with Mut, Panic, Div {

--- a/self-hosted/wasm/test_runner.sio
+++ b/self-hosted/wasm/test_runner.sio
@@ -3,7 +3,7 @@
 // Run with:  souc run self-hosted/wasm/test_runner.sio
 
 module wasm::test_runner
-use wasm::mod::*
+use wasm::emitter::*
 use wasm::encode::*
 use wasm::lower::*
 

--- a/self-hosted/wasm_smoke.sio
+++ b/self-hosted/wasm_smoke.sio
@@ -1,6 +1,6 @@
 // Minimal WASM module resolution smoke test
 module wasm::smoke
-use wasm::mod::*
+use wasm::emitter::*
 
 fn main() -> i64 with Mut, Panic, Div {
     if test_wasm_magic_header() {


### PR DESCRIPTION
## Problem

The self-hosted WASM emitter lives in `self-hosted/wasm/mod.sio` (`module wasm::mod`), which collides with `stdlib/wasm/mod.sio` — a 389-byte runtime-FFI stub (`module wasm`) — on the resolver path `wasm/mod.sio`.

The modular resolver is **path-based** and `SOUNIO_STDLIB_PATH` shadows self-hosted, so every `use wasm::mod::*` loads the **stdlib stub** and the real 44 KB emitter (all 77 `wasm_*` functions) is **never loaded**. Result: **136 `unknown identifier wasm_*` / `unknown field access` / `value is not indexable` errors** in the modular build (`wasm/encode.sio` + `wasm/lower.sio`).

(`wasm::core`/`encode`/`lower` have no stdlib twin, so they resolve fine — only `mod.sio` collides.)

## Fix

- Rename `self-hosted/wasm/mod.sio` → `emitter.sio`, `module wasm::mod` → `module wasm::emitter` (no stdlib twin at that path → no shadowing).
- Repoint the `use wasm::mod::*` sites (core, test_runner, test_mod, wasm_smoke, run_wasm_tests) and add direct `use wasm::emitter::*` to encode/lower/main.
- Pub-ify the emitter API (fns/structs) so symbols cross the module boundary.
- Update `scripts/bootstrap/bootstrap_concat.sh` file list to the new name.

## Verification

Built the modular compiler (`self-hosted/compiler/main.sio`) on this tree:
- **wasm errors: 136 → 0** ✓
- Build proceeds past the wasm backend into codegen.

The **checked-in `self-hosted/compiler/lean_single.sio` bundle is untouched** by this change (the rename is content-preserving; only the modular source files + the bundler's file list change), so the bootstrap/self-host path is unaffected.

## Not in scope

Three unrelated pre-existing ir-pass type errors remain in the modular build (`ir/opt_strategy.sio:229`, `ir/const_prop.sio:1676`, `ir/dce.sio:885`) — a separate follow-up before the modular compiler is fully functional. This PR fixes only the wasm module-path collision.

Found while investigating the modular-build state during EISA integration (Sounio-lang/sounio#767).

🤖 Generated with [Claude Code](https://claude.com/claude-code)