### PR TITLE
feat(gpu): complete Sounio WMMA octonion-multiply kernel emitter (HW-validated GB10)

### DIFF
--- a/docs/gpu/run_sounio_ptx.cu
+++ b/docs/gpu/run_sounio_ptx.cu
@@ -1,0 +1,67 @@
+// Host harness that loads the SOUNIO-EMITTED wmma PTX and launches it on the GB10 via the
+// CUDA Driver API. Builds L(a) (Convention X) + B on host, runs sounio_oct_mul_wmma, checks
+// the output equals the exact X octonion product. Validates the Sounio-emitted PTX end-to-end.
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+#include <cuda_fp16.h>
+
+int cd_sigma(int a,int b,int bits){
+    if(a==0||b==0) return 1;
+    if(bits<=1) return -1;
+    int h=1<<(bits-1), ah=a>=h, bh=b>=h, al=a&(h-1), bl=b&(h-1);
+    if(!ah&&!bh) return cd_sigma(al,bl,bits-1);
+    if(!ah&&bh)  return cd_sigma(bl,al,bits-1);
+    if(ah&&!bh)  return bl==0? cd_sigma(al,0,bits-1) : -cd_sigma(al,bl,bits-1);
+    if(bl==0) return -cd_sigma(0,al,bits-1);
+    return cd_sigma(bl,al,bits-1);
+}
+void octmul_ref(const float*a,const float*b,float*r){
+    for(int k=0;k<8;k++) r[k]=0;
+    for(int i=0;i<8;i++)for(int j=0;j<8;j++) r[i^j]+=cd_sigma(i,j,3)*a[i]*b[j];
+}
+#define CK(x) do{ CUresult e=(x); if(e!=CUDA_SUCCESS){ const char*s; cuGetErrorString(e,&s); printf("CUDA ERR %s at %d: %s\n",#x,__LINE__,s); return 2; } }while(0)
+
+int main(int argc,char**argv){
+    const char* ptxpath = argc>1?argv[1]:"/tmp/sounio_oct_wmma.ptx";
+    FILE*f=fopen(ptxpath,"rb"); if(!f){printf("no ptx\n");return 2;}
+    fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
+    char*ptx=(char*)malloc(n+1); fread(ptx,1,n,f); ptx[n]=0; fclose(f);
+
+    CK(cuInit(0)); CUdevice dev; CK(cuDeviceGet(&dev,0)); CUcontext ctx; CK(cuDevicePrimaryCtxRetain(&ctx,dev)); CK(cuCtxSetCurrent(ctx));
+    CUmodule mod; CK(cuModuleLoadData(&mod,ptx));
+    CUfunction k; CK(cuModuleGetFunction(&k,mod,"sounio_oct_mul_wmma"));
+
+    float a[8]={1,2,0,-1,3,0,1,-2};
+    float bcols[16][8];
+    for(int c=0;c<16;c++)for(int j=0;j<8;j++) bcols[c][j]=((c+1)*0.5f + j*0.25f)*((j%2)?-1:1);
+    // L(a) 16x16 row-major f16
+    half hL[256]; for(int i=0;i<256;i++)hL[i]=__float2half(0.0f);
+    for(int kk=0;kk<8;kk++)for(int j=0;j<8;j++){int i=kk^j; hL[kk*16+j]=__float2half((float)cd_sigma(i,j,3)*a[i]);}
+    // B 16x16 col-major f16: column c = b_c
+    half hB[256]; for(int i=0;i<256;i++)hB[i]=__float2half(0.0f);
+    for(int c=0;c<16;c++)for(int j=0;j<8;j++) hB[c*16+j]=__float2half(bcols[c][j]);
+    float hD[256];
+
+    CUdeviceptr dL,dB,dD; CK(cuMemAlloc(&dL,256*2)); CK(cuMemAlloc(&dB,256*2)); CK(cuMemAlloc(&dD,256*4));
+    CK(cuMemcpyHtoD(dL,hL,256*2)); CK(cuMemcpyHtoD(dB,hB,256*2));
+    void*args[]={&dL,&dB,&dD};
+    CK(cuLaunchKernel(k, 1,1,1, 32,1,1, 0, 0, args, 0));   // one warp
+    CK(cuCtxSynchronize());
+    CK(cuMemcpyDtoH(hD,dD,256*4));
+
+    int fails=0; float maxerr=0;
+    for(int c=0;c<16;c++){ float ref[8]; octmul_ref(a,bcols[c],ref);
+        for(int kk=0;kk<8;kk++){ float got=hD[kk*16+c],err=fabsf(got-ref[kk]); if(err>maxerr)maxerr=err;
+            if(err>0.15f){fails++; if(fails<=4)printf("  mismatch c=%d k=%d got=%.3f ref=%.3f\n",c,kk,got,ref[kk]);} } }
+    // e1·e2 discriminator
+    half hL2[256]; for(int i=0;i<256;i++)hL2[i]=__float2half(0.0f);
+    { float e1[8]={0,1,0,0,0,0,0,0}; for(int kk=0;kk<8;kk++)for(int j=0;j<8;j++){int i=kk^j; hL2[kk*16+j]=__float2half((float)cd_sigma(i,j,3)*e1[i]);} }
+    half hB2[256]; for(int i=0;i<256;i++)hB2[i]=__float2half(0.0f); hB2[0*16+2]=__float2half(1.0f); // b=e2 in col0
+    CK(cuMemcpyHtoD(dL,hL2,256*2)); CK(cuMemcpyHtoD(dB,hB2,256*2));
+    CK(cuLaunchKernel(k,1,1,1,32,1,1,0,0,args,0)); CK(cuCtxSynchronize()); CK(cuMemcpyDtoH(hD,dD,256*4));
+    float c3=hD[3*16+0], c4=hD[4*16+0];
+    printf("SOUNIO-emitted PTX on GB10: e1*e2 comp3=%.2f comp4=%.2f | batch %d/128 mismatch maxerr=%.3f\n",c3,c4,fails,maxerr);
+    if(fails==0 && c3>0.7f && c4<0.3f){ printf("PASS: Sounio-emitted WMMA octonion multiply is Convention X on GB10\n"); return 0; }
+    printf("FAIL\n"); return 1;
+}

--- a/docs/gpu/sounio_oct_mul_wmma.ptx
+++ b/docs/gpu/sounio_oct_mul_wmma.ptx
@@ -1,0 +1,28 @@
+.version 9.0
+.target sm_121
+.address_size 64
+
+.visible .entry sounio_oct_mul_wmma(
+    .param .u64 .ptr .align 1 p_lmat,
+    .param .u64 .ptr .align 1 p_b,
+    .param .u64 .ptr .align 1 p_out
+)
+{
+    .reg .b32 %r<18>;
+    .reg .b32 %f<10>;
+    .reg .b64 %rd<7>;
+
+    ld.param.u64 %rd1, [p_lmat];
+    ld.param.u64 %rd2, [p_b];
+    ld.param.u64 %rd3, [p_out];
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd5, %rd2;
+    cvta.to.global.u64 %rd6, %rd3;
+    mov.b32 %r1, 16;
+    wmma.load.a.sync.aligned.row.m16n16k16.global.f16 {%r2, %r3, %r4, %r5, %r6, %r7, %r8, %r9}, [%rd4], %r1;
+    wmma.load.b.sync.aligned.col.m16n16k16.global.f16 {%r10, %r11, %r12, %r13, %r14, %r15, %r16, %r17}, [%rd5], %r1;
+    mov.f32 %f1, 0f00000000;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%f2, %f3, %f4, %f5, %f6, %f7, %f8, %f9}, {%r2, %r3, %r4, %r5, %r6, %r7, %r8, %r9}, {%r10, %r11, %r12, %r13, %r14, %r15, %r16, %r17}, {%f1, %f1, %f1, %f1, %f1, %f1, %f1, %f1};
+    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [%rd6], {%f2, %f3, %f4, %f5, %f6, %f7, %f8, %f9}, %r1;
+    ret;
+}

--- a/scripts/ci/native_v2_epistemic_accel_spine_gate.sh
+++ b/scripts/ci/native_v2_epistemic_accel_spine_gate.sh
@@ -140,7 +140,9 @@ append_native_algebra_probes() {
     "fn hmma_oct_cd_sigma" \
     "fn hmma_left_mul_sign" \
     "fn hmma_emit_build_left_mul_matrix" \
-    "fn hmma_emit_unpack_result"
+    "fn hmma_emit_unpack_result" \
+    "fn hmma_emit_oct_mul_wmma_kernel" \
+    ".visible .entry sounio_oct_mul_wmma"
 
   append_source_probe \
     "native_ossm_ptx_emitter" \

--- a/self-hosted/gpu/emit_oct_mul_wmma_ptx.sio
+++ b/self-hosted/gpu/emit_oct_mul_wmma_ptx.sio
@@ -1,0 +1,87 @@
+// Sounio emitter for a complete, runnable WMMA octonion-multiply kernel PTX (Convention X).
+// The kernel loads the left-multiply matrix L(a) (16x16 f16, built by the host as
+// L(a)[k][j]=σ(k^j,j)·a[k^j]) and B (16x16 f16), does one wmma m16n16k16 tile, and stores
+// the f32 product D = L(a)·B = the octonion products. Matches the nvcc ground-truth PTX.
+// Emits programmatically (fragment register lists built by loop) — this is the emitter body
+// that ports into self-hosted/gpu/kernels/hmma_signs.sio.
+
+fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
+    if n == 0 { return "0" }
+    var digits = ""
+    var x = n
+    while x > 0 {
+        let d = x - (x / 10) * 10
+        var c = "0"
+        if d == 1 { c = "1" }
+        if d == 2 { c = "2" }
+        if d == 3 { c = "3" }
+        if d == 4 { c = "4" }
+        if d == 5 { c = "5" }
+        if d == 6 { c = "6" }
+        if d == 7 { c = "7" }
+        if d == 8 { c = "8" }
+        if d == 9 { c = "9" }
+        digits = str_concat(c, digits)
+        x = x / 10
+    }
+    digits
+}
+
+fn reg_list(prefix: string, start: i64, count: i64) -> string with Mut, Panic, Div, Alloc {
+    var s = "{"
+    var i: i64 = 0
+    while i < count {
+        if i > 0 { s = str_concat(s, ", ") }
+        s = str_concat(s, prefix)
+        s = str_concat(s, i64_to_string(start + i))
+        i = i + 1
+    }
+    str_concat(s, "}")
+}
+fn repeat_reg(reg: string, count: i64) -> string with Mut, Panic, Div, Alloc {
+    var s = "{"
+    var i: i64 = 0
+    while i < count {
+        if i > 0 { s = str_concat(s, ", ") }
+        s = str_concat(s, reg)
+        i = i + 1
+    }
+    str_concat(s, "}")
+}
+
+fn main() with IO, Mut, Panic, Div, Alloc {
+    print(".version 9.0\n")
+    print(".target sm_121\n")
+    print(".address_size 64\n\n")
+    print(".visible .entry sounio_oct_mul_wmma(\n")
+    print("    .param .u64 .ptr .align 1 p_lmat,\n")
+    print("    .param .u64 .ptr .align 1 p_b,\n")
+    print("    .param .u64 .ptr .align 1 p_out\n")
+    print(")\n{\n")
+    print("    .reg .b32 %r<18>;\n")
+    print("    .reg .b32 %f<10>;\n")
+    print("    .reg .b64 %rd<7>;\n\n")
+    print("    ld.param.u64 %rd1, [p_lmat];\n")
+    print("    ld.param.u64 %rd2, [p_b];\n")
+    print("    ld.param.u64 %rd3, [p_out];\n")
+    print("    cvta.to.global.u64 %rd4, %rd1;\n")
+    print("    cvta.to.global.u64 %rd5, %rd2;\n")
+    print("    cvta.to.global.u64 %rd6, %rd3;\n")
+    print("    mov.b32 %r1, 16;\n")
+
+    let aFrag = reg_list("%r", 2, 8)      // {%r2..%r9}
+    let bFrag = reg_list("%r", 10, 8)     // {%r10..%r17}
+    let dFrag = reg_list("%f", 2, 8)      // {%f2..%f9}
+    let cZero = repeat_reg("%f1", 8)      // {%f1 x8}
+
+    print("    wmma.load.a.sync.aligned.row.m16n16k16.global.f16 ")
+    print(aFrag) print(", [%rd4], %r1;\n")
+    print("    wmma.load.b.sync.aligned.col.m16n16k16.global.f16 ")
+    print(bFrag) print(", [%rd5], %r1;\n")
+    print("    mov.f32 %f1, 0f00000000;\n")
+    print("    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 ")
+    print(dFrag) print(", ") print(aFrag) print(", ") print(bFrag) print(", ") print(cZero) print(";\n")
+    print("    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [%rd6], ")
+    print(dFrag) print(", %r1;\n")
+    print("    ret;\n}\n")
+}

--- a/self-hosted/gpu/kernels/hmma_signs.sio
+++ b/self-hosted/gpu/kernels/hmma_signs.sio
@@ -111,3 +111,62 @@ fn hmma_emit_unpack_result(buf: HypercomplexPtxState, frag_reg: i64, oct_dst_bas
     }
     out
 }
+
+// ============================================================================
+// Complete WMMA octonion-multiply kernel emitter (Convention X)
+// ============================================================================
+
+// Emits "{%<prefix><start>, ..., %<prefix><start+count-1>}".
+fn hmma_emit_frag_list(buf: HypercomplexPtxState, prefix: string, start: i64, count: i64) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
+    var out = hc_push_str(buf, "{")
+    var i: i64 = 0
+    while i < count {
+        if i > 0 { out = hc_push_str(out, ", ") }
+        out = hc_push_str(out, prefix)
+        out = hc_push_str(out, i64_to_string(start + i))
+        i = i + 1
+    }
+    hc_push_str(out, "}")
+}
+
+// Emits a complete, runnable PTX kernel `sounio_oct_mul_wmma(L_ptr, B_ptr, out_ptr)` that
+// computes the octonion product on tensor cores: given L(a) (16×16 f16, the caller/host builds
+// L(a)[k][j]=σ(k⊕j,j)·a[k⊕j] via hmma_left_mul_sign) and B (16×16 f16), it runs one
+// wmma.m16n16k16.f16→f32 tile and stores D = L(a)·B (the octonion products, Convention X).
+// HARDWARE-VALIDATED on the DGX Spark (NVIDIA GB10, sm_121, CUDA 13.0): this exact emitted PTX
+// ptxas-assembles and launches; e1·e2 → component 3 (+1), batch 0/128 mismatch vs the exact X
+// reference. Reference harness: docs/gpu/run_sounio_ptx.cu (loads the Sounio-emitted PTX).
+pub fn hmma_emit_oct_mul_wmma_kernel(s: HypercomplexPtxState) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
+    var out = hc_push_str(s, ".version 9.0\n.target sm_121\n.address_size 64\n\n")
+    out = hc_push_str(out, ".visible .entry sounio_oct_mul_wmma(\n")
+    out = hc_push_str(out, "    .param .u64 .ptr .align 1 p_lmat,\n")
+    out = hc_push_str(out, "    .param .u64 .ptr .align 1 p_b,\n")
+    out = hc_push_str(out, "    .param .u64 .ptr .align 1 p_out\n)\n{\n")
+    out = hc_push_str(out, "    .reg .b32 %r<18>;\n    .reg .b32 %f<10>;\n    .reg .b64 %rd<7>;\n\n")
+    out = hc_push_str(out, "    ld.param.u64 %rd1, [p_lmat];\n")
+    out = hc_push_str(out, "    ld.param.u64 %rd2, [p_b];\n")
+    out = hc_push_str(out, "    ld.param.u64 %rd3, [p_out];\n")
+    out = hc_push_str(out, "    cvta.to.global.u64 %rd4, %rd1;\n")
+    out = hc_push_str(out, "    cvta.to.global.u64 %rd5, %rd2;\n")
+    out = hc_push_str(out, "    cvta.to.global.u64 %rd6, %rd3;\n")
+    out = hc_push_str(out, "    mov.b32 %r1, 16;\n")
+    out = hc_push_str(out, "    wmma.load.a.sync.aligned.row.m16n16k16.global.f16 ")
+    out = hmma_emit_frag_list(out, "%r", 2, 8)
+    out = hc_push_str(out, ", [%rd4], %r1;\n")
+    out = hc_push_str(out, "    wmma.load.b.sync.aligned.col.m16n16k16.global.f16 ")
+    out = hmma_emit_frag_list(out, "%r", 10, 8)
+    out = hc_push_str(out, ", [%rd5], %r1;\n")
+    out = hc_push_str(out, "    mov.f32 %f1, 0f00000000;\n")
+    out = hc_push_str(out, "    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 ")
+    out = hmma_emit_frag_list(out, "%f", 2, 8)
+    out = hc_push_str(out, ", ")
+    out = hmma_emit_frag_list(out, "%r", 2, 8)
+    out = hc_push_str(out, ", ")
+    out = hmma_emit_frag_list(out, "%r", 10, 8)
+    out = hc_push_str(out, ", {%f1, %f1, %f1, %f1, %f1, %f1, %f1, %f1};\n")
+    out = hc_push_str(out, "    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [%rd6], ")
+    out = hmma_emit_frag_list(out, "%f", 2, 8)
+    out = hc_push_str(out, ", %r1;\n")
+    out = hc_push_str(out, "    ret;\n}\n")
+    out
+}


### PR DESCRIPTION
## What

Builds on #1016 — turns the correct `L(a)` tensor-core approach into a **complete, compiler-emitted,
runnable** WMMA octonion-multiply kernel, validated end-to-end on real Blackwell hardware.

### The kernel
`hmma_emit_oct_mul_wmma_kernel` (in `self-hosted/gpu/kernels/hmma_signs.sio`) emits a complete
`.visible .entry sounio_oct_mul_wmma(L_ptr, B_ptr, out_ptr)`:
`wmma.load.a` / `wmma.load.b` / `wmma.mma.sync.m16n16k16.f32.f32` / `wmma.store.d`, computing
**D = L(a)·B** = the octonion products in **Convention X** (`L(a)[k][j] = σ(k⊕j,j)·a[k⊕j]`).
Fragment register lists are built programmatically.

### End-to-end HW validation (DGX Spark, NVIDIA GB10, sm_121, CUDA 13.0)
The **Sounio-emitted** PTX:
- `ptxas`-assembles cleanly → 5904-byte cubin;
- launches on the Blackwell tensor cores via the CUDA Driver API;
- **e1·e2 → component 3 (+1), not 4** (Convention X), and a full 16-column batch matches the exact X
  reference → **0/128 mismatches**.

```
PASS: Sounio-emitted WMMA octonion multiply is Convention X on GB10
```

### Contents
- `self-hosted/gpu/kernels/hmma_signs.sio` — the emitter (`hmma_emit_oct_mul_wmma_kernel` +
  `hmma_emit_frag_list`).
- `self-hosted/gpu/emit_oct_mul_wmma_ptx.sio` — standalone driver that emits the kernel PTX to stdout
  (reproducible → `ptxas`).
- `docs/gpu/sounio_oct_mul_wmma.ptx` — the Sounio-emitted PTX (byte-matches nvcc ground truth modulo
  the clean entry name).
- `docs/gpu/run_sounio_ptx.cu` — Driver-API harness that loads the Sounio-emitted PTX, builds `L(a)`
  on host, launches, checks X.
- `scripts/ci/native_v2_epistemic_accel_spine_gate.sh` — probe pins the new emitter surface.

This is (very likely) the **first compiler-emitted tensor-core octonion multiply**. The in-kernel
`L(a)` build (so the kernel takes raw octonions `a` and `b`, folding
`hmma_emit_build_left_mul_matrix` + f16 staging into the kernel) is a natural follow-up; here `L(a)`
is built by the caller/host.

Depends on #1016.
