### PR TITLE
docs(reality-fix): rewrite install/dev guides for the prebuilt self-hosted toolchain

### DIFF
--- a/docs/contributor-guide/BENCHMARK_GUIDE.md
+++ b/docs/contributor-guide/BENCHMARK_GUIDE.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.contributor-gu
 
 # GLM-4.7 Performance Benchmark Guide
 
+> **⚠️ Command reality updated 2026-07-11.** There is no `cargo bench` and no `crates/souc/benches/*.rs` in this self-hosted checkout, and no `./target/release/souc`. Benchmarks are `.sio` programs under `benchmarks/` driven by `scripts/benchmarks/*.sh`; run individual ones with `./bin/souc run benchmarks/<name>.sio` (set `SOUNIO_STDLIB_PATH=$(pwd)/stdlib`). Treat the `cargo`/`--glm-enabled`/`--features` commands below as historical.
+
+
 ## Overview
 
 This guide explains how to use the comprehensive GLM-4.7 performance benchmarking suite for the Sounio compiler.

--- a/docs/contributor-guide/BENCHMARK_RESULTS.md
+++ b/docs/contributor-guide/BENCHMARK_RESULTS.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.contributor-gu
 
 # Natural Gradient Descent Benchmark Results
 
+> **⚠️ Path reality updated 2026-07-11.** The cited `crates/souc/benches/*.rs`, `crates/souc/src/epistemic/*.rs`, and `cargo bench` do **not** exist in this self-hosted checkout (no Rust tree). The epistemic/benchmark code is self-hosted `.sio` under `stdlib/` and `benchmarks/`. The numeric results below are historical Rust-era figures.
+
+
 ## Summary
 
 Comprehensive benchmarking of natural gradient descent vs Euclidean gradient descent for Beta parameter estimation.

--- a/docs/contributor-guide/DEVELOPER_WORKFLOW.md
+++ b/docs/contributor-guide/DEVELOPER_WORKFLOW.md
@@ -9,6 +9,9 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.contributor-gu
 
 # Sounio Developer Workflow Guide
 
+> **⚠️ Command reality updated 2026-07-11 (doc-reality audit).** This guide predates the Rust→self-hosted cutover; the `cargo` / `crates/` / `./target/release/souc` commands below do **not** work (no `Cargo.toml`). Real equivalents on this checkout: the compiler is **prebuilt** — use `./bin/souc` directly. `cargo run -- <args>` → `./bin/souc <args>`; `cargo build --release` → `make build`; `cargo test` → `make test` or `bash scripts/run_sio_test_suite.sh`. The Make targets `make verify` / `verify-quick` / `test-selfhost` / `test-all` do **not** exist — real ones include `make build`, `make check`, `make test`, `make test-stdlib`, `make test-madaros-identity`, `make lint`. Project-structure paths have moved: `check/type_check.sio` → `self-hosted/check/check.sio`; `lexer/lexer.sio` → `self-hosted/lexer/mod.sio`; the frontend lives under `self-hosted/`.
+
+
 **Target Audience**: Contributors working on the self-hosted compiler
 **Last Updated**: 2026-02-13
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -26,20 +26,31 @@ This guide covers all installation scenarios for the Sounio compiler, from basic
 
 ---
 
+> **⚠️ Rewritten 2026-07-11 (doc-reality audit).** The current Sounio toolchain is **self-hosted and prebuilt** — you do **not** build it with `cargo`/Rust, there is no Cranelift/LLVM feature-flag build, and there is no `./target/release/souc`. The compiler binaries are checked into `bin/`. The Rust / `cargo` / LLVM 15–17 / Z3 / feature-flag sections further down describe the **retired** Rust build and no longer apply to this checkout; they are kept for historical reference only. Use the Quick Start below.
+
 ## Quick Start
 
-For most users, the basic build requires only Rust:
+The compiler ships **prebuilt** in `bin/`. No build step is needed to use it.
 
 ```bash
 # Clone the repository
-git clone https://github.com/sounio-lang/sounio.git
+git clone https://github.com/Sounio-lang/sounio.git
 cd sounio
 
-# Build with default features (Cranelift JIT)
-cargo build --release
+# bin/souc routes to the self-hosted Madaros engine (no Rust/cargo needed)
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"   # required when running from outside the repo root
+./bin/souc --version                        # -> Madaros v0.80.0 (an un-rebuilt checkout may still print "Madares")
+./bin/souc run examples/hello.sio           # smoke test -> "Hello, Sounio"
+```
 
-# Verify installation
-./target/release/souc --version
+### Building the compiler from source (optional)
+
+Only needed to *rebuild* the compiler itself. It is self-hosted in Sounio and bootstrapped from a small C stage0 — **no Rust, no cargo**:
+
+```bash
+make build          # boot chain gen1 -> gen2 -> gen3; verifies the gen2 == gen3 fixed point
+make build-madaros  # (re)build the modular Madaros compiler from self-hosted/compiler/main.sio
+make check          # type-check the compiler + CI gates
 ```
 
 ---
@@ -68,27 +79,23 @@ cargo build --release
 
 ## Basic Installation
 
-### Step 1: Install Rust
+### Step 1: Clone (the compiler is prebuilt — no Rust needed)
 
 ```bash
-# Install rustup (if not already installed)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# Ensure you have the latest stable
-rustup update stable
-```
-
-### Step 2: Clone and Build
-
-```bash
-git clone https://github.com/sounio-lang/sounio.git
+git clone https://github.com/Sounio-lang/sounio.git
 cd sounio
 
-# Basic build (uses Cranelift JIT)
-cargo build --release
+# The compiler binaries are checked into bin/; nothing to install.
+./bin/souc --version
+```
 
-# Install to PATH (optional)
-cargo install --path .
+### Step 2: (optional) Rebuild the self-hosted compiler
+
+Only if you want to rebuild it from source. Sounio is self-hosted and bootstrapped from a C stage0 — **no Rust, no cargo, no rustup**:
+
+```bash
+make build          # gen1 -> gen2 -> gen3, verifies gen2 == gen3 fixed point
+make install        # optional: place souc on PATH
 ```
 
 ### Step 3: Configure Stdlib Path
@@ -99,8 +106,8 @@ Set the stdlib path for programs that use standard library modules:
 # Add to ~/.bashrc or ~/.zshrc
 export SOUNIO_STDLIB_PATH=/path/to/sounio/stdlib
 
-# Verify stdlib resolution
-souc sysroot stdlib-paths
+# Verify stdlib resolution by type-checking a program that imports the stdlib
+./bin/souc check examples/hello.sio    # (there is no `souc sysroot` subcommand)
 ```
 
 ---
@@ -393,22 +400,19 @@ cargo build --features "llvm15,llvm17"  # Error!
 
 ## Verifying Installation
 
-After installation, run the test suite:
+After cloning, verify the prebuilt toolchain and run the test suite (no cargo):
 
 ```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+
 # Quick smoke test
-cargo test --release
+./bin/souc run examples/hello.sio
 
-# Full test suite
-cargo test --release --features "jit,gpu,ontology"
+# Full .sio test suite
+bash scripts/run_sio_test_suite.sh        # or: make test
 
-# With LLVM and SMT
-cargo test --release --features "llvm17,smt,gpu,ontology"
-```
-
-Expected output (as of v1.0):
-```
-test result: ok. 3851 passed; 0 failed; 0 ignored
+# Single test by pattern
+bash scripts/run_sio_test_suite.sh vancomycin --verbose
 ```
 
 ---
@@ -435,4 +439,4 @@ test result: ok. 3851 passed; 0 failed; 0 ignored
 
 ---
 
-*Last updated: January 2026 (v1.0.0)*
+*Last updated: 2026-07-11 (Madaros v0.80.0). Quick Start reflects the prebuilt self-hosted toolchain; the Rust/LLVM dependency sections are retained as historical reference for the retired Rust build.*


### PR DESCRIPTION
The last material drift pocket from the 2026-07-11 doc-reality audit: the install/dev/benchmark guides describe a **Rust/cargo/LLVM/Cranelift** build that does not exist. The compiler is **prebuilt** (`bin/souc`) and self-hosted.

**`installation.md` — real rewrite of the actionable path:**
- Quick Start + Basic Installation now use the prebuilt `bin/souc` (no `rustup`/`cargo`/`./target/release/souc`) with `SOUNIO_STDLIB_PATH`; from-source is `make build` / `make build-madaros` / `make install`.
- stdlib verification uses `souc check` (dropped the nonexistent `souc sysroot stdlib-paths`).
- test suite uses `scripts/run_sio_test_suite.sh` / `make test` (dropped `cargo test … 3851 passed`).
- version footer → 2026-07-11 / Madaros v0.80.0.
- A top banner marks the remaining Rust / LLVM 15–17 / Z3 / feature-flag sections as retired-build history (kept, not deleted).
- **Verified:** `./bin/souc run examples/hello.sio` → "Hello, Sounio"; `make build`/`install` targets exist.

**`DEVELOPER_WORKFLOW.md`** — banner mapping `cargo run`/`build`/`test` → `bin/souc` / `make build` / `make test`; flags the nonexistent `make verify`/`test-all`/`test-selfhost` and moved frontend paths (`check/type_check.sio` → `self-hosted/check/check.sio`, `lexer/lexer.sio` → `self-hosted/lexer/mod.sio`).

**`BENCHMARK_GUIDE.md` / `BENCHMARK_RESULTS.md`** — banners: no `cargo bench` / `crates/souc/benches`; benchmarks are `.sio` under `benchmarks/` via `scripts/benchmarks/`.

Docs registry + consistency gates pass.