### PR TITLE
feat(stdlib): DataFrame stable multi-key sort (data::dataframe_sort)

### DIFF
--- a/scripts/dataframe_sort_gate.sh
+++ b/scripts/dataframe_sort_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Gate for stdlib data::dataframe_sort (stable multi-key sort). lean_single engine.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check data/dataframe_sort.sio =="
+$SOUC check stdlib/data/dataframe_sort.sio >/dev/null 2>&1 || { echo "FAIL check"; fail=1; }
+echo "== run-proof: multi-key sort =="
+if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile tests/stdlib/data/test_dataframe_sort_stdlib.sio -o "$OUT/x.elf" >/dev/null 2>&1; then
+  chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "DATAFRAME_SORT_STDLIB_OK" || { echo "FAIL run"; fail=1; }
+else echo "FAIL compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "DATAFRAME_SORT_GATE_OK"
+exit $fail

--- a/stdlib/data/dataframe_sort.sio
+++ b/stdlib/data/dataframe_sort.sio
@@ -1,0 +1,60 @@
+//! Multi-key (lexicographic) sort for DataFrames.
+//!
+//! Complements the single-column `data::dataframe::df_sort_by` with a stable sort over several key
+//! columns in priority order: ties on the first key are broken by the second, and so on. Built on
+//! the public DataFrame accessors, so it composes with the rest of the surface.
+
+use data::dataframe::{DataFrame, df_new, df_get, df_add_row, df_nrows, df_ncols}
+
+// Lexicographic comparison of rows `i` and `j` over `keys[0..nk)` (ascending):
+// returns -1 if row i < row j, +1 if i > j, 0 if equal on all keys.
+fn cmp_rows(df: &DataFrame, i: i64, j: i64, keys: &[i64; 8], nk: i64) -> i64 with Mut, Div, Panic {
+    var k: i64 = 0
+    while k < nk && k < 8 {
+        let col = keys[k as usize]
+        let a = df_get(df, i, col)
+        let b = df_get(df, j, col)
+        if a < b { return 0 - 1 }
+        if a > b { return 1 }
+        k = k + 1
+    }
+    0
+}
+
+/// Return a new DataFrame with the rows sorted ascending by the columns in `keys[0..n_keys)`,
+/// in priority order (key 0 primary, key 1 tie-break, ...). The sort is stable: rows equal on all
+/// keys keep their original relative order. Up to 8 sort keys.
+pub fn df_sort_by_keys(df: &DataFrame, keys: &[i64; 8], n_keys: i64) -> DataFrame with Mut, Div, Panic {
+    let nr = df_nrows(df)
+    let nc = df_ncols(df)
+    // order[] is a permutation of the row indices
+    var order: [i64; 1024] = [0; 1024]
+    var i: i64 = 0
+    while i < nr && i < 1024 { order[i as usize] = i; i = i + 1 }
+    // stable insertion sort on the index array
+    i = 1
+    while i < nr && i < 1024 {
+        let cur = order[i as usize]
+        var j: i64 = i - 1
+        while j >= 0 && cmp_rows(df, order[j as usize], cur, keys, n_keys) > 0 {
+            order[(j + 1) as usize] = order[j as usize]
+            j = j - 1
+        }
+        order[(j + 1) as usize] = cur
+        i = i + 1
+    }
+    // emit rows in sorted order (all columns preserved)
+    var out = df_new(nc)
+    i = 0
+    while i < nr && i < 1024 {
+        var row: [f64; 64] = [0.0; 64]
+        var c: i64 = 0
+        while c < nc && c < 64 {
+            row[c as usize] = df_get(df, order[i as usize], c)
+            c = c + 1
+        }
+        df_add_row(&!out, &row)
+        i = i + 1
+    }
+    out
+}

--- a/tests/stdlib/data/test_dataframe_sort_stdlib.sio
+++ b/tests/stdlib/data/test_dataframe_sort_stdlib.sio
@@ -1,0 +1,38 @@
+// Run-proof for stdlib data::dataframe_sort — stable multi-key (lexicographic) sort.
+// Rows [dept, priority, id]; sort by dept asc then priority asc. lean_single engine.
+use data::dataframe::*
+use data::dataframe_sort::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn add3(df: &!DataFrame, a: f64, b: f64, c: f64) with Mut, Div, Panic { var r: [f64; 64] = [0.0; 64]; r[0]=a; r[1]=b; r[2]=c; df_add_row(df, &r) }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var df = df_new(3)
+    add3(&!df, 2.0, 1.0, 100.0)
+    add3(&!df, 1.0, 2.0, 101.0)
+    add3(&!df, 2.0, 0.0, 102.0)
+    add3(&!df, 1.0, 1.0, 103.0)
+    add3(&!df, 1.0, 1.0, 104.0)   // ties row3 on (dept 1, pri 1)
+    // two-key sort: dept asc, then priority asc
+    var keys: [i64; 8] = [0, 1, 0, 0, 0, 0, 0, 0]
+    let s = df_sort_by_keys(&df, &keys, 2)
+    if df_nrows(&s) != 5 || df_ncols(&s) != 3 { print("FAIL shape\n"); return 1 }
+    // expected id order: 103, 104, 101, 102, 100
+    if ae(df_get(&s, 0, 2), 103.0) >= 1.0e-9 { print("FAIL r0\n"); return 2 }
+    if ae(df_get(&s, 1, 2), 104.0) >= 1.0e-9 { print("FAIL r1_stable\n"); return 3 }   // stable tie
+    if ae(df_get(&s, 2, 2), 101.0) >= 1.0e-9 { print("FAIL r2\n"); return 4 }
+    if ae(df_get(&s, 3, 2), 102.0) >= 1.0e-9 { print("FAIL r3\n"); return 5 }
+    if ae(df_get(&s, 4, 2), 100.0) >= 1.0e-9 { print("FAIL r4\n"); return 6 }
+    // keys are globally non-decreasing after sort (dept primary, priority within dept)
+    var r: i64 = 1
+    while r < df_nrows(&s) {
+        let d0 = df_get(&s, r - 1, 0); let d1 = df_get(&s, r, 0)
+        if d1 < d0 { print("FAIL dept_order\n"); return 7 }
+        if d1 == d0 && df_get(&s, r, 1) < df_get(&s, r - 1, 1) { print("FAIL pri_order\n"); return 8 }
+        r = r + 1
+    }
+    // single-key sort by id descending is NOT provided, but single-key ascending works:
+    var keys1: [i64; 8] = [2, 0, 0, 0, 0, 0, 0, 0]
+    let s1 = df_sort_by_keys(&df, &keys1, 1)   // sort by id asc -> 100,101,102,103,104
+    if ae(df_get(&s1, 0, 2), 100.0) >= 1.0e-9 || ae(df_get(&s1, 4, 2), 104.0) >= 1.0e-9 { print("FAIL single\n"); return 9 }
+    print("DATAFRAME_SORT_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Sort a DataFrame by multiple keys

Adds `df_sort_by_keys(df, keys, n_keys)`, complementing the single-column `data::dataframe::df_sort_by` with a **stable lexicographic** sort over several key columns in priority order (key 0 primary, key 1 tie-break, …). Up to 8 keys.

```
rows [dept, priority, id]: (2,1,100)(1,2,101)(2,0,102)(1,1,103)(1,1,104)
sort by (dept, priority) -> id order: 103, 104, 101, 102, 100
                                        ^^^^^^^^ stable: (1,1,103) before (1,1,104)
```

### Design
- A **stable insertion sort** on a row-index permutation with a multi-key comparator, then rows emitted in sorted order with all columns preserved. Ties on all keys keep their original input order.
- Separate module, built only on the public DataFrame accessors — no conflict with the relational verbs.

### Verification
- `scripts/dataframe_sort_gate.sh` → `DATAFRAME_SORT_GATE_OK`.
- Run-proof checks the expected id order, the stable tie, global monotonicity (dept non-decreasing; priority non-decreasing within dept), and a single-key case.
- Math-review (xai/grok): *"All three statements hold for a correct stable lexicographic sort."*

### Notes
- Ascending order (a descending variant can follow). No compiler changes; passes standalone `souc check`. Driver runs under `SOUNIO_SOUC_ENGINE=lean_single`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)