### PR TITLE
test(stdlib): batch 8 — cybernetic coupling/observer + signal fractal verticals

### DIFF
--- a/scripts/verticals_batch8_gate.sh
+++ b/scripts/verticals_batch8_gate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Combined gate: cybernetic::coupling, signal::fractal, cybernetic::observer (all default Madaros).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel engine
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if [ "${4:-}" = "lean_single" ]; then
+    if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+      chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+    else echo "FAIL compile $2"; fail=1; fi
+  else
+    if $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+      "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+    else echo "FAIL compile $2"; fail=1; fi
+  fi
+}
+run stdlib/cybernetic/coupling.sio  tests/stdlib/cybernetic/test_coupling_stdlib.sio  COUPLING_STDLIB_OK
+run stdlib/signal/fractal.sio       tests/stdlib/signal/test_fractal_stdlib.sio       FRACTAL_STDLIB_OK
+run stdlib/cybernetic/observer.sio  tests/stdlib/cybernetic/test_observer_stdlib.sio  OBSERVER_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_BATCH8_GATE_OK"
+exit $fail

--- a/tests/stdlib/cybernetic/test_coupling_stdlib.sio
+++ b/tests/stdlib/cybernetic/test_coupling_stdlib.sio
@@ -1,0 +1,23 @@
+// Run-proof for stdlib cybernetic::coupling (structural coupling). By-value struct -> default Madaros.
+use cybernetic::coupling::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // perfectly aligned coupling: a==b every step -> congruence 1, prediction_error 0
+    var c = coupling_new(1, 2)
+    c = couple_step(c, 1.0, 1.0)
+    c = couple_step(c, 2.0, 2.0)
+    c = couple_step(c, 3.0, 3.0)
+    c = couple_step(c, 4.0, 4.0)
+    let cong = congruence(c)
+    if (if cong > 1.0 { cong-1.0 } else { 1.0-cong }) >= 1.0e-6 { print("FAIL cong1\n"); return 1 }
+    let pe = prediction_error(c)
+    if (if pe > 0.0 { pe } else { 0.0-pe }) >= 1.0e-6 { print("FAIL pe0\n"); return 2 }
+    // divergent coupling: a != b -> congruence < 1, prediction_error > 0
+    var d = coupling_new(3, 4)
+    d = couple_step(d, 1.0, 5.0)
+    d = couple_step(d, 2.0, 8.0)
+    d = couple_step(d, 3.0, 1.0)
+    if congruence(d) >= cong { print("FAIL cong_lt\n"); return 3 }
+    if prediction_error(d) <= 0.0 { print("FAIL pe_pos\n"); return 4 }
+    print("COUPLING_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/cybernetic/test_observer_stdlib.sio
+++ b/tests/stdlib/cybernetic/test_observer_stdlib.sio
@@ -1,0 +1,22 @@
+// Run-proof for stdlib cybernetic::observer (second-order observation / observer drift).
+// Each observation perturbs the observer: drift += drift_rate. Default Madaros.
+use cybernetic::observer::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // fresh observer: no accumulated drift -> blind_spot 0
+    let o = observer_new(1, 0.2)
+    if (if blind_spot(o) > 0.0 { blind_spot(o) } else { 0.0-blind_spot(o) }) >= 1.0e-9 { print("FAIL fresh\n"); return 1 }
+    // 3 observations -> drift = 3 * 0.2 = 0.6
+    let a = make_observation(o, 5.0, 0.1)
+    let b = make_observation(a.observer, 6.0, 0.1)
+    let c = make_observation(b.observer, 7.0, 0.1)
+    let drift = blind_spot(c.observer)
+    if (if drift > 0.6 { drift-0.6 } else { 0.6-drift }) >= 1.0e-6 { print("FAIL drift\n"); return 2 }
+    // relative blind spot now positive (drift contributes to total uncertainty)
+    if relative_blind_spot(c.observer) <= 0.0 { print("FAIL rel_pos\n"); return 3 }
+    // zero drift-rate observer stays unbiased after observations
+    let z = observer_new(2, 0.0)
+    let za = make_observation(z, 1.0, 0.1)
+    if (if blind_spot(za.observer) > 0.0 { blind_spot(za.observer) } else { 0.0-blind_spot(za.observer) }) >= 1.0e-9 { print("FAIL zero_drift\n"); return 4 }
+    print("OBSERVER_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/signal/test_fractal_stdlib.sio
+++ b/tests/stdlib/signal/test_fractal_stdlib.sio
@@ -1,0 +1,15 @@
+// Run-proof for stdlib signal::fractal (Higuchi FD, DFA). By-reference &[f64;1024] -> default Madaros.
+use signal::fractal::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // smooth linear ramp: Higuchi fractal dimension ~ 1.0 (a curve, not space-filling)
+    var ramp: [f64; 1024] = [0.0; 1024]
+    var i: i64 = 0
+    while i < 256 { ramp[i as usize] = (i as f64); i = i + 1 }
+    let fd = higuchi_fd(&ramp, 256, 8)
+    if (if fd > 1.0 { fd-1.0 } else { 1.0-fd }) >= 0.05 { print("FAIL fd_line\n"); return 1 }
+    // DFA scaling exponent of a linear trend ~ 2 (integrated linear -> quadratic profile)
+    let a = dfa(&ramp, 256)
+    if (if a > 2.0 { a-2.0 } else { 2.0-a }) >= 0.2 { print("FAIL dfa\n"); return 2 }
+    print("FRACTAL_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Batch 8 — three more stdlib compute verticals (no compiler changes)

Continues the lean run-proof pattern (batches 2–7): tests + gate script only, no shared-file edits. Each vertical is proven by **compile-and-run** to native ELF (default Madaros), asserting against first-principles values.

| Module | Proof |
|---|---|
| `cybernetic::coupling` | structural coupling: `congruence=1.0` + `prediction_error=0` for aligned signals; `congruence<1`, `error>0` for divergent |
| `signal::fractal` | Higuchi FD ≈ 1.0 for a linear ramp; DFA α ≈ 2.0 for a linear trend (integrated → quadratic profile) |
| `cybernetic::observer` | second-order observation drift: fresh `blind_spot=0`; `0.6` after 3 observations at `drift_rate 0.2`; zero-rate stays unbiased; `relative_blind_spot>0` once drift>0 |

### Verification
- `scripts/verticals_batch8_gate.sh` → `VERTICALS_BATCH8_GATE_OK` (checks each module + compiles/runs each driver, greps sentinel).
- Math-review (xai/grok): all three PASS from first principles.

### Constraint compliance
- No edits to `self-hosted/` or `bootstrap/` (compiler owned by CODEX-2).
- New files only: 3 test drivers + 1 gate script. No `.claude/` or governance-registry edits → stays mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)