### PR TITLE
[DO NOT MERGE] compiler: close final raw-field identity witness

### DIFF
--- a/scripts/ci/madaros_imported_struct_reassignment_gate.sh
+++ b/scripts/ci/madaros_imported_struct_reassignment_gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Prove imported struct-return identity survives and changes across assignment.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MADAROS="${SOUNIO_IMPORTED_STRUCT_REASSIGN_MADAROS:-$ROOT_DIR/bin/madaros}"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+WITNESS="$ROOT_DIR/tests/compiler/imported_struct_reassignment/main.sio"
+WORK="$(mktemp -d /tmp/sounio-imported-struct-reassign.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+  echo "[imported-struct-reassignment] FAIL: $*" >&2
+  exit 1
+}
+
+[[ -x "$MADAROS" ]] || fail "Madaros wrapper is missing: $MADAROS"
+[[ -n "$RAW_MADAROS" ]] || fail 'MADAROS_RAW_BIN must name an explicit current-source Madaros ELF'
+[[ -x "$RAW_MADAROS" ]] || fail "current-source Madaros is missing: $RAW_MADAROS"
+
+export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
+MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" build "$WITNESS" -o "$WORK/witness" >"$WORK/build.log" 2>&1 || {
+  cat "$WORK/build.log" >&2
+  fail 'witness did not compile'
+}
+chmod +x "$WORK/witness"
+
+set +e
+"$WORK/witness" >"$WORK/run.log" 2>&1
+rc=$?
+set -e
+if [[ "$rc" -ne 42 ]]; then
+  cat "$WORK/build.log" >&2
+  cat "$WORK/run.log" >&2
+  fail "witness returned rc=$rc instead of 42"
+fi
+
+echo '[imported-struct-reassignment] receipt initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar=PASS nominal_fallback=FORBIDDEN'

--- a/scripts/ci/madaros_imported_struct_reassignment_gate.sh
+++ b/scripts/ci/madaros_imported_struct_reassignment_gate.sh
@@ -36,4 +36,4 @@ if [[ "$rc" -ne 42 ]]; then
   fail "witness returned rc=$rc instead of 42"
 fi
 
-echo '[imported-struct-reassignment] receipt initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar=PASS nominal_fallback=FORBIDDEN'
+echo '[imported-struct-reassignment] receipt initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar=PASS nominal_fallback=FORBIDDEN legacy_raw_field_extension=FINAL'

--- a/scripts/ci/madaros_imported_struct_reassignment_gate.sh
+++ b/scripts/ci/madaros_imported_struct_reassignment_gate.sh
@@ -22,10 +22,9 @@ fail() {
 
 # The runtime scalar copy proves the non-call control remains operational; this
 # structural guard proves only ExprCall can reach the compatibility binder.
-grep -Fq 'if (*rhs_expr_struct).kind == ExprKind::ExprCall {' "$LOWERER" \
-  || fail 'struct identity binder is no longer guarded by ExprCall'
-grep -Fq 'lowerer_bind_local_struct_type_mut(&! lo, (*target_expr).name, rhs_struct_type)' "$LOWERER" \
-  || fail 'direct-call struct identity binder is missing'
+guard_window="$(grep -F -A3 'if (*rhs_expr_struct).kind == ExprKind::ExprCall {' "$LOWERER" || true)"
+grep -Fq 'lowerer_bind_local_struct_type_mut(&! lo, (*target_expr).name, rhs_struct_type)' <<<"$guard_window" \
+  || fail 'struct identity binder is no longer nested under the ExprCall guard'
 
 export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
 MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" build "$WITNESS" -o "$WORK/witness" >"$WORK/build.log" 2>&1 || {

--- a/scripts/ci/madaros_imported_struct_reassignment_gate.sh
+++ b/scripts/ci/madaros_imported_struct_reassignment_gate.sh
@@ -7,6 +7,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MADAROS="${SOUNIO_IMPORTED_STRUCT_REASSIGN_MADAROS:-$ROOT_DIR/bin/madaros}"
 RAW_MADAROS="${MADAROS_RAW_BIN:-}"
 WITNESS="$ROOT_DIR/tests/compiler/imported_struct_reassignment/main.sio"
+LOWERER="$ROOT_DIR/self-hosted/ir/lower.sio"
 WORK="$(mktemp -d /tmp/sounio-imported-struct-reassign.XXXXXX)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -18,6 +19,13 @@ fail() {
 [[ -x "$MADAROS" ]] || fail "Madaros wrapper is missing: $MADAROS"
 [[ -n "$RAW_MADAROS" ]] || fail 'MADAROS_RAW_BIN must name an explicit current-source Madaros ELF'
 [[ -x "$RAW_MADAROS" ]] || fail "current-source Madaros is missing: $RAW_MADAROS"
+
+# The runtime scalar copy proves the non-call control remains operational; this
+# structural guard proves only ExprCall can reach the compatibility binder.
+grep -Fq 'if (*rhs_expr_struct).kind == ExprKind::ExprCall {' "$LOWERER" \
+  || fail 'struct identity binder is no longer guarded by ExprCall'
+grep -Fq 'lowerer_bind_local_struct_type_mut(&! lo, (*target_expr).name, rhs_struct_type)' "$LOWERER" \
+  || fail 'direct-call struct identity binder is missing'
 
 export SOUNIO_STDLIB_PATH="$ROOT_DIR/stdlib"
 MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" build "$WITNESS" -o "$WORK/witness" >"$WORK/build.log" 2>&1 || {
@@ -36,4 +44,4 @@ if [[ "$rc" -ne 42 ]]; then
   fail "witness returned rc=$rc instead of 42"
 fi
 
-echo '[imported-struct-reassignment] receipt initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar=PASS nominal_fallback=FORBIDDEN legacy_raw_field_extension=FINAL'
+echo '[imported-struct-reassignment] receipt initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar_runtime=PASS noncall_binder_guard=PASS nominal_fallback=FORBIDDEN legacy_raw_field_extension=FINAL'

--- a/scripts/ci/madaros_imported_struct_reassignment_gate.sh
+++ b/scripts/ci/madaros_imported_struct_reassignment_gate.sh
@@ -43,4 +43,4 @@ if [[ "$rc" -ne 42 ]]; then
   fail "witness returned rc=$rc instead of 42"
 fi
 
-echo '[imported-struct-reassignment] receipt initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar_runtime=PASS noncall_binder_guard=PASS nominal_fallback=FORBIDDEN legacy_raw_field_extension=FINAL'
+echo '[imported-struct-reassignment] receipt explicit_over_transitive_homonym=PASS initial_let=PASS same_type_reassign=PASS replacement_type_reassign=PASS noncall_scalar_runtime=PASS noncall_binder_guard=PASS nominal_fallback=FORBIDDEN legacy_raw_field_extension=FINAL'

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -36,6 +36,7 @@ var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_VALUES: [i64; 64] = [0; 64]
 // lowering are synchronous, so one resettable table is sufficient.
 var MF_EXTERN_BINDING_NAMES: [Name; 2048] = [ir_empty_name(); 2048]
 var MF_EXTERN_BINDING_MODULE_IDS: [i64; 2048] = [IR_DEFINING_MODULE_UNKNOWN; 2048]
+var MF_PROGRAM_ITEMS: [Option<Box<ItemList>>; 256] = [None; 256]
 
 fn module_frontend_import_is_ident_ch(c: i8) -> bool {
     (c >= 65 as i8 && c <= 90 as i8) ||
@@ -4483,14 +4484,14 @@ fn module_frontend_lower_program_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_begin\n") }
     var epistemic = ir_empty_epistemic_section()
     let binding_count = module_frontend_collect_external_bindings(
-        programs,
+        &! MF_PROGRAM_ITEMS,
         file_paths,
         program_count,
         module_index
     )
     let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
         program,
-        programs,
+        &! MF_PROGRAM_ITEMS,
         program_count,
         module_index,
         &! MF_EXTERN_BINDING_NAMES,
@@ -4509,7 +4510,7 @@ fn module_frontend_lower_program_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
     var summary_val = (*summary_result.summary)
     let summary_module_box = summary_val.module
-    module_frontend_assign_function_provenance(&! (*summary_module_box), programs, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*summary_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
     summary_val.module = summary_module_box
     let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
         program,
@@ -4527,7 +4528,7 @@ fn module_frontend_lower_program_box_traced_with_externs(
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
     let body_module_box = body_result.module
-    module_frontend_assign_function_provenance(&! (*body_module_box), programs, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*body_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
 
     trace.body_lowered_modules = trace.body_lowered_modules + 1
     trace.lowered_modules = trace.lowered_modules + 1
@@ -4552,14 +4553,14 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     var epistemic = ir_empty_epistemic_section()
     let program = mf_program_from_items(items)
     let binding_count = module_frontend_collect_external_bindings(
-        programs,
+        &! MF_PROGRAM_ITEMS,
         file_paths,
         program_count,
         module_index
     )
     let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
         &program,
-        programs,
+        &! MF_PROGRAM_ITEMS,
         program_count,
         module_index,
         &! MF_EXTERN_BINDING_NAMES,
@@ -4578,7 +4579,7 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
     var summary_val = (*summary_result.summary)
     let summary_module_box = summary_val.module
-    module_frontend_assign_function_provenance(&! (*summary_module_box), programs, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*summary_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
     summary_val.module = summary_module_box
     let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
         &program,
@@ -4596,7 +4597,7 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
     let body_module_box = body_result.module
-    module_frontend_assign_function_provenance(&! (*body_module_box), programs, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*body_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
 
     trace.body_lowered_modules = trace.body_lowered_modules + 1
     trace.lowered_modules = trace.lowered_modules + 1
@@ -4776,7 +4777,7 @@ fn module_frontend_items_explicitly_import_from(
 }
 
 fn module_frontend_function_defining_module(
-    programs: &! [Program; 256],
+    program_items: &![Option<Box<ItemList>>; 256],
     file_paths: &![string; 256],
     program_count: i64,
     self_index: i64,
@@ -4789,7 +4790,7 @@ fn module_frontend_function_defining_module(
     // field directly avoids the bootstrap compiler's known by-value aggregate
     // copy loss while preserving exact module identity.
     if module_frontend_items_define_ir_function(
-        &(*programs)[self_index as usize].items,
+        &(*program_items)[self_index as usize],
         name
     ) {
         return self_index
@@ -4806,13 +4807,13 @@ fn module_frontend_function_defining_module(
     while i < program_count {
         if i != self_index {
             if module_frontend_items_define_ir_function(
-                &(*programs)[i as usize].items,
+                &(*program_items)[i as usize],
                 name
             ) {
                 found_module = i
                 found_count = found_count + 1
                 if module_frontend_items_explicitly_import_from(
-                    &(*programs)[self_index as usize].items,
+                    &(*program_items)[self_index as usize],
                     (*file_paths)[self_index as usize],
                     (*file_paths)[i as usize],
                     name
@@ -4855,7 +4856,7 @@ fn module_frontend_binding_name_index(
 }
 
 fn module_frontend_collect_external_bindings(
-    programs: &! [Program; 256],
+    program_items: &![Option<Box<ItemList>>; 256],
     file_paths: &![string; 256],
     program_count: i64,
     self_index: i64
@@ -4873,7 +4874,7 @@ fn module_frontend_collect_external_bindings(
     }
     while module_index < program_count && count < 2048 {
         if module_index != self_index {
-            var current = &(*programs)[module_index as usize].items
+            var current = &(*program_items)[module_index as usize]
             while count < 2048 {
                 match *current {
                     Some(list) => {
@@ -4891,11 +4892,11 @@ fn module_frontend_collect_external_bindings(
                             let item_name = head.name
                             let is_builtin = native_v2_builtin_id_for_name(item_name) != 0
                             let self_defines = module_frontend_items_define_ir_function(
-                               &(*programs)[self_index as usize].items,
+                               &(*program_items)[self_index as usize],
                                item_name
                             )
                             let explicit_route = module_frontend_items_explicitly_import_from(
-                                &(*programs)[self_index as usize].items,
+                                &(*program_items)[self_index as usize],
                                 (*file_paths)[self_index as usize],
                                 (*file_paths)[module_index as usize],
                                 item_name
@@ -4948,7 +4949,7 @@ fn module_frontend_collect_external_bindings(
     module_index = 0
     while module_index < program_count && count < 2048 {
         if module_index != self_index {
-            var current = &(*programs)[module_index as usize].items
+            var current = &(*program_items)[module_index as usize]
             while count < 2048 {
                 match *current {
                     Some(list) => {
@@ -4957,11 +4958,11 @@ fn module_frontend_collect_external_bindings(
                             let item_name = head.name
                             if native_v2_builtin_id_for_name(item_name) == 0 &&
                                !module_frontend_items_define_ir_function(
-                                   &(*programs)[self_index as usize].items,
+                                   &(*program_items)[self_index as usize],
                                    item_name
                                ) &&
                                !module_frontend_items_explicitly_import_from(
-                                   &(*programs)[self_index as usize].items,
+                                   &(*program_items)[self_index as usize],
                                    (*file_paths)[self_index as usize],
                                    (*file_paths)[module_index as usize],
                                    item_name
@@ -4997,7 +4998,7 @@ fn module_frontend_collect_external_bindings(
 // explicit and must fail closed during merge/finalize.
 fn module_frontend_assign_function_provenance(
     module: &! IrModule,
-    programs: &! [Program; 256],
+    program_items: &![Option<Box<ItemList>>; 256],
     file_paths: &![string; 256],
     program_count: i64,
     self_index: i64
@@ -5010,7 +5011,7 @@ fn module_frontend_assign_function_provenance(
         if defining_module_id == IR_DEFINING_MODULE_UNKNOWN ||
            defining_module_id == IR_DEFINING_MODULE_AMBIGUOUS {
             defining_module_id = module_frontend_function_defining_module(
-                programs,
+                program_items,
                 file_paths,
                 program_count,
                 self_index,
@@ -5160,6 +5161,16 @@ fn module_frontend_lower_programs_array_direct_box(
 ) -> ModuleFrontendLowerDirectBoxResult with IO, Mut, Panic, Div, Alloc {
     if loaded <= 0 {
         return module_frontend_lower_direct_box_error("no_modules_loaded")
+    }
+
+    // Snapshot only the stable ItemList handles. Directly projecting an
+    // external Program through the large programs array reads None under the
+    // bootstrap compiler, while copying this Option<Box<...>> handle is the
+    // already-proven seed/dep lowering path.
+    var snapshot_i: i64 = 0
+    while snapshot_i < loaded {
+        MF_PROGRAM_ITEMS[snapshot_i as usize] = (*programs)[snapshot_i as usize].items
+        snapshot_i = snapshot_i + 1
     }
 
     trace.last_stage = "lower_summary"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1489,6 +1489,8 @@ fn ir_module_dump_fn_body(module: &IrModule, fn_index: i64, label: string) with 
     print_int(fn_index)
     print(" name=")
     print(str_from_bytes((*module).functions[fn_index as usize].name.buf, (*module).functions[fn_index as usize].name.len))
+    print(" return=")
+    print(str_from_bytes((*module).functions[fn_index as usize].return_struct_name.buf, (*module).functions[fn_index as usize].return_struct_name.len))
     print(" ic=")
     print_int((*module).functions[fn_index as usize].instr_count)
     print("\n")
@@ -5644,6 +5646,7 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
     }
     if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_FN5"), "1") {
         ir_module_dump_fn_body(&merged_module, 5, "raw_field_runtime_owner")
+        ir_module_dump_fn_body(&merged_module, 18, "raw_field_ir_empty_function")
     }
     let fn_count = merged_module.fn_count
     trace.last_stage = "done"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4661,8 +4661,8 @@ fn module_frontend_items_define_ir_function(
     while true {
         match *current {
             Some(list) => {
-                let item = (*list).head
-                if item.kind == ItemKind::ItemFn && ir_name_eq(item.name, name) {
+                if (*list).head.kind == ItemKind::ItemFn &&
+                   ir_name_eq((*list).head.name, name) {
                     return true
                 }
                 current = &(*list).tail
@@ -4737,19 +4737,31 @@ fn module_frontend_items_explicitly_import_from(
     while true {
         match *current {
             Some(list) => {
-                let item = (*list).head
-                if item.kind == ItemKind::ItemUse &&
-                   module_frontend_use_path_targets_file(
-                       item.use_path,
+                if (*list).head.kind == ItemKind::ItemUse {
+                    let targets_file = module_frontend_use_path_targets_file(
+                       (*list).head.use_path,
                        importing_file_path,
                        candidate_file_path
-                   ) {
-                    var imports_name = item.use_glob
-                    match item.use_items {
-                        Some(_) => imports_name = module_frontend_import_item_list_contains(&item.use_items, name),
+                    )
+                    var imports_name = (*list).head.use_glob
+                    match (*list).head.use_items {
+                        Some(_) => imports_name = module_frontend_import_item_list_contains(&(*list).head.use_items, name),
                         None => imports_name = true,
                     }
-                    if imports_name {
+                    if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") &&
+                       (ir_name_eq(name, make_name("make_a")) ||
+                        ir_name_eq(name, make_name("ir_empty_function"))) {
+                        print("EXTERN_ROUTE name=")
+                        print(str_from_bytes(name.buf, name.len))
+                        print(" candidate=")
+                        print(candidate_file_path)
+                        print(" targets=")
+                        print_int(if targets_file { 1 } else { 0 })
+                        print(" imports=")
+                        print_int(if imports_name { 1 } else { 0 })
+                        print("\n")
+                    }
+                    if targets_file && imports_name {
                         return true
                     }
                 }
@@ -4856,30 +4868,49 @@ fn module_frontend_collect_external_bindings(
             while count < 2048 {
                 match *current {
                     Some(list) => {
-                        let item = (*list).head
-                        if item.kind == ItemKind::ItemFn &&
-                           native_v2_builtin_id_for_name(item.name) == 0 &&
-                           !module_frontend_items_define_ir_function(
+                        if (*list).head.kind == ItemKind::ItemFn {
+                            let item_name = (*list).head.name
+                            let is_builtin = native_v2_builtin_id_for_name(item_name) != 0
+                            let self_defines = module_frontend_items_define_ir_function(
                                &(*programs)[self_index as usize].items,
-                               item.name
-                           ) &&
-                           module_frontend_items_explicitly_import_from(
+                               item_name
+                            )
+                            let explicit_route = module_frontend_items_explicitly_import_from(
                                 &(*programs)[self_index as usize].items,
                                 (*file_paths)[self_index as usize],
                                 (*file_paths)[module_index as usize],
-                                item.name
-                            ) {
-                            let prior = module_frontend_binding_name_index(
-                                &! MF_EXTERN_BINDING_NAMES,
-                                count,
-                                item.name
+                                item_name
                             )
-                            if prior < 0 {
-                                MF_EXTERN_BINDING_NAMES[count as usize] = item.name
-                                MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
-                                count = count + 1
-                            } else if MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
-                                MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                            if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") &&
+                               (ir_name_eq(item_name, make_name("make_a")) ||
+                                ir_name_eq(item_name, make_name("ir_empty_function"))) {
+                                print("EXTERN_CANDIDATE name=")
+                                print(str_from_bytes(item_name.buf, item_name.len))
+                                print(" self=")
+                                print_int(self_index)
+                                print(" module=")
+                                print_int(module_index)
+                                print(" builtin=")
+                                print_int(if is_builtin { 1 } else { 0 })
+                                print(" self_defines=")
+                                print_int(if self_defines { 1 } else { 0 })
+                                print(" explicit=")
+                                print_int(if explicit_route { 1 } else { 0 })
+                                print("\n")
+                            }
+                            if !is_builtin && !self_defines && explicit_route {
+                                let prior = module_frontend_binding_name_index(
+                                    &! MF_EXTERN_BINDING_NAMES,
+                                    count,
+                                    item_name
+                                )
+                                if prior < 0 {
+                                    MF_EXTERN_BINDING_NAMES[count as usize] = item_name
+                                    MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
+                                    count = count + 1
+                                } else if MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
+                                    MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                                }
                             }
                         }
                         current = &(*list).tail
@@ -4902,31 +4933,32 @@ fn module_frontend_collect_external_bindings(
             while count < 2048 {
                 match *current {
                     Some(list) => {
-                        let item = (*list).head
-                        if item.kind == ItemKind::ItemFn &&
-                           native_v2_builtin_id_for_name(item.name) == 0 &&
-                           !module_frontend_items_define_ir_function(
-                               &(*programs)[self_index as usize].items,
-                               item.name
-                           ) &&
-                           !module_frontend_items_explicitly_import_from(
-                               &(*programs)[self_index as usize].items,
-                               (*file_paths)[self_index as usize],
-                               (*file_paths)[module_index as usize],
-                               item.name
-                           ) {
-                            let prior = module_frontend_binding_name_index(
-                                &! MF_EXTERN_BINDING_NAMES,
-                                count,
-                                item.name
-                            )
-                            if prior < 0 {
-                                MF_EXTERN_BINDING_NAMES[count as usize] = item.name
-                                MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
-                                count = count + 1
-                            } else if prior >= explicit_count &&
-                                      MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
-                                MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                        if (*list).head.kind == ItemKind::ItemFn {
+                            let item_name = (*list).head.name
+                            if native_v2_builtin_id_for_name(item_name) == 0 &&
+                               !module_frontend_items_define_ir_function(
+                                   &(*programs)[self_index as usize].items,
+                                   item_name
+                               ) &&
+                               !module_frontend_items_explicitly_import_from(
+                                   &(*programs)[self_index as usize].items,
+                                   (*file_paths)[self_index as usize],
+                                   (*file_paths)[module_index as usize],
+                                   item_name
+                               ) {
+                                let prior = module_frontend_binding_name_index(
+                                    &! MF_EXTERN_BINDING_NAMES,
+                                    count,
+                                    item_name
+                                )
+                                if prior < 0 {
+                                    MF_EXTERN_BINDING_NAMES[count as usize] = item_name
+                                    MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
+                                    count = count + 1
+                                } else if prior >= explicit_count &&
+                                          MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
+                                    MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                                }
                             }
                         }
                         current = &(*list).tail

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4500,6 +4500,17 @@ fn module_frontend_lower_program_box_traced_with_externs(
         binding_count,
         &epistemic
     )
+    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
+        let raw_summary_idx = ir_merge_find_function_name_index(
+            &(*(*summary_result.summary).module),
+            make_name("ir_empty_function")
+        )
+        ir_module_dump_fn_body(
+            &(*(*summary_result.summary).module),
+            raw_summary_idx,
+            "raw_field_summary_ir_empty_function"
+        )
+    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
     if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
         trace.last_stage = "lower_summary_error"
@@ -4518,6 +4529,17 @@ fn module_frontend_lower_program_box_traced_with_externs(
         &summary_val,
         &epistemic
     )
+    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
+        let raw_body_idx = ir_merge_find_function_name_index(
+            &(*body_result.module),
+            make_name("ir_empty_function")
+        )
+        ir_module_dump_fn_body(
+            &(*body_result.module),
+            raw_body_idx,
+            "raw_field_body_ir_empty_function"
+        )
+    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
     if module_frontend_lower_trace_enabled() {
         print("module_frontend_lower: body_fn_count ")
@@ -4569,6 +4591,17 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         binding_count,
         &epistemic
     )
+    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
+        let raw_summary_idx = ir_merge_find_function_name_index(
+            &(*(*summary_result.summary).module),
+            make_name("ir_empty_function")
+        )
+        ir_module_dump_fn_body(
+            &(*(*summary_result.summary).module),
+            raw_summary_idx,
+            "raw_field_summary_ir_empty_function"
+        )
+    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
     if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
         trace.last_stage = "lower_summary_error"
@@ -4587,6 +4620,17 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         &summary_val,
         &epistemic
     )
+    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
+        let raw_body_idx = ir_merge_find_function_name_index(
+            &(*body_result.module),
+            make_name("ir_empty_function")
+        )
+        ir_module_dump_fn_body(
+            &(*body_result.module),
+            raw_body_idx,
+            "raw_field_body_ir_empty_function"
+        )
+    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
     if module_frontend_lower_trace_enabled() {
         print("module_frontend_lower: body_fn_count ")

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4846,6 +4846,8 @@ fn module_frontend_collect_external_bindings(
     program_count: i64,
     self_index: i64
 ) -> i64 with IO, Mut, Panic, Div, Alloc {
+    // Pass 1 owns exact loader-resolved routes. One explicit route wins over
+    // every unimported homonym; multiple explicit routes remain ambiguous.
     var count: i64 = 0
     var module_index: i64 = 0
     while module_index < program_count && count < 2048 {
@@ -4855,44 +4857,76 @@ fn module_frontend_collect_external_bindings(
                 match *current {
                     Some(list) => {
                         let item = (*list).head
-                        if item.kind == ItemKind::ItemFn {
-                            var owner = module_frontend_function_defining_module(
-                                programs,
-                                file_paths,
-                                program_count,
-                                self_index,
-                                item.name
-                            )
-                            // The loader-resolved import route plus the ItemFn we
-                            // are currently visiting is already an exact DefId.
-                            // Do not re-derive it through another large AST scan.
-                            if (owner == IR_DEFINING_MODULE_UNKNOWN ||
-                                owner == IR_DEFINING_MODULE_AMBIGUOUS ||
-                                owner == module_index) &&
-                               module_frontend_items_explicitly_import_from(
+                        if item.kind == ItemKind::ItemFn &&
+                           native_v2_builtin_id_for_name(item.name) == 0 &&
+                           !module_frontend_items_define_ir_function(
+                               &(*programs)[self_index as usize].items,
+                               item.name
+                           ) &&
+                           module_frontend_items_explicitly_import_from(
                                 &(*programs)[self_index as usize].items,
                                 (*file_paths)[self_index as usize],
                                 (*file_paths)[module_index as usize],
                                 item.name
                             ) {
-                                owner = module_index
+                            let prior = module_frontend_binding_name_index(
+                                &! MF_EXTERN_BINDING_NAMES,
+                                count,
+                                item.name
+                            )
+                            if prior < 0 {
+                                MF_EXTERN_BINDING_NAMES[count as usize] = item.name
+                                MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
+                                count = count + 1
+                            } else if MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
+                                MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
                             }
-                            if owner == module_index {
-                                let prior = module_frontend_binding_name_index(
-                                    &! MF_EXTERN_BINDING_NAMES,
-                                    count,
-                                    item.name
-                                )
-                                if prior < 0 {
-                                    MF_EXTERN_BINDING_NAMES[count as usize] = item.name
-                                    MF_EXTERN_BINDING_MODULE_IDS[count as usize] = owner
-                                    count = count + 1
-                                } else if MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != owner {
-                                    // Two explicit routes with the same symbol are
-                                    // not an identity. Keep both from preseeding so
-                                    // downstream provenance validation fails closed.
-                                    MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
-                                }
+                        }
+                        current = &(*list).tail
+                    }
+                    _ => break,
+                }
+            }
+        }
+        module_index = module_index + 1
+    }
+
+    // Pass 2 preserves the legacy globally-unique fallback only for names with
+    // no explicit route. The collector's current ItemFn is the definition
+    // witness, so no second recursive Program scan is needed.
+    let explicit_count = count
+    module_index = 0
+    while module_index < program_count && count < 2048 {
+        if module_index != self_index {
+            var current = &(*programs)[module_index as usize].items
+            while count < 2048 {
+                match *current {
+                    Some(list) => {
+                        let item = (*list).head
+                        if item.kind == ItemKind::ItemFn &&
+                           native_v2_builtin_id_for_name(item.name) == 0 &&
+                           !module_frontend_items_define_ir_function(
+                               &(*programs)[self_index as usize].items,
+                               item.name
+                           ) &&
+                           !module_frontend_items_explicitly_import_from(
+                               &(*programs)[self_index as usize].items,
+                               (*file_paths)[self_index as usize],
+                               (*file_paths)[module_index as usize],
+                               item.name
+                           ) {
+                            let prior = module_frontend_binding_name_index(
+                                &! MF_EXTERN_BINDING_NAMES,
+                                count,
+                                item.name
+                            )
+                            if prior < 0 {
+                                MF_EXTERN_BINDING_NAMES[count as usize] = item.name
+                                MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
+                                count = count + 1
+                            } else if prior >= explicit_count &&
+                                      MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
+                                MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
                             }
                         }
                         current = &(*list).tail

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -9,7 +9,7 @@ use parser::parser::{parser_last_error_count, parser_reset_last_errors}
 use ir::ir::*
 use io::env::{read_env}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata}
-use ir::lower::{LowerProgramItemsHandle, lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
+use ir::lower::{LowerExternBindingHandle, LowerProgramItemsHandle, lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
 use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target, native_v2_builtin_id_for_name}
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
@@ -30,12 +30,11 @@ var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_NAME_HASHES: [i64; 64] = [0; 64]
 var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_KINDS: [i64; 64] = [0; 64]
 var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_TARGET_HASHES: [i64; 64] = [0; 64]
 var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_VALUES: [i64; 64] = [0; 64]
-// Per-lowering DefId binding scratch. These arrays live in BSS because the
-// multimodule lowering wrappers already have large frames and the bootstrap
-// compiler is sensitive to additional aggregate locals. Collection and summary
-// lowering are synchronous, so one resettable table is sufficient.
-var MF_EXTERN_BINDING_NAMES: [Name; 2048] = [ir_empty_name(); 2048]
-var MF_EXTERN_BINDING_MODULE_IDS: [i64; 2048] = [IR_DEFINING_MODULE_UNKNOWN; 2048]
+// Per-lowering DefId binding scratch. Only flat i64 pointer tables live in BSS:
+// the bootstrap corrupts Name/struct-valued global arrays. Aggregate payloads
+// stay in reusable heap nodes, while synchronous collection makes one table
+// sufficient for the current summary lowering.
+var MF_EXTERN_BINDING_PTRS: [i64; 2048] = [0; 2048]
 var MF_PROGRAM_ITEM_PTRS: [i64; 256] = [0; 256]
 
 fn module_frontend_import_is_ident_ch(c: i8) -> bool {
@@ -4489,13 +4488,16 @@ fn module_frontend_lower_program_box_traced_with_externs(
         program_count,
         module_index
     )
+    if binding_count < 0 {
+        trace.last_stage = "lower_summary_error"
+        return module_frontend_lower_box_error("extern_binding_handle_alloc_failed")
+    }
     let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
         program,
         &! MF_PROGRAM_ITEM_PTRS,
         program_count,
         module_index,
-        &! MF_EXTERN_BINDING_NAMES,
-        &! MF_EXTERN_BINDING_MODULE_IDS,
+        &! MF_EXTERN_BINDING_PTRS,
         binding_count,
         &epistemic
     )
@@ -4558,13 +4560,16 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         program_count,
         module_index
     )
+    if binding_count < 0 {
+        trace.last_stage = "lower_summary_error"
+        return module_frontend_lower_box_error("extern_binding_handle_alloc_failed")
+    }
     let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
         &program,
         &! MF_PROGRAM_ITEM_PTRS,
         program_count,
         module_index,
-        &! MF_EXTERN_BINDING_NAMES,
-        &! MF_EXTERN_BINDING_MODULE_IDS,
+        &! MF_EXTERN_BINDING_PTRS,
         binding_count,
         &epistemic
     )
@@ -4843,14 +4848,17 @@ fn module_frontend_function_defining_module(
 }
 
 fn module_frontend_binding_name_index(
-    names: &![Name; 2048],
+    binding_ptrs: &![i64; 2048],
     count: i64,
     name: Name
 ) -> i64 with Mut, Panic, Div {
     var i: i64 = 0
     while i < count {
-        if ir_name_eq((*names)[i as usize], name) {
-            return i
+        let binding = (*binding_ptrs)[i as usize] as *mut LowerExternBindingHandle
+        if binding as i64 != 0 {
+            if ir_name_eq((*binding).name, name) {
+                return i
+            }
         }
         i = i + 1
     }
@@ -4924,16 +4932,27 @@ fn module_frontend_collect_external_bindings(
                             }
                             if !is_builtin && !self_defines && explicit_route {
                                 let prior = module_frontend_binding_name_index(
-                                    &! MF_EXTERN_BINDING_NAMES,
+                                    &! MF_EXTERN_BINDING_PTRS,
                                     count,
                                     item_name
                                 )
                                 if prior < 0 {
-                                    MF_EXTERN_BINDING_NAMES[count as usize] = item_name
-                                    MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
+                                    var binding = MF_EXTERN_BINDING_PTRS[count as usize] as *mut LowerExternBindingHandle
+                                    if binding as i64 == 0 {
+                                        binding = heap_alloc(256) as *mut LowerExternBindingHandle
+                                        if binding as i64 == 0 {
+                                            return -1
+                                        }
+                                        MF_EXTERN_BINDING_PTRS[count as usize] = binding as i64
+                                    }
+                                    (*binding).name = item_name
+                                    (*binding).defining_module_id = module_index
                                     count = count + 1
-                                } else if MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
-                                    MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                                } else {
+                                    let binding = MF_EXTERN_BINDING_PTRS[prior as usize] as *mut LowerExternBindingHandle
+                                    if (*binding).defining_module_id != module_index {
+                                        (*binding).defining_module_id = IR_DEFINING_MODULE_AMBIGUOUS
+                                    }
                                 }
                             }
                         }
@@ -4974,17 +4993,27 @@ fn module_frontend_collect_external_bindings(
                                    item_name
                                ) {
                                 let prior = module_frontend_binding_name_index(
-                                    &! MF_EXTERN_BINDING_NAMES,
+                                    &! MF_EXTERN_BINDING_PTRS,
                                     count,
                                     item_name
                                 )
                                 if prior < 0 {
-                                    MF_EXTERN_BINDING_NAMES[count as usize] = item_name
-                                    MF_EXTERN_BINDING_MODULE_IDS[count as usize] = module_index
+                                    var binding = MF_EXTERN_BINDING_PTRS[count as usize] as *mut LowerExternBindingHandle
+                                    if binding as i64 == 0 {
+                                        binding = heap_alloc(256) as *mut LowerExternBindingHandle
+                                        if binding as i64 == 0 {
+                                            return -1
+                                        }
+                                        MF_EXTERN_BINDING_PTRS[count as usize] = binding as i64
+                                    }
+                                    (*binding).name = item_name
+                                    (*binding).defining_module_id = module_index
                                     count = count + 1
-                                } else if prior >= explicit_count &&
-                                          MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != module_index {
-                                    MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                                } else if prior >= explicit_count {
+                                    let binding = MF_EXTERN_BINDING_PTRS[prior as usize] as *mut LowerExternBindingHandle
+                                    if (*binding).defining_module_id != module_index {
+                                        (*binding).defining_module_id = IR_DEFINING_MODULE_AMBIGUOUS
+                                    }
                                 }
                             }
                         }

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -5178,6 +5178,9 @@ fn module_frontend_lower_programs_array_direct_box(
         var item_handle = MF_PROGRAM_ITEM_PTRS[snapshot_i as usize] as *mut LowerProgramItemsHandle
         if MF_PROGRAM_ITEM_PTRS[snapshot_i as usize] == 0 {
             item_handle = heap_alloc(32) as *mut LowerProgramItemsHandle
+            if item_handle as i64 == 0 {
+                return module_frontend_lower_direct_box_error("program_items_handle_alloc_failed")
+            }
             MF_PROGRAM_ITEM_PTRS[snapshot_i as usize] = item_handle as i64
         }
         (*item_handle).items = (*programs)[snapshot_i as usize].items

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4864,6 +4864,13 @@ fn module_frontend_collect_external_bindings(
     // every unimported homonym; multiple explicit routes remain ambiguous.
     var count: i64 = 0
     var module_index: i64 = 0
+    if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") {
+        print("EXTERN_COLLECT self=")
+        print_int(self_index)
+        print(" programs=")
+        print_int(program_count)
+        print("\n")
+    }
     while module_index < program_count && count < 2048 {
         if module_index != self_index {
             var current = &(*programs)[module_index as usize].items
@@ -4871,6 +4878,15 @@ fn module_frontend_collect_external_bindings(
                 match *current {
                     Some(list) => {
                         let head = &(*list).head
+                        if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") {
+                            print("EXTERN_HEAD module=")
+                            print_int(module_index)
+                            print(" kind=")
+                            print_int(head.kind as i64)
+                            print(" name=")
+                            print(str_from_bytes(head.name.buf, head.name.len))
+                            print("\n")
+                        }
                         if head.kind == ItemKind::ItemFn {
                             let item_name = head.name
                             let is_builtin = native_v2_builtin_id_for_name(item_name) != 0

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -5642,6 +5642,9 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
         print("DUMPALL: post_finalize\n")
         ir_module_dump_all_calls_diag(&merged_module)
     }
+    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_FN5"), "1") {
+        ir_module_dump_fn_body(&merged_module, 5, "raw_field_runtime_owner")
+    }
     let fn_count = merged_module.fn_count
     trace.last_stage = "done"
     trace.last_module_index = loaded - 1

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4661,8 +4661,9 @@ fn module_frontend_items_define_ir_function(
     while true {
         match *current {
             Some(list) => {
-                if (*list).head.kind == ItemKind::ItemFn &&
-                   ir_name_eq((*list).head.name, name) {
+                let head = &(*list).head
+                if head.kind == ItemKind::ItemFn &&
+                   ir_name_eq(head.name, name) {
                     return true
                 }
                 current = &(*list).tail
@@ -4737,15 +4738,16 @@ fn module_frontend_items_explicitly_import_from(
     while true {
         match *current {
             Some(list) => {
-                if (*list).head.kind == ItemKind::ItemUse {
+                let head = &(*list).head
+                if head.kind == ItemKind::ItemUse {
                     let targets_file = module_frontend_use_path_targets_file(
-                       (*list).head.use_path,
+                       head.use_path,
                        importing_file_path,
                        candidate_file_path
                     )
-                    var imports_name = (*list).head.use_glob
-                    match (*list).head.use_items {
-                        Some(_) => imports_name = module_frontend_import_item_list_contains(&(*list).head.use_items, name),
+                    var imports_name = head.use_glob
+                    match head.use_items {
+                        Some(_) => imports_name = module_frontend_import_item_list_contains(&head.use_items, name),
                         None => imports_name = true,
                     }
                     if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") &&
@@ -4868,8 +4870,9 @@ fn module_frontend_collect_external_bindings(
             while count < 2048 {
                 match *current {
                     Some(list) => {
-                        if (*list).head.kind == ItemKind::ItemFn {
-                            let item_name = (*list).head.name
+                        let head = &(*list).head
+                        if head.kind == ItemKind::ItemFn {
+                            let item_name = head.name
                             let is_builtin = native_v2_builtin_id_for_name(item_name) != 0
                             let self_defines = module_frontend_items_define_ir_function(
                                &(*programs)[self_index as usize].items,
@@ -4933,8 +4936,9 @@ fn module_frontend_collect_external_bindings(
             while count < 2048 {
                 match *current {
                     Some(list) => {
-                        if (*list).head.kind == ItemKind::ItemFn {
-                            let item_name = (*list).head.name
+                        let head = &(*list).head
+                        if head.kind == ItemKind::ItemFn {
+                            let item_name = head.name
                             if native_v2_builtin_id_for_name(item_name) == 0 &&
                                !module_frontend_items_define_ir_function(
                                    &(*programs)[self_index as usize].items,

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -1489,8 +1489,6 @@ fn ir_module_dump_fn_body(module: &IrModule, fn_index: i64, label: string) with 
     print_int(fn_index)
     print(" name=")
     print(str_from_bytes((*module).functions[fn_index as usize].name.buf, (*module).functions[fn_index as usize].name.len))
-    print(" return=")
-    print(str_from_bytes((*module).functions[fn_index as usize].return_struct_name.buf, (*module).functions[fn_index as usize].return_struct_name.len))
     print(" ic=")
     print_int((*module).functions[fn_index as usize].instr_count)
     print("\n")
@@ -4500,17 +4498,6 @@ fn module_frontend_lower_program_box_traced_with_externs(
         binding_count,
         &epistemic
     )
-    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
-        let raw_summary_idx = ir_merge_find_function_name_index(
-            &(*(*summary_result.summary).module),
-            make_name("ir_empty_function")
-        )
-        ir_module_dump_fn_body(
-            &(*(*summary_result.summary).module),
-            raw_summary_idx,
-            "raw_field_summary_ir_empty_function"
-        )
-    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
     if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
         trace.last_stage = "lower_summary_error"
@@ -4529,17 +4516,6 @@ fn module_frontend_lower_program_box_traced_with_externs(
         &summary_val,
         &epistemic
     )
-    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
-        let raw_body_idx = ir_merge_find_function_name_index(
-            &(*body_result.module),
-            make_name("ir_empty_function")
-        )
-        ir_module_dump_fn_body(
-            &(*body_result.module),
-            raw_body_idx,
-            "raw_field_body_ir_empty_function"
-        )
-    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
     if module_frontend_lower_trace_enabled() {
         print("module_frontend_lower: body_fn_count ")
@@ -4591,17 +4567,6 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         binding_count,
         &epistemic
     )
-    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
-        let raw_summary_idx = ir_merge_find_function_name_index(
-            &(*(*summary_result.summary).module),
-            make_name("ir_empty_function")
-        )
-        ir_module_dump_fn_body(
-            &(*(*summary_result.summary).module),
-            raw_summary_idx,
-            "raw_field_summary_ir_empty_function"
-        )
-    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_done\n") }
     if summary_result.had_error || (*(*summary_result.summary).module).fn_count <= 0 {
         trace.last_stage = "lower_summary_error"
@@ -4620,17 +4585,6 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         &summary_val,
         &epistemic
     )
-    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
-        let raw_body_idx = ir_merge_find_function_name_index(
-            &(*body_result.module),
-            make_name("ir_empty_function")
-        )
-        ir_module_dump_fn_body(
-            &(*body_result.module),
-            raw_body_idx,
-            "raw_field_body_ir_empty_function"
-        )
-    }
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
     if module_frontend_lower_trace_enabled() {
         print("module_frontend_lower: body_fn_count ")
@@ -4699,11 +4653,11 @@ fn module_frontend_populate_imported_programs(
 // requested name. The lowering preseed represents both function declarations
 // and global storage entries as IrFunction slots, so ItemFn is the exact AST
 // surface that owns their definition identity.
-fn module_frontend_program_defines_ir_function(
-    program: &Program,
+fn module_frontend_items_define_ir_function(
+    items: &Option<Box<ItemList>>,
     name: Name
 ) -> bool with Mut, Panic, Div {
-    var current = &(*program).items
+    var current = items
     while true {
         match *current {
             Some(list) => {
@@ -4773,13 +4727,13 @@ fn module_frontend_use_path_targets_file(
     str_eq(resolved, candidate_file_path)
 }
 
-fn module_frontend_program_explicitly_imports_from(
-    program: &Program,
+fn module_frontend_items_explicitly_import_from(
+    items: &Option<Box<ItemList>>,
     importing_file_path: string,
     candidate_file_path: string,
     name: Name
 ) -> bool with IO, Mut, Panic, Div, Alloc {
-    var current = &(*program).items
+    var current = items
     while true {
         match *current {
             Some(list) => {
@@ -4817,8 +4771,13 @@ fn module_frontend_function_defining_module(
     if self_index < 0 || self_index >= program_count {
         return IR_DEFINING_MODULE_UNKNOWN
     }
-    let self_program = (*programs)[self_index as usize]
-    if module_frontend_program_defines_ir_function(&self_program, name) {
+    // Program is a large recursive aggregate. Resolving through its item-list
+    // field directly avoids the bootstrap compiler's known by-value aggregate
+    // copy loss while preserving exact module identity.
+    if module_frontend_items_define_ir_function(
+        &(*programs)[self_index as usize].items,
+        name
+    ) {
         return self_index
     }
     if native_v2_builtin_id_for_name(name) != 0 {
@@ -4832,12 +4791,14 @@ fn module_frontend_function_defining_module(
     var i: i64 = 0
     while i < program_count {
         if i != self_index {
-            let candidate = (*programs)[i as usize]
-            if module_frontend_program_defines_ir_function(&candidate, name) {
+            if module_frontend_items_define_ir_function(
+                &(*programs)[i as usize].items,
+                name
+            ) {
                 found_module = i
                 found_count = found_count + 1
-                if module_frontend_program_explicitly_imports_from(
-                    &self_program,
+                if module_frontend_items_explicitly_import_from(
+                    &(*programs)[self_index as usize].items,
                     (*file_paths)[self_index as usize],
                     (*file_paths)[i as usize],
                     name
@@ -5687,10 +5648,6 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
     if str_eq(read_env("SOUNIO_DUMP_ALL_CALLS"), "1") {
         print("DUMPALL: post_finalize\n")
         ir_module_dump_all_calls_diag(&merged_module)
-    }
-    if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_FN5"), "1") {
-        ir_module_dump_fn_body(&merged_module, 5, "raw_field_runtime_owner")
-        ir_module_dump_fn_body(&merged_module, 18, "raw_field_ir_empty_function")
     }
     let fn_count = merged_module.fn_count
     trace.last_stage = "done"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -9,7 +9,7 @@ use parser::parser::{parser_last_error_count, parser_reset_last_errors}
 use ir::ir::*
 use io::env::{read_env}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata}
-use ir::lower::{lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
+use ir::lower::{LowerProgramItemsHandle, lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
 use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target, native_v2_builtin_id_for_name}
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
@@ -36,7 +36,7 @@ var MODULE_FRONTEND_IMPORTED_SIMPLE_FN_VALUES: [i64; 64] = [0; 64]
 // lowering are synchronous, so one resettable table is sufficient.
 var MF_EXTERN_BINDING_NAMES: [Name; 2048] = [ir_empty_name(); 2048]
 var MF_EXTERN_BINDING_MODULE_IDS: [i64; 2048] = [IR_DEFINING_MODULE_UNKNOWN; 2048]
-var MF_PROGRAM_ITEMS: [Option<Box<ItemList>>; 256] = [None; 256]
+var MF_PROGRAM_ITEM_PTRS: [i64; 256] = [0; 256]
 
 fn module_frontend_import_is_ident_ch(c: i8) -> bool {
     (c >= 65 as i8 && c <= 90 as i8) ||
@@ -4484,14 +4484,14 @@ fn module_frontend_lower_program_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: summary_begin\n") }
     var epistemic = ir_empty_epistemic_section()
     let binding_count = module_frontend_collect_external_bindings(
-        &! MF_PROGRAM_ITEMS,
+        &! MF_PROGRAM_ITEM_PTRS,
         file_paths,
         program_count,
         module_index
     )
     let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
         program,
-        &! MF_PROGRAM_ITEMS,
+        &! MF_PROGRAM_ITEM_PTRS,
         program_count,
         module_index,
         &! MF_EXTERN_BINDING_NAMES,
@@ -4510,7 +4510,7 @@ fn module_frontend_lower_program_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
     var summary_val = (*summary_result.summary)
     let summary_module_box = summary_val.module
-    module_frontend_assign_function_provenance(&! (*summary_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*summary_module_box), &! MF_PROGRAM_ITEM_PTRS, file_paths, program_count, module_index)
     summary_val.module = summary_module_box
     let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
         program,
@@ -4528,7 +4528,7 @@ fn module_frontend_lower_program_box_traced_with_externs(
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
     let body_module_box = body_result.module
-    module_frontend_assign_function_provenance(&! (*body_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*body_module_box), &! MF_PROGRAM_ITEM_PTRS, file_paths, program_count, module_index)
 
     trace.body_lowered_modules = trace.body_lowered_modules + 1
     trace.lowered_modules = trace.lowered_modules + 1
@@ -4553,14 +4553,14 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     var epistemic = ir_empty_epistemic_section()
     let program = mf_program_from_items(items)
     let binding_count = module_frontend_collect_external_bindings(
-        &! MF_PROGRAM_ITEMS,
+        &! MF_PROGRAM_ITEM_PTRS,
         file_paths,
         program_count,
         module_index
     )
     let summary_result = lower_program_to_ir_summary_box_with_externs_ref(
         &program,
-        &! MF_PROGRAM_ITEMS,
+        &! MF_PROGRAM_ITEM_PTRS,
         program_count,
         module_index,
         &! MF_EXTERN_BINDING_NAMES,
@@ -4579,7 +4579,7 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
     var summary_val = (*summary_result.summary)
     let summary_module_box = summary_val.module
-    module_frontend_assign_function_provenance(&! (*summary_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*summary_module_box), &! MF_PROGRAM_ITEM_PTRS, file_paths, program_count, module_index)
     summary_val.module = summary_module_box
     let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
         &program,
@@ -4597,7 +4597,7 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
         return module_frontend_lower_box_error("ir_bodies_failed")
     }
     let body_module_box = body_result.module
-    module_frontend_assign_function_provenance(&! (*body_module_box), &! MF_PROGRAM_ITEMS, file_paths, program_count, module_index)
+    module_frontend_assign_function_provenance(&! (*body_module_box), &! MF_PROGRAM_ITEM_PTRS, file_paths, program_count, module_index)
 
     trace.body_lowered_modules = trace.body_lowered_modules + 1
     trace.lowered_modules = trace.lowered_modules + 1
@@ -4777,7 +4777,7 @@ fn module_frontend_items_explicitly_import_from(
 }
 
 fn module_frontend_function_defining_module(
-    program_items: &![Option<Box<ItemList>>; 256],
+    program_item_ptrs: &![i64; 256],
     file_paths: &![string; 256],
     program_count: i64,
     self_index: i64,
@@ -4789,8 +4789,9 @@ fn module_frontend_function_defining_module(
     // Program is a large recursive aggregate. Resolving through its item-list
     // field directly avoids the bootstrap compiler's known by-value aggregate
     // copy loss while preserving exact module identity.
+    let self_item_handle = (*program_item_ptrs)[self_index as usize] as *mut LowerProgramItemsHandle
     if module_frontend_items_define_ir_function(
-        &(*program_items)[self_index as usize],
+        &(*self_item_handle).items,
         name
     ) {
         return self_index
@@ -4806,14 +4807,15 @@ fn module_frontend_function_defining_module(
     var i: i64 = 0
     while i < program_count {
         if i != self_index {
+            let candidate_item_handle = (*program_item_ptrs)[i as usize] as *mut LowerProgramItemsHandle
             if module_frontend_items_define_ir_function(
-                &(*program_items)[i as usize],
+                &(*candidate_item_handle).items,
                 name
             ) {
                 found_module = i
                 found_count = found_count + 1
                 if module_frontend_items_explicitly_import_from(
-                    &(*program_items)[self_index as usize],
+                    &(*self_item_handle).items,
                     (*file_paths)[self_index as usize],
                     (*file_paths)[i as usize],
                     name
@@ -4856,7 +4858,7 @@ fn module_frontend_binding_name_index(
 }
 
 fn module_frontend_collect_external_bindings(
-    program_items: &![Option<Box<ItemList>>; 256],
+    program_item_ptrs: &![i64; 256],
     file_paths: &![string; 256],
     program_count: i64,
     self_index: i64
@@ -4874,7 +4876,9 @@ fn module_frontend_collect_external_bindings(
     }
     while module_index < program_count && count < 2048 {
         if module_index != self_index {
-            var current = &(*program_items)[module_index as usize]
+            let module_item_handle = (*program_item_ptrs)[module_index as usize] as *mut LowerProgramItemsHandle
+            let self_item_handle = (*program_item_ptrs)[self_index as usize] as *mut LowerProgramItemsHandle
+            var current = &(*module_item_handle).items
             while count < 2048 {
                 match *current {
                     Some(list) => {
@@ -4892,11 +4896,11 @@ fn module_frontend_collect_external_bindings(
                             let item_name = head.name
                             let is_builtin = native_v2_builtin_id_for_name(item_name) != 0
                             let self_defines = module_frontend_items_define_ir_function(
-                               &(*program_items)[self_index as usize],
+                               &(*self_item_handle).items,
                                item_name
                             )
                             let explicit_route = module_frontend_items_explicitly_import_from(
-                                &(*program_items)[self_index as usize],
+                                &(*self_item_handle).items,
                                 (*file_paths)[self_index as usize],
                                 (*file_paths)[module_index as usize],
                                 item_name
@@ -4949,7 +4953,9 @@ fn module_frontend_collect_external_bindings(
     module_index = 0
     while module_index < program_count && count < 2048 {
         if module_index != self_index {
-            var current = &(*program_items)[module_index as usize]
+            let module_item_handle = (*program_item_ptrs)[module_index as usize] as *mut LowerProgramItemsHandle
+            let self_item_handle = (*program_item_ptrs)[self_index as usize] as *mut LowerProgramItemsHandle
+            var current = &(*module_item_handle).items
             while count < 2048 {
                 match *current {
                     Some(list) => {
@@ -4958,11 +4964,11 @@ fn module_frontend_collect_external_bindings(
                             let item_name = head.name
                             if native_v2_builtin_id_for_name(item_name) == 0 &&
                                !module_frontend_items_define_ir_function(
-                                   &(*program_items)[self_index as usize],
+                                   &(*self_item_handle).items,
                                    item_name
                                ) &&
                                !module_frontend_items_explicitly_import_from(
-                                   &(*program_items)[self_index as usize],
+                                   &(*self_item_handle).items,
                                    (*file_paths)[self_index as usize],
                                    (*file_paths)[module_index as usize],
                                    item_name
@@ -4998,7 +5004,7 @@ fn module_frontend_collect_external_bindings(
 // explicit and must fail closed during merge/finalize.
 fn module_frontend_assign_function_provenance(
     module: &! IrModule,
-    program_items: &![Option<Box<ItemList>>; 256],
+    program_item_ptrs: &![i64; 256],
     file_paths: &![string; 256],
     program_count: i64,
     self_index: i64
@@ -5011,7 +5017,7 @@ fn module_frontend_assign_function_provenance(
         if defining_module_id == IR_DEFINING_MODULE_UNKNOWN ||
            defining_module_id == IR_DEFINING_MODULE_AMBIGUOUS {
             defining_module_id = module_frontend_function_defining_module(
-                program_items,
+                program_item_ptrs,
                 file_paths,
                 program_count,
                 self_index,
@@ -5169,7 +5175,12 @@ fn module_frontend_lower_programs_array_direct_box(
     // already-proven seed/dep lowering path.
     var snapshot_i: i64 = 0
     while snapshot_i < loaded {
-        MF_PROGRAM_ITEMS[snapshot_i as usize] = (*programs)[snapshot_i as usize].items
+        var item_handle = MF_PROGRAM_ITEM_PTRS[snapshot_i as usize] as *mut LowerProgramItemsHandle
+        if MF_PROGRAM_ITEM_PTRS[snapshot_i as usize] == 0 {
+            item_handle = heap_alloc(32) as *mut LowerProgramItemsHandle
+            MF_PROGRAM_ITEM_PTRS[snapshot_i as usize] = item_handle as i64
+        }
+        (*item_handle).items = (*programs)[snapshot_i as usize].items
         snapshot_i = snapshot_i + 1
     }
 

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4825,22 +4825,19 @@ fn module_frontend_function_defining_module(
     IR_DEFINING_MODULE_UNKNOWN
 }
 
-fn module_frontend_binding_already_present(
+fn module_frontend_binding_name_index(
     names: &![Name; 2048],
-    module_ids: &![i64; 2048],
     count: i64,
-    defining_module_id: i64,
     name: Name
-) -> bool with Mut, Panic, Div {
+) -> i64 with Mut, Panic, Div {
     var i: i64 = 0
     while i < count {
-        if (*module_ids)[i as usize] == defining_module_id &&
-           ir_name_eq((*names)[i as usize], name) {
-            return true
+        if ir_name_eq((*names)[i as usize], name) {
+            return i
         }
         i = i + 1
     }
-    false
+    -1
 }
 
 fn module_frontend_collect_external_bindings(
@@ -4859,24 +4856,43 @@ fn module_frontend_collect_external_bindings(
                     Some(list) => {
                         let item = (*list).head
                         if item.kind == ItemKind::ItemFn {
-                            let owner = module_frontend_function_defining_module(
+                            var owner = module_frontend_function_defining_module(
                                 programs,
                                 file_paths,
                                 program_count,
                                 self_index,
                                 item.name
                             )
-                            if owner == module_index &&
-                               !module_frontend_binding_already_present(
-                                   &! MF_EXTERN_BINDING_NAMES,
-                                   &! MF_EXTERN_BINDING_MODULE_IDS,
-                                   count,
-                                   owner,
-                                   item.name
-                               ) {
-                                MF_EXTERN_BINDING_NAMES[count as usize] = item.name
-                                MF_EXTERN_BINDING_MODULE_IDS[count as usize] = owner
-                                count = count + 1
+                            // The loader-resolved import route plus the ItemFn we
+                            // are currently visiting is already an exact DefId.
+                            // Do not re-derive it through another large AST scan.
+                            if (owner == IR_DEFINING_MODULE_UNKNOWN ||
+                                owner == IR_DEFINING_MODULE_AMBIGUOUS ||
+                                owner == module_index) &&
+                               module_frontend_items_explicitly_import_from(
+                                &(*programs)[self_index as usize].items,
+                                (*file_paths)[self_index as usize],
+                                (*file_paths)[module_index as usize],
+                                item.name
+                            ) {
+                                owner = module_index
+                            }
+                            if owner == module_index {
+                                let prior = module_frontend_binding_name_index(
+                                    &! MF_EXTERN_BINDING_NAMES,
+                                    count,
+                                    item.name
+                                )
+                                if prior < 0 {
+                                    MF_EXTERN_BINDING_NAMES[count as usize] = item.name
+                                    MF_EXTERN_BINDING_MODULE_IDS[count as usize] = owner
+                                    count = count + 1
+                                } else if MF_EXTERN_BINDING_MODULE_IDS[prior as usize] != owner {
+                                    // Two explicit routes with the same symbol are
+                                    // not an identity. Keep both from preseeding so
+                                    // downstream provenance validation fails closed.
+                                    MF_EXTERN_BINDING_MODULE_IDS[prior as usize] = IR_DEFINING_MODULE_AMBIGUOUS
+                                }
                             }
                         }
                         current = &(*list).tail

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4756,19 +4756,6 @@ fn module_frontend_items_explicitly_import_from(
                         Some(_) => imports_name = module_frontend_import_item_list_contains(&head.use_items, name),
                         None => imports_name = true,
                     }
-                    if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") &&
-                       (ir_name_eq(name, make_name("make_a")) ||
-                        ir_name_eq(name, make_name("ir_empty_function"))) {
-                        print("EXTERN_ROUTE name=")
-                        print(str_from_bytes(name.buf, name.len))
-                        print(" candidate=")
-                        print(candidate_file_path)
-                        print(" targets=")
-                        print_int(if targets_file { 1 } else { 0 })
-                        print(" imports=")
-                        print_int(if imports_name { 1 } else { 0 })
-                        print("\n")
-                    }
                     if targets_file && imports_name {
                         return true
                     }
@@ -4875,13 +4862,6 @@ fn module_frontend_collect_external_bindings(
     // every unimported homonym; multiple explicit routes remain ambiguous.
     var count: i64 = 0
     var module_index: i64 = 0
-    if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") {
-        print("EXTERN_COLLECT self=")
-        print_int(self_index)
-        print(" programs=")
-        print_int(program_count)
-        print("\n")
-    }
     while module_index < program_count && count < 2048 {
         if module_index != self_index {
             let module_item_handle = (*program_item_ptrs)[module_index as usize] as *mut LowerProgramItemsHandle
@@ -4891,15 +4871,6 @@ fn module_frontend_collect_external_bindings(
                 match *current {
                     Some(list) => {
                         let head = &(*list).head
-                        if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") {
-                            print("EXTERN_HEAD module=")
-                            print_int(module_index)
-                            print(" kind=")
-                            print_int(head.kind as i64)
-                            print(" name=")
-                            print(str_from_bytes(head.name.buf, head.name.len))
-                            print("\n")
-                        }
                         if head.kind == ItemKind::ItemFn {
                             let item_name = head.name
                             let is_builtin = native_v2_builtin_id_for_name(item_name) != 0
@@ -4913,23 +4884,6 @@ fn module_frontend_collect_external_bindings(
                                 (*file_paths)[module_index as usize],
                                 item_name
                             )
-                            if str_eq(read_env("SOUNIO_DUMP_EXTERN_BINDINGS"), "1") &&
-                               (ir_name_eq(item_name, make_name("make_a")) ||
-                                ir_name_eq(item_name, make_name("ir_empty_function"))) {
-                                print("EXTERN_CANDIDATE name=")
-                                print(str_from_bytes(item_name.buf, item_name.len))
-                                print(" self=")
-                                print_int(self_index)
-                                print(" module=")
-                                print_int(module_index)
-                                print(" builtin=")
-                                print_int(if is_builtin { 1 } else { 0 })
-                                print(" self_defines=")
-                                print_int(if self_defines { 1 } else { 0 })
-                                print(" explicit=")
-                                print_int(if explicit_route { 1 } else { 0 })
-                                print("\n")
-                            }
                             if !is_builtin && !self_defines && explicit_route {
                                 let prior = module_frontend_binding_name_index(
                                     &! MF_EXTERN_BINDING_PTRS,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -7,6 +7,10 @@ use ir::ir::*
 use io::trace::*
 use io::env::{read_env}
 
+pub struct LowerProgramItemsHandle {
+    pub items: Option<Box<ItemList>>,
+}
+
 struct LowerLocalStack {
     names: [Name; 4096],
     regs: [i64; 4096],
@@ -10546,7 +10550,7 @@ fn lower_program_to_ir_summary_box_with_epistemic_ref(prog: &Program, epistemic:
 // right field_idx.
 fn lower_program_to_ir_summary_box_with_externs_ref(
     prog: &Program,
-    program_items: &![Option<Box<ItemList>>; 256],
+    program_item_ptrs: &![i64; 256],
     program_count: i64,
     self_index: i64,
     binding_names: &![Name; 2048],
@@ -10558,9 +10562,10 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     var i: i64 = 0
     while i < program_count {
         if i != self_index {
+            let item_handle = (*program_item_ptrs)[i as usize] as *mut LowerProgramItemsHandle
             lowerer_preseed_external_struct_items_mut(
                 &! lo,
-                &(*program_items)[i as usize]
+                &(*item_handle).items
             )
         }
         i = i + 1
@@ -10570,9 +10575,10 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     i = 0
     while i < program_count {
         if i != self_index {
+            let item_handle = (*program_item_ptrs)[i as usize] as *mut LowerProgramItemsHandle
             lowerer_preseed_external_function_items_mut(
                 &! lo,
-                &(*program_items)[i as usize],
+                &(*item_handle).items,
                 i,
                 binding_names,
                 binding_module_ids,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -7170,23 +7170,8 @@ impl Lowerer {
                     }
                     if !ir_name_is_box(callee_struct_name) {
                         let ret_name = lo.expr_call_return_struct_name_ref(&(*expr_box))
-                        if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
-                            print("RAW_FIELD_BIND: local=")
-                            print(str_from_bytes(s.name.buf, s.name.len))
-                            print(" callee=")
-                            print(str_from_bytes(callee_struct_name.buf, callee_struct_name.len))
-                            print(" return=")
-                            print(str_from_bytes(ret_name.buf, ret_name.len))
-                            print("\n")
-                        }
                         if ret_name.len > 0 {
                             lo = lo.bind_local_struct_type(s.name, ret_name)
-                            if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
-                                let bound_name = lo.lookup_local_struct_type(s.name)
-                                print("RAW_FIELD_BIND: rebound=")
-                                print(str_from_bytes(bound_name.buf, bound_name.len))
-                                print("\n")
-                            }
                         }
                     } else {
                         // `let b = Box::new(...)`: tag the local's struct-type slot with
@@ -7289,6 +7274,21 @@ impl Lowerer {
                                 lo = lo.emit(ir_store_global(rhs, bss_off_local, (*target_expr).name))
                             }
                             lo = lo.emit(ir_copy(dst, rhs))
+                            // Final raw-field compatibility boundary: preserve an
+                            // imported call's proven return identity across direct
+                            // local replacement. Place IR owns future projection
+                            // semantics; do not extend nominal field fallback here.
+                            if s.assign_op == AssignOp::AssignEq {
+                                match s.expr {
+                                    Some(rhs_expr_struct) => {
+                                        if (*rhs_expr_struct).kind == ExprKind::ExprCall {
+                                            let rhs_struct_type = lo.expr_call_return_struct_name_ref(&(*rhs_expr_struct))
+                                            lowerer_bind_local_struct_type_mut(&! lo, (*target_expr).name, rhs_struct_type)
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
                             if rhs_variance >= 0 {
                                 lo = lo.bind_local_variance_reg((*target_expr).name, rhs_variance)
                                 // Re-assert float scalar_kind only when the RHS is

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -11,6 +11,11 @@ pub struct LowerProgramItemsHandle {
     pub items: Option<Box<ItemList>>,
 }
 
+pub struct LowerExternBindingHandle {
+    pub name: Name,
+    pub defining_module_id: i64,
+}
+
 struct LowerLocalStack {
     names: [Name; 4096],
     regs: [i64; 4096],
@@ -939,17 +944,19 @@ fn lowerer_preseed_external_struct_items_mut(
 }
 
 fn lowerer_extern_binding_contains(
-    names: &![Name; 2048],
-    module_ids: &![i64; 2048],
+    binding_ptrs: &![i64; 2048],
     count: i64,
     defining_module_id: i64,
     name: Name
 ) -> bool with Mut, Panic, Div {
     var i: i64 = 0
     while i < count {
-        if (*module_ids)[i as usize] == defining_module_id &&
-           ir_name_eq((*names)[i as usize], name) {
-            return true
+        let binding = (*binding_ptrs)[i as usize] as *mut LowerExternBindingHandle
+        if binding as i64 != 0 {
+            if (*binding).defining_module_id == defining_module_id &&
+               ir_name_eq((*binding).name, name) {
+                return true
+            }
         }
         i = i + 1
     }
@@ -960,8 +967,7 @@ fn lowerer_preseed_external_function_items_mut(
     lo: &! Lowerer,
     items: &Option<Box<ItemList>>,
     defining_module_id: i64,
-    binding_names: &![Name; 2048],
-    binding_module_ids: &![i64; 2048],
+    binding_ptrs: &![i64; 2048],
     binding_count: i64
 ) with Mut, Panic, Div, Alloc {
     var current = items
@@ -971,8 +977,7 @@ fn lowerer_preseed_external_function_items_mut(
                 let head = &(*list).head
                 if head.kind == ItemKind::ItemFn &&
                    lowerer_extern_binding_contains(
-                       binding_names,
-                       binding_module_ids,
+                       binding_ptrs,
                        binding_count,
                        defining_module_id,
                        head.name
@@ -10553,8 +10558,7 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     program_item_ptrs: &![i64; 256],
     program_count: i64,
     self_index: i64,
-    binding_names: &![Name; 2048],
-    binding_module_ids: &![i64; 2048],
+    binding_ptrs: &![i64; 2048],
     binding_count: i64,
     epistemic: &IrEpistemicSection
 ) -> IrProgramSummaryBoxResult with Mut, Panic, Div, Alloc, IO {
@@ -10580,8 +10584,7 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
                 &! lo,
                 &(*item_handle).items,
                 i,
-                binding_names,
-                binding_module_ids,
+                binding_ptrs,
                 binding_count
             )
         }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -882,9 +882,9 @@ fn lowerer_preseed_external_struct_items_mut(
     while true {
         match *current {
             Some(list) => {
-                let head_owned = (*list).head
-                if head_owned.kind == ItemKind::ItemStruct {
-                    match head_owned.struct_def {
+                let head = &(*list).head
+                if head.kind == ItemKind::ItemStruct {
+                    match head.struct_def {
                         Some(sd) => {
                             // Inline registration: lowerer_register_struct_fields_mut
                             // silently no-ops from this call site (suspected
@@ -894,7 +894,7 @@ fn lowerer_preseed_external_struct_items_mut(
                             let pre_count = (*sl_box).count
                             if pre_count < 256 {
                                 var entry = empty_struct_layout_entry()
-                                entry.type_name = head_owned.name
+                                entry.type_name = head.name
                                 var fc: i64 = 0
                                 var fcur = (*sd).fields
                                 var keep_going = true

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10546,7 +10546,7 @@ fn lower_program_to_ir_summary_box_with_epistemic_ref(prog: &Program, epistemic:
 // right field_idx.
 fn lower_program_to_ir_summary_box_with_externs_ref(
     prog: &Program,
-    programs: &! [Program; 256],
+    program_items: &![Option<Box<ItemList>>; 256],
     program_count: i64,
     self_index: i64,
     binding_names: &![Name; 2048],
@@ -10560,7 +10560,7 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
         if i != self_index {
             lowerer_preseed_external_struct_items_mut(
                 &! lo,
-                &(*programs)[i as usize].items
+                &(*program_items)[i as usize]
             )
         }
         i = i + 1
@@ -10572,7 +10572,7 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
         if i != self_index {
             lowerer_preseed_external_function_items_mut(
                 &! lo,
-                &(*programs)[i as usize].items,
+                &(*program_items)[i as usize],
                 i,
                 binding_names,
                 binding_module_ids,

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -7170,8 +7170,23 @@ impl Lowerer {
                     }
                     if !ir_name_is_box(callee_struct_name) {
                         let ret_name = lo.expr_call_return_struct_name_ref(&(*expr_box))
+                        if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
+                            print("RAW_FIELD_BIND: local=")
+                            print(str_from_bytes(s.name.buf, s.name.len))
+                            print(" callee=")
+                            print(str_from_bytes(callee_struct_name.buf, callee_struct_name.len))
+                            print(" return=")
+                            print(str_from_bytes(ret_name.buf, ret_name.len))
+                            print("\n")
+                        }
                         if ret_name.len > 0 {
                             lo = lo.bind_local_struct_type(s.name, ret_name)
+                            if str_eq(read_env("SOUNIO_DUMP_RAW_FIELD_BINDING"), "1") {
+                                let bound_name = lo.lookup_local_struct_type(s.name)
+                                print("RAW_FIELD_BIND: rebound=")
+                                print(str_from_bytes(bound_name.buf, bound_name.len))
+                                print("\n")
+                            }
                         }
                     } else {
                         // `let b = Box::new(...)`: tag the local's struct-type slot with

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -10558,8 +10558,10 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     var i: i64 = 0
     while i < program_count {
         if i != self_index {
-            let ext_prog = (*programs)[i as usize]
-            lowerer_preseed_external_struct_items_mut(&! lo, &ext_prog.items)
+            lowerer_preseed_external_struct_items_mut(
+                &! lo,
+                &(*programs)[i as usize].items
+            )
         }
         i = i + 1
     }
@@ -10568,10 +10570,9 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     i = 0
     while i < program_count {
         if i != self_index {
-            let ext_prog = (*programs)[i as usize]
             lowerer_preseed_external_function_items_mut(
                 &! lo,
-                &ext_prog.items,
+                &(*programs)[i as usize].items,
                 i,
                 binding_names,
                 binding_module_ids,

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -9949,9 +9949,7 @@ fn native_v2_ir_trace_enabled() -> bool with IO {
 }
 
 fn native_v2_trace_instr_ref(fn_index: i64, instr_index: i64, instr: &IrInstr) with IO, Mut, Panic, Div {
-    // Diagnostic trace must retain unknown/new opcodes too; name classification
-    // below is intentionally best-effort, while the numeric tag is authoritative.
-    var interesting = true
+    var interesting = false
     if (*instr).op == IrOpcode::IrNop { interesting = true }
     if (*instr).op == IrOpcode::IrLoadImm { interesting = true }
     if (*instr).op == IrOpcode::IrLoadFloat { interesting = true }
@@ -9980,8 +9978,6 @@ fn native_v2_trace_instr_ref(fn_index: i64, instr_index: i64, instr: &IrInstr) w
     else if (*instr).op == IrOpcode::IrIndexSet { print("index_set") }
     else if (*instr).op == IrOpcode::IrReturn { print("return") }
     else { print("other") }
-    print(" op_num=")
-    print_int((*instr).op as i64)
     print(" dst=")
     print_int((*instr).dst)
     print(" src1=")

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -9949,7 +9949,9 @@ fn native_v2_ir_trace_enabled() -> bool with IO {
 }
 
 fn native_v2_trace_instr_ref(fn_index: i64, instr_index: i64, instr: &IrInstr) with IO, Mut, Panic, Div {
-    var interesting = false
+    // Diagnostic trace must retain unknown/new opcodes too; name classification
+    // below is intentionally best-effort, while the numeric tag is authoritative.
+    var interesting = true
     if (*instr).op == IrOpcode::IrNop { interesting = true }
     if (*instr).op == IrOpcode::IrLoadImm { interesting = true }
     if (*instr).op == IrOpcode::IrLoadFloat { interesting = true }
@@ -9978,6 +9980,8 @@ fn native_v2_trace_instr_ref(fn_index: i64, instr_index: i64, instr: &IrInstr) w
     else if (*instr).op == IrOpcode::IrIndexSet { print("index_set") }
     else if (*instr).op == IrOpcode::IrReturn { print("return") }
     else { print("other") }
+    print(" op_num=")
+    print_int((*instr).op as i64)
     print(" dst=")
     print_int((*instr).dst)
     print(" src1=")

--- a/tests/compiler/imported_struct_reassignment/main.sio
+++ b/tests/compiler/imported_struct_reassignment/main.sio
@@ -1,0 +1,22 @@
+use model::{ReturnedA, ReturnedB, make_a, make_b}
+
+fn main() -> i64 with Mut, Panic, Div {
+    var value = make_a()
+    value.shared_probe = 12
+    if value.shared_probe != 12 || value.a_guard != 11 { return 1 }
+
+    value = make_a()
+    value.shared_probe = 13
+    if value.shared_probe != 13 || value.a_guard != 11 { return 2 }
+
+    value = make_b()
+    value.shared_probe = 24
+    if value.b_guard_lo != 20 || value.b_guard_mid != 21 { return 3 }
+    if value.shared_probe != 24 || value.b_guard_hi != 23 { return 4 }
+
+    // Non-call assignment remains scalar and must not acquire a struct identity.
+    var scalar: i64 = 0
+    let scalar_source: i64 = 42
+    scalar = scalar_source
+    scalar
+}

--- a/tests/compiler/imported_struct_reassignment/model.sio
+++ b/tests/compiler/imported_struct_reassignment/model.sio
@@ -1,0 +1,32 @@
+module model
+
+// Registered first on purpose: spelling-only field lookup would select index 1.
+pub struct Decoy {
+    decoy_guard: i64,
+    shared_probe: i64,
+}
+
+pub struct ReturnedA {
+    shared_probe: i64,
+    a_guard: i64,
+}
+
+pub struct ReturnedB {
+    b_guard_lo: i64,
+    b_guard_mid: i64,
+    shared_probe: i64,
+    b_guard_hi: i64,
+}
+
+pub fn make_a() -> ReturnedA {
+    ReturnedA { shared_probe: 10, a_guard: 11 }
+}
+
+pub fn make_b() -> ReturnedB {
+    ReturnedB {
+        b_guard_lo: 20,
+        b_guard_mid: 21,
+        shared_probe: 22,
+        b_guard_hi: 23,
+    }
+}

--- a/tests/compiler/imported_struct_reassignment/model.sio
+++ b/tests/compiler/imported_struct_reassignment/model.sio
@@ -1,5 +1,7 @@
 module model
 
+use shadow::{shadow_anchor}
+
 // Registered first on purpose: spelling-only field lookup would select index 1.
 pub struct Decoy {
     decoy_guard: i64,
@@ -19,7 +21,8 @@ pub struct ReturnedB {
 }
 
 pub fn make_a() -> ReturnedA {
-    ReturnedA { shared_probe: 10, a_guard: 11 }
+    let anchor = shadow_anchor()
+    ReturnedA { shared_probe: 10 + anchor, a_guard: 11 }
 }
 
 pub fn make_b() -> ReturnedB {

--- a/tests/compiler/imported_struct_reassignment/shadow.sio
+++ b/tests/compiler/imported_struct_reassignment/shadow.sio
@@ -1,0 +1,16 @@
+module shadow
+
+pub struct ShadowReturnedA {
+    shadow_guard: i64,
+    shared_probe: i64,
+}
+
+// Deliberately homonymous but not imported by main. The explicit model::make_a
+// route must win even though this module is loaded transitively.
+pub fn make_a() -> ShadowReturnedA {
+    ShadowReturnedA { shadow_guard: 90, shared_probe: 91 }
+}
+
+pub fn shadow_anchor() -> i64 {
+    0
+}


### PR DESCRIPTION
## Scope

Closes the minimum imported call-result structural identity defect exposed by the strict SOIR writer witness. This is the final extension of the legacy raw-field model; future projection semantics belong to Place IR.

- propagates exact struct identity on direct `AssignEq` + `ExprCall` reassignment
- resolves imported function bindings with explicit-route precedence and fail-closed ambiguity
- parks aggregate item/binding state behind bootstrap-safe flat i64 pointer sidecars
- adds an adversarial A-to-B reassignment witness with an unimported homonymous decoy
- keeps legacy lowering as the differential oracle; no Place IR, SOIR Writer, or Arena v2 semantics are changed

## Proof

Clean source-fresh Madaros artifact from workflow run 29387157493:

- SHA-256: `b434513d49ddfbc0ed01de91838e11bb9b20abd5041aab875f05603c60ee4047`
- size: `107757766` bytes
- `madaros_imported_struct_reassignment_gate.sh`: PASS
- `madaros_visibility_context_gate.sh`: PASS (`resolved`, runtime pass, ambiguous global remains E137, privacy remains E175/E176/E177)
- `soir_writer_v0_gate.sh`: static contract PASS; dynamic path advances through all 8 modules and reaches `final_fn_count=2048` without the prior SIGSEGV
- orthogonal final review: no findings
- `bash -n`: PASS; shellcheck unavailable, so no shellcheck claim

## Independent blocker

`BLK-20260715-SOIR-NV2-CODE-OVERFLOW`: strict dynamic SOIR now reaches native emission and fails with rc=19 because the unchanged x86_64 backend exhausts the fixed 2 MiB `NC_BIG_CODE` buffer. This is a distinct native codegen-capacity lane, not a raw-field regression.

## Merge state

**DO NOT MERGE.** This PR is intentionally stacked on `codex/soir-import-provenance-20260715` and remains a qualification surface until its base and the independent codegen-capacity blocker are coordinated.