### PR TITLE
feat(stats): bivariate multivariate tools — mahalanobis, hotelling_t2, pca2

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2853,3 +2853,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - bic = **PASS**: AIC=2k−2lnL, BIC=k·ln(n)−2lnL, ln BF₁₀≈(BIC₀−BIC₁)/2 all exact; worked values verified.
 - Theme: Bayesian inference & model selection — expands the previously single-module Bayesian family (bayes_conjugate). All derivable, #852-safe. Suite runner: 73 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-n4B5X5/`, `/tmp/llm-offload-jNnXGV/`, `/tmp/llm-offload-ylWpE0/`.
+
+## 2026-07-15 — math-review: stats::mahalanobis, stats::hotelling_t2, stats::pca2
+- Files (all new): `stdlib/stats/mahalanobis.sio` (bivariate Mahalanobis distance via closed-form 2×2 inverse), `stdlib/stats/hotelling_t2.sio` (one-sample bivariate Hotelling's T² → F test), `stdlib/stats/pca2.sio` (two-variable PCA: closed-form eigenvalues + eigenvector + variance explained). Provider: xAI/Grok 4.3.
+- mahalanobis = **PASS**: D²=(syy·dx²−2sxy·dx·dy+sxx·dy²)/det, χ²(2) threshold; unit-square query (2,0)→D²=3 verified.
+- hotelling_t2 = **PASS**: T²=n·dᵀS⁻¹d, F=(n−p)/(p(n−1))·T² ~ F(2,n−2); 5-point example T²=10, F=3.75 verified.
+- pca2 = **PASS**: closed-form 2×2 eigenvalues, explained=λ₁/tr, null-space eigenvector with larger-norm candidate selection; correlated→λ₂=0, axis (0.707,0.707) verified.
+- Theme: multivariate (bivariate) — the suite's first multivariate tools, all closed-form over the 2×2 covariance (no general matrix inversion needed). All derivable, #852-safe. Suite runner: 76 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-Lz8r2j/`, `/tmp/llm-offload-ztMqlk/`, `/tmp/llm-offload-zLhBWR/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -82,6 +82,9 @@ MODULES=(
   stdlib/stats/bayes_ab.sio
   stdlib/stats/beta_hdi.sio
   stdlib/stats/bic.sio
+  stdlib/stats/mahalanobis.sio
+  stdlib/stats/hotelling_t2.sio
+  stdlib/stats/pca2.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -36,6 +36,8 @@ fourteen families:
   a parametric exponential fit.
 - **Meta-analysis & epidemiology** — fixed / random-effects pooling, RR / OR /
   NNT, and person-time incidence rates.
+- **Multivariate (bivariate)** — the Mahalanobis distance, one-sample
+  Hotelling's T² and two-variable PCA, all closed-form over the 2×2 covariance.
 - **Bayesian & model selection** — conjugate updates, the Beta-posterior
   credible interval, the Bayesian A/B test (P(pB>pA)), and AIC / BIC with the
   Schwarz Bayes-factor approximation.
@@ -1052,6 +1054,37 @@ Bayes-factor approximation `ln BF₁₀≈(BIC₀−BIC₁)/2`. Validated: lnL �
 −90/k3, n=50 → BIC 207.82 / 191.74, ln BF₁₀=8.044; equal fit + extra parameter →
 BIC penalty −ln(100).
 
+### `stats::mahalanobis` — bivariate Mahalanobis distance
+
+| Function | Signature |
+|---|---|
+| `mahalanobis` | `pub fn mahalanobis(x: &[f64; 256], y: &[f64; 256], n: i32, qx: f64, qy: f64) -> MahalResult with Mut, Div, Panic` |
+
+The covariance-aware distance of a point from a 2-D sample (multivariate outlier
+detection): `D²=(syy·dx²−2sxy·dx·dy+sxx·dy²)/(sxx·syy−sxy²)`, asymptotically
+χ²(2). Validated: a unit square, query (2,0) → D²=3, D=1.732; centre → 0.
+
+### `stats::hotelling_t2` — one-sample Hotelling's T²
+
+| Function | Signature |
+|---|---|
+| `hotelling_t2` | `pub fn hotelling_t2(x: &[f64; 256], y: &[f64; 256], n: i32, m0x: f64, m0y: f64) -> HotellingResult with Mut, Div, Panic` |
+
+The multivariate one-sample t-test for a 2-D mean vector: `T²=n·dᵀS⁻¹d`,
+`F=(n−p)/(p(n−1))·T² ~ F(2,n−2)`. Validated: 5-point example, μ₀=(0,0) →
+T²=10, F=3.75, df (2,3); testing the true mean → T²=0, p=1.
+
+### `stats::pca2` — two-variable PCA
+
+| Function | Signature |
+|---|---|
+| `pca2` | `pub fn pca2(x: &[f64; 256], y: &[f64; 256], n: i32) -> PCA2Result with Mut, Div, Panic` |
+
+The closed-form eigen-decomposition of the 2×2 covariance:
+`λ₁,₂=½[(sxx+syy)±√((sxx−syy)²+4sxy²)]`, the variance explained by PC1, and the
+PC1 unit axis. Validated: perfectly correlated data → λ₂=0, explained=1, axis
+(0.707, 0.707); isotropic → explained=0.5.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1129,6 +1162,9 @@ use stats::partial_corr::{PartialResult, partial_corr}
 use stats::bayes_ab::{ABResult, bayes_ab}
 use stats::beta_hdi::{BetaPostResult, beta_hdi, beta_tail_leq}
 use stats::bic::{BICResult, aic, bic, bic_compare}
+use stats::mahalanobis::{MahalResult, mahalanobis}
+use stats::hotelling_t2::{HotellingResult, hotelling_t2}
+use stats::pca2::{PCA2Result, pca2}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/hotelling_t2.sio
+++ b/stdlib/stats/hotelling_t2.sio
@@ -1,0 +1,237 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/hotelling_t2.sio — one-sample Hotelling's T² test (bivariate)
+//
+// The multivariate generalisation of the one-sample t-test: does the 2-D mean
+// vector equal a hypothesised (μ₀ₓ, μ₀ᵧ)?
+//
+//   hotelling_t2(x, y, n, m0x, m0y) -> HotellingResult
+//
+// With sample covariance S (÷(n−1)) and deviation d = (x̄−μ₀),
+//   T² = n·dᵀ S⁻¹ d,
+//   F = (n−p)/(p(n−1))·T²  ~  F(p, n−p),   p = 2.
+//
+// Pure Sounio: closed-form 2×2 inverse; the F tail via inline Lanczos log-gamma
+// + continued-fraction incomplete beta. No nested data-array calls.
+//
+// References:
+//   Hotelling (1931); Johnson & Wichern, "Applied Multivariate Statistical
+//   Analysis" 6e, §5.
+
+module stats::hotelling_t2
+
+fn ht_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ht_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn ht_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn ht_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * ht_ln(tt) - tt + ht_ln(a)
+}
+
+fn ht_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn ht_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = ht_lgamma(a) + ht_lgamma(b) - ht_lgamma(a + b)
+    let front = ht_exp(a * ht_ln(x) + b * ht_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * ht_betacf(a, b, x) / a }
+    return 1.0 - front * ht_betacf(b, a, 1.0 - x) / b
+}
+
+// upper-tail F: P(F_{d1,d2} > f)
+fn ht_f_sf(f: f64, d1: f64, d2: f64) -> f64 with Mut, Div, Panic {
+    if f <= 0.0 { return 1.0 }
+    let x = d2 / (d2 + d1 * f)
+    return ht_ibeta(d2 * 0.5, d1 * 0.5, x)
+}
+
+pub struct HotellingResult {
+    pub t2: f64,     // Hotelling's T²
+    pub f: f64,      // F statistic
+    pub df1: i64,    // p = 2
+    pub df2: i64,    // n - 2
+    pub p: f64,
+}
+
+/// One-sample bivariate Hotelling's T² test.
+///
+/// Parâmetros: x, y — sample coordinates; n — size (>=3); m0x, m0y — hypothesised mean.
+/// Retorno: HotellingResult (t2, f, df1, df2, p).
+/// Referências: Hotelling (1931).
+pub fn hotelling_t2(x: &[f64; 256], y: &[f64; 256], n: i32, m0x: f64, m0y: f64) -> HotellingResult with Mut, Div, Panic {
+    if n < 3 { return HotellingResult { t2: 0.0, f: 0.0, df1: 2, df2: (n - 2) as i64, p: 1.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var sxx = 0.0
+    var syy = 0.0
+    var sxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        let dy = y[j as usize] - my
+        sxx = sxx + dx * dx
+        syy = syy + dy * dy
+        sxy = sxy + dx * dy
+        j = j + 1
+    }
+    let dfc = nf - 1.0
+    sxx = sxx / dfc
+    syy = syy / dfc
+    sxy = sxy / dfc
+    let det = sxx * syy - sxy * sxy
+    if det <= 0.0 { return HotellingResult { t2: 0.0, f: 0.0, df1: 2, df2: (n - 2) as i64, p: 1.0 } }
+    let dx = mx - m0x
+    let dy = my - m0y
+    let d2 = (syy * dx * dx - 2.0 * sxy * dx * dy + sxx * dy * dy) / det
+    let t2 = nf * d2
+    let p = 2.0
+    let f = (nf - p) / (p * (nf - 1.0)) * t2
+    let pval = ht_f_sf(f, p, nf - p)
+    return HotellingResult { t2: t2, f: f, df1: 2, df2: (n - 2) as i64, p: pval }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {(0,0),(2,0),(0,2),(2,2),(1,1)}: mean (1,1), sxx=syy=1, sxy=0.
+// test mu0=(0,0): d=(1,1), D²=2, T²=5·2=10. F=(5-2)/(2·4)·10=3.75, df (2,3).
+fn test_hotelling() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=2.0; x[2]=0.0; x[3]=2.0; x[4]=1.0
+    y[0]=0.0; y[1]=0.0; y[2]=2.0; y[3]=2.0; y[4]=1.0
+    let r = hotelling_t2(&x, &y, 5, 0.0, 0.0)
+    var ok = true
+    ok = check(1, approx(r.t2, 10.0, 1.0e-5)) && ok
+    ok = check(2, approx(r.f, 3.75, 1.0e-5)) && ok
+    ok = check(3, r.df1 == 2) && ok
+    ok = check(4, r.df2 == 3) && ok
+    return ok
+}
+
+// testing the true mean -> T²=0, F=0, p=1.
+fn test_at_mean() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=2.0; x[2]=0.0; x[3]=2.0; x[4]=1.0
+    y[0]=0.0; y[1]=0.0; y[2]=2.0; y[3]=2.0; y[4]=1.0
+    let r = hotelling_t2(&x, &y, 5, 1.0, 1.0)
+    var ok = true
+    ok = check(10, approx(r.t2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_hotelling() && ok
+    ok = test_at_mean() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/mahalanobis.sio
+++ b/stdlib/stats/mahalanobis.sio
@@ -1,0 +1,154 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/mahalanobis.sio — bivariate Mahalanobis distance
+//
+// The covariance-aware distance of a point from a 2-D sample — multivariate
+// outlier detection and the kernel of Hotelling's T²:
+//
+//   mahalanobis(x, y, n, qx, qy) -> MahalResult
+//
+// With sample covariance Σ = [[sxx, sxy], [sxy, syy]] (÷(n−1)) and deviations
+// d = (qx−x̄, qy−ȳ),
+//   D² = dᵀ Σ⁻¹ d = ( syy·dx² − 2 sxy·dx·dy + sxx·dy² ) / (sxx·syy − sxy²),
+//   D = √D².
+// D² is asymptotically χ²(2), so D² > 5.99 flags a 5% multivariate outlier.
+//
+// Pure Sounio: closed-form 2×2 inverse; one pass for the moments; inline sqrt.
+// No external dependency, no nested data-array calls.
+//
+// References:
+//   Mahalanobis (1936); Johnson & Wichern, "Applied Multivariate Statistical
+//   Analysis" 6e, §5.
+
+module stats::mahalanobis
+
+fn mh_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct MahalResult {
+    pub d: f64,       // Mahalanobis distance
+    pub d2: f64,      // squared distance (~ χ²(2))
+    pub sxx: f64,
+    pub syy: f64,
+    pub sxy: f64,
+}
+
+/// Bivariate Mahalanobis distance of a query point from the sample.
+///
+/// Parâmetros: x, y — the two coordinates of the sample; n — size (>=3);
+///             qx, qy — the query point.
+/// Retorno: MahalResult (d, d2, sample covariance entries).
+/// Referências: Mahalanobis (1936).
+pub fn mahalanobis(x: &[f64; 256], y: &[f64; 256], n: i32, qx: f64, qy: f64) -> MahalResult with Mut, Div, Panic {
+    if n < 3 { return MahalResult { d: 0.0, d2: 0.0, sxx: 0.0, syy: 0.0, sxy: 0.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var sxx = 0.0
+    var syy = 0.0
+    var sxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        let dy = y[j as usize] - my
+        sxx = sxx + dx * dx
+        syy = syy + dy * dy
+        sxy = sxy + dx * dy
+        j = j + 1
+    }
+    let df = nf - 1.0
+    sxx = sxx / df
+    syy = syy / df
+    sxy = sxy / df
+    let det = sxx * syy - sxy * sxy
+    if det <= 0.0 { return MahalResult { d: 0.0, d2: 0.0, sxx: sxx, syy: syy, sxy: sxy } }
+    let dx = qx - mx
+    let dy = qy - my
+    let d2 = (syy * dx * dx - 2.0 * sxy * dx * dy + sxx * dy * dy) / det
+    let d = mh_sqrt(d2)
+    return MahalResult { d: d, d2: d2, sxx: sxx, syy: syy, sxy: sxy }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// square {(-1,-1),(1,-1),(-1,1),(1,1)}: mean (0,0), sxx=syy=4/3, sxy=0.
+// query (2,0): D² = (4/3·4)/((4/3)²) = (16/3)/(16/9) = 3. D=sqrt(3)=1.732051.
+fn test_mahal() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0-1.0; x[1]=1.0; x[2]=0.0-1.0; x[3]=1.0
+    y[0]=0.0-1.0; y[1]=0.0-1.0; y[2]=1.0; y[3]=1.0
+    let r = mahalanobis(&x, &y, 4, 2.0, 0.0)
+    var ok = true
+    ok = check(1, approx(r.sxx, 1.333333, 1.0e-5)) && ok
+    ok = check(2, approx(r.sxy, 0.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.d2, 3.0, 1.0e-5)) && ok
+    ok = check(4, approx(r.d, 1.732051, 1.0e-5)) && ok
+    return ok
+}
+
+// centre point has distance 0.
+fn test_centre() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0-1.0; x[1]=1.0; x[2]=0.0-1.0; x[3]=1.0
+    y[0]=0.0-1.0; y[1]=0.0-1.0; y[2]=1.0; y[3]=1.0
+    let r = mahalanobis(&x, &y, 4, 0.0, 0.0)
+    return check(10, approx(r.d, 0.0, 1.0e-9))
+}
+
+// correlated cloud: {(0,0),(1,1),(2,2),(3,3)} + jitter so det>0.
+// x={0,1,2,3}, y={0,1,2,4}. mean (1.5,1.75). sxx=5/3, sxy, syy computed.
+// query on the trend line should be closer than off-trend; just check d2 finite & >0.
+fn test_correlated() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=0.0; y[1]=1.0; y[2]=2.0; y[3]=4.0
+    let r = mahalanobis(&x, &y, 4, 5.0, 0.0)
+    // off-trend point (5,0) is far -> large d2
+    return check(20, r.d2 > 4.0)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_mahal() && ok
+    ok = test_centre() && ok
+    ok = test_correlated() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/pca2.sio
+++ b/stdlib/stats/pca2.sio
@@ -1,0 +1,182 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/pca2.sio — two-variable principal component analysis
+//
+// The closed-form eigen-decomposition of a 2×2 covariance — the principal axes,
+// their variances and the fraction of variance each explains:
+//
+//   pca2(x, y, n) -> PCA2Result
+//
+// For Σ = [[sxx, sxy], [sxy, syy]] the eigenvalues are
+//   λ₁,₂ = ½[ (sxx+syy) ± √((sxx−syy)² + 4 sxy²) ]   (λ₁ ≥ λ₂),
+// PC1 explains λ₁/(λ₁+λ₂); the PC1 axis is the (normalised) eigenvector of λ₁.
+//
+// Pure Sounio: one pass for the covariance; closed-form eigenvalues; inline
+// sqrt. No external dependency, no nested data-array calls.
+//
+// References:
+//   Pearson (1901); Jolliffe, "Principal Component Analysis" 2e.
+
+module stats::pca2
+
+fn pc_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct PCA2Result {
+    pub lambda1: f64,     // larger eigenvalue (PC1 variance)
+    pub lambda2: f64,     // smaller eigenvalue (PC2 variance)
+    pub explained1: f64,  // λ₁/(λ₁+λ₂)
+    pub v1x: f64,         // PC1 axis (unit vector)
+    pub v1y: f64,
+}
+
+/// Two-variable PCA from raw data.
+///
+/// Parâmetros: x, y — the two variables; n — size (>=2).
+/// Retorno: PCA2Result (lambda1, lambda2, explained1, PC1 unit vector).
+/// Referências: Pearson (1901).
+pub fn pca2(x: &[f64; 256], y: &[f64; 256], n: i32) -> PCA2Result with Mut, Div, Panic {
+    if n < 2 { return PCA2Result { lambda1: 0.0, lambda2: 0.0, explained1: 0.0, v1x: 1.0, v1y: 0.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var sxx = 0.0
+    var syy = 0.0
+    var sxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        let dy = y[j as usize] - my
+        sxx = sxx + dx * dx
+        syy = syy + dy * dy
+        sxy = sxy + dx * dy
+        j = j + 1
+    }
+    let df = nf - 1.0
+    sxx = sxx / df
+    syy = syy / df
+    sxy = sxy / df
+    let tr = sxx + syy
+    let diff = sxx - syy
+    let disc = pc_sqrt(diff * diff + 4.0 * sxy * sxy)
+    let l1 = 0.5 * (tr + disc)
+    let l2 = 0.5 * (tr - disc)
+    var explained = 0.0
+    if tr > 0.0 { explained = l1 / tr }
+    // eigenvector for λ₁: pick the larger-norm of the two candidate columns
+    let c1x = sxy
+    let c1y = l1 - sxx
+    let c2x = l1 - syy
+    let c2y = sxy
+    var vx = c1x
+    var vy = c1y
+    if (c2x * c2x + c2y * c2y) > (c1x * c1x + c1y * c1y) { vx = c2x; vy = c2y }
+    let nrm = pc_sqrt(vx * vx + vy * vy)
+    if nrm > 1.0e-300 { vx = vx / nrm; vy = vy / nrm } else { vx = 1.0; vy = 0.0 }
+    return PCA2Result { lambda1: l1, lambda2: l2, explained1: explained, v1x: vx, v1y: vy }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn abseq(a: f64, b: f64, tol: f64) -> bool {
+    let aa = if a < 0.0 { 0.0 - a } else { a }
+    let ab = if b < 0.0 { 0.0 - b } else { b }
+    let d = if aa > ab { aa - ab } else { ab - aa }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// axis-aligned: x variance 2, y variance 1, uncorrelated.
+// x={-2,-1,1,2,0,0,-... } — build sxx=2, syy=... let me use a direct construction.
+// x={0,2,0,2,1,1} deviations give some cov; simpler: use points on axes.
+// Data: x has spread, y small. x={-2,2,-2,2}, y={-1,1,1,-1}: sxx=Σx²/3=16/3, sxy=?
+// Use the clean case sxx=2,syy=1,sxy=0 via x={-1,1,-1,1}·sqrt-ish is messy;
+// instead test the CORRELATED clean case below and an eigenvalue-sum identity here.
+fn test_eig_sum() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0-1.0; x[1]=1.0; x[2]=0.0-1.0; x[3]=1.0
+    y[0]=0.0-1.0; y[1]=0.0-1.0; y[2]=1.0; y[3]=1.0
+    let r = pca2(&x, &y, 4)
+    // sxx=syy=4/3, sxy=0 -> l1=l2=4/3, explained 0.5, axis degenerate but unit.
+    var ok = true
+    ok = check(1, approx(r.lambda1, 1.333333, 1.0e-5)) && ok
+    ok = check(2, approx(r.lambda2, 1.333333, 1.0e-5)) && ok
+    ok = check(3, approx(r.explained1, 0.5, 1.0e-6)) && ok
+    ok = check(4, approx(r.v1x * r.v1x + r.v1y * r.v1y, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+// perfectly correlated y=x: {(0,0),(1,1),(2,2),(3,3)}. sxx=syy=sxy=5/3.
+// l1=(2·5/3 + sqrt(0+4·25/9))/2=(10/3 + 10/3)/2=10/3; l2=0. explained=1.
+// PC1 axis along (1,1)/sqrt2 = (0.707,0.707).
+fn test_correlated() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=0.0; y[1]=1.0; y[2]=2.0; y[3]=3.0
+    let r = pca2(&x, &y, 4)
+    var ok = true
+    ok = check(10, approx(r.lambda1, 3.333333, 1.0e-5)) && ok
+    ok = check(11, approx(r.lambda2, 0.0, 1.0e-6)) && ok
+    ok = check(12, approx(r.explained1, 1.0, 1.0e-6)) && ok
+    ok = check(13, abseq(r.v1x, 0.707107, 1.0e-4)) && ok      // sign is arbitrary
+    ok = check(14, abseq(r.v1y, 0.707107, 1.0e-4)) && ok
+    return ok
+}
+
+// anti-correlated y=-x direction: axis along (1,-1). {(0,0),(1,-1),(2,-2),(3,-3)}.
+fn test_anti() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=0.0; y[1]=0.0-1.0; y[2]=0.0-2.0; y[3]=0.0-3.0
+    let r = pca2(&x, &y, 4)
+    var ok = true
+    ok = check(20, approx(r.explained1, 1.0, 1.0e-6)) && ok
+    ok = check(21, abseq(r.v1x, 0.707107, 1.0e-4)) && ok
+    ok = check(22, abseq(r.v1y, 0.707107, 1.0e-4)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_eig_sum() && ok
+    ok = test_correlated() && ok
+    ok = test_anti() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

The suite's **first multivariate modules**, bringing the runner to **76 modules**. Until now everything was univariate or bivariate-scalar; these add the 2-D essentials, all closed-form over the 2×2 covariance (no general matrix inversion needed). Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::mahalanobis` | Covariance-aware distance of a point from a 2-D sample (D²~χ²(2)) |
| `stats::hotelling_t2` | One-sample Hotelling's T² — the multivariate one-sample t-test |
| `stats::pca2` | Two-variable PCA: eigenvalues, variance explained, PC1 axis |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Mahalanobis: unit square, query (2,0) → D²=3, D=1.732; centre → 0.
  - Hotelling: 5-point example, μ₀=(0,0) → T²=10, F=3.75, df (2,3); testing the true mean → T²=0, p=1.
  - PCA: perfectly correlated data → λ₂=0, explained=1, PC1 axis (0.707, 0.707); isotropic → explained=0.5.
- Full suite selftest: **76 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; the Hotelling F tail uses inline Lanczos log-gamma + continued-fraction incomplete beta.

## Note on scope
These are deliberately the **p=2 (bivariate)** cases, which cover the common two-variable analysis and are fully hand-verifiable via closed-form 2×2 linear algebra. General p-dimensional versions would need a matrix-inversion primitive the stdlib doesn't yet expose.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).