### PR TITLE
feat(clinical): midazolam CYP3A DDI E2E (Olkkola ~15× AUCR)

### DIFF
--- a/docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md
+++ b/docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md
@@ -1,0 +1,35 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.clinical-midazolam-ddi-e2e-vertical-2026-07-19
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.clinical-midazolam-ddi-e2e-vertical-2026-07-19
+-->
+
+# Midazolam CYP3A DDI E2E — 2026-07-19
+
+## Scope
+
+| | |
+|---|---|
+| Branch | `feat/clinical-midazolam-ddi-e2e` |
+| Module | `stdlib/darwin_pbpk/validation/midazolam_ddi.sio` (6/6 PASS) |
+| Driver | `tests/stdlib/clinical/test_midazolam_ddi_e2e.sio` |
+| Gate | `bash scripts/clinical_midazolam_ddi_e2e_gate.sh` → `CLINICAL_MIDAZOLAM_DDI_E2E_GATE_OK` |
+| Engine | **lean_single** multi-module |
+
+## Claim
+
+Mechanistic CYP3A well-stirred first-pass + competitive inhibition reproduces:
+
+- oral **F ∈ (0.30, 0.45)** (Heizmann 1984)
+- ketoconazole oral **AUCR ∈ (12, 18)** ≈15× (Olkkola 1994)
+- gut contribution required for full AUCR (Thummel 1996)
+- PGx ordering CYP3A5 expresser > non-expresser; CYP3A4\*22 slower
+
+Complements vancomycin PK/TDM validation with a **DDI mechanism** vertical.
+
+## claims_not_made
+
+full C(t) digitization · bedside DDI product · Madaros multi-module · NONMEM FOCE · numpy/sklearn

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1015
-- Repo-backed topics: 865
+- Total governed topics: 1016
+- Repo-backed topics: 866
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 615
+- Authority count `repo_only`: 616
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 634 topics
+- A2: 635 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -79,6 +79,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.checker-guard-wiring-dispatch-2026-07-11 | repo_only | docs/audit/CHECKER_GUARD_WIRING_DISPATCH_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.chi5-real-axiom-audit-2026-05-30 | repo_only | docs/audit/CHI5_REAL_AXIOM_AUDIT_2026-05-30.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-drug-switch-vanco-validation-2026-07-19 | repo_only | docs/audit/CLINICAL_DRUG_SWITCH_VANCO_VALIDATION_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.clinical-midazolam-ddi-e2e-vertical-2026-07-19 | repo_only | docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.clinical-vanco-tdm-e2e-vertical-2026-07-19 | repo_only | docs/audit/CLINICAL_VANCO_TDM_E2E_VERTICAL_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.data-io-lane-compiler-blocker-2026-07-13 | repo_only | docs/audit/DATA_IO_LANE_COMPILER_BLOCKER_2026-07-13.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.data-io-trilha-b-builtin-bufptr-dispatch-2026-07-14 | repo_only | docs/audit/DATA_IO_TRILHA_B_BUILTIN_BUFPTR_DISPATCH_2026-07-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -1281,6 +1281,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.clinical-midazolam-ddi-e2e-vertical-2026-07-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.clinical-vanco-tdm-e2e-vertical-2026-07-19",
       "collection": "repo",
       "repo_doc_path": "docs/audit/CLINICAL_VANCO_TDM_E2E_VERTICAL_2026-07-19.md",

--- a/scripts/clinical_midazolam_ddi_e2e_gate.sh
+++ b/scripts/clinical_midazolam_ddi_e2e_gate.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scripts/clinical_midazolam_ddi_e2e_gate.sh
+# Midazolam CYP3A DDI E2E under lean_single.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+export SOUNIO_SOUC_ENGINE="${SOUNIO_SOUC_ENGINE:-lean_single}"
+SOUC="${SOUC:-$ROOT/bin/souc}"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+echo "== clinical_midazolam_ddi_e2e_gate: engine=$SOUNIO_SOUC_ENGINE =="
+
+MOD="stdlib/darwin_pbpk/validation/midazolam_ddi.sio"
+echo "== module $MOD =="
+if ! "$SOUC" compile "$MOD" -o "$OUT/mod.elf" >"$OUT/modc.log" 2>&1; then
+  echo "FAIL: module compile"; tail -25 "$OUT/modc.log" || true; fail=1
+else
+  chmod +x "$OUT/mod.elf"
+  if ! "$OUT/mod.elf" >"$OUT/mod.log" 2>&1 || ! grep -q "ALL 6 TESTS PASSED" "$OUT/mod.log"; then
+    echo "FAIL: module selftest"; cat "$OUT/mod.log" || true; fail=1
+  else
+    echo "OK module ALL 6 TESTS PASSED"
+  fi
+fi
+
+SRC="tests/stdlib/clinical/test_midazolam_ddi_e2e.sio"
+echo "== e2e $SRC =="
+if ! "$SOUC" compile "$SRC" -o "$OUT/e2e.elf" >"$OUT/e2ec.log" 2>&1; then
+  echo "FAIL: e2e compile"; tail -30 "$OUT/e2ec.log" || true; fail=1
+else
+  chmod +x "$OUT/e2e.elf"
+  if ! "$OUT/e2e.elf" >"$OUT/e2e.log" 2>&1; then
+    echo "FAIL: e2e run"; cat "$OUT/e2e.log" || true; fail=1
+  elif ! grep -q "CLINICAL_MIDAZOLAM_DDI_E2E_OK" "$OUT/e2e.log"; then
+    echo "FAIL: missing sentinel"; cat "$OUT/e2e.log" || true; fail=1
+  else
+    grep '^MDZ_DDI_E2E' "$OUT/e2e.log" || true
+    # hard literature bands on printed tokens
+    if ! grep -E 'aucr_keto=1[2-7]\.' "$OUT/e2e.log"; then
+      # allow 14.x etc via broader check
+      aucr=$(grep 'aucr_keto=' "$OUT/e2e.log" | head -1 | tr ' ' '\n' | grep '^aucr_keto=' | cut -d= -f2)
+      python3 - <<PY
+aucr=float("$aucr")
+import sys
+sys.exit(0 if 12.0 < aucr < 18.0 else 1)
+PY
+      if [[ $? -ne 0 ]]; then echo "FAIL: aucr band"; fail=1; fi
+    fi
+  fi
+fi
+
+mkdir -p "$ROOT/artifacts/clinical"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+STATUS=fail
+[[ $fail -eq 0 ]] && STATUS=pass
+F=$(grep 'f_oral=' "$OUT/e2e.log" 2>/dev/null | head -1 | tr ' ' '\n' | grep '^f_oral=' | cut -d= -f2- || echo null)
+AUCR=$(grep 'aucr_keto=' "$OUT/e2e.log" 2>/dev/null | head -1 | tr ' ' '\n' | grep '^aucr_keto=' | cut -d= -f2- || echo null)
+
+cat >"$ROOT/artifacts/clinical/midazolam_ddi_e2e_receipt.v1.json" <<EOF
+{
+  "schema": "clinical_midazolam_ddi_e2e_receipt.v1",
+  "status": "$STATUS",
+  "engine": "$SOUNIO_SOUC_ENGINE",
+  "commit": "$COMMIT",
+  "source": "$SRC",
+  "module_selftest": "$MOD",
+  "sounio": { "f_oral": $F, "aucr_keto": $AUCR },
+  "literature": [
+    "Heizmann 1984 Br J Anaesth (oral F)",
+    "Olkkola 1994 Clin Pharmacol Ther (keto AUCR ~15x)",
+    "Thummel 1996 Clin Pharmacol Ther (gut first-pass)",
+    "Shih 2013 / Kuehl 2001 (CYP3A5)",
+    "Wang 2011 (CYP3A4*22)"
+  ],
+  "claims": [
+    "oral_f_in_heizmann_band",
+    "ketoconazole_aucr_olkkola_band",
+    "aucr_monotonic_in_i_over_ki",
+    "gut_wall_required_for_full_aucr",
+    "cyp3a5_expresser_faster_clh",
+    "cyp3a4_22_slower_clh"
+  ],
+  "claims_not_made": [
+    "pbpk28_ct_digitization",
+    "bedside_ddi_product",
+    "madaros_multimodule",
+    "nonmem_foce",
+    "numpy_sklearn"
+  ]
+}
+EOF
+echo "receipt: $ROOT/artifacts/clinical/midazolam_ddi_e2e_receipt.v1.json"
+
+if [[ $fail -eq 0 ]]; then
+  echo "CLINICAL_MIDAZOLAM_DDI_E2E_GATE_OK"
+  exit 0
+fi
+exit 1

--- a/tests/stdlib/clinical/test_midazolam_ddi_e2e.sio
+++ b/tests/stdlib/clinical/test_midazolam_ddi_e2e.sio
@@ -1,0 +1,101 @@
+//@ run-pass
+// Midazolam CYP3A DDI E2E (lean_single multi-module).
+//
+// Structural claim: well-stirred gut+hepatic first-pass + competitive inhibition
+// reproduces clinical literature endpoints without hand-waved AUCR factors.
+//
+// Literature anchors:
+//   Heizmann 1984  — oral F ~ 0.3–0.44
+//   Olkkola 1994   — oral midazolam + ketoconazole AUCR ~15× (band 12–18)
+//   Thummel 1996   — gut-wall CYP3A required for full AUCR magnitude
+//   Shih 2013 / Kuehl 2001 — CYP3A5 expresser clears faster
+//   Wang 2011      — CYP3A4*22 clears slower
+//
+// Engine: SOUNIO_SOUC_ENGINE=lean_single
+// Gate:   bash scripts/clinical_midazolam_ddi_e2e_gate.sh
+//
+// claims_not_made: full PBPK28 C(t) vs digital figure; bedside DDI product;
+//                  Madaros multi-module native path; NONMEM FOCE
+
+use darwin_pbpk::drugs::midazolam::{
+    midazolam_cyp3a_substrate,
+    ketoconazole_inhibitor,
+    midazolam_pbpk_params_pgx
+}
+use darwin_pbpk::ddi::cyp3a_competitive::{
+    cyp3a_factor_of,
+    cyp3a_aucr,
+    cyp3a_f_oral,
+    cyp3a_clh,
+    cyp3a_fg,
+    cyp3a_fh,
+    cyp3a_inhibition_factor
+}
+
+fn fail(code: i32) -> i32 with IO {
+    print("FAIL code ")
+    print(code)
+    print("\n")
+    return code
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let sub = midazolam_cyp3a_substrate()
+    let keto = ketoconazole_inhibitor()
+    let factor = cyp3a_factor_of(keto)
+
+    // T1: oral F (Heizmann 1984)
+    let f_solo = cyp3a_f_oral(sub, 1.0)
+    if f_solo <= 0.30 || f_solo >= 0.45 { return fail(1) }
+
+    // T2: ketoconazole AUCR ~15× (Olkkola 1994)
+    let aucr = cyp3a_aucr(sub, factor)
+    if aucr <= 12.0 || aucr >= 18.0 { return fail(2) }
+
+    // T3: monotonicity vs I/Ki
+    let aucr_weak = cyp3a_aucr(sub, cyp3a_inhibition_factor(0.008, 0.008))
+    let aucr_mid = cyp3a_aucr(sub, cyp3a_inhibition_factor(0.032, 0.008))
+    if !(aucr > aucr_mid && aucr_mid > aucr_weak && aucr_weak > 1.0) { return fail(3) }
+
+    // T4: gut essential (Thummel 1996)
+    let f0 = cyp3a_f_oral(sub, 1.0)
+    let clh0 = cyp3a_clh(sub, 1.0)
+    let f_hep_only = sub.fa * cyp3a_fg(sub, 1.0) * cyp3a_fh(sub, factor)
+    let aucr_hep_only = (f_hep_only / f0) * (clh0 / cyp3a_clh(sub, factor))
+    if !(aucr > aucr_hep_only && aucr_hep_only > 1.0) { return fail(4) }
+
+    // T5: CYP3A5 expresser faster
+    let p_exp = midazolam_pbpk_params_pgx(1, 0)
+    let p_non = midazolam_pbpk_params_pgx(0, 0)
+    let clh_exp = p_exp.cl_hepatic * p_exp.fu_plasma
+    let clh_non = p_non.cl_hepatic * p_non.fu_plasma
+    if clh_exp <= clh_non { return fail(5) }
+
+    // T6: CYP3A4*22 slower
+    let p_22 = midazolam_pbpk_params_pgx(0, 1)
+    let clh_22 = p_22.cl_hepatic * p_22.fu_plasma
+    if clh_22 >= clh_non { return fail(6) }
+
+    print("MDZ_DDI_E2E f_oral=")
+    print(f_solo)
+    print(" aucr_keto=")
+    print(aucr)
+    print(" aucr_weak=")
+    print(aucr_weak)
+    print(" aucr_mid=")
+    print(aucr_mid)
+    print(" aucr_hep_only=")
+    print(aucr_hep_only)
+    print("\n")
+
+    print("MDZ_DDI_E2E clh_expr=")
+    print(clh_exp)
+    print(" clh_non=")
+    print(clh_non)
+    print(" clh_22=")
+    print(clh_22)
+    print("\n")
+
+    print("CLINICAL_MIDAZOLAM_DDI_E2E_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Summary

Midazolam CYP3A **DDI mechanism** E2E — complements vancomycin PK/TDM validation.

| Check | Literature | Band / claim |
|---|---|---|
| oral F | Heizmann 1984 | (0.30, 0.45) |
| AUCR + keto | Olkkola 1994 | (12, 18) ≈15× |
| gut first-pass | Thummel 1996 | full AUCR > hepatic-only |
| CYP3A5 expresser | Shih/Kuehl | CL_h higher |
| CYP3A4*22 | Wang 2011 | CL_h lower |

## Gate

```bash
export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
bash scripts/clinical_midazolam_ddi_e2e_gate.sh
# → CLINICAL_MIDAZOLAM_DDI_E2E_GATE_OK
```

Live module values: F≈0.384, AUCR≈14.99

## claims_not_made
C(t) digitization · bedside DDI · Madaros multi-module · NONMEM · numpy/sklearn

Audit: `docs/audit/CLINICAL_MIDAZOLAM_DDI_E2E_VERTICAL_2026-07-19.md`