### PR TITLE
feat(stats): EDF normality tests & Bowker symmetry — anderson_darling, cramer_von_mises, bowker

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2975,3 +2975,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - uncertainty_coefficient = **PASS**: H(R), I(R;C), U(R|C)=I/H(R); I=0.2754, U=0.3973 verified, independence→0, diagonal→1.
 - Theme: nominal association / PRE & entropy measures — complements chi2_independence (Cramér's V) for contingency tables. All derivable, #852-safe. Suite runner: 112 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-rFk7TQ/`, `/tmp/llm-offload-nnqkco/`, `/tmp/llm-offload-wl6Rgd/`.
+
+## 2026-07-15 — math-review: stats::anderson_darling, stats::cramer_von_mises, stats::bowker
+- Files (all new): `stdlib/stats/anderson_darling.sio` (A-D normality, tail-weighted EDF test + Stephens p), `stdlib/stats/cramer_von_mises.sio` (CvM normality, evenly-weighted EDF), `stdlib/stats/bowker.sio` (Bowker k×k symmetry test, generalizes McNemar). Provider: xAI/Grok 4.3.
+- anderson_darling = **PASS**: A²=−n−(1/n)Σ(2i−1)[ln F_i+ln(1−F_{n+1−i})], A²*=A²(1+0.75/n+2.25/n²), Stephens 4-piece p; {1..5}→A²=0.1436 (Python-cross-checked), p>0.5.
+- cramer_von_mises = **PASS**: W²=1/(12n)+Σ(F_i−(2i−1)/(2n))²; {1..5}→W²=0.01934 (Python-cross-checked).
+- bowker = **PASS**: χ²=Σ_{i<j}(nᵢⱼ−nⱼᵢ)²/(nᵢⱼ+nⱼᵢ), df=k(k−1)/2, k=2 → McNemar; 3×3→χ²=4.667, reduction→4.545 verified.
+- Theme: EDF normality tests (A-D, CvM — more tail-sensitive than the existing KS) + Bowker matched-table symmetry (beyond 2×2 McNemar). AD/CvM reference constants cross-checked with Python (verification, not retrofit — the formulas are explicit). All derivable, #852-safe. Suite runner: 115 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-rzwVOv/`, `/tmp/llm-offload-rJWBlD/`, `/tmp/llm-offload-iLeZZI/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -121,6 +121,9 @@ MODULES=(
   stdlib/stats/gk_lambda.sio
   stdlib/stats/gk_tau.sio
   stdlib/stats/uncertainty_coefficient.sio
+  stdlib/stats/anderson_darling.sio
+  stdlib/stats/cramer_von_mises.sio
+  stdlib/stats/bowker.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -15,7 +15,8 @@ fourteen families:
   kurtosis); plus the robust median / IQR / MAD / trimmed & Winsorized means,
   the Hodges-Lehmann estimators, and Tukey / Grubbs / modified-z outlier rules.
 - **Assumption checks** — normality (Jarque-Bera, Q-Q, Kolmogorov-Smirnov,
-  χ²/G goodness-of-fit), independence (Wald-Wolfowitz runs, Durbin-Watson,
+  Anderson-Darling, Cramér-von Mises, χ²/G goodness-of-fit), independence
+  (Wald-Wolfowitz runs, Durbin-Watson,
   autocorrelation + Ljung-Box) and homoscedasticity (Bartlett, Levene /
   Brown-Forsythe, the variance F-test).
 - **Group comparison & planning** — one-way ANOVA, inference from summary
@@ -31,8 +32,9 @@ fourteen families:
   Deming / Theil-Sen / Passing-Bablok method-comparison fits, and the regression
   diagnostics (leverage, Cook's distance, VIF).
 - **Categorical & exact** — χ² independence, Fisher's exact 2×2, McNemar,
-  Cochran's Q, the Cochran-Armitage trend test, proportion CIs, and the nominal
-  association measures (Goodman-Kruskal λ and τ, Theil's uncertainty coefficient).
+  Cochran's Q, Bowker's k×k symmetry test, the Cochran-Armitage trend test,
+  proportion CIs, and the nominal association measures (Goodman-Kruskal λ and τ,
+  Theil's uncertainty coefficient).
 - **Agreement & reliability** — Bland-Altman, Lin's CCC + Cliff's δ, Cohen's and
   Fleiss' κ, Gwet's AC1, Krippendorff's α, ICC / Cronbach's α and the full
   Shrout-Fleiss ICC family.
@@ -1497,6 +1499,37 @@ of one variable's entropy explained by the other, both directions and symmetric.
 Validated: [[40,10],[5,45]] → I=0.2754, U(R|C)=0.3973; independence → 0; diagonal
 → 1.
 
+### `stats::anderson_darling` — Anderson-Darling normality test
+
+| Function | Signature |
+|---|---|
+| `anderson_darling` | `pub fn anderson_darling(x: &[f64; 256], n: i32) -> ADResult with Mut, Div, Panic` |
+
+An EDF normality test that weights the tails heavily (more tail-sensitive than
+KS): `A²=−n−(1/n)Σ(2i−1)[ln F(z₍ᵢ₎)+ln(1−F(z₍ₙ₊₁₋ᵢ₎))]`, with the small-sample
+adjustment and the Stephens p-value. Validated (Python-cross-checked): {1..5} →
+A²=0.1436, A²*=0.1781, p>0.5; skewed data → large A².
+
+### `stats::cramer_von_mises` — Cramér-von Mises normality test
+
+| Function | Signature |
+|---|---|
+| `cramer_von_mises` | `pub fn cramer_von_mises(x: &[f64; 256], n: i32) -> CvMResult with Mut, Div, Panic` |
+
+The evenly-weighted EDF companion to Anderson-Darling:
+`W²=1/(12n)+Σ(F(z₍ᵢ₎)−(2i−1)/(2n))²` with the small-sample adjustment. Validated
+(Python-cross-checked): {1..5} → W²=0.01934, W²*=0.02128; skewed data → large W².
+
+### `stats::bowker` — Bowker's test of symmetry
+
+| Function | Signature |
+|---|---|
+| `bowker` | `pub fn bowker(table: &[f64; 256], k: i32) -> BowkerResult with Mut, Div, Panic` |
+
+McNemar's test generalised to a k×k matched table:
+`χ²=Σ_{i<j}(nᵢⱼ−nⱼᵢ)²/(nᵢⱼ+nⱼᵢ)`, df k(k−1)/2. Validated: a 3×3 table → χ²=4.667,
+df=3; symmetric → χ²=0; k=2 reduces exactly to McNemar (χ²=4.545).
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1613,6 +1646,9 @@ use stats::shape::{ShapeResult, shape}
 use stats::gk_lambda::{LambdaResult, gk_lambda}
 use stats::gk_tau::{TauResult, gk_tau}
 use stats::uncertainty_coefficient::{UResult, uncertainty_coefficient}
+use stats::anderson_darling::{ADResult, anderson_darling}
+use stats::cramer_von_mises::{CvMResult, cramer_von_mises}
+use stats::bowker::{BowkerResult, bowker}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/anderson_darling.sio
+++ b/stdlib/stats/anderson_darling.sio
@@ -1,0 +1,191 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/anderson_darling.sio — Anderson-Darling normality test
+//
+// An empirical-distribution-function test of normality that weights the tails
+// heavily, so it is more sensitive than Kolmogorov-Smirnov to departures where
+// they matter most:
+//
+//   anderson_darling(x, n) -> ADResult
+//
+//   A² = −n − (1/n) Σ_{i=1}^n (2i−1)[ ln F(z_(i)) + ln(1 − F(z_(n+1−i))) ],
+// with z standardised by the sample mean and sd and F = Φ; the small-sample
+// adjustment is A²* = A²(1 + 0.75/n + 2.25/n²), with the Stephens p-value.
+//
+// Pure Sounio: inline erf/exp/ln/sqrt and an insertion sort. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Anderson & Darling (1954); D'Agostino & Stephens (1986) "Goodness-of-Fit
+//   Techniques".
+
+module stats::anderson_darling
+
+fn ad_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / ad_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn ad_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 - 700.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn ad_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn ad_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * ad_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn ad_normal_cdf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 + ad_erf(z * INV_SQRT2))
+}
+
+pub struct ADResult {
+    pub a2: f64,       // Anderson-Darling A²
+    pub a2_star: f64,  // small-sample adjusted A²*
+    pub p: f64,        // p-value (Stephens)
+}
+
+/// Anderson-Darling test of normality.
+///
+/// Parâmetros: x — sample; n — size (>=3, <=256).
+/// Retorno: ADResult (a2, a2_star, p).
+/// Referências: Anderson & Darling (1954); D'Agostino & Stephens (1986).
+pub fn anderson_darling(x: &[f64; 256], n: i32) -> ADResult with Mut, Div, Panic {
+    if n < 3 { return ADResult { a2: 0.0, a2_star: 0.0, p: 1.0 } }
+    let nf = n as f64
+    // mean and sample sd
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mean = s / nf
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; ss = ss + d * d; j = j + 1 }
+    let sd = ad_sqrt(ss / (nf - 1.0))
+    if sd <= 0.0 { return ADResult { a2: 0.0, a2_star: 0.0, p: 1.0 } }
+    // sorted standardized CDF values F_i
+    var f: [f64; 256] = [0.0; 256]
+    var a = 0
+    while a < n { f[a as usize] = x[a as usize]; a = a + 1 }
+    // insertion sort
+    var p = 1
+    while p < n {
+        let key = f[p as usize]
+        var q = p - 1
+        while q >= 0 && f[q as usize] > key { f[(q + 1) as usize] = f[q as usize]; q = q - 1 }
+        f[(q + 1) as usize] = key
+        p = p + 1
+    }
+    var t = 0
+    while t < n { f[t as usize] = ad_normal_cdf((f[t as usize] - mean) / sd); t = t + 1 }
+    // A² sum
+    var acc = 0.0
+    var k = 0
+    while k < n {
+        let fi = f[k as usize]
+        let frev = f[(n - 1 - k) as usize]
+        acc = acc + ((2 * (k + 1) - 1) as f64) * (ad_ln(fi) + ad_ln(1.0 - frev))
+        k = k + 1
+    }
+    let a2 = 0.0 - nf - acc / nf
+    let a2s = a2 * (1.0 + 0.75 / nf + 2.25 / (nf * nf))
+    // Stephens p-value from A²*
+    var pv = 0.0
+    if a2s < 0.2 { pv = 1.0 - ad_exp(0.0 - 13.436 + 101.14 * a2s - 223.73 * a2s * a2s) }
+    else { if a2s < 0.34 { pv = 1.0 - ad_exp(0.0 - 8.318 + 42.796 * a2s - 59.938 * a2s * a2s) }
+    else { if a2s < 0.6 { pv = ad_exp(0.9177 - 4.279 * a2s - 1.38 * a2s * a2s) }
+    else { pv = ad_exp(1.2937 - 5.709 * a2s + 0.0186 * a2s * a2s) } } }
+    if pv < 0.0 { pv = 0.0 }
+    if pv > 1.0 { pv = 1.0 }
+    return ADResult { a2: a2, a2_star: a2s, p: pv }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {1,2,3,4,5}: mean 3, sd=√2.5. A²=0.143594, A²*=0.178057 (Python-verified);
+// small A²* -> p large (no evidence against normality for n=5).
+fn test_ad() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = anderson_darling(&x, 5)
+    var ok = true
+    ok = check(1, approx(r.a2, 0.143594, 1.0e-3)) && ok
+    ok = check(2, approx(r.a2_star, 0.178057, 1.0e-3)) && ok
+    ok = check(3, r.p > 0.5) && ok
+    return ok
+}
+
+// strongly skewed data -> large A², small p.
+fn test_skewed() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=1.0; x[2]=1.0; x[3]=1.0; x[4]=1.0; x[5]=1.0; x[6]=1.0; x[7]=100.0
+    let r = anderson_darling(&x, 8)
+    return check(10, r.a2 > 1.0)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_ad() && ok
+    ok = test_skewed() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/bowker.sio
+++ b/stdlib/stats/bowker.sio
@@ -1,0 +1,227 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/bowker.sio — Bowker's test of symmetry
+//
+// The generalisation of McNemar's test to a k×k matched table: it tests whether
+// the off-diagonal cell counts are symmetric (nᵢⱼ = nⱼᵢ), i.e. whether category
+// changes are as likely in one direction as the other:
+//
+//   bowker(table, k) -> BowkerResult      (k×k matched-pair counts)
+//
+//   χ² = Σ_{i<j} (nᵢⱼ − nⱼᵢ)² / (nᵢⱼ + nⱼᵢ),   df = k(k−1)/2.
+// For k = 2 this reduces exactly to McNemar's test.
+//
+// Pure Sounio: an off-diagonal pair scan; χ² tail via inline Lanczos log-gamma +
+// incomplete gamma. No external dependency, no nested data-array calls.
+//
+// References:
+//   Bowker (1948) JASA 43:572.
+
+module stats::bowker
+
+fn bw_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / bw_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn bw_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn bw_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * bw_ln(tt) - tt + bw_ln(a)
+}
+
+fn bw_igamma_p(s: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x < s + 1.0 {
+        var ap = s
+        var sum = 1.0 / s
+        var del = sum
+        var n = 0
+        while n < 300 {
+            ap = ap + 1.0
+            del = del * x / ap
+            sum = sum + del
+            let ad = if del < 0.0 { 0.0 - del } else { del }
+            let asum = if sum < 0.0 { 0.0 - sum } else { sum }
+            if ad < asum * 1.0e-15 { n = 300 } else { n = n + 1 }
+        }
+        return sum * bw_exp(0.0 - x + s * bw_ln(x) - bw_lgamma(s))
+    }
+    var b = x + 1.0 - s
+    var c = 1.0e300
+    var d = 1.0 / b
+    var h = d
+    var i = 1
+    while i < 300 {
+        let an = 0.0 - (i as f64) * ((i as f64) - s)
+        b = b + 2.0
+        d = an * d + b
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = b + an / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-15 { i = 300 } else { i = i + 1 }
+    }
+    let q = bw_exp(0.0 - x + s * bw_ln(x) - bw_lgamma(s)) * h
+    return 1.0 - q
+}
+
+fn bw_chi2_sf(x: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 1.0 }
+    if df <= 0.0 { return 1.0 }
+    return 1.0 - bw_igamma_p(df * 0.5, x * 0.5)
+}
+
+pub struct BowkerResult {
+    pub chi2: f64,
+    pub df: i64,      // k(k-1)/2
+    pub p: f64,
+}
+
+/// Bowker's test of symmetry for a k×k matched table.
+///
+/// Parâmetros: table — row-major k×k matched-pair counts; k — categories (2..16).
+/// Retorno: BowkerResult (chi2, df, p).
+/// Referências: Bowker (1948).
+pub fn bowker(table: &[f64; 256], k: i32) -> BowkerResult with Mut, Div, Panic {
+    if k < 2 || k > 16 { return BowkerResult { chi2: 0.0, df: 0, p: 1.0 } }
+    var chi2 = 0.0
+    var i = 0
+    while i < k {
+        var j = i + 1
+        while j < k {
+            let nij = table[(i * k + j) as usize]
+            let nji = table[(j * k + i) as usize]
+            let sum = nij + nji
+            if sum > 0.0 {
+                let diff = nij - nji
+                chi2 = chi2 + diff * diff / sum
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let df = k * (k - 1) / 2
+    let p = bw_chi2_sf(chi2, df as f64)
+    return BowkerResult { chi2: chi2, df: df as i64, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 3×3 table, off-diagonal pairs: (n01,n10)=(10,20), (n02,n20)=(5,5), (n12,n21)=(8,4).
+// χ² = (10-20)²/30 + 0 + (8-4)²/12 = 100/30 + 16/12 = 3.333333+1.333333 = 4.666667.
+// df = 3.
+fn test_bowker() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=50.0; t[1]=10.0; t[2]=5.0
+    t[3]=20.0; t[4]=60.0; t[5]=8.0
+    t[6]=5.0;  t[7]=4.0;  t[8]=70.0
+    let r = bowker(&t, 3)
+    var ok = true
+    ok = check(1, approx(r.chi2, 4.666667, 1.0e-5)) && ok
+    ok = check(2, r.df == 3) && ok
+    return ok
+}
+
+// symmetric table -> χ² = 0.
+fn test_symmetric() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=50.0; t[1]=10.0; t[2]=5.0
+    t[3]=10.0; t[4]=60.0; t[5]=8.0
+    t[6]=5.0;  t[7]=8.0;  t[8]=70.0
+    let r = bowker(&t, 3)
+    var ok = true
+    ok = check(10, approx(r.chi2, 0.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.p, 1.0, 1.0e-6)) && ok
+    return ok
+}
+
+// k=2 reduces to McNemar: (n01-n10)²/(n01+n10). [[30,6],[16,48]] -> (6-16)²/22=4.545455.
+fn test_mcnemar_reduction() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    t[0]=30.0; t[1]=6.0
+    t[2]=16.0; t[3]=48.0
+    let r = bowker(&t, 2)
+    var ok = true
+    ok = check(20, approx(r.chi2, 4.545455, 1.0e-5)) && ok
+    ok = check(21, r.df == 1) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_bowker() && ok
+    ok = test_symmetric() && ok
+    ok = test_mcnemar_reduction() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/cramer_von_mises.sio
+++ b/stdlib/stats/cramer_von_mises.sio
@@ -1,0 +1,158 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/cramer_von_mises.sio — Cramér-von Mises normality test
+//
+// An empirical-distribution-function test of normality using the integrated
+// squared gap between the empirical and fitted CDF — the evenly-weighted
+// companion to Anderson-Darling (which weights the tails):
+//
+//   cramer_von_mises(x, n) -> CvMResult
+//
+//   W² = 1/(12n) + Σ_{i=1}^n ( F(z_(i)) − (2i−1)/(2n) )²,
+// with z standardised by the sample mean and sd and F = Φ; the small-sample
+// adjustment is W²* = W²(1 + 0.5/n).
+//
+// Pure Sounio: inline erf/exp/sqrt and an insertion sort. No external
+// dependency, no nested data-array calls.
+//
+// References:
+//   Cramér (1928); von Mises (1931); D'Agostino & Stephens (1986).
+
+module stats::cramer_von_mises
+
+fn cm_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / cm_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn cm_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn cm_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * cm_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn cm_normal_cdf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 + cm_erf(z * INV_SQRT2))
+}
+
+pub struct CvMResult {
+    pub w2: f64,       // Cramér-von Mises W²
+    pub w2_star: f64,  // small-sample adjusted W²*
+}
+
+/// Cramér-von Mises test of normality.
+///
+/// Parâmetros: x — sample; n — size (>=3, <=256).
+/// Retorno: CvMResult (w2, w2_star).
+/// Referências: Cramér (1928); von Mises (1931).
+pub fn cramer_von_mises(x: &[f64; 256], n: i32) -> CvMResult with Mut, Div, Panic {
+    if n < 3 { return CvMResult { w2: 0.0, w2_star: 0.0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mean = s / nf
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; ss = ss + d * d; j = j + 1 }
+    let sd = cm_sqrt(ss / (nf - 1.0))
+    if sd <= 0.0 { return CvMResult { w2: 0.0, w2_star: 0.0 } }
+    var f: [f64; 256] = [0.0; 256]
+    var a = 0
+    while a < n { f[a as usize] = x[a as usize]; a = a + 1 }
+    var p = 1
+    while p < n {
+        let key = f[p as usize]
+        var q = p - 1
+        while q >= 0 && f[q as usize] > key { f[(q + 1) as usize] = f[q as usize]; q = q - 1 }
+        f[(q + 1) as usize] = key
+        p = p + 1
+    }
+    var acc = 0.0
+    var k = 0
+    while k < n {
+        let fi = cm_normal_cdf((f[k as usize] - mean) / sd)
+        let target = ((2 * (k + 1) - 1) as f64) / (2.0 * nf)
+        let d = fi - target
+        acc = acc + d * d
+        k = k + 1
+    }
+    let w2 = 1.0 / (12.0 * nf) + acc
+    let w2s = w2 * (1.0 + 0.5 / nf)
+    return CvMResult { w2: w2, w2_star: w2s }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {1,2,3,4,5}: W²=0.019342 (Python-verified). W²*=W²(1+0.5/5)=W²·1.1.
+fn test_cvm() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = cramer_von_mises(&x, 5)
+    var ok = true
+    ok = check(1, approx(r.w2, 0.019342, 1.0e-4)) && ok
+    ok = check(2, approx(r.w2_star, 0.021276, 1.0e-4)) && ok
+    return ok
+}
+
+// skewed data -> larger W².
+fn test_skewed() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=1.0; x[2]=1.0; x[3]=1.0; x[4]=1.0; x[5]=1.0; x[6]=1.0; x[7]=100.0
+    let r = cramer_von_mises(&x, 8)
+    return check(10, r.w2 > 0.1)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_cvm() && ok
+    ok = test_skewed() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three modules bringing the runner to **115 modules**: two empirical-distribution-function (EDF) normality tests that are more tail-sensitive than the existing KS test, and the k×k generalisation of McNemar. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::anderson_darling` | A-D normality test (tail-weighted EDF) + Stephens p-value |
| `stats::cramer_von_mises` | CvM normality test (evenly-weighted EDF) |
| `stats::bowker` | Bowker's k×k symmetry test (generalises McNemar) |

## Validation

- Inline `//@ run-pass` tests against hand-computed / cross-checked examples:
  - Anderson-Darling: {1,2,3,4,5} → A²=0.1436, A²*=0.1781, p>0.5; skewed → large A². **The A² value was cross-checked against a Python computation** (verification of the explicit formula, not a retrofitted constant).
  - Cramér-von Mises: {1,2,3,4,5} → W²=0.01934 (also Python-cross-checked); skewed → large W².
  - Bowker: a 3×3 table → χ²=4.667, df=3; symmetric → χ²=0; **k=2 reduces exactly to McNemar** (χ²=4.545, df=1).
- Full suite selftest: **115 modules + 7 demos ALL GREEN** under `lean_single`.

The normality battery is now complete: Q-Q (visual) · Jarque-Bera (moments) · KS (supremum) · **Anderson-Darling (tail-weighted EDF)** · **Cramér-von Mises (evenly-weighted EDF)**.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).