### PR TITLE
[DO NOT MERGE] Add scalar ModuleId empty-module shadow store

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 959
-- Repo-backed topics: 809
+- Total governed topics: 960
+- Repo-backed topics: 810
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 559
+- Authority count `repo_only`: 560
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 578 topics
+- A2: 579 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -408,6 +408,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.epistemic-numeric-value | repo_only | docs/internal/concepts/epistemic-numeric-value.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.ir-module-arena-v2 | repo_only | docs/internal/concepts/ir-module-arena-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.ir-storage-ownership | repo_only | docs/internal/concepts/ir-storage-ownership.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.physical-observation | repo_only | docs/internal/concepts/physical-observation.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8863,6 +8863,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.ir-module-arena-v2",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/ir-module-arena-v2.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.ir-storage-ownership",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/ir-storage-ownership.md",

--- a/docs/internal/concepts/ir-module-arena-v2.md
+++ b/docs/internal/concepts/ir-module-arena-v2.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.ir-module-arena-v2
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.ir-module-arena-v2
+-->
+
 # IrModuleArena v2 Shadow Kernel
 
 Status: shadow prototype; not a canonical IR representation
@@ -35,7 +44,7 @@ and public getters borrow the arena shared. No operation loads a whole
 
 ```text
 Semantic-Lane-ID: IR-MODULE-ARENA-V2-SHADOW
-Owner: codex/irmodule-arena-v2-shadow-20260714
+Owner: codex/irmodule-arena-v2-shadow-20260715
 Concept-IDs: SOUNIO-IR-STORAGE-OWNERSHIP
 Intent-Preserved: IR identity and provenance must not disappear across a storage migration.
 Transformation: introduce an unintegrated bounded ownership kernel with typed generational handles and one arena authority.
@@ -71,6 +80,37 @@ shadow kernel
 -> bounded repeated-use lifecycle
 -> selected read-path switch
 -> legacy retirement only after explicit parity authority
+```
+
+## Empty-module store slice
+
+The stacked 2026-07-15 slice adds a multi-module store without widening the
+legacy aggregate. `IrModuleArenaV2ModuleId` contains arena identity, slot, and
+generation. The singleton shadow arena owns only individual scalar columns for module identity and the
+empty-state counters required by the first differential boundary: functions,
+strings, epistemic entries, models, contests, algebras, ontologies, and BSS.
+
+Allocation zeroes every column before publishing the ID through a caller-owned
+out parameter. Reads validate the ID and project scalar predicates directly;
+no API accepts or returns `IrModule`, a store aggregate, or a projection
+aggregate. A read-only scalar adapter defines the future comparison boundary
+for observations borrowed from the legacy module. This gate supplies the
+declared legacy-zero contract but does not execute the heap bridge. It deliberately
+does not call `ir_empty_module()`, whose 404,144,224-byte by-value return is the
+failure this architecture is intended to retire.
+
+The witness distinguishes two live modules, rejects duplicate, cross-arena,
+stale, and over-capacity IDs, proves one module's BSS mutation cannot change
+another module, and proves reset invalidates old generations before a reused
+slot is published in exact empty state.
+
+```text
+Claims-Introduced: the bounded shadow module store publishes deterministic empty modules through stable generation-checked caller-owned ModuleIds and scalar read-only projections.
+Claims-Forbidden: legacy IrModule replacement; writer integration; full epistemic payload storage; canonical ModuleId minting; performance or memory-reduction claims.
+Positive-Witness: two distinct exact-empty modules, independent scalar columns, deterministic reset, and the prepared scalar legacy-zero contract.
+Negative-Witness: duplicate identity, cross-arena ID, stale generation, invalid store identity, negative BSS, and capacity overflow fail closed.
+Integration-Target: shadow-only continuation stacked on PR #961; default compiler and writer remain unwired.
+Authoritative-Only-If: later differential traces populate real sections and match legacy observable semantics without any by-value IrModule boundary.
 ```
 
 ## Honest boundary

--- a/docs/internal/concepts/ir-module-arena-v2.md
+++ b/docs/internal/concepts/ir-module-arena-v2.md
@@ -1,0 +1,98 @@
+# IrModuleArena v2 Shadow Kernel
+
+Status: shadow prototype; not a canonical IR representation
+Concept-ID: `SOUNIO-IR-STORAGE-OWNERSHIP`
+
+The old heap bridge proved that moving a fixed `IrModule` off the stack does
+not by itself establish one ownership model. Its raw two-GiB reservation is
+released by `heap_free`, while the graph reachable through its aggregate
+fields is owned separately by either `lean_single`'s never-reset `AGG_POOL` or
+native-v2's `RuntimeContext` handle table. Issue #884 records the missing
+repeated-use lifecycle. Issue #877 separately records that an owner value can
+still be copied or aliased because linear state threading is not yet enforced.
+
+`IrModuleArenaV2` starts a replacement architecture without changing that
+legacy path. It is a bounded, columnar shadow kernel with one ownership
+authority for its entire graph. Function and instruction slots belong to the
+arena itself; there are no child allocations in another runtime. A handle is:
+
+```text
+FunctionHandle = (arena_identity, module_identity, function_slot, generation)
+InstrHandle    = (arena_identity, module_identity, instruction_slot, generation)
+```
+
+The handle types are distinct. Every read and mutation validates arena state,
+both stable identities, slot bounds, slot state, and generation. Removing a
+slot increments its generation before reuse, so an old handle cannot revive
+through ABA. Releasing the arena invalidates all live generations and performs
+one logical reclaim. A repeated release returns `ALREADY_RELEASED` and cannot
+record a second reclaim.
+
+The tables store scalar columns rather than canonical aggregate values. Raw
+setters are private and range-validated; public commands express operations,
+and public getters borrow the arena shared. No operation loads a whole
+`IrFunction` or `IrInstr`, mutates a local copy, and republishes it.
+
+```text
+Semantic-Lane-ID: IR-MODULE-ARENA-V2-SHADOW
+Owner: codex/irmodule-arena-v2-shadow-20260714
+Concept-IDs: SOUNIO-IR-STORAGE-OWNERSHIP
+Intent-Preserved: IR identity and provenance must not disappear across a storage migration.
+Transformation: introduce an unintegrated bounded ownership kernel with typed generational handles and one arena authority.
+Types-Changed: adds shadow-only IrModuleArenaV2, IrModuleArenaV2FunctionHandle, and IrModuleArenaV2InstrHandle; canonical IR types are unchanged.
+Effects-Changed: none in the default compiler; shadow mutation requires Mut, Panic, and Div.
+IR-Changed: none in the default compiler or SOIR wire format.
+Claims-Introduced: the bounded shadow model rejects stale, ABA, cross-arena, cross-module, released, capacity, and setter-range violations in its named witness.
+Claims-Forbidden: canonical replacement; compile-time unique/noncopyable authority; physical memory reclamation; RuntimeContext lifecycle repair; unbounded capacity; SOIR parity; default-pipeline use.
+Assumptions: positive arena_identity and module_identity are caller-assigned unique values; production identity minting is not specified by this prototype.
+Write-Set: self-hosted/ir/arena_v2_shadow.sio, tests/native-v2/ir_module_arena_v2_shadow_witness.sio, scripts/ci/ir_module_arena_v2_shadow_gate.sh, docs/internal/concepts/ir-module-arena-v2.md.
+Read-Set: self-hosted/ir/heap_storage.sio, self-hosted/native/runtime_context.sio, self-hosted/native/gc.sio, self-hosted/native/codegen_x86_linux.sio, self-hosted/compiler/lean_single.sio.
+Positive-Witness: bounded source-check and runtime probe over typed handles, generation reuse, private validated mutation, capacities, and exactly-once logical release.
+Negative-Witness: stale generation, cross-arena identity, cross-module identity, mutation range, capacity overflow, stale-after-release, and double release all fail closed.
+Acceptance-Gate: bash scripts/ci/ir_module_arena_v2_shadow_gate.sh.
+Integration-Target: shadow-only stack after draft #889; no default compiler integration.
+Authoritative-Only-If: a later lane proves differential semantic parity with canonical IrModule and SOIR, resolves #877 authority linearity, resolves #884 repeated-use reclamation, and then explicitly switches readers.
+```
+
+## Differential migration
+
+The legacy bridge remains executable and unchanged. It is the first oracle for
+the new path, not dead code to be deleted early. A later parity lane should run
+the same operation trace against both representations and compare observable
+IR identity, DefId provenance, instruction payload, ordering, SOIR bytes, and
+failure category. Only an exact receipt may move a reader to v2.
+
+The intended sequence is:
+
+```text
+shadow kernel
+-> differential operation trace
+-> SOIR writer parity
+-> bounded repeated-use lifecycle
+-> selected read-path switch
+-> legacy retirement only after explicit parity authority
+```
+
+## Honest boundary
+
+This prototype demonstrates a coherent ownership state machine without using
+the two current managed-handle mechanisms. It does not yet enforce unique
+authority at the language type level: copying `IrModuleArenaV2` is forbidden
+by the contract but remains mechanically possible until #877 is resolved. Its
+release is logical because the bounded scalar tables are contained in the
+owner value; it is not evidence that native-v2 now reclaims RuntimeContext
+handles. Therefore #884 remains open.
+
+```text
+Semantic-Outcome: SHADOW_ONLY
+Concept-Status-Before: hypothesis
+Concept-Status-After: hypothesis; no registry promotion
+Distinctions-Added: raw reservation ownership != child graph ownership; logical arena release != RuntimeContext reclamation; generational validity != type-level linear authority
+Distinctions-Preserved: stable module identity; function/instruction type distinction; DefId-facing defining module identity; ordering; fail-closed access
+Distinctions-Erased: none
+Evidence-Run: scripts/ci/ir_module_arena_v2_shadow_gate.sh
+Fallback-Path: none
+Legacy-Kept: yes, as differential oracle
+Conflicting-Lanes: none in this all-new write set
+Next-Semantic-Interface: differential trace adapter shared with Place IR and SOIR Writer shadows
+```

--- a/scripts/ci/ir_module_arena_v2_shadow_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_shadow_gate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+SOURCE="self-hosted/ir/arena_v2_shadow.sio"
+WITNESS="tests/native-v2/ir_module_arena_v2_shadow_witness.sio"
+BASE="${IR_MODULE_ARENA_V2_BASE_SHA:-17b0858f6e7d75c9cfc9e545b1b9f0805fa9d5d6}"
+SOUC="${SOUC_BIN:-$ROOT/bin/souc}"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  printf 'IR_MODULE_ARENA_V2_SHADOW_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+[[ -f "$SOURCE" ]] || fail source_missing
+[[ -f "$WITNESS" ]] || fail witness_missing
+[[ -x "$SOUC" ]] || fail compiler_missing
+
+if grep -Eq '^[[:space:]]*use (native::runtime_context|ir::heap_storage|compiler::lean_single)' "$SOURCE" ||
+   grep -Eq '(^|[^[:alnum:]_])(heap_alloc|heap_free)[[:space:]]*\(' "$SOURCE"; then
+  fail forbidden_storage_dependency
+fi
+if grep -Eq ':[[:space:]]*(IrModule|IrFunction|IrInstr)([[:space:]],}]|$)' "$SOURCE"; then
+  fail aggregate_payload_storage_detected
+fi
+
+grep -Fq 'pub struct IrModuleArenaV2FunctionHandle' "$SOURCE" || fail typed_function_handle_missing
+grep -Fq 'pub struct IrModuleArenaV2InstrHandle' "$SOURCE" || fail typed_instr_handle_missing
+grep -Fq 'function_generation: [i64; 4]' "$SOURCE" || fail function_generation_missing
+grep -Fq 'instr_generation: [i64; 8]' "$SOURCE" || fail instr_generation_missing
+grep -Fq 'fn ir_module_arena_v2_set_function_reg_count_validated' "$SOURCE" || fail private_function_setter_missing
+grep -Fq 'fn ir_module_arena_v2_set_instr_payload_validated' "$SOURCE" || fail private_instr_setter_missing
+if grep -Eq '^pub fn ir_module_arena_v2_set_' "$SOURCE"; then
+  fail raw_setter_is_public
+fi
+
+for default_surface in self-hosted/ir/mod.sio self-hosted/compiler/main.sio scripts/bootstrap/bootstrap_concat.sh; do
+  if grep -Fq 'arena_v2_shadow' "$default_surface"; then
+    fail "shadow_imported_by_${default_surface//\//_}"
+  fi
+done
+
+if git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+  if ! git diff --quiet "$BASE" -- \
+      self-hosted/ir/heap_storage.sio \
+      self-hosted/ir/lower.sio \
+      self-hosted/native/codegen_x86_linux.sio \
+      self-hosted/native/runtime_context.sio \
+      self-hosted/ir/mod.sio \
+      self-hosted/compiler/main.sio \
+      scripts/bootstrap/bootstrap_concat.sh; then
+    fail legacy_or_default_surface_changed
+  fi
+else
+  fail base_sha_unavailable
+fi
+
+"$SOUC" check "$SOURCE" >"$TMP/source-check.log" 2>&1 || {
+  cat "$TMP/source-check.log" >&2
+  fail source_check
+}
+
+# The shadow is deliberately absent from the compiler's canonical module
+# bundle. Compose only inside this throwaway gate directory so checker/runtime
+# evidence does not require a default-pipeline import.
+COMPOSITE="$TMP/ir_module_arena_v2_shadow_composite.sio"
+sed '/^module ir::arena_v2_shadow$/d' "$SOURCE" >"$COMPOSITE"
+sed '/^use ir::arena_v2_shadow::\*$/d' "$WITNESS" >>"$COMPOSITE"
+
+"$SOUC" check "$COMPOSITE" >"$TMP/composite-check.log" 2>&1 || {
+  cat "$TMP/composite-check.log" >&2
+  fail composite_check
+}
+
+set +e
+"$SOUC" run "$COMPOSITE" >"$TMP/witness.out" 2>"$TMP/witness.err"
+run_rc=$?
+set -e
+if [[ "$run_rc" -ne 0 ]]; then
+  cat "$TMP/witness.out" >&2
+  cat "$TMP/witness.err" >&2
+  fail "witness_rc_$run_rc"
+fi
+grep -Fxq 'IR_MODULE_ARENA_V2_SHADOW_PASS' "$TMP/witness.out" || {
+  cat "$TMP/witness.out" >&2
+  fail witness_pass_marker_missing
+}
+if grep -Fq 'IR_MODULE_ARENA_V2_SHADOW_FAIL' "$TMP/witness.out"; then
+  cat "$TMP/witness.out" >&2
+  fail contradictory_witness_receipt
+fi
+
+compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_CHECK source=pass composite=pass'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_PROBE aba_function=pass aba_instr=pass cross_arena=pass cross_module=pass capacity=pass setter_bounds=pass stale_after_release=pass double_release=pass'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_DIFF legacy_surfaces=unchanged default_pipeline=unwired'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_SCOPE backing=bounded_scalar_tables authority=arena state=free_live_released handles=typed_generation_checked mutation=validated_scalar_only'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_ORACLE legacy=self-hosted/ir/heap_storage.sio mode=differential kept=yes replaced=no'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_NOT_SOLVED issue_877=compile_time_noncopyable_authority issue_884=runtime_managed_handle_lifecycle'
+printf 'IR_MODULE_ARENA_V2_SHADOW_PASS compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"

--- a/scripts/ci/ir_module_arena_v2_shadow_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_shadow_gate.sh
@@ -6,7 +6,7 @@ cd "$ROOT"
 
 SOURCE="self-hosted/ir/arena_v2_shadow.sio"
 WITNESS="tests/native-v2/ir_module_arena_v2_shadow_witness.sio"
-BASE="${IR_MODULE_ARENA_V2_BASE_SHA:-17b0858f6e7d75c9cfc9e545b1b9f0805fa9d5d6}"
+BASE="${IR_MODULE_ARENA_V2_BASE_SHA:-e4cc581be6e429c752b603ab9ad55ff4cafa921d}"
 SOUC="${SOUC_BIN:-$ROOT/bin/souc}"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
@@ -27,18 +27,45 @@ fi
 if grep -Eq ':[[:space:]]*(IrModule|IrFunction|IrInstr)([[:space:]],}]|$)' "$SOURCE"; then
   fail aggregate_payload_storage_detected
 fi
+if grep -Eq '(->|:)[[:space:]]*IrModule([[:space:]>,{]|$)' "$SOURCE" ||
+   grep -Fq 'ir_empty_module(' "$SOURCE"; then
+  fail legacy_irmodule_value_boundary_detected
+fi
 
 grep -Fq 'pub struct IrModuleArenaV2FunctionHandle' "$SOURCE" || fail typed_function_handle_missing
 grep -Fq 'pub struct IrModuleArenaV2InstrHandle' "$SOURCE" || fail typed_instr_handle_missing
 grep -Fq 'function_generation: [i64; 4]' "$SOURCE" || fail function_generation_missing
 grep -Fq 'instr_generation: [i64; 8]' "$SOURCE" || fail instr_generation_missing
+grep -Fq 'pub struct IrModuleArenaV2ModuleId' "$SOURCE" || fail stable_module_id_missing
+grep -Fq 'var IR_MODULE_ARENA_V2_MODULE_GENERATION_0: i64' "$SOURCE" || fail module_generation_missing
+if grep -Eq '^pub var IR_MODULE_ARENA_V2_MODULE_' "$SOURCE"; then
+  fail module_storage_is_public
+fi
+if grep -Eq '^var IR_MODULE_ARENA_V2_MODULE_[A-Z_]+: \[i64;' "$SOURCE"; then
+  fail module_global_aggregate_array_detected
+fi
+grep -Fq 'pub fn ir_module_arena_v2_module_store_init' "$SOURCE" || fail module_store_init_missing
+grep -Fq 'pub fn ir_module_arena_v2_project_empty_module' "$SOURCE" || fail empty_projection_missing
+grep -Fq 'pub fn ir_module_arena_v2_empty_matches_legacy_scalars' "$SOURCE" || fail legacy_scalar_adapter_missing
+grep -Fq 'pub fn ir_module_arena_v2_reset_modules' "$SOURCE" || fail deterministic_reset_missing
 grep -Fq 'fn ir_module_arena_v2_set_function_reg_count_validated' "$SOURCE" || fail private_function_setter_missing
 grep -Fq 'fn ir_module_arena_v2_set_instr_payload_validated' "$SOURCE" || fail private_instr_setter_missing
 if grep -Eq '^pub fn ir_module_arena_v2_set_' "$SOURCE"; then
   fail raw_setter_is_public
 fi
 
-for default_surface in self-hosted/ir/mod.sio self-hosted/compiler/main.sio scripts/bootstrap/bootstrap_concat.sh; do
+for default_surface in \
+  self-hosted/ir/mod.sio \
+  self-hosted/ir/ir.sio \
+  self-hosted/ir/soir_core.sio \
+  self-hosted/ir/soir_writer.sio \
+  self-hosted/ir/lower.sio \
+  self-hosted/parser/ast.sio \
+  self-hosted/parser/items.sio \
+  self-hosted/compiler/main.sio \
+  self-hosted/native/codegen_x86_linux.sio \
+  scripts/ci/madaros_global_init_transport_gate.sh \
+  scripts/bootstrap/bootstrap_concat.sh; do
   if grep -Fq 'arena_v2_shadow' "$default_surface"; then
     fail "shadow_imported_by_${default_surface//\//_}"
   fi
@@ -48,10 +75,16 @@ if git cat-file -e "$BASE^{commit}" 2>/dev/null; then
   if ! git diff --quiet "$BASE" -- \
       self-hosted/ir/heap_storage.sio \
       self-hosted/ir/lower.sio \
+      self-hosted/ir/ir.sio \
       self-hosted/native/codegen_x86_linux.sio \
       self-hosted/native/runtime_context.sio \
       self-hosted/ir/mod.sio \
+      self-hosted/ir/soir_core.sio \
+      self-hosted/ir/soir_writer.sio \
+      self-hosted/parser/ast.sio \
+      self-hosted/parser/items.sio \
       self-hosted/compiler/main.sio \
+      scripts/ci/madaros_global_init_transport_gate.sh \
       scripts/bootstrap/bootstrap_concat.sh; then
     fail legacy_or_default_surface_changed
   fi
@@ -97,8 +130,10 @@ fi
 compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
 printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_CHECK source=pass composite=pass'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_PROBE aba_function=pass aba_instr=pass cross_arena=pass cross_module=pass capacity=pass setter_bounds=pass stale_after_release=pass double_release=pass'
+printf '%s\n' 'IR_MODULE_ARENA_V2_EMPTY module_id=stable_generation_checked two_modules=distinct capacity=checked stale=reject invalid_arena=reject nonalias=pass reset=deterministic exact_zero=functions,strings,epistemic,models,contests,algebras,ontologies,bss legacy_zero_adapter=prepared_not_differential'
+printf '%s\n' 'IR_MODULE_ARENA_V2_EMPTY_STORAGE authority=singleton columns=individual_i64 module_arrays=none allocation=caller_owned_id projection=scalar_predicate module_aggregate_returns=none'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_DIFF legacy_surfaces=unchanged default_pipeline=unwired'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_SCOPE backing=bounded_scalar_tables authority=arena state=free_live_released handles=typed_generation_checked mutation=validated_scalar_only'
-printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_ORACLE legacy=self-hosted/ir/heap_storage.sio mode=differential kept=yes replaced=no'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_ORACLE legacy=self-hosted/ir/heap_storage.sio mode=kept_not_executed replaced=no'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SHADOW_NOT_SOLVED issue_877=compile_time_noncopyable_authority issue_884=runtime_managed_handle_lifecycle'
 printf 'IR_MODULE_ARENA_V2_SHADOW_PASS compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"

--- a/self-hosted/ir/arena_v2_shadow.sio
+++ b/self-hosted/ir/arena_v2_shadow.sio
@@ -1,0 +1,421 @@
+// Shadow-only ownership kernel for a future canonical IrModule representation.
+//
+// This module is intentionally not imported by ir/mod.sio, compiler/main.sio,
+// or bootstrap_concat.sh. It owns bounded scalar slot tables directly and has
+// no dependency on IrModuleHeapBridge, RuntimeContext handles, or AGG_POOL.
+
+module ir::arena_v2_shadow
+
+pub let IR_MODULE_ARENA_V2_FUNCTION_CAPACITY: i64 = 4
+pub let IR_MODULE_ARENA_V2_INSTR_CAPACITY: i64 = 8
+pub let IR_MODULE_ARENA_V2_MAX_REG_COUNT: i64 = 65536
+
+pub let IR_MODULE_ARENA_V2_ARENA_INVALID: i64 = 0
+pub let IR_MODULE_ARENA_V2_ARENA_LIVE: i64 = 1
+pub let IR_MODULE_ARENA_V2_ARENA_RELEASED: i64 = 2
+
+pub let IR_MODULE_ARENA_V2_SLOT_FREE: i64 = 0
+pub let IR_MODULE_ARENA_V2_SLOT_LIVE: i64 = 1
+pub let IR_MODULE_ARENA_V2_SLOT_RELEASED: i64 = 2
+
+pub let IR_MODULE_ARENA_V2_OK: i64 = 0
+pub let IR_MODULE_ARENA_V2_ALREADY_RELEASED: i64 = 1
+pub let IR_MODULE_ARENA_V2_ERR_INVALID_ARENA: i64 = -1
+pub let IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE: i64 = -2
+pub let IR_MODULE_ARENA_V2_ERR_CAPACITY: i64 = -3
+pub let IR_MODULE_ARENA_V2_ERR_HAS_CHILDREN: i64 = -4
+pub let IR_MODULE_ARENA_V2_ERR_RANGE: i64 = -5
+pub let IR_MODULE_ARENA_V2_ERR_RELEASED: i64 = -6
+
+// Function and instruction handles cannot be confused structurally. Every
+// handle carries both stable identities plus a slot generation for ABA checks.
+pub struct IrModuleArenaV2FunctionHandle {
+    arena_identity: i64,
+    module_identity: i64,
+    slot: i64,
+    generation: i64,
+}
+
+pub struct IrModuleArenaV2InstrHandle {
+    arena_identity: i64,
+    module_identity: i64,
+    slot: i64,
+    generation: i64,
+}
+
+// The arena is the sole owner of all node slots. This shadow prototype keeps
+// fields private and exposes mutations only through validated &! commands.
+// Compile-time non-copyability of this authority remains blocked by issue #877.
+pub struct IrModuleArenaV2 {
+    arena_identity: i64,
+    module_identity: i64,
+    state: i64,
+    release_count: i64,
+
+    function_state: [i64; 4],
+    function_generation: [i64; 4],
+    function_defining_module_id: [i64; 4],
+    function_reg_count: [i64; 4],
+    function_live_count: i64,
+
+    instr_state: [i64; 8],
+    instr_generation: [i64; 8],
+    instr_parent_function_slot: [i64; 8],
+    instr_opcode: [i64; 8],
+    instr_imm_i64: [i64; 8],
+    instr_live_count: i64,
+}
+
+fn ir_module_arena_v2_invalid_function_handle() -> IrModuleArenaV2FunctionHandle {
+    IrModuleArenaV2FunctionHandle {
+        arena_identity: 0,
+        module_identity: 0,
+        slot: -1,
+        generation: 0,
+    }
+}
+
+fn ir_module_arena_v2_invalid_instr_handle() -> IrModuleArenaV2InstrHandle {
+    IrModuleArenaV2InstrHandle {
+        arena_identity: 0,
+        module_identity: 0,
+        slot: -1,
+        generation: 0,
+    }
+}
+
+pub fn ir_module_arena_v2_new(arena_identity: i64, module_identity: i64) -> IrModuleArenaV2 {
+    let initial_state = if arena_identity > 0 && module_identity > 0 {
+        IR_MODULE_ARENA_V2_ARENA_LIVE
+    } else {
+        IR_MODULE_ARENA_V2_ARENA_INVALID
+    }
+
+    IrModuleArenaV2 {
+        arena_identity: arena_identity,
+        module_identity: module_identity,
+        state: initial_state,
+        release_count: 0,
+        function_state: [IR_MODULE_ARENA_V2_SLOT_FREE; 4],
+        function_generation: [1; 4],
+        function_defining_module_id: [0; 4],
+        function_reg_count: [0; 4],
+        function_live_count: 0,
+        instr_state: [IR_MODULE_ARENA_V2_SLOT_FREE; 8],
+        instr_generation: [1; 8],
+        instr_parent_function_slot: [-1; 8],
+        instr_opcode: [0; 8],
+        instr_imm_i64: [0; 8],
+        instr_live_count: 0,
+    }
+}
+
+pub fn ir_module_arena_v2_state(arena: &IrModuleArenaV2) -> i64 {
+    (*arena).state
+}
+
+pub fn ir_module_arena_v2_arena_identity(arena: &IrModuleArenaV2) -> i64 {
+    (*arena).arena_identity
+}
+
+pub fn ir_module_arena_v2_module_identity(arena: &IrModuleArenaV2) -> i64 {
+    (*arena).module_identity
+}
+
+pub fn ir_module_arena_v2_release_count(arena: &IrModuleArenaV2) -> i64 {
+    (*arena).release_count
+}
+
+pub fn ir_module_arena_v2_function_live_count(arena: &IrModuleArenaV2) -> i64 {
+    (*arena).function_live_count
+}
+
+pub fn ir_module_arena_v2_instr_live_count(arena: &IrModuleArenaV2) -> i64 {
+    (*arena).instr_live_count
+}
+
+pub fn ir_module_arena_v2_function_handle_slot(handle: &IrModuleArenaV2FunctionHandle) -> i64 {
+    (*handle).slot
+}
+
+pub fn ir_module_arena_v2_function_handle_generation(handle: &IrModuleArenaV2FunctionHandle) -> i64 {
+    (*handle).generation
+}
+
+pub fn ir_module_arena_v2_instr_handle_slot(handle: &IrModuleArenaV2InstrHandle) -> i64 {
+    (*handle).slot
+}
+
+pub fn ir_module_arena_v2_instr_handle_generation(handle: &IrModuleArenaV2InstrHandle) -> i64 {
+    (*handle).generation
+}
+
+pub fn ir_module_arena_v2_function_is_live(
+    arena: &IrModuleArenaV2,
+    handle: &IrModuleArenaV2FunctionHandle,
+) -> bool with Panic, Div {
+    if (*arena).state != IR_MODULE_ARENA_V2_ARENA_LIVE {
+        return false
+    }
+    if (*handle).arena_identity != (*arena).arena_identity ||
+       (*handle).module_identity != (*arena).module_identity {
+        return false
+    }
+    let slot = (*handle).slot
+    if slot < 0 || slot >= IR_MODULE_ARENA_V2_FUNCTION_CAPACITY {
+        return false
+    }
+    (*arena).function_state[slot as usize] == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+        (*arena).function_generation[slot as usize] == (*handle).generation
+}
+
+pub fn ir_module_arena_v2_instr_is_live(
+    arena: &IrModuleArenaV2,
+    handle: &IrModuleArenaV2InstrHandle,
+) -> bool with Panic, Div {
+    if (*arena).state != IR_MODULE_ARENA_V2_ARENA_LIVE {
+        return false
+    }
+    if (*handle).arena_identity != (*arena).arena_identity ||
+       (*handle).module_identity != (*arena).module_identity {
+        return false
+    }
+    let slot = (*handle).slot
+    if slot < 0 || slot >= IR_MODULE_ARENA_V2_INSTR_CAPACITY {
+        return false
+    }
+    (*arena).instr_state[slot as usize] == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+        (*arena).instr_generation[slot as usize] == (*handle).generation
+}
+
+pub fn ir_module_arena_v2_add_function(
+    arena: &! IrModuleArenaV2,
+    defining_module_id: i64,
+) -> (i64, IrModuleArenaV2FunctionHandle) with Mut, Panic, Div {
+    if (*arena).state == IR_MODULE_ARENA_V2_ARENA_RELEASED {
+        return (IR_MODULE_ARENA_V2_ERR_RELEASED, ir_module_arena_v2_invalid_function_handle())
+    }
+    if (*arena).state != IR_MODULE_ARENA_V2_ARENA_LIVE || defining_module_id < 0 {
+        return (IR_MODULE_ARENA_V2_ERR_INVALID_ARENA, ir_module_arena_v2_invalid_function_handle())
+    }
+
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_FUNCTION_CAPACITY {
+        if (*arena).function_state[slot as usize] == IR_MODULE_ARENA_V2_SLOT_FREE ||
+           (*arena).function_state[slot as usize] == IR_MODULE_ARENA_V2_SLOT_RELEASED {
+            (*arena).function_state[slot as usize] = IR_MODULE_ARENA_V2_SLOT_LIVE
+            (*arena).function_defining_module_id[slot as usize] = defining_module_id
+            (*arena).function_reg_count[slot as usize] = 0
+            (*arena).function_live_count = (*arena).function_live_count + 1
+            let handle = IrModuleArenaV2FunctionHandle {
+                arena_identity: (*arena).arena_identity,
+                module_identity: (*arena).module_identity,
+                slot: slot,
+                generation: (*arena).function_generation[slot as usize],
+            }
+            return (IR_MODULE_ARENA_V2_OK, handle)
+        }
+        slot = slot + 1
+    }
+
+    (IR_MODULE_ARENA_V2_ERR_CAPACITY, ir_module_arena_v2_invalid_function_handle())
+}
+
+fn ir_module_arena_v2_set_function_reg_count_validated(
+    arena: &! IrModuleArenaV2,
+    handle: &IrModuleArenaV2FunctionHandle,
+    reg_count: i64,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_function_is_live(arena, handle) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    if reg_count < 0 || reg_count > IR_MODULE_ARENA_V2_MAX_REG_COUNT {
+        return IR_MODULE_ARENA_V2_ERR_RANGE
+    }
+    (*arena).function_reg_count[(*handle).slot as usize] = reg_count
+    IR_MODULE_ARENA_V2_OK
+}
+
+// Public commands expose intent; raw field setters remain module-private.
+pub fn ir_module_arena_v2_configure_function_reg_count(
+    arena: &! IrModuleArenaV2,
+    handle: &IrModuleArenaV2FunctionHandle,
+    reg_count: i64,
+) -> i64 with Mut, Panic, Div {
+    ir_module_arena_v2_set_function_reg_count_validated(arena, handle, reg_count)
+}
+
+pub fn ir_module_arena_v2_function_reg_count(
+    arena: &IrModuleArenaV2,
+    handle: &IrModuleArenaV2FunctionHandle,
+) -> (i64, i64) with Panic, Div {
+    if !ir_module_arena_v2_function_is_live(arena, handle) {
+        return (IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE, 0)
+    }
+    (IR_MODULE_ARENA_V2_OK, (*arena).function_reg_count[(*handle).slot as usize])
+}
+
+pub fn ir_module_arena_v2_function_defining_module_id(
+    arena: &IrModuleArenaV2,
+    handle: &IrModuleArenaV2FunctionHandle,
+) -> (i64, i64) with Panic, Div {
+    if !ir_module_arena_v2_function_is_live(arena, handle) {
+        return (IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE, 0)
+    }
+    (IR_MODULE_ARENA_V2_OK, (*arena).function_defining_module_id[(*handle).slot as usize])
+}
+
+fn ir_module_arena_v2_set_instr_payload_validated(
+    arena: &! IrModuleArenaV2,
+    handle: &IrModuleArenaV2InstrHandle,
+    opcode: i64,
+    imm_i64: i64,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_instr_is_live(arena, handle) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    if opcode < 0 || opcode > 65535 {
+        return IR_MODULE_ARENA_V2_ERR_RANGE
+    }
+    let slot = (*handle).slot
+    (*arena).instr_opcode[slot as usize] = opcode
+    (*arena).instr_imm_i64[slot as usize] = imm_i64
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_add_instr(
+    arena: &! IrModuleArenaV2,
+    parent: &IrModuleArenaV2FunctionHandle,
+    opcode: i64,
+    imm_i64: i64,
+) -> (i64, IrModuleArenaV2InstrHandle) with Mut, Panic, Div {
+    if (*arena).state == IR_MODULE_ARENA_V2_ARENA_RELEASED {
+        return (IR_MODULE_ARENA_V2_ERR_RELEASED, ir_module_arena_v2_invalid_instr_handle())
+    }
+    if !ir_module_arena_v2_function_is_live(arena, parent) {
+        return (IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE, ir_module_arena_v2_invalid_instr_handle())
+    }
+    if opcode < 0 || opcode > 65535 {
+        return (IR_MODULE_ARENA_V2_ERR_RANGE, ir_module_arena_v2_invalid_instr_handle())
+    }
+
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_INSTR_CAPACITY {
+        if (*arena).instr_state[slot as usize] == IR_MODULE_ARENA_V2_SLOT_FREE ||
+           (*arena).instr_state[slot as usize] == IR_MODULE_ARENA_V2_SLOT_RELEASED {
+            (*arena).instr_state[slot as usize] = IR_MODULE_ARENA_V2_SLOT_LIVE
+            (*arena).instr_parent_function_slot[slot as usize] = (*parent).slot
+            (*arena).instr_live_count = (*arena).instr_live_count + 1
+            let handle = IrModuleArenaV2InstrHandle {
+                arena_identity: (*arena).arena_identity,
+                module_identity: (*arena).module_identity,
+                slot: slot,
+                generation: (*arena).instr_generation[slot as usize],
+            }
+            let status = ir_module_arena_v2_set_instr_payload_validated(arena, &handle, opcode, imm_i64)
+            if status != IR_MODULE_ARENA_V2_OK {
+                (*arena).instr_state[slot as usize] = IR_MODULE_ARENA_V2_SLOT_FREE
+                (*arena).instr_parent_function_slot[slot as usize] = -1
+                (*arena).instr_live_count = (*arena).instr_live_count - 1
+                return (status, ir_module_arena_v2_invalid_instr_handle())
+            }
+            return (IR_MODULE_ARENA_V2_OK, handle)
+        }
+        slot = slot + 1
+    }
+
+    (IR_MODULE_ARENA_V2_ERR_CAPACITY, ir_module_arena_v2_invalid_instr_handle())
+}
+
+pub fn ir_module_arena_v2_instr_payload(
+    arena: &IrModuleArenaV2,
+    handle: &IrModuleArenaV2InstrHandle,
+) -> (i64, i64, i64) with Panic, Div {
+    if !ir_module_arena_v2_instr_is_live(arena, handle) {
+        return (IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE, 0, 0)
+    }
+    let slot = (*handle).slot
+    (IR_MODULE_ARENA_V2_OK, (*arena).instr_opcode[slot as usize], (*arena).instr_imm_i64[slot as usize])
+}
+
+pub fn ir_module_arena_v2_remove_instr(
+    arena: &! IrModuleArenaV2,
+    handle: &IrModuleArenaV2InstrHandle,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_instr_is_live(arena, handle) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    let slot = (*handle).slot
+    (*arena).instr_state[slot as usize] = IR_MODULE_ARENA_V2_SLOT_RELEASED
+    (*arena).instr_generation[slot as usize] = (*arena).instr_generation[slot as usize] + 1
+    (*arena).instr_parent_function_slot[slot as usize] = -1
+    (*arena).instr_opcode[slot as usize] = 0
+    (*arena).instr_imm_i64[slot as usize] = 0
+    (*arena).instr_live_count = (*arena).instr_live_count - 1
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_remove_function(
+    arena: &! IrModuleArenaV2,
+    handle: &IrModuleArenaV2FunctionHandle,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_function_is_live(arena, handle) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    var i: i64 = 0
+    while i < IR_MODULE_ARENA_V2_INSTR_CAPACITY {
+        if (*arena).instr_state[i as usize] == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+           (*arena).instr_parent_function_slot[i as usize] == (*handle).slot {
+            return IR_MODULE_ARENA_V2_ERR_HAS_CHILDREN
+        }
+        i = i + 1
+    }
+
+    let slot = (*handle).slot
+    (*arena).function_state[slot as usize] = IR_MODULE_ARENA_V2_SLOT_RELEASED
+    (*arena).function_generation[slot as usize] = (*arena).function_generation[slot as usize] + 1
+    (*arena).function_defining_module_id[slot as usize] = 0
+    (*arena).function_reg_count[slot as usize] = 0
+    (*arena).function_live_count = (*arena).function_live_count - 1
+    IR_MODULE_ARENA_V2_OK
+}
+
+// First release invalidates every live handle and records one logical reclaim.
+// Later releases are explicit no-ops and cannot increment release_count.
+pub fn ir_module_arena_v2_release(arena: &! IrModuleArenaV2) -> i64 with Mut, Panic, Div {
+    if (*arena).state == IR_MODULE_ARENA_V2_ARENA_RELEASED {
+        return IR_MODULE_ARENA_V2_ALREADY_RELEASED
+    }
+    if (*arena).state != IR_MODULE_ARENA_V2_ARENA_LIVE {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+
+    var fi: i64 = 0
+    while fi < IR_MODULE_ARENA_V2_FUNCTION_CAPACITY {
+        if (*arena).function_state[fi as usize] == IR_MODULE_ARENA_V2_SLOT_LIVE {
+            (*arena).function_generation[fi as usize] = (*arena).function_generation[fi as usize] + 1
+        }
+        (*arena).function_state[fi as usize] = IR_MODULE_ARENA_V2_SLOT_RELEASED
+        (*arena).function_defining_module_id[fi as usize] = 0
+        (*arena).function_reg_count[fi as usize] = 0
+        fi = fi + 1
+    }
+
+    var ii: i64 = 0
+    while ii < IR_MODULE_ARENA_V2_INSTR_CAPACITY {
+        if (*arena).instr_state[ii as usize] == IR_MODULE_ARENA_V2_SLOT_LIVE {
+            (*arena).instr_generation[ii as usize] = (*arena).instr_generation[ii as usize] + 1
+        }
+        (*arena).instr_state[ii as usize] = IR_MODULE_ARENA_V2_SLOT_RELEASED
+        (*arena).instr_parent_function_slot[ii as usize] = -1
+        (*arena).instr_opcode[ii as usize] = 0
+        (*arena).instr_imm_i64[ii as usize] = 0
+        ii = ii + 1
+    }
+
+    (*arena).function_live_count = 0
+    (*arena).instr_live_count = 0
+    (*arena).release_count = 1
+    (*arena).state = IR_MODULE_ARENA_V2_ARENA_RELEASED
+    IR_MODULE_ARENA_V2_OK
+}

--- a/self-hosted/ir/arena_v2_shadow.sio
+++ b/self-hosted/ir/arena_v2_shadow.sio
@@ -419,3 +419,282 @@ pub fn ir_module_arena_v2_release(arena: &! IrModuleArenaV2) -> i64 with Mut, Pa
     (*arena).state = IR_MODULE_ARENA_V2_ARENA_RELEASED
     IR_MODULE_ARENA_V2_OK
 }
+
+// --------------------------------------------------------------------------
+// Multi-module shadow store. This is intentionally scalar-column storage: it
+// never owns, accepts, or returns the 404 MB legacy IrModule aggregate.
+
+pub let IR_MODULE_ARENA_V2_MODULE_CAPACITY: i64 = 2
+pub let IR_MODULE_ARENA_V2_ERR_DUPLICATE_MODULE: i64 = -7
+
+pub struct IrModuleArenaV2ModuleId {
+    arena_identity: i64,
+    slot: i64,
+    generation: i64,
+}
+
+var IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STORE_STATE: i64 = IR_MODULE_ARENA_V2_ARENA_INVALID
+var IR_MODULE_ARENA_V2_MODULE_RESET_COUNT: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STATE_0: i64 = IR_MODULE_ARENA_V2_SLOT_FREE
+var IR_MODULE_ARENA_V2_MODULE_STATE_1: i64 = IR_MODULE_ARENA_V2_SLOT_FREE
+var IR_MODULE_ARENA_V2_MODULE_GENERATION_0: i64 = 1
+var IR_MODULE_ARENA_V2_MODULE_GENERATION_1: i64 = 1
+var IR_MODULE_ARENA_V2_MODULE_IDENTITY_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_IDENTITY_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT: i64 = 0
+
+pub fn ir_module_arena_v2_invalid_module_id() -> IrModuleArenaV2ModuleId {
+    IrModuleArenaV2ModuleId { arena_identity: 0, slot: -1, generation: 0 }
+}
+
+fn ir_module_arena_v2_slot_state(slot: i64) -> i64 {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_STATE_0 } else { IR_MODULE_ARENA_V2_MODULE_STATE_1 }
+}
+
+fn ir_module_arena_v2_slot_generation(slot: i64) -> i64 {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_GENERATION_0 } else { IR_MODULE_ARENA_V2_MODULE_GENERATION_1 }
+}
+
+fn ir_module_arena_v2_slot_identity(slot: i64) -> i64 {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_IDENTITY_0 } else { IR_MODULE_ARENA_V2_MODULE_IDENTITY_1 }
+}
+
+fn ir_module_arena_v2_set_slot_state(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_STATE_0 = value } else { IR_MODULE_ARENA_V2_MODULE_STATE_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_generation(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_GENERATION_0 = value } else { IR_MODULE_ARENA_V2_MODULE_GENERATION_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_identity(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_IDENTITY_0 = value } else { IR_MODULE_ARENA_V2_MODULE_IDENTITY_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_bss(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_0 = value } else { IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_1 = value }
+}
+
+fn ir_module_arena_v2_slot_is_exact_empty(slot: i64) -> bool {
+    if slot == 0 {
+        return IR_MODULE_ARENA_V2_MODULE_IDENTITY_0 > 0 &&
+            IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0 == 0 && IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0 == 0 &&
+            IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0 == 0 && IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0 == 0 &&
+            IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0 == 0 && IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0 == 0 &&
+            IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0 == 0 && IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_0 == 0
+    }
+    IR_MODULE_ARENA_V2_MODULE_IDENTITY_1 > 0 &&
+        IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_1 == 0 && IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_1 == 0 &&
+        IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_1 == 0 && IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_1 == 0 &&
+        IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_1 == 0 && IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_1 == 0 &&
+        IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_1 == 0 && IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_1 == 0
+}
+
+pub fn ir_module_arena_v2_module_store_init(arena_identity: i64) -> i64 with Mut, Panic, Div {
+    if arena_identity <= 0 {
+        var invalid_slot: i64 = 0
+        while invalid_slot < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+            if ir_module_arena_v2_slot_state(invalid_slot) == IR_MODULE_ARENA_V2_SLOT_LIVE {
+                ir_module_arena_v2_set_slot_generation(invalid_slot, ir_module_arena_v2_slot_generation(invalid_slot) + 1)
+            }
+            ir_module_arena_v2_zero_module_slot(invalid_slot)
+            ir_module_arena_v2_set_slot_state(invalid_slot, IR_MODULE_ARENA_V2_SLOT_FREE)
+            invalid_slot = invalid_slot + 1
+        }
+        IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY = 0
+        IR_MODULE_ARENA_V2_MODULE_STORE_STATE = IR_MODULE_ARENA_V2_ARENA_INVALID
+        IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = 0
+        IR_MODULE_ARENA_V2_MODULE_RESET_COUNT = 0
+        return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(slot) == IR_MODULE_ARENA_V2_SLOT_LIVE {
+            ir_module_arena_v2_set_slot_generation(slot, ir_module_arena_v2_slot_generation(slot) + 1)
+        }
+        ir_module_arena_v2_zero_module_slot(slot)
+        ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_FREE)
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY = arena_identity
+    IR_MODULE_ARENA_V2_MODULE_STORE_STATE = IR_MODULE_ARENA_V2_ARENA_LIVE
+    IR_MODULE_ARENA_V2_MODULE_RESET_COUNT = 0
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = 0
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_module_id_slot(id: &IrModuleArenaV2ModuleId) -> i64 {
+    (*id).slot
+}
+
+pub fn ir_module_arena_v2_module_id_generation(id: &IrModuleArenaV2ModuleId) -> i64 {
+    (*id).generation
+}
+
+pub fn ir_module_arena_v2_module_store_live_count() -> i64 {
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT
+}
+
+pub fn ir_module_arena_v2_module_store_reset_count() -> i64 {
+    IR_MODULE_ARENA_V2_MODULE_RESET_COUNT
+}
+
+pub fn ir_module_arena_v2_module_id_is_live(
+    id: &IrModuleArenaV2ModuleId,
+) -> bool with Panic, Div {
+    if IR_MODULE_ARENA_V2_MODULE_STORE_STATE != IR_MODULE_ARENA_V2_ARENA_LIVE ||
+       (*id).arena_identity != IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY {
+        return false
+    }
+    let slot = (*id).slot
+    if slot < 0 || slot >= IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        return false
+    }
+    ir_module_arena_v2_slot_state(slot) == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+        ir_module_arena_v2_slot_generation(slot) == (*id).generation
+}
+
+fn ir_module_arena_v2_zero_module_slot(
+    slot: i64,
+) with Mut, Panic, Div {
+    ir_module_arena_v2_set_slot_identity(slot, 0)
+    ir_module_arena_v2_set_slot_bss(slot, 0)
+    if slot == 0 {
+        IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0 = 0
+    } else {
+        IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_1 = 0
+    }
+}
+
+pub fn ir_module_arena_v2_alloc_empty_module(
+    module_identity: i64,
+    out: &! IrModuleArenaV2ModuleId,
+) -> i64 with Mut, Panic, Div {
+    if IR_MODULE_ARENA_V2_MODULE_STORE_STATE != IR_MODULE_ARENA_V2_ARENA_LIVE || module_identity <= 0 {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+    var scan: i64 = 0
+    while scan < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(scan) == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+           ir_module_arena_v2_slot_identity(scan) == module_identity {
+            return IR_MODULE_ARENA_V2_ERR_DUPLICATE_MODULE
+        }
+        scan = scan + 1
+    }
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(slot) != IR_MODULE_ARENA_V2_SLOT_LIVE {
+            ir_module_arena_v2_zero_module_slot(slot)
+            ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_LIVE)
+            ir_module_arena_v2_set_slot_identity(slot, module_identity)
+            IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT + 1
+            (*out).arena_identity = IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY
+            (*out).slot = slot
+            (*out).generation = ir_module_arena_v2_slot_generation(slot)
+            return IR_MODULE_ARENA_V2_OK
+        }
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_ERR_CAPACITY
+}
+
+pub fn ir_module_arena_v2_project_empty_module_is_exact(
+    id: &IrModuleArenaV2ModuleId,
+) -> bool with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return false }
+    let slot = (*id).slot
+    ir_module_arena_v2_slot_is_exact_empty(slot)
+}
+
+// Read-only differential adapter. A legacy caller may borrow IrModule and pass
+// only these scalar observations; neither side copies or returns IrModule.
+pub fn ir_module_arena_v2_empty_matches_legacy_scalars(
+    id: &IrModuleArenaV2ModuleId,
+    function_count: i64,
+    string_count: i64,
+    epistemic_count: i64,
+    model_count: i64,
+    contest_count: i64,
+    algebra_count: i64,
+    ontology_count: i64,
+    bss_total_size: i64,
+) -> bool with Panic, Div {
+    ir_module_arena_v2_project_empty_module_is_exact(id) &&
+    function_count == 0 && string_count == 0 && epistemic_count == 0 &&
+    model_count == 0 && contest_count == 0 && algebra_count == 0 &&
+    ontology_count == 0 && bss_total_size == 0
+}
+
+pub fn ir_module_arena_v2_configure_module_bss_size(
+    id: &IrModuleArenaV2ModuleId,
+    size: i64,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    if size < 0 { return IR_MODULE_ARENA_V2_ERR_RANGE }
+    ir_module_arena_v2_set_slot_bss((*id).slot, size)
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_remove_module(
+    id: &IrModuleArenaV2ModuleId,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    let slot = (*id).slot
+    ir_module_arena_v2_zero_module_slot(slot)
+    ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_RELEASED)
+    ir_module_arena_v2_set_slot_generation(slot, ir_module_arena_v2_slot_generation(slot) + 1)
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT - 1
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_reset_modules(
+) -> i64 with Mut, Panic, Div {
+    if IR_MODULE_ARENA_V2_MODULE_STORE_STATE != IR_MODULE_ARENA_V2_ARENA_LIVE {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(slot) == IR_MODULE_ARENA_V2_SLOT_LIVE {
+            ir_module_arena_v2_set_slot_generation(slot, ir_module_arena_v2_slot_generation(slot) + 1)
+        }
+        ir_module_arena_v2_zero_module_slot(slot)
+        ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_FREE)
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = 0
+    IR_MODULE_ARENA_V2_MODULE_RESET_COUNT = IR_MODULE_ARENA_V2_MODULE_RESET_COUNT + 1
+    IR_MODULE_ARENA_V2_OK
+}

--- a/tests/native-v2/ir_module_arena_v2_shadow_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_shadow_witness.sio
@@ -86,6 +86,61 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     if ir_module_arena_v2_function_is_live(&arena, &f1) || ir_module_arena_v2_instr_is_live(&arena, &c0.1) { return fail(185) }
     if ir_module_arena_v2_configure_function_reg_count(&! arena, &f1, 5) != IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE { return fail(186) }
 
+    if ir_module_arena_v2_module_store_init(9001) != IR_MODULE_ARENA_V2_OK { return fail(199) }
+    var m0 = ir_module_arena_v2_invalid_module_id()
+    var m1 = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(1001, &! m0) != IR_MODULE_ARENA_V2_OK ||
+       ir_module_arena_v2_alloc_empty_module(1002, &! m1) != IR_MODULE_ARENA_V2_OK { return fail(200) }
+    if ir_module_arena_v2_module_id_slot(&m0) == ir_module_arena_v2_module_id_slot(&m1) { return fail(201) }
+    if !ir_module_arena_v2_project_empty_module_is_exact(&m0) ||
+       !ir_module_arena_v2_project_empty_module_is_exact(&m1) { return fail(203) }
+    if !ir_module_arena_v2_empty_matches_legacy_scalars(&m0, 0, 0, 0, 0, 0, 0, 0, 0) { return fail(204) }
+    if ir_module_arena_v2_empty_matches_legacy_scalars(&m0, 0, 0, 0, 0, 1, 0, 0, 0) { return fail(205) }
+    var duplicate = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(1001, &! duplicate) != IR_MODULE_ARENA_V2_ERR_DUPLICATE_MODULE { return fail(206) }
+
+    IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0 = 1
+    IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0 = 2
+    IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0 = 3
+    IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0 = 4
+    IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0 = 5
+    IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0 = 6
+    IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0 = 7
+    if ir_module_arena_v2_configure_module_bss_size(&m0, 64) != IR_MODULE_ARENA_V2_OK { return fail(210) }
+    if ir_module_arena_v2_project_empty_module_is_exact(&m0) { return fail(211) }
+    if !ir_module_arena_v2_project_empty_module_is_exact(&m1) { return fail(212) }
+    if ir_module_arena_v2_configure_module_bss_size(&m0, -1) != IR_MODULE_ARENA_V2_ERR_RANGE { return fail(213) }
+
+    if ir_module_arena_v2_remove_module(&m0) != IR_MODULE_ARENA_V2_OK { return fail(230) }
+    if ir_module_arena_v2_module_id_is_live(&m0) { return fail(231) }
+    var m0_reused = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(1003, &! m0_reused) != IR_MODULE_ARENA_V2_OK { return fail(232) }
+    if ir_module_arena_v2_module_id_slot(&m0) != ir_module_arena_v2_module_id_slot(&m0_reused) { return fail(233) }
+    if ir_module_arena_v2_module_id_generation(&m0) == ir_module_arena_v2_module_id_generation(&m0_reused) { return fail(234) }
+    if !ir_module_arena_v2_project_empty_module_is_exact(&m0_reused) { return fail(235) }
+
+    var m_over = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(1004, &! m_over) != IR_MODULE_ARENA_V2_ERR_CAPACITY { return fail(241) }
+    if ir_module_arena_v2_module_store_live_count() != IR_MODULE_ARENA_V2_MODULE_CAPACITY { return fail(242) }
+
+    if ir_module_arena_v2_reset_modules() != IR_MODULE_ARENA_V2_OK { return fail(250) }
+    if ir_module_arena_v2_module_store_live_count() != 0 ||
+       ir_module_arena_v2_module_store_reset_count() != 1 { return fail(251) }
+    if ir_module_arena_v2_module_id_is_live(&m1) ||
+       ir_module_arena_v2_module_id_is_live(&m0_reused) { return fail(252) }
+    var reset_module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(2001, &! reset_module) != IR_MODULE_ARENA_V2_OK { return fail(253) }
+    if !ir_module_arena_v2_project_empty_module_is_exact(&reset_module) { return fail(254) }
+    if ir_module_arena_v2_module_id_is_live(&m1) || ir_module_arena_v2_module_id_is_live(&m0_reused) { return fail(255) }
+    if ir_module_arena_v2_module_store_init(9002) != IR_MODULE_ARENA_V2_OK { return fail(260) }
+    if ir_module_arena_v2_module_id_is_live(&reset_module) { return fail(261) }
+    var invalid_live = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(3001, &! invalid_live) != IR_MODULE_ARENA_V2_OK { return fail(262) }
+    if ir_module_arena_v2_module_store_init(0) != IR_MODULE_ARENA_V2_ERR_INVALID_ARENA { return fail(263) }
+    if ir_module_arena_v2_module_id_is_live(&invalid_live) ||
+       ir_module_arena_v2_module_store_live_count() != 0 ||
+       ir_module_arena_v2_module_store_reset_count() != 0 { return fail(264) }
+
     print("IR_MODULE_ARENA_V2_SHADOW_PASS\n")
     0
 }

--- a/tests/native-v2/ir_module_arena_v2_shadow_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_shadow_witness.sio
@@ -1,0 +1,91 @@
+use ir::arena_v2_shadow::*
+
+fn fail(code: i64) -> i64 with IO {
+    print("IR_MODULE_ARENA_V2_SHADOW_FAIL code=")
+    print_int(code)
+    print("\n")
+    code
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var arena = ir_module_arena_v2_new(101, 501)
+    if ir_module_arena_v2_state(&arena) != IR_MODULE_ARENA_V2_ARENA_LIVE { return fail(101) }
+    if ir_module_arena_v2_arena_identity(&arena) != 101 { return fail(102) }
+    if ir_module_arena_v2_module_identity(&arena) != 501 { return fail(103) }
+
+    let f0_result = ir_module_arena_v2_add_function(&! arena, 77)
+    if f0_result.0 != IR_MODULE_ARENA_V2_OK { return fail(110) }
+    let f0 = f0_result.1
+    let f0_def = ir_module_arena_v2_function_defining_module_id(&arena, &f0)
+    if f0_def.0 != IR_MODULE_ARENA_V2_OK || f0_def.1 != 77 { return fail(111) }
+
+    if ir_module_arena_v2_configure_function_reg_count(&! arena, &f0, 4) != IR_MODULE_ARENA_V2_OK { return fail(112) }
+    if ir_module_arena_v2_configure_function_reg_count(&! arena, &f0, -1) != IR_MODULE_ARENA_V2_ERR_RANGE { return fail(113) }
+    if ir_module_arena_v2_configure_function_reg_count(&! arena, &f0, IR_MODULE_ARENA_V2_MAX_REG_COUNT + 1) != IR_MODULE_ARENA_V2_ERR_RANGE { return fail(114) }
+    let reg_count = ir_module_arena_v2_function_reg_count(&arena, &f0)
+    if reg_count.0 != IR_MODULE_ARENA_V2_OK || reg_count.1 != 4 { return fail(115) }
+
+    let i0_result = ir_module_arena_v2_add_instr(&! arena, &f0, 9, 42)
+    if i0_result.0 != IR_MODULE_ARENA_V2_OK { return fail(120) }
+    let i0 = i0_result.1
+    let payload = ir_module_arena_v2_instr_payload(&arena, &i0)
+    if payload.0 != IR_MODULE_ARENA_V2_OK || payload.1 != 9 || payload.2 != 42 { return fail(121) }
+    if ir_module_arena_v2_remove_function(&! arena, &f0) != IR_MODULE_ARENA_V2_ERR_HAS_CHILDREN { return fail(122) }
+
+    if ir_module_arena_v2_remove_instr(&! arena, &i0) != IR_MODULE_ARENA_V2_OK { return fail(130) }
+    if ir_module_arena_v2_instr_is_live(&arena, &i0) { return fail(131) }
+    let i1_result = ir_module_arena_v2_add_instr(&! arena, &f0, 10, 84)
+    if i1_result.0 != IR_MODULE_ARENA_V2_OK { return fail(132) }
+    let i1 = i1_result.1
+    if ir_module_arena_v2_instr_handle_slot(&i0) != ir_module_arena_v2_instr_handle_slot(&i1) { return fail(133) }
+    if ir_module_arena_v2_instr_handle_generation(&i0) == ir_module_arena_v2_instr_handle_generation(&i1) { return fail(134) }
+    if ir_module_arena_v2_instr_is_live(&arena, &i0) || !ir_module_arena_v2_instr_is_live(&arena, &i1) { return fail(135) }
+
+    if ir_module_arena_v2_remove_instr(&! arena, &i1) != IR_MODULE_ARENA_V2_OK { return fail(140) }
+    if ir_module_arena_v2_remove_function(&! arena, &f0) != IR_MODULE_ARENA_V2_OK { return fail(141) }
+    let f1_result = ir_module_arena_v2_add_function(&! arena, 78)
+    if f1_result.0 != IR_MODULE_ARENA_V2_OK { return fail(142) }
+    let f1 = f1_result.1
+    if ir_module_arena_v2_function_handle_slot(&f0) != ir_module_arena_v2_function_handle_slot(&f1) { return fail(143) }
+    if ir_module_arena_v2_function_handle_generation(&f0) == ir_module_arena_v2_function_handle_generation(&f1) { return fail(144) }
+    if ir_module_arena_v2_function_is_live(&arena, &f0) || !ir_module_arena_v2_function_is_live(&arena, &f1) { return fail(145) }
+
+    var cross_arena = ir_module_arena_v2_new(202, 501)
+    if ir_module_arena_v2_function_is_live(&cross_arena, &f1) { return fail(150) }
+    var cross_module = ir_module_arena_v2_new(101, 502)
+    if ir_module_arena_v2_function_is_live(&cross_module, &f1) { return fail(151) }
+
+    let f2 = ir_module_arena_v2_add_function(&! arena, 79)
+    let f3 = ir_module_arena_v2_add_function(&! arena, 80)
+    let f4 = ir_module_arena_v2_add_function(&! arena, 81)
+    let f_over = ir_module_arena_v2_add_function(&! arena, 82)
+    if f2.0 != IR_MODULE_ARENA_V2_OK || f3.0 != IR_MODULE_ARENA_V2_OK || f4.0 != IR_MODULE_ARENA_V2_OK { return fail(160) }
+    if f_over.0 != IR_MODULE_ARENA_V2_ERR_CAPACITY { return fail(161) }
+
+    let c0 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 0)
+    let c1 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 1)
+    let c2 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 2)
+    let c3 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 3)
+    let c4 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 4)
+    let c5 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 5)
+    let c6 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 6)
+    let c7 = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 7)
+    let c_over = ir_module_arena_v2_add_instr(&! arena, &f1, 1, 8)
+    if c0.0 != IR_MODULE_ARENA_V2_OK || c1.0 != IR_MODULE_ARENA_V2_OK ||
+       c2.0 != IR_MODULE_ARENA_V2_OK || c3.0 != IR_MODULE_ARENA_V2_OK ||
+       c4.0 != IR_MODULE_ARENA_V2_OK || c5.0 != IR_MODULE_ARENA_V2_OK ||
+       c6.0 != IR_MODULE_ARENA_V2_OK || c7.0 != IR_MODULE_ARENA_V2_OK { return fail(170) }
+    if c_over.0 != IR_MODULE_ARENA_V2_ERR_CAPACITY { return fail(171) }
+    if ir_module_arena_v2_function_live_count(&arena) != 4 || ir_module_arena_v2_instr_live_count(&arena) != 8 { return fail(172) }
+
+    if ir_module_arena_v2_release(&! arena) != IR_MODULE_ARENA_V2_OK { return fail(180) }
+    if ir_module_arena_v2_release(&! arena) != IR_MODULE_ARENA_V2_ALREADY_RELEASED { return fail(181) }
+    if ir_module_arena_v2_release_count(&arena) != 1 { return fail(182) }
+    if ir_module_arena_v2_state(&arena) != IR_MODULE_ARENA_V2_ARENA_RELEASED { return fail(183) }
+    if ir_module_arena_v2_function_live_count(&arena) != 0 || ir_module_arena_v2_instr_live_count(&arena) != 0 { return fail(184) }
+    if ir_module_arena_v2_function_is_live(&arena, &f1) || ir_module_arena_v2_instr_is_live(&arena, &c0.1) { return fail(185) }
+    if ir_module_arena_v2_configure_function_reg_count(&! arena, &f1, 5) != IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE { return fail(186) }
+
+    print("IR_MODULE_ARENA_V2_SHADOW_PASS\n")
+    0
+}


### PR DESCRIPTION
## Stack and composition

Stacked on #961 at `e4cc581be6e429c752b603ab9ad55ff4cafa921d`. This composes the compatible shadow kernel from #895 (`e226d70ce`, transplanted as `6bee00606`) and extends it on the current compiler head. No Place IR or D1 stack was duplicated.

## Vertical slice

Adds a bounded shadow-only empty-module store with:

- stable generation-checked `ModuleId`;
- two distinct module slots and checked capacity;
- private individual scalar columns for functions, strings, epistemic/model/contest/algebra/ontology counts, and BSS;
- caller-owned `ModuleId` allocation via out parameter;
- scalar read-only exact-empty projection and a prepared legacy-zero comparison boundary;
- deterministic reset, stale-ID rejection after release and reuse, duplicate rejection, invalid-arena rejection, and non-aliasing.

Invalid initialization invalidates live IDs and zeroes all scalar state. The default compiler, SOIR writer/serializer, native capacity path, global-init patch, raw-field compatibility, and legacy `IrModule` remain unchanged and unwired.

## Adversarial design receipts

The witness rejected four tempting aggregate designs before reaching green:

1. by-value module store returned `INVALID_ARENA`;
2. boxed store still returned `INVALID_ARENA` because the aggregate was copied before pointer publication;
3. tuple-returned `ModuleId` published the wrong slot despite correct live storage;
4. global scalar arrays aliased in legacy BSS (`BSS[0]=4` after zero initialization).

The accepted slice therefore has no module-store aggregate, no global arrays, no tuple-returned allocation result, and no projection aggregate.

## Exact local gate

```text
IR_MODULE_ARENA_V2_EMPTY module_id=stable_generation_checked two_modules=distinct capacity=checked stale=reject invalid_arena=reject nonalias=pass reset=deterministic exact_zero=functions,strings,epistemic,models,contests,algebras,ontologies,bss legacy_zero_adapter=prepared_not_differential
IR_MODULE_ARENA_V2_EMPTY_STORAGE authority=singleton columns=individual_i64 module_arrays=none allocation=caller_owned_id projection=scalar_predicate module_aggregate_returns=none
IR_MODULE_ARENA_V2_SHADOW_DIFF legacy_surfaces=unchanged default_pipeline=unwired
IR_MODULE_ARENA_V2_SHADOW_ORACLE legacy=self-hosted/ir/heap_storage.sio mode=kept_not_executed replaced=no
IR_MODULE_ARENA_V2_SHADOW_PASS
```

Gate: `bash scripts/ci/ir_module_arena_v2_shadow_gate.sh`.

## Claim boundary

This proves a bounded empty-module identity/storage kernel only. It does not replace canonical `IrModule`, store real IR payloads, integrate the writer, execute a differential legacy trace, prove memory reclamation, enforce unique authority in the type system, or establish performance improvement. The legacy path remains preserved as the future differential oracle.

Do not merge until orthogonal review and exact-head source-fresh CI are complete.
