### PR TITLE
feat(ir): add shadow Arena v2 SOIR v5 vertical

### DIFF
--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-5a8ae321dbb78b2b8fcd405457c619d1821aadf5}"
+BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-a505fe5b3d66565236653f5dff203bc7fbad7076}"
 SOUC="${SOUC_BIN:-$ROOT/bin/madaros}"
 ARENA="self-hosted/ir/arena_v2_shadow.sio"
 WRITER="self-hosted/ir/soir_writer.sio"

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -12,6 +12,7 @@ ARENA="self-hosted/ir/arena_v2_shadow.sio"
 WRITER="self-hosted/ir/soir_writer.sio"
 BRIDGE="self-hosted/ir/arena_v2_soir_bridge.sio"
 PROVENANCE_MODE="${IR_MODULE_ARENA_V2_SOIR_PROVENANCE_MODE:-git}"
+GIT_SCOPE="${IR_MODULE_ARENA_V2_SOIR_GIT_SCOPE:-current_tree}"
 CONTENT_MANIFEST="${IR_MODULE_ARENA_V2_SOIR_CONTENT_MANIFEST:-}"
 EXPECTED_MANIFEST_SHA256="${IR_MODULE_ARENA_V2_SOIR_EXPECTED_MANIFEST_SHA256:-}"
 RUNTIME_TIMEOUT_SECONDS="${IR_MODULE_ARENA_V2_SOIR_RUNTIME_TIMEOUT_SECONDS:-15}"
@@ -24,6 +25,8 @@ BASE_RECEIPT="not_checked_manifest_scope"
 PRECISION_RECEIPT="not_checked_manifest_scope"
 LEGACY_RECEIPT="not_checked_manifest_scope"
 LANE_CONTENT_SHA256=""
+GIT_SCOPE_RECEIPT="not_applicable_manifest"
+EXACT_WRITE_SET_RECEIPT="not_checked_manifest_scope"
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2-soir-v5.XXXXXX")"
 
 cleanup() {
@@ -131,30 +134,51 @@ validate_git_provenance() {
   local -a expected_paths
   local dirty_paths
 
-  [[ "$REQUESTED_BASE" == "$PINNED_BASE" ]] || fail base_override_rejected
-  git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
   HEAD_SHA="$(git rev-parse HEAD)"
   TREE_SHA="$(git rev-parse 'HEAD^{tree}')"
-  [[ "$HEAD_SHA" != "$BASE" ]] || fail head_equals_pinned_base
-  git merge-base --is-ancestor "$BASE" "$HEAD_SHA" || fail pinned_base_not_ancestor
-
-  git diff --name-only "$BASE" "$HEAD_SHA" | LC_ALL=C sort >"$TMP/write-set.actual"
-  expected_write_set | LC_ALL=C sort >"$TMP/write-set.expected"
-  diff -u "$TMP/write-set.expected" "$TMP/write-set.actual" \
-    >"$TMP/write-set.diff" 2>&1 || {
-      cat "$TMP/write-set.diff" >&2
-      fail write_set_expanded
-    }
 
   mapfile -t expected_paths < <(expected_write_set)
+  for expected_path in "${expected_paths[@]}"; do
+    git ls-files --error-unmatch -- "$expected_path" >/dev/null 2>&1 \
+      || fail expected_write_set_path_untracked
+  done
   dirty_paths="$(git status --porcelain --untracked-files=all -- "${expected_paths[@]}")"
   if [[ -n "$dirty_paths" ]]; then
     printf '%s\n' "$dirty_paths" >&2
     fail expected_write_set_dirty
   fi
 
-  PROVENANCE_RECEIPT="git_head_tree_bound"
-  BASE_RECEIPT="$BASE"
+  case "$GIT_SCOPE" in
+    current_tree)
+      [[ -z "${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-}" ]] || fail base_not_applicable_current_tree
+      PROVENANCE_RECEIPT="git_head_tree_bound_current_tree"
+      BASE_RECEIPT="not_checked_current_tree"
+      GIT_SCOPE_RECEIPT="current_tree"
+      EXACT_WRITE_SET_RECEIPT="not_checked_current_tree"
+      ;;
+    publication)
+      [[ "$REQUESTED_BASE" == "$PINNED_BASE" ]] || fail base_override_rejected
+      git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
+      [[ "$HEAD_SHA" != "$BASE" ]] || fail head_equals_pinned_base
+      git merge-base --is-ancestor "$BASE" "$HEAD_SHA" || fail pinned_base_not_ancestor
+
+      git diff --name-only "$BASE" "$HEAD_SHA" | LC_ALL=C sort >"$TMP/write-set.actual"
+      expected_write_set | LC_ALL=C sort >"$TMP/write-set.expected"
+      diff -u "$TMP/write-set.expected" "$TMP/write-set.actual" \
+        >"$TMP/write-set.diff" 2>&1 || {
+          cat "$TMP/write-set.diff" >&2
+          fail write_set_expanded
+        }
+
+      PROVENANCE_RECEIPT="git_head_tree_bound_publication"
+      BASE_RECEIPT="$BASE"
+      GIT_SCOPE_RECEIPT="publication_branch_exact"
+      EXACT_WRITE_SET_RECEIPT="pass"
+      ;;
+    *)
+      fail git_scope_invalid
+      ;;
+  esac
 }
 
 validate_manifest_provenance() {
@@ -274,7 +298,9 @@ PROTECTED=(
 if [[ "$PROVENANCE_MODE" == "git" ]]; then
   for protected in "${PROTECTED[@]}"; do
     [[ -e "$protected" ]] || continue
-    git diff --quiet "$BASE" -- "$protected" || fail "protected_surface_changed_${protected//\//_}"
+    if [[ "$GIT_SCOPE" == "publication" ]]; then
+      git diff --quiet "$BASE" -- "$protected" || fail "protected_surface_changed_${protected//\//_}"
+    fi
     [[ -z "$(git status --short -- "$protected")" ]] || fail "protected_surface_dirty_${protected//\//_}"
   done
 
@@ -395,8 +421,8 @@ printf 'IR_MODULE_ARENA_V2_SOIR_V5_DIFFERENTIAL mode=shadow_canonical_not_differ
 if [[ "$PROVENANCE_MODE" == "manifest" ]]; then
   printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=manifest_pinned_lane_content manifest_sha256=%s entries=13 scope=lane_content_only protected_surfaces=not_checked\n' "$CONTENT_MANIFEST_SHA256"
 else
-  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=git_head_tree_bound base=%s head=%s tree=%s exact_write_set=pass expected_paths_clean=pass\n' \
-    "$BASE" "$HEAD_SHA" "$TREE_SHA"
+  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=%s scope=%s base=%s head=%s tree=%s exact_write_set=%s expected_paths_clean=pass\n' \
+    "$PROVENANCE_RECEIPT" "$GIT_SCOPE_RECEIPT" "$BASE_RECEIPT" "$HEAD_SHA" "$TREE_SHA" "$EXACT_WRITE_SET_RECEIPT"
 fi
-printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s head=%s tree=%s lane_content_sha256=%s provenance=%s\n' \
-  "$SOUC" "$compiler_sha256" "$BASE_RECEIPT" "$HEAD_SHA" "$TREE_SHA" "$LANE_CONTENT_SHA256" "$PROVENANCE_RECEIPT"
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s head=%s tree=%s lane_content_sha256=%s provenance=%s scope=%s exact_write_set=%s\n' \
+  "$SOUC" "$compiler_sha256" "$BASE_RECEIPT" "$HEAD_SHA" "$TREE_SHA" "$LANE_CONTENT_SHA256" "$PROVENANCE_RECEIPT" "$GIT_SCOPE_RECEIPT" "$EXACT_WRITE_SET_RECEIPT"

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -9,6 +9,11 @@ SOUC="${SOUC_BIN:-$ROOT/bin/madaros}"
 ARENA="self-hosted/ir/arena_v2_shadow.sio"
 WRITER="self-hosted/ir/soir_writer.sio"
 BRIDGE="self-hosted/ir/arena_v2_soir_bridge.sio"
+PROVENANCE_MODE="${IR_MODULE_ARENA_V2_SOIR_PROVENANCE_MODE:-git}"
+CONTENT_MANIFEST="${IR_MODULE_ARENA_V2_SOIR_CONTENT_MANIFEST:-}"
+EXPECTED_MANIFEST_SHA256="${IR_MODULE_ARENA_V2_SOIR_EXPECTED_MANIFEST_SHA256:-}"
+PROVENANCE_RECEIPT=""
+CONTENT_MANIFEST_SHA256=""
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2-soir-v5.XXXXXX")"
 
 cleanup() {
@@ -21,11 +26,78 @@ fail() {
   exit 1
 }
 
+expected_write_set() {
+  printf '%s\n' \
+    scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh \
+    self-hosted/ir/arena_v2_shadow.sio \
+    self-hosted/ir/arena_v2_soir_bridge.sio \
+    self-hosted/ir/soir_writer.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_cross_arena_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_invalid_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_plan_lifecycle_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_sequence_probe.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_stale_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio
+}
+
+validate_manifest_provenance() {
+  [[ -n "$CONTENT_MANIFEST" ]] || fail manifest_path_required
+  [[ -n "$EXPECTED_MANIFEST_SHA256" ]] || fail manifest_sha256_required
+  [[ "$EXPECTED_MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]] || fail manifest_sha256_malformed
+  [[ -f "$CONTENT_MANIFEST" ]] || fail manifest_missing
+  [[ -s "$CONTENT_MANIFEST" ]] || fail manifest_empty
+
+  CONTENT_MANIFEST_SHA256="$(sha256sum "$CONTENT_MANIFEST" | awk '{print $1}')"
+  [[ "$CONTENT_MANIFEST_SHA256" == "$EXPECTED_MANIFEST_SHA256" ]] || fail manifest_sha256_mismatch
+
+  set +e
+  LC_ALL=C grep -Env '^[0-9a-f]{64}  [A-Za-z0-9._/-]+$' "$CONTENT_MANIFEST" \
+    >"$TMP/manifest-format.log" 2>&1
+  manifest_format_rc=$?
+  set -e
+  if [[ "$manifest_format_rc" -eq 0 ]]; then
+    cat "$TMP/manifest-format.log" >&2
+    fail manifest_format_invalid
+  fi
+  [[ "$manifest_format_rc" -eq 1 ]] || fail manifest_format_scan_error
+  [[ "$(wc -l <"$CONTENT_MANIFEST" | tr -d ' ')" == 13 ]] || fail manifest_entry_count_not_13
+
+  awk '{print $2}' "$CONTENT_MANIFEST" | LC_ALL=C sort >"$TMP/manifest-paths.actual"
+  expected_write_set | LC_ALL=C sort >"$TMP/manifest-paths.expected"
+  diff -u "$TMP/manifest-paths.expected" "$TMP/manifest-paths.actual" \
+    >"$TMP/manifest-paths.diff" 2>&1 || {
+      cat "$TMP/manifest-paths.diff" >&2
+      fail manifest_write_set_mismatch
+    }
+
+  sha256sum -c "$CONTENT_MANIFEST" >"$TMP/manifest-content-check.log" 2>&1 || {
+    cat "$TMP/manifest-content-check.log" >&2
+    fail manifest_content_mismatch
+  }
+  PROVENANCE_RECEIPT="manifest_pinned"
+}
+
+case "$PROVENANCE_MODE" in
+  git)
+    command -v git >/dev/null 2>&1 || fail git_required_for_git_provenance
+    git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
+    PROVENANCE_RECEIPT="git"
+    ;;
+  manifest)
+    validate_manifest_provenance
+    ;;
+  *)
+    fail provenance_mode_invalid
+    ;;
+esac
+
 for file in "$ARENA" "$WRITER" "$BRIDGE"; do
   [[ -f "$file" ]] || fail "missing_${file//\//_}"
 done
 [[ -x "$SOUC" ]] || fail compiler_missing
-git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
 
 grep -Fq 'pub let SOIR_WRITER_SCALAR_EMPTY_V5_SIZE: i64 = 320' "$WRITER" || fail writer_size_contract_missing
 grep -Fq 'pub fn soir_writer_preflight_scalar_empty_module_v5(' "$WRITER" || fail writer_preflight_missing
@@ -76,14 +148,16 @@ PROTECTED=(
   scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
   scripts/ci/madaros_f128_f256_numeric_wire_gate.sh
 )
-for protected in "${PROTECTED[@]}"; do
-  [[ -e "$protected" ]] || continue
-  git diff --quiet "$BASE" -- "$protected" || fail "protected_surface_changed_${protected//\//_}"
-  [[ -z "$(git status --short -- "$protected")" ]] || fail "protected_surface_dirty_${protected//\//_}"
-done
+if [[ "$PROVENANCE_MODE" == "git" ]]; then
+  for protected in "${PROTECTED[@]}"; do
+    [[ -e "$protected" ]] || continue
+    git diff --quiet "$BASE" -- "$protected" || fail "protected_surface_changed_${protected//\//_}"
+    [[ -z "$(git status --short -- "$protected")" ]] || fail "protected_surface_dirty_${protected//\//_}"
+  done
 
-if git status --porcelain --untracked-files=all | cut -c4- | grep -Eiq '(^|/)contest'; then
-  fail contest_surface_dirty
+  if git status --porcelain --untracked-files=all | cut -c4- | grep -Eiq '(^|/)contest'; then
+    fail contest_surface_dirty
+  fi
 fi
 
 for default_surface in \
@@ -99,11 +173,38 @@ for default_surface in \
   fi
 done
 
-bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
-  >"$TMP/precision-identity.log" 2>&1 || {
-    cat "$TMP/precision-identity.log" >&2
-    fail precision_identity_regression
-  }
+run_manifest_precision_identity_check() {
+  local shim_dir="$TMP/manifest-tool-shim"
+  local shim="$shim_dir/git"
+  mkdir -p "$shim_dir"
+  # The canonical structural precision gate uses Git once, only to print a
+  # source identity. Bind that receipt to the pinned manifest and reject every
+  # other Git operation; all descriptor and containment checks run unchanged.
+  {
+    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+    printf '%s\n' 'if [[ "$#" -eq 2 && "$1" == "rev-parse" && "$2" == "HEAD" ]]; then'
+    printf '  printf '\''%%s\\n'\'' '\''manifest:%s'\''\n' "$CONTENT_MANIFEST_SHA256"
+    printf '%s\n' '  exit 0' 'fi'
+    printf '%s\n' 'echo "manifest provenance adapter rejected unsupported git command" >&2' 'exit 64'
+  } >"$shim"
+  chmod +x "$shim"
+  PATH="$shim_dir:$PATH" \
+    bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
+    >"$TMP/precision-identity.log" 2>&1 || {
+      cat "$TMP/precision-identity.log" >&2
+      fail precision_identity_regression
+    }
+}
+
+if [[ "$PROVENANCE_MODE" == "git" ]]; then
+  bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
+    >"$TMP/precision-identity.log" 2>&1 || {
+      cat "$TMP/precision-identity.log" >&2
+      fail precision_identity_regression
+    }
+else
+  run_manifest_precision_identity_check
+fi
 
 for source in "$WRITER" "$ARENA" "$BRIDGE"; do
   "$SOUC" check "$source" >"$TMP/$(basename "$source").check.log" 2>&1 || {
@@ -167,23 +268,9 @@ grep -Fq 'SEQUENCE_AFTER_REUSE status=-22' "$TMP/ir_module_arena_v2_soir_v5_brid
 grep -Fq 'canary=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_sequence_probe.out" || fail sequence_canary_receipt_missing
 grep -Fq 'MUTATION_PREFLIGHT status=-21 bss=8 id_live=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.out" || fail mutation_preflight_receipt_missing
 
-if [[ "$(git rev-parse HEAD)" != "$BASE" ]]; then
+if [[ "$PROVENANCE_MODE" == "git" && "$(git rev-parse HEAD)" != "$BASE" ]]; then
   git diff --name-only "$BASE" HEAD | sort >"$TMP/write-set.actual"
-  printf '%s\n' \
-    scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh \
-    self-hosted/ir/arena_v2_shadow.sio \
-    self-hosted/ir/arena_v2_soir_bridge.sio \
-    self-hosted/ir/soir_writer.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_cross_arena_witness.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_invalid_witness.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_witness.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_plan_lifecycle_witness.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_sequence_probe.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_stale_witness.sio \
-    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio \
-    | sort >"$TMP/write-set.expected"
+  expected_write_set | sort >"$TMP/write-set.expected"
   diff -u "$TMP/write-set.expected" "$TMP/write-set.actual" \
     >"$TMP/write-set.diff" 2>&1 || {
       cat "$TMP/write-set.diff" >&2
@@ -192,9 +279,13 @@ if [[ "$(git rev-parse HEAD)" != "$BASE" ]]; then
 fi
 
 compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
-printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_CHECK source=pass composite_matrix=9/9 precision_identity=preserved'
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_CHECK source=pass composite_matrix=9/9 precision_identity=preserved provenance=%s\n' "$PROVENANCE_RECEIPT"
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_PLAN storage=private_scalar_columns capacity=2 identity=slot,generation binding=arena,module_slot,module_generation,mutation_epoch,start,capacity,required,end,version'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_EMIT deterministic=pass wire=v5_empty_320 capacity_below=reject capacity_exact=pass no_partial_write=pass origin=zero_only'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_IDS invalid=reject stale=reject reuse=reject cross_arena=reject mutation_after_preflight=reject mutation_repreflight=pass'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_DIFFERENTIAL mode=shadow_canonical_not_differential byte_parity=not_claimed legacy=default'
-printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"
+if [[ "$PROVENANCE_MODE" == "manifest" ]]; then
+  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=manifest_pinned manifest_sha256=%s entries=13\n' "$CONTENT_MANIFEST_SHA256"
+fi
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s provenance=%s\n' \
+  "$SOUC" "$compiler_sha256" "$BASE" "$PROVENANCE_RECEIPT"

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-5a8ae321dbb78b2b8fcd405457c619d1821aadf5}"
+SOUC="${SOUC_BIN:-$ROOT/bin/madaros}"
+ARENA="self-hosted/ir/arena_v2_shadow.sio"
+WRITER="self-hosted/ir/soir_writer.sio"
+BRIDGE="self-hosted/ir/arena_v2_soir_bridge.sio"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2-soir-v5.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'IR_MODULE_ARENA_V2_SOIR_V5_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+for file in "$ARENA" "$WRITER" "$BRIDGE"; do
+  [[ -f "$file" ]] || fail "missing_${file//\//_}"
+done
+[[ -x "$SOUC" ]] || fail compiler_missing
+git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
+
+grep -Fq 'pub let SOIR_WRITER_SCALAR_EMPTY_V5_SIZE: i64 = 320' "$WRITER" || fail writer_size_contract_missing
+grep -Fq 'pub fn soir_writer_preflight_scalar_empty_module_v5(' "$WRITER" || fail writer_preflight_missing
+grep -Fq 'pub fn soir_writer_emit_scalar_empty_module_v5(' "$WRITER" || fail writer_emit_missing
+grep -Fq 'pub struct IrModuleArenaV2ModuleId {' "$ARENA" || fail module_id_missing
+grep -Fq 'pub let IR_MODULE_ARENA_V2_MODULE_CAPACITY: i64 = 2' "$ARENA" || fail module_capacity_not_two
+grep -Fq 'pub struct IrModuleArenaV2SoirPlanId {' "$BRIDGE" || fail plan_id_missing
+grep -Fq 'pub let IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY: i64 = 2' "$BRIDGE" || fail plan_capacity_not_two
+grep -Fq 'pub fn ir_module_arena_v2_soir_preflight_empty_v5(' "$BRIDGE" || fail bridge_preflight_missing
+grep -Fq 'pub fn ir_module_arena_v2_soir_emit_empty_v5(' "$BRIDGE" || fail bridge_emit_missing
+grep -Fq 'soir_writer_preflight_scalar_empty_module_v5' "$BRIDGE" || fail writer_preflight_not_delegated
+grep -Fq 'soir_writer_emit_scalar_empty_module_v5' "$BRIDGE" || fail writer_emit_not_delegated
+
+set +e
+rg -n 'use (parser|ir::ir)|\b(IrModule|IrInstr|TyF128|TyF256|numeric_payload)\b' \
+  "$ARENA" "$WRITER" "$BRIDGE" >"$TMP/dependency-leak.log" 2>&1
+dependency_scan_rc=$?
+set -e
+if [[ "$dependency_scan_rc" -eq 0 ]]; then
+  cat "$TMP/dependency-leak.log" >&2
+  fail shadow_dependency_expanded
+fi
+if [[ "$dependency_scan_rc" -ne 1 ]]; then
+  cat "$TMP/dependency-leak.log" >&2
+  fail dependency_scan_error
+fi
+if grep -Eq '(out_buf|buf):[[:space:]]*\[i8;[[:space:]]*131072\]' "$BRIDGE"; then
+  fail buffer_passed_by_value
+fi
+if grep -Eq '^pub var IR_MODULE_ARENA_V2_SOIR_PLAN_' "$BRIDGE"; then
+  fail plan_columns_public
+fi
+
+PROTECTED=(
+  self-hosted/check/check.sio
+  self-hosted/compiler/main.sio
+  self-hosted/compiler/module_frontend.sio
+  self-hosted/ir/lower.sio
+  self-hosted/ir/ir.sio
+  self-hosted/ir/serialize.sio
+  self-hosted/ir/mod.sio
+  self-hosted/ir/numeric_payload.sio
+  self-hosted/ir/numeric_payload_wire.sio
+  self-hosted/compiler/f128_f256_format_descriptor_probe.sio
+  self-hosted/compiler/f128_f256_numeric_payload_probe.sio
+  self-hosted/compiler/f128_f256_numeric_wire_probe.sio
+  scripts/ci/madaros_f128_f256_format_identity_gate.sh
+  scripts/ci/madaros_f128_f256_numeric_payload_gate.sh
+  scripts/ci/madaros_f128_f256_numeric_wire_gate.sh
+)
+for protected in "${PROTECTED[@]}"; do
+  [[ -e "$protected" ]] || continue
+  git diff --quiet "$BASE" -- "$protected" || fail "protected_surface_changed_${protected//\//_}"
+  [[ -z "$(git status --short -- "$protected")" ]] || fail "protected_surface_dirty_${protected//\//_}"
+done
+
+if git status --porcelain --untracked-files=all | cut -c4- | grep -Eiq '(^|/)contest'; then
+  fail contest_surface_dirty
+fi
+
+for default_surface in \
+  self-hosted/ir/serialize.sio \
+  self-hosted/ir/mod.sio \
+  self-hosted/ir/lower.sio \
+  self-hosted/check/check.sio \
+  self-hosted/compiler/main.sio \
+  self-hosted/compiler/module_frontend.sio; do
+  [[ -f "$default_surface" ]] || continue
+  if grep -Eq 'arena_v2_(shadow|soir_bridge)|ir::soir_writer' "$default_surface"; then
+    fail "shadow_imported_by_${default_surface//\//_}"
+  fi
+done
+
+bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
+  >"$TMP/precision-identity.log" 2>&1 || {
+    cat "$TMP/precision-identity.log" >&2
+    fail precision_identity_regression
+  }
+
+for source in "$WRITER" "$ARENA" "$BRIDGE"; do
+  "$SOUC" check "$source" >"$TMP/$(basename "$source").check.log" 2>&1 || {
+    cat "$TMP/$(basename "$source").check.log" >&2
+    fail "source_check_${source//\//_}"
+  }
+done
+
+compose_and_run() {
+  local witness="$1"
+  local marker="$2"
+  local name composite elf log
+  name="$(basename "$witness" .sio)"
+  composite="$TMP/$name.sio"
+  elf="$TMP/$name.elf"
+  log="$TMP/$name.log"
+
+  {
+    printf 'module ir::%s_gate\n\n' "$name"
+    sed '/^module ir::soir_writer$/d' "$WRITER"
+    sed '/^module ir::arena_v2_shadow$/d' "$ARENA"
+    sed -e '/^module ir::arena_v2_soir_bridge$/d' \
+        -e '/^use ir::arena_v2_shadow::\*$/d' \
+        -e '/^use ir::soir_writer::\*$/d' "$BRIDGE"
+    sed -e '/^use ir::arena_v2_shadow::\*$/d' \
+        -e '/^use ir::soir_writer::\*$/d' \
+        -e '/^use ir::arena_v2_soir_bridge::\*$/d' "$witness"
+  } >"$composite"
+
+  "$SOUC" check "$composite" >"$log" 2>&1 || {
+    cat "$log" >&2
+    fail "composite_check_$name"
+  }
+  "$SOUC" --native-v2-compile "$composite" -o "$elf" >>"$log" 2>&1 || {
+    cat "$log" >&2
+    fail "composite_build_$name"
+  }
+  chmod +x "$elf"
+  "$elf" >"$TMP/$name.out" 2>&1 || {
+    cat "$TMP/$name.out" >&2
+    fail "composite_runtime_$name"
+  }
+  grep -Fxq "$marker" "$TMP/$name.out" || {
+    cat "$TMP/$name.out" >&2
+    fail "marker_missing_$name"
+  }
+}
+
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_CANONICAL_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_invalid_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_INVALID_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_stale_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_STALE_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_REUSE_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_cross_arena_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_CROSS_ARENA_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_MUTATION_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_sequence_probe.sio IR_MODULE_ARENA_V2_SOIR_V5_SEQUENCE_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.sio IR_MODULE_ARENA_V2_SOIR_V5_MUTATION_PREFLIGHT_PASS
+compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_plan_lifecycle_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_PLAN_LIFECYCLE_PASS
+
+grep -Fq 'SEQUENCE_AFTER_STALE status=-20' "$TMP/ir_module_arena_v2_soir_v5_bridge_sequence_probe.out" || fail stale_sequence_receipt_missing
+grep -Fq 'SEQUENCE_AFTER_REUSE status=-22' "$TMP/ir_module_arena_v2_soir_v5_bridge_sequence_probe.out" || fail reuse_sequence_receipt_missing
+grep -Fq 'canary=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_sequence_probe.out" || fail sequence_canary_receipt_missing
+grep -Fq 'MUTATION_PREFLIGHT status=-21 bss=8 id_live=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.out" || fail mutation_preflight_receipt_missing
+
+if [[ "$(git rev-parse HEAD)" != "$BASE" ]]; then
+  git diff --name-only "$BASE" HEAD | sort >"$TMP/write-set.actual"
+  printf '%s\n' \
+    scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh \
+    self-hosted/ir/arena_v2_shadow.sio \
+    self-hosted/ir/arena_v2_soir_bridge.sio \
+    self-hosted/ir/soir_writer.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_cross_arena_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_invalid_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_plan_lifecycle_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_sequence_probe.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_stale_witness.sio \
+    tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio \
+    | sort >"$TMP/write-set.expected"
+  diff -u "$TMP/write-set.expected" "$TMP/write-set.actual" \
+    >"$TMP/write-set.diff" 2>&1 || {
+      cat "$TMP/write-set.diff" >&2
+      fail write_set_expanded
+    }
+fi
+
+compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_CHECK source=pass composite_matrix=9/9 precision_identity=preserved'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_PLAN storage=private_scalar_columns capacity=2 identity=slot,generation binding=arena,module_slot,module_generation,mutation_epoch,start,capacity,required,end,version'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_EMIT deterministic=pass wire=v5_empty_320 capacity_below=reject capacity_exact=pass no_partial_write=pass origin=zero_only'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_IDS invalid=reject stale=reject reuse=reject cross_arena=reject mutation_after_preflight=reject mutation_repreflight=pass'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_DIFFERENTIAL mode=shadow_canonical_not_differential byte_parity=not_claimed legacy=default'
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s\n' "$SOUC" "$compiler_sha256" "$BASE"

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-4a63c2ba16b4aecf85759bf3f3a7ba9105c79986}"
+PINNED_BASE="4a63c2ba16b4aecf85759bf3f3a7ba9105c79986"
+REQUESTED_BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-$PINNED_BASE}"
+BASE="$PINNED_BASE"
 SOUC="${SOUC_BIN:-$ROOT/bin/madaros}"
 ARENA="self-hosted/ir/arena_v2_shadow.sio"
 WRITER="self-hosted/ir/soir_writer.sio"
@@ -13,9 +15,15 @@ PROVENANCE_MODE="${IR_MODULE_ARENA_V2_SOIR_PROVENANCE_MODE:-git}"
 CONTENT_MANIFEST="${IR_MODULE_ARENA_V2_SOIR_CONTENT_MANIFEST:-}"
 EXPECTED_MANIFEST_SHA256="${IR_MODULE_ARENA_V2_SOIR_EXPECTED_MANIFEST_SHA256:-}"
 RUNTIME_TIMEOUT_SECONDS="${IR_MODULE_ARENA_V2_SOIR_RUNTIME_TIMEOUT_SECONDS:-15}"
-TIMEOUT_SELFTEST="${IR_MODULE_ARENA_V2_SOIR_TIMEOUT_SELFTEST:-0}"
+TIMEOUT_SELFTEST="${IR_MODULE_ARENA_V2_SOIR_TIMEOUT_SELFTEST:-1}"
 PROVENANCE_RECEIPT=""
 CONTENT_MANIFEST_SHA256=""
+HEAD_SHA="not_available"
+TREE_SHA="not_available"
+BASE_RECEIPT="not_checked_manifest_scope"
+PRECISION_RECEIPT="not_checked_manifest_scope"
+LEGACY_RECEIPT="not_checked_manifest_scope"
+LANE_CONTENT_SHA256=""
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2-soir-v5.XXXXXX")"
 
 cleanup() {
@@ -119,6 +127,36 @@ expected_write_set() {
     tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio
 }
 
+validate_git_provenance() {
+  local -a expected_paths
+  local dirty_paths
+
+  [[ "$REQUESTED_BASE" == "$PINNED_BASE" ]] || fail base_override_rejected
+  git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
+  HEAD_SHA="$(git rev-parse HEAD)"
+  TREE_SHA="$(git rev-parse 'HEAD^{tree}')"
+  [[ "$HEAD_SHA" != "$BASE" ]] || fail head_equals_pinned_base
+  git merge-base --is-ancestor "$BASE" "$HEAD_SHA" || fail pinned_base_not_ancestor
+
+  git diff --name-only "$BASE" "$HEAD_SHA" | LC_ALL=C sort >"$TMP/write-set.actual"
+  expected_write_set | LC_ALL=C sort >"$TMP/write-set.expected"
+  diff -u "$TMP/write-set.expected" "$TMP/write-set.actual" \
+    >"$TMP/write-set.diff" 2>&1 || {
+      cat "$TMP/write-set.diff" >&2
+      fail write_set_expanded
+    }
+
+  mapfile -t expected_paths < <(expected_write_set)
+  dirty_paths="$(git status --porcelain --untracked-files=all -- "${expected_paths[@]}")"
+  if [[ -n "$dirty_paths" ]]; then
+    printf '%s\n' "$dirty_paths" >&2
+    fail expected_write_set_dirty
+  fi
+
+  PROVENANCE_RECEIPT="git_head_tree_bound"
+  BASE_RECEIPT="$BASE"
+}
+
 validate_manifest_provenance() {
   [[ -n "$CONTENT_MANIFEST" ]] || fail manifest_path_required
   [[ -n "$EXPECTED_MANIFEST_SHA256" ]] || fail manifest_sha256_required
@@ -153,14 +191,13 @@ validate_manifest_provenance() {
     cat "$TMP/manifest-content-check.log" >&2
     fail manifest_content_mismatch
   }
-  PROVENANCE_RECEIPT="manifest_pinned"
+  PROVENANCE_RECEIPT="manifest_pinned_lane_content"
 }
 
 case "$PROVENANCE_MODE" in
   git)
     command -v git >/dev/null 2>&1 || fail git_required_for_git_provenance
-    git cat-file -e "$BASE^{commit}" 2>/dev/null || fail base_sha_unavailable
-    PROVENANCE_RECEIPT="git"
+    validate_git_provenance
     ;;
   manifest)
     validate_manifest_provenance
@@ -176,7 +213,8 @@ done
 [[ -x "$SOUC" ]] || fail compiler_missing
 command -v timeout >/dev/null 2>&1 || fail timeout_command_missing
 [[ "$RUNTIME_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail runtime_timeout_invalid
-[[ "$TIMEOUT_SELFTEST" == "0" || "$TIMEOUT_SELFTEST" == "1" ]] || fail timeout_selftest_mode_invalid
+if (( RUNTIME_TIMEOUT_SECONDS > 60 )); then fail runtime_timeout_exceeds_cap_60; fi
+[[ "$TIMEOUT_SELFTEST" == "1" ]] || fail timeout_selftest_required
 
 grep -Fq 'pub let SOIR_WRITER_SCALAR_EMPTY_V5_SIZE: i64 = 320' "$WRITER" || fail writer_size_contract_missing
 grep -Fq 'pub fn soir_writer_preflight_scalar_empty_module_v5(' "$WRITER" || fail writer_preflight_missing
@@ -258,50 +296,17 @@ for default_surface in \
   fi
 done
 
-run_manifest_precision_identity_check() {
-  local shim_dir="$TMP/manifest-tool-shim"
-  local git_shim="$shim_dir/git"
-  local rg_shim="$shim_dir/rg"
-  mkdir -p "$shim_dir"
-  # The canonical structural precision gate uses Git once, only to print a
-  # source identity. Bind that receipt to the pinned manifest and reject every
-  # other Git operation. Its one rg call receives a strict grep-backed adapter;
-  # all descriptor and containment checks run unchanged.
-  {
-    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
-    printf '%s\n' 'if [[ "$#" -eq 2 && "$1" == "rev-parse" && "$2" == "HEAD" ]]; then'
-    printf '  printf '\''%%s\\n'\'' '\''manifest:%s'\''\n' "$CONTENT_MANIFEST_SHA256"
-    printf '%s\n' '  exit 0' 'fi'
-    printf '%s\n' 'echo "manifest provenance adapter rejected unsupported git command" >&2' 'exit 64'
-  } >"$git_shim"
-  {
-    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
-    printf '%s\n' 'if [[ "${1:-}" != "-n" || "$#" -lt 3 ]]; then'
-    printf '%s\n' '  echo "manifest search adapter rejected unsupported rg arguments" >&2' '  exit 64' 'fi'
-    printf '%s\n' 'shift' 'exec grep -REn -- "$@"'
-  } >"$rg_shim"
-  chmod +x "$git_shim" "$rg_shim"
-  PATH="$shim_dir:$PATH" \
-    bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
-    >"$TMP/precision-identity.log" 2>&1 || {
-      cat "$TMP/precision-identity.log" >&2
-      fail precision_identity_regression
-    }
-}
-
 if [[ "$PROVENANCE_MODE" == "git" ]]; then
   bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
     >"$TMP/precision-identity.log" 2>&1 || {
       cat "$TMP/precision-identity.log" >&2
       fail precision_identity_regression
     }
-else
-  run_manifest_precision_identity_check
+  PRECISION_RECEIPT="preserved"
+  LEGACY_RECEIPT="default"
 fi
 
-if [[ "$TIMEOUT_SELFTEST" == "1" ]]; then
-  run_timeout_selftest
-fi
+run_timeout_selftest
 
 for source in "$WRITER" "$ARENA" "$BRIDGE"; do
   source_name="$(basename "$source" .sio)"
@@ -371,27 +376,27 @@ grep -Fq 'SEQUENCE_AFTER_STALE status=-20' "$TMP/ir_module_arena_v2_soir_v5_brid
 grep -Fq 'SEQUENCE_AFTER_REUSE status=-22' "$TMP/ir_module_arena_v2_soir_v5_bridge_sequence_probe.out" || fail reuse_sequence_receipt_missing
 grep -Fq 'canary=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_sequence_probe.out" || fail sequence_canary_receipt_missing
 grep -Fq 'MUTATION_PREFLIGHT status=-21 bss=8 id_live=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.out" || fail mutation_preflight_receipt_missing
+grep -Fq 'MODULE_OUTPUT_LIVE status=-8 live_count=1 id_live=1' "$TMP/ir_module_arena_v2_soir_v5_bridge_reuse_witness.out" || fail module_output_live_receipt_missing
 
-if [[ "$PROVENANCE_MODE" == "git" && "$(git rev-parse HEAD)" != "$BASE" ]]; then
-  git diff --name-only "$BASE" HEAD | sort >"$TMP/write-set.actual"
-  expected_write_set | sort >"$TMP/write-set.expected"
-  diff -u "$TMP/write-set.expected" "$TMP/write-set.actual" \
-    >"$TMP/write-set.diff" 2>&1 || {
-      cat "$TMP/write-set.diff" >&2
-      fail write_set_expanded
-    }
-fi
+while IFS= read -r lane_path; do
+  sha256sum "$lane_path"
+done < <(expected_write_set) >"$TMP/lane-content.sha256"
+LANE_CONTENT_SHA256="$(sha256sum "$TMP/lane-content.sha256" | awk '{print $1}')"
 
 compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
-printf 'IR_MODULE_ARENA_V2_SOIR_V5_WATCHDOG runtime_timeout_seconds=%s kill_after_seconds=2 timeout_rc=124 fail_closed=enabled\n' \
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_WATCHDOG runtime_timeout_seconds=%s kill_after_seconds=2 timeout_rc=124 selftest=pass fail_closed=pass\n' \
   "$RUNTIME_TIMEOUT_SECONDS"
-printf 'IR_MODULE_ARENA_V2_SOIR_V5_CHECK source=pass composite_matrix=9/9 precision_identity=preserved provenance=%s\n' "$PROVENANCE_RECEIPT"
-printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_PLAN storage=private_scalar_columns capacity=2 identity=slot,generation binding=arena,module_slot,module_generation,mutation_epoch,start,capacity,required,end,version'
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_CHECK source=pass composite_matrix=9/9 precision_identity=%s provenance=%s\n' \
+  "$PRECISION_RECEIPT" "$PROVENANCE_RECEIPT"
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_PLAN storage=module_owned_scalar_columns capacity=2 identity=slot,generation field_privacy=enforcement_not_claimed integrity=emit_revalidated binding=arena,module_slot,module_generation,mutation_epoch,start,capacity,required,end,version'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_EMIT deterministic=pass wire=v5_empty_320 capacity_below=reject capacity_exact=pass no_partial_write=pass origin=zero_only'
-printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_IDS invalid=reject stale=reject reuse=reject cross_arena=reject mutation_after_preflight=reject mutation_repreflight=pass'
-printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_DIFFERENTIAL mode=shadow_canonical_not_differential byte_parity=not_claimed legacy=default'
+printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_IDS invalid=reject stale=reject reuse=reject module_output_live=reject cross_arena=reject mutation_after_preflight=reject mutation_repreflight=pass'
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_DIFFERENTIAL mode=shadow_canonical_not_differential byte_parity=not_claimed legacy=%s\n' "$LEGACY_RECEIPT"
 if [[ "$PROVENANCE_MODE" == "manifest" ]]; then
-  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=manifest_pinned manifest_sha256=%s entries=13\n' "$CONTENT_MANIFEST_SHA256"
+  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=manifest_pinned_lane_content manifest_sha256=%s entries=13 scope=lane_content_only protected_surfaces=not_checked\n' "$CONTENT_MANIFEST_SHA256"
+else
+  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROVENANCE provenance=git_head_tree_bound base=%s head=%s tree=%s exact_write_set=pass expected_paths_clean=pass\n' \
+    "$BASE" "$HEAD_SHA" "$TREE_SHA"
 fi
-printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s provenance=%s\n' \
-  "$SOUC" "$compiler_sha256" "$BASE" "$PROVENANCE_RECEIPT"
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_PASS compiler=%s compiler_sha256=%s base=%s head=%s tree=%s lane_content_sha256=%s provenance=%s\n' \
+  "$SOUC" "$compiler_sha256" "$BASE_RECEIPT" "$HEAD_SHA" "$TREE_SHA" "$LANE_CONTENT_SHA256" "$PROVENANCE_RECEIPT"

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-a505fe5b3d66565236653f5dff203bc7fbad7076}"
+BASE="${IR_MODULE_ARENA_V2_SOIR_BASE_SHA:-4a63c2ba16b4aecf85759bf3f3a7ba9105c79986}"
 SOUC="${SOUC_BIN:-$ROOT/bin/madaros}"
 ARENA="self-hosted/ir/arena_v2_shadow.sio"
 WRITER="self-hosted/ir/soir_writer.sio"

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -111,9 +111,15 @@ grep -Fq 'pub fn ir_module_arena_v2_soir_emit_empty_v5(' "$BRIDGE" || fail bridg
 grep -Fq 'soir_writer_preflight_scalar_empty_module_v5' "$BRIDGE" || fail writer_preflight_not_delegated
 grep -Fq 'soir_writer_emit_scalar_empty_module_v5' "$BRIDGE" || fail writer_emit_not_delegated
 
+dependency_pattern='use (parser|ir::ir)|\b(IrModule|IrInstr|TyF128|TyF256|numeric_payload)\b'
 set +e
-rg -n 'use (parser|ir::ir)|\b(IrModule|IrInstr|TyF128|TyF256|numeric_payload)\b' \
-  "$ARENA" "$WRITER" "$BRIDGE" >"$TMP/dependency-leak.log" 2>&1
+if command -v rg >/dev/null 2>&1; then
+  rg -n "$dependency_pattern" "$ARENA" "$WRITER" "$BRIDGE" \
+    >"$TMP/dependency-leak.log" 2>&1
+else
+  grep -En "$dependency_pattern" "$ARENA" "$WRITER" "$BRIDGE" \
+    >"$TMP/dependency-leak.log" 2>&1
+fi
 dependency_scan_rc=$?
 set -e
 if [[ "$dependency_scan_rc" -eq 0 ]]; then
@@ -175,19 +181,27 @@ done
 
 run_manifest_precision_identity_check() {
   local shim_dir="$TMP/manifest-tool-shim"
-  local shim="$shim_dir/git"
+  local git_shim="$shim_dir/git"
+  local rg_shim="$shim_dir/rg"
   mkdir -p "$shim_dir"
   # The canonical structural precision gate uses Git once, only to print a
   # source identity. Bind that receipt to the pinned manifest and reject every
-  # other Git operation; all descriptor and containment checks run unchanged.
+  # other Git operation. Its one rg call receives a strict grep-backed adapter;
+  # all descriptor and containment checks run unchanged.
   {
     printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
     printf '%s\n' 'if [[ "$#" -eq 2 && "$1" == "rev-parse" && "$2" == "HEAD" ]]; then'
     printf '  printf '\''%%s\\n'\'' '\''manifest:%s'\''\n' "$CONTENT_MANIFEST_SHA256"
     printf '%s\n' '  exit 0' 'fi'
     printf '%s\n' 'echo "manifest provenance adapter rejected unsupported git command" >&2' 'exit 64'
-  } >"$shim"
-  chmod +x "$shim"
+  } >"$git_shim"
+  {
+    printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail'
+    printf '%s\n' 'if [[ "${1:-}" != "-n" || "$#" -lt 3 ]]; then'
+    printf '%s\n' '  echo "manifest search adapter rejected unsupported rg arguments" >&2' '  exit 64' 'fi'
+    printf '%s\n' 'shift' 'exec grep -REn -- "$@"'
+  } >"$rg_shim"
+  chmod +x "$git_shim" "$rg_shim"
   PATH="$shim_dir:$PATH" \
     bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
     >"$TMP/precision-identity.log" 2>&1 || {

--- a/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
+++ b/scripts/ci/ir_module_arena_v2_soir_v5_bridge_gate.sh
@@ -12,6 +12,8 @@ BRIDGE="self-hosted/ir/arena_v2_soir_bridge.sio"
 PROVENANCE_MODE="${IR_MODULE_ARENA_V2_SOIR_PROVENANCE_MODE:-git}"
 CONTENT_MANIFEST="${IR_MODULE_ARENA_V2_SOIR_CONTENT_MANIFEST:-}"
 EXPECTED_MANIFEST_SHA256="${IR_MODULE_ARENA_V2_SOIR_EXPECTED_MANIFEST_SHA256:-}"
+RUNTIME_TIMEOUT_SECONDS="${IR_MODULE_ARENA_V2_SOIR_RUNTIME_TIMEOUT_SECONDS:-15}"
+TIMEOUT_SELFTEST="${IR_MODULE_ARENA_V2_SOIR_TIMEOUT_SELFTEST:-0}"
 PROVENANCE_RECEIPT=""
 CONTENT_MANIFEST_SHA256=""
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-ir-module-arena-v2-soir-v5.XXXXXX")"
@@ -24,6 +26,80 @@ trap cleanup EXIT
 fail() {
   printf 'IR_MODULE_ARENA_V2_SOIR_V5_FAIL reason=%s\n' "$1" >&2
   exit 1
+}
+
+progress() {
+  printf 'IR_MODULE_ARENA_V2_SOIR_V5_PROGRESS stage=%s subject=%s status=%s\n' \
+    "$1" "$2" "$3" >&2
+}
+
+run_runtime_with_timeout() {
+  local elf="$1"
+  local out="$2"
+  local timeout_seconds="$3"
+  timeout --signal=TERM --kill-after=2s "${timeout_seconds}s" "$elf" >"$out" 2>&1
+}
+
+run_witness_runtime() {
+  local name="$1"
+  local elf="$2"
+  local out="$3"
+  local timeout_seconds="$4"
+  local runtime_rc
+
+  progress composite_runtime "$name" begin
+  set +e
+  run_runtime_with_timeout "$elf" "$out" "$timeout_seconds"
+  runtime_rc=$?
+  set -e
+  if [[ "$runtime_rc" -eq 124 ]]; then
+    progress composite_runtime "$name" timeout
+    cat "$out" >&2
+    fail "composite_runtime_timeout_$name"
+  fi
+  if [[ "$runtime_rc" -ne 0 ]]; then
+    progress composite_runtime "$name" fail
+    cat "$out" >&2
+    fail "composite_runtime_${name}_rc_${runtime_rc}"
+  fi
+  progress composite_runtime "$name" pass
+}
+
+run_timeout_selftest() {
+  local source="$TMP/runtime_timeout_selftest.sio"
+  local elf="$TMP/runtime_timeout_selftest.elf"
+  local build_log="$TMP/runtime_timeout_selftest.build.log"
+  local run_log="$TMP/runtime_timeout_selftest.out"
+  local classification_log="$TMP/runtime_timeout_selftest.classification.log"
+  local classification_rc
+
+  printf '%s\n' \
+    'module runtime_timeout_selftest' \
+    '' \
+    'fn main() -> i64 {' \
+    '    while true {}' \
+    '    0' \
+    '}' >"$source"
+
+  progress timeout_selftest forced_hang build_begin
+  "$SOUC" --native-v2-compile "$source" -o "$elf" >"$build_log" 2>&1 || {
+    cat "$build_log" >&2
+    fail timeout_selftest_build
+  }
+  chmod +x "$elf"
+  progress timeout_selftest forced_hang runtime_begin
+  set +e
+  (run_witness_runtime timeout_selftest "$elf" "$run_log" 1) \
+    >"$classification_log" 2>&1
+  classification_rc=$?
+  set -e
+  if [[ "$classification_rc" -ne 1 ]] ||
+     ! grep -Fxq 'IR_MODULE_ARENA_V2_SOIR_V5_FAIL reason=composite_runtime_timeout_timeout_selftest' "$classification_log"; then
+    cat "$classification_log" >&2
+    fail "timeout_selftest_classification_rc_${classification_rc}"
+  fi
+  progress timeout_selftest forced_hang timeout_classified
+  printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_TIMEOUT_SELFTEST forced_hang=timeout runtime_rc=124 fail_closed=pass seconds=1'
 }
 
 expected_write_set() {
@@ -98,6 +174,9 @@ for file in "$ARENA" "$WRITER" "$BRIDGE"; do
   [[ -f "$file" ]] || fail "missing_${file//\//_}"
 done
 [[ -x "$SOUC" ]] || fail compiler_missing
+command -v timeout >/dev/null 2>&1 || fail timeout_command_missing
+[[ "$RUNTIME_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail runtime_timeout_invalid
+[[ "$TIMEOUT_SELFTEST" == "0" || "$TIMEOUT_SELFTEST" == "1" ]] || fail timeout_selftest_mode_invalid
 
 grep -Fq 'pub let SOIR_WRITER_SCALAR_EMPTY_V5_SIZE: i64 = 320' "$WRITER" || fail writer_size_contract_missing
 grep -Fq 'pub fn soir_writer_preflight_scalar_empty_module_v5(' "$WRITER" || fail writer_preflight_missing
@@ -220,11 +299,18 @@ else
   run_manifest_precision_identity_check
 fi
 
+if [[ "$TIMEOUT_SELFTEST" == "1" ]]; then
+  run_timeout_selftest
+fi
+
 for source in "$WRITER" "$ARENA" "$BRIDGE"; do
+  source_name="$(basename "$source" .sio)"
+  progress source_check "$source_name" begin
   "$SOUC" check "$source" >"$TMP/$(basename "$source").check.log" 2>&1 || {
     cat "$TMP/$(basename "$source").check.log" >&2
     fail "source_check_${source//\//_}"
   }
+  progress source_check "$source_name" pass
 done
 
 compose_and_run() {
@@ -235,6 +321,8 @@ compose_and_run() {
   composite="$TMP/$name.sio"
   elf="$TMP/$name.elf"
   log="$TMP/$name.log"
+
+  progress composite "$name" begin
 
   {
     printf 'module ir::%s_gate\n\n' "$name"
@@ -248,23 +336,25 @@ compose_and_run() {
         -e '/^use ir::arena_v2_soir_bridge::\*$/d' "$witness"
   } >"$composite"
 
+  progress composite_check "$name" begin
   "$SOUC" check "$composite" >"$log" 2>&1 || {
     cat "$log" >&2
     fail "composite_check_$name"
   }
+  progress composite_check "$name" pass
+  progress composite_build "$name" begin
   "$SOUC" --native-v2-compile "$composite" -o "$elf" >>"$log" 2>&1 || {
     cat "$log" >&2
     fail "composite_build_$name"
   }
   chmod +x "$elf"
-  "$elf" >"$TMP/$name.out" 2>&1 || {
-    cat "$TMP/$name.out" >&2
-    fail "composite_runtime_$name"
-  }
+  progress composite_build "$name" pass
+  run_witness_runtime "$name" "$elf" "$TMP/$name.out" "$RUNTIME_TIMEOUT_SECONDS"
   grep -Fxq "$marker" "$TMP/$name.out" || {
     cat "$TMP/$name.out" >&2
     fail "marker_missing_$name"
   }
+  progress composite "$name" pass
 }
 
 compose_and_run tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio IR_MODULE_ARENA_V2_SOIR_V5_CANONICAL_PASS
@@ -293,6 +383,8 @@ if [[ "$PROVENANCE_MODE" == "git" && "$(git rev-parse HEAD)" != "$BASE" ]]; then
 fi
 
 compiler_sha256="$(sha256sum "$SOUC" | awk '{print $1}')"
+printf 'IR_MODULE_ARENA_V2_SOIR_V5_WATCHDOG runtime_timeout_seconds=%s kill_after_seconds=2 timeout_rc=124 fail_closed=enabled\n' \
+  "$RUNTIME_TIMEOUT_SECONDS"
 printf 'IR_MODULE_ARENA_V2_SOIR_V5_CHECK source=pass composite_matrix=9/9 precision_identity=preserved provenance=%s\n' "$PROVENANCE_RECEIPT"
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_PLAN storage=private_scalar_columns capacity=2 identity=slot,generation binding=arena,module_slot,module_generation,mutation_epoch,start,capacity,required,end,version'
 printf '%s\n' 'IR_MODULE_ARENA_V2_SOIR_V5_EMIT deterministic=pass wire=v5_empty_320 capacity_below=reject capacity_exact=pass no_partial_write=pass origin=zero_only'

--- a/self-hosted/ir/arena_v2_shadow.sio
+++ b/self-hosted/ir/arena_v2_shadow.sio
@@ -20,6 +20,7 @@ pub let IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE: i64 = -2
 pub let IR_MODULE_ARENA_V2_ERR_CAPACITY: i64 = -3
 pub let IR_MODULE_ARENA_V2_ERR_RANGE: i64 = -5
 pub let IR_MODULE_ARENA_V2_ERR_DUPLICATE_MODULE: i64 = -7
+pub let IR_MODULE_ARENA_V2_ERR_OUTPUT_LIVE: i64 = -8
 
 pub struct IrModuleArenaV2ModuleId {
     arena_identity: i64,
@@ -242,6 +243,9 @@ pub fn ir_module_arena_v2_alloc_empty_module(
     if IR_MODULE_ARENA_V2_MODULE_STORE_STATE != IR_MODULE_ARENA_V2_ARENA_LIVE ||
        module_identity <= 0 {
         return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+    if ir_module_arena_v2_module_id_is_live(out) {
+        return IR_MODULE_ARENA_V2_ERR_OUTPUT_LIVE
     }
     var scan: i64 = 0
     while scan < IR_MODULE_ARENA_V2_MODULE_CAPACITY {

--- a/self-hosted/ir/arena_v2_shadow.sio
+++ b/self-hosted/ir/arena_v2_shadow.sio
@@ -1,0 +1,303 @@
+// Shadow-only scalar ModuleId store for the Arena v2 experiment.
+//
+// It owns no legacy module aggregate and is not imported by the default compiler.
+// Two scalar slots are sufficient to prove identity, generation, reuse, arena
+// replacement, and mutation-epoch behaviour before widening the representation.
+
+module ir::arena_v2_shadow
+
+pub let IR_MODULE_ARENA_V2_MODULE_CAPACITY: i64 = 2
+
+pub let IR_MODULE_ARENA_V2_ARENA_INVALID: i64 = 0
+pub let IR_MODULE_ARENA_V2_ARENA_LIVE: i64 = 1
+pub let IR_MODULE_ARENA_V2_SLOT_FREE: i64 = 0
+pub let IR_MODULE_ARENA_V2_SLOT_LIVE: i64 = 1
+pub let IR_MODULE_ARENA_V2_SLOT_RELEASED: i64 = 2
+
+pub let IR_MODULE_ARENA_V2_OK: i64 = 0
+pub let IR_MODULE_ARENA_V2_ERR_INVALID_ARENA: i64 = -1
+pub let IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE: i64 = -2
+pub let IR_MODULE_ARENA_V2_ERR_CAPACITY: i64 = -3
+pub let IR_MODULE_ARENA_V2_ERR_RANGE: i64 = -5
+pub let IR_MODULE_ARENA_V2_ERR_DUPLICATE_MODULE: i64 = -7
+
+pub struct IrModuleArenaV2ModuleId {
+    arena_identity: i64,
+    slot: i64,
+    generation: i64,
+}
+
+var IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STORE_STATE: i64 = IR_MODULE_ARENA_V2_ARENA_INVALID
+var IR_MODULE_ARENA_V2_MODULE_STATE_0: i64 = IR_MODULE_ARENA_V2_SLOT_FREE
+var IR_MODULE_ARENA_V2_MODULE_STATE_1: i64 = IR_MODULE_ARENA_V2_SLOT_FREE
+var IR_MODULE_ARENA_V2_MODULE_GENERATION_0: i64 = 1
+var IR_MODULE_ARENA_V2_MODULE_GENERATION_1: i64 = 1
+var IR_MODULE_ARENA_V2_MODULE_IDENTITY_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_IDENTITY_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_MUTATION_EPOCH_0: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_MUTATION_EPOCH_1: i64 = 0
+var IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT: i64 = 0
+
+fn ir_module_arena_v2_slot_state(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_MODULE_STATE_0 }
+    IR_MODULE_ARENA_V2_MODULE_STATE_1
+}
+
+fn ir_module_arena_v2_slot_generation(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_MODULE_GENERATION_0 }
+    IR_MODULE_ARENA_V2_MODULE_GENERATION_1
+}
+
+fn ir_module_arena_v2_slot_identity(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_MODULE_IDENTITY_0 }
+    IR_MODULE_ARENA_V2_MODULE_IDENTITY_1
+}
+
+fn ir_module_arena_v2_slot_mutation_epoch(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_MODULE_MUTATION_EPOCH_0 }
+    IR_MODULE_ARENA_V2_MODULE_MUTATION_EPOCH_1
+}
+
+fn ir_module_arena_v2_set_slot_state(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_STATE_0 = value }
+    else { IR_MODULE_ARENA_V2_MODULE_STATE_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_generation(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_GENERATION_0 = value }
+    else { IR_MODULE_ARENA_V2_MODULE_GENERATION_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_identity(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_IDENTITY_0 = value }
+    else { IR_MODULE_ARENA_V2_MODULE_IDENTITY_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_bss(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_0 = value }
+    else { IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_1 = value }
+}
+
+fn ir_module_arena_v2_set_slot_mutation_epoch(slot: i64, value: i64) with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_MODULE_MUTATION_EPOCH_0 = value }
+    else { IR_MODULE_ARENA_V2_MODULE_MUTATION_EPOCH_1 = value }
+}
+
+fn ir_module_arena_v2_zero_module_slot(slot: i64) with Mut {
+    ir_module_arena_v2_set_slot_identity(slot, 0)
+    ir_module_arena_v2_set_slot_bss(slot, 0)
+    ir_module_arena_v2_set_slot_mutation_epoch(slot, 0)
+    if slot == 0 {
+        IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0 = 0
+        IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0 = 0
+    } else {
+        IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_1 = 0
+        IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_1 = 0
+    }
+}
+
+pub fn ir_module_arena_v2_invalid_module_id() -> IrModuleArenaV2ModuleId {
+    IrModuleArenaV2ModuleId { arena_identity: 0, slot: -1, generation: 0 }
+}
+
+pub fn ir_module_arena_v2_module_store_init(
+    arena_identity: i64,
+) -> i64 with Mut, Panic, Div {
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(slot) == IR_MODULE_ARENA_V2_SLOT_LIVE {
+            ir_module_arena_v2_set_slot_generation(
+                slot,
+                ir_module_arena_v2_slot_generation(slot) + 1,
+            )
+        }
+        ir_module_arena_v2_zero_module_slot(slot)
+        ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_FREE)
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = 0
+    if arena_identity <= 0 {
+        IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY = 0
+        IR_MODULE_ARENA_V2_MODULE_STORE_STATE = IR_MODULE_ARENA_V2_ARENA_INVALID
+        return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+    IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY = arena_identity
+    IR_MODULE_ARENA_V2_MODULE_STORE_STATE = IR_MODULE_ARENA_V2_ARENA_LIVE
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_module_id_slot(id: &IrModuleArenaV2ModuleId) -> i64 {
+    (*id).slot
+}
+
+pub fn ir_module_arena_v2_module_id_arena_identity(id: &IrModuleArenaV2ModuleId) -> i64 {
+    (*id).arena_identity
+}
+
+pub fn ir_module_arena_v2_module_id_generation(id: &IrModuleArenaV2ModuleId) -> i64 {
+    (*id).generation
+}
+
+pub fn ir_module_arena_v2_module_store_live_count() -> i64 {
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT
+}
+
+pub fn ir_module_arena_v2_module_id_is_live(
+    id: &IrModuleArenaV2ModuleId,
+) -> bool with Panic, Div {
+    if IR_MODULE_ARENA_V2_MODULE_STORE_STATE != IR_MODULE_ARENA_V2_ARENA_LIVE ||
+       (*id).arena_identity != IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY {
+        return false
+    }
+    let slot = (*id).slot
+    if slot < 0 || slot >= IR_MODULE_ARENA_V2_MODULE_CAPACITY { return false }
+    ir_module_arena_v2_slot_state(slot) == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+        ir_module_arena_v2_slot_generation(slot) == (*id).generation
+}
+
+pub fn ir_module_arena_v2_module_function_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_FUNCTION_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_string_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_STRING_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_epistemic_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_EPISTEMIC_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_model_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_MODEL_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_contest_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_CONTEST_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_algebra_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_ALGEBRA_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_ontology_count(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_0 }
+    IR_MODULE_ARENA_V2_MODULE_ONTOLOGY_COUNT_1
+}
+
+pub fn ir_module_arena_v2_module_bss_total_size(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_0 }
+    IR_MODULE_ARENA_V2_MODULE_BSS_TOTAL_SIZE_1
+}
+
+pub fn ir_module_arena_v2_module_mutation_epoch(id: &IrModuleArenaV2ModuleId) -> i64 with Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) { return -1 }
+    ir_module_arena_v2_slot_mutation_epoch((*id).slot)
+}
+
+pub fn ir_module_arena_v2_alloc_empty_module(
+    module_identity: i64,
+    out: &! IrModuleArenaV2ModuleId,
+) -> i64 with Mut, Panic, Div {
+    if IR_MODULE_ARENA_V2_MODULE_STORE_STATE != IR_MODULE_ARENA_V2_ARENA_LIVE ||
+       module_identity <= 0 {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_ARENA
+    }
+    var scan: i64 = 0
+    while scan < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(scan) == IR_MODULE_ARENA_V2_SLOT_LIVE &&
+           ir_module_arena_v2_slot_identity(scan) == module_identity {
+            return IR_MODULE_ARENA_V2_ERR_DUPLICATE_MODULE
+        }
+        scan = scan + 1
+    }
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_MODULE_CAPACITY {
+        if ir_module_arena_v2_slot_state(slot) != IR_MODULE_ARENA_V2_SLOT_LIVE {
+            ir_module_arena_v2_zero_module_slot(slot)
+            ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_LIVE)
+            ir_module_arena_v2_set_slot_identity(slot, module_identity)
+            IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT + 1
+            (*out).arena_identity = IR_MODULE_ARENA_V2_MODULE_ARENA_IDENTITY
+            (*out).slot = slot
+            (*out).generation = ir_module_arena_v2_slot_generation(slot)
+            return IR_MODULE_ARENA_V2_OK
+        }
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_ERR_CAPACITY
+}
+
+pub fn ir_module_arena_v2_configure_module_bss_size(
+    id: &IrModuleArenaV2ModuleId,
+    size: i64,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    if size < 0 { return IR_MODULE_ARENA_V2_ERR_RANGE }
+    let slot = (*id).slot
+    ir_module_arena_v2_set_slot_bss(slot, size)
+    ir_module_arena_v2_set_slot_mutation_epoch(
+        slot,
+        ir_module_arena_v2_slot_mutation_epoch(slot) + 1,
+    )
+    IR_MODULE_ARENA_V2_OK
+}
+
+pub fn ir_module_arena_v2_remove_module(
+    id: &IrModuleArenaV2ModuleId,
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_module_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_ERR_INVALID_HANDLE
+    }
+    let slot = (*id).slot
+    ir_module_arena_v2_zero_module_slot(slot)
+    ir_module_arena_v2_set_slot_state(slot, IR_MODULE_ARENA_V2_SLOT_RELEASED)
+    ir_module_arena_v2_set_slot_generation(
+        slot,
+        ir_module_arena_v2_slot_generation(slot) + 1,
+    )
+    IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT = IR_MODULE_ARENA_V2_MODULE_LIVE_COUNT - 1
+    IR_MODULE_ARENA_V2_OK
+}

--- a/self-hosted/ir/arena_v2_soir_bridge.sio
+++ b/self-hosted/ir/arena_v2_soir_bridge.sio
@@ -1,7 +1,7 @@
 // Shadow-only ModuleId -> SOIR v5 bridge.
 //
-// Identity revalidation stays in private scalar plan columns. The writer owns
-// all wire bytes; the arena owns module identity and mutation epochs.
+// Identity revalidation stays in module-owned scalar plan columns. The writer
+// owns all wire bytes; the arena owns module identity and mutation epochs.
 
 module ir::arena_v2_soir_bridge
 

--- a/self-hosted/ir/arena_v2_soir_bridge.sio
+++ b/self-hosted/ir/arena_v2_soir_bridge.sio
@@ -1,0 +1,348 @@
+// Shadow-only ModuleId -> SOIR v5 bridge.
+//
+// Identity revalidation stays in private scalar plan columns. The writer owns
+// all wire bytes; the arena owns module identity and mutation epochs.
+
+module ir::arena_v2_soir_bridge
+
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+
+pub let IR_MODULE_ARENA_V2_SOIR_OK: i64 = 0
+pub let IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID: i64 = -20
+pub let IR_MODULE_ARENA_V2_SOIR_MODULE_CONTRACT: i64 = -21
+pub let IR_MODULE_ARENA_V2_SOIR_STALE_PLAN: i64 = -22
+pub let IR_MODULE_ARENA_V2_SOIR_INVALID_PLAN_ID: i64 = -23
+pub let IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_EXHAUSTED: i64 = -24
+pub let IR_MODULE_ARENA_V2_SOIR_PLAN_OUTPUT_LIVE: i64 = -25
+pub let IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY: i64 = 2
+
+let IR_MODULE_ARENA_V2_SOIR_PLAN_FREE: i64 = 0
+let IR_MODULE_ARENA_V2_SOIR_PLAN_LIVE: i64 = 1
+
+pub struct IrModuleArenaV2SoirPlanId {
+    slot: i64,
+    generation: i64,
+}
+
+var IR_MODULE_ARENA_V2_SOIR_PLAN_STATE_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_STATE_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_GENERATION_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_GENERATION_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_START_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_START_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_END_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_END_1: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_0: i64 = 0
+var IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_1: i64 = 0
+
+fn ir_module_arena_v2_soir_plan_state(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_STATE_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_STATE_1
+}
+
+fn ir_module_arena_v2_soir_plan_generation_at(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_GENERATION_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_GENERATION_1
+}
+
+fn ir_module_arena_v2_soir_plan_set_state(slot: i64, value: i64) -> i64 with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_SOIR_PLAN_STATE_0 = value }
+    else { IR_MODULE_ARENA_V2_SOIR_PLAN_STATE_1 = value }
+    0
+}
+
+fn ir_module_arena_v2_soir_plan_set_generation(slot: i64, value: i64) -> i64 with Mut {
+    if slot == 0 { IR_MODULE_ARENA_V2_SOIR_PLAN_GENERATION_0 = value }
+    else { IR_MODULE_ARENA_V2_SOIR_PLAN_GENERATION_1 = value }
+    0
+}
+
+fn ir_module_arena_v2_soir_plan_zero(slot: i64) -> i64 with Mut {
+    if slot == 0 {
+        IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_START_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_END_0 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_0 = 0
+    } else {
+        IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_START_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_END_1 = 0
+        IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_1 = 0
+    }
+    0
+}
+
+pub fn ir_module_arena_v2_soir_plan_store_init() -> i64 with Mut {
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY {
+        if ir_module_arena_v2_soir_plan_state(slot) == IR_MODULE_ARENA_V2_SOIR_PLAN_LIVE {
+            let bumped = ir_module_arena_v2_soir_plan_generation_at(slot) + 1
+            let generation_status = ir_module_arena_v2_soir_plan_set_generation(slot, bumped)
+            if generation_status != 0 { return generation_status }
+        }
+        let zero_status = ir_module_arena_v2_soir_plan_zero(slot)
+        if zero_status != 0 { return zero_status }
+        let state_status = ir_module_arena_v2_soir_plan_set_state(
+            slot,
+            IR_MODULE_ARENA_V2_SOIR_PLAN_FREE,
+        )
+        if state_status != 0 { return state_status }
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_SOIR_OK
+}
+
+pub fn ir_module_arena_v2_soir_plan_id_clear(
+    out: &! IrModuleArenaV2SoirPlanId,
+) -> i64 with Mut {
+    (*out).slot = -1
+    (*out).generation = -1
+    IR_MODULE_ARENA_V2_SOIR_OK
+}
+
+pub fn ir_module_arena_v2_soir_invalid_plan_id() -> IrModuleArenaV2SoirPlanId {
+    IrModuleArenaV2SoirPlanId { slot: -1, generation: -1 }
+}
+
+pub fn ir_module_arena_v2_soir_plan_id_is_live(
+    id: &IrModuleArenaV2SoirPlanId,
+) -> bool {
+    let slot = (*id).slot
+    slot >= 0 && slot < IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY &&
+        ir_module_arena_v2_soir_plan_state(slot) == IR_MODULE_ARENA_V2_SOIR_PLAN_LIVE &&
+        ir_module_arena_v2_soir_plan_generation_at(slot) == (*id).generation
+}
+
+pub fn ir_module_arena_v2_soir_release_plan(
+    id: &IrModuleArenaV2SoirPlanId,
+) -> i64 with Mut {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_SOIR_INVALID_PLAN_ID
+    }
+    let slot = (*id).slot
+    let generation_status = ir_module_arena_v2_soir_plan_set_generation(
+        slot,
+        ir_module_arena_v2_soir_plan_generation_at(slot) + 1,
+    )
+    if generation_status != 0 { return generation_status }
+    let zero_status = ir_module_arena_v2_soir_plan_zero(slot)
+    if zero_status != 0 { return zero_status }
+    ir_module_arena_v2_soir_plan_set_state(slot, IR_MODULE_ARENA_V2_SOIR_PLAN_FREE)
+}
+
+fn ir_module_arena_v2_soir_empty_scalar_fingerprint(
+    id: &IrModuleArenaV2ModuleId,
+) -> i64 with Panic, Div {
+    if ir_module_arena_v2_module_function_count(id) != 0 ||
+       ir_module_arena_v2_module_string_count(id) != 0 ||
+       ir_module_arena_v2_module_epistemic_count(id) != 0 ||
+       ir_module_arena_v2_module_model_count(id) != 0 ||
+       ir_module_arena_v2_module_contest_count(id) != 0 ||
+       ir_module_arena_v2_module_algebra_count(id) != 0 ||
+       ir_module_arena_v2_module_ontology_count(id) != 0 ||
+       ir_module_arena_v2_module_bss_total_size(id) != 0 {
+        return -1
+    }
+    ir_module_arena_v2_module_mutation_epoch(id)
+}
+
+fn ir_module_arena_v2_soir_plan_write(
+    slot: i64,
+    arena_identity: i64,
+    module_slot: i64,
+    module_generation: i64,
+    fingerprint: i64,
+    start: i64,
+    capacity: i64,
+    required: i64,
+    end: i64,
+    version: i64,
+) -> i64 with Mut {
+    if slot == 0 {
+        IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_0 = arena_identity
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_0 = module_slot
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_0 = module_generation
+        IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_0 = fingerprint
+        IR_MODULE_ARENA_V2_SOIR_PLAN_START_0 = start
+        IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_0 = capacity
+        IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_0 = required
+        IR_MODULE_ARENA_V2_SOIR_PLAN_END_0 = end
+        IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_0 = version
+    } else {
+        IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_1 = arena_identity
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_1 = module_slot
+        IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_1 = module_generation
+        IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_1 = fingerprint
+        IR_MODULE_ARENA_V2_SOIR_PLAN_START_1 = start
+        IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_1 = capacity
+        IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_1 = required
+        IR_MODULE_ARENA_V2_SOIR_PLAN_END_1 = end
+        IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_1 = version
+    }
+    IR_MODULE_ARENA_V2_SOIR_OK
+}
+
+fn ir_module_arena_v2_soir_plan_arena_identity_at(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_ARENA_IDENTITY_1
+}
+
+fn ir_module_arena_v2_soir_plan_module_slot_at(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_SLOT_1
+}
+
+fn ir_module_arena_v2_soir_plan_module_generation_at(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_MODULE_GENERATION_1
+}
+
+fn ir_module_arena_v2_soir_plan_fingerprint_at(slot: i64) -> i64 {
+    if slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_FINGERPRINT_1
+}
+
+pub fn ir_module_arena_v2_soir_plan_start(id: &IrModuleArenaV2SoirPlanId) -> i64 {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_START_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_START_1
+}
+
+pub fn ir_module_arena_v2_soir_plan_capacity(id: &IrModuleArenaV2SoirPlanId) -> i64 {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_1
+}
+
+pub fn ir_module_arena_v2_soir_plan_required(id: &IrModuleArenaV2SoirPlanId) -> i64 {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_REQUIRED_1
+}
+
+pub fn ir_module_arena_v2_soir_plan_end(id: &IrModuleArenaV2SoirPlanId) -> i64 {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_END_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_END_1
+}
+
+pub fn ir_module_arena_v2_soir_plan_version(id: &IrModuleArenaV2SoirPlanId) -> i64 {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) { return -1 }
+    if (*id).slot == 0 { return IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_0 }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_VERSION_1
+}
+
+pub fn ir_module_arena_v2_soir_plan_bound_generation(id: &IrModuleArenaV2SoirPlanId) -> i64 {
+    if !ir_module_arena_v2_soir_plan_id_is_live(id) { return -1 }
+    ir_module_arena_v2_soir_plan_module_generation_at((*id).slot)
+}
+
+pub fn ir_module_arena_v2_soir_preflight_empty_v5(
+    id: &IrModuleArenaV2ModuleId,
+    start: i64,
+    capacity: i64,
+    out: &! IrModuleArenaV2SoirPlanId,
+) -> i64 with Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_id_is_live(out) {
+        return IR_MODULE_ARENA_V2_SOIR_PLAN_OUTPUT_LIVE
+    }
+    if !ir_module_arena_v2_module_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID
+    }
+    // The vertical is deliberately zero-origin until mutable-buffer forwarding
+    // through bridge and writer has its own source-fresh proof.
+    if start != 0 { return SOIR_WRITER_VIEW_BOUNDS }
+    let fingerprint = ir_module_arena_v2_soir_empty_scalar_fingerprint(id)
+    if fingerprint < 0 { return IR_MODULE_ARENA_V2_SOIR_MODULE_CONTRACT }
+
+    let writer_plan = soir_writer_preflight_scalar_empty_module_v5(start, capacity)
+    let writer_status = soir_write_plan_status(&writer_plan)
+    if writer_status != SOIR_WRITER_OK { return writer_status }
+
+    var slot: i64 = 0
+    while slot < IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY {
+        if ir_module_arena_v2_soir_plan_state(slot) != IR_MODULE_ARENA_V2_SOIR_PLAN_LIVE {
+            let zero_status = ir_module_arena_v2_soir_plan_zero(slot)
+            if zero_status != 0 { return zero_status }
+            let write_status = ir_module_arena_v2_soir_plan_write(
+                slot,
+                ir_module_arena_v2_module_id_arena_identity(id),
+                ir_module_arena_v2_module_id_slot(id),
+                ir_module_arena_v2_module_id_generation(id),
+                fingerprint,
+                soir_write_plan_start(&writer_plan),
+                capacity,
+                soir_write_plan_required(&writer_plan),
+                soir_write_plan_end(&writer_plan),
+                soir_write_plan_version(&writer_plan) as i64,
+            )
+            if write_status != IR_MODULE_ARENA_V2_SOIR_OK { return write_status }
+            let state_status = ir_module_arena_v2_soir_plan_set_state(
+                slot,
+                IR_MODULE_ARENA_V2_SOIR_PLAN_LIVE,
+            )
+            if state_status != 0 { return state_status }
+            (*out).slot = slot
+            (*out).generation = ir_module_arena_v2_soir_plan_generation_at(slot)
+            return IR_MODULE_ARENA_V2_SOIR_OK
+        }
+        slot = slot + 1
+    }
+    IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_EXHAUSTED
+}
+
+pub fn ir_module_arena_v2_soir_emit_empty_v5(
+    id: &IrModuleArenaV2ModuleId,
+    plan_id: &IrModuleArenaV2SoirPlanId,
+    out_buf: &![i8; 131072],
+) -> i64 with Mut, Panic, Div {
+    if !ir_module_arena_v2_soir_plan_id_is_live(plan_id) {
+        return IR_MODULE_ARENA_V2_SOIR_INVALID_PLAN_ID
+    }
+    if !ir_module_arena_v2_module_id_is_live(id) {
+        return IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID
+    }
+    let slot = (*plan_id).slot
+    if ir_module_arena_v2_module_id_arena_identity(id) != ir_module_arena_v2_soir_plan_arena_identity_at(slot) ||
+       ir_module_arena_v2_module_id_slot(id) != ir_module_arena_v2_soir_plan_module_slot_at(slot) ||
+       ir_module_arena_v2_module_id_generation(id) != ir_module_arena_v2_soir_plan_module_generation_at(slot) ||
+       ir_module_arena_v2_soir_empty_scalar_fingerprint(id) != ir_module_arena_v2_soir_plan_fingerprint_at(slot) {
+        return IR_MODULE_ARENA_V2_SOIR_STALE_PLAN
+    }
+
+    let start = ir_module_arena_v2_soir_plan_start(plan_id)
+    let capacity = ir_module_arena_v2_soir_plan_capacity(plan_id)
+    if start != 0 { return SOIR_WRITER_VIEW_BOUNDS }
+    let writer_plan = soir_writer_preflight_scalar_empty_module_v5(start, capacity)
+    if soir_write_plan_status(&writer_plan) != SOIR_WRITER_OK ||
+       soir_write_plan_required(&writer_plan) != ir_module_arena_v2_soir_plan_required(plan_id) ||
+       soir_write_plan_start(&writer_plan) != start ||
+       soir_write_plan_end(&writer_plan) != ir_module_arena_v2_soir_plan_end(plan_id) ||
+       soir_write_plan_version(&writer_plan) as i64 != ir_module_arena_v2_soir_plan_version(plan_id) {
+        return IR_MODULE_ARENA_V2_SOIR_STALE_PLAN
+    }
+    soir_writer_emit_scalar_empty_module_v5(&writer_plan, out_buf)
+}

--- a/self-hosted/ir/soir_writer.sio
+++ b/self-hosted/ir/soir_writer.sio
@@ -1,0 +1,191 @@
+// Shadow-only transactional SOIR v5 writer.
+//
+// This module is deliberately outside the default compiler pipeline. The
+// first vertical owns only the scalar empty-module wire form; it neither
+// accepts the legacy module aggregate nor touches the standalone wide-numeric
+// payload codec.
+
+module ir::soir_writer
+
+pub let SOIR_WRITER_MAX_SIZE: i64 = 131072
+pub let SOIR_WRITER_EMPTY_EXTENSION_COUNT_FIELDS: i64 = 36
+pub let SOIR_WRITER_SCALAR_EMPTY_V5_SIZE: i64 = 320
+pub let SOIR_WRITER_VERSION_V5: i8 = 5
+
+pub let SOIR_WRITER_OK: i64 = 0
+pub let SOIR_WRITER_VIEW_BOUNDS: i64 = -3
+pub let SOIR_WRITER_STALE_PLAN: i64 = -6
+pub let SOIR_WRITER_INTERNAL_BOUNDS: i64 = -7
+
+// The fields stay private so callers can inspect, but cannot forge, the
+// capability produced by preflight.
+pub struct SoirWritePlan {
+    start: i64,
+    capacity: i64,
+    required: i64,
+    end: i64,
+    version: i8,
+    status: i64,
+}
+
+struct SoirWriterCursor {
+    pos: i64,
+    limit: i64,
+    status: i64,
+}
+
+fn soir_writer_failed_plan(start: i64, capacity: i64, status: i64) -> SoirWritePlan {
+    SoirWritePlan {
+        start: start,
+        capacity: capacity,
+        required: 0,
+        end: start,
+        version: SOIR_WRITER_VERSION_V5,
+        status: status,
+    }
+}
+
+pub fn soir_write_plan_status(plan: &SoirWritePlan) -> i64 {
+    (*plan).status
+}
+
+pub fn soir_write_plan_required(plan: &SoirWritePlan) -> i64 {
+    (*plan).required
+}
+
+pub fn soir_write_plan_start(plan: &SoirWritePlan) -> i64 {
+    (*plan).start
+}
+
+pub fn soir_write_plan_end(plan: &SoirWritePlan) -> i64 {
+    (*plan).end
+}
+
+pub fn soir_write_plan_version(plan: &SoirWritePlan) -> i8 {
+    (*plan).version
+}
+
+fn soir_writer_put_i8(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    value: i8,
+) with Mut, Panic, Div {
+    if (*cursor).status != SOIR_WRITER_OK { return }
+    if (*cursor).pos < 0 ||
+       (*cursor).pos >= (*cursor).limit ||
+       (*cursor).pos >= SOIR_WRITER_MAX_SIZE {
+        (*cursor).status = SOIR_WRITER_INTERNAL_BOUNDS
+        return
+    }
+    out_buf[(*cursor).pos as usize] = value
+    (*cursor).pos = (*cursor).pos + 1
+}
+
+fn soir_writer_put_i64(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    value: i64,
+) with Mut, Panic, Div {
+    var shift: i64 = 0
+    while shift < 64 {
+        soir_writer_put_i8(cursor, out_buf, ((value >> shift) & 255) as i8)
+        shift = shift + 8
+    }
+}
+
+fn soir_writer_put_zeroes(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+    count: i64,
+) with Mut, Panic, Div {
+    var i: i64 = 0
+    while i < count {
+        soir_writer_put_i8(cursor, out_buf, 0 as i8)
+        i = i + 1
+    }
+}
+
+fn soir_writer_put_module_header_v5(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+) with Mut, Panic, Div {
+    soir_writer_put_i8(cursor, out_buf, 83 as i8)
+    soir_writer_put_i8(cursor, out_buf, 79 as i8)
+    soir_writer_put_i8(cursor, out_buf, 73 as i8)
+    soir_writer_put_i8(cursor, out_buf, 82 as i8)
+    soir_writer_put_i8(cursor, out_buf, SOIR_WRITER_VERSION_V5)
+    soir_writer_put_zeroes(cursor, out_buf, 3)
+    soir_writer_put_i64(cursor, out_buf, 0)
+}
+
+fn soir_writer_put_empty_module_tail_v5(
+    cursor: &! SoirWriterCursor,
+    out_buf: &![i8; 131072],
+) with Mut, Panic, Div {
+    // String count, the 36 empty extension counts, and BSS total size.
+    soir_writer_put_i64(cursor, out_buf, 0)
+    var extension_index: i64 = 0
+    while extension_index < SOIR_WRITER_EMPTY_EXTENSION_COUNT_FIELDS {
+        soir_writer_put_i64(cursor, out_buf, 0)
+        extension_index = extension_index + 1
+    }
+    soir_writer_put_i64(cursor, out_buf, 0)
+}
+
+fn soir_writer_scalar_plan_matches(left: &SoirWritePlan, right: &SoirWritePlan) -> bool {
+    (*left).status == (*right).status &&
+        (*left).start == (*right).start &&
+        (*left).capacity == (*right).capacity &&
+        (*left).required == (*right).required &&
+        (*left).end == (*right).end &&
+        (*left).version == (*right).version
+}
+
+pub fn soir_writer_preflight_scalar_empty_module_v5(
+    start: i64,
+    capacity: i64,
+) -> SoirWritePlan with Panic, Div {
+    if start < 0 ||
+       capacity < 0 ||
+       start > SOIR_WRITER_MAX_SIZE ||
+       capacity > SOIR_WRITER_MAX_SIZE - start ||
+       SOIR_WRITER_SCALAR_EMPTY_V5_SIZE > capacity {
+        return soir_writer_failed_plan(start, capacity, SOIR_WRITER_VIEW_BOUNDS)
+    }
+    SoirWritePlan {
+        start: start,
+        capacity: capacity,
+        required: SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+        end: start + SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+        version: SOIR_WRITER_VERSION_V5,
+        status: SOIR_WRITER_OK,
+    }
+}
+
+// Returns the absolute end cursor. The bridge currently admits start=0 only;
+// accepting non-zero views is deliberately outside this vertical's claim.
+pub fn soir_writer_emit_scalar_empty_module_v5(
+    plan: &SoirWritePlan,
+    out_buf: &![i8; 131072],
+) -> i64 with Mut, Panic, Div {
+    if (*plan).status != SOIR_WRITER_OK { return (*plan).status }
+    let verified = soir_writer_preflight_scalar_empty_module_v5(
+        (*plan).start,
+        (*plan).capacity,
+    )
+    if !soir_writer_scalar_plan_matches(plan, &verified) {
+        return SOIR_WRITER_STALE_PLAN
+    }
+
+    var cursor = SoirWriterCursor {
+        pos: (*plan).start,
+        limit: (*plan).end,
+        status: SOIR_WRITER_OK,
+    }
+    soir_writer_put_module_header_v5(&! cursor, out_buf)
+    soir_writer_put_empty_module_tail_v5(&! cursor, out_buf)
+    if cursor.status != SOIR_WRITER_OK || cursor.pos != (*plan).end {
+        return SOIR_WRITER_INTERNAL_BOUNDS
+    }
+    cursor.pos
+}

--- a/self-hosted/ir/soir_writer.sio
+++ b/self-hosted/ir/soir_writer.sio
@@ -17,8 +17,9 @@ pub let SOIR_WRITER_VIEW_BOUNDS: i64 = -3
 pub let SOIR_WRITER_STALE_PLAN: i64 = -6
 pub let SOIR_WRITER_INTERNAL_BOUNDS: i64 = -7
 
-// The fields stay private so callers can inspect, but cannot forge, the
-// capability produced by preflight.
+// Emit revalidates every scalar field produced by preflight before writing.
+// The current checker does not enforce field privacy, so this is an integrity
+// check rather than an unforgeable capability boundary.
 pub struct SoirWritePlan {
     start: i64,
     capacity: i64,

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_cross_arena_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_cross_arena_witness.sio
@@ -1,0 +1,33 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 169 }
+    if ir_module_arena_v2_module_store_init(7005) != IR_MODULE_ARENA_V2_OK { return 170 }
+    var source = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9006, &! source) != IR_MODULE_ARENA_V2_OK { return 171 }
+    var cross_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&source, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! cross_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 172
+    }
+    if ir_module_arena_v2_module_store_init(7006) != IR_MODULE_ARENA_V2_OK { return 173 }
+    var cross = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9007, &! cross) != IR_MODULE_ARENA_V2_OK { return 174 }
+    var canary: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&cross, &cross_plan, &! canary) != IR_MODULE_ARENA_V2_SOIR_STALE_PLAN ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 175
+    }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_CROSS_ARENA_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_invalid_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_invalid_witness.sio
@@ -1,0 +1,35 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 139 }
+    if ir_module_arena_v2_module_store_init(7003) != IR_MODULE_ARENA_V2_OK { return 140 }
+    var module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9003, &! module) != IR_MODULE_ARENA_V2_OK { return 141 }
+    var exact = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! exact) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 142
+    }
+    var invalid = ir_module_arena_v2_invalid_module_id()
+    var invalid_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&invalid, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! invalid_plan) != IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID {
+        return 143
+    }
+    var canary: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&invalid, &exact, &! canary) != IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 144
+    }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_INVALID_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_preflight_probe.sio
@@ -1,0 +1,28 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 209 }
+    if ir_module_arena_v2_module_store_init(7010) != IR_MODULE_ARENA_V2_OK { return 210 }
+    var module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9013, &! module) != IR_MODULE_ARENA_V2_OK { return 211 }
+    if ir_module_arena_v2_configure_module_bss_size(&module, 8) != IR_MODULE_ARENA_V2_OK { return 212 }
+    var rejected = ir_module_arena_v2_soir_invalid_plan_id()
+    let status = ir_module_arena_v2_soir_preflight_empty_v5(
+        &module,
+        0,
+        SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+        &! rejected,
+    )
+    print("MUTATION_PREFLIGHT status=")
+    print_int(status)
+    print(" bss=")
+    print_int(ir_module_arena_v2_module_bss_total_size(&module))
+    print(" id_live=")
+    if ir_module_arena_v2_module_id_is_live(&module) { print_int(1) } else { print_int(0) }
+    print("\n")
+    if status != IR_MODULE_ARENA_V2_SOIR_MODULE_CONTRACT { return 213 }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_MUTATION_PREFLIGHT_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_mutation_witness.sio
@@ -1,0 +1,36 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 179 }
+    if ir_module_arena_v2_module_store_init(7007) != IR_MODULE_ARENA_V2_OK { return 180 }
+    var module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9008, &! module) != IR_MODULE_ARENA_V2_OK { return 181 }
+    var mutation_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! mutation_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 182
+    }
+    if ir_module_arena_v2_configure_module_bss_size(&module, 8) != IR_MODULE_ARENA_V2_OK { return 183 }
+    if ir_module_arena_v2_configure_module_bss_size(&module, 0) != IR_MODULE_ARENA_V2_OK { return 184 }
+    var canary: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&module, &mutation_plan, &! canary) != IR_MODULE_ARENA_V2_SOIR_STALE_PLAN ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 185
+    }
+    var current_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! current_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 186
+    }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_MUTATION_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_plan_lifecycle_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_plan_lifecycle_witness.sio
@@ -1,0 +1,45 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 220 }
+    if ir_module_arena_v2_module_store_init(7011) != IR_MODULE_ARENA_V2_OK { return 221 }
+    var module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9014, &! module) != IR_MODULE_ARENA_V2_OK { return 222 }
+
+    var first = ir_module_arena_v2_soir_invalid_plan_id()
+    var second = ir_module_arena_v2_soir_invalid_plan_id()
+    var third = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! first) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 223
+    }
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! second) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 224
+    }
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! third) != IR_MODULE_ARENA_V2_SOIR_PLAN_CAPACITY_EXHAUSTED ||
+       ir_module_arena_v2_soir_plan_id_is_live(&third) {
+        return 225
+    }
+
+    if ir_module_arena_v2_configure_module_bss_size(&module, 8) != IR_MODULE_ARENA_V2_OK { return 226 }
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! first) != IR_MODULE_ARENA_V2_SOIR_PLAN_OUTPUT_LIVE ||
+       !ir_module_arena_v2_soir_plan_id_is_live(&first) {
+        return 227
+    }
+    if ir_module_arena_v2_configure_module_bss_size(&module, 0) != IR_MODULE_ARENA_V2_OK { return 228 }
+    if ir_module_arena_v2_soir_release_plan(&first) != IR_MODULE_ARENA_V2_SOIR_OK ||
+       ir_module_arena_v2_soir_plan_id_is_live(&first) {
+        return 229
+    }
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! third) != IR_MODULE_ARENA_V2_SOIR_OK ||
+       !ir_module_arena_v2_soir_plan_id_is_live(&third) {
+        return 230
+    }
+    if ir_module_arena_v2_soir_plan_id_is_live(&first) ||
+       ir_module_arena_v2_soir_release_plan(&first) != IR_MODULE_ARENA_V2_SOIR_INVALID_PLAN_ID {
+        return 231
+    }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_PLAN_LIFECYCLE_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio
@@ -16,6 +16,25 @@ fn main() -> i64 with IO, Mut, Panic, Div {
     if ir_module_arena_v2_module_store_init(7008) != IR_MODULE_ARENA_V2_OK { return 190 }
     var original = ir_module_arena_v2_invalid_module_id()
     if ir_module_arena_v2_alloc_empty_module(9009, &! original) != IR_MODULE_ARENA_V2_OK { return 191 }
+    let original_arena = ir_module_arena_v2_module_id_arena_identity(&original)
+    let original_slot = ir_module_arena_v2_module_id_slot(&original)
+    let original_generation = ir_module_arena_v2_module_id_generation(&original)
+    let output_live_status = ir_module_arena_v2_alloc_empty_module(9011, &! original)
+    print("MODULE_OUTPUT_LIVE status=")
+    print_int(output_live_status)
+    print(" live_count=")
+    print_int(ir_module_arena_v2_module_store_live_count())
+    print(" id_live=")
+    if ir_module_arena_v2_module_id_is_live(&original) { print_int(1) } else { print_int(0) }
+    print("\n")
+    if output_live_status != IR_MODULE_ARENA_V2_ERR_OUTPUT_LIVE ||
+       ir_module_arena_v2_module_store_live_count() != 1 ||
+       !ir_module_arena_v2_module_id_is_live(&original) ||
+       ir_module_arena_v2_module_id_arena_identity(&original) != original_arena ||
+       ir_module_arena_v2_module_id_slot(&original) != original_slot ||
+       ir_module_arena_v2_module_id_generation(&original) != original_generation {
+        return 196
+    }
     var old_plan = ir_module_arena_v2_soir_invalid_plan_id()
     if ir_module_arena_v2_soir_preflight_empty_v5(&original, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! old_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
         return 192

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_reuse_witness.sio
@@ -1,0 +1,33 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 189 }
+    if ir_module_arena_v2_module_store_init(7008) != IR_MODULE_ARENA_V2_OK { return 190 }
+    var original = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9009, &! original) != IR_MODULE_ARENA_V2_OK { return 191 }
+    var old_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&original, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! old_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 192
+    }
+    if ir_module_arena_v2_remove_module(&original) != IR_MODULE_ARENA_V2_OK { return 193 }
+    var reused = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9010, &! reused) != IR_MODULE_ARENA_V2_OK { return 194 }
+    var canary: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&reused, &old_plan, &! canary) != IR_MODULE_ARENA_V2_SOIR_STALE_PLAN ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 195
+    }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_REUSE_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_sequence_probe.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_sequence_probe.sio
@@ -1,0 +1,94 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 199 }
+    if ir_module_arena_v2_module_store_init(7009) != IR_MODULE_ARENA_V2_OK { return 200 }
+    var original = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9011, &! original) != IR_MODULE_ARENA_V2_OK { return 201 }
+    var old_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&original, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! old_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 202
+    }
+
+    print("SEQUENCE_BEFORE plan_live=")
+    if ir_module_arena_v2_soir_plan_id_is_live(&old_plan) { print_int(1) } else { print_int(0) }
+    print(" bound_generation=")
+    print_int(ir_module_arena_v2_soir_plan_bound_generation(&old_plan))
+    print(" start=")
+    print_int(ir_module_arena_v2_soir_plan_start(&old_plan))
+    print(" required=")
+    print_int(ir_module_arena_v2_soir_plan_required(&old_plan))
+    print(" end=")
+    print_int(ir_module_arena_v2_soir_plan_end(&old_plan))
+    print(" id_generation=")
+    print_int(ir_module_arena_v2_module_id_generation(&original))
+    print("\n")
+
+    if ir_module_arena_v2_remove_module(&original) != IR_MODULE_ARENA_V2_OK { return 203 }
+    var canary: [i8; 131072] = [85; 131072]
+    let stale_status = ir_module_arena_v2_soir_emit_empty_v5(&original, &old_plan, &! canary)
+    var stale_canary: bool = true
+    var stale_scan: i64 = 0
+    while stale_scan < 131072 {
+        if canary[stale_scan as usize] != 85 as i8 { stale_canary = false }
+        stale_scan = stale_scan + 1
+    }
+    print("SEQUENCE_AFTER_STALE status=")
+    print_int(stale_status)
+    print(" plan_live=")
+    if ir_module_arena_v2_soir_plan_id_is_live(&old_plan) { print_int(1) } else { print_int(0) }
+    print(" bound_generation=")
+    print_int(ir_module_arena_v2_soir_plan_bound_generation(&old_plan))
+    print(" required=")
+    print_int(ir_module_arena_v2_soir_plan_required(&old_plan))
+    print(" end=")
+    print_int(ir_module_arena_v2_soir_plan_end(&old_plan))
+    print(" id_live=")
+    if ir_module_arena_v2_module_id_is_live(&original) { print_int(1) } else { print_int(0) }
+    print(" arena_live_count=")
+    print_int(ir_module_arena_v2_module_store_live_count())
+    print(" canary=")
+    if stale_canary { print_int(1) } else { print_int(0) }
+    print("\n")
+    if stale_status != IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID || !stale_canary { return 204 }
+
+    var reused = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9012, &! reused) != IR_MODULE_ARENA_V2_OK { return 205 }
+    let reuse_status = ir_module_arena_v2_soir_emit_empty_v5(&reused, &old_plan, &! canary)
+    var reuse_canary: bool = true
+    var reuse_scan: i64 = 0
+    while reuse_scan < 131072 {
+        if canary[reuse_scan as usize] != 85 as i8 { reuse_canary = false }
+        reuse_scan = reuse_scan + 1
+    }
+    print("SEQUENCE_AFTER_REUSE status=")
+    print_int(reuse_status)
+    print(" plan_live=")
+    if ir_module_arena_v2_soir_plan_id_is_live(&old_plan) { print_int(1) } else { print_int(0) }
+    print(" bound_generation=")
+    print_int(ir_module_arena_v2_soir_plan_bound_generation(&old_plan))
+    print(" start=")
+    print_int(ir_module_arena_v2_soir_plan_start(&old_plan))
+    print(" required=")
+    print_int(ir_module_arena_v2_soir_plan_required(&old_plan))
+    print(" end=")
+    print_int(ir_module_arena_v2_soir_plan_end(&old_plan))
+    print(" id_live=")
+    if ir_module_arena_v2_module_id_is_live(&reused) { print_int(1) } else { print_int(0) }
+    print(" id_arena=")
+    print_int(ir_module_arena_v2_module_id_arena_identity(&reused))
+    print(" id_slot=")
+    print_int(ir_module_arena_v2_module_id_slot(&reused))
+    print(" id_generation=")
+    print_int(ir_module_arena_v2_module_id_generation(&reused))
+    print(" arena_live_count=")
+    print_int(ir_module_arena_v2_module_store_live_count())
+    print(" canary=")
+    if reuse_canary { print_int(1) } else { print_int(0) }
+    print("\n")
+    if reuse_status != IR_MODULE_ARENA_V2_SOIR_STALE_PLAN || !reuse_canary { return 206 }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_SEQUENCE_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_stale_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_stale_witness.sio
@@ -1,0 +1,31 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 149 }
+    if ir_module_arena_v2_module_store_init(7004) != IR_MODULE_ARENA_V2_OK { return 150 }
+    var module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9004, &! module) != IR_MODULE_ARENA_V2_OK { return 151 }
+    var stale_plan = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(&module, 0, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, &! stale_plan) != IR_MODULE_ARENA_V2_SOIR_OK {
+        return 152
+    }
+    if ir_module_arena_v2_remove_module(&module) != IR_MODULE_ARENA_V2_OK { return 153 }
+    var canary: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&module, &stale_plan, &! canary) != IR_MODULE_ARENA_V2_SOIR_INVALID_MODULE_ID ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 154
+    }
+    print("IR_MODULE_ARENA_V2_SOIR_V5_STALE_PASS\n")
+    0
+}

--- a/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio
+++ b/tests/native-v2/ir_module_arena_v2_soir_v5_bridge_witness.sio
@@ -1,0 +1,115 @@
+use ir::arena_v2_shadow::*
+use ir::soir_writer::*
+use ir::arena_v2_soir_bridge::*
+
+fn buffer_is_canary(buf: &[i8; 131072], canary: i8) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn ranges_equal(
+    left: &[i8; 131072],
+    right: &[i8; 131072],
+    len: i64,
+) -> bool with Panic, Div {
+    var i: i64 = 0
+    while i < len {
+        if (*left)[i as usize] != (*right)[i as usize] { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn tail_is_canary(buf: &[i8; 131072], start: i64, canary: i8) -> bool with Panic, Div {
+    var i: i64 = start
+    while i < 131072 {
+        if (*buf)[i as usize] != canary { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn empty_v5_wire_is_canonical(buf: &[i8; 131072]) -> bool with Panic, Div {
+    if (*buf)[0] != 83 as i8 || (*buf)[1] != 79 as i8 ||
+       (*buf)[2] != 73 as i8 || (*buf)[3] != 82 as i8 ||
+       (*buf)[4] != 5 as i8 {
+        return false
+    }
+    var i: i64 = 5
+    while i < SOIR_WRITER_SCALAR_EMPTY_V5_SIZE {
+        if (*buf)[i as usize] != 0 as i8 { return false }
+        i = i + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if ir_module_arena_v2_soir_plan_store_init() != IR_MODULE_ARENA_V2_SOIR_OK { return 100 }
+    if ir_module_arena_v2_module_store_init(7001) != IR_MODULE_ARENA_V2_OK { return 101 }
+    var module = ir_module_arena_v2_invalid_module_id()
+    if ir_module_arena_v2_alloc_empty_module(9001, &! module) != IR_MODULE_ARENA_V2_OK { return 102 }
+
+    var exact = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(
+           &module,
+           0,
+           SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+           &! exact,
+       ) != IR_MODULE_ARENA_V2_SOIR_OK ||
+       ir_module_arena_v2_soir_plan_required(&exact) != SOIR_WRITER_SCALAR_EMPTY_V5_SIZE ||
+       ir_module_arena_v2_soir_plan_start(&exact) != 0 ||
+       ir_module_arena_v2_soir_plan_end(&exact) != SOIR_WRITER_SCALAR_EMPTY_V5_SIZE ||
+       ir_module_arena_v2_soir_plan_version(&exact) != 5 {
+        return 110
+    }
+
+    var first: [i8; 131072] = [0; 131072]
+    var repeat: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&module, &exact, &! first) != SOIR_WRITER_SCALAR_EMPTY_V5_SIZE {
+        return 111
+    }
+    if ir_module_arena_v2_soir_emit_empty_v5(&module, &exact, &! repeat) != SOIR_WRITER_SCALAR_EMPTY_V5_SIZE {
+        return 112
+    }
+    if !empty_v5_wire_is_canonical(&first) ||
+       !ranges_equal(&first, &repeat, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE) ||
+       !tail_is_canary(&repeat, SOIR_WRITER_SCALAR_EMPTY_V5_SIZE, 85 as i8) {
+        return 113
+    }
+
+    var below = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(
+           &module,
+           0,
+           SOIR_WRITER_SCALAR_EMPTY_V5_SIZE - 1,
+           &! below,
+       ) != SOIR_WRITER_VIEW_BOUNDS {
+        return 120
+    }
+    var canary: [i8; 131072] = [85; 131072]
+    if ir_module_arena_v2_soir_emit_empty_v5(&module, &below, &! canary) != IR_MODULE_ARENA_V2_SOIR_INVALID_PLAN_ID ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 121
+    }
+
+    var offset = ir_module_arena_v2_soir_invalid_plan_id()
+    if ir_module_arena_v2_soir_preflight_empty_v5(
+           &module,
+           17,
+           SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+           &! offset,
+       ) != SOIR_WRITER_VIEW_BOUNDS {
+        return 122
+    }
+    if ir_module_arena_v2_soir_emit_empty_v5(&module, &offset, &! canary) != IR_MODULE_ARENA_V2_SOIR_INVALID_PLAN_ID ||
+       !buffer_is_canary(&canary, 85 as i8) {
+        return 123
+    }
+
+    print("IR_MODULE_ARENA_V2_SOIR_V5_CANONICAL_PASS\n")
+    0
+}


### PR DESCRIPTION
## What this proves

- adds a shadow-only, scalar `IrModuleArena v2` with two slots, generation-aware `ModuleId` lifecycle, stale/reuse/cross-arena rejection, and mutation epochs
- adds a deterministic SOIR v5 empty-module writer and an arena-to-writer preflight/emit bridge
- adds nine same-module composite witnesses covering valid emission, invalid/stale/reused identities, cross-arena use, mutation invalidation, sequencing, and plan lifecycle
- rejects allocation through an already-live output handle without leaking a slot or changing the original handle
- preserves the default compiler path and the existing `f128`/`f256` format-identity surface

## Evidence

Publication head: `36dfd52c0753606974aa2359a57f961aac8cb992`  
Tree: `ad6e4fb06850e02ced8b6d75f825fd0fa2c53890`  
Publication base: `4a63c2ba16b4aecf85759bf3f3a7ba9105c79986`  
Exact publication delta: 13 added files, 1,744 insertions.

Slurm job `6654` rebuilt Madaros from source at the immediately preceding semantic head `677b78464edb5a57c8ee5bc1b6eb0b8d38b83a0e` on `gpuorangefs-multi-r740-proxmox`:

- job: `COMPLETED`, `ExitCode=0:0`, elapsed `00:09:43`
- source build: `rc=0`, compiler errors `0`
- gate: `rc=0`, composite matrix `9/9`
- watchdog forced-hang self-test: `runtime_rc=124`, `selftest=pass`, `fail_closed=pass`
- Git status rows: `0`; exact write-set rows: `13`
- compiler: 98,939,624 bytes, SHA-256 `547db893a2b8cf9eb7b7bc3ca67f13fffd3c3361ebd208d019a1779387afe372`
- result archive SHA-256: `6bff04f28c68e6ec9e6430ba62c093687d4a76ba4d4a19bc7ade2113fc9ad77f`

`677b78464..36dfd52c` changes only this shell gate, not Madaros build inputs, Sounio IR sources, or witnesses. The final head was then rerun with the exact cluster-built compiler in both modes:

- `current_tree`: PASS, `base=not_checked_current_tree`, `exact_write_set=not_checked_current_tree`
- `publication`: PASS, `scope=publication_branch_exact`, `exact_write_set=pass`
- final lane-content SHA-256: `9a5b414e2569779e2a9fc8d9caf0be346c1d0a3ca3128fd338b44296d1242716`

A synthetic merge onto current `main` was also executed: default `current_tree` remained 9/9 green, while branch-only `publication` correctly failed `write_set_expanded`. This keeps the committed gate useful after merge without turning unrelated future commits into false R27 scope expansion.

## Honesty boundary

This PR is a shadow vertical, not a default-compiler cutover. It proves zero-origin empty-module SOIR v5 emission and lifecycle behavior. It does **not** claim byte parity with the legacy serializer, imported-module privacy, full `ModuleGraph` integration, or non-empty module lowering. The current checker does not enforce struct-field privacy, so handles are treated as emit-time revalidated integrity records, not unforgeable capabilities.

## Review

Two adversarial read-only reviews were run. The first found live-output leakage plus four receipt/provenance overclaims; all were corrected. The final review found no remaining actionable bug or overclaim and approved publication with the boundaries above.