### PR TITLE
fix(epistemic,units): negative-value display in gum_report/quantity_show (workaround #890)

### DIFF
--- a/scripts/negative_display_gate.sh
+++ b/scripts/negative_display_gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== gum_report negative =="
+if $SOUC compile tests/stdlib/epistemic/test_gum_negative.sio -o "$OUT/g.elf"; then
+  "$OUT/g.elf" | grep -q -- "delta = -5.000000" || { echo "FAIL: gum_report negative"; fail=1; }
+else echo "FAIL: gum negative compile"; fail=1; fi
+echo "== quantity_show negative =="
+if $SOUC compile tests/stdlib/units/test_units_negative.sio -o "$OUT/u.elf"; then
+  "$OUT/u.elf" | grep -q -- "offset = -10.000000" || { echo "FAIL: quantity_show negative"; fail=1; }
+else echo "FAIL: units negative compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "NEGATIVE_DISPLAY_GATE_OK"
+exit $fail

--- a/stdlib/epistemic/gum.sio
+++ b/stdlib/epistemic/gum.sio
@@ -260,7 +260,10 @@ pub fn gum_k95(r: GUMResult) -> f64 { r.k95 }
 pub fn gum_report(label: string, unit: string, r: GUMResult) with IO, Mut, Div, Panic {
     print(label)
     print(" = ")
-    print(gum_value(r))
+    // negative-safe: print(f64) drops the magnitude of negatives on current Madaros
+    // (docs/audit/MADAROS_PRINT_NEGATIVE_F64_2026-07-14.md); the value may be negative.
+    let v = gum_value(r)
+    if v < 0.0 { print("-"); print(0.0 - v) } else { print(v) }
     print(" ± ")
     print(gum_u95(r))
     print(" ")

--- a/stdlib/units/lib.sio
+++ b/stdlib/units/lib.sio
@@ -324,7 +324,10 @@ pub fn dim_show(d: UnitDim) with IO, Mut {
 pub fn quantity_show(label: string, q: Quantity) with IO, Mut, Div, Panic {
     print(label)
     print(" = ")
-    print(q.value)
+    // negative-safe: print(f64) drops the magnitude of negatives on current Madaros
+    // (docs/audit/MADAROS_PRINT_NEGATIVE_F64_2026-07-14.md); the value may be negative.
+    let v = q.value
+    if v < 0.0 { print("-"); print(0.0 - v) } else { print(v) }
     print(" ± ")
     print(q.uncertainty)
     print(" ")

--- a/tests/stdlib/epistemic/test_gum_negative.sio
+++ b/tests/stdlib/epistemic/test_gum_negative.sio
@@ -1,0 +1,8 @@
+// Regression: gum_report must render a negative value correctly (not -0.000000).
+// Guards docs/audit/MADAROS_PRINT_NEGATIVE_F64_2026-07-14.md workaround.
+use epistemic::gum::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let r = gum_simple(0.0 - 5.0, 0.3)
+    gum_report("delta", "K", r)
+    return 0
+}

--- a/tests/stdlib/units/test_units_negative.sio
+++ b/tests/stdlib/units/test_units_negative.sio
@@ -1,0 +1,7 @@
+// Regression: quantity_show must render a negative value correctly (not -0.000000).
+use units::lib::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let q = quantity_new(0.0 - 10.0, 0.5, dim_length())
+    quantity_show("offset", q)
+    return 0
+}


### PR DESCRIPTION
## Fix negative-value display in `gum_report` and `quantity_show`

Follow-up to #892, which discovered that `print(f64)` drops the magnitude of negative floats (#890). That bug latently affected the merged display helpers `epistemic::gum::gum_report` (#860) and `units::lib::quantity_show` (#873): a negative value printed as `-0.000000`. Their shipped examples used positive values, so CI stayed green, but it's a real correctness gap.

### Fix
Both helpers now print the sign manually and the positive magnitude (inlined — matching `linalg::matnm_show`; a cross-module helper call segfaults). Values were always correct; this is display-only.

Before → after:
- `delta = -0.000000 ± 0.588 K` → `delta = -5.000000 ± 0.588000 K`
- `offset = -0.000000 ± 0.5 m` → `offset = -10.000000 ± 0.500000 m`

### Regression
`tests/stdlib/epistemic/test_gum_negative.sio` + `tests/stdlib/units/test_units_negative.sio` + `scripts/negative_display_gate.sh` (greps for the correct negative output) → `NEGATIVE_DISPLAY_GATE_OK`.

Underlying compiler bug remains tracked in #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
