### PR TITLE
[DO NOT MERGE] native: close measured codegen capacity overflow

### DIFF
--- a/scripts/ci/madaros_native_code_capacity_gate.sh
+++ b/scripts/ci/madaros_native_code_capacity_gate.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+MADAROS="$ROOT/bin/madaros"
+WITNESS="$ROOT/self-hosted/native/test_code_capacity.sio"
+
+fail() {
+  printf 'madaros-native-code-capacity gate: FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -n "$RAW_MADAROS" ]] || fail 'MADAROS_RAW_BIN must name an explicit current-source Madaros ELF'
+[[ -x "$RAW_MADAROS" ]] || fail "MADAROS_RAW_BIN is not executable: $RAW_MADAROS"
+
+grep -Fq 'pub var NC_BIG_CODE: [i8; 8388608] = [0; 8388608]' "$ROOT/self-hosted/native/encode.sio" \
+  || fail '8 MiB BSS code tier is absent'
+grep -Fq 'pub fn nc_code_capacity_bytes() -> i64 { 8388608 }' "$ROOT/self-hosted/native/encode.sio" \
+  || fail 'checked code capacity does not match the BSS tier'
+grep -Fq 'fn witness_code_capacity_bytes() -> i64 { 8388608 }' "$WITNESS" \
+  || fail 'boundary witness is not tied to the checked code tier'
+grep -Fq 'var NC_BIG_ELF: [i8; 16777216] = [0; 16777216]' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail '16 MiB BSS ELF tier is absent'
+grep -Fq 'NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1' "$ROOT/self-hosted/native/encode.sio" \
+  || fail 'overflow accounting is absent from shared emitters'
+grep -Fq 'if nc.code_overflow || NC_CODE_OVERFLOWED {' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'active finalizer does not preserve rc19 exhaustion handling'
+
+if rg -n 'len < 2097152|jns_pos \+ 1 < 2097152|NC_BIG_ELF.*4194304|\(text_offset \+ i\) < 4194304|\(rodata_offset \+ i\) < 4194304' \
+  "$ROOT/self-hosted/native/encode.sio" \
+  "$ROOT/self-hosted/native/codegen.sio" \
+  "$ROOT/self-hosted/native/codegen_x86_linux.sio"; then
+  fail 'a stale code or ELF capacity guard remains'
+fi
+
+work="$(mktemp -d -t madaros-native-code-capacity.XXXXXX)"
+trap 'rm -rf "$work"' EXIT
+
+MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" check "$WITNESS" >"$work/check.log" 2>&1 || {
+  cat "$work/check.log" >&2
+  fail 'boundary witness did not check'
+}
+MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" run "$WITNESS" >"$work/run.log" 2>&1 || {
+  cat "$work/run.log" >&2
+  fail 'boundary witness did not run'
+}
+cat "$work/run.log"
+grep -Fxq 'PASS native_code_capacity below_at_above rc19' "$work/run.log" \
+  || fail 'exact boundary PASS receipt absent'
+
+printf 'madaros-native-code-capacity gate: PASS\n'

--- a/scripts/ci/madaros_native_code_capacity_gate.sh
+++ b/scripts/ci/madaros_native_code_capacity_gate.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+EXPECTED_RAW_SHA256="${MADAROS_EXPECTED_SHA256:-}"
 MADAROS="$ROOT/bin/madaros"
 WITNESS="$ROOT/self-hosted/native/test_code_capacity.sio"
 
@@ -13,19 +14,46 @@ fail() {
 
 [[ -n "$RAW_MADAROS" ]] || fail 'MADAROS_RAW_BIN must name an explicit current-source Madaros ELF'
 [[ -x "$RAW_MADAROS" ]] || fail "MADAROS_RAW_BIN is not executable: $RAW_MADAROS"
+[[ "$EXPECTED_RAW_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+  || fail 'MADAROS_EXPECTED_SHA256 must pin the explicit Madaros ELF'
+actual_raw_sha256="$(sha256sum "$RAW_MADAROS" | awk '{print $1}')"
+[[ "$actual_raw_sha256" == "$EXPECTED_RAW_SHA256" ]] \
+  || fail "Madaros SHA-256 mismatch: expected=$EXPECTED_RAW_SHA256 actual=$actual_raw_sha256"
 
 grep -Fq 'pub var NC_BIG_CODE: [i8; 8388608] = [0; 8388608]' "$ROOT/self-hosted/native/encode.sio" \
   || fail '8 MiB BSS code tier is absent'
 grep -Fq 'pub fn nc_code_capacity_bytes() -> i64 { 8388608 }' "$ROOT/self-hosted/native/encode.sio" \
   || fail 'checked code capacity does not match the BSS tier'
+grep -Fq 'offset >= 0 && offset < nc_code_capacity_bytes()' "$ROOT/self-hosted/native/encode.sio" \
+  || fail 'code boundary predicate is not strict at capacity'
+grep -Fq 'if nc_code_offset_is_writable(offset) { return 0 }' "$ROOT/self-hosted/native/encode.sio" \
+  || fail 'code exhaustion status is not tied to the boundary predicate'
 grep -Fq 'fn witness_code_capacity_bytes() -> i64 { 8388608 }' "$WITNESS" \
   || fail 'boundary witness is not tied to the checked code tier'
+grep -Fq 'fn witness_flat_reloc_capacity() -> i64 { 131072 }' "$WITNESS" \
+  || fail 'boundary witness is not tied to the checked relocation tier'
 grep -Fq 'var NC_BIG_ELF: [i8; 16777216] = [0; 16777216]' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
   || fail '16 MiB BSS ELF tier is absent'
+grep -Fq 'fn nc_elf_capacity_bytes() -> i64 { 16777216 }' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'checked ELF capacity does not match the BSS tier'
+grep -Fq 'if file_len <= 64 || file_len > nc_elf_capacity_bytes() { return 13 }' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'ELF preflight is not tied to checked capacity'
 grep -Fq 'NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1' "$ROOT/self-hosted/native/encode.sio" \
   || fail 'overflow accounting is absent from shared emitters'
 grep -Fq 'if nc.code_overflow || NC_CODE_OVERFLOWED {' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
   || fail 'active finalizer does not preserve rc19 exhaustion handling'
+grep -Fq '(*nc).flat_reloc_count = nc_flat_reloc_capacity() + 1' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'flat relocation overflow sentinel is absent'
+grep -Fq 'fn nc_flat_reloc_capacity() -> i64 { 131072 }' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'checked relocation capacity does not match the measured tier'
+for reloc_array in NC_FLAT_RELOC_OFFSETS NC_FLAT_RELOC_KIND_CODES NC_FLAT_RELOC_IS_FUNCTIONS NC_FLAT_RELOC_TARGET_INDICES; do
+  grep -Fq "pub var ${reloc_array}: [i64; 131072] = [0; 131072]" "$ROOT/self-hosted/native/frame.sio" \
+    || fail "relocation BSS tier mismatch for ${reloc_array}"
+done
+grep -Fq 'if NC_FLAT_RELOC_DROPPED > 0 || nc.flat_reloc_count > nc_flat_reloc_capacity() {' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'flat relocation overflow is not rejected before ELF write'
+grep -Fq 'return 20' "$ROOT/self-hosted/native/codegen_x86_linux.sio" \
+  || fail 'flat relocation exhaustion does not have a deterministic status'
 
 if rg -n 'len < 2097152|jns_pos \+ 1 < 2097152|NC_BIG_ELF.*4194304|\(text_offset \+ i\) < 4194304|\(rodata_offset \+ i\) < 4194304' \
   "$ROOT/self-hosted/native/encode.sio" \
@@ -46,7 +74,8 @@ MADAROS_RAW_BIN="$RAW_MADAROS" "$MADAROS" run "$WITNESS" >"$work/run.log" 2>&1 |
   fail 'boundary witness did not run'
 }
 cat "$work/run.log"
-grep -Fxq 'PASS native_code_capacity below_at_above rc19' "$work/run.log" \
+grep -Fxq 'PASS native_code_capacity below_at_above rc19 reloc_rc20' "$work/run.log" \
   || fail 'exact boundary PASS receipt absent'
 
 printf 'madaros-native-code-capacity gate: PASS\n'
+printf 'madaros-native-code-capacity receipt madaros_sha256=%s\n' "$actual_raw_sha256"

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -1178,14 +1178,9 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
-    if len >= 0 && len < nc_code_capacity_bytes() {
+    if len >= 0 && len < 2097152 {
         NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
-    } else {
-        NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1
-        NC_CODE_OVERFLOWED = true
-        (*nc).code_overflow = true
     }
 }
 

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -1178,7 +1178,7 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    if len >= 0 && len < 2097152 {
+    if nc_code_offset_is_writable(len) {
         NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
     }
@@ -2912,7 +2912,7 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
     // Patch jns displacement
     let neg_block_len = c.code.len - (jns_pos + 2)
-    if jns_pos + 1 < 2097152 {
+    if nc_code_offset_is_writable(jns_pos + 1) {
         NC_BIG_CODE[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
     }
 

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -1178,9 +1178,14 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    if len >= 0 && len < 2097152 {
+    NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
+    if len >= 0 && len < nc_code_capacity_bytes() {
         NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
+    } else {
+        NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1
+        NC_CODE_OVERFLOWED = true
+        (*nc).code_overflow = true
     }
 }
 

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -1412,10 +1412,13 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
-    if len >= 0 && len < 2097152 {
+    NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
+    if len >= 0 && len < nc_code_capacity_bytes() {
         NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
     } else {
+        NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1
+        NC_CODE_OVERFLOWED = true
         (*nc).code_overflow = true
     }
 }
@@ -10109,7 +10112,20 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
     // Machine code exceeded the 2MB NC_BIG_CODE buffer. nc_emit_byte drops
     // further bytes and sets code_overflow, which would leave a truncated ELF.
     // Fail with a distinct rc instead of writing a binary that crashes.
-    if nc.code_overflow {
+    if str_eq(read_env("SOUNIO_DUMP_NATIVE_CODE_CAPACITY"), "1") {
+        print("NATIVE_CODE_CAPACITY capacity=")
+        print_int(nc_code_capacity_bytes())
+        print(" emitted=")
+        print_int(nc.code.len)
+        print(" required=")
+        print_int(NC_CODE_REQUIRED_BYTES)
+        print(" dropped=")
+        print_int(NC_CODE_DROPPED_BYTES)
+        print(" overflow=")
+        print_int(if nc.code_overflow || NC_CODE_OVERFLOWED { 1 } else { 0 })
+        print("\n")
+    }
+    if nc.code_overflow || NC_CODE_OVERFLOWED {
         return 19
     }
     native_v2_write_min_elf64_to_file(output_path, &! nc, entry, 4194304)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -10032,6 +10032,10 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
 
     native_v2_trace_module_ir_ref(module)
 
+    NC_CODE_REQUIRED_BYTES = 0
+    NC_CODE_DROPPED_BYTES = 0
+    NC_CODE_OVERFLOWED = false
+
     var nc = compiler_new()
     compile_module_streaming_begin_into(&! nc, module)
     var fi: i64 = 0

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -50,7 +50,7 @@ var NC_FLAT_RELOC_REQUIRED: i64 = 0
 var NC_FLAT_RELOC_DROPPED: i64 = 0
 
 fn nc_elf_capacity_bytes() -> i64 { 16777216 }
-fn nc_flat_reloc_capacity() -> i64 { 65536 }
+fn nc_flat_reloc_capacity() -> i64 { 131072 }
 // Scratch IR functions for the sret witness. These are module-scope to avoid
 // putting IrFunction-sized temporaries on the Madaros runtime stack.
 var NV2_SRET_MAIN_FN: IrFunction = ir_empty_function()

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -45,7 +45,12 @@ var NATIVE_ELF_OFF: i64 = 0
 // for large programs (isa ELF ~700KB, evm ~2.1MB) and itself a large-stack-frame
 // hazard. This module-global BSS array (demand-paged, ~0 RSS until touched) holds
 // the assembled ELF image. Written INLINE only (direct NC_BIG_ELF[i]).
-var NC_BIG_ELF: [i8; 4194304] = [0; 4194304]
+var NC_BIG_ELF: [i8; 16777216] = [0; 16777216]
+var NC_FLAT_RELOC_REQUIRED: i64 = 0
+var NC_FLAT_RELOC_DROPPED: i64 = 0
+
+fn nc_elf_capacity_bytes() -> i64 { 16777216 }
+fn nc_flat_reloc_capacity() -> i64 { 65536 }
 // Scratch IR functions for the sret witness. These are module-scope to avoid
 // putting IrFunction-sized temporaries on the Madaros runtime stack.
 var NV2_SRET_MAIN_FN: IrFunction = ir_empty_function()
@@ -1413,7 +1418,7 @@ fn emit_store_runtime_context_imm(nc: NativeCompiler, field_offset: i64, value: 
 fn nc_emit_byte(nc: &! NativeCompiler, b: i64) with Mut, Panic, Div {
     let len = (*nc).code.len
     NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
-    if len >= 0 && len < nc_code_capacity_bytes() {
+    if nc_code_offset_is_writable(len) {
         NC_BIG_CODE[len as usize] = low8(b) as i8
         (*nc).code.len = len + 1
     } else {
@@ -1672,12 +1677,18 @@ fn nc_patch_u32_le(nc: &! NativeCompiler, offset: i64, val: i64) with Mut, Panic
 
 fn nc_add_flat_reloc(nc: &! NativeCompiler, patch_offset: i64, kind_code: i64, is_function: i64, target_index: i64) with Mut, Panic, Div {
     let idx = (*nc).flat_reloc_count
-    if idx >= 0 && idx < 65536 {
+    NC_FLAT_RELOC_REQUIRED = NC_FLAT_RELOC_REQUIRED + 1
+    if idx >= 0 && idx < nc_flat_reloc_capacity() {
         NC_FLAT_RELOC_OFFSETS[idx as usize] = patch_offset
         NC_FLAT_RELOC_KIND_CODES[idx as usize] = kind_code
         NC_FLAT_RELOC_IS_FUNCTIONS[idx as usize] = is_function
         NC_FLAT_RELOC_TARGET_INDICES[idx as usize] = target_index
         (*nc).flat_reloc_count = idx + 1
+    } else {
+        NC_FLAT_RELOC_DROPPED = NC_FLAT_RELOC_DROPPED + 1
+        // Preserve a scalar overflow sentinel after the fixed BSS table fills.
+        // Relocation application stays bounded, and finalization refuses the ELF.
+        (*nc).flat_reloc_count = nc_flat_reloc_capacity() + 1
     }
 }
 
@@ -4635,7 +4646,7 @@ fn emit_builtin_print_f64(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
     // Patch jns displacement
     let neg_block_len = c.code.len - (jns_pos + 2)
-    if jns_pos + 1 < 2097152 {
+    if nc_code_offset_is_writable(jns_pos + 1) {
         NC_BIG_CODE[(jns_pos + 1) as usize] = low8(neg_block_len) as i8
     }
 
@@ -4914,7 +4925,7 @@ fn native_v2_reloc_is_rip_disp_patch(nc: &NativeCompiler, patch_offset: i64) -> 
 
 fn apply_relocations_into(nc: &! NativeCompiler, rodata_file_offset: i64, data_file_offset: i64) with Mut, Panic, Div {
     var i = 0
-    while i < (*nc).flat_reloc_count && i < 65536 {
+    while i < (*nc).flat_reloc_count && i < nc_flat_reloc_capacity() {
         let patch_offset = NC_FLAT_RELOC_OFFSETS[i as usize]
         let kind_code = NC_FLAT_RELOC_KIND_CODES[i as usize]
         let is_function = NC_FLAT_RELOC_IS_FUNCTIONS[i as usize]
@@ -9799,7 +9810,7 @@ fn compile_to_elf_v2(module: &IrModule, base_addr: i64) -> NativeCompileResult w
 }
 
 fn native_v2_file_put_u8(pos: i64, val: i64) with Mut, Panic {
-    if pos >= 0 && pos < 4194304 {
+    if pos >= 0 && pos < nc_elf_capacity_bytes() {
         NC_BIG_ELF[pos as usize] = (val & 255) as i8
     }
 }
@@ -9857,7 +9868,7 @@ fn native_v2_write_min_elf64_to_file(output_path: string, nc: &! NativeCompiler,
     if data_len > 0 {
         file_len = data_offset + data_len
     }
-    if file_len <= 64 || file_len > 4194304 { return 13 }
+    if file_len <= 64 || file_len > nc_elf_capacity_bytes() { return 13 }
 
     // Zero the used region of the off-stack ELF image buffer (NC_BIG_ELF is a BSS
     // global — zero at process start, but re-zero here so page-alignment padding
@@ -9927,20 +9938,20 @@ fn native_v2_build_elf_image_into(nc: &! NativeCompiler, base_addr: i64, entry_o
     native_v2_file_emit_phdr(phoff, 0x6474e551, 6, 0, 0, 0, 0, 16)
 
     var i: i64 = 0
-    while i < code_len && (text_offset + i) < 4194304 {
+    while i < code_len && (text_offset + i) < nc_elf_capacity_bytes() {
         NC_BIG_ELF[(text_offset + i) as usize] = NC_BIG_CODE[i as usize]
         i = i + 1
     }
 
     if (*nc).flat_rodata_len > 0 {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 4194304 {
+        while i < rodata_len && (rodata_offset + i) < nc_elf_capacity_bytes() {
             NC_BIG_ELF[(rodata_offset + i) as usize] = (*nc).flat_rodata_bytes[i as usize]
             i = i + 1
         }
     } else {
         i = 0
-        while i < rodata_len && (rodata_offset + i) < 4194304 {
+        while i < rodata_len && (rodata_offset + i) < nc_elf_capacity_bytes() {
             NC_BIG_ELF[(rodata_offset + i) as usize] = (*nc).rodata.bytes[i as usize]
             i = i + 1
         }
@@ -10032,9 +10043,9 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
 
     native_v2_trace_module_ir_ref(module)
 
-    NC_CODE_REQUIRED_BYTES = 0
-    NC_CODE_DROPPED_BYTES = 0
-    NC_CODE_OVERFLOWED = false
+    nc_code_capacity_reset()
+    NC_FLAT_RELOC_REQUIRED = 0
+    NC_FLAT_RELOC_DROPPED = 0
 
     var nc = compiler_new()
     compile_module_streaming_begin_into(&! nc, module)
@@ -10113,7 +10124,7 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
     let entry = trampoline_offset(nc)
     nc.bss_total_size = (*module).bss_total_size
     if nc.bss_total_size < 8 { nc.bss_total_size = 8 }
-    // Machine code exceeded the 2MB NC_BIG_CODE buffer. nc_emit_byte drops
+    // Machine code exceeded the bounded NC_BIG_CODE tier. nc_emit_byte drops
     // further bytes and sets code_overflow, which would leave a truncated ELF.
     // Fail with a distinct rc instead of writing a binary that crashes.
     if str_eq(read_env("SOUNIO_DUMP_NATIVE_CODE_CAPACITY"), "1") {
@@ -10127,10 +10138,19 @@ pub fn compile_native_v2_preview_to_file(module: &IrModule, target_spec: NativeT
         print_int(NC_CODE_DROPPED_BYTES)
         print(" overflow=")
         print_int(if nc.code_overflow || NC_CODE_OVERFLOWED { 1 } else { 0 })
+        print(" relocs=")
+        print_int(NC_FLAT_RELOC_REQUIRED)
+        print(" reloc_dropped=")
+        print_int(NC_FLAT_RELOC_DROPPED)
+        print(" elf_capacity=")
+        print_int(nc_elf_capacity_bytes())
         print("\n")
     }
     if nc.code_overflow || NC_CODE_OVERFLOWED {
         return 19
+    }
+    if NC_FLAT_RELOC_DROPPED > 0 || nc.flat_reloc_count > nc_flat_reloc_capacity() {
+        return 20
     }
     native_v2_write_min_elf64_to_file(output_path, &! nc, entry, 4194304)
 }

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -23,6 +23,14 @@ pub struct CodeBuffer {
 // needed. Accessed INLINE only — never via a returning helper (miscompiles under
 // the seed). NOT used by the aarch64/suite scratch-buffer paths (those keep .bytes).
 pub var NC_BIG_CODE: [i8; 2097152] = [0; 2097152]
+// Capacity accounting is scalar global state because both by-value and by-ref
+// emitters append to NC_BIG_CODE. It records demand even after storage is full,
+// while code.len remains the number of bytes actually materialized.
+pub var NC_CODE_REQUIRED_BYTES: i64 = 0
+pub var NC_CODE_DROPPED_BYTES: i64 = 0
+pub var NC_CODE_OVERFLOWED: bool = false
+
+pub fn nc_code_capacity_bytes() -> i64 { 2097152 }
 
 pub fn code_buffer_new() -> CodeBuffer {
     var out: CodeBuffer
@@ -71,21 +79,25 @@ pub fn wide_copy_from_code_buffer(dst: WideCodeBuffer, src: CodeBuffer) -> WideC
 
 pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
     var out = buf
-    if out.len >= 0 {
-        if out.len < 2097152 {
-            NC_BIG_CODE[out.len as usize] = low8(b) as i8
-            out.len = out.len + 1
-        }
+    NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
+    if out.len >= 0 && out.len < nc_code_capacity_bytes() {
+        NC_BIG_CODE[out.len as usize] = low8(b) as i8
+        out.len = out.len + 1
+    } else {
+        NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1
+        NC_CODE_OVERFLOWED = true
     }
     out
 }
 
 pub fn emit_byte_mut(buf: &! CodeBuffer, b: i64) with Mut, Panic, Div {
-    if (*buf).len >= 0 {
-        if (*buf).len < 2097152 {
-            NC_BIG_CODE[(*buf).len as usize] = low8(b) as i8
-            (*buf).len = (*buf).len + 1
-        }
+    NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
+    if (*buf).len >= 0 && (*buf).len < nc_code_capacity_bytes() {
+        NC_BIG_CODE[(*buf).len as usize] = low8(b) as i8
+        (*buf).len = (*buf).len + 1
+    } else {
+        NC_CODE_DROPPED_BYTES = NC_CODE_DROPPED_BYTES + 1
+        NC_CODE_OVERFLOWED = true
     }
 }
 

--- a/self-hosted/native/encode.sio
+++ b/self-hosted/native/encode.sio
@@ -22,7 +22,10 @@ pub struct CodeBuffer {
 // to the same global at the shared offset, so no persist/call-site changes are
 // needed. Accessed INLINE only — never via a returning helper (miscompiles under
 // the seed). NOT used by the aarch64/suite scratch-buffer paths (those keep .bytes).
-pub var NC_BIG_CODE: [i8; 2097152] = [0; 2097152]
+// The first measured whole-SOIR compile required 5,355,994 bytes. Keep the
+// bootstrap-safe BSS representation and select the next established tier (8 MiB),
+// leaving 3,032,614 bytes of measured headroom without growing NativeCompiler.
+pub var NC_BIG_CODE: [i8; 8388608] = [0; 8388608]
 // Capacity accounting is scalar global state because both by-value and by-ref
 // emitters append to NC_BIG_CODE. It records demand even after storage is full,
 // while code.len remains the number of bytes actually materialized.
@@ -30,7 +33,27 @@ pub var NC_CODE_REQUIRED_BYTES: i64 = 0
 pub var NC_CODE_DROPPED_BYTES: i64 = 0
 pub var NC_CODE_OVERFLOWED: bool = false
 
-pub fn nc_code_capacity_bytes() -> i64 { 2097152 }
+pub fn nc_code_capacity_bytes() -> i64 { 8388608 }
+
+pub fn nc_code_offset_is_writable(offset: i64) -> bool {
+    offset >= 0 && offset < nc_code_capacity_bytes()
+}
+
+pub fn nc_code_emit_offset_status(offset: i64) -> i32 {
+    if nc_code_offset_is_writable(offset) { return 0 }
+    19
+}
+
+pub fn nc_code_capacity_status() -> i32 {
+    if NC_CODE_OVERFLOWED { return 19 }
+    0
+}
+
+pub fn nc_code_capacity_reset() with Mut {
+    NC_CODE_REQUIRED_BYTES = 0
+    NC_CODE_DROPPED_BYTES = 0
+    NC_CODE_OVERFLOWED = false
+}
 
 pub fn code_buffer_new() -> CodeBuffer {
     var out: CodeBuffer
@@ -80,7 +103,7 @@ pub fn wide_copy_from_code_buffer(dst: WideCodeBuffer, src: CodeBuffer) -> WideC
 pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
     var out = buf
     NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
-    if out.len >= 0 && out.len < nc_code_capacity_bytes() {
+    if nc_code_offset_is_writable(out.len) {
         NC_BIG_CODE[out.len as usize] = low8(b) as i8
         out.len = out.len + 1
     } else {
@@ -92,7 +115,7 @@ pub fn emit_byte(buf: CodeBuffer, b: i64) -> CodeBuffer with Mut, Panic, Div {
 
 pub fn emit_byte_mut(buf: &! CodeBuffer, b: i64) with Mut, Panic, Div {
     NC_CODE_REQUIRED_BYTES = NC_CODE_REQUIRED_BYTES + 1
-    if (*buf).len >= 0 && (*buf).len < nc_code_capacity_bytes() {
+    if nc_code_offset_is_writable((*buf).len) {
         NC_BIG_CODE[(*buf).len as usize] = low8(b) as i8
         (*buf).len = (*buf).len + 1
     } else {

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -210,13 +210,15 @@ pub var NC_V2_NEXT_CMP_LABEL: i64 = 210
 // silently dropping every reloc past 4096, so calls/rodata refs (incl. the entry
 // trampoline's call to main) stay unpatched → jump to garbage → SIGSEGV. Raising
 // the inline arrays would add ~2MB to NativeCompiler's stack frame (rc=14 zone),
-// so they live off-stack here (BSS, demand-paged). flat_reloc_count stays a scalar
+// so they live off-stack here (BSS, demand-paged). The first whole-SOIR compile
+// after lifting the code tier required 102,202 entries, so the table uses the next
+// power-of-two tier (131,072). flat_reloc_count stays a scalar
 // in NativeCompiler and indexes these. Accessed INLINE only (never a returning
 // helper — that miscompiles under the seed).
-pub var NC_FLAT_RELOC_OFFSETS: [i64; 65536] = [0; 65536]
-pub var NC_FLAT_RELOC_KIND_CODES: [i64; 65536] = [0; 65536]
-pub var NC_FLAT_RELOC_IS_FUNCTIONS: [i64; 65536] = [0; 65536]
-pub var NC_FLAT_RELOC_TARGET_INDICES: [i64; 65536] = [0; 65536]
+pub var NC_FLAT_RELOC_OFFSETS: [i64; 131072] = [0; 131072]
+pub var NC_FLAT_RELOC_KIND_CODES: [i64; 131072] = [0; 131072]
+pub var NC_FLAT_RELOC_IS_FUNCTIONS: [i64; 131072] = [0; 131072]
+pub var NC_FLAT_RELOC_TARGET_INDICES: [i64; 131072] = [0; 131072]
 
 // ============================================================================
 // Compiler state

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -329,9 +329,6 @@ pub struct NativeCompiler {
 
 pub fn compiler_new() -> NativeCompiler {
     var out: NativeCompiler
-    NC_CODE_REQUIRED_BYTES = 0
-    NC_CODE_DROPPED_BYTES = 0
-    NC_CODE_OVERFLOWED = false
     out.code = code_buffer_new()
     out.code_overflow = false
     out.relocs = reloc_table_new()

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -329,6 +329,9 @@ pub struct NativeCompiler {
 
 pub fn compiler_new() -> NativeCompiler {
     var out: NativeCompiler
+    NC_CODE_REQUIRED_BYTES = 0
+    NC_CODE_DROPPED_BYTES = 0
+    NC_CODE_OVERFLOWED = false
     out.code = code_buffer_new()
     out.code_overflow = false
     out.relocs = reloc_table_new()

--- a/self-hosted/native/test_code_capacity.sio
+++ b/self-hosted/native/test_code_capacity.sio
@@ -1,0 +1,35 @@
+// Executable model of encode.sio's checked bound. This stays standalone because
+// the current modular linker does not include imported module-global BSS in the
+// witness segment; the gate mechanically ties these constants to encode.sio.
+fn witness_code_capacity_bytes() -> i64 { 8388608 }
+
+fn witness_code_offset_is_writable(offset: i64) -> bool {
+    offset >= 0 && offset < witness_code_capacity_bytes()
+}
+
+fn witness_code_emit_offset_status(offset: i64) -> i32 {
+    if witness_code_offset_is_writable(offset) { return 0 }
+    19
+}
+
+fn fail_capacity_case(name: string) -> i32 with IO {
+    print("FAIL native_code_capacity ")
+    print(name)
+    print("\n")
+    1
+}
+
+fn main() -> i32 with IO {
+    let capacity = witness_code_capacity_bytes()
+
+    if capacity != 8388608 { return fail_capacity_case("unexpected_tier") }
+    if !witness_code_offset_is_writable(capacity - 1) { return fail_capacity_case("below_rejected") }
+    if witness_code_offset_is_writable(capacity) { return fail_capacity_case("at_accepted") }
+    if witness_code_offset_is_writable(capacity + 1) { return fail_capacity_case("above_accepted") }
+    if witness_code_emit_offset_status(capacity - 1) != 0 { return fail_capacity_case("below_status") }
+    if witness_code_emit_offset_status(capacity) != 19 { return fail_capacity_case("at_not_rc19") }
+    if witness_code_emit_offset_status(capacity + 1) != 19 { return fail_capacity_case("above_not_rc19") }
+
+    print("PASS native_code_capacity below_at_above rc19\n")
+    0
+}

--- a/self-hosted/native/test_code_capacity.sio
+++ b/self-hosted/native/test_code_capacity.sio
@@ -12,6 +12,13 @@ fn witness_code_emit_offset_status(offset: i64) -> i32 {
     19
 }
 
+fn witness_flat_reloc_capacity() -> i64 { 131072 }
+
+fn witness_flat_reloc_offset_status(offset: i64) -> i32 {
+    if offset >= 0 && offset < witness_flat_reloc_capacity() { return 0 }
+    20
+}
+
 fn fail_capacity_case(name: string) -> i32 with IO {
     print("FAIL native_code_capacity ")
     print(name)
@@ -30,6 +37,11 @@ fn main() -> i32 with IO {
     if witness_code_emit_offset_status(capacity) != 19 { return fail_capacity_case("at_not_rc19") }
     if witness_code_emit_offset_status(capacity + 1) != 19 { return fail_capacity_case("above_not_rc19") }
 
-    print("PASS native_code_capacity below_at_above rc19\n")
+    let reloc_capacity = witness_flat_reloc_capacity()
+    if witness_flat_reloc_offset_status(reloc_capacity - 1) != 0 { return fail_capacity_case("reloc_below_status") }
+    if witness_flat_reloc_offset_status(reloc_capacity) != 20 { return fail_capacity_case("reloc_at_not_rc20") }
+    if witness_flat_reloc_offset_status(reloc_capacity + 1) != 20 { return fail_capacity_case("reloc_above_not_rc20") }
+
+    print("PASS native_code_capacity below_at_above rc19 reloc_rc20\n")
     0
 }


### PR DESCRIPTION
## Status

**DO NOT MERGE.** Stacked on #956. This PR closes the x86-64/Linux native code and relocation capacity blocker, while preserving the newly exposed SOIR differential runtime failure as a separate downstream blocker.

## Measured design

- Initial whole-SOIR demand: code capacity `2,097,152`, required `5,355,994`, dropped `3,258,842`, deterministic `rc=19`.
- Code tier: `8 MiB` BSS, the next existing boot4 profile above measured demand (`3,032,614` bytes / `56.6%` headroom).
- Coupled ELF tier: guarded `16 MiB` BSS with a complete preflight; no routing through the unguarded alternate writer.
- First 8 MiB rerun: code `5,355,994/5,355,994`, but relocations required `102,202` versus `65,536`; `36,666` dropped and deterministic `rc=20`.
- Relocation tier: `131,072` entries in four off-stack BSS arrays, next power of two (`28,870` / `28.2%` headroom).

This is intentionally bounded and x86-64/Linux-only. AArch64/Mach-O remain out of scope. The historical dynamic CodeBuffer experiment remains unmerged; this lane keeps the bootstrap-proven BSS model.

## Implementation

- Central checked code/ELF/relocation capacities.
- Demand and dropped-byte receipts across by-value and by-reference emitters.
- Stable relocation overflow sentinel; application remains bounded.
- `rc19` remains exclusively code exhaustion; relocation exhaustion is `rc20`.
- Below/at/above boundary adversaries plus required raw-artifact SHA-256 pin.
- Legacy codegen remains present; no SOIR writer, serializer, lowerer, raw-field, or import-sidecar source was changed.

## Exact evidence

Final source-fresh workflow artifact:

- source SHA: `b2362d910ba4236a993c6eaf155e2ed275983909`
- workflow: https://github.com/Sounio-lang/sounio/actions/runs/29388717325
- artifact SHA-256: `833c22d99334258e6644df832c3efb9beeebc77ffc17a547e3ca4a2b73c73914`
- artifact size: `107,760,760` bytes

Final whole-SOIR receipt:

```text
NATIVE_CODE_CAPACITY capacity=8388608 emitted=5355994 required=5355994 dropped=0 overflow=0 relocs=102202 reloc_dropped=0 elf_capacity=16777216
Written to .../main.elf
Compilation successful!
```

Other gates:

- `madaros_native_code_capacity_gate.sh`: PASS with pinned final artifact SHA
- missing SHA adversary: expected `rc=1`
- wrong SHA adversary: expected `rc=1`
- `madaros_imported_struct_reassignment_gate.sh`: PASS
- `madaros_visibility_context_gate.sh`: PASS
- orthogonal review: no implementation findings; off-by-one, BSS placement, rc19/rc20 ordering and forbidden-file scope confirmed

## Remaining blockers

1. The workflow soft-gates on an existing `madaros_full_gate.sh` raw-directory diagnostic mismatch (banner only; expected `could not read input file`). The build itself succeeds and uploads the artifact.
2. With capacity now removed, the SOIR witness executes and reports `FAIL soir_writer_v0_differential`. Read-only diagnostic copy classified subcases as `empty=0 populated=0 rejections=1 v4=0`. This is downstream writer/legacy/decode semantics, not capacity; no forbidden SOIR source was edited here.

No LLM offload was required: compiler capacity mechanics only; no math claim, clinical pathway, or external-facing artifact changed.