### PR TITLE
feat(stats): concordance, rate_epi, weibull_negbin (3 new suite modules)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2675,3 +2675,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 ## 2026-07-14 — math-review: stats::reliability
 - File: `stdlib/stats/reliability.sio` (new). ICC(2,1) via ANOVA mean squares + Cronbach's alpha. Provider: xAI/Grok 4.3 = **PASS** — ICC formula, SS/MS decomposition, Cronbach formula, item/total variance estimators, test data all verified.
 - Funnel-plot figure (examples/stats/funnel_plot.sio) added. Correlation-heatmap figure attempted but DROPPED: needs a data matrix live during many render calls (custom pixel loops / plot_band with data[256]+corr[64] live) -> #852 crash. The funnel worked (no separate data matrix; proven plot path only).
+
+## 2026-07-14 — math-review: stats::concordance, stats::rate_epi, stats::weibull_negbin
+- Files (all new): `stdlib/stats/concordance.sio` (Lin's CCC + Cliff's delta), `stdlib/stats/rate_epi.sio` (person-time incidence rate / IRR / rate difference with Poisson-log & Wald CIs), `stdlib/stats/weibull_negbin.sio` (Weibull pdf/cdf/quantile/median/hazard/mean + negative-binomial pmf/cdf/mean via log-gamma). Provider: xAI/Grok 4.3.
+- concordance = **PASS**: CCC population-moment formula matches Lin (1989); Cliff δ definition + magnitude bins match Cliff (1993); all test values verified to 1e-3.
+- rate_epi = **PASS**: rate=a/pt, SE(ln rate)=1/√a, SE(ln IRR)=√(1/a1+1/a2), Var(r̂)=a/pt² all confirmed against Rothman §14; range-reduced exp/ln/sqrt accuracy sufficient.
+- weibull_negbin = **PASS**: all Weibull & NegBin closed forms match references; hazard=f/S reduction and mean=λΓ(1+1/k) correct; log-gamma binomial coefficient + geometric special case algebraically correct. No errors.
+- Suite selftest: 30 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-mS7gGT/`, `/tmp/llm-offload-Y62RoO/`, `/tmp/llm-offload-sF2UHr/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -34,6 +34,9 @@ MODULES=(
   stdlib/stats/epidemiology.sio
   stdlib/stats/sample_size.sio
   stdlib/stats/reliability.sio
+  stdlib/stats/concordance.sio
+  stdlib/stats/rate_epi.sio
+  stdlib/stats/weibull_negbin.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -471,6 +471,48 @@ ICC(2,1) (two-way random, single rater) via the ANOVA mean squares, and Cronbach
 alpha for scale internal consistency, from a subjects×raters/items matrix.
 Validated: perfect agreement → ICC 1.0; a 4×3 example → α 0.930.
 
+### `stats::concordance` — Lin's CCC & Cliff's delta
+
+| Function | Signature |
+|---|---|
+| `lin_ccc` | `pub fn lin_ccc(x: &[f64; 256], y: &[f64; 256], n: i32) -> CCCResult with Mut, Div, Panic` |
+| `cliff_delta` | `pub fn cliff_delta(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> DeltaResult with Mut, Div, Panic` |
+
+Lin's concordance correlation coefficient for paired-measurement agreement about
+the identity line — `CCC = 2·σxy/(σxx+σyy+(μx−μy)²)`, decomposed into precision
+(Pearson ρ) and accuracy (Cb) — and Cliff's delta, a robust distribution-free
+dominance effect size. Validated: precision ≈ 0.9955, CCC ≈ 0.9942 on a worked
+pair; perfect identity → CCC 1.0; fully-separated samples → δ = −1 (large).
+
+### `stats::rate_epi` — incidence-rate epidemiology (person-time)
+
+| Function | Signature |
+|---|---|
+| `incidence_rate` | `pub fn incidence_rate(a: f64, pt: f64) -> RateCI with Mut, Div, Panic` |
+| `rate_ratio` | `pub fn rate_ratio(a1: f64, pt1: f64, a2: f64, pt2: f64) -> RatioCI with Mut, Div, Panic` |
+| `rate_difference` | `pub fn rate_difference(a1: f64, pt1: f64, a2: f64, pt2: f64) -> DiffCI with Mut, Div, Panic` |
+
+Person-time incidence rates with the ratio (IRR) and difference measures and
+their large-sample intervals: a Poisson log CI for a single rate
+(`SE(ln rate)=1/√a`), a log CI for the IRR (`SE(ln IRR)=√(1/a1+1/a2)`), and a
+Wald CI for the rate difference (`SE=√(a1/pt1²+a2/pt2²)`). Validated: 10 events /
+500 py → rate 0.02, 95% CI [0.0108, 0.0372]; IRR 2.0, 95% CI [0.936, 4.273].
+
+### `stats::weibull_negbin` — Weibull & negative-binomial laws
+
+| Function | Signature |
+|---|---|
+| `weibull_pdf` / `weibull_cdf` / `weibull_hazard` | `pub fn weibull_*(x: f64, k: f64, l: f64) -> f64 with Mut, Div, Panic` |
+| `weibull_quantile` | `pub fn weibull_quantile(p: f64, k: f64, l: f64) -> f64 with Mut, Div, Panic` |
+| `weibull_median` / `weibull_mean` | `pub fn weibull_*(k: f64, l: f64) -> f64 with Mut, Div, Panic` |
+| `negbin_pmf` / `negbin_cdf` | `pub fn negbin_*(j: i32, r: f64, p: f64) -> f64 with Mut, Div, Panic` |
+| `negbin_mean` | `pub fn negbin_mean(r: f64, p: f64) -> f64 with Mut, Div, Panic` |
+
+The Weibull survival law (shape `k`, scale `λ`) with pdf/cdf/quantile/median/
+hazard/mean, and the negative binomial (successes `r`, prob `p`, support = failure
+count) with pmf/cdf/mean via log-gamma. Validated: Weibull(2,1) → F(1)=0.6321,
+median 0.8326, mean Γ(1.5)=0.8862; NegBin(3,0.5) → pmf(0)=0.125, mean 3.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -500,6 +542,9 @@ use stats::bayes_conjugate::{BetaPosterior, NormalPosterior, beta_binomial, norm
 use stats::diagnostic::{DiagResult, diag_metrics}
 use stats::cohen_kappa::{KappaResult, cohen_kappa, cohen_kappa_weighted}
 use stats::roc::{AUCResult, roc_auc, roc_point}
+use stats::concordance::{CCCResult, DeltaResult, lin_ccc, cliff_delta}
+use stats::rate_epi::{RateCI, RatioCI, DiffCI, incidence_rate, rate_ratio, rate_difference}
+use stats::weibull_negbin::{weibull_pdf, weibull_cdf, weibull_quantile, weibull_median, weibull_hazard, weibull_mean, negbin_pmf, negbin_cdf, negbin_mean}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/concordance.sio
+++ b/stdlib/stats/concordance.sio
@@ -1,0 +1,194 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/concordance.sio — Lin's CCC and Cliff's delta
+//
+// Two agreement / effect measures that sit beside Bland-Altman and Cohen's d:
+//
+//   lin_ccc(x, y, n)          -> CCCResult   (concordance: precision × accuracy)
+//   cliff_delta(x, nx, y, ny) -> DeltaResult (non-parametric dominance effect)
+//
+// Lin's concordance correlation coefficient measures agreement of paired
+// continuous measurements around the identity line, decomposing into precision
+// (Pearson ρ) and accuracy (a bias-correction factor):
+//   CCC = 2·ρ·σx·σy / (σx² + σy² + (μx − μy)²).
+// Cliff's delta is the probability a value from x exceeds one from y minus the
+// reverse — a robust, distribution-free effect size:
+//   δ = ( #{xi > yj} − #{xi < yj} ) / (nx·ny),  in [−1, 1].
+//
+// Pure Sounio, no external dependency (inline sqrt; no data-array nested calls).
+//
+// References:
+//   Lin (1989) "A concordance correlation coefficient..."; Cliff (1993)
+
+module stats::concordance
+
+fn cc_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 20 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct CCCResult {
+    pub ccc: f64,        // Lin's concordance correlation coefficient
+    pub precision: f64,  // Pearson correlation
+    pub accuracy: f64,   // bias-correction factor Cb = CCC/rho
+}
+
+pub struct DeltaResult {
+    pub delta: f64,      // Cliff's delta in [-1,1]
+    pub magnitude: i64,  // 0 negligible, 1 small, 2 medium, 3 large
+}
+
+/// Lin's concordance correlation coefficient for paired measurements.
+///
+/// Parâmetros: x, y — paired data; n — count (>= 2, <= 256).
+/// Retorno: CCCResult (ccc, precision = Pearson ρ, accuracy = Cb).
+/// Referências: Lin (1989).
+pub fn lin_ccc(x: &[f64; 256], y: &[f64; 256], n: i32) -> CCCResult with Mut, Div, Panic {
+    if n < 2 { return CCCResult { ccc: 0.0, precision: 0.0, accuracy: 0.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var vxx = 0.0
+    var vyy = 0.0
+    var vxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        let dy = y[j as usize] - my
+        vxx = vxx + dx * dx
+        vyy = vyy + dy * dy
+        vxy = vxy + dx * dy
+        j = j + 1
+    }
+    // population (÷n) moments, per Lin's definition
+    let sxx = vxx / nf
+    let syy = vyy / nf
+    let sxy = vxy / nf
+    var rho = 0.0
+    let den = cc_sqrt(sxx * syy)
+    if den > 1.0e-300 { rho = sxy / den }
+    let ccc_den = sxx + syy + (mx - my) * (mx - my)
+    var ccc = 0.0
+    if ccc_den > 1.0e-300 { ccc = 2.0 * sxy / ccc_den }
+    var acc = 0.0
+    if rho > 1.0e-300 || rho < 0.0 - 1.0e-300 { acc = ccc / rho }
+    return CCCResult { ccc: ccc, precision: rho, accuracy: acc }
+}
+
+fn cd_mag(d: f64) -> i64 {
+    let ad = if d < 0.0 { 0.0 - d } else { d }
+    if ad < 0.147 { return 0 }
+    if ad < 0.330 { return 1 }
+    if ad < 0.474 { return 2 }
+    return 3
+}
+
+/// Cliff's delta: non-parametric dominance effect size between two samples.
+///
+/// Parâmetros: x, y — the two samples; nx, ny — sizes.
+/// Retorno: DeltaResult (delta in [-1,1], magnitude code 0..3).
+/// Referências: Cliff (1993).
+pub fn cliff_delta(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> DeltaResult with Mut, Div, Panic {
+    if nx < 1 || ny < 1 { return DeltaResult { delta: 0.0, magnitude: 0 } }
+    var gt = 0
+    var lt = 0
+    var i = 0
+    while i < nx {
+        var j = 0
+        while j < ny {
+            let xi = x[i as usize]
+            let yj = y[j as usize]
+            if xi > yj { gt = gt + 1 } else { if xi < yj { lt = lt + 1 } }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let delta = ((gt - lt) as f64) / ((nx as f64) * (ny as f64))
+    return DeltaResult { delta: delta, magnitude: cd_mag(delta) }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x=1..5, y=1.1,2.1,2.9,4.2,4.8. mx=3, my=3.02.
+// sxx=2, syy=1.8216, sxy=1.9 -> rho=1.9/sqrt(2·1.8216)=0.995497.
+// ccc=2·1.9/(2+1.8216+0.0004)=3.8/3.822=0.994244. accuracy=ccc/rho=0.998741.
+fn test_ccc() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    y[0]=1.1; y[1]=2.1; y[2]=2.9; y[3]=4.2; y[4]=4.8
+    let r = lin_ccc(&x, &y, 5)
+    var ok = true
+    ok = check(1, approx(r.precision, 0.995497, 1.0e-3)) && ok
+    ok = check(2, approx(r.ccc, 0.994244, 1.0e-3)) && ok
+    ok = check(3, approx(r.accuracy, 0.998741, 1.0e-3)) && ok
+    return ok
+}
+
+// perfect identity y=x -> CCC=1.
+fn test_ccc_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 6 { x[i as usize] = i as f64; y[i as usize] = i as f64; i = i + 1 }
+    let r = lin_ccc(&x, &y, 6)
+    return check(10, approx(r.ccc, 1.0, 1.0e-9))
+}
+
+// Cliff: x=1,2,3 all below y=4,5,6 -> delta=-1 (large).
+fn test_cliff() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    y[0]=4.0; y[1]=5.0; y[2]=6.0
+    let r = cliff_delta(&x, 3, &y, 3)
+    var ok = true
+    ok = check(20, approx(r.delta, 0.0 - 1.0, 1.0e-12)) && ok
+    ok = check(21, r.magnitude == 3) && ok
+    // identical samples -> delta 0
+    let r2 = cliff_delta(&x, 3, &x, 3)
+    ok = check(22, approx(r2.delta, 0.0, 1.0e-12)) && ok
+    ok = check(23, r2.magnitude == 0) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_ccc() && ok
+    ok = test_ccc_perfect() && ok
+    ok = test_cliff() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/rate_epi.sio
+++ b/stdlib/stats/rate_epi.sio
@@ -1,0 +1,207 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/rate_epi.sio — incidence-rate epidemiology (person-time)
+//
+// Rates built from counts over person-time, with the ratio and difference
+// measures and their large-sample (log / Wald) confidence intervals:
+//
+//   incidence_rate(a, pt)            -> RateCI    (rate + Poisson log CI)
+//   rate_ratio(a1, pt1, a2, pt2)     -> RatioCI   (IRR + log CI)
+//   rate_difference(a1, pt1, a2, pt2)-> DiffCI    (RD + Wald CI)
+//
+// For a events over person-time T the incidence rate is a/T; on the log scale
+// SE(ln rate) = 1/sqrt(a), giving CI = exp( ln(a/T) ± z/sqrt(a) ).
+// For two groups the rate ratio (a1/T1)/(a2/T2) has SE(ln IRR)=sqrt(1/a1+1/a2);
+// the rate difference a1/T1 − a2/T2 has SE = sqrt(a1/T1² + a2/T2²).
+//
+// Pure Sounio: inline sqrt / exp / ln, no external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Rothman, Greenland & Lash, "Modern Epidemiology" 3e, ch. 14 (person-time).
+
+module stats::rate_epi
+
+fn re_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 24 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+// exp reduced to [0,2] after reflecting negatives (robust, no cancellation).
+fn re_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / re_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 {
+        term = term * r / (n as f64)
+        sum = sum + term
+        n = n + 1
+    }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+// ln via artanh series with range reduction to [1,2).
+fn re_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 {
+        sum = sum + term / ((2 * n + 1) as f64)
+        term = term * t2
+        n = n + 1
+    }
+    return e + 2.0 * sum
+}
+
+pub struct RateCI {
+    pub rate: f64,   // point estimate a/pt
+    pub lo: f64,     // 95% lower bound
+    pub hi: f64,     // 95% upper bound
+}
+
+pub struct RatioCI {
+    pub irr: f64,    // incidence-rate ratio
+    pub lo: f64,
+    pub hi: f64,
+}
+
+pub struct DiffCI {
+    pub rd: f64,     // rate difference
+    pub lo: f64,
+    pub hi: f64,
+}
+
+/// Incidence rate a/pt with a 95% Poisson log confidence interval.
+///
+/// Parâmetros: a — event count (>0 for a finite CI); pt — person-time (>0).
+/// Retorno: RateCI (rate, lo, hi).
+pub fn incidence_rate(a: f64, pt: f64) -> RateCI with Mut, Div, Panic {
+    if pt <= 0.0 { return RateCI { rate: 0.0, lo: 0.0, hi: 0.0 } }
+    let rate = a / pt
+    if a <= 0.0 { return RateCI { rate: 0.0, lo: 0.0, hi: 0.0 } }
+    let z = 1.959963984540054
+    let se = 1.0 / re_sqrt(a)            // SE(ln rate)
+    let lr = re_ln(rate)
+    return RateCI { rate: rate, lo: re_exp(lr - z * se), hi: re_exp(lr + z * se) }
+}
+
+/// Incidence-rate ratio (a1/pt1)/(a2/pt2) with a 95% log CI.
+///
+/// Parâmetros: a1,pt1 — exposed events/time; a2,pt2 — reference events/time.
+/// Retorno: RatioCI (irr, lo, hi).
+pub fn rate_ratio(a1: f64, pt1: f64, a2: f64, pt2: f64) -> RatioCI with Mut, Div, Panic {
+    if pt1 <= 0.0 || pt2 <= 0.0 || a1 <= 0.0 || a2 <= 0.0 {
+        return RatioCI { irr: 0.0, lo: 0.0, hi: 0.0 }
+    }
+    let r1 = a1 / pt1
+    let r2 = a2 / pt2
+    let irr = r1 / r2
+    let z = 1.959963984540054
+    let se = re_sqrt(1.0 / a1 + 1.0 / a2)   // SE(ln IRR)
+    let li = re_ln(irr)
+    return RatioCI { irr: irr, lo: re_exp(li - z * se), hi: re_exp(li + z * se) }
+}
+
+/// Rate difference a1/pt1 − a2/pt2 with a 95% Wald CI.
+///
+/// Parâmetros: a1,pt1 — exposed; a2,pt2 — reference.
+/// Retorno: DiffCI (rd, lo, hi).
+pub fn rate_difference(a1: f64, pt1: f64, a2: f64, pt2: f64) -> DiffCI with Mut, Div, Panic {
+    if pt1 <= 0.0 || pt2 <= 0.0 { return DiffCI { rd: 0.0, lo: 0.0, hi: 0.0 } }
+    let r1 = a1 / pt1
+    let r2 = a2 / pt2
+    let rd = r1 - r2
+    let z = 1.959963984540054
+    let se = re_sqrt(a1 / (pt1 * pt1) + a2 / (pt2 * pt2))
+    return DiffCI { rd: rd, lo: rd - z * se, hi: rd + z * se }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 10 events over 500 person-years -> rate 0.02.
+// SE(ln)=1/sqrt(10)=0.316228; ln(0.02)=-3.912023.
+// lo=exp(-3.912023-1.959964·0.316228)=exp(-4.531773)=0.010761
+// hi=exp(-3.912023+1.959964·0.316228)=exp(-3.292274)=0.037172
+fn test_rate() -> bool with IO, Mut, Div, Panic {
+    let r = incidence_rate(10.0, 500.0)
+    var ok = true
+    ok = check(1, approx(r.rate, 0.02, 1.0e-9)) && ok
+    ok = check(2, approx(r.lo, 0.010761, 1.0e-4)) && ok
+    ok = check(3, approx(r.hi, 0.037172, 1.0e-4)) && ok
+    return ok
+}
+
+// group1: 20 events / 1000 py = 0.02; group2: 10 / 1000 = 0.01. IRR=2.
+// SE(ln IRR)=sqrt(1/20+1/10)=sqrt(0.15)=0.387298; ln2=0.693147.
+// lo=exp(0.693147-1.959964·0.387298)=exp(-0.066014)=0.936120
+// hi=exp(0.693147+1.959964·0.387298)=exp(1.452308)=4.272797
+fn test_ratio() -> bool with IO, Mut, Div, Panic {
+    let r = rate_ratio(20.0, 1000.0, 10.0, 1000.0)
+    var ok = true
+    ok = check(10, approx(r.irr, 2.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.lo, 0.936120, 1.0e-3)) && ok
+    ok = check(12, approx(r.hi, 4.272797, 1.0e-3)) && ok
+    return ok
+}
+
+// rd = 0.02 - 0.01 = 0.01. SE=sqrt(20/1000²+10/1000²)=sqrt(30e-6)=0.005477.
+// lo=0.01-1.959964·0.005477=-0.000735; hi=0.01+...=0.020735.
+fn test_diff() -> bool with IO, Mut, Div, Panic {
+    let r = rate_difference(20.0, 1000.0, 10.0, 1000.0)
+    var ok = true
+    ok = check(20, approx(r.rd, 0.01, 1.0e-9)) && ok
+    ok = check(21, approx(r.lo, 0.0 - 0.000735, 1.0e-5)) && ok
+    ok = check(22, approx(r.hi, 0.020735, 1.0e-5)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_rate() && ok
+    ok = test_ratio() && ok
+    ok = test_diff() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/weibull_negbin.sio
+++ b/stdlib/stats/weibull_negbin.sio
@@ -1,0 +1,261 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/weibull_negbin.sio — Weibull and negative-binomial laws
+//
+// Two survival / count laws that sit beside the exponential and Poisson in the
+// densities module:
+//
+//   Weibull(shape k, scale λ):
+//     weibull_pdf(x,k,l)  weibull_cdf(x,k,l)  weibull_quantile(p,k,l)
+//     weibull_median(k,l) weibull_hazard(x,k,l) weibull_mean(k,l)
+//   Negative binomial (r successes, success prob p; support = #failures):
+//     negbin_pmf(j,r,p)   negbin_cdf(j,r,p)   negbin_mean(r,p)
+//
+// Weibull:  f(x)=(k/λ)(x/λ)^{k−1} e^{−(x/λ)^k},  F(x)=1−e^{−(x/λ)^k},
+//           Q(p)=λ(−ln(1−p))^{1/k},  median=λ(ln2)^{1/k},
+//           h(x)=(k/λ)(x/λ)^{k−1},  mean=λ·Γ(1+1/k).
+// NegBin:   P(J=j)=C(j+r−1,j) p^r (1−p)^j,  E[J]=r(1−p)/p.
+//
+// Pure Sounio: inline exp/ln/pow/lgamma; no external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Weibull (1951); Johnson, Kotz & Kemp, "Univariate Discrete Distributions".
+
+module stats::weibull_negbin
+
+fn wn_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / wn_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 {
+        term = term * r / (n as f64)
+        sum = sum + term
+        n = n + 1
+    }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn wn_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 {
+        sum = sum + term / ((2 * n + 1) as f64)
+        term = term * t2
+        n = n + 1
+    }
+    return e + 2.0 * sum
+}
+
+// x^y for x > 0 via exp(y ln x).
+fn wn_pow(x: f64, y: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { if y == 0.0 { return 1.0 } return 0.0 }
+    return wn_exp(y * wn_ln(x))
+}
+
+// Lanczos log-gamma (g=7, n=9), same coefficients as special::gamma.
+fn wn_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    if x < 0.5 {
+        // reflection: lgamma(x) = ln(pi/sin(pi x)) - lgamma(1-x)
+        let PI = 3.141592653589793
+        var s = PI * x
+        // sin via range-reduced Taylor (x in (0,0.5) -> s in (0, pi/2))
+        var t = s
+        var tm = s
+        var k = 1
+        while k < 12 {
+            tm = tm * (0.0 - s * s) / (((2 * k) * (2 * k + 1)) as f64)
+            t = t + tm
+            k = k + 1
+        }
+        return wn_ln(PI / t) - wn_lgamma(1.0 - x)
+    }
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * wn_ln(tt) - tt + wn_ln(a)
+}
+
+// ---- Weibull ---------------------------------------------------------------
+
+/// Weibull pdf f(x) = (k/λ)(x/λ)^{k−1} e^{−(x/λ)^k}.
+pub fn weibull_pdf(x: f64, k: f64, l: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 || k <= 0.0 || l <= 0.0 { return 0.0 }
+    let z = x / l
+    let zk = wn_pow(z, k)
+    return (k / l) * wn_pow(z, k - 1.0) * wn_exp(0.0 - zk)
+}
+
+/// Weibull cdf F(x) = 1 − e^{−(x/λ)^k}.
+pub fn weibull_cdf(x: f64, k: f64, l: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 || k <= 0.0 || l <= 0.0 { return 0.0 }
+    return 1.0 - wn_exp(0.0 - wn_pow(x / l, k))
+}
+
+/// Weibull quantile Q(p) = λ(−ln(1−p))^{1/k}.
+pub fn weibull_quantile(p: f64, k: f64, l: f64) -> f64 with Mut, Div, Panic {
+    if p <= 0.0 { return 0.0 }
+    if p >= 1.0 || k <= 0.0 || l <= 0.0 { return 0.0 }
+    return l * wn_pow(0.0 - wn_ln(1.0 - p), 1.0 / k)
+}
+
+/// Weibull median = λ(ln 2)^{1/k}.
+pub fn weibull_median(k: f64, l: f64) -> f64 with Mut, Div, Panic {
+    if k <= 0.0 || l <= 0.0 { return 0.0 }
+    let LN2 = 0.6931471805599453
+    return l * wn_pow(LN2, 1.0 / k)
+}
+
+/// Weibull hazard h(x) = (k/λ)(x/λ)^{k−1}.
+pub fn weibull_hazard(x: f64, k: f64, l: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 || k <= 0.0 || l <= 0.0 { return 0.0 }
+    return (k / l) * wn_pow(x / l, k - 1.0)
+}
+
+/// Weibull mean = λ·Γ(1 + 1/k).
+pub fn weibull_mean(k: f64, l: f64) -> f64 with Mut, Div, Panic {
+    if k <= 0.0 || l <= 0.0 { return 0.0 }
+    return l * wn_exp(wn_lgamma(1.0 + 1.0 / k))
+}
+
+// ---- Negative binomial (support = number of failures j >= 0) ---------------
+
+/// Negative-binomial pmf P(J=j) = C(j+r−1,j) p^r (1−p)^j via log-gamma.
+///
+/// Parâmetros: j — failure count (>=0); r — successes (>0, real ok); p — (0,1).
+pub fn negbin_pmf(j: i32, r: f64, p: f64) -> f64 with Mut, Div, Panic {
+    if j < 0 || r <= 0.0 || p <= 0.0 || p >= 1.0 { return 0.0 }
+    let jf = j as f64
+    // ln C(j+r-1, j) = lgamma(j+r) - lgamma(r) - lgamma(j+1)
+    let lc = wn_lgamma(jf + r) - wn_lgamma(r) - wn_lgamma(jf + 1.0)
+    let lp = lc + r * wn_ln(p) + jf * wn_ln(1.0 - p)
+    return wn_exp(lp)
+}
+
+/// Negative-binomial cdf P(J<=j) by summation.
+pub fn negbin_cdf(j: i32, r: f64, p: f64) -> f64 with Mut, Div, Panic {
+    if j < 0 || r <= 0.0 || p <= 0.0 || p >= 1.0 { return 0.0 }
+    var s = 0.0
+    var i = 0
+    while i <= j {
+        s = s + negbin_pmf(i, r, p)
+        i = i + 1
+    }
+    if s > 1.0 { return 1.0 }
+    return s
+}
+
+/// Negative-binomial mean E[J] = r(1−p)/p.
+pub fn negbin_mean(r: f64, p: f64) -> f64 with Mut, Div, Panic {
+    if r <= 0.0 || p <= 0.0 || p >= 1.0 { return 0.0 }
+    return r * (1.0 - p) / p
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Weibull(k=2, λ=1): F(1)=1-e^{-1}=0.632121; pdf(1)=2·1·e^{-1}=0.735759;
+// median=(ln2)^{1/2}=0.832555; hazard(1)=2·1=2; mean=Γ(1.5)=0.886227;
+// Q(0.632121)=1.
+fn test_weibull() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(1, approx(weibull_cdf(1.0, 2.0, 1.0), 0.632121, 1.0e-4)) && ok
+    ok = check(2, approx(weibull_pdf(1.0, 2.0, 1.0), 0.735759, 1.0e-4)) && ok
+    ok = check(3, approx(weibull_median(2.0, 1.0), 0.832555, 1.0e-4)) && ok
+    ok = check(4, approx(weibull_hazard(1.0, 2.0, 1.0), 2.0, 1.0e-6)) && ok
+    ok = check(5, approx(weibull_mean(2.0, 1.0), 0.886227, 1.0e-4)) && ok
+    ok = check(6, approx(weibull_quantile(0.632121, 2.0, 1.0), 1.0, 1.0e-4)) && ok
+    return ok
+}
+
+// exponential special case k=1, λ=2: F(2)=1-e^{-1}=0.632121; median=2·ln2=1.386294.
+fn test_weibull_exp() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(10, approx(weibull_cdf(2.0, 1.0, 2.0), 0.632121, 1.0e-4)) && ok
+    ok = check(11, approx(weibull_median(1.0, 2.0), 1.386294, 1.0e-4)) && ok
+    return ok
+}
+
+// NegBin r=3, p=0.5. pmf(0)=0.5^3=0.125; pmf(1)=C(3,1)·0.125·0.5=3·0.0625=0.1875;
+// mean=3·0.5/0.5=3; cdf(1)=0.125+0.1875=0.3125.
+fn test_negbin() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(20, approx(negbin_pmf(0, 3.0, 0.5), 0.125, 1.0e-5)) && ok
+    ok = check(21, approx(negbin_pmf(1, 3.0, 0.5), 0.1875, 1.0e-5)) && ok
+    ok = check(22, approx(negbin_mean(3.0, 0.5), 3.0, 1.0e-9)) && ok
+    ok = check(23, approx(negbin_cdf(1, 3.0, 0.5), 0.3125, 1.0e-5)) && ok
+    return ok
+}
+
+// geometric case r=1, p=0.25: pmf(j)=0.25·0.75^j. pmf(2)=0.25·0.5625=0.140625;
+// mean=1·0.75/0.25=3.
+fn test_negbin_geom() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(30, approx(negbin_pmf(2, 1.0, 0.25), 0.140625, 1.0e-5)) && ok
+    ok = check(31, approx(negbin_mean(1.0, 0.25), 3.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_weibull() && ok
+    ok = test_weibull_exp() && ok
+    ok = test_negbin() && ok
+    ok = test_negbin_geom() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three more pure-Sounio modules for the epistemic-statistics suite, bringing it to **30 modules**. All three are math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — no errors) and validated by inline worked-example tests.

| Module | What it adds |
|---|---|
| `stats::concordance` | Lin's concordance correlation coefficient (precision × accuracy decomposition) + Cliff's delta (distribution-free dominance effect size) |
| `stats::rate_epi` | Person-time incidence rate, rate ratio (IRR) and rate difference with Poisson-log & Wald CIs |
| `stats::weibull_negbin` | Weibull survival law (pdf/cdf/quantile/median/hazard/mean) + negative binomial (pmf/cdf/mean) via log-gamma |

## Validation

- Every module ships inline `//@ run-pass` / `//@ expect-stdout: ALL PASS` tests against hand-computed worked examples (e.g. Weibull(2,1) → F(1)=0.6321, median 0.8326, mean Γ(1.5)=0.8862; IRR 2.0, 95% CI [0.936, 4.273]).
- Full suite selftest green: **30 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency: analytic core is inline range-reduced exp/ln/sqrt and Lanczos log-gamma.
- `#852`-safe architecture: scalar/small-struct returns, no nested data-array calls.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).