### PR TITLE
feat(stats): resampling — jackknife, rng, bootstrap

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2861,3 +2861,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - pca2 = **PASS**: closed-form 2×2 eigenvalues, explained=λ₁/tr, null-space eigenvector with larger-norm candidate selection; correlated→λ₂=0, axis (0.707,0.707) verified.
 - Theme: multivariate (bivariate) — the suite's first multivariate tools, all closed-form over the 2×2 covariance (no general matrix inversion needed). All derivable, #852-safe. Suite runner: 76 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Lz8r2j/`, `/tmp/llm-offload-ztMqlk/`, `/tmp/llm-offload-zLhBWR/`.
+
+## 2026-07-15 — math-review: stats::jackknife, stats::rng, stats::bootstrap
+- Files (all new): `stdlib/stats/jackknife.sio` (leave-one-out jackknife bias/SE for mean & ÷n variance), `stdlib/stats/rng.sio` (Park-Miller MINSTD PRNG in exact f64 + Box-Muller normal), `stdlib/stats/bootstrap.sio` (nonparametric percentile bootstrap for the mean, seeded MINSTD). Provider: xAI/Grok 4.3.
+- jackknife = **PASS**: mean SE=s/√n, ÷n variance bias-corrected to unbiased ÷(n−1) (θ̂=2→2.5, bias −0.5, SE 1.0458); Quenouille formula verified.
+- rng = **PASS**: MINSTD xₙ₊₁=(16807·xₙ)mod(2³¹−1) exact in f64 (16807·(m−1)<2⁵³), seed-1 stream 7.826e−6/0.13154 exact, Box-Muller correct.
+- bootstrap = **PASS**: floor(u·n) index bound proven, percentile order statistics, SE→√(σ̂²/n); reviewer confirmed tolerances "explicitly stated and justified" (MC-error-calibrated 0.08 on SE).
+- Theme: resampling — the last major modern-staple gap. Derivability preserved: jackknife fully deterministic; the MINSTD stream is exactly reproducible from the recurrence (auditable), so the bootstrap tests assert derivable-in-expectation properties (exact point estimate, MC-calibrated SE tolerance, reproducibility). #852-safe. Suite runner: 79 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-Tq92DO/`, `/tmp/llm-offload-zDJZrw/`, `/tmp/llm-offload-wXrCs6/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -85,6 +85,9 @@ MODULES=(
   stdlib/stats/mahalanobis.sio
   stdlib/stats/hotelling_t2.sio
   stdlib/stats/pca2.sio
+  stdlib/stats/jackknife.sio
+  stdlib/stats/rng.sio
+  stdlib/stats/bootstrap.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -38,6 +38,8 @@ fourteen families:
   NNT, and person-time incidence rates.
 - **Multivariate (bivariate)** — the Mahalanobis distance, one-sample
   Hotelling's T² and two-variable PCA, all closed-form over the 2×2 covariance.
+- **Resampling** — the leave-one-out jackknife, a bit-reproducible Park-Miller
+  MINSTD generator (exact f64), and the nonparametric bootstrap for the mean.
 - **Bayesian & model selection** — conjugate updates, the Beta-posterior
   credible interval, the Bayesian A/B test (P(pB>pA)), and AIC / BIC with the
   Schwarz Bayes-factor approximation.
@@ -1085,6 +1087,42 @@ The closed-form eigen-decomposition of the 2×2 covariance:
 PC1 unit axis. Validated: perfectly correlated data → λ₂=0, explained=1, axis
 (0.707, 0.707); isotropic → explained=0.5.
 
+### `stats::jackknife` — leave-one-out jackknife
+
+| Function | Signature |
+|---|---|
+| `jackknife_mean` | `pub fn jackknife_mean(x: &[f64; 256], n: i32) -> JackResult with Mut, Div, Panic` |
+| `jackknife_variance` | `pub fn jackknife_variance(x: &[f64; 256], n: i32) -> JackResult with Mut, Div, Panic` |
+
+The deterministic resampling estimator of a statistic's bias and standard error
+from the n leave-one-out recomputations. Validated: mean of {1..5} → SE=0.7071,
+bias 0; the ÷n variance is bias-corrected back to the unbiased ÷(n−1) value
+(θ̂=2, jackknife estimate 2.5, bias −0.5, SE 1.0458).
+
+### `stats::rng` — Park-Miller MINSTD generator
+
+| Function | Signature |
+|---|---|
+| `rng_seed` / `rng_uniform` | `pub fn rng_seed(s: i64) -> Rng` · `rng_uniform(&!r) -> f64` |
+| `rng_range` / `rng_int` / `rng_normal` | uniforms in a range, integers, and Box-Muller normals |
+
+A deterministic, bit-reproducible uniform generator implemented entirely in
+exact f64 (no bit operations): `xₙ₊₁=(16807·xₙ) mod 2147483647`. Validated:
+seed-1 stream = 7.826e−6, 0.13154 (exact); uniforms in [0,1), integers in range,
+identical streams from identical seeds, Box-Muller normals ≈ mean 0.
+
+### `stats::bootstrap` — nonparametric bootstrap for the mean
+
+| Function | Signature |
+|---|---|
+| `bootstrap_mean` | `pub fn bootstrap_mean(x: &[f64; 256], n: i32, b: i32, conf: f64, seed: i64) -> BootResult with Mut, Div, Panic` |
+
+Resamples with replacement (seeded MINSTD, so bit-reproducible) to give a
+percentile confidence interval and standard error for the mean, with no
+distributional assumption. Validated: {1..5} → point estimate 3 exactly, SE
+converging to √(σ̂²/n)=0.6325 (within Monte-Carlo error), CI bracketing the mean,
+identical results from identical seeds.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1165,6 +1203,9 @@ use stats::bic::{BICResult, aic, bic, bic_compare}
 use stats::mahalanobis::{MahalResult, mahalanobis}
 use stats::hotelling_t2::{HotellingResult, hotelling_t2}
 use stats::pca2::{PCA2Result, pca2}
+use stats::jackknife::{JackResult, jackknife_mean, jackknife_variance}
+use stats::rng::{Rng, rng_seed, rng_uniform, rng_range, rng_int, rng_normal}
+use stats::bootstrap::{BootResult, bootstrap_mean}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/bootstrap.sio
+++ b/stdlib/stats/bootstrap.sio
@@ -1,0 +1,170 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bootstrap.sio — nonparametric bootstrap for the mean
+//
+// Resamples the data with replacement to estimate the sampling distribution of
+// the mean — a percentile confidence interval and standard error that need no
+// distributional assumption:
+//
+//   bootstrap_mean(x, n, b, conf, seed) -> BootResult
+//
+// Draw `b` resamples of size n (with replacement), take each resample mean; the
+// SE is the sd of those means and the percentile CI is their α/2 and 1−α/2
+// quantiles. As b → ∞ the SE converges to √(σ̂²/n) with σ̂² the ÷n variance.
+//
+// The generator is the Park-Miller MINSTD in exact f64 (seeded, so the whole run
+// is bit-reproducible). Pure Sounio: inline sort of the resample means; no
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Efron (1979); Efron & Tibshirani, "An Introduction to the Bootstrap".
+
+module stats::bootstrap
+
+fn bs_floor(v: f64) -> f64 {
+    return (v as i64) as f64
+}
+
+fn bs_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct BootResult {
+    pub mean: f64,   // original sample mean (point estimate)
+    pub se: f64,     // bootstrap standard error
+    pub lo: f64,     // percentile CI lower
+    pub hi: f64,     // percentile CI upper
+    pub b: i64,      // resamples used
+}
+
+/// Percentile bootstrap CI and SE for the sample mean.
+///
+/// Parâmetros: x — data; n — size (<=256); b — resamples (2..1024);
+///             conf — confidence (e.g. 0.95); seed — PRNG seed (>0).
+/// Retorno: BootResult (mean, se, lo, hi, b).
+/// Referências: Efron (1979).
+pub fn bootstrap_mean(x: &[f64; 256], n: i32, b: i32, conf: f64, seed: i64) -> BootResult with Mut, Div, Panic {
+    if n < 2 || b < 2 { return BootResult { mean: 0.0, se: 0.0, lo: 0.0, hi: 0.0, b: 0 } }
+    var bb = b
+    if bb > 1024 { bb = 1024 }
+    let nf = n as f64
+    // original mean
+    var s0 = 0.0
+    var i = 0
+    while i < n { s0 = s0 + x[i as usize]; i = i + 1 }
+    let mean0 = s0 / nf
+    // MINSTD state
+    let A = 16807.0
+    let M = 2147483647.0
+    var st = seed as f64
+    if st < 1.0 { st = 1.0 }
+    var means: [f64; 1024] = [0.0; 1024]
+    var rep = 0
+    while rep < bb {
+        var acc = 0.0
+        var k = 0
+        while k < n {
+            // next uniform
+            let prod = A * st
+            st = prod - bs_floor(prod / M) * M
+            let u = st / M
+            var idx = bs_floor(u * nf) as i32
+            if idx >= n { idx = n - 1 }
+            acc = acc + x[idx as usize]
+            k = k + 1
+        }
+        means[rep as usize] = acc / nf
+        rep = rep + 1
+    }
+    // bootstrap SE = sd of resample means
+    var sm = 0.0
+    var a = 0
+    while a < bb { sm = sm + means[a as usize]; a = a + 1 }
+    let mbar = sm / (bb as f64)
+    var ss = 0.0
+    var c = 0
+    while c < bb { let d = means[c as usize] - mbar; ss = ss + d * d; c = c + 1 }
+    let se = bs_sqrt(ss / ((bb - 1) as f64))
+    // percentile CI: inline insertion sort of the resample means
+    var p = 1
+    while p < bb {
+        let key = means[p as usize]
+        var q = p - 1
+        while q >= 0 && means[q as usize] > key { means[(q + 1) as usize] = means[q as usize]; q = q - 1 }
+        means[(q + 1) as usize] = key
+        p = p + 1
+    }
+    let alpha = 1.0 - conf
+    var ilo = bs_floor(alpha * 0.5 * (bb as f64)) as i32
+    var ihi = bs_floor((1.0 - alpha * 0.5) * (bb as f64)) as i32
+    if ilo < 0 { ilo = 0 }
+    if ihi > bb - 1 { ihi = bb - 1 }
+    return BootResult { mean: mean0, se: se, lo: means[ilo as usize], hi: means[ihi as usize], b: bb as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {1,2,3,4,5}: point estimate = sample mean = 3 (exact).
+// Bootstrap SE -> sqrt(biased_var/n) = sqrt(2/5) = 0.632456 as b grows;
+// with b=1000 the Monte-Carlo estimate lands within ~0.08. CI brackets the mean.
+fn test_bootstrap() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = bootstrap_mean(&x, 5, 1000, 0.95, 20260715)
+    var ok = true
+    ok = check(1, approx(r.mean, 3.0, 1.0e-9)) && ok               // exact
+    ok = check(2, approx(r.se, 0.632456, 0.08)) && ok              // MC estimate of √(2/5)
+    ok = check(3, r.lo < 3.0 && r.hi > 3.0) && ok                  // CI brackets the mean
+    ok = check(4, r.b == 1000) && ok
+    return ok
+}
+
+// reproducibility: same seed -> identical CI bounds.
+fn test_reproducible() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=6.0; x[3]=8.0; x[4]=10.0; x[5]=12.0
+    let r1 = bootstrap_mean(&x, 6, 500, 0.90, 99)
+    let r2 = bootstrap_mean(&x, 6, 500, 0.90, 99)
+    var ok = true
+    ok = check(10, approx(r1.lo, r2.lo, 1.0e-12)) && ok
+    ok = check(11, approx(r1.hi, r2.hi, 1.0e-12)) && ok
+    ok = check(12, approx(r1.se, r2.se, 1.0e-12)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_bootstrap() && ok
+    ok = test_reproducible() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/jackknife.sio
+++ b/stdlib/stats/jackknife.sio
@@ -1,0 +1,177 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/jackknife.sio — leave-one-out jackknife bias & standard error
+//
+// The deterministic resampling estimator of a statistic's bias and standard
+// error, from the n leave-one-out recomputations:
+//
+//   jackknife_mean(x, n)     -> JackResult
+//   jackknife_variance(x, n) -> JackResult      (biased ÷n variance as θ̂)
+//
+// With θ̂ the full-sample statistic and θ̂_(i) leaving out point i,
+//   θ̄ = mean θ̂_(i),
+//   bias = (n−1)(θ̄ − θ̂),   θ̂_jack = θ̂ − bias = n·θ̂ − (n−1)·θ̄,
+//   SE   = √( (n−1)/n · Σ(θ̂_(i) − θ̄)² ).
+// For the mean the jackknife SE reduces exactly to s/√n; for the ÷n variance the
+// jackknife recovers the unbiased ÷(n−1) estimate.
+//
+// Pure Sounio: leave-one-out recomputation in O(n²); inline sqrt. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Quenouille (1949); Tukey (1958); Efron & Tibshirani, "An Introduction to
+//   the Bootstrap", ch.11.
+
+module stats::jackknife
+
+fn jk_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct JackResult {
+    pub estimate: f64,   // bias-corrected jackknife estimate
+    pub theta: f64,      // full-sample statistic θ̂
+    pub bias: f64,       // (n-1)(θ̄ - θ̂)
+    pub se: f64,         // jackknife standard error
+}
+
+/// Jackknife bias & SE for the sample mean.
+///
+/// Parâmetros: x — data; n — size (>=2).
+/// Retorno: JackResult (estimate, theta = mean, bias = 0, se = s/√n).
+pub fn jackknife_mean(x: &[f64; 256], n: i32) -> JackResult with Mut, Div, Panic {
+    if n < 2 { return JackResult { estimate: 0.0, theta: 0.0, bias: 0.0, se: 0.0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let theta = s / nf
+    // leave-one-out means: mean_(i) = (S - x_i)/(n-1)
+    var sum_loo = 0.0
+    var j = 0
+    while j < n {
+        let mi = (s - x[j as usize]) / (nf - 1.0)
+        sum_loo = sum_loo + mi
+        j = j + 1
+    }
+    let tbar = sum_loo / nf
+    var ss = 0.0
+    var k = 0
+    while k < n {
+        let mi = (s - x[k as usize]) / (nf - 1.0)
+        let d = mi - tbar
+        ss = ss + d * d
+        k = k + 1
+    }
+    let se = jk_sqrt((nf - 1.0) / nf * ss)
+    let bias = (nf - 1.0) * (tbar - theta)
+    return JackResult { estimate: theta - bias, theta: theta, bias: bias, se: se }
+}
+
+// biased (÷m) variance of the first m entries of a buffer, excluding index skip.
+fn loo_variance(x: &[f64; 256], n: i32, skip: i32) -> f64 with Mut, Div, Panic {
+    let m = (n - 1) as f64
+    var s = 0.0
+    var i = 0
+    while i < n { if i != skip { s = s + x[i as usize] } i = i + 1 }
+    let mean = s / m
+    var ss = 0.0
+    var j = 0
+    while j < n { if j != skip { let d = x[j as usize] - mean; ss = ss + d * d } j = j + 1 }
+    return ss / m
+}
+
+/// Jackknife bias & SE for the (÷n biased) sample variance.
+///
+/// Parâmetros: x — data; n — size (>=3).
+/// Retorno: JackResult (estimate = bias-corrected variance, theta, bias, se).
+pub fn jackknife_variance(x: &[f64; 256], n: i32) -> JackResult with Mut, Div, Panic {
+    if n < 3 { return JackResult { estimate: 0.0, theta: 0.0, bias: 0.0, se: 0.0 } }
+    let nf = n as f64
+    // full-sample biased variance
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mean = s / nf
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; ss = ss + d * d; j = j + 1 }
+    let theta = ss / nf
+    // leave-one-out variances
+    var sum_loo = 0.0
+    var a = 0
+    while a < n { sum_loo = sum_loo + loo_variance(x, n, a); a = a + 1 }
+    let tbar = sum_loo / nf
+    var ssq = 0.0
+    var b = 0
+    while b < n { let d = loo_variance(x, n, b) - tbar; ssq = ssq + d * d; b = b + 1 }
+    let se = jk_sqrt((nf - 1.0) / nf * ssq)
+    let bias = (nf - 1.0) * (tbar - theta)
+    return JackResult { estimate: theta - bias, theta: theta, bias: bias, se: se }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// mean of {1,2,3,4,5}: theta=3, bias=0, se=s/sqrt(n)=sqrt(10/(5·4))=sqrt(0.5)=0.707107.
+fn test_mean() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = jackknife_mean(&x, 5)
+    var ok = true
+    ok = check(1, approx(r.theta, 3.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.bias, 0.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.se, 0.707107, 1.0e-5)) && ok
+    ok = check(4, approx(r.estimate, 3.0, 1.0e-9)) && ok
+    return ok
+}
+
+// variance of {1,2,3,4,5}: biased theta=2, jackknife estimate=2.5 (=unbiased),
+// bias=-0.5, se=sqrt((4/5)·1.367188)=sqrt(1.09375)=1.045825.
+fn test_variance() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = jackknife_variance(&x, 5)
+    var ok = true
+    ok = check(10, approx(r.theta, 2.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.estimate, 2.5, 1.0e-6)) && ok
+    ok = check(12, approx(r.bias, 0.0 - 0.5, 1.0e-6)) && ok
+    ok = check(13, approx(r.se, 1.045825, 1.0e-5)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_mean() && ok
+    ok = test_variance() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/rng.sio
+++ b/stdlib/stats/rng.sio
@@ -1,0 +1,206 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/rng.sio — Park-Miller MINSTD pseudo-random generator
+//
+// A deterministic, fully reproducible uniform generator implemented entirely in
+// exact f64 arithmetic (no bit operations) — the seed of any resampling routine:
+//
+//   rng_seed(s)             -> Rng
+//   rng_uniform(&!r)        -> f64 in [0,1)
+//   rng_range(&!r, lo, hi)  -> f64 in [lo,hi)
+//   rng_int(&!r, n)         -> i64 in {0,…,n−1}
+//   rng_normal(&!r)         -> f64 standard normal (Box-Muller)
+//
+// The recurrence is the minimal-standard MCG  xₙ₊₁ = (16807·xₙ) mod 2147483647,
+// uₙ = xₙ/m.  Since 16807·(m−1) ≈ 3.6·10¹³ < 2⁵³ the product is exact in f64, so
+// the whole stream is bit-reproducible from the seed.
+//
+// Pure Sounio: exact modular arithmetic via floor (i64 cast); inline
+// ln/sqrt/cos for the normal. No external dependency, no nested data-array calls.
+//
+// References:
+//   Park & Miller (1988) CACM 31:1192.
+
+module stats::rng
+
+let MINSTD_A: f64 = 16807.0
+let MINSTD_M: f64 = 2147483647.0
+
+fn rg_floor(v: f64) -> f64 {
+    return (v as i64) as f64
+}
+
+fn rg_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn rg_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+// cos via range reduction to [-π,π] then Taylor (12 terms).
+fn rg_cos(x: f64) -> f64 with Mut, Div, Panic {
+    let TWO_PI = 6.283185307179586
+    let PI = 3.141592653589793
+    var a = x
+    // reduce modulo 2π into [0,2π)
+    let k = rg_floor(a / TWO_PI)
+    a = a - k * TWO_PI
+    if a > PI { a = a - TWO_PI }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 12 {
+        term = term * (0.0 - a * a) / (((2 * n - 1) * (2 * n)) as f64)
+        sum = sum + term
+        n = n + 1
+    }
+    return sum
+}
+
+pub struct Rng {
+    pub state: f64,
+}
+
+/// Seed a MINSTD generator (state clamped to 1..m−1).
+pub fn rng_seed(s: i64) -> Rng with Mut, Div, Panic {
+    var v = (s as f64)
+    if v < 1.0 { v = 1.0 }
+    // fold into [1, m-1]
+    let m1 = MINSTD_M - 1.0
+    if v > m1 { v = v - rg_floor((v - 1.0) / m1) * m1 }
+    return Rng { state: v }
+}
+
+/// Next uniform in [0,1).
+pub fn rng_uniform(r: &!Rng) -> f64 with Mut, Div, Panic {
+    let prod = MINSTD_A * r.state
+    let next = prod - rg_floor(prod / MINSTD_M) * MINSTD_M
+    r.state = next
+    return next / MINSTD_M
+}
+
+/// Next uniform in [lo, hi).
+pub fn rng_range(r: &!Rng, lo: f64, hi: f64) -> f64 with Mut, Div, Panic {
+    return lo + rng_uniform(r) * (hi - lo)
+}
+
+/// Next integer in {0, …, n−1}.
+pub fn rng_int(r: &!Rng, n: i32) -> i64 with Mut, Div, Panic {
+    if n < 1 { return 0 }
+    let u = rng_uniform(r)
+    var k = rg_floor(u * (n as f64)) as i64
+    if k >= (n as i64) { k = (n as i64) - 1 }
+    return k
+}
+
+/// Next standard-normal deviate (Box-Muller).
+pub fn rng_normal(r: &!Rng) -> f64 with Mut, Div, Panic {
+    var u1 = rng_uniform(r)
+    let u2 = rng_uniform(r)
+    if u1 < 1.0e-300 { u1 = 1.0e-300 }
+    let TWO_PI = 6.283185307179586
+    return rg_sqrt(0.0 - 2.0 * rg_ln(u1)) * rg_cos(TWO_PI * u2)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// seed 1: u1 = 16807/2147483647 = 7.8263693e-6; u2 = 282475249/2147483647 = 0.131538.
+fn test_stream() -> bool with IO, Mut, Div, Panic {
+    var r = rng_seed(1)
+    let a = rng_uniform(&!r)
+    let b = rng_uniform(&!r)
+    var ok = true
+    ok = check(1, approx(a, 0.0000078263693, 1.0e-10)) && ok
+    ok = check(2, approx(b, 0.13153778, 1.0e-6)) && ok
+    return ok
+}
+
+// uniforms stay in [0,1); ints stay in {0..n-1}.
+fn test_bounds() -> bool with IO, Mut, Div, Panic {
+    var r = rng_seed(42)
+    var ok = true
+    var i = 0
+    while i < 200 {
+        let u = rng_uniform(&!r)
+        if u < 0.0 || u >= 1.0 { ok = false }
+        let k = rng_int(&!r, 6)
+        if k < 0 || k > 5 { ok = false }
+        i = i + 1
+    }
+    return check(10, ok)
+}
+
+// reproducibility: two generators with the same seed produce the same value.
+fn test_reproducible() -> bool with IO, Mut, Div, Panic {
+    var r1 = rng_seed(12345)
+    var r2 = rng_seed(12345)
+    var i = 0
+    while i < 50 { let a = rng_uniform(&!r1); i = i + 1 }
+    var j = 0
+    while j < 50 { let b = rng_uniform(&!r2); j = j + 1 }
+    let x = rng_uniform(&!r1)
+    let y = rng_uniform(&!r2)
+    return check(20, approx(x, y, 1.0e-15))
+}
+
+// normal deviates have roughly zero mean over many draws.
+fn test_normal_mean() -> bool with IO, Mut, Div, Panic {
+    var r = rng_seed(7)
+    var s = 0.0
+    var i = 0
+    while i < 1000 { s = s + rng_normal(&!r); i = i + 1 }
+    let mean = s / 1000.0
+    return check(30, approx(mean, 0.0, 0.15))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_stream() && ok
+    ok = test_bounds() && ok
+    ok = test_reproducible() && ok
+    ok = test_normal_mean() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

The **resampling family** for the epistemic-statistics suite, bringing the runner to **79 modules**. This closes the last major modern-staple gap. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::jackknife` | Leave-one-out bias & SE for the mean and variance (deterministic) |
| `stats::rng` | Park-Miller MINSTD generator in **exact f64** (no bit-ops), bit-reproducible; uniform / range / int / Box-Muller normal |
| `stats::bootstrap` | Nonparametric percentile bootstrap CI + SE for the mean, seeded (reproducible) |

## Keeping resampling derivable

Resampling is usually where auditability breaks down (random ⇒ non-reproducible). Two design choices keep it derivable:

1. **The jackknife is deterministic** — leave-one-out, no RNG. Its constants are hand-derived (the ÷n variance jackknife recovers the unbiased ÷(n−1) value: θ̂=2 → 2.5, bias −0.5).
2. **The RNG is exact and reproducible** — MINSTD `xₙ₊₁=(16807·xₙ) mod 2147483647` runs entirely in f64 because `16807·(m−1) ≈ 3.6e13 < 2⁵³`, so every product is exact and the whole stream is bit-reproducible from the seed (first two uniforms from seed 1 are the exact 7.826e−6 and 0.13154). The bootstrap therefore asserts **derivable-in-expectation** properties — exact point estimate, an SE tolerance calibrated to Monte-Carlo error (√(σ̂²/n)=0.6325 ± 0.08), and seed reproducibility — not retrofitted numbers.

## Validation

- Jackknife: mean of {1..5} → SE=0.7071, bias 0; variance bias-corrected 2 → 2.5.
- RNG: seed-1 stream exact; uniforms in [0,1); integers in range; identical seeds → identical streams (to 1e−15); Box-Muller normals ≈ mean 0.
- Bootstrap: {1..5} → point estimate 3 exactly, SE ≈ 0.6325 (MC), CI brackets the mean, reproducible.
- Full suite selftest: **79 modules + 7 demos ALL GREEN** under `lean_single`.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).