### PR TITLE
feat(gpu): batched hypercomplex ASSOCIATOR on tensor cores (oct_assoc/sed_assoc, HW-validated GB10)

### DIFF
--- a/docs/gpu/oct_assoc_wmma_tile.ptx
+++ b/docs/gpu/oct_assoc_wmma_tile.ptx
@@ -1,0 +1,325 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[64] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000};
+
+    .global .align 4 .b32 ossm_absgn[64] = {0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000};
+
+    .global .align 8 .b64 ossm_ab[16];
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pb,
+    .param .u64 pH,
+    .param .u64 pout
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[3072];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pb];
+    ld.param.u64 %rd2, [pH];
+    ld.param.u64 %rd3, [pout];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS0;
+    mov.u64 %rd5, ossm_ab;
+    mov.f64 %fd0, 0d0000000000000000;
+    mov.u32 %r5, 0;
+$AZAB:
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd5, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 8;
+    @%p1 bra $AZAB;
+    mov.u32 %r5, 0;
+$ABL:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r7, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.f64 %fd0, %fd0, %fd1;
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_absgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    mov.u64 %rd6, ossm_ab;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f64 %fd2, [%rd7];
+    add.f64 %fd2, %fd2, %fd0;
+    st.global.f64 [%rd7], %fd2;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $ABL;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ0:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ0;
+    mov.u32 %r5, 0;
+$LB20:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $LB20;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$AHS0:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $AHS0;
+$AS0:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS1;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 512;
+    mov.u32 %r3, shared_array;
+$AZ1:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ1;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$ARP:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    cvt.rn.f16.f32 %rs0, %f1;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $ARP;
+    mov.u32 %r5, 0;
+$LB21:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $LB21;
+$AS1:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS2;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$ASV:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 1024;
+    ld.shared.f32 %f1, [%r9];
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 2048;
+    st.shared.f32 [%r9], %f1;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $ASV;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ2:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ2;
+    mov.u64 %rd5, ossm_ab;
+    mov.u32 %r5, 0;
+$LB22:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd5, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $LB22;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$AHS1:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $AHS1;
+$AS2:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS3;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$ASUB:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 1024;
+    ld.shared.f32 %f1, [%r9];
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 2048;
+    ld.shared.f32 %f2, [%r9];
+    sub.f32 %f3, %f1, %f2;
+    cvt.u64.u32 %rd7, %r8;
+    add.s64 %rd7, %rd3, %rd7;
+    st.global.f32 [%rd7], %f3;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $ASUB;
+$AS3:
+    ret;
+}

--- a/docs/gpu/run_assoc_wmma_ptx.cu
+++ b/docs/gpu/run_assoc_wmma_ptx.cu
@@ -1,0 +1,46 @@
+// Driver-API harness for the compiler-lowered batched hypercomplex ASSOCIATOR tile kernel `step`:
+//   out[k*16+b] = [a,b,H_b][k] = ((a⊗b)⊗H_b − a⊗(b⊗H_b))[k]   (k<dim, 16-state batch)
+// Usage: run_assoc <ptx> <dim>   (dim=8 octonion / 16 sedenion). Validates vs the scalar CD oracle
+// on the DGX Spark GB10. Output is f32 (the wmma tile store format), tolerance covers f16 rounding.
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+// r = x ⊗ y for a `dim`-dimensional Cayley-Dickson algebra (bits levels).
+static void cdmul(const double*x,const double*y,double*r,int dim,int bits){
+ for(int k=0;k<dim;k++)r[k]=0;
+ for(int i=0;i<dim;i++)for(int j=0;j<dim;j++)r[i^j]+=(double)cds(i,j,bits)*x[i]*y[j];}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+int main(int c,char**v){
+ const char*p=c>1?v[1]:"/tmp/assoc.ptx"; int dim=c>2?atoi(v[2]):8; int bits=(dim==16)?4:3;
+ double a[16]={0},b[16]={0},H[256]={0};
+ for(int i=0;i<dim;i++){a[i]=0.4*((i%2)?-1:1)+0.05*i; b[i]=0.3-0.06*i+((i%3)?0.1:-0.1);}
+ for(int s=0;s<16;s++)for(int r=0;r<dim;r++)H[s*dim+r]=((s+1)*0.11+r*0.05)*((r%2)?-1:1);
+ // reference assoc[k][s] = ((a⊗b)⊗H_s − a⊗(b⊗H_s))[k]
+ double ab[16]; cdmul(a,b,ab,dim,bits);
+ double ref[256]={0};
+ for(int s=0;s<16;s++){
+   const double*Hs=&H[s*dim];
+   double left[16],bH[16],right[16];
+   cdmul(ab,Hs,left,dim,bits);
+   cdmul(b,Hs,bH,dim,bits); cdmul(a,bH,right,dim,bits);
+   for(int k=0;k<dim;k++)ref[k*16+s]=left[k]-right[k];
+ }
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext x;CK(cuDevicePrimaryCtxRetain(&x,d));CK(cuCtxSetCurrent(x));
+ CUmodule m;CK(cuModuleLoad(&m,p));CUfunction f;CK(cuModuleGetFunction(&f,m,"step"));
+ CUdeviceptr pa,pb,pH,po;
+ CK(cuMemAlloc(&pa,dim*8));CK(cuMemAlloc(&pb,dim*8));CK(cuMemAlloc(&pH,16*dim*8));CK(cuMemAlloc(&po,256*4));
+ CK(cuMemcpyHtoD(pa,a,dim*8));CK(cuMemcpyHtoD(pb,b,dim*8));CK(cuMemcpyHtoD(pH,H,16*dim*8));
+ float z[256]={0};CK(cuMemcpyHtoD(po,z,256*4));
+ void*args[]={&pa,&pb,&pH,&po};CK(cuLaunchKernel(f,1,1,1,32,1,1,0,0,args,0));CK(cuCtxSynchronize());
+ float D[256];CK(cuMemcpyDtoH(D,po,256*4));
+ int fails=0;double mx=0;int n=dim*16;
+ for(int k=0;k<dim;k++)for(int s=0;s<16;s++){double e=fabs(D[k*16+s]-ref[k*16+s]);if(e>mx)mx=e;if(e>0.06)fails++;}
+ const char*nm=(dim==16)?"SEDENION":"octonion";
+ printf("Sounio source-level BATCHED %s ASSOCIATOR [a,b,H] tensor-core GB10: mismatch %d/%d maxerr=%.4f\n",nm,fails,n,mx);
+ if(!fails){printf("PASS: compiler-emitted (a*b)*H - a*(b*H) tensor-core tiles match scalar reference on GB10\n");return 0;}
+ printf("FAIL\n");return 1;}

--- a/docs/gpu/sed_assoc_wmma_tile.ptx
+++ b/docs/gpu/sed_assoc_wmma_tile.ptx
@@ -1,0 +1,325 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+    .global .align 4 .b32 ossm_absgn[256] = {0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000};
+
+    .global .align 8 .b64 ossm_ab[16];
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pb,
+    .param .u64 pH,
+    .param .u64 pout
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[3072];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pb];
+    ld.param.u64 %rd2, [pH];
+    ld.param.u64 %rd3, [pout];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS0;
+    mov.u64 %rd5, ossm_ab;
+    mov.f64 %fd0, 0d0000000000000000;
+    mov.u32 %r5, 0;
+$AZAB:
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd5, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 16;
+    @%p1 bra $AZAB;
+    mov.u32 %r5, 0;
+$ABL:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r7, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.f64 %fd0, %fd0, %fd1;
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_absgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    mov.u64 %rd6, ossm_ab;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f64 %fd2, [%rd7];
+    add.f64 %fd2, %fd2, %fd0;
+    st.global.f64 [%rd7], %fd2;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $ABL;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ0:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ0;
+    mov.u32 %r5, 0;
+$LB20:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB20;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$AHS0:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $AHS0;
+$AS0:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS1;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 512;
+    mov.u32 %r3, shared_array;
+$AZ1:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ1;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$ARP:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    cvt.rn.f16.f32 %rs0, %f1;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $ARP;
+    mov.u32 %r5, 0;
+$LB21:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB21;
+$AS1:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS2;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$ASV:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 1024;
+    ld.shared.f32 %f1, [%r9];
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 2048;
+    st.shared.f32 [%r9], %f1;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $ASV;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ2:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ2;
+    mov.u64 %rd5, ossm_ab;
+    mov.u32 %r5, 0;
+$LB22:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd5, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r6, 16, %r7;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB22;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$AHS1:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $AHS1;
+$AS2:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $AS3;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$ASUB:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mad.lo.u32 %r8, %r6, 16, %r7;
+    mul.lo.u32 %r8, %r8, 4;
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 1024;
+    ld.shared.f32 %f1, [%r9];
+    add.u32 %r9, %r3, %r8;
+    add.u32 %r9, %r9, 2048;
+    ld.shared.f32 %f2, [%r9];
+    sub.f32 %f3, %f1, %f2;
+    cvt.u64.u32 %rd7, %r8;
+    add.s64 %rd7, %rd3, %rd7;
+    st.global.f32 [%rd7], %f3;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $ASUB;
+$AS3:
+    ret;
+}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1793,6 +1793,19 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             rec.compare_reg = instr.call_args[5]
             rec.byte_offset = instr.call_args[6]
             k = gpu_kernel_append_op(k, rec)
+        } else if hlir_name_is_oct_assoc(cn) || hlir_name_is_sed_assoc(cn) {
+            // Batched hypercomplex associator [a,b,H] = (a⊗b)⊗H − a⊗(b⊗H) on tensor cores.
+            // call_args = [pa, pb, pH, pout]. Three tiles (L(b)·H, L(a)·q, L(a⊗b)·H) + subtract →
+            // one GpuOctAssoc. Octonion dim=8; sedenion dim=16. Needs sL+sH+sS+sR = 3072 shared bytes.
+            if k.shared_bytes < 3072 { k.shared_bytes = 3072 }
+            var asc = gpu_op_new()
+            asc.opcode = GpuOpcode::GpuOctAssoc
+            asc.rhs_imm = if hlir_name_is_sed_assoc(cn) { 16 } else { 8 }
+            asc.lhs_reg = instr.call_args[0]
+            asc.rhs_reg = instr.call_args[1]
+            asc.addr_reg = instr.call_args[2]
+            asc.src_reg = instr.call_args[3]
+            k = gpu_kernel_append_op(k, asc)
         }
         // Other calls: skip in MVP
     }
@@ -1865,6 +1878,23 @@ fn hlir_name_is_sed_batch_mul(n: HlirName) -> bool {
     n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
     n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 109 as i8 && n.buf[11] == 117 as i8 &&
     n.buf[12] == 108 as i8
+}
+
+// "oct_assoc" (9 chars) — the batched octonion associator intrinsic: oct_assoc(pa,pb,pH,pout)
+// computes [a,b,H_b] = (a⊗b)⊗H_b − a⊗(b⊗H_b) for a 16-state batch on tensor cores (dim=8, bits=3).
+fn hlir_name_is_oct_assoc(n: HlirName) -> bool {
+    if n.len != 9 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 99 as i8 && n.buf[2] == 116 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 97 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 115 as i8 && n.buf[7] == 111 as i8 &&
+    n.buf[8] == 99 as i8
+}
+
+// "sed_assoc" (9 chars) — the batched sedenion associator intrinsic (dim=16, bits=4).
+fn hlir_name_is_sed_assoc(n: HlirName) -> bool {
+    if n.len != 9 { return false }
+    n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8 && n.buf[2] == 100 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 97 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 115 as i8 && n.buf[7] == 111 as i8 &&
+    n.buf[8] == 99 as i8
 }
 
 fn hlir_name_starts_with_gpu_thread(n: HlirName) -> bool {

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -118,6 +118,10 @@ pub enum GpuOpcode {
     GpuOctRecur,        // O-SSM recurrence over T timesteps: for t<T, h_t=sigmoid(A⊗h_{t-1}+B·x_t),
     //   y_t=Re(C⊗h_t). H persists in shared across steps; x_t/y_t indexed by t. Same pointer fields as
     //   GpuOctCell plus the timestep count register in byte_offset (px/py sized T×16).
+    GpuOctAssoc,        // Batched hypercomplex associator [a,b,H] = (a⊗b)⊗H − a⊗(b⊗H) over a 16-state
+    //   batch. THREE m16n16k16 tiles: q=L(b)·H, r=L(a)·q, p=L(a⊗b)·H, then out=p−r. a⊗b is formed
+    //   into a global scratch (ossm_ab) via the σ(i,j) table (ossm_absgn). Pointers pa,pb,pH,pout in
+    //   lhs_reg/rhs_reg/addr_reg/src_reg; rhs_imm = dim (8 octonion / 16 sedenion).
     GpuTmaLoad,         // Tensor memory access load (sm_90+)
     GpuTmaStore,        // Tensor memory access store (sm_90+)
 

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -23,6 +23,15 @@ pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, All
         let cbits = if cdim == 16 { 4 } else { 3 }
         buf = ptx_push_str(buf, gpu_emit_cell_sign_table(cdim, cbits))
     }
+    // Module-scope tables for the batched associator: ossm_Lsgn (σ(k⊕j,j) for the L-build, shared
+    // with the cell), ossm_absgn (σ(i,j) to form a⊗b), and the ossm_ab global f64 scratch.
+    if gpu_has_oct_assoc(kernel) {
+        let adim = gpu_assoc_dim(kernel)
+        let abits = if adim == 16 { 4 } else { 3 }
+        buf = ptx_push_str(buf, gpu_emit_cell_sign_table(adim, abits))
+        buf = ptx_push_str(buf, gpu_emit_assoc_absgn_table(adim, abits))
+        buf = ptx_push_str(buf, "    .global .align 8 .b64 ossm_ab[16];\n\n")
+    }
     // gpu_emit_kernel_mode_metadata skipped: calls gpu_legalize_kernel_to_ssa_v2 which
     // returns GpuKernelSsaV2 by value (~28MB frame) → SIGSEGV in lean_single-compiled binary.
     // The function only emits cosmetic PTX comment lines; skip it for correctness.
@@ -127,7 +136,7 @@ fn gpu_has_wmma_tile(kernel: GpuKernelIr) -> bool {
     var i: i64 = 0
     while i < kernel.op_count {
         let oc = kernel.ops[i as usize].opcode
-        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur { return true }
+        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc { return true }
         i = i + 1
     }
     false
@@ -140,7 +149,8 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
 
     let stage = gpu_has_oct_stage(kernel)
     let postadd = gpu_has_oct_postadd(kernel)
-    let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel)
+    // The associator needs the same register classes as the cell (runtime L-build + repack loops).
+    let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel)
     let stage_or_pa = stage || postadd || cell
 
     // .reg .pred %p<N> — the staging loop / post-add need at least %p<2>.
@@ -406,6 +416,194 @@ fn gpu_emit_cell_sign_table(dim: i64, bits: i64) -> string with Mut, Panic, Div,
     t
 }
 
+// Module-scope σ(i,j,bits) table for forming the associator product a⊗b: ossm_absgn[i*dim+j] as
+// f32 ±1. Used by the a⊗b accumulation loop (ab[i⊕j] += σ(i,j)·a[i]·b[j]). Emitted before .entry.
+fn gpu_emit_assoc_absgn_table(dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = str_concat("    .global .align 4 .b32 ossm_absgn[", i64_to_string(dim * dim))
+    t = str_concat(t, "] = {")
+    var idx: i64 = 0
+    while idx < dim * dim {
+        let i = idx / dim
+        let j = idx - i * dim
+        if idx > 0 { t = str_concat(t, ", ") }
+        if gpu_cd_sigma(i, j, bits) < 0 { t = str_concat(t, "0fBF800000") } else { t = str_concat(t, "0f3F800000") }
+        idx = idx + 1
+    }
+    t = str_concat(t, "};\n\n")
+    t
+}
+
+// Stage H (dim comps per state, col-major f16) into sH[shared_array+512] via a runtime loop, from
+// f64 pointer pHR. Same as gpu_emit_cell_hstage but with a `tag`-unique label so the associator can
+// stage H twice (tile1 L(b)·H and tile3 L(a⊗b)·H) without a duplicate $HSTG label.
+fn gpu_emit_assoc_hstage(pHR: string, dim: i64, tag: i64) -> string with Mut, Panic, Div, Alloc {
+    let sh = if dim == 16 { 4 } else { 3 }
+    var t = str_concat(str_concat("    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$AHS", i64_to_string(tag)), ":\n")
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r7, %r5, "), i64_to_string(dim - 1))
+    t = str_concat(str_concat(t, ";\n    mul.wide.u32 %rd7, %r5, 8;\n    add.s64 %rd7, "), pHR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n    cvt.rn.f16.f64 %rs0, %fd0;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r6, 16, %r7;\n    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(16 * dim))
+    t = str_concat(str_concat(t, ";\n    @%p1 bra $AHS"), i64_to_string(tag))
+    t = str_concat(t, ";\n")
+    t
+}
+
+// Batched hypercomplex associator [a,b,H_b] = (a⊗b)⊗H_b − a⊗(b⊗H_b) over a 16-state batch, on
+// tensor cores. Shared: sL@[0], sH@[512], sS(f32 tile out)@[1024], sR(saved r, f32)@[2048]. a⊗b is
+// formed once into the ossm_ab global (σ from ossm_absgn); the L-builds read ossm_Lsgn. THREE tiles:
+//   q = L(b)·H   →  repack q into sH  →  r = L(a)·q   →  save r to sR
+//   p = L(a⊗b)·H →  out[k*16+b] = p − r  (f32, matching the batch-mul output convention).
+// All builds/loops run on thread 0 (guarded); the wmma tiles are warp-collective (32 threads).
+// Slim driver: the associator emit is split into phase helpers to keep each Madaros stack frame
+// small (a single ~90-statement function segfaults in the lean_single-compiled emitter — the
+// "many locals across many calls" codegen limit). Thread-0 guards ($AS0..$AS2) wrap the builds;
+// the wmma tiles are warp-collective. Every str_concat literal stays short (≲90 chars).
+fn gpu_emit_oct_assoc(paR: string, pbR: string, pHR: string, poutR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+    let sh = if dim == 16 { 4 } else { 3 }
+    // tile1: q = L(b)·H  (also forms a⊗b into the ossm_ab global first)
+    var t = "    mov.u32 %r1, %tid.x;\n"
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $AS0;\n")
+    t = str_concat(t, gpu_emit_assoc_ab_product(paR, pbR, dim, sh))
+    t = str_concat(t, gpu_emit_assoc_zero_shared(0, 0, 1024))
+    t = str_concat(t, gpu_emit_cell_lbuild(pbR, dim, bits, 20))
+    t = str_concat(t, gpu_emit_assoc_hstage(pHR, dim, 0))
+    t = str_concat(t, "$AS0:\n    bar.sync 0;\n")
+    t = str_concat(t, gpu_emit_cell_shared_tile())
+    t = str_concat(t, "    bar.sync 0;\n")
+    // tile2: r = L(a)·q  (repack q → sH col-major, build L(a))
+    t = str_concat(t, "    mov.u32 %r1, %tid.x;\n")
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $AS1;\n")
+    t = str_concat(t, gpu_emit_assoc_zero_shared(1, 512, 1024))
+    t = str_concat(t, gpu_emit_assoc_repack(dim))
+    t = str_concat(t, gpu_emit_cell_lbuild(paR, dim, bits, 21))
+    t = str_concat(t, "$AS1:\n    bar.sync 0;\n")
+    t = str_concat(t, gpu_emit_cell_shared_tile())
+    t = str_concat(t, "    bar.sync 0;\n")
+    // tile3: p = L(a⊗b)·H  (save r → sR first, then build L(ab), stage H)
+    t = str_concat(t, "    mov.u32 %r1, %tid.x;\n")
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $AS2;\n")
+    t = str_concat(t, gpu_emit_assoc_save_r(dim))
+    t = str_concat(t, gpu_emit_assoc_zero_shared(2, 0, 1024))
+    t = str_concat(t, "    mov.u64 %rd5, ossm_ab;\n")
+    t = str_concat(t, gpu_emit_cell_lbuild("%rd5", dim, bits, 22))
+    t = str_concat(t, gpu_emit_assoc_hstage(pHR, dim, 1))
+    t = str_concat(t, "$AS2:\n    bar.sync 0;\n")
+    t = str_concat(t, gpu_emit_cell_shared_tile())
+    t = str_concat(t, "    bar.sync 0;\n")
+    // out[k*16+b] = p − r (f32), thread 0
+    t = str_concat(t, gpu_emit_assoc_subtract(poutR, dim))
+    t
+}
+
+// thread 0: form ab = a⊗b into the ossm_ab global. ab[i⊕j] += σ(i,j)·a[i]·b[j] via a runtime double
+// loop (idx=i*dim+j), reading σ(i,j) from ossm_absgn. Caller has already guarded on tid==0.
+fn gpu_emit_assoc_ab_product(paR: string, pbR: string, dim: i64, sh: i64) -> string with Mut, Panic, Div, Alloc {
+    // zero ossm_ab[0..dim]
+    var t = "    mov.u64 %rd5, ossm_ab;\n"
+    t = str_concat(t, "    mov.f64 %fd0, 0d0000000000000000;\n")
+    t = str_concat(t, "    mov.u32 %r5, 0;\n$AZAB:\n")
+    t = str_concat(t, "    mul.wide.u32 %rd7, %r5, 8;\n")
+    t = str_concat(t, "    add.s64 %rd7, %rd5, %rd7;\n")
+    t = str_concat(t, "    st.global.f64 [%rd7], %fd0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim))
+    t = str_concat(t, ";\n    @%p1 bra $AZAB;\n")
+    // double loop
+    t = str_concat(t, "    mov.u32 %r5, 0;\n$ABL:\n")
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r7, %r5, "), i64_to_string(dim - 1))
+    t = str_concat(str_concat(t, ";\n    mul.wide.u32 %rd7, %r6, 8;\n    add.s64 %rd7, "), paR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r7, 8;\n    add.s64 %rd7, "), pbR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd1, [%rd7];\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")
+    t = str_concat(t, "    mul.wide.u32 %rd7, %r5, 4;\n")
+    t = str_concat(t, "    mov.u64 %rd6, ossm_absgn;\n")
+    t = str_concat(t, "    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n")
+    t = str_concat(t, "    cvt.f64.f32 %fd1, %f0;\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")
+    t = str_concat(t, "    xor.b32 %r8, %r6, %r7;\n")
+    t = str_concat(t, "    mul.wide.u32 %rd7, %r8, 8;\n")
+    t = str_concat(t, "    mov.u64 %rd6, ossm_ab;\n")
+    t = str_concat(t, "    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f64 %fd2, [%rd7];\n")
+    t = str_concat(t, "    add.f64 %fd2, %fd2, %fd0;\n")
+    t = str_concat(t, "    st.global.f64 [%rd7], %fd2;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim))
+    t = str_concat(t, ";\n    @%p1 bra $ABL;\n")
+    t
+}
+
+// thread 0: repack the tile output q (sS@1024, row-major f32, q[k][b]) into sH@512 as a col-major
+// f16 batch (sH[(b*16+k)]), so tile2 can consume it as B. idx 0..dim*16, k=idx>>4, b=idx&15.
+fn gpu_emit_assoc_repack(dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$ARP:\n"
+    t = str_concat(t, "    shr.u32 %r6, %r5, 4;\n    and.b32 %r7, %r5, 15;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r6, 16, %r7;\n")
+    t = str_concat(t, "    mul.lo.u32 %r8, %r8, 4;\n    add.u32 %r8, %r8, 1024;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    ld.shared.f32 %f1, [%r9];\n")
+    t = str_concat(t, "    cvt.rn.f16.f32 %rs0, %f1;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r7, 16, %r6;\n")
+    t = str_concat(t, "    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $ARP;\n")
+    t
+}
+
+// thread 0: save r (sS@1024, row-major f32) to the sR scratch (shared_array+2048), so tile3's output
+// p can be subtracted against it. idx 0..dim*16 over (k*16+b)*4.
+fn gpu_emit_assoc_save_r(dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$ASV:\n"
+    t = str_concat(t, "    shr.u32 %r6, %r5, 4;\n    and.b32 %r7, %r5, 15;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r6, 16, %r7;\n    mul.lo.u32 %r8, %r8, 4;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    add.u32 %r9, %r9, 1024;\n")
+    t = str_concat(t, "    ld.shared.f32 %f1, [%r9];\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    add.u32 %r9, %r9, 2048;\n")
+    t = str_concat(t, "    st.shared.f32 [%r9], %f1;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $ASV;\n")
+    t
+}
+
+// thread 0: out[k*16+b] = p (sS@1024) − r (sR@2048), stored f32 to poutR (matches the batch-mul
+// output convention). Includes its own tid==0 guard ($AS3). idx 0..dim*16 over (k*16+b)*4.
+fn gpu_emit_assoc_subtract(poutR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r1, %tid.x;\n"
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $AS3;\n")
+    t = str_concat(t, "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$ASUB:\n")
+    t = str_concat(t, "    shr.u32 %r6, %r5, 4;\n    and.b32 %r7, %r5, 15;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r6, 16, %r7;\n    mul.lo.u32 %r8, %r8, 4;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    add.u32 %r9, %r9, 1024;\n")
+    t = str_concat(t, "    ld.shared.f32 %f1, [%r9];\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    add.u32 %r9, %r9, 2048;\n")
+    t = str_concat(t, "    ld.shared.f32 %f2, [%r9];\n")
+    t = str_concat(t, "    sub.f32 %f3, %f1, %f2;\n")
+    t = str_concat(t, "    cvt.u64.u32 %rd7, %r8;\n")
+    t = str_concat(str_concat(t, "    add.s64 %rd7, "), poutR)
+    t = str_concat(t, ", %rd7;\n    st.global.f32 [%rd7], %f3;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $ASUB;\n")
+    t = str_concat(t, "$AS3:\n")
+    t
+}
+
+// Zero the shared region [shared_array+base .. shared_array+endb) as f16 (thread 0). `tag` names the
+// unique loop label ($AZ<tag>). Used between associator tiles to clear sL/sH padding.
+fn gpu_emit_assoc_zero_shared(tag: i64, base: i64, endb: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = str_concat("    mov.u16 %rs0, 0;\n    mov.u32 %r2, ", i64_to_string(base))
+    t = str_concat(str_concat(t, ";\n    mov.u32 %r3, shared_array;\n$AZ"), i64_to_string(tag))
+    t = str_concat(t, ":\n    add.u32 %r4, %r3, %r2;\n")
+    t = str_concat(t, "    st.shared.u16 [%r4], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r2, %r2, 2;\n    setp.lt.u32 %p1, %r2, "), i64_to_string(endb))
+    t = str_concat(str_concat(t, ";\n    @%p1 bra $AZ"), i64_to_string(tag))
+    t = str_concat(t, ";\n")
+    t
+}
+
 // Build L(m) (row-major f16, σ(k⊕j,j,bits)·m[k⊕j], dim×dim in the 16×16 tile) into sL[shared_array]
 // from the f64 pointer mR, via a RUNTIME loop reading the ossm_Lsgn sign table (so the sedenion
 // dim=16 build — 256 entries — stays under the 64 KB PtxBuf). `tag` makes the loop label unique.
@@ -517,6 +715,29 @@ fn gpu_has_oct_recur(kernel: GpuKernelIr) -> bool {
         i = i + 1
     }
     false
+}
+
+// Does this kernel contain the batched associator op?
+fn gpu_has_oct_assoc(kernel: GpuKernelIr) -> bool {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctAssoc { return true }
+        i = i + 1
+    }
+    false
+}
+
+// The dim of the associator op (8 octonion / 16 sedenion), for the module-scope sign tables.
+fn gpu_assoc_dim(kernel: GpuKernelIr) -> i64 {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctAssoc {
+            if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
+            return 8
+        }
+        i = i + 1
+    }
+    8
 }
 
 // O-SSM recurrence over T timesteps. H0 staged once into sH; then a runtime loop over t<T:
@@ -930,6 +1151,13 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
             let rdim = if op.rhs_imm == 16 { 16 } else { 8 }
             let rbits = if rdim == 16 { 4 } else { 3 }
             ptx_push_str(buf, gpu_emit_oct_recur(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg), gpu_reg_u64(op.byte_offset), rdim, rbits))
+        }
+
+        GpuOpcode::GpuOctAssoc => {
+            // Batched associator [a,b,H] = (a⊗b)⊗H − a⊗(b⊗H). Pointers: pa=lhs, pb=rhs, pH=addr, pout=src.
+            let adim = if op.rhs_imm == 16 { 16 } else { 8 }
+            let abits = if adim == 16 { 4 } else { 3 }
+            ptx_push_str(buf, gpu_emit_oct_assoc(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), adim, abits))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/tests/gpu/oct_assoc_wmma_tile.sio
+++ b/tests/gpu/oct_assoc_wmma_tile.sio
@@ -1,0 +1,10 @@
+// Batched octonion ASSOCIATOR on tensor cores — ELEGANT array-of-Hyper syntax.
+// [a,b,H_b] = (a⊗b)⊗H_b − a⊗(b⊗H_b) for a 16-state batch: a,b are fixed octonions, H the batch.
+// Lowers to THREE m16n16k16 tiles (L(b)·H, L(a)·q, L(a⊗b)·H) + a σ-table a⊗b + a subtract.
+// Hyper<Octonion,f64> = 8 f64, so [Hyper<Octonion,f64>;16] is byte-identical to [f64;128].
+fn oct_assoc(pa: &Hyper<Octonion, f64>, pb: &Hyper<Octonion, f64>, pH: &[Hyper<Octonion, f64>; 16], pout: &! [f64; 256]) with GPU { }
+
+kernel fn step(pa: &Hyper<Octonion, f64>, pb: &Hyper<Octonion, f64>, pH: &[Hyper<Octonion, f64>; 16], pout: &! [f64; 256]) with GPU {
+    oct_assoc(pa, pb, pH, pout)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/sed_assoc_wmma_tile.sio
+++ b/tests/gpu/sed_assoc_wmma_tile.sio
@@ -1,0 +1,8 @@
+// Batched SEDENION associator on tensor cores — ELEGANT array-of-Hyper syntax (dim=16, bits=4).
+// [a,b,H_b] = (a⊗b)⊗H_b − a⊗(b⊗H_b). Hyper<Sedenion,f64> = 16 f64 → [Hyper<Sedenion,f64>;16] = [f64;256].
+fn sed_assoc(pa: &Hyper<Sedenion, f64>, pb: &Hyper<Sedenion, f64>, pH: &[Hyper<Sedenion, f64>; 16], pout: &! [f64; 256]) with GPU { }
+
+kernel fn step(pa: &Hyper<Sedenion, f64>, pb: &Hyper<Sedenion, f64>, pH: &[Hyper<Sedenion, f64>; 16], pout: &! [f64; 256]) with GPU {
+    sed_assoc(pa, pb, pH, pout)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

Lower a **first-class batched associator** `[a,b,H_b] = (a⊗b)⊗H_b − a⊗(b⊗H_b)` to tensor cores via the compiler. For fixed hypercomplex `a,b` and a 16-state batch `H`, using the left-multiply identity

```
[a,b,H] = L(a⊗b)·H − L(a)·(L(b)·H)
```

it expands to **three m16n16k16 wmma tiles** (`q=L(b)·H`, `r=L(a)·q`, `p=L(a⊗b)·H`) plus a σ-table product `a⊗b` and an elementwise subtract — reusing the L-build / H-stage / shared-tile machinery of the O-SSM cell.

```sio
kernel fn step(pa:&Hyper<Octonion,f64>, pb:&Hyper<Octonion,f64>,
               pH:&[Hyper<Octonion,f64>;16], pout:&![f64;256]) with GPU {
    oct_assoc(pa, pb, pH, pout)   // [a,b,H_b] over a 16-state batch
}
```

New intrinsics recognized by name in the GPU bridge: `oct_assoc` (dim=8, bits=3) and `sed_assoc` (dim=16, bits=4), in the elegant array-of-Hyper syntax.

## Implementation

- **kernel_ir.sio**: `GpuOctAssoc` opcode (pointers `pa/pb/pH/pout` in `lhs/rhs/addr/src`; `rhs_imm=dim`).
- **hlir_to_gpu.sio**: `hlir_name_is_oct_assoc` / `sed_assoc` + a CALL_DIRECT arm emitting `GpuOctAssoc`.
- **lower_to_ptx.sio**: `gpu_has_oct_assoc` / `gpu_assoc_dim`; sm_80 header + fragment decls; two module-scope sign tables (`ossm_Lsgn` σ(k⊕j,j) for the L-build, `ossm_absgn` σ(i,j) to form `a⊗b`) + an `ossm_ab` global f64 scratch; the renderer `gpu_emit_oct_assoc` is **split into phase helpers** (ab-product / zero-shared / repack / save-r / subtract) so each Madaros stack frame stays small — a single ~90-statement emitter segfaults in the lean_single-compiled binary (the "many locals across many calls" codegen limit). Every `str_concat` literal stays short (the ≳120-char literal abort).

## Hardware validation (DGX Spark GB10, sm_121a)

ptxas-clean; vs the scalar Cayley-Dickson oracle:

| intrinsic | result | maxerr |
|---|---|---|
| `oct_assoc` | 0/128 | 0.0013 |
| `sed_assoc` | 0/256 | 0.0060 |

Both within f16 tile tolerance. Harness `docs/gpu/run_assoc_wmma_ptx.cu`; validated PTX artifacts `docs/gpu/{oct,sed}_assoc_wmma_tile.ptx`. Builds on the tensor-core arc #1103/#1109/#1114/#1117/#1120/#1126/#1130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)