### PR TITLE
docs: bind science boundary concept

### DIFF
--- a/docs/internal/concepts/bindings.tsv
+++ b/docs/internal/concepts/bindings.tsv
@@ -36,6 +36,7 @@ SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	stdlib/algebra/cayley_dickson_exact_i64.sio	exac
 SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	tests/stdlib/eisa/test_eisa_h_zd.sio	evidence
 SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	scripts/ci/eisa_h_zd_reference_gate.sh	gate
 SOUNIO-HYPERCOMPLEX-ZD-EVIDENCE	self-hosted/ir/*	blocked-pending-interface
+SOUNIO-SCIENCE-RESEARCH-BOUNDARY	docs/architecture/science-research-boundary.md	canonical-contract
 SOUNIO-REBRACKETING-AUTHORITY	docs/internal/concepts/rebracketing-authority.md	concept-contract
 SOUNIO-REBRACKETING-AUTHORITY	self-hosted/ir/ir.sio	ontology-identity-transport
 SOUNIO-REBRACKETING-AUTHORITY	self-hosted/ir/opt_cleanup.sio	canonical-ir-transaction


### PR DESCRIPTION
## Summary

- bind `SOUNIO-SCIENCE-RESEARCH-BOUNDARY` to its existing canonical architecture contract
- restore `semantic_coordination_gate.sh` after #1055 introduced the concept registry row
- keep the change identical to the binding already present later in the validated R3 stack

## Validation

- `bash scripts/ci/semantic_coordination_gate.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `git diff --check`

This adds no new concept or claim. It repairs the intermediate `main` invariant before the remaining stacked PRs land.
