### PR TITLE
ci: isolate classifier self-test event contexts

### DIFF
--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -15,29 +15,33 @@ expect() {
   }
 }
 
-docs="$($CLASSIFIER docs/internal/concepts/README.md)"
+classify_pr() {
+  CI_EVENT_NAME=pull_request "$CLASSIFIER" "$@"
+}
+
+docs="$(classify_pr docs/internal/concepts/README.md)"
 expect "$docs" docs true
 expect "$docs" compiler false
 expect "$docs" lean false
 
-lean="$($CLASSIFIER formal/lean4/SounioGradedModal.lean)"
+lean="$(classify_pr formal/lean4/SounioGradedModal.lean)"
 expect "$lean" lean true
 expect "$lean" math true
 expect "$lean" compiler false
 
-compiler="$($CLASSIFIER self-hosted/compiler/main.sio)"
+compiler="$(classify_pr self-hosted/compiler/main.sio)"
 expect "$compiler" compiler true
 expect "$compiler" sio true
 
-unknown="$($CLASSIFIER newly-introduced/build.graph)"
+unknown="$(classify_pr newly-introduced/build.graph)"
 expect "$unknown" full true
 expect "$unknown" compiler true
 expect "$unknown" lean true
 
-root_build="$($CLASSIFIER Makefile)"
+root_build="$(classify_pr Makefile)"
 expect "$root_build" full true
 
-workflow="$($CLASSIFIER .github/workflows/ci.yml)"
+workflow="$(classify_pr .github/workflows/ci.yml)"
 for key in docs website compiler runtime stdlib tests lean math ontology clinical sio full; do
   expect "$workflow" "$key" true
 done


### PR DESCRIPTION
## Main CI hotfix

Post-merge CI on `main` SHA `05c4173cfbdeff3b160971234d16c88df20b04e9` failed in the Impact classifier self-test.

## Root cause

The workflow event was `push`. `classify_ci_impact.sh` correctly treats every non-PR event as full CI, but path-based self-test scenarios inherited `CI_EVENT_NAME=push` while expecting docs-only/Lean-only results.

Observed:

```text
impact-ci-selftest: expected compiler=false
compiler=true
full=true
```

## Fix

Route every explicit path scenario through `classify_pr`, which sets `CI_EVENT_NAME=pull_request`. Keep the existing explicit `push` scenario separate and unchanged.

No production classifier behavior changed.

## Proof

Exact workflow environment reproduction:

```text
CI_EVENT_NAME=push GITHUB_EVENT_NAME=push bash scripts/ci/impact_ci_selftest.sh
IMPACT_CI_SELFTEST_PASS
```

Default local environment also passes. `bash -n` and `git diff --check` pass.

Fixes the failure in run 29192307702.
