### PR TITLE
feat(ir): add explicit heap module bridge [BLOCKED]

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 957
-- Repo-backed topics: 807
+- Total governed topics: 958
+- Repo-backed topics: 808
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 557
+- Authority count `repo_only`: 558
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 576 topics
+- A2: 577 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -408,6 +408,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.ir-storage-ownership | repo_only | docs/internal/concepts/ir-storage-ownership.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.physical-observation | repo_only | docs/internal/concepts/physical-observation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.precision-preservation | repo_only | docs/internal/concepts/precision-preservation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8863,6 +8863,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.ir-storage-ownership",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/ir-storage-ownership.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.nonassociative-order",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/nonassociative-order.md",

--- a/docs/internal/concepts/bindings.tsv
+++ b/docs/internal/concepts/bindings.tsv
@@ -26,6 +26,10 @@ SOUNIO-PRECISION-PRESERVATION	stdlib/math/dd64.sio	canonical-dd64
 SOUNIO-PRECISION-PRESERVATION	self-hosted/enir/qd.sio	semantic-ir-arithmetic
 SOUNIO-PRECISION-PRESERVATION	self-hosted/native/*	native-backend
 SOUNIO-PRECISION-PRESERVATION	stdlib/eisa/*	execution-profile
+SOUNIO-IR-STORAGE-OWNERSHIP	self-hosted/ir/heap_storage.sio	prototype-bridge
+SOUNIO-IR-STORAGE-OWNERSHIP	self-hosted/ir/serialize.sio	serialization-boundary
+SOUNIO-IR-STORAGE-OWNERSHIP	self-hosted/compiler/main.sio	source-fresh-witness
+SOUNIO-IR-STORAGE-OWNERSHIP	scripts/ci/ir_module_heap_bridge_gate.sh	acceptance-gate
 SOUNIO-SECOND-ORDER-COMPILATION	docs/architecture/second-order-compilation.md	canonical-contract
 SOUNIO-SECOND-ORDER-COMPILATION	docs/decisions/adr-007-second-order-compilation.md	decision-record
 SOUNIO-SECOND-ORDER-COMPILATION	stdlib/eisa/*	first-witness-surface

--- a/docs/internal/concepts/ir-storage-ownership.md
+++ b/docs/internal/concepts/ir-storage-ownership.md
@@ -1,0 +1,94 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.ir-storage-ownership
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.ir-storage-ownership
+-->
+
+# IR Storage Ownership
+
+Status: hypothesis; prototype bridge pending executable validation
+Concept-ID: `SOUNIO-IR-STORAGE-OWNERSHIP`
+
+This lane makes ownership of an out-of-line `IrModule` allocation explicit
+without changing the canonical `IrModule`, `IrFunction`, `IrInstr`, DefId, or
+SOIR representations. It exists to prove that a small live module can avoid an
+inline value measuring hundreds of MiB in this stack and exceeding 1 GiB in
+adjacent compiler snapshots, while the broader IR representation remains
+unchanged.
+
+```text
+Semantic-Lane-ID: IR-HEAP-BRIDGE-V0
+Owner: codex/ir-arena-storage-20260714
+Concept-IDs: SOUNIO-IR-STORAGE-OWNERSHIP
+Intent-Preserved: IR identity and scientific provenance must not be erased by a storage migration.
+Transformation: selected IrModule construction and SOIR roundtrip use one explicit heap owner over the unchanged fixed IrModule ABI.
+Types-Changed: adds state-machine IrModuleHeapBridge; does not change IrModule, IrFunction, IrInstr, or DefId.
+Effects-Changed: heap construction and release require Alloc; existing serializer effects are unchanged.
+IR-Changed: storage location only; no opcode, field, identity, or interpretation changes.
+Claims-Introduced: a bounded small live IrModule can be constructed and round-tripped without materializing IrModule on stack/BSS.
+Claims-Forbidden: IrModuleHeapBridge is canonical or alias-safe; all 2048 functions are materialized; IR capacity is unbounded; by-value IrModule paths are eliminated; this is a general arena allocator.
+Assumptions: heap_alloc returns zeroed memory and heap_free accepts the unchanged user pointer; native-v2 stores its mapping header at ptr-8 while libc uses calloc/free directly.
+Write-Set: self-hosted/ir/heap_storage.sio, self-hosted/ir/serialize.sio, self-hosted/test_ir.sio, self-hosted/compiler/main.sio, scripts/ci/ir_module_heap_bridge_gate.sh, scripts/bootstrap/bootstrap_concat.sh, docs/internal/concepts/*, docs/governance/topic-registry.v1.json, docs/governance/DOCS_AUTHORITY_MATRIX.md, docs/governance/DOCS_ACCEPTANCE_REPORT.md.
+Read-Set: self-hosted/ir/ir.sio, stdlib/mem/box.sio, native-v2 heap builtin implementation, SOIR v4/v5 tests.
+Positive-Witness: one shared internal witness used by T17 and source-fresh Madaros adds one sparse function, two instructions, and one string; round-trips v5 and v4; preserves state after a truncated decode; and observes one FREED transition across two release calls.
+Negative-Witness: allocation failure is FAILED; invalid owner/index/capacity access fails closed; truncated staged decode preserves the live owner; second release is a FREED no-op; serializer capacity preflight remains authoritative; in-memory opcodes without stable SOIR tags leave serialized length zero.
+Acceptance-Gate: source-fresh modular compile plus scripts/ci/ir_module_heap_bridge_gate.sh PASS from the raw ELF, shared T17 witness PASS, and scripts/ci/madaros_visibility_context_gate.sh PASS.
+Integration-Target: stacked after draft #870 and current main.
+Authoritative-Only-If: source-fresh compiler executes T17 and v4/v5 identity assertions with no fallback.
+```
+
+The reservation is two GiB of virtual address space, not a claim that two GiB
+of physical memory is initialized. Linux anonymous mappings are demand-paged;
+the bridge explicitly initializes top-level counts and each inserted live
+function. The fixed reservation must be revisited if IR caps or layout grow.
+Deserialization temporarily holds two virtual reservations so it can adopt the
+staged pointer on success and leave the live owner unchanged on failure.
+
+The bridge owner is an explicit runtime state machine with private fields.
+`ir_module_heap_release(&! owner)` transitions `ALLOCATED` to `FREED`, nulls
+the pointer and byte count, and only then passes the original user pointer to
+`heap_free`. A second release observes `FREED` and cannot free again. This is
+exactly-once per owner instance, not a claim of alias-safe ownership: copying
+or aliasing `IrModuleHeapBridge` is forbidden and remains unverified until the
+checker accepts linear borrowed or state-threaded owners.
+
+```text
+Semantic-Outcome: BLOCKED before executable validation; implementation review is clean, but the source-fresh seed segfaults while emitting the newly activated full ir::serialize module closure.
+Concept-Status-Before: absent
+Concept-Status-After: hypothesis with reviewed prototype implementation
+Distinctions-Added: virtual reservation != touched physical memory; storage ownership != IR semantic identity; per-owner exactly-once != alias-safe linear ownership
+Distinctions-Preserved: DefId provenance; SOIR v5 identity; SOIR v4 unknown-provenance compatibility; fail-closed capacity; unsupported writer opcode != invented wire tag
+Distinctions-Erased: none
+Evidence-Run: exact base 00d3e5ac0 source-fresh build rc=0; integration build rc=139 with out_status=missing; writer-guard corrective build rc=139 with out_status=missing and no serializer exhaustiveness diagnostic
+Fallback-Path: none
+Legacy-Kept: canonical inline IrModule and all existing by-value paths
+Conflicting-Lanes: none observed by semantic status scanner before edit
+Next-Semantic-Interface: split a minimal SOIR core that the seed can emit, then rerun the source-fresh raw-ELF gate; issue #877 repairs linear owner state-threading; issue #878 separately owns unknown reader-tag fail-closed policy
+```
+
+```text
+Blocker-ID: BLK-20260714-IR-HEAP-SERIALIZE-CLOSURE
+Status: classified
+Severity: B1
+Class: bootstrap-runtime
+Owner: codex/ir-arena-storage-20260714
+Lane: IR-HEAP-BRIDGE-V0
+Worktree: /tmp/sounio-ir-arena-storage-20260714
+Branch: codex/ir-arena-storage-20260714
+Files-Owned: self-hosted/ir/heap_storage.sio, self-hosted/ir/serialize.sio, self-hosted/test_ir.sio, self-hosted/compiler/main.sio, scripts/ci/ir_module_heap_bridge_gate.sh, scripts/bootstrap/bootstrap_concat.sh, docs/internal/concepts/ir-storage-ownership.md, docs/internal/concepts/registry.tsv, docs/internal/concepts/bindings.tsv, docs/governance/topic-registry.v1.json, docs/governance/DOCS_AUTHORITY_MATRIX.md, docs/governance/DOCS_ACCEPTANCE_REPORT.md
+Files-Read-Only: self-hosted/compiler/module_frontend.sio, self-hosted/native/codegen_x86_linux.sio
+Do-Not-Touch: canonical IrModule/IrFunction/IrInstr layout and existing by-value paths
+Repro: ulimit -s 65536; /usr/bin/time -v bash scripts/ci/build_modular_madaros.sh artifacts/ir-heap-bridge/madaros-source-fresh
+Observed: exact base build succeeds; adding the explicit heap-storage/serializer closure reaches serializer lowering then the seed exits 139 with no output artifact, including after the writer exhaustiveness guard removes its only serializer checker diagnostic
+Expected: source-fresh Madaros ELF exists and executes --ir-heap-bridge-self-test with the exact PASS receipt
+Acceptance-Gate: MADAROS_RAW_BIN=<absolute-source-fresh-elf> IR_MODULE_HEAP_BRIDGE_EXPECT_SHA256=<sha256> bash scripts/ci/ir_module_heap_bridge_gate.sh
+Evidence-Level: E2
+Evidence: https://github.com/Sounio-lang/sounio/issues/879 records the exact control and two integration build receipts; control ELF SHA e586cfd19b4fe5aa68512c962a48fe88793e59aea7f1a2b58f33505042c317a7
+Fallback-Path: none
+Legacy-Kept: yes
+LLM-Offload: not-required
+Next-Action: extract the small SOIR v5/v4 module encode/decode core from the 4,700-line serializer closure without changing tags or identity, then repeat the same source-fresh build and raw gate
+```

--- a/docs/internal/concepts/registry.tsv
+++ b/docs/internal/concepts/registry.tsv
@@ -5,5 +5,6 @@ SOUNIO-NONASSOCIATIVE-ORDER	executable	founder	docs/internal/concepts/nonassocia
 SOUNIO-EXPLICIT-DISCHARGE	executable	founder	docs/internal/concepts/explicit-discharge.md	stdlib/epistemic/zero_event.sio	general-discharge-protocol
 SOUNIO-PHYSICAL-OBSERVATION	hypothesis	founder	docs/internal/concepts/physical-observation.md	stdlib/physics	observation-receipt
 SOUNIO-PRECISION-PRESERVATION	executable	founder	docs/internal/concepts/precision-preservation.md	stdlib/math/qd128.sio	native-v2-emission
+SOUNIO-IR-STORAGE-OWNERSHIP	hypothesis	founder	docs/internal/concepts/ir-storage-ownership.md	self-hosted/ir/heap_storage.sio	canonical-ir-representation
 SOUNIO-SECOND-ORDER-COMPILATION	hypothesis	founder	docs/internal/concepts/second-order-compilation.md	docs/architecture/second-order-compilation.md	first-divergence-receipt
 SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	executable	founder	docs/internal/concepts/hypercomplex-zero-divisor-evidence.md	stdlib/eisa/hypercomplex_zd.sio	checker-ir-hardware

--- a/scripts/bootstrap/bootstrap_concat.sh
+++ b/scripts/bootstrap/bootstrap_concat.sh
@@ -120,6 +120,7 @@ FILES=(
   self-hosted/ir/lower.sio
   self-hosted/ir/normalize.sio
   self-hosted/ir/serialize.sio
+  self-hosted/ir/heap_storage.sio
   self-hosted/ir/disasm.sio
   self-hosted/ir/verify.sio
   self-hosted/ir/optimize.sio
@@ -453,6 +454,7 @@ if [ "$BOOTSTRAP_PROFILE" != "full" ]; then
     self-hosted/ir/lower.sio
     self-hosted/ir/normalize.sio
     self-hosted/ir/serialize.sio
+    self-hosted/ir/heap_storage.sio
     self-hosted/ir/disasm.sio
     self-hosted/ir/verify.sio
     self-hosted/ir/optimize.sio

--- a/scripts/ci/ir_module_heap_bridge_gate.sh
+++ b/scripts/ci/ir_module_heap_bridge_gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+EXPECTED_SHA256="${IR_MODULE_HEAP_BRIDGE_EXPECT_SHA256:-}"
+EXPECTED_BANNER='Madaros v0.80.0 -- the Sounio self-hosted compiler'
+
+fail() {
+  echo "IR_MODULE_HEAP_BRIDGE_FAIL reason=$1" >&2
+  exit 1
+}
+
+[[ -n "$RAW_MADAROS" ]] || fail missing_explicit_madaros
+[[ "$RAW_MADAROS" == /* ]] || fail madaros_must_be_absolute
+[[ -f "$RAW_MADAROS" ]] || fail madaros_not_regular_file
+[[ -x "$RAW_MADAROS" ]] || fail madaros_not_executable
+magic="$(head -c4 "$RAW_MADAROS" | od -An -tx1 | tr -d '[:space:]')"
+[[ "$magic" == 7f454c46 ]] || fail madaros_not_raw_elf
+
+compiler_sha256="$(sha256sum "$RAW_MADAROS" | awk '{print $1}')"
+if [[ -n "$EXPECTED_SHA256" && "$compiler_sha256" != "$EXPECTED_SHA256" ]]; then
+  fail madaros_sha256_mismatch
+fi
+
+set +e
+output="$(
+  timeout 300 "$RAW_MADAROS" --ir-heap-bridge-self-test 2>&1
+)"
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 ]]; then
+  printf '%s\n' "$output" >&2
+  fail "internal_self_test_rc_$rc"
+fi
+grep -Fxq "$EXPECTED_BANNER" <<<"$output" || {
+  printf '%s\n' "$output" >&2
+  fail version_banner_missing
+}
+grep -Fxq 'IR_MODULE_HEAP_BRIDGE_PASS' <<<"$output" || {
+  printf '%s\n' "$output" >&2
+  fail pass_marker_missing
+}
+if grep -Fq 'IR_MODULE_HEAP_BRIDGE_FAIL' <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail contradictory_fail_marker
+fi
+if grep -Fq 'fallback' <<<"$output"; then
+  printf '%s\n' "$output" >&2
+  fail fallback_observed
+fi
+echo "IR_MODULE_HEAP_BRIDGE_PASS compiler=$RAW_MADAROS sha256=$compiler_sha256"

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -13,6 +13,7 @@
 use lexer::mod::*
 use parser::ast::*
 use ir::ir::*
+use ir::heap_storage::{ir_module_heap_roundtrip_self_test}
 use check::dependent::*
 use check::types::*
 use check::compat::*
@@ -27912,6 +27913,16 @@ fn main() with IO, Mut, Panic, Div, Alloc {
     println("the bare highland that does not negotiate with ill-formed code -- Sfakia, Crete")
     println("Horizon 3: self-hosted primary compiler.")
     println("")
+    // Run inside the source-fresh compiler artifact before any compiler
+    // pipeline state is initialized.
+    if compiler_mode_has_flag(args, "--ir-heap-bridge-self-test") {
+        if ir_module_heap_roundtrip_self_test() {
+            println("IR_MODULE_HEAP_BRIDGE_PASS")
+            return
+        }
+        println("IR_MODULE_HEAP_BRIDGE_FAIL reason=semantic_assertion")
+        panic("IrModule heap bridge self-test failed")
+    }
     if compiler_mode_has_flag(args, "--version") {
         return
     }

--- a/self-hosted/ir/heap_storage.sio
+++ b/self-hosted/ir/heap_storage.sio
@@ -1,0 +1,310 @@
+// Heap-backed owner for the current fixed-layout IrModule.
+//
+// This is a bridge, not the canonical IR representation. It removes the
+// very large IrModule value from selected stack/BSS paths while preserving the
+// existing IrModule ABI and all SOIR semantics. The layout is hundreds of MiB
+// in this stack and has exceeded 1 GiB in adjacent compiler snapshots. The 2
+// GiB mapping is a virtual upper envelope; heap_alloc returns zeroed pages, and
+// these APIs touch only top-level metadata plus live functions.
+
+module ir::heap_storage
+
+use ir::ir::*
+use ir::serialize::{serialize_ir_module_into, deserialize_ir_module_into}
+
+pub let IR_MODULE_HEAP_STATE_NULL: i64 = 0
+pub let IR_MODULE_HEAP_STATE_ALLOCATED: i64 = 1
+pub let IR_MODULE_HEAP_STATE_FREED: i64 = 2
+pub let IR_MODULE_HEAP_STATE_FAILED: i64 = 3
+
+// Keep this above the measured current IrModule layout. This is deliberately
+// not described as capacity for 2048 materialized functions: untouched mmap
+// pages remain virtual, and every live function must be inserted explicitly.
+pub let IR_MODULE_HEAP_RESERVATION_BYTES: i64 = 2147483648
+
+// Fields stay private so allocation state changes remain owned by this module.
+// The current checker rejects repeated borrows and state-threaded returns of a
+// linear owner (reduced in issue #877). This bootstrap bridge therefore uses
+// an explicit runtime state machine. Callers must not copy or alias the owner;
+// canonical linearization is a later lane.
+pub struct IrModuleHeapBridge {
+    ptr: *mut IrModule,
+    state: i64,
+    allocation_bytes: i64,
+}
+
+pub fn ir_module_heap_null() -> IrModuleHeapBridge {
+    IrModuleHeapBridge {
+        ptr: 0 as *mut IrModule,
+        state: IR_MODULE_HEAP_STATE_NULL,
+        allocation_bytes: 0,
+    }
+}
+
+pub fn ir_module_heap_new() -> IrModuleHeapBridge with Alloc, Mut {
+    let raw = heap_alloc(IR_MODULE_HEAP_RESERVATION_BYTES) as *mut IrModule
+    if raw as i64 == 0 {
+        return IrModuleHeapBridge {
+            ptr: 0 as *mut IrModule,
+            state: IR_MODULE_HEAP_STATE_FAILED,
+            allocation_bytes: 0,
+        }
+    }
+
+    // heap_alloc is zero-initializing on both the libc and native-v2 paths.
+    // Counts are written explicitly so the sparse-empty contract is visible;
+    // no [IrFunction; 2048] initializer is constructed or copied here.
+    (*raw).fn_count = 0
+    (*raw).string_count = 0
+    (*raw).prof_counter_count = 0
+    (*raw).export_count = 0
+    (*raw).bss_total_size = 0
+
+    IrModuleHeapBridge {
+        ptr: raw,
+        state: IR_MODULE_HEAP_STATE_ALLOCATED,
+        allocation_bytes: IR_MODULE_HEAP_RESERVATION_BYTES,
+    }
+}
+
+pub fn ir_module_heap_state(owner: &IrModuleHeapBridge) -> i64 {
+    (*owner).state
+}
+
+pub fn ir_module_heap_is_allocated(owner: &IrModuleHeapBridge) -> bool {
+    (*owner).state == IR_MODULE_HEAP_STATE_ALLOCATED &&
+        (*owner).ptr as i64 != 0 &&
+        (*owner).allocation_bytes == IR_MODULE_HEAP_RESERVATION_BYTES
+}
+
+pub fn ir_module_heap_fn_count(owner: &IrModuleHeapBridge) -> i64 {
+    if !ir_module_heap_is_allocated(owner) { return -1 }
+    (*(*owner).ptr).fn_count
+}
+
+pub fn ir_module_heap_string_count(owner: &IrModuleHeapBridge) -> i64 {
+    if !ir_module_heap_is_allocated(owner) { return -1 }
+    (*(*owner).ptr).string_count
+}
+
+pub fn ir_module_heap_add_function(owner: &! IrModuleHeapBridge, name: Name, defining_module_id: i64) -> i64 with Mut {
+    if !ir_module_heap_is_allocated(owner) { return -1 }
+    let module_ptr = (*owner).ptr
+    let index = (*module_ptr).fn_count
+    if index < 0 || index >= IR_MAX_FUNCS { return -1 }
+
+    // The allocation is already zeroed. Initialize only the live slot's
+    // non-zero/default-sensitive fields instead of constructing and copying a
+    // full IrFunction with its 2048-instruction inline array.
+    (*module_ptr).functions[index as usize].name = name
+    (*module_ptr).functions[index as usize].defining_module_id = defining_module_id
+    (*module_ptr).functions[index as usize].prof_counter_id = -1
+    (*module_ptr).functions[index as usize].hyper_algebra_kind = -1
+    (*module_ptr).functions[index as usize].sret_dest_reg = -1
+    var param_index: i64 = 0
+    while param_index < 64 {
+        (*module_ptr).functions[index as usize].param_regs[param_index as usize] = IR_INVALID_REG
+        param_index = param_index + 1
+    }
+    (*module_ptr).fn_count = index + 1
+    index
+}
+
+pub fn ir_module_heap_set_function_reg_count(owner: &! IrModuleHeapBridge, fn_index: i64, reg_count: i64) -> bool with Mut {
+    if !ir_module_heap_is_allocated(owner) { return false }
+    let module_ptr = (*owner).ptr
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return false }
+    if reg_count < 0 { return false }
+    (*module_ptr).functions[fn_index as usize].reg_count = reg_count
+    true
+}
+
+pub fn ir_module_heap_append_instr(owner: &! IrModuleHeapBridge, fn_index: i64, instr: IrInstr) -> bool with Mut {
+    if !ir_module_heap_is_allocated(owner) { return false }
+    let module_ptr = (*owner).ptr
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return false }
+    let instr_index = (*module_ptr).functions[fn_index as usize].instr_count
+    if instr_index < 0 || instr_index >= IR_MAX_INSTRS { return false }
+    (*module_ptr).functions[fn_index as usize].instrs[instr_index as usize] = instr
+    (*module_ptr).functions[fn_index as usize].instr_count = instr_index + 1
+    true
+}
+
+pub fn ir_module_heap_add_string(owner: &! IrModuleHeapBridge, name: Name) -> i64 with Mut {
+    if !ir_module_heap_is_allocated(owner) { return -1 }
+    let module_ptr = (*owner).ptr
+    let index = (*module_ptr).string_count
+    if index < 0 || index >= IR_MAX_STRINGS { return -1 }
+    (*module_ptr).string_table[index as usize] = name
+    (*module_ptr).string_count = index + 1
+    index
+}
+
+pub fn ir_module_heap_function_defining_module_id(owner: &IrModuleHeapBridge, fn_index: i64) -> i64 {
+    if !ir_module_heap_is_allocated(owner) { return IR_DEFINING_MODULE_UNKNOWN }
+    let module_ptr = (*owner).ptr
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return IR_DEFINING_MODULE_UNKNOWN }
+    (*module_ptr).functions[fn_index as usize].defining_module_id
+}
+
+pub fn ir_module_heap_function_instr_count(owner: &IrModuleHeapBridge, fn_index: i64) -> i64 {
+    if !ir_module_heap_is_allocated(owner) { return -1 }
+    let module_ptr = (*owner).ptr
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return -1 }
+    (*module_ptr).functions[fn_index as usize].instr_count
+}
+
+pub fn ir_module_heap_function_param_reg(owner: &IrModuleHeapBridge, fn_index: i64, param_index: i64) -> i64 {
+    if !ir_module_heap_is_allocated(owner) { return IR_INVALID_REG }
+    let module_ptr = (*owner).ptr
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return IR_INVALID_REG }
+    if param_index < 0 || param_index >= 64 { return IR_INVALID_REG }
+    (*module_ptr).functions[fn_index as usize].param_regs[param_index as usize]
+}
+
+pub fn ir_module_heap_instr_imm_i64(owner: &IrModuleHeapBridge, fn_index: i64, instr_index: i64) -> i64 {
+    if !ir_module_heap_is_allocated(owner) { return 0 }
+    let module_ptr = (*owner).ptr
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return 0 }
+    let func = &(*module_ptr).functions[fn_index as usize]
+    if instr_index < 0 || instr_index >= (*func).instr_count { return 0 }
+    (*func).instrs[instr_index as usize].imm_i64
+}
+
+pub fn ir_module_heap_string_at(owner: &IrModuleHeapBridge, index: i64) -> Name {
+    if !ir_module_heap_is_allocated(owner) { return ir_empty_name() }
+    let module_ptr = (*owner).ptr
+    if index < 0 || index >= (*module_ptr).string_count { return ir_empty_name() }
+    (*module_ptr).string_table[index as usize]
+}
+
+pub fn ir_module_heap_serialize_into(
+    owner: &IrModuleHeapBridge,
+    out_buf: &![i8; 131072],
+    out_len: &! i64,
+) -> bool with Mut, Panic, Div, Alloc {
+    (*out_len) = 0
+    if !ir_module_heap_is_allocated(owner) { return false }
+    serialize_ir_module_into(&(*(*owner).ptr), out_buf, out_len)
+    (*out_len) > 0
+}
+
+pub fn ir_module_heap_deserialize_into(
+    owner: &! IrModuleHeapBridge,
+    buf: [i8; 131072],
+    len: i64,
+) -> bool with Mut, Panic, Div, Alloc {
+    if !ir_module_heap_is_allocated(owner) { return false }
+
+    // Decode transactionally into a second virtual reservation. The base
+    // decoder intentionally publishes counts last, but can still modify other
+    // fields before returning false. Staging keeps the live owner bit-for-bit
+    // unchanged on every decode failure without copying an IrModule value.
+    var staged = ir_module_heap_new()
+    if !ir_module_heap_is_allocated(&staged) { return false }
+    if !deserialize_ir_module_into(buf, len, &!(*staged.ptr)) {
+        let _failed_release = ir_module_heap_release(&! staged)
+        return false
+    }
+
+    let old_ptr = (*owner).ptr
+    (*owner).ptr = staged.ptr
+    (*owner).state = IR_MODULE_HEAP_STATE_ALLOCATED
+    (*owner).allocation_bytes = IR_MODULE_HEAP_RESERVATION_BYTES
+    staged.ptr = 0 as *mut IrModule
+    staged.state = IR_MODULE_HEAP_STATE_FREED
+    staged.allocation_bytes = 0
+    heap_free(old_ptr as *mut u8)
+    true
+}
+
+// Transition before deallocation, then pass the exact user pointer returned
+// by heap_alloc. Native-v2 recovers its page-rounded mmap from the header at
+// ptr-8; the libc path receives the same pointer through ordinary free. A
+// second release observes FREED + null and therefore cannot call heap_free.
+pub fn ir_module_heap_release(owner: &! IrModuleHeapBridge) -> i64 with Alloc, Mut {
+    if !ir_module_heap_is_allocated(owner) {
+        return (*owner).state
+    }
+    let raw = (*owner).ptr
+    (*owner).ptr = 0 as *mut IrModule
+    (*owner).state = IR_MODULE_HEAP_STATE_FREED
+    (*owner).allocation_bytes = 0
+    heap_free(raw as *mut u8)
+    IR_MODULE_HEAP_STATE_FREED
+}
+
+// Shared semantic witness used by T17 and by the source-fresh Madaros internal
+// self-test. One implementation keeps CI on the actual SOIR v5/v4 bridge.
+pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc {
+    var owner = ir_module_heap_new()
+    let expected_name = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
+    let fn_index = ir_module_heap_add_function(
+        &! owner,
+        ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4),
+        37,
+    )
+    var ok = ir_module_heap_is_allocated(&owner) && fn_index == 0
+    ok = ir_module_heap_set_function_reg_count(&! owner, fn_index, 1) && ok
+    ok = ir_module_heap_append_instr(&! owner, fn_index, ir_load_imm(0, 42)) && ok
+    ok = ir_module_heap_append_instr(&! owner, fn_index, ir_return(0)) && ok
+    ok = ir_module_heap_add_string(&! owner, expected_name) == 0 && ok
+    ok = ir_module_heap_function_param_reg(&owner, fn_index, 0) == IR_INVALID_REG && ok
+    ok = ir_module_heap_function_param_reg(&owner, fn_index, 63) == IR_INVALID_REG && ok
+
+    var buf: [i8; 131072] = [0; 131072]
+    var len: i64 = 0
+    ok = ir_module_heap_serialize_into(&owner, &! buf, &! len) && ok
+    ok = ir_module_heap_deserialize_into(&! owner, buf, len) && ok
+    ok = ir_module_heap_fn_count(&owner) == 1 && ok
+    ok = ir_module_heap_function_instr_count(&owner, 0) == 2 && ok
+    ok = ir_module_heap_instr_imm_i64(&owner, 0, 0) == 42 && ok
+    ok = ir_module_heap_function_defining_module_id(&owner, 0) == 37 && ok
+
+    // A truncated v5 decode must not publish any staged writes.
+    ok = !ir_module_heap_deserialize_into(&! owner, buf, len - 1) && ok
+    ok = ir_module_heap_fn_count(&owner) == 1 && ok
+    ok = ir_module_heap_function_instr_count(&owner, 0) == 2 && ok
+    ok = ir_module_heap_instr_imm_i64(&owner, 0, 0) == 42 && ok
+    ok = ir_module_heap_function_defining_module_id(&owner, 0) == 37 && ok
+
+    // Build a genuine v4 buffer by removing the v5-only provenance word.
+    var legacy_buf = buf
+    let provenance_pos: i64 = 8 + 8 + 136 + 32 + 512 + 24
+    var shift_pos = provenance_pos
+    while shift_pos + 8 < len {
+        legacy_buf[shift_pos as usize] = legacy_buf[(shift_pos + 8) as usize]
+        shift_pos = shift_pos + 1
+    }
+    legacy_buf[4] = 4 as i8
+    ok = ir_module_heap_deserialize_into(&! owner, legacy_buf, len - 8) && ok
+    ok = ir_module_heap_fn_count(&owner) == 1 && ok
+    ok = ir_module_heap_function_defining_module_id(&owner, 0) == IR_DEFINING_MODULE_UNKNOWN && ok
+    ok = ir_module_heap_function_instr_count(&owner, 0) == 2 && ok
+    ok = ir_module_heap_instr_imm_i64(&owner, 0, 0) == 42 && ok
+    ok = ir_module_heap_string_count(&owner) == 1 && ok
+    ok = ir_name_eq(ir_module_heap_string_at(&owner, 0), expected_name) && ok
+
+    let first_release = ir_module_heap_release(&! owner)
+    let second_release = ir_module_heap_release(&! owner)
+    ok = first_release == IR_MODULE_HEAP_STATE_FREED && ok
+    ok = second_release == IR_MODULE_HEAP_STATE_FREED && ok
+    ok = ir_module_heap_state(&owner) == IR_MODULE_HEAP_STATE_FREED && ok
+
+    // Newer opcodes without assigned SOIR tags must make serialization fail
+    // with len=0; they can never be emitted as the placeholder NOP tag.
+    var unsupported_owner = ir_module_heap_new()
+    let unsupported_fn = ir_module_heap_add_function(&! unsupported_owner, ir_empty_name(), 91)
+    ok = unsupported_fn == 0 && ok
+    ok = ir_module_heap_append_instr(
+        &! unsupported_owner,
+        unsupported_fn,
+        ir_instr_new(IrOpcode::IrArrayLen),
+    ) && ok
+    var unsupported_buf: [i8; 131072] = [0; 131072]
+    var unsupported_len: i64 = 77
+    ok = !ir_module_heap_serialize_into(&unsupported_owner, &! unsupported_buf, &! unsupported_len) && ok
+    ok = unsupported_len == 0 && ok
+    ok = ir_module_heap_release(&! unsupported_owner) == IR_MODULE_HEAP_STATE_FREED && ok
+    ok
+}

--- a/self-hosted/ir/serialize.sio
+++ b/self-hosted/ir/serialize.sio
@@ -310,6 +310,13 @@ fn write_opcode(buf: [i8; 131072], pos: i64, op: IrOpcode) -> ([i8; 131072], i64
         IrOpcode::IrProfCounter => 34,
         IrOpcode::IrCallSret => 35,
         IrOpcode::IrReturnSret => 36,
+        // SOIR v5 has no stable wire tags for later opcodes. Mark the whole
+        // serialization failed; tag 18 is only a placeholder in the private
+        // scratch buffer and can never be published while this flag is set.
+        _ => {
+            SOIR_WRITE_FAILED = true
+            18
+        },
     }
     write_i8(buf, pos, tag)
 }
@@ -4558,7 +4565,7 @@ fn serialize_ir_module_core_preflight(module: &IrModule) -> bool with Panic, Div
     required <= SOIR_MAX_SIZE
 }
 
-fn serialize_ir_module_into(module: &IrModule, out_buf: &![i8; 131072], out_len: &! i64) with Mut, Panic, Div, Alloc {
+pub fn serialize_ir_module_into(module: &IrModule, out_buf: &![i8; 131072], out_len: &! i64) with Mut, Panic, Div, Alloc {
     var buf: [i8; 131072] = [0; 131072]
     var pos: i64 = 0
     SOIR_WRITE_FAILED = false
@@ -4642,7 +4649,7 @@ fn serialize_ir_module(module: IrModule) -> ([i8; 131072], i64) with Mut, Panic,
 // Decode into a freshly initialized destination. Counts remain zero until the
 // complete function and string tables have succeeded, so callers can treat a
 // false result as an empty module without copying a second 2048-function table.
-fn deserialize_ir_module_into(buf: [i8; 131072], len: i64, out: &! IrModule) -> bool with Mut, Panic, Div, Alloc {
+pub fn deserialize_ir_module_into(buf: [i8; 131072], len: i64, out: &! IrModule) -> bool with Mut, Panic, Div, Alloc {
     var pos: i64 = 0
     (*out).fn_count = 0
     (*out).string_count = 0

--- a/self-hosted/test_ir.sio
+++ b/self-hosted/test_ir.sio
@@ -867,63 +867,8 @@ fn ir_test_16_method_call_lowered() -> bool with Mut, Panic, Div, Alloc, IO {
 }
 
 // Phase 0 tests: IR serialization and normalization
-fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO {
-    var module = ir_empty_module()
-    module.fn_count = 1
-    module.string_count = 1
-    module.string_table[0] = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
-
-    var func = ir_empty_function()
-    func.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
-    func.defining_module_id = 37
-    func.instr_count = 2
-    func.reg_count = 1
-    func.instrs[0] = ir_load_imm(0, 42)
-    func.instrs[1] = ir_return(0)
-
-    module.functions[0] = func
-
-    let pair = serialize_ir_module(module)
-    let buf = pair.0
-    let len = pair.1
-
-    let restored = deserialize_ir_module(buf, len)
-
-    if restored.fn_count != 1 {
-        return false
-    }
-    if restored.functions[0].instr_count != 2 {
-        return false
-    }
-    if restored.functions[0].instrs[0].imm_i64 != 42 {
-        return false
-    }
-    if restored.functions[0].defining_module_id != 37 {
-        return false
-    }
-
-    // Build a genuine v4 module buffer from the v5 fixture: remove the v5-only
-    // provenance word and shift both instructions and following module sections.
-    // Offset = header + fn_count + Name + 4 counts + 64 params + strategy/prof/hyper.
-    var legacy_buf = buf
-    let provenance_pos: i64 = 8 + 8 + 136 + 32 + 512 + 24
-    var shift_pos = provenance_pos
-    while shift_pos + 8 < len {
-        legacy_buf[shift_pos as usize] = legacy_buf[(shift_pos + 8) as usize]
-        shift_pos = shift_pos + 1
-    }
-    legacy_buf[4] = 4 as i8
-    let legacy_restored = deserialize_ir_module(legacy_buf, len - 8)
-    if legacy_restored.fn_count != 1 ||
-       legacy_restored.functions[0].defining_module_id != IR_DEFINING_MODULE_UNKNOWN ||
-       legacy_restored.functions[0].instr_count != 2 ||
-       legacy_restored.functions[0].instrs[0].imm_i64 != 42 ||
-       legacy_restored.string_count != 1 ||
-       !ir_name_eq(legacy_restored.string_table[0], module.string_table[0]) {
-        return false
-    }
-
-    true
+fn ir_test_17_serialize_roundtrip() -> bool with Mut, Panic, Div, IO, Alloc {
+    ir_module_heap_roundtrip_self_test()
 }
 
 fn ir_test_18_normalize_deterministic() -> bool with Mut, Panic, Div {


### PR DESCRIPTION
## Stack

Replacement for #880. Draft stacked on the updated #870 branch `codex/ir-serialize-capacity-20260713` at exact base head `7a03af25ff247091bec62bd4a6f164433bbf398e`.

The dependent stack was advanced without force-pushes:

- #867 head `f052df7f424ecaff7877aff2708aaa9dbca9143d` includes `main@d1d515c86764e88184f9c51a200482faebe69d64`.
- #869 head `79e65e7986e54aeae1be212134ec83d85ab37099` merges updated #867.
- #870 head `7a03af25ff247091bec62bd4a6f164433bbf398e` merges updated #869.

This head contains only the three lane commits above updated #870 and changes exactly 12 lane/governance files. It is intentionally DRAFT and must not merge while the B1 blocker below is open.

## What changed

- Adds `IrModuleHeapBridge`, an explicit private-pointer runtime state machine over the unchanged fixed-layout `IrModule` ABI.
- Constructs sparse live function slots without materializing a full `IrFunction` value; all 64 `param_regs` receive the canonical `IR_INVALID_REG` sentinel.
- Adds checked add/read/mutate APIs and release ordering that tombstones the owner before freeing the exact user pointer.
- Makes SOIR module encode/decode entrypoints public by reference and performs heap decode transactionally through a staged allocation.
- Keeps SOIR v5 `defining_module_id=37`, v4 unknown provenance, truncated-decode preservation, and double-release behavior in one shared witness used by T17 and the Madaros internal self-test.
- Rejects in-memory opcodes without stable SOIR tags on write with `len=0`; no speculative wire tags are assigned.
- Adds a raw-ELF gate with ELF magic, exact version banner, optional required SHA-256, exact PASS receipt, contradictory FAIL/fallback rejection, and no wrapper path.
- Registers semantic concept `SOUNIO-IR-STORAGE-OWNERSHIP` as a hypothesis and records the executable blocker contract.

This is a bridge, not a canonical arena. It does not change `IrModule`, `IrFunction`, `IrInstr`, DefId, existing wire tags, capacity, or the approximately 804 function / 4,618 instruction access sites.

## Ownership boundaries

- Per-owner-instance release is reviewed clean, but alias-safe ownership is not claimed. The checker currently rejects valid linear consume-and-return threading; tracked by #877.
- Unknown SOIR reader tags retain the legacy reader policy in this lane. Fail-closed corrupt-tag decoding is tracked separately by #878.
- The canonical inline IR and all existing by-value paths remain intentionally present.
- Fallback path: none.
- LLM offload: not required; no math claim, clinical pathway, or external publication artifact changed.

## Lane commits

- `617537fe1` `feat(ir): add heap-backed module bridge`
- `f0188763c` `test(madaros): add raw IR heap bridge receipt`
- `71a627f63` `docs(ir): record heap bridge blocker contract`

## Validation receipts

### Clean local/static/review surfaces

- `git diff --check 7a03af25f..HEAD`: PASS
- Exact diff: 12 files, +514/-63
- `bash -n scripts/ci/ir_module_heap_bridge_gate.sh scripts/bootstrap/bootstrap_concat.sh`: PASS
- `bash scripts/ci/semantic_coordination_gate.sh`: PASS
- `bash scripts/dev/check_docs_registry.sh`: PASS, including registry selftest
- `bash scripts/dev/check_docs_consistency.sh`: PASS
- `jq -e . docs/governance/topic-registry.v1.json`: PASS
- Independent read-only reviews: bridge transaction/private pointer CLEAN; main dispatch/gate CLEAN; writer publication path CLEAN; final governance CLEAN.
- Stale raw compiler and deliberately wrong SHA controls: rejected fail-closed.

### Exact source-fresh control: GREEN

From exact integration control `00d3e5ac0a0dd5e65397af804df38d74fd15811a`, with stack `65536`, global build lock, and `/usr/bin/time -v`:

- exit `0`
- elapsed `3:11.58`
- maximum RSS `513024 KiB`
- ELF size `98463773` bytes
- ELF SHA-256 `e586cfd19b4fe5aa68512c962a48fe88793e59aea7f1a2b58f33505042c317a7`
- final marker `Madaros ready`

### Integration builds: BLOCKED

Initial bridge integration:

- exit `139`
- elapsed `2:32.77`
- maximum RSS `513180 KiB`
- output artifact missing
- exposed non-exhaustive legacy opcode writer, then seed segfault

After the reviewed writer fail-closed guard removed that diagnostic:

- exit `139`
- elapsed `2:32.31`
- maximum RSS `513180 KiB`
- output artifact missing
- no serializer exhaustiveness error
- seed still segfaults at `build_modular_madaros.sh:115` while emitting the newly activated full `ir::serialize` closure

The shared raw internal self-test therefore was not run: no source-fresh integration ELF exists. Exact durable receipts are in #879.

## Open blocker

```text
Blocker-ID: BLK-20260714-IR-HEAP-SERIALIZE-CLOSURE
Status: classified
Severity: B1
Class: bootstrap-runtime
Evidence-Level: E2
Evidence: #879
Fallback-Path: none
Legacy-Kept: yes
```

Acceptance requires splitting a minimal SOIR v5/v4 module encode/decode core without changing tags or identity, completing the same source-fresh build, and then passing:

```bash
MADAROS_RAW_BIN=<absolute-source-fresh-elf> \
IR_MODULE_HEAP_BRIDGE_EXPECT_SHA256=<sha256> \
bash scripts/ci/ir_module_heap_bridge_gate.sh
```

Expected exact receipt: `IR_MODULE_HEAP_BRIDGE_PASS` with the compiler path and SHA-256. The gate is not wired into the shared workflow in this draft.
