### PR TITLE
feat(gpu): backward/VJP of the batched hypercomplex multiply on tensor cores (GB10)

### DIFF
--- a/docs/gpu/oct_batch_vjp_tile.ptx
+++ b/docs/gpu/oct_batch_vjp_tile.ptx
@@ -1,0 +1,166 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[64] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000};
+
+    .global .align 4 .b32 ossm_absgn[64] = {0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000};
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pH,
+    .param .u64 pdD,
+    .param .u64 pdH,
+    .param .u64 pda
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[2048];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pH];
+    ld.param.u64 %rd2, [pdD];
+    ld.param.u64 %rd3, [pdH];
+    ld.param.u64 %rd4, [pda];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $VS0;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ5:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ5;
+    mov.u32 %r5, 0;
+$LB30:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r7, 16, %r6;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $LB30;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$VDS:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $VDS;
+$VS0:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $VS1;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$VSH:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.lo.u32 %r8, %r5, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    cvt.f64.f32 %fd0, %f1;
+    mad.lo.u32 %r8, %r7, 8, %r6;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $VSH;
+    mov.f64 %fd0, 0d0000000000000000;
+    mov.u32 %r5, 0;
+$VDAZ:
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 8;
+    @%p1 bra $VDAZ;
+    mov.u32 %r5, 0;
+$VDA:
+    shr.u32 %r6, %r5, 7;
+    and.b32 %r10, %r5, 127;
+    shr.u32 %r8, %r10, 4;
+    and.b32 %r9, %r10, 15;
+    xor.b32 %r7, %r8, %r6;
+    mad.lo.u32 %r10, %r9, 8, %r7;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mad.lo.u32 %r10, %r8, 16, %r9;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.f64 %fd0, %fd0, %fd1;
+    mad.lo.u32 %r10, %r6, 8, %r7;
+    mul.wide.u32 %rd7, %r10, 4;
+    mov.u64 %rd6, ossm_absgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    add.f64 %fd1, %fd1, %fd0;
+    st.global.f64 [%rd7], %fd1;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 1024;
+    @%p1 bra $VDA;
+$VS1:
+    ret;
+}

--- a/docs/gpu/run_vjp_wmma_ptx.cu
+++ b/docs/gpu/run_vjp_wmma_ptx.cu
@@ -1,0 +1,46 @@
+// Driver-API harness for the compiler-lowered VJP/backward kernel `step` of D = L(a)·H:
+//   dH[b*dim+j] = Σ_k σ(k⊕j,j)·a[k⊕j]·dD[k,b]        (tensor-core tile, L(a)ᵀ·dD)
+//   da[p]       = Σ_{k,b} σ(p,k⊕p)·H[k⊕p,b]·dD[k,b]  (runtime f64 accumulation)
+// Usage: run_vjp <ptx> <dim>  (dim=8 octonion / 16 sedenion). Validates vs the analytic Jacobian
+// transpose on the DGX Spark GB10. dH goes through the f16 tile (looser tol); da is full f64.
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+int main(int c,char**v){
+ const char*p=c>1?v[1]:"/tmp/vjp.ptx"; int dim=c>2?atoi(v[2]):8; int bits=(dim==16)?4:3;
+ double a[16]={0}, H[256]={0}, dD[256]={0};
+ for(int i=0;i<dim;i++)a[i]=0.4*((i%2)?-1:1)+0.05*i;
+ for(int b=0;b<16;b++)for(int j=0;j<dim;j++)H[b*dim+j]=((b+1)*0.11+j*0.05)*((j%2)?-1:1);
+ for(int k=0;k<dim;k++)for(int b=0;b<16;b++)dD[k*16+b]=0.2*((k+b)%3-1)+0.03*k-0.02*b;
+ // analytic VJP
+ double dH_ref[256]={0}, da_ref[16]={0};
+ for(int b=0;b<16;b++)for(int j=0;j<dim;j++){double s=0;
+   for(int k=0;k<dim;k++)s+=(double)cds(k^j,j,bits)*a[k^j]*dD[k*16+b];
+   dH_ref[b*dim+j]=s;}
+ for(int pp=0;pp<dim;pp++){double s=0;
+   for(int k=0;k<dim;k++)for(int b=0;b<16;b++){int m=k^pp; s+=(double)cds(pp,m,bits)*H[b*dim+m]*dD[k*16+b];}
+   da_ref[pp]=s;}
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext x;CK(cuDevicePrimaryCtxRetain(&x,d));CK(cuCtxSetCurrent(x));
+ CUmodule m;CK(cuModuleLoad(&m,p));CUfunction f;CK(cuModuleGetFunction(&f,m,"step"));
+ CUdeviceptr pa,pH,pdD,pdH,pda;
+ CK(cuMemAlloc(&pa,dim*8));CK(cuMemAlloc(&pH,16*dim*8));CK(cuMemAlloc(&pdD,256*8));
+ CK(cuMemAlloc(&pdH,256*8));CK(cuMemAlloc(&pda,16*8));
+ CK(cuMemcpyHtoD(pa,a,dim*8));CK(cuMemcpyHtoD(pH,H,16*dim*8));CK(cuMemcpyHtoD(pdD,dD,256*8));
+ double z[256]={0};CK(cuMemcpyHtoD(pdH,z,256*8));CK(cuMemcpyHtoD(pda,z,16*8));
+ void*args[]={&pa,&pH,&pdD,&pdH,&pda};CK(cuLaunchKernel(f,1,1,1,32,1,1,0,0,args,0));CK(cuCtxSynchronize());
+ double gdH[256],gda[16];CK(cuMemcpyDtoH(gdH,pdH,256*8));CK(cuMemcpyDtoH(gda,pda,16*8));
+ int fH=0,fA=0;double mH=0,mA=0;
+ for(int b=0;b<16;b++)for(int j=0;j<dim;j++){double e=fabs(gdH[b*dim+j]-dH_ref[b*dim+j]);if(e>mH)mH=e;if(e>0.05)fH++;}
+ for(int pp=0;pp<dim;pp++){double e=fabs(gda[pp]-da_ref[pp]);if(e>mA)mA=e;if(e>1e-4)fA++;}
+ const char*nm=(dim==16)?"SEDENION":"octonion";
+ printf("Sounio source-level %s VJP of D=L(a)*H tensor-core GB10:\n",nm);
+ printf("  dH = L(a)^T . dD  (tile): mismatch %d/%d  maxerr=%.4f\n",fH,dim*16,mH);
+ printf("  da = sum sigma.H.dD (f64): mismatch %d/%d  maxerr=%.2e\n",fA,dim,mA);
+ if(!fH&&!fA){printf("PASS: compiler-emitted VJP (dH tile + da accumulation) matches the analytic Jacobian transpose on GB10\n");return 0;}
+ printf("FAIL\n");return 1;}

--- a/docs/gpu/sed_batch_vjp_tile.ptx
+++ b/docs/gpu/sed_batch_vjp_tile.ptx
@@ -1,0 +1,166 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+    .global .align 4 .b32 ossm_absgn[256] = {0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000};
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pH,
+    .param .u64 pdD,
+    .param .u64 pdH,
+    .param .u64 pda
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[2048];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pH];
+    ld.param.u64 %rd2, [pdD];
+    ld.param.u64 %rd3, [pdH];
+    ld.param.u64 %rd4, [pda];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $VS0;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ5:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ5;
+    mov.u32 %r5, 0;
+$LB30:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r7, 16, %r6;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB30;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$VDS:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $VDS;
+$VS0:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $VS1;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$VSH:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.lo.u32 %r8, %r5, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    cvt.f64.f32 %fd0, %f1;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $VSH;
+    mov.f64 %fd0, 0d0000000000000000;
+    mov.u32 %r5, 0;
+$VDAZ:
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 16;
+    @%p1 bra $VDAZ;
+    mov.u32 %r5, 0;
+$VDA:
+    shr.u32 %r6, %r5, 8;
+    and.b32 %r10, %r5, 255;
+    shr.u32 %r8, %r10, 4;
+    and.b32 %r9, %r10, 15;
+    xor.b32 %r7, %r8, %r6;
+    mad.lo.u32 %r10, %r9, 16, %r7;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mad.lo.u32 %r10, %r8, 16, %r9;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.f64 %fd0, %fd0, %fd1;
+    mad.lo.u32 %r10, %r6, 16, %r7;
+    mul.wide.u32 %rd7, %r10, 4;
+    mov.u64 %rd6, ossm_absgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    add.f64 %fd1, %fd1, %fd0;
+    st.global.f64 [%rd7], %fd1;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 4096;
+    @%p1 bra $VDA;
+$VS1:
+    ret;
+}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1806,6 +1806,19 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             asc.addr_reg = instr.call_args[2]
             asc.src_reg = instr.call_args[3]
             k = gpu_kernel_append_op(k, asc)
+        } else if hlir_name_is_oct_batch_vjp(cn) || hlir_name_is_sed_batch_vjp(cn) {
+            // Backward / VJP of D = L(a)·H. call_args = [pa, pH, pdD, pdH, pda]. One transposed tile
+            // (dH = L(a)ᵀ·dD) + a runtime da accumulation → one GpuOctVjp. Needs sL+sH+sS = 2048 bytes.
+            if k.shared_bytes < 2048 { k.shared_bytes = 2048 }
+            var vjp = gpu_op_new()
+            vjp.opcode = GpuOpcode::GpuOctVjp
+            vjp.rhs_imm = if hlir_name_is_sed_batch_vjp(cn) { 16 } else { 8 }
+            vjp.lhs_reg = instr.call_args[0]
+            vjp.rhs_reg = instr.call_args[1]
+            vjp.addr_reg = instr.call_args[2]
+            vjp.src_reg = instr.call_args[3]
+            vjp.shared_addr = instr.call_args[4]
+            k = gpu_kernel_append_op(k, vjp)
         }
         // Other calls: skip in MVP
     }
@@ -1895,6 +1908,25 @@ fn hlir_name_is_sed_assoc(n: HlirName) -> bool {
     n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8 && n.buf[2] == 100 as i8 && n.buf[3] == 95 as i8 &&
     n.buf[4] == 97 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 115 as i8 && n.buf[7] == 111 as i8 &&
     n.buf[8] == 99 as i8
+}
+
+// "oct_batch_vjp" (13 chars) — VJP/backward of the batched octonion multiply: given dD, computes
+// dH = L(a)ᵀ·dD and da[p] = Σ σ(p,k⊕p)·H·dD. oct_batch_vjp(pa,pH,pdD,pdH,pda) (dim=8, bits=3).
+fn hlir_name_is_oct_batch_vjp(n: HlirName) -> bool {
+    if n.len != 13 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 99 as i8 && n.buf[2] == 116 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
+    n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 118 as i8 && n.buf[11] == 106 as i8 &&
+    n.buf[12] == 112 as i8
+}
+
+// "sed_batch_vjp" (13 chars) — VJP/backward of the batched sedenion multiply (dim=16, bits=4).
+fn hlir_name_is_sed_batch_vjp(n: HlirName) -> bool {
+    if n.len != 13 { return false }
+    n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8 && n.buf[2] == 100 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
+    n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 118 as i8 && n.buf[11] == 106 as i8 &&
+    n.buf[12] == 112 as i8
 }
 
 fn hlir_name_starts_with_gpu_thread(n: HlirName) -> bool {

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -122,6 +122,10 @@ pub enum GpuOpcode {
     //   batch. THREE m16n16k16 tiles: q=L(b)·H, r=L(a)·q, p=L(a⊗b)·H, then out=p−r. a⊗b is formed
     //   into a global scratch (ossm_ab) via the σ(i,j) table (ossm_absgn). Pointers pa,pb,pH,pout in
     //   lhs_reg/rhs_reg/addr_reg/src_reg; rhs_imm = dim (8 octonion / 16 sedenion).
+    GpuOctVjp,          // Backward / VJP of the batched multiply D = L(a)·H over a 16-state batch:
+    //   given upstream dD, compute dH = L(a)ᵀ·dD (ONE tensor-core tile with L(a) transposed) and
+    //   da[p] = Σ_{k,b} σ(p,k⊕p)·H[k⊕p,b]·dD[k,b] (runtime accumulation). Pointers pa,pH,pdD,pdH,pda
+    //   in lhs_reg/rhs_reg/addr_reg/src_reg/shared_addr; rhs_imm = dim (8 octonion / 16 sedenion).
     GpuTmaLoad,         // Tensor memory access load (sm_90+)
     GpuTmaStore,        // Tensor memory access store (sm_90+)
 

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -32,6 +32,14 @@ pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, All
         buf = ptx_push_str(buf, gpu_emit_assoc_absgn_table(adim, abits))
         buf = ptx_push_str(buf, "    .global .align 8 .b64 ossm_ab[16];\n\n")
     }
+    // VJP tables: ossm_Lsgn σ(k⊕j,j) for the transposed L(a)ᵀ build, ossm_absgn σ(i,j) for the da
+    // accumulation. No ossm_ab scratch (no product formed).
+    if gpu_has_oct_vjp(kernel) {
+        let vdim = gpu_vjp_dim(kernel)
+        let vbits = if vdim == 16 { 4 } else { 3 }
+        buf = ptx_push_str(buf, gpu_emit_cell_sign_table(vdim, vbits))
+        buf = ptx_push_str(buf, gpu_emit_assoc_absgn_table(vdim, vbits))
+    }
     // gpu_emit_kernel_mode_metadata skipped: calls gpu_legalize_kernel_to_ssa_v2 which
     // returns GpuKernelSsaV2 by value (~28MB frame) → SIGSEGV in lean_single-compiled binary.
     // The function only emits cosmetic PTX comment lines; skip it for correctness.
@@ -136,7 +144,7 @@ fn gpu_has_wmma_tile(kernel: GpuKernelIr) -> bool {
     var i: i64 = 0
     while i < kernel.op_count {
         let oc = kernel.ops[i as usize].opcode
-        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc { return true }
+        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc || oc == GpuOpcode::GpuOctVjp { return true }
         i = i + 1
     }
     false
@@ -149,8 +157,8 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
 
     let stage = gpu_has_oct_stage(kernel)
     let postadd = gpu_has_oct_postadd(kernel)
-    // The associator needs the same register classes as the cell (runtime L-build + repack loops).
-    let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel)
+    // The associator and the VJP need the same register classes as the cell (runtime L-build / accum).
+    let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel) || gpu_has_oct_vjp(kernel)
     let stage_or_pa = stage || postadd || cell
 
     // .reg .pred %p<N> — the staging loop / post-add need at least %p<2>.
@@ -604,6 +612,131 @@ fn gpu_emit_assoc_zero_shared(tag: i64, base: i64, endb: i64) -> string with Mut
     t
 }
 
+// ── Backward / VJP of the batched multiply D = L(a)·H ──────────────────────────────────────────
+// dH = L(a)ᵀ·dD (one transposed tensor-core tile) + da[p] = Σ_{k,b} σ(p,k⊕p)·H[k⊕p,b]·dD[k,b].
+// Split into phase helpers so each Madaros stack frame stays small (see gpu_emit_oct_assoc).
+fn gpu_emit_oct_vjp(paR: string, pHR: string, pdDR: string, pdHR: string, pdaR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+    // tile: build L(a)ᵀ into sL, stage dD col-major into sH, tile → sS = L(a)ᵀ·dD = dH_tile
+    var t = "    mov.u32 %r1, %tid.x;\n"
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $VS0;\n")
+    t = str_concat(t, gpu_emit_assoc_zero_shared(5, 0, 1024))
+    t = str_concat(t, gpu_emit_cell_lbuild_t(paR, dim, bits, 30))
+    t = str_concat(t, gpu_emit_vjp_dstage(pdDR, dim))
+    t = str_concat(t, "$VS0:\n    bar.sync 0;\n")
+    t = str_concat(t, gpu_emit_cell_shared_tile())
+    t = str_concat(t, "    bar.sync 0;\n")
+    // thread 0: store dH (sS → pdH state-major, f32→f64) + accumulate da
+    t = str_concat(t, "    mov.u32 %r1, %tid.x;\n")
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $VS1;\n")
+    t = str_concat(t, gpu_emit_vjp_store_dh(pdHR, dim))
+    t = str_concat(t, gpu_emit_vjp_da_accum(pHR, pdDR, pdaR, dim))
+    t = str_concat(t, "$VS1:\n")
+    t
+}
+
+// Build L(m)ᵀ (the TRANSPOSE of L(m)) into sL[shared_array], row-major f16. Same value as lbuild
+// (σ(k⊕j,j)·m[k⊕j]) but stored at (col*16+row) instead of (row*16+col) — used for dH = L(a)ᵀ·dD.
+fn gpu_emit_cell_lbuild_t(mR: string, dim: i64, bits: i64, tagnum: i64) -> string with Mut, Panic, Div, Alloc {
+    let sh = if dim == 16 { 4 } else { 3 }
+    var t = str_concat(str_concat("    mov.u32 %r5, 0;\n$LB", i64_to_string(tagnum)), ":\n")
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r7, %r5, "), i64_to_string(dim - 1))
+    t = str_concat(t, ";\n    xor.b32 %r8, %r6, %r7;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r8, 8;\n    add.s64 %rd7, "), mR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    t = str_concat(t, "    mul.wide.u32 %rd7, %r5, 4;\n")
+    t = str_concat(t, "    mov.u64 %rd6, ossm_Lsgn;\n")
+    t = str_concat(t, "    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n")
+    t = str_concat(t, "    cvt.f64.f32 %fd1, %f0;\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")
+    t = str_concat(t, "    cvt.rn.f16.f64 %rs0, %fd0;\n")
+    t = str_concat(t, "    mov.u32 %r3, shared_array;\n")
+    // TRANSPOSED store: dest = (col=%r7)*16 + (row=%r6)
+    t = str_concat(t, "    mad.lo.u32 %r9, %r7, 16, %r6;\n")
+    t = str_concat(t, "    mul.lo.u32 %r9, %r9, 2;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r9;\n")
+    t = str_concat(t, "    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim))
+    t = str_concat(str_concat(t, ";\n    @%p1 bra $LB"), i64_to_string(tagnum))
+    t = str_concat(t, ";\n")
+    t
+}
+
+// thread 0: stage dD (global f64, layout dD[k*16+b]) col-major f16 into sH@512: sH[(b*16+k)] =
+// dD[k*16+b]. Since k=idx>>4, b=idx&15 ⇒ k*16+b == idx, the source address is just pdDR+idx*8.
+fn gpu_emit_vjp_dstage(pdDR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$VDS:\n"
+    t = str_concat(t, "    shr.u32 %r6, %r5, 4;\n    and.b32 %r7, %r5, 15;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r5, 8;\n    add.s64 %rd7, "), pdDR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    t = str_concat(t, "    cvt.rn.f16.f64 %rs0, %fd0;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r7, 16, %r6;\n")
+    t = str_concat(t, "    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $VDS;\n")
+    t
+}
+
+// thread 0: store dH from the tile output sS@1024 (row-major f32, dH_tile[j][b] at (j*16+b)==idx)
+// to pdH state-major (dH[b*dim+j]) as f64. j=idx>>4, b=idx&15.
+fn gpu_emit_vjp_store_dh(pdHR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$VSH:\n"
+    t = str_concat(t, "    shr.u32 %r6, %r5, 4;\n    and.b32 %r7, %r5, 15;\n")
+    t = str_concat(t, "    mul.lo.u32 %r8, %r5, 4;\n    add.u32 %r8, %r8, 1024;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    ld.shared.f32 %f1, [%r9];\n")
+    t = str_concat(t, "    cvt.f64.f32 %fd0, %f1;\n")
+    t = str_concat(str_concat(t, "    mad.lo.u32 %r8, %r7, "), i64_to_string(dim))
+    t = str_concat(t, ", %r6;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r8, 8;\n    add.s64 %rd7, "), pdHR)
+    t = str_concat(t, ", %rd7;\n    st.global.f64 [%rd7], %fd0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $VSH;\n")
+    t
+}
+
+// thread 0: da[p] = Σ_{k,b} σ(p,k⊕p)·H[k⊕p,b]·dD[k,b], accumulated in-place into pda (f64).
+// Flat loop idx 0..dim·dim·16: p=idx>>psh, rem=idx&(dim·16−1), k=rem>>4, b=rem&15, m=k⊕p.
+fn gpu_emit_vjp_da_accum(pHR: string, pdDR: string, pdaR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    let psh = if dim == 16 { 8 } else { 7 }
+    let remmask = dim * 16 - 1
+    // zero da[0..dim]
+    var t = "    mov.f64 %fd0, 0d0000000000000000;\n    mov.u32 %r5, 0;\n$VDAZ:\n"
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r5, 8;\n    add.s64 %rd7, "), pdaR)
+    t = str_concat(t, ", %rd7;\n    st.global.f64 [%rd7], %fd0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim))
+    t = str_concat(t, ";\n    @%p1 bra $VDAZ;\n")
+    // accumulate
+    t = str_concat(t, "    mov.u32 %r5, 0;\n$VDA:\n")
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(psh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r10, %r5, "), i64_to_string(remmask))
+    t = str_concat(t, ";\n    shr.u32 %r8, %r10, 4;\n    and.b32 %r9, %r10, 15;\n")
+    t = str_concat(t, "    xor.b32 %r7, %r8, %r6;\n")
+    // H[b*dim+m]
+    t = str_concat(str_concat(t, "    mad.lo.u32 %r10, %r9, "), i64_to_string(dim))
+    t = str_concat(str_concat(t, ", %r7;\n    mul.wide.u32 %rd7, %r10, 8;\n    add.s64 %rd7, "), pHR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    // dD[k*16+b]
+    t = str_concat(t, "    mad.lo.u32 %r10, %r8, 16, %r9;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r10, 8;\n    add.s64 %rd7, "), pdDR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd1, [%rd7];\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")
+    // sign absgn[p*dim+m]
+    t = str_concat(str_concat(t, "    mad.lo.u32 %r10, %r6, "), i64_to_string(dim))
+    t = str_concat(t, ", %r7;\n    mul.wide.u32 %rd7, %r10, 4;\n")
+    t = str_concat(t, "    mov.u64 %rd6, ossm_absgn;\n    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n    cvt.f64.f32 %fd1, %f0;\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")
+    // da[p] +=
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r6, 8;\n    add.s64 %rd7, "), pdaR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd1, [%rd7];\n")
+    t = str_concat(t, "    add.f64 %fd1, %fd1, %fd0;\n    st.global.f64 [%rd7], %fd1;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $VDA;\n")
+    t
+}
+
 // Build L(m) (row-major f16, σ(k⊕j,j,bits)·m[k⊕j], dim×dim in the 16×16 tile) into sL[shared_array]
 // from the f64 pointer mR, via a RUNTIME loop reading the ossm_Lsgn sign table (so the sedenion
 // dim=16 build — 256 entries — stays under the 64 KB PtxBuf). `tag` makes the loop label unique.
@@ -732,6 +865,29 @@ fn gpu_assoc_dim(kernel: GpuKernelIr) -> i64 {
     var i: i64 = 0
     while i < kernel.op_count {
         if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctAssoc {
+            if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
+            return 8
+        }
+        i = i + 1
+    }
+    8
+}
+
+// Does this kernel contain the VJP/backward op?
+fn gpu_has_oct_vjp(kernel: GpuKernelIr) -> bool {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctVjp { return true }
+        i = i + 1
+    }
+    false
+}
+
+// The dim of the VJP op (8 octonion / 16 sedenion), for the module-scope sign tables.
+fn gpu_vjp_dim(kernel: GpuKernelIr) -> i64 {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctVjp {
             if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
             return 8
         }
@@ -1158,6 +1314,13 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
             let adim = if op.rhs_imm == 16 { 16 } else { 8 }
             let abits = if adim == 16 { 4 } else { 3 }
             ptx_push_str(buf, gpu_emit_oct_assoc(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), adim, abits))
+        }
+
+        GpuOpcode::GpuOctVjp => {
+            // VJP of D=L(a)·H. Pointers: pa=lhs, pH=rhs, pdD=addr, pdH=src, pda=shared_addr.
+            let vdim = if op.rhs_imm == 16 { 16 } else { 8 }
+            let vbits = if vdim == 16 { 4 } else { 3 }
+            ptx_push_str(buf, gpu_emit_oct_vjp(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), vdim, vbits))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/tests/gpu/oct_batch_vjp_tile.sio
+++ b/tests/gpu/oct_batch_vjp_tile.sio
@@ -1,0 +1,12 @@
+// Backward / VJP of the batched octonion multiply D = L(a)·H — ELEGANT array-of-Hyper syntax.
+// Given the upstream gradient dD, computes dH = L(a)ᵀ·dD (one transposed tensor-core tile) and
+// da[p] = Σ_{k,b} σ(p,k⊕p)·H[k⊕p,b]·dD[k,b] (runtime accumulation). This is the trainable backward
+// pass: dH is the gradient to the previous layer/timestep, da the parameter gradient of a.
+fn oct_batch_vjp(pa: &Hyper<Octonion, f64>, pH: &[Hyper<Octonion, f64>; 16],
+                 pdD: &[f64; 256], pdH: &! [f64; 256], pda: &! [f64; 16]) with GPU { }
+
+kernel fn step(pa: &Hyper<Octonion, f64>, pH: &[Hyper<Octonion, f64>; 16],
+               pdD: &[f64; 256], pdH: &! [f64; 256], pda: &! [f64; 16]) with GPU {
+    oct_batch_vjp(pa, pH, pdD, pdH, pda)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/sed_batch_vjp_tile.sio
+++ b/tests/gpu/sed_batch_vjp_tile.sio
@@ -1,0 +1,10 @@
+// Backward / VJP of the batched SEDENION multiply D = L(a)·H (dim=16, bits=4) — array-of-Hyper.
+// dH = L(a)ᵀ·dD (transposed tensor-core tile) + da[p] = Σ σ(p,k⊕p)·H·dD (runtime accumulation).
+fn sed_batch_vjp(pa: &Hyper<Sedenion, f64>, pH: &[Hyper<Sedenion, f64>; 16],
+                 pdD: &[f64; 256], pdH: &! [f64; 256], pda: &! [f64; 16]) with GPU { }
+
+kernel fn step(pa: &Hyper<Sedenion, f64>, pH: &[Hyper<Sedenion, f64>; 16],
+               pdD: &[f64; 256], pdH: &! [f64; 256], pda: &! [f64; 16]) with GPU {
+    sed_batch_vjp(pa, pH, pdD, pdH, pda)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

The **first backward pass** in the hypercomplex tensor-core lane — everything so far was forward-only; this unlocks **training** of the O-SSM. For the batched multiply `D = L(a)·H` (fixed hypercomplex `a`, 16-state batch `H`), given the upstream gradient `dD`:

```
dH[b,j] = Σ_k σ(k⊕j,j)·a[k⊕j]·dD[k,b]  =  (L(a)ᵀ·dD)[j,b]     — ONE transposed tensor-core tile
da[p]   = Σ_{k,b} σ(p,k⊕p)·H[k⊕p,b]·dD[k,b]                    — runtime f64 accumulation
```

`dH` (gradient to the previous layer/timestep) is a real m16n16k16 wmma tile with `L(a)` built **transposed** (store `(col*16+row)`) and `dD` staged col-major. `da` (gradient of the parameter `a`) is a full-f64 accumulation reusing the σ(i,j) table. Scalar-correct-first: `dH` rides the tensor core, `da` is exact f64.

```sio
kernel fn step(pa:&Hyper<Octonion,f64>, pH:&[Hyper<Octonion,f64>;16],
               pdD:&[f64;256], pdH:&![f64;256], pda:&![f64;16]) with GPU {
    oct_batch_vjp(pa, pH, pdD, pdH, pda)
}
```

## Implementation

- **kernel_ir.sio**: `GpuOctVjp` opcode (`pa,pH,pdD,pdH,pda` in `lhs/rhs/addr/src/shared_addr`; `rhs_imm=dim`).
- **hlir_to_gpu.sio**: `hlir_name_is_oct_batch_vjp` / `sed_batch_vjp` + a CALL_DIRECT arm.
- **lower_to_ptx.sio**: `gpu_has_oct_vjp` / `gpu_vjp_dim`; sm_80 header + frags; tables `ossm_Lsgn` + `ossm_absgn`; renderer `gpu_emit_oct_vjp` split into phase helpers — `gpu_emit_cell_lbuild_t` (transposed L build), `gpu_emit_vjp_dstage` (stage dD col-major), `gpu_emit_vjp_store_dh` (sS→pdH state-major f64), `gpu_emit_vjp_da_accum` (flat σ·H·dD accumulation) — small stack frames (the associator segfault lesson), short literals throughout.

## Hardware validation (DGX Spark GB10, sm_121a)

ptxas-clean; vs the analytic Jacobian transpose:

| algebra | dH (tile) | da (f64) |
|---|---|---|
| octonion | 0/128 · maxerr 0.0002 | 0/8 · maxerr 1.8e-15 |
| sedenion | 0/256 · maxerr 0.0007 | 0/16 · maxerr 3.6e-15 |

Harness `docs/gpu/run_vjp_wmma_ptx.cu`; PTX artifacts `docs/gpu/{oct,sed}_batch_vjp_tile.ptx`. Builds on the tensor-core arc #1103/#1109/#1114/#1117/#1120/#1126/#1130/#1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)