### PR TITLE
fix(ir): reconcile [IrInstr;1024] buffers with the [IrInstr;2048] IrFunction.instrs field

### DIFF
--- a/self-hosted/ir/const_prop.sio
+++ b/self-hosted/ir/const_prop.sio
@@ -1670,24 +1670,19 @@ fn cp_optimize_function(func: IrFunction) -> IrFunction with Mut, Div, Panic {
 // ============================================================================
 
 // Build a test IrFunction from an instruction array and count.
-fn cp_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
-    IrFunction {
-        name: ir_empty_name(),
-        instrs: instrs,
-        instr_count: count,
-        reg_count: count + 10,
-        label_count: 0,
-        param_count: 0,
-        param_regs: [IR_INVALID_REG; 64],
-        compile_strategy: IR_STRATEGY_STANDARD,
-        returns_float: 0,
-        return_struct_name: ir_empty_name(),
-        prof_counter_id: -1,
-        hyper_algebra_kind: -1,
-        is_sret: 0,
-        sret_dest_reg: -1,
-        bss_size: 0,
+fn cp_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction with Mut, Panic {
+    // instrs is [IrInstr; 1024] but IrFunction.instrs is [IrInstr; 2048]; a typed
+    // fixed-size array cannot be assigned across sizes, so build an empty function
+    // (its [2048] instrs come from a size-flexible fill literal) and copy in.
+    var f = ir_empty_function()
+    var i: i64 = 0
+    while i < count {
+        f.instrs[i as usize] = instrs[i as usize]
+        i = i + 1
     }
+    f.instr_count = count
+    f.reg_count = count + 10
+    f
 }
 
 // Build an empty instruction array filled with NOPs.

--- a/self-hosted/ir/dce.sio
+++ b/self-hosted/ir/dce.sio
@@ -879,24 +879,19 @@ fn dce_optimize_function(func: IrFunction) -> IrFunction with Mut, Panic, Div {
 // ============================================================================
 
 // Build a test IrFunction from an instruction array and count.
-fn dce_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
-    IrFunction {
-        name: ir_empty_name(),
-        instrs: instrs,
-        instr_count: count,
-        reg_count: count + 10,
-        label_count: 0,
-        param_count: 0,
-        param_regs: [IR_INVALID_REG; 64],
-        compile_strategy: IR_STRATEGY_STANDARD,
-        returns_float: 0,
-        return_struct_name: ir_empty_name(),
-        prof_counter_id: -1,
-        hyper_algebra_kind: -1,
-        is_sret: 0,
-        sret_dest_reg: -1,
-        bss_size: 0,
+fn dce_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction with Mut, Panic {
+    // instrs is [IrInstr; 1024] but IrFunction.instrs is [IrInstr; 2048]; a typed
+    // fixed-size array cannot be assigned across sizes, so build an empty function
+    // (its [2048] instrs come from a size-flexible fill literal) and copy in.
+    var f = ir_empty_function()
+    var i: i64 = 0
+    while i < count {
+        f.instrs[i as usize] = instrs[i as usize]
+        i = i + 1
     }
+    f.instr_count = count
+    f.reg_count = count + 10
+    f
 }
 
 // Check if instruction at position is a specific opcode (using IrOpcode).

--- a/self-hosted/ir/opt_strategy.sio
+++ b/self-hosted/ir/opt_strategy.sio
@@ -126,7 +126,7 @@ pub fn ir_opt_clone_instr(
 // Mutating in place avoids copying the entire fixed-size instruction buffer
 // on every append during the dual-path rewrite.
 pub fn ir_opt_append(
-    instrs: &! [IrInstr; 1024],
+    instrs: &! [IrInstr; 2048],
     count: i64,
     instr: IrInstr
 ) -> i64 with Mut, Panic {
@@ -138,7 +138,7 @@ pub fn ir_opt_append(
 
 pub fn ir_opt_apply_strategy_instrs_into(
     func: &IrFunction,
-    instrs: &! [IrInstr; 1024],
+    instrs: &! [IrInstr; 2048],
     vreg_offset: i64,
     label_offset: i64,
     count: i64,


### PR DESCRIPTION
**Stacked on #771** (wasm module-path fix). Together they take the modular Madaros build to **0 typecheck errors** and a working compiler.

## Problem

`IrFunction.instrs` is `[IrInstr; 2048]`, but the ir-pass code uses `[IrInstr; 1024]` scratch buffers pervasively. Three boundaries mismatched — typecheck errors that made the modular compiler non-functional:

- `const_prop.sio:1676` / `dce.sio:885` — `cp_make_test_func` / `dce_make_test_func` assign a `[1024]` param straight into the `[2048]` `instrs` field (`instrs: instrs`). A typed fixed-size array can't be assigned across sizes.
- `opt_strategy.sio:229` — `ir_opt_apply_strategy_instrs_into` / `ir_opt_append` take `&! [IrInstr; 1024]` but `ir_opt_apply_strategy` passes `&! out.instrs` (`[2048]`).

## Fix (loop-copy, not a size bump)

A naive `1024→2048` bump cascades to 1200+ errors (the split is deeply interconnected). Instead:

- **const_prop/dce**: build via `ir_empty_function()` (its `[2048]` instrs come from a size-flexible fill literal) and copy the `[1024]` param in element-wise. `[1024]` buffers stay unchanged.
- **opt_strategy**: `ir_opt_apply_strategy_instrs_into` and `ir_opt_append` are called **only** within `opt_strategy.sio`, so bumping their param to `[2048]` is contained and matches the buffer that must hold up to 2048 instrs.

## Verification (stacked on #771)

- modular build typecheck errors: **3 → 0**
- produces a working 98 MB madaros
- `madaros check <prog>` → `check: OK`
- `madaros build <trivial prog>` → emits a runnable ELF (runs, exit 0)

(Complex programs still hit native-v2 *backend* codegen limits — a separate madaros-maturity issue, out of scope here.)

Part of Sounio-lang/sounio#767 (W3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)