### PR TITLE
fix(ir): make SOIR capacity handling fail closed [BLOCKED]

### DIFF
--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -3548,7 +3548,7 @@ pub fn ir_empty_function() -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
         defining_module_id: IR_DEFINING_MODULE_UNKNOWN,
-        instrs: [ir_nop(); 1024],
+        instrs: [ir_nop(); 2048],
         instr_count: 0,
         reg_count: 0,
         label_count: 0,

--- a/self-hosted/ir/serialize.sio
+++ b/self-hosted/ir/serialize.sio
@@ -10,7 +10,7 @@ use check::types::*
 // ─────────────────────────
 // Header (8 bytes):
 //   - Magic: "SOIR" (0x534F4952 little-endian)
-//   - Version: 3 (1 byte)
+//   - Version: 5 (1 byte)
 //   - Reserved: 0x00 (3 bytes padding)
 //
 // Body:
@@ -34,7 +34,7 @@ use check::types::*
 //   - defining_module_id: i64 (v5+; older artifacts deserialize as UNKNOWN)
 //   - instrs: array of IrInstr
 //
-// IrInstr encoding (fixed-size, 128 bytes):
+// IrInstr encoding (fixed-size, 232 bytes):
 //   - op: IrOpcode (1 byte + 7 padding)
 //   - dst, src1, src2: i64 (8 bytes each)
 //   - imm_i64: i64
@@ -48,9 +48,26 @@ use check::types::*
 let SOIR_MAGIC: i64 = 1380206931  // "SOIR" as i32 cast to i64
 let SOIR_VERSION: i8 = 5
 let SOIR_MAX_SIZE: i64 = 131072  // 128KB max module size
+let SOIR_NAME_SIZE: i64 = 136
+let SOIR_INSTR_SIZE: i64 = 232
+let SOIR_FUNCTION_HEADER_V1_SIZE: i64 = 696
+let SOIR_FUNCTION_HEADER_V3_SIZE: i64 = 704
+let SOIR_FUNCTION_HEADER_V5_SIZE: i64 = 712
+let SOIR_INVALID_POS: i64 = 131073
+
+// Low-level readers and writers share the fixed SOIR buffer type, so keep the
+// active logical limit and failure bit here. This avoids widening every helper
+// signature while still making every primitive access capacity-aware.
+var SOIR_WRITE_FAILED: bool = false
+var SOIR_READ_FAILED: bool = false
+var SOIR_READ_LIMIT: i64 = 0
 
 fn write_i8(buf: [i8; 131072], pos: i64, val: i8) -> ([i8; 131072], i64) with Mut, Panic, Div {
     var b = buf
+    if pos < 0 || pos >= SOIR_MAX_SIZE {
+        SOIR_WRITE_FAILED = true
+        return (b, SOIR_INVALID_POS)
+    }
     b[pos] = val
     (b, pos + 1)
 }
@@ -96,6 +113,10 @@ fn write_f64(buf: [i8; 131072], pos: i64, val: f64) -> ([i8; 131072], i64) with 
 
 fn write_name(buf: [i8; 131072], pos: i64, n: Name) -> ([i8; 131072], i64) with Mut, Panic, Div {
     var b = buf
+    if pos < 0 || pos + SOIR_NAME_SIZE > SOIR_MAX_SIZE {
+        SOIR_WRITE_FAILED = true
+        return (b, SOIR_INVALID_POS)
+    }
     var p = pos
     // Write length first
     let pair = write_i64(b, p, n.len)
@@ -111,10 +132,18 @@ fn write_name(buf: [i8; 131072], pos: i64, n: Name) -> ([i8; 131072], i64) with 
 }
 
 fn read_i8(buf: [i8; 131072], pos: i64) -> (i8, i64) with Mut, Panic, Div {
+    if pos < 0 || pos >= SOIR_READ_LIMIT {
+        SOIR_READ_FAILED = true
+        return (0 as i8, pos)
+    }
     (buf[pos], pos + 1)
 }
 
 fn read_i64(buf: [i8; 131072], pos: i64) -> (i64, i64) with Mut, Panic, Div {
+    if pos < 0 || pos + 8 > SOIR_READ_LIMIT {
+        SOIR_READ_FAILED = true
+        return (0, pos)
+    }
     // Little-endian decoding - mask to ensure unsigned byte interpretation
     let raw0: i64 = buf[pos + 0] as i64
     let raw1: i64 = buf[pos + 1] as i64
@@ -202,6 +231,10 @@ fn read_f64(buf: [i8; 131072], pos: i64) -> (f64, i64) with Mut, Panic, Div {
 }
 
 fn read_name(buf: [i8; 131072], pos: i64) -> (Name, i64) with Mut, Panic, Div {
+    if pos < 0 || pos + SOIR_NAME_SIZE > SOIR_READ_LIMIT {
+        SOIR_READ_FAILED = true
+        return (Name { buf: [0; 128], len: 0 }, pos)
+    }
     let len_pair = read_i64(buf, pos)
     let len = len_pair.0
     var p = len_pair.1
@@ -537,61 +570,61 @@ fn deserialize_ir_instr(buf: [i8; 131072], pos: i64) -> (IrInstr, i64) with Mut,
     (instr, p)
 }
 
-fn serialize_ir_function(buf: [i8; 131072], pos: i64, func: IrFunction) -> ([i8; 131072], i64) with Mut, Panic, Div {
+fn serialize_ir_function(buf: [i8; 131072], pos: i64, func: &IrFunction) -> ([i8; 131072], i64) with Mut, Panic, Div {
     var b = buf
     var p = pos
 
-    let name_pair = write_name(b, p, func.name)
+    let name_pair = write_name(b, p, (*func).name)
     b = name_pair.0
     p = name_pair.1
-    let instr_count_pair = write_i64(b, p, func.instr_count)
+    let instr_count_pair = write_i64(b, p, (*func).instr_count)
     b = instr_count_pair.0
     p = instr_count_pair.1
-    let reg_count_pair = write_i64(b, p, func.reg_count)
+    let reg_count_pair = write_i64(b, p, (*func).reg_count)
     b = reg_count_pair.0
     p = reg_count_pair.1
-    let label_count_pair = write_i64(b, p, func.label_count)
+    let label_count_pair = write_i64(b, p, (*func).label_count)
     b = label_count_pair.0
     p = label_count_pair.1
-    let param_count_pair = write_i64(b, p, func.param_count)
+    let param_count_pair = write_i64(b, p, (*func).param_count)
     b = param_count_pair.0
     p = param_count_pair.1
 
     // Write param_regs array
     var i: i64 = 0
     while i < 64 {
-        let reg_pair = write_i64(b, p, func.param_regs[i])
+        let reg_pair = write_i64(b, p, (*func).param_regs[i as usize])
         b = reg_pair.0
         p = reg_pair.1
         i = i + 1
     }
 
     // Sprint 38: Write compile strategy
-    let strategy_pair = write_i64(b, p, func.compile_strategy)
+    let strategy_pair = write_i64(b, p, (*func).compile_strategy)
     b = strategy_pair.0
     p = strategy_pair.1
 
     // Sprint 44: Write prof_counter_id
-    let prof_ctr_pair = write_i64(b, p, func.prof_counter_id)
+    let prof_ctr_pair = write_i64(b, p, (*func).prof_counter_id)
     b = prof_ctr_pair.0
     p = prof_ctr_pair.1
 
     if SOIR_VERSION >= 3 {
-        let hyper_alg_pair = write_i64(b, p, func.hyper_algebra_kind)
+        let hyper_alg_pair = write_i64(b, p, (*func).hyper_algebra_kind)
         b = hyper_alg_pair.0
         p = hyper_alg_pair.1
     }
 
     if SOIR_VERSION >= 5 {
-        let defining_module_pair = write_i64(b, p, func.defining_module_id)
+        let defining_module_pair = write_i64(b, p, (*func).defining_module_id)
         b = defining_module_pair.0
         p = defining_module_pair.1
     }
 
     // Write instructions
     var j: i64 = 0
-    while j < func.instr_count {
-        let instr_pair = serialize_ir_instr(b, p, func.instrs[j])
+    while j < (*func).instr_count {
+        let instr_pair = serialize_ir_instr(b, p, (*func).instrs[j as usize])
         b = instr_pair.0
         p = instr_pair.1
         j = j + 1
@@ -600,15 +633,34 @@ fn serialize_ir_function(buf: [i8; 131072], pos: i64, func: IrFunction) -> ([i8;
     (b, p)
 }
 
-fn deserialize_ir_function(buf: [i8; 131072], pos: i64, version: i8) -> (IrFunction, i64) with Mut, Panic, Div {
+fn deserialize_ir_function_into(buf: [i8; 131072], pos: i64, version: i8, out: &! IrFunction) -> (i64, bool) with Mut, Panic, Div {
+    let header_size = if version >= 5 {
+        SOIR_FUNCTION_HEADER_V5_SIZE
+    } else if version >= 3 {
+        SOIR_FUNCTION_HEADER_V3_SIZE
+    } else {
+        SOIR_FUNCTION_HEADER_V1_SIZE
+    }
+    if pos < 0 || pos + header_size > SOIR_READ_LIMIT {
+        SOIR_READ_FAILED = true
+        return (pos, false)
+    }
+
     var p = pos
     let name_pair = read_name(buf, p)
     let name = name_pair.0
     p = name_pair.1
+    if name.len < 0 || name.len > 128 {
+        return (p, false)
+    }
 
     let instr_count_pair = read_i64(buf, p)
     let instr_count = instr_count_pair.0
     p = instr_count_pair.1
+
+    if instr_count < 0 || instr_count > IR_MAX_INSTRS {
+        return (p, false)
+    }
 
     let reg_count_pair = read_i64(buf, p)
     let reg_count = reg_count_pair.0
@@ -623,11 +675,10 @@ fn deserialize_ir_function(buf: [i8; 131072], pos: i64, version: i8) -> (IrFunct
     p = param_count_pair.1
 
     // Read param_regs array
-    var param_regs: [i64; 64] = [IR_INVALID_REG; 64]
     var i: i64 = 0
     while i < 64 {
         let reg_pair = read_i64(buf, p)
-        param_regs[i] = reg_pair.0
+        (*out).param_regs[i as usize] = reg_pair.0
         p = reg_pair.1
         i = i + 1
     }
@@ -656,34 +707,42 @@ fn deserialize_ir_function(buf: [i8; 131072], pos: i64, version: i8) -> (IrFunct
         p = defining_module_pair.1
     }
 
-    // Read instructions
-    var instrs: [IrInstr; 2048] = [ir_nop(); 2048]
+    if p < 0 || instr_count > (SOIR_READ_LIMIT - p) / SOIR_INSTR_SIZE {
+        SOIR_READ_FAILED = true
+        return (p, false)
+    }
+
+    // Commit scalar metadata, but publish instr_count only after the complete
+    // body has decoded. Callers keep fn_count at zero until every function and
+    // string succeeds, so a partial destination is never observable as valid.
+    (*out).name = name
+    (*out).defining_module_id = defining_module_id
+    (*out).instr_count = 0
+    (*out).reg_count = reg_count
+    (*out).label_count = label_count
+    (*out).param_count = param_count
+    (*out).compile_strategy = compile_strategy
+    (*out).returns_float = 0
+    (*out).return_struct_name = ir_empty_name()
+    (*out).prof_counter_id = prof_counter_id
+    (*out).hyper_algebra_kind = hyper_algebra_kind
+    (*out).is_sret = 0
+    (*out).sret_dest_reg = -1
+    (*out).bss_size = 0
+
     var j: i64 = 0
     while j < instr_count {
         let instr_pair = deserialize_ir_instr(buf, p)
-        instrs[j] = instr_pair.0
+        if SOIR_READ_FAILED {
+            return (p, false)
+        }
+        (*out).instrs[j as usize] = instr_pair.0
         p = instr_pair.1
         j = j + 1
     }
 
-    let func = IrFunction {
-        name: name,
-        defining_module_id: defining_module_id,
-        instrs: instrs,
-        instr_count: instr_count,
-        reg_count: reg_count,
-        label_count: label_count,
-        param_count: param_count,
-        param_regs: param_regs,
-        compile_strategy: compile_strategy,
-        returns_float: 0,
-        return_struct_name: ir_empty_name(),
-        prof_counter_id: prof_counter_id,
-        hyper_algebra_kind: hyper_algebra_kind,
-        is_sret: 0,
-        sret_dest_reg: -1,
-    }
-    (func, p)
+    (*out).instr_count = instr_count
+    (p, true)
 }
 
 fn write_ir_algebra_info(buf: [i8; 131072], pos: i64, info: IrAlgebraInfo) -> ([i8; 131072], i64) with Mut, Panic, Div {
@@ -761,6 +820,10 @@ fn read_ir_algebra_info(buf: [i8; 131072], pos: i64) -> (IrAlgebraInfo, i64) wit
 fn serialize_ir_algebra_table(buf: [i8; 131072], pos: i64, table: IrAlgebraTable) -> ([i8; 131072], i64) with Mut, Panic, Div {
     var b = buf
     var p = pos
+    if table.count < 0 || table.count > 32 {
+        SOIR_WRITE_FAILED = true
+        return (b, SOIR_INVALID_POS)
+    }
     let count_pair = write_i64(b, p, table.count)
     b = count_pair.0
     p = count_pair.1
@@ -780,14 +843,17 @@ fn deserialize_ir_algebra_table(buf: [i8; 131072], pos: i64) -> (IrAlgebraTable,
     let count = count_pair.0
     p = count_pair.1
     var table = ir_empty_algebra_table()
+    if !soir_require_count(count, 32) {
+        return (table, p)
+    }
     var i: i64 = 0
-    while i < count && i < 32 {
+    while i < count {
         let info_pair = read_ir_algebra_info(buf, p)
         table.entries[i] = info_pair.0
         p = info_pair.1
         i = i + 1
     }
-    table.count = if count > 32 { 32 } else { count }
+    table.count = count
     (table, p)
 }
 
@@ -3523,6 +3589,54 @@ fn read_hyper_expr_info(buf: [i8; 131072], pos: i64) -> (IrHyperExprInfo, i64) w
     }, p)
 }
 
+fn soir_epistemic_counts_valid(ep: &IrEpistemicSection) -> bool {
+    (*ep).model_family_count >= 0 && (*ep).model_family_count <= IR_MAX_EPI_MODEL_FAMILIES &&
+    (*ep).policy_count >= 0 && (*ep).policy_count <= IR_MAX_EPI_POLICIES &&
+    (*ep).decision_policy_count >= 0 && (*ep).decision_policy_count <= IR_MAX_EPI_DECISION_POLICIES &&
+    (*ep).deferral_policy_count >= 0 && (*ep).deferral_policy_count <= IR_MAX_EPI_DEFERRAL_POLICIES &&
+    (*ep).acquisition_policy_count >= 0 && (*ep).acquisition_policy_count <= IR_MAX_EPI_ACQUISITION_POLICIES &&
+    (*ep).recourse_policy_count >= 0 && (*ep).recourse_policy_count <= IR_MAX_EPI_RECOURSE_POLICIES &&
+    (*ep).validation_count >= 0 && (*ep).validation_count <= IR_MAX_EPI_VALIDATIONS &&
+    (*ep).mechanistic_report_count >= 0 && (*ep).mechanistic_report_count <= IR_MAX_EPI_MECHANISTIC_REPORTS &&
+    (*ep).posterior_weights_count >= 0 && (*ep).posterior_weights_count <= IR_MAX_EPI_POSTERIOR_WEIGHTS &&
+    (*ep).counterexample_count >= 0 && (*ep).counterexample_count <= IR_MAX_EPI_COUNTEREXAMPLES &&
+    (*ep).audit_count >= 0 && (*ep).audit_count <= IR_MAX_EPI_AUDITS &&
+    (*ep).contest_count >= 0 && (*ep).contest_count <= IR_MAX_EPI_CONTESTS &&
+    (*ep).contest_witness_count >= 0 && (*ep).contest_witness_count <= IR_MAX_EPI_CONTEST_WITNESSES &&
+    (*ep).robust_proof_count >= 0 && (*ep).robust_proof_count <= IR_MAX_EPI_ROBUST_PROOFS &&
+    (*ep).validated_manifest_count >= 0 && (*ep).validated_manifest_count <= IR_MAX_EPI_VALIDATED_MANIFESTS &&
+    (*ep).decision_certificate_count >= 0 && (*ep).decision_certificate_count <= IR_MAX_EPI_DECISION_CERTIFICATES &&
+    (*ep).deferred_certificate_count >= 0 && (*ep).deferred_certificate_count <= IR_MAX_EPI_DEFERRED_CERTIFICATES &&
+    (*ep).deferred_reason_witness_count >= 0 && (*ep).deferred_reason_witness_count <= IR_MAX_EPI_DEFERRED_REASON_WITNESSES &&
+    (*ep).acquisition_plan_count >= 0 && (*ep).acquisition_plan_count <= IR_MAX_EPI_ACQUISITION_PLANS &&
+    (*ep).acquisition_reason_witness_count >= 0 && (*ep).acquisition_reason_witness_count <= IR_MAX_EPI_ACQUISITION_REASON_WITNESSES &&
+    (*ep).recourse_plan_count >= 0 && (*ep).recourse_plan_count <= IR_MAX_EPI_RECOURSE_PLANS &&
+    (*ep).recourse_reason_witness_count >= 0 && (*ep).recourse_reason_witness_count <= IR_MAX_EPI_RECOURSE_REASON_WITNESSES &&
+    (*ep).alternative_policy_count >= 0 && (*ep).alternative_policy_count <= IR_MAX_EPI_ALTERNATIVE_POLICIES &&
+    (*ep).alternative_frontier_count >= 0 && (*ep).alternative_frontier_count <= IR_MAX_EPI_ALTERNATIVE_FRONTIERS &&
+    (*ep).alternative_candidate_count >= 0 && (*ep).alternative_candidate_count <= IR_MAX_EPI_ALTERNATIVE_CANDIDATES &&
+    (*ep).alternative_set_count >= 0 && (*ep).alternative_set_count <= IR_MAX_EPI_ALTERNATIVE_SETS &&
+    (*ep).alternative_reason_witness_count >= 0 && (*ep).alternative_reason_witness_count <= IR_MAX_EPI_ALTERNATIVE_REASON_WITNESSES &&
+    (*ep).transition_policy_count >= 0 && (*ep).transition_policy_count <= IR_MAX_EPI_TRANSITION_POLICIES &&
+    (*ep).transition_protocol_count >= 0 && (*ep).transition_protocol_count <= IR_MAX_EPI_TRANSITION_PROTOCOLS &&
+    (*ep).transition_step_count >= 0 && (*ep).transition_step_count <= IR_MAX_EPI_TRANSITION_STEPS &&
+    (*ep).transition_plan_count >= 0 && (*ep).transition_plan_count <= IR_MAX_EPI_TRANSITION_PLANS &&
+    (*ep).transition_reason_witness_count >= 0 && (*ep).transition_reason_witness_count <= IR_MAX_EPI_TRANSITION_REASON_WITNESSES &&
+    (*ep).monitoring_policy_count >= 0 && (*ep).monitoring_policy_count <= IR_MAX_EPI_MONITORING_POLICIES &&
+    (*ep).observed_transition_count >= 0 && (*ep).observed_transition_count <= IR_MAX_EPI_OBSERVED_TRANSITIONS &&
+    (*ep).rollback_certificate_count >= 0 && (*ep).rollback_certificate_count <= IR_MAX_EPI_ROLLBACK_CERTIFICATES &&
+    (*ep).hyper_expr_count >= 0 && (*ep).hyper_expr_count <= IR_MAX_EPI_HYPER_EXPRS
+}
+
+fn soir_require_count(count: i64, max_count: i64) -> bool with Mut {
+    if count < 0 || count > max_count {
+        SOIR_READ_FAILED = true
+        false
+    } else {
+        true
+    }
+}
+
 fn serialize_ir_epistemic_section(buf: [i8; 131072], pos: i64, ep: IrEpistemicSection) -> ([i8; 131072], i64) with Mut, Panic, Div, Alloc {
     var b = buf
     var p = pos
@@ -3928,13 +4042,14 @@ fn serialize_ir_epistemic_section(buf: [i8; 131072], pos: i64, ep: IrEpistemicSe
     (b, p)
 }
 
-fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemicSection, i64) with Mut, Panic, Div, Alloc {
+fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64, version: i8) -> (IrEpistemicSection, i64) with Mut, Panic, Div, Alloc {
     var p = pos
     var ep = ir_empty_epistemic_section()
 
     let c0 = read_i64(buf, p)
     ep.model_family_count = c0.0
     p = c0.1
+    if !soir_require_count(ep.model_family_count, IR_MAX_EPI_MODEL_FAMILIES) { return (ep, p) }
     var i: i64 = 0
     while i < ep.model_family_count && i < IR_MAX_EPI_MODEL_FAMILIES {
         let pair = read_model_family_info(buf, p)
@@ -3946,6 +4061,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c1 = read_i64(buf, p)
     ep.policy_count = c1.0
     p = c1.1
+    if !soir_require_count(ep.policy_count, IR_MAX_EPI_POLICIES) { return (ep, p) }
     i = 0
     while i < ep.policy_count && i < IR_MAX_EPI_POLICIES {
         let pair = read_ir_policy_info(buf, p)
@@ -3957,6 +4073,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c2 = read_i64(buf, p)
     ep.validation_count = c2.0
     p = c2.1
+    if !soir_require_count(ep.validation_count, IR_MAX_EPI_VALIDATIONS) { return (ep, p) }
     i = 0
     while i < ep.validation_count && i < IR_MAX_EPI_VALIDATIONS {
         let pair = read_validation_policy_info(buf, p)
@@ -3968,6 +4085,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c3 = read_i64(buf, p)
     ep.mechanistic_report_count = c3.0
     p = c3.1
+    if !soir_require_count(ep.mechanistic_report_count, IR_MAX_EPI_MECHANISTIC_REPORTS) { return (ep, p) }
     i = 0
     while i < ep.mechanistic_report_count && i < IR_MAX_EPI_MECHANISTIC_REPORTS {
         let pair = read_mechanistic_report_info(buf, p)
@@ -3979,6 +4097,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c4 = read_i64(buf, p)
     ep.posterior_weights_count = c4.0
     p = c4.1
+    if !soir_require_count(ep.posterior_weights_count, IR_MAX_EPI_POSTERIOR_WEIGHTS) { return (ep, p) }
     i = 0
     while i < ep.posterior_weights_count && i < IR_MAX_EPI_POSTERIOR_WEIGHTS {
         let pair = read_posterior_weights_info(buf, p)
@@ -3990,6 +4109,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c5 = read_i64(buf, p)
     ep.counterexample_count = c5.0
     p = c5.1
+    if !soir_require_count(ep.counterexample_count, IR_MAX_EPI_COUNTEREXAMPLES) { return (ep, p) }
     i = 0
     while i < ep.counterexample_count && i < IR_MAX_EPI_COUNTEREXAMPLES {
         let pair = read_counterexample_info(buf, p)
@@ -4001,6 +4121,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c5b = read_i64(buf, p)
     ep.audit_count = c5b.0
     p = c5b.1
+    if !soir_require_count(ep.audit_count, IR_MAX_EPI_AUDITS) { return (ep, p) }
     i = 0
     while i < ep.audit_count && i < IR_MAX_EPI_AUDITS {
         let pair = read_audit_info(buf, p)
@@ -4012,6 +4133,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c6 = read_i64(buf, p)
     ep.contest_count = c6.0
     p = c6.1
+    if !soir_require_count(ep.contest_count, IR_MAX_EPI_CONTESTS) { return (ep, p) }
     i = 0
     while i < ep.contest_count && i < IR_MAX_EPI_CONTESTS {
         let pair = read_contest_info(buf, p)
@@ -4023,6 +4145,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c7 = read_i64(buf, p)
     ep.contest_witness_count = c7.0
     p = c7.1
+    if !soir_require_count(ep.contest_witness_count, IR_MAX_EPI_CONTEST_WITNESSES) { return (ep, p) }
     i = 0
     while i < ep.contest_witness_count && i < IR_MAX_EPI_CONTEST_WITNESSES {
         let pair = read_contest_witness_info(buf, p)
@@ -4034,6 +4157,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c8 = read_i64(buf, p)
     ep.robust_proof_count = c8.0
     p = c8.1
+    if !soir_require_count(ep.robust_proof_count, IR_MAX_EPI_ROBUST_PROOFS) { return (ep, p) }
     i = 0
     while i < ep.robust_proof_count && i < IR_MAX_EPI_ROBUST_PROOFS {
         let pair = read_robust_proof_info(buf, p)
@@ -4045,6 +4169,7 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     let c9 = read_i64(buf, p)
     ep.validated_manifest_count = c9.0
     p = c9.1
+    if !soir_require_count(ep.validated_manifest_count, IR_MAX_EPI_VALIDATED_MANIFESTS) { return (ep, p) }
     i = 0
     while i < ep.validated_manifest_count && i < IR_MAX_EPI_VALIDATED_MANIFESTS {
         let pair = read_validated_manifest_info(buf, p)
@@ -4053,10 +4178,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         i = i + 1
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c10 = read_i64(buf, p)
         ep.decision_policy_count = c10.0
         p = c10.1
+        if !soir_require_count(ep.decision_policy_count, IR_MAX_EPI_DECISION_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.decision_policy_count && i < IR_MAX_EPI_DECISION_POLICIES {
             let pair = read_decision_policy_info(buf, p)
@@ -4066,10 +4192,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c11 = read_i64(buf, p)
         ep.decision_certificate_count = c11.0
         p = c11.1
+        if !soir_require_count(ep.decision_certificate_count, IR_MAX_EPI_DECISION_CERTIFICATES) { return (ep, p) }
         i = 0
         while i < ep.decision_certificate_count && i < IR_MAX_EPI_DECISION_CERTIFICATES {
             let pair = read_decision_certificate_info(buf, p)
@@ -4079,10 +4206,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c12 = read_i64(buf, p)
         ep.deferral_policy_count = c12.0
         p = c12.1
+        if !soir_require_count(ep.deferral_policy_count, IR_MAX_EPI_DEFERRAL_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.deferral_policy_count && i < IR_MAX_EPI_DEFERRAL_POLICIES {
             let pair = read_deferral_policy_info(buf, p)
@@ -4092,10 +4220,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c13 = read_i64(buf, p)
         ep.deferred_certificate_count = c13.0
         p = c13.1
+        if !soir_require_count(ep.deferred_certificate_count, IR_MAX_EPI_DEFERRED_CERTIFICATES) { return (ep, p) }
         i = 0
         while i < ep.deferred_certificate_count && i < IR_MAX_EPI_DEFERRED_CERTIFICATES {
             let pair = read_deferred_certificate_info(buf, p)
@@ -4105,10 +4234,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c14 = read_i64(buf, p)
         ep.deferred_reason_witness_count = c14.0
         p = c14.1
+        if !soir_require_count(ep.deferred_reason_witness_count, IR_MAX_EPI_DEFERRED_REASON_WITNESSES) { return (ep, p) }
         i = 0
         while i < ep.deferred_reason_witness_count && i < IR_MAX_EPI_DEFERRED_REASON_WITNESSES {
             let pair = read_deferred_reason_witness_info(buf, p)
@@ -4118,10 +4248,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c15 = read_i64(buf, p)
         ep.acquisition_policy_count = c15.0
         p = c15.1
+        if !soir_require_count(ep.acquisition_policy_count, IR_MAX_EPI_ACQUISITION_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.acquisition_policy_count && i < IR_MAX_EPI_ACQUISITION_POLICIES {
             let pair = read_acquisition_policy_info(buf, p)
@@ -4131,10 +4262,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c16 = read_i64(buf, p)
         ep.acquisition_plan_count = c16.0
         p = c16.1
+        if !soir_require_count(ep.acquisition_plan_count, IR_MAX_EPI_ACQUISITION_PLANS) { return (ep, p) }
         i = 0
         while i < ep.acquisition_plan_count && i < IR_MAX_EPI_ACQUISITION_PLANS {
             let pair = read_acquisition_plan_info(buf, p)
@@ -4144,10 +4276,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c17 = read_i64(buf, p)
         ep.acquisition_reason_witness_count = c17.0
         p = c17.1
+        if !soir_require_count(ep.acquisition_reason_witness_count, IR_MAX_EPI_ACQUISITION_REASON_WITNESSES) { return (ep, p) }
         i = 0
         while i < ep.acquisition_reason_witness_count && i < IR_MAX_EPI_ACQUISITION_REASON_WITNESSES {
             let pair = read_acquisition_reason_witness_info(buf, p)
@@ -4157,10 +4290,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c18 = read_i64(buf, p)
         ep.recourse_policy_count = c18.0
         p = c18.1
+        if !soir_require_count(ep.recourse_policy_count, IR_MAX_EPI_RECOURSE_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.recourse_policy_count && i < IR_MAX_EPI_RECOURSE_POLICIES {
             let pair = read_recourse_policy_info(buf, p)
@@ -4170,10 +4304,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c19 = read_i64(buf, p)
         ep.recourse_plan_count = c19.0
         p = c19.1
+        if !soir_require_count(ep.recourse_plan_count, IR_MAX_EPI_RECOURSE_PLANS) { return (ep, p) }
         i = 0
         while i < ep.recourse_plan_count && i < IR_MAX_EPI_RECOURSE_PLANS {
             let pair = read_recourse_plan_info(buf, p)
@@ -4183,10 +4318,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c20 = read_i64(buf, p)
         ep.recourse_reason_witness_count = c20.0
         p = c20.1
+        if !soir_require_count(ep.recourse_reason_witness_count, IR_MAX_EPI_RECOURSE_REASON_WITNESSES) { return (ep, p) }
         i = 0
         while i < ep.recourse_reason_witness_count && i < IR_MAX_EPI_RECOURSE_REASON_WITNESSES {
             let pair = read_recourse_reason_witness_info(buf, p)
@@ -4196,10 +4332,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c21 = read_i64(buf, p)
         ep.alternative_policy_count = c21.0
         p = c21.1
+        if !soir_require_count(ep.alternative_policy_count, IR_MAX_EPI_ALTERNATIVE_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.alternative_policy_count && i < IR_MAX_EPI_ALTERNATIVE_POLICIES {
             let pair = read_alternative_policy_info(buf, p)
@@ -4209,10 +4346,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c22 = read_i64(buf, p)
         ep.alternative_frontier_count = c22.0
         p = c22.1
+        if !soir_require_count(ep.alternative_frontier_count, IR_MAX_EPI_ALTERNATIVE_FRONTIERS) { return (ep, p) }
         i = 0
         while i < ep.alternative_frontier_count && i < IR_MAX_EPI_ALTERNATIVE_FRONTIERS {
             let pair = read_alternative_frontier_info(buf, p)
@@ -4222,10 +4360,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c23 = read_i64(buf, p)
         ep.alternative_candidate_count = c23.0
         p = c23.1
+        if !soir_require_count(ep.alternative_candidate_count, IR_MAX_EPI_ALTERNATIVE_CANDIDATES) { return (ep, p) }
         i = 0
         while i < ep.alternative_candidate_count && i < IR_MAX_EPI_ALTERNATIVE_CANDIDATES {
             let pair = read_alternative_candidate_info(buf, p)
@@ -4235,10 +4374,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c24 = read_i64(buf, p)
         ep.alternative_set_count = c24.0
         p = c24.1
+        if !soir_require_count(ep.alternative_set_count, IR_MAX_EPI_ALTERNATIVE_SETS) { return (ep, p) }
         i = 0
         while i < ep.alternative_set_count && i < IR_MAX_EPI_ALTERNATIVE_SETS {
             let pair = read_alternative_set_info(buf, p)
@@ -4248,10 +4388,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c25 = read_i64(buf, p)
         ep.alternative_reason_witness_count = c25.0
         p = c25.1
+        if !soir_require_count(ep.alternative_reason_witness_count, IR_MAX_EPI_ALTERNATIVE_REASON_WITNESSES) { return (ep, p) }
         i = 0
         while i < ep.alternative_reason_witness_count && i < IR_MAX_EPI_ALTERNATIVE_REASON_WITNESSES {
             let pair = read_alternative_reason_witness_info(buf, p)
@@ -4261,10 +4402,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c26 = read_i64(buf, p)
         ep.transition_policy_count = c26.0
         p = c26.1
+        if !soir_require_count(ep.transition_policy_count, IR_MAX_EPI_TRANSITION_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.transition_policy_count && i < IR_MAX_EPI_TRANSITION_POLICIES {
             let pair = read_transition_policy_info(buf, p)
@@ -4274,10 +4416,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c27 = read_i64(buf, p)
         ep.transition_protocol_count = c27.0
         p = c27.1
+        if !soir_require_count(ep.transition_protocol_count, IR_MAX_EPI_TRANSITION_PROTOCOLS) { return (ep, p) }
         i = 0
         while i < ep.transition_protocol_count && i < IR_MAX_EPI_TRANSITION_PROTOCOLS {
             let pair = read_transition_protocol_info(buf, p)
@@ -4287,10 +4430,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c28 = read_i64(buf, p)
         ep.transition_step_count = c28.0
         p = c28.1
+        if !soir_require_count(ep.transition_step_count, IR_MAX_EPI_TRANSITION_STEPS) { return (ep, p) }
         i = 0
         while i < ep.transition_step_count && i < IR_MAX_EPI_TRANSITION_STEPS {
             let pair = read_transition_step_info(buf, p)
@@ -4300,10 +4444,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c29 = read_i64(buf, p)
         ep.transition_plan_count = c29.0
         p = c29.1
+        if !soir_require_count(ep.transition_plan_count, IR_MAX_EPI_TRANSITION_PLANS) { return (ep, p) }
         i = 0
         while i < ep.transition_plan_count && i < IR_MAX_EPI_TRANSITION_PLANS {
             let pair = read_transition_plan_info(buf, p)
@@ -4313,10 +4458,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c30 = read_i64(buf, p)
         ep.transition_reason_witness_count = c30.0
         p = c30.1
+        if !soir_require_count(ep.transition_reason_witness_count, IR_MAX_EPI_TRANSITION_REASON_WITNESSES) { return (ep, p) }
         i = 0
         while i < ep.transition_reason_witness_count && i < IR_MAX_EPI_TRANSITION_REASON_WITNESSES {
             let pair = read_transition_reason_witness_info(buf, p)
@@ -4326,10 +4472,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c31 = read_i64(buf, p)
         ep.monitoring_policy_count = c31.0
         p = c31.1
+        if !soir_require_count(ep.monitoring_policy_count, IR_MAX_EPI_MONITORING_POLICIES) { return (ep, p) }
         i = 0
         while i < ep.monitoring_policy_count && i < IR_MAX_EPI_MONITORING_POLICIES {
             let pair = read_monitoring_policy_info(buf, p)
@@ -4339,10 +4486,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c32 = read_i64(buf, p)
         ep.observed_transition_count = c32.0
         p = c32.1
+        if !soir_require_count(ep.observed_transition_count, IR_MAX_EPI_OBSERVED_TRANSITIONS) { return (ep, p) }
         i = 0
         while i < ep.observed_transition_count && i < IR_MAX_EPI_OBSERVED_TRANSITIONS {
             let pair = read_observed_transition_info(buf, p)
@@ -4352,10 +4500,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c33 = read_i64(buf, p)
         ep.rollback_certificate_count = c33.0
         p = c33.1
+        if !soir_require_count(ep.rollback_certificate_count, IR_MAX_EPI_ROLLBACK_CERTIFICATES) { return (ep, p) }
         i = 0
         while i < ep.rollback_certificate_count && i < IR_MAX_EPI_ROLLBACK_CERTIFICATES {
             let pair = read_rollback_certificate_info(buf, p)
@@ -4365,10 +4514,11 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
         }
     }
 
-    if p < len {
+    if version >= 3 || p < SOIR_READ_LIMIT {
         let c34 = read_i64(buf, p)
         ep.hyper_expr_count = c34.0
         p = c34.1
+        if !soir_require_count(ep.hyper_expr_count, IR_MAX_EPI_HYPER_EXPRS) { return (ep, p) }
         i = 0
         while i < ep.hyper_expr_count && i < IR_MAX_EPI_HYPER_EXPRS {
             let pair = read_hyper_expr_info(buf, p)
@@ -4381,9 +4531,46 @@ fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemic
     (ep, p)
 }
 
-fn serialize_ir_module_into(module: IrModule, out_buf: &![i8; 131072], out_len: &! i64) with Mut, Panic, Div, Alloc {
+fn serialize_ir_module_core_preflight(module: &IrModule) -> bool with Panic, Div {
+    if (*module).fn_count < 0 || (*module).fn_count > IR_MAX_FUNCS ||
+       (*module).string_count < 0 || (*module).string_count > IR_MAX_STRINGS ||
+       (*module).algebras.count < 0 || (*module).algebras.count > 32 ||
+       !soir_epistemic_counts_valid(&(*module).epistemic) ||
+       (*module).bss_total_size != 0 {
+        return false
+    }
+
+    var required: i64 = 16
+    var i: i64 = 0
+    while i < (*module).fn_count {
+        let func = &(*module).functions[i as usize]
+        if (*func).instr_count < 0 || (*func).instr_count > IR_MAX_INSTRS || (*func).bss_size != 0 {
+            return false
+        }
+        required = required + SOIR_FUNCTION_HEADER_V5_SIZE + (*func).instr_count * SOIR_INSTR_SIZE
+        if required > SOIR_MAX_SIZE {
+            return false
+        }
+        i = i + 1
+    }
+
+    required = required + 8 + (*module).string_count * SOIR_NAME_SIZE
+    required <= SOIR_MAX_SIZE
+}
+
+fn serialize_ir_module_into(module: &IrModule, out_buf: &![i8; 131072], out_len: &! i64) with Mut, Panic, Div, Alloc {
     var buf: [i8; 131072] = [0; 131072]
     var pos: i64 = 0
+    SOIR_WRITE_FAILED = false
+    (*out_len) = 0
+
+    // SOIR v5 does not encode BSS sizes, and the 128 KiB artifact envelope is
+    // intentionally smaller than the in-memory IR backing stores. Reject both
+    // cases before the first byte is written rather than erasing semantics or
+    // indexing beyond the fixed buffer.
+    if !serialize_ir_module_core_preflight(module) {
+        return
+    }
 
     // Write header
     buf[0] = 83 as i8   // 'S'
@@ -4397,45 +4584,50 @@ fn serialize_ir_module_into(module: IrModule, out_buf: &![i8; 131072], out_len: 
     pos = 8
 
     // Write function count
-    let fn_count_pair = write_i64(buf, pos, module.fn_count)
+    let fn_count_pair = write_i64(buf, pos, (*module).fn_count)
     buf = fn_count_pair.0
     pos = fn_count_pair.1
 
     // Write functions
     var i: i64 = 0
-    while i < module.fn_count {
-        let func_pair = serialize_ir_function(buf, pos, module.functions[i])
+    while i < (*module).fn_count {
+        let func_pair = serialize_ir_function(buf, pos, &(*module).functions[i as usize])
         buf = func_pair.0
         pos = func_pair.1
+        if SOIR_WRITE_FAILED { return }
         i = i + 1
     }
 
     // Write string count
-    let string_count_pair = write_i64(buf, pos, module.string_count)
+    let string_count_pair = write_i64(buf, pos, (*module).string_count)
     buf = string_count_pair.0
     pos = string_count_pair.1
 
     // Write string table
     var j: i64 = 0
-    while j < module.string_count {
-        let name_pair = write_name(buf, pos, module.string_table[j])
+    while j < (*module).string_count {
+        let name_pair = write_name(buf, pos, (*module).string_table[j as usize])
         buf = name_pair.0
         pos = name_pair.1
+        if SOIR_WRITE_FAILED { return }
         j = j + 1
     }
 
     if SOIR_VERSION >= 2 {
-        let ep_pair = serialize_ir_epistemic_section(buf, pos, module.epistemic)
+        let ep_pair = serialize_ir_epistemic_section(buf, pos, (*module).epistemic)
         buf = ep_pair.0
         pos = ep_pair.1
+        if SOIR_WRITE_FAILED { return }
     }
 
     if SOIR_VERSION >= 3 {
-        let alg_pair = serialize_ir_algebra_table(buf, pos, module.algebras)
+        let alg_pair = serialize_ir_algebra_table(buf, pos, (*module).algebras)
         buf = alg_pair.0
         pos = alg_pair.1
+        if SOIR_WRITE_FAILED { return }
     }
 
+    if pos < 0 || pos > SOIR_MAX_SIZE { return }
     (*out_buf) = buf
     (*out_len) = pos
 }
@@ -4443,12 +4635,24 @@ fn serialize_ir_module_into(module: IrModule, out_buf: &![i8; 131072], out_len: 
 fn serialize_ir_module(module: IrModule) -> ([i8; 131072], i64) with Mut, Panic, Div, Alloc {
     var buf: [i8; 131072] = [0; 131072]
     var len: i64 = 0
-    serialize_ir_module_into(module, &! buf, &! len)
+    serialize_ir_module_into(&module, &! buf, &! len)
     (buf, len)
 }
 
-fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Panic, Div, Alloc {
+// Decode into a freshly initialized destination. Counts remain zero until the
+// complete function and string tables have succeeded, so callers can treat a
+// false result as an empty module without copying a second 2048-function table.
+fn deserialize_ir_module_into(buf: [i8; 131072], len: i64, out: &! IrModule) -> bool with Mut, Panic, Div, Alloc {
     var pos: i64 = 0
+    (*out).fn_count = 0
+    (*out).string_count = 0
+    (*out).bss_total_size = 0
+
+    if len < 8 || len > SOIR_MAX_SIZE {
+        return false
+    }
+    SOIR_READ_LIMIT = len
+    SOIR_READ_FAILED = false
 
     // Verify header magic - cast literals to i8 for comparison
     let b0: i8 = 83 as i8
@@ -4457,13 +4661,12 @@ fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Pani
     let b3: i8 = 82 as i8
     let magic_ok = buf[0] == b0 && buf[1] == b1 && buf[2] == b2 && buf[3] == b3
     if !magic_ok {
-        // Return empty module on invalid magic
-        return ir_empty_module()
+        return false
     }
 
     let version = buf[4]
     if version != 1 && version != 2 as i8 && version != 3 as i8 && version != 4 as i8 && version != SOIR_VERSION {
-        return ir_empty_module()
+        return false
     }
 
     pos = 8  // Skip header
@@ -4472,14 +4675,18 @@ fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Pani
     let fn_count_pair = read_i64(buf, pos)
     let fn_count = fn_count_pair.0
     pos = fn_count_pair.1
+    if SOIR_READ_FAILED || fn_count < 0 || fn_count > IR_MAX_FUNCS {
+        return false
+    }
 
     // Read functions
-    var functions: [IrFunction; 1024] = [ir_empty_function(); 1024]
     var i: i64 = 0
     while i < fn_count {
-        let func_pair = deserialize_ir_function(buf, pos, version)
-        functions[i] = func_pair.0
-        pos = func_pair.1
+        let func_pair = deserialize_ir_function_into(buf, pos, version, &! (*out).functions[i as usize])
+        if !func_pair.1 || SOIR_READ_FAILED {
+            return false
+        }
+        pos = func_pair.0
         i = i + 1
     }
 
@@ -4487,34 +4694,50 @@ fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Pani
     let string_count_pair = read_i64(buf, pos)
     let string_count = string_count_pair.0
     pos = string_count_pair.1
+    if SOIR_READ_FAILED || string_count < 0 || string_count > IR_MAX_STRINGS ||
+       pos < 0 || string_count > (SOIR_READ_LIMIT - pos) / SOIR_NAME_SIZE {
+        return false
+    }
 
     // Read string table
-    var string_table: [Name; 4096] = [ir_empty_name(); 4096]
     var j: i64 = 0
     while j < string_count {
         let name_pair = read_name(buf, pos)
-        string_table[j] = name_pair.0
+        if SOIR_READ_FAILED || name_pair.0.len < 0 || name_pair.0.len > 128 {
+            return false
+        }
+        (*out).string_table[j as usize] = name_pair.0
         pos = name_pair.1
         j = j + 1
     }
 
-    var module = ir_empty_module()
-    module.functions = functions
-    module.fn_count = fn_count
-    module.string_table = string_table
-    module.string_count = string_count
-
-    if version >= 2 && pos < len {
-        let ep_pair = deserialize_ir_epistemic_section(buf, pos)
-        module.epistemic = ep_pair.0
+    if version >= 2 {
+        let ep_pair = deserialize_ir_epistemic_section(buf, pos, version)
+        if SOIR_READ_FAILED { return false }
+        (*out).epistemic = ep_pair.0
         pos = ep_pair.1
     }
 
-    if version >= 3 && pos < len {
+    if version >= 3 {
         let alg_pair = deserialize_ir_algebra_table(buf, pos)
-        module.algebras = alg_pair.0
+        if SOIR_READ_FAILED { return false }
+        (*out).algebras = alg_pair.0
+        pos = alg_pair.1
     }
 
+    if SOIR_READ_FAILED || pos > len { return false }
+    (*out).fn_count = fn_count
+    (*out).string_count = string_count
+    true
+}
+
+fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Panic, Div, Alloc {
+    var module = ir_empty_module()
+    let ok = deserialize_ir_module_into(buf, len, &! module)
+    if !ok {
+        module.fn_count = 0
+        module.string_count = 0
+    }
     module
 }
 

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -867,10 +867,11 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 }
 
 // Phase 0 tests: IR serialization and normalization
-// IrModule is a huge fixed-capacity value. Keep only its pointer in BSS and use
-// zeroed heap storage so neither the stack nor global aggregate lowering must
-// materialize [IrFunction; 2048]. The allocation is deliberately oversized for
-// layout changes; calloc-backed heap_alloc commits only the pages the test uses.
+// IrModule is a huge fixed-capacity value. Back it with zeroed byte BSS so
+// neither the stack nor aggregate initialization materializes
+// [IrFunction; 2048]. Native BSS currently reserves eight bytes per i8 slot, so
+// this provides 1.12 GB for the largest current-source test layout.
+var IRT_SOIR_STORAGE: [i8; 140000000]
 var IRT_SOIR_MODULE_PTR: *mut IrModule
 var IRT_SOIR_BUF: [i8; 131072] = [0; 131072]
 var IRT_SOIR_LEGACY_BUF: [i8; 131072] = [0; 131072]
@@ -906,8 +907,7 @@ fn irt_soir_rejects_truncated(buf: [i8; 131072], len: i64) -> bool with Mut, Pan
 }
 
 fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
-    IRT_SOIR_MODULE_PTR = heap_alloc(1100000000) as *mut IrModule
-    if IRT_SOIR_MODULE_PTR == 0 as *mut IrModule { return false }
+    IRT_SOIR_MODULE_PTR = (&! IRT_SOIR_STORAGE) as *mut IrModule
     (*IRT_SOIR_MODULE_PTR).fn_count = 1
     (*IRT_SOIR_MODULE_PTR).string_count = 1
     (*IRT_SOIR_MODULE_PTR).string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -867,11 +867,44 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 }
 
 // Phase 0 tests: IR serialization and normalization
-fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
+fn irt_soir_v5_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
+    var restored = ir_empty_module()
+    if !deserialize_ir_module_into(buf, len, &! restored) { return false }
+    restored.fn_count == 1 &&
+    restored.functions[0].instr_count == 2 &&
+    restored.functions[0].instrs[0].imm_i64 == 42 &&
+    restored.functions[0].defining_module_id == 37 &&
+    restored.string_count == 1 &&
+    ir_name_eq(restored.string_table[0], expected_string) &&
+    restored.epistemic.hyper_expr_count == 1 &&
+    restored.algebras.count == 1
+}
+
+fn irt_soir_v4_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
+    var restored = ir_empty_module()
+    if !deserialize_ir_module_into(buf, len, &! restored) { return false }
+    restored.fn_count == 1 &&
+    restored.functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN &&
+    restored.functions[0].instr_count == 2 &&
+    restored.functions[0].instrs[0].imm_i64 == 42 &&
+    restored.string_count == 1 &&
+    ir_name_eq(restored.string_table[0], expected_string) &&
+    restored.epistemic.hyper_expr_count == 1 &&
+    restored.algebras.count == 1
+}
+
+fn irt_soir_rejects_truncated(buf: [i8; 131072], len: i64) -> bool with Mut, Panic, Div, Alloc {
+    var restored = ir_empty_module()
+    !deserialize_ir_module_into(buf, len, &! restored) && restored.fn_count == 0 && restored.string_count == 0
+}
+
+fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
     var module = ir_empty_module()
     module.fn_count = 1
     module.string_count = 1
     module.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
+    module.epistemic.hyper_expr_count = 1
+    module.algebras.count = 1
 
     var func = ir_empty_function()
     func.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
@@ -880,27 +913,47 @@ fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
     func.reg_count = 1
     func.instrs[0] = ir_load_imm(0, 42)
     func.instrs[1] = ir_return(0)
+    // These are in-memory backing-store witnesses, not claims that the 128 KiB
+    // SOIR envelope can serialize every allocated slot.
+    func.instrs[1023] = ir_load_imm(0, 1024)
+    func.instrs[(IR_MAX_INSTRS - 1) as usize] = ir_load_imm(0, 2048)
+    if func.instrs[1023].imm_i64 != 1024 ||
+       func.instrs[(IR_MAX_INSTRS - 1) as usize].imm_i64 != 2048 {
+        return false
+    }
 
     module.functions[0] = func
+    module.functions[1023].defining_module_id = 1023
+    module.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id = 2047
+    if module.functions[1023].defining_module_id != 1023 ||
+       module.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id != 2047 {
+        return false
+    }
+
+    // One maximum-sized function cannot fit in SOIR v5. Rejection must happen
+    // before any fixed-buffer write, while the in-memory 2048-slot store remains valid.
+    module.functions[0].instr_count = IR_MAX_INSTRS
+    if serialize_ir_module(module).1 != 0 { return false }
+    module.functions[0].instr_count = 2
+
+    // SOIR v5 does not encode BSS sizes. Refuse the artifact instead of silently
+    // restoring a different module.
+    module.bss_total_size = 8
+    if serialize_ir_module(module).1 != 0 { return false }
+    module.bss_total_size = 0
+    module.functions[0].bss_size = 8
+    if serialize_ir_module(module).1 != 0 { return false }
+    module.functions[0].bss_size = 0
 
     let pair = serialize_ir_module(module)
     let buf = pair.0
     let len = pair.1
 
-    let restored = deserialize_ir_module(buf, len)
-
-    if restored.fn_count != 1 {
-        return false
-    }
-    if restored.functions[0].instr_count != 2 {
-        return false
-    }
-    if restored.functions[0].instrs[0].imm_i64 != 42 {
-        return false
-    }
-    if restored.functions[0].defining_module_id != 37 {
-        return false
-    }
+    if len <= 0 || !irt_soir_v5_matches(buf, len, module.string_table[0]) { return false }
+    // The core function/string payload ends at byte 1336 for this fixture.
+    // v5 must still require its declared epistemic and algebra sections.
+    if !irt_soir_rejects_truncated(buf, 1336) { return false }
+    if !irt_soir_rejects_truncated(buf, len - 1) { return false }
 
     // Build a genuine v4 module buffer from the v5 fixture: remove the v5-only
     // provenance word and shift both instructions and following module sections.
@@ -913,15 +966,7 @@ fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
         shift_pos = shift_pos + 1
     }
     legacy_buf[4] = 4 as i8
-    let legacy_restored = deserialize_ir_module(legacy_buf, len - 8)
-    if legacy_restored.fn_count != 1 ||
-       legacy_restored.functions[0].defining_module_id != IR_DEFINING_MODULE_UNKNOWN ||
-       legacy_restored.functions[0].instr_count != 2 ||
-       legacy_restored.functions[0].instrs[0].imm_i64 != 42 ||
-       legacy_restored.string_count != 1 ||
-       !ir_name_eq(legacy_restored.string_table[0], module.string_table[0]) {
-        return false
-    }
+    if !irt_soir_v4_matches(legacy_buf, len - 8, module.string_table[0]) { return false }
 
     true
 }

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -867,44 +867,49 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 }
 
 // Phase 0 tests: IR serialization and normalization
+// IrModule is a 404 MB fixed-capacity value. Keep the T17 witness in BSS and
+// exercise the streaming APIs so the test does not require a matching stack.
+var IRT_SOIR_MODULE: IrModule = ir_empty_module()
+var IRT_SOIR_BUF: [i8; 131072] = [0; 131072]
+var IRT_SOIR_LEGACY_BUF: [i8; 131072] = [0; 131072]
+var IRT_SOIR_LEN: i64 = 0
+
 fn irt_soir_v5_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
-    var restored = ir_empty_module()
-    if !deserialize_ir_module_into(buf, len, &! restored) { return false }
-    restored.fn_count == 1 &&
-    restored.functions[0].instr_count == 2 &&
-    restored.functions[0].instrs[0].imm_i64 == 42 &&
-    restored.functions[0].defining_module_id == 37 &&
-    restored.string_count == 1 &&
-    ir_name_eq(restored.string_table[0], expected_string) &&
-    restored.epistemic.hyper_expr_count == 1 &&
-    restored.algebras.count == 1
+    if !deserialize_ir_module_into(buf, len, &! IRT_SOIR_MODULE) { return false }
+    IRT_SOIR_MODULE.fn_count == 1 &&
+    IRT_SOIR_MODULE.functions[0].instr_count == 2 &&
+    IRT_SOIR_MODULE.functions[0].instrs[0].imm_i64 == 42 &&
+    IRT_SOIR_MODULE.functions[0].defining_module_id == 37 &&
+    IRT_SOIR_MODULE.string_count == 1 &&
+    ir_name_eq(IRT_SOIR_MODULE.string_table[0], expected_string) &&
+    IRT_SOIR_MODULE.epistemic.hyper_expr_count == 1 &&
+    IRT_SOIR_MODULE.algebras.count == 1
 }
 
 fn irt_soir_v4_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
-    var restored = ir_empty_module()
-    if !deserialize_ir_module_into(buf, len, &! restored) { return false }
-    restored.fn_count == 1 &&
-    restored.functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN &&
-    restored.functions[0].instr_count == 2 &&
-    restored.functions[0].instrs[0].imm_i64 == 42 &&
-    restored.string_count == 1 &&
-    ir_name_eq(restored.string_table[0], expected_string) &&
-    restored.epistemic.hyper_expr_count == 1 &&
-    restored.algebras.count == 1
+    if !deserialize_ir_module_into(buf, len, &! IRT_SOIR_MODULE) { return false }
+    IRT_SOIR_MODULE.fn_count == 1 &&
+    IRT_SOIR_MODULE.functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN &&
+    IRT_SOIR_MODULE.functions[0].instr_count == 2 &&
+    IRT_SOIR_MODULE.functions[0].instrs[0].imm_i64 == 42 &&
+    IRT_SOIR_MODULE.string_count == 1 &&
+    ir_name_eq(IRT_SOIR_MODULE.string_table[0], expected_string) &&
+    IRT_SOIR_MODULE.epistemic.hyper_expr_count == 1 &&
+    IRT_SOIR_MODULE.algebras.count == 1
 }
 
 fn irt_soir_rejects_truncated(buf: [i8; 131072], len: i64) -> bool with Mut, Panic, Div, Alloc {
-    var restored = ir_empty_module()
-    !deserialize_ir_module_into(buf, len, &! restored) && restored.fn_count == 0 && restored.string_count == 0
+    !deserialize_ir_module_into(buf, len, &! IRT_SOIR_MODULE) &&
+    IRT_SOIR_MODULE.fn_count == 0 && IRT_SOIR_MODULE.string_count == 0
 }
 
 fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
-    var module = ir_empty_module()
-    module.fn_count = 1
-    module.string_count = 1
-    module.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
-    module.epistemic.hyper_expr_count = 1
-    module.algebras.count = 1
+    IRT_SOIR_MODULE.fn_count = 1
+    IRT_SOIR_MODULE.string_count = 1
+    IRT_SOIR_MODULE.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
+    IRT_SOIR_MODULE.epistemic.hyper_expr_count = 1
+    IRT_SOIR_MODULE.algebras.count = 1
+    let expected_string = IRT_SOIR_MODULE.string_table[0]
 
     var func = ir_empty_function()
     func.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
@@ -922,51 +927,57 @@ fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
         return false
     }
 
-    module.functions[0] = func
-    module.functions[1023].defining_module_id = 1023
-    module.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id = 2047
-    if module.functions[1023].defining_module_id != 1023 ||
-       module.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id != 2047 {
+    IRT_SOIR_MODULE.functions[0] = func
+    IRT_SOIR_MODULE.functions[1023].defining_module_id = 1023
+    IRT_SOIR_MODULE.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id = 2047
+    if IRT_SOIR_MODULE.functions[1023].defining_module_id != 1023 ||
+       IRT_SOIR_MODULE.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id != 2047 {
         return false
     }
 
     // One maximum-sized function cannot fit in SOIR v5. Rejection must happen
     // before any fixed-buffer write, while the in-memory 2048-slot store remains valid.
-    module.functions[0].instr_count = IR_MAX_INSTRS
-    if serialize_ir_module(module).1 != 0 { return false }
-    module.functions[0].instr_count = 2
+    IRT_SOIR_MODULE.functions[0].instr_count = IR_MAX_INSTRS
+    IRT_SOIR_LEN = -1
+    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    if IRT_SOIR_LEN != 0 { return false }
+    IRT_SOIR_MODULE.functions[0].instr_count = 2
 
     // SOIR v5 does not encode BSS sizes. Refuse the artifact instead of silently
     // restoring a different module.
-    module.bss_total_size = 8
-    if serialize_ir_module(module).1 != 0 { return false }
-    module.bss_total_size = 0
-    module.functions[0].bss_size = 8
-    if serialize_ir_module(module).1 != 0 { return false }
-    module.functions[0].bss_size = 0
+    IRT_SOIR_MODULE.bss_total_size = 8
+    IRT_SOIR_LEN = -1
+    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    if IRT_SOIR_LEN != 0 { return false }
+    IRT_SOIR_MODULE.bss_total_size = 0
+    IRT_SOIR_MODULE.functions[0].bss_size = 8
+    IRT_SOIR_LEN = -1
+    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    if IRT_SOIR_LEN != 0 { return false }
+    IRT_SOIR_MODULE.functions[0].bss_size = 0
 
-    let pair = serialize_ir_module(module)
-    let buf = pair.0
-    let len = pair.1
+    IRT_SOIR_LEN = 0
+    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    let len = IRT_SOIR_LEN
 
-    if len <= 0 || !irt_soir_v5_matches(buf, len, module.string_table[0]) { return false }
+    if len <= 0 || !irt_soir_v5_matches(IRT_SOIR_BUF, len, expected_string) { return false }
     // The core function/string payload ends at byte 1336 for this fixture.
     // v5 must still require its declared epistemic and algebra sections.
-    if !irt_soir_rejects_truncated(buf, 1336) { return false }
-    if !irt_soir_rejects_truncated(buf, len - 1) { return false }
+    if !irt_soir_rejects_truncated(IRT_SOIR_BUF, 1336) { return false }
+    if !irt_soir_rejects_truncated(IRT_SOIR_BUF, len - 1) { return false }
 
     // Build a genuine v4 module buffer from the v5 fixture: remove the v5-only
     // provenance word and shift both instructions and following module sections.
     // Offset = header + fn_count + Name + 4 counts + 64 params + strategy/prof/hyper.
-    var legacy_buf = buf
+    IRT_SOIR_LEGACY_BUF = IRT_SOIR_BUF
     let provenance_pos: i64 = 8 + 8 + 136 + 32 + 512 + 24
     var shift_pos = provenance_pos
     while shift_pos + 8 < len {
-        legacy_buf[shift_pos as usize] = legacy_buf[(shift_pos + 8) as usize]
+        IRT_SOIR_LEGACY_BUF[shift_pos as usize] = IRT_SOIR_LEGACY_BUF[(shift_pos + 8) as usize]
         shift_pos = shift_pos + 1
     }
-    legacy_buf[4] = 4 as i8
-    if !irt_soir_v4_matches(legacy_buf, len - 8, module.string_table[0]) { return false }
+    IRT_SOIR_LEGACY_BUF[4] = 4 as i8
+    if !irt_soir_v4_matches(IRT_SOIR_LEGACY_BUF, len - 8, expected_string) { return false }
 
     true
 }

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -867,49 +867,53 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 }
 
 // Phase 0 tests: IR serialization and normalization
-// IrModule is a 404 MB fixed-capacity value. Keep the T17 witness in BSS and
-// exercise the streaming APIs so the test does not require a matching stack.
-var IRT_SOIR_MODULE: IrModule
+// IrModule is a huge fixed-capacity value. Keep only its pointer in BSS and use
+// zeroed heap storage so neither the stack nor global aggregate lowering must
+// materialize [IrFunction; 2048]. The allocation is deliberately oversized for
+// layout changes; calloc-backed heap_alloc commits only the pages the test uses.
+var IRT_SOIR_MODULE_PTR: *mut IrModule
 var IRT_SOIR_BUF: [i8; 131072] = [0; 131072]
 var IRT_SOIR_LEGACY_BUF: [i8; 131072] = [0; 131072]
 var IRT_SOIR_LEN: i64 = 0
 
 fn irt_soir_v5_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
-    if !deserialize_ir_module_into(buf, len, &! IRT_SOIR_MODULE) { return false }
-    IRT_SOIR_MODULE.fn_count == 1 &&
-    IRT_SOIR_MODULE.functions[0].instr_count == 2 &&
-    IRT_SOIR_MODULE.functions[0].instrs[0].imm_i64 == 42 &&
-    IRT_SOIR_MODULE.functions[0].defining_module_id == 37 &&
-    IRT_SOIR_MODULE.string_count == 1 &&
-    ir_name_eq(IRT_SOIR_MODULE.string_table[0], expected_string) &&
-    IRT_SOIR_MODULE.epistemic.hyper_expr_count == 1 &&
-    IRT_SOIR_MODULE.algebras.count == 1
+    if !deserialize_ir_module_into(buf, len, &! (*IRT_SOIR_MODULE_PTR)) { return false }
+    (*IRT_SOIR_MODULE_PTR).fn_count == 1 &&
+    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count == 2 &&
+    (*IRT_SOIR_MODULE_PTR).functions[0].instrs[0].imm_i64 == 42 &&
+    (*IRT_SOIR_MODULE_PTR).functions[0].defining_module_id == 37 &&
+    (*IRT_SOIR_MODULE_PTR).string_count == 1 &&
+    ir_name_eq((*IRT_SOIR_MODULE_PTR).string_table[0], expected_string) &&
+    (*IRT_SOIR_MODULE_PTR).epistemic.hyper_expr_count == 1 &&
+    (*IRT_SOIR_MODULE_PTR).algebras.count == 1
 }
 
 fn irt_soir_v4_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
-    if !deserialize_ir_module_into(buf, len, &! IRT_SOIR_MODULE) { return false }
-    IRT_SOIR_MODULE.fn_count == 1 &&
-    IRT_SOIR_MODULE.functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN &&
-    IRT_SOIR_MODULE.functions[0].instr_count == 2 &&
-    IRT_SOIR_MODULE.functions[0].instrs[0].imm_i64 == 42 &&
-    IRT_SOIR_MODULE.string_count == 1 &&
-    ir_name_eq(IRT_SOIR_MODULE.string_table[0], expected_string) &&
-    IRT_SOIR_MODULE.epistemic.hyper_expr_count == 1 &&
-    IRT_SOIR_MODULE.algebras.count == 1
+    if !deserialize_ir_module_into(buf, len, &! (*IRT_SOIR_MODULE_PTR)) { return false }
+    (*IRT_SOIR_MODULE_PTR).fn_count == 1 &&
+    (*IRT_SOIR_MODULE_PTR).functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN &&
+    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count == 2 &&
+    (*IRT_SOIR_MODULE_PTR).functions[0].instrs[0].imm_i64 == 42 &&
+    (*IRT_SOIR_MODULE_PTR).string_count == 1 &&
+    ir_name_eq((*IRT_SOIR_MODULE_PTR).string_table[0], expected_string) &&
+    (*IRT_SOIR_MODULE_PTR).epistemic.hyper_expr_count == 1 &&
+    (*IRT_SOIR_MODULE_PTR).algebras.count == 1
 }
 
 fn irt_soir_rejects_truncated(buf: [i8; 131072], len: i64) -> bool with Mut, Panic, Div, Alloc {
-    !deserialize_ir_module_into(buf, len, &! IRT_SOIR_MODULE) &&
-    IRT_SOIR_MODULE.fn_count == 0 && IRT_SOIR_MODULE.string_count == 0
+    !deserialize_ir_module_into(buf, len, &! (*IRT_SOIR_MODULE_PTR)) &&
+    (*IRT_SOIR_MODULE_PTR).fn_count == 0 && (*IRT_SOIR_MODULE_PTR).string_count == 0
 }
 
 fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
-    IRT_SOIR_MODULE.fn_count = 1
-    IRT_SOIR_MODULE.string_count = 1
-    IRT_SOIR_MODULE.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
-    IRT_SOIR_MODULE.epistemic.hyper_expr_count = 1
-    IRT_SOIR_MODULE.algebras.count = 1
-    let expected_string = IRT_SOIR_MODULE.string_table[0]
+    IRT_SOIR_MODULE_PTR = heap_alloc(1100000000) as *mut IrModule
+    if IRT_SOIR_MODULE_PTR == 0 as *mut IrModule { return false }
+    (*IRT_SOIR_MODULE_PTR).fn_count = 1
+    (*IRT_SOIR_MODULE_PTR).string_count = 1
+    (*IRT_SOIR_MODULE_PTR).string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
+    (*IRT_SOIR_MODULE_PTR).epistemic.hyper_expr_count = 1
+    (*IRT_SOIR_MODULE_PTR).algebras.count = 1
+    let expected_string = (*IRT_SOIR_MODULE_PTR).string_table[0]
 
     var func = ir_empty_function()
     func.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
@@ -927,37 +931,37 @@ fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
         return false
     }
 
-    IRT_SOIR_MODULE.functions[0] = func
-    IRT_SOIR_MODULE.functions[1023].defining_module_id = 1023
-    IRT_SOIR_MODULE.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id = 2047
-    if IRT_SOIR_MODULE.functions[1023].defining_module_id != 1023 ||
-       IRT_SOIR_MODULE.functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id != 2047 {
+    (*IRT_SOIR_MODULE_PTR).functions[0] = func
+    (*IRT_SOIR_MODULE_PTR).functions[1023].defining_module_id = 1023
+    (*IRT_SOIR_MODULE_PTR).functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id = 2047
+    if (*IRT_SOIR_MODULE_PTR).functions[1023].defining_module_id != 1023 ||
+       (*IRT_SOIR_MODULE_PTR).functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id != 2047 {
         return false
     }
 
     // One maximum-sized function cannot fit in SOIR v5. Rejection must happen
     // before any fixed-buffer write, while the in-memory 2048-slot store remains valid.
-    IRT_SOIR_MODULE.functions[0].instr_count = IR_MAX_INSTRS
+    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count = IR_MAX_INSTRS
     IRT_SOIR_LEN = -1
-    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
     if IRT_SOIR_LEN != 0 { return false }
-    IRT_SOIR_MODULE.functions[0].instr_count = 2
+    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count = 2
 
     // SOIR v5 does not encode BSS sizes. Refuse the artifact instead of silently
     // restoring a different module.
-    IRT_SOIR_MODULE.bss_total_size = 8
+    (*IRT_SOIR_MODULE_PTR).bss_total_size = 8
     IRT_SOIR_LEN = -1
-    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
     if IRT_SOIR_LEN != 0 { return false }
-    IRT_SOIR_MODULE.bss_total_size = 0
-    IRT_SOIR_MODULE.functions[0].bss_size = 8
+    (*IRT_SOIR_MODULE_PTR).bss_total_size = 0
+    (*IRT_SOIR_MODULE_PTR).functions[0].bss_size = 8
     IRT_SOIR_LEN = -1
-    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
     if IRT_SOIR_LEN != 0 { return false }
-    IRT_SOIR_MODULE.functions[0].bss_size = 0
+    (*IRT_SOIR_MODULE_PTR).functions[0].bss_size = 0
 
     IRT_SOIR_LEN = 0
-    serialize_ir_module_into(&IRT_SOIR_MODULE, &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
+    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
     let len = IRT_SOIR_LEN
 
     if len <= 0 || !irt_soir_v5_matches(IRT_SOIR_BUF, len, expected_string) { return false }

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -869,7 +869,7 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 // Phase 0 tests: IR serialization and normalization
 // IrModule is a 404 MB fixed-capacity value. Keep the T17 witness in BSS and
 // exercise the streaming APIs so the test does not require a matching stack.
-var IRT_SOIR_MODULE: IrModule = ir_empty_module()
+var IRT_SOIR_MODULE: IrModule
 var IRT_SOIR_BUF: [i8; 131072] = [0; 131072]
 var IRT_SOIR_LEGACY_BUF: [i8; 131072] = [0; 131072]
 var IRT_SOIR_LEN: i64 = 0

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -867,53 +867,11 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 }
 
 // Phase 0 tests: IR serialization and normalization
-// IrModule is a huge fixed-capacity value. Back it with zeroed byte BSS so
-// neither the stack nor aggregate initialization materializes
-// [IrFunction; 2048]. Native BSS currently reserves eight bytes per i8 slot, so
-// this provides 1.12 GB for the largest current-source test layout.
-var IRT_SOIR_STORAGE: [i8; 140000000]
-var IRT_SOIR_MODULE_PTR: *mut IrModule
-var IRT_SOIR_BUF: [i8; 131072] = [0; 131072]
-var IRT_SOIR_LEGACY_BUF: [i8; 131072] = [0; 131072]
-var IRT_SOIR_LEN: i64 = 0
-
-fn irt_soir_v5_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
-    if !deserialize_ir_module_into(buf, len, &! (*IRT_SOIR_MODULE_PTR)) { return false }
-    (*IRT_SOIR_MODULE_PTR).fn_count == 1 &&
-    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count == 2 &&
-    (*IRT_SOIR_MODULE_PTR).functions[0].instrs[0].imm_i64 == 42 &&
-    (*IRT_SOIR_MODULE_PTR).functions[0].defining_module_id == 37 &&
-    (*IRT_SOIR_MODULE_PTR).string_count == 1 &&
-    ir_name_eq((*IRT_SOIR_MODULE_PTR).string_table[0], expected_string) &&
-    (*IRT_SOIR_MODULE_PTR).epistemic.hyper_expr_count == 1 &&
-    (*IRT_SOIR_MODULE_PTR).algebras.count == 1
-}
-
-fn irt_soir_v4_matches(buf: [i8; 131072], len: i64, expected_string: Name) -> bool with Mut, Panic, Div, Alloc {
-    if !deserialize_ir_module_into(buf, len, &! (*IRT_SOIR_MODULE_PTR)) { return false }
-    (*IRT_SOIR_MODULE_PTR).fn_count == 1 &&
-    (*IRT_SOIR_MODULE_PTR).functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN &&
-    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count == 2 &&
-    (*IRT_SOIR_MODULE_PTR).functions[0].instrs[0].imm_i64 == 42 &&
-    (*IRT_SOIR_MODULE_PTR).string_count == 1 &&
-    ir_name_eq((*IRT_SOIR_MODULE_PTR).string_table[0], expected_string) &&
-    (*IRT_SOIR_MODULE_PTR).epistemic.hyper_expr_count == 1 &&
-    (*IRT_SOIR_MODULE_PTR).algebras.count == 1
-}
-
-fn irt_soir_rejects_truncated(buf: [i8; 131072], len: i64) -> bool with Mut, Panic, Div, Alloc {
-    !deserialize_ir_module_into(buf, len, &! (*IRT_SOIR_MODULE_PTR)) &&
-    (*IRT_SOIR_MODULE_PTR).fn_count == 0 && (*IRT_SOIR_MODULE_PTR).string_count == 0
-}
-
-fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
-    IRT_SOIR_MODULE_PTR = (&! IRT_SOIR_STORAGE) as *mut IrModule
-    (*IRT_SOIR_MODULE_PTR).fn_count = 1
-    (*IRT_SOIR_MODULE_PTR).string_count = 1
-    (*IRT_SOIR_MODULE_PTR).string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
-    (*IRT_SOIR_MODULE_PTR).epistemic.hyper_expr_count = 1
-    (*IRT_SOIR_MODULE_PTR).algebras.count = 1
-    let expected_string = (*IRT_SOIR_MODULE_PTR).string_table[0]
+fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
+    var module = ir_empty_module()
+    module.fn_count = 1
+    module.string_count = 1
+    module.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
 
     var func = ir_empty_function()
     func.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
@@ -922,66 +880,48 @@ fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
     func.reg_count = 1
     func.instrs[0] = ir_load_imm(0, 42)
     func.instrs[1] = ir_return(0)
-    // These are in-memory backing-store witnesses, not claims that the 128 KiB
-    // SOIR envelope can serialize every allocated slot.
-    func.instrs[1023] = ir_load_imm(0, 1024)
-    func.instrs[(IR_MAX_INSTRS - 1) as usize] = ir_load_imm(0, 2048)
-    if func.instrs[1023].imm_i64 != 1024 ||
-       func.instrs[(IR_MAX_INSTRS - 1) as usize].imm_i64 != 2048 {
+
+    module.functions[0] = func
+
+    let pair = serialize_ir_module(module)
+    let buf = pair.0
+    let len = pair.1
+
+    let restored = deserialize_ir_module(buf, len)
+
+    if restored.fn_count != 1 {
         return false
     }
-
-    (*IRT_SOIR_MODULE_PTR).functions[0] = func
-    (*IRT_SOIR_MODULE_PTR).functions[1023].defining_module_id = 1023
-    (*IRT_SOIR_MODULE_PTR).functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id = 2047
-    if (*IRT_SOIR_MODULE_PTR).functions[1023].defining_module_id != 1023 ||
-       (*IRT_SOIR_MODULE_PTR).functions[(IR_MAX_FUNCS - 1) as usize].defining_module_id != 2047 {
+    if restored.functions[0].instr_count != 2 {
         return false
     }
-
-    // One maximum-sized function cannot fit in SOIR v5. Rejection must happen
-    // before any fixed-buffer write, while the in-memory 2048-slot store remains valid.
-    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count = IR_MAX_INSTRS
-    IRT_SOIR_LEN = -1
-    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
-    if IRT_SOIR_LEN != 0 { return false }
-    (*IRT_SOIR_MODULE_PTR).functions[0].instr_count = 2
-
-    // SOIR v5 does not encode BSS sizes. Refuse the artifact instead of silently
-    // restoring a different module.
-    (*IRT_SOIR_MODULE_PTR).bss_total_size = 8
-    IRT_SOIR_LEN = -1
-    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
-    if IRT_SOIR_LEN != 0 { return false }
-    (*IRT_SOIR_MODULE_PTR).bss_total_size = 0
-    (*IRT_SOIR_MODULE_PTR).functions[0].bss_size = 8
-    IRT_SOIR_LEN = -1
-    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
-    if IRT_SOIR_LEN != 0 { return false }
-    (*IRT_SOIR_MODULE_PTR).functions[0].bss_size = 0
-
-    IRT_SOIR_LEN = 0
-    serialize_ir_module_into(&(*IRT_SOIR_MODULE_PTR), &! IRT_SOIR_BUF, &! IRT_SOIR_LEN)
-    let len = IRT_SOIR_LEN
-
-    if len <= 0 || !irt_soir_v5_matches(IRT_SOIR_BUF, len, expected_string) { return false }
-    // The core function/string payload ends at byte 1336 for this fixture.
-    // v5 must still require its declared epistemic and algebra sections.
-    if !irt_soir_rejects_truncated(IRT_SOIR_BUF, 1336) { return false }
-    if !irt_soir_rejects_truncated(IRT_SOIR_BUF, len - 1) { return false }
+    if restored.functions[0].instrs[0].imm_i64 != 42 {
+        return false
+    }
+    if restored.functions[0].defining_module_id != 37 {
+        return false
+    }
 
     // Build a genuine v4 module buffer from the v5 fixture: remove the v5-only
     // provenance word and shift both instructions and following module sections.
     // Offset = header + fn_count + Name + 4 counts + 64 params + strategy/prof/hyper.
-    IRT_SOIR_LEGACY_BUF = IRT_SOIR_BUF
+    var legacy_buf = buf
     let provenance_pos: i64 = 8 + 8 + 136 + 32 + 512 + 24
     var shift_pos = provenance_pos
     while shift_pos + 8 < len {
-        IRT_SOIR_LEGACY_BUF[shift_pos as usize] = IRT_SOIR_LEGACY_BUF[(shift_pos + 8) as usize]
+        legacy_buf[shift_pos as usize] = legacy_buf[(shift_pos + 8) as usize]
         shift_pos = shift_pos + 1
     }
-    IRT_SOIR_LEGACY_BUF[4] = 4 as i8
-    if !irt_soir_v4_matches(IRT_SOIR_LEGACY_BUF, len - 8, expected_string) { return false }
+    legacy_buf[4] = 4 as i8
+    let legacy_restored = deserialize_ir_module(legacy_buf, len - 8)
+    if legacy_restored.fn_count != 1 ||
+       legacy_restored.functions[0].defining_module_id != IR_DEFINING_MODULE_UNKNOWN ||
+       legacy_restored.functions[0].instr_count != 2 ||
+       legacy_restored.functions[0].instrs[0].imm_i64 != 42 ||
+       legacy_restored.string_count != 1 ||
+       !ir_name_eq(legacy_restored.string_table[0], module.string_table[0]) {
+        return false
+    }
 
     true
 }


### PR DESCRIPTION
## Status

**DRAFT / BLOCKED / NOT MERGE ELIGIBLE**

Stacked on `agent/issue854-defid-provenance-stack-20260713` at exact base `0bdc3686e010ecc3b5a45a3ff80ee233ff5b4273` (PR #869 head when this draft was opened).

This patch makes SOIR serialization/deserialization capacity handling fail closed. Static implementation review is clean, but the current native-v2 runtime cannot execute the wide-`IrModule` roundtrip witness. No dynamic serializer PASS is claimed.

## Changes

- Align `ir_empty_function().instrs` with the declared 2048-instruction backing capacity.
- Correct SOIR wire-size constants for `Name`, `IrInstr`, and v1/v3/v4/v5 function headers.
- Add bounded reader/writer state and fail-closed publication from `serialize_ir_module_into`.
- Preflight function, string, instruction, epistemic, algebra, BSS, and fixed 128 KiB envelope constraints before writing.
- Stream function deserialization directly into caller-provided module storage with `deserialize_ir_module_into`.
- Preserve v1-v5 compatibility and the legacy by-value wrappers; no legacy path was removed.
- Reject BSS-bearing artifacts explicitly because SOIR v5 does not encode BSS sizes.

The attempted 1.12 GB BSS T17 witness was removed from the final diff after independent review. `self-hosted/test_ir.sio` is byte-for-byte unchanged from the base; no generated bundle, probe, executable, or receipt artifact is committed.

## Static receipts

Final head at publication: `2bc1f3d94d5d47b8ef19654d377b0d59a856391d`.

```text
git diff --check <base>..HEAD                                  rc=0
git diff --exit-code <base>..HEAD -- self-hosted/test_ir.sio  rc=0
bin/souc check self-hosted/ir/ir.sio                          rc=0 (check: OK)
```

Independent read-only review:

```text
ir.sio + serialize.sio: STATIC CLEAN
final diff after removing 1.12 GB canonical BSS witness: CLEAN_FOR_DRAFT
dynamic roundtrip: explicitly not proved
```

## Current-source build receipt

The modular Madaros ELF was rebuilt from commit `b992b91783ae92a2081cec811f0d4c4b04c66a5c` under the global build lock with a 65536 KiB stack:

```text
scripts/ci/build_modular_madaros.sh  rc=0
wall                                  3:11.06
max RSS                               513180 KB
ELF bytes                             98451235
ELF SHA256                            e38752bdaf2845f118bf1469ff1865a2d92509fd480ba27be18593f2fea1a186
compiled functions                    10195
code bytes                            98447139
bss bytes                             3396851624
```

Only test-demotion commits followed that source build. Freshness was proved at final head:

```text
git diff --exit-code b992b9178..HEAD -- \
  self-hosted/ir/ir.sio self-hosted/ir/serialize.sio \
  self-hosted/compiler/main.sio
rc=0
```

Source hashes used by that build:

```text
self-hosted/ir/ir.sio          05ac62851fbb377bb171b7d3e57b663c732345590a2b69c4f7de2c1fd8f1b574
self-hosted/ir/serialize.sio   ac9da89d8c181c5dfda01daf63fb9a67e753083ea704fa8f0a253ea9093bb14a
self-hosted/compiler/main.sio  8165de3e123e005acc60f38b033e2b74718fb8c03421b5b5e89fb87af62bbb26
```

## Dynamic blocker evidence

A focused current-source bundle using the actual patched `ir.sio` and `serialize.sio` was checked successfully. With a 64 MiB stack, native compilation failed `rc=139` at `lower_array: seed_begin`. With unlimited stack, compilation completed (`rc=0`, about 2.18 GB max RSS), but the resulting executable failed immediately with `rc=139` before its first print.

The focused layout reports an inline `IrModule` frame of `1044378208` bytes, while the attempted storage witness required about 1.12 GB of native BSS. A separate current-source `heap_alloc(8)` baseline probe also compiled `rc=0` and failed at runtime with `rc=139`. Therefore serializer execution was never reached and is not represented as passing.

### BLK-20260713-IR-T17-WIDE-MODULE-ARENA

```text
Severity: B1
Class: bootstrap-runtime
Evidence-Level: E2
Owner: native-v2 compiler/runtime lane
Observed: 64 MiB compile rc139; unlimited compile rc0; executable immediate rc139
Expected: focused SOIR v5/v4/rejection witness executes and exits rc0
Acceptance-Gate: current-source compile + execute focused T17 with explicit PASS and rc0
Next-Action: provide runtime-safe storage/addressing for the current ~1.12 GB IrModule layout, then rerun T17
```

### BLK-20260713-NATIVE-V2-HEAP-ALLOC-RUNTIME

```text
Severity: B1
Class: bootstrap-runtime
Evidence-Level: E2
Owner: native-v2 runtime lane
Observed: isolated current-source heap_alloc(8) probe compiles rc0 and runs rc139
Expected: non-null allocation and rc0
Acceptance-Gate: isolated heap_alloc baseline plus focused T17 both execute rc0
Next-Action: repair or classify native-v2 allocator initialization before using heap storage as the wide-module witness
```

## Path classification

- Implementation/static proof: repository default compiler entrypoint.
- Source freshness/build proof: rebuilt current-source modular Madaros path.
- Dynamic witness: current-source path, blocked before serializer execution.
- Fallback path: none used as proof.
- Legacy path: intentionally retained.
- LLM offload: not required; no math claim, clinical pathway, or external-facing artifact was changed.

Do not merge until both blockers have acceptance receipts and the focused serializer witness is green.
