### PR TITLE
results(ossm): add cognitive O-SSM smoke result (n=5)

### DIFF
--- a/examples/cognitive_ossm/results/ossm_sounio_smoke.json
+++ b/examples/cognitive_ossm/results/ossm_sounio_smoke.json
@@ -1,0 +1,9 @@
+{
+  "max_trajectories": 5,
+  "max_steps": 500,
+  "normative": {"n": 5, "mean_hidden_entropy_production_rate": 0.0014340538300110963, "mean_associator_norm": 0.23809741593990474, "mean_c_ent_variance": 0.13147885757287753, "mean_h_entropy": 0.9962227449893952},
+  "anxious": {"n": 5, "mean_hidden_entropy_production_rate": 0.014561295485448744, "mean_associator_norm": 0.054792887670430356, "mean_c_ent_variance": 0.05298061083501284, "mean_h_entropy": 0.9438034637928009},
+  "ruminative": {"n": 5, "mean_hidden_entropy_production_rate": 0.000666801962919369, "mean_associator_norm": 0.25117630129940804, "mean_c_ent_variance": 0.03244502845884405, "mean_h_entropy": 0.9984889179944991},
+  "psychotic": {"n": 5, "mean_hidden_entropy_production_rate": 0.023191633014258497, "mean_associator_norm": 0.008223839413761742, "mean_c_ent_variance": 0.03376719542998087, "mean_h_entropy": 0.9177325112104416},
+  "comparisons": {"normative_vs_anxious_hidden_entropy_production_rate_cohens_d": -9.057757423789452, "normative_vs_anxious_mean_associator_norm_cohens_d": 5.002332312156664}
+}


### PR DESCRIPTION
The n=5 smoke tier of the native cognitive O-SSM validator — same schema and series as the already-tracked `ossm_sounio_native_n100.json` / `n1000.json` in `examples/cognitive_ossm/results/`. Small (1 KB) result artifact; completes the smoke → n100 → n1000 ladder. Last item from the 2026-07-11 working-tree triage.