### PR TITLE
feat(stats): epidemiology measures, sample size (props/corr), box plot

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2659,3 +2659,9 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - summary_inference: Welch se/df (Satterthwaite), pooled-SD Cohen's d, one-sample t, t-CI — all verified. (Note: the code's Welch t deviates ~3e-4 from the true 3.29574 — an execution/float artifact under load, not a formula error; test tolerance loosened accordingly.)
 - meta_analysis: inverse-variance pooling, Cochran Q, I², DerSimonian-Laird τ², random-effects weights, homogeneous edge — all verified.
 - Both scalar/small-array -> #852-safe. Forest plot figure (examples/stats/forest_plot.sio) renders the meta-analysis.
+
+## 2026-07-14 — math-review: epidemiology + sample_size
+- Files: `stdlib/stats/{epidemiology,sample_size}.sio` (new). Provider: xAI/Grok 4.3 = **PASS** both.
+- epidemiology: risk_e/risk_u, RR/OR/RD, log-scale SEs (RR/OR), binomial RD SE, ARR/RRR/NNT — all verified.
+- sample_size: two-proportion, one-proportion, and Fisher-z correlation N formulas, normal_quantile, ss_ln/ss_sqrt/ss_ceil_pos, guards — all verified.
+- Both scalar -> #852-safe. Box-plot figure (examples/stats/box_plot.sio) added.

--- a/examples/stats/box_plot.sio
+++ b/examples/stats/box_plot.sio
@@ -1,0 +1,102 @@
+// examples/stats/box_plot.sio
+// Box-and-whisker plot comparing three groups: box = Q1..Q3, line = median,
+// whiskers = 1.5·IQR, points = outliers. Quartiles computed inline; rendered with
+// the pure-Sounio stats + PNG stack.
+//   souc run examples/stats/box_plot.sio -> box_plot.png
+use image::pure::types::{Image, image_new}
+use image::plot::{Area, area_new, plot_background, plot_grid, plot_band, plot_line_w, plot_point, plot_axes, plot_text_sc}
+use image::pure::png::{png_write}
+
+fn main() with IO, Mut, Div, Panic {
+    // three groups of trough measurements (ng/mL)
+    var g0: [f64; 64] = [0.0; 64]
+    var g1: [f64; 64] = [0.0; 64]
+    var g2: [f64; 64] = [0.0; 64]
+    g0[0]=12.1; g0[1]=14.8; g0[2]=13.2; g0[3]=15.9; g0[4]=11.7; g0[5]=13.5; g0[6]=14.1; g0[7]=22.0
+    g1[0]=8.4;  g1[1]=9.9;  g1[2]=7.6;  g1[3]=10.2; g1[4]=8.8;  g1[5]=9.1;  g1[6]=8.0;  g1[7]=9.5
+    g2[0]=5.1;  g2[1]=6.3;  g2[2]=4.8;  g2[3]=5.9;  g2[4]=6.7;  g2[5]=5.4;  g2[6]=6.0;  g2[7]=5.6
+    let ng = 8
+
+    let w = 1200; let h = 760
+    var img = image_new(w as i32, h as i32)
+    plot_background(&!img, w as i64, h as i64, 0xFFFFFF)
+    let a = area_new(160, 110, 1120, 640, 0.3, 3.7, 0.0, 24.0)
+    plot_grid(&!img, &a, 7, 8, 0xEEEEEE)
+    plot_axes(&!img, &a, 7, 8, 0x555555, 3)
+
+    let colors: [i64; 3] = [0xC0392B, 0x2E8B57, 0x1F5FA8]
+    let halfw = 0.28
+
+    var gi = 0
+    while gi < 3 {
+        // copy the current group into a sortable buffer
+        var s: [f64; 64] = [0.0; 64]
+        var i = 0
+        while i < ng {
+            if gi == 0 { s[i as usize] = g0[i as usize] }
+            else { if gi == 1 { s[i as usize] = g1[i as usize] } else { s[i as usize] = g2[i as usize] } }
+            i = i + 1
+        }
+        // inline selection sort
+        var p = 0
+        while p < ng - 1 {
+            var mn = p
+            var q = p + 1
+            while q < ng { if s[q as usize] < s[mn as usize] { mn = q }; q = q + 1 }
+            if mn != p { let tv = s[p as usize]; s[p as usize] = s[mn as usize]; s[mn as usize] = tv }
+            p = p + 1
+        }
+        // quartiles (type-7 linear interpolation)
+        let nf = ng as f64
+        let pos1 = 0.25 * (nf - 1.0)
+        let posm = 0.50 * (nf - 1.0)
+        let pos3 = 0.75 * (nf - 1.0)
+        let l1 = pos1 as i32; let q1 = s[l1 as usize] + (pos1 - (l1 as f64)) * (s[(l1 + 1) as usize] - s[l1 as usize])
+        let lm = posm as i32; let med = s[lm as usize] + (posm - (lm as f64)) * (s[(lm + 1) as usize] - s[lm as usize])
+        let l3 = pos3 as i32; let q3 = s[l3 as usize] + (pos3 - (l3 as f64)) * (s[(l3 + 1) as usize] - s[l3 as usize])
+        let iqr = q3 - q1
+        let wlo = q1 - 1.5 * iqr
+        let whi = q3 + 1.5 * iqr
+
+        let xc = (gi + 1) as f64
+        let col = colors[gi as usize]
+
+        // box (Q1..Q3) as a filled band across [xc-halfw, xc+halfw]
+        var bx: [f64; 512] = [0.0; 512]
+        var blo: [f64; 512] = [0.0; 512]
+        var bhi: [f64; 512] = [0.0; 512]
+        bx[0] = xc - halfw; bx[1] = xc + halfw
+        blo[0] = q1; blo[1] = q1; bhi[0] = q3; bhi[1] = q3
+        plot_band(&!img, &a, &bx, &blo, &bhi, 2, 0xE8EEF4)
+
+        // median line, box edges (top & bottom), whiskers
+        var lx: [f64; 512] = [0.0; 512]
+        var ly: [f64; 512] = [0.0; 512]
+        lx[0] = xc - halfw; lx[1] = xc + halfw; ly[0] = med; ly[1] = med
+        plot_line_w(&!img, &a, &lx, &ly, 2, col, 2.6)
+        ly[0] = q1; ly[1] = q1; plot_line_w(&!img, &a, &lx, &ly, 2, col, 1.6)
+        ly[0] = q3; ly[1] = q3; plot_line_w(&!img, &a, &lx, &ly, 2, col, 1.6)
+        // whiskers (vertical) with actual data extent inside 1.5·IQR
+        var lo_ext = s[0]; if lo_ext < wlo { lo_ext = wlo }
+        var hi_ext = s[(ng - 1) as usize]; if hi_ext > whi { hi_ext = whi }
+        lx[0] = xc; lx[1] = xc
+        ly[0] = q3; ly[1] = hi_ext; plot_line_w(&!img, &a, &lx, &ly, 2, col, 1.2)
+        ly[0] = q1; ly[1] = lo_ext; plot_line_w(&!img, &a, &lx, &ly, 2, col, 1.2)
+
+        // outliers (beyond the whiskers)
+        var o = 0
+        while o < ng {
+            let v = s[o as usize]
+            if v < wlo || v > whi { plot_point(&!img, &a, xc, v, col, 5) }
+            o = o + 1
+        }
+        gi = gi + 1
+    }
+
+    let _t1 = plot_text_sc(&!img, "Trough by CYP3A5 genotype (box plot)", 160, 40, 0x111111, 3)
+    let _t2 = plot_text_sc(&!img, "genotype: 1 slow  2 standard  3 fast", 420, 686, 0x333333, 3)
+    let _t3 = plot_text_sc(&!img, "trough (ng/mL)", 160, 78, 0x333333, 3)
+
+    let ok = png_write("box_plot.png", &img)
+    print("wrote="); print(ok); print("\n")
+}

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -31,6 +31,8 @@ MODULES=(
   stdlib/stats/roc.sio
   stdlib/stats/summary_inference.sio
   stdlib/stats/meta_analysis.sio
+  stdlib/stats/epidemiology.sio
+  stdlib/stats/sample_size.sio
 )
 
 fail=0
@@ -47,7 +49,7 @@ done
 # Smoke-run the integration demo (exit 0 = every tool composed cleanly).
 for demo in examples/stats/epistemic_suite_demo.sio examples/stats/full_analysis_report.sio \
             examples/stats/multiple_comparisons_test.sio examples/stats/permutation_test.sio \
-            examples/stats/forest_plot.sio; do
+            examples/stats/forest_plot.sio examples/stats/box_plot.sio; do
   if "$SOUC" run "$demo" >/dev/null 2>&1; then
     printf '  [PASS] %s\n' "$demo"
   else

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -439,6 +439,27 @@ tau2`. Validated: 3 studies → pooled 0.477, Q 2.69, I² 25.6%, τ² 0.0072. A
 **forest plot** figure (`examples/stats/forest_plot.sio`) renders it — per-study
 CI bars + the pooled diamond, pure-Sounio.
 
+### `stats::epidemiology` — risk / odds measures (2×2)
+
+`pub fn epi_2x2(a: i64, b: i64, c: i64, d: i64, conf: f64) -> EpiResult with Mut, Div, Panic`
+— risk ratio, odds ratio and risk difference (each with a CI), plus ARR, RRR and
+NNT. RR/OR CIs on the log scale, RD via the binomial SEs. Validated:
+15/85/5/95 → RR 3.0, OR 3.35, RD 0.10, NNT 10.
+
+### `stats::sample_size` — sample size for proportions & correlation
+
+| Function | Signature |
+|---|---|
+| `n_two_props` | `pub fn n_two_props(p1: f64, p2: f64, alpha: f64, power: f64) -> i64 with Mut, Div, Panic` |
+| `n_one_prop` | `pub fn n_one_prop(p0: f64, p1: f64, alpha: f64, power: f64) -> i64 with Mut, Div, Panic` |
+| `n_correlation` | `pub fn n_correlation(r: f64, alpha: f64, power: f64) -> i64 with Mut, Div, Panic` |
+
+Extends `stats::power` (t-tests) to the other common designs. Validated:
+`p=0.5→0.3` → ~93/group; `p=0.5→0.7` one-sample → ~47; `r=0.3` → ~85.
+
+A **box plot** figure (`examples/stats/box_plot.sio`) renders three groups with
+quartile boxes, median lines, 1.5·IQR whiskers and outlier points.
+
 ## Importing
 
 Import each tool directly from its module:

--- a/stdlib/stats/epidemiology.sio
+++ b/stdlib/stats/epidemiology.sio
@@ -1,0 +1,203 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/epidemiology.sio — risk / odds measures from a 2x2 table
+//
+// The effect measures of a cohort / trial 2x2 table, each with a confidence
+// interval — the language of clinical epidemiology:
+//
+//              outcome+   outcome-
+//   exposed      a          b
+//   unexposed    c          d
+//
+//   epi_2x2(a, b, c, d, conf) -> EpiResult
+//
+//   risk_e = a/(a+b),  risk_u = c/(c+d)
+//   RR  = risk_e/risk_u        (CI on the log scale, SE = sqrt(1/a−1/(a+b)+1/c−1/(c+d)))
+//   OR  = a·d/(b·c)            (CI on the log scale, SE = sqrt(1/a+1/b+1/c+1/d))
+//   RD  = risk_e − risk_u      (CI via the binomial SEs)
+//   ARR = |RD|,  RRR = 1 − RR (protective side),  NNT = 1/|RD|
+//
+// Scalar throughout (no data arrays) — sidesteps the array-heavy codegen crash.
+//
+// Pure Sounio; the only dependency is the normal quantile (special::erf).
+//
+// References:
+//   Altman (1991) "Practical Statistics for Medical Research";
+//   Rothman, Greenland & Lash (2008) "Modern Epidemiology"
+
+module stats::epidemiology
+
+use special::erf::{normal_quantile}
+
+fn epi_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 20 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn epi_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 - 1.0e300 }
+    if x == 1.0 { return 0.0 }
+    var m = x
+    var e = 0
+    while m >= 2.0 { m = m / 2.0; e = e + 1 }
+    while m < 0.5 { m = m * 2.0; e = e - 1 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var sum = t
+    var term = t
+    var k = 1
+    while k < 32 { term = term * t2; sum = sum + term / ((2 * k + 1) as f64); k = k + 1 }
+    return 2.0 * sum + (e as f64) * 0.6931471805599453
+}
+
+fn epi_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / epi_exp(0.0 - x) }
+    if x > 709.0 { return 1.0e300 }
+    if x > 2.0 { return epi_exp(x / 2.0) * epi_exp(x / 2.0) }
+    var sum = 1.0
+    var term = 1.0
+    var i = 1
+    while i <= 28 { term = term * x / (i as f64); sum = sum + term; i = i + 1 }
+    return sum
+}
+
+pub struct EpiResult {
+    pub risk_exposed: f64,
+    pub risk_unexposed: f64,
+    pub rr: f64,        pub rr_lo: f64,  pub rr_hi: f64,     // risk ratio + CI
+    pub or_: f64,       pub or_lo: f64,  pub or_hi: f64,     // odds ratio + CI
+    pub rd: f64,        pub rd_lo: f64,  pub rd_hi: f64,     // risk difference + CI
+    pub arr: f64,       // |risk difference|
+    pub rrr: f64,       // 1 - RR
+    pub nnt: f64,       // 1/|RD| (NNT to benefit or harm)
+}
+
+/// Risk/odds measures from a 2x2 table (a,b top row = exposed; c,d = unexposed).
+///
+/// Parâmetros: a,b,c,d — cell counts; conf — CI level (e.g. 0.95).
+/// Retorno: EpiResult (risks, RR/OR/RD with CIs, ARR, RRR, NNT).
+/// Referências: Altman (1991); Rothman et al. (2008).
+pub fn epi_2x2(a: i64, b: i64, c: i64, d: i64, conf: f64) -> EpiResult with Mut, Div, Panic {
+    let af = a as f64
+    let bf = b as f64
+    let cf = c as f64
+    let df = d as f64
+    let n_e = af + bf
+    let n_u = cf + df
+    let z = normal_quantile(0.5 + conf / 2.0)
+
+    var risk_e = 0.0
+    if n_e > 0.0 { risk_e = af / n_e }
+    var risk_u = 0.0
+    if n_u > 0.0 { risk_u = cf / n_u }
+
+    // risk ratio + log CI
+    var rr = 0.0
+    if risk_u > 1.0e-300 { rr = risk_e / risk_u }
+    var rr_lo = rr
+    var rr_hi = rr
+    if af > 0.0 && cf > 0.0 && rr > 0.0 {
+        let se_ln = epi_sqrt(1.0 / af - 1.0 / n_e + 1.0 / cf - 1.0 / n_u)
+        let lr = epi_ln(rr)
+        rr_lo = epi_exp(lr - z * se_ln)
+        rr_hi = epi_exp(lr + z * se_ln)
+    }
+
+    // odds ratio + log CI
+    var or_ = 0.0
+    if bf > 0.0 && cf > 0.0 { or_ = af * df / (bf * cf) }
+    var or_lo = or_
+    var or_hi = or_
+    if af > 0.0 && bf > 0.0 && cf > 0.0 && df > 0.0 && or_ > 0.0 {
+        let se_ln = epi_sqrt(1.0 / af + 1.0 / bf + 1.0 / cf + 1.0 / df)
+        let lo = epi_ln(or_)
+        or_lo = epi_exp(lo - z * se_ln)
+        or_hi = epi_exp(lo + z * se_ln)
+    }
+
+    // risk difference + CI
+    let rd = risk_e - risk_u
+    var rd_se = 0.0
+    if n_e > 0.0 && n_u > 0.0 {
+        rd_se = epi_sqrt(risk_e * (1.0 - risk_e) / n_e + risk_u * (1.0 - risk_u) / n_u)
+    }
+    let rd_lo = rd - z * rd_se
+    let rd_hi = rd + z * rd_se
+
+    let arr = if rd < 0.0 { 0.0 - rd } else { rd }
+    var nnt = 1.0e300
+    if arr > 1.0e-300 { nnt = 1.0 / arr }
+
+    return EpiResult {
+        risk_exposed: risk_e, risk_unexposed: risk_u,
+        rr: rr, rr_lo: rr_lo, rr_hi: rr_hi,
+        or_: or_, or_lo: or_lo, or_hi: or_hi,
+        rd: rd, rd_lo: rd_lo, rd_hi: rd_hi,
+        arr: arr, rrr: 1.0 - rr, nnt: nnt,
+    }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// a=15,b=85,c=5,d=95. risk_e=0.15, risk_u=0.05. RR=3.0, OR=(15·95)/(85·5)=3.352941,
+// RD=0.10, NNT=10. RR 95% CI ≈ [1.133, 7.94]; OR 95% CI ≈ [1.169, 9.61].
+fn test_epi() -> bool with IO, Mut, Div, Panic {
+    let r = epi_2x2(15, 85, 5, 95, 0.95)
+    var ok = true
+    ok = check(1, approx(r.risk_exposed, 0.15, 1.0e-12)) && ok
+    ok = check(2, approx(r.risk_unexposed, 0.05, 1.0e-12)) && ok
+    ok = check(3, approx(r.rr, 3.0, 1.0e-9)) && ok
+    ok = check(4, approx(r.or_, 3.352941, 1.0e-5)) && ok
+    ok = check(5, approx(r.rd, 0.10, 1.0e-12)) && ok
+    ok = check(6, approx(r.nnt, 10.0, 1.0e-9)) && ok
+    ok = check(7, approx(r.rr_lo, 1.133, 5.0e-3)) && ok
+    ok = check(8, approx(r.rr_hi, 7.94, 2.0e-2)) && ok
+    ok = check(9, approx(r.or_lo, 1.169, 5.0e-3)) && ok
+    return ok
+}
+
+// no association: equal risks -> RR=1, OR=1, RD=0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    let r = epi_2x2(20, 80, 20, 80, 0.95)
+    var ok = true
+    ok = check(20, approx(r.rr, 1.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.or_, 1.0, 1.0e-9)) && ok
+    ok = check(22, approx(r.rd, 0.0, 1.0e-12)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_epi() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/sample_size.sio
+++ b/stdlib/stats/sample_size.sio
@@ -1,0 +1,159 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/sample_size.sio — sample size for proportions and correlation
+//
+// Extends stats::power (which covers t-tests) to the other common designs, using
+// the standard normal-approximation formulas. All scalar (no data arrays).
+//
+//   n_two_props(p1, p2, alpha, power)    -> n per group
+//   n_one_prop(p0, p1, alpha, power)     -> n
+//   n_correlation(r, alpha, power)       -> n
+//
+//   two proportions (two-sided):
+//     n = ( z_{α/2}·sqrt(2·p̄·q̄) + z_β·sqrt(p1·q1 + p2·q2) )² / (p1 − p2)²
+//   one proportion:
+//     n = ( z_{α/2}·sqrt(p0·q0) + z_β·sqrt(p1·q1) )² / (p1 − p0)²
+//   correlation (Fisher z):  n = ( (z_{α/2} + z_β) / atanh(r) )² + 3
+//
+// Pure Sounio; the only dependency is the normal quantile (special::erf).
+//
+// References:
+//   Fleiss, Levin & Paik (2003) "Statistical Methods for Rates and Proportions";
+//   Cohen (1988) — correlation sample size
+
+module stats::sample_size
+
+use special::erf::{normal_quantile}
+
+fn ss_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 - 1.0e300 }
+    if x == 1.0 { return 0.0 }
+    var m = x
+    var e = 0
+    while m >= 2.0 { m = m / 2.0; e = e + 1 }
+    while m < 0.5 { m = m * 2.0; e = e - 1 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var sum = t
+    var term = t
+    var k = 1
+    while k < 32 { term = term * t2; sum = sum + term / ((2 * k + 1) as f64); k = k + 1 }
+    return 2.0 * sum + (e as f64) * 0.6931471805599453
+}
+
+fn ss_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 20 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn ss_ceil_pos(x: f64) -> i64 {
+    let t = x as i64
+    if (t as f64) < x { return t + 1 }
+    return t
+}
+
+/// Sample size PER GROUP for a two-sided two-proportion z-test.
+///
+/// Parâmetros: p1, p2 — the two proportions; alpha — level; power — desired power.
+/// Retorno: n per group (>= 2).
+/// Referências: Fleiss et al. (2003).
+pub fn n_two_props(p1: f64, p2: f64, alpha: f64, power: f64) -> i64 with Mut, Div, Panic {
+    let za = normal_quantile(1.0 - alpha / 2.0)
+    let zb = normal_quantile(power)
+    let pbar = (p1 + p2) / 2.0
+    let qbar = 1.0 - pbar
+    let term = za * ss_sqrt(2.0 * pbar * qbar) + zb * ss_sqrt(p1 * (1.0 - p1) + p2 * (1.0 - p2))
+    let diff = p1 - p2
+    if diff * diff < 1.0e-30 { return 1000000 }
+    let n = term * term / (diff * diff)
+    let ni = ss_ceil_pos(n)
+    if ni < 2 { return 2 }
+    return ni
+}
+
+/// Sample size for a one-sample proportion test (H0: p = p0, H1: p = p1).
+pub fn n_one_prop(p0: f64, p1: f64, alpha: f64, power: f64) -> i64 with Mut, Div, Panic {
+    let za = normal_quantile(1.0 - alpha / 2.0)
+    let zb = normal_quantile(power)
+    let term = za * ss_sqrt(p0 * (1.0 - p0)) + zb * ss_sqrt(p1 * (1.0 - p1))
+    let diff = p1 - p0
+    if diff * diff < 1.0e-30 { return 1000000 }
+    let n = term * term / (diff * diff)
+    let ni = ss_ceil_pos(n)
+    if ni < 2 { return 2 }
+    return ni
+}
+
+/// Sample size to detect a correlation r (two-sided), via the Fisher z-transform.
+pub fn n_correlation(r: f64, alpha: f64, power: f64) -> i64 with Mut, Div, Panic {
+    let za = normal_quantile(1.0 - alpha / 2.0)
+    let zb = normal_quantile(power)
+    let ar = if r < 0.0 { 0.0 - r } else { r }
+    if ar < 1.0e-9 { return 1000000 }
+    let zr = 0.5 * ss_ln((1.0 + ar) / (1.0 - ar))    // atanh(r)
+    let base = (za + zb) / zr
+    let n = base * base + 3.0
+    let ni = ss_ceil_pos(n)
+    if ni < 4 { return 4 }
+    return ni
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// n_two_props(0.5,0.3,0.05,0.80) ~ 93 per group (Fleiss, uncorrected).
+// n_one_prop(0.5,0.7,0.05,0.80)  ~ 47.
+// n_correlation(0.3,0.05,0.80)   ~ 85.
+fn test_sizes() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    let n1 = n_two_props(0.5, 0.3, 0.05, 0.80)
+    ok = check(1, n1 >= 91 && n1 <= 95) && ok
+    let n2 = n_one_prop(0.5, 0.7, 0.05, 0.80)
+    ok = check(2, n2 >= 45 && n2 <= 49) && ok
+    let n3 = n_correlation(0.3, 0.05, 0.80)
+    ok = check(3, n3 >= 82 && n3 <= 87) && ok
+    return ok
+}
+
+// monotonicity: a smaller effect needs a larger n.
+fn test_monotone() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    let big = n_two_props(0.5, 0.2, 0.05, 0.80)    // large gap
+    let small = n_two_props(0.5, 0.4, 0.05, 0.80)  // small gap
+    ok = check(10, small > big) && ok
+    // higher power needs more
+    let p80 = n_correlation(0.3, 0.05, 0.80)
+    let p90 = n_correlation(0.3, 0.05, 0.90)
+    ok = check(11, p90 > p80) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_sizes() && ok
+    ok = test_monotone() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
Three additions to the epistemic-statistics suite (24 in main), all #852-safe. **`stats::epidemiology`** (RR/OR/RD + CIs, ARR/RRR/NNT from a 2x2), **`stats::sample_size`** (n for two/one-proportion and correlation, extending `stats::power`), and a **box-plot figure** (quartile boxes + whiskers + outliers, pure-Sounio render). Math-reviewed (xAI/Grok PASS), validated against textbook values. Suite ALL GREEN.