### PR TITLE
feat(stats): survival extensions — km_greenwood, conditional_survival, cumulative_incidence

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -2999,3 +2999,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - weighted_quantile = **PASS**: smallest v with Σ_{x≤v}w ≥ p·Σw, sort-free O(n²); equal→median 2, heavy weight→median 4, quartiles verified.
 - Theme: weighted & grouped estimators — support for survey weights / frequency tables / meta-analytic precisions, absent until now. All derivable, #852-safe. Suite runner: 121 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-n3PQpI/`, `/tmp/llm-offload-lcsGkl/`, `/tmp/llm-offload-anzkI3/`.
+
+## 2026-07-15 — math-review: stats::km_greenwood, stats::conditional_survival, stats::cumulative_incidence
+- Files (all new): `stdlib/stats/km_greenwood.sio` (KM survival + Greenwood SE + complementary-log-log CI), `stdlib/stats/conditional_survival.sio` (S(t1|t0)=Ŝ(t1)/Ŝ(t0)), `stdlib/stats/cumulative_incidence.sio` (competing-risks CIF). Provider: xAI/Grok 4.3.
+- km_greenwood = **PASS**: Var(Ŝ)=Ŝ²Σd/(n(n−d)), log-log CI Ŝ^exp(±z·σ_L) keeping bounds in [0,1]; times 1–5 query 3→Ŝ=0.4, SE=0.2191 verified.
+- conditional_survival = **PASS**: Ŝ(t1)/Ŝ(t0) step-function values, S(t|t)=1, t0=0→unconditional; S(4|2)=0.333 verified.
+- cumulative_incidence = **PASS**: Aalen-Johansen/K-P CIF₁=ΣŜ(t_{j-1})d1/n with all-cause survival update; competing-event table→CIF₁(4)=0.75 (not 1), no-competing→1−KM verified.
+- Theme: survival extensions — the Greenwood CI the bare km lacked, conditional survival, and competing-risks CIF. All sort-free walks, derivable, #852-safe. Suite runner: 124 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-840gyX/`, `/tmp/llm-offload-LJbaM2/`, `/tmp/llm-offload-YWV9jA/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -130,6 +130,9 @@ MODULES=(
   stdlib/stats/weighted_stats.sio
   stdlib/stats/grouped_stats.sio
   stdlib/stats/weighted_quantile.sio
+  stdlib/stats/km_greenwood.sio
+  stdlib/stats/conditional_survival.sio
+  stdlib/stats/cumulative_incidence.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -43,9 +43,10 @@ fourteen families:
   Shrout-Fleiss ICC family.
 - **Diagnostic accuracy** — sensitivity / specificity / likelihood ratios and
   ROC AUC.
-- **Survival analysis** — Kaplan-Meier, Nelson-Aalen cumulative hazard,
-  restricted mean survival time, the actuarial life table, the log-rank test and
-  a parametric exponential fit.
+- **Survival analysis** — Kaplan-Meier (with the Greenwood CI), conditional
+  survival, the competing-risks cumulative incidence, Nelson-Aalen cumulative
+  hazard, restricted mean survival time, the actuarial life table, the log-rank
+  test and a parametric exponential fit.
 - **Meta-analysis & epidemiology** — fixed / random-effects pooling, RR / OR /
   NNT, person-time incidence rates, the Mantel-Haenszel stratified odds ratio
   with the Breslow-Day homogeneity test, attributable risk / fractions, and
@@ -1597,6 +1598,38 @@ The p-quantile of weighted data (smallest value carrying ≥p of the total weigh
 via a sort-free cumulative scan. Validated: equal weights {1,2,3} → median 2;
 {1,2,3,4} w={1,1,1,5} → weighted median 4; quartiles of {1,2,3,4}.
 
+### `stats::km_greenwood` — KM survival with a Greenwood CI
+
+| Function | Signature |
+|---|---|
+| `km_greenwood` | `pub fn km_greenwood(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64, conf: f64) -> KMCIResult with Mut, Div, Panic` |
+
+The Kaplan-Meier survival at a queried time with its Greenwood standard error
+`Var(Ŝ)=Ŝ²Σdⱼ/(nⱼ(nⱼ−dⱼ))` and a complementary-log-log confidence interval (which
+keeps the bounds inside [0,1]). Validated: times 1–5, query 3 → Ŝ=0.4, SE=0.2191,
+CI inside (0,1).
+
+### `stats::conditional_survival` — conditional survival probability
+
+| Function | Signature |
+|---|---|
+| `conditional_survival` | `pub fn conditional_survival(time: &[f64; 256], event: &[i64; 256], n: i32, t0: f64, t1: f64) -> f64 with Mut, Div, Panic` |
+
+The probability of surviving to t₁ given survival to t₀: `S(t₁|t₀)=Ŝ(t₁)/Ŝ(t₀)`
+— the "given you've made it this far" prognosis. Validated: times 1–5 →
+S(4|2)=0.333; S(t|t)=1; S(t1|0)=Ŝ(t1).
+
+### `stats::cumulative_incidence` — competing-risks CIF
+
+| Function | Signature |
+|---|---|
+| `cumulative_incidence` | `pub fn cumulative_incidence(time: &[f64; 256], cause: &[i64; 256], n: i32, t_query: f64) -> f64 with Mut, Div, Panic` |
+
+The cumulative incidence of one event type in the presence of competing risks
+(where 1−KM would overstate it): `CIF₁(t)=ΣŜ(t₍ⱼ₋₁₎)·d₁ⱼ/nⱼ`, with `cause` 0/1/2.
+Validated: a table with one competing event → CIF₁(4)=0.75 (not 1); no competing
+events → CIF₁=1−KM.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1722,6 +1755,9 @@ use stats::rank_transform::{RankResult, rank_transform}
 use stats::weighted_stats::{WeightedResult, weighted_stats}
 use stats::grouped_stats::{GroupedResult, grouped_stats}
 use stats::weighted_quantile::{weighted_quantile, weighted_median}
+use stats::km_greenwood::{KMCIResult, km_greenwood}
+use stats::conditional_survival::{conditional_survival}
+use stats::cumulative_incidence::{cumulative_incidence}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/conditional_survival.sio
+++ b/stdlib/stats/conditional_survival.sio
@@ -1,0 +1,128 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/conditional_survival.sio — conditional survival probability
+//
+// The probability of surviving to a later time given survival to an earlier one
+// — the clinically meaningful "given you have made it this far" statement:
+//
+//   conditional_survival(time, event, n, t0, t1) -> f64
+//
+//   S(t₁ | t₀) = Ŝ(t₁) / Ŝ(t₀),   t₁ ≥ t₀,
+// with Ŝ the Kaplan-Meier estimator. Unlike Ŝ(t₁) itself, this rises over time
+// for many diseases (prognosis improves the longer a patient survives).
+//
+// Pure Sounio: a single sort-free walk over the distinct death times,
+// accumulating Ŝ at both t₀ and t₁. No external dependency, no nested
+// data-array calls.
+//
+// References:
+//   Henson & Ries (1995); Zabor et al. (2013).
+
+module stats::conditional_survival
+
+/// Conditional Kaplan-Meier survival S(t1 | t0) = Ŝ(t1)/Ŝ(t0).
+///
+/// Parâmetros: time — follow-up; event — 1 death / 0 censored; n — size;
+///             t0 — conditioning time; t1 — target time (>= t0).
+/// Retorno: conditional survival probability.
+pub fn conditional_survival(time: &[f64; 256], event: &[i64; 256], n: i32, t0: f64, t1: f64) -> f64 with Mut, Div, Panic {
+    if n < 1 || t1 < t0 { return 1.0 }
+    var surv = 1.0
+    var s_t0 = 1.0
+    var s_t1 = 1.0
+    var prev = 0.0 - 1.0e300
+    var have_prev = false
+    var guard = 0
+    while guard <= n {
+        var found = false
+        var tau = 0.0
+        var i = 0
+        while i < n {
+            if event[i as usize] == 1 {
+                let ti = time[i as usize]
+                let after = if have_prev { ti > prev } else { true }
+                if after { if found == false || ti < tau { tau = ti; found = true } }
+            }
+            i = i + 1
+        }
+        if found == false { guard = n + 1 }
+        else {
+            var d = 0
+            var at_risk = 0
+            var j = 0
+            while j < n {
+                let tj = time[j as usize]
+                if tj >= tau { at_risk = at_risk + 1 }
+                if tj == tau && event[j as usize] == 1 { d = d + 1 }
+                j = j + 1
+            }
+            if at_risk > 0 { surv = surv * (1.0 - (d as f64) / (at_risk as f64)) }
+            if tau <= t0 { s_t0 = surv }
+            if tau <= t1 { s_t1 = surv }
+            prev = tau
+            have_prev = true
+            guard = guard + 1
+        }
+    }
+    if s_t0 <= 1.0e-300 { return 0.0 }
+    return s_t1 / s_t0
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// times 1..5 all deaths. S(2)=0.6, S(4)=0.2. S(4|2)=0.2/0.6=0.333333.
+fn test_conditional() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(1, approx(conditional_survival(&t, &e, 5, 2.0, 4.0), 0.333333, 1.0e-5))
+}
+
+// S(t | t) = 1 (conditioning on the same time).
+fn test_same_time() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(10, approx(conditional_survival(&t, &e, 5, 3.0, 3.0), 1.0, 1.0e-9))
+}
+
+// t0=0 gives the unconditional survival S(t1). S(3)=0.4.
+fn test_unconditional() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    return check(20, approx(conditional_survival(&t, &e, 5, 0.0, 3.0), 0.4, 1.0e-9))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_conditional() && ok
+    ok = test_same_time() && ok
+    ok = test_unconditional() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/cumulative_incidence.sio
+++ b/stdlib/stats/cumulative_incidence.sio
@@ -1,0 +1,138 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/cumulative_incidence.sio — competing-risks cumulative incidence
+//
+// The cumulative incidence function (CIF) for one event type in the presence of
+// competing risks — the correct estimator when 1 − KM would overstate the
+// probability of the event of interest:
+//
+//   cumulative_incidence(time, cause, n, t_query) -> f64
+//
+//   CIF₁(t) = Σ_{t_(j)≤t} Ŝ(t_(j−1)) · d₁ⱼ / nⱼ,
+// where Ŝ is the all-cause Kaplan-Meier survival, d₁ⱼ the events of interest at
+// t_(j) and nⱼ the risk set. `cause`: 0 = censored, 1 = event of interest,
+// 2 = competing event.
+//
+// Pure Sounio: a sort-free ordered walk over the distinct event times of any
+// cause. No external dependency, no nested data-array calls.
+//
+// References:
+//   Kalbfleisch & Prentice (1980); Gray (1988).
+
+module stats::cumulative_incidence
+
+/// Competing-risks cumulative incidence of cause 1 at a queried time.
+///
+/// Parâmetros: time — follow-up; cause — 0 censored / 1 event of interest /
+///             2 competing; n — size; t_query — evaluation time.
+/// Retorno: CIF₁(t_query).
+/// Referências: Kalbfleisch & Prentice (1980).
+pub fn cumulative_incidence(time: &[f64; 256], cause: &[i64; 256], n: i32, t_query: f64) -> f64 with Mut, Div, Panic {
+    if n < 1 { return 0.0 }
+    var surv = 1.0     // all-cause KM survival, Ŝ(t_(j-1))
+    var cif = 0.0
+    var prev = 0.0 - 1.0e300
+    var have_prev = false
+    var guard = 0
+    while guard <= n {
+        // next distinct time with any event (cause 1 or 2)
+        var found = false
+        var tau = 0.0
+        var i = 0
+        while i < n {
+            let ci = cause[i as usize]
+            if ci == 1 || ci == 2 {
+                let ti = time[i as usize]
+                let after = if have_prev { ti > prev } else { true }
+                if after { if found == false || ti < tau { tau = ti; found = true } }
+            }
+            i = i + 1
+        }
+        if found == false { guard = n + 1 }
+        else {
+            var at_risk = 0
+            var d1 = 0
+            var dall = 0
+            var j = 0
+            while j < n {
+                let tj = time[j as usize]
+                if tj >= tau { at_risk = at_risk + 1 }
+                if tj == tau {
+                    let cj = cause[j as usize]
+                    if cj == 1 { d1 = d1 + 1; dall = dall + 1 }
+                    else { if cj == 2 { dall = dall + 1 } }
+                }
+                j = j + 1
+            }
+            if at_risk > 0 {
+                let nr = at_risk as f64
+                if tau <= t_query { cif = cif + surv * (d1 as f64) / nr }
+                surv = surv * (1.0 - (dall as f64) / nr)
+            }
+            prev = tau
+            have_prev = true
+            guard = guard + 1
+        }
+    }
+    return cif
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// times {1,2,3,4}, causes {1,2,1,1}, n=4 (all events).
+// t=1: n=4, S_before=1, d1=1 -> CIF += 1·1/4=0.25; S=0.75.
+// t=2: n=3, d1=0 (cause2) -> CIF += 0; S=0.75·(1-1/3)=0.5.
+// t=3: n=2, d1=1 -> CIF += 0.5·1/2=0.25 (total 0.5); S=0.25.
+// t=4: n=1, d1=1 -> CIF += 0.25·1/1=0.25 (total 0.75). CIF1(4)=0.75.
+fn test_cif() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var c: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0
+    c[0]=1; c[1]=2; c[2]=1; c[3]=1
+    var ok = true
+    ok = check(1, approx(cumulative_incidence(&t, &c, 4, 2.0), 0.25, 1.0e-9)) && ok
+    ok = check(2, approx(cumulative_incidence(&t, &c, 4, 4.0), 0.75, 1.0e-9)) && ok
+    return ok
+}
+
+// no competing events -> CIF1(t) = 1 - KM survival. times 1..4 all cause 1.
+// CIF1(4) = 1 (everyone had the event). CIF1(2)=1-0.5=0.5.
+fn test_no_competing() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var c: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0
+    c[0]=1; c[1]=1; c[2]=1; c[3]=1
+    var ok = true
+    ok = check(10, approx(cumulative_incidence(&t, &c, 4, 4.0), 1.0, 1.0e-9)) && ok
+    ok = check(11, approx(cumulative_incidence(&t, &c, 4, 2.0), 0.5, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_cif() && ok
+    ok = test_no_competing() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/km_greenwood.sio
+++ b/stdlib/stats/km_greenwood.sio
@@ -1,0 +1,192 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/km_greenwood.sio — Kaplan-Meier survival with a Greenwood CI
+//
+// The Kaplan-Meier survival at a queried time together with its standard error
+// and a confidence interval — the interval the bare km estimator lacks:
+//
+//   km_greenwood(time, event, n, t_query, conf) -> KMCIResult
+//
+//   Ŝ(t) = Π(1−dⱼ/nⱼ),
+//   Var(Ŝ(t)) = Ŝ(t)² · Σ_{t_(j)≤t} dⱼ / (nⱼ(nⱼ−dⱼ))          (Greenwood),
+// and a complementary-log-log interval  Ŝ^{exp(±z·σ_L)}  with
+//   σ_L² = Var(Ŝ)/(Ŝ·ln Ŝ)²  — which keeps the bounds inside [0,1].
+//
+// Pure Sounio: a sort-free ordered walk over the distinct death times; inline
+// exp/ln/sqrt. No external dependency, no nested data-array calls.
+//
+// References:
+//   Greenwood (1926); Kalbfleisch & Prentice, "Statistical Analysis of Failure
+//   Time Data" 2e, §1.
+
+module stats::km_greenwood
+
+fn kg_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / kg_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn kg_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 - 700.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn kg_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn kg_zmult(conf: f64) -> f64 {
+    if conf >= 0.99 { return 2.5758293035489004 }
+    if conf >= 0.95 { return 1.959963984540054 }
+    if conf >= 0.90 { return 1.6448536269514722 }
+    return 1.959963984540054
+}
+
+pub struct KMCIResult {
+    pub surv: f64,   // Ŝ(t_query)
+    pub se: f64,     // Greenwood standard error
+    pub lo: f64,     // CI lower (complementary log-log)
+    pub hi: f64,     // CI upper
+}
+
+/// Kaplan-Meier survival at a queried time with a Greenwood confidence interval.
+///
+/// Parâmetros: time — follow-up; event — 1 death / 0 censored; n — size;
+///             t_query — evaluation time; conf — level (e.g. 0.95).
+/// Retorno: KMCIResult (surv, se, lo, hi).
+/// Referências: Greenwood (1926).
+pub fn km_greenwood(time: &[f64; 256], event: &[i64; 256], n: i32, t_query: f64, conf: f64) -> KMCIResult with Mut, Div, Panic {
+    if n < 1 { return KMCIResult { surv: 1.0, se: 0.0, lo: 1.0, hi: 1.0 } }
+    var surv = 1.0
+    var gsum = 0.0        // Σ d/(n(n-d))
+    var prev = 0.0 - 1.0e300
+    var have_prev = false
+    var guard = 0
+    while guard <= n {
+        var found = false
+        var tau = 0.0
+        var i = 0
+        while i < n {
+            if event[i as usize] == 1 {
+                let ti = time[i as usize]
+                let after = if have_prev { ti > prev } else { true }
+                if after { if found == false || ti < tau { tau = ti; found = true } }
+            }
+            i = i + 1
+        }
+        if found == false { guard = n + 1 }
+        else {
+            if tau <= t_query {
+                var d = 0
+                var at_risk = 0
+                var j = 0
+                while j < n {
+                    let tj = time[j as usize]
+                    if tj >= tau { at_risk = at_risk + 1 }
+                    if tj == tau && event[j as usize] == 1 { d = d + 1 }
+                    j = j + 1
+                }
+                if at_risk > 0 {
+                    let nr = at_risk as f64
+                    let df = d as f64
+                    surv = surv * (1.0 - df / nr)
+                    if nr - df > 0.0 { gsum = gsum + df / (nr * (nr - df)) }
+                }
+            }
+            prev = tau
+            have_prev = true
+            guard = guard + 1
+        }
+    }
+    let var_s = surv * surv * gsum
+    let se = kg_sqrt(var_s)
+    let z = kg_zmult(conf)
+    var lo = surv
+    var hi = surv
+    if surv > 0.0 && surv < 1.0 {
+        let lns = kg_ln(surv)
+        let se_l = se / (surv * (0.0 - lns))    // sd of ln(-ln S) ; -lnS>0
+        let center = kg_ln(0.0 - lns)           // ln(-ln S)
+        let up = center + z * se_l
+        let dn = center - z * se_l
+        // S = exp(-exp(L)); larger L -> smaller S
+        lo = kg_exp(0.0 - kg_exp(up))
+        hi = kg_exp(0.0 - kg_exp(dn))
+    }
+    return KMCIResult { surv: surv, se: se, lo: lo, hi: hi }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// times 1..5 all deaths, query=3. S(3)=0.4.
+// Greenwood Σ = 1/(5·4)+1/(4·3)+1/(3·2)=0.05+0.083333+0.166667=0.3.
+// Var=0.4²·0.3=0.048; SE=√0.048=0.219089. CI (log-log) brackets 0.4.
+fn test_greenwood() -> bool with IO, Mut, Div, Panic {
+    var t: [f64; 256] = [0.0; 256]
+    var e: [i64; 256] = [0; 256]
+    t[0]=1.0; t[1]=2.0; t[2]=3.0; t[3]=4.0; t[4]=5.0
+    e[0]=1; e[1]=1; e[2]=1; e[3]=1; e[4]=1
+    let r = km_greenwood(&t, &e, 5, 3.0, 0.95)
+    var ok = true
+    ok = check(1, approx(r.surv, 0.4, 1.0e-9)) && ok
+    ok = check(2, approx(r.se, 0.219089, 1.0e-5)) && ok
+    ok = check(3, r.lo < 0.4 && r.hi > 0.4) && ok
+    ok = check(4, r.lo > 0.0 && r.hi < 1.0) && ok        // log-log keeps it in [0,1]
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_greenwood() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three survival modules, bringing the runner to **124 modules**. These deepen the survival family with the confidence interval the bare Kaplan-Meier estimator lacked, conditional survival, and competing-risks analysis. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::km_greenwood` | KM survival + Greenwood SE + complementary-log-log CI |
| `stats::conditional_survival` | S(t₁\|t₀) = Ŝ(t₁)/Ŝ(t₀) |
| `stats::cumulative_incidence` | Competing-risks cumulative incidence function |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Greenwood: times 1–5, query 3 → Ŝ=0.4, SE=0.2191 (Greenwood Σ=0.3, Var=0.048), CI strictly inside (0,1) thanks to the log-log transform.
  - Conditional: times 1–5 → S(4|2)=0.2/0.6=0.333; S(t|t)=1; S(t1|0)=Ŝ(t1).
  - Cumulative incidence: a table with one competing event → **CIF₁(4)=0.75, not 1** (the point of the estimator); no competing events → CIF₁ = 1−KM exactly.
- Full suite selftest: **124 modules + 7 demos ALL GREEN** under `lean_single`.

The `cumulative_incidence` test is the clean illustration of *why* the estimator exists: with a competing event, the naive 1−KM would climb to 1, but the CIF correctly tops out at 0.75.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).