### PR TITLE
perf(stdlib): filter_materialize column-major raw gather (3.1x → 2.0x vs pandas)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -11,7 +11,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | col_sum (8-accumulator ILP) | | 1.44 | 0.55 | **2.6x** | 3.9x |
 | col_mean (via 8-acc sum) | | 2.05 | 1.00 | **2.1x** | 2.3x |
 | filter_count (`bf_count_gt`, raw scan) | | 1.84 | 0.74 | **2.5x** | 12.1x |
-| filter_materialize (2-pass pre-size) | | 22.8 | 7.3 | **3.1x** | 5.0x |
+| filter_materialize (col-major gather) | | 12.5 | 6.2 | **2.0x** | 5.0x |
 | groupby_sum (10 dense keys, O(n) accumulator) | | 13.7 | 13.8 | **0.99x — parity** | 0.99x |
 | frame build (1M x 3) | | ~20 (once) | — | — | — |
 

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -54,34 +54,41 @@ pub fn bf_count_gt(src: &BigFrame, col: i64, thresh: f64) -> i64 with Mut, Div, 
 // the survivors (via bf_count_gt) so the output is allocated ONCE at the exact size -- no doubling
 // realloc churn (the old single-pass version reallocated ~log2(survivors) times, copying the growing
 // buffer each time). Pass 2 copies the matching rows. Columns/order preserved; caller must bf_free.
-pub fn bf_filter_gt(src: &BigFrame, col: i64, thresh: f64) -> BigFrame with Alloc, Mut {
+pub fn bf_filter_gt(src: &BigFrame, col: i64, thresh: f64) -> BigFrame with Alloc, Mut, Div, Panic {
     let nc = bf_ncols(src)
     let nr = bf_nrows(src)
 
     if col < 0 { return bf_new(nc, 1) }
     if col >= nc { return bf_new(nc, 1) }
 
-    // Pass 1: exact survivor count -> pre-size the output (min 1 so the first alloc is a real
+    // Pass 1: exact survivor count -> pre-size the output once (min 1 so the first alloc is a real
     // heap_alloc, never a realloc on null).
-    var cap = bf_count_gt(src, col, thresh)
-    if cap < 1 { cap = 1 }
-    var out = bf_new(nc, cap)
+    var cnt = bf_count_gt(src, col, thresh)
+    if cnt < 1 { cnt = 1 }
+    var out = bf_new(nc, cnt)
 
-    // Pass 2: copy matching rows (no growth -- capacity is exact).
+    // Pass 2: COLUMN-MAJOR raw gather. For each column, a tight raw-pointer loop writes the surviving
+    // cells directly into the output column buffer via write_f64 -- no per-row bf_push_row, no stack
+    // row buffer, no per-cell accessor dispatch. The predicate is recomputed per column (cheap
+    // sequential reads of the key column); this is ~1.8x over the row-major push version. n_rows is
+    // set directly to the survivor count since we bypass bf_push_row.
     let kp = bf_col_ptr(src, col) as *mut f64
-    var row: [f64; 64] = [0.0; 64]
-    var r: i64 = 0
-    while r < nr {
-        if read_f64(kp, r) > thresh {
-            var c: i64 = 0
-            while c < nc {
-                row[c] = bf_get(src, r, c)
-                c = c + 1
+    var c: i64 = 0
+    while c < nc {
+        let sp = bf_col_ptr(src, c) as *mut f64
+        let op = bf_col_ptr(&out, c) as *mut f64
+        var w: i64 = 0
+        var r: i64 = 0
+        while r < nr {
+            if read_f64(kp, r) > thresh {
+                write_f64(op, w, read_f64(sp, r))
+                w = w + 1
             }
-            bf_push_row(&!out, &row, nc)
+            r = r + 1
         }
-        r = r + 1
+        c = c + 1
     }
+    out.n_rows = cnt
     out
 }
 


### PR DESCRIPTION
## filter_materialize — column-major raw gather (the memcpy-style follow-up)

Filter is row-selective (survivors are scattered), so there's no single `memcpy` — but the per-cell `write_f64` via `bf_push_row` was the bottleneck. Fix: **column-major raw gather**. For each column, a tight raw-pointer loop writes the surviving cells straight into the output column buffer — no per-row `bf_push_row`, no stack row buffer, no per-cell accessor dispatch. Output pre-sized once; `n_rows` set directly.

| filter_materialize @1M | ms | vs pandas |
|---|---|---|
| row-major `bf_push_row` (before) | 22.5 | 3.1× |
| **column-major raw gather (this PR)** | **12.5** | **2.0×** |

Reproduced by me (min-of-5, build baseline subtracted). Correct: 500,000 survivors, values exact; `BIGFRAME_OPS_GATE_OK`.

### Where the gap stands now
Every bigframe op is now **within ~2–2.6× of pandas** (or at parity for groupby), on scalar loops with no SIMD. The residual is the C3 auto-vectorization dispatch. For `filter` specifically, the next lever is a random-access **index-array precompute** (compute the survivor index list once, gather per column) — helps when survivors are scattered vs the contiguous test case. No compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)