### PR TITLE
fix(lower): preserve f64 array typing through deref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,17 @@ jobs:
             /tmp/sounio-arm64-array-element-field-witness
           retention-days: 1
 
+  madaros-current-source-deref-f64:
+    name: Madaros Current-Source Dereferenced f64 Array
+    needs: impact
+    if: needs.impact.outputs.compiler == 'true' || needs.impact.outputs.tests == 'true' || needs.impact.outputs.full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Rebuild Madaros and run imported dereferenced f64-array witness
+        run: bash scripts/ci/madaros_imported_deref_f64_array_gate.sh
+
   native-selfhost-macos-arm64:
     name: Native Self-Host (macOS arm64)
     runs-on: macos-15
@@ -423,6 +434,7 @@ jobs:
       - contracts
       - native-selfhost-linux-x86_64
       - source-bootstrap-selfhost-linux-x86_64
+      - madaros-current-source-deref-f64
       - native-selfhost-macos-arm64
       - full-test-suite
       - sounio-lint

--- a/scripts/ci/evaluate_ci_decision.py
+++ b/scripts/ci/evaluate_ci_decision.py
@@ -23,6 +23,9 @@ def main() -> int:
             truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")
         ),
         "source-bootstrap-selfhost-linux-x86_64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
+        "madaros-current-source-deref-f64": any(
+            truthy(impact.get(key)) for key in ("compiler", "tests", "full")
+        ),
         "native-selfhost-macos-arm64": truthy(impact.get("compiler")) or truthy(impact.get("full")),
         "full-test-suite": any(truthy(impact.get(key)) for key in ("compiler", "runtime", "stdlib", "tests", "full")),
         "sounio-lint": any(truthy(impact.get(key)) for key in ("compiler", "stdlib", "tests", "sio", "full")),

--- a/scripts/ci/impact_ci_selftest.sh
+++ b/scripts/ci/impact_ci_selftest.sh
@@ -50,7 +50,7 @@ non_pr="$(CI_EVENT_NAME=push $CLASSIFIER)"
 expect "$non_pr" full true
 expect "$non_pr" compiler true
 
-good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+good_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"false","tests":"false","sio":"false","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"skipped"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 NEEDS_JSON="$good_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
 
 bad_needs="${good_needs/\"contracts\":{\"result\":\"success\"}/\"contracts\":{\"result\":\"failure\"}}"
@@ -59,7 +59,15 @@ if NEEDS_JSON="$bad_needs" python3 "$DECISION" >/dev/null 2>&1; then
   exit 1
 fi
 
-stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+compiler_needs='{"impact":{"outputs":{"compiler":"true","runtime":"false","stdlib":"false","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"success"},"source-bootstrap-selfhost-linux-x86_64":{"result":"success"},"madaros-current-source-deref-f64":{"result":"failure"},"native-selfhost-macos-arm64":{"result":"success"},"full-test-suite":{"result":"success"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
+if NEEDS_JSON="$compiler_needs" python3 "$DECISION" >/dev/null 2>&1; then
+  echo "impact-ci-selftest: decision accepted failed current-source Madaros gate" >&2
+  exit 1
+fi
+compiler_green_needs="${compiler_needs/\"failure\"/\"success\"}"
+NEEDS_JSON="$compiler_green_needs" python3 "$DECISION" | grep -Fq CI_DECISION_PASS
+
+stdlib_needs='{"impact":{"outputs":{"compiler":"false","runtime":"false","stdlib":"true","tests":"false","sio":"true","lean":"false","website":"false","full":"false"}},"contracts":{"result":"success"},"native-selfhost-linux-x86_64":{"result":"skipped"},"source-bootstrap-selfhost-linux-x86_64":{"result":"skipped"},"madaros-current-source-deref-f64":{"result":"skipped"},"native-selfhost-macos-arm64":{"result":"skipped"},"full-test-suite":{"result":"skipped"},"sounio-lint":{"result":"success"},"lean-proofs":{"result":"skipped"},"website":{"result":"skipped"}}'
 if NEEDS_JSON="$stdlib_needs" python3 "$DECISION" >/dev/null 2>&1; then
   echo "impact-ci-selftest: decision accepted stdlib suite without native compiler/full suite" >&2
   exit 1

--- a/scripts/ci/madaros_full_gate.sh
+++ b/scripts/ci/madaros_full_gate.sh
@@ -135,4 +135,7 @@ pass "native-v2 ABI/backend witnesses"
 expect_log_contains "SPM self-tests: ALL PASSED" "$WORK/pkg_self_test.log"
 pass "package manager self-test"
 
-echo "[madaros-full] PASS: public CLI, source ELF path, ABI witnesses, visibility, and pkg self-test"
+bash "$ROOT_DIR/scripts/ci/madaros_imported_deref_f64_array_gate.sh"
+pass "current-source imported dereferenced f64-array lowering"
+
+echo "[madaros-full] PASS: public CLI, source ELF path, ABI witnesses, visibility, pkg self-test, and current-source dereferenced f64-array lowering"

--- a/scripts/ci/madaros_imported_deref_f64_array_gate.sh
+++ b/scripts/ci/madaros_imported_deref_f64_array_gate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KEEP_WORK="${SOUNIO_MADAROS_DEREF_F64_GATE_KEEP:-0}"
+SOURCE="$ROOT_DIR/tests/run-pass/imported_deref_f64_array.sio"
+
+fail() {
+  echo "[madaros-deref-f64] FAIL: $*" >&2
+  exit 1
+}
+
+if [[ -n "${SOUNIO_MADAROS_DEREF_F64_GATE_DIR:-}" ]]; then
+  WORK="$SOUNIO_MADAROS_DEREF_F64_GATE_DIR"
+  [[ ! -e "$WORK" ]] || fail "refusing existing gate directory: $WORK"
+  mkdir "$WORK" || fail "could not create gate directory: $WORK"
+else
+  WORK="$(mktemp -d /tmp/sounio-madaros-deref-f64.XXXXXX)"
+fi
+
+MADAROS_ELF="$WORK/madaros"
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+if ! bash "$ROOT_DIR/scripts/ci/build_modular_madaros.sh" "$MADAROS_ELF" >"$WORK/build.log" 2>&1; then
+  tail -n 80 "$WORK/build.log" >&2 || true
+  fail "current-source Madaros build failed"
+fi
+[[ -x "$MADAROS_ELF" ]] || fail "rebuilt Madaros is missing or not executable: $MADAROS_ELF"
+
+set +e
+MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros" run "$SOURCE" >"$WORK/run.log" 2>&1
+run_rc=$?
+set -e
+
+if [[ "$run_rc" != "0" ]]; then
+  cat "$WORK/run.log" >&2
+  fail "imported dereferenced f64-array witness exited rc=$run_rc"
+fi
+grep -Fxq 'PASS imported_deref_f64_array' "$WORK/run.log" || {
+  cat "$WORK/run.log" >&2
+  fail "exact PASS marker missing"
+}
+
+echo "[madaros-deref-f64] PASS: rebuilt current-source Madaros preserves f64 element typing through imported dereference"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -4905,6 +4905,9 @@ impl Lowerer {
                 if (*base_expr).kind == ExprKind::ExprFieldAccess {
                     return self.field_array_elem_is_float_for_base_ref(&(*base_expr).left, (*base_expr).name)
                 }
+                if (*base_expr).kind == ExprKind::ExprUnary && (*base_expr).un_op == UnaryOp::OpDeref {
+                    return self.index_base_elem_is_float_ref(&(*base_expr).left)
+                }
                 false
             }
             _ => false,

--- a/tests/run-pass/fixtures/imported_deref_f64_array_leaf.sio
+++ b/tests/run-pass/fixtures/imported_deref_f64_array_leaf.sio
@@ -1,0 +1,19 @@
+pub fn imported_read_i64(a: &[i64; 4]) -> i64 {
+    (*a)[2]
+}
+
+pub fn imported_read_f64(a: &[f64; 4]) -> f64 {
+    (*a)[1]
+}
+
+pub fn imported_read_f64_mut(a: &![f64; 4]) -> f64 {
+    (*a)[2]
+}
+
+pub fn imported_sum_f64(a: &[f64; 4]) -> f64 {
+    (*a)[1] + (*a)[2]
+}
+
+pub fn imported_f64_element_check(a: &[f64; 4]) -> i64 {
+    if (*a)[1] == 1.25 { 1 } else { 0 }
+}

--- a/tests/run-pass/imported_deref_f64_array.sio
+++ b/tests/run-pass/imported_deref_f64_array.sio
@@ -1,0 +1,25 @@
+//@ run-pass
+//@ expect-stdout: PASS imported_deref_f64_array
+//@ description: Imported dereferenced f64-array refs preserve float element typing.
+
+use fixtures::imported_deref_f64_array_leaf::{
+    imported_read_i64,
+    imported_read_f64,
+    imported_read_f64_mut,
+    imported_sum_f64,
+    imported_f64_element_check,
+}
+
+fn main() -> i32 with IO {
+    let ints: [i64; 4] = [0, 0, 7, 0]
+    if imported_read_i64(&ints) != 7 { return 1 }
+
+    var values: [f64; 4] = [0.0, 1.25, 2.75, 0.0]
+    if imported_f64_element_check(&values) != 1 { return 2 }
+    if imported_read_f64(&values) != 1.25 { return 3 }
+    if imported_read_f64_mut(&!values) != 2.75 { return 4 }
+    if imported_sum_f64(&values) != 4.0 { return 5 }
+
+    println("PASS imported_deref_f64_array")
+    0
+}


### PR DESCRIPTION
## Summary

- preserve `f64` element typing when imported array references are indexed through `(*a)[i]`
- add an imported immutable/mutable `f64` array witness with an `i64` control
- rebuild current-source Madaros in a focused gate and require that gate in ordinary PR CI

## Root cause

`Lowerer.index_base_elem_is_float_ref` recognized identifiers and field accesses but did not recurse through unary dereference nodes. The lowered index therefore selected integer element semantics for imported `&[f64; N]` / `&![f64; N]` parameters.

## Proof

- `bash scripts/ci/madaros_imported_deref_f64_array_gate.sh`
  - PASS
  - rebuilt binary: 98,386,602 bytes
  - elapsed: 190.36 seconds
  - max RSS: 513,024 KB
- canonical `bin/madaros run tests/run-pass/imported_deref_f64_array.sio`
  - rc=0
  - exact marker: `PASS imported_deref_f64_array`
- `bash scripts/ci/impact_ci_selftest.sh`
  - `IMPACT_CI_SELFTEST_PASS`
- workflow script references, shell/Python syntax, YAML parse, and `git diff --check`
  - PASS

## Claim boundary

This fixes imported dereferenced `f64` array element typing. The larger sedenion witness now compiles but retains a separate runtime failure in `sed_mul` (`out[12] != 0`), which is intentionally not claimed as fixed here.

## Review

Orthogonal read-only review: READY, no findings. The reviewer confirmed required ordinary-PR failure propagation and safe gate-directory ownership.
