### PR TITLE
feat(ir): add canonical f128/f256 payload wire codec

### DIFF
--- a/scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
+++ b/scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
@@ -69,11 +69,13 @@ rg -l 'IrWideNumericPayload|wide_numeric_payload|numeric_payload|IR_WIDE_NUMERIC
   | sort >"$TMP_DIR/payload-references.actual"
 printf '%s\n' \
   'self-hosted/compiler/f128_f256_numeric_payload_probe.sio' \
+  'self-hosted/compiler/f128_f256_numeric_wire_probe.sio' \
   'self-hosted/ir/numeric_payload.sio' \
+  'self-hosted/ir/numeric_payload_wire.sio' \
   >"$TMP_DIR/payload-references.expected"
 if ! diff -u "$TMP_DIR/payload-references.expected" "$TMP_DIR/payload-references.actual" \
     >"$TMP_DIR/integration-leak.log" 2>&1; then
-  echo "FAIL bounded V0-B payload pool leaked into IR instructions, lowering, native, or SOIR" >&2
+  echo "FAIL numeric payload surface leaked beyond the V0-B arena and bounded standalone V0-C wire codec" >&2
   cat "$TMP_DIR/integration-leak.log" >&2
   exit 1
 fi

--- a/scripts/ci/madaros_f128_f256_numeric_wire_gate.sh
+++ b/scripts/ci/madaros_f128_f256_numeric_wire_gate.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+BASE_SHA='9ccac660ff2cc3722f0811f1a273ccc9d6b9c7a0'
+SEED_COMPILER="$(realpath "${SOUNIO_F128_SEED_COMPILER:-$ROOT_DIR/bin/souc-lean-single-x86_64}")"
+if [[ ! -x "$SEED_COMPILER" ]]; then
+  echo "FAIL bootstrap seed is not executable: $SEED_COMPILER" >&2
+  exit 2
+fi
+if [[ "$(head -c2 "$SEED_COMPILER" 2>/dev/null)" == '#!' ]]; then
+  echo "FAIL gate requires a resolved seed ELF, not a wrapper: $SEED_COMPILER" >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PROBE='self-hosted/compiler/f128_f256_numeric_wire_probe.sio'
+CODEC='self-hosted/ir/numeric_payload_wire.sio'
+PROBE_ELF="$TMP_DIR/f128-f256-numeric-wire-probe.elf"
+BUILD_LOG="$TMP_DIR/build.log"
+RUN_LOG="$TMP_DIR/run.log"
+
+echo "seed_elf=$SEED_COMPILER"
+echo "seed_sha256=$(sha256sum "$SEED_COMPILER" | awk '{print $1}')"
+echo "source_head=$(git rev-parse HEAD)"
+echo "stack_base=$BASE_SHA"
+
+if ! "$SEED_COMPILER" "$PROBE" "$PROBE_ELF" >"$BUILD_LOG" 2>&1; then
+  echo "FAIL standalone numeric wire probe did not compile with the bootstrap seed" >&2
+  cat "$BUILD_LOG" >&2
+  exit 1
+fi
+chmod +x "$PROBE_ELF"
+if ! "$PROBE_ELF" >"$RUN_LOG" 2>&1; then
+  echo "FAIL standalone numeric wire probe returned nonzero" >&2
+  cat "$RUN_LOG" >&2
+  exit 1
+fi
+RECEIPT='PASS f128_f256_numeric_wire_probe bytes=136 payloads=2 limbs=6 le=exact high_bit=exact checksum=adler32:57941ddc roundtrip=byte_exact decode_negative=18 encode_negative=1 reseal_negative=2 destination=transactional'
+if ! grep -Fxq "$RECEIPT" "$RUN_LOG"; then
+  echo "FAIL standalone numeric wire probe omitted the exact receipt" >&2
+  cat "$RUN_LOG" >&2
+  exit 1
+fi
+
+for exact in \
+  'module ir::numeric_payload_wire' \
+  'IR_NUMERIC_WIRE_MAX_BYTES: i64 = 16384' \
+  'IR_NUMERIC_WIRE_MAGIC: i64 = 1347898963' \
+  'IR_NUMERIC_WIRE_VERSION: i64 = 1' \
+  'IR_NUMERIC_WIRE_HEADER_BYTES: i64 = 40' \
+  'IR_NUMERIC_WIRE_ENTRY_BYTES: i64 = 24' \
+  'IR_NUMERIC_WIRE_LIMB_BYTES: i64 = 8' \
+  'IR_NUMERIC_WIRE_ERR_BAD_MAGIC' \
+  'IR_NUMERIC_WIRE_ERR_BAD_VERSION' \
+  'IR_NUMERIC_WIRE_ERR_TRUNCATED' \
+  'IR_NUMERIC_WIRE_ERR_BAD_COUNTS' \
+  'IR_NUMERIC_WIRE_ERR_BAD_LENGTH' \
+  'IR_NUMERIC_WIRE_ERR_UNKNOWN_FORMAT' \
+  'IR_NUMERIC_WIRE_ERR_NONCANONICAL_SPAN' \
+  'IR_NUMERIC_WIRE_ERR_NONCANONICAL_COUNT' \
+  'IR_NUMERIC_WIRE_ERR_TRAILING_BYTES' \
+  'IR_NUMERIC_WIRE_ERR_CHECKSUM' \
+  'fn ir_numeric_payload_wire_checksum_unchecked' \
+  '(b << 16) | a' \
+  'pub fn ir_numeric_payload_wire_reseal_canonical(' \
+  'if (*wire).len < IR_NUMERIC_WIRE_HEADER_BYTES' \
+  'if (*wire).len > IR_NUMERIC_WIRE_MAX_BYTES' \
+  'Payload limbs retain arena order: limb 0 is least-significant' \
+  'The destination is not touched until all checks pass'; do
+  if ! grep -Fq "$exact" "$CODEC"; then
+    echo "FAIL numeric wire structural invariant missing: $exact" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq 'pub fn ir_numeric_payload_wire_checksum' "$CODEC"; then
+  echo "FAIL unchecked checksum primitive is public" >&2
+  exit 1
+fi
+
+if rg -n 'use ir::serialize|use ir::ir|IrModule|IrInstr|IrOpcode|IrNop' "$CODEC" >"$TMP_DIR/leak.log"; then
+  echo "FAIL standalone codec depends on current SOIR or instruction/module IR" >&2
+  cat "$TMP_DIR/leak.log" >&2
+  exit 1
+fi
+
+for protected in \
+  self-hosted/ir/serialize.sio \
+  self-hosted/ir/ir.sio \
+  self-hosted/ir/lower.sio \
+  self-hosted/compiler/module_loader.sio \
+  self-hosted/compiler/module_frontend.sio; do
+  if ! git diff --quiet "$BASE_SHA" -- "$protected"; then
+    echo "FAIL V0-C modified protected compiler/SOIR surface: $protected" >&2
+    exit 1
+  fi
+done
+
+{
+  git diff --name-only "$BASE_SHA"
+  git ls-files --others --exclude-standard
+} | sort -u >"$TMP_DIR/write-set.actual"
+printf '%s\n' \
+  'scripts/ci/madaros_f128_f256_numeric_payload_gate.sh' \
+  'scripts/ci/madaros_f128_f256_numeric_wire_gate.sh' \
+  'self-hosted/compiler/f128_f256_numeric_wire_probe.sio' \
+  'self-hosted/ir/numeric_payload_wire.sio' \
+  >"$TMP_DIR/write-set.expected"
+if ! diff -u "$TMP_DIR/write-set.expected" "$TMP_DIR/write-set.actual" \
+    >"$TMP_DIR/write-set.log" 2>&1; then
+  echo "FAIL V0-C write set exceeds the standalone codec/probe/gates" >&2
+  cat "$TMP_DIR/write-set.log" >&2
+  exit 1
+fi
+
+rg -l 'IrNumericPayloadWire|numeric_payload_wire|IR_NUMERIC_WIRE' self-hosted \
+  | sort >"$TMP_DIR/wire-references.actual"
+printf '%s\n' \
+  'self-hosted/compiler/f128_f256_numeric_wire_probe.sio' \
+  'self-hosted/ir/numeric_payload_wire.sio' \
+  >"$TMP_DIR/wire-references.expected"
+if ! diff -u "$TMP_DIR/wire-references.expected" "$TMP_DIR/wire-references.actual" \
+    >"$TMP_DIR/integration-leak.log" 2>&1; then
+  echo "FAIL standalone wire codec leaked into SOIR, IrModule, IrInstr, lowering, ABI, native, source, or arithmetic" >&2
+  cat "$TMP_DIR/integration-leak.log" >&2
+  exit 1
+fi
+
+echo "probe_elf_sha256=$(sha256sum "$PROBE_ELF" | awk '{print $1}')"
+echo "PASS numeric wire: canonical LE header/entries/limbs and byte-exact f128/f256 roundtrip"
+echo "PASS fail-closed: 18 decoder mutations + 1 corrupt-source encode + 2 bounded-reseal rejects, structured status, transactional destination"
+echo "PASS containment: standalone future-section codec; current SOIR/version/IR/lowering/ABI/native/source/arithmetic untouched"
+echo "PASS madaros_f128_f256_numeric_wire_gate"

--- a/self-hosted/compiler/f128_f256_numeric_wire_probe.sio
+++ b/self-hosted/compiler/f128_f256_numeric_wire_probe.sio
@@ -1,0 +1,243 @@
+use check::numeric_format::*
+use ir::numeric_payload::*
+use ir::numeric_payload_wire::*
+
+fn probe_put_u16(wire: &! IrNumericPayloadWireBuffer, offset: i64, value: i64) with Mut, Panic, Div {
+    (*wire).bytes[offset] = (value & 255) as i8
+    (*wire).bytes[offset + 1] = ((value >> 8) & 255) as i8
+}
+
+fn probe_put_i64(wire: &! IrNumericPayloadWireBuffer, offset: i64, value: i64) with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < 8 {
+        (*wire).bytes[offset + i] = ((value >> (i * 8)) & 255) as i8
+        i = i + 1
+    }
+}
+
+fn byte_is(wire: &IrNumericPayloadWireBuffer, offset: i64, expected: i64) -> bool with Mut, Panic, Div {
+    (((*wire).bytes[offset] as i64) & 255) == expected
+}
+
+fn pool_matches(
+    pool: &IrWideNumericPayloadPool,
+    limbs128: [i64; 4],
+    limbs256: [i64; 4],
+) -> bool with Mut, Panic, Div {
+    if (*pool).payload_count != 2 || (*pool).limb_count != 6 { return false }
+    if (*pool).entries[0].format_id != numeric_format_binary128_id() { return false }
+    if (*pool).entries[0].limb_start != 0 || (*pool).entries[0].limb_count != 2 { return false }
+    if (*pool).entries[1].format_id != numeric_format_binary256_id() { return false }
+    if (*pool).entries[1].limb_start != 2 || (*pool).entries[1].limb_count != 4 { return false }
+    if (*pool).limbs[0] != limbs128[0] || (*pool).limbs[1] != limbs128[1] { return false }
+    var i: i64 = 0
+    while i < 4 {
+        if (*pool).limbs[(i + 2) as usize] != limbs256[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn status_is(status: IrNumericPayloadWireStatus, code: i64, offset: i64) -> bool {
+    status.code == code && status.byte_offset == offset
+}
+
+fn sentinel_matches(pool: &IrWideNumericPayloadPool, limbs128: [i64; 4]) -> bool with Mut, Panic, Div {
+    if (*pool).payload_count != 1 || (*pool).limb_count != 2 { return false }
+    if (*pool).entries[0].format_id != numeric_format_binary128_id() { return false }
+    if (*pool).entries[0].limb_start != 0 || (*pool).entries[0].limb_count != 2 { return false }
+    (*pool).limbs[0] == limbs128[0] && (*pool).limbs[1] == limbs128[1]
+}
+
+fn main() -> i32 with IO, Mut, Panic, Div, Alloc {
+    var source = ir_empty_wide_numeric_payload_pool()
+    let limbs128: [i64; 4] = [72623859790382856, -1, 0, 0]
+    let limbs256: [i64; 4] = [2387509390608836392, -2, 4702394921427289928, -3]
+    let (id128, add128) = ir_wide_numeric_payload_pool_add(
+        &! source, numeric_format_binary128_id(), limbs128, 2
+    )
+    if id128 != 0 || add128 != IR_WIDE_NUMERIC_OK { return 1 }
+    let (id256, add256) = ir_wide_numeric_payload_pool_add(
+        &! source, numeric_format_binary256_id(), limbs256, 4
+    )
+    if id256 != 1 || add256 != IR_WIDE_NUMERIC_OK { return 2 }
+
+    var wire = ir_empty_numeric_payload_wire_buffer()
+    let encode_status = ir_numeric_payload_wire_encode(&source, &! wire)
+    if !status_is(encode_status, IR_NUMERIC_WIRE_OK, 0) { return 3 }
+    if wire.len != 136 { return 4 }
+    if !byte_is(&wire, 0, 83) || !byte_is(&wire, 1, 78) { return 5 }
+    if !byte_is(&wire, 2, 87) || !byte_is(&wire, 3, 80) { return 6 }
+    if !byte_is(&wire, 4, 1) || !byte_is(&wire, 5, 0) { return 7 }
+    if !byte_is(&wire, 6, 40) || !byte_is(&wire, 7, 0) { return 8 }
+    if !byte_is(&wire, 8, 136) || !byte_is(&wire, 9, 0) { return 9 }
+    if !byte_is(&wire, 16, 2) || !byte_is(&wire, 24, 6) { return 10 }
+    // Independent canonical Adler-32 oracle for this exact 136-byte fixture:
+    // 0x57941ddc, zero-extended into the 8-byte checksum slot.
+    if !byte_is(&wire, 32, 220) || !byte_is(&wire, 33, 29) { return 41 }
+    if !byte_is(&wire, 34, 148) || !byte_is(&wire, 35, 87) { return 42 }
+    if !byte_is(&wire, 36, 0) || !byte_is(&wire, 37, 0) { return 43 }
+    if !byte_is(&wire, 38, 0) || !byte_is(&wire, 39, 0) { return 44 }
+    // First raw word is 0x0102030405060708, encoded little-endian at byte 88.
+    if !byte_is(&wire, 88, 8) || !byte_is(&wire, 89, 7) { return 11 }
+    if !byte_is(&wire, 94, 2) || !byte_is(&wire, 95, 1) { return 12 }
+    // The next limb is -1: its high bit and every serialized byte are set.
+    if !byte_is(&wire, 96, 255) || !byte_is(&wire, 103, 255) { return 13 }
+    // f256 limb 1 is -2, proving high-bit raw transport beyond f128.
+    if !byte_is(&wire, 112, 254) || !byte_is(&wire, 119, 255) { return 14 }
+
+    var decoded = ir_empty_wide_numeric_payload_pool()
+    decoded.entries[10] = IrWideNumericPayloadEntry { format_id: 999, limb_start: 77, limb_count: 88 }
+    decoded.limbs[100] = 42
+    let decode_status = ir_numeric_payload_wire_decode(&wire, &! decoded)
+    if !status_is(decode_status, IR_NUMERIC_WIRE_OK, 0) { return 15 }
+    if !pool_matches(&decoded, limbs128, limbs256) { return 16 }
+    if decoded.entries[10].format_id != 0 || decoded.entries[10].limb_start != -1 { return 39 }
+    if decoded.entries[10].limb_count != 0 || decoded.limbs[100] != 0 { return 40 }
+
+    var reencoded = ir_empty_numeric_payload_wire_buffer()
+    let reencode_status = ir_numeric_payload_wire_encode(&decoded, &! reencoded)
+    if reencode_status.code != IR_NUMERIC_WIRE_OK || reencoded.len != wire.len { return 17 }
+    var wi: i64 = 0
+    while wi < wire.len {
+        if reencoded.bytes[wi] != wire.bytes[wi] { return 18 }
+        wi = wi + 1
+    }
+
+    var destination_sentinel = ir_empty_wide_numeric_payload_pool()
+    let (sentinel_id, sentinel_add) = ir_wide_numeric_payload_pool_add(
+        &! destination_sentinel, numeric_format_binary128_id(), limbs128, 2
+    )
+    if sentinel_id != 0 || sentinel_add != IR_WIDE_NUMERIC_OK { return 19 }
+
+    var bad_magic = wire
+    bad_magic.bytes[0] = 0
+    let s_magic = ir_numeric_payload_wire_decode(&bad_magic, &! destination_sentinel)
+    if !status_is(s_magic, IR_NUMERIC_WIRE_ERR_BAD_MAGIC, 0) { return 20 }
+    if !sentinel_matches(&destination_sentinel, limbs128) { return 21 }
+
+    var bad_version = wire
+    probe_put_u16(&! bad_version, 4, 2)
+    let s_version = ir_numeric_payload_wire_decode(&bad_version, &! destination_sentinel)
+    if !status_is(s_version, IR_NUMERIC_WIRE_ERR_BAD_VERSION, 4) { return 22 }
+
+    var bad_header = wire
+    probe_put_u16(&! bad_header, 6, 32)
+    let s_header = ir_numeric_payload_wire_decode(&bad_header, &! destination_sentinel)
+    if !status_is(s_header, IR_NUMERIC_WIRE_ERR_BAD_HEADER, 6) { return 23 }
+
+    var short_header = wire
+    short_header.len = 39
+    let s_short_header = ir_numeric_payload_wire_decode(&short_header, &! destination_sentinel)
+    if !status_is(s_short_header, IR_NUMERIC_WIRE_ERR_TRUNCATED, 39) { return 24 }
+
+    var short_body = wire
+    short_body.len = 135
+    let s_short_body = ir_numeric_payload_wire_decode(&short_body, &! destination_sentinel)
+    if !status_is(s_short_body, IR_NUMERIC_WIRE_ERR_TRUNCATED, 135) { return 25 }
+
+    var bad_payload_count = wire
+    probe_put_i64(&! bad_payload_count, 16, 257)
+    let s_payload_count = ir_numeric_payload_wire_decode(&bad_payload_count, &! destination_sentinel)
+    if !status_is(s_payload_count, IR_NUMERIC_WIRE_ERR_BAD_COUNTS, 16) { return 26 }
+
+    var bad_limb_count = wire
+    probe_put_i64(&! bad_limb_count, 24, 1025)
+    let s_limb_count = ir_numeric_payload_wire_decode(&bad_limb_count, &! destination_sentinel)
+    if !status_is(s_limb_count, IR_NUMERIC_WIRE_ERR_BAD_COUNTS, 24) { return 27 }
+
+    var negative_payload_count = wire
+    probe_put_i64(&! negative_payload_count, 16, -1)
+    let s_negative_payload_count = ir_numeric_payload_wire_decode(&negative_payload_count, &! destination_sentinel)
+    if !status_is(s_negative_payload_count, IR_NUMERIC_WIRE_ERR_BAD_COUNTS, 16) { return 52 }
+
+    var negative_limb_count = wire
+    probe_put_i64(&! negative_limb_count, 24, -1)
+    let s_negative_limb_count = ir_numeric_payload_wire_decode(&negative_limb_count, &! destination_sentinel)
+    if !status_is(s_negative_limb_count, IR_NUMERIC_WIRE_ERR_BAD_COUNTS, 24) { return 53 }
+
+    var bad_length = wire
+    probe_put_i64(&! bad_length, 16, 1)
+    let s_length = ir_numeric_payload_wire_decode(&bad_length, &! destination_sentinel)
+    if !status_is(s_length, IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8) { return 28 }
+
+    var negative_length = wire
+    probe_put_i64(&! negative_length, 8, -1)
+    let s_negative_length = ir_numeric_payload_wire_decode(&negative_length, &! destination_sentinel)
+    if !status_is(s_negative_length, IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8) { return 37 }
+
+    var excessive_length = wire
+    probe_put_i64(&! excessive_length, 8, 16385)
+    let s_excessive_length = ir_numeric_payload_wire_decode(&excessive_length, &! destination_sentinel)
+    if !status_is(s_excessive_length, IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8) { return 38 }
+
+    var oversized_wire = wire
+    oversized_wire.len = 16385
+    let s_oversized_wire = ir_numeric_payload_wire_decode(&oversized_wire, &! destination_sentinel)
+    if !status_is(s_oversized_wire, IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8) { return 54 }
+    if !sentinel_matches(&destination_sentinel, limbs128) { return 55 }
+
+    var trailing = wire
+    trailing.bytes[136] = 42
+    trailing.len = 137
+    let s_trailing = ir_numeric_payload_wire_decode(&trailing, &! destination_sentinel)
+    if !status_is(s_trailing, IR_NUMERIC_WIRE_ERR_TRAILING_BYTES, 136) { return 29 }
+
+    var unknown_format = wire
+    probe_put_i64(&! unknown_format, 40, 999)
+    let reseal_unknown = ir_numeric_payload_wire_reseal_canonical(&! unknown_format)
+    if reseal_unknown.code != IR_NUMERIC_WIRE_OK { return 45 }
+    let s_unknown = ir_numeric_payload_wire_decode(&unknown_format, &! destination_sentinel)
+    if !status_is(s_unknown, IR_NUMERIC_WIRE_ERR_UNKNOWN_FORMAT, 40) { return 30 }
+    if !sentinel_matches(&destination_sentinel, limbs128) { return 56 }
+
+    var bad_span = wire
+    probe_put_i64(&! bad_span, 48, 1)
+    let reseal_span = ir_numeric_payload_wire_reseal_canonical(&! bad_span)
+    if reseal_span.code != IR_NUMERIC_WIRE_OK { return 46 }
+    let s_span = ir_numeric_payload_wire_decode(&bad_span, &! destination_sentinel)
+    if !status_is(s_span, IR_NUMERIC_WIRE_ERR_NONCANONICAL_SPAN, 48) { return 31 }
+    if !sentinel_matches(&destination_sentinel, limbs128) { return 57 }
+
+    var bad_entry_count = wire
+    probe_put_i64(&! bad_entry_count, 56, 4)
+    let reseal_count = ir_numeric_payload_wire_reseal_canonical(&! bad_entry_count)
+    if reseal_count.code != IR_NUMERIC_WIRE_OK { return 47 }
+    let s_entry_count = ir_numeric_payload_wire_decode(&bad_entry_count, &! destination_sentinel)
+    if !status_is(s_entry_count, IR_NUMERIC_WIRE_ERR_NONCANONICAL_COUNT, 56) { return 32 }
+    if !sentinel_matches(&destination_sentinel, limbs128) { return 58 }
+
+    var tampered_payload = wire
+    tampered_payload.bytes[88] = 9
+    let s_tamper = ir_numeric_payload_wire_decode(&tampered_payload, &! destination_sentinel)
+    if !status_is(s_tamper, IR_NUMERIC_WIRE_ERR_CHECKSUM, 32) { return 33 }
+    if !sentinel_matches(&destination_sentinel, limbs128) { return 34 }
+
+    var corrupt_source = source
+    corrupt_source.entries[0].limb_count = 4
+    var untouched_wire = ir_empty_numeric_payload_wire_buffer()
+    untouched_wire.len = 7
+    untouched_wire.bytes[0] = 42
+    let s_source = ir_numeric_payload_wire_encode(&corrupt_source, &! untouched_wire)
+    if !status_is(s_source, IR_NUMERIC_WIRE_ERR_SOURCE_POOL, 0) { return 35 }
+    if untouched_wire.len != 7 || !byte_is(&untouched_wire, 0, 42) { return 36 }
+
+    var reseal_short = wire
+    reseal_short.len = 39
+    reseal_short.bytes[32] = 42
+    reseal_short.bytes[39] = 43
+    let s_reseal_short = ir_numeric_payload_wire_reseal_canonical(&! reseal_short)
+    if !status_is(s_reseal_short, IR_NUMERIC_WIRE_ERR_TRUNCATED, 39) { return 48 }
+    if !byte_is(&reseal_short, 32, 42) || !byte_is(&reseal_short, 39, 43) { return 49 }
+
+    var reseal_oversize = wire
+    reseal_oversize.len = 16385
+    reseal_oversize.bytes[32] = 44
+    reseal_oversize.bytes[39] = 45
+    let s_reseal_oversize = ir_numeric_payload_wire_reseal_canonical(&! reseal_oversize)
+    if !status_is(s_reseal_oversize, IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8) { return 50 }
+    if !byte_is(&reseal_oversize, 32, 44) || !byte_is(&reseal_oversize, 39, 45) { return 51 }
+
+    println("PASS f128_f256_numeric_wire_probe bytes=136 payloads=2 limbs=6 le=exact high_bit=exact checksum=adler32:57941ddc roundtrip=byte_exact decode_negative=18 encode_negative=1 reseal_negative=2 destination=transactional")
+    0
+}

--- a/self-hosted/ir/numeric_payload_wire.sio
+++ b/self-hosted/ir/numeric_payload_wire.sio
@@ -1,0 +1,313 @@
+// Canonical standalone wire codec for the compiler-owned wide numeric arena.
+//
+// This is not a SOIR serializer and does not change the current SOIR version.
+// Its section-sized, versioned envelope is intentionally suitable for later
+// embedding as one section of a future SOIR v6 container. All integers are
+// little-endian. Payload limbs retain arena order: limb 0 is least-significant.
+//
+// Wire v1:
+//   0  u32 magic "SNWP"       16 i64 payload_count
+//   4  u16 version             24 i64 limb_count
+//   6  u16 header_bytes        32 i64 zero-extended Adler-32
+//   8  i64 section_bytes       40 entries[payload_count]
+// Each 24-byte entry is { opaque format_id, limb_start, limb_count } as i64.
+// Entries are followed by raw i64 limb words with no numeric reinterpretation.
+
+module ir::numeric_payload_wire
+
+use ir::numeric_payload::*
+
+pub let IR_NUMERIC_WIRE_MAX_BYTES: i64 = 16384
+pub let IR_NUMERIC_WIRE_MAGIC: i64 = 1347898963  // bytes "SNWP"
+pub let IR_NUMERIC_WIRE_VERSION: i64 = 1
+pub let IR_NUMERIC_WIRE_HEADER_BYTES: i64 = 40
+pub let IR_NUMERIC_WIRE_ENTRY_BYTES: i64 = 24
+pub let IR_NUMERIC_WIRE_LIMB_BYTES: i64 = 8
+
+pub let IR_NUMERIC_WIRE_OK: i64 = 0
+pub let IR_NUMERIC_WIRE_ERR_BAD_MAGIC: i64 = 1
+pub let IR_NUMERIC_WIRE_ERR_BAD_VERSION: i64 = 2
+pub let IR_NUMERIC_WIRE_ERR_TRUNCATED: i64 = 3
+pub let IR_NUMERIC_WIRE_ERR_BAD_HEADER: i64 = 4
+pub let IR_NUMERIC_WIRE_ERR_BAD_COUNTS: i64 = 5
+pub let IR_NUMERIC_WIRE_ERR_BAD_LENGTH: i64 = 6
+pub let IR_NUMERIC_WIRE_ERR_UNKNOWN_FORMAT: i64 = 7
+pub let IR_NUMERIC_WIRE_ERR_NONCANONICAL_SPAN: i64 = 8
+pub let IR_NUMERIC_WIRE_ERR_NONCANONICAL_COUNT: i64 = 9
+pub let IR_NUMERIC_WIRE_ERR_TRAILING_BYTES: i64 = 10
+pub let IR_NUMERIC_WIRE_ERR_CHECKSUM: i64 = 11
+pub let IR_NUMERIC_WIRE_ERR_SOURCE_POOL: i64 = 12
+pub let IR_NUMERIC_WIRE_ERR_CAPACITY: i64 = 13
+
+pub struct IrNumericPayloadWireStatus {
+    code: i64,
+    byte_offset: i64,
+    detail: i64,
+}
+
+pub struct IrNumericPayloadWireBuffer {
+    bytes: [i8; 16384],
+    len: i64,
+}
+
+pub fn ir_numeric_payload_wire_status_ok() -> IrNumericPayloadWireStatus {
+    IrNumericPayloadWireStatus { code: IR_NUMERIC_WIRE_OK, byte_offset: 0, detail: 0 }
+}
+
+fn ir_numeric_payload_wire_status(code: i64, byte_offset: i64, detail: i64) -> IrNumericPayloadWireStatus {
+    IrNumericPayloadWireStatus { code: code, byte_offset: byte_offset, detail: detail }
+}
+
+pub fn ir_empty_numeric_payload_wire_buffer() -> IrNumericPayloadWireBuffer {
+    IrNumericPayloadWireBuffer { bytes: [0; 16384], len: 0 }
+}
+
+fn wire_put_u16(wire: &! IrNumericPayloadWireBuffer, offset: i64, value: i64) with Mut, Panic, Div {
+    (*wire).bytes[offset] = (value & 255) as i8
+    (*wire).bytes[offset + 1] = ((value >> 8) & 255) as i8
+}
+
+fn wire_put_u32(wire: &! IrNumericPayloadWireBuffer, offset: i64, value: i64) with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < 4 {
+        (*wire).bytes[offset + i] = ((value >> (i * 8)) & 255) as i8
+        i = i + 1
+    }
+}
+
+fn wire_put_i64(wire: &! IrNumericPayloadWireBuffer, offset: i64, value: i64) with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < 8 {
+        (*wire).bytes[offset + i] = ((value >> (i * 8)) & 255) as i8
+        i = i + 1
+    }
+}
+
+fn wire_get_u16(wire: &IrNumericPayloadWireBuffer, offset: i64) -> i64 with Mut, Panic, Div {
+    let b0 = ((*wire).bytes[offset] as i64) & 255
+    let b1 = ((*wire).bytes[offset + 1] as i64) & 255
+    b0 | (b1 << 8)
+}
+
+fn wire_get_u32(wire: &IrNumericPayloadWireBuffer, offset: i64) -> i64 with Mut, Panic, Div {
+    var value: i64 = 0
+    var i: i64 = 0
+    while i < 4 {
+        value = value | (((*wire).bytes[offset + i] as i64 & 255) << (i * 8))
+        i = i + 1
+    }
+    value
+}
+
+fn wire_get_i64(wire: &IrNumericPayloadWireBuffer, offset: i64) -> i64 with Mut, Panic, Div {
+    var value: i64 = 0
+    var i: i64 = 0
+    while i < 8 {
+        value = value | (((*wire).bytes[offset + i] as i64 & 255) << (i * 8))
+        i = i + 1
+    }
+    value
+}
+
+// Adler-32 is a non-cryptographic integrity checksum, not authentication. The checksum slot
+// itself (bytes 32..39) is excluded so the same routine serves encode, decode,
+// and adversarial canonical-repair probes.
+fn ir_numeric_payload_wire_checksum_unchecked(wire: &IrNumericPayloadWireBuffer) -> i64 with Mut, Panic, Div {
+    var a: i64 = 1
+    var b: i64 = 0
+    var i: i64 = 0
+    while i < (*wire).len {
+        if i < 32 || i >= 40 {
+            let octet = ((*wire).bytes[i] as i64) & 255
+            a = (a + octet) % 65521
+            b = (b + a) % 65521
+        }
+        i = i + 1
+    }
+    (b << 16) | a
+}
+
+// Test-facing canonical repair for adversarial fixtures. It intentionally does
+// not validate entry semantics, because malformed-but-integrity-correct entries
+// are required to exercise decoder diagnostics. Length is proven before the
+// checksum loop or slot write; rejected calls leave every byte unchanged.
+pub fn ir_numeric_payload_wire_reseal_canonical(
+    wire: &! IrNumericPayloadWireBuffer,
+) -> IrNumericPayloadWireStatus with Mut, Panic, Div {
+    if (*wire).len < IR_NUMERIC_WIRE_HEADER_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_TRUNCATED, (*wire).len, IR_NUMERIC_WIRE_HEADER_BYTES)
+    }
+    if (*wire).len > IR_NUMERIC_WIRE_MAX_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8, (*wire).len)
+    }
+    let checksum = ir_numeric_payload_wire_checksum_unchecked(wire)
+    wire_put_i64(wire, 32, checksum)
+    ir_numeric_payload_wire_status_ok()
+}
+
+pub fn ir_numeric_payload_wire_encode(
+    pool: &IrWideNumericPayloadPool,
+    out: &! IrNumericPayloadWireBuffer,
+) -> IrNumericPayloadWireStatus with Mut, Panic, Div {
+    let pool_status = ir_wide_numeric_payload_pool_validate(pool)
+    if pool_status != IR_WIDE_NUMERIC_OK {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_SOURCE_POOL, 0, pool_status)
+    }
+
+    let section_bytes = IR_NUMERIC_WIRE_HEADER_BYTES
+        + (*pool).payload_count * IR_NUMERIC_WIRE_ENTRY_BYTES
+        + (*pool).limb_count * IR_NUMERIC_WIRE_LIMB_BYTES
+    if section_bytes > IR_NUMERIC_WIRE_MAX_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_CAPACITY, 8, section_bytes)
+    }
+
+    // After validation and capacity proof there are no fallible encode steps,
+    // so publishing directly is transactional without relying on a wide
+    // temporary-struct copy in bootstrap compilers.
+    (*out).len = section_bytes
+    wire_put_u32(out, 0, IR_NUMERIC_WIRE_MAGIC)
+    wire_put_u16(out, 4, IR_NUMERIC_WIRE_VERSION)
+    wire_put_u16(out, 6, IR_NUMERIC_WIRE_HEADER_BYTES)
+    wire_put_i64(out, 8, section_bytes)
+    wire_put_i64(out, 16, (*pool).payload_count)
+    wire_put_i64(out, 24, (*pool).limb_count)
+    wire_put_i64(out, 32, 0)
+
+    var cursor: i64 = IR_NUMERIC_WIRE_HEADER_BYTES
+    var payload_id: i64 = 0
+    while payload_id < (*pool).payload_count {
+        let entry = (*pool).entries[payload_id as usize]
+        wire_put_i64(out, cursor, entry.format_id)
+        wire_put_i64(out, cursor + 8, entry.limb_start)
+        wire_put_i64(out, cursor + 16, entry.limb_count)
+        cursor = cursor + IR_NUMERIC_WIRE_ENTRY_BYTES
+        payload_id = payload_id + 1
+    }
+    var limb_index: i64 = 0
+    while limb_index < (*pool).limb_count {
+        wire_put_i64(out, cursor, (*pool).limbs[limb_index as usize])
+        cursor = cursor + IR_NUMERIC_WIRE_LIMB_BYTES
+        limb_index = limb_index + 1
+    }
+    let reseal_status = ir_numeric_payload_wire_reseal_canonical(out)
+    if reseal_status.code != IR_NUMERIC_WIRE_OK { return reseal_status }
+    ir_numeric_payload_wire_status_ok()
+}
+
+pub fn ir_numeric_payload_wire_decode(
+    wire: &IrNumericPayloadWireBuffer,
+    out: &! IrWideNumericPayloadPool,
+) -> IrNumericPayloadWireStatus with Mut, Panic, Div {
+    // Status precedence is stable and every indexed read is preceded by a
+    // length proof. The destination is not touched until all checks pass.
+    if (*wire).len < IR_NUMERIC_WIRE_HEADER_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_TRUNCATED, (*wire).len, IR_NUMERIC_WIRE_HEADER_BYTES)
+    }
+    if (*wire).len > IR_NUMERIC_WIRE_MAX_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8, (*wire).len)
+    }
+    if wire_get_u32(wire, 0) != IR_NUMERIC_WIRE_MAGIC {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_MAGIC, 0, wire_get_u32(wire, 0))
+    }
+    if wire_get_u16(wire, 4) != IR_NUMERIC_WIRE_VERSION {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_VERSION, 4, wire_get_u16(wire, 4))
+    }
+    if wire_get_u16(wire, 6) != IR_NUMERIC_WIRE_HEADER_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_HEADER, 6, wire_get_u16(wire, 6))
+    }
+
+    let section_bytes = wire_get_i64(wire, 8)
+    if section_bytes < IR_NUMERIC_WIRE_HEADER_BYTES || section_bytes > IR_NUMERIC_WIRE_MAX_BYTES {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8, section_bytes)
+    }
+    if section_bytes > (*wire).len {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_TRUNCATED, (*wire).len, section_bytes)
+    }
+    if section_bytes < (*wire).len {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_TRAILING_BYTES, section_bytes, (*wire).len - section_bytes)
+    }
+
+    let payload_count = wire_get_i64(wire, 16)
+    let limb_count = wire_get_i64(wire, 24)
+    if payload_count < 0 || payload_count > IR_WIDE_NUMERIC_MAX_PAYLOADS {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_COUNTS, 16, payload_count)
+    }
+    if limb_count < 0 || limb_count > IR_WIDE_NUMERIC_MAX_LIMBS {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_COUNTS, 24, limb_count)
+    }
+    let expected_bytes = IR_NUMERIC_WIRE_HEADER_BYTES
+        + payload_count * IR_NUMERIC_WIRE_ENTRY_BYTES
+        + limb_count * IR_NUMERIC_WIRE_LIMB_BYTES
+    if section_bytes != expected_bytes {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_BAD_LENGTH, 8, expected_bytes)
+    }
+
+    let stored_checksum = wire_get_i64(wire, 32)
+    let actual_checksum = ir_numeric_payload_wire_checksum_unchecked(wire)
+    if stored_checksum != actual_checksum {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_CHECKSUM, 32, 0)
+    }
+
+    var cursor: i64 = IR_NUMERIC_WIRE_HEADER_BYTES
+    var expected_start: i64 = 0
+    var payload_id: i64 = 0
+    while payload_id < payload_count {
+        let format_id = wire_get_i64(wire, cursor)
+        let limb_start = wire_get_i64(wire, cursor + 8)
+        let entry_limb_count = wire_get_i64(wire, cursor + 16)
+        let required = ir_wide_numeric_required_limb_count(format_id)
+        if required == 0 {
+            return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_UNKNOWN_FORMAT, cursor, format_id)
+        }
+        if entry_limb_count != required {
+            return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_NONCANONICAL_COUNT, cursor + 16, entry_limb_count)
+        }
+        if limb_start != expected_start {
+            return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_NONCANONICAL_SPAN, cursor + 8, limb_start)
+        }
+        // At this point limb_start == expected_start and expected_start is
+        // monotonically bounded by limb_count, so subtraction cannot overflow.
+        if limb_start < 0 || entry_limb_count > limb_count - limb_start {
+            return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_NONCANONICAL_SPAN, cursor + 8, limb_start)
+        }
+        expected_start = expected_start + entry_limb_count
+        cursor = cursor + IR_NUMERIC_WIRE_ENTRY_BYTES
+        payload_id = payload_id + 1
+    }
+    if expected_start != limb_count {
+        return ir_numeric_payload_wire_status(IR_NUMERIC_WIRE_ERR_NONCANONICAL_SPAN, 24, expected_start)
+    }
+
+    // All failure conditions have been discharged above. Publish only now;
+    // this keeps the caller's destination unchanged on every decoder error.
+    var clear_payload: i64 = 0
+    while clear_payload < IR_WIDE_NUMERIC_MAX_PAYLOADS {
+        (*out).entries[clear_payload as usize] = ir_empty_wide_numeric_payload_entry()
+        clear_payload = clear_payload + 1
+    }
+    var clear_limb: i64 = 0
+    while clear_limb < IR_WIDE_NUMERIC_MAX_LIMBS {
+        (*out).limbs[clear_limb as usize] = 0
+        clear_limb = clear_limb + 1
+    }
+    (*out).payload_count = payload_count
+    (*out).limb_count = limb_count
+    cursor = IR_NUMERIC_WIRE_HEADER_BYTES
+    payload_id = 0
+    while payload_id < payload_count {
+        (*out).entries[payload_id as usize] = IrWideNumericPayloadEntry {
+            format_id: wire_get_i64(wire, cursor),
+            limb_start: wire_get_i64(wire, cursor + 8),
+            limb_count: wire_get_i64(wire, cursor + 16),
+        }
+        cursor = cursor + IR_NUMERIC_WIRE_ENTRY_BYTES
+        payload_id = payload_id + 1
+    }
+    var limb_index: i64 = 0
+    while limb_index < limb_count {
+        (*out).limbs[limb_index as usize] = wire_get_i64(wire, cursor)
+        cursor = cursor + IR_NUMERIC_WIRE_LIMB_BYTES
+        limb_index = limb_index + 1
+    }
+    ir_numeric_payload_wire_status_ok()
+}


### PR DESCRIPTION
## Summary

- add a standalone canonical wire codec for the compiler-owned f128/f256 raw payload arena
- define an explicit 40-byte versioned envelope, 24-byte entries, and little-endian raw limb transport
- use standard Adler-32 as non-cryptographic integrity detection, not authentication
- decode with structured errors and transactional destination publication
- add byte-exact roundtrip, independent checksum oracle, adversarial mutations, and containment gates

## Stack

This PR is intentionally stacked on #931 and targets `codex/f128-v0b-numeric-pool-20260714`.

## Claim boundary

This proves a standalone numeric-payload wire v1 suitable for later embedding in a future SOIR v6 container. It is **not** current SOIR and does not modify the current serializer/version, `IrModule`, `IrInstr`, lowering, ABI, runtime, native backend, source types, arithmetic, or scientific claims.

## Canonical layout

- bytes 0..3: u32 magic `SNWP`
- bytes 4..5: u16 version 1
- bytes 6..7: u16 header length 40
- bytes 8..15: i64 section length
- bytes 16..23: i64 payload count
- bytes 24..31: i64 limb count
- bytes 32..39: zero-extended standard Adler-32
- entries: 24 bytes each as `{format_id, limb_start, limb_count}`
- body: raw i64 limbs, little-endian, arena order, limb 0 least-significant

## Evidence

- V0-C wire gate: PASS
- V0-B payload gate: PASS
- probe ELF SHA-256: `56dd75f973077045391da4d47aefa1875a61e4bd5ec498b3ccde4e724d287a6e`
- independent Adler-32 oracle: `0x57941ddc`
- exact oracle bytes: `dc 1d 94 57 00 00 00 00`
- 18 decoder negatives, 1 corrupt-source encode negative, 2 checked-reseal negatives
- byte-exact f128/f256 re-encode with high-bit limbs
- destination unchanged on structural, integrity, and semantic errors
- adversarial review: SAFE TO COMMIT

The review caught and caused correction of an initial nonstandard Adler packing and unchecked reseal bounds before commit. No mandatory LLM offload applies to this internal non-authenticating storage codec.