### PR TITLE
test(stdlib): batch run-proofs — special::beta + math::hyperbolic + math::rational

### DIFF
--- a/scripts/math_verticals_batch_gate.sh
+++ b/scripts/math_verticals_batch_gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Combined gate for the grouped run-proof batch: special::beta, math::hyperbolic, math::rational.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module_check_path  driver_path  sentinel
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/special/beta.sio       tests/stdlib/special/test_beta_stdlib.sio        BETA_STDLIB_OK
+run stdlib/math/hyperbolic.sio    tests/stdlib/math/test_hyperbolic_stdlib.sio     HYPERBOLIC_STDLIB_OK
+run stdlib/math/rational.sio      tests/stdlib/math/test_rational_stdlib.sio       RATIONAL_STDLIB_OK
+[ $fail -eq 0 ] && echo "MATH_VERTICALS_BATCH_GATE_OK"
+exit $fail

--- a/tests/stdlib/math/test_hyperbolic_stdlib.sio
+++ b/tests/stdlib/math/test_hyperbolic_stdlib.sio
@@ -1,0 +1,21 @@
+// Run-proof for stdlib math::hyperbolic. Self-contained scalar -> default Madaros.
+use math::hyperbolic::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    if (if hyp_cosh(0.0) > 1.0 { hyp_cosh(0.0)-1.0 } else { 1.0-hyp_cosh(0.0) }) >= 1.0e-9 { print("FAIL cosh0\n"); return 1 }
+    if (if hyp_sinh(0.0) > 0.0 { hyp_sinh(0.0) } else { 0.0-hyp_sinh(0.0) }) >= 1.0e-9 { print("FAIL sinh0\n"); return 2 }
+    let c1 = hyp_cosh(1.0)
+    if (if c1 > 1.5430806 { c1-1.5430806 } else { 1.5430806-c1 }) >= 1.0e-5 { print("FAIL cosh1\n"); return 3 }
+    let s1 = hyp_sinh(1.0)
+    if (if s1 > 1.1752012 { s1-1.1752012 } else { 1.1752012-s1 }) >= 1.0e-5 { print("FAIL sinh1\n"); return 4 }
+    // identity cosh^2 - sinh^2 = 1 at x=1.3
+    let c = hyp_cosh(1.3)
+    let s = hyp_sinh(1.3)
+    let id = c*c - s*s
+    if (if id > 1.0 { id-1.0 } else { 1.0-id }) >= 1.0e-6 { print("FAIL identity\n"); return 5 }
+    // arccosh round-trip: arccosh(cosh(2)) = 2 ; arccosh(1)=0
+    let r = arccosh(hyp_cosh(2.0))
+    if (if r > 2.0 { r-2.0 } else { 2.0-r }) >= 1.0e-5 { print("FAIL arccosh_rt\n"); return 6 }
+    if (if arccosh(1.0) > 0.0 { arccosh(1.0) } else { 0.0-arccosh(1.0) }) >= 1.0e-5 { print("FAIL arccosh1\n"); return 7 }
+    print("HYPERBOLIC_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_rational_stdlib.sio
+++ b/tests/stdlib/math/test_rational_stdlib.sio
@@ -1,0 +1,24 @@
+// Run-proof for stdlib math::rational (exact fraction arithmetic). Uses rat_cmp for value equality
+// (results may be unreduced). Self-contained -> default Madaros.
+use math::rational::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // 1/2 + 1/3 = 5/6 (reduced)
+    let s = rat_add(rat_make(1,2), rat_make(1,3))
+    if s.num != 5 { print("FAIL add num\n"); return 1 }
+    if s.den != 6 { print("FAIL add den\n"); return 2 }
+    // 2/3 * 3/4 = 1/2 (value)
+    if rat_cmp(rat_mul(rat_make(2,3), rat_make(3,4)), rat_make(1,2)) != 0 { print("FAIL mul\n"); return 3 }
+    // 3/4 - 1/4 = 1/2
+    if rat_cmp(rat_sub(rat_make(3,4), rat_make(1,4)), rat_make(1,2)) != 0 { print("FAIL sub\n"); return 4 }
+    // (1/2) / (1/4) = 2
+    if rat_cmp(rat_div(rat_make(1,2), rat_make(1,4)), rat_make(2,1)) != 0 { print("FAIL div\n"); return 5 }
+    // equality of unreduced forms: 1/2 == 2/4
+    if rat_cmp(rat_make(1,2), rat_make(2,4)) != 0 { print("FAIL eq\n"); return 6 }
+    // ordering: 1/2 > 1/3 ; 1/3 < 1/2
+    if rat_cmp(rat_make(1,2), rat_make(1,3)) <= 0 { print("FAIL gt\n"); return 7 }
+    if rat_cmp(rat_make(1,3), rat_make(1,2)) >= 0 { print("FAIL lt\n"); return 8 }
+    // negation: -(1/2) == (0-1)/2, and cmp to 1/2 is < 0
+    if rat_cmp(rat_neg(rat_make(1,2)), rat_make(1,2)) >= 0 { print("FAIL neg\n"); return 9 }
+    print("RATIONAL_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/special/test_beta_stdlib.sio
+++ b/tests/stdlib/special/test_beta_stdlib.sio
@@ -1,0 +1,26 @@
+// Run-proof for stdlib special::beta. Self-contained scalar -> default Madaros.
+use special::beta::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let pi = 3.1415926536
+    let b23 = beta(2.0, 3.0)                 // 1/12
+    if (if b23 > 0.0833333 { b23-0.0833333 } else { 0.0833333-b23 }) >= 1.0e-6 { print("FAIL b23\n"); return 1 }
+    let b11 = beta(1.0, 1.0)                 // 1
+    if (if b11 > 1.0 { b11-1.0 } else { 1.0-b11 }) >= 1.0e-6 { print("FAIL b11\n"); return 2 }
+    let b32 = beta(3.0, 2.0)                 // symmetry
+    if (if b23 > b32 { b23-b32 } else { b32-b23 }) >= 1.0e-9 { print("FAIL sym\n"); return 3 }
+    let bhh = beta(0.5, 0.5)                 // pi
+    if (if bhh > pi { bhh-pi } else { pi-bhh }) >= 1.0e-5 { print("FAIL bhh\n"); return 4 }
+    // regularized incomplete beta bounds
+    if (if ibeta(2.0,3.0,0.0) > 0.0 { ibeta(2.0,3.0,0.0) } else { 0.0-ibeta(2.0,3.0,0.0) }) >= 1.0e-9 { print("FAIL ib0\n"); return 5 }
+    let ib1 = ibeta(2.0,3.0,1.0)
+    if (if ib1 > 1.0 { ib1-1.0 } else { 1.0-ib1 }) >= 1.0e-6 { print("FAIL ib1\n"); return 6 }
+    // symmetric beta -> median at 0.5: I_{0.5}(2,2)=0.5
+    let med = ibeta(2.0,2.0,0.5)
+    if (if med > 0.5 { med-0.5 } else { 0.5-med }) >= 1.0e-5 { print("FAIL median\n"); return 7 }
+    // round-trip ibeta_inv
+    let x = ibeta_inv(2.0, 3.0, 0.7)
+    let back = ibeta(2.0, 3.0, x)
+    if (if back > 0.7 { back-0.7 } else { 0.7-back }) >= 1.0e-4 { print("FAIL roundtrip\n"); return 8 }
+    print("BETA_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
**Grouped PR (3 verticals in one)** to cut merge friction (repo has no auto-merge; main is hyperactive). Three cold/disjoint, self-contained modules, native under **default Madaros**, cross-module-safe APIs, **no source edits**:
- **special::beta** — beta(2,3)=1/12, beta(0.5,0.5)=π, symmetry, ibeta bounds + I_{0.5}(2,2)=0.5 + ibeta_inv round-trip → `BETA_STDLIB_OK`.
- **math::hyperbolic** — cosh/sinh(0,1), cosh²−sinh²=1, arccosh round-trip → `HYPERBOLIC_STDLIB_OK`.
- **math::rational** — exact fractions (1/2+1/3=5/6, etc. via rat_cmp) → `RATIONAL_STDLIB_OK`.

Combined gate `MATH_VERTICALS_BATCH_GATE_OK`; one math-review PASS on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)