### PR TITLE
test(stdlib): batch run-proofs — encoding::hex + math::dd64 + math::combinatorics_perm

### DIFF
--- a/scripts/verticals_batch2_gate.sh
+++ b/scripts/verticals_batch2_gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Combined gate: encoding::hex, math::dd64, math::combinatorics_perm.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() {
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/encoding/hex.sio               tests/stdlib/encoding/test_hex_stdlib.sio                   HEX_STDLIB_OK
+run stdlib/math/dd64.sio                  tests/stdlib/math/test_dd64_stdlib.sio                      DD64_STDLIB_OK
+run stdlib/math/combinatorics_perm.sio    tests/stdlib/math/test_combinatorics_perm_stdlib.sio        COMBINATORICS_PERM_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_BATCH2_GATE_OK"
+exit $fail

--- a/tests/stdlib/encoding/test_hex_stdlib.sio
+++ b/tests/stdlib/encoding/test_hex_stdlib.sio
@@ -1,0 +1,33 @@
+// Run-proof for stdlib encoding::hex. By-reference API -> default Madaros.
+use encoding::hex::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var data: [u8; 256] = [0; 256]
+    data[0] = 255   // 0xff
+    data[1] = 16    // 0x10
+    var out: [u8; 512] = [0; 512]
+    // encode -> "ff10" = bytes 'f','f','1','0' = 102,102,49,48
+    let n = hex_encode(&data, 2, &!out)
+    if n != 4 { print("FAIL enc_len\n"); return 1 }
+    if out[0] as i64 != 102 { print("FAIL e0\n"); return 2 }
+    if out[1] as i64 != 102 { print("FAIL e1\n"); return 3 }
+    if out[2] as i64 != 49  { print("FAIL e2\n"); return 4 }
+    if out[3] as i64 != 48  { print("FAIL e3\n"); return 5 }
+    // uppercase -> "FF10" = 70,70,49,48
+    var outu: [u8; 512] = [0; 512]
+    let nu = hex_encode_upper(&data, 2, &!outu)
+    if outu[0] as i64 != 70 { print("FAIL up0\n"); return 6 }
+    if outu[1] as i64 != 70 { print("FAIL up1\n"); return 7 }
+    // decode round-trip: hex "abcd" (bytes 0xab,0xcd = 171,205)
+    var hx: [u8; 512] = [0; 512]
+    hx[0] = 97   // a
+    hx[1] = 98   // b
+    hx[2] = 99   // c
+    hx[3] = 100  // d
+    var dec: [u8; 256] = [0; 256]
+    let m = hex_decode(&hx, 4, &!dec)
+    if m != 2 { print("FAIL dec_len\n"); return 8 }
+    if dec[0] as i64 != 171 { print("FAIL d0\n"); return 9 }
+    if dec[1] as i64 != 205 { print("FAIL d1\n"); return 10 }
+    print("HEX_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_combinatorics_perm_stdlib.sio
+++ b/tests/stdlib/math/test_combinatorics_perm_stdlib.sio
@@ -1,0 +1,29 @@
+// Run-proof for stdlib math::combinatorics_perm. count_permutations=n!, next_permutation lexicographic.
+use math::combinatorics_perm::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    if count_permutations(0) != 1 { print("FAIL 0!\n"); return 1 }
+    if count_permutations(1) != 1 { print("FAIL 1!\n"); return 2 }
+    if count_permutations(3) != 6 { print("FAIL 3!\n"); return 3 }
+    if count_permutations(5) != 120 { print("FAIL 5!\n"); return 4 }
+    if count_permutations(7) != 5040 { print("FAIL 7!\n"); return 5 }
+    // next_permutation iterates all n! permutations of [0..n)
+    var p = Perm128 { data: [0; 128] }
+    p.data[0] = 0
+    p.data[1] = 1
+    p.data[2] = 2
+    p.data[3] = 3
+    var cnt: i64 = 1
+    while next_permutation(&!p, 4) { cnt = cnt + 1 }
+    if cnt != 24 { print("FAIL perm4 count\n"); return 6 }
+    // lexicographic successor of [0,1,2] is [0,2,1]
+    var q = Perm128 { data: [0; 128] }
+    q.data[0] = 0
+    q.data[1] = 1
+    q.data[2] = 2
+    let ok = next_permutation(&!q, 3)
+    if !ok { print("FAIL succ exists\n"); return 7 }
+    if q.data[1] != 2 { print("FAIL succ d1\n"); return 8 }
+    if q.data[2] != 1 { print("FAIL succ d2\n"); return 9 }
+    print("COMBINATORICS_PERM_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_dd64_stdlib.sio
+++ b/tests/stdlib/math/test_dd64_stdlib.sio
@@ -1,0 +1,26 @@
+// Run-proof for stdlib math::dd64 (double-double / extended precision). By-value struct -> default Madaros.
+use math::dd64::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // round-trip
+    let three = dd_to_f64(dd_from_f64(3.0))
+    if (if three > 3.0 { three-3.0 } else { 3.0-three }) >= 1.0e-15 { print("FAIL rt\n"); return 1 }
+    // extended precision: (1 + 1e-20) - 1 = 1e-20 (f64 alone loses it)
+    let s = dd_add(dd_from_f64(1.0), dd_from_f64(1.0e-20))
+    let back = dd_to_f64(dd_sub(s, dd_from_f64(1.0)))
+    if back < 0.9e-20 { print("FAIL dd_low\n"); return 2 }
+    if back > 1.1e-20 { print("FAIL dd_high\n"); return 3 }
+    // f64 baseline loses it (contrast)
+    let f = (1.0 + 1.0e-20) - 1.0
+    if (if f > 0.0 { f } else { 0.0-f }) >= 1.0e-30 { print("FAIL f64_should_be_zero\n"); return 4 }
+    // dd_mul exact: 0.5 * 4 = 2
+    let m = dd_to_f64(dd_mul(dd_from_f64(0.5), dd_from_f64(4.0)))
+    if (if m > 2.0 { m-2.0 } else { 2.0-m }) >= 1.0e-28 { print("FAIL mul\n"); return 5 }
+    // sqrt(2)^2 = 2 to double-double precision (much tighter than f64 eps)
+    let r2 = dd_sqrt(dd_from_f64(2.0))
+    let sq = dd_to_f64(dd_mul(r2, r2))
+    if (if sq > 2.0 { sq-2.0 } else { 2.0-sq }) >= 1.0e-25 { print("FAIL sqrt2\n"); return 6 }
+    // ordering
+    if !dd_lt(dd_from_f64(1.0), dd_from_f64(2.0)) { print("FAIL lt\n"); return 7 }
+    print("DD64_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
**Grouped PR (3 verticals in one)**, lean (tests+gate only -> merges clean vs active main). Three cold/disjoint self-contained modules, native under **default Madaros**, cross-module-safe APIs, **no source edits**:
- **encoding::hex** — encode 0xff10 -> `ff10`/`FF10`; decode `abcd` -> [0xab,0xcd] round-trip -> `HEX_STDLIB_OK`.
- **math::dd64** (double-double) — recovers 1e-20 that f64 loses; 0.5*4=2; sqrt(2)^2=2 to ~1e-25 -> `DD64_STDLIB_OK`.
- **math::combinatorics_perm** — count_permutations=n! (120,5040); next_permutation enumerates 4!=24 + lexicographic successor -> `COMBINATORICS_PERM_STDLIB_OK`.

Combined gate `VERTICALS_BATCH2_GATE_OK`; math-review PASS on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)