### PR TITLE
feat(stats): chance-corrected agreement — gwet_ac1, krippendorff, icc_forms

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2926,3 +2926,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - cles = **PASS**: Φ(d/√2) from X₁−X₂~N(dσ,2σ²), non-parametric pair count (ties ½) = ROC AUC; d=1→0.7603, interleaved→1/3 verified.
 - Theme: effect-size conversion & derivation — the meta-analysis/reporting glue complementing effect_size (which computes from data). All derivable, #852-safe. Suite runner: 94 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-mWCVbQ/`, `/tmp/llm-offload-pTAF9f/`, `/tmp/llm-offload-rYFbnF/`.
+
+## 2026-07-15 — math-review: stats::gwet_ac1, stats::krippendorff, stats::icc_forms
+- Files (all new): `stdlib/stats/gwet_ac1.sio` (Gwet's AC1 paradox-resistant agreement), `stdlib/stats/krippendorff.sio` (Krippendorff's alpha, nominal, complete data, m raters), `stdlib/stats/icc_forms.sio` (all six Shrout-Fleiss ICC forms via two-way ANOVA). Provider: xAI/Grok 4.3.
+- gwet_ac1 = **PASS**: AC1=(Pₐ−Pₑ)/(1−Pₑ), Pₑ=1/(k−1)Σπc(1−πc); paradox case [[8,1],[1,0]]→AC1=0.756 (κ negative) verified.
+- krippendorff = **PASS**: coincidence-matrix Dₒ/Dₑ, α=1−Dₒ/Dₑ; 4-unit/2-rater→α=0.125, perfect→1 verified.
+- icc_forms = **PASS**: ICC(1,1)/(2,1)/(3,1) + average-measure forms from ANOVA MSB/MSR/MSW/MSE; **validated against the published Shrout-Fleiss (1979) 6×4 example** → 0.166/0.290/0.715 (all three match).
+- Theme: chance-corrected agreement — extends cohen_kappa/fleiss_kappa/reliability with the general Krippendorff α, the paradox-resistant Gwet AC1, and the full ICC family. All derivable, #852-safe. Suite runner: 97 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-QU0X4f/`, `/tmp/llm-offload-DxNLA5/`, `/tmp/llm-offload-xj10Av/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -103,6 +103,9 @@ MODULES=(
   stdlib/stats/effect_convert.sio
   stdlib/stats/effect_from_test.sio
   stdlib/stats/cles.sio
+  stdlib/stats/gwet_ac1.sio
+  stdlib/stats/krippendorff.sio
+  stdlib/stats/icc_forms.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -28,7 +28,8 @@ fourteen families:
 - **Categorical & exact** — χ² independence, Fisher's exact 2×2, McNemar,
   Cochran's Q, the Cochran-Armitage trend test and proportion CIs.
 - **Agreement & reliability** — Bland-Altman, Lin's CCC + Cliff's δ, Cohen's and
-  Fleiss' κ, and ICC / Cronbach's α.
+  Fleiss' κ, Gwet's AC1, Krippendorff's α, ICC / Cronbach's α and the full
+  Shrout-Fleiss ICC family.
 - **Diagnostic accuracy** — sensitivity / specificity / likelihood ratios and
   ROC AUC.
 - **Survival analysis** — Kaplan-Meier, Nelson-Aalen cumulative hazard,
@@ -1295,6 +1296,39 @@ The probability that a random draw from one group exceeds one from the other —
 (= the ROC AUC). Validated: d=0 → 0.5, d=1 → 0.7603; fully-separated samples → 1;
 interleaved → 1/3.
 
+### `stats::gwet_ac1` — Gwet's AC1 agreement
+
+| Function | Signature |
+|---|---|
+| `gwet_ac1` | `pub fn gwet_ac1(table: &[f64; 256], k: i32) -> AC1Result with Mut, Div, Panic` |
+
+A chance-corrected two-rater agreement coefficient that resists the kappa
+paradox (high agreement but low κ under lopsided prevalence): its chance term
+uses `πc(1−πc)` rather than κ's `πc²`. Validated: [[8,1],[1,0]] → Pₐ=0.8, AC1=0.756
+(where Cohen's κ goes negative); perfect → 1.
+
+### `stats::krippendorff` — Krippendorff's alpha (nominal)
+
+| Function | Signature |
+|---|---|
+| `krippendorff` | `pub fn krippendorff(rating: &[i64; 256], n_units: i32, m_raters: i32, k: i32) -> f64 with Mut, Div, Panic` |
+
+The general chance-corrected reliability coefficient for any number of raters
+(nominal, complete data), via the coincidence matrix: `α=1−Dₒ/Dₑ`. Validated:
+a 4-unit / 2-rater example → α=0.125; perfect agreement → 1; three concordant
+raters → 1.
+
+### `stats::icc_forms` — the intraclass-correlation family
+
+| Function | Signature |
+|---|---|
+| `icc_forms` | `pub fn icc_forms(data: &[f64; 256], n: i32, k: i32) -> ICCFormsResult with Mut, Div, Panic` |
+
+All six Shrout-Fleiss ICC forms — single- and average-measure ICC(1,1)/(2,1)/(3,1)
+— from the two-way ANOVA of a subjects×raters matrix. Validated against the
+published Shrout-Fleiss (1979) 6×4 example: ICC(1,1)=0.166, ICC(2,1)=0.290,
+ICC(3,1)=0.715.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1393,6 +1427,9 @@ use stats::cusum::{CusumResult, cusum}
 use stats::effect_convert::{d_to_r, r_to_d, d_to_logor, logor_to_d, d_to_or, hedges_g}
 use stats::effect_from_test::{r_from_t, d_from_t, eta2_from_f, omega2_from_f, d_from_means}
 use stats::cles::{cles_from_d, cles_from_samples}
+use stats::gwet_ac1::{AC1Result, gwet_ac1}
+use stats::krippendorff::{krippendorff}
+use stats::icc_forms::{ICCFormsResult, icc_forms}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/gwet_ac1.sio
+++ b/stdlib/stats/gwet_ac1.sio
@@ -1,0 +1,129 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/gwet_ac1.sio — Gwet's AC1 agreement coefficient
+//
+// A chance-corrected agreement coefficient for two raters that is resistant to
+// the "kappa paradox" (high observed agreement but a low or negative kappa when
+// one category dominates):
+//
+//   gwet_ac1(table, k) -> AC1Result       (k×k rater1×rater2 counts)
+//
+//   Pₐ = Σ diagonal / N,   πc = (rowc + colc)/(2N),
+//   Pₑ = 1/(k−1) · Σ πc(1−πc),   AC1 = (Pₐ − Pₑ)/(1 − Pₑ).
+// Gwet's chance term uses πc(1−πc) rather than kappa's πc², so a lopsided
+// category prevalence does not inflate the correction.
+//
+// Pure Sounio: one pass over the table for the diagonal and marginals. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Gwet (2008) Br. J. Math. Stat. Psychol. 61:29.
+
+module stats::gwet_ac1
+
+pub struct AC1Result {
+    pub ac1: f64,   // Gwet's AC1
+    pub pa: f64,    // observed agreement
+    pub pe: f64,    // AC1 chance agreement
+}
+
+/// Gwet's AC1 for a k×k two-rater agreement table.
+///
+/// Parâmetros: table — row-major k×k counts (rater1 = row, rater2 = col);
+///             k — number of categories (2..16).
+/// Retorno: AC1Result (ac1, pa, pe).
+/// Referências: Gwet (2008).
+pub fn gwet_ac1(table: &[f64; 256], k: i32) -> AC1Result with Mut, Div, Panic {
+    if k < 2 || k > 16 { return AC1Result { ac1: 0.0, pa: 0.0, pe: 0.0 } }
+    var total = 0.0
+    var diag = 0.0
+    var i = 0
+    while i < k {
+        var j = 0
+        while j < k {
+            let v = table[(i * k + j) as usize]
+            total = total + v
+            if i == j { diag = diag + v }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    if total <= 0.0 { return AC1Result { ac1: 0.0, pa: 0.0, pe: 0.0 } }
+    let pa = diag / total
+    // category proportions πc = (row_c + col_c)/(2N)
+    var pe_sum = 0.0
+    var c = 0
+    while c < k {
+        var rowc = 0.0
+        var colc = 0.0
+        var t = 0
+        while t < k {
+            rowc = rowc + table[(c * k + t) as usize]
+            colc = colc + table[(t * k + c) as usize]
+            t = t + 1
+        }
+        let pic = (rowc + colc) / (2.0 * total)
+        pe_sum = pe_sum + pic * (1.0 - pic)
+        c = c + 1
+    }
+    let pe = pe_sum / ((k - 1) as f64)
+    var ac1 = 0.0
+    let den = 1.0 - pe
+    if den > 1.0e-300 || den < 0.0 - 1.0e-300 { ac1 = (pa - pe) / den }
+    return AC1Result { ac1: ac1, pa: pa, pe: pe }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// paradox case [[8,1],[1,0]], N=10. Pa=0.8; π_yes=0.9, π_no=0.1;
+// Pe=0.9·0.1+0.1·0.9=0.18; AC1=(0.8-0.18)/0.82=0.756098.
+// (Cohen's kappa on the same table is negative — AC1 resists the paradox.)
+fn test_paradox() -> bool with IO, Mut, Div, Panic {
+    var tb: [f64; 256] = [0.0; 256]
+    tb[0]=8.0; tb[1]=1.0
+    tb[2]=1.0; tb[3]=0.0
+    let r = gwet_ac1(&tb, 2)
+    var ok = true
+    ok = check(1, approx(r.pa, 0.8, 1.0e-9)) && ok
+    ok = check(2, approx(r.pe, 0.18, 1.0e-9)) && ok
+    ok = check(3, approx(r.ac1, 0.756098, 1.0e-5)) && ok
+    return ok
+}
+
+// perfect agreement -> AC1 = 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var tb: [f64; 256] = [0.0; 256]
+    tb[0]=5.0; tb[1]=0.0
+    tb[2]=0.0; tb[3]=5.0
+    let r = gwet_ac1(&tb, 2)
+    return check(10, approx(r.ac1, 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_paradox() && ok
+    ok = test_perfect() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/icc_forms.sio
+++ b/stdlib/stats/icc_forms.sio
@@ -1,0 +1,175 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/icc_forms.sio — the intraclass-correlation family
+//
+// The six Shrout-Fleiss ICC forms from a subjects × raters matrix, via the
+// two-way ANOVA mean squares — choosing the right one depends on whether raters
+// are random, and whether a single or averaged measurement is used:
+//
+//   icc_forms(data, n, k) -> ICCFormsResult      (data row-major n × k)
+//
+//   ICC(1,1) = (MSB−MSW)/(MSB+(k−1)MSW),
+//   ICC(2,1) = (MSB−MSE)/(MSB+(k−1)MSE + k(MSR−MSE)/n),
+//   ICC(3,1) = (MSB−MSE)/(MSB+(k−1)MSE),
+// and the average-measures forms ICC(·,k) with the analogous numerator over MSB.
+//
+// Pure Sounio: row/column/grand means then the ANOVA sums of squares. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Shrout & Fleiss (1979) Psychol. Bull. 86:420.
+
+module stats::icc_forms
+
+pub struct ICCFormsResult {
+    pub icc11: f64,   // one-way random, single measure
+    pub icc21: f64,   // two-way random, single measure
+    pub icc31: f64,   // two-way mixed, single measure
+    pub icc1k: f64,   // one-way random, average measure
+    pub icc2k: f64,   // two-way random, average measure
+    pub icc3k: f64,   // two-way mixed, average measure
+}
+
+/// The six Shrout-Fleiss ICC forms from a subjects × raters matrix.
+///
+/// Parâmetros: data — row-major n × k measurements; n — subjects (>=2); k — raters (>=2).
+/// Retorno: ICCFormsResult (single- and average-measure ICC(1..3)).
+/// Referências: Shrout & Fleiss (1979).
+pub fn icc_forms(data: &[f64; 256], n: i32, k: i32) -> ICCFormsResult with Mut, Div, Panic {
+    if n < 2 || k < 2 {
+        return ICCFormsResult { icc11: 0.0, icc21: 0.0, icc31: 0.0, icc1k: 0.0, icc2k: 0.0, icc3k: 0.0 }
+    }
+    let nf = n as f64
+    let kf = k as f64
+    // grand mean
+    var grand = 0.0
+    var i = 0
+    while i < n {
+        var j = 0
+        while j < k { grand = grand + data[(i * k + j) as usize]; j = j + 1 }
+        i = i + 1
+    }
+    grand = grand / (nf * kf)
+    // row (subject) means and column (rater) means
+    var ssb = 0.0     // between subjects
+    var r = 0
+    while r < n {
+        var rs = 0.0
+        var j = 0
+        while j < k { rs = rs + data[(r * k + j) as usize]; j = j + 1 }
+        let rm = rs / kf
+        ssb = ssb + (rm - grand) * (rm - grand)
+        r = r + 1
+    }
+    ssb = ssb * kf
+    var ssr = 0.0     // between raters
+    var c = 0
+    while c < k {
+        var cs = 0.0
+        var t = 0
+        while t < n { cs = cs + data[(t * k + c) as usize]; t = t + 1 }
+        let cm = cs / nf
+        ssr = ssr + (cm - grand) * (cm - grand)
+        c = c + 1
+    }
+    ssr = ssr * nf
+    // total
+    var sst = 0.0
+    var a = 0
+    while a < n {
+        var b = 0
+        while b < k {
+            let d = data[(a * k + b) as usize] - grand
+            sst = sst + d * d
+            b = b + 1
+        }
+        a = a + 1
+    }
+    let sse = sst - ssb - ssr
+    let ssw = sst - ssb
+    let msb = ssb / (nf - 1.0)
+    let msr = ssr / (kf - 1.0)
+    let msw = ssw / (nf * (kf - 1.0))
+    let mse = sse / ((nf - 1.0) * (kf - 1.0))
+    // single-measure forms
+    var icc11 = 0.0
+    let d11 = msb + (kf - 1.0) * msw
+    if d11 > 1.0e-300 { icc11 = (msb - msw) / d11 }
+    var icc21 = 0.0
+    let d21 = msb + (kf - 1.0) * mse + kf * (msr - mse) / nf
+    if d21 > 1.0e-300 { icc21 = (msb - mse) / d21 }
+    var icc31 = 0.0
+    let d31 = msb + (kf - 1.0) * mse
+    if d31 > 1.0e-300 { icc31 = (msb - mse) / d31 }
+    // average-measures forms
+    var icc1k = 0.0
+    if msb > 1.0e-300 { icc1k = (msb - msw) / msb }
+    var icc2k = 0.0
+    let d2k = msb + (msr - mse) / nf
+    if d2k > 1.0e-300 { icc2k = (msb - mse) / d2k }
+    var icc3k = 0.0
+    if msb > 1.0e-300 { icc3k = (msb - mse) / msb }
+    return ICCFormsResult { icc11: icc11, icc21: icc21, icc31: icc31, icc1k: icc1k, icc2k: icc2k, icc3k: icc3k }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// Shrout & Fleiss (1979) 6×4 example: ICC(1,1)=0.166, ICC(2,1)=0.290, ICC(3,1)=0.715.
+fn test_shrout_fleiss() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=9.0;  d[1]=2.0;  d[2]=5.0;  d[3]=8.0
+    d[4]=6.0;  d[5]=1.0;  d[6]=3.0;  d[7]=2.0
+    d[8]=8.0;  d[9]=4.0;  d[10]=6.0; d[11]=8.0
+    d[12]=7.0; d[13]=1.0; d[14]=2.0; d[15]=6.0
+    d[16]=10.0;d[17]=5.0; d[18]=6.0; d[19]=9.0
+    d[20]=6.0; d[21]=2.0; d[22]=4.0; d[23]=7.0
+    let r = icc_forms(&d, 6, 4)
+    var ok = true
+    ok = check(1, approx(r.icc11, 0.165746, 1.0e-4)) && ok
+    ok = check(2, approx(r.icc21, 0.289762, 1.0e-4)) && ok
+    ok = check(3, approx(r.icc31, 0.714841, 1.0e-4)) && ok
+    ok = check(4, approx(r.icc3k, 0.909316, 1.0e-4)) && ok
+    return ok
+}
+
+// perfect agreement (all raters identical per subject) -> ICC = 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=1.0; d[2]=1.0
+    d[3]=5.0; d[4]=5.0; d[5]=5.0
+    d[6]=9.0; d[7]=9.0; d[8]=9.0
+    let r = icc_forms(&d, 3, 3)
+    var ok = true
+    ok = check(10, approx(r.icc31, 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.icc21, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_shrout_fleiss() && ok
+    ok = test_perfect() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/krippendorff.sio
+++ b/stdlib/stats/krippendorff.sio
@@ -1,0 +1,159 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/krippendorff.sio — Krippendorff's alpha (nominal)
+//
+// A general chance-corrected reliability coefficient for any number of raters,
+// here for nominal data with complete ratings:
+//
+//   krippendorff(rating, n_units, m_raters, k) -> f64
+//
+// From the coincidence matrix o_ck (nominal metric δ² = [c ≠ k]),
+//   Dₒ = Σ_{c≠k} o_ck / n,      Dₑ = Σ_{c≠k} nc·nk / (n(n−1)),
+//   α = 1 − Dₒ/Dₑ,
+// with per-unit coincidence  o_ck += cntc·cntk/(m−1)  (c≠k) and
+//   cntc(cntc−1)/(m−1)  (c=k).  α = 1 is perfect agreement, 0 is chance.
+//
+// Pure Sounio: per-unit category counts then a k×k coincidence accumulation. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Krippendorff (2004) "Content Analysis" 2e, ch.11.
+
+module stats::krippendorff
+
+/// Krippendorff's alpha for complete nominal reliability data.
+///
+/// Parâmetros: rating — row-major n_units × m_raters category codes (0..k-1);
+///             n_units — units (>=2); m_raters — raters per unit (>=2); k — categories (2..16).
+/// Retorno: alpha (1 = perfect, 0 = chance, <0 = systematic disagreement).
+/// Referências: Krippendorff (2004).
+pub fn krippendorff(rating: &[i64; 256], n_units: i32, m_raters: i32, k: i32) -> f64 with Mut, Div, Panic {
+    if n_units < 2 || m_raters < 2 || k < 2 || k > 16 { return 0.0 }
+    let mm1 = (m_raters - 1) as f64
+    var coin: [f64; 256] = [0.0; 256]   // k×k coincidence matrix
+    var u = 0
+    while u < n_units {
+        // count raters per category for this unit
+        var cnt: [f64; 16] = [0.0; 16]
+        var r = 0
+        while r < m_raters {
+            let cat = rating[(u * m_raters + r) as usize]
+            if cat >= 0 && cat < (k as i64) { cnt[cat as usize] = cnt[cat as usize] + 1.0 }
+            r = r + 1
+        }
+        // accumulate coincidences
+        var c = 0
+        while c < k {
+            var kk = 0
+            while kk < k {
+                let idx = (c * k + kk) as usize
+                if c == kk {
+                    coin[idx] = coin[idx] + cnt[c as usize] * (cnt[c as usize] - 1.0) / mm1
+                } else {
+                    coin[idx] = coin[idx] + cnt[c as usize] * cnt[kk as usize] / mm1
+                }
+                kk = kk + 1
+            }
+            c = c + 1
+        }
+        u = u + 1
+    }
+    // marginals and n
+    var nc: [f64; 16] = [0.0; 16]
+    var n = 0.0
+    var a = 0
+    while a < k {
+        var s = 0.0
+        var b = 0
+        while b < k { s = s + coin[(a * k + b) as usize]; b = b + 1 }
+        nc[a as usize] = s
+        n = n + s
+        a = a + 1
+    }
+    if n <= 1.0 { return 0.0 }
+    // observed and expected disagreement (nominal)
+    var do_off = 0.0
+    var de_off = 0.0
+    var i = 0
+    while i < k {
+        var j = 0
+        while j < k {
+            if i != j {
+                do_off = do_off + coin[(i * k + j) as usize]
+                de_off = de_off + nc[i as usize] * nc[j as usize]
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let d_o = do_off / n
+    let d_e = de_off / (n * (n - 1.0))
+    if d_e <= 1.0e-300 { return 1.0 }
+    return 1.0 - d_o / d_e
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 4 units, 2 raters, 2 categories: (0,1),(1,0),(0,0),(1,1).
+// o00=2,o11=2,o01=2,o10=2; n0=n1=4, n=8. Do=4/8=0.5; De=32/56=0.571429.
+// alpha = 1 - 0.5/0.571429 = 0.125.
+fn test_krippendorff() -> bool with IO, Mut, Div, Panic {
+    var d: [i64; 256] = [0; 256]
+    d[0]=0; d[1]=1
+    d[2]=1; d[3]=0
+    d[4]=0; d[5]=0
+    d[6]=1; d[7]=1
+    let a = krippendorff(&d, 4, 2, 2)
+    return check(1, approx(a, 0.125, 1.0e-5))
+}
+
+// perfect agreement -> alpha = 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var d: [i64; 256] = [0; 256]
+    d[0]=0; d[1]=0
+    d[2]=1; d[3]=1
+    d[4]=0; d[5]=0
+    d[6]=1; d[7]=1
+    let a = krippendorff(&d, 4, 2, 2)
+    return check(10, approx(a, 1.0, 1.0e-9))
+}
+
+// three raters, 3 units, 3 categories, all agree within unit -> alpha 1.
+fn test_three_raters() -> bool with IO, Mut, Div, Panic {
+    var d: [i64; 256] = [0; 256]
+    d[0]=0; d[1]=0; d[2]=0
+    d[3]=1; d[4]=1; d[5]=1
+    d[6]=2; d[7]=2; d[8]=2
+    let a = krippendorff(&d, 3, 3, 3)
+    return check(20, approx(a, 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_krippendorff() && ok
+    ok = test_perfect() && ok
+    ok = test_three_raters() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three inter-rater agreement modules, bringing the runner to **97 modules**. These extend the agreement family (`cohen_kappa`, `fleiss_kappa`, `reliability`) with the general reliability coefficient, a paradox-resistant alternative to kappa, and the full ICC family. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::gwet_ac1` | Gwet's AC1 — two-rater agreement that resists the kappa paradox |
| `stats::krippendorff` | Krippendorff's α (nominal, any number of raters) |
| `stats::icc_forms` | All six Shrout-Fleiss ICC forms from the two-way ANOVA |

## Validation

- Inline `//@ run-pass` tests against hand-computed / published examples:
  - Gwet AC1: [[8,1],[1,0]] → Pₐ=0.8, AC1=0.756 — where Cohen's κ is *negative* (the paradox); perfect → 1.
  - Krippendorff: 4-unit / 2-rater example → α=0.125; perfect agreement → 1; three concordant raters → 1.
  - ICC family: **validated against the published Shrout-Fleiss (1979) 6×4 example** → ICC(1,1)=0.166, ICC(2,1)=0.290, ICC(3,1)=0.715 (all three match).
- Full suite selftest: **97 modules + 7 demos ALL GREEN** under `lean_single`.

The ICC module is a nice case of validating against an external published reference rather than only self-derived constants — the Shrout-Fleiss values are the canonical textbook example.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).