### PR TITLE
ci: run changed Madaros tests with current-source build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
         run: python3 scripts/ci/souc_build_lock_selftest.py
       - name: CI watch receipt self-test
         run: python3 scripts/ci/ci_watch_receipt_selftest.py
+      - name: Madaros changed-test selector self-test
+        run: bash scripts/ci/madaros_changed_tests_selftest.sh
       - name: Executable payload comparator self-test
         run: bash scripts/ci/executable_payload_compare_selftest.sh
       - name: Output-path invariants
@@ -275,8 +277,18 @@ jobs:
       SOUNIO_MADAROS_F64_LOWERING_GATE_KEEP: 1
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Build Madaros once and run current-source f64 lowering gates
         run: bash scripts/ci/madaros_current_source_f64_lowering_gate.sh
+      - name: Run changed Madaros tests with the current-source compiler
+        env:
+          SOUNIO_MADAROS_CHANGED_TESTS_BIN: /tmp/sounio-madaros-current-source-f64-lowering/madaros
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SOUNIO_TEST_JOBS: 4
+        run: bash scripts/ci/madaros_changed_tests_gate.sh
       - name: Upload current-source f64 lowering logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVENT_NAME="${CI_EVENT_NAME:-${GITHUB_EVENT_NAME:-pull_request}}"
+BASE_SHA="${CI_BASE_SHA:-}"
+HEAD_SHA="${CI_HEAD_SHA:-HEAD}"
+MADAROS_BIN="${SOUNIO_MADAROS_CHANGED_TESTS_BIN:-}"
+SELECT_ONLY=0
+
+fail() {
+  echo "MADAROS_CHANGED_TESTS_FAIL reason=$1" >&2
+  exit 1
+}
+
+if [[ "${1:-}" == "--select-only" ]]; then
+  SELECT_ONLY=1
+  shift
+fi
+
+paths=()
+if (($#)); then
+  paths=("$@")
+elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+  [[ -n "$BASE_SHA" ]] || fail "missing_pull_request_base_sha"
+  if ! changed_paths="$(
+    git -C "$ROOT_DIR" diff --name-only --diff-filter=ACMR "$BASE_SHA...$HEAD_SHA"
+  )"; then
+    fail "changed_path_diff_failed"
+  fi
+  if [[ -n "$changed_paths" ]]; then
+    mapfile -t paths <<<"$changed_paths"
+  fi
+else
+  paths=("tests/run-pass/array_repeat_i8_binding.sio")
+fi
+
+selected=()
+for path in "${paths[@]}"; do
+  case "$path" in
+    tests/run-pass/*.sio) ;;
+    *) continue ;;
+  esac
+  [[ -f "$ROOT_DIR/$path" ]] || continue
+  grep -Fq '//@ requires: madaros' "$ROOT_DIR/$path" || continue
+  selected+=("$path")
+done
+
+if [[ "$SELECT_ONLY" == "1" ]]; then
+  printf '%s\n' "${selected[@]}"
+  exit 0
+fi
+
+if ((${#selected[@]} == 0)); then
+  echo 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests'
+  exit 0
+fi
+
+[[ -n "$MADAROS_BIN" ]] || fail "missing_explicit_madaros_bin"
+[[ "$MADAROS_BIN" == /* ]] || fail "madaros_bin_must_be_absolute"
+[[ -f "$MADAROS_BIN" && -r "$MADAROS_BIN" && -x "$MADAROS_BIN" ]] \
+  || fail "madaros_bin_not_executable"
+[[ "$(head -c 2 "$MADAROS_BIN" 2>/dev/null)" != '#!' ]] || fail "madaros_bin_is_wrapper"
+
+set +e
+identity="$("$MADAROS_BIN" --version 2>&1)"
+identity_rc=$?
+set -e
+[[ "$identity_rc" == "0" ]] || fail "madaros_identity_command_failed"
+grep -Fxq 'Madaros v0.80.0 -- the Sounio self-hosted compiler' <<<"$identity" \
+  || fail "madaros_identity_banner_missing"
+
+set +e
+negative_control="$("$MADAROS_BIN" --check \
+  "$ROOT_DIR/tests/compile-fail/array_repeat_i8_binding_type_mismatch.sio" 2>&1)"
+negative_control_rc=$?
+set -e
+[[ "$negative_control_rc" != "0" ]] || fail "madaros_negative_control_accepted"
+grep -Fq 'this binding expects a different type' <<<"$negative_control" \
+  || fail "madaros_negative_control_diagnostic_missing"
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/sounio-madaros-changed.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT
+test_list="$work_dir/tests.txt"
+printf '%s\n' "${selected[@]}" >"$test_list"
+
+compiler_sha256="$(sha256sum "$MADAROS_BIN" | cut -d' ' -f1)"
+echo "MADAROS_CHANGED_TESTS_START count=${#selected[@]} event=$EVENT_NAME compiler=$MADAROS_BIN compiler_sha256=$compiler_sha256"
+printf 'test=%s\n' "${selected[@]}"
+
+SOUNIO_MADAROS_AVAILABLE=1 \
+SOUNIO_SOUC_RAW_MODE=modular \
+SOUNIO_TEST_SOUC_BIN="$MADAROS_BIN" \
+  bash "$ROOT_DIR/scripts/run_sio_test_suite.sh" \
+    --test-list "$test_list" \
+    --jobs "${SOUNIO_TEST_JOBS:-4}"
+
+echo "MADAROS_CHANGED_TESTS_PASS count=${#selected[@]}"

--- a/scripts/ci/madaros_changed_tests_selftest.sh
+++ b/scripts/ci/madaros_changed_tests_selftest.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GATE="$ROOT_DIR/scripts/ci/madaros_changed_tests_gate.sh"
+
+bash -n "$GATE"
+
+selected="$($GATE --select-only \
+  tests/run-pass/array_repeat_i8_binding.sio \
+  tests/run-pass/generic_struct_return.sio \
+  docs/internal/coordination/CI_WATCH_CONTRACT.md)"
+
+grep -Fxq 'tests/run-pass/array_repeat_i8_binding.sio' <<<"$selected"
+if grep -Fq 'generic_struct_return.sio' <<<"$selected"; then
+  echo 'madaros-changed-tests: selected an unannotated test' >&2
+  exit 1
+fi
+if grep -Fq 'CI_WATCH_CONTRACT.md' <<<"$selected"; then
+  echo 'madaros-changed-tests: selected a path outside tests/run-pass' >&2
+  exit 1
+fi
+
+non_pr_selected="$(CI_EVENT_NAME=push "$GATE" --select-only)"
+grep -Fxq 'tests/run-pass/array_repeat_i8_binding.sio' <<<"$non_pr_selected"
+
+skip="$($GATE -- docs/internal/coordination/CI_WATCH_CONTRACT.md)"
+grep -Fxq 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests' <<<"$skip"
+
+set +e
+missing_bin="$(
+  env -u SOUNIO_MADAROS_CHANGED_TESTS_BIN \
+    "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio 2>&1
+)"
+missing_bin_rc=$?
+set -e
+if [[ "$missing_bin_rc" == "0" ]]; then
+  echo 'madaros-changed-tests: accepted a selected test without an explicit Madaros binary' >&2
+  exit 1
+fi
+grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=missing_explicit_madaros_bin' <<<"$missing_bin"
+
+set +e
+wrapper_bin="$(
+  SOUNIO_MADAROS_CHANGED_TESTS_BIN="$ROOT_DIR/bin/souc" \
+    "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio 2>&1
+)"
+wrapper_bin_rc=$?
+set -e
+if [[ "$wrapper_bin_rc" == "0" ]]; then
+  echo 'madaros-changed-tests: accepted the public wrapper as a Madaros ELF' >&2
+  exit 1
+fi
+grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=madaros_bin_is_wrapper' <<<"$wrapper_bin"
+
+set +e
+wrong_binary="$(
+  SOUNIO_MADAROS_CHANGED_TESTS_BIN=/bin/true \
+    "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio 2>&1
+)"
+wrong_binary_rc=$?
+set -e
+if [[ "$wrong_binary_rc" == "0" ]]; then
+  echo 'madaros-changed-tests: accepted a non-Madaros ELF' >&2
+  exit 1
+fi
+grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=madaros_identity_banner_missing' \
+  <<<"$wrong_binary"
+
+set +e
+bad_diff="$(
+  CI_EVENT_NAME=pull_request \
+  CI_BASE_SHA=0000000000000000000000000000000000000000 \
+  CI_HEAD_SHA=HEAD \
+    "$GATE" 2>&1
+)"
+bad_diff_rc=$?
+set -e
+if [[ "$bad_diff_rc" == "0" ]]; then
+  echo 'madaros-changed-tests: accepted an invalid pull-request diff' >&2
+  exit 1
+fi
+grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=changed_path_diff_failed' \
+  < <(tail -n 1 <<<"$bad_diff")
+
+echo 'MADAROS_CHANGED_TESTS_SELFTEST_PASS'


### PR DESCRIPTION
## Summary

- run changed `//@ requires: madaros` tests inside the existing required current-source Madaros job
- reuse the single Madaros ELF already built by the f64 lowering umbrella
- add fail-closed selection, compiler identity/provenance and adversarial selftests
- replace the now-conflicting standalone-job design from #815

## Current-Main Design

The existing job key and `CI Decision` dependency remain unchanged. The job now:

1. checks out full history for merge-base selection;
2. builds current-source Madaros once through the existing f64 lowering umbrella;
3. runs the changed-tests selector against the same ELF.

No second 98 MB compiler build and no new required job key are introduced.

## Selection Contract

- PRs use `BASE...HEAD` merge-base semantics
- non-PR events select an annotated committed smoke and must never silently select nothing
- only changed `tests/run-pass/*.sio` files carrying `//@ requires: madaros` are selected
- `START`, `SKIP` and `PASS` receipts are explicit

## False-Pass Defenses

The gate requires:

- an absolute executable path, not the repository wrapper
- exact Madaros identity
- compiler SHA-256 in the START receipt
- a paired compile-fail control with the expected diagnostic
- successful canonical harness execution for every selected test

`/bin/true`, missing binaries, wrappers, zero/invalid SHAs, invalid diffs, unannotated tests, out-of-tree paths and empty non-PR selection are rejected by the selftest.

## Exact E2E

Using the current-main CI artifact:

```text
compiler_sha256=7e6203c08b254ea46cbae4094a0109317ac28063e4bb3b84209d51eeef2ae8fa
test=tests/run-pass/array_repeat_i8_binding.sio
MADAROS_CHANGED_TESTS_PASS count=1
```

Also passed: selector selftest, workflow references, impact/CI-decision selftest, watcher selftest, Bash syntax and diff hygiene. `actionlint` was unavailable locally.

## Integration Order

This replacement should land before #814 is refreshed, so its annotated checker witness receives exact-head Madaros coverage. #816 and #817 must then be retargeted away from the old `work/madaros-changed-ci` stack.

Supersedes #815. No compiler semantic files or external-facing claims are changed; LLM offload was not required.
