### PR TITLE
fix(ci): enforce compile-fail diagnostic contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
         run: bash scripts/ci/madaros_changed_tests_selftest.sh
       - name: Executable payload comparator self-test
         run: bash scripts/ci/executable_payload_compare_selftest.sh
+      - name: Compile-fail harness contract
+        run: bash scripts/ci/compile_fail_harness_contract_gate.sh
       - name: Output-path invariants
         run: bash scripts/dev/check_outpath_invariant.sh
       - name: Output-path leading-dash guard

--- a/scripts/ci/compile_fail_harness_contract_gate.sh
+++ b/scripts/ci/compile_fail_harness_contract_gate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/scripts/dev/run_sio_test_suite_v2.sh"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sounio-compile-fail-contract.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+bash -n "$RUNNER"
+
+FIXTURE="$WORK_DIR/compile_fail_contract.sio"
+TEST_LIST="$WORK_DIR/tests.txt"
+cat >"$FIXTURE" <<'EOF'
+//@ compile-fail
+//@ error-pattern: expected compiler diagnostic
+//@ timeout: 1
+
+fn main() {}
+EOF
+printf '%s\n' "$FIXTURE" >"$TEST_LIST"
+
+cat >"$WORK_DIR/diagnostic-souc" <<'EOF'
+#!/usr/bin/env bash
+printf 'expected compiler diagnostic\n' >&2
+exit 1
+EOF
+
+cat >"$WORK_DIR/wrong-diagnostic-souc" <<'EOF'
+#!/usr/bin/env bash
+printf 'different compiler failure\n' >&2
+exit 1
+EOF
+
+cat >"$WORK_DIR/signal-souc" <<'EOF'
+#!/usr/bin/env bash
+printf 'expected compiler diagnostic\n' >&2
+kill -s SEGV "$$"
+EOF
+
+cat >"$WORK_DIR/timeout-souc" <<'EOF'
+#!/usr/bin/env bash
+sleep 5
+EOF
+
+chmod +x "$WORK_DIR"/*-souc
+
+run_harness() {
+  local compiler="$1"
+  local log="$2"
+
+  if SOUNIO_TEST_SOUC_BIN="$compiler" SOUNIO_TEST_JOBS=1 \
+      bash "$RUNNER" --test-list "$TEST_LIST" --jobs 1 >"$log" 2>&1; then
+    HARNESS_RC=0
+  else
+    HARNESS_RC=$?
+  fi
+}
+
+expect_failure() {
+  local label="$1"
+  local expected="$2"
+  local log="$3"
+
+  if [[ "$HARNESS_RC" -eq 0 ]]; then
+    echo "compile-fail harness: ${label} was accepted" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  if ! grep -Fq "$expected" "$log"; then
+    echo "compile-fail harness: ${label} did not report: ${expected}" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+}
+
+run_harness "$WORK_DIR/diagnostic-souc" "$WORK_DIR/diagnostic.log"
+if [[ "$HARNESS_RC" -ne 0 ]]; then
+  echo 'compile-fail harness: matching diagnostic was rejected' >&2
+  cat "$WORK_DIR/diagnostic.log" >&2
+  exit 1
+fi
+grep -Fxq 'All tests passed!' "$WORK_DIR/diagnostic.log"
+
+run_harness "$WORK_DIR/wrong-diagnostic-souc" "$WORK_DIR/wrong-diagnostic.log"
+expect_failure 'wrong diagnostic' 'missing error: expected compiler diagnostic' "$WORK_DIR/wrong-diagnostic.log"
+
+run_harness "$WORK_DIR/signal-souc" "$WORK_DIR/signal.log"
+expect_failure 'signal termination' 'compile terminated by signal 11 (exit 139)' "$WORK_DIR/signal.log"
+
+run_harness "$WORK_DIR/timeout-souc" "$WORK_DIR/timeout.log"
+expect_failure 'timeout' 'compile timed out after 1s' "$WORK_DIR/timeout.log"
+
+echo 'COMPILE_FAIL_HARNESS_CONTRACT_PASS'

--- a/scripts/dev/run_sio_test_suite_v2.sh
+++ b/scripts/dev/run_sio_test_suite_v2.sh
@@ -8,7 +8,7 @@
 #
 # Annotations:
 #   //@ run-pass              — expect exit 0
-#   //@ compile-fail          — expect exit != 0
+#   //@ compile-fail          — expect a compiler diagnostic, not a timeout or signal
 #   //@ ignore                — skip this test
 #   //@ check-only            — compile only, do not execute
 #   //@ expect-stdout: X      — stdout must contain X (run-pass only)
@@ -304,7 +304,7 @@ run_test() {
         if [[ "$line" =~ "//@ expect-stdout:\ "(.*) ]]; then
             expect_stdout+=("${BASH_REMATCH[1]}")
         fi
-        if [[ "$line" =~ "//@ error-pattern:\ "(.*) ]]; then
+        if [[ "$line" =~ ^[[:space:]]*//@[[:space:]]*error-pattern:[[:space:]]*(.*)$ ]]; then
             error_patterns+=("${BASH_REMATCH[1]}")
         fi
     done < "$file"
@@ -347,22 +347,36 @@ run_test() {
         
     elif $is_compile_fail; then
         local tmp_out
+        local compile_exit_code=0
+        local check_error_patterns=false
         tmp_out="$(mktemp /tmp/sounio-cf-XXXXXX.elf)"
-        output=$(timeout "$timeout_val" "$SOUC_BIN" compile "$file" -o "$tmp_out" 2>&1) || exit_code=$?
+        output=$(timeout "$timeout_val" "$SOUC_BIN" compile "$file" -o "$tmp_out" 2>&1) || compile_exit_code=$?
         rm -f "$tmp_out"
-        
-        if [[ $exit_code -eq 124 ]]; then
+
+        if [[ $compile_exit_code -eq 124 ]]; then
             test_output="compile timed out after ${timeout_val}s"
-        elif [[ $exit_code -eq 0 ]] && echo "$output" | grep -qF "typecheck: failed"; then
             exit_code=1
-        elif [[ $exit_code -eq 0 ]]; then
+        # Shells encode signal termination as 128 + signal. A crash is never
+        # a valid compile-fail rejection, even when its output matches.
+        elif [[ $compile_exit_code -ge 128 && $compile_exit_code -le 192 ]]; then
+            local signal_num=$((compile_exit_code - 128))
+            test_output="compile terminated by signal ${signal_num} (exit ${compile_exit_code})"
+            exit_code=1
+        elif [[ $compile_exit_code -ge 125 && $compile_exit_code -le 127 ]]; then
+            test_output="compile harness exited ${compile_exit_code}"
+            exit_code=1
+        elif [[ $compile_exit_code -eq 0 ]] && echo "$output" | grep -qF "typecheck: failed"; then
+            check_error_patterns=true
+            exit_code=0
+        elif [[ $compile_exit_code -eq 0 ]]; then
             test_output="expected compile failure but passed"
             exit_code=1
         else
-            exit_code=0  # Reset - compile failure is expected
+            check_error_patterns=true
+            exit_code=0
         fi
 
-        if [[ $exit_code -ne 124 && $test_output != "expected compile failure but passed" ]]; then
+        if $check_error_patterns; then
             for pattern in "${error_patterns[@]}"; do
                 if ! echo "$output" | grep -qiF "$pattern"; then
                     exit_code=1
@@ -370,9 +384,6 @@ run_test() {
                     break
                 fi
             done
-            if [[ -z "$test_output" ]]; then
-                exit_code=0  # Reset - compile failure is expected
-            fi
         fi
     fi
     

--- a/tests/known_failures/hardened_diagnostics_full_suite.txt
+++ b/tests/known_failures/hardened_diagnostics_full_suite.txt
@@ -11,6 +11,39 @@
 # "refinement type violation" for the case again.
 tests/compile-fail/refinement_f64_return_violation.sio
 
+# Added 2026-07-17: the compile-fail harness now parses and asserts every
+# declared error-pattern. These stage2-native fixtures reject compilation but
+# do not yet emit their declared diagnostic text. Keep them as explicit xfails
+# while compiler lanes repair the diagnostic contract; do not weaken the
+# harness or remove these entries until the declared pattern is observed.
+tests/compile-fail/acquisition_reason_requires_plan.sio
+tests/compile-fail/alternative_option_requires_set.sio
+tests/compile-fail/alternative_reason_requires_option.sio
+tests/compile-fail/contest_witness_wrong_operand.sio
+tests/compile-fail/deferral_reason_requires_deferred.sio
+tests/compile-fail/epistemic_epsilon_mismatch.sio
+tests/compile-fail/f128_f256_implicit_conversion_unimplemented.sio
+tests/compile-fail/f128_nested_knowledge_reserved.sio
+tests/compile-fail/knowledge_no_silent_unwrap.sio
+tests/compile-fail/rebracket_authority_unrelated_ontology_obligation.sio
+tests/compile-fail/recourse_reason_requires_plan.sio
+tests/compile-fail/refinement_subtype_strict.sio
+tests/compile-fail/sample_requires_sampling_effect.sio
+tests/compile-fail/tuple_pattern_arity_e213.sio
+tests/compile-fail/tuple_signature_param_arity_mismatch.sio
+tests/compile-fail/tuple_signature_param_type_mismatch.sio
+tests/compile-fail/unit_literal_clinical_reject_mass_as_amount_concentration.sio
+tests/compile-fail/zero_event_direct_erased_construction.sio
+tests/compile-fail/zero_event_direct_receipt_construction.sio
+tests/ui/ownership/call_boundary_failed_explicit_release_guard.sio
+tests/ui/ownership/call_boundary_failed_explicit_release_guard_mirror.sio
+tests/ui/ownership/call_boundary_failed_implicit_release_guard.sio
+tests/ui/type/extra_args.sio
+tests/ui/type/mismatch_return.sio
+tests/ui/type/tuple_signature_arg_arity.sio
+tests/ui/type/tuple_signature_arg_type.sio
+tests/ui/type/wrong_arg_count.sio
+
 # Re-opened 2026-06-12: the GitHub full-suite job now exercises the Linux
 # native artifact through scripts/ci/souc-native-wrapper.sh instead of invoking
 # a raw ELF as if it had subcommands. That restored coverage from a harness


### PR DESCRIPTION
## Summary

- Enforce each declared `//@ error-pattern` in the v2 compile-fail runner.
- Reject timeouts, harness failures, and signal termination instead of treating them as expected compiler rejection.
- Add a deterministic CI contract gate for matching diagnostics, wrong diagnostics, SIGSEGV, and timeout.
- Classify the 27 stage2-native diagnostic mismatches exposed by the new contract as named full-suite xfails.

Fixes #444.

## Root Cause

The v2 runner's error-pattern extraction regex left the pattern list empty. It also reset every non-timeout nonzero compile status to success, so an exit 139 SIGSEGV could satisfy a compile-fail fixture even when no compiler diagnostic had been validated.

## Validation

- `bash scripts/ci/compile_fail_harness_contract_gate.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash -n scripts/dev/run_sio_test_suite_v2.sh`
- `bash -n scripts/ci/compile_fail_harness_contract_gate.sh`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/ci.yml", encoding="utf-8")); print("ci.yml parsed")'`
- `SOUNIO_TEST_JOBS=1 bash scripts/run_sio_test_suite.sh --filter-exact parser_rust_let_mut.sio --verbose --jobs 1`
- Synthetic JUnit manifest-load check with a temporary rejecting wrapper: 101 known failures and 0 failures
- `git diff --check`

## Residual Diagnostic Backlog

The first remote full-suite run exposed 27 compile-fail/UI fixtures whose stage2-native compiler output does not contain their declared diagnostic text. They are now explicit xfails in `tests/known_failures/hardened_diagnostics_full_suite.txt`; the harness remains strict and must not be weakened to make them pass.

## Blocker Record

```text
Blocker-ID: BLK-20260717-compile-fail-harness-contract
Status: merge-ready
Severity: B1
Class: harness-routing
Owner: Codex
Lane: compile-fail-harness-contract
Worktree: /tmp/sounio-compile-fail-contract-20260717
Branch: codex/compile-fail-contract-20260717
Files-Owned: scripts/dev/run_sio_test_suite_v2.sh, scripts/ci/compile_fail_harness_contract_gate.sh, .github/workflows/ci.yml, tests/known_failures/hardened_diagnostics_full_suite.txt
Files-Read-Only: scripts/lib/resolve_souc.sh, tests/compile-fail/parser_rust_let_mut.sio
Do-Not-Touch: scripts/run_sio_test_suite.sh, scripts/lib/resolve_souc.sh
Repro: bash scripts/ci/compile_fail_harness_contract_gate.sh
Observed: a matching signal exit and an error-pattern mismatch could both be accepted as compile-fail passes
Expected: only a diagnostic rejection matching every declared error-pattern may pass; timeout, harness exit, and signal termination fail
Acceptance-Gate: bash scripts/ci/compile_fail_harness_contract_gate.sh
Evidence-Level: E4
Evidence: first remote Full Test Suite classified 27 stale diagnostic-pattern mismatches; https://github.com/Sounio-lang/sounio/actions/runs/29554999248 confirms Contracts, Full Test Suite, and CI Decision green
Fallback-Path: none
Legacy-Kept: yes; the v1 runner is intentionally untouched
LLM-Offload: not-required
Next-Action: human review and merge decision; keep the PR draft until promoted explicitly
```

```text
Blocker-ID: BLK-20260717-stage2-diagnostic-pattern-backlog
Status: classified
Severity: B1
Class: compiler-semantics
Owner: Codex
Lane: stage2-diagnostic-contract-triage
Worktree: /tmp/sounio-compile-fail-contract-20260717
Branch: codex/compile-fail-contract-20260717
Files-Owned: tests/known_failures/hardened_diagnostics_full_suite.txt
Files-Read-Only: affected tests/compile-fail and tests/ui fixtures
Do-Not-Touch: compiler semantic sources in this harness lane
Repro: remote Full Test Suite run 29554394979
Observed: 27 fixtures reject compilation but miss their declared error-pattern under the stage2-native artifact
Expected: each fixture emits every declared pattern and can be removed from the xfail manifest
Acceptance-Gate: Full Test Suite with no corresponding manifest entry
Evidence-Level: E4
Evidence: https://github.com/Sounio-lang/sounio/actions/runs/29554394979 exposed the 27 mismatches; https://github.com/Sounio-lang/sounio/actions/runs/29554999248 confirms their explicit xfail classification
Fallback-Path: audited xfail manifest; no silent pass
Legacy-Kept: n/a
LLM-Offload: not-required
Next-Action: split the diagnostics by compiler component and remove xfails only with matching stage2-native receipts
```
