### PR TITLE
feat(stdlib): bigrat sub/div/cmp + EXACT decimal parsing + col_mean

### DIFF
--- a/scripts/bigrat_ext_gate.sh
+++ b/scripts/bigrat_ext_gate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Gate for data::bigrat extensions (sub/div/cmp/from_decimal/col_mean). lean_single. The big values are
+# DIFFED against the Python oracle (bigrat_oracle.py ext) -- exit/token are not the signal (souc wall).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+echo "== run-proof + ORACLE DIFF: bigrat extensions =="
+if SOUNIO_SOUC_ENGINE=lean_single $SOUC compile tests/stdlib/data/test_bigrat_ext_stdlib.sio -o "$OUT/x.elf" >/dev/null 2>&1; then
+  chmod +x "$OUT/x.elf"; "$OUT/x.elf" > "$OUT/run.txt" 2>&1 || true
+  awk '/=/{k=$0; while(k !~ /~/){getline; k=k $0} gsub(/~/,"",k); gsub(/[ \t]/,"",k); print k}' "$OUT/run.txt" | grep -E "(bigdec|colmean)_(num|den)=" | sort > "$OUT/recon.txt"
+  python3 scripts/research/bigrat_oracle.py ext | sort > "$OUT/oracle.txt"
+  n=$(grep -c . "$OUT/recon.txt")
+  if [ "$n" -eq 4 ] && diff "$OUT/recon.txt" "$OUT/oracle.txt" >/dev/null; then echo "  oracle diff: EXACT MATCH (4 values)"; else echo "  ORACLE MISMATCH ($n/4):"; diff "$OUT/recon.txt" "$OUT/oracle.txt" || true; fail=1; fi
+  grep -q "BIGRAT_EXT_STDLIB_OK" "$OUT/run.txt" || { echo "  missing OK token (a big_eq assertion failed)"; fail=1; }
+else echo "FAIL compile"; fail=1; fi
+[ $fail -eq 0 ] && echo "BIGRAT_EXT_GATE_OK"
+exit $fail

--- a/scripts/research/bigrat_oracle.py
+++ b/scripts/research/bigrat_oracle.py
@@ -35,5 +35,12 @@ def col():
     for p in _first_primes(100): s += F(1, p)                                  # 220-digit denominator
     _emit("col_p100", s)
 
+
+def ext():
+    from fractions import Fraction as F
+    _emit("bigdec", F('0.123456789012345678901234567890'))   # 12345678901234567890123456789 / 10^29
+    _emit("colmean", (F(1,2)+F(1,3)+F(1,6)) / 3)              # 1 / 3
+
 if __name__ == "__main__":
-    (col if (len(sys.argv) > 1 and sys.argv[1] == "col") else base)()
+    g = sys.argv[1] if len(sys.argv) > 1 else "base"
+    {"base": base, "col": col, "ext": ext}[g]()

--- a/stdlib/data/bigrat.sio
+++ b/stdlib/data/bigrat.sio
@@ -332,3 +332,49 @@ pub fn bigrat_col_sum(num: &[i64; 256], den: &[i64; 256], n: i64) -> BigRat with
     }
     acc
 }
+
+/// Exact difference a - b, reduced.
+pub fn bigrat_sub(a: BigRat, b: BigRat) -> BigRat with Mut, Panic, Div {
+    bigrat_make(big_sub(big_mul(a.num, b.den), big_mul(b.num, a.den)), big_mul(a.den, b.den))
+}
+/// Exact quotient a / b, reduced (b must be non-zero). Sign is normalized onto the numerator.
+pub fn bigrat_div(a: BigRat, b: BigRat) -> BigRat with Mut, Panic, Div {
+    bigrat_make(big_mul(a.num, b.den), big_mul(a.den, b.num))
+}
+/// Sign of a - b: -1, 0, or 1 (exact; denominators are positive so cross-multiplication preserves order).
+pub fn bigrat_cmp(a: BigRat, b: BigRat) -> i64 with Mut, Panic, Div {
+    big_cmp(big_mul(a.num, b.den), big_mul(b.num, a.den))
+}
+
+/// Parse an exact rational from a decimal string, e.g. "3.14" -> 157/50, "0.1" -> 1/10, "-2.5" -> -5/2,
+/// "100" -> 100/1. A float64 engine reads "0.1" as 0.1000000000000000055...; this reads it EXACTLY. All
+/// digits are accumulated into a BigInt and divided by 10^(number of fractional digits). Non-digit,
+/// non-sign, non-point characters are ignored. A leading '-' negates.
+pub fn bigrat_from_decimal(s: string) -> BigRat with Mut, Panic, Div {
+    let n = str_len(s)
+    var acc = big_from_i64(0)
+    var frac: i64 = 0
+    var seen_point = false
+    var neg = false
+    var i: i64 = 0
+    while i < n {
+        let c = str_char_at(s, i)
+        if c == 45 { if i == 0 { neg = true } }          // '-'
+        else if c == 46 { seen_point = true }             // '.'
+        else if c >= 48 && c <= 57 {                      // '0'..'9'
+            acc = big_add(big_mul(acc, big_from_i64(10)), big_from_i64(c - 48))
+            if seen_point { frac = frac + 1 }
+        }
+        i = i + 1
+    }
+    if neg { acc = big_neg(acc) }
+    bigrat_make(acc, big_pow10(frac))
+}
+
+/// Exact mean of `n` fractions given as parallel i64 numerator/denominator arrays: the exact column sum
+/// divided by n (arbitrary precision). Returns a reduced BigRat.
+pub fn bigrat_col_mean(num: &[i64; 256], den: &[i64; 256], n: i64) -> BigRat with Mut, Panic, Div {
+    if n <= 0 { return BigRat { num: big_from_i64(0), den: big_from_i64(1) } }
+    let s = bigrat_col_sum(num, den, n)
+    bigrat_make(s.num, big_mul(s.den, big_from_i64(n)))
+}

--- a/tests/stdlib/data/test_bigrat_ext_stdlib.sio
+++ b/tests/stdlib/data/test_bigrat_ext_stdlib.sio
@@ -1,0 +1,29 @@
+// Run-proof for data::bigrat extensions: sub/div/cmp, EXACT decimal parsing, and col_mean. The
+// decimal parser reads "0.1" as EXACTLY 1/10 (a float64 engine reads 0.1000...0055). big_eq checks the
+// small cases; the gate oracle-diffs the big-decimal (30 digits -> 10^29 denominator) and col_mean.
+// lean_single engine.
+use data::bigrat::*
+fn same(g: BigRat, en: i64, ed: i64) -> bool with Mut, Panic, Div { bigrat_eq(g, bigrat_make(big_from_i64(en), big_from_i64(ed))) }
+fn main() -> i32 with IO, Mut, Panic, Div {
+    if !same(bigrat_from_decimal("0.1"), 1, 10) { print("FAIL d01\n"); return 1 }
+    if !same(bigrat_from_decimal("3.14"), 157, 50) { print("FAIL d314\n"); return 2 }
+    if !same(bigrat_from_decimal("-2.5"), 0-5, 2) { print("FAIL dneg\n"); return 3 }
+    if !same(bigrat_from_decimal("100"), 100, 1) { print("FAIL dint\n"); return 4 }
+    if !same(bigrat_from_decimal("0.001"), 1, 1000) { print("FAIL dmilli\n"); return 5 }
+    if !same(bigrat_sub(bigrat_make(big_from_i64(1),big_from_i64(2)), bigrat_make(big_from_i64(1),big_from_i64(3))), 1, 6) { print("FAIL sub\n"); return 6 }
+    if !same(bigrat_div(bigrat_make(big_from_i64(1),big_from_i64(2)), bigrat_make(big_from_i64(1),big_from_i64(4))), 2, 1) { print("FAIL div\n"); return 7 }
+    if bigrat_cmp(bigrat_make(big_from_i64(1),big_from_i64(3)), bigrat_make(big_from_i64(1),big_from_i64(2))) != (0-1) { print("FAIL cmp_lt\n"); return 8 }
+    if bigrat_cmp(bigrat_make(big_from_i64(1),big_from_i64(2)), bigrat_make(big_from_i64(1),big_from_i64(2))) != 0 { print("FAIL cmp_eq\n"); return 9 }
+    if bigrat_cmp(bigrat_make(big_from_i64(2),big_from_i64(3)), bigrat_make(big_from_i64(1),big_from_i64(2))) != 1 { print("FAIL cmp_gt\n"); return 10 }
+    // big decimal -> oracle diff (30 digits, 10^29 denominator)
+    print("bigdec_num="); big_print(bigrat_num(bigrat_from_decimal("0.123456789012345678901234567890"))); print("~\n")
+    print("bigdec_den="); big_print(bigrat_den(bigrat_from_decimal("0.123456789012345678901234567890"))); print("~\n")
+    // col_mean of [1/2, 1/3, 1/6] = (1)/3 = 1/3 -> oracle diff
+    var nn: [i64;256]=[0;256]; var dd: [i64;256]=[0;256]
+    nn[0]=1; dd[0]=2; nn[1]=1; dd[1]=3; nn[2]=1; dd[2]=6
+    let cm = bigrat_col_mean(&nn, &dd, 3)
+    print("colmean_num="); big_print(bigrat_num(cm)); print("~\n")
+    print("colmean_den="); big_print(bigrat_den(cm)); print("~\n")
+    print("BIGRAT_EXT_STDLIB_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Reading decimal data without float error

The standout here is `bigrat_from_decimal` — parse an exact rational straight from a decimal **string**:

```
"0.1"    → 1/10        (a float64 engine reads 0.1000000000000000055…)
"3.14"   → 157/50
"-2.5"   → -5/2
"100"    → 100/1
"0.123456789012345678901234567890"  →  12345678901234567890123456789 / 10²⁹   (exact)
```

pandas ingests `"0.1"` as the nearest float and the error is baked in before you compute anything. `bigrat_from_decimal` keeps decimal input **exact at the point of entry** — money, measurements, anything where the source data is decimal.

Also completes the exact-number surface:

| Verb | |
|---|---|
| `bigrat_sub` / `bigrat_div` | complete the arithmetic (reduced) |
| `bigrat_cmp(a, b)` | exact ordering (−1 / 0 / 1) |
| `bigrat_col_mean(num, den, n)` | exact mean of a rational column |

### Verification
- `scripts/bigrat_ext_gate.sh` → `BIGRAT_EXT_GATE_OK`. The big-decimal (30 digits → 10²⁹ denominator) and `col_mean` are **oracle-diffed** digit-for-digit (`bigrat_oracle.py ext`); `big_eq` covers the small cases. The base and column gates remain green.

Self-contained; no compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)