### PR TITLE
feat(stats): variance-homogeneity tests — bartlett, levene, var_ftest

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2794,3 +2794,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - **Bug found & fixed**: the tie-counting branches originally assigned tied-on-X pairs to Ty and vice-versa. Masked in kendall (τ_b denominator √((C+D+Tx)(C+D+Ty)) is symmetric in Tx/Ty) but surfaced in somers_d where the directions are distinct (D(Y|X) test gave 0.667 instead of 1.0). Fixed the labeling in both modules.
 - Theme: rank / ordinal association — complements the Pearson/Spearman correlation module. All O(n²) pair scans, scalar returns, #852-safe. Suite runner: 58 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-2RCSmH/`, `/tmp/llm-offload-sD8vnn/`, `/tmp/llm-offload-BerYTX/`.
+
+## 2026-07-14 — math-review: stats::bartlett, stats::levene, stats::var_ftest
+- Files (all new): `stdlib/stats/bartlett.sio` (Bartlett homogeneity-of-variance χ²), `stdlib/stats/levene.sio` (Levene/Brown-Forsythe F-test via ANOVA on abs deviations, mean/median centering), `stdlib/stats/var_ftest.sio` (two-sample variance F-test). Provider: xAI/Grok 4.3.
+- bartlett = **PASS**: pooled variance, χ² numerator + correction factor C, χ² tail all match; worked example (6.25, χ²=1.5868) exact.
+- levene = **PASS**: W=(df2/df1)(between/within) ~ F(k−1,N−k), mean/median centering, F tail via incomplete beta all correct; W=2.0571 verified.
+- var_ftest = **PASS**: F=s1²/s2², two-sided p=2·min(cdf,1−cdf), F-CDF via I_x(d1/2,d2/2); F(4,4) at 0.25 → p=0.208 exact. Reviewer flagged the inline exp/ln/betacf helpers as bounded-precision without proven error bounds at extreme args — a general property of every inline special function in the suite; reviewer confirms "all downstream statistical claims remain valid." Not a defect; sufficient for the tested tolerances.
+- Theme: homogeneity-of-variance / homoscedasticity tests — completes the parametric-assumption-checking trio (normality, independence, now equal variance). All scalar/small-array, #852-safe. Suite runner: 61 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-orKL2v/`, `/tmp/llm-offload-2oDw1A/`, `/tmp/llm-offload-5aKJEh/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -67,6 +67,9 @@ MODULES=(
   stdlib/stats/kendall_tau.sio
   stdlib/stats/goodman_kruskal.sio
   stdlib/stats/somers_d.sio
+  stdlib/stats/bartlett.sio
+  stdlib/stats/levene.sio
+  stdlib/stats/var_ftest.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -857,6 +857,36 @@ Asymmetric ordinal association: D(Y|X)=(C−D)/(C+D+Tx) penalises ties on the
 predictor, so for a binary Y it equals 2·AUC−1. Validated: no ties → D=0.667;
 ties → D(Y|X)=D(X|Y)=0.8; binary Y with perfect separation → D(Y|X)=1 (AUC=1).
 
+### `stats::bartlett` — Bartlett's test for equal variance
+
+| Function | Signature |
+|---|---|
+| `bartlett` | `pub fn bartlett(values: &[f64; 256], sizes: &[i32; 16], k: i32) -> BartlettResult with Mut, Div, Panic` |
+
+Homogeneity-of-variance test across k consecutive-block groups (powerful under
+normality): `χ²=[(N−k)ln(s_p²)−Σ(n_i−1)ln(s_i²)]/C ~ χ²(k−1)`. Validated:
+{1..5} vs {2,4..10} → pooled 6.25, χ²=1.5868, df=1; equal-spread → χ²=0.
+
+### `stats::levene` — Levene / Brown-Forsythe test
+
+| Function | Signature |
+|---|---|
+| `levene` | `pub fn levene(values: &[f64; 256], sizes: &[i32; 16], k: i32, center: i32) -> LeveneResult with Mut, Div, Panic` |
+
+The distribution-robust variance test: one-way ANOVA on absolute deviations from
+each group's centre (`center` = 0 mean → Levene, 1 median → Brown-Forsythe).
+`W ~ F(k−1, N−k)`. Validated: worked example → W=2.0571 (both centerings on
+symmetric data); equal-spread → W=0.
+
+### `stats::var_ftest` — two-sample variance F-test
+
+| Function | Signature |
+|---|---|
+| `var_ftest` | `pub fn var_ftest(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> VarFResult with Mut, Div, Panic` |
+
+The classical variance-ratio test `F=s₁²/s₂² ~ F(n₁−1,n₂−1)` with a two-sided
+p-value. Validated: var 2.5 vs 10 → F=0.25, p=0.208; equal variances → F=1, p=1.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -919,6 +949,9 @@ use stats::life_table::{life_table_survival, life_table_hazard}
 use stats::kendall_tau::{KendallResult, kendall_tau}
 use stats::goodman_kruskal::{GammaResult, goodman_kruskal}
 use stats::somers_d::{SomersResult, somers_d}
+use stats::bartlett::{BartlettResult, bartlett}
+use stats::levene::{LeveneResult, levene}
+use stats::var_ftest::{VarFResult, var_ftest}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/bartlett.sio
+++ b/stdlib/stats/bartlett.sio
@@ -1,0 +1,242 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bartlett.sio — Bartlett's test for homogeneity of variance
+//
+// Tests whether k groups share a common variance (the homoscedasticity
+// assumption behind ANOVA), under the assumption of normal data:
+//
+//   bartlett(values, sizes, k) -> BartlettResult    (groups = consecutive blocks)
+//
+// With group variances s_i², pooled s_p² = Σ(n_i−1)s_i²/(N−k),
+//   χ² = [ (N−k)·ln(s_p²) − Σ(n_i−1)·ln(s_i²) ] / C,
+//   C  = 1 + ( Σ 1/(n_i−1) − 1/(N−k) ) / (3(k−1)),   df = k−1.
+// Bartlett is powerful when normality holds but sensitive to departures from it
+// (use Levene / Brown-Forsythe otherwise).
+//
+// Pure Sounio: one pass per group for the variances; inline ln/exp + Lanczos
+// log-gamma & incomplete gamma for the χ² tail. No nested data-array calls.
+//
+// References:
+//   Bartlett (1937) Proc. R. Soc. A 160:268.
+
+module stats::bartlett
+
+fn bt_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / bt_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn bt_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn bt_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * bt_ln(tt) - tt + bt_ln(a)
+}
+
+fn bt_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * bt_exp(0.0 - x + s * bt_ln(x) - bt_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = bt_exp(0.0 - x + s * bt_ln(x) - bt_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn bt_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    if df <= 0.0 { return 1.0 }
+    return 1.0 - bt_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct BartlettResult {
+    pub chi2: f64,
+    pub df: i64,
+    pub p: f64,
+    pub pooled_var: f64,
+}
+
+/// Bartlett's test for equal variances across k consecutive-block groups.
+///
+/// Parâmetros: values — concatenated group data; sizes — per-group n (>=2);
+///             k — number of groups (2..16).
+/// Retorno: BartlettResult (chi2, df, p, pooled_var).
+/// Referências: Bartlett (1937).
+pub fn bartlett(values: &[f64; 256], sizes: &[i32; 16], k: i32) -> BartlettResult with Mut, Div, Panic {
+    if k < 2 || k > 16 { return BartlettResult { chi2: 0.0, df: 0, p: 1.0, pooled_var: 0.0 } }
+    var off = 0
+    var nk = 0.0            // N - k = Σ(n_i - 1)
+    var sum_dfvar = 0.0     // Σ(n_i-1)·s_i²
+    var sum_df_lnvar = 0.0  // Σ(n_i-1)·ln(s_i²)
+    var sum_inv = 0.0       // Σ 1/(n_i-1)
+    var g = 0
+    while g < k {
+        let ni = sizes[g as usize]
+        if ni < 2 { return BartlettResult { chi2: 0.0, df: 0, p: 1.0, pooled_var: 0.0 } }
+        let nif = ni as f64
+        var s = 0.0
+        var a = 0
+        while a < ni { s = s + values[(off + a) as usize]; a = a + 1 }
+        let mean = s / nif
+        var ss = 0.0
+        var b = 0
+        while b < ni {
+            let dv = values[(off + b) as usize] - mean
+            ss = ss + dv * dv
+            b = b + 1
+        }
+        let dfi = nif - 1.0
+        let vi = ss / dfi
+        nk = nk + dfi
+        sum_dfvar = sum_dfvar + dfi * vi
+        sum_df_lnvar = sum_df_lnvar + dfi * bt_ln(vi)
+        sum_inv = sum_inv + 1.0 / dfi
+        off = off + ni
+        g = g + 1
+    }
+    if nk <= 0.0 { return BartlettResult { chi2: 0.0, df: 0, p: 1.0, pooled_var: 0.0 } }
+    let sp2 = sum_dfvar / nk
+    let kf = k as f64
+    let num = nk * bt_ln(sp2) - sum_df_lnvar
+    let cfac = 1.0 + (sum_inv - 1.0 / nk) / (3.0 * (kf - 1.0))
+    var chi2 = 0.0
+    if cfac > 0.0 { chi2 = num / cfac }
+    let df = k - 1
+    let p = bt_chi2_sf(chi2, df as f64)
+    return BartlettResult { chi2: chi2, df: df as i64, p: p, pooled_var: sp2 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// g1={1,2,3,4,5} s²=2.5; g2={2,4,6,8,10} s²=10. N=10,k=2.
+// sp²=(4·2.5+4·10)/8=6.25. num=8·ln6.25-(4·ln2.5+4·ln10)=14.660650-12.875503=1.785147.
+// C=1+(0.5-0.125)/3=1.125. chi2=1.785147/1.125=1.586797. df=1.
+fn test_bartlett() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0; v[4]=5.0
+    v[5]=2.0; v[6]=4.0; v[7]=6.0; v[8]=8.0; v[9]=10.0
+    sz[0]=5; sz[1]=5
+    let r = bartlett(&v, &sz, 2)
+    var ok = true
+    ok = check(1, approx(r.pooled_var, 6.25, 1.0e-6)) && ok
+    ok = check(2, approx(r.chi2, 1.586797, 1.0e-4)) && ok
+    ok = check(3, r.df == 1) && ok
+    return ok
+}
+
+// equal variances (shifted copies) -> chi2 ~ 0, p ~ 1.
+fn test_equal() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0
+    v[4]=11.0; v[5]=12.0; v[6]=13.0; v[7]=14.0
+    sz[0]=4; sz[1]=4
+    let r = bartlett(&v, &sz, 2)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_bartlett() && ok
+    ok = test_equal() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/levene.sio
+++ b/stdlib/stats/levene.sio
@@ -1,0 +1,294 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/levene.sio — Levene / Brown-Forsythe test for equal variance
+//
+// A distribution-robust test of homogeneity of variance: run a one-way ANOVA on
+// the absolute deviations of each observation from its group centre. With the
+// group mean as centre it is Levene's original test; with the group median it is
+// the Brown-Forsythe variant, robust to non-normality.
+//
+//   levene(values, sizes, k, center) -> LeveneResult   (center: 0=mean, 1=median)
+//
+//   Zᵢⱼ = |xᵢⱼ − cᵢ|,
+//   W = [(N−k)/(k−1)] · Σ nᵢ(Z̄ᵢ − Z̄)² / ΣΣ(Zᵢⱼ − Z̄ᵢ)²   ~   F(k−1, N−k).
+//
+// Pure Sounio: an inline insertion sort per group for the median; incomplete
+// beta for the F tail. No nested data-array calls.
+//
+// References:
+//   Levene (1960); Brown & Forsythe (1974) JASA 69:364.
+
+module stats::levene
+
+fn lv_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / lv_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn lv_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn lv_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * lv_ln(tt) - tt + lv_ln(a)
+}
+
+fn lv_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn lv_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = lv_lgamma(a) + lv_lgamma(b) - lv_lgamma(a + b)
+    let front = lv_exp(a * lv_ln(x) + b * lv_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * lv_betacf(a, b, x) / a }
+    return 1.0 - front * lv_betacf(b, a, 1.0 - x) / b
+}
+
+// upper-tail F: P(F_{d1,d2} > f)
+fn lv_f_sf(f: f64, d1: f64, d2: f64) -> f64 with Mut, Div, Panic {
+    if f <= 0.0 { return 1.0 }
+    let x = d2 / (d2 + d1 * f)
+    return lv_ibeta(d2 * 0.5, d1 * 0.5, x)
+}
+
+pub struct LeveneResult {
+    pub w: f64,    // Levene statistic
+    pub df1: i64,  // k - 1
+    pub df2: i64,  // N - k
+    pub p: f64,
+}
+
+/// Levene / Brown-Forsythe test for equal variance across k consecutive groups.
+///
+/// Parâmetros: values — concatenated group data; sizes — per-group n (>=2);
+///             k — groups (2..16); center — 0 group mean (Levene), 1 median (Brown-Forsythe).
+/// Retorno: LeveneResult (w, df1, df2, p).
+/// Referências: Levene (1960); Brown & Forsythe (1974).
+pub fn levene(values: &[f64; 256], sizes: &[i32; 16], k: i32, center: i32) -> LeveneResult with Mut, Div, Panic {
+    if k < 2 || k > 16 { return LeveneResult { w: 0.0, df1: 0, df2: 0, p: 1.0 } }
+    var z: [f64; 256] = [0.0; 256]
+    var zmean: [f64; 16] = [0.0; 16]
+    var bign = 0
+    // build the Zij = |x - center_i| and per-group means
+    var off = 0
+    var g = 0
+    while g < k {
+        let ni = sizes[g as usize]
+        if ni < 2 { return LeveneResult { w: 0.0, df1: 0, df2: 0, p: 1.0 } }
+        let nif = ni as f64
+        var ctr = 0.0
+        if center == 1 {
+            // median via inline insertion sort of a local copy
+            var buf: [f64; 256] = [0.0; 256]
+            var a = 0
+            while a < ni { buf[a as usize] = values[(off + a) as usize]; a = a + 1 }
+            var ii = 1
+            while ii < ni {
+                let key = buf[ii as usize]
+                var jj = ii - 1
+                while jj >= 0 && buf[jj as usize] > key { buf[(jj + 1) as usize] = buf[jj as usize]; jj = jj - 1 }
+                buf[(jj + 1) as usize] = key
+                ii = ii + 1
+            }
+            if ni % 2 == 1 { ctr = buf[((ni - 1) / 2) as usize] }
+            else { ctr = 0.5 * (buf[(ni / 2 - 1) as usize] + buf[(ni / 2) as usize]) }
+        } else {
+            var s = 0.0
+            var a = 0
+            while a < ni { s = s + values[(off + a) as usize]; a = a + 1 }
+            ctr = s / nif
+        }
+        var zs = 0.0
+        var b = 0
+        while b < ni {
+            let dv = values[(off + b) as usize] - ctr
+            let az = if dv < 0.0 { 0.0 - dv } else { dv }
+            z[(off + b) as usize] = az
+            zs = zs + az
+            b = b + 1
+        }
+        zmean[g as usize] = zs / nif
+        bign = bign + ni
+        off = off + ni
+        g = g + 1
+    }
+    // grand mean of Z
+    var zsum = 0.0
+    var t = 0
+    while t < bign { zsum = zsum + z[t as usize]; t = t + 1 }
+    let zbar = zsum / (bign as f64)
+    // between and within sums of squares
+    var between = 0.0
+    var within = 0.0
+    var off2 = 0
+    var g2 = 0
+    while g2 < k {
+        let ni = sizes[g2 as usize]
+        let dmean = zmean[g2 as usize] - zbar
+        between = between + (ni as f64) * dmean * dmean
+        var b = 0
+        while b < ni {
+            let dv = z[(off2 + b) as usize] - zmean[g2 as usize]
+            within = within + dv * dv
+            b = b + 1
+        }
+        off2 = off2 + ni
+        g2 = g2 + 1
+    }
+    let kf = k as f64
+    let nf = bign as f64
+    let df1 = kf - 1.0
+    let df2 = nf - kf
+    var w = 0.0
+    if within > 1.0e-300 && df1 > 0.0 { w = (df2 / df1) * (between / within) }
+    let p = lv_f_sf(w, df1, df2)
+    return LeveneResult { w: w, df1: (k - 1) as i64, df2: (bign - k) as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// g1={1,2,3,4,5} mean3 devs{2,1,0,1,2} Z̄=1.2; g2={2,4,6,8,10} mean6 devs{4,2,0,2,4} Z̄=2.4.
+// Z̄=1.8. between=5·0.36+5·0.36=3.6. within=2.8+11.2=14.0. W=(8/1)(3.6/14)=2.057143.
+fn test_levene_mean() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0; v[4]=5.0
+    v[5]=2.0; v[6]=4.0; v[7]=6.0; v[8]=8.0; v[9]=10.0
+    sz[0]=5; sz[1]=5
+    let r = levene(&v, &sz, 2, 0)
+    var ok = true
+    ok = check(1, approx(r.w, 2.057143, 1.0e-4)) && ok
+    ok = check(2, r.df1 == 1) && ok
+    ok = check(3, r.df2 == 8) && ok
+    return ok
+}
+
+// median centering: same groups, medians are 3 and 6 (same as means here) -> same W.
+fn test_bf_median() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0; v[4]=5.0
+    v[5]=2.0; v[6]=4.0; v[7]=6.0; v[8]=8.0; v[9]=10.0
+    sz[0]=5; sz[1]=5
+    let r = levene(&v, &sz, 2, 1)
+    return check(10, approx(r.w, 2.057143, 1.0e-4))
+}
+
+// equal spread (shifted copies) -> W ~ 0, p ~ 1.
+fn test_equal() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0
+    v[4]=11.0; v[5]=12.0; v[6]=13.0; v[7]=14.0
+    sz[0]=4; sz[1]=4
+    let r = levene(&v, &sz, 2, 0)
+    var ok = true
+    ok = check(20, approx(r.w, 0.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_levene_mean() && ok
+    ok = test_bf_median() && ok
+    ok = test_equal() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/var_ftest.sio
+++ b/stdlib/stats/var_ftest.sio
@@ -1,0 +1,234 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/var_ftest.sio — two-sample F-test for equality of variances
+//
+// The classical variance-ratio test: under normality the ratio of two sample
+// variances follows an F distribution, giving a two-sided test of σ₁² = σ₂²:
+//
+//   var_ftest(x, nx, y, ny) -> VarFResult
+//
+//   F = s₁²/s₂²  ~  F(n₁−1, n₂−1),
+//   two-sided p = 2·min( P(F ≤ f), P(F ≥ f) ).
+// (Powerful under normality, but sensitive to it — prefer Levene/Bartlett for
+// k>2 or non-normal data.)
+//
+// Pure Sounio: one pass per sample for the variances; the F tail via inline
+// Lanczos log-gamma + continued-fraction incomplete beta. No nested data-array
+// calls.
+//
+// References:
+//   Snedecor & Cochran, "Statistical Methods" 8e, §6.11.
+
+module stats::var_ftest
+
+fn vf_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / vf_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn vf_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn vf_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * vf_ln(tt) - tt + vf_ln(a)
+}
+
+fn vf_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn vf_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = vf_lgamma(a) + vf_lgamma(b) - vf_lgamma(a + b)
+    let front = vf_exp(a * vf_ln(x) + b * vf_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * vf_betacf(a, b, x) / a }
+    return 1.0 - front * vf_betacf(b, a, 1.0 - x) / b
+}
+
+// F cdf P(F_{d1,d2} <= f)
+fn vf_f_cdf(f: f64, d1: f64, d2: f64) -> f64 with Mut, Div, Panic {
+    if f <= 0.0 { return 0.0 }
+    let x = d1 * f / (d1 * f + d2)
+    return vf_ibeta(d1 * 0.5, d2 * 0.5, x)
+}
+
+fn variance(a: &[f64; 256], off: i32, n: i32) -> f64 with Mut, Div, Panic {
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + a[(off + i) as usize]; i = i + 1 }
+    let mean = s / nf
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = a[(off + j) as usize] - mean; ss = ss + d * d; j = j + 1 }
+    return ss / (nf - 1.0)
+}
+
+pub struct VarFResult {
+    pub f: f64,      // s1²/s2²
+    pub df1: i64,    // n1 - 1
+    pub df2: i64,    // n2 - 1
+    pub p: f64,      // two-sided p
+    pub var1: f64,
+    pub var2: f64,
+}
+
+/// Two-sample F-test for equality of variances.
+///
+/// Parâmetros: x — sample 1; nx — size (>=2); y — sample 2; ny — size (>=2).
+/// Retorno: VarFResult (f, df1, df2, p, var1, var2).
+/// Referências: Snedecor & Cochran §6.11.
+pub fn var_ftest(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> VarFResult with Mut, Div, Panic {
+    if nx < 2 || ny < 2 {
+        return VarFResult { f: 0.0, df1: 0, df2: 0, p: 1.0, var1: 0.0, var2: 0.0 }
+    }
+    let v1 = variance(x, 0, nx)
+    let v2 = variance(y, 0, ny)
+    if v2 <= 0.0 { return VarFResult { f: 0.0, df1: (nx-1) as i64, df2: (ny-1) as i64, p: 1.0, var1: v1, var2: v2 } }
+    let f = v1 / v2
+    let d1 = (nx - 1) as f64
+    let d2 = (ny - 1) as f64
+    let lower = vf_f_cdf(f, d1, d2)
+    let upper = 1.0 - lower
+    var tail = lower
+    if upper < lower { tail = upper }
+    var p = 2.0 * tail
+    if p > 1.0 { p = 1.0 }
+    return VarFResult { f: f, df1: (nx - 1) as i64, df2: (ny - 1) as i64, p: p, var1: v1, var2: v2 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3,4,5} var 2.5; y={2,4,6,8,10} var 10. F=0.25, df1=df2=4.
+// P(F<=0.25)=I_{0.2}(2,2)=0.04·(3-0.4)=0.104. two-sided p=2·0.104=0.208.
+fn test_var_ftest() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    y[0]=2.0; y[1]=4.0; y[2]=6.0; y[3]=8.0; y[4]=10.0
+    let r = var_ftest(&x, 5, &y, 5)
+    var ok = true
+    ok = check(1, approx(r.f, 0.25, 1.0e-9)) && ok
+    ok = check(2, approx(r.var1, 2.5, 1.0e-9)) && ok
+    ok = check(3, approx(r.var2, 10.0, 1.0e-9)) && ok
+    ok = check(4, r.df1 == 4) && ok
+    ok = check(5, approx(r.p, 0.208, 1.0e-3)) && ok
+    return ok
+}
+
+// equal variances -> F=1, p=1.
+fn test_equal() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=11.0; y[1]=12.0; y[2]=13.0; y[3]=14.0
+    let r = var_ftest(&x, 4, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.f, 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_var_ftest() && ok
+    ok = test_equal() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three homoscedasticity tests for the epistemic-statistics suite, bringing the runner to **61 modules**. These complete the **parametric-assumption-checking trio** — the suite now covers normality (`normality`, `ks_test`), independence (`runs_test`, `durbin_watson`, `autocorr`), and now **equal variance**. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | Test | Reference dist |
|---|---|---|
| `stats::bartlett` | Bartlett's χ² (powerful under normality) | χ²(k−1) |
| `stats::levene` | Levene / Brown-Forsythe (robust; mean/median centering) | F(k−1, N−k) |
| `stats::var_ftest` | Two-sample variance ratio | F(n₁−1, n₂−1) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Bartlett: {1..5} vs {2,4,…,10} → pooled 6.25, χ²=1.5868, df=1; equal-spread → χ²=0.
  - Levene: worked example → W=2.0571 (both mean and median centering, symmetric data); equal-spread → W=0.
  - Var F-test: var 2.5 vs 10 → F=0.25, p=0.208 (= 2·I_{0.2}(2,2)); equal variances → F=1, p=1.
- Full suite selftest: **61 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; χ²/F tails via inline Lanczos log-gamma with incomplete gamma and beta.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS). One reviewer note flagged that the inline exp/ln/betacf helpers are bounded-precision series without proven error bounds at extreme arguments — a general property of every inline special function in the suite, with all downstream statistical claims confirmed valid.