### PR TITLE
[DO NOT MERGE] Fail closed on incomplete imported closure

### DIFF
--- a/scripts/ci/nominal_field_resolution_receipt_shadow_gate.sh
+++ b/scripts/ci/nominal_field_resolution_receipt_shadow_gate.sh
@@ -88,6 +88,7 @@ printf '%s\n' \
   scripts/ci/nominal_field_resolution_receipt_shadow_gate.sh \
   self-hosted/check/check.sio \
   self-hosted/check/nominal_field_resolution_receipt_shadow_probe.sio \
+  self-hosted/compiler/module_frontend.sio \
   self-hosted/ir/arena_v2_place_nominal_receipt_binding_shadow.sio \
   tests/native-v2/nominal_field_resolution_local_witness.sio \
   tests/native-v2/nominal_field_resolution_nested_witness.sio \
@@ -114,23 +115,15 @@ done
   cat "$TMP/witness.check.log" >&2
   fail witness_source_check
 }
-"$SOUC" compile "$WITNESS" -o "$TMP/witness.elf" >"$TMP/witness.build.log" 2>&1 || {
+if "$SOUC" compile "$WITNESS" -o "$TMP/witness.elf" >"$TMP/witness.build.log" 2>&1; then
   cat "$TMP/witness.build.log" >&2
-  fail witness_compile
-}
-chmod +x "$TMP/witness.elf"
-set +e
-"$TMP/witness.elf" >"$TMP/witness.out" 2>&1
-witness_rc=$?
-set -e
-[[ "$witness_rc" -eq 139 ]] || {
-  cat "$TMP/witness.out" >&2
-  fail "imported_transitive_lowering_expected_139_actual_${witness_rc}"
-}
-grep -Fq 'Merged IR: 2' "$TMP/witness.build.log" || {
+  fail imported_transitive_lowering_must_fail_closed
+fi
+grep -Fq 'imported_compile: unresolved import graph; closure incomplete path=check/nominal_field_resolution_receipt_shadow_probe.sio source=tests/native-v2/nominal_field_resolution_receipt_shadow_witness.sio' "$TMP/witness.build.log" || {
   cat "$TMP/witness.build.log" >&2
-  fail imported_transitive_lowering_evidence_missing
+  fail imported_transitive_lowering_fail_closed_evidence_missing
 }
+[[ ! -e "$TMP/witness.elf" ]] || fail imported_transitive_lowering_emitted_incomplete_elf
 
 run_legacy() {
   local label="$1"
@@ -161,5 +154,5 @@ printf '%s\n' 'NOMINAL_FIELD_RECEIPT_CHECK source=pass default_surfaces=unchange
 printf '%s\n' 'NOMINAL_FIELD_RECEIPT_OBSERVATION scope=snapshot_local authority=observational_only resolver_defid=false cross_snapshot_stable=false cross_order_numeric_comparison=forbidden ready_mask=31 lifecycle_contract=structural_begin,freeze,reset stale_snapshot_contract=reject stale_receipt_contract=reject live_output_contract=reject parent_link=structurally_present adversaries=encoded_not_executed_due_imported_lowering_blocker'
 printf '%s\n' 'NOMINAL_FIELD_RECEIPT_PLACE preflight=fail_closed target_layout=false layout_epoch=false place_allocated=false status=-75'
 printf 'NOMINAL_FIELD_RECEIPT_DIFFERENTIAL original=%s swapped=%s import_ab=%s import_ba=%s default_legacy_kept=true\n' "$original_rc" "$swapped_rc" "$import_ab_rc" "$import_ba_rc"
-printf '%s\n' 'NOMINAL_FIELD_RECEIPT_BLOCKER Blocker-ID=BLK-20260715-nominal-receipt-imported-transitive-lowering Status=classified Severity=B1 Class=harness-routing Evidence-Level=E2 Result=BLOCKED_IMPORTED_TRANSITIVE_LOWERING Observed=compile_success_merged_ir_2_runtime_rc_139 Expected=probe_facade_transitive_checker_bodies_lowered Acceptance-Gate=witness_runtime_prints_42 Owner=native-v2-imported-module-lowering Next-Action=lower_transitive_imported_function_closure'
+printf '%s\n' 'NOMINAL_FIELD_RECEIPT_BLOCKER Blocker-ID=BLK-20260715-nominal-receipt-imported-transitive-lowering Status=contained_not_unblocked Severity=B1 Class=harness-routing Evidence-Level=E3 Result=BLOCKED_IMPORTED_TRANSITIVE_LOWERING Observed=compile_fail_closed_unresolved_import_graph_no_elf Expected=probe_facade_transitive_checker_bodies_lowered Acceptance-Gate=witness_runtime_prints_42 Owner=native-v2-imported-module-lowering Next-Action=define_module_root_and_alias_semantics_before_lower_transitive_imported_function_closure'
 printf 'NOMINAL_FIELD_RECEIPT_PASS mode=source_preservation_slice_not_executable_hook_proof compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -2304,12 +2304,16 @@ fn visited_contains(visited: [string; 256], count: i64, path: string) -> bool wi
 pub struct ImportPathList {
     paths: [string; 256],
     count: i64,
+    unresolved_count: i64,
+    first_unresolved_path: string,
 }
 
 fn import_path_list_empty() -> ImportPathList {
     ImportPathList {
         paths: [""; 256],
         count: 0,
+        unresolved_count: 0,
+        first_unresolved_path: "",
     }
 }
 
@@ -2447,6 +2451,11 @@ pub fn module_frontend_import_files_from_source(path: string) -> ImportPathList 
                     if file_exists(dep_path) && !import_path_list_contains(imports, dep_path) {
                         imports.paths[imports.count] = dep_path
                         imports.count = imports.count + 1
+                    } else if !file_exists(dep_path) {
+                        if imports.unresolved_count == 0 {
+                            imports.first_unresolved_path = rel_path
+                        }
+                        imports.unresolved_count = imports.unresolved_count + 1
                     }
                 }
             }
@@ -5668,6 +5677,14 @@ pub fn module_frontend_compile_imported_to_file(main_path: string, output_path: 
 
     while work_front < loaded && loaded < 256 {
         let work_imports = module_frontend_import_files_from_source(file_paths[work_front])
+        if work_imports.unresolved_count > 0 {
+            print("imported_compile: unresolved import graph; closure incomplete path=")
+            print(work_imports.first_unresolved_path)
+            print(" source=")
+            print(file_paths[work_front])
+            print("\n")
+            return 1
+        }
         if module_frontend_lower_trace_enabled() {
             print("imported_compile: scan_front=")
             print_int(work_front)


### PR DESCRIPTION
## Scope

Contains BLK-20260715-nominal-receipt-imported-transitive-lowering without claiming the checker facade is executable. This is stacked on #991 and must not merge independently.

## Evidence

- current #991 compiler: compact path `Merged IR: 1`, emit failure, full fallback `loaded 1`, `Merged IR: 2`, generated ELF exits 139
- no-import control exits 42
- imported body/chain/nested controls exit 42 without fallback
- first unresolved textual import: `check/nominal_field_resolution_receipt_shadow_probe.sio`
- an explicit throwaway self-hosted root then exposes the non-root alias `module_parse`; even with that alias supplied, the 34-module graph fails modular typecheck before lowering

## Change

- retain unresolved import evidence in `ImportPathList`
- refuse full imported compilation when its graph is incomplete
- update #991 receipt gate to require deterministic failure and no ELF

## Claim boundary

Status: `contained_not_unblocked`, Evidence-Level E3. Acceptance remains: the witness must execute and print 42. No checker, receipt, binder, TargetDataLayout, or scientific semantics were changed.

## Local checks

- `bash -n scripts/ci/nominal_field_resolution_receipt_shadow_gate.sh`
- `git diff --check`
- receipt-owned files unchanged from `babe7ffb01ddff3f186b680ad0d3438caefbc950`

Remote current-source build and four-case non-regression proof are required before this draft can be considered mergeable.

DO NOT MERGE.