### PR TITLE
feat(stats): expand Bayesian family — bayes_ab, beta_hdi, bic

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2845,3 +2845,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - partial_corr = **PASS**: r_xy·z formula + t(n−3) test; discriminating case r_xy=0 but partial=−1 (r_xz=0.6,r_yz=0.8) verified; uncorrelated-z → partial=r_xy.
 - Theme: correlation-inference toolkit — the Fisher-z CI, point-biserial, and partial correlation beside the existing Pearson/Spearman module. partial_corr makes 3 nested pc_pearson calls (shared-ref reads, scalar return) — #852-safe. Suite runner: 70 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-1ZtLOb/`, `/tmp/llm-offload-rTCcaN/`, `/tmp/llm-offload-CqFiN9/`.
+
+## 2026-07-15 — math-review: stats::bayes_ab, stats::beta_hdi, stats::bic
+- Files (all new): `stdlib/stats/bayes_ab.sio` (Bayesian A/B test P(pB>pA) for two Beta posteriors via Miller's exact finite sum), `stdlib/stats/beta_hdi.sio` (Beta-posterior equal-tailed credible interval via inverse incomplete-beta bisection + tail probability), `stdlib/stats/bic.sio` (AIC/BIC + Schwarz Bayes-factor approximation). Provider: xAI/Grok 4.3.
+- bayes_ab = **PASS**: Miller/Berry-Fristedt identity for integer αB verified; Beta(2,1)vs(1,1)→2/3 (analytic), symmetric→0.5, separated→≈1.
+- beta_hdi = **PASS**: equal-tailed inverse-incomplete-beta interval, bisection convergence, incomplete beta all correct; Beta(1,1)→[0.025,0.975], I_0.8(2,2)=0.896 verified.
+- bic = **PASS**: AIC=2k−2lnL, BIC=k·ln(n)−2lnL, ln BF₁₀≈(BIC₀−BIC₁)/2 all exact; worked values verified.
+- Theme: Bayesian inference & model selection — expands the previously single-module Bayesian family (bayes_conjugate). All derivable, #852-safe. Suite runner: 73 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-n4B5X5/`, `/tmp/llm-offload-jNnXGV/`, `/tmp/llm-offload-ylWpE0/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -79,6 +79,9 @@ MODULES=(
   stdlib/stats/corr_ci.sio
   stdlib/stats/point_biserial.sio
   stdlib/stats/partial_corr.sio
+  stdlib/stats/bayes_ab.sio
+  stdlib/stats/beta_hdi.sio
+  stdlib/stats/bic.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -36,7 +36,9 @@ fourteen families:
   a parametric exponential fit.
 - **Meta-analysis & epidemiology** — fixed / random-effects pooling, RR / OR /
   NNT, and person-time incidence rates.
-- **Bayesian** — conjugate updates with credible sets.
+- **Bayesian & model selection** — conjugate updates, the Beta-posterior
+  credible interval, the Bayesian A/B test (P(pB>pA)), and AIC / BIC with the
+  Schwarz Bayes-factor approximation.
 
 Every routine is written in Sounio with no FFI, no sampling dependency and no
 external solver: the analytic core rests only on the special-function modules
@@ -1015,6 +1017,41 @@ control): `r_xy·z=(r_xy−r_xz·r_yz)/√((1−r_xz²)(1−r_yz²))` with a `t(
 Validated: r_xy=0 but r_xz=0.6, r_yz=0.8 → partial=−1; z uncorrelated with both
 → partial=r_xy.
 
+### `stats::bayes_ab` — Bayesian A/B test
+
+| Function | Signature |
+|---|---|
+| `bayes_ab` | `pub fn bayes_ab(aA: f64, bA: f64, aB: f64, bB: f64) -> ABResult with Mut, Div, Panic` |
+
+The posterior probability that one rate exceeds another, for two conjugate Beta
+posteriors — the decision quantity a Bayesian A/B test reports instead of a
+p-value. Exact finite-sum (Miller). Validated: Beta(2,1) vs Beta(1,1) →
+P(pB>pA)=2/3; identical → 0.5; well-separated → >0.999.
+
+### `stats::beta_hdi` — Beta posterior credible interval
+
+| Function | Signature |
+|---|---|
+| `beta_hdi` | `pub fn beta_hdi(a: f64, b: f64, conf: f64) -> BetaPostResult with Mut, Div, Panic` |
+| `beta_tail_leq` | `pub fn beta_tail_leq(a: f64, b: f64, t: f64) -> f64 with Mut, Div, Panic` |
+
+An equal-tailed credible interval for a Beta(a,b) posterior (inverse incomplete
+beta by bisection), plus the tail probability `P(p≤t)=I_t(a,b)`, posterior mean
+and mode. Validated: Beta(1,1) → 95% interval [0.025, 0.975]; Beta(2,2) → mode
+0.5, `P(p≤0.8)=0.896`.
+
+### `stats::bic` — AIC / BIC model selection
+
+| Function | Signature |
+|---|---|
+| `aic` / `bic` | `pub fn aic(loglik: f64, k: i32) -> f64` · `bic(loglik, k, n) -> f64` |
+| `bic_compare` | `pub fn bic_compare(ll0: f64, k0: i32, ll1: f64, k1: i32, n: i32) -> BICResult with Mut, Div, Panic` |
+
+Information criteria `AIC=2k−2lnL`, `BIC=k·ln(n)−2lnL` and the Schwarz
+Bayes-factor approximation `ln BF₁₀≈(BIC₀−BIC₁)/2`. Validated: lnL −100/k2 vs
+−90/k3, n=50 → BIC 207.82 / 191.74, ln BF₁₀=8.044; equal fit + extra parameter →
+BIC penalty −ln(100).
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1089,6 +1126,9 @@ use stats::fit_lognormal::{LogNormalFit, fit_lognormal}
 use stats::corr_ci::{CorrCIResult, corr_ci}
 use stats::point_biserial::{PointBiserialResult, point_biserial}
 use stats::partial_corr::{PartialResult, partial_corr}
+use stats::bayes_ab::{ABResult, bayes_ab}
+use stats::beta_hdi::{BetaPostResult, beta_hdi, beta_tail_leq}
+use stats::bic::{BICResult, aic, bic, bic_compare}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/bayes_ab.sio
+++ b/stdlib/stats/bayes_ab.sio
@@ -1,0 +1,179 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bayes_ab.sio — Bayesian A/B test for two proportions
+//
+// Given conjugate Beta posteriors for two rates, computes the posterior
+// probability that one exceeds the other — the decision quantity a Bayesian A/B
+// test actually reports (in place of a p-value):
+//
+//   bayes_ab(aA, bA, aB, bB) -> ABResult
+//
+// For pA ~ Beta(αA, βA), pB ~ Beta(αB, βB) (αB a positive integer), the exact
+// closed form (Miller) is
+//   P(pB > pA) = Σ_{i=0}^{αB−1}  B(αA+i, βA+βB)
+//                                 / [ (βB+i)·B(1+i, βB)·B(αA, βA) ].
+//
+// Pure Sounio: beta functions via inline Lanczos log-gamma; a finite sum. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Miller (2015) "Formulas for Bayesian A/B testing"; Berry & Fristedt (1985).
+
+module stats::bayes_ab
+
+fn ab_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ab_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn ab_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn ab_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * ab_ln(tt) - tt + ab_ln(a)
+}
+
+// ln B(a,b) = lgamma(a)+lgamma(b)-lgamma(a+b)
+fn ab_lbeta(a: f64, b: f64) -> f64 with Mut, Div, Panic {
+    return ab_lgamma(a) + ab_lgamma(b) - ab_lgamma(a + b)
+}
+
+pub struct ABResult {
+    pub prob_b_gt_a: f64,   // P(pB > pA)
+    pub prob_a_gt_b: f64,   // P(pA > pB)
+    pub mean_a: f64,        // αA/(αA+βA)
+    pub mean_b: f64,        // αB/(αB+βB)
+}
+
+/// Bayesian A/B test: posterior P(pB > pA) for two Beta posteriors.
+///
+/// Parâmetros: aA,bA — Beta params for A; aB,bB — for B (aB a positive integer).
+/// Retorno: ABResult (prob_b_gt_a, prob_a_gt_b, mean_a, mean_b).
+/// Referências: Miller (2015).
+pub fn bayes_ab(aA: f64, bA: f64, aB: f64, bB: f64) -> ABResult with Mut, Div, Panic {
+    if aA <= 0.0 || bA <= 0.0 || aB <= 0.0 || bB <= 0.0 {
+        return ABResult { prob_b_gt_a: 0.5, prob_a_gt_b: 0.5, mean_a: 0.0, mean_b: 0.0 }
+    }
+    let lbeta_a = ab_lbeta(aA, bA)
+    // number of terms = floor(aB)
+    var kmax = 0
+    while ((kmax + 1) as f64) <= aB { kmax = kmax + 1 }
+    var prob = 0.0
+    var i = 0
+    while i < kmax {
+        let fi = i as f64
+        // term = B(aA+i, bA+bB) / [ (bB+i)·B(1+i, bB)·B(aA,bA) ]
+        let ln_num = ab_lbeta(aA + fi, bA + bB)
+        let ln_den = ab_ln(bB + fi) + ab_lbeta(1.0 + fi, bB) + lbeta_a
+        prob = prob + ab_exp(ln_num - ln_den)
+        i = i + 1
+    }
+    if prob > 1.0 { prob = 1.0 }
+    if prob < 0.0 { prob = 0.0 }
+    let mean_a = aA / (aA + bA)
+    let mean_b = aB / (aB + bB)
+    return ABResult { prob_b_gt_a: prob, prob_a_gt_b: 1.0 - prob, mean_a: mean_a, mean_b: mean_b }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Beta(2,1) vs Beta(1,1): P(pB>pA) = 2/3 (analytic).
+fn test_two_thirds() -> bool with IO, Mut, Div, Panic {
+    let r = bayes_ab(1.0, 1.0, 2.0, 1.0)
+    var ok = true
+    ok = check(1, approx(r.prob_b_gt_a, 0.666667, 1.0e-4)) && ok
+    ok = check(2, approx(r.prob_a_gt_b, 0.333333, 1.0e-4)) && ok
+    return ok
+}
+
+// identical posteriors Beta(5,5) vs Beta(5,5): P = 0.5 by symmetry.
+fn test_symmetric() -> bool with IO, Mut, Div, Panic {
+    let r = bayes_ab(5.0, 5.0, 5.0, 5.0)
+    var ok = true
+    ok = check(10, approx(r.prob_b_gt_a, 0.5, 1.0e-4)) && ok
+    ok = check(11, approx(r.mean_b, 0.5, 1.0e-9)) && ok
+    return ok
+}
+
+// well-separated: B = Beta(20,2) (mean ~0.91), A = Beta(2,20) (mean ~0.09).
+// P(pB>pA) essentially 1.
+fn test_separated() -> bool with IO, Mut, Div, Panic {
+    let r = bayes_ab(2.0, 20.0, 20.0, 2.0)
+    var ok = true
+    ok = check(20, r.prob_b_gt_a > 0.999) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_two_thirds() && ok
+    ok = test_symmetric() && ok
+    ok = test_separated() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/beta_hdi.sio
+++ b/stdlib/stats/beta_hdi.sio
@@ -1,0 +1,223 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/beta_hdi.sio — Beta posterior credible interval & tail probability
+//
+// Summarises a Beta(α, β) posterior (e.g. the conjugate posterior of a rate)
+// with an equal-tailed credible interval and tail probabilities:
+//
+//   beta_hdi(a, b, conf) -> BetaPostResult
+//   beta_tail_leq(a, b, t)  -> f64         P(p ≤ t) = I_t(α, β)
+//
+// The credible interval [Q(α/2), Q(1−α/2)] inverts the regularised incomplete
+// beta by bisection; the posterior mean is α/(α+β) and the mode (α−1)/(α+β−2)
+// for α,β > 1.
+//
+// Pure Sounio: inline Lanczos log-gamma + continued-fraction incomplete beta,
+// inverted by bisection. No external dependency, no nested data-array calls.
+//
+// References:
+//   Gelman et al., "Bayesian Data Analysis" 3e, §2.
+
+module stats::beta_hdi
+
+fn bh_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / bh_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn bh_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn bh_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * bh_ln(tt) - tt + bh_ln(a)
+}
+
+fn bh_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn bh_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = bh_lgamma(a) + bh_lgamma(b) - bh_lgamma(a + b)
+    let front = bh_exp(a * bh_ln(x) + b * bh_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * bh_betacf(a, b, x) / a }
+    return 1.0 - front * bh_betacf(b, a, 1.0 - x) / b
+}
+
+// inverse incomplete beta: solve I_x(a,b) = target for x, by bisection.
+fn bh_ibeta_inv(a: f64, b: f64, target: f64) -> f64 with Mut, Div, Panic {
+    if target <= 0.0 { return 0.0 }
+    if target >= 1.0 { return 1.0 }
+    var lo = 0.0
+    var hi = 1.0
+    var mid = 0.5
+    var it = 0
+    while it < 80 {
+        mid = 0.5 * (lo + hi)
+        let cdf = bh_ibeta(a, b, mid)
+        if cdf < target { lo = mid } else { hi = mid }
+        it = it + 1
+    }
+    return mid
+}
+
+/// P(p ≤ t) under a Beta(a,b) posterior.
+pub fn beta_tail_leq(a: f64, b: f64, t: f64) -> f64 with Mut, Div, Panic {
+    return bh_ibeta(a, b, t)
+}
+
+pub struct BetaPostResult {
+    pub lo: f64,     // credible interval lower
+    pub hi: f64,     // credible interval upper
+    pub mean: f64,   // a/(a+b)
+    pub mode: f64,   // (a-1)/(a+b-2), or -1 if undefined
+}
+
+/// Equal-tailed credible interval and summaries for a Beta(a,b) posterior.
+///
+/// Parâmetros: a, b — Beta parameters (>0); conf — credible level (e.g. 0.95).
+/// Retorno: BetaPostResult (lo, hi, mean, mode).
+/// Referências: Gelman et al. §2.
+pub fn beta_hdi(a: f64, b: f64, conf: f64) -> BetaPostResult with Mut, Div, Panic {
+    if a <= 0.0 || b <= 0.0 { return BetaPostResult { lo: 0.0, hi: 0.0, mean: 0.0, mode: 0.0 - 1.0 } }
+    let alpha = 1.0 - conf
+    let lo = bh_ibeta_inv(a, b, alpha * 0.5)
+    let hi = bh_ibeta_inv(a, b, 1.0 - alpha * 0.5)
+    let mean = a / (a + b)
+    var mode = 0.0 - 1.0
+    if a > 1.0 && b > 1.0 { mode = (a - 1.0) / (a + b - 2.0) }
+    return BetaPostResult { lo: lo, hi: hi, mean: mean, mode: mode }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Beta(1,1) is uniform: 95% equal-tailed interval = [0.025, 0.975]; mean 0.5.
+fn test_uniform() -> bool with IO, Mut, Div, Panic {
+    let r = beta_hdi(1.0, 1.0, 0.95)
+    var ok = true
+    ok = check(1, approx(r.lo, 0.025, 1.0e-4)) && ok
+    ok = check(2, approx(r.hi, 0.975, 1.0e-4)) && ok
+    ok = check(3, approx(r.mean, 0.5, 1.0e-9)) && ok
+    return ok
+}
+
+// Beta(2,2): symmetric about 0.5. P(p<=0.5)=0.5; mean 0.5; mode 0.5.
+fn test_beta22() -> bool with IO, Mut, Div, Panic {
+    let r = beta_hdi(2.0, 2.0, 0.95)
+    var ok = true
+    ok = check(10, approx(r.mean, 0.5, 1.0e-9)) && ok
+    ok = check(11, approx(r.mode, 0.5, 1.0e-9)) && ok
+    ok = check(12, approx(r.lo, 1.0 - r.hi, 1.0e-4)) && ok        // symmetric interval
+    ok = check(13, approx(beta_tail_leq(2.0, 2.0, 0.5), 0.5, 1.0e-6)) && ok
+    return ok
+}
+
+// tail probability check: I_{0.8}(2,2) = 0.8²(3-1.6) = 0.64·1.4 = 0.896.
+fn test_tail() -> bool with IO, Mut, Div, Panic {
+    return check(20, approx(beta_tail_leq(2.0, 2.0, 0.8), 0.896, 1.0e-5))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_uniform() && ok
+    ok = test_beta22() && ok
+    ok = test_tail() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/bic.sio
+++ b/stdlib/stats/bic.sio
@@ -1,0 +1,142 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bic.sio — AIC / BIC model selection & the BIC Bayes factor
+//
+// Information criteria for comparing two fitted models by their maximised
+// log-likelihood, penalising parameter count:
+//
+//   aic(loglik, k)                            -> f64
+//   bic(loglik, k, n)                         -> f64
+//   bic_compare(ll0, k0, ll1, k1, n)          -> BICResult
+//
+//   AIC = 2k − 2·lnL,      BIC = k·ln(n) − 2·lnL,
+// and the Schwarz approximation to the Bayes factor for model 1 vs model 0 is
+//   ln BF₁₀ ≈ (BIC₀ − BIC₁)/2.
+//
+// Pure Sounio: inline ln; arithmetic only. No external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Akaike (1974); Schwarz (1978) Ann. Stat. 6:461; Kass & Raftery (1995).
+
+module stats::bic
+
+fn bc_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+/// Akaike information criterion.
+pub fn aic(loglik: f64, k: i32) -> f64 {
+    return 2.0 * (k as f64) - 2.0 * loglik
+}
+
+/// Bayesian (Schwarz) information criterion.
+pub fn bic(loglik: f64, k: i32, n: i32) -> f64 with Mut, Div, Panic {
+    return (k as f64) * bc_ln(n as f64) - 2.0 * loglik
+}
+
+pub struct BICResult {
+    pub aic0: f64,
+    pub aic1: f64,
+    pub bic0: f64,
+    pub bic1: f64,
+    pub delta_aic: f64,     // AIC0 - AIC1  (positive favours model 1)
+    pub delta_bic: f64,     // BIC0 - BIC1
+    pub log_bf10: f64,      // ln BF(model1 vs model0) ≈ delta_bic / 2
+}
+
+/// Compare two models by AIC, BIC and the BIC Bayes factor.
+///
+/// Parâmetros: ll0,k0 — model 0 log-likelihood & #params; ll1,k1 — model 1;
+///             n — sample size.
+/// Retorno: BICResult (aic/bic per model, deltas, log BF10).
+/// Referências: Schwarz (1978); Kass & Raftery (1995).
+pub fn bic_compare(ll0: f64, k0: i32, ll1: f64, k1: i32, n: i32) -> BICResult with Mut, Div, Panic {
+    let a0 = aic(ll0, k0)
+    let a1 = aic(ll1, k1)
+    let b0 = bic(ll0, k0, n)
+    let b1 = bic(ll1, k1, n)
+    let db = b0 - b1
+    return BICResult {
+        aic0: a0, aic1: a1, bic0: b0, bic1: b1,
+        delta_aic: a0 - a1, delta_bic: db, log_bf10: db / 2.0
+    }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// model0: lnL=-100, k=2; model1: lnL=-90, k=3; n=50.
+// AIC0=4+200=204; AIC1=6+180=186.
+// BIC0=2·ln50+200=7.824046+200=207.824046; BIC1=3·ln50+180=11.736069+180=191.736069.
+// delta_bic=16.087977; log_bf10=8.043989.
+fn test_compare() -> bool with IO, Mut, Div, Panic {
+    let r = bic_compare(0.0 - 100.0, 2, 0.0 - 90.0, 3, 50)
+    var ok = true
+    ok = check(1, approx(r.aic0, 204.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.aic1, 186.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.bic0, 207.824046, 1.0e-4)) && ok
+    ok = check(4, approx(r.bic1, 191.736069, 1.0e-4)) && ok
+    ok = check(5, approx(r.delta_bic, 16.087977, 1.0e-4)) && ok
+    ok = check(6, approx(r.log_bf10, 8.043989, 1.0e-4)) && ok
+    return ok
+}
+
+// equal fit, model1 has an extra parameter -> BIC penalises it (delta_bic < 0).
+fn test_penalty() -> bool with IO, Mut, Div, Panic {
+    let r = bic_compare(0.0 - 50.0, 2, 0.0 - 50.0, 3, 100)
+    // both lnL equal; BIC1 - BIC0 = ln(100) > 0 -> delta_bic = -ln(100) = -4.60517.
+    var ok = true
+    ok = check(10, approx(r.delta_bic, 0.0 - 4.60517, 1.0e-4)) && ok
+    ok = check(11, r.log_bf10 < 0.0) && ok
+    return ok
+}
+
+// standalone helpers.
+fn test_helpers() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(20, approx(aic(0.0 - 100.0, 2), 204.0, 1.0e-9)) && ok
+    ok = check(21, approx(bic(0.0 - 100.0, 2, 50), 207.824046, 1.0e-4)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_compare() && ok
+    ok = test_penalty() && ok
+    ok = test_helpers() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three Bayesian-inference and model-selection modules, bringing the runner to **73 modules**. These expand the previously single-module Bayesian family (`bayes_conjugate`). Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::bayes_ab` | Bayesian A/B test — posterior P(pB>pA) for two Beta posteriors (Miller's exact sum) |
| `stats::beta_hdi` | Beta credible interval (inverse incomplete beta) + tail probability, mean, mode |
| `stats::bic` | AIC / BIC + the Schwarz Bayes-factor approximation ln BF₁₀=(BIC₀−BIC₁)/2 |

## Validation

- Inline `//@ run-pass` tests against hand-computed / analytic worked examples:
  - Bayes A/B: Beta(2,1) vs Beta(1,1) → P(pB>pA)=2/3 (matches the closed-form integral); identical posteriors → 0.5; well-separated → >0.999.
  - Beta credible interval: Beta(1,1) → 95% interval [0.025, 0.975]; Beta(2,2) → mode 0.5, symmetric interval, `P(p≤0.8)=I_0.8(2,2)=0.896`.
  - BIC: lnL −100/k2 vs −90/k3, n=50 → AIC 204/186, BIC 207.82/191.74, ln BF₁₀=8.044; equal fit + one extra parameter → BIC penalty −ln(100).
- Full suite selftest: **73 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; Beta functions and incomplete beta via inline Lanczos log-gamma.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).