### PR TITLE
refactor(gpu): migrate GPU octonion emitters to canonical Convention X

### DIFF
--- a/self-hosted/gpu/kernels/hmma_signs.sio
+++ b/self-hosted/gpu/kernels/hmma_signs.sio
@@ -16,6 +16,15 @@
 // Fano plane sign table for octonion multiplication
 // ============================================================================
 //
+// ⚠️ CONVENTION NOTE (2026-07-15): this HMMA tensor-core path still uses **Convention Y**
+// (Fano triples (1,2,4)…, e1·e2=+e4). The main GPU octonion path (hypercomplex.sio `oct_mul_*`
+// and ossm_forward.sio `ossm_fano_*`) was migrated to the canonical **Convention X** (cd_sigma /
+// XOR, e1·e2=+e3) to match the CPU. The HMMA path is STANDALONE — nothing outside this file uses
+// it (only tests/gpu/test_hmma_octonion.sio), so there is no internal inconsistency. Do NOT wire
+// these helpers into the X path. Migrating the sign-mask encoding to X requires deriving the masks
+// from the exact HMMA tile-packing scheme + GPU-hardware validation — dispatched to CODEX (see the
+// #919/#921-style handoff). Oracle for X: tests/run-pass/hypercomplex_convention_crosscheck.sio.
+//
 // The octonion basis e0..e7 multiply according to the Fano plane:
 //   Lines: (1,2,4), (2,3,5), (3,4,6), (4,5,7), (5,6,1), (6,7,2), (7,1,3)
 //   For line (a,b,c): e_a*e_b = +e_c, e_b*e_a = -e_c (cyclic)

--- a/self-hosted/gpu/kernels/hypercomplex.sio
+++ b/self-hosted/gpu/kernels/hypercomplex.sio
@@ -255,140 +255,38 @@ fn hc_alloc_sixteen(s: HypercomplexPtxState) -> (HypercomplexPtxState, SixteenVe
 // Returns +1 or -1 for the sign of e_i * e_j.
 // e_0 is the identity so sign is always +1 when either index is 0.
 // e_i * e_i = -1 for i > 0.
+// Recursive Cayley–Dickson twist sign σ(i,j,bits) ∈ {+1,−1} — canonical Convention X
+// (matches stdlib cd_sigma; see stdlib/algebra/README.md). Migrated from the former Fano-triple
+// table (Convention Y, e1·e2=+e4) so GPU octonion multiplication agrees with the CPU (e1·e2=+e3).
+fn gpu_oct_cd_sigma(a: i64, b: i64, bits: i64) -> i64 {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return gpu_oct_cd_sigma(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return gpu_oct_cd_sigma(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return gpu_oct_cd_sigma(a_lo, 0, bits - 1) }
+        return 0 - gpu_oct_cd_sigma(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - gpu_oct_cd_sigma(0, a_lo, bits - 1) }
+    gpu_oct_cd_sigma(b_lo, a_lo, bits - 1)
+}
+
 fn oct_mul_sign(i: i64, j: i64) -> i64 {
-    // Identity element
-    if i == 0 { return 1 }
-    if j == 0 { return 1 }
-    // Self-product: e_i * e_i = -1
-    if i == j { return -1 }
-
-    // Fano plane line (1,2,4): e1*e2=+e4, e2*e4=+e1, e4*e1=+e2
-    if i == 1 && j == 2 { return 1 }
-    if i == 2 && j == 1 { return -1 }
-    if i == 2 && j == 4 { return 1 }
-    if i == 4 && j == 2 { return -1 }
-    if i == 4 && j == 1 { return 1 }
-    if i == 1 && j == 4 { return -1 }
-
-    // Fano plane line (2,3,5): e2*e3=+e5, e3*e5=+e2, e5*e2=+e3
-    if i == 2 && j == 3 { return 1 }
-    if i == 3 && j == 2 { return -1 }
-    if i == 3 && j == 5 { return 1 }
-    if i == 5 && j == 3 { return -1 }
-    if i == 5 && j == 2 { return 1 }
-    if i == 2 && j == 5 { return -1 }
-
-    // Fano plane line (3,4,6): e3*e4=+e6, e4*e6=+e3, e6*e3=+e4
-    if i == 3 && j == 4 { return 1 }
-    if i == 4 && j == 3 { return -1 }
-    if i == 4 && j == 6 { return 1 }
-    if i == 6 && j == 4 { return -1 }
-    if i == 6 && j == 3 { return 1 }
-    if i == 3 && j == 6 { return -1 }
-
-    // Fano plane line (4,5,7): e4*e5=+e7, e5*e7=+e4, e7*e4=+e5
-    if i == 4 && j == 5 { return 1 }
-    if i == 5 && j == 4 { return -1 }
-    if i == 5 && j == 7 { return 1 }
-    if i == 7 && j == 5 { return -1 }
-    if i == 7 && j == 4 { return 1 }
-    if i == 4 && j == 7 { return -1 }
-
-    // Fano plane line (5,6,1): e5*e6=+e1, e6*e1=+e5, e1*e5=+e6  (wait: cyclic)
-    // (a,b,c)=(5,6,1): e5*e6=+e1, e6*e1=+e5, e1*e5=+e6
-    if i == 5 && j == 6 { return 1 }
-    if i == 6 && j == 5 { return -1 }
-    if i == 6 && j == 1 { return 1 }
-    if i == 1 && j == 6 { return -1 }
-    if i == 1 && j == 5 { return 1 }
-    if i == 5 && j == 1 { return -1 }
-
-    // Fano plane line (6,7,2): e6*e7=+e2, e7*e2=+e6, e2*e6=+e7
-    if i == 6 && j == 7 { return 1 }
-    if i == 7 && j == 6 { return -1 }
-    if i == 7 && j == 2 { return 1 }
-    if i == 2 && j == 7 { return -1 }
-    if i == 2 && j == 6 { return 1 }
-    if i == 6 && j == 2 { return -1 }
-
-    // Fano plane line (7,1,3): e7*e1=+e3, e1*e3=+e7, e3*e7=+e1
-    if i == 7 && j == 1 { return 1 }
-    if i == 1 && j == 7 { return -1 }
-    if i == 1 && j == 3 { return 1 }
-    if i == 3 && j == 1 { return -1 }
-    if i == 3 && j == 7 { return 1 }
-    if i == 7 && j == 3 { return -1 }
-
-    // Should not reach here for valid indices 0..7
-    0
+    // Canonical Convention X sign via the Cayley–Dickson cocycle (XOR index).
+    gpu_oct_cd_sigma(i, j, 3)
 }
 
 // Returns index k such that e_i * e_j = sign * e_k.
 // When i==0: result is e_j. When j==0: result is e_i.
 // When i==j && i>0: result is e_0 (scalar, with sign -1).
 fn oct_mul_basis(i: i64, j: i64) -> i64 {
-    if i == 0 { return j }
-    if j == 0 { return i }
-    if i == j { return 0 }
-
-    // Fano line (1,2,4)
-    if i == 1 && j == 2 { return 4 }
-    if i == 2 && j == 1 { return 4 }
-    if i == 2 && j == 4 { return 1 }
-    if i == 4 && j == 2 { return 1 }
-    if i == 4 && j == 1 { return 2 }
-    if i == 1 && j == 4 { return 2 }
-
-    // Fano line (2,3,5)
-    if i == 2 && j == 3 { return 5 }
-    if i == 3 && j == 2 { return 5 }
-    if i == 3 && j == 5 { return 2 }
-    if i == 5 && j == 3 { return 2 }
-    if i == 5 && j == 2 { return 3 }
-    if i == 2 && j == 5 { return 3 }
-
-    // Fano line (3,4,6)
-    if i == 3 && j == 4 { return 6 }
-    if i == 4 && j == 3 { return 6 }
-    if i == 4 && j == 6 { return 3 }
-    if i == 6 && j == 4 { return 3 }
-    if i == 6 && j == 3 { return 4 }
-    if i == 3 && j == 6 { return 4 }
-
-    // Fano line (4,5,7)
-    if i == 4 && j == 5 { return 7 }
-    if i == 5 && j == 4 { return 7 }
-    if i == 5 && j == 7 { return 4 }
-    if i == 7 && j == 5 { return 4 }
-    if i == 7 && j == 4 { return 5 }
-    if i == 4 && j == 7 { return 5 }
-
-    // Fano line (5,6,1)
-    if i == 5 && j == 6 { return 1 }
-    if i == 6 && j == 5 { return 1 }
-    if i == 6 && j == 1 { return 5 }
-    if i == 1 && j == 6 { return 5 }
-    if i == 1 && j == 5 { return 6 }
-    if i == 5 && j == 1 { return 6 }
-
-    // Fano line (6,7,2)
-    if i == 6 && j == 7 { return 2 }
-    if i == 7 && j == 6 { return 2 }
-    if i == 7 && j == 2 { return 6 }
-    if i == 2 && j == 7 { return 6 }
-    if i == 2 && j == 6 { return 7 }
-    if i == 6 && j == 2 { return 7 }
-
-    // Fano line (7,1,3)
-    if i == 7 && j == 1 { return 3 }
-    if i == 1 && j == 7 { return 3 }
-    if i == 1 && j == 3 { return 7 }
-    if i == 3 && j == 1 { return 7 }
-    if i == 3 && j == 7 { return 1 }
-    if i == 7 && j == 3 { return 1 }
-
-    // Unreachable for valid 0..7 inputs
-    0
+    // e_i·e_j lands in e_{i⊕j} (XOR indexing) — Convention X.
+    i ^ j
 }
 
 // ============================================================================

--- a/self-hosted/gpu/kernels/ossm_forward.sio
+++ b/self-hosted/gpu/kernels/ossm_forward.sio
@@ -327,79 +327,33 @@ fn ossm_emit_sigmoid_f32(s: OssmPtxState, dst_reg: i64, src_reg: i64, sx2_reg: i
 // Octonion multiply via Fano plane — emits 64 PTX instructions
 // ============================================================================
 
+// Recursive Cayley–Dickson twist sign σ(i,j,bits) ∈ {+1,−1} — canonical Convention X
+// (matches stdlib cd_sigma; see stdlib/algebra/README.md). Migrated from the former Fano-triple
+// table (Convention Y, e1·e2=+e4) so GPU octonion multiplication agrees with the CPU (e1·e2=+e3).
+fn ossm_oct_cd_sigma(a: i64, b: i64, bits: i64) -> i64 {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return ossm_oct_cd_sigma(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return ossm_oct_cd_sigma(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return ossm_oct_cd_sigma(a_lo, 0, bits - 1) }
+        return 0 - ossm_oct_cd_sigma(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - ossm_oct_cd_sigma(0, a_lo, bits - 1) }
+    ossm_oct_cd_sigma(b_lo, a_lo, bits - 1)
+}
+
 fn ossm_fano_basis(i: i64, j: i64) -> i64 with Panic {
-    if i == 0 { return j }
-    if j == 0 { return i }
-    if i == j { return 0 }
-    if i == 1 && j == 2 { return 4 }
-    if i == 2 && j == 1 { return 4 }
-    if i == 1 && j == 4 { return 2 }
-    if i == 4 && j == 1 { return 2 }
-    if i == 2 && j == 4 { return 1 }
-    if i == 4 && j == 2 { return 1 }
-    if i == 2 && j == 3 { return 5 }
-    if i == 3 && j == 2 { return 5 }
-    if i == 2 && j == 5 { return 3 }
-    if i == 5 && j == 2 { return 3 }
-    if i == 3 && j == 5 { return 2 }
-    if i == 5 && j == 3 { return 2 }
-    if i == 3 && j == 4 { return 6 }
-    if i == 4 && j == 3 { return 6 }
-    if i == 3 && j == 6 { return 4 }
-    if i == 6 && j == 3 { return 4 }
-    if i == 4 && j == 6 { return 3 }
-    if i == 6 && j == 4 { return 3 }
-    if i == 4 && j == 5 { return 7 }
-    if i == 5 && j == 4 { return 7 }
-    if i == 4 && j == 7 { return 5 }
-    if i == 7 && j == 4 { return 5 }
-    if i == 5 && j == 7 { return 4 }
-    if i == 7 && j == 5 { return 4 }
-    if i == 5 && j == 6 { return 1 }
-    if i == 6 && j == 5 { return 1 }
-    if i == 5 && j == 1 { return 6 }
-    if i == 1 && j == 5 { return 6 }
-    if i == 6 && j == 1 { return 5 }
-    if i == 1 && j == 6 { return 5 }
-    if i == 6 && j == 7 { return 2 }
-    if i == 7 && j == 6 { return 2 }
-    if i == 6 && j == 2 { return 7 }
-    if i == 2 && j == 6 { return 7 }
-    if i == 7 && j == 2 { return 6 }
-    if i == 2 && j == 7 { return 6 }
-    if i == 7 && j == 1 { return 3 }
-    if i == 1 && j == 7 { return 3 }
-    if i == 7 && j == 3 { return 1 }
-    if i == 3 && j == 7 { return 1 }
-    0
+    i ^ j
 }
 
 fn ossm_fano_sign(i: i64, j: i64) -> i64 with Panic {
-    if i == 0 { return 1 }
-    if j == 0 { return 1 }
-    if i == j { return 0 - 1 }
-    if i == 1 && j == 2 { return 1 }
-    if i == 2 && j == 4 { return 1 }
-    if i == 4 && j == 1 { return 1 }
-    if i == 2 && j == 3 { return 1 }
-    if i == 3 && j == 5 { return 1 }
-    if i == 5 && j == 2 { return 1 }
-    if i == 3 && j == 4 { return 1 }
-    if i == 4 && j == 6 { return 1 }
-    if i == 6 && j == 3 { return 1 }
-    if i == 4 && j == 5 { return 1 }
-    if i == 5 && j == 7 { return 1 }
-    if i == 7 && j == 4 { return 1 }
-    if i == 5 && j == 6 { return 1 }
-    if i == 6 && j == 1 { return 1 }
-    if i == 1 && j == 5 { return 1 }
-    if i == 6 && j == 7 { return 1 }
-    if i == 7 && j == 2 { return 1 }
-    if i == 2 && j == 6 { return 1 }
-    if i == 7 && j == 1 { return 1 }
-    if i == 1 && j == 3 { return 1 }
-    if i == 3 && j == 7 { return 1 }
-    0 - 1
+    ossm_oct_cd_sigma(i, j, 3)
 }
 
 fn ossm_emit_oct_mul_f64(s: OssmPtxState, dst: [i64; 8], a: [i64; 8], b: [i64; 8], neg_scratch: i64) -> OssmPtxState with Mut, Panic, Div {


### PR DESCRIPTION
## What

Completes the hypercomplex convention canonicalization on the **GPU** side. The GPU octonion PTX
emitters used **Convention Y** (Fano triples `(1,2,4)…`, `e1·e2=+e4`) while the CPU was migrated to
**Convention X** (`cd_sigma` / XOR, `e1·e2=+e3`) in #940/#942 — a latent CPU/GPU divergence (the GPU
O-SSM would produce component-level results in a different basis labeling than the CPU reference).

### Changes
- **`hypercomplex.sio`** — `oct_mul_sign` / `oct_mul_basis` → `cd_sigma` sign + XOR index (X).
- **`ossm_forward.sio`** — `ossm_fano_sign` / `ossm_fano_basis` → `cd_sigma` + XOR (the O-SSM
  forward/backward/associator PTX emitter).
- **`hmma_signs.sio`** — **not migrated** (documented). The HMMA tensor-core path is standalone
  (only `tests/gpu/test_hmma_octonion.sio` uses it; nothing wires it into the main path → no internal
  inconsistency). Its sign-mask encoding needs the exact tile-packing derivation + GPU-HW validation,
  so it's left for a HW-validated follow-up; a warning note was added at the top of the file.

### Why safe
X and Y are isomorphic octonion algebras (both 168 non-associative triples). Only component-level
outputs move; norm / associator-norm invariants are unchanged.

## Validation
- **Emit-time convention proof**: `gpu_oct_cd_sigma` + `i^j` → `e1·e2=+e3`, `e2·e5=+e7`, `e_i²=−1`
  (`GPU-EMITTER-CONVENTION-X PASS`). The convention is an emit-time property, so this is the core proof.
- Standalone typecheck: error count **identical to baseline** (no new errors; remaining errors are
  pre-existing cross-module standalone-check artifacts).
- CI runs `native_v2_epistemic_accel_spine_gate.sh` (emitter surface + PTX/ptxas; CUDA run SKIPs
  gracefully without a GPU).
- **Optional HW confirmation** available via the Slurm GPU nodes (`gpuorangefs-*`) — the emitted
  X-convention PTX executing on real hardware.

Depends on #940/#942 (the CPU-side convention + oracle).
