### PR TITLE
ci(gpu): retain GB10 WMMA receipt

### DIFF
--- a/.github/workflows/gb10-wmma-receipt.yml
+++ b/.github/workflows/gb10-wmma-receipt.yml
@@ -1,0 +1,52 @@
+name: GB10 WMMA Receipt
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gb10-wmma-receipt
+  cancel-in-progress: false
+
+jobs:
+  validate-gb10-wmma:
+    name: GB10 WMMA Convention X receipt
+    runs-on: [self-hosted, linux, gpu, cuda, gb10]
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Compile and run the GB10 WMMA witness
+        env:
+          SOUNIO_GB10_WMMA_RECEIPT_DIR: ${{ runner.temp }}/gb10-wmma-receipt
+        run: bash scripts/ci/gb10_wmma_receipt_gate.sh
+
+      - name: Upload GB10 WMMA receipt
+        id: upload-receipt
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gb10-wmma-receipt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/gb10-wmma-receipt
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Publish receipt summary
+        if: always()
+        shell: bash
+        run: |
+          receipt_dir="${RUNNER_TEMP}/gb10-wmma-receipt"
+          if [[ -f "$receipt_dir/receipt.md" ]]; then
+            cat "$receipt_dir/receipt.md" >> "$GITHUB_STEP_SUMMARY"
+          elif [[ -f "$receipt_dir/status.txt" ]]; then
+            printf '# GB10 WMMA CI Receipt\n\nThe witness failed. See the retained artifact.\n\n' >> "$GITHUB_STEP_SUMMARY"
+            cat "$receipt_dir/status.txt" >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf '# GB10 WMMA CI Receipt\n\nNo receipt directory was created.\n' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/ci/gb10_wmma_receipt_gate.sh
+++ b/scripts/ci/gb10_wmma_receipt_gate.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Capture a narrow, retained GB10 hardware receipt for oct_wmma_validate.cu.
+# This checks the documented CUDA witness only; it is not a general GPU backend gate.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_REL="docs/gpu/oct_wmma_validate.cu"
+SOURCE_PATH="$ROOT_DIR/$SOURCE_REL"
+NVCC_BIN="${SOUNIO_GB10_NVCC:-/usr/local/cuda-13.0/bin/nvcc}"
+DEFAULT_RECEIPT_DIR="$ROOT_DIR/artifacts/gpu/gb10-wmma-receipt"
+RECEIPT_DIR="${SOUNIO_GB10_WMMA_RECEIPT_DIR:-$DEFAULT_RECEIPT_DIR}"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/ci/gb10_wmma_receipt_gate.sh [--output DIR]
+
+Compiles and runs docs/gpu/oct_wmma_validate.cu on exactly one NVIDIA GB10
+device with compute capability 12.1, then writes the command, environment,
+source hash, compiler output, runtime output, and receipt summary to DIR.
+
+Environment:
+  SOUNIO_GB10_WMMA_RECEIPT_DIR  Default output directory.
+  SOUNIO_GB10_NVCC              CUDA compiler path (default: /usr/local/cuda-13.0/bin/nvcc).
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ "${1:-}" == "--output" ]]; then
+    [[ "$#" -eq 2 ]] || { usage >&2; exit 2; }
+    RECEIPT_DIR="$2"
+elif [[ "$#" -ne 0 ]]; then
+    usage >&2
+    exit 2
+fi
+
+if [[ "$RECEIPT_DIR" != /* ]]; then
+    RECEIPT_DIR="$ROOT_DIR/$RECEIPT_DIR"
+fi
+
+if [[ -e "$RECEIPT_DIR" ]]; then
+    printf 'refusing to overwrite existing receipt directory: %s\n' "$RECEIPT_DIR" >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "$RECEIPT_DIR")"
+mkdir "$RECEIPT_DIR"
+
+on_exit() {
+    local rc=$?
+    if [[ -d "$RECEIPT_DIR" ]]; then
+        if [[ "$rc" -eq 0 ]]; then
+            printf 'status=pass\nexit_code=0\n' > "$RECEIPT_DIR/status.txt" || true
+        else
+            printf 'status=fail\nexit_code=%d\n' "$rc" > "$RECEIPT_DIR/status.txt" || true
+        fi
+    fi
+}
+trap on_exit EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" | tee -a "$RECEIPT_DIR/gate.stderr" >&2
+    exit 1
+}
+
+cd "$ROOT_DIR"
+
+[[ -f "$SOURCE_PATH" ]] || fail "missing witness source: $SOURCE_REL"
+command -v nvidia-smi >/dev/null 2>&1 || fail "nvidia-smi is required"
+[[ -x "$NVCC_BIN" ]] || fail "CUDA compiler is not executable: $NVCC_BIN"
+
+GPU_INFO="$(nvidia-smi --query-gpu=index,name,driver_version,compute_cap --format=csv,noheader)"
+GPU_COUNT="$(printf '%s\n' "$GPU_INFO" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "$GPU_COUNT" -ne 1 ]]; then
+    fail "expected exactly one visible GPU, found $GPU_COUNT"
+fi
+if ! printf '%s\n' "$GPU_INFO" | grep -Eq '^[0-9]+, NVIDIA GB10, [^,]+, 12\.1$'; then
+    fail "expected one NVIDIA GB10 with compute capability 12.1; inventory: $GPU_INFO"
+fi
+
+{
+    printf 'hostname=%s\n' "$(hostname)"
+    printf 'uname=%s\n' "$(uname -a)"
+    printf 'git_commit=%s\n' "$(git rev-parse HEAD)"
+    printf 'cuda_visible_devices=%s\n' "${CUDA_VISIBLE_DEVICES:-<unset>}"
+    printf '\nGPU inventory (index, name, driver, compute capability):\n%s\n' "$GPU_INFO"
+    printf '\nCUDA compiler path:\n%s\n' "$NVCC_BIN"
+    printf '\nCUDA compiler version:\n'
+    "$NVCC_BIN" --version
+} > "$RECEIPT_DIR/environment.txt"
+
+sha256sum "$SOURCE_REL" > "$RECEIPT_DIR/source.sha256"
+
+BINARY_PATH="$RECEIPT_DIR/oct_wmma_validate"
+COMPILE_COMMAND=("$NVCC_BIN" -std=c++17 -O2 -arch=sm_121 "$SOURCE_REL" -o "$BINARY_PATH")
+{
+    printf 'working_directory=%q\n' "$ROOT_DIR"
+    printf 'command='
+    printf '%q ' "${COMPILE_COMMAND[@]}"
+    printf '\n'
+} > "$RECEIPT_DIR/compile-command.txt"
+
+"${COMPILE_COMMAND[@]}" > "$RECEIPT_DIR/compile.stdout" 2> "$RECEIPT_DIR/compile.stderr"
+printf 'compile_exit_code=0\n' > "$RECEIPT_DIR/compile.status"
+sha256sum "$BINARY_PATH" > "$RECEIPT_DIR/binary.sha256"
+
+"$BINARY_PATH" > "$RECEIPT_DIR/run.stdout" 2> "$RECEIPT_DIR/run.stderr"
+printf 'run_exit_code=0\n' > "$RECEIPT_DIR/run.status"
+
+require_output() {
+    local expected="$1"
+    grep -Fqx "$expected" "$RECEIPT_DIR/run.stdout" || fail "runtime output did not contain expected line: $expected"
+}
+
+require_output 'e1*e2 on tensor core: comp3=1.00 comp4=0.00  (X: comp3=+1,comp4=0)'
+require_output 'batch: 0/128 comps mismatch, maxerr=0.000 (f16 tile precision)'
+require_output 'PASS: WMMA octonion multiply is Convention X on GB10'
+
+cat > "$RECEIPT_DIR/receipt.md" <<EOF
+# GB10 WMMA CI Receipt
+
+Status: pass.
+
+This artifact records one execution of \`$SOURCE_REL\` from commit
+\`$(git rev-parse HEAD)\` on the runner inventory in \`environment.txt\`.
+The source hash, compile command, compiler output, and runtime output are
+retained beside this summary.
+
+## Scope boundary
+
+This is a narrow CUDA WMMA witness for the documented Convention X discriminator
+and the 16-vector batch in \`oct_wmma_validate.cu\`. It does not claim general
+GPU backend correctness, code-generation coverage, or validation of unrelated
+GPU hardware.
+EOF
+
+printf 'PASS: retained GB10 WMMA receipt written to %s\n' "$RECEIPT_DIR"


### PR DESCRIPTION
## Scope

- add a manual-only `GB10 WMMA Receipt` workflow on the dedicated `self-hosted, linux, gpu, cuda, gb10` runner labels
- compile and execute `docs/gpu/oct_wmma_validate.cu` with CUDA 13.0 / `sm_121`
- retain environment, source hash, compile command, compiler output, runtime output, binary hash, and scope boundary for 90 days

## Evidence

The new gate passed directly on `spark-8e54` before this PR: NVIDIA GB10, compute capability 12.1, CUDA 13.0; it recorded `0/128` mismatches and the Convention X discriminator. The remaining acceptance run will be dispatched from `main` because GitHub only exposes a new `workflow_dispatch` endpoint after the workflow file reaches the default branch.

## Boundary

This is a narrow CUDA WMMA hardware witness. It does not claim general GPU backend correctness or execute on pull requests.