### PR TITLE
feat(gpu): nonlinear BPTT — cubic-sigmoid derivative chained through the O-SSM recurrence (GB10)

### DIFF
--- a/docs/gpu/ossm_oct_bwd_nl_tile.ptx
+++ b/docs/gpu/ossm_oct_bwd_nl_tile.ptx
@@ -1,0 +1,170 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[64] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000};
+
+    .global .align 4 .b32 ossm_absgn[64] = {0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000};
+
+.visible .entry step(
+    .param .u64 pA,
+    .param .u64 pHprev,
+    .param .u64 pdHt,
+    .param .u64 pS,
+    .param .u64 pdHprev,
+    .param .u64 pdA
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[2048];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pA];
+    ld.param.u64 %rd1, [pHprev];
+    ld.param.u64 %rd2, [pdHt];
+    ld.param.u64 %rd3, [pS];
+    ld.param.u64 %rd4, [pdHprev];
+    ld.param.u64 %rd5, [pdA];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BN0;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ7:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ7;
+    mov.u32 %r5, 0;
+$LB50:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r7, 16, %r6;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $LB50;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$NDS:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.f64 %fd2, %fd1, %fd1;
+    mul.f64 %fd2, %fd2, 0d3FA8000000000000;
+    add.f64 %fd2, %fd2, 0d3FD0000000000000;
+    mul.f64 %fd0, %fd0, %fd2;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $NDS;
+$BN0:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BN1;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$BST:
+    mul.lo.u32 %r8, %r5, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    cvt.f64.f32 %fd0, %f1;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 128;
+    @%p1 bra $BST;
+    mov.u32 %r5, 0;
+$NDA:
+    shr.u32 %r6, %r5, 7;
+    and.b32 %r10, %r5, 127;
+    shr.u32 %r8, %r10, 4;
+    and.b32 %r9, %r10, 15;
+    xor.b32 %r7, %r8, %r6;
+    mad.lo.u32 %r10, %r9, 8, %r7;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mad.lo.u32 %r10, %r8, 16, %r9;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    ld.global.f64 %fd2, [%rd7];
+    mul.f64 %fd2, %fd2, %fd2;
+    mul.f64 %fd2, %fd2, 0d3FA8000000000000;
+    add.f64 %fd2, %fd2, 0d3FD0000000000000;
+    mul.f64 %fd1, %fd1, %fd2;
+    mul.f64 %fd0, %fd0, %fd1;
+    mad.lo.u32 %r10, %r6, 8, %r7;
+    mul.wide.u32 %rd7, %r10, 4;
+    mov.u64 %rd6, ossm_absgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd2, %f0;
+    mul.f64 %fd0, %fd0, %fd2;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd5, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    add.f64 %fd1, %fd1, %fd0;
+    st.global.f64 [%rd7], %fd1;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 1024;
+    @%p1 bra $NDA;
+$BN1:
+    ret;
+}

--- a/docs/gpu/ossm_sed_bwd_nl_tile.ptx
+++ b/docs/gpu/ossm_sed_bwd_nl_tile.ptx
@@ -1,0 +1,170 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+    .global .align 4 .b32 ossm_absgn[256] = {0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000};
+
+.visible .entry step(
+    .param .u64 pA,
+    .param .u64 pHprev,
+    .param .u64 pdHt,
+    .param .u64 pS,
+    .param .u64 pdHprev,
+    .param .u64 pdA
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 4 .b8 shared_array[2048];
+    .reg .f32 %f<8>;
+    .reg .f64 %fd<3>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+    .reg .b16 %rs<2>;
+
+    ld.param.u64 %rd0, [pA];
+    ld.param.u64 %rd1, [pHprev];
+    ld.param.u64 %rd2, [pdHt];
+    ld.param.u64 %rd3, [pS];
+    ld.param.u64 %rd4, [pdHprev];
+    ld.param.u64 %rd5, [pdA];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BN0;
+    mov.u16 %rs0, 0;
+    mov.u32 %r2, 0;
+    mov.u32 %r3, shared_array;
+$AZ7:
+    add.u32 %r4, %r3, %r2;
+    st.shared.u16 [%r4], %rs0;
+    add.u32 %r2, %r2, 2;
+    setp.lt.u32 %p1, %r2, 1024;
+    @%p1 bra $AZ7;
+    mov.u32 %r5, 0;
+$LB50:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mov.u32 %r3, shared_array;
+    mad.lo.u32 %r9, %r7, 16, %r6;
+    mul.lo.u32 %r9, %r9, 2;
+    add.u32 %r9, %r3, %r9;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $LB50;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$NDS:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.f64 %fd2, %fd1, %fd1;
+    mul.f64 %fd2, %fd2, 0d3FA8000000000000;
+    add.f64 %fd2, %fd2, 0d3FD0000000000000;
+    mul.f64 %fd0, %fd0, %fd2;
+    cvt.rn.f16.f64 %rs0, %fd0;
+    mad.lo.u32 %r8, %r7, 16, %r6;
+    mul.lo.u32 %r8, %r8, 2;
+    add.u32 %r8, %r8, 512;
+    add.u32 %r9, %r3, %r8;
+    st.shared.u16 [%r9], %rs0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $NDS;
+$BN0:
+    bar.sync 0;
+    mov.u32 %r1, shared_array;
+    add.u32 %r2, %r1, 512;
+    add.u32 %r4, %r1, 1024;
+    mov.f32 %wd0, 0f00000000;
+    mov.f32 %wd1, 0f00000000;
+    mov.f32 %wd2, 0f00000000;
+    mov.f32 %wd3, 0f00000000;
+    mov.f32 %wd4, 0f00000000;
+    mov.f32 %wd5, 0f00000000;
+    mov.f32 %wd6, 0f00000000;
+    mov.f32 %wd7, 0f00000000;
+    wmma.load.a.sync.aligned.row.m16n16k16.shared.f16 {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, [%r1], 16;
+    wmma.load.b.sync.aligned.col.m16n16k16.shared.f16 {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, [%r2], 16;
+    wmma.mma.sync.aligned.row.col.m16n16k16.f32.f32 {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, {%wa0, %wa1, %wa2, %wa3, %wa4, %wa5, %wa6, %wa7}, {%wb0, %wb1, %wb2, %wb3, %wb4, %wb5, %wb6, %wb7}, {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7};
+    wmma.store.d.sync.aligned.row.m16n16k16.shared.f32 [%r4], {%wd0, %wd1, %wd2, %wd3, %wd4, %wd5, %wd6, %wd7}, 16;
+    bar.sync 0;
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BN1;
+    mov.u32 %r3, shared_array;
+    mov.u32 %r5, 0;
+$BST:
+    mul.lo.u32 %r8, %r5, 4;
+    add.u32 %r8, %r8, 1024;
+    add.u32 %r9, %r3, %r8;
+    ld.shared.f32 %f1, [%r9];
+    cvt.f64.f32 %fd0, %f1;
+    mul.wide.u32 %rd7, %r5, 8;
+    add.s64 %rd7, %rd4, %rd7;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $BST;
+    mov.u32 %r5, 0;
+$NDA:
+    shr.u32 %r6, %r5, 8;
+    and.b32 %r10, %r5, 255;
+    shr.u32 %r8, %r10, 4;
+    and.b32 %r9, %r10, 15;
+    xor.b32 %r7, %r8, %r6;
+    mad.lo.u32 %r10, %r9, 16, %r7;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd1, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mad.lo.u32 %r10, %r8, 16, %r9;
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd2, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    mul.wide.u32 %rd7, %r10, 8;
+    add.s64 %rd7, %rd3, %rd7;
+    ld.global.f64 %fd2, [%rd7];
+    mul.f64 %fd2, %fd2, %fd2;
+    mul.f64 %fd2, %fd2, 0d3FA8000000000000;
+    add.f64 %fd2, %fd2, 0d3FD0000000000000;
+    mul.f64 %fd1, %fd1, %fd2;
+    mul.f64 %fd0, %fd0, %fd1;
+    mad.lo.u32 %r10, %r6, 16, %r7;
+    mul.wide.u32 %rd7, %r10, 4;
+    mov.u64 %rd6, ossm_absgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd2, %f0;
+    mul.f64 %fd0, %fd0, %fd2;
+    mul.wide.u32 %rd7, %r6, 8;
+    add.s64 %rd7, %rd5, %rd7;
+    ld.global.f64 %fd1, [%rd7];
+    add.f64 %fd1, %fd1, %fd0;
+    st.global.f64 [%rd7], %fd1;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 4096;
+    @%p1 bra $NDA;
+$BN1:
+    ret;
+}

--- a/docs/gpu/run_bptt_nl_ptx.cu
+++ b/docs/gpu/run_bptt_nl_ptx.cu
@@ -1,0 +1,112 @@
+// End-to-end NONLINEAR BPTT + training for the batched hypercomplex cell
+//   S_t = A⊗H_{t-1} + B·x_t ,  H_t = σ(S_t) ,  σ(s) = (1/64)s³ + (1/4)s + 1/2 ,  Loss = Σ_t‖H_t−tgt_t‖²
+// on the DGX Spark GB10. FORWARD pre-activation S = ossm_oct_step (compiler-lowered tile+post-add);
+// the cubic activation σ(S) is elementwise (host). BACKWARD = ossm_oct_bwd_nl, which chains the cubic
+// sigmoid derivative σ'(S)=(3/64)s²+1/4 through the recurrence (the nonlinearity in BPTT) and does
+// dHprev = L(A)ᵀ·(dH⊙σ'(S)) + dA += da. Usage: run_bptt_nl <fwd.ptx> <bwdnl.ptx> <dim> [p1only].
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+static double sig(double s){return (1.0/64.0)*s*s*s + 0.25*s + 0.5;}
+static double sigp(double s){return (3.0/64.0)*s*s + 0.25;}
+#define CK(x) do{CUresult e=(x);if(e){const char*ss;cuGetErrorString(e,&ss);printf("ERR %s@%d:%s\n",#x,__LINE__,ss);return 2;}}while(0)
+static int DIM,BITS; static CUfunction FWD,BWN;
+static void fwd(CUdeviceptr A,CUdeviceptr B,CUdeviceptr x,CUdeviceptr H,CUdeviceptr S){
+ void*a[]={&A,&B,&x,&H,&S}; cuLaunchKernel(FWD,1,1,1,32,1,1,0,0,a,0); cuCtxSynchronize();}
+static void bwn(CUdeviceptr A,CUdeviceptr Hp,CUdeviceptr dHt,CUdeviceptr S,CUdeviceptr dHp,CUdeviceptr dA){
+ void*a[]={&A,&Hp,&dHt,&S,&dHp,&dA}; cuLaunchKernel(BWN,1,1,1,32,1,1,0,0,a,0); cuCtxSynchronize();}
+
+int main(int c,char**v){
+ const char*pf=c>1?v[1]:"/tmp/fwd.ptx"; const char*pb=c>2?v[2]:"/tmp/bwdnl.ptx"; DIM=c>3?atoi(v[3]):8; BITS=(DIM==16)?4:3;
+ const int ND=DIM*16;
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext cx;CK(cuDevicePrimaryCtxRetain(&cx,d));CK(cuCtxSetCurrent(cx));
+ CUmodule mf,mb;CK(cuModuleLoad(&mf,pf));CK(cuModuleLoad(&mb,pb));
+ CK(cuModuleGetFunction(&FWD,mf,"step"));CK(cuModuleGetFunction(&BWN,mb,"step"));
+ CUdeviceptr dA_,dB_,dx_,dH_,dS_,dHp_,dHt_,dSp_,dHpr_,dAg_;
+ CK(cuMemAlloc(&dA_,DIM*8));CK(cuMemAlloc(&dB_,DIM*8));CK(cuMemAlloc(&dx_,16*8));CK(cuMemAlloc(&dH_,ND*8));
+ CK(cuMemAlloc(&dS_,256*4));CK(cuMemAlloc(&dHp_,ND*8));CK(cuMemAlloc(&dHt_,256*8));CK(cuMemAlloc(&dSp_,256*8));
+ CK(cuMemAlloc(&dHpr_,256*8));CK(cuMemAlloc(&dAg_,DIM*8));
+
+ // ── Part 1: validate one NONLINEAR bwd step vs exact f64 ─────────────────────────────────────
+ {
+  double A[16]={0},Hp[256]={0},dHt[256]={0},S[256]={0};
+  for(int i=0;i<DIM;i++)A[i]=0.4*((i%2)?-1:1)+0.05*i;
+  for(int b=0;b<16;b++)for(int j=0;j<DIM;j++)Hp[b*DIM+j]=((b+1)*0.11+j*0.05)*((j%2)?-1:1);
+  for(int k=0;k<DIM;k++)for(int b=0;b<16;b++){dHt[k*16+b]=0.2*((k+b)%3-1)+0.03*k;S[k*16+b]=0.3*sin(0.5*k+0.3*b);}
+  double dS[256]; for(int k=0;k<DIM;k++)for(int b=0;b<16;b++)dS[k*16+b]=dHt[k*16+b]*sigp(S[k*16+b]);
+  double dHp_ref[256]={0},dA_ref[16]={0};
+  for(int j=0;j<DIM;j++)for(int b=0;b<16;b++){double s=0;for(int k=0;k<DIM;k++)s+=(double)cds(k^j,j,BITS)*A[k^j]*dS[k*16+b];dHp_ref[j*16+b]=s;}
+  for(int pp=0;pp<DIM;pp++){double s=0;for(int k=0;k<DIM;k++)for(int b=0;b<16;b++){int m=k^pp;s+=(double)cds(pp,m,BITS)*Hp[b*DIM+m]*dS[k*16+b];}dA_ref[pp]=s;}
+  double zA[16]={0};CK(cuMemcpyHtoD(dAg_,zA,DIM*8));
+  CK(cuMemcpyHtoD(dA_,A,DIM*8));CK(cuMemcpyHtoD(dHp_,Hp,ND*8));CK(cuMemcpyHtoD(dHt_,dHt,256*8));CK(cuMemcpyHtoD(dSp_,S,256*8));
+  bwn(dA_,dHp_,dHt_,dSp_,dHpr_,dAg_);
+  double gHp[256],gA[16];CK(cuMemcpyDtoH(gHp,dHpr_,256*8));CK(cuMemcpyDtoH(gA,dAg_,DIM*8));
+  int fH=0,fA=0;double mH=0,mA=0;
+  for(int j=0;j<DIM;j++)for(int b=0;b<16;b++){double e=fabs(gHp[j*16+b]-dHp_ref[j*16+b]);if(e>mH)mH=e;if(e>0.05)fH++;}
+  for(int pp=0;pp<DIM;pp++){double e=fabs(gA[pp]-dA_ref[pp]);if(e>mA)mA=e;if(e>1e-4)fA++;}
+  printf("Part 1 — one NONLINEAR BPTT backward step (%s):\n",(DIM==16)?"sedenion":"octonion");
+  printf("  dHprev = L(A)^T·(dH⊙σ'(S)) (tile): mismatch %d/%d maxerr=%.4f\n",fH,ND,mH);
+  printf("  dA += da(H, dH⊙σ'(S)) (f64):       mismatch %d/%d maxerr=%.2e\n",fA,DIM,mA);
+  if(fH||fA){printf("FAIL (part 1)\n");return 1;}
+  printf("  PASS\n");
+ }
+ if(c>4 && strcmp(v[4],"p1only")==0){printf("(p1only) nonlinear backward-step validated; training skipped.\n");return 0;}
+
+ // ── Part 2: NONLINEAR BPTT training loop ─────────────────────────────────────────────────────
+ const int T=3, NITER=60;
+ const double lr = (DIM==16)?0.010:0.05;
+ const double asc = (DIM==16)?0.5:1.0, pert = (DIM==16)?0.04:0.10;
+ double h0[256]={0}, x[3][16], As[16], Bs[16];
+ for(int b=0;b<16;b++)for(int j=0;j<DIM;j++)h0[b*DIM+j]=0.1*((b%2)?-1:1)+0.02*j;
+ for(int t=0;t<T;t++)for(int b=0;b<16;b++)x[t][b]=0.3*sin(0.7*t+0.4*b);
+ for(int i=0;i<DIM;i++){As[i]=asc*(0.25*((i%2)?-1:1)+0.04*i); Bs[i]=asc*(0.15-0.03*i);}
+ // teacher targets: forward (pre-act S via kernel, σ on host), teacher trajectory as input each step
+ double tgt[3][256]={{0}};
+ {
+  double hs[256]; memcpy(hs,h0,sizeof(double)*256);
+  CK(cuMemcpyHtoD(dA_,As,DIM*8));CK(cuMemcpyHtoD(dB_,Bs,DIM*8));
+  for(int t=0;t<T;t++){
+   CK(cuMemcpyHtoD(dx_,x[t],16*8));CK(cuMemcpyHtoD(dH_,hs,ND*8));fwd(dA_,dB_,dx_,dH_,dS_);
+   float S[256];CK(cuMemcpyDtoH(S,dS_,256*4));
+   for(int k=0;k<DIM;k++)for(int b=0;b<16;b++)tgt[t][k*16+b]=sig(S[k*16+b]);
+   double nh[256]={0};for(int k=0;k<DIM;k++)for(int b=0;b<16;b++)nh[b*DIM+k]=sig(S[k*16+b]);memcpy(hs,nh,sizeof(double)*256);
+  }
+ }
+ double A[16],Bp[16]; for(int i=0;i<DIM;i++){A[i]=As[i]+pert*((i%2)?-1:1); Bp[i]=Bs[i]+pert*0.83*((i%3)?1:-1);}
+ double loss0=0,lossN=0;
+ double Straj[3][256], Htraj[3][256], hst[4][256];
+ for(int it=0; it<NITER; it++){
+  memcpy(hst[0],h0,sizeof(double)*256);
+  CK(cuMemcpyHtoD(dA_,A,DIM*8));CK(cuMemcpyHtoD(dB_,Bp,DIM*8));
+  double loss=0;
+  for(int t=0;t<T;t++){
+   CK(cuMemcpyHtoD(dx_,x[t],16*8));CK(cuMemcpyHtoD(dH_,hst[t],ND*8));fwd(dA_,dB_,dx_,dH_,dS_);
+   float S[256];CK(cuMemcpyDtoH(S,dS_,256*4));
+   for(int k=0;k<DIM;k++)for(int b=0;b<16;b++){Straj[t][k*16+b]=S[k*16+b];double h=sig(S[k*16+b]);Htraj[t][k*16+b]=h;
+     double e=h-tgt[t][k*16+b];loss+=e*e;}
+   for(int k=0;k<DIM;k++)for(int b=0;b<16;b++)hst[t+1][b*DIM+k]=Htraj[t][k*16+b];
+  }
+  if(it==0)loss0=loss; lossN=loss;
+  double dBacc[16]={0}, dHnext[256]={0}, zA[16]={0};CK(cuMemcpyHtoD(dAg_,zA,DIM*8));
+  for(int t=T-1;t>=0;t--){
+   double dHt[256];
+   for(int k=0;k<DIM;k++)for(int b=0;b<16;b++){double dY=2.0*(Htraj[t][k*16+b]-tgt[t][k*16+b]);dHt[k*16+b]=dY+dHnext[k*16+b];}
+   for(int k=0;k<DIM;k++){double s=0;for(int b=0;b<16;b++)s+=dHt[k*16+b]*sigp(Straj[t][k*16+b])*x[t][b];dBacc[k]+=s;}
+   CK(cuMemcpyHtoD(dHt_,dHt,256*8));CK(cuMemcpyHtoD(dSp_,Straj[t],256*8));CK(cuMemcpyHtoD(dHp_,hst[t],ND*8));
+   bwn(dA_,dHp_,dHt_,dSp_,dHpr_,dAg_);
+   CK(cuMemcpyDtoH(dHnext,dHpr_,256*8));
+  }
+  double dA[16];CK(cuMemcpyDtoH(dA,dAg_,DIM*8));
+  for(int p=0;p<DIM;p++){A[p]-=lr*dA[p]; Bp[p]-=lr*dBacc[p];}
+  if(it==0||it==NITER-1||it%15==14)printf("  iter %2d  loss %.5f\n",it,loss);
+ }
+ printf("Part 2 — NONLINEAR BPTT training: loss %.5f → %.5f  (%.1f%% reduction)\n",loss0,lossN,100.0*(loss0-lossN)/loss0);
+ if(lossN < 0.5*loss0){printf("PASS: nonlinear BPTT + SGD trained h_t=σ(A⊗h+B·x) on GB10 (cubic-sigmoid derivative chained through the recurrence)\n");return 0;}
+ printf("FAIL: loss did not fall enough\n");return 1;
+}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1833,6 +1833,20 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             bwd.src_reg = instr.call_args[3]
             bwd.shared_addr = instr.call_args[4]
             k = gpu_kernel_append_op(k, bwd)
+        } else if hlir_name_is_ossm_oct_bwd_nl(cn) || hlir_name_is_ossm_sed_bwd_nl(cn) {
+            // NONLINEAR BPTT backward step. call_args = [pA, pHprev, pdHt, pS, pdHprev, pdA]. Applies
+            // dS = dHt ⊙ σ'(S) then the backward multiply → one GpuOctBwdNl. Needs 2048 shared bytes.
+            if k.shared_bytes < 2048 { k.shared_bytes = 2048 }
+            var bwn = gpu_op_new()
+            bwn.opcode = GpuOpcode::GpuOctBwdNl
+            bwn.rhs_imm = if hlir_name_is_ossm_sed_bwd_nl(cn) { 16 } else { 8 }
+            bwn.lhs_reg = instr.call_args[0]
+            bwn.rhs_reg = instr.call_args[1]
+            bwn.addr_reg = instr.call_args[2]
+            bwn.src_reg = instr.call_args[3]
+            bwn.shared_addr = instr.call_args[4]
+            bwn.compare_reg = instr.call_args[5]
+            k = gpu_kernel_append_op(k, bwn)
         }
         // Other calls: skip in MVP
     }
@@ -1967,6 +1981,25 @@ fn hlir_name_is_ossm_sed_bwd(n: HlirName) -> bool {
     n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
     n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
     n.buf[8] == 95 as i8 && n.buf[9] == 98 as i8 && n.buf[10] == 119 as i8 && n.buf[11] == 100 as i8
+}
+
+// "ossm_oct_bwd_nl" (15 chars) — NONLINEAR BPTT backward step (octonion): dS=dHt⊙σ'(S) then the
+// backward multiply. ossm_oct_bwd_nl(pA, pHprev, pdHt, pS, pdHprev, pdA) (dim=8, bits=3).
+fn hlir_name_is_ossm_oct_bwd_nl(n: HlirName) -> bool {
+    if n.len != 15 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
+    n.buf[4] == 95 as i8 && n.buf[5] == 111 as i8 && n.buf[6] == 99 as i8 && n.buf[7] == 116 as i8 &&
+    n.buf[8] == 95 as i8 && n.buf[9] == 98 as i8 && n.buf[10] == 119 as i8 && n.buf[11] == 100 as i8 &&
+    n.buf[12] == 95 as i8 && n.buf[13] == 110 as i8 && n.buf[14] == 108 as i8
+}
+
+// "ossm_sed_bwd_nl" (15 chars) — NONLINEAR BPTT backward step (sedenion, dim=16, bits=4).
+fn hlir_name_is_ossm_sed_bwd_nl(n: HlirName) -> bool {
+    if n.len != 15 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
+    n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
+    n.buf[8] == 95 as i8 && n.buf[9] == 98 as i8 && n.buf[10] == 119 as i8 && n.buf[11] == 100 as i8 &&
+    n.buf[12] == 95 as i8 && n.buf[13] == 110 as i8 && n.buf[14] == 108 as i8
 }
 
 fn hlir_name_starts_with_gpu_thread(n: HlirName) -> bool {

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -130,6 +130,10 @@ pub enum GpuOpcode {
     //   that chains directly as the next step's dHt) + dA += da(Hprev, dHt) accumulated IN-PLACE across
     //   timesteps. Like GpuOctVjp but D-layout dHprev + in-place dA (no zeroing). Pointers pa,pHprev,
     //   pdHt,pdHprev,pdA in lhs/rhs/addr/src/shared_addr; rhs_imm = dim (8 octonion / 16 sedenion).
+    GpuOctBwdNl,        // NONLINEAR BPTT backward step: like GpuOctBwd but applies the cubic-sigmoid
+    //   derivative dS = dHt ⊙ σ'(S), σ'(s)=(3/64)s²+1/4, using the pre-activation S, BEFORE the
+    //   backward multiply — so it trains h_t = σ(A⊗h_{t-1}+B·x_t). Extra pS pointer. Pointers pa,pHprev,
+    //   pdHt,pS,pdHprev,pdA in lhs/rhs/addr/src/shared_addr/compare_reg; rhs_imm = dim.
     GpuTmaLoad,         // Tensor memory access load (sm_90+)
     GpuTmaStore,        // Tensor memory access store (sm_90+)
 

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -47,6 +47,13 @@ pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, All
         buf = ptx_push_str(buf, gpu_emit_cell_sign_table(wdim, wbits))
         buf = ptx_push_str(buf, gpu_emit_assoc_absgn_table(wdim, wbits))
     }
+    // Nonlinear BPTT backward-step tables: same (ossm_Lsgn + ossm_absgn).
+    if gpu_has_oct_bwd_nl(kernel) {
+        let ndim = gpu_bwd_nl_dim(kernel)
+        let nbits = if ndim == 16 { 4 } else { 3 }
+        buf = ptx_push_str(buf, gpu_emit_cell_sign_table(ndim, nbits))
+        buf = ptx_push_str(buf, gpu_emit_assoc_absgn_table(ndim, nbits))
+    }
     // gpu_emit_kernel_mode_metadata skipped: calls gpu_legalize_kernel_to_ssa_v2 which
     // returns GpuKernelSsaV2 by value (~28MB frame) → SIGSEGV in lean_single-compiled binary.
     // The function only emits cosmetic PTX comment lines; skip it for correctness.
@@ -151,7 +158,7 @@ fn gpu_has_wmma_tile(kernel: GpuKernelIr) -> bool {
     var i: i64 = 0
     while i < kernel.op_count {
         let oc = kernel.ops[i as usize].opcode
-        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc || oc == GpuOpcode::GpuOctVjp || oc == GpuOpcode::GpuOctBwd { return true }
+        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc || oc == GpuOpcode::GpuOctVjp || oc == GpuOpcode::GpuOctBwd || oc == GpuOpcode::GpuOctBwdNl { return true }
         i = i + 1
     }
     false
@@ -165,7 +172,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     let stage = gpu_has_oct_stage(kernel)
     let postadd = gpu_has_oct_postadd(kernel)
     // The associator, VJP and BPTT-backward need the same register classes as the cell.
-    let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel) || gpu_has_oct_vjp(kernel) || gpu_has_oct_bwd(kernel)
+    let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel) || gpu_has_oct_vjp(kernel) || gpu_has_oct_bwd(kernel) || gpu_has_oct_bwd_nl(kernel)
     let stage_or_pa = stage || postadd || cell
 
     // .reg .pred %p<N> — the staging loop / post-add need at least %p<2>.
@@ -811,6 +818,88 @@ fn gpu_emit_bwd_da_accum(pHR: string, pdDR: string, pdaR: string, dim: i64) -> s
     t
 }
 
+// ── NONLINEAR BPTT backward step: dS = dHt ⊙ σ'(S), then dHprev = L(A)ᵀ·dS + dA += da(Hprev, dS) ──
+// σ'(s) = (3/64)s² + 1/4 (derivative of the cubic sigmoid). The pre-activation S is applied on the
+// fly inside the dS-staging and da-accumulation loops (no scratch buffer). Trains h_t=σ(A⊗h+B·x).
+fn gpu_emit_oct_bwd_nl(paR: string, pHprevR: string, pdHtR: string, pSR: string, pdHprevR: string, pdaR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+    // tile: build L(A)ᵀ into sL, stage dS = dHt⊙σ'(S) col-major into sH, tile → sS = L(A)ᵀ·dS
+    var t = "    mov.u32 %r1, %tid.x;\n"
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $BN0;\n")
+    t = str_concat(t, gpu_emit_assoc_zero_shared(7, 0, 1024))
+    t = str_concat(t, gpu_emit_cell_lbuild_t(paR, dim, bits, 50))
+    t = str_concat(t, gpu_emit_nl_dstage(pdHtR, pSR, dim))
+    t = str_concat(t, "$BN0:\n    bar.sync 0;\n")
+    t = str_concat(t, gpu_emit_cell_shared_tile())
+    t = str_concat(t, "    bar.sync 0;\n")
+    // thread 0: store dHprev (D-layout f64) + accumulate dA in-place (with σ' applied)
+    t = str_concat(t, "    mov.u32 %r1, %tid.x;\n")
+    t = str_concat(t, "    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $BN1;\n")
+    t = str_concat(t, gpu_emit_bwd_store_dhprev(pdHprevR, dim))
+    t = str_concat(t, gpu_emit_nl_da_accum(pHprevR, pdHtR, pSR, pdaR, dim))
+    t = str_concat(t, "$BN1:\n")
+    t
+}
+
+// thread 0: stage dS = dHt ⊙ σ'(S) (col-major f16) into sH@512. dHt, S are D-layout [k*16+b]==idx;
+// σ'(s) = (3/64)s² + 1/4 (0d3FA8000000000000, 0d3FD0000000000000). k=idx>>4, b=idx&15.
+fn gpu_emit_nl_dstage(pdHtR: string, pSR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r3, shared_array;\n    mov.u32 %r5, 0;\n$NDS:\n"
+    t = str_concat(t, "    shr.u32 %r6, %r5, 4;\n    and.b32 %r7, %r5, 15;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r5, 8;\n    add.s64 %rd7, "), pdHtR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r5, 8;\n    add.s64 %rd7, "), pSR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd1, [%rd7];\n")
+    t = str_concat(t, "    mul.f64 %fd2, %fd1, %fd1;\n")
+    t = str_concat(t, "    mul.f64 %fd2, %fd2, 0d3FA8000000000000;\n")
+    t = str_concat(t, "    add.f64 %fd2, %fd2, 0d3FD0000000000000;\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd2;\n    cvt.rn.f16.f64 %rs0, %fd0;\n")
+    t = str_concat(t, "    mad.lo.u32 %r8, %r7, 16, %r6;\n")
+    t = str_concat(t, "    mul.lo.u32 %r8, %r8, 2;\n    add.u32 %r8, %r8, 512;\n")
+    t = str_concat(t, "    add.u32 %r9, %r3, %r8;\n    st.shared.u16 [%r9], %rs0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $NDS;\n")
+    t
+}
+
+// thread 0: dA[p] += Σ_{k,b} σ(p,k⊕p)·Hprev[k⊕p,b]·dS[k,b], dS[k,b] = dHt[k,b]·σ'(S[k,b]). In-place.
+fn gpu_emit_nl_da_accum(pHR: string, pdHtR: string, pSR: string, pdaR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    let psh = if dim == 16 { 8 } else { 7 }
+    let remmask = dim * 16 - 1
+    var t = "    mov.u32 %r5, 0;\n$NDA:\n"
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(psh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r10, %r5, "), i64_to_string(remmask))
+    t = str_concat(t, ";\n    shr.u32 %r8, %r10, 4;\n    and.b32 %r9, %r10, 15;\n")
+    t = str_concat(t, "    xor.b32 %r7, %r8, %r6;\n")
+    // Hprev[b*dim+m] → %fd0
+    t = str_concat(str_concat(t, "    mad.lo.u32 %r10, %r9, "), i64_to_string(dim))
+    t = str_concat(str_concat(t, ", %r7;\n    mul.wide.u32 %rd7, %r10, 8;\n    add.s64 %rd7, "), pHR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    // dHt[k*16+b] → %fd1 ; S[k*16+b] → %fd2 → σ'(S)
+    t = str_concat(t, "    mad.lo.u32 %r10, %r8, 16, %r9;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r10, 8;\n    add.s64 %rd7, "), pdHtR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd1, [%rd7];\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r10, 8;\n    add.s64 %rd7, "), pSR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd2, [%rd7];\n")
+    t = str_concat(t, "    mul.f64 %fd2, %fd2, %fd2;\n")
+    t = str_concat(t, "    mul.f64 %fd2, %fd2, 0d3FA8000000000000;\n")
+    t = str_concat(t, "    add.f64 %fd2, %fd2, 0d3FD0000000000000;\n")
+    t = str_concat(t, "    mul.f64 %fd1, %fd1, %fd2;\n")   // dS = dHt·σ'
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd1;\n")   // Hprev·dS
+    // sign absgn[p*dim+m]
+    t = str_concat(str_concat(t, "    mad.lo.u32 %r10, %r6, "), i64_to_string(dim))
+    t = str_concat(t, ", %r7;\n    mul.wide.u32 %rd7, %r10, 4;\n")
+    t = str_concat(t, "    mov.u64 %rd6, ossm_absgn;\n    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n    cvt.f64.f32 %fd2, %f0;\n")
+    t = str_concat(t, "    mul.f64 %fd0, %fd0, %fd2;\n")   // σ·Hprev·dS
+    // dA[p] +=
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r6, 8;\n    add.s64 %rd7, "), pdaR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd1, [%rd7];\n")
+    t = str_concat(t, "    add.f64 %fd1, %fd1, %fd0;\n    st.global.f64 [%rd7], %fd1;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim * 16))
+    t = str_concat(t, ";\n    @%p1 bra $NDA;\n")
+    t
+}
+
 // Build L(m) (row-major f16, σ(k⊕j,j,bits)·m[k⊕j], dim×dim in the 16×16 tile) into sL[shared_array]
 // from the f64 pointer mR, via a RUNTIME loop reading the ossm_Lsgn sign table (so the sedenion
 // dim=16 build — 256 entries — stays under the 64 KB PtxBuf). `tag` makes the loop label unique.
@@ -985,6 +1074,29 @@ fn gpu_bwd_dim(kernel: GpuKernelIr) -> i64 {
     var i: i64 = 0
     while i < kernel.op_count {
         if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctBwd {
+            if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
+            return 8
+        }
+        i = i + 1
+    }
+    8
+}
+
+// Does this kernel contain the NONLINEAR BPTT backward-step op?
+fn gpu_has_oct_bwd_nl(kernel: GpuKernelIr) -> bool {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctBwdNl { return true }
+        i = i + 1
+    }
+    false
+}
+
+// The dim of the nonlinear BPTT backward-step op (8 octonion / 16 sedenion).
+fn gpu_bwd_nl_dim(kernel: GpuKernelIr) -> i64 {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctBwdNl {
             if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
             return 8
         }
@@ -1425,6 +1537,14 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
             let wdim = if op.rhs_imm == 16 { 16 } else { 8 }
             let wbits = if wdim == 16 { 4 } else { 3 }
             ptx_push_str(buf, gpu_emit_oct_bwd(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), wdim, wbits))
+        }
+
+        GpuOpcode::GpuOctBwdNl => {
+            // Nonlinear BPTT backward step. Pointers: pA=lhs, pHprev=rhs, pdHt=addr, pS=src,
+            // pdHprev=shared_addr, pdA=compare_reg.
+            let ndim = if op.rhs_imm == 16 { 16 } else { 8 }
+            let nbits = if ndim == 16 { 4 } else { 3 }
+            ptx_push_str(buf, gpu_emit_oct_bwd_nl(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg), ndim, nbits))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/tests/gpu/ossm_oct_bwd_nl_tile.sio
+++ b/tests/gpu/ossm_oct_bwd_nl_tile.sio
@@ -1,0 +1,12 @@
+// NONLINEAR one BPTT backward step of the octonion cell h_t = σ(A⊗H_{t-1} + B·x_t) — array-of-Hyper.
+// Applies the cubic-sigmoid derivative dS = dH_t ⊙ σ'(S), σ'(s)=(3/64)s²+1/4, using the pre-activation
+// S, then dHprev = L(A)ᵀ·dS (D-layout, chains) + dA += da(H_{t-1}, dS) in-place. This is the
+// nonlinearity in BPTT — the forward pre-activation S is ossm_oct_step; σ(S) is elementwise (host).
+fn ossm_oct_bwd_nl(pA: &Hyper<Octonion, f64>, pHprev: &[Hyper<Octonion, f64>; 16],
+                   pdHt: &[f64; 256], pS: &[f64; 256], pdHprev: &! [f64; 256], pdA: &! [f64; 16]) with GPU { }
+
+kernel fn step(pA: &Hyper<Octonion, f64>, pHprev: &[Hyper<Octonion, f64>; 16],
+               pdHt: &[f64; 256], pS: &[f64; 256], pdHprev: &! [f64; 256], pdA: &! [f64; 16]) with GPU {
+    ossm_oct_bwd_nl(pA, pHprev, pdHt, pS, pdHprev, pdA)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/ossm_sed_bwd_nl_tile.sio
+++ b/tests/gpu/ossm_sed_bwd_nl_tile.sio
@@ -1,0 +1,10 @@
+// NONLINEAR one BPTT backward step of the SEDENION cell (dim=16, bits=4) — array-of-Hyper.
+// dS = dH_t ⊙ σ'(S), σ'(s)=(3/64)s²+1/4; dHprev = L(A)ᵀ·dS + dA += da(H_{t-1}, dS) in-place.
+fn ossm_sed_bwd_nl(pA: &Hyper<Sedenion, f64>, pHprev: &[Hyper<Sedenion, f64>; 16],
+                   pdHt: &[f64; 256], pS: &[f64; 256], pdHprev: &! [f64; 256], pdA: &! [f64; 16]) with GPU { }
+
+kernel fn step(pA: &Hyper<Sedenion, f64>, pHprev: &[Hyper<Sedenion, f64>; 16],
+               pdHt: &[f64; 256], pS: &[f64; 256], pdHprev: &! [f64; 256], pdA: &! [f64; 16]) with GPU {
+    ossm_sed_bwd_nl(pA, pHprev, pdHt, pS, pdHprev, pdA)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

Trains the **nonlinear** hypercomplex cell `h_t = σ(A⊗h_{t-1} + B·x_t)` end-to-end on the DGX Spark GB10, with the **cubic-sigmoid derivative chained through the recurrence** — the nonlinearity in BPTT.

```
σ(s)  = (1/64)s³ + (1/4)s + 1/2     (the cell's cubic sigmoid)
σ'(s) = (3/64)s² + 1/4
```

The only change vs the linear BPTT step is applying `dS_t = dH_t ⊙ σ'(S_t)` (using the pre-activation `S_t`) before the backward multiply:

```
dHprev = L(A)ᵀ·dS_t   +   dA += da(H_{t-1}, dS_t)   (in-place across timesteps)
```

### New compiler intrinsic

```
ossm_oct_bwd_nl / ossm_sed_bwd_nl (pA, pHprev, pdHt, pS, pdHprev, pdA):
  like ossm_oct_bwd but applies σ'(S) on the fly inside the dS-staging and da-accumulation loops
  (no scratch buffer — σ'(S)=(3/64)S²+1/4 is folded in as it reads S).
```

The forward pre-activation `S = A⊗h + B·x` is the compiler-lowered `ossm_oct_step`; the cubic activation `σ(S)` is elementwise.

## Implementation

- **kernel_ir.sio**: `GpuOctBwdNl` opcode.
- **hlir_to_gpu.sio**: `hlir_name_is_ossm_oct_bwd_nl` / `ossm_sed_bwd_nl` + CALL_DIRECT arm.
- **lower_to_ptx.sio**: `gpu_has_oct_bwd_nl` / `gpu_bwd_nl_dim`; tables `ossm_Lsgn` + `ossm_absgn`; `gpu_emit_oct_bwd_nl` reuses `gpu_emit_cell_lbuild_t` + `gpu_emit_cell_shared_tile` + `gpu_emit_bwd_store_dhprev`; new `gpu_emit_nl_dstage` (dS = dHt⊙σ'(S) staged col-major) + `gpu_emit_nl_da_accum` (σ' applied in-loop). f64 σ' constants `0d3FA8000000000000` (3/64) + `0d3FD0000000000000` (1/4).

## Hardware validation (DGX Spark GB10, sm_121a)

ptxas-clean.

**One nonlinear backward step vs exact f64:**

| algebra | dHprev (tile) | dA (f64, in-place) |
|---|---|---|
| octonion | 0/128 · maxerr 0.0000 | 0/8 · maxerr 2.2e-16 |
| sedenion | 0/256 · maxerr 0.0002 | 0/16 · maxerr 2.2e-15 |

**Full nonlinear BPTT + SGD** training of `h_t=σ(A⊗h+B·x)` toward teacher targets:

| algebra | loss |
|---|---|
| octonion | 0.556 → **0.00136** (99.8%) |
| sedenion | 0.285 → **0.00185** (99.4%) |

Harness `docs/gpu/run_bptt_nl_ptx.cu`; PTX artifacts `docs/gpu/ossm_{oct,sed}_bwd_nl_tile.ptx`. Builds on the tensor-core arc through #1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)