### PR TITLE
feat(gpu): sedenion O-SSM cell + T-recurrence from source on tensor cores (HW-validated GB10)

### DIFF
--- a/docs/gpu/ossm_sed_cell_tile.ptx
+++ b/docs/gpu/ossm_sed_cell_tile.ptx
@@ -1,0 +1,217 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+.visible .entry step(
+    .param .u64 pA,
+    .param .u64 pB,
+    .param .u64 px,
+    .param .u64 pC,
+    .param .u64 pH,
+    .param .u64 py
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[2048];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pA];
+    ld.param.u64 %rd1, [pB];
+    ld.param.u64 %rd2, [px];
+    ld.param.u64 %rd3, [pC];
+    ld.param.u64 %rd4, [pH];
+    ld.param.u64 %rd5, [py];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $CELL1;
+    mov.u16 %rs1, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$CZ:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs1;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $CZ;
+    mov.u32 %r5, 0;
+$LB0:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB0;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$HSTG:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $HSTG;
+$CELL1:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $CELL2;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$CSIG:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    cvt.rn.f32.f64 %f1, %fd1;
+    mul.wide.u32 %rd7, %r7, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd2, [%rd7];
+    cvt.rn.f32.f64 %f2, %fd2;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f3, [%r9];
+    fma.rn.f32 %f3, %f1, %f2, %f3;
+    mul.f32 %f4, %f3, %f3;
+    mul.f32 %f5, %f4, %f3;
+    fma.rn.f32 %f6, %f3, 0f3E800000, 0f3F000000;
+    fma.rn.f32 %f3, %f5, 0f3C800000, %f6;
+    cvt.rn.f16.f32 %rs0, %f3;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $CSIG;
+    mov.u32 %r5, 0;
+$LB1:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB1;
+$CELL2:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $CELL3;
+    ld.shared.f32 %f1, [shared_array+1024];
+    st.global.f32 [%rd5+0], %f1;
+    ld.shared.f32 %f1, [shared_array+1028];
+    st.global.f32 [%rd5+4], %f1;
+    ld.shared.f32 %f1, [shared_array+1032];
+    st.global.f32 [%rd5+8], %f1;
+    ld.shared.f32 %f1, [shared_array+1036];
+    st.global.f32 [%rd5+12], %f1;
+    ld.shared.f32 %f1, [shared_array+1040];
+    st.global.f32 [%rd5+16], %f1;
+    ld.shared.f32 %f1, [shared_array+1044];
+    st.global.f32 [%rd5+20], %f1;
+    ld.shared.f32 %f1, [shared_array+1048];
+    st.global.f32 [%rd5+24], %f1;
+    ld.shared.f32 %f1, [shared_array+1052];
+    st.global.f32 [%rd5+28], %f1;
+    ld.shared.f32 %f1, [shared_array+1056];
+    st.global.f32 [%rd5+32], %f1;
+    ld.shared.f32 %f1, [shared_array+1060];
+    st.global.f32 [%rd5+36], %f1;
+    ld.shared.f32 %f1, [shared_array+1064];
+    st.global.f32 [%rd5+40], %f1;
+    ld.shared.f32 %f1, [shared_array+1068];
+    st.global.f32 [%rd5+44], %f1;
+    ld.shared.f32 %f1, [shared_array+1072];
+    st.global.f32 [%rd5+48], %f1;
+    ld.shared.f32 %f1, [shared_array+1076];
+    st.global.f32 [%rd5+52], %f1;
+    ld.shared.f32 %f1, [shared_array+1080];
+    st.global.f32 [%rd5+56], %f1;
+    ld.shared.f32 %f1, [shared_array+1084];
+    st.global.f32 [%rd5+60], %f1;
+$CELL3:
+    ret;
+}

--- a/docs/gpu/ossm_sed_recur_tile.ptx
+++ b/docs/gpu/ossm_sed_recur_tile.ptx
@@ -1,0 +1,214 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+.visible .entry step(
+    .param .u64 pA,
+    .param .u64 pB,
+    .param .u64 px,
+    .param .u64 pC,
+    .param .u64 pH,
+    .param .u64 py,
+    .param .s64 T
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[2048];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pA];
+    ld.param.u64 %rd1, [pB];
+    ld.param.u64 %rd2, [px];
+    ld.param.u64 %rd3, [pC];
+    ld.param.u64 %rd4, [pH];
+    ld.param.u64 %rd5, [py];
+    ld.param.u64 %rd6, [T];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $RINIT;
+    mov.u16 %rs1, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$RZ:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs1;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $RZ;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$HSTG:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $HSTG;
+$RINIT:
+    bar.sync 0;
+    cvt.u32.u64 %r10, %rd6;
+    mov.u32 %r11, 0;
+$TLOOP:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $RA;
+    mov.u32 %r5, 0;
+$LB0:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB0;
+$RA:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $RC;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$RSIG:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    cvt.rn.f32.f64 %f1, %fd1;
+    mad.lo.u32 %r8, %r11, 16, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd2, [%rd7];
+    cvt.rn.f32.f64 %f2, %fd2;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f3, [%r9];
+    fma.rn.f32 %f3, %f1, %f2, %f3;
+    mul.f32 %f4, %f3, %f3;
+    mul.f32 %f5, %f4, %f3;
+    fma.rn.f32 %f6, %f3, 0f3E800000, 0f3F000000;
+    fma.rn.f32 %f3, %f5, 0f3C800000, %f6;
+    cvt.rn.f16.f32 %rs0, %f3;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $RSIG;
+    mov.u32 %r5, 0;
+$LB1:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB1;
+$RC:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $RY;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r7, 0;
+$RYL:
+    mul.lo.u32 %r8, %r7, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    mad.lo.u32 %r8, %r11, 16, %r7;
+    mul.wide.u32 %rd7, %r8, 4;
+    add.s64 %rd7, %rd5, %rd7;
+    st.global.f32 [%rd7], %f1;
+    add.u32 %r7, %r7, 1;
+    setp.lt.u32 %p1, %r7, 16;
+    @%p1 bra $RYL;
+$RY:
+    bar.sync 0;
+    add.u32 %r11, %r11, 1;
+    setp.lt.u32 %p1, %r11, %r10;
+    @%p1 bra $TLOOP;
+    ret;
+}

--- a/docs/gpu/run_ossm_sed_cell_tile_ptx.cu
+++ b/docs/gpu/run_ossm_sed_cell_tile_ptx.cu
@@ -1,0 +1,28 @@
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+static float sigc(float x){return 0.015625f*x*x*x+0.25f*x+0.5f;}
+static void sm(const double*a,const double*b,double*r){for(int k=0;k<16;k++)r[k]=0;for(int i=0;i<16;i++)for(int j=0;j<16;j++)r[i^j]+=(double)cds(i,j,4)*a[i]*b[j];}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+int main(int c,char**v){const char*p=c>1?v[1]:"/tmp/sedc.ptx";
+ double A[16],Bb[16],xx[16],C[16],H[256];
+ for(int i=0;i<16;i++){A[i]=0.4*sin(1.0+i);Bb[i]=0.15*cos(0.5+i);C[i]=0.2*sin(2.0+i);xx[i]=0.3+0.04*i;}
+ for(int b=0;b<16;b++)for(int r=0;r<16;r++)H[b*16+r]=((b+1)*0.09+r*0.03)*((r%2)?-1:1);
+ double yref[16];
+ for(int b=0;b<16;b++){double ah[16];sm(A,&H[b*16],ah);double h[16];
+   for(int k=0;k<16;k++)h[k]=sigc((float)(ah[k]+Bb[k]*xx[b]));
+   double ch[16];sm(C,h,ch);yref[b]=ch[0];}
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext X;CK(cuDevicePrimaryCtxRetain(&X,d));CK(cuCtxSetCurrent(X));
+ CUmodule m;CK(cuModuleLoad(&m,p));CUfunction f;CK(cuModuleGetFunction(&f,m,"step"));
+ CUdeviceptr pA,pB,px,pC,pH,py;CK(cuMemAlloc(&pA,16*8));CK(cuMemAlloc(&pB,16*8));CK(cuMemAlloc(&px,16*8));CK(cuMemAlloc(&pC,16*8));CK(cuMemAlloc(&pH,256*8));CK(cuMemAlloc(&py,16*4));
+ CK(cuMemcpyHtoD(pA,A,16*8));CK(cuMemcpyHtoD(pB,Bb,16*8));CK(cuMemcpyHtoD(px,xx,16*8));CK(cuMemcpyHtoD(pC,C,16*8));CK(cuMemcpyHtoD(pH,H,256*8));float z[16]={0};CK(cuMemcpyHtoD(py,z,16*4));
+ void*args[]={&pA,&pB,&px,&pC,&pH,&py};CK(cuLaunchKernel(f,1,1,1,32,1,1,0,0,args,0));CK(cuCtxSynchronize());
+ float Y[16];CK(cuMemcpyDtoH(Y,py,16*4));
+ int fails=0;double mx=0;for(int b=0;b<16;b++){double e=fabs(Y[b]-yref[b]);if(e>mx)mx=e;if(e>0.03)fails++;}
+ printf("Sounio source-level FULL O-SSM SEDENION cell tensor-core GB10: mismatch %d/16 maxerr=%.4f\n",fails,mx);
+ if(!fails){printf("PASS: compiler-lowered full O-SSM sedenion cell matches scalar reference on GB10\n");return 0;}
+ printf("FAIL\n");return 1;}

--- a/docs/gpu/run_ossm_sed_recur_tile_ptx.cu
+++ b/docs/gpu/run_ossm_sed_recur_tile_ptx.cu
@@ -1,0 +1,32 @@
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+#define T 6
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+static float sigc(float x){return 0.015625f*x*x*x+0.25f*x+0.5f;}
+static void sm(const double*a,const double*b,double*r){for(int k=0;k<16;k++)r[k]=0;for(int i=0;i<16;i++)for(int j=0;j<16;j++)r[i^j]+=(double)cds(i,j,4)*a[i]*b[j];}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+int main(int c,char**v){const char*p=c>1?v[1]:"/tmp/sedr.ptx";
+ double A[16],Bb[16],C[16],xx[256]={0},H0[256];
+ for(int i=0;i<16;i++){A[i]=0.4*sin(1.0+i);Bb[i]=0.15*cos(0.5+i);C[i]=0.2*sin(2.0+i);}
+ for(int t=0;t<T;t++)for(int b=0;b<16;b++)xx[t*16+b]=0.3+0.04*b-0.015*t;
+ for(int b=0;b<16;b++)for(int r=0;r<16;r++)H0[b*16+r]=((b+1)*0.09+r*0.03)*((r%2)?-1:1);
+ double h[16][16]; for(int b=0;b<16;b++)for(int k=0;k<16;k++)h[b][k]=H0[b*16+k];
+ double yref[256]={0};
+ for(int t=0;t<T;t++)for(int b=0;b<16;b++){double ah[16];sm(A,h[b],ah);double hn[16];
+   for(int k=0;k<16;k++)hn[k]=sigc((float)(ah[k]+Bb[k]*xx[t*16+b]));
+   for(int k=0;k<16;k++)h[b][k]=hn[k];
+   double ch[16];sm(C,h[b],ch);yref[t*16+b]=ch[0];}
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext X;CK(cuDevicePrimaryCtxRetain(&X,d));CK(cuCtxSetCurrent(X));
+ CUmodule m;CK(cuModuleLoad(&m,p));CUfunction f;CK(cuModuleGetFunction(&f,m,"step"));
+ CUdeviceptr pA,pB,px,pC,pH,py;CK(cuMemAlloc(&pA,16*8));CK(cuMemAlloc(&pB,16*8));CK(cuMemAlloc(&px,256*8));CK(cuMemAlloc(&pC,16*8));CK(cuMemAlloc(&pH,256*8));CK(cuMemAlloc(&py,256*4));
+ CK(cuMemcpyHtoD(pA,A,16*8));CK(cuMemcpyHtoD(pB,Bb,16*8));CK(cuMemcpyHtoD(px,xx,256*8));CK(cuMemcpyHtoD(pC,C,16*8));CK(cuMemcpyHtoD(pH,H0,256*8));float z[256]={0};CK(cuMemcpyHtoD(py,z,256*4));
+ long long Tv=T;void*args[]={&pA,&pB,&px,&pC,&pH,&py,&Tv};CK(cuLaunchKernel(f,1,1,1,32,1,1,0,0,args,0));CK(cuCtxSynchronize());
+ float Y[256];CK(cuMemcpyDtoH(Y,py,256*4));
+ int fails=0;double mx=0;for(int t=0;t<T;t++)for(int b=0;b<16;b++){double e=fabs(Y[t*16+b]-yref[t*16+b]);if(e>mx)mx=e;if(e>0.04)fails++;}
+ printf("Sounio source-level O-SSM SEDENION RECURRENCE (T=%d) tensor-core GB10: y mismatch %d/%d maxerr=%.4f\n",T,fails,T*16,mx);
+ if(!fails){printf("PASS: compiler-lowered O-SSM sedenion T-step recurrence matches scalar reference on GB10\n");return 0;}
+ printf("FAIL\n");return 1;}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1765,12 +1765,13 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             pad.addr_reg = po_reg
             pad.rhs_imm = 8
             k = gpu_kernel_append_op(k, pad)
-        } else if hlir_name_is_ossm_oct_cell(cn) {
-            // Full O-SSM octonion cell: y = Re(C⊗sigmoid(A⊗H + B·x)).
-            // call_args = [pA, pB, px, pC, pH, py]. Two shared tiles + sigmoid + Re → one GpuOctCell.
+        } else if hlir_name_is_ossm_oct_cell(cn) || hlir_name_is_ossm_sed_cell(cn) {
+            // Full O-SSM cell: y = Re(C⊗sigmoid(A⊗H + B·x)). call_args = [pA,pB,px,pC,pH,py].
+            // Octonion dim=8; sedenion dim=16. Two shared tiles + sigmoid + Re → one GpuOctCell.
             if k.shared_bytes < 2048 { k.shared_bytes = 2048 }
             var cell = gpu_op_new()
             cell.opcode = GpuOpcode::GpuOctCell
+            cell.rhs_imm = if hlir_name_is_ossm_sed_cell(cn) { 16 } else { 8 }
             cell.lhs_reg = instr.call_args[0]
             cell.rhs_reg = instr.call_args[1]
             cell.addr_reg = instr.call_args[2]
@@ -1778,11 +1779,12 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             cell.shared_addr = instr.call_args[4]
             cell.compare_reg = instr.call_args[5]
             k = gpu_kernel_append_op(k, cell)
-        } else if hlir_name_is_ossm_oct_recur(cn) {
-            // O-SSM recurrence over T timesteps. call_args = [pA,pB,px,pC,pH,py,T].
+        } else if hlir_name_is_ossm_oct_recur(cn) || hlir_name_is_ossm_sed_recur(cn) {
+            // O-SSM recurrence over T. call_args = [pA,pB,px,pC,pH,py,T]. Octonion dim=8, sedenion 16.
             if k.shared_bytes < 2048 { k.shared_bytes = 2048 }
             var rec = gpu_op_new()
             rec.opcode = GpuOpcode::GpuOctRecur
+            rec.rhs_imm = if hlir_name_is_ossm_sed_recur(cn) { 16 } else { 8 }
             rec.lhs_reg = instr.call_args[0]
             rec.rhs_reg = instr.call_args[1]
             rec.addr_reg = instr.call_args[2]
@@ -1818,6 +1820,24 @@ fn hlir_name_is_ossm_oct_step(n: HlirName) -> bool {
     n.buf[4] == 95 as i8 && n.buf[5] == 111 as i8 && n.buf[6] == 99 as i8 && n.buf[7] == 116 as i8 &&
     n.buf[8] == 95 as i8 && n.buf[9] == 115 as i8 && n.buf[10] == 116 as i8 && n.buf[11] == 101 as i8 &&
     n.buf[12] == 112 as i8
+}
+
+// "ossm_sed_cell" (13 chars) — full O-SSM sedenion cell (dim=16, bits=4).
+fn hlir_name_is_ossm_sed_cell(n: HlirName) -> bool {
+    if n.len != 13 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
+    n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
+    n.buf[8] == 95 as i8 && n.buf[9] == 99 as i8 && n.buf[10] == 101 as i8 && n.buf[11] == 108 as i8 &&
+    n.buf[12] == 108 as i8
+}
+
+// "ossm_sed_recur" (14 chars) — O-SSM sedenion recurrence over T (dim=16, bits=4).
+fn hlir_name_is_ossm_sed_recur(n: HlirName) -> bool {
+    if n.len != 14 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
+    n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
+    n.buf[8] == 95 as i8 && n.buf[9] == 114 as i8 && n.buf[10] == 101 as i8 && n.buf[11] == 99 as i8 &&
+    n.buf[12] == 117 as i8 && n.buf[13] == 114 as i8
 }
 
 // "ossm_oct_cell" (13 chars) — the full O-SSM octonion cell: y = Re(C⊗sigmoid(A⊗H + B·x)).

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -17,6 +17,12 @@ pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, All
     } else {
         buf = ptx_emit_header(buf)
     }
+    // Module-scope sign table for the O-SSM cell/recur L(m) build (before the .entry).
+    if gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) {
+        let cdim = gpu_cell_dim(kernel)
+        let cbits = if cdim == 16 { 4 } else { 3 }
+        buf = ptx_push_str(buf, gpu_emit_cell_sign_table(cdim, cbits))
+    }
     // gpu_emit_kernel_mode_metadata skipped: calls gpu_legalize_kernel_to_ssa_v2 which
     // returns GpuKernelSsaV2 by value (~28MB frame) → SIGSEGV in lean_single-compiled binary.
     // The function only emits cosmetic PTX comment lines; skip it for correctness.
@@ -368,48 +374,95 @@ fn gpu_emit_cell_shared_tile() -> string with Mut, Panic, Div, Alloc {
     t
 }
 
-// Build L(m) (row-major f16, σ(k⊕j,j,3)·m[k⊕j], 8×8) into sL[shared_array] from the f64 pointer mR.
-fn gpu_emit_cell_lbuild(mR: string) -> string with Mut, Panic, Div, Alloc {
-    var t = ""
-    var k: i64 = 0
-    while k < 8 {
-        var j: i64 = 0
-        while j < 8 {
-            let i = k ^ j
-            t = str_concat(str_concat(t, "    ld.global.f64 %fd0, ["), mR)
-            t = str_concat(str_concat(t, "+"), i64_to_string(i * 8))
-            t = str_concat(t, "];\n")
-            if gpu_cd_sigma(i, j, 3) < 0 { t = str_concat(t, "    neg.f64 %fd0, %fd0;\n") }
-            t = str_concat(t, "    cvt.rn.f16.f64 %rs0, %fd0;\n    st.shared.u16 [shared_array+")
-            t = str_concat(str_concat(t, i64_to_string((k * 16 + j) * 2)), "], %rs0;\n")
-            j = j + 1
+// The dim of the cell/recur op (8 octonion / 16 sedenion), for the module-scope sign table.
+fn gpu_cell_dim(kernel: GpuKernelIr) -> i64 {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        let oc = kernel.ops[i as usize].opcode
+        if oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur {
+            if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
+            return 8
         }
-        k = k + 1
+        i = i + 1
     }
+    8
+}
+
+// Module-scope Cayley-Dickson sign table for the O-SSM cell/recur L(m) build:
+// ossm_Lsgn[k*dim+j] = σ(k⊕j, j, bits) as f32 ±1. Emitted before the .entry.
+fn gpu_emit_cell_sign_table(dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = str_concat("    .global .align 4 .b32 ossm_Lsgn[", i64_to_string(dim * dim))
+    t = str_concat(t, "] = {")
+    var idx: i64 = 0
+    while idx < dim * dim {
+        let k = idx / dim
+        let j = idx - k * dim
+        let i = k ^ j
+        if idx > 0 { t = str_concat(t, ", ") }
+        if gpu_cd_sigma(i, j, bits) < 0 { t = str_concat(t, "0fBF800000") } else { t = str_concat(t, "0f3F800000") }
+        idx = idx + 1
+    }
+    t = str_concat(t, "};\n\n")
+    t
+}
+
+// Build L(m) (row-major f16, σ(k⊕j,j,bits)·m[k⊕j], dim×dim in the 16×16 tile) into sL[shared_array]
+// from the f64 pointer mR, via a RUNTIME loop reading the ossm_Lsgn sign table (so the sedenion
+// dim=16 build — 256 entries — stays under the 64 KB PtxBuf). `tag` makes the loop label unique.
+fn gpu_emit_cell_lbuild(mR: string, dim: i64, bits: i64, tagnum: i64) -> string with Mut, Panic, Div, Alloc {
+    // Short string-literal chunks per str_concat: Madaros mangles/aborts on literals ≳120 chars.
+    let sh = if dim == 16 { 4 } else { 3 }
+    var t = str_concat(str_concat("    mov.u32 %r5, 0;\n$LB", i64_to_string(tagnum)), ":\n")
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r7, %r5, "), i64_to_string(dim - 1))
+    t = str_concat(t, ";\n    xor.b32 %r8, %r6, %r7;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r8, 8;\n    add.s64 %rd7, "), mR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    t = str_concat(t, "    mul.wide.u32 %rd7, %r5, 4;\n")
+    t = str_concat(t, "    mov.u64 %rd6, ossm_Lsgn;\n")
+    t = str_concat(t, "    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n")
+    t = str_concat(t, "    cvt.f64.f32 %fd1, %f0;\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")
+    t = str_concat(t, "    cvt.rn.f16.f64 %rs0, %fd0;\n")
+    t = str_concat(t, "    mov.u32 %r3, shared_array;\n")
+    t = str_concat(t, "    mad.lo.u32 %r9, %r6, 16, %r7;\n")
+    t = str_concat(t, "    mul.lo.u32 %r9, %r9, 2;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r9;\n")
+    t = str_concat(t, "    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim))
+    t = str_concat(str_concat(t, ";\n    @%p1 bra $LB"), i64_to_string(tagnum))
+    t = str_concat(t, ";\n")
+    t
+}
+
+// Stage H (dim components per state, col-major f16) into sH[shared_array+512] via a runtime loop,
+// from f64 pointer pHR. idx runs 0..(16*dim) over the source layout H[b*dim+r]; dest sH[b*16+r].
+// Runtime (not unrolled) so the sedenion cell/recur (dim=16) stays under the 64 KB PtxBuf.
+fn gpu_emit_cell_hstage(pHR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    let sh = if dim == 16 { 4 } else { 3 }
+    var t = "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$HSTG:\n"
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r7, %r5, "), i64_to_string(dim - 1))
+    t = str_concat(str_concat(t, ";\n    mul.wide.u32 %rd7, %r5, 8;\n    add.s64 %rd7, "), pHR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n    cvt.rn.f16.f64 %rs0, %fd0;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r6, 16, %r7;\n    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(16 * dim))
+    t = str_concat(t, ";\n    @%p1 bra $HSTG;\n")
     t
 }
 
 // Full O-SSM octonion cell (one timestep): y = Re(C⊗sigmoid(A⊗h_prev + B·x)).
 // Shared: sL@[0], sH@[512], sS(f32)@[1024]. Cubic sigmoid = (1/64)s³ + (1/4)s + 1/2.
-fn gpu_emit_oct_cell(pAR: string, pBR: string, pxR: string, pCR: string, pHR: string, pyR: string) -> string with Mut, Panic, Div, Alloc {
+fn gpu_emit_oct_cell(pAR: string, pBR: string, pxR: string, pCR: string, pHR: string, pyR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
     // thread 0: zero sL+sH, build L(A), stage H col-major
     var t = "    mov.u32 %r1, %tid.x;\n    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $CELL1;\n"
     t = str_concat(t, "    mov.u16 %rs1, 0;\n    mov.u32 %r2, 0;\n    mov.u32 %r3, shared_array;\n$CZ:\n")
     t = str_concat(t, "    add.u32 %r4, %r3, %r2;\n    st.shared.u16 [%r4], %rs1;\n")
     t = str_concat(t, "    add.u32 %r2, %r2, 2;\n    setp.lt.u32 %p1, %r2, 1024;\n    @%p1 bra $CZ;\n")
-    t = str_concat(t, gpu_emit_cell_lbuild(pAR))
-    var b0: i64 = 0
-    while b0 < 16 {
-        var r0: i64 = 0
-        while r0 < 8 {
-            t = str_concat(str_concat(t, "    ld.global.f64 %fd0, ["), pHR)
-            t = str_concat(str_concat(t, "+"), i64_to_string((b0 * 8 + r0) * 8))
-            t = str_concat(t, "];\n    cvt.rn.f16.f64 %rs0, %fd0;\n    st.shared.u16 [shared_array+")
-            t = str_concat(str_concat(t, i64_to_string(512 + (b0 * 16 + r0) * 2)), "], %rs0;\n")
-            r0 = r0 + 1
-        }
-        b0 = b0 + 1
-    }
+    t = str_concat(t, gpu_emit_cell_lbuild(pAR, dim, bits, 0))
+    t = str_concat(t, gpu_emit_cell_hstage(pHR, dim))
     // tile1: S = L(A)·H → sS
     t = str_concat(t, "$CELL1:\n    bar.sync 0;\n")
     t = str_concat(t, gpu_emit_cell_shared_tile())
@@ -434,9 +487,10 @@ fn gpu_emit_oct_cell(pAR: string, pBR: string, pxR: string, pCR: string, pHR: st
     // h into sH col-major at 512 + (b*16+k)*2
     t = str_concat(t, "    mad.lo.u32 %r8, %r7, 16, %r6;\n    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
     t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
-    t = str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, 128;\n    @%p1 bra $CSIG;\n")
+    t = str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, ")
+    t = str_concat(str_concat(t, i64_to_string(dim * 16)), ";\n    @%p1 bra $CSIG;\n")
     // thread 0: build L(C) into sL (padding stays zero from the initial clear)
-    t = str_concat(t, gpu_emit_cell_lbuild(pCR))
+    t = str_concat(t, gpu_emit_cell_lbuild(pCR, dim, bits, 1))
     t = str_concat(t, "$CELL2:\n    bar.sync 0;\n")
     // tile2: CH = L(C)·h → sS
     t = str_concat(t, gpu_emit_cell_shared_tile())
@@ -468,30 +522,19 @@ fn gpu_has_oct_recur(kernel: GpuKernelIr) -> bool {
 // O-SSM recurrence over T timesteps. H0 staged once into sH; then a runtime loop over t<T:
 // h_t = sigmoid(A⊗h_{t-1} + B·x_t) (tile1 + post-add + cubic sigmoid → sH col-major),
 // y_t = Re(C⊗h_t) (tile2 → sS row 0). x_t at px[(t*16+b)], y_t at py[(t*16+b)]. TR = T register.
-fn gpu_emit_oct_recur(pAR: string, pBR: string, pxR: string, pCR: string, pHR: string, pyR: string, TR: string) -> string with Mut, Panic, Div, Alloc {
+fn gpu_emit_oct_recur(pAR: string, pBR: string, pxR: string, pCR: string, pHR: string, pyR: string, TR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
     // thread 0: zero sL+sH, stage H0 col-major into sH
     var t = "    mov.u32 %r1, %tid.x;\n    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $RINIT;\n"
     t = str_concat(t, "    mov.u16 %rs1, 0;\n    mov.u32 %r2, 0;\n    mov.u32 %r3, shared_array;\n$RZ:\n")
     t = str_concat(t, "    add.u32 %r4, %r3, %r2;\n    st.shared.u16 [%r4], %rs1;\n")
     t = str_concat(t, "    add.u32 %r2, %r2, 2;\n    setp.lt.u32 %p1, %r2, 1024;\n    @%p1 bra $RZ;\n")
-    var b0: i64 = 0
-    while b0 < 16 {
-        var r0: i64 = 0
-        while r0 < 8 {
-            t = str_concat(str_concat(t, "    ld.global.f64 %fd0, ["), pHR)
-            t = str_concat(str_concat(t, "+"), i64_to_string((b0 * 8 + r0) * 8))
-            t = str_concat(t, "];\n    cvt.rn.f16.f64 %rs0, %fd0;\n    st.shared.u16 [shared_array+")
-            t = str_concat(str_concat(t, i64_to_string(512 + (b0 * 16 + r0) * 2)), "], %rs0;\n")
-            r0 = r0 + 1
-        }
-        b0 = b0 + 1
-    }
+    t = str_concat(t, gpu_emit_cell_hstage(pHR, dim))
     // T bound in %r10, timestep t in %r11
     t = str_concat(str_concat(t, "$RINIT:\n    bar.sync 0;\n    cvt.u32.u64 %r10, "), TR)
     t = str_concat(t, ";\n    mov.u32 %r11, 0;\n$TLOOP:\n")
     // thread 0: build L(A) into sL
     t = str_concat(t, "    mov.u32 %r1, %tid.x;\n    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $RA;\n")
-    t = str_concat(t, gpu_emit_cell_lbuild(pAR))
+    t = str_concat(t, gpu_emit_cell_lbuild(pAR, dim, bits, 0))
     t = str_concat(t, "$RA:\n    bar.sync 0;\n")
     // tile1: A⊗h_{t-1} → sS
     t = str_concat(t, gpu_emit_cell_shared_tile())
@@ -514,8 +557,9 @@ fn gpu_emit_oct_recur(pAR: string, pBR: string, pxR: string, pCR: string, pHR: s
     t = str_concat(t, "    fma.rn.f32 %f3, %f5, 0f3C800000, %f6;\n    cvt.rn.f16.f32 %rs0, %f3;\n")
     t = str_concat(t, "    mad.lo.u32 %r8, %r7, 16, %r6;\n    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
     t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
-    t = str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, 128;\n    @%p1 bra $RSIG;\n")
-    t = str_concat(t, gpu_emit_cell_lbuild(pCR))
+    t = str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, ")
+    t = str_concat(str_concat(t, i64_to_string(dim * 16)), ";\n    @%p1 bra $RSIG;\n")
+    t = str_concat(t, gpu_emit_cell_lbuild(pCR, dim, bits, 1))
     t = str_concat(t, "$RC:\n    bar.sync 0;\n")
     // tile2: C⊗h_t → sS
     t = str_concat(t, gpu_emit_cell_shared_tile())
@@ -876,12 +920,16 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
         GpuOpcode::GpuOctCell => {
             // Full O-SSM cell: y = Re(C⊗sigmoid(A⊗H + B·x)). Pointers: pA=lhs, pB=rhs, px=addr,
             // pC=src, pH=shared_addr, pY=compare_reg.
-            ptx_push_str(buf, gpu_emit_oct_cell(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg)))
+            let cdim = if op.rhs_imm == 16 { 16 } else { 8 }
+            let cbits = if cdim == 16 { 4 } else { 3 }
+            ptx_push_str(buf, gpu_emit_oct_cell(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg), cdim, cbits))
         }
 
         GpuOpcode::GpuOctRecur => {
             // O-SSM recurrence over T timesteps. Same pointers as the cell + T register in byte_offset.
-            ptx_push_str(buf, gpu_emit_oct_recur(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg), gpu_reg_u64(op.byte_offset)))
+            let rdim = if op.rhs_imm == 16 { 16 } else { 8 }
+            let rbits = if rdim == 16 { 4 } else { 3 }
+            ptx_push_str(buf, gpu_emit_oct_recur(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg), gpu_reg_u64(op.byte_offset), rdim, rbits))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/tests/gpu/ossm_sed_cell_tile.sio
+++ b/tests/gpu/ossm_sed_cell_tile.sio
@@ -1,0 +1,6 @@
+// Full O-SSM SEDENION forward cell on tensor cores: y = Re(C⊗sigmoid(A⊗H + B·x)), 16×16 exact.
+fn ossm_sed_cell(pA:&[f64;16], pB:&[f64;16], px:&[f64;16], pC:&[f64;16], pH:&[f64;256], py:&![f64;16]) with GPU { }
+kernel fn step(pA:&[f64;16], pB:&[f64;16], px:&[f64;16], pC:&[f64;16], pH:&[f64;256], py:&![f64;16]) with GPU {
+    ossm_sed_cell(pA, pB, px, pC, pH, py)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/ossm_sed_recur_tile.sio
+++ b/tests/gpu/ossm_sed_recur_tile.sio
@@ -1,0 +1,6 @@
+// O-SSM SEDENION recurrence over T timesteps on tensor cores.
+fn ossm_sed_recur(pA:&[f64;16], pB:&[f64;16], px:&[f64;256], pC:&[f64;16], pH:&[f64;256], py:&![f64;256], T:i64) with GPU { }
+kernel fn step(pA:&[f64;16], pB:&[f64;16], px:&[f64;256], pC:&[f64;16], pH:&[f64;256], py:&![f64;256], T:i64) with GPU {
+    ossm_sed_recur(pA, pB, px, pC, pH, py, T)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

Generalizes the O-SSM cell/recurrence (#1117/#1120) to **sedenions** — completing the hypercomplex
O-SSM-on-tensor-cores arc for both algebras:

```sio
kernel fn step(pA:&[f64;16], pB:&[f64;16], px:&[f64;256], pC:&[f64;16], pH:&[f64;256], py:&![f64;256], T:i64) with GPU {
    ossm_sed_recur(pA, pB, px, pC, pH, py, T)   // for t<T: h_t=sigmoid(A⊗h_{t-1}+B·x_t); y_t=Re(C⊗h_t), 16×16
}
```

The cell/recur renderers now take `dim`/`bits` (octonion 8/3, sedenion 16/4); `ossm_sed_cell` /
`ossm_sed_recur` are recognized alongside the octonion intrinsics, carrying `dim` in the op's `rhs_imm`.

## How it fits in 64 KB

The sedenion `L(m)` build is 256 entries — unrolled it overflows the 64 KB `PtxBuf`. So
`gpu_emit_cell_lbuild` is now a **runtime loop reading a module-scope sign table**
`.global ossm_Lsgn[dim*dim]` (σ(k⊕j,j,bits), emitted before the `.entry`); the H stage is likewise a
runtime loop. Two Madaros gotchas fixed: **string params inside `str_concat`** and **string literals
≳120 chars** mangle/abort the self-hosted binary — the L-build uses an integer label tag and one PTX
instruction per `str_concat`.

## Hardware validation (DGX Spark GB10, sm_121a)

```
FULL O-SSM SEDENION cell:       mismatch 0/16  maxerr=0.0003
O-SSM SEDENION RECURRENCE (T=6): mismatch 0/96  maxerr=0.0003
PASS (both)
```

Bit-close to the scalar `cd_sigma(bits=4)` reference. **Octonion cell/recur unchanged** (regression:
both 0/16 and 0/96). The full O-SSM forward — cell and T-recurrence — now lowers from source to tensor
cores for **both octonions and sedenions**.

Fixtures/artifacts: `tests/gpu/ossm_sed_{cell,recur}_tile.sio`, `docs/gpu/run_ossm_sed_{cell,recur}_tile_ptx.cu`.
Builds on #1117/#1120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)