### PR TITLE
feat(checker): wire E216 infinite-recursive-struct into the modular Madaros checker

### DIFF
--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3132,11 +3132,33 @@ fn checker_collect_field_defs_mut(c: *mut Checker, opt: Option<Box<FieldDefList>
     }
 }
 
+// E216: a struct whose field is the struct itself, by value (TyNamed == own
+// name), has infinite size. `Box<Node>` lowers to ty_named("Box") and `&Node`
+// to TyRef, so neither matches — pointer-wrapped recursion stays valid. Scope:
+// DIRECT self-reference only; mutual/transitive recursion is a documented
+// follow-on (needs a post-collection occurs-check over the struct graph).
+fn struct_field_list_has_direct_self_ref(opt: Option<Box<FieldInfoList> >, self_name: Name) -> bool with Mut, Panic, Div, Alloc {
+    match opt {
+        None => false
+        Some(list) => {
+            let f = (*list).head
+            if f.ty.kind == TypeKind::TyNamed && name_eq(f.ty.name, self_name) {
+                true
+            } else {
+                struct_field_list_has_direct_self_ref((*list).tail, self_name)
+            }
+        }
+    }
+}
+
 fn checker_collect_struct_def_inplace(c: *mut Checker, name: Name, opt: Option<Box<StructDef> >, visibility: Visibility, defining_module: AstPath) with Mut, Panic, Div, Alloc, IO {
     match opt {
         Some(sd) => {
             let tp_result = collect_type_params((*sd).type_params)
             let fc = checker_collect_field_defs_mut(c, (*sd).fields)
+            if struct_field_list_has_direct_self_ref(fc.fields, name) {
+                checker_report_error_at_inplace(c, (*sd).span, 216, 0, 0, 0)
+            }
             let info = StructInfo {
                 name: name,
                 fields: fc.fields,
@@ -11536,6 +11558,7 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 206 { print("Revivable<T> requires ZD and Temporal effects: time-bounded reversible surgery (G10) needs both the ZD annihilator algebra and an explicit Temporal window in which the op can be inverted. After the window, the surgery is irrevocable. Add `with ZD, Temporal` to your function signature.") }
     else if code == 207 { print("Interpretable<T> requires ZD effect: the 168-class canonical basis is the projective ZD-graph of sedenions. Without the ZD effect the compiler cannot guarantee that decomposition/reconstruction is fp-exact. Add `with ZD` to your function signature.") }
     else if code == 213 { print("tuple destructure arity mismatch") }
+    else if code == 216 { print("infinite recursive type") }
     else { print("unknown error") }
 }
 

--- a/tests/compile-fail/recursive_struct_e216.sio
+++ b/tests/compile-fail/recursive_struct_e216.sio
@@ -1,0 +1,9 @@
+//@ compile-fail
+//@ error-pattern: infinite recursive type
+// E216: a struct containing itself by value has infinite size and must be
+// rejected. Regression guard for the guard-wiring dispatch (#798). Box<Node>
+// (see recursive_struct_boxed.sio) stays valid — only by-value self-reference
+// is infinite.
+struct Node { val: i64, next: Node }
+
+fn main() -> i32 with IO { 0 }

--- a/tests/run-pass/recursive_struct_boxed.sio
+++ b/tests/run-pass/recursive_struct_boxed.sio
@@ -1,0 +1,6 @@
+//@ check-only
+// Box<Node> breaks the size cycle (pointer), so a boxed self-referential struct
+// is valid and must NOT trigger E216. Companion to recursive_struct_e216.sio.
+struct Node { val: i64, next: Box<Node> }
+
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
Second guard from the guard-wiring dispatch (#798), after E213 (#801). A struct whose field is the struct itself **by value** has infinite size; the modular checker accepted it silently (the guard lived only in the `lean_single` seed).

## Change — `self-hosted/check/check.sio`
- `struct_field_list_has_direct_self_ref` helper.
- `checker_collect_struct_def_inplace`: after lowering the field list, emit `error[E216]` if any field type is `TyNamed` with a name `name_eq` to the struct's own name (by-value direct self-reference).
- E216 message added to `print_error_message`.

**Box/ref exempt by construction:** `Box<Node>` lowers to `ty_named("Box")` (name "Box", not "Node") and `&Node` to `TyRef` (kind ≠ TyNamed). Verified: `struct N { next: Box<N> }` and `next: &N` still `check: OK`.

## Scope (honest)
**Direct** self-reference only. Mutual/transitive recursion (`A{b:B}`, `B{a:A}`) needs a post-collection occurs-check over the struct graph — documented follow-on.

## Verification (dispatch regression gate, off main incl. E213)
- **Full serial suite baseline vs post-change: ZERO new failures across 2215 tests.** The pre-existing `tests/run-pass/recursive_type.sio` (which expected this error) moved **fail → pass**; both new tests pass. Fail set 543 → 542.
- New tests: `tests/compile-fail/recursive_struct_e216.sio` (by-value → E216); `tests/run-pass/recursive_struct_boxed.sio` (`//@ check-only`, `Box<Node>` stays valid).
- Rebuilt Madaros under the build lock; shipped `bin/madaros-linux-x86_64`. E213 still fires; version Madaros v0.80.0.

One guard per PR. No `lean_single` / bootstrap-fixed-point / other-checker-path changes.