### PR TITLE
DefId provenance partial #854 SOIR blocked

### DIFF
--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -30,6 +30,12 @@ var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_NAME_HASHES: [i64; 64] = [0; 64]
 var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_KINDS: [i64; 64] = [0; 64]
 var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_TARGET_HASHES: [i64; 64] = [0; 64]
 var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_VALUES: [i64; 64] = [0; 64]
+// Per-lowering DefId binding scratch. These arrays live in BSS because the
+// multimodule lowering wrappers already have large frames and the bootstrap
+// compiler is sensitive to additional aggregate locals. Collection and summary
+// lowering are synchronous, so one resettable table is sufficient.
+var MF_EXTERN_BINDING_NAMES: [Name; 2048] = [ir_empty_name(); 2048]
+var MF_EXTERN_BINDING_MODULE_IDS: [i64; 2048] = [IR_DEFINING_MODULE_UNKNOWN; 2048]
 
 fn module_frontend_import_is_ident_ch(c: i8) -> bool {
     (c >= 65 as i8 && c <= 90 as i8) ||
@@ -1178,11 +1184,10 @@ fn ir_merge_prepare_function_with_remap_from_func(
             if old_id >= 0 && old_id < dep_fn_count {
                 let mapped_id = fn_remap[old_id as usize]
                 if mapped_id >= 0 {
-                    let dep_name = (*src).functions[old_id as usize].name
-                    let current_name = ir_merge_function_name_at(dst, old_id)
-                    if ir_name_eq(dep_name, current_name) || ir_merge_find_function_name_index(dst, dep_name) < 0 {
-                        func.instrs[ii as usize].fn_id = mapped_id
-                    }
+                    // fn_remap is built from the dependency slot's exact
+                    // (defining_module_id, name) identity. Rechecking by bare
+                    // name here reintroduced the collision the remap removed.
+                    func.instrs[ii as usize].fn_id = mapped_id
                 }
             }
         }
@@ -1242,44 +1247,85 @@ fn ir_merge_prepare_function_with_remap(
     )
 }
 
-// Resolve a merged-module fn_id by symbol name. Prefer a lowered body (instr_count>0)
-// over import stubs so dependency functions keep calling real implementations.
-fn ir_merge_find_function_name_index(module: &IrModule, name: Name) -> i64 with Mut, Div, Panic {
+fn ir_function_has_exact_definition_identity(func: IrFunction) -> bool {
+    func.defining_module_id >= 0 || func.defining_module_id == IR_DEFINING_MODULE_BUILTIN
+}
+
+fn ir_function_definition_identity_eq(a: IrFunction, b: IrFunction) -> bool with Mut, Div, Panic {
+    ir_function_has_exact_definition_identity(a) &&
+    ir_function_has_exact_definition_identity(b) &&
+    a.defining_module_id == b.defining_module_id &&
+    ir_name_eq(a.name, b.name)
+}
+
+// Exact DefId lookup. UNKNOWN and AMBIGUOUS are states, not identities.
+fn ir_merge_find_function_identity_index(
+    module: &IrModule,
+    defining_module_id: i64,
+    name: Name
+) -> i64 with Mut, Div, Panic {
+    if defining_module_id < 0 && defining_module_id != IR_DEFINING_MODULE_BUILTIN {
+        return -1
+    }
+    var found_body: i64 = -1
+    var found_stub: i64 = -1
     var fi: i64 = 0
-    var found: i64 = 0 - 1
-    var found_stub: i64 = 0 - 1
     while fi < (*module).fn_count {
-        if ir_name_eq((*module).functions[fi as usize].name, name) {
-            if (*module).functions[fi as usize].instr_count > 0 {
-                found = fi
+        let candidate = (*module).functions[fi as usize]
+        if candidate.defining_module_id == defining_module_id && ir_name_eq(candidate.name, name) {
+            if candidate.instr_count > 0 {
+                if found_body < 0 { found_body = fi }
             } else if found_stub < 0 {
                 found_stub = fi
             }
         }
         fi = fi + 1
     }
-    if found >= 0 { found } else { found_stub }
+    if found_body >= 0 { found_body } else { found_stub }
 }
 
-// After stub replacement, remap in-function IrCall/IrCallSret targets from the
-// dependency module's local fn_id space to the accumulated module by name.
-fn ir_merge_remap_existing_call_targets(func: IrFunction, src: &IrModule, dst: &IrModule) -> IrFunction with Mut, Panic, Div {
-    var out = func
-    var ii: i64 = 0
-    while ii < out.instr_count {
-        if out.instrs[ii as usize].op == IrOpcode::IrCall || out.instrs[ii as usize].op == IrOpcode::IrCallSret {
-            let old_id = out.instrs[ii as usize].fn_id
-            if old_id >= 0 && old_id < (*src).fn_count {
-                let target_name = (*src).functions[old_id as usize].name
-                let new_id = ir_merge_find_function_name_index(dst, target_name)
-                if new_id >= 0 {
-                    out.instrs[ii as usize].fn_id = new_id
+// Bare-name lookup is retained only for callers that do not yet carry a slot
+// identity. It succeeds when the name denotes exactly one proven identity (or
+// one legacy UNKNOWN slot), and fails closed for cross-module or explicit
+// AMBIGUOUS collisions. It never chooses the first distinct definition.
+fn ir_merge_find_function_name_index(module: &IrModule, name: Name) -> i64 with Mut, Div, Panic {
+    var selected: i64 = -1
+    var selected_module_id: i64 = IR_DEFINING_MODULE_UNKNOWN
+    var selected_exact: bool = false
+    var fi: i64 = 0
+    while fi < (*module).fn_count {
+        let candidate = (*module).functions[fi as usize]
+        if ir_name_eq(candidate.name, name) {
+            if candidate.defining_module_id == IR_DEFINING_MODULE_AMBIGUOUS {
+                return -1
+            }
+            let candidate_exact = ir_function_has_exact_definition_identity(candidate)
+            if selected < 0 {
+                selected = fi
+                selected_module_id = candidate.defining_module_id
+                selected_exact = candidate_exact
+            } else {
+                if !selected_exact || !candidate_exact || candidate.defining_module_id != selected_module_id {
+                    return -1
+                }
+                if (*module).functions[selected as usize].instr_count <= 0 && candidate.instr_count > 0 {
+                    selected = fi
                 }
             }
         }
-        ii = ii + 1
+        fi = fi + 1
     }
-    out
+    selected
+}
+
+fn ir_merge_find_function_for_target(module: &IrModule, target: IrFunction) -> i64 with Mut, Div, Panic {
+    if ir_function_has_exact_definition_identity(target) {
+        return ir_merge_find_function_identity_index(module, target.defining_module_id, target.name)
+    }
+    if target.defining_module_id == IR_DEFINING_MODULE_UNKNOWN {
+        return ir_merge_find_function_name_index(module, target.name)
+    }
+    -1
 }
 
 // Takes &! IrModule (not &! Box<IrModule>): the latter triggers a lean_single
@@ -1331,9 +1377,8 @@ fn ir_merge_append_function_into_box(dst: &! IrModule, src: &IrModule, src_fi: i
     (*dst).fn_count = (*dst).fn_count + 1
 }
 
-// Resolve a call's canonical target from its (fn_id, name) fields only.
-// Prefer lowered bodies (instr_count>0) over import stubs; fall back to the
-// callee symbol at the current fn_id when the call's name is empty.
+// Resolve a call's canonical target from its slot identity. Bare-name recovery
+// is allowed only when the name has one unambiguous definition in the module.
 //
 // A8 fix: the previous entry point (`ir_module_resolve_one_call_target`) took
 // `instr: IrInstr` BY VALUE. IrInstr is a
@@ -1343,32 +1388,26 @@ fn ir_merge_append_function_into_box(dst: &! IrModule, src: &IrModule, src_fi: i
 // (`var r = zero(k); r.c[i]=1; return r`). Passing only the scalar fn_id + fixed-size
 // Name avoids the large-struct/Box by-value copy entirely.
 fn ir_module_resolve_call_target_fields(module: &IrModule, old_id: i64, instr_name: Name) -> i64 with Mut, Div, Panic {
-    var resolve_name = instr_name
-    if resolve_name.len == 0 && old_id >= 0 && old_id < (*module).fn_count {
-        resolve_name = (*module).functions[old_id as usize].name
-    }
-    if resolve_name.len > 0 {
-        let new_id = ir_merge_find_function_name_index(module, resolve_name)
-        if new_id >= 0 && (*module).functions[new_id as usize].instr_count > 0 {
-            return new_id
+    if old_id >= 0 && old_id < (*module).fn_count {
+        let target = (*module).functions[old_id as usize]
+        if instr_name.len == 0 || ir_name_eq(instr_name, target.name) {
+            let exact_id = ir_merge_find_function_for_target(module, target)
+            if exact_id >= 0 && (*module).functions[exact_id as usize].instr_count > 0 {
+                return exact_id
+            }
         }
     }
-    // Remap calls that still point at import stubs (ic=0) even when name-based
-    // lookup above failed — duplicate symbols can leave stale low fn_ids.
-    if old_id >= 0 && old_id < (*module).fn_count {
-        if (*module).functions[old_id as usize].instr_count == 0 {
-            let stub_name = (*module).functions[old_id as usize].name
-            let new_id = ir_merge_find_function_name_index(module, stub_name)
-            if new_id >= 0 && new_id != old_id && (*module).functions[new_id as usize].instr_count > 0 {
-                return new_id
-            }
+    if instr_name.len > 0 {
+        let unique_id = ir_merge_find_function_name_index(module, instr_name)
+        if unique_id >= 0 && (*module).functions[unique_id as usize].instr_count > 0 {
+            return unique_id
         }
     }
     old_id
 }
 
-// After multimodule merge, rebind every direct IrCall/IrCallSret to the merged
-// module's canonical fn_id for instr.name. Prefer lowered bodies over import stubs.
+// After multimodule merge, rebind direct calls to the merged module's canonical
+// fn_id. IrLoadFnRef is handled by the owned-module finalize pass below.
 fn ir_module_resolve_all_call_targets(module: &! IrModule) with Mut, Div, Panic {
     var fi: i64 = 0
     while fi < (*module).fn_count {
@@ -1702,17 +1741,13 @@ fn ir_module_dump_merge_calls(module: &IrModule) with IO, Mut, Div, Panic {
     }
 }
 
-// Map a fn_id to the merged module's canonical index for its symbol name.
-// Prefer lowered bodies (instr_count>0) over import stubs.
+// Map a fn_id to the merged module's canonical index for its exact definition.
 fn ir_module_canonical_fn_id_for_index(module: &IrModule, fn_id: i64) -> i64 with Mut, Div, Panic {
     if fn_id < 0 || fn_id >= (*module).fn_count {
         return fn_id
     }
-    let sym_name = (*module).functions[fn_id as usize].name
-    if sym_name.len == 0 {
-        return fn_id
-    }
-    let canon = ir_merge_find_function_name_index(module, sym_name)
+    let target = (*module).functions[fn_id as usize]
+    let canon = ir_merge_find_function_for_target(module, target)
     if canon >= 0 {
         return canon
     }
@@ -1732,15 +1767,12 @@ fn ir_module_compact_duplicate_fn_refs(module: IrModule) -> IrModule with Mut, D
             while ii < f.instr_count {
                 if ir_merge_is_direct_fn_ref_opcode(f.instrs[ii as usize].op) {
                     let old_id = f.instrs[ii as usize].fn_id
-                    let nm = f.instrs[ii as usize].name
                     var canon: i64 = old_id
-                    if nm.len > 0 {
-                        let by_name = ir_merge_find_function_name_index(&out, nm)
-                        if by_name >= 0 && out.functions[by_name as usize].instr_count > 0 {
-                            canon = by_name
-                        }
-                    } else if old_id >= 0 {
+                    if old_id >= 0 {
                         canon = ir_module_canonical_fn_id_for_index(&out, old_id)
+                    } else if f.instrs[ii as usize].name.len > 0 {
+                        let unique = ir_merge_find_function_name_index(&out, f.instrs[ii as usize].name)
+                        if unique >= 0 { canon = unique }
                     }
                     if canon >= 0
                         && canon < out.fn_count
@@ -1781,9 +1813,9 @@ fn ir_module_promote_canonical_into_stub_slots(module: IrModule) -> IrModule wit
     var fi: i64 = 0
     while fi < out.fn_count {
         if out.functions[fi as usize].instr_count == 0 {
-            let sym_name = out.functions[fi as usize].name
-            if sym_name.len > 0 {
-                let canon = ir_merge_find_function_name_index(&out, sym_name)
+            let target = out.functions[fi as usize]
+            if target.name.len > 0 {
+                let canon = ir_merge_find_function_for_target(&out, target)
                 if canon >= 0 && canon != fi && out.functions[canon as usize].instr_count > 0 {
                     out.functions[fi as usize] = ir_function_deep_copy(out.functions[canon as usize])
                 }
@@ -1825,6 +1857,7 @@ fn ir_module_ensure_builtin_call_targets(module: IrModule) -> IrModule with Mut,
                         if target < 0 && out.fn_count < IR_MAX_FUNCS {
                             var stub = ir_empty_function()
                             stub.name = cn
+                            stub.defining_module_id = IR_DEFINING_MODULE_BUILTIN
                             out.functions[out.fn_count as usize] = stub
                             target = out.fn_count
                             out.fn_count = out.fn_count + 1
@@ -1887,6 +1920,36 @@ fn ir_module_finalize_merged_calls(module: IrModule) -> IrModule with Mut, Div, 
     out
 }
 
+// Multimodule codegen must never inherit a direct call whose definition
+// provenance is missing or ambiguous. Returning false keeps the compiler on a
+// diagnostic exit instead of executing whichever same-name slot was collected
+// first. Single-module bootstrap paths do not call this guard.
+fn ir_module_direct_fn_provenance_is_complete(module: &IrModule) -> bool with Mut, Div, Panic {
+    var fi: i64 = 0
+    while fi < (*module).fn_count {
+        let func = (*module).functions[fi as usize]
+        var ii: i64 = 0
+        while ii < func.instr_count {
+            let ins = func.instrs[ii as usize]
+            if ir_merge_is_direct_fn_ref_opcode(ins.op) {
+                if ins.fn_id < 0 || ins.fn_id >= (*module).fn_count {
+                    return false
+                }
+                let target = (*module).functions[ins.fn_id as usize]
+                if !ir_function_has_exact_definition_identity(target) {
+                    return false
+                }
+                if ins.name.len > 0 && !ir_name_eq(ins.name, target.name) {
+                    return false
+                }
+            }
+            ii = ii + 1
+        }
+        fi = fi + 1
+    }
+    true
+}
+
 // Reinstall seed user main after finalize: owned-module finalize passes can clobber
 // fn=0 under the lean_single JIT. Stub slots are already promoted; keep seed fn_ids.
 fn ir_module_restore_user_main_calls(module: IrModule, user_main: IrFunction) -> IrModule with Mut, Div, Panic {
@@ -1896,6 +1959,7 @@ fn ir_module_restore_user_main_calls(module: IrModule, user_main: IrFunction) ->
     }
     var slot = out.functions[0 as usize]
     slot.name = user_main.name
+    slot.defining_module_id = user_main.defining_module_id
     slot.instr_count = user_main.instr_count
     slot.reg_count = user_main.reg_count
     slot.label_count = user_main.label_count
@@ -1926,6 +1990,119 @@ fn ir_module_restore_user_main_calls(module: IrModule, user_main: IrFunction) ->
     }
     out.functions[0 as usize] = slot
     out
+}
+
+fn ir_direct_call_result_flags(op: IrOpcode, current_flags: i64, target_returns_float: i64) -> i64 {
+    if op != IrOpcode::IrCall {
+        return current_flags
+    }
+    if target_returns_float == 1 { IR_FLOAT_REG_MARKER_FLAG } else { 0 }
+}
+
+fn ir_fields_are_paired_float_marker(op: IrOpcode, imm_flags: i64, dst: i64, call_dst: i64) -> bool {
+    op == IrOpcode::IrNop &&
+    imm_flags == IR_FLOAT_REG_MARKER_FLAG &&
+    dst == call_dst
+}
+
+// Finalize scalar call result classes only after every direct target has its
+// exact merged DefId and canonical body metadata. This cannot be limited to
+// fn=0: source order may place main (or any other caller) in a later slot.
+// Keep the call flag and its lowering-convention marker Nop synchronized so
+// both native consumers observe the same class. SRET and builtin calls retain
+// their independent ABI/builtin classifications.
+fn ir_module_refresh_direct_call_result_classes(module: IrModule) -> IrModule with Mut, Div, Panic {
+    var out = module
+    var fi: i64 = 0
+    while fi < out.fn_count {
+        var func = out.functions[fi as usize]
+        var changed: bool = false
+        var ii: i64 = 0
+        while ii < func.instr_count {
+            var ins = func.instrs[ii as usize]
+            if ins.op == IrOpcode::IrCall && ins.fn_id >= 0 && ins.fn_id < out.fn_count {
+                let target = out.functions[ins.fn_id as usize]
+                if target.defining_module_id >= 0 {
+                    let result_flags = ir_direct_call_result_flags(ins.op, ins.imm_flags, target.returns_float)
+                    if ins.imm_flags != result_flags {
+                        ins.imm_flags = result_flags
+                        func.instrs[ii as usize] = ins
+                        changed = true
+                    }
+
+                    var has_pair = false
+                    if ii + 1 < func.instr_count {
+                        let next_op = func.instrs[(ii + 1) as usize].op
+                        let next_flags = func.instrs[(ii + 1) as usize].imm_flags
+                        let next_dst = func.instrs[(ii + 1) as usize].dst
+                        has_pair = ir_fields_are_paired_float_marker(next_op, next_flags, next_dst, ins.dst)
+                    }
+                    if result_flags == IR_FLOAT_REG_MARKER_FLAG && !has_pair && ins.dst >= 0 {
+                        if func.instr_count < IR_MAX_INSTRS {
+                            var shift = func.instr_count
+                            while shift > ii + 1 {
+                                func.instrs[shift as usize] = func.instrs[(shift - 1) as usize]
+                                shift = shift - 1
+                            }
+                            func.instrs[(ii + 1) as usize] = ir_mark_float_reg(ins.dst)
+                            func.instr_count = func.instr_count + 1
+                            changed = true
+                        }
+                    } else if result_flags == 0 && has_pair {
+                        var stale_marker = func.instrs[(ii + 1) as usize]
+                        stale_marker.imm_flags = 0
+                        func.instrs[(ii + 1) as usize] = stale_marker
+                        changed = true
+                    }
+                }
+            }
+            ii = ii + 1
+        }
+        if changed {
+            out.functions[fi as usize] = func
+        }
+        fi = fi + 1
+    }
+    out
+}
+
+fn ir_module_direct_call_result_classes_are_complete(module: &IrModule) -> bool with Mut, Div, Panic {
+    var fi: i64 = 0
+    while fi < (*module).fn_count {
+        let func = (*module).functions[fi as usize]
+        var ii: i64 = 0
+        while ii < func.instr_count {
+            let ins = func.instrs[ii as usize]
+            if ins.op == IrOpcode::IrCall && ins.fn_id >= 0 && ins.fn_id < (*module).fn_count {
+                let target = (*module).functions[ins.fn_id as usize]
+                if target.defining_module_id >= 0 {
+                    let expected = ir_direct_call_result_flags(ins.op, ins.imm_flags, target.returns_float)
+                    var has_pair = false
+                    if ii + 1 < func.instr_count {
+                        let next_op = func.instrs[(ii + 1) as usize].op
+                        let next_flags = func.instrs[(ii + 1) as usize].imm_flags
+                        let next_dst = func.instrs[(ii + 1) as usize].dst
+                        has_pair = ir_fields_are_paired_float_marker(next_op, next_flags, next_dst, ins.dst)
+                    }
+                    if ins.imm_flags != expected { return false }
+                    if expected == IR_FLOAT_REG_MARKER_FLAG && (ins.dst < 0 || !has_pair) { return false }
+                    if expected == 0 && has_pair { return false }
+                }
+            }
+            ii = ii + 1
+        }
+        fi = fi + 1
+    }
+    true
+}
+
+pub fn module_frontend_refresh_call_result_classes_self_test() -> i64 with Mut, Div, Panic {
+    if ir_direct_call_result_flags(IrOpcode::IrCall, 0, 1) != IR_FLOAT_REG_MARKER_FLAG { return 1 }
+    if ir_direct_call_result_flags(IrOpcode::IrCall, IR_FLOAT_REG_MARKER_FLAG, 0) != 0 { return 2 }
+    if ir_direct_call_result_flags(IrOpcode::IrCallSret, IR_FLOAT_REG_MARKER_FLAG, 2) != IR_FLOAT_REG_MARKER_FLAG { return 3 }
+    if !ir_fields_are_paired_float_marker(IrOpcode::IrNop, IR_FLOAT_REG_MARKER_FLAG, 17, 17) { return 4 }
+    if ir_fields_are_paired_float_marker(IrOpcode::IrNop, IR_FLOAT_REG_MARKER_FLAG, 17, 18) { return 5 }
+    0
 }
 
 // Resolve fn_id=-1 named calls (cross-module calls emitted by module_frontend_ir_named_call)
@@ -4243,6 +4420,7 @@ fn module_frontend_lower_program_items_box_traced(
 fn module_frontend_lower_program_box_traced_with_externs(
     program: &Program,
     programs: &! [Program; 256],
+    file_paths: &![string; 256],
     program_count: i64,
     module_index: i64,
     trace: &! LoadMultimoduleIrTrace
@@ -4251,7 +4429,22 @@ fn module_frontend_lower_program_box_traced_with_externs(
     trace.last_module_index = module_index
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_begin\n") }
     var epistemic = ir_empty_epistemic_section()
-    let summary_result = lower_program_to_ir_summary_box_with_externs_ref(program, programs, program_count, module_index, &epistemic)
+    let binding_count = module_frontend_collect_external_bindings(
+        programs,
+        file_paths,
+        program_count,
+        module_index
+    )
+    let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
+        program,
+        programs,
+        program_count,
+        module_index,
+        &! MF_EXTERN_BINDING_NAMES,
+        &! MF_EXTERN_BINDING_MODULE_IDS,
+        binding_count,
+        &epistemic
+    )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
     if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
         trace.last_stage = "lower_summary_error"
@@ -4262,6 +4455,9 @@ fn module_frontend_lower_program_box_traced_with_externs(
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
     var summary_val = (*summary_result.summary)
+    let summary_module_box = summary_val.module
+    module_frontend_assign_function_provenance(&! (*summary_module_box), programs, file_paths, program_count, module_index)
+    summary_val.module = summary_module_box
     let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
         program,
         &summary_val,
@@ -4277,6 +4473,8 @@ fn module_frontend_lower_program_box_traced_with_externs(
         trace.last_stage = "lower_bodies_error"
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
+    let body_module_box = body_result.module
+    module_frontend_assign_function_provenance(&! (*body_module_box), programs, file_paths, program_count, module_index)
 
     trace.body_lowered_modules = trace.body_lowered_modules + 1
     trace.lowered_modules = trace.lowered_modules + 1
@@ -4284,12 +4482,13 @@ fn module_frontend_lower_program_box_traced_with_externs(
     trace.patched_calls = trace.patched_calls + body_result.patch_stats.patched_calls
     trace.fallback_insertions = trace.fallback_insertions + body_result.patch_stats.fallback_insertions
     trace.last_stage = "lower_bodies_done"
-    module_frontend_lower_box_ok(body_result.module, body_result.patch_stats)
+    module_frontend_lower_box_ok(body_module_box, body_result.patch_stats)
 }
 
 fn module_frontend_lower_program_items_box_traced_with_externs(
     items: &Option<Box<ItemList>>,
     programs: &! [Program; 256],
+    file_paths: &![string; 256],
     program_count: i64,
     module_index: i64,
     trace: &! LoadMultimoduleIrTrace
@@ -4299,7 +4498,22 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_begin\n") }
     var epistemic = ir_empty_epistemic_section()
     let program = mf_program_from_items(items)
-    let summary_result = lower_program_to_ir_summary_box_with_externs_ref(&program, programs, program_count, module_index, &epistemic)
+    let binding_count = module_frontend_collect_external_bindings(
+        programs,
+        file_paths,
+        program_count,
+        module_index
+    )
+    let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
+        &program,
+        programs,
+        program_count,
+        module_index,
+        &! MF_EXTERN_BINDING_NAMES,
+        &! MF_EXTERN_BINDING_MODULE_IDS,
+        binding_count,
+        &epistemic
+    )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
     if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
         trace.last_stage = "lower_summary_error"
@@ -4310,6 +4524,9 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
     var summary_val = (*summary_result.summary)
+    let summary_module_box = summary_val.module
+    module_frontend_assign_function_provenance(&! (*summary_module_box), programs, file_paths, program_count, module_index)
+    summary_val.module = summary_module_box
     let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
         &program,
         &summary_val,
@@ -4325,6 +4542,8 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         trace.last_stage = "lower_bodies_error"
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
+    let body_module_box = body_result.module
+    module_frontend_assign_function_provenance(&! (*body_module_box), programs, file_paths, program_count, module_index)
 
     trace.body_lowered_modules = trace.body_lowered_modules + 1
     trace.lowered_modules = trace.lowered_modules + 1
@@ -4332,7 +4551,7 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     trace.patched_calls = trace.patched_calls + body_result.patch_stats.patched_calls
     trace.fallback_insertions = trace.fallback_insertions + body_result.patch_stats.fallback_insertions
     trace.last_stage = "lower_bodies_done"
-    module_frontend_lower_box_ok(body_result.module, body_result.patch_stats)
+    module_frontend_lower_box_ok(body_module_box, body_result.patch_stats)
 }
 
 fn module_frontend_populate_imported_programs(
@@ -4375,6 +4594,277 @@ fn module_frontend_populate_imported_programs(
 
     trace.resolved_modules = loaded
     loaded
+}
+
+// Return whether this program declares a free function/global slot with the
+// requested name. The lowering preseed represents both function declarations
+// and global storage entries as IrFunction slots, so ItemFn is the exact AST
+// surface that owns their definition identity.
+fn module_frontend_program_defines_ir_function(
+    program: &Program,
+    name: Name
+) -> bool with Mut, Panic, Div {
+    var current = &(*program).items
+    while true {
+        match *current {
+            Some(list) => {
+                let item = (*list).head
+                if item.kind == ItemKind::ItemFn && ir_name_eq(item.name, name) {
+                    return true
+                }
+                current = &(*list).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn module_frontend_import_item_list_contains(
+    items: &Option<Box<ImportItemList>>,
+    name: Name
+) -> bool with Mut, Panic, Div {
+    var current = items
+    while true {
+        match *current {
+            Some(list) => {
+                if ir_name_eq((*list).head, name) {
+                    return true
+                }
+                current = &(*list).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn module_frontend_use_path_to_loader_relpath(path: AstPath) -> string with Mut, Panic, Div, Alloc {
+    if path.seg_count <= 0 {
+        return ""
+    }
+    var buf: [i8; 512] = [0; 512]
+    let path_pair = string_list_to_path_buf(path.segments, 47 as i8, 0 as i8, buf, 0)
+    var final_buf = path_pair.0
+    var pos = path_pair.1
+    if pos < 508 {
+        final_buf[pos as usize] = 46 as i8
+        final_buf[(pos + 1) as usize] = 115 as i8
+        final_buf[(pos + 2) as usize] = 105 as i8
+        final_buf[(pos + 3) as usize] = 111 as i8
+        pos = pos + 4
+    }
+    str_from_bytes(final_buf, pos)
+}
+
+// Resolve the AST use route with the exact relpath resolver used by
+// module_frontend_import_files_from_source. That includes closest-ancestor,
+// stdlib and package-root (`use pkg` -> `packages/pkg/src/lib.sio`) lookup.
+fn module_frontend_use_path_targets_file(
+    use_path: AstPath,
+    importing_file_path: string,
+    candidate_file_path: string
+) -> bool with IO, Mut, Panic, Div, Alloc {
+    if use_path.seg_count <= 0 || str_len(candidate_file_path) <= 0 {
+        return false
+    }
+    let cur_dir = module_frontend_path_directory_slice(importing_file_path)
+    let rel_path = module_frontend_use_path_to_loader_relpath(use_path)
+    let resolved = module_frontend_resolve_import_relpath(rel_path, cur_dir)
+    str_eq(resolved, candidate_file_path)
+}
+
+fn module_frontend_program_explicitly_imports_from(
+    program: &Program,
+    importing_file_path: string,
+    candidate_file_path: string,
+    name: Name
+) -> bool with IO, Mut, Panic, Div, Alloc {
+    var current = &(*program).items
+    while true {
+        match *current {
+            Some(list) => {
+                let item = (*list).head
+                if item.kind == ItemKind::ItemUse &&
+                   module_frontend_use_path_targets_file(
+                       item.use_path,
+                       importing_file_path,
+                       candidate_file_path
+                   ) {
+                    var imports_name = item.use_glob
+                    match item.use_items {
+                        Some(_) => imports_name = module_frontend_import_item_list_contains(&item.use_items, name),
+                        None => imports_name = true,
+                    }
+                    if imports_name {
+                        return true
+                    }
+                }
+                current = &(*list).tail
+            }
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn module_frontend_function_defining_module(
+    programs: &! [Program; 256],
+    file_paths: &![string; 256],
+    program_count: i64,
+    self_index: i64,
+    name: Name
+) -> i64 with IO, Mut, Panic, Div, Alloc {
+    if self_index < 0 || self_index >= program_count {
+        return IR_DEFINING_MODULE_UNKNOWN
+    }
+    let self_program = (*programs)[self_index as usize]
+    if module_frontend_program_defines_ir_function(&self_program, name) {
+        return self_index
+    }
+    if native_v2_builtin_id_for_name(name) != 0 {
+        return IR_DEFINING_MODULE_BUILTIN
+    }
+
+    var explicit_module: i64 = IR_DEFINING_MODULE_UNKNOWN
+    var explicit_count: i64 = 0
+    var found_module: i64 = IR_DEFINING_MODULE_UNKNOWN
+    var found_count: i64 = 0
+    var i: i64 = 0
+    while i < program_count {
+        if i != self_index {
+            let candidate = (*programs)[i as usize]
+            if module_frontend_program_defines_ir_function(&candidate, name) {
+                found_module = i
+                found_count = found_count + 1
+                if module_frontend_program_explicitly_imports_from(
+                    &self_program,
+                    (*file_paths)[self_index as usize],
+                    (*file_paths)[i as usize],
+                    name
+                ) {
+                    explicit_module = i
+                    explicit_count = explicit_count + 1
+                }
+            }
+        }
+        i = i + 1
+    }
+    if explicit_count == 1 {
+        return explicit_module
+    }
+    if explicit_count > 1 {
+        return IR_DEFINING_MODULE_AMBIGUOUS
+    }
+    if found_count == 1 {
+        return found_module
+    }
+    if found_count > 1 {
+        return IR_DEFINING_MODULE_AMBIGUOUS
+    }
+    IR_DEFINING_MODULE_UNKNOWN
+}
+
+fn module_frontend_binding_already_present(
+    names: &![Name; 2048],
+    module_ids: &![i64; 2048],
+    count: i64,
+    defining_module_id: i64,
+    name: Name
+) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < count {
+        if (*module_ids)[i as usize] == defining_module_id &&
+           ir_name_eq((*names)[i as usize], name) {
+            return true
+        }
+        i = i + 1
+    }
+    false
+}
+
+fn module_frontend_collect_external_bindings(
+    programs: &! [Program; 256],
+    file_paths: &![string; 256],
+    program_count: i64,
+    self_index: i64
+) -> i64 with IO, Mut, Panic, Div, Alloc {
+    var count: i64 = 0
+    var module_index: i64 = 0
+    while module_index < program_count && count < 2048 {
+        if module_index != self_index {
+            var current = &(*programs)[module_index as usize].items
+            while count < 2048 {
+                match *current {
+                    Some(list) => {
+                        let item = (*list).head
+                        if item.kind == ItemKind::ItemFn {
+                            let owner = module_frontend_function_defining_module(
+                                programs,
+                                file_paths,
+                                program_count,
+                                self_index,
+                                item.name
+                            )
+                            if owner == module_index &&
+                               !module_frontend_binding_already_present(
+                                   &! MF_EXTERN_BINDING_NAMES,
+                                   &! MF_EXTERN_BINDING_MODULE_IDS,
+                                   count,
+                                   owner,
+                                   item.name
+                               ) {
+                                MF_EXTERN_BINDING_NAMES[count as usize] = item.name
+                                MF_EXTERN_BINDING_MODULE_IDS[count as usize] = owner
+                                count = count + 1
+                            }
+                        }
+                        current = &(*list).tail
+                    }
+                    _ => break,
+                }
+            }
+        }
+        module_index = module_index + 1
+    }
+    count
+}
+
+// Attach the loader's stable module index to summary/body slots not already
+// labeled by the DefId-aware preseed. Ambiguous or absent provenance remains
+// explicit and must fail closed during merge/finalize.
+fn module_frontend_assign_function_provenance(
+    module: &! IrModule,
+    programs: &! [Program; 256],
+    file_paths: &![string; 256],
+    program_count: i64,
+    self_index: i64
+) with IO, Mut, Panic, Div, Alloc {
+    var fi: i64 = 0
+    while fi < (*module).fn_count {
+        var func = (*module).functions[fi as usize]
+        let name = func.name
+        var defining_module_id = func.defining_module_id
+        if defining_module_id == IR_DEFINING_MODULE_UNKNOWN ||
+           defining_module_id == IR_DEFINING_MODULE_AMBIGUOUS {
+            defining_module_id = module_frontend_function_defining_module(
+                programs,
+                file_paths,
+                program_count,
+                self_index,
+                name
+            )
+            if defining_module_id == IR_DEFINING_MODULE_UNKNOWN && func.instr_count > 0 {
+                // Compiler-synthesized bodies (closures/impl lowering helpers)
+                // are necessarily defined by the module currently being lowered.
+                defining_module_id = self_index
+            }
+        }
+
+        func.defining_module_id = defining_module_id
+        (*module).functions[fi as usize] = func
+        fi = fi + 1
+    }
 }
 
 pub fn module_frontend_check_imported_modules_verdict(main_path: string) -> i64 with IO, Mut, Panic, Div, Alloc {
@@ -4502,6 +4992,7 @@ fn mf_arebox_apply(module: &! IrModule) with Alloc, Mut, Panic, Div {
 
 fn module_frontend_lower_programs_array_direct_box(
     programs: &! [Program; 256],
+    file_paths: &![string; 256],
     loaded: i64,
     trace: &! LoadMultimoduleIrTrace
 ) -> ModuleFrontendLowerDirectBoxResult with IO, Mut, Panic, Div, Alloc {
@@ -4513,7 +5004,7 @@ fn module_frontend_lower_programs_array_direct_box(
     trace.last_module_index = 0
     print("lower_array: seed_begin\n")
     let seed_items = (*programs)[0].items
-    let seed_lower = module_frontend_lower_program_items_box_traced_with_externs(&seed_items, programs, loaded, 0, trace)
+    let seed_lower = module_frontend_lower_program_items_box_traced_with_externs(&seed_items, programs, file_paths, loaded, 0, trace)
     print("lower_array: seed_done\n")
     if !seed_lower.ok {
         return module_frontend_lower_direct_box_error(seed_lower.error_msg)
@@ -4544,7 +5035,7 @@ fn module_frontend_lower_programs_array_direct_box(
                 // pulls in) falls inside [mark, reset).
                 let dep_arena_mark = __arena_mark()
                 let dep_items = (*programs)[i as usize].items
-                let dep_lower = module_frontend_lower_program_items_box_traced_with_externs(&dep_items, programs, loaded, i, trace)
+                let dep_lower = module_frontend_lower_program_items_box_traced_with_externs(&dep_items, programs, file_paths, loaded, i, trace)
                 print("lower_array: dep_lower_done ")
                 print_int(i)
                 print("\n")
@@ -4585,9 +5076,9 @@ fn module_frontend_lower_programs_array_direct_box(
                             var existing_body_idx: i64 = 0 - 1
                             var sfi: i64 = 0
                             while sfi < (*acc_box).fn_count {
-                                if ir_name_eq(
-                                    (*acc_box).functions[sfi as usize].name,
-                                    (*dep_box).functions[rfi as usize].name
+                                if ir_function_definition_identity_eq(
+                                    (*acc_box).functions[sfi as usize],
+                                    (*dep_box).functions[rfi as usize]
                                 ) {
                                     if (*acc_box).functions[sfi as usize].instr_count <= 0 {
                                         stub_idx = sfi
@@ -4629,12 +5120,10 @@ fn module_frontend_lower_programs_array_direct_box(
                             // dst_fi < acc_fn_before = a DEDUP reuse (body already present):
                             // skip re-placing it. Only place newly-appended functions.
                             if dst_fi >= acc_fn_before {
-                                // Remap cross-module call targets by symbol name while fn_id
+                                // Remap cross-module direct references by DefId while fn_id
                                 // values are still in the dependency module index space.
-                                var dep_func = (*dep_box).functions[mfi as usize]
-                                dep_func = ir_merge_remap_existing_call_targets(dep_func, &(*dep_box), &(*acc_box))
                                 var func = ir_merge_prepare_function_with_remap_from_func(
-                                    dep_func,
+                                    (*dep_box).functions[mfi as usize],
                                     &(*dep_box),
                                     &(*acc_box),
                                     dep_fn_count,
@@ -4714,6 +5203,7 @@ fn module_frontend_lower_programs_array_direct_box(
 
 fn module_frontend_lower_programs_array_boxed(
     programs: &! [Program; 256],
+    file_paths: &![string; 256],
     loaded: i64,
     trace: &! LoadMultimoduleIrTrace
 ) -> ModuleFrontendLowerBoxResult with IO, Mut, Panic, Div, Alloc {
@@ -4721,7 +5211,7 @@ fn module_frontend_lower_programs_array_boxed(
         return module_frontend_lower_box_error("no_modules_loaded")
     }
 
-    let lowered = module_frontend_lower_programs_array_direct_box(programs, loaded, trace)
+    let lowered = module_frontend_lower_programs_array_direct_box(programs, file_paths, loaded, trace)
     if !lowered.ok {
         return module_frontend_lower_box_error(lowered.error_msg)
     }
@@ -4882,6 +5372,7 @@ fn module_frontend_specialized_typecheck(programs: &! [Program; 256], count: i64
 
 fn module_frontend_merge_imported_into(
     programs: &! [Program; 256],
+    file_paths: &![string; 256],
     loaded: i64,
     trace: &! LoadMultimoduleIrTrace,
     out_module: &! IrModule
@@ -4906,7 +5397,7 @@ fn module_frontend_merge_imported_into(
 
     // Per-module check_program_with_artifacts cannot see cross-module imports and
     // either rejects (E137) or spins; multimodule verdict above is authoritative.
-    let lowered = module_frontend_lower_programs_array_direct_box(programs, loaded, trace)
+    let lowered = module_frontend_lower_programs_array_direct_box(programs, file_paths, loaded, trace)
     if !lowered.ok {
         print("IR lowering failed during merge: ")
         print(lowered.error_msg)
@@ -4920,7 +5411,16 @@ fn module_frontend_merge_imported_into(
     }
     let user_main_snapshot = ir_function_deep_copy((*module_box).functions[0 as usize])
     var finalized = ir_module_finalize_merged_calls(*module_box)
-    (*out_module) = ir_module_restore_user_main_calls(finalized, user_main_snapshot)
+    finalized = ir_module_restore_user_main_calls(finalized, user_main_snapshot)
+    (*out_module) = ir_module_refresh_direct_call_result_classes(finalized)
+    if loaded > 1 && !ir_module_direct_fn_provenance_is_complete(out_module) {
+        print("IR merge failed: unresolved or ambiguous function provenance\n")
+        return false
+    }
+    if loaded > 1 && !ir_module_direct_call_result_classes_are_complete(out_module) {
+        print("IR merge failed: incomplete direct-call result classification\n")
+        return false
+    }
     true
 }
 
@@ -5023,7 +5523,7 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
 
     trace.last_stage = "lower_merge"
     print("imported_compile: lower_begin\n")
-    let lowered = module_frontend_lower_programs_array_direct_box(&! programs, loaded, &! trace)
+    let lowered = module_frontend_lower_programs_array_direct_box(&! programs, &! file_paths, loaded, &! trace)
     print("imported_compile: lower_done\n")
     if !lowered.ok {
         print("IR lowering failed during merge: ")
@@ -5076,6 +5576,15 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
     }
     var merged_module = ir_module_finalize_merged_calls(*module_box)
     merged_module = ir_module_restore_user_main_calls(merged_module, user_main_snapshot)
+    merged_module = ir_module_refresh_direct_call_result_classes(merged_module)
+    if !ir_module_direct_fn_provenance_is_complete(&merged_module) {
+        print("IR merge failed: unresolved or ambiguous function provenance\n")
+        return 1
+    }
+    if !ir_module_direct_call_result_classes_are_complete(&merged_module) {
+        print("IR merge failed: incomplete direct-call result classification\n")
+        return 1
+    }
     if str_eq(read_env("SOUNIO_DUMP_ALL_CALLS"), "1") {
         print("DUMPALL: post_finalize\n")
         ir_module_dump_all_calls_diag(&merged_module)
@@ -6084,7 +6593,7 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
     }
 
     var merged_module = ir_empty_module()
-    if !module_frontend_merge_imported_into(&! programs, loaded, trace, &! merged_module) {
+    if !module_frontend_merge_imported_into(&! programs, &! file_paths, loaded, trace, &! merged_module) {
         return multimodule_ir_error("ir_lowering_failed")
     }
 

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -691,6 +691,13 @@ let IR_STRATEGY_PRECISION_PRESERVING_CHAOTIC: i64 = 6 // with Chaotic — A-laye
 let IR_STRATEGY_EXTERN: i64 = 6             // extern "C" fn — no body, C ABI stub (Sprint 108)
 let IR_STRATEGY_EXPORTED: i64 = 7           // export "C" fn — C ABI visibility (Sprint 109)
 
+// Function-definition provenance. Non-negative values are module indices from
+// the active module load. Negative sentinels are explicit states, never module
+// identities and never permission to choose a same-name function by order.
+pub let IR_DEFINING_MODULE_UNKNOWN: i64 = -1
+pub let IR_DEFINING_MODULE_AMBIGUOUS: i64 = -2
+pub let IR_DEFINING_MODULE_BUILTIN: i64 = -3
+
 pub fn ir_strategy_name(s: i64) -> string {
     if s == IR_STRATEGY_STANDARD { "standard" }
     else if s == IR_STRATEGY_AGGRESSIVE { "aggressive" }
@@ -705,6 +712,7 @@ pub fn ir_strategy_name(s: i64) -> string {
 
 pub struct IrFunction {
     pub name: Name,
+    pub defining_module_id: i64,
     pub instrs: [IrInstr; 2048],
     pub instr_count: i64,
     pub reg_count: i64,
@@ -3539,6 +3547,7 @@ fn ir_phi(dst: i64) -> IrInstr {
 pub fn ir_empty_function() -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
+        defining_module_id: IR_DEFINING_MODULE_UNKNOWN,
         instrs: [ir_nop(); 1024],
         instr_count: 0,
         reg_count: 0,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -477,6 +477,7 @@ fn lowerer_seed_module_from_summary(lo_in: Lowerer, summary: &IrProgramSummary) 
         let sm_strat = (*summary.module).functions[i as usize].compile_strategy
         var func = ir_empty_function()
         func.name = (*summary.module).functions[i as usize].name
+        func.defining_module_id = (*summary.module).functions[i as usize].defining_module_id
         func.param_count = (*summary.module).functions[i as usize].param_count
         func.compile_strategy = sm_strat
         func.returns_float = (*summary.module).functions[i as usize].returns_float
@@ -559,6 +560,7 @@ fn lowerer_new_from_program_summary_flat(summary: &IrProgramSummaryFlat, epistem
     while i < summary.module.fn_count && i < 1024 {
         var func = ir_empty_function()
         func.name = summary.module.functions[i as usize].name
+        func.defining_module_id = summary.module.functions[i as usize].defining_module_id
         func.param_count = summary.module.functions[i as usize].param_count
         func.compile_strategy = summary.module.functions[i as usize].compile_strategy
         func.returns_float = summary.module.functions[i as usize].returns_float
@@ -690,6 +692,38 @@ fn lowerer_find_or_add_fn_id_mut(lo: &! Lowerer, name: Name) -> i64 with Mut, Pa
     idx
 }
 
+fn lowerer_find_or_add_fn_identity_mut(
+    lo: &! Lowerer,
+    defining_module_id: i64,
+    name: Name
+) -> i64 with Mut, Panic, Div {
+    var module_box = (*lo).module
+    var i: i64 = 0
+    while i < (*module_box).fn_count {
+        let candidate = (*module_box).functions[i as usize]
+        if candidate.defining_module_id == defining_module_id && ir_name_eq(candidate.name, name) {
+            (*lo).module = module_box
+            return i
+        }
+        i = i + 1
+    }
+
+    if (*module_box).fn_count >= IR_MAX_FUNCS {
+        (*lo).module = module_box
+        lowerer_mark_error(lo)
+        return -1
+    }
+
+    let idx = (*module_box).fn_count
+    var fn_slot = (*module_box).functions[idx as usize]
+    fn_slot.name = name
+    fn_slot.defining_module_id = defining_module_id
+    (*module_box).functions[idx as usize] = fn_slot
+    (*module_box).fn_count = idx + 1
+    (*lo).module = module_box
+    idx
+}
+
 fn lowerer_flush_current_func_mut(lo: &! Lowerer) with Mut, Panic, Div {
     if (*lo).current_func_loaded && (*lo).current_fn >= 0 && (*lo).current_fn < (*(*lo).module).fn_count {
         var module_box = (*lo).module
@@ -719,6 +753,52 @@ fn lowerer_preseed_fn_signature_mut(
     // wrong and the write SIGSEGVs. This impl-method-signature preseed is the only
     // caller, so it stayed latent until an imported module carried an `impl`. Safe
     // idiom matches lowerer_preseed_program_items_mut's ItemFn branch.
+    var module_box = (*lo).module
+    var fn_slot = (*module_box).functions[fn_id as usize]
+    fn_slot.compile_strategy = strategy
+    fn_slot.returns_float = lower_opt_return_float_code(return_type)
+    fn_slot.return_struct_name = lower_opt_type_named_name(return_type)
+    fn_slot.param_count = ir_param_list_count_ref(params)
+    if strategy == IR_STRATEGY_INSTRUMENTED {
+        fn_slot.param_count = fn_slot.param_count + 1
+        if fn_slot.prof_counter_id < 0 {
+            let ctr_idx = (*module_box).prof_counter_count
+            if ctr_idx < 64 {
+                (*module_box).prof_counters[ctr_idx as usize] = IrProfCounterInfo {
+                    fn_id: fn_id,
+                    fn_name: name,
+                    counter_id: ctr_idx,
+                }
+                (*module_box).prof_counter_count = ctr_idx + 1
+                fn_slot.prof_counter_id = ctr_idx
+            } else {
+                lo.error_count = lo.error_count + 1
+                lo.had_error = true
+            }
+        }
+    }
+    fn_slot.param_regs = [IR_INVALID_REG; 64]
+    fn_slot.instr_count = 0
+    fn_slot.reg_count = 0
+    fn_slot.label_count = 0
+    (*module_box).functions[fn_id as usize] = fn_slot
+    (*lo).module = module_box
+}
+
+fn lowerer_preseed_external_fn_signature_mut(
+    lo: &! Lowerer,
+    defining_module_id: i64,
+    name: Name,
+    params: &Option<Box<ParamList>>,
+    return_type: &Option<Box<TypeExpr>>,
+    effects: &Option<Box<EffectList>>
+) with Mut, Panic, Div, Alloc {
+    let fn_id = lowerer_find_or_add_fn_identity_mut(lo, defining_module_id, name)
+    if fn_id < 0 {
+        return
+    }
+
+    let strategy = lowerer_compute_strategy_from_ast_ref(return_type, effects)
     var module_box = (*lo).module
     var fn_slot = (*module_box).functions[fn_id as usize]
     fn_slot.compile_strategy = strategy
@@ -847,15 +927,63 @@ fn lowerer_preseed_external_struct_items_mut(
                         _ => {}
                     }
                 }
-                // Also preseed imported FREE functions' signatures (returns_float /
-                // return_struct_name), so the caller recognizes an imported fn's f64
-                // return instead of treating the call result as int (cvtsi2sd). The
-                // struct-only preseed above left free-function returns unclassified.
-                if head_owned.kind == ItemKind::ItemFn {
-                    let fn_def_opt_ref: &Option<Box<FnDef>> = &head_owned.fn_def
+                current = &(*list).tail
+            }
+            _ => break
+        }
+    }
+}
+
+fn lowerer_extern_binding_contains(
+    names: &![Name; 2048],
+    module_ids: &![i64; 2048],
+    count: i64,
+    defining_module_id: i64,
+    name: Name
+) -> bool with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < count {
+        if (*module_ids)[i as usize] == defining_module_id &&
+           ir_name_eq((*names)[i as usize], name) {
+            return true
+        }
+        i = i + 1
+    }
+    false
+}
+
+fn lowerer_preseed_external_function_items_mut(
+    lo: &! Lowerer,
+    items: &Option<Box<ItemList>>,
+    defining_module_id: i64,
+    binding_names: &![Name; 2048],
+    binding_module_ids: &![i64; 2048],
+    binding_count: i64
+) with Mut, Panic, Div, Alloc {
+    var current = items
+    while true {
+        match *current {
+            Some(list) => {
+                let head = &(*list).head
+                if head.kind == ItemKind::ItemFn &&
+                   lowerer_extern_binding_contains(
+                       binding_names,
+                       binding_module_ids,
+                       binding_count,
+                       defining_module_id,
+                       head.name
+                   ) {
+                    let fn_def_opt_ref: &Option<Box<FnDef>> = &head.fn_def
                     match *fn_def_opt_ref {
                         Some(fd) => {
-                            lowerer_preseed_fn_signature_mut(lo, head_owned.name, &(*fd).params, &(*fd).return_type, &(*fd).effects)
+                            lowerer_preseed_external_fn_signature_mut(
+                                lo,
+                                defining_module_id,
+                                head.name,
+                                &(*fd).params,
+                                &(*fd).return_type,
+                                &(*fd).effects
+                            )
                         }
                         _ => {}
                     }
@@ -865,6 +993,23 @@ fn lowerer_preseed_external_struct_items_mut(
             _ => break
         }
     }
+}
+
+fn lowerer_assign_unknown_function_provenance_mut(
+    lo: &! Lowerer,
+    defining_module_id: i64
+) with Mut, Panic, Div {
+    var module_box = (*lo).module
+    var i: i64 = 0
+    while i < (*module_box).fn_count {
+        var fn_slot = (*module_box).functions[i as usize]
+        if fn_slot.defining_module_id == IR_DEFINING_MODULE_UNKNOWN {
+            fn_slot.defining_module_id = defining_module_id
+            (*module_box).functions[i as usize] = fn_slot
+        }
+        i = i + 1
+    }
+    (*lo).module = module_box
 }
 
 fn lowerer_register_struct_fields_direct_mut(
@@ -10227,6 +10372,9 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     programs: &! [Program; 256],
     program_count: i64,
     self_index: i64,
+    binding_names: &![Name; 2048],
+    binding_module_ids: &![i64; 2048],
+    binding_count: i64,
     epistemic: &IrEpistemicSection
 ) -> IrProgramSummaryBoxResult with Mut, Panic, Div, Alloc, IO {
     var lo = lowerer_new_with_epistemic(epistemic)
@@ -10239,6 +10387,22 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
         i = i + 1
     }
     lowerer_preseed_program_items_mut(&! lo, &prog.items, ir_empty_name())
+    lowerer_assign_unknown_function_provenance_mut(&! lo, self_index)
+    i = 0
+    while i < program_count {
+        if i != self_index {
+            let ext_prog = (*programs)[i as usize]
+            lowerer_preseed_external_function_items_mut(
+                &! lo,
+                &ext_prog.items,
+                i,
+                binding_names,
+                binding_module_ids,
+                binding_count
+            )
+        }
+        i = i + 1
+    }
     let error_count = lo.error_count
     let had_error = lo.had_error
     let inner = ir_program_summary_from_lowerer(lo)

--- a/self-hosted/ir/optimize.sio
+++ b/self-hosted/ir/optimize.sio
@@ -608,6 +608,7 @@ fn opt_check_load_imm(func: IrFunction, pos: i64, expected_val: i64) -> bool {
 fn opt_make_test_func(instrs: [IrInstr; 1024], count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
+        defining_module_id: IR_DEFINING_MODULE_UNKNOWN,
         instrs: instrs,
         instr_count: count,
         reg_count: count + 1,

--- a/self-hosted/ir/serialize.sio
+++ b/self-hosted/ir/serialize.sio
@@ -6,7 +6,7 @@ use parser::ast::*
 use ir::ir::*
 use check::types::*
 //
-// SOIR v3 Binary Format:
+// SOIR v5 Binary Format:
 // ─────────────────────────
 // Header (8 bytes):
 //   - Magic: "SOIR" (0x534F4952 little-endian)
@@ -31,6 +31,7 @@ use check::types::*
 //   - compile_strategy: i64
 //   - prof_counter_id: i64
 //   - hyper_algebra_kind: i64 (v3+)
+//   - defining_module_id: i64 (v5+; older artifacts deserialize as UNKNOWN)
 //   - instrs: array of IrInstr
 //
 // IrInstr encoding (fixed-size, 128 bytes):
@@ -45,7 +46,7 @@ use check::types::*
 //   - arg_count: i64
 
 let SOIR_MAGIC: i64 = 1380206931  // "SOIR" as i32 cast to i64
-let SOIR_VERSION: i8 = 4
+let SOIR_VERSION: i8 = 5
 let SOIR_MAX_SIZE: i64 = 131072  // 128KB max module size
 
 fn write_i8(buf: [i8; 131072], pos: i64, val: i8) -> ([i8; 131072], i64) with Mut, Panic, Div {
@@ -581,6 +582,12 @@ fn serialize_ir_function(buf: [i8; 131072], pos: i64, func: IrFunction) -> ([i8;
         p = hyper_alg_pair.1
     }
 
+    if SOIR_VERSION >= 5 {
+        let defining_module_pair = write_i64(b, p, func.defining_module_id)
+        b = defining_module_pair.0
+        p = defining_module_pair.1
+    }
+
     // Write instructions
     var j: i64 = 0
     while j < func.instr_count {
@@ -642,6 +649,13 @@ fn deserialize_ir_function(buf: [i8; 131072], pos: i64, version: i8) -> (IrFunct
         p = hyper_alg_pair.1
     }
 
+    var defining_module_id: i64 = IR_DEFINING_MODULE_UNKNOWN
+    if version >= 5 {
+        let defining_module_pair = read_i64(buf, p)
+        defining_module_id = defining_module_pair.0
+        p = defining_module_pair.1
+    }
+
     // Read instructions
     var instrs: [IrInstr; 2048] = [ir_nop(); 2048]
     var j: i64 = 0
@@ -654,6 +668,7 @@ fn deserialize_ir_function(buf: [i8; 131072], pos: i64, version: i8) -> (IrFunct
 
     let func = IrFunction {
         name: name,
+        defining_module_id: defining_module_id,
         instrs: instrs,
         instr_count: instr_count,
         reg_count: reg_count,
@@ -4447,7 +4462,7 @@ fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Pani
     }
 
     let version = buf[4]
-    if version != 1 && version != 2 as i8 && version != 3 as i8 && version != SOIR_VERSION {
+    if version != 1 && version != 2 as i8 && version != 3 as i8 && version != 4 as i8 && version != SOIR_VERSION {
         return ir_empty_module()
     }
 

--- a/self-hosted/ir/ssa.sio
+++ b/self-hosted/ir/ssa.sio
@@ -1061,6 +1061,7 @@ fn cfg_pred_at(cfg: CFGInfo, block: i64, idx: i64) -> i64 with Mut, Panic, Div {
 fn ssa_make_test_func(instrs: [IrInstr; 32768], count: i64, reg_count: i64, label_count: i64) -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
+        defining_module_id: IR_DEFINING_MODULE_UNKNOWN,
         instrs: instrs,
         instr_count: count,
         reg_count: reg_count,

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -870,9 +870,12 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
     var module = ir_empty_module()
     module.fn_count = 1
+    module.string_count = 1
+    module.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
 
     var func = ir_empty_function()
     func.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
+    func.defining_module_id = 37
     func.instr_count = 2
     func.reg_count = 1
     func.instrs[0] = ir_load_imm(0, 42)
@@ -893,6 +896,30 @@ fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
         return false
     }
     if restored.functions[0].instrs[0].imm_i64 != 42 {
+        return false
+    }
+    if restored.functions[0].defining_module_id != 37 {
+        return false
+    }
+
+    // Build a genuine v4 module buffer from the v5 fixture: remove the v5-only
+    // provenance word and shift both instructions and following module sections.
+    // Offset = header + fn_count + Name + 4 counts + 64 params + strategy/prof/hyper.
+    var legacy_buf = buf
+    let provenance_pos: i64 = 8 + 8 + 136 + 32 + 512 + 24
+    var shift_pos = provenance_pos
+    while shift_pos + 8 < len {
+        legacy_buf[shift_pos as usize] = legacy_buf[(shift_pos + 8) as usize]
+        shift_pos = shift_pos + 1
+    }
+    legacy_buf[4] = 4 as i8
+    let legacy_restored = deserialize_ir_module(legacy_buf, len - 8)
+    if legacy_restored.fn_count != 1 ||
+       legacy_restored.functions[0].defining_module_id != IR_DEFINING_MODULE_UNKNOWN ||
+       legacy_restored.functions[0].instr_count != 2 ||
+       legacy_restored.functions[0].instrs[0].imm_i64 != 42 ||
+       legacy_restored.string_count != 1 ||
+       !ir_name_eq(legacy_restored.string_table[0], module.string_table[0]) {
         return false
     }
 


### PR DESCRIPTION
> **DO NOT MERGE**

Stacked draft on `agent/issue854-contextual-checker-partial-20260713` (PR #867 head). This is the phase 1-2 DefId provenance slice for #854. It intentionally remains blocked and is not merge-eligible.

## Scope

- Add compiler-owned `IrFunction.defining_module_id` with explicit unknown, ambiguous, and builtin sentinels.
- Carry exact `(defining_module_id, name)` identity through summary/body lowering, extern preseed, merge/remap/finalize/promote/compact, and direct call/reference validation.
- Fail closed when a bare name is absent or ambiguous; do not select the first function by name.
- Refresh scalar call return classification and paired float markers from canonical post-finalization targets without changing DefIds, labels, call args, or SRET calls.
- Bump SOIR v4 to v5 for provenance, retain v1-v4 decoding as unknown provenance, and add roundtrip/downgrade coverage.

This does **not** add `is_public`, object linkage, symbol mangling, or object emission semantics.

## Exact receipts

Current-source modular build, fresh default `lean_single` seed, `ulimit -s 65536`, global build lock:

```
rc=0
elapsed=3:11.25
max_rss_kb=513180
elf_size_bytes=98451235
elf_sha256=e38752bdaf2845f118bf1469ff1865a2d92509fd480ba27be18593f2fea1a186
```

#854 visibility/context acceptance gate against that ELF:

```
rc=0
context_state=resolved runtime_state=pass ambiguous_global=E137 single_e175=0 matrix_e175=0 true_private_fn=E175 true_private_struct=E176 true_private_enum=E177
```

Controls:

- `madaros_multimodule_witness.sh`: GREEN, 11/11.
- `sret_forwarding_cross_module_min.sio`: `rc=0`, `CROSS_SRET_MIN_OK`.
- Final independent review: CLEAN for diff SHA-256 `0846133dc80db925713285fef4b1003e97b7ca05a187d6caa9176589dbe4506b`.
- `git diff --check`: clean.
- Temporary probes/runners: absent.

## Blocking contract

**Blocker-ID:** `BLK-20260713-IR-SERIALIZE-CAPACITY-DRIFT`  
**Severity:** B2  
**Class:** bootstrap-test-harness  
**Evidence:** E2  
**Owner:** IR capacity/serialization lane  
**Observed:** base `IrFunction.instrs` has capacity 2048 while `ir_empty_function` still initializes 1024; `deserialize_ir_module` similarly allocates 1024 functions for a 2048-function `IrModule`. Madaros reports E016 (expected 2048, found 1024), so T17 cannot currently establish the SOIR claim.  
**Acceptance gate:** T17 v5 provenance roundtrip plus genuine v4 downgrade both complete with `rc=0`.  
**Next action:** align the 1024/2048 capacities, review the resulting frame growth, rebuild, and rerun T17.

## Claim boundary

- Proven here: modular runtime resolution no longer exits with rc12 for the #854 gate; exact DefId identity survives the exercised compile/link path; negative visibility diagnostics remain classified.
- Not proven here: SOIR v5 roundtrip/backward compatibility, due to the blocker above.
- **No `emit-obj` claim.** Object linkage/mangling remains a later phase.
- Legacy/bootstrap paths are intentionally retained.
- No math, clinical-pathway, or external-facing artifact was changed; mandatory LLM offload categories were not triggered.

