### PR TITLE
fix(ir): align IrFunction instruction capacity

### DIFF
--- a/scripts/ci/irfunction_instr_capacity_coherence_gate.sh
+++ b/scripts/ci/irfunction_instr_capacity_coherence_gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="${IRFUNCTION_INSTR_CAPACITY_SOURCE:-$ROOT/self-hosted/ir/ir.sio}"
+EXPECTED_CAPACITY=2048
+
+fail() {
+  printf 'IRFUNCTION_INSTR_CAPACITY_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+[[ -f "$SOURCE" ]] || fail source_missing
+command -v python3 >/dev/null 2>&1 || fail python3_missing
+
+python3 - "$SOURCE" "$EXPECTED_CAPACITY" <<'PY' || exit $?
+import pathlib
+import re
+import sys
+
+
+source = pathlib.Path(sys.argv[1])
+expected = int(sys.argv[2])
+text = source.read_text(encoding="utf-8")
+
+
+def fail(reason: str) -> None:
+    print(f"IRFUNCTION_INSTR_CAPACITY_FAIL reason={reason}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def unique(pattern: str, subject: str, reason: str, flags: int = 0) -> re.Match[str]:
+    matches = list(re.finditer(pattern, subject, flags))
+    if len(matches) != 1:
+        fail(f"{reason}_count_{len(matches)}")
+    return matches[0]
+
+
+cap_match = unique(
+    r"^pub let IR_MAX_INSTRS: i64 = ([0-9]+)\s*$",
+    text,
+    "ir_max_instrs",
+    re.MULTILINE,
+)
+
+struct_match = unique(
+    r"^pub struct IrFunction\s*\{(?P<body>.*?)^\}\s*$",
+    text,
+    "irfunction_struct",
+    re.MULTILINE | re.DOTALL,
+)
+type_match = unique(
+    r"^\s*pub instrs:\s*\[IrInstr;\s*([0-9]+)\],\s*$",
+    struct_match.group("body"),
+    "irfunction_instrs_field",
+    re.MULTILINE,
+)
+
+function_starts = list(re.finditer(r"^pub fn ir_empty_function\(\) -> IrFunction\s*\{", text, re.MULTILINE))
+if len(function_starts) != 1:
+    fail(f"ir_empty_function_count_{len(function_starts)}")
+module_start = text.find("\npub fn ir_empty_module()", function_starts[0].end())
+if module_start < 0:
+    fail("ir_empty_function_end_missing")
+function_body = text[function_starts[0].end():module_start]
+initializer_match = unique(
+    r"^\s*instrs:\s*\[ir_nop\(\);\s*([0-9]+)\],\s*$",
+    function_body,
+    "ir_empty_function_instrs_initializer",
+    re.MULTILINE,
+)
+
+cap = int(cap_match.group(1))
+field = int(type_match.group(1))
+initializer = int(initializer_match.group(1))
+
+if cap != expected:
+    fail(f"ir_max_instrs_expected_{expected}_got_{cap}")
+if field != expected:
+    fail(f"irfunction_field_expected_{expected}_got_{field}")
+if initializer != expected:
+    fail(f"initializer_expected_{expected}_got_{initializer}")
+if not (cap == field == initializer):
+    fail(f"divergent_cap_{cap}_field_{field}_initializer_{initializer}")
+
+print(
+    "IRFUNCTION_INSTR_CAPACITY_CHECK "
+    f"cap={cap} field={field} initializer={initializer} coherent=pass"
+)
+PY
+
+source_sha256="$(sha256sum "$SOURCE" | awk '{print $1}')"
+head_sha="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || printf not_available)"
+tree_sha="$(git -C "$ROOT" rev-parse 'HEAD^{tree}' 2>/dev/null || printf not_available)"
+worktree_state=not_available
+if git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [[ -z "$(git -C "$ROOT" status --porcelain --untracked-files=all)" ]]; then
+    worktree_state=clean
+  else
+    worktree_state=dirty
+  fi
+fi
+
+printf '%s\n' \
+  'IRFUNCTION_INSTR_CAPACITY_BOUNDARY storage_coherence=proved runtime_readback=not_claimed soir_v6=unchanged legacy=preserved'
+printf 'IRFUNCTION_INSTR_CAPACITY_PASS source=%s source_sha256=%s expected=2048 head=%s tree=%s worktree=%s\n' \
+  "$SOURCE" "$source_sha256" "$head_sha" "$tree_sha" "$worktree_state"

--- a/self-hosted/ir/ir.sio
+++ b/self-hosted/ir/ir.sio
@@ -3712,7 +3712,7 @@ fn ir_phi(dst: i64) -> IrInstr {
 pub fn ir_empty_function() -> IrFunction {
     IrFunction {
         name: ir_empty_name(),
-        instrs: [ir_nop(); 1024],
+        instrs: [ir_nop(); 2048],
         instr_count: 0,
         reg_count: 0,
         label_count: 0,


### PR DESCRIPTION
## What changed

- Align `ir_empty_function().instrs` with `IR_MAX_INSTRS` and the `IrFunction.instrs` backing array at 2048 entries.
- Add `scripts/ci/irfunction_instr_capacity_coherence_gate.sh` to reject divergence among the cap, field extent, and initializer.
- Keep the existing IR representation and every SOIR path unchanged.

## Root cause

Commit `76d449e0b` raised `IR_MAX_INSTRS` and `IrFunction.instrs` from 1024 to 2048 but left the empty-function initializer at 1024. The mismatch survived because no executable structural gate compared all three declarations.

## Evidence boundary

This PR proves only structural storage coherence: `cap=2048`, `field=2048`, and `initializer=2048`. It does not claim a runtime behavior change, SOIR v6 integration, or issue closure.

The Slurm A/B specifically falsified the hypothesis that this line fixes the current SOIR v6 BSS receipt readback:

- Job `6736.1` built source-fresh Madaros from base `ce89e3201faeb43111e3f1b6566803e94afc32a5` and candidate `aa157befb992daaaf94c898b36dd398b5227b97c`.
- Both compilers consumed the same composite, SHA-256 `6ede9645b2b7aa99a43de636141475d166379b895cd491fb4bbbcb4d65d9c47a`.
- Base and candidate Madaros ELFs were identical, SHA-256 `a9d16e2f92bc8c189dc064e64fc67d799dfdb929548a9ca9ea955d1046fa65ea`.
- Base and candidate output ELFs were identical, SHA-256 `87111c121cafd009ff940eeafb5b99fd6b32dc2e0d6c738c9455b5a52eeef77a`.
- Both runtimes returned `rc=0` with `SOIR_V6_BSS_LAYOUT_CANONICAL_PASS`.

Therefore the source-fresh base already eliminates the observed readback failure. This patch remains warranted as a structural invariant, but it is not the causal SOIR v6 fix.

Slurm artifact SHA-256: `429b7528a65922bdb2816bc8ea374dcb006fb6cb6fb04dae63946be1837b455c`  
Receipt SHA-256: `19eabeccb04facb1b4a6b215eb967e5d336ca63ba98f1e0f5275926b2e3f2455`

## Validation

- `bash -n scripts/ci/irfunction_instr_capacity_coherence_gate.sh`
- `bash scripts/ci/irfunction_instr_capacity_coherence_gate.sh`
- Historical base control: rejected with `initializer_expected_2048_got_1024`
- `git diff --check ce89e3201faeb43111e3f1b6566803e94afc32a5..HEAD`
- Slurm source-fresh A/B: job `6736.1`, acceptance `pass`, runtime `998s`

## Governance

- Concept-IDs: none
- Legacy kept: existing `IrFunction` representation and all SOIR paths
- LLM offload: not required; compiler mechanics only
