### PR TITLE
feat(stats): regression diagnostics — leverage, cooks_distance, vif

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2942,3 +2942,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - breslow_day = **PASS**: common OR ψ=OR_MH, per-stratum fitted A via the quadratic with feasible-root selection, ψ=1 linear limit, χ²=Σ(a−A)²/V; homogeneous strata (both OR 2)→χ²≈0, heterogeneous (OR 4 vs 0.25)→large χ²/p<0.05 verified.
 - Theme: conjugate rate/category posteriors + the M-H homogeneity companion. **Milestone: the suite reaches 100 modules** + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Mn4tzk/`, `/tmp/llm-offload-zk00U0/`, `/tmp/llm-offload-MmHjA9/`.
+
+## 2026-07-15 — math-review: stats::leverage, stats::cooks_distance, stats::vif
+- Files (all new): `stdlib/stats/leverage.sio` (hat values for simple linear regression, out-array fill), `stdlib/stats/cooks_distance.sio` (Cook's distance per point, out-array fill), `stdlib/stats/vif.sio` (variance inflation factor). Provider: xAI/Grok 4.3.
+- leverage = **PASS**: hᵢ=1/n+(xᵢ−x̄)²/Sₓₓ, 4/n threshold; {1..5}→h={0.6,0.3,0.2,0.3,0.6}, Σh=2=p verified.
+- cooks_distance = **PASS**: Dᵢ=eᵢ²hᵢ/(p·s²(1−hᵢ)²); off-line point→D₅=2.25, D₁=0.5625, perfect fit→0 verified.
+- vif = **PASS**: VIF=1/(1−R²), tolerance=1−R²; r=0.8→2.778, R²=0.9→10 verified.
+- Theme: regression diagnostics — influence & multicollinearity checks complementing reg_bands/wls/logistic. leverage & cooks_distance use the out-array `&![f64;256]` fill pattern (works under lean_single). All derivable, #852-safe. Suite runner: 103 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-EUXpvg/`, `/tmp/llm-offload-VZ23Js/`, `/tmp/llm-offload-jJfuQo/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -109,6 +109,9 @@ MODULES=(
   stdlib/stats/poisson_gamma.sio
   stdlib/stats/dirichlet_mult.sio
   stdlib/stats/breslow_day.sio
+  stdlib/stats/leverage.sio
+  stdlib/stats/cooks_distance.sio
+  stdlib/stats/vif.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -23,8 +23,9 @@ fourteen families:
 - **Correlation & association** — Pearson / Spearman, the Fisher-z CI,
   point-biserial and partial correlation, Kendall's τ, Goodman-Kruskal γ and
   Somers' D.
-- **Regression** — OLS with bands, weighted LS, logistic and Poisson GLMs, and
-  the Deming / Theil-Sen / Passing-Bablok method-comparison fits.
+- **Regression** — OLS with bands, weighted LS, logistic and Poisson GLMs, the
+  Deming / Theil-Sen / Passing-Bablok method-comparison fits, and the regression
+  diagnostics (leverage, Cook's distance, VIF).
 - **Categorical & exact** — χ² independence, Fisher's exact 2×2, McNemar,
   Cochran's Q, the Cochran-Armitage trend test and proportion CIs.
 - **Agreement & reliability** — Bland-Altman, Lin's CCC + Cliff's δ, Cohen's and
@@ -1366,6 +1367,37 @@ OR). Fits each stratum under the common OR by the quadratic and forms
 `χ²=Σ(aᵢ−Aᵢ)²/Vᵢ`. Validated: two strata each OR 2 → χ²≈0 (poolable); OR 4 vs
 0.25 → large χ², p<0.05 (heterogeneous).
 
+### `stats::leverage` — regression leverage (hat values)
+
+| Function | Signature |
+|---|---|
+| `leverage` | `pub fn leverage(x: &[f64; 256], n: i32, out_h: &![f64; 256]) -> LeverageResult with Mut, Div, Panic` |
+
+The hat value `hᵢ=1/n+(xᵢ−x̄)²/Sₓₓ` for each observation in simple linear
+regression, flagging high-leverage points (`hᵢ>4/n`); the hat vector is written
+to `out_h`. Validated: {1..5} → h={0.6,0.3,0.2,0.3,0.6}, Σh=2 (=p); a far point
+→ h≈1.
+
+### `stats::cooks_distance` — Cook's distance
+
+| Function | Signature |
+|---|---|
+| `cooks_distance` | `pub fn cooks_distance(x: &[f64; 256], y: &[f64; 256], n: i32, out_d: &![f64; 256]) -> CooksResult with Mut, Div, Panic` |
+
+The influence of each point on the OLS fit,
+`Dᵢ=eᵢ²hᵢ/(p·s²(1−hᵢ)²)`, flagging influential points (`Dᵢ>4/n`); the
+distances are written to `out_d`. Validated: an off-line last point → D₅=2.25,
+D₁=0.5625; perfect fit → all 0.
+
+### `stats::vif` — variance inflation factor
+
+| Function | Signature |
+|---|---|
+| `vif_from_r2` / `vif_two` / `tolerance` | `pub fn vif_from_r2(r2: f64) -> f64` · `vif_two(r)` · `tolerance(r2)` |
+
+The multicollinearity diagnostic `VIFⱼ=1/(1−R²ⱼ)` (VIF>5 concern, >10 serious).
+Validated: r=0.8 → VIF=2.778, tolerance=0.36; R²=0.9 → VIF=10; R²=0 → VIF=1.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1470,6 +1502,9 @@ use stats::icc_forms::{ICCFormsResult, icc_forms}
 use stats::poisson_gamma::{RatePosterior, poisson_gamma}
 use stats::dirichlet_mult::{DirichletPosterior, dirichlet_mult}
 use stats::breslow_day::{BDResult, breslow_day}
+use stats::leverage::{LeverageResult, leverage}
+use stats::cooks_distance::{CooksResult, cooks_distance}
+use stats::vif::{vif_from_r2, vif_two, tolerance}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/cooks_distance.sio
+++ b/stdlib/stats/cooks_distance.sio
@@ -1,0 +1,144 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/cooks_distance.sio — Cook's distance for simple linear regression
+//
+// The influence of each observation on the fitted line — how much the whole fit
+// would move if that point were deleted:
+//
+//   cooks_distance(x, y, n, out_d) -> CooksResult
+//
+// After the OLS fit (residual eᵢ, leverage hᵢ, residual variance s² = SSE/(n−2)),
+//   Dᵢ = eᵢ²·hᵢ / (p·s²·(1−hᵢ)²),   p = 2.
+// A point with Dᵢ > 4/n is conventionally flagged as influential.
+//
+// Pure Sounio: OLS fit, then a pass filling the Cook's-distance vector. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Cook (1977) Technometrics 19:15.
+
+module stats::cooks_distance
+
+pub struct CooksResult {
+    pub max_d: f64,        // largest Cook's distance
+    pub n_influential: i64,// count with Dᵢ > 4/n
+    pub slope: f64,
+    pub intercept: f64,
+}
+
+/// Cook's distance for simple linear regression; fills out_d[0..n).
+///
+/// Parâmetros: x, y — data; n — size (>=3, <=256); out_d — receives Cook's Dᵢ.
+/// Retorno: CooksResult (max_d, n_influential, slope, intercept).
+/// Referências: Cook (1977).
+pub fn cooks_distance(x: &[f64; 256], y: &[f64; 256], n: i32, out_d: &![f64; 256]) -> CooksResult with Mut, Div, Panic {
+    if n < 3 { return CooksResult { max_d: 0.0, n_influential: 0, slope: 0.0, intercept: 0.0 } }
+    let nf = n as f64
+    var sx = 0.0
+    var sy = 0.0
+    var i = 0
+    while i < n { sx = sx + x[i as usize]; sy = sy + y[i as usize]; i = i + 1 }
+    let mx = sx / nf
+    let my = sy / nf
+    var sxx = 0.0
+    var sxy = 0.0
+    var j = 0
+    while j < n {
+        let dx = x[j as usize] - mx
+        sxx = sxx + dx * dx
+        sxy = sxy + dx * (y[j as usize] - my)
+        j = j + 1
+    }
+    var slope = 0.0
+    if sxx > 1.0e-300 { slope = sxy / sxx }
+    let intercept = my - slope * mx
+    // residual variance
+    var sse = 0.0
+    var k = 0
+    while k < n {
+        let e = y[k as usize] - (intercept + slope * x[k as usize])
+        sse = sse + e * e
+        k = k + 1
+    }
+    let s2 = sse / (nf - 2.0)
+    let thresh = 4.0 / nf
+    var maxd = 0.0
+    var ninf = 0
+    var t = 0
+    while t < n {
+        let e = y[t as usize] - (intercept + slope * x[t as usize])
+        let dx = x[t as usize] - mx
+        var h = 1.0 / nf
+        if sxx > 1.0e-300 { h = 1.0 / nf + dx * dx / sxx }
+        var d = 0.0
+        let om = 1.0 - h
+        if s2 > 1.0e-300 && om > 1.0e-12 {
+            d = e * e * h / (2.0 * s2 * om * om)
+        }
+        out_d[t as usize] = d
+        if d > maxd { maxd = d }
+        if d > thresh { ninf = ninf + 1 }
+        t = t + 1
+    }
+    return CooksResult { max_d: maxd, n_influential: ninf as i64, slope: slope, intercept: intercept }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3,4,5}, y={1,2,3,4,10}. fit slope 2, intercept -2; e={1,0,-1,-2,2};
+// s²=10/3; h={0.6,0.3,0.2,0.3,0.6}. D5=4·0.6/(2·(10/3)·0.16)=2.25; D1=0.5625.
+fn test_cooks() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var d: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    y[0]=1.0; y[1]=2.0; y[2]=3.0; y[3]=4.0; y[4]=10.0
+    let r = cooks_distance(&x, &y, 5, &!d)
+    var ok = true
+    ok = check(1, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.intercept, 0.0 - 2.0, 1.0e-9)) && ok
+    ok = check(3, approx(d[4], 2.25, 1.0e-4)) && ok
+    ok = check(4, approx(d[0], 0.5625, 1.0e-4)) && ok
+    ok = check(5, approx(r.max_d, 2.25, 1.0e-4)) && ok
+    return ok
+}
+
+// perfect fit -> all Cook's distances 0.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var d: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 5 { x[i as usize] = i as f64; y[i as usize] = 2.0 * (i as f64) + 1.0; i = i + 1 }
+    let r = cooks_distance(&x, &y, 5, &!d)
+    return check(10, approx(r.max_d, 0.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_cooks() && ok
+    ok = test_perfect() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/leverage.sio
+++ b/stdlib/stats/leverage.sio
@@ -1,0 +1,115 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/leverage.sio — leverage (hat values) for simple linear regression
+//
+// The leverage of each observation — how far its predictor is from the mean, and
+// hence how much pull it has on its own fitted value:
+//
+//   leverage(x, n, out_h) -> LeverageResult
+//
+//   hᵢ = 1/n + (xᵢ − x̄)² / Sₓₓ,   Sₓₓ = Σ(xⱼ − x̄)².
+// The hat values sum to p = 2 (the number of parameters); a point with
+// hᵢ > 2p/n = 4/n is conventionally flagged as high-leverage.
+//
+// Pure Sounio: one pass for the mean and Sₓₓ, a second to fill the hat vector.
+// No external dependency, no nested data-array calls.
+//
+// References:
+//   Belsley, Kuh & Welsch (1980) "Regression Diagnostics".
+
+module stats::leverage
+
+pub struct LeverageResult {
+    pub max_h: f64,    // largest leverage
+    pub sum_h: f64,    // Σ hᵢ (= p = 2)
+    pub n_high: i64,   // count with hᵢ > 4/n
+}
+
+/// Leverage (hat values) for simple linear regression; fills out_h[0..n).
+///
+/// Parâmetros: x — predictor; n — size (>=3, <=256); out_h — receives the hat values.
+/// Retorno: LeverageResult (max_h, sum_h, n_high).
+/// Referências: Belsley, Kuh & Welsch (1980).
+pub fn leverage(x: &[f64; 256], n: i32, out_h: &![f64; 256]) -> LeverageResult with Mut, Div, Panic {
+    if n < 3 { return LeverageResult { max_h: 0.0, sum_h: 0.0, n_high: 0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mx = s / nf
+    var sxx = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mx; sxx = sxx + d * d; j = j + 1 }
+    let thresh = 4.0 / nf
+    var maxh = 0.0
+    var sumh = 0.0
+    var nhigh = 0
+    var k = 0
+    while k < n {
+        let d = x[k as usize] - mx
+        var h = 1.0 / nf
+        if sxx > 1.0e-300 { h = 1.0 / nf + d * d / sxx }
+        out_h[k as usize] = h
+        sumh = sumh + h
+        if h > maxh { maxh = h }
+        if h > thresh { nhigh = nhigh + 1 }
+        k = k + 1
+    }
+    return LeverageResult { max_h: maxh, sum_h: sumh, n_high: nhigh as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3,4,5}: x̄=3, Sxx=10. h={0.6,0.3,0.2,0.3,0.6}; Σh=2.
+fn test_leverage() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var h: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = leverage(&x, 5, &!h)
+    var ok = true
+    ok = check(1, approx(h[0], 0.6, 1.0e-9)) && ok
+    ok = check(2, approx(h[2], 0.2, 1.0e-9)) && ok
+    ok = check(3, approx(h[4], 0.6, 1.0e-9)) && ok
+    ok = check(4, approx(r.sum_h, 2.0, 1.0e-9)) && ok
+    ok = check(5, approx(r.max_h, 0.6, 1.0e-9)) && ok
+    return ok
+}
+
+// an extreme x pulls its leverage up. x has one far point.
+fn test_high() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var h: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=50.0
+    let r = leverage(&x, 5, &!h)
+    // the far point dominates Sxx -> its leverage approaches 1.
+    return check(10, h[4] > 0.9)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_leverage() && ok
+    ok = test_high() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/vif.sio
+++ b/stdlib/stats/vif.sio
@@ -1,0 +1,89 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/vif.sio — variance inflation factor (multicollinearity)
+//
+// Quantifies how much a predictor's variance is inflated by its correlation with
+// the other predictors — the standard multicollinearity diagnostic:
+//
+//   vif_from_r2(r2)          -> f64   1/(1−R²) from a predictor's R² on the rest
+//   vif_two(r)               -> f64   two-predictor case, R² = r²
+//   tolerance(r2)            -> f64   1 − R²  (the reciprocal of VIF)
+//
+// A predictor's VIF = 1/(1−R²ⱼ) where R²ⱼ is the coefficient of determination of
+// regressing predictor j on all the others. VIF > 5 (R² > 0.8) signals concern,
+// VIF > 10 (R² > 0.9) serious multicollinearity.
+//
+// Pure Sounio: arithmetic only. No external dependency, no nested data-array calls.
+//
+// References:
+//   Marquardt (1970); Kutner et al., "Applied Linear Statistical Models" 5e, §10.5.
+
+module stats::vif
+
+/// Variance inflation factor from a predictor's R² on the other predictors.
+pub fn vif_from_r2(r2: f64) -> f64 {
+    let den = 1.0 - r2
+    if den <= 1.0e-12 { return 1.0e12 }   // effectively infinite (perfect collinearity)
+    return 1.0 / den
+}
+
+/// Tolerance = 1 − R² (the reciprocal of VIF).
+pub fn tolerance(r2: f64) -> f64 {
+    return 1.0 - r2
+}
+
+/// Two-predictor VIF from their pairwise correlation r (R² = r²).
+pub fn vif_two(r: f64) -> f64 {
+    let r2 = r * r
+    let den = 1.0 - r2
+    if den <= 1.0e-12 { return 1.0e12 }
+    return 1.0 / den
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// r=0.8 -> R²=0.64 -> VIF=1/0.36=2.777778; tolerance=0.36.
+fn test_vif() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(1, approx(vif_two(0.8), 2.777778, 1.0e-5)) && ok
+    ok = check(2, approx(vif_from_r2(0.64), 2.777778, 1.0e-5)) && ok
+    ok = check(3, approx(tolerance(0.64), 0.36, 1.0e-9)) && ok
+    return ok
+}
+
+// no collinearity -> VIF 1; R²=0.9 -> VIF 10.
+fn test_bounds() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(10, approx(vif_from_r2(0.0), 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(vif_from_r2(0.9), 10.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_vif() && ok
+    ok = test_bounds() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three regression-diagnostic modules, bringing the runner to **103 modules**. These are the influence and multicollinearity checks that complement the suite's regression fits (`reg_bands`, `wls`, `logistic`) — going from fitting a model to *diagnosing* it. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::leverage` | Hat values hᵢ; flags high-leverage points (hᵢ>4/n) |
| `stats::cooks_distance` | Cook's distance; flags influential points (Dᵢ>4/n) |
| `stats::vif` | Variance inflation factor VIF=1/(1−R²) for multicollinearity |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Leverage: {1..5} → h={0.6,0.3,0.2,0.3,0.6}, Σh=2 (the hat trace equals p=2); a far point → h≈1.
  - Cook's D: an off-line last point (y={1,2,3,4,10}) → D₅=2.25, D₁=0.5625; perfect fit → all 0.
  - VIF: r=0.8 → VIF=2.778, tolerance=0.36; R²=0.9 → VIF=10; R²=0 → VIF=1.
- Full suite selftest: **103 modules + 7 demos ALL GREEN** under `lean_single`.

`leverage` and `cooks_distance` write their per-point vectors to an `out_h`/`out_d` `&![f64;256]` out-array (the same fill pattern used by `multiple_comparisons`), returning a small summary struct — keeping them `#852`-safe.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).