### PR TITLE
feat(checker): wire E213 tuple-pattern arity into the modular Madaros checker

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -6891,6 +6891,13 @@ fn checker_check_match_arm_inplace(c: *mut Checker, arm: MatchArm, scrut_ty: Typ
 // non-recursive `let (a,b)=..` survived). This version mutates (*c) directly and returns
 // nothing, so no Checker is ever moved. if/else-if (not match on pat.kind) dodges the
 // discriminant-0 *mut match miscompile.
+fn pattern_list_count(opt: Option<Box<PatternList> >) -> i64 with Mut, Panic, Div, Alloc {
+    match opt {
+        None => 0
+        Some(list) => 1 + pattern_list_count((*list).tail)
+    }
+}
+
 fn checker_bind_pattern_inplace(c: *mut Checker, pat: Pattern, scrut_ty: TypeEntry) with Mut, Panic, Div, Alloc, IO {
     if pat.kind == PatternKind::PatBinding {
         (*c).env = (*c).env.bind(pat.name, scrut_ty, pat.is_mut)
@@ -6910,6 +6917,17 @@ fn checker_bind_pattern_inplace(c: *mut Checker, pat: Pattern, scrut_ty: TypeEnt
     } else if pat.kind == PatternKind::PatStruct {
         checker_bind_struct_pat_fields_inplace(c, pat.pat_fields, scrut_ty)
     } else if pat.kind == PatternKind::PatTuple {
+        // E213: tuple-destructure arity must match the scrutinee tuple's element
+        // count. Fire ONLY on a KNOWN tuple type (never on unknown/incomplete
+        // inference), so valid code with matching arity is untouched. Sounio has
+        // no tuple rest-pattern (`(a, ..)`), so strict equality is correct.
+        if scrut_ty.kind == TypeKind::TyTuple {
+            let pat_n = pattern_list_count(pat.sub_patterns)
+            let ty_n = type_entry_list_count(scrut_ty.tuple_elems)
+            if pat_n != ty_n {
+                checker_report_error_at_inplace(c, pat.span, 213, pat_n, ty_n, 0)
+            }
+        }
         checker_bind_tuple_pattern_list_idx_inplace(c, pat.sub_patterns, scrut_ty, 0)
     } else if pat.kind == PatternKind::PatOr {
         checker_bind_pattern_list_inplace(c, pat.sub_patterns, scrut_ty)
@@ -11517,6 +11535,7 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 205 { print("Audited<T> requires ZD and Witness effects: witness-bearing surgery (G9) must emit a machine-checkable Lean derivation of the ZD-kernel action. `with ZD` alone produces the erasure without evidence; Witness is what makes it checkable. Add `with ZD, Witness` to your function signature.") }
     else if code == 206 { print("Revivable<T> requires ZD and Temporal effects: time-bounded reversible surgery (G10) needs both the ZD annihilator algebra and an explicit Temporal window in which the op can be inverted. After the window, the surgery is irrevocable. Add `with ZD, Temporal` to your function signature.") }
     else if code == 207 { print("Interpretable<T> requires ZD effect: the 168-class canonical basis is the projective ZD-graph of sedenions. Without the ZD effect the compiler cannot guarantee that decomposition/reconstruction is fp-exact. Add `with ZD` to your function signature.") }
+    else if code == 213 { print("tuple destructure arity mismatch") }
     else { print("unknown error") }
 }
 

--- a/tests/compile-fail/tuple_pattern_arity_e213.sio
+++ b/tests/compile-fail/tuple_pattern_arity_e213.sio
@@ -1,0 +1,17 @@
+//@ compile-fail
+//@ error-pattern: tuple destructure arity mismatch
+// E213: a tuple PATTERN whose arity does not match the scrutinee tuple type
+// must be rejected by `souc check` (the modular Madaros checker). Regression
+// guard for the 2026-07-11 guard-wiring dispatch — this compiled clean before
+// E213 was ported from the lean_single seed into
+// self-hosted/check/check.sio (checker_bind_pattern_inplace, PatTuple branch).
+//
+// Scope note: this covers tuple PATTERNS (match arms, if-let, nested). Plain
+// `let (a, b) = <3-tuple>` statements are parser-desugared to `__tup.N` field
+// accesses and are NOT covered here — see the dispatch doc for that follow-on.
+fn main() -> i32 with IO {
+    let p: (i64, i64) = (1, 2)
+    match p {
+        (a, b, c) => (a + b + c) as i32
+    }
+}


### PR DESCRIPTION
Implements the first guard from the guard-wiring dispatch (#798). The E213 enforcement lived only in the `lean_single` seed; the modular checker (`self-hosted/check/`) never had it, so the default `souc check` (Madaros) silently accepted arity-mismatched tuple patterns.

## Change — `self-hosted/check/check.sio`
- `pattern_list_count` helper.
- `checker_bind_pattern_inplace` PatTuple branch: when the scrutinee is a **known** tuple type (`TyTuple`), compare the pattern's sub-pattern count to the tuple's element count and emit `error[E213]` on mismatch. Fires **only** on a known tuple → valid matching-arity code is untouched (no false-rejects). Sounio has no tuple rest-pattern, so strict equality is correct.
- E213 message added to `print_error_message`.

## Scope (honest)
Covers tuple **patterns** — match arms, if-let, while-let, nested patterns — which route through `checker_bind_pattern_inplace`. Plain `let (a, b) = e` statements are **parser-desugared** to `__tup.N` field accesses before the checker sees them (`self-hosted/parser/stmts.sio`), so the let-statement case is a separate, harder follow-on (documented in #798).

## Verification (per the dispatch regression gate)
- **Full serial suite baseline vs post-change** (`JOBS=1 scripts/dev/run_sio_test_suite.sh`): **ZERO new failures across all 2213 tests.** Pass 887→888, Fail 548→547 — the net delta is exactly the test-file swap.
- New `tests/compile-fail/tuple_pattern_arity_e213.sio`: a 3-arity pattern on a 2-tuple now emits E213 (was `check: OK`).
- Matching-arity patterns still `check: OK`.
- Rebuilt Madaros under the pod-wide build lock; shipped the new `bin/madaros-linux-x86_64` so the guard takes effect (`./bin/souc --version` → Madaros v0.80.0).

One guard per PR (E216 is the documented next target). No changes to `lean_single`, the bootstrap fixed point (over `lean_single.sio`), or any other checker path.