### PR TITLE
fix(madaros): align serializer with current IR shape

### DIFF
--- a/scripts/ci/madaros_serialize_shape_gate.sh
+++ b/scripts/ci/madaros_serialize_shape_gate.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Prove ir::serialize has no stale IR shape diagnostics under normal import.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MADAROS="${SOUNIO_MADAROS_SERIALIZE_SHAPE_BIN:-$ROOT_DIR/bin/madaros}"
+RAW_MADAROS="${MADAROS_RAW_BIN:-}"
+WORK="$(mktemp -d /tmp/sounio-madaros-serialize-shape.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+  echo "[madaros-serialize-shape] FAIL: $*" >&2
+  exit 1
+}
+
+count_marker() {
+  local marker="$1"
+  local log="$2"
+  grep -Fc "$marker" "$log" || true
+}
+
+[[ -x "$MADAROS" ]] || fail "Madaros wrapper is missing or not executable: $MADAROS"
+[[ -n "$RAW_MADAROS" ]] || fail 'MADAROS_RAW_BIN must name an explicit Madaros ELF'
+[[ -x "$RAW_MADAROS" ]] || fail "explicit Madaros ELF is missing or not executable: $RAW_MADAROS"
+
+SOURCE="$ROOT_DIR/tests/native-v2/soir_serialize_module_activation_witness.sio"
+LOG="$WORK/check.log"
+rc=0
+set +e
+SOUNIO_STDLIB_PATH="$ROOT_DIR/self-hosted" \
+  MADAROS_RAW_BIN="$RAW_MADAROS" \
+  "$MADAROS" check "$SOURCE" >"$LOG" 2>&1
+rc=$?
+set -e
+
+grep -Fq 'could not resolve import' "$LOG" && {
+  cat "$LOG" >&2
+  fail 'normal ir::serialize import did not resolve'
+}
+
+module_count="$(sed -n 's/^run_check_mode: about to check \([0-9][0-9]*\)$/\1/p' "$LOG")"
+[[ -n "$module_count" && "$module_count" -ge 2 ]] || {
+  cat "$LOG" >&2
+  fail "normal import did not activate a module closure (modules=${module_count:-missing})"
+}
+
+for code in E002 E016 E046 E137; do
+  count="$(count_marker "error[$code" "$LOG")"
+  [[ "$count" -eq 0 ]] || {
+    cat "$LOG" >&2
+    fail "mechanical shape diagnostic $code reappeared count=$count"
+  }
+done
+
+diagnostics="$(count_marker 'error[E' "$LOG")"
+e175="$(count_marker 'error[E175' "$LOG")"
+e177="$(count_marker 'error[E177' "$LOG")"
+compiler_sha256="$(sha256sum "$RAW_MADAROS" | awk '{print $1}')"
+
+if [[ "$rc" -eq 1 && "$diagnostics" -eq 32 && "$e175" -eq 25 && "$e177" -eq 7 ]]; then
+  echo "[madaros-serialize-shape] receipt state=visibility-blocked modules=$module_count diagnostics=$diagnostics E175=$e175 E177=$e177 compiler_sha256=$compiler_sha256"
+  exit 0
+fi
+
+if [[ "$rc" -eq 0 && "$diagnostics" -eq 0 ]] && grep -Fq 'check: OK' "$LOG"; then
+  echo "[madaros-serialize-shape] receipt state=resolved modules=$module_count diagnostics=0 compiler_sha256=$compiler_sha256"
+  exit 0
+fi
+
+cat "$LOG" >&2
+fail "unexpected diagnostic state rc=$rc diagnostics=$diagnostics E175=$e175 E177=$e177"

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -3712,7 +3712,7 @@ fn ir_phi(dst: i64) -> IrInstr {
 pub fn ir_empty_function() -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
-        instrs: [ir_nop(); 1024],
+        instrs: [ir_nop(); 2048],
         instr_count: 0,
         reg_count: 0,
         label_count: 0,

--- a/self-hosted/ir/serialize.sio
+++ b/self-hosted/ir/serialize.sio
@@ -667,6 +667,7 @@ fn deserialize_ir_function(buf: [i8; 131072], pos: i64, version: i8) -> (IrFunct
         hyper_algebra_kind: hyper_algebra_kind,
         is_sret: 0,
         sret_dest_reg: -1,
+        bss_size: 0,
     }
     (func, p)
 }
@@ -3913,7 +3914,7 @@ fn serialize_ir_epistemic_section(buf: [i8; 131072], pos: i64, ep: IrEpistemicSe
     (b, p)
 }
 
-fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64) -> (IrEpistemicSection, i64) with Mut, Panic, Div, Alloc {
+fn deserialize_ir_epistemic_section(buf: [i8; 131072], pos: i64, len: i64) -> (IrEpistemicSection, i64) with Mut, Panic, Div, Alloc {
     var p = pos
     var ep = ir_empty_epistemic_section()
 
@@ -4459,7 +4460,7 @@ fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Pani
     pos = fn_count_pair.1
 
     // Read functions
-    var functions: [IrFunction; 1024] = [ir_empty_function(); 1024]
+    var functions: [IrFunction; 2048] = [ir_empty_function(); 2048]
     var i: i64 = 0
     while i < fn_count {
         let func_pair = deserialize_ir_function(buf, pos, version)
@@ -4490,7 +4491,7 @@ fn deserialize_ir_module(buf: [i8; 131072], len: i64) -> IrModule with Mut, Pani
     module.string_count = string_count
 
     if version >= 2 && pos < len {
-        let ep_pair = deserialize_ir_epistemic_section(buf, pos)
+        let ep_pair = deserialize_ir_epistemic_section(buf, pos, len)
         module.epistemic = ep_pair.0
         pos = ep_pair.1
     }

--- a/tests/native-v2/soir_serialize_module_activation_witness.sio
+++ b/tests/native-v2/soir_serialize_module_activation_witness.sio
@@ -1,0 +1,6 @@
+use ir::serialize::*
+
+fn main() -> i64 with IO {
+    print("SOIR_SERIALIZE_MODULE_ACTIVATION_PASS\n")
+    0
+}


### PR DESCRIPTION
## What changed

- align `IrFunction` and `IrModule` deserialization with the current 2048-entry IR capacities
- initialize the current `IrFunction.bss_size` field during deserialization
- thread the existing buffer length into epistemic-section deserialization
- add a normal `use ir::serialize::*` activation witness and a focused, fail-closed shape gate

This is the mechanical prerequisite for #878. It does not change opcode handling, SOIR version semantics, transactions, visibility policy, or the R27 Arena v2 shadow path.

## Root cause

`self-hosted/ir/serialize.sio` had drifted behind the current IR aggregate shapes. A normal imported-module check therefore mixed real visibility diagnostics with stale capacity, struct-field, and undeclared-length failures.

## Evidence

Using the explicit repository ELF `fa3bcbcb5f72c6d3d851f97521f60dfd6a277ea7faff984d31a10ca377335c2e`, the same seven-module normal-import closure changes from:

```text
baseline:   diagnostics=60 E002=1 E016=1 E046=1 E137=25 E175=25 E177=7
this patch: diagnostics=32 E002=0 E016=0 E046=0 E137=0 E175=25 E177=7
```

Focused receipt:

```text
[madaros-serialize-shape] receipt state=visibility-blocked modules=7 diagnostics=32 E175=25 E177=7
```

The baseline and post-patch log SHA-256 values are `10de097a4fcd90baa96d685dadeed8b73399f0532f8f4c9ecea435668283d050` and `b0ffedac0cd45de773310e95be3171538af7533c57949fe7802eb4a69de49acc`.

## Source-fresh boundary

Slurm job `6657` rebuilt this exact head successfully on `gpuorangefs-multi-r740-proxmox`:

```text
commit=4037a8f3cfce7a8b89ed4ac19a19f0c97c3691ae
tree_before=863616ad4273c1959e37eb7ffd7f1e29726f20c9
tree_after=863616ad4273c1959e37eb7ffd7f1e29726f20c9
build_rc=0 build_errors=0
elf_bytes=98979299
elf_sha256=69b29ff025779019520f55a822eab91831fe2a10816d51e50f9cd602ddb8f0e2
```

The source-fresh gate is **BLOCKED**, not green: that ELF stops during raw AST closure construction with `AST closure incomplete nodes=7`, before the visibility checker runs. Minimal probes isolate the independent current-source parser defect to a public method inside an `impl`; private impl methods and public top-level functions parse. Consequently, the expected 32 visibility diagnostics were not observed with the fresh ELF and are not claimed as source-fresh evidence.

This dependency already has an active isolated lane with a focused `parser_public_impl_method.sio` witness. The shape gate must be rerun with a fresh ELF after that parser repair lands.

## Checks

- `bash -n scripts/ci/madaros_serialize_shape_gate.sh`
- `git diff --check`
- focused gate with an explicit repository ELF: pass in `state=visibility-blocked`
- gate without `MADAROS_RAW_BIN`: fails closed
- `founder_intent_contract_gate.sh`: pass
- Slurm exact-tree source build: pass
- Slurm source-fresh normal-import gate: blocked before checker by the independent public-impl parser defect

This PR does not resolve #878. It removes only the serializer shape drift needed before unknown-opcode rejection and transactional owner preservation can be implemented honestly.
