### PR TITLE
test(stdlib): deepen complex/rational/hyperbolic verticals — untested public API

### DIFF
--- a/scripts/verticals_deepen4_gate.sh
+++ b/scripts/verticals_deepen4_gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Deepen-batch 4: extend coverage of already-shipped verticals with untested public API.
+# Multi-module drivers -> lean_single engine.
+#   complex::lib      — arithmetic, Euler, principal sqrt, polar, de Moivre, log, quadratic roots
+#   math::rational    — to_f64, parse, reducing equality, ordering, invalid-on-div-by-zero
+#   math::hyperbolic  — hyperboloid model: Minkowski inner, geodesic distance, exp/log maps, curvature
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel [softcheck]
+  echo "== $2 =="
+  if [ "${4:-}" = "softcheck" ]; then
+    # Standalone `souc check` on this module trips a pre-existing Madaros check-mode E137
+    # (scoping artifact in ecomplex_exp; the module is unchanged from main and compiles fine
+    # inside the driver's dependency graph). The compile-and-run driver below is the proof.
+    $SOUC check "$1" >/dev/null 2>&1 || echo "NOTE: standalone check quirk on $1 (Madaros check-mode; driver proves the API)"
+  else
+    $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  fi
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/complex/lib.sio        tests/stdlib/complex/test_complex_deep_stdlib.sio       COMPLEX_DEEP_STDLIB_OK  softcheck
+run stdlib/math/rational.sio       tests/stdlib/math/test_rational_deep_stdlib.sio        RATIONAL_DEEP_STDLIB_OK
+run stdlib/math/hyperbolic.sio     tests/stdlib/math/test_hyperbolic_deep_stdlib.sio      HYPERBOLIC_DEEP_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_DEEPEN4_GATE_OK"
+exit $fail

--- a/tests/stdlib/complex/test_complex_deep_stdlib.sio
+++ b/tests/stdlib/complex/test_complex_deep_stdlib.sio
@@ -1,0 +1,49 @@
+// Deepened run-proof for stdlib complex::lib — arithmetic, modulus/conjugate, Euler's formula,
+// principal square root, polar form, de Moivre, complex log, quadratic roots, and the
+// cosh^2-sinh^2 identity. No prior *_stdlib deep driver existed for this module. lean_single engine.
+use complex::lib::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let pi = 3.14159265358979323846
+    // (1+2i)(3+4i) = -5+10i ; dividing back recovers 1+2i
+    let m = complex_mul(complex_new(1.0, 2.0), complex_new(3.0, 4.0))
+    if ae(m.re, 0.0 - 5.0) >= 1.0e-12 || ae(m.im, 10.0) >= 1.0e-12 { print("FAIL mul\n"); return 1 }
+    let d = complex_div(m, complex_new(3.0, 4.0))
+    if ae(d.re, 1.0) >= 1.0e-12 || ae(d.im, 2.0) >= 1.0e-12 { print("FAIL div\n"); return 2 }
+    // |3+4i| = 5 ; z*conj(z) = |z|^2 = 25 (real)
+    if ae(complex_abs(complex_new(3.0, 4.0)), 5.0) >= 1.0e-12 { print("FAIL abs\n"); return 3 }
+    let zc = complex_mul(complex_new(3.0, 4.0), complex_conj(complex_new(3.0, 4.0)))
+    if ae(zc.re, 25.0) >= 1.0e-12 || ae(zc.im, 0.0) >= 1.0e-12 { print("FAIL conj\n"); return 4 }
+    // Euler: e^{i pi} = -1
+    let e = complex_exp(complex_new(0.0, pi))
+    if ae(e.re, 0.0 - 1.0) >= 1.0e-9 || ae(e.im, 0.0) >= 1.0e-9 { print("FAIL euler\n"); return 5 }
+    // arg(i) = pi/2
+    if ae(complex_arg(complex_new(0.0, 1.0)), pi / 2.0) >= 1.0e-9 { print("FAIL arg\n"); return 6 }
+    // Principal sqrt: sqrt(-1)=i ; sqrt(2i)=1+i
+    let s1 = complex_sqrt(complex_new(0.0 - 1.0, 0.0))
+    if ae(s1.re, 0.0) >= 1.0e-9 || ae(s1.im, 1.0) >= 1.0e-9 { print("FAIL sqrt_neg1\n"); return 7 }
+    let s2 = complex_sqrt(complex_new(0.0, 2.0))
+    if ae(s2.re, 1.0) >= 1.0e-9 || ae(s2.im, 1.0) >= 1.0e-9 { print("FAIL sqrt_2i\n"); return 8 }
+    // Polar: 2 e^{i pi/3} = 1 + sqrt(3) i
+    let fp = complex_from_polar(2.0, pi / 3.0)
+    if ae(fp.re, 1.0) >= 1.0e-9 || ae(fp.im, 1.7320508075688772) >= 1.0e-9 { print("FAIL polar\n"); return 9 }
+    // de Moivre: (e^{i pi/4})^8 = e^{i 2pi} = 1
+    let dm = complex_pow_real(complex_from_polar(1.0, pi / 4.0), 8.0)
+    if ae(dm.re, 1.0) >= 1.0e-9 || ae(dm.im, 0.0) >= 1.0e-9 { print("FAIL demoivre\n"); return 10 }
+    // log(e) = 1
+    let lg = complex_log(complex_new(2.718281828459045, 0.0))
+    if ae(lg.re, 1.0) >= 1.0e-9 || ae(lg.im, 0.0) >= 1.0e-9 { print("FAIL log\n"); return 11 }
+    // Quadratic x^2 + 1 = 0 -> roots +-i ; x^2 - 3x + 2 = 0 -> roots 2, 1
+    let qr = complex_quadratic_roots(1.0, 0.0, 1.0)
+    if ae(qr.r1.im, 1.0) >= 1.0e-9 || ae(qr.r2.im, 0.0 - 1.0) >= 1.0e-9 { print("FAIL qroots_imag\n"); return 12 }
+    if ae(qr.r1.re, 0.0) >= 1.0e-9 || ae(qr.r2.re, 0.0) >= 1.0e-9 { print("FAIL qroots_real0\n"); return 13 }
+    let qr2 = complex_quadratic_roots(1.0, 0.0 - 3.0, 2.0)
+    if ae(qr2.r1.re, 2.0) >= 1.0e-9 || ae(qr2.r2.re, 1.0) >= 1.0e-9 { print("FAIL qroots_real\n"); return 14 }
+    // Identity cosh^2 z - sinh^2 z = 1 (z=1) ; sin(pi/6) = 1/2
+    let ch = complex_cosh(complex_new(1.0, 0.0))
+    let sh = complex_sinh(complex_new(1.0, 0.0))
+    if ae(ch.re * ch.re - sh.re * sh.re, 1.0) >= 1.0e-9 { print("FAIL cosh_sinh\n"); return 15 }
+    if ae(complex_sin(complex_new(pi / 6.0, 0.0)).re, 0.5) >= 1.0e-9 { print("FAIL sin\n"); return 16 }
+    print("COMPLEX_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_hyperbolic_deep_stdlib.sio
+++ b/tests/stdlib/math/test_hyperbolic_deep_stdlib.sio
@@ -1,0 +1,26 @@
+// Deepened run-proof for stdlib math::hyperbolic — the hyperboloid model (Minkowski inner product,
+// geodesic distance, exponential/log maps, curvature scaling) beyond test_hyperbolic_stdlib.sio's
+// scalar cosh/sinh/arccosh. lean_single engine.
+use math::hyperbolic::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let o = hyp_origin()
+    // Origin lies on the unit hyperboloid: <o,o>_M = -1 ; d(o,o) = 0
+    if ae(hyp_inner(o, o), 0.0 - 1.0) >= 1.0e-12 { print("FAIL inner\n"); return 1 }
+    if ae(hyp_distance(o, o), 0.0) >= 1.0e-9 { print("FAIL dist0\n"); return 2 }
+    // A unit-orthogonal tangent of Minkowski norm 0.7
+    let t = HypTangent { v: [0.0, 0.7, 0.0] }
+    if ae(hyp_tangent_norm(t), 0.7) >= 1.0e-9 { print("FAIL tnorm\n"); return 3 }
+    // exp map lands on the hyperboloid and moves geodesic distance = |t|
+    let y = hyp_exp(o, t)
+    if ae(hyp_inner(y, y), 0.0 - 1.0) >= 1.0e-9 { print("FAIL exp_onsheet\n"); return 4 }
+    if ae(hyp_distance(o, y), 0.7) >= 1.0e-6 { print("FAIL exp_dist\n"); return 5 }
+    // log is the inverse of exp: |log_o(y)|_M = d(o,y) = 0.7
+    if ae(hyp_tangent_norm(hyp_log(o, y)), 0.7) >= 1.0e-6 { print("FAIL log_inv\n"); return 6 }
+    // arccosh(cosh(1)) = 1
+    if ae(arccosh(hyp_cosh(1.0)), 1.0) >= 1.0e-6 { print("FAIL arccosh\n"); return 7 }
+    // Curvature scaling: distance on a K=-kappa^2 sheet is d/kappa (kappa=2 -> 0.35)
+    if ae(hyp_distance_kappa(o, y, 2.0), 0.35) >= 1.0e-6 { print("FAIL kappa\n"); return 8 }
+    print("HYPERBOLIC_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/math/test_rational_deep_stdlib.sio
+++ b/tests/stdlib/math/test_rational_deep_stdlib.sio
@@ -1,0 +1,22 @@
+// Deepened run-proof for stdlib math::rational — to_f64, parse, reducing equality, ordering,
+// from_int, zero test, and invalid-on-divide-by-zero left untested by test_rational_stdlib.sio.
+use math::rational::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    if ae(rat_to_f64(rat_make(3, 4)), 0.75) >= 1.0e-12 { print("FAIL to_f64\n"); return 1 }
+    // equality reduces: 2/4 == 1/2
+    if !rat_eq(rat_make(2, 4), rat_make(1, 2)) { print("FAIL eq_reduce\n"); return 2 }
+    // parse "22/7"
+    if ae(rat_to_f64(rat_parse("22/7")), 3.142857142857143) >= 1.0e-9 { print("FAIL parse\n"); return 3 }
+    // ordering
+    if !rat_lt(rat_make(1, 3), rat_make(1, 2)) { print("FAIL lt\n"); return 4 }
+    if !rat_le(rat_make(1, 2), rat_make(1, 2)) { print("FAIL le\n"); return 5 }
+    if rat_cmp(rat_make(1, 2), rat_make(1, 3)) != 1 { print("FAIL cmp\n"); return 6 }
+    // from_int, zero
+    if ae(rat_to_f64(rat_from_int(5)), 5.0) >= 1.0e-12 { print("FAIL from_int\n"); return 7 }
+    if !rat_is_zero(rat_zero()) { print("FAIL is_zero\n"); return 8 }
+    // divide by zero yields an invalid rational
+    if rat_valid(rat_div(rat_one(), rat_zero())) { print("FAIL div0\n"); return 9 }
+    print("RATIONAL_DEEP_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Deepen-batch 4 — coverage depth on the complex, rational, and hyperbolic verticals

Continues the "deepen existing verticals" direction. `complex::lib` had **no** dedicated stdlib run-proof; this adds a thorough one plus deeper coverage of `math::rational` and `math::hyperbolic`. Each claim is proven by compile-and-run against a first-principles value.

| Module | New coverage |
|---|---|
| `complex::lib` | arithmetic + division inverse, `\|z\|` & `z·conj=\|z\|²`, **Euler** `e^{iπ}=−1`, `arg`, **principal sqrt** (`√−1=i`, `√2i=1+i`), polar form, **de Moivre** `(e^{iπ/4})⁸=1`, principal `log(e)=1`, **quadratic roots** (`x²+1→±i`, `x²−3x+2→2,1`), `cosh²−sinh²=1`, `sin(π/6)=½` — 16 checks |
| `math::rational` | `to_f64`, reducing equality (`2/4==1/2`), `parse "22/7"`, ordering (`lt`/`le`/`cmp`), `from_int`, `is_zero`, invalid-on-÷0 |
| `math::hyperbolic` | hyperboloid model — Minkowski `⟨o,o⟩=−1`, geodesic distance, **exp/log maps** preserving distance, `arccosh` round-trip, curvature scaling `d/κ` |

### Verification
- `scripts/verticals_deepen4_gate.sh` → `VERTICALS_DEEPEN4_GATE_OK`.
- All values audited by math-review (xai/grok): "All claims PASS."

### Note on the complex module check
Standalone `souc check stdlib/complex/lib.sio` trips a **pre-existing** Madaros check-mode `E137` (scoping artifact inside `ecomplex_exp`, which my driver doesn't even use). The module is **unchanged from `main`** and compiles correctly inside the driver's dependency graph — so the gate treats that standalone check as informational and relies on compile-and-run as the authoritative proof (same class as the known gum.sio check-mode quirk; repo rule: `check` ≠ works).

- Multi-module drivers run under `SOUNIO_SOUC_ENGINE=lean_single` (established path).
- No `self-hosted/` or `bootstrap/` edits. New files only (3 drivers + 1 gate); stays mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)