### PR TITLE
docs(handoff): dispatch to CODEX-2 — lower sqrt from extern libc call to sqrtsd

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1027
-- Repo-backed topics: 877
+- Total governed topics: 1028
+- Repo-backed topics: 878
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 213
-- Authority count `repo_only`: 626
+- Authority count `repo_only`: 627
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 645 topics
+- A2: 646 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -415,6 +415,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.pending-changes-triage-2026-07-11 | repo_only | docs/handoff/pending_changes_triage_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-512-vreg-wall-codex-dispatch-2026-07-18 | repo_only | docs/handoff/souc_512_vreg_wall_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-decimal-literal-rounding-codex-dispatch-2026-07-18 | repo_only | docs/handoff/souc_decimal_literal_rounding_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.souc-sqrt-extern-to-sqrtsd-codex-dispatch-2026-07-19 | repo_only | docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.souc-v0800-defects | repo_only | docs/handoff/souc_v0800_defects.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.zero-event-native-compile-privacy-2026-07-11 | repo_only | docs/handoff/zero_event_native_compile_privacy_2026-07-11.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.implementation.bootstrap-seed-policy | historical | docs/implementation/BOOTSTRAP_SEED_POLICY.md | - | A7 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -9045,6 +9045,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.souc-sqrt-extern-to-sqrtsd-codex-dispatch-2026-07-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.souc-v0800-defects",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/souc_v0800_defects.md",

--- a/docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md
+++ b/docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md
@@ -1,0 +1,116 @@
+<!-- docs:meta
+topic_id: repo.docs.handoff.souc-sqrt-extern-to-sqrtsd-codex-dispatch-2026-07-19
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.souc-sqrt-extern-to-sqrtsd-codex-dispatch-2026-07-19
+-->
+
+# Dispatch to CODEX-2 — `sqrt` is an extern libc call (~244 ns/element), not the hardware `sqrtsd` instruction
+
+**Date:** 2026-07-19
+**Owner:** CODEX-2 (compiler back-end / codegen for math builtins; `self-hosted/`)
+**Author:** data-science lane (surfaced building `data::bigframe_ops::bf_expanding_std`)
+**Status:** confirmed perf defect, minimal repro + microbenchmark included — codegen, low blast radius
+
+---
+
+## TL;DR
+
+Sounio's `sqrt(x: f64) -> f64` is lowered as an **extern libc/libm call** (through the PLT, with
+full call-site register save/restore), costing **~244 ns per element**. The correct lowering is a
+single hardware instruction — `sqrtsd` on x86-64, `fsqrt` on arm64 — which is ~**1–4 ns** and
+already correctly-rounded IEEE-754 (bit-identical to libm `sqrt`). This one call sits on the hot path
+of *every* statistical / geometric verb, so fixing it is a broad, cheap win with zero accuracy change.
+
+## Evidence (reproducible now)
+
+**1. Microbenchmark — 30,000,000 `sqrt` calls in a tight loop:**
+
+| variant | time | per call |
+|---|---|---|
+| `sqrt(x)` (current extern) | **7336 ms** | **~244 ns** |
+| inline Newton–Raphson (bit-hack seed + 5 iters, no call) | 1579 ms | ~52 ns |
+
+The inline version does *more* floating-point work (5 iterations of `0.5*(y + x/y)`) yet is **~5×
+faster** — because it has no call. That isolates the cost as **call-site overhead**, not the math.
+(The hardware `sqrtsd` would beat both by another ~10×.)
+
+**2. End-to-end — `data::bigframe_ops` expanding stats over 1,000,000 rows:**
+
+| op | Sounio | pandas | ratio |
+|---|---|---|---|
+| `bf_expanding_var` (Welford, no sqrt) | 14.9 ms | 14.9 ms | **1.00× (parity)** |
+| `bf_expanding_std` (**same Welford + one `sqrt` per row**) | **256 ms** | 19.7 ms | **13.0×** |
+
+`var` and `std` are the identical single-pass Welford recurrence; the *only* difference is the
+per-element `sqrt`. It alone turns a parity result into a 13× loss.
+
+## Repro programs (either engine; lean_single shown)
+
+Extern (hot):
+```
+fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
+    var acc = 0.0; var i: i64 = 0
+    while i < 30000000 { acc = acc + sqrt((i%1000+1) as f64); i = i + 1 }
+    print(acc); print("\n"); return 0
+}
+```
+Inline Newton (for the ~5× comparison; needs an 8-byte scratch cell for the bit reinterpret):
+```
+fn nsqrt(x: f64, scratch: *mut f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    let b = f64_to_bits(x); let s = (b >> 1) + 2303591209400008704
+    write_i64(scratch as *mut i64, 0, s); var y = read_f64(scratch, 0)
+    y = 0.5*(y + x/y); y = 0.5*(y + x/y); y = 0.5*(y + x/y); y = 0.5*(y + x/y); y = 0.5*(y + x/y)
+    y
+}
+```
+Build: `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc compile f.sio -o out && ./out`, then `time ./out`.
+
+## Root-cause hypothesis
+
+`sqrt` resolves to a global builtin that the back-end emits as an **extern function call** (libm
+`sqrt`) rather than an intrinsic. The `x86-64` codegen already emits inline instruction sequences for
+other primitives (e.g. `emit_memcpy_a64` at `self-hosted/compiler/lean_single.sio:2104`), so emitting
+`sqrtsd xmm, xmm` for `sqrt` is the same class of change — recognise the `sqrt` builtin at the call
+site and emit the instruction on the f64 in the xmm register instead of setting up a call.
+
+## The ask
+
+Lower the `f64` `sqrt` builtin to the hardware square-root instruction:
+- **x86-64:** `sqrtsd %xmmSrc, %xmmDst` (or `vsqrtsd`).
+- **arm64:** `fsqrt d_dst, d_src`.
+
+Keep the extern fallback only if the argument type isn't a register f64. `sqrtsd` is IEEE-754
+correctly-rounded, so results stay **bit-identical** to today's libm path (no accuracy regression).
+
+If `fabs`, `floor`, `ceil`, `trunc`, `rint`/`round`, and `min`/`max` share the same extern-lowering
+path, they lower to single instructions too (`andpd`/`roundsd`/`minsd`/`maxsd`) — same fix, same file.
+
+## Acceptance
+
+- The 30M-call `sqrt` loop drops from ~7.3 s to well under ~1 s (ideally ~0.1 s).
+- `bf_expanding_std` at 1M rows lands within ~1.3× of pandas (from 13×), matching `bf_expanding_var`.
+- Results bit-identical to the current libm path on a fuzz set of positive doubles + edge cases
+  (0.0, +inf, subnormals; `sqrt(-x)` stays NaN).
+
+## Scope / impact
+
+- **Low blast radius:** codegen for one (or a few) math builtins; no front-end or type changes.
+- **Broad payoff:** every sqrt-bound verb flips from loss to competitive — expanding/rolling `std`,
+  RMS, L2 norm, Euclidean distance, correlation/covariance normalisation, z-score / Grubbs' outlier
+  tests, and the GUM uncertainty combine (`u_c = sqrt(Σ u_i²)`), which is core to the measurement-data
+  thesis.
+- Complements the other two open perf dispatches — `mem_copy` builtin
+  (`docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md`, which `bf_shift` is bound by) and C3
+  SIMD auto-vectorisation (`docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md`, which
+  `bf_diff` is bound by). Together they close the three known bigframe losses.
+
+## Pointers
+
+- Repro + microbenchmark: this file.
+- Verb that surfaced it: `stdlib/data/bigframe_ops.sio::bf_expanding_std` (vs `bf_expanding_var`).
+- Benchmark table: `scripts/bench/RESULTS.md` (expanding rows + the "expanding" honest-read bullet).
+- Existing inline-instruction precedent: `self-hosted/compiler/lean_single.sio:2104` (`emit_memcpy_a64`).


### PR DESCRIPTION
## What

A CODEX-2 work-order: **`sqrt(f64)` is emitted as an extern libc/libm call (~244 ns/element), not the hardware `sqrtsd`/`fsqrt` instruction** (~1–4 ns, already correctly-rounded IEEE-754).

## Evidence (reproduced locally)

- **30M-call microbenchmark**: extern `sqrt` 7336ms (~244ns/call); an inline Newton-Raphson (5 iterations — *more* FP work — but no call) runs 1579ms (~52ns), **~5× faster**, isolating the cost as **call-site overhead**, not the math.
- **End-to-end**: `bf_expanding_std` (Welford + one `sqrt`/row) is **13.0× pandas** at 1M rows, while the *identical* `bf_expanding_var` (same Welford, no sqrt) is at **parity**. The `sqrt` call alone is the entire gap.

## The ask

Emit `sqrtsd %xmm,%xmm` (x86-64) / `fsqrt` (arm64) for the f64 `sqrt` builtin — the same class of change as the existing `emit_memcpy_a64` (`self-hosted/compiler/lean_single.sio:2104`). Results stay **bit-identical** (sqrtsd is correctly-rounded). `fabs`/`floor`/`ceil`/`round`/`min`/`max` lower to single instructions too if they share the extern path.

## Why it matters

Every sqrt-bound verb is bottlenecked: expanding/rolling `std`, RMS, L2 norm, Euclidean distance, correlation/covariance, z-score & Grubbs' outlier tests, and the GUM uncertainty combine `u_c = sqrt(Σ u_i²)` — core to the measurement-data thesis. Complements the `mem_copy` (#1179, which `bf_shift` is bound by) and C3 SIMD (which `bf_diff` is bound by) dispatches; the three together close the known bigframe losses.

Repro programs, microbenchmark, root-cause hypothesis, and acceptance criteria are in the doc.

## Scope
- Docs only (a handoff work-order) — registered in the docs governance registry (`Contracts` check passes locally). No code changes.
- Files: `docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md` + the governance registry regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)