### PR TITLE
test(stdlib): tacrolimus PK, dialogue trajectory, perturbation-graph verticals

### DIFF
--- a/scripts/verticals_tacrolimus_trajectory_pgraph_gate.sh
+++ b/scripts/verticals_tacrolimus_trajectory_pgraph_gate.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Verticals: clinical::tacrolimus_oral_safety (PK), dialogue::trajectory (conversation store),
+# epistemic::perturbation_graph (octonion variance DAG). Multi-module drivers -> lean_single engine.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # module driver sentinel
+  echo "== $2 =="
+  $SOUC check "$1" >/dev/null 2>&1 || { echo "FAIL check $1"; fail=1; }
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$2" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "$3" || { echo "FAIL run $2"; fail=1; }
+  else echo "FAIL compile $2"; fail=1; fi
+}
+run stdlib/clinical/tacrolimus_oral_safety.sio  tests/stdlib/clinical/test_tacrolimus_stdlib.sio            TACROLIMUS_STDLIB_OK
+run stdlib/dialogue/trajectory.sio               tests/stdlib/dialogue/test_trajectory_stdlib.sio           TRAJECTORY_STDLIB_OK
+run stdlib/epistemic/perturbation_graph.sio      tests/stdlib/epistemic/test_perturbation_graph_stdlib.sio  PERTURBATION_GRAPH_STDLIB_OK
+[ $fail -eq 0 ] && echo "VERTICALS_TACROLIMUS_TRAJECTORY_PGRAPH_GATE_OK"
+exit $fail

--- a/tests/stdlib/clinical/test_tacrolimus_stdlib.sio
+++ b/tests/stdlib/clinical/test_tacrolimus_stdlib.sio
@@ -1,0 +1,25 @@
+// Run-proof for stdlib clinical::tacrolimus_oral_safety — population PK for oral tacrolimus:
+// V ~ 3.6 L/kg, CL ~ 0.144 L/h/kg, and an oral bioavailability F < 1 (tacrolimus is a low-F,
+// CYP3A-metabolised drug, so clearance is independent of renal function). lean_single engine.
+use epistemic::knightian::*
+use clinical::tacrolimus_oral_safety::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let p = tp_default(70.0, 90.0)
+    let vc = tp_vc_to_pbox(&p, 2)
+    if ae(pb_midpoint(&vc), 252.0) >= 1.0e-4 { print("FAIL vc\n"); return 1 }    // 3.6*70
+    let cl = tp_cl_to_pbox(&p, 2)
+    if ae(pb_midpoint(&cl), 10.08) >= 1.0e-4 { print("FAIL cl\n"); return 2 }     // 0.144*70
+    // oral bioavailability is a fraction in (0,1)
+    let f = tp_f_to_pbox(&p, 2)
+    let fm = pb_midpoint(&f)
+    if fm <= 0.0 || fm >= 1.0 { print("FAIL bioavail\n"); return 3 }
+    // pre-TDM ambiguity band present
+    if pb_gap(&vc) <= 0.0 { print("FAIL gap\n"); return 4 }
+    // tacrolimus is hepatically (CYP3A) cleared -> clearance independent of renal function
+    let p2 = tp_default(70.0, 180.0)
+    let cl2 = tp_cl_to_pbox(&p2, 2)
+    if ae(pb_midpoint(&cl2), pb_midpoint(&cl)) >= 1.0e-6 { print("FAIL hepatic\n"); return 5 }
+    print("TACROLIMUS_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/dialogue/test_trajectory_stdlib.sio
+++ b/tests/stdlib/dialogue/test_trajectory_stdlib.sio
@@ -1,0 +1,22 @@
+// Run-proof for stdlib dialogue::trajectory — an append-only conversational trajectory store:
+// push returns the slot index, length grows, and each event's fields (speaker, hash) read back. LS.
+use dialogue::trajectory::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var t = traj_empty()
+    if traj_len(&t) != 0 { print("FAIL empty\n"); return 1 }
+    // push two turns; the return value advances monotonically with each push
+    let i0 = traj_push(&t, 1, 100, 0, 0, 1)
+    let i1 = traj_push(&t, 2, 200, 0, 0, 1)
+    if i1 <= i0 { print("FAIL idx\n"); return 2 }
+    if traj_len(&t) != 2 { print("FAIL len\n"); return 3 }
+    // fields read back per slot
+    if traj_speaker(&t, 0) != 1 { print("FAIL sp0\n"); return 4 }
+    if traj_speaker(&t, 1) != 2 { print("FAIL sp1\n"); return 5 }
+    if traj_hash(&t, 0) != 100 { print("FAIL h0\n"); return 6 }
+    if traj_hash(&t, 1) != 200 { print("FAIL h1\n"); return 7 }
+    // payload set/get round-trip
+    traj_set_payload(&t, 0, 0, 3.5)
+    if (if traj_payload_at(&t, 0, 0) > 3.5 { traj_payload_at(&t,0,0)-3.5 } else { 3.5-traj_payload_at(&t,0,0) }) >= 1.0e-9 { print("FAIL payload\n"); return 8 }
+    print("TRAJECTORY_STDLIB_OK\n")
+    return 0
+}

--- a/tests/stdlib/epistemic/test_perturbation_graph_stdlib.sio
+++ b/tests/stdlib/epistemic/test_perturbation_graph_stdlib.sio
@@ -1,0 +1,23 @@
+// Run-proof for stdlib epistemic::perturbation_graph — a DAG that propagates octonion-valued
+// uncertainty: a leaf's variance is std^2; multiplication propagates variance and computes the
+// octonion product component-wise (e0*e1 = e1). Needs the NonAssoc effect. lean_single engine.
+use epistemic::perturbation_graph::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    var g = pg_new()
+    // leaf e0 (real unit), std 0.1 -> variance 0.01, component 0 = 1
+    var e0: [f64; 8] = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    let l0 = pg_leaf(&!g, &e0, 0.1)
+    if ae(pg_variance(&!g, l0), 0.01) >= 1.0e-9 { print("FAIL leaf0_var\n"); return 1 }
+    if ae(pg_component(&!g, l0, 0), 1.0) >= 1.0e-9 { print("FAIL leaf0_comp\n"); return 2 }
+    // leaf e1
+    var e1: [f64; 8] = [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    let l1 = pg_leaf(&!g, &e1, 0.1)
+    if ae(pg_variance(&!g, l1), 0.01) >= 1.0e-9 { print("FAIL leaf1_var\n"); return 3 }
+    // product node: e0 * e1 = e1 (component 1 = 1), variance propagates from both leaves
+    let p = pg_mul(&!g, l0, l1, 1.0)
+    if ae(pg_component(&!g, p, 1), 1.0) >= 1.0e-9 { print("FAIL prod_comp\n"); return 4 }
+    if pg_variance(&!g, p) < 0.01 { print("FAIL prod_var\n"); return 5 }
+    print("PERTURBATION_GRAPH_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Tacrolimus PK, conversation trajectories, and octonion-uncertainty propagation

Three modules, each proven by compile-and-run against first-principles / published values.

| Module | Coverage |
|---|---|
| `clinical::tacrolimus_oral_safety` | oral tacrolimus pop-PK — `V≈3.6 L/kg`→252 L, `CL≈0.144 L/h/kg`→10.08 L/h, oral bioavailability `F∈(0,1)`; **CL independent of CrCl** (CYP3A/hepatic clearance) — a clinical contrast to vancomycin's renal scaling |
| `dialogue::trajectory` | append-only conversation store — pushed turns' speaker/hash read back per slot, length grows, payload set/get round-trips |
| `epistemic::perturbation_graph` | a DAG propagating **octonion-valued uncertainty** — leaf variance `= std²`, multiplication computes the octonion product (`e₀·e₁=e₁`) and propagates variance |

### Highlights
- **tacrolimus** completes the PK lane (gentamicin, amikacin, vancomycin, tacrolimus): its hepatic (not renal) clearance is a clinically meaningful distinction the run-proof pins down (`CL(CrCl 90) == CL(CrCl 180)`).
- **perturbation_graph** ties the uncertainty lane to the exact-algebra lane — GUM variance flowing through octonion multiplication (the associator/uncertain-octonion work).

### Verification
- `scripts/verticals_tacrolimus_trajectory_pgraph_gate.sh` → `VERTICALS_TACROLIMUS_TRAJECTORY_PGRAPH_GATE_OK` (all three pass standalone `souc check`).
- Math-review (xai/grok): all PASS.

### Notes
- `pg_mul`/`pg_leaf` need the `NonAssoc` effect — the driver declares it.
- Found (not shipped): `epistemic::active`'s `coefficient_of_variation`/`relative_uncertainty` (and its Bayesian-update/UCB helpers) reference a non-existent `k.value` field (the `Epistemic` field is `val`), so they read garbage; the module also has lifetime-syntax parse errors. Left untouched — a separate fix.
- Multi-module drivers run under `SOUNIO_SOUC_ENGINE=lean_single`. No `self-hosted/`/`bootstrap/` edits. Uniquely-named branch + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)