### PR TITLE
perf(stdlib): bf_col_sum 8-accumulator (1.5x) + dispatch C3 SIMD auto-vectorization

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1006
-- Repo-backed topics: 856
+- Total governed topics: 1007
+- Repo-backed topics: 857
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 606
+- Authority count `repo_only`: 607
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 625 topics
+- A2: 626 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -363,6 +363,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.apple-selfhost-release-gate-sigsegv-2026-07-10 | repo_only | docs/handoff/apple_selfhost_release_gate_sigsegv_2026-07-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.butterfly-handoff | repo_only | docs/handoff/butterfly-handoff.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.c2-heap-columnar-dataframe-codex-dispatch-2026-07-18 | repo_only | docs/handoff/c2_heap_columnar_dataframe_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.c3-simd-autovectorization-codex-dispatch-2026-07-19 | repo_only | docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-651-defects-codex-dispatch-2026-07-15 | repo_only | docs/handoff/compiler_651_defects_codex_dispatch_2026-07-15.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-generic-f-engine-unblock-prompt | repo_only | docs/handoff/compiler_generic_F_engine_unblock_prompt.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-generic-struct-return-diagnosis | repo_only | docs/handoff/compiler_generic_struct_return_diagnosis.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7849,6 +7849,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.c3-simd-autovectorization-codex-dispatch-2026-07-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.compiler-651-defects-codex-dispatch-2026-07-15",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/compiler_651_defects_codex_dispatch_2026-07-15.md",

--- a/docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md
+++ b/docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md
@@ -1,0 +1,76 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.c3-simd-autovectorization-codex-dispatch-2026-07-19
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.c3-simd-autovectorization-codex-dispatch-2026-07-19
+-->
+
+# Dispatch to CODEX-2 — C3: SIMD auto-vectorization of reduction loops (close the pandas gap)
+
+**Date:** 2026-07-19
+**Owner:** CODEX-2 (native codegen / lean_single backend)
+**Author:** data-science lane (measured on the shipped bigframe benchmark)
+**Status:** measured, quantified — the remaining reduction gap vs pandas is vectorization
+
+---
+
+## TL;DR
+
+After the stdlib-level fix (below), `bf_col_sum` over 1,000,000 f64 is **1.44 ms** vs pandas/numpy
+**0.55 ms** — a **2.6x** gap. That residual gap is **pure SIMD vectorization**: numpy's sum runs AVX
+(4-wide f64) over a contiguous buffer; Sounio emits a scalar loop. Closing it needs the **native
+backend to auto-vectorize simple reduction loops** (or expose SIMD intrinsics). No stdlib trick can
+recover it — the loop is already an optimal raw-pointer scalar loop.
+
+## What was measured (reproducible: `scripts/bench/run_bench.sh`)
+
+Reduction of 1,000,000 f64 (Sounio min-of-6, build baseline subtracted; numpy/pandas 3.0.3 perf_counter):
+
+| variant | ms | note |
+|---|---|---|
+| `bf_get(r,c)` per element | 2.09 | bounds-checked accessor |
+| raw `read_f64(p,i)`, 1 accumulator | 2.09 | **identical** — the accessor is inlined; call overhead is NOT the bottleneck |
+| raw, **8 accumulators (SHIPPED)** | 1.44 | ILP: independent accumulators break the serial add chain (~1.5x) |
+| numpy `.sum()` (AVX SIMD) | 0.24–0.55 | vectorized C kernel |
+
+**Correction to an earlier analysis:** the reduction gap was hypothesized to be per-element
+bounds-checked `bf_get` calls. That is FALSE — the raw-pointer loop and the `bf_get` loop are
+byte-for-byte the same time (2.09 ms), so the accessor is already inlined. The gap is entirely the
+scalar-vs-SIMD loop.
+
+## What the stdlib already did (shipped in this PR)
+
+`bf_col_sum` now uses **8 independent accumulators** over the raw column buffer (`read_f64`), summed
+pairwise at the end. This is instruction-level parallelism — the CPU issues multiple `addsd` per cycle
+because the accumulators are independent — and it is ~1.5x over the single-accumulator loop, correct to
+the bit (`49999950000000.0`). This is the ceiling of what stdlib can do without SIMD.
+
+## The ask
+
+Make the native/lean_single backend **auto-vectorize counted loops of the form
+`acc[k] += load(ptr + i*8)`** (reductions, elementwise map, filter-compare) into packed SIMD
+(`addpd`/`mulpd`/`cmppd` + a horizontal reduce), OR expose SIMD builtins (`f64x4_load`, `f64x4_add`,
+`f64x4_hsum`) that stdlib can target directly. Either closes the remaining ~2.6x on reductions and the
+~10x on scan/compare ops (`filter`) toward numpy/pandas kernel speed.
+
+- Simplest first target: recognize a `while i < n { acc = acc + read_f64(p, i); i = i + 1 }` loop and
+  emit a 4-wide `addpd` body + scalar tail. That single pattern covers `bf_col_sum`/`bf_col_mean` and,
+  generalized, the filter compare.
+- Alternatively (broader): a `@simd` loop annotation or `f64x4` primitive type.
+
+## Acceptance
+- `bf_col_sum` over 1M f64 drops from ~1.44 ms toward ~0.3–0.6 ms (within ~1.5x of numpy).
+- Correctness unchanged (bit-exact for integer-valued data; documented FP-associativity note for
+  reordered sums, same as the multi-accumulator version already is).
+
+## Scope / non-goals
+- **GPU is a separate, later path:** a single 1M-element reduction is memory-bandwidth-bound; a
+  CPU→GPU transfer of 8 MB costs more than the sum. GPU wins only for GPU-resident columns with many
+  ops — that is a C3b campaign on top of the existing `self-hosted/gpu/` PTX backend, not this one.
+- This dispatch is CPU SIMD only: the highest-leverage, most broadly-applicable perf win.
+
+## Pointers
+- Shipped optimization + benchmark: `stdlib/data/bigframe.sio` (`bf_col_sum`), `scripts/bench/RESULTS.md`,
+  `scripts/bench/run_bench.sh`. Roadmap: `docs/vision/sounio_dataframe_overall_superiority_roadmap_2026-07-18.md` (C3).

--- a/stdlib/data/bigframe.sio
+++ b/stdlib/data/bigframe.sio
@@ -154,13 +154,36 @@ pub fn bf_col_sum(bf: &BigFrame, c: i64) -> f64 {
     if c < 0 { return 0.0 }
     if c >= bf.n_cols { return 0.0 }
     let p = bf.col_ptrs[c] as *mut f64
-    var s: f64 = 0.0
-    var r: i64 = 0
-    while r < bf.n_rows {
-        s = s + read_f64(p, r)
-        r = r + 1
+    let n = bf.n_rows
+    // 8 independent accumulators break the serial add dependency chain so the CPU pipelines the
+    // adds (instruction-level parallelism) -- ~1.4x over a single accumulator. True SIMD would close
+    // the rest of the gap to a vectorized kernel; that is a compiler auto-vectorization item (C3).
+    var a0: f64 = 0.0
+    var a1: f64 = 0.0
+    var a2: f64 = 0.0
+    var a3: f64 = 0.0
+    var a4: f64 = 0.0
+    var a5: f64 = 0.0
+    var a6: f64 = 0.0
+    var a7: f64 = 0.0
+    let n8 = n - (n % 8)
+    var i: i64 = 0
+    while i < n8 {
+        a0 = a0 + read_f64(p, i)
+        a1 = a1 + read_f64(p, i + 1)
+        a2 = a2 + read_f64(p, i + 2)
+        a3 = a3 + read_f64(p, i + 3)
+        a4 = a4 + read_f64(p, i + 4)
+        a5 = a5 + read_f64(p, i + 5)
+        a6 = a6 + read_f64(p, i + 6)
+        a7 = a7 + read_f64(p, i + 7)
+        i = i + 8
     }
-    s
+    while i < n {
+        a0 = a0 + read_f64(p, i)
+        i = i + 1
+    }
+    ((a0 + a1) + (a2 + a3)) + ((a4 + a5) + (a6 + a7))
 }
 
 pub fn bf_col_mean(bf: &BigFrame, c: i64) -> f64 {


### PR DESCRIPTION
## C3 (performance): the stdlib half shipped + the compiler half dispatched

### Shipped: `bf_col_sum` 8-accumulator — 1.5× faster, gap 3.9× → 2.6×
`bf_col_sum` now uses **8 independent accumulators** over the raw column buffer, so the CPU pipelines the adds (instruction-level parallelism, no SIMD needed).

| variant | 1M-f64 sum | |
|---|---|---|
| 1 accumulator (before) | 2.09 ms | |
| **8 accumulators (shipped)** | **1.44 ms** | **1.5× faster** |
| pandas | 0.55 ms | gap **3.9× → 2.6×** |

Bit-exact (`49999950000000.0`); bigframe + bigframe_ops gates still green.

### Correction to an earlier analysis
The reduction gap was blamed on per-element bounds-checked `bf_get` calls. **That's false** — the raw `read_f64` loop and the `bf_get` loop are the *same* 2.09 ms (the accessor is inlined). The gap is **pure scalar-vs-SIMD**: numpy's `.sum()` runs AVX 4-wide (0.24–0.55 ms). 8 accumulators is the ceiling of what stdlib can do without SIMD.

### Dispatched to CODEX-2: SIMD auto-vectorization
`docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md` — auto-vectorize counted reduction/map/compare loops into packed SIMD (`addpd` + horizontal reduce), or expose `f64x4` builtins. Closes the residual ~2.6× on reductions / ~10× on filter toward numpy. **GPU noted as a separate later path** (a single 1M reduction is memory-bandwidth-bound — CPU→GPU transfer costs more than the sum; GPU wins only for GPU-resident multi-op columns).

Reproducible: `scripts/bench/run_bench.sh`. No compiler changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)