### PR TITLE
ci: declare Madaros changed-test stack contract

### DIFF
--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -52,17 +52,6 @@ if [[ "$SELECT_ONLY" == "1" ]]; then
   exit 0
 fi
 
-if ((${#selected[@]} == 0)); then
-  echo 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests'
-  exit 0
-fi
-
-[[ -n "$MADAROS_BIN" ]] || fail "missing_explicit_madaros_bin"
-[[ "$MADAROS_BIN" == /* ]] || fail "madaros_bin_must_be_absolute"
-[[ -f "$MADAROS_BIN" && -r "$MADAROS_BIN" && -x "$MADAROS_BIN" ]] \
-  || fail "madaros_bin_not_executable"
-[[ "$(head -c 2 "$MADAROS_BIN" 2>/dev/null)" != '#!' ]] || fail "madaros_bin_is_wrapper"
-
 # This gate is wired to the Linux current-source CI job. Darwin's common
 # 65532 KiB ceiling is intentionally not normalized into this Linux contract.
 stack_kb="${SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB:-65536}"
@@ -108,6 +97,17 @@ if [[ "$stack_soft_after" != "unlimited" ]] && ((stack_soft_after < stack_kb)); 
   fail "stack_raise_not_effective"
 fi
 echo "MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=$stack_kb soft_before_kb=$stack_soft_before hard_before_kb=$stack_hard_before soft_after_kb=$stack_soft_after hard_after_kb=$stack_hard_after"
+
+if ((${#selected[@]} == 0)); then
+  echo 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests'
+  exit 0
+fi
+
+[[ -n "$MADAROS_BIN" ]] || fail "missing_explicit_madaros_bin"
+[[ "$MADAROS_BIN" == /* ]] || fail "madaros_bin_must_be_absolute"
+[[ -f "$MADAROS_BIN" && -r "$MADAROS_BIN" && -x "$MADAROS_BIN" ]] \
+  || fail "madaros_bin_not_executable"
+[[ "$(head -c 2 "$MADAROS_BIN" 2>/dev/null)" != '#!' ]] || fail "madaros_bin_is_wrapper"
 
 set +e
 identity="$("$MADAROS_BIN" --version 2>&1)"

--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -63,6 +63,52 @@ fi
   || fail "madaros_bin_not_executable"
 [[ "$(head -c 2 "$MADAROS_BIN" 2>/dev/null)" != '#!' ]] || fail "madaros_bin_is_wrapper"
 
+# This gate is wired to the Linux current-source CI job. Darwin's common
+# 65532 KiB ceiling is intentionally not normalized into this Linux contract.
+stack_kb="${SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB:-65536}"
+[[ "$stack_kb" =~ ^[1-9][0-9]*$ && ${#stack_kb} -le 9 ]] \
+  || fail "invalid_stack_kb"
+
+if ! stack_soft_before="$(ulimit -S -s 2>/dev/null)"; then
+  fail "stack_soft_limit_unavailable"
+fi
+if ! stack_hard_before="$(ulimit -H -s 2>/dev/null)"; then
+  fail "stack_hard_limit_unavailable"
+fi
+[[ "$stack_soft_before" == "unlimited" || "$stack_soft_before" =~ ^[0-9]+$ ]] \
+  || fail "invalid_stack_soft_limit"
+[[ "$stack_hard_before" == "unlimited" || "$stack_hard_before" =~ ^[0-9]+$ ]] \
+  || fail "invalid_stack_hard_limit"
+
+if [[ "$stack_soft_before" != "unlimited" ]] && ((stack_soft_before < stack_kb)); then
+  if [[ "$stack_hard_before" != "unlimited" ]] && ((stack_hard_before < stack_kb)); then
+    echo "MADAROS_CHANGED_TESTS_STACK status=blocked scope=linux_ci requested_kb=$stack_kb soft_before_kb=$stack_soft_before hard_before_kb=$stack_hard_before soft_after_kb=$stack_soft_before hard_after_kb=$stack_hard_before"
+    fail "stack_hard_limit_too_low"
+  fi
+  if ! ulimit -S -s "$stack_kb" 2>/dev/null; then
+    stack_soft_after="$(ulimit -S -s 2>/dev/null || echo unavailable)"
+    stack_hard_after="$(ulimit -H -s 2>/dev/null || echo unavailable)"
+    echo "MADAROS_CHANGED_TESTS_STACK status=blocked scope=linux_ci requested_kb=$stack_kb soft_before_kb=$stack_soft_before hard_before_kb=$stack_hard_before soft_after_kb=$stack_soft_after hard_after_kb=$stack_hard_after"
+    fail "stack_raise_failed"
+  fi
+fi
+
+if ! stack_soft_after="$(ulimit -S -s 2>/dev/null)"; then
+  fail "stack_soft_limit_after_unavailable"
+fi
+if ! stack_hard_after="$(ulimit -H -s 2>/dev/null)"; then
+  fail "stack_hard_limit_after_unavailable"
+fi
+[[ "$stack_soft_after" == "unlimited" || "$stack_soft_after" =~ ^[0-9]+$ ]] \
+  || fail "invalid_stack_soft_limit_after"
+[[ "$stack_hard_after" == "unlimited" || "$stack_hard_after" =~ ^[0-9]+$ ]] \
+  || fail "invalid_stack_hard_limit_after"
+if [[ "$stack_soft_after" != "unlimited" ]] && ((stack_soft_after < stack_kb)); then
+  echo "MADAROS_CHANGED_TESTS_STACK status=blocked scope=linux_ci requested_kb=$stack_kb soft_before_kb=$stack_soft_before hard_before_kb=$stack_hard_before soft_after_kb=$stack_soft_after hard_after_kb=$stack_hard_after"
+  fail "stack_raise_not_effective"
+fi
+echo "MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=$stack_kb soft_before_kb=$stack_soft_before hard_before_kb=$stack_hard_before soft_after_kb=$stack_soft_after hard_after_kb=$stack_hard_after"
+
 set +e
 identity="$("$MADAROS_BIN" --version 2>&1)"
 identity_rc=$?

--- a/scripts/ci/madaros_changed_tests_selftest.sh
+++ b/scripts/ci/madaros_changed_tests_selftest.sh
@@ -7,12 +7,16 @@ GATE="$ROOT_DIR/scripts/ci/madaros_changed_tests_gate.sh"
 
 bash -n "$GATE"
 
-selected="$($GATE --select-only \
+selected="$(SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=0 "$GATE" --select-only \
   tests/run-pass/array_repeat_i8_binding.sio \
   tests/run-pass/generic_struct_return.sio \
   docs/internal/coordination/CI_WATCH_CONTRACT.md)"
 
 grep -Fxq 'tests/run-pass/array_repeat_i8_binding.sio' <<<"$selected"
+if grep -Fq 'MADAROS_CHANGED_TESTS_STACK' <<<"$selected"; then
+  echo 'madaros-changed-tests: select-only emitted a stack receipt' >&2
+  exit 1
+fi
 if grep -Fq 'generic_struct_return.sio' <<<"$selected"; then
   echo 'madaros-changed-tests: selected an unannotated test' >&2
   exit 1
@@ -22,11 +26,29 @@ if grep -Fq 'CI_WATCH_CONTRACT.md' <<<"$selected"; then
   exit 1
 fi
 
-non_pr_selected="$(CI_EVENT_NAME=push "$GATE" --select-only)"
+non_pr_selected="$(
+  CI_EVENT_NAME=push \
+  SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=0 \
+    "$GATE" --select-only
+)"
 grep -Fxq 'tests/run-pass/array_repeat_i8_binding.sio' <<<"$non_pr_selected"
+if grep -Fq 'MADAROS_CHANGED_TESTS_STACK' <<<"$non_pr_selected"; then
+  echo 'madaros-changed-tests: non-PR select-only emitted a stack receipt' >&2
+  exit 1
+fi
 
-skip="$($GATE -- docs/internal/coordination/CI_WATCH_CONTRACT.md)"
+skip="$(
+  (
+    ulimit -S -s 8192
+    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=65536 \
+      "$GATE" -- docs/internal/coordination/CI_WATCH_CONTRACT.md
+  )
+)"
+grep -Eq '^MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=65536 soft_before_kb=8192 hard_before_kb=(unlimited|[0-9]+) soft_after_kb=65536 hard_after_kb=(unlimited|[0-9]+)$' \
+  <<<"$skip"
 grep -Fxq 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests' <<<"$skip"
+grep -Fxq 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests' \
+  < <(tail -n 1 <<<"$skip")
 
 set +e
 missing_bin="$(

--- a/scripts/ci/madaros_changed_tests_selftest.sh
+++ b/scripts/ci/madaros_changed_tests_selftest.sh
@@ -68,6 +68,77 @@ fi
 grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=madaros_identity_banner_missing' \
   <<<"$wrong_binary"
 
+for invalid_stack_kb in 0 999999999999999999999999999; do
+  set +e
+  invalid_stack="$(
+    SOUNIO_MADAROS_CHANGED_TESTS_BIN=/bin/true \
+    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB="$invalid_stack_kb" \
+      "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio 2>&1
+  )"
+  invalid_stack_rc=$?
+  set -e
+  if [[ "$invalid_stack_rc" == "0" ]]; then
+    echo "madaros-changed-tests: accepted invalid stack override: $invalid_stack_kb" >&2
+    exit 1
+  fi
+  grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=invalid_stack_kb' <<<"$invalid_stack"
+done
+
+set +e
+raised_stack="$(
+  (
+    ulimit -S -s 8192
+    SOUNIO_MADAROS_CHANGED_TESTS_BIN=/bin/true \
+    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=65536 \
+      "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio
+  ) 2>&1
+)"
+raised_stack_rc=$?
+set -e
+if [[ "$raised_stack_rc" == "0" ]]; then
+  echo 'madaros-changed-tests: accepted a non-Madaros ELF after raising stack' >&2
+  exit 1
+fi
+raised_stack_receipt="$(grep -F 'MADAROS_CHANGED_TESTS_STACK status=ready' <<<"$raised_stack")"
+ready_stack_pattern='^MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=65536 soft_before_kb=8192 hard_before_kb=(unlimited|[0-9]+) soft_after_kb=65536 hard_after_kb=(unlimited|[0-9]+)$'
+if [[ ! "$raised_stack_receipt" =~ $ready_stack_pattern ]]; then
+  echo 'madaros-changed-tests: stack raise receipt is malformed' >&2
+  exit 1
+fi
+raised_hard_before="${BASH_REMATCH[1]}"
+raised_hard_after="${BASH_REMATCH[2]}"
+if [[ "$raised_hard_before" != "$raised_hard_after" ]]; then
+  echo 'madaros-changed-tests: stack raise changed the hard limit' >&2
+  exit 1
+fi
+if [[ "$raised_hard_before" != "unlimited" ]] && ((raised_hard_before < 65536)); then
+  echo 'madaros-changed-tests: stack raise passed below the finite hard limit' >&2
+  exit 1
+fi
+grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=madaros_identity_banner_missing' \
+  < <(tail -n 1 <<<"$raised_stack")
+
+set +e
+hard_limited_stack="$(
+  (
+    ulimit -S -s 8192
+    ulimit -H -s 8192
+    SOUNIO_MADAROS_CHANGED_TESTS_BIN=/bin/true \
+    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=65536 \
+      "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio
+  ) 2>&1
+)"
+hard_limited_stack_rc=$?
+set -e
+if [[ "$hard_limited_stack_rc" == "0" ]]; then
+  echo 'madaros-changed-tests: accepted a stack target above the hard limit' >&2
+  exit 1
+fi
+grep -Fq 'MADAROS_CHANGED_TESTS_STACK status=blocked scope=linux_ci requested_kb=65536 soft_before_kb=8192 hard_before_kb=8192' \
+  <<<"$hard_limited_stack"
+grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=stack_hard_limit_too_low' \
+  < <(tail -n 1 <<<"$hard_limited_stack")
+
 set +e
 bad_diff="$(
   CI_EVENT_NAME=pull_request \


### PR DESCRIPTION
## Summary

- establish a Linux CI stack contract of 65536 KiB before the changed-tests gate invokes Madaros
- validate the optional `SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB` override before Bash arithmetic
- emit explicit ready/blocked receipts with requested, soft, and hard limits before and after the raise
- cover invalid/overflowing overrides, successful raises, finite sufficient hard limits, and insufficient hard limits

## Why

The changed current-source Madaros tests currently inherit GitHub Linux's 8192 KiB soft stack limit. The compiler's measured stack floor is higher even on unchanged controls: the base and PR compilers showed the same thresholds, with `array_repeat_i8_binding` requiring at least 12288 KiB, generic basic inference at least 16384 KiB, and generic return inference roughly 28672-32768 KiB.

That makes 8192 KiB a CI execution-environment failure, not evidence of a semantic regression. This PR makes the prerequisite executable and observable.

The contract is intentionally scoped to `linux_ci`. It does not add the separate per-test diagnostic preflight.

## Proof

- `bash -n scripts/ci/madaros_changed_tests_gate.sh scripts/ci/madaros_changed_tests_selftest.sh`
- `bash scripts/ci/madaros_changed_tests_selftest.sh`
- selftest repeated under finite hard limits 65536, 65537, and 131072 KiB
- `bash scripts/dev/check_workflow_script_refs.sh` (70 references)
- `bash scripts/ci/impact_ci_selftest.sh`
- `git diff --check origin/main...HEAD`
- real Madaros gate run inherited `soft_before_kb=8192`, raised to `soft_after_kb=65536`, and passed `array_repeat_i8_binding` 1/1

Reviewed read-only after the finite-hard-limit selftest fix: clean, no actionable findings.