### PR TITLE
feat(stats): study-planning tools — sample_size_survival, sample_size_precision, detectable_effect

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2950,3 +2950,12 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - vif = **PASS**: VIF=1/(1−R²), tolerance=1−R²; r=0.8→2.778, R²=0.9→10 verified.
 - Theme: regression diagnostics — influence & multicollinearity checks complementing reg_bands/wls/logistic. leverage & cooks_distance use the out-array `&![f64;256]` fill pattern (works under lean_single). All derivable, #852-safe. Suite runner: 103 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-EUXpvg/`, `/tmp/llm-offload-VZ23Js/`, `/tmp/llm-offload-jJfuQo/`.
+
+## 2026-07-15 — math-review: stats::sample_size_survival, stats::sample_size_precision, stats::detectable_effect
+- Files (all new): `stdlib/stats/sample_size_survival.sio` (Schoenfeld log-rank events + enrolment), `stdlib/stats/sample_size_precision.sio` (CI-half-width n for mean/proportion), `stdlib/stats/detectable_effect.sio` (minimum detectable Cohen's d). All use an inline Acklam inverse-normal-CDF. Provider: xAI/Grok 4.3.
+- sample_size_survival = **PASS**: events=(z_{1−α/2}+z_{1−β})²/(πA·πB·(ln HR)²); HR=2/α=0.05/80% → 65.35 events, Acklam z's (1.959964, 0.841621) exact.
+- sample_size_precision = **PASS**: n=(z·σ/E)² and z²p(1−p)/E²; 97 and 385 verified.
+- detectable_effect = **PASS**: d=(z+zb)·√(2/n) two-sample, /√n one-sample; 0.495228 and 0.350198 verified.
+- Note: sample_size_precision initially failed `souc check` (a standalone `sp_ceil` helper mutated a var without `with Mut`); `souc run` silently produced NO output on the failed type-check. Fixed by adding `with Mut`. Reminder logged: treat empty `souc run` output as a possible type-check failure — run `souc check`.
+- Theme: sample-size & power planning for designs beyond t-test/proportions (survival, precision, MDE). All derivable, #852-safe. Suite runner: 106 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-LLvTHx/`, `/tmp/llm-offload-IEFtUA/`, `/tmp/llm-offload-G3JirB/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -112,6 +112,9 @@ MODULES=(
   stdlib/stats/leverage.sio
   stdlib/stats/cooks_distance.sio
   stdlib/stats/vif.sio
+  stdlib/stats/sample_size_survival.sio
+  stdlib/stats/sample_size_precision.sio
+  stdlib/stats/detectable_effect.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -16,8 +16,10 @@ fourteen families:
   χ²/G goodness-of-fit), independence (Wald-Wolfowitz runs, Durbin-Watson,
   autocorrelation + Ljung-Box) and homoscedasticity (Bartlett, Levene /
   Brown-Forsythe, the variance F-test).
-- **Group comparison** — one-way ANOVA, inference from summary statistics,
-  standardised effect sizes, and power / sample-size planning.
+- **Group comparison & planning** — one-way ANOVA, inference from summary
+  statistics, standardised effect sizes, t-test power, and sample-size planning
+  for proportions/correlations, survival trials (Schoenfeld), target precision,
+  and the minimum detectable effect.
 - **Non-parametric tests** — sign test, Mann-Whitney, Wilcoxon signed-rank,
   Kruskal-Wallis, Mood's median, Friedman and Tukey HSD.
 - **Correlation & association** — Pearson / Spearman, the Fisher-z CI,
@@ -1398,6 +1400,36 @@ D₁=0.5625; perfect fit → all 0.
 The multicollinearity diagnostic `VIFⱼ=1/(1−R²ⱼ)` (VIF>5 concern, >10 serious).
 Validated: r=0.8 → VIF=2.778, tolerance=0.36; R²=0.9 → VIF=10; R²=0 → VIF=1.
 
+### `stats::sample_size_survival` — survival-trial sample size
+
+| Function | Signature |
+|---|---|
+| `ss_survival` | `pub fn ss_survival(hr: f64, alpha: f64, power: f64, alloc: f64, event_prob: f64) -> SurvSSResult with Mut, Div, Panic` |
+
+The Schoenfeld required number of events and enrolment for a log-rank / Cox test:
+`events=(z_{1−α/2}+z_{1−β})²/(πA·πB·(ln HR)²)`, `n=events/P(event)`. Validated:
+HR=2, α=0.05, 80% power, 1:1 → 65.3 events; a larger HR needs fewer.
+
+### `stats::sample_size_precision` — precision-based sample size
+
+| Function | Signature |
+|---|---|
+| `ss_mean` / `ss_proportion` | `pub fn ss_mean(sigma, margin, conf) -> i64` · `ss_proportion(p, margin, conf) -> i64` |
+
+The n needed for a confidence interval no wider than a chosen half-width:
+`n=(z·σ/E)²` for a mean, `n=z²p(1−p)/E²` for a proportion. Validated: σ=10, E=2,
+95% → 97; p=0.5, E=0.05, 95% → 385.
+
+### `stats::detectable_effect` — minimum detectable effect
+
+| Function | Signature |
+|---|---|
+| `mde_two_means` / `mde_one_mean` | `pub fn mde_two_means(n_per_group, alpha, power) -> f64` · `mde_one_mean(n, alpha, power) -> f64` |
+
+The smallest Cohen's d a study can detect: `d=(z_{1−α/2}+z_{1−β})·√(2/n)`
+(two-sample) or `/√n` (one-sample) — for judging whether a study was adequately
+powered. Validated: n=64/group, α=0.05, 80% → d=0.495; one-sample → 0.350.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1505,6 +1537,9 @@ use stats::breslow_day::{BDResult, breslow_day}
 use stats::leverage::{LeverageResult, leverage}
 use stats::cooks_distance::{CooksResult, cooks_distance}
 use stats::vif::{vif_from_r2, vif_two, tolerance}
+use stats::sample_size_survival::{SurvSSResult, ss_survival}
+use stats::sample_size_precision::{ss_mean, ss_proportion}
+use stats::detectable_effect::{mde_two_means, mde_one_mean}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/detectable_effect.sio
+++ b/stdlib/stats/detectable_effect.sio
@@ -1,0 +1,149 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/detectable_effect.sio — minimum detectable effect
+//
+// The smallest standardised effect a study can detect at a given size, level and
+// power — the inverse of a sample-size calculation, for judging whether a
+// planned or completed study was adequately powered:
+//
+//   mde_two_means(n_per_group, alpha, power) -> f64   d = (z_{1−α/2}+z_{1−β})·√(2/n)
+//   mde_one_mean(n, alpha, power)            -> f64   d = (z_{1−α/2}+z_{1−β})/√n
+//
+// Pure Sounio: inline ln/sqrt and an Acklam inverse-normal-CDF. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Cohen, "Statistical Power Analysis for the Behavioral Sciences" 2e.
+
+module stats::detectable_effect
+
+fn de_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn de_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn de_ninv(p: f64) -> f64 with Mut, Div, Panic {
+    if p <= 0.0 { return 0.0 - 40.0 }
+    if p >= 1.0 { return 40.0 }
+    let a0 = 0.0 - 39.69683028665376
+    let a1 = 220.9460984245205
+    let a2 = 0.0 - 275.9285104469687
+    let a3 = 138.3577518672690
+    let a4 = 0.0 - 30.66479806614716
+    let a5 = 2.506628277459239
+    let b0 = 0.0 - 54.47609879822406
+    let b1 = 161.5858368580409
+    let b2 = 0.0 - 155.6989798598866
+    let b3 = 66.80131188771972
+    let b4 = 0.0 - 13.28068155288572
+    let c0 = 0.0 - 0.007784894002430293
+    let c1 = 0.0 - 0.3223964580411365
+    let c2 = 0.0 - 2.400758277161838
+    let c3 = 0.0 - 2.549732539343734
+    let c4 = 4.374664141464968
+    let c5 = 2.938163982698783
+    let d0 = 0.007784695709041462
+    let d1 = 0.3224671290700398
+    let d2 = 2.445134137142996
+    let d3 = 3.754408661907416
+    let plow = 0.02425
+    let phigh = 1.0 - plow
+    if p < plow {
+        let q = de_sqrt(0.0 - 2.0 * de_ln(p))
+        return (((((c0 * q + c1) * q + c2) * q + c3) * q + c4) * q + c5) / ((((d0 * q + d1) * q + d2) * q + d3) * q + 1.0)
+    }
+    if p <= phigh {
+        let q = p - 0.5
+        let r = q * q
+        return (((((a0 * r + a1) * r + a2) * r + a3) * r + a4) * r + a5) * q / (((((b0 * r + b1) * r + b2) * r + b3) * r + b4) * r + 1.0)
+    }
+    let q = de_sqrt(0.0 - 2.0 * de_ln(1.0 - p))
+    return 0.0 - (((((c0 * q + c1) * q + c2) * q + c3) * q + c4) * q + c5) / ((((d0 * q + d1) * q + d2) * q + d3) * q + 1.0)
+}
+
+/// Minimum detectable Cohen's d for a two-sample test (n per group).
+pub fn mde_two_means(n_per_group: i32, alpha: f64, power: f64) -> f64 with Mut, Div, Panic {
+    if n_per_group < 2 { return 0.0 }
+    let za = de_ninv(1.0 - alpha * 0.5)
+    let zb = de_ninv(power)
+    return (za + zb) * de_sqrt(2.0 / (n_per_group as f64))
+}
+
+/// Minimum detectable Cohen's d for a one-sample / paired test.
+pub fn mde_one_mean(n: i32, alpha: f64, power: f64) -> f64 with Mut, Div, Panic {
+    if n < 2 { return 0.0 }
+    let za = de_ninv(1.0 - alpha * 0.5)
+    let zb = de_ninv(power)
+    return (za + zb) / de_sqrt(n as f64)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// two means, n=64/group, alpha=0.05, power=0.8:
+// d=(1.959964+0.841621)·√(2/64)=2.801585·0.176777=0.495228.
+fn test_two_means() -> bool with IO, Mut, Div, Panic {
+    return check(1, approx(mde_two_means(64, 0.05, 0.8), 0.495228, 1.0e-4))
+}
+
+// one mean, n=64: d=2.801585/√64=2.801585/8=0.350198.
+fn test_one_mean() -> bool with IO, Mut, Div, Panic {
+    return check(10, approx(mde_one_mean(64, 0.05, 0.8), 0.350198, 1.0e-4))
+}
+
+// larger n detects a smaller effect.
+fn test_monotone() -> bool with IO, Mut, Div, Panic {
+    return check(20, mde_two_means(256, 0.05, 0.8) < mde_two_means(64, 0.05, 0.8))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_two_means() && ok
+    ok = test_one_mean() && ok
+    ok = test_monotone() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/sample_size_precision.sio
+++ b/stdlib/stats/sample_size_precision.sio
@@ -1,0 +1,155 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/sample_size_precision.sio — sample size for a target precision
+//
+// The sample size needed so that a confidence interval has at most a chosen
+// half-width (margin of error) — estimation-based planning rather than
+// hypothesis-test power:
+//
+//   ss_mean(sigma, margin, conf) -> i64        n = (z·σ/E)²
+//   ss_proportion(p, margin, conf) -> i64      n = z²·p(1−p)/E²
+//
+// with z = Φ⁻¹(1 − α/2). For a proportion, p = 0.5 gives the conservative
+// (largest) n.
+//
+// Pure Sounio: inline ln/sqrt and an Acklam inverse-normal-CDF. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Cochran, "Sampling Techniques" 3e, §4.
+
+module stats::sample_size_precision
+
+fn sp_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn sp_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn sp_ninv(p: f64) -> f64 with Mut, Div, Panic {
+    if p <= 0.0 { return 0.0 - 40.0 }
+    if p >= 1.0 { return 40.0 }
+    let a0 = 0.0 - 39.69683028665376
+    let a1 = 220.9460984245205
+    let a2 = 0.0 - 275.9285104469687
+    let a3 = 138.3577518672690
+    let a4 = 0.0 - 30.66479806614716
+    let a5 = 2.506628277459239
+    let b0 = 0.0 - 54.47609879822406
+    let b1 = 161.5858368580409
+    let b2 = 0.0 - 155.6989798598866
+    let b3 = 66.80131188771972
+    let b4 = 0.0 - 13.28068155288572
+    let c0 = 0.0 - 0.007784894002430293
+    let c1 = 0.0 - 0.3223964580411365
+    let c2 = 0.0 - 2.400758277161838
+    let c3 = 0.0 - 2.549732539343734
+    let c4 = 4.374664141464968
+    let c5 = 2.938163982698783
+    let d0 = 0.007784695709041462
+    let d1 = 0.3224671290700398
+    let d2 = 2.445134137142996
+    let d3 = 3.754408661907416
+    let plow = 0.02425
+    let phigh = 1.0 - plow
+    if p < plow {
+        let q = sp_sqrt(0.0 - 2.0 * sp_ln(p))
+        return (((((c0 * q + c1) * q + c2) * q + c3) * q + c4) * q + c5) / ((((d0 * q + d1) * q + d2) * q + d3) * q + 1.0)
+    }
+    if p <= phigh {
+        let q = p - 0.5
+        let r = q * q
+        return (((((a0 * r + a1) * r + a2) * r + a3) * r + a4) * r + a5) * q / (((((b0 * r + b1) * r + b2) * r + b3) * r + b4) * r + 1.0)
+    }
+    let q = sp_sqrt(0.0 - 2.0 * sp_ln(1.0 - p))
+    return 0.0 - (((((c0 * q + c1) * q + c2) * q + c3) * q + c4) * q + c5) / ((((d0 * q + d1) * q + d2) * q + d3) * q + 1.0)
+}
+
+fn sp_ceil(x: f64) -> i64 with Mut {
+    var k = x as i64
+    if (k as f64) < x { k = k + 1 }
+    return k
+}
+
+/// Sample size for estimating a mean to within `margin` (half-width) at `conf`.
+pub fn ss_mean(sigma: f64, margin: f64, conf: f64) -> i64 with Mut, Div, Panic {
+    if sigma <= 0.0 || margin <= 0.0 { return 0 }
+    let z = sp_ninv(1.0 - (1.0 - conf) * 0.5)
+    let nf = (z * sigma / margin) * (z * sigma / margin)
+    return sp_ceil(nf)
+}
+
+/// Sample size for estimating a proportion p to within `margin` at `conf`.
+pub fn ss_proportion(p: f64, margin: f64, conf: f64) -> i64 with Mut, Div, Panic {
+    if margin <= 0.0 || p < 0.0 || p > 1.0 { return 0 }
+    let z = sp_ninv(1.0 - (1.0 - conf) * 0.5)
+    let nf = z * z * p * (1.0 - p) / (margin * margin)
+    return sp_ceil(nf)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// mean: sigma=10, margin=2, 95% -> n=(1.959964·10/2)²=(9.79982)²=96.036 -> 97.
+fn test_mean() -> bool with IO, Mut, Div, Panic {
+    return check(1, ss_mean(10.0, 2.0, 0.95) == 97)
+}
+
+// proportion: p=0.5, margin=0.05, 95% -> n=1.959964²·0.25/0.0025=384.15 -> 385.
+fn test_prop() -> bool with IO, Mut, Div, Panic {
+    return check(10, ss_proportion(0.5, 0.05, 0.95) == 385)
+}
+
+// tighter margin needs more; p away from 0.5 needs fewer.
+fn test_monotone() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = check(20, ss_mean(10.0, 1.0, 0.95) > ss_mean(10.0, 2.0, 0.95)) && ok
+    ok = check(21, ss_proportion(0.1, 0.05, 0.95) < ss_proportion(0.5, 0.05, 0.95)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_mean() && ok
+    ok = test_prop() && ok
+    ok = test_monotone() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/sample_size_survival.sio
+++ b/stdlib/stats/sample_size_survival.sio
@@ -1,0 +1,171 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/sample_size_survival.sio — sample size for a survival trial
+//
+// The required number of events (and enrolled subjects) to detect a hazard ratio
+// with a log-rank / Cox test — the planning tool for time-to-event studies:
+//
+//   ss_survival(hr, alpha, power, alloc, event_prob) -> SurvSSResult
+//
+//   events = (z_{1−α/2} + z_{1−β})² / ( πA·πB·(ln HR)² )        (Schoenfeld),
+//   n_total = events / P(event),
+// with allocation πA (group-A fraction), πB = 1−πA. For 1:1 allocation the
+// denominator is ¼(ln HR)².
+//
+// Pure Sounio: inline ln/sqrt and an Acklam inverse-normal-CDF. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Schoenfeld (1983) Biometrics 39:499.
+
+module stats::sample_size_survival
+
+fn ss_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn ss_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+// Acklam inverse normal CDF: returns z with Φ(z) = p, p in (0,1).
+fn ss_ninv(p: f64) -> f64 with Mut, Div, Panic {
+    if p <= 0.0 { return 0.0 - 40.0 }
+    if p >= 1.0 { return 40.0 }
+    let a0 = 0.0 - 39.69683028665376
+    let a1 = 220.9460984245205
+    let a2 = 0.0 - 275.9285104469687
+    let a3 = 138.3577518672690
+    let a4 = 0.0 - 30.66479806614716
+    let a5 = 2.506628277459239
+    let b0 = 0.0 - 54.47609879822406
+    let b1 = 161.5858368580409
+    let b2 = 0.0 - 155.6989798598866
+    let b3 = 66.80131188771972
+    let b4 = 0.0 - 13.28068155288572
+    let c0 = 0.0 - 0.007784894002430293
+    let c1 = 0.0 - 0.3223964580411365
+    let c2 = 0.0 - 2.400758277161838
+    let c3 = 0.0 - 2.549732539343734
+    let c4 = 4.374664141464968
+    let c5 = 2.938163982698783
+    let d0 = 0.007784695709041462
+    let d1 = 0.3224671290700398
+    let d2 = 2.445134137142996
+    let d3 = 3.754408661907416
+    let plow = 0.02425
+    let phigh = 1.0 - plow
+    if p < plow {
+        let q = ss_sqrt(0.0 - 2.0 * ss_ln(p))
+        return (((((c0 * q + c1) * q + c2) * q + c3) * q + c4) * q + c5) / ((((d0 * q + d1) * q + d2) * q + d3) * q + 1.0)
+    }
+    if p <= phigh {
+        let q = p - 0.5
+        let r = q * q
+        return (((((a0 * r + a1) * r + a2) * r + a3) * r + a4) * r + a5) * q / (((((b0 * r + b1) * r + b2) * r + b3) * r + b4) * r + 1.0)
+    }
+    let q = ss_sqrt(0.0 - 2.0 * ss_ln(1.0 - p))
+    return 0.0 - (((((c0 * q + c1) * q + c2) * q + c3) * q + c4) * q + c5) / ((((d0 * q + d1) * q + d2) * q + d3) * q + 1.0)
+}
+
+pub struct SurvSSResult {
+    pub events: f64,    // required number of events (Schoenfeld)
+    pub n_total: i64,   // required enrolment (ceil events / event_prob)
+    pub z_alpha: f64,
+    pub z_beta: f64,
+}
+
+/// Schoenfeld sample size for a log-rank / Cox survival test.
+///
+/// Parâmetros: hr — target hazard ratio (>0, ≠1); alpha — two-sided level;
+///             power — 1−β; alloc — group-A fraction (0,1); event_prob — P(event).
+/// Retorno: SurvSSResult (events, n_total, z_alpha, z_beta).
+/// Referências: Schoenfeld (1983).
+pub fn ss_survival(hr: f64, alpha: f64, power: f64, alloc: f64, event_prob: f64) -> SurvSSResult with Mut, Div, Panic {
+    if hr <= 0.0 || alloc <= 0.0 || alloc >= 1.0 {
+        return SurvSSResult { events: 0.0, n_total: 0, z_alpha: 0.0, z_beta: 0.0 }
+    }
+    let za = ss_ninv(1.0 - alpha * 0.5)
+    let zb = ss_ninv(power)
+    let lnhr = ss_ln(hr)
+    if lnhr == 0.0 { return SurvSSResult { events: 0.0, n_total: 0, z_alpha: za, z_beta: zb } }
+    let events = (za + zb) * (za + zb) / (alloc * (1.0 - alloc) * lnhr * lnhr)
+    var n_total = 0
+    if event_prob > 0.0 {
+        let nf = events / event_prob
+        // ceiling
+        n_total = nf as i32
+        if (n_total as f64) < nf { n_total = n_total + 1 }
+    }
+    return SurvSSResult { events: events, n_total: n_total as i64, z_alpha: za, z_beta: zb }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// HR=2, alpha=0.05, power=0.8, 1:1. z_a=1.959964, z_b=0.841621.
+// events=(2.801585)²/(0.25·(ln2)²)=7.848877/(0.25·0.480453)=7.848877/0.120113=65.346.
+fn test_survival() -> bool with IO, Mut, Div, Panic {
+    let r = ss_survival(2.0, 0.05, 0.8, 0.5, 0.5)
+    var ok = true
+    ok = check(1, approx(r.z_alpha, 1.959964, 1.0e-4)) && ok
+    ok = check(2, approx(r.z_beta, 0.841621, 1.0e-4)) && ok
+    ok = check(3, approx(r.events, 65.346, 1.0e-1)) && ok
+    ok = check(4, r.n_total > 0) && ok
+    return ok
+}
+
+// larger HR (further from 1) needs fewer events.
+fn test_larger_hr() -> bool with IO, Mut, Div, Panic {
+    let r2 = ss_survival(2.0, 0.05, 0.8, 0.5, 0.5)
+    let r3 = ss_survival(3.0, 0.05, 0.8, 0.5, 0.5)
+    return check(10, r3.events < r2.events)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_survival() && ok
+    ok = test_larger_hr() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three study-planning modules, bringing the runner to **106 modules**. These cover sample-size / power designs the existing `power` and `sample_size` modules did not — most importantly **survival trials**, the dominant clinical design. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::sample_size_survival` | Schoenfeld events + enrolment for a log-rank / Cox trial |
| `stats::sample_size_precision` | n for a target CI half-width (mean or proportion) |
| `stats::detectable_effect` | Minimum detectable Cohen's d given n, α, power |

All three use an inline **Acklam inverse-normal-CDF** for the z-quantiles (accurate to ~1e-9).

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Survival: HR=2, α=0.05, 80% power, 1:1 → 65.3 events (Schoenfeld), z's = 1.959964 / 0.841621; a larger HR needs fewer.
  - Precision: σ=10, E=2, 95% → n=97; p=0.5, E=0.05, 95% → n=385.
  - MDE: n=64/group, α=0.05, 80% → d=0.495; one-sample → d=0.350.
- Full suite selftest: **106 modules + 7 demos ALL GREEN** under `lean_single`.

## Process note
`sample_size_precision` initially had a standalone `sp_ceil` helper that mutated a `var` without declaring `with Mut`. `souc check` flagged it — and notably `souc run` produced **empty output** (exit 0) on the failed type-check rather than an error. Fixed by adding the effect; logged the reminder to treat an empty `souc run` as a possible type-check failure.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).