### PR TITLE
ci: preserve successful Madaros build status

### DIFF
--- a/scripts/ci/build_modular_madaros.sh
+++ b/scripts/ci/build_modular_madaros.sh
@@ -76,7 +76,11 @@ rm -f "$OUT"
 # compile the CURRENT lean_single.sio with it to obtain a fresh seed that carries the
 # current source's features (arena/vmem #719 etc.), then compile main.sio with that.
 TMP_SEED_DIR=""
-cleanup() { [[ -n "$TMP_SEED_DIR" && -d "$TMP_SEED_DIR" ]] && rm -rf "$TMP_SEED_DIR"; }
+cleanup() {
+    if [[ -n "$TMP_SEED_DIR" && -d "$TMP_SEED_DIR" ]]; then
+        rm -rf "$TMP_SEED_DIR"
+    fi
+}
 trap cleanup EXIT
 
 if [[ -n "${SOUC_BIN:-}" || -n "${SOUNIO_SOUC_BIN:-}" ]]; then


### PR DESCRIPTION
## Summary
- keep the modular Madaros build cleanup neutral when no temporary seed directory exists
- preserve the successful build exit status after `Madaros ready`

## Evidence
- prior empty cleanup reproduction: `ready`, `rc=1`
- patched empty cleanup reproduction: `ready`, `rc=0`
- populated cleanup reproduction: `rc=0`, temporary directory removed
- `bash -n scripts/ci/build_modular_madaros.sh`
- `git diff --check`

## Failure classification
Plumbing-only: #816/#817 exited immediately after the build because the EXIT trap returned 1. Their selected Madaros tests never started.