### PR TITLE
feat(stats): one-predictor GLMs — logistic, poisson_reg, wls

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2754,3 +2754,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - fleiss_kappa = **PASS**: Pᵢ, P̄, pⱼ, P̄ₑ, κ all match Fleiss (1971); three test cases (κ=-0.2, κ=1, three-category) correct. Note: significance-test SE deliberately omitted (fiddly Fleiss variance) — point estimate + components only.
 - Theme: exact & multi-condition categorical inference — complements chi2_independence/mcnemar/trend/cohen_kappa. All scalar/small-array, #852-safe. Suite selftest: 48 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-WWTpfo/`, `/tmp/llm-offload-s2BJ8J/`, `/tmp/llm-offload-JKGRlT/`.
+
+## 2026-07-14 — math-review: stats::logistic, stats::poisson_reg, stats::wls
+- Files (all new): `stdlib/stats/logistic.sio` (1-predictor logistic regression via Newton-Raphson/IRLS, Wald SE/z/p, predict), `stdlib/stats/poisson_reg.sio` (1-predictor Poisson log-link regression via Newton, rate ratio, predict), `stdlib/stats/wls.sio` (weighted least squares, closed-form coefficients + SEs + weighted R²). Provider: xAI/Grok 4.3.
+- logistic = **PASS**: score g=Xᵀ(y−p), Fisher info H=XᵀWX (W=diag p(1−p)), NR update, SE=√diag(H⁻¹), Wald z; two-point saturated MLE (b0=logit⅓, b1=logit⅔−logit⅓) exact.
+- poisson_reg = **PASS**: Poisson log-link score/Hessian, NR update, saturated two-point MLE (b0=ln ȳ|x=0, b1=ln ratio) exact; Wald inference correct.
+- wls = **PASS**: normal-equation WLS solution, σ̂²(XᵀWX)⁻¹ variance entries under Var(εᵢ)=σ²/wᵢ, weighted R²; perfect and outlier-downweight cases verified.
+- Theme: generalized linear models (one predictor) — pharmacometric dose-response / count / heteroscedastic fits. #852-safe: flat per-iteration passes, scalar accumulation, no nested data-array calls. Suite runner now tracks **49 modules** + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-V3U3Al/`, `/tmp/llm-offload-zlNiM7/`, `/tmp/llm-offload-p2IVgX/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -55,6 +55,9 @@ MODULES=(
   stdlib/stats/fisher_exact.sio
   stdlib/stats/cochran_q.sio
   stdlib/stats/fleiss_kappa.sio
+  stdlib/stats/logistic.sio
+  stdlib/stats/poisson_reg.sio
+  stdlib/stats/wls.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -723,6 +723,42 @@ agreement `κ=(P̄−P̄ₑ)/(1−P̄ₑ)` from a row-major N×k rater-count mat
 worked 2-subject case → P̄=0.6667, P̄ₑ=0.7222, κ=−0.2; perfect within-subject
 agreement → κ=1.
 
+### `stats::logistic` — one-predictor logistic regression
+
+| Function | Signature |
+|---|---|
+| `logistic_fit` | `pub fn logistic_fit(x: &[f64; 256], y: &[f64; 256], n: i32) -> LogisticFit with Mut, Div, Panic` |
+| `logistic_predict` | `pub fn logistic_predict(fit: &LogisticFit, x: f64) -> f64 with Mut, Div, Panic` |
+
+Maximum-likelihood logistic regression `logit(pᵢ)=b₀+b₁xᵢ`, fit by
+Newton-Raphson (IRLS) — the workhorse for binary dose-response. Returns the
+coefficients, standard errors, slope Wald z/p and convergence diagnostics.
+Validated: two-point saturated design → b₀=−0.6931, b₁=1.3863, p̂(0)=⅓, p̂(1)=⅔;
+balanced null → b₁=0.
+
+### `stats::poisson_reg` — one-predictor Poisson regression
+
+| Function | Signature |
+|---|---|
+| `poisson_fit` | `pub fn poisson_fit(x: &[f64; 256], y: &[f64; 256], n: i32) -> PoissonFit with Mut, Div, Panic` |
+| `poisson_predict` | `pub fn poisson_predict(fit: &PoissonFit, x: f64) -> f64 with Mut, Div, Panic` |
+
+Maximum-likelihood Poisson (log-link) count/rate regression `log(μᵢ)=b₀+b₁xᵢ`
+by Newton-Raphson; `exp(b₁)` is the rate ratio per unit x. Validated: two-point
+saturated design → b₀=ln3, b₁=ln4, rate ratio 4, μ̂(0)=3, μ̂(1)=12; flat counts
+→ b₁=0.
+
+### `stats::wls` — weighted least-squares regression
+
+| Function | Signature |
+|---|---|
+| `wls_fit` | `pub fn wls_fit(x: &[f64; 256], y: &[f64; 256], w: &[f64; 256], n: i32) -> WLSFit with Mut, Div, Panic` |
+
+Straight-line regression with per-observation weights (wᵢ∝1/σᵢ²) — the fit for
+heteroscedastic assay data. Closed-form coefficients, standard errors from
+`σ̂²(XᵀWX)⁻¹`, and a weighted R². Validated: perfect line → (1,2), R²=1;
+downweighting an outlier pulls the slope from OLS 5 to 1.229.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -773,6 +809,9 @@ use stats::passing_bablok::{PBFit, passing_bablok}
 use stats::fisher_exact::{FisherResult, fisher_exact}
 use stats::cochran_q::{CochranQResult, cochran_q}
 use stats::fleiss_kappa::{FleissResult, fleiss_kappa}
+use stats::logistic::{LogisticFit, logistic_fit, logistic_predict}
+use stats::poisson_reg::{PoissonFit, poisson_fit, poisson_predict}
+use stats::wls::{WLSFit, wls_fit}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/logistic.sio
+++ b/stdlib/stats/logistic.sio
@@ -1,0 +1,221 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/logistic.sio — one-predictor logistic regression
+//
+// Maximum-likelihood logistic regression logit(pᵢ) = b₀ + b₁·xᵢ, fit by
+// Newton-Raphson (iteratively reweighted least squares) — the workhorse for
+// binary dose-response:
+//
+//   logistic_fit(x, y, n) -> LogisticFit          (y ∈ {0,1})
+//   logistic_predict(fit, x) -> f64               (fitted probability)
+//
+// Score g = Σ(yᵢ−pᵢ)[1, xᵢ], Fisher information H = Σ pᵢ(1−pᵢ)[1,xᵢ]⊗[1,xᵢ];
+// update β ← β + H⁻¹g. Standard errors are √diag(H⁻¹); the slope Wald test is
+// z = b₁/se₁ with a two-sided normal p-value.
+//
+// Pure Sounio: inline exp/ln/sqrt/erf, a 2×2 solve; flat per-iteration passes
+// over the data (no nested data-array calls).
+//
+// References:
+//   McCullagh & Nelder, "Generalized Linear Models" 2e, §4.
+
+module stats::logistic
+
+fn lg_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / lg_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn lg_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn lg_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * lg_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn lg_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - lg_erf(z * INV_SQRT2))
+}
+
+fn lg_sigmoid(z: f64) -> f64 with Mut, Div, Panic {
+    return 1.0 / (1.0 + lg_exp(0.0 - z))
+}
+
+pub struct LogisticFit {
+    pub b0: f64,       // intercept
+    pub b1: f64,       // slope (log-odds per unit x)
+    pub se0: f64,      // SE(b0)
+    pub se1: f64,      // SE(b1)
+    pub z1: f64,       // Wald z for the slope
+    pub p1: f64,       // two-sided p for the slope
+    pub iters: i64,    // Newton iterations used
+    pub converged: i64,// 1 if converged
+}
+
+/// One-predictor logistic regression by Newton-Raphson.
+///
+/// Parâmetros: x — predictor; y — 0/1 outcome; n — size (>=3, <=256).
+/// Retorno: LogisticFit (b0, b1, SEs, Wald z/p, iteration diagnostics).
+/// Referências: McCullagh & Nelder §4.
+pub fn logistic_fit(x: &[f64; 256], y: &[f64; 256], n: i32) -> LogisticFit with Mut, Div, Panic {
+    if n < 3 {
+        return LogisticFit { b0: 0.0, b1: 0.0, se0: 0.0, se1: 0.0, z1: 0.0, p1: 1.0, iters: 0, converged: 0 }
+    }
+    var b0 = 0.0
+    var b1 = 0.0
+    var last_det = 1.0
+    var conv = 0
+    var used = 0
+    var it = 0
+    while it < 50 {
+        var g0 = 0.0
+        var g1 = 0.0
+        var h00 = 0.0
+        var h01 = 0.0
+        var h11 = 0.0
+        var i = 0
+        while i < n {
+            let xi = x[i as usize]
+            let p = lg_sigmoid(b0 + b1 * xi)
+            let w = p * (1.0 - p)
+            let resid = y[i as usize] - p
+            g0 = g0 + resid
+            g1 = g1 + resid * xi
+            h00 = h00 + w
+            h01 = h01 + w * xi
+            h11 = h11 + w * xi * xi
+            i = i + 1
+        }
+        let det = h00 * h11 - h01 * h01
+        last_det = det
+        if det <= 1.0e-300 && det >= 0.0 - 1.0e-300 { it = 50 }
+        else {
+            let db0 = (h11 * g0 - h01 * g1) / det
+            let db1 = (h00 * g1 - h01 * g0) / det
+            b0 = b0 + db0
+            b1 = b1 + db1
+            used = it + 1
+            let ad0 = if db0 < 0.0 { 0.0 - db0 } else { db0 }
+            let ad1 = if db1 < 0.0 { 0.0 - db1 } else { db1 }
+            if ad0 < 1.0e-10 && ad1 < 1.0e-10 { conv = 1; it = 50 } else { it = it + 1 }
+        }
+    }
+    // final information matrix for standard errors
+    var h00 = 0.0
+    var h01 = 0.0
+    var h11 = 0.0
+    var i2 = 0
+    while i2 < n {
+        let xi = x[i2 as usize]
+        let p = lg_sigmoid(b0 + b1 * xi)
+        let w = p * (1.0 - p)
+        h00 = h00 + w
+        h01 = h01 + w * xi
+        h11 = h11 + w * xi * xi
+        i2 = i2 + 1
+    }
+    let det = h00 * h11 - h01 * h01
+    var se0 = 0.0
+    var se1 = 0.0
+    if det > 1.0e-300 {
+        se0 = lg_sqrt(h11 / det)
+        se1 = lg_sqrt(h00 / det)
+    }
+    var z1 = 0.0
+    if se1 > 0.0 { z1 = b1 / se1 }
+    let az = if z1 < 0.0 { 0.0 - z1 } else { z1 }
+    let p1 = 2.0 * lg_normal_sf(az)
+    return LogisticFit { b0: b0, b1: b1, se0: se0, se1: se1, z1: z1, p1: p1, iters: used as i64, converged: conv as i64 }
+}
+
+/// Fitted probability p = sigmoid(b0 + b1·x).
+pub fn logistic_predict(fit: &LogisticFit, x: f64) -> f64 with Mut, Div, Panic {
+    return lg_sigmoid(fit.b0 + fit.b1 * x)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Two-point design x∈{0,1}: at x=0 successes 1/3, at x=1 successes 2/3.
+// Saturated MLE: b0=logit(1/3)=ln(0.5)=-0.693147; b1=logit(2/3)-logit(1/3)=1.386294.
+// predict(0)=1/3, predict(1)=2/3.
+fn test_two_point() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=0.0; x[2]=0.0; x[3]=1.0; x[4]=1.0; x[5]=1.0
+    y[0]=0.0; y[1]=0.0; y[2]=1.0; y[3]=1.0; y[4]=1.0; y[5]=0.0
+    let r = logistic_fit(&x, &y, 6)
+    var ok = true
+    ok = check(1, r.converged == 1) && ok
+    ok = check(2, approx(r.b0, 0.0 - 0.693147, 1.0e-4)) && ok
+    ok = check(3, approx(r.b1, 1.386294, 1.0e-4)) && ok
+    ok = check(4, approx(logistic_predict(&r, 0.0), 0.333333, 1.0e-4)) && ok
+    ok = check(5, approx(logistic_predict(&r, 1.0), 0.666667, 1.0e-4)) && ok
+    return ok
+}
+
+// Balanced null: at each x the successes are 50/50 -> b1=0, b0=0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=0.0; x[2]=1.0; x[3]=1.0
+    y[0]=0.0; y[1]=1.0; y[2]=0.0; y[3]=1.0
+    let r = logistic_fit(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.b0, 0.0, 1.0e-4)) && ok
+    ok = check(11, approx(r.b1, 0.0, 1.0e-4)) && ok
+    ok = check(12, r.p1 > 0.9) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_two_point() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/poisson_reg.sio
+++ b/stdlib/stats/poisson_reg.sio
@@ -1,0 +1,224 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/poisson_reg.sio — one-predictor Poisson regression (log link)
+//
+// Maximum-likelihood Poisson regression log(μᵢ) = b₀ + b₁·xᵢ, fit by
+// Newton-Raphson — the count/rate companion to logistic regression:
+//
+//   poisson_fit(x, y, n) -> PoissonFit             (y = counts ≥ 0)
+//   poisson_predict(fit, x) -> f64                 (fitted mean μ)
+//
+// Score g = Σ(yᵢ−μᵢ)[1, xᵢ], Fisher information H = Σ μᵢ[1,xᵢ]⊗[1,xᵢ], update
+// β ← β + H⁻¹g.  exp(b₁) is the multiplicative rate ratio per unit x. Standard
+// errors are √diag(H⁻¹); the slope Wald test is z = b₁/se₁.
+//
+// Pure Sounio: inline exp/ln/sqrt/erf and a 2×2 solve; flat per-iteration passes
+// over the data (no nested data-array calls).
+//
+// References:
+//   McCullagh & Nelder, "Generalized Linear Models" 2e, §6.
+
+module stats::poisson_reg
+
+fn pr_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / pr_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn pr_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn pr_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn pr_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * pr_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn pr_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - pr_erf(z * INV_SQRT2))
+}
+
+pub struct PoissonFit {
+    pub b0: f64,
+    pub b1: f64,
+    pub rate_ratio: f64, // exp(b1)
+    pub se1: f64,
+    pub z1: f64,
+    pub p1: f64,
+    pub iters: i64,
+    pub converged: i64,
+}
+
+/// One-predictor Poisson regression by Newton-Raphson.
+///
+/// Parâmetros: x — predictor; y — non-negative counts; n — size (>=3, <=256).
+/// Retorno: PoissonFit (b0, b1, rate_ratio=exp(b1), se1, Wald z/p, diagnostics).
+/// Referências: McCullagh & Nelder §6.
+pub fn poisson_fit(x: &[f64; 256], y: &[f64; 256], n: i32) -> PoissonFit with Mut, Div, Panic {
+    if n < 3 {
+        return PoissonFit { b0: 0.0, b1: 0.0, rate_ratio: 1.0, se1: 0.0, z1: 0.0, p1: 1.0, iters: 0, converged: 0 }
+    }
+    var b0 = 0.0
+    var b1 = 0.0
+    var conv = 0
+    var used = 0
+    var it = 0
+    while it < 50 {
+        var g0 = 0.0
+        var g1 = 0.0
+        var h00 = 0.0
+        var h01 = 0.0
+        var h11 = 0.0
+        var i = 0
+        while i < n {
+            let xi = x[i as usize]
+            let mu = pr_exp(b0 + b1 * xi)
+            let resid = y[i as usize] - mu
+            g0 = g0 + resid
+            g1 = g1 + resid * xi
+            h00 = h00 + mu
+            h01 = h01 + mu * xi
+            h11 = h11 + mu * xi * xi
+            i = i + 1
+        }
+        let det = h00 * h11 - h01 * h01
+        if det <= 1.0e-300 && det >= 0.0 - 1.0e-300 { it = 50 }
+        else {
+            let db0 = (h11 * g0 - h01 * g1) / det
+            let db1 = (h00 * g1 - h01 * g0) / det
+            b0 = b0 + db0
+            b1 = b1 + db1
+            used = it + 1
+            let ad0 = if db0 < 0.0 { 0.0 - db0 } else { db0 }
+            let ad1 = if db1 < 0.0 { 0.0 - db1 } else { db1 }
+            if ad0 < 1.0e-10 && ad1 < 1.0e-10 { conv = 1; it = 50 } else { it = it + 1 }
+        }
+    }
+    var h00 = 0.0
+    var h01 = 0.0
+    var h11 = 0.0
+    var i2 = 0
+    while i2 < n {
+        let xi = x[i2 as usize]
+        let mu = pr_exp(b0 + b1 * xi)
+        h00 = h00 + mu
+        h01 = h01 + mu * xi
+        h11 = h11 + mu * xi * xi
+        i2 = i2 + 1
+    }
+    let det = h00 * h11 - h01 * h01
+    var se1 = 0.0
+    if det > 1.0e-300 { se1 = pr_sqrt(h00 / det) }
+    var z1 = 0.0
+    if se1 > 0.0 { z1 = b1 / se1 }
+    let az = if z1 < 0.0 { 0.0 - z1 } else { z1 }
+    let p1 = 2.0 * pr_normal_sf(az)
+    return PoissonFit { b0: b0, b1: b1, rate_ratio: pr_exp(b1), se1: se1, z1: z1, p1: p1, iters: used as i64, converged: conv as i64 }
+}
+
+/// Fitted mean μ = exp(b0 + b1·x).
+pub fn poisson_predict(fit: &PoissonFit, x: f64) -> f64 with Mut, Div, Panic {
+    return pr_exp(fit.b0 + fit.b1 * x)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Two-point design x∈{0,1}: counts mean 3 at x=0, 12 at x=1.
+// Saturated MLE: b0=ln3=1.098612; b1=ln(12/3)=ln4=1.386294; rate ratio 4.
+// predict(0)=3, predict(1)=12.
+fn test_two_point() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=0.0; x[2]=1.0; x[3]=1.0
+    y[0]=2.0; y[1]=4.0; y[2]=8.0; y[3]=16.0
+    let r = poisson_fit(&x, &y, 4)
+    var ok = true
+    ok = check(1, r.converged == 1) && ok
+    ok = check(2, approx(r.b0, 1.098612, 1.0e-4)) && ok
+    ok = check(3, approx(r.b1, 1.386294, 1.0e-4)) && ok
+    ok = check(4, approx(r.rate_ratio, 4.0, 1.0e-3)) && ok
+    ok = check(5, approx(poisson_predict(&r, 0.0), 3.0, 1.0e-3)) && ok
+    ok = check(6, approx(poisson_predict(&r, 1.0), 12.0, 1.0e-3)) && ok
+    return ok
+}
+
+// Flat counts -> b1 = 0, rate ratio 1.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=5.0; y[1]=5.0; y[2]=5.0; y[3]=5.0
+    let r = poisson_fit(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.b1, 0.0, 1.0e-4)) && ok
+    ok = check(11, approx(r.rate_ratio, 1.0, 1.0e-4)) && ok
+    ok = check(12, approx(r.b0, 1.609438, 1.0e-4)) && ok    // ln 5
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_two_point() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/wls.sio
+++ b/stdlib/stats/wls.sio
@@ -1,0 +1,166 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/wls.sio — weighted least-squares regression (one predictor)
+//
+// Straight-line regression with per-observation weights — the right fit when
+// the measurement variance is not constant (heteroscedastic assay data, where
+// wᵢ ∝ 1/σᵢ²):
+//
+//   wls_fit(x, y, w, n) -> WLSFit
+//
+// Minimising Σ wᵢ(yᵢ − b₀ − b₁xᵢ)² gives, with D = Sw·Swxx − Swx²,
+//   b₁ = (Sw·Swxy − Swx·Swy)/D,   b₀ = (Swxx·Swy − Swx·Swxy)/D,
+//   σ̂² = Σwᵢ(yᵢ−ŷᵢ)²/(n−2),  Var(b₁) = σ̂²·Sw/D,  Var(b₀) = σ̂²·Swxx/D,
+// and the weighted R² = 1 − SSRw/SSTw.
+//
+// Pure Sounio: inline sqrt; two flat passes (weighted sums, then residuals);
+// no external dependency, no nested data-array calls.
+//
+// References:
+//   Draper & Smith, "Applied Regression Analysis" 3e, §2.11 (weighted LS).
+
+module stats::wls
+
+fn wl_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct WLSFit {
+    pub b0: f64,
+    pub b1: f64,
+    pub se0: f64,
+    pub se1: f64,
+    pub r_squared: f64,  // weighted R²
+}
+
+/// Weighted least-squares straight-line fit.
+///
+/// Parâmetros: x, y — data; w — non-negative weights; n — size (>=3, <=256).
+/// Retorno: WLSFit (b0, b1, se0, se1, weighted R²).
+/// Referências: Draper & Smith §2.11.
+pub fn wls_fit(x: &[f64; 256], y: &[f64; 256], w: &[f64; 256], n: i32) -> WLSFit with Mut, Div, Panic {
+    if n < 3 { return WLSFit { b0: 0.0, b1: 0.0, se0: 0.0, se1: 0.0, r_squared: 0.0 } }
+    var sw = 0.0
+    var swx = 0.0
+    var swy = 0.0
+    var swxx = 0.0
+    var swxy = 0.0
+    var i = 0
+    while i < n {
+        let wi = w[i as usize]
+        let xi = x[i as usize]
+        let yi = y[i as usize]
+        sw = sw + wi
+        swx = swx + wi * xi
+        swy = swy + wi * yi
+        swxx = swxx + wi * xi * xi
+        swxy = swxy + wi * xi * yi
+        i = i + 1
+    }
+    let det = sw * swxx - swx * swx
+    if det <= 1.0e-300 && det >= 0.0 - 1.0e-300 {
+        return WLSFit { b0: 0.0, b1: 0.0, se0: 0.0, se1: 0.0, r_squared: 0.0 }
+    }
+    let b1 = (sw * swxy - swx * swy) / det
+    let b0 = (swxx * swy - swx * swxy) / det
+    let ybar = swy / sw
+    // weighted residual and total sums of squares
+    var ssr = 0.0
+    var sst = 0.0
+    var j = 0
+    while j < n {
+        let wi = w[j as usize]
+        let xi = x[j as usize]
+        let yi = y[j as usize]
+        let fit = b0 + b1 * xi
+        let rr = yi - fit
+        ssr = ssr + wi * rr * rr
+        let dt = yi - ybar
+        sst = sst + wi * dt * dt
+        j = j + 1
+    }
+    let sigma2 = ssr / ((n - 2) as f64)
+    let var1 = sigma2 * sw / det
+    let var0 = sigma2 * swxx / det
+    var se1 = 0.0
+    var se0 = 0.0
+    if var1 > 0.0 { se1 = wl_sqrt(var1) }
+    if var0 > 0.0 { se0 = wl_sqrt(var0) }
+    var r2 = 0.0
+    if sst > 1.0e-300 { r2 = 1.0 - ssr / sst }
+    return WLSFit { b0: b0, b1: b1, se0: se0, se1: se1, r_squared: r2 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect line y=2x+1, uniform weights: b0=1, b1=2, R²=1, SE=0.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0
+    w[0]=1.0; w[1]=1.0; w[2]=1.0; w[3]=1.0
+    let r = wls_fit(&x, &y, &w, 4)
+    var ok = true
+    ok = check(1, approx(r.b0, 1.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.b1, 2.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.r_squared, 1.0, 1.0e-9)) && ok
+    ok = check(4, approx(r.se1, 0.0, 1.0e-9)) && ok
+    return ok
+}
+
+// weights matter: (0,0),(1,1),(2,10) with w=(1,1,0.01) downweights the outlier.
+// Sw=2.01,Swx=1.02,Swy=1.1,Swxx=1.04,Swxy=1.2; D=1.05.
+// b1=(2.01·1.2-1.02·1.1)/1.05=1.29/1.05=1.228571; b0=(1.04·1.1-1.02·1.2)/1.05=-0.076190.
+// (unweighted OLS slope would be 5 — the weights pull it to ~1.23.)
+fn test_weighted() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0
+    y[0]=0.0; y[1]=1.0; y[2]=10.0
+    w[0]=1.0; w[1]=1.0; w[2]=0.01
+    let r = wls_fit(&x, &y, &w, 3)
+    var ok = true
+    ok = check(10, approx(r.b1, 1.228571, 1.0e-5)) && ok
+    ok = check(11, approx(r.b0, 0.0 - 0.076190, 1.0e-5)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_weighted() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three generalized-linear-model regressions for the epistemic-statistics suite, bringing the runner to **49 modules**. These are the pharmacometric fits — binary dose-response, count/rate modeling, and heteroscedastic assay data. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | Model | Fit |
|---|---|---|
| `stats::logistic` | logit(p)=b₀+b₁x (binomial/logit) | Newton-Raphson / IRLS |
| `stats::poisson_reg` | log(μ)=b₀+b₁x (Poisson/log) | Newton-Raphson |
| `stats::wls` | weighted linear (Gaussian, wᵢ∝1/σᵢ²) | closed form |

## Validation

- Inline `//@ run-pass` tests against hand-computed saturated / closed-form cases:
  - Logistic: two-point saturated design → b₀=logit(⅓)=−0.6931, b₁=1.3863, p̂(0)=⅓, p̂(1)=⅔; balanced null → b₁=0.
  - Poisson: two-point saturated design → b₀=ln3, b₁=ln4, rate ratio 4, μ̂(0)=3, μ̂(1)=12; flat counts → b₁=0.
  - WLS: perfect line → (1,2), R²=1; downweighting an outlier pulls the slope from OLS 5 to 1.229.
- Full suite selftest: **49 modules + 7 demos ALL GREEN** under `lean_single`.
- The two iterative fits (logistic, Poisson) both **converge** on the test data (convergence flag asserted).

## `#852`-safety
The GLM fits use flat per-iteration passes over the data with scalar accumulation of the score/Hessian and a 2×2 solve — no nested calls with data arrays live.

## Note on module count
The suite runner tracks 49 epistemic-suite modules; the `stdlib/stats/` directory also contains pre-existing/library `.sio` files (descriptive, distributions, resampling, …) that are outside this suite's runner.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).