### PR TITLE
feat(stats): reliability (ICC + Cronbach) + funnel plot

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2665,3 +2665,7 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - epidemiology: risk_e/risk_u, RR/OR/RD, log-scale SEs (RR/OR), binomial RD SE, ARR/RRR/NNT — all verified.
 - sample_size: two-proportion, one-proportion, and Fisher-z correlation N formulas, normal_quantile, ss_ln/ss_sqrt/ss_ceil_pos, guards — all verified.
 - Both scalar -> #852-safe. Box-plot figure (examples/stats/box_plot.sio) added.
+
+## 2026-07-14 — math-review: stats::reliability
+- File: `stdlib/stats/reliability.sio` (new). ICC(2,1) via ANOVA mean squares + Cronbach's alpha. Provider: xAI/Grok 4.3 = **PASS** — ICC formula, SS/MS decomposition, Cronbach formula, item/total variance estimators, test data all verified.
+- Funnel-plot figure (examples/stats/funnel_plot.sio) added. Correlation-heatmap figure attempted but DROPPED: needs a data matrix live during many render calls (custom pixel loops / plot_band with data[256]+corr[64] live) -> #852 crash. The funnel worked (no separate data matrix; proven plot path only).

--- a/examples/stats/funnel_plot.sio
+++ b/examples/stats/funnel_plot.sio
@@ -1,0 +1,66 @@
+// examples/stats/funnel_plot.sio
+// Funnel plot for publication-bias assessment: each study's effect (x) against
+// its precision 1/SE (y). Under no bias the studies scatter symmetrically inside
+// the pseudo-95% funnel (pooled ± 1.96·SE), narrowing toward the top.
+//   souc run examples/stats/funnel_plot.sio -> funnel_plot.png
+use image::pure::types::{Image, image_new}
+use image::plot::{Area, area_new, plot_background, plot_grid, plot_vline, plot_point, plot_line_w, plot_axes, plot_text_sc, draw_number}
+use image::pure::png::{png_write}
+use stats::meta_analysis::{meta_fixed, MetaResult}
+
+fn main() with IO, Mut, Div, Panic {
+    var eff: [f64; 64] = [0.0; 64]
+    var se:  [f64; 64] = [0.0; 64]
+    eff[0]=0.20; se[0]=0.10
+    eff[1]=0.45; se[1]=0.15
+    eff[2]=0.35; se[2]=0.12
+    eff[3]=0.60; se[3]=0.20
+    eff[4]=0.30; se[4]=0.08
+    eff[5]=0.15; se[5]=0.09
+    let k = 6
+    let meta = meta_fixed(&eff, &se, k, 0.95)
+    let pooled = meta.pooled
+
+    let w = 1200; let h = 760
+    var img = image_new(w as i32, h as i32)
+    plot_background(&!img, w as i64, h as i64, 0xFFFFFF)
+    // x = effect, y = precision (1/SE), higher precision at the top
+    let a = area_new(160, 110, 1120, 640, 0.0 - 0.4, 1.2, 2.0, 15.0)
+    plot_grid(&!img, &a, 8, 8, 0xEEEEEE)
+    plot_vline(&!img, &a, pooled, 0xB03A2E)          // pooled effect
+
+    // pseudo-95% funnel: x = pooled ± 1.96/precision, sampled over precision
+    let np = 40
+    var lx: [f64; 512] = [0.0; 512]
+    var ly: [f64; 512] = [0.0; 512]
+    var rx: [f64; 512] = [0.0; 512]
+    var ry: [f64; 512] = [0.0; 512]
+    var i = 0
+    while i < np {
+        let prec = 2.5 + (i as f64) * (14.5 - 2.5) / ((np - 1) as f64)
+        let hw = 1.959964 / prec
+        lx[i as usize] = pooled - hw; ly[i as usize] = prec
+        rx[i as usize] = pooled + hw; ry[i as usize] = prec
+        i = i + 1
+    }
+    plot_line_w(&!img, &a, &lx, &ly, np, 0xB8C4D0, 1.6)
+    plot_line_w(&!img, &a, &rx, &ry, np, 0xB8C4D0, 1.6)
+    plot_axes(&!img, &a, 8, 8, 0x555555, 3)
+
+    // study points
+    var j = 0
+    while j < k {
+        let prec = 1.0 / se[j as usize]
+        plot_point(&!img, &a, eff[j as usize], prec, 0x22384C, 6)
+        j = j + 1
+    }
+
+    let _t1 = plot_text_sc(&!img, "Funnel plot (publication bias)", 160, 40, 0x111111, 3)
+    let _t2 = plot_text_sc(&!img, "effect (log RR)", 620, 686, 0x333333, 3)
+    let _t3 = plot_text_sc(&!img, "precision (1/SE)", 160, 78, 0x333333, 3)
+    let _lp = plot_text_sc(&!img, "pooled", 720, 150, 0xB03A2E, 2)
+    let _np2 = draw_number(&!img, pooled, 3, 810, 150, 0xB03A2E, 3)
+
+    let ok = png_write("funnel_plot.png", &img)
+    print("pooled="); print(pooled); print(" k="); print(k); print(" wrote="); print(ok); print("\n")
+}

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -33,6 +33,7 @@ MODULES=(
   stdlib/stats/meta_analysis.sio
   stdlib/stats/epidemiology.sio
   stdlib/stats/sample_size.sio
+  stdlib/stats/reliability.sio
 )
 
 fail=0
@@ -49,7 +50,8 @@ done
 # Smoke-run the integration demo (exit 0 = every tool composed cleanly).
 for demo in examples/stats/epistemic_suite_demo.sio examples/stats/full_analysis_report.sio \
             examples/stats/multiple_comparisons_test.sio examples/stats/permutation_test.sio \
-            examples/stats/forest_plot.sio examples/stats/box_plot.sio; do
+            examples/stats/forest_plot.sio examples/stats/box_plot.sio \
+            examples/stats/funnel_plot.sio; do
   if "$SOUC" run "$demo" >/dev/null 2>&1; then
     printf '  [PASS] %s\n' "$demo"
   else

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -460,6 +460,21 @@ Extends `stats::power` (t-tests) to the other common designs. Validated:
 A **box plot** figure (`examples/stats/box_plot.sio`) renders three groups with
 quartile boxes, median lines, 1.5·IQR whiskers and outlier points.
 
+### `stats::reliability` — inter-rater & internal-consistency reliability
+
+| Function | Signature |
+|---|---|
+| `icc` | `pub fn icc(data: &[f64; 256], n_subj: i32, n_rater: i32) -> ICCResult with Mut, Div, Panic` |
+| `cronbach_alpha` | `pub fn cronbach_alpha(data: &[f64; 256], n_subj: i32, n_item: i32) -> f64 with Mut, Div, Panic` |
+
+ICC(2,1) (two-way random, single rater) via the ANOVA mean squares, and Cronbach's
+alpha for scale internal consistency, from a subjects×raters/items matrix.
+Validated: perfect agreement → ICC 1.0; a 4×3 example → α 0.930.
+
+A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
+meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
+assessment).
+
 ## Importing
 
 Import each tool directly from its module:

--- a/stdlib/stats/reliability.sio
+++ b/stdlib/stats/reliability.sio
@@ -1,0 +1,207 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/reliability.sio — inter-rater and internal-consistency reliability
+//
+// Two workhorses of measurement reliability:
+//
+//   icc(data, n_subj, n_rater)        -> ICC(2,1)      (two-way random, single rater)
+//   cronbach_alpha(data, n_subj, n_item) -> alpha       (internal consistency)
+//
+// ICC(2,1) from a subjects×raters matrix by two-way ANOVA:
+//   ICC = (MSR − MSE) / (MSR + (k−1)·MSE + (k/n)·(MSC − MSE))
+//   where MSR = between-subjects, MSC = between-raters, MSE = residual mean square.
+// Cronbach's alpha:  α = (k/(k−1))·(1 − Σ var(item)/var(total score)).
+//
+// `data` is the n×k matrix in row-major order (subjects × raters/items, n·k ≤ 256).
+//
+// Pure Sounio, no external dependency (matrices are small; loops are inlined so no
+// nested call is made while the matrix is live — issue #852).
+//
+// References:
+//   Shrout & Fleiss (1979) "Intraclass correlations"; Cronbach (1951);
+//   Koo & Li (2016) — ICC selection guidance.
+
+module stats::reliability
+
+pub struct ICCResult {
+    pub icc: f64,
+    pub ms_subjects: f64,
+    pub ms_raters: f64,
+    pub ms_error: f64,
+    pub n_subj: i64,
+    pub n_rater: i64,
+}
+
+/// ICC(2,1): two-way random-effects, absolute-agreement, single measurement.
+///
+/// Parâmetros: data — subjects×raters, row-major; n_subj, n_rater (n·k <= 256).
+/// Retorno: ICCResult (ICC and the mean squares).
+/// Referências: Shrout & Fleiss (1979).
+pub fn icc(data: &[f64; 256], n_subj: i32, n_rater: i32) -> ICCResult with Mut, Div, Panic {
+    let n = n_subj as f64
+    let k = n_rater as f64
+
+    // grand mean
+    var grand = 0.0
+    var i = 0
+    while i < n_subj {
+        var j = 0
+        while j < n_rater { grand = grand + data[(i * n_rater + j) as usize]; j = j + 1 }
+        i = i + 1
+    }
+    grand = grand / (n * k)
+
+    // sums of squares
+    var ss_total = 0.0
+    var ss_rows = 0.0
+    var a = 0
+    while a < n_subj {
+        var rowsum = 0.0
+        var b = 0
+        while b < n_rater {
+            let x = data[(a * n_rater + b) as usize]
+            let dt = x - grand
+            ss_total = ss_total + dt * dt
+            rowsum = rowsum + x
+            b = b + 1
+        }
+        let rm = rowsum / k - grand
+        ss_rows = ss_rows + k * rm * rm
+        a = a + 1
+    }
+    var ss_cols = 0.0
+    var c = 0
+    while c < n_rater {
+        var colsum = 0.0
+        var r = 0
+        while r < n_subj { colsum = colsum + data[(r * n_rater + c) as usize]; r = r + 1 }
+        let cm = colsum / n - grand
+        ss_cols = ss_cols + n * cm * cm
+        c = c + 1
+    }
+    var ss_err = ss_total - ss_rows - ss_cols
+    if ss_err < 0.0 { ss_err = 0.0 }
+
+    let df_rows = n - 1.0
+    let df_cols = k - 1.0
+    let df_err = (n - 1.0) * (k - 1.0)
+    var msr = 0.0
+    if df_rows > 0.0 { msr = ss_rows / df_rows }
+    var msc = 0.0
+    if df_cols > 0.0 { msc = ss_cols / df_cols }
+    var mse = 0.0
+    if df_err > 0.0 { mse = ss_err / df_err }
+
+    let denom = msr + (k - 1.0) * mse + (k / n) * (msc - mse)
+    var v = 0.0
+    if denom > 1.0e-300 { v = (msr - mse) / denom }
+    return ICCResult { icc: v, ms_subjects: msr, ms_raters: msc, ms_error: mse,
+                       n_subj: n_subj as i64, n_rater: n_rater as i64 }
+}
+
+/// Cronbach's alpha (internal consistency) of a subjects×items matrix.
+///
+/// Parâmetros: data — subjects×items, row-major; n_subj, n_item (n·k <= 256).
+/// Retorno: alpha (usually in [0,1]).
+/// Referências: Cronbach (1951).
+pub fn cronbach_alpha(data: &[f64; 256], n_subj: i32, n_item: i32) -> f64 with Mut, Div, Panic {
+    let n = n_subj as f64
+    let k = n_item as f64
+    if n_subj < 2 || n_item < 2 { return 0.0 }
+
+    // sum of item variances (n-1 basis)
+    var sum_item_var = 0.0
+    var j = 0
+    while j < n_item {
+        var s = 0.0
+        var ss = 0.0
+        var i = 0
+        while i < n_subj {
+            let x = data[(i * n_item + j) as usize]
+            s = s + x
+            ss = ss + x * x
+            i = i + 1
+        }
+        let var_j = (ss - s * s / n) / (n - 1.0)
+        sum_item_var = sum_item_var + var_j
+        j = j + 1
+    }
+
+    // variance of the total (row-sum) score
+    var st = 0.0
+    var sst = 0.0
+    var r = 0
+    while r < n_subj {
+        var rowsum = 0.0
+        var c = 0
+        while c < n_item { rowsum = rowsum + data[(r * n_item + c) as usize]; c = c + 1 }
+        st = st + rowsum
+        sst = sst + rowsum * rowsum
+        r = r + 1
+    }
+    let var_total = (sst - st * st / n) / (n - 1.0)
+    if var_total <= 1.0e-300 { return 0.0 }
+    return (k / (k - 1.0)) * (1.0 - sum_item_var / var_total)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect agreement: 4 subjects, 2 raters, ratings identical across raters -> ICC=1.
+fn test_icc_perfect() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=1.0; d[2]=2.0; d[3]=2.0; d[4]=3.0; d[5]=3.0; d[6]=4.0; d[7]=4.0
+    let r = icc(&d, 4, 2)
+    return check(1, approx(r.icc, 1.0, 1.0e-9))
+}
+
+// partial agreement (raters differ) -> ICC strictly between 0 and 1.
+fn test_icc_partial() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    // subject rows: (9,2)(6,1)(8,4)(7,1)  -> raters disagree in level
+    d[0]=9.0; d[1]=2.0; d[2]=6.0; d[3]=1.0; d[4]=8.0; d[5]=4.0; d[6]=7.0; d[7]=1.0
+    let r = icc(&d, 4, 2)
+    return check(10, r.icc > 0.0 && r.icc < 1.0)
+}
+
+// Cronbach: 4 subjects, 3 items.
+// items var: 5/3, 2, 2.25 -> sum 5.916667. total-score var 15.583333.
+// alpha = (3/2)(1 - 5.916667/15.583333) = 1.5·0.620321 = 0.930481.
+fn test_cronbach() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=5.0; d[1]=4.0; d[2]=4.0
+    d[3]=3.0; d[4]=3.0; d[5]=2.0
+    d[6]=4.0; d[7]=4.0; d[8]=5.0
+    d[9]=2.0; d[10]=1.0; d[11]=2.0
+    let alpha = cronbach_alpha(&d, 4, 3)
+    return check(20, approx(alpha, 0.930481, 1.0e-5))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_icc_perfect() && ok
+    ok = test_icc_partial() && ok
+    ok = test_cronbach() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
Adds **`stats::reliability`** (ICC(2,1) via ANOVA mean squares + Cronbach's alpha, from a subjects×raters matrix) and a **funnel-plot figure** (effect vs precision with the pseudo-95% funnel, for publication-bias assessment). Math-reviewed (xAI/Grok PASS), validated (perfect agreement → ICC 1.0; α 0.930). A correlation-heatmap figure was attempted but dropped — it needs a data matrix live across many render calls, tripping #852. Suite ALL GREEN.