### PR TITLE
audit(madaros): compiler blockers for real-world stdlib usability (CODEX-2 dispatch)

### DIFF
--- a/docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md
+++ b/docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md
@@ -1,0 +1,104 @@
+# Data & Science I/O lane — blocked by compiler-owned file-I/O builtins
+
+**Date:** 2026-07-13
+**Toolchain:** `./bin/souc` → Madaros v0.80.0 (default engine)
+**Context:** Implementing the approved Data & Science I/O spec
+(`docs/superpowers/specs/2026-07-13-data-science-io-design.md`) under the constraint "no compiler
+changes" (compiler owned by CODEX-2). Empirical probing during Phase 0 uncovered that the lane's
+foundational primitives are broken at the compiler/runtime level.
+
+This is a **forensic dispatch for CODEX-2**, per CLAUDE.md §8 (do not patch `self-hosted/` ad hoc).
+
+## Summary
+
+The "Data & Science I/O" lane is, mechanically, *read a file's bytes → transform → write bytes out*.
+On current Madaros, **both file primitives are broken** and both are compiler-owned builtins:
+
+| Primitive | Status | Evidence |
+|---|---|---|
+| `read_file(path)` | **SIGSEGV (exit 139)** | probe below; matches known bug in `docs/audit/MADAROS_BUILTIN_EMISSION_2026-06-24.md:41` |
+| `write_file(path, &buf, n)` | **writes correct byte-count from WRONG address** (garbage on disk) | probe below; every caller shape fails identically |
+| `print(...)` → stdout | **works** | assembled byte content prints correctly |
+| `file_size(path)` | works | returns 12 for a 12-byte file |
+
+Because file read/write is broken and the compiler is off-limits, the lane cannot deliver its core
+("read/write real-world data files") without a CODEX-2 fix. Only **stdout output works today**.
+
+## Reproductions (all under `export SOUNIO_STDLIB_PATH=$(pwd)/stdlib`)
+
+### read_file → segfault
+```sounio
+fn main() -> i32 with IO, Mut, Panic, Div {
+    let path = "/tmp/w_out.csv"           // a real 12-byte file
+    let sz = file_size(path)              // prints 12  (OK)
+    let raw = read_file(path)             // <-- SIGSEGV here
+    let s = str_from_bytes(raw, sz)
+    print("readlen="); print_int(str_len(s)); print("\n")
+    return 0
+}
+```
+`./bin/souc compile r.sio -o r.elf && ./r.elf` → `size=12` then **exit 139**.
+
+### write_file → wrong buffer address (garbage bytes)
+```sounio
+fn main() -> i32 with IO, Mut, Panic, Div {
+    var buf: [i8; 64] = [0; 64]
+    let body = "x,y\n1,2\n3,4\n"           // 12 bytes
+    let n = str_len(body)
+    var i: i64 = 0
+    while i < n { buf[i as usize] = str_char_at(body, i) as i8; i = i + 1 }
+    let rc = write_file(path, &buf, n)    // rc = 12 (correct count) ...
+    print("wrote="); print_int(rc); print("\n")
+    return 0
+}
+```
+Result: `wrote=12`, and the on-disk file is exactly 12 bytes but contains **garbage**, not `x,y\n1,2\n3,4\n`.
+Call-shape matrix (all wrong):
+- `write_file(path, buf, n)`  → rc = **-14 (EFAULT)**, no file
+- `write_file(path, &buf, n)` → rc = n, **garbage bytes**
+- `write_file(path, &b.data, n)` with `struct Buf { data: [u8; 64] }` → rc = n, **garbage bytes**
+- `write_file(path, buf, 3u)` → **compile error**
+
+Conclusion: the builtin receives the length correctly but the buffer base pointer is mis-lowered.
+Caller-side shapes cannot fix it.
+
+## Secondary findings (older compiler surface removed)
+
+Many `.sio` files were written against a more permissive earlier compiler and **no longer compile** on
+Madaros v0.80.0:
+
+- `stdlib/data/frame.sio` — fails on both engines (Madaros `E004`/`E019`; lean_single `typecheck: failed`).
+  Uses builtin `String` (struct) + dynamic-array `.push()`/`.len()` + `++`, none of which the current
+  compiler accepts. **This was the spec's planned hub; it is dead code.**
+- `examples/cognitive_ossm/export_results.sio` — the reference file-I/O example — fails
+  (`method calls are not supported for this type`, `visibility preflight failed`).
+
+Working idiom on current Madaros (verified green + runnable):
+- **`string` primitive + `str_*` free functions** (`str_len`, `str_char_at`, `str_from_bytes`,
+  `str_slice`) — NOT builtin `String`.
+- **Fixed-capacity slabs** for growable data: `NativeF64Vec`/`NativeI64Vec` (cap 65536,
+  `stdlib/collections/native_vec.sio`), or large fixed arrays (`[f64; 100000]` checks OK). No heap
+  (JIT `malloc` broken — `KNOWN_LIMITATIONS.md:68`).
+- `.method()` works only on **structs with `impl`**, not on bare array types.
+- `print(...)` to stdout works for arbitrarily-assembled byte content.
+
+## Impact on the spec
+
+- **Readers (targets 1 + 3: CSV, Parquet, netCDF, HDF5):** blocked — require `read_file`.
+- **File writers (target 4 incl. artifact-to-disk):** blocked — require a working `write_file`.
+- **stdout writers (CSV/JSON/table to stdout, redirected with `>`):** **feasible today** — need only
+  `print`, `string`, `str_*`, and fixed-capacity in-memory columns.
+- The 65536-element (no-heap) ceiling also makes the spec's "full chunked+filtered HDF5 → DataFrame"
+  goal incoherent regardless of I/O (real scientific HDF5 is millions of elements).
+
+## Recommended asks for CODEX-2 (blockers, in priority order)
+
+1. **Fix `write_file` buffer-pointer ABI** — length is passed correctly; base pointer is not. Unblocks
+   all file output.
+2. **Fix `read_file` SIGSEGV** — unblocks every reader (the bulk of the lane).
+3. (Lower) A heap-backed growable buffer, or confirmation that ~65536-element fixed slabs are the
+   intended ceiling, so the DataFrame hub can be sized honestly.
+
+Until (1)/(2) land, the buildable slice is: an in-memory fixed-capacity DataFrame (string-primitive
+idiom) + **writers that emit to stdout**. That is genuinely usable (Unix redirection) and needs no
+broken builtin.

--- a/docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md
+++ b/docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13
+-->
+
 # Data & Science I/O lane — blocked by compiler-owned file-I/O builtins
 
 **Date:** 2026-07-13

--- a/docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md
+++ b/docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md
@@ -1,0 +1,89 @@
+# Madaros v0.80.0 — two multi-module defects (named import + print_f64)
+
+**Date:** 2026-07-13
+**Toolchain:** `./bin/souc` → Madaros v0.80.0
+**Owner:** CODEX-2 (`self-hosted/compiler/main.sio`, `run_check_mode` / visibility-preflight pass)
+**Discovery context:** hardening `epistemic::gum`; both defects are compiler-side, not stdlib.
+Forensic dispatch per CLAUDE.md §8 — do not patch `self-hosted/` ad hoc.
+
+## Defect 1 — single-symbol `use module::symbol` fails E137 even for `pub` symbols
+
+`use epistemic::gum::gum_type_b_uniform` (a symbol that IS `pub fn` in `stdlib/epistemic/gum.sio`) fails:
+```
+error[E137] use of undeclared variable
+  = help: declare the variable before use, or import it from another module
+run_check_mode: verdict=1
+```
+The **wildcard** form of the same import works:
+```sounio
+use epistemic::gum::*          // resolves; program compiles to ELF and runs
+```
+So named single-symbol import resolution is broken while wildcard import is fine. Publishing helpers does
+not change this (the failing symbol was already `pub`).
+
+**Workaround (in use):** import stdlib modules with `use module::*`.
+
+## Defect 2 — `print_f64` trips spurious E137 in any 2+-module (importing) program
+
+A `main` file that has at least one `use ...` import and calls `print_f64(x)` fails the same
+`E137`/visibility-preflight check. The overloaded `print(f64)` / `println(f64)` builtins print floats
+correctly in the same importing program.
+
+Evidence it is `print_f64`-specific, not the import:
+- `use epistemic::gum::*` + `print_f64(gum_std_u(r))` → **E137**.
+- `use epistemic::gum::*` + `print_int((uc*1e6) as i64)` → compiles + runs (`290401`).
+- `use epistemic::gum::*` + `print(gum_std_u(r))` / `println(gum_value(r))` → compiles + runs
+  (`0.290401`, `val=98.299999`).
+- Green multi-module `stdlib/clinical/vancomycin_pbpk.sio` (imports `epistemic::knightian`) prints floats
+  and runs — with **zero** `print_f64` calls (uses `println(f64)`).
+
+**Workaround (in use):** in importing programs print floats with `print(f64)`/`println(f64)`, never
+`print_f64`.
+
+## Defect 3 — a user-defined helper fn in an importing program trips visibility-preflight
+
+A `main` file with `use ...` **and** any second user-defined function fails:
+```
+run_check_mode: verdict=1   (note: "function arguments are checked against the declared parameter types")
+```
+The same logic **inlined into `main`** (no helper fn) compiles and runs. Verified: `use epistemic::gum::*`
++ `fn near(...)` + `main` → fail; identical program with the comparison inlined → runs.
+
+**Workaround (in use):** in importing programs, inline all logic into `main` — no user helper functions.
+This forces verbose drivers but works.
+
+## Defect 4 (adjacent, pre-existing) — `gum.sio`'s embedded self-test segfaults at runtime
+
+`stdlib/epistemic/gum.sio` is annotated `//@ run-pass` / `//@ expect-stdout: ALL PASS`, but compiled and
+run standalone it **segfaults (exit 139)** after printing `─── stdlib/epistemic/gum tests ───\n  PASS [`.
+This is **pre-existing** and independent of the GUM hardening: the pre-session file and the hardened file
+produce **byte-identical output** (same md5) and both exit 139. So `expect-stdout: ALL PASS` is stale —
+the file has not run clean on Madaros v0.80.0. The GUM *functions* are fine (an importing driver exercises
+them and asserts correct ISO-GUM values — `tests/stdlib/epistemic/test_gum_stdlib.sio`); the crash is in
+the file's own test `main`/print path. Not chased here (scope + likely codegen-side). The
+`epistemic_gum_gate.sh` gate therefore verifies the module via the **importing driver**, not by running
+`gum.sio`'s embedded self-test.
+
+## Impact
+Neither blocks the epistemic/GUM hardening (both have clean caller-side workarounds), but both are
+papercuts that make stdlib modules feel unusable to newcomers (the natural `use mod::name` + `print_f64`
+both fail). Fixing them would materially improve real-world usability of the whole stdlib.
+
+## Repro (self-contained)
+```sounio
+// FAILS (E137): single-symbol import
+use epistemic::gum::gum_type_b_uniform
+// FAILS (E137): print_f64 in an importing main
+use epistemic::gum::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print_f64(gum_std_u(gum_combine2(98.3, gum_type_a(0.0707,5), gum_type_b_uniform(0.5))))
+    return 0
+}
+// WORKS:
+use epistemic::gum::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let r = gum_combine2(98.3, gum_type_a(0.0707,5), gum_type_b_uniform(0.5))
+    print("u_c="); println(gum_std_u(r))     // 0.290401
+    return 0
+}
+```

--- a/docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md
+++ b/docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.madaros-multimodule-print-import-bugs-2026-07-13
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.madaros-multimodule-print-import-bugs-2026-07-13
+-->
+
 # Madaros v0.80.0 — two multi-module defects (named import + print_f64)
 
 **Date:** 2026-07-13

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 951
-- Repo-backed topics: 801
+- Total governed topics: 955
+- Repo-backed topics: 805
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 551
+- Authority count `repo_only`: 555
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 570 topics
+- A2: 574 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -77,6 +77,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.bucket-d-script-hardening-2026-06-21 | repo_only | docs/audit/BUCKET_D_SCRIPT_HARDENING_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.checker-guard-wiring-dispatch-2026-07-11 | repo_only | docs/audit/CHECKER_GUARD_WIRING_DISPATCH_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.chi5-real-axiom-audit-2026-05-30 | repo_only | docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13 | repo_only | docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12 | repo_only | docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-demo-sweep-2026-06-02 | repo_only | docs/audit/EPISTEMIC_DEMO_SWEEP_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.epistemic-nn-backward-e2e-2026-06-02 | repo_only | docs/audit/EPISTEMIC_NN_BACKWARD_E2E_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -148,6 +149,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.madaros-method-call-sigsegv-2026-06-20 | repo_only | docs/audit/MADAROS_METHOD_CALL_SIGSEGV_2026-06-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-multimodule-fallback-segfault-2026-06-30 | repo_only | docs/audit/MADAROS_MULTIMODULE_FALLBACK_SEGFAULT_2026-06-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-multimodule-native-seed-segfault-2026-06-22 | repo_only | docs/audit/MADAROS_MULTIMODULE_NATIVE_SEED_SEGFAULT_2026-06-22.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.madaros-multimodule-print-import-bugs-2026-07-13 | repo_only | docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-native-v2-codegen-census-2026-06-19 | repo_only | docs/audit/MADAROS_NATIVE_V2_CODEGEN_CENSUS_2026-06-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-net-mod-sio-standalone-check-silent-fail-2026-07-01 | repo_only | docs/audit/MADAROS_NET_MOD_SIO_STANDALONE_CHECK_SILENT_FAIL_2026-07-01.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.madaros-open-pr-worktree-disposition-2026-06-21 | repo_only | docs/audit/MADAROS_OPEN_PR_WORKTREE_DISPOSITION_2026-06-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -774,7 +776,9 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.stdlib.stdlib-api-reference | repo_only | docs/stdlib/STDLIB_API_REFERENCE.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.stdlib-language-limitations | repo_only | docs/stdlib/STDLIB_LANGUAGE_LIMITATIONS.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.stdlib-module-organization | repo_only | docs/stdlib/STDLIB_MODULE_ORGANIZATION.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-13-data-science-io | repo_only | docs/superpowers/plans/2026-07-13-data-science-io.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening | repo_only | docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design | repo_only | docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.testing | repo_only | docs/TESTING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1235,6 +1235,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.e043-rust-macro-design-dispatch-2026-07-12",
       "collection": "repo",
       "repo_doc_path": "docs/audit/E043_RUST_MACRO_DESIGN_DISPATCH_2026-07-12.md",
@@ -2848,6 +2871,29 @@
       "topic_id": "repo.docs.audit.madaros-multimodule-native-seed-segfault-2026-06-22",
       "collection": "repo",
       "repo_doc_path": "docs/audit/MADAROS_MULTIMODULE_NATIVE_SEED_SEGFAULT_2026-06-22.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.audit.madaros-multimodule-print-import-bugs-2026-07-13",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",
@@ -17108,9 +17154,55 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-13-data-science-io",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-13-data-science-io.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-13-data-science-io-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-13-data-science-io-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-07-13-data-science-io.md
+++ b/docs/superpowers/plans/2026-07-13-data-science-io.md
@@ -1,0 +1,841 @@
+# Data & Science I/O — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Sounio load, hold, and emit real-world scientific data through one canonical, epistemic-aware `DataFrame`, with pure-Sounio readers (CSV, Parquet, netCDF-classic, HDF5) and writers (CSV, JSON, table, provenance artifact) — no compiler changes.
+
+**Architecture:** `stdlib/data/frame.sio` is the hub (extended additively with a null mask, a datetime dtype, and per-column units/provenance). Writers and readers are spokes targeting the hub's frozen API. Shared substrate is `stdlib/io/binary.sio` (byte reads) and `stdlib/compress/*` (gzip/zstd, plus a new snappy). "Real" is defined by golden fixtures emitted by reference tools (pyarrow/netCDF4/h5py).
+
+**Tech Stack:** Sounio (`./bin/souc` → Madaros). Builtin `String` with `++` concat and `(x as String)` casts (the idiom already used in `frame.sio`). Test harness: `//@ check-only` or a `fn main() -> i32` returning `0` for pass, run via `./bin/souc run`.
+
+**Scope of THIS plan:** Phase 0 (hub hardening) and Phase 1 (text writers) are specified in full, executable, bite-sized TDD detail. Phases 2–5 (CSV read, Parquet, netCDF, HDF5) are laid out as roadmap tasks with fixed interfaces; **their detailed step-by-step plans are authored after the Phase 0 API freeze**, because reader code must target the frozen hub API and writing exact steps now would invalidate on the first API adjustment. This is deliberate decomposition, not deferral of design — the interfaces they must hit are pinned below.
+
+**Preamble — run once per shell before any task:**
+```bash
+cd /workspace/sounio
+export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+SOUC=./bin/souc
+```
+
+**Ground rules (from CLAUDE.md):**
+- Never touch `self-hosted/` or `bootstrap/`. If a step hits a codegen wall, STOP and report it as a forensic dispatch — do not work around it in the compiler.
+- Additive only: do not delete `data/dataframe.sio`, `dataframe/pure/core.sio`, or `data/csv_loader.sio`.
+- EN-UK orthography. Atomic commits, one logical change each, no AI attribution in messages.
+- `Column {` struct literals exist ONLY in `stdlib/data/frame.sio` (13 sites) — adding fields is contained to that file.
+
+---
+
+## File Structure
+
+| File | Responsibility | Phase |
+|---|---|---|
+| `stdlib/data/frame.sio` (modify) | Hub: `Column`/`DataFrame` + null mask, datetime dtype, units/provenance, metadata-preserving filter/slice | 0 |
+| `stdlib/data/README.md` (create) | Frozen hub API contract | 0 |
+| `tests/stdlib/data/test_frame_nulls.sio` (create) | Null-mask behaviour | 0 |
+| `tests/stdlib/data/test_frame_datetime.sio` (create) | Datetime dtype | 0 |
+| `tests/stdlib/data/test_frame_metadata.sio` (create) | Units/provenance survive slice/filter | 0 |
+| `stdlib/data/write_csv.sio` (create) | DataFrame → CSV string (RFC-4180) | 1 |
+| `stdlib/data/write_json.sio` (create) | DataFrame → JSON string (records + columnar) | 1 |
+| `stdlib/data/table.sio` (create) | DataFrame → aligned/markdown table string | 1 |
+| `stdlib/data/artifact.sio` (create) | DataFrame → data + `.meta.json` sidecar strings | 1 |
+| `tests/stdlib/data/test_write_*.sio` (create) | Writer round-trip/format gates | 1 |
+| `stdlib/compress/snappy.sio` (create) | Snappy block decompress (Parquet read) | 3 |
+| `stdlib/parquet/` (create) | Parquet reader + writer + Thrift codec | 3 |
+| `stdlib/netcdf/` (create) | netCDF-classic reader | 4 |
+| `stdlib/hdf5/` (create) | HDF5 reader (contiguous + chunked/filtered) | 5 |
+| `scripts/data_io_gate.sh` (create) | Golden-fixture conformance gate wiring | 1→5 |
+
+---
+
+## PHASE 0 — Hub hardening
+
+**Design decisions locked (from spec §10):**
+- Null mask: field `null_mask: [bool]`, entry `true` = **missing**. Empty `[]` = nothing missing (keeps existing constructors cheap).
+- Datetime: `dtype == 5`, epoch stored in `int_data` as `i64` **nanoseconds**; unit tag `dt_unit: i32` (0=ns, 1=us, 2=ms, 3=s).
+- Metadata: `units: String` and `provenance: String`, default `""`.
+
+### Task 1: Add metadata fields to `Column`
+
+**Files:**
+- Modify: `stdlib/data/frame.sio` (the `pub struct Column` + all 13 `Column {` constructor sites)
+- Test: `tests/stdlib/data/test_frame_metadata.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_frame_metadata.sio`:
+```sounio
+//@ check-only
+// tests/stdlib/data/test_frame_metadata.sio
+use data::frame::*
+
+fn assert_meta_defaults() -> bool {
+    var d: [f64] = []
+    d.push(1.0)
+    d.push(2.0)
+    let c = column_float("x", d)
+    if c.units != "" { return false }
+    if c.provenance != "" { return false }
+    if c.null_mask.len() != 0 { return false }
+    if c.dt_unit != 0 { return false }
+    true
+}
+
+fn main() -> i32 {
+    if !assert_meta_defaults() { return 1 }
+    0
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC check tests/stdlib/data/test_frame_metadata.sio`
+Expected: FAIL — unknown field `units` on `Column`.
+
+- [ ] **Step 3: Add the fields to the struct**
+
+In `stdlib/data/frame.sio`, extend `pub struct Column` (after `conf_data`):
+```sounio
+    pub uncert_data: [f64],
+    pub conf_data: [f64],
+    // --- Phase 0 additions ---
+    pub null_mask: [bool],    // entry true = missing; empty = none missing
+    pub units: String,        // "" = unitless
+    pub provenance: String,   // "" = no recorded provenance
+    pub dt_unit: i32,         // datetime unit: 0=ns 1=us 2=ms 3=s (only meaningful when dtype==5)
+```
+
+- [ ] **Step 4: Update every constructor**
+
+Each of the 13 `Column { ... }` literals in `frame.sio` must initialise the 4 new fields. Add these lines before the closing `}` of every `Column {` literal, and declare an empty bool array at the top of each constructor alongside the existing `empty_*`:
+```sounio
+    var empty_nm: [bool] = []
+```
+and in the literal:
+```sounio
+        null_mask: empty_nm,
+        units: "",
+        provenance: "",
+        dt_unit: 0,
+```
+For `column_epistemic` (dtype 4) and all others the values are identical defaults. Do this for all 13 sites (`column_float`, `column_int`, `column_string`, `column_bool`, `column_epistemic`, and the 8 rebuild literals inside `dataframe_filter`/`dataframe_slice`/`dataframe_head`/`dataframe_tail` if they inline `Column {` — grep to confirm: `grep -n "Column {" stdlib/data/frame.sio`).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `$SOUC check tests/stdlib/data/test_frame_metadata.sio`
+Expected: PASS (exit 0).
+
+- [ ] **Step 6: Regression — hub still checks**
+
+Run: `$SOUC check stdlib/data/frame.sio`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+```bash
+git add stdlib/data/frame.sio tests/stdlib/data/test_frame_metadata.sio
+git commit -m "feat(data): add null-mask/units/provenance/dt_unit fields to Column"
+```
+
+### Task 2: Null-mask accessors
+
+**Files:**
+- Modify: `stdlib/data/frame.sio`
+- Test: `tests/stdlib/data/test_frame_nulls.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_frame_nulls.sio`:
+```sounio
+//@ check-only
+// tests/stdlib/data/test_frame_nulls.sio
+use data::frame::*
+
+fn assert_nulls() -> bool {
+    var d: [f64] = []
+    d.push(1.0)
+    d.push(2.0)
+    d.push(3.0)
+    var c = column_float("x", d)
+    // no mask yet -> nothing null
+    if column_is_null(c, 1) { return false }
+    if column_null_count(c) != 0 { return false }
+    // mark index 1 as missing
+    var m: [bool] = []
+    m.push(false)
+    m.push(true)
+    m.push(false)
+    c = column_set_null_mask(c, m)
+    if !column_is_null(c, 1) { return false }
+    if column_is_null(c, 0) { return false }
+    if column_null_count(c) != 1 { return false }
+    true
+}
+
+fn main() -> i32 {
+    if !assert_nulls() { return 1 }
+    0
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC check tests/stdlib/data/test_frame_nulls.sio`
+Expected: FAIL — `column_is_null` not defined.
+
+- [ ] **Step 3: Implement the accessors**
+
+Append to `stdlib/data/frame.sio` (after the Column constructors, before `struct DataFrame`):
+```sounio
+pub fn column_set_null_mask(col: Column, mask: [bool]) -> Column {
+    var c = col
+    c.null_mask = mask
+    c
+}
+
+pub fn column_is_null(col: Column, i: usize) -> bool {
+    if col.null_mask.len() == 0 { return false }
+    if i >= col.null_mask.len() { return false }
+    col.null_mask[i]
+}
+
+pub fn column_null_count(col: Column) -> usize {
+    var n: usize = 0
+    var i: usize = 0
+    while i < col.null_mask.len() {
+        if col.null_mask[i] { n = n + 1 }
+        i = i + 1
+    }
+    n
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC check tests/stdlib/data/test_frame_nulls.sio`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/frame.sio tests/stdlib/data/test_frame_nulls.sio
+git commit -m "feat(data): null-mask accessors (is_null, null_count, set_null_mask)"
+```
+
+### Task 3: Datetime dtype (5)
+
+**Files:**
+- Modify: `stdlib/data/frame.sio` (`column_datetime`, extend `column_len`, `column_dtype_str`, `column_is_numeric`)
+- Test: `tests/stdlib/data/test_frame_datetime.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_frame_datetime.sio`:
+```sounio
+//@ check-only
+// tests/stdlib/data/test_frame_datetime.sio
+use data::frame::*
+
+fn assert_datetime() -> bool {
+    var e: [i64] = []
+    e.push(0)                       // epoch
+    e.push(1000000000)              // +1 s in ns
+    let c = column_datetime("t", e, 0)
+    if column_dtype_str(c) != "datetime" { return false }
+    if column_len(c) != 2 { return false }
+    if c.dt_unit != 0 { return false }
+    if column_is_numeric(c) { return false }   // datetime is not numeric
+    true
+}
+
+fn main() -> i32 {
+    if !assert_datetime() { return 1 }
+    0
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC check tests/stdlib/data/test_frame_datetime.sio`
+Expected: FAIL — `column_datetime` not defined.
+
+- [ ] **Step 3: Implement**
+
+Add the constructor to `stdlib/data/frame.sio` (near the other constructors):
+```sounio
+pub fn column_datetime(name: String, epoch: [i64], unit: i32) -> Column {
+    var empty_f: [f64] = []
+    var empty_s: [String] = []
+    var empty_b: [bool] = []
+    var empty_u: [f64] = []
+    var empty_c: [f64] = []
+    var empty_nm: [bool] = []
+    Column {
+        name: name,
+        dtype: 5,
+        float_data: empty_f,
+        int_data: epoch,
+        string_data: empty_s,
+        bool_data: empty_b,
+        uncert_data: empty_u,
+        conf_data: empty_c,
+        null_mask: empty_nm,
+        units: "",
+        provenance: "",
+        dt_unit: unit,
+    }
+}
+```
+Extend `column_len` — add before the final `0`:
+```sounio
+    if col.dtype == 5 { return col.int_data.len() }
+```
+Extend `column_dtype_str` — add before its final return:
+```sounio
+    if col.dtype == 5 { return "datetime" }
+```
+Confirm `column_is_numeric` returns `false` for dtype 5 (it should already, since it only trues on 0/1/4 — verify and, if it trues on `>= 1`, add an explicit `if col.dtype == 5 { return false }`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC check tests/stdlib/data/test_frame_datetime.sio`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/frame.sio tests/stdlib/data/test_frame_datetime.sio
+git commit -m "feat(data): datetime dtype (epoch-ns i64, unit tag)"
+```
+
+### Task 4: Metadata + null mask survive filter/slice
+
+**Files:**
+- Modify: `stdlib/data/frame.sio` (`dataframe_filter`, `dataframe_slice`)
+- Test: extend `tests/stdlib/data/test_frame_metadata.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/stdlib/data/test_frame_metadata.sio` a new function and call it from `main`:
+```sounio
+fn assert_meta_survives_filter() -> bool {
+    var d: [f64] = []
+    d.push(1.0)
+    d.push(2.0)
+    d.push(3.0)
+    var c = column_float("x", d)
+    c.units = "mg"
+    c.provenance = "unit-test"
+    var nm: [bool] = []
+    nm.push(false)
+    nm.push(true)
+    nm.push(false)
+    c = column_set_null_mask(c, nm)
+    var df = dataframe_new()
+    df = dataframe_add_column(df, c)
+    var mask: [bool] = []
+    mask.push(true)
+    mask.push(false)
+    mask.push(true)
+    let out = dataframe_filter(df, mask)
+    let oc = dataframe_get_column(out, "x")
+    if oc.units != "mg" { return false }
+    if oc.provenance != "unit-test" { return false }
+    // rows 0 and 2 kept; both were non-null -> 0 nulls
+    if column_null_count(oc) != 0 { return false }
+    true
+}
+```
+And in `main` add before `0`:
+```sounio
+    if !assert_meta_survives_filter() { return 1 }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC run tests/stdlib/data/test_frame_metadata.sio`
+Expected: exit 1 (units dropped by filter).
+
+- [ ] **Step 3: Add a dtype-agnostic metadata post-pass**
+
+In `stdlib/data/frame.sio`, at the END of `dataframe_filter` (after `new_cols` is fully built, before it constructs the returned `DataFrame`), insert:
+```sounio
+    // carry per-column metadata + filtered null mask (dtype-agnostic)
+    var k: usize = 0
+    while k < new_cols.len() {
+        let src = df.columns[k]
+        var nc = new_cols[k]
+        nc.units = src.units
+        nc.provenance = src.provenance
+        nc.dt_unit = src.dt_unit
+        if src.null_mask.len() > 0 {
+            var new_nm: [bool] = []
+            var j: usize = 0
+            while j < src.null_mask.len() && j < mask.len() {
+                if mask[j] { new_nm.push(src.null_mask[j]) }
+                j = j + 1
+            }
+            nc.null_mask = new_nm
+        }
+        new_cols[k] = nc
+        k = k + 1
+    }
+```
+Add the equivalent post-pass to `dataframe_slice`, but slice the mask by `[start, end)` instead of a bool mask:
+```sounio
+    var k: usize = 0
+    while k < new_cols.len() {
+        let src = df.columns[k]
+        var nc = new_cols[k]
+        nc.units = src.units
+        nc.provenance = src.provenance
+        nc.dt_unit = src.dt_unit
+        if src.null_mask.len() > 0 {
+            var new_nm: [bool] = []
+            var j: usize = start
+            while j < end && j < src.null_mask.len() {
+                new_nm.push(src.null_mask[j])
+                j = j + 1
+            }
+            nc.null_mask = new_nm
+        }
+        new_cols[k] = nc
+        k = k + 1
+    }
+```
+Also add a `dtype == 5` branch to `dataframe_filter`/`dataframe_slice`'s per-dtype rebuild that mirrors the `dtype == 1` (int) branch but constructs via `column_datetime(col.name, new_data, col.dt_unit)`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC run tests/stdlib/data/test_frame_metadata.sio`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/frame.sio tests/stdlib/data/test_frame_metadata.sio
+git commit -m "feat(data): preserve units/provenance/null-mask through filter and slice"
+```
+
+### Task 5: Freeze + document the hub API
+
+**Files:**
+- Create: `stdlib/data/README.md`
+
+- [ ] **Step 1: Write the API contract**
+
+Create `stdlib/data/README.md` documenting the frozen surface that Phases 1–5 target. Include: the `Column` field layout and dtype table (0=float,1=int,2=string,3=bool,4=epistemic,5=datetime); null-mask convention (`true` = missing, empty = none); `dt_unit` codes; and the full public function list from `frame.sio` (constructors, `column_is_null`/`column_null_count`/`column_set_null_mask`, `dataframe_*`). State the stability guarantee: **these signatures do not change without a spec amendment; readers/writers depend on them.**
+
+- [ ] **Step 2: Verify it reflects reality**
+
+Run: `grep -n -E "^pub fn |^pub struct " stdlib/data/frame.sio`
+Cross-check every `pub` symbol appears in the README.
+
+- [ ] **Step 3: Commit**
+```bash
+git add stdlib/data/README.md
+git commit -m "docs(data): freeze and document the DataFrame hub API"
+```
+
+### Task 6: Dissertation-critical regression gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the pbpk/petab tests that depend on existing data code**
+
+Run:
+```bash
+$SOUC check tests/stdlib/darwin_pbpk/test_observed_petab_fit_e2e.sio
+$SOUC check tests/packages/package_pbpk_gum_workflow.sio
+```
+Expected: both PASS (Phase 0 was additive; these must be unaffected).
+
+- [ ] **Step 2: If either fails**
+
+STOP. The Phase 0 change was not additive. Do not proceed to Phase 1. Report which symbol broke and why. (Halt-with-report is a valid deliverable.)
+
+---
+
+## PHASE 1 — Text writers
+
+All writers return a `String` (pure, no IO) so they are trivially testable; a thin file-writing wrapper can come later. Rendering rules:
+- Null cell → CSV empty field; JSON `null`.
+- `f64` → `(v as String)`; `i64` → `(v as String)`; `bool` → literal `"true"`/`"false"`; datetime → `(int_data[i] as String)` (raw epoch for now).
+
+### Task 7: CSV writer (RFC-4180)
+
+**Files:**
+- Create: `stdlib/data/write_csv.sio`
+- Test: `tests/stdlib/data/test_write_csv.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_write_csv.sio`:
+```sounio
+// tests/stdlib/data/test_write_csv.sio
+use data::frame::*
+use data::write_csv::*
+
+fn build() -> DataFrame {
+    var a: [f64] = []
+    a.push(1.0)
+    a.push(2.0)
+    var s: [String] = []
+    s.push("hi")
+    s.push("a,b")            // must be quoted
+    var df = dataframe_new()
+    df = dataframe_add_column(df, column_float("x", a))
+    df = dataframe_add_column(df, column_string("label", s))
+    df
+}
+
+fn main() -> i32 with Mut {
+    let df = build()
+    let csv = dataframe_to_csv(df)
+    let expected = "x,label\n1,hi\n2,\"a,b\"\n"
+    if csv != expected { return 1 }
+    0
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC run tests/stdlib/data/test_write_csv.sio`
+Expected: FAIL — `dataframe_to_csv` not defined.
+
+- [ ] **Step 3: Implement the writer**
+
+Create `stdlib/data/write_csv.sio`:
+```sounio
+// stdlib/data/write_csv.sio — DataFrame -> RFC-4180 CSV string
+use data::frame::*
+
+fn csv_needs_quote(s: String) -> bool {
+    // quote if contains comma, quote, CR or LF
+    var i: usize = 0
+    let bytes = s.as_bytes()
+    while i < bytes.len() {
+        let b = bytes[i]
+        if b == 44 { return true }      // ,
+        if b == 34 { return true }      // "
+        if b == 10 { return true }      // \n
+        if b == 13 { return true }      // \r
+        i = i + 1
+    }
+    false
+}
+
+fn csv_escape(s: String) -> String {
+    if !csv_needs_quote(s) { return s }
+    var out: String = "\""
+    let bytes = s.as_bytes()
+    var i: usize = 0
+    while i < bytes.len() {
+        let b = bytes[i]
+        if b == 34 { out = out ++ "\"\"" } else { out = out ++ byte_to_string(b) }
+        i = i + 1
+    }
+    out ++ "\""
+}
+
+fn cell_to_string(col: Column, i: usize) -> String {
+    if column_is_null(col, i) { return "" }
+    if col.dtype == 0 { return (col.float_data[i] as String) }
+    if col.dtype == 1 { return (col.int_data[i] as String) }
+    if col.dtype == 2 { return csv_escape(col.string_data[i]) }
+    if col.dtype == 3 { if col.bool_data[i] { return "true" } else { return "false" } }
+    if col.dtype == 4 { return (col.float_data[i] as String) }
+    if col.dtype == 5 { return (col.int_data[i] as String) }
+    ""
+}
+
+pub fn dataframe_to_csv(df: DataFrame) -> String {
+    var out: String = ""
+    // header
+    let names = dataframe_column_names(df)
+    var c: usize = 0
+    while c < names.len() {
+        if c > 0 { out = out ++ "," }
+        out = out ++ csv_escape(names[c])
+        c = c + 1
+    }
+    out = out ++ "\n"
+    // rows
+    let nrows = dataframe_nrows(df)
+    var r: usize = 0
+    while r < nrows {
+        var cc: usize = 0
+        while cc < df.columns.len() {
+            if cc > 0 { out = out ++ "," }
+            out = out ++ cell_to_string(df.columns[cc], r)
+            cc = cc + 1
+        }
+        out = out ++ "\n"
+        r = r + 1
+    }
+    out
+}
+```
+> NOTE on `byte_to_string`/`as_bytes`: if `String.as_bytes()` or a single-byte→String helper is not available on the builtin `String`, replace `csv_escape`'s byte loop with `str`-module equivalents (`stdlib/str/lib.sio`: `str_from_literal`, `str_replace_char`, `str_contains`) — grep first: `grep -n "as_bytes\|fn byte_to_string" stdlib/**/*.sio`. Keep the RFC-4180 semantics identical (double embedded quotes, wrap in quotes when comma/quote/newline present).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC run tests/stdlib/data/test_write_csv.sio`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/write_csv.sio tests/stdlib/data/test_write_csv.sio
+git commit -m "feat(data): RFC-4180 CSV writer"
+```
+
+### Task 8: JSON writer (records + columnar)
+
+**Files:**
+- Create: `stdlib/data/write_json.sio`
+- Test: `tests/stdlib/data/test_write_json.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_write_json.sio`:
+```sounio
+// tests/stdlib/data/test_write_json.sio
+use data::frame::*
+use data::write_json::*
+
+fn build() -> DataFrame {
+    var a: [f64] = []
+    a.push(1.0)
+    a.push(2.0)
+    var df = dataframe_new()
+    df = dataframe_add_column(df, column_float("x", a))
+    df
+}
+
+fn main() -> i32 with Mut {
+    let df = build()
+    let recs = dataframe_to_json_records(df)
+    if recs != "[{\"x\":1},{\"x\":2}]" { return 1 }
+    let cols = dataframe_to_json_columns(df)
+    if cols != "{\"x\":[1,2]}" { return 1 }
+    0
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC run tests/stdlib/data/test_write_json.sio`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement**
+
+Create `stdlib/data/write_json.sio`. Reuse a `json_cell(col, i)` that emits `null` when `column_is_null`, a JSON string (quoted, backslash-escaped) for dtype 2, `true`/`false` for dtype 3, and the numeric cast otherwise. Implement `dataframe_to_json_records` (array of `{ "name": value, ... }` objects, one per row) and `dataframe_to_json_columns` (`{ "name": [values...], ... }`). Follow the exact loop structure of `dataframe_to_csv` (header/rows), swapping delimiters/braces. Full code mirrors Task 7's structure — write it out in the file; do not abbreviate.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC run tests/stdlib/data/test_write_json.sio`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/write_json.sio tests/stdlib/data/test_write_json.sio
+git commit -m "feat(data): JSON writer (records + columnar)"
+```
+
+### Task 9: Table pretty-printer (terminal + markdown)
+
+**Files:**
+- Create: `stdlib/data/table.sio`
+- Test: `tests/stdlib/data/test_table.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_table.sio`:
+```sounio
+// tests/stdlib/data/test_table.sio
+use data::frame::*
+use data::table::*
+
+fn build() -> DataFrame {
+    var a: [f64] = []
+    a.push(1.0)
+    var df = dataframe_new()
+    df = dataframe_add_column(df, column_float("x", a))
+    df
+}
+
+fn main() -> i32 with Mut {
+    let df = build()
+    let md = dataframe_to_markdown(df)
+    if md != "| x |\n| --- |\n| 1 |\n" { return 1 }
+    0
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC run tests/stdlib/data/test_table.sio`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `stdlib/data/table.sio` with `dataframe_to_markdown(df) -> String` (header row `| a | b |`, separator `| --- | --- |`, then data rows) and `dataframe_to_table(df) -> String` (space-aligned: compute max width per column over header+cells in a first pass, left-pad in a second pass). Reuse `cell_to_string` semantics from Task 7 (re-implement locally — the writer files are independent; do not cross-import a non-`pub` helper).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC run tests/stdlib/data/test_table.sio`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/table.sio tests/stdlib/data/test_table.sio
+git commit -m "feat(data): markdown + aligned table renderers"
+```
+
+### Task 10: Provenance artifact writer (data + `.meta.json` sidecar)
+
+**Files:**
+- Create: `stdlib/data/artifact.sio`
+- Test: `tests/stdlib/data/test_artifact.sio`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/stdlib/data/test_artifact.sio`:
+```sounio
+// tests/stdlib/data/test_artifact.sio
+use data::frame::*
+use data::artifact::*
+
+fn build() -> DataFrame {
+    var a: [f64] = []
+    a.push(1.0)
+    a.push(2.0)
+    var col = column_float("dose", a)
+    col.units = "mg"
+    col.provenance = "vancomycin_run_2026"
+    var df = dataframe_new()
+    df = dataframe_add_column(df, col)
+    df
+}
+
+fn main() -> i32 with Mut {
+    let df = build()
+    let meta = artifact_meta_json(df)
+    // schema records name, dtype, units, provenance, and row/col counts
+    if !str_has(meta, "\"units\":\"mg\"") { return 1 }
+    if !str_has(meta, "\"provenance\":\"vancomycin_run_2026\"") { return 1 }
+    if !str_has(meta, "\"nrows\":2") { return 1 }
+    if !str_has(meta, "\"ncols\":1") { return 1 }
+    0
+}
+
+fn str_has(hay: String, needle: String) -> bool {
+    // substring test via the str module; see NOTE in Task 7 for helper resolution
+    let h = str_from_literal(hay)
+    let n = str_from_literal(needle)
+    str_contains(&h, &n)
+}
+```
+> If `str_from_literal`/`str_contains` signatures differ, adapt the `str_has` helper to whatever `stdlib/str/lib.sio` exposes (verified present: `str_from_literal`, `str_contains`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `$SOUC run tests/stdlib/data/test_artifact.sio`
+Expected: FAIL — `artifact_meta_json` not defined.
+
+- [ ] **Step 3: Implement**
+
+Create `stdlib/data/artifact.sio` with:
+- `artifact_meta_json(df) -> String` — emit `{"nrows":N,"ncols":M,"columns":[{"name":..,"dtype":"..","units":"..","provenance":".."},...],"checksum":"<hex>"}`. dtype uses `column_dtype_str`. Checksum: sum a simple rolling hash over the CSV body (call `dataframe_to_csv` from Task 7) — a stable content fingerprint, documented as non-cryptographic.
+- `artifact_write(df, path) -> i32 with IO` — writes the CSV body to `path` and the metadata to `path ++ ".meta.json"`, using the existing file-write primitive (grep `stdlib/io` / `stdlib/os` for the write helper, e.g. `write_file`/`fs_write`; do NOT invent one).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `$SOUC run tests/stdlib/data/test_artifact.sio`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+```bash
+git add stdlib/data/artifact.sio tests/stdlib/data/test_artifact.sio
+git commit -m "feat(data): provenance artifact writer (data + .meta.json sidecar)"
+```
+
+### Task 11: Phase-1 gate script
+
+**Files:**
+- Create: `scripts/data_io_gate.sh`
+
+- [ ] **Step 1: Write the gate**
+
+Create `scripts/data_io_gate.sh`:
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+fail=0
+for t in tests/stdlib/data/test_frame_nulls.sio \
+         tests/stdlib/data/test_frame_datetime.sio \
+         tests/stdlib/data/test_frame_metadata.sio \
+         tests/stdlib/data/test_write_csv.sio \
+         tests/stdlib/data/test_write_json.sio \
+         tests/stdlib/data/test_table.sio \
+         tests/stdlib/data/test_artifact.sio ; do
+  echo "== $t =="
+  if ! $SOUC run "$t"; then echo "FAIL: $t"; fail=1; fi
+done
+# regression: dissertation-critical path
+for c in tests/stdlib/darwin_pbpk/test_observed_petab_fit_e2e.sio \
+         tests/packages/package_pbpk_gum_workflow.sio ; do
+  if ! $SOUC check "$c"; then echo "REGRESSION: $c"; fail=1; fi
+done
+exit $fail
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `bash scripts/data_io_gate.sh`
+Expected: every test prints and exits 0.
+
+- [ ] **Step 3: Commit**
+```bash
+chmod +x scripts/data_io_gate.sh
+git add scripts/data_io_gate.sh
+git commit -m "test(data): Phase 0+1 conformance gate (hub + writers)"
+```
+
+---
+
+## PHASES 2–5 — Readers (roadmap; detailed plans authored post-freeze)
+
+Each reader targets the **frozen hub API** from Task 5 and is verified by a **golden-fixture gate** (reference-tool output committed under `tests/stdlib/<fmt>/fixtures/`, generated once by a checked-in `gen_fixtures.py` — verification tooling, not the science path). Each gets its own dated plan document produced right before it is executed, following the same TDD granularity as Phases 0–1. Interfaces are pinned here so the phases compose.
+
+### Phase 2 — CSV reader → typed DataFrame
+- File: `stdlib/data/read_csv.sio`; entry `csv_read_to_frame(text: String, opts: CsvReadOpts) -> DataFrame`.
+- Consolidate onto `stdlib/csv/parser.sio` (do not fork it). Add: type inference (int→float→bool→datetime→string precedence), missing→null-mask, RFC-4180 quoting, epistemic-column hook (`value±unc` or paired columns → `column_epistemic`).
+- Gate: pandas-emitted CSVs (quoted fields, embedded newlines, blanks, mixed types) → expected typed frame.
+
+### Phase 3 — Parquet reader + writer
+- Files: `stdlib/compress/snappy.sio` (new, ~200 loc, LZ77 variant — write it first, unit-test against snappy spec vectors); `stdlib/parquet/{thrift.sio,read.sio,write.sio,mod.sio}`.
+- Read: Thrift compact footer (FileMetaData/schema/row-groups/column-chunks) → plain + dictionary(RLE/bit-pack) + RLE encodings → codecs uncompressed/snappy/gzip/zstd → primitive types (BOOLEAN/INT32/INT64/FLOAT/DOUBLE/BYTE_ARRAY) + logical hints (string/date/timestamp) → hub dtypes + null-mask (definition levels).
+- Write: uncompressed/gzip/zstd (no snappy needed to write); reuse the shared Thrift codec.
+- Gate: pyarrow fixtures (each codec, dictionary on/off, with nulls) read → expected frame; + Sounio-written parquet re-read by pyarrow == original.
+- New binary primitives likely needed in `stdlib/io/binary.sio`: `read_f32/f64_le`, LEB128/zigzag varint (additive).
+
+### Phase 4 — netCDF-classic reader
+- Files: `stdlib/netcdf/{read.sio,mod.sio}`; entry `netcdf_read_classic(bytes) -> DataFrame` (1-D vars → columns) with N-D vars as flat buffer + `shape` tag (spec §10 default).
+- CDF-1/2/5 magic; header (dims/global-attrs/vars w/ offsets); big-endian decode; one unlimited (record) dim; `_FillValue` → null-mask.
+- Doc caveat: classic only; netCDF-4 routes through Phase 5.
+- Gate: netCDF4-emitted classic fixtures → expected frame/tensor.
+
+### Phase 5 — HDF5 reader (contiguous + chunked/filtered)
+- Files: `stdlib/hdf5/{superblock.sio,objheader.sio,btree.sio,heap.sio,filter.sio,dataset.sio,mod.sio}`.
+- Split 5a (contiguous/uncompressed: superblock v0/v2/v3, object-header messages, datatype/dataspace/layout, group traversal via symbol-table + link msgs) → 5b (chunked via B-tree v1 chunk index + filter pipeline: gzip via existing `inflate`, shuffle).
+- Datatypes fixed/float/string, LE + BE → hub dtypes; N-D → flat buffer + shape; 1-D → column.
+- Gate: h5py fixtures — contiguous, chunked, gzip-filtered, shuffle+gzip, big-endian — → expected arrays/frame.
+
+**Extend `scripts/data_io_gate.sh`** to include each format's fixture gate as it lands.
+
+---
+
+## Self-review notes
+- **Spec coverage:** hub null/datetime/units/provenance (Tasks 1–4), frozen API (Task 5), additive-consolidation regression (Task 6), all writers incl. artifact (Tasks 7–10, target 4), conformance-gate wiring (Task 11), readers + fixtures (Phases 2–5), snappy (Phase 3), netCDF caveat (Phase 4), HDF5 5a/5b split (Phase 5). No spec section is unmapped.
+- **Consistency:** field names (`null_mask`, `units`, `provenance`, `dt_unit`), dtype codes (5=datetime), and function names (`column_is_null`, `column_set_null_mask`, `column_null_count`, `column_datetime`, `dataframe_to_csv/json_*/markdown`, `artifact_meta_json`) are used identically across tasks.
+- **Known unknowns flagged inline (not placeholders):** builtin `String` byte access (`as_bytes`/`byte_to_string`) and the file-write primitive are marked "grep to resolve, fall back to `stdlib/str`/`stdlib/io`" with the verified fallback named — because these depend on compiler-surface details that must be confirmed at the machine, not guessed.
+```

--- a/docs/superpowers/plans/2026-07-13-data-science-io.md
+++ b/docs/superpowers/plans/2026-07-13-data-science-io.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-13-data-science-io
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-13-data-science-io
+-->
+
 # Data & Science I/O — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-07-13-data-science-io-design.md
+++ b/docs/superpowers/specs/2026-07-13-data-science-io-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-13-data-science-io-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-13-data-science-io-design
+-->
+
 # Design — Sounio Data & Science I/O release
 
 **Status:** approved design, pre-implementation

--- a/docs/superpowers/specs/2026-07-13-data-science-io-design.md
+++ b/docs/superpowers/specs/2026-07-13-data-science-io-design.md
@@ -1,0 +1,226 @@
+# Design — Sounio Data & Science I/O release
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-07-13
+**Author:** Claude (session), for founder review
+**Constraint:** No compiler changes. The compiler (`self-hosted/`, `bootstrap/`) is owned by CODEX-2. All work lands in `stdlib/`, `tools/`, `examples/`, `tests/`.
+**Orthography:** EN-UK (CLAUDE.md §9).
+
+---
+
+## 1. Intent
+
+Make Sounio able to load, hold, and emit real-world scientific data end-to-end. One canonical,
+epistemic-aware `DataFrame` acts as the hub; real readers (CSV, Parquet, netCDF-classic, HDF5) and
+writers (CSV, JSON, Parquet, formatted table, provenance artifact) are spokes. Everything is written
+in Sounio (operating principle 4 — the science path is Sounio, not Python).
+
+The differentiator over "pandas, but worse" is the through-line: **uncertainty, units, and provenance
+survive a full read → transform → write round-trip.** That is the spine, not an add-on.
+
+## 2. Scope
+
+### In scope
+- Hub hardening: null/missing mask, datetime dtype, per-column units + provenance metadata, frozen public API.
+- Writers: CSV, JSON, formatted table (terminal + markdown), reproducible results-artifact, Parquet write.
+- Readers: CSV → typed DataFrame; Parquet; netCDF-classic (CDF-1/2/5); HDF5 (contiguous **and** chunked+filtered).
+- A new snappy decompressor (`stdlib/compress/snappy.sio`), required for Parquet read.
+- Golden-fixture conformance gates per format, wired like existing stdlib gates.
+
+### Out of scope (explicit)
+- Embedded database (the `database/` stub lane) — deferred to a separate spec.
+- Parquet nested/repeated types (lists/maps/structs) — primitive columns first; nested deferred.
+- netCDF-4 as its own reader — netCDF-4 is HDF5-backed and is served by the HDF5 phase, not the netCDF-classic phase.
+- Writing HDF5 / netCDF / deleting any existing DataFrame or CSV implementation.
+
+## 3. Constraints & principles
+
+- **No compiler changes.** If a phase hits a codegen wall, it is reported as a forensic dispatch
+  (`docs/audit/`), not worked around in `self-hosted/`. (CLAUDE.md §8.)
+- **Additive consolidation, not deletion.** `stdlib/data/frame.sio` becomes canonical; new code targets
+  it. The other DataFrame impls (`data/dataframe.sio`, `dataframe/pure/core.sio`) and the second CSV
+  parser (`data/csv_loader.sio`) are marked deprecated in-file but **remain** — the petab-fit e2e
+  (`tests/stdlib/darwin_pbpk/test_observed_petab_fit_e2e.sio`) and pbpk workflow
+  (`tests/packages/package_pbpk_gum_workflow.sio`) depend on the existing code, which is the
+  dissertation-critical path (operating principles 2 & 5).
+- **Conformance oracle defines "real".** A reader is complete only when it reads bytes emitted by the
+  reference tool (pyarrow / netCDF4 / h5py). Fixture *generation* is verification tooling, in the same
+  spirit as the existing z3 crosscheck — not Python in the science path.
+- EN-UK orthography; no AI attribution in commits; atomic commits, one logical change each (principle 11).
+
+## 4. Architecture
+
+```
+                    ┌─────────────────────────────┐
+   readers ───────► │   canonical DataFrame hub    │ ───────► writers
+  CSV / Parquet     │  stdlib/data/frame.sio       │   CSV / JSON / Parquet
+  netCDF / HDF5     │  + null mask, datetime dtype,│   table / provenance-artifact
+                    │    units + provenance meta   │
+                    └─────────────────────────────┘
+        shared substrate:
+          stdlib/io/binary.sio    — read_uNN_le/be primitives
+          stdlib/compress/*.sio   — gzip/deflate/inflate, zstd, + NEW snappy
+```
+
+### 4.1 The hub (`stdlib/data/frame.sio`)
+
+Current state (verified): type-erased `Column` with `dtype` discriminator
+(0=Float, 1=Int, 2=String, 3=Bool, 4=Epistemic), a `DataFrame` of named columns, and a working public
+API (add/get/drop column, shape, slice/head/tail, filter by bool mask, row access, `col_sum`/`col_mean`,
+`col_mean_epistemic`, `info`). **Missing** (all additive):
+
+- **Null/missing mask** — per-column `[bool]` validity mask (or `null_mask`), so CSV blanks, Parquet
+  definition levels, and netCDF `_FillValue` map to a first-class "missing" rather than a sentinel.
+- **Datetime dtype** — new dtype (5=Datetime) stored as epoch `i64` (nanoseconds or seconds — decided in
+  Phase 0) plus a unit tag; date parsing/formatting helpers.
+- **Units + provenance metadata** — optional per-column `units: String` and `provenance: String`
+  (source file, tool, checksum). Carried through slice/filter/select and emitted by writers.
+- **Frozen public API** — the surface Phases 1–5 target. Once frozen in Phase 0, readers/writers build
+  against a stable contract. Documented in `stdlib/data/README.md` (or module header).
+
+`Column`/`DataFrame` remain value types (copy semantics), matching the current implementation. No new
+effects introduced beyond what `frame.sio` already uses.
+
+### 4.2 Shared substrate
+
+- `stdlib/io/binary.sio` already provides `read_u16/32/64_le/be`, `read_iNN`. Extend additively with any
+  missing primitives readers need (e.g. `read_f32/f64_le/be`, varint/zigzag for Parquet Thrift, LEB128).
+- `stdlib/compress/` has `gzip_decompress`, `inflate_stored`, `zstd_decompress`. **New:**
+  `stdlib/compress/snappy.sio` — snappy block-format decompress (LZ77 variant, ~200 loc). Snappy is
+  Parquet's default codec; without it Parquet read fails on the majority of real files.
+
+## 5. Components & phases
+
+Each phase is a working, independently gated slice. Order is dependency-driven: writers first so the hub
+API is proven before any reader targets it.
+
+### Phase 0 — Hub hardening
+- Files: `stdlib/data/frame.sio` (extend), `stdlib/data/README.md` (API contract).
+- Deliverable: null mask, datetime dtype, units/provenance metadata, frozen API.
+- Gate: a `.sio` test constructing frames with nulls/dates/units and asserting round-trip through
+  slice/filter/select preserves them.
+
+### Phase 1 — Text writers (target 4)
+- Files: `stdlib/data/write_csv.sio`, `stdlib/data/write_json.sio`, `stdlib/data/table.sio`,
+  `stdlib/data/artifact.sio`.
+- CSV: RFC-4180 quoting/escaping, null rendering, configurable delimiter.
+- JSON: records (array of objects) and columnar (object of arrays) modes; nulls as JSON `null`.
+- Table: aligned columns for terminal; GitHub-flavoured markdown mode.
+- **Results-artifact writer**: a reproducible bundle — data file + sidecar carrying schema, per-column
+  units, provenance, row/col counts, and a content checksum. This is the epistemic differentiator; format
+  decided in Phase 1 planning (leaning: data + `.meta.json` sidecar).
+- Parquet **write** is deferred to Phase 3, where it shares the `stdlib/parquet/` Thrift codec with the
+  reader (avoids building that module out of dependency order).
+- Gate: round-trip in-memory frame → write → self-read (CSV/JSON) equals original, nulls/units/provenance
+  preserved.
+
+### Phase 2 — CSV reader → typed DataFrame (target 1)
+- Files: consolidate onto `stdlib/csv/parser.sio`; new `stdlib/data/read_csv.sio` binding it to the hub.
+- Type inference (int → float → bool → datetime → string precedence), missing-value handling (blank/`NA`/
+  configurable → null mask), date parsing, quoting per RFC-4180, epistemic-column hook (e.g. `value±unc`
+  or paired columns → epistemic dtype).
+- Gate: golden CSVs (incl. quoted fields, embedded newlines, missing values, mixed types) → expected typed
+  frame; cross-check against pandas-emitted expectations.
+
+### Phase 3 — Parquet reader + writer (target 3)
+- Files: `stdlib/parquet/` (reader + writer + shared Thrift-compact codec), `stdlib/compress/snappy.sio` (new).
+- Parquet **write** (moved here from Phase 1): uncompressed / gzip / zstd — no snappy needed to *write*;
+  emits files pyarrow can read (write-side conformance gate). Reuses the shared Thrift-compact codec.
+- Thrift compact-protocol footer parse (FileMetaData, schema, row groups, column chunks); plain,
+  dictionary (RLE/bit-packed), and RLE encodings; codecs uncompressed/snappy/gzip/zstd; primitive
+  physical types (BOOLEAN, INT32/64, FLOAT, DOUBLE, BYTE_ARRAY) with logical-type hints (string, date,
+  timestamp) → hub dtypes incl. datetime and nulls (via definition levels).
+- Gate: read pyarrow-emitted `.parquet` fixtures (each codec, dictionary on/off, with nulls) → expected
+  frame; plus write-side round-trip (Sounio-written `.parquet` re-read by pyarrow equals original).
+
+### Phase 4 — netCDF-classic reader (target 3)
+- Files: `stdlib/netcdf/` (classic reader).
+- CDF-1/CDF-2/CDF-5 magic; header: dim list, global attrs, var list (name, dims, type, attrs, offset);
+  big-endian numeric decode; fixed vars and one record (unlimited) dim; `_FillValue` → null mask; map to
+  DataFrame (1-D vars as columns) and/or tensor for N-D vars.
+- Explicit doc caveat: **classic only**; netCDF-4 files route through the HDF5 reader (Phase 5).
+- Gate: read netCDF4-emitted classic-format fixtures → expected frame/tensor.
+
+### Phase 5 — HDF5 full reader (target 3, largest)
+- Files: `stdlib/hdf5/` (superblock, object header, B-tree, heap, filter pipeline, dataset reader).
+- Superblock v0/v2/v3; object-header messages (dataspace, datatype, data-layout, filter-pipeline,
+  attribute, link); group traversal via symbol-table (v0) and link messages (v2); **data layout**:
+  contiguous and **chunked** via **B-tree v1 chunk index**; **filter pipeline**: gzip/deflate (existing
+  `inflate`) and shuffle; datatypes: fixed/float/string, little- and big-endian → hub dtypes; N-D datasets
+  → tensor, 1-D → column.
+- May split during planning: **5a** contiguous/uncompressed (proves superblock+object-header+datatype),
+  **5b** chunked + filter pipeline (B-tree + gzip/shuffle).
+- Bonus (not committed): with HDF5 working, a thin netCDF-4 convention layer becomes feasible later.
+- Gate: read h5py-emitted fixtures — contiguous, chunked, gzip-filtered, shuffle+gzip, big-endian — →
+  expected arrays/frame.
+
+## 6. Module layout
+
+Top-level, matching existing convention (`json`, `csv`, `toml`, `yaml` are top-level):
+
+```
+stdlib/data/frame.sio          (hub — extended)
+stdlib/data/read_csv.sio       (new — CSV→hub binding)
+stdlib/data/write_csv.sio      (new)
+stdlib/data/write_json.sio     (new)
+stdlib/data/table.sio          (new — pretty/markdown table)
+stdlib/data/artifact.sio       (new — provenance artifact)
+stdlib/data/README.md          (new — frozen API contract)
+stdlib/compress/snappy.sio     (new)
+stdlib/parquet/                (new — reader, writer, thrift codec)
+stdlib/netcdf/                 (new — classic reader)
+stdlib/hdf5/                   (new — full reader)
+```
+
+Each new module follows the existing `lib.sio` / `mod.sio` convention used across `stdlib/`.
+
+## 7. Verification — the conformance gate
+
+"Real" is defined by the reference tool, per repo culture (z3 crosscheck; "always cross-verify vs an
+independent oracle").
+
+- **Fixtures**: generated by `pyarrow` (Parquet), `netCDF4` (netCDF-classic), `h5py` (HDF5), committed
+  under `tests/stdlib/<fmt>/fixtures/`. Generation scripts live in `scripts/research/` or
+  `tests/stdlib/<fmt>/gen_fixtures.py`, run once and checked in; they are verification tooling, not the
+  science path.
+- **Read gate**: each reader reads every fixture and asserts the resulting frame equals a committed
+  expected (schema + values + nulls + units where applicable).
+- **Round-trip gate**: writers → re-read (self for CSV/JSON; reference tool for Parquet) equals original,
+  with uncertainty/units/provenance preserved.
+- **Wiring**: one gate script per format under `scripts/`, invocable standalone and from the suite, in the
+  style of `scripts/stdlib_hyper_execution_gate.sh`. `SKIP_BUILD=1` honoured.
+- **Compiler-surface honesty**: gates run under `./bin/souc` (Madaros default; note lean_single fallback
+  if a file needs it). Report exact command + path + evidence (principle: auditability over speed).
+
+## 8. Risks & mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| HDF5 chunked+filter is very large; may not finish in one pass | High | Split 5a/5b; 5a is independently useful; each has its own gate. Halt-with-report is a valid deliverable (principle 8). |
+| Parquet Thrift-compact + dictionary/RLE encodings are fiddly | Med | Start with plain-encoded uncompressed fixtures; add dictionary/RLE/codecs incrementally, each gated. |
+| Snappy decompressor bug corrupts silently | Med | Golden-fixture byte-exact gate against pyarrow output; unit tests on snappy spec vectors. |
+| Codegen wall in a reader (large struct / array mutation) | Med | Known gotchas (struct wrappers, `(*arr)[i]`). If genuinely a compiler bug → forensic dispatch, not a `self-hosted/` patch. |
+| Hub API churn breaks in-flight reader work | Low | Freeze API in Phase 0 before any reader starts; writers (Phase 1) shake it out first. |
+| Consolidation accidentally breaks pbpk/petab tests | Low | Additive only; run those two tests as a regression gate after any `frame.sio` change. |
+
+## 9. Success criteria
+
+1. A Sounio program reads a real pyarrow-written `.parquet`, an h5py-written chunked+gzip `.h5`, a
+   netCDF4-written classic `.nc`, and a messy quoted CSV — each into the same `DataFrame` type.
+2. That frame can be written back to CSV, JSON, and Parquet, and a provenance artifact, with
+   uncertainty/units/provenance preserved end-to-end.
+3. Every format has a committed golden-fixture gate that passes under `./bin/souc`, cross-checked against
+   the reference tool.
+4. No file under `self-hosted/` or `bootstrap/` is modified. Existing pbpk/petab tests still pass.
+
+## 10. Resolved decisions (defaults taken 2026-07-13)
+
+- **Datetime storage** — store epoch as `i64` **nanoseconds** plus an explicit unit tag on the column
+  (so netCDF "seconds/days since epoch" attrs convert into the same representation). Nanoseconds match
+  Parquet/HDF5 conventions and avoid lossy sub-second truncation.
+- **Artifact bundle shape** — data file + `.meta.json` **sidecar** carrying schema, per-column units,
+  provenance, row/col counts, and content checksum. (Not a single packed file.)
+- **N-D arrays** — **flattened data + shape in column/frame metadata** for this release; a dedicated
+  `Tensor` type is not introduced (avoids a new cross-module dependency). N-D netCDF/HDF5 variables land
+  as a flat buffer plus a `shape: [usize]` tag; 1-D variables land as ordinary columns.
+```


### PR DESCRIPTION
## Dispatch for CODEX-2 — Madaros compiler blockers to real-world stdlib usability

Produced while attempting a real-world **Data & Science I/O** lane under the "no compiler changes" contract. The lane is blocked at the compiler; rather than work around it in `self-hosted/`, these are filed as forensic dispatches (per CLAUDE.md §8). **No compiler files are modified in this PR** — it is documentation only.

**Method:** every finding is verified by `souc compile … -o out && ./out` (not `check`), because on current Madaros `check:OK` ≠ runs.

### Blockers (priority order)
1. **`write_file` buffer-pointer ABI** — returns the correct byte-count but writes from the wrong address (garbage on disk) in every call shape. Length is passed correctly; base pointer is not.
2. **`read_file` SIGSEGV (139)** — crashes on read (matches the known bug in `MADAROS_BUILTIN_EMISSION_2026-06-24.md`).
3. **Multi-module papercuts** (`MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS`): single-symbol `use module::name` fails `E137` even for `pub` symbols; `print_f64` breaks in importing programs; a user helper fn alongside `use` fails visibility-preflight; `gum.sio`'s embedded self-test segfaults at runtime.

Each has a caller-side workaround (documented in the dispatch), so nothing is hard-blocked — but fixing (1)/(2) unblocks the entire data-I/O lane, and the multi-module fixes would make stdlib modules feel usable to newcomers.

### Also included (context, shelved)
`docs/superpowers/specs|plans/2026-07-13-data-science-io-*` — the DataFrame-hub + readers/writers design that these blockers shelved. Kept for context on impact; not proposed for implementation until the file-I/O builtins are fixed.

### Companion PR
The pivot deliverable (hardening the epistemic/GUM vertical, which lives entirely inside the working surface) is a separate feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
