### PR TITLE
feat(stats): weighted & grouped estimators — weighted_stats, grouped_stats, weighted_quantile

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2991,3 +2991,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - rank_transform = **PASS**: mid-rank less+(equal+1)/2, tie-group detection (first && equal>1) with Σ(t³−t); {3,1,4,1,5}→{3,1.5,4,1.5,5}, correction 6 verified.
 - Theme: data-transformation primitives — foundational preprocessing (feature scaling, rank transform) completing the descriptive layer. All derivable, #852-safe. Suite runner: 118 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-BIlCZ5/`, `/tmp/llm-offload-7CoTZR/`, `/tmp/llm-offload-Y2h33J/`.
+
+## 2026-07-15 — math-review: stats::weighted_stats, stats::grouped_stats, stats::weighted_quantile
+- Files (all new): `stdlib/stats/weighted_stats.sio` (weighted mean + population & Kish-unbiased variance), `stdlib/stats/grouped_stats.sio` (mean/variance/modal-class from a frequency table), `stdlib/stats/weighted_quantile.sio` (sort-free weighted p-quantile/median). Provider: xAI/Grok 4.3.
+- weighted_stats = **PASS**: x̄_w=Σwx/Σw, σ²_w=Σw(x−x̄)²/V₁, unbiased ÷(V₁−V₂/V₁); x={1,2,3}/w={1,2,3}→mean 2.333, var_pop 0.5556, var_ub 0.9091 verified.
+- grouped_stats = **PASS**: mean=Σfm/Σf, sample var ÷(Σf−1), modal class argmax; {5,15,25}/{10,20,10}→mean 15, var_pop 50, var_sample 51.28 verified.
+- weighted_quantile = **PASS**: smallest v with Σ_{x≤v}w ≥ p·Σw, sort-free O(n²); equal→median 2, heavy weight→median 4, quartiles verified.
+- Theme: weighted & grouped estimators — support for survey weights / frequency tables / meta-analytic precisions, absent until now. All derivable, #852-safe. Suite runner: 121 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-n3PQpI/`, `/tmp/llm-offload-lcsGkl/`, `/tmp/llm-offload-anzkI3/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -127,6 +127,9 @@ MODULES=(
   stdlib/stats/zscore.sio
   stdlib/stats/normalize.sio
   stdlib/stats/rank_transform.sio
+  stdlib/stats/weighted_stats.sio
+  stdlib/stats/grouped_stats.sio
+  stdlib/stats/weighted_quantile.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -15,7 +15,8 @@ fourteen families:
   kurtosis); plus the robust median / IQR / MAD / trimmed & Winsorized means,
   the Hodges-Lehmann estimators, Tukey / Grubbs / modified-z outlier rules, and
   the data-transformation primitives (z-scores, min-max & robust scaling, rank
-  transform).
+  transform), and the weighted / grouped estimators (weighted mean & variance,
+  grouped-frequency statistics, weighted quantiles).
 - **Assumption checks** — normality (Jarque-Bera, Q-Q, Kolmogorov-Smirnov,
   Anderson-Darling, Cramér-von Mises, χ²/G goodness-of-fit), independence
   (Wald-Wolfowitz runs, Durbin-Watson,
@@ -1565,6 +1566,37 @@ every rank-based method, plus the tie-correction `Σ(tᵢ³−tᵢ)`. Validated:
 {3,1,4,1,5} → ranks {3,1.5,4,1.5,5}, one tie group, correction 6; distinct data →
 1..n.
 
+### `stats::weighted_stats` — weighted mean & variance
+
+| Function | Signature |
+|---|---|
+| `weighted_stats` | `pub fn weighted_stats(x: &[f64; 256], w: &[f64; 256], n: i32) -> WeightedResult with Mut, Div, Panic` |
+
+The mean and variance for weighted observations (survey weights, precisions,
+counts): `x̄_w=Σwx/Σw`, population and reliability-weight unbiased variances
+(Kish `V₁−V₂/V₁` correction). Validated: x={1,2,3}, w={1,2,3} → mean 2.333,
+var_pop 0.5556, var_unbiased 0.9091.
+
+### `stats::grouped_stats` — grouped-frequency statistics
+
+| Function | Signature |
+|---|---|
+| `grouped_stats` | `pub fn grouped_stats(midpoint: &[f64; 64], freq: &[f64; 64], k: i32) -> GroupedResult with Mut, Div, Panic` |
+
+Statistics from a frequency table (bin midpoints + counts): mean, population &
+sample variance, and the modal class. Validated: midpoints {5,15,25}, freqs
+{10,20,10} → mean 15, var_pop 50, modal class 15, sample var 51.28.
+
+### `stats::weighted_quantile` — weighted quantiles
+
+| Function | Signature |
+|---|---|
+| `weighted_quantile` / `weighted_median` | `pub fn weighted_quantile(x: &[f64; 256], w: &[f64; 256], n: i32, p: f64) -> f64 with Mut, Div, Panic` |
+
+The p-quantile of weighted data (smallest value carrying ≥p of the total weight),
+via a sort-free cumulative scan. Validated: equal weights {1,2,3} → median 2;
+{1,2,3,4} w={1,1,1,5} → weighted median 4; quartiles of {1,2,3,4}.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1687,6 +1719,9 @@ use stats::bowker::{BowkerResult, bowker}
 use stats::zscore::{ZResult, zscore, percentile_rank}
 use stats::normalize::{MinMaxResult, RobustResult, minmax, robust_scale}
 use stats::rank_transform::{RankResult, rank_transform}
+use stats::weighted_stats::{WeightedResult, weighted_stats}
+use stats::grouped_stats::{GroupedResult, grouped_stats}
+use stats::weighted_quantile::{weighted_quantile, weighted_median}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/grouped_stats.sio
+++ b/stdlib/stats/grouped_stats.sio
@@ -1,0 +1,130 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/grouped_stats.sio — statistics from grouped frequency data
+//
+// The mean, variance and modal class of data given only as a frequency table
+// (bin midpoints and counts) rather than raw observations:
+//
+//   grouped_stats(midpoint, freq, k) -> GroupedResult
+//
+//   mean = Σfᵢmᵢ / Σfᵢ,
+//   population variance = Σfᵢ(mᵢ−mean)² / Σfᵢ,
+//   sample variance = Σfᵢ(mᵢ−mean)² / (Σfᵢ − 1).
+//
+// Pure Sounio: two passes over the bins; inline sqrt. No external dependency, no
+// nested data-array calls.
+//
+// References:
+//   Kenney & Keeping, "Mathematics of Statistics" 3e, §4 (grouped data).
+
+module stats::grouped_stats
+
+fn gs_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct GroupedResult {
+    pub mean: f64,
+    pub var_pop: f64,     // population variance (÷ Σf)
+    pub var_sample: f64,  // sample variance (÷ (Σf−1))
+    pub sd: f64,          // √var_sample
+    pub modal_class: f64, // midpoint of the highest-frequency bin
+    pub total: f64,       // Σf
+}
+
+/// Statistics from grouped frequency data.
+///
+/// Parâmetros: midpoint — bin midpoints; freq — bin frequencies; k — bins (>=2, <=64).
+/// Retorno: GroupedResult (mean, var_pop, var_sample, sd, modal_class, total).
+/// Referências: Kenney & Keeping.
+pub fn grouped_stats(midpoint: &[f64; 64], freq: &[f64; 64], k: i32) -> GroupedResult with Mut, Div, Panic {
+    if k < 2 || k > 64 { return GroupedResult { mean: 0.0, var_pop: 0.0, var_sample: 0.0, sd: 0.0, modal_class: 0.0, total: 0.0 } }
+    var total = 0.0
+    var sfm = 0.0
+    var maxf = 0.0 - 1.0
+    var modal = 0.0
+    var i = 0
+    while i < k {
+        let f = freq[i as usize]
+        let m = midpoint[i as usize]
+        total = total + f
+        sfm = sfm + f * m
+        if f > maxf { maxf = f; modal = m }
+        i = i + 1
+    }
+    if total <= 0.0 { return GroupedResult { mean: 0.0, var_pop: 0.0, var_sample: 0.0, sd: 0.0, modal_class: modal, total: 0.0 } }
+    let mean = sfm / total
+    var ss = 0.0
+    var j = 0
+    while j < k { let d = midpoint[j as usize] - mean; ss = ss + freq[j as usize] * d * d; j = j + 1 }
+    let var_pop = ss / total
+    var var_s = 0.0
+    if total > 1.0 { var_s = ss / (total - 1.0) }
+    let sd = gs_sqrt(var_s)
+    return GroupedResult { mean: mean, var_pop: var_pop, var_sample: var_s, sd: sd, modal_class: modal, total: total }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// midpoints {5,15,25}, freqs {10,20,10}. Σf=40. mean=600/40=15.
+// SS=10·100+20·0+10·100=2000. var_pop=2000/40=50. modal class = 15 (freq 20).
+fn test_grouped() -> bool with IO, Mut, Div, Panic {
+    var m: [f64; 64] = [0.0; 64]
+    var f: [f64; 64] = [0.0; 64]
+    m[0]=5.0; m[1]=15.0; m[2]=25.0
+    f[0]=10.0; f[1]=20.0; f[2]=10.0
+    let r = grouped_stats(&m, &f, 3)
+    var ok = true
+    ok = check(1, approx(r.mean, 15.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.var_pop, 50.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.modal_class, 15.0, 1.0e-9)) && ok
+    ok = check(4, approx(r.total, 40.0, 1.0e-9)) && ok
+    return ok
+}
+
+// sample variance uses Σf-1: var_sample=2000/39=51.282051.
+fn test_sample_var() -> bool with IO, Mut, Div, Panic {
+    var m: [f64; 64] = [0.0; 64]
+    var f: [f64; 64] = [0.0; 64]
+    m[0]=5.0; m[1]=15.0; m[2]=25.0
+    f[0]=10.0; f[1]=20.0; f[2]=10.0
+    let r = grouped_stats(&m, &f, 3)
+    return check(10, approx(r.var_sample, 51.282051, 1.0e-4))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_grouped() && ok
+    ok = test_sample_var() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/weighted_quantile.sio
+++ b/stdlib/stats/weighted_quantile.sio
@@ -1,0 +1,118 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/weighted_quantile.sio — weighted quantiles & median
+//
+// Quantiles for weighted data — the value below which a target fraction of the
+// total weight lies:
+//
+//   weighted_quantile(x, w, n, p) -> f64
+//   weighted_median(x, w, n)      -> f64      (p = 0.5)
+//
+// The p-quantile is the smallest value v with Σ_{xᵢ ≤ v} wᵢ ≥ p·Σwᵢ (the
+// lower / left-continuous definition). With equal weights this reduces to an
+// ordinary quantile.
+//
+// Pure Sounio: a sort-free O(n²) cumulative-weight scan (no paired-array sort).
+// No external dependency, no nested data-array calls.
+//
+// References:
+//   standard weighted-quantile definitions (e.g. Hmisc wtd.quantile).
+
+module stats::weighted_quantile
+
+/// Weighted p-quantile (lower definition).
+///
+/// Parâmetros: x — values; w — non-negative weights; n — size; p — in [0,1].
+/// Retorno: the weighted p-quantile.
+pub fn weighted_quantile(x: &[f64; 256], w: &[f64; 256], n: i32, p: f64) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var total = 0.0
+    var i = 0
+    while i < n { total = total + w[i as usize]; i = i + 1 }
+    if total <= 0.0 { return 0.0 }
+    let target = p * total
+    // smallest x_i whose cumulative weight (of all x_j <= x_i) reaches target
+    var best = 0.0
+    var have = false
+    var a = 0
+    while a < n {
+        let xi = x[a as usize]
+        var cw = 0.0
+        var b = 0
+        while b < n { if x[b as usize] <= xi { cw = cw + w[b as usize] } b = b + 1 }
+        if cw >= target - 1.0e-12 {
+            if have == false || xi < best { best = xi; have = true }
+        }
+        a = a + 1
+    }
+    if have == false { return x[0] }
+    return best
+}
+
+/// Weighted median (p = 0.5).
+pub fn weighted_median(x: &[f64; 256], w: &[f64; 256], n: i32) -> f64 with Mut, Div, Panic {
+    return weighted_quantile(x, w, n, 0.5)
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// equal weights {1,2,3} -> median = 2 (cum/total: 1/3,2/3,1; first ≥0.5 is x=2).
+fn test_equal() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    w[0]=1.0; w[1]=1.0; w[2]=1.0
+    return check(1, approx(weighted_median(&x, &w, 3), 2.0, 1.0e-9))
+}
+
+// heavy weight pulls the median: {1,2,3,4} w={1,1,1,5}. total 8, target 4.
+// cum at x=4 is 8 ≥ 4, and no smaller value reaches 4 -> weighted median = 4.
+fn test_heavy() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    w[0]=1.0; w[1]=1.0; w[2]=1.0; w[3]=5.0
+    return check(10, approx(weighted_median(&x, &w, 4), 4.0, 1.0e-9))
+}
+
+// quantile p=0.25 of {1,2,3,4} equal weights -> smallest v with cum/4 ≥ 0.25 = x=1.
+fn test_quartile() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    w[0]=1.0; w[1]=1.0; w[2]=1.0; w[3]=1.0
+    var ok = true
+    ok = check(20, approx(weighted_quantile(&x, &w, 4, 0.25), 1.0, 1.0e-9)) && ok
+    ok = check(21, approx(weighted_quantile(&x, &w, 4, 0.75), 3.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_equal() && ok
+    ok = test_heavy() && ok
+    ok = test_quartile() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/weighted_stats.sio
+++ b/stdlib/stats/weighted_stats.sio
@@ -1,0 +1,130 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/weighted_stats.sio — weighted mean & variance
+//
+// The mean and variance when observations carry weights (survey weights,
+// meta-analytic precisions, frequency counts):
+//
+//   weighted_stats(x, w, n) -> WeightedResult
+//
+//   x̄_w = Σwᵢxᵢ / Σwᵢ,
+//   population variance  σ²_w = Σwᵢ(xᵢ−x̄_w)² / Σwᵢ,
+//   reliability-weight unbiased variance  s²_w = Σwᵢ(xᵢ−x̄_w)² / (V₁ − V₂/V₁),
+// with V₁ = Σwᵢ, V₂ = Σwᵢ².
+//
+// Pure Sounio: two passes (weighted mean, then the weighted sum of squares);
+// inline sqrt. No external dependency, no nested data-array calls.
+//
+// References:
+//   Kish, "Survey Sampling" (1965); GNU Scientific Library weighted statistics.
+
+module stats::weighted_stats
+
+fn ws_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+pub struct WeightedResult {
+    pub mean: f64,        // weighted mean
+    pub var_pop: f64,     // population weighted variance (÷ Σw)
+    pub var_unbiased: f64,// reliability-weight unbiased variance
+    pub sd: f64,          // √var_unbiased
+    pub sum_w: f64,       // Σw
+}
+
+/// Weighted mean and variance.
+///
+/// Parâmetros: x — values; w — non-negative weights; n — size (>=2, <=256).
+/// Retorno: WeightedResult (mean, var_pop, var_unbiased, sd, sum_w).
+/// Referências: Kish (1965).
+pub fn weighted_stats(x: &[f64; 256], w: &[f64; 256], n: i32) -> WeightedResult with Mut, Div, Panic {
+    if n < 2 { return WeightedResult { mean: 0.0, var_pop: 0.0, var_unbiased: 0.0, sd: 0.0, sum_w: 0.0 } }
+    var v1 = 0.0
+    var v2 = 0.0
+    var swx = 0.0
+    var i = 0
+    while i < n {
+        let wi = w[i as usize]
+        v1 = v1 + wi
+        v2 = v2 + wi * wi
+        swx = swx + wi * x[i as usize]
+        i = i + 1
+    }
+    if v1 <= 0.0 { return WeightedResult { mean: 0.0, var_pop: 0.0, var_unbiased: 0.0, sd: 0.0, sum_w: 0.0 } }
+    let mean = swx / v1
+    var ss = 0.0
+    var j = 0
+    while j < n { let d = x[j as usize] - mean; ss = ss + w[j as usize] * d * d; j = j + 1 }
+    let var_pop = ss / v1
+    var var_ub = 0.0
+    let den = v1 - v2 / v1
+    if den > 1.0e-300 { var_ub = ss / den }
+    let sd = ws_sqrt(var_ub)
+    return WeightedResult { mean: mean, var_pop: var_pop, var_unbiased: var_ub, sd: sd, sum_w: v1 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1,2,3}, w={1,2,3}: x̄_w=14/6=2.333333.
+// SS=1·(1.333)²+2·(0.333)²+3·(0.667)²=1.777778+0.222222+1.333333=3.333333.
+// var_pop=3.333333/6=0.555556. V1-V2/V1=6-14/6=3.666667; var_ub=3.333333/3.666667=0.909091.
+fn test_weighted() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0
+    w[0]=1.0; w[1]=2.0; w[2]=3.0
+    let r = weighted_stats(&x, &w, 3)
+    var ok = true
+    ok = check(1, approx(r.mean, 2.333333, 1.0e-5)) && ok
+    ok = check(2, approx(r.var_pop, 0.555556, 1.0e-5)) && ok
+    ok = check(3, approx(r.var_unbiased, 0.909091, 1.0e-5)) && ok
+    ok = check(4, approx(r.sum_w, 6.0, 1.0e-9)) && ok
+    return ok
+}
+
+// equal weights -> weighted mean = arithmetic mean.
+fn test_equal_weights() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var w: [f64; 256] = [0.0; 256]
+    x[0]=2.0; x[1]=4.0; x[2]=6.0; x[3]=8.0
+    w[0]=1.0; w[1]=1.0; w[2]=1.0; w[3]=1.0
+    let r = weighted_stats(&x, &w, 4)
+    return check(10, approx(r.mean, 5.0, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_weighted() && ok
+    ok = test_equal_weights() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three modules, bringing the runner to **121 modules**. These add support for **weighted observations and frequency-table data** — survey weights, meta-analytic precisions, grouped counts — which the suite's estimators had assumed away. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::weighted_stats` | Weighted mean & variance (population + Kish unbiased) |
| `stats::grouped_stats` | Mean/variance/modal class from a frequency table |
| `stats::weighted_quantile` | Weighted quantiles & median (sort-free) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Weighted: x={1,2,3}, w={1,2,3} → mean 2.333, var_pop 0.5556, var_unbiased 0.9091 (Kish V₁−V₂/V₁).
  - Grouped: midpoints {5,15,25}, freqs {10,20,10} → mean 15, var_pop 50, modal class 15, sample var 51.28.
  - Weighted quantile: equal weights {1,2,3} → median 2; {1,2,3,4} w={1,1,1,5} → weighted median 4; quartiles of {1,2,3,4}.
- Full suite selftest: **121 modules + 7 demos ALL GREEN** under `lean_single`.

`weighted_quantile` uses a **sort-free O(n²)** cumulative-weight scan, avoiding a paired-array sort (and hence any `#852` exposure).

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).