### PR TITLE
test(integrate): run-proof for epistemic_ode ODE solver (coordinated disjoint lane)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2746,3 +2746,8 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - passing_bablok = **PASS**: shifted-median with K-offset matches Passing & Bablok 1983 exactly (1-indexed rank (N+1)/2+K → 0-based with clamping); -1 slope exclusion verified (N=5,K=0 case); K-offset case (N=6,K=1 → slope 2) confirmed.
 - Theme: method-comparison / robust regression — complements the agreement modules (bland_altman, concordance/CCC, reliability) for assay/instrument comparison. #852-safe: theil_sen & passing_bablok use bounded pairwise buffers with inline median sorts (no nested call while big buffer live). Suite selftest: 45 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-8JVsS1/`, `/tmp/llm-offload-NuJ1qi/`, `/tmp/llm-offload-LafnKF/`.
+
+## 2026-07-14 — math-review: integrate::epistemic_ode run-proof
+- Files: `tests/stdlib/integrate/test_integrate_stdlib.sio`, `examples/integrate/decay_report.sio` (no source edited).
+- Provider: xAI/Grok 4.3 = **PASS** (all). Confirmed y(t)=y0 e^{-kt}; Euler (1-1/n)^n→e^-1 O(1/n) (err@2000<err@200); half-life y(ln2)=y0/2; y(2)=2e^-1=0.735759; step-wise additive uncertainty recurrence u_{n+1}=u_n√(1+(k dt)²) is algebraically correct (u stays ~u0). Default Madaros. INTEGRATE_GATE_OK.
+- Raw review directory: see /tmp llm-offload dir.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 968
-- Repo-backed topics: 818
+- Total governed topics: 970
+- Repo-backed topics: 820
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 568
+- Authority count `repo_only`: 570
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 587 topics
+- A2: 589 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -781,6 +781,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.stdlib.stdlib-module-organization | repo_only | docs/stdlib/STDLIB_MODULE_ORGANIZATION.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-13-data-science-io | repo_only | docs/superpowers/plans/2026-07-13-data-science-io.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-13-epistemic-gum-hardening | repo_only | docs/superpowers/plans/2026-07-13-epistemic-gum-hardening.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-14-integrate-vertical | repo_only | docs/superpowers/plans/2026-07-14-integrate-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-linalg-vertical | repo_only | docs/superpowers/plans/2026-07-14-linalg-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-prob-vertical | repo_only | docs/superpowers/plans/2026-07-14-prob-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-signal-fft-vertical | repo_only | docs/superpowers/plans/2026-07-14-signal-fft-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -788,6 +789,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-14-units-vertical | repo_only | docs/superpowers/plans/2026-07-14-units-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design | repo_only | docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-14-integrate-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-integrate-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-linalg-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-linalg-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-prob-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-prob-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-signal-fft-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-signal-fft-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17269,6 +17269,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-14-integrate-vertical",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-14-integrate-vertical.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.plans.2026-07-14-linalg-vertical",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/plans/2026-07-14-linalg-vertical.md",
@@ -17410,6 +17433,29 @@
       "topic_id": "repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-14-integrate-vertical-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-14-integrate-vertical-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-07-14-integrate-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-integrate-vertical.md
@@ -1,0 +1,8 @@
+# integrate::epistemic_ode Run-Proof — Plan
+> Default Madaros (self-contained). No source edits (disjoint from active lanes). Spec: docs/superpowers/specs/2026-07-14-integrate-vertical-design.md.
+## Task 1 — run-proof driver
+- [ ] `tests/stdlib/integrate/test_integrate_stdlib.sio`: convergence to e⁻¹ (err@2000 < err@200, <2e-4); half-life y(ln2)=0.5; decay y(1)<y0; y(2)=2e⁻¹; uncertainty ∈[0.049,0.051]. `INTEGRATE_STDLIB_OK`. Compile+run. Commit.
+## Task 2 — example + gate
+- [ ] `examples/integrate/decay_report.sio` (elimination report). `scripts/integrate_gate.sh` → `INTEGRATE_GATE_OK`. Commit.
+## Task 3 — math-review + PR
+- [ ] math-review; governance sync; push; PR to main with `--auto` merge.

--- a/docs/superpowers/plans/2026-07-14-integrate-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-integrate-vertical.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-14-integrate-vertical
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-14-integrate-vertical
+-->
+
 # integrate::epistemic_ode Run-Proof — Plan
 > Default Madaros (self-contained). No source edits (disjoint from active lanes). Spec: docs/superpowers/specs/2026-07-14-integrate-vertical-design.md.
 ## Task 1 — run-proof driver

--- a/docs/superpowers/specs/2026-07-14-integrate-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-integrate-vertical-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-14-integrate-vertical-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-14-integrate-vertical-design
+-->
+
 # Design — Harden the integrate::epistemic_ode vertical
 
 **Status:** approved · **Date:** 2026-07-14 · **Constraint:** no compiler changes.

--- a/docs/superpowers/specs/2026-07-14-integrate-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-integrate-vertical-design.md
@@ -1,0 +1,53 @@
+# Design — Harden the integrate::epistemic_ode vertical
+
+**Status:** approved · **Date:** 2026-07-14 · **Constraint:** no compiler changes.
+**Coordination:** `integrate/` is cold (stable, no open PR) — disjoint from active stats/IR/special lanes.
+This lane **edits no source** — it adds an independent run-proof + gate + docs. EN-UK.
+
+## 1. Why
+Eighth playbook application (GUM #860, units #873, linalg #892, prob #902, stats #909, FFT #917).
+`integrate::epistemic_ode` is a self-contained, epistemic-aware ODE solver (GUM through-line) that
+native-compiles under the default Madaros engine.
+
+## 2. Verified starting state
+- `stdlib/integrate/epistemic_ode.sio` — GUM-uncertainty ODE solver (`epistemic_rk4_step`,
+  `epistemic_euler_solve`, `epistemic_solve_decay`); `EpistemicState { pub values[16], pub uncertainties[16], pub n }`.
+  Self-contained, green; returns `EpistemicState` by value across import correctly (verified — the #916
+  fixed-array-value-semantics fix applies).
+- **Runs under default Madaros** (verified): dy/dt=−ky, y₀=1,k=1 → y(1)→e⁻¹ as steps grow.
+- **Method note (honest):** `epistemic_solve_decay` feeds a fixed per-step derivative to `rk4_step`, so
+  the decay path is **first-order (Euler-equivalent)**: y(1) error 9.2e-4 (n=200) → 9.2e-5 (n=2000), O(1/n).
+  Uncertainty uses a **step-wise additive GUM model** (u(y_{n+1})²=u(y_n)²+(dt·u(f))²) → u stays ≈u₀
+  rather than the analytic correlated e^{−kt}·u₀. Both are properties of the existing code, asserted as-is.
+
+## 3. Goal
+An independent run-proof asserts the solver converges to the closed-form exponential-decay solution and
+propagates a stable uncertainty, gated under the default engine — no source edits.
+
+## 4. Scope
+### In: run-proof driver (convergence to e⁻¹, half-life, decay monotonicity, uncertainty stability),
+consumer example (first-order elimination report), gate, math-review.
+### Out: no source edits; no new solver; no compiler edits.
+
+## 5. Design — assertions (closed form y(t)=y₀e^{−kt})
+- **Convergence:** |y(1;n=2000) − e⁻¹| < |y(1;n=200) − e⁻¹|, and < 2e-4.
+- **Half-life:** y(ln2; n=2000) = 0.5 ± 2e-4.
+- **Decay:** y(1) < y₀.
+- **Value:** y(2) for y₀=2,k=0.5 = 2e⁻¹ = 0.735759 ± 5e-4.
+- **Uncertainty:** for u₀=0.05, u stays in [0.049, 0.051] (step-wise additive model), > 0.
+All inline in `main`; read `EpistemicState.values[0]`/`.uncertainties[0]`.
+
+## 6. Layout
+```
+tests/stdlib/integrate/test_integrate_stdlib.sio  (new)
+examples/integrate/decay_report.sio               (new)
+scripts/integrate_gate.sh                          (new)
+```
+
+## 7. Verification
+`souc check` green; `souc compile … && ./elf` (default Madaros) driver+example; gate → `INTEGRATE_GATE_OK`;
+math-review logged.
+
+## 8. Success criteria
+Run-proof asserts convergence + known decay values + uncertainty stability and passes under default Madaros;
+gate green; no source/compiler files touched (disjoint).

--- a/examples/integrate/decay_report.sio
+++ b/examples/integrate/decay_report.sio
@@ -1,0 +1,26 @@
+// First-order elimination with GUM uncertainty, via stdlib integrate::epistemic_ode.
+// dC/dt = -k C, C0 = 100 ± 2 mg/L, k = 0.1 /h. Reports concentration at t = 5, 10, 20 h.
+use integrate::epistemic_ode::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("=== First-order elimination (integrate::epistemic_ode) ===\n")
+    let s5  = epistemic_solve_decay(100.0, 2.0, 0.1, 0.0, 5.0, 2000)
+    let s10 = epistemic_solve_decay(100.0, 2.0, 0.1, 0.0, 10.0, 2000)
+    let s20 = epistemic_solve_decay(100.0, 2.0, 0.1, 0.0, 20.0, 2000)
+    print("t= 5h: C = ")
+    print(s5.values[0])
+    print(" +/- ")
+    print(s5.uncertainties[0])
+    print(" mg/L\n")
+    print("t=10h: C = ")
+    print(s10.values[0])
+    print(" +/- ")
+    print(s10.uncertainties[0])
+    print(" mg/L\n")
+    print("t=20h: C = ")
+    print(s20.values[0])
+    print(" +/- ")
+    print(s20.uncertainties[0])
+    print(" mg/L\n")
+    return 0
+}

--- a/scripts/integrate_gate.sh
+++ b/scripts/integrate_gate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check epistemic_ode.sio =="
+$SOUC check stdlib/integrate/epistemic_ode.sio || fail=1
+echo "== run-proof driver =="
+if $SOUC compile tests/stdlib/integrate/test_integrate_stdlib.sio -o "$OUT/ti.elf"; then
+  "$OUT/ti.elf" | grep -q "INTEGRATE_STDLIB_OK" || { echo "FAIL: driver assertions"; fail=1; }
+else echo "FAIL: driver compile"; fail=1; fi
+echo "== consumer example =="
+if $SOUC compile examples/integrate/decay_report.sio -o "$OUT/dr.elf"; then
+  "$OUT/dr.elf" >/dev/null || { echo "FAIL: example run"; fail=1; }
+else echo "FAIL: example compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "INTEGRATE_GATE_OK"
+exit $fail

--- a/tests/stdlib/integrate/test_integrate_stdlib.sio
+++ b/tests/stdlib/integrate/test_integrate_stdlib.sio
@@ -1,0 +1,38 @@
+// Run-proof for stdlib integrate::epistemic_ode (GUM-uncertainty ODE solver).
+// dy/dt = -k y, y(0)=y0 has closed form y(t)=y0 e^{-kt}. The solver's decay path is
+// first-order (Euler-equivalent: fixed per-step derivative), so we assert CONVERGENCE
+// to the closed form (tighter with more steps), not an exact match. Self-contained -> default Madaros.
+use integrate::epistemic_ode::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let e_inv = 0.3678794412   // e^-1
+    let ln2   = 0.6931471806
+
+    // (1) convergence to e^-1: error(n=2000) < error(n=200)
+    let a = epistemic_solve_decay(1.0, 0.0, 1.0, 0.0, 1.0, 200)
+    let b = epistemic_solve_decay(1.0, 0.0, 1.0, 0.0, 1.0, 2000)
+    let ea = if a.values[0] > e_inv { a.values[0]-e_inv } else { e_inv-a.values[0] }
+    let eb = if b.values[0] > e_inv { b.values[0]-e_inv } else { e_inv-b.values[0] }
+    if eb >= ea { print("FAIL convergence\n"); return 1 }
+    // (2) accurate at n=2000 (Euler error ~9e-5)
+    if eb >= 2.0e-4 { print("FAIL y(1)\n"); return 2 }
+    // (3) decay: y(1) < y0
+    if b.values[0] >= 1.0 { print("FAIL decay\n"); return 3 }
+
+    // (4) half-life: y(ln2) = 0.5
+    let h = epistemic_solve_decay(1.0, 0.0, 1.0, 0.0, ln2, 2000)
+    let eh = if h.values[0] > 0.5 { h.values[0]-0.5 } else { 0.5-h.values[0] }
+    if eh >= 2.0e-4 { print("FAIL half_life\n"); return 4 }
+
+    // (5) uncertainty propagation runs and stays stable (step-wise additive GUM model -> u ~ u0)
+    let u = epistemic_solve_decay(2.0, 0.05, 0.5, 0.0, 2.0, 2000)
+    if u.uncertainties[0] <= 0.0 { print("FAIL u positive\n"); return 5 }
+    if u.uncertainties[0] < 0.049 { print("FAIL u low\n"); return 6 }
+    if u.uncertainties[0] > 0.051 { print("FAIL u high\n"); return 7 }
+    // value y(2) = 2 e^-1 = 0.735759
+    let ey = if u.values[0] > 0.735759 { u.values[0]-0.735759 } else { 0.735759-u.values[0] }
+    if ey >= 5.0e-4 { print("FAIL y(2)\n"); return 8 }
+
+    print("INTEGRATE_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Harden the integrate::epistemic_ode vertical (coordinated, disjoint)

Eighth playbook application. Self-contained, epistemic-aware ODE solver (GUM through-line), native-compiles under default Madaros. `integrate/` is cold — **no source edits**, only new run-proof + gate + docs.

### What's here
- **Run-proof** (`tests/stdlib/integrate/test_integrate_stdlib.sio`) — dy/dt=−ky vs closed form y(t)=y₀e^{−kt}: **convergence** to e⁻¹ (err@n=2000 < err@n=200, <2e-4), half-life y(ln2)=0.5, decay monotonicity, y(2)=2e⁻¹, uncertainty stability. `INTEGRATE_STDLIB_OK`.
- **Example** (`examples/integrate/decay_report.sio`) — first-order elimination: C(5)=60.65, C(10)=36.78, C(20)=13.52 mg/L (=100e^{−0.1t}).
- **Gate** (`scripts/integrate_gate.sh`) → `INTEGRATE_GATE_OK`.

### Honest method notes
`epistemic_solve_decay` feeds a fixed per-step derivative to `rk4_step`, so the decay path is **first-order (Euler-equivalent)** — asserted via convergence, not exact match. Its **step-wise additive** uncertainty model keeps u≈u₀ (not the analytic e^{−kt}·u₀); asserted as-is (a property of the existing code, which I don't edit). Math-review (xAI/Grok) PASS on all, incl. the uncertainty recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
