### PR TITLE
fix(gpu): correct tensor-core octonion multiply in Convention X (HW-validated GB10)

### DIFF
--- a/docs/gpu/oct_wmma_validate.cu
+++ b/docs/gpu/oct_wmma_validate.cu
@@ -1,0 +1,79 @@
+// Tensor-core (WMMA) octonion multiply in canonical Convention X, validated on GB10.
+// Octonion product a·b is linear in b: (a·b) = L(a)·b, where the 8x8 left-mul matrix bakes in
+// the Cayley-Dickson signs:  L(a)[k][j] = sigma(k^j, j) * a[k^j].  A plain signed matmul then
+// yields the correct X product (e1·e2=+e3) with NO separate sign correction.
+// We pad L(a) to 16x16 and multiply by B (16x16, columns = up to 16 different b vectors) using
+// one wmma m16n16k16 f16 tile, then compare D against the exact X reference on host.
+#include <cstdio>
+#include <cmath>
+#include <cuda_fp16.h>
+#include <mma.h>
+using namespace nvcuda;
+
+// recursive Cayley-Dickson twist sign (host)
+int cd_sigma(int a,int b,int bits){
+    if(a==0||b==0) return 1;
+    if(bits<=1) return -1;
+    int h=1<<(bits-1), ah=a>=h, bh=b>=h, al=a&(h-1), bl=b&(h-1);
+    if(!ah&&!bh) return cd_sigma(al,bl,bits-1);
+    if(!ah&&bh)  return cd_sigma(bl,al,bits-1);
+    if(ah&&!bh)  return bl==0? cd_sigma(al,0,bits-1) : -cd_sigma(al,bl,bits-1);
+    if(bl==0) return -cd_sigma(0,al,bits-1);
+    return cd_sigma(bl,al,bits-1);
+}
+void octmul_ref(const float*a,const float*b,float*r){ // exact X reference
+    for(int k=0;k<8;k++) r[k]=0;
+    for(int i=0;i<8;i++)for(int j=0;j<8;j++) r[i^j]+=cd_sigma(i,j,3)*a[i]*b[j];
+}
+
+__global__ void oct_mul_wmma(const half* L, const half* B, float* D){
+    wmma::fragment<wmma::matrix_a,16,16,16,half,wmma::row_major> aF;
+    wmma::fragment<wmma::matrix_b,16,16,16,half,wmma::col_major> bF;
+    wmma::fragment<wmma::accumulator,16,16,16,float> cF;
+    wmma::fill_fragment(cF,0.0f);
+    wmma::load_matrix_sync(aF,L,16);
+    wmma::load_matrix_sync(bF,B,16);
+    wmma::mma_sync(cF,aF,bF,cF);
+    wmma::store_matrix_sync(D,cF,16,wmma::mem_row_major);
+}
+
+int main(){
+    // fixed left operand a (nontrivial), 16 different right operands b_col
+    float a[8]={1,2,0,-1,3,0,1,-2};
+    float bcols[16][8];
+    for(int c=0;c<16;c++) for(int j=0;j<8;j++) bcols[c][j]=((c+1)*0.5f + j*0.25f)*((j%2)?-1:1);
+    // build L(a) 16x16 row-major (only 8x8 nonzero)
+    half hL[256]; for(int i=0;i<256;i++) hL[i]=__float2half(0.0f);
+    for(int k=0;k<8;k++)for(int j=0;j<8;j++){ int i=k^j; hL[k*16+j]=__float2half((float)cd_sigma(i,j,3)*a[i]); }
+    // B 16x16 col-major: column c holds b_c in first 8 rows
+    half hB[256]; for(int i=0;i<256;i++) hB[i]=__float2half(0.0f);
+    for(int c=0;c<16;c++)for(int j=0;j<8;j++) hB[c*16+j]=__float2half(bcols[c][j]); // col-major: [col*16+row]
+    half *dL,*dB; float *dD; cudaMalloc(&dL,256*2); cudaMalloc(&dB,256*2); cudaMalloc(&dD,256*4);
+    cudaMemcpy(dL,hL,256*2,cudaMemcpyHostToDevice);
+    cudaMemcpy(dB,hB,256*2,cudaMemcpyHostToDevice);
+    oct_mul_wmma<<<1,32>>>(dL,dB,dD);
+    cudaError_t e=cudaDeviceSynchronize();
+    if(e!=cudaSuccess){ printf("CUDA ERROR: %s\n",cudaGetErrorString(e)); return 2; }
+    float hD[256]; cudaMemcpy(hD,dD,256*4,cudaMemcpyDeviceToHost);
+    // D is row-major 16x16: D[k*16+c] = (L(a)·B)[k][c] = (a·b_c)[k]
+    int fails=0; float maxerr=0;
+    for(int c=0;c<16;c++){
+        float ref[8]; octmul_ref(a,bcols[c],ref);
+        for(int k=0;k<8;k++){ float got=hD[k*16+c]; float err=fabsf(got-ref[k]); if(err>maxerr)maxerr=err;
+            if(err>0.15f){ fails++; if(fails<=4) printf("  mismatch c=%d k=%d got=%.3f ref=%.3f\n",c,k,got,ref[k]); } }
+    }
+    // discriminator: e1·e2 must land in component 3 (X), not 4 (Y)
+    float e1[8]={0,1,0,0,0,0,0,0}, e2[8]={0,0,1,0,0,0,0,0};
+    half hL2[256]; for(int i=0;i<256;i++)hL2[i]=__float2half(0.0f);
+    for(int k=0;k<8;k++)for(int j=0;j<8;j++){int i=k^j; hL2[k*16+j]=__float2half((float)cd_sigma(i,j,3)*e1[i]);}
+    half hB2[256]; for(int i=0;i<256;i++)hB2[i]=__float2half(0.0f);
+    for(int j=0;j<8;j++) hB2[0*16+j]=__float2half(e2[j]);
+    cudaMemcpy(dL,hL2,256*2,cudaMemcpyHostToDevice); cudaMemcpy(dB,hB2,256*2,cudaMemcpyHostToDevice);
+    oct_mul_wmma<<<1,32>>>(dL,dB,dD); cudaDeviceSynchronize();
+    cudaMemcpy(hD,dD,256*4,cudaMemcpyDeviceToHost);
+    float c3=hD[3*16+0], c4=hD[4*16+0];
+    printf("e1*e2 on tensor core: comp3=%.2f comp4=%.2f  (X: comp3=+1,comp4=0)\n",c3,c4);
+    printf("batch: %d/128 comps mismatch, maxerr=%.3f (f16 tile precision)\n",fails,maxerr);
+    if(fails==0 && c3>0.7f && c4<0.3f){ printf("PASS: WMMA octonion multiply is Convention X on GB10\n"); return 0; }
+    printf("FAIL\n"); return 1;
+}

--- a/scripts/ci/native_v2_epistemic_accel_spine_gate.sh
+++ b/scripts/ci/native_v2_epistemic_accel_spine_gate.sh
@@ -136,11 +136,11 @@ append_native_algebra_probes() {
   append_source_probe \
     "native_octonion_hmma_signs" \
     "$HMMA_SIGNS_KERNEL" \
-    "tensor_core_fano_sign_correction_surface" \
-    "fn hmma_sign_mask_for_output_component" \
-    "fn hmma_emit_pack_oct_pair" \
-    "fn hmma_emit_full_sign_correction" \
-    "cvt.rn.f16x2.f32"
+    "tensor_core_left_mul_matrix_surface_convention_x" \
+    "fn hmma_oct_cd_sigma" \
+    "fn hmma_left_mul_sign" \
+    "fn hmma_emit_build_left_mul_matrix" \
+    "fn hmma_emit_unpack_result"
 
   append_source_probe \
     "native_ossm_ptx_emitter" \

--- a/self-hosted/gpu/kernels/hmma_signs.sio
+++ b/self-hosted/gpu/kernels/hmma_signs.sio
@@ -1,116 +1,86 @@
-// self-hosted::gpu::kernels::hmma_signs — Fano plane sign pattern utilities for HMMA
+// self-hosted::gpu::kernels::hmma_signs — tensor-core (WMMA) octonion multiply, Convention X
 //
-// Provides sign-mask encoding and PTX emission for post-HMMA Fano plane
-// sign correction. When octonion vectors are packed into 16-wide HMMA
-// m16n16k16 tiles, the unsigned HMMA result must be corrected by applying
-// the sign pattern (+1/-1) from the octonion multiplication table.
+// Octonion multiplication a·b is LINEAR in b, so it is a matrix–vector product:
 //
-// Two octonion vectors (each 8 components) pack side-by-side into one
-// 16-wide tile. After HMMA multiply-accumulate, the result needs Fano
-// plane sign correction to produce the correct octonion product.
+//     a·b = L(a) · b,   where   L(a)[k][j] = σ(k⊕j, j) · a[k⊕j]     (X: e1·e2 = +e3)
+//
+// σ is the recursive Cayley–Dickson twist sign (canonical Convention X, matching
+// stdlib and the hypercomplex.sio / ossm_forward.sio GPU emitters — see
+// stdlib/algebra/README.md). Because the ±1 signs are BAKED INTO the left-multiply
+// matrix, a plain signed tensor-core matmul (`wmma.mma.sync.m16n16k16.f16.f32`) of the
+// 8×8 L(a) (padded to 16×16) against b yields the correct octonion product DIRECTLY —
+// there is NO post-multiply "sign correction" step.
+//
+// HISTORY: this file previously implemented a broken post-HMMA sign-mask correction
+// (`hmma_sign_mask_for_output_component` + `hmma_emit_full_sign_correction`) that
+// double-negated shared output components (e.g. dst[1] negated 3×, dst[2]/dst[5]/dst[6]
+// negated an even number of times → net no-op) and never implemented a coherent
+// convention. It was standalone/unused. Replaced 2026-07-16 by the L(a) construction
+// below, which is **hardware-validated on the DGX Spark (NVIDIA GB10, sm_121, CUDA 13.0)**:
+// a wmma m16n16k16 kernel computing L(a)·B matches the exact X reference for a full
+// 16-column batch (0/128 component mismatches) and the discriminator e1·e2 lands in
+// component 3 (+1), not 4 — Convention X. Reference: docs/gpu/oct_wmma_validate.cu.
 //
 // Architecture: all helpers precede callers (no forward references).
 // Uses HypercomplexPtxState from hypercomplex.sio for PTX emission.
 
 // ============================================================================
-// Fano plane sign table for octonion multiplication
-// ============================================================================
-//
-// ⚠️ CONVENTION NOTE (2026-07-15): this HMMA tensor-core path still uses **Convention Y**
-// (Fano triples (1,2,4)…, e1·e2=+e4). The main GPU octonion path (hypercomplex.sio `oct_mul_*`
-// and ossm_forward.sio `ossm_fano_*`) was migrated to the canonical **Convention X** (cd_sigma /
-// XOR, e1·e2=+e3) to match the CPU. The HMMA path is STANDALONE — nothing outside this file uses
-// it (only tests/gpu/test_hmma_octonion.sio), so there is no internal inconsistency. Do NOT wire
-// these helpers into the X path. Migrating the sign-mask encoding to X requires deriving the masks
-// from the exact HMMA tile-packing scheme + GPU-hardware validation — dispatched to CODEX (see the
-// #919/#921-style handoff). Oracle for X: tests/run-pass/hypercomplex_convention_crosscheck.sio.
-//
-// The octonion basis e0..e7 multiply according to the Fano plane:
-//   Lines: (1,2,4), (2,3,5), (3,4,6), (4,5,7), (5,6,1), (6,7,2), (7,1,3)
-//   For line (a,b,c): e_a*e_b = +e_c, e_b*e_a = -e_c (cyclic)
-//   Identity: e_0 is real (all products with e_0 are positive)
-//   Self-product: e_i*e_i = -e_0 for i > 0
-//
-// Full sign table for basis(i)*basis(j) -> component(k):
-//   (i,j)->k: sign
-//   (0,0)->0: +  (1,1)->0: -  (2,2)->0: -  (3,3)->0: -  (4,4)->0: -  (5,5)->0: -  (6,6)->0: -  (7,7)->0: -
-//   (0,1)->1: +  (1,0)->1: +  (2,3)->1: +  (3,2)->1: -  (5,6)->1: +  (6,5)->1: -  (3,7)->1: +  (7,3)->1: -
-//   (0,2)->2: +  (2,0)->2: +  (1,3)->2: -  (3,1)->2: +  (4,6)->2: +  (6,4)->2: -  (5,7)->2: -  (7,5)->2: +
-//   (0,3)->3: +  (3,0)->3: +  (1,2)->3: +  (2,1)->3: -  (4,7)->3: -  (7,4)->3: +  (5,6)->3: +  (6,5)->3: -
-//     Wait, let me re-derive these systematically.
-
-// ============================================================================
-// Sign mask computation for Fano plane output component
+// Canonical Cayley–Dickson sign (Convention X) — the value baked into L(a)
 // ============================================================================
 
-// Returns a 16-bit sign mask for Fano plane output component k (0-7).
-// Bit i in the low byte is set if the HMMA tile product at position i
-// should be negated (Fano plane sign is -1).
-// The mask encodes which of the 8 contributing product terms to a given
-// output component have negative sign.
-//
-// For each output component k, we look at all (i,j) pairs where
-// oct_mul_basis(i,j) == k. If oct_mul_sign(i,j) == -1, set bit at
-// position j in the mask (the column index in the GEMM).
-//
-// Returns: 16-bit integer where bit j is 1 if the sign at column j is -1.
-// Only bits 0..7 are meaningful for single-octonion tiles.
-fn hmma_sign_mask_for_output_component(k: i64) -> i64 {
-    var mask: i64 = 0
-
-    if k == 0 {
-        mask = 0
+// Recursive Cayley–Dickson twist sign σ(a,b,bits) ∈ {+1,−1}; pure i64.
+fn hmma_oct_cd_sigma(a: i64, b: i64, bits: i64) -> i64 {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return hmma_oct_cd_sigma(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return hmma_oct_cd_sigma(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return hmma_oct_cd_sigma(a_lo, 0, bits - 1) }
+        return 0 - hmma_oct_cd_sigma(a_lo, b_lo, bits - 1)
     }
-
-    if k == 1 {
-        mask = 0
-    }
-
-    if k == 2 {
-        mask = 2 + 32
-    }
-
-    if k == 3 {
-        mask = 2 + 128
-    }
-
-    if k == 4 {
-        mask = 4 + 16 + 64
-    }
-
-    if k == 5 {
-        mask = 8 + 32 + 128
-    }
-
-    if k == 6 {
-        mask = 2 + 16 + 64
-    }
-
-    if k == 7 {
-        mask = 4 + 16 + 128
-    }
-
-    mask
+    if b_lo == 0 { return 0 - hmma_oct_cd_sigma(0, a_lo, bits - 1) }
+    hmma_oct_cd_sigma(b_lo, a_lo, bits - 1)
 }
 
+// Which a-component feeds L(a)[k][j]:  a[k⊕j].
+fn hmma_left_mul_index(k: i64, j: i64) -> i64 { k ^ j }
+
+// Sign of L(a)[k][j] = σ(k⊕j, j) ∈ {+1,−1}. This is the entire "sign structure" —
+// it is a matrix entry, applied ONCE (baked into L(a)), never as a post-correction.
+fn hmma_left_mul_sign(k: i64, j: i64) -> i64 { hmma_oct_cd_sigma(k ^ j, j, 3) }
+
 // ============================================================================
-// PTX sign correction emitter
+// PTX: build the signed left-multiply matrix L(a) into 64 f32 registers
 // ============================================================================
 
-// Emits PTX to apply sign correction to 8 f32 registers starting at dst_base.
-// Uses the sign_mask to selectively neg.f32 components where the Fano plane
-// sign is -1. Bit i of sign_mask: 1 = negate, 0 = keep positive.
-fn hmma_emit_sign_correction(buf: HypercomplexPtxState, dst_base: i64, sign_mask: i64) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
+// Emits L(a)[k][j] into %f[lmat_base + k*8 + j] from the a-components at
+// %f[a_base + (k⊕j)], folding the compile-time σ(k⊕j,j) sign into a mov or neg.
+// The resulting register block is the matrix-A operand of the wmma matmul (padded
+// to 16×16 by the caller); after `wmma.mma.sync ... L, b`, no sign fixup is needed.
+fn hmma_emit_build_left_mul_matrix(buf: HypercomplexPtxState, a_base: i64, lmat_base: i64) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
     var out = buf
+    out = hc_push_str(out, "    // build L(a)[k][j] = sigma(k^j,j) * a[k^j]  (Convention X)\n")
     var k: i64 = 0
     while k < 8 {
-        let bit_val = (sign_mask >> k) & 1
-        if bit_val == 1 {
-            out = hc_push_str(out, "    neg.f32 %f")
-            out = hc_push_str(out, i64_to_string(dst_base + k))
+        var j: i64 = 0
+        while j < 8 {
+            let src = a_base + (k ^ j)
+            let dst = lmat_base + k * 8 + j
+            if hmma_left_mul_sign(k, j) < 0 {
+                out = hc_push_str(out, "    neg.f32 %f")
+            } else {
+                out = hc_push_str(out, "    mov.f32 %f")
+            }
+            out = hc_push_str(out, i64_to_string(dst))
             out = hc_push_str(out, ", %f")
-            out = hc_push_str(out, i64_to_string(dst_base + k))
+            out = hc_push_str(out, i64_to_string(src))
             out = hc_push_str(out, ";\n")
+            j = j + 1
         }
         k = k + 1
     }
@@ -121,47 +91,8 @@ fn hmma_emit_sign_correction(buf: HypercomplexPtxState, dst_base: i64, sign_mask
 // Fragment packing/unpacking PTX emitters
 // ============================================================================
 
-// Emits PTX to pack two 8-component octonion vectors into the packed
-// fragment ABI used by the split PTX lowering path:
-//   - oct_a pairs [0:1]..[6:7] -> fragment regs [0..3]
-//   - oct_b pairs [0:1]..[6:7] -> fragment regs [4..7]
-// Each fragment register is a packed .b32 lane formed via cvt.rn.f16x2.f32.
-fn hmma_emit_pack_oct_pair(buf: HypercomplexPtxState, oct_a_base: i64, oct_b_base: i64, frag_reg: i64) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
-    var out = buf
-    out = hc_push_str(out, "    // pack oct_a[")
-    out = hc_push_str(out, i64_to_string(oct_a_base))
-    out = hc_push_str(out, "..] + oct_b[")
-    out = hc_push_str(out, i64_to_string(oct_b_base))
-    out = hc_push_str(out, "..] -> frag[")
-    out = hc_push_str(out, i64_to_string(frag_reg))
-    out = hc_push_str(out, "..] as 8 packed .b32 regs via f16x2 pairs\n")
-
-    var pair_idx: i64 = 0
-    while pair_idx < 4 {
-        let lane_lo = pair_idx * 2
-        let lane_hi = lane_lo + 1
-        out = hc_push_str(out, "    cvt.rn.f16x2.f32 %r")
-        out = hc_push_str(out, i64_to_string(frag_reg + pair_idx))
-        out = hc_push_str(out, ", %f")
-        out = hc_push_str(out, i64_to_string(oct_a_base + lane_lo))
-        out = hc_push_str(out, ", %f")
-        out = hc_push_str(out, i64_to_string(oct_a_base + lane_hi))
-        out = hc_push_str(out, ";\n")
-        out = hc_push_str(out, "    cvt.rn.f16x2.f32 %r")
-        out = hc_push_str(out, i64_to_string(frag_reg + 4 + pair_idx))
-        out = hc_push_str(out, ", %f")
-        out = hc_push_str(out, i64_to_string(oct_b_base + lane_lo))
-        out = hc_push_str(out, ", %f")
-        out = hc_push_str(out, i64_to_string(oct_b_base + lane_hi))
-        out = hc_push_str(out, ";\n")
-        pair_idx = pair_idx + 1
-    }
-    out
-}
-
-// Emits PTX to unpack 16-wide HMMA f32 accumulator result into an
-// 8-component octonion output. Takes the first 8 f32 accumulator
-// registers and moves them to the destination octonion registers.
+// Emits PTX to unpack the first 8 f32 accumulator registers of the wmma result
+// into an 8-component octonion output (the product a·b in Convention X).
 fn hmma_emit_unpack_result(buf: HypercomplexPtxState, frag_reg: i64, oct_dst_base: i64) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
     var out = buf
     out = hc_push_str(out, "    // unpack HMMA result frag[")
@@ -169,7 +100,6 @@ fn hmma_emit_unpack_result(buf: HypercomplexPtxState, frag_reg: i64, oct_dst_bas
     out = hc_push_str(out, "..] -> dst[")
     out = hc_push_str(out, i64_to_string(oct_dst_base))
     out = hc_push_str(out, "..]\n")
-
     var i: i64 = 0
     while i < 8 {
         out = hc_push_str(out, "    mov.f32 %f")
@@ -178,26 +108,6 @@ fn hmma_emit_unpack_result(buf: HypercomplexPtxState, frag_reg: i64, oct_dst_bas
         out = hc_push_str(out, i64_to_string(frag_reg + i))
         out = hc_push_str(out, ";\n")
         i = i + 1
-    }
-    out
-}
-
-// ============================================================================
-// Convenience: full sign correction for all 8 output components
-// ============================================================================
-
-// Applies Fano plane sign correction for all 8 output components of an
-// octonion HMMA multiply. Emits neg.f32 instructions for each component
-// whose sign mask indicates negative sign.
-fn hmma_emit_full_sign_correction(buf: HypercomplexPtxState, dst_base: i64) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
-    var out = buf
-    var k: i64 = 0
-    while k < 8 {
-        let mask = hmma_sign_mask_for_output_component(k)
-        if mask != 0 {
-            out = hmma_emit_sign_correction(out, dst_base, mask)
-        }
-        k = k + 1
     }
     out
 }

--- a/tests/gpu/test_hmma_octonion.sio
+++ b/tests/gpu/test_hmma_octonion.sio
@@ -1,28 +1,56 @@
 //@ run-pass
-//@ expect-stdout: PASS: HMMA octonion sign correction
+//@ expect-stdout: PASS: HMMA octonion left-mul matrix is Convention X
 
-fn hmma_sign_mask_for_output_component(k: i64) -> i64 with Mut {
-    var mask: i64 = 0
-    if k == 0 { mask = 0 }
-    if k == 1 { mask = 0 }
-    if k == 2 { mask = 2 + 32 }
-    if k == 3 { mask = 2 + 128 }
-    if k == 4 { mask = 4 + 16 + 64 }
-    if k == 5 { mask = 8 + 32 + 128 }
-    if k == 6 { mask = 2 + 16 + 64 }
-    if k == 7 { mask = 4 + 16 + 128 }
-    mask
+// Verifies the tensor-core octonion multiply's left-multiply-matrix construction
+// (self-hosted/gpu/kernels/hmma_signs.sio) implements Convention X:
+//   a·b = L(a)·b,  L(a)[k][j] = σ(k⊕j, j) · a[k⊕j]
+// so e_ia · e_ib lands in component (ia⊕ib) with sign σ(ia, ib) = left_mul_sign(ia⊕ib, ib).
+// (Replaces the former trivial mask-property assertions on a broken sign-correction.)
+// The tensor-core execution of exactly this construction is hardware-validated on the
+// DGX Spark (GB10, sm_121): see docs/gpu/oct_wmma_validate.cu.
+
+fn cd_sigma(a: i64, b: i64, bits: i64) -> i64 {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma(0, a_lo, bits - 1) }
+    cd_sigma(b_lo, a_lo, bits - 1)
 }
+fn left_mul_sign(k: i64, j: i64) -> i64 { cd_sigma(k ^ j, j, 3) }
+fn prod_component(ia: i64, ib: i64) -> i64 { ia ^ ib }
+fn prod_sign(ia: i64, ib: i64) -> i64 { left_mul_sign(ia ^ ib, ib) }
 
 fn main() -> i32 with IO, Panic, Mut {
-    let mask0 = hmma_sign_mask_for_output_component(0)
-    assert(mask0 == 0)
-    let mask1 = hmma_sign_mask_for_output_component(1)
-    assert(mask1 == 0)
-    let mask2 = hmma_sign_mask_for_output_component(2)
-    assert(mask2 != 0)
-    let mask4 = hmma_sign_mask_for_output_component(4)
-    assert(mask4 != 0)
-    println("PASS: HMMA octonion sign correction")
+    var fails: i64 = 0
+    // e1·e2 = +e3  (Convention X; Convention Y would give e4)
+    if prod_component(1, 2) != 3 { fails = fails + 1 }
+    if prod_sign(1, 2) != 1 { fails = fails + 1 }
+    // e2·e1 = −e3
+    if prod_sign(2, 1) != 0 - 1 { fails = fails + 1 }
+    // e2·e5 = +e7
+    if prod_component(2, 5) != 7 { fails = fails + 1 }
+    if prod_sign(2, 5) != 1 { fails = fails + 1 }
+    // e_i·e_i = −e0  (i = 1..7): component 0, sign −1
+    var i: i64 = 1
+    while i < 8 {
+        if prod_component(i, i) != 0 { fails = fails + 1 }
+        if left_mul_sign(0, i) != 0 - 1 { fails = fails + 1 }
+        i = i + 1
+    }
+    if fails == 0 {
+        println("PASS: HMMA octonion left-mul matrix is Convention X")
+    } else {
+        println("FAIL: HMMA octonion left-mul matrix")
+    }
     0
 }


### PR DESCRIPTION
## What

Closes the **last** hypercomplex-convention residual — the tensor-core (HMMA/WMMA) octonion path.

### The problem
`hmma_signs.sio` implemented a **broken** post-HMMA sign-mask correction
(`hmma_sign_mask_for_output_component` + `hmma_emit_full_sign_correction`) that **double-negated
shared output components** (dst[1] negated 3×; dst[2]/dst[5]/dst[6] negated an even number of times
→ net no-op) and never implemented a coherent convention (neither X nor Y). The original author even
left a `// Wait, let me re-derive these systematically` note. It was standalone/unused (only a test
referenced it, and that test asserted only trivial mask properties).

### The fix — correct by construction
Octonion multiply is **linear in b**, so `a·b = L(a)·b` with the signs **baked into** the
left-multiply matrix:

```
L(a)[k][j] = σ(k⊕j, j) · a[k⊕j]     (Convention X: e1·e2 = +e3)
```

A plain **signed** `wmma.mma.sync.m16n16k16.f16.f32` of `L(a)` against `b` then yields the correct
octonion product **directly — no sign-correction step**.

### Hardware-validated on the DGX Spark (NVIDIA GB10, sm_121, CUDA 13.0)
A `wmma m16n16k16` kernel computing `L(a)·B`:
- matches the exact X reference for a full 16-column batch — **0/128 component mismatches**;
- discriminator **e1·e2 → component 3 (+1), not 4** → **Convention X** on real Blackwell tensor cores.

Reference kept as `docs/gpu/oct_wmma_validate.cu` (`PASS: WMMA octonion multiply is Convention X on GB10`).

### Changes
- `self-hosted/gpu/kernels/hmma_signs.sio`: `hmma_oct_cd_sigma` + `hmma_left_mul_sign/index` +
  `hmma_emit_build_left_mul_matrix` (emits `L(a)` with compile-time σ folded into mov/neg) +
  `hmma_emit_unpack_result`; removed the broken mask/sign-correction functions.
- `tests/gpu/test_hmma_octonion.sio`: asserts the `L(a)` sign structure is X (e1·e2=+e3, e2·e5=+e7,
  e_i²=−1) instead of trivial mask properties.
- `scripts/ci/native_v2_epistemic_accel_spine_gate.sh`: probe updated to the new correct surface.
- `docs/gpu/oct_wmma_validate.cu`: the HW-validated reference.

With #940/#942/#994, the **entire GPU octonion path is now Convention X**. (A full Sounio WMMA
kernel-assembly emitter that wires `build_left_mul_matrix` + `wmma.mma` + `unpack` into one runnable
kernel is a natural follow-up; the correct primitives + HW proof land here.)

## Verification
- `tests/gpu/test_hmma_octonion.sio` → `PASS: HMMA octonion left-mul matrix is Convention X`.
- `hmma_signs.sio` typecheck error count ≤ baseline (rewrite is simpler; 23 vs 51 standalone).
- GB10 CUDA reference: `PASS` (see above).
