### PR TITLE
feat(stats): time-series smoothing & forecasting — exp_smoothing, holt, ar1

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2886,3 +2886,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - standardized_rate = **PASS**: DSR=Σwr/Σw + Poisson SE, SMR=Σobs/Σexp; DSR=0.022, SMR=0.8 verified.
 - Theme: epidemiological confounding adjustment — extends the epidemiology/rate_epi family from crude single-table to stratified/standardized measures. All derivable, #852-safe. Suite runner: 85 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-M5Sfo4/`, `/tmp/llm-offload-OSy10Z/`, `/tmp/llm-offload-zWkR61/`.
+
+## 2026-07-15 — math-review: stats::exp_smoothing, stats::holt, stats::ar1
+- Files (all new): `stdlib/stats/exp_smoothing.sio` (simple exponential smoothing SES), `stdlib/stats/holt.sio` (Holt linear-trend double smoothing + h-step forecast), `stdlib/stats/ar1.sio` (AR(1) fit via lag-1 autocorrelation + forecast). Provider: xAI/Grok 4.3.
+- exp_smoothing = **PASS**: sₜ=α·xₜ+(1−α)sₜ₋₁, SSE over n−1 one-step errors; {10,12,14,16}/α=0.5→level 14.25, SSE 25.25 verified.
+- holt = **PASS**: Holt (1957) level/trend recurrence + forecast(h)=ℓ+h·b; linear {2,4,6,8}→level 8, trend 2, forecast(2)=12, SSE 0 verified.
+- ar1 = **PASS**: Yule-Walker φ̂=lag-1 autocorr, c=μ(1−φ), forecast=c+φ·x_last, resid_sd over n−1 residuals; {1..5}→φ=0.4, forecast 3.8 verified.
+- Theme: time-series smoothing & forecasting — the actionable complement to the serial-dependence diagnostics (runs/durbin_watson/autocorr). All single-pass recurrences, scalar returns, derivable, #852-safe. Suite runner: 88 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-Xz9JAt/`, `/tmp/llm-offload-KGiEVt/`, `/tmp/llm-offload-KNJO6S/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -94,6 +94,9 @@ MODULES=(
   stdlib/stats/mantel_haenszel.sio
   stdlib/stats/attributable.sio
   stdlib/stats/standardized_rate.sio
+  stdlib/stats/exp_smoothing.sio
+  stdlib/stats/holt.sio
+  stdlib/stats/ar1.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -39,6 +39,8 @@ fourteen families:
   attributable risk / fractions, and directly / indirectly standardised rates.
 - **Multivariate (bivariate)** — the Mahalanobis distance, one-sample
   Hotelling's T² and two-variable PCA, all closed-form over the 2×2 covariance.
+- **Time series** — simple and Holt (linear-trend) exponential smoothing and an
+  AR(1) fit with one-step forecasts, beside the serial-dependence diagnostics.
 - **Resampling** — the leave-one-out jackknife, a bit-reproducible Park-Miller
   MINSTD generator (exact f64), the nonparametric bootstrap for the mean, the
   two-sample difference and correlation bootstraps, and a permutation test.
@@ -1192,6 +1194,36 @@ standardised rate `DSR=Σwᵢrᵢ/Σwᵢ` with a Poisson SE, and the indirect
 standardised ratio `SMR=Σobserved/Σexpected`. Validated: stratum rates 0.01/0.03
 weighted 0.4/0.6 → DSR=0.022; observed 40 / expected 50 → SMR=0.8.
 
+### `stats::exp_smoothing` — simple exponential smoothing
+
+| Function | Signature |
+|---|---|
+| `exp_smoothing` | `pub fn exp_smoothing(x: &[f64; 256], n: i32, alpha: f64) -> SESResult with Mut, Div, Panic` |
+
+The one-parameter level smoother / one-step forecaster: `sₜ=α·xₜ+(1−α)sₜ₋₁`, with
+the fit SSE from the one-step errors. Validated: {10,12,14,16}, α=0.5 →
+level=14.25, SSE=25.25; α=1 → tracks last value; constant → SSE=0.
+
+### `stats::holt` — Holt's linear-trend smoothing
+
+| Function | Signature |
+|---|---|
+| `holt` | `pub fn holt(x: &[f64; 256], n: i32, alpha: f64, beta: f64, h: i32) -> HoltResult with Mut, Div, Panic` |
+
+Double exponential smoothing with a level and trend component and an h-step
+forecast. Validated: linear {2,4,6,8}, α=β=0.5 → level 8, trend 2, forecast(2)=12,
+SSE=0; a perfect line is captured exactly for any α,β.
+
+### `stats::ar1` — first-order autoregressive model
+
+| Function | Signature |
+|---|---|
+| `ar1` | `pub fn ar1(x: &[f64; 256], n: i32) -> AR1Result with Mut, Div, Panic` |
+
+The AR(1) fit by the lag-1 autocorrelation (Yule-Walker), with the intercept
+`c=μ(1−φ)`, the one-step forecast and residual sd. Validated: {1..5} → φ=0.4,
+μ=3, intercept 1.8, forecast 3.8; a ramp → φ>0.6; alternating → φ<0.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1281,6 +1313,9 @@ use stats::bootstrap_corr::{BootCorrResult, bootstrap_corr}
 use stats::mantel_haenszel::{MHResult, mantel_haenszel}
 use stats::attributable::{AttribResult, attributable}
 use stats::standardized_rate::{DSRResult, SMRResult, direct_standardized, smr}
+use stats::exp_smoothing::{SESResult, exp_smoothing}
+use stats::holt::{HoltResult, holt}
+use stats::ar1::{AR1Result, ar1}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/ar1.sio
+++ b/stdlib/stats/ar1.sio
@@ -1,0 +1,141 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/ar1.sio — first-order autoregressive model AR(1)
+//
+// Fits the simplest autoregressive model — each value regresses on the previous
+// one — and gives its one-step forecast:
+//
+//   ar1(x, n) -> AR1Result
+//
+//   φ̂ = Σ_{t=1}^{n−1}(xₜ−x̄)(xₜ₋₁−x̄) / Σ_{t=0}^{n−1}(xₜ−x̄)²   (lag-1 autocorr),
+//   μ̂ = x̄,   intercept c = μ̂(1−φ̂),
+//   one-step forecast = c + φ̂·xₙ₋₁ = μ̂ + φ̂(xₙ₋₁ − μ̂).
+//
+// Pure Sounio: two passes (mean, then the lag-1 and total sums); inline sqrt for
+// the residual sd. No external dependency, no nested data-array calls.
+//
+// References:
+//   Box & Jenkins (1970); Yule-Walker equations.
+
+module stats::ar1
+
+fn ar_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct AR1Result {
+    pub phi: f64,        // AR(1) coefficient
+    pub mu: f64,         // series mean
+    pub intercept: f64,  // c = μ(1−φ)
+    pub forecast: f64,   // one-step-ahead forecast
+    pub resid_sd: f64,   // residual standard deviation
+}
+
+/// Fit an AR(1) model by the lag-1 autocorrelation and give its forecast.
+///
+/// Parâmetros: x — series (in order); n — length (>=3, <=256).
+/// Retorno: AR1Result (phi, mu, intercept, forecast, resid_sd).
+/// Referências: Box & Jenkins (1970).
+pub fn ar1(x: &[f64; 256], n: i32) -> AR1Result with Mut, Div, Panic {
+    if n < 3 { return AR1Result { phi: 0.0, mu: 0.0, intercept: 0.0, forecast: 0.0, resid_sd: 0.0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mu = s / nf
+    var den = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mu; den = den + d * d; j = j + 1 }
+    var num = 0.0
+    var t = 1
+    while t < n {
+        num = num + (x[t as usize] - mu) * (x[(t - 1) as usize] - mu)
+        t = t + 1
+    }
+    var phi = 0.0
+    if den > 1.0e-300 { phi = num / den }
+    let intercept = mu * (1.0 - phi)
+    let last = x[(n - 1) as usize]
+    let forecast = intercept + phi * last
+    // residual sd: e_t = x_t - (c + phi·x_{t-1}) for t>=1
+    var sse = 0.0
+    var k = 1
+    while k < n {
+        let e = x[k as usize] - (intercept + phi * x[(k - 1) as usize])
+        sse = sse + e * e
+        k = k + 1
+    }
+    let resid_sd = ar_sqrt(sse / ((n - 1) as f64))
+    return AR1Result { phi: phi, mu: mu, intercept: intercept, forecast: forecast, resid_sd: resid_sd }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3,4,5}: mu=3, lag-1 acf phi=0.4, intercept=3·0.6=1.8,
+// forecast=1.8+0.4·5=3.8.
+fn test_ar1() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = ar1(&x, 5)
+    var ok = true
+    ok = check(1, approx(r.phi, 0.4, 1.0e-9)) && ok
+    ok = check(2, approx(r.mu, 3.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.intercept, 1.8, 1.0e-9)) && ok
+    ok = check(4, approx(r.forecast, 3.8, 1.0e-9)) && ok
+    return ok
+}
+
+// strong persistence: a smooth ramp has phi close to 1.
+fn test_persistent() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 12 { x[i as usize] = (i + 1) as f64; i = i + 1 }
+    let r = ar1(&x, 12)
+    return check(10, r.phi > 0.6)
+}
+
+// alternating series -> negative phi.
+fn test_negative() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=0.0-1.0; x[2]=1.0; x[3]=0.0-1.0; x[4]=1.0; x[5]=0.0-1.0
+    let r = ar1(&x, 6)
+    return check(20, r.phi < 0.0)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_ar1() && ok
+    ok = test_persistent() && ok
+    ok = test_negative() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/exp_smoothing.sio
+++ b/stdlib/stats/exp_smoothing.sio
@@ -1,0 +1,110 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/exp_smoothing.sio — simple exponential smoothing (SES)
+//
+// The one-parameter smoother / one-step forecaster for a level series with no
+// trend or seasonality:
+//
+//   exp_smoothing(x, n, alpha) -> SESResult
+//
+//   s₀ = x₀,   sₜ = α·xₜ + (1−α)·sₜ₋₁,
+// the final level sₙ₋₁ is the one-step-ahead forecast; the fit's SSE sums the
+// one-step forecast errors Σ (xₜ − sₜ₋₁)².
+//
+// Pure Sounio: a single recurrence pass. No external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Brown (1959); Hyndman & Athanasopoulos, "Forecasting: Principles and
+//   Practice", §7.1.
+
+module stats::exp_smoothing
+
+pub struct SESResult {
+    pub level: f64,      // final smoothed level = one-step forecast
+    pub sse: f64,        // sum of squared one-step forecast errors
+    pub forecast: f64,   // = level (flat forecast for any horizon)
+}
+
+/// Simple exponential smoothing with smoothing parameter alpha.
+///
+/// Parâmetros: x — series; n — length (>=2); alpha — smoothing in (0,1].
+/// Retorno: SESResult (level, sse, forecast).
+/// Referências: Brown (1959).
+pub fn exp_smoothing(x: &[f64; 256], n: i32, alpha: f64) -> SESResult with Mut, Div, Panic {
+    if n < 2 { return SESResult { level: 0.0, sse: 0.0, forecast: 0.0 } }
+    var s = x[0]
+    var sse = 0.0
+    var t = 1
+    while t < n {
+        let err = x[t as usize] - s          // one-step forecast error (forecast = s_{t-1})
+        sse = sse + err * err
+        s = alpha * x[t as usize] + (1.0 - alpha) * s
+        t = t + 1
+    }
+    return SESResult { level: s, sse: sse, forecast: s }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={10,12,14,16}, alpha=0.5. s0=10; s1=11; s2=12.5; s3=14.25.
+// errors: 2,3,3.5 -> SSE = 4+9+12.25 = 25.25.
+fn test_ses() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=12.0; x[2]=14.0; x[3]=16.0
+    let r = exp_smoothing(&x, 4, 0.5)
+    var ok = true
+    ok = check(1, approx(r.level, 14.25, 1.0e-9)) && ok
+    ok = check(2, approx(r.sse, 25.25, 1.0e-9)) && ok
+    ok = check(3, approx(r.forecast, 14.25, 1.0e-9)) && ok
+    return ok
+}
+
+// alpha=1 -> level tracks the last value exactly.
+fn test_alpha1() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=5.0; x[1]=7.0; x[2]=3.0; x[3]=9.0
+    let r = exp_smoothing(&x, 4, 1.0)
+    return check(10, approx(r.level, 9.0, 1.0e-9))
+}
+
+// constant series -> zero error, level = the constant.
+fn test_constant() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=4.0; x[1]=4.0; x[2]=4.0; x[3]=4.0
+    let r = exp_smoothing(&x, 4, 0.3)
+    var ok = true
+    ok = check(20, approx(r.level, 4.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.sse, 0.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_ses() && ok
+    ok = test_alpha1() && ok
+    ok = test_constant() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/holt.sio
+++ b/stdlib/stats/holt.sio
@@ -1,0 +1,110 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/holt.sio — Holt's linear-trend exponential smoothing
+//
+// Double exponential smoothing: a level and a trend component, for series with
+// a (locally) linear trend but no seasonality:
+//
+//   holt(x, n, alpha, beta, h) -> HoltResult
+//
+//   ℓ₀ = x₀,  b₀ = x₁ − x₀,
+//   ℓₜ = α·xₜ + (1−α)(ℓₜ₋₁ + bₜ₋₁),
+//   bₜ = β(ℓₜ − ℓₜ₋₁) + (1−β)·bₜ₋₁,
+//   forecast(h) = ℓₙ₋₁ + h·bₙ₋₁.
+//
+// Pure Sounio: a single recurrence pass. No external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Holt (1957); Hyndman & Athanasopoulos, "Forecasting", §7.2.
+
+module stats::holt
+
+pub struct HoltResult {
+    pub level: f64,      // final level ℓ
+    pub trend: f64,      // final trend b
+    pub forecast: f64,   // ℓ + h·b
+    pub sse: f64,        // one-step forecast SSE
+}
+
+/// Holt's linear-trend exponential smoothing with an h-step forecast.
+///
+/// Parâmetros: x — series; n — length (>=3); alpha, beta — smoothing in (0,1];
+///             h — forecast horizon (>=1).
+/// Retorno: HoltResult (level, trend, forecast, sse).
+/// Referências: Holt (1957).
+pub fn holt(x: &[f64; 256], n: i32, alpha: f64, beta: f64, h: i32) -> HoltResult with Mut, Div, Panic {
+    if n < 3 { return HoltResult { level: 0.0, trend: 0.0, forecast: 0.0, sse: 0.0 } }
+    var l = x[0]
+    var b = x[1] - x[0]
+    var sse = 0.0
+    var t = 1
+    while t < n {
+        let fcast = l + b                    // one-step forecast for time t
+        let err = x[t as usize] - fcast
+        sse = sse + err * err
+        let l_prev = l
+        l = alpha * x[t as usize] + (1.0 - alpha) * (l + b)
+        b = beta * (l - l_prev) + (1.0 - beta) * b
+        t = t + 1
+    }
+    let forecast = l + (h as f64) * b
+    return HoltResult { level: l, trend: b, forecast: forecast, sse: sse }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect linear x={2,4,6,8}, alpha=beta=0.5. l0=2,b0=2.
+// t=1: l=4,b=2; t=2: l=6,b=2; t=3: l=8,b=2. forecast(h=2)=8+2·2=12.
+// one-step forecasts are exact (linear) -> SSE=0.
+fn test_holt() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=6.0; x[3]=8.0
+    let r = holt(&x, 4, 0.5, 0.5, 2)
+    var ok = true
+    ok = check(1, approx(r.level, 8.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.trend, 2.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.forecast, 12.0, 1.0e-9)) && ok
+    ok = check(4, approx(r.sse, 0.0, 1.0e-9)) && ok
+    return ok
+}
+
+// perfect linear captured for any alpha/beta: x={0,3,6,9,12}, forecast(1)=15.
+fn test_linear() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=3.0; x[2]=6.0; x[3]=9.0; x[4]=12.0
+    let r = holt(&x, 5, 0.4, 0.3, 1)
+    var ok = true
+    ok = check(10, approx(r.trend, 3.0, 1.0e-6)) && ok
+    ok = check(11, approx(r.forecast, 15.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_holt() && ok
+    ok = test_linear() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three time-series modules, bringing the runner to **88 modules**. These are the actionable complement to the suite's serial-dependence *diagnostics* (`runs_test`, `durbin_watson`, `autocorr`) — going from detecting temporal structure to smoothing and forecasting it. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::exp_smoothing` | Simple exponential smoothing (SES): level smoother + flat one-step forecast |
| `stats::holt` | Holt's linear-trend double smoothing: level + trend + h-step forecast |
| `stats::ar1` | First-order autoregressive fit (Yule-Walker) + one-step forecast |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - SES: {10,12,14,16}, α=0.5 → level=14.25, SSE=25.25; α=1 tracks last value; constant → SSE=0.
  - Holt: linear {2,4,6,8}, α=β=0.5 → level 8, trend 2, forecast(2)=12, SSE=0; a perfect line is captured exactly for any α,β.
  - AR(1): {1..5} → φ=0.4, μ=3, intercept 1.8, forecast 3.8; a ramp → φ>0.6; alternating → φ<0.
- Full suite selftest: **88 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; single-pass recurrences, fully hand-derivable.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).