### PR TITLE
test(stdlib): deepen sedenion/clifford verticals + cmp run-proof

### DIFF
--- a/scripts/verticals_deepen7_gate.sh
+++ b/scripts/verticals_deepen7_gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deepen-batch 7: extend coverage of already-shipped verticals with untested public API.
+# Multi-module drivers -> lean_single engine.
+#   algebra::sedenion — the zero-divisor hallmark z*w=0 (|z|,|w|>0), norm/dot/add/scale
+#   algebra::clifford — geometric algebra: dim 2^n, signature squares, reversion, norm
+#   cmp::lib          — comparison / min-max / clamp / sign / approx_eq utilities
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/algebra/sedenion.sio  tests/stdlib/algebra/test_sedenion_deep_stdlib.sio  SEDENION_DEEP_STDLIB_OK
+run stdlib/algebra/clifford.sio   tests/stdlib/algebra/test_clifford_deep_stdlib.sio  CLIFFORD_DEEP_STDLIB_OK
+run stdlib/cmp/lib.sio            tests/stdlib/cmp/test_cmp_stdlib.sio                CMP_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_DEEPEN7_GATE_OK"
+exit $fail

--- a/tests/stdlib/algebra/test_clifford_deep_stdlib.sio
+++ b/tests/stdlib/algebra/test_clifford_deep_stdlib.sio
@@ -1,0 +1,28 @@
+// Deepened run-proof for stdlib algebra::clifford — geometric-algebra structure: dimension 2^n,
+// signature-dependent generator squares (e^2=+1 in Cl(3,0), =-1 in Cl(0,1)), reversion of a
+// bivector, scalar part, norm. ClElement carries [f64;32] by value. lean_single engine.
+use algebra::clifford::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let euc = cl_new(3, 0)
+    if cl_dim(euc) != 8 { print("FAIL dim\n"); return 1 }
+    if cl_generators(euc) != 3 { print("FAIL gens\n"); return 2 }
+    if cl_signature_p(euc) != 3 || cl_signature_q(euc) != 0 { print("FAIL sig\n"); return 3 }
+    // Euclidean generator squares to +1
+    let e1 = cl_basis(euc, 0)
+    if ae(cl_scalar_part(cl_mul(euc, e1, e1)), 1.0) >= 1.0e-12 { print("FAIL e1sq\n"); return 4 }
+    // negative-signature generator squares to -1
+    let neg = cl_new(0, 1)
+    let f1 = cl_basis(neg, 0)
+    if ae(cl_scalar_part(cl_mul(neg, f1, f1)), 0.0 - 1.0) >= 1.0e-12 { print("FAIL f1sq\n"); return 5 }
+    // bivector reverses sign: e1e2 + reverse(e1e2) = 0
+    let e2 = cl_basis(euc, 1)
+    let biv = cl_mul(euc, e1, e2)
+    let sum = cl_add(euc, biv, cl_reverse(euc, biv))
+    if cl_norm_sq(euc, sum) >= 1.0e-12 { print("FAIL reverse\n"); return 6 }
+    // scalar constructor + unit-vector norm
+    if ae(cl_scalar_part(cl_scalar(2.5)), 2.5) >= 1.0e-12 { print("FAIL scalar\n"); return 7 }
+    if ae(cl_norm_sq(euc, e1), 1.0) >= 1.0e-12 { print("FAIL norm\n"); return 8 }
+    print("CLIFFORD_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/algebra/test_sedenion_deep_stdlib.sio
+++ b/tests/stdlib/algebra/test_sedenion_deep_stdlib.sio
@@ -1,0 +1,32 @@
+// Deepened run-proof for stdlib algebra::sedenion — the hallmark that the sedenions are NOT a
+// division algebra: the canonical zero-divisor pair z=e3+e10, w=e6-e15 has z*w=0 with |z|,|w|>0.
+// Plus basis norm, dot, add, scale. By-reference [f64;16] API. lean_single engine.
+use algebra::sedenion::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    var z: [f64; 16] = [0.0; 16]
+    var w: [f64; 16] = [0.0; 16]
+    sed_zd_z(&!z); sed_zd_w(&!w)
+    // both nonzero (norm^2 = 2 each)
+    if ae(sed_norm_sq(&z), 2.0) >= 1.0e-12 { print("FAIL norm_z\n"); return 1 }
+    if ae(sed_norm_sq(&w), 2.0) >= 1.0e-12 { print("FAIL norm_w\n"); return 2 }
+    // ...yet their product is exactly zero -> zero divisor (norm is NOT multiplicative)
+    var zw: [f64; 16] = [0.0; 16]
+    sed_mul(&z, &w, &!zw)
+    if sed_norm_sq(&zw) >= 1.0e-12 { print("FAIL zero_divisor\n"); return 3 }
+    // basis e0 has unit norm; dot(z,z) = |z|^2 = 2
+    var e0: [f64; 16] = [0.0; 16]
+    sed_basis(0, &!e0)
+    if ae(sed_norm_sq(&e0), 1.0) >= 1.0e-12 { print("FAIL norm_e0\n"); return 4 }
+    if ae(sed_dot(&z, &z), 2.0) >= 1.0e-12 { print("FAIL dot\n"); return 5 }
+    // z and w are orthogonal (disjoint support) -> |z+w|^2 = |z|^2 + |w|^2 = 4
+    var s: [f64; 16] = [0.0; 16]
+    sed_add(&z, &w, &!s)
+    if ae(sed_norm_sq(&s), 4.0) >= 1.0e-12 { print("FAIL add\n"); return 6 }
+    // scaling by 2 multiplies norm^2 by 4
+    var z2: [f64; 16] = [0.0; 16]
+    sed_scale(&z, 2.0, &!z2)
+    if ae(sed_norm_sq(&z2), 8.0) >= 1.0e-12 { print("FAIL scale\n"); return 7 }
+    print("SEDENION_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/cmp/test_cmp_stdlib.sio
+++ b/tests/stdlib/cmp/test_cmp_stdlib.sio
@@ -1,0 +1,25 @@
+// Run-proof for stdlib cmp::lib — comparison, min/max, clamp, sign, approx_eq utilities.
+// Scalar API. lean_single engine.
+use cmp::lib::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    if cmp_i64(3, 5) != (0 - 1) { print("FAIL cmp_i_lt\n"); return 1 }
+    if cmp_i64(5, 3) != 1 { print("FAIL cmp_i_gt\n"); return 2 }
+    if cmp_f64(2.0, 2.0) != 0 { print("FAIL cmp_f_eq\n"); return 3 }
+    if min_i64(7, 4) != 4 { print("FAIL min_i\n"); return 4 }
+    if max_i64(7, 4) != 7 { print("FAIL max_i\n"); return 5 }
+    if max_f64(1.5, 2.5) != 2.5 { print("FAIL max_f\n"); return 6 }
+    if min_f64(1.5, 2.5) != 1.5 { print("FAIL min_f\n"); return 7 }
+    // clamp saturates on both ends and passes through the interior
+    if clamp_f64(5.0, 0.0, 3.0) != 3.0 { print("FAIL clamp_hi\n"); return 8 }
+    if clamp_f64(0.0 - 1.0, 0.0, 3.0) != 0.0 { print("FAIL clamp_lo\n"); return 9 }
+    if clamp_f64(1.5, 0.0, 3.0) != 1.5 { print("FAIL clamp_mid\n"); return 10 }
+    if clamp_i64(9, 1, 5) != 5 { print("FAIL clamp_i\n"); return 11 }
+    // sign
+    if sign_f64(0.0 - 3.0) != (0.0 - 1.0) { print("FAIL sign_neg\n"); return 12 }
+    if sign_f64(0.0) != 0.0 { print("FAIL sign_zero\n"); return 13 }
+    // approx_eq within / outside tolerance
+    if !approx_eq(1.0, 1.0005, 1.0e-3) { print("FAIL approx_in\n"); return 14 }
+    if approx_eq(1.0, 1.01, 1.0e-3) { print("FAIL approx_out\n"); return 15 }
+    print("CMP_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Deepen-batch 7 — Cayley-Dickson zero-divisors, Clifford algebra, and cmp utilities

Continues the "deepen existing verticals" direction. Each claim is proven by compile-and-run against first-principles values.

| Module | New coverage |
|---|---|
| `algebra::sedenion` | the **zero-divisor hallmark**: canonical pair `z=e₃+e₁₀`, `w=e₆−e₁₅` has `z·w=0` exactly while `\|z\|²=\|w\|²=2` (sedenions are **not** a division algebra / norm not multiplicative) + basis norm, dot, orthogonal add, scale |
| `algebra::clifford` | geometric-algebra structure — `dim Cl(3,0)=2³=8`, signature `(3,0)`, generator squares `+1` in `Cl(3,0)` / `−1` in `Cl(0,1)`, bivector reversion `e₁e₂ → −e₁e₂`, scalar part, unit-vector norm |
| `cmp::lib` | comparison / min-max / clamp (both saturations + interior) / sign / approx_eq |

### Highlight
The sedenion **zero-divisor** is the dissertation-relevant result: two nonzero elements whose product is exactly zero — the structural feature that distinguishes 𝕊 from ℝ, ℂ, ℍ, 𝕆. This ties into the Paper-1 exact-algebra lane.

### Verification
- `scripts/verticals_deepen7_gate.sh` → `VERTICALS_DEEPEN7_GATE_OK` (all three modules pass standalone `souc check`).
- Math-review (xai/grok): both algebra modules PASS ("standard zero-divisors exist; given pair is canonical"; Clifford dimension/signature/reversion "textbook").

### Notes
- `sed_mul` requires the `NonAssoc` effect — the driver declares it.
- Multi-module drivers run under `SOUNIO_SOUC_ENGINE=lean_single` (established path).
- No `self-hosted/` or `bootstrap/` edits. New files only (3 drivers + 1 gate); stays mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)