### PR TITLE
feat(stats): classical descriptives — central_tendency, dispersion, shape

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2959,3 +2959,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - Note: sample_size_precision initially failed `souc check` (a standalone `sp_ceil` helper mutated a var without `with Mut`); `souc run` silently produced NO output on the failed type-check. Fixed by adding `with Mut`. Reminder logged: treat empty `souc run` output as a possible type-check failure — run `souc check`.
 - Theme: sample-size & power planning for designs beyond t-test/proportions (survival, precision, MDE). All derivable, #852-safe. Suite runner: 106 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-LLvTHx/`, `/tmp/llm-offload-IEFtUA/`, `/tmp/llm-offload-G3JirB/`.
+
+## 2026-07-15 — math-review: stats::central_tendency, stats::dispersion, stats::shape
+- Files (all new): `stdlib/stats/central_tendency.sio` (arithmetic/geometric/harmonic/RMS means), `stdlib/stats/dispersion.sio` (variance/sd/range/CV/SEM), `stdlib/stats/shape.sio` (skewness g₁ + Fisher-Pearson G₁, excess kurtosis). Provider: xAI/Grok 4.3.
+- central_tendency = **PASS**: AM/GM/HM/RMS definitions, HM≤GM≤AM≤RMS ordering; {1,2,4}→2.333/2/1.714/2.646 verified.
+- dispersion = **PASS**: sample variance ÷(n−1), CV=sd/mean, SEM=sd/√n; {2,4,4,4,5,5,7,9}→var 4.571, sd 2.138, CV 0.4276, SEM 0.7559 verified.
+- shape = **PASS**: population g₁=m₃/m₂^1.5, excess kurtosis m₄/m₂²−3, Fisher-Pearson G₁=g₁√(n(n−1))/(n−2); g₁=0.6563, G₁=0.8185 verified.
+- Theme: classical descriptive statistics — completes the descriptive layer beside the robust module (median/IQR/MAD). All derivable, #852-safe. Suite runner: 109 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-Krlbft/`, `/tmp/llm-offload-gamSmC/`, `/tmp/llm-offload-iH6HMi/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -115,6 +115,9 @@ MODULES=(
   stdlib/stats/sample_size_survival.sio
   stdlib/stats/sample_size_precision.sio
   stdlib/stats/detectable_effect.sio
+  stdlib/stats/central_tendency.sio
+  stdlib/stats/dispersion.sio
+  stdlib/stats/shape.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -10,7 +10,9 @@ fourteen families:
   (full `pdf`/`cdf`/`sf`/`quantile` surfaces), a `densities` bank, Weibull /
   negative-binomial, and method-of-moments fitting for the gamma, beta and
   lognormal.
-- **Robust descriptives** — median / IQR / MAD / trimmed & Winsorized means,
+- **Descriptives** — the classical means (arithmetic / geometric / harmonic /
+  RMS), dispersion (variance / sd / range / CV / SEM), and shape (skewness /
+  kurtosis); plus the robust median / IQR / MAD / trimmed & Winsorized means,
   the Hodges-Lehmann estimators, and Tukey / Grubbs / modified-z outlier rules.
 - **Assumption checks** — normality (Jarque-Bera, Q-Q, Kolmogorov-Smirnov,
   χ²/G goodness-of-fit), independence (Wald-Wolfowitz runs, Durbin-Watson,
@@ -1430,6 +1432,38 @@ The smallest Cohen's d a study can detect: `d=(z_{1−α/2}+z_{1−β})·√(2/n
 (two-sample) or `/√n` (one-sample) — for judging whether a study was adequately
 powered. Validated: n=64/group, α=0.05, 80% → d=0.495; one-sample → 0.350.
 
+### `stats::central_tendency` — the mean family
+
+| Function | Signature |
+|---|---|
+| `arithmetic_mean` / `geometric_mean` / `harmonic_mean` / `rms` | `pub fn *(x: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic` |
+
+The classical means — arithmetic, geometric (ratios/growth), harmonic (rates)
+and root-mean-square. Validated: {1,2,4} → AM=2.333, GM=2, HM=1.714, RMS=2.646;
+the ordering HM≤GM≤AM≤RMS holds.
+
+### `stats::dispersion` — measures of spread
+
+| Function | Signature |
+|---|---|
+| `dispersion` | `pub fn dispersion(x: &[f64; 256], n: i32) -> DispersionResult with Mut, Div, Panic` |
+
+The classical variability summaries in one pass: sample variance & sd, range,
+the coefficient of variation (dimensionless relative spread) and the standard
+error of the mean. Validated: {2,4,4,4,5,5,7,9} → var 4.571, sd 2.138, range 7,
+CV 0.4276, SEM 0.7559.
+
+### `stats::shape` — skewness & kurtosis
+
+| Function | Signature |
+|---|---|
+| `shape` | `pub fn shape(x: &[f64; 256], n: i32) -> ShapeResult with Mut, Div, Panic` |
+
+The third and fourth standardised moments: population skewness `g₁`, the
+Fisher-Pearson sample-adjusted `G₁`, and (excess) kurtosis. Validated:
+{2,4,4,4,5,5,7,9} → g₁=0.6563, G₁=0.8185, excess kurtosis −0.2188; symmetric
+data → skewness 0.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1540,6 +1574,9 @@ use stats::vif::{vif_from_r2, vif_two, tolerance}
 use stats::sample_size_survival::{SurvSSResult, ss_survival}
 use stats::sample_size_precision::{ss_mean, ss_proportion}
 use stats::detectable_effect::{mde_two_means, mde_one_mean}
+use stats::central_tendency::{arithmetic_mean, geometric_mean, harmonic_mean, rms}
+use stats::dispersion::{DispersionResult, dispersion}
+use stats::shape::{ShapeResult, shape}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/central_tendency.sio
+++ b/stdlib/stats/central_tendency.sio
@@ -1,0 +1,173 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/central_tendency.sio — the mean family
+//
+// The classical measures of central tendency beyond the arithmetic mean — each
+// the right average for a different kind of quantity:
+//
+//   arithmetic_mean(x, n)   geometric_mean(x, n)   harmonic_mean(x, n)   rms(x, n)
+//
+//   AM = (1/n)Σxᵢ,   GM = exp((1/n)Σ ln xᵢ),   HM = n / Σ(1/xᵢ),
+//   RMS = √((1/n)Σxᵢ²).
+// The geometric mean suits ratios and growth rates; the harmonic mean suits
+// rates and averaged speeds; and always HM ≤ GM ≤ AM ≤ RMS for positive data.
+//
+// Pure Sounio: inline ln/exp/sqrt; one pass each. No external dependency, no
+// nested data-array calls.
+//
+// References:
+//   Kenney & Keeping, "Mathematics of Statistics" 3e.
+
+module stats::central_tendency
+
+fn ct_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn ct_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ct_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn ct_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+/// Arithmetic mean.
+pub fn arithmetic_mean(x: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    return s / (n as f64)
+}
+
+/// Geometric mean (positive data): exp(mean(ln x)).
+pub fn geometric_mean(x: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var s = 0.0
+    var i = 0
+    while i < n {
+        if x[i as usize] <= 0.0 { return 0.0 }
+        s = s + ct_ln(x[i as usize])
+        i = i + 1
+    }
+    return ct_exp(s / (n as f64))
+}
+
+/// Harmonic mean (positive data): n / Σ(1/x).
+pub fn harmonic_mean(x: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var s = 0.0
+    var i = 0
+    while i < n {
+        if x[i as usize] <= 0.0 { return 0.0 }
+        s = s + 1.0 / x[i as usize]
+        i = i + 1
+    }
+    if s <= 0.0 { return 0.0 }
+    return (n as f64) / s
+}
+
+/// Root-mean-square (quadratic mean): √(mean(x²)).
+pub fn rms(x: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize] * x[i as usize]; i = i + 1 }
+    return ct_sqrt(s / (n as f64))
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,4}: AM=7/3=2.333333; GM=8^(1/3)=2; HM=3/1.75=1.714286; RMS=√7=2.645751.
+fn test_means() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=4.0
+    var ok = true
+    ok = check(1, approx(arithmetic_mean(&x, 3), 2.333333, 1.0e-5)) && ok
+    ok = check(2, approx(geometric_mean(&x, 3), 2.0, 1.0e-5)) && ok
+    ok = check(3, approx(harmonic_mean(&x, 3), 1.714286, 1.0e-5)) && ok
+    ok = check(4, approx(rms(&x, 3), 2.645751, 1.0e-5)) && ok
+    return ok
+}
+
+// ordering HM <= GM <= AM <= RMS holds.
+fn test_ordering() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=8.0; x[2]=18.0; x[3]=32.0
+    let hm = harmonic_mean(&x, 4)
+    let gm = geometric_mean(&x, 4)
+    let am = arithmetic_mean(&x, 4)
+    let rm = rms(&x, 4)
+    return check(10, hm <= gm && gm <= am && am <= rm)
+}
+
+// equal values -> all means equal that value.
+fn test_equal() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=5.0; x[1]=5.0; x[2]=5.0
+    var ok = true
+    ok = check(20, approx(geometric_mean(&x, 3), 5.0, 1.0e-5)) && ok
+    ok = check(21, approx(harmonic_mean(&x, 3), 5.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_means() && ok
+    ok = test_ordering() && ok
+    ok = test_equal() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/dispersion.sio
+++ b/stdlib/stats/dispersion.sio
@@ -1,0 +1,131 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/dispersion.sio — measures of spread
+//
+// The classical variability summaries in one pass:
+//
+//   dispersion(x, n) -> DispersionResult
+//
+//   sample variance s² = Σ(xᵢ−x̄)²/(n−1),   sd = √s²,
+//   range = max − min,   CV = sd/x̄ (relative spread),   SEM = sd/√n.
+// The coefficient of variation is dimensionless, so it compares spread across
+// variables on different scales; the standard error of the mean scales the sd
+// by the sample size.
+//
+// Pure Sounio: one pass for the mean and extremes, a second for the variance.
+// Inline sqrt. No external dependency, no nested data-array calls.
+//
+// References:
+//   Kenney & Keeping, "Mathematics of Statistics" 3e.
+
+module stats::dispersion
+
+fn dp_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct DispersionResult {
+    pub variance: f64,   // sample variance (÷(n−1))
+    pub sd: f64,         // sample standard deviation
+    pub range: f64,      // max − min
+    pub cv: f64,         // coefficient of variation sd/mean
+    pub sem: f64,        // standard error of the mean sd/√n
+    pub mean: f64,
+}
+
+/// Classical measures of dispersion.
+///
+/// Parâmetros: x — data; n — size (>=2, <=256).
+/// Retorno: DispersionResult (variance, sd, range, cv, sem, mean).
+/// Referências: Kenney & Keeping.
+pub fn dispersion(x: &[f64; 256], n: i32) -> DispersionResult with Mut, Div, Panic {
+    if n < 2 { return DispersionResult { variance: 0.0, sd: 0.0, range: 0.0, cv: 0.0, sem: 0.0, mean: 0.0 } }
+    let nf = n as f64
+    var s = 0.0
+    var mn = x[0]
+    var mx = x[0]
+    var i = 0
+    while i < n {
+        let v = x[i as usize]
+        s = s + v
+        if v < mn { mn = v }
+        if v > mx { mx = v }
+        i = i + 1
+    }
+    let mean = s / nf
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; ss = ss + d * d; j = j + 1 }
+    let variance = ss / (nf - 1.0)
+    let sd = dp_sqrt(variance)
+    var cv = 0.0
+    if mean != 0.0 { cv = sd / mean }
+    let sem = sd / dp_sqrt(nf)
+    return DispersionResult { variance: variance, sd: sd, range: mx - mn, cv: cv, sem: sem, mean: mean }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {2,4,4,4,5,5,7,9}: mean 5, Σd²=32, sample var=32/7=4.571429; sd=2.138090;
+// range=9-2=7; cv=2.138090/5=0.427618; sem=2.138090/√8=0.755929.
+fn test_dispersion() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=4.0; x[3]=4.0; x[4]=5.0; x[5]=5.0; x[6]=7.0; x[7]=9.0
+    let r = dispersion(&x, 8)
+    var ok = true
+    ok = check(1, approx(r.mean, 5.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.variance, 4.571429, 1.0e-5)) && ok
+    ok = check(3, approx(r.sd, 2.138090, 1.0e-5)) && ok
+    ok = check(4, approx(r.range, 7.0, 1.0e-9)) && ok
+    ok = check(5, approx(r.cv, 0.427618, 1.0e-5)) && ok
+    ok = check(6, approx(r.sem, 0.755929, 1.0e-5)) && ok
+    return ok
+}
+
+// constant data -> zero spread.
+fn test_constant() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=3.0; x[1]=3.0; x[2]=3.0
+    let r = dispersion(&x, 3)
+    var ok = true
+    ok = check(10, approx(r.variance, 0.0, 1.0e-12)) && ok
+    ok = check(11, approx(r.range, 0.0, 1.0e-12)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_dispersion() && ok
+    ok = test_constant() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/shape.sio
+++ b/stdlib/stats/shape.sio
@@ -1,0 +1,134 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/shape.sio — distribution shape (skewness & kurtosis)
+//
+// The third and fourth standardised moments — how asymmetric and how heavy-
+// tailed a sample is:
+//
+//   shape(x, n) -> ShapeResult
+//
+//   population skew g₁ = m₃/m₂^{3/2},   excess kurtosis g₂ = m₄/m₂² − 3,
+//   sample-adjusted skew G₁ = g₁·√(n(n−1))/(n−2)  (Fisher-Pearson correction).
+// g₁ > 0 is a right tail; g₂ > 0 is heavier tails than the normal (leptokurtic).
+//
+// Pure Sounio: one pass for the mean, one for the central moments; inline sqrt.
+// No external dependency, no nested data-array calls.
+//
+// References:
+//   Joanes & Gill (1998) The Statistician 47:183.
+
+module stats::shape
+
+fn sh_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct ShapeResult {
+    pub skewness: f64,        // population g₁
+    pub skewness_adj: f64,    // sample-adjusted G₁
+    pub excess_kurtosis: f64, // population g₂ (normal = 0)
+    pub kurtosis: f64,        // raw kurtosis (normal = 3)
+}
+
+/// Distribution shape: skewness and (excess) kurtosis.
+///
+/// Parâmetros: x — data; n — size (>=3 for skewness_adj, <=256).
+/// Retorno: ShapeResult (skewness, skewness_adj, excess_kurtosis, kurtosis).
+/// Referências: Joanes & Gill (1998).
+pub fn shape(x: &[f64; 256], n: i32) -> ShapeResult with Mut, Div, Panic {
+    if n < 2 { return ShapeResult { skewness: 0.0, skewness_adj: 0.0, excess_kurtosis: 0.0 - 3.0, kurtosis: 0.0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mean = s / nf
+    var m2 = 0.0
+    var m3 = 0.0
+    var m4 = 0.0
+    var j = 0
+    while j < n {
+        let d = x[j as usize] - mean
+        let d2 = d * d
+        m2 = m2 + d2
+        m3 = m3 + d2 * d
+        m4 = m4 + d2 * d2
+        j = j + 1
+    }
+    m2 = m2 / nf
+    m3 = m3 / nf
+    m4 = m4 / nf
+    if m2 <= 0.0 { return ShapeResult { skewness: 0.0, skewness_adj: 0.0, excess_kurtosis: 0.0 - 3.0, kurtosis: 0.0 } }
+    let sd = sh_sqrt(m2)
+    let g1 = m3 / (sd * sd * sd)
+    let kurt = m4 / (m2 * m2)
+    let g2 = kurt - 3.0
+    var g1_adj = g1
+    if n > 2 { g1_adj = g1 * sh_sqrt(nf * (nf - 1.0)) / (nf - 2.0) }
+    return ShapeResult { skewness: g1, skewness_adj: g1_adj, excess_kurtosis: g2, kurtosis: kurt }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {2,4,4,4,5,5,7,9}: m2=4, m3=5.25, m4=44.5.
+// g1=5.25/8=0.65625; kurt=44.5/16=2.78125; g2=-0.21875.
+// G1=0.65625·√(8·7)/6=0.65625·7.483315/6=0.818487.
+fn test_shape() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=4.0; x[3]=4.0; x[4]=5.0; x[5]=5.0; x[6]=7.0; x[7]=9.0
+    let r = shape(&x, 8)
+    var ok = true
+    ok = check(1, approx(r.skewness, 0.65625, 1.0e-5)) && ok
+    ok = check(2, approx(r.excess_kurtosis, 0.0 - 0.21875, 1.0e-5)) && ok
+    ok = check(3, approx(r.kurtosis, 2.78125, 1.0e-5)) && ok
+    ok = check(4, approx(r.skewness_adj, 0.818487, 1.0e-4)) && ok
+    return ok
+}
+
+// symmetric data -> zero skewness. {1,2,3,4,5}: skew 0; kurt=1.7; excess -1.3.
+fn test_symmetric() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = shape(&x, 5)
+    var ok = true
+    ok = check(10, approx(r.skewness, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.kurtosis, 1.7, 1.0e-5)) && ok
+    ok = check(12, approx(r.excess_kurtosis, 0.0 - 1.3, 1.0e-5)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_shape() && ok
+    ok = test_symmetric() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three foundational descriptive-statistics modules, bringing the runner to **109 modules**. A surprising late gap: the suite had the *robust* descriptives (median/IQR/MAD) but no clean *classical* ones. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::central_tendency` | arithmetic / geometric / harmonic / RMS means |
| `stats::dispersion` | variance, sd, range, coefficient of variation, SEM |
| `stats::shape` | skewness (g₁ and Fisher-Pearson G₁) and (excess) kurtosis |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Means: {1,2,4} → AM=2.333, GM=2, HM=1.714, RMS=2.646; the ordering HM≤GM≤AM≤RMS holds.
  - Dispersion: {2,4,4,4,5,5,7,9} → var 4.571, sd 2.138, range 7, CV 0.4276, SEM 0.7559.
  - Shape: same data → g₁=0.6563, G₁=0.8185, excess kurtosis −0.2188; symmetric data → skewness 0.
- Full suite selftest: **109 modules + 7 demos ALL GREEN** under `lean_single`.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).