### PR TITLE
test(stats): published-value run-proof for stats::validation (coordinated disjoint lane)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2695,3 +2695,9 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - weibull_negbin = **PASS**: all Weibull & NegBin closed forms match references; hazard=f/S reduction and mean=λΓ(1+1/k) correct; log-gamma binomial coefficient + geometric special case algebraically correct. No errors.
 - Suite selftest: 30 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-mS7gGT/`, `/tmp/llm-offload-Y62RoO/`, `/tmp/llm-offload-sF2UHr/`.
+
+## 2026-07-14 — math-review: stats::validation run-proof (coordinated disjoint lane)
+- Files: `tests/stdlib/stats/test_validation_runproof.sio`, `scripts/stats_validation_gate.sh` (no stats source edited — module under active dev by another lane, PR #905).
+- Provider: xAI/Grok 4.3 = **PASS** (all items). Confirmed mean=6, sample var=10, std=√10≈3.162278, SE=√2≈1.414214, range=8; Pearson r=6/√60≈0.774597, r²=0.6; OLS slope=0.6, intercept=2.2.
+- Build: lean_single (validation.sio uses `.len()`/constructs the default Madaros engine rejects; importing programs hit Madaros visibility-preflight). STATS_VALIDATION_GATE_OK.
+- Raw review directory: see /tmp llm-offload dir for this run.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 963
-- Repo-backed topics: 813
+- Total governed topics: 965
+- Repo-backed topics: 815
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 563
+- Authority count `repo_only`: 565
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 582 topics
+- A2: 584 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -782,11 +782,13 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening | repo_only | docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-linalg-vertical | repo_only | docs/superpowers/plans/2026-07-14-linalg-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-prob-vertical | repo_only | docs/superpowers/plans/2026-07-14-prob-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof | repo_only | docs/superpowers/plans/2026-07-14-stats-validation-runproof.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-units-vertical | repo_only | docs/superpowers/plans/2026-07-14-units-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design | repo_only | docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-linalg-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-linalg-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-prob-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-prob-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design | repo_only | docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-units-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-units-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.testing | repo_only | docs/TESTING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17292,6 +17292,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-14-stats-validation-runproof.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.plans.2026-07-14-units-vertical",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/plans/2026-07-14-units-vertical.md",
@@ -17387,6 +17410,29 @@
       "topic_id": "repo.docs.superpowers.specs.2026-07-14-prob-vertical-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-14-prob-vertical-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-07-14-stats-validation-runproof.md
+++ b/docs/superpowers/plans/2026-07-14-stats-validation-runproof.md
@@ -1,0 +1,17 @@
+# Stats::validation Run-Proof — Implementation Plan (coordinated, disjoint)
+
+> Compile-and-run is the gate. Build with `SOUNIO_SOUC_ENGINE=lean_single` + `chmod +x`. **No edit to any stats source or existing test/harness** (the stats module is under active development by another lane — PR #905 / stats-suite-*).
+
+Spec: `docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md`.
+
+## Task 1 — Run-proof driver
+- [ ] `tests/stdlib/stats/test_validation_runproof.sio` (inline in main, `use stats::validation::*`). Assert published values: mean=6, variance=10, std=√10, SE≈1.414214, max=10, range=8 (data [2,4,6,8,10]); correlation≈0.774597, r²=0.6, OLS slope=0.6, intercept=2.2 (x=[1..5], y=[2,4,5,4,5]). Then `STATS_VALIDATION_OK`.
+- [ ] `SOUNIO_SOUC_ENGINE=lean_single souc compile … && chmod +x && ./elf` → `STATS_VALIDATION_OK`. No tolerance-retrofit. Commit.
+
+## Task 2 — Gate
+- [ ] `scripts/stats_validation_gate.sh` — check validation.sio; lean_single compile+chmod+run driver (grep `STATS_VALIDATION_OK`); end `STATS_VALIDATION_GATE_OK`. Run it. Commit.
+
+## Task 3 — Math-review + PR
+- [ ] `bin/llm-offload -t math-review -p xai` on the descriptive/regression identities; log it.
+- [ ] `node scripts/docs/sync_governance_metadata.mjs`; commit governance + docs.
+- [ ] Push; PR to `main`; ensure `Contracts`/`CI Decision` green; merge (rebase-on-conflict if the stats lane drifted).

--- a/docs/superpowers/plans/2026-07-14-stats-validation-runproof.md
+++ b/docs/superpowers/plans/2026-07-14-stats-validation-runproof.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof
+-->
+
 # Stats::validation Run-Proof — Implementation Plan (coordinated, disjoint)
 
 > Compile-and-run is the gate. Build with `SOUNIO_SOUC_ENGINE=lean_single` + `chmod +x`. **No edit to any stats source or existing test/harness** (the stats module is under active development by another lane — PR #905 / stats-suite-*).

--- a/docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md
+++ b/docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design
+-->
+
 # Design — Independent run-proof for stats::validation (coordinated, disjoint lane)
 
 **Status:** approved design, pre-implementation

--- a/docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md
+++ b/docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md
@@ -1,0 +1,70 @@
+# Design — Independent run-proof for stats::validation (coordinated, disjoint lane)
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-07-14
+**Constraint:** No compiler changes. **Coordination: the `stats` module is under active development by
+another lane (PR #905 `feat/stats-suite-11`, the `stats-suite-*` series). This lane is DISJOINT — it
+reads `stdlib/stats/validation.sio` and edits NO stats source and NO existing test/harness; write-set is
+only new, uniquely-named files.** EN-UK.
+
+## 1. Why
+Sixth application of the playbook (GUM #860, units #873, linalg #892, neg-fix #900, prob #902), adapted
+for coordination: instead of hardening a module the other lane owns, add **independent published-value
+verification** for a stable, unclaimed stats module — complementing the active lane's breadth with
+depth, without an ownership conflict.
+
+## 2. Verified starting state
+- `stdlib/stats/validation.sio` (self-contained, green, ~360 lines) exposes a `&[f64]`-slice descriptive +
+  regression API: `mean/variance/std_dev/variance_population/standard_error/min/max/range/correlation/
+  r_squared/linear_regression/residuals/mse/rmse/mae/t_statistic/confidence_interval_95/validate`.
+- **Disjoint**: last touched by an unrelated commit (`e8b7e2d65`, GPU); NOT in PR #905's files; no test
+  file references `stats::validation`.
+- **Runs correctly** under `lean_single` (verified): mean([2,4,6,8,10])=6, std=√10=3.162278; the `&x`
+  slice idiom sidesteps the cross-module `[f64;N]`-by-value corruption that blocks the array-by-value
+  regression API.
+- Build caveat: like other multi-module programs, native compile is via `SOUNIO_SOUC_ENGINE=lean_single`
+  (+ `chmod +x`); default Madaros hits visibility-preflight. (See the 2026-07-14 audit dispatches.)
+
+## 3. Goal
+An independent run-proof asserts `stats::validation`'s descriptive + regression outputs against
+published/hand-computed values, gated — proving correctness without touching the active lane's source.
+
+## 4. Scope
+### In
+1. **Run-proof driver** (`tests/stdlib/stats/test_validation_runproof.sio`) — asserts mean, variance,
+   std_dev, standard_error, max, range, correlation, r_squared, and OLS slope/intercept.
+2. **Gate** (`scripts/stats_validation_gate.sh`, lean_single).
+### Out
+- **No edit to any `stdlib/stats/` source or existing test/harness** (coordination — the other lane owns
+  those). No display helper. No new stats module.
+- No compiler edits.
+- Math-review of the statistical identities is run and logged.
+
+## 5. Design — assertions (published / hand-computed)
+- data = [2,4,6,8,10]: mean=6; sample variance=10; std=√10≈3.162278; SE=std/√5≈1.414214; max=10; range=8.
+- x=[1,2,3,4,5], y=[2,4,5,4,5]: Pearson r = Sxy/√(Sxx·Syy) = 6/√60 ≈ 0.774597; r²=0.6;
+  OLS slope = Sxy/Sxx = 0.6; intercept = ȳ − slope·x̄ = 2.2.
+All inline in `main` (multi-module importing-program constraint); assert on returned f64 fields.
+
+## 6. Module layout
+```
+tests/stdlib/stats/test_validation_runproof.sio   (new — uniquely named)
+scripts/stats_validation_gate.sh                   (new)
+```
+
+## 7. Verification
+- `validation.sio` compiles under lean_single (it uses `.len()` etc. the default Madaros engine rejects).
+- `SOUNIO_SOUC_ENGINE=lean_single souc compile … && chmod +x && ./elf` → `STATS_VALIDATION_OK`.
+- `scripts/stats_validation_gate.sh` → `STATS_VALIDATION_GATE_OK`.
+- Math-review logged.
+
+## 8. Success criteria
+1. Run-proof asserts published values for descriptive + regression stats and passes under lean_single.
+2. Gate green.
+3. No stats source or active-lane file modified (disjoint); no compiler files touched.
+
+## 9. Risks
+| Risk | Mitigation |
+|---|---|
+| Active stats lane drift causes a merge conflict | Unique filenames; no source edits; rebase-on-conflict (as done for #892/#902). |
+| Reader assumes default Madaros builds it | Gate + header comment state the lean_single requirement. |

--- a/scripts/stats_validation_gate.sh
+++ b/scripts/stats_validation_gate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+# NOTE: build under lean_single. stats/validation.sio uses `.len()` and other constructs the default
+# Madaros engine rejects, and importing multi-module programs hit Madaros visibility-preflight; lean_single
+# compiles both the module and the driver. lean_single output needs chmod +x.
+# (see docs/audit/MADAROS_*_2026-07-14.md)
+echo "== run-proof (lean_single, also compiles validation.sio) =="
+if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile tests/stdlib/stats/test_validation_runproof.sio -o "$OUT/sv.elf" >/dev/null 2>&1; then
+  chmod +x "$OUT/sv.elf"
+  "$OUT/sv.elf" | grep -q "STATS_VALIDATION_OK" || { echo "FAIL: run-proof assertions"; fail=1; }
+else echo "FAIL: run-proof compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "STATS_VALIDATION_GATE_OK"
+exit $fail

--- a/tests/stdlib/stats/test_validation_runproof.sio
+++ b/tests/stdlib/stats/test_validation_runproof.sio
@@ -1,0 +1,51 @@
+// Independent published-value run-proof for stdlib stats::validation (descriptive + regression).
+// Disjoint lane: reads the module, edits no stats source. Build with lean_single (multi-module).
+// data = [2,4,6,8,10]: mean=6, sample var=10, std=sqrt(10)=3.162278, se=std/sqrt5=1.414214, min=2,max=10,range=8.
+// x=[1,2,3,4,5], y=[2,4,5,4,5]: Pearson r=6/sqrt(60)=0.774597, r^2=0.6; OLS slope=0.6, intercept=2.2.
+use stats::validation::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var d: [f64; 5] = [0.0; 5]
+    d[0] = 2.0
+    d[1] = 4.0
+    d[2] = 6.0
+    d[3] = 8.0
+    d[4] = 10.0
+
+    let mn = mean(&d)
+    if (if mn > 6.0 { mn - 6.0 } else { 6.0 - mn }) >= 1.0e-6 { print("FAIL mean\n"); return 1 }
+    let vr = variance(&d)
+    if (if vr > 10.0 { vr - 10.0 } else { 10.0 - vr }) >= 1.0e-6 { print("FAIL variance\n"); return 2 }
+    let sd = std_dev(&d)
+    if (if sd > 3.162278 { sd - 3.162278 } else { 3.162278 - sd }) >= 1.0e-5 { print("FAIL std_dev\n"); return 3 }
+    let se = standard_error(&d)
+    if (if se > 1.414214 { se - 1.414214 } else { 1.414214 - se }) >= 1.0e-5 { print("FAIL se\n"); return 4 }
+    let mx = max(&d)
+    if (if mx > 10.0 { mx - 10.0 } else { 10.0 - mx }) >= 1.0e-9 { print("FAIL max\n"); return 5 }
+    let rg = range(&d)
+    if (if rg > 8.0 { rg - 8.0 } else { 8.0 - rg }) >= 1.0e-9 { print("FAIL range\n"); return 6 }
+
+    var x: [f64; 5] = [0.0; 5]
+    var y: [f64; 5] = [0.0; 5]
+    x[0] = 1.0
+    x[1] = 2.0
+    x[2] = 3.0
+    x[3] = 4.0
+    x[4] = 5.0
+    y[0] = 2.0
+    y[1] = 4.0
+    y[2] = 5.0
+    y[3] = 4.0
+    y[4] = 5.0
+
+    let r = correlation(&x, &y)
+    if (if r > 0.774597 { r - 0.774597 } else { 0.774597 - r }) >= 1.0e-5 { print("FAIL correlation\n"); return 7 }
+    let r2 = r_squared(&x, &y)
+    if (if r2 > 0.6 { r2 - 0.6 } else { 0.6 - r2 }) >= 1.0e-5 { print("FAIL r_squared\n"); return 8 }
+    let fit = linear_regression(&x, &y)
+    if (if fit.slope > 0.6 { fit.slope - 0.6 } else { 0.6 - fit.slope }) >= 1.0e-5 { print("FAIL slope\n"); return 9 }
+    if (if fit.intercept > 2.2 { fit.intercept - 2.2 } else { 2.2 - fit.intercept }) >= 1.0e-5 { print("FAIL intercept\n"); return 10 }
+
+    print("STATS_VALIDATION_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Independent run-proof for `stats::validation` (coordinated, disjoint lane)

Continues the playbook (GUM #860, units #873, linalg #892, prob #902) — adapted for **coordination**. The `stats` module is under active development by another lane (PR #905 `feat/stats-suite-11`, the `stats-suite-*` series), so instead of hardening a file they own, this PR adds **independent published-value verification** for a stable, unclaimed module.

**Disjoint by construction:** reads `stdlib/stats/validation.sio`, edits **no stats source and no existing test/harness**; write-set is only new, uniquely-named files. `validation.sio` was last touched by an unrelated commit and is not in PR #905.

### What's here
- **Run-proof** (`tests/stdlib/stats/test_validation_runproof.sio`) — asserts descriptive + regression outputs against hand-computed values: mean=6, sample var=10, std=√10, SE=√2, range=8 (data [2,4,6,8,10]); Pearson r=6/√60≈0.774597, r²=0.6, OLS slope=0.6, intercept=2.2 (x=[1..5], y=[2,4,5,4,5]). `STATS_VALIDATION_OK`.
- **Gate** (`scripts/stats_validation_gate.sh`) → `STATS_VALIDATION_GATE_OK`.

### Build note
Builds under `SOUNIO_SOUC_ENGINE=lean_single` (+ `chmod +x`): `validation.sio` uses `.len()`/constructs the default Madaros engine rejects, and importing multi-module programs hit Madaros visibility-preflight (both tracked in the 2026-07-14 audit dispatches / issues #890/#901). The `&x` slice idiom also sidesteps the cross-module `[f64;N]`-by-value corruption that blocks the array-by-value regression API.

### Verification
Compile-and-run under lean_single. Math-review (xAI/Grok) PASS on the statistical identities, logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
