### PR TITLE
feat(ir): terminal raw pointer field semantics [DO NOT MERGE]

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 958
-- Repo-backed topics: 808
+- Total governed topics: 961
+- Repo-backed topics: 811
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 558
+- Authority count `repo_only`: 561
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 577 topics
+- A2: 580 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -405,6 +405,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.implementation.test-triage-report | historical | docs/implementation/test_triage_report.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.tooling-summary | repo_only | docs/implementation/TOOLING_SUMMARY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.ui-type-deignore-candidates | historical | docs/implementation/UI_TYPE_DEIGNORE_CANDIDATES.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.compiler.raw-field-terminal-contract | repo_only | docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -504,6 +505,8 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.llm-guide.explanations.e226 | repo_only | docs/llm-guide/explanations/E226.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.llm-guide.explanations.e227 | repo_only | docs/llm-guide/explanations/E227.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.llm-guide.explanations.e228 | repo_only | docs/llm-guide/explanations/E228.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.llm-guide.explanations.e229 | repo_only | docs/llm-guide/explanations/E229.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.llm-guide.explanations.e230 | repo_only | docs/llm-guide/explanations/E230.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.llm-guide.readme | repo_only | docs/llm-guide/README.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.llm-guide.stdlib-index | repo_only | docs/llm-guide/stdlib-index.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.madaros-status | repo_only | docs/MADAROS_STATUS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8794,6 +8794,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.compiler.raw-field-terminal-contract",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.epistemic-numeric-value",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/epistemic-numeric-value.md",
@@ -11051,6 +11074,52 @@
       "topic_id": "repo.docs.llm-guide.explanations.e228",
       "collection": "repo",
       "repo_doc_path": "docs/llm-guide/explanations/E228.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.llm-guide.explanations.e229",
+      "collection": "repo",
+      "repo_doc_path": "docs/llm-guide/explanations/E229.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.llm-guide.explanations.e230",
+      "collection": "repo",
+      "repo_doc_path": "docs/llm-guide/explanations/E230.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md
+++ b/docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md
@@ -1,0 +1,97 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.compiler.raw-field-terminal-contract
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.compiler.raw-field-terminal-contract
+-->
+
+# Raw Field Terminal Contract
+
+Status: implementation checkpoint
+Concept-ID: `SOUNIO-IR-STORAGE-OWNERSHIP`
+
+This checkpoint is the final extension of legacy field-address lowering. After
+it is proven, the legacy compiler remains a differential oracle; new address,
+ownership, or place semantics belong in the successor IR rather than additional
+`label_id` conventions.
+
+## Semantic Boundary
+
+The supported raw projection is exactly:
+
+```text
+(*identifier_raw_pointer_to_named_struct).field
+```
+
+Reads accept `*const T` and `*mut T`. Writes accept only `*mut T`. The lowerer
+must know the pointer kind, the named pointee, the exact named field, and the
+compiler-owned physical word offset. Unknown pointees, missing fields, dynamic
+array extents, layout overflow, and non-identifier pointer expressions fail
+closed. A typed non-identifier raw pointer expression fails with `E230`:
+`raw field projection requires an identifier pointer operand`. The terminal
+legacy projection accepts only fields marked
+`raw_projectable` whose declared storage width is exactly one word. Scalars,
+pointers, references, and named-aggregate handle slots are projectable. Inline
+arrays are never projectable, including a one-element array. Fixed arrays still
+determine the offsets of later fields, but projecting the array field itself
+requires an aggregate/place result and therefore fails closed with `E229`:
+`raw inline aggregate field projection requires Place IR`. There is no
+field-name hash or cross-struct fallback.
+
+`IrFieldGet` and `IrFieldSet` use an opcode-local address mode:
+
+```text
+0 managed handle
+1 typed reference to a managed handle slot
+2 raw address
+```
+
+Raw mode carries a physical word offset in `field_idx`. Managed and reference
+modes retain their ordinal field index. SOIR already serializes both fields, so
+this checkpoint does not change the SOIR version or wire width.
+
+Because `label_id` is a shared physical slot, CFG transforms must call
+`ir_opcode_has_cfg_label` before scanning or renumbering it. Inlining,
+instrumented cloning, and normalization preserve field modes and every other
+opcode-local `label_id` payload verbatim.
+
+The modular native backend implements raw mode as `[base + offset_words * 8]`.
+It must not resolve a handle, add a managed-object header, or first dereference
+the pointee word. Machine IR preserves the same mode in its field-op-specific
+payload.
+
+## Physical Layout Authority
+
+The lowerer computes each declared field's final `offset_words`,
+`storage_words`, and `raw_projectable` category once while registering the named
+struct. Fixed arrays contribute their literal element count recursively; every
+non-array value contributes one managed/native word.
+This matches the existing modular aggregate representation: fixed arrays are
+tables of slots, while scalars, references, pointers, and named aggregates are
+one slot. Storing the final offset prevents later consumers from reconstructing
+or reinterpreting the layout.
+
+## Proof Surface
+
+The positive witness must distinguish same-named fields in different structs,
+place a fixed `[f64; 2]` before a scalar field, place a named aggregate handle
+before another field, cover raw const reads and raw mutable writes across a
+call, and preserve `f64` classification. Existing managed-field and typed-ref
+field witnesses remain green.
+
+The negative witnesses must reject a field write through `*const T`, inline
+aggregate projections, and raw reads or writes whose dereference operand is not
+an identifier. The static gate rejects modes outside `0..2`, any new field-mode
+label convention, CFG passes that renumber opcode-local payloads, raw lowering
+that emits `OpDeref`, global/hash fallback, handle resolution, or a
+managed-object header on the raw backend path.
+
+## Claims Forbidden
+
+This checkpoint does not claim general pointer arithmetic, C ABI struct layout,
+packed layout, dynamic-array field layout, arbitrary raw pointer expressions,
+raw indexing, provenance recovery, bounds safety, null safety, or canonical
+arena ownership. It does not change heap storage, the SOIR writer, or the
+default serializer.

--- a/docs/llm-guide/error-catalog.md
+++ b/docs/llm-guide/error-catalog.md
@@ -454,3 +454,5 @@ Codes the compiler *can* emit in `error[Exxxx]:` format. Note: there is **no** `
 | E226 | import | error | import path table full | [E226.md](explanations/E226.md) |
 | E227 | import | error | import too large for SRC buffer | [E227.md](explanations/E227.md) |
 | E228 | import | error | import copy truncated | [E228.md](explanations/E228.md) |
+| E229 | type-checker/raw-field | error | raw inline aggregate field projection requires Place IR | [E229.md](explanations/E229.md) |
+| E230 | type-checker/raw-field | error | raw field projection requires an identifier pointer operand | [E230.md](explanations/E230.md) |

--- a/docs/llm-guide/explanations/E229.md
+++ b/docs/llm-guide/explanations/E229.md
@@ -1,0 +1,27 @@
+<!-- docs:meta
+topic_id: repo.docs.llm-guide.explanations.e229
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.explanations.e229
+-->
+
+# E229 - Raw inline aggregate field projection requires Place IR
+
+**Severity:** error
+
+**Message pattern:** `error[E229]: raw inline aggregate field projection requires Place IR`
+
+## What happened
+
+The terminal legacy raw-field path was asked to project an inline aggregate,
+such as a fixed array, from a raw pointer. That path can return only one-word
+values. It cannot preserve the address, width, and storage identity required by
+an aggregate place. This includes one-element arrays.
+
+## Fix
+
+Project a scalar, pointer, reference, or named-aggregate handle field instead.
+Code that needs the inline aggregate itself must use a future Place IR path;
+the legacy raw-field path fails closed rather than silently loading one word.

--- a/docs/llm-guide/explanations/E230.md
+++ b/docs/llm-guide/explanations/E230.md
@@ -1,0 +1,33 @@
+<!-- docs:meta
+topic_id: repo.docs.llm-guide.explanations.e230
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.llm-guide.explanations.e230
+-->
+
+# E230 - Raw field projection requires an identifier pointer operand
+
+**Severity:** error
+
+**Message pattern:** `error[E230]: raw field projection requires an identifier pointer operand`
+
+## What happened
+
+The terminal legacy field path received a raw pointer expression that was not a
+named local, for example `(*(addr as *mut Sample)).value`. That path resolves a
+raw pointer's kind and named pointee from compiler-owned local metadata. An
+arbitrary expression has no supported identity in this legacy representation.
+
+## Fix
+
+Bind the raw pointer to a typed local before projecting its field:
+
+```sio
+let p: *mut Sample = addr as *mut Sample
+(*p).value = 1
+```
+
+This restriction is specific to the terminal legacy path. General raw pointer
+expressions require the successor Place IR.

--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -39,7 +39,7 @@ fi
 selected=()
 for path in "${paths[@]}"; do
   case "$path" in
-    tests/run-pass/*.sio) ;;
+    tests/run-pass/*.sio|tests/compile-fail/*.sio) ;;
     *) continue ;;
   esac
   [[ -f "$ROOT_DIR/$path" ]] || continue

--- a/scripts/ci/madaros_changed_tests_selftest.sh
+++ b/scripts/ci/madaros_changed_tests_selftest.sh
@@ -9,10 +9,12 @@ bash -n "$GATE"
 
 selected="$(SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=0 "$GATE" --select-only \
   tests/run-pass/array_repeat_i8_binding.sio \
+  tests/compile-fail/raw_array_field_projection.sio \
   tests/run-pass/generic_struct_return.sio \
   docs/internal/coordination/CI_WATCH_CONTRACT.md)"
 
 grep -Fxq 'tests/run-pass/array_repeat_i8_binding.sio' <<<"$selected"
+grep -Fxq 'tests/compile-fail/raw_array_field_projection.sio' <<<"$selected"
 if grep -Fq 'MADAROS_CHANGED_TESTS_STACK' <<<"$selected"; then
   echo 'madaros-changed-tests: select-only emitted a stack receipt' >&2
   exit 1
@@ -22,7 +24,7 @@ if grep -Fq 'generic_struct_return.sio' <<<"$selected"; then
   exit 1
 fi
 if grep -Fq 'CI_WATCH_CONTRACT.md' <<<"$selected"; then
-  echo 'madaros-changed-tests: selected a path outside tests/run-pass' >&2
+  echo 'madaros-changed-tests: selected a path outside supported test directories' >&2
   exit 1
 fi
 

--- a/scripts/ci/raw_ptr_field_semantics_gate.sh
+++ b/scripts/ci/raw_ptr_field_semantics_gate.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IR="$ROOT/self-hosted/ir/ir.sio"
+LOWER="$ROOT/self-hosted/ir/lower.sio"
+INLINE="$ROOT/self-hosted/ir/inline.sio"
+OPT_STRATEGY="$ROOT/self-hosted/ir/opt_strategy.sio"
+NORMALIZE="$ROOT/self-hosted/ir/normalize.sio"
+CHECKER="$ROOT/self-hosted/check/check.sio"
+TYPES="$ROOT/self-hosted/check/types.sio"
+MIR="$ROOT/self-hosted/native/machine_ir.sio"
+X86="$ROOT/self-hosted/native/codegen_x86_linux.sio"
+X86_MIRROR="$ROOT/self-hosted/native/codegen.sio"
+CONTRACT="$ROOT/docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md"
+WITNESS="$ROOT/tests/native-v2/raw_ptr_field_semantics_witness.sio"
+NEGATIVE="$ROOT/tests/compile-fail/raw_const_field_store.sio"
+ARRAY_NEGATIVE="$ROOT/tests/compile-fail/raw_array_field_projection.sio"
+NONIDENT_READ="$ROOT/tests/compile-fail/raw_nonident_field_read.sio"
+NONIDENT_STORE="$ROOT/tests/compile-fail/raw_nonident_field_store.sio"
+ERROR_CATALOG="$ROOT/docs/llm-guide/error-catalog.md"
+ERROR_EXPLANATION="$ROOT/docs/llm-guide/explanations/E229.md"
+ERROR_EXPLANATION_NONIDENT="$ROOT/docs/llm-guide/explanations/E230.md"
+
+require_fixed() {
+  local file="$1"
+  local text="$2"
+  if ! grep -Fq -- "$text" "$file"; then
+    printf 'raw-field terminal gate: missing `%s` in %s\n' "$text" "${file#$ROOT/}" >&2
+    exit 1
+  fi
+}
+
+require_fixed "$IR" 'pub let IR_FIELD_MODE_MANAGED: i64 = 0'
+require_fixed "$IR" 'pub let IR_FIELD_MODE_REF: i64 = 1'
+require_fixed "$IR" 'pub let IR_FIELD_MODE_RAW: i64 = 2'
+require_fixed "$IR" 'pub fn ir_opcode_has_cfg_label(op: IrOpcode) -> bool'
+require_fixed "$IR" 'IrOpcode::IrLabel => true'
+require_fixed "$IR" 'IrOpcode::IrJump => true'
+require_fixed "$IR" 'IrOpcode::IrBranchTrue => true'
+require_fixed "$IR" 'IrOpcode::IrBranchFalse => true'
+cfg_label_predicate="$(sed -n '/pub fn ir_opcode_has_cfg_label(/,/^}/p' "$IR")"
+if [[ "$(grep -c -- '=> true' <<<"$cfg_label_predicate")" != 4 ]] \
+  || grep -Eq 'IrField(Get|Set)' <<<"$cfg_label_predicate"; then
+  printf 'raw-field terminal gate: CFG label predicate must contain only Label/Jump/BranchTrue/BranchFalse\n' >&2
+  exit 1
+fi
+require_fixed "$IR" 'offset_words: i64'
+require_fixed "$IR" 'storage_words: i64'
+require_fixed "$IR" 'raw_projectable: i64'
+require_fixed "$LOWER" 'fn lower_typeexpr_storage_words_ref(ty: &TypeExpr) -> i64'
+require_fixed "$LOWER" 'fn lower_typeexpr_raw_projectable_ref(ty: &TypeExpr) -> i64'
+require_fixed "$LOWER" 'fn raw_field_offset_words(self, struct_name: Name, field_name: Name) -> i64'
+require_fixed "$LOWER" 'if field.raw_projectable != 1 || field.storage_words != 1 { return -1 }'
+require_fixed "$LOWER" 'let explicit_raw_ptr_kind = self.field_base_explicit_local_raw_ptr_kind(&e.left)'
+require_fixed "$LOWER" 'set_instr.label_id = IR_FIELD_MODE_RAW'
+require_fixed "$LOWER" 'instr.label_id = IR_FIELD_MODE_RAW'
+require_fixed "$LOWER" 'fn field_base_raw_ptr_operand_kind(self, base_opt: &Option<Box<Expr>>) -> i64'
+if [[ "$(rg -c 'raw_ptr_operand_kind > 0 && !explicit_raw_deref' "$LOWER")" != 2 ]]; then
+  printf 'raw-field terminal gate: lowerer must reject non-identifier raw reads and writes\n' >&2
+  exit 1
+fi
+
+require_fixed "$INLINE" 'if ir_opcode_has_cfg_label(out.op) && out.label_id >= 0 {'
+require_fixed "$OPT_STRATEGY" 'if ir_opcode_has_cfg_label(instr.op) && instr.label_id > max_id {'
+require_fixed "$OPT_STRATEGY" 'label_id:  if ir_opcode_has_cfg_label(instr.op) { ir_opt_remap_label(instr.label_id, label_offset) } else { instr.label_id },'
+require_fixed "$NORMALIZE" 'use ir::ir::{ir_opcode_has_cfg_label}'
+require_fixed "$NORMALIZE" 'let new_label = if ir_opcode_has_cfg_label(instr.op) && old_label >= 0 && old_label < 256 {'
+
+raw_lookup="$(sed -n '/fn raw_field_offset_words(/,/^    }/p' "$LOWER")"
+if grep -Eq 'field_idx_from_name|field_idx_from_name_simple|buf\[0\].*% 64' <<<"$raw_lookup"; then
+  printf 'raw-field terminal gate: raw offset lookup contains a legacy fallback\n' >&2
+  exit 1
+fi
+
+raw_read="$(sed -n '/fn lower_field_access_expr_ref(/,/fn lower_index_expr_ref(/p' "$LOWER")"
+raw_store="$(sed -n '/fn lower_assign_stmt_ref(/,/fn lower_assign_stmt(/p' "$LOWER")"
+require_fixed "$LOWER" 'if explicit_ref_deref || explicit_raw_deref {'
+if ! grep -Fq 'lo.lower_opt_expr_ref(&(*base_expr).left)' <<<"$raw_store" \
+  || ! grep -Fq 'self.lower_opt_expr_ref(&(*base_expr_ref).left)' <<<"$raw_read"; then
+  printf 'raw-field terminal gate: raw field projection no longer lowers its identifier directly\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'if explicit_raw_ptr_kind == 1' <<<"$raw_store"; then
+  printf 'raw-field terminal gate: lowerer no longer fails closed for *const stores\n' >&2
+  exit 1
+fi
+
+require_fixed "$CHECKER" 'ty_terminal_storage_kind(raw_ty) == 1'
+require_fixed "$CHECKER" 'else if code == 229 { print("raw inline aggregate field projection requires Place IR") }'
+require_fixed "$CHECKER" 'else if code == 230 { print("raw field projection requires an identifier pointer operand") }'
+require_fixed "$CHECKER" 'explicit_raw_operand_kind > 0 && explicit_raw_operand_kind < 3 && ty_terminal_storage_kind(field_ty) == 3'
+if [[ "$(rg -c 'if raw_operand_storage_kind == 1 \|\| raw_operand_storage_kind == 2' "$CHECKER")" != 2 ]]; then
+  printf 'raw-field terminal gate: E230 must accept only raw const/mut categories, never inline-array category 3\n' >&2
+  exit 1
+fi
+require_fixed "$TYPES" 'pub fn ty_terminal_storage_kind(ty: TypeEntry) -> i64'
+require_fixed "$TYPES" '0=other, 1=raw const, 2=raw mut, 3=inline array'
+require_fixed "$NEGATIVE" '(*p).value = 1.0'
+require_fixed "$ARRAY_NEGATIVE" '// expected: error[E229]'
+require_fixed "$ARRAY_NEGATIVE" 'raw inline aggregate field projection requires Place IR'
+require_fixed "$ARRAY_NEGATIVE" '(*p).singleton'
+require_fixed "$ARRAY_NEGATIVE" '(*p).wide'
+require_fixed "$ARRAY_NEGATIVE" 'singleton: [i64; 1]'
+require_fixed "$ARRAY_NEGATIVE" 'wide: [f64; 2]'
+require_fixed "$ERROR_CATALOG" '| E229 | type-checker/raw-field | error | raw inline aggregate field projection requires Place IR |'
+require_fixed "$ERROR_EXPLANATION" '# E229'
+require_fixed "$NONIDENT_READ" '// expected: error[E230]'
+require_fixed "$NONIDENT_READ" '(*(addr as *const RawNonIdentFieldRead)).value'
+require_fixed "$NONIDENT_STORE" '// expected: error[E230]'
+require_fixed "$NONIDENT_STORE" '(*(addr as *mut RawNonIdentFieldStore)).value = 1'
+require_fixed "$ERROR_CATALOG" '| E230 | type-checker/raw-field | error | raw field projection requires an identifier pointer operand |'
+require_fixed "$ERROR_EXPLANATION_NONIDENT" '# E230'
+
+checker_e229_calls="$(rg -n 'report_error_at(_inplace)?\([^\n]*, 229,' "$CHECKER" || true)"
+if [[ "$(wc -l <<<"$checker_e229_calls" | tr -d ' ')" != 2 ]]; then
+  printf 'raw-field terminal gate: expected exactly two E229 checker emission sites\n%s\n' "$checker_e229_calls" >&2
+  exit 1
+fi
+
+e229_owners="$(rg -l --hidden --glob '!.git/**' --glob '!training/**' --glob '!archive/**' \
+  'E229|code == 229|report_error_at(_inplace)?\([^\n]*, 229,' "$ROOT" | sed "s#^$ROOT/##" | sort)"
+expected_e229_owners="$(printf '%s\n' \
+  'docs/governance/DOCS_AUTHORITY_MATRIX.md' \
+  'docs/governance/topic-registry.v1.json' \
+  'docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md' \
+  'docs/llm-guide/error-catalog.md' \
+  'docs/llm-guide/explanations/E229.md' \
+  'scripts/ci/raw_ptr_field_semantics_gate.sh' \
+  'self-hosted/check/check.sio' \
+  'tests/compile-fail/raw_array_field_projection.sio')"
+if [[ "$e229_owners" != "$expected_e229_owners" ]]; then
+  printf 'raw-field terminal gate: E229 ownership collision\nexpected:\n%s\nactual:\n%s\n' \
+    "$expected_e229_owners" "$e229_owners" >&2
+  exit 1
+fi
+
+checker_e230_calls="$(rg -n 'report_error_at(_inplace)?\([^\n]*, 230,' "$CHECKER" || true)"
+if [[ "$(wc -l <<<"$checker_e230_calls" | tr -d ' ')" != 2 ]]; then
+  printf 'raw-field terminal gate: expected exactly two E230 checker emission sites\n%s\n' "$checker_e230_calls" >&2
+  exit 1
+fi
+
+e230_owners="$(rg -l --hidden --glob '!.git/**' --glob '!training/**' --glob '!archive/**' \
+  'E230|code == 230|report_error_at(_inplace)?\([^\n]*, 230,' "$ROOT" | sed "s#^$ROOT/##" | sort)"
+expected_e230_owners="$(printf '%s\n' \
+  'docs/governance/DOCS_AUTHORITY_MATRIX.md' \
+  'docs/governance/topic-registry.v1.json' \
+  'docs/internal/compiler/RAW_FIELD_TERMINAL_CONTRACT.md' \
+  'docs/llm-guide/error-catalog.md' \
+  'docs/llm-guide/explanations/E230.md' \
+  'scripts/ci/raw_ptr_field_semantics_gate.sh' \
+  'self-hosted/check/check.sio' \
+  'tests/compile-fail/raw_nonident_field_read.sio' \
+  'tests/compile-fail/raw_nonident_field_store.sio')"
+if [[ "$e230_owners" != "$expected_e230_owners" ]]; then
+  printf 'raw-field terminal gate: E230 ownership collision\nexpected:\n%s\nactual:\n%s\n' \
+    "$expected_e230_owners" "$e230_owners" >&2
+  exit 1
+fi
+
+require_fixed "$MIR" 'mi.arg_index = instr.label_id'
+require_fixed "$MIR" 'mi.arg_index = field_mode'
+require_fixed "$MIR" 'machine_instr_field_mode(instr)'
+require_fixed "$MIR" 'instr.arg_index == IR_FIELD_MODE_RAW'
+
+for backend in "$X86" "$X86_MIRROR"; do
+  require_fixed "$backend" 'instr.arg_index == IR_FIELD_MODE_RAW'
+  machine_raw="$(sed -n '/if instr.opcode == MIR_OP_FIELD_LOAD/,/if instr.opcode == MIR_OP_INDEX_LOAD/p' "$backend")"
+  if ! grep -Fq 'emit_mov_reg_imm(c.code, 3, instr.aux.value)' <<<"$machine_raw"; then
+    printf 'raw-field terminal gate: missing direct Machine-IR raw offset in %s\n' "${backend#$ROOT/}" >&2
+    exit 1
+  fi
+done
+
+require_fixed "$X86" 'label_id == IR_FIELD_MODE_RAW'
+core_raw_get="$(sed -n '/label_id == IR_FIELD_MODE_RAW/,/label_id == IR_FIELD_MODE_REF/p' "$X86" | head -n 8)"
+if grep -Eq 'resolve_handle|object_header|load_rax_mem_rax\(' <<<"$core_raw_get"; then
+  printf 'raw-field terminal gate: core raw load reintroduced handle/header/deref semantics\n' >&2
+  exit 1
+fi
+
+require_fixed "$WITNESS" 'prefix: [f64; 2]'
+require_fixed "$WITNESS" 'nested: RawFieldNested'
+require_fixed "$WITNESS" 'fn read_const_value(p: *const RawFieldWide) -> f64'
+require_fixed "$WITNESS" 'fn write_from_callee('
+require_fixed "$WITNESS" 'struct RawFieldCollision'
+require_fixed "$WITNESS" 'assert((*wide).nested.marker == 88)'
+
+require_fixed "$CONTRACT" 'final extension of legacy field-address lowering'
+require_fixed "$CONTRACT" '0 managed handle'
+require_fixed "$CONTRACT" '1 typed reference to a managed handle slot'
+require_fixed "$CONTRACT" '2 raw address'
+require_fixed "$CONTRACT" 'does not claim general pointer arithmetic'
+require_fixed "$CONTRACT" 'storage width is exactly one word'
+require_fixed "$CONTRACT" 'arrays are never projectable, including a one-element array.'
+require_fixed "$CONTRACT" 'named-aggregate handle slots are projectable'
+require_fixed "$CONTRACT" 'E229'
+require_fixed "$CONTRACT" 'E230'
+require_fixed "$CONTRACT" 'ir_opcode_has_cfg_label'
+
+if rg -n 'IR_FIELD_MODE_[A-Z_]+: i64 = ([3-9]|[1-9][0-9]+)' "$IR" >/dev/null; then
+  printf 'raw-field terminal gate: a field mode outside 0..2 was introduced\n' >&2
+  exit 1
+fi
+
+bash "$ROOT/scripts/ci/ref_field_autoderef_static_gate.sh"
+printf 'raw-field terminal static gate passed.\n'

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -5063,12 +5063,50 @@ fn checker_check_field_access_inplace(c: *mut Checker, e: Expr) -> TypeEntry wit
     if checker_expr_is_gpu_axis_field(e) {
         return ty_i64()
     }
-    let base_ty = checker_check_opt_expr_inplace(c, e.left)
+    var explicit_raw_operand_kind: i64 = 0
+    var prechecked_nonident_deref = false
+    var prechecked_base_ty = empty_type_entry()
+    match e.left {
+        Some(raw_base) => {
+            if (*raw_base).kind == ExprKind::ExprUnary && (*raw_base).un_op == UnaryOp::OpDeref {
+                match (*raw_base).left {
+                    Some(raw_operand) => {
+                        if (*raw_operand).kind == ExprKind::ExprIdent {
+                            explicit_raw_operand_kind = ty_terminal_storage_kind(type_env_binding_type(&(*c).env, (*raw_operand).name))
+                        } else {
+                            let raw_operand_ty = checker_check_expr_inplace(c, *raw_operand)
+                            let raw_operand_storage_kind = ty_terminal_storage_kind(raw_operand_ty)
+                            if raw_operand_storage_kind == 1 || raw_operand_storage_kind == 2 {
+                                checker_report_error_at_inplace(c, e.span, 230, 0, 0, 0)
+                                return empty_type_entry()
+                            }
+                            prechecked_base_ty = unary_result_type(UnaryOp::OpDeref, raw_operand_ty)
+                            if is_error_or_unknown(prechecked_base_ty) && !is_error_or_unknown(raw_operand_ty) {
+                                checker_report_error_at_inplace(c, e.span, 5, 0, 0, 0)
+                            }
+                            prechecked_nonident_deref = true
+                        }
+                    }
+                    None => {}
+                }
+            }
+        }
+        None => {}
+    }
+    let base_ty = if prechecked_nonident_deref {
+        prechecked_base_ty
+    } else {
+        checker_check_opt_expr_inplace(c, e.left)
+    }
     if base_ty.kind == TypeKind::TyNamed {
         let struct_idx = struct_table_find((*c).structs, base_ty.name)
         if struct_idx >= 0 {
             let si = struct_table_get((*c).structs, struct_idx)
                     let field_ty = field_info_list_find(si.fields, e.name)
+            if explicit_raw_operand_kind > 0 && explicit_raw_operand_kind < 3 && ty_terminal_storage_kind(field_ty) == 3 {
+                checker_report_error_at_inplace(c, e.span, 229, 0, 0, 0)
+                return empty_type_entry()
+            }
             if field_ty.kind == TypeKind::TyError && !field_info_list_has(si.fields, e.name) {
                 checker_report_error_at_inplace(c, e.span, 12, 0, 0, 0)
             }
@@ -7368,6 +7406,25 @@ fn checker_check_assign_mutability_inplace(c: *mut Checker, opt: Option<Box<Expr
                 // E003 on `GLOBAL = …` while preserving the true positive on local `let`.
                 if (*c).env.has_binding((*e).name) && !(*c).env.lookup_is_mutable((*e).name) {
                     checker_report_error_at_inplace(c, span, 3, 0, 0, 0)
+                }
+            } else if (*e).kind == ExprKind::ExprFieldAccess {
+                match (*e).left {
+                    Some(base) => {
+                        if (*base).kind == ExprKind::ExprUnary && (*base).un_op == UnaryOp::OpDeref {
+                            match (*base).left {
+                                Some(raw_ident) => {
+                                    if (*raw_ident).kind == ExprKind::ExprIdent {
+                                        let raw_ty = (*c).env.lookup((*raw_ident).name)
+                                        if ty_terminal_storage_kind(raw_ty) == 1 {
+                                            checker_report_error_at_inplace(c, span, 3, 0, 0, 0)
+                                        }
+                                    }
+                                }
+                                None => {}
+                            }
+                        }
+                    }
+                    None => {}
                 }
             }
         }
@@ -11594,6 +11651,8 @@ fn print_error_message(code: i64) with IO, Mut, Panic, Div {
     else if code == 205 { print("Audited<T> requires ZD and Witness effects: witness-bearing surgery (G9) must emit a machine-checkable Lean derivation of the ZD-kernel action. `with ZD` alone produces the erasure without evidence; Witness is what makes it checkable. Add `with ZD, Witness` to your function signature.") }
     else if code == 206 { print("Revivable<T> requires ZD and Temporal effects: time-bounded reversible surgery (G10) needs both the ZD annihilator algebra and an explicit Temporal window in which the op can be inverted. After the window, the surgery is irrevocable. Add `with ZD, Temporal` to your function signature.") }
     else if code == 207 { print("Interpretable<T> requires ZD effect: the 168-class canonical basis is the projective ZD-graph of sedenions. Without the ZD effect the compiler cannot guarantee that decomposition/reconstruction is fp-exact. Add `with ZD` to your function signature.") }
+    else if code == 229 { print("raw inline aggregate field projection requires Place IR") }
+    else if code == 230 { print("raw field projection requires an identifier pointer operand") }
     else if code == 213 { print("tuple destructure arity mismatch") }
     else if code == 216 { print("infinite recursive type") }
     else { print("unknown error") }
@@ -18175,6 +18234,26 @@ impl Checker {
                     } else {
                         self
                     }
+                } else if (*e).kind == ExprKind::ExprFieldAccess {
+                    match (*e).left {
+                        Some(base) => {
+                            if (*base).kind == ExprKind::ExprUnary && (*base).un_op == UnaryOp::OpDeref {
+                                match (*base).left {
+                                    Some(raw_ident) => {
+                                        if (*raw_ident).kind == ExprKind::ExprIdent {
+                                            let raw_ty = self.env.lookup((*raw_ident).name)
+                                            if ty_terminal_storage_kind(raw_ty) == 1 {
+                                                return self.report_error_at(span, 3, 0, 0, 0)
+                                            }
+                                        }
+                                    }
+                                    None => {}
+                                }
+                            }
+                        }
+                        None => {}
+                    }
+                    self
                 } else {
                     // Field access, index — assume mutable for now
                     self
@@ -18782,14 +18861,55 @@ impl Checker {
         if checker_expr_is_gpu_axis_field(e) {
             return (self, ty_i64())
         }
-        let pair = self.check_opt_expr(e.left)
-        var c = pair.0
-        let base_ty = pair.1
+        var c0 = self
+        var explicit_raw_operand_kind: i64 = 0
+        var prechecked_nonident_deref = false
+        var prechecked_base_ty = empty_type_entry()
+        match e.left {
+            Some(raw_base) => {
+                if (*raw_base).kind == ExprKind::ExprUnary && (*raw_base).un_op == UnaryOp::OpDeref {
+                    match (*raw_base).left {
+                        Some(raw_operand) => {
+                            if (*raw_operand).kind == ExprKind::ExprIdent {
+                                explicit_raw_operand_kind = ty_terminal_storage_kind(type_env_binding_type(&c0.env, (*raw_operand).name))
+                            } else {
+                                let raw_operand_pair = c0.check_expr(*raw_operand)
+                                c0 = raw_operand_pair.0
+                                let raw_operand_ty = raw_operand_pair.1
+                                let raw_operand_storage_kind = ty_terminal_storage_kind(raw_operand_ty)
+                                if raw_operand_storage_kind == 1 || raw_operand_storage_kind == 2 {
+                                    c0 = c0.report_error_at(e.span, 230, 0, 0, 0)
+                                    return (c0, empty_type_entry())
+                                }
+                                prechecked_base_ty = unary_result_type(UnaryOp::OpDeref, raw_operand_ty)
+                                if is_error_or_unknown(prechecked_base_ty) && !is_error_or_unknown(raw_operand_ty) {
+                                    c0 = c0.report_error_at(e.span, 5, 0, 0, 0)
+                                }
+                                prechecked_nonident_deref = true
+                            }
+                        }
+                        None => {}
+                    }
+                }
+            }
+            None => {}
+        }
+        var c = c0
+        var base_ty = prechecked_base_ty
+        if !prechecked_nonident_deref {
+            let pair = c0.check_opt_expr(e.left)
+            c = pair.0
+            base_ty = pair.1
+        }
         if base_ty.kind == TypeKind::TyNamed {
             let struct_idx = struct_table_find(c.structs, base_ty.name)
             if struct_idx >= 0 {
                 let si = struct_table_get(c.structs, struct_idx)
                 let field_ty = field_info_list_find(si.fields, e.name)
+                if explicit_raw_operand_kind > 0 && explicit_raw_operand_kind < 3 && ty_terminal_storage_kind(field_ty) == 3 {
+                    c = c.report_error_at(e.span, 229, 0, 0, 0)
+                    return (c, empty_type_entry())
+                }
                 if field_ty.kind == TypeKind::TyError && !field_info_list_has(si.fields, e.name) {
                     c = c.report_error_at(e.span, 12, 0, 0, 0)
                 }

--- a/self-hosted/check/env.sio
+++ b/self-hosted/check/env.sio
@@ -122,3 +122,14 @@ impl TypeEnv {
         false
     }
 }
+
+pub fn type_env_binding_type(env: &TypeEnv, name: Name) -> TypeEntry with Mut, Panic, Div {
+    var i = (*env).count - 1
+    while i >= 0 {
+        if name_eq((*env).bindings[i as usize].name, name) {
+            return (*env).bindings[i as usize].ty
+        }
+        i = i - 1
+    }
+    empty_type_entry()
+}

--- a/self-hosted/check/types.sio
+++ b/self-hosted/check/types.sio
@@ -675,6 +675,17 @@ fn ty_raw_ptr(inner: TypeEntry, is_mut: bool) -> TypeEntry with Alloc {
     }
 }
 
+// Terminal legacy storage categories exposed without leaking TypeKind's private
+// discriminants: 0=other, 1=raw const, 2=raw mut, 3=inline array.
+pub fn ty_terminal_storage_kind(ty: TypeEntry) -> i64 {
+    if ty.kind == TypeKind::TyRawPtr {
+        if ty.name.buf[0] == 0 { return 1 }
+        return 2
+    }
+    if ty.kind == TypeKind::TyArray { return 3 }
+    0
+}
+
 fn ty_ref_mut_with_idx(inner: TypeEntry, struct_idx: i64) -> TypeEntry with Alloc {
     var enc: Name = Name { buf: [0; 128], len: 0 }
     let enc_idx = struct_idx + 1

--- a/self-hosted/ir/inline.sio
+++ b/self-hosted/ir/inline.sio
@@ -807,7 +807,7 @@ fn inl_remap_instr(instr: IrInstr, rmap: InlRegMap) -> IrInstr with Mut, Div, Pa
 // Remap a label_id in an instruction by adding an offset
 fn inl_remap_label(instr: IrInstr, label_offset: i64) -> IrInstr with Mut, Div, Panic {
     var out = instr
-    if out.label_id >= 0 {
+    if ir_opcode_has_cfg_label(out.op) && out.label_id >= 0 {
         out.label_id = out.label_id + label_offset
     }
     return out

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -15,6 +15,11 @@ pub let IR_MAX_PARAMS: i64 = 64
 pub let IR_INVALID_REG: i64 = -1
 pub let IR_INVALID_LABEL: i64 = -1
 pub let IR_INVALID_FN: i64 = -1
+// IrFieldGet/IrFieldSet address domains. These values are opcode-local; branch
+// and index instructions retain their existing label_id meanings.
+pub let IR_FIELD_MODE_MANAGED: i64 = 0
+pub let IR_FIELD_MODE_REF: i64 = 1
+pub let IR_FIELD_MODE_RAW: i64 = 2
 pub let IR_MAX_EPI_MODEL_FAMILIES: i64 = 32
 pub let IR_MAX_EPI_POLICIES: i64 = 32
 pub let IR_MAX_EPI_DECISION_POLICIES: i64 = 32
@@ -647,6 +652,18 @@ pub enum IrOpcode {
     IrStoreGlobal,
     // Store through a raw pointer: [src1] = src2  (used for `*p = val` on a true reference).
     IrStorePtr,
+}
+
+// label_id is a shared physical slot with opcode-local meanings. Only these
+// control-flow instructions may have that slot renumbered as a CFG label.
+pub fn ir_opcode_has_cfg_label(op: IrOpcode) -> bool {
+    match op {
+        IrOpcode::IrLabel => true,
+        IrOpcode::IrJump => true,
+        IrOpcode::IrBranchTrue => true,
+        IrOpcode::IrBranchFalse => true,
+        _ => false,
+    }
 }
 
 pub struct IrRegList {
@@ -1996,10 +2013,13 @@ pub struct IrLowerResult {
 // Struct layout tracking (Phase 3.2)
 // ============================================================================
 
-// A single struct field: name + sequential index
+// A single struct field: managed ordinal plus compiler-owned raw layout.
 pub struct StructFieldEntry {
     name: Name,
     index: i64,
+    offset_words: i64,
+    storage_words: i64,
+    raw_projectable: i64,
     is_float: i64,
 }
 
@@ -2017,7 +2037,7 @@ pub struct StructLayoutTable {
 }
 
 fn empty_struct_field_entry() -> StructFieldEntry {
-    StructFieldEntry { name: ir_empty_name(), index: 0, is_float: 0 }
+    StructFieldEntry { name: ir_empty_name(), index: 0, offset_words: -1, storage_words: -1, raw_projectable: 0, is_float: 0 }
 }
 
 fn empty_struct_layout_entry() -> StructLayoutEntry {
@@ -3371,7 +3391,7 @@ fn ir_field_get(dst: i64, base_reg: i64, field_idx: i64, field_name: Name) -> Ir
         src2: base.src2,
         imm_i64: base.imm_i64,
         imm_f64: base.imm_f64,
-        label_id: base.label_id,
+        label_id: IR_FIELD_MODE_MANAGED,
         fn_id: base.fn_id,
         field_idx: field_idx,
         imm_flags: base.imm_flags,
@@ -3392,7 +3412,7 @@ fn ir_field_set(base_reg: i64, field_idx: i64, src: i64, field_name: Name) -> Ir
         src2: src,
         imm_i64: base.imm_i64,
         imm_f64: base.imm_f64,
-        label_id: base.label_id,
+        label_id: IR_FIELD_MODE_MANAGED,
         fn_id: base.fn_id,
         field_idx: field_idx,
         imm_flags: base.imm_flags,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -21,6 +21,8 @@ struct LowerLocalStack {
     // 0 = value, 1 = shared reference, 2 = mutable reference. A reference slot stores
     // a raw address of the caller slot, not the aggregate handle directly.
     is_ref: [i64; 4096],
+    // 0 = not raw, 1 = *const named struct, 2 = *mut named struct.
+    raw_ptr_kind: [i64; 4096],
     // 0=other 1=int 2=float; used by println dispatch to avoid routing i64/f64 vars through print_str
     scalar_kind: [i64; 4096],
     // f64 register carrying the GUM variance shadow for scalar locals, or -1 when absent.
@@ -44,6 +46,7 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         global_bss_sizes: [0; 4096],
         is_global: [0; 4096],
         is_ref: [0; 4096],
+        raw_ptr_kind: [0; 4096],
         scalar_kind: [0; 4096],
         variance_regs: [-1; 4096],
         closure_fn_id: [-1; 4096],
@@ -263,9 +266,9 @@ fn ir_register_knowledge_layout(table: StructLayoutTable) -> StructLayoutTable w
     }
     let idx = t.count
     var fields: [StructFieldEntry; 64] = [empty_struct_field_entry(); 64]
-    fields[0] = StructFieldEntry { name: make_name("value"), index: 0, is_float: 0 }
-    fields[1] = StructFieldEntry { name: make_name("variance"), index: 1, is_float: 0 }
-    fields[2] = StructFieldEntry { name: make_name("confidence"), index: 2, is_float: 0 }
+    fields[0] = StructFieldEntry { name: make_name("value"), index: 0, offset_words: 0, storage_words: 1, raw_projectable: 1, is_float: 0 }
+    fields[1] = StructFieldEntry { name: make_name("variance"), index: 1, offset_words: 1, storage_words: 1, raw_projectable: 1, is_float: 0 }
+    fields[2] = StructFieldEntry { name: make_name("confidence"), index: 2, offset_words: 2, storage_words: 1, raw_projectable: 1, is_float: 0 }
     t.entries[idx as usize] = StructLayoutEntry {
         type_name: make_name("Knowledge"),
         fields: fields,
@@ -896,6 +899,7 @@ fn lowerer_preseed_external_struct_items_mut(
                                 var entry = empty_struct_layout_entry()
                                 entry.type_name = head_owned.name
                                 var fc: i64 = 0
+                                var offset_words: i64 = 0
                                 var fcur = (*sd).fields
                                 var keep_going = true
                                 while keep_going && fc < 64 {
@@ -904,6 +908,9 @@ fn lowerer_preseed_external_struct_items_mut(
                                             entry.fields[fc as usize] = StructFieldEntry {
                                                 name: (*flist).head.name,
                                                 index: fc,
+                                                offset_words: offset_words,
+                                                storage_words: lower_typeexpr_storage_words_ref(&(*flist).head.ty),
+                                                raw_projectable: lower_typeexpr_raw_projectable_ref(&(*flist).head.ty),
                                                 // Was hardcoded is_float:0, which mis-classified imported
                                                 // struct f64 fields as int — cross-module reads of an
                                                 // imported struct's f64 field emitted cvtsi2sd (int->double)
@@ -912,6 +919,7 @@ fn lowerer_preseed_external_struct_items_mut(
                                                 // ir_fast_summary_register_struct_fields_owned.
                                                 is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_i64(&(*flist).head.ty) { 3 } else { 0 },
                                             }
+                                            offset_words = lower_next_field_offset_words(offset_words, &(*flist).head.ty)
                                             fc = fc + 1
                                             fcur = (*flist).tail
                                         }
@@ -1040,6 +1048,7 @@ fn lowerer_register_struct_fields_direct_mut(
     var entry = empty_struct_layout_entry()
     entry.type_name = type_name
     var fc: i64 = 0
+    var offset_words: i64 = 0
     var fcur = fields
     var keep_going = true
     while keep_going && fc < 64 {
@@ -1048,6 +1057,9 @@ fn lowerer_register_struct_fields_direct_mut(
                 entry.fields[fc as usize] = StructFieldEntry {
                     name: (*flist).head.name,
                     index: fc,
+                    offset_words: offset_words,
+                    storage_words: lower_typeexpr_storage_words_ref(&(*flist).head.ty),
+                    raw_projectable: lower_typeexpr_raw_projectable_ref(&(*flist).head.ty),
                     // println i64-segfault fix: keep in sync with register_struct_fields_ref's
                     // `3` = scalar-i64 marker (this is a separate early-pass registration path
                     // over the same struct_layouts table; a mismatch here would leave the
@@ -1055,6 +1067,7 @@ fn lowerer_register_struct_fields_direct_mut(
                     // without the i64 marker).
                     is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_i64(&(*flist).head.ty) { 3 } else { 0 },
                 }
+                offset_words = lower_next_field_offset_words(offset_words, &(*flist).head.ty)
                 fc = fc + 1
                 fcur = &(*flist).tail
             }
@@ -1074,6 +1087,7 @@ fn lowerer_register_struct_fields_mut(
 ) with Mut, Panic, Div, Alloc {
     var current = fields
     var field_idx = idx
+    var offset_words: i64 = 0
     while true {
         match *current {
             Some(list) => {
@@ -1105,9 +1119,13 @@ fn lowerer_register_struct_fields_mut(
                     (*(*lo).struct_layouts).entries[layout_idx as usize].fields[fc as usize] = StructFieldEntry {
                         name: (*list).head.name,
                         index: field_idx,
+                        offset_words: offset_words,
+                        storage_words: lower_typeexpr_storage_words_ref(&(*list).head.ty),
+                        raw_projectable: lower_typeexpr_raw_projectable_ref(&(*list).head.ty),
                         // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
                         is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
                     }
+                    offset_words = lower_next_field_offset_words(offset_words, &(*list).head.ty)
                     (*(*lo).struct_layouts).entries[layout_idx as usize].field_count = fc + 1
                 } else {
                     lo.error_count = lo.error_count + 1
@@ -1170,6 +1188,40 @@ fn lower_typeexpr_byte_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Div {
         }
         _ => { return 8 }
     }
+}
+
+// Native-v2 raw structs use one word for every non-array value and inline the
+// slot table of a fixed array. Unknown extents and arithmetic overflow are not
+// layouts: callers must fail closed instead of guessing an offset.
+fn lower_typeexpr_storage_words_ref(ty: &TypeExpr) -> i64 with Div {
+    if (*ty).kind != TypeExprKind::TypeArray { return 1 }
+    let inner_words = match (*ty).inner {
+        Some(inner) => lower_typeexpr_storage_words_ref(&(*inner)),
+        None => -1,
+    }
+    if inner_words <= 0 { return -1 }
+    let count = match (*ty).array_size {
+        Some(sz) => {
+            if (*sz).kind != ExprKind::ExprIntLit { return -1 }
+            (*sz).int_val
+        }
+        None => return -1,
+    }
+    if count < 0 { return -1 }
+    if count > 9223372036854775807 / inner_words { return -1 }
+    count * inner_words
+}
+
+fn lower_typeexpr_raw_projectable_ref(ty: &TypeExpr) -> i64 {
+    if (*ty).kind == TypeExprKind::TypeArray { 0 } else { 1 }
+}
+
+fn lower_next_field_offset_words(offset_words: i64, ty: &TypeExpr) -> i64 with Div {
+    if offset_words < 0 { return -1 }
+    let width_words = lower_typeexpr_storage_words_ref(ty)
+    if width_words < 0 { return -1 }
+    if offset_words > 9223372036854775807 - width_words { return -1 }
+    offset_words + width_words
 }
 
 fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Panic, Div {
@@ -1597,7 +1649,8 @@ fn ir_fast_summary_register_struct_fields_owned(
     table: StructLayoutTable,
     type_name: Name,
     fields: Option<Box<FieldDefList>>,
-    idx: i64
+    idx: i64,
+    offset_words: i64
 ) -> StructLayoutTable with Mut, Panic, Div, Alloc {
     match fields {
         Some(list) => {
@@ -1633,13 +1686,17 @@ fn ir_fast_summary_register_struct_fields_owned(
                 lay_entry.fields[fc as usize] = StructFieldEntry {
                     name: (*list).head.name,
                     index: idx,
+                    offset_words: offset_words,
+                    storage_words: lower_typeexpr_storage_words_ref(&(*list).head.ty),
+                    raw_projectable: lower_typeexpr_raw_projectable_ref(&(*list).head.ty),
                     // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
                     is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
                 }
                 lay_entry.field_count = fc + 1
                 table_value.entries[layout_idx as usize] = lay_entry
             }
-            ir_fast_summary_register_struct_fields_owned(table_value, type_name, (*list).tail, idx + 1)
+            let next_offset_words = lower_next_field_offset_words(offset_words, &(*list).head.ty)
+            ir_fast_summary_register_struct_fields_owned(table_value, type_name, (*list).tail, idx + 1, next_offset_words)
         }
         None => table,
     }
@@ -1724,7 +1781,7 @@ fn ir_fast_summary_preseed_items_seed_owned(
                     } else if kind == ItemKind::ItemStruct {
                 match item.struct_def {
                     Some(sd) => {
-                        seed_value.struct_layouts = ir_fast_summary_register_struct_fields_owned(seed_value.struct_layouts, name, (*sd).fields, 0)
+                        seed_value.struct_layouts = ir_fast_summary_register_struct_fields_owned(seed_value.struct_layouts, name, (*sd).fields, 0, 0)
                     }
                     _ => {}
                 }
@@ -1836,7 +1893,7 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                 } else if kind == ItemKind::ItemStruct {
                     match item.struct_def {
                         Some(sd) => {
-                            struct_layouts = ir_fast_summary_register_struct_fields_owned(struct_layouts, name, (*sd).fields, 0)
+                            struct_layouts = ir_fast_summary_register_struct_fields_owned(struct_layouts, name, (*sd).fields, 0, 0)
                         }
                         _ => {}
                     }
@@ -1948,6 +2005,7 @@ fn lowerer_bind_local_mut(
         (*locals_box).global_bss_sizes[idx as usize] = 0
         (*locals_box).is_global[idx as usize] = 0
         (*locals_box).is_ref[idx as usize] = 0
+        (*locals_box).raw_ptr_kind[idx as usize] = 0
         (*locals_box).scalar_kind[idx as usize] = 0
         (*locals_box).variance_regs[idx as usize] = -1
         (*locals_box).count = idx + 1
@@ -1969,6 +2027,23 @@ fn lowerer_mark_local_ref_kind_mut(
     while i >= 0 {
         if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
             (*locals_box).is_ref[i as usize] = ref_kind
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
+    }
+}
+
+fn lowerer_mark_local_raw_ptr_kind_mut(
+    lo: &! Lowerer,
+    name: Name,
+    raw_ptr_kind: i64
+) with Mut, Alloc, Panic, Div {
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).raw_ptr_kind[i as usize] = raw_ptr_kind
             (*lo).locals = locals_box
             return
         }
@@ -2110,6 +2185,10 @@ fn lowerer_lower_fn_params_mut(
                 let param_ref_kind = lower_type_expr_ref_kind(&(*list).head.ty)
                 if param_ref_kind > 0 {
                     lowerer_mark_local_ref_kind_mut(lo, (*list).head.name, param_ref_kind)
+                }
+                let param_raw_ptr_kind = lower_type_expr_raw_ptr_kind(&(*list).head.ty)
+                if param_raw_ptr_kind > 0 {
+                    lowerer_mark_local_raw_ptr_kind_mut(lo, (*list).head.name, param_raw_ptr_kind)
                 }
                 if lower_type_expr_is_array_of_f64(&(*list).head.ty) {
                     lowerer_mark_local_array_elem_float_mut(lo, (*list).head.name)
@@ -2570,7 +2649,7 @@ fn lower_param_struct_type_name(ty: &TypeExpr) -> Name with Mut, Panic, Div {
     if (*ty).kind == TypeExprKind::TypeNamed {
         return ir_path_first_name((*ty).path)
     }
-    if (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut {
+    if (*ty).kind == TypeExprKind::TypeReference || (*ty).kind == TypeExprKind::TypeRefMut || (*ty).kind == TypeExprKind::TypeRawPtr {
         return lower_opt_type_named_name(&(*ty).inner)
     }
     ir_empty_name()
@@ -2582,6 +2661,14 @@ fn lower_type_expr_ref_kind(ty: &TypeExpr) -> i64 {
     0
 }
 
+fn lower_type_expr_raw_ptr_kind(ty: &TypeExpr) -> i64 {
+    if (*ty).kind != TypeExprKind::TypeRawPtr { return 0 }
+    match (*ty).array_size {
+        Some(_) => 2,
+        None => 1,
+    }
+}
+
 fn lower_type_expr_is_ref_like(ty: &TypeExpr) -> bool {
     lower_type_expr_ref_kind(ty) > 0
 }
@@ -2589,6 +2676,13 @@ fn lower_type_expr_is_ref_like(ty: &TypeExpr) -> bool {
 fn lower_opt_type_ref_kind(opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
     match *opt {
         Some(ty) => lower_type_expr_ref_kind(&(*ty)),
+        None => 0,
+    }
+}
+
+fn lower_opt_type_raw_ptr_kind(opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
+    match *opt {
+        Some(ty) => lower_type_expr_raw_ptr_kind(&(*ty)),
         None => 0,
     }
 }
@@ -4063,6 +4157,7 @@ impl Lowerer {
                 stk.wide_bits[idx as usize] = 0
                 stk.wide_signed[idx as usize] = 0
                 stk.is_ref[idx as usize] = 0
+                stk.raw_ptr_kind[idx as usize] = 0
                 stk.variance_regs[idx as usize] = -1
                 stk.count = idx + 1
             lo.locals = Box::new(stk)
@@ -4198,6 +4293,32 @@ impl Lowerer {
         lo
     }
 
+    fn lookup_local_raw_ptr_kind(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).raw_ptr_kind[i as usize]
+            }
+            i = i - 1
+        }
+        0
+    }
+
+    fn bind_local_raw_ptr_kind(self, name: Name, raw_ptr_kind: i64) -> Lowerer with Mut, Alloc, Panic, Div {
+        var lo = self
+        var stk = *lo.locals
+        var i = stk.count - 1
+        while i >= 0 {
+            if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
+                stk.raw_ptr_kind[i as usize] = raw_ptr_kind
+                lo.locals = Box::new(stk)
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
     fn expr_local_ref_kind(self, e: &Expr) -> i64 with Mut, Panic, Div, Alloc {
         if (*e).kind == ExprKind::ExprUnary {
             if (*e).un_op == UnaryOp::OpRefMut { return 2 }
@@ -4205,6 +4326,16 @@ impl Lowerer {
         }
         if (*e).kind == ExprKind::ExprIdent {
             return self.lookup_local_ref_kind((*e).name)
+        }
+        0
+    }
+
+    fn expr_local_raw_ptr_kind(self, e: &Expr) -> i64 with Mut, Panic, Div, Alloc {
+        if (*e).kind == ExprKind::ExprCast {
+            return lower_opt_type_raw_ptr_kind(&(*e).cast_type)
+        }
+        if (*e).kind == ExprKind::ExprIdent {
+            return self.lookup_local_raw_ptr_kind((*e).name)
         }
         0
     }
@@ -4223,6 +4354,42 @@ impl Lowerer {
                             0
                         }
                     }
+                    _ => 0,
+                }
+            }
+            _ => 0,
+        }
+    }
+
+    fn field_base_explicit_local_raw_ptr_kind(self, base_opt: &Option<Box<Expr>>) -> i64 with Mut, Panic, Div, Alloc {
+        match *base_opt {
+            Some(base_expr) => {
+                if (*base_expr).kind != ExprKind::ExprUnary || (*base_expr).un_op != UnaryOp::OpDeref {
+                    return 0
+                }
+                match (*base_expr).left {
+                    Some(operand) => {
+                        if (*operand).kind == ExprKind::ExprIdent {
+                            self.lookup_local_raw_ptr_kind((*operand).name)
+                        } else {
+                            0
+                        }
+                    }
+                    _ => 0,
+                }
+            }
+            _ => 0,
+        }
+    }
+
+    fn field_base_raw_ptr_operand_kind(self, base_opt: &Option<Box<Expr>>) -> i64 with Mut, Panic, Div, Alloc {
+        match *base_opt {
+            Some(base_expr) => {
+                if (*base_expr).kind != ExprKind::ExprUnary || (*base_expr).un_op != UnaryOp::OpDeref {
+                    return 0
+                }
+                match (*base_expr).left {
+                    Some(operand) => self.expr_local_raw_ptr_kind(&(*operand)),
                     _ => 0,
                 }
             }
@@ -5006,6 +5173,29 @@ impl Lowerer {
         }
     }
 
+    // Raw addressing never uses the legacy global-name/hash fallbacks. The
+    // final offset was computed from the declaration when the layout was seeded.
+    fn raw_field_offset_words(self, struct_name: Name, field_name: Name) -> i64 with Mut, Panic, Div {
+        if struct_name.len <= 0 || field_name.len <= 0 { return -1 }
+        var si: i64 = 0
+        while si < (*self.struct_layouts).count {
+            if ir_name_eq((*self.struct_layouts).entries[si as usize].type_name, struct_name) {
+                var fi: i64 = 0
+                while fi < (*self.struct_layouts).entries[si as usize].field_count {
+                    let field = (*self.struct_layouts).entries[si as usize].fields[fi as usize]
+                    if ir_name_eq(field.name, field_name) {
+                        if field.raw_projectable != 1 || field.storage_words != 1 { return -1 }
+                        return field.offset_words
+                    }
+                    fi = fi + 1
+                }
+                return -1
+            }
+            si = si + 1
+        }
+        -1
+    }
+
     // Phase 3.2: Lookup struct field index without needing struct name
     // Used when we don't know the struct type at the call site
     fn field_idx_from_name_simple(self, n: Name) -> i64 with Mut, Panic, Div {
@@ -5509,6 +5699,10 @@ impl Lowerer {
                         lay_entry.fields[fc as usize] = StructFieldEntry {
                             name: (*list).head.name,
                             index: field_idx,
+                            // Literal-only layouts are not raw-layout authority.
+                            offset_words: -1,
+                            storage_words: -1,
+                            raw_projectable: 0,
                             is_float: lower_struct_field_float_kind_ref(&(*list).head.value),
                         }
                         lay_entry.field_count = fc + 1
@@ -5599,6 +5793,7 @@ impl Lowerer {
         }
         var current = fields
         var field_idx = idx
+        var offset_words: i64 = 0
         while true {
             match *current {
                 Some(list) => {
@@ -5610,12 +5805,16 @@ impl Lowerer {
                         lay_entry.fields[fc as usize] = StructFieldEntry {
                             name: (*list).head.name,
                             index: field_idx,
+                            offset_words: offset_words,
+                            storage_words: lower_typeexpr_storage_words_ref(&(*list).head.ty),
+                            raw_projectable: lower_typeexpr_raw_projectable_ref(&(*list).head.ty),
                             // println i64-segfault fix: reuse the `is_float` numeric-kind slot
                             // with a new `3` marker for scalar-i64 fields (2 is already taken by
                             // f64-array). Existing consumers only test `== 1` / `== 2`, so this
                             // is inert for them; field_is_int_* below tests `== 3`.
                             is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
                         }
+                        offset_words = lower_next_field_offset_words(offset_words, &(*list).head.ty)
                         lay_entry.field_count = fc + 1
                         (*lo.struct_layouts).entries[layout_idx as usize] = lay_entry
                     }
@@ -6320,6 +6519,7 @@ impl Lowerer {
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
                         locals.is_ref[idx as usize] = lower_type_expr_ref_kind(&(*list).head.ty)
+                        locals.raw_ptr_kind[idx as usize] = lower_type_expr_raw_ptr_kind(&(*list).head.ty)
                         locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) { 2 } else { 0 }
                         locals.count = idx + 1
                     } else {
@@ -7065,6 +7265,22 @@ impl Lowerer {
                 lo = lo.bind_local_struct_type(s.name, annotated_struct_type)
             }
         }
+        var local_raw_ptr_kind = lower_opt_type_raw_ptr_kind(&s.ty)
+        if local_raw_ptr_kind == 0 {
+            match s.expr {
+                Some(raw_expr) => {
+                    local_raw_ptr_kind = lo.expr_local_raw_ptr_kind(&(*raw_expr))
+                }
+                _ => {}
+            }
+        }
+        if local_raw_ptr_kind > 0 {
+            lo = lo.bind_local_raw_ptr_kind(s.name, local_raw_ptr_kind)
+            let annotated_raw_struct_type = lower_opt_type_struct_name(&s.ty)
+            if annotated_raw_struct_type.len > 0 {
+                lo = lo.bind_local_struct_type(s.name, annotated_raw_struct_type)
+            }
+        }
         // Closures step 2: if the RHS was a capturing closure, mark this local so a later
         // `name(args)` call injects the captured regs (direct call to the synthetic fn).
         if lo.pending_closure_fn_id >= 0 {
@@ -7186,6 +7402,13 @@ impl Lowerer {
                     if src_st.len > 0 {
                         lo = lo.bind_local_struct_type(s.name, src_st)
                     }
+                } else if (*expr_box).kind == ExprKind::ExprCast {
+                    // `let p = addr as *mut Named`: retain the raw pointer's
+                    // pointee identity for exact physical field lookup.
+                    let cast_struct_type = lower_opt_type_struct_name(&(*expr_box).cast_type)
+                    if cast_struct_type.len > 0 && lower_opt_type_raw_ptr_kind(&(*expr_box).cast_type) > 0 {
+                        lo = lo.bind_local_struct_type(s.name, cast_struct_type)
+                    }
                 } else if (*expr_box).kind == ExprKind::ExprUnary
                     && ((*expr_box).un_op == UnaryOp::OpRef || (*expr_box).un_op == UnaryOp::OpRefMut) {
                     // `let r = &x` / `let r = &!x`: keep the referent's layout identity.
@@ -7293,9 +7516,20 @@ impl Lowerer {
                         match base_opt {
                             Some(base_expr) => {
                                 let explicit_ref_kind = lo.field_base_explicit_local_ref_kind(&base_opt)
+                                let explicit_raw_ptr_kind = lo.field_base_explicit_local_raw_ptr_kind(&base_opt)
+                                let raw_ptr_operand_kind = lo.field_base_raw_ptr_operand_kind(&base_opt)
                                 // Shared-reference stores retain the pre-existing unary/handle
                                 // lowering until the checker rejects them. Only &!T normalizes.
                                 let explicit_ref_deref = explicit_ref_kind == 2
+                                let explicit_raw_deref = explicit_raw_ptr_kind > 0
+                                if raw_ptr_operand_kind > 0 && !explicit_raw_deref {
+                                    return (lo.report_error(), rhs)
+                                }
+                                if explicit_raw_ptr_kind == 1 {
+                                    // The checker emits E003 for this path. Lowering also
+                                    // fails closed if a caller bypasses checker diagnostics.
+                                    return (lo.report_error(), rhs)
+                                }
                                 let base_is_ref = if explicit_ref_deref {
                                     true
                                 } else if (*base_expr).kind == ExprKind::ExprIdent {
@@ -7303,12 +7537,23 @@ impl Lowerer {
                                 } else {
                                     false
                                 }
-                                let fidx = if explicit_ref_deref {
+                                let fidx = if explicit_raw_deref {
+                                    match (*base_expr).left {
+                                        Some(raw_ident) => {
+                                            let raw_struct_name = lo.lookup_local_struct_type((*raw_ident).name)
+                                            lo.raw_field_offset_words(raw_struct_name, (*target_expr).name)
+                                        }
+                                        _ => -1,
+                                    }
+                                } else if explicit_ref_deref {
                                     lo.field_idx_for_base_ref(&(*base_expr).left, (*target_expr).name)
                                 } else {
                                     lo.field_idx_for_base_ref(&(*target_expr).left, (*target_expr).name)
                                 }
-                                let pair_base = if explicit_ref_deref {
+                                if explicit_raw_deref && fidx < 0 {
+                                    return (lo.report_error(), rhs)
+                                }
+                                let pair_base = if explicit_ref_deref || explicit_raw_deref {
                                     lo.lower_opt_expr_ref(&(*base_expr).left)
                                 } else {
                                     lo.lower_expr_ref(&(*base_expr))
@@ -7316,8 +7561,10 @@ impl Lowerer {
                                 lo = pair_base.0
                                 let base_reg = pair_base.1
                                 var set_instr = ir_field_set(base_reg, fidx, rhs, (*target_expr).name)
-                                if base_is_ref {
-                                    set_instr.label_id = 1
+                                if explicit_raw_deref {
+                                    set_instr.label_id = IR_FIELD_MODE_RAW
+                                } else if base_is_ref {
+                                    set_instr.label_id = IR_FIELD_MODE_REF
                                 }
                                 lo = lo.emit(set_instr)
                                 (lo, rhs)
@@ -9008,14 +9255,19 @@ impl Lowerer {
     }
 
     fn lower_field_access_expr_ref(self, e: &Expr) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
-        // A typed reference's explicit projection `(*ref).field` is the same place as
-        // `ref.field`. Lower the referenced ident directly so no raw OpDeref temporary
-        // is emitted. Box, raw-pointer, and non-ident dereferences retain their paths.
+        // Typed-reference and terminal raw-pointer projections lower their identifier
+        // directly. In both cases an OpDeref temporary would destroy the address domain.
         let explicit_ref_kind = self.field_base_explicit_local_ref_kind(&e.left)
+        let explicit_raw_ptr_kind = self.field_base_explicit_local_raw_ptr_kind(&e.left)
+        let raw_ptr_operand_kind = self.field_base_raw_ptr_operand_kind(&e.left)
         let explicit_ref_deref = explicit_ref_kind > 0
+        let explicit_raw_deref = explicit_raw_ptr_kind > 0
+        if raw_ptr_operand_kind > 0 && !explicit_raw_deref {
+            return self.report_error().emit_unit()
+        }
         let pair_b = match e.left {
             Some(base_expr_ref) => {
-                if explicit_ref_deref {
+                if explicit_ref_deref || explicit_raw_deref {
                     self.lower_opt_expr_ref(&(*base_expr_ref).left)
                 } else {
                     self.lower_opt_expr_ref(&e.left)
@@ -9027,7 +9279,15 @@ impl Lowerer {
         let base = pair_b.1
         let fidx = match e.left {
             Some(base_expr_ref) => {
-                if explicit_ref_deref {
+                if explicit_raw_deref {
+                    match (*base_expr_ref).left {
+                        Some(raw_ident) => {
+                            let raw_struct_name = lo1.lookup_local_struct_type((*raw_ident).name)
+                            lo1.raw_field_offset_words(raw_struct_name, e.name)
+                        }
+                        _ => -1,
+                    }
+                } else if explicit_ref_deref {
                     lo1.field_idx_for_base_ref(&(*base_expr_ref).left, e.name)
                 } else {
                     lo1.field_idx_for_base_ref(&e.left, e.name)
@@ -9035,19 +9295,33 @@ impl Lowerer {
             }
             _ => lo1.field_idx_for_base_ref(&e.left, e.name),
         }
+        if explicit_raw_deref && fidx < 0 {
+            let loe = lo1.report_error()
+            return loe.emit_unit()
+        }
         let field_is_float = match e.left {
             Some(base_expr_ref) => {
-                if explicit_ref_deref {
+                if explicit_raw_deref {
+                    match (*base_expr_ref).left {
+                        Some(raw_ident) => lo1.field_is_float_for_struct(lo1.lookup_local_struct_type((*raw_ident).name), e.name),
+                        _ => false,
+                    }
+                } else if explicit_ref_deref {
                     lo1.field_is_float_for_base_ref(&(*base_expr_ref).left, e.name)
                 } else {
                     lo1.field_is_float_for_base_ref(&e.left, e.name)
                 }
             }
             _ => lo1.field_is_float_for_base_ref(&e.left, e.name),
-        } || lo1.field_is_float_by_name_simple(e.name)
+        } || (!explicit_raw_deref && lo1.field_is_float_by_name_simple(e.name))
         let field_array_elem_is_float = match e.left {
             Some(base_expr_ref) => {
-                if explicit_ref_deref {
+                if explicit_raw_deref {
+                    match (*base_expr_ref).left {
+                        Some(raw_ident) => lo1.field_array_elem_is_float_for_struct(lo1.lookup_local_struct_type((*raw_ident).name), e.name),
+                        _ => false,
+                    }
+                } else if explicit_ref_deref {
                     lo1.field_array_elem_is_float_for_base_ref(&(*base_expr_ref).left, e.name)
                 } else {
                     lo1.field_array_elem_is_float_for_base_ref(&e.left, e.name)
@@ -9110,8 +9384,10 @@ impl Lowerer {
         let lo2 = pair_d.0
         let dst = pair_d.1
         var instr = ir_field_get(dst, base, fidx, e.name)
-        if base_is_ref {
-            instr.label_id = 1
+        if explicit_raw_deref {
+            instr.label_id = IR_FIELD_MODE_RAW
+        } else if base_is_ref {
+            instr.label_id = IR_FIELD_MODE_REF
         }
         if field_is_float || field_array_elem_is_float {
             instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG

--- a/self-hosted/ir/normalize.sio
+++ b/self-hosted/ir/normalize.sio
@@ -11,6 +11,8 @@
 // and Stage 2 (self-hosted) produces byte-identical SOIR artifacts despite
 // different compilation strategies.
 
+use ir::ir::{ir_opcode_has_cfg_label}
+
 // String comparison for sorting
 fn name_less_than(a: Name, b: Name) -> bool with Mut, Panic, Div {
     let min_len = if a.len < b.len { a.len } else { b.len }
@@ -102,7 +104,7 @@ fn renumber_labels(func: IrFunction, label_map: [i64; 256]) -> IrFunction with M
     while i < new_func.instr_count {
         let instr = new_func.instrs[i]
         let old_label = instr.label_id
-        let new_label = if old_label >= 0 && old_label < 256 {
+        let new_label = if ir_opcode_has_cfg_label(instr.op) && old_label >= 0 && old_label < 256 {
             let mapped = label_map[old_label]
             if mapped != IR_INVALID_LABEL { mapped } else { old_label }
         } else {

--- a/self-hosted/ir/opt_strategy.sio
+++ b/self-hosted/ir/opt_strategy.sio
@@ -75,7 +75,9 @@ pub fn ir_opt_max_label_ref(func: &IrFunction) -> i64 {
     var i: i64 = 0
     while i < (*func).instr_count {
         let instr = (*func).instrs[i as usize]
-        if instr.label_id > max_id { max_id = instr.label_id }
+        if ir_opcode_has_cfg_label(instr.op) && instr.label_id > max_id {
+            max_id = instr.label_id
+        }
         i = i + 1
     }
     max_id
@@ -106,7 +108,7 @@ pub fn ir_opt_clone_instr(
         src2:      ir_opt_remap_vreg(instr.src2, vreg_offset, param_count),
         imm_i64:   instr.imm_i64,
         imm_f64:   instr.imm_f64,
-        label_id:  ir_opt_remap_label(instr.label_id, label_offset),
+        label_id:  if ir_opcode_has_cfg_label(instr.op) { ir_opt_remap_label(instr.label_id, label_offset) } else { instr.label_id },
         fn_id:     instr.fn_id,
         field_idx: instr.field_idx,
         imm_flags: instr.imm_flags,

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -7,7 +7,7 @@
 module native::codegen
 
 use parser::ast::{Name}
-use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IR_MAX_FUNCS, IR_MAX_STRINGS, BSS_BASE_LINUX, IR_STRATEGY_BSS_GLOBAL}
+use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IR_MAX_FUNCS, IR_MAX_STRINGS, IR_FIELD_MODE_REF, IR_FIELD_MODE_RAW, BSS_BASE_LINUX, IR_STRATEGY_BSS_GLOBAL}
 use native::encode::*
 use native::aarch64::*
 use native::elf::*
@@ -3771,18 +3771,35 @@ fn native_v2_emit_machine_instr(nc: NativeCompiler, instr: MachineInstr) -> Nati
 
     if instr.opcode == MIR_OP_FIELD_LOAD {
         c = native_v2_load_temp_to_rax(c, instr.src1.value)
-        c = native_v2_resolve_handle_to_object_base_rax(c)
-        c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        if instr.arg_index == IR_FIELD_MODE_REF {
+            c.code = emit_load_rax_mem_rax(c.code)
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        } else if instr.arg_index == IR_FIELD_MODE_RAW {
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value)
+        } else {
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        }
         c.code = emit_mov_rax_mem_rax_rbx8(c.code)
         return native_v2_store_rax_to_temp(c, instr.dst.value)
     }
 
     if instr.opcode == MIR_OP_FIELD_STORE {
         c = native_v2_load_temp_to_rax(c, instr.src1.value)
-        c = native_v2_resolve_handle_to_object_base_rax(c)
+        if instr.arg_index == IR_FIELD_MODE_REF {
+            c.code = emit_load_rax_mem_rax(c.code)
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+        } else if instr.arg_index != IR_FIELD_MODE_RAW {
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+        }
         c.code = emit_mov_rdx_rax(c.code)
         c = native_v2_load_temp_to_rax(c, instr.src2.value)
-        c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        if instr.arg_index == IR_FIELD_MODE_RAW {
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value)
+        } else {
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        }
         c.code = emit_store_rax_mem_rdx_rbx8(c.code)
         return c
     }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -7,7 +7,7 @@
 module native::codegen_x86_linux
 
 use parser::ast::{Name}
-use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IR_MAX_FUNCS, IR_MAX_STRINGS, IR_FLOAT_REG_MARKER_FLAG, ir_name_eq, BSS_BASE_LINUX, IR_STRATEGY_BSS_GLOBAL}
+use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IR_MAX_FUNCS, IR_MAX_STRINGS, IR_FLOAT_REG_MARKER_FLAG, IR_FIELD_MODE_MANAGED, IR_FIELD_MODE_REF, IR_FIELD_MODE_RAW, ir_name_eq, BSS_BASE_LINUX, IR_STRATEGY_BSS_GLOBAL}
 use native::encode::*
 use native::elf::*
 use native::aarch64::*
@@ -5623,18 +5623,35 @@ fn native_v2_emit_machine_instr(nc: NativeCompiler, instr: MachineInstr) -> Nati
 
     if instr.opcode == MIR_OP_FIELD_LOAD {
         c = native_v2_load_temp_to_rax(c, instr.src1.value)
-        c = native_v2_resolve_handle_to_object_base_rax(c)
-        c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        if instr.arg_index == IR_FIELD_MODE_REF {
+            c.code = emit_load_rax_mem_rax(c.code)
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        } else if instr.arg_index == IR_FIELD_MODE_RAW {
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value)
+        } else {
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        }
         c.code = emit_mov_rax_mem_rax_rbx8(c.code)
         return native_v2_store_rax_to_temp(c, instr.dst.value)
     }
 
     if instr.opcode == MIR_OP_FIELD_STORE {
         c = native_v2_load_temp_to_rax(c, instr.src1.value)
-        c = native_v2_resolve_handle_to_object_base_rax(c)
+        if instr.arg_index == IR_FIELD_MODE_REF {
+            c.code = emit_load_rax_mem_rax(c.code)
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+        } else if instr.arg_index != IR_FIELD_MODE_RAW {
+            c = native_v2_resolve_handle_to_object_base_rax(c)
+        }
         c.code = emit_mov_rdx_rax(c.code)
         c = native_v2_load_temp_to_rax(c, instr.src2.value)
-        c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        if instr.arg_index == IR_FIELD_MODE_RAW {
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value)
+        } else {
+            c.code = emit_mov_reg_imm(c.code, 3, instr.aux.value + (native_v2_object_header_size() / 8))
+        }
         c.code = emit_store_rax_mem_rdx_rbx8(c.code)
         return c
     }
@@ -6890,7 +6907,12 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             nc_add_rodata_reloc(nc, lea_pos + 3, str_offset)
             nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
         } else if instr_op == IrOpcode::IrFieldGet {
-            if (*func).instrs[i as usize].label_id == 1 {
+            if (*func).instrs[i as usize].label_id == IR_FIELD_MODE_RAW {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx)
+                nc_emit_mov_rax_mem_rax_rbx8(nc)
+                nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
+            } else if (*func).instrs[i as usize].label_id == IR_FIELD_MODE_REF {
                 native_v2_core_emit_load_ref_field_into(nc, (*func).instrs[i as usize].dst, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx)
             } else {
                 nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
@@ -6905,7 +6927,13 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 nc_core_mark_int_reg(nc, (*func).instrs[i as usize].dst)
             }
         } else if instr_op == IrOpcode::IrFieldSet {
-            if (*func).instrs[i as usize].label_id == 1 {
+            if (*func).instrs[i as usize].label_id == IR_FIELD_MODE_RAW {
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
+                nc_emit_mov_rdx_rax(nc)
+                nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src2)
+                nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx)
+                nc_emit_store_rax_mem_rdx_rbx8(nc)
+            } else if (*func).instrs[i as usize].label_id == IR_FIELD_MODE_REF {
                 native_v2_core_emit_store_ref_field_into(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx, (*func).instrs[i as usize].src2)
             } else {
                 nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
@@ -7590,7 +7618,7 @@ fn native_v2_ir_field_get(dst: i64, base_reg: i64, field_idx: i64, field_name: N
         src2: base.src2,
         imm_i64: base.imm_i64,
         imm_f64: base.imm_f64,
-        label_id: base.label_id,
+        label_id: IR_FIELD_MODE_MANAGED,
         fn_id: base.fn_id,
         field_idx: field_idx,
         imm_flags: base.imm_flags,
@@ -7611,7 +7639,7 @@ fn native_v2_ir_field_set(base_reg: i64, field_idx: i64, src: i64, field_name: N
         src2: src,
         imm_i64: base.imm_i64,
         imm_f64: base.imm_f64,
-        label_id: base.label_id,
+        label_id: IR_FIELD_MODE_MANAGED,
         fn_id: base.fn_id,
         field_idx: field_idx,
         imm_flags: base.imm_flags,

--- a/self-hosted/native/machine_ir.sio
+++ b/self-hosted/native/machine_ir.sio
@@ -5,7 +5,7 @@
 module native::machine_ir
 
 use parser::ast::{Name, BinaryOp, UnaryOp, empty_name}
-use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX, IR_FLOAT_REG_MARKER_FLAG}
+use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX, IR_FLOAT_REG_MARKER_FLAG, IR_FIELD_MODE_MANAGED, IR_FIELD_MODE_REF, IR_FIELD_MODE_RAW}
 
 pub let MIR_MAX_BLOCKS: i64 = 1
 pub let MIR_MAX_INSTRS: i64 = 1024
@@ -196,6 +196,12 @@ pub fn machine_instr_src2_value(instr: MachineInstr) -> i64 {
 
 pub fn machine_instr_aux_value(instr: MachineInstr) -> i64 {
     instr.aux.value
+}
+
+// Field ops use arg_index as their opcode-specific address-mode payload. It is
+// otherwise meaningful only for MIR_OP_ARG_MOVE.
+pub fn machine_instr_field_mode(instr: MachineInstr) -> i64 {
+    instr.arg_index
 }
 
 pub fn machine_instr_src1_kind(instr: MachineInstr) -> i64 {
@@ -501,6 +507,7 @@ pub fn native_v2_pseudo_from_ir(instr: IrInstr) -> MachineInstr with Alloc, Mut,
         mi.dst = machine_operand_stack_slot(instr.dst)
         mi.src1 = machine_operand_stack_slot(instr.src1)
         mi.aux = machine_operand_imm64(instr.field_idx)
+        mi.arg_index = instr.label_id
         return mi
     }
     if instr.op == IrOpcode::IrFieldSet {
@@ -508,6 +515,7 @@ pub fn native_v2_pseudo_from_ir(instr: IrInstr) -> MachineInstr with Alloc, Mut,
         mi.src1 = machine_operand_stack_slot(instr.src1)
         mi.src2 = machine_operand_stack_slot(instr.src2)
         mi.aux = machine_operand_imm64(instr.field_idx)
+        mi.arg_index = instr.label_id
         return mi
     }
     if instr.op == IrOpcode::IrIndexGet {
@@ -768,21 +776,23 @@ pub fn native_v2_make_alloc(temp: i64, alloc_size: i64, descriptor_id: i64) -> M
     mi
 }
 
-pub fn native_v2_make_field_load(dst: i64, base: i64, field_idx: i64) -> MachineInstr with Mut, Panic, Div {
+pub fn native_v2_make_field_load(dst: i64, base: i64, field_idx: i64, field_mode: i64) -> MachineInstr with Mut, Panic, Div {
     var mi = machine_empty_instr()
     mi.opcode = MIR_OP_FIELD_LOAD
     mi.dst = machine_operand_gpr64(dst)
     mi.src1 = machine_operand_gpr64(base)
     mi.aux = machine_operand_imm64(field_idx)
+    mi.arg_index = field_mode
     mi
 }
 
-pub fn native_v2_make_field_store(base: i64, src: i64, field_idx: i64) -> MachineInstr with Mut, Panic, Div {
+pub fn native_v2_make_field_store(base: i64, src: i64, field_idx: i64, field_mode: i64) -> MachineInstr with Mut, Panic, Div {
     var mi = machine_empty_instr()
     mi.opcode = MIR_OP_FIELD_STORE
     mi.src1 = machine_operand_gpr64(base)
     mi.src2 = machine_operand_gpr64(src)
     mi.aux = machine_operand_imm64(field_idx)
+    mi.arg_index = field_mode
     mi
 }
 
@@ -1242,7 +1252,7 @@ pub fn native_v2_lower_legal_function_from_ir_ref(func: &IrFunction, out: &! Mac
             let dst = (*out).temp_count
             (*out).temp_count = dst + 1
             native_v2_emit_legal_instr_mut(out, native_v2_make_load_stack(base, machine_instr_src1_value(instr)))
-            native_v2_emit_legal_instr_mut(out, native_v2_make_field_load(dst, base, machine_instr_aux_value(instr)))
+            native_v2_emit_legal_instr_mut(out, native_v2_make_field_load(dst, base, machine_instr_aux_value(instr), machine_instr_field_mode(instr)))
             native_v2_emit_legal_instr_mut(out, native_v2_make_store_stack(machine_instr_dst_value(instr), dst))
         } else if instr.opcode == MIR_OP_PSEUDO_FIELD_SET {
             let base = (*out).temp_count
@@ -1251,7 +1261,7 @@ pub fn native_v2_lower_legal_function_from_ir_ref(func: &IrFunction, out: &! Mac
             (*out).temp_count = src + 1
             native_v2_emit_legal_instr_mut(out, native_v2_make_load_stack(base, machine_instr_src1_value(instr)))
             native_v2_emit_legal_instr_mut(out, native_v2_make_load_stack(src, machine_instr_src2_value(instr)))
-            native_v2_emit_legal_instr_mut(out, native_v2_make_field_store(base, src, machine_instr_aux_value(instr)))
+            native_v2_emit_legal_instr_mut(out, native_v2_make_field_store(base, src, machine_instr_aux_value(instr), machine_instr_field_mode(instr)))
         } else if instr.opcode == MIR_OP_PSEUDO_INDEX_GET {
             let base = (*out).temp_count
             (*out).temp_count = base + 1
@@ -1431,7 +1441,7 @@ pub fn native_v2_legalize_function(func: MachineFunction) -> MachineFunction wit
             let dst = out.temp_count
             out.temp_count = dst + 1
             out = _emit_legal_byval(out, native_v2_make_load_stack(base, machine_instr_src1_value(instr)))
-            out = _emit_legal_byval(out, native_v2_make_field_load(dst, base, machine_instr_aux_value(instr)))
+            out = _emit_legal_byval(out, native_v2_make_field_load(dst, base, machine_instr_aux_value(instr), machine_instr_field_mode(instr)))
             out = _emit_legal_byval(out, native_v2_make_store_stack(machine_instr_dst_value(instr), dst))
         } else if instr.opcode == MIR_OP_PSEUDO_FIELD_SET {
             let base = out.temp_count
@@ -1440,7 +1450,7 @@ pub fn native_v2_legalize_function(func: MachineFunction) -> MachineFunction wit
             out.temp_count = src + 1
             out = _emit_legal_byval(out, native_v2_make_load_stack(base, machine_instr_src1_value(instr)))
             out = _emit_legal_byval(out, native_v2_make_load_stack(src, machine_instr_src2_value(instr)))
-            out = _emit_legal_byval(out, native_v2_make_field_store(base, src, machine_instr_aux_value(instr)))
+            out = _emit_legal_byval(out, native_v2_make_field_store(base, src, machine_instr_aux_value(instr), machine_instr_field_mode(instr)))
         } else if instr.opcode == MIR_OP_PSEUDO_INDEX_GET {
             let base = out.temp_count
             out.temp_count = base + 1
@@ -1568,9 +1578,11 @@ pub fn native_v2_machine_instr_is_legal(instr: MachineInstr) -> bool with Mut, P
     }
     if instr.opcode == MIR_OP_FIELD_LOAD {
         return instr.dst.kind == MIR_OPERAND_GPR64 && instr.src1.kind == MIR_OPERAND_GPR64 && instr.aux.kind == MIR_OPERAND_IMM64
+            && (instr.arg_index == IR_FIELD_MODE_MANAGED || instr.arg_index == IR_FIELD_MODE_REF || instr.arg_index == IR_FIELD_MODE_RAW)
     }
     if instr.opcode == MIR_OP_FIELD_STORE {
         return instr.src1.kind == MIR_OPERAND_GPR64 && instr.src2.kind == MIR_OPERAND_GPR64 && instr.aux.kind == MIR_OPERAND_IMM64
+            && (instr.arg_index == IR_FIELD_MODE_MANAGED || instr.arg_index == IR_FIELD_MODE_REF || instr.arg_index == IR_FIELD_MODE_RAW)
     }
     if instr.opcode == MIR_OP_INDEX_LOAD {
         return instr.dst.kind == MIR_OPERAND_GPR64 && instr.src1.kind == MIR_OPERAND_GPR64 && instr.src2.kind == MIR_OPERAND_GPR64

--- a/tests/compile-fail/raw_array_field_projection.sio
+++ b/tests/compile-fail/raw_array_field_projection.sio
@@ -1,0 +1,21 @@
+//@ compile-fail
+// expected: error[E229]
+//@ error-pattern: raw inline aggregate field projection requires Place IR
+
+struct RawArrayFieldProjection {
+    singleton: [i64; 1],
+    wide: [f64; 2],
+    tail: i64,
+}
+
+fn reject_singleton_projection(p: *const RawArrayFieldProjection) -> [i64; 1] {
+    (*p).singleton
+}
+
+fn reject_wide_projection(p: *const RawArrayFieldProjection) -> [f64; 2] {
+    (*p).wide
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/compile-fail/raw_array_field_projection.sio
+++ b/tests/compile-fail/raw_array_field_projection.sio
@@ -1,4 +1,5 @@
 //@ compile-fail
+//@ requires: madaros
 // expected: error[E229]
 //@ error-pattern: raw inline aggregate field projection requires Place IR
 

--- a/tests/compile-fail/raw_const_field_store.sio
+++ b/tests/compile-fail/raw_const_field_store.sio
@@ -1,0 +1,14 @@
+//@ compile-fail
+//@ error-pattern: immutable
+
+struct RawConstFieldStore {
+    value: f64,
+}
+
+fn reject_const_store(p: *const RawConstFieldStore) with Mut {
+    (*p).value = 1.0
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/compile-fail/raw_const_field_store.sio
+++ b/tests/compile-fail/raw_const_field_store.sio
@@ -1,4 +1,5 @@
 //@ compile-fail
+//@ requires: madaros
 //@ error-pattern: immutable
 
 struct RawConstFieldStore {

--- a/tests/compile-fail/raw_nonident_field_read.sio
+++ b/tests/compile-fail/raw_nonident_field_read.sio
@@ -1,0 +1,15 @@
+//@ compile-fail
+// expected: error[E230]
+//@ error-pattern: raw field projection requires an identifier pointer operand
+
+struct RawNonIdentFieldRead {
+    value: i64,
+}
+
+fn reject_nonident_read(addr: i64) -> i64 {
+    (*(addr as *const RawNonIdentFieldRead)).value
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/compile-fail/raw_nonident_field_store.sio
+++ b/tests/compile-fail/raw_nonident_field_store.sio
@@ -1,0 +1,15 @@
+//@ compile-fail
+// expected: error[E230]
+//@ error-pattern: raw field projection requires an identifier pointer operand
+
+struct RawNonIdentFieldStore {
+    value: i64,
+}
+
+fn reject_nonident_store(addr: i64) with Mut {
+    (*(addr as *mut RawNonIdentFieldStore)).value = 1
+}
+
+fn main() -> i64 {
+    0
+}

--- a/tests/compile-fail/raw_nonident_field_store.sio
+++ b/tests/compile-fail/raw_nonident_field_store.sio
@@ -1,4 +1,5 @@
 //@ compile-fail
+//@ requires: madaros
 // expected: error[E230]
 //@ error-pattern: raw field projection requires an identifier pointer operand
 

--- a/tests/native-v2/raw_ptr_field_semantics_witness.sio
+++ b/tests/native-v2/raw_ptr_field_semantics_witness.sio
@@ -1,0 +1,69 @@
+//@ run-pass
+//@ expect-stdout: PASS raw_ptr_field_semantics
+
+struct RawFieldNested {
+    marker: i64,
+}
+
+// Physical word layout: prefix=0..1, nested=2, value=3, tail=4.
+struct RawFieldWide {
+    prefix: [f64; 2],
+    nested: RawFieldNested,
+    value: f64,
+    tail: i64,
+}
+
+// `value` deliberately collides at a different physical offset.
+struct RawFieldCollision {
+    value: f64,
+    guard: i64,
+}
+
+fn read_const_value(p: *const RawFieldWide) -> f64 {
+    (*p).value
+}
+
+fn read_nested_marker(p: *const RawFieldWide) -> i64 {
+    (*p).nested.marker
+}
+
+fn write_from_callee(
+    p: *mut RawFieldWide,
+    nested: RawFieldNested,
+    value: f64,
+    tail: i64,
+) with Mut {
+    (*p).nested = nested
+    (*p).value = value
+    (*p).tail = tail
+}
+
+fn write_collision(p: *mut RawFieldCollision, value: f64, guard: i64) with Mut {
+    (*p).value = value
+    (*p).guard = guard
+}
+
+fn main() -> i64 with IO, Mut, Panic, Alloc {
+    let wide = heap_alloc(40) as *mut RawFieldWide
+    let collision = heap_alloc(16) as *mut RawFieldCollision
+
+    let nested = RawFieldNested { marker: 73 }
+    write_from_callee(wide, nested, 19.25, 91)
+    assert(read_const_value(wide as *const RawFieldWide) == 19.25)
+    assert(read_nested_marker(wide as *const RawFieldWide) == 73)
+    assert((*wide).tail == 91)
+
+    write_collision(collision, 7.5, 101)
+    assert((*collision).value == 7.5)
+    assert((*collision).guard == 101)
+
+    // A second caller-visible mutation proves the callee wrote the raw
+    // reservation, not a lowered temporary or managed object copy.
+    write_from_callee(wide, RawFieldNested { marker: 88 }, 33.5, 111)
+    assert((*wide).value == 33.5)
+    assert((*wide).nested.marker == 88)
+    assert((*wide).tail == 111)
+
+    println("PASS raw_ptr_field_semantics")
+    0
+}


### PR DESCRIPTION
## Stack contract

- **DO NOT MERGE** independently. This PR is stacked on #889 (`codex/ref-field-autoderef-e304-20260714`, exact parent `17b0858f6e7d75c9cfc9e545b1b9f0805fa9d5d6`).
- This is the final legacy field-address mode. After this checkpoint, legacy lowering remains a differential oracle; new address/place/ownership semantics belong in the successor IR.
- No heap consumer or SOIR serializer files are changed.

## What changed

- Adds compiler-owned physical `offset_words`, `storage_words`, and `raw_projectable` metadata for named struct fields.
- Defines opcode-local field address modes `managed=0`, `ref=1`, `raw=2`, preserved through Machine IR and direct x86 `[base + offset_words * 8]` emission.
- Supports terminal `(*identifier_raw_pointer_to_named_struct).field` reads through `*const`/`*mut` and writes through `*mut`, including fixed-array offset shifts, named-aggregate handle slots, colliding field names, calls, and f64 classification.
- Keeps managed/reference behavior distinct and prevents CFG inlining, instrumented cloning, and normalization from rewriting non-CFG `label_id` payloads.
- Fails closed for `*const` stores (`E003`), inline aggregate projections (`E229`), and non-identifier raw pointer projections (`E230`).
- Documents the terminal contract and registers E229/E230 with collision guards.

## Normalization note

`normalize.sio` now declares its minimal dependency on `ir_opcode_has_cfg_label`. Its standalone packaged check improves from the historical 13 diagnostics (`E015=2`, `E137=11`) to `rc=0`; the remaining touched compiler files preserve their exact baseline diagnostic categories.

## Validation

- Source-fresh Madaros build: `rc=0`, elapsed `3:15.00`, max RSS `513692 KiB`, size `107821676` bytes.
- Compiler SHA256: `b9bdd0fe4e51db7269c2b60c3d46001508a541c599bea4d03d7dad2b0953aaff`.
- Raw witness: compile `rc=0`, run `rc=0`, exact stdout `PASS raw_ptr_field_semantics`.
- #889 ref witness: compile `rc=0`, run `rc=0`, exact stdout `PASS ref_field_autoderef_semantics`.
- Const raw store: check/compile `rc=1`, `E003`, no output.
- Singleton + wide inline arrays: check/compile `rc=1`, two `E229`, no output.
- Non-identifier raw read and store: each check/compile `rc=1`, `E230`, no output.
- `bash scripts/ci/raw_ptr_field_semantics_gate.sh`: PASS (includes #889 ref static gate).
- `bash scripts/dev/check_docs_registry.sh`: PASS, including registry selftest.
- `git diff --check`: PASS.

## Separate blocker receipt

Using the exact compiler SHA above, `scripts/ci/ir_module_heap_bridge_gate.sh` remains isolated at `IR_MODULE_HEAP_BRIDGE_STAGE_FAIL code=165`, `reason=semantic_assertion`, `reason=internal_self_test_rc_1`. This PR does not edit that consumer lane.


## CI routing receipt (9c067532d)

- The three generation-sensitive cases remain `compile-fail`; no semantic test was weakened or converted to positive.
- Added `//@ requires: madaros` to `raw_array_field_projection`, `raw_const_field_store`, and `raw_nonident_field_store`, so the promoted/stale full-suite compiler reports exactly `0 pass / 0 fail / 3 skip`.
- Extended the current-source changed-test selector to annotated `tests/compile-fail/*.sio`; select-only returned exactly those three cases and ignored an unannotated negative plus unrelated paths.
- Reused source-fresh Madaros ELF SHA256 `e7a176404de16014671a551804c0c0b806a5936855dc7fbc36cfb3ed0e23804f`: changed-tests gate reported `3 pass / 0 fail / 0 skip` and `MADAROS_CHANGED_TESTS_PASS count=3`.
- `bash -n`, `madaros_changed_tests_selftest.sh`, `raw_ptr_field_semantics_gate.sh`, and `git diff --check`: PASS. `shellcheck` was unavailable in this workspace.
