### PR TITLE
feat(ir): planned SOIR Writer v0 [DO NOT MERGE]

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 958
-- Repo-backed topics: 808
+- Total governed topics: 959
+- Repo-backed topics: 809
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 558
+- Authority count `repo_only`: 559
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 577 topics
+- A2: 578 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -452,6 +452,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.implementation.self-hosting-phases | repo_only | docs/internal/implementation/SELF_HOSTING_PHASES.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.selfhost-checklist | repo_only | docs/internal/implementation/SELFHOST_CHECKLIST.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.selfhost-reproducibility-report | repo_only | docs/internal/implementation/SELFHOST_REPRODUCIBILITY_REPORT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.implementation.soir-writer-v0 | repo_only | docs/internal/implementation/SOIR_WRITER_V0.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.string-interning-summary | repo_only | docs/internal/implementation/STRING_INTERNING_SUMMARY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.summary-v0.2.0 | repo_only | docs/internal/implementation/SUMMARY_v0.2.0.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.implementation.test-triage-report | repo_only | docs/internal/implementation/test_triage_report.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -9875,6 +9875,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.implementation.soir-writer-v0",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/implementation/SOIR_WRITER_V0.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.implementation.string-interning-summary",
       "collection": "repo",
       "repo_doc_path": "docs/internal/implementation/STRING_INTERNING_SUMMARY.md",

--- a/docs/internal/implementation/SOIR_WRITER_V0.md
+++ b/docs/internal/implementation/SOIR_WRITER_V0.md
@@ -11,6 +11,13 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.imple
 
 Status: off-default prototype
 
+reviewed_on: 2026-07-14
+
+`last_validated` in the generated metadata block is currently owned by the
+repository-wide governance generator and remains pinned to its legacy
+`2026-03-07` value. `reviewed_on` records the factual date of this contract
+review without widening this compiler lane into a global metadata migration.
+
 Base: draft PR #889, `17b0858f6e7d75c9cfc9e545b1b9f0805fa9d5d6`
 
 Concept-ID: proposed `compiler.soir.writer.v0`
@@ -29,7 +36,7 @@ IR-Changed: none
 Claims-Introduced: checker-valid writer implementation; static wire-tag parity
 Claims-Forbidden: runtime byte parity, default integration, v4 emission, performance
 Assumptions: current SOIR v5 empty-extension layout is the differential baseline
-Write-Set: four all-new files listed by this checkpoint
+Write-Set: writer, witness, gate, spec, plus three mechanically generated governance files
 Read-Set: serialize.sio, soir_core.sio, heap_storage.sio, ir.sio
 Positive-Witness: legacy-vs-writer length and byte comparison for exactly two v5 fixtures
 Negative-Witness: full-buffer canaries for every declared input-rejection status exercised by v0
@@ -65,9 +72,10 @@ only `pos`, `limit`, and `status`; it never owns the byte buffer.
 
 Preflight validates before the first byte is written:
 
-- module function/string counts and per-function instruction/parameter counts
-  against `IR_MAX_FUNCS`, `IR_MAX_STRINGS`, `IR_MAX_INSTRS`, and
-  `IR_MAX_PARAMS`;
+- module function/string counts and per-function instruction counts against
+  `IR_MAX_FUNCS`, `IR_MAX_STRINGS`, and `IR_MAX_INSTRS`;
+- parameter counts against both canonical `IR_MAX_PARAMS` capacity and the
+  fixed `SOIR_V5_WIRE_PARAM_SLOTS` v5 wire capacity;
 - zero BSS, because SOIR v5 does not encode BSS sizes;
 - empty epistemic and algebra extensions for the v0 subset;
 - every function, instruction, and string `Name` length;
@@ -94,6 +102,9 @@ differential witness derives a v4 artifact by removing the v5 provenance word
 and verifies legacy decode behavior (`defining_module_id = UNKNOWN`).
 The writer pins its own version constant to `5`; a future default SOIR version
 cannot silently change the bytes emitted by this v0 contract.
+SOIR v5 always emits `SOIR_V5_WIRE_PARAM_SLOTS = 64` parameter-register slots.
+That wire-layout constant is deliberately independent from `IR_MAX_PARAMS`, so
+expanding the canonical IR cannot silently resize an established v5 artifact.
 
 ## Input-Rejection Atomicity
 

--- a/docs/internal/implementation/SOIR_WRITER_V0.md
+++ b/docs/internal/implementation/SOIR_WRITER_V0.md
@@ -1,0 +1,198 @@
+# SOIR Writer v0
+
+Status: off-default prototype
+
+Base: draft PR #889, `17b0858f6e7d75c9cfc9e545b1b9f0805fa9d5d6`
+
+Concept-ID: proposed `compiler.soir.writer.v0`
+
+## Semantic Lane
+
+```text
+Semantic-Lane-ID: compiler-soir-writer-v0-20260714
+Owner: Codex / soir_writer_v0
+Concept-IDs: proposed compiler.soir.writer.v0
+Intent-Preserved: SOIR v5 bytes and rejection semantics remain explicit and testable
+Transformation: add an off-default planned writer over a caller-owned arena view
+Types-Changed: none; introduces opaque SoirWritePlan and private SoirWriterCursor
+Effects-Changed: none
+IR-Changed: none
+Claims-Introduced: checker-valid writer implementation; static wire-tag parity
+Claims-Forbidden: runtime byte parity, default integration, v4 emission, performance
+Assumptions: current SOIR v5 empty-extension layout is the differential baseline
+Write-Set: four all-new files listed by this checkpoint
+Read-Set: serialize.sio, soir_core.sio, heap_storage.sio, ir.sio
+Positive-Witness: legacy-vs-writer length and byte comparison for two v5 fixtures
+Negative-Witness: full-buffer canaries for every declared input rejection
+Acceptance-Gate: SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh
+Integration-Target: none; stacked draft over PR #889
+Authoritative-Only-If: runtime differential gate passes locally and remotely
+```
+
+## Intent
+
+SOIR Writer v0 preserves the existing SOIR v5 bytes while removing two
+implementation accidents from the candidate write path:
+
+1. the 128 KiB artifact buffer is never passed or returned by value;
+2. writer failure state is not stored in a mutable global.
+
+This prototype does not replace `ir::serialize` or `ir::soir_core`. The legacy
+serializer remains the differential oracle and the default compiler path until
+the new writer proves parity on a declared surface.
+
+## Contract
+
+The writer is split into two phases:
+
+```text
+preflight(module, arena_view) -> SoirWritePlan
+emit(module, accepted_plan, caller_buffer) -> absolute_end | status
+```
+
+`SoirWritePlan` records `start`, `capacity`, `required`, `end`, `version`, and
+`status`. Its fields are private. `SoirWriterCursor` is private and contains
+only `pos`, `limit`, and `status`; it never owns the byte buffer.
+
+Preflight validates before the first byte is written:
+
+- module, function, instruction, string, and parameter count bounds;
+- zero BSS, because SOIR v5 does not encode BSS sizes;
+- empty epistemic and algebra extensions for the v0 subset;
+- every function, instruction, and string `Name` length;
+- every opcode against the existing SOIR v5 tag set;
+- exact byte length inside the caller's `start + capacity` arena view.
+
+Emit re-runs preflight and requires the result to match the opaque plan. An
+input rejection therefore occurs before cursor creation, leaving every byte in
+the caller buffer unchanged. Success returns the absolute end cursor; the byte
+length is `end - start`.
+
+## Supported Surface
+
+Writer v0 emits only:
+
+- SOIR v5;
+- function and instruction prefix fields already encoded by the legacy path;
+- the current stable opcode tags 0 through 36;
+- strings;
+- empty epistemic and algebra extension sections.
+
+SOIR v4 is decode/golden-only. Writer v0 has no v4 emit entrypoint. The
+differential witness derives a v4 artifact by removing the v5 provenance word
+and verifies legacy decode behavior (`defining_module_id = UNKNOWN`).
+The writer pins its own version constant to `5`; a future default SOIR version
+cannot silently change the bytes emitted by this v0 contract.
+
+## Failure Atomicity
+
+Failure atomicity is an observable contract, not an implementation comment.
+The witness fills the caller buffer with a canary and checks all 131072 bytes
+after rejected capacity, count bounds, module contract, stale plan,
+unsupported-opcode, and invalid-name inputs.
+
+The writer does not allocate a private 128 KiB scratch buffer. Its atomicity
+comes from complete preflight, an opaque plan, and an exact-size cursor. Any
+post-write cursor failure is an internal invariant breach and keeps this lane
+from promotion; it is not a fallback to partial output.
+
+## Differential Oracle
+
+`self-hosted/test_soir_writer_v0.sio` compares length and every emitted byte
+against `serialize_ir_module_into` for:
+
+- an empty module (`320` bytes);
+- one function, two instructions, and one string (`1632` bytes).
+
+It also pins v5 anchors for magic/version, function provenance at offset 720,
+and empty extensions at offset 1336, and repeats each accepted emission into a
+distinct canary-filled buffer. Once the runtime witness passes, these checks
+will establish deterministic parity only for the declared empty-extension
+subset.
+
+## Non-Claims
+
+- no default compiler integration;
+- no replacement of the legacy serializer;
+- no new SOIR version or opcode tag;
+- no support for non-empty epistemic, algebra, claim, or BSS payloads;
+- no performance claim until a source-fresh/Foundry benchmark exists;
+- no proof of general failure atomicity beyond the declared v0 input contract.
+
+## Promotion Rule
+
+The writer may become authoritative only after:
+
+1. byte-for-byte differential parity covers every supported v5 section;
+2. rejection canaries cover every status category;
+3. deterministic repeat emission is proven;
+4. source-fresh and remote gates are green;
+5. the legacy serializer remains available as a differential oracle during a
+   bounded migration window.
+
+Until then, `ir::serialize` is intentionally kept unchanged.
+
+## Checkpoint Receipt
+
+Status: `PARTIAL`
+
+```text
+Writer checker: PASS
+Static architecture gate: PASS
+Legacy tag-table parity: PASS
+Witness checker: BASELINE-EQUIVALENT
+Legacy serializer diagnostics: 22 E175, 7 E177
+Witness diagnostics: 22 E175, 7 E177
+Runtime differential: NOT RUN
+Heavy/source-fresh build: NOT RUN
+Default path: unchanged
+Legacy oracle: kept
+```
+
+The standalone modular checker accepts `soir_writer.sio`. Importing the legacy
+serializer into the differential witness reproduces the legacy serializer's
+existing privacy diagnostics exactly; the witness adds no diagnostic category
+or count. The gate therefore classifies runtime parity as not run rather than
+converting checker-baseline equivalence into a byte-parity claim.
+
+## Open Blocker
+
+```text
+Blocker-ID: BLK-20260714-soir-writer-v0-differential-runtime
+Status: classified
+Severity: B1
+Class: harness-routing
+Owner: /root integration shepherd
+Lane: SOIR Writer v0 differential qualification
+Worktree: /tmp/sounio-soir-writer-v0-20260714
+Branch: codex/soir-writer-v0-20260714
+Files-Owned: self-hosted/ir/soir_writer.sio, self-hosted/test_soir_writer_v0.sio, scripts/ci/soir_writer_v0_gate.sh, docs/internal/implementation/SOIR_WRITER_V0.md
+Files-Read-Only: serialize.sio, soir_core.sio, heap_storage.sio, bootstrap_concat.sh
+Do-Not-Touch: default serializer path and SOIR opcode tags
+Repro: SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh
+Observed: writer check passes; witness matches 22 E175 + 7 E177 legacy diagnostics; runtime not run; gate rc=1
+Expected: witness checker passes and prints PASS soir_writer_v0_differential
+Acceptance-Gate: SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh
+Evidence-Level: E3
+Evidence: gate output plus /tmp/soir-writer-v0-require-dynamic.log
+Fallback-Path: none
+Legacy-Kept: yes
+LLM-Offload: not-required
+Next-Action: run the differential through an isolated source-fresh integration surface without changing the default serializer in this lane
+```
+
+## Semantic Outcome
+
+```text
+Semantic-Outcome: implementation checkpoint; runtime qualification blocked
+Concept-Status-Before: proposed
+Concept-Status-After: proposed, checker-valid, not authoritative
+Distinctions-Added: accepted plan vs emitted bytes; input rejection vs internal invariant breach
+Distinctions-Preserved: wire value vs writer mechanism; compile success vs runtime parity
+Distinctions-Erased: none
+Evidence-Run: writer checker, static gate, tag parity, baseline diagnostic comparison
+Fallback-Path: none
+Legacy-Kept: yes, as default and differential oracle
+Conflicting-Lanes: none in the declared write-set
+Next-Semantic-Interface: IrModuleArena v2 read-only module view
+```

--- a/docs/internal/implementation/SOIR_WRITER_V0.md
+++ b/docs/internal/implementation/SOIR_WRITER_V0.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.implementation.soir-writer-v0
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.implementation.soir-writer-v0
+-->
+
 # SOIR Writer v0
 
 Status: off-default prototype
@@ -22,8 +31,8 @@ Claims-Forbidden: runtime byte parity, default integration, v4 emission, perform
 Assumptions: current SOIR v5 empty-extension layout is the differential baseline
 Write-Set: four all-new files listed by this checkpoint
 Read-Set: serialize.sio, soir_core.sio, heap_storage.sio, ir.sio
-Positive-Witness: legacy-vs-writer length and byte comparison for two v5 fixtures
-Negative-Witness: full-buffer canaries for every declared input rejection
+Positive-Witness: legacy-vs-writer length and byte comparison for exactly two v5 fixtures
+Negative-Witness: full-buffer canaries for every declared input-rejection status exercised by v0
 Acceptance-Gate: SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh
 Integration-Target: none; stacked draft over PR #889
 Authoritative-Only-If: runtime differential gate passes locally and remotely
@@ -56,7 +65,9 @@ only `pos`, `limit`, and `status`; it never owns the byte buffer.
 
 Preflight validates before the first byte is written:
 
-- module, function, instruction, string, and parameter count bounds;
+- module function/string counts and per-function instruction/parameter counts
+  against `IR_MAX_FUNCS`, `IR_MAX_STRINGS`, `IR_MAX_INSTRS`, and
+  `IR_MAX_PARAMS`;
 - zero BSS, because SOIR v5 does not encode BSS sizes;
 - empty epistemic and algebra extensions for the v0 subset;
 - every function, instruction, and string `Name` length;
@@ -84,9 +95,9 @@ and verifies legacy decode behavior (`defining_module_id = UNKNOWN`).
 The writer pins its own version constant to `5`; a future default SOIR version
 cannot silently change the bytes emitted by this v0 contract.
 
-## Failure Atomicity
+## Input-Rejection Atomicity
 
-Failure atomicity is an observable contract, not an implementation comment.
+Input-rejection atomicity is an observable contract, not an implementation comment.
 The witness fills the caller buffer with a canary and checks all 131072 bytes
 after rejected capacity, count bounds, module contract, stale plan,
 unsupported-opcode, and invalid-name inputs.
@@ -94,7 +105,9 @@ unsupported-opcode, and invalid-name inputs.
 The writer does not allocate a private 128 KiB scratch buffer. Its atomicity
 comes from complete preflight, an opaque plan, and an exact-size cursor. Any
 post-write cursor failure is an internal invariant breach and keeps this lane
-from promotion; it is not a fallback to partial output.
+from promotion; it is not a fallback to partial output. `SOIR_WRITER_INTERNAL_BOUNDS`
+may be reported after bytes were written, so it does not carry the unchanged-buffer
+guarantee and consumers must discard the entire candidate output.
 
 ## Differential Oracle
 
@@ -107,8 +120,8 @@ against `serialize_ir_module_into` for:
 It also pins v5 anchors for magic/version, function provenance at offset 720,
 and empty extensions at offset 1336, and repeats each accepted emission into a
 distinct canary-filled buffer. Once the runtime witness passes, these checks
-will establish deterministic parity only for the declared empty-extension
-subset.
+will establish deterministic parity only for these two fixtures. A broader
+empty-extension subset matrix remains future qualification work.
 
 ## Non-Claims
 
@@ -117,7 +130,9 @@ subset.
 - no new SOIR version or opcode tag;
 - no support for non-empty epistemic, algebra, claim, or BSS payloads;
 - no performance claim until a source-fresh/Foundry benchmark exists;
-- no proof of general failure atomicity beyond the declared v0 input contract.
+- no proof of general failure atomicity; only the declared v0 input rejections
+  promise an unchanged buffer;
+- no parity claim beyond the two declared fixtures until a subset matrix runs.
 
 ## Promotion Rule
 

--- a/scripts/ci/soir_writer_v0_gate.sh
+++ b/scripts/ci/soir_writer_v0_gate.sh
@@ -82,6 +82,10 @@ printf 'soir-writer-v0 gate: static contract PASS\n'
 # Import routing for standalone self-hosted modules is not assumed. When the
 # packaged compiler can resolve the lane, run the differential witness; when it
 # cannot, fail explicitly unless the caller selected static-only qualification.
+if [[ "${SOIR_WRITER_STATIC_ONLY:-0}" == "1" && "${SOIR_WRITER_REQUIRE_DYNAMIC:-0}" == "1" ]]; then
+  fail 'SOIR_WRITER_STATIC_ONLY=1 conflicts with SOIR_WRITER_REQUIRE_DYNAMIC=1'
+fi
+
 if [[ "${SOIR_WRITER_STATIC_ONLY:-0}" == "1" ]]; then
   printf 'soir-writer-v0 gate: dynamic witness NOT RUN (SOIR_WRITER_STATIC_ONLY=1)\n'
   exit 0

--- a/scripts/ci/soir_writer_v0_gate.sh
+++ b/scripts/ci/soir_writer_v0_gate.sh
@@ -25,12 +25,14 @@ done
 require_fixed "$WRITER" 'pub struct SoirWritePlan {'
 require_fixed "$WRITER" 'struct SoirWriterCursor {'
 require_fixed "$WRITER" 'pub let SOIR_WRITER_VERSION_V5: i8 = 5'
+require_fixed "$WRITER" 'pub let SOIR_V5_WIRE_PARAM_SLOTS: i64 = 64'
 require_fixed "$WRITER" 'pub fn soir_writer_preflight_empty_extensions_v5('
 require_fixed "$WRITER" 'pub fn soir_writer_emit_empty_extensions_v5('
 require_fixed "$WRITER" 'out_buf: &![i8; 131072]'
 require_fixed "$WRITER" 'let verified = soir_writer_preflight_empty_extensions_v5('
 require_fixed "$WRITER" '(*function).param_count > IR_MAX_PARAMS'
-require_fixed "$WRITER" 'while i < IR_MAX_PARAMS {'
+require_fixed "$WRITER" '(*function).param_count > SOIR_V5_WIRE_PARAM_SLOTS'
+require_fixed "$WRITER" 'while i < SOIR_V5_WIRE_PARAM_SLOTS {'
 
 if grep -Eq '(buf|out_buf): \[i8; 131072\]' "$WRITER"; then
   fail 'writer passes the 128 KiB buffer by value'

--- a/scripts/ci/soir_writer_v0_gate.sh
+++ b/scripts/ci/soir_writer_v0_gate.sh
@@ -29,6 +29,8 @@ require_fixed "$WRITER" 'pub fn soir_writer_preflight_empty_extensions_v5('
 require_fixed "$WRITER" 'pub fn soir_writer_emit_empty_extensions_v5('
 require_fixed "$WRITER" 'out_buf: &![i8; 131072]'
 require_fixed "$WRITER" 'let verified = soir_writer_preflight_empty_extensions_v5('
+require_fixed "$WRITER" '(*function).param_count > IR_MAX_PARAMS'
+require_fixed "$WRITER" 'while i < IR_MAX_PARAMS {'
 
 if grep -Eq '(buf|out_buf): \[i8; 131072\]' "$WRITER"; then
   fail 'writer passes the 128 KiB buffer by value'
@@ -105,7 +107,7 @@ if [[ "$witness_rc" -ne 0 ]]; then
     if [[ "${SOIR_WRITER_REQUIRE_DYNAMIC:-0}" == "1" ]]; then
       fail 'dynamic differential required but modular import routing is blocked'
     fi
-    exit 0
+    fail 'dynamic differential not run; use SOIR_WRITER_STATIC_ONLY=1 only for explicit static qualification'
   fi
   cat "$check_dir/witness.log" >&2
   fail 'witness checker introduced diagnostics beyond the legacy baseline'

--- a/scripts/ci/soir_writer_v0_gate.sh
+++ b/scripts/ci/soir_writer_v0_gate.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRITER="$ROOT/self-hosted/ir/soir_writer.sio"
+WITNESS="$ROOT/self-hosted/test_soir_writer_v0.sio"
+SPEC="$ROOT/docs/internal/implementation/SOIR_WRITER_V0.md"
+
+fail() {
+  printf 'soir-writer-v0 gate: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+require_fixed() {
+  local file="$1"
+  local text="$2"
+  grep -Fq -- "$text" "$file" || fail "missing '$text' in ${file#$ROOT/}"
+}
+
+for file in "$WRITER" "$WITNESS" "$SPEC"; do
+  [[ -f "$file" ]] || fail "missing ${file#$ROOT/}"
+done
+
+# The prototype owns cursor state, never the 128 KiB bytes.
+require_fixed "$WRITER" 'pub struct SoirWritePlan {'
+require_fixed "$WRITER" 'struct SoirWriterCursor {'
+require_fixed "$WRITER" 'pub let SOIR_WRITER_VERSION_V5: i8 = 5'
+require_fixed "$WRITER" 'pub fn soir_writer_preflight_empty_extensions_v5('
+require_fixed "$WRITER" 'pub fn soir_writer_emit_empty_extensions_v5('
+require_fixed "$WRITER" 'out_buf: &![i8; 131072]'
+require_fixed "$WRITER" 'let verified = soir_writer_preflight_empty_extensions_v5('
+
+if grep -Eq '(buf|out_buf): \[i8; 131072\]' "$WRITER"; then
+  fail 'writer passes the 128 KiB buffer by value'
+fi
+if grep -Eq '(^|[[:space:]])(pub[[:space:]]+)?var[[:space:]]+[A-Z_]+:' "$WRITER"; then
+  fail 'writer introduces mutable global state'
+fi
+if grep -Fq 'SOIR_WRITE_FAILED' "$WRITER"; then
+  fail 'writer depends on legacy global failure state'
+fi
+if grep -Eq 'emit_.*v4|writer_.*v4' "$WRITER"; then
+  fail 'v4 must remain decode/golden only'
+fi
+
+# Writer v0 copies the already-established wire tags. Compare the explicit
+# tables mechanically so the prototype cannot drift while the legacy core is
+# still the oracle.
+for enum_name in IrOpcode BinaryOp UnaryOp; do
+  if ! cmp -s \
+    <(grep -E "${enum_name}::[A-Za-z0-9_]+ => [0-9]+," "$ROOT/self-hosted/ir/soir_core.sio" | sed -E "s/^.*(${enum_name}::[A-Za-z0-9_]+ => [0-9]+,).*$/\\1/" | sort -u) \
+    <(grep -E "${enum_name}::[A-Za-z0-9_]+ => [0-9]+," "$WRITER" | sed -E "s/^.*(${enum_name}::[A-Za-z0-9_]+ => [0-9]+,).*$/\\1/" | sort -u); then
+    fail "$enum_name wire tags differ from legacy SOIR core"
+  fi
+done
+
+# Keep the new writer outside the default compiler path during differential
+# qualification. These files are read-only for this lane.
+for file in \
+  "$ROOT/self-hosted/ir/serialize.sio" \
+  "$ROOT/self-hosted/ir/soir_core.sio" \
+  "$ROOT/self-hosted/ir/heap_storage.sio" \
+  "$ROOT/scripts/bootstrap/bootstrap_concat.sh"; do
+  if grep -Fq 'soir_writer' "$file"; then
+    fail "default path imports prototype in ${file#$ROOT/}"
+  fi
+done
+
+require_fixed "$WITNESS" 'soir_writer_compare_with_legacy(&module, 320)'
+require_fixed "$WITNESS" 'soir_writer_compare_with_legacy(&module, 1632)'
+require_fixed "$WITNESS" 'SOIR_WRITER_UNSUPPORTED_OPCODE'
+require_fixed "$WITNESS" 'soir_writer_buffer_is_canary'
+require_fixed "$WITNESS" 'v4[4] = 4 as i8'
+require_fixed "$WITNESS" 'PASS soir_writer_v0_differential'
+
+printf 'soir-writer-v0 gate: static contract PASS\n'
+
+# Import routing for standalone self-hosted modules is not assumed. When the
+# packaged compiler can resolve the lane, run the differential witness; when it
+# cannot, fail explicitly unless the caller selected static-only qualification.
+if [[ "${SOIR_WRITER_STATIC_ONLY:-0}" == "1" ]]; then
+  printf 'soir-writer-v0 gate: dynamic witness NOT RUN (SOIR_WRITER_STATIC_ONLY=1)\n'
+  exit 0
+fi
+
+SOUC="${SOUC:-$ROOT/bin/souc}"
+"$SOUC" check "$WRITER"
+
+check_dir="$(mktemp -d -t soir-writer-v0-check.XXXXXX)"
+trap 'rm -rf "$check_dir"' EXIT
+set +e
+"$SOUC" check "$ROOT/self-hosted/ir/serialize.sio" >"$check_dir/legacy.log" 2>&1
+legacy_rc=$?
+"$SOUC" check "$WITNESS" >"$check_dir/witness.log" 2>&1
+witness_rc=$?
+set -e
+
+if [[ "$witness_rc" -ne 0 ]]; then
+  sed -n 's/.*error\[\(E[0-9][0-9][0-9]\).*/\1/p' "$check_dir/legacy.log" | sort | uniq -c >"$check_dir/legacy.categories"
+  sed -n 's/.*error\[\(E[0-9][0-9][0-9]\).*/\1/p' "$check_dir/witness.log" | sort | uniq -c >"$check_dir/witness.categories"
+  if [[ "$legacy_rc" -ne 0 ]] && cmp -s "$check_dir/legacy.categories" "$check_dir/witness.categories"; then
+    printf 'soir-writer-v0 gate: witness checker BASELINE-EQUIVALENT (legacy import privacy diagnostics)\n'
+    cat "$check_dir/witness.categories"
+    printf 'soir-writer-v0 gate: dynamic differential NOT RUN (modular import routing blocked)\n'
+    if [[ "${SOIR_WRITER_REQUIRE_DYNAMIC:-0}" == "1" ]]; then
+      fail 'dynamic differential required but modular import routing is blocked'
+    fi
+    exit 0
+  fi
+  cat "$check_dir/witness.log" >&2
+  fail 'witness checker introduced diagnostics beyond the legacy baseline'
+fi
+
+"$SOUC" run "$WITNESS" | tee "$check_dir/witness.out"
+grep -Fxq 'PASS soir_writer_v0_differential' "$check_dir/witness.out" \
+  || fail 'differential PASS marker absent'
+printf 'soir-writer-v0 gate: dynamic differential PASS\n'

--- a/self-hosted/ir/soir_writer.sio
+++ b/self-hosted/ir/soir_writer.sio
@@ -227,7 +227,10 @@ pub fn soir_writer_preflight_empty_extensions_v5(
         if (*function).instr_count < 0 || (*function).instr_count > IR_MAX_INSTRS {
             return soir_writer_failed_plan(start, capacity, SOIR_WRITER_COUNTS_BOUNDS)
         }
-        if (*function).param_count < 0 || (*function).param_count > 64 || (*function).bss_size != 0 {
+        if (*function).param_count < 0 || (*function).param_count > IR_MAX_PARAMS {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_COUNTS_BOUNDS)
+        }
+        if (*function).bss_size != 0 {
             return soir_writer_failed_plan(start, capacity, SOIR_WRITER_MODULE_CONTRACT)
         }
         if !soir_writer_name_is_valid(&(*function).name) {
@@ -384,7 +387,7 @@ fn soir_writer_put_function(
     soir_writer_put_i64(cursor, out_buf, (*function).param_count)
 
     var i: i64 = 0
-    while i < 64 {
+    while i < IR_MAX_PARAMS {
         soir_writer_put_i64(cursor, out_buf, (*function).param_regs[i as usize])
         i = i + 1
     }
@@ -411,8 +414,10 @@ fn soir_writer_plan_matches(left: &SoirWritePlan, right: &SoirWritePlan) -> bool
 }
 
 // Returns the absolute end cursor on success and a SOIR_WRITER_* status on
-// rejection. Every rejection occurs before cursor creation and before the
-// first buffer write. The emitted byte length is end - plan.start.
+// rejection. Every input rejection occurs before cursor creation and before
+// the first buffer write. An internal bounds failure can only happen after
+// emission starts and does not promise an unchanged buffer. The emitted byte
+// length is end - plan.start.
 pub fn soir_writer_emit_empty_extensions_v5(
     module: &IrModule,
     plan: &SoirWritePlan,

--- a/self-hosted/ir/soir_writer.sio
+++ b/self-hosted/ir/soir_writer.sio
@@ -1,0 +1,460 @@
+// Transactional SOIR v5 writer prototype.
+//
+// This module is deliberately outside the default compiler pipeline. It emits
+// the empty-extension SOIR v5 subset into a caller-owned buffer view without
+// passing the 128 KiB array by value or using mutable global writer state.
+
+module ir::soir_writer
+
+use parser::ast::*
+use ir::ir::*
+use ir::soir_core::{
+    SOIR_MAX_SIZE,
+    SOIR_NAME_SIZE,
+    SOIR_INSTR_SIZE,
+    SOIR_FUNCTION_HEADER_V5_SIZE,
+    SOIR_EMPTY_EXTENSION_COUNT_FIELDS,
+}
+
+pub let SOIR_WRITER_VERSION_V5: i8 = 5
+pub let SOIR_WRITER_OK: i64 = 0
+pub let SOIR_WRITER_COUNTS_BOUNDS: i64 = -1
+pub let SOIR_WRITER_MODULE_CONTRACT: i64 = -2
+pub let SOIR_WRITER_VIEW_BOUNDS: i64 = -3
+pub let SOIR_WRITER_UNSUPPORTED_OPCODE: i64 = -4
+pub let SOIR_WRITER_INVALID_NAME: i64 = -5
+pub let SOIR_WRITER_STALE_PLAN: i64 = -6
+pub let SOIR_WRITER_INTERNAL_BOUNDS: i64 = -7
+
+// Public only as an opaque capability passed from preflight to emit. Its
+// fields remain private to this module, so callers cannot forge an accepted
+// plan or alter the arena view after validation.
+pub struct SoirWritePlan {
+    start: i64,
+    capacity: i64,
+    required: i64,
+    end: i64,
+    version: i8,
+    status: i64,
+}
+
+// The cursor owns no bytes. It is a small state object over a caller-owned
+// array/arena view and is never returned across the public boundary.
+struct SoirWriterCursor {
+    pos: i64,
+    limit: i64,
+    status: i64,
+}
+
+fn soir_writer_failed_plan(start: i64, capacity: i64, status: i64) -> SoirWritePlan {
+    SoirWritePlan {
+        start: start,
+        capacity: capacity,
+        required: 0,
+        end: start,
+        version: SOIR_WRITER_VERSION_V5,
+        status: status,
+    }
+}
+
+pub fn soir_write_plan_status(plan: &SoirWritePlan) -> i64 {
+    (*plan).status
+}
+
+pub fn soir_write_plan_required(plan: &SoirWritePlan) -> i64 {
+    (*plan).required
+}
+
+pub fn soir_write_plan_start(plan: &SoirWritePlan) -> i64 {
+    (*plan).start
+}
+
+pub fn soir_write_plan_end(plan: &SoirWritePlan) -> i64 {
+    (*plan).end
+}
+
+pub fn soir_write_plan_version(plan: &SoirWritePlan) -> i8 {
+    (*plan).version
+}
+
+fn soir_writer_name_is_valid(name: &Name) -> bool {
+    (*name).len >= 0 && (*name).len <= 128
+}
+
+fn soir_writer_opcode_tag(op: IrOpcode) -> i64 {
+    match op {
+        IrOpcode::IrLoadImm => 0,
+        IrOpcode::IrLoadFloat => 1,
+        IrOpcode::IrLoadBool => 2,
+        IrOpcode::IrLoadString => 3,
+        IrOpcode::IrCopy => 4,
+        IrOpcode::IrBinOp => 5,
+        IrOpcode::IrUnaryOp => 6,
+        IrOpcode::IrCall => 7,
+        IrOpcode::IrReturn => 8,
+        IrOpcode::IrJump => 9,
+        IrOpcode::IrBranchTrue => 10,
+        IrOpcode::IrBranchFalse => 11,
+        IrOpcode::IrFieldGet => 12,
+        IrOpcode::IrFieldSet => 13,
+        IrOpcode::IrIndexGet => 14,
+        IrOpcode::IrIndexSet => 15,
+        IrOpcode::IrAlloc => 16,
+        IrOpcode::IrLabel => 17,
+        IrOpcode::IrNop => 18,
+        IrOpcode::IrPhi => 19,
+        IrOpcode::IrContest => 20,
+        IrOpcode::IrProveRobust => 21,
+        IrOpcode::IrValidated => 22,
+        IrOpcode::IrLiftKnowledge => 23,
+        IrOpcode::IrMeasure => 24,
+        IrOpcode::IrAdmitAction => 25,
+        IrOpcode::IrDeferAction => 26,
+        IrOpcode::IrPlanAcquisition => 27,
+        IrOpcode::IrPlanRecourse => 28,
+        IrOpcode::IrProposeAlternatives => 29,
+        IrOpcode::IrCommitAlternative => 30,
+        IrOpcode::IrObserveTransition => 31,
+        IrOpcode::IrRollbackTransition => 32,
+        IrOpcode::IrDebugGuard => 33,
+        IrOpcode::IrProfCounter => 34,
+        IrOpcode::IrCallSret => 35,
+        IrOpcode::IrReturnSret => 36,
+        _ => -1,
+    }
+}
+
+fn soir_writer_binary_op_tag(op: BinaryOp) -> i64 {
+    match op {
+        BinaryOp::OpAdd => 0,
+        BinaryOp::OpSub => 1,
+        BinaryOp::OpMul => 2,
+        BinaryOp::OpDiv => 3,
+        BinaryOp::OpRem => 4,
+        BinaryOp::OpEq => 5,
+        BinaryOp::OpNe => 6,
+        BinaryOp::OpLt => 7,
+        BinaryOp::OpLe => 8,
+        BinaryOp::OpGt => 9,
+        BinaryOp::OpGe => 10,
+        BinaryOp::OpAnd => 11,
+        BinaryOp::OpOr => 12,
+        BinaryOp::OpBitAnd => 13,
+        BinaryOp::OpBitOr => 14,
+        BinaryOp::OpBitXor => 15,
+        BinaryOp::OpShl => 16,
+        BinaryOp::OpShr => 17,
+        BinaryOp::OpConcat => 18,
+        BinaryOp::OpRange => 19,
+        BinaryOp::OpRangeInclusive => 20,
+    }
+}
+
+fn soir_writer_unary_op_tag(op: UnaryOp) -> i64 {
+    match op {
+        UnaryOp::OpNeg => 0,
+        UnaryOp::OpNot => 1,
+        UnaryOp::OpRef => 2,
+        UnaryOp::OpRefMut => 3,
+        UnaryOp::OpDeref => 4,
+    }
+}
+
+fn soir_writer_module_has_empty_extensions(module: &IrModule) -> bool {
+    let epistemic = &(*module).epistemic
+    let algebras = &(*module).algebras
+    (*algebras).count == 0 &&
+        (*epistemic).model_family_count == 0 &&
+        (*epistemic).policy_count == 0 &&
+        (*epistemic).decision_policy_count == 0 &&
+        (*epistemic).deferral_policy_count == 0 &&
+        (*epistemic).acquisition_policy_count == 0 &&
+        (*epistemic).recourse_policy_count == 0 &&
+        (*epistemic).validation_count == 0 &&
+        (*epistemic).mechanistic_report_count == 0 &&
+        (*epistemic).posterior_weights_count == 0 &&
+        (*epistemic).counterexample_count == 0 &&
+        (*epistemic).audit_count == 0 &&
+        (*epistemic).contest_count == 0 &&
+        (*epistemic).contest_witness_count == 0 &&
+        (*epistemic).robust_proof_count == 0 &&
+        (*epistemic).validated_manifest_count == 0 &&
+        (*epistemic).decision_certificate_count == 0 &&
+        (*epistemic).deferred_certificate_count == 0 &&
+        (*epistemic).deferred_reason_witness_count == 0 &&
+        (*epistemic).acquisition_plan_count == 0 &&
+        (*epistemic).acquisition_reason_witness_count == 0 &&
+        (*epistemic).recourse_plan_count == 0 &&
+        (*epistemic).recourse_reason_witness_count == 0 &&
+        (*epistemic).alternative_policy_count == 0 &&
+        (*epistemic).alternative_frontier_count == 0 &&
+        (*epistemic).alternative_candidate_count == 0 &&
+        (*epistemic).alternative_set_count == 0 &&
+        (*epistemic).alternative_reason_witness_count == 0 &&
+        (*epistemic).transition_policy_count == 0 &&
+        (*epistemic).transition_protocol_count == 0 &&
+        (*epistemic).transition_step_count == 0 &&
+        (*epistemic).transition_plan_count == 0 &&
+        (*epistemic).transition_reason_witness_count == 0 &&
+        (*epistemic).monitoring_policy_count == 0 &&
+        (*epistemic).observed_transition_count == 0 &&
+        (*epistemic).rollback_certificate_count == 0 &&
+        (*epistemic).hyper_expr_count == 0
+}
+
+// Preflight is the only input-rejection phase. It validates every count, name,
+// opcode and byte bound needed by emit before the caller buffer is touched.
+pub fn soir_writer_preflight_empty_extensions_v5(
+    module: &IrModule,
+    start: i64,
+    capacity: i64,
+) -> SoirWritePlan with Panic, Div {
+    if start < 0 || capacity < 0 || start > SOIR_MAX_SIZE || capacity > SOIR_MAX_SIZE - start {
+        return soir_writer_failed_plan(start, capacity, SOIR_WRITER_VIEW_BOUNDS)
+    }
+    if (*module).fn_count < 0 || (*module).fn_count > IR_MAX_FUNCS ||
+       (*module).string_count < 0 || (*module).string_count > IR_MAX_STRINGS {
+        return soir_writer_failed_plan(start, capacity, SOIR_WRITER_COUNTS_BOUNDS)
+    }
+    if (*module).bss_total_size != 0 || !soir_writer_module_has_empty_extensions(module) {
+        return soir_writer_failed_plan(start, capacity, SOIR_WRITER_MODULE_CONTRACT)
+    }
+
+    var required: i64 = 16
+    var i: i64 = 0
+    while i < (*module).fn_count {
+        let function = &(*module).functions[i as usize]
+        if (*function).instr_count < 0 || (*function).instr_count > IR_MAX_INSTRS {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_COUNTS_BOUNDS)
+        }
+        if (*function).param_count < 0 || (*function).param_count > 64 || (*function).bss_size != 0 {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_MODULE_CONTRACT)
+        }
+        if !soir_writer_name_is_valid(&(*function).name) {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_INVALID_NAME)
+        }
+
+        var j: i64 = 0
+        while j < (*function).instr_count {
+            let instr = &(*function).instrs[j as usize]
+            if soir_writer_opcode_tag((*instr).op) < 0 {
+                return soir_writer_failed_plan(start, capacity, SOIR_WRITER_UNSUPPORTED_OPCODE)
+            }
+            if !soir_writer_name_is_valid(&(*instr).name) {
+                return soir_writer_failed_plan(start, capacity, SOIR_WRITER_INVALID_NAME)
+            }
+            j = j + 1
+        }
+
+        required = required + SOIR_FUNCTION_HEADER_V5_SIZE + (*function).instr_count * SOIR_INSTR_SIZE
+        if required > capacity {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_VIEW_BOUNDS)
+        }
+        i = i + 1
+    }
+
+    required = required + 8
+    var string_index: i64 = 0
+    while string_index < (*module).string_count {
+        let name = &(*module).string_table[string_index as usize]
+        if !soir_writer_name_is_valid(name) {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_INVALID_NAME)
+        }
+        required = required + SOIR_NAME_SIZE
+        if required > capacity {
+            return soir_writer_failed_plan(start, capacity, SOIR_WRITER_VIEW_BOUNDS)
+        }
+        string_index = string_index + 1
+    }
+
+    required = required + SOIR_EMPTY_EXTENSION_COUNT_FIELDS * 8 + 8
+    if required > capacity || required > SOIR_MAX_SIZE - start {
+        return soir_writer_failed_plan(start, capacity, SOIR_WRITER_VIEW_BOUNDS)
+    }
+
+    SoirWritePlan {
+        start: start,
+        capacity: capacity,
+        required: required,
+        end: start + required,
+        version: SOIR_WRITER_VERSION_V5,
+        status: SOIR_WRITER_OK,
+    }
+}
+
+fn soir_writer_cursor_from_plan(plan: &SoirWritePlan) -> SoirWriterCursor {
+    SoirWriterCursor {
+        pos: (*plan).start,
+        limit: (*plan).end,
+        status: SOIR_WRITER_OK,
+    }
+}
+
+fn soir_writer_put_i8(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    value: i8,
+) with Mut, Panic, Div {
+    if (*cursor).status != SOIR_WRITER_OK { return }
+    if (*cursor).pos < 0 || (*cursor).pos >= (*cursor).limit || (*cursor).pos >= SOIR_MAX_SIZE {
+        (*cursor).status = SOIR_WRITER_INTERNAL_BOUNDS
+        return
+    }
+    out_buf[(*cursor).pos as usize] = value
+    (*cursor).pos = (*cursor).pos + 1
+}
+
+fn soir_writer_put_i64(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    value: i64,
+) with Mut, Panic, Div {
+    var shift: i64 = 0
+    while shift < 64 {
+        soir_writer_put_i8(cursor, out_buf, ((value >> shift) & 255) as i8)
+        shift = shift + 8
+    }
+}
+
+fn soir_writer_put_f64(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    value: f64,
+) with Mut, Panic, Div {
+    soir_writer_put_i64(cursor, out_buf, f64_to_bits(value))
+}
+
+fn soir_writer_put_zeroes(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    count: i64,
+) with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < count {
+        soir_writer_put_i8(cursor, out_buf, 0 as i8)
+        i = i + 1
+    }
+}
+
+fn soir_writer_put_name(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    name: &Name,
+) with Mut, Panic, Div {
+    soir_writer_put_i64(cursor, out_buf, (*name).len)
+    var i: i64 = 0
+    while i < 128 {
+        soir_writer_put_i8(cursor, out_buf, (*name).buf[i as usize])
+        i = i + 1
+    }
+}
+
+fn soir_writer_put_instr(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    instr: &IrInstr,
+) with Mut, Panic, Div {
+    soir_writer_put_i8(cursor, out_buf, soir_writer_opcode_tag((*instr).op) as i8)
+    soir_writer_put_zeroes(cursor, out_buf, 7)
+    soir_writer_put_i64(cursor, out_buf, (*instr).dst)
+    soir_writer_put_i64(cursor, out_buf, (*instr).src1)
+    soir_writer_put_i64(cursor, out_buf, (*instr).src2)
+    soir_writer_put_i64(cursor, out_buf, (*instr).imm_i64)
+    soir_writer_put_f64(cursor, out_buf, (*instr).imm_f64)
+    soir_writer_put_i64(cursor, out_buf, (*instr).label_id)
+    soir_writer_put_i64(cursor, out_buf, (*instr).fn_id)
+    soir_writer_put_i64(cursor, out_buf, (*instr).field_idx)
+    soir_writer_put_i8(cursor, out_buf, soir_writer_binary_op_tag((*instr).bin_op) as i8)
+    soir_writer_put_zeroes(cursor, out_buf, 7)
+    soir_writer_put_i8(cursor, out_buf, soir_writer_unary_op_tag((*instr).un_op) as i8)
+    soir_writer_put_zeroes(cursor, out_buf, 7)
+    soir_writer_put_name(cursor, out_buf, &(*instr).name)
+    soir_writer_put_i64(cursor, out_buf, (*instr).arg_count)
+}
+
+fn soir_writer_put_function(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    function: &IrFunction,
+) with Mut, Panic, Div {
+    soir_writer_put_name(cursor, out_buf, &(*function).name)
+    soir_writer_put_i64(cursor, out_buf, (*function).instr_count)
+    soir_writer_put_i64(cursor, out_buf, (*function).reg_count)
+    soir_writer_put_i64(cursor, out_buf, (*function).label_count)
+    soir_writer_put_i64(cursor, out_buf, (*function).param_count)
+
+    var i: i64 = 0
+    while i < 64 {
+        soir_writer_put_i64(cursor, out_buf, (*function).param_regs[i as usize])
+        i = i + 1
+    }
+    soir_writer_put_i64(cursor, out_buf, (*function).compile_strategy)
+    soir_writer_put_i64(cursor, out_buf, (*function).prof_counter_id)
+    soir_writer_put_i64(cursor, out_buf, (*function).hyper_algebra_kind)
+    soir_writer_put_i64(cursor, out_buf, (*function).defining_module_id)
+
+    var instr_index: i64 = 0
+    while instr_index < (*function).instr_count {
+        let instr = &(*function).instrs[instr_index as usize]
+        soir_writer_put_instr(cursor, out_buf, instr)
+        instr_index = instr_index + 1
+    }
+}
+
+fn soir_writer_plan_matches(left: &SoirWritePlan, right: &SoirWritePlan) -> bool {
+    (*left).status == (*right).status &&
+        (*left).start == (*right).start &&
+        (*left).capacity == (*right).capacity &&
+        (*left).required == (*right).required &&
+        (*left).end == (*right).end &&
+        (*left).version == (*right).version
+}
+
+// Returns the absolute end cursor on success and a SOIR_WRITER_* status on
+// rejection. Every rejection occurs before cursor creation and before the
+// first buffer write. The emitted byte length is end - plan.start.
+pub fn soir_writer_emit_empty_extensions_v5(
+    module: &IrModule,
+    plan: &SoirWritePlan,
+    out_buf: &![i8; 131072],
+) -> i64 with Mut, Panic, Div {
+    if (*plan).status != SOIR_WRITER_OK { return (*plan).status }
+    let verified = soir_writer_preflight_empty_extensions_v5(module, (*plan).start, (*plan).capacity)
+    if !soir_writer_plan_matches(plan, &verified) { return SOIR_WRITER_STALE_PLAN }
+
+    var cursor = soir_writer_cursor_from_plan(plan)
+    soir_writer_put_i8(&! cursor, out_buf, 83 as i8)
+    soir_writer_put_i8(&! cursor, out_buf, 79 as i8)
+    soir_writer_put_i8(&! cursor, out_buf, 73 as i8)
+    soir_writer_put_i8(&! cursor, out_buf, 82 as i8)
+    soir_writer_put_i8(&! cursor, out_buf, SOIR_WRITER_VERSION_V5)
+    soir_writer_put_zeroes(&! cursor, out_buf, 3)
+    soir_writer_put_i64(&! cursor, out_buf, (*module).fn_count)
+
+    var function_index: i64 = 0
+    while function_index < (*module).fn_count {
+        let function = &(*module).functions[function_index as usize]
+        soir_writer_put_function(&! cursor, out_buf, function)
+        function_index = function_index + 1
+    }
+
+    soir_writer_put_i64(&! cursor, out_buf, (*module).string_count)
+    var string_index: i64 = 0
+    while string_index < (*module).string_count {
+        let name = &(*module).string_table[string_index as usize]
+        soir_writer_put_name(&! cursor, out_buf, name)
+        string_index = string_index + 1
+    }
+
+    var extension_index: i64 = 0
+    while extension_index < SOIR_EMPTY_EXTENSION_COUNT_FIELDS {
+        soir_writer_put_i64(&! cursor, out_buf, 0)
+        extension_index = extension_index + 1
+    }
+    soir_writer_put_i64(&! cursor, out_buf, 0)
+
+    if cursor.status != SOIR_WRITER_OK || cursor.pos != (*plan).end {
+        return SOIR_WRITER_INTERNAL_BOUNDS
+    }
+    cursor.pos
+}

--- a/self-hosted/ir/soir_writer.sio
+++ b/self-hosted/ir/soir_writer.sio
@@ -17,6 +17,10 @@ use ir::soir_core::{
 }
 
 pub let SOIR_WRITER_VERSION_V5: i8 = 5
+// SOIR v5 encodes exactly 64 parameter-register slots per function. Keep this
+// wire-layout constant independent from the canonical IR capacity so a future
+// IR_MAX_PARAMS change cannot silently alter v5 bytes.
+pub let SOIR_V5_WIRE_PARAM_SLOTS: i64 = 64
 pub let SOIR_WRITER_OK: i64 = 0
 pub let SOIR_WRITER_COUNTS_BOUNDS: i64 = -1
 pub let SOIR_WRITER_MODULE_CONTRACT: i64 = -2
@@ -227,7 +231,9 @@ pub fn soir_writer_preflight_empty_extensions_v5(
         if (*function).instr_count < 0 || (*function).instr_count > IR_MAX_INSTRS {
             return soir_writer_failed_plan(start, capacity, SOIR_WRITER_COUNTS_BOUNDS)
         }
-        if (*function).param_count < 0 || (*function).param_count > IR_MAX_PARAMS {
+        if (*function).param_count < 0 ||
+           (*function).param_count > IR_MAX_PARAMS ||
+           (*function).param_count > SOIR_V5_WIRE_PARAM_SLOTS {
             return soir_writer_failed_plan(start, capacity, SOIR_WRITER_COUNTS_BOUNDS)
         }
         if (*function).bss_size != 0 {
@@ -387,7 +393,7 @@ fn soir_writer_put_function(
     soir_writer_put_i64(cursor, out_buf, (*function).param_count)
 
     var i: i64 = 0
-    while i < IR_MAX_PARAMS {
+    while i < SOIR_V5_WIRE_PARAM_SLOTS {
         soir_writer_put_i64(cursor, out_buf, (*function).param_regs[i as usize])
         i = i + 1
     }

--- a/self-hosted/test_soir_writer_v0.sio
+++ b/self-hosted/test_soir_writer_v0.sio
@@ -1,4 +1,4 @@
-// Differential and failure-atomicity witness for the off-default SOIR writer.
+// Differential and input-rejection-atomicity witness for the off-default SOIR writer.
 
 module selfhost::test_soir_writer_v0
 
@@ -116,6 +116,18 @@ fn soir_writer_rejections_preserve_canary() -> bool with Mut, Panic, Div, Alloc 
     let counts_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
     if soir_write_plan_status(&counts_plan) != SOIR_WRITER_COUNTS_BOUNDS { return false }
     if soir_writer_emit_empty_extensions_v5(&module, &counts_plan, &! canary) != SOIR_WRITER_COUNTS_BOUNDS {
+        return false
+    }
+    if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }
+    module.fn_count = 0
+
+    var excessive_params = ir_empty_function()
+    excessive_params.param_count = IR_MAX_PARAMS + 1
+    module.functions[0] = excessive_params
+    module.fn_count = 1
+    let params_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    if soir_write_plan_status(&params_plan) != SOIR_WRITER_COUNTS_BOUNDS { return false }
+    if soir_writer_emit_empty_extensions_v5(&module, &params_plan, &! canary) != SOIR_WRITER_COUNTS_BOUNDS {
         return false
     }
     if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }

--- a/self-hosted/test_soir_writer_v0.sio
+++ b/self-hosted/test_soir_writer_v0.sio
@@ -1,0 +1,211 @@
+// Differential and failure-atomicity witness for the off-default SOIR writer.
+
+module selfhost::test_soir_writer_v0
+
+use ir::ir::*
+use ir::serialize::{serialize_ir_module_into, deserialize_ir_module_into}
+use ir::soir_writer::*
+
+fn soir_writer_buffers_equal(
+    left: &[i8; 131072],
+    right: &[i8; 131072],
+    left_start: i64,
+    right_start: i64,
+    len: i64,
+) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < len {
+        if left[(left_start + i) as usize] != right[(right_start + i) as usize] {
+            return false
+        }
+        i = i + 1
+    }
+    true
+}
+
+fn soir_writer_buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn soir_writer_compare_with_legacy(module: &IrModule, expected_len: i64) -> bool with Mut, Panic, Div, Alloc {
+    var legacy: [i8; 131072] = [0; 131072]
+    var legacy_len: i64 = 0
+    serialize_ir_module_into(module, &! legacy, &! legacy_len)
+    if legacy_len != expected_len { return false }
+
+    var candidate: [i8; 131072] = [0; 131072]
+    let plan = soir_writer_preflight_empty_extensions_v5(module, 0, 131072)
+    if soir_write_plan_status(&plan) != SOIR_WRITER_OK ||
+       soir_write_plan_required(&plan) != expected_len ||
+       soir_write_plan_start(&plan) != 0 ||
+       soir_write_plan_end(&plan) != expected_len ||
+       soir_write_plan_version(&plan) != 5 as i8 {
+        return false
+    }
+    let end = soir_writer_emit_empty_extensions_v5(module, &plan, &! candidate)
+    if end != expected_len || !soir_writer_buffers_equal(&legacy, &candidate, 0, 0, expected_len) {
+        return false
+    }
+
+    var repeated: [i8; 131072] = [85; 131072]
+    let repeated_end = soir_writer_emit_empty_extensions_v5(module, &plan, &! repeated)
+    repeated_end == expected_len &&
+        soir_writer_buffers_equal(&candidate, &repeated, 0, 0, expected_len)
+}
+
+fn soir_writer_empty_module_differential() -> bool with Mut, Panic, Div, Alloc {
+    var module = ir_empty_module()
+    if !soir_writer_compare_with_legacy(&module, 320) { return false }
+
+    var candidate: [i8; 131072] = [0; 131072]
+    let plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    let end = soir_writer_emit_empty_extensions_v5(&module, &plan, &! candidate)
+    end == 320 &&
+        candidate[0] == 83 as i8 && candidate[1] == 79 as i8 &&
+        candidate[2] == 73 as i8 && candidate[3] == 82 as i8 &&
+        candidate[4] == 5 as i8 && candidate[319] == 0 as i8
+}
+
+fn soir_writer_populated_module_differential() -> bool with Mut, Panic, Div, Alloc {
+    var module = ir_empty_module()
+    var function = ir_empty_function()
+    function.name = ir_name_from_bytes(116 as i8, 101 as i8, 115 as i8, 116 as i8, 4)
+    function.defining_module_id = 37
+    function.reg_count = 1
+    function.instr_count = 2
+    function.instrs[0] = ir_load_imm(0, 42)
+    function.instrs[1] = ir_return(0)
+    module.functions[0] = function
+    module.fn_count = 1
+    module.string_table[0] = ir_name_from_bytes(118 as i8, 53 as i8, 0 as i8, 0 as i8, 2)
+    module.string_count = 1
+
+    if !soir_writer_compare_with_legacy(&module, 1632) { return false }
+
+    var arena: [i8; 131072] = [85; 131072]
+    let plan = soir_writer_preflight_empty_extensions_v5(&module, 17, 2000)
+    let end = soir_writer_emit_empty_extensions_v5(&module, &plan, &! arena)
+    if end != 1649 || soir_write_plan_required(&plan) != 1632 { return false }
+
+    // Stable v5 anchors: version, defining_module_id and extension start.
+    let provenance_offset: i64 = 720
+    let extensions_offset: i64 = 1336
+    arena[17 + 4] == 5 as i8 &&
+        arena[17 + provenance_offset] == 37 as i8 &&
+        arena[17 + extensions_offset] == 0 as i8 &&
+        arena[16] == 85 as i8 && arena[end] == 85 as i8
+}
+
+fn soir_writer_rejections_preserve_canary() -> bool with Mut, Panic, Div, Alloc {
+    var module = ir_empty_module()
+    var canary: [i8; 131072] = [85; 131072]
+
+    let capacity_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 319)
+    if soir_write_plan_status(&capacity_plan) != SOIR_WRITER_VIEW_BOUNDS { return false }
+    if soir_writer_emit_empty_extensions_v5(&module, &capacity_plan, &! canary) != SOIR_WRITER_VIEW_BOUNDS {
+        return false
+    }
+    if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }
+
+    module.fn_count = -1
+    let counts_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    if soir_write_plan_status(&counts_plan) != SOIR_WRITER_COUNTS_BOUNDS { return false }
+    if soir_writer_emit_empty_extensions_v5(&module, &counts_plan, &! canary) != SOIR_WRITER_COUNTS_BOUNDS {
+        return false
+    }
+    if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }
+    module.fn_count = 0
+
+    module.bss_total_size = 8
+    let contract_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    if soir_write_plan_status(&contract_plan) != SOIR_WRITER_MODULE_CONTRACT { return false }
+    if soir_writer_emit_empty_extensions_v5(&module, &contract_plan, &! canary) != SOIR_WRITER_MODULE_CONTRACT {
+        return false
+    }
+    if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }
+    module.bss_total_size = 0
+
+    let accepted_empty_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    module.string_count = 1
+    let stale_result = soir_writer_emit_empty_extensions_v5(&module, &accepted_empty_plan, &! canary)
+    if stale_result != SOIR_WRITER_STALE_PLAN { return false }
+    if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }
+    module.string_count = 0
+
+    var function = ir_empty_function()
+    function.instr_count = 1
+    function.instrs[0] = ir_instr_new(IrOpcode::IrArrayLen)
+    module.functions[0] = function
+    module.fn_count = 1
+    let opcode_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    if soir_write_plan_status(&opcode_plan) != SOIR_WRITER_UNSUPPORTED_OPCODE { return false }
+    if soir_writer_emit_empty_extensions_v5(&module, &opcode_plan, &! canary) != SOIR_WRITER_UNSUPPORTED_OPCODE {
+        return false
+    }
+    if !soir_writer_buffer_is_canary(&canary, 85 as i8) { return false }
+
+    function = ir_empty_function()
+    function.name.len = 129
+    module.functions[0] = function
+    let name_plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    if soir_write_plan_status(&name_plan) != SOIR_WRITER_INVALID_NAME { return false }
+    if soir_writer_emit_empty_extensions_v5(&module, &name_plan, &! canary) != SOIR_WRITER_INVALID_NAME {
+        return false
+    }
+    soir_writer_buffer_is_canary(&canary, 85 as i8)
+}
+
+fn soir_writer_v4_decode_only_anchor() -> bool with Mut, Panic, Div, Alloc {
+    var module = ir_empty_module()
+    var function = ir_empty_function()
+    function.defining_module_id = 37
+    function.instr_count = 1
+    function.instrs[0] = ir_return(0)
+    module.functions[0] = function
+    module.fn_count = 1
+
+    var v5: [i8; 131072] = [0; 131072]
+    let plan = soir_writer_preflight_empty_extensions_v5(&module, 0, 131072)
+    let v5_len = soir_writer_emit_empty_extensions_v5(&module, &plan, &! v5)
+    if v5_len <= 0 { return false }
+
+    let provenance_offset: i64 = 720
+    var v4: [i8; 131072] = [0; 131072]
+    var copy_index: i64 = 0
+    while copy_index < v5_len {
+        v4[copy_index as usize] = v5[copy_index as usize]
+        copy_index = copy_index + 1
+    }
+    var i = provenance_offset
+    while i + 8 < v5_len {
+        v4[i as usize] = v4[(i + 8) as usize]
+        i = i + 1
+    }
+    v4[4] = 4 as i8
+
+    var decoded = ir_empty_module()
+    if !deserialize_ir_module_into(v4, v5_len - 8, &! decoded) { return false }
+    decoded.fn_count == 1 && decoded.functions[0].defining_module_id == IR_DEFINING_MODULE_UNKNOWN
+}
+
+pub fn soir_writer_v0_differential_self_test() -> bool with Mut, Panic, Div, Alloc {
+    soir_writer_empty_module_differential() &&
+        soir_writer_populated_module_differential() &&
+        soir_writer_rejections_preserve_canary() &&
+        soir_writer_v4_decode_only_anchor()
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    if soir_writer_v0_differential_self_test() {
+        println("PASS soir_writer_v0_differential")
+        0
+    } else {
+        println("FAIL soir_writer_v0_differential")
+        1
+    }
+}


### PR DESCRIPTION
# DO NOT MERGE

This is an off-default architecture checkpoint stacked on draft #889. It does not replace the legacy serializer and is not merge-eligible while runtime differential qualification remains blocked.

Parent stack:

- parent PR: #889
- parent head: `17b0858f6e7d75c9cfc9e545b1b9f0805fa9d5d6`
- base branch: `codex/ref-field-autoderef-e304-20260714`

## What changed

- adds an opaque `SoirWritePlan` with arena-view `start`, `capacity`, exact `required`, `end`, version and status;
- adds a private `SoirWriterCursor` that owns no bytes and writes only through `&![i8; 131072]`;
- separates complete preflight from emit, with no 128 KiB array by-value parameter/return and no mutable global writer status;
- validates canonical counts and exact capacity before the first byte;
- pins Writer v0 to SOIR v5 and introduces `SOIR_V5_WIRE_PARAM_SLOTS = 64`, independent from `IR_MAX_PARAMS`, so future IR capacity changes cannot silently resize v5 artifacts;
- defines unchanged-buffer atomicity only for declared input rejections; `SOIR_WRITER_INTERNAL_BOUNDS` may follow partial writes and requires discarding the candidate output;
- limits prospective byte-parity evidence to exactly two fixtures; a broader empty-extension subset matrix remains future work;
- keeps v4 decode/golden-only and leaves the legacy serializer as default and differential oracle.

## Write set

Seven files across the complete PR:

- `self-hosted/ir/soir_writer.sio`
- `self-hosted/test_soir_writer_v0.sio`
- `scripts/ci/soir_writer_v0_gate.sh`
- `docs/internal/implementation/SOIR_WRITER_V0.md`
- `docs/governance/topic-registry.v1.json` (mechanically generated)
- `docs/governance/DOCS_AUTHORITY_MATRIX.md` (mechanically generated)
- `docs/governance/DOCS_ACCEPTANCE_REPORT.md` (mechanically generated)

## Exact evidence

```text
bin/souc check self-hosted/ir/soir_writer.sio: rc=0
SOIR_WRITER_STATIC_ONLY=1 bash scripts/ci/soir_writer_v0_gate.sh: rc=0
bash scripts/ci/soir_writer_v0_gate.sh: rc=1
SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh: rc=1
SOIR_WRITER_STATIC_ONLY=1 SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh: rc=1
git diff --check: rc=0
bash scripts/dev/check_docs_registry.sh: rc=0
docs registry selftest: PASS (5 failure scenarios + baseline)
legacy wire-tag table parity: PASS
default serialize/soir_core/heap/bootstrap files: unchanged
witness checker: BASELINE-EQUIVALENT
legacy serialize.sio diagnostics: 22 E175 + 7 E177
witness diagnostics: 22 E175 + 7 E177
runtime differential: NOT RUN
heavy/source-fresh build: NOT RUN
```

The static-only result is an explicitly requested static qualification. The plain gate now fails when the dynamic witness is not run; checker containment is not reported as runtime byte parity.

## Blocking acceptance gate

```text
SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh
```

Current result: rc=1 after classifying modular legacy-import privacy routing; the runtime witness is not executed.

Blocker: `BLK-20260714-soir-writer-v0-differential-runtime` (`B1`, `harness-routing`, `E3`). The exact record is in `docs/internal/implementation/SOIR_WRITER_V0.md`.

## Documentation date

The contract records factual `reviewed_on: 2026-07-14`. Its generated metadata keeps `last_validated: 2026-03-07` because the repository-wide generator currently hardcodes that legacy value. Issue #896 tracks a generator-owned per-topic validation date; this compiler lane does not alter the global governance generator.

## Boundaries

- legacy `ir::serialize` remains the default and differential oracle;
- no serializer, `soir_core`, heap bridge, bootstrap list, opcode tag, or default pipeline file changed;
- no new SOIR version, non-empty extension support, performance claim, or runtime parity claim;
- no fallback path;
- no LLM offload required (no math, clinical, or external-facing claim surface).
