### PR TITLE
test(ir): preserve terminal heap identity receipt [DO NOT MERGE]

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -17,6 +17,7 @@ use ir::heap_storage::{
     ir_module_heap_roundtrip_self_test_code,
     ir_module_heap_self_test_observed_len,
     ir_module_heap_self_test_observed_result,
+    ir_module_heap_self_test_observed_scalar,
     IR_MODULE_HEAP_SELF_TEST_PASS,
     IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT,
     IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT,
@@ -27931,6 +27932,10 @@ fn main() with IO, Mut, Panic, Div, Alloc {
         let observed_len = ir_module_heap_self_test_observed_len()
         if observed_len >= 0 {
             println("IR_MODULE_HEAP_BRIDGE_OBSERVED len=" + int_to_string(observed_len))
+        }
+        let observed_scalar = ir_module_heap_self_test_observed_scalar()
+        if observed_scalar >= 0 {
+            println("IR_MODULE_HEAP_BRIDGE_OBSERVED scalar=" + int_to_string(observed_scalar))
         }
         if heap_self_test_code == IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT ||
            heap_self_test_code == IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT {

--- a/self-hosted/ir/heap_storage.sio
+++ b/self-hosted/ir/heap_storage.sio
@@ -407,9 +407,17 @@ pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESET_COUNT: i64 = 167
 pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_PUBLISHED_COUNT: i64 = 168
 pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_RESULT: i64 = 169
 pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_RELEASE: i64 = 170
+// 165 is the legacy composite extension receipt. The failure-only receipts
+// below isolate its epistemic handle/ref boundaries without widening the
+// terminal adapter or instrumenting the later algebra path.
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_HANDLE_WORD_ZERO: i64 = 171
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_SETTER_FALSE: i64 = 172
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_SAME_LOCAL_COUNT: i64 = 173
+pub let IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_FRESH_RAW_RELOAD_COUNT: i64 = 174
 
 var IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN: i64 = -1
 var IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT: i64 = 0
+var IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR: i64 = -1
 
 pub fn ir_module_heap_self_test_observed_len() -> i64 {
     IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN
@@ -419,11 +427,23 @@ pub fn ir_module_heap_self_test_observed_result() -> i64 {
     IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT
 }
 
+pub fn ir_module_heap_self_test_observed_scalar() -> i64 {
+    IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR
+}
+
+// Evidence-only native-v2 slot observation. The shared reference ends at this
+// leaf boundary, so the caller can acquire the later exclusive leaf borrow.
+fn ir_module_heap_self_test_epistemic_handle_word(handle_slot: &IrEpistemicSection) -> i64 {
+    let raw_slot = handle_slot as *const i64
+    (*raw_slot)
+}
+
 // Shared semantic witness used by T17 and by the source-fresh Madaros internal
 // self-test. One implementation keeps CI on the actual SOIR v5/v4 bridge.
 pub fn ir_module_heap_roundtrip_self_test_code() -> i64 with Mut, Panic, Div, Alloc {
     IR_MODULE_HEAP_SELF_TEST_OBSERVED_LEN = -1
     IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT = 0
+    IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR = -1
     var owner = ir_module_heap_new()
     if !ir_module_heap_is_allocated(&owner) {
         return ir_module_heap_self_test_fail(&! owner, IR_MODULE_HEAP_SELF_TEST_ALLOC)
@@ -650,12 +670,32 @@ pub fn ir_module_heap_roundtrip_self_test_code() -> i64 with Mut, Panic, Div, Al
     if !ir_module_heap_is_allocated(&extension_owner) {
         return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_ALLOC)
     }
-    var extension_epistemic = (*extension_owner.ptr).epistemic
-    extension_epistemic.model_family_count = 1
-    (*extension_owner.ptr).epistemic = extension_epistemic
-    let published_extension_epistemic = (*extension_owner.ptr).epistemic
-    if published_extension_epistemic.model_family_count != 1 {
-        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_PUBLISHED_COUNT)
+    // This is the last adapter for the legacy raw-module representation. The
+    // raw field holds a compiler-runtime aggregate handle: stage that handle,
+    // borrow it only for the leaf call, and never republish or swap the slot.
+    var extension_epistemic_handle = (*extension_owner.ptr).epistemic
+    // Evidence-only observation of the native aggregate handle word stored in
+    // this local slot. This distinguishes zero/nonzero; it does not claim that
+    // a nonzero word is valid in the runtime handle table.
+    let extension_epistemic_handle_word = ir_module_heap_self_test_epistemic_handle_word(&extension_epistemic_handle)
+    if extension_epistemic_handle_word == 0 {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR = extension_epistemic_handle_word
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_HANDLE_WORD_ZERO)
+    }
+    if !ir_epistemic_set_model_family_count_for_heap_bridge(&! extension_epistemic_handle, 1) {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR = 0
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_SETTER_FALSE)
+    }
+    let same_local_epistemic_count = ir_epistemic_model_family_count(&extension_epistemic_handle)
+    if same_local_epistemic_count != 1 {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR = same_local_epistemic_count
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_SAME_LOCAL_COUNT)
+    }
+    let published_extension_epistemic_handle = (*extension_owner.ptr).epistemic
+    let fresh_raw_reload_epistemic_count = ir_epistemic_model_family_count(&published_extension_epistemic_handle)
+    if fresh_raw_reload_epistemic_count != 1 {
+        IR_MODULE_HEAP_SELF_TEST_OBSERVED_SCALAR = fresh_raw_reload_epistemic_count
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_FRESH_RAW_RELOAD_COUNT)
     }
     var extension_buf: [i8; 131072] = [0; 131072]
     let epistemic_extension_result = ir_module_heap_serialize_result_into(&extension_owner, &! extension_buf)
@@ -663,18 +703,20 @@ pub fn ir_module_heap_roundtrip_self_test_code() -> i64 with Mut, Panic, Div, Al
         IR_MODULE_HEAP_SELF_TEST_OBSERVED_RESULT = epistemic_extension_result
         return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESULT)
     }
-    extension_epistemic = (*extension_owner.ptr).epistemic
-    extension_epistemic.model_family_count = 0
-    (*extension_owner.ptr).epistemic = extension_epistemic
-    let reset_extension_epistemic = (*extension_owner.ptr).epistemic
-    if reset_extension_epistemic.model_family_count != 0 {
+    var reset_extension_epistemic_handle = (*extension_owner.ptr).epistemic
+    if !ir_epistemic_set_model_family_count_for_heap_bridge(&! reset_extension_epistemic_handle, 0) {
         return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESET_COUNT)
     }
-    var extension_algebras = (*extension_owner.ptr).algebras
-    extension_algebras.count = 1
-    (*extension_owner.ptr).algebras = extension_algebras
-    let published_extension_algebras = (*extension_owner.ptr).algebras
-    if published_extension_algebras.count != 1 {
+    let reset_extension_epistemic_handle_readback = (*extension_owner.ptr).epistemic
+    if ir_epistemic_model_family_count(&reset_extension_epistemic_handle_readback) != 0 {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_EPISTEMIC_RESET_COUNT)
+    }
+    var extension_algebras_handle = (*extension_owner.ptr).algebras
+    if !ir_algebra_table_set_count_for_heap_bridge(&! extension_algebras_handle, 1) {
+        return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_PUBLISHED_COUNT)
+    }
+    let published_extension_algebras_handle = (*extension_owner.ptr).algebras
+    if ir_algebra_table_count(&published_extension_algebras_handle) != 1 {
         return ir_module_heap_self_test_fail(&! extension_owner, IR_MODULE_HEAP_SELF_TEST_EXTENSION_ALGEBRA_PUBLISHED_COUNT)
     }
     let algebra_extension_result = ir_module_heap_serialize_result_into(&extension_owner, &! extension_buf)

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -20,6 +20,7 @@ pub let IR_INVALID_FN: i64 = -1
 pub let IR_FIELD_MODE_MANAGED: i64 = 0
 pub let IR_FIELD_MODE_REF: i64 = 1
 pub let IR_FIELD_MODE_RAW: i64 = 2
+pub let IR_MAX_ALGEBRAS: i64 = 32
 pub let IR_MAX_EPI_MODEL_FAMILIES: i64 = 32
 pub let IR_MAX_EPI_POLICIES: i64 = 32
 pub let IR_MAX_EPI_DECISION_POLICIES: i64 = 32
@@ -782,6 +783,18 @@ pub fn ir_empty_algebra_table() -> IrAlgebraTable {
         entries: [ir_empty_algebra_info(); 32],
         count: 0,
     }
+}
+
+pub fn ir_algebra_table_count(table: &IrAlgebraTable) -> i64 {
+    (*table).count
+}
+
+// Terminal adapter for the legacy heap bridge. New storage must own mutation
+// through IrModuleArena v2 rather than widening this field-by-field surface.
+pub fn ir_algebra_table_set_count_for_heap_bridge(table: &! IrAlgebraTable, count: i64) -> bool with Mut {
+    if count < 0 || count > IR_MAX_ALGEBRAS { return false }
+    (*table).count = count
+    true
 }
 
 // Returns correctly-initialized IrAlgebraInfo for each Cayley-Dickson / Clifford algebra.
@@ -1949,6 +1962,18 @@ pub fn ir_empty_epistemic_section() -> IrEpistemicSection {
         hyper_exprs: [ir_empty_hyper_expr_info(); 128],
         hyper_expr_count: 0,
     }
+}
+
+pub fn ir_epistemic_model_family_count(epistemic: &IrEpistemicSection) -> i64 {
+    (*epistemic).model_family_count
+}
+
+// Terminal adapter for the legacy heap bridge. New storage must own mutation
+// through IrModuleArena v2 rather than widening this field-by-field surface.
+pub fn ir_epistemic_set_model_family_count_for_heap_bridge(epistemic: &! IrEpistemicSection, count: i64) -> bool with Mut {
+    if count < 0 || count > IR_MAX_EPI_MODEL_FAMILIES { return false }
+    (*epistemic).model_family_count = count
+    true
 }
 
 // Build a heap IrEpistemicSection in THIS leaf's own short frame and return only


### PR DESCRIPTION
# DO NOT MERGE

This is a stacked diagnostic checkpoint on draft #897. It preserves the final falsifying receipt for the legacy raw-module bridge; it is not a merge-ready heap implementation.

## Stack contract

- parent PR: #897
- exact parent head: `9c067532d327c50ce451be3053e044c67882d8b3`
- checkpoint head: `984cb982a8fdb88c3d835bae3e4f8ce993afcce2`
- no force-push or edit to #897

## What changed

- adds bounded, compiler-owned leaf getters and terminal heap-bridge-only setters for `IrEpistemicSection.model_family_count` and private `IrAlgebraTable.count`;
- replaces whole-aggregate republish in the extension witness with raw-slot load -> local managed handle -> synchronous leaf borrow;
- keeps receipt 165 reserved and adds failure-only receipts 171-174 for handle word, setter result, same-local readback, and fresh raw-slot readback;
- adds a failure-only observed scalar, reset on every run and printed only when non-negative;
- does not change SOIR, wire format, default serializer, lowering, checker, Machine IR, codegen, or release behavior.

The setters validate `0..32` before mutation and carry only `Mut`. The handle-word probe observes only zero versus nonzero in a local native-v2 slot; it does not claim runtime handle-table validity.

## Exact dynamic receipt

One source-fresh evidence build was run with 65536 KiB stack, `/tmp/sounio-souc-build.lock`, and `/usr/bin/time -v`:

```text
build rc     0
wall         3:15.75
user/system  194.94 s / 0.73 s
max RSS      513180 KiB
ELF size     107824024 bytes
ELF SHA256   f841534799c53be79801c31d218b6f76bb1e7dfe3958b0c441475f516abfe3f7
version      Madaros v0.80.0 -- the Sounio self-hosted compiler
```

The exact-SHA heap gate was the first and only post-build gate:

```text
IR_MODULE_HEAP_BRIDGE_OBSERVED scalar=0
IR_MODULE_HEAP_BRIDGE_STAGE_FAIL code=174
IR_MODULE_HEAP_BRIDGE_FAIL reason=semantic_assertion
IR_MODULE_HEAP_BRIDGE_FAIL reason=internal_self_test_rc_1
```

Receipt interpretation is bounded and exact:

- 171 passed: the initially loaded local handle word was nonzero;
- 172 passed: the validated leaf setter returned true;
- 173 passed: the same-local getter observed count 1;
- 174 failed with scalar 0: a fresh raw-slot reload observed the original zero count.

The evidence build predates only the parent CI-routing commit `9c0675`; that parent changes two CI scripts and three compile-fail annotations, not compiler sources. The three compiler files in this checkpoint are unchanged by that routing commit.

## Conclusion

Legacy aggregate local materialization does not preserve canonical identity across a fresh raw-slot reload. The local reference mutation is real, but it is detached from the identity observed through the legacy raw module slot.

This receipt does not by itself distinguish detached aggregate-value materialization from an exact-slot identity mismatch. It does falsify the publication assumption required to make this bridge canonical.

No further legacy field-address extension is authorized. The legacy path remains a differential oracle. The next owner is IrModuleArena v2, which must prove canonical identity and parity against this checkpoint rather than inherit its aliasing model.

The algebra stage was not reached and received no new instrumentation.

## Static validation

- `git diff --check`: PASS
- packaged checker, `self-hosted/ir/ir.sio`: PASS
- packaged checker, `self-hosted/ir/heap_storage.sio`: PASS
- standalone `main.sio` diagnostics: exact base/lane parity (31 historical parse errors, identical E-code counts, 32632 lines)
- two orthogonal read-only reviews: CLEAN

No LLM offload was required: this checkpoint changes neither math/clinical claims nor external-facing artifacts.

Related: #882, #887, #889, #897.