### PR TITLE
parser: accept unbraced assignment match arms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
           "$SOUC_STAGE2" self-hosted/compiler/lean.sio "$CHECK_OUT"
           chmod +x "$CHECK_OUT"
           "$CHECK_OUT" --help | grep -F -- "--check <source.sio>"
+          "$CHECK_OUT" --check tests/run-pass/match_arm_unbraced_assignment.sio
           SOUC_NATIVE="$CHECK_OUT" \
             WORK_DIR=/tmp/sounio-source-bootstrap-native-typecheck-proof \
             bash scripts/selfhost/selfhost_native_typecheck_proof.sh

--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -866,7 +866,37 @@ impl Parser {
                 p = pb
             } else {
                 p = p.parse_expr()
-                // body in LAST_EXPR
+                // Un-braced assignment as a match arm body: `Pat => c = expr`.
+                // parse_expr stops at the assignment operator (assignments are
+                // statements, not expressions in the Pratt grammar), leaving only
+                // the lvalue in LAST_EXPR. Parse the rest as an assignment and wrap
+                // it in an implicit block — mirroring the braced `{ c = expr }` case
+                // that parse_block already handles.
+                if parser_assign_op_code(p) >= 0 {
+                    let assign_target = parser_take_expr_box()
+                    let assign_op_c = parser_assign_op_code(p)
+                    p = p.advance()  // skip the assignment operator
+                    p = p.parse_expr()
+                    let assign_rhs = parser_take_expr_box()
+                    let assign_span = p.span_from(arm_start)
+                    let assign_stmt = Stmt {
+                        kind: StmtKind::StmtAssign,
+                        span: assign_span,
+                        name: empty_name(),
+                        ty: None,
+                        expr: Some(assign_rhs),
+                        target: Some(assign_target),
+                        assign_op: assign_op_from_code(assign_op_c),
+                    }
+                    let assign_blk = Block {
+                        stmts: Some(Box::new(StmtList { head: assign_stmt, tail: None })),
+                        span: assign_span,
+                    }
+                    var abe = mk_expr(ExprKind::ExprBlock, assign_span)
+                    abe.block = Some(Box::new(assign_blk))
+                    parser_store_expr_box(Box::new(abe))
+                }
+                // body in LAST_EXPR (plain expr, or the wrapped assignment block)
             }
             let body_box = parser_take_expr_box()
             let arm = MatchArm { pattern: pattern, guard: guard_opt, body: *body_box, span: p.span_from(arm_start) }

--- a/self-hosted/parser/stmts.sio
+++ b/self-hosted/parser/stmts.sio
@@ -468,7 +468,7 @@ fn parse_assign_op(kind: TokenKind) -> AssignOp {
     }
 }
 
-fn assign_op_from_code(code: i64) -> AssignOp {
+pub fn assign_op_from_code(code: i64) -> AssignOp {
     if code == 1 { return AssignOp::AssignAdd }
     if code == 2 { return AssignOp::AssignSub }
     if code == 3 { return AssignOp::AssignMul }

--- a/tests/run-pass/match_arm_unbraced_assignment.sio
+++ b/tests/run-pass/match_arm_unbraced_assignment.sio
@@ -1,0 +1,10 @@
+//@ run-pass
+
+fn main() -> i32 with Mut {
+    var result: i64 = 0
+    match 7 {
+        7 => result = 41
+        _ => result = 1
+    }
+    if result == 41 { 0 } else { 1 }
+}


### PR DESCRIPTION
## What changed

Teach the modular parser to accept an assignment as an unbraced match-arm body, for example:

```sio
match value {
    7 => result = 41
    _ => result = 1
}
```

`parse_expr` stops before assignment operators because assignment is a statement. The parser now recognizes that remainder and wraps the assignment in the same implicit block shape produced by a braced arm.

## Witness

Adds `tests/run-pass/match_arm_unbraced_assignment.sio` and runs it through the source-fresh modular `lean.sio` compiler already built by the CI typecheck-proof step.

Source-fresh differential proof against `006b9a6e5749`:

- main modular compiler: `rc=1`, `expected=167 actual=124`, `parse_failed`
- patched modular compiler: `rc=0`, `souc-lean check: ok`
- legacy/source seed output is not used as the differential oracle because it does not consume `self-hosted/parser/*`
- `bash scripts/ci/impact_ci_selftest.sh`: PASS

This is target-independent parser work extracted from draft #812. It contains no AArch64 codegen changes.
