### PR TITLE
test(special): run-proof for special::gamma (coordinated disjoint lane)

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2797,3 +2797,7 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - **Bug found & fixed**: the tie-counting branches originally assigned tied-on-X pairs to Ty and vice-versa. Masked in kendall (τ_b denominator √((C+D+Tx)(C+D+Ty)) is symmetric in Tx/Ty) but surfaced in somers_d where the directions are distinct (D(Y|X) test gave 0.667 instead of 1.0). Fixed the labeling in both modules.
 - Theme: rank / ordinal association — complements the Pearson/Spearman correlation module. All O(n²) pair scans, scalar returns, #852-safe. Suite runner: 58 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-2RCSmH/`, `/tmp/llm-offload-sD8vnn/`, `/tmp/llm-offload-BerYTX/`.
+
+## 2026-07-14 — math-review: special::gamma run-proof
+- Files: `tests/stdlib/special/test_gamma_stdlib.sio`, `examples/special/gamma_report.sio` (no source edited).
+- Provider: xAI/Grok 4.3 = PASS. gamma(n)=(n-1)! (24,120) + recurrence; gamma(0.5)=√π, gamma(1.5)=√π/2; lgamma(5)=ln24=3.178054, lgamma(1)=0; digamma(1)=-γ=-0.5772157, digamma(2)=1-γ, recurrence. Default Madaros. SPECIAL_GAMMA_GATE_OK. (digamma negative asserted by value; print(f64) negative bug #890 worked around in the example.)

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 974
-- Repo-backed topics: 824
+- Total governed topics: 976
+- Repo-backed topics: 826
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 574
+- Authority count `repo_only`: 576
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 593 topics
+- A2: 595 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -787,6 +787,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-14-signal-fft-vertical | repo_only | docs/superpowers/plans/2026-07-14-signal-fft-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-signal-filter-vertical | repo_only | docs/superpowers/plans/2026-07-14-signal-filter-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-special-erf-vertical | repo_only | docs/superpowers/plans/2026-07-14-special-erf-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-14-special-gamma-vertical | repo_only | docs/superpowers/plans/2026-07-14-special-gamma-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof | repo_only | docs/superpowers/plans/2026-07-14-stats-validation-runproof.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-14-units-vertical | repo_only | docs/superpowers/plans/2026-07-14-units-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -797,6 +798,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.specs.2026-07-14-signal-fft-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-signal-fft-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-signal-filter-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-signal-filter-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-14-special-gamma-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design | repo_only | docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-units-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-units-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17407,6 +17407,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-14-special-gamma-vertical",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-14-special-gamma-vertical.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.plans.2026-07-14-stats-validation-runproof",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/plans/2026-07-14-stats-validation-runproof.md",
@@ -17617,6 +17640,29 @@
       "topic_id": "repo.docs.superpowers.specs.2026-07-14-special-erf-vertical-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-14-special-erf-vertical-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-14-special-gamma-vertical-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/superpowers/plans/2026-07-14-special-gamma-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-special-gamma-vertical.md
@@ -1,0 +1,5 @@
+# special::gamma Run-Proof — Plan
+> Default Madaros (self-contained, scalar). No source edits (disjoint). Spec: docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md.
+1. Run-proof `tests/stdlib/special/test_gamma_stdlib.sio`: gamma factorials + √π + recurrence; lgamma; digamma (=−γ, by value) + recurrence. `GAMMA_STDLIB_OK`.
+2. Example `examples/special/gamma_report.sio` (negative-safe digamma print) + gate `scripts/special_gamma_gate.sh` → `SPECIAL_GAMMA_GATE_OK`.
+3. math-review; governance sync; PR to main (rebase-on-conflict).

--- a/docs/superpowers/plans/2026-07-14-special-gamma-vertical.md
+++ b/docs/superpowers/plans/2026-07-14-special-gamma-vertical.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-14-special-gamma-vertical
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-14-special-gamma-vertical
+-->
+
 # special::gamma Run-Proof — Plan
 > Default Madaros (self-contained, scalar). No source edits (disjoint). Spec: docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md.
 1. Run-proof `tests/stdlib/special/test_gamma_stdlib.sio`: gamma factorials + √π + recurrence; lgamma; digamma (=−γ, by value) + recurrence. `GAMMA_STDLIB_OK`.

--- a/docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-14-special-gamma-vertical-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-14-special-gamma-vertical-design
+-->
+
 # Design — Harden the special::gamma vertical (coordinated, disjoint)
 **Date:** 2026-07-14 · no compiler changes · `special/gamma.sio` cold (no open PR). Scalar API is
 cross-module-safe. Reads the module + adds run-proof/example/gate; no source edits. EN-UK.

--- a/docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md
+++ b/docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md
@@ -1,0 +1,18 @@
+# Design — Harden the special::gamma vertical (coordinated, disjoint)
+**Date:** 2026-07-14 · no compiler changes · `special/gamma.sio` cold (no open PR). Scalar API is
+cross-module-safe. Reads the module + adds run-proof/example/gate; no source edits. EN-UK.
+
+## State
+`stdlib/special/gamma.sio` — self-contained, green, native under **default Madaros**. `gamma`, `lgamma`,
+`digamma` (scalar). Verified externally: gamma(5)=24, gamma(0.5)=√π, lgamma(5)=ln24, digamma(2)=1−γ.
+
+## Run-proof (known values / identities)
+- gamma(n)=(n−1)!: gamma(1)=1, gamma(5)=24, gamma(6)=120; recurrence gamma(6)=5·gamma(5).
+- gamma(0.5)=√π=1.7724539; gamma(1.5)=√π/2.
+- lgamma(5)=ln24=3.1780538; lgamma(1)=0.
+- digamma(1)=−γ=−0.5772157 (asserted by f64 value — print(f64) mis-renders negatives, #890);
+  digamma(2)=1−γ; recurrence digamma(2)=digamma(1)+1.
+
+## Layout / verification
+`tests/stdlib/special/test_gamma_stdlib.sio`, `examples/special/gamma_report.sio` (negative-safe digamma
+print), `scripts/special_gamma_gate.sh` (default Madaros) → `SPECIAL_GAMMA_GATE_OK`. Math-review logged. No source/compiler edits.

--- a/examples/special/gamma_report.sio
+++ b/examples/special/gamma_report.sio
@@ -1,0 +1,14 @@
+// Gamma / log-gamma / digamma report using stdlib special::gamma.
+// digamma(1) is negative; printed with a manual sign (print(f64) mis-renders negatives, bug #890).
+use special::gamma::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    print("=== special::gamma ===\n")
+    print("gamma(5) [=4! =24] = "); println(gamma(5.0))
+    print("gamma(0.5)[=sqrtpi]= "); println(gamma(0.5))
+    print("lgamma(10)[=ln9!]  = "); println(lgamma(10.0))
+    let d1 = digamma(1.0)
+    print("digamma(1)[=-gamma]= ")
+    if d1 < 0.0 { print("-"); println(0.0 - d1) } else { println(d1) }
+    print("digamma(2)[=1-gamma]= "); println(digamma(2.0))
+    return 0
+}

--- a/scripts/special_gamma_gate.sh
+++ b/scripts/special_gamma_gate.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check gamma.sio =="; $SOUC check stdlib/special/gamma.sio || fail=1
+echo "== run-proof =="
+if $SOUC compile tests/stdlib/special/test_gamma_stdlib.sio -o "$OUT/tg.elf"; then
+  "$OUT/tg.elf" | grep -q "GAMMA_STDLIB_OK" || { echo "FAIL: assertions"; fail=1; }
+else echo "FAIL: compile"; fail=1; fi
+echo "== example =="
+if $SOUC compile examples/special/gamma_report.sio -o "$OUT/gr.elf"; then "$OUT/gr.elf" >/dev/null || { echo "FAIL: example"; fail=1; }
+else echo "FAIL: example compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "SPECIAL_GAMMA_GATE_OK"
+exit $fail

--- a/tests/stdlib/special/test_gamma_stdlib.sio
+++ b/tests/stdlib/special/test_gamma_stdlib.sio
@@ -1,0 +1,46 @@
+// Run-proof for stdlib special::gamma against known values / identities.
+// Self-contained, scalar API -> default Madaros. Assert on f64 values (a negative digamma
+// value is correct even though print(f64) mis-renders negatives, bug #890).
+use special::gamma::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let sqrt_pi = 1.7724538509
+    let gamma_em = 0.5772156649   // Euler-Mascheroni gamma
+
+    // gamma(n) = (n-1)! : gamma(1)=1, gamma(2)=1, gamma(3)=2, gamma(4)=6, gamma(5)=24, gamma(6)=120
+    let g1 = gamma(1.0)
+    if (if g1 > 1.0 { g1-1.0 } else { 1.0-g1 }) >= 1.0e-6 { print("FAIL g1\n"); return 1 }
+    let g5 = gamma(5.0)
+    if (if g5 > 24.0 { g5-24.0 } else { 24.0-g5 }) >= 1.0e-4 { print("FAIL g5\n"); return 2 }
+    let g6 = gamma(6.0)
+    if (if g6 > 120.0 { g6-120.0 } else { 120.0-g6 }) >= 1.0e-3 { print("FAIL g6\n"); return 3 }
+    // recurrence gamma(6) = 5 * gamma(5)
+    let rec = 5.0 * g5
+    if (if g6 > rec { g6-rec } else { rec-g6 }) >= 1.0e-3 { print("FAIL recurrence\n"); return 4 }
+    // gamma(0.5) = sqrt(pi); gamma(1.5) = sqrt(pi)/2
+    let gh = gamma(0.5)
+    if (if gh > sqrt_pi { gh-sqrt_pi } else { sqrt_pi-gh }) >= 1.0e-5 { print("FAIL g_half\n"); return 5 }
+    let g15 = gamma(1.5)
+    let want15 = sqrt_pi / 2.0
+    if (if g15 > want15 { g15-want15 } else { want15-g15 }) >= 1.0e-5 { print("FAIL g1.5\n"); return 6 }
+
+    // lgamma(5) = ln(24) = 3.1780538; lgamma(1) = 0
+    let lg5 = lgamma(5.0)
+    if (if lg5 > 3.1780538 { lg5-3.1780538 } else { 3.1780538-lg5 }) >= 1.0e-5 { print("FAIL lg5\n"); return 7 }
+    let lg1 = lgamma(1.0)
+    if (if lg1 > 0.0 { lg1 } else { 0.0-lg1 }) >= 1.0e-6 { print("FAIL lg1\n"); return 8 }
+
+    // digamma(1) = -gamma_em (negative — asserted by value); digamma(2) = 1 - gamma_em
+    let d1 = digamma(1.0)
+    let want_d1 = 0.0 - gamma_em
+    if (if d1 > want_d1 { d1-want_d1 } else { want_d1-d1 }) >= 1.0e-5 { print("FAIL dg1\n"); return 9 }
+    let d2 = digamma(2.0)
+    let want_d2 = 1.0 - gamma_em
+    if (if d2 > want_d2 { d2-want_d2 } else { want_d2-d2 }) >= 1.0e-5 { print("FAIL dg2\n"); return 10 }
+    // digamma recurrence: digamma(2) = digamma(1) + 1
+    let dr = d1 + 1.0
+    if (if d2 > dr { d2-dr } else { dr-d2 }) >= 1.0e-6 { print("FAIL dg_recurrence\n"); return 11 }
+
+    print("GAMMA_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
Eleventh playbook vertical. Independent run-proof for self-contained `special::gamma` (native under **default Madaros**, scalar API): gamma(n)=(n-1)! + recurrence, gamma(0.5)=√π, lgamma, digamma(1)=-γ (asserted by value; #890 negative-print worked around in the example). Disjoint (`special/gamma.sio` cold, no open PR). No source edits. Gate `SPECIAL_GAMMA_GATE_OK`; math-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)