### PR TITLE
test(stdlib): batch run-proofs — epistemic::covariance + cybernetic::variety + audio::pure::types

### DIFF
--- a/scripts/verticals_batch7_gate.sh
+++ b/scripts/verticals_batch7_gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Combined gate: epistemic::covariance, cybernetic::variety (default); audio::pure::types (lean_single).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel engine
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if [ "${4:-}" = "lean_single" ]; then
+    if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+      chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+    else echo "FAIL compile $2"; fail=1; fi
+  else
+    if $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+      "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+    else echo "FAIL compile $2"; fail=1; fi
+  fi
+}
+run stdlib/epistemic/covariance.sio    tests/stdlib/epistemic/test_covariance_stdlib.sio    COVARIANCE_STDLIB_OK
+run stdlib/cybernetic/variety.sio      tests/stdlib/cybernetic/test_variety_stdlib.sio      VARIETY_STDLIB_OK
+run stdlib/audio/pure/types.sio        tests/stdlib/audio/test_audio_stdlib.sio             AUDIO_STDLIB_OK   lean_single
+[ $fail -eq 0 ] && echo "VERTICALS_BATCH7_GATE_OK"
+exit $fail

--- a/tests/stdlib/audio/test_audio_stdlib.sio
+++ b/tests/stdlib/audio/test_audio_stdlib.sio
@@ -1,0 +1,16 @@
+// Run-proof for stdlib audio::pure::types (AudioBuffer). Build with lean_single (native f32 path fails).
+use audio::pure::types::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var b = audio_buffer_new(44100)
+    if audio_buffer_sample_rate(&b) != 44100 { print("FAIL rate\n"); return 1 }
+    audio_buffer_push(&!b, 0.5)
+    audio_buffer_push(&!b, 0.25)
+    audio_buffer_push(&!b, 0.125)
+    if audio_buffer_size(&b) != 3 { print("FAIL size\n"); return 2 }
+    let s0 = audio_buffer_get(&b, 0) as f64
+    if (if s0 > 0.5 { s0-0.5 } else { 0.5-s0 }) >= 1.0e-6 { print("FAIL s0\n"); return 3 }
+    let s2 = audio_buffer_get(&b, 2) as f64
+    if (if s2 > 0.125 { s2-0.125 } else { 0.125-s2 }) >= 1.0e-6 { print("FAIL s2\n"); return 4 }
+    print("AUDIO_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/cybernetic/test_variety_stdlib.sio
+++ b/tests/stdlib/cybernetic/test_variety_stdlib.sio
@@ -1,0 +1,31 @@
+// Run-proof for stdlib cybernetic::variety (Ashby's law of requisite variety).
+// variety = log2(distinct states); deficit = reg_variety - env_variety. Default Madaros.
+use cybernetic::variety::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // regulator surplus: reg 4 distinct states (log2=2), env 2 (log2=1) -> deficit +1, requisite
+    var a = variety_new()
+    a = record_env_state(a, 0)
+    a = record_env_state(a, 1)
+    a = record_reg_state(a, 0)
+    a = record_reg_state(a, 1)
+    a = record_reg_state(a, 2)
+    a = record_reg_state(a, 3)
+    a = compute_variety(a)
+    if !has_requisite_variety(a) { print("FAIL requisite_true\n"); return 1 }
+    let da = variety_deficit(a)
+    if (if da > 1.0 { da-1.0 } else { 1.0-da }) >= 1.0e-6 { print("FAIL deficit_pos\n"); return 2 }
+    // regulator deficit: env 4 (log2=2), reg 2 (log2=1) -> deficit -1, NOT requisite
+    var b = variety_new()
+    b = record_env_state(b, 0)
+    b = record_env_state(b, 1)
+    b = record_env_state(b, 2)
+    b = record_env_state(b, 3)
+    b = record_reg_state(b, 0)
+    b = record_reg_state(b, 1)
+    b = compute_variety(b)
+    if has_requisite_variety(b) { print("FAIL requisite_false\n"); return 3 }
+    let db = variety_deficit(b)   // -1 (asserted by value; print mis-renders negatives, #890)
+    if db > (0.0 - 0.9) { print("FAIL deficit_neg\n"); return 4 }
+    print("VARIETY_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/epistemic/test_covariance_stdlib.sio
+++ b/tests/stdlib/epistemic/test_covariance_stdlib.sio
@@ -1,0 +1,23 @@
+// Run-proof for stdlib epistemic::covariance (covariance matrix). By-reference API -> default Madaros.
+use epistemic::covariance::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var m = cov_new(2)
+    cov_set_variance(&!m, 0, 4.0)
+    cov_set_variance(&!m, 1, 9.0)
+    cov_set(&!m, 0, 1, 3.0)
+    // std = sqrt(variance)
+    if (if cov_get_std(&m,0) > 2.0 { cov_get_std(&m,0)-2.0 } else { 2.0-cov_get_std(&m,0) }) >= 1.0e-9 { print("FAIL std0\n"); return 1 }
+    if (if cov_get_std(&m,1) > 3.0 { cov_get_std(&m,1)-3.0 } else { 3.0-cov_get_std(&m,1) }) >= 1.0e-9 { print("FAIL std1\n"); return 2 }
+    // correlation = cov(0,1)/(std0*std1) = 3/(2*3) = 0.5
+    let r = correlation_coefficient(&m, 0, 1)
+    if (if r > 0.5 { r-0.5 } else { 0.5-r }) >= 1.0e-9 { print("FAIL corr\n"); return 3 }
+    // variance accessor + off-diagonal
+    if (if cov_get_variance(&m,0) > 4.0 { cov_get_variance(&m,0)-4.0 } else { 4.0-cov_get_variance(&m,0) }) >= 1.0e-9 { print("FAIL var0\n"); return 4 }
+    if (if cov_get(&m,0,1) > 3.0 { cov_get(&m,0,1)-3.0 } else { 3.0-cov_get(&m,0,1) }) >= 1.0e-9 { print("FAIL off\n"); return 5 }
+    // perfect correlation: cov = std0*std1 = 6 -> r = 1
+    cov_set(&!m, 0, 1, 6.0)
+    let r1 = correlation_coefficient(&m, 0, 1)
+    if (if r1 > 1.0 { r1-1.0 } else { 1.0-r1 }) >= 1.0e-9 { print("FAIL corr1\n"); return 6 }
+    print("COVARIANCE_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
**Grouped PR (3 verticals in one)**, lean (tests+gate only). Three cold/disjoint self-contained modules, **no source edits**:
- **epistemic::covariance** — covariance matrix std, correlation_coefficient=0.5, perfect=1 (default Madaros) -> `COVARIANCE_STDLIB_OK`.
- **cybernetic::variety** — Ashby's Law: variety=log2(states), requisite + deficit sign (default Madaros) -> `VARIETY_STDLIB_OK`.
- **audio::pure::types** — AudioBuffer rate/size/get (lean_single) -> `AUDIO_STDLIB_OK`.

Combined gate `VERTICALS_BATCH7_GATE_OK`; math-review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)