### PR TITLE
fix(madaros): copy local known-extent word arrays by value

### DIFF
--- a/docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json
+++ b/docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json
@@ -1,0 +1,48 @@
+{
+  "schema": "sounio.madaros.fixed-array-call-boundary-alias.v1",
+  "recorded_utc": "2026-07-14T18:58:35Z",
+  "blocker_id": "BLK-20260714-madaros-fixed-array-call-boundary-alias",
+  "base_sha": "8ec2c17fa838d08945cd02bc0603353d45719b28",
+  "source": {
+    "path": "tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio",
+    "sha256": "e56cb0a880077c0fbf10956fc210ee877fbdb0ff38fe877114cd1fb7591884be"
+  },
+  "gate": {
+    "path": "scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh",
+    "sha256": "439273f65ebf74606ac7462a7a7735b8170361d3dd637f5e381a5f813bac8897"
+  },
+  "acceptance": {
+    "compiler_kind": "stage2_lean_single_cli",
+    "compiler_path": "/tmp/sounio-d1-compiler-899/souc-stage2",
+    "compiler_sha256": "204dc3665af5bb1cc4dff298bcfffe15f5331d7d4604cbd3d49648724c2b9476",
+    "command": "cd /tmp/sounio-madaros-fixed-array-copy-main-20260714 && /tmp/sounio-d1-compiler-899/souc-stage2 tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio /tmp/sounio-fixed-array-call-boundary-stage2-v1 && chmod +x /tmp/sounio-fixed-array-call-boundary-stage2-v1 && /tmp/sounio-fixed-array-call-boundary-stage2-v1",
+    "rc": 0,
+    "stdout": "PASS fixed_array_call_boundary_value_semantics caller=unchanged\n",
+    "elf_path": "/tmp/sounio-fixed-array-call-boundary-stage2-v1",
+    "elf_sha256": "6b9530af7a2a6e7aa70a8bbe96f62d429670f463422a3eb20f0c60f8aef53f83",
+    "compile_log_path": "/tmp/sounio-fixed-array-call-boundary-stage2-compile-v1.log",
+    "compile_log_sha256": "da7a47d70ce792450aef8c5fe8cf7bec953e51d47038e2563224ed6a9277bc5e",
+    "run_log_path": "/tmp/sounio-fixed-array-call-boundary-stage2-run-v1.log",
+    "run_log_sha256": "41e078d2f22d5c523a14680c60ccdb9c79ebe804b62f0772620903fa882f1788"
+  },
+  "blocked": {
+    "compiler_kind": "ci_derived_full_madaros_override",
+    "compiler_path": "/tmp/madaros-current-source-f64-lowering-899/madaros",
+    "compiler_sha256": "f841534799c53be79801c31d218b6f76bb1e7dfe3958b0c441475f516abfe3f7",
+    "command": "cd /tmp/sounio-madaros-fixed-array-copy-main-20260714 && SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_BIN=/tmp/madaros-current-source-f64-lowering-899/madaros SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_DIR=/tmp/sounio-madaros-array-call-boundary-f841-v1 SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_KEEP=1 bash scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh",
+    "gate_rc": 61,
+    "probe_rc": 61,
+    "stdout": "BLOCKED fixed_array_call_boundary_alias caller_changed_after_by_value_param_mutation\n",
+    "elf_path": "/tmp/sounio-madaros-array-call-boundary-f841-v1/fixed_array_call_boundary_alias_probe",
+    "elf_sha256": "5fd6e483d8cadbe4be8f58d042c4160f224cb84c97186e523ac7a8a84f2a2076",
+    "actual_stdout_path": "/tmp/sounio-madaros-array-call-boundary-f841-v1/actual.stdout",
+    "actual_stdout_sha256": "c9fe4bb402e496b7b727bb871d4fe77aeb4464d10de11fc3254e8112eaee7615",
+    "gate_log_path": "/tmp/sounio-madaros-array-call-boundary-f841-v1.gate.log",
+    "gate_log_sha256": "507f343673a35cc65eb73d60a37355bf3891d67bc5551f421c4195a548b875c9"
+  },
+  "claim_boundary": {
+    "proven_by_stage2": "caller remains unchanged after callee mutates a by-value fixed-array parameter",
+    "blocked_in_f841_madaros": "callee parameter aliases caller fixed-array backing storage",
+    "not_claimed": "current-source Madaros acceptance before a source-fresh rebuild"
+  }
+}

--- a/docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json
+++ b/docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json
@@ -40,9 +40,25 @@
     "gate_log_path": "/tmp/sounio-madaros-array-call-boundary-f841-v1.gate.log",
     "gate_log_sha256": "507f343673a35cc65eb73d60a37355bf3891d67bc5551f421c4195a548b875c9"
   },
+  "source_fresh_local_copy": {
+    "ci_run_url": "https://github.com/Sounio-lang/sounio/actions/runs/29360223188",
+    "merge_candidate_sha": "e715f5f27282cdef7f2106be84ddb2e254785eec",
+    "pr_head_sha": "31fb049731b38600568fb4d525e92913e2c32e23",
+    "artifact_id": 8321978196,
+    "artifact_url": "https://github.com/Sounio-lang/sounio/actions/runs/29360223188/artifacts/8321978196",
+    "compiler_sha256": "a1b63e5d651bbe21c6eb0f19b4f24aa967977f4734d687793322b09e6b573095",
+    "command": "SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_BIN=/tmp/sounio-pr915-madaros-artifact-8321978196/madaros SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_DIR=/tmp/sounio-pr915-word-array-source-fresh SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_KEEP=1 bash scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh",
+    "gate_rc": 1,
+    "witness_rc": 51,
+    "stdout": "FAIL local_known_extent_word_array_copy u64 parameter source copy\n",
+    "gate_log_path": "/tmp/sounio-pr915-word-array-source-fresh.gate.log",
+    "gate_log_sha256": "216bc73094ed766141d07ce87c81c14b1bfd01dda972f2dcfbb928e6b3f0f937",
+    "classification": "bootstrap-runtime",
+    "claim_boundary": "All required generic CI jobs except stale docs governance passed, but the dedicated source-fresh semantic gate failed. The local-copy port is not merge-ready."
+  },
   "claim_boundary": {
     "proven_by_stage2": "caller remains unchanged after callee mutates a by-value fixed-array parameter",
     "blocked_in_f841_madaros": "callee parameter aliases caller fixed-array backing storage",
-    "not_claimed": "current-source Madaros acceptance before a source-fresh rebuild"
+    "not_claimed": "current-source Madaros acceptance; the PR 915 source-fresh artifact fails the dedicated local-copy gate"
   }
 }

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 965
-- Repo-backed topics: 815
+- Total governed topics: 966
+- Repo-backed topics: 816
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 565
+- Authority count `repo_only`: 566
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 584 topics
+- A2: 585 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -363,6 +363,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.continuity.wp-b2 | repo_only | docs/handoff/continuity/WP-B2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.exact-engine-prereqs | repo_only | docs/handoff/exact_engine_prereqs.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.gpu-knowledge-vecmat-swarm-plan | repo_only | docs/handoff/gpu_knowledge_vecmat_swarm_plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.madaros-fixed-array-call-boundary-alias-2026-07-14 | repo_only | docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.monolithic-public-lower-call-blocker-2026-07-13 | repo_only | docs/handoff/monolithic_public_lower_call_blocker_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.neurodyn-ab-fixed-octmul-reaudit-2026-07-07 | repo_only | docs/handoff/neurodyn_ab_fixed_octmul_reaudit_2026-07-07.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.neurodyn-adhd200-pcp-pilot24-2026-07-07 | repo_only | docs/handoff/neurodyn_adhd200_pcp_pilot24_2026-07-07.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7849,6 +7849,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.madaros-fixed-array-call-boundary-alias-2026-07-14",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.monolithic-public-lower-call-blocker-2026-07-13",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/monolithic_public_lower_call_blocker_2026-07-13.md",

--- a/docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md
+++ b/docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md
@@ -1,0 +1,31 @@
+# Madaros Fixed-Array Call-Boundary Alias
+
+The local identifier-copy vertical does not change call ABI. This blocker keeps
+that boundary executable and separate from local known-extent word-array copy.
+
+```text
+Blocker-ID: BLK-20260714-madaros-fixed-array-call-boundary-alias
+Status: classified
+Severity: B1
+Class: compiler-semantics
+Owner: Codex agent /root/fixed_array_call_abi
+Lane: Madaros fixed-array by-value call-boundary semantics
+Worktree: /tmp/sounio-madaros-fixed-array-copy-main-20260714
+Branch: codex/madaros-fixed-array-copy-main-20260714
+Files-Owned: self-hosted/ir/lower.sio, self-hosted/native/codegen_x86_linux.sio, tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio, scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh, docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md, docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json
+Files-Read-Only: self-hosted/ir/ir.sio, scripts/ci/build_modular_madaros.sh
+Do-Not-Touch: scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh semantics; aggregate and nested-array legacy paths
+Repro: SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_BIN=/tmp/madaros-current-source-f64-lowering-899/madaros SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_DIR=/tmp/sounio-madaros-array-call-boundary-f841 SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_KEEP=1 bash scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh
+Observed: CI-derived Madaros f841534799c53be79801c31d218b6f76bb1e7dfe3958b0c441475f516abfe3f7 executes the probe with rc=61 and exact diagnostic BLOCKED fixed_array_call_boundary_alias caller_changed_after_by_value_param_mutation
+Expected: rc=0 and exact stdout PASS fixed_array_call_boundary_value_semantics caller=unchanged
+Acceptance-Gate: bash scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh
+Evidence-Level: E3
+Evidence: docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json records exact commands, hashes, rc values, and stdout for the f841 gate and Stage2 acceptance runs
+Fallback-Path: none
+Legacy-Kept: yes; local identifier-copy behavior and aggregate or nested-array paths are unchanged by the future call-boundary lane
+LLM-Offload: not-required
+Next-Action: implement a separate call-boundary ABI fix, then rebuild current-source Madaros and require the acceptance gate to return rc=0
+```
+
+The Stage2 result is an acceptance oracle, not evidence that current-source
+Madaros already satisfies the call-boundary contract.

--- a/docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md
+++ b/docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.madaros-fixed-array-call-boundary-alias-2026-07-14
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.madaros-fixed-array-call-boundary-alias-2026-07-14
+-->
+
 # Madaros Fixed-Array Call-Boundary Alias
 
 The local identifier-copy vertical does not change call ABI. This blocker keeps
@@ -29,3 +38,32 @@ Next-Action: implement a separate call-boundary ABI fix, then rebuild current-so
 
 The Stage2 result is an acceptance oracle, not evidence that current-source
 Madaros already satisfies the call-boundary contract.
+
+## Source-Fresh Local-Copy Blocker
+
+The PR #915 CI artifact builds successfully, but the dedicated local-copy gate
+fails when that compiler executes the `u64` parameter-source case.
+
+```text
+Blocker-ID: BLK-20260714-madaros-local-array-copy-bootstrap-replay
+Status: classified
+Severity: B2
+Class: bootstrap-runtime
+Owner: Codex agent /root/fixed_array_call_abi
+Lane: PR #915 local known-extent word-array copy promotion
+Worktree: /tmp/sounio-madaros-fixed-array-copy-main-20260714
+Branch: codex/madaros-fixed-array-copy-main-20260714
+Files-Owned: self-hosted/ir/lower.sio, scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh, tests/native-v2/local_known_extent_word_array_copy_witness.sio, docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json, docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md
+Files-Read-Only: scripts/ci/build_modular_madaros.sh, .github/workflows/ci.yml
+Do-Not-Touch: canonical compiler wrappers and CI workflow; aggregate, nested-array, and unknown-extent legacy paths
+Repro: SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_BIN=/tmp/sounio-pr915-madaros-artifact-8321978196/madaros SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_DIR=/tmp/sounio-pr915-word-array-source-fresh SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_KEEP=1 bash scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh
+Observed: PR #915 merge-candidate artifact a1b63e5d651bbe21c6eb0f19b4f24aa967977f4734d687793322b09e6b573095 exits the witness at rc=51 with FAIL local_known_extent_word_array_copy u64 parameter source copy
+Expected: gate rc=0 and exact PASS receipt for every narrow local-copy case
+Acceptance-Gate: bash scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh against a compiler rebuilt from the candidate head
+Evidence-Level: E4
+Evidence: docs/audit/receipts/madaros_fixed_array_call_boundary_alias_2026-07-14.json records CI run 29360223188, artifact 8321978196, merge-candidate and head SHAs, compiler SHA, command, exit codes, stdout, and gate-log SHA
+Fallback-Path: none
+Legacy-Kept: yes; unsupported aggregate, nested-array, and unknown-extent paths remain unchanged
+LLM-Offload: not-required
+Next-Action: determine whether a self-host replay internalizes the lowering change or whether the compiler requires an additional bootstrap-safe repair; then rerun both local-copy and call-boundary gates
+```

--- a/scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh
+++ b/scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="$ROOT_DIR/tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio"
+KEEP_WORK="${SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_KEEP:-0}"
+
+fail() {
+  echo "[madaros-array-call-boundary] FAIL: $*" >&2
+  exit 1
+}
+
+if [[ "$(uname -s 2>/dev/null || echo unknown)" != "Linux" ]]; then
+  echo "[madaros-array-call-boundary] SKIP: Linux-only gate" >&2
+  exit 0
+fi
+
+if [[ -n "${SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_DIR:-}" ]]; then
+  WORK="$SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_DIR"
+  [[ ! -e "$WORK" ]] || fail "refusing existing gate directory: $WORK"
+  mkdir -p "$WORK"
+else
+  WORK="$(mktemp -d /tmp/sounio-madaros-array-call-boundary.XXXXXX)"
+fi
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+MADAROS_ELF="${SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_BIN:-$WORK/madaros}"
+PROBE_ELF="$WORK/fixed_array_call_boundary_alias_probe"
+PASS_EXPECTED="$WORK/pass.expected.stdout"
+BLOCKED_EXPECTED="$WORK/blocked.expected.stdout"
+ACTUAL="$WORK/actual.stdout"
+
+if [[ -z "${SOUNIO_MADAROS_ARRAY_CALL_BOUNDARY_GATE_BIN:-}" ]]; then
+  COMPILER_SOURCE="current_source"
+  if ! bash "$ROOT_DIR/scripts/ci/build_modular_madaros.sh" "$MADAROS_ELF" >"$WORK/build.log" 2>&1; then
+    tail -n 80 "$WORK/build.log" >&2 || true
+    fail "current-source Madaros build failed"
+  fi
+else
+  COMPILER_SOURCE="override"
+fi
+[[ -x "$MADAROS_ELF" ]] || fail "Madaros is missing or not executable: $MADAROS_ELF"
+
+compiler_sha="$(sha256sum "$MADAROS_ELF" | awk '{print $1}')"
+source_sha="$(sha256sum "$SOURCE" | awk '{print $1}')"
+echo "[madaros-array-call-boundary] compiler_source=$COMPILER_SOURCE"
+echo "[madaros-array-call-boundary] compiler_sha256=$compiler_sha"
+echo "[madaros-array-call-boundary] probe_sha256=$source_sha"
+echo "[madaros-array-call-boundary] blocker_id=BLK-20260714-madaros-fixed-array-call-boundary-alias"
+
+printf '%s\n' 'PASS fixed_array_call_boundary_value_semantics caller=unchanged' >"$PASS_EXPECTED"
+printf '%s\n' 'BLOCKED fixed_array_call_boundary_alias caller_changed_after_by_value_param_mutation' >"$BLOCKED_EXPECTED"
+
+if ! MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros" check "$SOURCE" >"$WORK/check.log" 2>&1; then
+  cat "$WORK/check.log" >&2
+  fail "probe did not check"
+fi
+if ! MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros" compile "$SOURCE" -o "$PROBE_ELF" >"$WORK/compile.log" 2>&1; then
+  cat "$WORK/compile.log" >&2
+  fail "probe did not compile"
+fi
+[[ -x "$PROBE_ELF" ]] || fail "compile did not produce executable probe"
+
+set +e
+"$PROBE_ELF" >"$ACTUAL" 2>"$WORK/run.stderr"
+run_rc=$?
+set -e
+
+if [[ "$run_rc" == "0" ]] && cmp -s "$PASS_EXPECTED" "$ACTUAL"; then
+  echo "[madaros-array-call-boundary] PASS: caller remains unchanged after by-value fixed-array parameter mutation"
+  exit 0
+fi
+
+if [[ "$run_rc" == "61" ]] && cmp -s "$BLOCKED_EXPECTED" "$ACTUAL"; then
+  cat "$ACTUAL" >&2
+  echo "[madaros-array-call-boundary] BLOCKED: fixed-array call boundary aliases caller" >&2
+  exit 61
+fi
+
+cat "$ACTUAL" >&2 || true
+cat "$WORK/run.stderr" >&2 || true
+echo "[madaros-array-call-boundary] observed_rc=$run_rc" >&2
+fail "unexpected call-boundary result"

--- a/scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh
+++ b/scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="$ROOT_DIR/tests/native-v2/local_known_extent_word_array_copy_witness.sio"
+KEEP_WORK="${SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_KEEP:-0}"
+
+fail() {
+  echo "[madaros-word-array-copy] FAIL: $*" >&2
+  exit 1
+}
+
+if [[ "$(uname -s 2>/dev/null || echo unknown)" != "Linux" ]]; then
+  echo "[madaros-word-array-copy] SKIP: Linux-only gate" >&2
+  exit 0
+fi
+
+if [[ -n "${SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_DIR:-}" ]]; then
+  WORK="$SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_DIR"
+  [[ ! -e "$WORK" ]] || fail "refusing existing gate directory: $WORK"
+  mkdir -p "$WORK"
+else
+  WORK="$(mktemp -d /tmp/sounio-madaros-word-array-copy.XXXXXX)"
+fi
+
+if [[ "$KEEP_WORK" != "1" ]]; then
+  trap 'rm -rf "$WORK"' EXIT
+fi
+
+MADAROS_ELF="${SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_BIN:-$WORK/madaros}"
+WITNESS_ELF="$WORK/local_known_extent_word_array_copy"
+EXPECTED="$WORK/expected.stdout"
+ACTUAL="$WORK/actual.stdout"
+
+if [[ -z "${SOUNIO_MADAROS_WORD_ARRAY_COPY_GATE_BIN:-}" ]]; then
+  COMPILER_SOURCE="current_source"
+  if ! bash "$ROOT_DIR/scripts/ci/build_modular_madaros.sh" "$MADAROS_ELF" >"$WORK/build.log" 2>&1; then
+    tail -n 80 "$WORK/build.log" >&2 || true
+    fail "current-source Madaros build failed"
+  fi
+else
+  COMPILER_SOURCE="override"
+fi
+[[ -x "$MADAROS_ELF" ]] || fail "Madaros is missing or not executable: $MADAROS_ELF"
+
+compiler_sha="$(sha256sum "$MADAROS_ELF" | awk '{print $1}')"
+source_sha="$(sha256sum "$SOURCE" | awk '{print $1}')"
+echo "[madaros-word-array-copy] compiler_source=$COMPILER_SOURCE"
+echo "[madaros-word-array-copy] compiler_sha256=$compiler_sha"
+echo "[madaros-word-array-copy] witness_sha256=$source_sha"
+
+printf '%s\n' 'PASS local_known_extent_word_array_copy i64=independent i8=independent bool=independent repeat_i64_ident=independent repeat_bool_ident=independent repeat_f64_ident=independent u64_param_source_copy=independent scalar=stable' >"$EXPECTED"
+echo "[madaros-word-array-copy] blocker_id=BLK-20260714-madaros-fixed-array-call-boundary-alias"
+echo "[madaros-word-array-copy] blocker_gate=scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh"
+echo "[madaros-word-array-copy] blocker_doc=docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md"
+echo "[madaros-word-array-copy] residual_call_boundary_fixed_array_value_semantics=blocked"
+
+if ! MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros" check "$SOURCE" >"$WORK/check.log" 2>&1; then
+  cat "$WORK/check.log" >&2
+  fail "witness did not check"
+fi
+if ! MADAROS_RAW_BIN="$MADAROS_ELF" "$ROOT_DIR/bin/madaros" compile "$SOURCE" -o "$WITNESS_ELF" >"$WORK/compile.log" 2>&1; then
+  cat "$WORK/compile.log" >&2
+  fail "witness did not compile"
+fi
+[[ -x "$WITNESS_ELF" ]] || fail "compile did not produce executable witness"
+
+set +e
+"$WITNESS_ELF" >"$ACTUAL" 2>"$WORK/run.stderr"
+run_rc=$?
+set -e
+if [[ "$run_rc" != "0" ]]; then
+  cat "$ACTUAL" >&2 || true
+  cat "$WORK/run.stderr" >&2 || true
+  fail "witness exited rc=$run_rc"
+fi
+if ! cmp -s "$EXPECTED" "$ACTUAL"; then
+  diff -u "$EXPECTED" "$ACTUAL" >&2 || true
+  fail "stdout mismatch"
+fi
+
+echo "[madaros-word-array-copy] PASS: local known-extent direct word-scalar arrays copy independently"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -13,6 +13,12 @@ struct LowerLocalStack {
     depths: [i64; 4096],
     struct_types: [Name; 4096],
     array_elem_float: [i64; 4096],
+    // Logical element count for a directly-stored fixed array local. -1 means
+    // the local is not a fixed array (or its extent is not statically known).
+    array_lens: [i64; 4096],
+    // 1 only when each array element is known to occupy one non-aggregate word.
+    // Nested arrays and struct elements must not take the shallow slot-copy path.
+    array_copy_word_scalar: [i64; 4096],
     wide_bits: [i64; 4096],
     wide_signed: [i64; 4096],
     global_bss_offsets: [i64; 4096],
@@ -38,6 +44,8 @@ fn empty_lower_local_stack() -> LowerLocalStack {
         depths: [0; 4096],
         struct_types: [ir_empty_name(); 4096],
         array_elem_float: [0; 4096],
+        array_lens: [-1; 4096],
+        array_copy_word_scalar: [0; 4096],
         wide_bits: [0; 4096],
         wide_signed: [0; 4096],
         global_bss_offsets: [0; 4096],
@@ -1027,6 +1035,121 @@ fn lower_typeexpr_byte_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Div {
     }
 }
 
+fn lower_type_expr_fixed_array_len_ref(ty: &TypeExpr) -> i64 {
+    if (*ty).kind != TypeExprKind::TypeArray { return -1 }
+    match (*ty).array_size {
+        Some(sz) => {
+            if (*sz).kind == ExprKind::ExprIntLit && (*sz).int_val >= 0 {
+                return (*sz).int_val
+            }
+            -1
+        }
+        None => -1,
+    }
+}
+
+fn lower_opt_type_fixed_array_len(ty_opt: &Option<Box<TypeExpr>>) -> i64 {
+    match *ty_opt {
+        Some(ty) => lower_type_expr_fixed_array_len_ref(&(*ty)),
+        None => -1,
+    }
+}
+
+fn lower_name_is_direct_word_scalar_type(n: Name) -> bool with Panic, Div {
+    // Native-v2 local arrays use one boxed 8-byte slot per primitive element,
+    // including narrow integers. Keep this list explicit so structs, nested
+    // arrays, strings, and future multiword primitives cannot enter a shallow copy.
+    if n.len == 2 {
+        return (n.buf[0] == 105 as i8 || n.buf[0] == 117 as i8)
+            && n.buf[1] == 56 as i8 // i8/u8
+    }
+    if n.len == 3 {
+        let numeric_width = (n.buf[1] == 49 as i8 && n.buf[2] == 54 as i8)
+            || (n.buf[1] == 51 as i8 && n.buf[2] == 50 as i8)
+            || (n.buf[1] == 54 as i8 && n.buf[2] == 52 as i8)
+        if (n.buf[0] == 105 as i8 || n.buf[0] == 117 as i8) && numeric_width {
+            return true // i16/u16/i32/u32/i64/u64
+        }
+        return n.buf[0] == 102 as i8
+            && ((n.buf[1] == 51 as i8 && n.buf[2] == 50 as i8)
+                || (n.buf[1] == 54 as i8 && n.buf[2] == 52 as i8)) // f32/f64
+    }
+    if n.len == 4 {
+        let is_bool = n.buf[0] == 98 as i8 && n.buf[1] == 111 as i8
+            && n.buf[2] == 111 as i8 && n.buf[3] == 108 as i8
+        let is_char = n.buf[0] == 99 as i8 && n.buf[1] == 104 as i8
+            && n.buf[2] == 97 as i8 && n.buf[3] == 114 as i8
+        return is_bool || is_char
+    }
+    if n.len == 5 {
+        let suffix = n.buf[1] == 115 as i8 && n.buf[2] == 105 as i8
+            && n.buf[3] == 122 as i8 && n.buf[4] == 101 as i8
+        return suffix && (n.buf[0] == 105 as i8 || n.buf[0] == 117 as i8) // isize/usize
+    }
+    false
+}
+
+fn lower_type_expr_fixed_array_word_scalar_ref(ty: &TypeExpr) -> bool with Mut, Panic, Div {
+    if (*ty).kind != TypeExprKind::TypeArray { return false }
+    match (*ty).inner {
+        Some(elem_ty) => {
+            if (*elem_ty).kind != TypeExprKind::TypeNamed { return false }
+            lower_name_is_direct_word_scalar_type(ir_path_first_name((*elem_ty).path))
+        }
+        None => false,
+    }
+}
+
+fn lower_opt_type_fixed_array_word_scalar(ty_opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *ty_opt {
+        Some(ty) => lower_type_expr_fixed_array_word_scalar_ref(&(*ty)),
+        None => false,
+    }
+}
+
+fn lower_array_literal_fixed_len_ref(e: &Expr) -> i64 with Alloc, Mut, Div {
+    if (*e).kind != ExprKind::ExprArrayLit { return -1 }
+    match (*e).left {
+        Some(_) => {
+            match (*e).right {
+                Some(count_expr) => {
+                    if (*count_expr).kind == ExprKind::ExprIntLit && (*count_expr).int_val >= 0 {
+                        return (*count_expr).int_val
+                    }
+                    -1
+                }
+                None => -1,
+            }
+        }
+        None => count_expr_list_ref(&(*e).args),
+    }
+}
+
+fn lower_array_literal_word_scalar_ref(e: &Expr, repeat_ident_scalar_kind: i64) -> bool {
+    if (*e).kind != ExprKind::ExprArrayLit { return false }
+    match (*e).left {
+        Some(repeat_value) => {
+            (*repeat_value).kind == ExprKind::ExprIntLit
+                || (*repeat_value).kind == ExprKind::ExprFloatLit
+                || (*repeat_value).kind == ExprKind::ExprBoolTrue
+                || (*repeat_value).kind == ExprKind::ExprBoolFalse
+                || ((*repeat_value).kind == ExprKind::ExprIdent
+                    && (repeat_ident_scalar_kind == 1 || repeat_ident_scalar_kind == 2))
+        }
+        None => {
+            match (*e).args {
+                Some(args) => {
+                    (*args).head.kind == ExprKind::ExprIntLit
+                        || (*args).head.kind == ExprKind::ExprFloatLit
+                        || (*args).head.kind == ExprKind::ExprBoolTrue
+                        || (*args).head.kind == ExprKind::ExprBoolFalse
+                }
+                None => false,
+            }
+        }
+    }
+}
+
 fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Panic, Div {
     match *ty_opt {
         Some(ty) => {
@@ -1797,6 +1920,8 @@ fn lowerer_bind_local_mut(
         (*locals_box).depths[idx as usize] = (*lo).scope_depth
         (*locals_box).struct_types[idx as usize] = ir_empty_name()
         (*locals_box).array_elem_float[idx as usize] = 0
+        (*locals_box).array_lens[idx as usize] = -1
+        (*locals_box).array_copy_word_scalar[idx as usize] = 0
         (*locals_box).wide_bits[idx as usize] = 0
         (*locals_box).wide_signed[idx as usize] = 0
         (*locals_box).global_bss_offsets[idx as usize] = 0
@@ -1957,6 +2082,13 @@ fn lowerer_lower_fn_params_mut(
                 }
 
                 lowerer_bind_local_mut(lo, (*list).head.name, preg, (*list).head.is_self_mut)
+                let param_array_len = lower_type_expr_fixed_array_len_ref(&(*list).head.ty)
+                if param_array_len >= 0 {
+                    (*lo) = (*lo).bind_local_fixed_array_len((*list).head.name, param_array_len)
+                }
+                if lower_type_expr_fixed_array_word_scalar_ref(&(*list).head.ty) {
+                    (*lo) = (*lo).bind_local_array_copy_word_scalar((*list).head.name)
+                }
                 lowerer_bind_local_struct_type_mut(lo, (*list).head.name, lower_param_struct_type_name(&(*list).head.ty))
                 if lower_type_expr_is_f64(&(*list).head.ty) {
                     (*lo) = (*lo).bind_local_scalar_kind((*list).head.name, 2)
@@ -3362,6 +3494,62 @@ impl Lowerer {
         if elem_count <= 0 { 8 } else { elem_count * 8 }
     }
 
+    fn emit_fixed_array_value_copy(self, src_reg: i64, elem_count: i64, elem_is_float: bool) -> (Lowerer, i64) with Mut, Panic, Div, Alloc, IO {
+        let pair_dst = self.fresh_reg()
+        var lo = pair_dst.0
+        let dst_reg = pair_dst.1
+        lo = lo.emit(ir_alloc_array(dst_reg, lo.aggregate_storage_bytes(elem_count), elem_count))
+        if elem_is_float {
+            lo = lo.emit(ir_mark_float_reg(dst_reg))
+            lo = lo.bind_reg_array_elem_float(dst_reg)
+        }
+        if elem_count <= 0 {
+            return (lo, dst_reg)
+        }
+
+        let pair_idx = lo.emit_i64_const(0)
+        lo = pair_idx.0
+        let idx_reg = pair_idx.1
+        let pair_limit = lo.emit_i64_const(elem_count)
+        lo = pair_limit.0
+        let limit_reg = pair_limit.1
+        let pair_one = lo.emit_i64_const(1)
+        lo = pair_one.0
+        let one_reg = pair_one.1
+        let pair_top = lo.fresh_label()
+        lo = pair_top.0
+        let top_label = pair_top.1
+        let pair_end = lo.fresh_label()
+        lo = pair_end.0
+        let end_label = pair_end.1
+
+        lo = lo.emit(ir_label(top_label))
+        let pair_cond = lo.fresh_reg()
+        lo = pair_cond.0
+        let cond_reg = pair_cond.1
+        lo = lo.emit(ir_binop(cond_reg, idx_reg, BinaryOp::OpLt, limit_reg))
+        lo = lo.emit(ir_branch_false(cond_reg, end_label))
+
+        let pair_elem = lo.fresh_reg()
+        lo = pair_elem.0
+        let elem_reg = pair_elem.1
+        var load_instr = ir_index_get(elem_reg, src_reg, idx_reg)
+        if elem_is_float {
+            load_instr.imm_flags = IR_FLOAT_REG_MARKER_FLAG
+        }
+        lo = lo.emit(load_instr)
+        lo = lo.emit(ir_index_set(dst_reg, idx_reg, elem_reg))
+
+        let pair_next = lo.fresh_reg()
+        lo = pair_next.0
+        let next_reg = pair_next.1
+        lo = lo.emit(ir_binop(next_reg, idx_reg, BinaryOp::OpAdd, one_reg))
+        lo = lo.emit(ir_copy(idx_reg, next_reg))
+        lo = lo.emit(ir_jump(top_label))
+        lo = lo.emit(ir_label(end_label))
+        (lo, dst_reg)
+    }
+
     fn expr_is_zero_fill_value(self, e: Expr) -> bool {
         let _lo = self
         if e.kind == ExprKind::ExprIntLit { return e.int_val == 0 }
@@ -3893,6 +4081,8 @@ impl Lowerer {
                 stk.depths[idx as usize] = lo.scope_depth
                 stk.struct_types[idx as usize] = ir_empty_name()
                 stk.array_elem_float[idx as usize] = 0
+                stk.array_lens[idx as usize] = -1
+                stk.array_copy_word_scalar[idx as usize] = 0
                 stk.wide_bits[idx as usize] = 0
                 stk.wide_signed[idx as usize] = 0
                 stk.is_ref[idx as usize] = 0
@@ -3912,6 +4102,36 @@ impl Lowerer {
         while i >= 0 {
             if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
                 stk.array_elem_float[i as usize] = 1
+                lo.locals = Box::new(stk)
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
+    fn bind_local_fixed_array_len(self, name: Name, array_len: i64) -> Lowerer with Mut, Alloc, Panic, Div {
+        var lo = self
+        var stk = *lo.locals
+        var i = stk.count - 1
+        while i >= 0 {
+            if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
+                stk.array_lens[i as usize] = array_len
+                lo.locals = Box::new(stk)
+                return lo
+            }
+            i = i - 1
+        }
+        lo
+    }
+
+    fn bind_local_array_copy_word_scalar(self, name: Name) -> Lowerer with Mut, Alloc, Panic, Div {
+        var lo = self
+        var stk = *lo.locals
+        var i = stk.count - 1
+        while i >= 0 {
+            if stk.depths[i as usize] <= lo.scope_depth && ir_name_eq(stk.names[i as usize], name) {
+                stk.array_copy_word_scalar[i as usize] = 1
                 lo.locals = Box::new(stk)
                 return lo
             }
@@ -4050,6 +4270,28 @@ impl Lowerer {
         while i >= 0 {
             if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
                 return (*self.locals).array_elem_float[i as usize] == 1
+            }
+            i = i - 1
+        }
+        false
+    }
+
+    fn lookup_local_fixed_array_len(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).array_lens[i as usize]
+            }
+            i = i - 1
+        }
+        -1
+    }
+
+    fn lookup_local_array_copy_word_scalar(self, name: Name) -> bool with Mut, Panic, Div, Alloc {
+        var i = (*self.locals).count - 1
+        while i >= 0 {
+            if (*self.locals).depths[i as usize] <= self.scope_depth && ir_name_eq((*self.locals).names[i as usize], name) {
+                return (*self.locals).array_copy_word_scalar[i as usize] == 1
             }
             i = i - 1
         }
@@ -5061,7 +5303,7 @@ impl Lowerer {
         if (*e).kind == ExprKind::ExprIntLit {
             return false
         }
-        if (*e).kind == ExprKind::ExprBoolLit {
+        if (*e).kind == ExprKind::ExprBoolTrue || (*e).kind == ExprKind::ExprBoolFalse {
             return false
         }
         if (*e).kind == ExprKind::ExprStringLit {
@@ -6099,6 +6341,8 @@ impl Lowerer {
                         locals.depths[idx as usize] = lo.scope_depth
                         locals.struct_types[idx as usize] = lower_param_struct_type_name(&(*list).head.ty)
                         locals.array_elem_float[idx as usize] = if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 1 } else { 0 }
+                        locals.array_lens[idx as usize] = lower_type_expr_fixed_array_len_ref(&(*list).head.ty)
+                        locals.array_copy_word_scalar[idx as usize] = if lower_type_expr_fixed_array_word_scalar_ref(&(*list).head.ty) { 1 } else { 0 }
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
                         locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
@@ -6807,19 +7051,50 @@ impl Lowerer {
         var lo = pair.0
         lo.allow_direct_capturing_closure_literal = false
         let reg = pair.1
-        // A `var` initialized from a bare identifier must own its storage. An ident
-        // lowers to the SOURCE local's register (lookup_local returns it directly), so
-        // binding the var to `reg` aliases them onto the same vreg/stack slot — a later
-        // `y = ...` then clobbers the source `x`, and reads of `x` return y's value.
-        // This corrupted `var y = x; ... y = f(y, x)` patterns (e.g. Newton's method
-        // `y = 0.5*(y + x/y)`, which drifted to sqrt(garbage) once x was overwritten).
-        // Computed initializers already yield a fresh dst reg, so only the bare-ident
-        // case needs an explicit copy into a fresh register.
+        var fixed_array_len = lower_opt_type_fixed_array_len(&s.ty)
+        var fixed_array_word_scalar = lower_opt_type_fixed_array_word_scalar(&s.ty)
+        var rhs_array_elem_is_float = false
+        match s.expr {
+            Some(rhs_shape) => {
+                if fixed_array_len < 0 {
+                    if (*rhs_shape).kind == ExprKind::ExprIdent {
+                        fixed_array_len = lo.lookup_local_fixed_array_len((*rhs_shape).name)
+                        fixed_array_word_scalar = lo.lookup_local_array_copy_word_scalar((*rhs_shape).name)
+                    } else {
+                        fixed_array_len = lower_array_literal_fixed_len_ref(&(*rhs_shape))
+                        var repeat_ident_scalar_kind = 0
+                        match (*rhs_shape).left {
+                            Some(repeat_value) => {
+                                if (*repeat_value).kind == ExprKind::ExprIdent {
+                                    repeat_ident_scalar_kind = lo.lookup_local_scalar_kind((*repeat_value).name)
+                                    rhs_array_elem_is_float = repeat_ident_scalar_kind == 2
+                                }
+                            }
+                            _ => {}
+                        }
+                        fixed_array_word_scalar = lower_array_literal_word_scalar_ref(&(*rhs_shape), repeat_ident_scalar_kind)
+                    }
+                }
+                if (*rhs_shape).kind == ExprKind::ExprIdent {
+                    rhs_array_elem_is_float = lo.lookup_local_array_elem_float((*rhs_shape).name)
+                }
+            }
+            _ => {}
+        }
+
+        // A bare identifier lowers to the source local's register. Scalars need a
+        // fresh register only for mutable bindings; fixed arrays need fresh backing
+        // storage for both `let` and `var`, otherwise an indexed mutation through
+        // either binding changes the other value.
         var bind_reg = reg
-        if is_mut {
-            match s.expr {
-                Some(rhs_ident) => {
-                    if (*rhs_ident).kind == ExprKind::ExprIdent {
+        match s.expr {
+            Some(rhs_ident) => {
+                if (*rhs_ident).kind == ExprKind::ExprIdent {
+                    if fixed_array_len >= 0 && fixed_array_word_scalar {
+                        let array_copy_pair = lo.emit_fixed_array_value_copy(reg, fixed_array_len, rhs_array_elem_is_float)
+                        lo = array_copy_pair.0
+                        bind_reg = array_copy_pair.1
+                    } else if is_mut {
                         let copy_pair = lo.fresh_reg()
                         lo = copy_pair.0
                         let copy_reg = copy_pair.1
@@ -6827,10 +7102,16 @@ impl Lowerer {
                         bind_reg = copy_reg
                     }
                 }
-                _ => {}
             }
+            _ => {}
         }
         lo = lo.bind_local(s.name, bind_reg, is_mut)
+        if fixed_array_len >= 0 {
+            lo = lo.bind_local_fixed_array_len(s.name, fixed_array_len)
+        }
+        if fixed_array_word_scalar {
+            lo = lo.bind_local_array_copy_word_scalar(s.name)
+        }
         // Closures step 2: if the RHS was a capturing closure, mark this local so a later
         // `name(args)` call injects the captured regs (direct call to the synthetic fn).
         if lo.pending_closure_fn_id >= 0 {
@@ -6850,6 +7131,8 @@ impl Lowerer {
                         lo = lo.bind_local_array_elem_float(s.name)
                     } else if lo.expr_result_is_f64_array_ref(&(*expr_box_arr)) {
                         lo = lo.bind_local_array_elem_float(s.name)
+                    } else if rhs_array_elem_is_float {
+                        lo = lo.bind_local_array_elem_float(s.name)
                     }
                 }
                 _ => {}
@@ -6862,7 +7145,7 @@ impl Lowerer {
                 Some(expr_box_sk) => {
                     if (*expr_box_sk).kind == ExprKind::ExprIntLit {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
-                    } else if (*expr_box_sk).kind == ExprKind::ExprBoolLit {
+                    } else if (*expr_box_sk).kind == ExprKind::ExprBoolTrue || (*expr_box_sk).kind == ExprKind::ExprBoolFalse {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if lo.expr_result_is_float_ref(&(*expr_box_sk)) {
                         lo = lo.bind_local_scalar_kind(s.name, 2)

--- a/tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio
+++ b/tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio
@@ -1,0 +1,20 @@
+//@ known-failure: BLK-20260714-madaros-fixed-array-call-boundary-alias
+
+fn mutate_by_value_parameter(values: [u64; 4]) with Mut, Panic, Div {
+    values[0] = 61
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var caller: [u64; 4] = [0; 4]
+    caller[0] = 7
+
+    mutate_by_value_parameter(caller)
+
+    if caller[0] != 7 {
+        print("BLOCKED fixed_array_call_boundary_alias caller_changed_after_by_value_param_mutation\n")
+        return 61
+    }
+
+    print("PASS fixed_array_call_boundary_value_semantics caller=unchanged\n")
+    0
+}

--- a/tests/native-v2/local_known_extent_word_array_copy_witness.sio
+++ b/tests/native-v2/local_known_extent_word_array_copy_witness.sio
@@ -1,0 +1,106 @@
+//@ run-pass
+
+fn isolate_u64_parameter(original: [u64; 4]) -> i64 with Mut, Panic, Div {
+    var candidate = original
+    candidate[0] = 91
+    if original[0] != 7 || candidate[0] != 91 {
+        return 51
+    }
+    0
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var original: [i64; 2] = [0; 2]
+    original[0] = 3
+    original[1] = 1
+
+    var candidate = original
+    candidate[0] = 1
+    candidate[1] = 3
+    if original[0] != 3 || original[1] != 1 {
+        print("FAIL local_known_extent_word_array_copy destination aliases source\n")
+        return 41
+    }
+
+    original[0] = 8
+    original[1] = 5
+    if candidate[0] != 1 || candidate[1] != 3 {
+        print("FAIL local_known_extent_word_array_copy source aliases destination\n")
+        return 42
+    }
+
+    let snapshot = original
+    original[0] = 13
+    if snapshot[0] != 8 || snapshot[1] != 5 {
+        print("FAIL local_known_extent_word_array_copy let snapshot aliases source\n")
+        return 43
+    }
+
+    var narrow: [i8; 2] = [0; 2]
+    narrow[0] = 4
+    narrow[1] = 4
+    var narrow_copy = narrow
+    narrow_copy[0] = 6
+    if narrow[0] != 4 || narrow_copy[0] != 6 {
+        print("FAIL local_known_extent_word_array_copy i8 copy\n")
+        return 44
+    }
+
+    var flags: [bool; 2] = [false; 2]
+    var flags_copy = flags
+    flags_copy[1] = true
+    if flags[1] || !flags_copy[1] {
+        print("FAIL local_known_extent_word_array_copy bool copy\n")
+        return 45
+    }
+
+    var bool_seed = true
+    var bool_seed_values = [bool_seed; 2]
+    if bool_seed_values[0] != true || bool_seed_values[1] != true {
+        print("FAIL local_known_extent_word_array_copy bool identifier repeat init\n")
+        return 49
+    }
+    var bool_seed_copy = bool_seed_values
+    bool_seed_copy[0] = false
+    if bool_seed_values[0] != true || bool_seed_copy[0] != false {
+        print("FAIL local_known_extent_word_array_copy bool identifier repeat copy\n")
+        return 50
+    }
+
+    var seed: i64 = 7
+    var seeded = [seed; 2]
+    var seeded_copy = seeded
+    seeded_copy[1] = 11
+    if seeded[0] != 7 || seeded[1] != 7 {
+        print("FAIL local_known_extent_word_array_copy identifier repeat seed\n")
+        return 46
+    }
+
+    var float_seed: f64 = 1.25
+    var float_values = [float_seed; 2]
+    var float_copy = float_values
+    float_copy[0] = 2.5
+    if float_values[0] != 1.25 || float_copy[0] != 2.5 {
+        print("FAIL local_known_extent_word_array_copy f64 repeat seed\n")
+        return 47
+    }
+
+    var limbs: [u64; 4] = [0; 4]
+    limbs[0] = 7
+    let param_rc = isolate_u64_parameter(limbs)
+    if param_rc != 0 {
+        print("FAIL local_known_extent_word_array_copy u64 parameter source copy\n")
+        return param_rc
+    }
+
+    var scalar_original: i64 = 17
+    var scalar_copy = scalar_original
+    scalar_copy = 19
+    if scalar_original != 17 || scalar_copy != 19 {
+        print("FAIL local_known_extent_word_array_copy scalar regression\n")
+        return 52
+    }
+
+    print("PASS local_known_extent_word_array_copy i64=independent i8=independent bool=independent repeat_i64_ident=independent repeat_bool_ident=independent repeat_f64_ident=independent u64_param_source_copy=independent scalar=stable\n")
+    0
+}


### PR DESCRIPTION
## What changed

- track fixed-array extent and direct word-scalar eligibility in Madaros local metadata
- copy a bare-identifier fixed array into fresh backing storage for both `let` and `var`
- preserve that metadata through both parameter-binding paths and identifier-repeat literals
- add an exact local-copy witness and source-fresh acceptance gate
- preserve the separate call-boundary alias as an executable known failure with a full blocker handoff and receipt

## Why

The current Madaros lowering can bind two local fixed-array values to the same backing storage. Mutating the destination then mutates the source. This is already incorrect for ordinary value semantics and would make future compiler-owned `f128`/`f256` software representations unsafe.

This patch is intentionally narrow. The copy path is limited to statically known, direct arrays whose element type is an explicit one-word primitive (`i8` through `i64`, unsigned equivalents, `f32`, `f64`, `bool`, `char`, `isize`, or `usize`). Structs, nested arrays, strings, aliases, unknown extents, and future multiword primitives retain the legacy path.

It does **not** claim to fix by-value array parameters at the call boundary. That residual is `BLK-20260714-madaros-fixed-array-call-boundary-alias` and has its own failing acceptance gate.

## Validation

- `git diff --check`
- `bash -n scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh`
- `bash -n scripts/ci/madaros_fixed_array_call_boundary_alias_gate.sh`
- `./bin/souc check tests/native-v2/local_known_extent_word_array_copy_witness.sio`
- `./bin/souc check tests/known_failures/madaros_fixed_array_call_boundary_alias_probe.sio`
- Stage2 `204dc366...` executes the local-copy witness with exact `rc=0` PASS
- Stage2 executes the call-boundary acceptance oracle with exact `rc=0` PASS
- prior CI-derived Madaros `f841534...` reproduces the local alias and returns exact `rc=61` for the call-boundary blocker

## Promotion gate

This draft is safe to run through CI but is **not merge-ready** yet. After CI builds a Madaros artifact from this head, that exact compiler must pass:

```bash
bash scripts/ci/madaros_local_known_extent_word_array_copy_gate.sh
```

The compiler SHA and full gate log must be preserved before promotion.

LLM offload was not required: this change is internal compiler semantics and test plumbing, with no math claim, clinical pathway, or external-facing artifact.
