### PR TITLE
feat(gpu): BPTT on f64 TENSOR CORES — transposed f64 tile + recurrence trained to ~0 loss (GB10)

### DIFF
--- a/docs/gpu/oct_batch_mul_f64_t_tile.ptx
+++ b/docs/gpu/oct_batch_mul_f64_t_tile.ptx
@@ -1,0 +1,87 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[64] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000};
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pB,
+    .param .u64 pout
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 16 .b8 shared_array[2048];
+    .reg .f32 %f<1>;
+    .reg .f64 %fd<14>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pB];
+    ld.param.u64 %rd2, [pout];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BF0;
+    mov.u32 %r5, 0;
+$BFL:
+    shr.u32 %r6, %r5, 3;
+    and.b32 %r7, %r5, 7;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    mov.u32 %r9, shared_array;
+    mad.lo.u32 %r10, %r7, 8, %r6;
+    mul.lo.u32 %r10, %r10, 8;
+    add.u32 %r9, %r9, %r10;
+    st.shared.f64 [%r9], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 64;
+    @%p1 bra $BFL;
+$BF0:
+    bar.sync 0;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 0;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 32;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 0;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 512;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 8;
+    add.s64 %rd7, %rd1, 544;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 8;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 64;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    ret;
+}

--- a/docs/gpu/run_bptt_f64tc_ptx.cu
+++ b/docs/gpu/run_bptt_f64tc_ptx.cu
@@ -1,0 +1,97 @@
+// BPTT on F64 TENSOR CORES: trains the linear recurrence H_t = A⊗H_{t-1} + B·x_t on the DGX Spark
+// GB10 with BOTH matrix-multiplies running on f64 tensor cores (wmma m8n8k4.f64) — the forward
+// L(A)·H via oct_batch_mul_f64 and the backward recurrent gradient L(A)ᵀ·dS via oct_batch_mul_f64_t.
+// The tensor-core products are exact to machine precision, so the gradients are exact and Adam drives
+// the loss to ~0. B·x, the parameter gradients (da, dB), the dY and the layout transposes are host
+// arithmetic (not tensor-core ops). Usage: run_bptt_f64tc <mul.ptx> <mulT.ptx> <dim>.
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+static int DIM,BITS,ND;
+static CUfunction MUL,MULT;
+static CUdeviceptr dA_,dB_,dSm_,dout_;
+// D = L(A)·B (forward tile) or L(A)ᵀ·B (transpose tile), B state-major → D D-layout f64.
+static void tile(CUfunction f,CUdeviceptr A,CUdeviceptr Bsm,CUdeviceptr D){void*a[]={&A,&Bsm,&D};cuLaunchKernel(f,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+
+int main(int c,char**v){
+ const char*pm=c>1?v[1]:"/tmp/mul.ptx";const char*pt=c>2?v[2]:"/tmp/mulT.ptx";DIM=c>3?atoi(v[3]):8;BITS=(DIM==16)?4:3;ND=DIM*16;
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext cx;CK(cuDevicePrimaryCtxRetain(&cx,d));CK(cuCtxSetCurrent(cx));
+ CUmodule mm,mt;CK(cuModuleLoad(&mm,pm));CK(cuModuleLoad(&mt,pt));
+ CK(cuModuleGetFunction(&MUL,mm,"step"));CK(cuModuleGetFunction(&MULT,mt,"step"));
+ CK(cuMemAlloc(&dA_,DIM*8));CK(cuMemAlloc(&dB_,16*DIM*8));CK(cuMemAlloc(&dSm_,16*DIM*8));CK(cuMemAlloc(&dout_,256*8));
+
+ // ── Part 1: transposed tile L(A)ᵀ·B exactness vs host f64 ────────────────────────────────────
+ {
+  double A[16]={0},Bsm[256]={0};
+  for(int i=0;i<DIM;i++)A[i]=0.4*((i%2)?-1:1)+0.05*i;
+  for(int st=0;st<16;st++)for(int j=0;j<DIM;j++)Bsm[st*DIM+j]=0.2*sin(0.4*j+0.6*st);
+  double ref[256]={0};
+  for(int comp=0;comp<DIM;comp++)for(int st=0;st<16;st++){double s=0;
+    for(int j=0;j<DIM;j++)s+=(double)cds(j^comp,comp,BITS)*A[j^comp]*Bsm[st*DIM+j];ref[comp*16+st]=s;}
+  CK(cuMemcpyHtoD(dA_,A,DIM*8));CK(cuMemcpyHtoD(dSm_,Bsm,ND*8));double z[256]={0};CK(cuMemcpyHtoD(dout_,z,256*8));
+  tile(MULT,dA_,dSm_,dout_);double D[256];CK(cuMemcpyDtoH(D,dout_,256*8));
+  double mx=0;int f=0;for(int comp=0;comp<DIM;comp++)for(int st=0;st<16;st++){double e=fabs(D[comp*16+st]-ref[comp*16+st]);if(e>mx)mx=e;if(e>1e-12)f++;}
+  printf("Part 1 — transposed f64 tile L(A)ᵀ·B (%s): mismatch %d/%d maxerr=%.3e\n",(DIM==16)?"sedenion":"octonion",f,DIM*16,mx);
+  if(f){printf("FAIL (part 1)\n");return 1;}printf("  PASS (exact)\n");
+ }
+
+ // ── Part 2: BPTT training (both matmuls on f64 tensor cores) + Adam ──────────────────────────
+ const int T=3,NIT=120; const double lr=0.02,b1=0.9,b2=0.999,eps=1e-8;
+ double h0[256],x[3][16],As[16],Bs[16];
+ for(int st=0;st<16;st++)for(int j=0;j<DIM;j++)h0[st*DIM+j]=0.1*((st%2)?-1:1)+0.02*j;
+ for(int t=0;t<T;t++)for(int st=0;st<16;st++)x[t][st]=0.3*sin(0.7*t+0.4*st);
+ double asc=(DIM==16)?0.5:1.0;
+ for(int i=0;i<DIM;i++){As[i]=asc*(0.22*((i%2)?-1:1)+0.03*i);Bs[i]=asc*(0.12-0.02*i);}
+ // fwd helper (host-side orchestration of the f64 tile + B·x)
+ // teacher targets tgt[t] (D-layout) from the teacher trajectory
+ double tgt[3][256];
+ { double hsm[256];memcpy(hsm,h0,sizeof(double)*256);
+   CK(cuMemcpyHtoD(dA_,As,DIM*8));
+   for(int t=0;t<T;t++){ CK(cuMemcpyHtoD(dSm_,hsm,ND*8)); tile(MUL,dA_,dSm_,dout_);
+     double D[256];CK(cuMemcpyDtoH(D,dout_,256*8));
+     for(int k=0;k<DIM;k++)for(int st=0;st<16;st++)tgt[t][k*16+st]=D[k*16+st]+Bs[k]*x[t][st];
+     double nh[256]={0};for(int k=0;k<DIM;k++)for(int st=0;st<16;st++)nh[st*DIM+k]=tgt[t][k*16+st];memcpy(hsm,nh,sizeof(double)*256);}}
+ double A[16],Bp[16];for(int i=0;i<DIM;i++){A[i]=As[i]+0.08*((i%2)?-1:1);Bp[i]=Bs[i]+0.07*((i%3)?1:-1);}
+ double mA[16]={0},vA[16]={0},mB[16]={0},vB[16]={0};
+ double loss0=0,lossN=0;
+ for(int it=1; it<=NIT; it++){
+  double hsm[4][256],Straj[3][256];memcpy(hsm[0],h0,sizeof(double)*256);
+  CK(cuMemcpyHtoD(dA_,A,DIM*8));
+  double loss=0;
+  for(int t=0;t<T;t++){ CK(cuMemcpyHtoD(dSm_,hsm[t],ND*8)); tile(MUL,dA_,dSm_,dout_);
+    double D[256];CK(cuMemcpyDtoH(D,dout_,256*8));
+    for(int k=0;k<DIM;k++)for(int st=0;st<16;st++){Straj[t][k*16+st]=D[k*16+st]+Bp[k]*x[t][st];
+      double e=Straj[t][k*16+st]-tgt[t][k*16+st];loss+=e*e;}
+    for(int k=0;k<DIM;k++)for(int st=0;st<16;st++)hsm[t+1][st*DIM+k]=Straj[t][k*16+st];}
+  if(it==1)loss0=loss; lossN=loss;
+  // backward: dHnext(D-layout)=0; dA,dB accumulate
+  double dHnext[256]={0},dAacc[16]={0},dBacc[16]={0};
+  for(int t=T-1;t>=0;t--){
+   double dHt[256];for(int k=0;k<DIM;k++)for(int st=0;st<16;st++)dHt[k*16+st]=2.0*(Straj[t][k*16+st]-tgt[t][k*16+st])+dHnext[k*16+st];
+   // dB += Σ dHt·x
+   for(int k=0;k<DIM;k++){double s=0;for(int st=0;st<16;st++)s+=dHt[k*16+st]*x[t][st];dBacc[k]+=s;}
+   // dA += da(H_{t}, dHt): H_{t}=hsm[t] state-major; dA[q]=Σ σ(q,k⊕q) hsm[t][b*dim+(k⊕q)] dHt[k,b]
+   for(int q=0;q<DIM;q++){double s=0;for(int k=0;k<DIM;k++)for(int st=0;st<16;st++){int m=k^q;s+=(double)cds(q,m,BITS)*hsm[t][st*DIM+m]*dHt[k*16+st];}dAacc[q]+=s;}
+   // dHprev = L(A)ᵀ·dHt on the f64 tensor-core transpose tile (dHt provided state-major)
+   double dHt_sm[256]={0};for(int k=0;k<DIM;k++)for(int st=0;st<16;st++)dHt_sm[st*DIM+k]=dHt[k*16+st];
+   CK(cuMemcpyHtoD(dSm_,dHt_sm,ND*8)); tile(MULT,dA_,dSm_,dout_); CK(cuMemcpyDtoH(dHnext,dout_,256*8));
+  }
+  // Adam
+  double bc1=1.0-pow(b1,it),bc2=1.0-pow(b2,it);
+  for(int p=0;p<DIM;p++){
+   mA[p]=b1*mA[p]+(1-b1)*dAacc[p];vA[p]=b2*vA[p]+(1-b2)*dAacc[p]*dAacc[p];A[p]-=lr*(mA[p]/bc1)/(sqrt(vA[p]/bc2)+eps);
+   mB[p]=b1*mB[p]+(1-b1)*dBacc[p];vB[p]=b2*vB[p]+(1-b2)*dBacc[p]*dBacc[p];Bp[p]-=lr*(mB[p]/bc1)/(sqrt(vB[p]/bc2)+eps);}
+  if(it==1||it==NIT||it%30==0)printf("  iter %3d  loss %.6e\n",it,loss);
+ }
+ printf("Part 2 — BPTT on f64 tensor cores (fwd L(A)·H + bwd L(A)ᵀ·dS, both m8n8k4.f64) + Adam:\n");
+ printf("  loss %.6e → %.6e  (%.1f%% reduction)\n",loss0,lossN,100.0*(loss0-lossN)/loss0);
+ if(lossN<1e-4*loss0){printf("PASS: trained the recurrence with both matmuls on exact f64 tensor cores → loss ~0 on GB10\n");return 0;}
+ printf("FAIL: loss did not fall enough\n");return 1;
+}

--- a/docs/gpu/sed_batch_mul_f64_t_tile.ptx
+++ b/docs/gpu/sed_batch_mul_f64_t_tile.ptx
@@ -1,0 +1,167 @@
+.version 8.0
+.target sm_80
+.address_size 64
+
+    .global .align 4 .b32 ossm_Lsgn[256] = {0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0fBF800000, 0f3F800000, 0f3F800000, 0fBF800000, 0fBF800000, 0f3F800000, 0f3F800000};
+
+.visible .entry step(
+    .param .u64 pa,
+    .param .u64 pB,
+    .param .u64 pout
+)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<8>;
+    .shared .align 16 .b8 shared_array[2048];
+    .reg .f32 %f<1>;
+    .reg .f64 %fd<14>;
+    .reg .b32 %wa<8>;
+    .reg .b32 %wb<8>;
+    .reg .f32 %wd<8>;
+
+    ld.param.u64 %rd0, [pa];
+    ld.param.u64 %rd1, [pB];
+    ld.param.u64 %rd2, [pout];
+LBB0_0:
+    mov.u32 %r1, %tid.x;
+    setp.ne.u32 %p1, %r1, 0;
+    @%p1 bra $BF0;
+    mov.u32 %r5, 0;
+$BFL:
+    shr.u32 %r6, %r5, 4;
+    and.b32 %r7, %r5, 15;
+    xor.b32 %r8, %r6, %r7;
+    mul.wide.u32 %rd7, %r8, 8;
+    add.s64 %rd7, %rd0, %rd7;
+    ld.global.f64 %fd0, [%rd7];
+    mul.wide.u32 %rd7, %r5, 4;
+    mov.u64 %rd6, ossm_Lsgn;
+    add.s64 %rd7, %rd6, %rd7;
+    ld.global.f32 %f0, [%rd7];
+    cvt.f64.f32 %fd1, %f0;
+    mul.f64 %fd0, %fd0, %fd1;
+    mov.u32 %r9, shared_array;
+    mad.lo.u32 %r10, %r7, 16, %r6;
+    mul.lo.u32 %r10, %r10, 8;
+    add.u32 %r9, %r9, %r10;
+    st.shared.f64 [%r9], %fd0;
+    add.u32 %r5, %r5, 1;
+    setp.lt.u32 %p1, %r5, 256;
+    @%p1 bra $BFL;
+$BF0:
+    bar.sync 0;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 0;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 32;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 64;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 64;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 96;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 96;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 0;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 0;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1024;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 32;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1056;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 64;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1088;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 96;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1120;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 64;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1024;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 0;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1056;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 32;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1088;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 64;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1120;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 96;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 1024;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    mov.f64 %fd10, 0d0000000000000000;
+    mov.f64 %fd11, 0d0000000000000000;
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1024;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1024;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1056;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1056;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1088;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1088;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    mov.u32 %r1, shared_array;
+    add.u32 %r1, %r1, 1120;
+    wmma.load.a.sync.aligned.row.m8n8k4.shared.f64 {%fd12}, [%r1], 16;
+    add.s64 %rd7, %rd1, 1120;
+    wmma.load.b.sync.aligned.col.m8n8k4.f64 {%fd13}, [%rd7], 16;
+    wmma.mma.sync.aligned.row.col.m8n8k4.f64.f64.f64.f64.rn {%fd10,%fd11}, {%fd12}, {%fd13}, {%fd10,%fd11};
+    add.s64 %rd7, %rd2, 1088;
+    wmma.store.d.sync.aligned.row.m8n8k4.f64 [%rd7], {%fd10,%fd11}, 16;
+    ret;
+}

--- a/self-hosted/gpu/hlir_to_gpu.sio
+++ b/self-hosted/gpu/hlir_to_gpu.sio
@@ -1833,13 +1833,17 @@ fn hlir_instr_to_gpu_ops(kernel: GpuKernelIr, instr: HlirInstr) -> GpuKernelIr w
             bwd.src_reg = instr.call_args[3]
             bwd.shared_addr = instr.call_args[4]
             k = gpu_kernel_append_op(k, bwd)
-        } else if hlir_name_is_oct_batch_mul_f64(cn) || hlir_name_is_sed_batch_mul_f64(cn) {
+        } else if hlir_name_is_oct_batch_mul_f64(cn) || hlir_name_is_sed_batch_mul_f64(cn) || hlir_name_is_oct_batch_mul_f64_t(cn) || hlir_name_is_sed_batch_mul_f64_t(cn) {
             // Batched hypercomplex multiply on f64 TENSOR CORES (wmma m8n8k4.f64). call_args =
             // [pa, pH, pout]. L(a) f64 in shared + m8n8k4 f64 tiles → one GpuOctBatchF64. 2048 bytes.
+            // The "_t" variants build L(a)ᵀ (byte_offset=1) → L(a)ᵀ·B, the BPTT backward L(A)ᵀ·dS.
+            let is_t = hlir_name_is_oct_batch_mul_f64_t(cn) || hlir_name_is_sed_batch_mul_f64_t(cn)
+            let is_sed = hlir_name_is_sed_batch_mul_f64(cn) || hlir_name_is_sed_batch_mul_f64_t(cn)
             if k.shared_bytes < 2048 { k.shared_bytes = 2048 }
             var bf = gpu_op_new()
             bf.opcode = GpuOpcode::GpuOctBatchF64
-            bf.rhs_imm = if hlir_name_is_sed_batch_mul_f64(cn) { 16 } else { 8 }
+            bf.rhs_imm = if is_sed { 16 } else { 8 }
+            bf.byte_offset = if is_t { 1 } else { 0 }
             bf.lhs_reg = instr.call_args[0]
             bf.rhs_reg = instr.call_args[1]
             bf.addr_reg = instr.call_args[2]
@@ -2070,6 +2074,26 @@ fn hlir_name_is_sed_batch_mul_f64(n: HlirName) -> bool {
     n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 109 as i8 && n.buf[11] == 117 as i8 &&
     n.buf[12] == 108 as i8 && n.buf[13] == 95 as i8 && n.buf[14] == 102 as i8 && n.buf[15] == 54 as i8 &&
     n.buf[16] == 52 as i8
+}
+
+// "oct_batch_mul_f64_t" (19 chars) — TRANSPOSED f64 tensor-core tile L(a)ᵀ·B (the BPTT backward).
+fn hlir_name_is_oct_batch_mul_f64_t(n: HlirName) -> bool {
+    if n.len != 19 { return false }
+    n.buf[0] == 111 as i8 && n.buf[1] == 99 as i8 && n.buf[2] == 116 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
+    n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 109 as i8 && n.buf[11] == 117 as i8 &&
+    n.buf[12] == 108 as i8 && n.buf[13] == 95 as i8 && n.buf[14] == 102 as i8 && n.buf[15] == 54 as i8 &&
+    n.buf[16] == 52 as i8 && n.buf[17] == 95 as i8 && n.buf[18] == 116 as i8
+}
+
+// "sed_batch_mul_f64_t" (19 chars) — TRANSPOSED f64 tensor-core tile (sedenion, dim=16, bits=4).
+fn hlir_name_is_sed_batch_mul_f64_t(n: HlirName) -> bool {
+    if n.len != 19 { return false }
+    n.buf[0] == 115 as i8 && n.buf[1] == 101 as i8 && n.buf[2] == 100 as i8 && n.buf[3] == 95 as i8 &&
+    n.buf[4] == 98 as i8 && n.buf[5] == 97 as i8 && n.buf[6] == 116 as i8 && n.buf[7] == 99 as i8 &&
+    n.buf[8] == 104 as i8 && n.buf[9] == 95 as i8 && n.buf[10] == 109 as i8 && n.buf[11] == 117 as i8 &&
+    n.buf[12] == 108 as i8 && n.buf[13] == 95 as i8 && n.buf[14] == 102 as i8 && n.buf[15] == 54 as i8 &&
+    n.buf[16] == 52 as i8 && n.buf[17] == 95 as i8 && n.buf[18] == 116 as i8
 }
 
 // "ossm_oct_step_f64" (17 chars) — full-f64 O-SSM step S = A⊗H + B·x (octonion, dim=8, bits=3).

--- a/self-hosted/gpu/lower_to_ptx.sio
+++ b/self-hosted/gpu/lower_to_ptx.sio
@@ -1225,9 +1225,10 @@ fn gpu_batch_f64_dim(kernel: GpuKernelIr) -> i64 {
 // (its state-major layout [state*dim+comp] already matches a col-major B). D(dim×16) is computed as
 // (dim/8) m-tiles × 2 n-tiles × (dim/4) k-chunks of m8n8k4; each (m,n) tile accumulates its k-chunks in
 // the f64 fragment {%fd10,%fd11} then stores to pout (D-layout [comp*16+state]).
-fn gpu_emit_oct_batch_f64(paR: string, pHR: string, poutR: string, dim: i64, bits: i64) -> string with Mut, Panic, Div, Alloc {
+fn gpu_emit_oct_batch_f64(paR: string, pHR: string, poutR: string, dim: i64, bits: i64, transpose: bool) -> string with Mut, Panic, Div, Alloc {
     let sh = if dim == 16 { 4 } else { 3 }
-    // thread 0: build L(a) f64 row-major into sL[shared_array]  (sL[k*dim+j] = σ(k⊕j,j)·a[k⊕j])
+    // thread 0: build L(a) f64 into sL[shared_array]. Normal: sL[k*dim+j] = σ(k⊕j,j)·a[k⊕j] (row-major).
+    // Transpose: sL[j*dim+k] = same value → L(a)ᵀ, so the tile computes L(a)ᵀ·B (the BPTT backward).
     var t = "    mov.u32 %r1, %tid.x;\n    setp.ne.u32 %p1, %r1, 0;\n    @%p1 bra $BF0;\n"
     t = str_concat(t, "    mov.u32 %r5, 0;\n$BFL:\n")
     t = str_concat(str_concat(t, "    shr.u32 %r6, %r5, "), i64_to_string(sh))
@@ -1237,7 +1238,15 @@ fn gpu_emit_oct_batch_f64(paR: string, pHR: string, poutR: string, dim: i64, bit
     t = str_concat(t, ", %rd7;\n    ld.global.f64 %fd0, [%rd7];\n")
     t = str_concat(t, "    mul.wide.u32 %rd7, %r5, 4;\n    mov.u64 %rd6, ossm_Lsgn;\n    add.s64 %rd7, %rd6, %rd7;\n")
     t = str_concat(t, "    ld.global.f32 %f0, [%rd7];\n    cvt.f64.f32 %fd1, %f0;\n    mul.f64 %fd0, %fd0, %fd1;\n")
-    t = str_concat(t, "    mov.u32 %r9, shared_array;\n    mul.lo.u32 %r10, %r5, 8;\n    add.u32 %r9, %r9, %r10;\n")
+    t = str_concat(t, "    mov.u32 %r9, shared_array;\n")
+    if transpose {
+        // dest = (j*dim + k) = %r7*dim + %r6
+        t = str_concat(str_concat(t, "    mad.lo.u32 %r10, %r7, "), i64_to_string(dim))
+        t = str_concat(t, ", %r6;\n    mul.lo.u32 %r10, %r10, 8;\n")
+    } else {
+        t = str_concat(t, "    mul.lo.u32 %r10, %r5, 8;\n")
+    }
+    t = str_concat(t, "    add.u32 %r9, %r9, %r10;\n")
     t = str_concat(t, "    st.shared.f64 [%r9], %fd0;\n")
     t = str_concat(str_concat(t, "    add.u32 %r5, %r5, 1;\n    setp.lt.u32 %p1, %r5, "), i64_to_string(dim * dim))
     t = str_concat(t, ";\n    @%p1 bra $BFL;\n$BF0:\n    bar.sync 0;\n")
@@ -1767,9 +1776,11 @@ fn gpu_lower_op(buf: PtxBuf, op: GpuOp, kernel: GpuKernelIr) -> PtxBuf with Mut,
 
         GpuOpcode::GpuOctBatchF64 => {
             // Batched hypercomplex multiply on f64 tensor cores (m8n8k4.f64). pa=lhs, pH=rhs, pout=addr.
+            // byte_offset==1 → transpose (L(a)ᵀ·B, the BPTT backward L(A)ᵀ·dS).
             let tdim = if op.rhs_imm == 16 { 16 } else { 8 }
             let tbits = if tdim == 16 { 4 } else { 3 }
-            ptx_push_str(buf, gpu_emit_oct_batch_f64(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), tdim, tbits))
+            let ttr = op.byte_offset == 1
+            ptx_push_str(buf, gpu_emit_oct_batch_f64(gpu_reg_u64(op.lhs_reg), gpu_reg_u64(op.rhs_reg), gpu_reg_u64(op.addr_reg), tdim, tbits, ttr))
         }
 
         GpuOpcode::GpuWmmaTile => {

--- a/tests/gpu/oct_batch_mul_f64_t_tile.sio
+++ b/tests/gpu/oct_batch_mul_f64_t_tile.sio
@@ -1,0 +1,9 @@
+// TRANSPOSED batched octonion multiply D = L(a)ᵀ·B on f64 TENSOR CORES (m8n8k4.f64) — array-of-Hyper.
+// Same f64 tile as oct_batch_mul_f64 but builds L(a)ᵀ, so it computes L(a)ᵀ·B — the BPTT backward
+// recurrent gradient dHprev = L(A)ᵀ·dS (B = dS provided state-major). Output D-layout [comp*16+state].
+fn oct_batch_mul_f64_t(pa: &Hyper<Octonion, f64>, pB: &[Hyper<Octonion, f64>; 16], pout: &! [f64; 256]) with GPU { }
+
+kernel fn step(pa: &Hyper<Octonion, f64>, pB: &[Hyper<Octonion, f64>; 16], pout: &! [f64; 256]) with GPU {
+    oct_batch_mul_f64_t(pa, pB, pout)
+}
+fn main() -> i32 with IO { 0 }

--- a/tests/gpu/sed_batch_mul_f64_t_tile.sio
+++ b/tests/gpu/sed_batch_mul_f64_t_tile.sio
@@ -1,0 +1,8 @@
+// TRANSPOSED batched SEDENION multiply D = L(a)ᵀ·B on f64 TENSOR CORES (m8n8k4.f64, dim=16).
+// Builds L(a)ᵀ → the BPTT backward L(A)ᵀ·dS. Output D-layout [comp*16+state].
+fn sed_batch_mul_f64_t(pa: &Hyper<Sedenion, f64>, pB: &[Hyper<Sedenion, f64>; 16], pout: &! [f64; 256]) with GPU { }
+
+kernel fn step(pa: &Hyper<Sedenion, f64>, pB: &[Hyper<Sedenion, f64>; 16], pout: &! [f64; 256]) with GPU {
+    sed_batch_mul_f64_t(pa, pB, pout)
+}
+fn main() -> i32 with IO { 0 }


### PR DESCRIPTION
## What

Closes "BPTT on f64 tensor cores": the linear recurrence `H_t = A⊗H_{t-1} + B·x_t` is trained with **both matrix-multiplies running on exact f64 tensor cores** (`wmma m8n8k4.f64`) — the forward `L(A)·H` via `oct_batch_mul_f64` (#1186) and the backward recurrent gradient `L(A)ᵀ·dS` via the new **transposed** tile.

### New intrinsic — the transposed f64 tensor-core tile

```
oct_batch_mul_f64_t / sed_batch_mul_f64_t (pa, pB, pout):
  the SAME f64 m8n8k4 tile as oct_batch_mul_f64, but builds L(a)ᵀ instead of L(a)
  → computes L(a)ᵀ·B. With B state-major it gives the BPTT backward dHprev = L(A)ᵀ·dS (D-layout).
```

A one-line codegen delta: `gpu_emit_oct_batch_f64` gains a `transpose` flag (the L-build stores at `sL[j*dim+k]` rather than `[k*dim+j]`), carried in the op's `byte_offset`.

The tensor-core products are exact to machine precision, so the gradients are exact and Adam drives the loss to ~0. `B·x`, the parameter gradients (`da`, `dB`), `dY` and the layout transposes are host arithmetic (not tensor-core ops) — the two matmuls are the tensor-core work, both f64.

## Hardware validation (DGX Spark GB10, sm_121a)

ptxas-clean:

- **transposed tile `L(A)ᵀ·B` vs host f64**: octonion 0/128 maxerr **0.0** (bit-exact), sedenion 0/256 bit-exact.
- **BPTT training** (both matmuls on f64 tensor cores) + Adam, 120 iters:

| algebra | loss |
|---|---|
| octonion | 8.1e-01 → **1.5e-06** (100%) |
| sedenion | 5.0e+00 → **6.8e-07** (100%) |

Harness `docs/gpu/run_bptt_f64tc_ptx.cu`; PTX artifacts `docs/gpu/{oct,sed}_batch_mul_f64_t_tile.ptx`. Builds on the arc through #1186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)