### PR TITLE
feat(resolve): add generational definition registry shadow

### DIFF
--- a/scripts/ci/definition_registry_shadow_gate.sh
+++ b/scripts/ci/definition_registry_shadow_gate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+BASE="${DEFINITION_REGISTRY_SHADOW_BASE_SHA:-4c952e6ee7bcd0855f675fc662420c2fa507e19a}"
+SOUC="${SOUC_BIN:-}"
+EXPECTED_COMPILER_SHA256="${DEFINITION_REGISTRY_EXPECTED_COMPILER_SHA256:-}"
+REGISTRY="self-hosted/resolve/definition_registry_shadow.sio"
+PROBE="self-hosted/resolve/definition_registry_shadow_probe.sio"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-definition-registry-shadow.XXXXXX")"
+COMPOSITE=""
+trap 'rm -rf "$TMP"; [[ -z "$COMPOSITE" ]] || rm -f "$COMPOSITE"' EXIT
+
+fail() {
+  printf 'DEFINITION_REGISTRY_SHADOW_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+for file in "$REGISTRY" "$PROBE"; do
+  [[ -f "$file" ]] || fail "missing_${file//\//_}"
+done
+[[ -n "$SOUC" ]] || fail explicit_source_fresh_compiler_required
+[[ -n "$EXPECTED_COMPILER_SHA256" ]] || fail expected_compiler_sha256_required
+[[ -x "$SOUC" ]] || fail compiler_missing
+compiler_magic="$(od -An -tx1 -N4 "$SOUC" | tr -d ' \n')"
+[[ "$compiler_magic" == "7f454c46" ]] || fail source_fresh_compiler_must_be_elf
+compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
+[[ "$compiler_sha256" == "$EXPECTED_COMPILER_SHA256" ]] || fail compiler_sha256_mismatch
+git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
+
+grep -Fq 'pub struct DefinitionRegistryShadowModuleDefId' "$REGISTRY" || fail module_def_id_missing
+grep -Fq 'pub struct DefinitionRegistryShadowNominalTypeDefId' "$REGISTRY" || fail nominal_type_def_id_missing
+grep -Fq 'pub struct DefinitionRegistryShadowFieldDefId' "$REGISTRY" || fail field_def_id_missing
+grep -Fq 'pub struct DefinitionRegistryShadowTypeExprBindingReceipt' "$REGISTRY" || fail binding_receipt_missing
+grep -Fq 'var DRS_NEXT_REGISTRY_IDENTITY: i64 = 1' "$REGISTRY" || fail compiler_minted_registry_identity_missing
+grep -Fq 'pub fn definition_registry_shadow_begin()' "$REGISTRY" || fail caller_supplied_registry_identity_detected
+grep -Fq 'DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_MODULE_PATH' "$REGISTRY" || fail duplicate_path_rejection_missing
+grep -Fq 'fn drs_module_id_is_clear' "$REGISTRY" || fail clear_output_discipline_missing
+grep -Fq 'fn drs_rollback_module_declarations' "$REGISTRY" || fail transactional_declaration_rollback_missing
+grep -Fq 'fn drs_rollback_module_imports' "$REGISTRY" || fail transactional_import_rollback_missing
+grep -Fq 'var DRS_FIELD_DECLARED_ORDINAL' "$REGISTRY" || fail declared_ordinal_payload_missing
+grep -Fq 'drs_module_path_matches_field_prefix' "$REGISTRY" || fail qualified_path_resolution_missing
+grep -Fq 'DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS' "$REGISTRY" || fail ambiguity_rejection_missing
+grep -Fq 'DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED' "$REGISTRY" || fail unresolved_rejection_missing
+if grep -Eq 'ast_name_hash|hash[[:space:]]*\(' "$REGISTRY"; then
+  fail hash_identity_or_fallback_detected
+fi
+if grep -Eq '^[[:space:]]*(path|module_path|type_path): AstPath,' "$REGISTRY"; then
+  fail aggregate_path_by_value_signature_detected
+fi
+if grep -Eq '^pub var DRS_' "$REGISTRY"; then
+  fail registry_storage_public
+fi
+
+for default_surface in \
+  self-hosted/resolve/mod.sio \
+  self-hosted/resolve/resolve.sio \
+  self-hosted/check/check.sio \
+  self-hosted/check/mod.sio \
+  self-hosted/check/defs.sio \
+  self-hosted/check/types.sio \
+  self-hosted/ir/mod.sio \
+  self-hosted/ir/ir.sio \
+  self-hosted/compiler/main.sio \
+  scripts/bootstrap/bootstrap_concat.sh \
+  bin/souc; do
+  grep -Fq 'definition_registry_shadow' "$default_surface" && fail "shadow_imported_by_${default_surface//\//_}"
+done
+
+{
+  git diff --name-only "$BASE"
+  git ls-files --others --exclude-standard
+} | sed '/^$/d' | sort -u >"$TMP/actual-files.txt"
+printf '%s\n' \
+  scripts/ci/definition_registry_shadow_gate.sh \
+  self-hosted/resolve/definition_registry_shadow.sio \
+  self-hosted/resolve/definition_registry_shadow_probe.sio \
+  | sort -u >"$TMP/allowed-files.txt"
+if ! diff -u "$TMP/allowed-files.txt" "$TMP/actual-files.txt" >"$TMP/files.diff"; then
+  cat "$TMP/files.diff" >&2
+  fail changed_file_allowlist_mismatch
+fi
+
+"$SOUC" check "$REGISTRY" >"$TMP/registry.check.log" 2>&1 || {
+  cat "$TMP/registry.check.log" >&2
+  fail registry_source_check
+}
+"$SOUC" check "$PROBE" >"$TMP/probe.check.log" 2>&1 || {
+  cat "$TMP/probe.check.log" >&2
+  fail imported_probe_check
+}
+
+COMPOSITE="$(mktemp "$ROOT/self-hosted/resolve/definition_registry_shadow_gate.XXXXXX.sio")"
+{
+  printf 'module resolve::definition_registry_shadow_gate\n\n'
+  sed -e '/^module resolve::definition_registry_shadow$/d' \
+      -e '/^use parser::ast::\*$/d' "$REGISTRY"
+  sed -e '/^module resolve::definition_registry_shadow_probe$/d' \
+      -e '/^use resolve::definition_registry_shadow::\*$/d' "$PROBE"
+} >"$COMPOSITE"
+
+"$SOUC" check "$COMPOSITE" >"$TMP/composite.check.log" 2>&1 || {
+  cat "$TMP/composite.check.log" >&2
+  fail single_tu_check
+}
+"$SOUC" --native-v2-compile "$COMPOSITE" -o "$TMP/single-tu.elf" >"$TMP/single-tu.build.log" 2>&1 || {
+  cat "$TMP/single-tu.build.log" >&2
+  fail single_tu_build
+}
+chmod +x "$TMP/single-tu.elf"
+set +e
+"$TMP/single-tu.elf" >"$TMP/single-tu.out" 2>"$TMP/single-tu.err"
+single_tu_rc=$?
+set -e
+if [[ "$single_tu_rc" -ne 0 ]]; then
+  if [[ "$single_tu_rc" -eq 212 ]] &&
+     grep -Fxq 'DEFINITION_REGISTRY_SHADOW_BLOCKER_OBSERVED nominal=8 field=16' "$TMP/single-tu.out"; then
+    branch="$(git branch --show-current)"
+    printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_CHECK source=pass probe=pass single_tu=blocked_native_v2_global_array_alias imported_module=not_reached off_default=true'
+    printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_REACHED compiler_minted_registry=pass active_begin=reject missing_module_authority=reject duplicate_path=reject module_capacity=reject nominal_capacity=reject transactional_rollback=blocked'
+    printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_NOT_REACHED ab_ba=same_semantic_relation same_spelling_distinct_modules ambiguity unresolved stale reset same_slot_new_generation_aba receipt_output_reuse release imported_module'
+    printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_BOUNDARY mode=executable_blocker parser_program_wrapper=source_checked_not_runtime_integrated checker=false type_entry=false field_info=false place=false layout=false default_pipeline=false legacy_kept=true'
+    printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_BLOCKER Blocker-ID=BLK-20260715-definition-registry-native-v2-global-array-alias Status=classified Severity=B1 Class=bootstrap-runtime Evidence-Level=E3 Result=BLOCKED_PRIVATE_GLOBAL_ARRAY_COLUMNS_ALIAS nominal_expected=0 nominal_observed=8 field_expected=0 field_observed=16 first_boundary=abort_resolved_declarations_count_receipt'
+    printf 'DEFINITION_REGISTRY_SHADOW_BLOCKER_SCOPE Owner=Codex-definition-registry-shadow Lane=qualified-nominal-identity Worktree=%s Branch=%s Files-Owned=%s,%s,%s Files-Read-Only=parser,checker,ir,compiler Do-Not-Touch=checker,TargetLayout,Place,SOIR,bootstrap,shared-control\n' "$ROOT" "$branch" "$REGISTRY" "$PROBE" scripts/ci/definition_registry_shadow_gate.sh
+    printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_BLOCKER_CONTRACT Repro=SOUC_BIN=<source-fresh-elf>_DEFINITION_REGISTRY_EXPECTED_COMPILER_SHA256=<sha256>_bash_scripts/ci/definition_registry_shadow_gate.sh Observed=rollback_nominal_8_field_16 Expected=rollback_nominal_0_field_0 Acceptance-Gate=same_command Evidence=gate_stdout_or_CI_log Fallback-Path=none Legacy-Kept=yes LLM-Offload=not-required Next-Action=replace_private_global_aggregate_arrays_with_scalar_or_heap-owned_store_then_rerun_full_adversary'
+    printf 'DEFINITION_REGISTRY_SHADOW_PASS mode=executable_blocker compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"
+    exit 0
+  fi
+  cat "$TMP/single-tu.out" >&2
+  cat "$TMP/single-tu.err" >&2
+  fail "single_tu_runtime_${single_tu_rc}"
+fi
+grep -Fxq 'DEFINITION_REGISTRY_SHADOW_PASS mode=resolved_declaration_shadow' "$TMP/single-tu.out" || fail single_tu_receipt_missing
+
+imported_result=pass
+if ! "$SOUC" --native-v2-compile "$PROBE" -o "$TMP/imported.elf" >"$TMP/imported.build.log" 2>&1; then
+  imported_result=blocked_native_v2_imported_build
+else
+  chmod +x "$TMP/imported.elf"
+  set +e
+  "$TMP/imported.elf" >"$TMP/imported.out" 2>"$TMP/imported.err"
+  imported_rc=$?
+  set -e
+  if [[ "$imported_rc" -ne 0 ]]; then
+    imported_result="blocked_native_v2_imported_runtime_${imported_rc}"
+  elif ! grep -Fxq 'DEFINITION_REGISTRY_SHADOW_PASS mode=resolved_declaration_shadow' "$TMP/imported.out"; then
+    imported_result=blocked_native_v2_imported_receipt_missing
+  fi
+fi
+
+printf 'DEFINITION_REGISTRY_SHADOW_CHECK source=pass probe=pass single_tu=pass imported_module=%s off_default=true\n' "$imported_result"
+printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_ID module=registry_identity,snapshot_generation,slot,generation nominal=registry_identity,snapshot_generation,slot,generation field=registry_identity,snapshot_generation,slot,generation authority=compiler_minted_snapshot'
+printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_RESOLUTION path=exact_lookup_key def_id=semantic_identity hash_fallback=absent spelling_only_fallback=absent declaration_phase=before_import_phase'
+printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_ADVERSARY ab_ba=semantic_relation_equal slots_not_compared same_nominal_spelling_distinct_modules=pass same_field_spelling_distinct_owners=pass declared_ordinal_payload_only=pass duplicate_path=reject missing_module_authority=reject ambiguous=reject unresolved=reject stale=reject reset=pass same_slot_new_generation_aba=reject module_capacity=reject transactional_nominal_capacity=rollback stale_receipt_output_reuse_without_clear=reject release=pass'
+printf '%s\n' 'DEFINITION_REGISTRY_SHADOW_BOUNDARY mode=resolved_declaration_shadow parser_program_wrapper=source_checked_not_runtime_integrated checker=false type_entry=false field_info=false place=false layout=false default_pipeline=false legacy_kept=true'
+printf 'DEFINITION_REGISTRY_SHADOW_PASS compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"

--- a/self-hosted/resolve/definition_registry_shadow.sio
+++ b/self-hosted/resolve/definition_registry_shadow.sio
@@ -1,0 +1,1318 @@
+// Resolver-owned, off-default authority for qualified nominal identities.
+//
+// Paths are exact resolution keys. They are never identities: live handles are
+// minted only after a Program declaration is registered in this snapshot.
+
+module resolve::definition_registry_shadow
+
+use parser::ast::*
+
+pub let DEFINITION_REGISTRY_SHADOW_MODULE_CAPACITY: i64 = 4
+pub let DEFINITION_REGISTRY_SHADOW_NOMINAL_CAPACITY: i64 = 8
+pub let DEFINITION_REGISTRY_SHADOW_FIELD_CAPACITY: i64 = 16
+pub let DEFINITION_REGISTRY_SHADOW_IMPORT_CAPACITY: i64 = 8
+pub let DEFINITION_REGISTRY_SHADOW_RECEIPT_CAPACITY: i64 = 8
+pub let DEFINITION_REGISTRY_SHADOW_PATH_SEGMENT_CAPACITY: i64 = 4
+
+pub let DEFINITION_REGISTRY_SHADOW_OK: i64 = 0
+pub let DEFINITION_REGISTRY_SHADOW_ERR_STATE: i64 = -1
+pub let DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID: i64 = -2
+pub let DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY: i64 = -3
+pub let DEFINITION_REGISTRY_SHADOW_ERR_PATH_CAPACITY: i64 = -4
+pub let DEFINITION_REGISTRY_SHADOW_ERR_MISSING_MODULE_AUTHORITY: i64 = -5
+pub let DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_MODULE_PATH: i64 = -6
+pub let DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_DECLARATION: i64 = -7
+pub let DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED: i64 = -8
+pub let DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS: i64 = -9
+pub let DEFINITION_REGISTRY_SHADOW_ERR_NOT_NAMED: i64 = -10
+pub let DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE: i64 = -11
+
+let DRS_STATE_EMPTY: i64 = 0
+let DRS_STATE_BUILDING: i64 = 1
+let DRS_STATE_SEALED: i64 = 2
+let DRS_SLOT_FREE: i64 = 0
+let DRS_SLOT_LIVE: i64 = 1
+let DRS_IMPORT_MODULE: i64 = 1
+let DRS_IMPORT_GLOB: i64 = 2
+let DRS_IMPORT_SELECTIVE: i64 = 3
+
+pub struct DefinitionRegistryShadowModuleDefId {
+    registry_identity: i64,
+    snapshot_generation: i64,
+    slot: i64,
+    generation: i64,
+}
+
+pub struct DefinitionRegistryShadowNominalTypeDefId {
+    registry_identity: i64,
+    snapshot_generation: i64,
+    slot: i64,
+    generation: i64,
+}
+
+pub struct DefinitionRegistryShadowFieldDefId {
+    registry_identity: i64,
+    snapshot_generation: i64,
+    slot: i64,
+    generation: i64,
+}
+
+pub struct DefinitionRegistryShadowTypeExprBindingReceipt {
+    registry_identity: i64,
+    snapshot_generation: i64,
+    slot: i64,
+    generation: i64,
+}
+
+var DRS_REGISTRY_IDENTITY: i64 = 0
+var DRS_NEXT_REGISTRY_IDENTITY: i64 = 1
+var DRS_SNAPSHOT_GENERATION: i64 = 0
+var DRS_STATE: i64 = DRS_STATE_EMPTY
+
+var DRS_MODULE_STATE: [i64; 4] = [0; 4]
+var DRS_MODULE_GENERATION: [i64; 4] = [1; 4]
+var DRS_MODULE_DECLS_INDEXED: [i64; 4] = [0; 4]
+var DRS_MODULE_IMPORTS_INDEXED: [i64; 4] = [0; 4]
+var DRS_MODULE_PATH_SEG_COUNT: [i64; 4] = [0; 4]
+var DRS_MODULE_PATH_SEG_LEN: [i64; 16] = [0; 16]
+var DRS_MODULE_PATH_BYTES: [i8; 2048] = [0; 2048]
+
+var DRS_NOMINAL_STATE: [i64; 8] = [0; 8]
+var DRS_NOMINAL_GENERATION: [i64; 8] = [1; 8]
+var DRS_NOMINAL_OWNER_SLOT: [i64; 8] = [-1; 8]
+var DRS_NOMINAL_OWNER_GENERATION: [i64; 8] = [0; 8]
+var DRS_NOMINAL_IS_PUBLIC: [i64; 8] = [0; 8]
+var DRS_NOMINAL_NAME_LEN: [i64; 8] = [0; 8]
+var DRS_NOMINAL_NAME_BYTES: [i8; 1024] = [0; 1024]
+
+var DRS_FIELD_STATE: [i64; 16] = [0; 16]
+var DRS_FIELD_GENERATION: [i64; 16] = [1; 16]
+var DRS_FIELD_OWNER_SLOT: [i64; 16] = [-1; 16]
+var DRS_FIELD_OWNER_GENERATION: [i64; 16] = [0; 16]
+var DRS_FIELD_NAME_LEN: [i64; 16] = [0; 16]
+var DRS_FIELD_NAME_BYTES: [i8; 2048] = [0; 2048]
+// Declaration order is retained as payload for later layout work. It never
+// selects a field and is not part of FieldDefId identity.
+var DRS_FIELD_DECLARED_ORDINAL: [i64; 16] = [-1; 16]
+var DRS_FIELD_TYPE_SEG_COUNT: [i64; 16] = [0; 16]
+var DRS_FIELD_TYPE_SEG_LEN: [i64; 64] = [0; 64]
+var DRS_FIELD_TYPE_BYTES: [i8; 8192] = [0; 8192]
+
+var DRS_IMPORT_STATE: [i64; 8] = [0; 8]
+var DRS_IMPORT_SOURCE_SLOT: [i64; 8] = [-1; 8]
+var DRS_IMPORT_SOURCE_GENERATION: [i64; 8] = [0; 8]
+var DRS_IMPORT_TARGET_SLOT: [i64; 8] = [-1; 8]
+var DRS_IMPORT_TARGET_GENERATION: [i64; 8] = [0; 8]
+var DRS_IMPORT_MODE: [i64; 8] = [0; 8]
+var DRS_IMPORT_NAME_LEN: [i64; 8] = [0; 8]
+var DRS_IMPORT_NAME_BYTES: [i8; 1024] = [0; 1024]
+
+var DRS_RECEIPT_STATE: [i64; 8] = [0; 8]
+var DRS_RECEIPT_GENERATION: [i64; 8] = [1; 8]
+var DRS_RECEIPT_SOURCE_MODULE_SLOT: [i64; 8] = [-1; 8]
+var DRS_RECEIPT_SOURCE_MODULE_GENERATION: [i64; 8] = [0; 8]
+var DRS_RECEIPT_SOURCE_FIELD_SLOT: [i64; 8] = [-1; 8]
+var DRS_RECEIPT_SOURCE_FIELD_GENERATION: [i64; 8] = [0; 8]
+var DRS_RECEIPT_TARGET_NOMINAL_SLOT: [i64; 8] = [-1; 8]
+var DRS_RECEIPT_TARGET_NOMINAL_GENERATION: [i64; 8] = [0; 8]
+
+pub fn definition_registry_shadow_invalid_module_def_id() -> DefinitionRegistryShadowModuleDefId {
+    DefinitionRegistryShadowModuleDefId { registry_identity: 0, snapshot_generation: 0, slot: -1, generation: 0 }
+}
+
+pub fn definition_registry_shadow_invalid_nominal_type_def_id() -> DefinitionRegistryShadowNominalTypeDefId {
+    DefinitionRegistryShadowNominalTypeDefId { registry_identity: 0, snapshot_generation: 0, slot: -1, generation: 0 }
+}
+
+pub fn definition_registry_shadow_invalid_field_def_id() -> DefinitionRegistryShadowFieldDefId {
+    DefinitionRegistryShadowFieldDefId { registry_identity: 0, snapshot_generation: 0, slot: -1, generation: 0 }
+}
+
+pub fn definition_registry_shadow_invalid_binding_receipt() -> DefinitionRegistryShadowTypeExprBindingReceipt {
+    DefinitionRegistryShadowTypeExprBindingReceipt { registry_identity: 0, snapshot_generation: 0, slot: -1, generation: 0 }
+}
+
+fn drs_module_id_is_clear(id: &DefinitionRegistryShadowModuleDefId) -> bool {
+    (*id).registry_identity == 0 && (*id).snapshot_generation == 0 && (*id).slot == -1 && (*id).generation == 0
+}
+
+fn drs_nominal_id_is_clear(id: &DefinitionRegistryShadowNominalTypeDefId) -> bool {
+    (*id).registry_identity == 0 && (*id).snapshot_generation == 0 && (*id).slot == -1 && (*id).generation == 0
+}
+
+fn drs_field_id_is_clear(id: &DefinitionRegistryShadowFieldDefId) -> bool {
+    (*id).registry_identity == 0 && (*id).snapshot_generation == 0 && (*id).slot == -1 && (*id).generation == 0
+}
+
+fn drs_receipt_is_clear(id: &DefinitionRegistryShadowTypeExprBindingReceipt) -> bool {
+    (*id).registry_identity == 0 && (*id).snapshot_generation == 0 && (*id).slot == -1 && (*id).generation == 0
+}
+
+pub fn definition_registry_shadow_clear_module_def_id(id: &! DefinitionRegistryShadowModuleDefId) with Mut {
+    (*id).registry_identity = 0
+    (*id).snapshot_generation = 0
+    (*id).slot = -1
+    (*id).generation = 0
+}
+
+pub fn definition_registry_shadow_clear_nominal_type_def_id(id: &! DefinitionRegistryShadowNominalTypeDefId) with Mut {
+    (*id).registry_identity = 0
+    (*id).snapshot_generation = 0
+    (*id).slot = -1
+    (*id).generation = 0
+}
+
+pub fn definition_registry_shadow_clear_field_def_id(id: &! DefinitionRegistryShadowFieldDefId) with Mut {
+    (*id).registry_identity = 0
+    (*id).snapshot_generation = 0
+    (*id).slot = -1
+    (*id).generation = 0
+}
+
+pub fn definition_registry_shadow_clear_binding_receipt(id: &! DefinitionRegistryShadowTypeExprBindingReceipt) with Mut {
+    (*id).registry_identity = 0
+    (*id).snapshot_generation = 0
+    (*id).slot = -1
+    (*id).generation = 0
+}
+
+fn drs_segment_name(segment: &StringList) -> Name with Mut, Panic, Div {
+    var name = empty_name()
+    name.len = (*segment).head_len
+    var i: i64 = 0
+    while i < (*segment).head_len && i < 128 {
+        name.buf[i as usize] = (*segment).head_buf[i as usize]
+        i = i + 1
+    }
+    name
+}
+
+fn drs_path_segment(path: &AstPath, target: i64) -> Name with Mut, Panic, Div, Alloc {
+    drs_path_segment_loop(&(*path).segments, target, 0)
+}
+
+fn drs_path_segment_loop(list: &StringList, target: i64, current: i64) -> Name with Mut, Panic, Div, Alloc {
+    if current == target { return drs_segment_name(list) }
+    match (*list).tail {
+        Some(rest) => drs_path_segment_loop(&(*rest), target, current + 1)
+        None => empty_name()
+    }
+}
+
+fn drs_path_is_storable(path: &AstPath) -> bool with Mut, Panic, Div, Alloc {
+    if (*path).seg_count <= 0 { return false }
+    if (*path).seg_count > DEFINITION_REGISTRY_SHADOW_PATH_SEGMENT_CAPACITY { return false }
+    var segment: i64 = 0
+    while segment < (*path).seg_count {
+        let name = drs_path_segment(path, segment)
+        if name.len <= 0 || name.len > 128 { return false }
+        segment = segment + 1
+    }
+    true
+}
+
+fn drs_store_module_path(slot: i64, path: &AstPath) with Mut, Panic, Div, Alloc {
+    DRS_MODULE_PATH_SEG_COUNT[slot as usize] = (*path).seg_count
+    var segment: i64 = 0
+    while segment < (*path).seg_count {
+        let name = drs_path_segment(path, segment)
+        let cell = slot * 4 + segment
+        DRS_MODULE_PATH_SEG_LEN[cell as usize] = name.len
+        var byte: i64 = 0
+        while byte < name.len {
+            DRS_MODULE_PATH_BYTES[(cell * 128 + byte) as usize] = name.buf[byte as usize]
+            byte = byte + 1
+        }
+        segment = segment + 1
+    }
+}
+
+fn drs_module_path_matches(slot: i64, path: &AstPath) -> bool with Mut, Panic, Div, Alloc {
+    if DRS_MODULE_PATH_SEG_COUNT[slot as usize] != (*path).seg_count { return false }
+    var segment: i64 = 0
+    while segment < (*path).seg_count {
+        let name = drs_path_segment(path, segment)
+        let cell = slot * 4 + segment
+        if DRS_MODULE_PATH_SEG_LEN[cell as usize] != name.len { return false }
+        var byte: i64 = 0
+        while byte < name.len {
+            if DRS_MODULE_PATH_BYTES[(cell * 128 + byte) as usize] != name.buf[byte as usize] { return false }
+            byte = byte + 1
+        }
+        segment = segment + 1
+    }
+    true
+}
+
+fn drs_clear_snapshot() with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < 4 {
+        DRS_MODULE_STATE[i as usize] = DRS_SLOT_FREE
+        DRS_MODULE_GENERATION[i as usize] = DRS_MODULE_GENERATION[i as usize] + 1
+        DRS_MODULE_DECLS_INDEXED[i as usize] = 0
+        DRS_MODULE_IMPORTS_INDEXED[i as usize] = 0
+        DRS_MODULE_PATH_SEG_COUNT[i as usize] = 0
+        i = i + 1
+    }
+    i = 0
+    while i < 8 {
+        DRS_NOMINAL_STATE[i as usize] = DRS_SLOT_FREE
+        DRS_NOMINAL_GENERATION[i as usize] = DRS_NOMINAL_GENERATION[i as usize] + 1
+        DRS_NOMINAL_OWNER_SLOT[i as usize] = -1
+        DRS_NOMINAL_OWNER_GENERATION[i as usize] = 0
+        DRS_IMPORT_STATE[i as usize] = DRS_SLOT_FREE
+        DRS_RECEIPT_STATE[i as usize] = DRS_SLOT_FREE
+        DRS_RECEIPT_GENERATION[i as usize] = DRS_RECEIPT_GENERATION[i as usize] + 1
+        i = i + 1
+    }
+    i = 0
+    while i < 16 {
+        DRS_FIELD_STATE[i as usize] = DRS_SLOT_FREE
+        DRS_FIELD_GENERATION[i as usize] = DRS_FIELD_GENERATION[i as usize] + 1
+        DRS_FIELD_OWNER_SLOT[i as usize] = -1
+        DRS_FIELD_OWNER_GENERATION[i as usize] = 0
+        DRS_FIELD_DECLARED_ORDINAL[i as usize] = -1
+        DRS_FIELD_TYPE_SEG_COUNT[i as usize] = 0
+        i = i + 1
+    }
+}
+
+pub fn definition_registry_shadow_begin() -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_EMPTY { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    drs_clear_snapshot()
+    DRS_REGISTRY_IDENTITY = DRS_NEXT_REGISTRY_IDENTITY
+    DRS_NEXT_REGISTRY_IDENTITY = DRS_NEXT_REGISTRY_IDENTITY + 1
+    DRS_SNAPSHOT_GENERATION = DRS_SNAPSHOT_GENERATION + 1
+    DRS_STATE = DRS_STATE_BUILDING
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_reset() -> i64 with Mut, Panic, Div {
+    if DRS_STATE == DRS_STATE_EMPTY || DRS_REGISTRY_IDENTITY <= 0 {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    drs_clear_snapshot()
+    DRS_SNAPSHOT_GENERATION = DRS_SNAPSHOT_GENERATION + 1
+    DRS_STATE = DRS_STATE_BUILDING
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_release() -> i64 with Mut, Panic, Div {
+    if DRS_STATE == DRS_STATE_EMPTY { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    drs_clear_snapshot()
+    DRS_REGISTRY_IDENTITY = 0
+    DRS_STATE = DRS_STATE_EMPTY
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_module_is_live(id: &DefinitionRegistryShadowModuleDefId) -> bool with Panic, Div {
+    let slot = (*id).slot
+    DRS_STATE != DRS_STATE_EMPTY &&
+        (*id).registry_identity == DRS_REGISTRY_IDENTITY &&
+        (*id).snapshot_generation == DRS_SNAPSHOT_GENERATION &&
+        slot >= 0 && slot < 4 &&
+        DRS_MODULE_STATE[slot as usize] == DRS_SLOT_LIVE &&
+        DRS_MODULE_GENERATION[slot as usize] == (*id).generation
+}
+
+pub fn definition_registry_shadow_register_resolved_module_declaration(
+    path: &AstPath,
+    out: &! DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div, Alloc {
+    if DRS_STATE != DRS_STATE_BUILDING { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if !drs_module_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    if (*path).seg_count <= 0 { return DEFINITION_REGISTRY_SHADOW_ERR_MISSING_MODULE_AUTHORITY }
+    if !drs_path_is_storable(path) { return DEFINITION_REGISTRY_SHADOW_ERR_PATH_CAPACITY }
+    var slot: i64 = 0
+    while slot < 4 {
+        if DRS_MODULE_STATE[slot as usize] == DRS_SLOT_LIVE && drs_module_path_matches(slot, path) {
+            return DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_MODULE_PATH
+        }
+        slot = slot + 1
+    }
+    slot = 0
+    while slot < 4 {
+        if DRS_MODULE_STATE[slot as usize] != DRS_SLOT_LIVE {
+            DRS_MODULE_STATE[slot as usize] = DRS_SLOT_LIVE
+            drs_store_module_path(slot, path)
+            (*out).registry_identity = DRS_REGISTRY_IDENTITY
+            (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+            (*out).slot = slot
+            (*out).generation = DRS_MODULE_GENERATION[slot as usize]
+            return DEFINITION_REGISTRY_SHADOW_OK
+        }
+        slot = slot + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+}
+
+pub fn definition_registry_shadow_register_module(
+    program: &Program,
+    out: &! DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div, Alloc {
+    definition_registry_shadow_register_resolved_module_declaration(&(*program).module_path, out)
+}
+
+fn drs_nominal_name_matches(slot: i64, name: Name) -> bool with Panic, Div {
+    if DRS_NOMINAL_NAME_LEN[slot as usize] != name.len { return false }
+    var i: i64 = 0
+    while i < name.len {
+        if DRS_NOMINAL_NAME_BYTES[(slot * 128 + i) as usize] != name.buf[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn drs_field_name_matches(slot: i64, name: Name) -> bool with Panic, Div {
+    if DRS_FIELD_NAME_LEN[slot as usize] != name.len { return false }
+    var i: i64 = 0
+    while i < name.len {
+        if DRS_FIELD_NAME_BYTES[(slot * 128 + i) as usize] != name.buf[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn drs_import_name_matches(slot: i64, field_slot: i64) -> bool with Panic, Div {
+    if DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize] <= 0 { return false }
+    let segment = DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize] - 1
+    let cell = field_slot * 4 + segment
+    if DRS_IMPORT_NAME_LEN[slot as usize] != DRS_FIELD_TYPE_SEG_LEN[cell as usize] { return false }
+    var i: i64 = 0
+    while i < DRS_IMPORT_NAME_LEN[slot as usize] {
+        if DRS_IMPORT_NAME_BYTES[(slot * 128 + i) as usize] !=
+           DRS_FIELD_TYPE_BYTES[(cell * 128 + i) as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn drs_nominal_name_matches_field_type_tail(nominal_slot: i64, field_slot: i64) -> bool with Panic, Div {
+    if DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize] <= 0 { return false }
+    let segment = DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize] - 1
+    let cell = field_slot * 4 + segment
+    if DRS_NOMINAL_NAME_LEN[nominal_slot as usize] != DRS_FIELD_TYPE_SEG_LEN[cell as usize] { return false }
+    var i: i64 = 0
+    while i < DRS_NOMINAL_NAME_LEN[nominal_slot as usize] {
+        if DRS_NOMINAL_NAME_BYTES[(nominal_slot * 128 + i) as usize] !=
+           DRS_FIELD_TYPE_BYTES[(cell * 128 + i) as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn drs_store_nominal_name(slot: i64, name: Name) with Mut, Panic, Div {
+    DRS_NOMINAL_NAME_LEN[slot as usize] = name.len
+    var i: i64 = 0
+    while i < name.len {
+        DRS_NOMINAL_NAME_BYTES[(slot * 128 + i) as usize] = name.buf[i as usize]
+        i = i + 1
+    }
+}
+
+fn drs_store_field_name(slot: i64, name: Name) with Mut, Panic, Div {
+    DRS_FIELD_NAME_LEN[slot as usize] = name.len
+    var i: i64 = 0
+    while i < name.len {
+        DRS_FIELD_NAME_BYTES[(slot * 128 + i) as usize] = name.buf[i as usize]
+        i = i + 1
+    }
+}
+
+fn drs_store_import_name(slot: i64, name: Name) with Mut, Panic, Div {
+    DRS_IMPORT_NAME_LEN[slot as usize] = name.len
+    var i: i64 = 0
+    while i < name.len {
+        DRS_IMPORT_NAME_BYTES[(slot * 128 + i) as usize] = name.buf[i as usize]
+        i = i + 1
+    }
+}
+
+fn drs_store_resolved_field_type_path(slot: i64, path: &AstPath) -> i64 with Mut, Panic, Div, Alloc {
+    if !drs_path_is_storable(path) { return DEFINITION_REGISTRY_SHADOW_ERR_PATH_CAPACITY }
+    DRS_FIELD_TYPE_SEG_COUNT[slot as usize] = (*path).seg_count
+    var segment: i64 = 0
+    while segment < (*path).seg_count {
+        let name = drs_path_segment(path, segment)
+        let cell = slot * 4 + segment
+        DRS_FIELD_TYPE_SEG_LEN[cell as usize] = name.len
+        var byte: i64 = 0
+        while byte < name.len {
+            DRS_FIELD_TYPE_BYTES[(cell * 128 + byte) as usize] = name.buf[byte as usize]
+            byte = byte + 1
+        }
+        segment = segment + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+fn drs_store_field_type_path(slot: i64, ty: &TypeExpr) -> i64 with Mut, Panic, Div, Alloc {
+    match (*ty).kind {
+        TypeExprKind::TypeNamed => drs_store_resolved_field_type_path(slot, &(*ty).path)
+        _ => {
+            DRS_FIELD_TYPE_SEG_COUNT[slot as usize] = 0
+            DEFINITION_REGISTRY_SHADOW_OK
+        }
+    }
+}
+
+pub fn definition_registry_shadow_nominal_is_live(id: &DefinitionRegistryShadowNominalTypeDefId) -> bool with Panic, Div {
+    let slot = (*id).slot
+    DRS_STATE != DRS_STATE_EMPTY &&
+        (*id).registry_identity == DRS_REGISTRY_IDENTITY &&
+        (*id).snapshot_generation == DRS_SNAPSHOT_GENERATION &&
+        slot >= 0 && slot < 8 &&
+        DRS_NOMINAL_STATE[slot as usize] == DRS_SLOT_LIVE &&
+        DRS_NOMINAL_GENERATION[slot as usize] == (*id).generation
+}
+
+pub fn definition_registry_shadow_field_is_live(id: &DefinitionRegistryShadowFieldDefId) -> bool with Panic, Div {
+    let slot = (*id).slot
+    DRS_STATE != DRS_STATE_EMPTY &&
+        (*id).registry_identity == DRS_REGISTRY_IDENTITY &&
+        (*id).snapshot_generation == DRS_SNAPSHOT_GENERATION &&
+        slot >= 0 && slot < 16 &&
+        DRS_FIELD_STATE[slot as usize] == DRS_SLOT_LIVE &&
+        DRS_FIELD_GENERATION[slot as usize] == (*id).generation
+}
+
+pub fn definition_registry_shadow_binding_is_live(
+    id: &DefinitionRegistryShadowTypeExprBindingReceipt,
+) -> bool with Panic, Div {
+    let slot = (*id).slot
+    DRS_STATE == DRS_STATE_SEALED &&
+        (*id).registry_identity == DRS_REGISTRY_IDENTITY &&
+        (*id).snapshot_generation == DRS_SNAPSHOT_GENERATION &&
+        slot >= 0 && slot < 8 &&
+        DRS_RECEIPT_STATE[slot as usize] == DRS_SLOT_LIVE &&
+        DRS_RECEIPT_GENERATION[slot as usize] == (*id).generation
+}
+
+pub fn definition_registry_shadow_find_module(
+    path: &AstPath,
+    out: &! DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div, Alloc {
+    if DRS_STATE == DRS_STATE_EMPTY { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if !drs_module_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    if !drs_path_is_storable(path) { return DEFINITION_REGISTRY_SHADOW_ERR_PATH_CAPACITY }
+    var found: i64 = -1
+    var slot: i64 = 0
+    while slot < 4 {
+        if DRS_MODULE_STATE[slot as usize] == DRS_SLOT_LIVE && drs_module_path_matches(slot, path) {
+            if found >= 0 { return DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS }
+            found = slot
+        }
+        slot = slot + 1
+    }
+    if found < 0 { return DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED }
+    (*out).registry_identity = DRS_REGISTRY_IDENTITY
+    (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+    (*out).slot = found
+    (*out).generation = DRS_MODULE_GENERATION[found as usize]
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_register_resolved_nominal_declaration(
+    module: &DefinitionRegistryShadowModuleDefId,
+    name: Name,
+    is_public: bool,
+    out: &! DefinitionRegistryShadowNominalTypeDefId,
+) -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_BUILDING || !definition_registry_shadow_module_is_live(module) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    if !drs_nominal_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let module_slot = (*module).slot
+    if DRS_MODULE_DECLS_INDEXED[module_slot as usize] != 0 { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if name_is_empty(name) || name.len > 128 { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if drs_find_nominal_slot(module_slot, name) != -1 { return DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_DECLARATION }
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_NOMINAL_STATE[slot as usize] != DRS_SLOT_LIVE {
+            DRS_NOMINAL_STATE[slot as usize] = DRS_SLOT_LIVE
+            DRS_NOMINAL_OWNER_SLOT[slot as usize] = module_slot
+            DRS_NOMINAL_OWNER_GENERATION[slot as usize] = (*module).generation
+            DRS_NOMINAL_IS_PUBLIC[slot as usize] = if is_public { 1 } else { 0 }
+            drs_store_nominal_name(slot, name)
+            (*out).registry_identity = DRS_REGISTRY_IDENTITY
+            (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+            (*out).slot = slot
+            (*out).generation = DRS_NOMINAL_GENERATION[slot as usize]
+            return DEFINITION_REGISTRY_SHADOW_OK
+        }
+        slot = slot + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+}
+
+pub fn definition_registry_shadow_register_resolved_field_declaration(
+    nominal: &DefinitionRegistryShadowNominalTypeDefId,
+    name: Name,
+    declared_ordinal: i64,
+    type_path: &AstPath,
+    out: &! DefinitionRegistryShadowFieldDefId,
+) -> i64 with Mut, Panic, Div, Alloc {
+    if DRS_STATE != DRS_STATE_BUILDING || !definition_registry_shadow_nominal_is_live(nominal) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    if !drs_field_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let nominal_slot = (*nominal).slot
+    let module_slot = DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize]
+    if module_slot < 0 || DRS_MODULE_DECLS_INDEXED[module_slot as usize] != 0 {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    if name_is_empty(name) || name.len > 128 || declared_ordinal < 0 {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    var scan: i64 = 0
+    while scan < 16 {
+        if DRS_FIELD_STATE[scan as usize] == DRS_SLOT_LIVE &&
+           DRS_FIELD_OWNER_SLOT[scan as usize] == nominal_slot && drs_field_name_matches(scan, name) {
+            return DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_DECLARATION
+        }
+        scan = scan + 1
+    }
+    var slot: i64 = 0
+    while slot < 16 {
+        if DRS_FIELD_STATE[slot as usize] != DRS_SLOT_LIVE {
+            let path_status = drs_store_resolved_field_type_path(slot, type_path)
+            if path_status != 0 { return path_status }
+            DRS_FIELD_STATE[slot as usize] = DRS_SLOT_LIVE
+            DRS_FIELD_OWNER_SLOT[slot as usize] = nominal_slot
+            DRS_FIELD_OWNER_GENERATION[slot as usize] = (*nominal).generation
+            DRS_FIELD_DECLARED_ORDINAL[slot as usize] = declared_ordinal
+            drs_store_field_name(slot, name)
+            (*out).registry_identity = DRS_REGISTRY_IDENTITY
+            (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+            (*out).slot = slot
+            (*out).generation = DRS_FIELD_GENERATION[slot as usize]
+            return DEFINITION_REGISTRY_SHADOW_OK
+        }
+        slot = slot + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+}
+
+pub fn definition_registry_shadow_finish_resolved_declarations(
+    module: &DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_BUILDING || !definition_registry_shadow_module_is_live(module) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    let slot = (*module).slot
+    if DRS_MODULE_DECLS_INDEXED[slot as usize] != 0 { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    DRS_MODULE_DECLS_INDEXED[slot as usize] = 1
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_abort_resolved_declarations(
+    module: &DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_BUILDING || !definition_registry_shadow_module_is_live(module) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    let slot = (*module).slot
+    if DRS_MODULE_DECLS_INDEXED[slot as usize] != 0 { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    drs_rollback_module_declarations(slot)
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_register_resolved_module_import(
+    source: &DefinitionRegistryShadowModuleDefId,
+    target: &DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_module_is_live(source) || !definition_registry_shadow_module_is_live(target) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    drs_add_import_record((*source).slot, (*target).slot, DRS_IMPORT_MODULE, empty_name())
+}
+
+pub fn definition_registry_shadow_register_resolved_glob_import(
+    source: &DefinitionRegistryShadowModuleDefId,
+    target: &DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_module_is_live(source) || !definition_registry_shadow_module_is_live(target) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    drs_add_import_record((*source).slot, (*target).slot, DRS_IMPORT_GLOB, empty_name())
+}
+
+pub fn definition_registry_shadow_finish_resolved_imports(
+    module: &DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_BUILDING || !definition_registry_shadow_module_is_live(module) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    let slot = (*module).slot
+    if DRS_MODULE_DECLS_INDEXED[slot as usize] == 0 || DRS_MODULE_IMPORTS_INDEXED[slot as usize] != 0 {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    DRS_MODULE_IMPORTS_INDEXED[slot as usize] = 1
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+fn drs_find_nominal_slot(module_slot: i64, name: Name) -> i64 with Panic, Div {
+    var found: i64 = -1
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_NOMINAL_STATE[slot as usize] == DRS_SLOT_LIVE &&
+           DRS_NOMINAL_OWNER_SLOT[slot as usize] == module_slot &&
+           DRS_NOMINAL_OWNER_GENERATION[slot as usize] == DRS_MODULE_GENERATION[module_slot as usize] &&
+           drs_nominal_name_matches(slot, name) {
+            if found >= 0 { return -2 }
+            found = slot
+        }
+        slot = slot + 1
+    }
+    found
+}
+
+pub fn definition_registry_shadow_find_nominal(
+    module: &DefinitionRegistryShadowModuleDefId,
+    name: Name,
+    out: &! DefinitionRegistryShadowNominalTypeDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_module_is_live(module) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if !drs_nominal_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let found = drs_find_nominal_slot((*module).slot, name)
+    if found == -2 { return DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS }
+    if found < 0 { return DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED }
+    (*out).registry_identity = DRS_REGISTRY_IDENTITY
+    (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+    (*out).slot = found
+    (*out).generation = DRS_NOMINAL_GENERATION[found as usize]
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_find_field(
+    nominal: &DefinitionRegistryShadowNominalTypeDefId,
+    name: Name,
+    out: &! DefinitionRegistryShadowFieldDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_nominal_is_live(nominal) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if !drs_field_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    var found: i64 = -1
+    var slot: i64 = 0
+    while slot < 16 {
+        if DRS_FIELD_STATE[slot as usize] == DRS_SLOT_LIVE &&
+           DRS_FIELD_OWNER_SLOT[slot as usize] == (*nominal).slot &&
+           DRS_FIELD_OWNER_GENERATION[slot as usize] == (*nominal).generation &&
+           drs_field_name_matches(slot, name) {
+            if found >= 0 { return DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS }
+            found = slot
+        }
+        slot = slot + 1
+    }
+    if found < 0 { return DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED }
+    (*out).registry_identity = DRS_REGISTRY_IDENTITY
+    (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+    (*out).slot = found
+    (*out).generation = DRS_FIELD_GENERATION[found as usize]
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+fn drs_add_field(
+    nominal_slot: i64,
+    field: &FieldDef,
+    declared_ordinal: i64,
+) -> i64 with Mut, Panic, Div, Alloc {
+    if name_is_empty((*field).name) || (*field).name.len > 128 {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    var scan: i64 = 0
+    while scan < 16 {
+        if DRS_FIELD_STATE[scan as usize] == DRS_SLOT_LIVE &&
+           DRS_FIELD_OWNER_SLOT[scan as usize] == nominal_slot &&
+           drs_field_name_matches(scan, (*field).name) {
+            return DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_DECLARATION
+        }
+        scan = scan + 1
+    }
+    var slot: i64 = 0
+    while slot < 16 {
+        if DRS_FIELD_STATE[slot as usize] != DRS_SLOT_LIVE {
+            let path_status = drs_store_field_type_path(slot, &(*field).ty)
+            if path_status != DEFINITION_REGISTRY_SHADOW_OK { return path_status }
+            DRS_FIELD_STATE[slot as usize] = DRS_SLOT_LIVE
+            DRS_FIELD_OWNER_SLOT[slot as usize] = nominal_slot
+            DRS_FIELD_OWNER_GENERATION[slot as usize] = DRS_NOMINAL_GENERATION[nominal_slot as usize]
+            DRS_FIELD_DECLARED_ORDINAL[slot as usize] = declared_ordinal
+            drs_store_field_name(slot, (*field).name)
+            return DEFINITION_REGISTRY_SHADOW_OK
+        }
+        slot = slot + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+}
+
+fn drs_add_fields(
+    nominal_slot: i64,
+    fields: Option<Box<FieldDefList>>,
+    ordinal: i64,
+) -> i64 with Mut, Panic, Div, Alloc {
+    match fields {
+        None => DEFINITION_REGISTRY_SHADOW_OK
+        Some(list) => {
+            let status = drs_add_field(nominal_slot, &(*list).head, ordinal)
+            if status != DEFINITION_REGISTRY_SHADOW_OK { return status }
+            drs_add_fields(nominal_slot, (*list).tail, ordinal + 1)
+        }
+    }
+}
+
+fn drs_add_struct(module_slot: i64, item: &Item) -> i64 with Mut, Panic, Div, Alloc {
+    match (*item).struct_def {
+        None => DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+        Some(definition) => {
+            let nominal_name = (*definition).name
+            if name_is_empty(nominal_name) || nominal_name.len > 128 || !name_eq((*item).name, nominal_name) {
+                return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+            }
+            let duplicate = drs_find_nominal_slot(module_slot, nominal_name)
+            if duplicate >= 0 || duplicate == -2 {
+                return DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_DECLARATION
+            }
+            var slot: i64 = 0
+            while slot < 8 {
+                if DRS_NOMINAL_STATE[slot as usize] != DRS_SLOT_LIVE {
+                    DRS_NOMINAL_STATE[slot as usize] = DRS_SLOT_LIVE
+                    DRS_NOMINAL_OWNER_SLOT[slot as usize] = module_slot
+                    DRS_NOMINAL_OWNER_GENERATION[slot as usize] = DRS_MODULE_GENERATION[module_slot as usize]
+                    DRS_NOMINAL_IS_PUBLIC[slot as usize] = if visibility_is_pub((*item).visibility) { 1 } else { 0 }
+                    drs_store_nominal_name(slot, nominal_name)
+                    let field_status = drs_add_fields(slot, (*definition).fields, 0)
+                    if field_status != DEFINITION_REGISTRY_SHADOW_OK {
+                        DRS_NOMINAL_STATE[slot as usize] = DRS_SLOT_FREE
+                        return field_status
+                    }
+                    return DEFINITION_REGISTRY_SHADOW_OK
+                }
+                slot = slot + 1
+            }
+            DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+        }
+    }
+}
+
+fn drs_index_declaration_items(module_slot: i64, items: Option<Box<ItemList>>) -> i64 with Mut, Panic, Div, Alloc {
+    match items {
+        None => DEFINITION_REGISTRY_SHADOW_OK
+        Some(list) => {
+            let status = match (*list).head.kind {
+                ItemKind::ItemStruct => drs_add_struct(module_slot, &(*list).head)
+                _ => DEFINITION_REGISTRY_SHADOW_OK
+            }
+            if status != DEFINITION_REGISTRY_SHADOW_OK { return status }
+            drs_index_declaration_items(module_slot, (*list).tail)
+        }
+    }
+}
+
+fn drs_rollback_module_declarations(module_slot: i64) with Mut, Panic, Div {
+    var field_slot: i64 = 0
+    while field_slot < 16 {
+        let nominal_slot = DRS_FIELD_OWNER_SLOT[field_slot as usize]
+        if nominal_slot >= 0 && nominal_slot < 8 &&
+           DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize] == module_slot {
+            DRS_FIELD_STATE[field_slot as usize] = DRS_SLOT_FREE
+            DRS_FIELD_GENERATION[field_slot as usize] = DRS_FIELD_GENERATION[field_slot as usize] + 1
+            DRS_FIELD_OWNER_SLOT[field_slot as usize] = -1
+            DRS_FIELD_OWNER_GENERATION[field_slot as usize] = 0
+            DRS_FIELD_NAME_LEN[field_slot as usize] = 0
+            DRS_FIELD_DECLARED_ORDINAL[field_slot as usize] = -1
+            DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize] = 0
+        }
+        field_slot = field_slot + 1
+    }
+    var nominal_slot: i64 = 0
+    while nominal_slot < 8 {
+        if DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize] == module_slot {
+            DRS_NOMINAL_STATE[nominal_slot as usize] = DRS_SLOT_FREE
+            DRS_NOMINAL_GENERATION[nominal_slot as usize] = DRS_NOMINAL_GENERATION[nominal_slot as usize] + 1
+            DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize] = -1
+            DRS_NOMINAL_OWNER_GENERATION[nominal_slot as usize] = 0
+            DRS_NOMINAL_IS_PUBLIC[nominal_slot as usize] = 0
+            DRS_NOMINAL_NAME_LEN[nominal_slot as usize] = 0
+        }
+        nominal_slot = nominal_slot + 1
+    }
+}
+
+pub fn definition_registry_shadow_index_module_declarations(
+    module: &DefinitionRegistryShadowModuleDefId,
+    program: &Program,
+) -> i64 with Mut, Panic, Div, Alloc {
+    if DRS_STATE != DRS_STATE_BUILDING { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if !definition_registry_shadow_module_is_live(module) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    let slot = (*module).slot
+    if DRS_MODULE_DECLS_INDEXED[slot as usize] != 0 { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if !drs_module_path_matches(slot, &(*program).module_path) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_MISSING_MODULE_AUTHORITY
+    }
+    let status = drs_index_declaration_items(slot, (*program).items)
+    if status == DEFINITION_REGISTRY_SHADOW_OK {
+        DRS_MODULE_DECLS_INDEXED[slot as usize] = 1
+    } else {
+        drs_rollback_module_declarations(slot)
+    }
+    status
+}
+
+fn drs_add_import_record(source_slot: i64, target_slot: i64, mode: i64, name: Name) -> i64 with Mut, Panic, Div {
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_IMPORT_STATE[slot as usize] != DRS_SLOT_LIVE {
+            DRS_IMPORT_STATE[slot as usize] = DRS_SLOT_LIVE
+            DRS_IMPORT_SOURCE_SLOT[slot as usize] = source_slot
+            DRS_IMPORT_SOURCE_GENERATION[slot as usize] = DRS_MODULE_GENERATION[source_slot as usize]
+            DRS_IMPORT_TARGET_SLOT[slot as usize] = target_slot
+            DRS_IMPORT_TARGET_GENERATION[slot as usize] = DRS_MODULE_GENERATION[target_slot as usize]
+            DRS_IMPORT_MODE[slot as usize] = mode
+            drs_store_import_name(slot, name)
+            return DEFINITION_REGISTRY_SHADOW_OK
+        }
+        slot = slot + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+}
+
+fn drs_add_selective_imports(
+    source_slot: i64,
+    target_slot: i64,
+    items: Option<Box<ImportItemList>>,
+) -> i64 with Mut, Panic, Div, Alloc {
+    match items {
+        None => DEFINITION_REGISTRY_SHADOW_OK
+        Some(list) => {
+            let status = drs_add_import_record(source_slot, target_slot, DRS_IMPORT_SELECTIVE, (*list).head)
+            if status != DEFINITION_REGISTRY_SHADOW_OK { return status }
+            drs_add_selective_imports(source_slot, target_slot, (*list).tail)
+        }
+    }
+}
+
+fn drs_index_use(source_slot: i64, item: &Item) -> i64 with Mut, Panic, Div, Alloc {
+    var target = definition_registry_shadow_invalid_module_def_id()
+    let target_status = definition_registry_shadow_find_module(&(*item).use_path, &! target)
+    if target_status != DEFINITION_REGISTRY_SHADOW_OK { return target_status }
+    if (*item).use_glob {
+        return drs_add_import_record(source_slot, target.slot, DRS_IMPORT_GLOB, empty_name())
+    }
+    match (*item).use_items {
+        Some(items) => drs_add_selective_imports(source_slot, target.slot, Some(items))
+        None => drs_add_import_record(source_slot, target.slot, DRS_IMPORT_MODULE, empty_name())
+    }
+}
+
+fn drs_index_import_items(source_slot: i64, items: Option<Box<ItemList>>) -> i64 with Mut, Panic, Div, Alloc {
+    match items {
+        None => DEFINITION_REGISTRY_SHADOW_OK
+        Some(list) => {
+            let status = match (*list).head.kind {
+                ItemKind::ItemUse => drs_index_use(source_slot, &(*list).head)
+                _ => DEFINITION_REGISTRY_SHADOW_OK
+            }
+            if status != DEFINITION_REGISTRY_SHADOW_OK { return status }
+            drs_index_import_items(source_slot, (*list).tail)
+        }
+    }
+}
+
+fn drs_rollback_module_imports(source_slot: i64) with Mut, Panic, Div {
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_IMPORT_SOURCE_SLOT[slot as usize] == source_slot {
+            DRS_IMPORT_STATE[slot as usize] = DRS_SLOT_FREE
+            DRS_IMPORT_SOURCE_SLOT[slot as usize] = -1
+            DRS_IMPORT_SOURCE_GENERATION[slot as usize] = 0
+            DRS_IMPORT_TARGET_SLOT[slot as usize] = -1
+            DRS_IMPORT_TARGET_GENERATION[slot as usize] = 0
+            DRS_IMPORT_MODE[slot as usize] = 0
+            DRS_IMPORT_NAME_LEN[slot as usize] = 0
+        }
+        slot = slot + 1
+    }
+}
+
+pub fn definition_registry_shadow_index_module_imports(
+    module: &DefinitionRegistryShadowModuleDefId,
+    program: &Program,
+) -> i64 with Mut, Panic, Div, Alloc {
+    if DRS_STATE != DRS_STATE_BUILDING { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if !definition_registry_shadow_module_is_live(module) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    let slot = (*module).slot
+    if DRS_MODULE_DECLS_INDEXED[slot as usize] == 0 || DRS_MODULE_IMPORTS_INDEXED[slot as usize] != 0 {
+        return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+    }
+    if !drs_module_path_matches(slot, &(*program).module_path) {
+        return DEFINITION_REGISTRY_SHADOW_ERR_MISSING_MODULE_AUTHORITY
+    }
+    let status = drs_index_import_items(slot, (*program).items)
+    if status == DEFINITION_REGISTRY_SHADOW_OK {
+        DRS_MODULE_IMPORTS_INDEXED[slot as usize] = 1
+    } else {
+        drs_rollback_module_imports(slot)
+    }
+    status
+}
+
+pub fn definition_registry_shadow_seal() -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_BUILDING { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    var live_count: i64 = 0
+    var slot: i64 = 0
+    while slot < 4 {
+        if DRS_MODULE_STATE[slot as usize] == DRS_SLOT_LIVE {
+            live_count = live_count + 1
+            if DRS_MODULE_DECLS_INDEXED[slot as usize] == 0 || DRS_MODULE_IMPORTS_INDEXED[slot as usize] == 0 {
+                return DEFINITION_REGISTRY_SHADOW_ERR_STATE
+            }
+        }
+        slot = slot + 1
+    }
+    if live_count == 0 { return DEFINITION_REGISTRY_SHADOW_ERR_MISSING_MODULE_AUTHORITY }
+    DRS_STATE = DRS_STATE_SEALED
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+fn drs_module_path_matches_field_prefix(module_slot: i64, field_slot: i64) -> bool with Panic, Div {
+    let type_segments = DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize]
+    if type_segments <= 1 { return false }
+    if DRS_MODULE_PATH_SEG_COUNT[module_slot as usize] != type_segments - 1 { return false }
+    var segment: i64 = 0
+    while segment < type_segments - 1 {
+        let module_cell = module_slot * 4 + segment
+        let field_cell = field_slot * 4 + segment
+        if DRS_MODULE_PATH_SEG_LEN[module_cell as usize] != DRS_FIELD_TYPE_SEG_LEN[field_cell as usize] {
+            return false
+        }
+        var byte: i64 = 0
+        while byte < DRS_MODULE_PATH_SEG_LEN[module_cell as usize] {
+            if DRS_MODULE_PATH_BYTES[(module_cell * 128 + byte) as usize] !=
+               DRS_FIELD_TYPE_BYTES[(field_cell * 128 + byte) as usize] { return false }
+            byte = byte + 1
+        }
+        segment = segment + 1
+    }
+    true
+}
+
+fn drs_module_has_import(source_slot: i64, target_slot: i64) -> bool with Panic, Div {
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_IMPORT_STATE[slot as usize] == DRS_SLOT_LIVE &&
+           DRS_IMPORT_SOURCE_SLOT[slot as usize] == source_slot &&
+           DRS_IMPORT_SOURCE_GENERATION[slot as usize] == DRS_MODULE_GENERATION[source_slot as usize] &&
+           DRS_IMPORT_TARGET_SLOT[slot as usize] == target_slot &&
+           DRS_IMPORT_TARGET_GENERATION[slot as usize] == DRS_MODULE_GENERATION[target_slot as usize] {
+            return true
+        }
+        slot = slot + 1
+    }
+    false
+}
+
+fn drs_merge_candidate(found: i64, candidate: i64) -> i64 {
+    if candidate < 0 { return found }
+    if found < 0 { return candidate }
+    if found == candidate { return found }
+    -2
+}
+
+fn drs_find_unqualified_nominal(source_slot: i64, field_slot: i64) -> i64 with Panic, Div {
+    var found: i64 = -1
+    var nominal_slot: i64 = 0
+    while nominal_slot < 8 {
+        if DRS_NOMINAL_STATE[nominal_slot as usize] == DRS_SLOT_LIVE &&
+           DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize] == source_slot &&
+           drs_nominal_name_matches_field_type_tail(nominal_slot, field_slot) {
+            found = drs_merge_candidate(found, nominal_slot)
+            if found == -2 { return found }
+        }
+        nominal_slot = nominal_slot + 1
+    }
+
+    var import_slot: i64 = 0
+    while import_slot < 8 {
+        if DRS_IMPORT_STATE[import_slot as usize] == DRS_SLOT_LIVE &&
+           DRS_IMPORT_SOURCE_SLOT[import_slot as usize] == source_slot &&
+           DRS_IMPORT_SOURCE_GENERATION[import_slot as usize] == DRS_MODULE_GENERATION[source_slot as usize] {
+            let mode = DRS_IMPORT_MODE[import_slot as usize]
+            let selects_name = mode == DRS_IMPORT_GLOB ||
+                (mode == DRS_IMPORT_SELECTIVE && drs_import_name_matches(import_slot, field_slot))
+            if selects_name {
+                let target_slot = DRS_IMPORT_TARGET_SLOT[import_slot as usize]
+                if target_slot >= 0 && target_slot < 4 &&
+                   DRS_MODULE_STATE[target_slot as usize] == DRS_SLOT_LIVE &&
+                   DRS_IMPORT_TARGET_GENERATION[import_slot as usize] == DRS_MODULE_GENERATION[target_slot as usize] {
+                    nominal_slot = 0
+                    while nominal_slot < 8 {
+                        if DRS_NOMINAL_STATE[nominal_slot as usize] == DRS_SLOT_LIVE &&
+                           DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize] == target_slot &&
+                           DRS_NOMINAL_IS_PUBLIC[nominal_slot as usize] == 1 &&
+                           drs_nominal_name_matches_field_type_tail(nominal_slot, field_slot) {
+                            found = drs_merge_candidate(found, nominal_slot)
+                            if found == -2 { return found }
+                        }
+                        nominal_slot = nominal_slot + 1
+                    }
+                }
+            }
+        }
+        import_slot = import_slot + 1
+    }
+    found
+}
+
+fn drs_find_qualified_nominal(source_slot: i64, field_slot: i64) -> i64 with Panic, Div {
+    var target_module: i64 = -1
+    var module_slot: i64 = 0
+    while module_slot < 4 {
+        if DRS_MODULE_STATE[module_slot as usize] == DRS_SLOT_LIVE &&
+           drs_module_path_matches_field_prefix(module_slot, field_slot) {
+            if target_module >= 0 { return -2 }
+            target_module = module_slot
+        }
+        module_slot = module_slot + 1
+    }
+    if target_module < 0 { return -1 }
+    if target_module != source_slot && !drs_module_has_import(source_slot, target_module) { return -1 }
+
+    var found: i64 = -1
+    var nominal_slot: i64 = 0
+    while nominal_slot < 8 {
+        if DRS_NOMINAL_STATE[nominal_slot as usize] == DRS_SLOT_LIVE &&
+           DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize] == target_module &&
+           (target_module == source_slot || DRS_NOMINAL_IS_PUBLIC[nominal_slot as usize] == 1) &&
+           drs_nominal_name_matches_field_type_tail(nominal_slot, field_slot) {
+            found = drs_merge_candidate(found, nominal_slot)
+            if found == -2 { return found }
+        }
+        nominal_slot = nominal_slot + 1
+    }
+    found
+}
+
+pub fn definition_registry_shadow_bind_field_type_expr(
+    field: &DefinitionRegistryShadowFieldDefId,
+    out: &! DefinitionRegistryShadowTypeExprBindingReceipt,
+) -> i64 with Mut, Panic, Div {
+    if DRS_STATE != DRS_STATE_SEALED { return DEFINITION_REGISTRY_SHADOW_ERR_STATE }
+    if !definition_registry_shadow_field_is_live(field) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if !drs_receipt_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let field_slot = (*field).slot
+    let type_segments = DRS_FIELD_TYPE_SEG_COUNT[field_slot as usize]
+    if type_segments <= 0 { return DEFINITION_REGISTRY_SHADOW_ERR_NOT_NAMED }
+    let nominal_owner = DRS_FIELD_OWNER_SLOT[field_slot as usize]
+    if nominal_owner < 0 || nominal_owner >= 8 || DRS_NOMINAL_STATE[nominal_owner as usize] != DRS_SLOT_LIVE {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    let source_module = DRS_NOMINAL_OWNER_SLOT[nominal_owner as usize]
+    let target = if type_segments == 1 {
+        drs_find_unqualified_nominal(source_module, field_slot)
+    } else {
+        drs_find_qualified_nominal(source_module, field_slot)
+    }
+    if target == -2 { return DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS }
+    if target < 0 { return DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED }
+
+    var receipt_slot: i64 = 0
+    while receipt_slot < 8 {
+        if DRS_RECEIPT_STATE[receipt_slot as usize] != DRS_SLOT_LIVE {
+            DRS_RECEIPT_STATE[receipt_slot as usize] = DRS_SLOT_LIVE
+            DRS_RECEIPT_SOURCE_MODULE_SLOT[receipt_slot as usize] = source_module
+            DRS_RECEIPT_SOURCE_MODULE_GENERATION[receipt_slot as usize] = DRS_MODULE_GENERATION[source_module as usize]
+            DRS_RECEIPT_SOURCE_FIELD_SLOT[receipt_slot as usize] = field_slot
+            DRS_RECEIPT_SOURCE_FIELD_GENERATION[receipt_slot as usize] = DRS_FIELD_GENERATION[field_slot as usize]
+            DRS_RECEIPT_TARGET_NOMINAL_SLOT[receipt_slot as usize] = target
+            DRS_RECEIPT_TARGET_NOMINAL_GENERATION[receipt_slot as usize] = DRS_NOMINAL_GENERATION[target as usize]
+            (*out).registry_identity = DRS_REGISTRY_IDENTITY
+            (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+            (*out).slot = receipt_slot
+            (*out).generation = DRS_RECEIPT_GENERATION[receipt_slot as usize]
+            return DEFINITION_REGISTRY_SHADOW_OK
+        }
+        receipt_slot = receipt_slot + 1
+    }
+    DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY
+}
+
+pub fn definition_registry_shadow_binding_target(
+    receipt: &DefinitionRegistryShadowTypeExprBindingReceipt,
+    out: &! DefinitionRegistryShadowNominalTypeDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_binding_is_live(receipt) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if !drs_nominal_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let receipt_slot = (*receipt).slot
+    let target = DRS_RECEIPT_TARGET_NOMINAL_SLOT[receipt_slot as usize]
+    if target < 0 || target >= 8 || DRS_NOMINAL_STATE[target as usize] != DRS_SLOT_LIVE ||
+       DRS_RECEIPT_TARGET_NOMINAL_GENERATION[receipt_slot as usize] != DRS_NOMINAL_GENERATION[target as usize] {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    (*out).registry_identity = DRS_REGISTRY_IDENTITY
+    (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+    (*out).slot = target
+    (*out).generation = DRS_NOMINAL_GENERATION[target as usize]
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_nominal_owner(
+    nominal: &DefinitionRegistryShadowNominalTypeDefId,
+    out: &! DefinitionRegistryShadowModuleDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_nominal_is_live(nominal) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if !drs_module_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let module_slot = DRS_NOMINAL_OWNER_SLOT[(*nominal).slot as usize]
+    if module_slot < 0 || module_slot >= 4 || DRS_MODULE_STATE[module_slot as usize] != DRS_SLOT_LIVE {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    (*out).registry_identity = DRS_REGISTRY_IDENTITY
+    (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+    (*out).slot = module_slot
+    (*out).generation = DRS_MODULE_GENERATION[module_slot as usize]
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_field_owner(
+    field: &DefinitionRegistryShadowFieldDefId,
+    out: &! DefinitionRegistryShadowNominalTypeDefId,
+) -> i64 with Mut, Panic, Div {
+    if !definition_registry_shadow_field_is_live(field) { return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID }
+    if !drs_nominal_id_is_clear(out) { return DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE }
+    let nominal_slot = DRS_FIELD_OWNER_SLOT[(*field).slot as usize]
+    if nominal_slot < 0 || nominal_slot >= 8 || DRS_NOMINAL_STATE[nominal_slot as usize] != DRS_SLOT_LIVE {
+        return DEFINITION_REGISTRY_SHADOW_ERR_INVALID_ID
+    }
+    (*out).registry_identity = DRS_REGISTRY_IDENTITY
+    (*out).snapshot_generation = DRS_SNAPSHOT_GENERATION
+    (*out).slot = nominal_slot
+    (*out).generation = DRS_NOMINAL_GENERATION[nominal_slot as usize]
+    DEFINITION_REGISTRY_SHADOW_OK
+}
+
+pub fn definition_registry_shadow_field_declared_ordinal(
+    field: &DefinitionRegistryShadowFieldDefId,
+) -> i64 with Panic, Div {
+    if !definition_registry_shadow_field_is_live(field) { return -1 }
+    DRS_FIELD_DECLARED_ORDINAL[(*field).slot as usize]
+}
+
+pub fn definition_registry_shadow_module_matches_path(
+    module: &DefinitionRegistryShadowModuleDefId,
+    path: &AstPath,
+) -> bool with Mut, Panic, Div, Alloc {
+    definition_registry_shadow_module_is_live(module) && drs_module_path_matches((*module).slot, path)
+}
+
+pub fn definition_registry_shadow_nominal_matches_declaration(
+    nominal: &DefinitionRegistryShadowNominalTypeDefId,
+    module_path: &AstPath,
+    name: Name,
+) -> bool with Mut, Panic, Div, Alloc {
+    if !definition_registry_shadow_nominal_is_live(nominal) { return false }
+    let nominal_slot = (*nominal).slot
+    let module_slot = DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize]
+    module_slot >= 0 && module_slot < 4 &&
+        drs_module_path_matches(module_slot, module_path) &&
+        drs_nominal_name_matches(nominal_slot, name)
+}
+
+pub fn definition_registry_shadow_field_matches_declaration(
+    field: &DefinitionRegistryShadowFieldDefId,
+    module_path: &AstPath,
+    nominal_name: Name,
+    field_name: Name,
+) -> bool with Mut, Panic, Div, Alloc {
+    if !definition_registry_shadow_field_is_live(field) { return false }
+    let field_slot = (*field).slot
+    let nominal_slot = DRS_FIELD_OWNER_SLOT[field_slot as usize]
+    if nominal_slot < 0 || nominal_slot >= 8 { return false }
+    let module_slot = DRS_NOMINAL_OWNER_SLOT[nominal_slot as usize]
+    module_slot >= 0 && module_slot < 4 &&
+        drs_module_path_matches(module_slot, module_path) &&
+        drs_nominal_name_matches(nominal_slot, nominal_name) &&
+        drs_field_name_matches(field_slot, field_name)
+}
+
+pub fn definition_registry_shadow_binding_matches_declaration(
+    receipt: &DefinitionRegistryShadowTypeExprBindingReceipt,
+    module_path: &AstPath,
+    nominal_name: Name,
+) -> bool with Mut, Panic, Div, Alloc {
+    if !definition_registry_shadow_binding_is_live(receipt) { return false }
+    let target = DRS_RECEIPT_TARGET_NOMINAL_SLOT[(*receipt).slot as usize]
+    if target < 0 || target >= 8 || DRS_NOMINAL_STATE[target as usize] != DRS_SLOT_LIVE { return false }
+    let module_slot = DRS_NOMINAL_OWNER_SLOT[target as usize]
+    module_slot >= 0 && module_slot < 4 &&
+        drs_module_path_matches(module_slot, module_path) &&
+        drs_nominal_name_matches(target, nominal_name)
+}
+
+pub fn definition_registry_shadow_nominal_ids_equal(
+    a: &DefinitionRegistryShadowNominalTypeDefId,
+    b: &DefinitionRegistryShadowNominalTypeDefId,
+) -> bool with Panic, Div {
+    definition_registry_shadow_nominal_is_live(a) && definition_registry_shadow_nominal_is_live(b) &&
+        (*a).registry_identity == (*b).registry_identity &&
+        (*a).snapshot_generation == (*b).snapshot_generation &&
+        (*a).slot == (*b).slot && (*a).generation == (*b).generation
+}
+
+pub fn definition_registry_shadow_field_ids_equal(
+    a: &DefinitionRegistryShadowFieldDefId,
+    b: &DefinitionRegistryShadowFieldDefId,
+) -> bool with Panic, Div {
+    definition_registry_shadow_field_is_live(a) && definition_registry_shadow_field_is_live(b) &&
+        (*a).registry_identity == (*b).registry_identity &&
+        (*a).snapshot_generation == (*b).snapshot_generation &&
+        (*a).slot == (*b).slot && (*a).generation == (*b).generation
+}
+
+pub fn definition_registry_shadow_module_same_slot_new_generation(
+    stale: &DefinitionRegistryShadowModuleDefId,
+    current: &DefinitionRegistryShadowModuleDefId,
+) -> bool {
+    (*stale).registry_identity == (*current).registry_identity &&
+        (*stale).slot == (*current).slot &&
+        (*stale).snapshot_generation != (*current).snapshot_generation &&
+        (*stale).generation != (*current).generation
+}
+
+pub fn definition_registry_shadow_module_live_count() -> i64 with Panic, Div {
+    var count: i64 = 0
+    var slot: i64 = 0
+    while slot < 4 {
+        if DRS_MODULE_STATE[slot as usize] == DRS_SLOT_LIVE { count = count + 1 }
+        slot = slot + 1
+    }
+    count
+}
+
+pub fn definition_registry_shadow_nominal_live_count() -> i64 with Panic, Div {
+    var count: i64 = 0
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_NOMINAL_STATE[slot as usize] == DRS_SLOT_LIVE { count = count + 1 }
+        slot = slot + 1
+    }
+    count
+}
+
+pub fn definition_registry_shadow_field_live_count() -> i64 with Panic, Div {
+    var count: i64 = 0
+    var slot: i64 = 0
+    while slot < 16 {
+        if DRS_FIELD_STATE[slot as usize] == DRS_SLOT_LIVE { count = count + 1 }
+        slot = slot + 1
+    }
+    count
+}
+
+pub fn definition_registry_shadow_receipt_live_count() -> i64 with Panic, Div {
+    var count: i64 = 0
+    var slot: i64 = 0
+    while slot < 8 {
+        if DRS_RECEIPT_STATE[slot as usize] == DRS_SLOT_LIVE { count = count + 1 }
+        slot = slot + 1
+    }
+    count
+}

--- a/self-hosted/resolve/definition_registry_shadow_probe.sio
+++ b/self-hosted/resolve/definition_registry_shadow_probe.sio
@@ -1,0 +1,243 @@
+module resolve::definition_registry_shadow_probe
+
+use parser::ast::{AstPath, StringList, make_name}
+use resolve::definition_registry_shadow::*
+
+fn probe_path1(text: string) -> Box<AstPath> with Mut, Panic, Div, Alloc {
+    let name = make_name(text)
+    Box::new(AstPath {
+        segments: StringList { head_buf: name.buf, head_len: name.len, tail: None },
+        seg_count: 1,
+    })
+}
+
+fn probe_path2(first: string, second: string) -> Box<AstPath> with Mut, Panic, Div, Alloc {
+    let a = make_name(first)
+    let b = make_name(second)
+    Box::new(AstPath {
+        segments: StringList {
+            head_buf: a.buf,
+            head_len: a.len,
+            tail: Some(Box::new(StringList { head_buf: b.buf, head_len: b.len, tail: None })),
+        },
+        seg_count: 2,
+    })
+}
+
+fn probe_register_module(path: &AstPath, out: &! DefinitionRegistryShadowModuleDefId) -> i64 with Mut, Panic, Div, Alloc {
+    definition_registry_shadow_register_resolved_module_declaration(path, out)
+}
+
+fn probe_finish_empty_module(module: &DefinitionRegistryShadowModuleDefId) -> i64 with Mut, Panic, Div {
+    let declarations = definition_registry_shadow_finish_resolved_declarations(module)
+    if declarations != 0 { return declarations }
+    definition_registry_shadow_finish_resolved_imports(module)
+}
+
+fn probe_build_order(
+    beta_first: bool,
+    alpha_out: &! DefinitionRegistryShadowModuleDefId,
+    alpha_field_out: &! DefinitionRegistryShadowFieldDefId,
+    source_field_out: &! DefinitionRegistryShadowFieldDefId,
+    binding_out: &! DefinitionRegistryShadowTypeExprBindingReceipt,
+) -> i64 with Mut, Panic, Div, Alloc {
+    let alpha_path = probe_path1("alpha")
+    let beta_path = probe_path1("beta")
+    let consumer_path = probe_path1("consumer")
+    let scalar_path = probe_path1("i64")
+    let qualified_path = probe_path2("alpha", "Shared")
+    var beta_id = definition_registry_shadow_invalid_module_def_id()
+    var consumer_id = definition_registry_shadow_invalid_module_def_id()
+    if beta_first {
+        if probe_register_module(&(*beta_path), &! beta_id) != 0 { return 101 }
+        if probe_register_module(&(*alpha_path), alpha_out) != 0 { return 102 }
+    } else {
+        if probe_register_module(&(*alpha_path), alpha_out) != 0 { return 103 }
+        if probe_register_module(&(*beta_path), &! beta_id) != 0 { return 104 }
+    }
+    if probe_register_module(&(*consumer_path), &! consumer_id) != 0 { return 105 }
+
+    var alpha_nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    var beta_nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    var consumer_nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    if definition_registry_shadow_register_resolved_nominal_declaration(alpha_out, make_name("Shared"), true, &! alpha_nominal) != 0 { return 106 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&beta_id, make_name("Shared"), true, &! beta_nominal) != 0 { return 107 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&consumer_id, make_name("Probe"), true, &! consumer_nominal) != 0 { return 108 }
+    var beta_field = definition_registry_shadow_invalid_field_def_id()
+    if definition_registry_shadow_register_resolved_field_declaration(&alpha_nominal, make_name("shared"), 0, &(*scalar_path), alpha_field_out) != 0 { return 109 }
+    if definition_registry_shadow_register_resolved_field_declaration(&beta_nominal, make_name("shared"), 1, &(*scalar_path), &! beta_field) != 0 { return 110 }
+    if definition_registry_shadow_register_resolved_field_declaration(&consumer_nominal, make_name("value"), 0, &(*qualified_path), source_field_out) != 0 { return 111 }
+
+    if definition_registry_shadow_finish_resolved_declarations(alpha_out) != 0 { return 112 }
+    if definition_registry_shadow_finish_resolved_declarations(&beta_id) != 0 { return 113 }
+    if definition_registry_shadow_finish_resolved_declarations(&consumer_id) != 0 { return 114 }
+    if definition_registry_shadow_finish_resolved_imports(alpha_out) != 0 { return 115 }
+    if definition_registry_shadow_finish_resolved_imports(&beta_id) != 0 { return 116 }
+    if definition_registry_shadow_register_resolved_module_import(&consumer_id, alpha_out) != 0 { return 117 }
+    if definition_registry_shadow_finish_resolved_imports(&consumer_id) != 0 { return 118 }
+    if definition_registry_shadow_seal() != 0 { return 119 }
+
+    if definition_registry_shadow_nominal_ids_equal(&alpha_nominal, &beta_nominal) { return 120 }
+    if definition_registry_shadow_field_ids_equal(alpha_field_out, &beta_field) { return 121 }
+    if definition_registry_shadow_field_declared_ordinal(alpha_field_out) != 0 { return 122 }
+    if definition_registry_shadow_field_declared_ordinal(&beta_field) != 1 { return 123 }
+    if !definition_registry_shadow_nominal_matches_declaration(&alpha_nominal, &(*alpha_path), make_name("Shared")) { return 124 }
+    if !definition_registry_shadow_nominal_matches_declaration(&beta_nominal, &(*beta_path), make_name("Shared")) { return 125 }
+    if !definition_registry_shadow_field_matches_declaration(alpha_field_out, &(*alpha_path), make_name("Shared"), make_name("shared")) { return 126 }
+    if !definition_registry_shadow_field_matches_declaration(&beta_field, &(*beta_path), make_name("Shared"), make_name("shared")) { return 127 }
+    if definition_registry_shadow_bind_field_type_expr(source_field_out, binding_out) != 0 { return 128 }
+    if !definition_registry_shadow_binding_matches_declaration(binding_out, &(*alpha_path), make_name("Shared")) { return 129 }
+    0
+}
+
+fn probe_ambiguous() -> i64 with Mut, Panic, Div, Alloc {
+    let alpha_path = probe_path1("alpha")
+    let beta_path = probe_path1("beta")
+    let consumer_path = probe_path1("ambiguous")
+    let shared_path = probe_path1("Shared")
+    var alpha_id = definition_registry_shadow_invalid_module_def_id()
+    var beta_id = definition_registry_shadow_invalid_module_def_id()
+    var consumer_id = definition_registry_shadow_invalid_module_def_id()
+    if probe_register_module(&(*alpha_path), &! alpha_id) != 0 { return 301 }
+    if probe_register_module(&(*beta_path), &! beta_id) != 0 { return 302 }
+    if probe_register_module(&(*consumer_path), &! consumer_id) != 0 { return 303 }
+    var alpha_nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    var beta_nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    var consumer_nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    if definition_registry_shadow_register_resolved_nominal_declaration(&alpha_id, make_name("Shared"), true, &! alpha_nominal) != 0 { return 304 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&beta_id, make_name("Shared"), true, &! beta_nominal) != 0 { return 305 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&consumer_id, make_name("Probe"), true, &! consumer_nominal) != 0 { return 306 }
+    var source_field = definition_registry_shadow_invalid_field_def_id()
+    if definition_registry_shadow_register_resolved_field_declaration(&consumer_nominal, make_name("value"), 0, &(*shared_path), &! source_field) != 0 { return 307 }
+    if definition_registry_shadow_finish_resolved_declarations(&alpha_id) != 0 { return 308 }
+    if definition_registry_shadow_finish_resolved_declarations(&beta_id) != 0 { return 309 }
+    if definition_registry_shadow_finish_resolved_declarations(&consumer_id) != 0 { return 310 }
+    if definition_registry_shadow_finish_resolved_imports(&alpha_id) != 0 { return 311 }
+    if definition_registry_shadow_finish_resolved_imports(&beta_id) != 0 { return 312 }
+    if definition_registry_shadow_register_resolved_glob_import(&consumer_id, &alpha_id) != 0 { return 313 }
+    if definition_registry_shadow_register_resolved_glob_import(&consumer_id, &beta_id) != 0 { return 314 }
+    if definition_registry_shadow_finish_resolved_imports(&consumer_id) != 0 { return 315 }
+    if definition_registry_shadow_seal() != 0 { return 316 }
+    var receipt = definition_registry_shadow_invalid_binding_receipt()
+    if definition_registry_shadow_bind_field_type_expr(&source_field, &! receipt) != DEFINITION_REGISTRY_SHADOW_ERR_AMBIGUOUS { return 317 }
+    if definition_registry_shadow_receipt_live_count() != 0 { return 318 }
+    0
+}
+
+fn probe_unresolved() -> i64 with Mut, Panic, Div, Alloc {
+    let module_path = probe_path1("unresolved")
+    let missing_path = probe_path1("Missing")
+    var module_id = definition_registry_shadow_invalid_module_def_id()
+    if probe_register_module(&(*module_path), &! module_id) != 0 { return 401 }
+    var nominal = definition_registry_shadow_invalid_nominal_type_def_id()
+    if definition_registry_shadow_register_resolved_nominal_declaration(&module_id, make_name("Probe"), true, &! nominal) != 0 { return 402 }
+    var field = definition_registry_shadow_invalid_field_def_id()
+    if definition_registry_shadow_register_resolved_field_declaration(&nominal, make_name("value"), 0, &(*missing_path), &! field) != 0 { return 403 }
+    if definition_registry_shadow_finish_resolved_declarations(&module_id) != 0 { return 404 }
+    if definition_registry_shadow_finish_resolved_imports(&module_id) != 0 { return 405 }
+    if definition_registry_shadow_seal() != 0 { return 406 }
+    var receipt = definition_registry_shadow_invalid_binding_receipt()
+    if definition_registry_shadow_bind_field_type_expr(&field, &! receipt) != DEFINITION_REGISTRY_SHADOW_ERR_UNRESOLVED { return 407 }
+    0
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div, Alloc {
+    if definition_registry_shadow_begin() != 0 { return 1 }
+    if definition_registry_shadow_begin() != DEFINITION_REGISTRY_SHADOW_ERR_STATE { return 2 }
+    var missing = definition_registry_shadow_invalid_module_def_id()
+    let empty = Box::new(AstPath { segments: StringList { head_buf: [0; 128], head_len: 0, tail: None }, seg_count: 0 })
+    if probe_register_module(&(*empty), &! missing) != DEFINITION_REGISTRY_SHADOW_ERR_MISSING_MODULE_AUTHORITY { return 3 }
+
+    let alpha_path = probe_path1("alpha")
+    var alpha_cap = definition_registry_shadow_invalid_module_def_id()
+    var duplicate = definition_registry_shadow_invalid_module_def_id()
+    if probe_register_module(&(*alpha_path), &! alpha_cap) != 0 { return 4 }
+    if probe_register_module(&(*alpha_path), &! duplicate) != DEFINITION_REGISTRY_SHADOW_ERR_DUPLICATE_MODULE_PATH { return 5 }
+    var m1 = definition_registry_shadow_invalid_module_def_id()
+    var m2 = definition_registry_shadow_invalid_module_def_id()
+    var m3 = definition_registry_shadow_invalid_module_def_id()
+    var m4 = definition_registry_shadow_invalid_module_def_id()
+    let p1 = probe_path1("m1")
+    let p2 = probe_path1("m2")
+    let p3 = probe_path1("m3")
+    let p4 = probe_path1("m4")
+    if probe_register_module(&(*p1), &! m1) != 0 { return 6 }
+    if probe_register_module(&(*p2), &! m2) != 0 { return 7 }
+    if probe_register_module(&(*p3), &! m3) != 0 { return 8 }
+    if probe_register_module(&(*p4), &! m4) != DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY { return 9 }
+
+    if definition_registry_shadow_reset() != 0 { return 10 }
+    let overflow_path = probe_path1("overflow")
+    var overflow_module = definition_registry_shadow_invalid_module_def_id()
+    if probe_register_module(&(*overflow_path), &! overflow_module) != 0 { return 201 }
+    var n0 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n1 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n2 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n3 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n4 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n5 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n6 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n7 = definition_registry_shadow_invalid_nominal_type_def_id()
+    var n8 = definition_registry_shadow_invalid_nominal_type_def_id()
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N0"), true, &! n0) != 0 { return 202 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N1"), true, &! n1) != 0 { return 203 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N2"), true, &! n2) != 0 { return 204 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N3"), true, &! n3) != 0 { return 205 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N4"), true, &! n4) != 0 { return 206 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N5"), true, &! n5) != 0 { return 207 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N6"), true, &! n6) != 0 { return 208 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N7"), true, &! n7) != 0 { return 209 }
+    if definition_registry_shadow_register_resolved_nominal_declaration(&overflow_module, make_name("N8"), true, &! n8) != DEFINITION_REGISTRY_SHADOW_ERR_CAPACITY { return 210 }
+    if definition_registry_shadow_abort_resolved_declarations(&overflow_module) != 0 { return 211 }
+    let rollback_nominals = definition_registry_shadow_nominal_live_count()
+    let rollback_fields = definition_registry_shadow_field_live_count()
+    if rollback_nominals != 0 || rollback_fields != 0 {
+        print("DEFINITION_REGISTRY_SHADOW_BLOCKER_OBSERVED nominal=")
+        print_int(rollback_nominals)
+        print(" field=")
+        print_int(rollback_fields)
+        print("\n")
+        return 212
+    }
+
+    if definition_registry_shadow_reset() != 0 { return 11 }
+    var alpha_ab = definition_registry_shadow_invalid_module_def_id()
+    var field_ab = definition_registry_shadow_invalid_field_def_id()
+    var source_ab = definition_registry_shadow_invalid_field_def_id()
+    var binding_ab = definition_registry_shadow_invalid_binding_receipt()
+    let ab = probe_build_order(false, &! alpha_ab, &! field_ab, &! source_ab, &! binding_ab)
+    if ab != 0 { return ab }
+
+    if definition_registry_shadow_reset() != 0 { return 12 }
+    if definition_registry_shadow_module_is_live(&alpha_ab) || definition_registry_shadow_field_is_live(&field_ab) || definition_registry_shadow_binding_is_live(&binding_ab) { return 13 }
+    var alpha_aba = definition_registry_shadow_invalid_module_def_id()
+    var field_aba = definition_registry_shadow_invalid_field_def_id()
+    var source_aba = definition_registry_shadow_invalid_field_def_id()
+    var binding_aba = definition_registry_shadow_invalid_binding_receipt()
+    let aba = probe_build_order(false, &! alpha_aba, &! field_aba, &! source_aba, &! binding_aba)
+    if aba != 0 { return aba }
+    if !definition_registry_shadow_module_same_slot_new_generation(&alpha_ab, &alpha_aba) { return 14 }
+    if definition_registry_shadow_bind_field_type_expr(&source_aba, &! binding_ab) != DEFINITION_REGISTRY_SHADOW_ERR_OUTPUT_LIVE { return 15 }
+
+    if definition_registry_shadow_reset() != 0 { return 16 }
+    var alpha_ba = definition_registry_shadow_invalid_module_def_id()
+    var field_ba = definition_registry_shadow_invalid_field_def_id()
+    var source_ba = definition_registry_shadow_invalid_field_def_id()
+    var binding_ba = definition_registry_shadow_invalid_binding_receipt()
+    let ba = probe_build_order(true, &! alpha_ba, &! field_ba, &! source_ba, &! binding_ba)
+    if ba != 0 { return ba }
+
+    if definition_registry_shadow_reset() != 0 { return 17 }
+    let ambiguous = probe_ambiguous()
+    if ambiguous != 0 { return ambiguous }
+    if definition_registry_shadow_reset() != 0 { return 18 }
+    let unresolved = probe_unresolved()
+    if unresolved != 0 { return unresolved }
+    if definition_registry_shadow_release() != 0 { return 19 }
+    if definition_registry_shadow_release() != DEFINITION_REGISTRY_SHADOW_ERR_STATE { return 20 }
+    if definition_registry_shadow_begin() != 0 { return 21 }
+    if definition_registry_shadow_release() != 0 { return 22 }
+
+    print("DEFINITION_REGISTRY_SHADOW_PASS mode=resolved_declaration_shadow\n")
+    0
+}


### PR DESCRIPTION
## Scope

Adds an off-default, resolver-owned `DefinitionRegistryShadow` without changing parser, checker, IR, Place, TargetLayout, SOIR, bootstrap, or the default compiler pipeline.

The shadow mints private generational IDs for modules, nominal types, fields, and TypeExpr-binding receipts. Exact paths select declarations; paths, hashes, declaration order, field ordinals, and storage slots are never semantic identity.

## Evidence

Base: `4c952e6ee7bcd0855f675fc662420c2fa507e19a`

Source-fresh compiler:
- ELF: `/tmp/sounio-definition-registry-source-fresh-madaros.elf`
- SHA-256: `7ad961849c398ba6dc709dd327f14f14405062bb12638d48374d8619a1ba8372`

```sh
SOUC_BIN=/tmp/sounio-definition-registry-source-fresh-madaros.elf \
DEFINITION_REGISTRY_EXPECTED_COMPILER_SHA256=7ad961849c398ba6dc709dd327f14f14405062bb12638d48374d8619a1ba8372 \
bash scripts/ci/definition_registry_shadow_gate.sh
```

Result:
- source check: pass
- probe check: pass
- single-TU: pass
- imported module: pass
- AB/BA semantic relation invariance: pass
- same nominal spelling in distinct modules: pass
- same field spelling in distinct owners: pass
- duplicate path, missing authority, ambiguity, unresolved: reject
- stale, reset, same-slot/new-generation ABA, capacity rollback, uncleared receipt reuse, release: pass

A preexisting workspace compiler produced the diagnostic `nominal=8 field=16` after rollback. The one requested source-fresh control refuted that observation, so this PR does not classify it as a registry architecture blocker.

## Boundary

This is a resolved-declaration shadow. The `Program` wrapper is source checked but not runtime-integrated. Checker/type-entry/FieldInfo/Place/layout/default-pipeline integration remains false. Legacy paths remain intact.

## Review policy

No math claim, clinical pathway, or external-facing artifact changed, so no mandatory LLM offload was invoked.

Do not merge: this is a draft stacked architecture slice.