### PR TITLE
feat(stats): epidemiological adjustment — mantel_haenszel, attributable, standardized_rate

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2878,3 +2878,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - Note: test_separated initially used 3-vs-3 (permutation floor 2/20=0.1, can't reject at 0.05) — the failing assertion caught my hand-reasoning error; switched to 5-vs-5 (floor 2/252≈0.008). Another derivable-values catch.
 - Theme: resampling inference — extends the resampling family to two-sample and correlation, promoting the permutation test to a first-class module (was an external example). All seeded/reproducible, #852-safe. Suite runner: 82 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-4fFm8k/`, `/tmp/llm-offload-4Ksd2v/`, `/tmp/llm-offload-UN4If6/`.
+
+## 2026-07-15 — math-review: stats::mantel_haenszel, stats::attributable, stats::standardized_rate
+- Files (all new): `stdlib/stats/mantel_haenszel.sio` (M-H pooled OR across k 2×2 strata + M-H χ² + Robins-Breslow-Greenland CI), `stdlib/stats/attributable.sio` (AR/RR/AFE/PAF from a cohort 2×2), `stdlib/stats/standardized_rate.sio` (direct standardized rate + Poisson SE, indirect SMR). Provider: xAI/Grok 4.3.
+- mantel_haenszel = **PASS**: OR_MH=Σ(ad/n)/Σ(bc/n), M-H χ², RBG var(lnOR)=sPR/(2sR²)+sPSQR/(2sR·sS)+sQS/(2sS²) all match; two-strata OR=2 example → OR_MH=2, χ²=4.111, CI [1.024,3.906] verified.
+- attributable = **PASS**: AR, RR, AFE=(RR−1)/RR, Levin PAF=(I−Rᵤ)/I all correct; Rₑ=0.2/Rᵤ=0.1 → AFE=0.5, PAF=0.333 verified.
+- standardized_rate = **PASS**: DSR=Σwr/Σw + Poisson SE, SMR=Σobs/Σexp; DSR=0.022, SMR=0.8 verified.
+- Theme: epidemiological confounding adjustment — extends the epidemiology/rate_epi family from crude single-table to stratified/standardized measures. All derivable, #852-safe. Suite runner: 85 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-M5Sfo4/`, `/tmp/llm-offload-OSy10Z/`, `/tmp/llm-offload-zWkR61/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -91,6 +91,9 @@ MODULES=(
   stdlib/stats/perm_test.sio
   stdlib/stats/bootstrap_diff.sio
   stdlib/stats/bootstrap_corr.sio
+  stdlib/stats/mantel_haenszel.sio
+  stdlib/stats/attributable.sio
+  stdlib/stats/standardized_rate.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -35,7 +35,8 @@ fourteen families:
   restricted mean survival time, the actuarial life table, the log-rank test and
   a parametric exponential fit.
 - **Meta-analysis & epidemiology** — fixed / random-effects pooling, RR / OR /
-  NNT, and person-time incidence rates.
+  NNT, person-time incidence rates, the Mantel-Haenszel stratified odds ratio,
+  attributable risk / fractions, and directly / indirectly standardised rates.
 - **Multivariate (bivariate)** — the Mahalanobis distance, one-sample
   Hotelling's T² and two-variable PCA, all closed-form over the 2×2 covariance.
 - **Resampling** — the leave-one-out jackknife, a bit-reproducible Park-Miller
@@ -1157,6 +1158,40 @@ alternative to the Fisher-z interval when normality is doubtful). Validated:
 perfectly correlated data → r=1, SE=0, CI=[1,1]; noisy positive association → CI
 brackets the point r; reproducible.
 
+### `stats::mantel_haenszel` — stratified odds ratio
+
+| Function | Signature |
+|---|---|
+| `mantel_haenszel` | `pub fn mantel_haenszel(a: &[f64; 16], b: &[f64; 16], c: &[f64; 16], d: &[f64; 16], k: i32) -> MHResult with Mut, Div, Panic` |
+
+The confounding-adjusted pooled odds ratio across k 2×2 strata:
+`OR_MH=Σ(aᵢdᵢ/nᵢ)/Σ(bᵢcᵢ/nᵢ)`, the Mantel-Haenszel χ² test, and the
+Robins-Breslow-Greenland confidence interval. Validated: two strata each with
+OR 2 → OR_MH=2, χ²=4.111, 95% CI [1.024, 3.906]; null strata → OR_MH=1.
+
+### `stats::attributable` — attributable risk & fractions
+
+| Function | Signature |
+|---|---|
+| `attributable` | `pub fn attributable(a: f64, b: f64, c: f64, d: f64) -> AttribResult with Mut, Div, Panic` |
+
+Public-health impact from a cohort 2×2: risk difference (AR), risk ratio, the
+attributable fraction in the exposed `AFE=(RR−1)/RR`, and the population
+attributable fraction `PAF=(I−Rᵤ)/I`. Validated: Rₑ=0.2, Rᵤ=0.1 → AR=0.1, RR=2,
+AFE=0.5, PAF=0.333.
+
+### `stats::standardized_rate` — standardised rates
+
+| Function | Signature |
+|---|---|
+| `direct_standardized` | `pub fn direct_standardized(events: &[f64; 64], pop: &[f64; 64], std_weight: &[f64; 64], k: i32) -> DSRResult with Mut, Div, Panic` |
+| `smr` | `pub fn smr(events: &[f64; 64], expected: &[f64; 64], k: i32) -> SMRResult with Mut, Div, Panic` |
+
+Age/stratum standardisation to make populations comparable: the directly
+standardised rate `DSR=Σwᵢrᵢ/Σwᵢ` with a Poisson SE, and the indirect
+standardised ratio `SMR=Σobserved/Σexpected`. Validated: stratum rates 0.01/0.03
+weighted 0.4/0.6 → DSR=0.022; observed 40 / expected 50 → SMR=0.8.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1243,6 +1278,9 @@ use stats::bootstrap::{BootResult, bootstrap_mean}
 use stats::perm_test::{PermResult, perm_test}
 use stats::bootstrap_diff::{BootDiffResult, bootstrap_diff}
 use stats::bootstrap_corr::{BootCorrResult, bootstrap_corr}
+use stats::mantel_haenszel::{MHResult, mantel_haenszel}
+use stats::attributable::{AttribResult, attributable}
+use stats::standardized_rate::{DSRResult, SMRResult, direct_standardized, smr}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/attributable.sio
+++ b/stdlib/stats/attributable.sio
@@ -1,0 +1,111 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/attributable.sio — attributable risk & fractions
+//
+// The public-health impact measures from a cohort 2×2 table [[a,b],[c,d]]
+// (a = exposed cases, b = exposed non-cases, c = unexposed cases, d = unexposed
+// non-cases):
+//
+//   attributable(a, b, c, d) -> AttribResult
+//
+//   risk_exposed Rₑ = a/(a+b),  risk_unexposed Rᵤ = c/(c+d),
+//   AR   = Rₑ − Rᵤ                         (attributable risk / risk difference)
+//   RR   = Rₑ/Rᵤ,   AFE = (RR−1)/RR        (attributable fraction in the exposed)
+//   PAF  = (I − Rᵤ)/I,  I = (a+c)/n        (population attributable fraction)
+//
+// Pure Sounio: arithmetic only. No external dependency, no nested data-array calls.
+//
+// References:
+//   Levin (1953); Rothman, Greenland & Lash, "Modern Epidemiology" 3e, §3.
+
+module stats::attributable
+
+pub struct AttribResult {
+    pub risk_exposed: f64,
+    pub risk_unexposed: f64,
+    pub ar: f64,       // attributable risk (risk difference)
+    pub rr: f64,       // risk ratio
+    pub afe: f64,      // attributable fraction in the exposed
+    pub paf: f64,      // population attributable fraction
+}
+
+/// Attributable risk and fractions from a cohort 2×2 table.
+///
+/// Parâmetros: a,b — exposed cases / non-cases; c,d — unexposed cases / non-cases.
+/// Retorno: AttribResult (risks, AR, RR, AFE, PAF).
+/// Referências: Levin (1953); Rothman et al. §3.
+pub fn attributable(a: f64, b: f64, c: f64, d: f64) -> AttribResult with Mut, Div, Panic {
+    let ne = a + b
+    let nu = c + d
+    let n = ne + nu
+    if ne <= 0.0 || nu <= 0.0 || n <= 0.0 {
+        return AttribResult { risk_exposed: 0.0, risk_unexposed: 0.0, ar: 0.0, rr: 0.0, afe: 0.0, paf: 0.0 }
+    }
+    let re = a / ne
+    let ru = c / nu
+    let ar = re - ru
+    var rr = 0.0
+    if ru > 0.0 { rr = re / ru }
+    var afe = 0.0
+    if rr > 0.0 { afe = (rr - 1.0) / rr }
+    let ipop = (a + c) / n
+    var paf = 0.0
+    if ipop > 0.0 { paf = (ipop - ru) / ipop }
+    return AttribResult { risk_exposed: re, risk_unexposed: ru, ar: ar, rr: rr, afe: afe, paf: paf }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// exposed [[20,80]] Rₑ=0.2; unexposed [[10,90]] Rᵤ=0.1. n=200.
+// AR=0.1; RR=2; AFE=(2-1)/2=0.5; I=(20+10)/200=0.15; PAF=(0.15-0.1)/0.15=0.333333.
+fn test_attrib() -> bool with IO, Mut, Div, Panic {
+    let r = attributable(20.0, 80.0, 10.0, 90.0)
+    var ok = true
+    ok = check(1, approx(r.risk_exposed, 0.2, 1.0e-9)) && ok
+    ok = check(2, approx(r.risk_unexposed, 0.1, 1.0e-9)) && ok
+    ok = check(3, approx(r.ar, 0.1, 1.0e-9)) && ok
+    ok = check(4, approx(r.rr, 2.0, 1.0e-9)) && ok
+    ok = check(5, approx(r.afe, 0.5, 1.0e-9)) && ok
+    ok = check(6, approx(r.paf, 0.333333, 1.0e-5)) && ok
+    return ok
+}
+
+// no effect: equal risks -> AR 0, RR 1, AFE 0, PAF 0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    let r = attributable(10.0, 90.0, 10.0, 90.0)
+    var ok = true
+    ok = check(10, approx(r.ar, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.rr, 1.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.afe, 0.0, 1.0e-9)) && ok
+    ok = check(13, approx(r.paf, 0.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_attrib() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/mantel_haenszel.sio
+++ b/stdlib/stats/mantel_haenszel.sio
@@ -1,0 +1,217 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/mantel_haenszel.sio — Mantel-Haenszel stratified odds ratio
+//
+// Pools the odds ratio across k strata of a confounder, giving a single adjusted
+// estimate with the Mantel-Haenszel test and the Robins-Breslow-Greenland CI:
+//
+//   mantel_haenszel(a, b, c, d, k) -> MHResult      (each stratum a 2×2)
+//
+//   OR_MH = Σ(aᵢdᵢ/nᵢ) / Σ(bᵢcᵢ/nᵢ),
+//   χ²_MH = [Σ(aᵢ − E(aᵢ))]² / Σ Var(aᵢ)  (df 1),
+//   Var(ln OR_MH) via Robins-Breslow-Greenland (1986) for the CI.
+//
+// Pure Sounio: inline exp/ln/sqrt/erf; a single pass over the strata. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Mantel & Haenszel (1959); Robins, Breslow & Greenland (1986) Biometrics 42:311.
+
+module stats::mantel_haenszel
+
+fn mh_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / mh_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn mh_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn mh_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn mh_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * mh_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn mh_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - mh_erf(z * INV_SQRT2))
+}
+
+pub struct MHResult {
+    pub or_mh: f64,   // pooled odds ratio
+    pub chi2: f64,    // Mantel-Haenszel statistic (df 1)
+    pub p: f64,       // two-sided p
+    pub lo: f64,      // 95% CI lower (RBG)
+    pub hi: f64,      // 95% CI upper
+}
+
+/// Mantel-Haenszel pooled odds ratio across k 2×2 strata.
+///
+/// Parâmetros: a,b,c,d — per-stratum cell counts [[a,b],[c,d]]; k — strata (1..16).
+/// Retorno: MHResult (or_mh, chi2, p, lo, hi).
+/// Referências: Mantel & Haenszel (1959); Robins-Breslow-Greenland (1986).
+pub fn mantel_haenszel(a: &[f64; 16], b: &[f64; 16], c: &[f64; 16], d: &[f64; 16], k: i32) -> MHResult with Mut, Div, Panic {
+    if k < 1 || k > 16 { return MHResult { or_mh: 0.0, chi2: 0.0, p: 1.0, lo: 0.0, hi: 0.0 } }
+    var num = 0.0        // Σ a d / n
+    var den = 0.0        // Σ b c / n
+    var sum_a = 0.0
+    var sum_ea = 0.0
+    var sum_va = 0.0
+    // RBG accumulators
+    var sR = 0.0
+    var sS = 0.0
+    var sPR = 0.0
+    var sQS = 0.0
+    var sPSQR = 0.0
+    var i = 0
+    while i < k {
+        let ai = a[i as usize]
+        let bi = b[i as usize]
+        let ci = c[i as usize]
+        let di = d[i as usize]
+        let n = ai + bi + ci + di
+        if n > 0.0 {
+            num = num + ai * di / n
+            den = den + bi * ci / n
+            let r1 = ai + bi
+            let r2 = ci + di
+            let c1 = ai + ci
+            let c2 = bi + di
+            sum_a = sum_a + ai
+            sum_ea = sum_ea + r1 * c1 / n
+            if n > 1.0 { sum_va = sum_va + r1 * r2 * c1 * c2 / (n * n * (n - 1.0)) }
+            let P = (ai + di) / n
+            let Q = (bi + ci) / n
+            let R = ai * di / n
+            let S = bi * ci / n
+            sR = sR + R
+            sS = sS + S
+            sPR = sPR + P * R
+            sQS = sQS + Q * S
+            sPSQR = sPSQR + P * S + Q * R
+        }
+        i = i + 1
+    }
+    if den <= 0.0 || sR <= 0.0 || sS <= 0.0 {
+        return MHResult { or_mh: 0.0, chi2: 0.0, p: 1.0, lo: 0.0, hi: 0.0 }
+    }
+    let or_mh = num / den
+    var chi2 = 0.0
+    if sum_va > 0.0 {
+        let dev = sum_a - sum_ea
+        chi2 = dev * dev / sum_va
+    }
+    let p = 2.0 * mh_normal_sf(mh_sqrt(chi2))
+    // Robins-Breslow-Greenland variance of ln OR_MH
+    let var_ln = sPR / (2.0 * sR * sR) + sPSQR / (2.0 * sR * sS) + sQS / (2.0 * sS * sS)
+    let se = mh_sqrt(var_ln)
+    let lnor = mh_ln(or_mh)
+    let z = 1.959963984540054
+    return MHResult { or_mh: or_mh, chi2: chi2, p: p, lo: mh_exp(lnor - z * se), hi: mh_exp(lnor + z * se) }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// two strata, each OR=2. S1:[[20,10],[10,10]], S2:[[40,20],[20,20]].
+// OR_MH = (20·10/50 + 40·20/100)/(10·10/50 + 20·20/100) = (4+8)/(2+4) = 2.
+// chi2 = (6)²/8.756958 = 4.111; RBG var=0.116667, SE=0.341565,
+// CI = exp(ln2 ± 1.959964·0.341565) = [1.023978, 3.906455].
+fn test_mh() -> bool with IO, Mut, Div, Panic {
+    var a: [f64; 16] = [0.0; 16]
+    var b: [f64; 16] = [0.0; 16]
+    var c: [f64; 16] = [0.0; 16]
+    var d: [f64; 16] = [0.0; 16]
+    a[0]=20.0; b[0]=10.0; c[0]=10.0; d[0]=10.0
+    a[1]=40.0; b[1]=20.0; c[1]=20.0; d[1]=20.0
+    let r = mantel_haenszel(&a, &b, &c, &d, 2)
+    var ok = true
+    ok = check(1, approx(r.or_mh, 2.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.chi2, 4.111266, 1.0e-3)) && ok
+    ok = check(3, approx(r.lo, 1.023978, 1.0e-3)) && ok
+    ok = check(4, approx(r.hi, 3.906455, 1.0e-2)) && ok
+    return ok
+}
+
+// null: each stratum OR=1. S1:[[10,10],[10,10]], S2:[[20,20],[20,20]].
+// OR_MH=1, chi2≈0, CI brackets 1.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var a: [f64; 16] = [0.0; 16]
+    var b: [f64; 16] = [0.0; 16]
+    var c: [f64; 16] = [0.0; 16]
+    var d: [f64; 16] = [0.0; 16]
+    a[0]=10.0; b[0]=10.0; c[0]=10.0; d[0]=10.0
+    a[1]=20.0; b[1]=20.0; c[1]=20.0; d[1]=20.0
+    let r = mantel_haenszel(&a, &b, &c, &d, 2)
+    var ok = true
+    ok = check(10, approx(r.or_mh, 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.chi2, 0.0, 1.0e-6)) && ok
+    ok = check(12, r.lo < 1.0 && r.hi > 1.0) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_mh() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/standardized_rate.sio
+++ b/stdlib/stats/standardized_rate.sio
@@ -1,0 +1,154 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/standardized_rate.sio — directly & indirectly standardized rates
+//
+// Age- (or stratum-) standardised rates that make two populations comparable by
+// removing differences in their stratum structure:
+//
+//   direct_standardized(events, pop, std_weight, k) -> DSRResult
+//   smr(events, expected, k)                        -> SMRResult   (indirect)
+//
+// Direct: with stratum rates rᵢ = eventsᵢ/popᵢ and a standard-population weight
+// wᵢ,  DSR = Σ wᵢ rᵢ / Σ wᵢ,  with a Poisson SE  √(Σ wᵢ² rᵢ/popᵢ)/Σwᵢ.
+// Indirect: SMR = Σ observedᵢ / Σ expectedᵢ, expected from a reference rate.
+//
+// Pure Sounio: inline sqrt; one pass over the strata. No external dependency,
+// no nested data-array calls.
+//
+// References:
+//   Rothman, Greenland & Lash, "Modern Epidemiology" 3e, §4 (standardisation).
+
+module stats::standardized_rate
+
+fn sr_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct DSRResult {
+    pub dsr: f64,   // directly standardized rate
+    pub se: f64,    // Poisson standard error
+    pub lo: f64,    // 95% CI lower
+    pub hi: f64,    // 95% CI upper
+}
+
+pub struct SMRResult {
+    pub smr: f64,       // standardized mortality/morbidity ratio
+    pub observed: f64,
+    pub expected: f64,
+}
+
+/// Directly standardized rate over k strata against a standard-population weight.
+///
+/// Parâmetros: events, pop — per-stratum counts & person-time; std_weight — standard
+///             population weight per stratum; k — strata (1..64).
+/// Retorno: DSRResult (dsr, se, lo, hi).
+/// Referências: Rothman et al. §4.
+pub fn direct_standardized(events: &[f64; 64], pop: &[f64; 64], std_weight: &[f64; 64], k: i32) -> DSRResult with Mut, Div, Panic {
+    if k < 1 { return DSRResult { dsr: 0.0, se: 0.0, lo: 0.0, hi: 0.0 } }
+    var wsum = 0.0
+    var wr = 0.0       // Σ w r
+    var var_acc = 0.0  // Σ w² r / pop
+    var i = 0
+    while i < k {
+        let e = events[i as usize]
+        let p = pop[i as usize]
+        let w = std_weight[i as usize]
+        wsum = wsum + w
+        if p > 0.0 {
+            let r = e / p
+            wr = wr + w * r
+            var_acc = var_acc + w * w * r / p
+        }
+        i = i + 1
+    }
+    if wsum <= 0.0 { return DSRResult { dsr: 0.0, se: 0.0, lo: 0.0, hi: 0.0 } }
+    let dsr = wr / wsum
+    let se = sr_sqrt(var_acc) / wsum
+    let z = 1.959963984540054
+    return DSRResult { dsr: dsr, se: se, lo: dsr - z * se, hi: dsr + z * se }
+}
+
+/// Standardized mortality/morbidity ratio (indirect standardisation).
+///
+/// Parâmetros: events — observed per stratum; expected — expected per stratum
+///             (reference rate × local pop); k — strata (1..64).
+/// Retorno: SMRResult (smr, observed, expected).
+pub fn smr(events: &[f64; 64], expected: &[f64; 64], k: i32) -> SMRResult with Mut, Div, Panic {
+    if k < 1 { return SMRResult { smr: 0.0, observed: 0.0, expected: 0.0 } }
+    var obs = 0.0
+    var exp = 0.0
+    var i = 0
+    while i < k { obs = obs + events[i as usize]; exp = exp + expected[i as usize]; i = i + 1 }
+    var s = 0.0
+    if exp > 0.0 { s = obs / exp }
+    return SMRResult { smr: s, observed: obs, expected: exp }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// two strata: r1=10/1000=0.01, r2=30/1000=0.03; weights 0.4, 0.6.
+// DSR = (0.4·0.01 + 0.6·0.03)/(0.4+0.6) = (0.004+0.018)/1 = 0.022.
+fn test_dsr() -> bool with IO, Mut, Div, Panic {
+    var e: [f64; 64] = [0.0; 64]
+    var p: [f64; 64] = [0.0; 64]
+    var w: [f64; 64] = [0.0; 64]
+    e[0]=10.0; p[0]=1000.0; w[0]=0.4
+    e[1]=30.0; p[1]=1000.0; w[1]=0.6
+    let r = direct_standardized(&e, &p, &w, 2)
+    var ok = true
+    ok = check(1, approx(r.dsr, 0.022, 1.0e-9)) && ok
+    ok = check(2, r.se > 0.0) && ok
+    ok = check(3, r.lo < 0.022 && r.hi > 0.022) && ok
+    return ok
+}
+
+// SMR: observed 15+25=40, expected 10+40=50 -> SMR=0.8.
+fn test_smr() -> bool with IO, Mut, Div, Panic {
+    var o: [f64; 64] = [0.0; 64]
+    var ex: [f64; 64] = [0.0; 64]
+    o[0]=15.0; ex[0]=10.0
+    o[1]=25.0; ex[1]=40.0
+    let r = smr(&o, &ex, 2)
+    var ok = true
+    ok = check(10, approx(r.smr, 0.8, 1.0e-9)) && ok
+    ok = check(11, approx(r.observed, 40.0, 1.0e-9)) && ok
+    ok = check(12, approx(r.expected, 50.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_dsr() && ok
+    ok = test_smr() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three confounding-adjustment and impact modules, bringing the runner to **85 modules**. These extend the epidemiology / rate_epi family from crude single-table measures to **stratified and standardised analysis** — the core epidemiological problem of adjusting for confounders. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::mantel_haenszel` | Pooled OR across k 2×2 strata + M-H χ² + Robins-Breslow-Greenland CI |
| `stats::attributable` | Attributable risk (AR), RR, attributable fraction (AFE), population AF (PAF) |
| `stats::standardized_rate` | Directly standardised rate (+Poisson SE) and indirect SMR |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Mantel-Haenszel: two strata each OR 2 → OR_MH=2, χ²=4.111, 95% CI [1.024, 3.906] (RBG variance 0.1167 hand-derived); null strata → OR_MH=1.
  - Attributable: Rₑ=0.2, Rᵤ=0.1 → AR=0.1, RR=2, AFE=0.5, PAF=0.333.
  - Standardised: stratum rates 0.01/0.03 weighted 0.4/0.6 → DSR=0.022; observed 40 / expected 50 → SMR=0.8.
- Full suite selftest: **85 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; all deterministic and hand-derivable.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS, incl. the RBG variance formula).