### PR TITLE
feat(bench): associator weight gradients da, db — the associator VJP is complete (GB10)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1020
-- Repo-backed topics: 870
+- Total governed topics: 1022
+- Repo-backed topics: 872
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 620
+- Authority count `repo_only`: 622
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 639 topics
+- A2: 641 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -353,6 +353,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.glossary | repo_only | docs/GLOSSARY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.data-access-credentials | repo_only | docs/governance/data_access_credentials.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.docs-conventions | repo_only | docs/governance/DOCS_CONVENTIONS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.gpu.assoc-vjp-complete | repo_only | docs/gpu/ASSOC_VJP_COMPLETE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.batched-hyper-syntax | repo_only | docs/gpu/BATCHED_HYPER_SYNTAX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hyper-matvec-design | repo_only | docs/gpu/HYPER_MATVEC_DESIGN.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hypercomplex-ssm-novelty | repo_only | docs/gpu/HYPERCOMPLEX_SSM_NOVELTY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7604,6 +7604,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.gpu.assoc-vjp-complete",
+      "collection": "repo",
+      "repo_doc_path": "docs/gpu/ASSOC_VJP_COMPLETE.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.gpu.batched-hyper-syntax",
       "collection": "repo",
       "repo_doc_path": "docs/gpu/BATCHED_HYPER_SYNTAX.md",

--- a/docs/gpu/ASSOC_VJP_COMPLETE.md
+++ b/docs/gpu/ASSOC_VJP_COMPLETE.md
@@ -1,0 +1,41 @@
+<!-- docs:meta
+topic_id: repo.docs.gpu.assoc-vjp-complete
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.gpu.assoc-vjp-complete
+-->
+
+# The associator VJP is complete — dH (kernel) + da, db (decomposition)
+
+The associator `[a,b,H] = (a⊗b)⊗H − a⊗(b⊗H)` is now **fully differentiable** on tensor cores. Its
+reverse-mode VJP has three gradients, all validated on the DGX Spark GB10:
+
+## dH — gradient w.r.t. the batched input
+A dedicated kernel (`oct_assoc_bwd_dh` / `sed_assoc_bwd_dh`, merged): `dH = L(a⊗b)ᵀ·dD − L(b)ᵀ·(L(a)ᵀ·dD)`,
+three transposed m16n16k16 tiles + subtract, mirroring the forward associator. GB10: octonion 0/128
+(maxerr 1e-4), sedenion 0/256 (3e-4).
+
+## da, db — gradients w.r.t. the weights a, b
+These **decompose entirely into already-merged tensor-core kernels** (`ossm_oct_bwd` — which yields both
+`L(a)ᵀ·dD` and the f64 `da_accum`; and `oct_batch_mul` — which yields `q = L(b)·H`) plus host glue (the
+`a⊗b` product VJP, which is a single-octonion contraction):
+
+```
+dP        = da_accum(H, dD)              = ossm_oct_bwd(a, H, dD).dA          (exact f64)
+dq        = −L(a)ᵀ·dD                    = −ossm_oct_bwd(a, H, dD).dHprev
+q         = L(b)·H                       = oct_batch_mul(b, H)
+da_from_r = −da_accum(q, dD)             = −ossm_oct_bwd(·, qᵀ, dD).dA
+db_from_q =  da_accum(H, dq)             =  ossm_oct_bwd(·, H, dq).dA
+da_from_P[i] = Σ_j σ(i,j)·b[j]·dP[i⊕j]   ;   db_from_P[j] = Σ_i σ(i,j)·a[i]·dP[i⊕j]     (host)
+da = da_from_P + da_from_r   ;   db = db_from_P + db_from_q
+```
+
+GB10 vs the analytic VJP: `dP` maxerr 1.1e-16 (exact f64); `da` maxerr 1e-4; `db` maxerr 2e-4. That the
+weight gradients fall out of the merged primitives is itself a small result: the associator's full
+backward is expressible in the existing tensor-core op set.
+
+Harness: `run_assoc_dadb.cu`. With this the associator is a fully trainable operation — the remaining
+step to an end-to-end model that *uses* the associator (whose signal was shown, ablatably, in
+`NONASSOC_BENCHMARK.md`) is wiring these gradients through a training loop.

--- a/docs/gpu/run_assoc_dadb.cu
+++ b/docs/gpu/run_assoc_dadb.cu
@@ -1,0 +1,79 @@
+// Associator VJP w.r.t. the WEIGHTS a, b — completes the associator gradient. Given upstream dD of
+// [a,b,H] = (a⊗b)⊗H − a⊗(b⊗H), compute da, db. They DECOMPOSE into the already-merged tensor-core
+// kernels + host glue:
+//   dP = da_accum(H,dD)          = ossm_oct_bwd(a,H,dD).dA
+//   dq = −L(a)ᵀ·dD               = −ossm_oct_bwd(a,H,dD).dHprev
+//   q  = L(b)·H                  = oct_batch_mul(b,H)
+//   da_from_r = −da_accum(q,dD)  = −ossm_oct_bwd(·,qᵀ,dD).dA
+//   db_from_q =  da_accum(H,dq)  =  ossm_oct_bwd(·,H,dq).dA
+//   da_from_P[i]=Σ_j σ(i,j)b[j]dP[i⊕j] ; db_from_P[j]=Σ_i σ(i,j)a[i]dP[i⊕j]   (a⊗b product VJP, host)
+//   da = da_from_P + da_from_r ; db = db_from_P + db_from_q
+// Validated vs the analytic host da/db. Usage: run_assoc_dadb <ossm_oct_bwd.ptx> <oct_batch_mul.ptx>
+#include <cstdio>
+#include <cmath>
+#include <cuda.h>
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+static const int DIM=8, BITS=3;
+static CUfunction BWD,MUL;
+// ossm_oct_bwd(pA,pHprev[state-major],pdHt[D-layout],pdHprev[D-layout out],pdA[accumulate])
+static void bwd(CUdeviceptr A,CUdeviceptr Hp,CUdeviceptr dHt,CUdeviceptr dHp,CUdeviceptr dA){void*a[]={&A,&Hp,&dHt,&dHp,&dA};cuLaunchKernel(BWD,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+// oct_batch_mul(pa,pH[state-major],pout[D-layout f32])
+static void mul(CUdeviceptr a_,CUdeviceptr H,CUdeviceptr o){void*a[]={&a_,&H,&o};cuLaunchKernel(MUL,1,1,1,32,1,1,0,0,a,0);cuCtxSynchronize();}
+int main(int c,char**v){
+ const char*pb=c>1?v[1]:"/tmp/bwd.ptx"; const char*pm=c>2?v[2]:"/tmp/mul.ptx";
+ double a[8],b[8],H[128],dD[256];
+ for(int i=0;i<8;i++){a[i]=0.35*((i%2)?-1:1)+0.05*i; b[i]=0.25-0.04*i+((i%3)?0.1:-0.1);}
+ for(int bb=0;bb<16;bb++)for(int j=0;j<8;j++)H[bb*8+j]=0.2*sin(0.4*j+0.6*bb);     // state-major
+ for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++)dD[k*16+bb]=0.2*sin(0.5*k+0.3*bb);   // D-layout
+ // ── analytic host da, db ──
+ double P[8]={0}; for(int i=0;i<8;i++)for(int j=0;j<8;j++)P[i^j]+=(double)cds(i,j,BITS)*a[i]*b[j];
+ double dP[8]={0};
+ for(int p=0;p<8;p++){double s=0;for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++){int m=k^p;s+=(double)cds(p,m,BITS)*H[bb*8+m]*dD[k*16+bb];}dP[p]=s;}
+ double q[128],dq[256];
+ for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++){double s=0;for(int l=0;l<8;l++)s+=(double)cds(k^l,l,BITS)*b[k^l]*H[bb*8+l];q[bb*8+k]=s;} // q state-major
+ for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++){double s=0;for(int mm=0;mm<8;mm++)s+=(double)cds(mm^k,k,BITS)*a[mm^k]*dD[mm*16+bb];dq[k*16+bb]=-s;} // dq=−L(a)ᵀdD, D-layout
+ double da_r[8]={0},db_q[8]={0};
+ for(int p=0;p<8;p++){double s=0;for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++){int m=k^p;s+=(double)cds(p,m,BITS)*q[bb*8+m]*dD[k*16+bb];}da_r[p]=-s;}
+ for(int p=0;p<8;p++){double s=0;for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++){int m=k^p;s+=(double)cds(p,m,BITS)*H[bb*8+m]*dq[k*16+bb];}db_q[p]=s;}
+ double da_ref[8],db_ref[8];
+ for(int i=0;i<8;i++){double s=0;for(int j=0;j<8;j++)s+=(double)cds(i,j,BITS)*b[j]*dP[i^j];da_ref[i]=s+da_r[i];}
+ for(int j=0;j<8;j++){double s=0;for(int i=0;i<8;i++)s+=(double)cds(i,j,BITS)*a[i]*dP[i^j];db_ref[j]=s+db_q[j];}
+ // ── orchestrate merged kernels ──
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext x;CK(cuDevicePrimaryCtxRetain(&x,d));CK(cuCtxSetCurrent(x));
+ CUmodule mb,mm;CK(cuModuleLoad(&mb,pb));CK(cuModuleLoad(&mm,pm));
+ CK(cuModuleGetFunction(&BWD,mb,"step"));CK(cuModuleGetFunction(&MUL,mm,"step"));
+ CUdeviceptr dA_,dHp_,ddHt_,ddHpr_,ddA_,dq_,dMul_;
+ CK(cuMemAlloc(&dA_,8*8));CK(cuMemAlloc(&dHp_,128*8));CK(cuMemAlloc(&ddHt_,256*8));CK(cuMemAlloc(&ddHpr_,256*8));CK(cuMemAlloc(&ddA_,8*8));CK(cuMemAlloc(&dq_,128*8));CK(cuMemAlloc(&dMul_,256*4));
+ double z8[8]={0}; float z4[256]={0};
+ // Call 1: ossm_oct_bwd(a, H, dD) → dHprev1=L(a)ᵀ·dD, dA1=dP
+ CK(cuMemcpyHtoD(dA_,a,64));CK(cuMemcpyHtoD(dHp_,H,128*8));CK(cuMemcpyHtoD(ddHt_,dD,256*8));CK(cuMemcpyHtoD(ddA_,z8,64));
+ bwd(dA_,dHp_,ddHt_,ddHpr_,ddA_);
+ double kdP[8]; CK(cuMemcpyDtoH(kdP,ddA_,64));
+ double khp[256]; CK(cuMemcpyDtoH(khp,ddHpr_,256*8)); double kdq[256]; for(int i=0;i<256;i++)kdq[i]=-khp[i];
+ // q = oct_batch_mul(b, H) → D-layout f32; transpose to state-major
+ CK(cuMemcpyHtoD(dA_,b,64));CK(cuMemcpyHtoD(dHp_,H,128*8));CK(cuMemcpyHtoD(dMul_,z4,256*4));
+ mul(dA_,dHp_,dMul_); float qf[256]; CK(cuMemcpyDtoH(qf,dMul_,256*4));
+ double qsm[128]; for(int k=0;k<8;k++)for(int bb=0;bb<16;bb++)qsm[bb*8+k]=qf[k*16+bb];
+ // Call 2: ossm_oct_bwd(a, qsm, dD) → dA2 = da_accum(q,dD); da_from_r = −dA2
+ CK(cuMemcpyHtoD(dA_,a,64));CK(cuMemcpyHtoD(dHp_,qsm,128*8));CK(cuMemcpyHtoD(ddHt_,dD,256*8));CK(cuMemcpyHtoD(ddA_,z8,64));
+ bwd(dA_,dHp_,ddHt_,ddHpr_,ddA_); double kdar[8]; CK(cuMemcpyDtoH(kdar,ddA_,64)); for(int i=0;i<8;i++)kdar[i]=-kdar[i];
+ // Call 3: ossm_oct_bwd(a, H, dq) → dA3 = da_accum(H,dq) = db_from_q
+ CK(cuMemcpyHtoD(dA_,a,64));CK(cuMemcpyHtoD(dHp_,H,128*8));CK(cuMemcpyHtoD(ddHt_,kdq,256*8));CK(cuMemcpyHtoD(ddA_,z8,64));
+ bwd(dA_,dHp_,ddHt_,ddHpr_,ddA_); double kdbq[8]; CK(cuMemcpyDtoH(kdbq,ddA_,64));
+ // host product-VJP over the (exact-f64) dP from the kernel + combine
+ double da[8],db[8];
+ for(int i=0;i<8;i++){double s=0;for(int j=0;j<8;j++)s+=(double)cds(i,j,BITS)*b[j]*kdP[i^j];da[i]=s+kdar[i];}
+ for(int j=0;j<8;j++){double s=0;for(int i=0;i<8;i++)s+=(double)cds(i,j,BITS)*a[i]*kdP[i^j];db[j]=s+kdbq[j];}
+ double mda=0,mdb=0,mdp=0; for(int i=0;i<8;i++){mdp=fmax(mdp,fabs(kdP[i]-dP[i]));mda=fmax(mda,fabs(da[i]-da_ref[i]));mdb=fmax(mdb,fabs(db[i]-db_ref[i]));}
+ printf("Associator weight-gradient VJP (da, db) via merged kernels + host glue, vs analytic (GB10):\n");
+ printf("  dP = da_accum(H,dD)  (f64, exact):   maxerr = %.2e\n",mdp);
+ printf("  da = productVJP_a(b,dP) − da_accum(q,dD):   maxerr = %.4f\n",mda);
+ printf("  db = productVJP_b(a,dP) + da_accum(H,dq):   maxerr = %.4f\n",mdb);
+ if(mdp<1e-6 && mda<0.05 && mdb<0.05){printf("PASS: the associator's weight gradients da, db decompose into the merged tensor-core kernels and match the analytic VJP on GB10\n");return 0;}
+ printf("FAIL\n");return 1;
+}


### PR DESCRIPTION
Completes the associator's reverse-mode gradient. The forward `[a,b,H]=(a⊗b)⊗H−a⊗(b⊗H)` has a dedicated `dH` kernel (`oct_assoc_bwd_dh`, #1207); here the **weight gradients** `da, db` are shown to **decompose entirely into already-merged tensor-core kernels** + host glue:

```
dP        = da_accum(H,dD)   = ossm_oct_bwd(a,H,dD).dA        (exact f64)
dq        = −L(a)ᵀ·dD        = −ossm_oct_bwd(a,H,dD).dHprev
q         = L(b)·H           = oct_batch_mul(b,H)
da_from_r = −da_accum(q,dD)  ;  db_from_q = da_accum(H,dq)     (ossm_oct_bwd on q / dq)
da_from_P, db_from_P = the a⊗b product VJP (single-octonion contraction, host)
da = da_from_P + da_from_r   ;  db = db_from_P + db_from_q
```

GB10 vs the analytic VJP: `dP` maxerr **1.1e-16** (exact f64), `da` **1e-4**, `db` **2e-4**.

That the weight gradients fall out of the merged primitives is itself a small result: the associator's **whole backward is expressible in the existing tensor-core op set**. The associator is now a fully differentiable/trainable operation. Harness `run_assoc_dadb.cu`; summary `ASSOC_VJP_COMPLETE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)