### PR TITLE
test(checker): pin contextual visibility collisions

### DIFF
--- a/scripts/ci/madaros_visibility_context_gate.sh
+++ b/scripts/ci/madaros_visibility_context_gate.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Classify #854 without weakening real cross-module privacy diagnostics.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MADAROS="${SOUNIO_MADAROS_VISIBILITY_CONTEXT_BIN:-$ROOT_DIR/bin/madaros}"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+KEEP_WORK="${SOUNIO_MADAROS_VISIBILITY_CONTEXT_KEEP:-0}"
+EXPECT="${SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT:-classify}"
+
+fail() {
+  echo "[madaros-visibility-context] FAIL: $*" >&2
+  exit 1
+}
+
+if [[ -n "${SOUNIO_MADAROS_VISIBILITY_CONTEXT_DIR:-}" ]]; then
+  WORK="$SOUNIO_MADAROS_VISIBILITY_CONTEXT_DIR"
+  [[ ! -e "$WORK" ]] || fail "refusing existing gate directory: $WORK"
+  mkdir "$WORK" || fail "could not create gate directory: $WORK"
+else
+  WORK="$(mktemp -d /tmp/sounio-madaros-visibility-context.XXXXXX)"
+fi
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+case "$EXPECT" in
+  classify|baseline|resolved) ;;
+  *) fail "invalid SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=$EXPECT" ;;
+esac
+
+[[ -x "$MADAROS" ]] || fail "Madaros wrapper is missing or not executable: $MADAROS"
+[[ -n "$RAW_MADAROS" ]] || fail "MADAROS_RAW_BIN must name an explicit current-source Madaros ELF"
+[[ -x "$RAW_MADAROS" ]] || fail "explicit current-source Madaros is missing or not executable: $RAW_MADAROS"
+
+is_fatal_log() {
+  grep -Eiq 'segmentation fault|core dumped|terminated by signal|fatal:|bus error|illegal instruction' "$1"
+}
+
+count_marker() {
+  local marker="$1"
+  local log="$2"
+  grep -Fc "$marker" "$log" || true
+}
+
+classify_context_check() {
+  local label="$1"
+  local source="$2"
+  local expected_e175="$3"
+  local log="$WORK/$label.check.log"
+  local rc=0
+
+  set +e
+  MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" check "$source" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  is_fatal_log "$log" && {
+    cat "$log" >&2
+    fail "$label produced a fatal compiler/runtime log"
+  }
+
+  local e175_count
+  local message_count
+  local diagnostic_count
+  e175_count="$(count_marker 'error[E175' "$log")"
+  message_count="$(count_marker 'function is private in its defining module' "$log")"
+  diagnostic_count="$(count_marker 'error[E' "$log")"
+
+  if [[ "$rc" -eq 0 ]]; then
+    [[ "$diagnostic_count" -eq 0 ]] || fail "$label returned 0 while still emitting compiler diagnostics"
+    [[ "$message_count" -eq 0 ]] || fail "$label returned 0 while still emitting the E175 message"
+    grep -Fq 'check: OK' "$log" || {
+      cat "$log" >&2
+      fail "$label returned 0 without the check success marker"
+    }
+    CASE_STATE="resolved"
+    return 0
+  fi
+
+  if [[ "$rc" -eq 1 && "$diagnostic_count" -eq "$expected_e175" && "$e175_count" -eq "$expected_e175" && "$message_count" -eq "$expected_e175" ]]; then
+    grep -Fq 'run_check_mode: verdict=1' "$log" || {
+      cat "$log" >&2
+      fail "$label emitted E175 without the visibility-preflight verdict"
+    }
+    CASE_STATE="baseline"
+    return 0
+  fi
+
+  cat "$log" >&2
+  fail "$label was neither the exact #854 baseline nor the contextual-lookup result (rc=$rc diagnostics=$diagnostic_count E175=$e175_count message=$message_count)"
+}
+
+expect_context_runtime() {
+  local label="$1"
+  local source="$2"
+  local pass_marker="$3"
+  local log="$WORK/$label.run.log"
+  local rc=0
+
+  set +e
+  MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" run "$source" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  is_fatal_log "$log" && {
+    cat "$log" >&2
+    fail "$label produced a fatal compiler/runtime log after clean check"
+  }
+  [[ "$rc" -eq 0 ]] || {
+    cat "$log" >&2
+    fail "$label checked clean but runtime returned rc=$rc"
+  }
+  [[ "$(count_marker 'error[E' "$log")" -eq 0 ]] || {
+    cat "$log" >&2
+    fail "$label runtime emitted compiler diagnostics after clean check"
+  }
+  grep -Fxq "$pass_marker" "$log" || {
+    cat "$log" >&2
+    fail "$label runtime returned 0 without its exact marker"
+  }
+}
+
+expect_private_rejection() {
+  local label="$1"
+  local source="$2"
+  local code="$3"
+  local message="$4"
+  local log="$WORK/$label.log"
+  local rc=0
+
+  set +e
+  MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" check "$source" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  is_fatal_log "$log" && {
+    cat "$log" >&2
+    fail "$label produced a fatal compiler log"
+  }
+  [[ "$rc" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "$label must reject with rc=1, got rc=$rc"
+  }
+  [[ "$(count_marker 'error[E' "$log")" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "$label must emit exactly one compiler diagnostic"
+  }
+  [[ "$(count_marker "error[$code" "$log")" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "$label must emit exactly one $code diagnostic"
+  }
+  [[ "$(count_marker "$message" "$log")" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "$label must emit exactly one canonical privacy message"
+  }
+}
+
+FIXTURES="$ROOT_DIR/tests/compiler/madaros_visibility_context"
+classify_context_check single "$FIXTURES/duplicate_private_single_main.sio" 1
+single_state="$CASE_STATE"
+classify_context_check matrix18 "$FIXTURES/duplicate_private_18_main.sio" 18
+matrix_state="$CASE_STATE"
+
+[[ "$single_state" == "$matrix_state" ]] || {
+  fail "partial contextual lookup: single=$single_state matrix18=$matrix_state"
+}
+
+runtime_state="not-run-baseline"
+if [[ "$single_state" == resolved ]]; then
+  expect_context_runtime single "$FIXTURES/duplicate_private_single_main.sio" \
+    'PASS duplicate_private_single_context'
+  expect_context_runtime matrix18 "$FIXTURES/duplicate_private_18_main.sio" \
+    'PASS duplicate_private_18_context'
+  runtime_state="pass"
+fi
+
+expect_private_rejection private-fn \
+  "$ROOT_DIR/tests/multimodule/visibility_fn_private_main.sio" E175 \
+  'function is private in its defining module'
+expect_private_rejection private-struct \
+  "$ROOT_DIR/tests/multimodule/visibility_struct_private_main.sio" E176 \
+  'struct constructor is private in its defining module'
+expect_private_rejection private-enum \
+  "$ROOT_DIR/tests/multimodule/visibility_enum_private_main.sio" E177 \
+  'enum constructor is private in its defining module'
+
+echo "[madaros-visibility-context] receipt issue=854 context_state=$single_state runtime_state=$runtime_state single_e175=$([[ "$single_state" == baseline ]] && echo 1 || echo 0) matrix_e175=$([[ "$matrix_state" == baseline ]] && echo 18 || echo 0) true_private_fn=E175 true_private_struct=E176 true_private_enum=E177"
+
+if [[ "$EXPECT" == baseline && "$single_state" != baseline ]]; then
+  fail "expected the pinned baseline, got $single_state"
+fi
+if [[ "$EXPECT" == resolved && "$single_state" != resolved ]]; then
+  echo '[madaros-visibility-context] BLOCKED BLK-20260713-MADAROS-EISA-E5-VISIBILITY-E175: contextual module binding lookup is not implemented' >&2
+  exit 1
+fi
+
+if [[ "$single_state" == baseline ]]; then
+  echo '[madaros-visibility-context] KNOWN_BLOCKER: name-only lookup selects a private same-name binding from the wrong module'
+else
+  echo '[madaros-visibility-context] PASS: contextual lookup preserves same-name private bindings and real private access remains rejected'
+fi

--- a/tests/compiler/madaros_visibility_context/README.md
+++ b/tests/compiler/madaros_visibility_context/README.md
@@ -1,0 +1,150 @@
+# Madaros module-binding identity reducer
+
+This fixture family reduces issue #854 without changing checker semantics. It
+separates a false privacy diagnostic caused by name-only lookup from genuine
+cross-module private access.
+
+The one-call reducer mirrors the E5 test. The root and imported leaf each own a
+private `abs_f64`; the leaf's one internal call currently resolves to the
+root's earlier table entry and emits one false E175.
+
+The matrix mirrors the public example exactly at the causal level:
+
+```text
+eisa::format::abs_f64       1 internal call
+eisa::evm::print_i64_dec   17 internal calls
+                            -----------------
+                            18 false E175 diagnostics
+```
+
+The fixture uses the same two duplicate private names and the same `1 + 17`
+call topology. The baseline is classified with `madaros check`, before
+lowering or runtime can replace the diagnostic exit status. Only after both
+reducers check clean does the gate execute them. Different return values then
+make a superficial "allow access" change insufficient: the resolved state
+must print the exact PASS markers from the module-owned bindings.
+
+Run the classifier against a current-source Madaros:
+
+```bash
+MADAROS_RAW_BIN=/path/to/madaros \
+  bash scripts/ci/madaros_visibility_context_gate.sh
+```
+
+Require the implementing acceptance state with:
+
+```bash
+MADAROS_RAW_BIN=/path/to/madaros \
+SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved \
+  bash scripts/ci/madaros_visibility_context_gate.sh
+```
+
+`MADAROS_RAW_BIN` is mandatory so the gate cannot silently use the checked-in
+or otherwise stale compiler. The gate accepts only two coherent
+classifications: the exact `1/18` E175 check baseline, or two clean checks
+followed by both executable contextual-lookup witnesses. In either state it
+requires the canonical E175, E176, and E177 true-private negative controls.
+Mixed states, fatal logs, diagnostic-count drift, successful checks that
+retain privacy diagnostics, and runtime exits without exact markers are
+rejected.
+
+This diagnostic gate is intentionally **not wired into ordinary CI**. The
+implementation PR must wire the `EXPECT=resolved` form after it owns the
+checker change; the present lane records and classifies the blocker without
+making a known failure block unrelated pull requests.
+
+## Exact baseline receipt
+
+The initial classifier run used the `madaros-current-source-f64-lowering`
+artifact produced for exact `origin/main` SHA
+`e6725240d266353621639419f1c4fd859d90caad` by CI run `29270956296`
+(artifact ID `8287540274`). The compiler ELF was 98,413,103 bytes with SHA-256
+`7e6203c08b254ea46cbae4094a0109317ac28063e4bb3b84209d51eeef2ae8fa`.
+
+```text
+context_state=baseline
+runtime_state=not-run-baseline
+single_e175=1
+matrix_e175=18
+true_private_fn=E175
+true_private_struct=E176
+true_private_enum=E177
+```
+
+The same artifact with `SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved`
+exits 1 and emits the blocker ID without attempting reducer runtime. A
+synthetic resolved-state harness proves the gate orders clean checks before
+the two exact runtime markers; it is a gate self-test, not evidence that the
+compiler is fixed. A separate synthetic compiler that accepts every input is
+rejected when the E175 negative control returns 0. This pins the state machine
+and anti-weakening behavior independently of the current compiler result.
+
+## Blocker handoff
+
+```text
+Blocker-ID: BLK-20260713-MADAROS-EISA-E5-VISIBILITY-E175
+Status: classified
+Severity: B1
+Class: compiler-semantics
+Owner: Codex root coordinator (implementation dispatch pending)
+Lane: Madaros module-binding identity / issue #854
+Worktree: /tmp/sounio-issue-854-reducer-20260713
+Branch: codex/issue-854-reducer-20260713
+Files-Owned: tests/compiler/madaros_visibility_context/*; scripts/ci/madaros_visibility_context_gate.sh
+Files-Read-Only: self-hosted/check/check.sio; self-hosted/check/defs.sio; self-hosted/check/mod.sio; self-hosted/ir/lower.sio; EISA witnesses and stdlib
+Do-Not-Touch: self-hosted/check/check.sio while PR #814 owns it; canonical compiler artifacts; EISA mathematical thresholds and receipt semantics
+Repro: MADAROS_RAW_BIN=<current-source-madaros> bash scripts/ci/madaros_visibility_context_gate.sh
+Observed: name-only FnSigTable lookup selects the first same-name declaration even while checking a different defining module
+Expected: an unqualified call resolves through the caller module/import context before visibility is evaluated
+Acceptance-Gate: MADAROS_RAW_BIN=<current-source-madaros> SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved bash scripts/ci/madaros_visibility_context_gate.sh
+Evidence-Level: E3
+Evidence: exact-main CI run 29270956296 artifact 8287540274 plus the baseline receipt in this README
+Fallback-Path: none
+Legacy-Kept: yes; existing checker, EISA, and negative visibility paths are unchanged
+LLM-Offload: not-required (diagnostic fixtures/gate only; no math, clinical, or external claim change)
+Next-Action: implement module-aware function binding lookup after PR #814 releases checker ownership
+```
+
+## Semantic lane declaration
+
+`SOUNIO-MODULE-BINDING-IDENTITY` is proposed here for the future implementation
+lane. It is not yet registered as an executable concept, and this reducer does
+not alter its semantics.
+
+```text
+Semantic-Lane-ID: issue-854-module-binding-identity-reducer
+Owner: Codex issue #854 reducer lane
+Concept-IDs: proposed SOUNIO-MODULE-BINDING-IDENTITY
+Intent-Preserved: source-level module ownership remains part of symbol identity; privacy is checked after contextual binding resolution
+Transformation: none; executable characterization only
+Types-Changed: none
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: current-source Madaros reproduces exact 1-call and 18-call E175 name-collision boundaries while true private access remains rejected
+Claims-Forbidden: EISA runtime parity; general import/re-export correctness; implementation of module-aware bindings; weakening private visibility
+Assumptions: root module is collected before imported leaves; unqualified same-module declarations are in lexical scope
+Write-Set: tests/compiler/madaros_visibility_context/*; scripts/ci/madaros_visibility_context_gate.sh
+Read-Set: self-hosted/check/check.sio; self-hosted/check/defs.sio; self-hosted/check/mod.sio; self-hosted/compiler/main.sio; EISA fixtures and modules
+Positive-Witness: acceptance-only; after clean checks, duplicate_private_single_main.sio and duplicate_private_18_main.sio must execute their exact PASS markers
+Negative-Witness: visibility_fn_private_main.sio=E175; visibility_struct_private_main.sio=E176; visibility_enum_private_main.sio=E177
+Acceptance-Gate: MADAROS_RAW_BIN=<current-source-madaros> SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved bash scripts/ci/madaros_visibility_context_gate.sh
+Integration-Target: future checker/module-binding implementation lane after PR #814
+Authoritative-Only-If: both contextual witnesses execute and all three true-private diagnostics remain exact
+```
+
+## Integration receipt
+
+```text
+Semantic-Outcome: exact blocker reduced; implementation intentionally deferred
+Concept-Status-Before: unregistered proposal
+Concept-Status-After: unregistered proposal with executable characterization
+Distinctions-Added: same spelling != same binding; binding resolution != visibility authorization
+Distinctions-Preserved: private same-module access != private cross-module access; compile success != runtime binding parity
+Distinctions-Erased: none
+Evidence-Run: baseline classifier against exact-main CI artifact; resolved-state and accept-all harness self-tests
+Fallback-Path: none
+Legacy-Kept: all existing checker, EISA, and visibility paths
+Conflicting-Lanes: PR #814 owns self-hosted/check/check.sio; no overlap in this phase
+Ordinary-CI: not wired in this diagnostic lane; required wiring belongs to the implementation PR
+Next-Semantic-Interface: module-qualified binding records and caller-context lookup
+```

--- a/tests/compiler/madaros_visibility_context/duplicate_private_18_leaf.sio
+++ b/tests/compiler/madaros_visibility_context/duplicate_private_18_leaf.sio
@@ -1,0 +1,29 @@
+fn abs_f64(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+fn print_i64_dec(x: i64) -> i64 {
+    x + 10
+}
+
+pub fn leaf_call_matrix() -> i64 {
+    let abs_term = abs_f64(0.0 - 2.0) as i64
+    abs_term
+        + print_i64_dec(0)
+        + print_i64_dec(1)
+        + print_i64_dec(2)
+        + print_i64_dec(3)
+        + print_i64_dec(4)
+        + print_i64_dec(5)
+        + print_i64_dec(6)
+        + print_i64_dec(7)
+        + print_i64_dec(8)
+        + print_i64_dec(9)
+        + print_i64_dec(10)
+        + print_i64_dec(11)
+        + print_i64_dec(12)
+        + print_i64_dec(13)
+        + print_i64_dec(14)
+        + print_i64_dec(15)
+        + print_i64_dec(16)
+}

--- a/tests/compiler/madaros_visibility_context/duplicate_private_18_main.sio
+++ b/tests/compiler/madaros_visibility_context/duplicate_private_18_main.sio
@@ -1,0 +1,20 @@
+use duplicate_private_18_leaf::{leaf_call_matrix}
+
+// These private root bindings intentionally collide by name with the leaf
+// bindings. Contextual lookup must keep all four identities distinct.
+fn abs_f64(x: f64) -> f64 {
+    x + 1000.0
+}
+
+fn print_i64_dec(x: i64) -> i64 {
+    x + 2000
+}
+
+fn main() -> i64 with IO {
+    if abs_f64(2.0) != 1002.0 { return 21 }
+    if print_i64_dec(2) != 2002 { return 22 }
+    // 2 + sum(i + 10, i=0..16) = 2 + 136 + 170 = 308.
+    if leaf_call_matrix() != 308 { return 23 }
+    println("PASS duplicate_private_18_context")
+    0
+}

--- a/tests/compiler/madaros_visibility_context/duplicate_private_single_leaf.sio
+++ b/tests/compiler/madaros_visibility_context/duplicate_private_single_leaf.sio
@@ -1,0 +1,7 @@
+fn abs_f64(x: f64) -> f64 {
+    if x < 0.0 { 0.0 - x } else { x }
+}
+
+pub fn leaf_abs_once(x: f64) -> f64 {
+    abs_f64(x)
+}

--- a/tests/compiler/madaros_visibility_context/duplicate_private_single_main.sio
+++ b/tests/compiler/madaros_visibility_context/duplicate_private_single_main.sio
@@ -1,0 +1,14 @@
+use duplicate_private_single_leaf::{leaf_abs_once}
+
+// This deliberately has the same private name as the leaf helper. The two
+// declarations are different bindings because their defining modules differ.
+fn abs_f64(x: f64) -> f64 {
+    x + 100.0
+}
+
+fn main() -> i64 with IO {
+    if abs_f64(2.0) != 102.0 { return 11 }
+    if leaf_abs_once(0.0 - 2.0) != 2.0 { return 12 }
+    println("PASS duplicate_private_single_context")
+    0
+}


### PR DESCRIPTION
## Summary

- add exact causal reducers for issue #854's false E175 visibility diagnostics
- pin the observed `1 + 17 = 18` same-name collision topology
- retain true private-access E175/E176/E177 controls so a fix cannot simply weaken visibility
- add a fail-closed baseline/resolved classifier using an explicit current-source Madaros

## Causal Evidence

On exact `origin/main` `e6725240d266353621639419f1c4fd859d90caad`, using CI run `29270956296`, artifact `8287540274`, Madaros SHA-256 `7e6203c08b254ea46cbae4094a0109317ac28063e4bb3b84209d51eeef2ae8fa`:

```text
single_e175=1
matrix_e175=18
true_private_fn=E175
true_private_struct=E176
true_private_enum=E177
runtime_state=not-run-baseline
```

The single diagnostic is the internal `format::abs_f64` call resolving against a same-named private root function. The full example adds 17 internal `evm::print_i64_dec` calls shadowed by the same-named root helper.

## Gate Contract

- baseline classification uses `check`, preserving diagnostics
- reducers are run only after both checks are clean in `EXPECT=resolved`
- resolved mode requires exact runtime markers
- true private accesses must continue to reject with the exact E175/E176/E177 classes
- a compiler that accepts everything is rejected
- `MADAROS_RAW_BIN` is mandatory and explicitly identified

## Claim Boundary

This PR adds no checker, lowering or visibility implementation. It establishes that current global name-only lookup selects the wrong same-named private definition before contextual visibility is evaluated.

Proposed semantic contract: `SOUNIO-MODULE-BINDING-IDENTITY`, where lookup resolves `(ModuleId, Name) -> DefId` before checking visibility. The concept remains proposed and unregistered in this diagnostic lane.

The diagnostic gate is intentionally not wired into ordinary CI yet. Implementation and required-CI wiring belong to the subsequent contextual-lookup PR.

## Validation

- exact current-source artifact baseline: classified 1/18 without runtime
- exact artifact `EXPECT=resolved`: correctly BLOCKED
- resolved synthetic: PASS with checks, runs and markers
- accept-all synthetic: rejected by private controls
- shell syntax and diff checks: PASS
- independent read-only review: READY, no findings

Refs #854. This PR records the executable blocker and does not close the issue.
