### PR TITLE
feat(stdlib): Arrow/ecosystem interop bridge — bit-exact DataFrame → Python (C4)

### DIFF
--- a/scripts/arrow_bridge_gate.sh
+++ b/scripts/arrow_bridge_gate.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Campaign C4 -- SIO1 Arrow-bridge round-trip gate.
+#
+# Proves real Sounio -> Python interop end to end:
+#   1. compile + RUN the Sounio driver, which builds a known 3x5 DataFrame and
+#      writes it to a SIO1 binary file; the driver also prints each cell's exact
+#      IEEE-754 i64 bit pattern (via f64_to_bits).
+#   2. run the Python bridge, which reads the SAME file back and prints each
+#      cell's bits (struct.unpack '<q') plus the reconstructed float.
+#   3. assert BIT-EXACT equality of every cell between the two sides.
+#
+# Exit 0 only if the round trip is lossless for every cell.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export SOUNIO_STDLIB_PATH="$PWD/stdlib"
+ENGINE="${SOUNIO_SOUC_ENGINE:-lean_single}"
+SOUC="${SOUC:-./bin/souc}"
+
+DRIVER_SRC="tests/interop/arrow_bridge_driver.sio"
+BRIDGE_PY="scripts/research/arrow_bridge_bridge.py"
+SIO1_FILE="/tmp/arrow_bridge.sio1"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+DRIVER_BIN="$WORK/arrow_driver"
+DRIVER_OUT="$WORK/driver_stdout.txt"
+PY_OUT="$WORK/py_cells.txt"
+
+echo "== [1/4] compile Sounio driver ($ENGINE) =="
+SOUNIO_SOUC_ENGINE="$ENGINE" "$SOUC" compile "$DRIVER_SRC" -o "$DRIVER_BIN" >/dev/null
+chmod +x "$DRIVER_BIN"
+
+echo "== [2/4] run driver (writes $SIO1_FILE) =="
+rm -f "$SIO1_FILE"
+"$DRIVER_BIN" > "$DRIVER_OUT"
+cat "$DRIVER_OUT"
+test -f "$SIO1_FILE" || { echo "FAIL: driver did not write $SIO1_FILE"; exit 1; }
+
+echo "== [3/4] Python bridge dump =="
+python3 "$BRIDGE_PY" "$SIO1_FILE"
+python3 "$BRIDGE_PY" "$SIO1_FILE" --cells > "$PY_OUT"
+
+echo "== [4/4] bit-exact cross-check (Sounio CELL vs Python PYCELL) =="
+python3 - "$DRIVER_OUT" "$PY_OUT" <<'PYEOF'
+import sys
+
+driver_path, py_path = sys.argv[1], sys.argv[2]
+
+# Parse the Sounio driver stdout. Integer printing inserts newlines, so we
+# tokenize the whole stream on whitespace and walk it: after a "CELL" token
+# come col, row, bits.
+toks = open(driver_path).read().split()
+driver = {}
+i = 0
+while i < len(toks):
+    if toks[i] == "CELL":
+        col = int(toks[i + 1]); row = int(toks[i + 2]); bits = int(toks[i + 3])
+        driver[(col, row)] = bits
+        i += 4
+    else:
+        i += 1
+
+# Parse the Python PYCELL lines: PYCELL <col> <row> <bits> <float>
+py = {}
+for line in open(py_path):
+    p = line.split()
+    if p and p[0] == "PYCELL":
+        col = int(p[1]); row = int(p[2]); bits = int(p[3])
+        py[(col, row)] = bits
+
+if not driver:
+    print("FAIL: no CELL records parsed from driver output"); sys.exit(1)
+
+if driver.keys() != py.keys():
+    print("FAIL: cell-set mismatch")
+    print("  driver-only:", sorted(driver.keys() - py.keys()))
+    print("  python-only:", sorted(py.keys() - driver.keys()))
+    sys.exit(1)
+
+mism = [(k, driver[k], py[k]) for k in driver if driver[k] != py[k]]
+if mism:
+    print("FAIL: %d cell(s) differ in exact bits:" % len(mism))
+    for k, d, p in mism:
+        print("  cell %s: driver=%d python=%d" % (k, d, p))
+    sys.exit(1)
+
+print("OK: %d cells round-tripped BIT-EXACT (Sounio f64_to_bits == Python struct '<q')"
+      % len(driver))
+PYEOF
+
+echo
+echo "GATE PASS: SIO1 Sounio->Python round trip is lossless."

--- a/scripts/research/arrow_bridge_bridge.py
+++ b/scripts/research/arrow_bridge_bridge.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""SIO1 -> pyarrow.Table (or numpy / struct) reader -- Campaign C4 Arrow bridge.
+
+Reads the flat little-endian columnar binary emitted by
+`data::arrow_bridge::df_write_sio1` (stdlib/data/arrow_bridge.sio) and
+reconstructs the DataFrame's columns.
+
+Graceful degradation (this sandbox has neither pyarrow nor numpy):
+  - pyarrow present -> build a pyarrow.Table, one field per column.
+  - else numpy present -> np.frombuffer(col_bytes, dtype='<f8' | '<i8').
+  - else -> struct.unpack('<{n}d' | '<{n}q', col_bytes).
+
+SIO1 layout (all little-endian):
+  [0..4)   magic "SIO1"
+  [4..8)   version i32
+  [8..16)  n_rows i64
+  [16..24) n_cols i64
+  next 8*ncols  col name_ids  i64[]
+  next 8*ncols  dtype tags    i64[]  (0 = f64, 1 = i64)
+  next 8*nrows*ncols  column-major data i64/f64 bits
+
+Usage:
+  arrow_bridge_bridge.py <file.sio1>          # human-readable dump
+  arrow_bridge_bridge.py <file.sio1> --cells  # machine-readable PYCELL lines
+                                              # + raw i64 bits for the
+                                              # bit-exact gate cross-check.
+"""
+import struct
+import sys
+
+MAGIC = b"SIO1"
+
+try:
+    import numpy as _np
+except Exception:
+    _np = None
+
+try:
+    import pyarrow as _pa
+except Exception:
+    _pa = None
+
+
+def read_sio1(path):
+    """Parse a SIO1 file. Returns (meta, columns, bits_by_col).
+
+    meta = dict(version, n_rows, n_cols, name_ids, dtypes)
+    columns = list of per-column sequences (numpy arrays, or tuples for the
+    pure-struct fallback). bits_by_col holds the raw per-cell i64 bit patterns
+    for the exact gate check.
+    """
+    with open(path, "rb") as fh:
+        data = fh.read()
+
+    if data[0:4] != MAGIC:
+        raise ValueError("bad magic: %r (expected %r)" % (data[0:4], MAGIC))
+
+    (version,) = struct.unpack_from("<i", data, 4)
+    (n_rows,) = struct.unpack_from("<q", data, 8)
+    (n_cols,) = struct.unpack_from("<q", data, 16)
+
+    off = 24
+    name_ids = list(struct.unpack_from("<%dq" % n_cols, data, off)) if n_cols else []
+    off += 8 * n_cols
+    dtypes = list(struct.unpack_from("<%dq" % n_cols, data, off)) if n_cols else []
+    off += 8 * n_cols
+
+    columns = []
+    bits_by_col = []  # raw i64 bit patterns, exactly as Sounio wrote them
+    for c in range(n_cols):
+        span = data[off : off + 8 * n_rows]
+        off += 8 * n_rows
+        tag = dtypes[c] if c < len(dtypes) else 0
+        fmt_bits = "<%dq" % n_rows
+        bits = list(struct.unpack(fmt_bits, span)) if n_rows else []
+        bits_by_col.append(bits)
+
+        if tag == 1:
+            # int64 column
+            if _np is not None:
+                col = _np.frombuffer(span, dtype="<i8")
+            else:
+                col = struct.unpack("<%dq" % n_rows, span) if n_rows else ()
+        else:
+            # f64 column (v1 default)
+            if _np is not None:
+                col = _np.frombuffer(span, dtype="<f8")
+            else:
+                col = struct.unpack("<%dd" % n_rows, span) if n_rows else ()
+        columns.append(col)
+
+    meta = dict(
+        version=version,
+        n_rows=n_rows,
+        n_cols=n_cols,
+        name_ids=name_ids,
+        dtypes=dtypes,
+    )
+    return meta, columns, bits_by_col
+
+
+def to_arrow_table(meta, columns):
+    """Build a pyarrow.Table if pyarrow is available, else return None."""
+    if _pa is None:
+        return None
+    fields = {}
+    for i in range(meta["n_cols"]):
+        col = columns[i]
+        fields["col_%d" % i] = _pa.array(list(col))
+    return _pa.table(fields)
+
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: arrow_bridge_bridge.py <file.sio1> [--cells]", file=sys.stderr)
+        return 2
+    path = argv[1]
+    cells_mode = "--cells" in argv[2:]
+
+    meta, columns, bits_by_col = read_sio1(path)
+
+    if cells_mode:
+        # Machine-readable form the gate parses. One line per cell, in
+        # column-major order, matching the Sounio driver's CELL lines.
+        print("PYMETA n_rows=%d n_cols=%d version=%d"
+              % (meta["n_rows"], meta["n_cols"], meta["version"]))
+        print("PYNAMES " + " ".join(str(x) for x in meta["name_ids"]))
+        print("PYDTYPES " + " ".join(str(x) for x in meta["dtypes"]))
+        for c in range(meta["n_cols"]):
+            for r in range(meta["n_rows"]):
+                val = columns[c][r]
+                bits = bits_by_col[c][r]
+                # PYCELL <col> <row> <exact-i64-bits> <reconstructed-float>
+                print("PYCELL %d %d %d %r" % (c, r, bits, float(val)))
+        return 0
+
+    # Human-readable dump.
+    backend = "pyarrow" if _pa else ("numpy" if _np else "struct")
+    print("SIO1 file: %s" % path)
+    print("backend  : %s" % backend)
+    print("version  : %d" % meta["version"])
+    print("n_rows   : %d" % meta["n_rows"])
+    print("n_cols   : %d" % meta["n_cols"])
+    print("name_ids : %s" % meta["name_ids"])
+    print("dtypes   : %s  (0=f64, 1=i64)" % meta["dtypes"])
+
+    table = to_arrow_table(meta, columns)
+    if table is not None:
+        print("--- pyarrow.Table ---")
+        print(table)
+    else:
+        print("--- columns (%s reconstruction) ---" % backend)
+        for i in range(meta["n_cols"]):
+            vals = list(columns[i])
+            print("col_%d (name_id=%s): %s"
+                  % (i, meta["name_ids"][i] if i < len(meta["name_ids"]) else "?", vals))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/stdlib/data/arrow_bridge.sio
+++ b/stdlib/data/arrow_bridge.sio
@@ -1,0 +1,99 @@
+//! Sounio -> Python/Arrow interop bridge (Campaign C4, first step).
+//!
+//! Exports a `data::dataframe::DataFrame` to a flat little-endian columnar
+//! binary file ("SIO1" format) that the companion Python reader
+//! (scripts/research/arrow_bridge_bridge.py) parses into a pyarrow.Table
+//! (or a numpy / struct reconstruction when pyarrow/numpy are absent).
+//!
+//! EXACTNESS: every f64 cell is emitted losslessly via the `f64_to_bits`
+//! compiler intrinsic (pure IEEE-754 reinterpret) followed by an explicit
+//! 8-iteration little-endian byte-split into an [i8; N] buffer written with
+//! the `write_file` builtin. This is a bit-exact round trip -- verified end
+//! to end (compile + run + Python readback asserting exact float equality).
+//!
+//! SCOPE (v1): write-only from Sounio's side (there is no reverse
+//! bits->f64 intrinsic in the compiler today, and the DataFrame stores only
+//! f64), single flat file, all columns dtype f64 (tag 0). The dtype tag and
+//! i64 name-id table are emitted so a later integer fast-path and a real
+//! string table can be added without breaking the header layout.
+//!
+//! SIO1 layout (all little-endian):
+//!   [0..4)   magic  = "SIO1" (bytes 0x53 0x49 0x4F 0x31)
+//!   [4..8)   version i32 = 1
+//!   [8..16)  n_rows i64
+//!   [16..24) n_cols i64
+//!   [24 .. 24 + 8*ncols)                 col name_ids i64[] (df_get_col_name)
+//!   [.. + 8*ncols)                       dtype tag per col i64 (0 = f64)
+//!   [.. + 8*nrows*ncols)                 column-major f64 bits i64[]
+//!                                        (full column of nrows before next)
+
+use data::dataframe::{DataFrame, df_get, df_nrows, df_ncols, df_get_col_name}
+
+// Max SIO1 buffer: 24-byte header + 8*64 name-ids + 8*64 dtype tags +
+// 8*1024*64 data cells = 525336 bytes. Matches DataFrame's 64x1024 cap.
+fn sio1_max_bytes() -> i64 { 525336 }
+
+// Write an i64 as 8 little-endian bytes into buf starting at `off`.
+// Returns the next free offset (off + 8).
+fn put_i64_le(buf: &![i8; 525336], off: i64, val: i64) -> i64 with Mut, Panic {
+    var i: i64 = 0
+    while i < 8 {
+        buf[off + i] = ((val >> (i * 8)) & 0xFF) as i8
+        i = i + 1
+    }
+    return off + 8
+}
+
+/// Serialize `df` to `path` in SIO1 columnar binary format.
+/// Returns the number of bytes written (>= 0 on success, < 0 on I/O error).
+pub fn df_write_sio1(df: &DataFrame, path: string) -> i64 with Mut, Panic, IO, Div {
+    let nrows = df_nrows(df)
+    let ncols = df_ncols(df)
+
+    var buf: [i8; 525336] = [0; 525336]
+
+    // --- Header ---
+    // magic "SIO1"
+    buf[0] = 0x53 as i8   // 'S'
+    buf[1] = 0x49 as i8   // 'I'
+    buf[2] = 0x4F as i8   // 'O'
+    buf[3] = 0x31 as i8   // '1'
+    // version i32 = 1 (little-endian, 4 bytes)
+    buf[4] = 1 as i8
+    buf[5] = 0 as i8
+    buf[6] = 0 as i8
+    buf[7] = 0 as i8
+
+    var off: i64 = 8
+    off = put_i64_le(&!buf, off, nrows)   // [8..16)
+    off = put_i64_le(&!buf, off, ncols)   // [16..24)
+
+    // --- Column name IDs (i64 each) ---
+    var c: i64 = 0
+    while c < ncols {
+        off = put_i64_le(&!buf, off, df_get_col_name(df, c))
+        c = c + 1
+    }
+
+    // --- Column dtype tags (0 = f64; DataFrame stores f64 only) ---
+    c = 0
+    while c < ncols {
+        off = put_i64_le(&!buf, off, 0)
+        c = c + 1
+    }
+
+    // --- Column-major data: bit-exact f64 -> i64 bits, LE ---
+    c = 0
+    while c < ncols {
+        var r: i64 = 0
+        while r < nrows {
+            let bits = f64_to_bits(df_get(df, r, c))
+            off = put_i64_le(&!buf, off, bits)
+            r = r + 1
+        }
+        c = c + 1
+    }
+
+    // `off` is now the exact total byte length.
+    return write_file(path, buf, off)
+}

--- a/tests/interop/arrow_bridge_driver.sio
+++ b/tests/interop/arrow_bridge_driver.sio
@@ -1,0 +1,82 @@
+// Run-proof driver for the SIO1 Arrow bridge (Campaign C4).
+//
+// Builds a known 3-column x 5-row DataFrame, assigns column name IDs, writes
+// it to disk via df_write_sio1, and prints the ORIGINAL cell values so the
+// gate can cross-check them against the Python-side readback of the same file.
+//
+// Output path is /tmp/arrow_bridge.sio1.
+
+use data::dataframe::{DataFrame, df_new, df_add_row, df_set_col_name, df_get, df_nrows, df_ncols}
+use data::arrow_bridge::{df_write_sio1}
+
+fn main() with IO, Mut, Div, Panic {
+    var df = df_new(3)
+
+    // Column name IDs (arbitrary i64 tags; the Python side just echoes them).
+    df_set_col_name(&!df, 0, 100)
+    df_set_col_name(&!df, 1, 200)
+    df_set_col_name(&!df, 2, 300)
+
+    // Five rows of known, distinctive f64 values (negatives, fractions, large).
+    var r0: [f64; 64] = [0.0; 64]
+    r0[0] = 3.14159265358979
+    r0[1] = -2.5
+    r0[2] = 1000000.0
+    df_add_row(&!df, &r0)
+
+    var r1: [f64; 64] = [0.0; 64]
+    r1[0] = 0.0
+    r1[1] = 42.0
+    r1[2] = -0.001953125
+    df_add_row(&!df, &r1)
+
+    var r2: [f64; 64] = [0.0; 64]
+    r2[0] = 2.718281828459045
+    r2[1] = 6.022e23
+    r2[2] = -123456.789
+    df_add_row(&!df, &r2)
+
+    var r3: [f64; 64] = [0.0; 64]
+    r3[0] = -1.0
+    r3[1] = 0.333333333333333
+    r3[2] = 9.87654321
+    df_add_row(&!df, &r3)
+
+    var r4: [f64; 64] = [0.0; 64]
+    r4[0] = 1.7976931348623157e308
+    r4[1] = -5.0e-300
+    r4[2] = 100.5
+    df_add_row(&!df, &r4)
+
+    let path = "/tmp/arrow_bridge.sio1"
+    let n = df_write_sio1(&df, path)
+
+    // Emit a machine-readable manifest the gate parses and compares to Python.
+    println("SIO1_WRITE_OK")
+    print("bytes=")
+    println(n)
+    print("nrows=")
+    println(df_nrows(&df))
+    print("ncols=")
+    println(df_ncols(&df))
+
+    // Print every ORIGINAL cell in column-major order as
+    //   "CELL <col> <row> <exact-i64-bits>"
+    // The exact IEEE-754 bit pattern (via f64_to_bits) lets the gate assert
+    // BIT-EXACT equality against Python's struct.unpack('<q', cell_bytes),
+    // sidestepping any lossy float text formatting on either side.
+    var c: i64 = 0
+    while c < df_ncols(&df) {
+        var row: i64 = 0
+        while row < df_nrows(&df) {
+            print("CELL ")
+            print(c)
+            print(" ")
+            print(row)
+            print(" ")
+            println(f64_to_bits(df_get(&df, row, c)))
+            row = row + 1
+        }
+        c = c + 1
+    }
+}


### PR DESCRIPTION
## First step toward ecosystem parity (roadmap C4)

The roadmap's C4 says: don't rebuild the PyData universe — **bridge into it**. This is the first concrete step, and it's **bit-exact**.

The research phase discovered Sounio has an `f64_to_bits(x) -> i64` IEEE-754 reinterpret **intrinsic** (verified: `f64_to_bits(3.14159265358979) = 4614256656552045841`, identical to CPython `struct.pack('<d')`). So real binary f64 export works. `data::arrow_bridge` serializes a DataFrame to a flat little-endian columnar binary (`SIO1`) via `write_file([i8;N])`, and a Python bridge reads it into a **`pyarrow.Table`** (numpy/struct fallback when pyarrow is absent).

```
SIO1 layout: "SIO1" | version i32 | n_rows i64 | n_cols i64
             | name_ids i64[ncols] | dtype tags i64[ncols] | column-major f64 buffers
```

### Verification
- `scripts/arrow_bridge_gate.sh` → **"15 cells round-tripped BIT-EXACT ... GATE PASS"**. Builds a 3×5 frame in Sounio, writes SIO1 (192 bytes, exactly as the layout predicts), reads it back in Python, cross-checks every cell (`Sounio f64_to_bits == Python struct '<q'`).

### Honest scope
- Bit-exact for the f64 the program **holds at runtime**. Separate finding (flagged for follow-up): Sounio's **decimal-literal→double** front-end parser picks a slightly different double than CPython for some literals (~6 ULP on the DBL_MAX literal) — that's upstream of this bridge, not a round-trip loss.
- Full **Arrow IPC** (flatbuffers Schema + RecordBatch framing) is the next step; `SIO1` is the minimal viable interchange that already bridges to pyarrow.

Built via a model-routed worktree subagent (deep-research → build). No compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)