### PR TITLE
feat(gpu): f64 TENSOR CORES (wmma m8n8k4.f64) — exact batched hypercomplex multiply at tile throughput (GB10)

### DIFF
--- a/docs/gpu/oct_batch_mul_f64_tile.ptx
+++ b/docs/gpu/oct_batch_mul_f64_tile.ptx
@@ -1,0 +1,86 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[64] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000};
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pH,
+    .param .u64 pout
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 16 .b8 shared_array[2048];
+    .reg .f32 %f<1>;
+    .reg .f64 %fd<14>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pH];
+    ld.param.u64 %rd2, [pout];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BF0;
+    mov.u32 %r5, 0;
+$BFL:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    mov.u32 %r9, shared_array;
+    mul.lo.u32 %r10, %r5, 8;
+    add.u32 %r9, %r9, %r10;
+    st.shared.f64 [%r9], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $BFL;
+$BF0:
+    bar.sync 0;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 0;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 32;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 0;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 512;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 544;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 64;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    ret;
+}

--- a/docs/gpu/run_batch_f64_ptx.cu
+++ b/docs/gpu/run_batch_f64_ptx.cu
@@ -1,0 +1,40 @@
+// Validates the batched hypercomplex multiply D = L(a)·H on F64 TENSOR CORES (wmma m8n8k4.f64) against
+// the f16→f32 tile (oct_batch_mul) on the DGX Spark GB10 — exact f64 vs the lossy half-precision tile.
+// Usage: run_batch_f64 <f64tile.ptx> <f16tile.ptx> <dim>.
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+int main(int c,char**v){
+ const char*p64=c>1?v[1]:"/tmp/f64.ptx";const char*p16=c>2?v[2]:"/tmp/f16.ptx";int DIM=c>3?atoi(v[3]):8;int BITS=(DIM==16)?4:3;
+ double a[16]={0},H[256]={0};
+ for(int i=0;i<DIM;i++)a[i]=0.4*((i%2)?-1:1)+0.05*i;
+ for(int b=0;b<16;b++)for(int r=0;r<DIM;r++)H[b*DIM+r]=((b+1)*0.15+r*0.07)*((r%2)?-1:1);
+ double ref[256]={0};
+ for(int b=0;b<16;b++)for(int i=0;i<DIM;i++)for(int j=0;j<DIM;j++)ref[(i^j)*16+b]+=(double)cds(i,j,BITS)*a[i]*H[b*DIM+j];
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext x;CK(cuDevicePrimaryCtxRetain(&x,d));CK(cuCtxSetCurrent(x));
+ CUmodule m64,m16;CK(cuModuleLoad(&m64,p64));CK(cuModuleLoad(&m16,p16));
+ CUfunction f64,f16;CK(cuModuleGetFunction(&f64,m64,"step"));CK(cuModuleGetFunction(&f16,m16,"step"));
+ CUdeviceptr pa,pH,po8,po4;CK(cuMemAlloc(&pa,DIM*8));CK(cuMemAlloc(&pH,16*DIM*8));CK(cuMemAlloc(&po8,256*8));CK(cuMemAlloc(&po4,256*4));
+ CK(cuMemcpyHtoD(pa,a,DIM*8));CK(cuMemcpyHtoD(pH,H,16*DIM*8));
+ double z8[256]={0};CK(cuMemcpyHtoD(po8,z8,256*8));float z4[256]={0};CK(cuMemcpyHtoD(po4,z4,256*4));
+ void*a64[]={&pa,&pH,&po8};CK(cuLaunchKernel(f64,1,1,1,32,1,1,0,0,a64,0));CK(cuCtxSynchronize());
+ void*a16[]={&pa,&pH,&po4};CK(cuLaunchKernel(f16,1,1,1,32,1,1,0,0,a16,0));CK(cuCtxSynchronize());
+ double D8[256];float D4[256];CK(cuMemcpyDtoH(D8,po8,256*8));CK(cuMemcpyDtoH(D4,po4,256*4));
+ double m8=0,m4=0;int f8=0;
+ for(int k=0;k<DIM;k++)for(int b=0;b<16;b++){
+   double e8=fabs(D8[k*16+b]-ref[k*16+b]);if(e8>m8)m8=e8;if(e8>1e-12)f8++;
+   double e4=fabs((double)D4[k*16+b]-ref[k*16+b]);if(e4>m4)m4=e4;}
+ const char*nm=(DIM==16)?"SEDENION":"octonion";
+ printf("Batched %s multiply D = L(a)·H on GB10, maxerr vs host f64:\n",nm);
+ printf("  f64 tensor cores (m8n8k4.f64): %.3e  (%d/%d mism)   ← EXACT\n",m8,f8,DIM*16);
+ printf("  f16 tile (m16n16k16.f16):      %.3e                ← lossy\n",m4);
+ if(f8){printf("FAIL: f64 tensor-core tile not exact\n");return 1;}
+ printf("PASS: f64 tensor-core tile is exact to machine precision (vs the f16 tile's ~1e-2..1e-4) on GB10\n");
+ return 0;
+}

--- a/docs/gpu/sed_batch_mul_f64_tile.ptx
+++ b/docs/gpu/sed_batch_mul_f64_tile.ptx
@@ -1,0 +1,166 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pH,
+    .param .u64 pout
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 16 .b8 shared_array[2048];
+    .reg .f32 %f<1>;
+    .reg .f64 %fd<14>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pH];
+    ld.param.u64 %rd2, [pout];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BF0;
+    mov.u32 %r5, 0;
+$BFL:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    mov.u32 %r9, shared_array;
+    mul.lo.u32 %r10, %r5, 8;
+    add.u32 %r9, %r9, %r10;
+    st.shared.f64 [%r9], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $BFL;
+$BF0:
+    bar.sync 0;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 0;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 32;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 64;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 64;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 96;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 96;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 0;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1024;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1056;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 64;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1088;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 96;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1120;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 64;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1024;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 0;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1056;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 32;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1088;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 64;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1120;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 96;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 1024;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1024;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1024;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1056;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1056;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1088;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1088;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1120;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1120;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 1088;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    ret;
+}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1833,6 +1833,17 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             bwd.src_reg = instr.call_args[3]
             bwd.shared_addr = instr.call_args[4]
             k = gpu_kernel_append_op(k, bwd)
+        } else if hlir_name_is_oct_batch_mul_f64(cn) || hlir_name_is_sed_batch_mul_f64(cn) {
+            // Batched hypercomplex multiply on f64 TENSOR CORES (wmma m8n8k4.f64). call_args =
+            // [pa, pH, pout]. L(a) f64 in shared + m8n8k4 f64 tiles → one GpuOctBatchF64. 2048 bytes.
+            if k.shared_bytes < 2048 { k.shared_bytes = 2048 }
+            var bf = gpu_op_new()
+            bf.opcode = GpuOpcode::GpuOctBatchF64
+            bf.rhs_imm = if hlir_name_is_sed_batch_mul_f64(cn) { 16 } else { 8 }
+            bf.lhs_reg = instr.call_args[0]
+            bf.rhs_reg = instr.call_args[1]
+            bf.addr_reg = instr.call_args[2]
+            k = gpu_kernel_append_op(k, bf)
         } else if hlir_name_is_ossm_oct_step_f64(cn) || hlir_name_is_ossm_sed_step_f64(cn) {
             // Full-f64 O-SSM step. call_args = [pA, pB, px, pH, pout]. Exact f64 → one GpuOctStepF64.
             var sf = gpu_op_new()
@@ -2039,6 +2050,26 @@ fn hlir_name_is_ossm_sed_readout(n: HlirName) -> bool {
     n.buf[4] == 95 as i8 && n.buf[5] == 115 as i8 && n.buf[6] == 101 as i8 && n.buf[7] == 100 as i8 &&
     n.buf[8] == 95 as i8 && n.buf[9] == 114 as i8 && n.buf[10] == 101 as i8 && n.buf[11] == 97 as i8 &&
     n.buf[12] == 100 as i8 && n.buf[13] == 111 as i8 && n.buf[14] == 117 as i8 && n.buf[15] == 116 as i8
+}
+
+// "oct_batch_mul_f64" (17 chars) — batched octonion multiply on f64 tensor cores (m8n8k4.f64).
+fn hlir_name_is_oct_batch_mul_f64(n: HlirName) -> bool {
+    if n.len != 17 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 99 as i8 && n.buf[2] == 116 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
+    n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 109 as i8 && n.buf[11] == 117 as i8 &&
+    n.buf[12] == 108 as i8 && n.buf[13] == 95 as i8 && n.buf[14] == 102 as i8 && n.buf[15] == 54 as i8 &&
+    n.buf[16] == 52 as i8
+}
+
+// "sed_batch_mul_f64" (17 chars) — batched sedenion multiply on f64 tensor cores (dim=16, bits=4).
+fn hlir_name_is_sed_batch_mul_f64(n: HlirName) -> bool {
+    if n.len != 17 { return false }
+    n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8 && n.buf[2] == 100 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
+    n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 109 as i8 && n.buf[11] == 117 as i8 &&
+    n.buf[12] == 108 as i8 && n.buf[13] == 95 as i8 && n.buf[14] == 102 as i8 && n.buf[15] == 54 as i8 &&
+    n.buf[16] == 52 as i8
 }
 
 // "ossm_oct_step_f64" (17 chars) — full-f64 O-SSM step S = A⊗H + B·x (octonion, dim=8, bits=3).

--- a/self-hosted/gpu/kernel_ir.sio
+++ b/self-hosted/gpu/kernel_ir.sio
@@ -140,6 +140,10 @@ pub enum GpuOpcode {
     GpuOctStepF64,      // FULL-f64 O-SSM step S[k,b] = Σ_j σ(k⊕j,j)·A[k⊕j]·H[j,b] + B[k]·x[b], computed
     //   entirely in f64 (no f16 tile) → EXACT forward for sharp gradients / a clean FD check. Output S
     //   is f64 D-layout [k*16+b]. pA,pB,px,pH,pout in lhs/rhs/addr/src/shared_addr; rhs_imm = dim.
+    GpuOctBatchF64,     // Batched hypercomplex multiply D = L(a)·H on F64 TENSOR CORES (wmma m8n8k4.f64,
+    //   sm_80+): exact f64 at tile throughput. L(a) built f64 in shared; H loaded col-major from global;
+    //   D(dim×16) tiled as (dim/8) m-tiles × 2 n-tiles × (dim/4) k-chunks of m8n8k4. pa,pH,pout in
+    //   lhs/rhs/addr; rhs_imm = dim (8 octonion / 16 sedenion).
     GpuTmaLoad,         // Tensor memory access load (sm_90+)
     GpuTmaStore,        // Tensor memory access store (sm_90+)
 

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -60,6 +60,12 @@ pub fn gpu_lower_to_ptx(kernel: GpuKernelIr) -> PtxBuf with Mut, Panic, Div, All
         let fbits = if fdim == 16 { 4 } else { 3 }
         buf = ptx_push_str(buf, gpu_emit_cell_sign_table(fdim, fbits))
     }
+    // f64 tensor-core tile: ossm_Lsgn σ(k⊕j,j) for the f64 L(a) build.
+    if gpu_has_oct_batch_f64(kernel) {
+        let tdim = gpu_batch_f64_dim(kernel)
+        let tbits = if tdim == 16 { 4 } else { 3 }
+        buf = ptx_push_str(buf, gpu_emit_cell_sign_table(tdim, tbits))
+    }
     // gpu_emit_kernel_mode_metadata skipped: calls gpu_legalize_kernel_to_ssa_v2 which
     // returns GpuKernelSsaV2 by value (~28MB frame) → SIGSEGV in lean_single-compiled binary.
     // The function only emits cosmetic PTX comment lines; skip it for correctness.
@@ -164,7 +170,7 @@ fn gpu_has_wmma_tile(kernel: GpuKernelIr) -> bool {
     var i: i64 = 0
     while i < kernel.op_count {
         let oc = kernel.ops[i as usize].opcode
-        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc || oc == GpuOpcode::GpuOctVjp || oc == GpuOpcode::GpuOctBwd || oc == GpuOpcode::GpuOctBwdNl { return true }
+        if oc == GpuOpcode::GpuWmmaTile || oc == GpuOpcode::GpuOctCell || oc == GpuOpcode::GpuOctRecur || oc == GpuOpcode::GpuOctAssoc || oc == GpuOpcode::GpuOctVjp || oc == GpuOpcode::GpuOctBwd || oc == GpuOpcode::GpuOctBwdNl || oc == GpuOpcode::GpuOctBatchF64 { return true }
         i = i + 1
     }
     false
@@ -181,7 +187,8 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     let cell = gpu_has_oct_cell(kernel) || gpu_has_oct_recur(kernel) || gpu_has_oct_assoc(kernel) || gpu_has_oct_vjp(kernel) || gpu_has_oct_bwd(kernel) || gpu_has_oct_bwd_nl(kernel)
     let readout = gpu_has_oct_readout(kernel)
     let stepf64 = gpu_has_oct_step_f64(kernel)
-    let stage_or_pa = stage || postadd || cell || readout || stepf64
+    let tc64 = gpu_has_oct_batch_f64(kernel)
+    let stage_or_pa = stage || postadd || cell || readout || stepf64 || tc64
 
     // .reg .pred %p<N> — the staging loop / post-add need at least %p<2>.
     var pred_count = kernel.max_reg_pred
@@ -198,6 +205,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     if cell && b32_count < 12 { b32_count = 12 }
     if readout && b32_count < 6 { b32_count = 6 }
     if stepf64 && b32_count < 12 { b32_count = 12 }
+    if tc64 && b32_count < 12 { b32_count = 12 }
     if b32_count > 0 {
         out = ptx_push_str(out, "    .reg .b32 %r<")
         out = gpu_push_i64(out, b32_count)
@@ -208,7 +216,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     // (params occupy %rd0..%rd5, so scratch must avoid clobbering them, e.g. pC=%rd3).
     var b64_count = if kernel.max_reg_u64 > kernel.max_reg_i64 { kernel.max_reg_u64 } else { kernel.max_reg_i64 }
     // The cell and the O-SSM-step post-add both use %rd7 as address scratch (runtime loops).
-    if (cell || postadd || readout || stepf64) && b64_count < 8 { b64_count = 8 }
+    if (cell || postadd || readout || stepf64 || tc64) && b64_count < 8 { b64_count = 8 }
     if b64_count > 0 {
         out = ptx_push_str(out, "    .reg .b64 %rd<")
         out = gpu_push_i64(out, b64_count)
@@ -223,6 +231,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     var f32_count = kernel.max_reg_f32
     if postadd && f32_count < 4 { f32_count = 4 }
     if stepf64 && f32_count < 1 { f32_count = 1 }
+    if tc64 && f32_count < 1 { f32_count = 1 }
     if cell && f32_count < 8 { f32_count = 8 }
     if f32_count > 0 {
         out = ptx_push_str(out, "    .reg .f32 %f<")
@@ -234,6 +243,7 @@ fn gpu_emit_reg_decls(buf: PtxBuf, kernel: GpuKernelIr) -> PtxBuf with Mut, Pani
     var f64_count = kernel.max_reg_f64
     if stage && f64_count < 2 { f64_count = 2 }
     if (postadd || cell || readout || stepf64) && f64_count < 3 { f64_count = 3 }
+    if tc64 && f64_count < 14 { f64_count = 14 }
     if f64_count > 0 {
         out = ptx_push_str(out, "    .reg .f64 %fd<")
         out = gpu_push_i64(out, f64_count)
@@ -1187,6 +1197,91 @@ fn gpu_emit_oct_step_f64(pAR: string, pBR: string, pxR: string, pHR: string, pou
     t
 }
 
+// Does this kernel contain the f64 tensor-core batched-multiply op?
+fn gpu_has_oct_batch_f64(kernel: GpuKernelIr) -> bool {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctBatchF64 { return true }
+        i = i + 1
+    }
+    false
+}
+
+// The dim of the f64 tensor-core tile op (8 octonion / 16 sedenion), for the module-scope sign table.
+fn gpu_batch_f64_dim(kernel: GpuKernelIr) -> i64 {
+    var i: i64 = 0
+    while i < kernel.op_count {
+        if kernel.ops[i as usize].opcode == GpuOpcode::GpuOctBatchF64 {
+            if kernel.ops[i as usize].rhs_imm == 16 { return 16 }
+            return 8
+        }
+        i = i + 1
+    }
+    8
+}
+
+// Batched hypercomplex multiply D = L(a)·H on F64 TENSOR CORES (wmma m8n8k4.f64). L(a) (σ(k⊕j,j)·a[k⊕j])
+// is built f64 row-major into sL[shared]; H is loaded col-major directly from the global batch pointer
+// (its state-major layout [state*dim+comp] already matches a col-major B). D(dim×16) is computed as
+// (dim/8) m-tiles × 2 n-tiles × (dim/4) k-chunks of m8n8k4; each (m,n) tile accumulates its k-chunks in
+// the f64 fragment {%fd10,%fd11} then stores to pout (D-layout [comp*16+state]).
+fn gpu_emit_oct_batch_f64(paR: string, pHR: string, poutR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+    let sh = if dim == 16 { 4 } else { 3 }
+    // thread 0: build L(a) f64 row-major into sL[shared_array]  (sL[k*dim+j] = σ(k⊕j,j)·a[k⊕j])
+    var t = "    mov.u32 %r1, %tid.x;\n    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $BF0;\n"
+    t = str_concat(t, "    mov.u32 %r5, 0;\n$BFL:\n")
+    t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
+    t = str_concat(str_concat(t, ";\n    and.b32 %r7, %r5, "), i64_to_string(dim - 1))
+    t = str_concat(t, ";\n    xor.b32 %r8, %r6, %r7;\n")
+    t = str_concat(str_concat(t, "    mul.wide.u32 %rd7, %r8, 8;\n    add.s64 %rd7, "), paR)
+    t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
+    t = str_concat(t, "    mul.wide.u32 %rd7, %r5, 4;\n    mov.u64 %rd6, ossm_Lsgn;\n    add.s64 %rd7, %rd6, %rd7;\n")
+    t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n    cvt.f64.f32 %fd1, %f0;\n    mul.f64 %fd0, %fd0, %fd1;\n")
+    t = str_concat(t, "    mov.u32 %r9, shared_array;\n    mul.lo.u32 %r10, %r5, 8;\n    add.u32 %r9, %r9, %r10;\n")
+    t = str_concat(t, "    st.shared.f64 [%r9], %fd0;\n")
+    t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim))
+    t = str_concat(t, ";\n    @%p1 bra $BFL;\n$BF0:\n    bar.sync 0;\n")
+    // warp-collective: (dim/8) m-tiles × 2 n-tiles, each accumulating (dim/4) k-chunks of m8n8k4
+    let mtiles = dim / 8
+    let kchunks = dim / 4
+    var mt: i64 = 0
+    while mt < mtiles {
+        var nt: i64 = 0
+        while nt < 2 {
+            t = str_concat(t, gpu_emit_f64_mma_block(pHR, poutR, mt, nt, dim, kchunks))
+            nt = nt + 1
+        }
+        mt = mt + 1
+    }
+    t
+}
+
+// One (mt,nt) output tile: fd=0; accumulate kchunks m8n8k4 f64 mma; store D(8×8) to pout D-layout.
+fn gpu_emit_f64_mma_block(pHR: string, poutR: string, mt: i64, nt: i64, dim: i64, kchunks: i64) -> string with Mut, Panic, Div, Alloc {
+    var t = "    mov.f64 %fd10, 0d0000000000000000;\n    mov.f64 %fd11, 0d0000000000000000;\n"
+    var kc: i64 = 0
+    while kc < kchunks {
+        // A: sL 8×4 slice at (mt*8, kc*4), row-major ldm=dim → shared byte addr = (mt*8*dim + kc*4)*8
+        t = str_concat(str_concat(t, "    mov.u32 %r1, shared_array;\n    add.u32 %r1, %r1, "), i64_to_string((mt * 8 * dim + kc * 4) * 8))
+        t = str_concat(str_concat(t, ";\n    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], "), i64_to_string(dim))
+        t = str_concat(t, ";\n")
+        // B: H 4×8 slice at (kc*4, nt*8), col-major ldm=dim → global byte addr = (nt*8*dim + kc*4)*8
+        t = str_concat(str_concat(t, "    add.s64 %rd7, "), pHR)
+        t = str_concat(str_concat(t, ", "), i64_to_string((nt * 8 * dim + kc * 4) * 8))
+        t = str_concat(str_concat(t, ";\n    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], "), i64_to_string(dim))
+        t = str_concat(t, ";\n")
+        // mma accumulate
+        t = str_concat(t, "    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn ")
+        t = str_concat(t, "{%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};\n")
+        kc = kc + 1
+    }
+    // store D(8×8) at (mt*8 comps, nt*8 states) → pout D-layout [comp*16+state], ldm=16
+    t = str_concat(str_concat(t, "    add.s64 %rd7, "), poutR)
+    t = str_concat(str_concat(t, ", "), i64_to_string((mt * 8 * 16 + nt * 8) * 8))
+    t = str_concat(t, ";\n    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;\n")
+    t
+}
+
 // O-SSM real readout y[b] = Re(C⊗h)[b] = Σ_p σ(p,p)·C[p]·h[p,b], thread 0. σ(p,p)=+1 for p=0, −1 for
 // p≥1, so y[b] = C[0]·h[0,b] − Σ_{p≥1} C[p]·h[p,b]. h is D-layout [p*16+b]; the p-stride is 16*8=128
 // bytes (immediate offsets, p unrolled). b runs 0..16 as a runtime loop. CR/HR/yR are the pointers.
@@ -1668,6 +1763,13 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
             // Full-f64 O-SSM step. Pointers: pA=lhs, pB=rhs, px=addr, pH=src, pout=shared_addr.
             let fdim = if op.rhs_imm == 16 { 16 } else { 8 }
             ptx_push_str(buf, gpu_emit_oct_step_f64(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), gpu_reg_u64(op.src_reg), gpu_reg_u64(op.shared_addr), fdim))
+        }
+
+        GpuOpcode::GpuOctBatchF64 => {
+            // Batched hypercomplex multiply on f64 tensor cores (m8n8k4.f64). pa=lhs, pH=rhs, pout=addr.
+            let tdim = if op.rhs_imm == 16 { 16 } else { 8 }
+            let tbits = if tdim == 16 { 4 } else { 3 }
+            ptx_push_str(buf, gpu_emit_oct_batch_f64(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), tdim, tbits))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/self-hosted/gpu/ptx.sio
+++ b/self-hosted/gpu/ptx.sio
@@ -602,7 +602,9 @@ pub fn ptx_emit_shared_decl(
     bytes: i64
 ) -> PtxBuf with Mut, Panic, Div, Alloc {
     var out = buf
-    out = ptx_push_str(out, "    .shared .align 4 .b8 shared_array[")
+    // .align 16: covers f16 (2 B) and the f64 tensor-core tile's st.shared.f64 / wmma.load.*.f64,
+    // which need 8-byte alignment (16 ≥ 8, and over-aligning is always safe).
+    out = ptx_push_str(out, "    .shared .align 16 .b8 shared_array[")
     out = ptx_push_i64(out, bytes)
     out = ptx_push_str(out, "];\n")
     out

--- a/tests/gpu/oct_batch_mul_f64_tile.sio
+++ b/tests/gpu/oct_batch_mul_f64_tile.sio
@@ -1,0 +1,9 @@
+// Batched octonion multiply D = L(a)·H on F64 TENSOR CORES (wmma m8n8k4.f64) — array-of-Hyper.
+// Exact f64 at tile throughput: L(a) is built f64 in shared, H loaded col-major from global, and
+// D(8×16) is computed as 2 n-tiles × 2 k-chunks of m8n8k4 f64 mma. Output D is f64 D-layout [k*16+b].
+fn oct_batch_mul_f64(pa: &Hyper<Octonion, f64>, pH: &[Hyper<Octonion, f64>; 16], pout: &! [f64; 256]) with GPU { }
+
+kernel fn step(pa: &Hyper<Octonion, f64>, pH: &[Hyper<Octonion, f64>; 16], pout: &! [f64; 256]) with GPU {
+    oct_batch_mul_f64(pa, pH, pout)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/sed_batch_mul_f64_tile.sio
+++ b/tests/gpu/sed_batch_mul_f64_tile.sio
@@ -1,0 +1,8 @@
+// Batched SEDENION multiply D = L(a)·H on F64 TENSOR CORES (wmma m8n8k4.f64, dim=16) — array-of-Hyper.
+// D(16×16) = 2 m-tiles × 2 n-tiles × 4 k-chunks of m8n8k4 f64 mma. Output D is f64 D-layout [k*16+b].
+fn sed_batch_mul_f64(pa: &Hyper<Sedenion, f64>, pH: &[Hyper<Sedenion, f64>; 16], pout: &! [f64; 256]) with GPU { }
+
+kernel fn step(pa: &Hyper<Sedenion, f64>, pH: &[Hyper<Sedenion, f64>; 16], pout: &! [f64; 256]) with GPU {
+    sed_batch_mul_f64(pa, pH, pout)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

Lowers the batched hypercomplex multiply `D = L(a)·H` to real **f64 tensor cores** (`wmma m8n8k4.f64`, Blackwell/GB10), recovering tile throughput at **full f64 precision** — no more f16 quantization. Every tile in the arc so far was `m16n16k16.f16` (~1e-2..1e-4 error); this one is exact to machine precision.

The nvcc-verified f64 wmma abstraction keeps the same load/mma/store shape as the f16 tile, only the fragments are f64 (1 f64 for A, 1 for B, 2 for the D accumulator) and the shape is `m8n8k4`:

- `L(a)` is built f64 row-major into shared; `H` is loaded col-major **directly from the global batch pointer** (its state-major `[state*dim+comp]` layout already matches a col-major B).
- `D(dim×16)` is tiled as `(dim/8)` m-tiles × 2 n-tiles × `(dim/4)` k-chunks of m8n8k4 f64 mma: **octonion = 4 mma** (1×2×2), **sedenion = 16 mma** (2×2×4). Each (m,n) tile accumulates its k-chunks in the f64 fragment `{%fd10,%fd11}` then stores to `pout`.

New intrinsic `oct_batch_mul_f64` / `sed_batch_mul_f64` (pa, pH, pout).

## Implementation

- **kernel_ir.sio**: `GpuOctBatchF64` opcode.
- **hlir_to_gpu.sio**: name helpers + CALL_DIRECT arm.
- **lower_to_ptx.sio**: `gpu_has_oct_batch_f64` / `gpu_batch_f64_dim`; sm_80 header; `ossm_Lsgn` table; reg-decls force `%fd<14>`; `gpu_emit_oct_batch_f64` + `gpu_emit_f64_mma_block`.
- **ptx.sio**: `shared_array` `.align 4` → `.align 16` — the f64 tile's `st.shared.f64` / `wmma.load.*.shared.f64` need 8-byte alignment (16 ≥ 8; safe for the existing f16 tiles, re-verified).

## Hardware validation (DGX Spark GB10, sm_121a)

ptxas-clean, vs a host f64 reference:

| algebra | f64 tensor cores (m8n8k4) | f16 tile (m16n16k16) |
|---|---|---|
| octonion (4 mma) | **8.9e-16** (0/128) | 2.0e-03 |
| sedenion (16 mma) | **2.6e-15** (0/256) | 4.4e-03 |

Exact to machine precision — the f16-tile error is eliminated **at tile throughput**. Harness `docs/gpu/run_batch_f64_ptx.cu`; PTX artifacts `docs/gpu/{oct,sed}_batch_mul_f64_tile.ptx`. Builds on the arc through #1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)