### PR TITLE
fix(ir): normalize explicit reference field projections [DO NOT MERGE]

### DIFF
--- a/scripts/ci/ref_field_autoderef_static_gate.sh
+++ b/scripts/ci/ref_field_autoderef_static_gate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOWER="$ROOT/self-hosted/ir/lower.sio"
+WITNESS="$ROOT/tests/native-v2/ref_field_autoderef_semantics_witness.sio"
+
+require_fixed() {
+  local file="$1"
+  local text="$2"
+  if ! grep -Fq -- "$text" "$file"; then
+    printf 'ref-field static gate: missing `%s` in %s\n' "$text" "${file#$ROOT/}" >&2
+    exit 1
+  fi
+}
+
+# The encoded local type is the semantic boundary: reads accept both reference
+# kinds, while explicit field stores normalize only mutable references.
+require_fixed "$LOWER" 'if (*ty).kind == TypeExprKind::TypeRefMut { return 2 }'
+require_fixed "$LOWER" 'if (*ty).kind == TypeExprKind::TypeReference { return 1 }'
+store_block="$(sed -n '/fn lower_assign_stmt_ref(/,/fn lower_assign_stmt(/p' "$LOWER")"
+read_block="$(sed -n '/fn lower_field_access_expr_ref(/,/fn lower_index_expr_ref(/p' "$LOWER")"
+if ! grep -Fq 'let explicit_ref_deref = explicit_ref_kind == 2' <<<"$store_block" \
+  || grep -Fq 'let explicit_ref_deref = explicit_ref_kind > 0' <<<"$store_block"; then
+  printf 'ref-field static gate: FieldSet must normalize only mutable references\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'let explicit_ref_deref = explicit_ref_kind > 0' <<<"$read_block" \
+  || grep -Fq 'let explicit_ref_deref = explicit_ref_kind == 2' <<<"$read_block"; then
+  printf 'ref-field static gate: FieldGet must normalize shared and mutable references\n' >&2
+  exit 1
+fi
+
+# Keep the witness broad enough to cover the metadata paths changed by the
+# normalization, plus a let-bound mutable-reference alias.
+require_fixed "$WITNESS" 'second: f64'
+require_fixed "$WITNESS" 'samples: [f64; 2]'
+require_fixed "$WITNESS" 'let alias = pair'
+require_fixed "$WITNESS" '(*alias).second = value'
+require_fixed "$WITNESS" '(*pair).samples[1] = value'
+require_fixed "$WITNESS" 'let alias: &!RefFieldCollision = pair'
+require_fixed "$WITNESS" 'let alias = &!local'
+require_fixed "$WITNESS" '(*alias).guard == 99.5'
+
+printf 'ref-field autoderef static gate passed.\n'

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -18,8 +18,8 @@ struct LowerLocalStack {
     global_bss_offsets: [i64; 4096],
     global_bss_sizes: [i64; 4096],
     is_global: [i64; 4096],
-    // 1 = local/param holds a reference (&P / &[T;N] / &![T;N]) to a heap aggregate,
-    // i.e. its slot stores a raw address of the caller slot, not the handle directly.
+    // 0 = value, 1 = shared reference, 2 = mutable reference. A reference slot stores
+    // a raw address of the caller slot, not the aggregate handle directly.
     is_ref: [i64; 4096],
     // 0=other 1=int 2=float; used by println dispatch to avoid routing i64/f64 vars through print_str
     scalar_kind: [i64; 4096],
@@ -1959,15 +1959,16 @@ fn lowerer_bind_local_mut(
 
 // *mut analogue: mark a just-bound param/local as a reference-typed binding so
 // field/index lowering can emit the extra dereference for &P / &[T;N] params.
-fn lowerer_mark_local_ref_mut(
+fn lowerer_mark_local_ref_kind_mut(
     lo: &! Lowerer,
-    name: Name
+    name: Name,
+    ref_kind: i64
 ) with Mut, Alloc, Panic, Div {
     var locals_box = (*lo).locals
     var i = (*locals_box).count - 1
     while i >= 0 {
         if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
-            (*locals_box).is_ref[i as usize] = 1
+            (*locals_box).is_ref[i as usize] = ref_kind
             (*lo).locals = locals_box
             return
         }
@@ -2106,8 +2107,9 @@ fn lowerer_lower_fn_params_mut(
                 if lower_type_expr_is_f64(&(*list).head.ty) {
                     (*lo) = (*lo).bind_local_scalar_kind((*list).head.name, 2)
                 }
-                if lower_type_expr_is_ref_like(&(*list).head.ty) {
-                    lowerer_mark_local_ref_mut(lo, (*list).head.name)
+                let param_ref_kind = lower_type_expr_ref_kind(&(*list).head.ty)
+                if param_ref_kind > 0 {
+                    lowerer_mark_local_ref_kind_mut(lo, (*list).head.name, param_ref_kind)
                 }
                 if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
                     lowerer_mark_local_array_elem_float_mut(lo, (*list).head.name)
@@ -2574,8 +2576,28 @@ fn lower_param_struct_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
     ir_empty_name()
 }
 
+fn lower_type_expr_ref_kind(ty: &TypeExpr) -> i64 {
+    if (*ty).kind == TypeExprKind::TypeRefMut { return 2 }
+    if (*ty).kind == TypeExprKind::TypeReference { return 1 }
+    0
+}
+
 fn lower_type_expr_is_ref_like(ty: &TypeExpr) -> bool {
-    (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut
+    lower_type_expr_ref_kind(ty) > 0
+}
+
+fn lower_opt_type_ref_kind(opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
+    match *opt {
+        Some(ty) => lower_type_expr_ref_kind(&(*ty)),
+        None => 0,
+    }
+}
+
+fn lower_opt_type_struct_name(opt: &Option<Box<TypeExpr>>) -> Name with Mut, Panic, Div {
+    match *opt {
+        Some(ty) => lower_param_struct_type_name(&(*ty)),
+        None => ir_empty_name(),
+    }
 }
 
 fn lower_name_wide_int_bits(n: Name) -> i64 with Panic, Div {
@@ -4146,15 +4168,66 @@ impl Lowerer {
         false
     }
 
-    fn lookup_local_is_ref(self, name: Name) -> bool with Mut, Panic, Div, Alloc {
+    fn lookup_local_ref_kind(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
         var i = (*self.locals).count - 1
         while i >= 0 {
             if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
-                return (*self.locals).is_ref[i as usize] == 1
+                return (*self.locals).is_ref[i as usize]
             }
             i = i - 1
         }
-        false
+        0
+    }
+
+    fn lookup_local_is_ref(self, name: Name) -> bool with Mut, Panic, Div, Alloc {
+        self.lookup_local_ref_kind(name) > 0
+    }
+
+    fn bind_local_ref_kind(self, name: Name, ref_kind: i64) -> Lowerer with Mut, Alloc, Panic, Div {
+        var lo = self
+        var stk = *lo.locals
+        var i = stk.count - 1
+        while i >= 0 {
+            if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
+                stk.is_ref[i as usize] = ref_kind
+                lo.locals = Box::new(stk)
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
+    fn expr_local_ref_kind(self, e: &Expr) -> i64 with Mut, Panic, Div, Alloc {
+        if (*e).kind == ExprKind::ExprUnary {
+            if (*e).un_op == UnaryOp::OpRefMut { return 2 }
+            if (*e).un_op == UnaryOp::OpRef { return 1 }
+        }
+        if (*e).kind == ExprKind::ExprIdent {
+            return self.lookup_local_ref_kind((*e).name)
+        }
+        0
+    }
+
+    fn field_base_explicit_local_ref_kind(self, base_opt: &Option<Box<Expr>>) -> i64 with Mut, Panic, Div, Alloc {
+        match *base_opt {
+            Some(base_expr) => {
+                if (*base_expr).kind != ExprKind::ExprUnary || (*base_expr).un_op != UnaryOp::OpDeref {
+                    return 0
+                }
+                match (*base_expr).left {
+                    Some(operand) => {
+                        if (*operand).kind == ExprKind::ExprIdent {
+                            self.lookup_local_ref_kind((*operand).name)
+                        } else {
+                            0
+                        }
+                    }
+                    _ => 0,
+                }
+            }
+            _ => 0,
+        }
     }
 
     fn lookup_local_global_bss_offset(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
@@ -6246,7 +6319,7 @@ impl Lowerer {
                         locals.array_elem_float[idx as usize] = if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 1 } else { 0 }
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
-                        locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
+                        locals.is_ref[idx as usize] = lower_type_expr_ref_kind(&(*list).head.ty)
                         locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) { 2 } else { 0 }
                         locals.count = idx + 1
                     } else {
@@ -6976,6 +7049,22 @@ impl Lowerer {
             }
         }
         lo = lo.bind_local(s.name, bind_reg, is_mut)
+        var local_ref_kind = lower_opt_type_ref_kind(&s.ty)
+        if local_ref_kind == 0 {
+            match s.expr {
+                Some(ref_expr) => {
+                    local_ref_kind = lo.expr_local_ref_kind(&(*ref_expr))
+                }
+                _ => {}
+            }
+        }
+        if local_ref_kind > 0 {
+            lo = lo.bind_local_ref_kind(s.name, local_ref_kind)
+            let annotated_struct_type = lower_opt_type_struct_name(&s.ty)
+            if annotated_struct_type.len > 0 {
+                lo = lo.bind_local_struct_type(s.name, annotated_struct_type)
+            }
+        }
         // Closures step 2: if the RHS was a capturing closure, mark this local so a later
         // `name(args)` call injects the captured regs (direct call to the synthetic fn).
         if lo.pending_closure_fn_id >= 0 {
@@ -7097,6 +7186,22 @@ impl Lowerer {
                     if src_st.len > 0 {
                         lo = lo.bind_local_struct_type(s.name, src_st)
                     }
+                } else if (*expr_box).kind == ExprKind::ExprUnary
+                    && ((*expr_box).un_op == UnaryOp::OpRef || (*expr_box).un_op == UnaryOp::OpRefMut) {
+                    // `let r = &x` / `let r = &!x`: keep the referent's layout identity.
+                    // Without it, explicit projection can select a same-named field from
+                    // an unrelated struct through the global field-name fallback.
+                    match (*expr_box).left {
+                        Some(ref_operand) => {
+                            if (*ref_operand).kind == ExprKind::ExprIdent {
+                                let referent_st = lo.lookup_local_struct_type((*ref_operand).name)
+                                if referent_st.len > 0 {
+                                    lo = lo.bind_local_struct_type(s.name, referent_st)
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
                 }
             }
             _ => {}
@@ -7187,13 +7292,27 @@ impl Lowerer {
                         let base_opt: Option<Box<Expr>> = (*target_expr).left
                         match base_opt {
                             Some(base_expr) => {
-                                let base_is_ref = if (*base_expr).kind == ExprKind::ExprIdent {
+                                let explicit_ref_kind = lo.field_base_explicit_local_ref_kind(&base_opt)
+                                // Shared-reference stores retain the pre-existing unary/handle
+                                // lowering until the checker rejects them. Only &!T normalizes.
+                                let explicit_ref_deref = explicit_ref_kind == 2
+                                let base_is_ref = if explicit_ref_deref {
+                                    true
+                                } else if (*base_expr).kind == ExprKind::ExprIdent {
                                     lo.lookup_local_is_ref((*base_expr).name)
                                 } else {
                                     false
                                 }
-                                let fidx = lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
-                                let pair_base = lo.lower_expr_ref(&(*base_expr))
+                                let fidx = if explicit_ref_deref {
+                                    lo.field_idx_for_base_ref(&(*base_expr).left, (*target_expr).name)
+                                } else {
+                                    lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
+                                }
+                                let pair_base = if explicit_ref_deref {
+                                    lo.lower_opt_expr_ref(&(*base_expr).left)
+                                } else {
+                                    lo.lower_expr_ref(&(*base_expr))
+                                }
                                 lo = pair_base.0
                                 let base_reg = pair_base.1
                                 var set_instr = ir_field_set(base_reg, fidx, rhs, (*target_expr).name)
@@ -8889,15 +9008,58 @@ impl Lowerer {
     }
 
     fn lower_field_access_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
-        let pair_b = self.lower_opt_expr_ref(&e.left)
+        // A typed reference's explicit projection `(*ref).field` is the same place as
+        // `ref.field`. Lower the referenced ident directly so no raw OpDeref temporary
+        // is emitted. Box, raw-pointer, and non-ident dereferences retain their paths.
+        let explicit_ref_kind = self.field_base_explicit_local_ref_kind(&e.left)
+        let explicit_ref_deref = explicit_ref_kind > 0
+        let pair_b = match e.left {
+            Some(base_expr_ref) => {
+                if explicit_ref_deref {
+                    self.lower_opt_expr_ref(&(*base_expr_ref).left)
+                } else {
+                    self.lower_opt_expr_ref(&e.left)
+                }
+            }
+            _ => self.lower_opt_expr_ref(&e.left),
+        }
         let lo1 = pair_b.0
         let base = pair_b.1
-        let fidx = lo1.field_idx_for_base_ref(&e.left, e.name)
-        let field_is_float = lo1.field_is_float_for_base_ref(&e.left, e.name) || lo1.field_is_float_by_name_simple(e.name)
-        let field_array_elem_is_float = lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name)
+        let fidx = match e.left {
+            Some(base_expr_ref) => {
+                if explicit_ref_deref {
+                    lo1.field_idx_for_base_ref(&(*base_expr_ref).left, e.name)
+                } else {
+                    lo1.field_idx_for_base_ref(&e.left, e.name)
+                }
+            }
+            _ => lo1.field_idx_for_base_ref(&e.left, e.name),
+        }
+        let field_is_float = match e.left {
+            Some(base_expr_ref) => {
+                if explicit_ref_deref {
+                    lo1.field_is_float_for_base_ref(&(*base_expr_ref).left, e.name)
+                } else {
+                    lo1.field_is_float_for_base_ref(&e.left, e.name)
+                }
+            }
+            _ => lo1.field_is_float_for_base_ref(&e.left, e.name),
+        } || lo1.field_is_float_by_name_simple(e.name)
+        let field_array_elem_is_float = match e.left {
+            Some(base_expr_ref) => {
+                if explicit_ref_deref {
+                    lo1.field_array_elem_is_float_for_base_ref(&(*base_expr_ref).left, e.name)
+                } else {
+                    lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name)
+                }
+            }
+            _ => lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name),
+        }
         let base_is_ref = match e.left {
             Some(base_expr_ref) => {
-                if (*base_expr_ref).kind == ExprKind::ExprIdent {
+                if explicit_ref_deref {
+                    true
+                } else if (*base_expr_ref).kind == ExprKind::ExprIdent {
                     lo1.lookup_local_is_ref((*base_expr_ref).name)
                 } else {
                     false

--- a/tests/native-v2/ref_field_autoderef_semantics_witness.sio
+++ b/tests/native-v2/ref_field_autoderef_semantics_witness.sio
@@ -1,0 +1,96 @@
+//@ run-pass
+//@ expect-stdout: PASS ref_field_autoderef_semantics
+// A typed reference projection and an explicit dereference projection must
+// name the same field and preserve writes into the caller-owned object.
+
+struct RefFieldPair {
+    first: i64,
+    second: f64,
+    samples: [f64; 2],
+}
+
+// `second` deliberately has a different index than RefFieldPair.second. Both
+// fields are f64 so this detects layout identity, not an unrelated type error.
+struct RefFieldCollision {
+    second: f64,
+    guard: f64,
+}
+
+fn read_auto(pair: &RefFieldPair) -> f64 {
+    pair.second
+}
+
+fn read_explicit(pair: &RefFieldPair) -> f64 {
+    (*pair).second
+}
+
+fn read_mut_explicit(pair: &!RefFieldPair) -> f64 {
+    (*pair).second
+}
+
+fn read_array_explicit(pair: &RefFieldPair) -> f64 with Panic {
+    (*pair).samples[1]
+}
+
+fn write_auto(pair: &!RefFieldPair, value: f64) with Mut {
+    pair.second = value
+}
+
+fn write_explicit(pair: &!RefFieldPair, value: f64) with Mut {
+    (*pair).second = value
+}
+
+fn write_array_explicit(pair: &!RefFieldPair, value: f64) with Mut, Panic {
+    (*pair).samples[1] = value
+}
+
+fn write_via_local_alias(pair: &!RefFieldPair, value: f64) with Mut {
+    let alias = pair
+    (*alias).second = value
+}
+
+fn write_via_annotated_alias(pair: &!RefFieldCollision, value: f64) with Mut {
+    let alias: &!RefFieldCollision = pair
+    (*alias).second = value
+}
+
+fn local_borrow_keeps_layout() -> i64 with Mut {
+    var local = RefFieldCollision { second: 12.5, guard: 99.5 }
+    let alias = &!local
+    (*alias).second = 77.5
+    if (*alias).second == 77.5 && (*alias).guard == 99.5 { 1 } else { 0 }
+}
+
+fn main() -> i64 with IO, Mut, Panic {
+    var pair = RefFieldPair { first: 11, second: 22.5, samples: [3.5, 4.5] }
+
+    assert(read_auto(&pair) == 22.5)
+    assert(read_explicit(&pair) == 22.5)
+    assert(read_mut_explicit(&!pair) == 22.5)
+    assert(read_array_explicit(&pair) == 4.5)
+
+    write_auto(&!pair, 33.5)
+    assert(pair.first == 11)
+    assert(pair.second == 33.5)
+
+    write_explicit(&!pair, 44.5)
+    assert(pair.first == 11)
+    assert(pair.second == 44.5)
+
+    write_array_explicit(&!pair, 6.5)
+    assert(pair.samples[0] == 3.5)
+    assert(pair.samples[1] == 6.5)
+
+    write_via_local_alias(&!pair, 55.5)
+    assert(pair.first == 11)
+    assert(pair.second == 55.5)
+
+    var collision = RefFieldCollision { second: 7.5, guard: 101.5 }
+    write_via_annotated_alias(&!collision, 8.5)
+    assert(collision.second == 8.5)
+    assert(collision.guard == 101.5)
+    assert(local_borrow_keeps_layout() == 1)
+
+    println("PASS ref_field_autoderef_semantics")
+    0
+}


### PR DESCRIPTION
# DO NOT MERGE

This is a stacked compiler-semantics checkpoint on top of draft #887. It is not merge-eligible while the stack remains diagnostic and the heap-bridge consumer still fails at stage 165.

Parent stack:

- parent PR: #887
- parent head: `e304b7e8cea639db065719726fb375505155c806`
- base branch: `codex/ir-heap-selftest-receipts-20260714`

## What changed

- encodes lowerer local reference kind as `0=value`, `1=&T`, `2=&!T` in both parameter-lowering paths;
- propagates reference kind and structural layout identity through annotated let bindings, `&` / `&!` identifier borrows, and identifier aliases;
- normalizes explicit `(*ref).field` reads for shared and mutable typed local references to the existing `IrFieldGet(label_id=1)` path without an `OpDeref` temporary;
- normalizes explicit field stores only for `&!T` to `IrFieldSet(label_id=1)`; shared-reference stores retain the prior lowering path;
- adds an adversarial zero-import witness with repeated field names at different indices, f64 and array-f64 metadata, aliases, and caller-visible mutation;
- adds a context-anchored static gate that rejects read/store predicate inversion.

`Box`, raw pointers, and non-identifier dereferences remain on their previous paths. The separate Machine-IR field conversion is not claimed by this checkpoint.

## Source-fresh receipt

Exactly one build was run, with no retry:

```text
stack       65536 KiB
lock        /tmp/sounio-souc-build.lock
build       rc=0
wall        3:13.44
user        192.63 s
system      0.69 s
max RSS     513180 KiB
ELF size    107744868 bytes
ELF sha256  ca6fcbe990e4b3cf4138861d4290ccc083125213f17f0014142a2b75ecb576e5
version     Madaros v0.80.0
```

The final strengthened witness intentionally fails at runtime under the stale packaged compiler:

```text
packaged compile  rc=0
packaged runtime  rc=1, no PASS marker
```

Using the exact source-fresh ELF above:

```text
witness compile  rc=0, wall=0.17 s, max RSS=378628 KiB
witness ELF      3a98edd05dba3fe5a52f67451638233a91f21e4ea6bc393dbcaf8afc736b6bec, 16392 bytes
witness runtime  rc=0
stdout exact     PASS ref_field_autoderef_semantics
```

## Remaining heap blocker

The raw heap bridge was pinned to the same compiler SHA and version. It still fails:

```text
IR_MODULE_HEAP_BRIDGE_STAGE_FAIL code=165
IR_MODULE_HEAP_BRIDGE_FAIL reason=semantic_assertion
IR_MODULE_HEAP_BRIDGE_FAIL reason=internal_self_test_rc_1
```

This proves the ref-field lowering repair independently, but does not close the composite #887 blocker. The heap self-test consumer has not yet migrated its extension-handle mutation to the now-proven typed mutable-reference projection path. No heap serializer file was edited here.

## Validation

- `git diff --check`: PASS
- `bash scripts/ci/ref_field_autoderef_static_gate.sh`: PASS
- packaged checker for the zero-import witness: PASS
- packaged checker parity for `lower.sio`: base/lane both 303 diagnostics with identical categories (`E009=8`, `E012=44`, `E035=49`, `E175=202`)
- three orthogonal read-only reviews: FIXABLE, FIXABLE, then CLEAN
- adversarial gate simulation: swapped store predicate rejected; swapped read predicate rejected

## Out of scope

The checker currently accepts field stores through shared `&T`. That pre-existing checker defect is recorded separately in #888 with a minimal reproducer. This PR neither claims nor implements that checker repair; its explicit store normalization is restricted to `TypeRefMut`.

Files in this checkpoint:

- `self-hosted/ir/lower.sio`
- `tests/native-v2/ref_field_autoderef_semantics_witness.sio`
- `scripts/ci/ref_field_autoderef_static_gate.sh`
