### PR TITLE
docs(handoff): dispatch a bulk-copy builtin (mem_copy_f64/memcpy) to CODEX-2

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1007
-- Repo-backed topics: 857
+- Total governed topics: 1008
+- Repo-backed topics: 858
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 607
+- Authority count `repo_only`: 608
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 626 topics
+- A2: 627 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -386,6 +386,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.exact-engine-prereqs | repo_only | docs/handoff/exact_engine_prereqs.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.gpu-knowledge-vecmat-swarm-plan | repo_only | docs/handoff/gpu_knowledge_vecmat_swarm_plan.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.madaros-fixed-array-call-boundary-alias-2026-07-14 | repo_only | docs/handoff/madaros_fixed_array_call_boundary_alias_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.mem-copy-builtin-codex-dispatch-2026-07-19 | repo_only | docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.monolithic-public-lower-call-blocker-2026-07-13 | repo_only | docs/handoff/monolithic_public_lower_call_blocker_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.neurodyn-ab-fixed-octmul-reaudit-2026-07-07 | repo_only | docs/handoff/neurodyn_ab_fixed_octmul_reaudit_2026-07-07.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.neurodyn-adhd200-pcp-pilot24-2026-07-07 | repo_only | docs/handoff/neurodyn_adhd200_pcp_pilot24_2026-07-07.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8378,6 +8378,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.mem-copy-builtin-codex-dispatch-2026-07-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.monolithic-public-lower-call-blocker-2026-07-13",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/monolithic_public_lower_call_blocker_2026-07-13.md",

--- a/docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md
+++ b/docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md
@@ -1,0 +1,89 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.mem-copy-builtin-codex-dispatch-2026-07-19
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.mem-copy-builtin-codex-dispatch-2026-07-19
+-->
+
+# Dispatch to CODEX-2 — expose a bulk-copy builtin (mem_copy_f64 / memcpy) for the lean_single/native backend
+
+**Date:** 2026-07-19
+**Owner:** CODEX-2 (compiler builtins / lean_single + native codegen)
+**Author:** data-science lane (measured on the bigframe filter)
+**Status:** measured, quantified, low blast radius — a builtin wire-up, not new machinery
+
+---
+
+## TL;DR
+
+Bulk memory copies in stdlib (contiguous DataFrame slices, buffer growth, binary serialization) are
+currently a scalar `read_f64`/`write_f64` element loop that runs at **~3.25 GB/s** — ~6x below memory
+bandwidth. libc `memcpy` (SIMD / `rep movsb`) does the same move at **~20 GB/s**. Expose a **bulk-copy
+builtin** (`mem_copy_f64(dst: *mut f64, src: *mut f64, n: i64)`, or a generic byte `mem_copy(dst, src,
+bytes)`) that lowers to `memcpy`, and every bulk move in the data layer speeds up ~6x. The machinery
+already exists in the compiler; this is wiring, not invention.
+
+## Measurement (reproducible)
+
+Copying a contiguous 12 MB block (500,000 rows x 3 f64 columns) via the current `read_f64`/`write_f64`
+loop: **3.69 ms/copy (~3.25 GB/s)**. At memory bandwidth (~20 GB/s) that is ~0.6 ms. In the shipped
+`bf_filter_gt` contiguous fast-path, the copy is ~3.7 ms of a 9.1 ms filter; a `memcpy` builtin would
+drop the filter toward ~6 ms, closing the pandas gap on that op from ~2.1x toward ~1.4x. The same win
+applies to every bulk move (below).
+
+## The machinery already exists (cite)
+
+- **The builtin pattern to copy:** `read_f64`/`write_f64` are already backend builtins emitted directly
+  by the lean_single codegen — `self-hosted/compiler/lean_single.sio:8855` (`emit_read_f64`),
+  `:8870` (`emit_write_f64`), dispatched by name at `:13133` (`src_match(ns, ne-ns, "read_f64")`).
+  A `mem_copy` builtin slots in exactly the same way: recognize the name, emit a call to libc `memcpy`
+  (or an inlined `rep movsb`).
+- **memcpy is already used in other backends:** `self-hosted/llvm/builder.sio:267` (`llvm_build_memcpy`
+  -> `LLVMBuildMemCpy`, `ffi.sio:254`), and the GPU runtime `self-hosted/gpu/runtime/cuda.sio:472`
+  (`cuda_memcpy_h2d`/`d2h`). So the concept and the FFI are present; only the lean_single/native
+  user-facing builtin is missing.
+- Heap works only under lean_single today (see the C2 dispatch), so the builtin must live in the
+  lean_single/native builtin set alongside `read_f64`/`write_f64`.
+
+## The ask
+
+Add a builtin, callable from Sounio under lean_single/native:
+
+```
+mem_copy_f64(dst: *mut f64, src: *mut f64, n: i64)      // copy n f64 (n*8 bytes)
+// or generic:
+mem_copy(dst: *mut u8, src: *mut u8, bytes: i64)         // lowers to memcpy(dst, src, bytes)
+```
+
+lowering to libc `memcpy` (non-overlapping; add `mem_move`/`memmove` if overlap support is wanted).
+Mirror it in the LLVM backend via the existing `llvm_build_memcpy`. No new dependency — `memcpy` is
+libc, already linked (the heap uses libc `calloc`/`realloc`/`free`).
+
+## Where stdlib uses it immediately
+
+- `stdlib/data/bigframe_ops.sio` `bf_filter_gt` contiguous fast-path — one `mem_copy_f64` per column
+  instead of a per-element loop.
+- `stdlib/data/bigframe.sio` `bf_push_row` / `bf_reserve` growth — bulk-copy on realloc paths.
+- `stdlib/data/arrow_bridge.sio` SIO1 serialization — bulk-copy each column buffer into the output.
+- Any future columnar copy / concat / take.
+
+## Acceptance
+
+- `mem_copy_f64` over 1.5M f64 sustains >= 10 GB/s (vs ~3.25 GB/s for the current loop).
+- `bf_filter_gt` on 500k contiguous survivors drops from ~9.1 ms toward ~6 ms.
+- Bit-identical output (it is a byte copy).
+
+## Scope / non-goals
+
+- Non-overlapping `memcpy` semantics are enough for the columnar use (src and dst are distinct heap
+  buffers). Overlap-safe `memmove` is optional.
+- This is orthogonal to the C3 SIMD auto-vectorization dispatch
+  (`c3_simd_autovectorization_codex_dispatch_2026-07-19.md`): that one speeds up *reductions/scans*
+  (compute), this one speeds up *bulk moves* (copy). Both are needed to reach kernel-speed.
+
+## Pointers
+- Measurement + usage: `stdlib/data/bigframe_ops.sio` (`bf_filter_gt` contiguous path),
+  `scripts/bench/RESULTS.md`. Builtin template: `self-hosted/compiler/lean_single.sio:8855-8886`.
+  Existing memcpy: `self-hosted/llvm/builder.sio:267`, `self-hosted/gpu/runtime/cuda.sio:472`.


### PR DESCRIPTION
## A bulk-copy builtin — the copy half of closing the pandas gap

The C3 SIMD dispatch covers *compute* (reductions/scans). This covers *copy*. stdlib bulk moves — contiguous DataFrame slices, buffer growth, SIO1 serialization — are a scalar `read_f64`/`write_f64` element loop running at **~3.25 GB/s**, ~6× below memory bandwidth. libc `memcpy` does the same 12 MB in ~0.6 ms (**~20 GB/s**).

**Ask:** expose `mem_copy_f64(dst, src, n)` (or generic `mem_copy(dst, src, bytes)`) in the lean_single/native builtin set — the same slot as `read_f64`/`write_f64` (`lean_single.sio:8855/8870/13133`) — lowering to libc `memcpy`. Mirror via the existing `llvm_build_memcpy` (`builder.sio:267`).

**The machinery already exists** — `LLVMBuildMemCpy`, `cuda_memcpy_h2d/d2h` — only the user-facing lean_single builtin is missing. `memcpy` is libc, already linked (the heap uses libc `calloc`/`realloc`/`free`).

**Immediate wins:** `bf_filter_gt` contiguous fast-path (9.1 ms → ~6 ms, one `mem_copy_f64` per column), `bf_push_row`/`bf_reserve` growth, `arrow_bridge` serialization.

Quantified, low blast radius (a builtin wire-up), orthogonal to the C3 SIMD dispatch (both needed for kernel speed). No compiler changes in this PR — it's the work order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)