### PR TITLE
fix(parser): `study` soft keyword — final piece of arm64 parity (#740)

### DIFF
--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -307,7 +307,7 @@ impl Parser {
             self.parse_contest_expr()
         }
         // Identifier (variable, function name, enum path, struct literal)
-        else if k == TokenKind::Ident || k == TokenKind::Knowledge || k == TokenKind::Close || k == TokenKind::Unit || k == TokenKind::Kernel {
+        else if k == TokenKind::Ident || k == TokenKind::Knowledge || k == TokenKind::Close || k == TokenKind::Unit || k == TokenKind::Kernel || k == TokenKind::Study {
             self.parse_ident_expr()
         }
         // Error recovery: advance past unrecognized token to avoid infinite loops

--- a/self-hosted/parser/patterns.sio
+++ b/self-hosted/parser/patterns.sio
@@ -100,7 +100,7 @@ impl Parser {
             self.parse_string_pattern()
         } else if k == TokenKind::LParen {
             self.parse_tuple_pattern()
-        } else if k == TokenKind::Ident || k == TokenKind::Handle || k == TokenKind::Unit || k == TokenKind::Kernel {
+        } else if k == TokenKind::Ident || k == TokenKind::Handle || k == TokenKind::Unit || k == TokenKind::Kernel || k == TokenKind::Study {
             self.parse_ident_or_enum_pattern()
         } else if k == TokenKind::Var {
             self.parse_mut_binding_pattern()


### PR DESCRIPTION
## Summary

Final piece of the **#740 arm64 backend-parity campaign**: make the modular
`lean.sio` check compiler cross-compile to arm64-macOS and run the native
typecheck proof on real Apple Silicon.

Over the campaign, **11 distinct codegen/parser bugs** were found — none of which
the "0 typecheck errors" milestone could see, because they only manifest when the
emitted binary actually *runs* on Apple Silicon hardware. **10 of the 11 are
already merged to `main`** (via earlier PRs and parallel-agent branches). This PR
carries the **one remaining genuinely-unmerged fix** — the `study` soft keyword —
and documents the full campaign for the record.

## This PR (the 1 remaining fix)

**`fix(parser): treat \`study\` as a soft keyword`** — the lexer unconditionally
maps `study` → `TokenKind::Study` (for `study { ... }` item declarations), so the
token leaked into ordinary expression/pattern position. `check.sio` itself uses
`study` as a plain local (`let study = …`, `while i < study.hypothesis_count`,
`study.hypotheses[i].outcome`), so `parse_prefix`/`parse_pattern_atom` fell through
to error recovery and emitted spurious `E018`s. Added `TokenKind::Study` to both
allowlists, mirroring the existing `Knowledge`/`Close`/`Unit`/`Kernel`/`Handle`
treatment. Two lines, target-independent.

**Verified** (modular Madaros checker built from this tree):
- minimal bare-`study` repro: `exit 1` (clean main) → `exit 0` / `check: OK`
- `check.sio`: `2297 → 2290` diagnostics — the 7 removed are exactly the `study`
  `E018`s; every other diagnostic byte-identical to clean main.

## The full 11-fix campaign (10 already in main)

Each was found only by running the arm64 binary on Apple Silicon (macOS 27.0),
diagnosed via crash-report `.ips` triage (`x[16]` syscall #, `far` fault addr,
`imageOffset`→fn map), and HW-verified after the fix.

**arm64 codegen (9) — all merged to `main`:**
| commit | root cause |
|---|---|
| `e6c298d64` | "no main": pass-2 clobbers `FN_NS/FN_NE` → locate `main` via `FN_NAME_TOK` |
| `39ff65cae` | string `==`/`!=` compared **pointers** → byte-compare branch |
| `3dd8e3d39` | `file_exists` raw Linux syscalls (openat 257) → SIGSYS on macOS → target-aware `file_size` |
| `d8644104e` | `Option<Box>` field-load missing `type_is_option_inline` → deref of value(0) → parser SIGSEGV |
| `87d0b2b60` | field-load offset ≥32768 wrapped the 12-bit `ldr` imm → wild read → checker SIGBUS → register fallback |
| `d205d239f` | `arr[i]=v` on byte-array used qword `str …,lsl#3` → OOB write clobbered caller frame → width from `arr_hash_esiz` |
| `d0bbee498` | macOS `open()` failure detected via `fd<0` (Linux) not the carry flag → wrong import resolution → SIGSEGV |
| `3008629a0` | string `+` did integer pointer-add → concat branch |
| `5b6c4dc57` | `compile_stmt_a64` missing two-level deref field/field-array stores → checker `env.count` stuck at 0 → lost builtins (merged to main as **#819/#823**) |

**parser (2) — target-independent:**
| commit | root cause |
|---|---|
| `653e9883c` | un-braced assignment as a match-arm body (`Pat => c = expr`) — already in `main` |
| `98e1d1a9c` (this PR) | `study` soft keyword in expression/pattern position |

## End-to-end proof (Apple Silicon, macOS 27.0, arm64)

The campaign binary passed the complete proof on real hardware: valid source →
`check: ok` (exit 0), type-error source → `failed` (exit 1), self-test → ok,
algebra-test → `T1201 OK`, and every real module checked (`ast`, `ir/ir`,
`parser`, `check/mod`, `ir/lower`, `check/check` @ 971 KB) → `check: ok`.

## Verification methodology
- **x86 byte-neutrality** for codegen fixes (fixes live in `_a64` twins → arm64-only).
- **Fixed-point** gate (stage2 == stage3) held across the campaign.
- **Module suite** no-regression.
- Parser fixes are target-independent; the `study` fix's exact diagnostic delta is shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
