### PR TITLE
fix(ir): isolate scalar-result ref-writer receipts [DO NOT MERGE]

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -13,7 +13,14 @@
 use lexer::mod::*
 use parser::ast::*
 use ir::ir::*
-use ir::heap_storage::{ir_module_heap_roundtrip_self_test}
+use ir::heap_storage::{
+    ir_module_heap_roundtrip_self_test_code,
+    ir_module_heap_self_test_observed_len,
+    ir_module_heap_self_test_observed_result,
+    IR_MODULE_HEAP_SELF_TEST_PASS,
+    IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT,
+    IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT,
+}
 use check::dependent::*
 use check::types::*
 use check::compat::*
@@ -27916,10 +27923,20 @@ fn main() with IO, Mut, Panic, Div, Alloc {
     // Run inside the source-fresh compiler artifact before any compiler
     // pipeline state is initialized.
     if compiler_mode_has_flag(args, "--ir-heap-bridge-self-test") {
-        if ir_module_heap_roundtrip_self_test() {
+        let heap_self_test_code = ir_module_heap_roundtrip_self_test_code()
+        if heap_self_test_code == IR_MODULE_HEAP_SELF_TEST_PASS {
             println("IR_MODULE_HEAP_BRIDGE_PASS")
             return
         }
+        let observed_len = ir_module_heap_self_test_observed_len()
+        if observed_len >= 0 {
+            println("IR_MODULE_HEAP_BRIDGE_OBSERVED len=" + int_to_string(observed_len))
+        }
+        if heap_self_test_code == IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT ||
+           heap_self_test_code == IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT {
+            println("IR_MODULE_HEAP_BRIDGE_OBSERVED result=" + int_to_string(ir_module_heap_self_test_observed_result()))
+        }
+        println("IR_MODULE_HEAP_BRIDGE_STAGE_FAIL code=" + int_to_string(heap_self_test_code))
         println("IR_MODULE_HEAP_BRIDGE_FAIL reason=semantic_assertion")
         panic("IrModule heap bridge self-test failed")
     }

--- a/self-hosted/ir/heap_storage.sio
+++ b/self-hosted/ir/heap_storage.sio
@@ -15,8 +15,14 @@ module ir::heap_storage
 
 use ir::ir::*
 use ir::soir_core::{
-    soir_core_serialize_ir_module_empty_extensions_into,
+    soir_core_serialize_ir_module_empty_extensions_result_into,
     soir_core_deserialize_ir_module_empty_extensions_materialized_into,
+    SOIR_CORE_SERIALIZE_OK,
+    SOIR_CORE_SERIALIZE_COUNTS_BOUNDS,
+    SOIR_CORE_SERIALIZE_MODULE_CONTRACT,
+    SOIR_CORE_SERIALIZE_ENVELOPE_CAPACITY,
+    SOIR_CORE_SERIALIZE_FUNCTION_INSTR,
+    SOIR_CORE_SERIALIZE_STRING,
 }
 
 pub let IR_MODULE_HEAP_STATE_NULL: i64 = 0
@@ -110,13 +116,13 @@ pub fn ir_module_heap_add_function(owner: &! IrModuleHeapBridge, name: Name, def
     let index = (*module_ptr).fn_count
     if index < 0 || index >= IR_MAX_FUNCS { return -1 }
 
-    // Native-v2 lowers [IrFunction; N] as aggregate handles. A zeroed raw
-    // reservation therefore contains null slots, not inline empty functions.
-    // Install the canonical empty value before any field dereference so the
-    // backend owns the physical representation and all sentinel defaults.
-    (*module_ptr).functions[index as usize] = ir_empty_function()
-    (*module_ptr).functions[index as usize].name = name
-    (*module_ptr).functions[index as usize].defining_module_id = defining_module_id
+    // Build through a local canonical lvalue, then publish its managed handle
+    // once. Native-v2 raw->array->field mutation can target a lowered temporary
+    // instead of the handle stored in the raw reservation.
+    var function = ir_empty_function()
+    function.name = name
+    function.defining_module_id = defining_module_id
+    (*module_ptr).functions[index as usize] = function
     (*module_ptr).fn_count = index + 1
     index
 }
@@ -126,21 +132,54 @@ pub fn ir_module_heap_set_function_reg_count(owner: &! IrModuleHeapBridge, fn_in
     let module_ptr = (*owner).ptr
     if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return false }
     if reg_count < 0 { return false }
-    (*module_ptr).functions[fn_index as usize].reg_count = reg_count
+    var function = (*module_ptr).functions[fn_index as usize]
+    function.reg_count = reg_count
+    (*module_ptr).functions[fn_index as usize] = function
     true
 }
 
-pub fn ir_module_heap_append_instr(owner: &! IrModuleHeapBridge, fn_index: i64, instr: IrInstr) -> bool with Mut {
-    if !ir_module_heap_is_allocated(owner) { return false }
+let IR_MODULE_HEAP_APPEND_OK: i64 = 0
+let IR_MODULE_HEAP_APPEND_INVALID_OWNER: i64 = 1
+let IR_MODULE_HEAP_APPEND_FUNCTION_BOUNDS: i64 = 2
+let IR_MODULE_HEAP_APPEND_INSTR_BOUNDS: i64 = 3
+let IR_MODULE_HEAP_APPEND_LOCAL_OPCODE: i64 = 4
+let IR_MODULE_HEAP_APPEND_LOCAL_IMM: i64 = 5
+let IR_MODULE_HEAP_APPEND_PUBLISHED_COUNT: i64 = 6
+let IR_MODULE_HEAP_APPEND_PUBLISHED_OPCODE: i64 = 7
+let IR_MODULE_HEAP_APPEND_PUBLISHED_IMM: i64 = 8
+
+fn ir_module_heap_append_instr_status(owner: &! IrModuleHeapBridge, fn_index: i64, instr: &IrInstr) -> i64 with Mut {
+    if !ir_module_heap_is_allocated(owner) { return IR_MODULE_HEAP_APPEND_INVALID_OWNER }
     let module_ptr = (*owner).ptr
-    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return false }
-    let instr_index = (*module_ptr).functions[fn_index as usize].instr_count
-    if instr_index < 0 || instr_index >= IR_MAX_INSTRS { return false }
-    // The function slot above is already materialized. Assigning the canonical
-    // IrInstr value installs its managed handle in the instruction array.
-    (*module_ptr).functions[fn_index as usize].instrs[instr_index as usize] = instr
-    (*module_ptr).functions[fn_index as usize].instr_count = instr_index + 1
-    true
+    if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return IR_MODULE_HEAP_APPEND_FUNCTION_BOUNDS }
+    var function = (*module_ptr).functions[fn_index as usize]
+    let instr_index = function.instr_count
+    if instr_index < 0 || instr_index >= IR_MAX_INSTRS { return IR_MODULE_HEAP_APPEND_INSTR_BOUNDS }
+    let source_opcode = (*instr).op
+    let source_imm_i64 = (*instr).imm_i64
+    function.instrs[instr_index as usize] = *instr
+    if function.instrs[instr_index as usize].op != source_opcode {
+        return IR_MODULE_HEAP_APPEND_LOCAL_OPCODE
+    }
+    if function.instrs[instr_index as usize].imm_i64 != source_imm_i64 {
+        return IR_MODULE_HEAP_APPEND_LOCAL_IMM
+    }
+    function.instr_count = instr_index + 1
+    (*module_ptr).functions[fn_index as usize] = function
+    if (*module_ptr).functions[fn_index as usize].instr_count != instr_index + 1 {
+        return IR_MODULE_HEAP_APPEND_PUBLISHED_COUNT
+    }
+    if (*module_ptr).functions[fn_index as usize].instrs[instr_index as usize].op != source_opcode {
+        return IR_MODULE_HEAP_APPEND_PUBLISHED_OPCODE
+    }
+    if (*module_ptr).functions[fn_index as usize].instrs[instr_index as usize].imm_i64 != source_imm_i64 {
+        return IR_MODULE_HEAP_APPEND_PUBLISHED_IMM
+    }
+    IR_MODULE_HEAP_APPEND_OK
+}
+
+pub fn ir_module_heap_append_instr(owner: &! IrModuleHeapBridge, fn_index: i64, instr: &IrInstr) -> bool with Mut {
+    ir_module_heap_append_instr_status(owner, fn_index, instr) == IR_MODULE_HEAP_APPEND_OK
 }
 
 pub fn ir_module_heap_add_string(owner: &! IrModuleHeapBridge, name: Name) -> i64 with Mut {
@@ -157,14 +196,16 @@ pub fn ir_module_heap_function_defining_module_id(owner: &IrModuleHeapBridge, fn
     if !ir_module_heap_is_allocated(owner) { return IR_DEFINING_MODULE_UNKNOWN }
     let module_ptr = (*owner).ptr
     if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return IR_DEFINING_MODULE_UNKNOWN }
-    (*module_ptr).functions[fn_index as usize].defining_module_id
+    let function = (*module_ptr).functions[fn_index as usize]
+    function.defining_module_id
 }
 
 pub fn ir_module_heap_function_instr_count(owner: &IrModuleHeapBridge, fn_index: i64) -> i64 {
     if !ir_module_heap_is_allocated(owner) { return -1 }
     let module_ptr = (*owner).ptr
     if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return -1 }
-    (*module_ptr).functions[fn_index as usize].instr_count
+    let function = (*module_ptr).functions[fn_index as usize]
+    function.instr_count
 }
 
 pub fn ir_module_heap_function_param_reg(owner: &IrModuleHeapBridge, fn_index: i64, param_index: i64) -> i64 {
@@ -172,34 +213,56 @@ pub fn ir_module_heap_function_param_reg(owner: &IrModuleHeapBridge, fn_index: i
     let module_ptr = (*owner).ptr
     if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return IR_INVALID_REG }
     if param_index < 0 || param_index >= 64 { return IR_INVALID_REG }
-    (*module_ptr).functions[fn_index as usize].param_regs[param_index as usize]
+    let function = (*module_ptr).functions[fn_index as usize]
+    function.param_regs[param_index as usize]
 }
 
 pub fn ir_module_heap_instr_imm_i64(owner: &IrModuleHeapBridge, fn_index: i64, instr_index: i64) -> i64 {
     if !ir_module_heap_is_allocated(owner) { return 0 }
     let module_ptr = (*owner).ptr
     if fn_index < 0 || fn_index >= (*module_ptr).fn_count { return 0 }
-    let func = &(*module_ptr).functions[fn_index as usize]
-    if instr_index < 0 || instr_index >= (*func).instr_count { return 0 }
-    (*func).instrs[instr_index as usize].imm_i64
+    let function = (*module_ptr).functions[fn_index as usize]
+    if instr_index < 0 || instr_index >= function.instr_count { return 0 }
+    let instr = function.instrs[instr_index as usize]
+    instr.imm_i64
 }
 
 pub fn ir_module_heap_string_at(owner: &IrModuleHeapBridge, index: i64) -> Name {
     if !ir_module_heap_is_allocated(owner) { return ir_empty_name() }
     let module_ptr = (*owner).ptr
     if index < 0 || index >= (*module_ptr).string_count { return ir_empty_name() }
-    (*module_ptr).string_table[index as usize]
+    let name = (*module_ptr).string_table[index as usize]
+    name
 }
 
-pub fn ir_module_heap_serialize_into(
+pub let IR_MODULE_HEAP_SERIALIZE_OK: i64 = 0
+pub let IR_MODULE_HEAP_SERIALIZE_INVALID_OWNER: i64 = -1
+pub let IR_MODULE_HEAP_SERIALIZE_COUNTS_BOUNDS: i64 = -2
+pub let IR_MODULE_HEAP_SERIALIZE_MODULE_CONTRACT: i64 = -3
+pub let IR_MODULE_HEAP_SERIALIZE_ENVELOPE_CAPACITY: i64 = -4
+pub let IR_MODULE_HEAP_SERIALIZE_FUNCTION_INSTR: i64 = -5
+pub let IR_MODULE_HEAP_SERIALIZE_STRING: i64 = -6
+pub let IR_MODULE_HEAP_SERIALIZE_FINAL_PUBLISH: i64 = -7
+
+// Canonical heap serialization boundary: positive length is success, while
+// negative values are stable failure categories. The buffer is the sole
+// out-parameter, avoiding the falsified buffer-plus-length publication path.
+pub fn ir_module_heap_serialize_result_into(
     owner: &IrModuleHeapBridge,
     out_buf: &![i8; 131072],
-    out_len: &! i64,
-) -> bool with Mut, Panic, Div, Alloc {
-    (*out_len) = 0
-    if !ir_module_heap_is_allocated(owner) { return false }
-    soir_core_serialize_ir_module_empty_extensions_into(&(*(*owner).ptr), out_buf, out_len)
-    (*out_len) > 0
+) -> i64 with Mut, Panic, Div, Alloc {
+    if !ir_module_heap_is_allocated(owner) { return IR_MODULE_HEAP_SERIALIZE_INVALID_OWNER }
+    let core_result = soir_core_serialize_ir_module_empty_extensions_result_into(
+        &(*(*owner).ptr),
+        out_buf,
+    )
+    if core_result > SOIR_CORE_SERIALIZE_OK { return core_result }
+    if core_result == SOIR_CORE_SERIALIZE_COUNTS_BOUNDS { return IR_MODULE_HEAP_SERIALIZE_COUNTS_BOUNDS }
+    if core_result == SOIR_CORE_SERIALIZE_MODULE_CONTRACT { return IR_MODULE_HEAP_SERIALIZE_MODULE_CONTRACT }
+    if core_result == SOIR_CORE_SERIALIZE_ENVELOPE_CAPACITY { return IR_MODULE_HEAP_SERIALIZE_ENVELOPE_CAPACITY }
+    if core_result == SOIR_CORE_SERIALIZE_FUNCTION_INSTR { return IR_MODULE_HEAP_SERIALIZE_FUNCTION_INSTR }
+    if core_result == SOIR_CORE_SERIALIZE_STRING { return IR_MODULE_HEAP_SERIALIZE_STRING }
+    IR_MODULE_HEAP_SERIALIZE_FINAL_PUBLISH
 }
 
 pub fn ir_module_heap_deserialize_into(
@@ -242,7 +305,9 @@ fn ir_module_heap_free_raw_graph(raw: *mut IrModule) with Alloc, Mut {
     if live_functions > IR_MAX_FUNCS { live_functions = IR_MAX_FUNCS }
     while live_functions > 0 {
         live_functions = live_functions - 1
-        (*raw).functions[live_functions as usize].instr_count = 0
+        var function = (*raw).functions[live_functions as usize]
+        function.instr_count = 0
+        (*raw).functions[live_functions as usize] = function
     }
     (*raw).fn_count = 0
     (*raw).string_count = 0
@@ -268,19 +333,123 @@ pub fn ir_module_heap_release(owner: &! IrModuleHeapBridge) -> i64 with Alloc, M
     IR_MODULE_HEAP_STATE_FREED
 }
 
+fn ir_module_heap_self_test_fail(owner: &! IrModuleHeapBridge, code: i64) -> i64 with Alloc, Mut {
+    // Preserve the first diagnostic while preventing T17's bool wrapper from
+    // carrying a live raw reservation into later tests after a failed stage.
+    let _release_state = ir_module_heap_release(owner)
+    code
+}
+
+// Stage codes are stable diagnostic receipts, not semantic result categories.
+// Zero is success; the first failing checkpoint is returned unchanged.
+pub let IR_MODULE_HEAP_SELF_TEST_PASS: i64 = 0
+pub let IR_MODULE_HEAP_SELF_TEST_ALLOC: i64 = 101
+pub let IR_MODULE_HEAP_SELF_TEST_ADD_FUNCTION: i64 = 102
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5: i64 = 103
+pub let IR_MODULE_HEAP_SELF_TEST_DESERIALIZE_V5: i64 = 104
+pub let IR_MODULE_HEAP_SELF_TEST_DEFID_V5: i64 = 105
+pub let IR_MODULE_HEAP_SELF_TEST_NONEMPTY_EXTENSION: i64 = 106
+pub let IR_MODULE_HEAP_SELF_TEST_TRUNCATION: i64 = 107
+pub let IR_MODULE_HEAP_SELF_TEST_DESERIALIZE_V4: i64 = 108
+pub let IR_MODULE_HEAP_SELF_TEST_RELEASE: i64 = 109
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_OPCODE: i64 = 110
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_PREFLIGHT: i64 = 111
+pub let IR_MODULE_HEAP_SELF_TEST_ADD_INDEX: i64 = 120
+pub let IR_MODULE_HEAP_SELF_TEST_LIVE_SLOT: i64 = 121
+pub let IR_MODULE_HEAP_SELF_TEST_SENTINELS: i64 = 122
+pub let IR_MODULE_HEAP_SELF_TEST_REG_COUNT: i64 = 123
+pub let IR_MODULE_HEAP_SELF_TEST_INSTR_0: i64 = 124
+pub let IR_MODULE_HEAP_SELF_TEST_INSTR_1: i64 = 125
+pub let IR_MODULE_HEAP_SELF_TEST_STRING_0: i64 = 126
+pub let IR_MODULE_HEAP_SELF_TEST_FN_COUNT: i64 = 127
+pub let IR_MODULE_HEAP_SELF_TEST_EMPTY_INSTR_COUNT: i64 = 128
+pub let IR_MODULE_HEAP_SELF_TEST_INITIAL_DEFID: i64 = 129
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_0: i64 = 130
+pub let IR_MODULE_HEAP_SELF_TEST_INSTR_COUNT_1: i64 = 131
+pub let IR_MODULE_HEAP_SELF_TEST_OPCODE_0: i64 = 132
+pub let IR_MODULE_HEAP_SELF_TEST_IMM_0: i64 = 133
+pub let IR_MODULE_HEAP_SELF_TEST_INPUT_OPCODE_0: i64 = 134
+pub let IR_MODULE_HEAP_SELF_TEST_INPUT_IMM_0: i64 = 135
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_OWNER: i64 = 136
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_FN_BOUNDS: i64 = 137
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_INSTR_BOUNDS: i64 = 138
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_LOCAL_OPCODE: i64 = 139
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_LOCAL_IMM: i64 = 140
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_PUBLISHED_COUNT: i64 = 141
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_PUBLISHED_OPCODE: i64 = 142
+pub let IR_MODULE_HEAP_SELF_TEST_APPEND_PUBLISHED_IMM: i64 = 143
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_CALL: i64 = 144
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_LEN: i64 = 145
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_VERSION: i64 = 146
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_DEFID: i64 = 147
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_EXTENSIONS: i64 = 148
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_INVALID_OWNER: i64 = 149
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_COUNTS_BOUNDS: i64 = 150
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_MODULE_CONTRACT: i64 = 151
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_ENVELOPE_CAPACITY: i64 = 152
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_FUNCTION_INSTR: i64 = 153
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_STRING: i64 = 154
+pub let IR_MODULE_HEAP_SELF_TEST_SERIALIZE_FINAL_PUBLISH: i64 = 155
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_FN_INDEX: i64 = 156
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_CONSTRUCTOR_OPCODE: i64 = 157
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_APPEND: i64 = 158
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_PUBLISHED_COUNT: i64 = 159
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_PUBLISHED_OPCODE: i64 = 160
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_CANONICAL_RESULT: i64 = 161
+// 162-163 are reserved receipts from the removed bool/out_len compatibility
+// wrapper. Code 163 proved that its mutable length promise was not reliable.
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_COMPAT_BOOL: i64 = 162
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_COMPAT_LEN: i64 = 163
+pub let IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_RELEASE: i64 = 164
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_PUBLISHED_COUNT: i64 = 165
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT: i64 = 166
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESET_COUNT: i64 = 167
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_PUBLISHED_COUNT: i64 = 168
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT: i64 = 169
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_RELEASE: i64 = 170
+
+var IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN: i64 = -1
+var IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT: i64 = 0
+
+pub fn ir_module_heap_self_test_observed_len() -> i64 {
+    IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN
+}
+
+pub fn ir_module_heap_self_test_observed_result() -> i64 {
+    IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT
+}
+
 // Shared semantic witness used by T17 and by the source-fresh Madaros internal
 // self-test. One implementation keeps CI on the actual SOIR v5/v4 bridge.
-pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc {
+pub fn ir_module_heap_roundtrip_self_test_code() -> i64 with Mut, Panic, Div, Alloc {
+    IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN = -1
+    IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT = 0
     var owner = ir_module_heap_new()
+    if !ir_module_heap_is_allocated(&owner) {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_ALLOC)
+    }
+
     let expected_name = ir_name_from_bytes(118 as i8, 52 as i8, 0 as i8, 0 as i8, 2)
     let fn_index = ir_module_heap_add_function(
         &! owner,
         ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4),
         37,
     )
-    var ok = ir_module_heap_is_allocated(&owner) && fn_index == 0
-    ok = ir_module_heap_function_instr_count(&owner, fn_index) == 0 && ok
-    ok = ir_module_heap_function_defining_module_id(&owner, fn_index) == 37 && ok
+    if fn_index != 0 { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_ADD_INDEX) }
+
+    if ir_module_heap_fn_count(&owner) != 1 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_FN_COUNT)
+    }
+    if ir_module_heap_function_instr_count(&owner, fn_index) != 0 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_EMPTY_INSTR_COUNT)
+    }
+    if ir_module_heap_function_defining_module_id(&owner, fn_index) != 37 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_INITIAL_DEFID)
+    }
+
+    // Codes 102 and 121 remain reserved for the original aggregate checkpoints.
+    // The leaf receipts now identify their first false assertion.
+    var ok = true
     var sentinel_index: i64 = 0
     while sentinel_index < 64 {
         ok = ir_module_heap_function_param_reg(&owner, fn_index, sentinel_index) == IR_INVALID_REG && ok
@@ -293,25 +462,108 @@ pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc 
     ok = (*owner.ptr).functions[fn_index as usize].is_sret == 0 && ok
     ok = (*owner.ptr).functions[fn_index as usize].sret_dest_reg == -1 && ok
     ok = (*owner.ptr).functions[fn_index as usize].bss_size == 0 && ok
-    ok = ir_module_heap_set_function_reg_count(&! owner, fn_index, 1) && ok
-    ok = ir_module_heap_append_instr(&! owner, fn_index, ir_load_imm(0, 42)) && ok
-    ok = ir_module_heap_append_instr(&! owner, fn_index, ir_return(0)) && ok
-    ok = ir_module_heap_add_string(&! owner, expected_name) == 0 && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_SENTINELS) }
+
+    ok = ir_module_heap_set_function_reg_count(&! owner, fn_index, 1)
+    ok = (*owner.ptr).functions[fn_index as usize].reg_count == 1 && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_REG_COUNT) }
+
+    // Code 124 remains reserved for the original first-instruction checkpoint.
+    var input_instr_0 = ir_load_imm(0, 42)
+    if input_instr_0.op != IrOpcode::IrLoadImm {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_INPUT_OPCODE_0)
+    }
+    if input_instr_0.imm_i64 != 42 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_INPUT_IMM_0)
+    }
+    let append_0_status = ir_module_heap_append_instr_status(&! owner, fn_index, &input_instr_0)
+    if append_0_status != IR_MODULE_HEAP_APPEND_OK {
+        let append_0_code = if append_0_status == IR_MODULE_HEAP_APPEND_INVALID_OWNER {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_OWNER
+        } else if append_0_status == IR_MODULE_HEAP_APPEND_FUNCTION_BOUNDS {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_FN_BOUNDS
+        } else if append_0_status == IR_MODULE_HEAP_APPEND_INSTR_BOUNDS {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_INSTR_BOUNDS
+        } else if append_0_status == IR_MODULE_HEAP_APPEND_LOCAL_OPCODE {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_LOCAL_OPCODE
+        } else if append_0_status == IR_MODULE_HEAP_APPEND_LOCAL_IMM {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_LOCAL_IMM
+        } else if append_0_status == IR_MODULE_HEAP_APPEND_PUBLISHED_COUNT {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_PUBLISHED_COUNT
+        } else if append_0_status == IR_MODULE_HEAP_APPEND_PUBLISHED_OPCODE {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_PUBLISHED_OPCODE
+        } else {
+            IR_MODULE_HEAP_SELF_TEST_APPEND_PUBLISHED_IMM
+        }
+        return ir_module_heap_self_test_fail(&! owner, append_0_code)
+    }
+    if ir_module_heap_function_instr_count(&owner, fn_index) != 1 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_INSTR_COUNT_1)
+    }
+    if (*owner.ptr).functions[fn_index as usize].instrs[0].op != IrOpcode::IrLoadImm {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_OPCODE_0)
+    }
+    if ir_module_heap_instr_imm_i64(&owner, fn_index, 0) != 42 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_IMM_0)
+    }
+
+    var input_instr_1 = ir_return(0)
+    ok = ir_module_heap_append_instr(&! owner, fn_index, &input_instr_1)
+    ok = ir_module_heap_function_instr_count(&owner, fn_index) == 2 && ok
+    ok = (*owner.ptr).functions[fn_index as usize].instrs[1].op == IrOpcode::IrReturn && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_INSTR_1) }
+
+    ok = ir_module_heap_add_string(&! owner, expected_name) == 0
+    ok = ir_module_heap_string_count(&owner) == 1 && ok
+    ok = ir_name_eq(ir_module_heap_string_at(&owner, 0), expected_name) && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_STRING_0) }
 
     var buf: [i8; 131072] = [0; 131072]
     var len: i64 = 0
-    ok = ir_module_heap_serialize_into(&owner, &! buf, &! len) && ok
+    let serialize_result = ir_module_heap_serialize_result_into(&owner, &! buf)
+    if serialize_result <= IR_MODULE_HEAP_SERIALIZE_OK {
+        let serialize_code = if serialize_result == IR_MODULE_HEAP_SERIALIZE_INVALID_OWNER {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_INVALID_OWNER
+        } else if serialize_result == IR_MODULE_HEAP_SERIALIZE_COUNTS_BOUNDS {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_COUNTS_BOUNDS
+        } else if serialize_result == IR_MODULE_HEAP_SERIALIZE_MODULE_CONTRACT {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_MODULE_CONTRACT
+        } else if serialize_result == IR_MODULE_HEAP_SERIALIZE_ENVELOPE_CAPACITY {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_ENVELOPE_CAPACITY
+        } else if serialize_result == IR_MODULE_HEAP_SERIALIZE_FUNCTION_INSTR {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_FUNCTION_INSTR
+        } else if serialize_result == IR_MODULE_HEAP_SERIALIZE_STRING {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_STRING
+        } else {
+            IR_MODULE_HEAP_SELF_TEST_SERIALIZE_FINAL_PUBLISH
+        }
+        return ir_module_heap_self_test_fail(&! owner, serialize_code)
+    }
+    len = serialize_result
+    if len != 1632 {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN = len
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_LEN)
+    }
     let provenance_pos: i64 = 8 + 8 + 136 + 32 + 512 + 24
     let extensions_pos: i64 = len - 296
-    ok = len == 1632 && ok
-    ok = buf[4] == 5 as i8 && ok
-    ok = provenance_pos == 720 && buf[provenance_pos as usize] == 37 as i8 && ok
-    ok = extensions_pos == 1336 && buf[extensions_pos as usize] == 0 as i8 && ok
+    if buf[4] != 5 as i8 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_VERSION)
+    }
+    if provenance_pos != 720 || buf[provenance_pos as usize] != 37 as i8 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_DEFID)
+    }
+    if extensions_pos != 1336 || buf[extensions_pos as usize] != 0 as i8 {
+        return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_SERIALIZE_V5_EXTENSIONS)
+    }
+
     ok = ir_module_heap_deserialize_into(&! owner, buf, len) && ok
     ok = ir_module_heap_fn_count(&owner) == 1 && ok
     ok = ir_module_heap_function_instr_count(&owner, 0) == 2 && ok
     ok = ir_module_heap_instr_imm_i64(&owner, 0, 0) == 42 && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_DESERIALIZE_V5) }
+
     ok = ir_module_heap_function_defining_module_id(&owner, 0) == 37 && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_DEFID_V5) }
 
     // The bounded core must reject, not skip, any non-empty extension section.
     var nonempty_extension_buf = buf
@@ -319,6 +571,7 @@ pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc 
     ok = !ir_module_heap_deserialize_into(&! owner, nonempty_extension_buf, len) && ok
     ok = ir_module_heap_fn_count(&owner) == 1 && ok
     ok = ir_module_heap_function_defining_module_id(&owner, 0) == 37 && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_NONEMPTY_EXTENSION) }
 
     // A truncated v5 decode must not publish any staged writes.
     ok = !ir_module_heap_deserialize_into(&! owner, buf, len - 1) && ok
@@ -326,6 +579,7 @@ pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc 
     ok = ir_module_heap_function_instr_count(&owner, 0) == 2 && ok
     ok = ir_module_heap_instr_imm_i64(&owner, 0, 0) == 42 && ok
     ok = ir_module_heap_function_defining_module_id(&owner, 0) == 37 && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_TRUNCATION) }
 
     // Build a genuine v4 buffer by removing the v5-only provenance word.
     var legacy_buf = buf
@@ -343,6 +597,7 @@ pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc 
     ok = ir_module_heap_instr_imm_i64(&owner, 0, 0) == 42 && ok
     ok = ir_module_heap_string_count(&owner) == 1 && ok
     ok = ir_name_eq(ir_module_heap_string_at(&owner, 0), expected_name) && ok
+    if !ok { return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_DESERIALIZE_V4) }
 
     let first_release = ir_module_heap_release(&! owner)
     let second_release = ir_module_heap_release(&! owner)
@@ -351,36 +606,88 @@ pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc 
     ok = ir_module_heap_state(&owner) == IR_MODULE_HEAP_STATE_FREED && ok
     ok = ir_module_heap_fn_count(&owner) == -1 && ok
     ok = ir_module_heap_string_count(&owner) == -1 && ok
+    if !ok { return IR_MODULE_HEAP_SELF_TEST_RELEASE }
 
     // Newer opcodes without assigned SOIR tags must make serialization fail
     // with len=0; they can never be emitted as the placeholder NOP tag.
     var unsupported_owner = ir_module_heap_new()
     let unsupported_fn = ir_module_heap_add_function(&! unsupported_owner, ir_empty_name(), 91)
-    ok = unsupported_fn == 0 && ok
-    ok = ir_module_heap_append_instr(
+    if unsupported_fn != 0 {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_FN_INDEX)
+    }
+    var unsupported_instr = ir_instr_new(IrOpcode::IrArrayLen)
+    if unsupported_instr.op != IrOpcode::IrArrayLen {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_CONSTRUCTOR_OPCODE)
+    }
+    let unsupported_append_status = ir_module_heap_append_instr_status(
         &! unsupported_owner,
         unsupported_fn,
-        ir_instr_new(IrOpcode::IrArrayLen),
-    ) && ok
+        &unsupported_instr,
+    )
+    if unsupported_append_status != IR_MODULE_HEAP_APPEND_OK {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_APPEND)
+    }
+    let unsupported_function = (*unsupported_owner.ptr).functions[unsupported_fn as usize]
+    if unsupported_function.instr_count != 1 {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_PUBLISHED_COUNT)
+    }
+    let unsupported_published_instr = unsupported_function.instrs[0]
+    if unsupported_published_instr.op != IrOpcode::IrArrayLen {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_PUBLISHED_OPCODE)
+    }
     var unsupported_buf: [i8; 131072] = [0; 131072]
-    var unsupported_len: i64 = 77
-    ok = !ir_module_heap_serialize_into(&unsupported_owner, &! unsupported_buf, &! unsupported_len) && ok
-    ok = unsupported_len == 0 && ok
-    ok = ir_module_heap_release(&! unsupported_owner) == IR_MODULE_HEAP_STATE_FREED && ok
+    let unsupported_result = ir_module_heap_serialize_result_into(&unsupported_owner, &! unsupported_buf)
+    if unsupported_result != IR_MODULE_HEAP_SERIALIZE_FUNCTION_INSTR {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_CANONICAL_RESULT)
+    }
+    if ir_module_heap_release(&! unsupported_owner) != IR_MODULE_HEAP_STATE_FREED {
+        return ir_module_heap_self_test_fail(&! unsupported_owner, IR_MODULE_HEAP_SELF_TEST_UNSUPPORTED_RELEASE)
+    }
 
     // Non-empty in-memory epistemic/algebra sections are outside this bounded
     // codec and must fail preflight with no published bytes.
     var extension_owner = ir_module_heap_new()
-    (*extension_owner.ptr).epistemic.model_family_count = 1
+    if !ir_module_heap_is_allocated(&extension_owner) {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_ALLOC)
+    }
+    var extension_epistemic = (*extension_owner.ptr).epistemic
+    extension_epistemic.model_family_count = 1
+    (*extension_owner.ptr).epistemic = extension_epistemic
+    let published_extension_epistemic = (*extension_owner.ptr).epistemic
+    if published_extension_epistemic.model_family_count != 1 {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_PUBLISHED_COUNT)
+    }
     var extension_buf: [i8; 131072] = [0; 131072]
-    var extension_len: i64 = 91
-    ok = !ir_module_heap_serialize_into(&extension_owner, &! extension_buf, &! extension_len) && ok
-    ok = extension_len == 0 && ok
-    (*extension_owner.ptr).epistemic.model_family_count = 0
-    (*extension_owner.ptr).algebras.count = 1
-    extension_len = 92
-    ok = !ir_module_heap_serialize_into(&extension_owner, &! extension_buf, &! extension_len) && ok
-    ok = extension_len == 0 && ok
-    ok = ir_module_heap_release(&! extension_owner) == IR_MODULE_HEAP_STATE_FREED && ok
-    ok
+    let epistemic_extension_result = ir_module_heap_serialize_result_into(&extension_owner, &! extension_buf)
+    if epistemic_extension_result != IR_MODULE_HEAP_SERIALIZE_MODULE_CONTRACT {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT = epistemic_extension_result
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT)
+    }
+    extension_epistemic = (*extension_owner.ptr).epistemic
+    extension_epistemic.model_family_count = 0
+    (*extension_owner.ptr).epistemic = extension_epistemic
+    let reset_extension_epistemic = (*extension_owner.ptr).epistemic
+    if reset_extension_epistemic.model_family_count != 0 {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESET_COUNT)
+    }
+    var extension_algebras = (*extension_owner.ptr).algebras
+    extension_algebras.count = 1
+    (*extension_owner.ptr).algebras = extension_algebras
+    let published_extension_algebras = (*extension_owner.ptr).algebras
+    if published_extension_algebras.count != 1 {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_PUBLISHED_COUNT)
+    }
+    let algebra_extension_result = ir_module_heap_serialize_result_into(&extension_owner, &! extension_buf)
+    if algebra_extension_result != IR_MODULE_HEAP_SERIALIZE_MODULE_CONTRACT {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT = algebra_extension_result
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT)
+    }
+    if ir_module_heap_release(&! extension_owner) != IR_MODULE_HEAP_STATE_FREED {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_RELEASE)
+    }
+    IR_MODULE_HEAP_SELF_TEST_PASS
+}
+
+pub fn ir_module_heap_roundtrip_self_test() -> bool with Mut, Panic, Div, Alloc {
+    ir_module_heap_roundtrip_self_test_code() == IR_MODULE_HEAP_SELF_TEST_PASS
 }

--- a/self-hosted/ir/soir_core.sio
+++ b/self-hosted/ir/soir_core.sio
@@ -755,137 +755,326 @@ pub fn deserialize_ir_function_into(buf: [i8; 131072], pos: i64, version: i8, ou
 // extension sections to be empty. The general serializer remains authoritative
 // for modules carrying epistemic, algebra, or claim payloads.
 pub let SOIR_EMPTY_EXTENSION_COUNT_FIELDS: i64 = 36
+pub let SOIR_CORE_SERIALIZE_OK: i64 = 0
+pub let SOIR_CORE_SERIALIZE_COUNTS_BOUNDS: i64 = -1
+pub let SOIR_CORE_SERIALIZE_MODULE_CONTRACT: i64 = -2
+pub let SOIR_CORE_SERIALIZE_ENVELOPE_CAPACITY: i64 = -3
+pub let SOIR_CORE_SERIALIZE_FUNCTION_INSTR: i64 = -4
+pub let SOIR_CORE_SERIALIZE_STRING: i64 = -5
+pub let SOIR_CORE_SERIALIZE_FINAL_PUBLISH: i64 = -6
 
 fn soir_core_module_has_empty_extensions(module: &IrModule) -> bool {
-    let ep = &(*module).epistemic
-    (*module).algebras.count == 0 &&
-        (*ep).model_family_count == 0 &&
-        (*ep).policy_count == 0 &&
-        (*ep).decision_policy_count == 0 &&
-        (*ep).deferral_policy_count == 0 &&
-        (*ep).acquisition_policy_count == 0 &&
-        (*ep).recourse_policy_count == 0 &&
-        (*ep).validation_count == 0 &&
-        (*ep).mechanistic_report_count == 0 &&
-        (*ep).posterior_weights_count == 0 &&
-        (*ep).counterexample_count == 0 &&
-        (*ep).audit_count == 0 &&
-        (*ep).contest_count == 0 &&
-        (*ep).contest_witness_count == 0 &&
-        (*ep).robust_proof_count == 0 &&
-        (*ep).validated_manifest_count == 0 &&
-        (*ep).decision_certificate_count == 0 &&
-        (*ep).deferred_certificate_count == 0 &&
-        (*ep).deferred_reason_witness_count == 0 &&
-        (*ep).acquisition_plan_count == 0 &&
-        (*ep).acquisition_reason_witness_count == 0 &&
-        (*ep).recourse_plan_count == 0 &&
-        (*ep).recourse_reason_witness_count == 0 &&
-        (*ep).alternative_policy_count == 0 &&
-        (*ep).alternative_frontier_count == 0 &&
-        (*ep).alternative_candidate_count == 0 &&
-        (*ep).alternative_set_count == 0 &&
-        (*ep).alternative_reason_witness_count == 0 &&
-        (*ep).transition_policy_count == 0 &&
-        (*ep).transition_protocol_count == 0 &&
-        (*ep).transition_step_count == 0 &&
-        (*ep).transition_plan_count == 0 &&
-        (*ep).transition_reason_witness_count == 0 &&
-        (*ep).monitoring_policy_count == 0 &&
-        (*ep).observed_transition_count == 0 &&
-        (*ep).rollback_certificate_count == 0 &&
-        (*ep).hyper_expr_count == 0
+    let epistemic = (*module).epistemic
+    let algebras = (*module).algebras
+    algebras.count == 0 &&
+        epistemic.model_family_count == 0 &&
+        epistemic.policy_count == 0 &&
+        epistemic.decision_policy_count == 0 &&
+        epistemic.deferral_policy_count == 0 &&
+        epistemic.acquisition_policy_count == 0 &&
+        epistemic.recourse_policy_count == 0 &&
+        epistemic.validation_count == 0 &&
+        epistemic.mechanistic_report_count == 0 &&
+        epistemic.posterior_weights_count == 0 &&
+        epistemic.counterexample_count == 0 &&
+        epistemic.audit_count == 0 &&
+        epistemic.contest_count == 0 &&
+        epistemic.contest_witness_count == 0 &&
+        epistemic.robust_proof_count == 0 &&
+        epistemic.validated_manifest_count == 0 &&
+        epistemic.decision_certificate_count == 0 &&
+        epistemic.deferred_certificate_count == 0 &&
+        epistemic.deferred_reason_witness_count == 0 &&
+        epistemic.acquisition_plan_count == 0 &&
+        epistemic.acquisition_reason_witness_count == 0 &&
+        epistemic.recourse_plan_count == 0 &&
+        epistemic.recourse_reason_witness_count == 0 &&
+        epistemic.alternative_policy_count == 0 &&
+        epistemic.alternative_frontier_count == 0 &&
+        epistemic.alternative_candidate_count == 0 &&
+        epistemic.alternative_set_count == 0 &&
+        epistemic.alternative_reason_witness_count == 0 &&
+        epistemic.transition_policy_count == 0 &&
+        epistemic.transition_protocol_count == 0 &&
+        epistemic.transition_step_count == 0 &&
+        epistemic.transition_plan_count == 0 &&
+        epistemic.transition_reason_witness_count == 0 &&
+        epistemic.monitoring_policy_count == 0 &&
+        epistemic.observed_transition_count == 0 &&
+        epistemic.rollback_certificate_count == 0 &&
+        epistemic.hyper_expr_count == 0
 }
 
-fn soir_core_empty_extensions_preflight(module: &IrModule) -> bool with Mut, Panic, Div {
+fn soir_core_empty_extensions_preflight_status(module: &IrModule) -> i64 with Mut, Panic, Div {
     if (*module).fn_count < 0 || (*module).fn_count > IR_MAX_FUNCS ||
-       (*module).string_count < 0 || (*module).string_count > IR_MAX_STRINGS ||
-       !soir_core_module_has_empty_extensions(module) ||
-       (*module).bss_total_size != 0 {
-        return false
+       (*module).string_count < 0 || (*module).string_count > IR_MAX_STRINGS {
+        return SOIR_CORE_SERIALIZE_COUNTS_BOUNDS
+    }
+    if !soir_core_module_has_empty_extensions(module) || (*module).bss_total_size != 0 {
+        return SOIR_CORE_SERIALIZE_MODULE_CONTRACT
     }
 
     var required: i64 = 16
     var i: i64 = 0
     while i < (*module).fn_count {
-        let func = &(*module).functions[i as usize]
-        if (*func).instr_count < 0 || (*func).instr_count > IR_MAX_INSTRS || (*func).bss_size != 0 {
-            return false
+        let function = (*module).functions[i as usize]
+        if function.instr_count < 0 || function.instr_count > IR_MAX_INSTRS {
+            return SOIR_CORE_SERIALIZE_COUNTS_BOUNDS
         }
-        required = required + SOIR_FUNCTION_HEADER_V5_SIZE + (*func).instr_count * SOIR_INSTR_SIZE
-        if required > SOIR_MAX_SIZE { return false }
+        if function.bss_size != 0 { return SOIR_CORE_SERIALIZE_MODULE_CONTRACT }
+        required = required + SOIR_FUNCTION_HEADER_V5_SIZE + function.instr_count * SOIR_INSTR_SIZE
+        if required > SOIR_MAX_SIZE { return SOIR_CORE_SERIALIZE_ENVELOPE_CAPACITY }
         i = i + 1
     }
 
     required = required + 8 + (*module).string_count * SOIR_NAME_SIZE
     required = required + SOIR_EMPTY_EXTENSION_COUNT_FIELDS * 8 + 8
-    required <= SOIR_MAX_SIZE
+    if required > SOIR_MAX_SIZE { return SOIR_CORE_SERIALIZE_ENVELOPE_CAPACITY }
+    SOIR_CORE_SERIALIZE_OK
 }
 
-pub fn soir_core_serialize_ir_module_empty_extensions_into(
+fn soir_core_write_i8_into(out_buf: &![i8; 131072], pos: i64, value: i8) -> i64 with Mut, Panic, Div {
+    if pos < 0 || pos >= SOIR_MAX_SIZE {
+        SOIR_WRITE_FAILED = true
+        return SOIR_INVALID_POS
+    }
+    out_buf[pos] = value
+    pos + 1
+}
+
+fn soir_core_write_i64_into(out_buf: &![i8; 131072], pos: i64, value: i64) -> i64 with Mut, Panic, Div {
+    var p = pos
+    var shift: i64 = 0
+    while shift < 64 {
+        p = soir_core_write_i8_into(out_buf, p, ((value >> shift) & 255) as i8)
+        shift = shift + 8
+    }
+    p
+}
+
+fn soir_core_write_f64_into(out_buf: &![i8; 131072], pos: i64, value: f64) -> i64 with Mut, Panic, Div {
+    soir_core_write_i64_into(out_buf, pos, f64_to_bits(value))
+}
+
+fn soir_core_write_name_into(out_buf: &![i8; 131072], pos: i64, name: &Name) -> i64 with Mut, Panic, Div {
+    if pos < 0 || pos + SOIR_NAME_SIZE > SOIR_MAX_SIZE {
+        SOIR_WRITE_FAILED = true
+        return SOIR_INVALID_POS
+    }
+    var p = soir_core_write_i64_into(out_buf, pos, (*name).len)
+    var i: i64 = 0
+    while i < 128 {
+        out_buf[p + i] = (*name).buf[i]
+        i = i + 1
+    }
+    p + 128
+}
+
+fn soir_core_write_padding_into(out_buf: &![i8; 131072], pos: i64, count: i64) -> i64 with Mut, Panic, Div {
+    var p = pos
+    var i: i64 = 0
+    while i < count {
+        p = soir_core_write_i8_into(out_buf, p, 0 as i8)
+        i = i + 1
+    }
+    p
+}
+
+fn soir_core_write_opcode_into(out_buf: &![i8; 131072], pos: i64, op: IrOpcode) -> i64 with Mut, Panic, Div {
+    let tag: i8 = match op {
+        IrOpcode::IrLoadImm => 0,
+        IrOpcode::IrLoadFloat => 1,
+        IrOpcode::IrLoadBool => 2,
+        IrOpcode::IrLoadString => 3,
+        IrOpcode::IrCopy => 4,
+        IrOpcode::IrBinOp => 5,
+        IrOpcode::IrUnaryOp => 6,
+        IrOpcode::IrCall => 7,
+        IrOpcode::IrReturn => 8,
+        IrOpcode::IrJump => 9,
+        IrOpcode::IrBranchTrue => 10,
+        IrOpcode::IrBranchFalse => 11,
+        IrOpcode::IrFieldGet => 12,
+        IrOpcode::IrFieldSet => 13,
+        IrOpcode::IrIndexGet => 14,
+        IrOpcode::IrIndexSet => 15,
+        IrOpcode::IrAlloc => 16,
+        IrOpcode::IrLabel => 17,
+        IrOpcode::IrNop => 18,
+        IrOpcode::IrPhi => 19,
+        IrOpcode::IrContest => 20,
+        IrOpcode::IrProveRobust => 21,
+        IrOpcode::IrValidated => 22,
+        IrOpcode::IrLiftKnowledge => 23,
+        IrOpcode::IrMeasure => 24,
+        IrOpcode::IrAdmitAction => 25,
+        IrOpcode::IrDeferAction => 26,
+        IrOpcode::IrPlanAcquisition => 27,
+        IrOpcode::IrPlanRecourse => 28,
+        IrOpcode::IrProposeAlternatives => 29,
+        IrOpcode::IrCommitAlternative => 30,
+        IrOpcode::IrObserveTransition => 31,
+        IrOpcode::IrRollbackTransition => 32,
+        IrOpcode::IrDebugGuard => 33,
+        IrOpcode::IrProfCounter => 34,
+        IrOpcode::IrCallSret => 35,
+        IrOpcode::IrReturnSret => 36,
+        _ => {
+            SOIR_WRITE_FAILED = true
+            18
+        },
+    }
+    soir_core_write_i8_into(out_buf, pos, tag)
+}
+
+fn soir_core_write_binary_op_into(out_buf: &![i8; 131072], pos: i64, op: BinaryOp) -> i64 with Mut, Panic, Div {
+    let tag: i8 = match op {
+        BinaryOp::OpAdd => 0,
+        BinaryOp::OpSub => 1,
+        BinaryOp::OpMul => 2,
+        BinaryOp::OpDiv => 3,
+        BinaryOp::OpRem => 4,
+        BinaryOp::OpEq => 5,
+        BinaryOp::OpNe => 6,
+        BinaryOp::OpLt => 7,
+        BinaryOp::OpLe => 8,
+        BinaryOp::OpGt => 9,
+        BinaryOp::OpGe => 10,
+        BinaryOp::OpAnd => 11,
+        BinaryOp::OpOr => 12,
+        BinaryOp::OpBitAnd => 13,
+        BinaryOp::OpBitOr => 14,
+        BinaryOp::OpBitXor => 15,
+        BinaryOp::OpShl => 16,
+        BinaryOp::OpShr => 17,
+        BinaryOp::OpConcat => 18,
+        BinaryOp::OpRange => 19,
+        BinaryOp::OpRangeInclusive => 20,
+    }
+    soir_core_write_i8_into(out_buf, pos, tag)
+}
+
+fn soir_core_write_unary_op_into(out_buf: &![i8; 131072], pos: i64, op: UnaryOp) -> i64 with Mut, Panic, Div {
+    let tag: i8 = match op {
+        UnaryOp::OpNeg => 0,
+        UnaryOp::OpNot => 1,
+        UnaryOp::OpRef => 2,
+        UnaryOp::OpRefMut => 3,
+        UnaryOp::OpDeref => 4,
+    }
+    soir_core_write_i8_into(out_buf, pos, tag)
+}
+
+fn soir_core_serialize_ir_instr_into(out_buf: &![i8; 131072], pos: i64, instr: &IrInstr) -> i64 with Mut, Panic, Div {
+    var p = soir_core_write_opcode_into(out_buf, pos, (*instr).op)
+    p = soir_core_write_padding_into(out_buf, p, 7)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).dst)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).src1)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).src2)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).imm_i64)
+    p = soir_core_write_f64_into(out_buf, p, (*instr).imm_f64)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).label_id)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).fn_id)
+    p = soir_core_write_i64_into(out_buf, p, (*instr).field_idx)
+    p = soir_core_write_binary_op_into(out_buf, p, (*instr).bin_op)
+    p = soir_core_write_padding_into(out_buf, p, 7)
+    p = soir_core_write_unary_op_into(out_buf, p, (*instr).un_op)
+    p = soir_core_write_padding_into(out_buf, p, 7)
+    let name = (*instr).name
+    p = soir_core_write_name_into(out_buf, p, &name)
+    soir_core_write_i64_into(out_buf, p, (*instr).arg_count)
+}
+
+fn soir_core_serialize_ir_function_into(out_buf: &![i8; 131072], pos: i64, function: &IrFunction) -> i64 with Mut, Panic, Div {
+    let name = (*function).name
+    var p = soir_core_write_name_into(out_buf, pos, &name)
+    p = soir_core_write_i64_into(out_buf, p, (*function).instr_count)
+    p = soir_core_write_i64_into(out_buf, p, (*function).reg_count)
+    p = soir_core_write_i64_into(out_buf, p, (*function).label_count)
+    p = soir_core_write_i64_into(out_buf, p, (*function).param_count)
+
+    var i: i64 = 0
+    while i < 64 {
+        p = soir_core_write_i64_into(out_buf, p, (*function).param_regs[i as usize])
+        i = i + 1
+    }
+    p = soir_core_write_i64_into(out_buf, p, (*function).compile_strategy)
+    p = soir_core_write_i64_into(out_buf, p, (*function).prof_counter_id)
+    if SOIR_VERSION >= 3 {
+        p = soir_core_write_i64_into(out_buf, p, (*function).hyper_algebra_kind)
+    }
+    if SOIR_VERSION >= 5 {
+        p = soir_core_write_i64_into(out_buf, p, (*function).defining_module_id)
+    }
+
+    var j: i64 = 0
+    while j < (*function).instr_count {
+        let instr = (*function).instrs[j as usize]
+        p = soir_core_serialize_ir_instr_into(out_buf, p, &instr)
+        j = j + 1
+    }
+    p
+}
+
+// Returns the positive serialized length on success or one of the negative
+// SOIR_CORE_SERIALIZE_* categories on failure. Keeping length in the scalar
+// result avoids forwarding a mutable scalar beside the 128 KiB buffer copy.
+pub fn soir_core_serialize_ir_module_empty_extensions_result_into(
     module: &IrModule,
     out_buf: &![i8; 131072],
-    out_len: &! i64,
-) with Mut, Panic, Div, Alloc {
-    var buf: [i8; 131072] = [0; 131072]
+) -> i64 with Mut, Panic, Div, Alloc {
     var pos: i64 = 0
     SOIR_WRITE_FAILED = false
-    (*out_len) = 0
 
-    if !soir_core_empty_extensions_preflight(module) { return }
+    let preflight_status = soir_core_empty_extensions_preflight_status(module)
+    if preflight_status != SOIR_CORE_SERIALIZE_OK { return preflight_status }
 
-    buf[0] = 83 as i8
-    buf[1] = 79 as i8
-    buf[2] = 73 as i8
-    buf[3] = 82 as i8
-    buf[4] = SOIR_VERSION
-    buf[5] = 0 as i8
-    buf[6] = 0 as i8
-    buf[7] = 0 as i8
+    out_buf[0] = 83 as i8
+    out_buf[1] = 79 as i8
+    out_buf[2] = 73 as i8
+    out_buf[3] = 82 as i8
+    out_buf[4] = SOIR_VERSION
+    out_buf[5] = 0 as i8
+    out_buf[6] = 0 as i8
+    out_buf[7] = 0 as i8
     pos = 8
 
-    let fn_count_pair = write_i64(buf, pos, (*module).fn_count)
-    buf = fn_count_pair.0
-    pos = fn_count_pair.1
+    pos = soir_core_write_i64_into(out_buf, pos, (*module).fn_count)
+    if SOIR_WRITE_FAILED { return SOIR_CORE_SERIALIZE_ENVELOPE_CAPACITY }
 
     var i: i64 = 0
     while i < (*module).fn_count {
-        let func_pair = serialize_ir_function(buf, pos, &(*module).functions[i as usize])
-        buf = func_pair.0
-        pos = func_pair.1
-        if SOIR_WRITE_FAILED { return }
+        let function = (*module).functions[i as usize]
+        pos = soir_core_serialize_ir_function_into(out_buf, pos, &function)
+        if SOIR_WRITE_FAILED { return SOIR_CORE_SERIALIZE_FUNCTION_INSTR }
         i = i + 1
     }
 
-    let string_count_pair = write_i64(buf, pos, (*module).string_count)
-    buf = string_count_pair.0
-    pos = string_count_pair.1
+    pos = soir_core_write_i64_into(out_buf, pos, (*module).string_count)
+    if SOIR_WRITE_FAILED { return SOIR_CORE_SERIALIZE_STRING }
 
     var j: i64 = 0
     while j < (*module).string_count {
-        let name_pair = write_name(buf, pos, (*module).string_table[j as usize])
-        buf = name_pair.0
-        pos = name_pair.1
-        if SOIR_WRITE_FAILED { return }
+        let name = (*module).string_table[j as usize]
+        pos = soir_core_write_name_into(out_buf, pos, &name)
+        if SOIR_WRITE_FAILED { return SOIR_CORE_SERIALIZE_STRING }
         j = j + 1
     }
 
     var extension_count_index: i64 = 0
     while extension_count_index < SOIR_EMPTY_EXTENSION_COUNT_FIELDS {
-        let zero_count = write_i64(buf, pos, 0)
-        buf = zero_count.0
-        pos = zero_count.1
+        pos = soir_core_write_i64_into(out_buf, pos, 0)
+        if SOIR_WRITE_FAILED { return SOIR_CORE_SERIALIZE_FINAL_PUBLISH }
         extension_count_index = extension_count_index + 1
     }
 
     // IrAlgebraTable.count follows the epistemic section in SOIR v3+.
-    let algebra_count = write_i64(buf, pos, 0)
-    buf = algebra_count.0
-    pos = algebra_count.1
+    pos = soir_core_write_i64_into(out_buf, pos, 0)
 
-    if SOIR_WRITE_FAILED || pos < 0 || pos > SOIR_MAX_SIZE { return }
-    (*out_buf) = buf
-    (*out_len) = pos
+    if SOIR_WRITE_FAILED || pos < 0 || pos > SOIR_MAX_SIZE {
+        return SOIR_CORE_SERIALIZE_FINAL_PUBLISH
+    }
+    pos
 }
 
 fn soir_core_read_empty_extensions(buf: [i8; 131072], pos: i64) -> (i64, bool) with Mut, Panic, Div {
@@ -976,15 +1165,22 @@ fn soir_core_deserialize_ir_module_empty_extensions_impl(
     var i: i64 = 0
     while i < fn_count {
         if materialize_functions {
-            // Raw heap-backed IrModule storage starts with null aggregate
-            // slots in native-v2. Materialize through the canonical language
-            // constructor before deserialize_ir_function_into dereferences it.
-            // Ordinary initialized callers retain their existing handles.
-            (*out).functions[i as usize] = ir_empty_function()
+            // Decode through a local canonical lvalue and publish exactly once
+            // after the complete function validates. Raw->array->field writes
+            // can otherwise mutate a lowered temporary instead of the handle
+            // installed in the heap reservation.
+            var materialized_function = ir_empty_function()
+            let materialized_pair = deserialize_ir_function_into(buf, pos, version, &! materialized_function)
+            if !materialized_pair.1 || SOIR_READ_FAILED { return false }
+            (*out).functions[i as usize] = materialized_function
+            pos = materialized_pair.0
+        } else {
+            // Ordinary initialized callers retain and mutate their existing
+            // function handles; only raw heap reservations need publication.
+            let initialized_pair = deserialize_ir_function_into(buf, pos, version, &! (*out).functions[i as usize])
+            if !initialized_pair.1 || SOIR_READ_FAILED { return false }
+            pos = initialized_pair.0
         }
-        let func_pair = deserialize_ir_function_into(buf, pos, version, &! (*out).functions[i as usize])
-        if !func_pair.1 || SOIR_READ_FAILED { return false }
-        pos = func_pair.0
         i = i + 1
     }
 


### PR DESCRIPTION
# DO NOT MERGE

This is a stacked diagnostic checkpoint on top of draft #885. It is not merge-eligible while the heap-backed extension-handle write remains blocked.

Base stack:

- parent PR: #885
- parent head: `cc6b9a2f5d50313e3cd8832c867151e81c94b2e7`
- parent branch: `codex/ir-heap-graph-materializer-20260714`

## What changed

- replaces the heap/core `bool + mutable out_len` serialization boundary with a scalar result contract: positive serialized length or a stable negative failure category;
- writes the bounded SOIR buffer through references and scalar positions, avoiding 128 KiB array and tuple returns in the active path;
- preserves the existing SOIR v5 wire tags, widths, little-endian encoding, padding, function header size, and instruction size;
- makes unsupported writer opcodes fail closed as `FUNCTION_INSTR = -5` instead of emitting the placeholder NOP tag;
- adds stable first-failure receipts and failure-only observed values to the source-fresh internal heap bridge witness;
- removes the unconsumed heap/core compatibility wrappers whose mutable length publication was falsified.

## Exact receipt progression

The raw source-fresh gate progressed through the actual failing frontier:

```text
145  serialized length observed as 0
146  scalar length publication repaired; first wire assertion reached
110  valid v5/v4 roundtrip passed; unsupported-opcode aggregate failed
111  unsupported opcode exact -5 passed; extension preflight aggregate failed
165  epistemic local-mutate / whole-aggregate-republish / staged-readback failed
```

The last proven source-fresh ELF is:

```text
sha256  a919dc944c8c2d64f42c79ea4c37f1ee33538ad5a2be267f99bec933c311a391
size    107734262 bytes
build   rc=0, wall=3:14.01, max RSS=513180 KiB
gate    rc=1, IR_MODULE_HEAP_BRIDGE_STAGE_FAIL code=165
```

The committed source hashes exactly match the build's recorded input hashes.

## What code 165 proves

The failure occurs before serializer preflight. The composite path that loads the MB-scale `IrEpistemicSection` aggregate, mutates a local scalar, republishes the whole aggregate into the heap-backed `IrModule`, and reads it back does not preserve the nonzero count.

Code 165 does not yet distinguish whether the local field mutation or the whole-aggregate publication is the first failing sub-operation. It does prove that another heap serializer workaround would be the wrong layer.

The next blocker belongs to checker/lowerer reference-field semantics:

- explicit `(*ref).field` is not normalized to the specialized ref-field path and can pass through raw `OpDeref`/temporary-slot semantics;
- identifier autoderef for `&IrAlgebraTable` private fields is rejected by the checker with `E012`;
- the repair needs a focused reference-field witness before the heap bridge can mutate canonical extension handles in place.

## Validation

- `git diff --check`: PASS
- source-fresh checker for `self-hosted/ir/heap_storage.sio`: PASS
- source-fresh checker for `self-hosted/ir/soir_core.sio`: PASS
- removed wrapper symbol search: zero definitions/callers
- exact current source hashes equal the recorded inputs for ELF `a919dc...`
- orthogonal review of scalar-result/ref-writer/wire mapping: CLEAN
- orthogonal review of the attempted ref-field API: BLOCKED before build; the speculative API was reverted

No fallback path was used. No new build was run after the exact proven source checkpoint. Legacy general SOIR serialization and the canonical inline `IrModule` remain intact.

Related: #882, #886. Reader-side unknown-tag handling in #878 remains a separate lane.
