### PR TITLE
fix(madaros): route scalar print dispatch

### DIFF
--- a/scripts/ci/madaros_changed_tests_gate.sh
+++ b/scripts/ci/madaros_changed_tests_gate.sh
@@ -52,9 +52,11 @@ if [[ "$SELECT_ONLY" == "1" ]]; then
   exit 0
 fi
 
-# This gate is wired to the Linux current-source CI job. Darwin's common
-# 65532 KiB ceiling is intentionally not normalized into this Linux contract.
-stack_kb="${SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB:-65536}"
+# This gate is wired to the Linux current-source CI job. Current-source
+# lowering can exceed a 64 MiB stack; match the canonical compiler gate's
+# 1 GiB Linux soft limit. Darwin's lower ceiling is intentionally not
+# normalized into this Linux contract.
+stack_kb="${SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB:-1048576}"
 [[ "$stack_kb" =~ ^[1-9][0-9]*$ && ${#stack_kb} -le 9 ]] \
   || fail "invalid_stack_kb"
 

--- a/scripts/ci/madaros_changed_tests_selftest.sh
+++ b/scripts/ci/madaros_changed_tests_selftest.sh
@@ -40,11 +40,10 @@ fi
 skip="$(
   (
     ulimit -S -s 8192
-    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=65536 \
-      "$GATE" -- docs/internal/coordination/CI_WATCH_CONTRACT.md
+    "$GATE" -- docs/internal/coordination/CI_WATCH_CONTRACT.md
   )
 )"
-grep -Eq '^MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=65536 soft_before_kb=8192 hard_before_kb=(unlimited|[0-9]+) soft_after_kb=65536 hard_after_kb=(unlimited|[0-9]+)$' \
+grep -Eq '^MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=1048576 soft_before_kb=8192 hard_before_kb=(unlimited|[0-9]+) soft_after_kb=1048576 hard_after_kb=(unlimited|[0-9]+)$' \
   <<<"$skip"
 grep -Fxq 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests' <<<"$skip"
 grep -Fxq 'MADAROS_CHANGED_TESTS_SKIP reason=no_changed_requires_madaros_tests' \
@@ -111,7 +110,6 @@ raised_stack="$(
   (
     ulimit -S -s 8192
     SOUNIO_MADAROS_CHANGED_TESTS_BIN=/bin/true \
-    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=65536 \
       "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio
   ) 2>&1
 )"
@@ -122,7 +120,7 @@ if [[ "$raised_stack_rc" == "0" ]]; then
   exit 1
 fi
 raised_stack_receipt="$(grep -F 'MADAROS_CHANGED_TESTS_STACK status=ready' <<<"$raised_stack")"
-ready_stack_pattern='^MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=65536 soft_before_kb=8192 hard_before_kb=(unlimited|[0-9]+) soft_after_kb=65536 hard_after_kb=(unlimited|[0-9]+)$'
+ready_stack_pattern='^MADAROS_CHANGED_TESTS_STACK status=ready scope=linux_ci requested_kb=1048576 soft_before_kb=8192 hard_before_kb=(unlimited|[0-9]+) soft_after_kb=1048576 hard_after_kb=(unlimited|[0-9]+)$'
 if [[ ! "$raised_stack_receipt" =~ $ready_stack_pattern ]]; then
   echo 'madaros-changed-tests: stack raise receipt is malformed' >&2
   exit 1
@@ -133,7 +131,7 @@ if [[ "$raised_hard_before" != "$raised_hard_after" ]]; then
   echo 'madaros-changed-tests: stack raise changed the hard limit' >&2
   exit 1
 fi
-if [[ "$raised_hard_before" != "unlimited" ]] && ((raised_hard_before < 65536)); then
+if [[ "$raised_hard_before" != "unlimited" ]] && ((raised_hard_before < 1048576)); then
   echo 'madaros-changed-tests: stack raise passed below the finite hard limit' >&2
   exit 1
 fi
@@ -146,7 +144,6 @@ hard_limited_stack="$(
     ulimit -S -s 8192
     ulimit -H -s 8192
     SOUNIO_MADAROS_CHANGED_TESTS_BIN=/bin/true \
-    SOUNIO_MADAROS_CHANGED_TESTS_STACK_KB=65536 \
       "$GATE" -- tests/run-pass/array_repeat_i8_binding.sio
   ) 2>&1
 )"
@@ -156,7 +153,7 @@ if [[ "$hard_limited_stack_rc" == "0" ]]; then
   echo 'madaros-changed-tests: accepted a stack target above the hard limit' >&2
   exit 1
 fi
-grep -Fq 'MADAROS_CHANGED_TESTS_STACK status=blocked scope=linux_ci requested_kb=65536 soft_before_kb=8192 hard_before_kb=8192' \
+grep -Fq 'MADAROS_CHANGED_TESTS_STACK status=blocked scope=linux_ci requested_kb=1048576 soft_before_kb=8192 hard_before_kb=8192' \
   <<<"$hard_limited_stack"
 grep -Fxq 'MADAROS_CHANGED_TESTS_FAIL reason=stack_hard_limit_too_low' \
   < <(tail -n 1 <<<"$hard_limited_stack")

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1249,6 +1249,7 @@ fn lowerer_preseed_program_items_mut(
                                     bss_slot.param_count = bss_off
                                     bss_slot.bss_size = bss_size
                                     bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&head.type_alias_ty)
+                                    bss_slot.return_struct_name = lower_opt_type_named_name(&head.type_alias_ty)
                                     let init_val = ast_lookup_global_var_init(name)
                                     if init_val != 0 {
                                         bss_slot.returns_float = 1
@@ -1686,6 +1687,7 @@ fn ir_fast_summary_preseed_items_seed_owned(
                                         bss_slot.param_count = bss_mod.bss_total_size
                                         bss_slot.bss_size = bss_size
                                         bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&item.type_alias_ty)
+                                        bss_slot.return_struct_name = lower_opt_type_named_name(&item.type_alias_ty)
                                         let init_val = ast_lookup_global_var_init(name)
                                         if init_val != 0 {
                                             bss_slot.returns_float = 1
@@ -1800,6 +1802,7 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                                 bss_slot.param_count = module.bss_total_size
                                 bss_slot.bss_size = bss_size
                                 bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&item.type_alias_ty)
+                                bss_slot.return_struct_name = lower_opt_type_named_name(&item.type_alias_ty)
                                 let init_val = ast_lookup_global_var_init(name)
                                 if init_val != 0 {
                                     bss_slot.returns_float = 1
@@ -1934,6 +1937,26 @@ fn lowerer_bind_local_mut(
         (*lo).locals = locals_box
     } else {
         lowerer_mark_error(lo)
+    }
+}
+
+// *mut analogue of bind_local_scalar_kind. Mutable lowering paths update a
+// summary-owned Lowerer through a pointer, so returning a copied Lowerer can
+// silently lose scalar metadata on the active path.
+fn lowerer_mark_local_scalar_kind_mut(
+    lo: &! Lowerer,
+    name: Name,
+    kind: i64
+) with Mut, Alloc, Panic, Div {
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).scalar_kind[i as usize] = kind
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
     }
 }
 
@@ -2141,7 +2164,9 @@ fn lowerer_lower_fn_params_mut(
                 }
                 lowerer_bind_local_struct_type_mut(lo, (*list).head.name, lower_param_struct_type_name(&(*list).head.ty))
                 if lower_type_expr_is_f64(&(*list).head.ty) {
-                    (*lo) = (*lo).bind_local_scalar_kind((*list).head.name, 2)
+                    lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 2)
+                } else if lower_type_expr_is_i64(&(*list).head.ty) {
+                    lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 1)
                 }
                 if lower_type_expr_is_ref_like(&(*list).head.ty) {
                     lowerer_mark_local_ref_mut(lo, (*list).head.name)
@@ -4758,6 +4783,9 @@ impl Lowerer {
                 if global_elem_kind == LOWER_GLOBAL_ELEM_F64 {
                     lowerer_mark_local_array_elem_float_mut(&! lo, g.name)
                 }
+                if lower_name_is_i64_type(g.return_struct_name) {
+                    lowerer_mark_local_scalar_kind_mut(&! lo, g.name, 1)
+                }
             }
             i = i + 1
         }
@@ -5518,8 +5546,24 @@ impl Lowerer {
             if lower_binary_op_is_compare((*e).bin_op) {
                 return 1
             }
+            if self.expr_result_is_string_ref(e) {
+                return 3
+            }
             if self.expr_result_is_float_ref(e) {
                 return 2
+            }
+            match (*e).left {
+                Some(left) => {
+                    match (*e).right {
+                        Some(right) => {
+                            if self.expr_result_scalar_kind_ref(&(*left)) == 1 && self.expr_result_scalar_kind_ref(&(*right)) == 1 {
+                                return 1
+                            }
+                        }
+                        None => {}
+                    }
+                }
+                None => {}
             }
         }
         if self.expr_result_is_float_ref(e) {
@@ -6411,7 +6455,7 @@ impl Lowerer {
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
                         locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
-                        locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) { 2 } else { 0 }
+                        locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 1 } else { 0 }
                         locals.count = idx + 1
                     } else {
                         lo = lo.report_error()

--- a/tests/run-pass/madaros_print_i64_param.sio
+++ b/tests/run-pass/madaros_print_i64_param.sio
@@ -1,0 +1,31 @@
+//@ run-pass
+//@ expect-stdout: GLOBAL=7
+//@ expect-stdout: SUM=8
+//@ expect-stdout: PARAM=42
+//@ expect-stdout: PARAM_FLOAT=2.500000
+
+var GLOBAL_I64: i64 = 7
+
+fn render(value: i64) with IO {
+    print("PARAM=")
+    print(value)
+    print("\n")
+}
+
+fn render_float(value: f64) with IO {
+    print("PARAM_FLOAT=")
+    print(value)
+    print("\n")
+}
+
+fn main() -> i32 with IO {
+    print("GLOBAL=")
+    print(GLOBAL_I64)
+    print("\n")
+    print("SUM=")
+    print(GLOBAL_I64 + 1)
+    print("\n")
+    render(42)
+    render_float(2.5)
+    0
+}

--- a/tests/run-pass/madaros_print_i64_param.sio
+++ b/tests/run-pass/madaros_print_i64_param.sio
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ requires: madaros
 //@ expect-stdout: GLOBAL=7
 //@ expect-stdout: SUM=8
 //@ expect-stdout: PARAM=42


### PR DESCRIPTION
## Summary

- Preserve declared scalar type metadata for BSS globals through all summary/preseed lowering paths.
- Mark `i64` and `f64` parameters on the active mutable lowering path rather than updating a copied `Lowerer`.
- Classify integer binary expressions when both operands are known `i64` values, so `print()` selects the integer builtin.
- Add a run-pass regression covering BSS `i64`, an `i64` binary expression, an `i64` parameter, and an `f64` parameter.

## Root Cause

The printer dispatch inferred only a subset of scalar kinds. A function parameter of type `i64`, a BSS `i64` global, and a binary `i64` expression could all fall through to the string-print path. That path dereferences the integer as a character pointer and caused the reduced repro to exit with SIGSEGV (139).

## Validation

- `bash scripts/ci/build_modular_madaros.sh /tmp/sounio-madaros-scalar-print-v4/madaros`
- `SOUNIO_MADAROS_BIN=/tmp/sounio-madaros-scalar-print-v4/madaros ./bin/madaros run tests/run-pass/madaros_print_i64_param.sio`
  - exit 0; output: `GLOBAL=7`, `SUM=8`, `PARAM=42`, `PARAM_FLOAT=2.500000`
- `ulimit -s unlimited; SOUNIO_TEST_SOUC_BIN=/tmp/sounio-madaros-scalar-print-v4/madaros bash scripts/run_sio_test_suite.sh --filter-exact madaros_print_i64_param.sio --verbose --jobs 1`
  - `Pass: 1, Fail: 0, Skip: 0`
- `SOUNIO_MADAROS_BIN=/tmp/sounio-madaros-scalar-print-v4/madaros ./bin/madaros run stdlib/ssm/lib.sio`
  - exit 0; the previous SIGSEGV is gone and all 13 checks print `PASS`.
- CI run `29581555387`: success.
  - Full Test Suite: `Pass: 1411`, `Fail: 0`; its uploaded `test-results.xml` includes `madaros_print_i64_param`.
  - Its initial current-source selector skipped the fixture because it lacked `//@ requires: madaros`.
- CI run `29582472289`: selected the fixture after follow-up commit `2b364bb64`, but exposed that the Linux changed-test gate's 64 MiB stack was too small for current-source lowering. The identical Madaros ELF passes the selected test at the canonical 1 GiB stack target.
  - Follow-up commit `200510a5c` raises the Linux gate default to 1 GiB and updates its self-test. The local exact gate then passed with `Pass: 1, Fail: 0, Skip: 0`.
- CI run `29583582889`: success. The current-source Madaros job raised the stack from 16384 KiB to 1048576 KiB, selected `madaros_print_i64_param.sio`, and reported `Pass: 1`, `Fail: 0`, `MADAROS_CHANGED_TESTS_PASS count=1`.

## Scope And Semantic Boundary

- Concept-IDs: none. This changes compiler scalar metadata routing, not a language concept, type definition, effect, or scientific claim.
- Claim introduced: known `i64` and `f64` values reach their matching native printer dispatch.
- Claim explicitly excluded: this does not establish BSS global writeback semantics or full SSM self-test validity.
- `self-hosted/ir/lower.sio` has recent parallel-writer activity; rebase/merge validation should rebuild and rerun this focused test against the merge result.

## Remaining Blocker

- Blocker-ID: `BLK-20260717-madaros-bss-global-writeback`
- Severity: B1
- Class: compiler-semantics
- Evidence level: E3, source-built reproduction
- Owner: unassigned follow-up lane
- Worktree: `/tmp/sounio-madaros-ssm-segv-repro-20260717`
- Branch: `codex/madaros-ssm-segv-repro-20260717`
- Acceptance gate: a minimal BSS global increment reads back the expected stored value and the SSM summary reports `13/13`.
- Next action: reduce `T_PASS = T_PASS + 1` to a tiny BSS mutation repro, then repair assignment lowering in an isolated lane.

## LLM Offload

Not invoked: this change contains no math claim, clinical-pathway code, or external-facing artifact covered by `.claude/AGENT_OFFLOAD_POLICY.md`.