### PR TITLE
feat(native): dynamic-mmap read_file — remove the 1 MiB cap (native-v2)

### DIFF
--- a/scripts/native_read_file_dynmmap_gate.sh
+++ b/scripts/native_read_file_dynmmap_gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Gate: native-v2 read_file dynamic-mmap (codegen_x86_linux::emit_builtin_read_file).
+#
+# The old emitter mmap'd a fixed 1 MiB anon buffer per call and read up to 1 MiB, so any
+# file >= 1 MiB either truncated silently or (all-NUL-free content, full buffer) made
+# downstream str_len/str_char_at walk off the mapping and SIGSEGV. The dynamic emitter
+# fstat's the file, mmap's round_up(size + 64, page), and reads mmap_len-1 so a zero tail
+# always terminates the string. This gate proves the cap is gone.
+#
+# read_file for user programs is emitted by codegen_x86_linux (native-v2), which the
+# checked-in bin/souc (prebuilt Madaros) LAGS — it must be a current-source Madaros that
+# carries #1078 + this change. Point the gate at one:
+#   SOUNIO_TEST_SOUC_BIN=/path/to/current-source/madaros bash scripts/native_read_file_dynmmap_gate.sh
+# Dev-tier (not wired into ci.yml; the shipping prebuilt is refreshed on a separate cadence).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+if ! "$SOUC" compile tests/data_io_gated/read_file_dynmmap.sio -o "$OUT/probe.elf" >/dev/null 2>&1; then
+  echo "FAIL compile read_file_dynmmap.sio"; exit 1
+fi
+chmod +x "$OUT/probe.elf"
+
+# name:bytes:expected-sentinel
+for case in "empty:0:CAP_SMALL" "100KiB:102400:CAP_SMALL" "2MiB:2097152:CAP_2M_OK" "20MiB:20971520:CAP_GE_20M"; do
+  name="${case%%:*}"; rest="${case#*:}"; bytes="${rest%%:*}"; want="${rest##*:}"
+  head -c "$bytes" /dev/zero | tr '\0' 'A' > "$OUT/big.dat"
+  got="$( cd "$OUT" && timeout 20 ./probe.elf 2>/dev/null || true )"
+  if [ "$got" = "$want" ]; then
+    echo "PASS $name ($bytes bytes) -> $got"
+  else
+    echo "FAIL $name ($bytes bytes) -> got '${got:-<crash/empty>}' want '$want'"; fail=1
+  fi
+done
+
+if [ "$fail" = 0 ]; then echo "NATIVE_READ_FILE_DYNMMAP_GATE_OK"; else echo "GATE FAILED"; exit 1; fi

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -3962,36 +3962,53 @@ fn emit_builtin_read_file(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
     var b = c.code
     b = emit_byte(b, 0x55)                                                       // push rbp
     b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0xe5)       // mov rbp,rsp
-    b = emit_byte(b, 0x48); b = emit_byte(b, 0x83); b = emit_byte(b, 0xec); b = emit_byte(b, 0x20)  // sub rsp,32
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x81); b = emit_byte(b, 0xec); b = emit_byte(b, 0xc0); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // sub rsp,192 (locals + 144B statbuf)
     b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xf8)  // mov [rbp-8],rdi (path)
-    // sys_mmap(NULL, 1 MiB, PROT_READ|PROT_WRITE=3, MAP_PRIVATE|MAP_ANONYMOUS=0x22, -1, 0)
-    b = emit_byte(b, 0x31); b = emit_byte(b, 0xff)                               // xor edi,edi
-    b = emit_byte(b, 0xbe); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x10); b = emit_byte(b, 0x00)  // mov esi,1048576
-    b = emit_byte(b, 0xba); b = emit_byte(b, 0x03); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov edx,3
-    b = emit_byte(b, 0x41); b = emit_byte(b, 0xba); b = emit_byte(b, 0x22); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov r10d,0x22
-    b = emit_byte(b, 0x41); b = emit_byte(b, 0xb8); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff)  // mov r8d,-1
-    b = emit_byte(b, 0x45); b = emit_byte(b, 0x31); b = emit_byte(b, 0xc9)       // xor r9d,r9d
-    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x09); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,9 (mmap)
-    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
-    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xf0)  // mov [rbp-16],rax (buf ptr)
     // sys_open(path, O_RDONLY=0, 0)
     b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xf8)  // mov rdi,[rbp-8]
     b = emit_byte(b, 0xb8); b = emit_byte(b, 0x02); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,2 (open)
     b = emit_byte(b, 0x31); b = emit_byte(b, 0xf6)                               // xor esi,esi
     b = emit_byte(b, 0x31); b = emit_byte(b, 0xd2)                               // xor edx,edx
     b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
-    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xe8)  // mov [rbp-24],rax (fd)
-    // sys_read(fd, buf, 1 MiB)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xf0)  // mov [rbp-16],rax (fd)
+    // zero-init st_size slot [rbp-144] (guards fstat-fail / procfs size-0)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0xc7); b = emit_byte(b, 0x85); b = emit_byte(b, 0x70); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov qword [rbp-144],0
+    // sys_fstat(fd, statbuf @ rbp-192) -> st_size at [rbp-144]
     b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0xc7)       // mov rdi,rax (fd)
-    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x75); b = emit_byte(b, 0xf0)  // mov rsi,[rbp-16] (buf)
-    b = emit_byte(b, 0xba); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x10); b = emit_byte(b, 0x00)  // mov edx,1048576
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8d); b = emit_byte(b, 0xb5); b = emit_byte(b, 0x40); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff)  // lea rsi,[rbp-192]
+    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x05); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,5 (fstat)
+    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
+    // size = st_size; fall back to 1 MiB if <= 0 (empty/procfs/fstat-fail)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x85); b = emit_byte(b, 0x70); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff)  // mov rax,[rbp-144]
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x85); b = emit_byte(b, 0xc0)       // test rax,rax
+    b = emit_byte(b, 0x7f); b = emit_byte(b, 0x05)                               // jg +5 (skip fallback)
+    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x10); b = emit_byte(b, 0x00)  // mov eax,0x100000 (1 MiB fallback)
+    // mmap_len = (size + 64 + 4095) & ~4095  (>=64B zero tail guarantees NUL past content)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x05); b = emit_byte(b, 0x3f); b = emit_byte(b, 0x10); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // add rax,0x103F
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x25); b = emit_byte(b, 0x00); b = emit_byte(b, 0xf0); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff)  // and rax,~0xFFF (page align)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xe0)  // mov [rbp-32],rax (mmap_len)
+    // sys_mmap(NULL, mmap_len, PROT_READ|PROT_WRITE=3, MAP_PRIVATE|MAP_ANONYMOUS=0x22, -1, 0)
+    b = emit_byte(b, 0x31); b = emit_byte(b, 0xff)                               // xor edi,edi
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x75); b = emit_byte(b, 0xe0)  // mov rsi,[rbp-32] (mmap_len)
+    b = emit_byte(b, 0xba); b = emit_byte(b, 0x03); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov edx,3
+    b = emit_byte(b, 0x41); b = emit_byte(b, 0xba); b = emit_byte(b, 0x22); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov r10d,0x22
+    b = emit_byte(b, 0x41); b = emit_byte(b, 0xb8); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff); b = emit_byte(b, 0xff)  // mov r8d,-1
+    b = emit_byte(b, 0x45); b = emit_byte(b, 0x31); b = emit_byte(b, 0xc9)       // xor r9d,r9d
+    b = emit_byte(b, 0xb8); b = emit_byte(b, 0x09); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,9 (mmap)
+    b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0x45); b = emit_byte(b, 0xe8)  // mov [rbp-24],rax (buf ptr)
+    // sys_read(fd, buf, mmap_len - 1)  -- leaves the final zero byte as NUL terminator
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xf0)  // mov rdi,[rbp-16] (fd)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x89); b = emit_byte(b, 0xc6)       // mov rsi,rax (buf)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x55); b = emit_byte(b, 0xe0)  // mov rdx,[rbp-32] (mmap_len)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0xff); b = emit_byte(b, 0xca)       // dec rdx (mmap_len-1)
     b = emit_byte(b, 0x31); b = emit_byte(b, 0xc0)                               // xor eax,eax (read)
     b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
     // sys_close(fd)
-    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xe8)  // mov rdi,[rbp-24] (fd)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x7d); b = emit_byte(b, 0xf0)  // mov rdi,[rbp-16] (fd)
     b = emit_byte(b, 0xb8); b = emit_byte(b, 0x03); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00); b = emit_byte(b, 0x00)  // mov eax,3 (close)
     b = emit_byte(b, 0x0f); b = emit_byte(b, 0x05)                               // syscall
-    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x45); b = emit_byte(b, 0xf0)  // mov rax,[rbp-16] (return buf ptr)
+    b = emit_byte(b, 0x48); b = emit_byte(b, 0x8b); b = emit_byte(b, 0x45); b = emit_byte(b, 0xe8)  // mov rax,[rbp-24] (return buf ptr)
     b = emit_byte(b, 0xc9)                                                       // leave
     b = emit_byte(b, 0xc3)                                                       // ret
     c.code = b

--- a/tests/data_io_gated/read_file_dynmmap.sio
+++ b/tests/data_io_gated/read_file_dynmmap.sio
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ expect-stdout: CAP_2M_OK
+// Dynamic-mmap read_file cap probe (native-v2 codegen_x86_linux emit_builtin_read_file).
+// Reads "big.dat" from the cwd and buckets its byte length via str_len. Under the old
+// fixed 1 MiB mmap this crashes (str_len walks off the full, NUL-free buffer) for any
+// file >= 1 MiB; under the dynamic-mmap emitter it returns the true length. The gate
+// (scripts/native_read_file_dynmmap_gate.sh) rewrites big.dat at 100 KiB / 2 MiB / 20 MiB
+// and checks the sentinel for each. 2 MiB = exactly 512*4096 — the page-boundary NUL trap.
+fn main() -> i32 with IO, Mut, Panic, Div {
+    let s = read_file("big.dat")
+    let n = str_len(s)
+    if n >= 20000000 { print("CAP_GE_20M\n") }
+    else { if n >= 16000000 { print("CAP_16M\n") }
+    else { if n >= 4000000 { print("CAP_4M\n") }
+    else { if n >= 2000000 { print("CAP_2M_OK\n") }
+    else { if n >= 1000000 { print("CAP_1M\n") }
+    else { print("CAP_SMALL\n") } } } } }
+    return 0
+}


### PR DESCRIPTION
## What

`codegen_x86_linux::emit_builtin_read_file` — the emitter for user-program `read_file` on the `bin/souc compile` / native-v2 path (the one #1078 fixed) — mmap'd a **fixed 1 MiB** anon buffer per call and read up to 1 MiB. Files ≥ 1 MiB truncated silently; a NUL-free file that filled the buffer made downstream `str_len`/`str_char_at` walk off the mapping and **SIGSEGV**.

## How

`open → fstat(fd) → mmap round_up(size + 64, page) → read mmap_len-1 → close → return buf`

- **NUL tail:** the ≥64-byte zero tail (anon zero-fill) guarantees a terminator past the content even for exact-page-multiple files — the page-boundary trap.
- **Read count `mmap_len-1`** so the final zero byte always survives (covers regular files and the procfs case in one path).
- **`size ≤ 0` fallback → 1 MiB** (empty / procfs / fstat failure; the `st_size` slot is zero-initialized before fstat).
- Linux x86-64 raw syscalls; frame grown to 192 B for the 144-byte statbuf. **Emitted bytes verified byte-exact against a reference assembler** before transcription into `emit_byte`.

## Verification

`scripts/native_read_file_dynmmap_gate.sh` + `tests/data_io_gated/read_file_dynmmap.sio`, run against a **current-source Madaros carrying #1078 + this change**:

| file | sentinel | checks |
|---|---|---|
| 100 KiB | `CAP_SMALL` | health — read_file returns a real pointer |
| 2 MiB | `CAP_2M_OK` | 2097152 = 512·4096 — the page-boundary NUL trap |
| 20 MiB | `CAP_GE_20M` | single-read completeness past the old cap |

→ `NATIVE_READ_FILE_DYNMMAP_GATE_OK`. The old fixed-1 MiB emitter could not produce these (it crashes/truncates at > 1 MiB), so the change is what enables them.

## Scope / shipping caveat

Source-only. The shipping prebuilt `bin/souc` **lags the source** (it predates #1078 too), so this reaches the shipping compiler only after the next `madaros-prebuilt-refresh` cadence — verified via a locally-built current-source Madaros, the **same terms as #1078**. Gate is dev-tier (needs a `SOUNIO_TEST_SOUC_BIN` current-source Madaros), not wired into ci.yml.