### PR TITLE
perf(stdlib): two-pass filter + raw-scan count + rebench (filter 12x → 2.5x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -1,22 +1,30 @@
-# bigframe vs pandas — honest 1M-row benchmark (2026-07-18)
+# bigframe vs pandas — honest 1M-row benchmark
 
-Reproducible via `scripts/bench/run_bench.sh` (compiles the 4 Sounio `bench/sio/*.sio` under lean_single,
-times min-of-4 with the build baseline subtracted; pandas timed with `perf_counter` around the op only).
-Machine snapshot, pandas 3.0.3 / numpy 2.5.1:
+Reproducible via `scripts/bench/run_bench.sh` (Sounio min-of-N process launches, build baseline
+subtracted; pandas 3.0.3 / numpy 2.5.1, perf_counter around the op only). All numbers reproduced
+directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49999950000000.0).
 
-| operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas |
-|---|---|---|---|---|
-| col_sum | | 2.09 | 0.54 | 3.9x slower |
-| filter_count | | 8.05 | 0.66 | 12.1x slower |
-| **groupby_sum (10 keys)** | | **13.67** | **13.83** | **0.99x — parity** |
-| frame build (1M x 3) | | 23 (once) | — | — |
+## Current (after C3 stdlib optimizations)
 
-Correctness cross-check: Sounio and pandas `col_sum` agree exactly (49999950000000.0, integer-exact in f64).
+| operation | 1M rows | Sounio ms | pandas ms | Sounio/pandas | before |
+|---|---|---|---|---|---|
+| col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
+| col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |
+| filter_count (`bf_count_gt`, raw scan) | | 1.84 | 0.74 | **2.5x** | 12.1x |
+| filter_materialize (2-pass pre-size) | | 22.8 | 7.3 | **3.1x** | 5.0x |
+| groupby_sum (10 dense keys, O(n) accumulator) | | 13.7 | 13.8 | **0.99x — parity** | 0.99x |
+| frame build (1M x 3) | | ~20 (once) | — | — | — |
+
+## What changed (all stdlib, no compiler)
+- **col_sum: 8 independent accumulators** break the serial add chain -> instruction-level parallelism (1.5x). mean inherits it.
+- **filter_count: a raw-pointer scan** (`bf_count_gt`) instead of an accessor loop.
+- **filter_materialize: two-pass** -- count survivors first, allocate the output ONCE at exact size, then fill. Kills the old doubling-realloc churn (~15 reallocs copying the growing buffer for 500k survivors).
 
 ## Honest read
-- **Scale works.** A heap-backed `bigframe` holds 1,000,000 rows and runs filter/groupby correctly — ~1000x past the fixed frame's 1024-row cap.
-- **Simple reductions trail (3.9x–12x).** `col_sum`/`filter_count` are the pure "scalar bounds-checked loop vs. vectorized C/SIMD kernel" gap. Each Sounio `bf_get` is a bounds-checked call into the heap buffer; pandas runs SIMD over a contiguous NumPy array. This is exactly the gap roadmap **C3 (vectorization/GPU)** exists to close — until then, expect ~4x on reductions and ~10x on scan-heavy ops.
-- **groupby is at parity (0.99x).** The O(n) direct-index accumulator matches pandas' hash groupby at 1M rows — the more algorithm-bound the op, the closer Sounio gets, because the per-element scalar penalty is amortized against real work.
-- **Not measured / caveats:** groupby uses a dense small-integer key domain (≤1024 keys); a sparse/large key domain needs hashing. `filter` materialization pays doubling-realloc churn (start the output capacity near the expected size to fix). No SIMD, no parallelism yet.
+- **Scale + correctness**: 1M rows, exact results, ~1000x the fixed frame's 1024 cap.
+- **Reductions/scans now within ~2.1-2.6x of pandas** (were 2.3-12x). The residual is pure SIMD: pandas runs AVX 4-wide, Sounio a scalar loop. That is the C3 compiler auto-vectorization dispatch (`docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md`) -- the stdlib multi-accumulator/raw-scan is the ceiling without SIMD codegen.
+- **groupby at parity**: the more algorithm-bound the op, the closer Sounio gets.
+- **filter_materialize (3.1x)**: bounded by copying 500k*3 cells one write_f64 at a time; a bulk column-wise copy (memcpy-style contiguous move) would close most of the rest -- a follow-up.
+- **GPU**: a single 1M reduction is memory-bandwidth-bound (8MB CPU->GPU transfer > the op); GPU is for GPU-resident multi-op columns (C3b), and the DGX is remote (not benchmarked here).
 
-**Bottom line:** today Sounio's data layer is *scale-correct and algorithmically competitive* (groupby parity) but *raw-throughput behind* pandas on vectorizable reductions. The honest superiority claim remains **correctness + now scale**; closing the reduction gap is the C3 vectorization campaign.
+**Bottom line:** the data layer is scale-correct, algorithmically competitive (groupby parity), and now within ~2-3x of pandas on reductions/scans/filter -- with the remaining gap being SIMD codegen (dispatched) and a bulk-copy filter follow-up.

--- a/stdlib/data/bigframe.sio
+++ b/stdlib/data/bigframe.sio
@@ -150,6 +150,8 @@ pub fn bf_cap_rows(bf: &BigFrame) -> i64 {
 // AGGREGATION
 // ============================================================================
 
+pub fn bf_col_ptr(bf: &BigFrame, c: i64) -> i64 { bf.col_ptrs[c] }
+
 pub fn bf_col_sum(bf: &BigFrame, c: i64) -> f64 {
     if c < 0 { return 0.0 }
     if c >= bf.n_cols { return 0.0 }

--- a/stdlib/data/bigframe.sio
+++ b/stdlib/data/bigframe.sio
@@ -156,13 +156,36 @@ pub fn bf_col_sum(bf: &BigFrame, c: i64) -> f64 {
     if c < 0 { return 0.0 }
     if c >= bf.n_cols { return 0.0 }
     let p = bf.col_ptrs[c] as *mut f64
-    var s: f64 = 0.0
-    var r: i64 = 0
-    while r < bf.n_rows {
-        s = s + read_f64(p, r)
-        r = r + 1
+    let n = bf.n_rows
+    // 8 independent accumulators break the serial add dependency chain so the CPU pipelines the
+    // adds (instruction-level parallelism) -- ~1.4x over a single accumulator. True SIMD would close
+    // the rest of the gap to a vectorized kernel; that is a compiler auto-vectorization item (C3).
+    var a0: f64 = 0.0
+    var a1: f64 = 0.0
+    var a2: f64 = 0.0
+    var a3: f64 = 0.0
+    var a4: f64 = 0.0
+    var a5: f64 = 0.0
+    var a6: f64 = 0.0
+    var a7: f64 = 0.0
+    let n8 = n - (n % 8)
+    var i: i64 = 0
+    while i < n8 {
+        a0 = a0 + read_f64(p, i)
+        a1 = a1 + read_f64(p, i + 1)
+        a2 = a2 + read_f64(p, i + 2)
+        a3 = a3 + read_f64(p, i + 3)
+        a4 = a4 + read_f64(p, i + 4)
+        a5 = a5 + read_f64(p, i + 5)
+        a6 = a6 + read_f64(p, i + 6)
+        a7 = a7 + read_f64(p, i + 7)
+        i = i + 8
     }
-    s
+    while i < n {
+        a0 = a0 + read_f64(p, i)
+        i = i + 1
+    }
+    ((a0 + a1) + (a2 + a3)) + ((a4 + a5) + (a6 + a7))
 }
 
 pub fn bf_col_mean(bf: &BigFrame, c: i64) -> f64 {

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -33,22 +33,46 @@ fn bf_groupby_max_keys() -> i64 { 1024 }
 // Single O(n_rows * n_cols) pass: for each qualifying row we copy every column
 // value into a stack row buffer and append it via bf_push_row (which grows the
 // result's column buffers 2x on demand).
+// Count the rows of `src` whose column `col` is strictly greater than `thresh` (a pure O(n) scan
+// over the raw column buffer -- no allocation).
+pub fn bf_count_gt(src: &BigFrame, col: i64, thresh: f64) -> i64 with Mut, Div, Panic {
+    let nc = bf_ncols(src)
+    if col < 0 { return 0 }
+    if col >= nc { return 0 }
+    let p = bf_col_ptr(src, col) as *mut f64
+    let n = bf_nrows(src)
+    var cnt: i64 = 0
+    var i: i64 = 0
+    while i < n {
+        if read_f64(p, i) > thresh { cnt = cnt + 1 }
+        i = i + 1
+    }
+    cnt
+}
+
+// Return a NEW BigFrame with exactly the rows where column `col` > `thresh`. TWO-PASS: pass 1 counts
+// the survivors (via bf_count_gt) so the output is allocated ONCE at the exact size -- no doubling
+// realloc churn (the old single-pass version reallocated ~log2(survivors) times, copying the growing
+// buffer each time). Pass 2 copies the matching rows. Columns/order preserved; caller must bf_free.
 pub fn bf_filter_gt(src: &BigFrame, col: i64, thresh: f64) -> BigFrame with Alloc, Mut {
     let nc = bf_ncols(src)
     let nr = bf_nrows(src)
 
-    // Small starting capacity; bf_push_row auto-grows. cap>=1 keeps the first
-    // allocation a real heap_alloc (never a realloc on null).
-    var out = bf_new(nc, 16)
+    if col < 0 { return bf_new(nc, 1) }
+    if col >= nc { return bf_new(nc, 1) }
 
-    // Guard: an out-of-range column matches nothing -> empty frame.
-    if col < 0 { return out }
-    if col >= nc { return out }
+    // Pass 1: exact survivor count -> pre-size the output (min 1 so the first alloc is a real
+    // heap_alloc, never a realloc on null).
+    var cap = bf_count_gt(src, col, thresh)
+    if cap < 1 { cap = 1 }
+    var out = bf_new(nc, cap)
 
+    // Pass 2: copy matching rows (no growth -- capacity is exact).
+    let kp = bf_col_ptr(src, col) as *mut f64
     var row: [f64; 64] = [0.0; 64]
     var r: i64 = 0
     while r < nr {
-        if bf_get(src, r, col) > thresh {
+        if read_f64(kp, r) > thresh {
             var c: i64 = 0
             while c < nc {
                 row[c] = bf_get(src, r, c)


### PR DESCRIPTION
## C3 stdlib perf, round 2 — filter & mean (all reproduced at 1M rows)

Applying the same "do less per element" discipline to the remaining ops. Numbers reproduced directly vs pandas 3.0.3:

| operation | Sounio | pandas | ratio | before |
|---|---|---|---|---|
| filter_count (`bf_count_gt`, raw scan) | 1.84 ms | 0.74 ms | **2.5×** | 12.1× |
| filter_materialize (**two-pass**) | 22.8 ms | 7.3 ms | **3.1×** | 5.0× |
| col_mean (inherits 8-acc sum) | 2.05 ms | 1.00 ms | **2.1×** | 2.3× |
| col_sum (8-acc, prev PR) | 1.44 ms | 0.55 ms | 2.6× | 3.9× |
| groupby_sum | 13.7 ms | 13.8 ms | 0.99× parity | — |

### What changed (all stdlib)
- **`bf_count_gt`** — pure raw-pointer O(n) scan count.
- **`bf_filter_gt` is now two-pass** — count survivors first, allocate the output **once at exact size**, then fill. Kills the old `cap=16` doubling-realloc churn (~15 reallocs copying the growing 500k-row buffer).
- **`bf_col_mean`** already delegated to `bf_col_sum`, so it inherited the 8-accumulator win.
- Added `bf_col_ptr(bf, c)` accessor (raw column heap address) enabling the raw scans.

Gates green — correctness unchanged (`filter→500k`, `groupby→10×100k`, `col_sum` bit-exact).

### Honest read
Reductions/scans are now **within ~2.1–2.6× of pandas** (were 2.3–12×). The residual is **pure SIMD** — dispatched as C3 auto-vectorization (`docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md`). `filter_materialize` (3.1×) is still bounded by copying 500k×3 cells one `write_f64` at a time; a **bulk column-wise copy** is the next follow-up. Full table in `scripts/bench/RESULTS.md`. No compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)