### PR TITLE
ci: resync docs governance registry

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,25 +19,25 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 988
-- Repo-backed topics: 838
+- Total governed topics: 980
+- Repo-backed topics: 830
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 218
-- Authority count `repo_only`: 582
+- Authority count `historical`: 212
+- Authority count `repo_only`: 580
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 601 topics
+- A2: 599 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 252 topics
+- A6: 246 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -123,8 +123,6 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.g1-wip.tuple-match-feature-design-2026-06-03 | repo_only | docs/audit/g1_wip/TUPLE_MATCH_FEATURE_DESIGN_2026-06-03.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.g1-wip.verdict-parity-2026-06-02 | repo_only | docs/audit/g1_wip/VERDICT_PARITY_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.gpu-pipeline-sota-assessment-2026-05-30 | repo_only | docs/audit/GPU_PIPELINE_SOTA_ASSESSMENT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.audit.hypercomplex-651-rootcause-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.audit.hypercomplex-algebra-audit-2026-07-14 | repo_only | docs/audit/HYPERCOMPLEX_ALGEBRA_AUDIT_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17 | repo_only | docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-a64-knowledge-arithmetic-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_KNOWLEDGE_ARITHMETIC_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.lean-single-a64-struct-field-aggregate-copy-2026-07-05 | repo_only | docs/audit/LEAN_SINGLE_A64_STRUCT_FIELD_AGGREGATE_COPY_2026-07-05.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -608,15 +606,9 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.cd-tower-seam | historical | docs/research/cd_tower_seam.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.chi5-mathlib-free-novelty-2026-05-30 | historical | docs/research/chi5-mathlib-free-novelty-2026-05-30.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.commutator-associator-identity | historical | docs/research/commutator_associator_identity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.research.cpc2026-cobre-orc-preregistration-2026-07-11 | historical | docs/research/cpc2026_cobre_orc_preregistration_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.research.cpc2026-cobre-orc-preregistration-amendment1-2026-07-11 | historical | docs/research/cpc2026_cobre_orc_preregistration_amendment1_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.research.cpc2026-fisher-orc-analysis-lock-2026-07-11 | historical | docs/research/cpc2026_fisher_orc_analysis_lock_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.cpc2026-orc-group-preregistration-2026-07-11 | historical | docs/research/cpc2026_orc_group_preregistration_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.cpc2026-yale-evidence-dossier-2026-07-11 | historical | docs/research/cpc2026_yale_evidence_dossier_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.delta-epistemic-gradual-compilation-paper | historical | docs/research/delta_epistemic_gradual_compilation_paper.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.research.discourse-uwo-orc-access-protocol-2026-07-11 | historical | docs/research/discourse_uwo_orc_access_protocol_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.research.discourse-uwo-orc-preregistration-2026-07-11 | historical | docs/research/discourse_uwo_orc_preregistration_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
-| repo.docs.research.ecss-formal-model-2026-07-15 | historical | docs/research/ecss_formal_model_2026-07-15.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.epistemic-algebra-review | repo_only | docs/research/epistemic_algebra_review.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.epistemic-calculus-value-carrying-redesign | historical | docs/research/epistemic_calculus_value_carrying_redesign.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.epistemic-self-reference-design | historical | docs/research/epistemic_self_reference_design.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -2293,52 +2293,6 @@
       "related_artifacts": []
     },
     {
-      "topic_id": "repo.docs.audit.hypercomplex-651-rootcause-2026-07-14",
-      "collection": "repo",
-      "repo_doc_path": "docs/audit/HYPERCOMPLEX_651_ROOTCAUSE_2026-07-14.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "users",
-      "authority": "repo_only",
-      "owner_agent": "A2",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh",
-        "bash scripts/check_docs_consistency.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
-      "topic_id": "repo.docs.audit.hypercomplex-algebra-audit-2026-07-14",
-      "collection": "repo",
-      "repo_doc_path": "docs/audit/HYPERCOMPLEX_ALGEBRA_AUDIT_2026-07-14.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "users",
-      "authority": "repo_only",
-      "owner_agent": "A2",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh",
-        "bash scripts/check_docs_consistency.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
       "topic_id": "repo.docs.audit.kaxi-ptx-target-sm-audit-2026-06-17",
       "collection": "repo",
       "repo_doc_path": "docs/audit/KAXI_PTX_TARGET_SM_AUDIT_2026-06-17.md",
@@ -13447,72 +13401,6 @@
       "related_artifacts": []
     },
     {
-      "topic_id": "repo.docs.research.cpc2026-cobre-orc-preregistration-2026-07-11",
-      "collection": "repo",
-      "repo_doc_path": "docs/research/cpc2026_cobre_orc_preregistration_2026-07-11.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "researchers",
-      "authority": "historical",
-      "owner_agent": "A6",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
-      "topic_id": "repo.docs.research.cpc2026-cobre-orc-preregistration-amendment1-2026-07-11",
-      "collection": "repo",
-      "repo_doc_path": "docs/research/cpc2026_cobre_orc_preregistration_amendment1_2026-07-11.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "researchers",
-      "authority": "historical",
-      "owner_agent": "A6",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
-      "topic_id": "repo.docs.research.cpc2026-fisher-orc-analysis-lock-2026-07-11",
-      "collection": "repo",
-      "repo_doc_path": "docs/research/cpc2026_fisher_orc_analysis_lock_2026-07-11.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "researchers",
-      "authority": "historical",
-      "owner_agent": "A6",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
       "topic_id": "repo.docs.research.cpc2026-orc-group-preregistration-2026-07-11",
       "collection": "repo",
       "repo_doc_path": "docs/research/cpc2026_orc_group_preregistration_2026-07-11.md",
@@ -13560,72 +13448,6 @@
       "topic_id": "repo.docs.research.delta-epistemic-gradual-compilation-paper",
       "collection": "repo",
       "repo_doc_path": "docs/research/delta_epistemic_gradual_compilation_paper.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "researchers",
-      "authority": "historical",
-      "owner_agent": "A6",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
-      "topic_id": "repo.docs.research.discourse-uwo-orc-access-protocol-2026-07-11",
-      "collection": "repo",
-      "repo_doc_path": "docs/research/discourse_uwo_orc_access_protocol_2026-07-11.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "researchers",
-      "authority": "historical",
-      "owner_agent": "A6",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
-      "topic_id": "repo.docs.research.discourse-uwo-orc-preregistration-2026-07-11",
-      "collection": "repo",
-      "repo_doc_path": "docs/research/discourse_uwo_orc_preregistration_2026-07-11.md",
-      "website_slug": null,
-      "website_paths": {},
-      "audience": "researchers",
-      "authority": "historical",
-      "owner_agent": "A6",
-      "locale_status": {
-        "en": "n/a",
-        "pt": "n/a",
-        "el": "n/a",
-        "zh": "n/a",
-        "ja": "n/a",
-        "es": "n/a"
-      },
-      "validation_commands": [
-        "bash scripts/check_docs_registry.sh"
-      ],
-      "related_artifacts": []
-    },
-    {
-      "topic_id": "repo.docs.research.ecss-formal-model-2026-07-15",
-      "collection": "repo",
-      "repo_doc_path": "docs/research/ecss_formal_model_2026-07-15.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "researchers",


### PR DESCRIPTION
## Summary

- regenerate the docs topic registry and acceptance views with the canonical sync script
- remove eight stale registry entries whose repository paths are absent from current `main`
- keep the repair restricted to the three generated governance artifacts

## Exact scope

Base: `36259f1dd8c0e50a72b8e5f115363105de800917`
Head: `75d2e0b729d61d85c72c0313b3c334a34899cddf`

Generated files only:
- `docs/governance/topic-registry.v1.json`
- `docs/governance/DOCS_AUTHORITY_MATRIX.md`
- `docs/governance/DOCS_ACCEPTANCE_REPORT.md`

## Validation

- second `node scripts/docs/sync_governance_metadata.mjs` run produced byte-identical hashes
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- website/package/LoRA/issue-template/legacy-path/heuristic-firewall support gates
- compiler-lane/build-lock/CI-watch/changed-tests/payload/outpath/Claude contract self-tests
- `bash scripts/dev/check_offload_policy.sh`
- `git diff --check`

The local global worktree audit is not a branch result: it sees 28 unrelated dirty compiler worktrees in the shared workspace. CI runs that gate in a clean checkout and is the acceptance receipt.

No compiler files, semantic docs, scientific claims, or runtime artifacts are changed. No LLM offload is required for generated registry metadata.