### PR TITLE
test(stdlib): klibanoff ambiguity CE, vancomycin PK, correlation verticals

### DIFF
--- a/scripts/verticals_klibanoff_vanco_correlation_gate.sh
+++ b/scripts/verticals_klibanoff_vanco_correlation_gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Verticals: epistemic::klibanoff (smooth-ambiguity CE sandwich), clinical::vancomycin_pbpk (PK),
+# epistemic::correlation (GUM covariance tracking). Multi-module drivers -> lean_single engine.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/epistemic/klibanoff.sio        tests/stdlib/epistemic/test_klibanoff_stdlib.sio       KLIBANOFF_STDLIB_OK
+run stdlib/clinical/vancomycin_pbpk.sio    tests/stdlib/clinical/test_vancomycin_pbpk_stdlib.sio VANCOMYCIN_PBPK_STDLIB_OK
+run stdlib/epistemic/correlation.sio       tests/stdlib/epistemic/test_correlation_stdlib.sio    CORRELATION_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_KLIBANOFF_VANCO_CORRELATION_GATE_OK"
+exit $fail

--- a/tests/stdlib/clinical/test_vancomycin_pbpk_stdlib.sio
+++ b/tests/stdlib/clinical/test_vancomycin_pbpk_stdlib.sio
@@ -1,0 +1,21 @@
+// Run-proof for stdlib clinical::vancomycin_pbpk — population PK parameters against the module's
+// documented values: Vc = 0.5 L/kg, CL = 0.05 L/h per mL/min CrCl (Cockcroft-Gault scaled), with a
+// non-zero Knightian pre-TDM ambiguity band. Reads the p-box via knightian accessors. lean_single.
+use epistemic::knightian::*
+use clinical::vancomycin_pbpk::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let p = vp_default(70.0, 90.0)
+    let vc = vp_vc_to_pbox(&p, 2)
+    if ae(pb_midpoint(&vc), 35.0) >= 1.0e-6 { print("FAIL vc\n"); return 1 }   // 0.5*70
+    let cl = vp_cl_to_pbox(&p, 2)
+    if ae(pb_midpoint(&cl), 4.5) >= 1.0e-6 { print("FAIL cl\n"); return 2 }     // 0.05*90
+    // a pre-TDM p-box carries a non-zero ambiguity band (gap)
+    if pb_gap(&vc) <= 0.0 { print("FAIL gap\n"); return 3 }
+    // clearance scales with renal function: higher CrCl -> higher CL
+    let p2 = vp_default(70.0, 120.0)
+    let cl2 = vp_cl_to_pbox(&p2, 2)
+    if pb_midpoint(&cl2) <= pb_midpoint(&cl) { print("FAIL crcl_scaling\n"); return 4 }
+    print("VANCOMYCIN_PBPK_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/epistemic/test_correlation_stdlib.sio
+++ b/tests/stdlib/epistemic/test_correlation_stdlib.sio
@@ -1,0 +1,23 @@
+// Run-proof for stdlib epistemic::correlation — GUM covariance tracking across shared sources:
+// two values drawn from the SAME uncertainty source are correlated (positive covariance = product
+// of their standard uncertainties), independent values have zero covariance, and self-covariance
+// equals the variance. lean_single engine.
+use epistemic::correlation::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // same source (var_id 1), standard uncertainty 0.5 each -> cov = 0.5*0.5 = 0.25
+    let a = correlated_from_source(5.0, 1, 0.5, 0.9)
+    let b = correlated_from_source(3.0, 1, 0.5, 0.9)
+    if ae(covariance(a, b), 0.25) >= 1.0e-9 { print("FAIL same_source\n"); return 1 }
+    // independent values -> zero covariance
+    let x = correlated_independent(5.0, 0.5, 0.9)
+    let y = correlated_independent(3.0, 0.5, 0.9)
+    if ae(covariance(x, y), 0.0) >= 1.0e-9 { print("FAIL independent\n"); return 2 }
+    // self-covariance = variance = 0.5^2
+    if ae(covariance(a, a), 0.25) >= 1.0e-9 { print("FAIL self\n"); return 3 }
+    // different sources are uncorrelated
+    let d = correlated_from_source(3.0, 2, 0.5, 0.9)
+    if ae(covariance(a, d), 0.0) >= 1.0e-9 { print("FAIL cross_source\n"); return 4 }
+    print("CORRELATION_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/epistemic/test_klibanoff_stdlib.sio
+++ b/tests/stdlib/epistemic/test_klibanoff_stdlib.sio
@@ -1,0 +1,25 @@
+// Run-proof for stdlib epistemic::klibanoff — the smooth-ambiguity (KMM) certainty-equivalent
+// sandwich: the precise SEU value dominates the smooth-ambiguity value, which dominates the
+// worst-case (Walley/maxmin) value. Under no ambiguity the three collapse. lean_single engine.
+use epistemic::walley::*
+use epistemic::klibanoff::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let c = cs_neighborhood(5.0, 1.0, 0.2, 0.0, 10.0, 900)
+    let lambda = 1.0
+    let alpha = 2.0
+    let pce = kl_precise_ce(&c, lambda)
+    let sce = kl_smooth_ce(&c, alpha, lambda)
+    let wce = kl_walley_ce(&c, lambda)
+    // ambiguity-aversion sandwich: precise >= smooth >= walley
+    if pce < sce { print("FAIL sandwich_ps\n"); return 1 }
+    if sce < wce { print("FAIL sandwich_sw\n"); return 2 }
+    if !kl_sandwich_holds(&c, alpha, lambda) { print("FAIL sandwich_fn\n"); return 3 }
+    // ambiguity present -> strict gap between SEU and maxmin
+    if pce <= wce { print("FAIL strict\n"); return 4 }
+    // no ambiguity (precise credal set) -> the sandwich collapses (SEU == maxmin)
+    let pc = cs_precise(5.0, 1.0, 0.0, 10.0, 900)
+    if ae(kl_precise_ce(&pc, lambda), kl_walley_ce(&pc, lambda)) >= 1.0e-9 { print("FAIL collapse\n"); return 5 }
+    print("KLIBANOFF_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Smooth-ambiguity decision theory, vancomycin PK, and GUM correlation

Three dissertation-central modules, each proven by compile-and-run against first-principles / published values.

| Module | Coverage |
|---|---|
| `epistemic::klibanoff` | the **smooth-ambiguity (KMM)** certainty-equivalent sandwich `precise_CE ≥ smooth_CE ≥ walley_CE` (SEU ≥ smooth-ambiguity ≥ maxmin); strict under ambiguity; **collapses** to equality for a precise credal set |
| `clinical::vancomycin_pbpk` | population PK — `Vc=0.5 L/kg`→35 L, `CL=0.05 L/h·mL/min`→4.5 L/h at CrCl 90 (↑ with renal function); non-zero pre-TDM Knightian band |
| `epistemic::correlation` | GUM covariance across shared sources — same-source `cov=u_a·u_b=0.25`, independent `cov=0`, self-covariance = variance, different sources uncorrelated |

### Highlights
- The **klibanoff sandwich** is the KMM ambiguity-aversion ordering (SEU dominates smooth-ambiguity dominates maxmin), collapsing when the credal set is a singleton — a clean executable proof of the decision-theoretic hierarchy.
- **vancomycin** is the thesis's central drug; PK params match the documented pop-PK model with correct renal-clearance scaling.

### Verification
- `scripts/verticals_klibanoff_vanco_correlation_gate.sh` → `VERTICALS_KLIBANOFF_VANCO_CORRELATION_GATE_OK` (all three pass standalone `souc check`).
- Math-review (xai/grok): all PASS (ambiguity ordering, PK arithmetic + CrCl direction, GUM covariance bookkeeping).

### Notes
- Multi-module drivers run under `SOUNIO_SOUC_ENGINE=lean_single`. No `self-hosted/`/`bootstrap/` edits. Uniquely-named branch + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)