### PR TITLE
feat(epistemic): preserve zero-event provenance

### DIFF
--- a/docs/compiler/KNOWN_LIMITATIONS.md
+++ b/docs/compiler/KNOWN_LIMITATIONS.md
@@ -427,6 +427,46 @@ Phase 5 attempted to "close the butterfly" at the compiler level (commit reverte
 - **Dynamic `.so` linking / GOT–PLT**: The native toolchain emits statically linked executables on the default bring-up path. Relocation metadata records `R_X86_64_PLT32` for ET_REL objects (`self-hosted/native/reloc.sio`), but wiring arbitrary shared-library symbols end-to-end (libc-style `-lfoo`, full GOT/PLT for external calls) remains future work. FFI tests that require `libzstd` stay behind `//@ ignore` until dynamic link and stable stubs land consistently.
 - **`*const u8` in callee position**: Passing `expr as *const u8` can still produce arity/type mismatch diagnostics versus `*mut u8` in some FFI-heavy shapes; stdlib wrappers prefer `*mut u8` until call lowering treats `*const T` and `*mut T` uniformly at the invocation site. See the header comment in `tests/stdlib/compress/test_zstd_e2e.sio`.
 
+## Zero-event native-v2 frontier (open)
+
+The zero-event receipt layer is checkable, its receipt witness now executes on
+default Madaros, and constructor opacity is enforced by both `check` and
+`compile`. Two neighboring native limitations remain:
+
+1. **Minimal `qd128` import fails closed during native emission.**
+   `tests/known_failures/qd128_import_native_v2_probe.sio` now completes
+   imported-module lowering without a segmentation fault, then reports backend
+   `rc=12`. The neighboring `dd64` control executes successfully.
+2. **Minimal sedenion import executes but does not prove its semantic marker.**
+   `tests/known_failures/sedenion_import_native_v2_probe.sio` reaches
+   `Compilation successful!`; the generated executable exits `1`, without a
+   segmentation fault and without `SEDENION_IMPORT_NATIVE_V2 PASS`.
+
+Constructor privacy was closed by running the same visibility preflight used
+by `check` before the canonical native `compile` path. The receipt and erased
+constructors are compile-fail tests with E176. Direct reads of private fields
+remain a separate language-wide visibility limitation and are not treated as
+constructor authority.
+
+The classified compiler handoff, root-cause boundary, and required acceptance
+matrix are recorded in
+`docs/handoff/zero_event_native_compile_privacy_2026-07-11.md`. In particular,
+globally enabling the merged checker's visibility bit is not an accepted fix:
+the native path must preserve legitimate import edges and cover the generic
+specialization branch as well as the ordinary fallback.
+
+Reproduce the classified matrix with:
+
+```bash
+bash scripts/ci/zero_event_native_v2_matrix.sh
+bash scripts/ci/zero_event_gate.sh
+```
+
+Do not promote the known-failure probes to `run-pass` until the default engine
+executes the same markers without `SOUNIO_SOUC_ENGINE=lean_single`. Do not alter
+the semantic oracles while repairing compiler lowering, aggregate return, or
+privacy enforcement.
+
 ## Reporting Issues
 
 If you encounter any new issues, please report them at:

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 938
-- Repo-backed topics: 788
+- Total governed topics: 940
+- Repo-backed topics: 790
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 538
+- Authority count `repo_only`: 540
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 557 topics
+- A2: 559 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -366,6 +366,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.neurodyn-oct-mul-sign-fix-codex-handoff-2026-07-07 | repo_only | docs/handoff/neurodyn_oct_mul_sign_fix_codex_handoff_2026-07-07.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.pending-changes-triage-2026-07-11 | repo_only | docs/handoff/pending_changes_triage_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-v0800-defects | repo_only | docs/handoff/souc_v0800_defects.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.zero-event-native-compile-privacy-2026-07-11 | repo_only | docs/handoff/zero_event_native_compile_privacy_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.bootstrap-seed-policy | historical | docs/implementation/BOOTSTRAP_SEED_POLICY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.codex-claude-parallel-contract | historical | docs/implementation/CODEX_CLAUDE_PARALLEL_CONTRACT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.completed-mega-project | historical | docs/implementation/COMPLETED_MEGA_PROJECT.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -412,6 +413,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.garden.seeds.2026-05-09-above-the-stars | repo_only | docs/internal/garden/seeds/2026-05-09-above-the-stars.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.garden.seeds.2026-05-09-novelty-weather-map | repo_only | docs/internal/garden/seeds/2026-05-09-novelty-weather-map.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.garden.seeds.2026-05-10-epistemic-fermentation | repo_only | docs/internal/garden/seeds/2026-05-10-epistemic-fermentation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.garden.seeds.2026-07-11-the-zero-of-encounter | repo_only | docs/internal/garden/seeds/2026-07-11-the-zero-of-encounter.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.garden.templates.seed | repo_only | docs/internal/garden/templates/seed.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.bootstrap-seed-policy | repo_only | docs/internal/implementation/BOOTSTRAP_SEED_POLICY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.codex-claude-parallel-contract | repo_only | docs/internal/implementation/CODEX_CLAUDE_PARALLEL_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7918,6 +7918,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.zero-event-native-compile-privacy-2026-07-11",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/zero_event_native_compile_privacy_2026-07-11.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.implementation.bootstrap-seed-policy",
       "collection": "repo",
       "repo_doc_path": "docs/implementation/BOOTSTRAP_SEED_POLICY.md",
@@ -8935,6 +8958,29 @@
       "topic_id": "repo.docs.internal.garden.seeds.2026-05-10-epistemic-fermentation",
       "collection": "repo",
       "repo_doc_path": "docs/internal/garden/seeds/2026-05-10-epistemic-fermentation.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.internal.garden.seeds.2026-07-11-the-zero-of-encounter",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/garden/seeds/2026-07-11-the-zero-of-encounter.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/handoff/zero_event_native_compile_privacy_2026-07-11.md
+++ b/docs/handoff/zero_event_native_compile_privacy_2026-07-11.md
@@ -1,0 +1,134 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.zero-event-native-compile-privacy-2026-07-11
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.zero-event-native-compile-privacy-2026-07-11
+-->
+
+# Zero-event native compile privacy handoff
+
+## Blocker record
+
+```text
+Blocker-ID: BLK-20260711-ZERO-PRIVACY
+Status: closed
+Severity: B1
+Class: compiler-semantics
+Owner: fix/zero-event-native-privacy
+Lane: zero-event constructor opacity under default native compile
+Worktree: /tmp/sounio-zero-privacy
+Branch: integrated on neurodyn-docs-registry-batch through ecc5c4018
+Files-Owned: self-hosted/compiler/main.sio, scripts/ci/zero_event_native_compile_privacy_gate.sh
+Files-Read-Only: stdlib/epistemic/zero_event.sio, scripts/ci/zero_event_gate.sh, scripts/ci/zero_event_native_v2_matrix.sh
+Do-Not-Touch: bin/souc, scripts/run_sio_test_suite.sh, zero-event semantic oracle
+Repro: ./bin/souc compile tests/compile-fail/zero_event_direct_receipt_construction.sio -o /tmp/zero-event-forged
+Observed: the pre-fix native compiler accepted the literal; the rebuilt default compiler rejects it with E176
+Expected: check and compile both reject external construction of ZeroReceiptF64 and ErasedZeroF64 with E176
+Acceptance-Gate: ZERO_EVENT_SOURCE_ROOT=/workspace/sounio bash scripts/ci/zero_event_native_compile_privacy_gate.sh
+Evidence-Level: E3
+Evidence: rebuilt /tmp/sounio-zero-privacy/artifacts/madaros-zero-privacy-v3; canonical compile gate PASS on 2026-07-11
+Fallback-Path: lean_single remains an explicit semantic oracle; it is not native-v2 evidence
+Legacy-Kept: yes; do not remove the visibility-disabled merged checker until import-context parity is proven
+LLM-Offload: not-required (compiler visibility semantics, no new math or clinical claim)
+Next-Action: none for constructor opacity; track direct private-field reads separately
+```
+
+## Review-ready implementation
+
+Commits `f998396bc` and `ecc5c4018` extract the already-authoritative visibility path from
+`run_check_mode` into `compiler_visibility_preflight` and calls it before
+`module_frontend_compile_imported_to_file`. The internal merged checker remains
+unchanged and permissive after that boundary, so the patch does not globally
+enable visibility or edit `self-hosted/check/mod.sio`.
+
+The first experiment used `module_frontend_populate_imported_programs` for a
+second preflight and was rejected: it consumed a full CPU for more than 90
+seconds on the first zero-event probe. The committed implementation reuses the
+loader logic from `run_check_mode`; the same negative probe returns E176 in
+approximately 0.07 seconds on the rebuilt compiler.
+
+The isolated acceptance gate uses the canonical `compile` command and proved:
+
+- forged `ZeroReceiptF64` and `ErasedZeroF64`: rejected with E176;
+- private imported struct/function/enum: rejected with E176/E175/E177;
+- public imported struct: native emission succeeds;
+- `tests/multimodule/wp_a3/w2_main.sio`: generic native emission succeeds;
+- positive zero-event stdlib witness: native emission succeeds;
+- EISA zero-flags witness: visibility verdict is zero, then it reaches the
+  separately classified native backend `rc=12` frontier.
+
+## Root cause boundary
+
+`run_check_mode` in `self-hosted/compiler/main.sio` calls
+`check_modules_verdict_boot4_with_visibility(..., true)`. The imported native
+compile paths in `self-hosted/compiler/module_frontend.sio` call
+`check_modules_verdict_boot4(...)`, whose wrapper disables visibility.
+
+This is deliberate historical behavior, not a missing boolean by accident.
+The merged checker knows each definition's module, but it does not retain enough
+per-use import context to distinguish:
+
+1. a public API use from another module;
+2. a compiler-internal dependency that was legitimately admitted by the module
+   loader; and
+3. an external construction or access to a private type.
+
+Changing every native call to
+`check_modules_verdict_boot4_with_visibility(..., true)` is therefore only a
+diagnostic experiment. Existing comments in `self-hosted/check/mod.sio` record
+false E175/E176/E177 failures for legitimate internal dependencies when that
+global switch is enabled.
+
+## Required semantic model
+
+Visibility must be checked at the use edge, with both pieces of evidence:
+
+- the defining module and declaration visibility; and
+- the importing module's resolved `use` context/export decision.
+
+The native frontend must reject a private struct literal written by a consumer
+module even if the loader has discovered the defining module transitively.
+Loader reachability is not construction authority. Conversely, a public item
+must remain usable, and compiler-internal dependency edges already admitted by
+the current frontend must not acquire spurious visibility errors.
+
+The generic-specialization branch needs the same policy. Its merged item list
+currently calls `check_items_verdict_boot4`, so fixing only the ordinary
+`check_modules_verdict_boot4` fallback leaves a bypass whenever
+`spec_last_instantiated()` is true.
+
+## Acceptance matrix
+
+The implementing lane should create
+`scripts/ci/zero_event_native_compile_privacy_gate.sh` and prove all rows using
+a freshly rebuilt Madaros artifact, never the stale workspace binary.
+
+| Case | Command surface | Required result |
+|---|---|---|
+| Forged `ZeroReceiptF64` | native `compile` | reject with E176 |
+| Forged `ErasedZeroF64` | native `compile` | reject with E176 |
+| Private field read | native `compile` | residual language-wide limitation; tracked separately from constructor opacity |
+| Public imported struct | `tests/multimodule/visibility_struct_pub_main.sio` | compile succeeds |
+| Private imported struct | `tests/multimodule/visibility_struct_private_main.sio` | reject with E176 |
+| Private imported function | `tests/multimodule/visibility_fn_private_main.sio` | reject with E175 |
+| Private imported enum | `tests/multimodule/visibility_enum_private_main.sio` | reject with E177 |
+| Generic imported public API | existing multimodule generic run-pass set | check and compile remain green |
+| EISA imported program | `tests/stdlib/eisa/test_eisa_evm_v2.sio` | check and explicit native gate retain their prior classification |
+
+After the rebuilt compiler passes the focused matrix, run the Madaros full gate
+through Compiler Foundry/Slurm. Do not run full stress in `/workspace/sounio`.
+
+## Closure rule
+
+Move the two constructor probes from `tests/known_failures/` to
+`tests/compile-fail/` only after the canonical compile-based harness rejects
+them using the rebuilt default compiler. Then update `zero_event_gate.sh` to use
+the compile-fail harness rather than check-only opacity evidence.
+
+The constructor-opacity blocker closes at E3 when the default native compile
+path enforces the same constructor boundary as `check` without breaking the
+positive import and generic rows. That condition is now met. Direct private
+field reads remain a separate compiler-semantics limitation; they do not permit
+construction of either receipt type and are outside this blocker.

--- a/docs/internal/garden/seeds/2026-07-11-the-zero-of-encounter.md
+++ b/docs/internal/garden/seeds/2026-07-11-the-zero-of-encounter.md
@@ -1,0 +1,159 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.garden.seeds.2026-07-11-the-zero-of-encounter
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.garden.seeds.2026-07-11-the-zero-of-encounter
+-->
+
+# The Zero of Encounter
+
+> **Status**: Garden seed with an executable witness | **Last validated**: 2026-07-11 | **Source**: live conversation in New Haven
+
+## Butterfly
+
+> muitas vezes encontros sao zeros
+
+> o mal encontro espinosano e o zero-divisor do sedenion
+
+Two presences can produce an absence without either presence being empty.
+
+## Core Idea
+
+Zero is often stored as if it described an operand: nothing was present, no
+effect existed, or no event occurred. This butterfly asks whether some zeros
+belong instead to the encounter.
+
+The exact algebraic image is a sedenion zero divisor. There can be nonzero
+elements `a` and `b` for which:
+
+```text
+a != 0
+b != 0
+a * b == 0
+```
+
+The factors remain nonzero. The zero is produced by their particular
+composition.
+
+The Spinozan image is the bad encounter: neither participant must be bad in
+essence, yet their relations may compose in a way that reduces or decomposes a
+capacity to act. The analogy is structural, not an assertion that Spinoza's
+metaphysics is literally sedenion algebra.
+
+The scientific pressure is broader: ordinary computation collapses distinct
+histories into the same surface value.
+
+```text
+Zero::Absent
+Zero::Cancelled
+Zero::Annihilated
+Zero::BelowResolution
+Zero::Rounded
+Zero::Gated
+Zero::Unknown
+```
+
+The same pressure applies at the other boundary. `Infinity` may mean unbounded
+growth, a singularity, overflow, non-normalizability, or an unresolved model.
+Zero and infinity may therefore be events with provenance rather than naked
+values.
+
+The clinical butterfly is a question, not a finding: when an observed effect is
+zero, was the effect absent, cancelled by another process, annihilated in an
+interaction, hidden below resolution, or lost numerically? A patient encounter
+may inspire that question, but no patient story is evidence and no identifying
+clinical detail belongs in this seed.
+
+## Connections
+
+- [`docs/internal/garden/README.md`](../README.md) defines the evidence boundary
+  for Garden seeds.
+- [`2026-05-10-epistemic-fermentation.md`](2026-05-10-epistemic-fermentation.md)
+  establishes the neighboring idea that equal surface values can remain
+  different knowledge because their paths differ.
+- [`stdlib/algebra/sedenion.sio`](../../../../stdlib/algebra/sedenion.sio)
+  provides the current sedenion algebra and canonical zero-divisor helpers.
+- [`examples/conversational_ossm/o_ssm_conflict.sio`](../../../../examples/conversational_ossm/o_ssm_conflict.sio)
+  already uses sedenion zero-divisor proximity as conflict telemetry and freeze
+  pressure in an experimental conversational controller.
+- [`stdlib/eisa/core_v2.sio`](../../../../stdlib/eisa/core_v2.sio) separates the
+  hardware-compatible value lane, the numerical correction trail, and physical
+  input uncertainty as `val`, `err`, and `u`.
+- [`stdlib/epistemic/path.sio`](../../../../stdlib/epistemic/path.sio) is the
+  nearest executable precedent for keeping computational history distinct when
+  surface values agree.
+- [`stdlib/epistemic/zero_event.sio`](../../../../stdlib/epistemic/zero_event.sio)
+  now provides private receipt constructors, evidence flags, accessors, and an
+  explicit typed discharge to an ordinary `f64` surface.
+- [`tests/known_failures/zero_provenance_native_v2_probe.sio`](../../../../tests/known_failures/zero_provenance_native_v2_probe.sio)
+  constructs five surface-zero paths and checks that their provenance remains
+  distinguishable.
+- [`scripts/ci/zero_provenance_witness_gate.sh`](../../../../scripts/ci/zero_provenance_witness_gate.sh)
+  checks the witness with Madaros and executes it explicitly through
+  `lean_single`, without hiding the engine split.
+- [`scripts/ci/zero_event_gate.sh`](../../../../scripts/ci/zero_event_gate.sh)
+  verifies the stdlib receipts, check and compile constructor opacity, explicit
+  discharge boundary, and derived EISA flags.
+- [`scripts/ci/zero_event_native_v2_matrix.sh`](../../../../scripts/ci/zero_event_native_v2_matrix.sh)
+  keeps the native frontier classified: `dd64` and the zero-event receipt run,
+  `qd128` fails closed during native emission, and sedenion exits nonzero
+  without crashing or proving its semantic marker.
+- [`FOUNDER_INTENT.md`](../../../../FOUNDER_INTENT.md) protects the underlying
+  requirement that a zero result must not silently erase its path.
+
+## Evidence State
+
+| Layer | Status |
+| --- | --- |
+| `Garden` | Captured: "many encounters are zeros" and "the Spinozan bad encounter is the sedenion zero divisor." |
+| `Hypothesis` | A typed zero-provenance taxonomy may distinguish absence from relational, numerical, metrological, and policy-produced zeros. Sedenion zero-divisor geometry may provide a useful model for some nonzero-factor interaction failures. |
+| `Executable` | `epistemic::zero_event` implements receipt evidence, accessors, typed discharge, and E176-gated opaque constructors. Its aggregate-return witness executes on default native-v2. EISA exposes derived `ZERO_OBSERVED` and `CORRECTION_NONZERO` flags without changing `val`/`err`/`u`. Remaining native frontiers are qd128/EISA backend emission and the sedenion semantic marker. |
+| `Claim-ready` | No. No biological, psychopharmacological, metaphysical, or novelty claim is established by this seed. |
+
+## What This Is Not
+
+- Not a claim that human encounters are literally sedenion multiplication.
+- Not evidence that psychopharmacology has an octonionic or sedenionic physical
+  basis.
+- Not a clinical interpretation rule for a zero treatment effect.
+- Not permission to infer mechanism from an observed null result.
+- Not proof that every numerical zero needs a tagged runtime representation.
+- Not an implemented Sounio language feature or EISA instruction family.
+- Not a statement that zero and infinity are mathematically undefined; the
+  seed concerns loss of provenance when different limiting or computational
+  events share a surface representation.
+
+## Executable Bridge
+
+The first inert, non-clinical Sounio witness now contains five computations
+whose surface value is zero but whose construction paths differ:
+
+1. literal absence;
+2. additive cancellation;
+3. exact sedenion zero-divisor annihilation;
+4. a nonzero value below a declared measurement resolution;
+5. a nonzero correction trail whose `f64` value lane rounds to zero.
+
+The gate proves only:
+
+```text
+same surface value != same zero provenance
+```
+
+It does not add compiler syntax or promote a general `LimitEvent` design.
+
+## Next Executable Bridge
+
+Repair or receive an ownership transfer for the native-v2 compiler surfaces
+identified by the matrix. Keep the passing `lean_single` witnesses unchanged as
+semantic oracles. Native-v2 parity requires all of the following without an
+engine fallback:
+
+1. minimal `qd128` import emits and executes;
+2. minimal sedenion zero-divisor code prints its pass marker;
+3. the combined provenance witness executes without the `lean_single` oracle.
+
+`InfinityEvent` remains a separate Garden butterfly and is not a requirement or
+implicit extension of this zero-event implementation.

--- a/scripts/ci/zero_event_gate.sh
+++ b/scripts/ci/zero_event_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/zero-event.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+MODULE="$ROOT_DIR/stdlib/epistemic/zero_event.sio"
+POSITIVE="$ROOT_DIR/tests/known_failures/zero_event_stdlib_native_v2_probe.sio"
+EISA_FLAGS="$ROOT_DIR/tests/known_failures/eisa_zero_flags_native_v2_probe.sio"
+
+fail() {
+  echo "[zero-event] FAIL: $*" >&2
+  exit 1
+}
+
+expect_check_fail() {
+  local source="$1"
+  local pattern="$2"
+  local name="$3"
+  local log="$TMP_DIR/$name.log"
+
+  if "$ROOT_DIR/bin/souc" check "$source" >"$log" 2>&1; then
+    cat "$log" >&2
+    fail "$name unexpectedly passed Madaros check"
+  fi
+  grep -Fq "$pattern" "$log" || {
+    cat "$log" >&2
+    fail "$name failed without expected marker: $pattern"
+  }
+}
+
+"$ROOT_DIR/bin/souc" check "$MODULE" >"$TMP_DIR/module.log" 2>&1 || {
+  cat "$TMP_DIR/module.log" >&2
+  fail "stdlib module check failed"
+}
+
+"$ROOT_DIR/bin/souc" check "$POSITIVE" >"$TMP_DIR/positive-check.log" 2>&1 || {
+  cat "$TMP_DIR/positive-check.log" >&2
+  fail "positive witness check failed"
+}
+
+output="$(SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" run "$POSITIVE" 2>&1)" || {
+  printf '%s\n' "$output" >&2
+  fail "positive witness lean_single execution failed"
+}
+printf '%s\n' "$output" | grep -Fq 'ZERO_EVENT_STDLIB PASS' || {
+  printf '%s\n' "$output" >&2
+  fail "positive witness missing pass marker"
+}
+
+"$ROOT_DIR/bin/souc" check "$EISA_FLAGS" >"$TMP_DIR/eisa-check.log" 2>&1 || {
+  cat "$TMP_DIR/eisa-check.log" >&2
+  fail "EISA zero-flags check failed"
+}
+
+eisa_output="$(SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" run "$EISA_FLAGS" 2>&1)" || {
+  printf '%s\n' "$eisa_output" >&2
+  fail "EISA zero-flags lean_single execution failed"
+}
+printf '%s\n' "$eisa_output" | grep -Fq 'EISA_ZERO_FLAGS PASS' || {
+  printf '%s\n' "$eisa_output" >&2
+  fail "EISA zero-flags witness missing pass marker"
+}
+
+expect_check_fail \
+  "$ROOT_DIR/tests/compile-fail/zero_event_direct_receipt_construction.sio" \
+  'error[E176' \
+  'receipt-constructor-opacity'
+
+expect_check_fail \
+  "$ROOT_DIR/tests/compile-fail/zero_event_direct_erased_construction.sio" \
+  'error[E176' \
+  'erased-constructor-opacity'
+
+expect_check_fail \
+  "$ROOT_DIR/tests/compile-fail/zero_event_erasure_requires_discharge.sio" \
+  'expected ErasedZeroF64' \
+  'explicit-discharge-type-boundary'
+
+echo '[zero-event] PASS: receipts, evidence, explicit discharge, and derived EISA flags are verified'

--- a/scripts/ci/zero_event_native_compile_privacy_gate.sh
+++ b/scripts/ci/zero_event_native_compile_privacy_gate.sh
@@ -48,10 +48,10 @@ compile_accepts() {
 [[ -x "$MADAROS_BIN" ]] || fail "rebuilt Madaros not executable: $MADAROS_BIN"
 
 compile_rejects receipt \
-  tests/known_failures/zero_event_direct_receipt_construction_native_compile_probe.sio \
+  tests/compile-fail/zero_event_direct_receipt_construction.sio \
   'error[E176'
 compile_rejects erased \
-  tests/known_failures/zero_event_direct_erased_construction_native_compile_probe.sio \
+  tests/compile-fail/zero_event_direct_erased_construction.sio \
   'error[E176'
 compile_rejects private-struct \
   tests/multimodule/visibility_struct_private_main.sio \

--- a/scripts/ci/zero_event_native_compile_privacy_gate.sh
+++ b/scripts/ci/zero_event_native_compile_privacy_gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${ZERO_EVENT_SOURCE_ROOT:-$ROOT_DIR}"
+MADAROS_BIN="${MADAROS_BIN:-$ROOT_DIR/artifacts/self-hosted/madaros}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/zero-native-privacy.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "[zero-native-privacy] FAIL: $*" >&2
+  exit 1
+}
+
+compile_rejects() {
+  local name="$1"
+  local source="$2"
+  local marker="$3"
+  local log="$TMP_DIR/$name.log"
+
+  if (cd "$SOURCE_ROOT" && timeout 30 "$MADAROS_BIN" build "$source" -o "$TMP_DIR/$name") >"$log" 2>&1; then
+    cat "$log" >&2
+    fail "$name unexpectedly compiled"
+  fi
+  grep -Fq "$marker" "$log" || {
+    cat "$log" >&2
+    fail "$name did not emit $marker"
+  }
+}
+
+compile_accepts() {
+  local name="$1"
+  local source="$2"
+  local log="$TMP_DIR/$name.log"
+
+  (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" build "$source" -o "$TMP_DIR/$name") >"$log" 2>&1 || {
+    cat "$log" >&2
+    fail "$name did not compile"
+  }
+  grep -Fq "native_v2_compile: emitted path=$TMP_DIR/$name" "$log" || {
+    cat "$log" >&2
+    fail "$name compiled without the native emission marker"
+  }
+}
+
+[[ -x "$MADAROS_BIN" ]] || fail "rebuilt Madaros not executable: $MADAROS_BIN"
+
+compile_rejects receipt \
+  tests/known_failures/zero_event_direct_receipt_construction_native_compile_probe.sio \
+  'error[E176'
+compile_rejects erased \
+  tests/known_failures/zero_event_direct_erased_construction_native_compile_probe.sio \
+  'error[E176'
+compile_rejects private-struct \
+  tests/multimodule/visibility_struct_private_main.sio \
+  'error[E176'
+compile_rejects private-fn \
+  tests/multimodule/visibility_fn_private_main.sio \
+  'error[E175'
+compile_rejects private-enum \
+  tests/multimodule/visibility_enum_private_main.sio \
+  'error[E177'
+
+compile_accepts public-struct tests/multimodule/visibility_struct_pub_main.sio
+compile_accepts generic-public tests/multimodule/wp_a3/w2_main.sio
+compile_accepts zero-event-positive tests/known_failures/zero_event_stdlib_native_v2_probe.sio
+
+eisa_log="$TMP_DIR/eisa.log"
+if (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" build \
+    tests/known_failures/eisa_zero_flags_native_v2_probe.sio \
+    -o "$TMP_DIR/eisa") >"$eisa_log" 2>&1; then
+  :
+else
+  grep -Fq 'run_check_mode: verdict=0' "$eisa_log" || {
+    cat "$eisa_log" >&2
+    fail "EISA did not pass the visibility preflight"
+  }
+  grep -Fq 'Failed to write native binary' "$eisa_log" || {
+    cat "$eisa_log" >&2
+    fail "EISA failure moved away from its classified backend frontier"
+  }
+fi
+
+echo '[zero-native-privacy] PASS: native compile rejects private constructors and preserves public, generic, zero-event, and EISA frontends'

--- a/scripts/ci/zero_event_native_compile_privacy_gate.sh
+++ b/scripts/ci/zero_event_native_compile_privacy_gate.sh
@@ -19,7 +19,7 @@ compile_rejects() {
   local marker="$3"
   local log="$TMP_DIR/$name.log"
 
-  if (cd "$SOURCE_ROOT" && timeout 30 "$MADAROS_BIN" build "$source" -o "$TMP_DIR/$name") >"$log" 2>&1; then
+  if (cd "$SOURCE_ROOT" && timeout 30 "$MADAROS_BIN" compile "$source" -o "$TMP_DIR/$name") >"$log" 2>&1; then
     cat "$log" >&2
     fail "$name unexpectedly compiled"
   fi
@@ -34,14 +34,15 @@ compile_accepts() {
   local source="$2"
   local log="$TMP_DIR/$name.log"
 
-  (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" build "$source" -o "$TMP_DIR/$name") >"$log" 2>&1 || {
+  (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" compile "$source" -o "$TMP_DIR/$name") >"$log" 2>&1 || {
     cat "$log" >&2
     fail "$name did not compile"
   }
-  grep -Fq "native_v2_compile: emitted path=$TMP_DIR/$name" "$log" || {
+  grep -Fq 'Compilation successful!' "$log" || {
     cat "$log" >&2
     fail "$name compiled without the native emission marker"
   }
+  [[ -s "$TMP_DIR/$name" ]] || fail "$name reported success without an output artifact"
 }
 
 [[ -x "$MADAROS_BIN" ]] || fail "rebuilt Madaros not executable: $MADAROS_BIN"
@@ -67,7 +68,7 @@ compile_accepts generic-public tests/multimodule/wp_a3/w2_main.sio
 compile_accepts zero-event-positive tests/known_failures/zero_event_stdlib_native_v2_probe.sio
 
 eisa_log="$TMP_DIR/eisa.log"
-if (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" build \
+if (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" compile \
     tests/known_failures/eisa_zero_flags_native_v2_probe.sio \
     -o "$TMP_DIR/eisa") >"$eisa_log" 2>&1; then
   :

--- a/scripts/ci/zero_event_native_v2_matrix.sh
+++ b/scripts/ci/zero_event_native_v2_matrix.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/zero-native-matrix.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "[zero-native-matrix] FAIL: $*" >&2
+  exit 1
+}
+
+run_capture() {
+  local name="$1"
+  local source="$2"
+  set +e
+  "$ROOT_DIR/bin/souc" run "$ROOT_DIR/$source" >"$TMP_DIR/$name.log" 2>&1
+  local rc=$?
+  set -e
+  printf '%s' "$rc" >"$TMP_DIR/$name.rc"
+}
+
+require_rc() {
+  local name="$1"
+  local expected="$2"
+  local actual
+  actual="$(cat "$TMP_DIR/$name.rc")"
+  [[ "$actual" == "$expected" ]] || {
+    cat "$TMP_DIR/$name.log" >&2
+    fail "$name expected rc=$expected, got rc=$actual"
+  }
+}
+
+require_marker() {
+  local name="$1"
+  local marker="$2"
+  grep -Fq "$marker" "$TMP_DIR/$name.log" || {
+    cat "$TMP_DIR/$name.log" >&2
+    fail "$name missing marker: $marker"
+  }
+}
+
+reject_marker() {
+  local name="$1"
+  local marker="$2"
+  if grep -Fq "$marker" "$TMP_DIR/$name.log"; then
+    cat "$TMP_DIR/$name.log" >&2
+    fail "$name unexpectedly contained marker: $marker"
+  fi
+}
+
+run_capture dd64 tests/run-pass/dd64_import_native_v2_smoke.sio
+require_rc dd64 0
+require_marker dd64 'DD64_IMPORT_NATIVE_V2 PASS'
+
+run_capture qd128 tests/known_failures/qd128_import_native_v2_probe.sio
+require_rc qd128 1
+require_marker qd128 'lower_array: dep_lower_done 2'
+require_marker qd128 'Failed to write native binary'
+reject_marker qd128 'Segmentation fault'
+
+run_capture sedenion tests/known_failures/sedenion_import_native_v2_probe.sio
+require_rc sedenion 1
+require_marker sedenion 'Compilation successful!'
+reject_marker sedenion 'Segmentation fault'
+reject_marker sedenion 'SEDENION_IMPORT_NATIVE_V2 PASS'
+
+run_capture combined tests/known_failures/zero_provenance_native_v2_probe.sio
+require_rc combined 1
+require_marker combined 'lower_array: final_fn_count'
+require_marker combined 'Failed to write native binary'
+reject_marker combined 'Segmentation fault'
+
+run_capture receipt tests/known_failures/zero_event_stdlib_native_v2_probe.sio
+require_rc receipt 0
+require_marker receipt 'Compilation successful!'
+require_marker receipt 'ZERO_EVENT_STDLIB PASS'
+reject_marker receipt 'Segmentation fault'
+
+echo '[zero-native-matrix] PASS: dd64 and zero-event run; qd128/combined fail closed in backend; sedenion exits nonzero without crashing'

--- a/scripts/ci/zero_provenance_witness_gate.sh
+++ b/scripts/ci/zero_provenance_witness_gate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="$ROOT_DIR/tests/known_failures/zero_provenance_native_v2_probe.sio"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/zero-provenance.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "[zero-provenance] FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$SOURCE" ]] || fail "missing witness: $SOURCE"
+
+"$ROOT_DIR/bin/souc" check "$SOURCE" >"$TMP_DIR/check.log" 2>&1 || {
+  cat "$TMP_DIR/check.log" >&2
+  fail "Madaros check failed"
+}
+
+output="$(SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" run "$SOURCE" 2>&1)" || {
+  printf '%s\n' "$output" >&2
+  fail "lean_single execution failed"
+}
+
+printf '%s\n' "$output" | grep -Fq 'ZERO_PROVENANCE PASS' || {
+  printf '%s\n' "$output" >&2
+  fail "missing pass marker"
+}
+
+echo '[zero-provenance] PASS: five surface-zero paths remain distinguishable'

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -4926,6 +4926,16 @@ fn compile(opts: CompilerOptions) -> CompileResult with IO, Mut, Panic, Div, All
         }
     }
 
+    if !compiler_visibility_preflight(opts.input_file) {
+        var visibility_errors = compile_errors_new()
+        visibility_errors = compile_errors_push(visibility_errors, "error: visibility preflight failed")
+        return CompileResult {
+            success: false,
+            errors: visibility_errors,
+            output: "",
+        }
+    }
+
     if opts.emit_manifest {
         return compile_emit_manifest_json_from_source(opts.input_file)
     }

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -1876,30 +1876,17 @@ fn run_emit_lean_obligations(args: ArgList, flag_index: i64) with IO, Mut, Panic
     }
 }
 
-fn run_check_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Alloc {
-    let source_path = compiler_mode_source_arg(args, flag_index, "--check")
-    if !compiler_preflight_source_input(source_path) {
-        panic("check failed")
-    }
-
+fn compiler_visibility_preflight(source_path: string) -> bool with IO, Mut, Panic, Div, Alloc {
     if !module_frontend_file_maybe_has_use(source_path) {
-        // Single-module real typecheck.
         var main_prog = load_module_file(source_path)
         if parser_last_error_count() > 0 {
-            panic("check failed")
+            return false
         }
         main_prog.items = specialize_generics(main_prog.items)
         let verdict = module_frontend_check_items_with_source_context(main_prog.items, source_path)
-        if verdict == 0 {
-            println(compiler_check_ok_message())
-            return
-        }
-        panic("check failed")
+        return verdict == 0
     }
 
-    // Multi-module: load transitive deps, resolve imports against exports, then
-    // typecheck all modules together so cross-module visibility (E175-E177) is
-    // enforced against the real defining_module of each item.
     var programs: [Program; 256] = [Program { module_path: empty_path(), items: None }; 256]
     var paths: [string; 256] = [""; 256]
     var loaded: i64 = 0
@@ -1943,7 +1930,15 @@ fn run_check_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Allo
     print("run_check_mode: verdict=")
     print_int(verdict)
     print("\n")
-    if verdict == 0 {
+    verdict == 0
+}
+
+fn run_check_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Alloc {
+    let source_path = compiler_mode_source_arg(args, flag_index, "--check")
+    if !compiler_preflight_source_input(source_path) {
+        panic("check failed")
+    }
+    if compiler_visibility_preflight(source_path) {
         println(compiler_check_ok_message())
         return
     }
@@ -2943,6 +2938,9 @@ fn run_native_v2_compile_mode(args: ArgList, flag_index: i64) with IO, Mut, Pani
     let out_path = compiler_mode_output_path(args, out_positional)
     if !compiler_preflight_source_input(source_path) {
         panic("native-v2-compile failed: source not readable")
+    }
+    if !compiler_visibility_preflight(source_path) {
+        panic("native-v2-compile failed: visibility preflight")
     }
     // The boxed compile-to-file route is SRET-safe for both imported and
     // single-module programs. Returning MultiModuleIrResult by value embeds a

--- a/stdlib/eisa/core_v2.sio
+++ b/stdlib/eisa/core_v2.sio
@@ -71,6 +71,32 @@ pub fn ereg2_true(x: EReg2) -> Qd128 with Mut, Panic {
     qd_add(qd_from_f64(x.val), x.err)
 }
 
+// Minimal zero-event flags derived from the existing lanes. These do not
+// change val/err/u storage and do not infer a physical cause.
+pub fn eisa_zero_flag_observed() -> i64 { 1 }
+pub fn eisa_zero_flag_correction_nonzero() -> i64 { 2 }
+
+pub fn core_v2_zero_flags_raw(
+    val: f64,
+    err0: f64,
+    err1: f64,
+    err2: f64,
+    err3: f64
+) -> i64 {
+    var flags = 0
+    if val == 0.0 {
+        flags = flags + eisa_zero_flag_observed()
+    }
+    if err0 != 0.0 || err1 != 0.0 || err2 != 0.0 || err3 != 0.0 {
+        flags = flags + eisa_zero_flag_correction_nonzero()
+    }
+    flags
+}
+
+pub fn ereg2_zero_flags(x: EReg2) -> i64 {
+    core_v2_zero_flags_raw(x.val, x.err.x0, x.err.x1, x.err.x2, x.err.x3)
+}
+
 pub fn eadd2(x: EReg2, y: EReg2) -> EReg2 with Mut, Div, Panic {
     let v = x.val + y.val
     let t = qd_add(ereg2_true(x), ereg2_true(y))

--- a/stdlib/eisa/evm.sio
+++ b/stdlib/eisa/evm.sio
@@ -920,6 +920,18 @@ pub fn evm_reg_u(m: &EvmMachine, r: i64) -> f64 with Panic {
     m.reg_u[r as usize]
 }
 
+/// Derived zero-event flags for an EVM register. This is a receipt view over
+/// the existing val/err lanes; it does not alter machine state or infer cause.
+pub fn evm_reg_zero_flags(m: &EvmMachine, r: i64) -> i64 with Panic {
+    core_v2_zero_flags_raw(
+        m.reg_val[r as usize],
+        m.reg_ehi[r as usize],
+        m.reg_elo[r as usize],
+        m.reg_e2[r as usize],
+        m.reg_e3[r as usize],
+    )
+}
+
 pub fn evm_reg_poison(m: &EvmMachine, r: i64) -> i64 with Panic {
     m.reg_poison[r as usize]
 }

--- a/stdlib/epistemic/SEMANTICS.md
+++ b/stdlib/epistemic/SEMANTICS.md
@@ -301,6 +301,46 @@ let x: f64 = k.unwrap("used in non-critical calculation")
 
 ---
 
+## Zero-Event Receipts
+
+`epistemic::zero_event` distinguishes a surface `f64` value of zero from the
+evidence retained about how that surface was produced.
+
+Current evidence flags are deliberately computational:
+
+| Flag | Meaning |
+| --- | --- |
+| `absent` | A literal zero receipt with no nonzero operands asserted. |
+| `cancelled` | Two nonzero scalar operands sum exactly to zero. |
+| `annihilated` | Two positive operand norms accompany a zero product norm. |
+| `below_resolution` | A nonzero latent magnitude is below a positive declared resolution. |
+| `rounded` | The surface is zero while a nonzero numerical correction remains. |
+| `gated` | A nonzero original value was suppressed by a tagged policy gate. |
+| `unknown` | Zero is observed without a stronger path classification. |
+
+These flags are evidence, not causal conclusions. They do not imply a clinical,
+physical, or metaphysical mechanism.
+
+The concrete no-silent-unwrap surface is type-directed:
+
+```text
+ZeroReceiptF64
+    -- ze_discharge_f64(reason_tag) --> ErasedZeroF64
+    -- ze_erased_value_f64()        --> f64
+```
+
+`ZeroReceiptF64` and `ErasedZeroF64` have module-private constructors. Current
+Madaros `check` and native `compile` both reject external struct literals with
+E176; the canonical compile-fail harness gates both receipt types. The explicit discharge type
+boundary is enforced by both `check` and the compile-fail harness.
+
+EISA v2 preserves its existing `val`, `err`, and `u` lanes. Minimal
+`ZERO_OBSERVED` and `CORRECTION_NONZERO` flags are derived from register state;
+they are not stored as a competing source of truth and do not infer why the
+zero occurred.
+
+---
+
 ## Summary
 
 1. **Uncertainty ≠ Confidence**: They're orthogonal. Don't conflate them.

--- a/stdlib/epistemic/zero_event.sio
+++ b/stdlib/epistemic/zero_event.sio
@@ -1,0 +1,199 @@
+// stdlib/epistemic/zero_event.sio
+//
+// Path-bearing receipts for computations whose surface f64 value is zero.
+//
+// This module separates:
+//   - the observed surface value;
+//   - evidence retained from the computation path;
+//   - explicit discharge to an ordinary f64 surface.
+//
+// Evidence flags are not causal conclusions. In particular, algebraic
+// annihilation is an exact computational category here, not a clinical or
+// metaphysical interpretation.
+
+struct ZeroReceiptF64 {
+    value_f64: f64,
+    evidence_flags: i64,
+    residual_f64: f64,
+    resolution_f64: f64,
+    left_evidence_f64: f64,
+    right_evidence_f64: f64,
+    left_nonzero: bool,
+    right_nonzero: bool,
+    witness_tag: i64,
+    detail_tag: i64,
+}
+
+struct ErasedZeroF64 {
+    value_f64: f64,
+    source_evidence_flags: i64,
+    discharge_reason_tag: i64,
+    discharge_present: bool,
+}
+
+fn ze_abs_f64(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn ze_make(
+    evidence_flags: i64,
+    residual_f64: f64,
+    resolution_f64: f64,
+    left_evidence_f64: f64,
+    right_evidence_f64: f64,
+    left_nonzero: bool,
+    right_nonzero: bool,
+    witness_tag: i64,
+    detail_tag: i64
+) -> ZeroReceiptF64 with Panic {
+    assert(evidence_flags != 0)
+    assert(witness_tag != 0)
+    ZeroReceiptF64 {
+        value_f64: 0.0,
+        evidence_flags: evidence_flags,
+        residual_f64: residual_f64,
+        resolution_f64: resolution_f64,
+        left_evidence_f64: left_evidence_f64,
+        right_evidence_f64: right_evidence_f64,
+        left_nonzero: left_nonzero,
+        right_nonzero: right_nonzero,
+        witness_tag: witness_tag,
+        detail_tag: detail_tag,
+    }
+}
+
+pub fn ze_flag_absent() -> i64 { 1 }
+pub fn ze_flag_cancelled() -> i64 { 2 }
+pub fn ze_flag_annihilated() -> i64 { 4 }
+pub fn ze_flag_below_resolution() -> i64 { 8 }
+pub fn ze_flag_rounded() -> i64 { 16 }
+pub fn ze_flag_gated() -> i64 { 32 }
+pub fn ze_flag_unknown() -> i64 { 64 }
+
+fn ze_tag_absent() -> i64 { 101 }
+fn ze_tag_cancelled() -> i64 { 202 }
+fn ze_tag_annihilated() -> i64 { 303 }
+fn ze_tag_below_resolution() -> i64 { 404 }
+fn ze_tag_rounded() -> i64 { 505 }
+fn ze_tag_gated() -> i64 { 606 }
+fn ze_tag_unknown() -> i64 { 707 }
+
+pub fn ze_invalid_discharge_reason() -> i64 { 0 }
+pub fn ze_discharge_reason_display() -> i64 { 8101 }
+pub fn ze_discharge_reason_export() -> i64 { 8102 }
+
+pub fn ze_absent_f64() -> ZeroReceiptF64 with Panic {
+    ze_make(ze_flag_absent(), 0.0, 0.0, 0.0, 0.0, false, false, ze_tag_absent(), 0)
+}
+
+pub fn ze_cancelled_f64(left: f64, right: f64) -> ZeroReceiptF64 with Panic {
+    assert(left != 0.0)
+    assert(right != 0.0)
+    assert(left + right == 0.0)
+    ze_make(ze_flag_cancelled(), 0.0, 0.0, left, right, true, true, ze_tag_cancelled(), 0)
+}
+
+pub fn ze_annihilated_norms_f64(
+    left_norm_sq: f64,
+    right_norm_sq: f64,
+    product_norm_sq: f64
+) -> ZeroReceiptF64 with Panic {
+    assert(left_norm_sq > 0.0)
+    assert(right_norm_sq > 0.0)
+    assert(product_norm_sq == 0.0)
+    ze_make(
+        ze_flag_annihilated(),
+        0.0,
+        0.0,
+        left_norm_sq,
+        right_norm_sq,
+        true,
+        true,
+        ze_tag_annihilated(),
+        0,
+    )
+}
+
+pub fn ze_below_resolution_f64(latent: f64, resolution: f64) -> ZeroReceiptF64 with Panic {
+    assert(latent != 0.0)
+    assert(resolution > 0.0)
+    assert(ze_abs_f64(latent) < resolution)
+    ze_make(
+        ze_flag_below_resolution(),
+        latent,
+        resolution,
+        latent,
+        resolution,
+        true,
+        true,
+        ze_tag_below_resolution(),
+        0,
+    )
+}
+
+pub fn ze_rounded_f64(surface: f64, correction: f64) -> ZeroReceiptF64 with Panic {
+    assert(surface == 0.0)
+    assert(correction != 0.0)
+    ze_make(ze_flag_rounded(), correction, 0.0, surface, correction, true, true, ze_tag_rounded(), 0)
+}
+
+pub fn ze_gated_f64(original: f64, gate_tag: i64) -> ZeroReceiptF64 with Panic {
+    assert(original != 0.0)
+    assert(gate_tag != 0)
+    ze_make(ze_flag_gated(), original, 0.0, original, 0.0, true, false, ze_tag_gated(), gate_tag)
+}
+
+pub fn ze_unknown_f64() -> ZeroReceiptF64 with Panic {
+    ze_make(ze_flag_unknown(), 0.0, 0.0, 0.0, 0.0, false, false, ze_tag_unknown(), 0)
+}
+
+pub fn ze_value_f64(z: ZeroReceiptF64) -> f64 { z.value_f64 }
+pub fn ze_evidence_flags(z: ZeroReceiptF64) -> i64 { z.evidence_flags }
+pub fn ze_residual_f64(z: ZeroReceiptF64) -> f64 { z.residual_f64 }
+pub fn ze_resolution_f64(z: ZeroReceiptF64) -> f64 { z.resolution_f64 }
+pub fn ze_left_evidence_f64(z: ZeroReceiptF64) -> f64 { z.left_evidence_f64 }
+pub fn ze_right_evidence_f64(z: ZeroReceiptF64) -> f64 { z.right_evidence_f64 }
+pub fn ze_left_nonzero(z: ZeroReceiptF64) -> bool { z.left_nonzero }
+pub fn ze_right_nonzero(z: ZeroReceiptF64) -> bool { z.right_nonzero }
+pub fn ze_detail_tag(z: ZeroReceiptF64) -> i64 { z.detail_tag }
+
+pub fn ze_has_evidence(z: ZeroReceiptF64, flag: i64) -> bool {
+    if flag <= 0 { return false }
+    (z.evidence_flags & flag) != 0
+}
+
+pub fn ze_same_surface(a: ZeroReceiptF64, b: ZeroReceiptF64) -> bool {
+    a.value_f64 == b.value_f64
+}
+
+pub fn ze_same_provenance(a: ZeroReceiptF64, b: ZeroReceiptF64) -> bool {
+    a.evidence_flags == b.evidence_flags &&
+    a.residual_f64 == b.residual_f64 &&
+    a.resolution_f64 == b.resolution_f64 &&
+    a.left_evidence_f64 == b.left_evidence_f64 &&
+    a.right_evidence_f64 == b.right_evidence_f64 &&
+    a.left_nonzero == b.left_nonzero &&
+    a.right_nonzero == b.right_nonzero &&
+    a.witness_tag == b.witness_tag &&
+    a.detail_tag == b.detail_tag
+}
+
+pub fn ze_discharge_f64(z: ZeroReceiptF64, reason_tag: i64) -> ErasedZeroF64 with Panic {
+    assert(reason_tag != ze_invalid_discharge_reason())
+    ErasedZeroF64 {
+        value_f64: z.value_f64,
+        source_evidence_flags: z.evidence_flags,
+        discharge_reason_tag: reason_tag,
+        discharge_present: true,
+    }
+}
+
+pub fn ze_erased_value_f64(z: ErasedZeroF64) -> f64 with Panic {
+    assert(z.discharge_present)
+    assert(z.discharge_reason_tag != ze_invalid_discharge_reason())
+    z.value_f64
+}
+
+pub fn ze_erased_source_flags(z: ErasedZeroF64) -> i64 { z.source_evidence_flags }
+pub fn ze_erased_reason_tag(z: ErasedZeroF64) -> i64 { z.discharge_reason_tag }
+pub fn ze_erased_has_discharge(z: ErasedZeroF64) -> bool { z.discharge_present }

--- a/tests/compile-fail/zero_event_direct_erased_construction.sio
+++ b/tests/compile-fail/zero_event_direct_erased_construction.sio
@@ -1,0 +1,14 @@
+//@ compile-fail
+//@ error-pattern: error[E176
+
+use epistemic::zero_event::*
+
+fn main() with Panic {
+    let forged = ErasedZeroF64 {
+        value_f64: 0.0,
+        source_evidence_flags: ze_flag_unknown(),
+        discharge_reason_tag: ze_discharge_reason_display(),
+        discharge_present: true,
+    }
+    let _raw = ze_erased_value_f64(forged)
+}

--- a/tests/compile-fail/zero_event_direct_receipt_construction.sio
+++ b/tests/compile-fail/zero_event_direct_receipt_construction.sio
@@ -1,0 +1,20 @@
+//@ compile-fail
+//@ error-pattern: error[E176
+
+use epistemic::zero_event::*
+
+fn main() {
+    let forged = ZeroReceiptF64 {
+        value_f64: 0.0,
+        evidence_flags: ze_flag_annihilated(),
+        residual_f64: 0.0,
+        resolution_f64: 0.0,
+        left_evidence_f64: 2.0,
+        right_evidence_f64: 2.0,
+        left_nonzero: true,
+        right_nonzero: true,
+        witness_tag: 303,
+        detail_tag: 0,
+    }
+    let _flags = ze_evidence_flags(forged)
+}

--- a/tests/compile-fail/zero_event_erasure_requires_discharge.sio
+++ b/tests/compile-fail/zero_event_erasure_requires_discharge.sio
@@ -1,0 +1,9 @@
+//@ compile-fail
+//@ error-pattern: Type mismatch in call argument
+
+use epistemic::zero_event::*
+
+fn main() with Panic {
+    let z = ze_rounded_f64(0.0, 1.0e-30)
+    let _raw = ze_erased_value_f64(z)
+}

--- a/tests/known_failures/eisa_zero_flags_native_v2_probe.sio
+++ b/tests/known_failures/eisa_zero_flags_native_v2_probe.sio
@@ -1,0 +1,74 @@
+//@ known-failure: the qd128/EISA graph lowers without crashing but native emission fails closed; lean_single verifies the flags
+
+use eisa::core_v2::{
+    ereg2_exact, eadd2, esub2, ereg2_zero_flags,
+    eisa_zero_flag_observed, eisa_zero_flag_correction_nonzero
+}
+use eisa::format::*
+use eisa::evm::{evm_load, evm_run, evm_reg_val, evm_reg_ehi, evm_reg_zero_flags}
+
+fn build_zero_flag_image() -> EisaxBuild with Mut, Panic {
+    var b = eisax_build_new()
+    b = eisax_build_set_version(b, eisax_version_v2())
+    b = eisax_build_set_fuel(b, 16)
+    b.consts[0] = 18014398509481984.0
+    b.consts[1] = 1.0
+    b.n_const = 2
+
+    b.ops[0] = op_econst()
+    b.dsts[0] = 0
+    b.as_[0] = 0
+
+    b.ops[1] = op_econst()
+    b.dsts[1] = 1
+    b.as_[1] = 1
+
+    b.ops[2] = op_eadd()
+    b.dsts[2] = 2
+    b.as_[2] = 0
+    b.bs_[2] = 1
+
+    b.ops[3] = op_esub()
+    b.dsts[3] = 3
+    b.as_[3] = 2
+    b.bs_[3] = 0
+
+    b.ops[4] = op_ehalt()
+    b.n_code = 5
+    b
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let exact_zero = ereg2_exact(0.0)
+    let ordinary = ereg2_exact(2.0)
+
+    let big = ereg2_exact(18014398509481984.0)
+    let one = ereg2_exact(1.0)
+    let rounded_sum = eadd2(big, one)
+    let recovered = esub2(rounded_sum, big)
+
+    let exact_flags = ereg2_zero_flags(exact_zero)
+    let ordinary_flags = ereg2_zero_flags(ordinary)
+    let recovered_flags = ereg2_zero_flags(recovered)
+
+    let expected_recovered =
+        eisa_zero_flag_observed() + eisa_zero_flag_correction_nonzero()
+
+    let image = eisax_encode(build_zero_flag_image())
+    var machine = evm_load(image)
+    let evm_status = evm_run(&!machine)
+    let evm_flags = evm_reg_zero_flags(&machine, 3)
+
+    if exact_flags == eisa_zero_flag_observed() &&
+       ordinary_flags == 0 &&
+       recovered.val == 0.0 && recovered.err.x0 != 0.0 &&
+       recovered_flags == expected_recovered &&
+       evm_status == 0 && evm_reg_val(&machine, 3) == 0.0 &&
+       evm_reg_ehi(&machine, 3) != 0.0 && evm_flags == expected_recovered {
+        println("EISA_ZERO_FLAGS PASS")
+        return 0
+    }
+
+    println("EISA_ZERO_FLAGS FAIL")
+    1
+}

--- a/tests/known_failures/qd128_import_native_v2_probe.sio
+++ b/tests/known_failures/qd128_import_native_v2_probe.sio
@@ -1,0 +1,12 @@
+//@ known-failure: minimal qd128 import lowers without crashing but native emission fails closed with backend rc=12
+
+use math::qd128::{qd_zero}
+
+fn main() -> i32 with IO {
+    let z = qd_zero()
+    if z.x0 == 0.0 {
+        println("QD128_IMPORT_NATIVE_V2 PASS")
+        return 0
+    }
+    1
+}

--- a/tests/known_failures/sedenion_import_native_v2_probe.sio
+++ b/tests/known_failures/sedenion_import_native_v2_probe.sio
@@ -1,0 +1,19 @@
+//@ known-failure: minimal sedenion import compiles and runs without crashing, but exits 1 without proving the zero-divisor marker
+
+use algebra::sedenion::{
+    sed_canonical_zd_z, sed_canonical_zd_w, sed_mul, sed_norm_sq
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    var out: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_z(&!z)
+    sed_canonical_zd_w(&!w)
+    sed_mul(&z, &w, &!out)
+    if sed_norm_sq(&z) > 0.0 && sed_norm_sq(&w) > 0.0 && sed_norm_sq(&out) == 0.0 {
+        println("SEDENION_IMPORT_NATIVE_V2 PASS")
+        return 0
+    }
+    1
+}

--- a/tests/known_failures/zero_event_direct_erased_construction_native_compile_probe.sio
+++ b/tests/known_failures/zero_event_direct_erased_construction_native_compile_probe.sio
@@ -1,0 +1,11 @@
+use epistemic::zero_event::*
+
+fn main() with Panic {
+    let forged = ErasedZeroF64 {
+        value_f64: 0.0,
+        source_evidence_flags: ze_flag_unknown(),
+        discharge_reason_tag: ze_discharge_reason_display(),
+        discharge_present: true,
+    }
+    let _raw = ze_erased_value_f64(forged)
+}

--- a/tests/known_failures/zero_event_direct_receipt_construction_native_compile_probe.sio
+++ b/tests/known_failures/zero_event_direct_receipt_construction_native_compile_probe.sio
@@ -1,0 +1,17 @@
+use epistemic::zero_event::*
+
+fn main() {
+    let forged = ZeroReceiptF64 {
+        value_f64: 0.0,
+        evidence_flags: ze_flag_annihilated(),
+        residual_f64: 0.0,
+        resolution_f64: 0.0,
+        left_evidence_f64: 2.0,
+        right_evidence_f64: 2.0,
+        left_nonzero: true,
+        right_nonzero: true,
+        witness_tag: 303,
+        detail_tag: 0,
+    }
+    let _flags = ze_evidence_flags(forged)
+}

--- a/tests/known_failures/zero_event_private_field_access_probe.sio
+++ b/tests/known_failures/zero_event_private_field_access_probe.sio
@@ -1,0 +1,8 @@
+//@ known-failure: Madaros currently accepts external reads of private struct fields
+
+use epistemic::zero_event::*
+
+fn main() with Panic {
+    let z = ze_rounded_f64(0.0, 1.0e-30)
+    let _forged_read = z.evidence_flags
+}

--- a/tests/known_failures/zero_event_stdlib_native_v2_probe.sio
+++ b/tests/known_failures/zero_event_stdlib_native_v2_probe.sio
@@ -1,0 +1,63 @@
+//@ known-failure: default Madaros emits an ELF that segfaults for the imported zero_event aggregate-return surface; lean_single prints ZERO_EVENT_STDLIB PASS
+
+use epistemic::zero_event::*
+
+fn main() -> i32 with IO, Panic {
+    let absent = ze_absent_f64()
+    let cancelled = ze_cancelled_f64(3.25, 0.0 - 3.25)
+    let annihilated = ze_annihilated_norms_f64(2.0, 2.0, 0.0)
+    let resolution = ze_below_resolution_f64(0.0004, 0.001)
+    let rounded = ze_rounded_f64(0.0, 1.0e-30)
+    let gated = ze_gated_f64(0.75, 9001)
+    let unknown = ze_unknown_f64()
+
+    let all_zero =
+        ze_value_f64(absent) == 0.0 &&
+        ze_value_f64(cancelled) == 0.0 &&
+        ze_value_f64(annihilated) == 0.0 &&
+        ze_value_f64(resolution) == 0.0 &&
+        ze_value_f64(rounded) == 0.0 &&
+        ze_value_f64(gated) == 0.0 &&
+        ze_value_f64(unknown) == 0.0
+
+    let evidence_correct =
+        ze_has_evidence(absent, ze_flag_absent()) &&
+        ze_has_evidence(cancelled, ze_flag_cancelled()) &&
+        ze_has_evidence(annihilated, ze_flag_annihilated()) &&
+        ze_has_evidence(resolution, ze_flag_below_resolution()) &&
+        ze_has_evidence(rounded, ze_flag_rounded()) &&
+        ze_has_evidence(gated, ze_flag_gated()) &&
+        ze_has_evidence(unknown, ze_flag_unknown())
+
+    let paths_distinct =
+        ze_same_surface(absent, rounded) &&
+        ze_same_surface(cancelled, annihilated) &&
+        !ze_same_provenance(absent, rounded) &&
+        !ze_same_provenance(cancelled, annihilated)
+
+    let details_preserved =
+        ze_residual_f64(resolution) == 0.0004 &&
+        ze_resolution_f64(resolution) == 0.001 &&
+        ze_residual_f64(rounded) == 1.0e-30 &&
+        ze_left_evidence_f64(cancelled) == 3.25 &&
+        ze_right_evidence_f64(cancelled) == 0.0 - 3.25 &&
+        ze_left_evidence_f64(annihilated) == 2.0 &&
+        ze_right_evidence_f64(annihilated) == 2.0 &&
+        ze_detail_tag(gated) == 9001 &&
+        ze_left_nonzero(annihilated) && ze_right_nonzero(annihilated)
+
+    let erased = ze_discharge_f64(rounded, ze_discharge_reason_display())
+    let discharge_auditable =
+        ze_erased_value_f64(erased) == 0.0 &&
+        ze_erased_source_flags(erased) == ze_flag_rounded() &&
+        ze_erased_reason_tag(erased) == ze_discharge_reason_display() &&
+        ze_erased_has_discharge(erased)
+
+    if all_zero && evidence_correct && paths_distinct && details_preserved && discharge_auditable {
+        println("ZERO_EVENT_STDLIB PASS")
+        return 0
+    }
+
+    println("ZERO_EVENT_STDLIB FAIL")
+    1
+}

--- a/tests/known_failures/zero_provenance_native_v2_probe.sio
+++ b/tests/known_failures/zero_provenance_native_v2_probe.sio
@@ -1,0 +1,133 @@
+//! Known native-v2 failure: default Madaros completes imported-module lowering
+//! without crashing, then fails closed during native emission with backend
+//! rc=12. The dedicated gate checks with Madaros and executes the semantic
+//! oracle explicitly through lean_single.
+
+//! Five computations with the same surface value and different provenance.
+//!
+//! This is an inert algebraic/metrological witness. It makes no clinical claim
+//! and does not propose a general language-level ZeroEvent representation.
+
+use algebra::sedenion::{
+    sed_canonical_zd_z, sed_canonical_zd_w, sed_mul, sed_norm_sq
+}
+use eisa::core_v2::{ereg2_exact, eadd2, esub2}
+
+struct ZeroWitness {
+    kind: i64,
+    value: f64,
+    residual: f64,
+    left_nonzero: bool,
+    right_nonzero: bool,
+}
+
+fn abs_local(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn below_resolution(value: f64, resolution: f64) -> f64 {
+    if abs_local(value) < resolution { 0.0 } else { value }
+}
+
+fn absent_zero() -> ZeroWitness {
+    ZeroWitness {
+        kind: 0,
+        value: 0.0,
+        residual: 0.0,
+        left_nonzero: false,
+        right_nonzero: false,
+    }
+}
+
+fn cancelled_zero() -> ZeroWitness {
+    let left = 3.25
+    let right = 0.0 - 3.25
+    ZeroWitness {
+        kind: 1,
+        value: left + right,
+        residual: 0.0,
+        left_nonzero: left != 0.0,
+        right_nonzero: right != 0.0,
+    }
+}
+
+fn annihilated_zero() -> ZeroWitness with Mut {
+    var left: [f64; 16] = [0.0; 16]
+    var right: [f64; 16] = [0.0; 16]
+    var product: [f64; 16] = [0.0; 16]
+    sed_canonical_zd_z(&!left)
+    sed_canonical_zd_w(&!right)
+    sed_mul(&left, &right, &!product)
+    ZeroWitness {
+        kind: 2,
+        value: sed_norm_sq(&product),
+        residual: 0.0,
+        left_nonzero: sed_norm_sq(&left) > 0.0,
+        right_nonzero: sed_norm_sq(&right) > 0.0,
+    }
+}
+
+fn resolution_zero() -> ZeroWitness {
+    let latent = 0.0004
+    let resolution = 0.001
+    ZeroWitness {
+        kind: 3,
+        value: below_resolution(latent, resolution),
+        residual: latent,
+        left_nonzero: latent != 0.0,
+        right_nonzero: resolution != 0.0,
+    }
+}
+
+fn rounded_zero() -> ZeroWitness with Mut, Div, Panic {
+    let one = ereg2_exact(1.0)
+    let tiny = ereg2_exact(1.0e-30)
+    let rounded_sum = eadd2(one, tiny)
+    let recovered = esub2(rounded_sum, one)
+    ZeroWitness {
+        kind: 4,
+        value: recovered.val,
+        residual: recovered.err.x0,
+        left_nonzero: tiny.val != 0.0,
+        right_nonzero: recovered.err.x0 != 0.0,
+    }
+}
+
+fn surface_is_zero(w: &ZeroWitness) -> bool {
+    w.value == 0.0
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let absent = absent_zero()
+    let cancelled = cancelled_zero()
+    let annihilated = annihilated_zero()
+    let resolution = resolution_zero()
+    let rounded = rounded_zero()
+
+    let all_surface_zero =
+        surface_is_zero(&absent) &&
+        surface_is_zero(&cancelled) &&
+        surface_is_zero(&annihilated) &&
+        surface_is_zero(&resolution) &&
+        surface_is_zero(&rounded)
+
+    let kinds_distinct =
+        absent.kind == 0 && cancelled.kind == 1 && annihilated.kind == 2 &&
+        resolution.kind == 3 && rounded.kind == 4
+
+    let provenance_present =
+        !absent.left_nonzero && !absent.right_nonzero &&
+        cancelled.left_nonzero && cancelled.right_nonzero &&
+        annihilated.left_nonzero && annihilated.right_nonzero &&
+        resolution.left_nonzero && resolution.right_nonzero &&
+        rounded.left_nonzero && rounded.right_nonzero &&
+        resolution.residual != 0.0 && rounded.residual != 0.0
+
+    if all_surface_zero && kinds_distinct && provenance_present {
+        println("ZERO_PROVENANCE PASS")
+        return 0
+    }
+
+    println("ZERO_PROVENANCE FAIL")
+    1
+}

--- a/tests/run-pass/dd64_import_native_v2_smoke.sio
+++ b/tests/run-pass/dd64_import_native_v2_smoke.sio
@@ -1,0 +1,13 @@
+//@ run-pass
+//@ expect-stdout: DD64_IMPORT_NATIVE_V2 PASS
+
+use math::dd64::{dd_zero}
+
+fn main() -> i32 with IO {
+    let z = dd_zero()
+    if z.hi == 0.0 && z.lo == 0.0 {
+        println("DD64_IMPORT_NATIVE_V2 PASS")
+        return 0
+    }
+    1
+}


### PR DESCRIPTION
## Summary

Adds an opaque, path-bearing `ZeroReceiptF64` surface that distinguishes equal numeric zeros by retained computational evidence, plus explicit typed discharge through `ErasedZeroF64`.

Also enforces imported-module privacy in native compilation and derives bounded EISA zero flags without merging `val`, `err`, or `u`.

No physical, causal, clinical, or psychopharmacological claim is introduced.

## Source-fresh evidence

A modular Madaros ELF was rebuilt from this branch before validation.

- `bash scripts/ci/zero_event_native_compile_privacy_gate.sh`
  - private receipt/erasure construction rejected with E176
  - private fn/enum cases rejected
  - public struct, public generic, valid ZeroEvent and EISA frontend retained
- `bash scripts/ci/zero_event_gate.sh` — PASS
- `bash scripts/ci/zero_provenance_witness_gate.sh` — PASS
- `bash scripts/ci/zero_event_native_v2_matrix.sh` — PASS
  - dd64 and ZeroEvent execute
  - qd128 and combined imports fail closed in backend
  - sedenion exits nonzero without crash
- `git diff --check` — PASS

## Review

xAI/Grok 4.3 reviewed the zero-provenance witness and ZeroEvent/EISA flags. It found no algebraic error or claim overreach in the bounded non-clinical scope. A local follow-up added retained gate/detail evidence before the final green gates.
