### PR TITLE
ci(coordination): expose compiler lane status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
           bash scripts/ci/heuristic_firewall_gate.sh
       - name: Worktree governance gate
         run: bash scripts/dev/worktree_branch_audit.sh --check
+      - name: Compiler lane status contract
+        run: bash scripts/ci/compiler_lane_status_gate.sh
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 940
-- Repo-backed topics: 790
+- Total governed topics: 941
+- Repo-backed topics: 791
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 540
+- Authority count `repo_only`: 541
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 559 topics
+- A2: 560 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -407,6 +407,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.readme | repo_only | docs/internal/concepts/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.semantic-lane-contract | repo_only | docs/internal/concepts/SEMANTIC_LANE_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.zero-provenance | repo_only | docs/internal/concepts/zero-provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.coordination.compiler-lane-contract | repo_only | docs/internal/coordination/COMPILER_LANE_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.enir-semantic-interface-contract-2026-07-12 | repo_only | docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.semantic-hotspot-triage-2026-07-12 | repo_only | docs/internal/coordination/semantic-hotspot-triage-2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.garden.readme | repo_only | docs/internal/garden/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8840,6 +8840,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.coordination.compiler-lane-contract",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/coordination/COMPILER_LANE_CONTRACT.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.coordination.enir-semantic-interface-contract-2026-07-12",
       "collection": "repo",
       "repo_doc_path": "docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md",

--- a/docs/internal/coordination/COMPILER_LANE_CONTRACT.md
+++ b/docs/internal/coordination/COMPILER_LANE_CONTRACT.md
@@ -1,0 +1,49 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.coordination.compiler-lane-contract
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.coordination.compiler-lane-contract
+-->
+
+# Compiler Lane Contract
+
+Sounio separates compiler work by evidence state rather than by the number of
+branches or worktrees that happen to exist.
+
+- `origin/main` is the integrated product surface.
+- `origin/canon/madaros-v2-sota` is the ENIR/MIR compiler frontier.
+- recent dirty worktrees are active benches and retain exclusive write
+  authority over the compiler paths they touch.
+- old dirty worktrees are preserved residue, not active work and not deletion
+  candidates.
+
+`scripts/dev/compiler_lane_status.sh` provides the read-only snapshot. Its
+classifications mean:
+
+- `INTEGRATED`: the clean worktree tip is contained in the configured main ref.
+- `REVIEW_READY`: the worktree is clean but its tip is not contained in main.
+- `ACTIVE`: a compiler path has a recent working-tree modification.
+- `STALE_WITH_RESIDUE`: compiler changes remain, but no recent file activity was
+  observed.
+- `SCRATCH_COPY`: compiler files occur in a scratchpad worktree; they are inputs
+  for comparison, not an authoritative lane.
+- `UNCLASSIFIED`: the scanner lacks enough Git evidence.
+
+These states are observations. They never assign an owner, authorize a merge,
+or prove semantic correctness. Promotion still requires the lane's positive
+witness, negative witness, acceptance gate, correct integration base, and any
+review mandated by `.claude/AGENT_OFFLOAD_POLICY.md`.
+
+Run:
+
+```bash
+bash scripts/dev/compiler_lane_status.sh --verbose
+bash scripts/ci/compiler_lane_status_gate.sh
+```
+
+An active lane must not edit a compiler path already reported as active in
+another worktree. A stale lane must be reduced to a bounded witness before any
+code is recovered. An integrated lane may be removed only through an explicit
+cleanup decision; the scanner itself is deliberately incapable of doing so.

--- a/scripts/ci/compiler_lane_status_gate.sh
+++ b/scripts/ci/compiler_lane_status_gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCANNER="$ROOT_DIR/scripts/dev/compiler_lane_status.sh"
+
+bash -n "$SCANNER"
+current_output="$(bash "$SCANNER" --current-only)"
+global_output="$(bash "$SCANNER")"
+
+grep -q '^Sounio compiler lane status$' <<< "$current_output"
+grep -q '^scanner_mode=current-only$' <<< "$current_output"
+grep -q '^scanner_mode=all-worktrees$' <<< "$global_output"
+grep -q '^== Summary ==$' <<< "$global_output"
+
+echo '[compiler-lanes] PASS: read-only lane classification is executable'

--- a/scripts/ci/compiler_lane_status_gate.sh
+++ b/scripts/ci/compiler_lane_status_gate.sh
@@ -6,10 +6,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCANNER="$ROOT_DIR/scripts/dev/compiler_lane_status.sh"
 
 bash -n "$SCANNER"
-current_output="$(bash "$SCANNER" --current-only)"
-global_output="$(bash "$SCANNER")"
+# actions/checkout checks out a synthetic merge commit without creating
+# origin/main. HEAD is the correct integration snapshot for this isolated gate.
+current_output="$(bash "$SCANNER" --main-ref HEAD --current-only)"
+global_output="$(bash "$SCANNER" --main-ref HEAD)"
 
 grep -q '^Sounio compiler lane status$' <<< "$current_output"
+grep -Eq '^main_ref=HEAD main_sha=[0-9a-f]{10}$' <<< "$current_output"
 grep -q '^scanner_mode=current-only$' <<< "$current_output"
 grep -q '^scanner_mode=all-worktrees$' <<< "$global_output"
 grep -q '^== Summary ==$' <<< "$global_output"

--- a/scripts/dev/compiler_lane_status.sh
+++ b/scripts/dev/compiler_lane_status.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MAIN_REF="${SOUNIO_COMPILER_MAIN_REF:-origin/main}"
+FRONTIER_REF="${SOUNIO_COMPILER_FRONTIER_REF:-origin/canon/madaros-v2-sota}"
+ACTIVITY_SECONDS="${SOUNIO_COMPILER_ACTIVITY_SECONDS:-14400}"
+CURRENT_ONLY=0
+VERBOSE=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/dev/compiler_lane_status.sh [options]
+
+Read-only classification of compiler worktrees. The scanner never assigns
+ownership, changes branches, removes worktrees, or promotes a compiler claim.
+
+Options:
+  --current-only       inspect only the current worktree
+  --verbose            print compiler paths changed by each dirty lane
+  --activity-seconds N recent-file threshold (default: 14400)
+  --main-ref REF       integrated-product reference (default: origin/main)
+  --frontier-ref REF   compiler-frontier reference
+  -h, --help           show this help
+USAGE
+}
+
+while (($#)); do
+  case "$1" in
+    --current-only) CURRENT_ONLY=1 ;;
+    --verbose) VERBOSE=1 ;;
+    --activity-seconds)
+      shift
+      [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]] || {
+        echo "error: --activity-seconds requires a nonnegative integer" >&2
+        exit 2
+      }
+      ACTIVITY_SECONDS="$1"
+      ;;
+    --main-ref) shift; [[ $# -gt 0 ]] || exit 2; MAIN_REF="$1" ;;
+    --frontier-ref) shift; [[ $# -gt 0 ]] || exit 2; FRONTIER_REF="$1" ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+git -C "$ROOT_DIR" rev-parse --verify "$MAIN_REF^{commit}" >/dev/null 2>&1 || {
+  echo "error: main reference is unavailable: $MAIN_REF" >&2
+  exit 1
+}
+
+is_compiler_path() {
+  case "$1" in
+    self-hosted/compiler/*|self-hosted/parser/*|self-hosted/check/*|self-hosted/ir/*|self-hosted/codegen/*|\
+    scripts/lib/resolve_souc.sh|scripts/lib/resolve_madaros.sh|scripts/ci/build_native_souc.sh|\
+    scripts/ci/build_modular_madaros.sh|scripts/run_sio_test_suite.sh|bin/souc|bin/madaros)
+      return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+branch_for() {
+  local wt="$1" branch
+  branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
+  [[ -n "$branch" ]] || branch="detached@$(git -C "$wt" rev-parse --short=10 HEAD 2>/dev/null || echo unknown)"
+  printf '%s' "$branch"
+}
+
+mapfile -t WORKTREES < <(
+  if [[ "$CURRENT_ONLY" == "1" ]]; then
+    printf '%s\n' "$ROOT_DIR"
+  else
+    git -C "$ROOT_DIR" worktree list --porcelain | sed -n 's/^worktree //p'
+  fi
+)
+
+now="$(date +%s)"
+integrated=0
+active=0
+review_ready=0
+stale=0
+scratch=0
+unclassified=0
+
+printf 'Sounio compiler lane status\n'
+printf 'snapshot_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'main_ref=%s main_sha=%s\n' "$MAIN_REF" "$(git -C "$ROOT_DIR" rev-parse --short=10 "$MAIN_REF")"
+if git -C "$ROOT_DIR" rev-parse --verify "$FRONTIER_REF^{commit}" >/dev/null 2>&1; then
+  printf 'frontier_ref=%s frontier_sha=%s\n' "$FRONTIER_REF" "$(git -C "$ROOT_DIR" rev-parse --short=10 "$FRONTIER_REF")"
+else
+  printf 'frontier_ref=%s frontier_sha=unavailable\n' "$FRONTIER_REF"
+fi
+printf 'worktrees_seen=%s\n\n' "${#WORKTREES[@]}"
+
+for wt in "${WORKTREES[@]}"; do
+  [[ -d "$wt" ]] || continue
+  branch="$(branch_for "$wt")"
+  head="$(git -C "$wt" rev-parse HEAD 2>/dev/null || true)"
+  short_head="${head:0:10}"
+  head_epoch="$(git -C "$wt" show -s --format=%ct HEAD 2>/dev/null || echo 0)"
+  dirty_count=0
+  latest_epoch=0
+  compiler_paths=()
+
+  while IFS= read -r status_line; do
+    [[ -n "$status_line" ]] || continue
+    path="${status_line:3}"
+    [[ "$path" == *' -> '* ]] && path="${path##* -> }"
+    is_compiler_path "$path" || continue
+    compiler_paths+=("$path")
+    dirty_count=$((dirty_count + 1))
+    file_epoch="$(stat -c %Y "$wt/$path" 2>/dev/null || echo 0)"
+    ((file_epoch == 0)) && file_epoch="$head_epoch"
+    ((file_epoch > latest_epoch)) && latest_epoch="$file_epoch"
+  done < <(git -C "$wt" status --porcelain=v1 --untracked-files=all 2>/dev/null || true)
+
+  age_seconds=-1
+  if ((latest_epoch > 0)); then
+    age_seconds=$((now - latest_epoch))
+    ((age_seconds < 0)) && age_seconds=0
+  fi
+
+  if [[ "$wt" == */scratchpad/* && "$dirty_count" -gt 0 ]]; then
+    state="SCRATCH_COPY"; scratch=$((scratch + 1))
+  elif [[ "$dirty_count" -gt 0 && "$age_seconds" -le "$ACTIVITY_SECONDS" ]]; then
+    state="ACTIVE"; active=$((active + 1))
+  elif [[ "$dirty_count" -gt 0 ]]; then
+    state="STALE_WITH_RESIDUE"; stale=$((stale + 1))
+  elif [[ -n "$head" ]] && git -C "$ROOT_DIR" merge-base --is-ancestor "$head" "$MAIN_REF" 2>/dev/null; then
+    state="INTEGRATED"; integrated=$((integrated + 1))
+  elif [[ -n "$head" ]]; then
+    state="REVIEW_READY"; review_ready=$((review_ready + 1))
+  else
+    state="UNCLASSIFIED"; unclassified=$((unclassified + 1))
+  fi
+
+  printf 'state=%s branch=%s head=%s dirty_compiler_paths=%s age_seconds=%s worktree=%s\n' \
+    "$state" "$branch" "${short_head:-unknown}" "$dirty_count" "$age_seconds" "$wt"
+  if [[ "$VERBOSE" == "1" ]]; then
+    for path in "${compiler_paths[@]}"; do printf '  path=%s\n' "$path"; done
+  fi
+done
+
+printf '\n== Summary ==\n'
+printf 'integrated=%s\nactive=%s\nreview_ready=%s\nstale_with_residue=%s\nscratch_copy=%s\nunclassified=%s\n' \
+  "$integrated" "$active" "$review_ready" "$stale" "$scratch" "$unclassified"
+printf 'scanner_mode=%s\n' "$( [[ "$CURRENT_ONLY" == "1" ]] && echo current-only || echo all-worktrees )"


### PR DESCRIPTION
## O que muda

- adiciona um scanner somente leitura para classificar worktrees do compilador
- distingue `INTEGRATED`, `REVIEW_READY`, `ACTIVE`, `STALE_WITH_RESIDUE`, `SCRATCH_COPY` e `UNCLASSIFIED`
- documenta o contrato entre produto integrado, fronteira e bancadas
- liga um gate mínimo ao job `Contracts`
- preserva ownership: o scanner não altera branches, worktrees ou arquivos

## Prova local

- `bash scripts/ci/compiler_lane_status_gate.sh`
- `bash scripts/ci/impact_ci_selftest.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `git diff --check`

Todos passaram.