### PR TITLE
test(stdlib): batch run-proofs — data::json + data::csv + math::approx

### DIFF
--- a/scripts/verticals_batch6_gate.sh
+++ b/scripts/verticals_batch6_gate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Combined gate: data::json + data::csv (serializers, output-conformance) + math::approx (values).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== json =="
+$SOUC check stdlib/data/json.sio >/dev/null 2>&1 || { echo "FAIL check json"; fail=1; }
+if $SOUC compile tests/stdlib/data/test_json_stdlib.sio -o "$OUT/j.elf" >/dev/null 2>&1; then
+  o=$("$OUT/j.elf")
+  echo "$o" | grep -qF '{"id":7,"name":"ok","active":true,"note":null}' || { echo "FAIL json output"; fail=1; }
+  echo "$o" | grep -q "JSON_EMIT_OK" || { echo "FAIL json sentinel"; fail=1; }
+else echo "FAIL json compile"; fail=1; fi
+echo "== csv =="
+$SOUC check stdlib/data/csv.sio >/dev/null 2>&1 || { echo "FAIL check csv"; fail=1; }
+if $SOUC compile tests/stdlib/data/test_csv_stdlib.sio -o "$OUT/c.elf" >/dev/null 2>&1; then
+  o=$("$OUT/c.elf")
+  echo "$o" | grep -qF 'name,age' || { echo "FAIL csv header"; fail=1; }
+  echo "$o" | grep -qF 'alice,30' || { echo "FAIL csv row"; fail=1; }
+  echo "$o" | grep -q "CSV_EMIT_OK" || { echo "FAIL csv sentinel"; fail=1; }
+else echo "FAIL csv compile"; fail=1; fi
+echo "== approx =="
+$SOUC check stdlib/math/approx.sio >/dev/null 2>&1 || { echo "FAIL check approx"; fail=1; }
+if $SOUC compile tests/stdlib/math/test_approx_stdlib.sio -o "$OUT/a.elf" >/dev/null 2>&1; then
+  "$OUT/a.elf" | grep -q "APPROX_STDLIB_OK" || { echo "FAIL approx"; fail=1; }
+else echo "FAIL approx compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "VERTICALS_BATCH6_GATE_OK"
+exit $fail

--- a/tests/stdlib/data/test_csv_stdlib.sio
+++ b/tests/stdlib/data/test_csv_stdlib.sio
@@ -1,0 +1,14 @@
+// Run-proof for stdlib data::csv (serializer). Emits known rows; gate greps the exact output.
+use data::csv::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var c: i64 = 0
+    c = csv_field_str(c, "name")
+    c = csv_field_str(c, "age")
+    c = csv_end_row(c)
+    c = 0
+    c = csv_field_str(c, "alice")
+    c = csv_field_int(c, 30)
+    c = csv_end_row(c)
+    print("CSV_EMIT_OK\n")
+    return 0
+}

--- a/tests/stdlib/data/test_json_stdlib.sio
+++ b/tests/stdlib/data/test_json_stdlib.sio
@@ -1,0 +1,13 @@
+// Run-proof for stdlib data::json (serializer). Emits a known object; gate greps the exact output.
+use data::json::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    json_obj_open()
+    var n: i64 = 0
+    n = json_member_int(n, "id", 7)
+    n = json_member_str(n, "name", "ok")
+    n = json_member_bool(n, "active", true)
+    n = json_member_null(n, "note")
+    json_obj_close()
+    print("\nJSON_EMIT_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_approx_stdlib.sio
+++ b/tests/stdlib/math/test_approx_stdlib.sio
@@ -1,0 +1,16 @@
+// Run-proof for stdlib math::approx (Newton sqrt, Taylor sin). Scalar API -> default Madaros.
+use math::approx::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let s2 = approx_newton_sqrt(2.0)          // 1.41421356
+    if (if s2 > 1.4142136 { s2-1.4142136 } else { 1.4142136-s2 }) >= 1.0e-6 { print("FAIL sqrt2\n"); return 1 }
+    let s9 = approx_newton_sqrt(9.0)          // 3
+    if (if s9 > 3.0 { s9-3.0 } else { 3.0-s9 }) >= 1.0e-6 { print("FAIL sqrt9\n"); return 2 }
+    // sin(pi/6) = 0.5
+    let sin30 = approx_taylor_sin(0.5235987756, 12)
+    if (if sin30 > 0.5 { sin30-0.5 } else { 0.5-sin30 }) >= 1.0e-6 { print("FAIL sin30\n"); return 3 }
+    // sin(0) = 0
+    let sin0 = approx_taylor_sin(0.0, 12)
+    if (if sin0 > 0.0 { sin0 } else { 0.0-sin0 }) >= 1.0e-9 { print("FAIL sin0\n"); return 4 }
+    print("APPROX_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
**Grouped PR (3 verticals in one)**, lean (tests+gate only). Three cold/disjoint self-contained modules, native under **default Madaros**, **no source edits**:
- **data::json** — serializer emits exactly `{"id":7,"name":"ok","active":true,"note":null}` (output-conformance) -> `JSON_EMIT_OK`.
- **data::csv** — serializer emits `name,age` / `alice,30` -> `CSV_EMIT_OK`.
- **math::approx** — Newton sqrt(2)/sqrt(9)=3, Taylor sin(pi/6)=0.5, sin(0)=0 -> `APPROX_STDLIB_OK`.

Combined gate `VERTICALS_BATCH6_GATE_OK`; math-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)