### PR TITLE
feat(gpu): sedenion S-SSM step on tensor cores + zero-divisor gating (HW-validated GB10)

### DIFF
--- a/docs/gpu/run_sed_ssm_step_ptx.cu
+++ b/docs/gpu/run_sed_ssm_step_ptx.cu
@@ -1,0 +1,42 @@
+// Driver-API harness: load Sounio-emitted PTX, launch sounio_sed_ssm_step, validate (1) random batch
+// vs scalar sedenion reference and (2) zero-divisor gating, on the GB10.
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+static int cds(int a,int b,int bits){ int s=1;
+    while(bits>0){ if(a==0||b==0)return s; if(bits==1)return -s;
+        int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+        if(!ah&&!bh){a=al;b=bl;} else if(!ah&&bh){a=bl;b=al;}
+        else if(ah&&!bh){ if(bl==0){a=al;b=0;} else{s=-s;a=al;b=bl;} }
+        else { if(bl==0){s=-s;a=0;b=al;} else{a=bl;b=al;} } bits--; } return s; }
+static void sm(const float*a,const float*b,float*r){for(int k=0;k<16;k++)r[k]=0;for(int i=0;i<16;i++)for(int j=0;j<16;j++)r[i^j]+=cds(i,j,4)*a[i]*b[j];}
+#define CK(x) do{CUresult e=(x); if(e!=CUDA_SUCCESS){const char*s;cuGetErrorString(e,&s);printf("ERR %s @%d: %s\n",#x,__LINE__,s);return 2;}}while(0)
+int main(int argc,char**argv){
+    const char* ptx = argc>1?argv[1]:"/tmp/sounio_sed_ssm_step.ptx";
+    CK(cuInit(0)); CUdevice dev; CK(cuDeviceGet(&dev,0)); CUcontext ctx;
+    CK(cuDevicePrimaryCtxRetain(&ctx,dev)); CK(cuCtxSetCurrent(ctx));
+    CUmodule mod; CK(cuModuleLoad(&mod,ptx)); CUfunction fn; CK(cuModuleGetFunction(&fn,mod,"sounio_sed_ssm_step"));
+    CUdeviceptr dA,dB,dx,dH,dS;
+    CK(cuMemAlloc(&dA,16*4));CK(cuMemAlloc(&dB,16*4));CK(cuMemAlloc(&dx,16*4));CK(cuMemAlloc(&dH,256*4));CK(cuMemAlloc(&dS,256*4));
+    float hS[256];
+    // (1) random validation
+    unsigned s=1234567; auto rn=[&](){s=s*1103515245+12345; return ((s>>16)&0x7fff)/16384.0f-1.0f;};
+    float A[16],B[16],x[16],H[256]; for(int i=0;i<16;i++){A[i]=rn();B[i]=rn();x[i]=rn();} for(int i=0;i<256;i++)H[i]=rn();
+    CK(cuMemcpyHtoD(dA,A,16*4));CK(cuMemcpyHtoD(dB,B,16*4));CK(cuMemcpyHtoD(dx,x,16*4));CK(cuMemcpyHtoD(dH,H,256*4));
+    void* a1[]={&dA,&dB,&dx,&dH,&dS};
+    CK(cuLaunchKernel(fn,1,1,1,32,1,1,0,0,a1,0)); CK(cuCtxSynchronize()); CK(cuMemcpyDtoH(hS,dS,256*4));
+    int fails=0; float mx=0;
+    for(int b=0;b<16;b++){ float ah[16]; sm(A,&H[b*16],ah);
+        for(int k=0;k<16;k++){ float ref=ah[k]+B[k]*x[b]; float e=fabsf(hS[k*16+b]-ref); if(e>mx)mx=e; if(e>0.05f)fails++; } }
+    // (2) zero-divisor gating: A=(e3+e10), B=0, x=0; col0 h=(e6−e15) annihilates, col1 h=e1 passes
+    float Az[16]={0}; Az[3]=1; Az[10]=1; float Bz[16]={0}, xz[16]={0}, Hz[256]={0};
+    Hz[0*16+6]=1; Hz[0*16+15]=-1; Hz[1*16+1]=1;
+    CK(cuMemcpyHtoD(dA,Az,16*4));CK(cuMemcpyHtoD(dB,Bz,16*4));CK(cuMemcpyHtoD(dx,xz,16*4));CK(cuMemcpyHtoD(dH,Hz,256*4));
+    CK(cuLaunchKernel(fn,1,1,1,32,1,1,0,0,a1,0)); CK(cuCtxSynchronize()); CK(cuMemcpyDtoH(hS,dS,256*4));
+    float gate=0,ctrl=0; for(int k=0;k<16;k++){ gate+=hS[k*16+0]*hS[k*16+0]; ctrl+=hS[k*16+1]*hS[k*16+1]; }
+    gate=sqrtf(gate); ctrl=sqrtf(ctrl);
+    printf("Sounio SEDENION S-SSM step PTX GB10: A⊗H+B·x  mismatch %d/256 maxerr=%.4f\n",fails,mx);
+    printf("  zero-divisor gate: ||(e3+e10)⊗(e6−e15)||=%.4f (~0)  ||(e3+e10)⊗e1||=%.4f (>0)\n",gate,ctrl);
+    if(!fails && gate<0.05f && ctrl>0.5f){ printf("PASS: Sounio-emitted tensor-core sedenion S-SSM step + zero-divisor gating on GB10\n"); return 0; }
+    printf("FAIL\n"); return 1;
+}

--- a/docs/gpu/sed_ssm_step_tc.cu
+++ b/docs/gpu/sed_ssm_step_tc.cu
@@ -1,0 +1,64 @@
+// SEDENION S-SSM linear recurrence step on tensor cores, batched, + zero-divisor gating.
+// For a 16-wide batch of sedenion states H (each 16-dim), the sedenion multiply A⊗H is L16(A)·H —
+// EXACTLY one wmma m16n16k16 tile (bits=4, no padding). Step:  S[k][b] = (A⊗H[:,b])[k] + B[k]·x[b].
+// Two validations on the GB10:
+//   (1) matches the scalar sedenion reference for random A,B,x,H;
+//   (2) ZERO-DIVISOR GATING: with A=(e3+e10) and a state column h=(e6−e15), A⊗h=0 — the zero divisor
+//       acts as a hard gate that annihilates that state direction (canonical sedenion ZD), while other
+//       columns pass through. This is the S-SSM zero-divisor gate realized on tensor cores.
+#include <cstdio>
+#include <cmath>
+#include <cuda_fp16.h>
+#include <mma.h>
+using namespace nvcuda;
+__device__ __host__ int cds(int a,int b,int bits){ int s=1;
+    while(bits>0){ if(a==0||b==0)return s; if(bits==1)return -s;
+        int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+        if(!ah&&!bh){a=al;b=bl;} else if(!ah&&bh){a=bl;b=al;}
+        else if(ah&&!bh){ if(bl==0){a=al;b=0;} else{s=-s;a=al;b=bl;} }
+        else { if(bl==0){s=-s;a=0;b=al;} else{a=bl;b=al;} } bits--; } return s; }
+// L16(A)·H (16x16 · 16x16) then S[k][b] += B[k]*x[b]
+__global__ void sed_step(const float* A,const float* B,const float* x,const float* H,float* S){
+    __shared__ half sL[256], sH[256];
+    int t=threadIdx.x;
+    for(int idx=t; idx<256; idx+=32){ int k=idx>>4,j=idx&15,i=k^j; sL[idx]=__float2half((float)cds(i,j,4)*A[i]); }
+    for(int idx=t; idx<256; idx+=32){ int b=idx>>4,r=idx&15; sH[idx]=__float2half(H[b*16+r]); } // col-major H[b][r]
+    __syncwarp();
+    wmma::fragment<wmma::matrix_a,16,16,16,half,wmma::row_major> aF;
+    wmma::fragment<wmma::matrix_b,16,16,16,half,wmma::col_major> hF;
+    wmma::fragment<wmma::accumulator,16,16,16,float> acc;
+    wmma::fill_fragment(acc,0.f);
+    wmma::load_matrix_sync(aF,sL,16); wmma::load_matrix_sync(hF,sH,16); wmma::mma_sync(acc,aF,hF,acc);
+    wmma::store_matrix_sync(S,acc,16,wmma::mem_row_major);   // S[k*16+b]
+    __syncwarp();
+    if(t==0) for(int b=0;b<16;b++) for(int k=0;k<16;k++) S[k*16+b]+=B[k]*x[b];
+}
+void sm(const float*a,const float*b,float*r){for(int k=0;k<16;k++)r[k]=0;for(int i=0;i<16;i++)for(int j=0;j<16;j++)r[i^j]+=cds(i,j,4)*a[i]*b[j];}
+int main(){
+    float *dA,*dB,*dx,*dH,*dS; cudaMalloc(&dA,16*4);cudaMalloc(&dB,16*4);cudaMalloc(&dx,16*4);cudaMalloc(&dH,256*4);cudaMalloc(&dS,256*4);
+    float hS[256];
+    // (1) random validation
+    unsigned s=1234567; auto rn=[&](){s=s*1103515245+12345; return ((s>>16)&0x7fff)/16384.0f-1.0f;};
+    float A[16],B[16],x[16],H[256]; for(int i=0;i<16;i++){A[i]=rn();B[i]=rn();x[i]=rn();} for(int i=0;i<256;i++)H[i]=rn();
+    cudaMemcpy(dA,A,16*4,cudaMemcpyHostToDevice);cudaMemcpy(dB,B,16*4,cudaMemcpyHostToDevice);
+    cudaMemcpy(dx,x,16*4,cudaMemcpyHostToDevice);cudaMemcpy(dH,H,256*4,cudaMemcpyHostToDevice);
+    sed_step<<<1,32>>>(dA,dB,dx,dH,dS); if(cudaDeviceSynchronize()){printf("ERR\n");return 2;}
+    cudaMemcpy(hS,dS,256*4,cudaMemcpyDeviceToHost);
+    int fails=0; float mx=0;
+    for(int b=0;b<16;b++){ float ah[16]; sm(A,&H[b*16],ah);
+        for(int k=0;k<16;k++){ float ref=ah[k]+B[k]*x[b]; float e=fabsf(hS[k*16+b]-ref); if(e>mx)mx=e; if(e>0.05f)fails++; } }
+    // (2) zero-divisor gating: A=(e3+e10), B=0; column 0 h=(e6−e15) must annihilate, column 1 h=e1 must pass
+    float Az[16]={0}; Az[3]=1; Az[10]=1; float Bz[16]={0}, xz[16]={0}, Hz[256]={0};
+    Hz[0*16+6]=1; Hz[0*16+15]=-1;   // column 0 = e6 − e15  (ZD partner)
+    Hz[1*16+1]=1;                    // column 1 = e1        (control)
+    cudaMemcpy(dA,Az,16*4,cudaMemcpyHostToDevice);cudaMemcpy(dB,Bz,16*4,cudaMemcpyHostToDevice);
+    cudaMemcpy(dx,xz,16*4,cudaMemcpyHostToDevice);cudaMemcpy(dH,Hz,256*4,cudaMemcpyHostToDevice);
+    sed_step<<<1,32>>>(dA,dB,dx,dH,dS); cudaDeviceSynchronize(); cudaMemcpy(hS,dS,256*4,cudaMemcpyDeviceToHost);
+    float gate_norm=0, ctrl_norm=0;
+    for(int k=0;k<16;k++){ gate_norm+=hS[k*16+0]*hS[k*16+0]; ctrl_norm+=hS[k*16+1]*hS[k*16+1]; }
+    gate_norm=sqrtf(gate_norm); ctrl_norm=sqrtf(ctrl_norm);
+    printf("SEDENION S-SSM step tensor-core GB10: A⊗H+B·x  batch mismatch %d/256 maxerr=%.4f\n",fails,mx);
+    printf("  zero-divisor gate: ||(e3+e10)⊗(e6−e15)||=%.4f (expect ~0)  ||(e3+e10)⊗e1||=%.4f (expect >0)\n",gate_norm,ctrl_norm);
+    if(!fails && gate_norm<0.05f && ctrl_norm>0.5f){ printf("PASS: tensor-core sedenion S-SSM step + zero-divisor gating on GB10\n"); return 0; }
+    printf("FAIL\n"); return 1;
+}

--- a/docs/gpu/sounio_sed_ssm_step.ptx
+++ b/docs/gpu/sounio_sed_ssm_step.ptx
@@ -1,0 +1,99 @@
+.version 9.0
+.target sm_121
+.address_size 64
+
+.global .align 4 .b32 sounio_sedsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+.visible .entry sounio_sed_ssm_step(
+    .param .u64 .ptr .align 4 p_A,
+    .param .u64 .ptr .align 4 p_B,
+    .param .u64 .ptr .align 4 p_x,
+    .param .u64 .ptr .align 4 p_H,
+    .param .u64 .ptr .align 4 p_out
+)
+{
+    .reg .pred %p<2>;
+    .reg .b16 %rs<2>;
+    .reg .b32 %r<28>;
+    .reg .f32 %f<12>;
+    .reg .b64 %rd<18>;
+    .shared .align 2 .b8 sL[512];
+    .shared .align 2 .b8 sH[512];
+    ld.param.u64 %rd1, [p_A];
+    ld.param.u64 %rd2, [p_B];
+    ld.param.u64 %rd7, [p_x];
+    ld.param.u64 %rd8, [p_H];
+    ld.param.u64 %rd3, [p_out];
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd9, %rd2;
+    cvta.to.global.u64 %rd10, %rd7;
+    cvta.to.global.u64 %rd5, %rd8;
+    cvta.to.global.u64 %rd6, %rd3;
+    mov.u32 %r18, sL;
+    mov.u32 %r19, sH;
+    mov.u64 %rd14, sounio_sedsgn;
+    mov.u32 %r16, %tid.x;
+    setp.ne.u32 %p1, %r16, 0;
+    @%p1 bra $AFTERBUILD;
+    mov.u32 %r20, 0;
+$BUILD:
+    shr.u32 %r21, %r20, 4;
+    and.b32 %r22, %r20, 15;
+    xor.b32 %r23, %r21, %r22;
+    mul.wide.u32 %rd13, %r23, 4;
+    add.s64 %rd13, %rd4, %rd13;
+    ld.global.f32 %f1, [%rd13];
+    mul.wide.u32 %rd15, %r20, 4;
+    add.s64 %rd15, %rd14, %rd15;
+    ld.global.f32 %f2, [%rd15];
+    mul.f32 %f1, %f1, %f2;
+    cvt.rn.f16.f32 %rs1, %f1;
+    mad.lo.u32 %r24, %r20, 2, %r18;
+    st.shared.u16 [%r24], %rs1;
+    add.u32 %r20, %r20, 1;
+    setp.lt.u32 %p1, %r20, 256;
+    @%p1 bra $BUILD;
+    mov.u32 %r20, 0;
+$STAGE:
+    mul.wide.u32 %rd13, %r20, 4;
+    add.s64 %rd13, %rd5, %rd13;
+    ld.global.f32 %f1, [%rd13];
+    cvt.rn.f16.f32 %rs1, %f1;
+    mad.lo.u32 %r24, %r20, 2, %r19;
+    st.shared.u16 [%r24], %rs1;
+    add.u32 %r20, %r20, 1;
+    setp.lt.u32 %p1, %r20, 256;
+    @%p1 bra $STAGE;
+$AFTERBUILD:
+    bar.sync 0;
+    mov.b32 %r1, 16;
+    mov.f32 %f0, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%r2, %r3, %r4, %r5, %r6, %r7, %r8, %r9}, [%r18], %r1;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%r10, %r11, %r12, %r13, %r14, %r15, %r16, %r17}, [%r19], %r1;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%f2, %f3, %f4, %f5, %f6, %f7, %f8, %f9}, {%r2, %r3, %r4, %r5, %r6, %r7, %r8, %r9}, {%r10, %r11, %r12, %r13, %r14, %r15, %r16, %r17}, {%f0, %f0, %f0, %f0, %f0, %f0, %f0, %f0};
+    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [%rd6], {%f2, %f3, %f4, %f5, %f6, %f7, %f8, %f9}, %r1;
+    bar.sync 0;
+    mov.u32 %r16, %tid.x;
+    setp.ne.u32 %p1, %r16, 0;
+    @%p1 bra $DONE;
+    mov.u32 %r20, 0;
+$PADD:
+    shr.u32 %r21, %r20, 4;
+    and.b32 %r22, %r20, 15;
+    mul.wide.u32 %rd13, %r21, 4;
+    add.s64 %rd13, %rd9, %rd13;
+    ld.global.f32 %f5, [%rd13];
+    mul.wide.u32 %rd13, %r22, 4;
+    add.s64 %rd13, %rd10, %rd13;
+    ld.global.f32 %f6, [%rd13];
+    mul.wide.u32 %rd13, %r20, 4;
+    add.s64 %rd13, %rd6, %rd13;
+    ld.global.f32 %f7, [%rd13];
+    fma.rn.f32 %f7, %f5, %f6, %f7;
+    st.global.f32 [%rd13], %f7;
+    add.u32 %r20, %r20, 1;
+    setp.lt.u32 %p1, %r20, 256;
+    @%p1 bra $PADD;
+$DONE:
+    ret;
+}

--- a/scripts/ci/native_v2_epistemic_accel_spine_gate.sh
+++ b/scripts/ci/native_v2_epistemic_accel_spine_gate.sh
@@ -159,7 +159,9 @@ append_native_algebra_probes() {
     "fn hmma_emit_ossm_oct_step_kernel" \
     ".visible .entry sounio_ossm_oct_step" \
     "fn hmma_emit_ossm_oct_cell_kernel" \
-    ".visible .entry sounio_ossm_oct_cell"
+    ".visible .entry sounio_ossm_oct_cell" \
+    "fn hmma_emit_sed_ssm_step_kernel" \
+    ".visible .entry sounio_sed_ssm_step"
 
   append_source_probe \
     "native_ossm_ptx_emitter" \

--- a/self-hosted/gpu/emit_sed_ssm_step_ptx.sio
+++ b/self-hosted/gpu/emit_sed_ssm_step_ptx.sio
@@ -1,0 +1,138 @@
+// Sounio emitter for the SEDENION S-SSM linear recurrence step on tensor cores (Convention X, bits=4).
+// sounio_sed_ssm_step(A[16],B[16],x[16],H[256],out[256]): for a 16-wide batch of sedenion states H,
+// the sedenion multiply A⊗H is L16(A)·H — EXACTLY one wmma m16n16k16 tile (no padding) — then thread 0
+// adds B·x: S[k][b] = (A⊗H[:,b])[k] + B[k]·x[b]. The cd_sigma sign table σ(k⊕j,j,4) is emitted as a
+// module .global constant and the XOR index i=k⊕j is computed at runtime, so build/stage/post-add are
+// compact PTX loops (fits the emitter buffer). HW-validated on the DGX Spark GB10, incl. zero-divisor gating.
+fn i64_to_string(n: i64) -> string with Mut, Panic, Div, Alloc {
+    if n == 0 { return "0" }
+    var digits = ""
+    var x = n
+    while x > 0 {
+        let d = x - (x / 10) * 10
+        var ch = "0"
+        if d == 1 { ch = "1" }
+        if d == 2 { ch = "2" }
+        if d == 3 { ch = "3" }
+        if d == 4 { ch = "4" }
+        if d == 5 { ch = "5" }
+        if d == 6 { ch = "6" }
+        if d == 7 { ch = "7" }
+        if d == 8 { ch = "8" }
+        if d == 9 { ch = "9" }
+        digits = str_concat(ch, digits)
+        x = x / 10
+    }
+    digits
+}
+fn cd_sigma(a: i64, b: i64, bits: i64) -> i64 {
+    if a == 0 || b == 0 { return 1 }
+    if bits <= 1 { return 0 - 1 }
+    let half = 1 << (bits - 1)
+    let a_hi = if a >= half { 1 } else { 0 }
+    let b_hi = if b >= half { 1 } else { 0 }
+    let a_lo = a & (half - 1)
+    let b_lo = b & (half - 1)
+    if a_hi == 0 && b_hi == 0 { return cd_sigma(a_lo, b_lo, bits - 1) }
+    if a_hi == 0 && b_hi == 1 { return cd_sigma(b_lo, a_lo, bits - 1) }
+    if a_hi == 1 && b_hi == 0 {
+        if b_lo == 0 { return cd_sigma(a_lo, 0, bits - 1) }
+        return 0 - cd_sigma(a_lo, b_lo, bits - 1)
+    }
+    if b_lo == 0 { return 0 - cd_sigma(0, a_lo, bits - 1) }
+    cd_sigma(b_lo, a_lo, bits - 1)
+}
+fn frag(prefix: string, start: i64, count: i64) -> string with Mut, Panic, Div, Alloc {
+    var s = "{"
+    var i: i64 = 0
+    while i < count {
+        if i > 0 { s = str_concat(s, ", ") }
+        s = str_concat(str_concat(s, prefix), i64_to_string(start + i))
+        i = i + 1
+    }
+    str_concat(s, "}")
+}
+fn main() with IO, Mut, Panic, Div, Alloc {
+    print(".version 9.0\n")
+    print(".target sm_121\n")
+    print(".address_size 64\n\n")
+    // sign table: sedsgn[k*16+j] = σ(k⊕j, j, 4) as f32 ±1
+    print(".global .align 4 .b32 sounio_sedsgn[256] = {")
+    var idx: i64 = 0
+    while idx < 256 {
+        let k = idx >> 4
+        let j = idx & 15
+        let i = k ^ j
+        if idx > 0 { print(", ") }
+        if cd_sigma(i, j, 4) < 0 { print("0fBF800000") } else { print("0f3F800000") }
+        idx = idx + 1
+    }
+    print("};\n\n")
+    print(".visible .entry sounio_sed_ssm_step(\n")
+    print("    .param .u64 .ptr .align 4 p_A,\n")
+    print("    .param .u64 .ptr .align 4 p_B,\n")
+    print("    .param .u64 .ptr .align 4 p_x,\n")
+    print("    .param .u64 .ptr .align 4 p_H,\n")
+    print("    .param .u64 .ptr .align 4 p_out\n)\n{\n")
+    print("    .reg .pred %p<2>;\n")
+    print("    .reg .b16 %rs<2>;\n")
+    print("    .reg .b32 %r<28>;\n")
+    print("    .reg .f32 %f<12>;\n")
+    print("    .reg .b64 %rd<18>;\n")
+    print("    .shared .align 2 .b8 sL[512];\n")
+    print("    .shared .align 2 .b8 sH[512];\n")
+    print("    ld.param.u64 %rd1, [p_A];\n")
+    print("    ld.param.u64 %rd2, [p_B];\n")
+    print("    ld.param.u64 %rd7, [p_x];\n")
+    print("    ld.param.u64 %rd8, [p_H];\n")
+    print("    ld.param.u64 %rd3, [p_out];\n")
+    print("    cvta.to.global.u64 %rd4, %rd1;\n")
+    print("    cvta.to.global.u64 %rd9, %rd2;\n")
+    print("    cvta.to.global.u64 %rd10, %rd7;\n")
+    print("    cvta.to.global.u64 %rd5, %rd8;\n")
+    print("    cvta.to.global.u64 %rd6, %rd3;\n")
+    print("    mov.u32 %r18, sL;\n")
+    print("    mov.u32 %r19, sH;\n")
+    print("    mov.u64 %rd14, sounio_sedsgn;\n")
+    print("    mov.u32 %r16, %tid.x;\n")
+    print("    setp.ne.u32 %p1, %r16, 0;\n")
+    print("    @%p1 bra $AFTERBUILD;\n")
+    // build L(A): sL[idx] = σ(k⊕j,j,4) * A[k⊕j], idx=k*16+j
+    print("    mov.u32 %r20, 0;\n$BUILD:\n")
+    print("    shr.u32 %r21, %r20, 4;\n")
+    print("    and.b32 %r22, %r20, 15;\n")
+    print("    xor.b32 %r23, %r21, %r22;\n")
+    print("    mul.wide.u32 %rd13, %r23, 4;\n    add.s64 %rd13, %rd4, %rd13;\n    ld.global.f32 %f1, [%rd13];\n")
+    print("    mul.wide.u32 %rd15, %r20, 4;\n    add.s64 %rd15, %rd14, %rd15;\n    ld.global.f32 %f2, [%rd15];\n")
+    print("    mul.f32 %f1, %f1, %f2;\n    cvt.rn.f16.f32 %rs1, %f1;\n")
+    print("    mad.lo.u32 %r24, %r20, 2, %r18;\n    st.shared.u16 [%r24], %rs1;\n")
+    print("    add.u32 %r20, %r20, 1;\n    setp.lt.u32 %p1, %r20, 256;\n    @%p1 bra $BUILD;\n")
+    // stage H col-major (H[b*16+r] already contiguous): sH[idx]=half(H[idx])
+    print("    mov.u32 %r20, 0;\n$STAGE:\n")
+    print("    mul.wide.u32 %rd13, %r20, 4;\n    add.s64 %rd13, %rd5, %rd13;\n    ld.global.f32 %f1, [%rd13];\n")
+    print("    cvt.rn.f16.f32 %rs1, %f1;\n")
+    print("    mad.lo.u32 %r24, %r20, 2, %r19;\n    st.shared.u16 [%r24], %rs1;\n")
+    print("    add.u32 %r20, %r20, 1;\n    setp.lt.u32 %p1, %r20, 256;\n    @%p1 bra $STAGE;\n")
+    print("$AFTERBUILD:\n")
+    print("    bar.sync 0;\n")
+    print("    mov.b32 %r1, 16;\n")
+    print("    mov.f32 %f0, 0f00000000;\n")
+    // AH = L(A)·H : one wmma 16x16x16 tile
+    print("    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 ") print(frag("%r", 2, 8)) print(", [%r18], %r1;\n")
+    print("    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 ") print(frag("%r", 10, 8)) print(", [%r19], %r1;\n")
+    print("    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 ") print(frag("%f", 2, 8)) print(", ") print(frag("%r", 2, 8)) print(", ") print(frag("%r", 10, 8))
+    print(", {%f0, %f0, %f0, %f0, %f0, %f0, %f0, %f0};\n")
+    print("    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [%rd6], ") print(frag("%f", 2, 8)) print(", %r1;\n")
+    print("    bar.sync 0;\n")
+    // thread 0: S[k*16+b] += B[k]*x[b]
+    print("    mov.u32 %r16, %tid.x;\n    setp.ne.u32 %p1, %r16, 0;\n    @%p1 bra $DONE;\n")
+    print("    mov.u32 %r20, 0;\n$PADD:\n")
+    print("    shr.u32 %r21, %r20, 4;\n")
+    print("    and.b32 %r22, %r20, 15;\n")
+    print("    mul.wide.u32 %rd13, %r21, 4;\n    add.s64 %rd13, %rd9, %rd13;\n    ld.global.f32 %f5, [%rd13];\n")
+    print("    mul.wide.u32 %rd13, %r22, 4;\n    add.s64 %rd13, %rd10, %rd13;\n    ld.global.f32 %f6, [%rd13];\n")
+    print("    mul.wide.u32 %rd13, %r20, 4;\n    add.s64 %rd13, %rd6, %rd13;\n    ld.global.f32 %f7, [%rd13];\n")
+    print("    fma.rn.f32 %f7, %f5, %f6, %f7;\n    st.global.f32 [%rd13], %f7;\n")
+    print("    add.u32 %r20, %r20, 1;\n    setp.lt.u32 %p1, %r20, 256;\n    @%p1 bra $PADD;\n")
+    print("$DONE:\n    ret;\n}\n")
+}

--- a/self-hosted/gpu/kernels/hmma_signs.sio
+++ b/self-hosted/gpu/kernels/hmma_signs.sio
@@ -752,3 +752,82 @@ pub fn hmma_emit_ossm_oct_cell_kernel(s: HypercomplexPtxState) -> HypercomplexPt
     out = hc_push_str(out, "    ret;\n}\n")
     out
 }
+
+// ============================================================================
+// SEDENION S-SSM linear recurrence step on tensor cores (16×16 exact tile) + zero-divisor gating
+// ============================================================================
+
+// Emits sounio_sed_ssm_step(A,B,x,H,out): for a 16-wide batch of sedenion states H, the sedenion
+// multiply A⊗H is L16(A)·H — EXACTLY one wmma m16n16k16 tile (bits=4, no padding) — then thread 0 adds
+// B·x: S[k][b] = (A⊗H[:,b])[k] + B[k]·x[b]. The cd_sigma sign table σ(k⊕j,j,4) is emitted as a module
+// .global constant (hmma_sed_left_mul_sign) and the XOR index i=k⊕j is computed at runtime, so
+// build/stage/post-add are compact PTX loops. This is the sedenion counterpart of the octonion step
+// (sounio_ossm_oct_step) — the S-SSM linear recurrence. HW-validated on the DGX Spark GB10, including
+// the zero-divisor GATE: A=(e3+e10) annihilates the state direction (e6−e15) (||·||=0) while e1 passes.
+pub fn hmma_emit_sed_ssm_step_kernel(s: HypercomplexPtxState) -> HypercomplexPtxState with Mut, Panic, Div, Alloc {
+    var out = hc_push_str(s, ".version 9.0\n.target sm_121\n.address_size 64\n\n")
+    // sign table: sedsgn[k*16+j] = σ(k⊕j,j,4) as f32 ±1
+    out = hc_push_str(out, ".global .align 4 .b32 sounio_sedsgn[256] = {")
+    var idx: i64 = 0
+    while idx < 256 {
+        let k = idx >> 4
+        let j = idx & 15
+        if idx > 0 { out = hc_push_str(out, ", ") }
+        if hmma_sed_left_mul_sign(k, j) < 0 { out = hc_push_str(out, "0fBF800000") } else { out = hc_push_str(out, "0f3F800000") }
+        idx = idx + 1
+    }
+    out = hc_push_str(out, "};\n\n")
+    out = hc_push_str(out, ".visible .entry sounio_sed_ssm_step(\n")
+    out = hc_push_str(out, "    .param .u64 .ptr .align 4 p_A,\n    .param .u64 .ptr .align 4 p_B,\n")
+    out = hc_push_str(out, "    .param .u64 .ptr .align 4 p_x,\n    .param .u64 .ptr .align 4 p_H,\n")
+    out = hc_push_str(out, "    .param .u64 .ptr .align 4 p_out\n)\n{\n")
+    out = hc_push_str(out, "    .reg .pred %p<2>;\n    .reg .b16 %rs<2>;\n    .reg .b32 %r<28>;\n")
+    out = hc_push_str(out, "    .reg .f32 %f<12>;\n    .reg .b64 %rd<18>;\n")
+    out = hc_push_str(out, "    .shared .align 2 .b8 sL[512];\n    .shared .align 2 .b8 sH[512];\n")
+    out = hc_push_str(out, "    ld.param.u64 %rd1, [p_A];\n    ld.param.u64 %rd2, [p_B];\n")
+    out = hc_push_str(out, "    ld.param.u64 %rd7, [p_x];\n    ld.param.u64 %rd8, [p_H];\n    ld.param.u64 %rd3, [p_out];\n")
+    out = hc_push_str(out, "    cvta.to.global.u64 %rd4, %rd1;\n    cvta.to.global.u64 %rd9, %rd2;\n")
+    out = hc_push_str(out, "    cvta.to.global.u64 %rd10, %rd7;\n    cvta.to.global.u64 %rd5, %rd8;\n    cvta.to.global.u64 %rd6, %rd3;\n")
+    out = hc_push_str(out, "    mov.u32 %r18, sL;\n    mov.u32 %r19, sH;\n    mov.u64 %rd14, sounio_sedsgn;\n")
+    out = hc_push_str(out, "    mov.u32 %r16, %tid.x;\n    setp.ne.u32 %p1, %r16, 0;\n    @%p1 bra $AFTERBUILD;\n")
+    // build L(A): sL[idx] = σ(k⊕j,j,4) * A[k⊕j]
+    out = hc_push_str(out, "    mov.u32 %r20, 0;\n$BUILD:\n")
+    out = hc_push_str(out, "    shr.u32 %r21, %r20, 4;\n    and.b32 %r22, %r20, 15;\n    xor.b32 %r23, %r21, %r22;\n")
+    out = hc_push_str(out, "    mul.wide.u32 %rd13, %r23, 4;\n    add.s64 %rd13, %rd4, %rd13;\n    ld.global.f32 %f1, [%rd13];\n")
+    out = hc_push_str(out, "    mul.wide.u32 %rd15, %r20, 4;\n    add.s64 %rd15, %rd14, %rd15;\n    ld.global.f32 %f2, [%rd15];\n")
+    out = hc_push_str(out, "    mul.f32 %f1, %f1, %f2;\n    cvt.rn.f16.f32 %rs1, %f1;\n")
+    out = hc_push_str(out, "    mad.lo.u32 %r24, %r20, 2, %r18;\n    st.shared.u16 [%r24], %rs1;\n")
+    out = hc_push_str(out, "    add.u32 %r20, %r20, 1;\n    setp.lt.u32 %p1, %r20, 256;\n    @%p1 bra $BUILD;\n")
+    // stage H col-major (H[b*16+r] contiguous): sH[idx]=half(H[idx])
+    out = hc_push_str(out, "    mov.u32 %r20, 0;\n$STAGE:\n")
+    out = hc_push_str(out, "    mul.wide.u32 %rd13, %r20, 4;\n    add.s64 %rd13, %rd5, %rd13;\n    ld.global.f32 %f1, [%rd13];\n")
+    out = hc_push_str(out, "    cvt.rn.f16.f32 %rs1, %f1;\n")
+    out = hc_push_str(out, "    mad.lo.u32 %r24, %r20, 2, %r19;\n    st.shared.u16 [%r24], %rs1;\n")
+    out = hc_push_str(out, "    add.u32 %r20, %r20, 1;\n    setp.lt.u32 %p1, %r20, 256;\n    @%p1 bra $STAGE;\n")
+    out = hc_push_str(out, "$AFTERBUILD:\n    bar.sync 0;\n    mov.b32 %r1, 16;\n    mov.f32 %f0, 0f00000000;\n")
+    out = hc_push_str(out, "    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 ")
+    out = hmma_emit_frag_list(out, "%r", 2, 8)
+    out = hc_push_str(out, ", [%r18], %r1;\n    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 ")
+    out = hmma_emit_frag_list(out, "%r", 10, 8)
+    out = hc_push_str(out, ", [%r19], %r1;\n    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 ")
+    out = hmma_emit_frag_list(out, "%f", 2, 8)
+    out = hc_push_str(out, ", ")
+    out = hmma_emit_frag_list(out, "%r", 2, 8)
+    out = hc_push_str(out, ", ")
+    out = hmma_emit_frag_list(out, "%r", 10, 8)
+    out = hc_push_str(out, ", {%f0, %f0, %f0, %f0, %f0, %f0, %f0, %f0};\n")
+    out = hc_push_str(out, "    wmma.store.d.sync.aligned.row.m16n16k16.global.f32 [%rd6], ")
+    out = hmma_emit_frag_list(out, "%f", 2, 8)
+    out = hc_push_str(out, ", %r1;\n    bar.sync 0;\n")
+    // thread 0: S[k*16+b] += B[k]*x[b]
+    out = hc_push_str(out, "    mov.u32 %r16, %tid.x;\n    setp.ne.u32 %p1, %r16, 0;\n    @%p1 bra $DONE;\n")
+    out = hc_push_str(out, "    mov.u32 %r20, 0;\n$PADD:\n")
+    out = hc_push_str(out, "    shr.u32 %r21, %r20, 4;\n    and.b32 %r22, %r20, 15;\n")
+    out = hc_push_str(out, "    mul.wide.u32 %rd13, %r21, 4;\n    add.s64 %rd13, %rd9, %rd13;\n    ld.global.f32 %f5, [%rd13];\n")
+    out = hc_push_str(out, "    mul.wide.u32 %rd13, %r22, 4;\n    add.s64 %rd13, %rd10, %rd13;\n    ld.global.f32 %f6, [%rd13];\n")
+    out = hc_push_str(out, "    mul.wide.u32 %rd13, %r20, 4;\n    add.s64 %rd13, %rd6, %rd13;\n    ld.global.f32 %f7, [%rd13];\n")
+    out = hc_push_str(out, "    fma.rn.f32 %f7, %f5, %f6, %f7;\n    st.global.f32 [%rd13], %f7;\n")
+    out = hc_push_str(out, "    add.u32 %r20, %r20, 1;\n    setp.lt.u32 %p1, %r20, 256;\n    @%p1 bra $PADD;\n")
+    out = hc_push_str(out, "$DONE:\n    ret;\n}\n")
+    out
+}


### PR DESCRIPTION
## What

The **sedenion counterpart** of the octonion O-SSM linear step (#1042). For a 16-wide batch of
sedenion states `H` (each 16-dim), the sedenion multiply `A⊗H` is `L16(A)·H` — **exactly one wmma
m16n16k16 tile** (bits=4, no padding) — then thread 0 adds `B·x`:
`S[k][b] = (A⊗H[:,b])[k] + B[k]·x[b]`.

The `cd_sigma` sign table `σ(k⊕j,j,4)` is emitted as a module `.global` constant
(`hmma_sed_left_mul_sign`) and the XOR index `i=k⊕j` is computed **at runtime**, so build/stage/post-add
are compact PTX loops — the emitted kernel is ~6 KB (vs ~100 KB fully unrolled), fitting the emitter
buffer.

## Zero-divisor gating

The sedenions carry zero divisors. This kernel realizes the **S-SSM zero-divisor gate** on tensor cores:
with `A=(e3+e10)`, the state direction `(e6−e15)` is annihilated while `e1` passes through — a hard,
algebraic gate.

## Contents

- **`hmma_signs.sio`** — `hmma_emit_sed_ssm_step_kernel` emits `sounio_sed_ssm_step(A,B,x,H,out)`.
- **`emit_sed_ssm_step_ptx.sio`** — standalone Sounio driver (byte-identical PTX).
- **`docs/gpu/`** — CUDA proof `sed_ssm_step_tc.cu`, Driver-API harness `run_sed_ssm_step_ptx.cu`,
  emitted `sounio_sed_ssm_step.ptx`.
- **spine gate** — pins `hmma_emit_sed_ssm_step_kernel` + `.visible .entry sounio_sed_ssm_step`.

## Hardware validation (DGX Spark GB10, sm_121, CUDA 13.0)

```
Sounio SEDENION S-SSM step PTX GB10: A⊗H+B·x  mismatch 0/256 maxerr=0.0009
  zero-divisor gate: ||(e3+e10)⊗(e6−e15)||=0.0000 (~0)  ||(e3+e10)⊗e1||=1.4142 (>0)
PASS: Sounio-emitted tensor-core sedenion S-SSM step + zero-divisor gating on GB10
```

## Convention

Convention X (`cd_sigma`, bits=4) throughout. Reuses `hmma_sed_left_mul_sign` from the merged sed-mul
kernel (#1031). Sibling of the octonion step #1042 and full cell #1048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)