### PR TITLE
fix(frontend): preserve imported call arguments across arena windows

### DIFF
--- a/scripts/ci/zero_event_native_compile_privacy_gate.sh
+++ b/scripts/ci/zero_event_native_compile_privacy_gate.sh
@@ -68,6 +68,17 @@ compile_accepts generic-public tests/multimodule/wp_a3/w2_main.sio
 compile_accepts zero-event-positive tests/known_failures/zero_event_stdlib_native_v2_probe.sio
 compile_accepts eisa-core tests/stdlib/eisa/test_eisa_core.sio
 
+eisa_core_run_log="$TMP_DIR/eisa-core.run.log"
+chmod +x "$TMP_DIR/eisa-core"
+timeout 30 "$TMP_DIR/eisa-core" >"$eisa_core_run_log" 2>&1 || {
+  cat "$eisa_core_run_log" >&2
+  fail "eisa-core compiled but failed at runtime"
+}
+grep -Fq 'ALL PASS: eisa core W1 W2 W3 W4 W5' "$eisa_core_run_log" || {
+  cat "$eisa_core_run_log" >&2
+  fail "eisa-core runtime did not emit the W1-W5 receipt"
+}
+
 eisa_log="$TMP_DIR/eisa.log"
 if (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" compile \
     tests/known_failures/eisa_zero_flags_native_v2_probe.sio \
@@ -84,4 +95,4 @@ else
   }
 fi
 
-echo '[zero-native-privacy] PASS: native compile rejects private constructors and preserves public, generic, zero-event, and EISA frontends'
+echo '[zero-native-privacy] PASS: private constructors rejected; public, generic, zero-event, and EISA compile paths preserved; EISA W1-W5 runtime receipt verified'

--- a/scripts/ci/zero_event_native_compile_privacy_gate.sh
+++ b/scripts/ci/zero_event_native_compile_privacy_gate.sh
@@ -66,6 +66,7 @@ compile_rejects private-enum \
 compile_accepts public-struct tests/multimodule/visibility_struct_pub_main.sio
 compile_accepts generic-public tests/multimodule/wp_a3/w2_main.sio
 compile_accepts zero-event-positive tests/known_failures/zero_event_stdlib_native_v2_probe.sio
+compile_accepts eisa-core tests/stdlib/eisa/test_eisa_core.sio
 
 eisa_log="$TMP_DIR/eisa.log"
 if (cd "$SOURCE_ROOT" && timeout 60 "$MADAROS_BIN" compile \

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4399,16 +4399,10 @@ pub fn module_frontend_check_imported_modules_verdict(main_path: string) -> i64 
 // whose Box POINTER is copied shallow by struct assignment. Left alone,
 // that pointer would keep referencing dep_box's soon-to-be-reset memory.
 //
-// Fix: before resetting the arena, walk the newly-appended function range
-// [old_fn_count, new_fn_count) and extract every call_args chain (bounded
-// to 8 args/call-site, matching the existing native_v2_collect_call_args /
-// tco_extract_call_args convention) into this BSS scratch buffer -- plain
-// fixed arrays, NOT Box-arena memory, so __arena_reset never touches them.
-// After the reset, rebuild fresh Box<IrRegList> chains from the scratch
-// buffer (landing in the just-freed, now-reused window) and write them
-// back into acc_box's instrs. If a module's call-arg sites exceed the
-// bounded capacity, the reset is skipped for that module only (strictly
-// correctness-preserving fallback -- just reclaims less memory).
+// The intended re-box path snapshots call_args into BSS scratch before reset.
+// The current bootstrap corrupts IrRegList heads during that move, so callers
+// conservatively reset only dependency windows with no live call chains. The
+// scratch machinery remains here for a future bootstrap-safe re-box repair.
 // ============================================================================
 let MF_AREBOX_CAP: i64 = 8192
 var MF_AREBOX_FI: [i64; 8192] = [0; 8192]
@@ -4683,12 +4677,16 @@ fn module_frontend_lower_programs_array_direct_box(
                         // (source still valid), reset, then rebuild fresh in the
                         // freed window.
                         let dep_merge_new_fn_count = (*acc_box).fn_count
-                        let dep_arena_can_reset = mf_arebox_scan(&(*acc_box), dep_merge_old_fn_count, dep_merge_new_fn_count)
+                        let dep_arena_scan_ok = mf_arebox_scan(&(*acc_box), dep_merge_old_fn_count, dep_merge_new_fn_count)
+                        // The current bootstrap corrupts IrRegList heads while moving
+                        // them through the scratch re-box path. Preserve correctness by
+                        // reclaiming only dependency windows with no live call chains.
+                        let dep_arena_can_reset = dep_arena_scan_ok && MF_AREBOX_COUNT == 0
                         if dep_arena_can_reset {
                             __arena_reset(dep_arena_mark)
                             mf_arebox_apply(&! (*acc_box))
                         } else {
-                            print("lower_array: arena_reset_skipped (call-arg scratch overflow) module ")
+                            print("lower_array: arena_reset_skipped (live call_args) module ")
                             print_int(i)
                             print("\n")
                         }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6460,22 +6460,6 @@ fn nc_core_call_arg_at(args: Option<Box<IrRegList>>, index: i64) -> i64 with Mut
     }
 }
 
-fn nc_core_call_arg_compat(args: Option<Box<IrRegList>>, arg_count: i64, src1: i64, src2: i64, index: i64) -> i64 with Mut, Panic, Div {
-    let listed = nc_core_call_arg_at(args, index)
-    if listed >= 0 {
-        return listed
-    }
-    // ir_call caches the first two arguments in src1/src2 for compatibility.
-    // Imported-module arena compaction can leave only that scalar cache alive.
-    if index == 0 && arg_count > 0 {
-        return src1
-    }
-    if index == 1 && arg_count > 1 {
-        return src2
-    }
-    -1
-}
-
 fn nc_core_func_param_index(func: &IrFunction, reg: i64) -> i64 with Mut, Panic, Div {
     var i = 0
     while i < (*func).param_count && i < 64 {
@@ -6488,13 +6472,7 @@ fn nc_core_func_param_index(func: &IrFunction, reg: i64) -> i64 with Mut, Panic,
 }
 
 fn nc_core_load_call_arg_into(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64, arg_index: i64, preg: i64) -> bool with Mut, Panic, Div {
-    let arg = nc_core_call_arg_compat(
-        (*func).instrs[instr_index as usize].call_args,
-        (*func).instrs[instr_index as usize].arg_count,
-        (*func).instrs[instr_index as usize].src1,
-        (*func).instrs[instr_index as usize].src2,
-        arg_index,
-    )
+    let arg = nc_core_call_arg_at((*func).instrs[instr_index as usize].call_args, arg_index)
     if arg < 0 {
         if native_v2_ir_trace_enabled() {
             print("NV2_IR missing_call_arg fn=")
@@ -6518,13 +6496,7 @@ fn nc_core_load_call_arg_into(nc: &! NativeCompiler, func: &IrFunction, instr_in
 }
 
 fn nc_core_load_call_arg_to_rax(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64, arg_index: i64) -> bool with Mut, Panic, Div {
-    let arg = nc_core_call_arg_compat(
-        (*func).instrs[instr_index as usize].call_args,
-        (*func).instrs[instr_index as usize].arg_count,
-        (*func).instrs[instr_index as usize].src1,
-        (*func).instrs[instr_index as usize].src2,
-        arg_index,
-    )
+    let arg = nc_core_call_arg_at((*func).instrs[instr_index as usize].call_args, arg_index)
     if arg < 0 {
         return false
     }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -6460,6 +6460,22 @@ fn nc_core_call_arg_at(args: Option<Box<IrRegList>>, index: i64) -> i64 with Mut
     }
 }
 
+fn nc_core_call_arg_compat(args: Option<Box<IrRegList>>, arg_count: i64, src1: i64, src2: i64, index: i64) -> i64 with Mut, Panic, Div {
+    let listed = nc_core_call_arg_at(args, index)
+    if listed >= 0 {
+        return listed
+    }
+    // ir_call caches the first two arguments in src1/src2 for compatibility.
+    // Imported-module arena compaction can leave only that scalar cache alive.
+    if index == 0 && arg_count > 0 {
+        return src1
+    }
+    if index == 1 && arg_count > 1 {
+        return src2
+    }
+    -1
+}
+
 fn nc_core_func_param_index(func: &IrFunction, reg: i64) -> i64 with Mut, Panic, Div {
     var i = 0
     while i < (*func).param_count && i < 64 {
@@ -6472,8 +6488,29 @@ fn nc_core_func_param_index(func: &IrFunction, reg: i64) -> i64 with Mut, Panic,
 }
 
 fn nc_core_load_call_arg_into(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64, arg_index: i64, preg: i64) -> bool with Mut, Panic, Div {
-    let arg = nc_core_call_arg_at((*func).instrs[instr_index as usize].call_args, arg_index)
+    let arg = nc_core_call_arg_compat(
+        (*func).instrs[instr_index as usize].call_args,
+        (*func).instrs[instr_index as usize].arg_count,
+        (*func).instrs[instr_index as usize].src1,
+        (*func).instrs[instr_index as usize].src2,
+        arg_index,
+    )
     if arg < 0 {
+        if native_v2_ir_trace_enabled() {
+            print("NV2_IR missing_call_arg fn=")
+            print(str_from_bytes((*func).name.buf, (*func).name.len))
+            print(" i=")
+            print_int(instr_index)
+            print(" arg_index=")
+            print_int(arg_index)
+            print(" arg_count=")
+            print_int((*func).instrs[instr_index as usize].arg_count)
+            print(" src1=")
+            print_int((*func).instrs[instr_index as usize].src1)
+            print(" src2=")
+            print_int((*func).instrs[instr_index as usize].src2)
+            print("\n")
+        }
         return false
     }
     nc_emit_load_rbp_disp32_reg(nc, preg, ir_slot_offset(arg))
@@ -6481,7 +6518,13 @@ fn nc_core_load_call_arg_into(nc: &! NativeCompiler, func: &IrFunction, instr_in
 }
 
 fn nc_core_load_call_arg_to_rax(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64, arg_index: i64) -> bool with Mut, Panic, Div {
-    let arg = nc_core_call_arg_at((*func).instrs[instr_index as usize].call_args, arg_index)
+    let arg = nc_core_call_arg_compat(
+        (*func).instrs[instr_index as usize].call_args,
+        (*func).instrs[instr_index as usize].arg_count,
+        (*func).instrs[instr_index as usize].src1,
+        (*func).instrs[instr_index as usize].src2,
+        arg_index,
+    )
     if arg < 0 {
         return false
     }


### PR DESCRIPTION
## Summary

- preserve dependency arena windows whenever merged functions still own live `call_args` chains
- keep native call emission fail-closed when a structured argument list is absent; remove the `src1`/`src2` fallback that could silently emit vreg zero
- execute the compiled EISA core ELF in CI and require the exact W1-W5 runtime receipt

## Root cause

The per-module arena reset shallow-copied `IrInstr.call_args`, then attempted to snapshot and rebuild each `IrRegList`. Under the current bootstrap, moving the list head through the scratch re-box path corrupts it to `-1`. Disabling the reset made the original argument chains survive and changed EISA core from W5 runtime failure to full pass. The contained fix reclaims dependency windows only when the scan finds no live call chains.

## Evidence

- source-fresh Madaros: `/tmp/sounio-eisa-rc12-madaros-v20`
- zero-event/privacy gate: PASS, including executed `ALL PASS: eisa core W1 W2 W3 W4 W5` receipt
- EISA bridge conformance: PASS, all 32 cases including `e5-cancellation`, tamper sensitivity, and anti-vacuity
- EISA ISA: PASS P1-P5
- EISA v1e showcase: PASS S1-S3 with receipts
- hello: PASS (`Hello from self-hosted Sounio!`, `42`)
- octonion Fano spine: PASS (`168`)
- EISA core compile/run: 0.63 s, peak RSS 808,788 KiB
- EISA v1e showcase compile/run: 2.61 s, peak RSS 2,580,820 KiB

## Claim boundary

This closes the EISA core runtime acceptance boundary without claiming that scratch re-boxing itself is repaired. The safe containment increases peak memory for imported modules with live call chains. `tests/stdlib/eisa/test_eisa_e5_kernel.sio` remains independently blocked in visibility preflight by E175; the conformance gate e5 cancellation case passes. No EISA math semantics, thresholds, or canonical compiler artifacts changed.

## LLM offload

Not required: compiler/frontend lifetime handling and CI gate only; no math claim, clinical pathway, or external-facing artifact changed.