### PR TITLE
feat(stats): serial-dependence diagnostics — runs_test, durbin_watson, autocorr

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2762,3 +2762,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - wls = **PASS**: normal-equation WLS solution, σ̂²(XᵀWX)⁻¹ variance entries under Var(εᵢ)=σ²/wᵢ, weighted R²; perfect and outlier-downweight cases verified.
 - Theme: generalized linear models (one predictor) — pharmacometric dose-response / count / heteroscedastic fits. #852-safe: flat per-iteration passes, scalar accumulation, no nested data-array calls. Suite runner now tracks **49 modules** + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-V3U3Al/`, `/tmp/llm-offload-zlNiM7/`, `/tmp/llm-offload-p2IVgX/`.
+
+## 2026-07-14 — math-review: stats::runs_test, stats::durbin_watson, stats::autocorr
+- Files (all new): `stdlib/stats/runs_test.sio` (Wald-Wolfowitz runs test, normal approximation), `stdlib/stats/durbin_watson.sio` (DW autocorrelation statistic + ρ̂), `stdlib/stats/autocorr.sio` (sample ACF at lag k + Ljung-Box portmanteau test, χ² tail via igamma). Provider: xAI/Grok 4.3.
+- runs_test = **PASS**: μ_R=2n₁n₂/n+1, σ²_R=2n₁n₂(2n₁n₂−n)/(n²(n−1)), z, two-sided p all match; random/clustered/alternating cases verified.
+- durbin_watson = **PASS**: d=Σ(eᵢ−e_{i−1})²/Σeᵢ², ρ̂≈1−d/2 canonical; three cases (d=3.333/0.667/2.0) verified.
+- autocorr = **PASS**: biased r_k, Ljung-Box Q=n(n+2)Σr_k²/(n−k) ~ χ²(m); acf(1)=0.4/acf(2)=−0.1 and Q≈1.5167 hand-checked.
+- Theme: serial-dependence / independence-assumption diagnostics — complements the goodness-of-fit / normality family for ordered & time-course data (PK sampling, longitudinal). All scalar/read-only-array, #852-safe. Suite runner: 52 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-0yOUhT/`, `/tmp/llm-offload-5OiuG1/`, `/tmp/llm-offload-FpKA3Q/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -58,6 +58,9 @@ MODULES=(
   stdlib/stats/logistic.sio
   stdlib/stats/poisson_reg.sio
   stdlib/stats/wls.sio
+  stdlib/stats/runs_test.sio
+  stdlib/stats/durbin_watson.sio
+  stdlib/stats/autocorr.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -759,6 +759,40 @@ heteroscedastic assay data. Closed-form coefficients, standard errors from
 `σ̂²(XᵀWX)⁻¹`, and a weighted R². Validated: perfect line → (1,2), R²=1;
 downweighting an outlier pulls the slope from OLS 5 to 1.229.
 
+### `stats::runs_test` — Wald-Wolfowitz runs test
+
+| Function | Signature |
+|---|---|
+| `runs_test` | `pub fn runs_test(seq: &[i64; 256], n: i32) -> RunsResult with Mut, Div, Panic` |
+
+Tests a 0/1 sequence for randomness against serial dependence: with n₁ ones, n₂
+zeros and R runs, `z=(R−μ_R)/σ_R` where `μ_R=2n₁n₂/n+1`. Too few runs →
+clustering, too many → over-alternation. Validated: balanced random-like →
+R=6, z=0; clustered → R=2, z=−2.683, p<0.01; alternating → R=10, z=2.683.
+
+### `stats::durbin_watson` — Durbin-Watson statistic
+
+| Function | Signature |
+|---|---|
+| `durbin_watson` | `pub fn durbin_watson(e: &[f64; 256], n: i32) -> DWResult with Mut, Div, Panic` |
+
+First-order serial-correlation diagnostic for residuals:
+`d=Σ(eᵢ−e_{i−1})²/Σeᵢ² ∈ [0,4]`, with ρ̂≈1−d/2 (d≈2 → none, d<2 → positive,
+d>2 → negative). Validated: alternating residuals → d=3.333, ρ̂=−0.667;
+block residuals → d=0.667, ρ̂=0.667.
+
+### `stats::autocorr` — autocorrelation & Ljung-Box
+
+| Function | Signature |
+|---|---|
+| `acf` | `pub fn acf(x: &[f64; 256], n: i32, k: i32) -> f64 with Mut, Div, Panic` |
+| `ljung_box` | `pub fn ljung_box(x: &[f64; 256], n: i32, m: i32) -> LBResult with Mut, Div, Panic` |
+
+Sample autocorrelation at lag k and the Ljung-Box portmanteau test
+`Q=n(n+2)Σr_k²/(n−k) ~ χ²(m)` for white noise up to lag m. Validated:
+{1,2,3,4,5}→acf(1)=0.4, acf(2)=−0.1; Ljung-Box(m=2)→Q=1.517; a monotone ramp →
+acf(1)>0.6, Q significant.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -812,6 +846,9 @@ use stats::fleiss_kappa::{FleissResult, fleiss_kappa}
 use stats::logistic::{LogisticFit, logistic_fit, logistic_predict}
 use stats::poisson_reg::{PoissonFit, poisson_fit, poisson_predict}
 use stats::wls::{WLSFit, wls_fit}
+use stats::runs_test::{RunsResult, runs_test}
+use stats::durbin_watson::{DWResult, durbin_watson}
+use stats::autocorr::{LBResult, acf, ljung_box}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/autocorr.sio
+++ b/stdlib/stats/autocorr.sio
@@ -1,0 +1,256 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/autocorr.sio — sample autocorrelation & Ljung-Box test
+//
+// The serial-dependence diagnostics for an ordered series:
+//
+//   acf(x, n, k)          -> f64         autocorrelation at lag k
+//   ljung_box(x, n, m)    -> LBResult    portmanteau test over lags 1..m
+//
+//   r_k = Σ_{i=1}^{n−k}(xᵢ−x̄)(x_{i+k}−x̄) / Σ_{i=1}^n (xᵢ−x̄)²,
+//   Q = n(n+2) Σ_{k=1}^m r_k²/(n−k)   ~   χ²(m)   under independence.
+//
+// Q is the Ljung-Box refinement of Box-Pierce; a large Q rejects the hypothesis
+// that the series is white noise up to lag m.
+//
+// Pure Sounio: mean and total variance in one pass, each lag numerator inline;
+// χ² tail via inline Lanczos log-gamma + incomplete gamma. No nested data-array
+// calls.
+//
+// References:
+//   Box & Pierce (1970); Ljung & Box (1978) Biometrika 65:297.
+
+module stats::autocorr
+
+fn ac_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ac_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn ac_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn ac_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * ac_ln(tt) - tt + ac_ln(a)
+}
+
+fn ac_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * ac_exp(0.0 - x + s * ac_ln(x) - ac_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = ac_exp(0.0 - x + s * ac_ln(x) - ac_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn ac_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    if df <= 0.0 { return 1.0 }
+    return 1.0 - ac_igamma_p(df * 0.5, x * 0.5)
+}
+
+/// Sample autocorrelation at lag k (biased / divide-by-total-variance form).
+///
+/// Parâmetros: x — series; n — length; k — lag (0 <= k < n).
+/// Retorno: r_k in [-1,1] (r_0 = 1).
+pub fn acf(x: &[f64; 256], n: i32, k: i32) -> f64 with Mut, Div, Panic {
+    if n < 2 || k < 0 || k >= n { return 0.0 }
+    let nf = n as f64
+    var sum = 0.0
+    var i = 0
+    while i < n { sum = sum + x[i as usize]; i = i + 1 }
+    let mean = sum / nf
+    var den = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; den = den + d * d; j = j + 1 }
+    if den <= 1.0e-300 { return 0.0 }
+    var num = 0.0
+    var t = 0
+    while t < n - k {
+        num = num + (x[t as usize] - mean) * (x[(t + k) as usize] - mean)
+        t = t + 1
+    }
+    return num / den
+}
+
+pub struct LBResult {
+    pub q: f64,   // Ljung-Box statistic
+    pub df: i64,  // m
+    pub p: f64,   // chi-squared p-value
+}
+
+/// Ljung-Box portmanteau test over lags 1..m.
+///
+/// Parâmetros: x — series; n — length (>=3); m — max lag (1 <= m < n).
+/// Retorno: LBResult (q, df=m, p).
+/// Referências: Ljung & Box (1978).
+pub fn ljung_box(x: &[f64; 256], n: i32, m: i32) -> LBResult with Mut, Div, Panic {
+    if n < 3 || m < 1 || m >= n { return LBResult { q: 0.0, df: 0, p: 1.0 } }
+    let nf = n as f64
+    var sum = 0.0
+    var i = 0
+    while i < n { sum = sum + x[i as usize]; i = i + 1 }
+    let mean = sum / nf
+    var den = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; den = den + d * d; j = j + 1 }
+    if den <= 1.0e-300 { return LBResult { q: 0.0, df: m as i64, p: 1.0 } }
+    var acc = 0.0
+    var k = 1
+    while k <= m {
+        var num = 0.0
+        var t = 0
+        while t < n - k {
+            num = num + (x[t as usize] - mean) * (x[(t + k) as usize] - mean)
+            t = t + 1
+        }
+        let rk = num / den
+        acc = acc + rk * rk / ((n - k) as f64)
+        k = k + 1
+    }
+    let q = nf * (nf + 2.0) * acc
+    let p = ac_chi2_sf(q, m as f64)
+    return LBResult { q: q, df: m as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3,4,5}, mean 3, Σd²=10. acf(1)=4/10=0.4; acf(2)=-1/10=-0.1; acf(0)=1.
+fn test_acf() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    var ok = true
+    ok = check(1, approx(acf(&x, 5, 0), 1.0, 1.0e-9)) && ok
+    ok = check(2, approx(acf(&x, 5, 1), 0.4, 1.0e-9)) && ok
+    ok = check(3, approx(acf(&x, 5, 2), 0.0 - 0.1, 1.0e-9)) && ok
+    return ok
+}
+
+// Ljung-Box m=2: Q = 5·7·(0.4²/4 + 0.1²/3) = 35·(0.04+0.003333) = 1.516667. df=2.
+fn test_ljung_box() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = ljung_box(&x, 5, 2)
+    var ok = true
+    ok = check(10, approx(r.q, 1.516667, 1.0e-4)) && ok
+    ok = check(11, r.df == 2) && ok
+    ok = check(12, r.p > 0.1) && ok
+    return ok
+}
+
+// strong autocorrelation: a long monotone ramp has large lag-1 acf and a large Q.
+fn test_strong() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 12 { x[i as usize] = (i + 1) as f64; i = i + 1 }
+    let r = ljung_box(&x, 12, 3)
+    // lag-1 acf of a ramp is high (~0.7); Q over 3 lags is large -> p small.
+    var ok = true
+    ok = check(20, acf(&x, 12, 1) > 0.6) && ok
+    ok = check(21, r.p < 0.05) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_acf() && ok
+    ok = test_ljung_box() && ok
+    ok = test_strong() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/durbin_watson.sio
+++ b/stdlib/stats/durbin_watson.sio
@@ -1,0 +1,118 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/durbin_watson.sio — Durbin-Watson autocorrelation statistic
+//
+// Tests regression residuals for first-order serial correlation:
+//
+//   durbin_watson(e, n) -> DWResult
+//
+//   d = Σ_{i=2}^n (eᵢ − e_{i−1})² / Σ_{i=1}^n eᵢ²   ∈ [0, 4],
+//   ρ̂ ≈ 1 − d/2.
+// d ≈ 2 → no autocorrelation; d < 2 → positive (successive residuals alike);
+// d > 2 → negative (successive residuals opposite). The exact critical bounds
+// depend on the design matrix and are not computed here — d and ρ̂ are reported.
+//
+// Pure Sounio: one pass for the two sums; no external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Durbin & Watson (1950, 1951) Biometrika 37:409, 38:159.
+
+module stats::durbin_watson
+
+pub struct DWResult {
+    pub d: f64,    // Durbin-Watson statistic in [0,4]
+    pub rho: f64,  // approximate first-order autocorrelation 1 - d/2
+}
+
+/// Durbin-Watson statistic for a residual (or ordered) series.
+///
+/// Parâmetros: e — residual series (in order); n — length (>=2, <=256).
+/// Retorno: DWResult (d, rho ≈ 1 − d/2).
+/// Referências: Durbin & Watson (1950, 1951).
+pub fn durbin_watson(e: &[f64; 256], n: i32) -> DWResult with Mut, Div, Panic {
+    if n < 2 { return DWResult { d: 0.0, rho: 0.0 } }
+    var num = 0.0
+    var den = 0.0
+    var i = 0
+    while i < n {
+        let ei = e[i as usize]
+        den = den + ei * ei
+        if i > 0 {
+            let diff = ei - e[(i - 1) as usize]
+            num = num + diff * diff
+        }
+        i = i + 1
+    }
+    if den <= 1.0e-300 { return DWResult { d: 0.0, rho: 0.0 } }
+    let d = num / den
+    return DWResult { d: d, rho: 1.0 - d / 2.0 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// strong negative autocorr: e={1,-1,1,-1,1,-1}. Σe²=6; Σdiff²=5·4=20.
+// d=20/6=3.333333; rho=1-1.666667=-0.666667.
+fn test_negative() -> bool with IO, Mut, Div, Panic {
+    var e: [f64; 256] = [0.0; 256]
+    e[0]=1.0; e[1]=0.0-1.0; e[2]=1.0; e[3]=0.0-1.0; e[4]=1.0; e[5]=0.0-1.0
+    let r = durbin_watson(&e, 6)
+    var ok = true
+    ok = check(1, approx(r.d, 3.333333, 1.0e-5)) && ok
+    ok = check(2, approx(r.rho, 0.0 - 0.666667, 1.0e-5)) && ok
+    return ok
+}
+
+// strong positive autocorr: e={1,1,1,-1,-1,-1}. Σe²=6; Σdiff²=4 (one jump of -2).
+// d=4/6=0.666667; rho=1-0.333333=0.666667.
+fn test_positive() -> bool with IO, Mut, Div, Panic {
+    var e: [f64; 256] = [0.0; 256]
+    e[0]=1.0; e[1]=1.0; e[2]=1.0; e[3]=0.0-1.0; e[4]=0.0-1.0; e[5]=0.0-1.0
+    let r = durbin_watson(&e, 6)
+    var ok = true
+    ok = check(10, approx(r.d, 0.666667, 1.0e-5)) && ok
+    ok = check(11, approx(r.rho, 0.666667, 1.0e-5)) && ok
+    return ok
+}
+
+// no autocorr sanity: alternating small pattern giving d near 2.
+// e={1,-1,-1,1,1,-1} -> Σe²=6; diffs: -2,0,2,0,-2 -> squares 4,0,4,0,4=12. d=2, rho=0.
+fn test_none() -> bool with IO, Mut, Div, Panic {
+    var e: [f64; 256] = [0.0; 256]
+    e[0]=1.0; e[1]=0.0-1.0; e[2]=0.0-1.0; e[3]=1.0; e[4]=1.0; e[5]=0.0-1.0
+    let r = durbin_watson(&e, 6)
+    var ok = true
+    ok = check(20, approx(r.d, 2.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.rho, 0.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_negative() && ok
+    ok = test_positive() && ok
+    ok = test_none() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/runs_test.sio
+++ b/stdlib/stats/runs_test.sio
@@ -1,0 +1,176 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/runs_test.sio — Wald-Wolfowitz runs test for randomness
+//
+// Tests whether a dichotomous sequence is random against the alternative that
+// its elements are serially dependent (clustered or over-alternating):
+//
+//   runs_test(seq, n) -> RunsResult          seq ∈ {0,1}
+//
+// A run is a maximal block of identical symbols. With n₁ ones, n₂ zeros and R
+// runs, under randomness
+//   μ_R = 2 n₁ n₂ / n + 1,
+//   σ²_R = 2 n₁ n₂ (2 n₁ n₂ − n) / ( n²(n−1) ),
+// and z = (R − μ_R)/σ_R is asymptotically standard normal (two-sided p). Too few
+// runs ⇒ clustering / positive dependence; too many ⇒ over-alternation.
+//
+// Pure Sounio: inline sqrt/erf; a single pass counts runs and symbol totals; no
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Wald & Wolfowitz (1940) Ann. Math. Stat. 11:147.
+
+module stats::runs_test
+
+fn rt_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn rt_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / rt_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn rt_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * rt_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn rt_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - rt_erf(z * INV_SQRT2))
+}
+
+pub struct RunsResult {
+    pub runs: i64,   // observed number of runs
+    pub z: f64,      // standardized statistic
+    pub p: f64,      // two-sided p-value
+    pub n1: i64,     // count of ones
+    pub n2: i64,     // count of zeros
+}
+
+/// Wald-Wolfowitz runs test on a 0/1 sequence.
+///
+/// Parâmetros: seq — sequence of 0/1; n — length (>=2, <=256).
+/// Retorno: RunsResult (runs, z, p, n1, n2).
+/// Referências: Wald & Wolfowitz (1940).
+pub fn runs_test(seq: &[i64; 256], n: i32) -> RunsResult with Mut, Div, Panic {
+    if n < 2 { return RunsResult { runs: 0, z: 0.0, p: 1.0, n1: 0, n2: 0 } }
+    var n1 = 0
+    var n2 = 0
+    var runs = 1
+    var i = 0
+    while i < n {
+        if seq[i as usize] == 1 { n1 = n1 + 1 } else { n2 = n2 + 1 }
+        if i > 0 {
+            if seq[i as usize] != seq[(i - 1) as usize] { runs = runs + 1 }
+        }
+        i = i + 1
+    }
+    if n1 == 0 || n2 == 0 {
+        // a single symbol: one run, test undefined -> p = 1
+        return RunsResult { runs: runs as i64, z: 0.0, p: 1.0, n1: n1 as i64, n2: n2 as i64 }
+    }
+    let n1f = n1 as f64
+    let n2f = n2 as f64
+    let nf = n as f64
+    let prod = 2.0 * n1f * n2f
+    let mu = prod / nf + 1.0
+    let varr = prod * (prod - nf) / (nf * nf * (nf - 1.0))
+    var z = 0.0
+    if varr > 0.0 { z = ((runs as f64) - mu) / rt_sqrt(varr) }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * rt_normal_sf(az)
+    return RunsResult { runs: runs as i64, z: z, p: p, n1: n1 as i64, n2: n2 as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// random-looking: 1,1,0,0,1,0,1,1,0,0. n1=5,n2=5,R=6. mu=6 -> z=0, p=1.
+fn test_random() -> bool with IO, Mut, Div, Panic {
+    var s: [i64; 256] = [0; 256]
+    s[0]=1; s[1]=1; s[2]=0; s[3]=0; s[4]=1; s[5]=0; s[6]=1; s[7]=1; s[8]=0; s[9]=0
+    let r = runs_test(&s, 10)
+    var ok = true
+    ok = check(1, r.runs == 6) && ok
+    ok = check(2, approx(r.z, 0.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+// clustered: 1,1,1,1,1,0,0,0,0,0. R=2. mu=6, sd=sqrt(2.222222)=1.490712.
+// z=(2-6)/1.490712=-2.683281 -> p<0.01.
+fn test_clustered() -> bool with IO, Mut, Div, Panic {
+    var s: [i64; 256] = [0; 256]
+    s[0]=1; s[1]=1; s[2]=1; s[3]=1; s[4]=1; s[5]=0; s[6]=0; s[7]=0; s[8]=0; s[9]=0
+    let r = runs_test(&s, 10)
+    var ok = true
+    ok = check(10, r.runs == 2) && ok
+    ok = check(11, approx(r.z, 0.0 - 2.683281, 1.0e-4)) && ok
+    ok = check(12, r.p < 0.01) && ok
+    return ok
+}
+
+// over-alternating: 1,0,1,0,1,0,1,0,1,0. R=10. z=(10-6)/1.490712=2.683281 -> p<0.01.
+fn test_alternating() -> bool with IO, Mut, Div, Panic {
+    var s: [i64; 256] = [0; 256]
+    var i = 0
+    while i < 10 { s[i as usize] = if i % 2 == 0 { 1 } else { 0 }; i = i + 1 }
+    let r = runs_test(&s, 10)
+    var ok = true
+    ok = check(20, r.runs == 10) && ok
+    ok = check(21, approx(r.z, 2.683281, 1.0e-4)) && ok
+    ok = check(22, r.p < 0.01) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_random() && ok
+    ok = test_clustered() && ok
+    ok = test_alternating() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three more pure-Sounio modules for the epistemic-statistics suite, bringing the runner to **52 modules**. These check the **independence assumption** for ordered / time-course data (PK sampling, longitudinal measurements) — the serial counterpart to the suite's goodness-of-fit / normality family. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::runs_test` | Wald-Wolfowitz runs test for randomness of a 0/1 sequence (normal-approx z, p) |
| `stats::durbin_watson` | Durbin-Watson d∈[0,4] + ρ̂≈1−d/2 for first-order residual autocorrelation |
| `stats::autocorr` | Sample ACF at lag k + Ljung-Box Q ~ χ²(m) portmanteau test |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Runs: balanced random-like → R=6, z=0; clustered → R=2, z=−2.683, p<0.01; alternating → R=10, z=2.683.
  - Durbin-Watson: alternating residuals → d=3.333, ρ̂=−0.667; block residuals → d=0.667, ρ̂=0.667; d=2 → ρ̂=0.
  - Autocorr: {1,2,3,4,5} → acf(1)=0.4, acf(2)=−0.1; Ljung-Box(m=2) → Q=1.517; a monotone ramp → acf(1)>0.6, Q significant.
- Full suite selftest: **52 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; Ljung-Box χ² tail via inline Lanczos log-gamma + regularised incomplete gamma.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).