### PR TITLE
test(stdlib): deepen prob/erf/gamma verticals — untested public API

### DIFF
--- a/scripts/verticals_deepen1_gate.sh
+++ b/scripts/verticals_deepen1_gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deepen-batch 1: extend coverage of already-shipped science verticals with the public API
+# left untested by their original run-proofs. All multi-module -> lean_single engine.
+#   prob::distributions  — gamma/exponential/uniform/poisson/dirichlet + non-standard normal
+#   special::erf         — erfinv + erfc tail
+#   special::gamma       — half-integer + large-argument reference points
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/prob/distributions.sio  tests/stdlib/prob/test_prob_deep_stdlib.sio      PROB_DEEP_STDLIB_OK
+run stdlib/special/erf.sio          tests/stdlib/special/test_erf_deep_stdlib.sio    ERF_DEEP_STDLIB_OK
+run stdlib/special/gamma.sio        tests/stdlib/special/test_gamma_deep_stdlib.sio  GAMMA_DEEP_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_DEEPEN1_GATE_OK"
+exit $fail

--- a/tests/stdlib/prob/test_prob_deep_stdlib.sio
+++ b/tests/stdlib/prob/test_prob_deep_stdlib.sio
@@ -1,0 +1,34 @@
+// Deepened run-proof for stdlib prob::distributions — exercises the public API left
+// uncovered by test_prob_stdlib.sio (gamma/exponential/uniform/poisson/dirichlet + non-standard
+// normal), asserting each against a first-principles / published value.
+// Multi-module (pulls special::gamma via lgamma/igamma) -> lean_single engine. Assert on f64 values.
+use prob::distributions::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // Gamma(alpha, beta) shape-rate: mean=a/b, var=a/b^2
+    if ae(gamma_mean(2.0, 0.5), 4.0) >= 1.0e-9 { print("FAIL gamma_mean\n"); return 1 }
+    if ae(gamma_variance(2.0, 0.5), 8.0) >= 1.0e-9 { print("FAIL gamma_var\n"); return 2 }
+    // Gamma(1,b) == Exp(b): CDF(x)=1-e^{-b x}
+    if ae(gamma_cdf(1.0, 1.0, 1.0), 0.6321205588) >= 1.0e-5 { print("FAIL gamma_cdf1\n"); return 3 }
+    if ae(gamma_cdf(1.0, 1.0, 2.0), 0.8646647168) >= 1.0e-5 { print("FAIL gamma_cdf2\n"); return 4 }
+    // Gamma(1,1) log-pdf(2) = ln(1) - 1*2 = -2
+    if ae(gamma_log_pdf(2.0, 1.0, 1.0), 0.0 - 2.0) >= 1.0e-6 { print("FAIL gamma_lpdf\n"); return 5 }
+    // Exponential(rate): quantile(0.5)=ln2/lambda ; log-pdf(0)=ln(lambda)
+    if ae(exponential_quantile(0.5, 1.0), 0.6931471806) >= 1.0e-6 { print("FAIL exp_q\n"); return 6 }
+    if ae(exponential_log_pdf(0.0, 2.0), 0.6931471806) >= 1.0e-6 { print("FAIL exp_lpdf\n"); return 7 }
+    // Uniform(0,10): cdf(2.5)=0.25 ; log-pdf=-ln(10)
+    if ae(uniform_cdf(2.5, 0.0, 10.0), 0.25) >= 1.0e-9 { print("FAIL unif_cdf\n"); return 8 }
+    if ae(uniform_log_pdf(5.0, 0.0, 10.0), 0.0 - 2.302585093) >= 1.0e-6 { print("FAIL unif_lpdf\n"); return 9 }
+    // Poisson(lambda): mean=lambda ; log-pmf(0)=-lambda ; log-pmf(2|2)=ln(2 e^{-2})
+    if ae(poisson_mean(3.0), 3.0) >= 1.0e-9 { print("FAIL pois_mean\n"); return 10 }
+    if ae(poisson_log_pmf(0, 2.0), 0.0 - 2.0) >= 1.0e-6 { print("FAIL pois_lpmf0\n"); return 11 }
+    if ae(poisson_log_pmf(2, 2.0), 0.0 - 1.306852819) >= 1.0e-5 { print("FAIL pois_lpmf2\n"); return 12 }
+    // Non-standard normal N(1,2): pdf peak=1/(2 sqrt(2pi)) ; cdf(3)=Phi(1)
+    if ae(dist_normal_pdf(1.0, 1.0, 2.0), 0.1994711402) >= 1.0e-6 { print("FAIL npdf\n"); return 13 }
+    if ae(normal_cdf_full(3.0, 1.0, 2.0), 0.8413447461) >= 1.0e-4 { print("FAIL ncdf_full\n"); return 14 }
+    // Dirichlet K=2: uniform(a=1,1) has log-density 0 on the simplex ; Beta(2,2) at (0.5,0.5)=ln(1.5)
+    if ae(dirichlet_log_pdf_2(0.3, 0.7, 1.0, 1.0), 0.0) >= 1.0e-9 { print("FAIL dir_unif\n"); return 15 }
+    if ae(dirichlet_log_pdf_2(0.5, 0.5, 2.0, 2.0), 0.405465108) >= 1.0e-5 { print("FAIL dir_beta22\n"); return 16 }
+    print("PROB_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/special/test_erf_deep_stdlib.sio
+++ b/tests/stdlib/special/test_erf_deep_stdlib.sio
@@ -1,0 +1,18 @@
+// Deepened run-proof for stdlib special::erf — covers erfinv (untested) + an erfc tail point.
+// lean_single engine (native miscompiles erfinv here). Assert on f64 values.
+use special::erf::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // erfinv(0)=0 ; erfinv(0.5)=0.4769362762 (published)
+    if ae(erfinv(0.0), 0.0) >= 1.0e-9 { print("FAIL erfinv0\n"); return 1 }
+    if ae(erfinv(0.5), 0.4769362762) >= 1.0e-5 { print("FAIL erfinv_half\n"); return 2 }
+    // erfinv is the inverse of erf: erfinv(erf(1)) = 1 ; and odd
+    if ae(erfinv(0.8427007929), 1.0) >= 1.0e-4 { print("FAIL erfinv_inv\n"); return 3 }
+    if ae(erfinv(0.0 - 0.8427007929), 0.0 - 1.0) >= 1.0e-4 { print("FAIL erfinv_odd\n"); return 4 }
+    // round-trip erf(erfinv(p)) = p
+    if ae(erf(erfinv(0.3)), 0.3) >= 1.0e-5 { print("FAIL roundtrip\n"); return 5 }
+    // erfc tail: erfc(2) = 1 - erf(2) = 0.0046777349
+    if ae(erfc(2.0), 0.0046777349) >= 1.0e-6 { print("FAIL erfc2\n"); return 6 }
+    print("ERF_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/special/test_gamma_deep_stdlib.sio
+++ b/tests/stdlib/special/test_gamma_deep_stdlib.sio
@@ -1,0 +1,18 @@
+// Deepened run-proof for stdlib special::gamma — half-integer + large-argument reference points
+// beyond test_gamma_stdlib.sio. lean_single engine. Assert on f64 values.
+use special::gamma::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // lgamma(0.5) = ln(sqrt(pi)) = 0.5723649429
+    if ae(lgamma(0.5), 0.5723649429) >= 1.0e-6 { print("FAIL lgamma_half\n"); return 1 }
+    // gamma(2.5) = 1.5*0.5*sqrt(pi) = 1.329340388
+    if ae(gamma(2.5), 1.329340388) >= 1.0e-5 { print("FAIL gamma_2p5\n"); return 2 }
+    // digamma(0.5) = -gamma_em - 2 ln2 = -1.963510026
+    if ae(digamma(0.5), 0.0 - 1.963510026) >= 1.0e-5 { print("FAIL digamma_half\n"); return 3 }
+    // lgamma(10) = ln(9!) = ln(362880) = 12.80182748
+    if ae(lgamma(10.0), 12.80182748) >= 1.0e-5 { print("FAIL lgamma_10\n"); return 4 }
+    // reflection at 0.5: gamma(0.5)^2 = pi
+    if ae(gamma(0.5) * gamma(0.5), 3.141592654) >= 1.0e-5 { print("FAIL gamma_refl\n"); return 5 }
+    print("GAMMA_DEEP_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Deepen-batch 1 — coverage depth on three already-shipped science verticals

Per the "deepen existing verticals" direction: instead of adding new thin modules, this extends three science-central verticals (`prob::distributions`, `special::erf`, `special::gamma`) to cover the public functions their original run-proofs left **untested** — each asserted by compile-and-run against a first-principles / published value.

| Module | New coverage (27 checks total) |
|---|---|
| `prob::distributions` | gamma mean/var/cdf/log_pdf (shape-rate), exponential quantile/log_pdf, uniform cdf/log_pdf, poisson mean/log_pmf, dirichlet K=2, non-standard normal pdf/cdf |
| `special::erf` | `erfinv` (0, 0.5, inverse-of-erf, odd, round-trip) + `erfc(2)` tail |
| `special::gamma` | half-integer + large-arg: `lgamma(0.5)=ln√π`, `gamma(2.5)`, `digamma(0.5)=−γ−2ln2`, `lgamma(10)=ln 9!`, reflection `gamma(0.5)²=π` |

### Verification
- `scripts/verticals_deepen1_gate.sh` → `VERTICALS_DEEPEN1_GATE_OK` (checks each module + compiles/runs each driver under lean_single, greps sentinel).
- Reference values audited by math-review (xai/grok): all confirmed. Grok flagged `gamma_log_pdf(2,1,1)=−2` but that was an argument-order misread on its part — the signature is `gamma_log_pdf(x, α, β)`, so this is Gamma(shape=1, rate=1)=Exp(1) log-density at x=2 = ln β − βx = −2; verified against the source formula and runtime output.

### Notes
- Multi-module drivers (prob pulls in `special::gamma` via `lgamma`/`igamma`) exceed the native multimodule thin-link limit, so they run under `SOUNIO_SOUC_ENGINE=lean_single` (established path, as in earlier batches). Values are identical across engines where both compile.
- No `self-hosted/` or `bootstrap/` edits. New files only (3 drivers + 1 gate); no `.claude/` or governance-registry edits → stays mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)