### PR TITLE
test(stdlib): deepen core::result + jordan/cayley_dickson algebra verticals

### DIFF
--- a/scripts/verticals_deepen8_gate.sh
+++ b/scripts/verticals_deepen8_gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deepen-batch 8: extend coverage of already-shipped verticals with untested public API.
+# Multi-module drivers -> lean_single engine.
+#   core::result             — IntResult/FloatResult monad (ok/err, unwrap, unwrap_or, err)
+#   algebra::jordan          — exceptional Jordan algebra J3(O): trace, det, Jordan product, square
+#   algebra::cayley_dickson  — CD tower: commutativity/associativity by level (168 = |PSL(2,7)|)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/core/result.sio             tests/stdlib/core/test_result_deep_stdlib.sio            RESULT_DEEP_STDLIB_OK
+run stdlib/algebra/jordan.sio          tests/stdlib/algebra/test_jordan_deep_stdlib.sio         JORDAN_DEEP_STDLIB_OK
+run stdlib/algebra/cayley_dickson.sio  tests/stdlib/algebra/test_cayley_dickson_deep_stdlib.sio CAYLEY_DICKSON_DEEP_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_DEEPEN8_GATE_OK"
+exit $fail

--- a/tests/stdlib/algebra/test_cayley_dickson_deep_stdlib.sio
+++ b/tests/stdlib/algebra/test_cayley_dickson_deep_stdlib.sio
@@ -1,0 +1,24 @@
+// Run-proof for stdlib algebra::cayley_dickson — the Cayley-Dickson tower: commutativity is lost at
+// the quaternions and associativity at the octonions, where the count of non-associative basis
+// triples is exactly 168 = |PSL(2,7)|. Plus basis norm and the unit. lean_single engine.
+use algebra::cayley_dickson::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // commutativity by level: R (0) and C (1) commutative; H (2) not
+    if !cd_is_commutative(0) { print("FAIL comm0\n"); return 1 }
+    if !cd_is_commutative(1) { print("FAIL comm1\n"); return 2 }
+    if cd_is_commutative(2) { print("FAIL comm2\n"); return 3 }
+    // associativity by level: H (2) associative -> 0 non-associative triples;
+    // O (3) non-associative -> exactly 168 = |PSL(2,7)|
+    if cd_count_nonassociative(2) != 0 { print("FAIL assoc2\n"); return 4 }
+    if cd_count_nonassociative(3) != 168 { print("FAIL nonassoc3\n"); return 5 }
+    // octonion basis unit norm; imaginary unit squares to a unit-norm element
+    let e1 = cd_basis(3, 1)
+    if ae(cd_norm_sq(e1), 1.0) >= 1.0e-9 { print("FAIL norm_e1\n"); return 6 }
+    if ae(cd_norm_sq(cd_mul(e1, e1)), 1.0) >= 1.0e-9 { print("FAIL e1sq\n"); return 7 }
+    // multiplicative identity
+    let one = cd_one(3)
+    if ae(cd_norm_sq(cd_mul(one, one)), 1.0) >= 1.0e-9 { print("FAIL one\n"); return 8 }
+    print("CAYLEY_DICKSON_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/algebra/test_jordan_deep_stdlib.sio
+++ b/tests/stdlib/algebra/test_jordan_deep_stdlib.sio
@@ -1,0 +1,27 @@
+// Run-proof for stdlib algebra::jordan — the exceptional Jordan algebra J3(O) of 3x3 octonionic
+// Hermitian matrices: trace, determinant, the (commutative) Jordan product x.y=(xy+yx)/2, the
+// identity element, and squaring. lean_single engine.
+use algebra::jordan::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let id = j3o_identity()
+    if ae(j3o_trace(id), 3.0) >= 1.0e-9 { print("FAIL tr_id\n"); return 1 }
+    if ae(j3o_determinant(id), 1.0) >= 1.0e-9 { print("FAIL det_id\n"); return 2 }
+    // diagonal element diag(2,3,4): trace=9, det=24
+    let d = j3o_diag(2.0, 3.0, 4.0)
+    if ae(j3o_trace(d), 9.0) >= 1.0e-9 { print("FAIL tr_d\n"); return 3 }
+    if ae(j3o_determinant(d), 24.0) >= 1.0e-9 { print("FAIL det_d\n"); return 4 }
+    // Jordan product is commutative: x.y = y.x  (norm of difference = 0)
+    let x = j3o_diag(1.0, 2.0, 3.0)
+    let xy = j3o_jordan_product(x, d)
+    let yx = j3o_jordan_product(d, x)
+    if j3o_norm_sq(j3o_sub(xy, yx)) >= 1.0e-9 { print("FAIL commute\n"); return 5 }
+    // identity acts as unit: x.I = x
+    if j3o_norm_sq(j3o_sub(j3o_jordan_product(x, id), x)) >= 1.0e-9 { print("FAIL unit\n"); return 6 }
+    // square of diag(1,2,3) = diag(1,4,9): trace 14, det 36
+    let sq = j3o_square(x)
+    if ae(j3o_trace(sq), 14.0) >= 1.0e-9 { print("FAIL sq_tr\n"); return 7 }
+    if ae(j3o_determinant(sq), 36.0) >= 1.0e-9 { print("FAIL sq_det\n"); return 8 }
+    print("JORDAN_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/core/test_result_deep_stdlib.sio
+++ b/tests/stdlib/core/test_result_deep_stdlib.sio
@@ -1,0 +1,25 @@
+// Run-proof for stdlib core::result — the IntResult / FloatResult error-handling monad:
+// ok/err construction, is_ok/is_err, unwrap, unwrap_or (default only on err), err payload.
+use core::result::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ok = int_ok(5)
+    if !int_result_is_ok(&ok) || int_result_is_err(&ok) { print("FAIL ok_flags\n"); return 1 }
+    if int_result_unwrap(&ok) != 5 { print("FAIL unwrap\n"); return 2 }
+    if int_result_unwrap_or(&ok, 9) != 5 { print("FAIL ok_or_keeps\n"); return 3 }
+    let er = int_err(2)
+    if int_result_is_ok(&er) || !int_result_is_err(&er) { print("FAIL err_flags\n"); return 4 }
+    if int_result_unwrap_or(&er, 9) != 9 { print("FAIL err_or_default\n"); return 5 }
+    if int_result_err(&er) != 2 { print("FAIL err_payload\n"); return 6 }
+    // aliases
+    if !is_ok(&ok) || is_err(&ok) { print("FAIL alias\n"); return 7 }
+    // float variant
+    let fok = float_ok(3.5)
+    if ae(float_result_unwrap(&fok), 3.5) >= 1.0e-12 { print("FAIL f_unwrap\n"); return 8 }
+    if ae(float_result_unwrap_or(&fok, 2.5), 3.5) >= 1.0e-12 { print("FAIL f_ok_keeps\n"); return 9 }
+    let fer = float_err(1)
+    if !float_result_is_err(&fer) { print("FAIL f_err_flag\n"); return 10 }
+    if ae(float_result_unwrap_or(&fer, 2.5), 2.5) >= 1.0e-12 { print("FAIL f_err_default\n"); return 11 }
+    print("RESULT_DEEP_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Deepen-batch 8 — error-handling monad, the exceptional Jordan algebra, and the CD tower

Continues the "deepen existing verticals" direction. Each claim is proven by compile-and-run against first-principles values.

| Module | New coverage |
|---|---|
| `core::result` | `IntResult`/`FloatResult` monad — ok/err, `is_ok`/`is_err`, `unwrap`, `unwrap_or` (default only on err), `err` payload, aliases |
| `algebra::jordan` | the **exceptional Jordan algebra** J₃(𝕆): identity `trace 3`/`det 1`, `diag(2,3,4)` `trace 9`/`det 24`, **commutative Jordan product** `x·y=y·x`, unit `x·I=x`, `square(diag(1,2,3))=diag(1,4,9)` `trace 14`/`det 36` |
| `algebra::cayley_dickson` | the **CD tower** — commutativity holds at ℝ/ℂ, fails at ℍ; ℍ is associative (0 non-assoc triples) while 𝕆 has exactly **168 = |PSL(2,7)|** non-associative basis triples; octonion basis norm + unit |

### Highlight
`cd_count_nonassociative(3) == 168` — the Fano-plane count of non-associative octonion basis triples, `= |PSL(2,7)|`. This is the same 168 at the heart of the Paper-1 exact-algebra lane, now covered by an executable run-proof. J₃(𝕆) is the exceptional Jordan algebra (Freudenthal / 𝔢₆ magic-square territory).

### Verification
- `scripts/verticals_deepen8_gate.sh` → `VERTICALS_DEEPEN8_GATE_OK` (all three modules pass standalone `souc check`).
- Math-review (xai/grok): both algebra modules PASS ("168 = |PSL(2,7)| matches Fano-plane count of non-assoc ordered triples").

### Notes
- Multi-module drivers run under `SOUNIO_SOUC_ENGINE=lean_single` (established path).
- No `self-hosted/` or `bootstrap/` edits. New files only (3 drivers + 1 gate); stays mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)