### PR TITLE
feat(stats): statistical process control — process_capability, control_chart, cusum

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2894,3 +2894,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - ar1 = **PASS**: Yule-Walker φ̂=lag-1 autocorr, c=μ(1−φ), forecast=c+φ·x_last, resid_sd over n−1 residuals; {1..5}→φ=0.4, forecast 3.8 verified.
 - Theme: time-series smoothing & forecasting — the actionable complement to the serial-dependence diagnostics (runs/durbin_watson/autocorr). All single-pass recurrences, scalar returns, derivable, #852-safe. Suite runner: 88 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Xz9JAt/`, `/tmp/llm-offload-KGiEVt/`, `/tmp/llm-offload-KNJO6S/`.
+
+## 2026-07-15 — math-review: stats::process_capability, stats::control_chart, stats::cusum
+- Files (all new): `stdlib/stats/process_capability.sio` (Cp/Cpk/Cpu/Cpl), `stdlib/stats/control_chart.sio` (Shewhart individuals-moving-range I-MR chart), `stdlib/stats/cusum.sio` (tabular CUSUM). Provider: xAI/Grok 4.3.
+- process_capability = **PASS**: Cp=(USL−LSL)/6σ, Cpk=min(Cpu,Cpl); centred→1.333, off-centre→Cpk=1 verified.
+- control_chart = **PASS**: σ̂=M̄R/d₂ (d₂=1.128), UCL/LCL=x̄±3σ̂ (=±2.66·M̄R), UCL_MR=D₄·M̄R (D₄=3.267); {10,12,11,13,12}→CL 11.6, UCL 15.589, UCL_MR 4.9005 verified.
+- cusum = **PASS**: tabular Page/Montgomery C⁺/C⁻ recurrences; upward-drift C⁺ sequence 0,0,0.5,2,4.5,8 signalling at index 4 verified step-by-step.
+- Theme: statistical process control (SPC) — the lab-QC / manufacturing quality toolkit (relevant to biomaterials production). All derivable, #852-safe. Suite runner: 91 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-M8a5V7/`, `/tmp/llm-offload-Di0Efu/`, `/tmp/llm-offload-HR4OMO/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -97,6 +97,9 @@ MODULES=(
   stdlib/stats/exp_smoothing.sio
   stdlib/stats/holt.sio
   stdlib/stats/ar1.sio
+  stdlib/stats/process_capability.sio
+  stdlib/stats/control_chart.sio
+  stdlib/stats/cusum.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -41,6 +41,8 @@ fourteen families:
   Hotelling's T² and two-variable PCA, all closed-form over the 2×2 covariance.
 - **Time series** — simple and Holt (linear-trend) exponential smoothing and an
   AR(1) fit with one-step forecasts, beside the serial-dependence diagnostics.
+- **Process control (SPC)** — process capability indices (Cp/Cpk), the Shewhart
+  individuals (I-MR) control chart, and the tabular CUSUM.
 - **Resampling** — the leave-one-out jackknife, a bit-reproducible Park-Miller
   MINSTD generator (exact f64), the nonparametric bootstrap for the mean, the
   two-sample difference and correlation bootstraps, and a permutation test.
@@ -1224,6 +1226,39 @@ The AR(1) fit by the lag-1 autocorrelation (Yule-Walker), with the intercept
 `c=μ(1−φ)`, the one-step forecast and residual sd. Validated: {1..5} → φ=0.4,
 μ=3, intercept 1.8, forecast 3.8; a ramp → φ>0.6; alternating → φ<0.
 
+### `stats::process_capability` — process capability indices
+
+| Function | Signature |
+|---|---|
+| `process_capability` | `pub fn process_capability(mu: f64, sigma: f64, lsl: f64, usl: f64) -> CapabilityResult with Mut, Div, Panic` |
+
+The quality-control capability measures against specification limits:
+`Cp=(USL−LSL)/6σ` (potential) and `Cpk=min(Cpu,Cpl)` (centring-aware).
+Validated: centred (μ=6, σ=1, spec 2–10) → Cp=Cpk=1.333; off-centre (μ=7) →
+Cp=1.333 but Cpk=1.
+
+### `stats::control_chart` — Shewhart I-MR control chart
+
+| Function | Signature |
+|---|---|
+| `imr_chart` | `pub fn imr_chart(x: &[f64; 256], n: i32) -> IMRResult with Mut, Div, Panic` |
+
+Individuals & moving-range control limits from a measurement stream:
+`σ̂=M̄R/d₂`, `UCL/LCL=x̄±3σ̂`, `UCL_MR=D₄·M̄R`, with an out-of-control count.
+Validated: {10,12,11,13,12} → CL=11.6, M̄R=1.5, UCL=15.589, UCL_MR=4.9005; an
+obvious outlier trips the limit.
+
+### `stats::cusum` — tabular CUSUM control chart
+
+| Function | Signature |
+|---|---|
+| `cusum` | `pub fn cusum(x: &[f64; 256], n: i32, target: f64, k: f64, h: f64) -> CusumResult with Mut, Div, Panic` |
+
+The cumulative-sum chart, sensitive to small sustained shifts:
+`Cᵢ⁺=max(0,Cᵢ₋₁⁺+(xᵢ−(target+k)))` (and the lower analogue), signalling when a
+CUSUM exceeds the decision interval h. Validated: an upward drift → C⁺ reaches 8,
+signals at index 4; on-target → no signal; downward drift → lower CUSUM signals.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1316,6 +1351,9 @@ use stats::standardized_rate::{DSRResult, SMRResult, direct_standardized, smr}
 use stats::exp_smoothing::{SESResult, exp_smoothing}
 use stats::holt::{HoltResult, holt}
 use stats::ar1::{AR1Result, ar1}
+use stats::process_capability::{CapabilityResult, process_capability}
+use stats::control_chart::{IMRResult, imr_chart}
+use stats::cusum::{CusumResult, cusum}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/control_chart.sio
+++ b/stdlib/stats/control_chart.sio
@@ -1,0 +1,125 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/control_chart.sio — Shewhart individuals (I-MR) control chart
+//
+// Control limits for a stream of individual measurements, using the average
+// moving range to estimate short-term variation:
+//
+//   imr_chart(x, n) -> IMRResult
+//
+//   MRᵢ = |xᵢ − xᵢ₋₁|,   M̄R = mean MR,   σ̂ = M̄R / d₂  (d₂ = 1.128 for n=2),
+//   individuals: CL = x̄,  UCL/LCL = x̄ ± 3·σ̂  (= x̄ ± 2.66·M̄R),
+//   moving range: UCL = D₄·M̄R  (D₄ = 3.267),  LCL = 0.
+// Points outside the individuals limits signal an out-of-control process.
+//
+// Pure Sounio: two passes (mean, moving ranges); a final pass flags points. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Shewhart (1931); Montgomery, "Statistical Quality Control" 7e, §6.4.
+
+module stats::control_chart
+
+pub struct IMRResult {
+    pub cl: f64,        // centre line (mean)
+    pub ucl: f64,       // upper control limit (individuals)
+    pub lcl: f64,       // lower control limit
+    pub mr_bar: f64,    // average moving range
+    pub ucl_mr: f64,    // upper control limit for moving range
+    pub n_out: i64,     // count of points outside the individuals limits
+}
+
+/// Shewhart individuals & moving-range (I-MR) control chart.
+///
+/// Parâmetros: x — measurement series; n — length (>=2, <=256).
+/// Retorno: IMRResult (cl, ucl, lcl, mr_bar, ucl_mr, n_out).
+/// Referências: Shewhart (1931); Montgomery §6.4.
+pub fn imr_chart(x: &[f64; 256], n: i32) -> IMRResult with Mut, Div, Panic {
+    if n < 2 { return IMRResult { cl: 0.0, ucl: 0.0, lcl: 0.0, mr_bar: 0.0, ucl_mr: 0.0, n_out: 0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let cl = s / nf
+    // average moving range
+    var smr = 0.0
+    var t = 1
+    while t < n {
+        let d = x[t as usize] - x[(t - 1) as usize]
+        let ad = if d < 0.0 { 0.0 - d } else { d }
+        smr = smr + ad
+        t = t + 1
+    }
+    let mr_bar = smr / ((n - 1) as f64)
+    let D2 = 1.128
+    let D4 = 3.267
+    let sigma = mr_bar / D2
+    let ucl = cl + 3.0 * sigma
+    let lcl = cl - 3.0 * sigma
+    let ucl_mr = D4 * mr_bar
+    // count points outside the individuals limits
+    var cnt = 0
+    var j = 0
+    while j < n {
+        let v = x[j as usize]
+        if v > ucl || v < lcl { cnt = cnt + 1 }
+        j = j + 1
+    }
+    return IMRResult { cl: cl, ucl: ucl, lcl: lcl, mr_bar: mr_bar, ucl_mr: ucl_mr, n_out: cnt as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={10,12,11,13,12}: mean 11.6. MR={2,1,2,1}, M̄R=1.5.
+// sigma=1.5/1.128=1.329787; UCL=11.6+3.989362=15.589362; LCL=7.610638.
+// UCL_MR=3.267·1.5=4.9005. All points in control -> n_out=0.
+fn test_imr() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=12.0; x[2]=11.0; x[3]=13.0; x[4]=12.0
+    let r = imr_chart(&x, 5)
+    var ok = true
+    ok = check(1, approx(r.cl, 11.6, 1.0e-9)) && ok
+    ok = check(2, approx(r.mr_bar, 1.5, 1.0e-9)) && ok
+    ok = check(3, approx(r.ucl, 15.589362, 1.0e-4)) && ok
+    ok = check(4, approx(r.lcl, 7.610638, 1.0e-4)) && ok
+    ok = check(5, approx(r.ucl_mr, 4.9005, 1.0e-4)) && ok
+    ok = check(6, r.n_out == 0) && ok
+    return ok
+}
+
+// an obvious outlier trips the limit. x={10,10,10,10,30}.
+fn test_outlier() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=10.0; x[2]=10.0; x[3]=10.0; x[4]=30.0
+    let r = imr_chart(&x, 5)
+    return check(10, r.n_out >= 1)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_imr() && ok
+    ok = test_outlier() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/cusum.sio
+++ b/stdlib/stats/cusum.sio
@@ -1,0 +1,127 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/cusum.sio — tabular CUSUM control chart
+//
+// The cumulative-sum control chart, far more sensitive than a Shewhart chart to
+// small sustained shifts away from a target:
+//
+//   cusum(x, n, target, k, h) -> CusumResult
+//
+// With reference value k (the allowance, typically ½σ) and decision interval h
+// (typically 4σ or 5σ),
+//   Cᵢ⁺ = max(0, Cᵢ₋₁⁺ + (xᵢ − (target + k))),
+//   Cᵢ⁻ = max(0, Cᵢ₋₁⁻ + ((target − k) − xᵢ)),
+// and the process signals the first time Cᵢ⁺ > h or Cᵢ⁻ > h.
+//
+// Pure Sounio: a single recurrence pass. No external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Page (1954) Biometrika 41:100; Montgomery, "Statistical Quality Control"
+//   7e, §9.1.
+
+module stats::cusum
+
+pub struct CusumResult {
+    pub c_plus: f64,        // final upper CUSUM
+    pub c_minus: f64,       // final lower CUSUM
+    pub signaled: i64,      // 1 if the chart ever crossed h
+    pub signal_index: i64,  // first index that signalled, or -1
+}
+
+/// Tabular CUSUM control chart for a shift from `target`.
+///
+/// Parâmetros: x — series; n — length (>=1); target — process target;
+///             k — reference value (allowance); h — decision interval.
+/// Retorno: CusumResult (c_plus, c_minus, signaled, signal_index).
+/// Referências: Page (1954); Montgomery §9.1.
+pub fn cusum(x: &[f64; 256], n: i32, target: f64, k: f64, h: f64) -> CusumResult with Mut, Div, Panic {
+    if n < 1 { return CusumResult { c_plus: 0.0, c_minus: 0.0, signaled: 0, signal_index: 0 - 1 } }
+    var cp = 0.0
+    var cm = 0.0
+    var signaled = 0
+    var sig_idx = 0 - 1
+    let up = target + k
+    let dn = target - k
+    var i = 0
+    while i < n {
+        let xi = x[i as usize]
+        cp = cp + (xi - up)
+        if cp < 0.0 { cp = 0.0 }
+        cm = cm + (dn - xi)
+        if cm < 0.0 { cm = 0.0 }
+        if signaled == 0 {
+            if cp > h || cm > h { signaled = 1; sig_idx = i }
+        }
+        i = i + 1
+    }
+    return CusumResult { c_plus: cp, c_minus: cm, signaled: signaled as i64, signal_index: sig_idx as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// target=10, k=0.5, h=4. x={10,10,11,12,13,14}.
+// C+: 0,0,0.5,2.0,4.5(>4 signal @4),8.0. C- stays 0.
+fn test_cusum() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=10.0; x[2]=11.0; x[3]=12.0; x[4]=13.0; x[5]=14.0
+    let r = cusum(&x, 6, 10.0, 0.5, 4.0)
+    var ok = true
+    ok = check(1, approx(r.c_plus, 8.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.c_minus, 0.0, 1.0e-9)) && ok
+    ok = check(3, r.signaled == 1) && ok
+    ok = check(4, r.signal_index == 4) && ok
+    return ok
+}
+
+// on-target series never signals.
+fn test_on_target() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=9.5; x[2]=10.5; x[3]=10.0; x[4]=9.8; x[5]=10.2
+    let r = cusum(&x, 6, 10.0, 0.5, 4.0)
+    var ok = true
+    ok = check(10, r.signaled == 0) && ok
+    ok = check(11, r.signal_index == 0 - 1) && ok
+    return ok
+}
+
+// downward shift trips the lower CUSUM. target=10, x drifting down.
+fn test_downward() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=9.0; x[2]=8.0; x[3]=7.0; x[4]=6.0
+    let r = cusum(&x, 5, 10.0, 0.5, 4.0)
+    var ok = true
+    ok = check(20, r.signaled == 1) && ok
+    ok = check(21, r.c_minus > 4.0) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_cusum() && ok
+    ok = test_on_target() && ok
+    ok = test_downward() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/process_capability.sio
+++ b/stdlib/stats/process_capability.sio
@@ -1,0 +1,99 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/process_capability.sio — process capability indices
+//
+// Summarises how well a process fits its specification limits — the standard
+// quality-control capability measures:
+//
+//   process_capability(mu, sigma, lsl, usl) -> CapabilityResult
+//
+//   Cp  = (USL − LSL) / (6σ)                        (potential capability)
+//   Cpu = (USL − μ)/(3σ),   Cpl = (μ − LSL)/(3σ),
+//   Cpk = min(Cpu, Cpl)                              (actual, centring-aware)
+// A process is usually called capable at Cpk ≥ 1.33.
+//
+// Pure Sounio: arithmetic only. No external dependency, no nested data-array
+// calls.
+//
+// References:
+//   Kane (1986) J. Qual. Technol. 18:41; Montgomery, "Statistical Quality
+//   Control" 7e, §8.
+
+module stats::process_capability
+
+pub struct CapabilityResult {
+    pub cp: f64,     // potential capability
+    pub cpk: f64,    // actual capability (min of Cpu, Cpl)
+    pub cpu: f64,    // upper capability
+    pub cpl: f64,    // lower capability
+}
+
+/// Process capability indices from the mean, sd and specification limits.
+///
+/// Parâmetros: mu, sigma — process mean & sd (sigma>0); lsl, usl — spec limits (usl>lsl).
+/// Retorno: CapabilityResult (cp, cpk, cpu, cpl).
+/// Referências: Kane (1986); Montgomery §8.
+pub fn process_capability(mu: f64, sigma: f64, lsl: f64, usl: f64) -> CapabilityResult with Mut, Div, Panic {
+    if sigma <= 0.0 || usl <= lsl {
+        return CapabilityResult { cp: 0.0, cpk: 0.0, cpu: 0.0, cpl: 0.0 }
+    }
+    let cp = (usl - lsl) / (6.0 * sigma)
+    let cpu = (usl - mu) / (3.0 * sigma)
+    let cpl = (mu - lsl) / (3.0 * sigma)
+    var cpk = cpu
+    if cpl < cpu { cpk = cpl }
+    return CapabilityResult { cp: cp, cpk: cpk, cpu: cpu, cpl: cpl }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// centered: mu=6, sigma=1, LSL=2, USL=10.
+// Cp=(10-2)/6=1.333333; Cpu=Cpl=(4)/3=1.333333; Cpk=1.333333.
+fn test_centered() -> bool with IO, Mut, Div, Panic {
+    let r = process_capability(6.0, 1.0, 2.0, 10.0)
+    var ok = true
+    ok = check(1, approx(r.cp, 1.333333, 1.0e-5)) && ok
+    ok = check(2, approx(r.cpk, 1.333333, 1.0e-5)) && ok
+    return ok
+}
+
+// off-centre: mu=7, sigma=1, LSL=2, USL=10.
+// Cp still 1.333333; Cpu=(10-7)/3=1; Cpl=(7-2)/3=1.666667; Cpk=1.
+fn test_offcenter() -> bool with IO, Mut, Div, Panic {
+    let r = process_capability(7.0, 1.0, 2.0, 10.0)
+    var ok = true
+    ok = check(10, approx(r.cp, 1.333333, 1.0e-5)) && ok
+    ok = check(11, approx(r.cpu, 1.0, 1.0e-6)) && ok
+    ok = check(12, approx(r.cpl, 1.666667, 1.0e-5)) && ok
+    ok = check(13, approx(r.cpk, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_centered() && ok
+    ok = test_offcenter() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three SPC modules, bringing the runner to **91 modules**. These add the lab-QC and manufacturing quality toolkit — directly relevant to biomaterials production (batch consistency, assay drift). Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::process_capability` | Cp (potential) and Cpk (centring-aware) vs specification limits |
| `stats::control_chart` | Shewhart individuals & moving-range (I-MR) control chart |
| `stats::cusum` | Tabular CUSUM — sensitive to small sustained shifts |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Capability: centred (μ=6, σ=1, spec 2–10) → Cp=Cpk=1.333; off-centre (μ=7) → Cp=1.333 but Cpk=1.
  - I-MR: {10,12,11,13,12} → CL=11.6, M̄R=1.5, UCL=15.589 (=x̄+2.66·M̄R), UCL_MR=4.9005; an obvious outlier trips the limit.
  - CUSUM: upward drift → C⁺ sequence 0,0,0.5,2,4.5,8, signals at index 4; on-target → no signal; downward drift → lower CUSUM signals.
- Full suite selftest: **91 modules + 7 demos ALL GREEN** under `lean_single`.
- No FFI, no external dependency; all deterministic and hand-derivable.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).