### PR TITLE
ci: run changed Madaros tests incrementally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
         run: bash scripts/ci/compiler_lane_status_gate.sh
       - name: CI watch receipt self-test
         run: python3 scripts/ci/ci_watch_receipt_selftest.py
+      - name: Madaros changed-test selector self-test
+        run: bash scripts/ci/madaros_changed_tests_selftest.sh
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard
@@ -323,6 +325,32 @@ jobs:
           path: test-results.xml
           retention-days: 30
 
+  madaros-changed-tests:
+    name: Madaros Changed Tests
+    runs-on: ubuntu-24.04
+    needs: [impact, native-selfhost-linux-x86_64]
+    if: always() && (needs.impact.outputs.compiler == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true') && needs.native-selfhost-linux-x86_64.result == 'success'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download native compiler seed
+        uses: actions/download-artifact@v4
+        with:
+          name: native-compiler-linux-x86_64
+          path: /tmp
+      - name: Run changed Madaros tests
+        env:
+          SOUC_BIN: /tmp/souc-stage2
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SOUNIO_TEST_JOBS: 4
+        run: |
+          chmod +x /tmp/souc-stage2
+          bash scripts/ci/madaros_changed_tests_gate.sh
+
   sounio-lint:
     name: Sounio Lint
     needs: impact
@@ -405,6 +433,7 @@ jobs:
       - source-bootstrap-selfhost-linux-x86_64
       - native-selfhost-macos-arm64
       - full-test-suite
+      - madaros-changed-tests
       - sounio-lint
       - lean-proofs
       - website

--- a/scripts/ci/evaluate_ci_decision.py
+++ b/scripts/ci/evaluate_ci_decision.py
@@ -25,6 +25,7 @@ def main() -> int:
         "source-bootstrap-selfhost-linux-x86_64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
         "native-selfhost-macos-arm64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
         "full-test-suite": any(truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")),
+        "madaros-changed-tests": any(truthy(impact.get(key)) for key in ("compiler", "tests", "full")),
         "sounio-lint": any(truthy(impact.get(key)) for key in ("compiler", "stdlib", "tests", "sio", "full")),
         "lean-proofs": truthy(impact.get("lean")) or truthy(impact.get("full")),
         "website": truthy(impact.get("website")) or truthy(impact.get("full")),

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -46,7 +46,7 @@ non_pr="$(CI_EVENT_NAME=push $CLASSIFIER)"
 expect "$non_pr" full true
 expect "$non_pr" compiler true
 
-good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-changed-tests":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 NEEDS_JSON="$good_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 
 bad_needs="${good_needs/\"contracts\":{\"result\":\"success\"}/\"contracts\":{\"result\":\"failure\"}}"
@@ -55,9 +55,15 @@ if NEEDS_JSON="$bad_needs" python3 "$DECISION" >/dev/null 2>&1; then
   exit 1
 fi
 
-stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"madaros-changed-tests":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 if NEEDS_JSON="$stdlib_needs" python3 "$DECISION" >/dev/null 2>&1; then
   echo "impact-ci-selftest: decision accepted stdlib suite without native compiler/full suite" >&2
+  exit 1
+fi
+
+compiler_madaros_failure='{"impact":{"outputs":{"compiler":"true","runtime":"false","stdlib":"false","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"success"},"source-bootstrap-selfhost-linux-x86_64":{"result":"success"},"native-selfhost-macos-arm64":{"result":"success"},"full-test-suite":{"result":"success"},"madaros-changed-tests":{"result":"failure"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+if NEEDS_JSON="$compiler_madaros_failure" python3 "$DECISION" >/dev/null 2>&1; then
+  echo "impact-ci-selftest: decision accepted failed Madaros changed tests" >&2
   exit 1
 fi
 

--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVENT_NAME="${CI_EVENT_NAME:-${GITHUB_EVENT_NAME:-pull_request}}"
+BASE_SHA="${CI_BASE_SHA:-}"
+HEAD_SHA="${CI_HEAD_SHA:-HEAD}"
+SELECT_ONLY=0
+
+if [[ "${1:-}" == "--select-only" ]]; then
+  SELECT_ONLY=1
+  shift
+fi
+
+paths=()
+if (($#)); then
+  paths=("$@")
+elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+  [[ -n "$BASE_SHA" ]] || { echo 'error: CI_BASE_SHA is required for pull_request' >&2; exit 2; }
+  mapfile -t paths < <(git -C "$ROOT_DIR" diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+else
+  # Non-PR runs prove that the modular build and harness remain executable.
+  paths=("tests/run-pass/generic_struct_return.sio")
+fi
+
+selected=()
+for path in "${paths[@]}"; do
+  case "$path" in tests/run-pass/*.sio) ;; *) continue ;; esac
+  [[ -f "$ROOT_DIR/$path" ]] || continue
+  grep -Fq '//@ requires: madaros' "$ROOT_DIR/$path" || continue
+  selected+=("$path")
+done
+
+if [[ "$SELECT_ONLY" == "1" ]]; then
+  printf '%s\n' "${selected[@]}"
+  exit 0
+fi
+
+if ((${#selected[@]} == 0)); then
+  echo 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests'
+  exit 0
+fi
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/sounio-madaros-changed.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+compiler="$work_dir/madaros"
+test_list="$work_dir/tests.txt"
+printf '%s\n' "${selected[@]}" > "$test_list"
+
+echo "MADAROS_CHANGED_TESTS_START count=${#selected[@]}"
+printf 'test=%s\n' "${selected[@]}"
+bash "$ROOT_DIR/scripts/ci/build_modular_madaros.sh" "$compiler"
+
+SOUNIO_MADAROS_AVAILABLE=1 \
+SOUNIO_TEST_SOUC_BIN="$compiler" \
+  bash "$ROOT_DIR/scripts/run_sio_test_suite.sh" --test-list "$test_list" --jobs "${SOUNIO_TEST_JOBS:-4}"
+
+echo "MADAROS_CHANGED_TESTS_PASS count=${#selected[@]}"

--- a/scripts/ci/madaros_changed_tests_selftest.sh
+++ b/scripts/ci/madaros_changed_tests_selftest.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$ROOT_DIR/scripts/ci/madaros_changed_tests_gate.sh"
+
+bash -n "$GATE"
+
+selected="$($GATE --select-only \
+  tests/run-pass/array_repeat_i8_binding.sio \
+  tests/run-pass/generic_struct_return.sio \
+  docs/internal/coordination/CI_WATCH_CONTRACT.md)"
+
+grep -Fxq 'tests/run-pass/array_repeat_i8_binding.sio' <<< "$selected"
+if grep -Fq 'generic_struct_return.sio' <<< "$selected"; then
+  echo 'madaros-changed-tests: selected an unannotated test' >&2
+  exit 1
+fi
+if grep -Fq 'CI_WATCH_CONTRACT.md' <<< "$selected"; then
+  echo 'madaros-changed-tests: selected a path outside tests/run-pass' >&2
+  exit 1
+fi
+
+skip="$($GATE -- docs/internal/coordination/CI_WATCH_CONTRACT.md)"
+grep -Fq 'MADAROS_CHANGED_TESTS_SKIP' <<< "$skip"
+
+echo 'MADAROS_CHANGED_TESTS_SELFTEST_PASS'


### PR DESCRIPTION
## Why

The repository has 613 `//@ requires: madaros` run-pass tests. Full Test Suite correctly skips them because it executes the `lean_single` stage2 compiler, but no remote job currently exercises changed modular-checker witnesses. Running all 613 on every PR would recreate universal-CI latency.

## Contract

- PRs: select only changed `tests/run-pass/*.sio` files with the literal Madaros annotation
- no selected tests: fast successful skip receipt
- push/main/merge queue/manual: rebuild Madaros and execute a fixed smoke
- reuse the native self-host stage2 artifact as the modular build seed
- run in parallel with Full Test Suite
- make the result mandatory through `CI Decision` for compiler/test/full impacts

## Proof

- selector self-test PASS
- Impact/CI Decision self-test PASS, including rejected Madaros failure
- CI watcher self-test PASS
- workflow references PASS
- focused end-to-end: rebuilt Madaros + `array_repeat_i8_binding.sio` PASS 1/1
- `git diff --check` PASS

No compiler source or canonical artifact is changed.