### PR TITLE
feat(image): native compressed PNG output (dynamic DEFLATE + filters), colormaps, canvas, up to 512x512

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 942
-- Repo-backed topics: 792
+- Total governed topics: 943
+- Repo-backed topics: 793
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 542
+- Authority count `repo_only`: 543
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 561 topics
+- A2: 562 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -558,6 +558,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.preprint.rapamycin-des-combo-outline | repo_only | docs/preprint/rapamycin_des_combo_outline.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.epistemic-meta-analysis | repo_only | docs/proposals/epistemic-meta-analysis.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.epistemic-workflows | repo_only | docs/proposals/epistemic-workflows.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.proposals.native-heap-allocation-2026-07-12 | repo_only | docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.nma-nonassociative-algebra-note | repo_only | docs/proposals/nma_nonassociative_algebra_note.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.pbpk-osp-interop-roadmap | repo_only | docs/proposals/pbpk-osp-interop-roadmap.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.qnn.api.comparison-guide | repo_only | docs/qnn/api/COMPARISON_GUIDE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -12313,6 +12313,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.proposals.native-heap-allocation-2026-07-12",
+      "collection": "repo",
+      "repo_doc_path": "docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.proposals.nma-nonassociative-algebra-note",
       "collection": "repo",
       "repo_doc_path": "docs/proposals/nma_nonassociative_algebra_note.md",

--- a/docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
+++ b/docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.proposals.native-heap-allocation-2026-07-12
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.proposals.native-heap-allocation-2026-07-12
+-->
+
 # Proposal: a heap-allocation primitive for the native (`souc run`) ELF
 
 **Status:** proposal · **Date:** 2026-07-12 · **Motivating work:** PR #828 (pure-Sounio PNG encoder, `image::pure::png`)

--- a/docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
+++ b/docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
@@ -1,0 +1,111 @@
+# Proposal: a heap-allocation primitive for the native (`souc run`) ELF
+
+**Status:** proposal · **Date:** 2026-07-12 · **Motivating work:** PR #828 (pure-Sounio PNG encoder, `image::pure::png`)
+
+## Ask (one line)
+
+Give user code a **working heap allocator under the `lean_single` native ELF**, so
+buffers can be sized to the data at run time instead of to a compile-time maximum.
+
+## Why
+
+`image::pure::png` (PR #828) is a complete, dependency-free PNG encoder — dynamic
+Huffman DEFLATE + adaptive scanline filters, no libpng, no Python. Its only real
+limitation is **image size**. Every buffer is a fixed array sized to the worst
+case (`[i8; 800000]`, `[i64; 800000]`, `[u32; 262144]`), so:
+
+- The maximum image is a compile-time constant (currently 512×512).
+- Every encode allocates the maximum footprint (~11 MB at 512²) regardless of the
+  actual image — a 32×32 icon pays the same as a 512×512 fractal.
+
+The correct fix is to allocate `raw`, the hash chain, the pixel buffer and the
+output proportionally to `width × height` on the heap. That needs a heap.
+
+## What was measured (2026-07-12, `SOUNIO_SOUC_ENGINE=lean_single`)
+
+| Probe | Result |
+|---|---|
+| `use mem::box::{heap_alloc}` → `heap_alloc(64)` → `write_i8`/`read_i8` | **`souc check` passes**, but the native ELF exits **1 at startup** — the very first `print("START")` never runs |
+| Same, direct run (no pipe) | `REAL_EXIT=1`, zero output |
+| A plain `print` program (no heap) | runs, `EXIT=0` |
+| `syscall(9, …)` (raw mmap attempt) | **typecheck fails** — no `syscall` intrinsic for user code |
+| Fixed arrays `[i8;3.2M]+[i64;3.2M]+[u32;1.05M]` (~46 MB, a 1024² footprint) | **runs, `EXIT=0`**, all prints, 0.24 s |
+
+**Conclusion.** `heap_alloc` in `stdlib/mem/box.sio` is `extern "C" { calloc … }`.
+The lean_single native ELF is **not linked against libc**, so those symbols are
+unresolved and the process dies before `main` executes. There is **no
+`syscall`/`mmap` intrinsic** to allocate memory another way. The Sounio **arena**
+(what fixed arrays live in) *does* handle tens of MB — but it only grows fixed
+arrays, which are compile-time-sized.
+
+So the blocker is not byte addressing or file output — it is that **there is no
+way to obtain a run-time-sized block of memory in the native path.**
+
+## The one primitive that unblocks everything
+
+Any *one* of these makes the heap-backed rewrite possible. Ranked by
+preference:
+
+1. **Link libc (or crt) into the native ELF**, so the existing
+   `extern "C" { malloc/calloc/free }` in `stdlib/mem/box.sio` resolve. Smallest
+   surface — `mem::box`, `mem::pool`, `display::window` already assume this and
+   would start working. `write_i64`/`read_i64` (pointer load/store) are already
+   intrinsics and already used by `display::window`.
+2. **A raw `mmap`/`munmap` syscall intrinsic** (or a `brk`) exposed to user code,
+   e.g. `fn os_mmap(len: i64) -> *mut u8`. No libc dependency; the native codegen
+   already emits `syscall` (see `self-hosted/native/encode.sio::emit_syscall`) —
+   this just surfaces it behind a checked builtin.
+3. **A builtin bump/arena allocator returning a run-time pointer**, e.g.
+   `fn heap_bytes(n: i64) -> *mut u8` implemented in the runtime (same allocator
+   the arena uses, but callable with a dynamic size).
+
+Byte addressing is *not* a blocker: `write_i8`/`read_i8` and `ptr[i]` on
+`*mut u8` type-check today; they simply could not be runtime-verified because the
+pointer they need comes from the missing allocator.
+
+## Secondary ask (for *unbounded* output, not just input)
+
+`write_file(path, data: [i8; N], len)` takes a **fixed** array, so the final PNG
+must live in a compile-time-sized buffer. For compressible images this is fine
+(the compressed PNG is small and fits a modest fixed buffer even when the image
+is large), so **the primary ask alone already enables large *compressible*
+images**. Truly unbounded output (incompressible data at arbitrary size) also
+needs a pointer/`fd`-based writer, e.g. `fn write_file_ptr(path, ptr: *mut u8,
+len: i64) -> i64`, or an `open`/`write`/`close` syscall trio.
+
+## The rewrite this unblocks (design sketch)
+
+With a heap allocator, `png_write` becomes size-agnostic:
+
+```
+let px_bytes = w * h * 4          // Image pixels
+let raw_len  = h * (1 + w*3)
+let pix  = heap_bytes(px_bytes)   // or reuse the caller's heap raster
+let raw  = heap_bytes(raw_len)    // filtered scanlines
+let prev = heap_i64(raw_len)      // LZ hash chain, one i64 per position
+let out  = heap_bytes(raw_len)    // deflate body (≤ raw_len via stored fallback)
+… run the existing filter + dynamic-Huffman pipeline over pointers via
+   read_i8/write_i8 / read_i64/write_i64 …
+write_file_ptr(path, png_ptr, png_len)   // secondary ask
+free(pix); free(raw); free(prev); free(out)
+```
+
+Memory then scales with the image and is released after each call — no
+compile-time cap, no worst-case tax on small images. The algorithm is unchanged
+and already validated byte-exact against an independent zlib decoder.
+
+## Available today (stopgap, no compiler change)
+
+Fixed-array arena buffers, bounded by the arena (~46 MB verified → up to
+1024×1024). Current cap is **512×512** (~11 MB/call) as the balance point; raising
+it to 1024×1024 is a one-line change to the buffer constants in
+`stdlib/image/pure/png.sio` and `types.sio`, at the cost of ~46 MB per encode
+regardless of image size.
+
+## Recommendation
+
+Adopt option **1 (link libc into the native ELF)** — it is the smallest change,
+unblocks `mem::box` / `mem::pool` / `display` simultaneously, and needs no new
+surface since the pointer load/store intrinsics already exist. Track the
+secondary `write_file_ptr` ask separately; it is only needed for unbounded
+*incompressible* output.

--- a/docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
+++ b/docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
@@ -2,6 +2,37 @@
 
 **Status:** proposal · **Date:** 2026-07-12 · **Motivating work:** PR #828 (pure-Sounio PNG encoder, `image::pure::png`)
 
+## Dispatch to the compiler lane (per `.claude/PARALLEL_BLOCKER_CONTRACT.md`)
+
+```text
+Blocker-ID: BLK-20260712-image-heap
+Status: proposed
+Severity: B1
+Class: compiler-semantics
+Owner: Codex-2 (lane-4 nv2-compiler-hardening)
+Lane: native-image-encoding (large-image sub-goal of PR #828)
+Worktree: /tmp/claude-1000/-workspace-sounio/51dcb45e-4018-4254-b1cb-e9fc1d11d1e3/scratchpad/wt-png
+Branch: feat/native-png-encoder
+Files-Owned: stdlib/image/pure/png.sio, stdlib/image/pure/types.sio, docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md
+Files-Read-Only: stdlib/mem/box.sio, stdlib/display/window.sio
+Do-Not-Touch: self-hosted/native/* (compiler lane owns codegen/linking)
+Repro: `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run p.sio` where p.sio is
+       `use mem::box::{heap_alloc}` + `fn main() with IO,Mut,Div,Panic,Alloc { print("START\n"); let p = heap_alloc(64) as *mut i8; write_i8(p,7,123); print(read_i8(p,7) as i64); print("\n") }`
+Observed: process exits 1 at startup; "START" never prints (extern "C" calloc/malloc unresolved — native ELF not linked against libc)
+Expected: heap_alloc returns a usable block; program prints "START" then "123"
+Acceptance-Gate: the repro program runs to completion and prints 123 under `souc run`
+Evidence-Level: E2
+Evidence: this document (measured-probe table below); reproducible with the Repro command
+Fallback-Path: fixed-array arena buffers — 512×512 shipped (PR #828 commit 0102f7b64), 1024×1024 by a one-line constant change (~46 MB/call). Named, not silent.
+Legacy-Kept: n/a
+LLM-Offload: not-required (no math/clinical/external claim; pure runtime capability)
+Next-Action: Codex-2 — link libc (or crt) into the native ELF so the existing `extern "C" { malloc/calloc/free }` resolve (option 1 below); alternatively expose an mmap syscall intrinsic (option 2).
+```
+
+**Note:** this does NOT block PR #828 itself — the 512×512 encoder is complete and
+independently mergeable. It blocks only the *unbounded-size* follow-up, which
+depends on this compiler capability.
+
 ## Ask (one line)
 
 Give user code a **working heap allocator under the `lean_single` native ELF**, so

--- a/examples/image/canvas_field.sio
+++ b/examples/image/canvas_field.sio
@@ -1,0 +1,34 @@
+// examples/image/canvas_field.sio — the ergonomic native-plot path:
+//   compute a field → canvas_render_field(..., colormap) → canvas_save(png).
+//
+//   souc run examples/image/canvas_field.sio   -> interference.png
+
+use image::pure::types::{Image}
+use image::canvas::{canvas_new, canvas_render_field, canvas_save}
+use viz::colormap::{inferno_u32}
+
+fn main() with IO, Mut, Div, Panic {
+    let n = 240
+    var field: [f64; 65536] = [0.0; 65536]
+    let k = 0.30
+    var vmin = 1.0e30
+    var vmax = 0.0 - 1.0e30
+    var y = 0
+    while y < n {
+        var x = 0
+        while x < n {
+            let dx1 = (x as f64) - 80.0;  let dy1 = (y as f64) - 120.0
+            let dx2 = (x as f64) - 160.0; let dy2 = (y as f64) - 120.0
+            let v = sin(k * sqrt(dx1*dx1 + dy1*dy1)) + sin(k * sqrt(dx2*dx2 + dy2*dy2))
+            field[(y * n + x) as usize] = v
+            if v < vmin { vmin = v }
+            if v > vmax { vmax = v }
+            x = x + 1
+        }
+        y = y + 1
+    }
+    var c = canvas_new(n as i32, n as i32)
+    canvas_render_field(&!c, &field, vmin, vmax, inferno_u32)
+    let ok = canvas_save(&c, "interference.png")
+    if ok { print("wrote interference.png\n") } else { print("fail\n") }
+}

--- a/examples/image/fractal_512.sio
+++ b/examples/image/fractal_512.sio
@@ -1,0 +1,39 @@
+// examples/image/fractal_512.sio — a 512x512 inferno Mandelbrot rendered and
+// PNG-encoded entirely in Sounio (exercises the 512x512 cap).
+//   souc run examples/image/fractal_512.sio   -> fractal512.png
+use image::pure::types::{Image, image_new, image_set_pixel}
+use image::pure::png::{png_write}
+use viz::colormap::{inferno_r, inferno_g, inferno_b, cm_pack_rgb8}
+fn main() with IO, Mut, Div, Panic {
+    let n = 512
+    var img = image_new(n as i32, n as i32)
+    let cx0 = 0.0 - 0.746; let cy0 = 0.108; let yh = 0.035
+    let xh = yh; let xmin=cx0-xh; let xmax=cx0+xh; let ymin=cy0-yh; let ymax=cy0+yh
+    let maxit=800; let bail2=65536.0; let invln2=1.4426950408889634; let freq=0.055
+    var y = 0
+    while y < n {
+        let cy = ymin + ((y as f64)/(n as f64))*(ymax-ymin)
+        var x = 0
+        while x < n {
+            let cx = xmin + ((x as f64)/(n as f64))*(xmax-xmin)
+            var zx=0.0; var zy=0.0; var it=0; var esc=false
+            while it<maxit && esc==false {
+                let zx2=zx*zx; let zy2=zy*zy
+                if zx2+zy2>bail2 { esc=true } else { let tmp=zx2-zy2+cx; zy=2.0*zx*zy+cy; zx=tmp; it=it+1 }
+            }
+            var c = 0
+            if esc {
+                let zn=sqrt(zx*zx+zy*zy)
+                let mu=(it as f64)+1.0-ln(ln(zn))*invln2
+                let tt=mu*freq; let ip=tt as i64; let f2=tt-(ip as f64)
+                var t=2.0*f2; if f2>=0.5 { t=2.0-2.0*f2 }
+                c = cm_pack_rgb8(inferno_r(t), inferno_g(t), inferno_b(t)) as i64
+            }
+            image_set_pixel(&!img, x as i32, y as i32, c as u32)
+            x = x + 1
+        }
+        y = y + 1
+    }
+    let ok = png_write("fractal512.png", &img)
+    if ok { print("wrote fractal512.png\n") } else { print("fail\n") }
+}

--- a/examples/image/pk_uncertainty_field.sio
+++ b/examples/image/pk_uncertainty_field.sio
@@ -1,0 +1,76 @@
+// examples/image/pk_uncertainty_field.sio
+//
+// The epistemic pipeline drawing itself: a pharmacokinetic field where every
+// cell is an `Epistemic` value with GUM-propagated variance, rendered natively
+// to PNG — no FFI, no Python, no plotting library.
+//
+//   souc run examples/image/pk_uncertainty_field.sio
+//     -> pk_auc.png            (mean exposure, log scale, inferno)
+//     -> pk_uncertainty.png    (confidence in the therapeutic margin, viridis)
+//
+// Model (one-compartment IV bolus):
+//   clearance CL = ke * V        exposure AUC = Dose / CL     margin = AUC - target
+// Dose, ke, V and the target each carry uncertainty; `Epistemic` propagates it
+// through mul/div/sub by the GUM delta method. The uncertainty panel lights up
+// along the contour AUC = target, where the sign of the margin is unknowable —
+// exactly the information a plain heatmap of the mean cannot show.
+
+use image::pure::types::{Image, image_new, image_set_pixel}
+use image::pure::png::{png_write}
+use viz::colormap::{inferno_r, inferno_g, inferno_b, viridis_r, viridis_g, viridis_b, cm_pack_rgb8}
+use epistemic::knowledge::{Epistemic}
+
+fn main() with IO, Mut, Div, Panic {
+    let n = 240
+    var auc_img = image_new(n as i32, n as i32)
+    var unc_img = image_new(n as i32, n as i32)
+
+    let dose = Epistemic::measured(500.0, 10.0)   // 500 mg, ~2% dosing CV
+    let target = Epistemic::measured(40.0, 4.0)   // target AUC 40 mg·h/L, ~10%
+    let ke_lo = 0.05; let ke_hi = 0.60            // elimination rate constant (1/h)
+    let v_lo = 15.0;  let v_hi = 90.0             // volume of distribution (L)
+    let denom = (n - 1) as f64
+    let logmin = ln(500.0 / (ke_hi * v_hi))       // AUC range, log scale
+    let logmax = ln(500.0 / (ke_lo * v_lo))
+
+    var yy = 0
+    while yy < n {
+        let v = v_lo + ((yy as f64) / denom) * (v_hi - v_lo)
+        var xx = 0
+        while xx < n {
+            let ke = ke_lo + ((xx as f64) / denom) * (ke_hi - ke_lo)
+            let ke_e = Epistemic::measured(ke, ke * 0.10)  // 10% CV on ke
+            let v_e = Epistemic::measured(v, v * 0.08)     // 8% CV on V
+            let cl = ke_e.mul(&v_e)                        // CL = ke·V (variance propagated)
+            let auc = dose.div(&cl)                        // AUC = Dose/CL
+            let margin = auc.sub(&target)                  // therapeutic margin
+
+            // Panel A — mean exposure, log-normalised, inferno
+            let ta = (ln(auc.val()) - logmin) / (logmax - logmin)
+            image_set_pixel(&!auc_img, xx as i32, yy as i32,
+                cm_pack_rgb8(inferno_r(ta), inferno_g(ta), inferno_b(ta)))
+
+            // Panel B — relative uncertainty of the margin, viridis
+            let ru = margin.rel_uncertainty()
+            var tu = ru / 1.5
+            if tu > 1.0 { tu = 1.0 }
+            image_set_pixel(&!unc_img, xx as i32, yy as i32,
+                cm_pack_rgb8(viridis_r(tu), viridis_g(tu), viridis_b(tu)))
+            xx = xx + 1
+        }
+        yy = yy + 1
+    }
+
+    // A numeric witness for one operating point (ke=0.20/h, V=50 L).
+    let ke_r = Epistemic::measured(0.20, 0.020)
+    let v_r = Epistemic::measured(50.0, 4.0)
+    let cl_r = ke_r.mul(&v_r)
+    let auc_r = dose.div(&cl_r)
+    print("AUC(ke=0.20, V=50) = "); print(auc_r.val())
+    print(" mg*h/L, sigma = "); print(auc_r.std())
+    print(", rel_unc = "); print(auc_r.rel_uncertainty()); print("\n")
+
+    let ok1 = png_write("pk_auc.png", &auc_img)
+    let ok2 = png_write("pk_uncertainty.png", &unc_img)
+    if ok1 && ok2 { print("wrote pk_auc.png + pk_uncertainty.png\n") } else { print("write failed\n") }
+}

--- a/examples/image/png_native.sio
+++ b/examples/image/png_native.sio
@@ -1,0 +1,30 @@
+// examples/image/png_native.sio — native PNG output, no FFI, no Python.
+//
+//   souc run examples/image/png_native.sio   # writes png_native_demo.png
+//
+// Draws an RGB gradient into an Image and encodes it with the pure-Sounio
+// `image::pure::png` encoder.
+
+use image::pure::types::{Image, image_new, image_set_pixel}
+use image::pure::png::{png_write}
+
+fn main() with IO, Mut, Div, Panic {
+    let w = 256
+    let h = 256
+    var img = image_new(w as i32, h as i32)
+    var y = 0
+    while y < h {
+        var x = 0
+        while x < w {
+            let r = x & 255
+            let g = y & 255
+            let b = ((x + y) / 2) & 255
+            let c = ((r << 16) | (g << 8) | b) as u32
+            image_set_pixel(&!img, x as i32, y as i32, c)
+            x = x + 1
+        }
+        y = y + 1
+    }
+    let ok = png_write("png_native_demo.png", &img)
+    if ok { print("wrote png_native_demo.png\n") } else { print("png_write failed\n") }
+}

--- a/stdlib/image/canvas.sio
+++ b/stdlib/image/canvas.sio
@@ -1,0 +1,54 @@
+// stdlib/image/canvas.sio — Headless raster canvas: compute → colour → PNG
+//
+// A thin ergonomic layer over image::pure::types::Image and the pure PNG
+// encoder, for turning a computed scalar field into a coloured image file
+// without a window, an FFI, or a plotting library:
+//
+//   var c = canvas_new(w, h)
+//   canvas_render_field(&!c, &field, vmin, vmax, inferno_u32)
+//   canvas_save(&c, "out.png")
+//
+// This is the offline/data-plotting counterpart to the interactive,
+// window-backed display::canvas::Canvas; the two do not overlap.
+
+module image::canvas
+
+use image::pure::types::{Image, image_new, image_set_pixel}
+use image::pure::png::{png_write}
+
+// Allocate a blank canvas (bounded by Image's 65536-pixel / 256x256 cap).
+pub fn canvas_new(w: i32, h: i32) -> Image { image_new(w, h) }
+
+// Fill the canvas from a row-major scalar field of img.width * img.height
+// values. Each value is normalised (v - vmin)/(vmax - vmin), clamped to
+// [0,1], and mapped through `cmap` — any colormap as a fn(f64) -> u32, e.g.
+// inferno_u32 / viridis_u32 / magma_u32 / plasma_u32 from viz::colormap.
+pub fn canvas_render_field(
+    img: &!Image,
+    field: &[f64; 65536],
+    vmin: f64,
+    vmax: f64,
+    cmap: fn(f64) -> u32 with Div,
+) with Mut, Div, Panic {
+    let w = img.width as i64
+    let h = img.height as i64
+    let span = if vmax - vmin == 0.0 { 1.0 } else { vmax - vmin }
+    var y = 0
+    while y < h {
+        var x = 0
+        while x < w {
+            let v = field[(y * w + x) as usize]
+            var t = (v - vmin) / span
+            if t < 0.0 { t = 0.0 }
+            if t > 1.0 { t = 1.0 }
+            image_set_pixel(img, x as i32, y as i32, cmap(t))
+            x = x + 1
+        }
+        y = y + 1
+    }
+}
+
+// Encode the canvas to `filename` as a native PNG. Returns true on success.
+pub fn canvas_save(img: &Image, filename: string) -> bool with IO, Mut, Div, Panic {
+    png_write(filename, img)
+}

--- a/stdlib/image/mod.sio
+++ b/stdlib/image/mod.sio
@@ -15,3 +15,5 @@ pub use image::ffi::bindings::{libpng_available, stb_image_available}
 pub use image::ffi::wrapper::{image_load_file, image_save_file}
 
 pub use image::pure::png::{png_write}
+
+pub use image::canvas::{canvas_new, canvas_render_field, canvas_save}

--- a/stdlib/image/mod.sio
+++ b/stdlib/image/mod.sio
@@ -13,3 +13,5 @@ pub use image::pure::types::{
 
 pub use image::ffi::bindings::{libpng_available, stb_image_available}
 pub use image::ffi::wrapper::{image_load_file, image_save_file}
+
+pub use image::pure::png::{png_write}

--- a/stdlib/image/pure/png.sio
+++ b/stdlib/image/pure/png.sio
@@ -1,0 +1,138 @@
+// stdlib/image/pure/png.sio — Pure-Sounio PNG encoder (no FFI, no libpng)
+//
+// Writes a spec-valid 8-bit RGB PNG straight to disk via the `write_file` builtin.
+// DEFLATE is emitted as *stored* (uncompressed) blocks, so output is a valid PNG
+// that every decoder reads, at the cost of no compression (file ~= raw RGB size).
+// This is the self-contained alternative to the `image::ffi` libpng/stb path.
+//
+// Pixel format: each `u32` in `Image.pixels` is interpreted as 0x00RRGGBB
+// (low 24 bits; the top byte is ignored).
+//
+// Size bound: `Image` caps at 65536 pixels (256x256). The scratch buffer below
+// holds the worst-case PNG for that cap: 256*(1+256*3) raw + chunk overhead.
+
+module image::pure::png
+
+use image::pure::types::{Image}
+
+// Scratch byte buffer with a running length. A struct wrapper is used because
+// bare `&![i8; N]` element mutation is not reliable under the current JIT.
+struct PngBuf { data: [i8; 262144], len: i64 }
+
+fn put(b: &!PngBuf, v: i64) with Mut, Panic {
+    (*b).data[(*b).len as usize] = (v & 255) as i8
+    (*b).len = (*b).len + 1
+}
+
+fn put_be32(b: &!PngBuf, v: i64) with Mut, Panic {
+    put(b, (v >> 24) & 255)
+    put(b, (v >> 16) & 255)
+    put(b, (v >> 8) & 255)
+    put(b, v & 255)
+}
+
+// CRC-32 (PNG polynomial 0xEDB88320 = 3988292384) over data[start..end].
+fn crc_range(b: &PngBuf, start: i64, end: i64) -> i64 with Mut, Panic {
+    var crc = 4294967295
+    var i = start
+    while i < end {
+        let byte = ((*b).data[i as usize] as i64) & 255
+        crc = crc ^ byte
+        var k = 0
+        while k < 8 {
+            if (crc & 1) == 1 { crc = (crc >> 1) ^ 3988292384 } else { crc = crc >> 1 }
+            k = k + 1
+        }
+        i = i + 1
+    }
+    (crc ^ 4294967295) & 4294967295
+}
+
+// Encode `img` as an 8-bit RGB PNG and write it to `filename`.
+// Returns true on success.
+pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic {
+    let w = img.width as i64
+    let h = img.height as i64
+    if w <= 0 || h <= 0 { return false }
+
+    // ---- filtered raw scanlines: a leading filter byte (0 = none) per row ----
+    var raw = PngBuf { data: [0; 262144], len: 0 }
+    var y = 0
+    while y < h {
+        put(&!raw, 0)
+        var x = 0
+        while x < w {
+            let p = (img.pixels[(y * w + x) as usize] as i64) & 16777215
+            put(&!raw, (p >> 16) & 255)
+            put(&!raw, (p >> 8) & 255)
+            put(&!raw, p & 255)
+            x = x + 1
+        }
+        y = y + 1
+    }
+
+    // ---- Adler-32 over the raw stream ----
+    var s1 = 1
+    var s2 = 0
+    var ai = 0
+    while ai < raw.len {
+        let byte = (raw.data[ai as usize] as i64) & 255
+        s1 = (s1 + byte) % 65521
+        s2 = (s2 + s1) % 65521
+        ai = ai + 1
+    }
+    let adler = ((s2 << 16) | s1) & 4294967295
+
+    // ---- assemble the PNG ----
+    var png = PngBuf { data: [0; 262144], len: 0 }
+    // signature
+    put(&!png, 137); put(&!png, 80); put(&!png, 78); put(&!png, 71)
+    put(&!png, 13); put(&!png, 10); put(&!png, 26); put(&!png, 10)
+    // IHDR
+    put_be32(&!png, 13)
+    let ihdr_start = png.len
+    put(&!png, 73); put(&!png, 72); put(&!png, 68); put(&!png, 82)  // "IHDR"
+    put_be32(&!png, w); put_be32(&!png, h)
+    put(&!png, 8); put(&!png, 2); put(&!png, 0); put(&!png, 0); put(&!png, 0)
+    let ihdr_crc = crc_range(&png, ihdr_start, png.len)
+    put_be32(&!png, ihdr_crc)
+    // IDAT — zlib stream length is analytic for stored blocks
+    var nblocks = raw.len / 65535
+    if (raw.len % 65535) != 0 { nblocks = nblocks + 1 }
+    if nblocks == 0 { nblocks = 1 }
+    let zlen = 2 + 5 * nblocks + raw.len + 4
+    put_be32(&!png, zlen)
+    let idat_start = png.len
+    put(&!png, 73); put(&!png, 68); put(&!png, 65); put(&!png, 84)  // "IDAT"
+    put(&!png, 120); put(&!png, 1)  // zlib header 0x78 0x01
+    var pos = 0
+    var remaining = raw.len
+    while remaining > 0 {
+        var blk = remaining
+        if blk > 65535 { blk = 65535 }
+        var bfinal = 0
+        if blk == remaining { bfinal = 1 }
+        put(&!png, bfinal)
+        put(&!png, blk & 255); put(&!png, (blk >> 8) & 255)
+        let nlen = 65535 - blk
+        put(&!png, nlen & 255); put(&!png, (nlen >> 8) & 255)
+        var j = 0
+        while j < blk {
+            put(&!png, (raw.data[(pos + j) as usize] as i64) & 255)
+            j = j + 1
+        }
+        pos = pos + blk
+        remaining = remaining - blk
+    }
+    put_be32(&!png, adler)
+    let idat_crc = crc_range(&png, idat_start, png.len)
+    put_be32(&!png, idat_crc)
+    // IEND
+    put_be32(&!png, 0)
+    let iend_start = png.len
+    put(&!png, 73); put(&!png, 69); put(&!png, 78); put(&!png, 68)  // "IEND"
+    let iend_crc = crc_range(&png, iend_start, png.len)
+    put_be32(&!png, iend_crc)
+
+    write_file(filename, png.data, png.len) >= 0
+}

--- a/stdlib/image/pure/png.sio
+++ b/stdlib/image/pure/png.sio
@@ -1,15 +1,17 @@
 // stdlib/image/pure/png.sio — Pure-Sounio PNG encoder (no FFI, no libpng)
 //
 // Writes a spec-valid 8-bit RGB PNG straight to disk via the `write_file` builtin.
-// DEFLATE is emitted as *stored* (uncompressed) blocks, so output is a valid PNG
-// that every decoder reads, at the cost of no compression (file ~= raw RGB size).
+// Compression is real DEFLATE: fixed-Huffman blocks with LZ77 back-references
+// found by a capped hash-chain matcher. If the compressed body would be larger
+// than the input (e.g. smooth high-entropy data), it falls back to a stored
+// (uncompressed) block, so output is never worse than raw + a few bytes.
 // This is the self-contained alternative to the `image::ffi` libpng/stb path.
 //
 // Pixel format: each `u32` in `Image.pixels` is interpreted as 0x00RRGGBB
 // (low 24 bits; the top byte is ignored).
 //
-// Size bound: `Image` caps at 65536 pixels (256x256). The scratch buffer below
-// holds the worst-case PNG for that cap: 256*(1+256*3) raw + chunk overhead.
+// Size bound: `Image` caps at 65536 pixels (256x256). Scratch buffers below
+// hold the worst-case PNG and hash state for that cap.
 
 module image::pure::png
 
@@ -18,6 +20,9 @@ use image::pure::types::{Image}
 // Scratch byte buffer with a running length. A struct wrapper is used because
 // bare `&![i8; N]` element mutation is not reliable under the current JIT.
 struct PngBuf { data: [i8; 262144], len: i64 }
+
+// Bit-level output for the DEFLATE stream (LSB-first bit packing).
+struct BitOut { data: [i8; 262144], len: i64, acc: i64, nbits: i64 }
 
 fn put(b: &!PngBuf, v: i64) with Mut, Panic {
     (*b).data[(*b).len as usize] = (v & 255) as i8
@@ -47,6 +52,175 @@ fn crc_range(b: &PngBuf, start: i64, end: i64) -> i64 with Mut, Panic {
     }
     (crc ^ 4294967295) & 4294967295
 }
+
+// ---- DEFLATE (fixed Huffman + LZ77) ----------------------------------------
+
+fn bo_put(d: &!BitOut, v: i64) with Mut, Panic {
+    (*d).data[(*d).len as usize] = (v & 255) as i8
+    (*d).len = (*d).len + 1
+}
+
+fn bit_write(d: &!BitOut, val: i64, n: i64) with Mut, Panic {
+    (*d).acc = (*d).acc | (val << (*d).nbits)
+    (*d).nbits = (*d).nbits + n
+    while (*d).nbits >= 8 {
+        bo_put(d, (*d).acc & 255)
+        (*d).acc = (*d).acc >> 8
+        (*d).nbits = (*d).nbits - 8
+    }
+}
+
+fn flush_bits(d: &!BitOut) with Mut, Panic {
+    if (*d).nbits > 0 {
+        bo_put(d, (*d).acc & 255)
+        (*d).acc = 0
+        (*d).nbits = 0
+    }
+}
+
+fn reverse_bits(code: i64, n: i64) -> i64 with Mut {
+    var r = 0
+    var i = 0
+    while i < n { r = (r << 1) | ((code >> i) & 1); i = i + 1 }
+    r
+}
+
+// Fixed literal/length Huffman code for symbol 0..287.
+fn emit_litlen(d: &!BitOut, sym: i64) with Mut, Panic {
+    if sym <= 143 { bit_write(d, reverse_bits(48 + sym, 8), 8); return }
+    if sym <= 255 { bit_write(d, reverse_bits(400 + (sym - 144), 9), 9); return }
+    if sym <= 279 { bit_write(d, reverse_bits(sym - 256, 7), 7); return }
+    bit_write(d, reverse_bits(192 + (sym - 280), 8), 8)
+}
+
+// Length symbol (257..285) + extra bits, for match length 3..258.
+fn emit_len(d: &!BitOut, len: i64) with Mut, Panic {
+    if len <= 10 { emit_litlen(d, len + 254); return }
+    if len <= 12 { emit_litlen(d, 265); bit_write(d, len - 11, 1); return }
+    if len <= 14 { emit_litlen(d, 266); bit_write(d, len - 13, 1); return }
+    if len <= 16 { emit_litlen(d, 267); bit_write(d, len - 15, 1); return }
+    if len <= 18 { emit_litlen(d, 268); bit_write(d, len - 17, 1); return }
+    if len <= 22 { emit_litlen(d, 269); bit_write(d, len - 19, 2); return }
+    if len <= 26 { emit_litlen(d, 270); bit_write(d, len - 23, 2); return }
+    if len <= 30 { emit_litlen(d, 271); bit_write(d, len - 27, 2); return }
+    if len <= 34 { emit_litlen(d, 272); bit_write(d, len - 31, 2); return }
+    if len <= 42 { emit_litlen(d, 273); bit_write(d, len - 35, 3); return }
+    if len <= 50 { emit_litlen(d, 274); bit_write(d, len - 43, 3); return }
+    if len <= 58 { emit_litlen(d, 275); bit_write(d, len - 51, 3); return }
+    if len <= 66 { emit_litlen(d, 276); bit_write(d, len - 59, 3); return }
+    if len <= 82 { emit_litlen(d, 277); bit_write(d, len - 67, 4); return }
+    if len <= 98 { emit_litlen(d, 278); bit_write(d, len - 83, 4); return }
+    if len <= 114 { emit_litlen(d, 279); bit_write(d, len - 99, 4); return }
+    if len <= 130 { emit_litlen(d, 280); bit_write(d, len - 115, 4); return }
+    if len <= 162 { emit_litlen(d, 281); bit_write(d, len - 131, 5); return }
+    if len <= 194 { emit_litlen(d, 282); bit_write(d, len - 163, 5); return }
+    if len <= 226 { emit_litlen(d, 283); bit_write(d, len - 195, 5); return }
+    if len <= 257 { emit_litlen(d, 284); bit_write(d, len - 227, 5); return }
+    emit_litlen(d, 285)
+}
+
+// Distance symbol (0..29, 5-bit code) + extra bits, for distance 1..32768.
+fn emit_dist(d: &!BitOut, dist: i64) with Mut, Panic {
+    if dist <= 4 { bit_write(d, reverse_bits(dist - 1, 5), 5); return }
+    if dist <= 6 { bit_write(d, reverse_bits(4, 5), 5); bit_write(d, dist - 5, 1); return }
+    if dist <= 8 { bit_write(d, reverse_bits(5, 5), 5); bit_write(d, dist - 7, 1); return }
+    if dist <= 12 { bit_write(d, reverse_bits(6, 5), 5); bit_write(d, dist - 9, 2); return }
+    if dist <= 16 { bit_write(d, reverse_bits(7, 5), 5); bit_write(d, dist - 13, 2); return }
+    if dist <= 24 { bit_write(d, reverse_bits(8, 5), 5); bit_write(d, dist - 17, 3); return }
+    if dist <= 32 { bit_write(d, reverse_bits(9, 5), 5); bit_write(d, dist - 25, 3); return }
+    if dist <= 48 { bit_write(d, reverse_bits(10, 5), 5); bit_write(d, dist - 33, 4); return }
+    if dist <= 64 { bit_write(d, reverse_bits(11, 5), 5); bit_write(d, dist - 49, 4); return }
+    if dist <= 96 { bit_write(d, reverse_bits(12, 5), 5); bit_write(d, dist - 65, 5); return }
+    if dist <= 128 { bit_write(d, reverse_bits(13, 5), 5); bit_write(d, dist - 97, 5); return }
+    if dist <= 192 { bit_write(d, reverse_bits(14, 5), 5); bit_write(d, dist - 129, 6); return }
+    if dist <= 256 { bit_write(d, reverse_bits(15, 5), 5); bit_write(d, dist - 193, 6); return }
+    if dist <= 384 { bit_write(d, reverse_bits(16, 5), 5); bit_write(d, dist - 257, 7); return }
+    if dist <= 512 { bit_write(d, reverse_bits(17, 5), 5); bit_write(d, dist - 385, 7); return }
+    if dist <= 768 { bit_write(d, reverse_bits(18, 5), 5); bit_write(d, dist - 513, 8); return }
+    if dist <= 1024 { bit_write(d, reverse_bits(19, 5), 5); bit_write(d, dist - 769, 8); return }
+    if dist <= 1536 { bit_write(d, reverse_bits(20, 5), 5); bit_write(d, dist - 1025, 9); return }
+    if dist <= 2048 { bit_write(d, reverse_bits(21, 5), 5); bit_write(d, dist - 1537, 9); return }
+    if dist <= 3072 { bit_write(d, reverse_bits(22, 5), 5); bit_write(d, dist - 2049, 10); return }
+    if dist <= 4096 { bit_write(d, reverse_bits(23, 5), 5); bit_write(d, dist - 3073, 10); return }
+    if dist <= 6144 { bit_write(d, reverse_bits(24, 5), 5); bit_write(d, dist - 4097, 11); return }
+    if dist <= 8192 { bit_write(d, reverse_bits(25, 5), 5); bit_write(d, dist - 6145, 11); return }
+    if dist <= 12288 { bit_write(d, reverse_bits(26, 5), 5); bit_write(d, dist - 8193, 12); return }
+    if dist <= 16384 { bit_write(d, reverse_bits(27, 5), 5); bit_write(d, dist - 12289, 12); return }
+    if dist <= 24576 { bit_write(d, reverse_bits(28, 5), 5); bit_write(d, dist - 16385, 13); return }
+    bit_write(d, reverse_bits(29, 5), 5); bit_write(d, dist - 24577, 13)
+}
+
+// One fixed-Huffman DEFLATE block (BFINAL=1) over raw[0..raw.len], with LZ77
+// matches from a capped hash chain. Local hash state (head/prev) avoids passing
+// bare `&![i64; N]` array refs.
+fn deflate_fixed(out: &!BitOut, raw: &PngBuf) with Mut, Panic {
+    let n = (*raw).len
+    var head: [i64; 32768] = [0; 32768]
+    var prev: [i64; 200000] = [0; 200000]
+    var hi = 0
+    while hi < 32768 { head[hi as usize] = 0 - 1; hi = hi + 1 }
+
+    bit_write(out, 1, 1)  // BFINAL = 1
+    bit_write(out, 1, 2)  // BTYPE  = 01 (fixed Huffman)
+
+    let max_match = 258
+    let max_dist = 32768
+    let max_chain = 128
+    var pos = 0
+    while pos < n {
+        var best_len = 0
+        var best_dist = 0
+        if pos + 2 < n {
+            let a = ((*raw).data[pos as usize] as i64) & 255
+            let b = ((*raw).data[(pos + 1) as usize] as i64) & 255
+            let c = ((*raw).data[(pos + 2) as usize] as i64) & 255
+            let h = ((a << 10) + (b << 5) + c) & 32767
+            var cand = head[h as usize]
+            var chain = 0
+            while cand >= 0 && chain < max_chain {
+                let dist = pos - cand
+                if dist > max_dist { cand = 0 - 1 }
+                else {
+                    var l = 0
+                    while l < max_match && (pos + l) < n
+                          && (*raw).data[(cand + l) as usize] == (*raw).data[(pos + l) as usize] {
+                        l = l + 1
+                    }
+                    if l > best_len { best_len = l; best_dist = dist }
+                    cand = prev[cand as usize]
+                    chain = chain + 1
+                }
+            }
+            prev[pos as usize] = head[h as usize]
+            head[h as usize] = pos
+        }
+        if best_len >= 3 {
+            emit_len(out, best_len)
+            emit_dist(out, best_dist)
+            var q = pos + 1
+            let stop = pos + best_len
+            while q < stop {
+                if q + 2 < n {
+                    let a2 = ((*raw).data[q as usize] as i64) & 255
+                    let b2 = ((*raw).data[(q + 1) as usize] as i64) & 255
+                    let c2 = ((*raw).data[(q + 2) as usize] as i64) & 255
+                    let h2 = ((a2 << 10) + (b2 << 5) + c2) & 32767
+                    prev[q as usize] = head[h2 as usize]
+                    head[h2 as usize] = q
+                }
+                q = q + 1
+            }
+            pos = pos + best_len
+        } else {
+            emit_litlen(out, ((*raw).data[pos as usize] as i64) & 255)
+            pos = pos + 1
+        }
+    }
+    emit_litlen(out, 256)  // end of block
+    flush_bits(out)
+}
+
+// ----------------------------------------------------------------------------
 
 // Encode `img` as an 8-bit RGB PNG and write it to `filename`.
 // Returns true on success.
@@ -83,9 +257,13 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     }
     let adler = ((s2 << 16) | s1) & 4294967295
 
+    // ---- DEFLATE, with stored-block fallback if it would expand ----
+    var bo = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
+    deflate_fixed(&!bo, &raw)
+    let use_deflate = bo.len < raw.len
+
     // ---- assemble the PNG ----
     var png = PngBuf { data: [0; 262144], len: 0 }
-    // signature
     put(&!png, 137); put(&!png, 80); put(&!png, 78); put(&!png, 71)
     put(&!png, 13); put(&!png, 10); put(&!png, 26); put(&!png, 10)
     // IHDR
@@ -96,33 +274,39 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     put(&!png, 8); put(&!png, 2); put(&!png, 0); put(&!png, 0); put(&!png, 0)
     let ihdr_crc = crc_range(&png, ihdr_start, png.len)
     put_be32(&!png, ihdr_crc)
-    // IDAT — zlib stream length is analytic for stored blocks
+    // IDAT — zlib stream: header + (deflate | stored) + Adler-32
+    var zlen = 0
     var nblocks = raw.len / 65535
     if (raw.len % 65535) != 0 { nblocks = nblocks + 1 }
     if nblocks == 0 { nblocks = 1 }
-    let zlen = 2 + 5 * nblocks + raw.len + 4
+    if use_deflate { zlen = 2 + bo.len + 4 } else { zlen = 2 + 5 * nblocks + raw.len + 4 }
     put_be32(&!png, zlen)
     let idat_start = png.len
     put(&!png, 73); put(&!png, 68); put(&!png, 65); put(&!png, 84)  // "IDAT"
     put(&!png, 120); put(&!png, 1)  // zlib header 0x78 0x01
-    var pos = 0
-    var remaining = raw.len
-    while remaining > 0 {
-        var blk = remaining
-        if blk > 65535 { blk = 65535 }
-        var bfinal = 0
-        if blk == remaining { bfinal = 1 }
-        put(&!png, bfinal)
-        put(&!png, blk & 255); put(&!png, (blk >> 8) & 255)
-        let nlen = 65535 - blk
-        put(&!png, nlen & 255); put(&!png, (nlen >> 8) & 255)
-        var j = 0
-        while j < blk {
-            put(&!png, (raw.data[(pos + j) as usize] as i64) & 255)
-            j = j + 1
+    if use_deflate {
+        var i = 0
+        while i < bo.len { put(&!png, (bo.data[i as usize] as i64) & 255); i = i + 1 }
+    } else {
+        var pos = 0
+        var remaining = raw.len
+        while remaining > 0 {
+            var blk = remaining
+            if blk > 65535 { blk = 65535 }
+            var bfinal = 0
+            if blk == remaining { bfinal = 1 }
+            put(&!png, bfinal)
+            put(&!png, blk & 255); put(&!png, (blk >> 8) & 255)
+            let nlen = 65535 - blk
+            put(&!png, nlen & 255); put(&!png, (nlen >> 8) & 255)
+            var j = 0
+            while j < blk {
+                put(&!png, (raw.data[(pos + j) as usize] as i64) & 255)
+                j = j + 1
+            }
+            pos = pos + blk
+            remaining = remaining - blk
         }
-        pos = pos + blk
-        remaining = remaining - blk
     }
     put_be32(&!png, adler)
     let idat_crc = crc_range(&png, idat_start, png.len)

--- a/stdlib/image/pure/png.sio
+++ b/stdlib/image/pure/png.sio
@@ -9,15 +9,15 @@
 // This is the self-contained alternative to the `image::ffi` libpng/stb path.
 //
 // Pixel format: each `u32` in `Image.pixels` is 0x00RRGGBB (top byte ignored).
-// Size bound: `Image` caps at 65536 pixels (256x256).
+// Size bound: `Image` caps at 262144 pixels (512x512).
 
 module image::pure::png
 
 use image::pure::types::{Image}
 
-struct PngBuf { data: [i8; 262144], len: i64 }
-struct BitOut { data: [i8; 262144], len: i64, acc: i64, nbits: i64 }
-struct Hash { head: [i64; 32768], prev: [i64; 200000] }
+struct PngBuf { data: [i8; 800000], len: i64 }
+struct BitOut { data: [i8; 800000], len: i64, acc: i64, nbits: i64 }
+struct Hash { head: [i64; 32768], prev: [i64; 800000] }
 struct Huff { len: [i64; 288], code: [i64; 288] }
 struct Match { len: i64, dist: i64 }
 struct LC { sym: i64, xb: i64, xval: i64 }
@@ -307,7 +307,7 @@ fn lz_tokenize(raw: &PngBuf, n: i64, hh: &!Hash, mode: i64, fr: &!Freqs,
 // ---- one dynamic-Huffman DEFLATE block over raw[0..raw.len] -----------------
 fn deflate_dynamic(out: &!BitOut, raw: &PngBuf) with Mut, Div, Panic {
     let n = (*raw).len
-    var hash = Hash { head: [0; 32768], prev: [0; 200000] }
+    var hash = Hash { head: [0; 32768], prev: [0; 800000] }
     var fr = Freqs { ll: [0; 288], d: [0; 288] }
     var huff_ll = Huff { len: [0; 288], code: [0; 288] }
     var huff_d = Huff { len: [0; 288], code: [0; 288] }
@@ -424,7 +424,7 @@ fn paeth(a: i64, b: i64, c: i64) -> i64 with Mut {
 }
 
 // One filtered byte for filter type f at row index i (bpp = 3).
-fn filt_byte(cur: &[i64; 768], prev: &[i64; 768], i: i64, f: i64) -> i64 with Mut, Panic, Div {
+fn filt_byte(cur: &[i64; 1536], prev: &[i64; 1536], i: i64, f: i64) -> i64 with Mut, Panic, Div {
     let a = if i >= 3 { cur[(i - 3) as usize] } else { 0 }
     let up = prev[i as usize]
     let c = if i >= 3 { prev[(i - 3) as usize] } else { 0 }
@@ -441,8 +441,8 @@ fn build_filtered_raw(img: &Image, adaptive: i64, raw: &!PngBuf) with Mut, Div, 
     let w = img.width as i64
     let h = img.height as i64
     let rowlen = w * 3
-    var cur: [i64; 768] = [0; 768]
-    var prev: [i64; 768] = [0; 768]
+    var cur: [i64; 1536] = [0; 1536]
+    var prev: [i64; 1536] = [0; 1536]
     var y = 0
     while y < h {
         var x = 0
@@ -501,12 +501,12 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
 
     // Try adaptive filtering and no filtering; DEFLATE both and keep the smaller.
     // (Adaptive helps smooth gradients hugely but can hurt LZ-matchable content.)
-    var raw_a = PngBuf { data: [0; 262144], len: 0 }
-    var raw_n = PngBuf { data: [0; 262144], len: 0 }
+    var raw_a = PngBuf { data: [0; 800000], len: 0 }
+    var raw_n = PngBuf { data: [0; 800000], len: 0 }
     build_filtered_raw(img, 1, &!raw_a)
     build_filtered_raw(img, 0, &!raw_n)
-    var bo_a = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
-    var bo_n = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
+    var bo_a = BitOut { data: [0; 800000], len: 0, acc: 0, nbits: 0 }
+    var bo_n = BitOut { data: [0; 800000], len: 0, acc: 0, nbits: 0 }
     deflate_dynamic(&!bo_a, &raw_a)
     deflate_dynamic(&!bo_n, &raw_n)
 
@@ -519,7 +519,7 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     let use_deflate = best_deflate < raw_len
 
     // assemble PNG
-    var png = PngBuf { data: [0; 262144], len: 0 }
+    var png = PngBuf { data: [0; 800000], len: 0 }
     put(&!png, 137); put(&!png, 80); put(&!png, 78); put(&!png, 71)
     put(&!png, 13); put(&!png, 10); put(&!png, 26); put(&!png, 10)
     put_be32(&!png, 13)

--- a/stdlib/image/pure/png.sio
+++ b/stdlib/image/pure/png.sio
@@ -21,6 +21,7 @@ struct Hash { head: [i64; 32768], prev: [i64; 200000] }
 struct Huff { len: [i64; 288], code: [i64; 288] }
 struct Match { len: i64, dist: i64 }
 struct LC { sym: i64, xb: i64, xval: i64 }
+struct Freqs { ll: [i64; 288], d: [i64; 288] }
 
 fn put(b: &!PngBuf, v: i64) with Mut, Panic {
     (*b).data[(*b).len as usize] = (v & 255) as i8
@@ -138,13 +139,14 @@ fn hash_insert(raw: &PngBuf, q: i64, n: i64, hh: &!Hash) with Mut, Panic {
         (*hh).head[h as usize] = q
     }
 }
-fn find_match(raw: &PngBuf, pos: i64, n: i64, hh: &!Hash) -> Match with Mut, Panic {
+// Longest match at pos among already-inserted earlier positions (no insert).
+fn search_match(raw: &PngBuf, pos: i64, n: i64, hh: &!Hash) -> Match with Mut, Panic {
     var best_len = 0; var best_dist = 0
     if pos + 2 < n {
         let h = hash_of(raw, pos)
         var cand = (*hh).head[h as usize]
         var chain = 0
-        while cand >= 0 && chain < 128 {
+        while cand >= 0 && chain < 256 {
             let dist = pos - cand
             if dist > 32768 { cand = 0 - 1 }
             else {
@@ -155,8 +157,6 @@ fn find_match(raw: &PngBuf, pos: i64, n: i64, hh: &!Hash) -> Match with Mut, Pan
                 chain = chain + 1
             }
         }
-        (*hh).prev[pos as usize] = (*hh).head[h as usize]
-        (*hh).head[h as usize] = pos
     }
     Match { len: best_len, dist: best_dist }
 }
@@ -261,42 +261,70 @@ fn build_huff(freq: &[i64; 288], n: i64, maxbits: i64, h: &!Huff) with Mut, Pani
     }
 }
 
+// Greedy LZ77, run in one of two modes so the count and emit passes make
+// identical decisions. mode 0: accumulate symbol frequencies into `fr`.
+// mode 1: emit tokens with the built `hll`/`hd` codes. (Lazy matching was
+// implemented and measured but regressed periodic/run-heavy image content, so
+// greedy with a deep hash chain is used — it never loses to a shallower search.)
+fn lz_tokenize(raw: &PngBuf, n: i64, hh: &!Hash, mode: i64, fr: &!Freqs,
+               out: &!BitOut, hll: &Huff, hd: &Huff) with Mut, Div, Panic {
+    hash_reset(hh)
+    var pos = 0
+    while pos < n {
+        var mlen = 0
+        var mdist = 0
+        if pos + 2 < n {
+            let m = search_match(raw, pos, n, hh)
+            mlen = m.len
+            mdist = m.dist
+        }
+        hash_insert(raw, pos, n, hh)
+        if mlen >= 3 {
+            let lc = len_code(mlen)
+            let dc = dist_code(mdist)
+            if mode == 0 {
+                (*fr).ll[lc.sym as usize] = (*fr).ll[lc.sym as usize] + 1
+                (*fr).d[dc.sym as usize] = (*fr).d[dc.sym as usize] + 1
+            } else {
+                emit_code(out, hll, lc.sym)
+                if lc.xb > 0 { bit_write(out, lc.xval, lc.xb) }
+                emit_code(out, hd, dc.sym)
+                if dc.xb > 0 { bit_write(out, dc.xval, dc.xb) }
+            }
+            var q = pos + 1
+            let stop = pos + mlen
+            while q < stop { hash_insert(raw, q, n, hh); q = q + 1 }
+            pos = pos + mlen
+        } else {
+            let byte = ((*raw).data[pos as usize] as i64) & 255
+            if mode == 0 { (*fr).ll[byte as usize] = (*fr).ll[byte as usize] + 1 }
+            else { emit_code(out, hll, byte) }
+            pos = pos + 1
+        }
+    }
+}
+
 // ---- one dynamic-Huffman DEFLATE block over raw[0..raw.len] -----------------
 fn deflate_dynamic(out: &!BitOut, raw: &PngBuf) with Mut, Div, Panic {
     let n = (*raw).len
     var hash = Hash { head: [0; 32768], prev: [0; 200000] }
-    var freq_ll: [i64; 288] = [0; 288]
-    var freq_d: [i64; 288] = [0; 288]
-
-    // pass 1 — count
-    hash_reset(&!hash)
-    var pos = 0
-    while pos < n {
-        let m = find_match(raw, pos, n, &!hash)
-        if m.len >= 3 {
-            let lc = len_code(m.len)
-            freq_ll[lc.sym as usize] = freq_ll[lc.sym as usize] + 1
-            let dc = dist_code(m.dist)
-            freq_d[dc.sym as usize] = freq_d[dc.sym as usize] + 1
-            var q = pos + 1
-            let stop = pos + m.len
-            while q < stop { hash_insert(raw, q, n, &!hash); q = q + 1 }
-            pos = pos + m.len
-        } else {
-            let byte = ((*raw).data[pos as usize] as i64) & 255
-            freq_ll[byte as usize] = freq_ll[byte as usize] + 1
-            pos = pos + 1
-        }
-    }
-    freq_ll[256 as usize] = freq_ll[256 as usize] + 1
-    var anyd = 0; var td = 0
-    while td < 30 { if freq_d[td as usize] > 0 { anyd = 1 } td = td + 1 }
-    if anyd == 0 { freq_d[0 as usize] = 1 }
-
+    var fr = Freqs { ll: [0; 288], d: [0; 288] }
     var huff_ll = Huff { len: [0; 288], code: [0; 288] }
     var huff_d = Huff { len: [0; 288], code: [0; 288] }
-    build_huff(&freq_ll, 286, 15, &!huff_ll)
-    build_huff(&freq_d, 30, 15, &!huff_d)
+
+    // pass 1 — count symbol frequencies (out/huffs unused in mode 0)
+    lz_tokenize(raw, n, &!hash, 0, &!fr, out, &huff_ll, &huff_d)
+    fr.ll[256 as usize] = fr.ll[256 as usize] + 1
+    var anyd = 0; var td = 0
+    while td < 30 { if fr.d[td as usize] > 0 { anyd = 1 } td = td + 1 }
+    if anyd == 0 { fr.d[0 as usize] = 1 }
+
+    var llf: [i64; 288] = [0; 288]
+    var df: [i64; 288] = [0; 288]
+    var ci = 0
+    while ci < 288 { llf[ci as usize] = fr.ll[ci as usize]; df[ci as usize] = fr.d[ci as usize]; ci = ci + 1 }
+    build_huff(&llf, 286, 15, &!huff_ll)
+    build_huff(&df, 30, 15, &!huff_d)
 
     var numll = 257
     var s = 285
@@ -378,29 +406,89 @@ fn deflate_dynamic(out: &!BitOut, raw: &PngBuf) with Mut, Div, Panic {
         j = j + 1
     }
 
-    // pass 2 — emit data with the dynamic codes
-    hash_reset(&!hash)
-    pos = 0
-    while pos < n {
-        let m = find_match(raw, pos, n, &!hash)
-        if m.len >= 3 {
-            let lc = len_code(m.len)
-            emit_code(out, &huff_ll, lc.sym)
-            if lc.xb > 0 { bit_write(out, lc.xval, lc.xb) }
-            let dc = dist_code(m.dist)
-            emit_code(out, &huff_d, dc.sym)
-            if dc.xb > 0 { bit_write(out, dc.xval, dc.xb) }
-            var q = pos + 1
-            let stop = pos + m.len
-            while q < stop { hash_insert(raw, q, n, &!hash); q = q + 1 }
-            pos = pos + m.len
-        } else {
-            emit_code(out, &huff_ll, ((*raw).data[pos as usize] as i64) & 255)
-            pos = pos + 1
-        }
-    }
+    // pass 2 — emit data with the dynamic codes (fr unused in mode 1)
+    lz_tokenize(raw, n, &!hash, 1, &!fr, out, &huff_ll, &huff_d)
     emit_code(out, &huff_ll, 256)
     flush_bits(out)
+}
+
+// PNG Paeth predictor (a=left, b=up, c=up-left).
+fn paeth(a: i64, b: i64, c: i64) -> i64 with Mut {
+    let p = a + b - c
+    var pa = p - a; if pa < 0 { pa = 0 - pa }
+    var pb = p - b; if pb < 0 { pb = 0 - pb }
+    var pc = p - c; if pc < 0 { pc = 0 - pc }
+    if pa <= pb && pa <= pc { return a }
+    if pb <= pc { return b }
+    c
+}
+
+// One filtered byte for filter type f at row index i (bpp = 3).
+fn filt_byte(cur: &[i64; 768], prev: &[i64; 768], i: i64, f: i64) -> i64 with Mut, Panic, Div {
+    let a = if i >= 3 { cur[(i - 3) as usize] } else { 0 }
+    let up = prev[i as usize]
+    let c = if i >= 3 { prev[(i - 3) as usize] } else { 0 }
+    if f == 0 { return cur[i as usize] & 255 }
+    if f == 1 { return (cur[i as usize] - a) & 255 }
+    if f == 2 { return (cur[i as usize] - up) & 255 }
+    if f == 3 { return (cur[i as usize] - ((a + up) / 2)) & 255 }
+    (cur[i as usize] - paeth(a, up, c)) & 255
+}
+
+// Build the filtered raw scanlines. `adaptive`: 0 = filter None on every row,
+// 1 = pick the filter (0..4) with the smallest sum of |signed residual| per row.
+fn build_filtered_raw(img: &Image, adaptive: i64, raw: &!PngBuf) with Mut, Div, Panic {
+    let w = img.width as i64
+    let h = img.height as i64
+    let rowlen = w * 3
+    var cur: [i64; 768] = [0; 768]
+    var prev: [i64; 768] = [0; 768]
+    var y = 0
+    while y < h {
+        var x = 0
+        while x < w {
+            let px = (img.pixels[(y * w + x) as usize] as i64) & 16777215
+            cur[(x * 3) as usize] = (px >> 16) & 255
+            cur[(x * 3 + 1) as usize] = (px >> 8) & 255
+            cur[(x * 3 + 2) as usize] = px & 255
+            x = x + 1
+        }
+        var best_f = 0
+        if adaptive == 1 {
+            var best_sad = 0 - 1
+            var f = 0
+            while f < 5 {
+                var sad = 0
+                var i = 0
+                while i < rowlen {
+                    let v = filt_byte(&cur, &prev, i, f)
+                    sad = sad + (if v < 128 { v } else { 256 - v })
+                    i = i + 1
+                }
+                if best_sad < 0 || sad < best_sad { best_sad = sad; best_f = f }
+                f = f + 1
+            }
+        }
+        put(raw, best_f)
+        var i2 = 0
+        while i2 < rowlen { put(raw, filt_byte(&cur, &prev, i2, best_f)); i2 = i2 + 1 }
+        var i3 = 0
+        while i3 < rowlen { prev[i3 as usize] = cur[i3 as usize]; i3 = i3 + 1 }
+        y = y + 1
+    }
+}
+
+fn adler32(raw: &PngBuf) -> i64 with Mut, Div, Panic {
+    var s1 = 1
+    var s2 = 0
+    var ai = 0
+    while ai < (*raw).len {
+        let byte = ((*raw).data[ai as usize] as i64) & 255
+        s1 = (s1 + byte) % 65521
+        s2 = (s2 + s1) % 65521
+        ai = ai + 1
+    }
+    ((s2 << 16) | s1) & 4294967295
 }
 
 // ----------------------------------------------------------------------------
@@ -411,38 +499,24 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     let h = img.height as i64
     if w <= 0 || h <= 0 { return false }
 
-    // filtered raw scanlines (filter byte 0 per row)
-    var raw = PngBuf { data: [0; 262144], len: 0 }
-    var y = 0
-    while y < h {
-        put(&!raw, 0)
-        var x = 0
-        while x < w {
-            let px = (img.pixels[(y * w + x) as usize] as i64) & 16777215
-            put(&!raw, (px >> 16) & 255)
-            put(&!raw, (px >> 8) & 255)
-            put(&!raw, px & 255)
-            x = x + 1
-        }
-        y = y + 1
-    }
+    // Try adaptive filtering and no filtering; DEFLATE both and keep the smaller.
+    // (Adaptive helps smooth gradients hugely but can hurt LZ-matchable content.)
+    var raw_a = PngBuf { data: [0; 262144], len: 0 }
+    var raw_n = PngBuf { data: [0; 262144], len: 0 }
+    build_filtered_raw(img, 1, &!raw_a)
+    build_filtered_raw(img, 0, &!raw_n)
+    var bo_a = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
+    var bo_n = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
+    deflate_dynamic(&!bo_a, &raw_a)
+    deflate_dynamic(&!bo_n, &raw_n)
 
-    // Adler-32
-    var s1 = 1
-    var s2 = 0
-    var ai = 0
-    while ai < raw.len {
-        let byte = (raw.data[ai as usize] as i64) & 255
-        s1 = (s1 + byte) % 65521
-        s2 = (s2 + s1) % 65521
-        ai = ai + 1
-    }
-    let adler = ((s2 << 16) | s1) & 4294967295
-
-    // DEFLATE (dynamic Huffman) with stored-block fallback
-    var bo = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
-    deflate_dynamic(&!bo, &raw)
-    let use_deflate = bo.len < raw.len
+    // pick the smaller compressed body; raw is the matching filtered stream
+    var use_adaptive = 1
+    if bo_n.len < bo_a.len { use_adaptive = 0 }
+    let best_deflate = if use_adaptive == 1 { bo_a.len } else { bo_n.len }
+    let raw_len = if use_adaptive == 1 { raw_a.len } else { raw_n.len }
+    let adler = if use_adaptive == 1 { adler32(&raw_a) } else { adler32(&raw_n) }
+    let use_deflate = best_deflate < raw_len
 
     // assemble PNG
     var png = PngBuf { data: [0; 262144], len: 0 }
@@ -456,20 +530,24 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     let ihdr_crc = crc_range(&png, ihdr_start, png.len)
     put_be32(&!png, ihdr_crc)
     var zlen = 0
-    var nblocks = raw.len / 65535
-    if (raw.len % 65535) != 0 { nblocks = nblocks + 1 }
+    var nblocks = raw_len / 65535
+    if (raw_len % 65535) != 0 { nblocks = nblocks + 1 }
     if nblocks == 0 { nblocks = 1 }
-    if use_deflate { zlen = 2 + bo.len + 4 } else { zlen = 2 + 5 * nblocks + raw.len + 4 }
+    if use_deflate { zlen = 2 + best_deflate + 4 } else { zlen = 2 + 5 * nblocks + raw_len + 4 }
     put_be32(&!png, zlen)
     let idat_start = png.len
     put(&!png, 73); put(&!png, 68); put(&!png, 65); put(&!png, 84)  // "IDAT"
     put(&!png, 120); put(&!png, 1)  // zlib header
     if use_deflate {
         var i = 0
-        while i < bo.len { put(&!png, (bo.data[i as usize] as i64) & 255); i = i + 1 }
+        while i < best_deflate {
+            if use_adaptive == 1 { put(&!png, (bo_a.data[i as usize] as i64) & 255) }
+            else { put(&!png, (bo_n.data[i as usize] as i64) & 255) }
+            i = i + 1
+        }
     } else {
         var pos = 0
-        var remaining = raw.len
+        var remaining = raw_len
         while remaining > 0 {
             var blk = remaining
             if blk > 65535 { blk = 65535 }
@@ -480,7 +558,11 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
             let nlen = 65535 - blk
             put(&!png, nlen & 255); put(&!png, (nlen >> 8) & 255)
             var j = 0
-            while j < blk { put(&!png, (raw.data[(pos + j) as usize] as i64) & 255); j = j + 1 }
+            while j < blk {
+                if use_adaptive == 1 { put(&!png, (raw_a.data[(pos + j) as usize] as i64) & 255) }
+                else { put(&!png, (raw_n.data[(pos + j) as usize] as i64) & 255) }
+                j = j + 1
+            }
             pos = pos + blk
             remaining = remaining - blk
         }

--- a/stdlib/image/pure/png.sio
+++ b/stdlib/image/pure/png.sio
@@ -1,42 +1,34 @@
 // stdlib/image/pure/png.sio — Pure-Sounio PNG encoder (no FFI, no libpng)
 //
 // Writes a spec-valid 8-bit RGB PNG straight to disk via the `write_file` builtin.
-// Compression is real DEFLATE: fixed-Huffman blocks with LZ77 back-references
-// found by a capped hash-chain matcher. If the compressed body would be larger
-// than the input (e.g. smooth high-entropy data), it falls back to a stored
-// (uncompressed) block, so output is never worse than raw + a few bytes.
+// Compression is real DEFLATE with DYNAMIC Huffman codes: a two-pass LZ77
+// (count symbol frequencies, build per-image Huffman trees, emit) with matches
+// found by a capped hash chain, code lengths run-length encoded per RFC 1951.
+// If the compressed body would exceed the input (incompressible data), it falls
+// back to a stored block, so output is never worse than raw + a few bytes.
 // This is the self-contained alternative to the `image::ffi` libpng/stb path.
 //
-// Pixel format: each `u32` in `Image.pixels` is interpreted as 0x00RRGGBB
-// (low 24 bits; the top byte is ignored).
-//
-// Size bound: `Image` caps at 65536 pixels (256x256). Scratch buffers below
-// hold the worst-case PNG and hash state for that cap.
+// Pixel format: each `u32` in `Image.pixels` is 0x00RRGGBB (top byte ignored).
+// Size bound: `Image` caps at 65536 pixels (256x256).
 
 module image::pure::png
 
 use image::pure::types::{Image}
 
-// Scratch byte buffer with a running length. A struct wrapper is used because
-// bare `&![i8; N]` element mutation is not reliable under the current JIT.
 struct PngBuf { data: [i8; 262144], len: i64 }
-
-// Bit-level output for the DEFLATE stream (LSB-first bit packing).
 struct BitOut { data: [i8; 262144], len: i64, acc: i64, nbits: i64 }
+struct Hash { head: [i64; 32768], prev: [i64; 200000] }
+struct Huff { len: [i64; 288], code: [i64; 288] }
+struct Match { len: i64, dist: i64 }
+struct LC { sym: i64, xb: i64, xval: i64 }
 
 fn put(b: &!PngBuf, v: i64) with Mut, Panic {
     (*b).data[(*b).len as usize] = (v & 255) as i8
     (*b).len = (*b).len + 1
 }
-
 fn put_be32(b: &!PngBuf, v: i64) with Mut, Panic {
-    put(b, (v >> 24) & 255)
-    put(b, (v >> 16) & 255)
-    put(b, (v >> 8) & 255)
-    put(b, v & 255)
+    put(b, (v >> 24) & 255); put(b, (v >> 16) & 255); put(b, (v >> 8) & 255); put(b, v & 255)
 }
-
-// CRC-32 (PNG polynomial 0xEDB88320 = 3988292384) over data[start..end].
 fn crc_range(b: &PngBuf, start: i64, end: i64) -> i64 with Mut, Panic {
     var crc = 4294967295
     var i = start
@@ -44,208 +36,398 @@ fn crc_range(b: &PngBuf, start: i64, end: i64) -> i64 with Mut, Panic {
         let byte = ((*b).data[i as usize] as i64) & 255
         crc = crc ^ byte
         var k = 0
-        while k < 8 {
-            if (crc & 1) == 1 { crc = (crc >> 1) ^ 3988292384 } else { crc = crc >> 1 }
-            k = k + 1
-        }
+        while k < 8 { if (crc & 1) == 1 { crc = (crc >> 1) ^ 3988292384 } else { crc = crc >> 1 } k = k + 1 }
         i = i + 1
     }
     (crc ^ 4294967295) & 4294967295
 }
 
-// ---- DEFLATE (fixed Huffman + LZ77) ----------------------------------------
-
+// ---- DEFLATE bit output ----------------------------------------------------
 fn bo_put(d: &!BitOut, v: i64) with Mut, Panic {
     (*d).data[(*d).len as usize] = (v & 255) as i8
     (*d).len = (*d).len + 1
 }
-
 fn bit_write(d: &!BitOut, val: i64, n: i64) with Mut, Panic {
     (*d).acc = (*d).acc | (val << (*d).nbits)
     (*d).nbits = (*d).nbits + n
-    while (*d).nbits >= 8 {
-        bo_put(d, (*d).acc & 255)
-        (*d).acc = (*d).acc >> 8
-        (*d).nbits = (*d).nbits - 8
-    }
+    while (*d).nbits >= 8 { bo_put(d, (*d).acc & 255); (*d).acc = (*d).acc >> 8; (*d).nbits = (*d).nbits - 8 }
 }
-
 fn flush_bits(d: &!BitOut) with Mut, Panic {
-    if (*d).nbits > 0 {
-        bo_put(d, (*d).acc & 255)
-        (*d).acc = 0
-        (*d).nbits = 0
-    }
+    if (*d).nbits > 0 { bo_put(d, (*d).acc & 255); (*d).acc = 0; (*d).nbits = 0 }
 }
-
 fn reverse_bits(code: i64, n: i64) -> i64 with Mut {
-    var r = 0
-    var i = 0
+    var r = 0; var i = 0
     while i < n { r = (r << 1) | ((code >> i) & 1); i = i + 1 }
     r
 }
-
-// Fixed literal/length Huffman code for symbol 0..287.
-fn emit_litlen(d: &!BitOut, sym: i64) with Mut, Panic {
-    if sym <= 143 { bit_write(d, reverse_bits(48 + sym, 8), 8); return }
-    if sym <= 255 { bit_write(d, reverse_bits(400 + (sym - 144), 9), 9); return }
-    if sym <= 279 { bit_write(d, reverse_bits(sym - 256, 7), 7); return }
-    bit_write(d, reverse_bits(192 + (sym - 280), 8), 8)
+fn emit_code(d: &!BitOut, h: &Huff, sym: i64) with Mut, Panic {
+    let L = (*h).len[sym as usize]
+    bit_write(d, reverse_bits((*h).code[sym as usize], L), L)
 }
 
-// Length symbol (257..285) + extra bits, for match length 3..258.
-fn emit_len(d: &!BitOut, len: i64) with Mut, Panic {
-    if len <= 10 { emit_litlen(d, len + 254); return }
-    if len <= 12 { emit_litlen(d, 265); bit_write(d, len - 11, 1); return }
-    if len <= 14 { emit_litlen(d, 266); bit_write(d, len - 13, 1); return }
-    if len <= 16 { emit_litlen(d, 267); bit_write(d, len - 15, 1); return }
-    if len <= 18 { emit_litlen(d, 268); bit_write(d, len - 17, 1); return }
-    if len <= 22 { emit_litlen(d, 269); bit_write(d, len - 19, 2); return }
-    if len <= 26 { emit_litlen(d, 270); bit_write(d, len - 23, 2); return }
-    if len <= 30 { emit_litlen(d, 271); bit_write(d, len - 27, 2); return }
-    if len <= 34 { emit_litlen(d, 272); bit_write(d, len - 31, 2); return }
-    if len <= 42 { emit_litlen(d, 273); bit_write(d, len - 35, 3); return }
-    if len <= 50 { emit_litlen(d, 274); bit_write(d, len - 43, 3); return }
-    if len <= 58 { emit_litlen(d, 275); bit_write(d, len - 51, 3); return }
-    if len <= 66 { emit_litlen(d, 276); bit_write(d, len - 59, 3); return }
-    if len <= 82 { emit_litlen(d, 277); bit_write(d, len - 67, 4); return }
-    if len <= 98 { emit_litlen(d, 278); bit_write(d, len - 83, 4); return }
-    if len <= 114 { emit_litlen(d, 279); bit_write(d, len - 99, 4); return }
-    if len <= 130 { emit_litlen(d, 280); bit_write(d, len - 115, 4); return }
-    if len <= 162 { emit_litlen(d, 281); bit_write(d, len - 131, 5); return }
-    if len <= 194 { emit_litlen(d, 282); bit_write(d, len - 163, 5); return }
-    if len <= 226 { emit_litlen(d, 283); bit_write(d, len - 195, 5); return }
-    if len <= 257 { emit_litlen(d, 284); bit_write(d, len - 227, 5); return }
-    emit_litlen(d, 285)
+// ---- DEFLATE length / distance symbol tables (single source) ---------------
+fn len_code(len: i64) -> LC {
+    if len <= 10 { return LC { sym: len + 254, xb: 0, xval: 0 } }
+    if len <= 12 { return LC { sym: 265, xb: 1, xval: len - 11 } }
+    if len <= 14 { return LC { sym: 266, xb: 1, xval: len - 13 } }
+    if len <= 16 { return LC { sym: 267, xb: 1, xval: len - 15 } }
+    if len <= 18 { return LC { sym: 268, xb: 1, xval: len - 17 } }
+    if len <= 22 { return LC { sym: 269, xb: 2, xval: len - 19 } }
+    if len <= 26 { return LC { sym: 270, xb: 2, xval: len - 23 } }
+    if len <= 30 { return LC { sym: 271, xb: 2, xval: len - 27 } }
+    if len <= 34 { return LC { sym: 272, xb: 2, xval: len - 31 } }
+    if len <= 42 { return LC { sym: 273, xb: 3, xval: len - 35 } }
+    if len <= 50 { return LC { sym: 274, xb: 3, xval: len - 43 } }
+    if len <= 58 { return LC { sym: 275, xb: 3, xval: len - 51 } }
+    if len <= 66 { return LC { sym: 276, xb: 3, xval: len - 59 } }
+    if len <= 82 { return LC { sym: 277, xb: 4, xval: len - 67 } }
+    if len <= 98 { return LC { sym: 278, xb: 4, xval: len - 83 } }
+    if len <= 114 { return LC { sym: 279, xb: 4, xval: len - 99 } }
+    if len <= 130 { return LC { sym: 280, xb: 4, xval: len - 115 } }
+    if len <= 162 { return LC { sym: 281, xb: 5, xval: len - 131 } }
+    if len <= 194 { return LC { sym: 282, xb: 5, xval: len - 163 } }
+    if len <= 226 { return LC { sym: 283, xb: 5, xval: len - 195 } }
+    if len <= 257 { return LC { sym: 284, xb: 5, xval: len - 227 } }
+    LC { sym: 285, xb: 0, xval: 0 }
+}
+fn dist_code(dist: i64) -> LC {
+    if dist <= 4 { return LC { sym: dist - 1, xb: 0, xval: 0 } }
+    if dist <= 6 { return LC { sym: 4, xb: 1, xval: dist - 5 } }
+    if dist <= 8 { return LC { sym: 5, xb: 1, xval: dist - 7 } }
+    if dist <= 12 { return LC { sym: 6, xb: 2, xval: dist - 9 } }
+    if dist <= 16 { return LC { sym: 7, xb: 2, xval: dist - 13 } }
+    if dist <= 24 { return LC { sym: 8, xb: 3, xval: dist - 17 } }
+    if dist <= 32 { return LC { sym: 9, xb: 3, xval: dist - 25 } }
+    if dist <= 48 { return LC { sym: 10, xb: 4, xval: dist - 33 } }
+    if dist <= 64 { return LC { sym: 11, xb: 4, xval: dist - 49 } }
+    if dist <= 96 { return LC { sym: 12, xb: 5, xval: dist - 65 } }
+    if dist <= 128 { return LC { sym: 13, xb: 5, xval: dist - 97 } }
+    if dist <= 192 { return LC { sym: 14, xb: 6, xval: dist - 129 } }
+    if dist <= 256 { return LC { sym: 15, xb: 6, xval: dist - 193 } }
+    if dist <= 384 { return LC { sym: 16, xb: 7, xval: dist - 257 } }
+    if dist <= 512 { return LC { sym: 17, xb: 7, xval: dist - 385 } }
+    if dist <= 768 { return LC { sym: 18, xb: 8, xval: dist - 513 } }
+    if dist <= 1024 { return LC { sym: 19, xb: 8, xval: dist - 769 } }
+    if dist <= 1536 { return LC { sym: 20, xb: 9, xval: dist - 1025 } }
+    if dist <= 2048 { return LC { sym: 21, xb: 9, xval: dist - 1537 } }
+    if dist <= 3072 { return LC { sym: 22, xb: 10, xval: dist - 2049 } }
+    if dist <= 4096 { return LC { sym: 23, xb: 10, xval: dist - 3073 } }
+    if dist <= 6144 { return LC { sym: 24, xb: 11, xval: dist - 4097 } }
+    if dist <= 8192 { return LC { sym: 25, xb: 11, xval: dist - 6145 } }
+    if dist <= 12288 { return LC { sym: 26, xb: 12, xval: dist - 8193 } }
+    if dist <= 16384 { return LC { sym: 27, xb: 12, xval: dist - 12289 } }
+    if dist <= 24576 { return LC { sym: 28, xb: 13, xval: dist - 16385 } }
+    LC { sym: 29, xb: 13, xval: dist - 24577 }
 }
 
-// Distance symbol (0..29, 5-bit code) + extra bits, for distance 1..32768.
-fn emit_dist(d: &!BitOut, dist: i64) with Mut, Panic {
-    if dist <= 4 { bit_write(d, reverse_bits(dist - 1, 5), 5); return }
-    if dist <= 6 { bit_write(d, reverse_bits(4, 5), 5); bit_write(d, dist - 5, 1); return }
-    if dist <= 8 { bit_write(d, reverse_bits(5, 5), 5); bit_write(d, dist - 7, 1); return }
-    if dist <= 12 { bit_write(d, reverse_bits(6, 5), 5); bit_write(d, dist - 9, 2); return }
-    if dist <= 16 { bit_write(d, reverse_bits(7, 5), 5); bit_write(d, dist - 13, 2); return }
-    if dist <= 24 { bit_write(d, reverse_bits(8, 5), 5); bit_write(d, dist - 17, 3); return }
-    if dist <= 32 { bit_write(d, reverse_bits(9, 5), 5); bit_write(d, dist - 25, 3); return }
-    if dist <= 48 { bit_write(d, reverse_bits(10, 5), 5); bit_write(d, dist - 33, 4); return }
-    if dist <= 64 { bit_write(d, reverse_bits(11, 5), 5); bit_write(d, dist - 49, 4); return }
-    if dist <= 96 { bit_write(d, reverse_bits(12, 5), 5); bit_write(d, dist - 65, 5); return }
-    if dist <= 128 { bit_write(d, reverse_bits(13, 5), 5); bit_write(d, dist - 97, 5); return }
-    if dist <= 192 { bit_write(d, reverse_bits(14, 5), 5); bit_write(d, dist - 129, 6); return }
-    if dist <= 256 { bit_write(d, reverse_bits(15, 5), 5); bit_write(d, dist - 193, 6); return }
-    if dist <= 384 { bit_write(d, reverse_bits(16, 5), 5); bit_write(d, dist - 257, 7); return }
-    if dist <= 512 { bit_write(d, reverse_bits(17, 5), 5); bit_write(d, dist - 385, 7); return }
-    if dist <= 768 { bit_write(d, reverse_bits(18, 5), 5); bit_write(d, dist - 513, 8); return }
-    if dist <= 1024 { bit_write(d, reverse_bits(19, 5), 5); bit_write(d, dist - 769, 8); return }
-    if dist <= 1536 { bit_write(d, reverse_bits(20, 5), 5); bit_write(d, dist - 1025, 9); return }
-    if dist <= 2048 { bit_write(d, reverse_bits(21, 5), 5); bit_write(d, dist - 1537, 9); return }
-    if dist <= 3072 { bit_write(d, reverse_bits(22, 5), 5); bit_write(d, dist - 2049, 10); return }
-    if dist <= 4096 { bit_write(d, reverse_bits(23, 5), 5); bit_write(d, dist - 3073, 10); return }
-    if dist <= 6144 { bit_write(d, reverse_bits(24, 5), 5); bit_write(d, dist - 4097, 11); return }
-    if dist <= 8192 { bit_write(d, reverse_bits(25, 5), 5); bit_write(d, dist - 6145, 11); return }
-    if dist <= 12288 { bit_write(d, reverse_bits(26, 5), 5); bit_write(d, dist - 8193, 12); return }
-    if dist <= 16384 { bit_write(d, reverse_bits(27, 5), 5); bit_write(d, dist - 12289, 12); return }
-    if dist <= 24576 { bit_write(d, reverse_bits(28, 5), 5); bit_write(d, dist - 16385, 13); return }
-    bit_write(d, reverse_bits(29, 5), 5); bit_write(d, dist - 24577, 13)
+// ---- LZ77 hash chain -------------------------------------------------------
+fn hash_reset(hh: &!Hash) with Mut, Panic {
+    var i = 0
+    while i < 32768 { (*hh).head[i as usize] = 0 - 1; i = i + 1 }
+}
+fn hash_of(raw: &PngBuf, p: i64) -> i64 with Panic {
+    let a = ((*raw).data[p as usize] as i64) & 255
+    let b = ((*raw).data[(p + 1) as usize] as i64) & 255
+    let c = ((*raw).data[(p + 2) as usize] as i64) & 255
+    ((a << 10) + (b << 5) + c) & 32767
+}
+fn hash_insert(raw: &PngBuf, q: i64, n: i64, hh: &!Hash) with Mut, Panic {
+    if q + 2 < n {
+        let h = hash_of(raw, q)
+        (*hh).prev[q as usize] = (*hh).head[h as usize]
+        (*hh).head[h as usize] = q
+    }
+}
+fn find_match(raw: &PngBuf, pos: i64, n: i64, hh: &!Hash) -> Match with Mut, Panic {
+    var best_len = 0; var best_dist = 0
+    if pos + 2 < n {
+        let h = hash_of(raw, pos)
+        var cand = (*hh).head[h as usize]
+        var chain = 0
+        while cand >= 0 && chain < 128 {
+            let dist = pos - cand
+            if dist > 32768 { cand = 0 - 1 }
+            else {
+                var l = 0
+                while l < 258 && (pos + l) < n && (*raw).data[(cand + l) as usize] == (*raw).data[(pos + l) as usize] { l = l + 1 }
+                if l > best_len { best_len = l; best_dist = dist }
+                cand = (*hh).prev[cand as usize]
+                chain = chain + 1
+            }
+        }
+        (*hh).prev[pos as usize] = (*hh).head[h as usize]
+        (*hh).head[h as usize] = pos
+    }
+    Match { len: best_len, dist: best_dist }
 }
 
-// One fixed-Huffman DEFLATE block (BFINAL=1) over raw[0..raw.len], with LZ77
-// matches from a capped hash chain. Local hash state (head/prev) avoids passing
-// bare `&![i64; N]` array refs.
-fn deflate_fixed(out: &!BitOut, raw: &PngBuf) with Mut, Panic {
+// ---- canonical length-limited Huffman --------------------------------------
+fn build_huff(freq: &[i64; 288], n: i64, maxbits: i64, h: &!Huff) with Mut, Panic, Div {
+    var i = 0
+    while i < n { (*h).len[i as usize] = 0; (*h).code[i as usize] = 0; i = i + 1 }
+    var nleaf = 0
+    i = 0
+    while i < n { if freq[i as usize] > 0 { nleaf = nleaf + 1 } i = i + 1 }
+    if nleaf == 0 { return }
+    if nleaf == 1 {
+        i = 0
+        while i < n { if freq[i as usize] > 0 { (*h).len[i as usize] = 1 } i = i + 1 }
+    } else {
+        var wt: [i64; 600] = [0; 600]
+        var par: [i64; 600] = [0; 600]
+        var alive: [i64; 600] = [0; 600]
+        var na = 0
+        i = 0
+        while i < n {
+            if freq[i as usize] > 0 { wt[i as usize] = freq[i as usize]; par[i as usize] = 0 - 1; alive[na as usize] = i; na = na + 1 }
+            i = i + 1
+        }
+        var next = n
+        while na > 1 {
+            var m1 = 0; var m2 = 1
+            if wt[alive[m1 as usize] as usize] > wt[alive[m2 as usize] as usize] { let t = m1; m1 = m2; m2 = t }
+            var k = 2
+            while k < na {
+                let wk = wt[alive[k as usize] as usize]
+                if wk < wt[alive[m1 as usize] as usize] { m2 = m1; m1 = k }
+                else { if wk < wt[alive[m2 as usize] as usize] { m2 = k } }
+                k = k + 1
+            }
+            let a1 = alive[m1 as usize]; let a2 = alive[m2 as usize]
+            wt[next as usize] = wt[a1 as usize] + wt[a2 as usize]
+            par[next as usize] = 0 - 1; par[a1 as usize] = next; par[a2 as usize] = next
+            alive[m1 as usize] = next; alive[m2 as usize] = alive[(na - 1) as usize]
+            na = na - 1; next = next + 1
+        }
+        var overflow = 0
+        i = 0
+        while i < n {
+            if freq[i as usize] > 0 {
+                var dd = 0; var node = i
+                while par[node as usize] >= 0 { node = par[node as usize]; dd = dd + 1 }
+                if dd > maxbits { dd = maxbits; overflow = overflow + 1 }
+                (*h).len[i as usize] = dd
+            }
+            i = i + 1
+        }
+        if overflow > 0 {
+            var bl: [i64; 32] = [0; 32]
+            i = 0
+            while i < n { let li = (*h).len[i as usize]; if li > 0 { bl[li as usize] = bl[li as usize] + 1 } i = i + 1 }
+            var ov = overflow
+            while ov > 0 {
+                var bb = maxbits - 1
+                while bl[bb as usize] == 0 { bb = bb - 1 }
+                bl[bb as usize] = bl[bb as usize] - 1
+                bl[(bb + 1) as usize] = bl[(bb + 1) as usize] + 2
+                bl[maxbits as usize] = bl[maxbits as usize] - 1
+                ov = ov - 2
+            }
+            var order: [i64; 288] = [0; 288]
+            var oc = 0
+            i = 0
+            while i < n { if freq[i as usize] > 0 { order[oc as usize] = i; oc = oc + 1 } i = i + 1 }
+            var a = 1
+            while a < oc {
+                let key = order[a as usize]; let kf = freq[key as usize]
+                var jj = a - 1
+                while jj >= 0 && freq[order[jj as usize] as usize] > kf { order[(jj + 1) as usize] = order[jj as usize]; jj = jj - 1 }
+                order[(jj + 1) as usize] = key
+                a = a + 1
+            }
+            i = 0
+            while i < n { (*h).len[i as usize] = 0; i = i + 1 }
+            var idx = 0
+            var bb2 = maxbits
+            while bb2 >= 1 {
+                var cnt = bl[bb2 as usize]
+                while cnt > 0 { (*h).len[order[idx as usize] as usize] = bb2; idx = idx + 1; cnt = cnt - 1 }
+                bb2 = bb2 - 1
+            }
+        }
+    }
+    var blc: [i64; 32] = [0; 32]
+    i = 0
+    while i < n { let li = (*h).len[i as usize]; if li > 0 { blc[li as usize] = blc[li as usize] + 1 } i = i + 1 }
+    var nextcode: [i64; 32] = [0; 32]
+    var code = 0
+    var bits = 1
+    while bits <= maxbits { code = (code + blc[(bits - 1) as usize]) << 1; nextcode[bits as usize] = code; bits = bits + 1 }
+    i = 0
+    while i < n {
+        let li = (*h).len[i as usize]
+        if li > 0 { (*h).code[i as usize] = nextcode[li as usize]; nextcode[li as usize] = nextcode[li as usize] + 1 }
+        i = i + 1
+    }
+}
+
+// ---- one dynamic-Huffman DEFLATE block over raw[0..raw.len] -----------------
+fn deflate_dynamic(out: &!BitOut, raw: &PngBuf) with Mut, Div, Panic {
     let n = (*raw).len
-    var head: [i64; 32768] = [0; 32768]
-    var prev: [i64; 200000] = [0; 200000]
-    var hi = 0
-    while hi < 32768 { head[hi as usize] = 0 - 1; hi = hi + 1 }
+    var hash = Hash { head: [0; 32768], prev: [0; 200000] }
+    var freq_ll: [i64; 288] = [0; 288]
+    var freq_d: [i64; 288] = [0; 288]
 
-    bit_write(out, 1, 1)  // BFINAL = 1
-    bit_write(out, 1, 2)  // BTYPE  = 01 (fixed Huffman)
-
-    let max_match = 258
-    let max_dist = 32768
-    let max_chain = 128
+    // pass 1 — count
+    hash_reset(&!hash)
     var pos = 0
     while pos < n {
-        var best_len = 0
-        var best_dist = 0
-        if pos + 2 < n {
-            let a = ((*raw).data[pos as usize] as i64) & 255
-            let b = ((*raw).data[(pos + 1) as usize] as i64) & 255
-            let c = ((*raw).data[(pos + 2) as usize] as i64) & 255
-            let h = ((a << 10) + (b << 5) + c) & 32767
-            var cand = head[h as usize]
-            var chain = 0
-            while cand >= 0 && chain < max_chain {
-                let dist = pos - cand
-                if dist > max_dist { cand = 0 - 1 }
-                else {
-                    var l = 0
-                    while l < max_match && (pos + l) < n
-                          && (*raw).data[(cand + l) as usize] == (*raw).data[(pos + l) as usize] {
-                        l = l + 1
-                    }
-                    if l > best_len { best_len = l; best_dist = dist }
-                    cand = prev[cand as usize]
-                    chain = chain + 1
-                }
-            }
-            prev[pos as usize] = head[h as usize]
-            head[h as usize] = pos
-        }
-        if best_len >= 3 {
-            emit_len(out, best_len)
-            emit_dist(out, best_dist)
+        let m = find_match(raw, pos, n, &!hash)
+        if m.len >= 3 {
+            let lc = len_code(m.len)
+            freq_ll[lc.sym as usize] = freq_ll[lc.sym as usize] + 1
+            let dc = dist_code(m.dist)
+            freq_d[dc.sym as usize] = freq_d[dc.sym as usize] + 1
             var q = pos + 1
-            let stop = pos + best_len
-            while q < stop {
-                if q + 2 < n {
-                    let a2 = ((*raw).data[q as usize] as i64) & 255
-                    let b2 = ((*raw).data[(q + 1) as usize] as i64) & 255
-                    let c2 = ((*raw).data[(q + 2) as usize] as i64) & 255
-                    let h2 = ((a2 << 10) + (b2 << 5) + c2) & 32767
-                    prev[q as usize] = head[h2 as usize]
-                    head[h2 as usize] = q
-                }
-                q = q + 1
-            }
-            pos = pos + best_len
+            let stop = pos + m.len
+            while q < stop { hash_insert(raw, q, n, &!hash); q = q + 1 }
+            pos = pos + m.len
         } else {
-            emit_litlen(out, ((*raw).data[pos as usize] as i64) & 255)
+            let byte = ((*raw).data[pos as usize] as i64) & 255
+            freq_ll[byte as usize] = freq_ll[byte as usize] + 1
             pos = pos + 1
         }
     }
-    emit_litlen(out, 256)  // end of block
+    freq_ll[256 as usize] = freq_ll[256 as usize] + 1
+    var anyd = 0; var td = 0
+    while td < 30 { if freq_d[td as usize] > 0 { anyd = 1 } td = td + 1 }
+    if anyd == 0 { freq_d[0 as usize] = 1 }
+
+    var huff_ll = Huff { len: [0; 288], code: [0; 288] }
+    var huff_d = Huff { len: [0; 288], code: [0; 288] }
+    build_huff(&freq_ll, 286, 15, &!huff_ll)
+    build_huff(&freq_d, 30, 15, &!huff_d)
+
+    var numll = 257
+    var s = 285
+    while s >= 257 { if huff_ll.len[s as usize] > 0 { numll = s + 1; s = 256 } else { s = s - 1 } }
+    var numd = 1
+    s = 29
+    while s >= 1 { if huff_d.len[s as usize] > 0 { numd = s + 1; s = 0 } else { s = s - 1 } }
+
+    // combined code-length list
+    var cl: [i64; 320] = [0; 320]
+    var cln = 0
+    var i = 0
+    while i < numll { cl[cln as usize] = huff_ll.len[i as usize]; cln = cln + 1; i = i + 1 }
+    i = 0
+    while i < numd { cl[cln as usize] = huff_d.len[i as usize]; cln = cln + 1; i = i + 1 }
+
+    // RLE of code lengths
+    var rsym: [i64; 640] = [0; 640]
+    var rxb: [i64; 640] = [0; 640]
+    var rxv: [i64; 640] = [0; 640]
+    var rn = 0
+    var freq_cl: [i64; 288] = [0; 288]
+    var p = 0
+    while p < cln {
+        let cur = cl[p as usize]
+        var run = 1
+        while (p + run) < cln && cl[(p + run) as usize] == cur { run = run + 1 }
+        if cur == 0 {
+            while run >= 11 {
+                var r = run; if r > 138 { r = 138 }
+                rsym[rn as usize] = 18; rxb[rn as usize] = 7; rxv[rn as usize] = r - 11; rn = rn + 1
+                freq_cl[18 as usize] = freq_cl[18 as usize] + 1; run = run - r; p = p + r
+            }
+            while run >= 3 {
+                var r2 = run; if r2 > 10 { r2 = 10 }
+                rsym[rn as usize] = 17; rxb[rn as usize] = 3; rxv[rn as usize] = r2 - 3; rn = rn + 1
+                freq_cl[17 as usize] = freq_cl[17 as usize] + 1; run = run - r2; p = p + r2
+            }
+            while run > 0 {
+                rsym[rn as usize] = 0; rxb[rn as usize] = 0; rxv[rn as usize] = 0; rn = rn + 1
+                freq_cl[0 as usize] = freq_cl[0 as usize] + 1; run = run - 1; p = p + 1
+            }
+        } else {
+            rsym[rn as usize] = cur; rxb[rn as usize] = 0; rxv[rn as usize] = 0; rn = rn + 1
+            freq_cl[cur as usize] = freq_cl[cur as usize] + 1; run = run - 1; p = p + 1
+            while run >= 3 {
+                var r3 = run; if r3 > 6 { r3 = 6 }
+                rsym[rn as usize] = 16; rxb[rn as usize] = 2; rxv[rn as usize] = r3 - 3; rn = rn + 1
+                freq_cl[16 as usize] = freq_cl[16 as usize] + 1; run = run - r3; p = p + r3
+            }
+            while run > 0 {
+                rsym[rn as usize] = cur; rxb[rn as usize] = 0; rxv[rn as usize] = 0; rn = rn + 1
+                freq_cl[cur as usize] = freq_cl[cur as usize] + 1; run = run - 1; p = p + 1
+            }
+        }
+    }
+
+    var huff_cl = Huff { len: [0; 288], code: [0; 288] }
+    build_huff(&freq_cl, 19, 7, &!huff_cl)
+
+    var perm: [i64; 19] = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]
+    var numcl = 19
+    s = 18
+    while s >= 4 { if huff_cl.len[perm[s as usize] as usize] > 0 { numcl = s + 1; s = 3 } else { s = s - 1 } }
+    if numcl < 4 { numcl = 4 }
+
+    // emit block header
+    bit_write(out, 1, 1)               // BFINAL
+    bit_write(out, 2, 2)               // BTYPE = 10 (dynamic)
+    bit_write(out, numll - 257, 5)     // HLIT
+    bit_write(out, numd - 1, 5)        // HDIST
+    bit_write(out, numcl - 4, 4)       // HCLEN
+    var j = 0
+    while j < numcl { bit_write(out, huff_cl.len[perm[j as usize] as usize], 3); j = j + 1 }
+    j = 0
+    while j < rn {
+        emit_code(out, &huff_cl, rsym[j as usize])
+        if rxb[j as usize] > 0 { bit_write(out, rxv[j as usize], rxb[j as usize]) }
+        j = j + 1
+    }
+
+    // pass 2 — emit data with the dynamic codes
+    hash_reset(&!hash)
+    pos = 0
+    while pos < n {
+        let m = find_match(raw, pos, n, &!hash)
+        if m.len >= 3 {
+            let lc = len_code(m.len)
+            emit_code(out, &huff_ll, lc.sym)
+            if lc.xb > 0 { bit_write(out, lc.xval, lc.xb) }
+            let dc = dist_code(m.dist)
+            emit_code(out, &huff_d, dc.sym)
+            if dc.xb > 0 { bit_write(out, dc.xval, dc.xb) }
+            var q = pos + 1
+            let stop = pos + m.len
+            while q < stop { hash_insert(raw, q, n, &!hash); q = q + 1 }
+            pos = pos + m.len
+        } else {
+            emit_code(out, &huff_ll, ((*raw).data[pos as usize] as i64) & 255)
+            pos = pos + 1
+        }
+    }
+    emit_code(out, &huff_ll, 256)
     flush_bits(out)
 }
 
 // ----------------------------------------------------------------------------
 
-// Encode `img` as an 8-bit RGB PNG and write it to `filename`.
-// Returns true on success.
+// Encode `img` as an 8-bit RGB PNG and write it to `filename`. Returns true on success.
 pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic {
     let w = img.width as i64
     let h = img.height as i64
     if w <= 0 || h <= 0 { return false }
 
-    // ---- filtered raw scanlines: a leading filter byte (0 = none) per row ----
+    // filtered raw scanlines (filter byte 0 per row)
     var raw = PngBuf { data: [0; 262144], len: 0 }
     var y = 0
     while y < h {
         put(&!raw, 0)
         var x = 0
         while x < w {
-            let p = (img.pixels[(y * w + x) as usize] as i64) & 16777215
-            put(&!raw, (p >> 16) & 255)
-            put(&!raw, (p >> 8) & 255)
-            put(&!raw, p & 255)
+            let px = (img.pixels[(y * w + x) as usize] as i64) & 16777215
+            put(&!raw, (px >> 16) & 255)
+            put(&!raw, (px >> 8) & 255)
+            put(&!raw, px & 255)
             x = x + 1
         }
         y = y + 1
     }
 
-    // ---- Adler-32 over the raw stream ----
+    // Adler-32
     var s1 = 1
     var s2 = 0
     var ai = 0
@@ -257,16 +439,15 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     }
     let adler = ((s2 << 16) | s1) & 4294967295
 
-    // ---- DEFLATE, with stored-block fallback if it would expand ----
+    // DEFLATE (dynamic Huffman) with stored-block fallback
     var bo = BitOut { data: [0; 262144], len: 0, acc: 0, nbits: 0 }
-    deflate_fixed(&!bo, &raw)
+    deflate_dynamic(&!bo, &raw)
     let use_deflate = bo.len < raw.len
 
-    // ---- assemble the PNG ----
+    // assemble PNG
     var png = PngBuf { data: [0; 262144], len: 0 }
     put(&!png, 137); put(&!png, 80); put(&!png, 78); put(&!png, 71)
     put(&!png, 13); put(&!png, 10); put(&!png, 26); put(&!png, 10)
-    // IHDR
     put_be32(&!png, 13)
     let ihdr_start = png.len
     put(&!png, 73); put(&!png, 72); put(&!png, 68); put(&!png, 82)  // "IHDR"
@@ -274,7 +455,6 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     put(&!png, 8); put(&!png, 2); put(&!png, 0); put(&!png, 0); put(&!png, 0)
     let ihdr_crc = crc_range(&png, ihdr_start, png.len)
     put_be32(&!png, ihdr_crc)
-    // IDAT — zlib stream: header + (deflate | stored) + Adler-32
     var zlen = 0
     var nblocks = raw.len / 65535
     if (raw.len % 65535) != 0 { nblocks = nblocks + 1 }
@@ -283,7 +463,7 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     put_be32(&!png, zlen)
     let idat_start = png.len
     put(&!png, 73); put(&!png, 68); put(&!png, 65); put(&!png, 84)  // "IDAT"
-    put(&!png, 120); put(&!png, 1)  // zlib header 0x78 0x01
+    put(&!png, 120); put(&!png, 1)  // zlib header
     if use_deflate {
         var i = 0
         while i < bo.len { put(&!png, (bo.data[i as usize] as i64) & 255); i = i + 1 }
@@ -300,10 +480,7 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
             let nlen = 65535 - blk
             put(&!png, nlen & 255); put(&!png, (nlen >> 8) & 255)
             var j = 0
-            while j < blk {
-                put(&!png, (raw.data[(pos + j) as usize] as i64) & 255)
-                j = j + 1
-            }
+            while j < blk { put(&!png, (raw.data[(pos + j) as usize] as i64) & 255); j = j + 1 }
             pos = pos + blk
             remaining = remaining - blk
         }
@@ -311,7 +488,6 @@ pub fn png_write(filename: string, img: &Image) -> bool with IO, Mut, Div, Panic
     put_be32(&!png, adler)
     let idat_crc = crc_range(&png, idat_start, png.len)
     put_be32(&!png, idat_crc)
-    // IEND
     put_be32(&!png, 0)
     let iend_start = png.len
     put(&!png, 73); put(&!png, 69); put(&!png, 78); put(&!png, 68)  // "IEND"

--- a/stdlib/image/pure/types.sio
+++ b/stdlib/image/pure/types.sio
@@ -5,11 +5,11 @@ module image::pure::types
 pub struct Image {
     pub width: i32,
     pub height: i32,
-    pub pixels: [u32; 65536],  // max 256x256 pixels
+    pub pixels: [u32; 262144],  // max 512x512 pixels
 }
 
 pub fn image_new(w: i32, h: i32) -> Image {
-    Image { width: w, height: h, pixels: [0; 65536] }
+    Image { width: w, height: h, pixels: [0; 262144] }
 }
 
 pub fn image_get_pixel(img: &Image, x: i32, y: i32) -> u32 {

--- a/stdlib/viz/colormap.sio
+++ b/stdlib/viz/colormap.sio
@@ -78,3 +78,46 @@ pub fn plasma_b(t: f64) -> i64 with Div {
     let anchors: [i64; 8] = [135, 163, 165, 137, 104, 73, 43, 33]
     cm_interp8(&anchors, t)
 }
+
+// ============================================================
+// Inferno & Magma — degree-6 analytic fits (higher fidelity than
+// the 8-anchor maps above). Coefficients are Matt Zucker's polynomial
+// approximations of the Matplotlib maps; each channel poly outputs
+// [0,1] over t ∈ [0,1], evaluated by Horner and scaled to [0,255].
+// (Negative coefficients are written `0.0 - x`: Sounio has no unary minus.)
+// ============================================================
+
+fn cm_poly6(a0: f64, a1: f64, a2: f64, a3: f64, a4: f64, a5: f64, a6: f64, t: f64) -> i64 {
+    let tc = if t < 0.0 { 0.0 } else { if t > 1.0 { 1.0 } else { t } }
+    let v = a0 + tc*(a1 + tc*(a2 + tc*(a3 + tc*(a4 + tc*(a5 + tc*a6)))))
+    let s = v * 255.0
+    if s < 0.0 { 0 } else { if s > 255.0 { 255 } else { s as i64 } }
+}
+
+// Inferno — black → purple → red → orange → yellow
+pub fn inferno_r(t: f64) -> i64 {
+    cm_poly6(0.00021894, 0.10651342, 11.60249308, 0.0 - 41.70399613, 77.16293570, 0.0 - 71.31942824, 25.13112622, t)
+}
+pub fn inferno_g(t: f64) -> i64 {
+    cm_poly6(0.00165100, 0.56395644, 0.0 - 3.97285397, 17.43639888, 0.0 - 33.40235894, 32.62606426, 0.0 - 12.24266895, t)
+}
+pub fn inferno_b(t: f64) -> i64 {
+    cm_poly6(0.0 - 0.01948090, 3.93271239, 0.0 - 15.94239411, 44.35414520, 0.0 - 81.80730926, 73.20951986, 0.0 - 23.07032500, t)
+}
+
+// Magma — black → purple → pink → cream
+pub fn magma_r(t: f64) -> i64 {
+    cm_poly6(0.0 - 0.00213649, 0.25166054, 8.35371728, 0.0 - 27.66873309, 52.17613981, 0.0 - 50.76852536, 18.65570507, t)
+}
+pub fn magma_g(t: f64) -> i64 {
+    cm_poly6(0.0 - 0.00074966, 0.67752324, 0.0 - 3.57771951, 14.26473078, 0.0 - 27.94360607, 29.04658282, 0.0 - 11.48977352, t)
+}
+pub fn magma_b(t: f64) -> i64 {
+    cm_poly6(0.0 - 0.00538613, 2.49402660, 0.31446790, 0.0 - 13.64921319, 12.94416944, 4.23415299, 0.0 - 5.60196151, t)
+}
+
+// Pack three [0,255] channels into a 0x00RRGGBB u32 — the pixel format the
+// image::pure::png encoder and image::pure::types::Image expect.
+pub fn cm_pack_rgb8(r: i64, g: i64, b: i64) -> u32 {
+    (((r & 255) << 16) | ((g & 255) << 8) | (b & 255)) as u32
+}

--- a/stdlib/viz/colormap.sio
+++ b/stdlib/viz/colormap.sio
@@ -121,3 +121,11 @@ pub fn magma_b(t: f64) -> i64 {
 pub fn cm_pack_rgb8(r: i64, g: i64, b: i64) -> u32 {
     (((r & 255) << 16) | ((g & 255) << 8) | (b & 255)) as u32
 }
+
+// Packed 0x00RRGGBB convenience — colormap as a single fn(f64)->u32, so it can
+// be passed as a value (e.g. to a field-plotting helper). Effect signatures are
+// unified (with Div) so all four share one function-pointer type.
+pub fn inferno_u32(t: f64) -> u32 with Div { cm_pack_rgb8(inferno_r(t), inferno_g(t), inferno_b(t)) }
+pub fn magma_u32(t: f64) -> u32 with Div { cm_pack_rgb8(magma_r(t), magma_g(t), magma_b(t)) }
+pub fn viridis_u32(t: f64) -> u32 with Div { cm_pack_rgb8(viridis_r(t), viridis_g(t), viridis_b(t)) }
+pub fn plasma_u32(t: f64) -> u32 with Div { cm_pack_rgb8(plasma_r(t), plasma_g(t), plasma_b(t)) }


### PR DESCRIPTION
## What

A dependency-free path from Sounio computation to a compressed PNG on disk — no libpng/stb FFI, no external toolchain. Eight atomic commits:

1. **`image::pure::png`** — a spec-valid 8-bit RGB PNG encoder written entirely in Sounio: **dynamic-Huffman DEFLATE** (two-pass LZ77 count→build→emit, canonical length-limited trees, code-length RLE) + **adaptive scanline filters** (None/Sub/Up/Average/Paeth). Stored-block fallback and an unfiltered-stream fallback mean output is never worse than raw. Consumes the existing `image::pure::types::Image`; closes the gap where `image::ffi::wrapper::image_save_file` is a stub returning `false`.
2. **`viz::colormap`** — `inferno`/`magma` (Horner) + `cm_pack_rgb8` + packed `*_u32` colormap-as-value wrappers. `viridis`/`plasma` untouched.
3. **`image::canvas`** — headless `canvas_new` / `canvas_render_field(&!c, &field, vmin, vmax, cmap)` / `canvas_save`.
4. **`examples/image/pk_uncertainty_field.sio`** — GUM-propagated `Epistemic` PK field rendered natively.
5. **`examples/image/{png_native,canvas_field}.sio`** — gradient + interference demos.

## Compression (240×240 native renders; round-trip byte-exact + pixels verified after unfiltering)

| image | stored | final (dyn + filters) |
|---|---:|---:|
| pk_auc field | 173 KB | 20 KB (0.116) |
| pk_uncertainty | 173 KB | 22 KB (0.130) |
| interference | 173 KB | 87 KB (0.501) |
| smooth gradient (256²) | 197 KB | 0.9 KB (0.005) |
| Mandelbrot ref | 173 KB | 0.230 (edges zlib -9's 0.255) |

Filters turn a smooth gradient (no exact repeats) from 0.998 → **0.005**, a ~220× reduction. The encoder tries both filtered and unfiltered streams and keeps the smaller, so filters never hurt LZ-matchable content.

## Verification

- `souc check` clean; examples run under `lean_single` producing valid PNGs (IHDR/IDAT/IEND CRCs, zlib inflate, Adler-32, exact raw length, gradient pixels reconstructed exactly after unfiltering).
- DEFLATE + canonical Huffman proven byte-exact against Python `zlib` before integration.

## Scope / limitations

- 8-bit RGB; bounded by `Image`'s 65536-pixel (256×256) cap. Greedy match (deep hash chain). **Lazy matching was implemented and measured but regressed periodic image content (interference 0.501→0.510), so it is not shipped** — a heuristic that doesn't reliably beat greedy here.
- Additive: new symbols/files plus a few `mod.sio` export lines; no existing behaviour changed.

## Note (separate finding)

A latent `lean_single` codegen bug: `&` of a temporary that is a struct-returning method call (e.g. `dose.div(&ke.mul(&v))`) passes `check` but SIGSEGVs at runtime. Worked around by binding the intermediate. Worth a forensic dispatch under `docs/audit/`.

## Update — raster cap 512×512

Image + encoder buffers raised to the 512×512 worst case (65536→262144 px, 4× area). A 512×512 inferno Mandelbrot renders + PNG-encodes end-to-end in ~4 s (169 KB, 0.215, round-trip exact); `examples/image/fractal_512.sio` demonstrates it. Existing smaller examples unchanged. Beyond 512 the fixed-array model pays the max footprint every call; unbounded sizes need a heap-backed rewrite (blocked on a byte-granular heap primitive + `write_file`'s fixed-array output).

## Dispatch to compiler lane (Codex-2)

Unbounded image size beyond the 512×512 fixed-array cap needs a native heap allocator, which is **blocked in the `souc run` path**: `stdlib/mem/box` `heap_alloc` (extern "C" calloc) makes the ELF exit 1 at startup — it isn't linked against libc — and there is no mmap/syscall intrinsic. Filed as **`BLK-20260712-image-heap`** (compiler-semantics, B1, E2, owner **Codex-2 / lane-4 nv2-compiler-hardening**) in `docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md`, with repro, acceptance gate, and design sketch. **This does not block merging #828** — the 512×512 encoder is complete; the dispatch is only for the unbounded follow-up.