### PR TITLE
fix(arm64): restore nested deref stores and standalone builtin binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
           "$SOUC_STAGE2" self-hosted/compiler/lean_single.sio "$MACOS_OUT" --target aarch64-macos
           chmod +x "$MACOS_OUT"
           file "$MACOS_OUT" | grep -E "Mach-O 64-bit.*arm64.*executable|Mach-O 64-bit.*executable.*arm64"
+      - name: Cross-compile ARM64 nested-store witness
+        env:
+          SOUNIO_ARM64_WITNESS_COMPILER: /tmp/sounio-source-bootstrap-selfhost-linux-x86_64/artifacts/souc-stage2
+          SOUNIO_ARM64_WITNESS_DIR: /tmp/sounio-arm64-nested-store-witness
+          SOUNIO_ARM64_WITNESS_MODE: attest
+        run: bash scripts/ci/arm64_nested_store_witness_gate.sh
       - name: Source-bootstrap modular typecheck proof
         run: |
           SOUC_STAGE2=/tmp/sounio-source-bootstrap-selfhost-linux-x86_64/artifacts/souc-stage2
@@ -172,6 +178,7 @@ jobs:
           path: |
             /tmp/sounio-source-bootstrap-selfhost-linux-x86_64
             /tmp/sounio-source-bootstrap-native-typecheck-proof
+            /tmp/sounio-arm64-nested-store-witness
           retention-days: 1
 
   native-selfhost-macos-arm64:

--- a/scripts/ci/arm64_nested_store_witness_gate.sh
+++ b/scripts/ci/arm64_nested_store_witness_gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MODE="${SOUNIO_ARM64_WITNESS_MODE:-attest}"
+COMPILER="${SOUNIO_ARM64_WITNESS_COMPILER:-${1:-}}"
+OUT_DIR="${SOUNIO_ARM64_WITNESS_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/sounio-arm64-nested-store.XXXXXX")}"
+SOURCE="tests/run-pass/nested_ref_field_array_store.sio"
+TARGET="aarch64-macos"
+BIN="$OUT_DIR/nested-ref-field-array-store"
+COMPILE_LOG="$OUT_DIR/compile.log"
+RUN_LOG="$OUT_DIR/run.log"
+SUMMARY="$OUT_DIR/summary.txt"
+
+if [[ -z "$COMPILER" || ! -x "$COMPILER" ]]; then
+  echo "error: set SOUNIO_ARM64_WITNESS_COMPILER to an executable source-fresh compiler" >&2
+  exit 2
+fi
+if [[ "$MODE" != "attest" && "$MODE" != "execute" ]]; then
+  echo "error: SOUNIO_ARM64_WITNESS_MODE must be attest or execute" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+"$COMPILER" "$SOURCE" "$BIN" --target "$TARGET" >"$COMPILE_LOG" 2>&1
+chmod +x "$BIN" 2>/dev/null || true
+
+FILE_KIND="$(file "$BIN")"
+if [[ ! "$FILE_KIND" =~ Mach-O\ 64-bit.*arm64.*executable && ! "$FILE_KIND" =~ Mach-O\ 64-bit.*executable.*arm64 ]]; then
+  echo "error: witness is not a Mach-O arm64 executable: $FILE_KIND" >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "attest" ]]; then
+  cat >"$SUMMARY" <<EOF
+status=ATTESTED
+mode=attest
+target=$TARGET
+source=$SOURCE
+compiler=$COMPILER
+artifact=$BIN
+semantic_execution=not_run
+EOF
+  echo "ARM64_NESTED_STORE_WITNESS_ATTESTED target=$TARGET semantic_execution=not_run"
+  echo "ARM64_NESTED_STORE_WITNESS_ARTIFACT_DIR=$OUT_DIR"
+  exit 0
+fi
+
+HOST_OS="$(uname -s 2>/dev/null || echo unknown)"
+HOST_ARCH="$(uname -m 2>/dev/null || echo unknown)"
+if [[ "$HOST_OS:$HOST_ARCH" != "Darwin:arm64" && "$HOST_OS:$HOST_ARCH" != "Darwin:aarch64" ]]; then
+  echo "error: execute mode requires Apple Silicon; host=$HOST_OS:$HOST_ARCH" >&2
+  exit 2
+fi
+
+if [[ -f scripts/lib/macos_codesign.sh ]]; then
+  # shellcheck source=/dev/null
+  source scripts/lib/macos_codesign.sh
+  sounio_ad_hoc_codesign "$BIN"
+fi
+
+set +e
+"$BIN" >"$RUN_LOG" 2>&1
+RUN_RC=$?
+set -e
+if [[ $RUN_RC -ne 0 || "$(cat "$RUN_LOG")" != "PASS" ]]; then
+  echo "error: ARM64 nested-store witness failed with rc=$RUN_RC" >&2
+  cat "$RUN_LOG" >&2
+  exit 1
+fi
+
+cat >"$SUMMARY" <<EOF
+status=EXECUTED
+mode=execute
+target=$TARGET
+source=$SOURCE
+compiler=$COMPILER
+artifact=$BIN
+semantic_execution=pass
+EOF
+echo "ARM64_NESTED_STORE_WITNESS_EXECUTED target=$TARGET semantic_execution=pass"
+echo "ARM64_NESTED_STORE_WITNESS_ARTIFACT_DIR=$OUT_DIR"

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -35606,6 +35606,194 @@ fn compile_stmt_a64() with IO, Mut, Panic, Div {
         }
         return
     }
+    // (*name).field1.field2 = expr — two-level nested field store through a *mut/ref.
+    // a64 mirror of compile_deref_field_field_store_x86. WITHOUT this, `(*c).env.count = X`
+    // (env is an inline sub-struct) fell to the generic assignment path, which materialised
+    // the intermediate INLINE field as a value-copy, wrote into the copy, and discarded it —
+    // so the checker env.count never incremented (read back 0) and the runtime-builtin
+    // bindings (Some/None/…) were lost → standalone files (no imports) E137'd.
+    if stmt_is_deref_field_field_store(EP) {
+        let ff_name_tok = EP + 2
+        let ff_field1_tok = EP + 5
+        let ff_field2_tok = EP + 7
+        if current_fn_allows_mutation() == false {
+            tc_effect_violation(ff_field2_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+        }
+        let ff_ns = TS[ff_name_tok as usize]
+        let ff_ne = TE[ff_name_tok as usize]
+        let ff_h1 = gl_name_hash(TS[ff_field1_tok as usize], TE[ff_field1_tok as usize])
+        let ff_h2 = gl_name_hash(TS[ff_field2_tok as usize], TE[ff_field2_tok as usize])
+        EP = EP + 9
+        compile_or_a64()
+        let ff_rhs_ty = EXPR_TY
+        let ff_rhs_hash = EXPR_TY_HASH
+        let ff_lslot = var_find(ff_ns, ff_ne)
+        if ff_lslot < 0 {
+            tc_undefined_var(ff_name_tok)
+            return
+        }
+        let ff_lvi = var_find_idx(ff_ns, ff_ne)
+        if ff_lvi < 0 || type_is_pointer_like(VAR_TY[ff_lvi as usize], VAR_TY_HASH[ff_lvi as usize]) == false {
+            tc_error(ff_field1_tok, "field access through deref requires ref or pointer binding")
+            return
+        }
+        let ff_inner_ty = ptr_hash_inner_ty(VAR_TY_HASH[ff_lvi as usize])
+        let ff_inner_hash = ptr_hash_inner_hash(VAR_TY_HASH[ff_lvi as usize])
+        if ff_inner_ty != 6 {
+            tc_error(ff_field1_tok, "field access through pointer/ref requires struct pointee")
+            return
+        }
+        let ff_si1 = st_find(ff_inner_hash)
+        if ff_si1 < 0 {
+            tc_error(ff_field1_tok, "unknown field access")
+            return
+        }
+        if st_private_access_denied(ff_si1, ff_field1_tok) {
+            tc_error_hard(ff_field1_tok, "private struct field access")
+            return
+        }
+        ST_QUERY_NS = TS[ff_field1_tok as usize]
+        ST_QUERY_NE = TE[ff_field1_tok as usize]
+        let ff_foff1 = st_field_offset(ff_si1, ff_h1)
+        let ff_fty1 = st_field_ty(ff_si1, ff_h1)
+        let ff_fhash1 = st_field_hash(ff_si1, ff_h1)
+        ST_QUERY_NS = -1
+        ST_QUERY_NE = -1
+        if ff_foff1 < 0 {
+            tc_error(ff_field1_tok, "unknown field access")
+            return
+        }
+        if ff_fty1 != 6 {
+            tc_error(ff_field2_tok, "field access through pointer/ref requires struct pointee")
+            return
+        }
+        let ff_si2 = st_find(ff_fhash1)
+        if ff_si2 < 0 {
+            tc_error(ff_field2_tok, "unknown field access")
+            return
+        }
+        if st_private_access_denied(ff_si2, ff_field2_tok) {
+            tc_error_hard(ff_field2_tok, "private struct field access")
+            return
+        }
+        ST_QUERY_NS = TS[ff_field2_tok as usize]
+        ST_QUERY_NE = TE[ff_field2_tok as usize]
+        let ff_foff2 = st_field_offset(ff_si2, ff_h2)
+        let ff_fty2 = st_field_ty(ff_si2, ff_h2)
+        let ff_fhash2 = st_field_hash(ff_si2, ff_h2)
+        ST_QUERY_NS = -1
+        ST_QUERY_NE = -1
+        if ff_foff2 < 0 {
+            tc_error(ff_field2_tok, "unknown field access")
+            return
+        }
+        if ty_eq(ff_fty2, ff_fhash2, ff_rhs_ty, ff_rhs_hash) == false {
+            tc_error(EP - 1, "assignment type mismatch")
+        } else {
+            emit_store_to_pointer_offset_a64(ff_lslot, ff_foff1 + ff_foff2, ff_fty2, ff_fhash2)
+        }
+        return
+    }
+    // (*name).field1.field2[idx] = expr — two-level nested ARRAY-field store through a
+    // *mut/ref. a64 mirror of compile_deref_field_field_array_store_x86. WITHOUT this,
+    // `(*c).env.bindings[idx] = TypeBinding{…}` fell to the generic path and wrote nowhere,
+    // so bound builtins were lost. Base = ptr + off(field1) + off(field2); element by idx.
+    if stmt_is_deref_field_field_array_store(EP) {
+        let fa_name_tok = EP + 2
+        let fa_ns = TS[fa_name_tok as usize]
+        let fa_ne = TE[fa_name_tok as usize]
+        let fa_field1_tok = EP + 5
+        let fa_field2_tok = EP + 7
+        let fa_h1 = gl_name_hash(TS[fa_field1_tok as usize], TE[fa_field1_tok as usize])
+        let fa_h2 = gl_name_hash(TS[fa_field2_tok as usize], TE[fa_field2_tok as usize])
+        if current_fn_allows_mutation() == false {
+            tc_effect_violation(fa_field2_tok, 2, FN_EFFECTS[CURRENT_FN as usize])
+        }
+        EP = EP + 9
+        compile_or_a64()
+        if TK[EP as usize] == 37 { EP = EP + 1; EP = EP + 1 }
+        if TK[EP as usize] == 42 { EP = EP + 1 }
+        if TK[EP as usize] == 16 { EP = EP + 1 }
+        emit_push_a64()
+        compile_or_a64()
+        let fa_rhs_ty = EXPR_TY
+        let fa_rhs_hash = EXPR_TY_HASH
+        let fa_lslot = var_find(fa_ns, fa_ne)
+        let fa_lvi = var_find_idx(fa_ns, fa_ne)
+        if fa_lslot < 0 || fa_lvi < 0 || type_is_pointer_like(VAR_TY[fa_lvi as usize], VAR_TY_HASH[fa_lvi as usize]) == false {
+            tc_error(fa_field1_tok, "field access through deref requires ref or pointer binding")
+            emit_pop_x1_a64()
+            return
+        }
+        let fa_inner_ty = ptr_hash_inner_ty(VAR_TY_HASH[fa_lvi as usize])
+        let fa_inner_hash = ptr_hash_inner_hash(VAR_TY_HASH[fa_lvi as usize])
+        if fa_inner_ty != 6 {
+            tc_error(fa_field1_tok, "field access through pointer/ref requires struct pointee")
+            emit_pop_x1_a64()
+            return
+        }
+        let fa_si1 = st_find(fa_inner_hash)
+        if fa_si1 < 0 {
+            tc_error(fa_field1_tok, "unknown field access")
+            emit_pop_x1_a64()
+            return
+        }
+        if st_private_access_denied(fa_si1, fa_field1_tok) {
+            tc_error_hard(fa_field1_tok, "private struct field access")
+            emit_pop_x1_a64()
+            return
+        }
+        ST_QUERY_NS = TS[fa_field1_tok as usize]
+        ST_QUERY_NE = TE[fa_field1_tok as usize]
+        let fa_foff1 = st_field_offset(fa_si1, fa_h1)
+        let fa_fty1 = st_field_ty(fa_si1, fa_h1)
+        let fa_fhash1 = st_field_hash(fa_si1, fa_h1)
+        ST_QUERY_NS = -1
+        ST_QUERY_NE = -1
+        if fa_foff1 < 0 || fa_fty1 != 6 {
+            tc_error(fa_field2_tok, "field access through pointer/ref requires struct pointee")
+            emit_pop_x1_a64()
+            return
+        }
+        let fa_si2 = st_find(fa_fhash1)
+        if fa_si2 < 0 {
+            tc_error(fa_field2_tok, "unknown field access")
+            emit_pop_x1_a64()
+            return
+        }
+        if st_private_access_denied(fa_si2, fa_field2_tok) {
+            tc_error_hard(fa_field2_tok, "private struct field access")
+            emit_pop_x1_a64()
+            return
+        }
+        ST_QUERY_NS = TS[fa_field2_tok as usize]
+        ST_QUERY_NE = TE[fa_field2_tok as usize]
+        let fa_foff2 = st_field_offset(fa_si2, fa_h2)
+        let fa_fty2 = st_field_ty(fa_si2, fa_h2)
+        let fa_fhash2 = st_field_hash(fa_si2, fa_h2)
+        ST_QUERY_NS = -1
+        ST_QUERY_NE = -1
+        if fa_fty2 != 8 {
+            tc_error(fa_field2_tok, "indexed field store requires array field")
+            emit_pop_x1_a64()
+            return
+        }
+        if ty_eq(arr_hash_elem_ty(fa_fhash2), arr_hash_elem_hash(fa_fhash2), fa_rhs_ty, fa_rhs_hash) == false {
+            tc_error(EP - 1, "assignment type mismatch")
+        }
+        materialize_aggregate_array_element_a64(fa_fhash2)
+        em32(0xAA0003EA)  // mov x10, x0 (value)
+        emit_pop_x1_a64()  // x1 = index
+        emit_load_var_a64(fa_lslot)  // x0 = base pointer
+        let fa_total_off = fa_foff1 + fa_foff2
+        if fa_total_off != 0 {
+            emit_imm64_reg_a64(11, fa_total_off)
+            em32(0x8B0B0000)  // add x0, x0, x11
+        }
+        if arr_hash_esiz(fa_fhash2) == 8 { em32(0xF821780A) }
+        else { em32(0x3821680A) }
+        return
+    }
     // (*PTR).field = expr
     if stmt_is_deref_field_store(EP) {
         let name_tok = EP + 2

--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -866,7 +866,37 @@ impl Parser {
                 p = pb
             } else {
                 p = p.parse_expr()
-                // body in LAST_EXPR
+                // Un-braced assignment as a match arm body: `Pat => c = expr`.
+                // parse_expr stops at the assignment operator (assignments are
+                // statements, not expressions in the Pratt grammar), leaving only
+                // the lvalue in LAST_EXPR. Parse the rest as an assignment and wrap
+                // it in an implicit block — mirroring the braced `{ c = expr }` case
+                // that parse_block already handles.
+                if parser_assign_op_code(p) >= 0 {
+                    let assign_target = parser_take_expr_box()
+                    let assign_op_c = parser_assign_op_code(p)
+                    p = p.advance()  // skip the assignment operator
+                    p = p.parse_expr()
+                    let assign_rhs = parser_take_expr_box()
+                    let assign_span = p.span_from(arm_start)
+                    let assign_stmt = Stmt {
+                        kind: StmtKind::StmtAssign,
+                        span: assign_span,
+                        name: empty_name(),
+                        ty: None,
+                        expr: Some(assign_rhs),
+                        target: Some(assign_target),
+                        assign_op: assign_op_from_code(assign_op_c),
+                    }
+                    let assign_blk = Block {
+                        stmts: Some(Box::new(StmtList { head: assign_stmt, tail: None })),
+                        span: assign_span,
+                    }
+                    var abe = mk_expr(ExprKind::ExprBlock, assign_span)
+                    abe.block = Some(Box::new(assign_blk))
+                    parser_store_expr_box(Box::new(abe))
+                }
+                // body in LAST_EXPR (plain expr, or the wrapped assignment block)
             }
             let body_box = parser_take_expr_box()
             let arm = MatchArm { pattern: pattern, guard: guard_opt, body: *body_box, span: p.span_from(arm_start) }

--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -454,7 +454,7 @@ fn parse_assign_op(kind: TokenKind) -> AssignOp {
     }
 }
 
-fn assign_op_from_code(code: i64) -> AssignOp {
+pub fn assign_op_from_code(code: i64) -> AssignOp {
     if code == 1 { return AssignOp::AssignAdd }
     if code == 2 { return AssignOp::AssignSub }
     if code == 3 { return AssignOp::AssignMul }

--- a/tests/run-pass/match_arm_unbraced_assignment.sio
+++ b/tests/run-pass/match_arm_unbraced_assignment.sio
@@ -1,0 +1,10 @@
+//@ run-pass
+
+fn main() -> i32 with Mut {
+    var result: i64 = 0
+    match 7 {
+        7 => result = 41
+        _ => result = 1
+    }
+    if result == 41 { 0 } else { 1 }
+}


### PR DESCRIPTION
## Estado

Draft de coordenação para dois commits limpos já publicados:

1. `653e9883c` aceita assignment sem chaves como corpo de match arm.
2. `5b6c4dc57` porta para AArch64 os stores `(*p).f1.f2 =` e `(*p).f1.f2[i] =`.

## Evidência existente

Os commit receipts registram verificação em Apple Silicon: contagem do builtin environment volta de `0 -> 0 -> 0` para `0 -> 11 -> 15`, fixtures Some/None/str_concat/heap_alloc passam, x86 permanece byte-identical e stage2 == stage3.

Essa evidência ainda está apenas no receipt dos commits e em artefatos locais não rastreados.

## Antes de promover

- versionar witness mínimo para o match arm `None => c = foo(c)`
- versionar witness AArch64 para nested field e nested field-array stores
- ligar os witnesses a um gate focado executável no runner adequado
- decidir se o parser target-independent deve ser um PR separado ou permanecer como pré-requisito causal explícito
- não adicionar `artifacts/apple/lean.arm64` ao PR

Até esses pontos serem satisfeitos, o estado correto é `DRAFT / E2 hardware receipt`, não merge-ready.