### PR TITLE
fix(specializer): raise generic tracking cap to 256

### DIFF
--- a/self-hosted/check/specializer.sio
+++ b/self-hosted/check/specializer.sio
@@ -125,13 +125,13 @@ struct SpecStructDefStage { sd: StructDef }
 // process (preflight + IR-lowering both invoke it on independently
 // re-parsed item lists), so no state may leak across invocations.
 var SPEC_GF_COUNT: i64 = 0
-var SPEC_GF_PTRS: [i64; 16] = [0; 16]
-var SPEC_GF_NEEDED: [bool; 16] = [false; 16]
-var SPEC_GF_INST_HASH: [i64; 16] = [0; 16]
-var SPEC_GF_POISONED: [bool; 16] = [false; 16]
-var SPEC_GF_CLONE_PTR: [i64; 16] = [0; 16]
+var SPEC_GF_PTRS: [i64; 256] = [0; 256]
+var SPEC_GF_NEEDED: [bool; 256] = [false; 256]
+var SPEC_GF_INST_HASH: [i64; 256] = [0; 256]
+var SPEC_GF_POISONED: [bool; 256] = [false; 256]
+var SPEC_GF_CLONE_PTR: [i64; 256] = [0; 256]
 var SPEC_ST_COUNT: i64 = 0
-var SPEC_ST_PTRS: [i64; 16] = [0; 16]
+var SPEC_ST_PTRS: [i64; 256] = [0; 256]
 var SPEC_EMITTED_HASHES: [i64; 64] = [0; 64]
 var SPEC_EMITTED_COUNT: i64 = 0
 var SPEC_EXTRA_HEAD: i64 = 0
@@ -140,7 +140,7 @@ fn spec_reset_state() with Mut {
     SPEC_EMITTED_COUNT = 0
     SPEC_EXTRA_HEAD = 0
     var i: i64 = 0
-    while i < 16 {
+    while i < 256 {
         SPEC_GF_PTRS[i as usize] = 0
         SPEC_GF_NEEDED[i as usize] = false
         SPEC_GF_INST_HASH[i as usize] = 0
@@ -424,7 +424,7 @@ fn spec_collect_generic_structs(items: Option<Box<ItemList>>) with Mut, Panic, D
                 match it.struct_def {
                     Some(sd_box) => {
                         let tp_count = spec_struct_tp_count_of((*sd_box).type_params)
-                        if tp_count > 0 && tp_count <= 4 && SPEC_ST_COUNT < 16 && spec_struct_table_find(it.name) < 0 {
+                        if tp_count > 0 && tp_count <= 4 && SPEC_ST_COUNT < 256 && spec_struct_table_find(it.name) < 0 {
                             let slot = SPEC_ST_COUNT
                             let p = heap_alloc(4096) as *mut SpecStNode
                             (*p).name_hash = ast_name_hash(it.name)
@@ -455,7 +455,7 @@ fn spec_collect_generic_fns(items: Option<Box<ItemList>>, known: SpecKnownNames)
                 match it.fn_def {
                     Some(fd_box) => {
                         let tp = spec_collect_free_vars_from_fndef((*fd_box), known)
-                        if tp.count > 0 && SPEC_GF_COUNT < 16 && spec_generic_table_find(it.name) < 0 {
+                        if tp.count > 0 && SPEC_GF_COUNT < 256 && spec_generic_table_find(it.name) < 0 {
                             let slot = SPEC_GF_COUNT
                             let p = heap_alloc(4096) as *mut SpecGfNode
                             (*p).name_hash = ast_name_hash(it.name)

--- a/tests/run-pass/specializer_many_generic_fns.sio
+++ b/tests/run-pass/specializer_many_generic_fns.sio
@@ -1,0 +1,36 @@
+//@ run-pass
+// Regression guard: the AST specializer must handle MORE than 16 distinct generic
+// functions. The SPEC_GF_* tables were fixed at [_; 16]; a program with >16
+// instantiated generic fns silently left the overflow ones un-monomorphized
+// (symbolic type params -> E008 / codegen crash). Cap raised to 256. This
+// instantiates 20 distinct generic fns and verifies their sum.
+struct W<T> { v: T }
+fn g0<T>(x: T) -> W<T> { W { v: x } }
+fn g1<T>(x: T) -> W<T> { W { v: x } }
+fn g2<T>(x: T) -> W<T> { W { v: x } }
+fn g3<T>(x: T) -> W<T> { W { v: x } }
+fn g4<T>(x: T) -> W<T> { W { v: x } }
+fn g5<T>(x: T) -> W<T> { W { v: x } }
+fn g6<T>(x: T) -> W<T> { W { v: x } }
+fn g7<T>(x: T) -> W<T> { W { v: x } }
+fn g8<T>(x: T) -> W<T> { W { v: x } }
+fn g9<T>(x: T) -> W<T> { W { v: x } }
+fn g10<T>(x: T) -> W<T> { W { v: x } }
+fn g11<T>(x: T) -> W<T> { W { v: x } }
+fn g12<T>(x: T) -> W<T> { W { v: x } }
+fn g13<T>(x: T) -> W<T> { W { v: x } }
+fn g14<T>(x: T) -> W<T> { W { v: x } }
+fn g15<T>(x: T) -> W<T> { W { v: x } }
+fn g16<T>(x: T) -> W<T> { W { v: x } }
+fn g17<T>(x: T) -> W<T> { W { v: x } }
+fn g18<T>(x: T) -> W<T> { W { v: x } }
+fn g19<T>(x: T) -> W<T> { W { v: x } }
+fn main() -> i64 with Mut, Panic {
+    var s: i64 = 0
+    s = s + g0::<i64>(1).v + g1::<i64>(1).v + g2::<i64>(1).v + g3::<i64>(1).v + g4::<i64>(1).v
+    s = s + g5::<i64>(1).v + g6::<i64>(1).v + g7::<i64>(1).v + g8::<i64>(1).v + g9::<i64>(1).v
+    s = s + g10::<i64>(1).v + g11::<i64>(1).v + g12::<i64>(1).v + g13::<i64>(1).v + g14::<i64>(1).v
+    s = s + g15::<i64>(1).v + g16::<i64>(1).v + g17::<i64>(1).v + g18::<i64>(1).v + g19::<i64>(1).v
+    if s != 20 { return 1 }
+    return 0
+}


### PR DESCRIPTION
## Focus

Extracts only the generic function/struct tracking-cap repair from topology-blocked PR #742. No EISA, OD256, IR, imported-generic, or GPU changes are included.

The specializer previously stopped collecting templates after 16 entries. The focused witness instantiates 20 distinct generic functions and verifies the result internally.

## Evidence

- default checked-in compiler: witness fails, demonstrating the old cap
- source-fresh modular Madaros built from this branch: `specializer_many_generic_fns.sio` PASS 1/1
- `git diff --check` PASS

Build used the rebuilt current-source path:

```bash
bash scripts/ci/build_modular_madaros.sh /tmp/sounio-specializer-cap-madaros
SOUC_BIN=/tmp/sounio-specializer-cap-madaros \
  bash scripts/run_sio_test_suite.sh --filter specializer_many_generic_fns --verbose
```

The temporary ELF is not committed. Legacy/prebuilt compiler paths remain untouched.