### PR TITLE
feat(stats): data-transformation primitives — zscore, normalize, rank_transform

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2983,3 +2983,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - bowker = **PASS**: χ²=Σ_{i<j}(nᵢⱼ−nⱼᵢ)²/(nᵢⱼ+nⱼᵢ), df=k(k−1)/2, k=2 → McNemar; 3×3→χ²=4.667, reduction→4.545 verified.
 - Theme: EDF normality tests (A-D, CvM — more tail-sensitive than the existing KS) + Bowker matched-table symmetry (beyond 2×2 McNemar). AD/CvM reference constants cross-checked with Python (verification, not retrofit — the formulas are explicit). All derivable, #852-safe. Suite runner: 115 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-rzwVOv/`, `/tmp/llm-offload-rJWBlD/`, `/tmp/llm-offload-iLeZZI/`.
+
+## 2026-07-15 — math-review: stats::zscore, stats::normalize, stats::rank_transform
+- Files (all new): `stdlib/stats/zscore.sio` (standardization + percentile rank), `stdlib/stats/normalize.sio` (min-max & robust scaling), `stdlib/stats/rank_transform.sio` (mid-rank transform + tie correction). Provider: xAI/Grok 4.3. All use the out-array `&![f64;256]` fill pattern.
+- zscore = **PASS**: z=(x−mean)/s (÷(n−1) sd), Σz=0 property, mid-rank percentile (#<+½#=)/n·100; {2,4,4,4,5,5,7,9}→z₀=−1.403, prank(5)=62.5 verified.
+- normalize = **PASS**: min-max (x−min)/(max−min), robust (x−median)/IQR (type-7 quantiles); {1..5}→[0..1] and median-centred verified.
+- rank_transform = **PASS**: mid-rank less+(equal+1)/2, tie-group detection (first && equal>1) with Σ(t³−t); {3,1,4,1,5}→{3,1.5,4,1.5,5}, correction 6 verified.
+- Theme: data-transformation primitives — foundational preprocessing (feature scaling, rank transform) completing the descriptive layer. All derivable, #852-safe. Suite runner: 118 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-BIlCZ5/`, `/tmp/llm-offload-7CoTZR/`, `/tmp/llm-offload-Y2h33J/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -124,6 +124,9 @@ MODULES=(
   stdlib/stats/anderson_darling.sio
   stdlib/stats/cramer_von_mises.sio
   stdlib/stats/bowker.sio
+  stdlib/stats/zscore.sio
+  stdlib/stats/normalize.sio
+  stdlib/stats/rank_transform.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -13,7 +13,9 @@ fourteen families:
 - **Descriptives** — the classical means (arithmetic / geometric / harmonic /
   RMS), dispersion (variance / sd / range / CV / SEM), and shape (skewness /
   kurtosis); plus the robust median / IQR / MAD / trimmed & Winsorized means,
-  the Hodges-Lehmann estimators, and Tukey / Grubbs / modified-z outlier rules.
+  the Hodges-Lehmann estimators, Tukey / Grubbs / modified-z outlier rules, and
+  the data-transformation primitives (z-scores, min-max & robust scaling, rank
+  transform).
 - **Assumption checks** — normality (Jarque-Bera, Q-Q, Kolmogorov-Smirnov,
   Anderson-Darling, Cramér-von Mises, χ²/G goodness-of-fit), independence
   (Wald-Wolfowitz runs, Durbin-Watson,
@@ -1530,6 +1532,39 @@ McNemar's test generalised to a k×k matched table:
 `χ²=Σ_{i<j}(nᵢⱼ−nⱼᵢ)²/(nᵢⱼ+nⱼᵢ)`, df k(k−1)/2. Validated: a 3×3 table → χ²=4.667,
 df=3; symmetric → χ²=0; k=2 reduces exactly to McNemar (χ²=4.545).
 
+### `stats::zscore` — standardisation & percentile rank
+
+| Function | Signature |
+|---|---|
+| `zscore` | `pub fn zscore(x: &[f64; 256], n: i32, out_z: &![f64; 256]) -> ZResult with Mut, Div, Panic` |
+| `percentile_rank` | `pub fn percentile_rank(x: &[f64; 256], n: i32, value: f64) -> f64 with Mut, Div, Panic` |
+
+Standardise to zero mean / unit sd (fills `out_z`), and locate a value in the
+sample by its mid-rank percentile. Validated: {2,4,4,4,5,5,7,9} → z₀=−1.403,
+z₇=1.871, Σz=0; percentile rank of 5 → 62.5.
+
+### `stats::normalize` — feature scaling
+
+| Function | Signature |
+|---|---|
+| `minmax` | `pub fn minmax(x: &[f64; 256], n: i32, out: &![f64; 256]) -> MinMaxResult with Mut, Div, Panic` |
+| `robust_scale` | `pub fn robust_scale(x: &[f64; 256], n: i32, out: &![f64; 256]) -> RobustResult with Mut, Div, Panic` |
+
+The two non-standardising scalers: min-max to [0,1], and robust scaling by
+median & IQR (outlier-resistant). Validated: {1..5} → min-max {0,.25,.5,.75,1};
+robust → median 3, IQR 2, centred.
+
+### `stats::rank_transform` — rank transform with mid-ranks
+
+| Function | Signature |
+|---|---|
+| `rank_transform` | `pub fn rank_transform(x: &[f64; 256], n: i32, out_r: &![f64; 256]) -> RankResult with Mut, Div, Panic` |
+
+Replaces each value by its 1-based rank (ties → average), the primitive under
+every rank-based method, plus the tie-correction `Σ(tᵢ³−tᵢ)`. Validated:
+{3,1,4,1,5} → ranks {3,1.5,4,1.5,5}, one tie group, correction 6; distinct data →
+1..n.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1649,6 +1684,9 @@ use stats::uncertainty_coefficient::{UResult, uncertainty_coefficient}
 use stats::anderson_darling::{ADResult, anderson_darling}
 use stats::cramer_von_mises::{CvMResult, cramer_von_mises}
 use stats::bowker::{BowkerResult, bowker}
+use stats::zscore::{ZResult, zscore, percentile_rank}
+use stats::normalize::{MinMaxResult, RobustResult, minmax, robust_scale}
+use stats::rank_transform::{RankResult, rank_transform}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/normalize.sio
+++ b/stdlib/stats/normalize.sio
@@ -1,0 +1,154 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/normalize.sio — feature scaling
+//
+// Rescales data onto a common range — the two standard non-standardising
+// scalers:
+//
+//   minmax(x, n, out) -> MinMaxResult          (xᵢ − min)/(max − min) → [0,1]
+//   robust_scale(x, n, out) -> RobustResult    (xᵢ − median)/IQR
+//
+// Min-max is the usual [0,1] scaler; robust scaling centres on the median and
+// divides by the inter-quartile range, so a few outliers do not dominate.
+//
+// Pure Sounio: min/max in one pass; the median and IQR via an inline sort. No
+// external dependency, no nested data-array calls.
+//
+// References:
+//   standard feature-scaling definitions (e.g. scikit-learn MinMaxScaler,
+//   RobustScaler).
+
+module stats::normalize
+
+// type-7 quantile of a sorted [256] buffer.
+fn nz_quantile_sorted(s: &[f64; 256], n: i32, p: f64) -> f64 with Mut, Div, Panic {
+    if n == 1 { return s[0] }
+    let h = ((n - 1) as f64) * p
+    var lo = 0
+    while (lo as f64) + 1.0 <= h { lo = lo + 1 }
+    let frac = h - (lo as f64)
+    if lo >= n - 1 { return s[(n - 1) as usize] }
+    return s[lo as usize] + frac * (s[(lo + 1) as usize] - s[lo as usize])
+}
+
+pub struct MinMaxResult {
+    pub min: f64,
+    pub max: f64,
+}
+
+pub struct RobustResult {
+    pub median: f64,
+    pub iqr: f64,
+}
+
+/// Min-max scale x onto [0,1]; fills out[0..n).
+pub fn minmax(x: &[f64; 256], n: i32, out: &![f64; 256]) -> MinMaxResult with Mut, Div, Panic {
+    if n < 1 { return MinMaxResult { min: 0.0, max: 0.0 } }
+    var mn = x[0]
+    var mx = x[0]
+    var i = 0
+    while i < n {
+        let v = x[i as usize]
+        if v < mn { mn = v }
+        if v > mx { mx = v }
+        i = i + 1
+    }
+    let rng = mx - mn
+    var k = 0
+    while k < n {
+        var s = 0.0
+        if rng > 1.0e-300 { s = (x[k as usize] - mn) / rng }
+        out[k as usize] = s
+        k = k + 1
+    }
+    return MinMaxResult { min: mn, max: mx }
+}
+
+/// Robust-scale x by median and IQR; fills out[0..n).
+pub fn robust_scale(x: &[f64; 256], n: i32, out: &![f64; 256]) -> RobustResult with Mut, Div, Panic {
+    if n < 2 { return RobustResult { median: 0.0, iqr: 0.0 } }
+    var buf: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < n { buf[i as usize] = x[i as usize]; i = i + 1 }
+    // insertion sort
+    var p = 1
+    while p < n {
+        let key = buf[p as usize]
+        var q = p - 1
+        while q >= 0 && buf[q as usize] > key { buf[(q + 1) as usize] = buf[q as usize]; q = q - 1 }
+        buf[(q + 1) as usize] = key
+        p = p + 1
+    }
+    let med = nz_quantile_sorted(&buf, n, 0.5)
+    let q1 = nz_quantile_sorted(&buf, n, 0.25)
+    let q3 = nz_quantile_sorted(&buf, n, 0.75)
+    let iqr = q3 - q1
+    var k = 0
+    while k < n {
+        var s = 0.0
+        if iqr > 1.0e-300 { s = (x[k as usize] - med) / iqr }
+        out[k as usize] = s
+        k = k + 1
+    }
+    return RobustResult { median: med, iqr: iqr }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {1,2,3,4,5}: min1 max5. out=(0,0.25,0.5,0.75,1).
+fn test_minmax() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var o: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = minmax(&x, 5, &!o)
+    var ok = true
+    ok = check(1, approx(r.min, 1.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.max, 5.0, 1.0e-9)) && ok
+    ok = check(3, approx(o[0], 0.0, 1.0e-9)) && ok
+    ok = check(4, approx(o[2], 0.5, 1.0e-9)) && ok
+    ok = check(5, approx(o[4], 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// robust: {1,2,3,4,5}: median 3, Q1=2, Q3=4, IQR=2. out=(x-3)/2 -> centre 0.
+fn test_robust() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var o: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = robust_scale(&x, 5, &!o)
+    var ok = true
+    ok = check(10, approx(r.median, 3.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.iqr, 2.0, 1.0e-9)) && ok
+    ok = check(12, approx(o[2], 0.0, 1.0e-9)) && ok       // median maps to 0
+    ok = check(13, approx(o[0], 0.0 - 1.0, 1.0e-9)) && ok // (1-3)/2 = -1
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_minmax() && ok
+    ok = test_robust() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/rank_transform.sio
+++ b/stdlib/stats/rank_transform.sio
@@ -1,0 +1,123 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/rank_transform.sio — rank transform with mid-ranks
+//
+// Replaces each value by its rank in the sample (ties → average rank) — the
+// transform underlying every rank-based method (Spearman, Wilcoxon, Kruskal-
+// Wallis), exposed as a reusable primitive:
+//
+//   rank_transform(x, n, out_r) -> RankResult
+//
+// rank_i = less_i + (equal_i + 1)/2, where less/equal count values strictly
+// below / equal to xᵢ; ranks are 1-based and tied values share their mean rank.
+//
+// Pure Sounio: an O(n²) less/equal count per element; a tie-block scan for the
+// tie-correction sum. No external dependency, no nested data-array calls.
+//
+// References:
+//   Conover, "Practical Nonparametric Statistics" 3e.
+
+module stats::rank_transform
+
+pub struct RankResult {
+    pub n_ties: i64,       // number of tied groups (size > 1)
+    pub tie_correction: f64, // Σ(tᵢ³ − tᵢ) over tied groups (for rank-test variance)
+}
+
+/// Rank-transform x with mid-ranks; fills out_r[0..n) with 1-based ranks.
+///
+/// Parâmetros: x — data; n — size (>=1, <=256); out_r — receives the ranks.
+/// Retorno: RankResult (n_ties, tie_correction Σ(t³−t)).
+/// Referências: Conover.
+pub fn rank_transform(x: &[f64; 256], n: i32, out_r: &![f64; 256]) -> RankResult with Mut, Div, Panic {
+    if n < 1 { return RankResult { n_ties: 0, tie_correction: 0.0 } }
+    var tie_sum = 0.0
+    var ntie = 0
+    var i = 0
+    while i < n {
+        var less = 0
+        var equal = 0
+        var first = true
+        var j = 0
+        while j < n {
+            let vj = x[j as usize]
+            let vi = x[i as usize]
+            if vj < vi { less = less + 1 }
+            else { if vj == vi { equal = equal + 1; if j < i { first = false } } }
+            j = j + 1
+        }
+        out_r[i as usize] = (less as f64) + ((equal + 1) as f64) * 0.5
+        if first && equal > 1 {
+            let t = equal as f64
+            tie_sum = tie_sum + (t * t * t - t)
+            ntie = ntie + 1
+        }
+        i = i + 1
+    }
+    return RankResult { n_ties: ntie as i64, tie_correction: tie_sum }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {3,1,4,1,5}: sorted 1,1,3,4,5. value 1 (positions 1,2) -> mid-rank 1.5; 3->3;
+// 4->4; 5->5. So x -> {3, 1.5, 4, 1.5, 5}. one tied group of size 2 -> Σ(t³-t)=6.
+fn test_rank() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var r: [f64; 256] = [0.0; 256]
+    x[0]=3.0; x[1]=1.0; x[2]=4.0; x[3]=1.0; x[4]=5.0
+    let res = rank_transform(&x, 5, &!r)
+    var ok = true
+    ok = check(1, approx(r[0], 3.0, 1.0e-9)) && ok
+    ok = check(2, approx(r[1], 1.5, 1.0e-9)) && ok
+    ok = check(3, approx(r[3], 1.5, 1.0e-9)) && ok
+    ok = check(4, approx(r[4], 5.0, 1.0e-9)) && ok
+    ok = check(5, res.n_ties == 1) && ok
+    ok = check(6, approx(res.tie_correction, 6.0, 1.0e-9)) && ok
+    return ok
+}
+
+// distinct data -> ranks 1..n, sum = n(n+1)/2.
+fn test_distinct() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var r: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=30.0; x[2]=20.0; x[3]=40.0
+    let res = rank_transform(&x, 4, &!r)
+    var s = 0.0
+    var i = 0
+    while i < 4 { s = s + r[i as usize]; i = i + 1 }
+    var ok = true
+    ok = check(10, approx(r[0], 1.0, 1.0e-9)) && ok      // 10 is smallest
+    ok = check(11, approx(r[3], 4.0, 1.0e-9)) && ok      // 40 is largest
+    ok = check(12, approx(s, 10.0, 1.0e-9)) && ok        // 1+2+3+4
+    ok = check(13, res.n_ties == 0) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_rank() && ok
+    ok = test_distinct() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/zscore.sio
+++ b/stdlib/stats/zscore.sio
@@ -1,0 +1,142 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/zscore.sio — standardisation (z-scores) & percentile rank
+//
+// Centres and scales data to zero mean and unit sd, and locates a value in the
+// sample — the basic feature-scaling and positioning primitives:
+//
+//   zscore(x, n, out_z) -> ZResult                 zᵢ = (xᵢ − x̄)/s
+//   percentile_rank(x, n, value) -> f64            (#< + ½·#=)/n · 100
+//
+// The z-scores use the sample sd (÷(n−1)); the percentile rank uses the mid-rank
+// convention so ties are split evenly.
+//
+// Pure Sounio: one pass for the mean, one for the sd, one to fill out_z; inline
+// sqrt. No external dependency, no nested data-array calls.
+//
+// References:
+//   Kreyszig, "Advanced Engineering Mathematics"; standard definitions.
+
+module stats::zscore
+
+fn zs_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct ZResult {
+    pub mean: f64,
+    pub sd: f64,
+}
+
+/// Standardise x to z-scores; fills out_z[0..n).
+///
+/// Parâmetros: x — data; n — size (>=2, <=256); out_z — receives the z-scores.
+/// Retorno: ZResult (mean, sd).
+pub fn zscore(x: &[f64; 256], n: i32, out_z: &![f64; 256]) -> ZResult with Mut, Div, Panic {
+    if n < 2 { return ZResult { mean: 0.0, sd: 0.0 } }
+    let nf = n as f64
+    var s = 0.0
+    var i = 0
+    while i < n { s = s + x[i as usize]; i = i + 1 }
+    let mean = s / nf
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; ss = ss + d * d; j = j + 1 }
+    let sd = zs_sqrt(ss / (nf - 1.0))
+    var k = 0
+    while k < n {
+        var z = 0.0
+        if sd > 1.0e-300 { z = (x[k as usize] - mean) / sd }
+        out_z[k as usize] = z
+        k = k + 1
+    }
+    return ZResult { mean: mean, sd: sd }
+}
+
+/// Percentile rank of a value within the sample (mid-rank convention, 0..100).
+pub fn percentile_rank(x: &[f64; 256], n: i32, value: f64) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var below = 0
+    var equal = 0
+    var i = 0
+    while i < n {
+        let v = x[i as usize]
+        if v < value { below = below + 1 } else { if v == value { equal = equal + 1 } }
+        i = i + 1
+    }
+    return ((below as f64) + 0.5 * (equal as f64)) / (n as f64) * 100.0
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// {2,4,4,4,5,5,7,9}: mean 5, sample sd 2.138090.
+// z_0=(2-5)/2.138090=-1.403191; z_7=(9-5)/2.138090=1.870922.
+fn test_zscore() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var z: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=4.0; x[3]=4.0; x[4]=5.0; x[5]=5.0; x[6]=7.0; x[7]=9.0
+    let r = zscore(&x, 8, &!z)
+    var ok = true
+    ok = check(1, approx(r.mean, 5.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.sd, 2.138090, 1.0e-5)) && ok
+    ok = check(3, approx(z[0], 0.0 - 1.403191, 1.0e-4)) && ok
+    ok = check(4, approx(z[7], 1.870922, 1.0e-4)) && ok
+    return ok
+}
+
+// standardized data has mean 0 (sum of z ≈ 0).
+fn test_mean_zero() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var z: [f64; 256] = [0.0; 256]
+    x[0]=10.0; x[1]=20.0; x[2]=30.0; x[3]=40.0; x[4]=50.0
+    let r = zscore(&x, 5, &!z)
+    var s = 0.0
+    var i = 0
+    while i < 5 { s = s + z[i as usize]; i = i + 1 }
+    return check(10, approx(s, 0.0, 1.0e-9))
+}
+
+// percentile rank: value 5 in {2,4,4,4,5,5,7,9}: below=4, equal=2 -> (4+1)/8·100=62.5.
+fn test_prank() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=4.0; x[3]=4.0; x[4]=5.0; x[5]=5.0; x[6]=7.0; x[7]=9.0
+    return check(20, approx(percentile_rank(&x, 8, 5.0), 62.5, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_zscore() && ok
+    ok = test_mean_zero() && ok
+    ok = test_prank() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three foundational preprocessing modules, bringing the runner to **118 modules**. A late but real gap: the suite had no **data-transformation primitives** — the feature scaling and rank transforms that underpin nearly everything else. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::zscore` | Standardisation (z-scores) + mid-rank percentile rank |
| `stats::normalize` | Min-max to [0,1] and robust (median/IQR) scaling |
| `stats::rank_transform` | Mid-rank transform + tie-correction Σ(t³−t) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Z-score: {2,4,4,4,5,5,7,9} → z₀=−1.403, z₇=1.871, Σz=0; percentile rank of 5 → 62.5.
  - Normalize: {1..5} → min-max {0,0.25,0.5,0.75,1}; robust → median 3, IQR 2, centred.
  - Rank: {3,1,4,1,5} → ranks {3,1.5,4,1.5,5}, one tie group, correction 6; distinct data → 1..n.
- Full suite selftest: **118 modules + 7 demos ALL GREEN** under `lean_single`.

All three fill an out-array (`out_z`/`out`/`out_r`) and return a small summary struct — the same `#852`-safe pattern used by `leverage`/`cooks_distance`.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).