### PR TITLE
feat(stats): non-parametric location tests — mann_whitney, sign_test, mood_median

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2805,3 +2805,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - var_ftest = **PASS**: F=s1²/s2², two-sided p=2·min(cdf,1−cdf), F-CDF via I_x(d1/2,d2/2); F(4,4) at 0.25 → p=0.208 exact. Reviewer flagged the inline exp/ln/betacf helpers as bounded-precision without proven error bounds at extreme args — a general property of every inline special function in the suite; reviewer confirms "all downstream statistical claims remain valid." Not a defect; sufficient for the tested tolerances.
 - Theme: homogeneity-of-variance / homoscedasticity tests — completes the parametric-assumption-checking trio (normality, independence, now equal variance). All scalar/small-array, #852-safe. Suite runner: 61 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-orKL2v/`, `/tmp/llm-offload-2oDw1A/`, `/tmp/llm-offload-5aKJEh/`.
+
+## 2026-07-14 — math-review: stats::mann_whitney, stats::sign_test, stats::mood_median
+- Files (all new): `stdlib/stats/mann_whitney.sio` (two-sample rank-sum U test with tie-corrected normal approx), `stdlib/stats/sign_test.sio` (paired & one-sample sign test, exact binomial), `stdlib/stats/mood_median.sio` (k-sample median test, χ² on 2×k table). Provider: xAI/Grok 4.3.
+- mann_whitney = **PASS**: μ_U=n₁n₂/2, tie-corrected σ²_U=(n₁n₂/12)[(N+1)−Σ(t³−t)/(N(N−1))], z, two-sided p all match; mid-rank less/eq counting correct; separated case z=−1.964, p=0.0495 verified.
+- sign_test = **PASS**: Bin(m,½) exact two-sided p via forward binomial recurrence, zeros dropped; 46/512=0.1797 and 5/16=0.625 verified.
+- mood_median = **PASS**: 2×k Pearson χ², df=k−1, degenerate-split guard; median 5.5/χ²=10 verified.
+- Theme: non-parametric location tests — fills the standalone rank-sum / sign / median-test gap beside wilcoxon (paired) and kruskal_wallis (k-sample). All deterministic/derivable, #852-safe. Suite runner: 64 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-ChPzJD/`, `/tmp/llm-offload-sVEzvh/`, `/tmp/llm-offload-nZbhUO/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -70,6 +70,9 @@ MODULES=(
   stdlib/stats/bartlett.sio
   stdlib/stats/levene.sio
   stdlib/stats/var_ftest.sio
+  stdlib/stats/mann_whitney.sio
+  stdlib/stats/sign_test.sio
+  stdlib/stats/mood_median.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -887,6 +887,37 @@ symmetric data); equal-spread → W=0.
 The classical variance-ratio test `F=s₁²/s₂² ~ F(n₁−1,n₂−1)` with a two-sided
 p-value. Validated: var 2.5 vs 10 → F=0.25, p=0.208; equal variances → F=1, p=1.
 
+### `stats::mann_whitney` — Mann-Whitney U / rank-sum test
+
+| Function | Signature |
+|---|---|
+| `mann_whitney` | `pub fn mann_whitney(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> MannWhitneyResult with Mut, Div, Panic` |
+
+The two-sample rank-sum test (unpaired counterpart to Wilcoxon signed-rank):
+`U₁=R₁−n₁(n₁+1)/2`, tie-corrected normal-approximation z. Validated: fully
+separated → U=0, z=−1.964, p=0.0495; overlapping → U₁=3, p>0.5; cross-group ties
+→ R₁=8.
+
+### `stats::sign_test` — sign test
+
+| Function | Signature |
+|---|---|
+| `sign_test` | `pub fn sign_test(x: &[f64; 256], y: &[f64; 256], n: i32) -> SignResult with Mut, Div, Panic` |
+| `sign_test_median` | `pub fn sign_test_median(x: &[f64; 256], n: i32, m0: f64) -> SignResult with Mut, Div, Panic` |
+
+The simplest distribution-free test — signs only, exact binomial p (zeros
+dropped). Validated: 7+/2− → p=0.1797; one-sample median → p=0.625.
+
+### `stats::mood_median` — Mood's median test
+
+| Function | Signature |
+|---|---|
+| `mood_median` | `pub fn mood_median(values: &[f64; 256], sizes: &[i32; 16], k: i32) -> MoodResult with Mut, Div, Panic` |
+
+A robust k-sample equal-medians test: χ² on the 2×k above/below-pooled-median
+table. Less powerful than Kruskal-Wallis but far more outlier-resistant.
+Validated: {1..5} vs {6..10} → median 5.5, χ²=10, df=1; identical groups → χ²=0.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -952,6 +983,9 @@ use stats::somers_d::{SomersResult, somers_d}
 use stats::bartlett::{BartlettResult, bartlett}
 use stats::levene::{LeveneResult, levene}
 use stats::var_ftest::{VarFResult, var_ftest}
+use stats::mann_whitney::{MannWhitneyResult, mann_whitney}
+use stats::sign_test::{SignResult, sign_test, sign_test_median}
+use stats::mood_median::{MoodResult, mood_median}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/mann_whitney.sio
+++ b/stdlib/stats/mann_whitney.sio
@@ -1,0 +1,204 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/mann_whitney.sio — Mann-Whitney U / Wilcoxon rank-sum test
+//
+// The two-sample non-parametric test of whether one distribution is
+// stochastically shifted from the other — the unpaired counterpart to Wilcoxon
+// signed-rank:
+//
+//   mann_whitney(x, nx, y, ny) -> MannWhitneyResult
+//
+// Rank the pooled sample (mid-ranks for ties). With R₁ the rank sum of x,
+//   U₁ = R₁ − n₁(n₁+1)/2,   U₂ = n₁n₂ − U₁,   U = min(U₁, U₂),
+//   μ_U = n₁n₂/2,
+//   σ²_U = (n₁n₂/12)·[ (N+1) − Σ(tᵢ³−tᵢ)/(N(N−1)) ],   z = (U₁ − μ_U)/σ_U,
+// with a tie correction over each tied group of size tᵢ; two-sided normal p.
+//
+// Pure Sounio: mid-ranks via O(N²) less/equal counting; inline sqrt/erf; no
+// nested data-array calls.
+//
+// References:
+//   Mann & Whitney (1947) Ann. Math. Stat. 18:50; Wilcoxon (1945).
+
+module stats::mann_whitney
+
+fn mw_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn mw_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / mw_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn mw_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * mw_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn mw_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - mw_erf(z * INV_SQRT2))
+}
+
+pub struct MannWhitneyResult {
+    pub u: f64,       // min(U1, U2)
+    pub u1: f64,      // U for sample x
+    pub r1: f64,      // rank sum of x
+    pub z: f64,
+    pub p: f64,       // two-sided p
+}
+
+/// Mann-Whitney U test between samples x and y.
+///
+/// Parâmetros: x, y — the two samples; nx, ny — sizes (<=128 each; nx+ny<=256).
+/// Retorno: MannWhitneyResult (u, u1, r1, z, p).
+/// Referências: Mann & Whitney (1947).
+pub fn mann_whitney(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> MannWhitneyResult with Mut, Div, Panic {
+    if nx < 1 || ny < 1 {
+        return MannWhitneyResult { u: 0.0, u1: 0.0, r1: 0.0, z: 0.0, p: 1.0 }
+    }
+    let ntot = nx + ny
+    // pooled values: first nx are x, next ny are y
+    var all: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < nx { all[i as usize] = x[i as usize]; i = i + 1 }
+    var j = 0
+    while j < ny { all[(nx + j) as usize] = y[j as usize]; j = j + 1 }
+    // mid-rank of each element and rank sum of the x group
+    var r1 = 0.0
+    var tie_sum = 0.0
+    var a = 0
+    while a < ntot {
+        var less = 0
+        var eq = 0
+        var first = true
+        var b = 0
+        while b < ntot {
+            let vb = all[b as usize]
+            let va = all[a as usize]
+            if vb < va { less = less + 1 }
+            else { if vb == va { eq = eq + 1; if b < a { first = false } } }
+            b = b + 1
+        }
+        let rank = (less as f64) + ((eq + 1) as f64) * 0.5
+        if a < nx { r1 = r1 + rank }
+        // accumulate tie correction once per tied group
+        if first && eq > 1 {
+            let t = eq as f64
+            tie_sum = tie_sum + (t * t * t - t)
+        }
+        a = a + 1
+    }
+    let nxf = nx as f64
+    let nyf = ny as f64
+    let nf = ntot as f64
+    let u1 = r1 - nxf * (nxf + 1.0) / 2.0
+    let u2 = nxf * nyf - u1
+    var u = u1
+    if u2 < u1 { u = u2 }
+    let mu = nxf * nyf / 2.0
+    var varu = (nxf * nyf / 12.0) * ((nf + 1.0) - tie_sum / (nf * (nf - 1.0)))
+    var z = 0.0
+    if varu > 0.0 { z = (u1 - mu) / mw_sqrt(varu) }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * mw_normal_sf(az)
+    return MannWhitneyResult { u: u, u1: u1, r1: r1, z: z, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// fully separated x={1,2,3}, y={4,5,6}: R1=6, U1=0, U=0. mu=4.5, var=5.25,
+// z=(0-4.5)/2.291288=-1.963961; p=2·Φ̄(1.963961)=0.049536.
+fn test_separated() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    y[0]=4.0; y[1]=5.0; y[2]=6.0
+    let r = mann_whitney(&x, 3, &y, 3)
+    var ok = true
+    ok = check(1, approx(r.r1, 6.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.u1, 0.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.u, 0.0, 1.0e-9)) && ok
+    ok = check(4, approx(r.z, 0.0 - 1.963961, 1.0e-4)) && ok
+    ok = check(5, approx(r.p, 0.049536, 1.0e-3)) && ok
+    return ok
+}
+
+// identical distributions x={1,3,5}, y={2,4,6}: R1=1+3+5 ranks(1,3,5)=9. U1=9-6=3.
+// mu=4.5. symmetric -> z small, p large.
+fn test_overlap() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=3.0; x[2]=5.0
+    y[0]=2.0; y[1]=4.0; y[2]=6.0
+    let r = mann_whitney(&x, 3, &y, 3)
+    var ok = true
+    ok = check(10, approx(r.u1, 3.0, 1.0e-9)) && ok
+    ok = check(11, r.p > 0.5) && ok
+    return ok
+}
+
+// ties across groups x={1,2,3}, y={2,3,4}: ranks 1,2.5,4.5 for x -> R1=8, U1=2.
+fn test_ties() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    y[0]=2.0; y[1]=3.0; y[2]=4.0
+    let r = mann_whitney(&x, 3, &y, 3)
+    var ok = true
+    ok = check(20, approx(r.r1, 8.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.u1, 2.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_separated() && ok
+    ok = test_overlap() && ok
+    ok = test_ties() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/mood_median.sio
+++ b/stdlib/stats/mood_median.sio
@@ -1,0 +1,279 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/mood_median.sio — Mood's median test
+//
+// A robust k-sample test of equal medians: split every observation by whether
+// it exceeds the pooled median, then run a chi-squared test on the resulting
+// 2×k table.
+//
+//   mood_median(values, sizes, k) -> MoodResult   (groups = consecutive blocks)
+//
+// With Aᵢ above / Bᵢ at-or-below the grand median M in group i, row totals A,B
+// and N observations,
+//   χ² = ΣΣ (O − E)²/E,   E(above,i) = A·nᵢ/N,   df = k − 1.
+// Less powerful than Kruskal-Wallis but far more resistant to outliers and
+// heavy tails.
+//
+// Pure Sounio: an inline sort of the pooled sample for the median; the χ² tail
+// via inline Lanczos log-gamma + incomplete gamma. No nested data-array calls.
+//
+// References:
+//   Mood (1950); Brown & Mood (1951).
+
+module stats::mood_median
+
+fn md_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / md_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn md_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn md_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * md_ln(tt) - tt + md_ln(a)
+}
+
+fn md_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * md_exp(0.0 - x + s * md_ln(x) - md_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = md_exp(0.0 - x + s * md_ln(x) - md_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn md_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    if df <= 0.0 { return 1.0 }
+    return 1.0 - md_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct MoodResult {
+    pub chi2: f64,
+    pub df: i64,
+    pub p: f64,
+    pub grand_median: f64,
+}
+
+/// Mood's median test across k consecutive-block groups.
+///
+/// Parâmetros: values — concatenated group data; sizes — per-group n (>=1);
+///             k — number of groups (2..16).
+/// Retorno: MoodResult (chi2, df, p, grand_median).
+/// Referências: Mood (1950); Brown & Mood (1951).
+pub fn mood_median(values: &[f64; 256], sizes: &[i32; 16], k: i32) -> MoodResult with Mut, Div, Panic {
+    if k < 2 || k > 16 { return MoodResult { chi2: 0.0, df: 0, p: 1.0, grand_median: 0.0 } }
+    var ntot = 0
+    var g = 0
+    while g < k { ntot = ntot + sizes[g as usize]; g = g + 1 }
+    if ntot < 2 { return MoodResult { chi2: 0.0, df: 0, p: 1.0, grand_median: 0.0 } }
+    // pooled median via inline insertion sort of a copy
+    var buf: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < ntot { buf[i as usize] = values[i as usize]; i = i + 1 }
+    var ii = 1
+    while ii < ntot {
+        let key = buf[ii as usize]
+        var jj = ii - 1
+        while jj >= 0 && buf[jj as usize] > key { buf[(jj + 1) as usize] = buf[jj as usize]; jj = jj - 1 }
+        buf[(jj + 1) as usize] = key
+        ii = ii + 1
+    }
+    var med = 0.0
+    if ntot % 2 == 1 { med = buf[((ntot - 1) / 2) as usize] }
+    else { med = 0.5 * (buf[(ntot / 2 - 1) as usize] + buf[(ntot / 2) as usize]) }
+    // per-group above/below the grand median
+    let nf = ntot as f64
+    var above_tot = 0
+    var off = 0
+    var g2 = 0
+    // first pass: total above
+    while g2 < k {
+        let ni = sizes[g2 as usize]
+        var b = 0
+        while b < ni { if values[(off + b) as usize] > med { above_tot = above_tot + 1 } b = b + 1 }
+        off = off + ni
+        g2 = g2 + 1
+    }
+    let A = above_tot as f64
+    let B = nf - A
+    if A <= 0.0 || B <= 0.0 {
+        // median splits nothing (e.g. all tied) -> no evidence
+        return MoodResult { chi2: 0.0, df: (k - 1) as i64, p: 1.0, grand_median: med }
+    }
+    var chi2 = 0.0
+    var off2 = 0
+    var g3 = 0
+    while g3 < k {
+        let ni = sizes[g3 as usize]
+        var ai = 0
+        var b = 0
+        while b < ni { if values[(off2 + b) as usize] > med { ai = ai + 1 } b = b + 1 }
+        let nif = ni as f64
+        let e_above = A * nif / nf
+        let e_below = B * nif / nf
+        let o_above = ai as f64
+        let o_below = nif - o_above
+        if e_above > 0.0 { chi2 = chi2 + (o_above - e_above) * (o_above - e_above) / e_above }
+        if e_below > 0.0 { chi2 = chi2 + (o_below - e_below) * (o_below - e_below) / e_below }
+        off2 = off2 + ni
+        g3 = g3 + 1
+    }
+    let df = k - 1
+    let p = md_chi2_sf(chi2, df as f64)
+    return MoodResult { chi2: chi2, df: df as i64, p: p, grand_median: med }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// g1={1,2,3,4,5}, g2={6,7,8,9,10}. grand median 5.5. above: g1=0,g2=5.
+// A=5,B=5,N=10. all E=2.5. chi2=4·2.5=10. df=1.
+fn test_mood() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0; v[4]=5.0
+    v[5]=6.0; v[6]=7.0; v[7]=8.0; v[8]=9.0; v[9]=10.0
+    sz[0]=5; sz[1]=5
+    let r = mood_median(&v, &sz, 2)
+    var ok = true
+    ok = check(1, approx(r.grand_median, 5.5, 1.0e-9)) && ok
+    ok = check(2, approx(r.chi2, 10.0, 1.0e-6)) && ok
+    ok = check(3, r.df == 1) && ok
+    ok = check(4, r.p < 0.01) && ok
+    return ok
+}
+
+// identical groups g1={1,2,3,4}, g2={1,2,3,4}. grand median 2.5. above=2,2 -> chi2=0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0; v[3]=4.0
+    v[4]=1.0; v[5]=2.0; v[6]=3.0; v[7]=4.0
+    sz[0]=4; sz[1]=4
+    let r = mood_median(&v, &sz, 2)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+// three groups, distinct locations.
+fn test_three() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0
+    v[3]=4.0; v[4]=5.0; v[5]=6.0
+    v[6]=7.0; v[7]=8.0; v[8]=9.0
+    sz[0]=3; sz[1]=3; sz[2]=3
+    let r = mood_median(&v, &sz, 3)
+    // grand median 5. above: g1=0,g2=1(6),g3=3. df=2.
+    var ok = true
+    ok = check(20, approx(r.grand_median, 5.0, 1.0e-9)) && ok
+    ok = check(21, r.df == 2) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_mood() && ok
+    ok = test_null() && ok
+    ok = test_three() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/sign_test.sio
+++ b/stdlib/stats/sign_test.sio
@@ -1,0 +1,175 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/sign_test.sio — sign test for a paired / one-sample median
+//
+// The simplest distribution-free test: it uses only the *signs* of the
+// differences, so it needs no assumption beyond independent pairs.
+//
+//   sign_test(x, y, n)          -> SignResult   (paired: signs of xᵢ − yᵢ)
+//   sign_test_median(x, n, m0)  -> SignResult   (one-sample: signs of xᵢ − m0)
+//
+// With n₊ positive and n₋ negative differences (zeros dropped), under H₀ the
+// number of successes is Binomial(n₊+n₋, ½), so the exact two-sided p is
+//   p = 2·P(X ≥ max(n₊, n₋)),   X ~ Bin(n₊+n₋, ½),
+// capped at 1.
+//
+// Pure Sounio: the exact binomial tail via a running coefficient; no external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Arbuthnott (1710); Conover, "Practical Nonparametric Statistics" 3e, §3.4.
+
+module stats::sign_test
+
+fn st_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / st_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+pub struct SignResult {
+    pub n_pos: i64,
+    pub n_neg: i64,
+    pub p: f64,      // exact two-sided p-value
+}
+
+// exact two-sided sign-test p from n+ and n-.
+fn sign_pvalue(npos: i32, nneg: i32) -> f64 with Mut, Div, Panic {
+    let m = npos + nneg
+    if m <= 0 { return 1.0 }
+    var hi = npos
+    if nneg > npos { hi = nneg }
+    let half_pow = st_exp((0.0 - (m as f64)) * 0.6931471805599453)  // 0.5^m
+    // advance coef to C(m, hi)
+    var coef = 1.0
+    var k = 0
+    while k < hi { coef = coef * ((m - k) as f64) / ((k + 1) as f64); k = k + 1 }
+    var tail = 0.0
+    var kk = hi
+    var cf = coef
+    while kk <= m {
+        tail = tail + cf * half_pow
+        cf = cf * ((m - kk) as f64) / ((kk + 1) as f64)
+        kk = kk + 1
+    }
+    var p = 2.0 * tail
+    if p > 1.0 { p = 1.0 }
+    return p
+}
+
+/// Paired sign test on the signs of xᵢ − yᵢ.
+///
+/// Parâmetros: x, y — paired samples; n — size.
+/// Retorno: SignResult (n_pos, n_neg, p).
+/// Referências: Conover §3.4.
+pub fn sign_test(x: &[f64; 256], y: &[f64; 256], n: i32) -> SignResult with Mut, Div, Panic {
+    var npos = 0
+    var nneg = 0
+    var i = 0
+    while i < n {
+        let d = x[i as usize] - y[i as usize]
+        if d > 0.0 { npos = npos + 1 } else { if d < 0.0 { nneg = nneg + 1 } }
+        i = i + 1
+    }
+    return SignResult { n_pos: npos as i64, n_neg: nneg as i64, p: sign_pvalue(npos, nneg) }
+}
+
+/// One-sample sign test that the median equals m0.
+///
+/// Parâmetros: x — sample; n — size; m0 — hypothesised median.
+/// Retorno: SignResult (n_pos, n_neg, p).
+pub fn sign_test_median(x: &[f64; 256], n: i32, m0: f64) -> SignResult with Mut, Div, Panic {
+    var npos = 0
+    var nneg = 0
+    var i = 0
+    while i < n {
+        let d = x[i as usize] - m0
+        if d > 0.0 { npos = npos + 1 } else { if d < 0.0 { nneg = nneg + 1 } }
+        i = i + 1
+    }
+    return SignResult { n_pos: npos as i64, n_neg: nneg as i64, p: sign_pvalue(npos, nneg) }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 7 positive, 2 negative differences (n=9). p = 2·P(X>=7), X~Bin(9,0.5).
+// P(X>=7)=(C(9,7)+C(9,8)+C(9,9))/512=(36+9+1)/512=46/512=0.089844. p=0.179688.
+fn test_paired() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    // 7 pairs x>y, 2 pairs x<y
+    x[0]=2.0; x[1]=2.0; x[2]=2.0; x[3]=2.0; x[4]=2.0; x[5]=2.0; x[6]=2.0; x[7]=0.0; x[8]=0.0
+    y[0]=1.0; y[1]=1.0; y[2]=1.0; y[3]=1.0; y[4]=1.0; y[5]=1.0; y[6]=1.0; y[7]=1.0; y[8]=1.0
+    let r = sign_test(&x, &y, 9)
+    var ok = true
+    ok = check(1, r.n_pos == 7) && ok
+    ok = check(2, r.n_neg == 2) && ok
+    ok = check(3, approx(r.p, 0.179688, 1.0e-5)) && ok
+    return ok
+}
+
+// zeros dropped: differences of exactly 0 are ignored.
+// x-y signs: +,+,0,-,+  -> n+=3, n-=1. p=2·P(X>=3),X~Bin(4,.5)=2·(4+1)/16=0.625.
+fn test_zeros() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=3.0; x[1]=3.0; x[2]=5.0; x[3]=1.0; x[4]=3.0
+    y[0]=1.0; y[1]=1.0; y[2]=5.0; y[3]=2.0; y[4]=1.0
+    let r = sign_test(&x, &y, 5)
+    var ok = true
+    ok = check(10, r.n_pos == 3) && ok
+    ok = check(11, r.n_neg == 1) && ok
+    ok = check(12, approx(r.p, 0.625, 1.0e-6)) && ok
+    return ok
+}
+
+// one-sample median test: {1,2,3,4,10} vs m0=2 -> 3 above, 1 below (2 excluded).
+// p=2·P(X>=3),Bin(4,.5)=0.625.
+fn test_median() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=10.0
+    let r = sign_test_median(&x, 5, 2.0)
+    var ok = true
+    ok = check(20, r.n_pos == 3) && ok
+    ok = check(21, r.n_neg == 1) && ok
+    ok = check(22, approx(r.p, 0.625, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_paired() && ok
+    ok = test_zeros() && ok
+    ok = test_median() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three distribution-free location tests for the epistemic-statistics suite, bringing the runner to **64 modules**. These fill the standalone rank-sum / sign / median-test gap beside `wilcoxon` (paired) and `kruskal_wallis` (k-sample). Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | Test | Design |
|---|---|---|
| `stats::mann_whitney` | Mann-Whitney U / Wilcoxon rank-sum (tie-corrected z) | two independent samples |
| `stats::sign_test` | sign test, exact binomial (zeros dropped) | paired & one-sample median |
| `stats::mood_median` | Mood's median test, χ² on 2×k table | k-sample, outlier-robust |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Mann-Whitney: {1,2,3} vs {4,5,6} → U=0, z=−1.964, p=0.0495; overlapping → U₁=3, p>0.5; cross-group ties → R₁=8.
  - Sign test: 7+/2− → p=2·(46/512)=0.1797; one-sample median with a tie dropped → p=0.625.
  - Mood: {1..5} vs {6..10} → grand median 5.5, χ²=10, df=1; identical groups → χ²=0.
- Full suite selftest: **64 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; all three are deterministic and fully hand-derivable.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).