### PR TITLE
test(signal): run-proof for signal::filter DSP filters (coordinated disjoint lane)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2785,3 +2785,7 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - life_table = **PASS**: n'ᵢ=nᵢ−wᵢ/2, qᵢ=dᵢ/n'ᵢ, Ŝ=Πpᵢ (Cutler-Ederer) exact; 3-interval example (0.9, 0.8047, 0.7231) verified.
 - Theme: survival-analysis extensions — completes the survival family (km, logrank, exp_survival + Nelson-Aalen, RMST, life-table). All deterministic, fully hand-derivable. #852-safe: sort-free walks / cumulative products, no nested data-array calls. Suite runner: 55 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-dUWR1L/`, `/tmp/llm-offload-K5q4eh/`, `/tmp/llm-offload-vpkpHX/`.
+
+## 2026-07-14 — math-review: signal::filter run-proof
+- Files: `tests/stdlib/signal/test_filter_stdlib.sio`, `examples/signal/filter_report.sio` (no source edited).
+- Provider: xAI/Grok 4.3 = PASS. FIR MA(4) DC gain=Σh=1 + impulse response = h (0.25×4 then 0); IIR1 bilinear lowpass DC gain(z=1)=1 (const 2→2); IIR1 highpass DC gain(z=1)=0 (DC blocked). Default Madaros. SIGNAL_FILTER_GATE_OK.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 970
-- Repo-backed topics: 820
+- Total governed topics: 974
+- Repo-backed topics: 824
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 570
+- Authority count `repo_only`: 574
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 589 topics
+- A2: 593 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -785,6 +785,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-14-linalg-vertical | repo_only | docs/superpowers/plans/2026-07-14-linalg-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-prob-vertical | repo_only | docs/superpowers/plans/2026-07-14-prob-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-signal-fft-vertical | repo_only | docs/superpowers/plans/2026-07-14-signal-fft-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-14-signal-filter-vertical | repo_only | docs/superpowers/plans/2026-07-14-signal-filter-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-special-erf-vertical | repo_only | docs/superpowers/plans/2026-07-14-special-erf-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof | repo_only | docs/superpowers/plans/2026-07-14-stats-validation-runproof.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-units-vertical | repo_only | docs/superpowers/plans/2026-07-14-units-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -794,6 +795,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.specs.2026-07-14-linalg-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-linalg-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-prob-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-prob-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-signal-fft-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-signal-fft-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-14-signal-filter-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design | repo_only | docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-units-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-units-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17361,6 +17361,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-14-signal-filter-vertical",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-14-signal-filter-vertical.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.plans.2026-07-14-special-erf-vertical",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/plans/2026-07-14-special-erf-vertical.md",
@@ -17548,6 +17571,29 @@
       "topic_id": "repo.docs.superpowers.specs.2026-07-14-signal-fft-vertical-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-14-signal-fft-vertical-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-14-signal-filter-vertical-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-07-14-signal-filter-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-signal-filter-vertical.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-14-signal-filter-vertical
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-14-signal-filter-vertical
+-->
+
 # signal::filter Run-Proof — Plan
 > Default Madaros (self-contained, by-reference API). No source edits (disjoint). Spec: docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md.
 1. Run-proof `tests/stdlib/signal/test_filter_stdlib.sio`: MA DC gain 1 + impulse 0.25×4; IIR1 lowpass DC gain 1; IIR1 highpass DC gain 0. `FILTER_STDLIB_OK`.

--- a/docs/superpowers/plans/2026-07-14-signal-filter-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-signal-filter-vertical.md
@@ -1,0 +1,5 @@
+# signal::filter Run-Proof — Plan
+> Default Madaros (self-contained, by-reference API). No source edits (disjoint). Spec: docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md.
+1. Run-proof `tests/stdlib/signal/test_filter_stdlib.sio`: MA DC gain 1 + impulse 0.25×4; IIR1 lowpass DC gain 1; IIR1 highpass DC gain 0. `FILTER_STDLIB_OK`.
+2. Example `examples/signal/filter_report.sio` + gate `scripts/signal_filter_gate.sh` → `SIGNAL_FILTER_GATE_OK`.
+3. math-review; governance sync; PR to main (rebase-on-conflict).

--- a/docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-14-signal-filter-vertical-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-14-signal-filter-vertical-design
+-->
+
 # Design — Harden the signal::filter vertical (coordinated, disjoint)
 **Date:** 2026-07-14 · no compiler changes · `signal/` cold (no open PR touching signal/special/math). By-reference
 API (`&!filter`, `&[f64;512]`) is cross-module-safe. Adds run-proof/example/gate; only `filter.sio` header optional (none needed). EN-UK.

--- a/docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md
@@ -1,0 +1,18 @@
+# Design — Harden the signal::filter vertical (coordinated, disjoint)
+**Date:** 2026-07-14 · no compiler changes · `signal/` cold (no open PR touching signal/special/math). By-reference
+API (`&!filter`, `&[f64;512]`) is cross-module-safe. Adds run-proof/example/gate; only `filter.sio` header optional (none needed). EN-UK.
+
+## State
+`stdlib/signal/filter.sio` — self-contained, green, native-compiles under **default Madaros**. Biosignal
+digital filters: IIR1 (lowpass/highpass), IIR2 (notch/bandpass), FIR64 (moving average). Filters passed by
+`&!`; batch via `&[f64;512]`/`&![f64;512]`. Verified externally: MA(4) DC gain 1, impulse 0.25×4, IIR1
+lowpass const 2→2, highpass const 2→0.
+
+## Run-proof (known DSP properties)
+- **FIR MA(4)**: DC gain 1 (const 1 → 1); impulse response 0.25,0.25,0.25,0.25,0.
+- **IIR1 lowpass** (fc=10, fs=1000): DC gain 1 (const 2 → 2 at steady state).
+- **IIR1 highpass**: DC gain 0 (const 2 → 0; blocks DC).
+
+## Layout / verification
+`tests/stdlib/signal/test_filter_stdlib.sio`, `examples/signal/filter_report.sio`,
+`scripts/signal_filter_gate.sh` (default Madaros) → `SIGNAL_FILTER_GATE_OK`. Math-review logged. No source/compiler edits.

--- a/examples/signal/filter_report.sio
+++ b/examples/signal/filter_report.sio
@@ -1,0 +1,22 @@
+// Biosignal filtering demo with stdlib signal::filter.
+// A DC baseline (2.0) + alternating +/-1 ripple; lowpass smooths the ripple, highpass removes the DC.
+use signal::filter::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("=== signal::filter (fs=1000 Hz, fc=10 Hz) ===\n")
+    var lp = iir1_lowpass(10.0, 1000.0)
+    var hp = iir1_highpass(10.0, 1000.0)
+    var lpv = 0.0
+    var hpv = 0.0
+    var i: i64 = 0
+    while i < 2000 {
+        let ripple = if (i % 2) == 0 { 1.0 } else { 0.0 - 1.0 }
+        let x = 2.0 + ripple
+        lpv = iir1_step(&!lp, x)
+        hpv = iir1_step(&!hp, x)
+        i = i + 1
+    }
+    print("input  = 2.0 +/- 1.0 ripple\n")
+    print("lowpass (smoothed, ~DC 2.0) = "); println(lpv)
+    print("highpass (DC removed, ~0)   = "); println(hpv)
+    return 0
+}

--- a/scripts/signal_filter_gate.sh
+++ b/scripts/signal_filter_gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check filter.sio =="; $SOUC check stdlib/signal/filter.sio || fail=1
+echo "== run-proof =="
+if $SOUC compile tests/stdlib/signal/test_filter_stdlib.sio -o "$OUT/tf.elf"; then
+  "$OUT/tf.elf" | grep -q "FILTER_STDLIB_OK" || { echo "FAIL: assertions"; fail=1; }
+else echo "FAIL: compile"; fail=1; fi
+echo "== example =="
+if $SOUC compile examples/signal/filter_report.sio -o "$OUT/fr.elf"; then "$OUT/fr.elf" >/dev/null || { echo "FAIL: example"; fail=1; }
+else echo "FAIL: example compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "SIGNAL_FILTER_GATE_OK"
+exit $fail

--- a/tests/stdlib/signal/test_filter_stdlib.sio
+++ b/tests/stdlib/signal/test_filter_stdlib.sio
@@ -1,0 +1,41 @@
+// Run-proof for stdlib signal::filter against known DSP filter properties.
+// Self-contained, by-reference API -> default Madaros. Inline in main.
+use signal::filter::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // (1) FIR moving average, 4 taps: DC gain 1 (constant 1 -> steady 1)
+    var fir = fir64_ma(4)
+    var y = 0.0
+    var i: i64 = 0
+    while i < 20 { y = fir64_step(&!fir, 1.0); i = i + 1 }
+    if (if y > 1.0 { y-1.0 } else { 1.0-y }) >= 1.0e-9 { print("FAIL ma_dc\n"); return 1 }
+
+    // (2) MA(4) impulse response: [1,0,0,...] -> 0.25,0.25,0.25,0.25,0
+    var f2 = fir64_ma(4)
+    let r0 = fir64_step(&!f2, 1.0)
+    let r1 = fir64_step(&!f2, 0.0)
+    let r3 = fir64_step(&!f2, 0.0)
+    let r4b = fir64_step(&!f2, 0.0)   // 4th tap still 0.25
+    let r5 = fir64_step(&!f2, 0.0)    // 5th: impulse left window -> 0
+    if (if r0 > 0.25 { r0-0.25 } else { 0.25-r0 }) >= 1.0e-9 { print("FAIL imp0\n"); return 2 }
+    if (if r1 > 0.25 { r1-0.25 } else { 0.25-r1 }) >= 1.0e-9 { print("FAIL imp1\n"); return 3 }
+    if (if r4b > 0.25 { r4b-0.25 } else { 0.25-r4b }) >= 1.0e-9 { print("FAIL imp3\n"); return 4 }
+    if r5 >= 1.0e-9 { print("FAIL imp5\n"); return 5 }
+
+    // (3) IIR1 lowpass: DC gain 1 (constant 2 -> converges to 2)
+    var lp = iir1_lowpass(10.0, 1000.0)
+    var z = 0.0
+    i = 0
+    while i < 5000 { z = iir1_step(&!lp, 2.0); i = i + 1 }
+    if (if z > 2.0 { z-2.0 } else { 2.0-z }) >= 1.0e-4 { print("FAIL lp_dc\n"); return 6 }
+
+    // (4) IIR1 highpass: DC gain 0 (constant 2 -> converges to 0, blocks DC)
+    var hp = iir1_highpass(10.0, 1000.0)
+    var w = 0.0
+    i = 0
+    while i < 5000 { w = iir1_step(&!hp, 2.0); i = i + 1 }
+    if (if w > 0.0 { w } else { 0.0-w }) >= 1.0e-4 { print("FAIL hp_dc\n"); return 7 }
+
+    print("FILTER_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
Tenth playbook vertical. Independent run-proof for self-contained `signal::filter` (biosignal IIR/FIR, native under **default Madaros**, by-reference API — cross-module-safe): FIR MA DC gain 1 + impulse response 0.25×4; IIR1 lowpass DC gain 1; IIR1 highpass blocks DC. Disjoint (`signal/` cold, no open PR). No source edits. Gate `SIGNAL_FILTER_GATE_OK`; math-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)