### PR TITLE
feat(epistemic): harden the GUM vertical — importable, run-proven, gated

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 949
-- Repo-backed topics: 799
+- Total governed topics: 951
+- Repo-backed topics: 801
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 549
+- Authority count `repo_only`: 551
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 568 topics
+- A2: 570 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -774,6 +774,8 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.stdlib.stdlib-api-reference | repo_only | docs/stdlib/STDLIB_API_REFERENCE.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.stdlib-language-limitations | repo_only | docs/stdlib/STDLIB_LANGUAGE_LIMITATIONS.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.stdlib.stdlib-module-organization | repo_only | docs/stdlib/STDLIB_MODULE_ORGANIZATION.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening | repo_only | docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design | repo_only | docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.testing | repo_only | docs/TESTING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.theory.epistemic-monotonicity | repo_only | docs/theory/epistemic_monotonicity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17108,6 +17108,52 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.test-infrastructure-v2",
       "collection": "repo",
       "repo_doc_path": "docs/test-infrastructure-v2.md",

--- a/docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md
+++ b/docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening
+-->
+
 # Epistemic / GUM Hardening — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.

--- a/docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md
+++ b/docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md
@@ -1,0 +1,280 @@
+# Epistemic / GUM Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make `stdlib/epistemic/gum.sio` a genuinely-usable, importable GUM module — a program can `use` it, propagate ISO-GUM uncertainty, and print a correct report — proven by compile-and-run against a published GUM value. No compiler changes.
+
+**Architecture:** The module already imports (via wildcard); document the working idiom, add a print-based `gum_report`, prove the full API runs as native ELF with assertions against a published GUM result, and ship a consumer example + a runnable gate.
+
+**Tech stack:** Sounio (`./bin/souc` → Madaros v0.80.0). Verified working surface only: `print`/`println` (incl. `print(f64)`/`println(f64)`) to stdout, `string`+`str_*`, structs+`impl`, fixed slabs. **`check:OK` ≠ works — every runtime claim must be `souc compile … -o out && ./out`.**
+
+**Compiler workarounds (dispatched: `docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md`):**
+- Import stdlib modules with **`use module::*`** (single-symbol `use module::name` fails `E137`).
+- In importing programs print floats with **`print(f64)`/`println(f64)`**, never `print_f64` (spurious `E137`).
+
+**Preamble — run once per shell:**
+```bash
+cd /workspace/sounio
+export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
+SOUC=./bin/souc
+SCRATCH=/tmp/claude-1000/-workspace-sounio/def94f67-8a00-442d-991e-327034e5bf67/scratchpad
+mkdir -p "$SCRATCH"
+```
+
+**Ground rules:** Never touch `self-hosted/` or `bootstrap/`. Do not change any existing `pub` signature in `gum.sio`. Do not `git add` unrelated pre-existing WIP. EN-UK; atomic commits; no AI attribution.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `stdlib/epistemic/gum.sio` (modify) | Header usage-note; add `gum_report` | 1, 2 |
+| `tests/stdlib/epistemic/test_gum_stdlib.sio` (create) | Run-proof: import stdlib gum, assert published values | 3 |
+| `examples/epistemic/gum_measurement_chain.sio` (create) | Consumer example using stdlib gum + `gum_report` | 4 |
+| `scripts/epistemic_gum_gate.sh` (create) | Compile+run gate | 5 |
+
+---
+
+## Task 1: Verify `epistemic::gum` imports + runs; document the idiom
+
+**Files:** Modify `stdlib/epistemic/gum.sio` (header comment only). Scratch driver in `$SCRATCH`.
+
+**Context (corrected — spec §2):** `epistemic::gum` is **already importable** via the wildcard form. The earlier "not importable" reading was a misdiagnosis of two compiler bugs (single-symbol import; `print_f64` in importing programs) — both dispatched, both with caller-side workarounds. No visibility edit to `gum.sio` is needed. This task proves import+run and records the idiom in the module header.
+
+- [ ] **Step 1: Prove import + run (in-repo, native ELF).**
+
+Create `examples/_scratch_gum_import.sio`:
+```sounio
+use epistemic::gum::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ub = gum_type_b_uniform(0.5)
+    let ua = gum_type_a(0.070710, 5)
+    let r = gum_combine2(98.3, ua, ub)
+    print("u_c=")
+    println(gum_std_u(r))     // println(f64) — NOT print_f64
+    return 0
+}
+```
+Run: `$SOUC compile examples/_scratch_gum_import.sio -o "$SCRATCH/gi.elf" && "$SCRATCH/gi.elf"; echo "exit=$?"`
+Expected: prints `u_c=0.29…`, `exit=0`. If it fails, capture the error and report DONE_WITH_CONCERNS — do not edit `self-hosted/`.
+
+- [ ] **Step 2: Add a usage note to the module header.**
+
+At the top of `stdlib/epistemic/gum.sio`, inside the existing comment block, add:
+```sounio
+// USAGE: import with `use epistemic::gum::*` (single-symbol `use epistemic::gum::name`
+// currently fails to resolve — Madaros bug, docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md).
+// Print floats with print(x)/println(x); do NOT use print_f64 in an importing program.
+```
+Change no code and no signature.
+
+- [ ] **Step 3: Self-check stays green.**
+
+Run: `$SOUC check stdlib/epistemic/gum.sio`
+Expected: `check: OK`.
+
+- [ ] **Step 4: Clean up scratch + commit.**
+```bash
+rm -f examples/_scratch_gum_import.sio
+git add stdlib/epistemic/gum.sio
+git commit -m "docs(epistemic): document gum import + float-print idiom (Madaros workarounds)"
+```
+
+## Task 2: Add `gum_report` formatted stdout
+
+**Files:** Modify `stdlib/epistemic/gum.sio`. Depends on Task 1.
+
+- [ ] **Step 1: Write the report function.**
+
+Append to `stdlib/epistemic/gum.sio` (after the accessors, before any `main`). Floats print via `print(f64)` — never `print_f64`:
+```sounio
+pub fn gum_report(label: string, unit: string, r: GUMResult) with IO, Mut, Div, Panic {
+    print(label)
+    print(" = ")
+    print(gum_value(r))
+    print(" ± ")
+    print(gum_u95(r))
+    print(" ")
+    print(unit)
+    print("   (k = ")
+    print(gum_k95(r))
+    print(", 95%)\n    u_c = ")
+    print(gum_std_u(r))
+    print(" ")
+    print(unit)
+    print(",  nu_eff = ")
+    print(gum_dof(r))
+    print("\n")
+}
+```
+> If `print(f64)` inline does not compile inside `gum.sio` itself (single-module context may differ), fall back to `print_f64` **inside gum.sio only** — the multi-module bug affects importing callers, and `gum.sio` compiled standalone may accept `print_f64`. Verify by the Step 3 run (which imports it).
+
+- [ ] **Step 2: Self-check stays green.**
+
+Run: `$SOUC check stdlib/epistemic/gum.sio`
+Expected: `check: OK`.
+
+- [ ] **Step 3: Smoke via an importing driver, compile+run.**
+
+Create `examples/_scratch_report.sio`:
+```sounio
+use epistemic::gum::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ua = gum_type_a(0.070710, 5)
+    let ub = gum_type_b_uniform(0.5)
+    let r = gum_combine2(98.3, ua, ub)
+    gum_report("recovery", "%", r)
+    return 0
+}
+```
+Run: `$SOUC compile examples/_scratch_report.sio -o "$SCRATCH/rep.elf" && "$SCRATCH/rep.elf"; echo "exit=$?"`
+Expected: `recovery = 98.3… ± … %   (k = …, 95%)` then `u_c … nu_eff …`, `exit=0`.
+
+- [ ] **Step 4: Clean up + commit.**
+```bash
+rm -f examples/_scratch_report.sio
+git add stdlib/epistemic/gum.sio
+git commit -m "feat(epistemic): gum_report — formatted ISO-GUM stdout report"
+```
+
+## Task 3: Run-proof driver with published-value assertions
+
+**Files:** Create `tests/stdlib/epistemic/test_gum_stdlib.sio`.
+
+**Context:** Published anchor (reproduced at runtime from `examples/real_world/04_gum_measurement_simple.sio`): Type-B rectangular half-width 0.5 → variance a²/3 = 0.083333, std 0.288675; Type-A s≈0.070710 over n=5; combined at 98.30 → u_c ≈ 0.293914, U(k=2) ≈ 0.587828. Assert on the raw f64 accessors (not printed text) within tolerance.
+
+- [ ] **Step 1: Write the driver (compile-and-run IS the gate).**
+
+Create `tests/stdlib/epistemic/test_gum_stdlib.sio`:
+```sounio
+use epistemic::gum::*
+
+fn near(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    d < tol
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ub = gum_type_b_uniform(0.5)
+    let ua = gum_type_a(0.070710, 5)
+    let r = gum_combine2(98.3, ua, ub)
+
+    if !near(gum_value(r), 98.3, 1.0e-6) { print("FAIL value\n"); return 1 }
+    if !near(gum_std_u(r), 0.293914, 1.0e-3) { print("FAIL u_c\n"); return 2 }
+    if !near(gum_u95(r), 0.587828, 5.0e-2) { print("FAIL U95\n"); return 3 }
+    if gum_k95(r) < 1.9 { print("FAIL k95 range\n"); return 4 }
+
+    gum_report("recovery", "%", r)
+    print("GUM_STDLIB_OK\n")
+    return 0
+}
+```
+> Tolerances: `u_c` tight (1e-3); `U95` looser (5e-2) because `k95` depends on effective dof via Welch–Satterthwaite and the reference used k=2 exactly. If `u_c` matches but `U95` differs because `k95` ≠ 2 at this dof, that is CORRECT GUM behaviour — keep the loose bound; do NOT retrofit tolerances to force a pass.
+
+- [ ] **Step 2: Compile and run (the gate).**
+
+Run: `$SOUC compile tests/stdlib/epistemic/test_gum_stdlib.sio -o "$SCRATCH/tg.elf" && "$SCRATCH/tg.elf"; echo "exit=$?"`
+Expected: report line(s) + `GUM_STDLIB_OK`, `exit=0`.
+If an assertion fails: do NOT loosen tolerances. Investigate — either the stdlib value is wrong (report it) or the expectation is wrong (fix the derivation, cite it). Report DONE_WITH_CONCERNS if the discrepancy is real.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add tests/stdlib/epistemic/test_gum_stdlib.sio
+git commit -m "test(epistemic): run-proof GUM stdlib driver vs published values"
+```
+
+## Task 4: Consumer example (reuse, not reinvention)
+
+**Files:** Create `examples/epistemic/gum_measurement_chain.sio`.
+
+- [ ] **Step 1: Write the example.**
+
+Create `examples/epistemic/gum_measurement_chain.sio`:
+```sounio
+// GUM measurement chain using the stdlib epistemic::gum module.
+// Two Type-B sources + one Type-A, combined and reported per ISO GUM.
+use epistemic::gum::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("=== GUM measurement chain (stdlib epistemic::gum) ===\n")
+
+    let u_ref = gum_type_b_expanded(0.5, 2.0)   // certificate ±0.5% expanded, k=2
+    let u_res = gum_type_b_uniform(0.05)         // resolution, rectangular half-width 0.05
+    let u_rep = gum_type_a(0.12, 8)              // repeatability, s=0.12 over n=8
+
+    let r = gum_combine3(99.4, u_ref, u_res, u_rep)
+    gum_report("assay", "%", r)
+    return 0
+}
+```
+
+- [ ] **Step 2: Compile and run.**
+
+Run: `$SOUC compile examples/epistemic/gum_measurement_chain.sio -o "$SCRATCH/chain.elf" && "$SCRATCH/chain.elf"; echo "exit=$?"`
+Expected: header + `assay = 99.4… ± … %` report, `exit=0`.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add examples/epistemic/gum_measurement_chain.sio
+git commit -m "docs(epistemic): example — GUM measurement chain using stdlib gum"
+```
+
+## Task 5: Runnable gate
+
+**Files:** Create `scripts/epistemic_gum_gate.sh`.
+
+- [ ] **Step 1: Write the gate.**
+
+Create `scripts/epistemic_gum_gate.sh`:
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+echo "== check gum.sio =="
+$SOUC check stdlib/epistemic/gum.sio || fail=1
+
+echo "== run-proof driver =="
+if $SOUC compile tests/stdlib/epistemic/test_gum_stdlib.sio -o "$OUT/tg.elf"; then
+  "$OUT/tg.elf" | grep -q "GUM_STDLIB_OK" || { echo "FAIL: driver assertions"; fail=1; }
+else echo "FAIL: driver compile"; fail=1; fi
+
+echo "== consumer example =="
+if $SOUC compile examples/epistemic/gum_measurement_chain.sio -o "$OUT/chain.elf"; then
+  "$OUT/chain.elf" >/dev/null || { echo "FAIL: example run"; fail=1; }
+else echo "FAIL: example compile"; fail=1; fi
+
+echo "== regression: vancomycin (shares epistemic package) =="
+$SOUC check stdlib/clinical/vancomycin_pbpk.sio || { echo "REGRESSION"; fail=1; }
+
+[ $fail -eq 0 ] && echo "EPISTEMIC_GUM_GATE_OK"
+exit $fail
+```
+
+- [ ] **Step 2: Run it.**
+
+Run: `chmod +x scripts/epistemic_gum_gate.sh && bash scripts/epistemic_gum_gate.sh`
+Expected: ends with `EPISTEMIC_GUM_GATE_OK`, exit 0.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add scripts/epistemic_gum_gate.sh
+git commit -m "test(epistemic): compile-and-run gate for the GUM vertical"
+```
+
+---
+
+## Self-review
+- **Spec coverage:** import verify+document (Task 1), `gum_report` (Task 2), run-proof vs published value (Task 3), consumer example (Task 4), runnable gate + vancomycin regression (Task 5). All spec items mapped.
+- **`check`≠run enforced:** Tasks 1–5 each require `souc compile … && ./elf`, not just `check`.
+- **Compiler workarounds baked in:** wildcard imports; `print(f64)`/`println(f64)` not `print_f64`.
+- **No tolerance-retrofit:** Task 3 forbids loosening bounds and explains the correct `k95`/dof behaviour.
+- **Consistency:** symbol names (`gum_type_a/_b_uniform/_b_expanded`, `gum_combine2/3`, `gum_value/std_u/u95/k95/dof`, `gum_report`) match `gum.sio`'s verified surface.

--- a/docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md
@@ -1,0 +1,131 @@
+# Design — Harden the epistemic / GUM vertical
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-07-13
+**Constraint:** No compiler changes (Madaros owned by CODEX-2). All work in `stdlib/`, `examples/`, `tests/`, `scripts/`.
+**Orthography:** EN-UK.
+
+## 1. Why
+
+The prior "Data & Science I/O" lane was blocked at the compiler (file-I/O builtins broken —
+`docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md`). We pivoted to a lane that lives entirely
+inside the *verified* working surface of current Madaros: `print`/`print_f64` to stdout, the `string`
+primitive + `str_*` helpers, fixed-capacity slabs (no heap), structs + `impl`, and pure compute.
+
+Within that surface we harden **one** vertical to genuinely-usable depth: **GUM uncertainty**
+(ISO/IEC Guide 98-3) — Sounio's identity feature and dissertation-central (vancomycin PK, calibration).
+
+## 2. Verified starting state
+
+- `stdlib/epistemic/gum.sio` (417 lines) is green and implements GUM properly: `GUMComponent`
+  (Type-A `gum_type_a`, Type-B `gum_type_b`/`_uniform`/`_triangular`/`_expanded`, `gum_with_sensitivity`),
+  `GUMResult`, Welch–Satterthwaite effective dof (`ws2`), t-tables (`t95`/`t99`), combination
+  (`gum_combine2`/`gum_combine3`), propagation (`gum_add`/`sub`/`mul`/`div`/`scale`), and accessors
+  (`gum_value`/`gum_std_u`/`gum_u95`/`gum_u99`/`gum_dof`/`gum_k95`).
+- The GUM math **compiles to native ELF and runs correctly** (verified: a full Type-A + Type-B report,
+  rectangular variance a²/3 confirmed, expanded k=2).
+- **Importability (corrected 2026-07-13 by run-proof):** `epistemic::gum` **is already importable** via
+  the wildcard form — `use epistemic::gum::*` + `print(f64)` compiles to native ELF and runs (verified:
+  u_c = 0.290401, value 98.299999). The earlier "not importable" reading was a **misdiagnosis**: my probe
+  failed on the `print_f64` call and on a single-symbol import, not on the module import itself. The two
+  real defects are **compiler-side** (Madaros `run_check_mode`/visibility-preflight in `self-hosted/`,
+  off-limits), recorded as a dispatch (`docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md`):
+  1. **Single-symbol `use module::symbol`** fails `E137` even for already-`pub` symbols; **wildcard
+     `use module::*` works**. → *Workaround: always import GUM via `use epistemic::gum::*`.*
+  2. **`print_f64` in a 2+-module (importing) program** trips a spurious `E137`. The overloaded
+     **`print(f64)` / `println(f64)`** print floats correctly in importing programs (as green multi-module
+     `stdlib/clinical/vancomycin_pbpk.sio` does). → *Workaround: report with `print`/`println`, never
+     `print_f64`.*
+- Consequence today: every green GUM example (`examples/real_world/04_gum_measurement_*.sio`,
+  `examples/pbpk_gum_vs_montecarlo.sio`) **reinvents GUM inline** instead of reusing the stdlib — so the
+  reuse gap (not importability) is what this work closes.
+
+## 3. Goal
+
+A program can `use` the stdlib GUM module, build Type-A/Type-B components, combine and propagate through
+operations, and print a proper ISO-GUM report — all proven by **compile-and-run** with assertions
+against a **published** GUM value, plus a runnable gate and a dissertation-aligned example that consumes
+the stdlib rather than reinventing it.
+
+## 4. Scope
+
+### In
+1. **Importability — verify + document the working idiom** (revised): the module already imports via
+   `use epistemic::gum::*`. This item is now: prove import+run from a standalone in-repo program, and
+   record the two compiler-side workarounds (wildcard import; `print`/`println` not `print_f64`) in the
+   module header + dispatch. No `gum.sio` visibility edit is needed.
+2. **Run-proof driver** — exercises the full public API, asserts against a published GUM textbook result.
+3. **Formatted report** — a `gum_report(...)` that prints `y = value ± U (k=…, 95%), u_c=…, ν_eff=…`
+   to stdout (print-based; no `string` assembly, sidestepping the `Str`/`string` split).
+4. **Runnable gate** — compile+run the driver, assert exit 0 + numeric tolerances; wired like existing gates.
+5. **Consumer example** — a dissertation-aligned measurement chain that `use`s stdlib GUM.
+
+### Out
+- No fix to `knowledge.sio` (the older `Epistemic` struct path; fails check) — additive, leave it.
+- No file/stdin/argv I/O (compiler-blocked). Output is stdout only.
+- No new GUM theory; we expose and harden what exists. Missing ops added only if the run-proof needs them.
+- No compiler edits. The import path is already viable (wildcard) so no fallback is needed; the two
+  compiler defects found (single-symbol import, `print_f64` multi-module) are recorded as a dispatch, not
+  worked around in `self-hosted/`.
+
+## 5. Design
+
+### 5.1 Importability (item 1) — verify + document
+No stdlib fix required (import already works). Deliverable:
+- A standalone in-repo program does `use epistemic::gum::*`, calls the API, prints floats with
+  `print`/`println`, compiles to ELF and runs — committed as the run-proof driver (item 2).
+- The module header of `gum.sio` gains a short usage note: *import via `use epistemic::gum::*` (single-
+  symbol import is a compiler bug); print floats with `print`/`println`, not `print_f64`.*
+- The two compiler defects are captured in
+  `docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md` (dispatch for CODEX-2).
+
+### 5.2 Report (item 3)
+`gum_report(label: string, unit: string, r: GUMResult) with IO, Mut, Div, Panic` prints, using
+`print` (strings) and `print(f64)` for numbers — **never `print_f64`** (compiler bug in importing
+programs, §2):
+```
+<label> = <value> ± <U95> <unit>   (k = <k95>, 95%)
+    u_c = <std_u> <unit>,  ν_eff = <dof>
+```
+Pure stdout; no return string. Lives in `gum.sio` (so it's part of the importable surface).
+
+### 5.3 Run-proof (items 2, 4) — the oracle
+Assert against a **published** GUM result so "real" is externally defined (repo culture: cross-check vs an
+independent oracle). Chosen anchor: **ISO GUM (JCGM 100) Annex H.1** end-gauge calibration, OR the
+simpler documented calibration in `examples/real_world/04_gum_measurement_simple.sio` whose expected
+numbers (recovery 98.30, u_c 0.2939, U(k=2) 0.5878) we already reproduced at runtime. The driver computes
+via **stdlib** `gum_*` and asserts each within tolerance (e.g. |Δ| < 1e-3), returning non-zero on any miss.
+
+### 5.4 Consumer example (item 5)
+`examples/epistemic/gum_measurement_chain.sio` — a short, commented measurement chain (e.g. two Type-B
+sources + one Type-A, combined and scaled) that imports `epistemic::gum` and calls `gum_report`. Compiles,
+runs, prints a clean report. Demonstrates reuse (the anti-reinvention proof).
+
+## 6. Module layout
+```
+stdlib/epistemic/gum.sio                     (modify: helper visibility fix + gum_report)
+tests/stdlib/epistemic/test_gum_stdlib.sio   (new: run-proof driver w/ published-value asserts)
+examples/epistemic/gum_measurement_chain.sio (new: consumer example using stdlib gum)
+scripts/epistemic_gum_gate.sh                (new: compile+run gate)
+```
+
+## 7. Verification
+- `souc check stdlib/epistemic/gum.sio` → green (unchanged public API).
+- `souc compile tests/stdlib/epistemic/test_gum_stdlib.sio -o out && ./out` → exit 0, published values
+  matched within tolerance. **Compile-and-run, never `check` alone** (repo rule: `check:OK` ≠ works).
+- `scripts/epistemic_gum_gate.sh` → runs driver + example, both exit 0.
+- Regression: `souc check stdlib/clinical/vancomycin_pbpk.sio` still green (shares the epistemic package).
+
+## 8. Success criteria
+1. A standalone in-repo program `use`s `epistemic::gum`, runs as native ELF, and prints a correct GUM report.
+2. The run-proof asserts against a published GUM value and passes.
+3. `gum_report` produces the specified formatted output.
+4. The consumer example reuses stdlib GUM (no inline reinvention) and runs.
+5. No compiler files touched; vancomycin regression stays green.
+
+## 9. Risks
+| Risk | Mitigation |
+|---|---|
+| Import already works only via wildcard + `print`/`println` | Documented as the required idiom (§2, §5.1); single-symbol `use` and `print_f64` avoided; compiler bugs dispatched. |
+| `print_f64` formatting too coarse for tolerance asserts | Assert on the raw f64 accessors (`gum_value` etc.) in-program, not on printed text. |
+| Making helpers `pub` collides with names elsewhere in the epistemic package | Namespaced `gum_` prefixes already; check for collisions before publishing. |

--- a/docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design
+-->
+
 # Design — Harden the epistemic / GUM vertical
 
 **Status:** approved design, pre-implementation

--- a/examples/epistemic/gum_measurement_chain.sio
+++ b/examples/epistemic/gum_measurement_chain.sio
@@ -1,0 +1,18 @@
+// GUM measurement chain using the stdlib epistemic::gum module.
+// Two Type-B sources + one Type-A, combined per ISO GUM and reported.
+//
+// Import via wildcard; keep all logic inline in main (current Madaros
+// importing-program constraints — see the epistemic::gum module header).
+use epistemic::gum::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("=== GUM measurement chain (stdlib epistemic::gum) ===\n")
+
+    let u_ref = gum_type_b_expanded(0.5, 2.0)   // certificate ±0.5% expanded, k=2
+    let u_res = gum_type_b_uniform(0.05)         // resolution, rectangular half-width 0.05
+    let u_rep = gum_type_a(0.12, 8)              // repeatability, s=0.12 over n=8
+
+    let r = gum_combine3(99.4, u_ref, u_res, u_rep)
+    gum_report("assay", "%", r)
+    return 0
+}

--- a/scripts/epistemic_gum_gate.sh
+++ b/scripts/epistemic_gum_gate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+# NOTE: gum.sio's own embedded self-test segfaults at runtime on Madaros v0.80.0
+# (pre-existing; see docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md, Defect 4).
+# We therefore verify the module via the importing run-proof driver below, not by running gum.sio.
+echo "== check gum.sio =="
+$SOUC check stdlib/epistemic/gum.sio || fail=1
+
+echo "== run-proof driver =="
+if $SOUC compile tests/stdlib/epistemic/test_gum_stdlib.sio -o "$OUT/tg.elf"; then
+  "$OUT/tg.elf" | grep -q "GUM_STDLIB_OK" || { echo "FAIL: driver assertions"; fail=1; }
+else echo "FAIL: driver compile"; fail=1; fi
+
+echo "== consumer example =="
+if $SOUC compile examples/epistemic/gum_measurement_chain.sio -o "$OUT/chain.elf"; then
+  "$OUT/chain.elf" >/dev/null || { echo "FAIL: example run"; fail=1; }
+else echo "FAIL: example compile"; fail=1; fi
+
+echo "== regression: vancomycin (shares epistemic package) =="
+$SOUC check stdlib/clinical/vancomycin_pbpk.sio || { echo "REGRESSION"; fail=1; }
+
+[ $fail -eq 0 ] && echo "EPISTEMIC_GUM_GATE_OK"
+exit $fail

--- a/scripts/epistemic_gum_gate.sh
+++ b/scripts/epistemic_gum_gate.sh
@@ -13,10 +13,15 @@ fail=0
 echo "== check gum.sio =="
 $SOUC check stdlib/epistemic/gum.sio || fail=1
 
-echo "== run-proof driver =="
+echo "== run-proof driver (combine + report) =="
 if $SOUC compile tests/stdlib/epistemic/test_gum_stdlib.sio -o "$OUT/tg.elf"; then
   "$OUT/tg.elf" | grep -q "GUM_STDLIB_OK" || { echo "FAIL: driver assertions"; fail=1; }
 else echo "FAIL: driver compile"; fail=1; fi
+
+echo "== run-proof ops (add/sub/mul/div/scale, triangular, sensitivity, u99) =="
+if $SOUC compile tests/stdlib/epistemic/test_gum_ops.sio -o "$OUT/ops.elf"; then
+  "$OUT/ops.elf" | grep -q "GUM_OPS_OK" || { echo "FAIL: ops assertions"; fail=1; }
+else echo "FAIL: ops compile"; fail=1; fi
 
 echo "== consumer example =="
 if $SOUC compile examples/epistemic/gum_measurement_chain.sio -o "$OUT/chain.elf"; then

--- a/stdlib/epistemic/gum.sio
+++ b/stdlib/epistemic/gum.sio
@@ -11,6 +11,10 @@
 //   - Expanded uncertainty at 95% and 99% confidence
 //
 // Reference: JCGM 100:2008 (GUM)
+//
+// USAGE: import with `use epistemic::gum::*` (single-symbol `use epistemic::gum::name`
+// currently fails to resolve — Madaros bug, docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md).
+// Print floats with print(x)/println(x); do NOT use print_f64 in an importing program.
 
 // ============================================================================
 // HELPERS
@@ -250,6 +254,27 @@ pub fn gum_u95(r: GUMResult) -> f64 { r.u95 }
 pub fn gum_u99(r: GUMResult) -> f64 { r.u99 }
 pub fn gum_dof(r: GUMResult) -> f64 { r.dof }
 pub fn gum_k95(r: GUMResult) -> f64 { r.k95 }
+
+// Formatted ISO-GUM report to stdout. Floats print via print(f64) (never print_f64
+// in importing programs — Madaros bug, see module header).
+pub fn gum_report(label: string, unit: string, r: GUMResult) with IO, Mut, Div, Panic {
+    print(label)
+    print(" = ")
+    print(gum_value(r))
+    print(" ± ")
+    print(gum_u95(r))
+    print(" ")
+    print(unit)
+    print("   (k = ")
+    print(gum_k95(r))
+    print(", 95%)\n    u_c = ")
+    print(gum_std_u(r))
+    print(" ")
+    print(unit)
+    print(",  nu_eff = ")
+    print(gum_dof(r))
+    print("\n")
+}
 
 pub fn gum_rel_uncertainty(r: GUMResult) -> f64 with Div, Panic {
     if gum_abs(r.value) < 1.0e-15 { return 0.0 }

--- a/tests/stdlib/epistemic/test_gum_ops.sio
+++ b/tests/stdlib/epistemic/test_gum_ops.sio
@@ -1,0 +1,76 @@
+// Next-increment run-proof: assert the GUM ops/components previously importable-but-unasserted.
+// First-principles expected values (all inputs via gum_simple -> dof = 1e9 -> k95=1.96, k99=2.576):
+//   r1 = (3.0, u=0.4), r2 = (5.0, u=0.3)
+//   add : 8.0,  u_c = sqrt(0.16+0.09)          = 0.5      ; u95=1.96*0.5=0.98 ; u99=2.576*0.5=1.288
+//   sub : -2.0, u_c = 0.5
+//   mul : 15.0, u_c = sqrt((5*0.4)^2+(3*0.3)^2) = sqrt(4.81) = 2.193171
+//   div : 0.6,  u_c = sqrt((0.4/5)^2+(3*0.3/25)^2) = sqrt(0.007696) = 0.0877268
+//   scale(r1,2): 6.0, u_c = 2*0.4 = 0.8
+//   u99(r1) = 2.576*0.4 = 1.0304 ; u95(r1) = 1.96*0.4 = 0.784
+//   triangular(0.6): u = 0.6/sqrt(6) = 0.2449490 (checked via combine2 with a zero Type-B)
+//   with_sensitivity(type_b(0.2), 3.0): contribution 3*0.2 = 0.6 (checked via combine2)
+//
+// Importing-program constraints: wildcard import, all logic inlined into main, print()/println() only.
+use epistemic::gum::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let r1 = gum_simple(3.0, 0.4)
+    let r2 = gum_simple(5.0, 0.3)
+
+    // add
+    let a = gum_add(r1, r2)
+    let dav = if gum_value(a) > 8.0 { gum_value(a) - 8.0 } else { 8.0 - gum_value(a) }
+    if dav >= 1.0e-6 { print("FAIL add value\n"); return 1 }
+    let dau = if gum_std_u(a) > 0.5 { gum_std_u(a) - 0.5 } else { 0.5 - gum_std_u(a) }
+    if dau >= 1.0e-6 { print("FAIL add u_c\n"); return 2 }
+    let da95 = if gum_u95(a) > 0.98 { gum_u95(a) - 0.98 } else { 0.98 - gum_u95(a) }
+    if da95 >= 1.0e-6 { print("FAIL add u95\n"); return 3 }
+
+    // sub
+    let s = gum_sub(r1, r2)
+    let sb = 0.0 - 2.0
+    let dsv = if gum_value(s) > sb { gum_value(s) - sb } else { sb - gum_value(s) }
+    if dsv >= 1.0e-6 { print("FAIL sub value\n"); return 4 }
+    let dsu = if gum_std_u(s) > 0.5 { gum_std_u(s) - 0.5 } else { 0.5 - gum_std_u(s) }
+    if dsu >= 1.0e-6 { print("FAIL sub u_c\n"); return 5 }
+
+    // mul
+    let m = gum_mul(r1, r2)
+    let dmv = if gum_value(m) > 15.0 { gum_value(m) - 15.0 } else { 15.0 - gum_value(m) }
+    if dmv >= 1.0e-6 { print("FAIL mul value\n"); return 6 }
+    let dmu = if gum_std_u(m) > 2.193171 { gum_std_u(m) - 2.193171 } else { 2.193171 - gum_std_u(m) }
+    if dmu >= 1.0e-5 { print("FAIL mul u_c\n"); return 7 }
+
+    // div
+    let dv = gum_div(r1, r2)
+    let ddv = if gum_value(dv) > 0.6 { gum_value(dv) - 0.6 } else { 0.6 - gum_value(dv) }
+    if ddv >= 1.0e-6 { print("FAIL div value\n"); return 8 }
+    let ddu = if gum_std_u(dv) > 0.0877268 { gum_std_u(dv) - 0.0877268 } else { 0.0877268 - gum_std_u(dv) }
+    if ddu >= 1.0e-6 { print("FAIL div u_c\n"); return 9 }
+
+    // scale
+    let sc = gum_scale(r1, 2.0)
+    let dcv = if gum_value(sc) > 6.0 { gum_value(sc) - 6.0 } else { 6.0 - gum_value(sc) }
+    if dcv >= 1.0e-6 { print("FAIL scale value\n"); return 10 }
+    let dcu = if gum_std_u(sc) > 0.8 { gum_std_u(sc) - 0.8 } else { 0.8 - gum_std_u(sc) }
+    if dcu >= 1.0e-6 { print("FAIL scale u_c\n"); return 11 }
+
+    // u99 / u95 accessors on r1
+    let du99 = if gum_u99(r1) > 1.0304 { gum_u99(r1) - 1.0304 } else { 1.0304 - gum_u99(r1) }
+    if du99 >= 1.0e-4 { print("FAIL u99\n"); return 12 }
+    let du95 = if gum_u95(r1) > 0.784 { gum_u95(r1) - 0.784 } else { 0.784 - gum_u95(r1) }
+    if du95 >= 1.0e-4 { print("FAIL u95\n"); return 13 }
+
+    // triangular: u = 0.6/sqrt(6) = 0.2449490 (combine with a zero Type-B)
+    let tri = gum_combine2(10.0, gum_type_b_triangular(0.6), gum_type_b(0.0))
+    let dtri = if gum_std_u(tri) > 0.2449490 { gum_std_u(tri) - 0.2449490 } else { 0.2449490 - gum_std_u(tri) }
+    if dtri >= 1.0e-5 { print("FAIL triangular\n"); return 14 }
+
+    // with_sensitivity: 3.0 * 0.2 = 0.6
+    let sens = gum_combine2(10.0, gum_with_sensitivity(gum_type_b(0.2), 3.0), gum_type_b(0.0))
+    let dsens = if gum_std_u(sens) > 0.6 { gum_std_u(sens) - 0.6 } else { 0.6 - gum_std_u(sens) }
+    if dsens >= 1.0e-6 { print("FAIL with_sensitivity\n"); return 15 }
+
+    print("GUM_OPS_OK\n")
+    return 0
+}

--- a/tests/stdlib/epistemic/test_gum_stdlib.sio
+++ b/tests/stdlib/epistemic/test_gum_stdlib.sio
@@ -1,0 +1,39 @@
+// Run-proof for stdlib epistemic::gum, checked against first-principles ISO-GUM values.
+//
+// Components:
+//   Type-A: gum_type_a(0.070710, 5) -> u_A = 0.070710 / sqrt(5) = 0.0316227, nu_A = 4
+//   Type-B: gum_type_b_uniform(0.5) -> u_B = 0.5 / sqrt(3)       = 0.2886751, nu_B = inf
+// Combined (RSS, unit sensitivities):
+//   u_c    = sqrt(u_A^2 + u_B^2) = sqrt(0.001 + 0.0833333) = 0.2904020
+//   nu_eff (Welch-Satterthwaite) ~= 28449  ->  t95 ~= 1.960
+//   U95    = k95 * u_c ~= 1.960 * 0.2904020 = 0.569188
+//
+// NOTE: importing programs on current Madaros must inline all logic into main()
+// (no user helper fns, no print_f64) — see docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md
+use epistemic::gum::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ub = gum_type_b_uniform(0.5)
+    let ua = gum_type_a(0.070710, 5)
+    let r = gum_combine2(98.3, ua, ub)
+
+    let v = gum_value(r)
+    let dv = if v > 98.3 { v - 98.3 } else { 98.3 - v }
+    if dv >= 1.0e-6 { print("FAIL value\n"); return 1 }
+
+    let uc = gum_std_u(r)
+    let duc = if uc > 0.290402 { uc - 0.290402 } else { 0.290402 - uc }
+    if duc >= 1.0e-4 { print("FAIL u_c\n"); return 2 }
+
+    let k = gum_k95(r)
+    let dk = if k > 1.960 { k - 1.960 } else { 1.960 - k }
+    if dk >= 1.0e-2 { print("FAIL k95\n"); return 3 }
+
+    let u95 = gum_u95(r)
+    let du = if u95 > 0.569188 { u95 - 0.569188 } else { 0.569188 - u95 }
+    if du >= 1.0e-3 { print("FAIL U95\n"); return 4 }
+
+    gum_report("recovery", "%", r)
+    print("GUM_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Harden the epistemic / GUM vertical (importable, run-proven, gated)

Makes Sounio's identity feature — **ISO-GUM uncertainty propagation** — genuinely *reusable* rather than reinvented inline in every example. Lives entirely inside the current compiler's verified working surface (stdout + pure compute + fixed slabs). **No compiler changes.**

### What's here
- **`gum_report`** (`stdlib/epistemic/gum.sio`) — formatted stdout report: `y = value ± U (k, 95%), u_c, ν_eff`.
- **Run-proof driver** (`tests/stdlib/epistemic/test_gum_stdlib.sio`) — imports the stdlib module and asserts against **first-principles ISO-GUM values** (rectangular a/√3, Type-A s/√n, RSS, Welch–Satterthwaite). Passes at exit 0.
- **Consumer example** (`examples/epistemic/gum_measurement_chain.sio`) — a 3-component chain using stdlib GUM.
- **Gate** (`scripts/epistemic_gum_gate.sh`) → `EPISTEMIC_GUM_GATE_OK`.

### Verification
Every claim is `souc compile … -o out && ./out`, not `check` (on current Madaros `check:OK` ≠ runs). The gate was re-run against **main's stdlib and compiler** and passes.

### Honest scope (not hidden gaps)
- **Proven surface:** Type-A/B + `combine2`/`combine3` + `gum_report`. `gum_add/sub/mul/div/scale`, triangular, sensitivity, `u99` are importable but **unasserted** (one test each is the next increment).
- **Number formatting** is raw `print(f64)` (`98.299999`) — layout is clean, decimal control is future work (needs the `Str` path).
- **`gum.sio`'s own embedded self-test segfaults at runtime** — verified **pre-existing** (byte-identical before/after these edits); the module is verified via the importing driver instead.

### Companion PR
Depends conceptually on the compiler-blocker dispatches in #859 (the header comment references that audit doc). The three multi-module quirks worked around here are filed there for CODEX-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
