### PR TITLE
feat(stdlib): DataFrame descending / mixed-direction multi-key sort

### DIFF
--- a/scripts/dataframe_sort_desc_gate.sh
+++ b/scripts/dataframe_sort_desc_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Gate for stdlib data::dataframe_sort descending / mixed-direction sort. lean_single engine.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check data/dataframe_sort.sio =="
+$SOUC check stdlib/data/dataframe_sort.sio >/dev/null 2>&1 || { echo "FAIL check"; fail=1; }
+echo "== run-proof: descending + mixed-direction sort =="
+if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile tests/stdlib/data/test_dataframe_sort_desc_stdlib.sio -o "$OUT/x.elf" >/dev/null 2>&1; then
+  chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "DATAFRAME_SORT_DESC_STDLIB_OK" || { echo "FAIL run"; fail=1; }
+else echo "FAIL compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "DATAFRAME_SORT_DESC_GATE_OK"
+exit $fail

--- a/stdlib/data/dataframe_sort.sio
+++ b/stdlib/data/dataframe_sort.sio
@@ -58,3 +58,65 @@ pub fn df_sort_by_keys(df: &DataFrame, keys: &[i64; 8], n_keys: i64) -> DataFram
     }
     out
 }
+
+// Direction-aware comparison: dirs[k] >= 0 sorts key k ascending, otherwise descending.
+fn cmp_rows_dir(df: &DataFrame, i: i64, j: i64, keys: &[i64; 8], dirs: &[i64; 8], nk: i64) -> i64
+    with Mut, Div, Panic
+{
+    var k: i64 = 0
+    while k < nk && k < 8 {
+        let col = keys[k as usize]
+        let a = df_get(df, i, col)
+        let b = df_get(df, j, col)
+        if a != b {
+            if dirs[k as usize] >= 0 {
+                if a < b { return 0 - 1 } else { return 1 }   // ascending
+            } else {
+                if a > b { return 0 - 1 } else { return 1 }   // descending
+            }
+        }
+        k = k + 1
+    }
+    0
+}
+
+/// Stable multi-key sort with a per-key direction: dirs[k] >= 0 sorts key k ascending, otherwise
+/// descending (so you can mix, e.g. sort by col A ascending then col B descending). Up to 8 keys.
+pub fn df_sort_by_keys_dir(df: &DataFrame, keys: &[i64; 8], dirs: &[i64; 8], n_keys: i64) -> DataFrame
+    with Mut, Div, Panic
+{
+    let nr = df_nrows(df)
+    let nc = df_ncols(df)
+    var order: [i64; 1024] = [0; 1024]
+    var i: i64 = 0
+    while i < nr && i < 1024 { order[i as usize] = i; i = i + 1 }
+    i = 1
+    while i < nr && i < 1024 {
+        let cur = order[i as usize]
+        var j: i64 = i - 1
+        while j >= 0 && cmp_rows_dir(df, order[j as usize], cur, keys, dirs, n_keys) > 0 {
+            order[(j + 1) as usize] = order[j as usize]
+            j = j - 1
+        }
+        order[(j + 1) as usize] = cur
+        i = i + 1
+    }
+    var out = df_new(nc)
+    i = 0
+    while i < nr && i < 1024 {
+        var row: [f64; 64] = [0.0; 64]
+        var c: i64 = 0
+        while c < nc && c < 64 { row[c as usize] = df_get(df, order[i as usize], c); c = c + 1 }
+        df_add_row(&!out, &row)
+        i = i + 1
+    }
+    out
+}
+
+/// Stable multi-key sort with every key descending (convenience over df_sort_by_keys_dir).
+pub fn df_sort_by_keys_desc(df: &DataFrame, keys: &[i64; 8], n_keys: i64) -> DataFrame
+    with Mut, Div, Panic
+{
+    var dirs: [i64; 8] = [0 - 1, 0 - 1, 0 - 1, 0 - 1, 0 - 1, 0 - 1, 0 - 1, 0 - 1]
+    df_sort_by_keys_dir(df, keys, &dirs, n_keys)
+}

--- a/tests/stdlib/data/test_dataframe_sort_desc_stdlib.sio
+++ b/tests/stdlib/data/test_dataframe_sort_desc_stdlib.sio
@@ -1,0 +1,42 @@
+// Run-proof for stdlib data::dataframe_sort descending / mixed-direction sort.
+// Rows [dept, priority, id]; verify all-descending and mixed (dept ASC, priority DESC). lean_single.
+use data::dataframe::*
+use data::dataframe_sort::*
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn add3(df: &!DataFrame, a: f64, b: f64, c: f64) with Mut, Div, Panic { var r: [f64; 64] = [0.0; 64]; r[0]=a; r[1]=b; r[2]=c; df_add_row(df, &r) }
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var df = df_new(3)
+    add3(&!df, 2.0, 1.0, 100.0)
+    add3(&!df, 1.0, 2.0, 101.0)
+    add3(&!df, 2.0, 0.0, 102.0)
+    add3(&!df, 1.0, 1.0, 103.0)
+    add3(&!df, 1.0, 1.0, 104.0)   // ties (1,1)
+    var keys: [i64; 8] = [0, 1, 0, 0, 0, 0, 0, 0]
+    // all descending by (dept, priority): id order 100,102,101,103,104 (103 before 104 = stable)
+    let d = df_sort_by_keys_desc(&df, &keys, 2)
+    if df_nrows(&d) != 5 { print("FAIL desc_rows\n"); return 1 }
+    if ae(df_get(&d,0,2),100.0) >= 1.0e-9 { print("FAIL d0\n"); return 2 }
+    if ae(df_get(&d,1,2),102.0) >= 1.0e-9 { print("FAIL d1\n"); return 3 }
+    if ae(df_get(&d,2,2),101.0) >= 1.0e-9 { print("FAIL d2\n"); return 4 }
+    if ae(df_get(&d,3,2),103.0) >= 1.0e-9 { print("FAIL d3_stable\n"); return 5 }
+    if ae(df_get(&d,4,2),104.0) >= 1.0e-9 { print("FAIL d4\n"); return 6 }
+    // dept is non-increasing after all-desc sort
+    var r: i64 = 1
+    while r < df_nrows(&d) { if df_get(&d,r,0) > df_get(&d,r-1,0) { print("FAIL desc_mono\n"); return 7 } r = r + 1 }
+    // mixed: dept ASC, priority DESC -> id order 101,103,104,100,102
+    var dirs: [i64; 8] = [1, 0 - 1, 0, 0, 0, 0, 0, 0]
+    let m = df_sort_by_keys_dir(&df, &keys, &dirs, 2)
+    if ae(df_get(&m,0,2),101.0) >= 1.0e-9 { print("FAIL m0\n"); return 8 }    // dept1, highest pri
+    if ae(df_get(&m,3,2),100.0) >= 1.0e-9 { print("FAIL m3\n"); return 9 }    // dept2, pri1
+    if ae(df_get(&m,4,2),102.0) >= 1.0e-9 { print("FAIL m4\n"); return 10 }   // dept2, pri0
+    // mixed monotonicity: dept non-decreasing; within dept, priority non-increasing
+    r = 1
+    while r < df_nrows(&m) {
+        let d0=df_get(&m,r-1,0); let d1=df_get(&m,r,0)
+        if d1 < d0 { print("FAIL m_dept\n"); return 11 }
+        if d1 == d0 && df_get(&m,r,1) > df_get(&m,r-1,1) { print("FAIL m_pri\n"); return 12 }
+        r = r + 1
+    }
+    print("DATAFRAME_SORT_DESC_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Descending (and mixed-direction) sort

Extends `data::dataframe_sort` (after the ascending multi-key sort in #1044) with per-key sort **direction**.

| Verb | Semantics |
|---|---|
| `df_sort_by_keys_dir(df, keys, dirs, n_keys)` | `dirs[k] >= 0` → key k ascending, else descending — keys can mix (e.g. `ORDER BY dept ASC, priority DESC`) |
| `df_sort_by_keys_desc(df, keys, n_keys)` | convenience: every key descending |

Still a **stable** insertion sort — rows equal on all keys keep their original order in either direction. Up to 8 keys.

```
rows [dept, priority, id]: (2,1,100)(1,2,101)(2,0,102)(1,1,103)(1,1,104)

all DESC (dept,priority)          -> id 100,102,101,103,104   (103 before 104 = stable)
mixed (dept ASC, priority DESC)   -> id 101,103,104,100,102
```

### Verification
- `scripts/dataframe_sort_desc_gate.sh` → `DATAFRAME_SORT_DESC_GATE_OK`.
- Run-proof checks the all-descending order (with a stable tie), the mixed asc/desc order, and monotonicity of both keys in each direction.
- Math-review (xai/grok): *"correct stable lexicographic sort with mixed asc/desc keys."*

### Notes
- No compiler changes — pure `stdlib/`, passes standalone `souc check`. Driver runs under `SOUNIO_SOUC_ENGINE=lean_single`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)