### PR TITLE
test(stdlib): batch run-proofs — collections::hashmap + core::result + math::qd128

### DIFF
--- a/scripts/verticals_batch4_gate.sh
+++ b/scripts/verticals_batch4_gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Combined gate: collections::hashmap, core::result (default Madaros); math::qd128 (lean_single, imports dd64).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel engine
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if [ "${4:-}" = "lean_single" ]; then
+    if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+      chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+    else echo "FAIL compile $2"; fail=1; fi
+  else
+    if $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+      "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+    else echo "FAIL compile $2"; fail=1; fi
+  fi
+}
+run stdlib/collections/hashmap.sio  tests/stdlib/collections/test_hashmap_stdlib.sio  HASHMAP_STDLIB_OK
+run stdlib/core/result.sio          tests/stdlib/core/test_result_stdlib.sio          RESULT_STDLIB_OK
+run stdlib/math/qd128.sio           tests/stdlib/math/test_qd128_stdlib.sio           QD128_STDLIB_OK   lean_single
+[ $fail -eq 0 ] && echo "VERTICALS_BATCH4_GATE_OK"
+exit $fail

--- a/tests/stdlib/collections/test_hashmap_stdlib.sio
+++ b/tests/stdlib/collections/test_hashmap_stdlib.sio
@@ -1,0 +1,20 @@
+// Run-proof for stdlib collections::hashmap (HashMap64). By-reference API -> default Madaros.
+use collections::hashmap::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var m = hashmap_new()
+    let a = hashmap_insert(&!m, 7, 3.5)
+    let b = hashmap_insert(&!m, 42, 9.0)
+    if (if hashmap_get(&m,7) > 3.5 { hashmap_get(&m,7)-3.5 } else { 3.5-hashmap_get(&m,7) }) >= 1.0e-9 { print("FAIL get7\n"); return 1 }
+    if (if hashmap_get(&m,42) > 9.0 { hashmap_get(&m,42)-9.0 } else { 9.0-hashmap_get(&m,42) }) >= 1.0e-9 { print("FAIL get42\n"); return 2 }
+    if hashmap_count(&m) != 2 { print("FAIL count\n"); return 3 }
+    if !hashmap_contains(&m, 7) { print("FAIL has7\n"); return 4 }
+    if hashmap_contains(&m, 99) { print("FAIL no99\n"); return 5 }
+    let r = hashmap_remove(&!m, 7)
+    if hashmap_count(&m) != 1 { print("FAIL count_after_rm\n"); return 6 }
+    if hashmap_contains(&m, 7) { print("FAIL still_has7\n"); return 7 }
+    // update existing key overwrites (count stays)
+    let u = hashmap_insert(&!m, 42, 1.0)
+    if (if hashmap_get(&m,42) > 1.0 { hashmap_get(&m,42)-1.0 } else { 1.0-hashmap_get(&m,42) }) >= 1.0e-9 { print("FAIL update\n"); return 8 }
+    print("HASHMAP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/core/test_result_stdlib.sio
+++ b/tests/stdlib/core/test_result_stdlib.sio
@@ -1,0 +1,18 @@
+// Run-proof for stdlib core::result (IntResult/FloatResult). By-reference API -> default Madaros.
+use core::result::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ok = int_ok(42)
+    if !int_result_is_ok(&ok) { print("FAIL ok_is_ok\n"); return 1 }
+    if int_result_is_err(&ok) { print("FAIL ok_not_err\n"); return 2 }
+    if int_result_unwrap(&ok) != 42 { print("FAIL unwrap\n"); return 3 }
+    let err = int_err(5)
+    if !int_result_is_err(&err) { print("FAIL err_is_err\n"); return 4 }
+    if int_result_unwrap_or(&err, 99) != 99 { print("FAIL unwrap_or\n"); return 5 }
+    if int_result_err(&err) != 5 { print("FAIL err_code\n"); return 6 }
+    if int_result_unwrap_or(&ok, 99) != 42 { print("FAIL ok_unwrap_or\n"); return 7 }
+    let fok = float_ok(3.14)
+    if !float_result_is_ok(&fok) { print("FAIL float_ok\n"); return 8 }
+    if (if float_result_unwrap(&fok) > 3.14 { float_result_unwrap(&fok)-3.14 } else { 3.14-float_result_unwrap(&fok) }) >= 1.0e-9 { print("FAIL float_unwrap\n"); return 9 }
+    print("RESULT_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_qd128_stdlib.sio
+++ b/tests/stdlib/math/test_qd128_stdlib.sio
@@ -1,0 +1,25 @@
+// Run-proof for stdlib math::qd128 (quad-double / ~63-digit precision).
+// Imports dd64 (2-module) -> build with SOUNIO_SOUC_ENGINE=lean_single + chmod +x.
+use math::qd128::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // round-trip
+    let three = qd_to_f64(qd_from_f64(3.0))
+    if (if three > 3.0 { three-3.0 } else { 3.0-three }) >= 1.0e-15 { print("FAIL rt\n"); return 1 }
+    // extended precision: (1 + 1e-40) - 1 = 1e-40 (dd64 tops out ~1e-32, f64 ~1e-16)
+    let s = qd_add(qd_from_f64(1.0), qd_from_f64(1.0e-40))
+    let back = qd_to_f64(qd_sub(s, qd_from_f64(1.0)))
+    if back < 0.9e-40 { print("FAIL qd_low\n"); return 2 }
+    if back > 1.1e-40 { print("FAIL qd_high\n"); return 3 }
+    // f64 baseline loses it
+    let f = (1.0 + 1.0e-40) - 1.0
+    if (if f > 0.0 { f } else { 0.0-f }) >= 1.0e-50 { print("FAIL f64_zero\n"); return 4 }
+    // 0.5 * 4 = 2
+    let m = qd_to_f64(qd_mul(qd_from_f64(0.5), qd_from_f64(4.0)))
+    if (if m > 2.0 { m-2.0 } else { 2.0-m }) >= 1.0e-28 { print("FAIL mul\n"); return 5 }
+    // sqrt(2)^2 = 2 to quad-double precision
+    let r2 = qd_sqrt(qd_from_f64(2.0))
+    let sq = qd_to_f64(qd_mul(r2, r2))
+    if (if sq > 2.0 { sq-2.0 } else { 2.0-sq }) >= 1.0e-28 { print("FAIL sqrt2\n"); return 6 }
+    print("QD128_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
**Grouped PR (3 verticals in one)**, lean (tests+gate only). Three cold/disjoint self-contained modules, cross-module-safe APIs, **no source edits**:
- **collections::hashmap** — HashMap64 insert/get/count/contains/remove/update (default Madaros) -> `HASHMAP_STDLIB_OK`.
- **core::result** — IntResult/FloatResult ok/err/unwrap/unwrap_or (default Madaros) -> `RESULT_STDLIB_OK`.
- **math::qd128** — quad-double (~63-digit) precision: recovers 1e-40, sqrt(2)^2=2 to 1e-28 (lean_single, imports dd64) -> `QD128_STDLIB_OK`.

Combined gate `VERTICALS_BATCH4_GATE_OK`; math-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)