### PR TITLE
test(chemistry): lock excess-base pH behavior

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3023,3 +3023,11 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - mann_kendall = **PASS**: S=Σsign, Var=n(n−1)(2n+5)/18, continuity-corrected z, τ=2S/(n(n−1)); increasing {1..5}→S=10, z=2.2045, τ=1. Note: test constant z=2.204793 was a hand slip — correct 9/√16.6667=2.204541 (Python-verified); caught by the failing assertion, fixed.
 - Theme: ordered-alternative & monotonic-trend tests — extends the non-parametric family beyond the proportion trend (cochran_armitage) to continuous/ordinal ordered groups, repeated measures, and time series. All derivable, #852-safe. Suite runner: 130 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-iOjAr1/`, `/tmp/llm-offload-5fFzUi/`, `/tmp/llm-offload-N6zSm6/`.
+
+## 2026-07-16 — math-review: chemistry::acids pH range reduction (PR #1014)
+- Target: `stdlib/chemistry/acids.sio`; regression: `tests/stdlib/chemistry/test_acids_stdlib.sio`.
+- xAI/Grok 4.3: **PASS_SINGLE_PROVIDER_DEGRADED** for the changed `ln_approx` range reduction, `ph`, and Henderson-Hasselbalch formulas. It correctly accepted the reduction of `x` to `[1/sqrt(10), sqrt(10)]` before the artanh series and the first-order pH uncertainty formula.
+- Documented disagreement: Grok called the excess-base branch `14 + log10(oh)` wrong. It is correct because `pOH = -log10([OH-])`, hence `pH = 14 - pOH = 14 + log10([OH-])`. The added regression uses `[OH-]=0.01`, where the implemented branch returns `12` and the suggested alternative would incorrectly return `16`.
+- Independent-provider fallback: Z.AI GLM-5.2 timed out after more than 120 seconds (`/tmp/llm-offload-mxTIVr/`); Qwen failed with OpenRouter HTTP 402 (`/tmp/llm-offload-83btKx/`); DeepSeek returned `Insufficient Balance` (`/tmp/llm-offload-xlyMGm/`); Groq returned `Invalid API Key` (`/tmp/llm-offload-sFR2Ue/`). Re-review with Z.AI remains pending when that provider is responsive.
+- Scope boundary: Grok also marked the pre-existing `calibrate` slope uncertainty and `mm_rate` rough uncertainty as overreach. Neither is changed by this PR or used to support its pH regression claim; they remain separate investigation items rather than silently being folded into this numerical-fix patch.
+- Gate: `bash scripts/verticals_rng_iter_acids_gate.sh` -> `VERTICALS_RNG_ITER_ACIDS_GATE_OK`; `git diff --check` -> PASS.

--- a/stdlib/chemistry/acids.sio
+++ b/stdlib/chemistry/acids.sio
@@ -20,7 +20,7 @@ fn sqrt_approx(x: f64) -> f64 with Mut, Div, Panic {
 // wrong for [H+] far from 1 (e.g. pH(1e-7) returned ~2.15 instead of 7).
 fn ln_approx(x: f64) -> f64 with Mut, Div, Panic {
     if x <= 0.0 { return 0.0; }
-    let ln10: f64 = 2.302585092994046   // exact ln(10) (was itself approximated before)
+    let ln10: f64 = 2.302585092994046   // fixed f64 approximation of ln(10)
     let sqrt10: f64 = 3.1622776601683795
     // range-reduce x into [1/sqrt(10), sqrt(10)] tracking the power of ten
     var y = x
@@ -38,7 +38,7 @@ fn ln_approx(x: f64) -> f64 with Mut, Div, Panic {
 }
 
 fn log10_approx(x: f64) -> f64 with Mut, Div, Panic {
-    ln_approx(x) / 2.302585092994046   // divide by exact ln(10)
+    ln_approx(x) / 2.302585092994046   // divide by the same fixed f64 ln(10) constant
 }
 
 // pH with GUM
@@ -63,7 +63,7 @@ pub fn titration_ph(vol_acid: f64, conc_acid: f64, vol_base: f64, conc_base: f64
     let excess = moles_base - moles_acid;
     if excess > 0.0 {
         let oh = excess / (vol_acid + vol_base);
-        return 14.0 + log10_approx(oh); // wait sign, actually 14 - pOH
+        return 14.0 + log10_approx(oh); // pH = 14 - pOH = 14 + log10([OH-])
     } else if excess < 0.0 {
         let h = (0.0 - excess) / (vol_acid + vol_base);
         return 0.0 - log10_approx(h);

--- a/tests/stdlib/chemistry/test_acids_stdlib.sio
+++ b/tests/stdlib/chemistry/test_acids_stdlib.sio
@@ -14,6 +14,9 @@ fn main() -> i32 with IO, Mut, Div, Panic {
     if ae(p0, 0.0) >= 1.0e-6 { print("FAIL ph0\n"); return 4 }
     let (p14, _u14) = ph(0.00000000000001, 0.0)                 // 1e-14 -> pH 14
     if ae(p14, 14.0) >= 1.0e-5 { print("FAIL ph14\n"); return 5 }
+    // Excess base: [OH-]=0.01 -> pOH=2, hence pH=12.
+    let pbase = titration_ph(0.0, 0.0, 0.1, 0.01)
+    if ae(pbase, 12.0) >= 1.0e-6 { print("FAIL titration_base\n"); return 11 }
     // Henderson-Hasselbalch: pH = pKa + log10([A-]/[HA])
     let (hh1, _h1) = henderson_hasselbalch(4.76, 0.0, 1.0, 0.0)
     if ae(hh1, 4.76) >= 1.0e-6 { print("FAIL hh1\n"); return 6 }


### PR DESCRIPTION
## Summary

- Makes the excess-base identity explicit: `pH = 14 - pOH = 14 + log10([OH-])`.
- Adds a regression for `[OH-] = 0.01 -> pH = 12`, protecting the base-side titration branch.
- Records the pH range-reduction math review and its documented fallback state.

## Why

PR #1014 was merged while its review audit was being recovered. This follow-up keeps the numerical boundary precise without changing the pH range-reduction algorithm.

## Verification

- `bash scripts/verticals_rng_iter_acids_gate.sh`
- `git diff --check`

## Review Note

Grok accepted the range reduction and pH formulas but made an incorrect sign objection to the base branch; the new regression distinguishes the two formulas. Z.AI timed out and the alternate-provider fallbacks were unavailable; the complete evidence and re-review requirement are recorded in `.claude/llm_offload_log.md`.
