### PR TITLE
feat(parser): E040/E041 helpful diagnostics for Rust let mut / &mut

### DIFF
--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -272,6 +272,20 @@ impl Parser {
         let start = self.current_span()
         var p = parser_advance(self)  // skip 'let'
 
+        // E040: Rust `let mut` — Sounio uses `var` for mutable bindings. `mut` is
+        // a dedicated keyword token, so detect it directly and emit a helpful,
+        // coded diagnostic instead of a bare "expected token" parse error. Recover
+        // by consuming `mut` and parsing the rest as an ordinary `let <pat>`.
+        if parser_peek(p) == TokenKind::Mut {
+            p.had_error = true
+            p.error_count = p.error_count + 1
+            if p.error_count <= 20 {
+                print("error[E040]: Sounio uses `var` for mutable bindings, not `let mut`\n")
+                print("  help: change `let mut x = ...` to `var x = ...`\n")
+            }
+            p = parser_advance(p)  // skip `mut`, continue as `let <name>`
+        }
+
         let pat_pair = p.parse_pattern()
         p = pat_pair.0
         let pat = pat_pair.1

--- a/self-hosted/parser/types.sio
+++ b/self-hosted/parser/types.sio
@@ -344,6 +344,18 @@ impl Parser {
     fn parse_ref_type(self) -> (Parser, TypeExpr) with Mut, IO, Panic, Div, Alloc {
         let start = self.current_span()
         var p = self.advance()  // skip &
+        // E041: Rust `&mut T` — Sounio uses `&!T` for exclusive references. Detect
+        // the `mut` keyword after `&` and emit a coded, helpful diagnostic; recover
+        // by consuming `mut` and parsing the inner type as a shared `&T`.
+        if parser_peek(p) == TokenKind::Mut {
+            p.had_error = true
+            p.error_count = p.error_count + 1
+            if p.error_count <= 20 {
+                print("error[E041]: Sounio uses `&!T` for exclusive references, not `&mut T`\n")
+                print("  help: change `&mut T` to `&!T`\n")
+            }
+            p = p.advance()  // skip `mut`
+        }
         let pair = p.parse_type()
         p = pair.0
         let inner_ty = pair.1

--- a/tests/compile-fail/rust_let_mut_e040.sio
+++ b/tests/compile-fail/rust_let_mut_e040.sio
@@ -1,0 +1,7 @@
+//@ compile-fail
+//@ error-pattern: E040
+// E040: Rust `let mut` is rejected with a helpful diagnostic (use `var`).
+fn main() -> i32 with IO {
+    let mut x = 0
+    x as i32
+}

--- a/tests/compile-fail/rust_ref_mut_e041.sio
+++ b/tests/compile-fail/rust_ref_mut_e041.sio
@@ -1,0 +1,5 @@
+//@ compile-fail
+//@ error-pattern: E041
+// E041: Rust `&mut T` is rejected with a helpful diagnostic (use `&!T`).
+fn takes(a: &mut i64) with Mut { }
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
Guard-wiring dispatch (#798) follow-up, after E213 (#801) and E216 (#802). The modular Madaros parser gave a bare `parse error: expected token` for `let mut` and `&mut`; these now emit **coded, actionable** diagnostics — high value for the LLM-agent audience that reaches for Rust idioms.

## Change
- **`stmts.sio` (`parse_let_stmt`)**: `mut` (a dedicated keyword token) after `let` → `error[E040]` with the fix (`use var`); recover by consuming `mut`.
- **`types.sio` (`parse_ref_type`)**: `mut` after `&` → `error[E041]` with the fix (`use &!T`); recover by consuming `mut` and parsing the inner as `&T`.

**Zero false-reject risk:** `mut` is a keyword token, so `let mut` / `&mut` never appear in valid Sounio (`var`, `&!T`, `&T` are the real forms).

## Scope
E042 (`#[...]` attributes) and E043 (`ident!(...)` macros — currently the one case that compiles **clean**, accepting invalid code) need item-level / postfix `Bang`-vs-not disambiguation and are **documented follow-ons** in the dispatch.

## Verification (regression gate, off main incl. E213+E216)
- **Full serial suite: ZERO new failures across 2217 tests.**
- New: `tests/compile-fail/rust_let_mut_e040.sio`, `rust_ref_mut_e041.sio`.
- Negatives: `var x`, `&!i64`, `&i64` still `check: OK`; E213/E216 still fire.
- Rebuilt Madaros under the build lock; shipped `bin/madaros-linux-x86_64`.