### PR TITLE
feat(stats): method-comparison regression — deming, theil_sen, passing_bablok

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2733,3 +2733,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - outlier = **PASS**: Tukey interpolation, Grubbs G + r=G²n/(n-1)², t²=r(n-2)/(1-r), p=n·2P(T>|t|) via I_x(ν/2,1/2), modified-z constant 0.67449, and the Lanczos+Lentz incomplete-beta all correct.
 - Theme: robust / outlier-resistant statistics — the descriptive layer under the inferential suite. #852-safe: HL uses a bounded pairwise buffer with an *inline* median sort (no nested call while the big buffer is live). Suite selftest: 42 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-V9LS18/`, `/tmp/llm-offload-vOSDSg/`, `/tmp/llm-offload-w3oWGw/`.
+
+## 2026-07-14 — math-review: stats::deming, stats::theil_sen, stats::passing_bablok
+- Files (all new): `stdlib/stats/deming.sio` (errors-in-variables regression, closed-form quadratic-root slope), `stdlib/stats/theil_sen.sio` (median-of-pairwise-slopes robust regression), `stdlib/stats/passing_bablok.sio` (clinical-chemistry method-comparison regression: -1 exclusion + K-offset shifted median). Provider: xAI/Grok 4.3.
+- deming = **PASS**: slope = positive quadratic root of the Deming normal equations, intercept ȳ−b·x̄; perfect (2,1) and staircase (0.8828 vs OLS 0.8) verified.
+- theil_sen = **PASS**: median pairwise slope + median residual; 29% breakdown demonstrated (outlier at (5,100) leaves slope 2); buffer 2080≥C(64,2) sizing correct.
+- passing_bablok = **PASS**: shifted-median with K-offset matches Passing & Bablok 1983 exactly (1-indexed rank (N+1)/2+K → 0-based with clamping); -1 slope exclusion verified (N=5,K=0 case); K-offset case (N=6,K=1 → slope 2) confirmed.
+- Theme: method-comparison / robust regression — complements the agreement modules (bland_altman, concordance/CCC, reliability) for assay/instrument comparison. #852-safe: theil_sen & passing_bablok use bounded pairwise buffers with inline median sorts (no nested call while big buffer live). Suite selftest: 45 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-8JVsS1/`, `/tmp/llm-offload-NuJ1qi/`, `/tmp/llm-offload-LafnKF/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -49,6 +49,9 @@ MODULES=(
   stdlib/stats/robust.sio
   stdlib/stats/hodges_lehmann.sio
   stdlib/stats/outlier.sio
+  stdlib/stats/deming.sio
+  stdlib/stats/theil_sen.sio
+  stdlib/stats/passing_bablok.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -657,6 +657,39 @@ single-outlier test `G=max|xᵢ−x̄|/s` with the exact two-sided Bonferroni t
 p-value, and the MAD-based Iglewicz-Hoaglin modified z-score. Validated:
 {…,100}→1 Tukey outlier; {1,2,3,4,5,50}→G=2.036, p<0.01, modified-z=20.9.
 
+### `stats::deming` — Deming regression (errors-in-variables)
+
+| Function | Signature |
+|---|---|
+| `deming` | `pub fn deming(x: &[f64; 256], y: &[f64; 256], n: i32, lambda: f64) -> DemingFit with Mut, Div, Panic` |
+
+The method-comparison regression that allows measurement error in *both*
+variables (λ = error-variance ratio; λ=1 → orthogonal). Closed-form slope
+`b = [(Syy−λSxx)+√((Syy−λSxx)²+4λSxy²)]/(2Sxy)`, intercept ȳ−b·x̄. Validated:
+perfect line → slope 2, intercept 1; staircase → slope 0.8828 (vs OLS 0.8).
+
+### `stats::theil_sen` — Theil-Sen robust regression
+
+| Function | Signature |
+|---|---|
+| `theil_sen` | `pub fn theil_sen(x: &[f64; 256], y: &[f64; 256], n: i32) -> TSFit with Mut, Div, Panic` |
+
+Distribution-free line fit: slope = median of pairwise slopes, intercept =
+median residual — resistant to ~29% arbitrary outliers. Validated: perfect line
+→ (2,1); with a wild outlier at (5,100) still → (2,1); negative slope → −3.
+
+### `stats::passing_bablok` — Passing-Bablok regression
+
+| Function | Signature |
+|---|---|
+| `passing_bablok` | `pub fn passing_bablok(x: &[f64; 256], y: &[f64; 256], n: i32) -> PBFit with Mut, Div, Panic` |
+
+The clinical-chemistry standard for method comparison: the shifted-median slope
+(pairwise slopes with the −1 exclusion and the `K` = #{slope<−1} rank offset,
+per Passing & Bablok 1983 / the R `mcr` package) and the median-residual
+intercept. Validated: perfect line → (2,1); −1-slope pair correctly excluded;
+K-offset case → slope 2.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -701,6 +734,9 @@ use stats::exp_survival::{ExpSurvResult, exp_survival}
 use stats::robust::{median, quantile, iqr, mad, trimmed_mean, winsorized_mean}
 use stats::hodges_lehmann::{hl_one, hl_two}
 use stats::outlier::{OutlierFences, GrubbsResult, ModZResult, tukey_outliers, grubbs, modified_z}
+use stats::deming::{DemingFit, deming}
+use stats::theil_sen::{TSFit, theil_sen}
+use stats::passing_bablok::{PBFit, passing_bablok}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/deming.sio
+++ b/stdlib/stats/deming.sio
@@ -1,0 +1,132 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/deming.sio — Deming regression (errors-in-variables)
+//
+// The method-comparison regression that, unlike ordinary least squares, allows
+// measurement error in *both* variables — the correct model when comparing two
+// assays that are each imprecise:
+//
+//   deming(x, y, n, lambda) -> DemingFit
+//
+// With λ = σ²_ε(y)/σ²_ε(x) (λ = 1 → orthogonal regression) and the centred
+// sums Sxx, Syy, Sxy,
+//   slope  b = [ (Syy − λ Sxx) + √((Syy − λ Sxx)² + 4λ Sxy²) ] / (2 Sxy),
+//   intercept a = ȳ − b x̄.
+//
+// Pure Sounio: inline sqrt; two passes (means, then centred sums); no external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Deming (1943); Linnet (1990) Clin. Chem. 36:1329 (method comparison).
+
+module stats::deming
+
+fn dm_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct DemingFit {
+    pub slope: f64,
+    pub intercept: f64,
+}
+
+/// Deming regression of y on x with error-variance ratio lambda.
+///
+/// Parâmetros: x, y — paired measurements; n — size (>=3); lambda — σ²ε(y)/σ²ε(x)
+///             (1.0 for orthogonal / equal error).
+/// Retorno: DemingFit (slope, intercept).
+/// Referências: Deming (1943); Linnet (1990).
+pub fn deming(x: &[f64; 256], y: &[f64; 256], n: i32, lambda: f64) -> DemingFit with Mut, Div, Panic {
+    if n < 3 { return DemingFit { slope: 0.0, intercept: 0.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var sxx = 0.0
+    var syy = 0.0
+    var sxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        let dy = y[j as usize] - my
+        sxx = sxx + dx * dx
+        syy = syy + dy * dy
+        sxy = sxy + dx * dy
+        j = j + 1
+    }
+    if sxy == 0.0 { return DemingFit { slope: 0.0, intercept: my } }
+    let u = syy - lambda * sxx
+    let slope = (u + dm_sqrt(u * u + 4.0 * lambda * sxy * sxy)) / (2.0 * sxy)
+    let intercept = my - slope * mx
+    return DemingFit { slope: slope, intercept: intercept }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect line y = 2x + 1: (1,3),(2,5),(3,7),(4,9). lambda=1 -> slope 2, intercept 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0
+    let r = deming(&x, &y, 4, 1.0)
+    var ok = true
+    ok = check(1, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.intercept, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// staircase (0,1),(1,1),(2,3),(3,3): Sxx=5,Syy=4,Sxy=4.
+// lambda=1: slope=(-1+sqrt(1+64))/8=(-1+8.062258)/8=0.882782; intercept=2-0.882782·1.5=0.675827.
+// (OLS slope would be 0.8; Deming pulls it up because both axes carry error.)
+fn test_staircase() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=1.0; y[1]=1.0; y[2]=3.0; y[3]=3.0
+    let r = deming(&x, &y, 4, 1.0)
+    var ok = true
+    ok = check(10, approx(r.slope, 0.882782, 1.0e-5)) && ok
+    ok = check(11, approx(r.intercept, 0.675827, 1.0e-5)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_staircase() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/passing_bablok.sio
+++ b/stdlib/stats/passing_bablok.sio
@@ -1,0 +1,187 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/passing_bablok.sio — Passing-Bablok regression
+//
+// The clinical-chemistry standard for method comparison: a non-parametric line
+// fit robust to error in both variables and to outliers, with no distributional
+// assumption on the measurements.
+//
+//   passing_bablok(x, y, n) -> PBFit
+//
+// Pairwise slopes Sᵢⱼ = (yⱼ−yᵢ)/(xⱼ−xᵢ) (i<j, xᵢ≠xⱼ) are formed; those equal to
+// −1 are excluded (they cancel the shift correction). With N valid slopes sorted
+// ascending and K = #{Sᵢⱼ < −1}, the estimated slope is the *shifted* median
+//   b = S_{(N+1)/2 + K}                (N odd)
+//   b = ½(S_{N/2+K} + S_{N/2+K+1})     (N even)   [1-indexed],
+// and the intercept a = median_i(yᵢ − b·xᵢ).  The K offset corrects the bias of
+// the plain slope median (Passing & Bablok 1983; matches the R `mcr` package).
+//
+// Pure Sounio: pairwise slopes in a bounded [2080] scratch (n ≤ 64) with an
+// *inline* sort; residual median with a second inline sort. No nested call is
+// made while a large buffer is live.
+//
+// References:
+//   Passing & Bablok (1983) J. Clin. Chem. Clin. Biochem. 21:709.
+
+module stats::passing_bablok
+
+// sort the first m entries of a [2080] buffer ascending (inline insertion sort).
+fn pb_sort_big(buf: &![f64; 2080], m: i32) with Mut {
+    var i = 1
+    while i < m {
+        let key = buf[i as usize]
+        var j = i - 1
+        while j >= 0 && buf[j as usize] > key { buf[(j + 1) as usize] = buf[j as usize]; j = j - 1 }
+        buf[(j + 1) as usize] = key
+        i = i + 1
+    }
+}
+
+// median of the first m entries of a [256] buffer (inline insertion sort).
+fn pb_median_small(buf: &![f64; 256], m: i32) -> f64 with Mut, Div, Panic {
+    if m < 1 { return 0.0 }
+    var i = 1
+    while i < m {
+        let key = buf[i as usize]
+        var j = i - 1
+        while j >= 0 && buf[j as usize] > key { buf[(j + 1) as usize] = buf[j as usize]; j = j - 1 }
+        buf[(j + 1) as usize] = key
+        i = i + 1
+    }
+    if m % 2 == 1 { return buf[((m - 1) / 2) as usize] }
+    return 0.5 * (buf[(m / 2 - 1) as usize] + buf[(m / 2) as usize])
+}
+
+pub struct PBFit {
+    pub slope: f64,
+    pub intercept: f64,
+}
+
+/// Passing-Bablok regression.
+///
+/// Parâmetros: x, y — paired measurements; n — size (2..64).
+/// Retorno: PBFit (slope, intercept).
+/// Referências: Passing & Bablok (1983).
+pub fn passing_bablok(x: &[f64; 256], y: &[f64; 256], n: i32) -> PBFit with Mut, Div, Panic {
+    if n < 2 || n > 64 { return PBFit { slope: 0.0, intercept: 0.0 } }
+    var slopes: [f64; 2080] = [0.0; 2080]
+    var m = 0
+    var kneg = 0
+    var i = 0
+    while i < n {
+        var j = i + 1
+        while j < n {
+            let dx = x[j as usize] - x[i as usize]
+            if dx != 0.0 {
+                let s = (y[j as usize] - y[i as usize]) / dx
+                if s != 0.0 - 1.0 {            // exclude slopes exactly -1
+                    slopes[m as usize] = s
+                    m = m + 1
+                    if s < 0.0 - 1.0 { kneg = kneg + 1 }
+                }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    if m < 1 { return PBFit { slope: 0.0, intercept: 0.0 } }
+    pb_sort_big(&!slopes, m)
+    // shifted median (1-indexed rank (N+1)/2 + K), translated to 0-indexed
+    var slope = 0.0
+    if m % 2 == 1 {
+        var idx = (m + 1) / 2 + kneg - 1
+        if idx < 0 { idx = 0 }
+        if idx > m - 1 { idx = m - 1 }
+        slope = slopes[idx as usize]
+    } else {
+        var idlo = m / 2 + kneg - 1
+        var idhi = m / 2 + kneg
+        if idlo < 0 { idlo = 0 }
+        if idhi > m - 1 { idhi = m - 1 }
+        slope = 0.5 * (slopes[idlo as usize] + slopes[idhi as usize])
+    }
+    // intercept = median residual
+    var resid: [f64; 256] = [0.0; 256]
+    var k = 0
+    while k < n {
+        resid[k as usize] = y[k as usize] - slope * x[k as usize]
+        k = k + 1
+    }
+    let intercept = pb_median_small(&!resid, n)
+    return PBFit { slope: slope, intercept: intercept }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect line y=2x+1: all 6 slopes = 2, N=6, K=0 -> b=(S3+S4)/2=2, intercept 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0
+    let r = passing_bablok(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.intercept, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// -1 exclusion: (1,1),(2,3),(3,2),(4,5). the (2,3) pair has slope -1 and is
+// dropped, leaving valid {2,0.5,1.333333,1,3}, N=5, K=0 -> b=S_3=1.333333.
+// intercept = median(y-b·x) = median{-0.333333,0.333333,-2,-0.333333} = -0.333333.
+fn test_exclude_minus1() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=1.0; y[1]=3.0; y[2]=2.0; y[3]=5.0
+    let r = passing_bablok(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.slope, 1.333333, 1.0e-5)) && ok
+    ok = check(11, approx(r.intercept, 0.0 - 0.333333, 1.0e-5)) && ok
+    return ok
+}
+
+// K-offset case: (1,5),(2,1),(3,6),(4,7). slopes {-4,0.5,0.666667,5,3,1}, N=6,
+// K=1 (the -4 < -1). sorted -4,0.5,0.666667,1,3,5 -> b=(S_{3+1}+S_{3+2})/2
+// = (S_4+S_5)/2 = (1+3)/2 = 2. intercept=median(5-2,1-4,6-6,7-8)=med{3,-3,0,-1}=-0.5.
+fn test_k_offset() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=5.0; y[1]=1.0; y[2]=6.0; y[3]=7.0
+    let r = passing_bablok(&x, &y, 4)
+    var ok = true
+    ok = check(20, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.intercept, 0.0 - 0.5, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_exclude_minus1() && ok
+    ok = test_k_offset() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/theil_sen.sio
+++ b/stdlib/stats/theil_sen.sio
@@ -1,0 +1,164 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/theil_sen.sio — Theil-Sen robust regression
+//
+// The distribution-free line fit: the slope is the median of the pairwise
+// slopes, so up to ~29% of the points can be arbitrary outliers without moving
+// it:
+//
+//   theil_sen(x, y, n) -> TSFit
+//
+//   slope  b = median_{i<j, xᵢ≠xⱼ} (yⱼ − yᵢ)/(xⱼ − xᵢ),
+//   intercept a = median_i (yᵢ − b·xᵢ).
+//
+// Pure Sounio: the pairwise slopes are materialised into a bounded [2080]
+// scratch (n ≤ 64) and the median is taken with an *inline* insertion sort;
+// the residual median for the intercept uses a second inline sort. No nested
+// call is made while a large buffer is live.
+//
+// References:
+//   Theil (1950); Sen (1968) JASA 63:1379.
+
+module stats::theil_sen
+
+// median of the first m entries of a [2080] buffer (inline insertion sort).
+fn ts_median_big(buf: &![f64; 2080], m: i32) -> f64 with Mut, Div, Panic {
+    if m < 1 { return 0.0 }
+    var i = 1
+    while i < m {
+        let key = buf[i as usize]
+        var j = i - 1
+        while j >= 0 && buf[j as usize] > key { buf[(j + 1) as usize] = buf[j as usize]; j = j - 1 }
+        buf[(j + 1) as usize] = key
+        i = i + 1
+    }
+    if m % 2 == 1 { return buf[((m - 1) / 2) as usize] }
+    return 0.5 * (buf[(m / 2 - 1) as usize] + buf[(m / 2) as usize])
+}
+
+// median of the first m entries of a [256] buffer (inline insertion sort).
+fn ts_median_small(buf: &![f64; 256], m: i32) -> f64 with Mut, Div, Panic {
+    if m < 1 { return 0.0 }
+    var i = 1
+    while i < m {
+        let key = buf[i as usize]
+        var j = i - 1
+        while j >= 0 && buf[j as usize] > key { buf[(j + 1) as usize] = buf[j as usize]; j = j - 1 }
+        buf[(j + 1) as usize] = key
+        i = i + 1
+    }
+    if m % 2 == 1 { return buf[((m - 1) / 2) as usize] }
+    return 0.5 * (buf[(m / 2 - 1) as usize] + buf[(m / 2) as usize])
+}
+
+pub struct TSFit {
+    pub slope: f64,
+    pub intercept: f64,
+}
+
+/// Theil-Sen robust regression.
+///
+/// Parâmetros: x, y — paired data; n — size (2..64).
+/// Retorno: TSFit (slope = median pairwise slope, intercept = median residual).
+/// Referências: Theil (1950); Sen (1968).
+pub fn theil_sen(x: &[f64; 256], y: &[f64; 256], n: i32) -> TSFit with Mut, Div, Panic {
+    if n < 2 || n > 64 { return TSFit { slope: 0.0, intercept: 0.0 } }
+    var slopes: [f64; 2080] = [0.0; 2080]
+    var m = 0
+    var i = 0
+    while i < n {
+        var j = i + 1
+        while j < n {
+            let dx = x[j as usize] - x[i as usize]
+            if dx != 0.0 {
+                slopes[m as usize] = (y[j as usize] - y[i as usize]) / dx
+                m = m + 1
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    if m < 1 { return TSFit { slope: 0.0, intercept: 0.0 } }
+    let slope = ts_median_big(&!slopes, m)
+    // intercept = median residual y_i - slope*x_i
+    var resid: [f64; 256] = [0.0; 256]
+    var k = 0
+    while k < n {
+        resid[k as usize] = y[k as usize] - slope * x[k as usize]
+        k = k + 1
+    }
+    let intercept = ts_median_small(&!resid, n)
+    return TSFit { slope: slope, intercept: intercept }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect line y=2x+1: all pairwise slopes 2, all residuals 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0
+    let r = theil_sen(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.intercept, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// robustness: y=2x+1 for x=1..4, then a wild outlier (5,100).
+// 10 slopes: six 2's + four large -> median (5th,6th) = 2. residual median = 1.
+fn test_robust() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0; y[4]=100.0
+    let r = theil_sen(&x, &y, 5)
+    var ok = true
+    ok = check(10, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.intercept, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// negative slope y = -3x + 10: (0,10),(1,7),(2,4),(3,1). slopes all -3, resid 10.
+fn test_negative() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=10.0; y[1]=7.0; y[2]=4.0; y[3]=1.0
+    let r = theil_sen(&x, &y, 4)
+    var ok = true
+    ok = check(20, approx(r.slope, 0.0 - 3.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.intercept, 10.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_robust() && ok
+    ok = test_negative() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three robust line-fit modules for the epistemic-statistics suite, bringing it to **45 modules**. These are the **method-comparison regression** companions to the suite's agreement measures (Bland-Altman, CCC, ICC) — the standard tools for comparing a new assay/instrument against a reference, central to biomaterials/pharmacology. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::deming` | Errors-in-variables regression (error in both axes, variance ratio λ), closed form |
| `stats::theil_sen` | Distribution-free: median of pairwise slopes + median residual (~29% breakdown) |
| `stats::passing_bablok` | Clinical-chemistry standard: shifted-median slope with −1 exclusion + K-offset |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Deming: perfect line → (2,1); staircase → slope 0.8828 (vs OLS 0.8, showing the errors-in-variables pull).
  - Theil-Sen: perfect → (2,1); a wild outlier at (5,100) still → (2,1); negative slope → −3.
  - Passing-Bablok: perfect → (2,1); a slope=−1 pair correctly excluded; a K-offset case (N=6, K=1) → slope 2.
- The Passing-Bablok **K-offset was math-review-confirmed against Passing & Bablok 1983** (matches the R `mcr` implementation) — the one subtle formula here, checked with extra scrutiny.
- Full suite selftest: **45 modules + 7 demos ALL GREEN** under `lean_single`.

## `#852`-safety
`theil_sen` and `passing_bablok` materialise up to C(64,2)=2016 pairwise slopes into a bounded `[2080]` buffer and take the median with an **inline** sort — no nested call while the large buffer is live. Caps: n≤64.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).