### PR TITLE
feat(stats): survival extensions — nelson_aalen, rmst, life_table

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2770,3 +2770,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - autocorr = **PASS**: biased r_k, Ljung-Box Q=n(n+2)Σr_k²/(n−k) ~ χ²(m); acf(1)=0.4/acf(2)=−0.1 and Q≈1.5167 hand-checked.
 - Theme: serial-dependence / independence-assumption diagnostics — complements the goodness-of-fit / normality family for ordered & time-course data (PK sampling, longitudinal). All scalar/read-only-array, #852-safe. Suite runner: 52 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-0yOUhT/`, `/tmp/llm-offload-5OiuG1/`, `/tmp/llm-offload-FpKA3Q/`.
+
+## 2026-07-14 — math-review: stats::nelson_aalen, stats::rmst, stats::life_table
+- Files (all new): `stdlib/stats/nelson_aalen.sio` (Nelson-Aalen cumulative hazard Ĥ + variance + implied survival), `stdlib/stats/rmst.sio` (restricted mean survival time = area under KM up to τ), `stdlib/stats/life_table.sio` (actuarial Cutler-Ederer grouped survival + interval hazard). Provider: xAI/Grok 4.3.
+- nelson_aalen = **PASS**: Ĥ=Σd_j/n_j, Var=Σd_j/n_j², Ŝ=e^{-Ĥ} canonical; sort-free distinct-death-time walk correct; Ĥ(3)=0.7833, Var=0.2136 verified.
+- rmst = **PASS**: exact right-continuous KM step-function area truncated at τ; all five cases (3.0, 2.4, 3.0, 2.1, 3.667) reproduced; edge cases correct.
+- life_table = **PASS**: n'ᵢ=nᵢ−wᵢ/2, qᵢ=dᵢ/n'ᵢ, Ŝ=Πpᵢ (Cutler-Ederer) exact; 3-interval example (0.9, 0.8047, 0.7231) verified.
+- Theme: survival-analysis extensions — completes the survival family (km, logrank, exp_survival + Nelson-Aalen, RMST, life-table). All deterministic, fully hand-derivable. #852-safe: sort-free walks / cumulative products, no nested data-array calls. Suite runner: 55 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-dUWR1L/`, `/tmp/llm-offload-K5q4eh/`, `/tmp/llm-offload-vpkpHX/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -61,6 +61,9 @@ MODULES=(
   stdlib/stats/runs_test.sio
   stdlib/stats/durbin_watson.sio
   stdlib/stats/autocorr.sio
+  stdlib/stats/nelson_aalen.sio
+  stdlib/stats/rmst.sio
+  stdlib/stats/life_table.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -793,6 +793,39 @@ Sample autocorrelation at lag k and the Ljung-Box portmanteau test
 {1,2,3,4,5}→acf(1)=0.4, acf(2)=−0.1; Ljung-Box(m=2)→Q=1.517; a monotone ramp →
 acf(1)>0.6, Q significant.
 
+### `stats::nelson_aalen` — Nelson-Aalen cumulative hazard
+
+| Function | Signature |
+|---|---|
+| `nelson_aalen` | `pub fn nelson_aalen(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64) -> NAResult with Mut, Div, Panic` |
+
+The non-parametric cumulative hazard `Ĥ(t)=Σd_j/n_j` with variance `Σd_j/n_j²`
+and implied survival `Ŝ=e^{−Ĥ}` — the KM companion, better-behaved in the tail.
+Validated: times 1–5 all deaths → Ĥ(3)=0.7833, Var=0.2136, Ŝ(3)=0.4569; with
+censoring → Ĥ(4)=0.5333.
+
+### `stats::rmst` — restricted mean survival time
+
+| Function | Signature |
+|---|---|
+| `rmst` | `pub fn rmst(time: &[f64; 256], event: &[i64; 256], n: i32, tau: f64) -> f64 with Mut, Div, Panic` |
+
+The area under the KM curve up to a horizon τ — a clinically interpretable
+event-free-time summary, robust to non-proportional hazards. Exact truncated
+step-function integral. Validated: times 1–5 → RMST(5)=3.0, RMST(3)=2.4,
+RMST(2.5)=2.1; with censoring → RMST(5)=3.667.
+
+### `stats::life_table` — actuarial (cohort) life table
+
+| Function | Signature |
+|---|---|
+| `life_table_survival` | `pub fn life_table_survival(entering: &[f64; 64], deaths: &[f64; 64], withdrawn: &[f64; 64], k: i32, q_interval: i32) -> f64 with Mut, Div, Panic` |
+| `life_table_hazard` | `pub fn life_table_hazard(entering, deaths, withdrawn, k, q_interval) -> f64` |
+
+Interval-grouped survival for count-per-interval data: with the withdrawal-
+adjusted risk set `n'ᵢ=nᵢ−wᵢ/2`, `qᵢ=dᵢ/n'ᵢ` and `Ŝ=Πpᵢ` (Cutler-Ederer).
+Validated: 3-interval example → S=0.9, 0.8047, 0.7231; hazard(i1)=0.1059.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -849,6 +882,9 @@ use stats::wls::{WLSFit, wls_fit}
 use stats::runs_test::{RunsResult, runs_test}
 use stats::durbin_watson::{DWResult, durbin_watson}
 use stats::autocorr::{LBResult, acf, ljung_box}
+use stats::nelson_aalen::{NAResult, nelson_aalen}
+use stats::rmst::{rmst}
+use stats::life_table::{life_table_survival, life_table_hazard}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/life_table.sio
+++ b/stdlib/stats/life_table.sio
@@ -1,0 +1,114 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/life_table.sio — actuarial (cohort) life table
+//
+// The interval-grouped survival estimator for data reported as counts per time
+// interval rather than exact event times:
+//
+//   life_table_survival(entering, deaths, withdrawn, k, q_interval) -> f64
+//   life_table_hazard(entering, deaths, withdrawn, k, q_interval)   -> f64
+//
+// In each interval the effective number at risk adjusts for withdrawals
+// (censoring) assumed uniform across the interval:
+//   n'ᵢ = nᵢ − wᵢ/2,  qᵢ = dᵢ/n'ᵢ,  pᵢ = 1 − qᵢ,
+//   Ŝ(end of interval m) = Π_{i≤m} pᵢ.
+//
+// Pure Sounio: a single cumulative product across intervals; no external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Cutler & Ederer (1958); Collett, "Modelling Survival Data" 3e, §2.
+
+module stats::life_table
+
+/// Cumulative survival at the end of interval `q_interval` (0-indexed).
+///
+/// Parâmetros: entering — n at start of each interval; deaths — d per interval;
+///             withdrawn — censored per interval; k — number of intervals;
+///             q_interval — interval index to report (0..k-1).
+/// Retorno: Ŝ at the end of that interval.
+/// Referências: Cutler & Ederer (1958).
+pub fn life_table_survival(entering: &[f64; 64], deaths: &[f64; 64], withdrawn: &[f64; 64],
+                           k: i32, q_interval: i32) -> f64 with Mut, Div, Panic {
+    if k < 1 || q_interval < 0 { return 1.0 }
+    var surv = 1.0
+    var i = 0
+    while i <= q_interval && i < k {
+        let neff = entering[i as usize] - 0.5 * withdrawn[i as usize]
+        if neff > 0.0 {
+            let q = deaths[i as usize] / neff
+            surv = surv * (1.0 - q)
+        }
+        i = i + 1
+    }
+    return surv
+}
+
+/// Interval conditional hazard qᵢ = dᵢ/n'ᵢ for interval `q_interval`.
+pub fn life_table_hazard(entering: &[f64; 64], deaths: &[f64; 64], withdrawn: &[f64; 64],
+                         k: i32, q_interval: i32) -> f64 with Mut, Div, Panic {
+    if k < 1 || q_interval < 0 || q_interval >= k { return 0.0 }
+    let neff = entering[q_interval as usize] - 0.5 * withdrawn[q_interval as usize]
+    if neff <= 0.0 { return 0.0 }
+    return deaths[q_interval as usize] / neff
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 3 intervals:
+//  i0: n=100 d=10 w=0  -> n'=100, q=0.1,   S=0.9
+//  i1: n=90  d=9  w=10 -> n'=85,  q=0.105882, S=0.9·0.894118=0.804706
+//  i2: n=71  d=7  w=4  -> n'=69,  q=0.101449, S=0.804706·0.898551=0.723073
+fn test_life_table() -> bool with IO, Mut, Div, Panic {
+    var en: [f64; 64] = [0.0; 64]
+    var de: [f64; 64] = [0.0; 64]
+    var wd: [f64; 64] = [0.0; 64]
+    en[0]=100.0; de[0]=10.0; wd[0]=0.0
+    en[1]=90.0;  de[1]=9.0;  wd[1]=10.0
+    en[2]=71.0;  de[2]=7.0;  wd[2]=4.0
+    var ok = true
+    ok = check(1, approx(life_table_survival(&en, &de, &wd, 3, 0), 0.9, 1.0e-9)) && ok
+    ok = check(2, approx(life_table_survival(&en, &de, &wd, 3, 1), 0.804706, 1.0e-5)) && ok
+    ok = check(3, approx(life_table_survival(&en, &de, &wd, 3, 2), 0.723073, 1.0e-5)) && ok
+    ok = check(4, approx(life_table_hazard(&en, &de, &wd, 3, 1), 0.105882, 1.0e-5)) && ok
+    return ok
+}
+
+// no withdrawals, no deaths -> survival stays 1.
+fn test_no_events() -> bool with IO, Mut, Div, Panic {
+    var en: [f64; 64] = [0.0; 64]
+    var de: [f64; 64] = [0.0; 64]
+    var wd: [f64; 64] = [0.0; 64]
+    en[0]=50.0; en[1]=50.0
+    let r = life_table_survival(&en, &de, &wd, 2, 1)
+    return check(10, approx(r, 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_life_table() && ok
+    ok = test_no_events() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/nelson_aalen.sio
+++ b/stdlib/stats/nelson_aalen.sio
@@ -1,0 +1,167 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/nelson_aalen.sio — Nelson-Aalen cumulative-hazard estimator
+//
+// The non-parametric cumulative hazard, a companion to Kaplan-Meier that is
+// often better behaved in the tail:
+//
+//   nelson_aalen(time, event, n, t_query) -> NAResult
+//
+//   Ĥ(t) = Σ_{t_(j) ≤ t} d_j / n_j,      Var(Ĥ(t)) = Σ_{t_(j) ≤ t} d_j / n_j²,
+// with d_j deaths and n_j at risk at each distinct death time; the implied
+// survival is Ŝ(t) = e^{−Ĥ(t)}.
+//
+// Pure Sounio: a sort-free ordered walk over the distinct death times (no nested
+// data-array calls); exp via an inline reduced series.
+//
+// References:
+//   Nelson (1972); Aalen (1978) Ann. Stat. 6:701.
+
+module stats::nelson_aalen
+
+fn na_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / na_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+pub struct NAResult {
+    pub h: f64,     // cumulative hazard Ĥ(t_query)
+    pub var_h: f64, // variance of Ĥ(t_query)
+    pub surv: f64,  // implied survival e^{-Ĥ}
+    pub n_events: i64,
+}
+
+/// Nelson-Aalen cumulative hazard at a queried time.
+///
+/// Parâmetros: time — follow-up times; event — 1 death / 0 censored; n — size;
+///             t_query — evaluation time.
+/// Retorno: NAResult (h, var_h, surv, n_events).
+/// Referências: Nelson (1972); Aalen (1978).
+pub fn nelson_aalen(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64) -> NAResult with Mut, Div, Panic {
+    if n < 1 { return NAResult { h: 0.0, var_h: 0.0, surv: 1.0, n_events: 0 } }
+    var h = 0.0
+    var vh = 0.0
+    var nev = 0
+    var prev = 0.0 - 1.0e300
+    var have_prev = false
+    var guard = 0
+    while guard <= n {
+        var found = false
+        var tau = 0.0
+        var i = 0
+        while i < n {
+            if event[i as usize] == 1 {
+                let ti = time[i as usize]
+                let after = if have_prev { ti > prev } else { true }
+                if after {
+                    if found == false || ti < tau { tau = ti; found = true }
+                }
+            }
+            i = i + 1
+        }
+        if found == false { guard = n + 1 }
+        else {
+            var d = 0
+            var at_risk = 0
+            var j = 0
+            while j < n {
+                let tj = time[j as usize]
+                if tj >= tau { at_risk = at_risk + 1 }
+                if tj == tau && event[j as usize] == 1 { d = d + 1 }
+                j = j + 1
+            }
+            if tau <= t_query && at_risk > 0 {
+                let df = d as f64
+                let nr = at_risk as f64
+                h = h + df / nr
+                vh = vh + df / (nr * nr)
+                nev = nev + d
+            }
+            prev = tau
+            have_prev = true
+            guard = guard + 1
+        }
+    }
+    return NAResult { h: h, var_h: vh, surv: na_exp(0.0 - h), n_events: nev as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// times 1..5 all deaths. Ĥ(3)=1/5+1/4+1/3=0.783333.
+// Var(3)=1/25+1/16+1/9=0.213611. S(3)=exp(-0.783333)=0.456876.
+fn test_na() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    let r = nelson_aalen(&t, &e, 5, 3.0)
+    var ok = true
+    ok = check(1, approx(r.h, 0.783333, 1.0e-5)) && ok
+    ok = check(2, approx(r.var_h, 0.213611, 1.0e-5)) && ok
+    ok = check(3, approx(r.surv, 0.456876, 1.0e-5)) && ok
+    ok = check(4, r.n_events == 3) && ok
+    return ok
+}
+
+// full hazard Ĥ(5)=1/5+1/4+1/3+1/2+1=2.283333.
+fn test_full() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    let r = nelson_aalen(&t, &e, 5, 5.0)
+    return check(10, approx(r.h, 2.283333, 1.0e-5))
+}
+
+// censoring: times 1..5, events {1,0,1,0,1}. deaths at 1(n=5),3(n=3),5(n=1).
+// Ĥ(4)=1/5+1/3=0.533333.
+fn test_censor() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=0; e[2]=1; e[3]=0; e[4]=1
+    let r = nelson_aalen(&t, &e, 5, 4.0)
+    var ok = true
+    ok = check(20, approx(r.h, 0.533333, 1.0e-5)) && ok
+    ok = check(21, r.n_events == 2) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_na() && ok
+    ok = test_full() && ok
+    ok = test_censor() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/rmst.sio
+++ b/stdlib/stats/rmst.sio
@@ -1,0 +1,162 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/rmst.sio — restricted mean survival time
+//
+// The area under the Kaplan-Meier curve up to a horizon τ — a clinically
+// interpretable single-number summary (mean event-free time within τ), often
+// preferred to the hazard ratio when hazards are non-proportional:
+//
+//   rmst(time, event, n, tau) -> f64
+//
+//   RMST(τ) = ∫₀^τ Ŝ(t) dt = Σ Ŝ(t_(j−1))·(min(t_(j), τ) − t_(j−1)),
+// the exact area of the right-continuous KM step function truncated at τ.
+//
+// Pure Sounio: a sort-free ordered walk over the distinct death times, adding
+// each rectangle as it goes (no nested data-array calls).
+//
+// References:
+//   Royston & Parmar (2013) BMC Med. Res. Methodol. 13:152.
+
+module stats::rmst
+
+/// Restricted mean survival time up to horizon tau (area under the KM curve).
+///
+/// Parâmetros: time — follow-up times; event — 1 death / 0 censored; n — size;
+///             tau — horizon (>0).
+/// Retorno: RMST(tau).
+/// Referências: Royston & Parmar (2013).
+pub fn rmst(time: &[f64; 256], event: &[i64; 256], n: i32, tau: f64) -> f64 with Mut, Div, Panic {
+    if n < 1 || tau <= 0.0 { return 0.0 }
+    var surv = 1.0
+    var area = 0.0
+    var prev = 0.0
+    var have_prev = false
+    var done = false
+    var guard = 0
+    while guard <= n {
+        if done { guard = n + 1 }
+        else {
+            // next distinct death time strictly greater than prev
+            var found = false
+            var tau_j = 0.0
+            var i = 0
+            while i < n {
+                if event[i as usize] == 1 {
+                    let ti = time[i as usize]
+                    let after = if have_prev { ti > prev } else { ti > 0.0 - 1.0 }
+                    if after {
+                        if found == false || ti < tau_j { tau_j = ti; found = true }
+                    }
+                }
+                i = i + 1
+            }
+            if found == false {
+                // tail segment [prev, tau)
+                if prev < tau { area = area + surv * (tau - prev) }
+                done = true
+            } else {
+                let seg_end = if tau_j < tau { tau_j } else { tau }
+                if seg_end > prev { area = area + surv * (seg_end - prev) }
+                if tau_j >= tau { done = true }
+                else {
+                    // update survival by the KM factor at tau_j
+                    var d = 0
+                    var at_risk = 0
+                    var j = 0
+                    while j < n {
+                        let tj = time[j as usize]
+                        if tj >= tau_j { at_risk = at_risk + 1 }
+                        if tj == tau_j && event[j as usize] == 1 { d = d + 1 }
+                        j = j + 1
+                    }
+                    if at_risk > 0 { surv = surv * (1.0 - (d as f64) / (at_risk as f64)) }
+                    prev = tau_j
+                    have_prev = true
+                }
+            }
+            guard = guard + 1
+        }
+    }
+    return area
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// times 1..5 all deaths. KM steps: S=1,0.8,0.6,0.4,0.2 on unit intervals.
+// RMST(5) = 1+0.8+0.6+0.4+0.2 = 3.0.
+fn test_rmst_full() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(1, approx(rmst(&t, &e, 5, 5.0), 3.0, 1.0e-9))
+}
+
+// RMST(3) = area on [0,1)+[1,2)+[2,3) = 1 + 0.8 + 0.6 = 2.4.
+fn test_rmst_tau3() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(10, approx(rmst(&t, &e, 5, 3.0), 2.4, 1.0e-9))
+}
+
+// horizon beyond last death: RMST(6) = 3.0 (S=0 after t=5, no extra area).
+fn test_rmst_beyond() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(20, approx(rmst(&t, &e, 5, 6.0), 3.0, 1.0e-9))
+}
+
+// mid-interval horizon: RMST(2.5) = 1 + 0.8 + 0.6·0.5 = 2.1.
+fn test_rmst_mid() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(30, approx(rmst(&t, &e, 5, 2.5), 2.1, 1.0e-9))
+}
+
+// censoring: times 1..5, events {1,0,1,0,1}. S: 0.8 after t=1, 0.533333 after t=3.
+// RMST(5) = 1·1 + 0.8·2 + 0.533333·2 = 1 + 1.6 + 1.066667 = 3.666667.
+fn test_rmst_censor() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=0; e[2]=1; e[3]=0; e[4]=1
+    return check(40, approx(rmst(&t, &e, 5, 5.0), 3.666667, 1.0e-5))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_rmst_full() && ok
+    ok = test_rmst_tau3() && ok
+    ok = test_rmst_beyond() && ok
+    ok = test_rmst_mid() && ok
+    ok = test_rmst_censor() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three more pure-Sounio modules for the epistemic-statistics suite, bringing the runner to **55 modules**. These complete the **survival-analysis family** beside `km`, `logrank` and `exp_survival` — the cumulative-hazard and integrated-survival tools clinical survival reporting needs. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::nelson_aalen` | Nelson-Aalen cumulative hazard Ĥ=Σd_j/n_j + variance + Ŝ=e^{−Ĥ} |
| `stats::rmst` | Restricted mean survival time — exact area under KM up to horizon τ |
| `stats::life_table` | Actuarial (Cutler-Ederer) grouped survival, withdrawal-adjusted risk set |

## Validation

All three are **fully deterministic and hand-derivable** (no stochastic component):

- Nelson-Aalen: times 1–5 all deaths → Ĥ(3)=1/5+1/4+1/3=0.7833, Var=0.2136, Ŝ(3)=0.4569; with censoring → Ĥ(4)=0.5333.
- RMST: times 1–5 → RMST(5)=3.0, RMST(3)=2.4, RMST(2.5)=2.1, RMST(6)=3.0; with censoring → RMST(5)=3.667.
- Life table: 3-interval example → S=0.9, 0.8047, 0.7231; interval hazard(i1)=0.1059.
- Full suite selftest: **55 modules + 7 demos ALL GREEN** under `lean_single`.

## `#852`-safety
Nelson-Aalen and RMST use the same sort-free ordered walk over distinct death times as `km`; the life table is a single cumulative product. No nested calls with data arrays live.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).