### PR TITLE
feat(soir): add bounded v6 BSS layout vertical

### DIFF
--- a/scripts/ci/soir_v6_bss_layout_gate.sh
+++ b/scripts/ci/soir_v6_bss_layout_gate.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+COMPILER_CLI="${SOUC_BIN:-$ROOT/bin/madaros}"
+RAW_COMPILER="${SOIR_V6_BSS_LAYOUT_RAW_BIN:-${MADAROS_RAW_BIN:-$ROOT/bin/madaros-linux-x86_64}}"
+EXPECTED_RAW_SHA256="${SOIR_V6_BSS_LAYOUT_EXPECTED_RAW_SHA256:-}"
+COMPILER_SOURCE_SHA="${SOIR_V6_BSS_LAYOUT_COMPILER_SOURCE_SHA:-not_claimed}"
+WRITER="self-hosted/ir/soir_v6_writer.sio"
+READER="self-hosted/ir/soir_v6_reader.sio"
+RUNTIME_TIMEOUT_SECONDS="${SOIR_V6_BSS_LAYOUT_RUNTIME_TIMEOUT_SECONDS:-15}"
+SCHEMA_DESCRIPTOR='SOIRv6:bss-range-v1:le64:header64:dir48:kind5:critical+singleton:payload(module_total,range_count,range_offset,range_size):adler32'
+SCHEMA_FINGERPRINT='3946524625'
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sounio-soir-v6-bss-layout.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'SOIR_V6_BSS_LAYOUT_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+progress() {
+  printf 'SOIR_V6_BSS_LAYOUT_PROGRESS stage=%s subject=%s status=%s\n' \
+    "$1" "$2" "$3" >&2
+}
+
+run_compiler() {
+  MADAROS_RAW_BIN="$RAW_COMPILER" "$COMPILER_CLI" "$@"
+}
+
+expected_paths() {
+  printf '%s\n' \
+    scripts/ci/soir_v6_bss_layout_gate.sh \
+    self-hosted/ir/soir_v6_reader.sio \
+    self-hosted/ir/soir_v6_writer.sio \
+    tests/native-v2/soir_v6_bss_layout_reject_witness.sio \
+    tests/native-v2/soir_v6_bss_layout_witness.sio
+}
+
+schema_adler32() {
+  local descriptor="$1"
+  local a=1
+  local b=0
+  local octet
+  for octet in $(printf '%s' "$descriptor" | od -An -tu1 -v); do
+    a=$(((a + octet) % 65521))
+    b=$(((b + a) % 65521))
+  done
+  printf '%s\n' "$(((b << 16) | a))"
+}
+
+[[ -x "$COMPILER_CLI" ]] || fail compiler_cli_missing
+[[ -x "$RAW_COMPILER" ]] || fail raw_compiler_missing
+[[ "$(head -c 2 "$RAW_COMPILER" 2>/dev/null)" != '#!' ]] || fail raw_compiler_is_launcher
+command -v timeout >/dev/null 2>&1 || fail timeout_command_missing
+command -v od >/dev/null 2>&1 || fail od_command_missing
+[[ "$RUNTIME_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || fail runtime_timeout_invalid
+(( RUNTIME_TIMEOUT_SECONDS <= 60 )) || fail runtime_timeout_exceeds_cap_60
+
+for path in "$WRITER" "$READER"; do
+  [[ -f "$path" ]] || fail "missing_${path//\//_}"
+done
+
+[[ "$(schema_adler32 "$SCHEMA_DESCRIPTOR")" == "$SCHEMA_FINGERPRINT" ]] \
+  || fail schema_descriptor_fingerprint_mismatch
+for path in "$WRITER" "$READER"; do
+  grep -Fq "// $SCHEMA_DESCRIPTOR" "$path" \
+    || fail "schema_descriptor_missing_${path//\//_}"
+  grep -Fq "SCHEMA_FINGERPRINT: i64 = $SCHEMA_FINGERPRINT" "$path" \
+    || fail "schema_fingerprint_missing_${path//\//_}"
+  grep -Fq 'Adler-32 is a non-cryptographic integrity checksum, not authentication.' "$path" \
+    || fail "integrity_boundary_missing_${path//\//_}"
+done
+
+grep -Fq 'pub let SOIR_V6_WRITER_BSS_FRAME_SIZE: i64 = 144' "$WRITER" \
+  || fail writer_frame_contract_missing
+grep -Fq 'pub fn soir_v6_writer_preflight_bss_layout(' "$WRITER" \
+  || fail writer_preflight_missing
+grep -Fq 'pub fn soir_v6_writer_emit_bss_layout(' "$WRITER" \
+  || fail writer_emit_missing
+grep -Fq 'pub let SOIR_V6_READER_BSS_FRAME_SIZE: i64 = 144' "$READER" \
+  || fail reader_frame_contract_missing
+grep -Fq 'pub fn soir_v6_reader_decode_bss_layout(' "$READER" \
+  || fail reader_decode_missing
+grep -Fq 'var section_cursor = SoirV6ReaderCursor {' "$READER" \
+  || fail section_local_cursor_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_WORDS: i64 = 7' "$READER" \
+  || fail reader_receipt_contract_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_PHYSICAL_WORDS: i64 = 7' "$READER" \
+  || fail reader_receipt_physical_contract_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_CODE: i64 = 0' "$READER" \
+  || fail reader_receipt_code_slot_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_BYTE_OFFSET: i64 = 1' "$READER" \
+  || fail reader_receipt_byte_offset_slot_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_DETAIL: i64 = 2' "$READER" \
+  || fail reader_receipt_detail_slot_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_BSS_MODULE_TOTAL: i64 = 3' "$READER" \
+  || fail reader_receipt_module_total_slot_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_BSS_RANGE_COUNT: i64 = 4' "$READER" \
+  || fail reader_receipt_range_count_slot_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_BSS_RANGE_OFFSET: i64 = 5' "$READER" \
+  || fail reader_receipt_range_offset_slot_missing
+grep -Fq 'pub let SOIR_V6_READER_RECEIPT_BSS_RANGE_SIZE: i64 = 6' "$READER" \
+  || fail reader_receipt_contract_missing
+
+dependency_pattern='^use (parser|ir::ir|ir::serialize|ir::numeric_payload_wire)|\b(IrModule|IrInstr|TyF128|TyF256|TyF512)\b'
+set +e
+if command -v rg >/dev/null 2>&1; then
+  rg -n "$dependency_pattern" "$WRITER" "$READER" >"$TMP/dependency-leak.log" 2>&1
+else
+  grep -En "$dependency_pattern" "$WRITER" "$READER" >"$TMP/dependency-leak.log" 2>&1
+fi
+dependency_scan_rc=$?
+set -e
+if [[ "$dependency_scan_rc" -eq 0 ]]; then
+  cat "$TMP/dependency-leak.log" >&2
+  fail shadow_dependency_expanded
+fi
+[[ "$dependency_scan_rc" -eq 1 ]] || fail dependency_scan_error
+
+for default_surface in \
+  self-hosted/ir/serialize.sio \
+  self-hosted/ir/mod.sio \
+  self-hosted/ir/lower.sio \
+  self-hosted/check/check.sio \
+  self-hosted/compiler/main.sio \
+  self-hosted/compiler/module_frontend.sio; do
+  [[ -f "$default_surface" ]] || continue
+  if grep -Eq 'ir::soir_v6_(writer|reader)' "$default_surface"; then
+    fail "shadow_imported_by_${default_surface//\//_}"
+  fi
+done
+
+bash scripts/ci/madaros_f128_f256_format_identity_gate.sh --structural-only \
+  >"$TMP/precision-identity.log" 2>&1 || {
+    cat "$TMP/precision-identity.log" >&2
+    fail precision_identity_regression
+  }
+
+head_sha="$(git rev-parse HEAD)"
+tree_sha="$(git rev-parse 'HEAD^{tree}')"
+mapfile -t evidence_paths < <(expected_paths)
+for evidence_path in "${evidence_paths[@]}"; do
+  git ls-files --error-unmatch -- "$evidence_path" >/dev/null 2>&1 \
+    || fail evidence_path_untracked
+done
+dirty_tree="$(git status --porcelain --untracked-files=all)"
+if [[ -n "$dirty_tree" ]]; then
+  printf '%s\n' "$dirty_tree" >&2
+  fail worktree_dirty
+fi
+if [[ "$COMPILER_SOURCE_SHA" != "not_claimed" && "$COMPILER_SOURCE_SHA" != "$head_sha" ]]; then
+  fail compiler_source_sha_mismatch
+fi
+
+raw_compiler_sha256="$(sha256sum "$RAW_COMPILER" | awk '{print $1}')"
+if [[ -n "$EXPECTED_RAW_SHA256" && "$raw_compiler_sha256" != "$EXPECTED_RAW_SHA256" ]]; then
+  fail raw_compiler_sha256_mismatch
+fi
+compiler_cli_sha256="$(sha256sum "$COMPILER_CLI" | awk '{print $1}')"
+
+for source in "$WRITER" "$READER"; do
+  name="$(basename "$source" .sio)"
+  progress source_check "$name" begin
+  run_compiler check "$source" >"$TMP/$name.check.log" 2>&1 || {
+    cat "$TMP/$name.check.log" >&2
+    fail "source_check_$name"
+  }
+  progress source_check "$name" pass
+done
+
+compose_and_run() {
+  local witness="$1"
+  local marker="$2"
+  local name composite elf build_log run_log runtime_rc
+  name="$(basename "$witness" .sio)"
+  composite="$TMP/$name.sio"
+  elf="$TMP/$name.elf"
+  build_log="$TMP/$name.build.log"
+  run_log="$TMP/$name.run.log"
+
+  {
+    printf 'module ir::%s_gate\n\n' "$name"
+    sed '/^module ir::soir_v6_writer$/d' "$WRITER"
+    sed '/^module ir::soir_v6_reader$/d' "$READER"
+    sed -e '/^use ir::soir_v6_writer::\*$/d' \
+        -e '/^use ir::soir_v6_reader::\*$/d' \
+        "$witness"
+  } >"$composite"
+
+  progress composite_check "$name" begin
+  run_compiler check "$composite" >"$build_log" 2>&1 || {
+    cat "$build_log" >&2
+    fail "composite_check_$name"
+  }
+  progress composite_build "$name" begin
+  run_compiler --native-v2-compile "$composite" -o "$elf" >>"$build_log" 2>&1 || {
+    cat "$build_log" >&2
+    fail "composite_build_$name"
+  }
+  chmod +x "$elf"
+  progress composite_runtime "$name" begin
+  set +e
+  timeout --signal=TERM --kill-after=2s "${RUNTIME_TIMEOUT_SECONDS}s" "$elf" >"$run_log" 2>&1
+  runtime_rc=$?
+  set -e
+  if [[ "$runtime_rc" -eq 124 ]]; then
+    cat "$run_log" >&2
+    fail "composite_runtime_timeout_$name"
+  fi
+  if [[ "$runtime_rc" -ne 0 ]]; then
+    cat "$run_log" >&2
+    fail "composite_runtime_${name}_rc_${runtime_rc}"
+  fi
+  grep -Fxq "$marker" "$run_log" || {
+    cat "$run_log" >&2
+    fail "marker_missing_$name"
+  }
+  progress composite_runtime "$name" pass
+}
+
+compose_and_run \
+  tests/native-v2/soir_v6_bss_layout_witness.sio \
+  SOIR_V6_BSS_LAYOUT_CANONICAL_PASS
+compose_and_run \
+  tests/native-v2/soir_v6_bss_layout_reject_witness.sio \
+  SOIR_V6_BSS_LAYOUT_REJECT_PASS
+
+while IFS= read -r path; do
+  sha256sum "$path"
+done < <(expected_paths) >"$TMP/lane-content.sha256"
+lane_content_sha256="$(sha256sum "$TMP/lane-content.sha256" | awk '{print $1}')"
+
+printf '%s\n' 'SOIR_V6_BSS_LAYOUT_CHECK source=2/2 composite=2/2 precision_identity=preserved'
+printf '%s\n' 'SOIR_V6_BSS_LAYOUT_WIRE profile=v6-d0-single-bss-range bytes=144 header=64 directory_entries=1 directory_entry_bytes=48 section=BSS_LAYOUT section_bytes=32 schema_descriptor=canonical schema_fingerprint=adler32-derived little_endian=i64'
+printf '%s\n' 'SOIR_V6_BSS_LAYOUT_INTEGRITY checksum=adler32 integrity_only=true authentication=not_claimed corruption_without_reseal=reject corruption_resealed_semantic_invalid=reject'
+printf '%s\n' 'SOIR_V6_BSS_LAYOUT_WRITER preflight=exact emit_revalidation=pass validation_rejection_no_write=pass forged_plan=reject deterministic_bytes=pass offset_view=pass terminal_view=pass'
+printf '%s\n' 'SOIR_V6_BSS_LAYOUT_READER frame_cursor=local section_cursor=local truncation_0_143=reject trailing=reject unknown_critical=reject unknown_optional=explicit_reject decoded_canary_on_failure=preserved receipt_storage=fixed_scalar_words semantic_words=7 physical_words=7 padding_words=0 aggregate_return=none status_slots=code,byte_offset,detail success_status=zeroed decoded_slots=module_total,range_count,range_offset,range_size slot_reuse=none'
+printf '%s\n' 'SOIR_V6_BSS_LAYOUT_BOUNDARY module_graph=not_implemented opcode=not_implemented arena_install=not_implemented function_binding=not_claimed target_layout=not_claimed abi=not_claimed numeric_payload=not_imported multi_section_ordering=not_claimed issue_1162=partial_not_closed default_pipeline=unchanged legacy_v1_v4=kept soir_v5=unchanged'
+printf 'SOIR_V6_BSS_LAYOUT_PROVENANCE head=%s tree=%s worktree_clean=pass compiler_source_sha=%s\n' \
+  "$head_sha" "$tree_sha" "$COMPILER_SOURCE_SHA"
+printf 'SOIR_V6_BSS_LAYOUT_PASS compiler_cli=%s compiler_cli_sha256=%s raw_compiler=%s raw_compiler_sha256=%s head=%s tree=%s lane_content_sha256=%s\n' \
+  "$COMPILER_CLI" "$compiler_cli_sha256" "$RAW_COMPILER" "$raw_compiler_sha256" "$head_sha" "$tree_sha" "$lane_content_sha256"

--- a/self-hosted/ir/soir_v6_reader.sio
+++ b/self-hosted/ir/soir_v6_reader.sio
@@ -1,0 +1,557 @@
+// Shadow-only bounded SOIR v6 reader for the first BSS/layout profile.
+//
+// This reader accepts exactly one 144-byte frame with one critical singleton
+// BSS/layout section. Unknown critical sections reject; unknown noncritical
+// sections reject explicitly because opaque preservation is not implemented by
+// this vertical. Decoded fields are published only after the complete frame,
+// section checksum, and anonymous-range layout relation validate.
+
+module ir::soir_v6_reader
+
+pub let SOIR_V6_READER_MAX_SIZE: i64 = 131072
+pub let SOIR_V6_READER_VERSION: i64 = 6
+pub let SOIR_V6_READER_HEADER_SIZE: i64 = 64
+pub let SOIR_V6_READER_DIRECTORY_OFFSET: i64 = 64
+pub let SOIR_V6_READER_DIRECTORY_ENTRY_SIZE: i64 = 48
+pub let SOIR_V6_READER_DIRECTORY_SIZE: i64 = 48
+pub let SOIR_V6_READER_SECTION_COUNT: i64 = 1
+pub let SOIR_V6_READER_BSS_PAYLOAD_OFFSET: i64 = 112
+pub let SOIR_V6_READER_BSS_PAYLOAD_SIZE: i64 = 32
+pub let SOIR_V6_READER_BSS_FRAME_SIZE: i64 = 144
+// Adler-32 of the exact ASCII descriptor (without a terminal NUL):
+// SOIRv6:bss-range-v1:le64:header64:dir48:kind5:critical+singleton:payload(module_total,range_count,range_offset,range_size):adler32
+pub let SOIR_V6_READER_SCHEMA_FINGERPRINT: i64 = 3946524625
+
+pub let SOIR_V6_READER_SECTION_KIND_BSS_LAYOUT: i64 = 5
+pub let SOIR_V6_READER_SECTION_SCHEMA_BSS_LAYOUT: i64 = 1
+pub let SOIR_V6_READER_SECTION_FLAG_CRITICAL: i64 = 1
+pub let SOIR_V6_READER_SECTION_FLAG_SINGLETON: i64 = 2
+pub let SOIR_V6_READER_SECTION_FLAGS_BSS_LAYOUT: i64 = 3
+pub let SOIR_V6_READER_BSS_RANGE_COUNT: i64 = 1
+
+pub let SOIR_V6_READER_OK: i64 = 0
+pub let SOIR_V6_READER_ERR_VIEW_BOUNDS: i64 = 1
+pub let SOIR_V6_READER_ERR_TRUNCATED: i64 = 2
+pub let SOIR_V6_READER_ERR_TRAILING_BYTES: i64 = 3
+pub let SOIR_V6_READER_ERR_BAD_MAGIC: i64 = 4
+pub let SOIR_V6_READER_ERR_BAD_VERSION: i64 = 5
+pub let SOIR_V6_READER_ERR_BAD_FEATURES: i64 = 6
+pub let SOIR_V6_READER_ERR_BAD_RESERVED: i64 = 7
+pub let SOIR_V6_READER_ERR_TOTAL_LENGTH: i64 = 8
+pub let SOIR_V6_READER_ERR_DIRECTORY: i64 = 9
+pub let SOIR_V6_READER_ERR_SCHEMA_FINGERPRINT: i64 = 10
+pub let SOIR_V6_READER_ERR_UNKNOWN_CRITICAL_SECTION: i64 = 11
+pub let SOIR_V6_READER_ERR_UNKNOWN_OPTIONAL_SECTION: i64 = 12
+pub let SOIR_V6_READER_ERR_SECTION_SCHEMA: i64 = 13
+pub let SOIR_V6_READER_ERR_SECTION_FLAGS: i64 = 14
+pub let SOIR_V6_READER_ERR_SECTION_BOUNDS: i64 = 15
+pub let SOIR_V6_READER_ERR_SECTION_DIGEST: i64 = 16
+pub let SOIR_V6_READER_ERR_BSS_LAYOUT: i64 = 17
+pub let SOIR_V6_READER_ERR_INTERNAL_BOUNDS: i64 = 18
+
+// The fixed seven-word receipt keeps diagnostic status and decoded BSS data
+// disjoint. Failure writes only {code, byte_offset, detail}; success clears
+// that prefix and publishes all four decoded scalars after full validation.
+pub let SOIR_V6_READER_RECEIPT_WORDS: i64 = 7
+pub let SOIR_V6_READER_RECEIPT_PHYSICAL_WORDS: i64 = 7
+pub let SOIR_V6_READER_RECEIPT_CODE: i64 = 0
+pub let SOIR_V6_READER_RECEIPT_BYTE_OFFSET: i64 = 1
+pub let SOIR_V6_READER_RECEIPT_DETAIL: i64 = 2
+pub let SOIR_V6_READER_RECEIPT_BSS_MODULE_TOTAL: i64 = 3
+pub let SOIR_V6_READER_RECEIPT_BSS_RANGE_COUNT: i64 = 4
+pub let SOIR_V6_READER_RECEIPT_BSS_RANGE_OFFSET: i64 = 5
+pub let SOIR_V6_READER_RECEIPT_BSS_RANGE_SIZE: i64 = 6
+
+struct SoirV6ReaderCursor {
+    pos: i64,
+    end: i64,
+}
+
+fn soir_v6_reader_status_set(
+    out: &![i64; 7],
+    code: i64,
+    byte_offset: i64,
+    detail: i64,
+) -> i64 with Mut {
+    out[SOIR_V6_READER_RECEIPT_CODE as usize] = code
+    out[SOIR_V6_READER_RECEIPT_BYTE_OFFSET as usize] = byte_offset
+    out[SOIR_V6_READER_RECEIPT_DETAIL as usize] = detail
+    code
+}
+
+fn soir_v6_reader_publish_bss_layout(
+    out: &![i64; 7],
+    module_bss_total_size: i64,
+    range_count: i64,
+    range_offset: i64,
+    range_size: i64,
+) with Mut {
+    out[SOIR_V6_READER_RECEIPT_BSS_MODULE_TOTAL as usize] = module_bss_total_size
+    out[SOIR_V6_READER_RECEIPT_BSS_RANGE_COUNT as usize] = range_count
+    out[SOIR_V6_READER_RECEIPT_BSS_RANGE_OFFSET as usize] = range_offset
+    out[SOIR_V6_READER_RECEIPT_BSS_RANGE_SIZE as usize] = range_size
+}
+
+pub fn soir_v6_bss_read_status_code(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_CODE as usize]
+}
+
+pub fn soir_v6_bss_read_status_byte_offset(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_BYTE_OFFSET as usize]
+}
+
+pub fn soir_v6_bss_read_status_detail(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_DETAIL as usize]
+}
+
+pub fn soir_v6_bss_decoded_module_total(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_BSS_MODULE_TOTAL as usize]
+}
+
+pub fn soir_v6_bss_decoded_range_count(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_BSS_RANGE_COUNT as usize]
+}
+
+pub fn soir_v6_bss_decoded_range_offset(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_BSS_RANGE_OFFSET as usize]
+}
+
+pub fn soir_v6_bss_decoded_range_size(status: &[i64; 7]) -> i64 with Panic, Div {
+    (*status)[SOIR_V6_READER_RECEIPT_BSS_RANGE_SIZE as usize]
+}
+
+// Adler-32 is a non-cryptographic integrity checksum, not authentication.
+fn soir_v6_reader_bss_payload_checksum(
+    module_bss_total_size: i64,
+    range_count: i64,
+    range_offset: i64,
+    range_size: i64,
+) -> i64 with Div {
+    var a: i64 = 1
+    var b: i64 = 0
+    var word_index: i64 = 0
+    while word_index < 4 {
+        var value = module_bss_total_size
+        if word_index == 1 { value = range_count }
+        else if word_index == 2 { value = range_offset }
+        else if word_index == 3 { value = range_size }
+        var byte_index: i64 = 0
+        while byte_index < 8 {
+            let octet = (value >> (byte_index * 8)) & 255
+            a = (a + octet) % 65521
+            b = (b + a) % 65521
+            byte_index = byte_index + 1
+        }
+        word_index = word_index + 1
+    }
+    (b << 16) | a
+}
+
+pub fn soir_v6_reader_decode_bss_layout(
+    buf: &[i8; 131072],
+    start: i64,
+    len: i64,
+    status_out: &![i64; 7],
+) -> i64 with Mut, Panic, Div {
+    if start < 0 ||
+       len < 0 ||
+       start > SOIR_V6_READER_MAX_SIZE ||
+       len > SOIR_V6_READER_MAX_SIZE - start {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_VIEW_BOUNDS,
+            start,
+            len,
+        )
+    }
+    if len < SOIR_V6_READER_BSS_FRAME_SIZE {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_TRUNCATED,
+            start + len,
+            SOIR_V6_READER_BSS_FRAME_SIZE,
+        )
+    }
+    if len > SOIR_V6_READER_BSS_FRAME_SIZE {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_TRAILING_BYTES,
+            start + SOIR_V6_READER_BSS_FRAME_SIZE,
+            len - SOIR_V6_READER_BSS_FRAME_SIZE,
+        )
+    }
+
+    var cursor = SoirV6ReaderCursor {
+        pos: start,
+        end: start + len,
+    }
+
+    var magic_index: i64 = 0
+    while magic_index < 4 {
+        if cursor.pos < 0 || cursor.pos >= cursor.end {
+            return soir_v6_reader_status_set(
+                status_out,
+                SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+                cursor.pos,
+                1,
+            )
+        }
+        let magic_offset = cursor.pos
+        let magic = ((*buf)[cursor.pos as usize] as i64) & 255
+        cursor.pos = cursor.pos + 1
+        var expected_magic: i64 = 83
+        if magic_index == 1 { expected_magic = 79 }
+        else if magic_index == 2 { expected_magic = 73 }
+        else if magic_index == 3 { expected_magic = 82 }
+        if magic != expected_magic {
+            return soir_v6_reader_status_set(
+                status_out,
+                SOIR_V6_READER_ERR_BAD_MAGIC,
+                magic_offset,
+                magic,
+            )
+        }
+        magic_index = magic_index + 1
+    }
+
+    let version_offset = cursor.pos
+    let version = ((*buf)[cursor.pos as usize] as i64) & 255
+    cursor.pos = cursor.pos + 1
+    if version != SOIR_V6_READER_VERSION {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BAD_VERSION,
+            version_offset,
+            version,
+        )
+    }
+
+    let feature_offset = cursor.pos
+    let feature_flags = ((*buf)[cursor.pos as usize] as i64) & 255
+    cursor.pos = cursor.pos + 1
+    if feature_flags != 0 {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BAD_FEATURES,
+            feature_offset,
+            feature_flags,
+        )
+    }
+
+    var reserved_byte_index: i64 = 0
+    while reserved_byte_index < 2 {
+        let reserved_offset = cursor.pos
+        let reserved = ((*buf)[cursor.pos as usize] as i64) & 255
+        cursor.pos = cursor.pos + 1
+        if reserved != 0 {
+            return soir_v6_reader_status_set(
+                status_out,
+                SOIR_V6_READER_ERR_BAD_RESERVED,
+                reserved_offset,
+                reserved,
+            )
+        }
+        reserved_byte_index = reserved_byte_index + 1
+    }
+
+    var header_fields: [i64; 7] = [0; 7]
+    var header_field_index: i64 = 0
+    while header_field_index < 7 {
+        if cursor.pos < 0 ||
+           cursor.pos > cursor.end ||
+           8 > cursor.end - cursor.pos {
+            return soir_v6_reader_status_set(
+                status_out,
+                SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+                cursor.pos,
+                8,
+            )
+        }
+        var field_value: i64 = 0
+        var shift: i64 = 0
+        while shift < 64 {
+            let octet = ((*buf)[cursor.pos as usize] as i64) & 255
+            field_value = field_value | (octet << shift)
+            cursor.pos = cursor.pos + 1
+            shift = shift + 8
+        }
+        header_fields[header_field_index as usize] = field_value
+        header_field_index = header_field_index + 1
+    }
+
+    let total_length = header_fields[0]
+    let directory_offset = header_fields[1]
+    let directory_length = header_fields[2]
+    let section_count = header_fields[3]
+    let schema_fingerprint = header_fields[4]
+    let header_size = header_fields[5]
+    let reserved_word = header_fields[6]
+
+    if total_length != SOIR_V6_READER_BSS_FRAME_SIZE || total_length != len {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_TOTAL_LENGTH,
+            start + 8,
+            total_length,
+        )
+    }
+    if directory_offset != SOIR_V6_READER_DIRECTORY_OFFSET ||
+       directory_length != SOIR_V6_READER_DIRECTORY_SIZE ||
+       section_count != SOIR_V6_READER_SECTION_COUNT ||
+       header_size != SOIR_V6_READER_HEADER_SIZE {
+        var directory_error_offset = start + 16
+        var directory_error_detail = directory_offset
+        if directory_offset == SOIR_V6_READER_DIRECTORY_OFFSET &&
+           directory_length != SOIR_V6_READER_DIRECTORY_SIZE {
+            directory_error_offset = start + 24
+            directory_error_detail = directory_length
+        } else if directory_offset == SOIR_V6_READER_DIRECTORY_OFFSET &&
+                  directory_length == SOIR_V6_READER_DIRECTORY_SIZE &&
+                  section_count != SOIR_V6_READER_SECTION_COUNT {
+            directory_error_offset = start + 32
+            directory_error_detail = section_count
+        } else if directory_offset == SOIR_V6_READER_DIRECTORY_OFFSET &&
+                  directory_length == SOIR_V6_READER_DIRECTORY_SIZE &&
+                  section_count == SOIR_V6_READER_SECTION_COUNT &&
+                  header_size != SOIR_V6_READER_HEADER_SIZE {
+            directory_error_offset = start + 48
+            directory_error_detail = header_size
+        }
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_DIRECTORY,
+            directory_error_offset,
+            directory_error_detail,
+        )
+    }
+    if schema_fingerprint != SOIR_V6_READER_SCHEMA_FINGERPRINT {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_SCHEMA_FINGERPRINT,
+            start + 40,
+            schema_fingerprint,
+        )
+    }
+    if reserved_word != 0 {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BAD_RESERVED,
+            start + 56,
+            reserved_word,
+        )
+    }
+    if cursor.pos != start + directory_offset {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+            cursor.pos,
+            start + directory_offset,
+        )
+    }
+
+    var directory_fields: [i64; 6] = [0; 6]
+    var directory_field_index: i64 = 0
+    while directory_field_index < 6 {
+        if cursor.pos < 0 ||
+           cursor.pos > cursor.end ||
+           8 > cursor.end - cursor.pos {
+            return soir_v6_reader_status_set(
+                status_out,
+                SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+                cursor.pos,
+                8,
+            )
+        }
+        var field_value: i64 = 0
+        var shift: i64 = 0
+        while shift < 64 {
+            let octet = ((*buf)[cursor.pos as usize] as i64) & 255
+            field_value = field_value | (octet << shift)
+            cursor.pos = cursor.pos + 1
+            shift = shift + 8
+        }
+        directory_fields[directory_field_index as usize] = field_value
+        directory_field_index = directory_field_index + 1
+    }
+
+    let section_kind = directory_fields[0]
+    let section_schema = directory_fields[1]
+    let section_flags = directory_fields[2]
+    let section_offset = directory_fields[3]
+    let section_length = directory_fields[4]
+    let section_digest = directory_fields[5]
+
+    if section_flags < 0 || section_flags > SOIR_V6_READER_SECTION_FLAGS_BSS_LAYOUT {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_SECTION_FLAGS,
+            start + SOIR_V6_READER_DIRECTORY_OFFSET + 16,
+            section_flags,
+        )
+    }
+    if section_kind != SOIR_V6_READER_SECTION_KIND_BSS_LAYOUT {
+        var unknown_code = SOIR_V6_READER_ERR_UNKNOWN_OPTIONAL_SECTION
+        if (section_flags & SOIR_V6_READER_SECTION_FLAG_CRITICAL) != 0 {
+            unknown_code = SOIR_V6_READER_ERR_UNKNOWN_CRITICAL_SECTION
+        }
+        return soir_v6_reader_status_set(
+            status_out,
+            unknown_code,
+            start + SOIR_V6_READER_DIRECTORY_OFFSET,
+            section_kind,
+        )
+    }
+    if section_schema != SOIR_V6_READER_SECTION_SCHEMA_BSS_LAYOUT {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_SECTION_SCHEMA,
+            start + SOIR_V6_READER_DIRECTORY_OFFSET + 8,
+            section_schema,
+        )
+    }
+    if section_flags != SOIR_V6_READER_SECTION_FLAGS_BSS_LAYOUT {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_SECTION_FLAGS,
+            start + SOIR_V6_READER_DIRECTORY_OFFSET + 16,
+            section_flags,
+        )
+    }
+    if section_offset < 0 ||
+       section_length < 0 ||
+       section_offset > len ||
+       section_length > len - section_offset ||
+       section_offset != SOIR_V6_READER_BSS_PAYLOAD_OFFSET ||
+       section_length != SOIR_V6_READER_BSS_PAYLOAD_SIZE {
+        var section_error_offset = start + SOIR_V6_READER_DIRECTORY_OFFSET + 24
+        var section_error_detail = section_offset
+        if section_offset == SOIR_V6_READER_BSS_PAYLOAD_OFFSET &&
+           section_length != SOIR_V6_READER_BSS_PAYLOAD_SIZE {
+            section_error_offset = start + SOIR_V6_READER_DIRECTORY_OFFSET + 32
+            section_error_detail = section_length
+        }
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_SECTION_BOUNDS,
+            section_error_offset,
+            section_error_detail,
+        )
+    }
+    if cursor.pos != start + section_offset {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+            cursor.pos,
+            start + section_offset,
+        )
+    }
+
+    // Every section owns a request-local cursor bounded to its directory view.
+    // The additions are safe because section_offset/length were proven above
+    // using subtraction against the already-bounded frame length.
+    var section_cursor = SoirV6ReaderCursor {
+        pos: start + section_offset,
+        end: start + section_offset + section_length,
+    }
+    var payload_fields: [i64; 4] = [0; 4]
+    var payload_field_index: i64 = 0
+    while payload_field_index < 4 {
+        if section_cursor.pos < 0 ||
+           section_cursor.pos > section_cursor.end ||
+           8 > section_cursor.end - section_cursor.pos {
+            return soir_v6_reader_status_set(
+                status_out,
+                SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+                section_cursor.pos,
+                8,
+            )
+        }
+        var field_value: i64 = 0
+        var shift: i64 = 0
+        while shift < 64 {
+            let octet = ((*buf)[section_cursor.pos as usize] as i64) & 255
+            field_value = field_value | (octet << shift)
+            section_cursor.pos = section_cursor.pos + 1
+            shift = shift + 8
+        }
+        payload_fields[payload_field_index as usize] = field_value
+        payload_field_index = payload_field_index + 1
+    }
+    if section_cursor.pos != section_cursor.end || section_cursor.end != cursor.end {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_INTERNAL_BOUNDS,
+            section_cursor.pos,
+            section_cursor.end,
+        )
+    }
+
+    let module_bss_total_size = payload_fields[0]
+    let range_count = payload_fields[1]
+    let range_offset = payload_fields[2]
+    let range_size = payload_fields[3]
+    let computed_digest = soir_v6_reader_bss_payload_checksum(
+        module_bss_total_size,
+        range_count,
+        range_offset,
+        range_size,
+    )
+    if computed_digest != section_digest {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_SECTION_DIGEST,
+            start + SOIR_V6_READER_DIRECTORY_OFFSET + 40,
+            section_digest,
+        )
+    }
+    if module_bss_total_size < 0 {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BSS_LAYOUT,
+            start + SOIR_V6_READER_BSS_PAYLOAD_OFFSET,
+            module_bss_total_size,
+        )
+    }
+    if range_count != SOIR_V6_READER_BSS_RANGE_COUNT {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BSS_LAYOUT,
+            start + SOIR_V6_READER_BSS_PAYLOAD_OFFSET + 8,
+            range_count,
+        )
+    }
+    if range_offset < 0 || range_offset > module_bss_total_size {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BSS_LAYOUT,
+            start + SOIR_V6_READER_BSS_PAYLOAD_OFFSET + 16,
+            range_offset,
+        )
+    }
+    if range_size < 0 ||
+       range_offset > module_bss_total_size ||
+       range_size > module_bss_total_size - range_offset {
+        return soir_v6_reader_status_set(
+            status_out,
+            SOIR_V6_READER_ERR_BSS_LAYOUT,
+            start + SOIR_V6_READER_BSS_PAYLOAD_OFFSET + 24,
+            range_size,
+        )
+    }
+
+    // The full frame is now valid; publish the complete decoded receipt.
+    soir_v6_reader_status_set(
+        status_out,
+        SOIR_V6_READER_OK,
+        0,
+        0,
+    )
+    soir_v6_reader_publish_bss_layout(
+        status_out,
+        module_bss_total_size,
+        range_count,
+        range_offset,
+        range_size,
+    )
+    SOIR_V6_READER_OK
+}

--- a/self-hosted/ir/soir_v6_writer.sio
+++ b/self-hosted/ir/soir_v6_writer.sio
@@ -1,0 +1,297 @@
+// Shadow-only SOIR v6 writer for the first sectioned BSS/layout profile.
+//
+// Semantic-Lane-ID: SOIR-V6-BSS-LAYOUT-R1
+// Concept-IDs: none
+// Intent-Preserved: scientific payloads keep distinct future sections; this
+// lane never narrows or reconstructs numeric, epistemic, algebra, or receipt
+// meaning from the BSS/layout scalars.
+// Claims-Introduced: one canonical v6 frame with one critical singleton
+// BSS/layout section has validation-rejection-no-write before emission.
+// Claims-Forbidden: module graph, opcode, Arena install, numeric payload,
+// wide-numeric decode, multi-section ordering, and default-pipeline use.
+
+module ir::soir_v6_writer
+
+pub let SOIR_V6_WRITER_MAX_SIZE: i64 = 131072
+pub let SOIR_V6_WRITER_VERSION: i8 = 6
+pub let SOIR_V6_WRITER_HEADER_SIZE: i64 = 64
+pub let SOIR_V6_WRITER_DIRECTORY_OFFSET: i64 = 64
+pub let SOIR_V6_WRITER_DIRECTORY_ENTRY_SIZE: i64 = 48
+pub let SOIR_V6_WRITER_DIRECTORY_SIZE: i64 = 48
+pub let SOIR_V6_WRITER_SECTION_COUNT: i64 = 1
+pub let SOIR_V6_WRITER_BSS_PAYLOAD_OFFSET: i64 = 112
+pub let SOIR_V6_WRITER_BSS_PAYLOAD_SIZE: i64 = 32
+pub let SOIR_V6_WRITER_BSS_FRAME_SIZE: i64 = 144
+// Adler-32 of the exact ASCII descriptor (without a terminal NUL):
+// SOIRv6:bss-range-v1:le64:header64:dir48:kind5:critical+singleton:payload(module_total,range_count,range_offset,range_size):adler32
+pub let SOIR_V6_WRITER_SCHEMA_FINGERPRINT: i64 = 3946524625
+
+pub let SOIR_V6_WRITER_SECTION_KIND_BSS_LAYOUT: i64 = 5
+pub let SOIR_V6_WRITER_SECTION_SCHEMA_BSS_LAYOUT: i64 = 1
+pub let SOIR_V6_WRITER_SECTION_FLAG_CRITICAL: i64 = 1
+pub let SOIR_V6_WRITER_SECTION_FLAG_SINGLETON: i64 = 2
+pub let SOIR_V6_WRITER_SECTION_FLAGS_BSS_LAYOUT: i64 = 3
+
+pub let SOIR_V6_WRITER_BSS_RANGE_COUNT: i64 = 1
+
+pub let SOIR_V6_WRITER_OK: i64 = 0
+pub let SOIR_V6_WRITER_ERR_VIEW_BOUNDS: i64 = -1
+pub let SOIR_V6_WRITER_ERR_LAYOUT: i64 = -2
+pub let SOIR_V6_WRITER_ERR_STALE_PLAN: i64 = -3
+pub let SOIR_V6_WRITER_ERR_INTERNAL_BOUNDS: i64 = -4
+
+pub struct SoirV6BssWritePlan {
+    start: i64,
+    capacity: i64,
+    required: i64,
+    end: i64,
+    module_bss_total_size: i64,
+    range_offset: i64,
+    range_size: i64,
+    version: i8,
+    status: i64,
+}
+
+struct SoirV6WriterCursor {
+    pos: i64,
+    limit: i64,
+    status: i64,
+}
+
+fn soir_v6_writer_failed_plan(
+    start: i64,
+    capacity: i64,
+    module_bss_total_size: i64,
+    range_offset: i64,
+    range_size: i64,
+    status: i64,
+) -> SoirV6BssWritePlan {
+    SoirV6BssWritePlan {
+        start: start,
+        capacity: capacity,
+        required: 0,
+        end: start,
+        module_bss_total_size: module_bss_total_size,
+        range_offset: range_offset,
+        range_size: range_size,
+        version: SOIR_V6_WRITER_VERSION,
+        status: status,
+    }
+}
+
+pub fn soir_v6_bss_write_plan_status(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).status
+}
+
+pub fn soir_v6_bss_write_plan_start(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).start
+}
+
+pub fn soir_v6_bss_write_plan_required(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).required
+}
+
+pub fn soir_v6_bss_write_plan_end(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).end
+}
+
+pub fn soir_v6_bss_write_plan_version(plan: &SoirV6BssWritePlan) -> i8 {
+    (*plan).version
+}
+
+pub fn soir_v6_bss_write_plan_module_total(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).module_bss_total_size
+}
+
+pub fn soir_v6_bss_write_plan_range_offset(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).range_offset
+}
+
+pub fn soir_v6_bss_write_plan_range_size(plan: &SoirV6BssWritePlan) -> i64 {
+    (*plan).range_size
+}
+
+fn soir_v6_writer_put_i8(
+    cursor: &! SoirV6WriterCursor,
+    out_buf: &![i8; 131072],
+    value: i8,
+) with Mut, Panic, Div {
+    if (*cursor).status != SOIR_V6_WRITER_OK { return }
+    if (*cursor).pos < 0 ||
+       (*cursor).pos >= (*cursor).limit ||
+       (*cursor).pos >= SOIR_V6_WRITER_MAX_SIZE {
+        (*cursor).status = SOIR_V6_WRITER_ERR_INTERNAL_BOUNDS
+        return
+    }
+    out_buf[(*cursor).pos as usize] = value
+    (*cursor).pos = (*cursor).pos + 1
+}
+
+fn soir_v6_writer_put_i64(
+    cursor: &! SoirV6WriterCursor,
+    out_buf: &![i8; 131072],
+    value: i64,
+) with Mut, Panic, Div {
+    var shift: i64 = 0
+    while shift < 64 {
+        soir_v6_writer_put_i8(cursor, out_buf, ((value >> shift) & 255) as i8)
+        shift = shift + 8
+    }
+}
+
+// Adler-32 is a non-cryptographic integrity checksum, not authentication.
+fn soir_v6_writer_bss_payload_checksum(
+    module_bss_total_size: i64,
+    range_offset: i64,
+    range_size: i64,
+) -> i64 with Div {
+    var a: i64 = 1
+    var b: i64 = 0
+    var word_index: i64 = 0
+    while word_index < 4 {
+        var value = module_bss_total_size
+        if word_index == 1 { value = SOIR_V6_WRITER_BSS_RANGE_COUNT }
+        else if word_index == 2 { value = range_offset }
+        else if word_index == 3 { value = range_size }
+        var byte_index: i64 = 0
+        while byte_index < 8 {
+            let octet = (value >> (byte_index * 8)) & 255
+            a = (a + octet) % 65521
+            b = (b + a) % 65521
+            byte_index = byte_index + 1
+        }
+        word_index = word_index + 1
+    }
+    (b << 16) | a
+}
+
+fn soir_v6_writer_plan_matches(
+    left: &SoirV6BssWritePlan,
+    right: &SoirV6BssWritePlan,
+) -> bool {
+    (*left).status == (*right).status &&
+        (*left).start == (*right).start &&
+        (*left).capacity == (*right).capacity &&
+        (*left).required == (*right).required &&
+        (*left).end == (*right).end &&
+        (*left).module_bss_total_size == (*right).module_bss_total_size &&
+        (*left).range_offset == (*right).range_offset &&
+        (*left).range_size == (*right).range_size &&
+        (*left).version == (*right).version
+}
+
+pub fn soir_v6_writer_preflight_bss_layout(
+    start: i64,
+    capacity: i64,
+    module_bss_total_size: i64,
+    range_offset: i64,
+    range_size: i64,
+) -> SoirV6BssWritePlan with Panic, Div {
+    if start < 0 ||
+       capacity < 0 ||
+       start > SOIR_V6_WRITER_MAX_SIZE ||
+       capacity > SOIR_V6_WRITER_MAX_SIZE - start ||
+       SOIR_V6_WRITER_BSS_FRAME_SIZE > capacity {
+        return soir_v6_writer_failed_plan(
+            start,
+            capacity,
+            module_bss_total_size,
+            range_offset,
+            range_size,
+            SOIR_V6_WRITER_ERR_VIEW_BOUNDS,
+        )
+    }
+    if module_bss_total_size < 0 ||
+       range_offset < 0 ||
+       range_size < 0 ||
+       range_offset > module_bss_total_size ||
+       range_size > module_bss_total_size - range_offset {
+        return soir_v6_writer_failed_plan(
+            start,
+            capacity,
+            module_bss_total_size,
+            range_offset,
+            range_size,
+            SOIR_V6_WRITER_ERR_LAYOUT,
+        )
+    }
+    SoirV6BssWritePlan {
+        start: start,
+        capacity: capacity,
+        required: SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        end: start + SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        module_bss_total_size: module_bss_total_size,
+        range_offset: range_offset,
+        range_size: range_size,
+        version: SOIR_V6_WRITER_VERSION,
+        status: SOIR_V6_WRITER_OK,
+    }
+}
+
+pub fn soir_v6_writer_emit_bss_layout(
+    plan: &SoirV6BssWritePlan,
+    out_buf: &![i8; 131072],
+) -> i64 with Mut, Panic, Div {
+    if (*plan).status != SOIR_V6_WRITER_OK { return (*plan).status }
+    let verified = soir_v6_writer_preflight_bss_layout(
+        (*plan).start,
+        (*plan).capacity,
+        (*plan).module_bss_total_size,
+        (*plan).range_offset,
+        (*plan).range_size,
+    )
+    if !soir_v6_writer_plan_matches(plan, &verified) {
+        return SOIR_V6_WRITER_ERR_STALE_PLAN
+    }
+
+    var cursor = SoirV6WriterCursor {
+        pos: (*plan).start,
+        limit: (*plan).end,
+        status: SOIR_V6_WRITER_OK,
+    }
+
+    // Fixed header: magic, version/feature policy, lengths, and schema identity.
+    soir_v6_writer_put_i8(&! cursor, out_buf, 83 as i8)
+    soir_v6_writer_put_i8(&! cursor, out_buf, 79 as i8)
+    soir_v6_writer_put_i8(&! cursor, out_buf, 73 as i8)
+    soir_v6_writer_put_i8(&! cursor, out_buf, 82 as i8)
+    soir_v6_writer_put_i8(&! cursor, out_buf, SOIR_V6_WRITER_VERSION)
+    soir_v6_writer_put_i8(&! cursor, out_buf, 0 as i8)
+    soir_v6_writer_put_i8(&! cursor, out_buf, 0 as i8)
+    soir_v6_writer_put_i8(&! cursor, out_buf, 0 as i8)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_BSS_FRAME_SIZE)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_DIRECTORY_OFFSET)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_DIRECTORY_SIZE)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_SECTION_COUNT)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_SCHEMA_FINGERPRINT)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_HEADER_SIZE)
+    soir_v6_writer_put_i64(&! cursor, out_buf, 0)
+
+    // One canonical critical singleton directory entry.
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_SECTION_KIND_BSS_LAYOUT)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_SECTION_SCHEMA_BSS_LAYOUT)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_SECTION_FLAGS_BSS_LAYOUT)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_BSS_PAYLOAD_OFFSET)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_BSS_PAYLOAD_SIZE)
+    soir_v6_writer_put_i64(
+        &! cursor,
+        out_buf,
+        soir_v6_writer_bss_payload_checksum(
+            (*plan).module_bss_total_size,
+            (*plan).range_offset,
+            (*plan).range_size,
+        ),
+    )
+
+    // BSS/layout schema v1: one anonymous range. Function binding awaits the
+    // canonical ModuleGraph and is deliberately not inferred from range order.
+    soir_v6_writer_put_i64(&! cursor, out_buf, (*plan).module_bss_total_size)
+    soir_v6_writer_put_i64(&! cursor, out_buf, SOIR_V6_WRITER_BSS_RANGE_COUNT)
+    soir_v6_writer_put_i64(&! cursor, out_buf, (*plan).range_offset)
+    soir_v6_writer_put_i64(&! cursor, out_buf, (*plan).range_size)
+
+    if cursor.status != SOIR_V6_WRITER_OK || cursor.pos != (*plan).end {
+        return SOIR_V6_WRITER_ERR_INTERNAL_BOUNDS
+    }
+    cursor.pos
+}

--- a/tests/native-v2/soir_v6_bss_layout_reject_witness.sio
+++ b/tests/native-v2/soir_v6_bss_layout_reject_witness.sio
@@ -1,0 +1,334 @@
+use ir::soir_v6_writer::*
+use ir::soir_v6_reader::*
+
+let REJECT_CANARY: i64 = 7070707
+
+fn decoded_canaries_preserved(receipt: &[i64; 7]) -> bool with Panic, Div {
+    var index: i64 = SOIR_V6_READER_RECEIPT_BSS_MODULE_TOTAL
+    while index < SOIR_V6_READER_RECEIPT_WORDS {
+        if (*receipt)[index as usize] != REJECT_CANARY { return false }
+        index = index + 1
+    }
+    true
+}
+
+fn expect_failure(
+    wire: &[i8; 131072],
+    start: i64,
+    len: i64,
+    expected_code: i64,
+    expected_byte_offset: i64,
+    expected_detail: i64,
+) -> bool with Mut, Panic, Div {
+    var receipt: [i64; 7] = [REJECT_CANARY; 7]
+    let code = soir_v6_reader_decode_bss_layout(
+        wire,
+        start,
+        len,
+        &! receipt,
+    )
+    if code != expected_code { return false }
+    if receipt[0 as usize] != expected_code { return false }
+    if receipt[1 as usize] != expected_byte_offset { return false }
+    if receipt[2 as usize] != expected_detail { return false }
+    if soir_v6_bss_read_status_code(&receipt) != expected_code { return false }
+    if soir_v6_bss_read_status_byte_offset(&receipt) != expected_byte_offset { return false }
+    if soir_v6_bss_read_status_detail(&receipt) != expected_detail { return false }
+    if !decoded_canaries_preserved(&receipt) { return false }
+    true
+}
+
+fn witness_write_i64(
+    wire: &![i8; 131072],
+    offset: i64,
+    value: i64,
+) with Mut, Panic, Div {
+    var shift: i64 = 0
+    while shift < 64 {
+        wire[(offset + (shift / 8)) as usize] = ((value >> shift) & 255) as i8
+        shift = shift + 8
+    }
+}
+
+fn witness_payload_checksum(
+    module_bss_total_size: i64,
+    range_count: i64,
+    range_offset: i64,
+    range_size: i64,
+) -> i64 with Div {
+    var a: i64 = 1
+    var b: i64 = 0
+    var word_index: i64 = 0
+    while word_index < 4 {
+        var value = module_bss_total_size
+        if word_index == 1 { value = range_count }
+        else if word_index == 2 { value = range_offset }
+        else if word_index == 3 { value = range_size }
+        var byte_index: i64 = 0
+        while byte_index < 8 {
+            let octet = (value >> (byte_index * 8)) & 255
+            a = (a + octet) % 65521
+            b = (b + a) % 65521
+            byte_index = byte_index + 1
+        }
+        word_index = word_index + 1
+    }
+    (b << 16) | a
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    var wire: [i8; 131072] = [85; 131072]
+    let plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    let emitted_end = soir_v6_writer_emit_bss_layout(&plan, &! wire)
+    if emitted_end != SOIR_V6_WRITER_BSS_FRAME_SIZE { return 9 }
+
+    if !expect_failure(
+           &wire,
+           0 - 1,
+           SOIR_V6_READER_BSS_FRAME_SIZE,
+           SOIR_V6_READER_ERR_VIEW_BOUNDS,
+           0 - 1,
+           SOIR_V6_READER_BSS_FRAME_SIZE,
+       ) { return 10 }
+    if !expect_failure(
+           &wire,
+           0,
+           0 - 1,
+           SOIR_V6_READER_ERR_VIEW_BOUNDS,
+           0,
+           0 - 1,
+       ) { return 10 }
+    let overflowing_start = SOIR_V6_READER_MAX_SIZE - SOIR_V6_READER_BSS_FRAME_SIZE + 1
+    if !expect_failure(
+           &wire,
+           overflowing_start,
+           SOIR_V6_READER_BSS_FRAME_SIZE,
+           SOIR_V6_READER_ERR_VIEW_BOUNDS,
+           overflowing_start,
+           SOIR_V6_READER_BSS_FRAME_SIZE,
+       ) { return 10 }
+
+    var truncated_len: i64 = 0
+    while truncated_len < SOIR_V6_READER_BSS_FRAME_SIZE {
+        if !expect_failure(
+               &wire,
+               0,
+               truncated_len,
+               SOIR_V6_READER_ERR_TRUNCATED,
+               truncated_len,
+               SOIR_V6_READER_BSS_FRAME_SIZE,
+           ) {
+            return 11
+        }
+        truncated_len = truncated_len + 1
+    }
+    if !expect_failure(
+           &wire,
+           0,
+           SOIR_V6_READER_BSS_FRAME_SIZE + 1,
+           SOIR_V6_READER_ERR_TRAILING_BYTES,
+           SOIR_V6_READER_BSS_FRAME_SIZE,
+           1,
+       ) {
+        return 12
+    }
+
+    wire[0] = 84 as i8
+    if !expect_failure(&wire, 0, emitted_end, SOIR_V6_READER_ERR_BAD_MAGIC, 0, 84) { return 20 }
+    wire[0] = 83 as i8
+
+    wire[4] = 7 as i8
+    if !expect_failure(&wire, 0, emitted_end, SOIR_V6_READER_ERR_BAD_VERSION, 4, 7) { return 21 }
+    wire[4] = SOIR_V6_WRITER_VERSION
+
+    wire[5] = 1 as i8
+    if !expect_failure(&wire, 0, emitted_end, SOIR_V6_READER_ERR_BAD_FEATURES, 5, 1) { return 22 }
+    wire[5] = 0 as i8
+
+    wire[6] = 1 as i8
+    if !expect_failure(&wire, 0, emitted_end, SOIR_V6_READER_ERR_BAD_RESERVED, 6, 1) { return 23 }
+    wire[6] = 0 as i8
+
+    witness_write_i64(&! wire, 8, SOIR_V6_READER_BSS_FRAME_SIZE + 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_TOTAL_LENGTH,
+           8, SOIR_V6_READER_BSS_FRAME_SIZE + 1,
+       ) { return 24 }
+    witness_write_i64(&! wire, 8, SOIR_V6_READER_BSS_FRAME_SIZE)
+
+    witness_write_i64(&! wire, 16, SOIR_V6_READER_DIRECTORY_OFFSET + 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_DIRECTORY,
+           16, SOIR_V6_READER_DIRECTORY_OFFSET + 1,
+       ) { return 25 }
+    witness_write_i64(&! wire, 16, SOIR_V6_READER_DIRECTORY_OFFSET)
+
+    witness_write_i64(&! wire, 24, SOIR_V6_READER_DIRECTORY_SIZE + 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_DIRECTORY,
+           24, SOIR_V6_READER_DIRECTORY_SIZE + 1,
+       ) { return 26 }
+    witness_write_i64(&! wire, 24, SOIR_V6_READER_DIRECTORY_SIZE)
+
+    witness_write_i64(&! wire, 32, SOIR_V6_READER_SECTION_COUNT + 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_DIRECTORY,
+           32, SOIR_V6_READER_SECTION_COUNT + 1,
+       ) { return 27 }
+    witness_write_i64(&! wire, 32, SOIR_V6_READER_SECTION_COUNT)
+
+    witness_write_i64(&! wire, 40, SOIR_V6_READER_SCHEMA_FINGERPRINT ^ 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SCHEMA_FINGERPRINT,
+           40, SOIR_V6_READER_SCHEMA_FINGERPRINT ^ 1,
+       ) { return 28 }
+    witness_write_i64(&! wire, 40, SOIR_V6_READER_SCHEMA_FINGERPRINT)
+
+    witness_write_i64(&! wire, 48, SOIR_V6_READER_HEADER_SIZE - 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_DIRECTORY,
+           48, SOIR_V6_READER_HEADER_SIZE - 1,
+       ) { return 29 }
+    witness_write_i64(&! wire, 48, SOIR_V6_READER_HEADER_SIZE)
+
+    witness_write_i64(&! wire, 56, 1)
+    if !expect_failure(&wire, 0, emitted_end, SOIR_V6_READER_ERR_BAD_RESERVED, 56, 1) { return 30 }
+    witness_write_i64(&! wire, 56, 0)
+
+    witness_write_i64(&! wire, 64, 99)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_UNKNOWN_CRITICAL_SECTION,
+           64, 99,
+       ) { return 31 }
+    witness_write_i64(&! wire, 80, SOIR_V6_READER_SECTION_FLAG_SINGLETON)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_UNKNOWN_OPTIONAL_SECTION,
+           64, 99,
+       ) { return 32 }
+    witness_write_i64(&! wire, 64, SOIR_V6_READER_SECTION_KIND_BSS_LAYOUT)
+    witness_write_i64(&! wire, 80, SOIR_V6_READER_SECTION_FLAGS_BSS_LAYOUT)
+
+    witness_write_i64(&! wire, 72, SOIR_V6_READER_SECTION_SCHEMA_BSS_LAYOUT + 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_SCHEMA,
+           72, SOIR_V6_READER_SECTION_SCHEMA_BSS_LAYOUT + 1,
+       ) { return 33 }
+    witness_write_i64(&! wire, 72, SOIR_V6_READER_SECTION_SCHEMA_BSS_LAYOUT)
+
+    witness_write_i64(&! wire, 80, 4)
+    if !expect_failure(&wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_FLAGS, 80, 4) { return 34 }
+    witness_write_i64(&! wire, 80, SOIR_V6_READER_SECTION_FLAGS_BSS_LAYOUT)
+
+    witness_write_i64(&! wire, 88, SOIR_V6_READER_BSS_PAYLOAD_OFFSET - 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_BOUNDS,
+           88, SOIR_V6_READER_BSS_PAYLOAD_OFFSET - 1,
+       ) { return 35 }
+    witness_write_i64(&! wire, 88, SOIR_V6_READER_BSS_PAYLOAD_OFFSET)
+
+    witness_write_i64(&! wire, 96, SOIR_V6_READER_BSS_PAYLOAD_SIZE - 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_BOUNDS,
+           96, SOIR_V6_READER_BSS_PAYLOAD_SIZE - 1,
+       ) { return 36 }
+    witness_write_i64(&! wire, 96, SOIR_V6_READER_BSS_PAYLOAD_SIZE)
+
+    witness_write_i64(&! wire, 88, SOIR_V6_READER_BSS_FRAME_SIZE + 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_BOUNDS,
+           88, SOIR_V6_READER_BSS_FRAME_SIZE + 1,
+       ) { return 37 }
+    witness_write_i64(&! wire, 88, SOIR_V6_READER_BSS_PAYLOAD_OFFSET)
+
+    witness_write_i64(&! wire, 96, 0 - 1)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_BOUNDS,
+           96, 0 - 1,
+       ) { return 38 }
+    witness_write_i64(&! wire, 96, SOIR_V6_READER_BSS_PAYLOAD_SIZE)
+
+    let canonical_digest = witness_payload_checksum(8, 1, 0, 8)
+    wire[104] = (wire[104] ^ 1 as i8)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_DIGEST,
+           104, canonical_digest ^ 1,
+       ) { return 39 }
+    wire[104] = (wire[104] ^ 1 as i8)
+
+    wire[112] = (wire[112] ^ 1 as i8)
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_SECTION_DIGEST,
+           104, canonical_digest,
+       ) { return 40 }
+    wire[112] = (wire[112] ^ 1 as i8)
+
+    witness_write_i64(&! wire, 120, 2)
+    witness_write_i64(&! wire, 104, witness_payload_checksum(8, 2, 0, 8))
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_BSS_LAYOUT,
+           120, 2,
+       ) { return 41 }
+    soir_v6_writer_emit_bss_layout(&plan, &! wire)
+
+    witness_write_i64(&! wire, 112, 0 - 1)
+    witness_write_i64(&! wire, 136, 0 - 1)
+    witness_write_i64(&! wire, 104, witness_payload_checksum(0 - 1, 1, 0, 0 - 1))
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_BSS_LAYOUT,
+           112, 0 - 1,
+       ) { return 42 }
+    soir_v6_writer_emit_bss_layout(&plan, &! wire)
+
+    witness_write_i64(&! wire, 128, 1)
+    witness_write_i64(&! wire, 104, witness_payload_checksum(8, 1, 1, 8))
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_BSS_LAYOUT,
+           136, 8,
+       ) { return 43 }
+    soir_v6_writer_emit_bss_layout(&plan, &! wire)
+
+    witness_write_i64(&! wire, 136, 16)
+    witness_write_i64(&! wire, 104, witness_payload_checksum(8, 1, 0, 16))
+    if !expect_failure(
+           &wire, 0, emitted_end, SOIR_V6_READER_ERR_BSS_LAYOUT,
+           136, 16,
+       ) { return 44 }
+
+    var first_failure: [i64; 7] = [REJECT_CANARY; 7]
+    var repeated_failure: [i64; 7] = [REJECT_CANARY; 7]
+    let first_code = soir_v6_reader_decode_bss_layout(
+        &wire,
+        0,
+        emitted_end,
+        &! first_failure,
+    )
+    let repeated_code = soir_v6_reader_decode_bss_layout(
+        &wire,
+        0,
+        emitted_end,
+        &! repeated_failure,
+    )
+    if first_code != SOIR_V6_READER_ERR_BSS_LAYOUT { return 45 }
+    if repeated_code != first_code { return 45 }
+    if first_failure[0 as usize] != SOIR_V6_READER_ERR_BSS_LAYOUT { return 45 }
+    if first_failure[1 as usize] != 136 { return 45 }
+    if first_failure[2 as usize] != 16 { return 45 }
+    var receipt_index: i64 = 0
+    while receipt_index < SOIR_V6_READER_RECEIPT_WORDS {
+        if first_failure[receipt_index as usize] != repeated_failure[receipt_index as usize] {
+            return 45
+        }
+        receipt_index = receipt_index + 1
+    }
+    if !decoded_canaries_preserved(&first_failure) { return 45 }
+    if !decoded_canaries_preserved(&repeated_failure) { return 45 }
+
+    print("SOIR_V6_BSS_LAYOUT_REJECT_PASS\n")
+    0
+}

--- a/tests/native-v2/soir_v6_bss_layout_witness.sio
+++ b/tests/native-v2/soir_v6_bss_layout_witness.sio
@@ -1,0 +1,328 @@
+use ir::soir_v6_writer::*
+use ir::soir_v6_reader::*
+
+fn receipt_matches_v6_bss(
+    receipt: &[i64; 7],
+    module_bss_total_size: i64,
+    range_count: i64,
+    range_offset: i64,
+    range_size: i64,
+) -> bool with Panic, Div {
+    // Raw slots prove the physical contract independently of the accessors.
+    if (*receipt)[0 as usize] != SOIR_V6_READER_OK { return false }
+    if (*receipt)[1 as usize] != 0 { return false }
+    if (*receipt)[2 as usize] != 0 { return false }
+    if (*receipt)[3 as usize] != module_bss_total_size { return false }
+    if (*receipt)[4 as usize] != range_count { return false }
+    if (*receipt)[5 as usize] != range_offset { return false }
+    if (*receipt)[6 as usize] != range_size { return false }
+
+    if soir_v6_bss_read_status_code(receipt) != SOIR_V6_READER_OK { return false }
+    if soir_v6_bss_read_status_byte_offset(receipt) != 0 { return false }
+    if soir_v6_bss_read_status_detail(receipt) != 0 { return false }
+    if soir_v6_bss_decoded_module_total(receipt) != module_bss_total_size { return false }
+    if soir_v6_bss_decoded_range_count(receipt) != range_count { return false }
+    if soir_v6_bss_decoded_range_offset(receipt) != range_offset { return false }
+    if soir_v6_bss_decoded_range_size(receipt) != range_size { return false }
+    true
+}
+
+fn receipts_match(left: &[i64; 7], right: &[i64; 7]) -> bool with Panic, Div {
+    var index: i64 = 0
+    while index < SOIR_V6_READER_RECEIPT_WORDS {
+        if (*left)[index as usize] != (*right)[index as usize] { return false }
+        index = index + 1
+    }
+    true
+}
+
+fn wire_is_filled(wire: &[i8; 131072], expected: i8) -> bool with Panic, Div {
+    var index: i64 = 0
+    while index < SOIR_V6_WRITER_MAX_SIZE {
+        if (*wire)[index as usize] != expected { return false }
+        index = index + 1
+    }
+    true
+}
+
+fn main() -> i64 with IO, Mut, Panic, Div {
+    if SOIR_V6_WRITER_MAX_SIZE != SOIR_V6_READER_MAX_SIZE ||
+       SOIR_V6_WRITER_VERSION as i64 != SOIR_V6_READER_VERSION ||
+       SOIR_V6_WRITER_HEADER_SIZE != SOIR_V6_READER_HEADER_SIZE ||
+       SOIR_V6_WRITER_DIRECTORY_OFFSET != SOIR_V6_READER_DIRECTORY_OFFSET ||
+       SOIR_V6_WRITER_DIRECTORY_ENTRY_SIZE != SOIR_V6_READER_DIRECTORY_ENTRY_SIZE ||
+       SOIR_V6_WRITER_DIRECTORY_SIZE != SOIR_V6_READER_DIRECTORY_SIZE ||
+       SOIR_V6_WRITER_SECTION_COUNT != SOIR_V6_READER_SECTION_COUNT ||
+       SOIR_V6_WRITER_BSS_PAYLOAD_OFFSET != SOIR_V6_READER_BSS_PAYLOAD_OFFSET ||
+       SOIR_V6_WRITER_BSS_PAYLOAD_SIZE != SOIR_V6_READER_BSS_PAYLOAD_SIZE ||
+       SOIR_V6_WRITER_BSS_FRAME_SIZE != SOIR_V6_READER_BSS_FRAME_SIZE ||
+       SOIR_V6_WRITER_SCHEMA_FINGERPRINT != SOIR_V6_READER_SCHEMA_FINGERPRINT ||
+       SOIR_V6_WRITER_SECTION_KIND_BSS_LAYOUT != SOIR_V6_READER_SECTION_KIND_BSS_LAYOUT ||
+       SOIR_V6_WRITER_SECTION_SCHEMA_BSS_LAYOUT != SOIR_V6_READER_SECTION_SCHEMA_BSS_LAYOUT ||
+       SOIR_V6_WRITER_SECTION_FLAGS_BSS_LAYOUT != SOIR_V6_READER_SECTION_FLAGS_BSS_LAYOUT {
+        return 9
+    }
+
+    let short_plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE - 1,
+        8,
+        0,
+        8,
+    )
+    if soir_v6_bss_write_plan_status(&short_plan) != SOIR_V6_WRITER_ERR_VIEW_BOUNDS {
+        return 10
+    }
+    let range_plan = soir_v6_writer_preflight_bss_layout(
+        SOIR_V6_WRITER_MAX_SIZE - SOIR_V6_WRITER_BSS_FRAME_SIZE + 1,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    if soir_v6_bss_write_plan_status(&range_plan) != SOIR_V6_WRITER_ERR_VIEW_BOUNDS {
+        return 11
+    }
+    let negative_module_plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        0 - 1,
+        0,
+        0,
+    )
+    let negative_offset_plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0 - 1,
+        1,
+    )
+    let negative_size_plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        0 - 1,
+    )
+    let mismatch_plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        16,
+    )
+    if soir_v6_bss_write_plan_status(&negative_module_plan) != SOIR_V6_WRITER_ERR_LAYOUT ||
+       soir_v6_bss_write_plan_status(&negative_offset_plan) != SOIR_V6_WRITER_ERR_LAYOUT ||
+       soir_v6_bss_write_plan_status(&negative_size_plan) != SOIR_V6_WRITER_ERR_LAYOUT ||
+       soir_v6_bss_write_plan_status(&mismatch_plan) != SOIR_V6_WRITER_ERR_LAYOUT {
+        return 12
+    }
+
+    var wire: [i8; 131072] = [85; 131072]
+    let failed_emit = soir_v6_writer_emit_bss_layout(&mismatch_plan, &! wire)
+    if failed_emit != SOIR_V6_WRITER_ERR_LAYOUT { return 13 }
+    if !wire_is_filled(&wire, 85 as i8) { return 13 }
+
+    let plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    if soir_v6_bss_write_plan_status(&plan) != SOIR_V6_WRITER_OK ||
+       soir_v6_bss_write_plan_start(&plan) != 0 ||
+       soir_v6_bss_write_plan_required(&plan) != SOIR_V6_WRITER_BSS_FRAME_SIZE ||
+       soir_v6_bss_write_plan_end(&plan) != SOIR_V6_WRITER_BSS_FRAME_SIZE ||
+       soir_v6_bss_write_plan_version(&plan) as i64 != SOIR_V6_READER_VERSION ||
+       soir_v6_bss_write_plan_module_total(&plan) != 8 ||
+       soir_v6_bss_write_plan_range_offset(&plan) != 0 ||
+       soir_v6_bss_write_plan_range_size(&plan) != 8 {
+        return 20
+    }
+
+    // Revalidation, not struct privacy, authorizes emission. Forged plans must
+    // fail before the first byte is written.
+    var stale_required = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    stale_required.required = stale_required.required + 1
+    var stale_end = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    stale_end.end = stale_end.end + 1
+    var stale_version = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    stale_version.version = 7 as i8
+    var stale_source = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    stale_source.range_offset = 4
+    var stale_wire: [i8; 131072] = [85; 131072]
+    let stale_required_code = soir_v6_writer_emit_bss_layout(&stale_required, &! stale_wire)
+    if stale_required_code != SOIR_V6_WRITER_ERR_STALE_PLAN { return 21 }
+    if !wire_is_filled(&stale_wire, 85 as i8) { return 21 }
+    let stale_end_code = soir_v6_writer_emit_bss_layout(&stale_end, &! stale_wire)
+    if stale_end_code != SOIR_V6_WRITER_ERR_STALE_PLAN { return 21 }
+    if !wire_is_filled(&stale_wire, 85 as i8) { return 21 }
+    let stale_version_code = soir_v6_writer_emit_bss_layout(&stale_version, &! stale_wire)
+    if stale_version_code != SOIR_V6_WRITER_ERR_STALE_PLAN { return 21 }
+    if !wire_is_filled(&stale_wire, 85 as i8) { return 21 }
+    let stale_source_code = soir_v6_writer_emit_bss_layout(&stale_source, &! stale_wire)
+    if stale_source_code != SOIR_V6_WRITER_ERR_STALE_PLAN { return 21 }
+    if !wire_is_filled(&stale_wire, 85 as i8) { return 21 }
+    let emitted_end = soir_v6_writer_emit_bss_layout(&plan, &! wire)
+    if emitted_end != SOIR_V6_WRITER_BSS_FRAME_SIZE ||
+       wire[0] != 83 as i8 ||
+       wire[1] != 79 as i8 ||
+       wire[2] != 73 as i8 ||
+       wire[3] != 82 as i8 ||
+       wire[4] != SOIR_V6_WRITER_VERSION ||
+       wire[SOIR_V6_WRITER_BSS_FRAME_SIZE as usize] != 85 as i8 {
+        return 22
+    }
+
+    var duplicate_wire: [i8; 131072] = [85; 131072]
+    let duplicate_plan = soir_v6_writer_preflight_bss_layout(
+        0,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    let duplicate_end = soir_v6_writer_emit_bss_layout(
+        &duplicate_plan,
+        &! duplicate_wire,
+    )
+    var wire_index: i64 = 0
+    while wire_index < SOIR_V6_WRITER_BSS_FRAME_SIZE {
+        if wire[wire_index as usize] != duplicate_wire[wire_index as usize] {
+            return 23
+        }
+        wire_index = wire_index + 1
+    }
+    if duplicate_end != emitted_end { return 23 }
+
+    var receipt: [i64; 7] = [0 - 91; 7]
+    let read_code = soir_v6_reader_decode_bss_layout(
+        &wire,
+        0,
+        emitted_end,
+        &! receipt,
+    )
+    var canonical_receipt_ok = true
+    if read_code != SOIR_V6_READER_OK { canonical_receipt_ok = false }
+    if !receipt_matches_v6_bss(&receipt, 8, 1, 0, 8) { canonical_receipt_ok = false }
+    if !canonical_receipt_ok {
+        print("SOIR_V6_BSS_LAYOUT_CANONICAL_FAIL code=")
+        print_int(read_code)
+        print(" offset=")
+        print_int(soir_v6_bss_read_status_byte_offset(&receipt))
+        print(" detail=")
+        print_int(soir_v6_bss_read_status_detail(&receipt))
+        print(" module_total=")
+        print_int(soir_v6_bss_decoded_module_total(&receipt))
+        print(" range_count=")
+        print_int(soir_v6_bss_decoded_range_count(&receipt))
+        print(" range_offset=")
+        print_int(soir_v6_bss_decoded_range_offset(&receipt))
+        print(" range_size=")
+        print_int(soir_v6_bss_decoded_range_size(&receipt))
+        print("\n")
+        return 24
+    }
+
+    var repeated: [i64; 7] = [0 - 77; 7]
+    let repeated_code = soir_v6_reader_decode_bss_layout(
+        &wire,
+        0,
+        emitted_end,
+        &! repeated,
+    )
+    var repeated_receipt_ok = true
+    if repeated_code != SOIR_V6_READER_OK { repeated_receipt_ok = false }
+    if !receipts_match(&receipt, &repeated) { repeated_receipt_ok = false }
+    if !repeated_receipt_ok {
+        print("SOIR_V6_BSS_LAYOUT_REPEAT_FAIL code=")
+        print_int(repeated_code)
+        var mismatch_index: i64 = 0
+        while mismatch_index < SOIR_V6_READER_RECEIPT_WORDS {
+            if receipt[mismatch_index as usize] != repeated[mismatch_index as usize] {
+                print(" index=")
+                print_int(mismatch_index)
+                print(" first=")
+                print_int(receipt[mismatch_index as usize])
+                print(" second=")
+                print_int(repeated[mismatch_index as usize])
+            }
+            mismatch_index = mismatch_index + 1
+        }
+        print("\n")
+        return 25
+    }
+
+    var offset_wire: [i8; 131072] = [85; 131072]
+    let offset_start: i64 = 17
+    let offset_plan = soir_v6_writer_preflight_bss_layout(
+        offset_start,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        8,
+        0,
+        8,
+    )
+    let offset_end = soir_v6_writer_emit_bss_layout(&offset_plan, &! offset_wire)
+    var offset_receipt: [i64; 7] = [0 - 66; 7]
+    let offset_code = soir_v6_reader_decode_bss_layout(
+        &offset_wire,
+        offset_start,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        &! offset_receipt,
+    )
+    if offset_end != offset_start + SOIR_V6_WRITER_BSS_FRAME_SIZE { return 26 }
+    if offset_code != SOIR_V6_READER_OK { return 26 }
+    if offset_wire[(offset_start - 1) as usize] != 85 as i8 { return 26 }
+    if offset_wire[offset_end as usize] != 85 as i8 { return 26 }
+    if !receipt_matches_v6_bss(&offset_receipt, 8, 1, 0, 8) { return 26 }
+
+    var terminal_wire: [i8; 131072] = [85; 131072]
+    let terminal_start = SOIR_V6_WRITER_MAX_SIZE - SOIR_V6_WRITER_BSS_FRAME_SIZE
+    let terminal_plan = soir_v6_writer_preflight_bss_layout(
+        terminal_start,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        4096,
+        2048,
+        128,
+    )
+    let terminal_end = soir_v6_writer_emit_bss_layout(&terminal_plan, &! terminal_wire)
+    var terminal_receipt: [i64; 7] = [0 - 55; 7]
+    let terminal_code = soir_v6_reader_decode_bss_layout(
+        &terminal_wire,
+        terminal_start,
+        SOIR_V6_WRITER_BSS_FRAME_SIZE,
+        &! terminal_receipt,
+    )
+    if terminal_end != SOIR_V6_WRITER_MAX_SIZE { return 27 }
+    if terminal_code != SOIR_V6_READER_OK { return 27 }
+    if terminal_wire[(terminal_start - 1) as usize] != 85 as i8 { return 27 }
+    if !receipt_matches_v6_bss(&terminal_receipt, 4096, 1, 2048, 128) { return 27 }
+
+    print("SOIR_V6_BSS_LAYOUT_CANONICAL_PASS\n")
+    0
+}


### PR DESCRIPTION
## What this proves

- adds a shadow-only SOIR v6-D0 frame: 64-byte header, one 48-byte directory entry, one 32-byte critical singleton BSS_LAYOUT payload
- adds exact writer preflight plus emit-time revalidation; rejected and forged plans preserve all 131072 output bytes
- adds a bounded reader with frame-local and section-local cursors, Adler-32 integrity checking, exact truncation/trailing/critical-section rejection, and semantic layout validation
- fixes the receipt contract at seven disjoint scalar words: `code, byte_offset, detail, module_total, range_count, range_offset, range_size`
- keeps v1-v5 and the default compiler pipeline unchanged

## Evidence

Default-path clean-tree gate on current head `fcc58fdaf`:

```
SOIR_V6_BSS_LAYOUT_CHECK source=2/2 composite=2/2 precision_identity=preserved
SOIR_V6_BSS_LAYOUT_WRITER preflight=exact emit_revalidation=pass validation_rejection_no_write=pass forged_plan=reject deterministic_bytes=pass offset_view=pass terminal_view=pass
SOIR_V6_BSS_LAYOUT_READER ... semantic_words=7 physical_words=7 padding_words=0 ... success_status=zeroed ... slot_reuse=none
SOIR_V6_BSS_LAYOUT_PASS ... raw_compiler_sha256=99f6d955d6a07286f3c9653012bccb6ff8b50fbe87853b33121fc0e9a51979ef ... lane_content_sha256=010e98f9c4d59de64faf8c88071be3433a56336ba9f5464fb09015673dd7255c
```

No compiler override or fallback was used. The raw compiler is the checked-in Madaros refreshed by successful workflow run `29670125837`: source `87ac6b162`, full/enum/loop/multimodule/source-to-ELF gates green, 99,077,387 bytes, artifact byte-identical to the committed binary.

Negative causality was established before refresh: old raw `fa3bcbcb...` compiled the same composite but returned rc=24 with `range_offset=8` for encoded `range_offset=0`; source-fresh Madaros passed. The stale binary has now been replaced. A separate Slurm rebuild of exact semantic commit `1fb1471ca` remains the independent source-fresh receipt before this draft is promoted.

## Honesty boundary

This is one anonymous BSS range only. It does not implement or claim ModuleGraph identity, opcode/function binding, IrModuleArena installation, TargetLayout, ABI semantics, numeric payload transport, multi-section ordering, or default-pipeline adoption. It partially advances #1162 and does not close it.

## Review

Independent read-only review found and then verified fixes for physical slot identity, full-buffer rejection/no-write evidence, exact failure triplets, seven-word determinism, and removal of compound boolean lowering from receipt-critical checks.

LLM offload: not applicable; this lane changes compiler serialization mechanics and contains no math claim, clinical pathway, or external-facing artifact.