### PR TITLE
ci: add asynchronous evidence watcher

### DIFF
--- a/.github/workflows/ci-watch.yml
+++ b/.github/workflows/ci-watch.yml
@@ -1,0 +1,80 @@
+name: CI Watch
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  receipt:
+    name: Classify and publish receipt
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Collect run evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          mkdir -p /tmp/ci-watch/logs
+          gh api "repos/$GH_REPO/actions/runs/$RUN_ID" > /tmp/ci-watch/run.json
+          gh api "repos/$GH_REPO/actions/runs/$RUN_ID/jobs?per_page=100" > /tmp/ci-watch/jobs.json
+          jq -r '.jobs[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral") | .id' \
+            /tmp/ci-watch/jobs.json | while read -r job_id; do
+              gh api "repos/$GH_REPO/actions/jobs/$job_id/logs" > "/tmp/ci-watch/logs/$job_id.log" || true
+            done
+      - id: classify
+        name: Classify evidence
+        run: |
+          python3 scripts/ci/ci_watch_receipt.py \
+            --run /tmp/ci-watch/run.json \
+            --jobs /tmp/ci-watch/jobs.json \
+            --logs /tmp/ci-watch/logs \
+            --receipt-json /tmp/ci-watch/receipt.json \
+            --receipt-md /tmp/ci-watch/receipt.md
+      - name: Publish PR receipt
+        if: steps.classify.outputs.status != 'SUPERSEDED'
+        uses: actions/github-script@v7
+        env:
+          RECEIPT_PATH: /tmp/ci-watch/receipt.md
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync(process.env.RECEIPT_PATH, 'utf8');
+            const issue_number = Number(process.env.PR_NUMBER);
+            const marker = '<!-- sounio-ci-watch -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previous = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body?.includes(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: bash scripts/dev/worktree_branch_audit.sh --check
       - name: Compiler lane status contract
         run: bash scripts/ci/compiler_lane_status_gate.sh
+      - name: CI watch receipt self-test
+        run: python3 scripts/ci/ci_watch_receipt_selftest.py
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 941
-- Repo-backed topics: 791
+- Total governed topics: 942
+- Repo-backed topics: 792
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 541
+- Authority count `repo_only`: 542
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 560 topics
+- A2: 561 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -407,6 +407,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.readme | repo_only | docs/internal/concepts/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.semantic-lane-contract | repo_only | docs/internal/concepts/SEMANTIC_LANE_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.zero-provenance | repo_only | docs/internal/concepts/zero-provenance.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.coordination.ci-watch-contract | repo_only | docs/internal/coordination/CI_WATCH_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.compiler-lane-contract | repo_only | docs/internal/coordination/COMPILER_LANE_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.enir-semantic-interface-contract-2026-07-12 | repo_only | docs/internal/coordination/enir-semantic-interface-contract-2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.coordination.semantic-hotspot-triage-2026-07-12 | repo_only | docs/internal/coordination/semantic-hotspot-triage-2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8840,6 +8840,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.coordination.ci-watch-contract",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/coordination/CI_WATCH_CONTRACT.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.coordination.compiler-lane-contract",
       "collection": "repo",
       "repo_doc_path": "docs/internal/coordination/COMPILER_LANE_CONTRACT.md",

--- a/docs/internal/coordination/CI_WATCH_CONTRACT.md
+++ b/docs/internal/coordination/CI_WATCH_CONTRACT.md
@@ -1,0 +1,37 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.coordination.ci-watch-contract
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.coordination.ci-watch-contract
+-->
+
+# Asynchronous CI Watch Contract
+
+No human or principal agent waits for CI. A low-cost, event-driven watcher
+observes completed CI runs and interrupts creative work only when new evidence
+exists.
+
+The watcher emits one of four public receipts:
+
+- `GREEN`: selected checks passed and repository policy may permit merge.
+- `FIXABLE`: a code or contract gate failed with evidence an owning lane can
+  reproduce.
+- `BLOCKED`: the run lacks a trustworthy code verdict because of runner,
+  credential, quota, or infrastructure failure.
+- `TIMEOUT`: a selected job exceeded its declared execution window.
+
+Cancelled superseded runs are silent. The current CI concurrency policy owns
+cancellation; the watcher records no obsolete verdict.
+
+The watcher may read Actions metadata and logs, classify operational evidence,
+and create or update one receipt comment on the associated pull request. It may
+not write repository contents, merge a pull request, change compiler semantics,
+repair scientific code, or promote a scientific claim. `GITHUB_TOKEN`
+permissions are restricted accordingly.
+
+When a receipt is not `GREEN`, a capable agent receives the failed jobs, a
+bounded evidence excerpt, and the next operational action. That agent remains
+responsible for reproducing the focused gate and deciding whether any patch is
+semantically valid.

--- a/scripts/ci/ci_watch_receipt.py
+++ b/scripts/ci/ci_watch_receipt.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Classify a completed GitHub Actions run and emit a short CI receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+
+
+BLOCKED_PATTERNS = (
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"no space left on device",
+        r"hosted runner.*(lost|offline|unavailable)",
+        r"runner.*communication.*lost",
+        r"resource not accessible by integration",
+        r"bad credentials",
+        r"authentication failed",
+        r"rate limit exceeded",
+        r"quota.*exceeded",
+        r"secret.*(not set|unavailable|missing)",
+    )
+)
+BLOCKED_PATTERNS = tuple(BLOCKED_PATTERNS)
+
+
+def classify(run: dict, jobs: list[dict], logs: str) -> tuple[str, str]:
+    conclusion = run.get("conclusion", "")
+    job_conclusions = {job.get("conclusion", "") for job in jobs}
+    if conclusion == "success":
+        return "GREEN", "All selected checks passed; ready for merge subject to repository policy."
+    if conclusion == "cancelled":
+        return "SUPERSEDED", "Cancelled runs are silent because a newer run owns the evidence."
+    if conclusion == "timed_out" or "timed_out" in job_conclusions:
+        return "TIMEOUT", "Inspect the last completed step and reduce or split the bounded gate."
+    if conclusion in {"action_required", "startup_failure", "stale"}:
+        return "BLOCKED", "The run did not reach a trustworthy code verdict; inspect runner or repository infrastructure."
+    if any(pattern.search(logs) for pattern in BLOCKED_PATTERNS):
+        return "BLOCKED", "Retry only after the runner, credential, quota, or infrastructure condition changes."
+    return "FIXABLE", "Open the failed job receipt, reproduce its focused gate, and patch the owning lane."
+
+
+def evidence_lines(logs: str) -> list[str]:
+    selected: list[str] = []
+    for raw in logs.splitlines():
+        line = re.sub(r"\x1b\[[0-9;]*m", "", raw).strip()
+        if not line or not re.search(r"(^|\W)(error|failed|failure|timeout|timed out)(\W|$)", line, re.IGNORECASE):
+            continue
+        line = line.replace("`", "'")
+        selected.append(line[-240:])
+    return selected[-3:]
+
+
+def render(run: dict, jobs: list[dict], logs: str) -> tuple[dict, str]:
+    status, next_action = classify(run, jobs, logs)
+    failed = [
+        job.get("name", "unnamed")
+        for job in jobs
+        if job.get("conclusion") not in {"success", "skipped", "neutral", None, ""}
+    ]
+    receipt = {
+        "schema": "sounio.ci-watch-receipt.v1",
+        "status": status,
+        "run_id": run.get("id"),
+        "head_sha": run.get("head_sha"),
+        "url": run.get("html_url"),
+        "failed_jobs": failed,
+        "next_action": next_action,
+    }
+    lines = [
+        "<!-- sounio-ci-watch -->",
+        f"**CI Watch: {status}**",
+        "",
+        f"Run: [{run.get('id', 'unknown')}]({run.get('html_url', '#')})  ",
+        f"Head: `{str(run.get('head_sha', 'unknown'))[:12]}`  ",
+        f"Failed jobs: `{', '.join(failed) if failed else 'none'}`",
+        "",
+        f"Next action: {next_action}",
+    ]
+    evidence = evidence_lines(logs)
+    if evidence:
+        lines.extend(("", "Evidence:"))
+        lines.extend(f"- `{line}`" for line in evidence)
+    lines.extend(("", "This watcher observes CI only. It cannot merge, edit code, or decide scientific semantics."))
+    return receipt, "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run", required=True, type=Path)
+    parser.add_argument("--jobs", required=True, type=Path)
+    parser.add_argument("--logs", required=True, type=Path)
+    parser.add_argument("--receipt-json", required=True, type=Path)
+    parser.add_argument("--receipt-md", required=True, type=Path)
+    args = parser.parse_args()
+
+    run = json.loads(args.run.read_text())
+    jobs_payload = json.loads(args.jobs.read_text())
+    jobs = jobs_payload.get("jobs", jobs_payload if isinstance(jobs_payload, list) else [])
+    logs = "\n".join(path.read_text(errors="replace") for path in sorted(args.logs.glob("*.log")))
+    receipt, markdown = render(run, jobs, logs)
+    args.receipt_json.write_text(json.dumps(receipt, indent=2) + "\n")
+    args.receipt_md.write_text(markdown)
+
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as handle:
+            handle.write(f"status={receipt['status']}\n")
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/ci_watch_receipt_selftest.py
+++ b/scripts/ci/ci_watch_receipt_selftest.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("ci_watch_receipt.py")
+SPEC = importlib.util.spec_from_file_location("ci_watch_receipt", MODULE_PATH)
+assert SPEC and SPEC.loader
+WATCH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(WATCH)
+
+
+def check(expected: str, conclusion: str, jobs=None, logs: str = "") -> None:
+    status, _ = WATCH.classify(
+        {"conclusion": conclusion}, jobs or [], logs
+    )
+    assert status == expected, (expected, status)
+
+
+check("GREEN", "success")
+check("SUPERSEDED", "cancelled")
+check("TIMEOUT", "failure", [{"conclusion": "timed_out"}])
+check("BLOCKED", "failure", logs="The hosted runner is unavailable")
+check("BLOCKED", "startup_failure")
+check("FIXABLE", "failure", logs="assertion failed: expected 3, got 2")
+
+receipt, markdown = WATCH.render(
+    {"conclusion": "failure", "id": 42, "head_sha": "abcdef123456", "html_url": "https://example.test/run/42"},
+    [{"name": "Contracts", "conclusion": "failure"}],
+    "error: registry is stale",
+)
+assert receipt["status"] == "FIXABLE"
+assert "CI Watch: FIXABLE" in markdown
+assert "cannot merge, edit code" in markdown
+print("CI_WATCH_RECEIPT_SELFTEST_PASS")


### PR DESCRIPTION
## Contract

No human or principal agent waits for CI. A deterministic `workflow_run` watcher classifies completed CI evidence and updates one short PR receipt.

Public states:
- `GREEN`: selected checks passed
- `FIXABLE`: reproducible code or contract failure
- `BLOCKED`: runner, credential, quota, or infrastructure condition
- `TIMEOUT`: declared execution window exceeded

Superseded cancelled runs are silent. The watcher has read access to Actions and no repository-content write or merge permission. It cannot decide compiler semantics or scientific claims.

## Proof

- `python3 scripts/ci/ci_watch_receipt_selftest.py`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/ci/check_parallel_blocker_contract.sh`
- `git diff --check`

All passed locally. The watcher itself becomes active only after this bootstrap PR reaches the default branch.