### PR TITLE
feat(stats): correlation-inference toolkit — corr_ci, point_biserial, partial_corr

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2837,3 +2837,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - fit_lognormal = **PASS after fix**: reviewer flagged the docstring claim "exact MLE" as WRONG (code uses unbiased ÷(n−1), MLE uses ÷n) — corrected the docstring to "sample-moment fit (consistent with fit_gamma/fit_beta); strict MLE divides by n"; the math (μ̂, median=e^μ̂, mean=e^{μ̂+σ̂²/2}) is correct. Also calibrated the fitted-mean tolerance to 3e-3: exp amplifies the inline-ln error in var_y (d(mean)/d(var)≈mean/2), giving ~1.5e-3 absolute error — the reviewer's 3e-6 estimate assumed exact arithmetic.
 - Theme: distribution parameter fitting (method of moments) — pairs with densities/weibull_negbin. All deterministic/derivable, #852-safe. Suite runner: 67 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Sub7Nk/`, `/tmp/llm-offload-t2Rz1k/`, `/tmp/llm-offload-tfPQe1/`.
+
+## 2026-07-15 — math-review: stats::corr_ci, stats::point_biserial, stats::partial_corr
+- Files (all new): `stdlib/stats/corr_ci.sio` (Fisher-z CI + ρ=0 t-test from r,n), `stdlib/stats/point_biserial.sio` (continuous-vs-binary correlation + t-test), `stdlib/stats/partial_corr.sio` (first-order partial correlation r_xy·z + t-test). Provider: xAI/Grok 4.3.
+- corr_ci = **PASS**: z=atanh(r), CI=tanh(z±z_c/√(n−3)), t=r√(n−2)/√(1−r²), t-tail via I_x(ν/2,½); r=0.8/n=20 → CI [0.5534,0.9177], t=5.657 verified.
+- point_biserial = **PASS**: Pearson-equivalent r_pb + t(n−2) test; {1,2,3,4}vs{0,0,1,1}→r=0.8944, t=2.828 verified.
+- partial_corr = **PASS**: r_xy·z formula + t(n−3) test; discriminating case r_xy=0 but partial=−1 (r_xz=0.6,r_yz=0.8) verified; uncorrelated-z → partial=r_xy.
+- Theme: correlation-inference toolkit — the Fisher-z CI, point-biserial, and partial correlation beside the existing Pearson/Spearman module. partial_corr makes 3 nested pc_pearson calls (shared-ref reads, scalar return) — #852-safe. Suite runner: 70 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-1ZtLOb/`, `/tmp/llm-offload-rTCcaN/`, `/tmp/llm-offload-CqFiN9/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -76,6 +76,9 @@ MODULES=(
   stdlib/stats/fit_gamma.sio
   stdlib/stats/fit_beta.sio
   stdlib/stats/fit_lognormal.sio
+  stdlib/stats/corr_ci.sio
+  stdlib/stats/point_biserial.sio
+  stdlib/stats/partial_corr.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -949,6 +949,38 @@ the implied `median=e^{μ̂}` and `mean=e^{μ̂+σ̂²/2}`. Natural for right-sk
 positive data (concentrations, PK exposures). Validated: data e⁰…e³ → μ=1.5,
 σ=1.291, median=4.482.
 
+### `stats::corr_ci` — Fisher-z correlation CI & test
+
+| Function | Signature |
+|---|---|
+| `corr_ci` | `pub fn corr_ci(r: f64, n: i32, conf: f64) -> CorrCIResult with Mut, Div, Panic` |
+
+Turns a Pearson r into a confidence interval and a significance test via the
+Fisher z-transform: `z=atanh(r)`, `SE=1/√(n−3)`, `CI=tanh(z±z_c·SE)`, plus the
+exact `t=r√(n−2)/√(1−r²)` test of ρ=0. Composes with `stats::correlation`.
+Validated: r=0.8, n=20 → z=1.0986, 95% CI [0.5534, 0.9177], t=5.657.
+
+### `stats::point_biserial` — point-biserial correlation
+
+| Function | Signature |
+|---|---|
+| `point_biserial` | `pub fn point_biserial(x: &[f64; 256], y: &[f64; 256], n: i32) -> PointBiserialResult with Mut, Div, Panic` |
+
+The correlation between a continuous variable and a 0/1 dichotomy (the effect-
+size companion to the two-sample t-test), with its `t(n−2)` test. Validated:
+{1,2,3,4} vs {0,0,1,1} → r=0.8944, t=2.828; equal group means → r=0.
+
+### `stats::partial_corr` — first-order partial correlation
+
+| Function | Signature |
+|---|---|
+| `partial_corr` | `pub fn partial_corr(x: &[f64; 256], y: &[f64; 256], z: &[f64; 256], n: i32) -> PartialResult with Mut, Div, Panic` |
+
+The correlation of x and y after removing the linear effect of z (confounding
+control): `r_xy·z=(r_xy−r_xz·r_yz)/√((1−r_xz²)(1−r_yz²))` with a `t(n−3)` test.
+Validated: r_xy=0 but r_xz=0.6, r_yz=0.8 → partial=−1; z uncorrelated with both
+→ partial=r_xy.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1020,6 +1052,9 @@ use stats::mood_median::{MoodResult, mood_median}
 use stats::fit_gamma::{GammaFit, fit_gamma}
 use stats::fit_beta::{BetaFit, fit_beta}
 use stats::fit_lognormal::{LogNormalFit, fit_lognormal}
+use stats::corr_ci::{CorrCIResult, corr_ci}
+use stats::point_biserial::{PointBiserialResult, point_biserial}
+use stats::partial_corr::{PartialResult, partial_corr}
 ```
 
 A worked end-to-end example that runs all five tools on one dataset lives at

--- a/stdlib/stats/corr_ci.sio
+++ b/stdlib/stats/corr_ci.sio
@@ -1,0 +1,242 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/corr_ci.sio — Fisher z confidence interval & test for Pearson r
+//
+// Turns a sample correlation into a confidence interval and a significance
+// test, via the variance-stabilising Fisher z-transform:
+//
+//   corr_ci(r, n, conf) -> CorrCIResult
+//
+//   z = atanh(r) = ½·ln((1+r)/(1−r)),   SE_z = 1/√(n−3),
+//   CI on r = tanh( z ± z_{α/2}·SE_z ),
+//   exact H₀: ρ=0 test  t = r·√(n−2)/√(1−r²) ~ t(n−2).
+//
+// Pure Sounio: inline ln/exp/sqrt, Lanczos log-gamma + continued-fraction
+// incomplete beta for the t tail; takes r and n (composes with stats::correlation).
+//
+// References:
+//   Fisher (1915, 1921); Snedecor & Cochran §10.
+
+module stats::corr_ci
+
+fn cc_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / cc_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn cc_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn cc_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn cc_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * cc_ln(tt) - tt + cc_ln(a)
+}
+
+fn cc_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn cc_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = cc_lgamma(a) + cc_lgamma(b) - cc_lgamma(a + b)
+    let front = cc_exp(a * cc_ln(x) + b * cc_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * cc_betacf(a, b, x) / a }
+    return 1.0 - front * cc_betacf(b, a, 1.0 - x) / b
+}
+
+// two-sided Student-t p: 2·P(T_df > |t|)
+fn cc_t_two_tail(t: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if df <= 0.0 { return 1.0 }
+    let at = if t < 0.0 { 0.0 - t } else { t }
+    let x = df / (df + at * at)
+    return cc_ibeta(df * 0.5, 0.5, x)
+}
+
+fn cc_tanh(z: f64) -> f64 with Mut, Div, Panic {
+    let e2 = cc_exp(2.0 * z)
+    return (e2 - 1.0) / (e2 + 1.0)
+}
+
+pub struct CorrCIResult {
+    pub r: f64,
+    pub z: f64,     // Fisher z
+    pub lo: f64,    // CI lower on r
+    pub hi: f64,    // CI upper on r
+    pub t: f64,     // t statistic for rho = 0
+    pub df: i64,    // n - 2
+    pub p: f64,     // two-sided p for rho = 0
+}
+
+// z-multiplier for a two-sided confidence level.
+fn cc_zmult(conf: f64) -> f64 {
+    if conf >= 0.99 { return 2.5758293035489004 }
+    if conf >= 0.98 { return 2.326347874040841 }
+    if conf >= 0.95 { return 1.959963984540054 }
+    if conf >= 0.90 { return 1.6448536269514722 }
+    return 1.959963984540054
+}
+
+/// Fisher-z confidence interval and rho=0 test for a Pearson correlation.
+///
+/// Parâmetros: r — sample correlation in (−1,1); n — sample size (>=4);
+///             conf — confidence level (e.g. 0.95).
+/// Retorno: CorrCIResult (r, z, lo, hi, t, df, p).
+/// Referências: Fisher (1921).
+pub fn corr_ci(r: f64, n: i32, conf: f64) -> CorrCIResult with Mut, Div, Panic {
+    if n < 4 || r <= 0.0 - 1.0 || r >= 1.0 {
+        return CorrCIResult { r: r, z: 0.0, lo: r, hi: r, t: 0.0, df: (n - 2) as i64, p: 1.0 }
+    }
+    let z = 0.5 * cc_ln((1.0 + r) / (1.0 - r))
+    let se = 1.0 / cc_sqrt((n as f64) - 3.0)
+    let zc = cc_zmult(conf)
+    let lo = cc_tanh(z - zc * se)
+    let hi = cc_tanh(z + zc * se)
+    let dff = (n as f64) - 2.0
+    let t = r * cc_sqrt(dff) / cc_sqrt(1.0 - r * r)
+    let p = cc_t_two_tail(t, dff)
+    return CorrCIResult { r: r, z: z, lo: lo, hi: hi, t: t, df: (n - 2) as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// r=0.8, n=20, 95%. z=atanh(0.8)=1.098612. SE=1/sqrt(17)=0.242536.
+// CI_z=1.098612±1.959964·0.242536 -> [0.623258,1.573966].
+// r_lo=tanh(0.623258)=0.553372; r_hi=tanh(1.573966)=0.917663.
+// t=0.8·sqrt(18)/sqrt(0.36)=3.394113/0.6=5.656854, df=18.
+fn test_corr_ci() -> bool with IO, Mut, Div, Panic {
+    let r = corr_ci(0.8, 20, 0.95)
+    var ok = true
+    ok = check(1, approx(r.z, 1.098612, 1.0e-5)) && ok
+    ok = check(2, approx(r.lo, 0.553372, 1.0e-3)) && ok
+    ok = check(3, approx(r.hi, 0.917663, 1.0e-3)) && ok
+    ok = check(4, approx(r.t, 5.656854, 1.0e-4)) && ok
+    ok = check(5, r.df == 18) && ok
+    ok = check(6, r.p < 0.001) && ok
+    return ok
+}
+
+// r=0 -> z=0, symmetric CI around 0, t=0, p=1.
+fn test_zero() -> bool with IO, Mut, Div, Panic {
+    let r = corr_ci(0.0, 30, 0.95)
+    var ok = true
+    ok = check(10, approx(r.z, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.t, 0.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.p, 1.0, 1.0e-6)) && ok
+    ok = check(13, approx(r.lo, 0.0 - r.hi, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_corr_ci() && ok
+    ok = test_zero() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/partial_corr.sio
+++ b/stdlib/stats/partial_corr.sio
@@ -1,0 +1,264 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/partial_corr.sio — first-order partial correlation
+//
+// The correlation between x and y after removing the linear effect of a third
+// variable z — the tool for distinguishing genuine association from confounding:
+//
+//   partial_corr(x, y, z, n) -> PartialResult
+//
+//   r_xy·z = (r_xy − r_xz·r_yz) / √((1 − r_xz²)(1 − r_yz²)),
+// with a t-test  t = r_xy·z·√(n−3)/√(1 − r_xy·z²) ~ t(n−3).
+//
+// Pure Sounio: three Pearson correlations in one pass each; incomplete beta for
+// the t tail. No nested data-array calls.
+//
+// References:
+//   Yule (1907); Anderson, "An Introduction to Multivariate Statistical Analysis".
+
+module stats::partial_corr
+
+fn pc_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / pc_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn pc_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn pc_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn pc_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * pc_ln(tt) - tt + pc_ln(a)
+}
+
+fn pc_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn pc_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = pc_lgamma(a) + pc_lgamma(b) - pc_lgamma(a + b)
+    let front = pc_exp(a * pc_ln(x) + b * pc_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * pc_betacf(a, b, x) / a }
+    return 1.0 - front * pc_betacf(b, a, 1.0 - x) / b
+}
+
+fn pc_t_two_tail(t: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if df <= 0.0 { return 1.0 }
+    let at = if t < 0.0 { 0.0 - t } else { t }
+    let x = df / (df + at * at)
+    return pc_ibeta(df * 0.5, 0.5, x)
+}
+
+// Pearson correlation of two columns held in [256] buffers.
+fn pc_pearson(a: &[f64; 256], b: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic {
+    let nf = n as f64
+    var sa = 0.0
+    var sb = 0.0
+    var i = 0
+    while i < n { sa = sa + a[i as usize]; sb = sb + b[i as usize]; i = i + 1 }
+    let ma = sa / nf
+    let mb = sb / nf
+    var saa = 0.0
+    var sbb = 0.0
+    var sab = 0.0
+    var j = 0
+    while j < n {
+        let da = a[j as usize] - ma
+        let db = b[j as usize] - mb
+        saa = saa + da * da
+        sbb = sbb + db * db
+        sab = sab + da * db
+        j = j + 1
+    }
+    let den = pc_sqrt(saa * sbb)
+    if den <= 0.0 { return 0.0 }
+    return sab / den
+}
+
+pub struct PartialResult {
+    pub partial: f64,   // r_xy.z
+    pub r_xy: f64,
+    pub r_xz: f64,
+    pub r_yz: f64,
+    pub t: f64,
+    pub df: i64,        // n - 3
+    pub p: f64,
+}
+
+/// First-order partial correlation of x and y controlling for z.
+///
+/// Parâmetros: x, y, z — the three variables; n — size (>=4, <=256).
+/// Retorno: PartialResult (partial, r_xy, r_xz, r_yz, t, df, p).
+/// Referências: Yule (1907).
+pub fn partial_corr(x: &[f64; 256], y: &[f64; 256], z: &[f64; 256], n: i32) -> PartialResult with Mut, Div, Panic {
+    if n < 4 {
+        return PartialResult { partial: 0.0, r_xy: 0.0, r_xz: 0.0, r_yz: 0.0, t: 0.0, df: 0, p: 1.0 }
+    }
+    let rxy = pc_pearson(x, y, n)
+    let rxz = pc_pearson(x, z, n)
+    let ryz = pc_pearson(y, z, n)
+    let den = pc_sqrt((1.0 - rxz * rxz) * (1.0 - ryz * ryz))
+    var partial = 0.0
+    if den > 1.0e-300 { partial = (rxy - rxz * ryz) / den }
+    if partial > 1.0 { partial = 1.0 }
+    if partial < 0.0 - 1.0 { partial = 0.0 - 1.0 }
+    let dff = (n as f64) - 3.0
+    var t = 0.0
+    let om = 1.0 - partial * partial
+    if om > 1.0e-300 { t = partial * pc_sqrt(dff) / pc_sqrt(om) } else { t = 1.0e9 }
+    let p = pc_t_two_tail(t, dff)
+    return PartialResult { partial: partial, r_xy: rxy, r_xz: rxz, r_yz: ryz, t: t, df: (n - 3) as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// z={1,2,3,4}, x={2,1,4,3}, y={1,3,2,4}. r_xy=0, r_xz=0.6, r_yz=0.8.
+// partial = (0 - 0.48)/sqrt(0.64·0.36) = -0.48/0.48 = -1.
+fn test_partial() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var z: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=1.0; x[2]=4.0; x[3]=3.0
+    y[0]=1.0; y[1]=3.0; y[2]=2.0; y[3]=4.0
+    z[0]=1.0; z[1]=2.0; z[2]=3.0; z[3]=4.0
+    let r = partial_corr(&x, &y, &z, 4)
+    var ok = true
+    ok = check(1, approx(r.r_xy, 0.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.r_xz, 0.6, 1.0e-6)) && ok
+    ok = check(3, approx(r.r_yz, 0.8, 1.0e-6)) && ok
+    ok = check(4, approx(r.partial, 0.0 - 1.0, 1.0e-5)) && ok
+    return ok
+}
+
+// z uncorrelated with x and y -> partial = r_xy. x=y={1,2,3,4}, z={1,-1,-1,1}.
+// r_xz=0, r_yz=0 -> partial = r_xy = 1.
+fn test_uncorrelated_z() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var z: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0; y[3]=4.0
+    z[0]=1.0; z[1]=0.0-1.0; z[2]=0.0-1.0; z[3]=1.0
+    let r = partial_corr(&x, &y, &z, 4)
+    var ok = true
+    ok = check(10, approx(r.r_xz, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.r_yz, 0.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.partial, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_partial() && ok
+    ok = test_uncorrelated_z() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/point_biserial.sio
+++ b/stdlib/stats/point_biserial.sio
@@ -1,0 +1,243 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/point_biserial.sio — point-biserial correlation
+//
+// The correlation between a continuous variable and a dichotomous (0/1) one —
+// algebraically a Pearson correlation, and the effect-size companion to the
+// two-sample t-test:
+//
+//   point_biserial(x, y, n) -> PointBiserialResult      (y ∈ {0,1})
+//
+//   r_pb = (M₁ − M₀)/s · √(p·q),   p = n₁/n, q = n₀/n,
+// where s is the population sd of x; equivalently Pearson(x, y). The H₀: ρ=0
+// test is  t = r_pb·√(n−2)/√(1−r_pb²) ~ t(n−2).
+//
+// Pure Sounio: one pass for the Pearson moments; incomplete beta for the t tail.
+// No nested data-array calls.
+//
+// References:
+//   Tate (1954) Biometrika 41:205.
+
+module stats::point_biserial
+
+fn pb_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / pb_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn pb_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn pb_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn pb_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * pb_ln(tt) - tt + pb_ln(a)
+}
+
+fn pb_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn pb_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = pb_lgamma(a) + pb_lgamma(b) - pb_lgamma(a + b)
+    let front = pb_exp(a * pb_ln(x) + b * pb_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * pb_betacf(a, b, x) / a }
+    return 1.0 - front * pb_betacf(b, a, 1.0 - x) / b
+}
+
+fn pb_t_two_tail(t: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if df <= 0.0 { return 1.0 }
+    let at = if t < 0.0 { 0.0 - t } else { t }
+    let x = df / (df + at * at)
+    return pb_ibeta(df * 0.5, 0.5, x)
+}
+
+pub struct PointBiserialResult {
+    pub r: f64,     // point-biserial correlation
+    pub t: f64,     // t statistic
+    pub df: i64,    // n - 2
+    pub p: f64,     // two-sided p
+}
+
+/// Point-biserial correlation between continuous x and binary y.
+///
+/// Parâmetros: x — continuous; y — 0/1 group indicator; n — size (>=3, <=256).
+/// Retorno: PointBiserialResult (r, t, df, p).
+/// Referências: Tate (1954).
+pub fn point_biserial(x: &[f64; 256], y: &[f64; 256], n: i32) -> PointBiserialResult with Mut, Div, Panic {
+    if n < 3 { return PointBiserialResult { r: 0.0, t: 0.0, df: 0, p: 1.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var sxx = 0.0
+    var syy = 0.0
+    var sxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        let dy = y[j as usize] - my
+        sxx = sxx + dx * dx
+        syy = syy + dy * dy
+        sxy = sxy + dx * dy
+        j = j + 1
+    }
+    let den = pb_sqrt(sxx * syy)
+    if den <= 0.0 { return PointBiserialResult { r: 0.0, t: 0.0, df: (n - 2) as i64, p: 1.0 } }
+    let r = sxy / den
+    let dff = nf - 2.0
+    var t = 0.0
+    let om = 1.0 - r * r
+    if om > 0.0 { t = r * pb_sqrt(dff) / pb_sqrt(om) } else { t = 1.0e9 }
+    let p = pb_t_two_tail(t, dff)
+    return PointBiserialResult { r: r, t: t, df: (n - 2) as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3,4}, y={0,0,1,1}. Sxy=2, Sxx=5, Syy=1. r=2/sqrt(5)=0.894427.
+// t=0.894427·sqrt(2)/sqrt(0.2)=1.264911/0.447214=2.828427, df=2.
+fn test_pb() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=0.0; y[1]=0.0; y[2]=1.0; y[3]=1.0
+    let r = point_biserial(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.r, 0.894427, 1.0e-5)) && ok
+    ok = check(2, approx(r.t, 2.828427, 1.0e-4)) && ok
+    ok = check(3, r.df == 2) && ok
+    return ok
+}
+
+// no association: x same mean in both groups. x={1,2,1,2}, y={0,0,1,1}.
+// group0 mean 1.5, group1 mean 1.5 -> r=0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=1.0; x[3]=2.0
+    y[0]=0.0; y[1]=0.0; y[2]=1.0; y[3]=1.0
+    let r = point_biserial(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.r, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_pb() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three correlation-inference modules for the epistemic-statistics suite, bringing the runner to **70 modules**. These extend the existing Pearson/Spearman `correlation` module from a point estimate to full inference and correlation variants. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::corr_ci` | Fisher-z confidence interval + ρ=0 t-test for a Pearson r |
| `stats::point_biserial` | continuous-vs-binary correlation (t-test companion) |
| `stats::partial_corr` | first-order partial correlation controlling for z |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Fisher-z: r=0.8, n=20 → z=1.0986, 95% CI [0.5534, 0.9177], t=5.657, p<0.001.
  - Point-biserial: {1,2,3,4} vs {0,0,1,1} → r=0.8944, t=2.828; equal group means → r=0.
  - Partial: a discriminating case where r_xy=0 but r_xz=0.6, r_yz=0.8 → partial=−1; z uncorrelated with both → partial=r_xy.
- Full suite selftest: **70 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; t tails via inline Lanczos log-gamma + continued-fraction incomplete beta.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).