### PR TITLE
chore(gpu): record Convention X math audit

### DIFF
--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3044,3 +3044,8 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - Independent review is incomplete: default Z.AI GLM-5.2 ran for 125 s and timed out with an empty response; DeepSeek returned `Insufficient Balance`; Gemini returned OpenRouter HTTP 402 insufficient credits. Raw: `/tmp/llm-offload-eOI06E/`, `/tmp/llm-offload-tVR4tH/`, `/tmp/llm-offload-GVFRRL/`.
 - Local source-level witness: `SOUNIO_TEST_JOBS=1 bash scripts/run_sio_test_suite.sh --filter-exact test_hmma_octonion.sio --verbose --jobs 1` = **PASS** (1/1) under the canonical `bin/souc` path.
 - Outcome: **PASS_SINGLE_PROVIDER_DEGRADED** for the algebraic review only; no provider or local test here establishes the documented GB10 execution. Hardware evidence is tracked separately in #1022; independent math re-review remains pending when a second provider is available.
+
+## 2026-07-16 — hardware evidence update: tensor-core HMMA Convention X
+- Manual GB10 witness: `docs/gpu/oct_wmma_validate.cu` at commit `8b5e07050` (SHA-256 `5bd22146ac869c92854b0821418d742e43141c1a3b4a137583325311b21e913f`) compiled with CUDA 13.0 for `sm_121` and ran on `spark-8e54` (`NVIDIA GB10`, driver `580.159.03`, compute capability `12.1`).
+- Runtime result: `e1*e2` produced component 3 = 1.00 and component 4 = 0.00; batch result was `0/128` mismatches with `maxerr=0.000`; process printed `PASS: WMMA octonion multiply is Convention X on GB10`.
+- Retained receipt: `docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md`. Scope remains manual hardware evidence only: the GitHub `validate-on-gpu` job is still conditional/skipped, so workflow automation and artifact retention remain tracked in #1022.

--- a/.claude/llm_offload_log.md
+++ b/.claude/llm_offload_log.md
@@ -3023,3 +3023,10 @@ tracked as issues #862/#864/#865/#890/#901/#913 and audit docs under docs/audit/
 - mann_kendall = **PASS**: S=Σsign, Var=n(n−1)(2n+5)/18, continuity-corrected z, τ=2S/(n(n−1)); increasing {1..5}→S=10, z=2.2045, τ=1. Note: test constant z=2.204793 was a hand slip — correct 9/√16.6667=2.204541 (Python-verified); caught by the failing assertion, fixed.
 - Theme: ordered-alternative & monotonic-trend tests — extends the non-parametric family beyond the proportion trend (cochran_armitage) to continuous/ordinal ordered groups, repeated measures, and time series. All derivable, #852-safe. Suite runner: 130 modules + 7 demos ALL GREEN under lean_single.
 - Raw review dirs: `/tmp/llm-offload-iOjAr1/`, `/tmp/llm-offload-5fFzUi/`, `/tmp/llm-offload-N6zSm6/`.
+
+## 2026-07-16 — post-merge math-review: tensor-core HMMA Convention X (PR #1016)
+- Target: merged diff `827852d47^..827852d47` over `self-hosted/gpu/kernels/hmma_signs.sio`, `tests/gpu/test_hmma_octonion.sio`, `docs/gpu/oct_wmma_validate.cu`, and `scripts/ci/native_v2_epistemic_accel_spine_gate.sh`.
+- xAI/Grok 4.3 = **PASS**: accepted the bilinear left-multiply representation `L(a)[k][j] = sigma(k xor j, j) * a[k xor j]`, the recursive Convention X sign, the 8x8-to-16x16 WMMA construction, and the `e1*e2` discriminator. Raw: `/tmp/llm-offload-eOI06E/grok.md`.
+- Independent review is incomplete: default Z.AI GLM-5.2 ran for 125 s and timed out with an empty response; DeepSeek returned `Insufficient Balance`; Gemini returned OpenRouter HTTP 402 insufficient credits. Raw: `/tmp/llm-offload-eOI06E/`, `/tmp/llm-offload-tVR4tH/`, `/tmp/llm-offload-GVFRRL/`.
+- Local source-level witness: `SOUNIO_TEST_JOBS=1 bash scripts/run_sio_test_suite.sh --filter-exact test_hmma_octonion.sio --verbose --jobs 1` = **PASS** (1/1) under the canonical `bin/souc` path.
+- Outcome: **PASS_SINGLE_PROVIDER_DEGRADED** for the algebraic review only; no provider or local test here establishes the documented GB10 execution. Hardware evidence is tracked separately in #1022; independent math re-review remains pending when a second provider is available.

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 984
-- Repo-backed topics: 834
+- Total governed topics: 985
+- Repo-backed topics: 835
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 584
+- Authority count `repo_only`: 585
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 603 topics
+- A2: 604 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -333,6 +333,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.glossary | repo_only | docs/GLOSSARY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.data-access-credentials | repo_only | docs/governance/data_access_credentials.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.docs-conventions | repo_only | docs/governance/DOCS_CONVENTIONS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.gpu.oct-wmma-validate.gb10-receipt-20260716 | repo_only | docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.check-sounio-guide | repo_only | docs/guide/CHECK_SOUNIO_GUIDE.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.egc-depth-guide | repo_only | docs/guide/EGC_DEPTH_GUIDE.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.getting-started-pt | repo_only | docs/guide/getting-started_PT.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7144,6 +7144,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.gpu.oct-wmma-validate.gb10-receipt-20260716",
+      "collection": "repo",
+      "repo_doc_path": "docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.guide.check-sounio-guide",
       "collection": "repo",
       "repo_doc_path": "docs/guide/CHECK_SOUNIO_GUIDE.md",

--- a/docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md
+++ b/docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md
@@ -1,0 +1,37 @@
+# GB10 WMMA Receipt
+
+Status: manual hardware witness passed on 2026-07-16.
+
+This receipt records a manual execution of `docs/gpu/oct_wmma_validate.cu` from
+commit `8b5e07050c890e39c4e71424f16f58cd7fbe4170`. It is not a replacement for a
+CI GPU job and does not claim general GPU backend correctness.
+
+## Source
+
+- File: `docs/gpu/oct_wmma_validate.cu`
+- SHA-256: `5bd22146ac869c92854b0821418d742e43141c1a3b4a137583325311b21e913f`
+- Compile command: `/usr/local/cuda-13.0/bin/nvcc -std=c++17 -O2 -arch=sm_121 oct_wmma_validate.cu -o oct_wmma_validate`
+
+## Environment
+
+- Host: `spark-8e54`
+- Architecture: `aarch64`
+- GPU: `NVIDIA GB10`
+- Driver: `580.159.03`
+- Compute capability: `12.1`
+- CUDA compiler: `Build cuda_13.0.r13.0/compiler.36424714_0`
+
+## Runtime Output
+
+```text
+e1*e2 on tensor core: comp3=1.00 comp4=0.00  (X: comp3=+1,comp4=0)
+batch: 0/128 comps mismatch, maxerr=0.000 (f16 tile precision)
+PASS: WMMA octonion multiply is Convention X on GB10
+```
+
+## Boundary
+
+The repository GPU Performance Validation workflow still skipped its
+`validate-on-gpu` job at the time of this witness. This receipt proves the
+specified CUDA source ran on the named GB10 environment; it does not prove that
+the GitHub workflow automatically runs or retains the same witness.

--- a/docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md
+++ b/docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md
@@ -1,3 +1,12 @@
+<!-- docs:meta
+topic_id: repo.docs.gpu.oct-wmma-validate.gb10-receipt-20260716
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.gpu.oct-wmma-validate.gb10-receipt-20260716
+-->
+
 # GB10 WMMA Receipt
 
 Status: manual hardware witness passed on 2026-07-16.


### PR DESCRIPTION
Post-merge audit and retained evidence for #1016. Records the mandatory math-review attempt, xAI result, independent-provider failures, and the narrow canonical source-level test. It also adds a pinned-source manual GB10 receipt for docs/gpu/oct_wmma_validate.cu: CUDA 13.0, sm_121, spark-8e54, with the documented Convention X discriminator and 0/128 batch mismatches. The receipt is reproducible manual hardware evidence, not a claim that GitHub CI executed the GPU path. The conditional/skipped validate-on-gpu workflow and artifact-retention gap remain tracked in #1022.