### PR TITLE
feat(stats): effect-size conversion & derivation — effect_convert, effect_from_test, cles

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2902,3 +2902,11 @@ Verdict: "NO MATHEMATICAL CONTENT TO REVIEW" (engineering change; IEEE-754 non-a
 - cusum = **PASS**: tabular Page/Montgomery C⁺/C⁻ recurrences; upward-drift C⁺ sequence 0,0,0.5,2,4.5,8 signalling at index 4 verified step-by-step.
 - Theme: statistical process control (SPC) — the lab-QC / manufacturing quality toolkit (relevant to biomaterials production). All derivable, #852-safe. Suite runner: 91 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-M8a5V7/`, `/tmp/llm-offload-Di0Efu/`, `/tmp/llm-offload-HR4OMO/`.
+
+## 2026-07-15 — math-review: stats::effect_convert, stats::effect_from_test, stats::cles
+- Files (all new): `stdlib/stats/effect_convert.sio` (d↔r, d↔ln OR / OR, Hedges g), `stdlib/stats/effect_from_test.sio` (r/d from t, η²/ω² from F, d from means), `stdlib/stats/cles.sio` (common-language effect size Φ(d/√2) + non-parametric pair proportion). Provider: xAI/Grok 4.3.
+- effect_convert = **PASS**: r=d/√(d²+4), ln OR=d·π/√3, Hedges J=1−3/(4df−1) all correct; d=0.5→r=0.2425, OR=2.4766, g=0.4615; round-trips involutive. Note: test constant OR=2.476381 was a hand-exp error (correct 2.476632, cross-checked vs Python) — caught by the failing assertion, fixed.
+- effect_from_test = **PASS**: r=t/√(t²+df), d=t√(1/n₁+1/n₂), η²=df₁F/(df₁F+df₂), ω²=df₁(F−1)/(df₁F+df₂+1), pooled-sd d all match.
+- cles = **PASS**: Φ(d/√2) from X₁−X₂~N(dσ,2σ²), non-parametric pair count (ties ½) = ROC AUC; d=1→0.7603, interleaved→1/3 verified.
+- Theme: effect-size conversion & derivation — the meta-analysis/reporting glue complementing effect_size (which computes from data). All derivable, #852-safe. Suite runner: 94 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-mWCVbQ/`, `/tmp/llm-offload-pTAF9f/`, `/tmp/llm-offload-rYFbnF/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -100,6 +100,9 @@ MODULES=(
   stdlib/stats/process_capability.sio
   stdlib/stats/control_chart.sio
   stdlib/stats/cusum.sio
+  stdlib/stats/effect_convert.sio
+  stdlib/stats/effect_from_test.sio
+  stdlib/stats/cles.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -1259,6 +1259,42 @@ The cumulative-sum chart, sensitive to small sustained shifts:
 CUSUM exceeds the decision interval h. Validated: an upward drift → C⁺ reaches 8,
 signals at index 4; on-target → no signal; downward drift → lower CUSUM signals.
 
+### `stats::effect_convert` — effect-size conversions
+
+| Function | Signature |
+|---|---|
+| `d_to_r` / `r_to_d` | `pub fn d_to_r(d: f64) -> f64 …` (equal-n) |
+| `d_to_logor` / `logor_to_d` / `d_to_or` | Cox logit-method odds-ratio conversions |
+| `hedges_g` | `pub fn hedges_g(d: f64, df: i32) -> f64` (small-sample correction) |
+
+The standard meta-analysis conversions between Cohen's d, the correlation r, the
+(log) odds ratio and Hedges' g. Validated: d=0.5 → r=0.2425, ln OR=0.9069,
+OR=2.4766, g(df=10)=0.4615; d↔r and d↔ln OR round-trip.
+
+### `stats::effect_from_test` — effect sizes from test statistics
+
+| Function | Signature |
+|---|---|
+| `r_from_t` / `d_from_t` | `pub fn r_from_t(t, df) -> f64` · `d_from_t(t, n1, n2) -> f64` |
+| `eta2_from_f` / `omega2_from_f` | variance-explained from an F statistic |
+| `d_from_means` | Cohen's d from two groups' means, sds and sizes |
+
+Recovers a standardised effect from a reported statistic (for meta-analysing
+published t/F results). Validated: t=2,df=10 → r=0.5345; t=2,n=10,10 → d=0.8944;
+F=4,(2,10) → η²=0.4444, ω²=0.3158; means → d=1.5.
+
+### `stats::cles` — common-language effect size
+
+| Function | Signature |
+|---|---|
+| `cles_from_d` | `pub fn cles_from_d(d: f64) -> f64 with Mut, Div, Panic` |
+| `cles_from_samples` | `pub fn cles_from_samples(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> f64 with Mut, Div, Panic` |
+
+The probability that a random draw from one group exceeds one from the other —
+`Φ(d/√2)` under normality, or the distribution-free proportion of superior pairs
+(= the ROC AUC). Validated: d=0 → 0.5, d=1 → 0.7603; fully-separated samples → 1;
+interleaved → 1/3.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1354,6 +1390,9 @@ use stats::ar1::{AR1Result, ar1}
 use stats::process_capability::{CapabilityResult, process_capability}
 use stats::control_chart::{IMRResult, imr_chart}
 use stats::cusum::{CusumResult, cusum}
+use stats::effect_convert::{d_to_r, r_to_d, d_to_logor, logor_to_d, d_to_or, hedges_g}
+use stats::effect_from_test::{r_from_t, d_from_t, eta2_from_f, omega2_from_f, d_from_means}
+use stats::cles::{cles_from_d, cles_from_samples}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/cles.sio
+++ b/stdlib/stats/cles.sio
@@ -1,0 +1,135 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/cles.sio — common-language effect size
+//
+// Restates a standardised effect on an intuitive probability scale: the chance
+// that a randomly drawn observation from one group exceeds one from the other —
+// far easier to communicate than Cohen's d:
+//
+//   cles_from_d(d)              -> f64   P(X₁ > X₂) = Φ(d/√2)
+//   cles_from_samples(x, nx, y, ny) -> f64   the non-parametric estimate #{xᵢ>yⱼ}/(nx·ny)
+//
+// The first assumes normal groups with equal variance; the second is the
+// distribution-free proportion of superior pairs (the same quantity as the ROC
+// AUC).
+//
+// Pure Sounio: inline exp/erf for the normal CDF; an O(nx·ny) pair count for the
+// empirical version. No external dependency, no nested data-array calls.
+//
+// References:
+//   McGraw & Wong (1992) Psychol. Bull. 111:361.
+
+module stats::cles
+
+fn cl_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / cl_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn cl_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * cl_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn cl_normal_cdf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 + cl_erf(z * INV_SQRT2))
+}
+
+/// Common-language effect size from Cohen's d: P(X₁ > X₂) = Φ(d/√2).
+pub fn cles_from_d(d: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return cl_normal_cdf(d * INV_SQRT2)
+}
+
+/// Non-parametric CLES: the proportion of pairs with xᵢ > yⱼ (ties count ½).
+pub fn cles_from_samples(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32) -> f64 with Mut, Div, Panic {
+    if nx < 1 || ny < 1 { return 0.5 }
+    var wins = 0.0
+    var i = 0
+    while i < nx {
+        var j = 0
+        while j < ny {
+            let xi = x[i as usize]
+            let yj = y[j as usize]
+            if xi > yj { wins = wins + 1.0 } else { if xi == yj { wins = wins + 0.5 } }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    return wins / ((nx as f64) * (ny as f64))
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// d=0 -> 0.5; d=1 -> Φ(1/√2)=Φ(0.707107)=0.760250.
+fn test_from_d() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(1, approx(cles_from_d(0.0), 0.5, 1.0e-6)) && ok
+    ok = check(2, approx(cles_from_d(1.0), 0.760250, 1.0e-4)) && ok
+    return ok
+}
+
+// non-parametric: x={4,5,6}, y={1,2,3} -> every pair x>y -> CLES=1.
+fn test_samples() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=4.0; x[1]=5.0; x[2]=6.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0
+    let r = cles_from_samples(&x, 3, &y, 3)
+    return check(10, approx(r, 1.0, 1.0e-9))
+}
+
+// interleaved x={1,3,5}, y={2,4,6}: pairs x>y count = (1>none)+(3>2)+(5>2,4)=1+2=3
+// of 9 -> CLES = 3/9 = 0.333333.
+fn test_interleaved() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=3.0; x[2]=5.0
+    y[0]=2.0; y[1]=4.0; y[2]=6.0
+    let r = cles_from_samples(&x, 3, &y, 3)
+    return check(20, approx(r, 0.333333, 1.0e-5))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_from_d() && ok
+    ok = test_samples() && ok
+    ok = test_interleaved() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/effect_convert.sio
+++ b/stdlib/stats/effect_convert.sio
@@ -1,0 +1,136 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/effect_convert.sio — conversions between effect-size metrics
+//
+// Meta-analysis routinely needs one effect-size scale expressed on another; this
+// gives the standard conversions between Cohen's d, the correlation r, the
+// (log) odds ratio and Hedges' g:
+//
+//   d_to_r(d)          r_to_d(r)
+//   d_to_logor(d)      logor_to_d(lor)
+//   hedges_g(d, df)
+//
+//   r = d/√(d²+4),   d = 2r/√(1−r²)            (equal-n)
+//   ln OR = d·π/√3,  d = ln OR·√3/π            (Cox logit method)
+//   g = d·J,  J = 1 − 3/(4·df − 1)             (small-sample bias correction)
+//
+// Pure Sounio: inline sqrt/exp. No external dependency, no nested data-array calls.
+//
+// References:
+//   Borenstein et al., "Introduction to Meta-Analysis" (2009), ch.7; Hedges (1981).
+
+module stats::effect_convert
+
+fn ec_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn ec_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ec_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+/// Cohen's d → Pearson r (equal group sizes).
+pub fn d_to_r(d: f64) -> f64 with Mut, Div, Panic {
+    return d / ec_sqrt(d * d + 4.0)
+}
+
+/// Pearson r → Cohen's d.
+pub fn r_to_d(r: f64) -> f64 with Mut, Div, Panic {
+    let den = ec_sqrt(1.0 - r * r)
+    if den <= 1.0e-300 { return 0.0 }
+    return 2.0 * r / den
+}
+
+/// Cohen's d → log odds ratio (Cox logit method).
+pub fn d_to_logor(d: f64) -> f64 {
+    let PI = 3.141592653589793
+    let SQRT3 = 1.7320508075688772
+    return d * PI / SQRT3
+}
+
+/// log odds ratio → Cohen's d.
+pub fn logor_to_d(lor: f64) -> f64 {
+    let PI = 3.141592653589793
+    let SQRT3 = 1.7320508075688772
+    return lor * SQRT3 / PI
+}
+
+/// Cohen's d → odds ratio.
+pub fn d_to_or(d: f64) -> f64 with Mut, Div, Panic {
+    return ec_exp(d_to_logor(d))
+}
+
+/// Hedges' g: the small-sample bias-corrected d (df = n1+n2-2).
+pub fn hedges_g(d: f64, df: i32) -> f64 {
+    if df < 2 { return d }
+    let j = 1.0 - 3.0 / (4.0 * (df as f64) - 1.0)
+    return d * j
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// d=0.5: r=0.5/sqrt(4.25)=0.242536; logOR=0.5·π/√3=0.9068997; OR=exp(0.9068997)=2.476632.
+// hedges g (df=10) = 0.5·(1-3/39)=0.5·0.923077=0.461538.
+fn test_convert() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(1, approx(d_to_r(0.5), 0.242536, 1.0e-5)) && ok
+    ok = check(2, approx(d_to_logor(0.5), 0.906900, 1.0e-5)) && ok
+    ok = check(3, approx(d_to_or(0.5), 2.476632, 1.0e-4)) && ok
+    ok = check(4, approx(hedges_g(0.5, 10), 0.461538, 1.0e-5)) && ok
+    return ok
+}
+
+// round trips: r_to_d(d_to_r(d)) = d; logor_to_d(d_to_logor(d)) = d.
+fn test_roundtrip() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(10, approx(r_to_d(d_to_r(0.8)), 0.8, 1.0e-5)) && ok
+    ok = check(11, approx(logor_to_d(d_to_logor(1.2)), 1.2, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_convert() && ok
+    ok = test_roundtrip() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/effect_from_test.sio
+++ b/stdlib/stats/effect_from_test.sio
@@ -1,0 +1,122 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/effect_from_test.sio — effect sizes from test statistics
+//
+// Recovers a standardised effect size from a reported test statistic — the tool
+// for extracting effect sizes from published results that only give t / F:
+//
+//   r_from_t(t, df)               d_from_t(t, n1, n2)
+//   eta2_from_f(f, df1, df2)      omega2_from_f(f, df1, df2)
+//   d_from_means(m1, s1, n1, m2, s2, n2)
+//
+//   r = t/√(t²+df),   d = t·√(1/n₁ + 1/n₂),
+//   η² = df₁·F/(df₁·F + df₂),   ω² = df₁(F−1)/(df₁·F + df₂ + 1),
+//   d = (m₁−m₂)/s_pooled.
+//
+// Pure Sounio: inline sqrt. No external dependency, no nested data-array calls.
+//
+// References:
+//   Rosnow & Rosenthal (1996); Lakens (2013) Front. Psychol. 4:863.
+
+module stats::effect_from_test
+
+fn ef_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+/// Pearson r from a t statistic and its df.
+pub fn r_from_t(t: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if df <= 0.0 { return 0.0 }
+    return t / ef_sqrt(t * t + df)
+}
+
+/// Cohen's d from a two-sample t statistic and group sizes.
+pub fn d_from_t(t: f64, n1: i32, n2: i32) -> f64 with Mut, Div, Panic {
+    if n1 < 1 || n2 < 1 { return 0.0 }
+    return t * ef_sqrt(1.0 / (n1 as f64) + 1.0 / (n2 as f64))
+}
+
+/// η² (proportion of variance) from an F statistic.
+pub fn eta2_from_f(f: f64, df1: f64, df2: f64) -> f64 with Mut, Div, Panic {
+    let den = df1 * f + df2
+    if den <= 0.0 { return 0.0 }
+    return df1 * f / den
+}
+
+/// ω² (less-biased variance explained) from an F statistic.
+pub fn omega2_from_f(f: f64, df1: f64, df2: f64) -> f64 with Mut, Div, Panic {
+    let den = df1 * f + df2 + 1.0
+    if den <= 0.0 { return 0.0 }
+    let num = df1 * (f - 1.0)
+    var w = num / den
+    if w < 0.0 { w = 0.0 }
+    return w
+}
+
+/// Cohen's d from two groups' means, sds and sizes (pooled sd).
+pub fn d_from_means(m1: f64, s1: f64, n1: i32, m2: f64, s2: f64, n2: i32) -> f64 with Mut, Div, Panic {
+    if n1 < 2 || n2 < 2 { return 0.0 }
+    let df1 = (n1 - 1) as f64
+    let df2 = (n2 - 1) as f64
+    let sp2 = (df1 * s1 * s1 + df2 * s2 * s2) / (df1 + df2)
+    let sp = ef_sqrt(sp2)
+    if sp <= 1.0e-300 { return 0.0 }
+    return (m1 - m2) / sp
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// t=2, df=10: r=2/sqrt(14)=0.534522.
+// d from t=2, n1=n2=10: d=2·sqrt(0.2)=0.894427.
+// F=4, df1=2, df2=10: eta²=8/18=0.444444; omega²=2·3/(8+10+1)=6/19=0.315789.
+fn test_from_test() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(1, approx(r_from_t(2.0, 10.0), 0.534522, 1.0e-5)) && ok
+    ok = check(2, approx(d_from_t(2.0, 10, 10), 0.894427, 1.0e-5)) && ok
+    ok = check(3, approx(eta2_from_f(4.0, 2.0, 10.0), 0.444444, 1.0e-5)) && ok
+    ok = check(4, approx(omega2_from_f(4.0, 2.0, 10.0), 0.315789, 1.0e-5)) && ok
+    return ok
+}
+
+// d from means: m1=10,s1=2,n1=5; m2=7,s2=2,n2=5. sp=2. d=(10-7)/2=1.5.
+fn test_from_means() -> bool with IO, Mut, Div, Panic {
+    let d = d_from_means(10.0, 2.0, 5, 7.0, 2.0, 5)
+    return check(10, approx(d, 1.5, 1.0e-6))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_from_test() && ok
+    ok = test_from_means() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three effect-size utility modules, bringing the runner to **94 modules**. These are the meta-analysis and reporting glue that complements `effect_size` (which computes d/g/η² *from raw data*) — here we **convert between metrics** and **derive effects from published statistics**. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::effect_convert` | d ↔ r ↔ (log) OR conversions + Hedges' g bias correction |
| `stats::effect_from_test` | r/d from t, η²/ω² from F, d from means/sds |
| `stats::cles` | Common-language effect size (probability of superiority) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Convert: d=0.5 → r=0.2425, ln OR=0.9069, OR=2.4766, g(df=10)=0.4615; d↔r and d↔ln OR round-trip as involutions.
  - From test: t=2,df=10 → r=0.5345; t=2,n=10,10 → d=0.8944; F=4,(2,10) → η²=0.4444, ω²=0.3158; means → d=1.5.
  - CLES: d=0 → 0.5, d=1 → 0.7603; fully-separated samples → 1; interleaved → 1/3 (= ROC AUC).
- Full suite selftest: **94 modules + 7 demos ALL GREEN** under `lean_single`.

## A derivable-values catch
The `d_to_or(0.5)` test constant was hand-mis-computed as 2.476381 (imprecise mental exp); the failing assertion caught it, and cross-checking against a reference gave the correct 2.476632 — which is exactly what the module produces. Fixed the constant.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).