### PR TITLE
feat(ir): add f128/f256 raw payload arena

### DIFF
--- a/scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
+++ b/scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+SEED_COMPILER="$(realpath "${SOUNIO_F128_SEED_COMPILER:-$ROOT_DIR/bin/souc-lean-single-x86_64}")"
+if [[ ! -x "$SEED_COMPILER" ]]; then
+  echo "FAIL bootstrap seed is not executable: $SEED_COMPILER" >&2
+  exit 2
+fi
+if [[ "$(head -c2 "$SEED_COMPILER" 2>/dev/null)" == '#!' ]]; then
+  echo "FAIL gate requires a resolved seed ELF, not a wrapper: $SEED_COMPILER" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+SOURCE_HEAD="$(git rev-parse HEAD)"
+PROBE='self-hosted/compiler/f128_f256_numeric_payload_probe.sio'
+PROBE_ELF="$TMP_DIR/f128-f256-numeric-payload-probe.elf"
+BUILD_LOG="$TMP_DIR/build.log"
+RUN_LOG="$TMP_DIR/run.log"
+
+echo "seed_elf=$SEED_COMPILER"
+echo "seed_sha256=$(sha256sum "$SEED_COMPILER" | awk '{print $1}')"
+echo "source_head=$SOURCE_HEAD"
+
+if ! "$SEED_COMPILER" "$PROBE" "$PROBE_ELF" >"$BUILD_LOG" 2>&1; then
+  echo "FAIL numeric payload probe did not compile with the bootstrap seed" >&2
+  cat "$BUILD_LOG" >&2
+  exit 1
+fi
+chmod +x "$PROBE_ELF"
+if ! "$PROBE_ELF" >"$RUN_LOG" 2>&1; then
+  echo "FAIL numeric payload probe returned nonzero" >&2
+  cat "$RUN_LOG" >&2
+  exit 1
+fi
+if ! grep -Fxq 'PASS f128_f256_numeric_payload_probe payloads=3 limbs=8 order=lsw-first duplicate_ids=distinct full=256x4 negative_cases=10' "$RUN_LOG"; then
+  echo "FAIL numeric payload probe omitted the exact receipt" >&2
+  cat "$RUN_LOG" >&2
+  exit 1
+fi
+
+PAYLOAD_FILE='self-hosted/ir/numeric_payload.sio'
+if ! grep -Fq 'module ir::numeric_payload' "$PAYLOAD_FILE"; then
+  echo "FAIL numeric payload pool is not compiler-owned under ir::numeric_payload" >&2
+  exit 1
+fi
+for exact in \
+  'IR_WIDE_NUMERIC_MAX_PAYLOADS: i64 = 256' \
+  'IR_WIDE_NUMERIC_MAX_LIMBS: i64 = 1024' \
+  'IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD: i64 = 4' \
+  'entries: [IrWideNumericPayloadEntry; 256]' \
+  'limbs: [i64; 1024]' \
+  'raw_limbs: [i64; 4]' \
+  'required > IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD' \
+  'descriptor.storage_bits / 64' \
+  'limb 0 is the least-significant'; do
+  if ! grep -Fq "$exact" "$PAYLOAD_FILE"; then
+    echo "FAIL numeric payload structural invariant missing: $exact" >&2
+    exit 1
+  fi
+done
+
+rg -l 'IrWideNumericPayload|wide_numeric_payload|numeric_payload|IR_WIDE_NUMERIC' self-hosted \
+  | sort >"$TMP_DIR/payload-references.actual"
+printf '%s\n' \
+  'self-hosted/compiler/f128_f256_numeric_payload_probe.sio' \
+  'self-hosted/ir/numeric_payload.sio' \
+  >"$TMP_DIR/payload-references.expected"
+if ! diff -u "$TMP_DIR/payload-references.expected" "$TMP_DIR/payload-references.actual" \
+    >"$TMP_DIR/integration-leak.log" 2>&1; then
+  echo "FAIL bounded V0-B payload pool leaked into IR instructions, lowering, native, or SOIR" >&2
+  cat "$TMP_DIR/integration-leak.log" >&2
+  exit 1
+fi
+
+echo "PASS f128/f256 payload pool exact roundtrip and deterministic corruption rejection"
+echo "PASS containment: no IrInstr/lowering/ABI/SOIR/arithmetic/source integration"
+echo "PASS madaros_f128_f256_numeric_payload_gate"

--- a/self-hosted/check/numeric_format.sio
+++ b/self-hosted/check/numeric_format.sio
@@ -42,3 +42,13 @@ pub fn binary_format_binary256_descriptor() -> BinaryFormatDescriptor {
         trailing_significand_bits: 236,
     }
 }
+
+pub fn binary_format_descriptor_for_id(format_id: i64) -> BinaryFormatDescriptor {
+    if format_id == numeric_format_binary128_id() {
+        return binary_format_binary128_descriptor()
+    }
+    if format_id == numeric_format_binary256_id() {
+        return binary_format_binary256_descriptor()
+    }
+    invalid_binary_format_descriptor()
+}

--- a/self-hosted/compiler/f128_f256_numeric_payload_probe.sio
+++ b/self-hosted/compiler/f128_f256_numeric_payload_probe.sio
@@ -1,0 +1,135 @@
+use check::numeric_format::*
+use ir::numeric_payload::*
+
+fn expect_limb(pool: &IrWideNumericPayloadPool, payload_id: i64, limb_index: i64, expected: i64, code: i32) -> i32 with Mut, Panic, Div {
+    let (actual, status) = ir_wide_numeric_payload_limb_checked(pool, payload_id, limb_index)
+    if status != IR_WIDE_NUMERIC_OK { return code }
+    if actual != expected { return code }
+    0
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    let by_id_128 = binary_format_descriptor_for_id(numeric_format_binary128_id())
+    if by_id_128.format_id != 128 || by_id_128.storage_bits != 128 { return 9 }
+    if by_id_128.exponent_bits != 15 || by_id_128.precision_bits != 113 { return 34 }
+    if by_id_128.trailing_significand_bits != 112 { return 35 }
+    let by_id_256 = binary_format_descriptor_for_id(numeric_format_binary256_id())
+    if by_id_256.format_id != 256 || by_id_256.storage_bits != 256 { return 10 }
+    if by_id_256.exponent_bits != 19 || by_id_256.precision_bits != 237 { return 36 }
+    if by_id_256.trailing_significand_bits != 236 { return 37 }
+    let by_id_invalid = binary_format_descriptor_for_id(999)
+    if by_id_invalid.format_id != 0 || by_id_invalid.storage_bits != 0 { return 11 }
+    if by_id_invalid.exponent_bits != 0 || by_id_invalid.precision_bits != 0 { return 53 }
+    if by_id_invalid.trailing_significand_bits != 0 { return 54 }
+
+    var pool = ir_empty_wide_numeric_payload_pool()
+    let limbs128: [i64; 4] = [72623859790382856, -1, 0, 0]
+    let (id128, add128_status) = ir_wide_numeric_payload_pool_add(
+        &! pool, numeric_format_binary128_id(), limbs128, 2
+    )
+    if add128_status != IR_WIDE_NUMERIC_OK || id128 != 0 { return 12 }
+
+    let limbs256: [i64; 4] = [
+        2387509390608836392,
+        -2,
+        4702394921427289928,
+        5859837686836516696
+    ]
+    let (id256, add256_status) = ir_wide_numeric_payload_pool_add(
+        &! pool, numeric_format_binary256_id(), limbs256, 4
+    )
+    if add256_status != IR_WIDE_NUMERIC_OK || id256 != 1 { return 13 }
+
+    let (duplicate_id, duplicate_status) = ir_wide_numeric_payload_pool_add(
+        &! pool, numeric_format_binary128_id(), limbs128, 2
+    )
+    if duplicate_status != IR_WIDE_NUMERIC_OK || duplicate_id != 2 { return 38 }
+
+    if pool.payload_count != 3 || pool.limb_count != 8 { return 14 }
+    if ir_wide_numeric_payload_pool_validate(&pool) != IR_WIDE_NUMERIC_OK { return 15 }
+    if expect_limb(&pool, id128, 0, limbs128[0], 16) != 0 { return 16 }
+    if expect_limb(&pool, id128, 1, limbs128[1], 17) != 0 { return 17 }
+    if expect_limb(&pool, id256, 0, limbs256[0], 18) != 0 { return 18 }
+    if expect_limb(&pool, id256, 1, limbs256[1], 19) != 0 { return 19 }
+    if expect_limb(&pool, id256, 2, limbs256[2], 20) != 0 { return 20 }
+    if expect_limb(&pool, id256, 3, limbs256[3], 21) != 0 { return 21 }
+    if expect_limb(&pool, duplicate_id, 0, limbs128[0], 39) != 0 { return 39 }
+    if expect_limb(&pool, duplicate_id, 1, limbs128[1], 40) != 0 { return 40 }
+
+    let (bad_format_id, bad_format_status) = ir_wide_numeric_payload_pool_add(&! pool, 999, limbs128, 2)
+    if bad_format_id != -1 || bad_format_status != IR_WIDE_NUMERIC_ERR_UNKNOWN_FORMAT { return 22 }
+    let (bad_count_id, bad_count_status) = ir_wide_numeric_payload_pool_add(
+        &! pool, numeric_format_binary128_id(), limbs128, 4
+    )
+    if bad_count_id != -1 || bad_count_status != IR_WIDE_NUMERIC_ERR_LIMB_COUNT { return 23 }
+    if pool.payload_count != 3 || pool.limb_count != 8 { return 30 }
+
+    var full_pool = ir_empty_wide_numeric_payload_pool()
+    var full_i: i64 = 0
+    while full_i < IR_WIDE_NUMERIC_MAX_PAYLOADS {
+        let (full_id, full_status) = ir_wide_numeric_payload_pool_add(
+            &! full_pool, numeric_format_binary256_id(), limbs256, 4
+        )
+        if full_status != IR_WIDE_NUMERIC_OK || full_id != full_i { return 41 }
+        full_i = full_i + 1
+    }
+    if full_pool.payload_count != 256 || full_pool.limb_count != 1024 { return 42 }
+    if ir_wide_numeric_payload_pool_validate(&full_pool) != IR_WIDE_NUMERIC_OK { return 43 }
+    let full_last_limb = full_pool.limbs[1023]
+    let (payload_capacity_id, payload_capacity_status) = ir_wide_numeric_payload_pool_add(
+        &! full_pool, numeric_format_binary128_id(), limbs128, 2
+    )
+    if payload_capacity_id != -1 || payload_capacity_status != IR_WIDE_NUMERIC_ERR_PAYLOAD_CAPACITY { return 44 }
+    if full_pool.payload_count != 256 || full_pool.limb_count != 1024 { return 45 }
+    if full_pool.limbs[1023] != full_last_limb { return 46 }
+
+    let (_, invalid_id_status) = ir_wide_numeric_payload_entry_checked(&pool, 3)
+    if invalid_id_status != IR_WIDE_NUMERIC_ERR_PAYLOAD_ID { return 24 }
+    let (_, invalid_limb_status) = ir_wide_numeric_payload_limb_checked(&pool, id128, 2)
+    if invalid_limb_status != IR_WIDE_NUMERIC_ERR_LIMB_INDEX { return 25 }
+
+    pool.entries[1].limb_start = 3
+    if ir_wide_numeric_payload_pool_validate(&pool) != IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY { return 26 }
+    pool.entries[1].limb_start = 2
+
+    pool.entries[0].limb_count = 4
+    if ir_wide_numeric_payload_pool_validate(&pool) != IR_WIDE_NUMERIC_ERR_LIMB_COUNT { return 27 }
+    pool.entries[0].limb_count = 2
+
+    pool.entries[0].format_id = 999
+    if ir_wide_numeric_payload_pool_validate(&pool) != IR_WIDE_NUMERIC_ERR_UNKNOWN_FORMAT { return 28 }
+    pool.entries[0].format_id = numeric_format_binary128_id()
+
+    pool.limb_count = 5
+    if ir_wide_numeric_payload_pool_validate(&pool) != IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY { return 29 }
+    pool.limb_count = 8
+    if ir_wide_numeric_payload_pool_validate(&pool) != IR_WIDE_NUMERIC_OK { return 31 }
+
+    var corrupt_add_pool = ir_empty_wide_numeric_payload_pool()
+    corrupt_add_pool.payload_count = 1
+    corrupt_add_pool.entries[0] = IrWideNumericPayloadEntry {
+        format_id: numeric_format_binary128_id(),
+        limb_start: 0,
+        limb_count: 4,
+    }
+    let corrupt_before_entry0 = corrupt_add_pool.entries[0]
+    let corrupt_before_entry1 = corrupt_add_pool.entries[1]
+    let corrupt_before_limb0 = corrupt_add_pool.limbs[0]
+    let corrupt_before_limb1 = corrupt_add_pool.limbs[1]
+    let (corrupt_add_id, corrupt_add_status) = ir_wide_numeric_payload_pool_add(
+        &! corrupt_add_pool, 999, limbs128, 2
+    )
+    if corrupt_add_id != -1 || corrupt_add_status != IR_WIDE_NUMERIC_ERR_LIMB_COUNT { return 47 }
+    if corrupt_add_pool.payload_count != 1 || corrupt_add_pool.limb_count != 0 { return 48 }
+    if corrupt_add_pool.entries[0].format_id != corrupt_before_entry0.format_id { return 49 }
+    if corrupt_add_pool.entries[0].limb_start != corrupt_before_entry0.limb_start { return 50 }
+    if corrupt_add_pool.entries[0].limb_count != corrupt_before_entry0.limb_count { return 51 }
+    if corrupt_add_pool.entries[1].format_id != corrupt_before_entry1.format_id { return 52 }
+    if corrupt_add_pool.entries[1].limb_start != corrupt_before_entry1.limb_start { return 55 }
+    if corrupt_add_pool.entries[1].limb_count != corrupt_before_entry1.limb_count { return 56 }
+    if corrupt_add_pool.limbs[0] != corrupt_before_limb0 { return 57 }
+    if corrupt_add_pool.limbs[1] != corrupt_before_limb1 { return 58 }
+
+    println("PASS f128_f256_numeric_payload_probe payloads=3 limbs=8 order=lsw-first duplicate_ids=distinct full=256x4 negative_cases=10")
+    0
+}

--- a/self-hosted/ir/numeric_payload.sio
+++ b/self-hosted/ir/numeric_payload.sio
@@ -1,0 +1,159 @@
+// Compiler-owned raw payload storage for fixed wide numeric formats.
+//
+// This module intentionally does not attach payload IDs to IrInstr or IrModule
+// yet. It establishes the arena and its invariants before any lowering, ABI,
+// arithmetic, or serialization path can depend on them. Inserts are append-only
+// and are not interned: equal bit patterns retain distinct payload identities.
+
+module ir::numeric_payload
+
+use check::numeric_format::{binary_format_descriptor_for_id}
+
+pub let IR_WIDE_NUMERIC_MAX_PAYLOADS: i64 = 256
+pub let IR_WIDE_NUMERIC_MAX_LIMBS: i64 = 1024
+pub let IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD: i64 = 4
+
+pub let IR_WIDE_NUMERIC_OK: i64 = 0
+pub let IR_WIDE_NUMERIC_ERR_UNKNOWN_FORMAT: i64 = 1
+pub let IR_WIDE_NUMERIC_ERR_LIMB_COUNT: i64 = 2
+pub let IR_WIDE_NUMERIC_ERR_PAYLOAD_CAPACITY: i64 = 3
+pub let IR_WIDE_NUMERIC_ERR_LIMB_CAPACITY: i64 = 4
+pub let IR_WIDE_NUMERIC_ERR_PAYLOAD_ID: i64 = 5
+pub let IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY: i64 = 6
+pub let IR_WIDE_NUMERIC_ERR_LIMB_INDEX: i64 = 7
+
+pub struct IrWideNumericPayloadEntry {
+    format_id: i64,
+    limb_start: i64,
+    limb_count: i64,
+}
+
+pub struct IrWideNumericPayloadPool {
+    entries: [IrWideNumericPayloadEntry; 256],
+    payload_count: i64,
+    // Raw words only: limb 0 is the least-significant 64-bit word.
+    limbs: [i64; 1024],
+    limb_count: i64,
+}
+
+pub fn ir_empty_wide_numeric_payload_entry() -> IrWideNumericPayloadEntry {
+    IrWideNumericPayloadEntry {
+        format_id: 0,
+        limb_start: 0 - 1,
+        limb_count: 0,
+    }
+}
+
+pub fn ir_empty_wide_numeric_payload_pool() -> IrWideNumericPayloadPool {
+    IrWideNumericPayloadPool {
+        entries: [ir_empty_wide_numeric_payload_entry(); 256],
+        payload_count: 0,
+        limbs: [0; 1024],
+        limb_count: 0,
+    }
+}
+
+pub fn ir_wide_numeric_required_limb_count(format_id: i64) -> i64 with Div {
+    let descriptor = binary_format_descriptor_for_id(format_id)
+    if descriptor.format_id == 0 { return 0 }
+    descriptor.storage_bits / 64
+}
+
+pub fn ir_wide_numeric_payload_pool_add(
+    pool: &! IrWideNumericPayloadPool,
+    format_id: i64,
+    raw_limbs: [i64; 4],
+    raw_limb_count: i64,
+) -> (i64, i64) with Mut, Panic, Div {
+    // Status precedence is stable: existing arena corruption, request format,
+    // request limb count, payload capacity, then the defensive limb capacity.
+    // No write occurs before all five checks pass.
+    let existing_status = ir_wide_numeric_payload_pool_validate(pool)
+    if existing_status != IR_WIDE_NUMERIC_OK {
+        return (0 - 1, existing_status)
+    }
+    let required = ir_wide_numeric_required_limb_count(format_id)
+    if required == 0 || required > IR_WIDE_NUMERIC_MAX_LIMBS_PER_PAYLOAD {
+        return (0 - 1, IR_WIDE_NUMERIC_ERR_UNKNOWN_FORMAT)
+    }
+    if raw_limb_count != required {
+        return (0 - 1, IR_WIDE_NUMERIC_ERR_LIMB_COUNT)
+    }
+    if (*pool).payload_count < 0 || (*pool).payload_count >= IR_WIDE_NUMERIC_MAX_PAYLOADS {
+        return (0 - 1, IR_WIDE_NUMERIC_ERR_PAYLOAD_CAPACITY)
+    }
+    // Unreachable for a valid pool under today's 256 * 4 capacities, but kept
+    // as defense in depth if those capacities diverge in a later slice.
+    if (*pool).limb_count > IR_WIDE_NUMERIC_MAX_LIMBS - required {
+        return (0 - 1, IR_WIDE_NUMERIC_ERR_LIMB_CAPACITY)
+    }
+
+    let payload_id = (*pool).payload_count
+    let limb_start = (*pool).limb_count
+    var i: i64 = 0
+    while i < required {
+        (*pool).limbs[(limb_start + i) as usize] = raw_limbs[i as usize]
+        i = i + 1
+    }
+    (*pool).entries[payload_id as usize] = IrWideNumericPayloadEntry {
+        format_id: format_id,
+        limb_start: limb_start,
+        limb_count: required,
+    }
+    (*pool).payload_count = payload_id + 1
+    (*pool).limb_count = limb_start + required
+    (payload_id, IR_WIDE_NUMERIC_OK)
+}
+
+pub fn ir_wide_numeric_payload_pool_validate(pool: &IrWideNumericPayloadPool) -> i64 with Mut, Panic, Div {
+    if (*pool).payload_count < 0 || (*pool).payload_count > IR_WIDE_NUMERIC_MAX_PAYLOADS {
+        return IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY
+    }
+    if (*pool).limb_count < 0 || (*pool).limb_count > IR_WIDE_NUMERIC_MAX_LIMBS {
+        return IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY
+    }
+
+    var expected_start: i64 = 0
+    var payload_id: i64 = 0
+    while payload_id < (*pool).payload_count {
+        let entry = (*pool).entries[payload_id as usize]
+        let required = ir_wide_numeric_required_limb_count(entry.format_id)
+        if required == 0 { return IR_WIDE_NUMERIC_ERR_UNKNOWN_FORMAT }
+        if entry.limb_count != required { return IR_WIDE_NUMERIC_ERR_LIMB_COUNT }
+        if entry.limb_start != expected_start { return IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY }
+        if entry.limb_start < 0 || entry.limb_start + entry.limb_count > (*pool).limb_count {
+            return IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY
+        }
+        expected_start = entry.limb_start + entry.limb_count
+        payload_id = payload_id + 1
+    }
+    if expected_start != (*pool).limb_count { return IR_WIDE_NUMERIC_ERR_CORRUPT_ENTRY }
+    IR_WIDE_NUMERIC_OK
+}
+
+pub fn ir_wide_numeric_payload_entry_checked(
+    pool: &IrWideNumericPayloadPool,
+    payload_id: i64,
+) -> (IrWideNumericPayloadEntry, i64) with Mut, Panic, Div {
+    if payload_id < 0 || payload_id >= (*pool).payload_count {
+        return (ir_empty_wide_numeric_payload_entry(), IR_WIDE_NUMERIC_ERR_PAYLOAD_ID)
+    }
+    let validation = ir_wide_numeric_payload_pool_validate(pool)
+    if validation != IR_WIDE_NUMERIC_OK {
+        return (ir_empty_wide_numeric_payload_entry(), validation)
+    }
+    ((*pool).entries[payload_id as usize], IR_WIDE_NUMERIC_OK)
+}
+
+pub fn ir_wide_numeric_payload_limb_checked(
+    pool: &IrWideNumericPayloadPool,
+    payload_id: i64,
+    limb_index: i64,
+) -> (i64, i64) with Mut, Panic, Div {
+    let (entry, status) = ir_wide_numeric_payload_entry_checked(pool, payload_id)
+    if status != IR_WIDE_NUMERIC_OK { return (0, status) }
+    if limb_index < 0 || limb_index >= entry.limb_count {
+        return (0, IR_WIDE_NUMERIC_ERR_LIMB_INDEX)
+    }
+    ((*pool).limbs[(entry.limb_start + limb_index) as usize], IR_WIDE_NUMERIC_OK)
+}


### PR DESCRIPTION
## Summary

- add a standalone compiler-owned raw wide-numeric payload arena
- resolve numeric format descriptors by opaque `format_id`
- store f128 as exactly 2 raw limbs and f256 as exactly 4 raw limbs, limb 0 least-significant
- prevalidate the entire arena before append so corrupt state fails closed before mutation
- preserve distinct payload identities for equal bit patterns
- add an executable probe and a containment gate

## Stack

This PR is intentionally stacked on #929 and targets `codex/f128-v0-format-identity-20260714`.

## Claim boundary

This slice proves only:

`standalone_compiler_owned_raw_payload_arena`

It does **not** attach payload IDs to `IrModule` or `IrInstr`, enable source values, define arithmetic or rounding, serialize SOIR, choose a wire endianness, cross ABI/runtime boundaries, or lower to hardware.

## Evidence

- executable V0-B gate: PASS
- post-rebase gate log SHA-256: `edac5750b5422975982f4bff7d1b05f6c706437269cc31b6db13d18243f9309d`
- bootstrap seed SHA-256: `d20605847fac0f6e86c3c518300d19db06eece295b596d87cc8fd5e59bd0c978`
- V0-A structural gate: PASS
- aggregate Madaros source check: PASS
- `git diff --check` and gate `bash -n`: PASS
- adversarial review: SAFE TO COMMIT

The probe proves complete descriptor lookup, exact high-bit limb roundtrip, append-only non-interned identities, a valid 256 x f256 = 1024-limb full arena, unchanged rejection of the 257th append, and deterministic rejection of malformed IDs, spans, counts, formats, logical length, and pre-corrupt state.

No LLM offload was required for this raw-storage-only lane; the unchanged numeric descriptor values were already reviewed by xAI in #929.