### PR TITLE
test(madaros): cover BSS local bindings

### DIFF
--- a/tests/run-pass/madaros_bss_global_local_loop_binding.sio
+++ b/tests/run-pass/madaros_bss_global_local_loop_binding.sio
@@ -1,0 +1,136 @@
+//@ run-pass
+//@ requires: madaros
+
+let PLAN_CAPACITY: i64 = 2
+let PLAN_FREE: i64 = 0
+let PLAN_LIVE: i64 = 1
+
+struct PlanId {
+    slot: i64,
+    generation: i64,
+}
+
+var PLAN_STATE_0: i64 = 0
+var PLAN_STATE_1: i64 = 0
+var PLAN_GENERATION_0: i64 = 0
+var PLAN_GENERATION_1: i64 = 0
+var PLAN_ARENA_IDENTITY_0: i64 = 0
+var PLAN_ARENA_IDENTITY_1: i64 = 0
+var PLAN_MODULE_SLOT_0: i64 = 0
+var PLAN_MODULE_SLOT_1: i64 = 0
+var PLAN_MODULE_GENERATION_0: i64 = 0
+var PLAN_MODULE_GENERATION_1: i64 = 0
+var PLAN_FINGERPRINT_0: i64 = 0
+var PLAN_FINGERPRINT_1: i64 = 0
+var PLAN_START_0: i64 = 0
+var PLAN_START_1: i64 = 0
+var PLAN_CAPACITY_0: i64 = 0
+var PLAN_CAPACITY_1: i64 = 0
+var PLAN_REQUIRED_0: i64 = 0
+var PLAN_REQUIRED_1: i64 = 0
+var PLAN_END_0: i64 = 0
+var PLAN_END_1: i64 = 0
+var PLAN_VERSION_0: i64 = 0
+var PLAN_VERSION_1: i64 = 0
+
+fn plan_state(slot: i64) -> i64 {
+    if slot == 0 { return PLAN_STATE_0 }
+    PLAN_STATE_1
+}
+
+fn plan_generation(slot: i64) -> i64 {
+    if slot == 0 { return PLAN_GENERATION_0 }
+    PLAN_GENERATION_1
+}
+
+fn plan_set_state(slot: i64, value: i64) -> i64 with Mut {
+    if slot == 0 { PLAN_STATE_0 = value }
+    else { PLAN_STATE_1 = value }
+    0
+}
+
+fn plan_set_generation(slot: i64, value: i64) -> i64 with Mut {
+    if slot == 0 { PLAN_GENERATION_0 = value }
+    else { PLAN_GENERATION_1 = value }
+    0
+}
+
+fn plan_zero(slot: i64) -> i64 with Mut {
+    if slot == 0 {
+        PLAN_ARENA_IDENTITY_0 = 0
+        PLAN_MODULE_SLOT_0 = 0
+        PLAN_MODULE_GENERATION_0 = 0
+        PLAN_FINGERPRINT_0 = 0
+        PLAN_START_0 = 0
+        PLAN_CAPACITY_0 = 0
+        PLAN_REQUIRED_0 = 0
+        PLAN_END_0 = 0
+        PLAN_VERSION_0 = 0
+    } else {
+        PLAN_ARENA_IDENTITY_1 = 0
+        PLAN_MODULE_SLOT_1 = 0
+        PLAN_MODULE_GENERATION_1 = 0
+        PLAN_FINGERPRINT_1 = 0
+        PLAN_START_1 = 0
+        PLAN_CAPACITY_1 = 0
+        PLAN_REQUIRED_1 = 0
+        PLAN_END_1 = 0
+        PLAN_VERSION_1 = 0
+    }
+    0
+}
+
+fn plan_store_init() -> i64 with Mut {
+    var slot: i64 = 0
+    while slot < PLAN_CAPACITY {
+        if plan_state(slot) == PLAN_LIVE {
+            let bumped = plan_generation(slot) + 1
+            let generation_status = plan_set_generation(slot, bumped)
+            if generation_status != 0 { return generation_status }
+        }
+        let zero_status = plan_zero(slot)
+        if zero_status != 0 { return zero_status }
+        let state_status = plan_set_state(slot, PLAN_FREE)
+        if state_status != 0 { return state_status }
+        slot = slot + 1
+    }
+    0
+}
+
+fn plan_id_clear(out: &! PlanId) -> i64 with Mut {
+    (*out).slot = -1
+    (*out).generation = -1
+    0
+}
+
+fn invalid_plan_id() -> PlanId {
+    PlanId { slot: -1, generation: -1 }
+}
+
+fn plan_id_is_live(id: &PlanId) -> bool {
+    let slot = (*id).slot
+    slot >= 0 && slot < PLAN_CAPACITY &&
+        plan_state(slot) == PLAN_LIVE &&
+        plan_generation(slot) == (*id).generation
+}
+
+fn release_plan(id: &PlanId) -> i64 with Mut {
+    if !plan_id_is_live(id) {
+        return -1
+    }
+    let slot = (*id).slot
+    let generation_status = plan_set_generation(slot, plan_generation(slot) + 1)
+    if generation_status != 0 { return generation_status }
+    let zero_status = plan_zero(slot)
+    if zero_status != 0 { return zero_status }
+    plan_set_state(slot, PLAN_FREE)
+}
+
+fn main() -> i64 with IO, Mut {
+    print("BSS_LOCAL_LOOP_ENTER\n")
+    if plan_store_init() != 0 {
+        return 1
+    }
+    println("BSS_LOCAL_LOOP_PASS")
+    return 0
+}

--- a/tests/run-pass/madaros_bss_global_local_struct_binding.sio
+++ b/tests/run-pass/madaros_bss_global_local_struct_binding.sio
@@ -1,0 +1,31 @@
+//@ run-pass
+//@ requires: madaros
+
+let THRESHOLD_1_DIRECT_0: i64 = 0
+
+struct Threshold1Direct {
+    first: i64,
+    second: i64,
+    third: i64,
+}
+
+fn threshold_slot_1_direct(value: &! Threshold1Direct) -> i64 with Mut {
+    (*value).second = 32
+    (*value).second
+}
+
+fn main() -> i64 with IO, Mut {
+    print("BSS_LOCAL_STRUCT_ENTER\n")
+    var value = Threshold1Direct { first: 0, second: -1, third: 0 }
+    if value.second != -1 {
+        return 1
+    }
+    if threshold_slot_1_direct(&!value) != 32 {
+        return 2
+    }
+    if value.second != 32 {
+        return 3
+    }
+    println("BSS_LOCAL_STRUCT_PASS")
+    return 0
+}


### PR DESCRIPTION
## Summary

- add a loop-local binding witness that reads an imported-style BSS global
- add a struct-local binding witness over the same global path
- keep the lane tests-only; no compiler implementation files change

## Evidence

- rebased onto `origin/main` at `8104e5d5d687873ec5cc2fb33c6847af8afb21ac`
- tested with source-fresh Madaros SHA-256 `61bcab72e61df6d8e9a8f4945b4b30690445ced5ae679e3b82acfabfb073860d`
- `CI_BASE_SHA=origin/main CI_HEAD_SHA=HEAD SOUNIO_MADAROS_CHANGED_TESTS_BIN=... bash scripts/ci/madaros_changed_tests_gate.sh`
- result: `MADAROS_CHANGED_TESTS_PASS count=2`, Pass 2, Fail 0

## Scope boundary

These witnesses preserve the two regressions exposed while testing the now-merged lazy BSS-global resolution fix. The speculative `LowerLocalStack` refactor was intentionally not carried into this PR because adversarial no-global witnesses did not distinguish it from the corrected baseline.