### PR TITLE
fix(parser): accept public impl methods

### DIFF
--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -907,20 +907,29 @@ impl Parser {
             }
 
             if parser_peek(p) != TokenKind::RBrace && parser_peek(p) != TokenKind::Eof {
+                var method_visibility = visibility_private()
+                if parser_peek(p) == TokenKind::Pub {
+                    let visibility_pair = p.parse_pub_visibility()
+                    p = visibility_pair.0
+                    method_visibility = visibility_pair.1
+                }
+
                 if parser_peek(p) == TokenKind::Fn {
                     // First arg is `visibility: Visibility` (a struct), NOT a bool. Passing
                     // `false` here was an ABI mismatch (bool bits read as a Visibility) that
                     // corrupted the call and SIGSEGV'd on every impl method; it built only
                     // because the type error is a non-fatal warning. Methods default private.
-                    let pair2 = p.parse_fn_item(visibility_private(), false)
+                    let pair2 = p.parse_fn_item(method_visibility, false)
                     p = pair2.0
                     let method = pair2.1
                     rev_methods_opt = Some(Box::new(ItemList { head: method, tail: rev_methods_opt }))
                 } else {
-                    // Recovery: consume one unexpected token inside impl body.
+                    // Record unexpected input, but preserve the impl boundary after incomplete visibility.
                     p.had_error = true
                     p.error_count = p.error_count + 1
-                    p = p.advance()
+                    if parser_peek(p) != TokenKind::RBrace && parser_peek(p) != TokenKind::Eof {
+                        p = p.advance()
+                    }
                 }
             }
         }

--- a/self-hosted/test_parser.sio
+++ b/self-hosted/test_parser.sio
@@ -390,6 +390,45 @@ fn second_item_kind(prog: Program) -> ItemKind with Alloc {
     }
 }
 
+fn method_tail_is_empty(tail: Option<Box<ItemList>>) -> bool with Alloc {
+    match tail {
+        Some(_) => false,
+        None => true,
+    }
+}
+
+fn method_tail_is_single_private(tail: Option<Box<ItemList>>) -> bool with Alloc {
+    match tail {
+        Some(rest) => !visibility_to_bool((*rest).head.visibility) && method_tail_is_empty((*rest).tail),
+        None => false,
+    }
+}
+
+fn method_list_is_public_then_private(methods: ItemList) -> bool with Alloc {
+    visibility_is_pub(methods.head.visibility) && method_tail_is_single_private(methods.tail)
+}
+
+fn impl_def_methods_are_public_then_private(impl_def: ImplDef) -> bool with Alloc {
+    match impl_def.methods {
+        Some(methods) => method_list_is_public_then_private(*methods),
+        None => false,
+    }
+}
+
+fn item_methods_are_public_then_private(item: Item) -> bool with Alloc {
+    match item.impl_def {
+        Some(impl_def) => impl_def_methods_are_public_then_private(*impl_def),
+        None => false,
+    }
+}
+
+fn first_impl_methods_are_public_then_private(prog: Program) -> bool with Alloc {
+    match prog.items {
+        Some(items) => item_methods_are_public_then_private((*items).head),
+        None => false,
+    }
+}
+
 fn first_fn_has_ret(prog: Program) -> bool with Alloc {
     match prog.items {
         Some(list) => fndef_opt_has_ret((*list).head.fn_def),
@@ -963,6 +1002,75 @@ fn test_card_a_raw_pointer_types() -> bool with Mut, IO, Panic, Div, Alloc {
     parser_last_error_count() == 0
 }
 
+// T17: impl S { pub fn a() {} fn b() {} } preserves method visibility in the AST.
+fn test_impl_method_visibility() -> bool with Mut, IO, Panic, Div, Alloc {
+    var input: [i8; 256] = [0; 256]
+    input[0] = 105 as i8  // i
+    input[1] = 109 as i8  // m
+    input[2] = 112 as i8  // p
+    input[3] = 108 as i8  // l
+    input[4] = 32 as i8
+    input[5] = 83 as i8   // S
+    input[6] = 123 as i8  // {
+    input[7] = 112 as i8  // p
+    input[8] = 117 as i8  // u
+    input[9] = 98 as i8   // b
+    input[10] = 32 as i8
+    input[11] = 102 as i8 // f
+    input[12] = 110 as i8 // n
+    input[13] = 32 as i8
+    input[14] = 97 as i8  // a
+    input[15] = 40 as i8  // (
+    input[16] = 41 as i8  // )
+    input[17] = 123 as i8 // {
+    input[18] = 125 as i8 // }
+    input[19] = 102 as i8 // f
+    input[20] = 110 as i8 // n
+    input[21] = 32 as i8
+    input[22] = 98 as i8  // b
+    input[23] = 40 as i8  // (
+    input[24] = 41 as i8  // )
+    input[25] = 123 as i8 // {
+    input[26] = 125 as i8 // }
+    input[27] = 125 as i8 // }
+
+    let prog = parse_program_from_ascii(input, 28)
+    count_items(prog) == 1 &&
+    first_item_kind(prog) == ItemKind::ItemImpl &&
+    parser_last_error_count() == 0 &&
+    first_impl_methods_are_public_then_private(prog)
+}
+
+// T18: an incomplete pub method must not consume the impl's closing brace.
+fn test_incomplete_pub_impl_recovers_next_fn() -> bool with Mut, IO, Panic, Div, Alloc {
+    var input: [i8; 256] = [0; 256]
+    input[0] = 105 as i8  // i
+    input[1] = 109 as i8  // m
+    input[2] = 112 as i8  // p
+    input[3] = 108 as i8  // l
+    input[4] = 32 as i8
+    input[5] = 83 as i8   // S
+    input[6] = 123 as i8  // {
+    input[7] = 112 as i8  // p
+    input[8] = 117 as i8  // u
+    input[9] = 98 as i8   // b
+    input[10] = 125 as i8 // }
+    input[11] = 102 as i8 // f
+    input[12] = 110 as i8 // n
+    input[13] = 32 as i8
+    input[14] = 102 as i8 // f
+    input[15] = 40 as i8  // (
+    input[16] = 41 as i8  // )
+    input[17] = 123 as i8 // {
+    input[18] = 125 as i8 // }
+
+    let prog = parse_program_from_ascii(input, 19)
+    count_items(prog) == 2 &&
+    first_item_kind(prog) == ItemKind::ItemImpl &&
+    second_item_kind(prog) == ItemKind::ItemFn &&
+    parser_last_error_count() == 1
+}
+
 // ============================================================================
 // TEST RUNNER
 // ============================================================================
@@ -1018,6 +1126,12 @@ fn run_parser_tests() -> i32 with IO, Mut, Panic, Div, Alloc {
 
     total = total + 1
     if test_card_a_raw_pointer_types() { passed = passed + 1 } else { print("FAIL: T16 card_a_raw_pointer_types\n") }
+
+    total = total + 1
+    if test_impl_method_visibility() { passed = passed + 1 } else { print("FAIL: T17 impl_method_visibility\n") }
+
+    total = total + 1
+    if test_incomplete_pub_impl_recovers_next_fn() { passed = passed + 1 } else { print("FAIL: T18 incomplete_pub_impl_recovers_next_fn\n") }
 
     if passed == total {
         print("ALL PARSER TESTS PASSED\n")

--- a/tests/run-pass/parser_public_impl_method.sio
+++ b/tests/run-pass/parser_public_impl_method.sio
@@ -1,0 +1,17 @@
+//@ run-pass
+//@ check-only
+//@ description: Public associated methods inside impl blocks must parse and typecheck.
+
+struct PublicImplMethod {
+    value: i64,
+}
+
+impl PublicImplMethod {
+    pub fn zero() -> PublicImplMethod {
+        PublicImplMethod { value: 0 }
+    }
+}
+
+fn main() -> i64 {
+    0
+}


### PR DESCRIPTION
## Description

Accept an optional visibility modifier before methods inside `impl` blocks by routing it through the parser's existing `parse_pub_visibility()` path. Methods still default to private.

The recovery path now preserves `RBrace` and EOF after an incomplete visibility modifier, so malformed `impl S { pub }` input cannot consume the impl boundary or swallow the following top-level item.

The parser harness adds two structural witnesses:

- T17 requires exactly `Pub -> Private -> end` for two adjacent methods.
- T18 requires `impl S { pub } fn f() {}` to retain `ItemImpl`, retain the following `ItemFn`, and record exactly one parser error.

A normal run-pass witness covers public associated-method parsing and checking.

## Type of Change

- [x] Bug fix (non-breaking change that fixes a compiler or runtime bug)
- [ ] New feature (non-breaking change that adds a language or stdlib capability)
- [ ] Breaking change (fix or feature that would cause existing Sounio code to fail compilation)
- [ ] Refactoring (internal compiler or website optimization, no functional changes)
- [ ] Documentation update (translations, expansions, or spec syncs)
- [x] Test improvement (adding compile-fail gates or golden snapshot validations)
- [ ] Performance improvement (reduction of bootstrap build time or codegen optimization)

## Related Issues

Related to #878. This is a parser prerequisite and does not close the SOIR v5 decoder issue.

## Traceability

- Traceability Matrix ID(s): `BLK-20260718-public-impl-integration`
- Evidence Log(s): Slurm jobs `6662` and `6664`; `/tmp/sounio-slurm-5b827c2f-20260718/`

## Release Scope

- [x] Compiler (self-hosted / codegen)
- [ ] Stdlib (modules, units, epistemic types, ontology)
- [ ] Docs
- [ ] Website
- [ ] CI / Workflow contracts
- [ ] Non-release-blocking change

## Evidence Boundary

- Integrated source commit: `5b827c2fa8f7e44af130c5684ce88328e391dcfe`
- Tree: `fd3576ff0f245435b9c48b4d2eb90963130200e7`
- Base: `e05a06e05eefeda0b8078b4c82b04e82c8545f00`
- Slurm `6662`: source build `rc=0`, zero build errors; ELF SHA-256 `8403b8aa37e7dd6382fd1b8a4273ed67732f3e3e58b6d4ce6ba531c51473275c`; closure, raw check, canonical check, run-pass harness, and controls passed.
- Focused local source bundle: GREEN; counterfactual old recovery: RED at T18.
- Slurm `6664`: T17/T18 source predicates and Madaros typecheck passed, but native execution was not reached because the large parser composite hit the independent 671 MiB by-value-array lowerer wall (`rc=139`, `lower_array: seed_begin`). A same-tree legacy runtime oracle is pending. This PR does not classify `6664` as GREEN.
- Independent re-review: no findings after the recovery and structural-test amendment.

Scope limit: this slice proves plain `pub`. Boot4 token recovery for `pub(crate)` and `pub(super)` remains separate work. Checker, IR, backend, serializer, and bundled compiler ELFs are unchanged.

---

## Quality Checklist

- [x] **Semicolon Check**: I have verified there are absolutely no semicolons at the end of Sounio statements.
- [x] **Sounio Syntax Standards**: I used `var` instead of `let mut`, and `&!` instead of `&mut`.
- [x] **Algebraic Effects declared**: Every modified function declares its active side-effects correctly (`with IO, Mut, Div, Panic`, etc.).
- [x] **No Rust Macro syntax**: I used standard `println()` and `assert()` instead of `println!` or `assert!`.
- [x] **Mathematical Operators**: I wrote negative numbers using explicit math (`0 - x` instead of `-x`).
- [x] **Bit Shifts**: Shift operands are explicitly cast or typed as `u8` (e.g. `x >> 4u8`).
- [x] **Compile and Type-Check**: The exact source commit built and passed focused checks with a source-fresh Madaros ELF on Slurm job `6662`.
- [ ] **Test Suite passes**: Full merge-ref CI is pending; the focused source-fresh gates above passed.
- [x] **Documentation Registry Sync**: No documentation or registry files are changed; the current-base Contracts gate is green.
- [x] **LLM-Offload Policy Compliance**: No math derivation, Lean proof, clinical pathway, or external-facing artifact is changed; offload is not required.
- [x] **Apache-2.0 License**: I understand that my contributions will be licensed under the Apache License, Version 2.0.
