### PR TITLE
ci(octonion): wire the O-SSM probes gate into CI (math impact)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Furey octonion generation cross-verification
         if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/furey_octonion_gate.sh
+      - name: Octonion / O-SSM probes gate
+        if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
+        run: bash scripts/ci/octonion_probes_gate.sh
       - name: Sedenion dynamics cross-verification
         if: needs.impact.outputs.math == 'true' || needs.impact.outputs.full == 'true'
         run: bash scripts/ci/sedenion_dynamics_gate.sh

--- a/scripts/ci/classify_ci_impact.sh
+++ b/scripts/ci/classify_ci_impact.sh
@@ -68,7 +68,7 @@ else
     case "$path" in tests/*|check_sounio.sh) mark tests; recognized=true ;; esac
     case "$path" in formal/lean4/*) mark lean; recognized=true ;; esac
     case "$path" in
-      formal/lean4/*|scripts/ci/sedenion_*|scripts/ci/cd_tower_*|scripts/ci/gresnigt_*|scripts/ci/furey_*|scripts/research/sedenion_*|scripts/research/cd_tower_*)
+      formal/lean4/*|scripts/ci/sedenion_*|scripts/ci/cd_tower_*|scripts/ci/gresnigt_*|scripts/ci/furey_*|scripts/ci/octonion_probes_gate.sh|scripts/research/sedenion_*|scripts/research/cd_tower_*|scripts/research/oct_*|scripts/research/ossm_*)
         mark math
         recognized=true
         ;;

--- a/scripts/ci/octonion_probes_gate.sh
+++ b/scripts/ci/octonion_probes_gate.sh
@@ -7,6 +7,9 @@
 #   ossm_separation  — representational separation O-SSM(oct) - H-SSM(assoc) = 500 permil
 #   ossm_recover     — associator-recovery positive control: octonion reaches 987 permil
 #   rk4_correlated   — CorrelatedValue sd matches Monte-Carlo truth (3.279153) vs independent
+# NOTE: the exact-value sentinels below (e.g. `cc     987`, `sd = 3.279153`) are reproducible
+# because CI runs the SAME committed lean_single ELF this was pinned against; if souc is ever
+# rebuilt these two are the first that could drift — re-pin them from a fresh run if so.
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"

--- a/scripts/ci/octonion_probes_gate.sh
+++ b/scripts/ci/octonion_probes_gate.sh
@@ -8,7 +8,7 @@
 #   ossm_recover     — associator-recovery positive control: octonion reaches 987 permil
 #   rk4_correlated   — CorrelatedValue sd matches Monte-Carlo truth (3.279153) vs independent
 set -euo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../.."
 export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
 SOUC=./bin/souc
 OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT

--- a/scripts/research/HYPERCOMPLEX_SSM_LANE.md
+++ b/scripts/research/HYPERCOMPLEX_SSM_LANE.md
@@ -20,7 +20,7 @@ Write-Set:
   scripts/research/ossm_recover.sio
   scripts/research/ossm_separation.sio
   scripts/research/HYPERCOMPLEX_SSM_LANE.md
-  scripts/octonion_probes_gate.sh
+  scripts/ci/octonion_probes_gate.sh
   examples/epistemic/rk4_correlated_uncertainty.sio   (bundled epistemic/GUM example)
   (future: examples/*ossm*.sio, examples/*octonion*.sio, stdlib/ssm/*, stdlib/{algebra,math}/octonion.sio, docs/briefings/OSSM_*.md)
 Read-Set:
@@ -30,8 +30,10 @@ Not-Touched:
   examples/associativity_probe_benchmark.sio — main already carries the gated
   run-pass version (//@ expect-stdout: ALL PASS); this lane defers to it and does
   NOT revert it. The provable separation lives in ossm_separation.sio.
-Required-Gates: scripts/octonion_probes_gate.sh green (compile+run every probe
+Required-Gates: scripts/ci/octonion_probes_gate.sh green (compile+run every probe
   under lean_single, assert invariants in stdout) -> OCTONION_PROBES_GATE_OK.
+  Wired into .github/workflows/ci.yml (Contracts job, math-impact condition); the
+  impact classifier marks scripts/research/oct_*|ossm_* and the gate itself as `math`.
 Merge-Target: main
 Known-Blockers:
   BLK-20260714-madaros-print_int-f64 (issue #891, owner codex-2) + sibling Madaros
@@ -56,7 +58,7 @@ Note: `ossm_separation.sio` carries `with Mut` on `oct_class`/`left_class`/`righ
 ## Run everything
 
 ```bash
-bash scripts/octonion_probes_gate.sh          # asserts every invariant above
+bash scripts/ci/octonion_probes_gate.sh          # asserts every invariant above
 # or individually:
 for f in oct_truth oct_algebra ossm_recover ossm_separation; do
   SOUNIO_SOUC_ENGINE=lean_single ./bin/souc compile scripts/research/$f.sio -o /tmp/x.elf && /tmp/x.elf


### PR DESCRIPTION
## What

Wires the octonion / O-SSM probes gate (merged ungated in #907) into CI so the verified
probes are protected from regression — the exact failure mode by which #904's octonion
content silently rotted for a month.

## Changes

- **Move** `scripts/octonion_probes_gate.sh` → `scripts/ci/octonion_probes_gate.sh`
  (CI convention, sibling of `furey_octonion_gate.sh`) + fix its repo-root `cd`.
- **Wire** a Contracts-job step running it under the same `math || full` impact condition
  as the sedenion/furey octonion gates.
- **Teach** `scripts/ci/classify_ci_impact.sh` to mark `math` for the probe paths
  (`scripts/research/oct_*`, `scripts/research/ossm_*`) and the gate itself — they only
  marked `sio` before, so a probe change would not have triggered the gate.
- Update `HYPERCOMPLEX_SSM_LANE.md` gate path + note the CI wiring.

## Verification (local, repo's own selftests)

| check | result |
|---|---|
| gate from new path | `OCTONION_PROBES_GATE_OK` |
| `impact_ci_selftest.sh` | `IMPACT_CI_SELFTEST_PASS` |
| `check_workflow_script_refs.sh` | passed (72 refs) |
| `ci.yml` YAML | valid |
| classifier on isolated `oct_truth.sio` change | `math=true` |
| classifier on this PR diff | `full=true` → gate runs on this very PR |

The gate compiles+runs the five probes under `lean_single` (committed ELF; same mechanism
as `sedenion_zd168_crosscheck_gate.sh` which already runs `./bin/souc` in the Contracts job)
and asserts each scientific invariant in stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)