### PR TITLE
feat(gpu): real readout Re(C⊗h) → train the FULL O-SSM cell (A, B, C) on tensor cores (GB10)

### DIFF
--- a/docs/gpu/ossm_oct_readout_tile.ptx
+++ b/docs/gpu/ossm_oct_readout_tile.ptx
@@ -1,0 +1,66 @@
+.version 7.0
+.target sm_50
+.address_size 64
+
+.visible .entry step(
+    .param .u64 pC,
+    .param .u64 pH,
+    .param .u64 py
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<8>;
+    .reg .f64 %fd<3>;
+
+    ld.param.u64 %rd0, [pC];
+    ld.param.u64 %rd1, [pH];
+    ld.param.u64 %rd2, [py];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $RDONE;
+    mov.u32 %r5, 0;
+$RB:
+    mul.wide.u32 %rd6, %r5, 8;
+    add.s64 %rd7, %rd1, %rd6;
+    ld.global.f64 %fd1, [%rd0];
+    ld.global.f64 %fd2, [%rd7];
+    mul.f64 %fd0, %fd1, %fd2;
+    ld.global.f64 %fd1, [%rd0+8];
+    ld.global.f64 %fd2, [%rd7+128];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+16];
+    ld.global.f64 %fd2, [%rd7+256];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+24];
+    ld.global.f64 %fd2, [%rd7+384];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+32];
+    ld.global.f64 %fd2, [%rd7+512];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+40];
+    ld.global.f64 %fd2, [%rd7+640];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+48];
+    ld.global.f64 %fd2, [%rd7+768];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+56];
+    ld.global.f64 %fd2, [%rd7+896];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    mul.wide.u32 %rd6, %r5, 8;
+    add.s64 %rd7, %rd2, %rd6;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 16;
+    @%p1 bra $RB;
+$RDONE:
+    ret;
+}

--- a/docs/gpu/ossm_sed_readout_tile.ptx
+++ b/docs/gpu/ossm_sed_readout_tile.ptx
@@ -1,0 +1,98 @@
+.version 7.0
+.target sm_50
+.address_size 64
+
+.visible .entry step(
+    .param .u64 pC,
+    .param .u64 pH,
+    .param .u64 py
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<8>;
+    .reg .f64 %fd<3>;
+
+    ld.param.u64 %rd0, [pC];
+    ld.param.u64 %rd1, [pH];
+    ld.param.u64 %rd2, [py];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $RDONE;
+    mov.u32 %r5, 0;
+$RB:
+    mul.wide.u32 %rd6, %r5, 8;
+    add.s64 %rd7, %rd1, %rd6;
+    ld.global.f64 %fd1, [%rd0];
+    ld.global.f64 %fd2, [%rd7];
+    mul.f64 %fd0, %fd1, %fd2;
+    ld.global.f64 %fd1, [%rd0+8];
+    ld.global.f64 %fd2, [%rd7+128];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+16];
+    ld.global.f64 %fd2, [%rd7+256];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+24];
+    ld.global.f64 %fd2, [%rd7+384];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+32];
+    ld.global.f64 %fd2, [%rd7+512];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+40];
+    ld.global.f64 %fd2, [%rd7+640];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+48];
+    ld.global.f64 %fd2, [%rd7+768];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+56];
+    ld.global.f64 %fd2, [%rd7+896];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+64];
+    ld.global.f64 %fd2, [%rd7+1024];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+72];
+    ld.global.f64 %fd2, [%rd7+1152];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+80];
+    ld.global.f64 %fd2, [%rd7+1280];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+88];
+    ld.global.f64 %fd2, [%rd7+1408];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+96];
+    ld.global.f64 %fd2, [%rd7+1536];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+104];
+    ld.global.f64 %fd2, [%rd7+1664];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+112];
+    ld.global.f64 %fd2, [%rd7+1792];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    ld.global.f64 %fd1, [%rd0+120];
+    ld.global.f64 %fd2, [%rd7+1920];
+    mul.f64 %fd1, %fd1, %fd2;
+    sub.f64 %fd0, %fd0, %fd1;
+    mul.wide.u32 %rd6, %r5, 8;
+    add.s64 %rd7, %rd2, %rd6;
+    st.global.f64 [%rd7], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 16;
+    @%p1 bra $RB;
+$RDONE:
+    ret;
+}

--- a/docs/gpu/run_bptt_cell_ptx.cu
+++ b/docs/gpu/run_bptt_cell_ptx.cu
@@ -1,0 +1,118 @@
+// End-to-end training of the FULL O-SSM cell with the real readout, on the DGX Spark GB10:
+//   S_t = A⊗H_{t-1} + B·x_t ,  H_t = σ(S_t) ,  y_t = Re(C⊗H_t) ,  Loss = Σ_t Σ_b (y_t[b] − tgt_t[b])²
+// Four compiler-lowered kernels: ossm_oct_step (S), ossm_oct_readout (y=Re(C⊗H)), ossm_oct_bwd_nl
+// (dA via σ'), and ossm_oct_bwd applied to (C, H, row-0 gradient) for the readout backward (dC + the
+// activation-space gradient dH_readout = L(C)ᵀ·dD_row0). Trains A, B AND C. Recurrence unroll + SGD
+// on the host. Usage: run_bptt_cell <step.ptx> <readout.ptx> <bwd.ptx> <bwdnl.ptx> <dim> [p1only].
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+static double sig(double s){return (1.0/64.0)*s*s*s+0.25*s+0.5;}
+static double sigp(double s){return (3.0/64.0)*s*s+0.25;}
+#define CK(x) do{CUresult e=(x);if(e){const char*ss;cuGetErrorString(e,&ss);printf("ERR %s@%d:%s\n",#x,__LINE__,ss);return 2;}}while(0)
+static int DIM,BITS; static CUfunction FWD,RDO,BWD,BWN;
+static void fwd(CUdeviceptr A,CUdeviceptr B,CUdeviceptr x,CUdeviceptr H,CUdeviceptr S){void*a[]={&A,&B,&x,&H,&S};cuLaunchKernel(FWD,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+static void rdo(CUdeviceptr C,CUdeviceptr H,CUdeviceptr y){void*a[]={&C,&H,&y};cuLaunchKernel(RDO,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+static void bwd(CUdeviceptr C,CUdeviceptr Hp,CUdeviceptr dD,CUdeviceptr dHp,CUdeviceptr dC){void*a[]={&C,&Hp,&dD,&dHp,&dC};cuLaunchKernel(BWD,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+static void bwn(CUdeviceptr A,CUdeviceptr Hp,CUdeviceptr dHt,CUdeviceptr S,CUdeviceptr dHp,CUdeviceptr dA){void*a[]={&A,&Hp,&dHt,&S,&dHp,&dA};cuLaunchKernel(BWN,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+
+int main(int c,char**v){
+ const char*ps=c>1?v[1]:"/tmp/step.ptx"; const char*pr=c>2?v[2]:"/tmp/rdo.ptx";
+ const char*pb=c>3?v[3]:"/tmp/bwd.ptx"; const char*pn=c>4?v[4]:"/tmp/bwdnl.ptx"; DIM=c>5?atoi(v[5]):8; BITS=(DIM==16)?4:3;
+ const int ND=DIM*16;
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext cx;CK(cuDevicePrimaryCtxRetain(&cx,d));CK(cuCtxSetCurrent(cx));
+ CUmodule ms,mr,mb,mn;CK(cuModuleLoad(&ms,ps));CK(cuModuleLoad(&mr,pr));CK(cuModuleLoad(&mb,pb));CK(cuModuleLoad(&mn,pn));
+ CK(cuModuleGetFunction(&FWD,ms,"step"));CK(cuModuleGetFunction(&RDO,mr,"step"));CK(cuModuleGetFunction(&BWD,mb,"step"));CK(cuModuleGetFunction(&BWN,mn,"step"));
+ CUdeviceptr dA_,dB_,dC_,dx_,dHsm_,dHd_,dS_,dy_,dD_,dHp_,dHt_,dSp_,dgA_,dgC_;
+ CK(cuMemAlloc(&dA_,DIM*8));CK(cuMemAlloc(&dB_,DIM*8));CK(cuMemAlloc(&dC_,DIM*8));CK(cuMemAlloc(&dx_,16*8));
+ CK(cuMemAlloc(&dHsm_,ND*8));CK(cuMemAlloc(&dHd_,256*8));CK(cuMemAlloc(&dS_,256*4));CK(cuMemAlloc(&dy_,16*8));
+ CK(cuMemAlloc(&dD_,256*8));CK(cuMemAlloc(&dHp_,256*8));CK(cuMemAlloc(&dHt_,256*8));CK(cuMemAlloc(&dSp_,256*8));
+ CK(cuMemAlloc(&dgA_,DIM*8));CK(cuMemAlloc(&dgC_,DIM*8));
+
+ // ── Part 1: validate the real readout y = Re(C⊗H) vs host ────────────────────────────────────
+ {
+  double C[16]={0},Hd[256]={0};
+  for(int i=0;i<DIM;i++)C[i]=0.3*((i%2)?-1:1)+0.04*i;
+  for(int p=0;p<DIM;p++)for(int b=0;b<16;b++)Hd[p*16+b]=0.2*sin(0.4*p+0.6*b);
+  double yref[16]={0};
+  for(int b=0;b<16;b++){double s=0;for(int p=0;p<DIM;p++)s+=(double)cds(p,p,BITS)*C[p]*Hd[p*16+b];yref[b]=s;}
+  CK(cuMemcpyHtoD(dC_,C,DIM*8));CK(cuMemcpyHtoD(dHd_,Hd,256*8));
+  rdo(dC_,dHd_,dy_);
+  double gy[16];CK(cuMemcpyDtoH(gy,dy_,16*8));
+  int f=0;double mx=0;for(int b=0;b<16;b++){double e=fabs(gy[b]-yref[b]);if(e>mx)mx=e;if(e>1e-9)f++;}
+  printf("Part 1 — real readout y = Re(C⊗H) (%s): mismatch %d/16 maxerr=%.2e\n",(DIM==16)?"sedenion":"octonion",f,mx);
+  if(f){printf("FAIL (part 1)\n");return 1;} printf("  PASS\n");
+ }
+ if(c>6 && strcmp(v[6],"p1only")==0){printf("(p1only) readout validated; training skipped.\n");return 0;}
+
+ // ── Part 2: full-cell training (learns A, B, C) ──────────────────────────────────────────────
+ const int T=3, NITER=120;
+ const double lr=(DIM==16)?0.003:0.012;
+ const double asc=(DIM==16)?0.5:1.0, pert=(DIM==16)?0.035:0.07;
+ double h0[256]={0}, x[3][16], As[16],Bs[16],Cs[16];
+ for(int b=0;b<16;b++)for(int j=0;j<DIM;j++)h0[b*DIM+j]=0.1*((b%2)?-1:1)+0.02*j;
+ for(int t=0;t<T;t++)for(int b=0;b<16;b++)x[t][b]=0.3*sin(0.7*t+0.4*b);
+ for(int i=0;i<DIM;i++){As[i]=asc*(0.25*((i%2)?-1:1)+0.04*i);Bs[i]=asc*(0.15-0.03*i);Cs[i]=0.3*((i%2)?1:-1)+0.03*i;}
+ // teacher targets y_t via the full forward (step+σ+readout)
+ double tgt[3][16]={{0}};
+ {
+  double hsm[256];memcpy(hsm,h0,sizeof(double)*256);
+  CK(cuMemcpyHtoD(dA_,As,DIM*8));CK(cuMemcpyHtoD(dB_,Bs,DIM*8));CK(cuMemcpyHtoD(dC_,Cs,DIM*8));
+  for(int t=0;t<T;t++){
+   CK(cuMemcpyHtoD(dx_,x[t],16*8));CK(cuMemcpyHtoD(dHsm_,hsm,ND*8));fwd(dA_,dB_,dx_,dHsm_,dS_);
+   float S[256];CK(cuMemcpyDtoH(S,dS_,256*4)); double hd[256];
+   for(int p=0;p<DIM;p++)for(int b=0;b<16;b++)hd[p*16+b]=sig(S[p*16+b]);
+   CK(cuMemcpyHtoD(dHd_,hd,256*8));rdo(dC_,dHd_,dy_);CK(cuMemcpyDtoH(tgt[t],dy_,16*8));
+   for(int p=0;p<DIM;p++)for(int b=0;b<16;b++)hsm[b*DIM+p]=hd[p*16+b];
+  }
+ }
+ double A[16],Bp[16],C[16];for(int i=0;i<DIM;i++){A[i]=As[i]+pert*((i%2)?-1:1);Bp[i]=Bs[i]+pert*0.8*((i%3)?1:-1);C[i]=Cs[i]+pert*0.9*((i%2)?-1:1);}
+ double loss0=0,lossN=0;
+ double Straj[3][256],Hd[3][256],hsm[4][256];
+ for(int it=0; it<NITER; it++){
+  memcpy(hsm[0],h0,sizeof(double)*256);
+  CK(cuMemcpyHtoD(dA_,A,DIM*8));CK(cuMemcpyHtoD(dB_,Bp,DIM*8));CK(cuMemcpyHtoD(dC_,C,DIM*8));
+  double loss=0, ytr[3][16];
+  for(int t=0;t<T;t++){
+   CK(cuMemcpyHtoD(dx_,x[t],16*8));CK(cuMemcpyHtoD(dHsm_,hsm[t],ND*8));fwd(dA_,dB_,dx_,dHsm_,dS_);
+   float S[256];CK(cuMemcpyDtoH(S,dS_,256*4));
+   for(int p=0;p<DIM;p++)for(int b=0;b<16;b++){Straj[t][p*16+b]=S[p*16+b];Hd[t][p*16+b]=sig(S[p*16+b]);}
+   CK(cuMemcpyHtoD(dHd_,Hd[t],256*8));rdo(dC_,dHd_,dy_);CK(cuMemcpyDtoH(ytr[t],dy_,16*8));
+   for(int b=0;b<16;b++){double e=ytr[t][b]-tgt[t][b];loss+=e*e;}
+   for(int p=0;p<DIM;p++)for(int b=0;b<16;b++)hsm[t+1][b*DIM+p]=Hd[t][p*16+b];
+  }
+  if(it==0)loss0=loss; lossN=loss;
+  // backward
+  double dBacc[16]={0}, dHnext[256]={0}, z[16]={0};
+  CK(cuMemcpyHtoD(dgA_,z,DIM*8));CK(cuMemcpyHtoD(dgC_,z,DIM*8));
+  for(int t=T-1;t>=0;t--){
+   // readout backward: dD_row0[k*16+b] = (k==0? dy:0); ossm_oct_bwd(C, H_t_sm, dD_row0) → dH_readout, dC
+   double dD[256]={0}; for(int b=0;b<16;b++)dD[0*16+b]=2.0*(ytr[t][b]-tgt[t][b]);
+   double Hsm[256]={0}; for(int p=0;p<DIM;p++)for(int b=0;b<16;b++)Hsm[b*DIM+p]=Hd[t][p*16+b];
+   CK(cuMemcpyHtoD(dHp_,dD,256*8)); // dD_row0 (reuse dHp_ as dD input to bwd)
+   CK(cuMemcpyHtoD(dSp_,Hsm,ND*8)); // H_t state-major (Hprev of the readout multiply)
+   bwd(dC_,dSp_,dHp_,dD_,dgC_);      // dC_=C, dSp_=H, dHp_=dD_row0 → dD_=dH_readout(Dlayout), dgC_+=dC
+   double dHr[256];CK(cuMemcpyDtoH(dHr,dD_,256*8));
+   // total activation gradient dH_t = dH_readout + dH_recurrent
+   double dHt[256]; for(int k=0;k<DIM;k++)for(int b=0;b<16;b++)dHt[k*16+b]=dHr[k*16+b]+dHnext[k*16+b];
+   // dB += Σ (dHt·σ'(S))·x
+   for(int k=0;k<DIM;k++){double s=0;for(int b=0;b<16;b++)s+=dHt[k*16+b]*sigp(Straj[t][k*16+b])*x[t][b];dBacc[k]+=s;}
+   // recurrent backward (nonlinear): ossm_oct_bwd_nl(A, h_{t-1}_sm, dHt, S_t) → dH_recurrent, dA
+   CK(cuMemcpyHtoD(dHt_,dHt,256*8));CK(cuMemcpyHtoD(dSp_,Straj[t],256*8));CK(cuMemcpyHtoD(dHp_,hsm[t],ND*8));
+   bwn(dA_,dHp_,dHt_,dSp_,dD_,dgA_);
+   CK(cuMemcpyDtoH(dHnext,dD_,256*8));
+  }
+  double dA[16],dC[16];CK(cuMemcpyDtoH(dA,dgA_,DIM*8));CK(cuMemcpyDtoH(dC,dgC_,DIM*8));
+  for(int p=0;p<DIM;p++){A[p]-=lr*dA[p];Bp[p]-=lr*dBacc[p];C[p]-=lr*dC[p];}
+  if(it==0||it==NITER-1||it%20==19)printf("  iter %2d  loss %.5f\n",it,loss);
+ }
+ printf("Part 2 — FULL-CELL training (A,B,C via Re(C⊗σ(A⊗h+B·x))): loss %.5f → %.5f  (%.1f%% reduction)\n",loss0,lossN,100.0*(loss0-lossN)/loss0);
+ if(lossN < 0.5*loss0){printf("PASS: trained the full O-SSM cell (state recurrence + nonlinearity + real readout) on GB10\n");return 0;}
+ printf("FAIL: loss did not fall enough\n");return 1;
+}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1833,6 +1833,16 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             bwd.src_reg = instr.call_args[3]
             bwd.shared_addr = instr.call_args[4]
             k = gpu_kernel_append_op(k, bwd)
+        } else if hlir_name_is_ossm_oct_readout(cn) || hlir_name_is_ossm_sed_readout(cn) {
+            // O-SSM real readout y = Re(C⊗h). call_args = [pC, pH, py]. σ(p,p)-signed reduction → one
+            // GpuOctReadout (no tile). Octonion dim=8; sedenion dim=16.
+            var rdo = gpu_op_new()
+            rdo.opcode = GpuOpcode::GpuOctReadout
+            rdo.rhs_imm = if hlir_name_is_ossm_sed_readout(cn) { 16 } else { 8 }
+            rdo.lhs_reg = instr.call_args[0]
+            rdo.rhs_reg = instr.call_args[1]
+            rdo.addr_reg = instr.call_args[2]
+            k = gpu_kernel_append_op(k, rdo)
         } else if hlir_name_is_ossm_oct_bwd_nl(cn) || hlir_name_is_ossm_sed_bwd_nl(cn) {
             // NONLINEAR BPTT backward step. call_args = [pA, pHprev, pdHt, pS, pdHprev, pdA]. Applies
             // dS = dHt ⊙ σ'(S) then the backward multiply → one GpuOctBwdNl. Needs 2048 shared bytes.
@@ -2000,6 +2010,24 @@ fn hlir_name_is_ossm_sed_bwd_nl(n: HlirName) -> bool {
     n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
     n.buf[8] == 95 as i8 && n.buf[9] == 98 as i8 && n.buf[10] == 119 as i8 && n.buf[11] == 100 as i8 &&
     n.buf[12] == 95 as i8 && n.buf[13] == 110 as i8 && n.buf[14] == 108 as i8
+}
+
+// "ossm_oct_readout" (16 chars) — O-SSM real readout y = Re(C⊗h) (octonion, dim=8, bits=3).
+fn hlir_name_is_ossm_oct_readout(n: HlirName) -> bool {
+    if n.len != 16 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
+    n.buf[4] == 95 as i8 && n.buf[5] == 111 as i8 && n.buf[6] == 99 as i8 && n.buf[7] == 116 as i8 &&
+    n.buf[8] == 95 as i8 && n.buf[9] == 114 as i8 && n.buf[10] == 101 as i8 && n.buf[11] == 97 as i8 &&
+    n.buf[12] == 100 as i8 && n.buf[13] == 111 as i8 && n.buf[14] == 117 as i8 && n.buf[15] == 116 as i8
+}
+
+// "ossm_sed_readout" (16 chars) — O-SSM real readout y = Re(C⊗h) (sedenion, dim=16, bits=4).
+fn hlir_name_is_ossm_sed_readout(n: HlirName) -> bool {
+    if n.len != 16 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 115 as i8 && n.buf[2] == 115 as i8 && n.buf[3] == 109 as i8 &&
+    n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
+    n.buf[8] == 95 as i8 && n.buf[9] == 114 as i8 && n.buf[10] == 101 as i8 && n.buf[11] == 97 as i8 &&
+    n.buf[12] == 100 as i8 && n.buf[13] == 111 as i8 && n.buf[14] == 117 as i8 && n.buf[15] == 116 as i8
 }
 
 fn hlir_name_starts_with_gpu_thread(n: HlirName) -> bool {

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -134,6 +134,9 @@ pub enum GpuOpcode {
     //   derivative dS = dHt ⊙ σ'(S), σ'(s)=(3/64)s²+1/4, using the pre-activation S, BEFORE the
     //   backward multiply — so it trains h_t = σ(A⊗h_{t-1}+B·x_t). Extra pS pointer. Pointers pa,pHprev,
     //   pdHt,pS,pdHprev,pdA in lhs/rhs/addr/src/shared_addr/compare_reg; rhs_imm = dim.
+    GpuOctReadout,      // O-SSM real readout y[b] = Re(C⊗h)[b] = Σ_p σ(p,p)·C[p]·h[p,b] = C[0]h[0,b]
+    //   − Σ_{p≥1}C[p]h[p,b] (the diagonal p⊕q=0 terms). h is D-layout [p*16+b]; y is real [16].
+    //   A σ(p,p)-signed reduction (no tile — Re is diagonal). pC,pH,py in lhs/rhs/addr; rhs_imm = dim.
     GpuTmaLoad,         // Tensor memory access load (sm_90+)
     GpuTmaStore,        // Tensor memory access store (sm_90+)
 

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -173,7 +173,8 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     let postadd = gpu_has_oct_postadd(kernel)
     // The associator, VJP and BPTT-backward need the same register classes as the cell.
     let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel) || gpu_has_oct_vjp(kernel) || gpu_has_oct_bwd(kernel) || gpu_has_oct_bwd_nl(kernel)
-    let stage_or_pa = stage || postadd || cell
+    let readout = gpu_has_oct_readout(kernel)
+    let stage_or_pa = stage || postadd || cell || readout
 
     // .reg .pred %p<N> — the staging loop / post-add need at least %p<2>.
     var pred_count = kernel.max_reg_pred
@@ -188,6 +189,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     var b32_count = if kernel.max_reg_u32 > kernel.max_reg_i32 { kernel.max_reg_u32 } else { kernel.max_reg_i32 }
     if stage_or_pa && b32_count < 8 { b32_count = 8 }
     if cell && b32_count < 12 { b32_count = 12 }
+    if readout && b32_count < 6 { b32_count = 6 }
     if b32_count > 0 {
         out = ptx_push_str(out, "    .reg .b32 %r<")
         out = gpu_push_i64(out, b32_count)
@@ -198,7 +200,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     // (params occupy %rd0..%rd5, so scratch must avoid clobbering them, e.g. pC=%rd3).
     var b64_count = if kernel.max_reg_u64 > kernel.max_reg_i64 { kernel.max_reg_u64 } else { kernel.max_reg_i64 }
     // The cell and the O-SSM-step post-add both use %rd7 as address scratch (runtime loops).
-    if (cell || postadd) && b64_count < 8 { b64_count = 8 }
+    if (cell || postadd || readout) && b64_count < 8 { b64_count = 8 }
     if b64_count > 0 {
         out = ptx_push_str(out, "    .reg .b64 %rd<")
         out = gpu_push_i64(out, b64_count)
@@ -222,7 +224,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     // .reg .f64 %fd<N> — staging needs %fd0; post-add/cell need %fd1..%fd2.
     var f64_count = kernel.max_reg_f64
     if stage && f64_count < 2 { f64_count = 2 }
-    if (postadd || cell) && f64_count < 3 { f64_count = 3 }
+    if (postadd || cell || readout) && f64_count < 3 { f64_count = 3 }
     if f64_count > 0 {
         out = ptx_push_str(out, "    .reg .f64 %fd<")
         out = gpu_push_i64(out, f64_count)
@@ -1105,6 +1107,45 @@ fn gpu_bwd_nl_dim(kernel: GpuKernelIr) -> i64 {
     8
 }
 
+// Does this kernel contain the real-readout op?
+fn gpu_has_oct_readout(kernel: GpuKernelIr) -> bool {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctReadout { return true }
+        i = i + 1
+    }
+    false
+}
+
+// O-SSM real readout y[b] = Re(C⊗h)[b] = Σ_p σ(p,p)·C[p]·h[p,b], thread 0. σ(p,p)=+1 for p=0, −1 for
+// p≥1, so y[b] = C[0]·h[0,b] − Σ_{p≥1} C[p]·h[p,b]. h is D-layout [p*16+b]; the p-stride is 16*8=128
+// bytes (immediate offsets, p unrolled). b runs 0..16 as a runtime loop. CR/HR/yR are the pointers.
+fn gpu_emit_oct_readout(CR: string, HR: string, yR: string, dim: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.u32 %r1, %tid.x;\n    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $RDONE;\n"
+    t = str_concat(t, "    mov.u32 %r5, 0;\n$RB:\n")
+    // %rd7 = HR + b*8  (base for h[p,b], p-stride +128)
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd6, %r5, 8;\n    add.s64 %rd7, "), HR)
+    t = str_concat(t, ", %rd6;\n")
+    // p=0: acc = C[0]·h[0,b]
+    t = str_concat(str_concat(t, "    ld.global.f64 %fd1, ["), CR)
+    t = str_concat(t, "];\n    ld.global.f64 %fd2, [%rd7];\n    mul.f64 %fd0, %fd1, %fd2;\n")
+    // p=1..dim-1: acc -= C[p]·h[p,b]  (immediate offsets p*8 on C, p*128 on h)
+    var p: i64 = 1
+    while p < dim {
+        t = str_concat(str_concat(t, "    ld.global.f64 %fd1, ["), CR)
+        t = str_concat(str_concat(t, "+"), i64_to_string(p * 8))
+        t = str_concat(t, "];\n")
+        t = str_concat(str_concat(t, "    ld.global.f64 %fd2, [%rd7+"), i64_to_string(p * 128))
+        t = str_concat(t, "];\n    mul.f64 %fd1, %fd1, %fd2;\n    sub.f64 %fd0, %fd0, %fd1;\n")
+        p = p + 1
+    }
+    // y[b] = acc
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd6, %r5, 8;\n    add.s64 %rd7, "), yR)
+    t = str_concat(t, ", %rd6;\n    st.global.f64 [%rd7], %fd0;\n")
+    t = str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, 16;\n    @%p1 bra $RB;\n$RDONE:\n")
+    t
+}
+
 // O-SSM recurrence over T timesteps. H0 staged once into sH; then a runtime loop over t<T:
 // h_t = sigmoid(A⊗h_{t-1} + B·x_t) (tile1 + post-add + cubic sigmoid → sH col-major),
 // y_t = Re(C⊗h_t) (tile2 → sS row 0). x_t at px[(t*16+b)], y_t at py[(t*16+b)]. TR = T register.
@@ -1545,6 +1586,12 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
             let ndim = if op.rhs_imm == 16 { 16 } else { 8 }
             let nbits = if ndim == 16 { 4 } else { 3 }
             ptx_push_str(buf, gpu_emit_oct_bwd_nl(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), gpu_reg_u64(op.compare_reg), ndim, nbits))
+        }
+
+        GpuOpcode::GpuOctReadout => {
+            // O-SSM real readout y = Re(C⊗h). Pointers: pC=lhs, pH=rhs, py=addr.
+            let odim = if op.rhs_imm == 16 { 16 } else { 8 }
+            ptx_push_str(buf, gpu_emit_oct_readout(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), odim))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/tests/gpu/ossm_oct_readout_tile.sio
+++ b/tests/gpu/ossm_oct_readout_tile.sio
@@ -1,0 +1,10 @@
+// O-SSM octonion real readout y[b] = Re(C⊗h)[b] = Σ_p σ(p,p)·C[p]·h[p,b] — array-of-Hyper for C.
+// σ(p,p)=+1 for p=0, −1 for p≥1, so y = C[0]·h[0,b] − Σ_{p≥1} C[p]·h[p,b] (the diagonal p⊕q=0 terms;
+// no tensor-core tile — Re is diagonal). h is D-layout [p*16+b] (the σ(S) state); y is real [16].
+// The readout of the full O-SSM cell; its backward reuses ossm_oct_bwd with a row-0-only gradient.
+fn ossm_oct_readout(pC: &Hyper<Octonion, f64>, pH: &[f64; 256], py: &! [f64; 16]) with GPU { }
+
+kernel fn step(pC: &Hyper<Octonion, f64>, pH: &[f64; 256], py: &! [f64; 16]) with GPU {
+    ossm_oct_readout(pC, pH, py)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/ossm_sed_readout_tile.sio
+++ b/tests/gpu/ossm_sed_readout_tile.sio
@@ -1,0 +1,8 @@
+// O-SSM SEDENION real readout y[b] = Re(C⊗h)[b] = Σ_p σ(p,p)·C[p]·h[p,b] (dim=16, bits=4).
+// σ(p,p)=+1 for p=0, −1 for p≥1. h is D-layout [p*16+b]; y is real [16]. No tile (Re is diagonal).
+fn ossm_sed_readout(pC: &Hyper<Sedenion, f64>, pH: &[f64; 256], py: &! [f64; 16]) with GPU { }
+
+kernel fn step(pC: &Hyper<Sedenion, f64>, pH: &[f64; 256], py: &! [f64; 16]) with GPU {
+    ossm_sed_readout(pC, pH, py)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

Adds the O-SSM **real readout** `y_t = Re(C⊗h_t)` and trains the **complete cell**

```
S_t = A⊗h_{t-1} + B·x_t ,   h_t = σ(S_t) ,   y_t = Re(C⊗h_t)
```

end-to-end on the DGX Spark GB10 — learning **A, B AND the readout weights C**.

### New compiler intrinsic — the real readout

```
ossm_oct_readout / ossm_sed_readout (pC, pH, py):
  y[b] = Re(C⊗h)[b] = Σ_p σ(p,p)·C[p]·h[p,b] = C[0]·h[0,b] − Σ_{p≥1} C[p]·h[p,b]
```

`Re(C⊗h)` is **diagonal** (only the `p⊕q=0` terms survive), so this is a σ(p,p)-signed reduction — **not** a tensor-core tile. `h` is D-layout `[p*16+b]`; the p-stride is 16·8=128 B so `C[p]`/`h[p,b]` use immediate offsets (p unrolled), b a runtime loop. Tiny kernel: no tile, no tables, sm_50 header.

### The readout backward reuses `ossm_oct_bwd`

No new backward intrinsic — reuse `ossm_oct_bwd` on `(C, h_t)` with a **row-0-only** upstream gradient `dD[k,b]=(k==0? dy_t[b] : 0)`: then `dHprev = L(C)ᵀ·dD_row0 = dh_readout` (the activation-space gradient) and `dA = da(h_t, dD_row0) = dC` exactly. The full-cell BPTT chains:

```
dh_t = dh_readout + L(A)ᵀ·dS_{t+1};  dS_t = dh_t⊙σ'(S_t);  dA += da(h_{t-1},dS_t);  dB, dC accumulate
```

Four compiler-lowered kernels orchestrated in the harness: `ossm_oct_step` (S), `ossm_oct_readout` (y), `ossm_oct_bwd` (dC + dh_readout via row-0), `ossm_oct_bwd_nl` (dA via σ').

## Hardware validation (DGX Spark GB10, sm_121a)

ptxas-clean.

- **readout `y = Re(C⊗h)` vs host**: octonion 0/16 maxerr **1.4e-17**, sedenion 0/16 (machine precision).
- **Full-cell BPTT + SGD** (learns A, B, C) toward teacher targets:

| algebra | loss |
|---|---|
| octonion | 0.168 → **0.0156** (90.7%) |
| sedenion | 0.037 → **0.00151** (95.9%) |

Harness `docs/gpu/run_bptt_cell_ptx.cu`; PTX artifacts `docs/gpu/ossm_{oct,sed}_readout_tile.ptx`. **Completes the trainable hypercomplex O-SSM cell.** Builds on the arc through #1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)