### PR TITLE
test(stdlib): batch run-proofs — autodiff::epistemic_dual + collections::vec + collections::stack

### DIFF
--- a/scripts/verticals_batch3_gate.sh
+++ b/scripts/verticals_batch3_gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Combined gate: autodiff::epistemic_dual, collections::vec, collections::stack.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() {
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/autodiff/epistemic_dual.sio  tests/stdlib/autodiff/test_edual_stdlib.sio        EDUAL_STDLIB_OK
+run stdlib/collections/vec.sio          tests/stdlib/collections/test_vec_stdlib.sio        VEC_STDLIB_OK
+run stdlib/collections/stack.sio        tests/stdlib/collections/test_stack_stdlib.sio      STACK_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_BATCH3_GATE_OK"
+exit $fail

--- a/tests/stdlib/autodiff/test_edual_stdlib.sio
+++ b/tests/stdlib/autodiff/test_edual_stdlib.sio
@@ -1,0 +1,23 @@
+// Run-proof for stdlib autodiff::epistemic_dual (forward-mode AD). Small struct by value -> default Madaros.
+use autodiff::epistemic_dual::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // d/dx(x^2) at x=3 = 6 ; value 9
+    let x = edual_new(3.0, 1.0, 0.0, 0.0)
+    let x2 = edual_mul(x, x)
+    if (if x2.val > 9.0 { x2.val-9.0 } else { 9.0-x2.val }) >= 1.0e-9 { print("FAIL sq val\n"); return 1 }
+    if (if x2.dot > 6.0 { x2.dot-6.0 } else { 6.0-x2.dot }) >= 1.0e-9 { print("FAIL sq dot\n"); return 2 }
+    // d/dx(x + 5) at x=3 = 1 ; value 8
+    let sum = edual_add(x, edual_const(5.0))
+    if (if sum.val > 8.0 { sum.val-8.0 } else { 8.0-sum.val }) >= 1.0e-9 { print("FAIL add val\n"); return 3 }
+    if (if sum.dot > 1.0 { sum.dot-1.0 } else { 1.0-sum.dot }) >= 1.0e-9 { print("FAIL add dot\n"); return 4 }
+    // product rule: d/dx(x * (x+5)) at 3 = 2x+5 = 11 ; value 3*8=24
+    let prod = edual_mul(x, sum)
+    if (if prod.val > 24.0 { prod.val-24.0 } else { 24.0-prod.val }) >= 1.0e-9 { print("FAIL prod val\n"); return 5 }
+    if (if prod.dot > 11.0 { prod.dot-11.0 } else { 11.0-prod.dot }) >= 1.0e-9 { print("FAIL prod dot\n"); return 6 }
+    // d/dx(e^x) at x=0 = 1 ; value 1
+    let e = edual_exp(edual_new(0.0, 1.0, 0.0, 0.0))
+    if (if e.val > 1.0 { e.val-1.0 } else { 1.0-e.val }) >= 1.0e-6 { print("FAIL exp val\n"); return 7 }
+    if (if e.dot > 1.0 { e.dot-1.0 } else { 1.0-e.dot }) >= 1.0e-6 { print("FAIL exp dot\n"); return 8 }
+    print("EDUAL_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/collections/test_stack_stdlib.sio
+++ b/tests/stdlib/collections/test_stack_stdlib.sio
@@ -1,0 +1,18 @@
+// Run-proof for stdlib collections::stack (Stack64 LIFO). By-reference API -> default Madaros.
+use collections::stack::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var s = stack_new()
+    if !stack_empty(&s) { print("FAIL empty0\n"); return 1 }
+    let a = stack_push(&!s, 10)
+    let b = stack_push(&!s, 20)
+    let c = stack_push(&!s, 30)
+    if stack_size(&s) != 3 { print("FAIL size\n"); return 2 }
+    if stack_peek(&s) != 30 { print("FAIL peek\n"); return 3 }        // LIFO top
+    if stack_pop(&!s) != 30 { print("FAIL pop30\n"); return 4 }
+    if stack_pop(&!s) != 20 { print("FAIL pop20\n"); return 5 }
+    if stack_size(&s) != 1 { print("FAIL size1\n"); return 6 }
+    if stack_pop(&!s) != 10 { print("FAIL pop10\n"); return 7 }
+    if !stack_empty(&s) { print("FAIL empty_end\n"); return 8 }
+    print("STACK_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/collections/test_vec_stdlib.sio
+++ b/tests/stdlib/collections/test_vec_stdlib.sio
@@ -1,0 +1,24 @@
+// Run-proof for stdlib collections::vec (VecF64). By-reference API -> default Madaros.
+use collections::vec::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var v = vec_new()
+    vec_push(&!v, 1.0)
+    vec_push(&!v, 2.0)
+    vec_push(&!v, 3.0)
+    if vec_len(&v) != 3 { print("FAIL len\n"); return 1 }
+    if (if vec_sum(&v) > 6.0 { vec_sum(&v)-6.0 } else { 6.0-vec_sum(&v) }) >= 1.0e-9 { print("FAIL sum\n"); return 2 }
+    if (if vec_mean(&v) > 2.0 { vec_mean(&v)-2.0 } else { 2.0-vec_mean(&v) }) >= 1.0e-9 { print("FAIL mean\n"); return 3 }
+    if (if vec_get(&v,1) > 2.0 { vec_get(&v,1)-2.0 } else { 2.0-vec_get(&v,1) }) >= 1.0e-9 { print("FAIL get\n"); return 4 }
+    // set
+    vec_set(&!v, 0, 10.0)
+    if (if vec_get(&v,0) > 10.0 { vec_get(&v,0)-10.0 } else { 10.0-vec_get(&v,0) }) >= 1.0e-9 { print("FAIL set\n"); return 5 }
+    // pop
+    let top = vec_pop(&!v)
+    if (if top > 3.0 { top-3.0 } else { 3.0-top }) >= 1.0e-9 { print("FAIL pop\n"); return 6 }
+    if vec_len(&v) != 2 { print("FAIL len after pop\n"); return 7 }
+    // reverse [10,2] -> [2,10]
+    vec_reverse(&!v)
+    if (if vec_get(&v,0) > 2.0 { vec_get(&v,0)-2.0 } else { 2.0-vec_get(&v,0) }) >= 1.0e-9 { print("FAIL reverse\n"); return 8 }
+    print("VEC_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
**Grouped PR (3 verticals in one)**, lean (tests+gate only -> merges clean vs active main). Three cold/disjoint self-contained modules, native under **default Madaros**, cross-module-safe APIs, **no source edits**:
- **autodiff::epistemic_dual** — forward-mode AD: d/dx(x^2)=2x (=6), product rule (=11), d/dx(e^x)=1 -> `EDUAL_STDLIB_OK`.
- **collections::vec** — VecF64 push/pop/sum/mean/get/set/reverse -> `VEC_STDLIB_OK`.
- **collections::stack** — Stack64 LIFO push/peek/pop/size/empty -> `STACK_STDLIB_OK`.

Combined gate `VERTICALS_BATCH3_GATE_OK`; math-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)