### PR TITLE
feat(stats): goodness-of-fit tests — ks_test, gof, normality

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2703,3 +2703,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - trend = **PASS**: CA score statistic T, centered Sxx, null variance V, χ²=T²/V, slope=T/Sxx all match; worked example (T=50, χ²=26.667, z=5.164, slope=0.10) reproduced exactly.
 - Theme: paired / repeated-measures / ordered-design tests — fills the gap left by the suite's independent-groups tests. Suite selftest: 33 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-c3hsRt/`, `/tmp/llm-offload-n1l38u/`, `/tmp/llm-offload-QM8I6l/`.
+
+## 2026-07-14 — math-review: stats::ks_test, stats::gof, stats::normality
+- Files (all new): `stdlib/stats/ks_test.sio` (Kolmogorov-Smirnov one-sample-vs-normal and two-sample, Stephens 1970 asymptotic p, internal insertion sort), `stdlib/stats/gof.sio` (Pearson χ² + likelihood-ratio G goodness-of-fit with ddof, χ² tail via Lanczos log-gamma + regularised incomplete gamma), `stdlib/stats/normality.sio` (Jarque-Bera omnibus normality: skewness, kurtosis, JB, closed-form p=exp(-JB/2)). Provider: xAI/Grok 4.3.
+- ks_test = **PASS**: Kolmogorov asymptotic p (finite-sample λ), one-sample d±/order-statistic sup, two-sample merge-walk sup, erf/exp/sqrt helpers, all four test D/ne values verified.
+- gof = **PASS**: Pearson χ², G=2ΣO ln(O/E), df=k−1−ddof, incomplete-gamma χ² tail all correct; worked values (χ²=20, G=21.288, p=1.7e−4) exact.
+- normality = **PASS**: JB formulas + χ²(2) survival exp(−x/2); hand-verified moments (mean 5, m2=4, m3=5.25, m4=44.5); edge cases (n<2, m2=0) defined.
+- Theme: goodness-of-fit / distributional diagnostics — the analytic complement to the visual qq_normal. Suite selftest: 36 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-TFBYYh/`, `/tmp/llm-offload-tezDcO/`, `/tmp/llm-offload-tjxfPd/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -40,6 +40,9 @@ MODULES=(
   stdlib/stats/mcnemar.sio
   stdlib/stats/friedman.sio
   stdlib/stats/trend.sio
+  stdlib/stats/ks_test.sio
+  stdlib/stats/gof.sio
+  stdlib/stats/normality.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -549,6 +549,41 @@ T²/V` (df 1), two-sided p, and the fitted slope (proportion per unit score).
 Validated: doses 0–3 with proportions 0.1–0.4 → χ²=26.667, z=5.164, slope=0.10;
 flat proportions → χ²=0.
 
+### `stats::ks_test` — Kolmogorov-Smirnov tests
+
+| Function | Signature |
+|---|---|
+| `ks_one_normal` | `pub fn ks_one_normal(x: &[f64; 256], n: i32, mu: f64, sigma: f64) -> KSResult with Mut, Div, Panic` |
+| `ks_two` | `pub fn ks_two(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> KSResult with Mut, Div, Panic` |
+
+The distribution-free supremum goodness-of-fit test in both forms: one-sample
+against a Normal(μ,σ) reference (`D = supₓ|Fₙ(x)−Φ(x)|`) and two-sample
+(`D = supₓ|F₁−F₂|`), with the Kolmogorov asymptotic p-value (Stephens 1970
+finite-sample λ). Data is copied and sorted internally. Validated: {−1,0,1} vs
+N(0,1) → D=0.1747; fully-separated samples → D=1; identical → D=0, p=1.
+
+### `stats::gof` — chi-squared & G goodness-of-fit
+
+| Function | Signature |
+|---|---|
+| `gof` | `pub fn gof(observed: &[f64; 64], expected: &[f64; 64], k: i32, ddof: i32) -> GofResult with Mut, Div, Panic` |
+
+Pearson's `χ² = Σ(Oᵢ−Eᵢ)²/Eᵢ` and the likelihood-ratio `G = 2ΣOᵢln(Oᵢ/Eᵢ)`
+for binned counts, both against χ²(k−1−ddof), where `ddof` counts parameters
+estimated from the data. Validated: O={10,20,30,40} vs E=25 → χ²=20, G=21.288,
+df=3, p≈1.7e−4; perfect fit → χ²=G=0, p=1.
+
+### `stats::normality` — Jarque-Bera omnibus normality test
+
+| Function | Signature |
+|---|---|
+| `normality` | `pub fn normality(x: &[f64; 256], n: i32) -> NormalityResult with Mut, Div, Panic` |
+
+The moment-based (skewness + kurtosis) complement to the visual `qq_normal`
+check: reports sample skewness, kurtosis (normal=3) and excess, the Jarque-Bera
+statistic `JB = n/6·(S²+(K−3)²/4) ~ χ²(2)`, and its closed-form p = e^{−JB/2}.
+Validated: {2,4,4,4,5,5,7,9} → S=0.6563, K=2.7813, JB=0.5902, p=0.7445.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -584,6 +619,9 @@ use stats::weibull_negbin::{weibull_pdf, weibull_cdf, weibull_quantile, weibull_
 use stats::mcnemar::{McNemarResult, mcnemar}
 use stats::friedman::{FriedmanResult, friedman}
 use stats::trend::{TrendResult, cochran_armitage}
+use stats::ks_test::{KSResult, ks_one_normal, ks_two}
+use stats::gof::{GofResult, gof}
+use stats::normality::{NormalityResult, normality}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/gof.sio
+++ b/stdlib/stats/gof.sio
@@ -1,0 +1,242 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/gof.sio — goodness-of-fit for binned counts
+//
+// Pearson's chi-squared and the likelihood-ratio (G) test for a set of observed
+// bin counts against expected counts:
+//
+//   gof(observed, expected, k, ddof) -> GofResult
+//
+//   Pearson  χ² = Σ (Oᵢ − Eᵢ)² / Eᵢ
+//   G-test   G  = 2 Σ Oᵢ ln(Oᵢ / Eᵢ)          (Oᵢ=0 term contributes 0)
+//   df = k − 1 − ddof   (ddof = #parameters estimated from the data)
+//
+// Both are asymptotically χ²(df); the G-test is the likelihood-ratio form and
+// is preferred for sparse tables. Expected counts may be supplied directly or
+// derived from an assumed distribution by the caller.
+//
+// Pure Sounio: inline ln/exp + Lanczos log-gamma & regularised incomplete gamma
+// for the χ² tail; no external dependency, no nested data-array calls.
+//
+// References:
+//   Pearson (1900); Sokal & Rohlf, "Biometry" 4e, §17 (G-test, Williams corr.).
+
+module stats::gof
+
+fn gf_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / gf_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn gf_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn gf_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * gf_ln(tt) - tt + gf_ln(a)
+}
+
+fn gf_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * gf_exp(0.0 - x + s * gf_ln(x) - gf_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = gf_exp(0.0 - x + s * gf_ln(x) - gf_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn gf_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    if df <= 0.0 { return 1.0 }
+    return 1.0 - gf_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct GofResult {
+    pub chi2: f64,   // Pearson statistic
+    pub g: f64,      // likelihood-ratio (G) statistic
+    pub df: i64,     // k - 1 - ddof
+    pub p_chi2: f64, // asymptotic p for Pearson
+    pub p_g: f64,    // asymptotic p for G
+}
+
+/// Goodness-of-fit test on k observed vs expected bin counts.
+///
+/// Parâmetros: observed, expected — length-k count vectors (expected>0);
+///             k — bins (>=2); ddof — extra params estimated (df = k-1-ddof).
+/// Retorno: GofResult (chi2, g, df, p_chi2, p_g).
+/// Referências: Pearson (1900); Sokal & Rohlf §17.
+pub fn gof(observed: &[f64; 64], expected: &[f64; 64], k: i32, ddof: i32) -> GofResult with Mut, Div, Panic {
+    if k < 2 { return GofResult { chi2: 0.0, g: 0.0, df: 0, p_chi2: 1.0, p_g: 1.0 } }
+    var chi2 = 0.0
+    var g = 0.0
+    var i = 0
+    while i < k {
+        let o = observed[i as usize]
+        let e = expected[i as usize]
+        if e > 0.0 {
+            let dif = o - e
+            chi2 = chi2 + dif * dif / e
+            if o > 0.0 { g = g + o * gf_ln(o / e) }
+        }
+        i = i + 1
+    }
+    g = 2.0 * g
+    let df = k - 1 - ddof
+    var p_chi2 = 1.0
+    var p_g = 1.0
+    if df > 0 {
+        p_chi2 = gf_chi2_sf(chi2, df as f64)
+        p_g = gf_chi2_sf(g, df as f64)
+    }
+    return GofResult { chi2: chi2, g: g, df: df as i64, p_chi2: p_chi2, p_g: p_g }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// O={10,20,30,40}, E=25 each. chi2 = (225+25+25+225)/25 = 20, df=3.
+// G = 2[10ln0.4 + 20ln0.8 + 30ln1.2 + 40ln1.6] = 2·10.644018 = 21.288036.
+// chi2 tail df=3 at 20 -> p ~ 0.000170.
+fn test_gof() -> bool with IO, Mut, Div, Panic {
+    var o: [f64; 64] = [0.0; 64]
+    var e: [f64; 64] = [0.0; 64]
+    o[0]=10.0; o[1]=20.0; o[2]=30.0; o[3]=40.0
+    e[0]=25.0; e[1]=25.0; e[2]=25.0; e[3]=25.0
+    let r = gof(&o, &e, 4, 0)
+    var ok = true
+    ok = check(1, approx(r.chi2, 20.0, 1.0e-6)) && ok
+    ok = check(2, approx(r.g, 21.288036, 1.0e-4)) && ok
+    ok = check(3, r.df == 3) && ok
+    ok = check(4, approx(r.p_chi2, 0.000170, 1.0e-4)) && ok
+    return ok
+}
+
+// Perfect fit O=E -> chi2 0, G 0, p 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var o: [f64; 64] = [0.0; 64]
+    var e: [f64; 64] = [0.0; 64]
+    o[0]=25.0; o[1]=25.0; o[2]=25.0; o[3]=25.0
+    e[0]=25.0; e[1]=25.0; e[2]=25.0; e[3]=25.0
+    let r = gof(&o, &e, 4, 0)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.g, 0.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.p_chi2, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// ddof reduces df: same data, ddof=1 -> df=2.
+fn test_ddof() -> bool with IO, Mut, Div, Panic {
+    var o: [f64; 64] = [0.0; 64]
+    var e: [f64; 64] = [0.0; 64]
+    o[0]=8.0; o[1]=12.0; o[2]=10.0
+    e[0]=10.0; e[1]=10.0; e[2]=10.0
+    let r = gof(&o, &e, 3, 1)
+    // chi2 = (4+4+0)/10 = 0.8, df = 3-1-1 = 1.
+    var ok = true
+    ok = check(20, approx(r.chi2, 0.8, 1.0e-9)) && ok
+    ok = check(21, r.df == 1) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_gof() && ok
+    ok = test_perfect() && ok
+    ok = test_ddof() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/ks_test.sio
+++ b/stdlib/stats/ks_test.sio
@@ -1,0 +1,252 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/ks_test.sio — Kolmogorov-Smirnov tests
+//
+// The distribution-free supremum test of goodness of fit, in both forms:
+//
+//   ks_one_normal(x, n, mu, sigma) -> KSResult   (vs a normal reference)
+//   ks_two(x, nx, y, ny)           -> KSResult   (two-sample)
+//
+// D is the largest vertical gap between the empirical CDF(s):
+//   one-sample  D = supₓ |Fₙ(x) − Φ(x)|,
+//   two-sample  D = supₓ |F₁(x) − F₂(x)|.
+// The asymptotic p-value uses the Kolmogorov distribution
+//   P(D > d) = 2 Σ_{j≥1} (−1)^{j−1} e^{−2 j² λ²},   λ = (√ne + 0.12 + 0.11/√ne)·D,
+// with ne = n one-sample and ne = n₁n₂/(n₁+n₂) two-sample (Stephens 1970).
+//
+// Pure Sounio: inline erf + insertion sort over a fixed [256] scratch; no
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Kolmogorov (1933); Smirnov (1948); Stephens (1970) JRSS-B 32:115.
+
+module stats::ks_test
+
+fn ks_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 24 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn ks_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ks_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn ks_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * ks_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn ks_normal_cdf(x: f64, mu: f64, sigma: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 + ks_erf((x - mu) / sigma * INV_SQRT2))
+}
+
+// Kolmogorov p-value from the effective-sample statistic; series truncated at
+// 100 terms (converges geometrically for any positive D).
+fn ks_pvalue(ne: f64, d: f64) -> f64 with Mut, Div, Panic {
+    if d <= 0.0 { return 1.0 }
+    let sn = ks_sqrt(ne)
+    let lam = (sn + 0.12 + 0.11 / sn) * d
+    let a = 0.0 - 2.0 * lam * lam
+    var sum = 0.0
+    var sign = 1.0
+    var j = 1
+    while j <= 100 {
+        let term = sign * ks_exp(a * (j as f64) * (j as f64))
+        sum = sum + term
+        let at = if term < 0.0 { 0.0 - term } else { term }
+        if at < 1.0e-12 { j = 101 } else { j = j + 1 }
+        sign = 0.0 - sign
+    }
+    var p = 2.0 * sum
+    if p > 1.0 { p = 1.0 }
+    if p < 0.0 { p = 0.0 }
+    return p
+}
+
+// insertion sort of the first n entries of a [256] buffer, ascending.
+fn ks_sort(a: &![f64; 256], n: i32) with Mut {
+    var i = 1
+    while i < n {
+        let key = a[i as usize]
+        var j = i - 1
+        while j >= 0 && a[j as usize] > key {
+            a[(j + 1) as usize] = a[j as usize]
+            j = j - 1
+        }
+        a[(j + 1) as usize] = key
+        i = i + 1
+    }
+}
+
+pub struct KSResult {
+    pub d: f64,      // KS statistic (sup gap)
+    pub p: f64,      // asymptotic two-sided p-value
+    pub ne: f64,     // effective sample size used
+}
+
+/// One-sample KS test against a Normal(mu, sigma) reference.
+///
+/// Parâmetros: x — sample (copied & sorted internally); n — size (<=256);
+///             mu, sigma — reference mean and sd (sigma>0).
+/// Retorno: KSResult (d, p, ne=n).
+pub fn ks_one_normal(x: &[f64; 256], n: i32, mu: f64, sigma: f64) -> KSResult with Mut, Div, Panic {
+    if n < 1 || sigma <= 0.0 { return KSResult { d: 0.0, p: 1.0, ne: 0.0 } }
+    var s: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < n { s[i as usize] = x[i as usize]; i = i + 1 }
+    ks_sort(&!s, n)
+    let nf = n as f64
+    var dmax = 0.0
+    var k = 0
+    while k < n {
+        let fx = ks_normal_cdf(s[k as usize], mu, sigma)
+        let dplus = ((k + 1) as f64) / nf - fx     // F_n at/above point minus F
+        let dminus = fx - (k as f64) / nf          // F minus F_n just below point
+        if dplus > dmax { dmax = dplus }
+        if dminus > dmax { dmax = dminus }
+        k = k + 1
+    }
+    return KSResult { d: dmax, p: ks_pvalue(nf, dmax), ne: nf }
+}
+
+/// Two-sample KS test.
+///
+/// Parâmetros: x, y — the two samples (copied & sorted internally); nx, ny — sizes.
+/// Retorno: KSResult (d, p, ne=nx·ny/(nx+ny)).
+pub fn ks_two(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> KSResult with Mut, Div, Panic {
+    if nx < 1 || ny < 1 { return KSResult { d: 0.0, p: 1.0, ne: 0.0 } }
+    var sx: [f64; 256] = [0.0; 256]
+    var sy: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < nx { sx[i as usize] = x[i as usize]; i = i + 1 }
+    var j = 0
+    while j < ny { sy[j as usize] = y[j as usize]; j = j + 1 }
+    ks_sort(&!sx, nx)
+    ks_sort(&!sy, ny)
+    let nxf = nx as f64
+    let nyf = ny as f64
+    // merge-walk the two ECDFs, tracking the max |F1 - F2|
+    var ia = 0
+    var ib = 0
+    var dmax = 0.0
+    while ia < nx && ib < ny {
+        let va = sx[ia as usize]
+        let vb = sy[ib as usize]
+        if va <= vb { ia = ia + 1 }
+        if vb <= va { ib = ib + 1 }
+        let f1 = (ia as f64) / nxf
+        let f2 = (ib as f64) / nyf
+        var gap = f1 - f2
+        if gap < 0.0 { gap = 0.0 - gap }
+        if gap > dmax { dmax = gap }
+    }
+    let ne = nxf * nyf / (nxf + nyf)
+    return KSResult { d: dmax, p: ks_pvalue(ne, dmax), ne: ne }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// One-sample: data {-1,0,1} vs standard normal.
+// Φ(-1)=0.158655, Φ(0)=0.5, Φ(1)=0.841345.
+// k=0 (x=-1): d+=1/3-0.158655=0.174679; d-=0.158655-0=0.158655
+// k=1 (x=0):  d+=2/3-0.5=0.166667;      d-=0.5-1/3=0.166667
+// k=2 (x=1):  d+=1-0.841345=0.158655;   d-=0.841345-2/3=0.174679
+// D = 0.174679.
+fn test_one() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0] = 0.0 - 1.0; x[1] = 0.0; x[2] = 1.0
+    let r = ks_one_normal(&x, 3, 0.0, 1.0)
+    var ok = true
+    ok = check(1, approx(r.d, 0.174679, 1.0e-4)) && ok
+    ok = check(2, r.p > 0.9) && ok            // tiny sample, no evidence against normal
+    return ok
+}
+
+// Two-sample, fully separated: x={1,2,3}, y={4,5,6} -> ECDFs never overlap, D=1.
+fn test_two_separated() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    y[0]=4.0; y[1]=5.0; y[2]=6.0
+    let r = ks_two(&x, 3, &y, 3)
+    var ok = true
+    ok = check(10, approx(r.d, 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.ne, 1.5, 1.0e-9)) && ok   // 3·3/6
+    return ok
+}
+
+// Two-sample identical samples -> D=0, p=1.
+fn test_two_identical() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    let r = ks_two(&x, 4, &x, 4)
+    var ok = true
+    ok = check(20, approx(r.d, 0.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.p, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// Two-sample partial overlap: x={1,2,3,4}, y={3,4,5,6}.
+// walk: at 1 f1=.25,f2=0 gap .25; at 2 f1=.5 gap .5; at 3 both advance
+// f1=.75,f2=.25 gap .5; at 4 f1=1,f2=.5 gap .5; then y 5,6. D=0.5.
+fn test_two_overlap() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=3.0; y[1]=4.0; y[2]=5.0; y[3]=6.0
+    let r = ks_two(&x, 4, &y, 4)
+    return check(30, approx(r.d, 0.5, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_one() && ok
+    ok = test_two_separated() && ok
+    ok = test_two_identical() && ok
+    ok = test_two_overlap() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/normality.sio
+++ b/stdlib/stats/normality.sio
@@ -1,0 +1,160 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/normality.sio — Jarque-Bera omnibus normality test
+//
+// A moment-based test of normality from a sample's skewness and kurtosis — the
+// analytic complement to the visual qq_normal check:
+//
+//   normality(x, n) -> NormalityResult
+//
+// With population central moments m₂,m₃,m₄ and s=√m₂:
+//   skewness  S = m₃ / s³
+//   kurtosis  K = m₄ / m₂²         (normal → 3; excess = K − 3)
+//   Jarque-Bera  JB = n/6 · ( S² + (K−3)²/4 )   ~  χ²(2)  under H₀,
+// so the p-value has the closed form  p = e^{−JB/2}  (χ²₂ survival).
+//
+// Pure Sounio: inline sqrt/exp; single pass for the mean, one pass for the
+// moments; no external dependency, no nested data-array calls.
+//
+// References:
+//   Jarque & Bera (1987) Int. Stat. Rev. 55:163; Bowman & Shenton (1975).
+
+module stats::normality
+
+fn nm_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 24 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn nm_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / nm_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+pub struct NormalityResult {
+    pub skewness: f64,   // m3 / s^3
+    pub kurtosis: f64,   // m4 / m2^2 (normal = 3)
+    pub excess: f64,     // kurtosis - 3
+    pub jb: f64,         // Jarque-Bera statistic
+    pub p: f64,          // p-value, chi-squared(2) survival = exp(-JB/2)
+}
+
+/// Jarque-Bera omnibus normality test on a sample.
+///
+/// Parâmetros: x — sample; n — size (>=4 for a meaningful test, <=256).
+/// Retorno: NormalityResult (skewness, kurtosis, excess, jb, p).
+/// Referências: Jarque & Bera (1987).
+pub fn normality(x: &[f64; 256], n: i32) -> NormalityResult with Mut, Div, Panic {
+    if n < 2 {
+        return NormalityResult { skewness: 0.0, kurtosis: 0.0, excess: 0.0 - 3.0, jb: 0.0, p: 1.0 }
+    }
+    let nf = n as f64
+    var sum = 0.0
+    var i = 0
+    while i < n { sum = sum + x[i as usize]; i = i + 1 }
+    let mean = sum / nf
+    var m2 = 0.0
+    var m3 = 0.0
+    var m4 = 0.0
+    var j = 0
+    while j < n {
+        let d = x[j as usize] - mean
+        let d2 = d * d
+        m2 = m2 + d2
+        m3 = m3 + d2 * d
+        m4 = m4 + d2 * d2
+        j = j + 1
+    }
+    m2 = m2 / nf
+    m3 = m3 / nf
+    m4 = m4 / nf
+    if m2 <= 0.0 {
+        // constant sample: no dispersion, perfectly degenerate
+        return NormalityResult { skewness: 0.0, kurtosis: 0.0, excess: 0.0 - 3.0, jb: 0.0, p: 1.0 }
+    }
+    let s = nm_sqrt(m2)
+    let skew = m3 / (s * s * s)
+    let kurt = m4 / (m2 * m2)
+    let excess = kurt - 3.0
+    let jb = nf / 6.0 * (skew * skew + excess * excess / 4.0)
+    let p = nm_exp(0.0 - jb / 2.0)   // chi-squared(2) survival
+    return NormalityResult { skewness: skew, kurtosis: kurt, excess: excess, jb: jb, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {2,4,4,4,5,5,7,9}: mean 5, m2=4, m3=42/8=5.25, m4=356/8=44.5.
+// skew=5.25/8=0.65625; kurt=44.5/16=2.78125; excess=-0.21875.
+// JB = 8/6·(0.65625² + 0.21875²/4) = 1.333333·0.442627 = 0.590169.
+// p = exp(-0.295085) = 0.744493.
+fn test_normality() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=4.0; x[3]=4.0; x[4]=5.0; x[5]=5.0; x[6]=7.0; x[7]=9.0
+    let r = normality(&x, 8)
+    var ok = true
+    ok = check(1, approx(r.skewness, 0.65625, 1.0e-5)) && ok
+    ok = check(2, approx(r.kurtosis, 2.78125, 1.0e-5)) && ok
+    ok = check(3, approx(r.excess, 0.0 - 0.21875, 1.0e-5)) && ok
+    ok = check(4, approx(r.jb, 0.590169, 1.0e-4)) && ok
+    ok = check(5, approx(r.p, 0.744493, 1.0e-4)) && ok
+    return ok
+}
+
+// symmetric {1,2,3,4,5}: skew 0; m2=2, m4=34/5=6.8; kurt=6.8/4=1.7.
+// JB = 5/6·(0 + 1.3²/4) = 0.833333·0.4225 = 0.352083; p=exp(-0.176042)=0.838586.
+fn test_symmetric() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = normality(&x, 5)
+    var ok = true
+    ok = check(10, approx(r.skewness, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.kurtosis, 1.7, 1.0e-5)) && ok
+    ok = check(12, approx(r.jb, 0.352083, 1.0e-4)) && ok
+    ok = check(13, approx(r.p, 0.838586, 1.0e-4)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_normality() && ok
+    ok = test_symmetric() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three more pure-Sounio modules for the epistemic-statistics suite, bringing it to **36 modules**. These give the suite a formal **distributional-testing** family — until now the only normality check was the *visual* `qq_normal`. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::ks_test` | Kolmogorov-Smirnov: one-sample vs Normal + two-sample, Stephens (1970) asymptotic p; internal sort |
| `stats::gof` | Pearson χ² + likelihood-ratio G-test for binned counts, with ddof adjustment |
| `stats::normality` | Jarque-Bera omnibus normality (skewness + kurtosis), closed-form χ²(2) p = e^(−JB/2) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - KS: {−1,0,1} vs N(0,1) → D=0.1747; fully-separated → D=1; identical → D=0, p=1; partial overlap → D=0.5.
  - GoF: O={10,20,30,40} vs E=25 → χ²=20, G=21.288, df=3, p≈1.7e−4; perfect fit → χ²=G=0.
  - Normality: {2,4,4,4,5,5,7,9} → S=0.6563, K=2.7813, JB=0.5902, p=0.7445 (all exact).
- Full suite selftest: **36 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency: χ² tails via inline Lanczos log-gamma + regularised incomplete gamma; KS tail via the Kolmogorov series; normal CDF via inline A-S erf.
- `#852`-safe: fixed-width scratch, scalar/small-struct returns, no nested data-array calls.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).