### PR TITLE
[DO NOT MERGE] Preserve f64 bitcast DefId through SOIR merge

### DIFF
--- a/scripts/ci/madaros_f64_to_bits_builtin_gate.sh
+++ b/scripts/ci/madaros_f64_to_bits_builtin_gate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Prove the modular compiler preserves the bootstrap f64_to_bits intrinsic.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MADAROS="${SOUNIO_MADAROS_F64_TO_BITS_BIN:-$ROOT_DIR/bin/madaros}"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+WITNESS="$ROOT_DIR/tests/compiler/madaros_f64_to_bits_builtin.sio"
+WORK="$(mktemp -d /tmp/sounio-madaros-f64-to-bits.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+  echo "[madaros-f64-to-bits] FAIL: $*" >&2
+  exit 1
+}
+
+[[ -x "$MADAROS" ]] || fail "Madaros wrapper is missing or not executable: $MADAROS"
+[[ -n "$RAW_MADAROS" ]] || fail 'MADAROS_RAW_BIN must name an explicit current-source Madaros ELF'
+[[ -x "$RAW_MADAROS" ]] || fail "current-source Madaros is missing or not executable: $RAW_MADAROS"
+
+set +e
+MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" run "$WITNESS" >"$WORK/run.log" 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 ]]; then
+  cat "$WORK/run.log" >&2
+  fail "witness returned rc=$rc"
+fi
+if grep -Fq 'error[E' "$WORK/run.log"; then
+  cat "$WORK/run.log" >&2
+  fail 'witness emitted compiler diagnostics'
+fi
+grep -Fxq 'PASS madaros_f64_to_bits_builtin' "$WORK/run.log" || {
+  cat "$WORK/run.log" >&2
+  fail 'exact PASS marker absent'
+}
+
+echo '[madaros-f64-to-bits] receipt builtin_runtime=PASS payload=IEEE754_BIT_EXACT'

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1848,12 +1848,12 @@ fn ir_module_ensure_builtin_call_targets(module: IrModule) -> IrModule with Mut,
                 let cn = f.instrs[ii as usize].name
                 if cn.len > 0 && native_v2_builtin_id_for_name(cn) != 0 {
                     let cur = f.instrs[ii as usize].fn_id
-                    var ok: bool = false
+                    var target: i64 = -1
                     if cur >= 0 && cur < out.fn_count {
-                        if ir_name_eq(out.functions[cur as usize].name, cn) { ok = true }
+                        if ir_name_eq(out.functions[cur as usize].name, cn) { target = cur }
                     }
-                    if !ok {
-                        var target = ir_merge_find_function_name_index(&out, cn)
+                    if target < 0 {
+                        target = ir_merge_find_function_name_index(&out, cn)
                         if target < 0 && out.fn_count < IR_MAX_FUNCS {
                             var stub = ir_empty_function()
                             stub.name = cn
@@ -1865,6 +1865,14 @@ fn ir_module_ensure_builtin_call_targets(module: IrModule) -> IrModule with Mut,
                         if target >= 0 {
                             f.instrs[ii as usize].fn_id = target
                             changed = true
+                        }
+                    }
+                    if target >= 0 && target < out.fn_count {
+                        var target_slot = out.functions[target as usize]
+                        if target_slot.instr_count == 0
+                            && target_slot.defining_module_id == IR_DEFINING_MODULE_UNKNOWN {
+                            target_slot.defining_module_id = IR_DEFINING_MODULE_BUILTIN
+                            out.functions[target as usize] = target_slot
                         }
                     }
                 }

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1924,7 +1924,49 @@ fn ir_module_finalize_merged_calls(module: IrModule) -> IrModule with Mut, Div, 
 // provenance is missing or ambiguous. Returning false keeps the compiler on a
 // diagnostic exit instead of executing whichever same-name slot was collected
 // first. Single-module bootstrap paths do not call this guard.
-fn ir_module_direct_fn_provenance_is_complete(module: &IrModule) -> bool with Mut, Div, Panic {
+fn ir_module_report_direct_fn_provenance_failure(
+    module: &IrModule,
+    owner_idx: i64,
+    instr_idx: i64,
+    reason: string
+) with IO, Mut, Div, Panic {
+    let owner_module_id = (*module).functions[owner_idx as usize].defining_module_id
+    let owner_name = (*module).functions[owner_idx as usize].name
+    let opcode = (*module).functions[owner_idx as usize].instrs[instr_idx as usize].op
+    let fn_id = (*module).functions[owner_idx as usize].instrs[instr_idx as usize].fn_id
+    let instr_name = (*module).functions[owner_idx as usize].instrs[instr_idx as usize].name
+    print("PROVENANCE_FAIL reason=")
+    print(reason)
+    print("\nPROVENANCE_FAIL owner_idx ")
+    print_int(owner_idx)
+    print("PROVENANCE_FAIL owner_module_id ")
+    print_int(owner_module_id)
+    print("PROVENANCE_FAIL owner_name [")
+    print(str_from_bytes(owner_name.buf, owner_name.len))
+    print("]\nPROVENANCE_FAIL instr_idx ")
+    print_int(instr_idx)
+    print("PROVENANCE_FAIL opcode ")
+    print_int(ir_diag_opcode_tag(opcode))
+    print("PROVENANCE_FAIL fn_id ")
+    print_int(fn_id)
+    print("PROVENANCE_FAIL instr_name [")
+    print(str_from_bytes(instr_name.buf, instr_name.len))
+    print("]\n")
+    if fn_id >= 0 && fn_id < (*module).fn_count {
+        let target_module_id = (*module).functions[fn_id as usize].defining_module_id
+        let target_instr_count = (*module).functions[fn_id as usize].instr_count
+        let target_name = (*module).functions[fn_id as usize].name
+        print("PROVENANCE_FAIL target_module_id ")
+        print_int(target_module_id)
+        print("PROVENANCE_FAIL target_instr_count ")
+        print_int(target_instr_count)
+        print("PROVENANCE_FAIL target_name [")
+        print(str_from_bytes(target_name.buf, target_name.len))
+        print("]\n")
+    }
+}
+
+fn ir_module_direct_fn_provenance_is_complete(module: &IrModule) -> bool with IO, Mut, Div, Panic {
     var fi: i64 = 0
     while fi < (*module).fn_count {
         let func = (*module).functions[fi as usize]
@@ -1933,13 +1975,16 @@ fn ir_module_direct_fn_provenance_is_complete(module: &IrModule) -> bool with Mu
             let ins = func.instrs[ii as usize]
             if ir_merge_is_direct_fn_ref_opcode(ins.op) {
                 if ins.fn_id < 0 || ins.fn_id >= (*module).fn_count {
+                    ir_module_report_direct_fn_provenance_failure(module, fi, ii, "fn_id_range")
                     return false
                 }
                 let target = (*module).functions[ins.fn_id as usize]
                 if !ir_function_has_exact_definition_identity(target) {
+                    ir_module_report_direct_fn_provenance_failure(module, fi, ii, "target_identity")
                     return false
                 }
                 if ins.name.len > 0 && !ir_name_eq(ins.name, target.name) {
+                    ir_module_report_direct_fn_provenance_failure(module, fi, ii, "name_mismatch")
                     return false
                 }
             }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1057,6 +1057,7 @@ fn native_v2_builtin_id_for_name_ref(name: &Name) -> i64 with Mut, Panic, Div {
     if name_is_assert(*name) { return 21 }
     if name_is_heap_alloc(*name) { return 23 }
     if name_is_heap_free(*name) { return 24 }
+    if name_is_f64_to_bits(*name) { return 25 }
     0
 }
 
@@ -1124,6 +1125,7 @@ fn native_v2_builtin_id_for_func_ref(func: &IrFunction) -> i64 with Mut, Panic, 
     if name_is_str_from_bytes((*func).name) { return 22 }
     if name_is_heap_alloc((*func).name) { return 23 }
     if name_is_heap_free((*func).name) { return 24 }
+    if name_is_f64_to_bits((*func).name) { return 25 }
     0
 }
 
@@ -1365,6 +1367,22 @@ pub fn name_is_cos(n: Name) -> bool with Mut, Panic, Div {
     if n.buf[0] != 99 as i8 { return false }    // 'c'
     if n.buf[1] != 111 as i8 { return false }   // 'o'
     if n.buf[2] != 115 as i8 { return false }   // 's'
+    true
+}
+
+pub fn name_is_f64_to_bits(n: Name) -> bool with Mut, Panic, Div {
+    if n.len != 11 { return false }
+    if n.buf[0] != 102 as i8 { return false }  // 'f'
+    if n.buf[1] != 54 as i8 { return false }   // '6'
+    if n.buf[2] != 52 as i8 { return false }   // '4'
+    if n.buf[3] != 95 as i8 { return false }   // '_'
+    if n.buf[4] != 116 as i8 { return false }  // 't'
+    if n.buf[5] != 111 as i8 { return false }  // 'o'
+    if n.buf[6] != 95 as i8 { return false }   // '_'
+    if n.buf[7] != 98 as i8 { return false }   // 'b'
+    if n.buf[8] != 105 as i8 { return false }  // 'i'
+    if n.buf[9] != 116 as i8 { return false }  // 't'
+    if n.buf[10] != 115 as i8 { return false } // 's'
     true
 }
 
@@ -3258,6 +3276,13 @@ fn emit_builtin_assert_into(nc: &! NativeCompiler) with Mut, Panic, Div {
     nc_emit_jnz_rel8(nc, 16)
     nc_emit_exit_code(nc, 1)
     nc_emit_mov_rax_imm(nc, 0)
+    nc_emit_ret(nc)
+}
+
+// f64 values already use their raw IEEE 754 payload in the internal integer
+// calling convention. Reinterpretation is therefore an identity move.
+fn emit_builtin_f64_to_bits_into(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_mov_reg_reg(nc, 0, 7)
     nc_emit_ret(nc)
 }
 
@@ -5794,6 +5819,7 @@ pub fn native_v2_builtin_id_for_name(name: Name) -> i64 with Mut, Panic, Div {
     if name_is_str_from_bytes(name) { return 22 }
     if name_is_heap_alloc(name) { return 23 }
     if name_is_heap_free(name) { return 24 }
+    if name_is_f64_to_bits(name) { return 25 }
     0
 }
 
@@ -5831,6 +5857,7 @@ fn native_v2_emit_builtin_by_id_into(nc: &! NativeCompiler, builtin_id: i64) wit
     if builtin_id == 22 { native_v2_persist_builtin_emit_into(nc, emit_builtin_str_from_bytes((*nc))); return }
     if builtin_id == 23 { emit_builtin_heap_alloc_into(nc); return }
     if builtin_id == 24 { emit_builtin_heap_free_into(nc); return }
+    if builtin_id == 25 { emit_builtin_f64_to_bits_into(nc); return }
 }
 
 pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func: MachineFunction, fn_index: i64) -> NativeCompiler with Mut, Panic, Div, Alloc {
@@ -5886,6 +5913,7 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
     if name_is_assert(func.name) { return emit_builtin_assert(c) }
     if name_is_heap_alloc(func.name) { emit_builtin_heap_alloc_into(&! c); return c }
     if name_is_heap_free(func.name) { emit_builtin_heap_free_into(&! c); return c }
+    if name_is_f64_to_bits(func.name) { emit_builtin_f64_to_bits_into(&! c); return c }
 
     c.current_strategy = func.compile_strategy
 
@@ -6015,6 +6043,10 @@ pub fn compile_ir_function_v2_into(nc: &! NativeCompiler, func: &IrFunction, mac
         }
         if builtin_id == 24 {
             emit_builtin_heap_free_into(nc)
+            return
+        }
+        if builtin_id == 25 {
+            emit_builtin_f64_to_bits_into(nc)
             return
         }
         return
@@ -7890,6 +7922,7 @@ fn compile_ir_function_v2_mut(nc: &! NativeCompiler, func: IrFunction, machine_f
     if name_is_assert(func.name) { (*nc) = emit_builtin_assert((*nc)); return }
     if name_is_heap_alloc(func.name) { emit_builtin_heap_alloc_into(nc); return }
     if name_is_heap_free(func.name) { emit_builtin_heap_free_into(nc); return }
+    if name_is_f64_to_bits(func.name) { emit_builtin_f64_to_bits_into(nc); return }
 
     (*nc).current_strategy = func.compile_strategy
     native_v2_run_machine_regalloc_mut(nc, machine_func)

--- a/tests/compiler/madaros_f64_to_bits_builtin.sio
+++ b/tests/compiler/madaros_f64_to_bits_builtin.sio
@@ -1,0 +1,19 @@
+fn main() -> i64 with IO, Div {
+    let pos_zero = f64_to_bits(0.0)
+    if pos_zero != 0 { return 11 }
+
+    let neg_zero = f64_to_bits(0.0 / (0.0 - 1.0))
+    if neg_zero >= 0 { return 12 }
+    if (neg_zero & 9223372036854775807) != 0 { return 13 }
+
+    if f64_to_bits(1.0) != 4607182418800017408 { return 14 }
+    if f64_to_bits(0.0 - 1.0) != -4616189618054758400 { return 15 }
+
+    let quiet_nan = f64_to_bits(0.0 / 0.0)
+    if (quiet_nan & 9218868437227405312) != 9218868437227405312 { return 16 }
+    if (quiet_nan & 4503599627370495) == 0 { return 17 }
+    if (quiet_nan & 2251799813685248) == 0 { return 18 }
+
+    println("PASS madaros_f64_to_bits_builtin")
+    0
+}


### PR DESCRIPTION
## Scope

Stacked on #946. This closes the exact imported-module provenance failure exposed after the visibility repair. It does not promote the SOIR writer or alter the writer, serializer, legacy v4 oracle, or visibility policy.

## Root cause

The first incomplete identity was an imported `f64_to_bits` call in `write_f64`: owner module 6, instruction 21, fn_id 648. Its zero-body target retained `IR_DEFINING_MODULE_UNKNOWN` because the modular x86 backend omitted the bootstrap-reserved bit reinterpret intrinsic from its builtin classifier.

## Change

- report the first incomplete direct-call DefId fail-closed;
- classify `f64_to_bits` as modular native-v2 builtin id 25;
- emit the existing internal ABI reinterpretation as `mov rax, rdi; ret`;
- promote only recognized, zero-body, UNKNOWN builtin targets to the BUILTIN sentinel;
- preserve bodies, AMBIGUOUS state, nonnegative module identities, and nonbuiltin names;
- add a source-fresh bit-exact runtime gate for +0, -0, +1, -1, and qNaN exponent/payload/quiet bit.

The internal ABI proof is explicit: `IrLoadFloat` moves the raw payload from XMM to a GPR-backed stack slot; direct-call lowering reloads that slot and passes argument 0 in RDI; scalar results return in RAX. This is not a numeric conversion.

## Evidence

Source-fresh build:

- workflow: `29381328895`
- job: `87245408198`
- artifact: `8329868565`
- ELF SHA-256: `23ca9c5b2966c328cc090dae09ca2dcc72a4060caa70373348ae4b0a81d0472f`

Acceptance:

- `madaros_f64_to_bits_builtin_gate.sh`: PASS, log SHA-256 `db2b67243b775a8735e2e9a06ee18c85611aecf9d926a207101324fa1cb5c713`
- #869 same-name contextual adversary: PASS, log SHA-256 `b5db042796432269c8e922aa90bcc71561e05fc795325c69877ee47b2f2627b0`
- crate/super plus true-private controls: PASS, log SHA-256 `efb23af9879f4605c2e67ab2c7159c871cbc8861d677b9c6903bd390407016f7`
- strict SOIR gate: provenance guard PASS; 8 modules merge; 654 functions; ELF emitted; runtime rc=139, log SHA-256 `567f502ea4dd083ee85e16c5a6d6f8daf3722b0df136519282c7b210d1df56bf`

The old `BLK-20260715-SOIR-IMPORT-PROVENANCE` is closed at E4. The dynamic differential is not green yet.

## Next blocker

- Blocker-ID: `BLK-20260715-SOIR-RUNTIME-RAW-FIELD`
- Severity: B1
- Class: compiler-runtime / aggregate-lowering
- Evidence: E4 source-fresh ELF plus reproducible core register/disassembly evidence
- Owner: next isolated compiler lane
- Worktree: `/tmp/sounio-soir-import-provenance-20260715`
- Branch: `codex/soir-import-provenance-20260715`
- Acceptance gate: `SOUC=<source-fresh-elf> SOIR_WRITER_REQUIRE_DYNAMIC=1 bash scripts/ci/soir_writer_v0_gate.sh`
- Next action: reduce the generated null-base store in `soir_writer_rejections_preserve_canary`; do not patch the SOIR writer around it.

First exact runtime evidence: generated function index 5, `soir_writer_rejections_preserve_canary`, faults at RIP `0x4052cd`, instruction `mov %rax,(%rdx,%rbx,8)`, with `rdx=0`, `rbx=5`, and fault address `0x28`. The crash lies late in the function near the nested aggregate assignment `function.instrs[0] = ir_instr_new(IrOpcode::IrArrayLen)`, consistent with the legacy raw-field aggregate storage boundary. This is a new independent blocker after DefId resolution, not a provenance regression.

## Claim limits

- Linux x86-64 native-v2 only; no modular AArch64 parity claim.
- Runtime bit payload is proven; modular checker argument-type parity remains outside this patch.
- `IrLoadFnRef` builtin provenance remains outside the observed direct-call witness.
- Legacy paths remain intentionally present.

DO NOT MERGE: stacked qualification branch only.
