### PR TITLE
test(special): run-proof for special::erf (coordinated disjoint lane)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2754,3 +2754,7 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - fleiss_kappa = **PASS**: Pᵢ, P̄, pⱼ, P̄ₑ, κ all match Fleiss (1971); three test cases (κ=-0.2, κ=1, three-category) correct. Note: significance-test SE deliberately omitted (fiddly Fleiss variance) — point estimate + components only.
 - Theme: exact & multi-condition categorical inference — complements chi2_independence/mcnemar/trend/cohen_kappa. All scalar/small-array, #852-safe. Suite selftest: 48 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-WWTpfo/`, `/tmp/llm-offload-s2BJ8J/`, `/tmp/llm-offload-JKGRlT/`.
+
+## 2026-07-14 — math-review: special::erf run-proof
+- Files: `tests/stdlib/special/test_erf_stdlib.sio`, `examples/special/erf_report.sio` (no source edited).
+- Provider: xAI/Grok 4.3 = PASS. erf(1)=0.8427008, odd symmetry, erfc=1-erf, Phi(0)=0.5/Phi(1)=0.8413447/Phi(1.96)=0.9750, z(0.975)=1.95996, round-trip Phi(z(0.9))=0.9. normal_quantile deep-tail approximation not over-claimed. Default Madaros. SPECIAL_ERF_GATE_OK.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 968
-- Repo-backed topics: 818
+- Total governed topics: 970
+- Repo-backed topics: 820
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 568
+- Authority count `repo_only`: 570
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 587 topics
+- A2: 589 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -784,6 +784,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-14-linalg-vertical | repo_only | docs/superpowers/plans/2026-07-14-linalg-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-prob-vertical | repo_only | docs/superpowers/plans/2026-07-14-prob-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-signal-fft-vertical | repo_only | docs/superpowers/plans/2026-07-14-signal-fft-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-14-special-erf-vertical | repo_only | docs/superpowers/plans/2026-07-14-special-erf-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof | repo_only | docs/superpowers/plans/2026-07-14-stats-validation-runproof.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-units-vertical | repo_only | docs/superpowers/plans/2026-07-14-units-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -791,6 +792,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.specs.2026-07-14-linalg-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-linalg-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-prob-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-prob-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-signal-fft-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-signal-fft-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design | repo_only | docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-units-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-units-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17338,6 +17338,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-14-special-erf-vertical",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-14-special-erf-vertical.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/plans/2026-07-14-stats-validation-runproof.md",
@@ -17479,6 +17502,29 @@
       "topic_id": "repo.docs.superpowers.specs.2026-07-14-signal-fft-vertical-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-14-signal-fft-vertical-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-07-14-special-erf-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-special-erf-vertical.md
@@ -1,0 +1,5 @@
+# special::erf Run-Proof — Plan
+> Default Madaros (self-contained). No source edits (disjoint). Spec: docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md.
+1. Run-proof `tests/stdlib/special/test_erf_stdlib.sio` (erf/erfc/ncdf/nquantile known values + odd/complement/round-trip). `ERF_STDLIB_OK`.
+2. Example `examples/special/erf_report.sio` + gate `scripts/special_erf_gate.sh` → `SPECIAL_ERF_GATE_OK`.
+3. math-review; governance sync; PR to main (rebase-on-conflict).

--- a/docs/superpowers/plans/2026-07-14-special-erf-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-special-erf-vertical.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-14-special-erf-vertical
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-14-special-erf-vertical
+-->
+
 # special::erf Run-Proof — Plan
 > Default Madaros (self-contained). No source edits (disjoint). Spec: docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md.
 1. Run-proof `tests/stdlib/special/test_erf_stdlib.sio` (erf/erfc/ncdf/nquantile known values + odd/complement/round-trip). `ERF_STDLIB_OK`.

--- a/docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design
+-->
+
 # Design — Harden the special::erf vertical (coordinated, disjoint)
 **Date:** 2026-07-14 · no compiler changes · `special/` disjoint from active lanes (no open PR touching it);
 scalar API is cross-module-safe (no arrays/HOF). This lane reads the module + adds run-proof/gate/docs; no source edits. EN-UK.

--- a/docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md
@@ -1,0 +1,16 @@
+# Design — Harden the special::erf vertical (coordinated, disjoint)
+**Date:** 2026-07-14 · no compiler changes · `special/` disjoint from active lanes (no open PR touching it);
+scalar API is cross-module-safe (no arrays/HOF). This lane reads the module + adds run-proof/gate/docs; no source edits. EN-UK.
+
+## State
+`stdlib/special/erf.sio` — self-contained, green, native-compiles under **default Madaros**. Scalar API:
+`erf`, `erfc`, `erfinv`, `normal_cdf`, `normal_quantile`. Verified externally: erf(1)=0.8427, Phi(1.96)=0.975002, z(0.975)=1.95996.
+
+## Run-proof (known values / identities)
+- erf(1)=0.8427008; erf(0)=0; odd: erf(−1)=−erf(1); erfc(0)=1; erfc(1)=1−erf(1).
+- normal_cdf(0)=0.5; normal_cdf(1)=0.8413447; normal_cdf(1.96)=0.975 (±1e-3).
+- normal_quantile(0.5)=0; normal_quantile(0.975)=1.96 (±1e-2); round-trip Phi(z(0.9))=0.9.
+- Honest bound: `normal_quantile` is accurate near centre; deep-tail (p≥0.99) is approximate — not asserted; the example avoids implying tail precision.
+
+## Layout / verification
+`tests/stdlib/special/test_erf_stdlib.sio`, `examples/special/erf_report.sio`, `scripts/special_erf_gate.sh` (default Madaros) → `SPECIAL_ERF_GATE_OK`. Math-review logged. No source/compiler edits.

--- a/examples/special/erf_report.sio
+++ b/examples/special/erf_report.sio
@@ -1,0 +1,13 @@
+// Error-function / normal-tail report using stdlib special::erf.
+// (normal_quantile is accurate near the centre; deep-tail p is approximate.)
+use special::erf::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("=== special::erf ===\n")
+    print("erf(1)            = "); println(erf(1.0))
+    print("erfc(1)           = "); println(erfc(1.0))
+    print("Phi(1)   [~.8413] = "); println(normal_cdf(1.0))
+    print("Phi(1.96)[~.9750] = "); println(normal_cdf(1.96))
+    print("z(0.975) [~1.96]  = "); println(normal_quantile(0.975))
+    print("z(0.90)  [~1.2816]= "); println(normal_quantile(0.90))
+    return 0
+}

--- a/scripts/special_erf_gate.sh
+++ b/scripts/special_erf_gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check erf.sio =="; $SOUC check stdlib/special/erf.sio || fail=1
+echo "== run-proof =="
+if $SOUC compile tests/stdlib/special/test_erf_stdlib.sio -o "$OUT/te.elf"; then
+  "$OUT/te.elf" | grep -q "ERF_STDLIB_OK" || { echo "FAIL: assertions"; fail=1; }
+else echo "FAIL: compile"; fail=1; fi
+echo "== example =="
+if $SOUC compile examples/special/erf_report.sio -o "$OUT/er.elf"; then "$OUT/er.elf" >/dev/null || { echo "FAIL: example"; fail=1; }
+else echo "FAIL: example compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "SPECIAL_ERF_GATE_OK"
+exit $fail

--- a/tests/stdlib/special/test_erf_stdlib.sio
+++ b/tests/stdlib/special/test_erf_stdlib.sio
@@ -1,0 +1,36 @@
+// Run-proof for stdlib special::erf against known values / identities.
+// Self-contained module -> default Madaros. Scalar API. Inline in main.
+use special::erf::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // erf(1) = 0.8427007929
+    let e1 = erf(1.0)
+    if (if e1 > 0.8427008 { e1-0.8427008 } else { 0.8427008-e1 }) >= 1.0e-5 { print("FAIL erf1\n"); return 1 }
+    // erf(0)=0 ; odd: erf(-1) = -erf(1)
+    if (if erf(0.0) > 0.0 { erf(0.0) } else { 0.0-erf(0.0) }) >= 1.0e-9 { print("FAIL erf0\n"); return 2 }
+    let en1 = erf(0.0 - 1.0)
+    if (if en1 > (0.0-e1) { en1-(0.0-e1) } else { (0.0-e1)-en1 }) >= 1.0e-6 { print("FAIL erf odd\n"); return 3 }
+    // erfc(x) = 1 - erf(x): erfc(0)=1, erfc(1)=1-erf(1)
+    if (if erfc(0.0) > 1.0 { erfc(0.0)-1.0 } else { 1.0-erfc(0.0) }) >= 1.0e-9 { print("FAIL erfc0\n"); return 4 }
+    let ec1 = erfc(1.0)
+    let want_ec1 = 1.0 - e1
+    if (if ec1 > want_ec1 { ec1-want_ec1 } else { want_ec1-ec1 }) >= 1.0e-6 { print("FAIL erfc1\n"); return 5 }
+    // normal_cdf(0)=0.5 ; normal_cdf(1)=0.8413447
+    if (if normal_cdf(0.0) > 0.5 { normal_cdf(0.0)-0.5 } else { 0.5-normal_cdf(0.0) }) >= 1.0e-6 { print("FAIL ncdf0\n"); return 6 }
+    let nc1 = normal_cdf(1.0)
+    if (if nc1 > 0.8413447 { nc1-0.8413447 } else { 0.8413447-nc1 }) >= 1.0e-4 { print("FAIL ncdf1\n"); return 7 }
+    // normal_cdf(1.96) ~ 0.975
+    let nc196 = normal_cdf(1.96)
+    if (if nc196 > 0.975 { nc196-0.975 } else { 0.975-nc196 }) >= 1.0e-3 { print("FAIL ncdf196\n"); return 8 }
+    // normal_quantile(0.5)=0 ; normal_quantile(0.975) ~ 1.96
+    let nq5 = normal_quantile(0.5)
+    if (if nq5 > 0.0 { nq5 } else { 0.0-nq5 }) >= 1.0e-4 { print("FAIL nq5\n"); return 9 }
+    let nq975 = normal_quantile(0.975)
+    if (if nq975 > 1.96 { nq975-1.96 } else { 1.96-nq975 }) >= 1.0e-2 { print("FAIL nq975\n"); return 10 }
+    // round-trip: normal_cdf(normal_quantile(0.9)) = 0.9
+    let rt = normal_cdf(normal_quantile(0.9))
+    if (if rt > 0.9 { rt-0.9 } else { 0.9-rt }) >= 1.0e-4 { print("FAIL roundtrip\n"); return 11 }
+
+    print("ERF_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
Ninth playbook vertical. Independent run-proof for the self-contained `special::erf` (native-compiles under **default Madaros**): erf/erfc/normal_cdf/normal_quantile vs known values + odd/complement identities + round-trip. Disjoint (`special/` has no open PR; scalar API is cross-module-safe). No source edits. Gate `SPECIAL_ERF_GATE_OK`; math-review PASS. Honest bound: normal_quantile deep-tail (p≥0.99) is approximate, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)