### PR TITLE
ci: compare unsigned macOS self-host payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
         run: bash scripts/ci/compiler_lane_status_gate.sh
       - name: CI watch receipt self-test
         run: python3 scripts/ci/ci_watch_receipt_selftest.py
+      - name: Executable payload comparator self-test
+        run: bash scripts/ci/executable_payload_compare_selftest.sh
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard

--- a/scripts/ci/executable_payload_compare_selftest.sh
+++ b/scripts/ci/executable_payload_compare_selftest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPARE="$ROOT_DIR/scripts/lib/compare_executable_payloads.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sounio-payload-selftest.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+printf 'same payload\n' >"$WORK_DIR/first"
+cp "$WORK_DIR/first" "$WORK_DIR/second"
+printf 'different payload\n' >"$WORK_DIR/different"
+
+"$COMPARE" "$WORK_DIR/first" "$WORK_DIR/second"
+if "$COMPARE" "$WORK_DIR/first" "$WORK_DIR/different"; then
+  echo "error: payload comparator accepted different files" >&2
+  exit 1
+fi
+
+echo "EXECUTABLE_PAYLOAD_COMPARE_SELFTEST_PASS"

--- a/scripts/ci/selfhost_host_gate.sh
+++ b/scripts/ci/selfhost_host_gate.sh
@@ -193,7 +193,7 @@ chmod +x "$STAGE3_BIN" 2>/dev/null || true
 maybe_codesign "$STAGE3_BIN"
 assert_file_kind "$STAGE3_BIN" "$HOST_FILE_KIND"
 
-if ! cmp -s "$STAGE2_BIN" "$STAGE3_BIN"; then
+if ! bash "$ROOT_DIR/scripts/lib/compare_executable_payloads.sh" "$STAGE2_BIN" "$STAGE3_BIN"; then
   echo "error: self-host fixed-point mismatch for $HOST_TARGET" >&2
   exit 1
 fi

--- a/scripts/lib/compare_executable_payloads.sh
+++ b/scripts/lib/compare_executable_payloads.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <first executable> <second executable>" >&2
+  exit 64
+fi
+
+FIRST="$1"
+SECOND="$2"
+HOST_OS="${SOUNIO_HOST_OS_OVERRIDE:-$(uname -s 2>/dev/null || echo unknown)}"
+
+if [[ "$HOST_OS" != "Darwin" ]] || ! command -v codesign >/dev/null 2>&1; then
+  cmp -s "$FIRST" "$SECOND"
+  exit $?
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sounio-payload-compare.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+FIRST_COPY="$WORK_DIR/first"
+SECOND_COPY="$WORK_DIR/second"
+cp "$FIRST" "$FIRST_COPY"
+cp "$SECOND" "$SECOND_COPY"
+
+if codesign -dv "$FIRST_COPY" >/dev/null 2>&1; then
+  codesign --remove-signature "$FIRST_COPY"
+fi
+if codesign -dv "$SECOND_COPY" >/dev/null 2>&1; then
+  codesign --remove-signature "$SECOND_COPY"
+fi
+
+cmp -s "$FIRST_COPY" "$SECOND_COPY"


### PR DESCRIPTION
## Problem

Ad-hoc signing makes byte-identical Mach-O compiler payloads differ because the code-signing envelope depends on artifact identity/path. A raw `cmp` between signed `souc-stage2` and `souc-stage3` therefore reports a false fixed-point mismatch.

Discovered during real Apple Silicon bootstrap investigation for #821.

## Change

Add a platform-aware executable payload comparator:

- Linux and non-Darwin hosts retain direct `cmp`
- Darwin copies both artifacts to a temporary directory
- signatures are removed only from the copies
- unsigned payloads are compared
- original signed executables remain untouched

`selfhost_host_gate.sh` now uses this comparator for the fixed-point assertion.

## Evidence

Local:

- comparator equal/different self-test: PASS
- `bash -n`: PASS
- `git diff --check`: PASS
- impact CI self-test: PASS

Apple Silicon evidence collected before this patch:

```text
stage2_unsigned_sha256=c2bcc80f...629233
stage3_unsigned_sha256=c2bcc80f...629233
stage4_unsigned_sha256=c2bcc80f...629233
unsigned_stage2_stage3=PASS
unsigned_stage3_stage4=PASS
```

The signed files had different hashes and sizes, proving the raw comparison was measuring the signing envelope rather than compiler fixed point.
