### PR TITLE
feat(stats): ordered-alternative & trend tests — jonckheere, page_trend, mann_kendall

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3015,3 +3015,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - welch_anova = **PASS**: weighted F with Welch fractional df₂=(k²−1)/(3A); groups var 2.5/10/0.5 → F=3.405, df₂=6.398 (Python-cross-checked).
 - Theme: ANOVA contrasts & robust ANOVA — planned/post-hoc contrasts (linear, Scheffé) and the unequal-variance ANOVA complementing anova + bartlett/levene. All derivable, #852-safe. Suite runner: 127 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-GjsIyt/`, `/tmp/llm-offload-Z5IqUV/`, `/tmp/llm-offload-NWs9px/`.
+
+## 2026-07-16 — math-review: stats::jonckheere, stats::page_trend, stats::mann_kendall
+- Files (all new): `stdlib/stats/jonckheere.sio` (Jonckheere-Terpstra ordered-groups trend), `stdlib/stats/page_trend.sio` (Page's L repeated-measures ordered trend), `stdlib/stats/mann_kendall.sio` (Mann-Kendall time-series monotonic trend). Provider: xAI/Grok 4.3.
+- jonckheere = **PASS**: J=Σ_{i<j}Uᵢⱼ (+½ ties), E[J]=(N²−Σn²)/4, Var[J]=(N²(2N+3)−Σn²(2n+3))/72; increasing 3×3→J=27, E=13.5, z=3.0 verified.
+- page_trend = **PASS**: L=Σj·Rⱼ, E[L]=nk(k+1)²/4, Var[L]=nk²(k²−1)(k+1)/144, mid-rank ties; ordered 3×3→L=42, z=2.449 verified.
+- mann_kendall = **PASS**: S=Σsign, Var=n(n−1)(2n+5)/18, continuity-corrected z, τ=2S/(n(n−1)); increasing {1..5}→S=10, z=2.2045, τ=1. Note: test constant z=2.204793 was a hand slip — correct 9/√16.6667=2.204541 (Python-verified); caught by the failing assertion, fixed.
+- Theme: ordered-alternative & monotonic-trend tests — extends the non-parametric family beyond the proportion trend (cochran_armitage) to continuous/ordinal ordered groups, repeated measures, and time series. All derivable, #852-safe. Suite runner: 130 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-iOjAr1/`, `/tmp/llm-offload-5fFzUi/`, `/tmp/llm-offload-N6zSm6/`.

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -136,6 +136,9 @@ MODULES=(
   stdlib/stats/linear_contrast.sio
   stdlib/stats/scheffe.sio
   stdlib/stats/welch_anova.sio
+  stdlib/stats/jonckheere.sio
+  stdlib/stats/page_trend.sio
+  stdlib/stats/mann_kendall.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -29,7 +29,8 @@ fourteen families:
   for proportions/correlations, survival trials (Schoenfeld), target precision,
   and the minimum detectable effect.
 - **Non-parametric tests** — sign test, Mann-Whitney, Wilcoxon signed-rank,
-  Kruskal-Wallis, Mood's median, Friedman and Tukey HSD.
+  Kruskal-Wallis, Mood's median, Friedman and Tukey HSD, plus the
+  ordered-alternative / trend tests (Jonckheere-Terpstra, Page's L, Mann-Kendall).
 - **Correlation & association** — Pearson / Spearman, the Fisher-z CI,
   point-biserial and partial correlation, Kendall's τ, Goodman-Kruskal γ and
   Somers' D.
@@ -1663,6 +1664,37 @@ unequal variances): weighted between-group F with the Welch-corrected fractional
 df₂. Validated (Python-cross-checked): three groups with variances 2.5/10/0.5 →
 F=3.405, df₂=6.398; equal groups → F=0.
 
+### `stats::jonckheere` — Jonckheere-Terpstra ordered-alternatives test
+
+| Function | Signature |
+|---|---|
+| `jonckheere` | `pub fn jonckheere(values: &[f64; 256], sizes: &[i32; 16], k: i32) -> JTResult with Mut, Div, Panic` |
+
+A non-parametric test for a monotone trend across k *ordered* groups (more
+powerful than Kruskal-Wallis when the order is known): `J=Σ_{i<j}Uᵢⱼ` with the
+normal-approximation z. Validated: three increasing groups → J=27, E[J]=13.5,
+z=3.0; identical groups → z=0.
+
+### `stats::page_trend` — Page's L test
+
+| Function | Signature |
+|---|---|
+| `page_trend` | `pub fn page_trend(data: &[f64; 256], n: i32, k: i32) -> PageResult with Mut, Div, Panic` |
+
+The repeated-measures ordered-alternative test (ordered Friedman): `L=Σj·Rⱼ` on
+a row-major n×k matrix. Validated: perfectly ordered 3×3 → L=42, E[L]=36,
+z=2.449; no trend → z=0.
+
+### `stats::mann_kendall` — Mann-Kendall trend test
+
+| Function | Signature |
+|---|---|
+| `mann_kendall` | `pub fn mann_kendall(x: &[f64; 256], n: i32) -> MKResult with Mut, Div, Panic` |
+
+The rank-based monotonic-trend test for a time-ordered series (the environmental-
+statistics standard): `S=Σ_{i<j}sign(xⱼ−xᵢ)`, continuity-corrected z, and Kendall's
+τ. Validated: increasing {1..5} → S=10, z=2.2045, τ=1; decreasing → S=−10, τ=−1.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1794,6 +1826,9 @@ use stats::cumulative_incidence::{cumulative_incidence}
 use stats::linear_contrast::{ContrastResult, linear_contrast}
 use stats::scheffe::{ScheffeResult, scheffe}
 use stats::welch_anova::{WelchAnovaResult, welch_anova}
+use stats::jonckheere::{JTResult, jonckheere}
+use stats::page_trend::{PageResult, page_trend}
+use stats::mann_kendall::{MKResult, mann_kendall}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/jonckheere.sio
+++ b/stdlib/stats/jonckheere.sio
@@ -1,0 +1,184 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/jonckheere.sio — Jonckheere-Terpstra test for ordered alternatives
+//
+// A non-parametric test for a *monotone* trend in location across k a-priori
+// ordered groups — more powerful than Kruskal-Wallis when the ordering is known:
+//
+//   jonckheere(values, sizes, k) -> JTResult      (groups = consecutive blocks,
+//                                                   in the hypothesised order)
+//
+//   J = Σ_{i<j} Uᵢⱼ,   Uᵢⱼ = #{ a∈gᵢ, b∈gⱼ : b > a } (+½ for ties),
+//   E[J] = (N² − Σnᵢ²)/4,   Var[J] = (N²(2N+3) − Σnᵢ²(2nᵢ+3))/72,
+//   z = (J − E[J])/√Var[J].
+//
+// Pure Sounio: an O(N²) pairwise count over the group blocks; inline sqrt/erf.
+// No external dependency, no nested data-array calls.
+//
+// References:
+//   Jonckheere (1954); Terpstra (1952).
+
+module stats::jonckheere
+
+fn jt_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn jt_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / jt_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn jt_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * jt_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn jt_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - jt_erf(z * INV_SQRT2))
+}
+
+pub struct JTResult {
+    pub j: f64,       // Jonckheere J statistic
+    pub expected: f64,
+    pub z: f64,
+    pub p: f64,       // two-sided p
+}
+
+/// Jonckheere-Terpstra test across k ordered groups.
+///
+/// Parâmetros: values — concatenated group data (in hypothesised order);
+///             sizes — per-group n; k — groups (2..16).
+/// Retorno: JTResult (j, expected, z, p).
+/// Referências: Jonckheere (1954).
+pub fn jonckheere(values: &[f64; 256], sizes: &[i32; 16], k: i32) -> JTResult with Mut, Div, Panic {
+    if k < 2 || k > 16 { return JTResult { j: 0.0, expected: 0.0, z: 0.0, p: 1.0 } }
+    // group offsets
+    var off: [i32; 16] = [0; 16]
+    var cum = 0
+    var bign = 0.0
+    var sum_n2 = 0.0
+    var sum_n2b = 0.0    // Σ nᵢ²(2nᵢ+3)
+    var g = 0
+    while g < k {
+        off[g as usize] = cum
+        cum = cum + sizes[g as usize]
+        let nif = sizes[g as usize] as f64
+        bign = bign + nif
+        sum_n2 = sum_n2 + nif * nif
+        sum_n2b = sum_n2b + nif * nif * (2.0 * nif + 3.0)
+        g = g + 1
+    }
+    // J = Σ_{i<j} #{b in gj > a in gi} + ½ ties
+    var jstat = 0.0
+    var i = 0
+    while i < k {
+        var jg = i + 1
+        while jg < k {
+            var ai = 0
+            while ai < sizes[i as usize] {
+                let a = values[(off[i as usize] + ai) as usize]
+                var bj = 0
+                while bj < sizes[jg as usize] {
+                    let b = values[(off[jg as usize] + bj) as usize]
+                    if b > a { jstat = jstat + 1.0 } else { if b == a { jstat = jstat + 0.5 } }
+                    bj = bj + 1
+                }
+                ai = ai + 1
+            }
+            jg = jg + 1
+        }
+        i = i + 1
+    }
+    let ej = (bign * bign - sum_n2) / 4.0
+    let varj = (bign * bign * (2.0 * bign + 3.0) - sum_n2b) / 72.0
+    var z = 0.0
+    if varj > 0.0 { z = (jstat - ej) / jt_sqrt(varj) }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * jt_normal_sf(az)
+    return JTResult { j: jstat, expected: ej, z: z, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// three ordered groups g1={1,2,3}, g2={4,5,6}, g3={7,8,9} (perfect increase).
+// J = 9+9+9 = 27. E[J]=(81-27)/4=13.5. Var=(81·21 - 3·81)/72=(1701-243)/72=20.25.
+// z=(27-13.5)/4.5=3.0.
+fn test_jt() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0
+    v[3]=4.0; v[4]=5.0; v[5]=6.0
+    v[6]=7.0; v[7]=8.0; v[8]=9.0
+    sz[0]=3; sz[1]=3; sz[2]=3
+    let r = jonckheere(&v, &sz, 3)
+    var ok = true
+    ok = check(1, approx(r.j, 27.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.expected, 13.5, 1.0e-9)) && ok
+    ok = check(3, approx(r.z, 3.0, 1.0e-4)) && ok
+    ok = check(4, r.p < 0.01) && ok
+    return ok
+}
+
+// no trend (groups identical) -> J = E[J], z ≈ 0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var v: [f64; 256] = [0.0; 256]
+    var sz: [i32; 16] = [0; 16]
+    v[0]=1.0; v[1]=2.0; v[2]=3.0
+    v[3]=1.0; v[4]=2.0; v[5]=3.0
+    v[6]=1.0; v[7]=2.0; v[8]=3.0
+    sz[0]=3; sz[1]=3; sz[2]=3
+    let r = jonckheere(&v, &sz, 3)
+    return check(10, approx(r.z, 0.0, 1.0e-6))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_jt() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/mann_kendall.sio
+++ b/stdlib/stats/mann_kendall.sio
@@ -1,0 +1,165 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/mann_kendall.sio — Mann-Kendall trend test
+//
+// A rank-based test for a monotone trend in a time-ordered series — the standard
+// tool in environmental and hydrological statistics because it needs no
+// distributional assumption and is robust to outliers:
+//
+//   mann_kendall(x, n) -> MKResult
+//
+//   S = Σ_{i<j} sign(xⱼ − xᵢ),   Var(S) = n(n−1)(2n+5)/18,
+//   z = (S−1)/√Var(S)  (S>0),  (S+1)/√Var(S)  (S<0),  0 (S=0)   [continuity].
+// A positive z is an increasing trend. Sen's slope (median pairwise slope) is
+// the companion estimator (see stats::theil_sen).
+//
+// Pure Sounio: an O(n²) sign count; inline sqrt/erf. No external dependency, no
+// nested data-array calls.
+//
+// References:
+//   Mann (1945); Kendall (1975); Hirsch, Slack & Smith (1982).
+
+module stats::mann_kendall
+
+fn mk_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn mk_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / mk_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn mk_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * mk_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn mk_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - mk_erf(z * INV_SQRT2))
+}
+
+pub struct MKResult {
+    pub s: f64,       // Mann-Kendall S
+    pub z: f64,       // standardized statistic (with continuity correction)
+    pub p: f64,       // two-sided p
+    pub tau: f64,     // Kendall's tau = S / (n(n-1)/2)
+}
+
+/// Mann-Kendall trend test on a time-ordered series.
+///
+/// Parâmetros: x — series in time order; n — length (>=3, <=256).
+/// Retorno: MKResult (s, z, p, tau).
+/// Referências: Mann (1945); Kendall (1975).
+pub fn mann_kendall(x: &[f64; 256], n: i32) -> MKResult with Mut, Div, Panic {
+    if n < 3 { return MKResult { s: 0.0, z: 0.0, p: 1.0, tau: 0.0 } }
+    var s = 0.0
+    var i = 0
+    while i < n {
+        var j = i + 1
+        while j < n {
+            let d = x[j as usize] - x[i as usize]
+            if d > 0.0 { s = s + 1.0 } else { if d < 0.0 { s = s - 1.0 } }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let nf = n as f64
+    let var_s = nf * (nf - 1.0) * (2.0 * nf + 5.0) / 18.0
+    var z = 0.0
+    if var_s > 0.0 {
+        if s > 0.0 { z = (s - 1.0) / mk_sqrt(var_s) }
+        else { if s < 0.0 { z = (s + 1.0) / mk_sqrt(var_s) } }
+    }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * mk_normal_sf(az)
+    let tau = s / (nf * (nf - 1.0) / 2.0)
+    return MKResult { s: s, z: z, p: p, tau: tau }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// monotone increasing {1,2,3,4,5}: all C(5,2)=10 pairs positive -> S=10.
+// Var=5·4·15/18=16.666667. z=(10-1)/4.082483=2.204541. tau=10/10=1.
+fn test_increasing() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = mann_kendall(&x, 5)
+    var ok = true
+    ok = check(1, approx(r.s, 10.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.z, 2.204541, 1.0e-4)) && ok
+    ok = check(3, approx(r.tau, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// monotone decreasing -> S=-10, tau=-1, negative z.
+fn test_decreasing() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=5.0; x[1]=4.0; x[2]=3.0; x[3]=2.0; x[4]=1.0
+    let r = mann_kendall(&x, 5)
+    var ok = true
+    ok = check(10, approx(r.s, 0.0 - 10.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.tau, 0.0 - 1.0, 1.0e-9)) && ok
+    ok = check(12, r.z < 0.0) && ok
+    return ok
+}
+
+// no trend (symmetric zig-zag) -> S small, z near 0.
+fn test_notrend() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=3.0; x[1]=1.0; x[2]=4.0; x[3]=2.0; x[4]=5.0; x[5]=3.0
+    let r = mann_kendall(&x, 6)
+    return check(20, r.p > 0.3)
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_increasing() && ok
+    ok = test_decreasing() && ok
+    ok = test_notrend() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/page_trend.sio
+++ b/stdlib/stats/page_trend.sio
@@ -1,0 +1,169 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/page_trend.sio — Page's L test for ordered alternatives
+//
+// The repeated-measures analogue of Jonckheere-Terpstra: n subjects each ranked
+// across k treatments that have an a-priori order, testing for a monotone trend
+// (the ordered-alternative version of Friedman):
+//
+//   page_trend(data, n, k) -> PageResult      (data row-major n×k, in treatment order)
+//
+//   L = Σ_{j=1}^k j·Rⱼ,   Rⱼ = column rank sum,
+//   E[L] = n·k(k+1)²/4,   Var[L] = n·k²(k²−1)(k+1)/144,
+//   z = (L − E[L])/√Var[L].
+//
+// Pure Sounio: per-row mid-ranking over a fixed [16]-wide scratch (k ≤ 16);
+// inline sqrt/erf. No nested data-array calls.
+//
+// References:
+//   Page (1963) JASA 58:216.
+
+module stats::page_trend
+
+fn pt_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn pt_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / pt_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn pt_erf(x: f64) -> f64 with Mut, Div, Panic {
+    let sgn = if x < 0.0 { 0.0 - 1.0 } else { 1.0 }
+    let ax = if x < 0.0 { 0.0 - x } else { x }
+    let t = 1.0 / (1.0 + 0.3275911 * ax)
+    let y = 1.0 - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t
+              - 0.284496736) * t + 0.254829592) * t * pt_exp(0.0 - ax * ax)
+    return sgn * y
+}
+
+fn pt_normal_sf(z: f64) -> f64 with Mut, Div, Panic {
+    let INV_SQRT2 = 0.7071067811865476
+    return 0.5 * (1.0 - pt_erf(z * INV_SQRT2))
+}
+
+pub struct PageResult {
+    pub l: f64,        // Page's L
+    pub expected: f64,
+    pub z: f64,
+    pub p: f64,        // two-sided p
+}
+
+/// Page's L trend test on a row-major n×k subject×treatment matrix.
+///
+/// Parâmetros: data — n·k values (treatments in hypothesised order);
+///             n — subjects (>=2); k — treatments (2..16).
+/// Retorno: PageResult (l, expected, z, p).
+/// Referências: Page (1963).
+pub fn page_trend(data: &[f64; 256], n: i32, k: i32) -> PageResult with Mut, Div, Panic {
+    if n < 2 || k < 2 || k > 16 { return PageResult { l: 0.0, expected: 0.0, z: 0.0, p: 1.0 } }
+    var rsum: [f64; 16] = [0.0; 16]
+    var row: [f64; 16] = [0.0; 16]
+    var i = 0
+    while i < n {
+        var j = 0
+        while j < k { row[j as usize] = data[(i * k + j) as usize]; j = j + 1 }
+        // mid-rank within the row
+        var a = 0
+        while a < k {
+            var less = 0
+            var eq = 0
+            var b = 0
+            while b < k {
+                if row[b as usize] < row[a as usize] { less = less + 1 }
+                else { if row[b as usize] == row[a as usize] { eq = eq + 1 } }
+                b = b + 1
+            }
+            let rk = (less as f64) + ((eq + 1) as f64) * 0.5
+            rsum[a as usize] = rsum[a as usize] + rk
+            a = a + 1
+        }
+        i = i + 1
+    }
+    // L = Σ j·R_j (j = 1..k)
+    var l = 0.0
+    var jj = 0
+    while jj < k { l = l + ((jj + 1) as f64) * rsum[jj as usize]; jj = jj + 1 }
+    let nf = n as f64
+    let kf = k as f64
+    let el = nf * kf * (kf + 1.0) * (kf + 1.0) / 4.0
+    let varl = nf * kf * kf * (kf * kf - 1.0) * (kf + 1.0) / 144.0
+    var z = 0.0
+    if varl > 0.0 { z = (l - el) / pt_sqrt(varl) }
+    let az = if z < 0.0 { 0.0 - z } else { z }
+    let p = 2.0 * pt_normal_sf(az)
+    return PageResult { l: l, expected: el, z: z, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// 3 blocks, 3 treatments, each block ranks (1,2,3) in order (perfect trend).
+// R=(3,6,9). L=1·3+2·6+3·9=42. E[L]=3·3·16/4=36. Var=3·9·8·4/144=6. z=(42-36)/√6=2.449490.
+fn test_page() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=1.0; d[1]=2.0; d[2]=3.0
+    d[3]=1.0; d[4]=2.0; d[5]=3.0
+    d[6]=1.0; d[7]=2.0; d[8]=3.0
+    let r = page_trend(&d, 3, 3)
+    var ok = true
+    ok = check(1, approx(r.l, 42.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.expected, 36.0, 1.0e-9)) && ok
+    ok = check(3, approx(r.z, 2.449490, 1.0e-4)) && ok
+    return ok
+}
+
+// no trend (constant rows) -> L = E[L], z ≈ 0.
+fn test_null() -> bool with IO, Mut, Div, Panic {
+    var d: [f64; 256] = [0.0; 256]
+    d[0]=5.0; d[1]=5.0; d[2]=5.0
+    d[3]=5.0; d[4]=5.0; d[5]=5.0
+    let r = page_trend(&d, 2, 3)
+    return check(10, approx(r.z, 0.0, 1.0e-6))
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_page() && ok
+    ok = test_null() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three non-parametric monotonic-trend tests, bringing the runner to **130 modules**. The suite tested trend in *proportions* (Cochran-Armitage) but had no ordered-alternative tests for continuous/ordinal data. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::jonckheere` | Jonckheere-Terpstra — trend across k ordered independent groups |
| `stats::page_trend` | Page's L — trend across ordered treatments (repeated measures) |
| `stats::mann_kendall` | Mann-Kendall — monotonic trend in a time series (+ Kendall's τ) |

## Validation

- Inline `//@ run-pass` tests against hand-computed worked examples:
  - Jonckheere: three increasing groups → J=27, E[J]=13.5, z=3.0; identical groups → z=0.
  - Page's L: perfectly ordered 3×3 → L=42, E[L]=36, z=2.449; no trend → z=0.
  - Mann-Kendall: increasing {1..5} → S=10, z=2.2045, τ=1; decreasing → S=−10, τ=−1.
- Full suite selftest: **130 modules + 7 demos ALL GREEN** under `lean_single`.

One more derivable-values catch: the Mann-Kendall z test constant was a hand slip (2.204793); the assertion failed, and 9/√16.667 = 2.204541 (Python-verified) is correct.

The three cover the three trend designs: independent ordered groups (Jonckheere), ordered repeated measures (Page), and time series (Mann-Kendall).

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).