### PR TITLE
feat(bench): end-to-end training through the associator — a trainable tensor-core layer (GB10)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1021
-- Repo-backed topics: 871
+- Total governed topics: 1022
+- Repo-backed topics: 872
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 621
+- Authority count `repo_only`: 622
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 640 topics
+- A2: 641 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1022
-- Repo-backed topics: 872
+- Total governed topics: 1023
+- Repo-backed topics: 873
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 212
-- Authority count `repo_only`: 622
+- Authority count `repo_only`: 623
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 641 topics
+- A2: 642 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -353,6 +353,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.glossary | repo_only | docs/GLOSSARY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.data-access-credentials | repo_only | docs/governance/data_access_credentials.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.docs-conventions | repo_only | docs/governance/DOCS_CONVENTIONS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.gpu.assoc-e2e-training | repo_only | docs/gpu/ASSOC_E2E_TRAINING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.batched-hyper-syntax | repo_only | docs/gpu/BATCHED_HYPER_SYNTAX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hyper-matvec-design | repo_only | docs/gpu/HYPER_MATVEC_DESIGN.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hypercomplex-ssm-novelty | repo_only | docs/gpu/HYPERCOMPLEX_SSM_NOVELTY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -354,6 +354,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.governance.data-access-credentials | repo_only | docs/governance/data_access_credentials.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.governance.docs-conventions | repo_only | docs/governance/DOCS_CONVENTIONS.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.assoc-e2e-training | repo_only | docs/gpu/ASSOC_E2E_TRAINING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.gpu.assoc-vjp-complete | repo_only | docs/gpu/ASSOC_VJP_COMPLETE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.batched-hyper-syntax | repo_only | docs/gpu/BATCHED_HYPER_SYNTAX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hyper-matvec-design | repo_only | docs/gpu/HYPER_MATVEC_DESIGN.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hypercomplex-ssm-novelty | repo_only | docs/gpu/HYPERCOMPLEX_SSM_NOVELTY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7627,6 +7627,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.gpu.assoc-vjp-complete",
+      "collection": "repo",
+      "repo_doc_path": "docs/gpu/ASSOC_VJP_COMPLETE.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.gpu.batched-hyper-syntax",
       "collection": "repo",
       "repo_doc_path": "docs/gpu/BATCHED_HYPER_SYNTAX.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7604,6 +7604,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.gpu.assoc-e2e-training",
+      "collection": "repo",
+      "repo_doc_path": "docs/gpu/ASSOC_E2E_TRAINING.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.gpu.batched-hyper-syntax",
       "collection": "repo",
       "repo_doc_path": "docs/gpu/BATCHED_HYPER_SYNTAX.md",

--- a/docs/gpu/ASSOC_E2E_TRAINING.md
+++ b/docs/gpu/ASSOC_E2E_TRAINING.md
@@ -1,0 +1,41 @@
+<!-- docs:meta
+topic_id: repo.docs.gpu.assoc-e2e-training
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.gpu.assoc-e2e-training
+-->
+
+# End-to-end training through the associator
+
+The synthetic benchmark (`NONASSOC_BENCHMARK.md`) showed the associator is a useful **frozen** feature
+(non-associativity is required, associative models are blind). With the associator's full VJP now in
+hand (`ASSOC_VJP_COMPLETE.md`), this closes the loop: a model that **uses** the associator, trained
+**end-to-end**, with the associator's forward and backward both running on compiler-lowered tensor-core
+kernels.
+
+## Model & training
+    y = w · [a, b, c]          learnable octonion weights a, b and a linear readout w
+- **forward**: `z = oct_assoc(a, b, C)` (the associator tensor-core kernel); `y_i = w·z_i`.
+- **backward**: `dz_i = dy_i·w` → upstream `dD`; `dw += Σ dy_i·z_i`; and `da, db` via the merged
+  tensor-core decomposition (`ossm_oct_bwd` + `oct_batch_mul` + the `a⊗b` product VJP).
+- **optimizer**: Adam on `a, b, w`.
+- **targets**: teacher-generated (reachable) — 8 batches × 16 = 128 samples.
+
+## Result (DGX Spark GB10, 300 iters)
+    iter   1  loss 1.10e+01
+    iter  50  loss 2.68e-03
+    iter 150  loss 1.15e-05
+    iter 300  loss 1.06e-05          →  100% reduction
+
+**The associator is a trainable tensor-core layer** — the loss falls through its VJP. This is the
+stronger claim on top of the frozen-feature benchmark: not only does the associator carry signal
+associative models are blind to, a model can be trained to exploit it end-to-end, with every heavy op
+(the associator forward, the backward `L(·)ᵀ` tiles and `da`-accumulations) emitted by the compiler.
+
+Harness: `run_assoc_train.cu`. Honest scope: teacher-target (reachable) — it validates that the
+gradients flow and the model converges through the associator, not a benchmark-beating claim. The
+non-associativity-required claim is the benchmark's (#1204); this is the trainability claim. Next: a
+task combining both — where a model must *learn* to use non-associativity to solve something an
+associative model cannot — and ultimately real data.

--- a/docs/gpu/run_assoc_train.cu
+++ b/docs/gpu/run_assoc_train.cu
@@ -1,0 +1,90 @@
+// END-TO-END training THROUGH the associator on the DGX Spark GB10. Model: y = w·[a,b,c], with
+// LEARNABLE octonion weights a, b and a linear readout w. The associator [a,b,c] and its reverse-mode
+// gradients (da, db) run on the compiler-lowered tensor-core kernels (oct_assoc forward; ossm_oct_bwd +
+// oct_batch_mul for the backward). Teacher-generated targets (reachable); Adam. Shows the associator is
+// a trainable layer — the loss falls through the associator's VJP.
+// Usage: run_assoc_train <oct_assoc.ptx> <ossm_oct_bwd.ptx> <oct_batch_mul.ptx>
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <cuda.h>
+static unsigned RS=777; static double rnd(){RS=RS*1664525u+1013904223u; return ((RS>>8)&0xffffff)/16777216.0*2-1;}
+static int cds(int a,int b,int bits){int s=1;while(bits>0){if(a==0||b==0)return s;if(bits==1)return -s;
+ int h=1<<(bits-1),ah=a>=h,bh=b>=h,al=a&(h-1),bl=b&(h-1);
+ if(!ah&&!bh){a=al;b=bl;}else if(!ah&&bh){a=bl;b=al;}
+ else if(ah&&!bh){if(bl==0){a=al;b=0;}else{s=-s;a=al;b=bl;}}
+ else{if(bl==0){s=-s;a=0;b=al;}else{a=bl;b=al;}}bits--;}return s;}
+#define CK(x) do{CUresult e=(x);if(e){const char*s;cuGetErrorString(e,&s);printf("ERR %s@%d:%s\n",#x,__LINE__,s);return 2;}}while(0)
+static const int BITS=3;
+static CUfunction ASS,BWD,MUL;
+static void assoc(CUdeviceptr a,CUdeviceptr b,CUdeviceptr H,CUdeviceptr o){void*A[]={&a,&b,&H,&o};cuLaunchKernel(ASS,1,1,1,32,1,1,0,0,A,0);cuCtxSynchronize();}
+static void bwd(CUdeviceptr a,CUdeviceptr Hp,CUdeviceptr dHt,CUdeviceptr dHp,CUdeviceptr dA){void*A[]={&a,&Hp,&dHt,&dHp,&dA};cuLaunchKernel(BWD,1,1,1,32,1,1,0,0,A,0);cuCtxSynchronize();}
+static void mul(CUdeviceptr a,CUdeviceptr H,CUdeviceptr o){void*A[]={&a,&H,&o};cuLaunchKernel(MUL,1,1,1,32,1,1,0,0,A,0);cuCtxSynchronize();}
+static CUdeviceptr da_,db_,dH_,dO_,dHt_,dHpr_,dAacc_,dq_,dMul_;
+// z = oct_assoc(a,b,C) → D-layout f32 [k*16+i]
+static void fwd_assoc(const double*a,const double*b,const double*C,float*z){
+ cuMemcpyHtoD(da_,a,64);cuMemcpyHtoD(db_,b,64);cuMemcpyHtoD(dH_,C,128*8);float zz[256]={0};cuMemcpyHtoD(dO_,zz,256*4);
+ assoc(da_,db_,dH_,dO_);cuMemcpyDtoH(z,dO_,256*4);
+}
+// accumulate da_g, db_g for one group into gda,gdb given upstream dD (D-layout f64)
+static void grad_ab(const double*a,const double*b,const double*C,const double*dD,double*gda,double*gdb){
+ double z8[8]={0};
+ // dP + dq: ossm_oct_bwd(a, C, dD)
+ cuMemcpyHtoD(da_,a,64);cuMemcpyHtoD(dH_,C,128*8);cuMemcpyHtoD(dHt_,dD,256*8);cuMemcpyHtoD(dAacc_,z8,64);
+ bwd(da_,dH_,dHt_,dHpr_,dAacc_);
+ double dP[8];cuMemcpyDtoH(dP,dAacc_,64); double dhp[256];cuMemcpyDtoH(dhp,dHpr_,256*8);
+ double dq[256];for(int i=0;i<256;i++)dq[i]=-dhp[i];
+ // q = oct_batch_mul(b,C) → transpose to state-major
+ cuMemcpyHtoD(da_,b,64);cuMemcpyHtoD(dH_,C,128*8);float zz[256]={0};cuMemcpyHtoD(dMul_,zz,256*4);
+ mul(da_,dH_,dMul_);float qf[256];cuMemcpyDtoH(qf,dMul_,256*4);
+ double qsm[128];for(int k=0;k<8;k++)for(int i=0;i<16;i++)qsm[i*8+k]=qf[k*16+i];
+ // da_from_r = −ossm_oct_bwd(a, qsm, dD).dA
+ cuMemcpyHtoD(da_,a,64);cuMemcpyHtoD(dH_,qsm,128*8);cuMemcpyHtoD(dHt_,dD,256*8);cuMemcpyHtoD(dAacc_,z8,64);
+ bwd(da_,dH_,dHt_,dHpr_,dAacc_);double dar[8];cuMemcpyDtoH(dar,dAacc_,64);
+ // db_from_q = ossm_oct_bwd(a, C, dq).dA
+ cuMemcpyHtoD(da_,a,64);cuMemcpyHtoD(dH_,C,128*8);cuMemcpyHtoD(dHt_,dq,256*8);cuMemcpyHtoD(dAacc_,z8,64);
+ bwd(da_,dH_,dHt_,dHpr_,dAacc_);double dbq[8];cuMemcpyDtoH(dbq,dAacc_,64);
+ for(int i=0;i<8;i++){double s=0;for(int j=0;j<8;j++)s+=(double)cds(i,j,BITS)*b[j]*dP[i^j];gda[i]+=s-dar[i];}
+ for(int j=0;j<8;j++){double s=0;for(int i=0;i<8;i++)s+=(double)cds(i,j,BITS)*a[i]*dP[i^j];gdb[j]+=s+dbq[j];}
+}
+int main(int c,char**v){
+ const char*pa=c>1?v[1]:"/tmp/assoc.ptx";const char*pbw=c>2?v[2]:"/tmp/bwd.ptx";const char*pm=c>3?v[3]:"/tmp/mul.ptx";
+ CK(cuInit(0));CUdevice d;CK(cuDeviceGet(&d,0));CUcontext x;CK(cuDevicePrimaryCtxRetain(&x,d));CK(cuCtxSetCurrent(x));
+ CUmodule ma,mb,mm;CK(cuModuleLoad(&ma,pa));CK(cuModuleLoad(&mb,pbw));CK(cuModuleLoad(&mm,pm));
+ CK(cuModuleGetFunction(&ASS,ma,"step"));CK(cuModuleGetFunction(&BWD,mb,"step"));CK(cuModuleGetFunction(&MUL,mm,"step"));
+ CK(cuMemAlloc(&da_,64));CK(cuMemAlloc(&db_,64));CK(cuMemAlloc(&dH_,128*8));CK(cuMemAlloc(&dO_,256*4));
+ CK(cuMemAlloc(&dHt_,256*8));CK(cuMemAlloc(&dHpr_,256*8));CK(cuMemAlloc(&dAacc_,64));CK(cuMemAlloc(&dq_,128*8));CK(cuMemAlloc(&dMul_,256*4));
+ const int G=8; double C[8][128];
+ for(int g=0;g<G;g++)for(int i=0;i<16;i++)for(int k=0;k<8;k++)C[g][i*8+k]=rnd();
+ double as[8],bs[8],ws[8]; for(int k=0;k<8;k++){as[k]=0.4*rnd();bs[k]=0.4*rnd();ws[k]=rnd();}
+ // teacher targets
+ double tgt[8][16];
+ for(int g=0;g<G;g++){float z[256];fwd_assoc(as,bs,C[g],z);
+   for(int i=0;i<16;i++){double y=0;for(int k=0;k<8;k++)y+=ws[k]*(double)z[k*16+i];tgt[g][i]=y;}}
+ // student init = teacher + perturbation
+ double a[8],b[8],w[8];for(int k=0;k<8;k++){a[k]=as[k]+0.15*rnd();b[k]=bs[k]+0.15*rnd();w[k]=ws[k]+0.15*rnd();}
+ double mA[8]={0},vA[8]={0},mB[8]={0},vB[8]={0},mW[8]={0},vW[8]={0};
+ const double lr=0.02,b1=0.9,b2=0.999,eps=1e-8; const int NIT=300;
+ double loss0=0,lossN=0;
+ for(int it=1;it<=NIT;it++){
+  double gda[8]={0},gdb[8]={0},gdw[8]={0},loss=0;
+  for(int g=0;g<G;g++){
+   float z[256];fwd_assoc(a,b,C[g],z);
+   double dD[256]={0};
+   for(int i=0;i<16;i++){double y=0;for(int k=0;k<8;k++)y+=w[k]*(double)z[k*16+i];
+     double dy=2.0*(y-tgt[g][i]);loss+=(y-tgt[g][i])*(y-tgt[g][i]);
+     for(int k=0;k<8;k++){gdw[k]+=dy*(double)z[k*16+i]; dD[k*16+i]=dy*w[k];}}
+   grad_ab(a,b,C[g],dD,gda,gdb);
+  }
+  if(it==1)loss0=loss; lossN=loss;
+  double bc1=1.0-pow(b1,it),bc2=1.0-pow(b2,it);
+#define ADAM(TH,G,M,V) for(int k=0;k<8;k++){M[k]=b1*M[k]+(1-b1)*G[k];V[k]=b2*V[k]+(1-b2)*G[k]*G[k];TH[k]-=lr*(M[k]/bc1)/(sqrt(V[k]/bc2)+eps);}
+  ADAM(a,gda,mA,vA) ADAM(b,gdb,mB,vB) ADAM(w,gdw,mW,vW)
+#undef ADAM
+  if(it==1||it==NIT||it%50==0)printf("  iter %3d  loss %.6e\n",it,loss);
+ }
+ printf("End-to-end training THROUGH the associator (learn a,b,w; associator forward + da/db on tensor cores) + Adam:\n");
+ printf("  loss %.6e → %.6e  (%.2f%% reduction, %d samples)\n",loss0,lossN,100.0*(loss0-lossN)/loss0,G*16);
+ if(lossN<1e-3*loss0){printf("PASS: the associator is a TRAINABLE tensor-core layer — the loss falls through its VJP on GB10\n");return 0;}
+ printf("FAIL\n");return 1;
+}


### PR DESCRIPTION
Closes the loop from "the associator is a useful **frozen** feature" (#1204) to "the associator is a **trainable** layer."

## Model & training
A model `y = w·[a,b,c]` with learnable octonion weights `a, b` and a linear readout `w` is trained **end-to-end**, with the associator's **forward** (`oct_assoc`) and **backward** (`da, db` via `ossm_oct_bwd` + `oct_batch_mul` + the `a⊗b` product VJP) both on compiler-lowered tensor-core kernels; Adam on `a, b, w`; teacher-generated (reachable) targets, 128 samples.

## Result (DGX Spark GB10, 300 iters)
```
iter   1  loss 1.10e+01
iter  50  loss 2.68e-03
iter 150  loss 1.15e-05
iter 300  loss 1.06e-05      →  100% reduction
```

**The associator is a trainable tensor-core layer** — the loss falls through its VJP. Every heavy op (the associator forward, the backward `L(·)ᵀ` tiles and `da`-accumulations) is emitted by the compiler.

**Honest scope:** teacher-target (reachable) — this validates the gradients flow and the model converges *through* the associator; it is the trainability claim, not a benchmark-beating one. The *non-associativity-required* claim is the benchmark's (#1204). Next: a task combining both (a model that must learn to use non-associativity to solve something associative models cannot), then real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)