### PR TITLE
feat(stats): rank/ordinal association — kendall_tau, goodman_kruskal, somers_d

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2785,3 +2785,12 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - life_table = **PASS**: n'ᵢ=nᵢ−wᵢ/2, qᵢ=dᵢ/n'ᵢ, Ŝ=Πpᵢ (Cutler-Ederer) exact; 3-interval example (0.9, 0.8047, 0.7231) verified.
 - Theme: survival-analysis extensions — completes the survival family (km, logrank, exp_survival + Nelson-Aalen, RMST, life-table). All deterministic, fully hand-derivable. #852-safe: sort-free walks / cumulative products, no nested data-array calls. Suite runner: 55 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-dUWR1L/`, `/tmp/llm-offload-K5q4eh/`, `/tmp/llm-offload-vpkpHX/`.
+
+## 2026-07-14 — math-review: stats::kendall_tau, stats::goodman_kruskal, stats::somers_d
+- Files (all new): `stdlib/stats/kendall_tau.sio` (Kendall τ_a/τ_b + no-tie z-test), `stdlib/stats/goodman_kruskal.sio` (γ=(C−D)/(C+D) + Wald z), `stdlib/stats/somers_d.sio` (asymmetric Somers' D both directions). Provider: xAI/Grok 4.3.
+- kendall_tau = **PASS**: τ_a, tie-corrected τ_b, Var₀(S)=n(n−1)(2n+5)/18 z-test all correct; {1,3,2,4}→τ_a=0.667, z=1.359 (note: initial test constant z=1.358601 was a hand-arithmetic error — correct value 4/√8.666667=1.358732; caught by the failing assertion, fixed).
+- goodman_kruskal = **PASS**: γ + SE(γ)=√(4CD/(C+D)³) Wald z verified.
+- somers_d = **PASS**: D(Y|X)=(C−D)/(C+D+Tx), D(X|Y)=(C−D)/(C+D+Ty), and the 2·AUC−1 identity for binary Y confirmed.
+- **Bug found & fixed**: the tie-counting branches originally assigned tied-on-X pairs to Ty and vice-versa. Masked in kendall (τ_b denominator √((C+D+Tx)(C+D+Ty)) is symmetric in Tx/Ty) but surfaced in somers_d where the directions are distinct (D(Y|X) test gave 0.667 instead of 1.0). Fixed the labeling in both modules.
+- Theme: rank / ordinal association — complements the Pearson/Spearman correlation module. All O(n²) pair scans, scalar returns, #852-safe. Suite runner: 58 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-2RCSmH/`, `/tmp/llm-offload-sD8vnn/`, `/tmp/llm-offload-BerYTX/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -64,6 +64,9 @@ MODULES=(
   stdlib/stats/nelson_aalen.sio
   stdlib/stats/rmst.sio
   stdlib/stats/life_table.sio
+  stdlib/stats/kendall_tau.sio
+  stdlib/stats/goodman_kruskal.sio
+  stdlib/stats/somers_d.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -826,6 +826,37 @@ Interval-grouped survival for count-per-interval data: with the withdrawal-
 adjusted risk set `n'ᵢ=nᵢ−wᵢ/2`, `qᵢ=dᵢ/n'ᵢ` and `Ŝ=Πpᵢ` (Cutler-Ederer).
 Validated: 3-interval example → S=0.9, 0.8047, 0.7231; hazard(i1)=0.1059.
 
+### `stats::kendall_tau` — Kendall's rank correlation
+
+| Function | Signature |
+|---|---|
+| `kendall_tau` | `pub fn kendall_tau(x: &[f64; 256], y: &[f64; 256], n: i32) -> KendallResult with Mut, Div, Panic` |
+
+Concordance-based rank correlation robust to outliers and monotone non-linear
+relationships: τ_a=(C−D)/(n(n−1)/2), the tie-corrected τ_b, and the no-tie null
+z-test. Validated: perfect concordance → τ=1; {1,3,2,4} → τ_a=0.667, z=1.359;
+ties → τ_a=0.667 but τ_b=0.8; perfect discordance → τ=−1.
+
+### `stats::goodman_kruskal` — Goodman-Kruskal gamma
+
+| Function | Signature |
+|---|---|
+| `goodman_kruskal` | `pub fn goodman_kruskal(x: &[f64; 256], y: &[f64; 256], n: i32) -> GammaResult with Mut, Div, Panic` |
+
+Ordinal association ignoring tied pairs entirely: γ=(C−D)/(C+D) with the
+pair-count Wald z. Validated: {1,3,2,4} → γ=0.667; ties (using only untied
+pairs) → γ=1; perfect discordance → γ=−1.
+
+### `stats::somers_d` — Somers' D (asymmetric)
+
+| Function | Signature |
+|---|---|
+| `somers_d` | `pub fn somers_d(x: &[f64; 256], y: &[f64; 256], n: i32) -> SomersResult with Mut, Div, Panic` |
+
+Asymmetric ordinal association: D(Y|X)=(C−D)/(C+D+Tx) penalises ties on the
+predictor, so for a binary Y it equals 2·AUC−1. Validated: no ties → D=0.667;
+ties → D(Y|X)=D(X|Y)=0.8; binary Y with perfect separation → D(Y|X)=1 (AUC=1).
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -885,6 +916,9 @@ use stats::autocorr::{LBResult, acf, ljung_box}
 use stats::nelson_aalen::{NAResult, nelson_aalen}
 use stats::rmst::{rmst}
 use stats::life_table::{life_table_survival, life_table_hazard}
+use stats::kendall_tau::{KendallResult, kendall_tau}
+use stats::goodman_kruskal::{GammaResult, goodman_kruskal}
+use stats::somers_d::{SomersResult, somers_d}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/goodman_kruskal.sio
+++ b/stdlib/stats/goodman_kruskal.sio
@@ -1,0 +1,183 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/goodman_kruskal.sio — Goodman-Kruskal gamma
+//
+// The ordinal association measure that ignores tied pairs entirely — the
+// proportion by which concordant pairs exceed discordant among the *untied*
+// pairs:
+//
+//   goodman_kruskal(x, y, n) -> GammaResult
+//
+//   γ = (C − D) / (C + D)   ∈ [−1, 1].
+// A null Wald test uses the pair-count standard error
+//   SE(γ) = √( 4·C·D / (C+D)³ ) = (2/(C+D))·√( C·D/(C+D) ),  z = γ/SE,
+// which is the large-sample SE under H₀: γ = 0 (Goodman & Kruskal 1963).
+//
+// Pure Sounio: an O(n²) pair scan; inline sqrt/erf; no external dependency, no
+// nested data-array calls.
+//
+// References:
+//   Goodman & Kruskal (1954, 1963) JASA 49:732, 58:310.
+
+module stats::goodman_kruskal
+
+fn gk_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn gk_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / gk_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn gk_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * gk_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn gk_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - gk_erf(z * INV_SQRT2))
+}
+
+pub struct GammaResult {
+    pub gamma: f64,
+    pub z: f64,          // Wald z for H0: gamma = 0
+    pub p: f64,          // two-sided p
+    pub concordant: i64,
+    pub discordant: i64,
+}
+
+/// Goodman-Kruskal gamma between x and y.
+///
+/// Parâmetros: x, y — paired ordinal data; n — size (2..256).
+/// Retorno: GammaResult (gamma, z, p, C, D).
+/// Referências: Goodman & Kruskal (1954, 1963).
+pub fn goodman_kruskal(x: &[f64; 256], y: &[f64; 256], n: i32) -> GammaResult with Mut, Div, Panic {
+    if n < 2 { return GammaResult { gamma: 0.0, z: 0.0, p: 1.0, concordant: 0, discordant: 0 } }
+    var c = 0
+    var d = 0
+    var i = 0
+    while i < n {
+        var j = i + 1
+        while j < n {
+            let dx = x[j as usize] - x[i as usize]
+            let dy = y[j as usize] - y[i as usize]
+            if dx != 0.0 && dy != 0.0 {
+                if (dx > 0.0) == (dy > 0.0) { c = c + 1 } else { d = d + 1 }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let cd = (c + d) as f64
+    if cd <= 0.0 { return GammaResult { gamma: 0.0, z: 0.0, p: 1.0, concordant: c as i64, discordant: d as i64 } }
+    let gamma = ((c - d) as f64) / cd
+    // consistent large-sample SE: sqrt( (1 - gamma^2)^2 / (C+D) · (n(n-1)/... ))
+    // simple form SE = (2/(C+D)) sqrt(C*D/(C+D)); z = gamma/SE
+    let cf = c as f64
+    let df = d as f64
+    var z = 0.0
+    if cf > 0.0 && df > 0.0 {
+        let se = (2.0 / cd) * gk_sqrt(cf * df / cd)
+        if se > 0.0 { z = gamma / se }
+    } else {
+        z = 1.0e9   // perfect association -> effectively infinite z
+    }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    var p = 2.0 * gk_normal_sf(az)
+    if p < 0.0 { p = 0.0 }
+    return GammaResult { gamma: gamma, z: z, p: p, concordant: c as i64, discordant: d as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// partial x={1,2,3,4}, y={1,3,2,4}: C=5,D=1 -> gamma=(5-1)/(5+1)=0.666667.
+fn test_partial() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=1.0; y[1]=3.0; y[2]=2.0; y[3]=4.0
+    let r = goodman_kruskal(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.gamma, 0.666667, 1.0e-5)) && ok
+    ok = check(2, r.concordant == 5) && ok
+    ok = check(3, r.discordant == 1) && ok
+    return ok
+}
+
+// with ties, gamma still uses only untied pairs. x={1,1,2,3}, y={1,2,2,3}.
+// untied pairs: C=4, D=0 -> gamma=1 (perfect on untied pairs).
+fn test_ties() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=1.0; y[1]=2.0; y[2]=2.0; y[3]=3.0
+    let r = goodman_kruskal(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.gamma, 1.0, 1.0e-9)) && ok
+    ok = check(11, r.concordant == 4) && ok
+    ok = check(12, r.discordant == 0) && ok
+    return ok
+}
+
+// perfect discordance -> gamma = -1.
+fn test_discordant() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=4.0; y[1]=3.0; y[2]=2.0; y[3]=1.0
+    let r = goodman_kruskal(&x, &y, 4)
+    return check(20, approx(r.gamma, 0.0 - 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_partial() && ok
+    ok = test_ties() && ok
+    ok = test_discordant() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/kendall_tau.sio
+++ b/stdlib/stats/kendall_tau.sio
@@ -1,0 +1,212 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/kendall_tau.sio — Kendall's rank correlation
+//
+// The concordance-based rank correlation, robust to outliers and monotone
+// (non-linear) relationships:
+//
+//   kendall_tau(x, y, n) -> KendallResult
+//
+// Over all n(n−1)/2 pairs, count concordant C and discordant D, with Tx/Ty the
+// pairs tied in only x / only y. Then
+//   τ_a = (C − D)/(n(n−1)/2),
+//   τ_b = (C − D)/√((C+D+Tx)(C+D+Ty)),         (tie-corrected)
+//   S = C − D,  Var₀(S) = n(n−1)(2n+5)/18,  z = S/√Var₀(S)  (no-tie null).
+//
+// Pure Sounio: an O(n²) pair scan; inline sqrt/erf for the normal tail; no
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Kendall (1938) Biometrika 30:81; Kendall & Gibbons, "Rank Correlation".
+
+module stats::kendall_tau
+
+fn kt_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn kt_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / kt_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn kt_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * kt_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn kt_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - kt_erf(z * INV_SQRT2))
+}
+
+pub struct KendallResult {
+    pub tau_a: f64,       // uncorrected tau
+    pub tau_b: f64,       // tie-corrected tau
+    pub s: f64,           // C - D
+    pub z: f64,           // no-tie null z
+    pub p: f64,           // two-sided p
+    pub concordant: i64,
+    pub discordant: i64,
+}
+
+/// Kendall's rank correlation between x and y.
+///
+/// Parâmetros: x, y — paired data; n — size (2..256).
+/// Retorno: KendallResult (tau_a, tau_b, S, z, p, C, D).
+/// Referências: Kendall (1938).
+pub fn kendall_tau(x: &[f64; 256], y: &[f64; 256], n: i32) -> KendallResult with Mut, Div, Panic {
+    if n < 2 {
+        return KendallResult { tau_a: 0.0, tau_b: 0.0, s: 0.0, z: 0.0, p: 1.0, concordant: 0, discordant: 0 }
+    }
+    var c = 0
+    var d = 0
+    var tx = 0
+    var ty = 0
+    var i = 0
+    while i < n {
+        var j = i + 1
+        while j < n {
+            let dx = x[j as usize] - x[i as usize]
+            let dy = y[j as usize] - y[i as usize]
+            let sx = if dx > 0.0 { 1 } else { if dx < 0.0 { 0 - 1 } else { 0 } }
+            let sy = if dy > 0.0 { 1 } else { if dy < 0.0 { 0 - 1 } else { 0 } }
+            if sx == 0 && sy == 0 {
+                // tied in both -> excluded from all counts
+            } else {
+                if sx == 0 { tx = tx + 1 }        // tied on X only
+                else {
+                    if sy == 0 { ty = ty + 1 }    // tied on Y only
+                    else {
+                        if sx == sy { c = c + 1 } else { d = d + 1 }
+                    }
+                }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let nf = n as f64
+    let n0 = nf * (nf - 1.0) / 2.0
+    let s = (c - d) as f64
+    var tau_a = 0.0
+    if n0 > 0.0 { tau_a = s / n0 }
+    let cd = (c + d) as f64
+    let denb = kt_sqrt((cd + (tx as f64)) * (cd + (ty as f64)))
+    var tau_b = 0.0
+    if denb > 0.0 { tau_b = s / denb }
+    let var_s = nf * (nf - 1.0) * (2.0 * nf + 5.0) / 18.0
+    var z = 0.0
+    if var_s > 0.0 { z = s / kt_sqrt(var_s) }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * kt_normal_sf(az)
+    return KendallResult { tau_a: tau_a, tau_b: tau_b, s: s, z: z, p: p, concordant: c as i64, discordant: d as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect concordance x={1,2,3,4}, y={1,2,3,4}: C=6,D=0, tau=1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 4 { x[i as usize]=(i+1) as f64; y[i as usize]=(i+1) as f64; i=i+1 }
+    let r = kendall_tau(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.tau_a, 1.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.tau_b, 1.0, 1.0e-9)) && ok
+    ok = check(3, r.concordant == 6) && ok
+    return ok
+}
+
+// partial x={1,2,3,4}, y={1,3,2,4}: C=5,D=1 -> tau_a=4/6=0.666667; S=4.
+// z=S/sqrt(n(n-1)(2n+5)/18)=4/sqrt(8.666667)=4/2.943920=1.358732.
+fn test_partial() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=1.0; y[1]=3.0; y[2]=2.0; y[3]=4.0
+    let r = kendall_tau(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.tau_a, 0.666667, 1.0e-5)) && ok
+    ok = check(11, r.concordant == 5) && ok
+    ok = check(12, r.discordant == 1) && ok
+    ok = check(13, approx(r.z, 1.358732, 1.0e-4)) && ok
+    return ok
+}
+
+// ties: x={1,1,2,3}, y={1,2,2,3}. C=4,D=0,Tx=1,Ty=1.
+// tau_a=4/6=0.666667; tau_b=4/sqrt(5·5)=0.8.
+fn test_ties() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=1.0; y[1]=2.0; y[2]=2.0; y[3]=3.0
+    let r = kendall_tau(&x, &y, 4)
+    var ok = true
+    ok = check(20, approx(r.tau_a, 0.666667, 1.0e-5)) && ok
+    ok = check(21, approx(r.tau_b, 0.8, 1.0e-5)) && ok
+    return ok
+}
+
+// perfect discordance x={1,2,3,4}, y={4,3,2,1}: C=0,D=6, tau=-1.
+fn test_discordant() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=4.0; y[1]=3.0; y[2]=2.0; y[3]=1.0
+    let r = kendall_tau(&x, &y, 4)
+    return check(30, approx(r.tau_a, 0.0 - 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_partial() && ok
+    ok = test_ties() && ok
+    ok = test_discordant() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/somers_d.sio
+++ b/stdlib/stats/somers_d.sio
@@ -1,0 +1,158 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/somers_d.sio — Somers' D (asymmetric ordinal association)
+//
+// The asymmetric rank-association measure: unlike gamma it penalises ties in the
+// dependent variable, and D(Y|X) is directly the rescaled AUC (D = 2·AUC − 1)
+// for a binary outcome:
+//
+//   somers_d(x, y, n) -> SomersResult
+//
+//   D(Y|X) = (C − D) / (C + D + T_x),      (ties on the predictor X)
+//   D(X|Y) = (C − D) / (C + D + T_y),
+// where T_x / T_y are pairs tied on X / Y (but not both). Putting the predictor's
+// ties in the denominator is what makes D(Y|X) = 2·AUC − 1 for a binary Y.
+// Kendall's τ_b is the geometric mean √(D(Y|X)·D(X|Y)).
+//
+// Pure Sounio: an O(n²) pair scan classifying each pair; no external dependency,
+// no nested data-array calls.
+//
+// References:
+//   Somers (1962) Am. Sociol. Rev. 27:799; Newson (2002) Stata J. 2:45.
+
+module stats::somers_d
+
+pub struct SomersResult {
+    pub d_yx: f64,        // Somers' D(Y|X)  (= 2·AUC − 1 for binary Y)
+    pub d_xy: f64,        // Somers' D(X|Y)
+    pub concordant: i64,
+    pub discordant: i64,
+    pub ties_x: i64,      // pairs tied in X only
+    pub ties_y: i64,      // pairs tied in Y only
+}
+
+/// Somers' D between x and y in both asymmetric directions.
+///
+/// Parâmetros: x, y — paired ordinal data; n — size (2..256).
+/// Retorno: SomersResult (d_yx, d_xy, C, D, Tx, Ty).
+/// Referências: Somers (1962).
+pub fn somers_d(x: &[f64; 256], y: &[f64; 256], n: i32) -> SomersResult with Mut, Div, Panic {
+    if n < 2 {
+        return SomersResult { d_yx: 0.0, d_xy: 0.0, concordant: 0, discordant: 0, ties_x: 0, ties_y: 0 }
+    }
+    var c = 0
+    var d = 0
+    var tx = 0
+    var ty = 0
+    var i = 0
+    while i < n {
+        var j = i + 1
+        while j < n {
+            let dx = x[j as usize] - x[i as usize]
+            let dy = y[j as usize] - y[i as usize]
+            let ex = dx == 0.0
+            let ey = dy == 0.0
+            if ex && ey {
+                // tied in both -> excluded
+            } else {
+                if ex { tx = tx + 1 }        // tied on X only
+                else {
+                    if ey { ty = ty + 1 }    // tied on Y only
+                    else {
+                        if (dx > 0.0) == (dy > 0.0) { c = c + 1 } else { d = d + 1 }
+                    }
+                }
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let s = (c - d) as f64
+    let cd = (c + d) as f64
+    // D(Y|X) conditions on the predictor X: its ties (Tx) go in the denominator.
+    var d_yx = 0.0
+    let den_yx = cd + (tx as f64)
+    if den_yx > 0.0 { d_yx = s / den_yx }
+    var d_xy = 0.0
+    let den_xy = cd + (ty as f64)
+    if den_xy > 0.0 { d_xy = s / den_xy }
+    return SomersResult { d_yx: d_yx, d_xy: d_xy, concordant: c as i64, discordant: d as i64, ties_x: tx as i64, ties_y: ty as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// no ties x={1,2,3,4}, y={1,3,2,4}: C=5,D=1,Tx=Ty=0.
+// D(Y|X)=D(X|Y)=(5-1)/6=0.666667.
+fn test_no_ties() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=1.0; y[1]=3.0; y[2]=2.0; y[3]=4.0
+    let r = somers_d(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.d_yx, 0.666667, 1.0e-5)) && ok
+    ok = check(2, approx(r.d_xy, 0.666667, 1.0e-5)) && ok
+    return ok
+}
+
+// ties: x={1,1,2,3}, y={1,2,2,3}. C=4,D=0,Tx=1,Ty=1.
+// D(Y|X)=4/(4+1)=0.8; D(X|Y)=4/(4+1)=0.8. tau_b = sqrt(0.8·0.8)=0.8 (matches kendall).
+fn test_ties() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=1.0; y[1]=2.0; y[2]=2.0; y[3]=3.0
+    let r = somers_d(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.d_yx, 0.8, 1.0e-5)) && ok
+    ok = check(11, approx(r.d_xy, 0.8, 1.0e-5)) && ok
+    ok = check(12, r.ties_x == 1) && ok
+    ok = check(13, r.ties_y == 1) && ok
+    return ok
+}
+
+// binary Y -> D(Y|X) = 2·AUC - 1. x scores, y in {0,1}, perfect separation:
+// x={1,2,3,4}, y={0,0,1,1}. all cross-pairs concordant: C=4, D=0, and pairs
+// within each y-level are tied in Y (Ty). AUC=1 -> D(Y|X)=1.
+fn test_auc() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=0.0; y[1]=0.0; y[2]=1.0; y[3]=1.0
+    let r = somers_d(&x, &y, 4)
+    // cross pairs (one y=0, one y=1): 4 of them, all concordant. within-level: 2 tied in Y.
+    var ok = true
+    ok = check(20, approx(r.d_yx, 1.0, 1.0e-9)) && ok
+    ok = check(21, r.ties_y == 2) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_no_ties() && ok
+    ok = test_ties() && ok
+    ok = test_auc() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three concordance-based ordinal-association measures for the epistemic-statistics suite, bringing the runner to **58 modules**. These complement the existing Pearson/Spearman `correlation` module and are heavily used in epidemiology (Somers' D relates directly to AUC). Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | Measure | Denominator |
|---|---|---|
| `stats::kendall_tau` | τ_a, τ_b (tie-corrected) + z | n(n−1)/2 · / √((C+D+Tx)(C+D+Ty)) |
| `stats::goodman_kruskal` | γ = (C−D)/(C+D) | untied pairs only |
| `stats::somers_d` | D(Y|X), D(X|Y) | C+D+Tx · / · C+D+Ty |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Kendall: perfect → τ=1; {1,3,2,4} → τ_a=0.667, z=1.359; ties → τ_a=0.667 but τ_b=0.8; discordant → τ=−1.
  - Gamma: {1,3,2,4} → γ=0.667; ties (untied pairs only) → γ=1; discordant → γ=−1.
  - Somers: no ties → D=0.667; ties → D(Y|X)=D(X|Y)=0.8; **binary Y, perfect separation → D(Y|X)=1 (= 2·AUC−1)**.
- Full suite selftest: **58 modules + 7 demos ALL GREEN** under `lean_single`.

## Bug found & fixed during development

Two things worth noting, both caught by the derivable-values discipline:

1. **Tie-labeling bug**: the pair tie-counting branches assigned tied-on-X pairs to `Ty` and vice-versa. This was *masked* in `kendall_tau` because τ_b's denominator `√((C+D+Tx)(C+D+Ty))` is symmetric in Tx/Ty, but it *surfaced* in `somers_d` where the two directions are distinct (the binary-Y AUC test returned 0.667 instead of 1.0). Fixed in both modules.
2. **Bad hand constant**: a Kendall z test constant was hand-mis-computed (1.358601 instead of the correct 4/√8.666667 = 1.358732); the failing assertion caught it — the implementation was right.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS) and the bug notes.