### PR TITLE
fix(madaros): file_size() returns -1 for directories → reject dir input

### DIFF
--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -9593,7 +9593,12 @@ fn emit_read_file() with Mut, Panic, Div {
 }
 
 fn emit_file_size() with Mut, Panic {
-    // rax = path. stat(path, &statbuf) → statbuf.st_size at offset 48
+    // rax = path. stat(path, &statbuf) → statbuf.st_size at offset 48.
+    // A directory (st_mode S_IFDIR at offset 24) returns -1 so callers treat it
+    // like an unreadable/absent file: file_exists() == (file_size() >= 0) then
+    // reports false, and `--check <dir>` / `check <dir>` emit "could not read
+    // input file" instead of parsing an empty AST. (Returning st_size for a dir
+    // is a latent bug — a directory is never a valid source/import file.)
     em(0x48); em(0x89); em(0xc7)  // mov rdi, rax (path)
     em(0x48); em(0x81); em(0xec); em32(160)  // sub rsp, 160 (struct stat + padding)
     em(0x48); em(0x89); em(0xe6)  // mov rsi, rsp (statbuf)
@@ -9601,12 +9606,18 @@ fn emit_file_size() with Mut, Panic {
     em(0x0f); em(0x05)
     em(0x48); em(0x85); em(0xc0)  // test rax, rax
     em(0x0f); em(0x88); let stat_fail = CL; em32(0)  // js stat_fail
+    // reject directories: (st_mode & S_IFMT) == S_IFDIR → -1
+    em(0x8b); em(0x44); em(0x24); em(24)  // mov eax, [rsp+24] (st_mode, 32-bit)
+    em(0x25); em32(0xF000)  // and eax, 0xF000 (S_IFMT)
+    em(0x3d); em32(0x4000)  // cmp eax, 0x4000 (S_IFDIR)
+    em(0x0f); em(0x84); let dir_fail = CL; em32(0)  // je stat_fail
     em(0x48); em(0x8b); em(0x44); em(0x24); em(48)  // mov rax, [rsp+48] (st_size)
     em(0xe9); let stat_done = CL; em32(0)
     let stat_fail_target = CL
     em(0x48); em(0xc7); em(0xc0); em32(-1)  // mov rax, -1 (missing/unreadable → sentinel)
     let stat_done_target = CL
     patch32(stat_fail, stat_fail_target)
+    patch32(dir_fail, stat_fail_target)
     patch32(stat_done, stat_done_target)
     em(0x48); em(0x81); em(0xc4); em32(160)  // add rsp, 160
 }


### PR DESCRIPTION
## What

`--check <dir>` / `check <dir>` parsed an empty AST → "AST closure incomplete" (exit 1, wrong message) instead of `could not read input file`. Root cause: the source-input preflight gates only on `file_exists(path)`, and `module_parse::file_exists` is `file_size(path) >= 0` — `stat()` succeeds on a directory, so a directory passed as a valid input.

## Why it matters (the real blocker)

This has blocked **every `madaros-prebuilt-refresh`** since the `--check /tmp` assertion landed in the messy mega-commit `e8b7e2d65` (06-29). The auto-refresh's `madaros_full_gate.sh` fails at that assertion → the shipped `bin/madaros-linux-x86_64` stays stale → merged source fixes (#1078, #1116, #1145) never reach the out-of-box compiler. (The binary has only ever advanced via manual rebuilds by the maintainer.)

## Fix

`emit_file_size` (lean_single x86) now checks `st_mode` — `S_IFDIR` at offset 24 of the same `struct stat` it already reads `st_size` from at offset 48 — and returns `-1` for a directory. Then `file_exists(dir) == false` and the **existing** preflight emits `could not read input file`, covering both the raw `--check` and wrapper `check` paths. A directory is never a valid source/import file, so returning its `st_size` was a latent bug in every `file_size` caller; `-1` is correct everywhere. Emitted bytes **verified byte-exact vs a reference assembler**.

## Verification (current-source Madaros built with this change)

| Gate | Result |
|---|---|
| `madaros_full_gate.sh` | ✅ PASS (was FAIL at "raw check CLI" `--check /tmp`) |
| enum / loop / multimodule_witness / source_to_elf | ✅ PASS (no regression) |
| read_file dynmmap gate (#1145) + CSV reader gate (#1116) | ✅ PASS (`file_size` on real files intact) |

Behavioral: `--check /tmp` → `could not read input file` exit 1; `check /tmp` → exit 2 (+ "requires <source.sio>…"); missing file → unchanged; empty/real files → `check: OK`.

## Scope

lean_single **x86** — the seed that builds `main.sio` for the Linux prebuilt, the only path `full_gate` exercises. The a64 `emit_file_size_a64` and the `codegen_x86_linux` / `mini_native` `emit_file_size` carry the same latent `dir→st_size`; adding the `S_IFDIR` check there is a consistency follow-up (no gate covers `file_size(dir)` on those paths). Once merged, a prebuilt refresh will pass `full_gate` and ship #1078 + #1116 + #1145 + this fix.