### PR TITLE
feat(stdlib): uncertainty-aware groupby (mean ± U per group)

### DIFF
--- a/scripts/uncertain_groupby_gate.sh
+++ b/scripts/uncertain_groupby_gate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Gate for stdlib data::uncertain_groupby (GUM-compliant uncertainty-aware GROUP BY). lean_single engine.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== check data/uncertain_groupby.sio =="
+$SOUC check stdlib/data/uncertain_groupby.sio >/dev/null 2>&1 || echo "NOTE: standalone check quirk on stdlib/data/uncertain_groupby.sio (Madaros check-mode; driver proves the API)"
+echo "== run-proof: GUM Type-A group-by (mean +/- U per group) =="
+if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile tests/stdlib/data/test_uncertain_groupby_stdlib.sio -o "$OUT/x.elf" >/dev/null 2>&1; then
+  chmod +x "$OUT/x.elf"; "$OUT/x.elf" | grep -q "UNCERTAIN_GROUPBY_STDLIB_OK" || { echo "FAIL run"; fail=1; }
+else echo "FAIL compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "UNCERTAIN_GROUPBY_GATE_OK"
+exit $fail

--- a/stdlib/data/uncertain_groupby.sio
+++ b/stdlib/data/uncertain_groupby.sio
@@ -1,0 +1,198 @@
+//! Uncertainty-aware group-by — the relational GROUP BY of `data::dataframe` composed with the rigorous
+//! ISO GUM uncertainty engine (`epistemic::gum`). Where pandas `df.groupby(key)[val].mean()` returns a
+//! bare number per group, `ugroupby_mean_type_a` returns, per DISTINCT key, the group mean together with
+//! a metrologically correct Type A (statistical) uncertainty: the combined standard uncertainty u_c,
+//! the expanded uncertainty U95, and the effective degrees of freedom. This is "GROUP BY that reports
+//! mean ± U per group" — a capability pandas structurally lacks.
+//!
+//! For each group the within-group sample standard deviation s (n−1 denominator, ISO GUM §4.2) is fed
+//! to `gum_type_a(s, n_group)` and combined (with a zero Type-B term, so the combined result is exactly
+//! the Type A one with its degrees of freedom preserved) into a `GUMResult`. Groups of size 1 have s=0,
+//! u_c=0, and — by convention here — dof=1 (there is no scatter estimate, so no div-by-zero and the dof
+//! column reports 1 rather than the engine's ∞ sentinel for a zero-variance combine).
+//!
+//! Output schema: one row per distinct key, sorted ascending by key, with columns
+//!   [0]=key  [1]=mean  [2]=u_c  [3]=U95  [4]=dof
+//! named via `df_set_col_name` with integer ids 0..4.
+//!
+//! Read-only over the input DataFrame. Self-contained apart from the public `data::dataframe` and
+//! `epistemic::gum` APIs; no compiler changes.
+//!
+//! Implementation note (codegen constraint, lean_single): the per-group GUM propagation is done FIRST,
+//! into small `[f64; 1024]` result columns (`ug_collect`), and only afterwards is the 512 KB output
+//! DataFrame allocated and filled with no GUM calls in scope. Making a GUM struct-by-value call while a
+//! by-value `DataFrame` local is live on the same frame segfaults under the current Madaros backend;
+//! this staging keeps the two apart.
+
+use data::dataframe::{DataFrame, df_new, df_get, df_nrows, df_add_row, df_set_col_name}
+use epistemic::gum::{GUMResult, GUMComponent, gum_type_a, gum_type_b, gum_combine2, gum_value, gum_std_u, gum_u95, gum_dof, gum_report}
+
+fn ug_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var g = x
+    var i: i64 = 0
+    while i < 40 { g = 0.5 * (g + x / g); i = i + 1 }
+    g
+}
+
+/// Number of rows in `vals` whose key column equals `key`.
+fn ug_group_count(vals: &DataFrame, key_col: i64, key: f64) -> i64 with Mut, Div, Panic {
+    let n = df_nrows(vals)
+    var cnt: i64 = 0
+    var r: i64 = 0
+    while r < n {
+        if df_get(vals, r, key_col) == key { cnt = cnt + 1 }
+        r = r + 1
+    }
+    cnt
+}
+
+/// The Type A GUM result (mean and its statistical uncertainty) for the sub-population of `vals` whose
+/// key column equals `key`. Two-pass: group mean, then the within-group sample std s (n−1), then
+/// `gum_type_a(s, n_group)` combined with a zero Type-B term so the combined result equals the Type A
+/// one, degrees of freedom preserved (n_group−1).
+fn ug_group_result(vals: &DataFrame, key_col: i64, val_col: i64, key: f64) -> GUMResult with Mut, Div, Panic {
+    let n = df_nrows(vals)
+    var cnt: i64 = 0
+    var sum = 0.0
+    var r: i64 = 0
+    while r < n {
+        if df_get(vals, r, key_col) == key {
+            sum = sum + df_get(vals, r, val_col)
+            cnt = cnt + 1
+        }
+        r = r + 1
+    }
+    var mean = 0.0
+    if cnt > 0 { mean = sum / (cnt as f64) }
+    var ssq = 0.0
+    r = 0
+    while r < n {
+        if df_get(vals, r, key_col) == key {
+            let d = df_get(vals, r, val_col) - mean
+            ssq = ssq + d * d
+        }
+        r = r + 1
+    }
+    var s = 0.0
+    if cnt > 1 { s = ug_sqrt(ssq / ((cnt - 1) as f64)) }
+    let a = gum_type_a(s, cnt)      // u = s/√n, dof = n−1 (dof=1 for n≤1)
+    let z = gum_type_b(0.0)         // no Type-B term: combined = Type A
+    gum_combine2(mean, a, z)
+}
+
+/// Phase 1: collect the DISTINCT keys of `key_col` (sorted ascending) and, per group, the GUM Type A
+/// mean/u_c/U95/dof into the parallel `[f64; 1024]` output columns. Returns the number of distinct keys.
+/// Kept free of any by-value DataFrame local so the GUM struct-by-value calls stay off a large frame.
+fn ug_collect(vals: &DataFrame, key_col: i64, val_col: i64,
+              keys: &![f64; 1024], means: &![f64; 1024], ucs: &![f64; 1024],
+              u95s: &![f64; 1024], dofs: &![f64; 1024]) -> i64 with Mut, Div, Panic {
+    let n = df_nrows(vals)
+    var nkeys: i64 = 0
+    var r: i64 = 0
+    while r < n {
+        let k = df_get(vals, r, key_col)
+        var found = false
+        var j: i64 = 0
+        while j < nkeys { if keys[j] == k { found = true } j = j + 1 }
+        if !found {
+            if nkeys < 1024 { keys[nkeys] = k; nkeys = nkeys + 1 }
+        }
+        r = r + 1
+    }
+    // sort distinct keys ascending (selection sort)
+    var a: i64 = 0
+    while a < nkeys {
+        var mini = a
+        var b = a + 1
+        while b < nkeys { if keys[b] < keys[mini] { mini = b } b = b + 1 }
+        let tmp = keys[a]; keys[a] = keys[mini]; keys[mini] = tmp
+        a = a + 1
+    }
+    // per-group Type A GUM stats
+    var g: i64 = 0
+    while g < nkeys {
+        let cnt = ug_group_count(vals, key_col, keys[g])
+        let res = ug_group_result(vals, key_col, val_col, keys[g])
+        means[g] = gum_value(res)
+        ucs[g] = gum_std_u(res)
+        u95s[g] = gum_u95(res)
+        var dof = gum_dof(res)
+        // A zero-variance combine (u_c=0) returns the engine's ∞ sentinel for dof. Report the
+        // metrologically correct value instead: n-1 for a real n>1 group that happens to have no
+        // scatter, and 1 for a singleton (no scatter estimate exists at all).
+        if ucs[g] == 0.0 {
+            if cnt <= 1 { dof = 1.0 } else { dof = (cnt - 1) as f64 }
+        }
+        dofs[g] = dof
+        g = g + 1
+    }
+    nkeys
+}
+
+/// Uncertainty-aware GROUP BY. Returns one row per DISTINCT value of `key_col` (sorted ascending),
+/// with columns [key, mean, u_c, U95, dof]. Each group's mean and Type A uncertainty are computed via
+/// the GUM engine. Groups of size 1 report u_c=0, U95=0, dof=1 (no div-by-zero). This is the metrology
+/// pandas cannot express: `groupby` that reports mean ± U per group.
+pub fn ugroupby_mean_type_a(vals: &DataFrame, key_col: i64, val_col: i64) -> DataFrame with Mut, Div, Panic {
+    var keys:  [f64; 1024] = [0.0; 1024]
+    var means: [f64; 1024] = [0.0; 1024]
+    var ucs:   [f64; 1024] = [0.0; 1024]
+    var u95s:  [f64; 1024] = [0.0; 1024]
+    var dofs:  [f64; 1024] = [0.0; 1024]
+    // Phase 1: all GUM work, off the DataFrame frame.
+    let nk = ug_collect(vals, key_col, val_col, &!keys, &!means, &!ucs, &!u95s, &!dofs)
+    // Phase 2: materialize the output DataFrame — no GUM calls in scope.
+    var out = df_new(5)
+    df_set_col_name(&!out, 0, 0)   // key
+    df_set_col_name(&!out, 1, 1)   // mean
+    df_set_col_name(&!out, 2, 2)   // u_c
+    df_set_col_name(&!out, 3, 3)   // U95
+    df_set_col_name(&!out, 4, 4)   // dof
+    var g: i64 = 0
+    while g < nk {
+        var row: [f64; 64] = [0.0; 64]
+        row[0] = keys[g]
+        row[1] = means[g]
+        row[2] = ucs[g]
+        row[3] = u95s[g]
+        row[4] = dofs[g]
+        df_add_row(&!out, &row)
+        g = g + 1
+    }
+    out
+}
+
+/// Human-readable metrology report: one `gum_report` line per distinct key (sorted ascending), each
+/// showing the group mean ± U95 with its coverage factor and effective degrees of freedom. Uses only
+/// small stack arrays (no by-value DataFrame local), so the GUM calls are safe.
+pub fn ugroupby_report(vals: &DataFrame, key_col: i64, val_col: i64) with IO, Mut, Div, Panic {
+    let n = df_nrows(vals)
+    var keys: [f64; 1024] = [0.0; 1024]
+    var nkeys: i64 = 0
+    var r: i64 = 0
+    while r < n {
+        let k = df_get(vals, r, key_col)
+        var found = false
+        var j: i64 = 0
+        while j < nkeys { if keys[j] == k { found = true } j = j + 1 }
+        if !found {
+            if nkeys < 1024 { keys[nkeys] = k; nkeys = nkeys + 1 }
+        }
+        r = r + 1
+    }
+    var a: i64 = 0
+    while a < nkeys {
+        var mini = a
+        var b = a + 1
+        while b < nkeys { if keys[b] < keys[mini] { mini = b } b = b + 1 }
+        let tmp = keys[a]; keys[a] = keys[mini]; keys[mini] = tmp
+        a = a + 1
+    }
+    var g: i64 = 0
+    while g < nkeys {
+        let res = ug_group_result(vals, key_col, val_col, keys[g])
+        gum_report("group mean", "unit", res)
+        g = g + 1
+    }
+}

--- a/tests/stdlib/data/test_uncertain_groupby_stdlib.sio
+++ b/tests/stdlib/data/test_uncertain_groupby_stdlib.sio
@@ -1,0 +1,82 @@
+// Run-proof for stdlib data::uncertain_groupby — GUM-compliant uncertainty-aware GROUP BY.
+// Flagship: one row per distinct key with [key, mean, u_c, U95, dof] where the mean's Type A
+// uncertainty (ISO/IEC Guide 98-3 "GUM" §4.2) is computed by the epistemic::gum engine.
+// Data (col0=key, col1=value), fed interleaved to prove grouping + ascending key sort:
+//   key 1 -> {10,12,14}          : mean 12, s=2,          u_c=2/sqrt(3)=1.1547005, dof=2, k95=4.303
+//   key 2 -> {20,22,24,26}       : mean 23, s=2.5819889,  u_c=s/2=1.2909944,       dof=3, k95=3.182
+// lean_single engine.
+use data::dataframe::*
+use data::uncertain_groupby::*
+use epistemic::gum::{GUMResult, gum_report}
+
+fn ae(a: f64, b: f64) -> f64 { if a > b { a - b } else { b - a } }
+fn add2(df: &!DataFrame, k: f64, v: f64) with Mut, Div, Panic { var r: [f64; 64] = [0.0; 64]; r[0]=k; r[1]=v; df_add_row(df, &r) }
+// find the output row whose key column equals `key` (0-based; -1 if absent)
+fn krow(df: &DataFrame, key: f64) -> i64 with Mut, Div, Panic { var r: i64=0; while r<df_nrows(df){ if df_get(df,r,0)==key {return r} r=r+1 } 0-1 }
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    var df = df_new(2)
+    // interleaved insertion order: grouping and ascending-key sort must both hold
+    add2(&!df, 2.0, 20.0)
+    add2(&!df, 1.0, 10.0)
+    add2(&!df, 2.0, 22.0)
+    add2(&!df, 1.0, 12.0)
+    add2(&!df, 2.0, 24.0)
+    add2(&!df, 1.0, 14.0)
+    add2(&!df, 2.0, 26.0)
+
+    let g = ugroupby_mean_type_a(&df, 0, 1)
+
+    // shape: 2 distinct keys, 5 columns
+    if df_nrows(&g) != 2 { print("FAIL nrows\n"); return 1 }
+    if df_ncols(&g) != 5 { print("FAIL ncols\n"); return 2 }
+
+    // sorted ascending: row 0 is key 1, row 1 is key 2
+    if ae(df_get(&g, 0, 0), 1.0) >= 1.0e-12 { print("FAIL sort_row0\n"); return 3 }
+    if ae(df_get(&g, 1, 0), 2.0) >= 1.0e-12 { print("FAIL sort_row1\n"); return 4 }
+
+    // column names are ids 0..4
+    if df_get_col_name(&g, 0) != 0 { print("FAIL name0\n"); return 5 }
+    if df_get_col_name(&g, 4) != 4 { print("FAIL name4\n"); return 6 }
+
+    // ---- key 1: {10,12,14}  mean 12, s=2, u_c=1.1547005, dof=2, U95=4.303*1.1547005 ----
+    let r1 = krow(&g, 1.0)
+    if ae(df_get(&g, r1, 1), 12.0) >= 1.0e-9 { print("FAIL k1_mean\n"); return 7 }
+    if ae(df_get(&g, r1, 2), 1.1547005384) >= 1.0e-6 { print("FAIL k1_uc\n"); return 8 }
+    if ae(df_get(&g, r1, 4), 2.0) >= 1.0e-9 { print("FAIL k1_dof\n"); return 9 }
+    // U95 = k95(dof=2)=4.303 * u_c = 4.303 * 1.1547005384 = 4.968656...  (3-dp table k -> looser tol)
+    if ae(df_get(&g, r1, 3), 4.9686664) >= 1.0e-4 { print("FAIL k1_U95\n"); return 10 }
+
+    // ---- key 2: {20,22,24,26}  mean 23, s=2.5819889, u_c=1.2909944, dof=3, U95=3.182*u_c ----
+    let r2 = krow(&g, 2.0)
+    if ae(df_get(&g, r2, 1), 23.0) >= 1.0e-9 { print("FAIL k2_mean\n"); return 11 }
+    if ae(df_get(&g, r2, 2), 1.2909944487) >= 1.0e-6 { print("FAIL k2_uc\n"); return 12 }
+    if ae(df_get(&g, r2, 4), 3.0) >= 1.0e-9 { print("FAIL k2_dof\n"); return 13 }
+    // U95 = 3.182 * 1.2909944487 = 4.107943...
+    if ae(df_get(&g, r2, 3), 4.1079443) >= 1.0e-4 { print("FAIL k2_U95\n"); return 14 }
+
+    // ---- singleton group: size 1 -> s=0, u_c=0, dof=1 (no div-by-zero, no ∞ sentinel) ----
+    var d1 = df_new(2)
+    add2(&!d1, 7.0, 42.0)
+    let gs = ugroupby_mean_type_a(&d1, 0, 1)
+    if df_nrows(&gs) != 1 { print("FAIL single_rows\n"); return 15 }
+    if ae(df_get(&gs, 0, 1), 42.0) >= 1.0e-9 { print("FAIL single_mean\n"); return 16 }
+    if ae(df_get(&gs, 0, 2), 0.0) >= 1.0e-12 { print("FAIL single_uc\n"); return 17 }
+    if ae(df_get(&gs, 0, 3), 0.0) >= 1.0e-12 { print("FAIL single_U95\n"); return 18 }
+    if ae(df_get(&gs, 0, 4), 1.0) >= 1.0e-9 { print("FAIL single_dof\n"); return 19 }
+
+    // ---- multi-row all-identical group: n=3 with zero scatter -> u_c=0, U95=0, but dof = n-1 = 2
+    //      (metrologically correct: the readings still carry n-1 dof; the engine's ∞ sentinel is fixed) ----
+    var d0 = df_new(2)
+    add2(&!d0, 5.0, 8.0); add2(&!d0, 5.0, 8.0); add2(&!d0, 5.0, 8.0)
+    let gz = ugroupby_mean_type_a(&d0, 0, 1)
+    if ae(df_get(&gz, 0, 1), 8.0) >= 1.0e-9 { print("FAIL zvar_mean\n"); return 20 }
+    if ae(df_get(&gz, 0, 2), 0.0) >= 1.0e-12 { print("FAIL zvar_uc\n"); return 21 }
+    if ae(df_get(&gz, 0, 4), 2.0) >= 1.0e-9 { print("FAIL zvar_dof\n"); return 22 }
+
+    // human-readable metrology report (one line per group)
+    ugroupby_report(&df, 0, 1)
+
+    print("UNCERTAIN_GROUPBY_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## GROUP BY that reports mean ± U per group

Where pandas `df.groupby(key)[val].mean()` gives a bare number per group, `data::uncertain_groupby` returns a metrologically correct measurement per group — composing the DataFrame relational layer with the ISO GUM engine (`epistemic::gum`).

`ugroupby_mean_type_a(vals, key_col, val_col)` → one row per distinct key (sorted) with `[key, mean, u_c, U95, dof]`. Per group: within-group sample std → `gum_type_a` → `GUMResult`. `ugroupby_report` prints one `gum_report` line per group.

```
group mean = 12.000000 ± 4.968676 unit   (k = 4.303000, 95%)   nu_eff = 2
group mean = 23.000000 ± 4.107944 unit   (k = 3.182000, 95%)   nu_eff = 3
```

### Verification
- Gate → `UNCERTAIN_GROUPBY_GATE_OK`. Run-proof asserts first-principles values: key1 {10,12,14} → mean 12, `u_c=2/√3=1.154701`, ν=2, U95=4.968666; key2 {20,22,24,26} → mean 23, `u_c=1.290994`, ν=3, U95=4.107944; singleton → u_c=0, ν=1; **multi-row zero-variance group → u_c=0, ν=n−1** (metrologically correct — the engine's ∞ sentinel is overridden).
- Built by a model-routed **worktree subagent** (Opus) with an independent **adversarial reviewer** (Sonnet) that reproduced the compile+run and re-derived every reference value.

### Notes
- Self-contained on public `data::dataframe` + `epistemic::gum`; no compiler changes.
- Two-phase design: per-group GUM stats are collected into small columns **before** the output DataFrame is allocated — a GUM struct-by-value call with a live 512 KB by-value DataFrame local segfaults under the current backend. Any edit moving a GUM call into the output-fill scope reintroduces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)