### PR TITLE
test(stdlib): deepen path range and pcg64 verticals

### DIFF
--- a/scripts/verticals_deepen12_gate.sh
+++ b/scripts/verticals_deepen12_gate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Deepen-batch 12: extend coverage of already-shipped deterministic utility APIs.
+# Multi-module drivers -> lean_single engine.
+#   path::lib          - join/parent/filename/stem/extension/from_bytes edge cases
+#   iter::range        - stepped ranges, reset, empty ranges, 64-item collect cap
+#   random::pcg64_core - bit helpers, 128-bit carry/mul, deterministic PCG stepping
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel [softcheck]
+  echo "== $2 =="
+  if [ "${4:-}" = "softcheck" ]; then
+    $SOUC check "$1" >/dev/null 2>&1 || echo "NOTE: standalone check quirk on $1 (driver proves the API)"
+  else
+    $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  fi
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/path/lib.sio             tests/stdlib/path/test_path_deep_stdlib.sio        PATH_DEEP_STDLIB_OK
+run stdlib/iter/range.sio           tests/stdlib/iter/test_range_deep_stdlib.sio       RANGE_DEEP_STDLIB_OK
+run stdlib/random/pcg64_core.sio    tests/stdlib/random/test_pcg64_core_deep_stdlib.sio PCG64_CORE_DEEP_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_DEEPEN12_GATE_OK"
+exit $fail

--- a/tests/stdlib/iter/test_range_deep_stdlib.sio
+++ b/tests/stdlib/iter/test_range_deep_stdlib.sio
@@ -1,0 +1,36 @@
+// Run-proof for stdlib iter::range public API.
+use iter::range::*;
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var r = range_step(2, 11, 3)
+    if range_len(&r) != 3 { print("FAIL range len\n"); return 1 }
+    if !range_has_next(&r) { print("FAIL has next\n"); return 2 }
+    if range_next(&!r) != 2 { print("FAIL next 2\n"); return 3 }
+    if range_next(&!r) != 5 { print("FAIL next 5\n"); return 4 }
+    range_reset(&!r)
+    if range_next(&!r) != 2 { print("FAIL reset\n"); return 5 }
+
+    let collected = range_collect(&!r)
+    if collected.len != 3 { print("FAIL collect len\n"); return 6 }
+    if collected.data[0] != 2 || collected.data[1] != 5 || collected.data[2] != 8 {
+        print("FAIL collect data\n")
+        return 7
+    }
+
+    var empty = range_new(5, 5)
+    if range_len(&empty) != 0 { print("FAIL empty len\n"); return 8 }
+    if range_has_next(&empty) { print("FAIL empty has next\n"); return 9 }
+    let empty_collected = range_collect(&!empty)
+    if empty_collected.len != 0 { print("FAIL empty collect\n"); return 10 }
+
+    var capped = range_new(0, 100)
+    let capped_collected = range_collect(&!capped)
+    if capped_collected.len != 64 { print("FAIL cap len\n"); return 11 }
+    if capped_collected.data[0] != 0 || capped_collected.data[63] != 63 {
+        print("FAIL cap data\n")
+        return 12
+    }
+
+    print("RANGE_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/path/test_path_deep_stdlib.sio
+++ b/tests/stdlib/path/test_path_deep_stdlib.sio
@@ -1,0 +1,94 @@
+// Run-proof for stdlib path::lib edge cases:
+// absolute join preservation, hidden-file extension, trailing slash filename,
+// root parent, stem, filename, and byte-copy construction.
+use path::lib::*;
+
+fn make_path_4(a: u8, b: u8, c: u8, d: u8) -> Path with Mut {
+    var p = path_new()
+    p.data[0] = a
+    p.data[1] = b
+    p.data[2] = c
+    p.data[3] = d
+    p.len = 4
+    p
+}
+
+fn make_path_6(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8) -> Path with Mut {
+    var p = path_new()
+    p.data[0] = a
+    p.data[1] = b
+    p.data[2] = c
+    p.data[3] = d
+    p.data[4] = e
+    p.data[5] = f
+    p.len = 6
+    p
+}
+
+fn make_path_7(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8, g: u8) -> Path with Mut {
+    var p = path_new()
+    p.data[0] = a
+    p.data[1] = b
+    p.data[2] = c
+    p.data[3] = d
+    p.data[4] = e
+    p.data[5] = f
+    p.data[6] = g
+    p.len = 7
+    p
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let usr = make_path_4(47, 117, 115, 114)              // "/usr"
+    let bin = make_path_4(98, 105, 110, 47)               // "bin/"
+    let joined = path_join(&usr, &bin)
+    if joined.len != 9 { print("FAIL join len\n"); return 1 }
+    if joined.data[0] != 47 || joined.data[4] != 47 || joined.data[8] != 47 {
+        print("FAIL join slash placement\n")
+        return 2
+    }
+    if !path_is_absolute(&joined) { print("FAIL absolute\n"); return 3 }
+
+    let fname_empty = path_filename(&joined)
+    if fname_empty.len != 0 { print("FAIL trailing slash filename\n"); return 4 }
+
+    let root = make_path_4(47, 0, 0, 0)
+    var root_one = root
+    root_one.len = 1
+    let root_parent = path_parent(&root_one)
+    if root_parent.len != 1 || root_parent.data[0] != 47 {
+        print("FAIL root parent\n")
+        return 5
+    }
+
+    let hidden = make_path_7(46, 112, 114, 111, 102, 105, 108) // ".profil"
+    let hidden_ext = path_extension(&hidden)
+    if hidden_ext.len != 6 || hidden_ext.data[0] != 112 {
+        print("FAIL hidden extension\n")
+        return 6
+    }
+    let hidden_stem = path_stem(&hidden)
+    if hidden_stem.len != 0 { print("FAIL hidden stem\n"); return 7 }
+
+    let module = make_path_6(109, 111, 100, 46, 115, 111) // "mod.so"
+    let ext = path_extension(&module)
+    if ext.len != 2 || ext.data[0] != 115 || ext.data[1] != 111 {
+        print("FAIL module ext\n")
+        return 8
+    }
+    let stem = path_stem(&module)
+    if stem.len != 3 || stem.data[0] != 109 || stem.data[2] != 100 {
+        print("FAIL module stem\n")
+        return 9
+    }
+
+    var bytes: [u8; 256] = [0; 256]
+    bytes[0] = 97
+    bytes[1] = 98
+    bytes[2] = 99
+    let copied = path_from_bytes(&bytes, 3)
+    if copied.len != 3 || copied.data[2] != 99 { print("FAIL from bytes\n"); return 10 }
+
+    print("PATH_DEEP_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/random/test_pcg64_core_deep_stdlib.sio
+++ b/tests/stdlib/random/test_pcg64_core_deep_stdlib.sio
@@ -1,0 +1,52 @@
+// Run-proof for random::pcg64_core bit helpers and deterministic state stepping.
+use random::pcg64_core::*;
+
+fn seed_state() -> PcgState {
+    PcgState {
+        state_hi: 42,
+        state_lo: 54,
+        inc_hi: 0,
+        inc_lo: 1442695040888963407,
+    }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    if !pcg_u_lt(0, -1) { print("FAIL unsigned lt max\n"); return 1 }
+    if pcg_u_lt(-1, 0) { print("FAIL unsigned lt zero\n"); return 2 }
+    if pcg_lshr(-1, 63) != 1 { print("FAIL lshr high\n"); return 3 }
+    if pcg_lshr(-1, 64) != 0 { print("FAIL lshr cap\n"); return 4 }
+
+    let add = pcg_u128_add(0, -1, 0, 1)
+    if add.hi != 1 || add.lo != 0 { print("FAIL u128 add carry\n"); return 5 }
+
+    let mul = pcg_u128_mul(0, 7, 0, 9)
+    if mul.hi != 0 || mul.lo != 63 { print("FAIL u128 mul small\n"); return 6 }
+
+    let rot = pcg_rotr64(8, 1)
+    if rot != 4 { print("FAIL rotr simple\n"); return 7 }
+
+    let s0 = seed_state()
+    let a1 = pcg_step(s0)
+    let a2 = pcg_step(a1.0)
+    let b1 = pcg_step(seed_state())
+    let b2 = pcg_step(b1.0)
+    if a1.1 != b1.1 || a2.1 != b2.1 { print("FAIL deterministic step\n"); return 8 }
+    if a1.0.state_hi == s0.state_hi && a1.0.state_lo == s0.state_lo {
+        print("FAIL state advance\n")
+        return 9
+    }
+
+    let f = pcg_next_f64(seed_state())
+    if f.1 < 0.0 || f.1 >= 1.0 { print("FAIL f64 range\n"); return 10 }
+
+    let nz = pcg_next_f64_nonzero(seed_state())
+    if nz.1 <= 0.0 || nz.1 >= 1.0 { print("FAIL f64 nonzero\n"); return 11 }
+
+    let bounded = pcg_bounded(seed_state(), 10)
+    if bounded.1 < 0 || bounded.1 >= 10 { print("FAIL bounded\n"); return 12 }
+    if pcg_umod(15, 8) != 7 { print("FAIL power modulo\n"); return 13 }
+    if pcg_umod(17, 5) != 2 { print("FAIL modulo\n"); return 14 }
+
+    print("PCG64_CORE_DEEP_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Summary
- add path::lib edge-case run-proof for joins, parent/root, filename/stem/extension, and path_from_bytes
- add iter::range run-proof for stepped ranges, reset, empty ranges, and 64-item collect cap
- add random::pcg64_core run-proof for bit helpers, u128 carry/mul, deterministic stepping, f64 range, and bounded modulo
- add scripts/verticals_deepen12_gate.sh

## Validation
- bash scripts/verticals_deepen12_gate.sh -> VERTICALS_DEEPEN12_GATE_OK

## Notes
- Test-only stdlib vertical expansion; no compiler/runtime changes.
- No LLM-offload invoked: this does not touch math claims, clinical-pathway code, or external-facing artifacts.