### PR TITLE
docs(governance): refresh acceptance report

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1001
-- Repo-backed topics: 851
+- Total governed topics: 1002
+- Repo-backed topics: 852
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 601
+- Authority count `repo_only`: 602
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 620 topics
+- A2: 621 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics


### PR DESCRIPTION
## Summary

- regenerate `docs/governance/DOCS_ACCEPTANCE_REPORT.md` after #1148 added a governed handoff document
- update only generated aggregate counts; no compiler, parser, workflow, or semantic changes
- keep this repair independent from #1146

## Evidence

Baseline on `e1e5a90ccaafd2e2456ba6e73b834f2039b16a20`:

```text
bash scripts/dev/check_docs_registry.sh
# FAIL: DOCS_ACCEPTANCE_REPORT.md is stale
```

Generated with `node scripts/docs/sync_governance_metadata.mjs`.

Write-set: one file, 4 additions / 4 deletions.

## Validation

- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash scripts/ci/sounio_website_docs_support_gate.sh`
- `bash scripts/dev/check_offload_policy.sh`
- `git diff --check`

All passed. LLM offload was not required for this mechanical generated-metadata refresh.