### PR TITLE
feat(stats): exact & multi-condition categorical tests — fisher_exact, cochran_q, fleiss_kappa

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2746,3 +2746,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - passing_bablok = **PASS**: shifted-median with K-offset matches Passing & Bablok 1983 exactly (1-indexed rank (N+1)/2+K → 0-based with clamping); -1 slope exclusion verified (N=5,K=0 case); K-offset case (N=6,K=1 → slope 2) confirmed.
 - Theme: method-comparison / robust regression — complements the agreement modules (bland_altman, concordance/CCC, reliability) for assay/instrument comparison. #852-safe: theil_sen & passing_bablok use bounded pairwise buffers with inline median sorts (no nested call while big buffer live). Suite selftest: 45 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-8JVsS1/`, `/tmp/llm-offload-NuJ1qi/`, `/tmp/llm-offload-LafnKF/`.
+
+## 2026-07-14 — math-review: stats::fisher_exact, stats::cochran_q, stats::fleiss_kappa
+- Files (all new): `stdlib/stats/fisher_exact.sio` (Fisher's exact 2×2: hypergeometric two-sided/one-sided p + odds ratio, log-factorials via Lanczos), `stdlib/stats/cochran_q.sio` (Cochran's Q for k paired binary conditions, χ² tail via igamma), `stdlib/stats/fleiss_kappa.sio` (Fleiss' multi-rater kappa). Provider: xAI/Grok 4.3.
+- fisher_exact = **PASS**: hypergeometric P via log-factorials, two-sided sum over P≤P_obs with float-tolerant threshold, support bounds max(0,c1-r2)..min(r1,c1), OR=ad/bc all correct; tea-test 0.4857/OR 9 verified.
+- cochran_q = **PASS**: Q=(k-1)(kΣC²-N²)/(kN-ΣR²) transcription exact, denom=0 guard, χ² tail standard; Q=2.667 and Q=6 examples verified.
+- fleiss_kappa = **PASS**: Pᵢ, P̄, pⱼ, P̄ₑ, κ all match Fleiss (1971); three test cases (κ=-0.2, κ=1, three-category) correct. Note: significance-test SE deliberately omitted (fiddly Fleiss variance) — point estimate + components only.
+- Theme: exact & multi-condition categorical inference — complements chi2_independence/mcnemar/trend/cohen_kappa. All scalar/small-array, #852-safe. Suite selftest: 48 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-WWTpfo/`, `/tmp/llm-offload-s2BJ8J/`, `/tmp/llm-offload-JKGRlT/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -52,6 +52,9 @@ MODULES=(
   stdlib/stats/deming.sio
   stdlib/stats/theil_sen.sio
   stdlib/stats/passing_bablok.sio
+  stdlib/stats/fisher_exact.sio
+  stdlib/stats/cochran_q.sio
+  stdlib/stats/fleiss_kappa.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -690,6 +690,39 @@ per Passing & Bablok 1983 / the R `mcr` package) and the median-residual
 intercept. Validated: perfect line → (2,1); −1-slope pair correctly excluded;
 K-offset case → slope 2.
 
+### `stats::fisher_exact` — Fisher's exact test (2×2)
+
+| Function | Signature |
+|---|---|
+| `fisher_exact` | `pub fn fisher_exact(a: i64, b: i64, c: i64, d: i64) -> FisherResult with Mut, Div, Panic` |
+
+The exact small-sample test of 2×2 association (valid where χ² is not): the
+two-sided p sums hypergeometric probabilities of all tables with P≤P(observed);
+one-sided tails and the sample odds ratio too. Validated: tea-test [[3,1],[1,3]]
+→ p_two=0.4857, p_greater=0.2429, OR=9; [[9,1],[1,9]] → p<0.01, OR=81;
+[[5,5],[5,5]] → p=1, OR=1.
+
+### `stats::cochran_q` — Cochran's Q test
+
+| Function | Signature |
+|---|---|
+| `cochran_q` | `pub fn cochran_q(data: &[f64; 256], n: i32, k: i32) -> CochranQResult with Mut, Div, Panic` |
+
+McNemar extended to k≥2 matched binary conditions: `Q=(k−1)(k·ΣCⱼ²−N²)/(k·N−ΣRᵢ²)
+~ χ²(k−1)` on a row-major n×k 0/1 matrix. Validated: 4×3 example → Q=2.667, df=2;
+one-condition-always-positive → Q=6, p<0.05; all-agree → Q=0.
+
+### `stats::fleiss_kappa` — Fleiss' kappa (multi-rater)
+
+| Function | Signature |
+|---|---|
+| `fleiss_kappa` | `pub fn fleiss_kappa(counts: &[f64; 256], subjects: i32, k: i32, raters: i32) -> FleissResult with Mut, Div, Panic` |
+
+Cohen's κ extended to a fixed number of raters per subject: chance-corrected
+agreement `κ=(P̄−P̄ₑ)/(1−P̄ₑ)` from a row-major N×k rater-count matrix. Validated:
+worked 2-subject case → P̄=0.6667, P̄ₑ=0.7222, κ=−0.2; perfect within-subject
+agreement → κ=1.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -737,6 +770,9 @@ use stats::outlier::{OutlierFences, GrubbsResult, ModZResult, tukey_outliers, gr
 use stats::deming::{DemingFit, deming}
 use stats::theil_sen::{TSFit, theil_sen}
 use stats::passing_bablok::{PBFit, passing_bablok}
+use stats::fisher_exact::{FisherResult, fisher_exact}
+use stats::cochran_q::{CochranQResult, cochran_q}
+use stats::fleiss_kappa::{FleissResult, fleiss_kappa}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/cochran_q.sio
+++ b/stdlib/stats/cochran_q.sio
@@ -1,0 +1,242 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/cochran_q.sio — Cochran's Q test
+//
+// The extension of McNemar's test to k ≥ 2 matched binary conditions: n
+// subjects each measured 0/1 under k treatments, testing whether the success
+// proportion differs across treatments.
+//
+//   cochran_q(data, n, k) -> CochranQResult      (data row-major n×k, 0/1)
+//
+// With column success totals Cⱼ, row totals Rᵢ and grand total N=ΣCⱼ=ΣRᵢ,
+//   Q = (k−1)·( k·ΣCⱼ² − N² ) / ( k·N − ΣRᵢ² )  ~  χ²(k−1).
+//
+// Pure Sounio: one pass for the row/column totals; χ² tail via inline Lanczos
+// log-gamma + regularised incomplete gamma; no nested data-array calls.
+//
+// References:
+//   Cochran (1950) Biometrika 37:256; Sheskin, "Handbook of Parametric and
+//   Nonparametric Statistical Procedures" 5e.
+
+module stats::cochran_q
+
+fn cq_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / cq_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn cq_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn cq_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * cq_ln(tt) - tt + cq_ln(a)
+}
+
+fn cq_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * cq_exp(0.0 - x + s * cq_ln(x) - cq_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = cq_exp(0.0 - x + s * cq_ln(x) - cq_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn cq_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    if df <= 0.0 { return 1.0 }
+    return 1.0 - cq_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct CochranQResult {
+    pub q: f64,    // Cochran's Q statistic
+    pub df: i64,   // k - 1
+    pub p: f64,    // asymptotic chi-squared p-value
+}
+
+/// Cochran's Q test on a row-major n×k matrix of 0/1 outcomes.
+///
+/// Parâmetros: data — n·k binary values, row i = subject i; n — subjects (>=2);
+///             k — conditions (2..16).
+/// Retorno: CochranQResult (q, df, p).
+/// Referências: Cochran (1950).
+pub fn cochran_q(data: &[f64; 256], n: i32, k: i32) -> CochranQResult with Mut, Div, Panic {
+    if n < 2 || k < 2 || k > 16 { return CochranQResult { q: 0.0, df: 0, p: 1.0 } }
+    var col: [f64; 16] = [0.0; 16]
+    var sum_r = 0.0
+    var sum_r2 = 0.0
+    var i = 0
+    while i < n {
+        var ri = 0.0
+        var j = 0
+        while j < k {
+            let v = data[(i * k + j) as usize]
+            col[j as usize] = col[j as usize] + v
+            ri = ri + v
+            j = j + 1
+        }
+        sum_r = sum_r + ri
+        sum_r2 = sum_r2 + ri * ri
+        i = i + 1
+    }
+    var sum_c2 = 0.0
+    var jj = 0
+    while jj < k { sum_c2 = sum_c2 + col[jj as usize] * col[jj as usize]; jj = jj + 1 }
+    let kf = k as f64
+    let bigN = sum_r                     // grand total of successes
+    let denom = kf * bigN - sum_r2
+    var q = 0.0
+    if denom > 0.0 {
+        q = (kf - 1.0) * (kf * sum_c2 - bigN * bigN) / denom
+    }
+    let df = k - 1
+    let p = cq_chi2_sf(q, df as f64)
+    return CochranQResult { q: q, df: df as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 4 subjects × 3 conditions. rows (1,1,0)(1,0,0)(0,1,0)(1,1,1).
+// C=(3,3,1) N=7 ΣC²=19; R=(2,1,1,3) ΣR²=15.
+// Q = 2·(3·19 - 49)/(3·7 - 15) = 2·8/6 = 2.666667. df=2.
+fn test_q() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=1.0; d[2]=0.0
+    d[3]=1.0; d[4]=0.0; d[5]=0.0
+    d[6]=0.0; d[7]=1.0; d[8]=0.0
+    d[9]=1.0; d[10]=1.0; d[11]=1.0
+    let r = cochran_q(&d, 4, 3)
+    var ok = true
+    ok = check(1, approx(r.q, 2.666667, 1.0e-4)) && ok
+    ok = check(2, r.df == 2) && ok
+    return ok
+}
+
+// strong difference: condition 1 always 1, others always 0 (3 subjects).
+// C=(3,0,0) N=3 ΣC²=9; R=(1,1,1) ΣR²=3. Q=2·(3·9-9)/(3·3-3)=2·18/6=6. df=2.
+fn test_strong() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=0.0; d[2]=0.0
+    d[3]=1.0; d[4]=0.0; d[5]=0.0
+    d[6]=1.0; d[7]=0.0; d[8]=0.0
+    let r = cochran_q(&d, 3, 3)
+    var ok = true
+    ok = check(10, approx(r.q, 6.0, 1.0e-4)) && ok
+    ok = check(11, r.p < 0.05) && ok
+    return ok
+}
+
+// no difference: all rows (1,1,1) -> denom 0 -> Q 0, p 1.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=1.0; d[2]=1.0
+    d[3]=1.0; d[4]=1.0; d[5]=1.0
+    let r = cochran_q(&d, 2, 3)
+    var ok = true
+    ok = check(20, approx(r.q, 0.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.p, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_q() && ok
+    ok = test_strong() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/fisher_exact.sio
+++ b/stdlib/stats/fisher_exact.sio
@@ -1,0 +1,209 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/fisher_exact.sio — Fisher's exact test for a 2×2 table
+//
+// The exact small-sample test of association, valid where the chi-squared
+// approximation is not (expected cell counts < 5):
+//
+//   fisher_exact(a, b, c, d) -> FisherResult      table [[a,b],[c,d]]
+//
+// Conditioning on the margins, each table has hypergeometric probability
+//   P(a) = C(r1,a)·C(r2,c) / C(N,c1)
+//        = r1! r2! c1! c2! / ( N! a! b! c! d! ).
+// The two-sided p sums the probabilities of every table (same margins) with
+// P ≤ P(observed); the one-sided tails sum a′ ≥ a and a′ ≤ a. The sample odds
+// ratio is a·d / (b·c).
+//
+// Pure Sounio: log-factorials via inline Lanczos log-gamma, summed in the
+// probability domain; no external dependency, no nested data-array calls.
+//
+// References:
+//   Fisher (1934); Agresti, "Categorical Data Analysis" 3e, §3.5.
+
+module stats::fisher_exact
+
+fn fe_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / fe_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn fe_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn fe_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * fe_ln(tt) - tt + fe_ln(a)
+}
+
+// log(k!) = lgamma(k+1)
+fn fe_logfact(k: i64) -> f64 with Mut, Div, Panic {
+    if k <= 1 { return 0.0 }
+    return fe_lgamma((k as f64) + 1.0)
+}
+
+pub struct FisherResult {
+    pub p_two: f64,       // two-sided p-value
+    pub p_greater: f64,   // one-sided (a' >= a)
+    pub p_less: f64,      // one-sided (a' <= a)
+    pub odds_ratio: f64,  // sample OR a·d/(b·c)
+}
+
+// hypergeometric probability of cell value av given fixed margins.
+fn fe_prob(av: i64, r1: i64, r2: i64, c1v: i64, cN: i64, base: f64) -> f64 with Mut, Div, Panic {
+    let bv = r1 - av
+    let cv = c1v - av
+    let dv = r2 - cv
+    if av < 0 || bv < 0 || cv < 0 || dv < 0 { return 0.0 }
+    let lp = base - fe_logfact(av) - fe_logfact(bv) - fe_logfact(cv) - fe_logfact(dv)
+    return fe_exp(lp)
+}
+
+/// Fisher's exact test for the 2×2 table [[a,b],[c,d]].
+///
+/// Parâmetros: a,b,c,d — the four non-negative cell counts.
+/// Retorno: FisherResult (p_two, p_greater, p_less, odds_ratio).
+/// Referências: Fisher (1934); Agresti §3.5.
+pub fn fisher_exact(a: i64, b: i64, c: i64, d: i64) -> FisherResult with Mut, Div, Panic {
+    let r1 = a + b
+    let r2 = c + d
+    let c1v = a + c
+    let c2v = b + d
+    let cN = a + b + c + d
+    if cN <= 0 {
+        return FisherResult { p_two: 1.0, p_greater: 1.0, p_less: 1.0, odds_ratio: 0.0 }
+    }
+    // constant part of log P: r1! r2! c1! c2! / N!
+    let base = fe_logfact(r1) + fe_logfact(r2) + fe_logfact(c1v) + fe_logfact(c2v) - fe_logfact(cN)
+    let p_obs = fe_prob(a, r1, r2, c1v, cN, base)
+    // range of a': max(0, c1 - r2) .. min(r1, c1)
+    var lo = 0
+    if c1v - r2 > 0 { lo = (c1v - r2) as i32 }
+    var hi = r1
+    if c1v < r1 { hi = c1v }
+    var p_two = 0.0
+    var p_greater = 0.0
+    var p_less = 0.0
+    let tol = p_obs * 1.0000001 + 1.0e-12
+    var av = lo
+    while (av as i64) <= hi {
+        let p = fe_prob(av as i64, r1, r2, c1v, cN, base)
+        if p <= tol { p_two = p_two + p }
+        if (av as i64) >= a { p_greater = p_greater + p }
+        if (av as i64) <= a { p_less = p_less + p }
+        av = av + 1
+    }
+    if p_two > 1.0 { p_two = 1.0 }
+    if p_greater > 1.0 { p_greater = 1.0 }
+    if p_less > 1.0 { p_less = 1.0 }
+    var or = 0.0
+    let bf = b as f64
+    let cf = c as f64
+    if bf > 0.0 && cf > 0.0 { or = ((a as f64) * (d as f64)) / (bf * cf) }
+    return FisherResult { p_two: p_two, p_greater: p_greater, p_less: p_less, odds_ratio: or }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// tea-test style [[3,1],[1,3]]: margins all 4, N=8, C(8,4)=70.
+// P(a) for a=0..4: 1/70,16/70,36/70,16/70,1/70. Observed a=3, P=16/70=0.228571.
+// two-sided = tables with P<=0.228571 = (1+16+16+1)/70 = 34/70 = 0.485714.
+// one-sided (a'>=3) = (16+1)/70 = 17/70 = 0.242857. OR = 9.
+fn test_tea() -> bool with IO, Mut, Div, Panic {
+    let r = fisher_exact(3, 1, 1, 3)
+    var ok = true
+    ok = check(1, approx(r.p_two, 0.485714, 1.0e-5)) && ok
+    ok = check(2, approx(r.p_greater, 0.242857, 1.0e-5)) && ok
+    ok = check(3, approx(r.odds_ratio, 9.0, 1.0e-9)) && ok
+    return ok
+}
+
+// strong association [[9,1],[1,9]]: two-sided p tiny, OR=81.
+fn test_significant() -> bool with IO, Mut, Div, Panic {
+    let r = fisher_exact(9, 1, 1, 9)
+    var ok = true
+    ok = check(10, r.p_two < 0.01) && ok
+    ok = check(11, approx(r.odds_ratio, 81.0, 1.0e-6)) && ok
+    return ok
+}
+
+// no association [[5,5],[5,5]]: p_two = 1, OR = 1.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    let r = fisher_exact(5, 5, 5, 5)
+    var ok = true
+    ok = check(20, approx(r.p_two, 1.0, 1.0e-6)) && ok
+    ok = check(21, approx(r.odds_ratio, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_tea() && ok
+    ok = test_significant() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/fleiss_kappa.sio
+++ b/stdlib/stats/fleiss_kappa.sio
@@ -1,0 +1,146 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/fleiss_kappa.sio — Fleiss' kappa (multi-rater agreement)
+//
+// The extension of Cohen's kappa to a fixed number of raters per subject: N
+// subjects, each rated by n raters into k categories, measuring chance-corrected
+// agreement.
+//
+//   fleiss_kappa(counts, subjects, k, raters) -> FleissResult
+//
+// counts is row-major N×k, where entry nᵢⱼ = #raters assigning subject i to
+// category j (each row sums to `raters`). With
+//   Pᵢ = ( Σⱼ nᵢⱼ² − n ) / ( n(n−1) ),      P̄ = mean Pᵢ,
+//   pⱼ = (1/(N n)) Σᵢ nᵢⱼ,                   P̄ₑ = Σⱼ pⱼ²,
+//   κ = (P̄ − P̄ₑ) / (1 − P̄ₑ).
+//
+// Pure Sounio: one pass for the category totals and per-subject agreement; no
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Fleiss (1971) Psychol. Bull. 76:378.
+
+module stats::fleiss_kappa
+
+pub struct FleissResult {
+    pub kappa: f64,   // Fleiss' kappa
+    pub p_bar: f64,   // mean observed agreement
+    pub p_e: f64,     // expected agreement by chance
+}
+
+/// Fleiss' kappa for multi-rater categorical agreement.
+///
+/// Parâmetros: counts — row-major N×k rater-count matrix (rows sum to `raters`);
+///             subjects — N (>=2); k — categories (2..16); raters — n per subject (>=2).
+/// Retorno: FleissResult (kappa, p_bar, p_e).
+/// Referências: Fleiss (1971).
+pub fn fleiss_kappa(counts: &[f64; 256], subjects: i32, k: i32, raters: i32) -> FleissResult with Mut, Div, Panic {
+    if subjects < 2 || k < 2 || k > 16 || raters < 2 {
+        return FleissResult { kappa: 0.0, p_bar: 0.0, p_e: 0.0 }
+    }
+    let nf = raters as f64
+    let Nf = subjects as f64
+    var cat: [f64; 16] = [0.0; 16]
+    var sum_pi = 0.0
+    var i = 0
+    while i < subjects {
+        var ss = 0.0
+        var j = 0
+        while j < k {
+            let v = counts[(i * k + j) as usize]
+            cat[j as usize] = cat[j as usize] + v
+            ss = ss + v * v
+            j = j + 1
+        }
+        let pi = (ss - nf) / (nf * (nf - 1.0))
+        sum_pi = sum_pi + pi
+        i = i + 1
+    }
+    let p_bar = sum_pi / Nf
+    // category proportions and expected agreement
+    var p_e = 0.0
+    var jj = 0
+    while jj < k {
+        let pj = cat[jj as usize] / (Nf * nf)
+        p_e = p_e + pj * pj
+        jj = jj + 1
+    }
+    var kappa = 0.0
+    let denom = 1.0 - p_e
+    if denom > 1.0e-300 || denom < 0.0 - 1.0e-300 {
+        kappa = (p_bar - p_e) / denom
+    }
+    return FleissResult { kappa: kappa, p_bar: p_bar, p_e: p_e }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// N=2, n=3, k=2. subj1 (3,0), subj2 (2,1).
+// P1=(9-3)/6=1; P2=(4+1-3)/6=0.333333; P̄=0.666667.
+// p1=5/6=0.833333, p2=1/6=0.166667; P̄e=0.694444+0.027778=0.722222.
+// kappa=(0.666667-0.722222)/(1-0.722222)=-0.055556/0.277778=-0.2.
+fn test_fleiss() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=3.0; d[1]=0.0
+    d[2]=2.0; d[3]=1.0
+    let r = fleiss_kappa(&d, 2, 2, 3)
+    var ok = true
+    ok = check(1, approx(r.p_bar, 0.666667, 1.0e-5)) && ok
+    ok = check(2, approx(r.p_e, 0.722222, 1.0e-5)) && ok
+    ok = check(3, approx(r.kappa, 0.0 - 0.2, 1.0e-5)) && ok
+    return ok
+}
+
+// perfect within-subject agreement, split categories: subj1 (3,0), subj2 (0,3).
+// P1=P2=1 -> P̄=1; p1=p2=0.5 -> P̄e=0.5; kappa=(1-0.5)/(1-0.5)=1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=3.0; d[1]=0.0
+    d[2]=0.0; d[3]=3.0
+    let r = fleiss_kappa(&d, 2, 2, 3)
+    var ok = true
+    ok = check(10, approx(r.kappa, 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p_bar, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// three categories, 3 subjects, 4 raters. all raters agree within each subject
+// but on different categories -> kappa 1.
+fn test_three_cat() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=4.0; d[1]=0.0; d[2]=0.0
+    d[3]=0.0; d[4]=4.0; d[5]=0.0
+    d[6]=0.0; d[7]=0.0; d[8]=4.0
+    let r = fleiss_kappa(&d, 3, 3, 4)
+    return check(20, approx(r.kappa, 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_fleiss() && ok
+    ok = test_perfect() && ok
+    ok = test_three_cat() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three more pure-Sounio modules for the epistemic-statistics suite, bringing it to **48 modules**. These complete the **small-sample and multi-rater categorical** gaps beside the existing `chi2_independence`, `mcnemar`, `trend` and `cohen_kappa`. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::fisher_exact` | Fisher's exact 2×2 test: exact hypergeometric two-sided & one-sided p + odds ratio |
| `stats::cochran_q` | Cochran's Q — McNemar extended to k≥2 matched binary conditions |
| `stats::fleiss_kappa` | Fleiss' κ — Cohen's κ extended to a fixed number of raters per subject |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Fisher: tea-test [[3,1],[1,3]] → p_two=0.4857, p_greater=0.2429, OR=9; [[9,1],[1,9]] → p<0.01, OR=81; [[5,5],[5,5]] → p=1.
  - Cochran's Q: 4×3 example → Q=2.667, df=2; one-condition-always-positive → Q=6, p<0.05; all-agree → Q=0.
  - Fleiss: worked 2-subject case → P̄=0.6667, P̄ₑ=0.7222, κ=−0.2; perfect within-subject agreement → κ=1.
- Full suite selftest: **48 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; Fisher uses inline Lanczos log-factorials, Cochran's Q an inline incomplete-gamma χ² tail.

## Note
`fleiss_kappa` reports the point estimate + observed/expected agreement components; the asymptotic significance-test SE (the fiddly Fleiss variance) is deliberately omitted rather than shipped with risk.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).