### PR TITLE
research(octonion): verified O-SSM/H-SSM probes on the valid octonion table (salvage of #904)

### DIFF
--- a/examples/epistemic/rk4_correlated_uncertainty.sio
+++ b/examples/epistemic/rk4_correlated_uncertainty.sio
@@ -1,0 +1,130 @@
+// rk4_correlated_uncertainty.sio
+//
+// PITFALL + FIX: propagating uncertainty through iterative numerical methods.
+//
+// When you integrate an ODE with RK4 — or run any iterative method (Newton,
+// fixed-point) that reuses the same uncertain quantity across steps — the
+// intermediate values are CORRELATED. The simple independent `Epistemic` type
+// (epistemic::knowledge) propagates variance as Var(a+b) = Var(a) + Var(b),
+// i.e. assuming independence. For correlated intermediates — the four RK4 stage
+// derivatives and both compartments all descend from the same uncertain dose —
+// this OVERESTIMATES the uncertainty and freezes it at the initial value.
+//
+// Use `CorrelatedValue` (epistemic::correlation) instead: it marks a measurement
+// as a shared source (a VarID) and tracks every derived value's sensitivity to
+// it, applying GUM Eq. 14 with the covariance term. (Or use epistemic-autodiff /
+// dual numbers for the exact first-order sensitivity.)
+//
+// Measured here on a 2-compartment linear PK model (dose = 100 +/- 5 mg, RK4 to t = 1):
+//   independent Epistemic   ->  C1 sd = 5.00   (+52 %, wrong: frozen at initial sd)
+//   CorrelatedValue         ->  C1 sd = 3.28   (correct: sd shrinks as drug clears)
+//   Monte-Carlo (100k)      ->  C1 sd = 3.29   (ground truth)
+//
+// Rule of thumb: the independent `Epistemic` type is for INDEPENDENT measurements.
+// For any computation that reuses an uncertain value, reach for `CorrelatedValue`
+// or epistemic-autodiff.
+//
+// Run:
+//   SOUNIO_STDLIB_PATH=$(pwd)/stdlib ./bin/souc run examples/epistemic/rk4_correlated_uncertainty.sio
+
+use epistemic::knowledge::{Epistemic}
+use epistemic::correlation::{CorrelatedValue, correlated_from_source, correlated_independent, add_correlated, sub_correlated, scale_correlated, covariance}
+
+// ── Naive (independent Epistemic) — linear 2-compartment RK4, returns C1(1) sd ──
+fn ni_f1(c1: &Epistemic, c2: &Epistemic) -> Epistemic with Mut, Div, Panic {
+    let t1 = c1.scale(0.0 - 0.5)
+    let t2 = c2.scale(0.3)
+    t1.add(&t2)
+}
+fn ni_f2(c1: &Epistemic, c2: &Epistemic) -> Epistemic with Mut, Div, Panic {
+    let t1 = c1.scale(0.5)
+    let t2 = c2.scale(0.3)
+    t1.sub(&t2)
+}
+fn ni_inc(k1: &Epistemic, k2: &Epistemic, k3: &Epistemic, k4: &Epistemic, h: f64) -> Epistemic with Mut, Div, Panic {
+    let a = k2.scale(2.0)
+    let b = k3.scale(2.0)
+    let s1 = k1.add(&a)
+    let s2 = s1.add(&b)
+    let s3 = s2.add(k4)
+    s3.scale(h / 6.0)
+}
+fn run_naive(dt: f64, steps: i32) -> Epistemic with Mut, Div, Panic {
+    var c1 = Epistemic::measured(100.0, 5.0)
+    var c2 = Epistemic::certain(0.0)
+    var s = 0
+    while s < steps {
+        let k1a = ni_f1(&c1, &c2); let k1b = ni_f2(&c1, &c2)
+        let ha = k1a.scale(0.5 * dt); let hb = k1b.scale(0.5 * dt)
+        let a2 = c1.add(&ha); let b2 = c2.add(&hb)
+        let k2a = ni_f1(&a2, &b2); let k2b = ni_f2(&a2, &b2)
+        let ha2 = k2a.scale(0.5 * dt); let hb2 = k2b.scale(0.5 * dt)
+        let a3 = c1.add(&ha2); let b3 = c2.add(&hb2)
+        let k3a = ni_f1(&a3, &b3); let k3b = ni_f2(&a3, &b3)
+        let ha3 = k3a.scale(dt); let hb3 = k3b.scale(dt)
+        let a4 = c1.add(&ha3); let b4 = c2.add(&hb3)
+        let k4a = ni_f1(&a4, &b4); let k4b = ni_f2(&a4, &b4)
+        let inca = ni_inc(&k1a, &k2a, &k3a, &k4a, dt)
+        let incb = ni_inc(&k1b, &k2b, &k3b, &k4b, dt)
+        c1 = c1.add(&inca)
+        c2 = c2.add(&incb)
+        s = s + 1
+    }
+    c1
+}
+
+// ── Calibrated (CorrelatedValue) — same integration, covariance-tracked ──
+fn co_f1(c1: CorrelatedValue, c2: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
+    add_correlated(scale_correlated(c1, 0.0 - 0.5), scale_correlated(c2, 0.3))
+}
+fn co_f2(c1: CorrelatedValue, c2: CorrelatedValue) -> CorrelatedValue with Mut, Div, Panic {
+    sub_correlated(scale_correlated(c1, 0.5), scale_correlated(c2, 0.3))
+}
+fn co_inc(k1: CorrelatedValue, k2: CorrelatedValue, k3: CorrelatedValue, k4: CorrelatedValue, h: f64) -> CorrelatedValue with Mut, Div, Panic {
+    let s1 = add_correlated(k1, scale_correlated(k2, 2.0))
+    let s2 = add_correlated(s1, scale_correlated(k3, 2.0))
+    let s3 = add_correlated(s2, k4)
+    scale_correlated(s3, h / 6.0)
+}
+fn run_corr(dt: f64, steps: i32) -> CorrelatedValue with Mut, Div, Panic {
+    var c1 = correlated_from_source(100.0, 1, 5.0, 900.0)   // dose is shared source VarID 1
+    var c2 = correlated_independent(0.0, 0.0, 1000.0)
+    var s = 0
+    while s < steps {
+        let k1a = co_f1(c1, c2); let k1b = co_f2(c1, c2)
+        let a2 = add_correlated(c1, scale_correlated(k1a, 0.5 * dt))
+        let b2 = add_correlated(c2, scale_correlated(k1b, 0.5 * dt))
+        let k2a = co_f1(a2, b2); let k2b = co_f2(a2, b2)
+        let a3 = add_correlated(c1, scale_correlated(k2a, 0.5 * dt))
+        let b3 = add_correlated(c2, scale_correlated(k2b, 0.5 * dt))
+        let k3a = co_f1(a3, b3); let k3b = co_f2(a3, b3)
+        let a4 = add_correlated(c1, scale_correlated(k3a, dt))
+        let b4 = add_correlated(c2, scale_correlated(k3b, dt))
+        let k4a = co_f1(a4, b4); let k4b = co_f2(a4, b4)
+        c1 = add_correlated(c1, co_inc(k1a, k2a, k3a, k4a, dt))
+        c2 = add_correlated(c2, co_inc(k1b, k2b, k3b, k4b, dt))
+        s = s + 1
+    }
+    c1
+}
+
+fn main() with IO, Mut, Div, Panic {
+    let dt = 0.002
+    let steps = 500
+
+    let naive = run_naive(dt, steps)
+    let corr = run_corr(dt, steps)
+    let corr_sd = sqrt(covariance(corr, corr))
+
+    println("RK4 uncertainty propagation: independent Epistemic vs CorrelatedValue")
+    println("  (2-compartment linear PK, dose = 100 +/- 5 mg, integrated to t = 1)")
+    println("")
+    print("  independent Epistemic   C1 = "); print_f64(naive.val()); print("  sd = "); print_f64(naive.std())
+    println("   <- overestimates (correlated stages summed as independent)")
+    print("  CorrelatedValue         C1 = "); print_f64(corr.value); print("  sd = "); print_f64(corr_sd)
+    println("   <- matches Monte-Carlo truth (3.29)")
+    println("")
+    println("  Lesson: independent Epistemic is for INDEPENDENT measurements. For any")
+    println("  computation that reuses an uncertain value (RK4, Newton, ...), use")
+    println("  CorrelatedValue (VarID/covariance) or epistemic-autodiff.")
+}

--- a/scripts/octonion_probes_gate.sh
+++ b/scripts/octonion_probes_gate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Verified octonion / O-SSM research probes — keep them live (math-bearing .sio rots
+# if nothing runs it). Each probe is self-validating; this gate asserts the scientific
+# invariants in its stdout, not just that it compiled. Octonion/f64 -> lean_single engine.
+#   oct_truth        — valid octonion table: alternative error 0, norm-mult error 0
+#   oct_algebra      — associator antisymmetry 0, alternative 0, flexible 0 (Fano/Moufang)
+#   ossm_separation  — representational separation O-SSM(oct) - H-SSM(assoc) = 500 permil
+#   ossm_recover     — associator-recovery positive control: octonion reaches 987 permil
+#   rk4_correlated   — CorrelatedValue sd matches Monte-Carlo truth (3.279153) vs independent
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+run() { # file, then one or more required stdout substrings
+  local f="$1"; shift
+  echo "== $f =="
+  if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile "$f" -o "$OUT/x.elf" >/dev/null 2>&1; then
+    chmod +x "$OUT/x.elf"
+    local out; out="$("$OUT/x.elf" 2>&1)"
+    local s
+    for s in "$@"; do
+      printf '%s' "$out" | grep -qF "$s" || { echo "FAIL invariant [$f]: «$s»"; fail=1; }
+    done
+  else echo "FAIL compile $f"; fail=1; fi
+}
+run scripts/research/oct_truth.sio \
+  "alternative (x,x,y) ||.||^2 (*1e6): 0" \
+  "norm-mult |xy|^2-|x|^2|y|^2 (*1e6): 0"
+run scripts/research/oct_algebra.sio \
+  "antisymmetry violations = 0" \
+  "alternative violations = 0" \
+  "flexible ||.||^2 (*1e6) = 0"
+run scripts/research/ossm_separation.sio \
+  "permil): 500"
+run scripts/research/ossm_recover.sio \
+  "cc     987"
+run examples/epistemic/rk4_correlated_uncertainty.sio \
+  "sd = 3.279153"
+[ $fail -eq 0 ] && echo "OCTONION_PROBES_GATE_OK"
+exit $fail

--- a/scripts/research/oct_algebra.sio
+++ b/scripts/research/oct_algebra.sio
@@ -1,0 +1,149 @@
+// Octonion algebra, verified live. Graves table. No training, no RNG.
+// Enumerates Fano lines, the 168/42 decomposition, and checks the identities
+// that MUST hold in a normed alternative division algebra:
+//   total antisymmetry of the associator, alternative, flexible, middle Moufang.
+
+struct Oct { a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64 }
+
+fn oct_mul(a: Oct, b: Oct) -> Oct {
+    let c0 = a.a*b.a - a.b*b.b - a.c*b.c - a.d*b.d - a.e*b.e - a.f*b.f - a.g*b.g - a.h*b.h
+    let c1 = a.a*b.b + a.b*b.a + a.c*b.d - a.d*b.c + a.e*b.f - a.f*b.e - a.g*b.h + a.h*b.g
+    let c2 = a.a*b.c - a.b*b.d + a.c*b.a + a.d*b.b + a.e*b.g + a.f*b.h - a.g*b.e - a.h*b.f
+    let c3 = a.a*b.d + a.b*b.c - a.c*b.b + a.d*b.a + a.e*b.h - a.f*b.g + a.g*b.f - a.h*b.e
+    let c4 = a.a*b.e - a.b*b.f - a.c*b.g - a.d*b.h + a.e*b.a + a.f*b.b + a.g*b.c + a.h*b.d
+    let c5 = a.a*b.f + a.b*b.e - a.c*b.h + a.d*b.g - a.e*b.b + a.f*b.a - a.g*b.d + a.h*b.c
+    let c6 = a.a*b.g + a.b*b.h + a.c*b.e - a.d*b.f - a.e*b.c + a.f*b.d + a.g*b.a - a.h*b.b
+    let c7 = a.a*b.h - a.b*b.g + a.c*b.f + a.d*b.e - a.e*b.d - a.f*b.c + a.g*b.b + a.h*b.a
+    Oct { a: c0, b: c1, c: c2, d: c3, e: c4, f: c5, g: c6, h: c7 }
+}
+
+fn oct_sub(a: Oct, b: Oct) -> Oct {
+    Oct { a: a.a-b.a, b: a.b-b.b, c: a.c-b.c, d: a.d-b.d,
+          e: a.e-b.e, f: a.f-b.f, g: a.g-b.g, h: a.h-b.h }
+}
+
+fn oct_nsq(o: Oct) -> f64 {
+    o.a*o.a + o.b*o.b + o.c*o.c + o.d*o.d + o.e*o.e + o.f*o.f + o.g*o.g + o.h*o.h
+}
+
+fn basis(i: i64) -> Oct {
+    Oct {
+        a: if i == 0 { 1.0 } else { 0.0 }, b: if i == 1 { 1.0 } else { 0.0 },
+        c: if i == 2 { 1.0 } else { 0.0 }, d: if i == 3 { 1.0 } else { 0.0 },
+        e: if i == 4 { 1.0 } else { 0.0 }, f: if i == 5 { 1.0 } else { 0.0 },
+        g: if i == 6 { 1.0 } else { 0.0 }, h: if i == 7 { 1.0 } else { 0.0 },
+    }
+}
+
+fn comp(o: Oct, k: i64) -> f64 {
+    if k == 0 { o.a } else { if k == 1 { o.b } else { if k == 2 { o.c } else {
+    if k == 3 { o.d } else { if k == 4 { o.e } else { if k == 5 { o.f } else {
+    if k == 6 { o.g } else { o.h } } } } } } }
+}
+
+fn assoc(x: Oct, y: Oct, z: Oct) -> Oct {
+    oct_sub(oct_mul(oct_mul(x, y), z), oct_mul(x, oct_mul(y, z)))
+}
+
+fn nz(v: f64) -> bool { let a = if v < 0.0 { 0.0 - v } else { v }; a > 0.000001 }
+
+fn main() -> i64 with IO, Panic {
+    println("== octonion algebra, verified ==")
+
+    // (1) Fano lines: unordered {i<j<k} of imaginaries with zero associator.
+    var lines = 0
+    var nonlines = 0
+    var i = 1
+    while i < 8 {
+        var j = i + 1
+        while j < 8 {
+            var k = j + 1
+            while k < 8 {
+                let an = oct_nsq(assoc(basis(i), basis(j), basis(k)))
+                if nz(an) {
+                    nonlines = nonlines + 1
+                } else {
+                    lines = lines + 1
+                    // e_i * e_j = sign * e_k ; report the closed line
+                    let s = comp(oct_mul(basis(i), basis(j)), k)
+                    let sgn = if s > 0.0 { 1 } else { 0 - 1 }
+                    print("  line ")
+                    print_int(i)
+                    print(" ")
+                    print_int(j)
+                    print(" ")
+                    print_int(k)
+                    print("   e_i*e_j = ")
+                    print_int(sgn)
+                    print(" * e_")
+                    print_int(k)
+                    println("")
+                }
+                k = k + 1
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    print("Fano lines = ")
+    print_int(lines)
+    print("  (expect 7); off-line triples = ")
+    print_int(nonlines)
+    println("  (expect 28)")
+    print("ordered non-assoc = 6*28 = ")
+    print_int(6 * nonlines)
+    print("  (168 = |PSL(2,7)|); ordered associative = 6*7 = ")
+    print_int(6 * lines)
+    println("  (42)")
+
+    // (2) The associator is ALTERNATING (theorem for alternative algebras):
+    //     sign-flips under any transposition; vanishes on repeated args.
+    var anti_viol = 0     // ||[a,b,c] + [b,a,c]|| and ||[a,b,c] + [a,c,b]||
+    var alt_viol = 0      // ||[a,a,c]|| and ||[a,c,c]||
+    i = 0
+    while i < 8 {
+        var j = 0
+        while j < 8 {
+            var k = 0
+            while k < 8 {
+                let A = assoc(basis(i), basis(j), basis(k))
+                let swap_ij = assoc(basis(j), basis(i), basis(k))
+                let swap_jk = assoc(basis(i), basis(k), basis(j))
+                // antisymmetry: A + swap == 0
+                if nz(oct_nsq(add_oct(A, swap_ij))) { anti_viol = anti_viol + 1 }
+                if nz(oct_nsq(add_oct(A, swap_jk))) { anti_viol = anti_viol + 1 }
+                if i == j { if nz(oct_nsq(A)) { alt_viol = alt_viol + 1 } }
+                if j == k { if nz(oct_nsq(A)) { alt_viol = alt_viol + 1 } }
+                k = k + 1
+            }
+            j = j + 1
+        }
+        i = i + 1
+    }
+    print("associator antisymmetry violations = ")
+    print_int(anti_viol)
+    print("  (expect 0); alternative violations = ")
+    print_int(alt_viol)
+    println("  (expect 0)")
+
+    // (3) Flexible and middle-Moufang on generic octonions.
+    let x = Oct { a: 0.3, b: 1.0, c: -0.7, d: 0.5, e: -1.2, f: 0.9, g: 0.2, h: -0.4 }
+    let y = Oct { a: -0.6, b: 0.4, c: 1.1, d: -0.9, e: 0.3, f: -0.5, g: 0.8, h: 0.1 }
+    let z = Oct { a: 0.2, b: -1.3, c: 0.6, d: 0.7, e: -0.1, f: 0.4, g: -0.8, h: 1.0 }
+    // flexible: (xy)x = x(yx)
+    let flex = oct_sub(oct_mul(oct_mul(x, y), x), oct_mul(x, oct_mul(y, x)))
+    // middle Moufang: (zx)(yz) = z((xy)z)
+    let mou = oct_sub(oct_mul(oct_mul(z, x), oct_mul(y, z)),
+                      oct_mul(z, oct_mul(oct_mul(x, y), z)))
+    print("flexible ||.||^2 (*1e6) = ")
+    print_int((oct_nsq(flex) * 1000000.0) as i64)
+    print("  ; middle-Moufang ||.||^2 (*1e6) = ")
+    print_int((oct_nsq(mou) * 1000000.0) as i64)
+    println("")
+    0
+}
+
+fn add_oct(a: Oct, b: Oct) -> Oct {
+    Oct { a: a.a+b.a, b: a.b+b.b, c: a.c+b.c, d: a.d+b.d,
+          e: a.e+b.e, f: a.f+b.f, g: a.g+b.g, h: a.h+b.h }
+}

--- a/scripts/research/oct_truth.sio
+++ b/scripts/research/oct_truth.sio
@@ -1,0 +1,122 @@
+// Ground-truth octonion probe. Exact Graves multiply, no training, no RNG.
+// Prints: real non-associative fraction over basis triples, one concrete
+// associator, norm-multiplicativity error, alternative-property error.
+
+struct Oct { a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64 }
+
+fn oct_mul(a: Oct, b: Oct) -> Oct {
+    let c0 = a.a*b.a - a.b*b.b - a.c*b.c - a.d*b.d - a.e*b.e - a.f*b.f - a.g*b.g - a.h*b.h
+    let c1 = a.a*b.b + a.b*b.a + a.c*b.d - a.d*b.c + a.e*b.f - a.f*b.e - a.g*b.h + a.h*b.g
+    let c2 = a.a*b.c - a.b*b.d + a.c*b.a + a.d*b.b + a.e*b.g + a.f*b.h - a.g*b.e - a.h*b.f
+    let c3 = a.a*b.d + a.b*b.c - a.c*b.b + a.d*b.a + a.e*b.h - a.f*b.g + a.g*b.f - a.h*b.e
+    let c4 = a.a*b.e - a.b*b.f - a.c*b.g - a.d*b.h + a.e*b.a + a.f*b.b + a.g*b.c + a.h*b.d
+    let c5 = a.a*b.f + a.b*b.e - a.c*b.h + a.d*b.g - a.e*b.b + a.f*b.a - a.g*b.d + a.h*b.c
+    let c6 = a.a*b.g + a.b*b.h + a.c*b.e - a.d*b.f - a.e*b.c + a.f*b.d + a.g*b.a - a.h*b.b
+    let c7 = a.a*b.h - a.b*b.g + a.c*b.f + a.d*b.e - a.e*b.d - a.f*b.c + a.g*b.b + a.h*b.a
+    Oct { a: c0, b: c1, c: c2, d: c3, e: c4, f: c5, g: c6, h: c7 }
+}
+
+fn oct_sub(a: Oct, b: Oct) -> Oct {
+    Oct { a: a.a-b.a, b: a.b-b.b, c: a.c-b.c, d: a.d-b.d,
+          e: a.e-b.e, f: a.f-b.f, g: a.g-b.g, h: a.h-b.h }
+}
+
+fn oct_nsq(o: Oct) -> f64 {
+    o.a*o.a + o.b*o.b + o.c*o.c + o.d*o.d + o.e*o.e + o.f*o.f + o.g*o.g + o.h*o.h
+}
+
+// unit basis octonion e_i, i in 0..8
+fn basis(i: i64) -> Oct {
+    Oct {
+        a: if i == 0 { 1.0 } else { 0.0 },
+        b: if i == 1 { 1.0 } else { 0.0 },
+        c: if i == 2 { 1.0 } else { 0.0 },
+        d: if i == 3 { 1.0 } else { 0.0 },
+        e: if i == 4 { 1.0 } else { 0.0 },
+        f: if i == 5 { 1.0 } else { 0.0 },
+        g: if i == 6 { 1.0 } else { 0.0 },
+        h: if i == 7 { 1.0 } else { 0.0 },
+    }
+}
+
+// associator norm^2 = ||(x*y)*z - x*(y*z)||^2
+fn assoc_nsq(x: Oct, y: Oct, z: Oct) -> f64 {
+    let left = oct_mul(oct_mul(x, y), z)
+    let right = oct_mul(x, oct_mul(y, z))
+    oct_nsq(oct_sub(left, right))
+}
+
+fn main() -> i64 with IO, Panic {
+    // 1) real non-associative fraction over ALL 512 ordered basis triples
+    var all_total = 0
+    var all_nonassoc = 0
+    // and over the 210 ordered triples of DISTINCT imaginary units (1..7)
+    var imag_total = 0
+    var imag_nonassoc = 0
+
+    var ia = 0
+    while ia < 8 {
+        var ib = 0
+        while ib < 8 {
+            var ic = 0
+            while ic < 8 {
+                let ea = basis(ia)
+                let eb = basis(ib)
+                let ec = basis(ic)
+                let ansq = assoc_nsq(ea, eb, ec)
+                all_total = all_total + 1
+                if ansq > 0.000001 { all_nonassoc = all_nonassoc + 1 }
+                let distinct = ia != ib && ib != ic && ia != ic
+                let imaginary = ia > 0 && ib > 0 && ic > 0
+                if distinct && imaginary {
+                    imag_total = imag_total + 1
+                    if ansq > 0.000001 { imag_nonassoc = imag_nonassoc + 1 }
+                }
+                ic = ic + 1
+            }
+            ib = ib + 1
+        }
+        ia = ia + 1
+    }
+
+    println("== octonion ground truth ==")
+    print("non-assoc basis triples (all 512):    ")
+    print_int(all_nonassoc)
+    print(" / ")
+    print_int(all_total)
+    println("")
+    print("non-assoc DISTINCT imaginary (of 210): ")
+    print_int(imag_nonassoc)
+    print(" / ")
+    print_int(imag_total)
+    println("")
+
+    // 2) concrete associators: {1,2,3} is a Fano line here (e1*e2=e3) -> 0;
+    //    {1,2,4} is NOT a line -> nonzero. Show both.
+    let dL = oct_sub(oct_mul(oct_mul(basis(1), basis(2)), basis(3)),
+                     oct_mul(basis(1), oct_mul(basis(2), basis(3))))
+    let dN = oct_sub(oct_mul(oct_mul(basis(1), basis(2)), basis(4)),
+                     oct_mul(basis(1), oct_mul(basis(2), basis(4))))
+    print("[e1,e2,e3] ||assoc||^2*1000 (Fano line) = ")
+    print_int((oct_nsq(dL) * 1000.0) as i64)
+    println("")
+    print("[e1,e2,e4] ||assoc||^2*1000 (off-line)  = ")
+    print_int((oct_nsq(dN) * 1000.0) as i64)
+    println("")
+
+    // 3) norm-multiplicativity: |xy|^2 - |x|^2|y|^2 (should be ~0)
+    let x = Oct { a: 1.0, b: 2.0, c: 3.0, d: 4.0, e: 5.0, f: 6.0, g: 7.0, h: 8.0 }
+    let y = Oct { a: 0.5, b: -1.5, c: 2.5, d: -3.5, e: 0.25, f: 1.25, g: -2.25, h: 3.25 }
+    let nm_err = oct_nsq(oct_mul(x, y)) - oct_nsq(x) * oct_nsq(y)
+    let nm_abs = if nm_err < 0.0 { 0.0 - nm_err } else { nm_err }
+    print("norm-mult |xy|^2-|x|^2|y|^2 (*1e6): ")
+    print_int((nm_abs * 1000000.0) as i64)
+    println("")
+
+    // 4) alternative property: (x*x)*y - x*(x*y) should be ~0
+    let alt = oct_sub(oct_mul(oct_mul(x, x), y), oct_mul(x, oct_mul(x, y)))
+    print("alternative (x,x,y) ||.||^2 (*1e6): ")
+    print_int((oct_nsq(alt) * 1000000.0) as i64)
+    println("")
+    0
+}

--- a/scripts/research/ossm_recover.sio
+++ b/scripts/research/ossm_recover.sio
@@ -1,0 +1,115 @@
+// §3 associator-recovery, positive control (no BPTT, no autograd).
+// Label depends ONLY on the octonion associator of the inputs; commutator is
+// held constant across the alpha sweep. Two observers:
+//   OCT: computes proj([u,v,w])  -> can see the associator
+//   ASS: computes proj(uv - vu)  -> associative/commutator handle only
+// Same noise, same samples for every alpha. alpha scales the associator signal.
+
+struct Oct { a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64 }
+
+fn oct_mul(a: Oct, b: Oct) -> Oct {
+    let c0 = a.a*b.a - a.b*b.b - a.c*b.c - a.d*b.d - a.e*b.e - a.f*b.f - a.g*b.g - a.h*b.h
+    let c1 = a.a*b.b + a.b*b.a + a.c*b.d - a.d*b.c + a.e*b.f - a.f*b.e - a.g*b.h + a.h*b.g
+    let c2 = a.a*b.c - a.b*b.d + a.c*b.a + a.d*b.b + a.e*b.g + a.f*b.h - a.g*b.e - a.h*b.f
+    let c3 = a.a*b.d + a.b*b.c - a.c*b.b + a.d*b.a + a.e*b.h - a.f*b.g + a.g*b.f - a.h*b.e
+    let c4 = a.a*b.e - a.b*b.f - a.c*b.g - a.d*b.h + a.e*b.a + a.f*b.b + a.g*b.c + a.h*b.d
+    let c5 = a.a*b.f + a.b*b.e - a.c*b.h + a.d*b.g - a.e*b.b + a.f*b.a - a.g*b.d + a.h*b.c
+    let c6 = a.a*b.g + a.b*b.h + a.c*b.e - a.d*b.f - a.e*b.c + a.f*b.d + a.g*b.a - a.h*b.b
+    let c7 = a.a*b.h - a.b*b.g + a.c*b.f + a.d*b.e - a.e*b.d - a.f*b.c + a.g*b.b + a.h*b.a
+    Oct { a: c0, b: c1, c: c2, d: c3, e: c4, f: c5, g: c6, h: c7 }
+}
+fn oct_sub(a: Oct, b: Oct) -> Oct {
+    Oct { a: a.a-b.a, b: a.b-b.b, c: a.c-b.c, d: a.d-b.d,
+          e: a.e-b.e, f: a.f-b.f, g: a.g-b.g, h: a.h-b.h }
+}
+fn assoc(x: Oct, y: Oct, z: Oct) -> Oct {
+    oct_sub(oct_mul(oct_mul(x, y), z), oct_mul(x, oct_mul(y, z)))
+}
+// fixed linear functional on the imaginary part
+fn proj(o: Oct) -> f64 {
+    o.b - o.c + o.d - o.e + o.f - o.g + o.h
+}
+fn fabs(v: f64) -> f64 { if v < 0.0 { 0.0 - v } else { v } }
+
+var RA: i64 = 1
+var RB: i64 = 1
+fn rseed(s: i64) with Mut {
+    RA = s + 1
+    RB = s * 13 + 1234567
+    var w = 0
+    while w < 4 { let t = rnext(); w = w + 1 }
+}
+fn rnext() -> i64 with Mut {
+    var x = RA; let y = RB; RA = y
+    x = x ^ (x << 23); x = x ^ (x >> 17); x = x ^ (y ^ (y >> 26))
+    RB = x; let r = x + y; if r < 0 { 0 - r } else { r }
+}
+fn rf() -> f64 with Mut, Div {
+    let r = rnext(); let m = r % 20000
+    (m as f64) / 10000.0 - 1.0
+}
+fn rand_oct() -> Oct with Mut, Div {
+    Oct { a: rf(), b: rf(), c: rf(), d: rf(), e: rf(), f: rf(), g: rf(), h: rf() }
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    println("== associator recovery (positive control) ==")
+    println("alpha   BA_oct(permil)  BA_assoc(permil)   [0=random, 1000=perfect]")
+    let sigma = 0.9
+    let N = 400
+    // alpha sweep
+    var ai = 0
+    let ALPHAS: [f64; 6] = [0.0, 0.25, 0.5, 1.0, 2.0, 4.0]
+    while ai < 6 {
+        let alpha = ALPHAS[ai]
+        var cp = 0; var cn = 0
+        var okp = 0; var okn = 0        // OCT observer
+        var okp2 = 0; var okn2 = 0      // ASS observer
+        var i = 0
+        while i < N {
+            // sample (u,v,w) fixed per i, identical across alpha
+            rseed(i + 1)
+            let u = rand_oct(); let v = rand_oct(); let w = rand_oct()
+            let s = proj(assoc(u, v, w))            // associator signal
+            if fabs(s) > 0.000001 {
+                let ypos = s > 0.0
+                // noise fixed per i (independent of alpha)
+                rseed(i + 777)
+                let n1 = rf(); let n2 = rf()
+                let f_oct = alpha * s + sigma * n1
+                let comm = proj(oct_sub(oct_mul(u, v), oct_mul(v, u)))
+                let f_ass = comm + sigma * n2
+                let pred_oct = f_oct > 0.0
+                let pred_ass = f_ass > 0.0
+                if ypos {
+                    cp = cp + 1
+                    if pred_oct { okp = okp + 1 }
+                    if pred_ass { okp2 = okp2 + 1 }
+                } else {
+                    cn = cn + 1
+                    if !pred_oct { okn = okn + 1 }
+                    if !pred_ass { okn2 = okn2 + 1 }
+                }
+            }
+            i = i + 1
+        }
+        // balanced accuracy in permil (float division; guard against empty class)
+        var ba_oct = 0 - 1
+        var ba_ass = 0 - 1
+        if cp > 0 && cn > 0 {
+            let cpf = cp as f64
+            let cnf = cn as f64
+            ba_oct = (500.0 * ((okp as f64) / cpf + (okn as f64) / cnf)) as i64
+            ba_ass = (500.0 * ((okp2 as f64) / cpf + (okn2 as f64) / cnf)) as i64
+        }
+        print_int((alpha * 100.0) as i64)
+        print("cc     ")
+        print_int(ba_oct)
+        print("            ")
+        print_int(ba_ass)
+        println("")
+        ai = ai + 1
+    }
+    println("(alpha printed x100; commutator identical across the sweep by construction)")
+    0
+}

--- a/scripts/research/ossm_separation.sio
+++ b/scripts/research/ossm_separation.sio
@@ -1,0 +1,123 @@
+// O-SSM vs H-SSM separation on non-associative triples — clean reimplementation.
+// The label of (e_a,e_b,e_c,mode) is the octonion product under that bracketing:
+//   LEFT = (e_a*e_b)*e_c , RIGHT = e_a*(e_b*e_c) , encoded as 16 classes (sign x index).
+// A triple is mode-sensitive (non-associative) iff LEFT-class != RIGHT-class.
+//
+// Capacity claim (no training, provable):
+//   O-SSM (octonion algebra) computes the product in the given bracketing -> can hit 100%.
+//   H-SSM (associative algebra) has (xy)z = x(yz): its product is MODE-BLIND, so on a
+//   non-assoc triple its single prediction matches at most one of {LEFT,RIGHT} -> <=50%.
+// The associative CEILING is instantiated here by the fairest mode-blind predictor.
+
+struct Oct { a: f64, b: f64, c: f64, d: f64, e: f64, f: f64, g: f64, h: f64 }
+
+fn oct_mul(a: Oct, b: Oct) -> Oct {
+    let c0 = a.a*b.a - a.b*b.b - a.c*b.c - a.d*b.d - a.e*b.e - a.f*b.f - a.g*b.g - a.h*b.h
+    let c1 = a.a*b.b + a.b*b.a + a.c*b.d - a.d*b.c + a.e*b.f - a.f*b.e - a.g*b.h + a.h*b.g
+    let c2 = a.a*b.c - a.b*b.d + a.c*b.a + a.d*b.b + a.e*b.g + a.f*b.h - a.g*b.e - a.h*b.f
+    let c3 = a.a*b.d + a.b*b.c - a.c*b.b + a.d*b.a + a.e*b.h - a.f*b.g + a.g*b.f - a.h*b.e
+    let c4 = a.a*b.e - a.b*b.f - a.c*b.g - a.d*b.h + a.e*b.a + a.f*b.b + a.g*b.c + a.h*b.d
+    let c5 = a.a*b.f + a.b*b.e - a.c*b.h + a.d*b.g - a.e*b.b + a.f*b.a - a.g*b.d + a.h*b.c
+    let c6 = a.a*b.g + a.b*b.h + a.c*b.e - a.d*b.f - a.e*b.c + a.f*b.d + a.g*b.a - a.h*b.b
+    let c7 = a.a*b.h - a.b*b.g + a.c*b.f + a.d*b.e - a.e*b.d - a.f*b.c + a.g*b.b + a.h*b.a
+    Oct { a: c0, b: c1, c: c2, d: c3, e: c4, f: c5, g: c6, h: c7 }
+}
+
+fn basis(i: i64) -> Oct {
+    Oct {
+        a: if i == 0 { 1.0 } else { 0.0 }, b: if i == 1 { 1.0 } else { 0.0 },
+        c: if i == 2 { 1.0 } else { 0.0 }, d: if i == 3 { 1.0 } else { 0.0 },
+        e: if i == 4 { 1.0 } else { 0.0 }, f: if i == 5 { 1.0 } else { 0.0 },
+        g: if i == 6 { 1.0 } else { 0.0 }, h: if i == 7 { 1.0 } else { 0.0 },
+    }
+}
+
+fn comp(o: Oct, k: i64) -> f64 {
+    if k == 0 { o.a } else { if k == 1 { o.b } else { if k == 2 { o.c } else {
+    if k == 3 { o.d } else { if k == 4 { o.e } else { if k == 5 { o.f } else {
+    if k == 6 { o.g } else { o.h } } } } } } }
+}
+
+// product of basis elements is +-e_k ; class = k + 8*(sign<0)
+fn oct_class(o: Oct) -> i64 with Mut {
+    var k = 0
+    while k < 8 {
+        let v = comp(o, k)
+        if v > 0.5 { return k }
+        if v < 0.0 - 0.5 { return 8 + k }
+        k = k + 1
+    }
+    0 - 1
+}
+
+fn left_class(a: i64, b: i64, c: i64) -> i64 with Mut {
+    oct_class(oct_mul(oct_mul(basis(a), basis(b)), basis(c)))
+}
+fn right_class(a: i64, b: i64, c: i64) -> i64 with Mut {
+    oct_class(oct_mul(basis(a), oct_mul(basis(b), basis(c))))
+}
+
+fn permil(num: i64, den: i64) -> i64 {
+    if den <= 0 { return 0 - 1 }
+    (1000.0 * (num as f64) / (den as f64)) as i64
+}
+
+fn main() -> i64 with IO, Mut, Panic {
+    println("== O-SSM vs H-SSM: representational separation on bracketing ==")
+    var na512 = 0
+    var na_dimag = 0
+    // (triple, mode) accuracy accumulators
+    var osm_ok_na = 0; var tot_na = 0     // non-assoc (triple,mode) pairs
+    var asc_ok_na = 0
+    var osm_ok_as = 0; var tot_as = 0     // assoc pairs
+    var asc_ok_as = 0
+
+    var a = 0
+    while a < 8 {
+        var b = 0
+        while b < 8 {
+            var c = 0
+            while c < 8 {
+                let lc = left_class(a, b, c)
+                let rc = right_class(a, b, c)
+                let nonassoc = lc != rc
+                if nonassoc {
+                    na512 = na512 + 1
+                    if a > 0 && b > 0 && c > 0 && a != b && b != c && a != c {
+                        na_dimag = na_dimag + 1
+                    }
+                    // two modes: octonion right on both; mode-blind (always LEFT) right on LEFT only
+                    tot_na = tot_na + 2
+                    osm_ok_na = osm_ok_na + 2
+                    asc_ok_na = asc_ok_na + 1
+                } else {
+                    tot_as = tot_as + 2
+                    osm_ok_as = osm_ok_as + 2
+                    asc_ok_as = asc_ok_as + 2
+                }
+                c = c + 1
+            }
+            b = b + 1
+        }
+        a = a + 1
+    }
+
+    print("non-assoc triples: "); print_int(na512); print(" / 512   (distinct-imag ")
+    print_int(na_dimag); println(" / 210)")
+
+    println("")
+    println("accuracy (permil) on the 16-class bracketing label:")
+    print("  O-SSM (octonion)   non-assoc: "); print_int(permil(osm_ok_na, tot_na))
+    print("   assoc: "); print_int(permil(osm_ok_as, tot_as))
+    print("   overall: "); print_int(permil(osm_ok_na + osm_ok_as, tot_na + tot_as)); println("")
+    print("  H-SSM (associative) non-assoc: "); print_int(permil(asc_ok_na, tot_na))
+    print("   assoc: "); print_int(permil(asc_ok_as, tot_as))
+    print("   overall: "); print_int(permil(asc_ok_na + asc_ok_as, tot_na + tot_as)); println("")
+
+    println("")
+    print("SEPARATION on non-assoc triples (O-SSM - H-SSM, permil): ")
+    print_int(permil(osm_ok_na, tot_na) - permil(asc_ok_na, tot_na))
+    println("")
+    println("(H-SSM ceiling is 500 on non-assoc: an associative algebra cannot use bracketing.)")
+    0
+}


### PR DESCRIPTION
## What

Five verified octonion / O-SSM research probes, all on a **valid** octonion table
(e2·e5 = +e7, confirmed), plus a sentinel gate. This is the salvaged unique content of
**#904** (`feat/epistemic-gum-hardening`), rebased cleanly onto current `main`.

## Why not just deconflict #904?

#904 is ~60% superseded: 39 of its 65 changed files are already **byte-identical on main**,
and the features it is named for already landed via other PRs:
- the GUM-hardening stdlib + gate (`stdlib/epistemic/gum.sio`, `scripts/epistemic_gum_gate.sh`),
- the compiler visibility preflight (`compiler_visibility_preflight` is on `main`),
- the native-compile privacy gate (`scripts/ci/zero_event_native_compile_privacy_gate.sh`).

The only content absent from `main` was these 5 new files. A 398-commit merge to deliver
5 conflict-free files is pure noise, so #904 is being **closed as superseded** in favour of
this small PR.

## The files (numerically verified on `lean_single`, current main)

| File | Verified invariant |
|---|---|
| `scripts/research/oct_truth.sio` | valid table: 168/512 non-assoc triples (=\|PSL(2,7)\|), **alternative error 0, norm-mult error 0** |
| `scripts/research/oct_algebra.sio` | **associator antisymmetry 0, alternative 0, flexible 0**; 7 Fano lines, 28 off-line, middle-Moufang 0 |
| `scripts/research/ossm_separation.sio` | representational separation: O-SSM(oct) **1000** vs H-SSM(assoc) ceiling **500** permil on non-assoc triples |
| `scripts/research/ossm_recover.sio` | associator-recovery positive control: octonion **987** permil vs commutator/assoc at chance (521) |
| `examples/epistemic/rk4_correlated_uncertainty.sio` | CorrelatedValue sd **3.28** = Monte-Carlo truth vs independent Epistemic overestimate (5.0) |

## Honest framing

`ossm_separation` is a **representational-capacity** statement (an associative algebra is
structurally bracket-blind → capped at chance on non-associative triples), i.e. the honest
#907 reframe — **not** an empirical ML-benchmark-win claim. None of these files carry the
retracted e2·e5 sign error (#1024); `oct_truth`/`oct_algebra` prove the table valid at runtime.

## Notes

- `ossm_separation.sio` needed `with Mut` on `oct_class`/`left_class`/`right_class`/`main` to
  satisfy the current (stricter) effect checker; product and output unchanged.
- `scripts/octonion_probes_gate.sh` asserts the invariants above (substring sentinels, robust
  against `print_int` number formatting; prints `OCTONION_PROBES_GATE_OK`). It is a runnable
  dev-gate (same tier as `verticals_deepen3_gate.sh`) and is **not yet wired into `ci.yml`** —
  wire it there if you want it enforced per-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)