### PR TITLE
docs(handoff): dispatch souc decimal-literal parser not-correctly-rounded to CODEX-2

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1004
-- Repo-backed topics: 854
+- Total governed topics: 1006
+- Repo-backed topics: 856
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 604
+- Authority count `repo_only`: 606
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 623 topics
+- A2: 625 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -396,6 +396,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.neurodyn-oct-mul-sign-fix-codex-handoff-2026-07-07 | repo_only | docs/handoff/neurodyn_oct_mul_sign_fix_codex_handoff_2026-07-07.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.pending-changes-triage-2026-07-11 | repo_only | docs/handoff/pending_changes_triage_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-512-vreg-wall-codex-dispatch-2026-07-18 | repo_only | docs/handoff/souc_512_vreg_wall_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.souc-decimal-literal-rounding-codex-dispatch-2026-07-18 | repo_only | docs/handoff/souc_decimal_literal_rounding_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-v0800-defects | repo_only | docs/handoff/souc_v0800_defects.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.zero-event-native-compile-privacy-2026-07-11 | repo_only | docs/handoff/zero_event_native_compile_privacy_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.bootstrap-seed-policy | historical | docs/implementation/BOOTSTRAP_SEED_POLICY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8608,6 +8608,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.souc-decimal-literal-rounding-codex-dispatch-2026-07-18",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/souc_decimal_literal_rounding_codex_dispatch_2026-07-18.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.souc-v0800-defects",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/souc_v0800_defects.md",

--- a/docs/handoff/souc_decimal_literal_rounding_codex_dispatch_2026-07-18.md
+++ b/docs/handoff/souc_decimal_literal_rounding_codex_dispatch_2026-07-18.md
@@ -1,0 +1,95 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.souc-decimal-literal-rounding-codex-dispatch-2026-07-18
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.souc-decimal-literal-rounding-codex-dispatch-2026-07-18
+-->
+
+# Dispatch to CODEX-2 — souc decimal-literal parser is not correctly-rounded (drifts up to ~17 ULP)
+
+**Date:** 2026-07-18
+**Owner:** CODEX-2 (compiler front-end / lexer-numeric conversion; `self-hosted/`)
+**Author:** data-science lane (surfaced while building the C4 Arrow bridge)
+**Status:** confirmed defect, minimal repro included — front-end, low blast radius, correctness-relevant
+
+---
+
+## TL;DR
+
+Sounio's **decimal-literal → f64** conversion in the front-end is **not correctly-rounded** (not
+round-to-nearest-even against the exact decimal value). It is exact for short, normal-magnitude
+literals, but drifts by **+1 to +17 ULP** for literals with long mantissas (>~17 significant digits)
+or extreme exponents (near `DBL_MAX` / near the subnormal floor). A correctly-rounded parser (big-
+integer / Grisu / Ryū-style) would return the IEEE-nearest double for every literal.
+
+This matters because it is upstream of *every* float constant in the language: for a correctness-first
+data stack, `let x = 1.23456789012345678` should be the nearest double, and it currently is not.
+
+## Repro (exact, reproducible now)
+
+`f64_to_bits(<literal>)` compiled under either engine, compared to CPython's correctly-rounded
+`struct.pack('<d', float(s))`:
+
+| literal | souc bits | CPython (IEEE-nearest) bits | drift |
+|---|---|---|---|
+| `0.1` | 4591870180066957722 | 4591870180066957722 | **0 (exact)** |
+| `3.14` | 4614253070214989087 | 4614253070214989087 | **0 (exact)** |
+| `0.333333333333333` | 4599676419421066575 | 4599676419421066575 | **0 (exact)** |
+| `2.718281828459045` | 4613303445314885481 | 4613303445314885481 | **0 (exact)** |
+| `1.23456789012345678` | 4608238818662570492 | 4608238818662570491 | **+1 ULP** |
+| `6.022e23` | 4962933069378480660 | 4962933069378480659 | **+1 ULP** |
+| `1.7976931348623157e308` | 9218868437227405305 | 9218868437227405311 | **−6 ULP** |
+| `5e-300` | 129137261445328960 | 129137261445328943 | **+17 ULP** |
+
+Repro program (single file, either engine):
+```
+fn line(name: string, x: f64) with IO, Mut, Panic, Div { print(name); print(" "); print(f64_to_bits(x)); print("\n") }
+fn main() -> i32 with IO, Mut, Panic, Div {
+    line("1.23456789012345678", 1.23456789012345678)
+    line("1.7976931348623157e308", 1.7976931348623157e308)
+    line("5e-300", 5e-300)
+    return 0
+}
+```
+Oracle (Python): `import struct; struct.unpack('<q', struct.pack('<d', float(s)))[0]`.
+
+## Root-cause hypothesis
+
+The pattern — exact for short values, drifting for many-digit mantissas and extreme exponents — is the
+signature of a **naive `mantissa * 10^exp` (or repeated `*10` / `/10`) float evaluation** in the
+lexer's numeric path, where each floating multiply rounds, and the errors accumulate/compound for long
+digit strings and large `|exp|`. A correctly-rounded conversion parses the full decimal into an exact
+big integer (or uses a proven shortest-round-trip algorithm) and rounds once, at the end.
+
+CODEX-2 to confirm the exact conversion routine (front-end lexer / literal folding, likely in the
+tokenizer or a `parse_float`-style helper) — this dispatch does not touch `self-hosted/`.
+
+## The ask
+
+Replace the decimal-literal → f64 conversion with a **correctly-rounded** one (round-to-nearest-even
+against the exact decimal): a big-integer scaling approach is the simplest provably-correct option, or
+adopt a known algorithm (Clinger/Gay, Grisu3, Ryū). Same for `f32` if it shares the path.
+
+## Acceptance
+
+- The eight literals above all match CPython's `struct.pack('<d')` bits exactly (0 ULP).
+- A fuzz set of random decimal strings (varied digit counts and exponents) round-trips to the
+  IEEE-nearest double for 100% of cases.
+
+## Scope / impact
+
+- **Low blast radius:** front-end only; does not affect the runtime `f64_to_bits` intrinsic (which is
+  a correct IEEE reinterpret) nor the round-trip fidelity of already-parsed values.
+- **Correctness relevance:** this is the front-end analogue of the exact-arithmetic lane's guarantees —
+  `data::bigrat::bigrat_from_decimal` already parses decimal *strings* to exact rationals correctly; the
+  *language literal* path should be at least IEEE-correctly-rounded to match.
+- Normal-magnitude literals (the common case) are already exact, so this is a precision-edge fix, not a
+  pervasive breakage.
+
+## Pointers
+- Repro + oracle: this file's table; `scratchpad/parsedrift.sio`.
+- Related: `stdlib/data/bigrat.sio::bigrat_from_decimal` (exact decimal→rational, the correct-by-
+  construction reference), `stdlib/data/arrow_bridge.sio` (where the drift was noticed — the SIO1
+  round-trip is bit-exact for the *runtime* double; this defect is upstream, at parse time).

--- a/scratchpad/parsedrift.sio
+++ b/scratchpad/parsedrift.sio
@@ -1,0 +1,12 @@
+fn line(name: string, x: f64) with IO, Mut, Panic, Div { print(name); print(" "); print(f64_to_bits(x)); print("\n") }
+fn main() -> i32 with IO, Mut, Panic, Div {
+    line("0.1", 0.1)
+    line("3.14", 3.14)
+    line("0.333333333333333", 0.333333333333333)
+    line("2.718281828459045", 2.718281828459045)
+    line("6.022e23", 6.022e23)
+    line("1.7976931348623157e308", 1.7976931348623157e308)
+    line("5e-300", 5e-300)
+    line("1.23456789012345678", 1.23456789012345678)
+    return 0
+}


### PR DESCRIPTION
## souc decimal-literal → f64 is not correctly-rounded (drifts up to ~17 ULP)

Surfaced while building the C4 Arrow bridge and confirmed with a minimal repro. souc parses everyday literals exactly but drifts for long mantissas / extreme exponents:

| literal | drift from IEEE-nearest |
|---|---|
| `0.1`, `3.14`, `1/3`, `e` | **exact** |
| `1.23456789012345678` | +1 ULP |
| `6.022e23` | +1 ULP |
| `1.7976931348623157e308` | −6 ULP |
| `5e-300` | +17 ULP |

`f64_to_bits(<literal>)` vs CPython `struct.pack('<d')`. The pattern is the signature of a **naive `mantissa * 10^exp` float evaluation** in the lexer (each multiply rounds; errors compound). **Ask:** replace with a correctly-rounded conversion (big-integer / Grisu / Ryū / Clinger).

**Low blast radius:** front-end only — the runtime `f64_to_bits` intrinsic is a correct IEEE reinterpret, and already-parsed values round-trip fine (the SIO1 bridge is bit-exact for the *runtime* double; this defect is upstream at parse time). **Correctness relevance:** the language-literal path should be at least IEEE-nearest to match `bigrat_from_decimal`'s exact string→rational parse.

Minimal repro + oracle in the dispatch (`scratchpad/parsedrift.sio`). No compiler changes here — it's the work order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)