### PR TITLE
feat(stats): multiple-comparison corrections + permutation test (+2 modules)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2647,3 +2647,9 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - **diagnostic = PASS**: sens/spec/PPV/NPV/LR±/accuracy/Youden, Wilson CIs. "No errors or leaps."
 - **roc = PASS**: AUC=(wins+0.5·ties)/(n_pos·n_neg), Hanley-McNeil q1/q2/variance, CI clipping, roc_point TPR/FPR. "All verified."
 - **cohen_kappa = PASS on formulas** (κ=(po-pe)/(1-pe), weighted linear/quadratic, Landis-Koch). One **[TIGHTENABLE] was a legitimate caveat** (unlike the previous two reviewer false-flags): the Fleiss SE is exact for unweighted kappa but only approximate for weighted — documented in the module and the weighted fn doc; the kappa value itself is exact for both.
+
+## 2026-07-13 — math-review: multiple_comparisons + permutation
+- Files: `stdlib/stats/{multiple_comparisons,permutation}.sio` (new, library modules). Provider: xAI/Grok 4.3 = **PASS** both.
+- multiple_comparisons: Bonferroni min(1,m·p), Holm max-form, BH-FDR min-form, O(m²) rank enumeration — all verified.
+- permutation: two-sample |mean diff| test, p=(count+1)/(iters+1), Fisher-Yates, two-sided abs counting, inline LCG — verified.
+- Both hit the #852 codegen crash for in-module test harnesses; shipped as libraries validated by external examples/stats/*_test.sio (bonf=1 holm=1 bh=5; sep_significant=1 null_notsig=1). Functions structured to avoid #852 (no big callee arrays, inlined loops).

--- a/examples/stats/multiple_comparisons_test.sio
+++ b/examples/stats/multiple_comparisons_test.sio
@@ -1,0 +1,15 @@
+//@ run-pass
+//@ expect-stdout: bonf=1 holm=1 bh=5
+// Validation for stats::multiple_comparisons (kept external: an in-module test
+// harness triggers the #852 codegen crash). p = 0.01..0.05 -> Bonferroni & Holm
+// reject 1, Benjamini-Hochberg rejects all 5.
+use stats::multiple_comparisons::{bonferroni, holm, bh_fdr}
+fn main() with IO, Mut, Div, Panic {
+    var p: [f64; 64] = [0.0; 64]
+    var adj: [f64; 64] = [0.0; 64]
+    p[0]=0.01; p[1]=0.02; p[2]=0.03; p[3]=0.04; p[4]=0.05
+    let nb = bonferroni(&p, 5, 0.05, &!adj)
+    let nh = holm(&p, 5, 0.05, &!adj)
+    let nf = bh_fdr(&p, 5, 0.05, &!adj)
+    print("bonf="); print(nb); print(" holm="); print(nh); print(" bh="); print(nf); print("\n")
+}

--- a/examples/stats/permutation_test.sio
+++ b/examples/stats/permutation_test.sio
@@ -1,0 +1,24 @@
+//@ run-pass
+//@ expect-stdout: sep_significant=1 null_notsig=1
+// Validation for stats::permutation. Separated groups -> small p (<0.05);
+// identical-location groups -> large p (>0.2). Deterministic (fixed seed).
+use stats::permutation::{perm_test_means}
+fn main() with IO, Mut, Div, Panic {
+    var a: [f64; 256] = [0.0; 256]
+    var b: [f64; 256] = [0.0; 256]
+    // well-separated: a around 1, b around 5
+    a[0]=1.0; a[1]=1.5; a[2]=0.8; a[3]=1.2; a[4]=1.1
+    b[0]=5.0; b[1]=5.5; b[2]=4.8; b[3]=5.2; b[4]=5.1
+    let p_sep = perm_test_means(&a, 5, &b, 5, 500, 42)
+    // overlapping: c and d same location
+    var c: [f64; 256] = [0.0; 256]
+    var d: [f64; 256] = [0.0; 256]
+    c[0]=3.0; c[1]=3.5; c[2]=2.8; c[3]=3.2; c[4]=3.1
+    d[0]=3.1; d[1]=2.9; d[2]=3.3; d[3]=2.7; d[4]=3.0
+    let p_null = perm_test_means(&c, 5, &d, 5, 500, 42)
+    var sep_sig = 0
+    if p_sep < 0.05 { sep_sig = 1 }
+    var null_ns = 0
+    if p_null > 0.2 { null_ns = 1 }
+    print("sep_significant="); print(sep_sig); print(" null_notsig="); print(null_ns); print("\n")
+}

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -43,7 +43,8 @@ for m in "${MODULES[@]}"; do
 done
 
 # Smoke-run the integration demo (exit 0 = every tool composed cleanly).
-for demo in examples/stats/epistemic_suite_demo.sio examples/stats/full_analysis_report.sio; do
+for demo in examples/stats/epistemic_suite_demo.sio examples/stats/full_analysis_report.sio \
+            examples/stats/multiple_comparisons_test.sio examples/stats/permutation_test.sio; do
   if "$SOUC" run "$demo" >/dev/null 2>&1; then
     printf '  [PASS] %s\n' "$demo"
   else

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -393,6 +393,33 @@ computed exactly by pairwise concordance; SE by Hanley & McNeil (1982), CI clipp
 to [0,1]. `roc_point` gives one (TPR, FPR) operating point. Validated: AUC 0.75 on
 the classic 4-point example; perfect separation → 1; a tied pair → 0.5.
 
+### `stats::multiple_comparisons` — p-value adjustment
+
+| Function | Signature |
+|---|---|
+| `bonferroni` | `pub fn bonferroni(p: &[f64; 64], m: i32, alpha: f64, out_adj: &![f64; 64]) -> i64 with Mut, Div, Panic` |
+| `holm` | `pub fn holm(p: &[f64; 64], m: i32, alpha: f64, out_adj: &![f64; 64]) -> i64 with Mut, Div, Panic` |
+| `bh_fdr` | `pub fn bh_fdr(p: &[f64; 64], m: i32, alpha: f64, out_adj: &![f64; 64]) -> i64 with Mut, Div, Panic` |
+
+Adjust m raw p-values for multiple testing (writes adjusted p into `out_adj` in the
+same order, returns the count rejected at `alpha`): Bonferroni and Holm control the
+FWER, Benjamini-Hochberg the FDR. Validated: p=0.01..0.05 → Bonferroni/Holm reject
+1, BH rejects all 5. (Library module — validation in `examples/stats/`.)
+
+### `stats::permutation` — two-sample permutation test
+
+`pub fn perm_test_means(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, iters: i32, seed: i64) -> f64 with Mut, Div, Panic`
+— distribution-free test of a location difference: p = (1 + #{|Δ*|≥|Δ_obs|})/(iters+1)
+over `iters` random relabellings (inline LCG, deterministic in `seed`). The mean
+bootstrap CI already lives in `stats::epistemic::bootstrap`. Validated: separated
+groups → p<0.05; identical → p>0.2.
+
+> **Codegen caveat (#852):** these two are library modules with external tests
+> (`examples/stats/*_test.sio`) rather than inline `main` tests — a routine with
+> big local arrays, or an in-module test harness making many nested calls while
+> arrays are live, triggers a silent native-codegen crash. The public functions
+> are structured around it (no big callee arrays; inlined loops).
+
 ## Importing
 
 Import each tool directly from its module:

--- a/stdlib/stats/multiple_comparisons.sio
+++ b/stdlib/stats/multiple_comparisons.sio
@@ -1,0 +1,102 @@
+
+// stdlib/stats/multiple_comparisons.sio — p-value adjustment for multiple tests
+//
+// When many hypotheses are tested at once the family-wise error inflates. These
+// procedures adjust the p-values (and count rejections at a level alpha):
+//
+//   bonferroni(p, m, alpha, out_adj)   -> n_rejected   (FWER, most conservative)
+//   holm(p, m, alpha, out_adj)         -> n_rejected   (FWER, step-down, uniformly better)
+//   bh_fdr(p, m, alpha, out_adj)       -> n_rejected   (FDR, Benjamini-Hochberg)
+//
+//   Bonferroni:  p_adj = min(1, m·p).
+//   Holm (step-down):  sort ascending, p_adj_(i) = max_{j<=i} min(1, (m-j+1)·p_(j)).
+//   BH (step-up FDR):  sort ascending, p_adj_(i) = min_{j>=i} min(1, (m/j)·p_(j)).
+//
+// `p` holds the m raw p-values; `out_adj` receives the adjusted p-values in the
+// SAME order (m <= 256). Only the existing stdlib piece is
+// stats::multiple_testing::holm_bonferroni; this adds Bonferroni and BH-FDR and a
+// consistent trio.
+//
+// Pure Sounio, no external dependency.
+//
+// References:
+//   Bonferroni (1936); Holm (1979) "A simple sequentially rejective multiple test
+//     procedure"; Benjamini & Hochberg (1995) "Controlling the false discovery rate"
+
+module stats::multiple_comparisons
+
+fn mc_min(a: f64, b: f64) -> f64 { if a < b { a } else { b } }
+
+fn mc_count_rejected(out_adj: &[f64; 64], m: i32, alpha: f64) -> i64 {
+    var c = 0
+    var i = 0
+    while i < m { if out_adj[i as usize] <= alpha { c = c + 1 }; i = i + 1 }
+    return c as i64
+}
+
+/// Bonferroni: p_adj = min(1, m·p). Returns the number rejected at `alpha`.
+pub fn bonferroni(p: &[f64; 64], m: i32, alpha: f64, out_adj: &![f64; 64]) -> i64 with Mut, Div, Panic {
+    let mf = m as f64
+    var i = 0
+    while i < m { out_adj[i as usize] = mc_min(1.0, mf * p[i as usize]); i = i + 1 }
+    return mc_count_rejected(out_adj, m, alpha)
+}
+
+// ascending rank of position `i` (1-based) = #{ p_j <= p_i }
+fn mc_rank(p: &[f64; 64], m: i32, i: i32) -> f64 {
+    var r = 0
+    var j = 0
+    while j < m { if p[j as usize] <= p[i as usize] { r = r + 1 }; j = j + 1 }
+    return r as f64
+}
+
+/// Holm step-down (FWER). Returns the number rejected at `alpha`.
+/// Ranks are computed by O(m²) counting (no sort array) — a function with big
+/// local arrays crashes the current engine when called with arrays live (#852).
+pub fn holm(p: &[f64; 64], m: i32, alpha: f64, out_adj: &![f64; 64]) -> i64 with Mut, Div, Panic {
+    let mf = m as f64
+    // p_adj_i = max over k with p_k <= p_i of min(1, (m - rank_k + 1)·p_k)
+    var i = 0
+    while i < m {
+        var best = 0.0
+        var k = 0
+        while k < m {
+            if p[k as usize] <= p[i as usize] {
+                let rank_k = mc_rank(p, m, k)
+                var raw = 1.0
+                let cand = (mf - rank_k + 1.0) * p[k as usize]
+                if cand < 1.0 { raw = cand }
+                if raw > best { best = raw }
+            }
+            k = k + 1
+        }
+        out_adj[i as usize] = best
+        i = i + 1
+    }
+    return mc_count_rejected(out_adj, m, alpha)
+}
+
+/// Benjamini-Hochberg FDR (step-up). Returns the number rejected at `alpha`.
+pub fn bh_fdr(p: &[f64; 64], m: i32, alpha: f64, out_adj: &![f64; 64]) -> i64 with Mut, Div, Panic {
+    let mf = m as f64
+    // p_adj_i = min over k with p_k >= p_i of min(1, (m/rank_k)·p_k)
+    var i = 0
+    while i < m {
+        var best = 1.0e300
+        var k = 0
+        while k < m {
+            if p[k as usize] >= p[i as usize] {
+                let rank_k = mc_rank(p, m, k)
+                var raw = 1.0
+                let cand = mf / rank_k * p[k as usize]
+                if cand < 1.0 { raw = cand }
+                if raw < best { best = raw }
+            }
+            k = k + 1
+        }
+        out_adj[i as usize] = best
+        i = i + 1
+    }
+    return mc_count_rejected(out_adj, m, alpha)
+}
+

--- a/stdlib/stats/permutation.sio
+++ b/stdlib/stats/permutation.sio
@@ -1,0 +1,88 @@
+// stdlib/stats/permutation.sio — two-sample permutation test (difference of means)
+//
+// A distribution-free test of whether two samples differ in location: it compares
+// the observed mean difference to the distribution of mean differences under all
+// random relabellings of the pooled data (approximated by `iters` random
+// permutations). No normality assumption.
+//
+//   perm_test_means(x, nx, y, ny, iters, seed) -> p_value   (two-sided)
+//
+// p = (1 + #{ |Δ*| >= |Δ_obs| }) / (iters + 1)   (add-one, so p is never 0).
+//
+// The one-sample / mean bootstrap CI already lives in
+// stats::epistemic::bootstrap (bootstrap_mean_ci, incl. BCa); this adds the
+// permutation test, which was missing.
+//
+// Uses a small self-contained LCG (fully inlined, so the routine makes no nested
+// call while its pooled array is live — issue #852). Deterministic given `seed`.
+//
+// References:
+//   Fisher (1935) "The Design of Experiments"; Ernst (2004) "Permutation methods"
+//   Good (2005) "Permutation, Parametric, and Bootstrap Tests of Hypotheses"
+
+module stats::permutation
+
+/// Two-sample permutation test on the difference of means.
+///
+/// Parâmetros: x, y — the two samples; nx, ny — sizes (nx+ny <= 256);
+///             iters — number of random permutations (e.g. 1000); seed — RNG seed.
+/// Retorno: two-sided p-value (add-one corrected, in (0,1]).
+/// Complexidade: O(iters · (nx+ny)).
+/// Referências: Fisher (1935); Ernst (2004).
+pub fn perm_test_means(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, iters: i32, seed: i64) -> f64 with Mut, Div, Panic {
+    if nx < 1 || ny < 1 { return 1.0 }
+    let nxf = nx as f64
+    let nyf = ny as f64
+
+    // observed |mean(x) - mean(y)|
+    var sx = 0.0
+    var i = 0
+    while i < nx { sx = sx + x[i as usize]; i = i + 1 }
+    var sy = 0.0
+    var j = 0
+    while j < ny { sy = sy + y[j as usize]; j = j + 1 }
+    var obs = sx / nxf - sy / nyf
+    if obs < 0.0 { obs = 0.0 - obs }
+
+    // pool the data
+    let n = nx + ny
+    var pool: [f64; 256] = [0.0; 256]
+    var k = 0
+    while k < nx { pool[k as usize] = x[k as usize]; k = k + 1 }
+    var q = 0
+    while q < ny { pool[(nx + q) as usize] = y[q as usize]; q = q + 1 }
+
+    // LCG state (kept in [0, 2^31))
+    var state = seed
+    if state < 0 { state = 0 - state }
+    state = state % 2147483648
+
+    let tol = 1.0e-12
+    var count = 0
+    var it = 0
+    while it < iters {
+        // Fisher-Yates shuffle of pool[0..n] with the inline LCG
+        var a = n - 1
+        while a >= 1 {
+            state = (state * 1103515245 + 12345) % 2147483648
+            let b = (state % ((a + 1) as i64)) as i32
+            let tmp = pool[a as usize]
+            pool[a as usize] = pool[b as usize]
+            pool[b as usize] = tmp
+            a = a - 1
+        }
+        // mean of first nx vs the remaining ny
+        var s1 = 0.0
+        var u = 0
+        while u < nx { s1 = s1 + pool[u as usize]; u = u + 1 }
+        var s2 = 0.0
+        var v = 0
+        while v < ny { s2 = s2 + pool[(nx + v) as usize]; v = v + 1 }
+        var d = s1 / nxf - s2 / nyf
+        if d < 0.0 { d = 0.0 - d }
+        if d >= obs - tol { count = count + 1 }
+        it = it + 1
+    }
+
+    return ((count + 1) as f64) / ((iters + 1) as f64)
+}


### PR DESCRIPTION
Adds two modules to the epistemic-statistics suite (20 already in main).

- **`stats::multiple_comparisons`** — Bonferroni, Holm (FWER) and Benjamini-Hochberg (FDR) p-value adjustment. Ranks by O(m²) counting; only `holm_bonferroni` existed before. (p=0.01..0.05 → Bonferroni/Holm reject 1, BH rejects all 5.)
- **`stats::permutation`** — two-sample permutation test of a mean difference, `p=(1+#{|Δ*|≥|Δ_obs|})/(iters+1)`, inline deterministic LCG. (The mean bootstrap CI already exists in `stats::epistemic::bootstrap`.)

Both math-reviewed (xAI/Grok PASS), validated against textbook values.

**Codegen note (#852):** both ship as **library modules with external tests** (`examples/stats/*_test.sio`) instead of inline `main` tests — an in-module harness making many nested calls while `[64]`/`[256]` arrays are live triggers the silent native-codegen crash. Functions are structured around it (no big callee-local arrays; the sort was replaced by O(m²) rank counting; loops inlined). Suite runner + README updated, ALL GREEN.