### PR TITLE
dev: make compiler build lock portable to macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: bash scripts/dev/worktree_branch_audit.sh --check
       - name: Compiler lane status contract
         run: bash scripts/ci/compiler_lane_status_gate.sh
+      - name: Portable compiler build lock self-test
+        run: python3 scripts/ci/souc_build_lock_selftest.py
       - name: CI watch receipt self-test
         run: python3 scripts/ci/ci_watch_receipt_selftest.py
       - name: Output-path invariants

--- a/scripts/ci/souc_build_lock_selftest.py
+++ b/scripts/ci/souc_build_lock_selftest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Prove that the portable build lock serializes concurrent commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCKER = ROOT / "scripts/dev/souc_build_lock.py"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="sounio-build-lock-selftest.") as raw_dir:
+        work_dir = Path(raw_dir)
+        lock = work_dir / "build.lock"
+        events = work_dir / "events"
+        worker = work_dir / "worker.py"
+        worker.write_text(
+            "import pathlib, sys, time\n"
+            "events = pathlib.Path(sys.argv[1])\n"
+            "label = sys.argv[2]\n"
+            "delay = float(sys.argv[3])\n"
+            "with events.open('a') as f: f.write(label + ':start\\n')\n"
+            "time.sleep(delay)\n"
+            "with events.open('a') as f: f.write(label + ':end\\n')\n",
+            encoding="utf-8",
+        )
+
+        first = subprocess.Popen(
+            [
+                sys.executable,
+                str(LOCKER),
+                str(lock),
+                sys.executable,
+                str(worker),
+                str(events),
+                "first",
+                "0.4",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        time.sleep(0.1)
+        second = subprocess.Popen(
+            [
+                sys.executable,
+                str(LOCKER),
+                str(lock),
+                sys.executable,
+                str(worker),
+                str(events),
+                "second",
+                "0",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        first_out, first_err = first.communicate(timeout=5)
+        second_out, second_err = second.communicate(timeout=5)
+
+        if first.returncode != 0 or second.returncode != 0:
+            print(first_out + first_err + second_out + second_err, file=sys.stderr)
+            return 1
+        if events.read_text(encoding="utf-8").splitlines() != [
+            "first:start",
+            "first:end",
+            "second:start",
+            "second:end",
+        ]:
+            print(events.read_text(encoding="utf-8"), file=sys.stderr)
+            return 1
+        if "another heavy build holds the lock; waiting..." not in second_err:
+            print(second_err, file=sys.stderr)
+            return 1
+
+    print("SOUC_BUILD_LOCK_SELFTEST_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/souc-build-lock.sh
+++ b/scripts/dev/souc-build-lock.sh
@@ -12,10 +12,11 @@
 #
 # WHAT THIS DOES
 # --------------
-# Takes a single exclusive flock on a repo-wide lockfile, then execs the build
-# command. Concurrent heavy builds queue instead of stampeding the CPU, so the
-# load never spikes high enough to trip the probe. Cheap `souc check` calls do
-# NOT need this wrapper — only full self-compiles / bundle checks.
+# Takes a single exclusive advisory lock on a repo-wide lockfile, then execs the
+# build command. Linux uses flock(1); macOS falls back to Python's fcntl.flock.
+# Concurrent heavy builds queue instead of stampeding the CPU, so the load never
+# spikes high enough to trip the probe. Cheap `souc check` calls do NOT need this
+# wrapper — only full self-compiles / bundle checks.
 #
 # USAGE
 # -----
@@ -33,10 +34,18 @@ if [ "$#" -eq 0 ]; then
 fi
 
 LOCK="${SOUNIO_BUILD_LOCK:-/tmp/sounio-souc-build.lock}"
-exec 9>"$LOCK"
 
+if ! command -v flock >/dev/null 2>&1; then
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: build locking requires flock(1) or python3 with fcntl support" >&2
+    exit 69
+  fi
+  exec python3 "$(dirname "$0")/souc_build_lock.py" "$LOCK" "$@"
+fi
+
+exec 9>"$LOCK"
 if ! flock -n 9; then
-  echo "[souc-build-lock] another heavy build holds the lock; waiting…" >&2
+  echo "[souc-build-lock] another heavy build holds the lock; waiting..." >&2
   flock 9
 fi
 echo "[souc-build-lock] acquired ($LOCK); running: $*" >&2

--- a/scripts/dev/souc_build_lock.py
+++ b/scripts/dev/souc_build_lock.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Portable advisory-lock fallback for souc-build-lock.sh."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(f"usage: {sys.argv[0]} <lock path> <build command...>", file=sys.stderr)
+        return 64
+
+    lock_path = sys.argv[1]
+    command = sys.argv[2:]
+    lock_file = open(lock_path, "a", encoding="utf-8")
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        print(
+            "[souc-build-lock] another heavy build holds the lock; waiting...",
+            file=sys.stderr,
+            flush=True,
+        )
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+    print(
+        f"[souc-build-lock] acquired ({lock_path}); running: {' '.join(command)}",
+        file=sys.stderr,
+        flush=True,
+    )
+    os.set_inheritable(lock_file.fileno(), True)
+    os.execvp(command[0], command)
+    return 70
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

`script/dev/souc-build-lock.sh` assumes `flock(1)`, which macOS does not provide. On Apple Silicon it printed both `flock: command not found` and the misleading message that another build held the lock.

Observed remotely on a MacBook Pro M3 while validating #819; tracked in #821.

## Change

- retain the existing `flock(1)` path when available
- fall back to Python `fcntl.flock` when `flock` is absent
- preserve the lock descriptor across `exec`, so the build owns the lock until it exits
- fail explicitly with exit 69 if neither backend exists
- replace the non-ASCII waiting marker with portable ASCII
- add a concurrent self-test to the Contracts job

## Proof

- `python3 scripts/ci/souc_build_lock_selftest.py`: PASS
- self-test proves event order `first:start -> first:end -> second:start -> second:end`
- self-test requires the second process to emit the waiting receipt
- native Linux `flock` path: PASS
- `bash -n`, Python byte-compilation, `git diff --check`: PASS
- `bash scripts/ci/impact_ci_selftest.sh`: PASS

The checked-in ARM64 compiler seed SIGSEGV from #821 is intentionally not addressed here.
