### PR TITLE
test(madaros): #651 array-of-struct witness + exact CD zero-divisor over ℚ

### DIFF
--- a/tests/run-pass/cd_exact_rational_concrete.sio
+++ b/tests/run-pass/cd_exact_rational_concrete.sio
@@ -1,0 +1,109 @@
+//@ run-pass
+//@ requires: madaros
+// Issue #651 — the SCIENCE the issue said was blocked, PROVED on Madaros.
+// Exact Cayley–Dickson product over Rational (ℚ) at k=4 (sedenion, 16 components):
+// the canonical zero-divisor pair (e3+e10)(e6−e15) ANNIHILATES exactly — decidable
+// rational equality, no f64 tolerance — and e1² = −1/1. A 16×16 = 256-iteration loop,
+// far below the 2²⁰ handle-table wrap (#651 Defect A) that only bites the large-N d8 repro.
+//
+// Complements sr_mul_array_of_struct_651.sio (that guards codegen at N=16 with integer
+// coeffs; this proves the actual algebra over ℚ). cd_sigma is INLINED so this stays a
+// SINGLE-module program (import math::rational only): adding a second module import trips
+// the multimodule native thin-link (#651 Defect B) on current Madaros — a leaf cd_sigma
+// module does NOT dodge it (leaf+rational still fails). See
+// docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md.
+use math::rational::{Rational, rat_zero, rat_one, rat_make, rat_add, rat_sub, rat_mul, rat_is_zero, rat_eq}
+
+// Cayley–Dickson twist sign σ(i,j,bits) ∈ {+1,−1}; pure i32, field-independent.
+fn cd_sigma(a: i32, b: i32, bits: i32) -> i32 with Mut, Panic, Div {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return -1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma(0, a_lo, bits - 1) }
+    cd_sigma(b_lo, a_lo, bits - 1)
+}
+
+struct SedR { c: [Rational; 16] }
+
+fn sr_zero() -> SedR with Mut, Panic, Div { SedR { c: [rat_zero(); 16] } }
+
+fn sr_basis(idx: i32) -> SedR with Mut, Panic, Div {
+    var r = sr_zero()
+    r.c[idx as usize] = rat_one()
+    r
+}
+
+fn sr_add(a: SedR, b: SedR) -> SedR with Mut, Panic, Div {
+    var r = sr_zero()
+    var i: i32 = 0
+    while i < 16 {
+        r.c[i as usize] = rat_add(a.c[i as usize], b.c[i as usize])
+        i = i + 1
+    }
+    r
+}
+fn sr_sub(a: SedR, b: SedR) -> SedR with Mut, Panic, Div {
+    var r = sr_zero()
+    var i: i32 = 0
+    while i < 16 {
+        r.c[i as usize] = rat_sub(a.c[i as usize], b.c[i as usize])
+        i = i + 1
+    }
+    r
+}
+
+// (a*b)[i^j] += σ(i,j,4) · a[i]·b[j]
+fn sr_mul(a: SedR, b: SedR) -> SedR with Mut, Panic, Div {
+    var r = sr_zero()
+    var i: i32 = 0
+    while i < 16 {
+        if !rat_is_zero(a.c[i as usize]) {
+            var j: i32 = 0
+            while j < 16 {
+                if !rat_is_zero(b.c[j as usize]) {
+                    let idx = i ^ j
+                    let sign = cd_sigma(i, j, 4)
+                    let prod = rat_mul(a.c[i as usize], b.c[j as usize])
+                    if sign > 0 { r.c[idx as usize] = rat_add(r.c[idx as usize], prod) }
+                    else { r.c[idx as usize] = rat_sub(r.c[idx as usize], prod) }
+                }
+                j = j + 1
+            }
+        }
+        i = i + 1
+    }
+    r
+}
+
+fn sr_is_zero(x: SedR) -> bool with Mut, Panic, Div {
+    var i: i32 = 0
+    while i < 16 {
+        if !rat_is_zero(x.c[i as usize]) { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    let a = sr_add(sr_basis(3), sr_basis(10))
+    let b = sr_sub(sr_basis(6), sr_basis(15))
+    let zd = sr_is_zero(sr_mul(a, b))
+    if zd { print("RAT-ZD PROVED\n") } else { print("RAT-ZD FAIL\n") }
+
+    let sq = sr_mul(sr_basis(1), sr_basis(1))
+    let sqok = rat_eq(sq.c[0 as usize], rat_make(0 - 1, 1))
+    if sqok { print("RAT-SQ PASS\n") } else { print("RAT-SQ FAIL\n") }
+
+    if zd && sqok { return 0 }
+    return 1
+}

--- a/tests/run-pass/sr_mul_array_of_struct_651.sio
+++ b/tests/run-pass/sr_mul_array_of_struct_651.sio
@@ -1,0 +1,50 @@
+//@ run-pass
+//@ requires: madaros
+// Regression guard for issue #651 — the [struct;N] array-of-struct multiply-
+// accumulate loop. This exact shape once miscompiled (N=16 → garbage, N=2048 →
+// SIGSEGV) due to struct-value-copy aliasing; fixed by commit ff7afab69
+// ("value semantics for aggregate ident-init — deep copy, not alias"). This is
+// the single-module, non-generic form (the [i64;N] analogue was always correct)
+// so CI can glob it. If struct-value semantics regress, this prints "651 FAIL".
+//
+// Values chosen so the accumulate crosses several slots: a.c[i]*b.c[i] lands in
+// idx = i^i = 0, so c[0] = 2*3 + 5*7 = 6 + 35 = 41 (den 1 under naive rat_add).
+use math::rational::{Rational, rat_zero, rat_one, rat_add, rat_mul}
+
+struct SmallR { c: [Rational; 16] }
+
+// e_i * e_j accumulate over idx = i XOR j (sign dropped — this guards codegen,
+// not the algebra), writing back into the array-of-struct slot each iteration.
+fn sr_mul(a: SmallR, b: SmallR) -> SmallR with Mut, Panic, Div {
+    var r = SmallR { c: [rat_zero(); 16] }
+    var i: i32 = 0
+    while i < 16 {
+        var j: i32 = 0
+        while j < 16 {
+            let idx = i ^ j
+            r.c[idx as usize] = rat_add(r.c[idx as usize], rat_mul(a.c[i as usize], b.c[j as usize]))
+            j = j + 1
+        }
+        i = i + 1
+    }
+    r
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var a = SmallR { c: [rat_zero(); 16] }
+    var b = SmallR { c: [rat_zero(); 16] }
+    a.c[1 as usize] = Rational { num: 2, den: 1 }
+    b.c[1 as usize] = Rational { num: 3, den: 1 }
+    a.c[2 as usize] = Rational { num: 5, den: 1 }
+    b.c[2 as usize] = Rational { num: 7, den: 1 }
+    let p = sr_mul(a, b)
+    let c0 = p.c[0 as usize]
+    print("c0="); print_int(c0.num); print("/"); print_int(c0.den); print("\n")
+    if c0.num == 41 && c0.den == 1 {
+        print("651 PASS\n")
+        return 0
+    } else {
+        print("651 FAIL\n")
+        return 1
+    }
+}

--- a/tests/run-pass/sr_mul_array_of_struct_651.sio
+++ b/tests/run-pass/sr_mul_array_of_struct_651.sio
@@ -1,11 +1,18 @@
 //@ run-pass
 //@ requires: madaros
 // Regression guard for issue #651 — the [struct;N] array-of-struct multiply-
-// accumulate loop. This exact shape once miscompiled (N=16 → garbage, N=2048 →
-// SIGSEGV) due to struct-value-copy aliasing; fixed by commit ff7afab69
-// ("value semantics for aggregate ident-init — deep copy, not alias"). This is
-// the single-module, non-generic form (the [i64;N] analogue was always correct)
-// so CI can glob it. If struct-value semantics regress, this prints "651 FAIL".
+// accumulate loop at N=16. The N=16 GARBAGE was struct-value-copy aliasing, fixed
+// by commit ff7afab69 ("value semantics for aggregate ident-init — deep copy, not
+// alias"); this test guards that fix. This is the single-module, non-generic form
+// (the [i64;N] analogue was always correct) so CI can glob it. Prints "651 FAIL"
+// if struct-value semantics regress.
+//
+// SCOPE NOTE (corrected 2026-07-14): the N=2048 SIGSEGV is a *separate* defect and
+// is NOT fixed by ff7afab69. It is the native handle-table wrap at 2²⁰ allocations
+// (#651 Defect A; self-hosted/native/gc.sio) — a scalar accumulate loop with zero
+// struct-copy corrupts identically at exactly 2²⁰. A guard at N=16 (256 allocations)
+// can never catch it; asserting the N=2048 case needs runs below AND above 2²⁰.
+// See docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md.
 //
 // Values chosen so the accumulate crosses several slots: a.c[i]*b.c[i] lands in
 // idx = i^i = 0, so c[0] = 2*3 + 5*7 = 6 + 35 = 41 (den 1 under naive rat_add).


### PR DESCRIPTION
## Stacked validation for #815

This PR is intentionally based on `work/madaros-changed-ci`. It is the first real client of the incremental Madaros job.

The historical test from `c7e132ee2` printed `651 FAIL` but still returned success. It now:

- declares `//@ requires: madaros`
- returns `0` only for `c0 = 41/1`
- returns `1` for an incorrect result

## Local evidence

- selector chooses exactly this file
- default/lean_single suite: explicit Madaros skip
- source-fresh modular Madaros: PASS 1/1, `c0=41/1`
- legacy raw engine was observed producing `c0=4206985/1` and `651 FAIL`
- `git diff --check`: PASS

Expected remote behavior: `Madaros Changed Tests` rebuilds the modular compiler and executes this one changed witness.

---

## Added 2026-07-14 (`8d98d1b09`) — exact CD zero-divisor over ℚ + N=2048 scope correction

Reconciles this witness with the #651 root-cause investigation (dispatch: PR #923; issues #919, #921).

- **New `tests/run-pass/cd_exact_rational_concrete.sio`** — proves the science #651 said was blocked:
  the canonical sedenion zero-divisor `(e3+e10)(e6−e15)` annihilates **exactly over ℚ** (decidable
  rational equality, no f64 tolerance) and `e1²=−1/1`, at k=4. Green on Madaros. Single-module
  (cd_sigma inlined) to sidestep the multimodule thin-link failure (#921).
- **Corrects this witness's comment**: `ff7afab69` fixed the N=16 struct-value-copy aliasing, but the
  N=2048 SIGSEGV is a **separate, still-open** defect — the native handle-table wrap at 2²⁰
  allocations (#919). A scalar accumulate with zero struct-copy corrupts identically at exactly 2²⁰,
  so an N=16 guard cannot catch it. Full diagnosis in `docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md` (PR #923).
