### PR TITLE
docs(reality-fix C): correct llm-guide error catalog vs real Madaros behavior

### DIFF
--- a/docs/llm-guide/README.md
+++ b/docs/llm-guide/README.md
@@ -24,7 +24,7 @@ How to teach an LLM to write correct Sounio code. Start here.
 ## What an LLM needs to know
 
 1. **Syntax differs from Rust** — same look, different rules. `llms.txt` covers this.
-2. **Effects are not optional** — every function that divides, mutates, or prints must declare it. The compiler rejects missing effects.
+2. **Effects are a design discipline, not a hard gate (today)** — every function that divides, mutates, or prints *should* declare it (`with Div`/`Mut`/`IO`), and style/lint expects it. But note: as of Madaros v0.80.0 the default `souc check` does **not** reject a missing IO/Div/Observe effect (E035 is not wired under `check`). Write effects correctly for readability and forward-compat; do not rely on the compiler to catch a missing one.
 3. **No dynamic features** — no generics, no closures, no traits, no dynamic dispatch.
 4. **stdlib is extensive** — 95 modules. `stdlib-index.md` maps what's usable.
 

--- a/docs/llm-guide/error-catalog.md
+++ b/docs/llm-guide/error-catalog.md
@@ -404,9 +404,9 @@ Got an error?
 
 ## Machine-Readable Error Code Reference
 
-Stable codes emitted by the compiler in `error[Exxxx]:` format. Parseable by `souc check --json` into `sounio.diagnostic.v1` JSON.
+Codes the compiler *can* emit in `error[Exxxx]:` format. Note: there is **no** `souc check --json` flag and **no** `souc explain <CODE>` subcommand in Madaros v0.80.0 (both were removed / never shipped — verify with `souc --help`). Read the per-code files under `explanations/` directly.
 
-Use `souc explain <CODE>` for a one-paragraph explanation + minimal example + canonical fix.
+> **⚠️ Enforcement reality — verified 2026-07-11 against the default `bin/souc` (Madaros).** The default compiler is **more permissive** than this table implies; several listed codes do **not** currently fire under `souc check` (the "wrong" example compiles clean). Verified non-firing: **E035** (missing IO/Div/Observe effect — effects are not enforced under `check`), **E040/E041/E042/E043** (Rust `let mut` / `&mut` / `#[...]` / `ident!()` — these surface as a bare `parse error` or `check: OK`, not a coded compat error), **E201–E207** (the `ZD` capability family — unenforced), **E208/E209** (refinement predicates — `Pos`/`Prob` treated nominally; the predicate is not evaluated), **E213** (tuple-destructure arity), **E216** (recursive struct type), **E224** (unreadable/dead import — silently ignored). Wrong code numbers: an arity mismatch surfaces as **E010** (not E006); a tail/return-type mismatch as **E008** (not E218). Confirmed firing: E001, E010, E170, E171. `check` stops before codegen, so codegen/linker codes (E007, E217–E223) are not reachable via `check`. Treat this table as the code *namespace*, not a guarantee that every guard is wired. (Note: the `lean_single` seed engine is stricter and rejects some of the above — but agents use the default Madaros.)
 
 | Code | Component | Severity | Gloss | Explanation |
 |------|-----------|----------|-------|-------------|

--- a/docs/llm-guide/explanations/E006.md
+++ b/docs/llm-guide/explanations/E006.md
@@ -14,6 +14,9 @@ severity: error
 component: type-checker
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** the default `souc check` reports this defect as **E010**, not the code named here. See [error-catalog.md](../error-catalog.md).
+
+
 **E006 — Arity mismatch**
 
 A function was called with the wrong number of arguments.

--- a/docs/llm-guide/explanations/E035.md
+++ b/docs/llm-guide/explanations/E035.md
@@ -14,6 +14,9 @@ severity: error
 component: type-checker/effects
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E035 — Effect not declared in function signature**
 
 A function performs an operation that requires an effect (IO, Mut, Div, Panic, Alloc, Observe, Audit, Hypothesis, Epistemic, ZD…) but the function's `with` clause does not list that effect.

--- a/docs/llm-guide/explanations/E040.md
+++ b/docs/llm-guide/explanations/E040.md
@@ -14,6 +14,9 @@ severity: error
 component: parser/compat
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E040 — `let mut` is not valid Sounio**
 
 Sounio uses `var` for mutable bindings, not `let mut`.

--- a/docs/llm-guide/explanations/E041.md
+++ b/docs/llm-guide/explanations/E041.md
@@ -14,6 +14,9 @@ severity: error
 component: parser/compat
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E041 — `&mut` is not valid Sounio**
 
 Sounio uses `&!T` for exclusive (mutable) references, not `&mut T`.

--- a/docs/llm-guide/explanations/E042.md
+++ b/docs/llm-guide/explanations/E042.md
@@ -14,6 +14,9 @@ severity: error
 component: parser/compat
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E042 — Rust attributes `#[...]` are not valid Sounio**
 
 Sounio has no attribute macro system. Remove `#[derive(...)]`, `#[cfg(...)]`, `#[allow(...)]`, and similar Rust annotations.

--- a/docs/llm-guide/explanations/E043.md
+++ b/docs/llm-guide/explanations/E043.md
@@ -14,6 +14,9 @@ severity: error
 component: parser/compat
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E043 — Rust macro syntax `ident!(...)` is not valid Sounio**
 
 Sounio has no macro system. Use regular function calls.

--- a/docs/llm-guide/explanations/E201.md
+++ b/docs/llm-guide/explanations/E201.md
@@ -14,6 +14,9 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E201 — `ExactlyPrivate<T>` parameter requires `with ZD`**
 
 Functions that receive or produce zero-divisor-typed values (`ExactlyPrivate<T>`, `Editable<T>`, `CapabilityGated<T>`, `Composable<T>`, `Audited<T>`, `Revivable<T>`, `Interpretable<T>`) must declare the corresponding effects in their signature.

--- a/docs/llm-guide/explanations/E202.md
+++ b/docs/llm-guide/explanations/E202.md
@@ -14,4 +14,7 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E202** — See [E201](E201.md) for the general zero-divisor effect rule. This code is emitted for the specific zero-divisor type variant used in this context. Add `with ZD` (and `Witness`/`Temporal` as noted in the error message) to the function's effect clause.

--- a/docs/llm-guide/explanations/E203.md
+++ b/docs/llm-guide/explanations/E203.md
@@ -14,4 +14,7 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E203** — See [E201](E201.md) for the general zero-divisor effect rule. This code is emitted for the specific zero-divisor type variant used in this context. Add `with ZD` (and `Witness`/`Temporal` as noted in the error message) to the function's effect clause.

--- a/docs/llm-guide/explanations/E204.md
+++ b/docs/llm-guide/explanations/E204.md
@@ -14,4 +14,7 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E204** — See [E201](E201.md) for the general zero-divisor effect rule. This code is emitted for the specific zero-divisor type variant used in this context. Add `with ZD` (and `Witness`/`Temporal` as noted in the error message) to the function's effect clause.

--- a/docs/llm-guide/explanations/E205.md
+++ b/docs/llm-guide/explanations/E205.md
@@ -14,4 +14,7 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E205** — See [E201](E201.md) for the general zero-divisor effect rule. This code is emitted for the specific zero-divisor type variant used in this context. Add `with ZD` (and `Witness`/`Temporal` as noted in the error message) to the function's effect clause.

--- a/docs/llm-guide/explanations/E206.md
+++ b/docs/llm-guide/explanations/E206.md
@@ -14,4 +14,7 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E206** — See [E201](E201.md) for the general zero-divisor effect rule. This code is emitted for the specific zero-divisor type variant used in this context. Add `with ZD` (and `Witness`/`Temporal` as noted in the error message) to the function's effect clause.

--- a/docs/llm-guide/explanations/E207.md
+++ b/docs/llm-guide/explanations/E207.md
@@ -14,4 +14,7 @@ severity: error
 component: type-checker/zero-divisor
 ---
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean under the default engine (the `lean_single` seed is stricter). Kept for the intended semantics and forward-compat; see the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **E207** — See [E201](E201.md) for the general zero-divisor effect rule. This code is emitted for the specific zero-divisor type variant used in this context. Add `with ZD` (and `Witness`/`Temporal` as noted in the error message) to the function's effect clause.

--- a/docs/llm-guide/explanations/E208.md
+++ b/docs/llm-guide/explanations/E208.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.expl
 
 # E208 — Refinement type violation (integer)
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean or surfaces a different code under the default engine. See the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **Severity:** error
 
 **Message pattern:** `error[E208]: refinement type violation — value N does not satisfy predicate at line L`

--- a/docs/llm-guide/explanations/E209.md
+++ b/docs/llm-guide/explanations/E209.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.expl
 
 # E209 — Refinement type violation (f64)
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean or surfaces a different code under the default engine. See the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **Severity:** error
 
 **Message pattern:** `error[E209]: refinement type violation — f64 value violates predicate at line L`

--- a/docs/llm-guide/explanations/E213.md
+++ b/docs/llm-guide/explanations/E213.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.expl
 
 # E213 — Tuple destructure arity mismatch
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean or surfaces a different code under the default engine. See the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **Severity:** error
 
 **Message pattern:** `error[E213]: tuple destructure arity mismatch: has N elements but type has M at line L`

--- a/docs/llm-guide/explanations/E216.md
+++ b/docs/llm-guide/explanations/E216.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.expl
 
 # E216 — Infinite recursive type
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean or surfaces a different code under the default engine. See the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **Severity:** error
 
 **Message pattern:** `error[E216]: infinite recursive type`

--- a/docs/llm-guide/explanations/E218.md
+++ b/docs/llm-guide/explanations/E218.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.expl
 
 # E218 — Tail type mismatch
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** the default `souc check` reports this defect as **E008**, not the code named here. See [error-catalog.md](../error-catalog.md).
+
+
 **Severity:** error
 
 **Message pattern:** `error[E218]: tail type mismatch at line L`

--- a/docs/llm-guide/explanations/E224.md
+++ b/docs/llm-guide/explanations/E224.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.expl
 
 # E224 — Unreadable import
 
+> **⚠️ Reality check (Madaros v0.80.0, verified 2026-07-11):** this code does **not** currently fire under the default `souc check` — the "wrong" example below compiles clean or surfaces a different code under the default engine. See the enforcement-reality note in [error-catalog.md](../error-catalog.md).
+
+
 **Severity:** error
 
 **Message pattern:** `error[E224]: unreadable import: PATH`


### PR DESCRIPTION
**Front C of 3** from the 2026-07-11 deep doc-reality audit — the most important for AI agents, since these are the docs agents rely on for the error→fix loop.

The audit found the error catalog **systematically wrong**: the default `souc check` (Madaros v0.80.0) is far **more permissive** than documented, so an agent told to expect a guard gets code that compiles clean. Every claim below was re-verified against the default `bin/souc` (the `lean_single` seed is stricter, but agents use the default).

**`error-catalog.md`**
- Header no longer advertises the nonexistent `souc check --json` flag and `souc explain <CODE>` subcommand (both verified dead — not in `--help`).
- Adds an **"Enforcement reality"** note listing codes that do **not** fire under `check`: **E035** (effects), **E040–E043** (Rust-compat), **E201–E207** (ZD family), **E208/E209** (refinement predicates — nominal only), **E213** (tuple arity), **E216** (recursive struct), **E224** (dead import); and wrong-code cases: arity → **E010** (not E006), tail mismatch → **E008** (not E218).

**`README.md`**: "the compiler rejects missing effects" → effects are a design discipline, not a hard `check` gate today (E035 unwired).

**23 × `explanations/E*.md`**: each non-firing / wrong-code page gets a **⚠️ Reality check** caveat linking to the enforcement note.

Confirmed still-accurate and untouched: **E001, E010, E170, E171**. Codegen/linker codes (E007, E217–E223) are not `check`-reachable and were not claimed stale. Docs registry + consistency gates pass.

**Note:** the underlying compiler *permissiveness* (unwired effect/refinement/ZD enforcement) is itself a finding — this PR documents reality honestly; wiring those guards is a separate compiler task.