### PR TITLE
ci: select validation by changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,52 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: '23 3 * * *'
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  impact:
+    name: Impact
+    runs-on: ubuntu-24.04
+    outputs:
+      docs: ${{ steps.classify.outputs.docs }}
+      website: ${{ steps.classify.outputs.website }}
+      compiler: ${{ steps.classify.outputs.compiler }}
+      runtime: ${{ steps.classify.outputs.runtime }}
+      stdlib: ${{ steps.classify.outputs.stdlib }}
+      tests: ${{ steps.classify.outputs.tests }}
+      lean: ${{ steps.classify.outputs.lean }}
+      math: ${{ steps.classify.outputs.math }}
+      ontology: ${{ steps.classify.outputs.ontology }}
+      clinical: ${{ steps.classify.outputs.clinical }}
+      sio: ${{ steps.classify.outputs.sio }}
+      full: ${{ steps.classify.outputs.full }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: classify
+        name: Classify changed paths
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: bash scripts/ci/classify_ci_impact.sh
+      - name: Classifier self-test
+        run: bash scripts/ci/impact_ci_selftest.sh
+
   contracts:
     name: Contracts
+    needs: impact
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -44,50 +83,73 @@ jobs:
       - name: Claude operational contract
         run: bash scripts/ci/claude_operational_contract_gate.sh
       - name: Ontology validation
+        if: needs.impact.outputs.ontology == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/run_ontology_validation.sh --mode rebuilt ontology
       - name: Ontology CLI smoke gate
+        if: needs.impact.outputs.ontology == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/ontology_cli_smoke_gate.sh
       - name: Package-backed PBPK/GUM contract
+        if: needs.impact.outputs.clinical == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/package_pbpk_gum_gate.sh
       - name: Sedenion zd168 cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_zd168_crosscheck_gate.sh
       - name: Sedenion exact unbounded-Q CD cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_cd_qbig_gate.sh
       - name: Sedenion e8-seam bridge cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_seam_bridge_gate.sh
       - name: CD tower seam cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/cd_tower_seam_gate.sh
       - name: Gresnigt G2xS3 cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/gresnigt_g2s3_gate.sh
       - name: Gresnigt family-S3 cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/gresnigt_family_s3_gate.sh
       - name: Furey charge / G2 cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/furey_charge_g2_gate.sh
       - name: Sedenion Gresnigt-octonions cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_gresnigt_octonions_gate.sh
       - name: Sedenion octonion-census cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_octonion_census_gate.sh
       - name: Sedenion Clifford-8 cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_clifford8_gate.sh
       - name: Sedenion ladder-extension cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_ladder_extension_gate.sh
       - name: Furey octonion generation cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/furey_octonion_gate.sh
       - name: Sedenion dynamics cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_dynamics_gate.sh
       - name: Sedenion spectra cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_spectra_gate.sh
       - name: Sedenion quartet-fiber incidence cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_quartet_fiber_incidence_gate.sh
       - name: Sedenion zd-quartets cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_zd_quartets_gate.sh
       - name: Sedenion associator-1848 cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_associator_1848_gate.sh
       - name: Sedenion fiber-identity cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_zd_fiber_identity_gate.sh
       - name: Sedenion zd-fibers cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_zd_fibers_gate.sh
       - name: Sedenion e8-boundary cross-verification
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_e8_boundary_gate.sh
       - name: Upload contract artifacts
         if: always()
@@ -99,6 +161,8 @@ jobs:
 
   native-selfhost-linux-x86_64:
     name: Native Self-Host (Linux x86_64)
+    needs: impact
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.runtime == 'true' || needs.impact.outputs.stdlib == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
@@ -133,6 +197,8 @@ jobs:
 
   source-bootstrap-selfhost-linux-x86_64:
     name: Source-Bootstrap Self-Host (Linux x86_64)
+    needs: impact
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.full == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
@@ -177,7 +243,8 @@ jobs:
   native-selfhost-macos-arm64:
     name: Native Self-Host (macOS arm64)
     runs-on: macos-15
-    needs: source-bootstrap-selfhost-linux-x86_64
+    needs: [impact, source-bootstrap-selfhost-linux-x86_64]
+    if: always() && (needs.impact.outputs.compiler == 'true' || needs.impact.outputs.full == 'true') && needs.source-bootstrap-selfhost-linux-x86_64.result == 'success'
     timeout-minutes: 15
     env:
       SOUNIO_SELFHOST_HOST_GATE_DIR: /tmp/sounio-selfhost-macos-arm64
@@ -227,7 +294,8 @@ jobs:
   full-test-suite:
     name: Full Test Suite
     runs-on: ubuntu-24.04
-    needs: native-selfhost-linux-x86_64
+    needs: [impact, native-selfhost-linux-x86_64]
+    if: always() && (needs.impact.outputs.compiler == 'true' || needs.impact.outputs.runtime == 'true' || needs.impact.outputs.stdlib == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true') && needs.native-selfhost-linux-x86_64.result == 'success'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -253,6 +321,8 @@ jobs:
 
   sounio-lint:
     name: Sounio Lint
+    needs: impact
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.stdlib == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.sio == 'true' || needs.impact.outputs.full == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -261,6 +331,8 @@ jobs:
 
   lean-proofs:
     name: Lean Proofs
+    needs: impact
+    if: needs.impact.outputs.lean == 'true' || needs.impact.outputs.full == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -303,6 +375,8 @@ jobs:
 
   website:
     name: Website
+    needs: impact
+    if: needs.impact.outputs.website == 'true' || needs.impact.outputs.full == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -316,3 +390,24 @@ jobs:
         run: npm ci
       - name: Quality check
         run: npm --prefix website run check:quality
+
+  ci-decision:
+    name: CI Decision
+    if: always()
+    needs:
+      - impact
+      - contracts
+      - native-selfhost-linux-x86_64
+      - source-bootstrap-selfhost-linux-x86_64
+      - native-selfhost-macos-arm64
+      - full-test-suite
+      - sounio-lint
+      - lean-proofs
+      - website
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Evaluate selected jobs
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: python3 scripts/ci/evaluate_ci_decision.py

--- a/scripts/ci/classify_ci_impact.sh
+++ b/scripts/ci/classify_ci_impact.sh
@@ -41,36 +41,45 @@ else
 
   for path in "${paths[@]}"; do
     [[ -n "$path" ]] || continue
+    recognized=false
 
     case "$path" in
       .github/workflows/*|scripts/ci/classify_ci_impact.sh|scripts/ci/evaluate_ci_decision.py|scripts/ci/impact_ci_selftest.sh|scripts/dev/check_workflow_script_refs.sh)
         mark full
+        recognized=true
         ;;
     esac
 
     case "$path" in
       *.md|docs/*|AGENTS.md|CLAUDE.md|CLAUDE_HANDOFF.md|FOUNDER_INTENT.md|ONBOARDING.md|README.md)
         mark docs
+        recognized=true
         ;;
     esac
-    case "$path" in website/*) mark website ;; esac
+    case "$path" in website/*) mark website; recognized=true ;; esac
     case "$path" in
       self-hosted/*|bin/*|scripts/lib/*|scripts/ci/build_*|scripts/ci/selfhost_*|scripts/selfhost/*|scripts/run_sio_test_suite.sh)
         mark compiler
+        recognized=true
         ;;
     esac
-    case "$path" in stdlib/runtime/*|self-hosted/native/*) mark runtime ;; esac
-    case "$path" in stdlib/*) mark stdlib ;; esac
-    case "$path" in tests/*|check_sounio.sh) mark tests ;; esac
-    case "$path" in formal/lean4/*) mark lean ;; esac
+    case "$path" in stdlib/runtime/*|self-hosted/native/*) mark runtime; recognized=true ;; esac
+    case "$path" in stdlib/*) mark stdlib; recognized=true ;; esac
+    case "$path" in tests/*|check_sounio.sh) mark tests; recognized=true ;; esac
+    case "$path" in formal/lean4/*) mark lean; recognized=true ;; esac
     case "$path" in
       formal/lean4/*|scripts/ci/sedenion_*|scripts/ci/cd_tower_*|scripts/ci/gresnigt_*|scripts/ci/furey_*|scripts/research/sedenion_*|scripts/research/cd_tower_*)
         mark math
+        recognized=true
         ;;
     esac
-    case "$path" in stdlib/compiler/ontology/*|scripts/ci/*ontology*|docs/ontology/*) mark ontology ;; esac
-    case "$path" in stdlib/clinical/*|tests/*vancomycin*|docs/clinical/*|docs/*pbpk*|scripts/ci/*pbpk*|scripts/ci/*clinical*) mark clinical ;; esac
-    case "$path" in *.sio) mark sio ;; esac
+    case "$path" in stdlib/compiler/ontology/*|scripts/ci/*ontology*|docs/ontology/*) mark ontology; recognized=true ;; esac
+    case "$path" in stdlib/clinical/*|tests/*vancomycin*|docs/clinical/*|docs/*pbpk*|scripts/ci/*pbpk*|scripts/ci/*clinical*) mark clinical; recognized=true ;; esac
+    case "$path" in *.sio) mark sio; recognized=true ;; esac
+
+    # A newly introduced surface must receive the full matrix until this
+    # classifier explicitly learns its dependency boundary.
+    [[ "$recognized" == true ]] || mark full
   done
 
   if [[ "${impact[full]}" == true ]]; then

--- a/scripts/ci/classify_ci_impact.sh
+++ b/scripts/ci/classify_ci_impact.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+EVENT_NAME="${CI_EVENT_NAME:-${GITHUB_EVENT_NAME:-pull_request}}"
+BASE_SHA="${CI_BASE_SHA:-}"
+HEAD_SHA="${CI_HEAD_SHA:-HEAD}"
+OUTPUT_FILE="${GITHUB_OUTPUT:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage: classify_ci_impact.sh [path ...]
+
+With explicit paths, classifies those paths. Without paths, reads the changed
+paths from CI_BASE_SHA..CI_HEAD_SHA. Non-pull-request events select the full CI.
+Writes key=value rows to stdout and, when set, GITHUB_OUTPUT.
+USAGE
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+declare -A impact=()
+keys=(docs website compiler runtime stdlib tests lean math ontology clinical sio full)
+for key in "${keys[@]}"; do impact["$key"]=false; done
+
+mark() { impact["$1"]=true; }
+
+if [[ "$EVENT_NAME" != "pull_request" ]]; then
+  for key in "${keys[@]}"; do impact["$key"]=true; done
+else
+  paths=()
+  if (($#)); then
+    paths=("$@")
+  else
+    [[ -n "$BASE_SHA" ]] || { echo "error: CI_BASE_SHA is required for pull_request classification" >&2; exit 2; }
+    mapfile -t paths < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+  fi
+
+  for path in "${paths[@]}"; do
+    [[ -n "$path" ]] || continue
+
+    case "$path" in
+      .github/workflows/*|scripts/ci/classify_ci_impact.sh|scripts/ci/evaluate_ci_decision.py|scripts/ci/impact_ci_selftest.sh|scripts/dev/check_workflow_script_refs.sh)
+        mark full
+        ;;
+    esac
+
+    case "$path" in
+      *.md|docs/*|AGENTS.md|CLAUDE.md|CLAUDE_HANDOFF.md|FOUNDER_INTENT.md|ONBOARDING.md|README.md)
+        mark docs
+        ;;
+    esac
+    case "$path" in website/*) mark website ;; esac
+    case "$path" in
+      self-hosted/*|bin/*|scripts/lib/*|scripts/ci/build_*|scripts/ci/selfhost_*|scripts/selfhost/*|scripts/run_sio_test_suite.sh)
+        mark compiler
+        ;;
+    esac
+    case "$path" in stdlib/runtime/*|self-hosted/native/*) mark runtime ;; esac
+    case "$path" in stdlib/*) mark stdlib ;; esac
+    case "$path" in tests/*|check_sounio.sh) mark tests ;; esac
+    case "$path" in formal/lean4/*) mark lean ;; esac
+    case "$path" in
+      formal/lean4/*|scripts/ci/sedenion_*|scripts/ci/cd_tower_*|scripts/ci/gresnigt_*|scripts/ci/furey_*|scripts/research/sedenion_*|scripts/research/cd_tower_*)
+        mark math
+        ;;
+    esac
+    case "$path" in stdlib/compiler/ontology/*|scripts/ci/*ontology*|docs/ontology/*) mark ontology ;; esac
+    case "$path" in stdlib/clinical/*|tests/*vancomycin*|docs/clinical/*|docs/*pbpk*|scripts/ci/*pbpk*|scripts/ci/*clinical*) mark clinical ;; esac
+    case "$path" in *.sio) mark sio ;; esac
+  done
+
+  if [[ "${impact[full]}" == true ]]; then
+    for key in "${keys[@]}"; do impact["$key"]=true; done
+  fi
+fi
+
+for key in "${keys[@]}"; do
+  row="$key=${impact[$key]}"
+  echo "$row"
+  [[ -z "$OUTPUT_FILE" ]] || echo "$row" >>"$OUTPUT_FILE"
+done

--- a/scripts/ci/evaluate_ci_decision.py
+++ b/scripts/ci/evaluate_ci_decision.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Fail unless every CI job selected by impact classification succeeded."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def truthy(value: str | None) -> bool:
+    return value == "true"
+
+
+def main() -> int:
+    needs = json.loads(os.environ.get("NEEDS_JSON", "{}"))
+    impact = needs.get("impact", {}).get("outputs", {})
+    failures: list[str] = []
+
+    required = {
+        "contracts": True,
+        "native-selfhost-linux-x86_64": any(
+            truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")
+        ),
+        "source-bootstrap-selfhost-linux-x86_64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
+        "native-selfhost-macos-arm64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
+        "full-test-suite": any(truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")),
+        "sounio-lint": any(truthy(impact.get(key)) for key in ("compiler", "stdlib", "tests", "sio", "full")),
+        "lean-proofs": truthy(impact.get("lean")) or truthy(impact.get("full")),
+        "website": truthy(impact.get("website")) or truthy(impact.get("full")),
+    }
+
+    for job, selected in required.items():
+        result = needs.get(job, {}).get("result", "missing")
+        if selected and result != "success":
+            failures.append(f"selected job {job} ended as {result}")
+        elif not selected and result not in {"success", "skipped"}:
+            failures.append(f"unselected job {job} ended as {result}")
+
+    if failures:
+        for failure in failures:
+            print(f"CI_DECISION_FAIL: {failure}", file=sys.stderr)
+        return 1
+
+    selected_jobs = ",".join(job for job, selected in required.items() if selected)
+    print(f"CI_DECISION_PASS selected={selected_jobs}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -29,6 +29,14 @@ compiler="$($CLASSIFIER self-hosted/compiler/main.sio)"
 expect "$compiler" compiler true
 expect "$compiler" sio true
 
+unknown="$($CLASSIFIER newly-introduced/build.graph)"
+expect "$unknown" full true
+expect "$unknown" compiler true
+expect "$unknown" lean true
+
+root_build="$($CLASSIFIER Makefile)"
+expect "$root_build" full true
+
 workflow="$($CLASSIFIER .github/workflows/ci.yml)"
 for key in docs website compiler runtime stdlib tests lean math ontology clinical sio full; do
   expect "$workflow" "$key" true

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLASSIFIER="$ROOT_DIR/scripts/ci/classify_ci_impact.sh"
+DECISION="$ROOT_DIR/scripts/ci/evaluate_ci_decision.py"
+
+expect() {
+  local output="$1" key="$2" value="$3"
+  grep -Fxq "$key=$value" <<<"$output" || {
+    echo "impact-ci-selftest: expected $key=$value" >&2
+    echo "$output" >&2
+    exit 1
+  }
+}
+
+docs="$($CLASSIFIER docs/internal/concepts/README.md)"
+expect "$docs" docs true
+expect "$docs" compiler false
+expect "$docs" lean false
+
+lean="$($CLASSIFIER formal/lean4/SounioGradedModal.lean)"
+expect "$lean" lean true
+expect "$lean" math true
+expect "$lean" compiler false
+
+compiler="$($CLASSIFIER self-hosted/compiler/main.sio)"
+expect "$compiler" compiler true
+expect "$compiler" sio true
+
+workflow="$($CLASSIFIER .github/workflows/ci.yml)"
+for key in docs website compiler runtime stdlib tests lean math ontology clinical sio full; do
+  expect "$workflow" "$key" true
+done
+
+non_pr="$(CI_EVENT_NAME=push $CLASSIFIER)"
+expect "$non_pr" full true
+expect "$non_pr" compiler true
+
+good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+NEEDS_JSON="$good_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
+
+bad_needs="${good_needs/\"contracts\":{\"result\":\"success\"}/\"contracts\":{\"result\":\"failure\"}}"
+if NEEDS_JSON="$bad_needs" python3 "$DECISION" >/dev/null 2>&1; then
+  echo "impact-ci-selftest: decision accepted failed contracts" >&2
+  exit 1
+fi
+
+stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+if NEEDS_JSON="$stdlib_needs" python3 "$DECISION" >/dev/null 2>&1; then
+  echo "impact-ci-selftest: decision accepted stdlib suite without native compiler/full suite" >&2
+  exit 1
+fi
+
+echo 'IMPACT_CI_SELFTEST_PASS'


### PR DESCRIPTION
## O que muda

- classifica o impacto do diff antes de executar validações pesadas
- preserva os nomes atuais dos jobs para uma migração segura da branch protection
- mantém CI completo em mudanças do próprio workflow, pushes em `main`, merge queue, schedule e execução manual
- adiciona `CI Decision` como decisão agregada e verificável
- cancela execuções obsoletas do mesmo PR/ref

## Política inicial

- documentação: contratos leves, sem self-host, suíte completa, Lean ou website build
- compilador/runtime/stdlib/testes: somente as superfícies afetadas e suas dependências
- Lean, website, ontologia, clínica e math crosschecks: acionados pelas respectivas áreas
- alterações de CI/política: matriz completa

## Prova local

- `bash scripts/ci/impact_ci_selftest.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/ci/check_parallel_blocker_contract.sh`
- `git diff --check`

Todos passaram. `actionlint` não está instalado no ambiente; este PR toca o workflow e, por projeto, será classificado como `full`, validando a sintaxe e todos os jobs no GitHub.

## Migração da proteção

Não remover os required checks atuais antes deste PR ficar verde. Após a prova real, adicionar `CI Decision` como required check; a simplificação dos checks antigos pode ocorrer em uma mudança administrativa separada.