### PR TITLE
chore(docs): housekeeping — batched math-review logs + verticals index

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2894,3 +2894,20 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - ar1 = **PASS**: Yule-Walker φ̂=lag-1 autocorr, c=μ(1−φ), forecast=c+φ·x_last, resid_sd over n−1 residuals; {1..5}→φ=0.4, forecast 3.8 verified.
 - Theme: time-series smoothing & forecasting — the actionable complement to the serial-dependence diagnostics (runs/durbin_watson/autocorr). All single-pass recurrences, scalar returns, derivable, #852-safe. Suite runner: 88 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Xz9JAt/`, `/tmp/llm-offload-KGiEVt/`, `/tmp/llm-offload-KNJO6S/`.
+
+## 2026-07-15 — math-review housekeeping: grouped stdlib run-proof batches (#941–#967)
+The following math-reviews were run (xAI/Grok 4.3, all **PASS**) during grouped run-proof PRs whose branches
+were kept lean (tests+gate only) for clean merges; recorded here in batch for offload-policy compliance.
+Each verifies stdlib module outputs against known/first-principles values (gates under scripts/*_gate.sh).
+
+- **#941** special::beta (beta(2,3)=1/12, beta(0.5,0.5)=π, ibeta bounds + I_{0.5}(2,2)=0.5 + ibeta_inv round-trip), math::hyperbolic (cosh/sinh(0,1), cosh²−sinh²=1, arccosh round-trip), math::rational (exact fractions via rat_cmp). PASS.
+- **#948** encoding::hex (0xff10→"ff10"/"FF10", decode round-trip), math::dd64 (double-double: recovers 1e-20, √2²=2 to 1e-25), math::combinatorics_perm (n! + next_permutation lexicographic). PASS.
+- **#950** autodiff::epistemic_dual (d/dx x²=2x, product rule, d/dx eˣ=1), collections::vec (push/pop/sum/mean/reverse), collections::stack (LIFO). PASS.
+- **#954** collections::hashmap (insert/get/count/contains/remove), core::result (IntResult/FloatResult ok/err/unwrap), math::qd128 (quad-double ~63-digit: recovers 1e-40, √2²=2 to 1e-28; lean_single). PASS.
+- **#957** viz::colormap (viridis knots (68,1,84)/(35,144,138)/(253,231,37) = matplotlib, [0,255]), geo::pure::types (Euclidean 3-4-5=5, 3D=3, triangle area=6), queue::pure::types (FIFO). PASS.
+- **#963** data::json (serializer output-conformance, RFC-8259), data::csv (header+row), math::approx (Newton sqrt, Taylor sin). PASS.
+- **#967** epistemic::covariance (std, correlation_coefficient=0.5/perfect=1), cybernetic::variety (Ashby: variety=log₂ states, requisite + deficit), audio::pure::types (buffer; lean_single). PASS.
+
+Evidence boundary: each verifies numeric/serialization/structural correctness of the named module's public
+API against known values; no source or compiler edits. Compiler bugs surfaced during the campaign are
+tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 983
-- Repo-backed topics: 833
+- Total governed topics: 984
+- Repo-backed topics: 834
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 583
+- Authority count `repo_only`: 584
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 602 topics
+- A2: 603 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -808,6 +808,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.specs.2026-07-14-special-gamma-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-special-gamma-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-stats-validation-runproof-design | repo_only | docs/superpowers/specs/2026-07-14-stats-validation-runproof-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-units-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-units-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-15-batched-verticals-index | repo_only | docs/superpowers/specs/2026-07-15-batched-verticals-index.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.testing | repo_only | docs/TESTING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.theory.epistemic-monotonicity | repo_only | docs/theory/epistemic_monotonicity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17890,6 +17890,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-15-batched-verticals-index",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-15-batched-verticals-index.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.test-infrastructure-v2",
       "collection": "repo",
       "repo_doc_path": "docs/test-infrastructure-v2.md",

--- a/docs/superpowers/specs/2026-07-15-batched-verticals-index.md
+++ b/docs/superpowers/specs/2026-07-15-batched-verticals-index.md
@@ -1,0 +1,41 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-15-batched-verticals-index
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-15-batched-verticals-index
+-->
+
+# Index — grouped stdlib run-proof verticals (batches #941–#967)
+
+**Date:** 2026-07-15 · No compiler changes. Coordination: all modules cold/disjoint from active lanes.
+
+This is the consolidated record for the seven **grouped** run-proof PRs. Each PR was kept lean (only
+`tests/stdlib/**` + `scripts/*_gate.sh`, no shared-file edits) so it merged cleanly against a hyperactive
+`main`; this index (plus the batched offload-log entry in `.claude/llm_offload_log.md`) is the housekeeping
+record. Every module is imported and run as native ELF (default Madaros unless noted), asserting outputs
+against known / first-principles values; each PR ships a combined gate.
+
+| PR | Modules | Gate | Known-value anchors |
+|---|---|---|---|
+| #941 | special::beta, math::hyperbolic, math::rational | `math_verticals_batch_gate.sh` | beta(2,3)=1/12, β(½,½)=π; cosh²−sinh²=1; exact fractions |
+| #948 | encoding::hex, math::dd64, math::combinatorics_perm | `verticals_batch2_gate.sh` | hex round-trip; dd64 recovers 1e-20; n! + next_permutation |
+| #950 | autodiff::epistemic_dual, collections::vec, collections::stack | `verticals_batch3_gate.sh` | d/dx x²=2x; vec sum/mean/reverse; LIFO |
+| #954 | collections::hashmap, core::result, math::qd128 | `verticals_batch4_gate.sh` | map semantics; Result ok/err; qd128 recovers 1e-40 (lean_single) |
+| #957 | viz::colormap, geo::pure::types, queue::pure::types | `verticals_batch5_gate.sh` | viridis knots=matplotlib; Euclidean 3-4-5; FIFO |
+| #963 | data::json, data::csv, math::approx | `verticals_batch6_gate.sh` | RFC-8259 JSON; CSV; Newton sqrt, Taylor sin |
+| #967 | epistemic::covariance, cybernetic::variety, audio::pure::types | `verticals_batch7_gate.sh` | corr coeff 0.5; Ashby log₂ variety; audio buffer (lean_single) |
+
+## Method (playbook)
+Discover importable module → probe for cross-module-safe API (scalar / by-reference / small-struct;
+avoid `[T;N]`-by-value #913, HOF, large-struct SRET) → run-proof vs known values → combined gate →
+math-review (xAI/Grok, logged) → lean PR → merge. `check:OK` never trusted alone — every claim is
+compile-and-run.
+
+## Also delivered this campaign (individual PRs, with their own specs/plans on main)
+GUM #860, units #873, linalg::matnm #892, negative-display fix #900, prob::distributions #902,
+stats::validation #909, signal::fft #917, integrate::epistemic_ode #924, special::erf #926,
+signal::filter #934, special::gamma #938. Plus compiler-blocker dispatches #859.
+
+**Total: 32 stdlib verticals run-proven, no compiler changes.**


### PR DESCRIPTION
Records the offload-policy compliance items kept out of the lean grouped-batch PRs:
- **Offload log**: the 7 grouped-batch math-reviews (#941–#967, all xAI/Grok PASS) appended to `.claude/llm_offload_log.md` in one batched entry.
- **Index**: `docs/superpowers/specs/2026-07-15-batched-verticals-index.md` — consolidated record of all 32 run-proven stdlib verticals (7 grouped batches + 11 individual PRs), with gate names, known-value anchors, and the playbook/method.

No source or compiler edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)