### PR TITLE
feat(stats): nominal association measures — gk_lambda, gk_tau, uncertainty_coefficient

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2967,3 +2967,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - shape = **PASS**: population g₁=m₃/m₂^1.5, excess kurtosis m₄/m₂²−3, Fisher-Pearson G₁=g₁√(n(n−1))/(n−2); g₁=0.6563, G₁=0.8185 verified.
 - Theme: classical descriptive statistics — completes the descriptive layer beside the robust module (median/IQR/MAD). All derivable, #852-safe. Suite runner: 109 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-Krlbft/`, `/tmp/llm-offload-gamSmC/`, `/tmp/llm-offload-iH6HMi/`.
+
+## 2026-07-15 — math-review: stats::gk_lambda, stats::gk_tau, stats::uncertainty_coefficient
+- Files (all new): `stdlib/stats/gk_lambda.sio` (Goodman-Kruskal λ, mode-prediction PRE), `stdlib/stats/gk_tau.sio` (Goodman-Kruskal τ, proportional-prediction PRE), `stdlib/stats/uncertainty_coefficient.sio` (Theil's U, entropy/mutual-information). Provider: xAI/Grok 4.3.
+- gk_lambda = **PASS**: λ(R|C)=(Σ_c maxᵣn_rc−maxᵣn_r+)/(N−maxᵣn_r+), both directions + symmetric; [[40,10],[5,45]]→0.7/0.667, mode-only→0, diagonal→1.
+- gk_tau = **PASS**: τ(R|C)=(Σ_cΣ_r n_rc²/n_+c − Σ_r n_r+²/N)/(N−Σn_r+²/N); 0.4949 verified, independence→0, diagonal→1.
+- uncertainty_coefficient = **PASS**: H(R), I(R;C), U(R|C)=I/H(R); I=0.2754, U=0.3973 verified, independence→0, diagonal→1.
+- Theme: nominal association / PRE & entropy measures — complements chi2_independence (Cramér's V) for contingency tables. All derivable, #852-safe. Suite runner: 112 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-rFk7TQ/`, `/tmp/llm-offload-nnqkco/`, `/tmp/llm-offload-wl6Rgd/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -118,6 +118,9 @@ MODULES=(
   stdlib/stats/central_tendency.sio
   stdlib/stats/dispersion.sio
   stdlib/stats/shape.sio
+  stdlib/stats/gk_lambda.sio
+  stdlib/stats/gk_tau.sio
+  stdlib/stats/uncertainty_coefficient.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -31,7 +31,8 @@ fourteen families:
   Deming / Theil-Sen / Passing-Bablok method-comparison fits, and the regression
   diagnostics (leverage, Cook's distance, VIF).
 - **Categorical & exact** — χ² independence, Fisher's exact 2×2, McNemar,
-  Cochran's Q, the Cochran-Armitage trend test and proportion CIs.
+  Cochran's Q, the Cochran-Armitage trend test, proportion CIs, and the nominal
+  association measures (Goodman-Kruskal λ and τ, Theil's uncertainty coefficient).
 - **Agreement & reliability** — Bland-Altman, Lin's CCC + Cliff's δ, Cohen's and
   Fleiss' κ, Gwet's AC1, Krippendorff's α, ICC / Cronbach's α and the full
   Shrout-Fleiss ICC family.
@@ -1464,6 +1465,38 @@ Fisher-Pearson sample-adjusted `G₁`, and (excess) kurtosis. Validated:
 {2,4,4,4,5,5,7,9} → g₁=0.6563, G₁=0.8185, excess kurtosis −0.2188; symmetric
 data → skewness 0.
 
+### `stats::gk_lambda` — Goodman-Kruskal lambda
+
+| Function | Signature |
+|---|---|
+| `gk_lambda` | `pub fn gk_lambda(table: &[f64; 256], nr: i32, nc: i32) -> LambdaResult with Mut, Div, Panic` |
+
+A proportional-reduction-in-error nominal association measure (mode prediction):
+`λ(R|C)=(Σ_c maxᵣn_rc−maxᵣn_r+)/(N−maxᵣn_r+)`, both directions and symmetric.
+Validated: [[40,10],[5,45]] → λ(R|C)=0.7, λ(C|R)=0.667; mode-only table → 0;
+diagonal → 1.
+
+### `stats::gk_tau` — Goodman-Kruskal tau
+
+| Function | Signature |
+|---|---|
+| `gk_tau` | `pub fn gk_tau(table: &[f64; 256], nr: i32, nc: i32) -> TauResult with Mut, Div, Panic` |
+
+Like lambda but predicting with the full category distribution, so it is non-zero
+under any dependence: `τ(R|C)=(Σ_c Σ_r n_rc²/n_+c − Σ_r n_r+²/N)/(N−Σn_r+²/N)`.
+Validated: [[40,10],[5,45]] → τ(R|C)=0.4949; rank-1 table → 0; diagonal → 1.
+
+### `stats::uncertainty_coefficient` — Theil's U
+
+| Function | Signature |
+|---|---|
+| `uncertainty_coefficient` | `pub fn uncertainty_coefficient(table: &[f64; 256], nr: i32, nc: i32) -> UResult with Mut, Div, Panic` |
+
+The information-theoretic association measure: `U(R|C)=I(R;C)/H(R)`, the fraction
+of one variable's entropy explained by the other, both directions and symmetric.
+Validated: [[40,10],[5,45]] → I=0.2754, U(R|C)=0.3973; independence → 0; diagonal
+→ 1.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1577,6 +1610,9 @@ use stats::detectable_effect::{mde_two_means, mde_one_mean}
 use stats::central_tendency::{arithmetic_mean, geometric_mean, harmonic_mean, rms}
 use stats::dispersion::{DispersionResult, dispersion}
 use stats::shape::{ShapeResult, shape}
+use stats::gk_lambda::{LambdaResult, gk_lambda}
+use stats::gk_tau::{TauResult, gk_tau}
+use stats::uncertainty_coefficient::{UResult, uncertainty_coefficient}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/gk_lambda.sio
+++ b/stdlib/stats/gk_lambda.sio
@@ -1,0 +1,159 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/gk_lambda.sio — Goodman-Kruskal lambda (nominal association)
+//
+// A proportional-reduction-in-error measure of association for a nominal
+// contingency table: how much better one variable predicts the other than the
+// marginal mode alone:
+//
+//   gk_lambda(table, nr, nc) -> LambdaResult      (row-major nr × nc counts)
+//
+//   λ(R|C) = ( Σ_c maxᵣ n_rc − maxᵣ n_r+ ) / ( N − maxᵣ n_r+ ),
+//   λ(C|R) analogously, and the symmetric λ pools both directions.
+// λ = 0 means the column gives no help predicting the row (the mode is always
+// chosen); λ = 1 means perfect prediction.
+//
+// Pure Sounio: row/column maxima and marginals in nested loops. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Goodman & Kruskal (1954) JASA 49:732.
+
+module stats::gk_lambda
+
+pub struct LambdaResult {
+    pub lambda_rc: f64,   // λ(R|C): predict row from column
+    pub lambda_cr: f64,   // λ(C|R): predict column from row
+    pub lambda_sym: f64,  // symmetric λ
+}
+
+/// Goodman-Kruskal lambda for a nominal contingency table.
+///
+/// Parâmetros: table — row-major nr×nc counts; nr — rows (2..16); nc — cols (2..16).
+/// Retorno: LambdaResult (lambda_rc, lambda_cr, lambda_sym).
+/// Referências: Goodman & Kruskal (1954).
+pub fn gk_lambda(table: &[f64; 256], nr: i32, nc: i32) -> LambdaResult with Mut, Div, Panic {
+    if nr < 2 || nr > 16 || nc < 2 || nc > 16 {
+        return LambdaResult { lambda_rc: 0.0, lambda_cr: 0.0, lambda_sym: 0.0 }
+    }
+    var total = 0.0
+    // row marginals and their max
+    var max_row = 0.0
+    var i = 0
+    while i < nr {
+        var rs = 0.0
+        var j = 0
+        while j < nc { let v = table[(i * nc + j) as usize]; rs = rs + v; total = total + v; j = j + 1 }
+        if rs > max_row { max_row = rs }
+        i = i + 1
+    }
+    // column marginals and their max
+    var max_col = 0.0
+    var c = 0
+    while c < nc {
+        var cs = 0.0
+        var t = 0
+        while t < nr { cs = cs + table[(t * nc + c) as usize]; t = t + 1 }
+        if cs > max_col { max_col = cs }
+        c = c + 1
+    }
+    // Σ_c max_r n_rc  (max within each column)
+    var sum_maxrow_incol = 0.0
+    var cc = 0
+    while cc < nc {
+        var m = 0.0
+        var r = 0
+        while r < nr { let v = table[(r * nc + cc) as usize]; if v > m { m = v } r = r + 1 }
+        sum_maxrow_incol = sum_maxrow_incol + m
+        cc = cc + 1
+    }
+    // Σ_r max_c n_rc  (max within each row)
+    var sum_maxcol_inrow = 0.0
+    var rr = 0
+    while rr < nr {
+        var m = 0.0
+        var k = 0
+        while k < nc { let v = table[(rr * nc + k) as usize]; if v > m { m = v } k = k + 1 }
+        sum_maxcol_inrow = sum_maxcol_inrow + m
+        rr = rr + 1
+    }
+    var lrc = 0.0
+    let den_rc = total - max_row
+    if den_rc > 0.0 { lrc = (sum_maxrow_incol - max_row) / den_rc }
+    var lcr = 0.0
+    let den_cr = total - max_col
+    if den_cr > 0.0 { lcr = (sum_maxcol_inrow - max_col) / den_cr }
+    var lsym = 0.0
+    let den_sym = 2.0 * total - max_row - max_col
+    if den_sym > 0.0 {
+        lsym = (sum_maxrow_incol + sum_maxcol_inrow - max_row - max_col) / den_sym
+    }
+    return LambdaResult { lambda_rc: lrc, lambda_cr: lcr, lambda_sym: lsym }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// [[40,10],[5,45]]: row marg (50,50) max 50; col marg (45,55) max 55.
+// Σ_c max_r = max(40,5)+max(10,45)=40+45=85. λ(R|C)=(85-50)/(100-50)=0.7.
+// Σ_r max_c = max(40,10)+max(5,45)=40+45=85. λ(C|R)=(85-55)/(100-55)=30/45=0.666667.
+fn test_lambda() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=40.0; t[1]=10.0
+    t[2]=5.0;  t[3]=45.0
+    let r = gk_lambda(&t, 2, 2)
+    var ok = true
+    ok = check(1, approx(r.lambda_rc, 0.7, 1.0e-6)) && ok
+    ok = check(2, approx(r.lambda_cr, 0.666667, 1.0e-5)) && ok
+    return ok
+}
+
+// no predictive gain (mode always same row): [[10,20],[30,40]] -> λ(R|C)=0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=10.0; t[1]=20.0
+    t[2]=30.0; t[3]=40.0
+    let r = gk_lambda(&t, 2, 2)
+    return check(10, approx(r.lambda_rc, 0.0, 1.0e-9))
+}
+
+// perfect association (diagonal) -> λ = 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=50.0; t[1]=0.0
+    t[2]=0.0;  t[3]=50.0
+    let r = gk_lambda(&t, 2, 2)
+    var ok = true
+    ok = check(20, approx(r.lambda_rc, 1.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.lambda_sym, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_lambda() && ok
+    ok = test_null() && ok
+    ok = test_perfect() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/gk_tau.sio
+++ b/stdlib/stats/gk_tau.sio
@@ -1,0 +1,156 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/gk_tau.sio — Goodman-Kruskal tau (nominal association)
+//
+// A proportional-reduction-in-error measure like lambda, but predicting with the
+// full category *distribution* (proportional prediction) rather than only the
+// mode — so it is non-zero whenever the variables are dependent:
+//
+//   gk_tau(table, nr, nc) -> TauResult      (row-major nr × nc counts)
+//
+//   τ(R|C) = ( Σ_c Σ_r n_rc²/n_+c − Σ_r n_r+²/N ) / ( N − Σ_r n_r+²/N ),
+//   τ(C|R) analogously.  τ = 0 under independence, 1 under perfect prediction.
+//
+// Pure Sounio: row/column marginals then the conditional error terms. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   Goodman & Kruskal (1954) JASA 49:732.
+
+module stats::gk_tau
+
+pub struct TauResult {
+    pub tau_rc: f64,   // τ(R|C): predict row from column
+    pub tau_cr: f64,   // τ(C|R): predict column from row
+}
+
+/// Goodman-Kruskal tau for a nominal contingency table.
+///
+/// Parâmetros: table — row-major nr×nc counts; nr — rows (2..16); nc — cols (2..16).
+/// Retorno: TauResult (tau_rc, tau_cr).
+/// Referências: Goodman & Kruskal (1954).
+pub fn gk_tau(table: &[f64; 256], nr: i32, nc: i32) -> TauResult with Mut, Div, Panic {
+    if nr < 2 || nr > 16 || nc < 2 || nc > 16 {
+        return TauResult { tau_rc: 0.0, tau_cr: 0.0 }
+    }
+    var total = 0.0
+    var rowm: [f64; 16] = [0.0; 16]
+    var colm: [f64; 16] = [0.0; 16]
+    var i = 0
+    while i < nr {
+        var j = 0
+        while j < nc {
+            let v = table[(i * nc + j) as usize]
+            total = total + v
+            rowm[i as usize] = rowm[i as usize] + v
+            colm[j as usize] = colm[j as usize] + v
+            j = j + 1
+        }
+        i = i + 1
+    }
+    if total <= 0.0 { return TauResult { tau_rc: 0.0, tau_cr: 0.0 } }
+    // Σ_r n_r+²/N  and  Σ_c n_+c²/N
+    var srow2 = 0.0
+    var a = 0
+    while a < nr { srow2 = srow2 + rowm[a as usize] * rowm[a as usize] / total; a = a + 1 }
+    var scol2 = 0.0
+    var b = 0
+    while b < nc { scol2 = scol2 + colm[b as usize] * colm[b as usize] / total; b = b + 1 }
+    // τ(R|C): Σ_c Σ_r n_rc²/n_+c
+    var cond_rc = 0.0
+    var c = 0
+    while c < nc {
+        if colm[c as usize] > 0.0 {
+            var r = 0
+            while r < nr {
+                let v = table[(r * nc + c) as usize]
+                cond_rc = cond_rc + v * v / colm[c as usize]
+                r = r + 1
+            }
+        }
+        c = c + 1
+    }
+    // τ(C|R): Σ_r Σ_c n_rc²/n_r+
+    var cond_cr = 0.0
+    var rr = 0
+    while rr < nr {
+        if rowm[rr as usize] > 0.0 {
+            var k = 0
+            while k < nc {
+                let v = table[(rr * nc + k) as usize]
+                cond_cr = cond_cr + v * v / rowm[rr as usize]
+                k = k + 1
+            }
+        }
+        rr = rr + 1
+    }
+    var trc = 0.0
+    let den_rc = total - srow2
+    if den_rc > 1.0e-300 { trc = (cond_rc - srow2) / den_rc }
+    var tcr = 0.0
+    let den_cr = total - scol2
+    if den_cr > 1.0e-300 { tcr = (cond_cr - scol2) / den_cr }
+    return TauResult { tau_rc: trc, tau_cr: tcr }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// [[40,10],[5,45]]: N=100, rows (50,50), cols (45,55).
+// Σr²/N=(2500+2500)/100=50. Σc²/N=(2025+3025)/100=50.5.
+// cond_rc = (40²+5²)/45 + (10²+45²)/55 = 1625/45 + 2125/55 = 36.111111+38.636364=74.747475.
+// τ(R|C)=(74.747475-50)/(100-50)=0.494949.
+fn test_tau() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=40.0; t[1]=10.0
+    t[2]=5.0;  t[3]=45.0
+    let r = gk_tau(&t, 2, 2)
+    return check(1, approx(r.tau_rc, 0.494949, 1.0e-5))
+}
+
+// independence: rows proportional -> τ ≈ 0. [[10,20],[20,40]] (rank-1).
+fn test_independent() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=10.0; t[1]=20.0
+    t[2]=20.0; t[3]=40.0
+    let r = gk_tau(&t, 2, 2)
+    return check(10, approx(r.tau_rc, 0.0, 1.0e-9))
+}
+
+// perfect association (diagonal) -> τ = 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=50.0; t[1]=0.0
+    t[2]=0.0;  t[3]=50.0
+    let r = gk_tau(&t, 2, 2)
+    return check(20, approx(r.tau_rc, 1.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_tau() && ok
+    ok = test_independent() && ok
+    ok = test_perfect() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/uncertainty_coefficient.sio
+++ b/stdlib/stats/uncertainty_coefficient.sio
@@ -1,0 +1,174 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/uncertainty_coefficient.sio — Theil's U (entropy association)
+//
+// An information-theoretic measure of nominal association: the fraction of one
+// variable's entropy explained by the other:
+//
+//   uncertainty_coefficient(table, nr, nc) -> UResult      (row-major nr × nc)
+//
+//   H(R) = −Σ pᵣ₊ ln pᵣ₊,   I(R;C) = ΣΣ p_rc ln( p_rc /(pᵣ₊ p₊c) ),
+//   U(R|C) = I/H(R),   U(C|R) = I/H(C),   symmetric U = 2I/(H(R)+H(C)).
+// U = 0 under independence, 1 when C perfectly determines R.
+//
+// Pure Sounio: marginals then the entropy / mutual-information sums; inline ln.
+// No external dependency, no nested data-array calls.
+//
+// References:
+//   Theil (1970) Am. J. Sociol. 76:103.
+
+module stats::uncertainty_coefficient
+
+fn uc_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+pub struct UResult {
+    pub u_rc: f64,    // U(R|C): fraction of H(R) explained by C
+    pub u_cr: f64,    // U(C|R)
+    pub u_sym: f64,   // symmetric U
+    pub mutual_info: f64,
+}
+
+/// Theil's uncertainty coefficient for a nominal contingency table.
+///
+/// Parâmetros: table — row-major nr×nc counts; nr — rows (2..16); nc — cols (2..16).
+/// Retorno: UResult (u_rc, u_cr, u_sym, mutual_info).
+/// Referências: Theil (1970).
+pub fn uncertainty_coefficient(table: &[f64; 256], nr: i32, nc: i32) -> UResult with Mut, Div, Panic {
+    if nr < 2 || nr > 16 || nc < 2 || nc > 16 {
+        return UResult { u_rc: 0.0, u_cr: 0.0, u_sym: 0.0, mutual_info: 0.0 }
+    }
+    var total = 0.0
+    var rowm: [f64; 16] = [0.0; 16]
+    var colm: [f64; 16] = [0.0; 16]
+    var i = 0
+    while i < nr {
+        var j = 0
+        while j < nc {
+            let v = table[(i * nc + j) as usize]
+            total = total + v
+            rowm[i as usize] = rowm[i as usize] + v
+            colm[j as usize] = colm[j as usize] + v
+            j = j + 1
+        }
+        i = i + 1
+    }
+    if total <= 0.0 { return UResult { u_rc: 0.0, u_cr: 0.0, u_sym: 0.0, mutual_info: 0.0 } }
+    // entropies of the marginals
+    var hr = 0.0
+    var a = 0
+    while a < nr {
+        let p = rowm[a as usize] / total
+        if p > 0.0 { hr = hr - p * uc_ln(p) }
+        a = a + 1
+    }
+    var hc = 0.0
+    var b = 0
+    while b < nc {
+        let p = colm[b as usize] / total
+        if p > 0.0 { hc = hc - p * uc_ln(p) }
+        b = b + 1
+    }
+    // mutual information
+    var mi = 0.0
+    var r = 0
+    while r < nr {
+        var c = 0
+        while c < nc {
+            let v = table[(r * nc + c) as usize]
+            if v > 0.0 {
+                let p = v / total
+                let pr = rowm[r as usize] / total
+                let pcl = colm[c as usize] / total
+                mi = mi + p * uc_ln(p / (pr * pcl))
+            }
+            c = c + 1
+        }
+        r = r + 1
+    }
+    var urc = 0.0
+    if hr > 1.0e-300 { urc = mi / hr }
+    var ucr = 0.0
+    if hc > 1.0e-300 { ucr = mi / hc }
+    var usym = 0.0
+    if hr + hc > 1.0e-300 { usym = 2.0 * mi / (hr + hc) }
+    return UResult { u_rc: urc, u_cr: ucr, u_sym: usym, mutual_info: mi }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// [[40,10],[5,45]]: H(R)=ln2=0.693147; I=0.275396; U(R|C)=0.275396/0.693147=0.397313.
+fn test_u() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=40.0; t[1]=10.0
+    t[2]=5.0;  t[3]=45.0
+    let r = uncertainty_coefficient(&t, 2, 2)
+    var ok = true
+    ok = check(1, approx(r.mutual_info, 0.275396, 1.0e-4)) && ok
+    ok = check(2, approx(r.u_rc, 0.397313, 1.0e-4)) && ok
+    return ok
+}
+
+// independence (rank-1 table) -> I ≈ 0, U ≈ 0.
+fn test_independent() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=10.0; t[1]=20.0
+    t[2]=20.0; t[3]=40.0
+    let r = uncertainty_coefficient(&t, 2, 2)
+    return check(10, approx(r.u_rc, 0.0, 1.0e-6))
+}
+
+// perfect association (diagonal) -> U = 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=50.0; t[1]=0.0
+    t[2]=0.0;  t[3]=50.0
+    let r = uncertainty_coefficient(&t, 2, 2)
+    var ok = true
+    ok = check(20, approx(r.u_rc, 1.0, 1.0e-6)) && ok
+    ok = check(21, approx(r.u_sym, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_u() && ok
+    ok = test_independent() && ok
+    ok = test_perfect() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three nominal contingency-table association measures, bringing the runner to **112 modules**. These complement `chi2_independence` (which gives Cramér's V) with the proportional-reduction-in-error and information-theoretic families. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::gk_lambda` | Goodman-Kruskal λ — PRE from mode prediction |
| `stats::gk_tau` | Goodman-Kruskal τ — PRE from proportional prediction |
| `stats::uncertainty_coefficient` | Theil's U — entropy fraction explained (mutual information) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples (all on the [[40,10],[5,45]] table):
  - λ: λ(R|C)=0.7, λ(C|R)=0.667; a mode-only table → 0; diagonal → 1.
  - τ: τ(R|C)=0.4949; a rank-1 (independent) table → 0; diagonal → 1.
  - U: I=0.2754 nats, U(R|C)=0.3973; independence → 0; diagonal → 1.
- Full suite selftest: **112 modules + 7 demos ALL GREEN** under `lean_single`.

Each measure captures a different notion of "association": λ (can you predict the mode?), τ (proportional prediction), U (information shared) — where χ² only tests independence and Cramér's V gives a single symmetric magnitude.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).