### PR TITLE
fix(madaros): reload scalar BSS globals

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -132,6 +132,7 @@ fn empty_lower_loop_labels() -> LowerLoopLabels {
 }
 
 let LOWER_GLOBAL_ELEM_F64: i64 = 2
+let LOWER_GLOBAL_SCALAR_F64: i64 = 3
 
 pub struct LowerGlobalTypeTable {
     // Indexed by IrModule.functions slot. Keep this aligned with IR_MAX_FUNCS;
@@ -1785,7 +1786,8 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                             }
                         }
                         _ => {
-                            let bss_fid = module.fn_count
+                            var bss_mod = module
+                            let bss_fid = bss_mod.fn_count
                             if bss_fid < IR_MAX_FUNCS {
                                 global_types = lower_global_type_table_record(
                                     global_types,
@@ -1797,7 +1799,7 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                                 var bss_slot = ir_empty_function()
                                 bss_slot.name = name
                                 bss_slot.compile_strategy = IR_STRATEGY_BSS_GLOBAL
-                                bss_slot.param_count = module.bss_total_size
+                                bss_slot.param_count = bss_mod.bss_total_size
                                 bss_slot.bss_size = bss_size
                                 bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&item.type_alias_ty)
                                 let init_val = ast_lookup_global_var_init(name)
@@ -1805,10 +1807,11 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                                     bss_slot.returns_float = 1
                                     bss_slot.prof_counter_id = init_val
                                 }
-                                module.functions[bss_fid as usize] = bss_slot
-                                module.fn_count = bss_fid + 1
-                                module.bss_total_size = module.bss_total_size + aligned_size
+                                bss_mod.functions[bss_fid as usize] = bss_slot
+                                bss_mod.fn_count = bss_fid + 1
+                                bss_mod.bss_total_size = bss_mod.bss_total_size + aligned_size
                             }
+                            module = bss_mod
                         }
                     }
                 } else if kind == ItemKind::ItemStruct {
@@ -1970,6 +1973,23 @@ fn lowerer_mark_local_array_elem_float_mut(
     while i >= 0 {
         if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
             (*locals_box).array_elem_float[i as usize] = 1
+            (*lo).locals = locals_box
+            return
+        }
+        i = i - 1
+    }
+}
+
+fn lowerer_mark_local_scalar_kind_mut(
+    lo: &! Lowerer,
+    name: Name,
+    kind: i64
+) with Mut, Alloc, Panic, Div {
+    var locals_box = (*lo).locals
+    var i = (*locals_box).count - 1
+    while i >= 0 {
+        if (*locals_box).depths[i as usize] <= (*lo).scope_depth && ir_name_eq((*locals_box).names[i as usize], name) {
+            (*locals_box).scalar_kind[i as usize] = kind
             (*lo).locals = locals_box
             return
         }
@@ -2498,6 +2518,7 @@ fn lower_type_expr_is_array_of_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
 fn lower_global_elem_kind(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
     match *ty_opt {
         Some(ty) => {
+            if lower_type_expr_is_f64(&(*ty)) { return LOWER_GLOBAL_SCALAR_F64 }
             if lower_type_expr_is_array_of_f64(&(*ty)) { return LOWER_GLOBAL_ELEM_F64 }
             0
         }
@@ -4755,7 +4776,10 @@ impl Lowerer {
                     print_int(global_elem_kind)
                     print("\n")
                 }
-                if global_elem_kind == LOWER_GLOBAL_ELEM_F64 {
+                if global_elem_kind == LOWER_GLOBAL_SCALAR_F64 {
+                    lo = lo.emit(ir_mark_float_reg(reg))
+                    lowerer_mark_local_scalar_kind_mut(&! lo, g.name, 2)
+                } else if global_elem_kind == LOWER_GLOBAL_ELEM_F64 {
                     lowerer_mark_local_array_elem_float_mut(&! lo, g.name)
                 }
             }
@@ -9869,6 +9893,21 @@ impl Lowerer {
                     print("error: capturing closure cannot be used as a value (escaping closures are not yet supported); only a direct call of the closure is allowed\n")
                     let loe = self.report_fatal_lowering_error()
                     return (loe, 0)
+                }
+                // Scalar BSS bindings are loaded in each function only to retain
+                // global metadata for stores. A callee can update the backing
+                // slot, so reads must reload it instead of using that stale
+                // per-function snapshot. Aggregate bindings remain base pointers.
+                if self.lookup_local_is_global(e.name) && self.lookup_local_global_bss_size(e.name) <= 8 {
+                    let bss_off = self.lookup_local_global_bss_offset(e.name)
+                    let pair = self.fresh_reg()
+                    let lo = pair.0
+                    let reg = pair.1
+                    let lo2 = lo.emit(ir_load_global(reg, bss_off, e.name))
+                    if self.lookup_local_scalar_kind(e.name) == 2 {
+                        return (lo2.emit(ir_mark_float_reg(reg)), reg)
+                    }
+                    return (lo2, reg)
                 }
                 (self, src)
             } else {

--- a/tests/run-pass/madaros_bss_global_writeback.sio
+++ b/tests/run-pass/madaros_bss_global_writeback.sio
@@ -1,0 +1,31 @@
+//@ run-pass
+//@ requires: madaros
+
+var BSS_COUNTER: i64 = 0
+var BSS_RATIO: f64 = 0.0
+
+fn increment() -> i64 with Mut {
+    BSS_COUNTER = BSS_COUNTER + 1
+    return BSS_COUNTER
+}
+
+fn increment_ratio() -> f64 with Mut {
+    BSS_RATIO = BSS_RATIO + 1.0
+    return BSS_RATIO
+}
+
+fn main() -> i64 with Mut {
+    if increment() != 1 {
+        return 1
+    }
+    if increment_ratio() != 1.0 {
+        return 3
+    }
+    if BSS_COUNTER != 1 {
+        return 2
+    }
+    if BSS_RATIO != 1.0 {
+        return 4
+    }
+    return 0
+}


### PR DESCRIPTION
## Summary

Fix scalar BSS globals so a caller observes mutations made by a callee. The
regression covers independent `i64` and `f64` globals across function calls.

## Root Cause

Three defects compounded here:

1. Each function preloaded scalar BSS values into registers and subsequent
   identifier reads reused that stale snapshot after a callee wrote the BSS slot.
2. The active flat-summary path updated the wide `IrModule` aggregate directly,
   causing later BSS globals to reuse offset zero rather than accumulate offsets.
3. Scalar `f64` globals were not recorded as float local metadata, so their
   reloads reached native codegen on the integer conversion path.

## Change

- Reload scalar BSS bindings for identifier reads; aggregate BSS bindings keep
  their existing base-pointer behavior.
- Allocate BSS slots through a local `IrModule` copy and assign it back after
  each global, preserving distinct offsets.
- Record scalar `f64` global type metadata through a mutable local update and
  emit the float marker for initial and reloaded values.
- Add `madaros_bss_global_writeback.sio`, which verifies both scalar types
  after calls that mutate their respective globals.

## Validation

- `bash scripts/ci/build_modular_madaros.sh /tmp/sounio-madaros-bss-writeback-v6/madaros`
- `SOUNIO_MADAROS_CHANGED_TESTS_BIN=/tmp/sounio-madaros-bss-writeback-v6/madaros bash scripts/ci/madaros_changed_tests_gate.sh tests/run-pass/madaros_bss_global_writeback.sio`
  - `Pass: 1`, `Fail: 0`
- `SOUNIO_MADAROS_GLOBAL_F64_GATE_BIN=/tmp/sounio-madaros-bss-writeback-v6/madaros bash scripts/ci/madaros_global_f64_scratch_gate.sh`
  - passed the f64-array witness after 256 globals
- `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tests/run-pass/madaros_bss_global_writeback.sio`
  - exit `0`
- The generated ELF reserves 16 BSS bytes for the two globals; its f64 reload
  uses `movq xmm0, rax`, not `cvtsi2sd`.

## Scope And Coordination

This does not claim aggregate BSS or unrelated global-initializer semantics.
`self-hosted/ir/lower.sio` also has a separate committed Contest-metadata lane;
its hunks were disjoint at integration time. Rebase and rerun the focused gate
if that lane lands first.

## Semantic Lane

```text
Semantic-Lane-ID: madaros-bss-writeback
Owner: Codex
Concept-IDs: none
Intent-Preserved: scalar mutable globals reflect writes across function calls
Transformation: scalar BSS identifier reads emit a fresh IrLoadGlobal
Types-Changed: scalar f64 globals retain float register metadata
Effects-Changed: none
IR-Changed: scalar BSS read path; BSS offset accumulation in flat summary
Claims-Introduced: i64 and f64 scalar BSS read-after-call behavior is covered
Claims-Forbidden: no aggregate-BSS or broad global-initializer claim
Assumptions: BSS values with size <= 8 are scalar reloads; larger BSS values are pointers
Write-Set: self-hosted/ir/lower.sio; tests/run-pass/madaros_bss_global_writeback.sio
Read-Set: self-hosted/ir/ir.sio; self-hosted/native/codegen_x86_linux.sio
Positive-Witness: madaros_bss_global_writeback.sio
Negative-Witness: pre-fix current-source binary exited 2 for stale scalar read
Acceptance: rebuilt Madaros changed-test gate passes
Integration target: main
Authoritative only if: current-source CI is green after rebase
```

## Blocker Contract

`BLK-20260717-madaros-bss-scalar-read-after-call` is resolved locally at E4:
severity B1, class `compiler-semantics`, owner Codex, acceptance gate
`madaros_changed_tests_gate.sh`, next action GitHub CI. Legacy `lean_single`
remains available as a control and is not used as a silent fallback.

LLM offload review: not invoked; this change does not touch math claims,
clinical-pathway code, or external-facing artifacts.
