### PR TITLE
test(madaros): repair and enforce generic struct-return witness

### DIFF
--- a/tests/run-pass/generic_struct_return_structf.sio
+++ b/tests/run-pass/generic_struct_return_structf.sio
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ requires: madaros
 // Acceptance test 3 for compiler prerequisite #1 (generic-struct-return monomorphization).
 // Tests generic struct return with type parameter instantiated at a user-defined struct.
 // Also tests generic->generic function chaining.
@@ -36,18 +37,18 @@ fn make_cdexact4<F>(c0: F, c1: F, c2: F, c3: F, bits: i64) -> CDExact<F> with Mu
 }
 
 // Generic function returning CDExact<F>
-fn cd_add_generic<F>(a: CDExact<F>, b: CDExact<F>) -> CDExact<F> with Mut {
+fn cd_add_generic<F>(a: CDExact<F>, b: CDExact<F>) -> CDExact<F> with Mut, Panic {
     var out = CDExact { c: a.c, bits: a.bits }
     out
 }
 
 // Generic function that calls another generic function internally.
 // This tests generic->generic chaining.
-fn cd_double_generic<F>(a: CDExact<F>) -> CDExact<F> with Mut {
+fn cd_double_generic<F>(a: CDExact<F>) -> CDExact<F> with Mut, Panic {
     cd_add_generic::<F>(a, a)
 }
 
-fn main() with IO, Mut {
+fn main() -> i64 with IO, Mut, Panic {
     let z = RatLike { num: 0, den: 1 }
     let a = make_cdexact4::<RatLike>(RatLike { num: 3, den: 1 }, z, z, z, 4)
     let b = make_cdexact4::<RatLike>(RatLike { num: 2, den: 1 }, z, z, z, 4)
@@ -60,6 +61,8 @@ fn main() with IO, Mut {
     // cd_add_generic::<F>(a, a) call. We print r.c[0].num to keep the assertion
     // simple: should be 3 (from a.c[0].num).
     let final_val = r.c[0]
+    if final_val.num != 3 { return 1 }
     println(final_val.num)
     println("structf PASS")
+    return 0
 }


### PR DESCRIPTION
## Stacked validation for #815

This test-only PR is based on the incremental Madaros CI branch.

It extracts `66cd83950` and strengthens the witness:

- adds the required `Panic` effect to array-copy/indexing functions
- declares `//@ requires: madaros`
- returns nonzero unless `final_val.num == 3`
- retains the expected printed receipt

## Evidence

- current unpatched test: FAIL under source-fresh Madaros due missing effect
- patched source-fresh Madaros: PASS 1/1
- lean_single: fails during generic struct-literal monomorphization, confirming engine-specific scope
- default suite: explicit Madaros skip
- incremental selector: selects exactly this file
- `git diff --check`: PASS

Expected remote behavior: `Madaros Changed Tests` rebuilds Madaros and executes this witness.