### PR TITLE
feat(soir): add bounded empty-v5 reader

### DIFF
--- a/scripts/ci/soir_v5_empty_reader_gate.sh
+++ b/scripts/ci/soir_v5_empty_reader_gate.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+COMPILER_CLI="${SOUC_BIN:-$ROOT/bin/madaros}"
+RAW_COMPILER="${SOIR_V5_EMPTY_READER_RAW_BIN:-${MADAROS_RAW_BIN:-$ROOT/bin/madaros-linux-x86_64}}"
+EXPECTED_RAW_SHA256="${SOIR_V5_EMPTY_READER_EXPECTED_RAW_SHA256:-}"
+COMPILER_SOURCE_SHA="${SOIR_V5_EMPTY_READER_COMPILER_SOURCE_SHA:-not_claimed}"
+WRITER="self-hosted/ir/soir_writer.sio"
+READER="self-hosted/ir/soir_reader.sio"
+RUNTIME_TIMEOUT_SECONDS="${SOIR_V5_EMPTY_READER_RUNTIME_TIMEOUT_SECONDS:-15}"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-soir-v5-empty-reader.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'SOIR_V5_EMPTY_READER_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+progress() {
+  printf 'SOIR_V5_EMPTY_READER_PROGRESS stage=%s subject=%s status=%s\n' \
+    "$1" "$2" "$3" >&2
+}
+
+run_compiler() {
+  MADAROS_RAW_BIN="$RAW_COMPILER" "$COMPILER_CLI" "$@"
+}
+
+expected_paths() {
+  printf '%s\n' \
+    scripts/ci/soir_v5_empty_reader_gate.sh \
+    self-hosted/ir/soir_reader.sio \
+    self-hosted/ir/soir_writer.sio \
+    tests/native-v2/soir_v5_empty_reader_reject_witness.sio \
+    tests/native-v2/soir_v5_empty_reader_witness.sio
+}
+
+[[ -x "$COMPILER_CLI" ]] || fail compiler_cli_missing
+[[ -x "$RAW_COMPILER" ]] || fail raw_compiler_missing
+[[ "$(head -c 2 "$RAW_COMPILER" 2>/dev/null)" != '#!' ]] || fail raw_compiler_is_launcher
+command -v timeout >/dev/null 2>&1 || fail timeout_command_missing
+[[ "$RUNTIME_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail runtime_timeout_invalid
+(( RUNTIME_TIMEOUT_SECONDS <= 60 )) || fail runtime_timeout_exceeds_cap_60
+
+for path in "$WRITER" "$READER"; do
+  [[ -f "$path" ]] || fail "missing_${path//\//_}"
+done
+
+grep -Fq 'pub let SOIR_READER_SCALAR_EMPTY_V5_SIZE: i64 = 320' "$READER" \
+  || fail reader_size_contract_missing
+grep -Fq 'pub fn soir_reader_decode_scalar_empty_module_v5(' "$READER" \
+  || fail reader_decode_missing
+grep -Fq 'pub let SOIR_READER_RECEIPT_WORDS: i64 = 8' "$READER" \
+  || fail reader_receipt_contract_missing
+
+dependency_pattern='use (parser|ir::ir|ir::serialize)|\b(IrModule|IrInstr|TyF128|TyF256|numeric_payload)\b'
+set +e
+if command -v rg >/dev/null 2>&1; then
+  rg -n "$dependency_pattern" "$READER" >"$TMP/dependency-leak.log" 2>&1
+else
+  grep -En "$dependency_pattern" "$READER" >"$TMP/dependency-leak.log" 2>&1
+fi
+dependency_scan_rc=$?
+set -e
+if [[ "$dependency_scan_rc" -eq 0 ]]; then
+  cat "$TMP/dependency-leak.log" >&2
+  fail shadow_dependency_expanded
+fi
+[[ "$dependency_scan_rc" -eq 1 ]] || fail dependency_scan_error
+
+for default_surface in \
+  self-hosted/ir/serialize.sio \
+  self-hosted/ir/mod.sio \
+  self-hosted/ir/lower.sio \
+  self-hosted/check/check.sio \
+  self-hosted/compiler/main.sio \
+  self-hosted/compiler/module_frontend.sio; do
+  [[ -f "$default_surface" ]] || continue
+  if grep -Eq 'ir::soir_reader' "$default_surface"; then
+    fail "shadow_imported_by_${default_surface//\//_}"
+  fi
+done
+
+bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
+  >"$TMP/precision-identity.log" 2>&1 || {
+    cat "$TMP/precision-identity.log" >&2
+    fail precision_identity_regression
+  }
+
+head_sha="$(git rev-parse HEAD)"
+tree_sha="$(git rev-parse 'HEAD^{tree}')"
+mapfile -t evidence_paths < <(expected_paths)
+for evidence_path in "${evidence_paths[@]}"; do
+  git ls-files --error-unmatch -- "$evidence_path" >/dev/null 2>&1 \
+    || fail evidence_path_untracked
+done
+dirty_tree="$(git status --porcelain --untracked-files=all)"
+if [[ -n "$dirty_tree" ]]; then
+  printf '%s\n' "$dirty_tree" >&2
+  fail worktree_dirty
+fi
+if [[ "$COMPILER_SOURCE_SHA" != "not_claimed" && "$COMPILER_SOURCE_SHA" != "$head_sha" ]]; then
+  fail compiler_source_sha_mismatch
+fi
+
+raw_compiler_sha256="$(sha256sum "$RAW_COMPILER" | awk '{print $1}')"
+if [[ -n "$EXPECTED_RAW_SHA256" && "$raw_compiler_sha256" != "$EXPECTED_RAW_SHA256" ]]; then
+  fail raw_compiler_sha256_mismatch
+fi
+compiler_cli_sha256="$(sha256sum "$COMPILER_CLI" | awk '{print $1}')"
+
+for source in "$WRITER" "$READER"; do
+  name="$(basename "$source" .sio)"
+  progress source_check "$name" begin
+  run_compiler check "$source" >"$TMP/$name.check.log" 2>&1 || {
+    cat "$TMP/$name.check.log" >&2
+    fail "source_check_$name"
+  }
+  progress source_check "$name" pass
+done
+
+compose_and_run() {
+  local witness="$1"
+  local marker="$2"
+  local name composite elf build_log run_log runtime_rc
+  name="$(basename "$witness" .sio)"
+  composite="$TMP/$name.sio"
+  elf="$TMP/$name.elf"
+  build_log="$TMP/$name.build.log"
+  run_log="$TMP/$name.run.log"
+
+  {
+    printf 'module ir::%s_gate\n\n' "$name"
+    sed '/^module ir::soir_writer$/d' "$WRITER"
+    sed '/^module ir::soir_reader$/d' "$READER"
+    sed -e '/^use ir::soir_writer::\*$/d' \
+        -e '/^use ir::soir_reader::\*$/d' \
+        "$witness"
+  } >"$composite"
+
+  progress composite_check "$name" begin
+  run_compiler check "$composite" >"$build_log" 2>&1 || {
+    cat "$build_log" >&2
+    fail "composite_check_$name"
+  }
+  progress composite_build "$name" begin
+  run_compiler --native-v2-compile "$composite" -o "$elf" >>"$build_log" 2>&1 || {
+    cat "$build_log" >&2
+    fail "composite_build_$name"
+  }
+  chmod +x "$elf"
+  progress composite_runtime "$name" begin
+  set +e
+  timeout --signal=TERM --kill-after=2s "${RUNTIME_TIMEOUT_SECONDS}s" "$elf" >"$run_log" 2>&1
+  runtime_rc=$?
+  set -e
+  if [[ "$runtime_rc" -eq 124 ]]; then
+    cat "$run_log" >&2
+    fail "composite_runtime_timeout_$name"
+  fi
+  if [[ "$runtime_rc" -ne 0 ]]; then
+    cat "$run_log" >&2
+    fail "composite_runtime_${name}_rc_${runtime_rc}"
+  fi
+  grep -Fxq "$marker" "$run_log" || {
+    cat "$run_log" >&2
+    fail "marker_missing_$name"
+  }
+  progress composite_runtime "$name" pass
+}
+
+compose_and_run \
+  tests/native-v2/soir_v5_empty_reader_witness.sio \
+  SOIR_V5_EMPTY_READER_CANONICAL_PASS
+compose_and_run \
+  tests/native-v2/soir_v5_empty_reader_reject_witness.sio \
+  SOIR_V5_EMPTY_READER_REJECT_PASS
+while IFS= read -r path; do
+  sha256sum "$path"
+done < <(expected_paths) >"$TMP/lane-content.sha256"
+lane_content_sha256="$(sha256sum "$TMP/lane-content.sha256" | awk '{print $1}')"
+
+printf '%s\n' 'SOIR_V5_EMPTY_READER_CHECK source=2/2 composite=2/2 precision_identity=preserved'
+printf '%s\n' 'SOIR_V5_EMPTY_READER_WIRE exact_bytes=320 writer_length_bound=pass extension_count_bound=36 magic=checked version=5 reserved=zero-only truncated=reject trailing=reject unsupported_nonzero=reject request_cursor=local bounds_matrix=negative_start,negative_len,terminal_empty,insufficient_remaining,last_valid_frame repeat=pass offset_view=pass'
+printf '%s\n' 'SOIR_V5_EMPTY_READER_RECEIPT storage=fixed_scalar_words semantic_words=8 physical_words=9 padding_words=1 decoded_canary_on_failure=preserved aggregate_return=none'
+printf '%s\n' 'SOIR_V5_EMPTY_READER_BOUNDARY non_empty=not_claimed legacy_v1_v4=not_claimed opcode_decode=not_claimed arena_install=not_claimed issue_878=not_claimed default_pipeline=unchanged'
+printf 'SOIR_V5_EMPTY_READER_PROVENANCE head=%s tree=%s worktree_clean=pass compiler_source_sha=%s\n' \
+  "$head_sha" "$tree_sha" "$COMPILER_SOURCE_SHA"
+printf 'SOIR_V5_EMPTY_READER_PASS compiler_cli=%s compiler_cli_sha256=%s raw_compiler=%s raw_compiler_sha256=%s head=%s tree=%s lane_content_sha256=%s\n' \
+  "$COMPILER_CLI" "$compiler_cli_sha256" "$RAW_COMPILER" "$raw_compiler_sha256" "$head_sha" "$tree_sha" "$lane_content_sha256"

--- a/self-hosted/ir/soir_reader.sio
+++ b/self-hosted/ir/soir_reader.sio
@@ -1,0 +1,264 @@
+// Shadow-only bounded reader for the scalar empty SOIR v5 wire form.
+//
+// The reader accepts exactly the 320-byte frame emitted by soir_writer.sio.
+// Non-empty modules, legacy SOIR versions, opcodes, and extension payloads are
+// deliberately outside this vertical. The decoded receipt is published only
+// after every byte has been validated.
+
+module ir::soir_reader
+
+pub let SOIR_READER_MAX_SIZE: i64 = 131072
+pub let SOIR_READER_SCALAR_EMPTY_V5_SIZE: i64 = 320
+pub let SOIR_READER_EMPTY_EXTENSION_COUNT_FIELDS: i64 = 36
+pub let SOIR_READER_VERSION_V5: i64 = 5
+
+pub let SOIR_READER_OK: i64 = 0
+pub let SOIR_READER_ERR_VIEW_BOUNDS: i64 = 1
+pub let SOIR_READER_ERR_TRUNCATED: i64 = 2
+pub let SOIR_READER_ERR_TRAILING_BYTES: i64 = 3
+pub let SOIR_READER_ERR_BAD_MAGIC: i64 = 4
+pub let SOIR_READER_ERR_BAD_VERSION: i64 = 5
+pub let SOIR_READER_ERR_BAD_RESERVED: i64 = 6
+pub let SOIR_READER_ERR_UNSUPPORTED_NONZERO: i64 = 7
+pub let SOIR_READER_ERR_INTERNAL_BOUNDS: i64 = 8
+
+// Eight semantic words live in a nine-word physical view. The terminal word is
+// write-only padding and is never read as part of the receipt.
+pub let SOIR_READER_RECEIPT_WORDS: i64 = 8
+pub let SOIR_READER_RECEIPT_PHYSICAL_WORDS: i64 = 9
+pub let SOIR_READER_RECEIPT_CODE: i64 = 0
+pub let SOIR_READER_RECEIPT_BYTE_OFFSET: i64 = 1
+pub let SOIR_READER_RECEIPT_DETAIL: i64 = 2
+pub let SOIR_READER_RECEIPT_VERSION: i64 = 3
+pub let SOIR_READER_RECEIPT_FUNCTION_COUNT: i64 = 4
+pub let SOIR_READER_RECEIPT_STRING_COUNT: i64 = 5
+pub let SOIR_READER_RECEIPT_EXTENSION_FIELDS: i64 = 6
+pub let SOIR_READER_RECEIPT_BSS_TOTAL_SIZE: i64 = 7
+pub let SOIR_READER_RECEIPT_PADDING: i64 = 8
+
+struct SoirV5ReaderCursor {
+    pos: i64,
+    end: i64,
+}
+
+fn soir_v5_empty_read_status_set(
+    out: &![i64; 9],
+    code: i64,
+    byte_offset: i64,
+    detail: i64,
+) -> i64 with Mut {
+    out[SOIR_READER_RECEIPT_CODE as usize] = code
+    out[SOIR_READER_RECEIPT_BYTE_OFFSET as usize] = byte_offset
+    out[SOIR_READER_RECEIPT_DETAIL as usize] = detail
+    code
+}
+
+pub fn soir_v5_empty_read_status_code(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_CODE as usize]
+}
+
+pub fn soir_v5_empty_read_status_byte_offset(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_BYTE_OFFSET as usize]
+}
+
+pub fn soir_v5_empty_read_status_detail(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_DETAIL as usize]
+}
+
+pub fn soir_v5_empty_decoded_version(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_VERSION as usize]
+}
+
+pub fn soir_v5_empty_decoded_function_count(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_FUNCTION_COUNT as usize]
+}
+
+pub fn soir_v5_empty_decoded_string_count(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_STRING_COUNT as usize]
+}
+
+pub fn soir_v5_empty_decoded_extension_count_fields(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_EXTENSION_FIELDS as usize]
+}
+
+pub fn soir_v5_empty_decoded_bss_total_size(status: &[i64; 9]) -> i64 with Panic, Div {
+    (*status)[SOIR_READER_RECEIPT_BSS_TOTAL_SIZE as usize]
+}
+
+pub fn soir_reader_decode_scalar_empty_module_v5(
+    buf: &[i8; 131072],
+    start: i64,
+    len: i64,
+    status_out: &![i64; 9],
+) -> i64 with Mut, Panic, Div {
+    // Prove the request view before computing start + len or indexing buf.
+    if start < 0 ||
+       len < 0 ||
+       start > SOIR_READER_MAX_SIZE ||
+       len > SOIR_READER_MAX_SIZE - start {
+        return soir_v5_empty_read_status_set(
+            status_out,
+            SOIR_READER_ERR_VIEW_BOUNDS,
+            start,
+            len,
+        )
+    }
+    if len < SOIR_READER_SCALAR_EMPTY_V5_SIZE {
+        return soir_v5_empty_read_status_set(
+            status_out,
+            SOIR_READER_ERR_TRUNCATED,
+            start + len,
+            SOIR_READER_SCALAR_EMPTY_V5_SIZE,
+        )
+    }
+    if len > SOIR_READER_SCALAR_EMPTY_V5_SIZE {
+        return soir_v5_empty_read_status_set(
+            status_out,
+            SOIR_READER_ERR_TRAILING_BYTES,
+            start + SOIR_READER_SCALAR_EMPTY_V5_SIZE,
+            len - SOIR_READER_SCALAR_EMPTY_V5_SIZE,
+        )
+    }
+
+    var cursor = SoirV5ReaderCursor {
+        pos: start,
+        end: start + len,
+    }
+
+    // Keep wire loads in this request frame. Helper-level reference forwarding
+    // is outside the native-v2 proof surface for this shadow vertical.
+    var magic_index: i64 = 0
+    while magic_index < 4 {
+        if cursor.pos < 0 || cursor.pos >= cursor.end {
+            return soir_v5_empty_read_status_set(
+                status_out,
+                SOIR_READER_ERR_INTERNAL_BOUNDS,
+                cursor.pos,
+                1,
+            )
+        }
+        let magic_offset = cursor.pos
+        let magic = ((*buf)[cursor.pos as usize] as i64) & 255
+        cursor.pos = cursor.pos + 1
+        var expected_magic: i64 = 83
+        if magic_index == 1 { expected_magic = 79 }
+        else if magic_index == 2 { expected_magic = 73 }
+        else if magic_index == 3 { expected_magic = 82 }
+        if magic != expected_magic {
+            return soir_v5_empty_read_status_set(
+                status_out,
+                SOIR_READER_ERR_BAD_MAGIC,
+                magic_offset,
+                magic,
+            )
+        }
+        magic_index = magic_index + 1
+    }
+
+    if cursor.pos < 0 || cursor.pos >= cursor.end {
+        return soir_v5_empty_read_status_set(
+            status_out,
+            SOIR_READER_ERR_INTERNAL_BOUNDS,
+            cursor.pos,
+            1,
+        )
+    }
+    let version_offset = cursor.pos
+    let version = ((*buf)[cursor.pos as usize] as i64) & 255
+    cursor.pos = cursor.pos + 1
+    if version != SOIR_READER_VERSION_V5 {
+        return soir_v5_empty_read_status_set(
+            status_out,
+            SOIR_READER_ERR_BAD_VERSION,
+            version_offset,
+            version,
+        )
+    }
+
+    var reserved_index: i64 = 0
+    while reserved_index < 3 {
+        if cursor.pos < 0 || cursor.pos >= cursor.end {
+            return soir_v5_empty_read_status_set(
+                status_out,
+                SOIR_READER_ERR_INTERNAL_BOUNDS,
+                cursor.pos,
+                1,
+            )
+        }
+        let reserved_offset = cursor.pos
+        let reserved = ((*buf)[cursor.pos as usize] as i64) & 255
+        cursor.pos = cursor.pos + 1
+        if reserved != 0 {
+            return soir_v5_empty_read_status_set(
+                status_out,
+                SOIR_READER_ERR_BAD_RESERVED,
+                reserved_offset,
+                reserved,
+            )
+        }
+        reserved_index = reserved_index + 1
+    }
+
+    var function_count: i64 = 0
+    var string_count: i64 = 0
+    var bss_total_size: i64 = 0
+    var extension_index: i64 = 0
+    var field_index: i64 = 0
+    while field_index < 39 {
+        let field_offset = cursor.pos
+        if cursor.pos < 0 ||
+           cursor.pos > cursor.end ||
+           8 > cursor.end - cursor.pos {
+            return soir_v5_empty_read_status_set(
+                status_out,
+                SOIR_READER_ERR_INTERNAL_BOUNDS,
+                cursor.pos,
+                8,
+            )
+        }
+        var field_value: i64 = 0
+        var shift: i64 = 0
+        while shift < 64 {
+            let octet = ((*buf)[cursor.pos as usize] as i64) & 255
+            field_value = field_value | (octet << shift)
+            cursor.pos = cursor.pos + 1
+            shift = shift + 8
+        }
+        if field_value != 0 {
+            return soir_v5_empty_read_status_set(
+                status_out,
+                SOIR_READER_ERR_UNSUPPORTED_NONZERO,
+                field_offset,
+                field_value,
+            )
+        }
+        if field_index == 0 { function_count = field_value }
+        else if field_index == 1 { string_count = field_value }
+        else if field_index < 38 { extension_index = extension_index + 1 }
+        else { bss_total_size = field_value }
+        field_index = field_index + 1
+    }
+    if cursor.pos != cursor.end {
+        return soir_v5_empty_read_status_set(
+            status_out,
+            SOIR_READER_ERR_INTERNAL_BOUNDS,
+            cursor.pos,
+            cursor.end,
+        )
+    }
+
+    // All failure conditions are discharged. Publish the decoded scalars now.
+    soir_v5_empty_read_status_set(
+        status_out,
+        SOIR_READER_OK,
+        cursor.pos,
+        cursor.pos - start,
+    )
+    status_out[SOIR_READER_RECEIPT_VERSION as usize] = SOIR_READER_VERSION_V5
+    status_out[SOIR_READER_RECEIPT_FUNCTION_COUNT as usize] = function_count
+    status_out[SOIR_READER_RECEIPT_STRING_COUNT as usize] = string_count
+    status_out[SOIR_READER_RECEIPT_EXTENSION_FIELDS as usize] = extension_index
+    status_out[SOIR_READER_RECEIPT_BSS_TOTAL_SIZE as usize] = bss_total_size
+    status_out[SOIR_READER_RECEIPT_PADDING as usize] = 0
+    SOIR_READER_OK
+}

--- a/tests/native-v2/soir_v5_empty_reader_reject_witness.sio
+++ b/tests/native-v2/soir_v5_empty_reader_reject_witness.sio
@@ -1,0 +1,104 @@
+use ir::soir_writer::*
+use ir::soir_reader::*
+
+struct RejectExpectation {
+    start: i64,
+    len: i64,
+    code: i64,
+    offset: i64,
+    detail: i64,
+}
+
+fn rejected_with_preserved_decoded_canary(
+    wire: &[i8; 131072],
+    expected: &RejectExpectation,
+) -> bool with Mut, Panic, Div {
+    var status: [i64; 9] = [-1; 9]
+    let code = soir_reader_decode_scalar_empty_module_v5(
+        wire,
+        (*expected).start,
+        (*expected).len,
+        &! status,
+    )
+    code == (*expected).code &&
+        soir_v5_empty_read_status_code(&status) == (*expected).code &&
+        soir_v5_empty_read_status_byte_offset(&status) == (*expected).offset &&
+        soir_v5_empty_read_status_detail(&status) == (*expected).detail &&
+        soir_v5_empty_decoded_version(&status) == -1 &&
+        soir_v5_empty_decoded_function_count(&status) == -1 &&
+        soir_v5_empty_decoded_string_count(&status) == -1 &&
+        soir_v5_empty_decoded_extension_count_fields(&status) == -1 &&
+        soir_v5_empty_decoded_bss_total_size(&status) == -1
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var wire: [i8; 131072] = [85; 131072]
+    let plan = soir_writer_preflight_scalar_empty_module_v5(
+        0,
+        SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+    )
+    if soir_write_plan_status(&plan) != SOIR_WRITER_OK ||
+       soir_writer_emit_scalar_empty_module_v5(&plan, &! wire) != SOIR_WRITER_SCALAR_EMPTY_V5_SIZE {
+        return 10
+    }
+    wire[0] = 0 as i8
+    let bad_magic = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_BAD_MAGIC, offset: 0, detail: 0 }
+    if !rejected_with_preserved_decoded_canary(&wire, &bad_magic) { return 20 }
+    wire[0] = 83 as i8
+
+    wire[4] = 4 as i8
+    let bad_version = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_BAD_VERSION, offset: 4, detail: 4 }
+    if !rejected_with_preserved_decoded_canary(&wire, &bad_version) { return 21 }
+    wire[4] = 5 as i8
+
+    wire[5] = 1 as i8
+    let bad_reserved = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_BAD_RESERVED, offset: 5, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &bad_reserved) { return 22 }
+    wire[5] = 0 as i8
+
+    let truncated = RejectExpectation { start: 0, len: 319, code: SOIR_READER_ERR_TRUNCATED, offset: 319, detail: 320 }
+    if !rejected_with_preserved_decoded_canary(&wire, &truncated) { return 23 }
+    let trailing = RejectExpectation { start: 0, len: 321, code: SOIR_READER_ERR_TRAILING_BYTES, offset: 320, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &trailing) { return 24 }
+    let bad_view = RejectExpectation { start: -1, len: 320, code: SOIR_READER_ERR_VIEW_BOUNDS, offset: -1, detail: 320 }
+    if !rejected_with_preserved_decoded_canary(&wire, &bad_view) { return 25 }
+    let negative_len = RejectExpectation { start: 0, len: -1, code: SOIR_READER_ERR_VIEW_BOUNDS, offset: 0, detail: -1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &negative_len) { return 26 }
+    let terminal_empty = RejectExpectation { start: SOIR_READER_MAX_SIZE, len: 0, code: SOIR_READER_ERR_TRUNCATED, offset: SOIR_READER_MAX_SIZE, detail: 320 }
+    if !rejected_with_preserved_decoded_canary(&wire, &terminal_empty) { return 27 }
+    let insufficient_remaining = RejectExpectation { start: SOIR_READER_MAX_SIZE - 319, len: 320, code: SOIR_READER_ERR_VIEW_BOUNDS, offset: SOIR_READER_MAX_SIZE - 319, detail: 320 }
+    if !rejected_with_preserved_decoded_canary(&wire, &insufficient_remaining) { return 28 }
+
+    wire[8] = 1 as i8
+    let nonzero_fn = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_UNSUPPORTED_NONZERO, offset: 8, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &nonzero_fn) { return 30 }
+    wire[8] = 0 as i8
+
+    wire[15] = 1 as i8
+    let high_byte_fn = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_UNSUPPORTED_NONZERO, offset: 8, detail: 72057594037927936 }
+    if !rejected_with_preserved_decoded_canary(&wire, &high_byte_fn) { return 35 }
+    wire[15] = 0 as i8
+
+    wire[16] = 1 as i8
+    let nonzero_string = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_UNSUPPORTED_NONZERO, offset: 16, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &nonzero_string) { return 31 }
+    wire[16] = 0 as i8
+
+    wire[24] = 1 as i8
+    let nonzero_first_extension = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_UNSUPPORTED_NONZERO, offset: 24, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &nonzero_first_extension) { return 32 }
+    wire[24] = 0 as i8
+
+    wire[304] = 1 as i8
+    let nonzero_last_extension = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_UNSUPPORTED_NONZERO, offset: 304, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &nonzero_last_extension) { return 33 }
+    wire[304] = 0 as i8
+
+    wire[312] = 1 as i8
+    let nonzero_bss = RejectExpectation { start: 0, len: 320, code: SOIR_READER_ERR_UNSUPPORTED_NONZERO, offset: 312, detail: 1 }
+    if !rejected_with_preserved_decoded_canary(&wire, &nonzero_bss) { return 34 }
+    wire[312] = 0 as i8
+
+    print("SOIR_V5_EMPTY_READER_REJECT_PASS\n")
+    0
+}

--- a/tests/native-v2/soir_v5_empty_reader_witness.sio
+++ b/tests/native-v2/soir_v5_empty_reader_witness.sio
@@ -1,0 +1,113 @@
+use ir::soir_writer::*
+use ir::soir_reader::*
+
+fn receipt_is_empty_v5(
+    receipt: &[i64; 9],
+    absolute_end: i64,
+    frame_len: i64,
+) -> bool with Panic, Div {
+    soir_v5_empty_read_status_code(receipt) == SOIR_READER_OK &&
+        soir_v5_empty_read_status_byte_offset(receipt) == absolute_end &&
+        soir_v5_empty_read_status_detail(receipt) == frame_len &&
+        soir_v5_empty_decoded_version(receipt) == SOIR_READER_VERSION_V5 &&
+        soir_v5_empty_decoded_function_count(receipt) == 0 &&
+        soir_v5_empty_decoded_string_count(receipt) == 0 &&
+        soir_v5_empty_decoded_extension_count_fields(receipt) == SOIR_READER_EMPTY_EXTENSION_COUNT_FIELDS &&
+        soir_v5_empty_decoded_bss_total_size(receipt) == 0
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if SOIR_WRITER_SCALAR_EMPTY_V5_SIZE != SOIR_READER_SCALAR_EMPTY_V5_SIZE ||
+       SOIR_WRITER_EMPTY_EXTENSION_COUNT_FIELDS != SOIR_READER_EMPTY_EXTENSION_COUNT_FIELDS {
+        return 9
+    }
+    var wire: [i8; 131072] = [85; 131072]
+    let plan = soir_writer_preflight_scalar_empty_module_v5(
+        0,
+        SOIR_WRITER_SCALAR_EMPTY_V5_SIZE,
+    )
+    let emitted_end = soir_writer_emit_scalar_empty_module_v5(&plan, &! wire)
+    if soir_write_plan_status(&plan) != SOIR_WRITER_OK ||
+       emitted_end != SOIR_WRITER_SCALAR_EMPTY_V5_SIZE {
+        return 10
+    }
+
+    var first: [i64; 9] = [-1; 9]
+    let first_code = soir_reader_decode_scalar_empty_module_v5(
+        &wire,
+        0,
+        emitted_end,
+        &! first,
+    )
+    if first_code != SOIR_READER_OK ||
+       !receipt_is_empty_v5(&first, emitted_end, emitted_end) {
+        return 20
+    }
+
+    var repeated: [i64; 9] = [-77; 9]
+    let repeated_code = soir_reader_decode_scalar_empty_module_v5(
+        &wire,
+        0,
+        emitted_end,
+        &! repeated,
+    )
+    var receipts_match: bool = true
+    var receipt_index: i64 = 0
+    while receipt_index < SOIR_READER_RECEIPT_WORDS {
+        if first[receipt_index as usize] != repeated[receipt_index as usize] {
+            receipts_match = false
+        }
+        receipt_index = receipt_index + 1
+    }
+    if repeated_code != SOIR_READER_OK || !receipts_match {
+        return 21
+    }
+
+    var offset_wire: [i8; 131072] = [85; 131072]
+    var byte_index: i64 = 0
+    while byte_index < emitted_end {
+        offset_wire[(17 + byte_index) as usize] = wire[byte_index as usize]
+        byte_index = byte_index + 1
+    }
+    var offset_receipt: [i64; 9] = [-33; 9]
+    let offset_code = soir_reader_decode_scalar_empty_module_v5(
+        &offset_wire,
+        17,
+        emitted_end,
+        &! offset_receipt,
+    )
+    if offset_code != SOIR_READER_OK ||
+       !receipt_is_empty_v5(
+           &offset_receipt,
+           17 + emitted_end,
+           emitted_end,
+       ) {
+        return 22
+    }
+
+    var terminal_wire: [i8; 131072] = [85; 131072]
+    let terminal_start = SOIR_READER_MAX_SIZE - emitted_end
+    byte_index = 0
+    while byte_index < emitted_end {
+        terminal_wire[(terminal_start + byte_index) as usize] = wire[byte_index as usize]
+        byte_index = byte_index + 1
+    }
+    var terminal_receipt: [i64; 9] = [-44; 9]
+    let terminal_code = soir_reader_decode_scalar_empty_module_v5(
+        &terminal_wire,
+        terminal_start,
+        emitted_end,
+        &! terminal_receipt,
+    )
+    if terminal_code != SOIR_READER_OK ||
+       !receipt_is_empty_v5(
+           &terminal_receipt,
+           SOIR_READER_MAX_SIZE,
+           emitted_end,
+       ) {
+        return 23
+    }
+
+    print("SOIR_V5_EMPTY_READER_CANONICAL_PASS\n")
+    0
+}


### PR DESCRIPTION
## Description

Adds a shadow-only, bounded reader for the exact 320-byte scalar empty SOIR v5 frame already emitted by the existing writer.

The reader uses a request-local cursor, validates magic/version/reserved bytes, validates all 39 zero scalar words, and returns a fixed `[i64; 9]` status/decoded receipt without aggregate returns. The gate covers canonical, repeated, offset, terminal-frame, truncation, trailing-data, invalid-range, nonzero-field, and high-byte rejection cases. It passes the writer's returned `emitted_end` directly to the reader and requires the writer/reader size and extension-field constants to agree.

This is deliberately a narrow proof surface. It does **not** claim non-empty decoding, opcode reconstruction, Arena installation, legacy v1-v4 compatibility, or resolution of #878. The default compiler pipeline is unchanged, and the legacy writer remains intact as a differential oracle.

Independent review initially found four proof weaknesses: launcher hashing instead of raw compiler hashing, provenance not bound to a clean tree, a duplicated 320-byte length assumption, and an incomplete bounded-input rejection matrix. All four were fixed; the final independent rereview was clean.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes a compiler or runtime bug)
- [x] New feature (non-breaking change that adds a language or stdlib capability)
- [ ] Breaking change (fix or feature that would cause existing Sounio code to fail compilation)
- [ ] Refactoring (internal compiler or website optimization, no functional changes)
- [ ] Documentation update (translations, expansions, or spec syncs)
- [x] Test improvement (adding compile-fail gates or golden snapshot validations)
- [ ] Performance improvement (reduction of bootstrap build time or codegen optimization)

## Related Issues

Related to #1162 and #878. Context for the rejected legacy-v4 activation path: #1161.

## Traceability

- Traceability Matrix ID(s): N/A (shadow-only SOIR reader proof)
- Evidence Log(s): Slurm job/step `6669.5`; `results.tgz` SHA-256 `e0a1ce907ca61a5cc6aeb9e496610ee5f75e791924d45b314bb265afb4e05c10`

## Release Scope

- [x] Compiler (self-hosted / codegen)
- [ ] Stdlib (modules, units, epistemic types, ontology)
- [ ] Docs
- [ ] Website
- [x] CI / Workflow contracts
- [x] Non-release-blocking change

---

## Validation

Local strict gate on commit `f891fbd137c6606930d3cb4394e3e04f2a85ecab` and tree `93401d9b1dbcd2a3f6ed673ba590592a8c3eed61`:

- raw compiler SHA-256 pinned to `fa3bcbcb5f72c6d3d851f97521f60dfd6a277ea7faff984d31a10ca377335c2e`
- source witnesses: 2/2
- composite witnesses: 2/2
- missing raw compiler, wrong raw SHA, and wrong source SHA controls: all rejected with `rc=1` and no false PASS
- `bash -n scripts/ci/soir_v5_empty_reader_gate.sh`: PASS
- `git diff --check HEAD^ HEAD`: PASS

Source-fresh Slurm proof on job/step `6669.5`:

- independent build-source and proof-source extractions matched tree `93401d9b1dbcd2a3f6ed673ba590592a8c3eed61`
- fresh lean seed: `rc=0`, zero errors
- fresh Madaros raw compiler: `rc=0`, zero errors, SHA-256 `a6ded2f0f916de145ef915fe61c7324ac2043c0a48038cae914f5b3f6ea45a39`
- strict reader gate: source 2/2 and composite 2/2
- all three provenance-negative controls rejected with `rc=1` and exact markers
- no fallback compiler path was used

The broad repository suite was not run locally; the focused source-fresh Slurm gate is the semantic evidence for this shadow-only slice.

## Quality Checklist

- [x] **Semicolon Check**: I have verified there are absolutely no semicolons at the end of Sounio statements.
- [x] **Sounio Syntax Standards**: I used `var` instead of `let mut`, and `&!` instead of `&mut`.
- [x] **Algebraic Effects declared**: Every modified function declares its active side-effects correctly (`with IO, Mut, Div, Panic`, etc.).
- [x] **No Rust Macro syntax**: I used standard `println()` and `assert()` instead of `println!` or `assert!`.
- [x] **Mathematical Operators**: I wrote negative numbers using explicit math (`0 - x` instead of `-x`).
- [x] **Bit Shifts**: Shift operands are explicitly cast or typed as `u8` (e.g. `x >> 4u8`).
- [x] **Compile and Type-Check**: Targeted witnesses compile and execute through the strict gate using both pinned local raw Madaros and a source-fresh Slurm build.
- [ ] **Test Suite passes**: The entire repository suite was not run locally; GitHub CI is delegated to the asynchronous watcher.
- [ ] **Documentation Registry Sync**: No documentation files were changed.
- [x] **LLM-Offload Policy Compliance**: This parser/reader mechanics change touches no math claim, Lean theorem, clinical pathway, or external-facing artifact, so mandatory offload was not triggered.
- [x] **Apache-2.0 License**: I understand that my contributions will be licensed under the Apache License, Version 2.0.
