### PR TITLE
test(lean-single): pin pub use visibility blocker

### DIFF
--- a/scripts/ci/lean_single_pub_use_reexport_gate.sh
+++ b/scripts/ci/lean_single_pub_use_reexport_gate.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Contract gate for named function re-exports in braced `pub use` lists.
+# Types, constants, aliases, globs, renames, and chained re-exports are out of scope.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+KEEP_WORK="${SOUNIO_LEAN_SINGLE_PUB_USE_GATE_KEEP:-0}"
+
+fail() {
+  echo "[lean-single-pub-use] FAIL: $*" >&2
+  exit 1
+}
+
+if [[ -n "${SOUNIO_LEAN_SINGLE_PUB_USE_GATE_DIR:-}" ]]; then
+  WORK="$SOUNIO_LEAN_SINGLE_PUB_USE_GATE_DIR"
+  [[ ! -e "$WORK" ]] || fail "refusing existing gate directory: $WORK"
+  mkdir "$WORK" || fail "could not create gate directory: $WORK"
+else
+  WORK="$(mktemp -d /tmp/sounio-lean-single-pub-use.XXXXXX)"
+fi
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+semantic_unknown_rejection() {
+  local rc="$1"
+  local log="$2"
+  local symbol="$3"
+
+  [[ "$rc" -eq 1 ]] || return 1
+  grep -Eq "^error: unknown identifier \`$symbol\` at " "$log" || return 1
+  grep -Fxq 'typecheck: failed' "$log" || return 1
+  if grep -Eiq 'segmentation fault|core dumped|terminated by signal|fatal:|bus error|illegal instruction' "$log"; then
+    return 1
+  fi
+  return 0
+}
+
+adversarial_log="$WORK/adversarial-rc139.log"
+printf '%s\n' \
+  'error: unknown identifier `synthetic_value` at <main>:1' \
+  'typecheck: failed' \
+  'Segmentation fault (core dumped)' >"$adversarial_log"
+if semantic_unknown_rejection 139 "$adversarial_log" synthetic_value; then
+  fail "adversarial expected-diagnostic plus rc=139 was accepted"
+fi
+
+valid_semantic_log="$WORK/valid-semantic-rc1.log"
+printf '%s\n' \
+  'error: unknown identifier `synthetic_value` at <main>:1' \
+  'typecheck: failed' >"$valid_semantic_log"
+semantic_unknown_rejection 1 "$valid_semantic_log" synthetic_value || {
+  fail "valid semantic rc=1 diagnostic was rejected"
+}
+
+fatal_log="$WORK/adversarial-fatal-rc1.log"
+printf '%s\n' \
+  'error: unknown identifier `synthetic_value` at <main>:1' \
+  'typecheck: failed' \
+  'fatal: synthetic compiler abort' >"$fatal_log"
+if semantic_unknown_rejection 1 "$fatal_log" synthetic_value; then
+  fail "fatal diagnostic with rc=1 was accepted as semantic rejection"
+fi
+
+echo "[lean-single-pub-use] PASS: semantic_rc1_accepted=1 adversarial_rc139_rejected=1 fatal_rc1_rejected=1"
+
+if [[ "${SOUNIO_LEAN_SINGLE_PUB_USE_GATE_SELF_TEST_ONLY:-0}" == "1" ]]; then
+  exit 0
+fi
+
+COMPILER="${SOUNIO_LEAN_SINGLE_PUB_USE_GATE_BIN:-$WORK/lean_single}"
+if [[ -z "${SOUNIO_LEAN_SINGLE_PUB_USE_GATE_BIN:-}" ]]; then
+  SEED="${SOUNIO_LEAN_SINGLE_PUB_USE_GATE_SEED:-$ROOT_DIR/bin/souc-lean-single-x86_64}"
+  [[ -x "$SEED" ]] || fail "lean_single seed is missing or not executable: $SEED"
+  if ! "$ROOT_DIR/scripts/dev/souc-build-lock.sh" \
+      "$SEED" "$ROOT_DIR/self-hosted/compiler/lean_single.sio" "$COMPILER" \
+      >"$WORK/build.log" 2>&1; then
+    tail -n 80 "$WORK/build.log" >&2 || true
+    fail "current-source lean_single build failed"
+  fi
+  chmod +x "$COMPILER"
+fi
+[[ -x "$COMPILER" ]] || fail "lean_single candidate is missing or not executable: $COMPILER"
+
+compile_case() {
+  local name="$1"
+  local source="$2"
+  local elf="$WORK/$name.elf"
+  local log="$WORK/$name.compile.log"
+
+  CASE_RC=0
+  set +e
+  SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib" "$COMPILER" "$source" "$elf" >"$log" 2>&1
+  CASE_RC=$?
+  set -e
+}
+
+run_case() {
+  local name="$1"
+  local elf="$WORK/$name.elf"
+  local log="$WORK/$name.run.log"
+
+  chmod +x "$elf"
+  CASE_RC=0
+  set +e
+  "$elf" >"$log" 2>&1
+  CASE_RC=$?
+  set -e
+}
+
+compile_case direct "$ROOT_DIR/tests/run-pass/pub_use_reexport_direct_control.sio"
+[[ "$CASE_RC" -eq 0 ]] || {
+  cat "$WORK/direct.compile.log" >&2
+  fail "direct-import positive control did not compile"
+}
+run_case direct
+[[ "$CASE_RC" -eq 0 ]] || {
+  cat "$WORK/direct.run.log" >&2
+  fail "direct-import positive control did not execute"
+}
+grep -Fxq 'PASS pub_use_reexport_direct_control' "$WORK/direct.run.log" || {
+  cat "$WORK/direct.run.log" >&2
+  fail "direct-import exact PASS marker missing"
+}
+
+facade_forwarding=0
+compile_case facade "$ROOT_DIR/tests/compiler/pub_use_reexport/public_consumer.sio"
+if [[ "$CASE_RC" -eq 0 ]]; then
+  run_case facade
+  [[ "$CASE_RC" -eq 0 ]] || {
+    cat "$WORK/facade.run.log" >&2
+    fail "facade compiled but did not execute"
+  }
+  grep -Fxq 'PASS pub_use_named_function_reexport' "$WORK/facade.run.log" || {
+    cat "$WORK/facade.run.log" >&2
+    fail "facade exact PASS marker missing"
+  }
+  facade_forwarding=1
+elif ! semantic_unknown_rejection "$CASE_RC" "$WORK/facade.compile.log" public_route_value; then
+  cat "$WORK/facade.compile.log" >&2
+  fail "facade failed for a reason other than absent forwarding"
+fi
+
+compile_case missing "$ROOT_DIR/tests/compiler/pub_use_reexport/missing_consumer.sio"
+[[ "$CASE_RC" -ne 0 ]] || fail "missing re-exported symbol compiled unexpectedly"
+semantic_unknown_rejection "$CASE_RC" "$WORK/missing.compile.log" missing_route_value || {
+  cat "$WORK/missing.compile.log" >&2
+  fail "missing-symbol diagnostic was not preserved"
+}
+
+selective_reexport=0
+compile_case not-reexported "$ROOT_DIR/tests/compiler/pub_use_reexport/not_reexported_consumer.sio"
+if [[ "$CASE_RC" -ne 0 ]]; then
+  semantic_unknown_rejection "$CASE_RC" "$WORK/not-reexported.compile.log" not_reexported_value || {
+    cat "$WORK/not-reexported.compile.log" >&2
+    fail "non-reexported witness failed for an unrelated reason"
+  }
+  selective_reexport=1
+fi
+
+# This is a separate known residual: private imports currently globalize public
+# declarations. It is reported in the receipt but does not substitute for the
+# selected public re-export contract above.
+private_import_isolated=0
+compile_case private "$ROOT_DIR/tests/compiler/pub_use_reexport/private_consumer.sio"
+if [[ "$CASE_RC" -eq 0 ]]; then
+  echo "[lean-single-pub-use] XFAIL BLK-20260713-lean-single-private-import-visibility: private use still globalizes a public leaf"
+elif semantic_unknown_rejection "$CASE_RC" "$WORK/private.compile.log" private_route_value; then
+  private_import_isolated=1
+  echo "[lean-single-pub-use] PASS: private use no longer re-exports its public leaf"
+else
+  cat "$WORK/private.compile.log" >&2
+  fail "private-use witness failed for a reason other than route visibility"
+fi
+
+echo "[lean-single-pub-use] receipt scope=named_function_reexports direct_import=PASS missing_symbol=REJECTED facade_forwarding=$facade_forwarding selective_reexport=$selective_reexport private_import_isolated=$private_import_isolated"
+
+if [[ "$facade_forwarding" -eq 0 ]]; then
+  echo "[lean-single-pub-use] BLOCKED BLK-20260713-lean-single-import-visibility: public forwarding is absent" >&2
+  exit 1
+fi
+if [[ "$selective_reexport" -eq 0 ]]; then
+  echo "[lean-single-pub-use] BLOCKED BLK-20260713-lean-single-import-visibility: forwarding exposes the whole leaf instead of the selected export" >&2
+  exit 1
+fi
+echo "[lean-single-pub-use] PASS: named function facade forwarding is selective and missing symbols remain rejected"

--- a/tests/compiler/pub_use_reexport/README.md
+++ b/tests/compiler/pub_use_reexport/README.md
@@ -1,0 +1,134 @@
+# lean_single named-function `pub use` contract
+
+This fixture set pins GitHub issue #842 without claiming that the compiler bug
+is fixed. The supported claim boundary is deliberately narrow:
+
+```sio
+pub use public_leaf::{public_route_value}
+use public_facade::{public_route_value}
+```
+
+The acceptance contract covers a named function in a braced `pub use` list.
+It does not establish semantics for types, structs, constants, aliases, globs,
+renames, or chained re-exports.
+
+## State matrix
+
+`scripts/ci/lean_single_pub_use_reexport_gate.sh` emits these independent
+receipt fields:
+
+| State | `facade_forwarding` | `selective_reexport` | Classification |
+|---|---:|---:|---|
+| Current seed | 0 | 1 | public forwarding absent |
+| Rejected load-whole-leaf patch | 1 | 0 | omitted leaf symbol overexposed |
+| Issue #842 acceptance | 1 | 1 | named-function re-export is selective |
+
+`private_import_isolated` is telemetry for a separate residual. It does not
+block issue #842 acceptance.
+
+Every semantic rejection must exit exactly `1`, contain an anchored
+`unknown identifier` diagnostic, and contain the exact line
+`typecheck: failed`. Signal exits, fatal diagnostics, and `rc >= 128` are not
+semantic success. The gate self-test accepts a valid `rc=1` receipt, rejects
+the same expected substring with `rc=139`, and rejects `rc=1` contaminated by
+a fatal diagnostic:
+
+```bash
+SOUNIO_LEAN_SINGLE_PUB_USE_GATE_SELF_TEST_ONLY=1 \
+  bash scripts/ci/lean_single_pub_use_reexport_gate.sh
+```
+
+## Blocker: named function forwarding
+
+```text
+Blocker-ID: BLK-20260713-lean-single-import-visibility
+Status: owned
+Severity: B1
+Class: compiler-semantics
+Owner: Codex compiler coordination (/root)
+Lane: future dedicated lean_single module bindings/exports implementation
+Worktree: /tmp/sounio-issue-842-pub-use-20260713
+Branch: codex/issue-842-pub-use-20260713
+Files-Owned: scripts/ci/lean_single_pub_use_reexport_gate.sh; tests/compiler/pub_use_reexport/*; tests/run-pass/pub_use_reexport_direct_control.sio; tests/run-pass/fixtures/pub_use_reexport_leaf.sio
+Files-Read-Only: self-hosted/compiler/lean_single.sio
+Do-Not-Touch: self-hosted/compiler/main.sio; self-hosted/ir/lower.sio; self-hosted/check/check.sio
+Repro: SOUNIO_LEAN_SINGLE_PUB_USE_GATE_BIN=bin/souc-lean-single-x86_64 bash scripts/ci/lean_single_pub_use_reexport_gate.sh
+Observed: direct import passes, but the named function is unknown through its public facade
+Expected: the listed function resolves through the facade while an omitted public leaf function remains unknown
+Acceptance-Gate: scripts/ci/lean_single_pub_use_reexport_gate.sh exits 0 with facade_forwarding=1 selective_reexport=1
+Evidence-Level: E3
+Evidence: reproducible gate receipt; latest local baseline under /tmp/sounio-842-baseline-*
+Fallback-Path: none
+Legacy-Kept: yes
+LLM-Offload: not-required
+Next-Action: design module-owned binding/export records and contextual lookup before editing compiler semantics
+```
+
+This B1 is explicitly transferred out of the diagnostic evidence lane. It
+blocks the future implementation lane, not a PR that adds only the executable
+contract and receipts in this directory.
+
+## Residual: private import visibility
+
+```text
+Blocker-ID: BLK-20260713-lean-single-private-import-visibility
+Status: classified
+Severity: B4
+Class: compiler-semantics
+Owner: Codex compiler coordination (/root)
+Lane: lean_single private import visibility follow-up
+Worktree: /tmp/sounio-issue-842-pub-use-20260713
+Branch: codex/issue-842-pub-use-20260713
+Files-Owned: tests/compiler/pub_use_reexport/private_*.sio
+Files-Read-Only: self-hosted/compiler/lean_single.sio
+Do-Not-Touch: issue #842 named-function acceptance semantics
+Repro: run the issue #842 gate and inspect private_import_isolated
+Observed: a public leaf function reached through private use is callable by the consumer
+Expected: private use does not add the leaf function to the facade public surface
+Acceptance-Gate: gate receipt reports private_import_isolated=1
+Evidence-Level: E3
+Evidence: private.compile.log in the gate receipt directory
+Fallback-Path: none
+Legacy-Kept: yes
+LLM-Offload: not-required
+Next-Action: schedule a separate visibility lane; this residual does not block issue #842
+```
+
+## Handoff and PR scope
+
+The diagnostic branch owns only the gate and fixtures named above. It contains
+no compiler-semantic patch and must not be presented as fixing #842. A PR from
+this branch should say:
+
+```text
+Adds an executable named-function re-export contract for issue #842.
+Pins the current missing-forwarding behavior, rejects whole-leaf overexposure,
+and records private-import globalization under a separate non-blocking receipt.
+No compiler implementation or public language claim changes in this PR.
+```
+
+The next implementation lane should start from current `origin/main`, retain
+these witnesses unchanged, and make the acceptance gate green without a
+facade-only byte scanner or load-whole-leaf shortcut.
+
+### Formal handoff
+
+```text
+Current-SHA: branch HEAD; resolve immutably with git rev-parse HEAD and use the SHA from the final agent receipt
+Current-Branch: codex/issue-842-pub-use-20260713
+Current-Worktree: /tmp/sounio-issue-842-pub-use-20260713
+Dirty-Status: clean after the diagnostic commit; verify with git status --short
+Owned-Files: scripts/ci/lean_single_pub_use_reexport_gate.sh; tests/compiler/pub_use_reexport/*; tests/run-pass/pub_use_reexport_direct_control.sio; tests/run-pass/fixtures/pub_use_reexport_leaf.sio
+Do-Not-Touch: self-hosted/compiler/lean_single.sio; self-hosted/compiler/main.sio; self-hosted/ir/lower.sio; self-hosted/check/check.sio
+Last-Green-Gates: gate self-test rc=0; canonical direct control PASS 1/1; canonical pub_use inventory contains only the direct control; bash -n; git diff --check
+Failing-Gates: baseline classifier rc=1 with facade_forwarding=0; rejected naive candidate rc=1 with selective_reexport=0
+Open-Blockers: BLK-20260713-lean-single-import-visibility transferred to the future bindings/exports implementation lane; BLK-20260713-lean-single-private-import-visibility is B4 telemetry
+Artifacts: /tmp/sounio-842-baseline-d2dd32b0f; /tmp/sounio-842-naive-d2dd32b0f; reproducible with the gate
+Next-Command: git fetch origin main
+```
+
+Diagnostic-Lane-Status: `locally-green`. The red classifier receipts above are
+the expected evidence produced by the diagnostic contract, not failed required
+gates for this evidence-only lane. Before publishing a PR, re-evaluate the
+branch against current `origin/main`; the original evidence base was
+`81a36104478fa79ca685c9b2ef87cee1c39dfa5d`.

--- a/tests/compiler/pub_use_reexport/missing_consumer.sio
+++ b/tests/compiler/pub_use_reexport/missing_consumer.sio
@@ -1,0 +1,5 @@
+use public_facade::{missing_route_value}
+
+fn main() -> i64 {
+    missing_route_value()
+}

--- a/tests/compiler/pub_use_reexport/not_reexported_consumer.sio
+++ b/tests/compiler/pub_use_reexport/not_reexported_consumer.sio
@@ -1,0 +1,5 @@
+use public_facade::{not_reexported_value}
+
+fn main() -> i64 {
+    not_reexported_value()
+}

--- a/tests/compiler/pub_use_reexport/private_consumer.sio
+++ b/tests/compiler/pub_use_reexport/private_consumer.sio
@@ -1,0 +1,5 @@
+use private_facade::{private_route_value}
+
+fn main() -> i64 {
+    private_route_value()
+}

--- a/tests/compiler/pub_use_reexport/private_facade.sio
+++ b/tests/compiler/pub_use_reexport/private_facade.sio
@@ -1,0 +1,1 @@
+use private_leaf::{private_route_value}

--- a/tests/compiler/pub_use_reexport/private_leaf.sio
+++ b/tests/compiler/pub_use_reexport/private_leaf.sio
@@ -1,0 +1,3 @@
+pub fn private_route_value() -> i64 {
+    17
+}

--- a/tests/compiler/pub_use_reexport/public_consumer.sio
+++ b/tests/compiler/pub_use_reexport/public_consumer.sio
@@ -1,0 +1,7 @@
+use public_facade::{public_route_value}
+
+fn main() -> i64 with IO {
+    if public_route_value() != 23 { return 1 }
+    println("PASS pub_use_named_function_reexport")
+    0
+}

--- a/tests/compiler/pub_use_reexport/public_facade.sio
+++ b/tests/compiler/pub_use_reexport/public_facade.sio
@@ -1,0 +1,1 @@
+pub use public_leaf::{public_route_value}

--- a/tests/compiler/pub_use_reexport/public_leaf.sio
+++ b/tests/compiler/pub_use_reexport/public_leaf.sio
@@ -1,0 +1,7 @@
+pub fn public_route_value() -> i64 {
+    23
+}
+
+pub fn not_reexported_value() -> i64 {
+    29
+}

--- a/tests/run-pass/fixtures/pub_use_reexport_leaf.sio
+++ b/tests/run-pass/fixtures/pub_use_reexport_leaf.sio
@@ -1,0 +1,3 @@
+pub fn pub_use_reexport_value() -> i64 {
+    842
+}

--- a/tests/run-pass/pub_use_reexport_direct_control.sio
+++ b/tests/run-pass/pub_use_reexport_direct_control.sio
@@ -1,0 +1,11 @@
+//@ run-pass
+//@ expect-stdout: PASS pub_use_reexport_direct_control
+//@ description: Direct import control for the public re-export fixture.
+
+use fixtures::pub_use_reexport_leaf::{pub_use_reexport_value}
+
+fn main() -> i64 with IO {
+    if pub_use_reexport_value() != 842 { return 1 }
+    println("PASS pub_use_reexport_direct_control")
+    0
+}


### PR DESCRIPTION
## Summary

- add an executable contract for issue #842 named-function `pub use` forwarding
- distinguish missing forwarding from the unsafe whole-leaf flattening produced by the rejected naive patch
- preserve direct-import and missing-name controls
- classify private-import globalization as a separate non-blocking residual

## Current Result

The current lean_single baseline is intentionally classified, not presented as fixed:

```text
facade_forwarding=0
selective_reexport=1
private_import_isolated=0
BLOCKED: public forwarding is absent
```

The rejected naive candidate loaded the leaf but failed selectivity:

```text
facade_forwarding=1
selective_reexport=0
BLOCKED: forwarding exposes the whole leaf
```

Its semantic compiler patch was completely removed. This PR has no diff under `self-hosted/compiler`, `self-hosted/ir`, or `self-hosted/check`.

## Gate Integrity

- semantic rejections require exact `rc=1` and anchored diagnostics
- an adversarial process printing the expected text and returning `139` is rejected
- `fatal:` contamination is rejected
- only the direct-import control enters ordinary `tests/run-pass`
- blocked witnesses remain under `tests/compiler`

## Claim Boundary

This contract covers named function reexports in braced `pub use` lists. It does not claim support for types, constants, aliases, globs, renames, or nested reexports.

`BLK-20260713-lean-single-import-visibility` remains B1 and blocks implementation of #842. A robust fix requires module-scoped bindings/exports and contextual lookup, not another byte-level pure-facade parser.

`BLK-20260713-lean-single-private-import-visibility` is a distinct B4 residual and does not block the #842 acceptance condition.

## Validation

- current-main base `848ab6bc98ce194f06ca94e9248c9e86bf85ee9a`
- direct canonical run-pass: 1/1
- validator adversarial selftest: PASS
- docs registry/consistency and blocker contracts: PASS
- shell syntax and diff checks: PASS
- independent read-only review: READY

Refs #842. This PR records the executable blocker and does not close the issue.
