### PR TITLE
feat(stats): robust M-estimation — huber_location, siegel_regression, yuen

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3023,3 +3023,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - mann_kendall = **PASS**: S=Σsign, Var=n(n−1)(2n+5)/18, continuity-corrected z, τ=2S/(n(n−1)); increasing {1..5}→S=10, z=2.2045, τ=1. Note: test constant z=2.204793 was a hand slip — correct 9/√16.6667=2.204541 (Python-verified); caught by the failing assertion, fixed.
 - Theme: ordered-alternative & monotonic-trend tests — extends the non-parametric family beyond the proportion trend (cochran_armitage) to continuous/ordinal ordered groups, repeated measures, and time series. All derivable, #852-safe. Suite runner: 130 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-iOjAr1/`, `/tmp/llm-offload-5fFzUi/`, `/tmp/llm-offload-N6zSm6/`.
+
+## 2026-07-16 — math-review: stats::huber_location, stats::siegel_regression, stats::yuen
+- Files (all new): `stdlib/stats/huber_location.sio` (Huber M-estimator of location, MAD-scaled reweighting), `stdlib/stats/siegel_regression.sio` (Siegel repeated-median regression, 50% breakdown), `stdlib/stats/yuen.sio` (Yuen trimmed-means t-test). Provider: xAI/Grok 4.3.
+- huber_location = **PASS**: MAD scale 1.4826, weight 1 if |u|≤c else c/|u|, iterated location; symmetric {1..5}→3, outlier {1,2,3,4,100}→3 (Python-verified, fully robust vs mean 22).
+- siegel_regression = **PASS**: b=medianᵢ(median_{j≠i} slope), intercept=median residual; perfect→(2,1), outlier at (5,100)→(2,1). Two big buffers (point_med + slopes) live across the median helper call — ran clean under lean_single (no #852).
+- yuen = **PASS**: Winsorized variance s²_w=Σ(v−wmean)²/(n−1), d=(n−1)s²_w/(h(h−1)), t=(x̄_t1−x̄_t2)/√(d1+d2), Welch-style df; x={1..10}/y={3..11,50}/γ=0.2→tm 5.5/7.5, t=−1.188182, df=10 (Python-cross-checked).
+- Theme: robust M-estimation — robust location (Huber), robust regression (Siegel, higher breakdown than Theil-Sen), robust two-sample test (Yuen). All derivable / Python-anchored, #852-safe. Suite runner: 133 modules + 7 demos ALL GREEN under lean_single.
+- Raw review dirs: `/tmp/llm-offload-pxPazF/`, `/tmp/llm-offload-jQ7cVi/`, `/tmp/llm-offload-3CzPbg/`.

--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3024,6 +3024,12 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - Theme: ordered-alternative & monotonic-trend tests — extends the non-parametric family beyond the proportion trend (cochran_armitage) to continuous/ordinal ordered groups, repeated measures, and time series. All derivable, #852-safe. Suite runner: 130 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-iOjAr1/`, `/tmp/llm-offload-5fFzUi/`, `/tmp/llm-offload-N6zSm6/`.
 
+## 2026-07-16 — math-review follow-up: stats::huber_location, stats::siegel_regression, stats::yuen (PR #1009)
+- Target: `stdlib/stats/huber_location.sio`, `stdlib/stats/siegel_regression.sio`, and `stdlib/stats/yuen.sio`.
+- xAI/Grok 4.3: **PASS_SINGLE_PROVIDER_DEGRADED**. It accepted the Huber IRLS update and MAD normal-consistency scale, Siegel's repeated-median slope/intercept definition, Yuen's trimmed/Winsorized variance, Welch-style degrees of freedom and t statistic, the incomplete-beta two-tail identity, and every documented test value.
+- Independent-provider fallback: Z.AI GLM-5.2 produced no response before the 65-second timeout (`/tmp/llm-offload-9WIwRq/`); Qwen failed with OpenRouter HTTP 402 (`/tmp/llm-offload-3Af1we/`). Re-review with Z.AI remains pending when the provider is responsive.
+- Scope: audit-only follow-up; no statistical implementation changed. The pre-existing PR CI was fully green before this receipt update. Local hygiene: `git diff --check` -> PASS.
+
 ## 2026-07-16 — math-review: stats::huber_location, stats::siegel_regression, stats::yuen
 - Files (all new): `stdlib/stats/huber_location.sio` (Huber M-estimator of location, MAD-scaled reweighting), `stdlib/stats/siegel_regression.sio` (Siegel repeated-median regression, 50% breakdown), `stdlib/stats/yuen.sio` (Yuen trimmed-means t-test). Provider: xAI/Grok 4.3.
 - huber_location = **PASS**: MAD scale 1.4826, weight 1 if |u|≤c else c/|u|, iterated location; symmetric {1..5}→3, outlier {1,2,3,4,100}→3 (Python-verified, fully robust vs mean 22).

--- a/scripts/stats_epistemic_suite_selftest.sh
+++ b/scripts/stats_epistemic_suite_selftest.sh
@@ -139,6 +139,9 @@ MODULES=(
   stdlib/stats/jonckheere.sio
   stdlib/stats/page_trend.sio
   stdlib/stats/mann_kendall.sio
+  stdlib/stats/huber_location.sio
+  stdlib/stats/siegel_regression.sio
+  stdlib/stats/yuen.sio
 )
 
 fail=0

--- a/stdlib/stats/EPISTEMIC_SUITE.md
+++ b/stdlib/stats/EPISTEMIC_SUITE.md
@@ -15,8 +15,9 @@ fourteen families:
   kurtosis); plus the robust median / IQR / MAD / trimmed & Winsorized means,
   the Hodges-Lehmann estimators, Tukey / Grubbs / modified-z outlier rules, and
   the data-transformation primitives (z-scores, min-max & robust scaling, rank
-  transform), and the weighted / grouped estimators (weighted mean & variance,
-  grouped-frequency statistics, weighted quantiles).
+  transform), the weighted / grouped estimators (weighted mean & variance,
+  grouped-frequency statistics, weighted quantiles), and the robust M-estimators
+  (Huber location, Siegel repeated-median regression, Yuen's trimmed t-test).
 - **Assumption checks** — normality (Jarque-Bera, Q-Q, Kolmogorov-Smirnov,
   Anderson-Darling, Cramér-von Mises, χ²/G goodness-of-fit), independence
   (Wald-Wolfowitz runs, Durbin-Watson,
@@ -1695,6 +1696,37 @@ The rank-based monotonic-trend test for a time-ordered series (the environmental
 statistics standard): `S=Σ_{i<j}sign(xⱼ−xᵢ)`, continuity-corrected z, and Kendall's
 τ. Validated: increasing {1..5} → S=10, z=2.2045, τ=1; decreasing → S=−10, τ=−1.
 
+### `stats::huber_location` — Huber M-estimator of location
+
+| Function | Signature |
+|---|---|
+| `huber_location` | `pub fn huber_location(x: &[f64; 256], n: i32, c: f64) -> HuberResult with Mut, Div, Panic` |
+
+A robust centre that behaves like the mean near the bulk but downweights outliers
+(iteratively reweighted with a MAD scale and tuning constant c≈1.345). Validated:
+symmetric {1..5} → 3; {1,2,3,4,100} → 3 (fully robust, vs the mean 22).
+
+### `stats::siegel_regression` — repeated-median regression
+
+| Function | Signature |
+|---|---|
+| `siegel_regression` | `pub fn siegel_regression(x: &[f64; 256], y: &[f64; 256], n: i32) -> SiegelFit with Mut, Div, Panic` |
+
+The 50%-breakdown robust regression: `b=medianᵢ(median_{j≠i} slopeᵢⱼ)` — the inner
+per-point median then the median across points buys higher robustness than
+Theil-Sen. Validated: perfect line → (2,1); a wild outlier at (5,100) still →
+(2,1).
+
+### `stats::yuen` — Yuen's trimmed-means t-test
+
+| Function | Signature |
+|---|---|
+| `yuen` | `pub fn yuen(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, gamma: f64) -> YuenResult with Mut, Div, Panic` |
+
+A robust two-sample test comparing γ-trimmed means with Winsorized variances (the
+outlier-resistant Welch). Validated (Python-cross-checked): x={1..10} vs
+{3..11,50}, γ=0.2 → trimmed means 5.5/7.5, t=−1.188, df=10.
+
 A **funnel plot** figure (`examples/stats/funnel_plot.sio`) accompanies the
 meta-analysis (effect vs precision with the pseudo-95% funnel, for publication-bias
 assessment).
@@ -1829,6 +1861,9 @@ use stats::welch_anova::{WelchAnovaResult, welch_anova}
 use stats::jonckheere::{JTResult, jonckheere}
 use stats::page_trend::{PageResult, page_trend}
 use stats::mann_kendall::{MKResult, mann_kendall}
+use stats::huber_location::{HuberResult, huber_location}
+use stats::siegel_regression::{SiegelFit, siegel_regression}
+use stats::yuen::{YuenResult, yuen}
 ```
 
 Worked end-to-end examples that compose several tools on one dataset live at

--- a/stdlib/stats/huber_location.sio
+++ b/stdlib/stats/huber_location.sio
@@ -1,0 +1,138 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/huber_location.sio — Huber M-estimator of location
+//
+// A robust estimator of centre that behaves like the mean near the bulk of the
+// data but downweights outliers like the median — the standard M-estimator:
+//
+//   huber_location(x, n, c) -> HuberResult
+//
+// With MAD scale s and tuning constant c (usually 1.345, ~95% efficiency under
+// normality), iterate mₜ₊₁ = Σwᵢxᵢ/Σwᵢ where wᵢ = 1 if |uᵢ|≤c else c/|uᵢ| and
+// uᵢ = (xᵢ − mₜ)/s. The result lies between the mean and the median.
+//
+// Pure Sounio: an inline sort for the median and MAD; a fixed-iteration
+// reweighting loop. No external dependency, no nested data-array calls.
+//
+// References:
+//   Huber (1964) Ann. Math. Stat. 35:73.
+
+module stats::huber_location
+
+fn hl_abs(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    return x
+}
+
+// median of the first m entries of a [256] buffer (inline insertion sort).
+fn hl_median(buf: &![f64; 256], m: i32) -> f64 with Mut, Div, Panic {
+    if m < 1 { return 0.0 }
+    var i = 1
+    while i < m {
+        let key = buf[i as usize]
+        var j = i - 1
+        while j >= 0 && buf[j as usize] > key { buf[(j + 1) as usize] = buf[j as usize]; j = j - 1 }
+        buf[(j + 1) as usize] = key
+        i = i + 1
+    }
+    if m % 2 == 1 { return buf[((m - 1) / 2) as usize] }
+    return 0.5 * (buf[(m / 2 - 1) as usize] + buf[(m / 2) as usize])
+}
+
+pub struct HuberResult {
+    pub location: f64,   // Huber M-estimate of centre
+    pub scale: f64,      // MAD scale used
+    pub iters: i64,      // iterations to converge
+}
+
+/// Huber M-estimator of location.
+///
+/// Parâmetros: x — data; n — size (>=2, <=256); c — tuning constant (e.g. 1.345).
+/// Retorno: HuberResult (location, scale, iters).
+/// Referências: Huber (1964).
+pub fn huber_location(x: &[f64; 256], n: i32, c: f64) -> HuberResult with Mut, Div, Panic {
+    if n < 2 { return HuberResult { location: 0.0, scale: 0.0, iters: 0 } }
+    var buf: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < n { buf[i as usize] = x[i as usize]; i = i + 1 }
+    var m = hl_median(&!buf, n)
+    // MAD: median of |x - m|, scaled
+    var dev: [f64; 256] = [0.0; 256]
+    var j = 0
+    while j < n { dev[j as usize] = hl_abs(x[j as usize] - m); j = j + 1 }
+    let mad = 1.482602218505602 * hl_median(&!dev, n)
+    if mad <= 1.0e-300 { return HuberResult { location: m, scale: 0.0, iters: 0 } }
+    var used = 0
+    var it = 0
+    while it < 50 {
+        var num = 0.0
+        var den = 0.0
+        var k = 0
+        while k < n {
+            let u = (x[k as usize] - m) / mad
+            let au = hl_abs(u)
+            var w = 1.0
+            if au > c { w = c / au }
+            num = num + w * x[k as usize]
+            den = den + w
+            k = k + 1
+        }
+        if den <= 0.0 { it = 50 }
+        else {
+            let mnew = num / den
+            used = it + 1
+            if hl_abs(mnew - m) < 1.0e-10 { m = mnew; it = 50 } else { m = mnew; it = it + 1 }
+        }
+    }
+    return HuberResult { location: m, scale: mad, iters: used as i64 }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// symmetric {1,2,3,4,5} -> Huber location = 3 (= mean = median).
+fn test_symmetric() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    let r = huber_location(&x, 5, 1.345)
+    return check(1, approx(r.location, 3.0, 1.0e-6))
+}
+
+// outlier {1,2,3,4,100}: Huber ≈ 3.0 (fully robust), vs the mean 22 (Python-verified).
+fn test_outlier() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=100.0
+    let r = huber_location(&x, 5, 1.345)
+    var ok = true
+    ok = check(10, approx(r.location, 3.0, 1.0e-2)) && ok
+    ok = check(11, r.location < 5.0) && ok            // far below the mean 22
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_symmetric() && ok
+    ok = test_outlier() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/siegel_regression.sio
+++ b/stdlib/stats/siegel_regression.sio
@@ -1,0 +1,150 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/siegel_regression.sio — Siegel repeated-median regression
+//
+// The most outlier-resistant simple regression in common use — a 50% breakdown
+// point, higher than Theil-Sen's ~29%:
+//
+//   siegel_regression(x, y, n) -> SiegelFit
+//
+//   slope b = median_i ( median_{j≠i} (yⱼ−yᵢ)/(xⱼ−xᵢ) ),
+//   intercept a = median_i ( yᵢ − b·xᵢ ).
+// The inner median per point, then the median across points, is what buys the
+// extra robustness over the single median of all pairwise slopes.
+//
+// Pure Sounio: per-point slope medians in bounded [256] scratch (n ≤ 64) with an
+// inline sort; no nested call while a large buffer is live.
+//
+// References:
+//   Siegel (1982) Biometrika 69:242.
+
+module stats::siegel_regression
+
+// median of the first m entries of a [256] buffer (inline insertion sort).
+fn sg_median(buf: &![f64; 256], m: i32) -> f64 with Mut, Div, Panic {
+    if m < 1 { return 0.0 }
+    var i = 1
+    while i < m {
+        let key = buf[i as usize]
+        var j = i - 1
+        while j >= 0 && buf[j as usize] > key { buf[(j + 1) as usize] = buf[j as usize]; j = j - 1 }
+        buf[(j + 1) as usize] = key
+        i = i + 1
+    }
+    if m % 2 == 1 { return buf[((m - 1) / 2) as usize] }
+    return 0.5 * (buf[(m / 2 - 1) as usize] + buf[(m / 2) as usize])
+}
+
+pub struct SiegelFit {
+    pub slope: f64,
+    pub intercept: f64,
+}
+
+/// Siegel repeated-median regression.
+///
+/// Parâmetros: x, y — paired data; n — size (3..64).
+/// Retorno: SiegelFit (slope, intercept).
+/// Referências: Siegel (1982).
+pub fn siegel_regression(x: &[f64; 256], y: &[f64; 256], n: i32) -> SiegelFit with Mut, Div, Panic {
+    if n < 3 || n > 64 { return SiegelFit { slope: 0.0, intercept: 0.0 } }
+    var point_med: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < n {
+        // slopes from point i to all j != i
+        var slopes: [f64; 256] = [0.0; 256]
+        var cnt = 0
+        var j = 0
+        while j < n {
+            if j != i {
+                let dx = x[j as usize] - x[i as usize]
+                if dx != 0.0 {
+                    slopes[cnt as usize] = (y[j as usize] - y[i as usize]) / dx
+                    cnt = cnt + 1
+                }
+            }
+            j = j + 1
+        }
+        if cnt > 0 { point_med[i as usize] = sg_median(&!slopes, cnt) }
+        i = i + 1
+    }
+    let slope = sg_median(&!point_med, n)
+    // intercept = median of (y_i - slope*x_i)
+    var resid: [f64; 256] = [0.0; 256]
+    var k = 0
+    while k < n { resid[k as usize] = y[k as usize] - slope * x[k as usize]; k = k + 1 }
+    let intercept = sg_median(&!resid, n)
+    return SiegelFit { slope: slope, intercept: intercept }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// perfect line y=2x+1: every slope 2 -> slope 2, intercept 1.
+fn test_perfect() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0
+    let r = siegel_regression(&x, &y, 4)
+    var ok = true
+    ok = check(1, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(2, approx(r.intercept, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// robustness: y=2x+1 for x=1..4, plus a wild outlier (5,100).
+// each in-line point's median slope is 2; the overall median is 2 -> slope 2,
+// intercept = median(1,1,1,1,90) = 1.
+fn test_robust() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=1.0; x[1]=2.0; x[2]=3.0; x[3]=4.0; x[4]=5.0
+    y[0]=3.0; y[1]=5.0; y[2]=7.0; y[3]=9.0; y[4]=100.0
+    let r = siegel_regression(&x, &y, 5)
+    var ok = true
+    ok = check(10, approx(r.slope, 2.0, 1.0e-9)) && ok
+    ok = check(11, approx(r.intercept, 1.0, 1.0e-9)) && ok
+    return ok
+}
+
+// negative slope y = -3x + 10.
+fn test_negative() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    x[0]=0.0; x[1]=1.0; x[2]=2.0; x[3]=3.0
+    y[0]=10.0; y[1]=7.0; y[2]=4.0; y[3]=1.0
+    let r = siegel_regression(&x, &y, 4)
+    var ok = true
+    ok = check(20, approx(r.slope, 0.0 - 3.0, 1.0e-9)) && ok
+    ok = check(21, approx(r.intercept, 10.0, 1.0e-9)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_perfect() && ok
+    ok = test_robust() && ok
+    ok = test_negative() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}

--- a/stdlib/stats/yuen.sio
+++ b/stdlib/stats/yuen.sio
@@ -1,0 +1,301 @@
+//@ run-pass
+//@ expect-stdout: ALL PASS
+
+// stdlib/stats/yuen.sio — Yuen's trimmed-means t-test
+//
+// A robust two-sample test comparing trimmed means with Winsorized variances —
+// far less sensitive to outliers and non-normal tails than Welch's t-test:
+//
+//   yuen(x, nx, y, ny, gamma) -> YuenResult
+//
+// Trim γ from each tail (h = n − 2⌊γn⌋ kept), with the Winsorized variance s²_w,
+//   dⱼ = (nⱼ−1)·s²_wⱼ / (hⱼ(hⱼ−1)),
+//   t_y = (x̄_t1 − x̄_t2)/√(d₁+d₂),   df = (d₁+d₂)²/(d₁²/(h₁−1)+d₂²/(h₂−1)).
+//
+// Pure Sounio: inline sort per group; incomplete beta for the t tail. No nested
+// data-array calls.
+//
+// References:
+//   Yuen (1974) Biometrika 61:165.
+
+module stats::yuen
+
+fn yn_exp(x: f64) -> f64 with Mut, Div, Panic {
+    if x < 0.0 { return 1.0 / yn_exp(0.0 - x) }
+    var k = 0
+    var r = x
+    while r > 2.0 { r = r * 0.5; k = k + 1 }
+    var term = 1.0
+    var sum = 1.0
+    var n = 1
+    while n < 40 { term = term * r / (n as f64); sum = sum + term; n = n + 1 }
+    var i = 0
+    while i < k { sum = sum * sum; i = i + 1 }
+    return sum
+}
+
+fn yn_ln(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var m = x
+    var e = 0.0
+    let LN2 = 0.6931471805599453
+    while m >= 2.0 { m = m * 0.5; e = e + LN2 }
+    while m < 1.0 { m = m * 2.0; e = e - LN2 }
+    let t = (m - 1.0) / (m + 1.0)
+    let t2 = t * t
+    var term = t
+    var sum = 0.0
+    var n = 0
+    while n < 40 { sum = sum + term / ((2 * n + 1) as f64); term = term * t2; n = n + 1 }
+    return e + 2.0 * sum
+}
+
+fn yn_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var s = x
+    var sb = 1.0
+    while s < 1.0 { s = s * 4.0; sb = sb * 2.0 }
+    while s > 4.0 { s = s * 0.25; sb = sb * 0.5 }
+    var y = 1.5
+    var i = 0
+    while i < 30 { y = 0.5 * (y + s / y); i = i + 1 }
+    return y / sb
+}
+
+fn yn_lgamma(x: f64) -> f64 with Mut, Div, Panic {
+    let g = 7.0
+    var c0 = 0.99999999999980993
+    var c1 = 676.5203681218851
+    var c2 = 0.0 - 1259.1392167224028
+    var c3 = 771.32342877765313
+    var c4 = 0.0 - 176.61502916214059
+    var c5 = 12.507343278686905
+    var c6 = 0.0 - 0.13857109526572012
+    var c7 = 0.0000099843695780195716
+    var c8 = 0.00000015056327351493116
+    let xm = x - 1.0
+    var a = c0
+    a = a + c1 / (xm + 1.0)
+    a = a + c2 / (xm + 2.0)
+    a = a + c3 / (xm + 3.0)
+    a = a + c4 / (xm + 4.0)
+    a = a + c5 / (xm + 5.0)
+    a = a + c6 / (xm + 6.0)
+    a = a + c7 / (xm + 7.0)
+    a = a + c8 / (xm + 8.0)
+    let tt = xm + g + 0.5
+    let HALF_LN_2PI = 0.9189385332046727
+    return HALF_LN_2PI + (xm + 0.5) * yn_ln(tt) - tt + yn_ln(a)
+}
+
+fn yn_betacf(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    let qab = a + b
+    let qap = a + 1.0
+    let qam = a - 1.0
+    var c = 1.0
+    var d = 1.0 - qab * x / qap
+    if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+    d = 1.0 / d
+    var h = d
+    var m = 1
+    while m <= 200 {
+        let mf = m as f64
+        let m2 = 2.0 * mf
+        var aa = mf * (b - mf) * x / ((qam + m2) * (a + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        h = h * d * c
+        aa = 0.0 - (a + mf) * (qab + mf) * x / ((a + m2) * (qap + m2))
+        d = 1.0 + aa * d
+        if d < 1.0e-300 && d > 0.0 - 1.0e-300 { d = 1.0e-300 }
+        c = 1.0 + aa / c
+        if c < 1.0e-300 && c > 0.0 - 1.0e-300 { c = 1.0e-300 }
+        d = 1.0 / d
+        let del = d * c
+        h = h * del
+        let dd = if del - 1.0 < 0.0 { 1.0 - del } else { del - 1.0 }
+        if dd < 1.0e-14 { m = 201 } else { m = m + 1 }
+    }
+    return h
+}
+
+fn yn_ibeta(a: f64, b: f64, x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    if x >= 1.0 { return 1.0 }
+    let lbeta = yn_lgamma(a) + yn_lgamma(b) - yn_lgamma(a + b)
+    let front = yn_exp(a * yn_ln(x) + b * yn_ln(1.0 - x) - lbeta)
+    if x < (a + 1.0) / (a + b + 2.0) { return front * yn_betacf(a, b, x) / a }
+    return 1.0 - front * yn_betacf(b, a, 1.0 - x) / b
+}
+
+fn yn_t_two_tail(t: f64, df: f64) -> f64 with Mut, Div, Panic {
+    if df <= 0.0 { return 1.0 }
+    let at = if t < 0.0 { 0.0 - t } else { t }
+    let x = df / (df + at * at)
+    return yn_ibeta(df * 0.5, 0.5, x)
+}
+
+pub struct YuenResult {
+    pub trimmed_mean_x: f64,
+    pub trimmed_mean_y: f64,
+    pub t: f64,
+    pub df: f64,
+    pub p: f64,
+}
+
+/// Yuen's trimmed-means t-test.
+///
+/// Parâmetros: x, y — the two samples; nx, ny — sizes; gamma — trim fraction (e.g. 0.2).
+/// Retorno: YuenResult (trimmed means, t, df, p).
+/// Referências: Yuen (1974).
+pub fn yuen(x: &[f64; 256], nx: i32, y: &[f64; 256], ny: i32, gamma: f64) -> YuenResult with Mut, Div, Panic {
+    if nx < 4 || ny < 4 { return YuenResult { trimmed_mean_x: 0.0, trimmed_mean_y: 0.0, t: 0.0, df: 0.0, p: 1.0 } }
+    // group X
+    var sx: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < nx { sx[i as usize] = x[i as usize]; i = i + 1 }
+    var p1 = 1
+    while p1 < nx {
+        let key = sx[p1 as usize]
+        var q = p1 - 1
+        while q >= 0 && sx[q as usize] > key { sx[(q + 1) as usize] = sx[q as usize]; q = q - 1 }
+        sx[(q + 1) as usize] = key
+        p1 = p1 + 1
+    }
+    var kx = 0
+    while ((kx + 1) as f64) <= gamma * (nx as f64) { kx = kx + 1 }
+    let hx = nx - 2 * kx
+    if hx < 2 { return YuenResult { trimmed_mean_x: 0.0, trimmed_mean_y: 0.0, t: 0.0, df: 0.0, p: 1.0 } }
+    // trimmed mean X
+    var tmx = 0.0
+    var a1 = kx
+    while a1 < nx - kx { tmx = tmx + sx[a1 as usize]; a1 = a1 + 1 }
+    tmx = tmx / (hx as f64)
+    // Winsorized mean & variance X
+    let lox = sx[kx as usize]
+    let hix = sx[(nx - kx - 1) as usize]
+    var wsx = 0.0
+    var b1 = 0
+    while b1 < nx {
+        var v = sx[b1 as usize]
+        if v < lox { v = lox }
+        if v > hix { v = hix }
+        wsx = wsx + v
+        b1 = b1 + 1
+    }
+    let wmx = wsx / (nx as f64)
+    var swx = 0.0
+    var c1 = 0
+    while c1 < nx {
+        var v = sx[c1 as usize]
+        if v < lox { v = lox }
+        if v > hix { v = hix }
+        let d = v - wmx
+        swx = swx + d * d
+        c1 = c1 + 1
+    }
+    let sw2x = swx / ((nx - 1) as f64)
+    let dx = ((nx - 1) as f64) * sw2x / ((hx as f64) * ((hx - 1) as f64))
+    // group Y
+    var sy: [f64; 256] = [0.0; 256]
+    var j = 0
+    while j < ny { sy[j as usize] = y[j as usize]; j = j + 1 }
+    var p2 = 1
+    while p2 < ny {
+        let key = sy[p2 as usize]
+        var q = p2 - 1
+        while q >= 0 && sy[q as usize] > key { sy[(q + 1) as usize] = sy[q as usize]; q = q - 1 }
+        sy[(q + 1) as usize] = key
+        p2 = p2 + 1
+    }
+    var ky = 0
+    while ((ky + 1) as f64) <= gamma * (ny as f64) { ky = ky + 1 }
+    let hy = ny - 2 * ky
+    if hy < 2 { return YuenResult { trimmed_mean_x: tmx, trimmed_mean_y: 0.0, t: 0.0, df: 0.0, p: 1.0 } }
+    var tmy = 0.0
+    var a2 = ky
+    while a2 < ny - ky { tmy = tmy + sy[a2 as usize]; a2 = a2 + 1 }
+    tmy = tmy / (hy as f64)
+    let loy = sy[ky as usize]
+    let hiy = sy[(ny - ky - 1) as usize]
+    var wsy = 0.0
+    var b2 = 0
+    while b2 < ny {
+        var v = sy[b2 as usize]
+        if v < loy { v = loy }
+        if v > hiy { v = hiy }
+        wsy = wsy + v
+        b2 = b2 + 1
+    }
+    let wmy = wsy / (ny as f64)
+    var swy = 0.0
+    var c2 = 0
+    while c2 < ny {
+        var v = sy[c2 as usize]
+        if v < loy { v = loy }
+        if v > hiy { v = hiy }
+        let d = v - wmy
+        swy = swy + d * d
+        c2 = c2 + 1
+    }
+    let sw2y = swy / ((ny - 1) as f64)
+    let dy = ((ny - 1) as f64) * sw2y / ((hy as f64) * ((hy - 1) as f64))
+    // Yuen statistic
+    let se = yn_sqrt(dx + dy)
+    var t = 0.0
+    if se > 0.0 { t = (tmx - tmy) / se }
+    var df = 0.0
+    let ddf = dx * dx / ((hx - 1) as f64) + dy * dy / ((hy - 1) as f64)
+    if ddf > 0.0 { df = (dx + dy) * (dx + dy) / ddf }
+    let p = yn_t_two_tail(t, df)
+    return YuenResult { trimmed_mean_x: tmx, trimmed_mean_y: tmy, t: t, df: df, p: p }
+}
+
+// ============================================================================
+// INLINE TESTS
+// ============================================================================
+
+fn approx(a: f64, b: f64, tol: f64) -> bool {
+    let d = if a > b { a - b } else { b - a }
+    return d <= tol
+}
+
+fn check(name: i64, ok: bool) -> bool with IO {
+    if ok { return true }
+    print("FAIL at case "); print(name); print("\n")
+    return false
+}
+
+// x={1..10}, y={3..11,50}, gamma=0.2 (Python-verified):
+// trimmed means 5.5 / 7.5; t=-1.188182; df=10.
+fn test_yuen() -> bool with IO, Mut, Div, Panic {
+    var x: [f64; 256] = [0.0; 256]
+    var y: [f64; 256] = [0.0; 256]
+    var i = 0
+    while i < 10 { x[i as usize] = (i + 1) as f64; i = i + 1 }
+    y[0]=3.0; y[1]=4.0; y[2]=5.0; y[3]=6.0; y[4]=7.0; y[5]=8.0; y[6]=9.0; y[7]=10.0; y[8]=11.0; y[9]=50.0
+    let r = yuen(&x, 10, &y, 10, 0.2)
+    var ok = true
+    ok = check(1, approx(r.trimmed_mean_x, 5.5, 1.0e-9)) && ok
+    ok = check(2, approx(r.trimmed_mean_y, 7.5, 1.0e-9)) && ok
+    ok = check(3, approx(r.t, 0.0 - 1.188182, 1.0e-4)) && ok
+    ok = check(4, approx(r.df, 10.0, 1.0e-3)) && ok
+    return ok
+}
+
+pub fn run_tests() -> bool with IO, Mut, Div, Panic {
+    var ok = true
+    ok = test_yuen() && ok
+    return ok
+}
+
+fn main() with IO, Mut, Div, Panic {
+    if run_tests() {
+        print("ALL PASS\n")
+    } else {
+        print("SOME FAILED\n")
+    }
+}


### PR DESCRIPTION
## Summary

Three robust methods, bringing the runner to **133 modules**. These extend the suite's robust descriptives (median/MAD) and robust regression (Theil-Sen/Passing-Bablok) with an M-estimator of location, a higher-breakdown regression, and a robust two-sample test. Math-reviewed by an orthogonal LLM (xAI/Grok 4.3 — PASS on all three).

| Module | What it adds |
|---|---|
| `stats::huber_location` | Huber M-estimator of location (MAD-scaled reweighting) |
| `stats::siegel_regression` | Repeated-median regression (50% breakdown) |
| `stats::yuen` | Yuen's trimmed-means t-test (outlier-resistant Welch) |

## Validation

- Inline `//@ run-pass` tests against hand-computed / Python-cross-checked examples:
  - Huber: symmetric {1..5} → 3; {1,2,3,4,100} → **3** (fully robust, vs the mean 22).
  - Siegel: perfect line → (2,1); a wild outlier at (5,100) still → (2,1).
  - Yuen: x={1..10} vs {3..11,50}, γ=0.2 → trimmed means 5.5/7.5, **t=−1.188, df=10** (Python-cross-checked).
- Full suite selftest: **133 modules + 7 demos ALL GREEN** under `lean_single`.

Siegel's regression keeps two large buffers (the per-point slope-median vector and the inner slope vector) live across the median helper call — it runs clean under `lean_single`, no `#852`.

## Offload audit
`.claude/llm_offload_log.md` updated with the three math-reviews (all PASS).