### PR TITLE
test(stdlib): deepen chemistry equilibrium/kinetics + signal fft verticals

### DIFF
--- a/scripts/verticals_deepen5_gate.sh
+++ b/scripts/verticals_deepen5_gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Deepen-batch 5: extend coverage of already-shipped verticals with untested public API.
+# Multi-module drivers -> lean_single engine.
+#   chemistry::equilibrium — dG<->K (van 't Hoff), Nernst equation
+#   chemistry::kinetics    — Arrhenius rate law across regimes + GUM uncertainty
+#   signal::fft            — spectral content of known signals (DC, cosine), power, inverse
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel [softcheck]
+  echo "== $2 =="
+  if [ "${4:-}" = "softcheck" ]; then
+    # Standalone `souc check` on this module trips a pre-existing Madaros check-mode error
+    # (isolated method/type resolution; module unchanged from main and compiles fine inside the
+    # driver's dependency graph). The compile-and-run driver below is the authoritative proof.
+    $SOUC check "$1" >/dev/null 2>&1 || echo "NOTE: standalone check quirk on $1 (Madaros check-mode; driver proves the API)"
+  else
+    $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  fi
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/chemistry/equilibrium.sio  tests/stdlib/chemistry/test_equilibrium_deep_stdlib.sio  EQUILIBRIUM_DEEP_STDLIB_OK  softcheck
+run stdlib/chemistry/kinetics.sio      tests/stdlib/chemistry/test_kinetics_deep_stdlib.sio     KINETICS_DEEP_STDLIB_OK     softcheck
+run stdlib/signal/fft.sio              tests/stdlib/signal/test_fft_deep_stdlib.sio             FFT_DEEP_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_DEEPEN5_GATE_OK"
+exit $fail

--- a/tests/stdlib/chemistry/test_equilibrium_deep_stdlib.sio
+++ b/tests/stdlib/chemistry/test_equilibrium_deep_stdlib.sio
@@ -1,0 +1,26 @@
+// Deepened run-proof for stdlib chemistry::equilibrium — thermodynamic/electrochemical relations
+// exercised directly against first principles (the existing driver calls the module's own tests).
+// Functions return (value, uncertainty) tuples. lean_single engine.
+use chemistry::equilibrium::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // dG = 0 <=> K = 1
+    let (dg1, _u1) = delta_g_from_k(1.0, 0.0, 298.0, 0.0)
+    if ae(dg1, 0.0) >= 1.0e-6 { print("FAIL dg_k1\n"); return 1 }
+    // K = exp(-dG/RT): dG=-5000 J/mol, T=298 -> K = 7.5232
+    let (k, _uk) = k_from_delta_g(0.0 - 5000.0, 0.0, 298.0, 0.0)
+    if ae(k, 7.523207) >= 1.0e-3 { print("FAIL k_from_dg\n"); return 2 }
+    // round-trip dG(K(dG)) recovers -5000
+    let (dgb, _ub) = delta_g_from_k(k, 0.0, 298.0, 0.0)
+    if ae(dgb, 0.0 - 5000.0) >= 1.0e-1 { print("FAIL dg_roundtrip\n"); return 3 }
+    // Nernst: Q=1 -> E = E0
+    let (e0, _ue0) = nernst(1.1, 0.0, 2, 1.0, 0.0, 298.0, 0.0)
+    if ae(e0, 1.1) >= 1.0e-9 { print("FAIL nernst_q1\n"); return 4 }
+    // Nernst: Q=10, n=2, T=298 -> E = 1.1 - (RT/2F) ln 10 = 1.070428
+    let (eq, _ueq) = nernst(1.1, 0.0, 2, 10.0, 0.0, 298.0, 0.0)
+    if ae(eq, 1.070428) >= 1.0e-4 { print("FAIL nernst_q10\n"); return 5 }
+    // Nernst directionality: larger reaction quotient lowers the cell potential (n>0)
+    if eq >= e0 { print("FAIL nernst_dir\n"); return 6 }
+    print("EQUILIBRIUM_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/chemistry/test_kinetics_deep_stdlib.sio
+++ b/tests/stdlib/chemistry/test_kinetics_deep_stdlib.sio
@@ -1,0 +1,25 @@
+// Deepened run-proof for stdlib chemistry::kinetics — the Arrhenius rate law across regimes,
+// including its GUM uncertainty propagation, verified against k = A exp(-Ea/RT). lean_single engine.
+use chemistry::kinetics::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let rt = 8.314462618 * 300.0
+    // Ea = 0 -> k = A
+    let (k0, _u0) = arrhenius(1000.0, 0.0, 0.0, 0.0, 300.0, 0.0)
+    if ae(k0, 1000.0) >= 1.0e-6 { print("FAIL ea0\n"); return 1 }
+    // Ea = RT -> k = A e^{-1} ; Ea = 2RT -> A e^{-2}
+    let (k1, _u1) = arrhenius(1.0, 0.0, rt, 0.0, 300.0, 0.0)
+    if ae(k1, 0.36787944117) >= 1.0e-6 { print("FAIL ea_rt\n"); return 2 }
+    let (k2, _u2) = arrhenius(1.0, 0.0, 2.0 * rt, 0.0, 300.0, 0.0)
+    if ae(k2, 0.13533528324) >= 1.0e-6 { print("FAIL ea_2rt\n"); return 3 }
+    // Temperature dependence: for Ea>0, k increases with T
+    let (klo, _ul) = arrhenius(1.0, 0.0, 20000.0, 0.0, 300.0, 0.0)
+    let (khi, _uh) = arrhenius(1.0, 0.0, 20000.0, 0.0, 600.0, 0.0)
+    if khi <= klo { print("FAIL temp_dep\n"); return 4 }
+    // GUM: with only a 1% relative uncertainty in A (Ea=0), u_k = 0.01*k = 10 for k=1000
+    let (kA, uA) = arrhenius(1000.0, 10.0, 0.0, 0.0, 300.0, 0.0)
+    if ae(kA, 1000.0) >= 1.0e-6 { print("FAIL unc_k\n"); return 5 }
+    if ae(uA, 10.0) >= 1.0e-6 { print("FAIL unc_prop\n"); return 6 }
+    print("KINETICS_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/signal/test_fft_deep_stdlib.sio
+++ b/tests/stdlib/signal/test_fft_deep_stdlib.sio
@@ -1,0 +1,39 @@
+// Deepened run-proof for stdlib signal::fft — spectral content of known signals: DC -> bin 0,
+// a bin-1 cosine -> conjugate peaks at bins 1 and N-1 (magnitude N/2), power spectrum, and the
+// inverse round-trip. Extends test_fft_stdlib.sio. lean_single engine.
+use signal::fft::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // DC signal of 8 ones -> all spectral energy in bin 0: mag[0]=8, mag[1]=0, power[0]=64
+    var arr = ComplexArray { re: [0.0; 256], im: [0.0; 256], n: 0 }
+    var data: [f64; 256] = [0.0; 256]
+    var i: i64 = 0
+    while i < 8 { data[i as usize] = 1.0; i = i + 1 }
+    ca_load_real(&!arr, &data, 8)
+    fft_forward(&!arr)
+    var mag: [f64; 256] = [0.0; 256]
+    fft_magnitude(&arr, &!mag)
+    if ae(mag[0], 8.0) >= 1.0e-6 { print("FAIL dc_mag0\n"); return 1 }
+    if ae(mag[1], 0.0) >= 1.0e-6 { print("FAIL dc_mag1\n"); return 2 }
+    var pw: [f64; 256] = [0.0; 256]
+    fft_power(&arr, &!pw)
+    if ae(pw[0], 64.0) >= 1.0e-6 { print("FAIL dc_power\n"); return 3 }
+    // cos(2pi n/8) -> conjugate-symmetric peaks at bins 1 and 7, magnitude N/2 = 4 ; bin 2 = 0
+    var arr2 = ComplexArray { re: [0.0; 256], im: [0.0; 256], n: 0 }
+    var d2: [f64; 256] = [0.0; 256]
+    i = 0
+    while i < 8 { d2[i as usize] = fft_cos(2.0 * fft_pi() * (i as f64) / 8.0); i = i + 1 }
+    ca_load_real(&!arr2, &d2, 8)
+    fft_forward(&!arr2)
+    var mag2: [f64; 256] = [0.0; 256]
+    fft_magnitude(&arr2, &!mag2)
+    if ae(mag2[1], 4.0) >= 1.0e-5 { print("FAIL cos_bin1\n"); return 4 }
+    if ae(mag2[7], 4.0) >= 1.0e-5 { print("FAIL cos_bin7\n"); return 5 }
+    if ae(mag2[2], 0.0) >= 1.0e-5 { print("FAIL cos_bin2\n"); return 6 }
+    // inverse FFT recovers the original DC signal
+    fft_inverse(&!arr)
+    if ae(arr.re[0], 1.0) >= 1.0e-6 { print("FAIL inv0\n"); return 7 }
+    if ae(arr.re[3], 1.0) >= 1.0e-6 { print("FAIL inv3\n"); return 8 }
+    print("FFT_DEEP_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Deepen-batch 5 — first-principles depth on chemistry and DSP verticals

Continues the "deepen existing verticals" direction. The existing chemistry drivers only invoked the modules' **own** `test_*` self-tests; this adds run-proofs that call the public API directly and assert against textbook relations. FFT gains spectral-content coverage.

| Module | New coverage |
|---|---|
| `chemistry::equilibrium` | **van 't Hoff** `ΔG=−RT ln K` (`K=1→ΔG=0`, `ΔG=−5000→K=7.52`, round-trip) + **Nernst** `E=E0−(RT/nF)ln Q` (`Q=1→E0`, `Q=10,n=2→1.0704 < E0`) |
| `chemistry::kinetics` | **Arrhenius** `k=A·exp(−Ea/RT)` across regimes (`Ea=0→A`, `Ea=RT→A/e`, `Ea=2RT→A/e²`), temperature monotonicity, and **GUM propagation** (1% `u(A)` → `u_k=0.01k`) |
| `signal::fft` | spectral content of known signals — DC → bin 0 (`mag=N`, `power=N²`), unit cosine → conjugate peaks at bins 1 & N−1 (`mag N/2`), inverse round-trip |

### Verification
- `scripts/verticals_deepen5_gate.sh` → `VERTICALS_DEEPEN5_GATE_OK`.
- All claims audited by math-review (xai/grok): "All claims standard and correct."

### Notes
- Functions return `(value, uncertainty)` tuples; tuple returns work cross-module under `SOUNIO_SOUC_ENGINE=lean_single` (established path).
- Standalone `souc check` on both chemistry modules trips a **pre-existing** Madaros check-mode error (isolated method/type resolution; modules **unchanged from `main`** and compile fine inside the driver's dependency graph). The gate treats that check as informational and relies on compile-and-run as the proof (same handling as the complex/gum check-mode quirks; repo rule: `check` ≠ works).
- No `self-hosted/` or `bootstrap/` edits. New files only (3 drivers + 1 gate); stays mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)