### PR TITLE
feat(stats): survival analysis — km, logrank, exp_survival

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2711,3 +2711,12 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - normality = **PASS**: JB formulas + χ²(2) survival exp(−x/2); hand-verified moments (mean 5, m2=4, m3=5.25, m4=44.5); edge cases (n<2, m2=0) defined.
 - Theme: goodness-of-fit / distributional diagnostics — the analytic complement to the visual qq_normal. Suite selftest: 36 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-TFBYYh/`, `/tmp/llm-offload-tezDcO/`, `/tmp/llm-offload-tjxfPd/`.
+
+## 2026-07-14 — math-review: stats::km, stats::logrank, stats::exp_survival
+- Files (all new): `stdlib/stats/km.sio` (Kaplan-Meier product-limit survival, scalar summaries: S(t), median, S_final, events — sort-free ordered walk over distinct death times), `stdlib/stats/logrank.sio` (two-group Mantel-Haenszel log-rank test: hypergeometric O/E/V per death time, χ², O/E hazard ratio), `stdlib/stats/exp_survival.sio` (MLE exponential survival: λ̂=D/T, log-scale CI, median/mean/S(t)). Provider: xAI/Grok 4.3.
+- km = **PASS**: product-limit definition, median rule, risk-set/deaths counting, censoring + ties all verified; four test cases algebraically correct.
+- logrank = **PASS**: hypergeometric expectation e₁=d·n₁/n and finite-population variance, χ²=(O₁−E₁)²/V, M-H hazard ratio all match; worked example (E₁=3.7667, V=1.2122, χ²=0.4849, HR=0.5929) exact; null symmetry → 0.
+- exp_survival = **PASS**: λ̂=D/T MLE, Var=λ̂²/D, log-scale CI exp(±z/√D), S/median/mean all standard; all test constants match.
+- **Milestone**: survival analysis was the historical #852 codegen blocker (km_fit silent crash). The #852-safe re-architecture (flat loops, scalar returns, no nested calls with big arrays live) delivers a full survival family running cleanly under lean_single.
+- Suite selftest: 39 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-7arr1i/`, `/tmp/llm-offload-j5337P/`, `/tmp/llm-offload-4Cujib/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -43,6 +43,9 @@ MODULES=(
   stdlib/stats/ks_test.sio
   stdlib/stats/gof.sio
   stdlib/stats/normality.sio
+  stdlib/stats/km.sio
+  stdlib/stats/logrank.sio
+  stdlib/stats/exp_survival.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -584,6 +584,41 @@ check: reports sample skewness, kurtosis (normal=3) and excess, the Jarque-Bera
 statistic `JB = n/6·(S²+(K−3)²/4) ~ χ²(2)`, and its closed-form p = e^{−JB/2}.
 Validated: {2,4,4,4,5,5,7,9} → S=0.6563, K=2.7813, JB=0.5902, p=0.7445.
 
+### `stats::km` — Kaplan-Meier survival summaries
+
+| Function | Signature |
+|---|---|
+| `km` | `pub fn km(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64) -> KMResult with Mut, Div, Panic` |
+
+The non-parametric product-limit estimator `Ŝ(t) = Π(1−dⱼ/nⱼ)`, reported as
+scalar summaries — Ŝ at a queried time, median survival (first death time with
+Ŝ≤½), final Ŝ, and event count. Right-censoring (event=0) reduces the risk set
+without a step. Validated: times 1–5 all deaths → S(2)=0.6, median 3; with
+censoring {1,0,1,0,1} → S(4)=0.5333; tied deaths handled.
+
+### `stats::logrank` — two-group log-rank test
+
+| Function | Signature |
+|---|---|
+| `logrank` | `pub fn logrank(time: &[f64; 256], event: &[i64; 256], group: &[i64; 256], n: i32) -> LogRankResult with Mut, Div, Panic` |
+
+The Mantel-Haenszel test for a difference between two survival curves:
+observed vs expected deaths with the hypergeometric variance at each distinct
+death time, giving `χ²=(O₁−E₁)²/V` (df 1) and the O/E hazard ratio. Validated:
+interleaved-deaths example → χ²=0.4849, E₁=3.7667, HR=0.5929; identical groups
+→ χ²=0, HR=1.
+
+### `stats::exp_survival` — parametric exponential survival fit
+
+| Function | Signature |
+|---|---|
+| `exp_survival` | `pub fn exp_survival(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64) -> ExpSurvResult with Mut, Div, Panic` |
+
+The MLE constant-hazard model from right-censored data — the parametric
+companion to Kaplan-Meier: `λ̂ = D/T` with a log-scale 95% CI `λ̂·exp(±1.96/√D)`,
+plus median `ln2/λ̂`, mean `1/λ̂`, and Ŝ(t)=e^{−λ̂t}. Validated: {2,3,5⁺,6,7}
+with one censored → λ̂=0.1739, median 3.986, mean 5.75, S(4)=0.4988.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -622,6 +657,9 @@ use stats::trend::{TrendResult, cochran_armitage}
 use stats::ks_test::{KSResult, ks_one_normal, ks_two}
 use stats::gof::{GofResult, gof}
 use stats::normality::{NormalityResult, normality}
+use stats::km::{KMResult, km}
+use stats::logrank::{LogRankResult, logrank}
+use stats::exp_survival::{ExpSurvResult, exp_survival}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/exp_survival.sio
+++ b/stdlib/stats/exp_survival.sio
@@ -1,0 +1,159 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/exp_survival.sio — parametric exponential survival fit
+//
+// The maximum-likelihood exponential (constant-hazard) survival model from
+// right-censored follow-up data — the parametric companion to the Kaplan-Meier
+// estimator:
+//
+//   exp_survival(time, event, n, t_query) -> ExpSurvResult
+//
+// With D deaths over total exposure T = Σtᵢ (censored times included), the MLE
+// hazard is  λ̂ = D / T,  Var(λ̂) = λ̂²/D  ⇒  a log-scale 95% CI
+//   λ̂·exp(±1.96/√D).  From λ̂:
+//   S(t) = e^{−λ̂ t},  median = ln2/λ̂,  mean = 1/λ̂,  hazard = λ̂ (constant).
+//
+// Pure Sounio: inline exp/ln/sqrt; single pass over the data; no external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Lawless, "Statistical Models and Methods for Lifetime Data" 2e, §3.
+
+module stats::exp_survival
+
+fn es_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 24 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn es_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / es_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+pub struct ExpSurvResult {
+    pub rate: f64,        // MLE hazard λ̂ = D / T
+    pub rate_lo: f64,     // 95% lower bound on λ
+    pub rate_hi: f64,     // 95% upper bound on λ
+    pub median: f64,      // ln2 / λ̂
+    pub mean: f64,        // 1 / λ̂
+    pub s_at_query: f64,  // Ŝ(t_query) = exp(-λ̂ t_query)
+}
+
+/// Maximum-likelihood exponential survival fit from censored follow-up data.
+///
+/// Parâmetros: time — follow-up times; event — 1 death / 0 censored; n — size;
+///             t_query — time at which to report Ŝ.
+/// Retorno: ExpSurvResult (rate, rate_lo, rate_hi, median, mean, s_at_query).
+/// Referências: Lawless §3.
+pub fn exp_survival(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64) -> ExpSurvResult with Mut, Div, Panic {
+    if n < 1 {
+        return ExpSurvResult { rate: 0.0, rate_lo: 0.0, rate_hi: 0.0, median: 0.0, mean: 0.0, s_at_query: 1.0 }
+    }
+    var total_time = 0.0
+    var deaths = 0
+    var i = 0
+    while i < n {
+        total_time = total_time + time[i as usize]
+        if event[i as usize] == 1 { deaths = deaths + 1 }
+        i = i + 1
+    }
+    if total_time <= 0.0 || deaths <= 0 {
+        return ExpSurvResult { rate: 0.0, rate_lo: 0.0, rate_hi: 0.0, median: 0.0, mean: 0.0, s_at_query: 1.0 }
+    }
+    let df = deaths as f64
+    let rate = df / total_time
+    let z = 1.959963984540054
+    let f = es_exp(z / es_sqrt(df))       // log-scale multiplier
+    let rate_lo = rate / f
+    let rate_hi = rate * f
+    let LN2 = 0.6931471805599453
+    let median = LN2 / rate
+    let mean = 1.0 / rate
+    let s_at_query = es_exp(0.0 - rate * t_query)
+    return ExpSurvResult {
+        rate: rate, rate_lo: rate_lo, rate_hi: rate_hi,
+        median: median, mean: mean, s_at_query: s_at_query
+    }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// times {2,3,5,6,7}, events {1,1,0,1,1}. D=4, T=23. rate=4/23=0.173913.
+// median=ln2/rate=3.985597; mean=5.75; S(4)=exp(-0.695652)=0.498782.
+// CI: rate·exp(±1.959964/2): f=exp(0.979982)=2.664403.
+// lo=0.173913/2.664403=0.065272; hi=0.173913·2.664403=0.463378.
+fn test_exp_surv() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=2.0; t[1]=3.0; t[2]=5.0; t[3]=6.0; t[4]=7.0
+    e[0]=1; e[1]=1; e[2]=0; e[3]=1; e[4]=1
+    let r = exp_survival(&t, &e, 5, 4.0)
+    var ok = true
+    ok = check(1, approx(r.rate, 0.173913, 1.0e-5)) && ok
+    ok = check(2, approx(r.median, 3.985597, 1.0e-4)) && ok
+    ok = check(3, approx(r.mean, 5.75, 1.0e-4)) && ok
+    ok = check(4, approx(r.s_at_query, 0.498782, 1.0e-4)) && ok
+    ok = check(5, approx(r.rate_lo, 0.065272, 1.0e-4)) && ok
+    ok = check(6, approx(r.rate_hi, 0.463378, 1.0e-4)) && ok
+    return ok
+}
+
+// all events, unit times: D=4, T=4, rate=1. median=ln2=0.693147; S(1)=exp(-1)=0.367879.
+fn test_unit() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=1.0; t[2]=1.0; t[3]=1.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1
+    let r = exp_survival(&t, &e, 4, 1.0)
+    var ok = true
+    ok = check(10, approx(r.rate, 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.median, 0.693147, 1.0e-5)) && ok
+    ok = check(12, approx(r.s_at_query, 0.367879, 1.0e-5)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_exp_surv() && ok
+    ok = test_unit() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/km.sio
+++ b/stdlib/stats/km.sio
@@ -1,0 +1,178 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/km.sio — Kaplan-Meier survival summaries
+//
+// The non-parametric survival estimator, reported as scalar summaries rather
+// than a full step curve (so the caller gets auditable numbers directly):
+//
+//   km(time, event, n, t_query) -> KMResult
+//
+// Ŝ(t) = Π_{t_(j) ≤ t} ( 1 − d_j / n_j ),  product over distinct death times,
+// with d_j deaths and n_j = #{i : timeᵢ ≥ t_(j)} at risk.  Right-censored
+// observations (event = 0) leave the estimator flat but reduce the risk set.
+//
+// Returns: Ŝ at the queried time, the median survival (first death time whose
+// Ŝ ≤ ½, or −1 if never reached), the final Ŝ, and the event count.
+//
+// Pure Sounio: an ordered walk over distinct death times (no sort, no nested
+// data-array calls); the risk set is counted inline. O(n²) for n ≤ 256.
+//
+// References:
+//   Kaplan & Meier (1958) JASA 53:457; Collett, "Modelling Survival Data" 3e.
+
+module stats::km
+
+pub struct KMResult {
+    pub s_at_query: f64,  // Ŝ(t_query)
+    pub median: f64,      // median survival time, or -1 if Ŝ never drops to ½
+    pub s_final: f64,     // Ŝ at the largest death time
+    pub n_events: i64,    // total deaths
+}
+
+/// Kaplan-Meier survival summaries.
+///
+/// Parâmetros: time — follow-up times; event — 1 death / 0 censored; n — size
+///             (<=256); t_query — time at which to report Ŝ.
+/// Retorno: KMResult (s_at_query, median, s_final, n_events).
+/// Referências: Kaplan & Meier (1958).
+pub fn km(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64) -> KMResult with Mut, Div, Panic {
+    if n < 1 { return KMResult { s_at_query: 1.0, median: 0.0 - 1.0, s_final: 1.0, n_events: 0 } }
+    var surv = 1.0
+    var s_query = 1.0
+    var median = 0.0 - 1.0
+    var n_events = 0
+    // ordered walk over distinct death times: repeatedly take the smallest
+    // death time strictly greater than the previous one processed.
+    var prev = 0.0 - 1.0e300
+    var have_prev = false
+    var guard = 0
+    while guard <= n {
+        // find the next distinct death time
+        var found = false
+        var tau = 0.0
+        var i = 0
+        while i < n {
+            if event[i as usize] == 1 {
+                let ti = time[i as usize]
+                let after_prev = if have_prev { ti > prev } else { true }
+                if after_prev {
+                    if found == false || ti < tau { tau = ti; found = true }
+                }
+            }
+            i = i + 1
+        }
+        if found == false { guard = n + 1 }
+        else {
+            // deaths at tau and risk set (time >= tau)
+            var d = 0
+            var at_risk = 0
+            var j = 0
+            while j < n {
+                let tj = time[j as usize]
+                if tj >= tau { at_risk = at_risk + 1 }
+                if tj == tau && event[j as usize] == 1 { d = d + 1 }
+                j = j + 1
+            }
+            n_events = n_events + d
+            if at_risk > 0 {
+                surv = surv * (1.0 - (d as f64) / (at_risk as f64))
+            }
+            if tau <= t_query { s_query = surv }
+            if median < 0.0 && surv <= 0.5 { median = tau }
+            prev = tau
+            have_prev = true
+            guard = guard + 1
+        }
+    }
+    return KMResult { s_at_query: s_query, median: median, s_final: surv, n_events: n_events as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// No censoring: times 1..5, all deaths.
+// S(1)=.8, S(2)=.6, S(3)=.4, S(4)=.2, S(5)=0. median=3 (first S<=.5).
+fn test_km_nocensor() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    let r = km(&t, &e, 5, 2.0)
+    var ok = true
+    ok = check(1, approx(r.s_at_query, 0.6, 1.0e-9)) && ok    // S(2)
+    ok = check(2, approx(r.median, 3.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.s_final, 0.0, 1.0e-9)) && ok
+    ok = check(4, r.n_events == 5) && ok
+    return ok
+}
+
+// Same data, query at 4 -> S(4)=0.2.
+fn test_km_query4() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    let r = km(&t, &e, 5, 4.0)
+    return check(10, approx(r.s_at_query, 0.2, 1.0e-9))
+}
+
+// Censoring: times 1..5, events {1,0,1,0,1}.
+// death t=1: n=5,d=1 -> S=.8; t=3: n=3,d=1 -> S=.8·2/3=.533333; t=5: n=1,d=1 -> S=0.
+// median: first S<=.5 is at t=5. S(4)=0.533333. n_events=3.
+fn test_km_censor() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=0; e[2]=1; e[3]=0; e[4]=1
+    let r = km(&t, &e, 5, 4.0)
+    var ok = true
+    ok = check(20, approx(r.s_at_query, 0.533333, 1.0e-5)) && ok
+    ok = check(21, approx(r.median, 5.0, 1.0e-9)) && ok
+    ok = check(22, r.n_events == 3) && ok
+    return ok
+}
+
+// Tied death times: two deaths at t=2.
+// t=1: n=4,d=1 -> S=.75; t=2: n=3,d=2 -> S=.75·(1-2/3)=.75·1/3=.25. median=2.
+fn test_km_ties() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=2.0; t[3]=3.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=0
+    let r = km(&t, &e, 4, 2.0)
+    var ok = true
+    ok = check(30, approx(r.s_at_query, 0.25, 1.0e-9)) && ok
+    ok = check(31, approx(r.median, 2.0, 1.0e-9)) && ok
+    ok = check(32, r.n_events == 3) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_km_nocensor() && ok
+    ok = test_km_query4() && ok
+    ok = test_km_censor() && ok
+    ok = test_km_ties() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/logrank.sio
+++ b/stdlib/stats/logrank.sio
@@ -1,0 +1,275 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/logrank.sio — two-group log-rank test
+//
+// The standard test for a difference between two survival curves, comparing
+// observed to expected deaths across the pooled distinct death times:
+//
+//   logrank(time, event, group, n) -> LogRankResult   (group ∈ {0,1})
+//
+// At each distinct death time t_(j) with dⱼ deaths and nⱼ at risk, split by
+// group, the group-1 expected deaths and hypergeometric variance are
+//   e₁ⱼ = dⱼ · n₁ⱼ / nⱼ,
+//   v₁ⱼ = dⱼ · (n₁ⱼ/nⱼ)(n₀ⱼ/nⱼ) · (nⱼ − dⱼ)/(nⱼ − 1).
+// Then  χ² = (O₁ − E₁)² / V  ~ χ²(1),  and the O/E hazard ratio is
+//   HR = (O₁/E₁) / (O₀/E₀).
+//
+// Pure Sounio: ordered walk over distinct death times (no sort, no nested
+// data-array calls); χ² tail via inline Lanczos log-gamma + incomplete gamma.
+//
+// References:
+//   Mantel (1966); Peto & Peto (1972); Collett, "Modelling Survival Data" §2.
+
+module stats::logrank
+
+fn lr_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / lr_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn lr_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn lr_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * lr_ln(tt) - tt + lr_ln(a)
+}
+
+fn lr_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * lr_exp(0.0 - x + s * lr_ln(x) - lr_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = lr_exp(0.0 - x + s * lr_ln(x) - lr_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn lr_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    return 1.0 - lr_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct LogRankResult {
+    pub chi2: f64,  // log-rank statistic, df 1
+    pub p: f64,     // asymptotic p-value
+    pub o1: f64,    // observed deaths in group 1
+    pub e1: f64,    // expected deaths in group 1
+    pub hr: f64,    // O/E hazard ratio (group1 relative to group0)
+}
+
+/// Two-group log-rank test.
+///
+/// Parâmetros: time — follow-up times; event — 1 death / 0 censored;
+///             group — 0 or 1; n — size (<=256).
+/// Retorno: LogRankResult (chi2, p, o1, e1, hr).
+/// Referências: Mantel (1966); Peto & Peto (1972).
+pub fn logrank(time: &[f64; 256], event: &[i64; 256], group: &[i64; 256], n: i32) -> LogRankResult with Mut, Div, Panic {
+    if n < 2 { return LogRankResult { chi2: 0.0, p: 1.0, o1: 0.0, e1: 0.0, hr: 1.0 } }
+    var o1 = 0.0
+    var e1 = 0.0
+    var v = 0.0
+    var o0 = 0.0
+    var prev = 0.0 - 1.0e300
+    var have_prev = false
+    var guard = 0
+    while guard <= n {
+        // next distinct death time > prev
+        var found = false
+        var tau = 0.0
+        var i = 0
+        while i < n {
+            if event[i as usize] == 1 {
+                let ti = time[i as usize]
+                let after_prev = if have_prev { ti > prev } else { true }
+                if after_prev {
+                    if found == false || ti < tau { tau = ti; found = true }
+                }
+            }
+            i = i + 1
+        }
+        if found == false { guard = n + 1 }
+        else {
+            var nrisk = 0
+            var n1 = 0
+            var d = 0
+            var d1 = 0
+            var j = 0
+            while j < n {
+                let tj = time[j as usize]
+                if tj >= tau {
+                    nrisk = nrisk + 1
+                    if group[j as usize] == 1 { n1 = n1 + 1 }
+                }
+                if tj == tau && event[j as usize] == 1 {
+                    d = d + 1
+                    if group[j as usize] == 1 { d1 = d1 + 1 }
+                }
+                j = j + 1
+            }
+            let nf = nrisk as f64
+            let n1f = n1 as f64
+            let df_ = d as f64
+            let e = df_ * n1f / nf
+            o1 = o1 + (d1 as f64)
+            o0 = o0 + ((d - d1) as f64)
+            e1 = e1 + e
+            if nrisk > 1 {
+                let n0f = (nrisk - n1) as f64
+                v = v + df_ * (n1f / nf) * (n0f / nf) * (nf - df_) / (nf - 1.0)
+            }
+            prev = tau
+            have_prev = true
+            guard = guard + 1
+        }
+    }
+    var chi2 = 0.0
+    if v > 0.0 { chi2 = (o1 - e1) * (o1 - e1) / v }
+    let p = lr_chi2_sf(chi2, 1.0)
+    // O/E hazard ratio
+    let e0 = (o0 + o1) - e1   // total deaths - E1 = E0
+    var hr = 1.0
+    if e1 > 0.0 && e0 > 0.0 && o0 > 0.0 {
+        hr = (o1 / e1) / (o0 / e0)
+    }
+    return LogRankResult { chi2: chi2, p: p, o1: o1, e1: e1, hr: hr }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// group0 deaths at 1,3,5; group1 deaths at 2,4,6 (all events, n=6).
+// O1=3, E1=3.766667, V=1.212222 -> chi2=(0.766667)²/1.212222=0.484877.
+// HR=(O1/E1)/(O0/E0)=(3/3.766667)/(3/2.233333)=0.796460/1.343284=0.592920.
+fn test_logrank() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    var g: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=3.0; t[2]=5.0; t[3]=2.0; t[4]=4.0; t[5]=6.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1; e[5]=1
+    g[0]=0; g[1]=0; g[2]=0; g[3]=1; g[4]=1; g[5]=1
+    let r = logrank(&t, &e, &g, 6)
+    var ok = true
+    ok = check(1, approx(r.chi2, 0.484877, 1.0e-4)) && ok
+    ok = check(2, approx(r.o1, 3.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.e1, 3.766667, 1.0e-4)) && ok
+    ok = check(4, approx(r.hr, 0.592920, 1.0e-4)) && ok
+    return ok
+}
+
+// identical groups (interleaved, symmetric) -> chi2 ~ 0, HR ~ 1.
+// group0 {1,2,3}, group1 {1,2,3}: every death time has equal risk sets.
+fn test_logrank_null() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    var g: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=1.0; t[4]=2.0; t[5]=3.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1; e[5]=1
+    g[0]=0; g[1]=0; g[2]=0; g[3]=1; g[4]=1; g[5]=1
+    let r = logrank(&t, &e, &g, 6)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.hr, 1.0, 1.0e-6)) && ok
+    ok = check(12, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_logrank() && ok
+    ok = test_logrank_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

A **survival-analysis family** for the epistemic-statistics suite, bringing it to **39 modules**. This is the subsystem historically blocked by the **`#852` codegen crash** (the Kaplan-Meier `km_fit` silent failure) — the three modules here are `#852`-safe *by construction* and run cleanly under `lean_single`. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::km` | Kaplan-Meier product-limit estimator → scalar summaries (Ŝ(t), median, final Ŝ, events), censoring + ties |
| `stats::logrank` | Two-group Mantel-Haenszel log-rank test: χ² (df 1) + O/E hazard ratio |
| `stats::exp_survival` | MLE exponential (constant-hazard) fit: λ̂=D/T, log-scale CI, median/mean/S(t) |

## How it stays `#852`-safe

The original crash came from a function making nested calls with several large arrays live across frames. These modules avoid that: **flat loops only, scalar/small-struct returns, no array returns, no nested calls with the data arrays live**. Kaplan-Meier and the log-rank walk process the distinct death times with a **sort-free ordered walk** (repeatedly take the smallest death time greater than the last), so there is no paired-array sort either.

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - KM: times 1–5 all deaths → S(2)=0.6, median 3, S_final=0; censored {1,0,1,0,1} → S(4)=0.5333; tied deaths at one time → S=0.25.
  - Log-rank: interleaved deaths (grp0 {1,3,5}, grp1 {2,4,6}) → χ²=0.4849, E₁=3.7667, HR=0.5929; identical groups → χ²=0, HR=1.
  - Exp survival: {2,3,5⁺,6,7} one censored → λ̂=0.1739, median 3.986, mean 5.75, S(4)=0.4988, CI [0.0653, 0.4634].
- Full suite selftest: **39 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; log-rank χ² tail via inline Lanczos log-gamma + regularised incomplete gamma.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS) and the `#852` milestone note.