### PR TITLE
feat(eisa): add exact hypercomplex zero-divisor evidence

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2527,3 +2527,21 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - A DeepSeek second-provider review was also attempted and returned `Insufficient Balance`; the xAI review is therefore the only completed external review for this lane.
 - Raw review directory: `/tmp/llm-offload-OTGkvg/`.
 - DeepSeek failure directory: `/tmp/llm-offload-Rzt9rw/`.
+
+## 2026-07-12 — M1 math-review: bounded EISA-H zero-divisor reference
+- Files: `stdlib/eisa/hypercomplex_zd.sio`, `tests/stdlib/eisa/test_eisa_h_zd.sio`, and `docs/internal/concepts/hypercomplex-zero-divisor-evidence.md`.
+- xAI/Grok 4.3 = **PASS** on the executable reference. It confirmed the Cayley-Dickson XOR/sign multiplication, exhaustive sparse accumulation, nonzero-factor requirement, bounded `+/-1` no-overflow envelope, and exact-versus-measured separation.
+- Z.AI/GLM-5.2 = **PASS** on the executable reference. It independently confirmed XOR basis indexing, rank-two zero-divisor coverage, the maximum four-term exact accumulator bound, and the refusal to promote a floating norm observation into an exact proof.
+- A first Z.AI review of the concept prose was inconclusive: it attempted a long informal reconstruction of the existing `84/336/168` census and ended without a verdict or counterexample. No implementation change was made from that response; the counts remain bounded to the existing executable, Python, and Lean census surfaces rather than being re-proved by this lane.
+- Evidence boundary: this review supports only the bounded stdlib software reference. It does not review or authorize checker emission, `IrSedZDCheck`, EISA opcodes, ABI, native lowering, RTL, hardware, or physical/clinical interpretation.
+- Raw reviews: `/tmp/llm-offload-FW6J2k/` (xAI implementation), `/tmp/llm-offload-9ysuAE/` (Z.AI implementation), and `/tmp/llm-offload-zuKRa7/` (concept prose fan-out).
+
+## 2026-07-12 — M1 adversarial follow-up: EISA-H forged evidence and measurement boundaries
+- Files: `stdlib/eisa/hypercomplex_zd.sio`, `tests/stdlib/eisa/test_eisa_h_zd.sio`, and `docs/internal/concepts/hypercomplex-zero-divisor-evidence.md`.
+- Repair: caller-controlled `element_status`, token tags, and checksums are no longer authority. Exact consumers revalidate identities, tags, actual arrays, at-most-two support, `+/-1` coefficients, nonzero operands, and the ordered exact product before accepting a checksum.
+- Adversarial witnesses: an externally forged operand with two `2^32` coefficients and `element_status=OK` is rejected before multiplication; a forged token for nonzero `e1*e2` with a cloned checksum is rejected by exact-product recomputation. NaN, positive and negative infinity, negative norms, invalid resolution, and equality-at-threshold measurement cases are classified explicitly.
+- Z.AI test review found a real classification wording issue: coefficient `2` is outside the V0 domain but is not itself an overflow risk. The implementation now classifies such inputs as `UNSUPPORTED` and reserves `OVERFLOW_RISK` for magnitude above `1518500249`, the exact largest `c` satisfying `4*c*c <= i64::MAX` for the four-term sparse accumulator.
+- Final xAI/Grok 4.3 review = **PASS** after the repair. It confirmed the exact overflow threshold, coefficient/support filter, exhaustive multiplication, product recomputation, and proof/measurement separation.
+- Final Z.AI/GLM-5.2 review = **PASS** after the repair. It independently recomputed the threshold, checked the four-term assumption against the enforced sparse domain, and confirmed the XOR/sign exact product and finite measurement boundary.
+- Execution receipt: Madaros checks pass; default Madaros execution is **BLOCKED** with wrapper rc `1` after native driver write rc `12`; the passing execution witness is explicitly `lean_single`.
+- Raw reviews: `/tmp/llm-offload-Fdh6AM/` (first repaired module), `/tmp/llm-offload-WdnICv/` (adversarial test review), and `/tmp/llm-offload-2cc7Cc/` (final post-fix xAI+ZAI module review).

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 946
-- Repo-backed topics: 796
+- Total governed topics: 947
+- Repo-backed topics: 797
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 546
+- Authority count `repo_only`: 547
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 565 topics
+- A2: 566 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -403,6 +403,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.implementation.ui-type-deignore-candidates | historical | docs/implementation/UI_TYPE_DEIGNORE_CANDIDATES.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.physical-observation | repo_only | docs/internal/concepts/physical-observation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.precision-preservation | repo_only | docs/internal/concepts/precision-preservation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8748,6 +8748,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/hypercomplex-zero-divisor-evidence.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.nonassociative-order",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/nonassociative-order.md",

--- a/docs/internal/concepts/README.md
+++ b/docs/internal/concepts/README.md
@@ -50,6 +50,7 @@ concept.
 - [Physical Observation](physical-observation.md)
 - [Precision Preservation](precision-preservation.md)
 - [Second-Order Compilation](second-order-compilation.md)
+- [Hypercomplex Zero-Divisor Evidence](hypercomplex-zero-divisor-evidence.md)
 
 ```bash
 bash scripts/dev/sounio_semantic_status.sh

--- a/docs/internal/concepts/bindings.tsv
+++ b/docs/internal/concepts/bindings.tsv
@@ -31,3 +31,8 @@ SOUNIO-SECOND-ORDER-COMPILATION	docs/decisions/adr-007-second-order-compilation.
 SOUNIO-SECOND-ORDER-COMPILATION	stdlib/eisa/*	first-witness-surface
 SOUNIO-SECOND-ORDER-COMPILATION	self-hosted/enir/*	pending-ir-interface
 SOUNIO-SECOND-ORDER-COMPILATION	scripts/ci/*counterfactual*	pending-gate
+SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	stdlib/eisa/hypercomplex_zd.sio	canonical-reference
+SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	stdlib/algebra/cayley_dickson_exact_i64.sio	exact-sign-oracle
+SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	tests/stdlib/eisa/test_eisa_h_zd.sio	evidence
+SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	scripts/ci/eisa_h_zd_reference_gate.sh	gate
+SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	self-hosted/ir/*	blocked-pending-interface

--- a/docs/internal/concepts/hypercomplex-zero-divisor-evidence.md
+++ b/docs/internal/concepts/hypercomplex-zero-divisor-evidence.md
@@ -1,0 +1,151 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence
+-->
+
+# Hypercomplex Zero-Divisor Evidence
+
+Concept-ID: `SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE`
+
+## Founder Intent
+
+When nonzero hypercomplex operands annihilate, the zero result must not erase
+the ordered operands, signed coefficients, algebra convention, coefficient
+domain, detector, or distinction between exact proof and numerical measurement.
+
+## V0 Executable Boundary
+
+The first executable surface is a bounded software reference for ordered pairs
+of 16-component sedenions. Each operand has at most two nonzero `i64`
+coefficients, each exactly `+1` or `-1`. Multiplication uses the public
+`cd_sigma_exact_i64` Cayley-Dickson convention.
+
+`ZDExactTokenV0` and `ZDMeasuredReceiptV0` are distinct types, so a measured
+near-zero receipt cannot satisfy a consumer that requires an exact token.
+They are not currently an opacity boundary: both compiler engines permit
+external struct literals despite non-public fields. Exact-token consumers
+therefore revalidate identities, tags, coefficient arrays, nonzero operands,
+the ordered exact product, and the checksum. The checksum is diagnostic, not
+authority. Inputs outside the bounded no-overflow envelope are classified
+before multiplication. Coefficients other than `+/-1` are unsupported; a
+magnitude above `1518500249` is specifically overflow risk because four
+same-component products can exceed `i64`.
+
+## Canonical Distinctions
+
+```text
+zero-divisor element       != ordered zero-divisor pair
+a * b == 0                 != b * a == 0
+nonzero-factor annihilation != multiplication by zero
+signed coefficients        != unsigned support bitmask
+exact product equality     != tolerance-gated near-zero
+ordered pair               != unordered projective class
+status flag                != evidence token
+computational evidence     != physical or clinical mechanism
+software reference         != ISA, ABI, native lowering, or RTL support
+```
+
+The existing primitive census surfaces distinguish 84 participating primitive
+vectors, 336 ordered annihilation pairs, and 168 unordered projective classes.
+Those counts are bound to
+`docs/research/SEDENION_ZERO_DIVISOR_GEOMETRY_REPORT.md`,
+`scripts/research/generate_sedenion_zero_divisor_geometry.py`,
+`formal/lean4/SounioZeroDivisorBridge.lean`, and
+`scripts/ci/sedenion_zd168_crosscheck_gate.sh`. This V0 lane consumes that
+evidence and does not re-prove the counts. The three counts are not
+interchangeable names for one object.
+
+## Authoritative Surface
+
+- `stdlib/eisa/hypercomplex_zd.sio`
+- `tests/stdlib/eisa/test_eisa_h_zd.sio`
+- `scripts/ci/eisa_h_zd_reference_gate.sh`
+
+## Required Invariants
+
+- Exact tokens bind signed coefficient arrays and ordered operand identities.
+- Exact tokens name the multiplication convention, coefficient domain,
+  detector, and orientation.
+- Both operands must be nonzero before an exact token can be minted.
+- Same-support sign changes are recomputed, not accepted by support alone.
+- Measurement receipts never coerce to exact tokens.
+- Unsupported inputs and overflow risk fail closed before multiplication.
+- Caller-provided element status and token checksum are never accepted as
+  arithmetic authority.
+- Exact-token consumers independently recompute the bounded ordered product.
+- NaN, infinities, negative norms, negative products, and nonpositive
+  measurement resolution are unsupported; zero norm remains a distinct
+  zero-operand classification.
+- A token does not authorize cancellation, inversion, reassociation, or a
+  physical interpretation.
+
+## Pending Interface
+
+Checker emission and sign-sensitive semantics for an IR operation, followed by
+an explicit EISA/RTL profile. The current `IrSedZDCheck` placeholder is not an
+authoritative implementation of this concept.
+
+## Claims Permitted
+
+After the focused gate passes, the named software reference may claim exact
+annihilation detection for its bounded V0 domain under the named convention.
+
+## Claims Forbidden
+
+- General zero-divisor decision for arbitrary sedenions or hypercomplex algebras.
+- Native compiler, EISA opcode, ABI, FPGA, or silicon support.
+- Equating measured near-zero with exact annihilation.
+- Physical, biological, psychiatric, or clinical interpretation.
+
+## Semantic Lane Declaration
+
+```text
+Semantic-Lane-ID: EISA-H-ZD-REF-V0
+Owner: Codex eisa_h_inventory lane
+Concept-IDs: SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE; SOUNIO-ZERO-PROVENANCE; SOUNIO-EPISTEMIC-NUMERIC-VALUE; SOUNIO-NONASSOCIATIVE-ORDER; SOUNIO-EXPLICIT-DISCHARGE; SOUNIO-PRECISION-PRESERVATION
+Intent-Preserved: ordered nonzero-factor annihilation retains signed operands, identities, convention, domain, detector, and proof-versus-measurement status
+Transformation: add a bounded stdlib software reference with semantic revalidation at every exact-token consumer
+Types-Changed: add SedExact16V0, ZDExactAttemptV0, ZDExactTokenV0, and ZDMeasuredReceiptV0
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: exact ordered annihilation detection for at-most-two-support +/-1 i64 sedenions under cd_sigma_exact_i64
+Claims-Forbidden: arbitrary-sedenion decision; native runtime; EISA opcode; ABI; RTL; silicon; physical or clinical interpretation
+Assumptions: cd_sigma_exact_i64 is the named convention; each admitted operand has at most two nonzero coefficients, each +/-1; exact accumulation magnitude is at most four
+Write-Set: stdlib/eisa/hypercomplex_zd.sio; tests/stdlib/eisa/test_eisa_h_zd.sio; scripts/ci/eisa_h_zd_reference_gate.sh; this concept and generated governance metadata; .claude/llm_offload_log.md
+Read-Set: stdlib/algebra/cayley_dickson_exact_i64.sio; stdlib/epistemic/zero_event.sio; existing exact census report, Python, Lean, and gate surfaces
+Positive-Witness: (e3+e10)*(e6-e15) mints a revalidated exact token
+Negative-Witness: e1*e2, zero operand, same-support sign tamper, forged 2^32 coefficients, forged token, invalid measurements, and equality threshold are rejected or classified
+Acceptance-Gate: bash scripts/ci/eisa_h_zd_reference_gate.sh; bash scripts/ci/zero_event_gate.sh; semantic and docs gates; xAI and ZAI math review
+Integration-Target: origin/main
+Authoritative-Only-If: focused gate reports check=Madaros and execution=lean_single, all adversarial witnesses pass, and no compiler, ISA, ABI, native, or hardware claim is inferred
+```
+
+## Semantic Integration Receipt
+
+```text
+Semantic-Outcome: bounded software reference revalidates exact evidence and passes focused adversarial witnesses
+Concept-Status-Before: proposed
+Concept-Status-After: executable
+Distinctions-Added: signed support; ordered identity; exact token versus measured receipt; unsupported versus overflow-risk versus zero operand; finite measurement requirement
+Distinctions-Preserved: value versus error versus uncertainty; zero provenance; nonassociative order; explicit discharge; software reference versus native or hardware support
+Distinctions-Erased: none
+Evidence-Run: Madaros check; lean_single execution; focused reference gate; zero-event gate; semantic/docs gates; xAI and ZAI math review
+Fallback-Path: explicit lean_single execution only; default Madaros wrapper exits 1 after native driver write rc=12
+Legacy-Kept: all existing EISA, algebra, compiler, IR, native, ABI, and hardware paths
+Conflicting-Lanes: none in this write set
+Next-Semantic-Interface: E176/private-field enforcement, then separately reviewed sign-sensitive checker emission and non-placeholder IR/native semantics
+```
+
+The durable execution receipt for this revision is:
+
+```text
+check=Madaros
+execution=lean_single
+default_madaros_runtime=BLOCKED
+default_madaros_wrapper_rc=1
+default_madaros_native_driver_rc=12
+```

--- a/docs/internal/concepts/registry.tsv
+++ b/docs/internal/concepts/registry.tsv
@@ -6,3 +6,4 @@ SOUNIO-EXPLICIT-DISCHARGE	executable	founder	docs/internal/concepts/explicit-dis
 SOUNIO-PHYSICAL-OBSERVATION	hypothesis	founder	docs/internal/concepts/physical-observation.md	stdlib/physics	observation-receipt
 SOUNIO-PRECISION-PRESERVATION	executable	founder	docs/internal/concepts/precision-preservation.md	stdlib/math/qd128.sio	native-v2-emission
 SOUNIO-SECOND-ORDER-COMPILATION	hypothesis	founder	docs/internal/concepts/second-order-compilation.md	docs/architecture/second-order-compilation.md	first-divergence-receipt
+SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	executable	founder	docs/internal/concepts/hypercomplex-zero-divisor-evidence.md	stdlib/eisa/hypercomplex_zd.sio	checker-ir-hardware

--- a/scripts/ci/eisa_h_zd_reference_gate.sh
+++ b/scripts/ci/eisa_h_zd_reference_gate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/eisa-h-zd-ref.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+MODULE="$ROOT_DIR/stdlib/eisa/hypercomplex_zd.sio"
+WITNESS="$ROOT_DIR/tests/stdlib/eisa/test_eisa_h_zd.sio"
+
+fail() {
+  echo "[eisa-h-zd-ref] FAIL: $*" >&2
+  exit 1
+}
+
+"$ROOT_DIR/bin/souc" check "$MODULE" >"$TMP_DIR/module.check.log" 2>&1 || {
+  cat "$TMP_DIR/module.check.log" >&2
+  fail "Madaros module check"
+}
+
+"$ROOT_DIR/bin/souc" check "$WITNESS" >"$TMP_DIR/witness.check.log" 2>&1 || {
+  cat "$TMP_DIR/witness.check.log" >&2
+  fail "Madaros witness check"
+}
+
+set +e
+"$ROOT_DIR/bin/souc" run "$WITNESS" >"$TMP_DIR/madaros.run.log" 2>&1
+madaros_wrapper_rc=$?
+set -e
+if [[ "$madaros_wrapper_rc" -eq 0 ]]; then
+  madaros_runtime_status="PASS"
+  madaros_driver_rc="0"
+elif [[ "$madaros_wrapper_rc" -eq 1 ]] && grep -Fq 'main.elf rc=12' "$TMP_DIR/madaros.run.log"; then
+  madaros_runtime_status="BLOCKED"
+  madaros_driver_rc="12"
+else
+  cat "$TMP_DIR/madaros.run.log" >&2
+  fail "unexpected default Madaros runtime result rc=$madaros_wrapper_rc"
+fi
+
+output="$(SOUNIO_SOUC_ENGINE=lean_single "$ROOT_DIR/bin/souc" run "$WITNESS" 2>&1)" || {
+  printf '%s\n' "$output" >&2
+  fail "lean_single witness execution"
+}
+printf '%s\n' "$output" | grep -Fq 'EISA_H_ZD_REF_V0 PASS' || {
+  printf '%s\n' "$output" >&2
+  fail "missing witness marker"
+}
+
+cat >"$TMP_DIR/proof_measurement_type_error.sio" <<'EOF'
+use eisa::hypercomplex_zd::{zd_measured_norm_f64_v0, zd_requires_exact}
+
+fn main() -> i32 with Mut {
+    let measured = zd_measured_norm_f64_v0(1, 2, 2.0, 2.0, 0.0, 1.0e-12)
+    if zd_requires_exact(measured) { 1 } else { 0 }
+}
+EOF
+
+if "$ROOT_DIR/bin/souc" check "$TMP_DIR/proof_measurement_type_error.sio" >"$TMP_DIR/type-error.log" 2>&1; then
+  fail "measured receipt was accepted by exact-token consumer"
+fi
+grep -Eq 'type mismatch|expected ZDExactTokenV0|does not match' "$TMP_DIR/type-error.log" || {
+  cat "$TMP_DIR/type-error.log" >&2
+  fail "proof/measurement rejection lacked a type boundary diagnostic"
+}
+
+echo "[eisa-h-zd-ref] RECEIPT check=Madaros execution=lean_single madaros_runtime=${madaros_runtime_status} wrapper_rc=${madaros_wrapper_rc} native_driver_rc=${madaros_driver_rc}"
+echo '[eisa-h-zd-ref] PASS: bounded exact token, measured receipt, sign tamper, identity binding, and fail-closed classifications'

--- a/stdlib/eisa/hypercomplex_zd.sio
+++ b/stdlib/eisa/hypercomplex_zd.sio
@@ -1,0 +1,412 @@
+// stdlib/eisa/hypercomplex_zd.sio
+//
+// Bounded EISA-H software reference for exact sedenion zero-divisor evidence.
+// This is not an EISA opcode, compiler intrinsic, ABI, or hardware contract.
+//
+// V0 accepts sedenions with at most two nonzero coefficients, each exactly
+// +1 or -1. Multiplication uses the repository's public Cayley-Dickson sign
+// primitive. Inputs outside that proven no-overflow envelope fail closed.
+module eisa::hypercomplex_zd
+
+use algebra::cayley_dickson_exact_i64::{cd_sigma_exact_i64}
+
+pub struct SedExact16V0 {
+    coeffs: [i64; 16],
+    identity: i64,
+    element_status: i64,
+}
+
+pub struct ZDExactTokenV0 {
+    left_coeffs: [i64; 16],
+    right_coeffs: [i64; 16],
+    left_identity: i64,
+    right_identity: i64,
+    convention_tag: i64,
+    domain_tag: i64,
+    detector_tag: i64,
+    orientation_tag: i64,
+    valid: bool,
+    integrity_tag: i64,
+}
+
+pub struct ZDExactAttemptV0 {
+    status: i64,
+    token: ZDExactTokenV0,
+}
+
+pub struct ZDMeasuredReceiptV0 {
+    left_identity: i64,
+    right_identity: i64,
+    left_norm_sq: f64,
+    right_norm_sq: f64,
+    product_norm_sq: f64,
+    resolution: f64,
+    domain_tag: i64,
+    detector_tag: i64,
+    near_zero: bool,
+    status: i64,
+}
+
+pub fn zd_status_proved() -> i64 { 0 }
+pub fn zd_status_not_zd() -> i64 { 1 }
+pub fn zd_status_zero_operand() -> i64 { 2 }
+pub fn zd_status_unsupported() -> i64 { 3 }
+pub fn zd_status_overflow_risk() -> i64 { 4 }
+pub fn zd_status_identity_invalid() -> i64 { 5 }
+pub fn zd_status_measured_near_zero() -> i64 { 6 }
+
+pub fn zd_convention_cd_sigma_v0() -> i64 { 41001 }
+pub fn zd_domain_sed16_sparse_pm1_i64_v0() -> i64 { 41002 }
+pub fn zd_detector_exact_product_v0() -> i64 { 41003 }
+pub fn zd_orientation_ordered() -> i64 { 41004 }
+pub fn zd_detector_measured_norm_f64_v0() -> i64 { 41005 }
+pub fn zd_domain_measured_norm_f64_v0() -> i64 { 41006 }
+
+fn sed_element_ok() -> i64 { 0 }
+fn sed_element_unsupported() -> i64 { 1 }
+fn sed_element_overflow_risk() -> i64 { 2 }
+
+fn zd_zero_coeffs() -> [i64; 16] {
+    [0; 16]
+}
+
+fn zd_unsupported_coeffs() -> [i64; 16] with Mut {
+    var coeffs: [i64; 16] = [0; 16]
+    coeffs[0] = 1
+    coeffs[1] = 1
+    coeffs[2] = 1
+    coeffs
+}
+
+pub fn sed16_v0_zero(identity: i64) -> SedExact16V0 {
+    SedExact16V0 {
+        coeffs: zd_zero_coeffs(),
+        identity: identity,
+        element_status: sed_element_ok(),
+    }
+}
+
+pub fn sed16_v0_basis(identity: i64, index: i64, coefficient: i64) -> SedExact16V0 with Mut {
+    var coeffs = zd_zero_coeffs()
+    if index < 0 || index >= 16 {
+        return SedExact16V0 {
+            coeffs: zd_unsupported_coeffs(),
+            identity: identity,
+            element_status: sed_element_unsupported(),
+        }
+    }
+    if coefficient < -1 || coefficient > 1 {
+        coeffs[index as usize] = coefficient
+        let advisory_status = if coefficient > 1518500249 || coefficient < -1518500249 {
+            sed_element_overflow_risk()
+        } else {
+            sed_element_unsupported()
+        }
+        return SedExact16V0 {
+            coeffs: coeffs,
+            identity: identity,
+            element_status: advisory_status,
+        }
+    }
+    coeffs[index as usize] = coefficient
+    SedExact16V0 {
+        coeffs: coeffs,
+        identity: identity,
+        element_status: sed_element_ok(),
+    }
+}
+
+pub fn sed16_v0_two_support(
+    identity: i64,
+    index_a: i64,
+    coefficient_a: i64,
+    index_b: i64,
+    coefficient_b: i64
+) -> SedExact16V0 with Mut {
+    var coeffs = zd_zero_coeffs()
+    if index_a < 0 || index_a >= 16 || index_b < 0 || index_b >= 16 || index_a == index_b {
+        return SedExact16V0 {
+            coeffs: zd_unsupported_coeffs(),
+            identity: identity,
+            element_status: sed_element_unsupported(),
+        }
+    }
+    if coefficient_a < -1 || coefficient_a > 1 || coefficient_b < -1 || coefficient_b > 1 {
+        coeffs[index_a as usize] = coefficient_a
+        coeffs[index_b as usize] = coefficient_b
+        let overflow_risk = coefficient_a > 1518500249 || coefficient_a < -1518500249 ||
+                            coefficient_b > 1518500249 || coefficient_b < -1518500249
+        return SedExact16V0 {
+            coeffs: coeffs,
+            identity: identity,
+            element_status: if overflow_risk { sed_element_overflow_risk() } else { sed_element_unsupported() },
+        }
+    }
+    if coefficient_a == 0 || coefficient_b == 0 {
+        return SedExact16V0 {
+            coeffs: zd_unsupported_coeffs(),
+            identity: identity,
+            element_status: sed_element_unsupported(),
+        }
+    }
+    coeffs[index_a as usize] = coefficient_a
+    coeffs[index_b as usize] = coefficient_b
+    SedExact16V0 {
+        coeffs: coeffs,
+        identity: identity,
+        element_status: sed_element_ok(),
+    }
+}
+
+fn sed16_v0_is_zero(x: SedExact16V0) -> bool with Mut {
+    var i = 0
+    while i < 16 {
+        if x.coeffs[i as usize] != 0 { return false }
+        i = i + 1
+    }
+    true
+}
+
+// Revalidate the received coefficient array. element_status is advisory only:
+// current compiler engines permit external struct literals, so it is never an
+// authority for arithmetic admission.
+fn sed16_v0_array_status(coeffs: [i64; 16]) -> i64 with Mut {
+    var nonzero_count = 0
+    var i = 0
+    while i < 16 {
+        let coefficient = coeffs[i as usize]
+        if coefficient != 0 {
+            // Four products can accumulate in one output component. This is
+            // the largest magnitude c with 4*c*c <= i64::MAX.
+            if coefficient > 1518500249 || coefficient < -1518500249 {
+                return zd_status_overflow_risk()
+            }
+            if coefficient != 1 && coefficient != -1 {
+                return zd_status_unsupported()
+            }
+            nonzero_count = nonzero_count + 1
+        }
+        i = i + 1
+    }
+    if nonzero_count > 2 { return zd_status_unsupported() }
+    zd_status_proved()
+}
+
+fn sed16_v0_product_is_zero(a: SedExact16V0, b: SedExact16V0) -> bool with Mut, Panic, Div {
+    var product: [i64; 16] = [0; 16]
+    var i = 0
+    while i < 16 {
+        if a.coeffs[i as usize] != 0 {
+            var j = 0
+            while j < 16 {
+                if b.coeffs[j as usize] != 0 {
+                    let output_index = i ^ j
+                    let sign = cd_sigma_exact_i64(i as i32, j as i32, 4)
+                    let term = a.coeffs[i as usize] * b.coeffs[j as usize]
+                    if sign > 0 {
+                        product[output_index as usize] = product[output_index as usize] + term
+                    } else {
+                        product[output_index as usize] = product[output_index as usize] - term
+                    }
+                }
+                j = j + 1
+            }
+        }
+        i = i + 1
+    }
+    i = 0
+    while i < 16 {
+        if product[i as usize] != 0 { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn zd_token_integrity_raw(
+    left: [i64; 16],
+    right: [i64; 16],
+    left_identity: i64,
+    right_identity: i64
+) -> i64 with Mut {
+    var h = 7919 + (left_identity % 1000003) * 17 + (right_identity % 1000003) * 31
+    var i = 0
+    while i < 16 {
+        h = (h * 131 + (left[i as usize] + 2) * (i + 3)) % 2147483647
+        h = (h * 131 + (right[i as usize] + 2) * (i + 19)) % 2147483647
+        i = i + 1
+    }
+    h
+}
+
+fn zd_invalid_token() -> ZDExactTokenV0 {
+    ZDExactTokenV0 {
+        left_coeffs: [0; 16],
+        right_coeffs: [0; 16],
+        left_identity: 0,
+        right_identity: 0,
+        convention_tag: zd_convention_cd_sigma_v0(),
+        domain_tag: zd_domain_sed16_sparse_pm1_i64_v0(),
+        detector_tag: zd_detector_exact_product_v0(),
+        orientation_tag: zd_orientation_ordered(),
+        valid: false,
+        integrity_tag: 0,
+    }
+}
+
+fn zd_failed_attempt(status: i64) -> ZDExactAttemptV0 {
+    ZDExactAttemptV0 { status: status, token: zd_invalid_token() }
+}
+
+pub fn zd_exact_attempt_v0(left: SedExact16V0, right: SedExact16V0) -> ZDExactAttemptV0 with Mut, Panic, Div {
+    if left.identity <= 0 || right.identity <= 0 {
+        return zd_failed_attempt(zd_status_identity_invalid())
+    }
+    let left_array_status = sed16_v0_array_status(left.coeffs)
+    let right_array_status = sed16_v0_array_status(right.coeffs)
+    if left_array_status == zd_status_overflow_risk() || right_array_status == zd_status_overflow_risk() {
+        return zd_failed_attempt(zd_status_overflow_risk())
+    }
+    if left_array_status != zd_status_proved() || right_array_status != zd_status_proved() {
+        return zd_failed_attempt(zd_status_unsupported())
+    }
+    if sed16_v0_is_zero(left) || sed16_v0_is_zero(right) {
+        return zd_failed_attempt(zd_status_zero_operand())
+    }
+    if !sed16_v0_product_is_zero(left, right) {
+        return zd_failed_attempt(zd_status_not_zd())
+    }
+    let integrity = zd_token_integrity_raw(left.coeffs, right.coeffs, left.identity, right.identity)
+    let token = ZDExactTokenV0 {
+        left_coeffs: left.coeffs,
+        right_coeffs: right.coeffs,
+        left_identity: left.identity,
+        right_identity: right.identity,
+        convention_tag: zd_convention_cd_sigma_v0(),
+        domain_tag: zd_domain_sed16_sparse_pm1_i64_v0(),
+        detector_tag: zd_detector_exact_product_v0(),
+        orientation_tag: zd_orientation_ordered(),
+        valid: true,
+        integrity_tag: integrity,
+    }
+    ZDExactAttemptV0 { status: zd_status_proved(), token: token }
+}
+
+pub fn zd_exact_attempt_status(a: ZDExactAttemptV0) -> i64 { a.status }
+
+pub fn zd_exact_attempt_proved(a: ZDExactAttemptV0) -> bool with Mut, Panic, Div {
+    a.status == zd_status_proved() && zd_exact_token_integrity_ok(a.token)
+}
+
+pub fn zd_exact_token(a: ZDExactAttemptV0) -> ZDExactTokenV0 with Mut, Panic, Div {
+    assert(zd_exact_attempt_proved(a))
+    a.token
+}
+
+pub fn zd_exact_token_integrity_ok(token: ZDExactTokenV0) -> bool with Mut, Panic, Div {
+    if !token.valid { return false }
+    if token.left_identity <= 0 || token.right_identity <= 0 { return false }
+    if token.convention_tag != zd_convention_cd_sigma_v0() { return false }
+    if token.domain_tag != zd_domain_sed16_sparse_pm1_i64_v0() { return false }
+    if token.detector_tag != zd_detector_exact_product_v0() { return false }
+    if token.orientation_tag != zd_orientation_ordered() { return false }
+    if sed16_v0_array_status(token.left_coeffs) != zd_status_proved() { return false }
+    if sed16_v0_array_status(token.right_coeffs) != zd_status_proved() { return false }
+    let left = SedExact16V0 {
+        coeffs: token.left_coeffs,
+        identity: token.left_identity,
+        element_status: sed_element_ok(),
+    }
+    let right = SedExact16V0 {
+        coeffs: token.right_coeffs,
+        identity: token.right_identity,
+        element_status: sed_element_ok(),
+    }
+    if sed16_v0_is_zero(left) || sed16_v0_is_zero(right) { return false }
+    // Recompute the exact ordered product before consulting the checksum.
+    // A matching or cloned checksum never establishes annihilation.
+    if !sed16_v0_product_is_zero(left, right) { return false }
+    token.integrity_tag == zd_token_integrity_raw(
+        token.left_coeffs,
+        token.right_coeffs,
+        token.left_identity,
+        token.right_identity,
+    )
+}
+
+fn zd_coeffs_equal(a: [i64; 16], b: [i64; 16]) -> bool with Mut {
+    var i = 0
+    while i < 16 {
+        if a[i as usize] != b[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+pub fn zd_exact_token_matches_ordered(
+    token: ZDExactTokenV0,
+    left: SedExact16V0,
+    right: SedExact16V0
+) -> bool with Mut, Panic, Div {
+    zd_exact_token_integrity_ok(token) &&
+    token.left_identity == left.identity &&
+    token.right_identity == right.identity &&
+    zd_coeffs_equal(token.left_coeffs, left.coeffs) &&
+    zd_coeffs_equal(token.right_coeffs, right.coeffs)
+}
+
+pub fn zd_requires_exact(token: ZDExactTokenV0) -> bool with Mut, Panic, Div {
+    zd_exact_token_integrity_ok(token)
+}
+
+fn zd_is_finite_f64(x: f64) -> bool {
+    if x != x { return false }
+    // The measured lean_single NaN path can compare equal to both operands.
+    if x == 0.0 && x == 1.0 { return false }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    ax <= 1.7976931348623157e308
+}
+
+pub fn zd_measured_norm_f64_v0(
+    left_identity: i64,
+    right_identity: i64,
+    left_norm_sq: f64,
+    right_norm_sq: f64,
+    product_norm_sq: f64,
+    resolution: f64
+) -> ZDMeasuredReceiptV0 with Mut {
+    var status = zd_status_not_zd()
+    var near_zero = false
+    if left_identity <= 0 || right_identity <= 0 {
+        status = zd_status_identity_invalid()
+    } else if !zd_is_finite_f64(left_norm_sq) || !zd_is_finite_f64(right_norm_sq) ||
+              !zd_is_finite_f64(product_norm_sq) || !zd_is_finite_f64(resolution) {
+        status = zd_status_unsupported()
+    } else if left_norm_sq < 0.0 || right_norm_sq < 0.0 ||
+              resolution <= 0.0 || product_norm_sq < 0.0 {
+        status = zd_status_unsupported()
+    } else if left_norm_sq == 0.0 || right_norm_sq == 0.0 {
+        status = zd_status_zero_operand()
+    } else if product_norm_sq < resolution {
+        near_zero = true
+        status = zd_status_measured_near_zero()
+    }
+    ZDMeasuredReceiptV0 {
+        left_identity: left_identity,
+        right_identity: right_identity,
+        left_norm_sq: left_norm_sq,
+        right_norm_sq: right_norm_sq,
+        product_norm_sq: product_norm_sq,
+        resolution: resolution,
+        domain_tag: zd_domain_measured_norm_f64_v0(),
+        detector_tag: zd_detector_measured_norm_f64_v0(),
+        near_zero: near_zero,
+        status: status,
+    }
+}
+
+pub fn zd_measurement_status(r: ZDMeasuredReceiptV0) -> i64 { r.status }
+pub fn zd_measurement_near_zero(r: ZDMeasuredReceiptV0) -> bool { r.near_zero }
+pub fn zd_measurement_is_exact_proof(r: ZDMeasuredReceiptV0) -> bool {
+    let _observed = r
+    false
+}

--- a/tests/stdlib/eisa/test_eisa_h_zd.sio
+++ b/tests/stdlib/eisa/test_eisa_h_zd.sio
@@ -1,0 +1,101 @@
+//@ run-pass
+
+use eisa::hypercomplex_zd::*
+
+fn main() -> i32 with IO, Mut, Panic, Div {
+    let left = sed16_v0_two_support(101, 3, 1, 10, 1)
+    let right = sed16_v0_two_support(202, 6, 1, 15, -1)
+    let proved = zd_exact_attempt_v0(left, right)
+    if !zd_exact_attempt_proved(proved) { println("FAIL positive"); return 1 }
+    let token = zd_exact_token(proved)
+    if !zd_requires_exact(token) { println("FAIL exact-consumer"); return 1 }
+    if !zd_exact_token_matches_ordered(token, left, right) { println("FAIL ordered-match"); return 1 }
+
+    let non_zd_left = sed16_v0_basis(301, 1, 1)
+    let non_zd_right = sed16_v0_basis(302, 2, 1)
+    let non_zd = zd_exact_attempt_v0(non_zd_left, non_zd_right)
+    if zd_exact_attempt_status(non_zd) != zd_status_not_zd() { println("FAIL negative"); return 1 }
+
+    let zero = sed16_v0_zero(401)
+    let zero_attempt = zd_exact_attempt_v0(zero, right)
+    if zd_exact_attempt_status(zero_attempt) != zd_status_zero_operand() { println("FAIL zero-operand"); return 1 }
+
+    // Same support bits as the proved right operand, but the e15 sign is flipped.
+    // The product is 2e5 + 2e12, not zero.
+    let sign_tamper = sed16_v0_two_support(203, 6, 1, 15, 1)
+    let sign_attempt = zd_exact_attempt_v0(left, sign_tamper)
+    if zd_exact_attempt_status(sign_attempt) != zd_status_not_zd() { println("FAIL sign-tamper"); return 1 }
+
+    let identity_tamper = sed16_v0_two_support(999, 3, 1, 10, 1)
+    if zd_exact_token_matches_ordered(token, identity_tamper, right) { println("FAIL identity-tamper"); return 1 }
+    if zd_exact_token_matches_ordered(token, right, left) { println("FAIL orientation"); return 1 }
+
+    let measured = zd_measured_norm_f64_v0(501, 502, 2.0, 2.0, 1.0e-20, 1.0e-12)
+    if !zd_measurement_near_zero(measured) { println("FAIL measured-near-zero"); return 1 }
+    if zd_measurement_status(measured) != zd_status_measured_near_zero() { println("FAIL measured-status"); return 1 }
+    if zd_measurement_is_exact_proof(measured) { println("FAIL proof-measurement"); return 1 }
+
+    let outside_domain = sed16_v0_two_support(601, 3, 2, 10, 1)
+    let outside_domain_attempt = zd_exact_attempt_v0(outside_domain, right)
+    if zd_exact_attempt_status(outside_domain_attempt) != zd_status_unsupported() { println("FAIL coefficient-domain"); return 1 }
+
+    let unsupported = sed16_v0_two_support(701, 3, 1, 3, -1)
+    let unsupported_attempt = zd_exact_attempt_v0(unsupported, right)
+    if zd_exact_attempt_status(unsupported_attempt) != zd_status_unsupported() { println("FAIL unsupported"); return 1 }
+
+    let invalid_identity = sed16_v0_two_support(0, 3, 1, 10, 1)
+    let invalid_attempt = zd_exact_attempt_v0(invalid_identity, right)
+    if zd_exact_attempt_status(invalid_attempt) != zd_status_identity_invalid() { println("FAIL identity-invalid"); return 1 }
+
+    // External struct literals are currently accepted. The forged advisory
+    // status must not admit coefficients whose multiplication could wrap i64.
+    var huge_coeffs: [i64; 16] = [0; 16]
+    huge_coeffs[1] = 4294967296
+    huge_coeffs[2] = 4294967296
+    let forged_huge = SedExact16V0 {
+        coeffs: huge_coeffs,
+        identity: 801,
+        element_status: 0,
+    }
+    let forged_huge_attempt = zd_exact_attempt_v0(forged_huge, forged_huge)
+    if zd_exact_attempt_status(forged_huge_attempt) != zd_status_overflow_risk() { println("FAIL forged-overflow"); return 1 }
+
+    // Clone a checksum from a real token but replace the ordered operands with
+    // e1 and e2. Token acceptance must recompute the nonzero product.
+    var e1_coeffs: [i64; 16] = [0; 16]
+    var e2_coeffs: [i64; 16] = [0; 16]
+    e1_coeffs[1] = 1
+    e2_coeffs[2] = 1
+    let forged_token = ZDExactTokenV0 {
+        left_coeffs: e1_coeffs,
+        right_coeffs: e2_coeffs,
+        left_identity: 901,
+        right_identity: 902,
+        convention_tag: zd_convention_cd_sigma_v0(),
+        domain_tag: zd_domain_sed16_sparse_pm1_i64_v0(),
+        detector_tag: zd_detector_exact_product_v0(),
+        orientation_tag: zd_orientation_ordered(),
+        valid: true,
+        integrity_tag: token.integrity_tag,
+    }
+    if zd_requires_exact(forged_token) { println("FAIL forged-token"); return 1 }
+
+    let inf = 1.0e308 * 10.0
+    let neg_inf = 0.0 - inf
+    let nan = inf - inf
+    let measured_nan = zd_measured_norm_f64_v0(1001, 1002, 2.0, 2.0, nan, 1.0e-12)
+    if zd_measurement_status(measured_nan) != zd_status_unsupported() { println("FAIL measured-nan"); return 1 }
+    let measured_inf = zd_measured_norm_f64_v0(1003, 1004, inf, 2.0, 0.0, 1.0e-12)
+    if zd_measurement_status(measured_inf) != zd_status_unsupported() { println("FAIL measured-inf"); return 1 }
+    let resolution_inf = zd_measured_norm_f64_v0(1005, 1006, 2.0, 2.0, 0.0, inf)
+    if zd_measurement_status(resolution_inf) != zd_status_unsupported() { println("FAIL resolution-inf"); return 1 }
+    let measured_neg_inf = zd_measured_norm_f64_v0(1005, 1006, 2.0, neg_inf, 0.0, 1.0e-12)
+    if zd_measurement_status(measured_neg_inf) != zd_status_unsupported() { println("FAIL measured-neg-inf"); return 1 }
+    let negative_norm = zd_measured_norm_f64_v0(1007, 1008, -1.0, 2.0, 0.0, 1.0e-12)
+    if zd_measurement_status(negative_norm) != zd_status_unsupported() { println("FAIL negative-norm"); return 1 }
+    let threshold_equal = zd_measured_norm_f64_v0(1009, 1010, 2.0, 2.0, 1.0e-12, 1.0e-12)
+    if zd_measurement_status(threshold_equal) != zd_status_not_zd() || zd_measurement_near_zero(threshold_equal) { println("FAIL threshold-equality"); return 1 }
+
+    println("EISA_H_ZD_REF_V0 PASS")
+    0
+}


### PR DESCRIPTION
## Summary

- add a bounded exact software reference for ordered sedenion zero-divisor evidence
- separate exact proof tokens from measured near-zero receipts at the type boundary
- preserve signed coefficients, operand order and identity, Cayley-Dickson convention, domain, detector, and explicit failure class
- register `SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE` as executable only within the declared sparse `+/-1 i64` domain

## Load-bearing witness

The gate distinguishes the same-support sign pair:

```text
(e3 + e10) * (e6 - e15) = 0
(e3 + e10) * (e6 + e15) = 2e5 + 2e12
```

It therefore does not inherit the unsigned-support blindness of the current non-authoritative `IrSedZDCheck` placeholder.

## Adversarial repairs

Read-only review found that both installed compilers currently permit external struct literals despite nominally private fields. The final implementation therefore never trusts construction privacy or caller-controlled status:

- coefficient arrays are revalidated before multiplication
- forged `2^32` operands are rejected before i64 wraparound
- every token consumer revalidates tags, identities, domain, nonzero operands and exact product before consulting the checksum
- a forged `e1*e2` token with a cloned checksum is rejected
- NaN, infinities, negative norms/products and invalid resolution are unsupported
- threshold equality remains `NOT_ZD`

## Verification

- `bash scripts/ci/eisa_h_zd_reference_gate.sh` PASS
- `bash scripts/ci/zero_event_gate.sh` PASS
- `bash scripts/ci/semantic_coordination_gate.sh` PASS
- `bash scripts/dev/check_docs_registry.sh` PASS + selftest
- `bash scripts/dev/check_docs_consistency.sh` PASS
- `git diff --check` PASS
- post-commit focused gate PASS

Execution receipt:

```text
check=Madaros
execution=lean_single
madaros_runtime=BLOCKED
wrapper_rc=1
native_driver_rc=12
```

## LLM offload

- xAI/Grok 4.3: PASS after repair
- ZAI/GLM-5.2: PASS after repair; independently recomputed the exact four-term i64 bound

## Claim boundary

Supported: exact ordered annihilation detection only for at-most-two-support `+/-1 i64` sedenions under `cd_sigma_exact_i64`, checked by Madaros and executed through lean_single.

Not supported: arbitrary-sedenion decision, default Madaros runtime, authoritative `IrSedZDCheck`, checker emission, EISA opcode, ABI, native lowering, RTL, silicon, cancellation/inversion authority, or any physical or clinical interpretation. E176/private-field enforcement and Madaros native write rc=12 remain explicit blockers.