### PR TITLE
feat(ir): generational Place shadow on Arena v2 [DO NOT MERGE]

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 961
-- Repo-backed topics: 811
+- Total governed topics: 962
+- Repo-backed topics: 812
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 561
+- Authority count `repo_only`: 562
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 580 topics
+- A2: 581 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -409,6 +409,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.internal.concepts.explicit-discharge | repo_only | docs/internal/concepts/explicit-discharge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.hypercomplex-zero-divisor-evidence | repo_only | docs/internal/concepts/hypercomplex-zero-divisor-evidence.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.ir-module-arena-v2 | repo_only | docs/internal/concepts/ir-module-arena-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.internal.concepts.ir-module-arena-v2-place-shadow | repo_only | docs/internal/concepts/ir-module-arena-v2-place-shadow.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.ir-module-arena-v2-soir-v5-bridge | repo_only | docs/internal/concepts/ir-module-arena-v2-soir-v5-bridge.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.ir-storage-ownership | repo_only | docs/internal/concepts/ir-storage-ownership.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.internal.concepts.nonassociative-order | repo_only | docs/internal/concepts/nonassociative-order.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8886,6 +8886,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.internal.concepts.ir-module-arena-v2-place-shadow",
+      "collection": "repo",
+      "repo_doc_path": "docs/internal/concepts/ir-module-arena-v2-place-shadow.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.internal.concepts.ir-module-arena-v2-soir-v5-bridge",
       "collection": "repo",
       "repo_doc_path": "docs/internal/concepts/ir-module-arena-v2-soir-v5-bridge.md",

--- a/docs/internal/concepts/ir-module-arena-v2-place-shadow.md
+++ b/docs/internal/concepts/ir-module-arena-v2-place-shadow.md
@@ -1,0 +1,161 @@
+<!-- docs:meta
+topic_id: repo.docs.internal.concepts.ir-module-arena-v2-place-shadow
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.internal.concepts.ir-module-arena-v2-place-shadow
+-->
+
+# IrModuleArena v2 Place IR Shadow
+
+Status: executable structural witness; off-default and not parity
+Concept-ID: `SOUNIO-IR-STORAGE-OWNERSHIP`
+
+This slice gives the Arena v2 module store a bounded, generation-checked Place
+identity without importing it into the parser, canonical lowering, SOIR,
+serialization, or a backend. It reuses the semantic vocabulary characterized
+by draft PRs #894 and #910, but does not reuse their aggregate Place values or
+test-local wire representation.
+
+The representation is deliberately split:
+
+```text
+Place identity =
+  PlaceId(slot, generation)
+  + ModuleId(arena, slot, generation)
+  + module mutation/layout epoch
+  + root identity, type, layout
+  + ordered field projections
+
+Field projection identity =
+  owner type, owner layout, field ordinal
+  + result type, result layout
+
+Access instance =
+  read or write event, write policy, event order
+```
+
+Access events are not part of structural Place equality. A field-name hash is
+stored only to construct a deliberate same-hash collision witness. It
+never selects a field and cannot establish name equality by itself; the shadow
+classifies only a same-hash structural collision. Field ordinal
+is separate from spelling and from any future physical byte offset.
+
+A Place is built and then finalized. Projection append is permitted only while
+building; structural comparison and access events are permitted only after
+finalization. Thus a published `PlaceId` cannot silently change structural
+meaning after it becomes usable. Write authorization is supplied to the store
+event rather than stored in Place identity.
+
+Every semantic Place read or mutation first validates the live `ModuleId`, then the
+live `PlaceId`, then the exact root binding and the module mutation epoch. A
+module mutation therefore invalidates an earlier Place even when its module
+slot and generation remain live. Place release increments its own generation
+before slot reuse. A lifecycle-only discard validates only the generational
+`PlaceId`, so an invalid module or epoch cannot leak bounded capacity; it does
+not permit any semantic read. This authority remains copyable until the wider
+Arena linearity blocker in issue #877 is resolved. The implementation uses
+private scalar columns only; no
+Place store, projection array, Place value, or projection value crosses an API
+boundary.
+
+## Executable differential
+
+The structural shadow creates two modules with structs whose field spelling is
+the same but whose owner type, layout, field ordinal, and result identity are
+different. It records the second struct's declared ordinal 1, rejects hash-only
+equivalence, validates a nested type/layout transition, records load before
+store, and rejects stale ModuleId, reused ModuleId, stale PlaceId, capacity,
+and projection overflow.
+
+The comparable legacy program executes through the current compiler. Its typed
+local control observes `B.shared == 42`, but `make_b().shared` exits with `11`.
+The current lowering loses the nominal base of the call expression and its
+global name fallback selects ordinal 0 from a different struct. This is a real
+differentiating observation, not parity:
+
+```text
+mode=place_structural_witness_not_parity
+shadow declared structural record: B.shared ordinal 1
+legacy typed control: 42
+legacy call expression: rc 11
+```
+
+The legacy path remains unchanged as a control and counterexample. This shadow
+does not yet load or store the program value, emit a backend Place operation,
+or serialize a logical Place. Root, type, layout, ordinal, and result IDs are
+caller-supplied declarations checked for chain consistency; they are not yet
+resolved against a canonical module/type/layout table. It therefore cannot
+claim field selection authority or replace current lowering.
+
+The full adversary matrix runs as a throwaway composite module. A separate
+minimal imported probe executes calls carrying `ModuleId`, `PlaceId`, projection
+scalars, finalization, and access arguments across the real module boundary.
+That probe is an API transport smoke test, not imported execution of every
+adversary or evidence of default wiring.
+
+## Prior-art boundary
+
+Root plus ordered projections is established prior art. Rust MIR represents a
+Place as a local plus ordered projections and derives types stepwise. LLVM GEP
+preserves a base pointer, source element type, address space, and ordered
+structural indices. MLIR MemRef preserves explicit layout and memory-space
+information. Swift SIL separates storage identity, access paths, formal access
+scope, exclusivity, and value ownership.
+
+The defensible Sounio question is narrower and remains unproven beyond this
+bounded witness: can every serialization, rekey, lowering, and backend access
+revalidate `(ModuleId, PlaceId, semantic/layout epoch)` and reject ABA or path
+drift before executing the operation? This lane proves only the first
+in-memory structural component.
+
+Primary sources, pinned and accessed 2026-07-15:
+
+- Rust MIR `Place` and `ProjectionElem`, rust-lang/rust
+  `47101adcea71daee3c2879218f5b883bcdf180aa`.
+- LLVM `getelementptr` specification and design notes, llvm-project
+  `0350a23a8bbc091e646406a2aaeafa35dc0216d3`.
+- MLIR LLVM `GEPOp`, MemRef and data-layout documentation, llvm-project at the
+  same commit.
+- Swift SIL memory-access and ownership documentation, swiftlang/swift
+  `e9e1fa9e028bb8dcff68550afb939ac3103a8702`.
+
+## Semantic lane
+
+```text
+Semantic-Lane-ID: IR-MODULE-ARENA-V2-PLACE-SHADOW
+Owner: codex/place-ir-arena-v2-shadow-20260715
+Concept-IDs: SOUNIO-IR-STORAGE-OWNERSHIP
+Intent-Preserved: exact structural identity, projection order, and compiler-caused misselection remain observable rather than collapsing into a field spelling.
+Transformation: add an off-default scalar PlaceId authority bound to a live ModuleId and mutation/layout epoch, plus an executable legacy counterexample.
+Types-Changed: adds shadow-only IrModuleArenaV2PlaceId; canonical IR and borrow-checker Place types are unchanged.
+Effects-Changed: none in the default compiler; shadow allocation, projection append, release, and access receipts require Mut.
+IR-Changed: none in canonical IR, SOIR, serializer, writer, or backend routing.
+Claims-Introduced: the exact source-fresh gate proves bounded caller-declared structural recording, self-consistent nested type transitions, access-event ordering, fail-closed generation/epoch adversaries, and a minimal imported API smoke.
+Claims-Forbidden: first Place IR; canonical alias identity; provenance completeness; default-pipeline correctness; backend readiness; SOIR parity; serializer parity; performance superiority; replacement of legacy lowering.
+Assumptions: module mutation epoch changes for every future type/layout-affecting mutation; caller-declared IDs are not canonical type-table proof; this first slice supports root-module-defined fields and two field projections only.
+Write-Set: self-hosted/ir/arena_v2_place_shadow.sio, self-hosted/ir/arena_v2_place_import_probe.sio, tests/native-v2/place_ir_arena_v2_shadow_witness.sio, tests/native-v2/place_ir_legacy_nominal_collision_witness.sio, scripts/ci/place_ir_arena_v2_shadow_gate.sh, docs/internal/concepts/ir-module-arena-v2-place-shadow.md, generated docs governance metadata.
+Read-Set: self-hosted/ir/arena_v2_shadow.sio, self-hosted/ir/lower.sio, draft PR #894, draft PR #910.
+Positive-Witness: declared ordinal recording, self-consistent nested transition, finalized load-before-store, two-module structural distinction, Place generation reuse, stale lifecycle discard, distinct capacity receipts, and imported API transport smoke.
+Negative-Witness: same-hash structural collision, type-chain mismatch, access before finalization, append after finalization, store-before-load, unauthorized store, stale module, reused module, stale Place generation, and module-epoch drift reject.
+Acceptance-Gate: SOUC_BIN=<exact-source-fresh-madaros> bash scripts/ci/place_ir_arena_v2_shadow_gate.sh.
+Integration-Target: shadow-only stack on PR #965; no default reader or writer switch.
+Authoritative-Only-If: a later lane serializes and rekeys logical Places, executes the same values and mutations through both paths, matches every valid legacy observation, and explicitly resolves the current legacy misselection before any reader switch.
+```
+
+## Integration receipt
+
+```text
+Semantic-Outcome: PLACE_STRUCTURAL_WITNESS_NOT_PARITY
+Concept-Status-Before: hypothesis
+Concept-Status-After: hypothesis; no registry promotion
+Distinctions-Added: field spelling != name hash != structural field identity; declared identity != canonical resolution; Place identity != access instance; live slot != live generation/epoch binding; differentiating observation != parity
+Distinctions-Preserved: module identity and generation; projection order; type/layout transitions; legacy counterexample availability; fail-closed validation
+Distinctions-Erased: none
+Evidence-Run: scripts/ci/place_ir_arena_v2_shadow_gate.sh with source-fresh compiler sha256 7ad961849c398ba6dc709dd327f14f14405062bb12638d48374d8619a1ba8372
+Fallback-Path: none
+Legacy-Kept: yes, byte-identical to base and executed as the current control/counterexample, not a parity oracle
+Conflicting-Lanes: draft PRs #894 and #910 remain discovery material only; neither was merged or cherry-picked
+Next-Semantic-Interface: canonical module/type/layout resolver, then logical Place serialization and explicit rekey, followed by value/load/store differential execution and zero-backend-op rejection receipts
+```

--- a/scripts/ci/place_ir_arena_v2_shadow_gate.sh
+++ b/scripts/ci/place_ir_arena_v2_shadow_gate.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+BASE="${PLACE_IR_ARENA_V2_BASE_SHA:-8f6e88e5260f55e4db3e7cefa49e1cf4ecc73634}"
+SOUC="${SOUC_BIN:-$ROOT/bin/souc}"
+ARENA="self-hosted/ir/arena_v2_shadow.sio"
+PLACE="self-hosted/ir/arena_v2_place_shadow.sio"
+WITNESS="tests/native-v2/place_ir_arena_v2_shadow_witness.sio"
+IMPORT_PROBE="self-hosted/ir/arena_v2_place_import_probe.sio"
+LEGACY_WITNESS="tests/native-v2/place_ir_legacy_nominal_collision_witness.sio"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-place-ir-arena-v2.XXXXXX")"
+COMPOSITE=""
+
+cleanup() {
+  rm -rf "$TMP"
+  [[ -z "$COMPOSITE" ]] || rm -f "$COMPOSITE"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'PLACE_IR_ARENA_V2_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+for file in "$ARENA" "$PLACE" "$WITNESS" "$IMPORT_PROBE" "$LEGACY_WITNESS"; do
+  [[ -f "$file" ]] || fail "missing_${file//\//_}"
+done
+[[ -x "$SOUC" ]] || fail compiler_missing
+git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
+
+grep -Fq 'pub struct IrModuleArenaV2PlaceId {' "$PLACE" || fail place_id_missing
+grep -Fq 'pub let IR_MODULE_ARENA_V2_PLACE_CAPACITY: i64 = 2' "$PLACE" || fail place_capacity_not_two
+grep -Fq 'pub let IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY: i64 = 2' "$PLACE" || fail projection_capacity_not_two
+grep -Fq 'out: &! IrModuleArenaV2PlaceId' "$PLACE" || fail place_allocation_not_out_parameter
+grep -Fq 'ir_module_arena_v2_module_id_generation(module)' "$PLACE" || fail module_generation_binding_missing
+grep -Fq 'ir_module_arena_v2_module_mutation_epoch(module)' "$PLACE" || fail module_epoch_binding_missing
+grep -Fq 'proj_field_ordinal(cell_a) == proj_field_ordinal(cell_b)' "$PLACE" || fail structural_field_ordinal_missing
+grep -Fq 'proj_owner_type(cell_a) == proj_owner_type(cell_b)' "$PLACE" || fail structural_owner_type_missing
+grep -Fq 'proj_result_type(cell_a) == proj_result_type(cell_b)' "$PLACE" || fail structural_result_type_missing
+grep -Fq 'IR_MODULE_ARENA_V2_PLACE_ERR_SAME_HASH_STRUCTURAL_COLLISION' "$PLACE" || fail same_hash_collision_status_missing
+grep -Fq 'ir_module_arena_v2_place_record_store_after_load' "$PLACE" || fail ordered_store_missing
+grep -Fq 'ir_module_arena_v2_place_finalize' "$PLACE" || fail place_finalize_missing
+grep -Fq 'ir_module_arena_v2_place_discard' "$PLACE" || fail stale_lifecycle_discard_missing
+grep -Fq 'place_structural_witness_not_parity' "$WITNESS" || fail nonparity_classification_missing
+grep -Fq 'PLACE_IR_ARENA_V2_IMPORT_PASS' "$IMPORT_PROBE" || fail import_probe_marker_missing
+grep -Fq 'if typed.shared != 42' "$LEGACY_WITNESS" || fail typed_legacy_control_missing
+grep -Fq 'make_b().shared' "$LEGACY_WITNESS" || fail legacy_collision_expression_missing
+grep -Fq 'PRs #894 and #910' "$PLACE" || fail characterization_reuse_attribution_missing
+
+if grep -Eq '\[[[:space:]]*[A-Za-z0-9_:]+[[:space:]]*;[[:space:]]*[0-9]+' "$PLACE"; then
+  fail aggregate_array_storage_present
+fi
+if grep -Eq '^pub var PLACE_|^pub var PROJ_' "$PLACE"; then
+  fail scalar_columns_public
+fi
+if grep -Fq 'pub struct PlaceProjection' "$PLACE" || grep -Fq 'pub struct PlaceStore' "$PLACE"; then
+  fail aggregate_place_or_projection_store_present
+fi
+if grep -Eq -- '->[[:space:]]*(Place|IrModuleArenaV2Place)([[:space:]<{]|$)' "$PLACE"; then
+  fail aggregate_place_return_present
+fi
+
+for default_surface in \
+  self-hosted/ir/mod.sio \
+  self-hosted/ir/lower.sio \
+  self-hosted/ir/ir.sio \
+  self-hosted/ir/arena_v2_shadow.sio \
+  self-hosted/ir/arena_v2_soir_bridge.sio \
+  self-hosted/ir/soir_writer.sio \
+  self-hosted/ir/soir_core.sio \
+  self-hosted/ir/serialize.sio \
+  self-hosted/ir/heap_storage.sio \
+  self-hosted/parser/ast.sio \
+  self-hosted/parser/items.sio \
+  self-hosted/compiler/main.sio \
+  self-hosted/native/codegen_x86_linux.sio \
+  self-hosted/native/runtime_context.sio \
+  scripts/ci/madaros_global_init_transport_gate.sh \
+  scripts/bootstrap/bootstrap_concat.sh; do
+  grep -Fq 'arena_v2_place_shadow' "$default_surface" && fail "place_imported_by_${default_surface//\//_}"
+done
+
+if ! git diff --quiet "$BASE" -- \
+    self-hosted/ir/mod.sio \
+    self-hosted/ir/lower.sio \
+    self-hosted/ir/ir.sio \
+    self-hosted/ir/arena_v2_shadow.sio \
+    self-hosted/ir/arena_v2_soir_bridge.sio \
+    self-hosted/ir/soir_writer.sio \
+    self-hosted/ir/soir_core.sio \
+    self-hosted/ir/serialize.sio \
+    self-hosted/ir/heap_storage.sio \
+    self-hosted/parser/ast.sio \
+    self-hosted/parser/items.sio \
+    self-hosted/compiler/main.sio \
+    self-hosted/native/codegen_x86_linux.sio \
+    self-hosted/native/runtime_context.sio \
+    scripts/ci/madaros_global_init_transport_gate.sh \
+    scripts/bootstrap/bootstrap_concat.sh; then
+  fail legacy_or_default_surface_changed
+fi
+
+"$SOUC" check "$PLACE" >"$TMP/place.check.log" 2>&1 || {
+  cat "$TMP/place.check.log" >&2
+  fail place_source_check
+}
+
+COMPOSITE="$(mktemp "$ROOT/self-hosted/ir/place_ir_arena_v2_shadow_gate.XXXXXX.sio")"
+{
+  printf 'module ir::place_ir_arena_v2_shadow_gate\n\n'
+  sed '/^module ir::arena_v2_shadow$/d' "$ARENA"
+  sed -e '/^module ir::arena_v2_place_shadow$/d' \
+      -e '/^use ir::arena_v2_shadow::\*$/d' "$PLACE"
+  sed -e '/^use ir::arena_v2_shadow::\*$/d' \
+      -e '/^use ir::arena_v2_place_shadow::\*$/d' "$WITNESS"
+} >"$COMPOSITE"
+
+"$SOUC" check "$COMPOSITE" >"$TMP/composite.log" 2>&1 || {
+  cat "$TMP/composite.log" >&2
+  fail composite_check
+}
+"$SOUC" --native-v2-compile "$COMPOSITE" -o "$TMP/place-shadow.elf" >>"$TMP/composite.log" 2>&1 || {
+  cat "$TMP/composite.log" >&2
+  fail composite_build
+}
+chmod +x "$TMP/place-shadow.elf"
+"$TMP/place-shadow.elf" >"$TMP/place-shadow.out" 2>&1 || {
+  cat "$TMP/place-shadow.out" >&2
+  fail composite_runtime
+}
+grep -Fxq 'PLACE_IR_ARENA_V2_SHADOW_PASS mode=place_structural_witness_not_parity' "$TMP/place-shadow.out" || {
+  cat "$TMP/place-shadow.out" >&2
+  fail shadow_receipt_missing
+}
+
+# This probe is intentionally not concatenated. It exercises imported calls
+# carrying ModuleId, PlaceId, scalar projection payloads, and access arguments.
+"$SOUC" --native-v2-compile "$IMPORT_PROBE" -o "$TMP/import-probe.elf" >"$TMP/import-probe.log" 2>&1 || {
+  cat "$TMP/import-probe.log" >&2
+  fail imported_probe_build
+}
+chmod +x "$TMP/import-probe.elf"
+"$TMP/import-probe.elf" >"$TMP/import-probe.out" 2>&1 || {
+  cat "$TMP/import-probe.out" >&2
+  fail imported_probe_runtime
+}
+grep -Fxq 'PLACE_IR_ARENA_V2_IMPORT_PASS' "$TMP/import-probe.out" || {
+  cat "$TMP/import-probe.out" >&2
+  fail imported_probe_receipt_missing
+}
+
+"$SOUC" compile "$LEGACY_WITNESS" -o "$TMP/legacy.elf" >"$TMP/legacy.log" 2>&1 || {
+  cat "$TMP/legacy.log" >&2
+  fail legacy_compile
+}
+chmod +x "$TMP/legacy.elf"
+set +e
+"$TMP/legacy.elf" >"$TMP/legacy.out" 2>&1
+legacy_rc=$?
+set -e
+case "$legacy_rc" in
+  11) legacy_observation=current_name_fallback_counterexample ;;
+  42) legacy_observation=legacy_fixed ;;
+  *)
+    cat "$TMP/legacy.out" >&2
+    fail "legacy_runtime_unexpected_${legacy_rc}"
+    ;;
+esac
+
+compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
+printf '%s\n' 'PLACE_IR_ARENA_V2_CHECK source=pass composite=pass imported_api_probe=pass default_surfaces=unchanged off_default=true'
+printf '%s\n' 'PLACE_IR_ARENA_V2_ID place_id=slot,generation lifecycle=build,finalized,released stale_discard=generation_only root_binding=module_arena,module_slot,module_generation,module_mutation_epoch root=identity,type,layout'
+printf '%s\n' 'PLACE_IR_ARENA_V2_PROJECTION storage=private_scalar_columns order=append declared_identity=module,type,layout,ordinal result=type,layout authority=caller_supplied_shadow name_hash=diagnostic_only nested_type_chain=self_consistency_checked'
+printf '%s\n' 'PLACE_IR_ARENA_V2_ADVERSARY same_hash_structural_collision=reject nested=pass unfinalized_access=reject append_after_finalize=reject load_then_store=pass write_flag_zero=reject write_authority=caller_supplied_shadow module_stale=reject module_reuse=reject stale_discard=pass stale_capacity_recovery=pass place_aba=reject structural_distinct=pass place_capacity=distinct projection_capacity=distinct'
+printf 'PLACE_IR_ARENA_V2_DIFFERENTIAL mode=place_structural_witness_not_parity shadow_declared_field_ordinal=1 legacy_typed_control=42 legacy_call_expression_rc=%s legacy_observation=%s\n' "$legacy_rc" "$legacy_observation"
+printf '%s\n' 'PLACE_IR_ARENA_V2_BOUNDARY canonical=false backend=false writer=false serializer=false alias_analysis=false canonical_type_layout_resolution=false structural_matrix=composite imported_api=smoke legacy_kept=true'
+printf 'PLACE_IR_ARENA_V2_PASS compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"

--- a/self-hosted/ir/arena_v2_place_import_probe.sio
+++ b/self-hosted/ir/arena_v2_place_import_probe.sio
@@ -1,0 +1,26 @@
+module ir::arena_v2_place_import_probe
+
+use ir::arena_v2_shadow::*
+use ir::arena_v2_place_shadow::*
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_module_store_init(7201) != IR_MODULE_ARENA_V2_OK { return 101 }
+    if ir_module_arena_v2_place_store_init() != IR_MODULE_ARENA_V2_PLACE_OK { return 102 }
+
+    var module_id = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(8201, &! module_id) != IR_MODULE_ARENA_V2_OK { return 103 }
+    var place_id = ir_module_arena_v2_invalid_place_id()
+    if ir_module_arena_v2_place_alloc_root(&module_id, 7, 707, 7007, &! place_id) !=
+       IR_MODULE_ARENA_V2_PLACE_OK { return 104 }
+    if ir_module_arena_v2_place_append_field(&module_id, &place_id, 707, 7007, 3, 909, 808, 8008) !=
+       IR_MODULE_ARENA_V2_PLACE_OK { return 105 }
+    if ir_module_arena_v2_place_finalize(&module_id, &place_id) != IR_MODULE_ARENA_V2_PLACE_OK { return 106 }
+    if ir_module_arena_v2_place_field_ordinal(&module_id, &place_id, 0) != 3 { return 107 }
+    if ir_module_arena_v2_place_record_load(&module_id, &place_id) != IR_MODULE_ARENA_V2_PLACE_OK { return 108 }
+    if ir_module_arena_v2_place_record_store_after_load(&module_id, &place_id, 1) !=
+       IR_MODULE_ARENA_V2_PLACE_OK { return 109 }
+    if !ir_module_arena_v2_place_load_precedes_store(&module_id, &place_id) { return 110 }
+
+    print("PLACE_IR_ARENA_V2_IMPORT_PASS\n")
+    0
+}

--- a/self-hosted/ir/arena_v2_place_shadow.sio
+++ b/self-hosted/ir/arena_v2_place_shadow.sio
@@ -1,0 +1,666 @@
+// Executable Place IR shadow over the scalar IrModuleArena v2 store.
+//
+// This module is deliberately off-default. It reuses the semantic vocabulary
+// characterized by PRs #894 and #910, but replaces their aggregate Place
+// values with generational IDs and private scalar columns.
+
+module ir::arena_v2_place_shadow
+
+use ir::arena_v2_shadow::*
+
+pub let IR_MODULE_ARENA_V2_PLACE_CAPACITY: i64 = 2
+pub let IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY: i64 = 2
+
+pub let IR_MODULE_ARENA_V2_PLACE_OK: i64 = 0
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_MODULE: i64 = -30
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_PLACE: i64 = -31
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_STALE_ROOT: i64 = -32
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_CAPACITY: i64 = -33
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_OUTPUT_LIVE: i64 = -34
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_PROJECTION_CAPACITY: i64 = -35
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_TYPE_CHAIN: i64 = -36
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_SAME_HASH_STRUCTURAL_COLLISION: i64 = -37
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_STRUCTURAL_MISMATCH: i64 = -38
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_WRITE_FORBIDDEN: i64 = -39
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_ACCESS_ORDER: i64 = -40
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_RANGE: i64 = -41
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_FINALIZED: i64 = -42
+pub let IR_MODULE_ARENA_V2_PLACE_ERR_UNFINALIZED: i64 = -43
+
+let PLACE_SLOT_FREE: i64 = 0
+let PLACE_SLOT_LIVE: i64 = 1
+let PLACE_SLOT_RELEASED: i64 = 2
+
+pub struct IrModuleArenaV2PlaceId {
+    slot: i64,
+    generation: i64,
+}
+
+var PLACE_STORE_LIVE: i64 = 0
+var PLACE_ACCESS_SEQUENCE: i64 = 0
+
+var PLACE_STATE_0: i64 = PLACE_SLOT_FREE
+var PLACE_STATE_1: i64 = PLACE_SLOT_FREE
+var PLACE_GENERATION_0: i64 = 1
+var PLACE_GENERATION_1: i64 = 1
+
+var PLACE_MODULE_ARENA_0: i64 = 0
+var PLACE_MODULE_ARENA_1: i64 = 0
+var PLACE_MODULE_SLOT_0: i64 = -1
+var PLACE_MODULE_SLOT_1: i64 = -1
+var PLACE_MODULE_GENERATION_0: i64 = 0
+var PLACE_MODULE_GENERATION_1: i64 = 0
+var PLACE_MODULE_EPOCH_0: i64 = 0
+var PLACE_MODULE_EPOCH_1: i64 = 0
+var PLACE_ROOT_IDENTITY_0: i64 = 0
+var PLACE_ROOT_IDENTITY_1: i64 = 0
+var PLACE_ROOT_TYPE_0: i64 = 0
+var PLACE_ROOT_TYPE_1: i64 = 0
+var PLACE_ROOT_LAYOUT_0: i64 = 0
+var PLACE_ROOT_LAYOUT_1: i64 = 0
+var PLACE_FINALIZED_0: i64 = 0
+var PLACE_FINALIZED_1: i64 = 0
+var PLACE_PROJECTION_COUNT_0: i64 = 0
+var PLACE_PROJECTION_COUNT_1: i64 = 0
+var PLACE_LAST_LOAD_0: i64 = 0
+var PLACE_LAST_LOAD_1: i64 = 0
+var PLACE_LAST_STORE_0: i64 = 0
+var PLACE_LAST_STORE_1: i64 = 0
+
+// Four projection cells: place_slot * 2 + projection_index. Every logical
+// field remains its own scalar column; no aggregate Place/Projection store
+// crosses a function boundary.
+var PROJ_OWNER_TYPE_0: i64 = 0
+var PROJ_OWNER_TYPE_1: i64 = 0
+var PROJ_OWNER_TYPE_2: i64 = 0
+var PROJ_OWNER_TYPE_3: i64 = 0
+var PROJ_OWNER_LAYOUT_0: i64 = 0
+var PROJ_OWNER_LAYOUT_1: i64 = 0
+var PROJ_OWNER_LAYOUT_2: i64 = 0
+var PROJ_OWNER_LAYOUT_3: i64 = 0
+var PROJ_FIELD_ORDINAL_0: i64 = 0
+var PROJ_FIELD_ORDINAL_1: i64 = 0
+var PROJ_FIELD_ORDINAL_2: i64 = 0
+var PROJ_FIELD_ORDINAL_3: i64 = 0
+// Name hashes are diagnostic collision witnesses only; they never select a
+// field or participate as the sole structural authority.
+var PROJ_FIELD_NAME_HASH_0: i64 = 0
+var PROJ_FIELD_NAME_HASH_1: i64 = 0
+var PROJ_FIELD_NAME_HASH_2: i64 = 0
+var PROJ_FIELD_NAME_HASH_3: i64 = 0
+var PROJ_RESULT_TYPE_0: i64 = 0
+var PROJ_RESULT_TYPE_1: i64 = 0
+var PROJ_RESULT_TYPE_2: i64 = 0
+var PROJ_RESULT_TYPE_3: i64 = 0
+var PROJ_RESULT_LAYOUT_0: i64 = 0
+var PROJ_RESULT_LAYOUT_1: i64 = 0
+var PROJ_RESULT_LAYOUT_2: i64 = 0
+var PROJ_RESULT_LAYOUT_3: i64 = 0
+
+pub fn ir_module_arena_v2_invalid_place_id() -> IrModuleArenaV2PlaceId {
+    IrModuleArenaV2PlaceId { slot: -1, generation: 0 }
+}
+
+pub fn ir_module_arena_v2_place_id_slot(id: &IrModuleArenaV2PlaceId) -> i64 {
+    (*id).slot
+}
+
+pub fn ir_module_arena_v2_place_id_generation(id: &IrModuleArenaV2PlaceId) -> i64 {
+    (*id).generation
+}
+
+fn place_state(slot: i64) -> i64 {
+    if slot == 0 { PLACE_STATE_0 } else { PLACE_STATE_1 }
+}
+
+fn place_generation(slot: i64) -> i64 {
+    if slot == 0 { PLACE_GENERATION_0 } else { PLACE_GENERATION_1 }
+}
+
+fn place_module_arena(slot: i64) -> i64 {
+    if slot == 0 { PLACE_MODULE_ARENA_0 } else { PLACE_MODULE_ARENA_1 }
+}
+
+fn place_module_slot(slot: i64) -> i64 {
+    if slot == 0 { PLACE_MODULE_SLOT_0 } else { PLACE_MODULE_SLOT_1 }
+}
+
+fn place_module_generation(slot: i64) -> i64 {
+    if slot == 0 { PLACE_MODULE_GENERATION_0 } else { PLACE_MODULE_GENERATION_1 }
+}
+
+fn place_module_epoch(slot: i64) -> i64 {
+    if slot == 0 { PLACE_MODULE_EPOCH_0 } else { PLACE_MODULE_EPOCH_1 }
+}
+
+fn place_root_identity(slot: i64) -> i64 {
+    if slot == 0 { PLACE_ROOT_IDENTITY_0 } else { PLACE_ROOT_IDENTITY_1 }
+}
+
+fn place_root_type(slot: i64) -> i64 {
+    if slot == 0 { PLACE_ROOT_TYPE_0 } else { PLACE_ROOT_TYPE_1 }
+}
+
+fn place_root_layout(slot: i64) -> i64 {
+    if slot == 0 { PLACE_ROOT_LAYOUT_0 } else { PLACE_ROOT_LAYOUT_1 }
+}
+
+fn place_finalized(slot: i64) -> i64 {
+    if slot == 0 { PLACE_FINALIZED_0 } else { PLACE_FINALIZED_1 }
+}
+
+fn place_projection_count(slot: i64) -> i64 {
+    if slot == 0 { PLACE_PROJECTION_COUNT_0 } else { PLACE_PROJECTION_COUNT_1 }
+}
+
+fn place_last_load(slot: i64) -> i64 {
+    if slot == 0 { PLACE_LAST_LOAD_0 } else { PLACE_LAST_LOAD_1 }
+}
+
+fn place_last_store(slot: i64) -> i64 {
+    if slot == 0 { PLACE_LAST_STORE_0 } else { PLACE_LAST_STORE_1 }
+}
+
+fn set_place_state(slot: i64, value: i64) with Mut {
+    if slot == 0 { PLACE_STATE_0 = value } else { PLACE_STATE_1 = value }
+}
+
+fn set_place_generation(slot: i64, value: i64) with Mut {
+    if slot == 0 { PLACE_GENERATION_0 = value } else { PLACE_GENERATION_1 = value }
+}
+
+fn set_place_binding(
+    slot: i64,
+    module: &IrModuleArenaV2ModuleId,
+    module_epoch: i64,
+    root_identity: i64,
+    root_type: i64,
+    root_layout: i64,
+) with Mut {
+    if slot == 0 {
+        PLACE_MODULE_ARENA_0 = ir_module_arena_v2_module_id_arena_identity(module)
+        PLACE_MODULE_SLOT_0 = ir_module_arena_v2_module_id_slot(module)
+        PLACE_MODULE_GENERATION_0 = ir_module_arena_v2_module_id_generation(module)
+        PLACE_MODULE_EPOCH_0 = module_epoch
+        PLACE_ROOT_IDENTITY_0 = root_identity
+        PLACE_ROOT_TYPE_0 = root_type
+        PLACE_ROOT_LAYOUT_0 = root_layout
+        PLACE_FINALIZED_0 = 0
+        PLACE_PROJECTION_COUNT_0 = 0
+        PLACE_LAST_LOAD_0 = 0
+        PLACE_LAST_STORE_0 = 0
+    } else {
+        PLACE_MODULE_ARENA_1 = ir_module_arena_v2_module_id_arena_identity(module)
+        PLACE_MODULE_SLOT_1 = ir_module_arena_v2_module_id_slot(module)
+        PLACE_MODULE_GENERATION_1 = ir_module_arena_v2_module_id_generation(module)
+        PLACE_MODULE_EPOCH_1 = module_epoch
+        PLACE_ROOT_IDENTITY_1 = root_identity
+        PLACE_ROOT_TYPE_1 = root_type
+        PLACE_ROOT_LAYOUT_1 = root_layout
+        PLACE_FINALIZED_1 = 0
+        PLACE_PROJECTION_COUNT_1 = 0
+        PLACE_LAST_LOAD_1 = 0
+        PLACE_LAST_STORE_1 = 0
+    }
+}
+
+fn clear_place_slot(slot: i64) with Mut {
+    if slot == 0 {
+        PLACE_MODULE_ARENA_0 = 0
+        PLACE_MODULE_SLOT_0 = -1
+        PLACE_MODULE_GENERATION_0 = 0
+        PLACE_MODULE_EPOCH_0 = 0
+        PLACE_ROOT_IDENTITY_0 = 0
+        PLACE_ROOT_TYPE_0 = 0
+        PLACE_ROOT_LAYOUT_0 = 0
+        PLACE_FINALIZED_0 = 0
+        PLACE_PROJECTION_COUNT_0 = 0
+        PLACE_LAST_LOAD_0 = 0
+        PLACE_LAST_STORE_0 = 0
+    } else {
+        PLACE_MODULE_ARENA_1 = 0
+        PLACE_MODULE_SLOT_1 = -1
+        PLACE_MODULE_GENERATION_1 = 0
+        PLACE_MODULE_EPOCH_1 = 0
+        PLACE_ROOT_IDENTITY_1 = 0
+        PLACE_ROOT_TYPE_1 = 0
+        PLACE_ROOT_LAYOUT_1 = 0
+        PLACE_FINALIZED_1 = 0
+        PLACE_PROJECTION_COUNT_1 = 0
+        PLACE_LAST_LOAD_1 = 0
+        PLACE_LAST_STORE_1 = 0
+    }
+    let cell = slot * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY
+    set_proj_owner_type(cell, 0)
+    set_proj_owner_layout(cell, 0)
+    set_proj_field_ordinal(cell, 0)
+    set_proj_field_name_hash(cell, 0)
+    set_proj_result_type(cell, 0)
+    set_proj_result_layout(cell, 0)
+    set_proj_owner_type(cell + 1, 0)
+    set_proj_owner_layout(cell + 1, 0)
+    set_proj_field_ordinal(cell + 1, 0)
+    set_proj_field_name_hash(cell + 1, 0)
+    set_proj_result_type(cell + 1, 0)
+    set_proj_result_layout(cell + 1, 0)
+}
+
+fn proj_owner_type(cell: i64) -> i64 {
+    if cell == 0 { return PROJ_OWNER_TYPE_0 }
+    if cell == 1 { return PROJ_OWNER_TYPE_1 }
+    if cell == 2 { return PROJ_OWNER_TYPE_2 }
+    PROJ_OWNER_TYPE_3
+}
+
+fn proj_owner_layout(cell: i64) -> i64 {
+    if cell == 0 { return PROJ_OWNER_LAYOUT_0 }
+    if cell == 1 { return PROJ_OWNER_LAYOUT_1 }
+    if cell == 2 { return PROJ_OWNER_LAYOUT_2 }
+    PROJ_OWNER_LAYOUT_3
+}
+
+fn proj_field_ordinal(cell: i64) -> i64 {
+    if cell == 0 { return PROJ_FIELD_ORDINAL_0 }
+    if cell == 1 { return PROJ_FIELD_ORDINAL_1 }
+    if cell == 2 { return PROJ_FIELD_ORDINAL_2 }
+    PROJ_FIELD_ORDINAL_3
+}
+
+fn proj_field_name_hash(cell: i64) -> i64 {
+    if cell == 0 { return PROJ_FIELD_NAME_HASH_0 }
+    if cell == 1 { return PROJ_FIELD_NAME_HASH_1 }
+    if cell == 2 { return PROJ_FIELD_NAME_HASH_2 }
+    PROJ_FIELD_NAME_HASH_3
+}
+
+fn proj_result_type(cell: i64) -> i64 {
+    if cell == 0 { return PROJ_RESULT_TYPE_0 }
+    if cell == 1 { return PROJ_RESULT_TYPE_1 }
+    if cell == 2 { return PROJ_RESULT_TYPE_2 }
+    PROJ_RESULT_TYPE_3
+}
+
+fn proj_result_layout(cell: i64) -> i64 {
+    if cell == 0 { return PROJ_RESULT_LAYOUT_0 }
+    if cell == 1 { return PROJ_RESULT_LAYOUT_1 }
+    if cell == 2 { return PROJ_RESULT_LAYOUT_2 }
+    PROJ_RESULT_LAYOUT_3
+}
+
+fn set_proj_owner_type(cell: i64, value: i64) with Mut {
+    if cell == 0 { PROJ_OWNER_TYPE_0 = value }
+    else if cell == 1 { PROJ_OWNER_TYPE_1 = value }
+    else if cell == 2 { PROJ_OWNER_TYPE_2 = value }
+    else { PROJ_OWNER_TYPE_3 = value }
+}
+
+fn set_proj_owner_layout(cell: i64, value: i64) with Mut {
+    if cell == 0 { PROJ_OWNER_LAYOUT_0 = value }
+    else if cell == 1 { PROJ_OWNER_LAYOUT_1 = value }
+    else if cell == 2 { PROJ_OWNER_LAYOUT_2 = value }
+    else { PROJ_OWNER_LAYOUT_3 = value }
+}
+
+fn set_proj_field_ordinal(cell: i64, value: i64) with Mut {
+    if cell == 0 { PROJ_FIELD_ORDINAL_0 = value }
+    else if cell == 1 { PROJ_FIELD_ORDINAL_1 = value }
+    else if cell == 2 { PROJ_FIELD_ORDINAL_2 = value }
+    else { PROJ_FIELD_ORDINAL_3 = value }
+}
+
+fn set_proj_field_name_hash(cell: i64, value: i64) with Mut {
+    if cell == 0 { PROJ_FIELD_NAME_HASH_0 = value }
+    else if cell == 1 { PROJ_FIELD_NAME_HASH_1 = value }
+    else if cell == 2 { PROJ_FIELD_NAME_HASH_2 = value }
+    else { PROJ_FIELD_NAME_HASH_3 = value }
+}
+
+fn set_proj_result_type(cell: i64, value: i64) with Mut {
+    if cell == 0 { PROJ_RESULT_TYPE_0 = value }
+    else if cell == 1 { PROJ_RESULT_TYPE_1 = value }
+    else if cell == 2 { PROJ_RESULT_TYPE_2 = value }
+    else { PROJ_RESULT_TYPE_3 = value }
+}
+
+fn set_proj_result_layout(cell: i64, value: i64) with Mut {
+    if cell == 0 { PROJ_RESULT_LAYOUT_0 = value }
+    else if cell == 1 { PROJ_RESULT_LAYOUT_1 = value }
+    else if cell == 2 { PROJ_RESULT_LAYOUT_2 = value }
+    else { PROJ_RESULT_LAYOUT_3 = value }
+}
+
+fn place_id_is_live(id: &IrModuleArenaV2PlaceId) -> bool {
+    let slot = (*id).slot
+    if slot < 0 || slot >= IR_MODULE_ARENA_V2_PLACE_CAPACITY { return false }
+    place_state(slot) == PLACE_SLOT_LIVE && place_generation(slot) == (*id).generation
+}
+
+fn place_binding_matches(
+    module: &IrModuleArenaV2ModuleId,
+    slot: i64,
+) -> bool with Panic, Div {
+    place_module_arena(slot) == ir_module_arena_v2_module_id_arena_identity(module) &&
+    place_module_slot(slot) == ir_module_arena_v2_module_id_slot(module) &&
+    place_module_generation(slot) == ir_module_arena_v2_module_id_generation(module) &&
+    place_module_epoch(slot) == ir_module_arena_v2_module_mutation_epoch(module)
+}
+
+fn validate_place(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(module) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_MODULE
+    }
+    if !place_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_PLACE
+    }
+    if !place_binding_matches(module, (*id).slot) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_STALE_ROOT
+    }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+fn validate_finalized_place(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Panic, Div {
+    let status = validate_place(module, id)
+    if status != IR_MODULE_ARENA_V2_PLACE_OK { return status }
+    if place_finalized((*id).slot) == 0 {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_UNFINALIZED
+    }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_store_init() -> i64 with Mut {
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_PLACE_CAPACITY {
+        if place_state(slot) == PLACE_SLOT_LIVE {
+            set_place_generation(slot, place_generation(slot) + 1)
+        }
+        clear_place_slot(slot)
+        set_place_state(slot, PLACE_SLOT_FREE)
+        slot = slot + 1
+    }
+    PLACE_STORE_LIVE = 0
+    PLACE_ACCESS_SEQUENCE = 0
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_live_count() -> i64 {
+    PLACE_STORE_LIVE
+}
+
+pub fn ir_module_arena_v2_place_is_live(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> bool with Panic, Div {
+    validate_place(module, id) == IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_alloc_root(
+    module: &IrModuleArenaV2ModuleId,
+    root_identity: i64,
+    root_type: i64,
+    root_layout: i64,
+    out: &! IrModuleArenaV2PlaceId,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(module) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_MODULE
+    }
+    if place_id_is_live(out) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_OUTPUT_LIVE
+    }
+    if root_identity <= 0 || root_type <= 0 || root_layout <= 0 {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_RANGE
+    }
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_PLACE_CAPACITY {
+        if place_state(slot) != PLACE_SLOT_LIVE {
+            clear_place_slot(slot)
+            set_place_binding(
+                slot,
+                module,
+                ir_module_arena_v2_module_mutation_epoch(module),
+                root_identity,
+                root_type,
+                root_layout,
+            )
+            set_place_state(slot, PLACE_SLOT_LIVE)
+            PLACE_STORE_LIVE = PLACE_STORE_LIVE + 1
+            (*out).slot = slot
+            (*out).generation = place_generation(slot)
+            return IR_MODULE_ARENA_V2_PLACE_OK
+        }
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_PLACE_ERR_CAPACITY
+}
+
+pub fn ir_module_arena_v2_place_release(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Mut, Panic, Div {
+    let status = validate_place(module, id)
+    if status != IR_MODULE_ARENA_V2_PLACE_OK { return status }
+    let slot = (*id).slot
+    clear_place_slot(slot)
+    set_place_generation(slot, place_generation(slot) + 1)
+    set_place_state(slot, PLACE_SLOT_RELEASED)
+    PLACE_STORE_LIVE = PLACE_STORE_LIVE - 1
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+// Lifecycle-only discard. It validates the generational PlaceId but does not
+// grant semantic access, so a stale module/epoch binding cannot leak capacity.
+pub fn ir_module_arena_v2_place_discard(
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Mut {
+    if !place_id_is_live(id) { return IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_PLACE }
+    let slot = (*id).slot
+    clear_place_slot(slot)
+    set_place_generation(slot, place_generation(slot) + 1)
+    set_place_state(slot, PLACE_SLOT_RELEASED)
+    PLACE_STORE_LIVE = PLACE_STORE_LIVE - 1
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_finalize(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Mut, Panic, Div {
+    let status = validate_place(module, id)
+    if status != IR_MODULE_ARENA_V2_PLACE_OK { return status }
+    let slot = (*id).slot
+    if place_finalized(slot) != 0 { return IR_MODULE_ARENA_V2_PLACE_ERR_FINALIZED }
+    if slot == 0 { PLACE_FINALIZED_0 = 1 } else { PLACE_FINALIZED_1 = 1 }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_append_field(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+    owner_type: i64,
+    owner_layout: i64,
+    field_ordinal: i64,
+    field_name_hash: i64,
+    result_type: i64,
+    result_layout: i64,
+) -> i64 with Mut, Panic, Div {
+    let status = validate_place(module, id)
+    if status != IR_MODULE_ARENA_V2_PLACE_OK { return status }
+    if owner_type <= 0 || owner_layout <= 0 || field_ordinal < 0 ||
+       field_name_hash <= 0 || result_type <= 0 || result_layout <= 0 {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_RANGE
+    }
+    let slot = (*id).slot
+    if place_finalized(slot) != 0 { return IR_MODULE_ARENA_V2_PLACE_ERR_FINALIZED }
+    let count = place_projection_count(slot)
+    if count >= IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_PROJECTION_CAPACITY
+    }
+    let expected_type = if count == 0 {
+        place_root_type(slot)
+    } else {
+        proj_result_type(slot * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + count - 1)
+    }
+    let expected_layout = if count == 0 {
+        place_root_layout(slot)
+    } else {
+        proj_result_layout(slot * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + count - 1)
+    }
+    if owner_type != expected_type || owner_layout != expected_layout {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_TYPE_CHAIN
+    }
+    let cell = slot * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + count
+    set_proj_owner_type(cell, owner_type)
+    set_proj_owner_layout(cell, owner_layout)
+    set_proj_field_ordinal(cell, field_ordinal)
+    set_proj_field_name_hash(cell, field_name_hash)
+    set_proj_result_type(cell, result_type)
+    set_proj_result_layout(cell, result_layout)
+    if slot == 0 { PLACE_PROJECTION_COUNT_0 = count + 1 }
+    else { PLACE_PROJECTION_COUNT_1 = count + 1 }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_projection_count(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Panic, Div {
+    if validate_finalized_place(module, id) != IR_MODULE_ARENA_V2_PLACE_OK { return -1 }
+    place_projection_count((*id).slot)
+}
+
+pub fn ir_module_arena_v2_place_field_ordinal(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+    projection: i64,
+) -> i64 with Panic, Div {
+    if validate_finalized_place(module, id) != IR_MODULE_ARENA_V2_PLACE_OK { return -1 }
+    let slot = (*id).slot
+    if projection < 0 || projection >= place_projection_count(slot) { return -1 }
+    proj_field_ordinal(slot * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + projection)
+}
+
+pub fn ir_module_arena_v2_place_result_type(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+    projection: i64,
+) -> i64 with Panic, Div {
+    if validate_finalized_place(module, id) != IR_MODULE_ARENA_V2_PLACE_OK { return -1 }
+    let slot = (*id).slot
+    if projection < 0 || projection >= place_projection_count(slot) { return -1 }
+    proj_result_type(slot * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + projection)
+}
+
+fn projection_equal(slot_a: i64, index_a: i64, slot_b: i64, index_b: i64) -> bool {
+    let cell_a = slot_a * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + index_a
+    let cell_b = slot_b * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + index_b
+    proj_owner_type(cell_a) == proj_owner_type(cell_b) &&
+    proj_owner_layout(cell_a) == proj_owner_layout(cell_b) &&
+    proj_field_ordinal(cell_a) == proj_field_ordinal(cell_b) &&
+    proj_result_type(cell_a) == proj_result_type(cell_b) &&
+    proj_result_layout(cell_a) == proj_result_layout(cell_b)
+}
+
+pub fn ir_module_arena_v2_place_structural_equal(
+    module_a: &IrModuleArenaV2ModuleId,
+    place_a: &IrModuleArenaV2PlaceId,
+    module_b: &IrModuleArenaV2ModuleId,
+    place_b: &IrModuleArenaV2PlaceId,
+) -> bool with Panic, Div {
+    if validate_finalized_place(module_a, place_a) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       validate_finalized_place(module_b, place_b) != IR_MODULE_ARENA_V2_PLACE_OK {
+        return false
+    }
+    let slot_a = (*place_a).slot
+    let slot_b = (*place_b).slot
+    if place_module_arena(slot_a) != place_module_arena(slot_b) ||
+       place_module_slot(slot_a) != place_module_slot(slot_b) ||
+       place_module_generation(slot_a) != place_module_generation(slot_b) ||
+       place_module_epoch(slot_a) != place_module_epoch(slot_b) ||
+       place_root_identity(slot_a) != place_root_identity(slot_b) ||
+       place_root_type(slot_a) != place_root_type(slot_b) ||
+       place_root_layout(slot_a) != place_root_layout(slot_b) ||
+       place_projection_count(slot_a) != place_projection_count(slot_b) {
+        return false
+    }
+    let count = place_projection_count(slot_a)
+    if count > 0 && !projection_equal(slot_a, 0, slot_b, 0) { return false }
+    if count > 1 && !projection_equal(slot_a, 1, slot_b, 1) { return false }
+    true
+}
+
+pub fn ir_module_arena_v2_place_classify_same_name_hash(
+    module_a: &IrModuleArenaV2ModuleId,
+    place_a: &IrModuleArenaV2PlaceId,
+    projection_a: i64,
+    module_b: &IrModuleArenaV2ModuleId,
+    place_b: &IrModuleArenaV2PlaceId,
+    projection_b: i64,
+) -> i64 with Panic, Div {
+    let status_a = validate_finalized_place(module_a, place_a)
+    if status_a != IR_MODULE_ARENA_V2_PLACE_OK { return status_a }
+    let status_b = validate_finalized_place(module_b, place_b)
+    if status_b != IR_MODULE_ARENA_V2_PLACE_OK { return status_b }
+    let slot_a = (*place_a).slot
+    let slot_b = (*place_b).slot
+    if projection_a < 0 || projection_a >= place_projection_count(slot_a) ||
+       projection_b < 0 || projection_b >= place_projection_count(slot_b) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_RANGE
+    }
+    let cell_a = slot_a * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + projection_a
+    let cell_b = slot_b * IR_MODULE_ARENA_V2_PLACE_PROJECTION_CAPACITY + projection_b
+    if proj_field_name_hash(cell_a) != proj_field_name_hash(cell_b) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_STRUCTURAL_MISMATCH
+    }
+    if place_module_arena(slot_a) != place_module_arena(slot_b) ||
+       place_module_slot(slot_a) != place_module_slot(slot_b) ||
+       place_module_generation(slot_a) != place_module_generation(slot_b) ||
+       !projection_equal(slot_a, projection_a, slot_b, projection_b) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_SAME_HASH_STRUCTURAL_COLLISION
+    }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_record_load(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> i64 with Mut, Panic, Div {
+    let status = validate_finalized_place(module, id)
+    if status != IR_MODULE_ARENA_V2_PLACE_OK { return status }
+    PLACE_ACCESS_SEQUENCE = PLACE_ACCESS_SEQUENCE + 1
+    if (*id).slot == 0 { PLACE_LAST_LOAD_0 = PLACE_ACCESS_SEQUENCE }
+    else { PLACE_LAST_LOAD_1 = PLACE_ACCESS_SEQUENCE }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_record_store_after_load(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+    write_authorized: i64,
+) -> i64 with Mut, Panic, Div {
+    let status = validate_finalized_place(module, id)
+    if status != IR_MODULE_ARENA_V2_PLACE_OK { return status }
+    if write_authorized != 0 && write_authorized != 1 { return IR_MODULE_ARENA_V2_PLACE_ERR_RANGE }
+    let slot = (*id).slot
+    if write_authorized == 0 { return IR_MODULE_ARENA_V2_PLACE_ERR_WRITE_FORBIDDEN }
+    if place_last_load(slot) <= place_last_store(slot) {
+        return IR_MODULE_ARENA_V2_PLACE_ERR_ACCESS_ORDER
+    }
+    PLACE_ACCESS_SEQUENCE = PLACE_ACCESS_SEQUENCE + 1
+    if slot == 0 { PLACE_LAST_STORE_0 = PLACE_ACCESS_SEQUENCE }
+    else { PLACE_LAST_STORE_1 = PLACE_ACCESS_SEQUENCE }
+    IR_MODULE_ARENA_V2_PLACE_OK
+}
+
+pub fn ir_module_arena_v2_place_load_precedes_store(
+    module: &IrModuleArenaV2ModuleId,
+    id: &IrModuleArenaV2PlaceId,
+) -> bool with Panic, Div {
+    if validate_finalized_place(module, id) != IR_MODULE_ARENA_V2_PLACE_OK { return false }
+    let slot = (*id).slot
+    place_last_load(slot) > 0 && place_last_store(slot) > place_last_load(slot)
+}

--- a/tests/native-v2/place_ir_arena_v2_shadow_witness.sio
+++ b/tests/native-v2/place_ir_arena_v2_shadow_witness.sio
@@ -1,0 +1,116 @@
+use ir::arena_v2_shadow::*
+use ir::arena_v2_place_shadow::*
+
+fn fail(code: i64) -> i64 with IO {
+    print("PLACE_IR_ARENA_V2_SHADOW_FAIL code=")
+    print_int(code)
+    print("\n")
+    code
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_module_store_init(7001) != IR_MODULE_ARENA_V2_OK { return fail(101) }
+    if ir_module_arena_v2_place_store_init() != IR_MODULE_ARENA_V2_PLACE_OK { return fail(102) }
+
+    var module_a = ir_module_arena_v2_invalid_module_id()
+    var module_b = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(8101, &! module_a) != IR_MODULE_ARENA_V2_OK ||
+       ir_module_arena_v2_alloc_empty_module(8102, &! module_b) != IR_MODULE_ARENA_V2_OK { return fail(103) }
+
+    var place_a = ir_module_arena_v2_invalid_place_id()
+    var place_b = ir_module_arena_v2_invalid_place_id()
+    if ir_module_arena_v2_place_alloc_root(&module_a, 1, 101, 1001, &! place_a) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_alloc_root(&module_b, 1, 202, 2002, &! place_b) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(110) }
+    if ir_module_arena_v2_place_alloc_root(&module_a, 9, 909, 9009, &! place_a) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_OUTPUT_LIVE { return fail(109) }
+
+    // Same spelling hash, different module/type/layout/ordinal/result identity.
+    if ir_module_arena_v2_place_append_field(&module_a, &place_a, 101, 1001, 0, 777, 11, 111) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_append_field(&module_b, &place_b, 202, 2002, 1, 777, 22, 222) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(111) }
+    if ir_module_arena_v2_place_record_load(&module_a, &place_a) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_UNFINALIZED { return fail(115) }
+    // Nested projection must consume the exact prior result type/layout.
+    if ir_module_arena_v2_place_append_field(&module_b, &place_b, 202, 2002, 0, 888, 33, 333) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_TYPE_CHAIN { return fail(120) }
+    if ir_module_arena_v2_place_append_field(&module_b, &place_b, 22, 222, 0, 888, 33, 333) !=
+       IR_MODULE_ARENA_V2_PLACE_OK { return fail(121) }
+    if ir_module_arena_v2_place_append_field(&module_b, &place_b, 33, 333, 0, 999, 44, 444) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_PROJECTION_CAPACITY { return fail(123) }
+    if ir_module_arena_v2_place_finalize(&module_a, &place_a) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_finalize(&module_b, &place_b) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(124) }
+    if ir_module_arena_v2_place_projection_count(&module_b, &place_b) != 2 ||
+       ir_module_arena_v2_place_result_type(&module_b, &place_b, 1) != 33 { return fail(122) }
+    if ir_module_arena_v2_place_append_field(&module_a, &place_a, 11, 111, 0, 999, 44, 444) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_FINALIZED { return fail(125) }
+    if ir_module_arena_v2_place_field_ordinal(&module_a, &place_a, 0) != 0 ||
+       ir_module_arena_v2_place_field_ordinal(&module_b, &place_b, 0) != 1 { return fail(112) }
+    if ir_module_arena_v2_place_classify_same_name_hash(&module_a, &place_a, 0, &module_b, &place_b, 0) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_SAME_HASH_STRUCTURAL_COLLISION { return fail(113) }
+    if ir_module_arena_v2_place_structural_equal(&module_a, &place_a, &module_b, &place_b) { return fail(114) }
+
+    // Access events preserve order but are not structural Place identity.
+    if ir_module_arena_v2_place_record_store_after_load(&module_b, &place_b, 1) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_ACCESS_ORDER { return fail(130) }
+    if ir_module_arena_v2_place_record_load(&module_b, &place_b) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_record_store_after_load(&module_b, &place_b, 1) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       !ir_module_arena_v2_place_load_precedes_store(&module_b, &place_b) { return fail(131) }
+
+    // Both slots are live and structurally distinct; failed allocation preserves out.
+    var over = ir_module_arena_v2_invalid_place_id()
+    if ir_module_arena_v2_place_alloc_root(&module_a, 9, 909, 9009, &! over) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_CAPACITY { return fail(140) }
+    if ir_module_arena_v2_place_id_slot(&over) != -1 || ir_module_arena_v2_place_live_count() != 2 { return fail(141) }
+    if ir_module_arena_v2_place_record_load(&module_a, &place_a) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(142) }
+    if !ir_module_arena_v2_place_is_live(&module_b, &place_b) { return fail(143) }
+
+    // Place ABA: release/reuse same slot, old generation stays rejected.
+    let old_place_slot = ir_module_arena_v2_place_id_slot(&place_a)
+    let old_place_generation = ir_module_arena_v2_place_id_generation(&place_a)
+    if ir_module_arena_v2_place_release(&module_a, &place_a) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(150) }
+    var place_reused = ir_module_arena_v2_invalid_place_id()
+    if ir_module_arena_v2_place_alloc_root(&module_a, 2, 102, 1002, &! place_reused) !=
+       IR_MODULE_ARENA_V2_PLACE_OK { return fail(151) }
+    if ir_module_arena_v2_place_id_slot(&place_reused) != old_place_slot ||
+       ir_module_arena_v2_place_id_generation(&place_reused) == old_place_generation { return fail(152) }
+    if ir_module_arena_v2_place_is_live(&module_a, &place_a) { return fail(153) }
+    if ir_module_arena_v2_place_finalize(&module_a, &place_reused) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(154) }
+    if ir_module_arena_v2_place_record_store_after_load(&module_a, &place_reused, 0) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_WRITE_FORBIDDEN { return fail(155) }
+
+    // Module mutation epoch invalidates a Place before any later access.
+    if ir_module_arena_v2_configure_module_bss_size(&module_a, 8) != IR_MODULE_ARENA_V2_OK { return fail(160) }
+    if ir_module_arena_v2_place_is_live(&module_a, &place_reused) { return fail(161) }
+    if ir_module_arena_v2_place_record_load(&module_a, &place_reused) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_STALE_ROOT { return fail(162) }
+    if ir_module_arena_v2_place_discard(&place_reused) != IR_MODULE_ARENA_V2_PLACE_OK { return fail(163) }
+
+    // Reset/reuse invalidates the old ModuleId and old Place binding.
+    let old_module_slot = ir_module_arena_v2_module_id_slot(&module_b)
+    let old_module_generation = ir_module_arena_v2_module_id_generation(&module_b)
+    if ir_module_arena_v2_reset_modules() != IR_MODULE_ARENA_V2_OK { return fail(170) }
+    if ir_module_arena_v2_place_record_load(&module_b, &place_b) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_INVALID_MODULE { return fail(171) }
+    var module_filler = ir_module_arena_v2_invalid_module_id()
+    var module_b_reused = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9101, &! module_filler) != IR_MODULE_ARENA_V2_OK ||
+       ir_module_arena_v2_alloc_empty_module(9102, &! module_b_reused) != IR_MODULE_ARENA_V2_OK { return fail(172) }
+    if ir_module_arena_v2_module_id_slot(&module_b_reused) != old_module_slot ||
+       ir_module_arena_v2_module_id_generation(&module_b_reused) == old_module_generation { return fail(173) }
+    if ir_module_arena_v2_place_record_load(&module_b_reused, &place_b) !=
+       IR_MODULE_ARENA_V2_PLACE_ERR_STALE_ROOT { return fail(174) }
+    if ir_module_arena_v2_place_discard(&place_b) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_live_count() != 0 { return fail(175) }
+    var reclaimed_a = ir_module_arena_v2_invalid_place_id()
+    var reclaimed_b = ir_module_arena_v2_invalid_place_id()
+    if ir_module_arena_v2_place_alloc_root(&module_filler, 3, 303, 3003, &! reclaimed_a) !=
+       IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_alloc_root(&module_b_reused, 4, 404, 4004, &! reclaimed_b) !=
+       IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_live_count() != 2 { return fail(176) }
+    if ir_module_arena_v2_place_discard(&reclaimed_a) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_discard(&reclaimed_b) != IR_MODULE_ARENA_V2_PLACE_OK ||
+       ir_module_arena_v2_place_live_count() != 0 { return fail(177) }
+
+    print("PLACE_IR_ARENA_V2_SHADOW_PASS mode=place_structural_witness_not_parity\n")
+    0
+}

--- a/tests/native-v2/place_ir_legacy_nominal_collision_witness.sio
+++ b/tests/native-v2/place_ir_legacy_nominal_collision_witness.sio
@@ -1,0 +1,22 @@
+struct A {
+    shared: i64,
+    pad: i64,
+}
+
+struct B {
+    pad: i64,
+    shared: i64,
+}
+
+fn make_b() -> B {
+    B { pad: 11, shared: 42 }
+}
+
+fn main() -> i64 {
+    // Control: a typed local preserves B.shared ordinal 1.
+    let typed = make_b()
+    if typed.shared != 42 { return 90 }
+    // Current lowering loses the nominal base on a call expression and its
+    // name-only fallback selects A.shared ordinal 0, producing pad=11.
+    make_b().shared
+}


### PR DESCRIPTION
## Stack

- Base: #965 at `8f6e88e5260f55e4db3e7cefa49e1cf4ecc73634`
- Head: `90a8a83ac15bac6fc91e631d6847131d1b5fd257`
- Draft / DO NOT MERGE

## What this proves

Adds an off-default `PlaceId(slot,generation)` scalar-column store bound to live `ModuleId` identity/generation and module mutation epoch. Places are built then finalized; access policy is separate from structural identity; stale Places can be generation-discarded without semantic access. The witness covers same-hash structural collision, nested declared type/layout chains, access order, module/Place ABA, stale capacity recovery, structural distinction, and checked capacities.

A real imported-module smoke loads three modules and executes the public handle/scalar API. A separate current-lowering counterexample runs a typed control at 42 while `make_b().shared` exits 11. Classification is deliberately `place_structural_witness_not_parity`.

## Honesty boundary

Type/layout/ordinal identities are caller-supplied shadow declarations checked for self-consistency. This does not prove canonical resolution, alias analysis, SOIR/serializer/backend parity, default routing, or replacement of current lowering. The legacy result is a counterexample/control, not a parity oracle.

## Exact local evidence

```text
SOUC_BIN=/tmp/pr965-current-source-29415954476/madaros bash scripts/ci/place_ir_arena_v2_shadow_gate.sh
PLACE_IR_ARENA_V2_PASS compiler_sha256=7ad961849c398ba6dc709dd327f14f14405062bb12638d48374d8619a1ba8372 base=8f6e88e5260f55e4db3e7cefa49e1cf4ecc73634
```

Also green: parent Arena v2 gate, parent Arena/SOIR v5 bridge gate, docs registry/selftest, research packet validation, shell syntax, and `git diff --check`. Orthogonal review verdict after fixes: approve with claim-wording cleanup; cleanup applied.