### PR TITLE
fix(native): read_file(path:string)->string returns the mmap buffer pointer

### DIFF
--- a/docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md
+++ b/docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md
@@ -9,6 +9,30 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.data-io-
 
 # Data & Science I/O — Trilha B dispatch: `&local_array` mis-lowered into builtin calls
 
+> ⚠️ **CORRECTION (2026-07-17) — this dispatch's Defect 1 is MISDIAGNOSED. Do not fix as written.**
+> Re-verified on current `main` (Madaros v0.80.0), tree clean, no `self-hosted/` changes kept:
+> - **`str_from_bytes` is NOT broken.** The canonical call shape `str_from_bytes(buf, n)` works
+>   (used by 54 `self-hosted/` files incl. `main.sio`; baseline prints `hi`). The repro below used
+>   `str_from_bytes(&buf, n)` — the **wrong shape**: `&buf` passes the slot address, `buf` passes the
+>   array handle the builtin expects. A codegen "fix" that adds a deref for `&buf` **breaks the
+>   canonical `buf` shape** (verified: it made `str_from_bytes(buf,n)` SIGSEGV) and would break
+>   Madaros self-compilation. Reverted.
+> - **`read_file` is `read_file(path: string) -> string`** (per LSP + all 54 callers), NOT the
+>   `(path:*u8, buf:*u8, max_len)->i64` shape the codegen comment claims, and NOT a `[i8;N]` byte
+>   array (the repro's shape). `read_file(path)` and `file_size(path)` on a `string` **succeed**
+>   (Madaros reads every source file this way).
+> - **The one REAL defect** (different from what is dispatched below): the value returned by
+>   `read_file` (an mmap-backed "string") is **unusable in a standalone Madaros-compiled program** —
+>   every access crashes (`raw[i]`, `str_len(raw)`, `str_char_at(raw,i)` all SIGSEGV), even though
+>   `frd_open`'s identical `raw[i]` idiom works **inside** the Madaros compiler binary. So the string
+>   representation / runtime of `read_file`'s result differs standalone vs in-compiler. This is the
+>   blocker for file readers; it needs FRESH localization (result-string representation, not `&buf`
+>   arg marshalling). See the 2026-07-17 investigation continuing this lane.
+>
+> Net: the "`&local_array` into builtin" root cause below is not the bug. `str_from_bytes`/`file_size`
+> work; `read_file` returns but its result is inaccessible standalone. Everything below is retained as
+> the original (incorrect) dispatch record.
+
 **Date:** 2026-07-14
 **Toolchain:** `./bin/souc` → Madaros v0.80.0 (default engine)
 **Owner:** CODEX-2 (`self-hosted/` — native codegen, builtin argument marshalling)

--- a/docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md
+++ b/docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md
@@ -21,17 +21,33 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.data-io-
 >   `(path:*u8, buf:*u8, max_len)->i64` shape the codegen comment claims, and NOT a `[i8;N]` byte
 >   array (the repro's shape). `read_file(path)` and `file_size(path)` on a `string` **succeed**
 >   (Madaros reads every source file this way).
-> - **The one REAL defect** (different from what is dispatched below): the value returned by
->   `read_file` (an mmap-backed "string") is **unusable in a standalone Madaros-compiled program** —
->   every access crashes (`raw[i]`, `str_len(raw)`, `str_char_at(raw,i)` all SIGSEGV), even though
->   `frd_open`'s identical `raw[i]` idiom works **inside** the Madaros compiler binary. So the string
->   representation / runtime of `read_file`'s result differs standalone vs in-compiler. This is the
->   blocker for file readers; it needs FRESH localization (result-string representation, not `&buf`
->   arg marshalling). See the 2026-07-17 investigation continuing this lane.
+> - **The one REAL defect — ROOT-CAUSED and FIXED 2026-07-17** (commit on branch
+>   `fix/native-builtin-local-array-marshalling`). The native-v2 `emit_builtin_read_file`
+>   (`self-hosted/native/codegen_x86_linux.sio`) implemented a **different 3-arg** function
+>   `read_file(path,buf,max_len)->i64(bytes_read)` and returned an **integer**, while the contract is
+>   1-arg `read_file(path:string)->string` returning a **pointer to a freshly-mmap'd buffer**. So 1-arg
+>   callers dereferenced a non-pointer → SIGSEGV on `raw[i]`/`str_len`/`str_char_at`. It worked
+>   in-compiler only because Madaros's own read_file is emitted by a DIFFERENT emitter (the lean_single
+>   seed's 16 MiB cached-mmap read_file / the bootstrap chain), not by this native-v2 path — so the fix
+>   is native-v2-user-programs-only and cannot touch the bootstrap/self-host. **Fix:** rewrote
+>   `emit_builtin_read_file` to mirror `bootstrap_v0.sio:15028-15087` byte-for-byte (mmap→open→read→
+>   close→return buffer ptr). **Verified:** `read_file`+`str_len`+`str_char_at` byte-exact over a
+>   multi-line CSV; `str_from_bytes(buf,n)` intact; 0/40 run-pass compile regressions.
+>
+> **⚠️ READER LANDMINE:** `raw[i]` (array-index syntax) on `read_file`'s string result **still
+> SIGSEGVs** — a SEPARATE, unfixed string-index-operator bug. `frd_open` uses the `raw[i]` form and it
+> works *in-compiler*, so the idiomatic-looking form is exactly the trap. **File readers MUST use
+> `str_char_at(s,i)` + `str_len(s)`, never `raw[i]`,** until the string-index bug is fixed.
+>
+> **Remaining siblings (NOT fixed; separate items):** (1) `write_file` — identical 3-arg body in the
+> same file, same defect. (2) The `self-hosted/native/codegen.sio` old-backend copy of
+> `emit_builtin_read_file` (reachable via wide/render drivers, not the default path). (3) The `raw[i]`
+> string-index-operator crash above. (4) `file_size`/`read_file` fail on some ABSOLUTE paths but work
+> on relative ones (path-length or cwd resolution — unconfirmed).
 >
 > Net: the "`&local_array` into builtin" root cause below is not the bug. `str_from_bytes`/`file_size`
-> work; `read_file` returns but its result is inaccessible standalone. Everything below is retained as
-> the original (incorrect) dispatch record.
+> work; `read_file` is now FIXED (native-v2 user path). Everything below is retained as the original
+> (incorrect) dispatch record.
 
 **Date:** 2026-07-14
 **Toolchain:** `./bin/souc` → Madaros v0.80.0 (default engine)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -3946,49 +3946,55 @@ fn emit_builtin_str_char_at_into(nc: &! NativeCompiler) with Mut, Panic, Div {
 // M5: File I/O builtins
 // ============================================================================
 
-// read_file(path: *u8, buf: *u8, max_len: i64) -> i64 (bytes read)
-// Uses sys_open, sys_read, sys_close
+// read_file(path: string) -> string  (1-arg): mmap a 1 MiB buffer, open/read/close,
+// return the buffer POINTER (rax). Byte-for-byte mirror of the bootstrap emitter
+// self-hosted/bootstrap/bootstrap_v0.sio:15028-15087 — the form the running compiler
+// (and all 54 self-hosted callers + the LSP contract) uses. The previous native-v2 body
+// implemented a DIFFERENT 3-arg read_file(path,buf,max_len)->bytes_read and returned an
+// INTEGER, so 1-arg callers dereferenced a non-pointer -> SIGSEGV on raw[i]/str_len/
+// str_char_at. (The only 3-arg caller, examples/cognitive_ossm/run_ossm_native_reference.sio,
+// self-documents that it does not native-compile, so no working native 3-arg contract exists.)
+// NUL-termination relies on anonymous-mmap zero-fill: OK for text/CSV < 1 MiB with no embedded
+// NUL; larger/binary files are a known limit. The mmap is intentionally leaked (matches the
+// bootstrap reference). Linux x86-64 only (raw syscalls), per CLAUDE.md.
 fn emit_builtin_read_file(nc: NativeCompiler) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    c.code = emit_push_rbp(c.code)
-    c.code = emit_mov_rbp_rsp(c.code)
-    c.code = emit_sub_rsp_imm32(c.code, 32)
-
-    // Save args: rdi=path, rsi=buf, rdx=max_len
-    // Store buf and max_len on stack for later
-    c.code = emit_store_reg_rbp_disp32(c.code, -8, 6)    // [rbp-8] = rsi (buf)
-    c.code = emit_store_reg_rbp_disp32(c.code, -16, 2)   // [rbp-16] = rdx (max_len)
-
-    // open(path, O_RDONLY=0, 0)
-    // rdi already = path
-    c.code = emit_mov_rax_rdi(c.code)                    // rax = path for Win64
-    c = emit_open_syscall_for_target(c, c.target_os_id, 0, 0)
-
-    // Save fd/handle
-    c.code = emit_store_rax_rbp_disp32(c.code, -24)      // [rbp-24] = fd
-
-    // read(fd, buf, max_len)
-    c.code = emit_mov_rdi_rax(c.code)                    // rdi = fd
-    c.code = emit_load_rbp_disp32_rax(c.code, -8)        // rax = buf
-    c.code = emit_mov_rsi_rax(c.code)                    // rsi = buf
-    c.code = emit_load_rbp_disp32_rax(c.code, -16)       // rax = max_len
-    c.code = emit_mov_rdx_rax(c.code)                    // rdx = max_len
-    c = emit_read_syscall_for_target(c, c.target_os_id)
-
-    // Save bytes_read
-    c.code = emit_store_rax_rbp_disp32(c.code, -32)      // [rbp-32] = bytes_read
-
-    // close(fd)
-    c.code = emit_load_rbp_disp32_rax(c.code, -24)       // rax = fd
-    c.code = emit_mov_rdi_rax(c.code)                    // rdi = fd
-    c = emit_close_syscall_for_target(c, c.target_os_id)
-
-    // Return bytes_read
-    c.code = emit_load_rbp_disp32_rax(c.code, -32)
-
-    c.code = emit_mov_rsp_rbp(c.code)
-    c.code = emit_pop_rbp(c.code)
-    c.code = emit_ret(c.code)
+    var b = c.code
+    b = emit_byte(b, 0x55)                                                       // push rbp
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0xe5)       // mov rbp,rsp
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x83); b = emit_byte(b, 0xec); b = emit_byte(b, 0x20)  // sub rsp,32
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xf8)  // mov [rbp-8],rdi (path)
+    // sys_mmap(NULL, 1 MiB, PROT_READ|PROT_WRITE=3, MAP_PRIVATE|MAP_ANONYMOUS=0x22, -1, 0)
+    b = emit_byte(b, 0x31); b = emit_byte(b, 0xff)                               // xor edi,edi
+    b = emit_byte(b, 0xbe); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x10); b = emit_byte(b, 0x00)  // mov esi,1048576
+    b = emit_byte(b, 0xba); b = emit_byte(b, 0x03); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov edx,3
+    b = emit_byte(b, 0x41); b = emit_byte(b, 0xba); b = emit_byte(b, 0x22); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov r10d,0x22
+    b = emit_byte(b, 0x41); b = emit_byte(b, 0xb8); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff)  // mov r8d,-1
+    b = emit_byte(b, 0x45); b = emit_byte(b, 0x31); b = emit_byte(b, 0xc9)       // xor r9d,r9d
+    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x09); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,9 (mmap)
+    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xf0)  // mov [rbp-16],rax (buf ptr)
+    // sys_open(path, O_RDONLY=0, 0)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xf8)  // mov rdi,[rbp-8]
+    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x02); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,2 (open)
+    b = emit_byte(b, 0x31); b = emit_byte(b, 0xf6)                               // xor esi,esi
+    b = emit_byte(b, 0x31); b = emit_byte(b, 0xd2)                               // xor edx,edx
+    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xe8)  // mov [rbp-24],rax (fd)
+    // sys_read(fd, buf, 1 MiB)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0xc7)       // mov rdi,rax (fd)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x75); b = emit_byte(b, 0xf0)  // mov rsi,[rbp-16] (buf)
+    b = emit_byte(b, 0xba); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x10); b = emit_byte(b, 0x00)  // mov edx,1048576
+    b = emit_byte(b, 0x31); b = emit_byte(b, 0xc0)                               // xor eax,eax (read)
+    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
+    // sys_close(fd)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xe8)  // mov rdi,[rbp-24] (fd)
+    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x03); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,3 (close)
+    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x45); b = emit_byte(b, 0xf0)  // mov rax,[rbp-16] (return buf ptr)
+    b = emit_byte(b, 0xc9)                                                       // leave
+    b = emit_byte(b, 0xc3)                                                       // ret
+    c.code = b
     c
 }
 


### PR DESCRIPTION
## What

The native-v2 `emit_builtin_read_file` (`self-hosted/native/codegen_x86_linux.sio`) implemented
the **wrong function**: a 3-arg `read_file(path, buf, max_len) -> i64 (bytes_read)` that returned
an **integer** in `rax`. But the language contract (LSP + all 54 self-hosted callers) is the 1-arg
`read_file(path: string) -> string` that returns a **pointer to a freshly-mmap'd buffer**. So a
1-arg caller dereferenced a non-pointer — `raw[i]`, `str_len(raw)`, `str_char_at(raw,i)` all
SIGSEGV'd on the result. It worked inside the running compiler only because Madaros's own read_file
is emitted by a **different** emitter (the lean_single seed's 16 MiB cached-mmap read_file / the
bootstrap chain), not by this native-v2 path.

## Fix

Rewrote `emit_builtin_read_file` to mirror `self-hosted/bootstrap/bootstrap_v0.sio:15028-15087`
byte-for-byte: `sys_mmap(1 MiB, anon, rw)` → `open(O_RDONLY)` → `read` → `close` → return the
buffer pointer in `rax`, ignoring `rsi`/`rdx`. NUL-termination relies on anonymous-mmap zero-fill
(text/CSV < 1 MiB, no embedded NUL). Linux x86-64 raw syscalls (per CLAUDE.md).

## Scope / self-host

This is the native-v2 `souc compile` path for **user programs only**. The Madaros build chain emits
`main.sio`'s read_file via the lean_single seed (which does **not** import `codegen_x86_linux.sio`
and has its own read_file), so this edit **cannot** affect the bootstrap/self-host — confirmed by
grep, self-host is *not-applicable* here, not merely low-risk.

## Verification (fixed Madaros, discriminators)

| Check | Result |
|---|---|
| `read_file`+`str_len`+`str_char_at` over a 25-byte multi-line CSV | ✅ byte-exact (was 3× SIGSEGV) |
| baseline Madaros, same test | ✗ crashes (proves the fix did it) |
| `str_from_bytes(buf,n)` → "hi" | ✅ intact |
| user-fn `&[i8;N]` ref → 104 | ✅ intact |
| 40 run-pass tests, differential baseline vs fixed | ✅ **0 compile regressions** |

## ⚠️ Reader landmine (separate, NOT fixed here)

`raw[i]` (array-index syntax) on read_file's string result **still SIGSEGVs** — a separate
string-index-operator bug. `frd_open` uses `raw[i]` and it works *in-compiler*, so the idiomatic
form is the trap. **File readers MUST use `str_char_at(s,i)` + `str_len(s)`, never `raw[i]`.**

## Remaining siblings (separate items, tracked in the corrected dispatch doc)

`write_file` (identical 3-arg body, same file), the `codegen.sio` old-backend copy, the `raw[i]`
string-index crash, and `file_size` failing on some absolute paths.

## Context

Continues the Data & Science I/O Trilha B lane. Investigation corrected two prior misdiagnoses
(the dispatched "`&local_array` into builtin" root cause was wrong-shape repros — `str_from_bytes(buf,n)`
and `file_size` already work); see the updated `docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)