### PR TITLE
docs(governance): sync rebracketing acceptance counts

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 985
-- Repo-backed topics: 835
+- Total governed topics: 986
+- Repo-backed topics: 836
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 585
+- Authority count `repo_only`: 586
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 604 topics
+- A2: 605 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics


### PR DESCRIPTION
## Summary

- regenerate the governed documentation acceptance snapshot after #1001 introduced `SOUNIO-REBRACKETING-AUTHORITY`
- increment only the total, repo-backed, `repo_only`, and A2 counts associated with that one new governed topic

## Evidence

- `node scripts/docs/sync_governance_metadata.mjs` changed only `docs/governance/DOCS_ACCEPTANCE_REPORT.md`
- `bash scripts/dev/check_docs_registry.sh`: PASS, including five failure scenarios and baseline self-test
- `bash scripts/dev/check_docs_consistency.sh`: PASS
- `git diff --check`: PASS

This is a generated-metadata integration follow-up to #1001. It changes no compiler or semantic implementation.
