### PR TITLE
docs(reality-fix): salvage 4 partially-stale compiler docs with verified path banners

### DIFF
--- a/docs/compiler/DEBUGGING_GUIDE.md
+++ b/docs/compiler/DEBUGGING_GUIDE.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.compiler.debug
 
 # Debugging Guide for Sounio Programs
 
+> **⚠️ File paths updated 2026-07-11 (doc-reality audit).** This page was written against the retired Rust compiler tree (`crates/`, `compiler/src/*.rs`, `codegen/llvm/`); those files no longer exist — the compiler is self-hosted Sounio (Madaros v0.80.0). The design and concepts below remain accurate, but DWARF/debug-info emission now lives in `self-hosted/native/dwarf.sio` and `self-hosted/native/debug_info.sio`; the epistemic/knowledge runtime in `self-hosted/compiler/knowledge_runtime_guard*.sio` — not any `codegen/llvm/*.rs` or `backend/native/*.rs`. Do not look for the `.rs` paths below.
+
+
 ## 1. Introduction
 
 Debugging scientific code presents unique challenges compared to general-purpose programming, as it often involves not just correctness but also the reliability and interpretability of results. In Sounio programs, epistemic values—such as confidence levels and provenance—require special inspection to ensure that uncertainties are properly tracked and propagated. Refinement constraints, which enforce properties like positivity or bounds at the type level, demand validation to catch violations early. Units add another layer of complexity, as mismatches can lead to physically meaningless computations if not detected. To address these aspects in native code, Sounio leverages DWARF debug information, enabling detailed inspection of variables, types, and execution flow.

--- a/docs/compiler/EPISTEMIC_BACKEND_GUIDE.md
+++ b/docs/compiler/EPISTEMIC_BACKEND_GUIDE.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.compiler.epist
 
 # Epistemic Backend Guide
 
+> **⚠️ File paths updated 2026-07-11 (doc-reality audit).** This page was written against the retired Rust compiler tree (`crates/`, `compiler/src/*.rs`, `codegen/llvm/`); those files no longer exist — the compiler is self-hosted Sounio (Madaros v0.80.0). The design and concepts below remain accurate, but the epistemic backend/runtime now lives in `self-hosted/` as `.sio` (knowledge-runtime guards in `self-hosted/compiler/knowledge_runtime_guard*.sio`, native emission in `self-hosted/native/`) — not any `epistemic_runtime.rs` / `c_layout.rs` / LLVM backend variant. Do not look for the `.rs` paths below.
+
+
 ## 1. Introduction
 
 Epistemic computing in Sounio represents a paradigm for handling uncertainty and knowledge provenance directly within the computational framework, enabling precise tracking of confidence levels, intervals, and origins in data processing. At its core, the `Knowledge<T>` type serves as a first-class primitive, embedding epistemic metadata alongside the primary value to ensure that computations reflect not just results but also their reliability and context. This approach is particularly vital in scientific computing, where epistemic metadata—such as confidence scores, uncertainty intervals, and provenance trails—facilitates reproducibility, regulatory compliance, and error mitigation in fields like pharmaceuticals, engineering, and data analysis. By making uncertainty explicit, Sounio prevents silent propagation of errors and supports informed decision-making under partial knowledge.

--- a/docs/compiler/SIR_PASSES.md
+++ b/docs/compiler/SIR_PASSES.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.compiler.sir-p
 
 # SIR Transformation Passes
 
+> **⚠️ File paths updated 2026-07-11 (doc-reality audit).** This page was written against the retired Rust compiler tree (`crates/`, `compiler/src/*.rs`, `codegen/llvm/`); those files no longer exist — the compiler is self-hosted Sounio (Madaros v0.80.0). The design and concepts below remain accurate, but the SIR/IR passes now live in `self-hosted/ir/` (`const_prop.sio`, `dce.sio`, `inline.sio`, `loop_opt.sio`, `lower.sio`, `normalize.sio`, `optimize.sio`, …) and refinement handling in `self-hosted/check/refinement.sio` — not any `compiler/src/sir/*.rs` or `compiler/src/types/*.rs`. Do not look for the `.rs` paths below.
+
+
 This document describes the modular SIR transformation pass infrastructure.
 
 ## Architecture

--- a/docs/compiler/TECHNICAL_REPORT.md
+++ b/docs/compiler/TECHNICAL_REPORT.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.compiler.techn
 
 # Native GPU Octonion Support for Deep Learning: A Compiler-First Approach
 
+> **⚠️ File paths updated 2026-07-11 (doc-reality audit).** This page was written against the retired Rust compiler tree (`crates/`, `compiler/src/*.rs`, `codegen/llvm/`); those files no longer exist — the compiler is self-hosted Sounio (Madaros v0.80.0). The design and concepts below remain accurate, but the GPU/PTX & Metal codegen now lives in `self-hosted/gpu/` (`lower_to_ptx.sio`, `kretikos_emit_ptx.sio`, `kretikos_emit_metal.sio`); tests and benchmarks are `.sio` under `tests/` and `benchmarks/` (no Criterion.rs / cargo). Do not look for the `.rs` paths below.
+
+
 **Authors**: Sounio Development Team
 **Preprint v1.0** — January 2026
 


### PR DESCRIPTION
Follow-on to the doc-reality fronts (#786/#788/#790): the 4 **salvageable** docs the audit flagged — they describe **real** subsystems but cite retired Rust paths (`crates/`, `compiler/src/*.rs`, `codegen/llvm/`).

Rather than demote them (the concepts are accurate) or guess ambiguous 1:1 file mappings (`ptx.rs` → which of 10 `*.sio`?), each gets a **verified path-correction banner** pointing to the real `self-hosted/` location:

- **TECHNICAL_REPORT.md** → GPU/PTX/Metal codegen in `self-hosted/gpu/` (`lower_to_ptx.sio`, `kretikos_emit_ptx.sio`, `kretikos_emit_metal.sio`); tests/benches are `.sio` (no cargo/Criterion).
- **DEBUGGING_GUIDE.md** → DWARF/debug-info in `self-hosted/native/dwarf.sio` + `debug_info.sio`; epistemic runtime in `self-hosted/compiler/knowledge_runtime_guard*.sio`.
- **SIR_PASSES.md** → SIR/IR passes in `self-hosted/ir/` (`const_prop.sio`, `dce.sio`, `inline.sio`, `loop_opt.sio`, `lower.sio`, …); refinement in `self-hosted/check/refinement.sio`.
- **EPISTEMIC_BACKEND_GUIDE.md** → epistemic backend/runtime in `self-hosted/` `.sio`.

Every target location verified to exist (`git ls-files`). Docs registry + consistency gates pass. These stay `repo_only` (salvaged, not historical). Precise inline path substitution is deliberately avoided where the old→new mapping is ambiguous — the banner carries the honest correction without risking a new wrong path.