### PR TITLE
fix(madaros): file_size() rejects directories in the remaining emitters

### DIFF
--- a/bootstrap/mini_native.sio
+++ b/bootstrap/mini_native.sio
@@ -453,13 +453,22 @@ fn emit_read_file() with Mut {
 }
 
 fn emit_file_size() with Mut {
-    // rax = path. stat(path, &statbuf) → statbuf.st_size at offset 48
+    // rax = path. stat(path, &statbuf) → statbuf.st_size at offset 48.
+    // A directory (st_mode S_IFDIR at offset 24) returns -1 so a directory is
+    // treated as an unreadable/absent file (matches lean_single emit_file_size).
     em(0x48); em(0x89); em(0xc7)  // mov rdi, rax (path)
     em(0x48); em(0x83); em(0xec); em(0x90 as i64 & 0xFF)  // sub rsp, 144 (struct stat)
     em(0x48); em(0x89); em(0xe6)  // mov rsi, rsp (statbuf)
     em(0xb8); em32(4)  // mov eax, 4 (sys_stat)
     em(0x0f); em(0x05)
+    // reject directories: (st_mode & S_IFMT) == S_IFDIR → -1
+    em(0x8b); em(0x44); em(0x24); em(24)  // mov eax, [rsp+24] (st_mode)
+    em(0x25); em32(0xF000)  // and eax, 0xF000 (S_IFMT)
+    em(0x3d); em32(0x4000)  // cmp eax, 0x4000 (S_IFDIR)
+    em(0x74); em(0x07)  // je +7 (directory → -1)
     em(0x48); em(0x8b); em(0x44); em(0x24); em(48)  // mov rax, [rsp+48] (st_size)
+    em(0xeb); em(0x07)  // jmp +7 (done)
+    em(0x48); em(0xc7); em(0xc0); em32(-1)  // mov rax, -1 (directory)
     em(0x48); em(0x83); em(0xc4); em(0x90 as i64 & 0xFF)  // add rsp, 144
 }
 

--- a/self-hosted/compiler/lean_single.sio
+++ b/self-hosted/compiler/lean_single.sio
@@ -30628,10 +30628,19 @@ fn emit_file_size_a64() with Mut, Panic {
     }
     emit_syscall_a64()
     if TARGET_OS == 2 {
+        em32(0x79400BEA)  // ldrh w10, [sp, #4] (Darwin st_mode, offset 4, 16-bit)
         em32(0xF94033E9)  // ldr x9, [sp, #96] (Darwin syscall 339 stat layout)
     } else {
+        em32(0xB9401BEA)  // ldr w10, [sp, #24] (Linux st_mode, offset 24, 32-bit)
         em32(0xF9400000 | ((48/8) << 10) | (31 << 5) | 9)  // ldr x9, [sp, #48]
     }
+    // reject directories: (st_mode & S_IFMT) == S_IFDIR → x9 = -1 (mirror x86;
+    // callers treat a directory like an unreadable/absent file). Encodings
+    // verified byte-exact vs clang --target=aarch64.
+    em32(0x12140D4A)  // and w10, w10, #0xF000 (S_IFMT)
+    em32(0x7140115F)  // cmp w10, #0x4000 (S_IFDIR)
+    em32(0x54000041)  // b.ne +8 (skip movn if not a directory)
+    em32(0x92800009)  // movn x9, #0 → x9 = -1 (directory)
     em32(0x91000000 | (160 << 10) | (31 << 5) | 31)     // add sp, sp, #160
     em32(0xF84107E0)  // pop fd
     if TARGET_OS == 2 {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -4780,12 +4780,20 @@ fn emit_builtin_file_size(nc: NativeCompiler) -> NativeCompiler with Mut, Panic,
 
     // Check for error
     c.code = emit_test_rax_rax(c.code)
-    // If error (rax < 0), return -1
-    // For simplicity: load st_size regardless, on error it'll be garbage
-    // but we can check: if rax != 0, return rax (the error code)
-    c.code = emit_jnz_rel8(c.code, 5)                    // if error, skip to return rax
-    // Load st_size from [rsp + 48]
-    c.code = emit_mov_rax_rsp_disp8(c.code, 48)          // rax = st_size
+    // stat error (rax != 0) → return rax (negative errno). Directory (st_mode
+    // S_IFDIR at offset 24) → -1 so file_exists()==false (a directory is never a
+    // valid source/import file). Otherwise load st_size at offset 48. Mirrors the
+    // lean_single emit_file_size directory guard. Fixed-size block, hand-computed
+    // relative jumps (block spans 32 bytes; targets: err/done = +32, dir = the
+    // `mov rax,-1`). Verified byte-exact vs a reference assembler.
+    c.code = emit_byte(c.code, 0x75); c.code = emit_byte(c.code, 0x1e)  // jnz +30 (stat error → return rax)
+    c.code = emit_byte(c.code, 0x8b); c.code = emit_byte(c.code, 0x44); c.code = emit_byte(c.code, 0x24); c.code = emit_byte(c.code, 0x18)  // mov eax,[rsp+24] (st_mode)
+    c.code = emit_byte(c.code, 0x25); c.code = emit_byte(c.code, 0x00); c.code = emit_byte(c.code, 0xf0); c.code = emit_byte(c.code, 0x00); c.code = emit_byte(c.code, 0x00)  // and eax,0xF000 (S_IFMT)
+    c.code = emit_byte(c.code, 0x3d); c.code = emit_byte(c.code, 0x00); c.code = emit_byte(c.code, 0x40); c.code = emit_byte(c.code, 0x00); c.code = emit_byte(c.code, 0x00)  // cmp eax,0x4000 (S_IFDIR)
+    c.code = emit_byte(c.code, 0x74); c.code = emit_byte(c.code, 0x07)  // je +7 (directory → -1)
+    c.code = emit_byte(c.code, 0x48); c.code = emit_byte(c.code, 0x8b); c.code = emit_byte(c.code, 0x44); c.code = emit_byte(c.code, 0x24); c.code = emit_byte(c.code, 0x30)  // mov rax,[rsp+48] (st_size)
+    c.code = emit_byte(c.code, 0xeb); c.code = emit_byte(c.code, 0x07)  // jmp +7 (done)
+    c.code = emit_byte(c.code, 0x48); c.code = emit_byte(c.code, 0xc7); c.code = emit_byte(c.code, 0xc0); c.code = emit_byte(c.code, 0xff); c.code = emit_byte(c.code, 0xff); c.code = emit_byte(c.code, 0xff); c.code = emit_byte(c.code, 0xff)  // mov rax,-1 (directory)
 
     c.code = emit_mov_rsp_rbp(c.code)
     c.code = emit_pop_rbp(c.code)


### PR DESCRIPTION
Consistency follow-up to #1170 (which fixed only the lean_single **x86** `emit_file_size`). The sibling `emit_file_size` emitters still returned a directory's `st_size` — a latent bug, since a directory is never a valid source/import file and callers use `file_size(path) >= 0` as "exists". Same `S_IFDIR` guard applied:

- **`self-hosted/native/codegen_x86_linux.sio`** (native-v2 x86): `st_mode` @ offset 24, `(& 0xF000)==0x4000 → -1`, hand-computed relative jumps around the existing stat-error path. Byte-exact vs a reference assembler.
- **`bootstrap/mini_native.sio`** (bootstrap x86): same x86 guard.
- **`self-hosted/compiler/lean_single.sio` `emit_file_size_a64`** (ARM64): `st_mode` is offset 24 / 32-bit on Linux, offset 4 / 16-bit on Darwin — loaded per-target, then the common `(& 0xF000)==0x4000 → x9=-1`. The fd is still closed before returning. Encodings byte-exact vs `clang --target=aarch64`.

## Verification tiers (do not conflate)

| Emitter | Tier |
|---|---|
| codegen_x86_linux | **Runtime-verified** — a program built by this Madaros gets `file_size("/tmp") < 0` (DIR_REJECTED) and a real file `> 0` (FILE_OK); all 5 Madaros gates + read_file dynmmap + CSV reader gates green |
| a64 | **Encoding-verified** vs clang; Linux rebuild proves it *compiles*; runtime rests on **macOS self-host CI**. Green Linux CI is *not* a64 runtime verification |
| mini_native | **Encoding-verified only**; `bin/souc-native` isn't rebuilt by this path, so not runtime-exercised (bootstrap / low-traffic) |

No behavior change for the shipping compiler beyond #1170; this hardens the sibling emitters for user programs / other targets. (No prebuilt refresh needed — the load-bearing fixes already shipped via #1170's refresh.)