### PR TITLE
feat(stats): resampling inference — perm_test, bootstrap_diff, bootstrap_corr

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2869,3 +2869,12 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - bootstrap = **PASS**: floor(u·n) index bound proven, percentile order statistics, SE→√(σ̂²/n); reviewer confirmed tolerances "explicitly stated and justified" (MC-error-calibrated 0.08 on SE).
 - Theme: resampling — the last major modern-staple gap. Derivability preserved: jackknife fully deterministic; the MINSTD stream is exactly reproducible from the recurrence (auditable), so the bootstrap tests assert derivable-in-expectation properties (exact point estimate, MC-calibrated SE tolerance, reproducibility). #852-safe. Suite runner: 79 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Tq92DO/`, `/tmp/llm-offload-zDJZrw/`, `/tmp/llm-offload-wXrCs6/`.
+
+## 2026-07-15 — math-review: stats::perm_test, stats::bootstrap_diff, stats::bootstrap_corr
+- Files (all new): `stdlib/stats/perm_test.sio` (Monte-Carlo two-sample permutation test on mean difference, Fisher-Yates via seeded MINSTD), `stdlib/stats/bootstrap_diff.sio` (two-sample bootstrap difference-in-means CI/SE), `stdlib/stats/bootstrap_corr.sio` (bootstrap Pearson-correlation CI). Provider: xAI/Grok 4.3.
+- perm_test = **PASS**: Fisher-Yates uniform permutation, MINSTD exact, p=(count+1)/(b+1); identical means→p=1, separated 5-vs-5→p<0.05 (reviewer confirmed 2/252≈0.0079 enumeration floor), reproducible.
+- bootstrap_diff = **PASS**: percentile CI + SE for x̄−ȳ, independent group resampling, MINSTD; point-estimate/coverage/reproducibility verified.
+- bootstrap_corr = **PASS**: paired resampling, r from raw sums, percentile CI; perfect dependence→r=1/SE=0/CI=[1,1] verified.
+- Note: test_separated initially used 3-vs-3 (permutation floor 2/20=0.1, can't reject at 0.05) — the failing assertion caught my hand-reasoning error; switched to 5-vs-5 (floor 2/252≈0.008). Another derivable-values catch.
+- Theme: resampling inference — extends the resampling family to two-sample and correlation, promoting the permutation test to a first-class module (was an external example). All seeded/reproducible, #852-safe. Suite runner: 82 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-4fFm8k/`, `/tmp/llm-offload-4Ksd2v/`, `/tmp/llm-offload-UN4If6/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -88,6 +88,9 @@ MODULES=(
   stdlib/stats/jackknife.sio
   stdlib/stats/rng.sio
   stdlib/stats/bootstrap.sio
+  stdlib/stats/perm_test.sio
+  stdlib/stats/bootstrap_diff.sio
+  stdlib/stats/bootstrap_corr.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -39,7 +39,8 @@ fourteen families:
 - **Multivariate (bivariate)** — the Mahalanobis distance, one-sample
   Hotelling's T² and two-variable PCA, all closed-form over the 2×2 covariance.
 - **Resampling** — the leave-one-out jackknife, a bit-reproducible Park-Miller
-  MINSTD generator (exact f64), and the nonparametric bootstrap for the mean.
+  MINSTD generator (exact f64), the nonparametric bootstrap for the mean, the
+  two-sample difference and correlation bootstraps, and a permutation test.
 - **Bayesian & model selection** — conjugate updates, the Beta-posterior
   credible interval, the Bayesian A/B test (P(pB>pA)), and AIC / BIC with the
   Schwarz Bayes-factor approximation.
@@ -1123,6 +1124,39 @@ distributional assumption. Validated: {1..5} → point estimate 3 exactly, SE
 converging to √(σ̂²/n)=0.6325 (within Monte-Carlo error), CI bracketing the mean,
 identical results from identical seeds.
 
+### `stats::perm_test` — two-sample permutation test
+
+| Function | Signature |
+|---|---|
+| `perm_test` | `pub fn perm_test(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, b: i32, seed: i64) -> PermResult with Mut, Div, Panic` |
+
+A Monte-Carlo permutation test on the difference in means: pool, randomly
+reassign nx values to group A `b` times (Fisher-Yates via seeded MINSTD), and
+report `p=(#{|Δ*|≥|Δ_obs|}+1)/(b+1)`. Validated: identical means → p=1;
+well-separated 5-vs-5 → p<0.05 (permutation floor 2/252≈0.008); reproducible.
+
+### `stats::bootstrap_diff` — two-sample bootstrap difference
+
+| Function | Signature |
+|---|---|
+| `bootstrap_diff` | `pub fn bootstrap_diff(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, b: i32, conf: f64, seed: i64) -> BootDiffResult with Mut, Div, Panic` |
+
+The resampling counterpart to Welch's t-test: a percentile CI and SE for the
+difference in means, resampling each group independently (seeded). Validated:
+{5,6,7} vs {1,2,3} → point diff 4 exactly, CI brackets 4; identical groups → CI
+brackets 0; reproducible.
+
+### `stats::bootstrap_corr` — bootstrap correlation CI
+
+| Function | Signature |
+|---|---|
+| `bootstrap_corr` | `pub fn bootstrap_corr(x: &[f64; 256], y: &[f64; 256], n: i32, b: i32, conf: f64, seed: i64) -> BootCorrResult with Mut, Div, Panic` |
+
+A distribution-free CI for a Pearson correlation by resampling pairs (the
+alternative to the Fisher-z interval when normality is doubtful). Validated:
+perfectly correlated data → r=1, SE=0, CI=[1,1]; noisy positive association → CI
+brackets the point r; reproducible.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1206,6 +1240,9 @@ use stats::pca2::{PCA2Result, pca2}
 use stats::jackknife::{JackResult, jackknife_mean, jackknife_variance}
 use stats::rng::{Rng, rng_seed, rng_uniform, rng_range, rng_int, rng_normal}
 use stats::bootstrap::{BootResult, bootstrap_mean}
+use stats::perm_test::{PermResult, perm_test}
+use stats::bootstrap_diff::{BootDiffResult, bootstrap_diff}
+use stats::bootstrap_corr::{BootCorrResult, bootstrap_corr}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/bootstrap_corr.sio
+++ b/stdlib/stats/bootstrap_corr.sio
@@ -1,0 +1,203 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bootstrap_corr.sio — bootstrap CI for a Pearson correlation
+//
+// Resamples paired observations (the same drawn index for both coordinates) to
+// give a distribution-free confidence interval for a Pearson correlation — where
+// the Fisher-z interval's normality assumption is doubtful:
+//
+//   bootstrap_corr(x, y, n, b, conf, seed) -> BootCorrResult
+//
+// Each of `b` resamples draws n pairs with replacement and recomputes r; the SE
+// is the sd of the resampled r's and the CI is their α/2, 1−α/2 quantiles.
+//
+// Seeded Park-Miller MINSTD (exact f64) → bit-reproducible. Pure Sounio: inline
+// sort of the resampled correlations; no external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Efron & Tibshirani, "An Introduction to the Bootstrap", §12.
+
+module stats::bootstrap_corr
+
+fn bc_floor(v: f64) -> f64 {
+    return (v as i64) as f64
+}
+
+fn bc_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct BootCorrResult {
+    pub r: f64,      // original Pearson correlation (point estimate)
+    pub se: f64,
+    pub lo: f64,
+    pub hi: f64,
+    pub b: i64,
+}
+
+/// Percentile bootstrap CI and SE for a Pearson correlation.
+///
+/// Parâmetros: x, y — paired data; n — size (>=3, <=256); b — resamples (2..1024);
+///             conf — confidence; seed — PRNG seed (>0).
+/// Retorno: BootCorrResult (r, se, lo, hi, b).
+/// Referências: Efron & Tibshirani §12.
+pub fn bootstrap_corr(x: &[f64; 256], y: &[f64; 256], n: i32, b: i32, conf: f64, seed: i64) -> BootCorrResult with Mut, Div, Panic {
+    if n < 3 || b < 2 { return BootCorrResult { r: 0.0, se: 0.0, lo: 0.0, hi: 0.0, b: 0 } }
+    var bb = b
+    if bb > 1024 { bb = 1024 }
+    let nf = n as f64
+    // original r
+    var sx0 = 0.0
+    var sy0 = 0.0
+    var i = 0
+    while i < n { sx0 = sx0 + x[i as usize]; sy0 = sy0 + y[i as usize]; i = i + 1 }
+    let mx0 = sx0 / nf
+    let my0 = sy0 / nf
+    var sxx0 = 0.0
+    var syy0 = 0.0
+    var sxy0 = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx0
+        let dy = y[j as usize] - my0
+        sxx0 = sxx0 + dx * dx
+        syy0 = syy0 + dy * dy
+        sxy0 = sxy0 + dx * dy
+        j = j + 1
+    }
+    var r0 = 0.0
+    let den0 = bc_sqrt(sxx0 * syy0)
+    if den0 > 0.0 { r0 = sxy0 / den0 }
+    let A = 16807.0
+    let M = 2147483647.0
+    var st = seed as f64
+    if st < 1.0 { st = 1.0 }
+    var rs: [f64; 1024] = [0.0; 1024]
+    var rep = 0
+    while rep < bb {
+        // one bootstrap sample of n paired indices; accumulate moments in one pass
+        var sx = 0.0
+        var sy = 0.0
+        var sxx = 0.0
+        var syy = 0.0
+        var sxy = 0.0
+        var k = 0
+        while k < n {
+            let prod = A * st
+            st = prod - bc_floor(prod / M) * M
+            let u = st / M
+            var idx = bc_floor(u * nf) as i32
+            if idx >= n { idx = n - 1 }
+            let xv = x[idx as usize]
+            let yv = y[idx as usize]
+            sx = sx + xv
+            sy = sy + yv
+            sxx = sxx + xv * xv
+            syy = syy + yv * yv
+            sxy = sxy + xv * yv
+            k = k + 1
+        }
+        // r from raw sums: cov = sxy - sx·sy/n, etc.
+        let cxx = sxx - sx * sx / nf
+        let cyy = syy - sy * sy / nf
+        let cxy = sxy - sx * sy / nf
+        var rr = 0.0
+        let den = bc_sqrt(cxx * cyy)
+        if den > 1.0e-300 { rr = cxy / den }
+        if rr > 1.0 { rr = 1.0 }
+        if rr < 0.0 - 1.0 { rr = 0.0 - 1.0 }
+        rs[rep as usize] = rr
+        rep = rep + 1
+    }
+    var sm = 0.0
+    var a = 0
+    while a < bb { sm = sm + rs[a as usize]; a = a + 1 }
+    let mbar = sm / (bb as f64)
+    var ss = 0.0
+    var c = 0
+    while c < bb { let d = rs[c as usize] - mbar; ss = ss + d * d; c = c + 1 }
+    let se = bc_sqrt(ss / ((bb - 1) as f64))
+    var p = 1
+    while p < bb {
+        let key = rs[p as usize]
+        var q = p - 1
+        while q >= 0 && rs[q as usize] > key { rs[(q + 1) as usize] = rs[q as usize]; q = q - 1 }
+        rs[(q + 1) as usize] = key
+        p = p + 1
+    }
+    let alpha = 1.0 - conf
+    var ilo = bc_floor(alpha * 0.5 * (bb as f64)) as i32
+    var ihi = bc_floor((1.0 - alpha * 0.5) * (bb as f64)) as i32
+    if ilo < 0 { ilo = 0 }
+    if ihi > bb - 1 { ihi = bb - 1 }
+    return BootCorrResult { r: r0, se: se, lo: rs[ilo as usize], hi: rs[ihi as usize], b: bb as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfectly correlated y=2x+1: every resample has r=1, so r=1, SE=0, CI=[1,1].
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 6 { x[i as usize] = (i + 1) as f64; y[i as usize] = 2.0 * ((i + 1) as f64) + 1.0; i = i + 1 }
+    let r = bootstrap_corr(&x, &y, 6, 500, 0.95, 42)
+    var ok = true
+    ok = check(1, approx(r.r, 1.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.se, 0.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.lo, 1.0, 1.0e-9)) && ok
+    ok = check(4, approx(r.hi, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// noisy positive association: point r > 0.5, CI brackets it, SE > 0.
+fn test_noisy() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0; x[5]=6.0; x[6]=7.0; x[7]=8.0
+    y[0]=1.0; y[1]=3.0; y[2]=2.0; y[3]=5.0; y[4]=4.0; y[5]=7.0; y[6]=6.0; y[7]=9.0
+    let r = bootstrap_corr(&x, &y, 8, 800, 0.95, 20261)
+    var ok = true
+    ok = check(10, r.r > 0.8) && ok
+    ok = check(11, r.lo < r.r + 1.0e-9 && r.hi > r.r - 1.0e-9) && ok
+    ok = check(12, r.se > 0.0) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_noisy() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/bootstrap_diff.sio
+++ b/stdlib/stats/bootstrap_diff.sio
@@ -1,0 +1,194 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bootstrap_diff.sio — two-sample bootstrap difference in means
+//
+// Resamples each group independently to give a percentile confidence interval
+// and standard error for the difference of means — the resampling counterpart
+// to Welch's t-test:
+//
+//   bootstrap_diff(x, nx, y, ny, b, conf, seed) -> BootDiffResult
+//
+// The point estimate is x̄ − ȳ; each of `b` resamples draws nx values from x and
+// ny from y (with replacement), the SE is the sd of the resampled differences
+// and the CI is their α/2 and 1−α/2 quantiles.
+//
+// Seeded Park-Miller MINSTD (exact f64) → bit-reproducible. Pure Sounio: inline
+// sort of the resampled differences; no external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Efron & Tibshirani, "An Introduction to the Bootstrap", ch.6.
+
+module stats::bootstrap_diff
+
+fn bd_floor(v: f64) -> f64 {
+    return (v as i64) as f64
+}
+
+fn bd_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct BootDiffResult {
+    pub diff: f64,   // x̄ − ȳ (point estimate)
+    pub se: f64,
+    pub lo: f64,
+    pub hi: f64,
+    pub b: i64,
+}
+
+/// Percentile bootstrap CI and SE for the difference in means x̄ − ȳ.
+///
+/// Parâmetros: x, y — the two samples; nx, ny — sizes (<=256); b — resamples
+///             (2..1024); conf — confidence; seed — PRNG seed (>0).
+/// Retorno: BootDiffResult (diff, se, lo, hi, b).
+/// Referências: Efron & Tibshirani ch.6.
+pub fn bootstrap_diff(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, b: i32, conf: f64, seed: i64) -> BootDiffResult with Mut, Div, Panic {
+    if nx < 2 || ny < 2 || b < 2 { return BootDiffResult { diff: 0.0, se: 0.0, lo: 0.0, hi: 0.0, b: 0 } }
+    var bb = b
+    if bb > 1024 { bb = 1024 }
+    let nxf = nx as f64
+    let nyf = ny as f64
+    var sx = 0.0
+    var i = 0
+    while i < nx { sx = sx + x[i as usize]; i = i + 1 }
+    var sy = 0.0
+    var j = 0
+    while j < ny { sy = sy + y[j as usize]; j = j + 1 }
+    let diff0 = sx / nxf - sy / nyf
+    let A = 16807.0
+    let M = 2147483647.0
+    var st = seed as f64
+    if st < 1.0 { st = 1.0 }
+    var diffs: [f64; 1024] = [0.0; 1024]
+    var rep = 0
+    while rep < bb {
+        var accx = 0.0
+        var kx = 0
+        while kx < nx {
+            let prod = A * st
+            st = prod - bd_floor(prod / M) * M
+            let u = st / M
+            var idx = bd_floor(u * nxf) as i32
+            if idx >= nx { idx = nx - 1 }
+            accx = accx + x[idx as usize]
+            kx = kx + 1
+        }
+        var accy = 0.0
+        var ky = 0
+        while ky < ny {
+            let prod = A * st
+            st = prod - bd_floor(prod / M) * M
+            let u = st / M
+            var idy = bd_floor(u * nyf) as i32
+            if idy >= ny { idy = ny - 1 }
+            accy = accy + y[idy as usize]
+            ky = ky + 1
+        }
+        diffs[rep as usize] = accx / nxf - accy / nyf
+        rep = rep + 1
+    }
+    var sm = 0.0
+    var a = 0
+    while a < bb { sm = sm + diffs[a as usize]; a = a + 1 }
+    let mbar = sm / (bb as f64)
+    var ss = 0.0
+    var c = 0
+    while c < bb { let d = diffs[c as usize] - mbar; ss = ss + d * d; c = c + 1 }
+    let se = bd_sqrt(ss / ((bb - 1) as f64))
+    var p = 1
+    while p < bb {
+        let key = diffs[p as usize]
+        var q = p - 1
+        while q >= 0 && diffs[q as usize] > key { diffs[(q + 1) as usize] = diffs[q as usize]; q = q - 1 }
+        diffs[(q + 1) as usize] = key
+        p = p + 1
+    }
+    let alpha = 1.0 - conf
+    var ilo = bd_floor(alpha * 0.5 * (bb as f64)) as i32
+    var ihi = bd_floor((1.0 - alpha * 0.5) * (bb as f64)) as i32
+    if ilo < 0 { ilo = 0 }
+    if ihi > bb - 1 { ihi = bb - 1 }
+    return BootDiffResult { diff: diff0, se: se, lo: diffs[ilo as usize], hi: diffs[ihi as usize], b: bb as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={5,6,7}, y={1,2,3}: point diff = 6 - 2 = 4 (exact). CI brackets 4.
+fn test_diff() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=5.0; x[1]=6.0; x[2]=7.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0
+    let r = bootstrap_diff(&x, 3, &y, 3, 800, 0.95, 20260715)
+    var ok = true
+    ok = check(1, approx(r.diff, 4.0, 1.0e-9)) && ok
+    ok = check(2, r.lo < 4.0 && r.hi > 4.0) && ok
+    ok = check(3, r.se > 0.0) && ok
+    return ok
+}
+
+// identical groups -> point diff 0, CI brackets 0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0; y[3]=4.0
+    let r = bootstrap_diff(&x, 4, &y, 4, 600, 0.95, 31)
+    var ok = true
+    ok = check(10, approx(r.diff, 0.0, 1.0e-9)) && ok
+    ok = check(11, r.lo < 0.0 && r.hi > 0.0) && ok
+    return ok
+}
+
+// reproducibility.
+fn test_reproducible() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=3.0; x[1]=5.0; x[2]=7.0
+    y[0]=2.0; y[1]=4.0; y[2]=6.0
+    let r1 = bootstrap_diff(&x, 3, &y, 3, 500, 0.9, 88)
+    let r2 = bootstrap_diff(&x, 3, &y, 3, 500, 0.9, 88)
+    var ok = true
+    ok = check(20, approx(r1.lo, r2.lo, 1.0e-12)) && ok
+    ok = check(21, approx(r1.hi, r2.hi, 1.0e-12)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_diff() && ok
+    ok = test_null() && ok
+    ok = test_reproducible() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/perm_test.sio
+++ b/stdlib/stats/perm_test.sio
@@ -1,0 +1,160 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/perm_test.sio — two-sample permutation test (mean difference)
+//
+// A Monte-Carlo permutation test of whether two samples share a distribution,
+// using the difference in means as the statistic — exact-in-spirit, assumption-
+// free inference:
+//
+//   perm_test(x, nx, y, ny, b, seed) -> PermResult
+//
+// The observed statistic is x̄ − ȳ. Pooling the N = nx+ny values and randomly
+// reassigning nx of them to group A `b` times gives the permutation null; the
+// two-sided p-value is (#{ |Δ*| ≥ |Δ_obs| } + 1)/(b + 1).
+//
+// The shuffle uses an inline Park-Miller MINSTD (exact f64), so a run is
+// bit-reproducible from the seed. Pure Sounio: Fisher-Yates over a pooled [256]
+// buffer; no external dependency, no nested data-array calls.
+//
+// References:
+//   Fisher (1935); Ernst (2004) Stat. Sci. 19:676.
+
+module stats::perm_test
+
+fn pt_floor(v: f64) -> f64 {
+    return (v as i64) as f64
+}
+
+pub struct PermResult {
+    pub obs_diff: f64,   // x̄ − ȳ
+    pub p: f64,          // two-sided permutation p-value
+    pub b: i64,          // permutations used
+}
+
+/// Monte-Carlo two-sample permutation test on the difference in means.
+///
+/// Parâmetros: x, y — the two samples; nx, ny — sizes (nx+ny <= 256);
+///             b — permutations (>=1); seed — PRNG seed (>0).
+/// Retorno: PermResult (obs_diff, p, b).
+/// Referências: Fisher (1935); Ernst (2004).
+pub fn perm_test(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, b: i32, seed: i64) -> PermResult with Mut, Div, Panic {
+    if nx < 1 || ny < 1 || b < 1 { return PermResult { obs_diff: 0.0, p: 1.0, b: 0 } }
+    let ntot = nx + ny
+    let nxf = nx as f64
+    let nyf = ny as f64
+    // pooled buffer: first nx from x, rest from y
+    var pool: [f64; 256] = [0.0; 256]
+    var sx = 0.0
+    var i = 0
+    while i < nx { pool[i as usize] = x[i as usize]; sx = sx + x[i as usize]; i = i + 1 }
+    var sy = 0.0
+    var j = 0
+    while j < ny { pool[(nx + j) as usize] = y[j as usize]; sy = sy + y[j as usize]; j = j + 1 }
+    let obs = sx / nxf - sy / nyf
+    let abs_obs = if obs < 0.0 { 0.0 - obs } else { obs }
+    let total = sx + sy
+    // MINSTD state
+    let A = 16807.0
+    let M = 2147483647.0
+    var st = seed as f64
+    if st < 1.0 { st = 1.0 }
+    var count = 0
+    var rep = 0
+    while rep < b {
+        // Fisher-Yates shuffle of the first ntot pooled values
+        var k = ntot - 1
+        while k >= 1 {
+            let prod = A * st
+            st = prod - pt_floor(prod / M) * M
+            let u = st / M
+            var idx = pt_floor(u * ((k + 1) as f64)) as i32
+            if idx > k { idx = k }
+            let tmp = pool[k as usize]
+            pool[k as usize] = pool[idx as usize]
+            pool[idx as usize] = tmp
+            k = k - 1
+        }
+        // group A = first nx, group B = rest
+        var sa = 0.0
+        var m = 0
+        while m < nx { sa = sa + pool[m as usize]; m = m + 1 }
+        let diff = sa / nxf - (total - sa) / nyf
+        let ad = if diff < 0.0 { 0.0 - diff } else { diff }
+        if ad >= abs_obs - 1.0e-12 { count = count + 1 }
+        rep = rep + 1
+    }
+    let p = ((count + 1) as f64) / ((b + 1) as f64)
+    return PermResult { obs_diff: obs, p: p, b: b as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// identical group means -> obs_diff 0 -> every permutation |Δ*| >= 0 -> p = 1.
+fn test_identical() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0
+    let r = perm_test(&x, 3, &y, 3, 500, 12345)
+    var ok = true
+    ok = check(1, approx(r.obs_diff, 0.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.p, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// well separated, 5 vs 5 -> the two extreme splits out of C(10,5)=252 give the
+// exact two-sided p ≈ 2/252 = 0.0079; the MC estimate is < 0.05.
+// (With only 3+3 the minimum attainable p is 2/20 = 0.1 — too coarse to reject.)
+// x={10..14}, y={1..5}. obs_diff = 12 - 3 = 9.
+fn test_separated() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=11.0; x[2]=12.0; x[3]=13.0; x[4]=14.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0; y[3]=4.0; y[4]=5.0
+    let r = perm_test(&x, 5, &y, 5, 1000, 777)
+    var ok = true
+    ok = check(10, approx(r.obs_diff, 9.0, 1.0e-9)) && ok
+    ok = check(11, r.p < 0.05) && ok
+    return ok
+}
+
+// reproducibility: same seed -> identical p.
+fn test_reproducible() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=4.0; x[1]=5.0; x[2]=7.0; x[3]=8.0
+    y[0]=2.0; y[1]=3.0; y[2]=5.0; y[3]=6.0
+    let r1 = perm_test(&x, 4, &y, 4, 400, 55)
+    let r2 = perm_test(&x, 4, &y, 4, 400, 55)
+    return check(20, approx(r1.p, r2.p, 1.0e-12))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_identical() && ok
+    ok = test_separated() && ok
+    ok = test_reproducible() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three resampling-inference modules building on the new RNG primitive, bringing the runner to **82 modules**. These extend the resampling family to two-sample and correlation problems, and promote the permutation test from an external example to a first-class module. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::perm_test` | Monte-Carlo two-sample permutation test on the mean difference |
| `stats::bootstrap_diff` | Percentile bootstrap CI + SE for x̄−ȳ (Welch counterpart) |
| `stats::bootstrap_corr` | Distribution-free bootstrap CI for a Pearson correlation |

## Validation

- Inline `//@ run-pass` tests, all seeded and bit-reproducible:
  - Permutation: identical means → p=1 (exact); well-separated 5-vs-5 → p<0.05; reproducible.
  - Bootstrap-diff: {5,6,7} vs {1,2,3} → point diff 4 exactly, CI brackets 4; identical → CI brackets 0.
  - Bootstrap-corr: perfectly correlated data → r=1, SE=0, CI=[1,1]; noisy → CI brackets the point r.
- Full suite selftest: **82 modules + 7 demos ALL GREEN** under `lean_single`.

## A derivable-values catch worth noting
`perm_test`'s "separated → p<0.05" test initially used **3-vs-3** groups — but the permutation floor there is 2/C(6,3) = 2/20 = **0.1**, which can never reject at 0.05. The failing assertion caught my faulty hand-reasoning; I switched to **5-vs-5** (floor 2/252 ≈ 0.008). The math-review independently confirmed the 2/252 enumeration bound. This is the assumption-checking discipline working exactly as intended — a test that would have "passed" only by loosening to hide a wrong premise instead exposed the premise.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).