### PR TITLE
feat(stats): paired & ordered-design tests — mcnemar, friedman, trend

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2689,3 +2689,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - weibull_negbin = **PASS**: all Weibull & NegBin closed forms match references; hazard=f/S reduction and mean=λΓ(1+1/k) correct; log-gamma binomial coefficient + geometric special case algebraically correct. No errors.
 - Suite selftest: 30 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-mS7gGT/`, `/tmp/llm-offload-Y62RoO/`, `/tmp/llm-offload-sF2UHr/`.
+
+## 2026-07-14 — math-review: stats::mcnemar, stats::friedman, stats::trend
+- Files (all new): `stdlib/stats/mcnemar.sio` (McNemar paired-binary test: continuity-corrected χ², exact sign-test p, paired OR), `stdlib/stats/friedman.sio` (Friedman repeated-measures test + Kendall's W, mid-rank ties, χ² tail via Lanczos log-gamma + regularised incomplete gamma), `stdlib/stats/trend.sio` (Cochran-Armitage trend test for ordered proportions: z, χ², slope). Provider: xAI/Grok 4.3.
+- mcnemar = **PASS**: Yates-corrected χ²=(|b−c|−1)²/(b+c), exact 2·P(X≥max(b,c)) via running binomial coefficients, paired OR=c/b, A-S erf tail — all verified; three test cases hold.
+- friedman = **PASS**: χ²_F and Kendall's W identities verified by direct substitution on perfect/null/ties cases; mid-rank formula correct. One cosmetic comment-arithmetic note (computed χ² correct).
+- trend = **PASS**: CA score statistic T, centered Sxx, null variance V, χ²=T²/V, slope=T/Sxx all match; worked example (T=50, χ²=26.667, z=5.164, slope=0.10) reproduced exactly.
+- Theme: paired / repeated-measures / ordered-design tests — fills the gap left by the suite's independent-groups tests. Suite selftest: 33 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-c3hsRt/`, `/tmp/llm-offload-n1l38u/`, `/tmp/llm-offload-QM8I6l/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -37,6 +37,9 @@ MODULES=(
   stdlib/stats/concordance.sio
   stdlib/stats/rate_epi.sio
   stdlib/stats/weibull_negbin.sio
+  stdlib/stats/mcnemar.sio
+  stdlib/stats/friedman.sio
+  stdlib/stats/trend.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -513,6 +513,42 @@ hazard/mean, and the negative binomial (successes `r`, prob `p`, support = failu
 count) with pmf/cdf/mean via log-gamma. Validated: Weibull(2,1) → F(1)=0.6321,
 median 0.8326, mean Γ(1.5)=0.8862; NegBin(3,0.5) → pmf(0)=0.125, mean 3.
 
+### `stats::mcnemar` — McNemar's test for paired binary data
+
+| Function | Signature |
+|---|---|
+| `mcnemar` | `pub fn mcnemar(a: i64, b: i64, c: i64, d: i64) -> McNemarResult with Mut, Div, Panic` |
+
+The paired-sample analogue of the 2×2 χ² test (before/after, matched
+case-control): continuity-corrected `χ² = (|b−c|−1)²/(b+c)` with its asymptotic
+p, the exact two-sided sign-test p (`X ~ Bin(b+c, ½)`), and the paired odds
+ratio c/b. Validated: Agresti b=6/c=16 → χ²=3.6818, OR=2.667; exact b=1/c=9 →
+p=0.02148.
+
+### `stats::friedman` — Friedman test & Kendall's W
+
+| Function | Signature |
+|---|---|
+| `friedman` | `pub fn friedman(data: &[f64; 256], n: i32, k: i32) -> FriedmanResult with Mut, Div, Panic` |
+
+Repeated-measures (matched-block) non-parametric ANOVA — the paired counterpart
+to Kruskal-Wallis — on a row-major n×k subject×treatment matrix, with mid-rank
+tie handling. Returns `χ²_F = 12/(n·k·(k+1))·ΣRⱼ² − 3n(k+1)` (df k−1), its
+asymptotic p, and Kendall's W = χ²_F/(n(k−1)) ∈ [0,1]. Validated: perfectly
+concordant 3×3 → χ²=6, W=1.0; opposing ranks → χ²=0, W=0.
+
+### `stats::trend` — Cochran-Armitage test for trend in proportions
+
+| Function | Signature |
+|---|---|
+| `cochran_armitage` | `pub fn cochran_armitage(events: &[f64; 32], totals: &[f64; 32], scores: &[f64; 32], k: i32) -> TrendResult with Mut, Div, Panic` |
+
+The categorical dose-response analogue of a slope test: is the event proportion
+linearly trending across k *ordered* groups? Returns the signed trend z, `χ² =
+T²/V` (df 1), two-sided p, and the fitted slope (proportion per unit score).
+Validated: doses 0–3 with proportions 0.1–0.4 → χ²=26.667, z=5.164, slope=0.10;
+flat proportions → χ²=0.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -545,6 +581,9 @@ use stats::roc::{AUCResult, roc_auc, roc_point}
 use stats::concordance::{CCCResult, DeltaResult, lin_ccc, cliff_delta}
 use stats::rate_epi::{RateCI, RatioCI, DiffCI, incidence_rate, rate_ratio, rate_difference}
 use stats::weibull_negbin::{weibull_pdf, weibull_cdf, weibull_quantile, weibull_median, weibull_hazard, weibull_mean, negbin_pmf, negbin_cdf, negbin_mean}
+use stats::mcnemar::{McNemarResult, mcnemar}
+use stats::friedman::{FriedmanResult, friedman}
+use stats::trend::{TrendResult, cochran_armitage}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/friedman.sio
+++ b/stdlib/stats/friedman.sio
@@ -1,0 +1,274 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/friedman.sio — Friedman test & Kendall's W
+//
+// The repeated-measures (matched-block) analogue of Kruskal-Wallis: n subjects
+// each ranked across k treatments, testing whether the treatment rank sums
+// differ. Kendall's W rescales the same statistic to an agreement coefficient
+// in [0,1].
+//
+//   friedman(data, n, k) -> FriedmanResult    (data laid out row-major n×k)
+//
+// Within each subject (row) the k values are ranked 1..k (ties → mid-ranks);
+// with column rank sums Rj,
+//   χ²_F = 12 / (n·k·(k+1)) · Σ Rj²  −  3·n·(k+1),   df = k−1,
+//   W = χ²_F / (n·(k−1))  ∈ [0,1].
+//
+// Pure Sounio: inline erf/exp/lgamma for the χ² tail; ranking done in a flat
+// per-row loop over a fixed [16]-wide scratch (k ≤ 16), no nested data-array
+// calls.
+//
+// References:
+//   Friedman (1937); Kendall & Babington Smith (1939); Conover, "Practical
+//   Nonparametric Statistics" 3e, §5.8.
+
+module stats::friedman
+
+fn fr_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / fr_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn fr_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+// Lanczos log-gamma (g=7), x > 0.
+fn fr_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * fr_ln(tt) - tt + fr_ln(a)
+}
+
+// Regularised lower incomplete gamma P(s,x) via series / continued fraction.
+fn fr_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 200 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 200 } else { n = n + 1 }
+        }
+        return sum * fr_exp(0.0 - x + s * fr_ln(x) - fr_lgamma(s))
+    }
+    // continued fraction for Q, then P = 1 - Q
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 200 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 200 } else { i = i + 1 }
+    }
+    let q = fr_exp(0.0 - x + s * fr_ln(x) - fr_lgamma(s)) * h
+    return 1.0 - q
+}
+
+// chi-squared survival function P(X > x) for df degrees of freedom.
+fn fr_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    return 1.0 - fr_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct FriedmanResult {
+    pub chi2: f64,  // Friedman statistic
+    pub df: i64,    // k - 1
+    pub p: f64,     // asymptotic p-value (chi-squared)
+    pub w: f64,     // Kendall's W in [0,1]
+}
+
+/// Friedman test on a row-major n×k matrix of subject × treatment values.
+///
+/// Parâmetros: data — n·k values, row i = subject i; n — subjects; k — treatments (2..16).
+/// Retorno: FriedmanResult (chi2, df, p, w = Kendall's W).
+/// Referências: Friedman (1937); Conover §5.8.
+pub fn friedman(data: &[f64; 256], n: i32, k: i32) -> FriedmanResult with Mut, Div, Panic {
+    if n < 2 || k < 2 || k > 16 {
+        return FriedmanResult { chi2: 0.0, df: 0, p: 1.0, w: 0.0 }
+    }
+    var rsum: [f64; 16] = [0.0; 16]
+    var row: [f64; 16] = [0.0; 16]
+    var rk: [f64; 16] = [0.0; 16]
+    var i = 0
+    while i < n {
+        // load this subject's row
+        var j = 0
+        while j < k {
+            row[j as usize] = data[(i * k + j) as usize]
+            j = j + 1
+        }
+        // rank the k values with mid-ranks for ties
+        var a = 0
+        while a < k {
+            var less = 0
+            var eq = 0
+            var b = 0
+            while b < k {
+                if row[b as usize] < row[a as usize] { less = less + 1 }
+                else { if row[b as usize] == row[a as usize] { eq = eq + 1 } }
+                b = b + 1
+            }
+            // mid-rank = (less+1 .. less+eq) average = less + (eq+1)/2
+            rk[a as usize] = (less as f64) + ((eq + 1) as f64) * 0.5
+            a = a + 1
+        }
+        // accumulate column rank sums
+        var c = 0
+        while c < k {
+            rsum[c as usize] = rsum[c as usize] + rk[c as usize]
+            c = c + 1
+        }
+        i = i + 1
+    }
+    let nf = n as f64
+    let kf = k as f64
+    var sumsq = 0.0
+    var j2 = 0
+    while j2 < k {
+        sumsq = sumsq + rsum[j2 as usize] * rsum[j2 as usize]
+        j2 = j2 + 1
+    }
+    let chi2 = 12.0 / (nf * kf * (kf + 1.0)) * sumsq - 3.0 * nf * (kf + 1.0)
+    let df = k - 1
+    let p = fr_chi2_sf(chi2, df as f64)
+    var w = 0.0
+    if n > 0 && k > 1 { w = chi2 / (nf * (kf - 1.0)) }
+    return FriedmanResult { chi2: chi2, df: df as i64, p: p, w: w }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Conover-style example: n=3 subjects, k=3 treatments, perfectly concordant
+// ranking (each subject ranks A<B<C). Column rank sums 3,6,9.
+// chi2 = 12/(3·3·4)·(9+36+81) - 3·3·4 = (12/36)·126 - 36 = 42 - 36 = 6.
+// df=2. W = 6/(3·2) = 1.0 (perfect agreement).
+fn test_friedman_perfect() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    // row-major 3x3
+    d[0]=1.0; d[1]=2.0; d[2]=3.0
+    d[3]=1.0; d[4]=2.0; d[5]=3.0
+    d[6]=1.0; d[7]=2.0; d[8]=3.0
+    let r = friedman(&d, 3, 3)
+    var ok = true
+    ok = check(1, approx(r.chi2, 6.0, 1.0e-6)) && ok
+    ok = check(2, r.df == 2) && ok
+    ok = check(3, approx(r.w, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// No agreement: subjects rank in opposing orders -> rank sums equal -> chi2 0.
+// rows: (1,2,3),(3,2,1),(2,3,1),(2,1,3): sums col0=1+3+2+2=8,col1=2+2+3+1=8,col2=3+1+1+3=8.
+// chi2 = 12/(4·3·4)·(64·3) - 3·4·4 = (12/48)·192 - 48 = 48 - 48 = 0. W=0.
+fn test_friedman_null() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=2.0; d[2]=3.0
+    d[3]=3.0; d[4]=2.0; d[5]=1.0
+    d[6]=2.0; d[7]=3.0; d[8]=1.0
+    d[9]=2.0; d[10]=1.0; d[11]=3.0
+    let r = friedman(&d, 4, 3)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-6)) && ok
+    ok = check(11, approx(r.w, 0.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+// Ties within a subject use mid-ranks: row (5,5,9) -> ranks (1.5,1.5,3).
+fn test_ties() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=5.0; d[1]=5.0; d[2]=9.0
+    d[3]=5.0; d[4]=5.0; d[5]=9.0
+    let r = friedman(&d, 2, 3)
+    // col sums: (3,3,6). chi2 = 12/(2·3·4)·(9+9+36) - 3·2·4 = (12/24)·54 - 24 = 27-24=3.
+    var ok = true
+    ok = check(20, approx(r.chi2, 3.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_friedman_perfect() && ok
+    ok = test_friedman_null() && ok
+    ok = test_ties() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/mcnemar.sio
+++ b/stdlib/stats/mcnemar.sio
@@ -1,0 +1,187 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/mcnemar.sio — McNemar's test for paired binary data
+//
+// The paired-sample analogue of the 2×2 chi-squared test: given a matched
+// table of before/after (or test-A/test-B) binary outcomes, McNemar's test
+// asks whether the two discordant cells differ.
+//
+//   paired 2×2:            After +   After −
+//     Before +               a          b
+//     Before −               c          d
+//
+//   mcnemar(a, b, c, d) -> McNemarResult
+//
+// Only the discordant pairs b and c carry information. With continuity
+// correction  χ² = (|b−c|−1)² / (b+c),  df = 1; the exact test is the
+// two-sided sign (binomial) test  p = 2·P(X ≥ max(b,c)),  X ~ Bin(b+c, ½).
+// The paired odds ratio is c/b.
+//
+// Pure Sounio: inline erf (normal tail) and an exact binomial sum; no external
+// dependency, no nested data-array calls.
+//
+// References:
+//   McNemar (1947); Agresti, "Categorical Data Analysis" 3e, §11.1.
+
+module stats::mcnemar
+
+fn mn_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 24 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn mn_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / mn_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+// erf via Abramowitz-Stegun 7.1.26 (max err ~1.5e-7).
+fn mn_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * mn_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+// upper-tail normal probability P(Z > z).
+fn mn_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - mn_erf(z * INV_SQRT2))
+}
+
+pub struct McNemarResult {
+    pub chi2: f64,      // continuity-corrected statistic, df = 1
+    pub p_approx: f64,  // asymptotic two-sided p from chi2
+    pub p_exact: f64,   // exact two-sided sign-test p
+    pub or_paired: f64, // paired odds ratio c/b
+    pub n_discord: i64, // b + c
+}
+
+/// McNemar's test for a paired 2×2 table (a,b,c,d as laid out above).
+///
+/// Parâmetros: a,b,c,d — the four cell counts (b,c are the discordant pairs).
+/// Retorno: McNemarResult (chi2, p_approx, p_exact, or_paired, n_discord).
+/// Referências: McNemar (1947); Agresti §11.1.
+pub fn mcnemar(a: i64, b: i64, c: i64, d: i64) -> McNemarResult with Mut, Div, Panic {
+    let n = b + c
+    if n <= 0 {
+        return McNemarResult { chi2: 0.0, p_approx: 1.0, p_exact: 1.0, or_paired: 1.0, n_discord: 0 }
+    }
+    let bf = b as f64
+    let cf = c as f64
+    // continuity-corrected chi-squared
+    var diff = bf - cf
+    if diff < 0.0 { diff = 0.0 - diff }
+    let cont = if diff - 1.0 > 0.0 { diff - 1.0 } else { 0.0 }
+    let chi2 = cont * cont / (bf + cf)
+    let p_approx = 2.0 * mn_normal_sf(mn_sqrt(chi2))
+    // exact two-sided sign test: 2 * P(X >= max(b,c)), X ~ Bin(n, 0.5)
+    var hi = b
+    if c > b { hi = c }
+    // sum_{k=hi}^{n} C(n,k) 0.5^n  via iterative binomial coefficient
+    let half_pow = mn_exp((0.0 - (n as f64)) * 0.6931471805599453)  // 0.5^n
+    var coef = 1.0
+    var k = 0
+    // advance coef to C(n, hi)
+    while k < hi { coef = coef * ((n - k) as f64) / ((k + 1) as f64); k = k + 1 }
+    var tail = 0.0
+    var kk = hi
+    var cf2 = coef
+    while kk <= n {
+        tail = tail + cf2 * half_pow
+        // C(n,kk+1) = C(n,kk) * (n-kk)/(kk+1)
+        cf2 = cf2 * ((n - kk) as f64) / ((kk + 1) as f64)
+        kk = kk + 1
+    }
+    var p_exact = 2.0 * tail
+    if p_exact > 1.0 { p_exact = 1.0 }
+    var or_paired = 0.0
+    if bf > 0.0 { or_paired = cf / bf }
+    return McNemarResult {
+        chi2: chi2, p_approx: p_approx, p_exact: p_exact,
+        or_paired: or_paired, n_discord: n
+    }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Classic worked example (Agresti): b=6, c=16 discordant (a,d irrelevant).
+// chi2 = (|6-16|-1)²/(6+16) = 81/22 = 3.681818.
+// p_approx = 2·Φ̄(√3.681818)=2·Φ̄(1.918806)=0.055011 (approx).
+// or_paired = 16/6 = 2.666667. n_discord = 22.
+fn test_mcnemar() -> bool with IO, Mut, Div, Panic {
+    let r = mcnemar(30, 6, 16, 48)
+    var ok = true
+    ok = check(1, approx(r.chi2, 3.681818, 1.0e-4)) && ok
+    ok = check(2, approx(r.or_paired, 2.666667, 1.0e-4)) && ok
+    ok = check(3, r.n_discord == 22) && ok
+    ok = check(4, approx(r.p_approx, 0.055011, 5.0e-3)) && ok
+    return ok
+}
+
+// Exact sign test: b=1, c=9 -> n=10, hi=9.
+// tail = [C(10,9)+C(10,10)]·0.5^10 = (10+1)/1024 = 0.010742; p_exact = 0.021484.
+fn test_exact() -> bool with IO, Mut, Div, Panic {
+    let r = mcnemar(20, 1, 9, 30)
+    var ok = true
+    ok = check(10, approx(r.p_exact, 0.021484, 1.0e-4)) && ok
+    ok = check(11, r.n_discord == 10) && ok
+    return ok
+}
+
+// Symmetric discordance b=c -> corrected chi2 = max(|0|-1,0)²/16 = 0, OR 1.
+fn test_symmetric() -> bool with IO, Mut, Div, Panic {
+    let r = mcnemar(10, 8, 8, 10)
+    var ok = true
+    ok = check(20, approx(r.chi2, 0.0, 1.0e-12)) && ok
+    ok = check(21, approx(r.or_paired, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_mcnemar() && ok
+    ok = test_exact() && ok
+    ok = test_symmetric() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/trend.sio
+++ b/stdlib/stats/trend.sio
@@ -1,0 +1,201 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/trend.sio — Cochran-Armitage test for trend in proportions
+//
+// Tests whether an event proportion changes linearly across k *ordered* groups
+// (e.g. dose levels): the categorical dose-response analogue of a regression
+// slope test.
+//
+//   cochran_armitage(events, totals, scores, k) -> TrendResult
+//
+// With group scores dᵢ, counts nᵢ, events rᵢ, N=Σnᵢ, R=Σrᵢ, p̄=R/N:
+//   T   = Σ dᵢ (rᵢ − nᵢ p̄)
+//   Sxx = Σ nᵢ dᵢ² − (Σ nᵢ dᵢ)² / N
+//   V   = p̄(1−p̄)·Sxx,   χ² = T²/V  (df 1),   z = T/√V,
+//   slope (proportion per unit score) = T / Sxx.
+//
+// Pure Sounio: inline sqrt/erf for the normal tail; fixed [32]-wide group
+// scratch (k ≤ 32); no nested data-array calls.
+//
+// References:
+//   Cochran (1954); Armitage (1955); Agresti "Categorical Data Analysis" §5.3.5.
+
+module stats::trend
+
+fn tr_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 24 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn tr_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / tr_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn tr_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * tr_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn tr_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - tr_erf(z * INV_SQRT2))
+}
+
+pub struct TrendResult {
+    pub z: f64,     // signed trend z-statistic
+    pub chi2: f64,  // T²/V, df 1
+    pub p: f64,     // two-sided p-value
+    pub slope: f64, // fitted proportion change per unit score
+    pub pbar: f64,  // overall event proportion R/N
+}
+
+/// Cochran-Armitage trend test across k ordered groups.
+///
+/// Parâmetros: events[i], totals[i] — counts; scores[i] — ordered dose scores;
+///             k — number of groups (2..32).
+/// Retorno: TrendResult (z, chi2, p, slope, pbar).
+/// Referências: Armitage (1955); Agresti §5.3.5.
+pub fn cochran_armitage(events: &[f64; 32], totals: &[f64; 32],
+                        scores: &[f64; 32], k: i32) -> TrendResult with Mut, Div, Panic {
+    if k < 2 || k > 32 {
+        return TrendResult { z: 0.0, chi2: 0.0, p: 1.0, slope: 0.0, pbar: 0.0 }
+    }
+    var bigN = 0.0
+    var bigR = 0.0
+    var snd = 0.0    // Σ n_i d_i
+    var snd2 = 0.0   // Σ n_i d_i²
+    var i = 0
+    while i < k {
+        let ni = totals[i as usize]
+        let ri = events[i as usize]
+        let di = scores[i as usize]
+        bigN = bigN + ni
+        bigR = bigR + ri
+        snd = snd + ni * di
+        snd2 = snd2 + ni * di * di
+        i = i + 1
+    }
+    if bigN <= 0.0 { return TrendResult { z: 0.0, chi2: 0.0, p: 1.0, slope: 0.0, pbar: 0.0 } }
+    let pbar = bigR / bigN
+    // T = Σ d_i (r_i - n_i·pbar)
+    var t = 0.0
+    var j = 0
+    while j < k {
+        t = t + scores[j as usize] * (events[j as usize] - totals[j as usize] * pbar)
+        j = j + 1
+    }
+    let sxx = snd2 - snd * snd / bigN
+    if sxx <= 0.0 || pbar <= 0.0 || pbar >= 1.0 {
+        return TrendResult { z: 0.0, chi2: 0.0, p: 1.0, slope: 0.0, pbar: pbar }
+    }
+    let v = pbar * (1.0 - pbar) * sxx
+    let z = t / tr_sqrt(v)
+    let chi2 = t * t / v
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * tr_normal_sf(az)
+    let slope = t / sxx
+    return TrendResult { z: z, chi2: chi2, p: p, slope: slope, pbar: pbar }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Perfect linear dose-response: d=0,1,2,3; n=100 each; r=10,20,30,40 (p=.1..4).
+// N=400, R=100, pbar=0.25. T=50. Sxx=1400-600²/400=500. V=.25·.75·500=93.75.
+// chi2=2500/93.75=26.6667; z=50/9.682458=5.163978; slope=50/500=0.1.
+fn test_trend() -> bool with IO, Mut, Div, Panic {
+    var ev: [f64; 32] = [0.0; 32]
+    var nt: [f64; 32] = [0.0; 32]
+    var sc: [f64; 32] = [0.0; 32]
+    ev[0]=10.0; ev[1]=20.0; ev[2]=30.0; ev[3]=40.0
+    nt[0]=100.0; nt[1]=100.0; nt[2]=100.0; nt[3]=100.0
+    sc[0]=0.0; sc[1]=1.0; sc[2]=2.0; sc[3]=3.0
+    let r = cochran_armitage(&ev, &nt, &sc, 4)
+    var ok = true
+    ok = check(1, approx(r.chi2, 26.666667, 1.0e-4)) && ok
+    ok = check(2, approx(r.z, 5.163978, 1.0e-4)) && ok
+    ok = check(3, approx(r.slope, 0.1, 1.0e-6)) && ok
+    ok = check(4, approx(r.pbar, 0.25, 1.0e-9)) && ok
+    return ok
+}
+
+// No trend: equal proportions across groups -> T=0, chi2=0, slope=0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var ev: [f64; 32] = [0.0; 32]
+    var nt: [f64; 32] = [0.0; 32]
+    var sc: [f64; 32] = [0.0; 32]
+    ev[0]=10.0; ev[1]=10.0; ev[2]=10.0
+    nt[0]=50.0; nt[1]=50.0; nt[2]=50.0
+    sc[0]=0.0; sc[1]=1.0; sc[2]=2.0
+    let r = cochran_armitage(&ev, &nt, &sc, 3)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.slope, 0.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+// Decreasing trend gives negative z (protective dose-response).
+fn test_negative() -> bool with IO, Mut, Div, Panic {
+    var ev: [f64; 32] = [0.0; 32]
+    var nt: [f64; 32] = [0.0; 32]
+    var sc: [f64; 32] = [0.0; 32]
+    ev[0]=40.0; ev[1]=30.0; ev[2]=20.0; ev[3]=10.0
+    nt[0]=100.0; nt[1]=100.0; nt[2]=100.0; nt[3]=100.0
+    sc[0]=0.0; sc[1]=1.0; sc[2]=2.0; sc[3]=3.0
+    let r = cochran_armitage(&ev, &nt, &sc, 4)
+    var ok = true
+    ok = check(20, approx(r.z, 0.0 - 5.163978, 1.0e-4)) && ok
+    ok = check(21, approx(r.slope, 0.0 - 0.1, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_trend() && ok
+    ok = test_null() && ok
+    ok = test_negative() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three more pure-Sounio modules for the epistemic-statistics suite, bringing it to **33 modules**. These close a real gap: every prior test in the suite compares **independent** groups — this trio covers **paired**, **repeated-measures**, and **ordered-design** analyses, all of which are standard in clinical and pharmacometric work. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds | Design |
|---|---|---|
| `stats::mcnemar` | Continuity-corrected χ² + exact sign-test p + paired OR | Paired binary (before/after, matched case-control) |
| `stats::friedman` | Friedman χ² + Kendall's W, mid-rank ties | Repeated-measures non-parametric ANOVA |
| `stats::trend` | Cochran-Armitage z / χ² / slope | Linear trend in proportions across ordered (dose) groups |

## Validation

- Inline `//@ run-pass` tests against textbook worked examples:
  - McNemar: Agresti b=6/c=16 → χ²=3.6818, OR=2.667; exact b=1/c=9 → p=0.02148.
  - Friedman: perfectly concordant 3×3 → χ²=6, W=1.0; opposing ranks → χ²=0, W=0.
  - Trend: doses 0–3 with proportions 0.1–0.4 → χ²=26.667, z=5.164, slope=0.10 (exact).
- Full suite selftest: **33 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency: χ² tails via inline Lanczos log-gamma + regularised incomplete gamma; normal tails via inline A-S erf.
- `#852`-safe: fixed-width scratch arrays, scalar/small-struct returns, no nested data-array calls.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).