### PR TITLE
checker: contextual function lookup (partial #854, runtime blocked)

### DIFF
--- a/scripts/ci/madaros_visibility_context_gate.sh
+++ b/scripts/ci/madaros_visibility_context_gate.sh
@@ -27,7 +27,7 @@ if [[ "$KEEP_WORK" != "1" ]]; then
 fi
 
 case "$EXPECT" in
-  classify|baseline|resolved) ;;
+  classify|baseline|checker-resolved|resolved) ;;
   *) fail "invalid SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=$EXPECT" ;;
 esac
 
@@ -96,7 +96,8 @@ classify_context_check() {
 expect_context_runtime() {
   local label="$1"
   local source="$2"
-  local pass_marker="$3"
+  shift 2
+  [[ "$#" -gt 0 ]] || fail "$label runtime requires at least one exact PASS marker"
   local log="$WORK/$label.run.log"
   local rc=0
 
@@ -117,10 +118,13 @@ expect_context_runtime() {
     cat "$log" >&2
     fail "$label runtime emitted compiler diagnostics after clean check"
   }
-  grep -Fxq "$pass_marker" "$log" || {
-    cat "$log" >&2
-    fail "$label runtime returned 0 without its exact marker"
-  }
+  local pass_marker
+  for pass_marker in "$@"; do
+    grep -Fxq "$pass_marker" "$log" || {
+      cat "$log" >&2
+      fail "$label runtime returned 0 without exact marker: $pass_marker"
+    }
+  done
 }
 
 expect_private_rejection() {
@@ -158,6 +162,38 @@ expect_private_rejection() {
   }
 }
 
+expect_ambiguous_rejection() {
+  local source="$1"
+  local log="$WORK/ambiguous-global.log"
+  local rc=0
+
+  set +e
+  MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" check "$source" >"$log" 2>&1
+  rc=$?
+  set -e
+
+  is_fatal_log "$log" && {
+    cat "$log" >&2
+    fail "ambiguous-global produced a fatal compiler log"
+  }
+  [[ "$rc" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "ambiguous-global must fail closed instead of selecting the first global candidate (rc=$rc)"
+  }
+  [[ "$(count_marker 'error[E' "$log")" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "ambiguous-global must emit exactly one compiler diagnostic"
+  }
+  [[ "$(count_marker 'error[E137' "$log")" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "ambiguous-global must remain unresolved with exactly one E137 diagnostic"
+  }
+  [[ "$(count_marker 'use of undeclared variable' "$log")" -eq 1 ]] || {
+    cat "$log" >&2
+    fail "ambiguous-global must emit the canonical unresolved-name message"
+  }
+}
+
 FIXTURES="$ROOT_DIR/tests/compiler/madaros_visibility_context"
 classify_context_check single "$FIXTURES/duplicate_private_single_main.sio" 1
 single_state="$CASE_STATE"
@@ -169,12 +205,21 @@ matrix_state="$CASE_STATE"
 }
 
 runtime_state="not-run-baseline"
+ambiguous_global="not-run-baseline"
 if [[ "$single_state" == resolved ]]; then
-  expect_context_runtime single "$FIXTURES/duplicate_private_single_main.sio" \
-    'PASS duplicate_private_single_context'
-  expect_context_runtime matrix18 "$FIXTURES/duplicate_private_18_main.sio" \
-    'PASS duplicate_private_18_context'
-  runtime_state="pass"
+  expect_ambiguous_rejection "$FIXTURES/ambiguous_public_main.sio"
+  ambiguous_global="E137"
+  if [[ "$EXPECT" == checker-resolved ]]; then
+    runtime_state="not-run-checker-slice"
+  else
+    expect_context_runtime single "$FIXTURES/duplicate_private_single_main.sio" \
+      'PASS duplicate_private_root_context' \
+      'PASS duplicate_private_leaf_context' \
+      'PASS duplicate_private_single_context'
+    expect_context_runtime matrix18 "$FIXTURES/duplicate_private_18_main.sio" \
+      'PASS duplicate_private_18_context'
+    runtime_state="pass"
+  fi
 fi
 
 expect_private_rejection private-fn \
@@ -187,10 +232,14 @@ expect_private_rejection private-enum \
   "$ROOT_DIR/tests/multimodule/visibility_enum_private_main.sio" E177 \
   'enum constructor is private in its defining module'
 
-echo "[madaros-visibility-context] receipt issue=854 context_state=$single_state runtime_state=$runtime_state single_e175=$([[ "$single_state" == baseline ]] && echo 1 || echo 0) matrix_e175=$([[ "$matrix_state" == baseline ]] && echo 18 || echo 0) true_private_fn=E175 true_private_struct=E176 true_private_enum=E177"
+echo "[madaros-visibility-context] receipt issue=854 context_state=$single_state runtime_state=$runtime_state ambiguous_global=$ambiguous_global single_e175=$([[ "$single_state" == baseline ]] && echo 1 || echo 0) matrix_e175=$([[ "$matrix_state" == baseline ]] && echo 18 || echo 0) true_private_fn=E175 true_private_struct=E176 true_private_enum=E177"
 
 if [[ "$EXPECT" == baseline && "$single_state" != baseline ]]; then
   fail "expected the pinned baseline, got $single_state"
+fi
+if [[ "$EXPECT" == checker-resolved && "$single_state" != resolved ]]; then
+  echo '[madaros-visibility-context] BLOCKED BLK-20260713-MADAROS-EISA-E5-VISIBILITY-E175: contextual checker lookup is not implemented' >&2
+  exit 1
 fi
 if [[ "$EXPECT" == resolved && "$single_state" != resolved ]]; then
   echo '[madaros-visibility-context] BLOCKED BLK-20260713-MADAROS-EISA-E5-VISIBILITY-E175: contextual module binding lookup is not implemented' >&2
@@ -199,6 +248,8 @@ fi
 
 if [[ "$single_state" == baseline ]]; then
   echo '[madaros-visibility-context] KNOWN_BLOCKER: name-only lookup selects a private same-name binding from the wrong module'
+elif [[ "$runtime_state" == not-run-checker-slice ]]; then
+  echo '[madaros-visibility-context] PASS: contextual checker lookup is resolved; runtime binding remains outside this checker slice'
 else
   echo '[madaros-visibility-context] PASS: contextual lookup preserves same-name private bindings and real private access remains rejected'
 fi

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3924,7 +3924,7 @@ fn checker_check_fn_item_inplace(c: *mut Checker, opt: Option<Box<FnDef> >) with
             // return-type path until the expr spine lands — so the conservative
             // proven path ships. Revisit direct-read with a real return-mismatch
             // gate once `return <expr>` no longer crashes the check spine.
-            let sig_id = fn_sig_table_find((*c).fn_sigs, (*fd).name)
+            let sig_id = checker_fn_sigs_find_inplace(c, (*fd).name)
             if sig_id >= 0 {
                 let sig = fn_sig_table_get((*c).fn_sigs, sig_id)
                 (*c).current_return_type = sig.return_type
@@ -6215,7 +6215,11 @@ fn checker_check_box_new_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
 }
 
 fn checker_fn_sigs_find_inplace(c: *mut Checker, name: Name) -> i64 with Mut, Panic, Div, Alloc, IO {
-    fn_sig_table_find((*c).fn_sigs, name)
+    let local_id = fn_sig_table_find_in_module((*c).fn_sigs, name, (*c).current_module_id)
+    if local_id >= 0 {
+        return local_id
+    }
+    fn_sig_table_find_unique((*c).fn_sigs, name)
 }
 
 fn checker_fn_sig_visible_inplace(c: *mut Checker, sig_id: i64) -> bool with Mut, Panic, Div, Alloc, IO {
@@ -17728,7 +17732,10 @@ impl Checker {
                 let saved_effect_count = c.current_effect_count
                 let saved_multitest_count = c.multitest_count
                 let saved_multitest_corrected = c.multitest_corrected
-                let sig_id = fn_sig_table_find(c.fn_sigs, (*fd).name)
+                var sig_id = fn_sig_table_find_in_module(c.fn_sigs, (*fd).name, c.current_module_id)
+                if sig_id < 0 {
+                    sig_id = fn_sig_table_find_unique(c.fn_sigs, (*fd).name)
+                }
                 if sig_id >= 0 {
                     let sig = fn_sig_table_get(c.fn_sigs, sig_id)
                     c.current_return_type = sig.return_type
@@ -18262,7 +18269,10 @@ impl Checker {
             ExprKind::ExprIdent => {
                 if !c.env.has_binding(e.name) {
                     // Functions live in fn_sigs (not env) — resolve a bare fn reference there.
-                    let fn_sig_id = fn_sig_table_find(c.fn_sigs, e.name)
+                    var fn_sig_id = fn_sig_table_find_in_module(c.fn_sigs, e.name, c.current_module_id)
+                    if fn_sig_id < 0 {
+                        fn_sig_id = fn_sig_table_find_unique(c.fn_sigs, e.name)
+                    }
                     if fn_sig_id >= 0 {
                         return (c, ty_fn(fn_sig_id))
                     }

--- a/self-hosted/check/defs.sio
+++ b/self-hosted/check/defs.sio
@@ -1424,6 +1424,55 @@ fn fn_sig_table_find(t: *mut FnSigTable, name: Name) -> i64 with Mut, Panic, Div
     0 - 1
 }
 
+// Resolve a non-method function whose source identity is exactly
+// (defining_module_id, name). Module-local lookup must happen before any
+// cross-module fallback so a same-spelled definition in another module cannot
+// steal the binding and turn a valid local call into a false visibility error.
+fn fn_sig_table_find_in_module(t: *mut FnSigTable, name: Name, module_id: i64) -> i64 with Mut, Panic, Div {
+    var gi: i64 = 0
+    var cur = (*t).head
+    while gi < (*t).count {
+        if cur == (0 as *mut FnSigChunk) { return 0 - 1 }
+        var local: i64 = 0
+        while local < 512 && gi < (*t).count {
+            let sig = (*cur).entries[local as usize]
+            if name_eq(sig.name, name) && !sig.is_method && sig.defining_module_id == module_id {
+                return gi
+            }
+            local = local + 1
+            gi = gi + 1
+        }
+        cur = (*cur).next
+    }
+    0 - 1
+}
+
+// Cross-module fallback is deliberately unique-only. Import bindings are not
+// represented in FnSigTable yet, so choosing the first of multiple global
+// candidates would merely replace one collection-order bug with another.
+fn fn_sig_table_find_unique(t: *mut FnSigTable, name: Name) -> i64 with Mut, Panic, Div {
+    var found: i64 = 0 - 1
+    var gi: i64 = 0
+    var cur = (*t).head
+    while gi < (*t).count {
+        if cur == (0 as *mut FnSigChunk) { return 0 - 1 }
+        var local: i64 = 0
+        while local < 512 && gi < (*t).count {
+            let sig = (*cur).entries[local as usize]
+            if name_eq(sig.name, name) && !sig.is_method {
+                if found >= 0 {
+                    return 0 - 1
+                }
+                found = gi
+            }
+            local = local + 1
+            gi = gi + 1
+        }
+        cur = (*cur).next
+    }
+    found
+}
+
 fn fn_sig_table_find_method(t: *mut FnSigTable, type_name: Name, method_name: Name) -> i64 with Mut, Panic, Div {
     var gi: i64 = 0
     var cur = (*t).head

--- a/tests/compiler/madaros_visibility_context/README.md
+++ b/tests/compiler/madaros_visibility_context/README.md
@@ -1,8 +1,8 @@
 # Madaros module-binding identity reducer
 
-This fixture family reduces issue #854 without changing checker semantics. It
-separates a false privacy diagnostic caused by name-only lookup from genuine
-cross-module private access.
+This fixture family reduces issue #854 and validates the narrow checker slice.
+It separates a false privacy diagnostic caused by name-only lookup from genuine
+cross-module private access, while keeping runtime binding as a separate gate.
 
 The one-call reducer mirrors the E5 test. The root and imported leaf each own a
 private `abs_f64`; the leaf's one internal call currently resolves to the
@@ -31,7 +31,15 @@ MADAROS_RAW_BIN=/path/to/madaros \
   bash scripts/ci/madaros_visibility_context_gate.sh
 ```
 
-Require the implementing acceptance state with:
+Require the checker slice, without claiming runtime binding parity, with:
+
+```bash
+MADAROS_RAW_BIN=/path/to/madaros \
+SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=checker-resolved \
+  bash scripts/ci/madaros_visibility_context_gate.sh
+```
+
+Require the full checker plus runtime acceptance state with:
 
 ```bash
 MADAROS_RAW_BIN=/path/to/madaros \
@@ -40,30 +48,30 @@ SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved \
 ```
 
 `MADAROS_RAW_BIN` is mandatory so the gate cannot silently use the checked-in
-or otherwise stale compiler. The gate accepts only two coherent
-classifications: the exact `1/18` E175 check baseline, or two clean checks
-followed by both executable contextual-lookup witnesses. In either state it
-requires the canonical E175, E176, and E177 true-private negative controls.
-Mixed states, fatal logs, diagnostic-count drift, successful checks that
-retain privacy diagnostics, and runtime exits without exact markers are
-rejected.
+or otherwise stale compiler. The gate distinguishes the exact `1/18` E175
+baseline, a checker-resolved state that deliberately does not execute runtime,
+and the full resolved state. A clean checker must also reject multiple global
+same-name candidates with exactly one E137 instead of choosing by collection
+order. Every state retains the canonical E175, E176, and E177 true-private
+negative controls. Mixed states, fatal logs, diagnostic-count drift, successful
+checks that retain privacy diagnostics, and runtime exits without all exact
+markers are rejected.
 
-This diagnostic gate is intentionally **not wired into ordinary CI**. The
-implementation PR must wire the `EXPECT=resolved` form after it owns the
-checker change; the present lane records and classifies the blocker without
-making a known failure block unrelated pull requests.
+This diagnostic gate is intentionally **not wired into ordinary CI** while the
+full `EXPECT=resolved` state remains blocked in runtime binding.
 
 ## Exact baseline receipt
 
-The initial classifier run used the `madaros-current-source-f64-lowering`
+The baseline was revalidated against the `madaros-current-source-f64-lowering`
 artifact produced for exact `origin/main` SHA
-`e6725240d266353621639419f1c4fd859d90caad` by CI run `29270956296`
-(artifact ID `8287540274`). The compiler ELF was 98,413,103 bytes with SHA-256
-`7e6203c08b254ea46cbae4094a0109317ac28063e4bb3b84209d51eeef2ae8fa`.
+`c9bee0ccdf2bc34663252c2d3e68ea97eb6b83fe` by CI run `29286276017`
+(artifact ID `8293421642`). The compiler ELF was 98,415,171 bytes with SHA-256
+`f080c73f4a9890d1f947d03f1ba9f6fe4cbffd5c1170d70ed7338e2664f215d9`.
 
 ```text
 context_state=baseline
 runtime_state=not-run-baseline
+ambiguous_global=not-run-baseline
 single_e175=1
 matrix_e175=18
 true_private_fn=E175
@@ -71,80 +79,92 @@ true_private_struct=E176
 true_private_enum=E177
 ```
 
-The same artifact with `SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved`
-exits 1 and emits the blocker ID without attempting reducer runtime. A
-synthetic resolved-state harness proves the gate orders clean checks before
-the two exact runtime markers; it is a gate self-test, not evidence that the
-compiler is fixed. A separate synthetic compiler that accepts every input is
-rejected when the E175 negative control returns 0. This pins the state machine
-and anti-weakening behavior independently of the current compiler result.
+The checker implementation was rebuilt from this exact base on Slurm with a
+65536 KiB soft stack. The resulting 98,418,936-byte ELF has SHA-256
+`a46802988c34661a09eba2d1b8c3c9ec7b0da37b4406507660da701960b6949e`.
+
+```text
+context_state=resolved
+runtime_state=not-run-checker-slice
+ambiguous_global=E137
+single_e175=0
+matrix_e175=0
+true_private_fn=E175
+true_private_struct=E176
+true_private_enum=E177
+```
+
+The same ELF with `EXPECT=resolved` exits 1 because the one-call witness checks
+clean but returns `rc=12`: merged runtime IR still binds the leaf call to the
+root's same-name body. That is a contained runtime/IR blocker, not a checker
+failure and not a full issue-resolution claim.
 
 ## Blocker handoff
 
 ```text
 Blocker-ID: BLK-20260713-MADAROS-EISA-E5-VISIBILITY-E175
-Status: classified
+Status: partial (checker-resolved; runtime-binding blocked)
 Severity: B1
 Class: compiler-semantics
-Owner: Codex root coordinator (implementation dispatch pending)
+Owner: Codex root coordinator
 Lane: Madaros module-binding identity / issue #854
-Worktree: /tmp/sounio-issue-854-reducer-20260713
-Branch: codex/issue-854-reducer-20260713
-Files-Owned: tests/compiler/madaros_visibility_context/*; scripts/ci/madaros_visibility_context_gate.sh
-Files-Read-Only: self-hosted/check/check.sio; self-hosted/check/defs.sio; self-hosted/check/mod.sio; self-hosted/ir/lower.sio; EISA witnesses and stdlib
-Do-Not-Touch: self-hosted/check/check.sio while PR #814 owns it; canonical compiler artifacts; EISA mathematical thresholds and receipt semantics
+Worktree: /tmp/sounio-issue854-contextual-20260713
+Branch: codex/issue854-contextual-20260713
+Files-Owned: self-hosted/check/check.sio; self-hosted/check/defs.sio; tests/compiler/madaros_visibility_context/*; scripts/ci/madaros_visibility_context_gate.sh
+Files-Read-Only: self-hosted/check/mod.sio; self-hosted/compiler/module_frontend.sio; self-hosted/ir/ir.sio; self-hosted/ir/lower.sio; native codegen; EISA witnesses and stdlib
+Do-Not-Touch: IR/lowering/codegen without a separately reviewed provenance lane; canonical compiler artifacts; pub-use; EISA mathematical thresholds and receipt semantics
 Repro: MADAROS_RAW_BIN=<current-source-madaros> bash scripts/ci/madaros_visibility_context_gate.sh
 Observed: name-only FnSigTable lookup selects the first same-name declaration even while checking a different defining module
-Expected: an unqualified call resolves through the caller module/import context before visibility is evaluated
-Acceptance-Gate: MADAROS_RAW_BIN=<current-source-madaros> SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved bash scripts/ci/madaros_visibility_context_gate.sh
+Expected: same-module function lookup uses `(defining_module_id, name)` before visibility; cross-module fallback succeeds only when globally unique
+Acceptance-Gate: MADAROS_RAW_BIN=<current-source-madaros> SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=checker-resolved bash scripts/ci/madaros_visibility_context_gate.sh
 Evidence-Level: E3
-Evidence: exact-main CI run 29270956296 artifact 8287540274 plus the baseline receipt in this README
+Evidence: exact-main CI run 29286276017 artifact 8293421642 plus Slurm source rebuild SHA-256 a46802988c34661a09eba2d1b8c3c9ec7b0da37b4406507660da701960b6949e
 Fallback-Path: none
-Legacy-Kept: yes; existing checker, EISA, and negative visibility paths are unchanged
+Legacy-Kept: yes; legacy name-only helper remains for unproven callers; IR/lowering/codegen are byte-unchanged
 LLM-Offload: not-required (diagnostic fixtures/gate only; no math, clinical, or external claim change)
-Next-Action: implement module-aware function binding lookup after PR #814 releases checker ownership
+Next-Action: carry DefId/module provenance through imported function preseed, merge, finalization, and native linkage; remove name fallback only after the forward-import and seed-stub controls pass
 ```
 
 ## Semantic lane declaration
 
-`SOUNIO-MODULE-BINDING-IDENTITY` is proposed here for the future implementation
-lane. It is not yet registered as an executable concept, and this reducer does
-not alter its semantics.
+`SOUNIO-MODULE-BINDING-IDENTITY` remains proposed. This lane implements only
+the checker-local `(module_id, name)` lookup and its unique-only fallback; it
+does not claim end-to-end import or runtime identity.
 
 ```text
 Semantic-Lane-ID: issue-854-module-binding-identity-reducer
 Owner: Codex issue #854 reducer lane
 Concept-IDs: proposed SOUNIO-MODULE-BINDING-IDENTITY
 Intent-Preserved: source-level module ownership remains part of symbol identity; privacy is checked after contextual binding resolution
-Transformation: none; executable characterization only
+Transformation: checker function lookup is local-first and global-unique-only
 Types-Changed: none
 Effects-Changed: none
 IR-Changed: none
-Claims-Introduced: current-source Madaros reproduces exact 1-call and 18-call E175 name-collision boundaries while true private access remains rejected
-Claims-Forbidden: EISA runtime parity; general import/re-export correctness; implementation of module-aware bindings; weakening private visibility
+Claims-Introduced: current-source Madaros removes the exact 1-call and 18-call false E175 diagnostics, fails closed on ambiguous global names, and preserves true E175/E176/E177 diagnostics
+Claims-Forbidden: runtime-binding parity; EISA runtime parity; general import/re-export correctness; full DefId propagation; weakening private visibility
 Assumptions: root module is collected before imported leaves; unqualified same-module declarations are in lexical scope
-Write-Set: tests/compiler/madaros_visibility_context/*; scripts/ci/madaros_visibility_context_gate.sh
-Read-Set: self-hosted/check/check.sio; self-hosted/check/defs.sio; self-hosted/check/mod.sio; self-hosted/compiler/main.sio; EISA fixtures and modules
-Positive-Witness: acceptance-only; after clean checks, duplicate_private_single_main.sio and duplicate_private_18_main.sio must execute their exact PASS markers
-Negative-Witness: visibility_fn_private_main.sio=E175; visibility_struct_private_main.sio=E176; visibility_enum_private_main.sio=E177
-Acceptance-Gate: MADAROS_RAW_BIN=<current-source-madaros> SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=resolved bash scripts/ci/madaros_visibility_context_gate.sh
-Integration-Target: future checker/module-binding implementation lane after PR #814
-Authoritative-Only-If: both contextual witnesses execute and all three true-private diagnostics remain exact
+Write-Set: self-hosted/check/check.sio; self-hosted/check/defs.sio; tests/compiler/madaros_visibility_context/*; scripts/ci/madaros_visibility_context_gate.sh
+Read-Set: self-hosted/check/mod.sio; self-hosted/compiler/module_frontend.sio; self-hosted/ir/ir.sio; self-hosted/ir/lower.sio; native codegen; EISA fixtures and modules
+Positive-Witness: duplicate_private_single_main.sio and duplicate_private_18_main.sio check clean with zero E175
+Negative-Witness: ambiguous_public_main.sio=E137; visibility_fn_private_main.sio=E175; visibility_struct_private_main.sio=E176; visibility_enum_private_main.sio=E177
+Acceptance-Gate: MADAROS_RAW_BIN=<current-source-madaros> SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=checker-resolved bash scripts/ci/madaros_visibility_context_gate.sh
+Integration-Target: checker slice now; future DefId/runtime-provenance lane separately
+Authoritative-Only-If: both contextual checks stay clean, ambiguity stays E137, and all three true-private diagnostics remain exact
 ```
 
 ## Integration receipt
 
 ```text
-Semantic-Outcome: exact blocker reduced; implementation intentionally deferred
+Semantic-Outcome: checker blocker resolved; runtime-binding blocker contained
 Concept-Status-Before: unregistered proposal
-Concept-Status-After: unregistered proposal with executable characterization
+Concept-Status-After: unregistered proposal with an executable checker slice
 Distinctions-Added: same spelling != same binding; binding resolution != visibility authorization
 Distinctions-Preserved: private same-module access != private cross-module access; compile success != runtime binding parity
 Distinctions-Erased: none
-Evidence-Run: baseline classifier against exact-main CI artifact; resolved-state and accept-all harness self-tests
+Evidence-Run: exact-main baseline; Slurm current-source checker rebuild; checker-resolved gate; full runtime rejection; disposable forward-import and seed-stub controls
 Fallback-Path: none
-Legacy-Kept: all existing checker, EISA, and visibility paths
-Conflicting-Lanes: PR #814 owns self-hosted/check/check.sio; no overlap in this phase
-Ordinary-CI: not wired in this diagnostic lane; required wiring belongs to the implementation PR
-Next-Semantic-Interface: module-qualified binding records and caller-context lookup
+Legacy-Kept: legacy name-only checker helper for unproven callers; all IR/lowering/codegen paths
+Conflicting-Lanes: none observed at implementation start; PR #814 was already merged
+Ordinary-CI: not wired while full runtime acceptance is red
+Next-Semantic-Interface: DefId-bearing imported function records and exact merge/linkage identity
 ```

--- a/tests/compiler/madaros_visibility_context/ambiguous_public_a.sio
+++ b/tests/compiler/madaros_visibility_context/ambiguous_public_a.sio
@@ -1,0 +1,7 @@
+pub fn same_public_name() -> i64 {
+    101
+}
+
+pub fn load_ambiguous_a() -> i64 {
+    1
+}

--- a/tests/compiler/madaros_visibility_context/ambiguous_public_b.sio
+++ b/tests/compiler/madaros_visibility_context/ambiguous_public_b.sio
@@ -1,0 +1,7 @@
+pub fn same_public_name() -> i64 {
+    202
+}
+
+pub fn load_ambiguous_b() -> i64 {
+    2
+}

--- a/tests/compiler/madaros_visibility_context/ambiguous_public_main.sio
+++ b/tests/compiler/madaros_visibility_context/ambiguous_public_main.sio
@@ -1,0 +1,11 @@
+//@ compile-fail
+//@ error-pattern: E137
+
+// Load both modules without importing their duplicate public name. The checker
+// must not select either global candidate by collection order.
+use ambiguous_public_a::{load_ambiguous_a}
+use ambiguous_public_b::{load_ambiguous_b}
+
+fn main() -> i64 {
+    same_public_name()
+}

--- a/tests/compiler/madaros_visibility_context/duplicate_private_single_main.sio
+++ b/tests/compiler/madaros_visibility_context/duplicate_private_single_main.sio
@@ -6,9 +6,15 @@ fn abs_f64(x: f64) -> f64 {
     x + 100.0
 }
 
+fn root_abs_once(x: f64) -> f64 {
+    abs_f64(x)
+}
+
 fn main() -> i64 with IO {
-    if abs_f64(2.0) != 102.0 { return 11 }
+    if root_abs_once(2.0) != 102.0 { return 11 }
+    println("PASS duplicate_private_root_context")
     if leaf_abs_once(0.0 - 2.0) != 2.0 { return 12 }
+    println("PASS duplicate_private_leaf_context")
     println("PASS duplicate_private_single_context")
     0
 }


### PR DESCRIPTION
## Non-merge checkpoint

> **DO NOT MERGE.** This draft preserves the checker-only portion of #854. The checker gate is green, but the full runtime-binding gate remains red and requires a separate DefId provenance lane.

## What changed

- resolve non-method function signatures by exact `(defining_module_id, name)` in the current checker module;
- allow global fallback only when exactly one same-name function signature exists;
- fail closed with canonical E137 when multiple global candidates exist;
- preserve the exact E175, E176, and E177 true-private controls;
- add a `checker-resolved` gate state that cannot be mistaken for full runtime acceptance;
- strengthen the root/leaf reducer markers and document the contained blocker.

No changes are included in `self-hosted/check/mod.sio`, `self-hosted/compiler/module_frontend.sio`, `self-hosted/ir/ir.sio`, `self-hosted/ir/lower.sio`, native codegen, or EISA source.

## Exact baseline

Base commit:

```text
c9bee0ccdf2bc34663252c2d3e68ea97eb6b83fe
```

CI run `29286276017`, artifact `8293421642`, compiler SHA-256:

```text
f080c73f4a9890d1f947d03f1ba9f6fe4cbffd5c1170d70ed7338e2664f215d9
```

Baseline receipt:

```text
context_state=baseline
runtime_state=not-run-baseline
ambiguous_global=not-run-baseline
single_e175=1
matrix_e175=18
true_private_fn=E175
true_private_struct=E176
true_private_enum=E177
```

## Checker head receipt

Branch head:

```text
3d37cf73bbaf3499676376b9557a8c008798aebe
```

The exact source was rebuilt on Slurm with a 65536 KiB soft stack. Compiler SHA-256:

```text
a46802988c34661a09eba2d1b8c3c9ec7b0da37b4406507660da701960b6949e
```

```text
context_state=resolved
runtime_state=not-run-checker-slice
ambiguous_global=E137
single_e175=0
matrix_e175=0
true_private_fn=E175
true_private_struct=E176
true_private_enum=E177
```

Command:

```bash
MADAROS_RAW_BIN=<source-fresh-elf> \
SOUNIO_MADAROS_VISIBILITY_CONTEXT_EXPECT=checker-resolved \
  bash scripts/ci/madaros_visibility_context_gate.sh
```

## Runtime blocker

The same source-fresh checker ELF with `EXPECT=resolved` exits 1:

```text
single checked clean but runtime returned rc=12
```

The leaf's private `abs_f64` call is still rebound to the root's same-name body during multimodule IR merge. This PR does not claim runtime parity or complete import-context resolution.

An attempted module-frontend-only patch made the exact two-module reducer pass, but failed the required disposable controls and was fully reverted:

```text
three-module forward collision: previous rc=32, attempted patch rc=139
seed imported-stub collision:   previous rc=0,  attempted patch rc=139
```

The rejected patch is not present in this branch.

## Additional controls

```text
thin_single_main       rc=7 expected=7
thin_chain_main        rc=7 expected=7
thin_return_call_main  rc=7 expected=7
```

Imported IR trace:

```text
modules=3
body_lowered=3
merged=3
probe_load_ir_trace: ok
```

Static and review controls:

```text
bash -n scripts/ci/madaros_visibility_context_gate.sh: PASS
git diff --check: PASS
independent read-only review: CLEAN for narrow checker scope
module_frontend/IR/lowering/check-mod blobs: byte-identical to base
```

`--emit-obj` is present, but the imported reducer path returned `Merged IR: 0 functions` before producing an object. Duplicate private symbol linkage therefore remains unpromoted evidence and part of the next lane.

## Blocker contract

```text
Blocker-ID: BLK-20260713-MADAROS-EISA-E5-VISIBILITY-E175
Status: partial (checker-resolved; runtime-binding blocked)
Severity: B1
Class: compiler-semantics
Evidence-Level: E3
Owner: Codex root coordinator
Acceptance-Gate: EXPECT=resolved plus forward-import and seed-stub controls
Fallback-Path: none
Legacy-Kept: yes; name-only helper remains for unproven callers and IR/lowering/codegen are unchanged
LLM-Offload: not-required (no math, clinical, or external-facing claim changes)
Next-Action: DefId-bearing imported function preseed, merge, finalization, and native linkage lane
```

## Next lane

The durable solution must carry module provenance rather than add another name fallback:

1. add defining-module identity to IR function records;
2. preseed external functions only from explicit `use` targets;
3. key function slots, remaps, stubs, promotion, and finalization by DefId;
4. fail closed when provenance is absent;
5. mangle or internalize private symbols for relocatable output;
6. require the three-module forward collision and seed imported-stub controls before merge eligibility.

Closes no issue. Preserves a reviewed checkpoint for #854.
