### PR TITLE
feat(stats): stats↔mpmath distribution parity — 19 functions mapped, standard_normal_cdf fixed

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1028
-- Repo-backed topics: 878
+- Total governed topics: 1029
+- Repo-backed topics: 879
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 213
-- Authority count `repo_only`: 627
+- Authority count `repo_only`: 628
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 646 topics
+- A2: 647 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1029
-- Repo-backed topics: 879
+- Total governed topics: 1030
+- Repo-backed topics: 880
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 213
-- Authority count `repo_only`: 628
+- Authority count `repo_only`: 629
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 647 topics
+- A2: 648 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1030
-- Repo-backed topics: 880
+- Total governed topics: 1031
+- Repo-backed topics: 881
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 213
+- Authority count `historical`: 214
 - Authority count `repo_only`: 629
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 247 topics
+- A6: 248 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -632,6 +632,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.reference.stdlib-reference | repo_only | docs/reference/STDLIB_REFERENCE.md | - | A3 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.release-policy | repo_only | docs/RELEASE_POLICY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.2026-07-19-special-scipy-parity | historical | docs/research/2026-07-19-special-scipy-parity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.2026-07-19-stats-dist-parity | historical | docs/research/2026-07-19-stats-dist-parity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.associator-spectral-bound-status | historical | docs/research/associator_spectral_bound_status.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.bbb-pbpk-dissertation-chapter | historical | docs/research/bbb_pbpk_dissertation_chapter.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.beta0-octonion-gum-derivation | historical | docs/research/beta0_octonion_gum_derivation.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -852,6 +852,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.specs.2026-07-15-batched-verticals-index | repo_only | docs/superpowers/specs/2026-07-15-batched-verticals-index.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-17-csv-reader-design | repo_only | docs/superpowers/specs/2026-07-17-csv-reader-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-19-special-scipy-parity-design | repo_only | docs/superpowers/specs/2026-07-19-special-scipy-parity-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.specs.2026-07-19-stats-dist-parity-design | repo_only | docs/superpowers/specs/2026-07-19-stats-dist-parity-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.test-infrastructure-v2 | repo_only | docs/test-infrastructure-v2.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.testing | repo_only | docs/TESTING.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.theory.epistemic-monotonicity | repo_only | docs/theory/epistemic_monotonicity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -838,6 +838,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.superpowers.plans.2026-07-14-units-vertical | repo_only | docs/superpowers/plans/2026-07-14-units-vertical.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-17-csv-reader | repo_only | docs/superpowers/plans/2026-07-17-csv-reader.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.plans.2026-07-19-special-scipy-parity | repo_only | docs/superpowers/plans/2026-07-19-special-scipy-parity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.superpowers.plans.2026-07-19-stats-dist-parity | repo_only | docs/superpowers/plans/2026-07-19-stats-dist-parity.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-data-science-io-design | repo_only | docs/superpowers/specs/2026-07-13-data-science-io-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-13-epistemic-gum-hardening-design | repo_only | docs/superpowers/specs/2026-07-13-epistemic-gum-hardening-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.superpowers.specs.2026-07-14-integrate-vertical-design | repo_only | docs/superpowers/specs/2026-07-14-integrate-vertical-design.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14014,6 +14014,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.2026-07-19-stats-dist-parity",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/2026-07-19-stats-dist-parity.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.associator-spectral-bound-status",
       "collection": "repo",
       "repo_doc_path": "docs/research/associator_spectral_bound_status.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -18579,6 +18579,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.plans.2026-07-19-stats-dist-parity",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/plans/2026-07-19-stats-dist-parity.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.superpowers.specs.2026-07-13-data-science-io-design",
       "collection": "repo",
       "repo_doc_path": "docs/superpowers/specs/2026-07-13-data-science-io-design.md",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -18901,6 +18901,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.superpowers.specs.2026-07-19-stats-dist-parity-design",
+      "collection": "repo",
+      "repo_doc_path": "docs/superpowers/specs/2026-07-19-stats-dist-parity-design.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.test-infrastructure-v2",
       "collection": "repo",
       "repo_doc_path": "docs/test-infrastructure-v2.md",

--- a/docs/research/2026-07-19-stats-dist-parity.md
+++ b/docs/research/2026-07-19-stats-dist-parity.md
@@ -1,0 +1,102 @@
+<!-- docs:meta
+topic_id: repo.docs.research.2026-07-19-stats-dist-parity
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.2026-07-19-stats-dist-parity
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# stats↔mpmath distribution parity — `stdlib/stats`
+
+**Status:** complete (2026-07-19)
+**Reference:** mpmath 1.3.0 at `mp.dps = 30`, each distribution computed from its
+closed-form definition — the arbitrary-precision ground truth `scipy.stats` is
+itself validated against (scipy not installed).
+**Reuses:** the special-function parity harness (PR #1210) — same bit-exact
+`f64_to_bits` bridge, same `stdlib/parity/emit.sio`, same lean_single-locked
+gate/comparator pattern. **Spec/plan:** `docs/superpowers/{specs,plans}/2026-07-19-stats-dist-parity*.md`.
+
+## What this is
+
+A per-function accuracy map of Sounio's probability-distribution functions
+(`stdlib/stats/densities.sio`, `distributions.sio`) vs arbitrary-precision ground
+truth. **19 functions across 9 distributions**, all green under a deterministic,
+coverage-complete gate. The screen found and fixed **1 real defect** and surfaced
+**1 compiler-infra bug** (worked around).
+
+## The parity map (max relative error vs mpmath, dps=30)
+
+| function | pts | max rel err | | function | pts | max rel err |
+|---|---:|---:|---|---|---:|---:|
+| normal_pdf | 10 | 3.86e-16 | | uniform_pdf | 10 | 0.00e+00 |
+| normal_cdf_at | 5 | 7.07e-08 | | uniform_cdf | 10 | 0.00e+00 |
+| standard_normal_cdf | 8 | 3.04e-06 | | poisson_pmf | 10 | 3.34e-15 |
+| inverse_standard_normal_cdf | 7 | 2.62e-08 | | poisson_cdf | 10 | 1.42e-12 |
+| exponential_pdf | 5 | 5.58e-16 | | binomial_pmf | 8 | 8.45e-15 |
+| exponential_cdf | 5 | 0.00e+00 | | binomial_cdf | 8 | 6.26e-15 |
+| gamma_pdf | 16 | 2.06e-15 | | geometric_pmf | 8 | 1.11e-15 |
+| gamma_cdf | 16 | 8.28e-13 | | lognormal_pdf | 12 | 6.04e-16 |
+| beta_pdf | 15 | 5.21e-15 | | lognormal_cdf | 12 | 6.91e-07 |
+| beta_cdf | 15 | 8.38e-15 | | | | |
+
+Most functions are at machine precision. The normal-family cdfs
+(`standard_normal_cdf` 3e-6, `normal_cdf_at`/`lognormal_cdf` ~7e-8/7e-7) inherit
+the accuracy of the underlying erf/Φ approximation — genuine finite-approximation
+error, comfortably inside the 1e-2 gross bar (and consistent with the special
+vertical's erf-family numbers).
+
+## Defect found and fixed
+
+**`standard_normal_cdf` (`stdlib/stats/distributions.sio`)** applied the
+Abramowitz & Stegun 7.1.26 rational erf approximation directly to `|z|` instead of
+`|z|/√2` — computing `0.5·(1+erf(|z|))` instead of `Φ(z)=0.5·(1+erf(z/√2))`. This
+made the standard normal CDF **~90 % wrong** (max_rel_err **8.97e-01**), a
+load-bearing function used throughout the stats module. One-line fix (scale by
+1/√2 before the approximation) → **3.04e-06**; no regression in
+`tests/stdlib/stats/test_distributions.sio` or `densities.sio`'s inline tests.
+Separate commit `fix(stats): scale by 1/sqrt(2) before A&S 7.1.26 erf approx …`.
+
+## Compiler-infra finding (worked around, not a distribution bug)
+
+The **lean_single bundler has a flat symbol table**: compiling a unit that imports
+BOTH `stats::densities` and `stats::distributions` breaks, because each module
+defines same-named, different-arity `pub fn`s (`normal_pdf`, `normal_cdf`,
+`beta_pdf`) and the bundler mis-resolves them across modules (fully-qualified
+`module::fn(...)` call syntax is also unsupported). Worked around by splitting the
+emitter so each imports a single module (`stats_parity_continuous1.sio` = densities,
+`stats_parity_stdnormal.sio` = distributions). No stdlib API change. **This is a
+real compiler defect worth a separate fix** — any code needing two modules that
+share a bare function name will hit it.
+
+## Convention notes (verified empirically in Phase 0, matched in the reference)
+
+- **gamma is RATE-parameterized:** `gamma_pdf/cdf(x, shape, rate)` = `P(shape, rate·x)`
+  (not shape-scale). Confirmed: `gamma_cdf(2,2,2)` = 0.9084 (rate) not 0.2642 (scale).
+- **geometric is FROM-0:** `geometric_pmf(k,p) = (1−p)^k·p`, support k=0,1,2,…
+  Confirmed: `geometric_pmf(2,0.3)` = 0.147 (from-0) not 0.21 (from-1).
+- normal/lognormal `σ` is std-dev; exponential parameter is rate λ; uniform
+  clamps pdf→0 outside [a,b], cdf→0/1 — all match the reference.
+
+## Reproduce
+
+```bash
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+bash scripts/stats_dist_parity_gate.sh     # → STATS_DIST_PARITY_GATE_OK
+```
+Requires `mpmath`; SKIPs cleanly if absent. lean_single-locked, `--require-all`
+coverage assertion, deterministic. Dev-tier — not wired into `ci.yml`.
+
+## Out of scope
+
+The ~430 non-distribution stats pubs (hypothesis tests, descriptive, survival,
+Bayesian, correlation). `t`/`F` distribution cdfs are not in `stdlib/stats` (χ²
+lives in `stdlib/special` as `chi2_cdf`, mapped in #1210). The struct-based
+`distributions.sio` variants (`normal_pdf(NormalDist,…)`) were skipped in favor of
+the scalar `densities.sio` forms. Nothing ships into the prebuilt; the
+`standard_normal_cdf` fix reaches users on the normal build path.

--- a/docs/superpowers/plans/2026-07-19-stats-dist-parity.md
+++ b/docs/superpowers/plans/2026-07-19-stats-dist-parity.md
@@ -1,0 +1,327 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.plans.2026-07-19-stats-dist-parity
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.plans.2026-07-19-stats-dist-parity
+-->
+
+# stats↔mpmath Distribution Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Per-function accuracy map of `stdlib/stats` distribution functions vs mpmath (dps=30), behind a gate, fixing any root-caused defects the map surfaces.
+
+**Architecture:** Reuses the special-function parity harness merged in #1210 — same bit-exact `f64_to_bits` bridge, same `stdlib/parity/emit.sio` (emit1..emit4), same lean_single-locked gate/comparator pattern. A parallel comparator (`stats_parity_ref.py`) holds the distribution reference formulas; a parallel gate (`stats_dist_parity_gate.sh`) drives the stats emitters.
+
+**Tech Stack:** Sounio (`stdlib/stats`, `bin/souc` under `SOUNIO_SOUC_ENGINE=lean_single`), Python 3 + mpmath, bash.
+
+**Spec:** `docs/superpowers/specs/2026-07-19-stats-dist-parity-design.md`
+
+---
+
+## Confirmed signatures & conventions (from `densities.sio`, read during planning)
+
+All distribution fns are `pub` in `stdlib/stats/densities.sio`; discrete ones take
+`k` (and `n`) as **i64**. Two conventions differ from the naïve guess — bake these
+into the reference:
+
+- **gamma is RATE-parameterized:** `gamma_pdf/cdf(x, shape, rate)` computes
+  `shape·ln(rate) − rate·x` → cdf = `P(shape, rate·x)`, pdf = `rate^shape · x^{shape−1} · e^{−rate·x} / Γ(shape)`.
+- **geometric is FROM-0:** `geometric_pmf(k, p) = (1−p)^k · p`, support `k = 0,1,2,…`.
+
+Scalars used (avoid the struct-based `distributions.sio` variants):
+`normal_pdf(x,mu,sigma)`, `normal_cdf_at(x,mu,sigma)`, `standard_normal_cdf(z)`,
+`inverse_standard_normal_cdf(p)`, `exponential_pdf/cdf(x,lambda)`,
+`gamma_pdf/cdf(x,shape,rate)`, `beta_pdf/cdf(x,a,b)`, `lognormal_pdf/cdf(x,mu,sigma)`,
+`uniform_pdf/cdf(x,a,b)`, `poisson_pmf/cdf(k,lambda)`, `binomial_pmf/cdf(k,n,p)`,
+`geometric_pmf(k,p)`.
+
+`standard_normal_cdf` and `inverse_standard_normal_cdf` are in `distributions.sio`;
+the rest are in `densities.sio`.
+
+## Wire format & bridge (reused, unchanged from #1210)
+
+`<fn> <nargs> <arg_bits...> <val_bits>` — each field the signed-i64 IEEE-754 bit
+pattern of the f64 (`f64_to_bits`, a builtin). Discrete `k`/`n` are emitted as
+f64 (`f64_to_bits(3.0)`); Python rounds them back to int for the formula. Bit f64
+on LOCALS in the emitter's `main`; pass i64 to `emit1..emit4`. Everything runs
+under `SOUNIO_SOUC_ENGINE=lean_single`. `print_int` appends a newline → the
+comparator tokenizes the whole stream (whitespace-agnostic).
+
+## File structure
+
+- Create `scripts/parity/stats_parity_ref.py` — mpmath comparator (distribution REF).
+- Create `scripts/stats_dist_parity_gate.sh` — orchestrator.
+- Create `tests/parity/stats_parity_continuous1.sio` — normal/exponential/standard-normal/quantile.
+- Create `tests/parity/stats_parity_continuous2.sio` — gamma/beta.
+- Create `tests/parity/stats_parity_continuous3.sio` — lognormal/uniform.
+- Create `tests/parity/stats_parity_discrete.sio` — poisson/binomial/geometric.
+- Create `docs/research/2026-07-19-stats-dist-parity.md` — the report.
+- Reuse (do NOT modify) `stdlib/parity/emit.sio`.
+
+---
+
+## Task 0: Phase-0 sanity + convention confirmation
+
+**Files:** Create `tests/parity/stats_probe.sio`.
+
+- [ ] **Step 1: Confirm the reused bridge still works under lean_single.**
+
+`tests/parity/stats_probe.sio`:
+```
+//@ run-pass
+use stats::densities::*
+use parity::emit::*
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let v = normal_cdf_at(1.0, 0.0, 1.0)   // ≈ 0.8413447
+    emit3("normal_cdf_at", f64_to_bits(1.0), f64_to_bits(0.0), f64_to_bits(1.0), f64_to_bits(v))
+    return 0
+}
+```
+Run: `export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"; SOUNIO_SOUC_ENGINE=lean_single ./bin/souc compile tests/parity/stats_probe.sio -o /tmp/sp.elf && chmod +x /tmp/sp.elf && /tmp/sp.elf`
+Expected: one line `normal_cdf_at 3 <bits> <bits> <bits> <bits>`. If it won't
+compile/run under lean_single, STOP and report (the reused path is broken).
+
+- [ ] **Step 2: Confirm the two tricky conventions empirically.**
+
+Emit `gamma_cdf(2.0, 2.0, 1.0)` and `geometric_pmf(2, 0.3)` from a scratch program;
+run; decode the bits in Python and compare:
+- gamma_cdf(x=2, shape=2, rate=1): rate form → `mp.gammainc(2,0,1·2,regularized=True)` ≈ 0.5940; scale form would be `gammainc(2,0,2/1)` — same here, so also test `gamma_cdf(2.0, 2.0, 2.0)`: rate → `gammainc(2,0,4)` ≈ 0.9084 vs scale `gammainc(2,0,1)` ≈ 0.2642. Confirm Sounio matches the RATE value.
+- geometric_pmf(k=2, p=0.3): from-0 → `0.7²·0.3 = 0.147`; from-1 → `0.7¹·0.3 = 0.21`. Confirm Sounio = 0.147.
+
+Record both. (Planning already read the source: gamma=rate, geometric=from-0 — this step verifies at runtime.)
+
+- [ ] **Step 3: Commit the probe.**
+```bash
+git add tests/parity/stats_probe.sio
+git commit -m "test(parity): stats Phase-0 probe (bridge reuse + gamma-rate/geometric-from-0 conventions)"
+```
+
+---
+
+## Task 1: mpmath distribution comparator
+
+**Files:** Create `scripts/parity/stats_parity_ref.py`.
+
+- [ ] **Step 1: Write the comparator** (mirrors `scripts/parity/special_parity_ref.py`: whole-stream tokenizer, `bits_to_f64`, `--require-all`, `--selftest`). The distribution `REF`:
+
+```python
+#!/usr/bin/env python3
+"""stats distribution parity vs mpmath (dps=30). Bit-exact wire on stdin:
+`<fn> <nargs> <arg_bits...> <val_bits>` (signed-i64 IEEE-754). No scipy."""
+import sys, struct, math, mpmath as mp
+mp.mp.dps = 30
+def bits_to_f64(f): return struct.unpack('<d', struct.pack('<q', int(f)))[0]
+def _bits(x): return struct.unpack('<q', struct.pack('<d', x))[0]
+SQRT2PI = mp.sqrt(2*mp.pi)
+
+def _norm_pdf(x, mu, s):  z=(x-mu)/s; return mp.e**(-z*z/2)/(s*SQRT2PI)
+def _lognorm_pdf(x, mu, s):
+    if x <= 0: return mp.mpf(0)
+    z=(mp.log(x)-mu)/s; return mp.e**(-z*z/2)/(x*s*SQRT2PI)
+def _gamma_pdf(x, sh, rate):
+    if x <= 0: return mp.mpf(0)
+    return rate**sh * x**(sh-1) * mp.e**(-rate*x) / mp.gamma(sh)
+def _beta_pdf(x, a, b):
+    if x <= 0 or x >= 1: return mp.mpf(0)
+    return x**(a-1)*(1-x)**(b-1)/mp.beta(a,b)
+def _uniform_pdf(x, a, b): return mp.mpf(1)/(b-a) if a <= x <= b else mp.mpf(0)
+def _uniform_cdf(x, a, b): return mp.mpf(0) if x < a else (mp.mpf(1) if x > b else (x-a)/(b-a))
+def _pois_pmf(k, lam): k=int(round(k)); return lam**k * mp.e**(-lam) / mp.factorial(k)
+def _pois_cdf(k, lam): k=int(round(k)); return mp.gammainc(k+1, lam, mp.inf, regularized=True)
+def _binom_pmf(k, n, p):
+    k=int(round(k)); n=int(round(n)); return mp.binomial(n,k)*mp.mpf(p)**k*(1-mp.mpf(p))**(n-k)
+def _binom_cdf(k, n, p):
+    k=int(round(k)); n=int(round(n))
+    if k >= n: return mp.mpf(1)
+    return mp.betainc(n-k, k+1, 0, 1-mp.mpf(p), regularized=True)
+def _geom_pmf(k, p): k=int(round(k)); return (1-mp.mpf(p))**k * p    # FROM-0
+
+REF = {
+    "normal_pdf":    (lambda x,mu,s: _norm_pdf(x,mu,s), 1e-2),
+    "normal_cdf_at": (lambda x,mu,s: mp.ncdf((x-mu)/s), 1e-2),
+    "standard_normal_cdf":         (lambda z: mp.ncdf(z), 1e-2),
+    "inverse_standard_normal_cdf": (lambda p: mp.sqrt(2)*mp.erfinv(2*p-1), 1e-2),
+    "exponential_pdf": (lambda x,l: l*mp.e**(-l*x) if x>=0 else mp.mpf(0), 1e-2),
+    "exponential_cdf": (lambda x,l: 1-mp.e**(-l*x) if x>=0 else mp.mpf(0), 1e-2),
+    "gamma_pdf": (lambda x,sh,r: _gamma_pdf(x,sh,r), 1e-2),
+    "gamma_cdf": (lambda x,sh,r: mp.gammainc(sh,0,r*x,regularized=True) if x>0 else mp.mpf(0), 1e-2),
+    "beta_pdf":  (lambda x,a,b: _beta_pdf(x,a,b), 1e-2),
+    "beta_cdf":  (lambda x,a,b: mp.betainc(a,b,0,x,regularized=True), 1e-2),
+    "lognormal_pdf": (lambda x,mu,s: _lognorm_pdf(x,mu,s), 1e-2),
+    "lognormal_cdf": (lambda x,mu,s: mp.ncdf((mp.log(x)-mu)/s) if x>0 else mp.mpf(0), 1e-2),
+    "uniform_pdf": (lambda x,a,b: _uniform_pdf(x,a,b), 1e-2),
+    "uniform_cdf": (lambda x,a,b: _uniform_cdf(x,a,b), 1e-2),
+    "poisson_pmf": (lambda k,l: _pois_pmf(k,l), 1e-2),
+    "poisson_cdf": (lambda k,l: _pois_cdf(k,l), 1e-2),
+    "binomial_pmf": (lambda k,n,p: _binom_pmf(k,n,p), 1e-2),
+    "binomial_cdf": (lambda k,n,p: _binom_cdf(k,n,p), 1e-2),
+    "geometric_pmf": (lambda k,p: _geom_pmf(k,p), 1e-2),
+}
+
+def main(require_all=False):
+    rows = {}
+    tokens = [t for t in sys.stdin.read().split() if not t.startswith("#")]
+    i, n = 0, 0; N = len(tokens)
+    while i < N:
+        fn = tokens[i]
+        if fn not in REF: i += 1; continue
+        nargs = int(tokens[i+1])
+        args = [bits_to_f64(tokens[i+2+j]) for j in range(nargs)]
+        value = bits_to_f64(tokens[i+2+nargs]); i += 2+nargs+1
+        ref = float(REF[fn][0](*[mp.mpf(a) for a in args]))
+        rel = abs(value-ref)/max(abs(ref),1e-300)
+        rows.setdefault(fn, []).append((args, value, ref, rel))
+    fail = 0
+    print(f"{'function':<26}{'points':>7}{'max_rel_err':>16}  verdict")
+    for fn in REF:
+        pts = rows.get(fn, [])
+        if not pts:
+            print(f"{fn:<26}{0:>7}{'NO DATA':>16}  {'FAIL(no-data)' if require_all else 'SKIP'}")
+            if require_all: fail = 1
+            continue
+        worst = max(pts, key=lambda r: r[3]); mre = worst[3]; thr = REF[fn][1]
+        ok = mre <= thr
+        print(f"{fn:<26}{len(pts):>7}{mre:>16.3e}  {'PASS' if ok else 'FAIL(thr=%.0e)'%thr}")
+        if not ok: fail = 1
+    print("STATS_DIST_PARITY_OK" if not fail else "STATS_DIST_PARITY_FAIL")
+    return fail
+
+def selftest():
+    v = float(mp.ncdf(1.0))
+    line = f"standard_normal_cdf 1 {_bits(1.0)} {_bits(v)}\n"
+    import io; sys.stdin = io.StringIO(line)
+    assert main() == 0, "selftest: standard_normal_cdf(1) should pass"
+    print("STATS_REF_SELFTEST_OK")
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv: selftest()
+    else: sys.exit(main(require_all=("--require-all" in sys.argv)))
+```
+
+- [ ] **Step 2: Positive self-test.** `python3 scripts/parity/stats_parity_ref.py --selftest` → `STATS_REF_SELFTEST_OK`.
+- [ ] **Step 3: Negative test.** `python3 -c "import struct;print('standard_normal_cdf 1', struct.unpack('<q',struct.pack('<d',1.0))[0], struct.unpack('<q',struct.pack('<d',0.5))[0])" | python3 scripts/parity/stats_parity_ref.py` → shows a large err and `STATS_DIST_PARITY_FAIL` (exit 1).
+- [ ] **Step 4: Commit.**
+```bash
+git add scripts/parity/stats_parity_ref.py
+git commit -m "feat(parity): mpmath distribution comparator (stats_parity_ref.py)"
+```
+
+---
+
+## Task 2: continuous group 1 + gate (the proving slice)
+
+**Files:** Create `tests/parity/stats_parity_continuous1.sio`, `scripts/stats_dist_parity_gate.sh`.
+
+- [ ] **Step 1: Emitter** `tests/parity/stats_parity_continuous1.sio` — normal_pdf/normal_cdf_at (from densities), standard_normal_cdf/inverse_standard_normal_cdf (from distributions), exponential_pdf/cdf. Bit LOCALS in main:
+```
+//@ run-pass
+use stats::densities::*
+use stats::distributions::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // standard normal cdf + quantile (1-arg)
+    let zs = [-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 1.96, 2.0]
+    var i = 0
+    while i < 8 {
+        let z = zs[i]
+        let c = standard_normal_cdf(z)
+        emit1("standard_normal_cdf", f64_to_bits(z), f64_to_bits(c))
+        i = i + 1
+    }
+    let ps = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.975]
+    var k = 0
+    while k < 7 {
+        let p = ps[k]
+        let q = inverse_standard_normal_cdf(p)
+        emit1("inverse_standard_normal_cdf", f64_to_bits(p), f64_to_bits(q))
+        k = k + 1
+    }
+    // normal pdf/cdf with (mu,sigma) and exponential with lambda
+    let xs = [-1.0, 0.0, 0.5, 1.0, 2.0]
+    var j = 0
+    while j < 5 {
+        let x = xs[j]
+        let np = normal_pdf(x, 0.0, 1.0)
+        let nc = normal_cdf_at(x, 0.0, 1.0)
+        let np2 = normal_pdf(x, 1.0, 2.0)
+        emit3("normal_pdf", f64_to_bits(x), f64_to_bits(0.0), f64_to_bits(1.0), f64_to_bits(np))
+        emit3("normal_cdf_at", f64_to_bits(x), f64_to_bits(0.0), f64_to_bits(1.0), f64_to_bits(nc))
+        emit3("normal_pdf", f64_to_bits(x), f64_to_bits(1.0), f64_to_bits(2.0), f64_to_bits(np2))
+        j = j + 1
+    }
+    let exs = [0.0, 0.5, 1.0, 2.0, 5.0]
+    var m = 0
+    while m < 5 {
+        let x = exs[m]
+        let ep = exponential_pdf(x, 1.5)
+        let ec = exponential_cdf(x, 1.5)
+        emit2("exponential_pdf", f64_to_bits(x), f64_to_bits(1.5), f64_to_bits(ep))
+        emit2("exponential_cdf", f64_to_bits(x), f64_to_bits(1.5), f64_to_bits(ec))
+        m = m + 1
+    }
+    return 0
+}
+```
+
+- [ ] **Step 2: Gate** `scripts/stats_dist_parity_gate.sh` — clone `scripts/special_scipy_parity_gate.sh`, changing: `REF=scripts/parity/stats_parity_ref.py`, family token → source file map `tests/parity/stats_parity_<fam>.sio`, default families `continuous1 continuous2 continuous3 discrete`, sentinel `STATS_DIST_PARITY_OK`/`STATS_DIST_PARITY_GATE_OK`, `--require-all` unless `REQUIRE_ALL=0`. Keep `export SOUNIO_SOUC_ENGINE=lean_single` and the mpmath SKIP guard. `chmod +x`.
+
+- [ ] **Step 3: Run** `PARITY_FAMILIES="continuous1" REQUIRE_ALL=0 bash scripts/stats_dist_parity_gate.sh`. Paste the table. Expect the 6 functions PASS. **FIX-AS-FOUND:** any fn > 1e-2 → root-cause in the relevant `stdlib/stats/*.sio`; fix if a clear ≈1-line bug (re-verify + no regression in `tests/stdlib/stats/**`), else flag. Convention mismatch → fix the REF, not stdlib. Never loosen a threshold to hide a bug.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add tests/parity/stats_parity_continuous1.sio scripts/stats_dist_parity_gate.sh
+git commit -m "feat(parity): stats continuous group 1 (normal/quantile/exponential) + gate"
+```
+
+---
+
+## Task 3: continuous group 2 — gamma (RATE) + beta
+
+**Files:** Create `tests/parity/stats_parity_continuous2.sio`.
+
+- [ ] **Emitter:** `gamma_pdf/cdf(x, shape, rate)` at (shape,rate) ∈ {(2,1),(2,2),(0.5,1),(5,1)}, x ∈ [0.5,1,2,5] → emit3. `beta_pdf/cdf(x, a, b)` at (a,b) ∈ {(2,3),(0.5,0.5),(5,2)}, x ∈ [0.1,0.25,0.5,0.75,0.9] → emit3. (The REF already encodes gamma-as-rate.)
+- [ ] Run `PARITY_FAMILIES="continuous1 continuous2" REQUIRE_ALL=0 bash scripts/stats_dist_parity_gate.sh`; paste table; fix-as-found; commit `feat(parity): stats gamma(rate)+beta`.
+
+## Task 4: continuous group 3 — lognormal + uniform
+
+**Files:** Create `tests/parity/stats_parity_continuous3.sio`.
+
+- [ ] **Emitter:** `lognormal_pdf/cdf(x, mu, sigma)` at (mu,sigma) ∈ {(0,1),(0,0.5),(1,1)}, x ∈ [0.5,1,2,5] → emit3. `uniform_pdf/cdf(x, a, b)` at (a,b)=(0,1) and (2,5), x spanning below/inside/above support (e.g. [-1,0.5,1.5,3,6]) to exercise the 0/1 clamps → emit3.
+- [ ] Run adding `continuous3`; paste table; fix-as-found; commit `feat(parity): stats lognormal+uniform`.
+
+## Task 5: discrete — poisson + binomial + geometric
+
+**Files:** Create `tests/parity/stats_parity_discrete.sio`.
+
+- [ ] **Emitter (k/n are i64 — call with int literals, emit their f64 form):**
+  - `poisson_pmf/cdf(k, lambda)` at lambda ∈ {1.0, 4.0}, k ∈ {0,1,2,4,8} → `emit2("poisson_pmf", f64_to_bits(0.0), f64_to_bits(lambda), f64_to_bits(poisson_pmf(0, lambda)))` (one call per literal k).
+  - `binomial_pmf/cdf(k, n, p)` at (n,p) ∈ {(10,0.3),(20,0.5)}, k ∈ {0,3,5,10} → emit3 with `f64_to_bits(k_as_float)`, `f64_to_bits(n_as_float)`, `f64_to_bits(p)`.
+  - `geometric_pmf(k, p)` at p ∈ {0.3, 0.5}, k ∈ {0,1,2,5} → emit2. (REF is FROM-0.)
+  Anchors to include: `poisson_pmf(0,λ)=e^{−λ}`, `binomial_pmf(0,n,p)=(1−p)^n`, `geometric_pmf(0,p)=p`.
+- [ ] Run the FULL default gate `bash scripts/stats_dist_parity_gate.sh` (require-all, all 4 groups); paste table; fix-as-found; commit `feat(parity): stats discrete (poisson/binomial/geometric)`.
+
+---
+
+## Task 6: report + final verification
+
+**Files:** Create `docs/research/2026-07-19-stats-dist-parity.md`.
+
+- [ ] **Step 1: Full gate green + coverage.** `bash scripts/stats_dist_parity_gate.sh` → `STATS_DIST_PARITY_GATE_OK`, all ~20 functions present (require-all).
+- [ ] **Step 2: Calibrate thresholds** for any genuine-approximation function above a tight bound (never for a bug — those get fixed or flagged).
+- [ ] **Step 3: Determinism** — two runs identical.
+- [ ] **Step 4: Anchors** — normal_cdf(0)=0.5, geometric_pmf(0,p)=p, poisson_pmf(0,λ)=e^{−λ} at rel_err < 1e-12.
+- [ ] **Step 5: Write the report** (mirror the special report): method (reused bit-exact bridge, mpmath formulas), the full per-function accuracy map, the **convention findings** (gamma=rate, geometric=from-0, and any others), defects found+fixed, reproduce command. Register governance: `node scripts/docs/sync_governance_metadata.mjs`.
+- [ ] **Step 6: Commit** report + governance + any calibrated thresholds.
+
+---
+
+## Notes for the implementer
+
+- `SOUNIO_SOUC_ENGINE=lean_single` for every compile (the gate sets it).
+- No `f64 as string`. Discrete `k`/`n` cross the wire as f64 bits; Python rounds them.
+- Never loosen a threshold to hide a bug. A convention mismatch is a REF fix, not a stdlib fix.
+- Fix-as-found: root-caused ≈1-line stdlib defects fixed in separate `fix(stats):` commits, re-verified, no regression in existing `tests/stdlib/stats/**`.

--- a/docs/superpowers/specs/2026-07-19-stats-dist-parity-design.md
+++ b/docs/superpowers/specs/2026-07-19-stats-dist-parity-design.md
@@ -1,0 +1,117 @@
+<!-- docs:meta
+topic_id: repo.docs.superpowers.specs.2026-07-19-stats-dist-parity-design
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.superpowers.specs.2026-07-19-stats-dist-parity-design
+-->
+
+# stats↔mpmath distribution parity vertical — `stdlib/stats`
+
+**Status:** design (approved 2026-07-19)
+**Owner:** Data & Science verticals
+**Reuses:** the special-function parity harness merged in PR #1210
+(`stdlib/parity/emit.sio`, the bit-exact bridge, the gate/comparator pattern).
+See `docs/research/2026-07-19-special-scipy-parity.md`.
+
+## 1. Goal
+
+An honest, reproducible per-function accuracy map of Sounio's **probability
+distribution** functions (`stdlib/stats/densities.sio`, `distributions.sio`)
+against an arbitrary-precision **mpmath (dps=30)** reference, computed from each
+distribution's closed-form definition. Same philosophy as the special vertical:
+measure the genuine achieved accuracy vs ground truth, gate on it, and fix any
+root-caused defects the map surfaces. mpmath is the reference `scipy.stats` is
+itself validated against (scipy is not installed).
+
+## 2. Scope — the catalog (~18–20 functions)
+
+| Distribution | File | Functions | mpmath reference (formula) |
+|---|---|---|---|
+| normal | densities/distributions | `normal_pdf(x,μ,σ)`, `normal_cdf`/`normal_cdf_at` | pdf `exp(−z²/2)/(σ√(2π))`; cdf `mp.ncdf((x−μ)/σ)` |
+| normal quantile | distributions | `inverse_standard_normal_cdf(p)` | `mp.sqrt(2)·mp.erfinv(2p−1)` |
+| exponential | densities | `exponential_pdf(x,λ)`, `exponential_cdf` | pdf `λe^{−λx}`; cdf `1−e^{−λx}` |
+| gamma | densities | `gamma_pdf(x,k,θ)`, `gamma_cdf` | pdf via `mp.gamma`; cdf `mp.gammainc(k,0,x/θ,regularized=True)` |
+| beta | densities/distributions | `beta_pdf(x,a,b)`, `beta_cdf` | pdf via `mp.beta`; cdf `mp.betainc(a,b,0,x,regularized=True)` |
+| lognormal | densities | `lognormal_pdf(x,μ,σ)`, `lognormal_cdf` | pdf `exp(−(ln x−μ)²/2σ²)/(xσ√(2π))`; cdf `mp.ncdf((ln x−μ)/σ)` |
+| uniform | densities | `uniform_pdf(x,a,b)`, `uniform_cdf` | pdf `1/(b−a)` on [a,b]; cdf `(x−a)/(b−a)` clamped |
+| poisson | densities | `poisson_pmf(k,λ)`, `poisson_cdf` | pmf `λ^k e^{−λ}/k!`; cdf `mp.gammainc(k+1,λ,∞,regularized=True)` |
+| binomial | densities | `binomial_pmf(k,n,p)`, `binomial_cdf` | pmf `C(n,k)p^k(1−p)^{n−k}`; cdf `mp.betainc(n−k,k+1,0,1−p,regularized=True)` |
+| geometric | densities | `geometric_pmf(k,p)` | pmf `(1−p)^{k−1}p` (verify k-convention: from-1 vs from-0) |
+
+Exact names/signatures/parameter conventions are confirmed per file during
+implementation (`git grep -nE '^\s*(pub )?fn ' stdlib/stats/<file>.sio`). The
+functions in these files are `pub`, but the vertical still runs under
+`lean_single` (the bit-exact `f64_to_bits` bridge requires it).
+
+**Out of scope:** hypothesis tests, descriptive stats, survival/hazard,
+Bayesian, correlation — the ~430 other stats pubs. Only the distribution
+`pdf/cdf/pmf/quantile` surface. `t`/`F`/`χ²` distribution CDFs are not in
+`stdlib/stats` (χ² lives in `stdlib/special` as `chi2_cdf`, already mapped in
+#1210); if any turn up during implementation, add them, else note their absence.
+
+## 3. Convention checks (WILL bite — verify empirically before trusting a ref)
+
+- **Parameterization:** gamma `(k,θ)` shape-scale vs `(α,β)` shape-rate; exponential
+  `λ` rate vs mean; normal/lognormal `σ` std vs variance. Read each Sounio fn and
+  match the mpmath formula to ITS convention (compare one known value).
+- **Discrete support:** geometric `k` from 1 (`(1−p)^{k−1}p`) vs from 0
+  (`(1−p)^k p`); binomial/poisson cdf inclusive of `k`.
+- **CDF edge clamping:** uniform/beta outside support → 0/1.
+
+Each mismatch between the Sounio fn and the chosen mpmath ref is a REFERENCE fix
+(match the code's convention), NOT a Sounio bug — as in the special vertical.
+
+## 4. Architecture — reuse the special harness
+
+1. **Bit-exact bridge (unchanged):** the Sounio emitter prints IEEE-754 bit
+   patterns (`f64_to_bits`, `print_int` builtins) as i64; wire
+   `<fn> <nargs> <arg_bits...> <val_bits>`. Bit f64 on LOCALS in `main`, i64 to
+   `emit1..emit4` (already in `stdlib/parity/emit.sio` from #1210).
+2. **Comparator** `scripts/parity/stats_parity_ref.py` — a parallel copy of the
+   special comparator's structure with a distributions `REF` (fn → mpmath-formula
+   lambda + gross threshold), the whole-stream tokenizer, `--require-all`
+   coverage assertion, and a `--selftest`. mpmath only; no scipy.
+3. **Emitters** `tests/parity/stats_parity_<group>.sio` (one per small group of
+   distributions to keep imports clean), `use stats::densities::*` etc.
+4. **Gate** `scripts/stats_dist_parity_gate.sh` — mirrors
+   `special_scipy_parity_gate.sh`: `SOUNIO_SOUC_ENGINE=lean_single`, compile+run
+   emitters, pipe to the comparator with `--require-all`, emit
+   `STATS_DIST_PARITY_GATE_OK`. Deterministic; dev-tier (needs mpmath).
+5. **Report** `docs/research/2026-07-19-stats-dist-parity.md` — the full
+   per-function accuracy map, convention notes, any defects found+fixed.
+
+## 5. Tolerance philosophy (same as special)
+
+Measure the genuine `max_rel_err` per function; fail loudly only on gross error
+(> 1e-2, likely a bug); calibrate a function's threshold to its real accuracy
+only after confirming it's an approximation, never to hide a bug; exact anchors
+(e.g. `normal_cdf(μ)=0.5`, `uniform_cdf` midpoints, `poisson_pmf(0,λ)=e^{−λ}`)
+held tight. **Fix-as-found:** root-caused ≈1-line defects are fixed in
+`stdlib/stats/*.sio` (separate `fix(stats):` commits, re-verified, no regression
+in existing `tests/stdlib/stats/**`); non-trivial ones are flagged in the report.
+
+## 6. Point sets
+
+Per function, representative points across the parameter domain: interior
+typical, near support boundaries (documented margin), a couple parameter sets per
+distribution (e.g. gamma at (k,θ) ∈ {(2,1),(0.5,2),(5,1)}), and known exact
+anchors. Discrete: k over 0..n and around the mean. ~8–20 points per function.
+Arguments chosen so bit-exact round-trip is exact (any f64 works via `f64_to_bits`).
+
+## 7. Non-goals
+
+- Not the non-distribution stats surface (tests, descriptive, survival, Bayesian).
+- Not installing scipy (mpmath is the reference).
+- Nothing ships into the prebuilt compiler; stdlib fixes reach users on the
+  normal build path.
+
+## 8. Verification of the vertical
+
+- Phase-0 sanity: the reused bridge/emit path still works (a 1-point normal_cdf
+  emitter round-trips) under lean_single.
+- Gate emits `STATS_DIST_PARITY_GATE_OK`; coverage-complete (`--require-all`);
+  deterministic across runs.
+- ≥3 exact anchors pass at 1e-12.
+- Existing `tests/stdlib/stats/**` for any fix-touched file stay green.

--- a/scripts/parity/stats_parity_ref.py
+++ b/scripts/parity/stats_parity_ref.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""stats distribution parity vs mpmath (dps=30). Bit-exact wire on stdin:
+`<fn> <nargs> <arg_bits...> <val_bits>` (signed-i64 IEEE-754). No scipy."""
+import sys, struct, math, mpmath as mp
+mp.mp.dps = 30
+def bits_to_f64(f): return struct.unpack('<d', struct.pack('<q', int(f)))[0]
+def _bits(x): return struct.unpack('<q', struct.pack('<d', x))[0]
+SQRT2PI = mp.sqrt(2*mp.pi)
+
+def _norm_pdf(x, mu, s):  z=(x-mu)/s; return mp.e**(-z*z/2)/(s*SQRT2PI)
+def _lognorm_pdf(x, mu, s):
+    if x <= 0: return mp.mpf(0)
+    z=(mp.log(x)-mu)/s; return mp.e**(-z*z/2)/(x*s*SQRT2PI)
+def _gamma_pdf(x, sh, rate):
+    if x <= 0: return mp.mpf(0)
+    return rate**sh * x**(sh-1) * mp.e**(-rate*x) / mp.gamma(sh)
+def _beta_pdf(x, a, b):
+    if x <= 0 or x >= 1: return mp.mpf(0)
+    return x**(a-1)*(1-x)**(b-1)/mp.beta(a,b)
+def _uniform_pdf(x, a, b): return mp.mpf(1)/(b-a) if a <= x <= b else mp.mpf(0)
+def _uniform_cdf(x, a, b): return mp.mpf(0) if x < a else (mp.mpf(1) if x > b else (x-a)/(b-a))
+def _pois_pmf(k, lam): k=int(round(k)); return lam**k * mp.e**(-lam) / mp.factorial(k)
+def _pois_cdf(k, lam): k=int(round(k)); return mp.gammainc(k+1, lam, mp.inf, regularized=True)
+def _binom_pmf(k, n, p):
+    k=int(round(k)); n=int(round(n)); return mp.binomial(n,k)*mp.mpf(p)**k*(1-mp.mpf(p))**(n-k)
+def _binom_cdf(k, n, p):
+    k=int(round(k)); n=int(round(n))
+    if k >= n: return mp.mpf(1)
+    return mp.betainc(n-k, k+1, 0, 1-mp.mpf(p), regularized=True)
+def _geom_pmf(k, p): k=int(round(k)); return (1-mp.mpf(p))**k * p    # FROM-0
+
+REF = {
+    "normal_pdf":    (lambda x,mu,s: _norm_pdf(x,mu,s), 1e-2),
+    "normal_cdf_at": (lambda x,mu,s: mp.ncdf((x-mu)/s), 1e-2),
+    "standard_normal_cdf":         (lambda z: mp.ncdf(z), 1e-2),
+    "inverse_standard_normal_cdf": (lambda p: mp.sqrt(2)*mp.erfinv(2*p-1), 1e-2),
+    "exponential_pdf": (lambda x,l: l*mp.e**(-l*x) if x>=0 else mp.mpf(0), 1e-2),
+    "exponential_cdf": (lambda x,l: 1-mp.e**(-l*x) if x>=0 else mp.mpf(0), 1e-2),
+    "gamma_pdf": (lambda x,sh,r: _gamma_pdf(x,sh,r), 1e-2),
+    "gamma_cdf": (lambda x,sh,r: mp.gammainc(sh,0,r*x,regularized=True) if x>0 else mp.mpf(0), 1e-2),
+    "beta_pdf":  (lambda x,a,b: _beta_pdf(x,a,b), 1e-2),
+    "beta_cdf":  (lambda x,a,b: mp.betainc(a,b,0,x,regularized=True), 1e-2),
+    "lognormal_pdf": (lambda x,mu,s: _lognorm_pdf(x,mu,s), 1e-2),
+    "lognormal_cdf": (lambda x,mu,s: mp.ncdf((mp.log(x)-mu)/s) if x>0 else mp.mpf(0), 1e-2),
+    "uniform_pdf": (lambda x,a,b: _uniform_pdf(x,a,b), 1e-2),
+    "uniform_cdf": (lambda x,a,b: _uniform_cdf(x,a,b), 1e-2),
+    "poisson_pmf": (lambda k,l: _pois_pmf(k,l), 1e-2),
+    "poisson_cdf": (lambda k,l: _pois_cdf(k,l), 1e-2),
+    "binomial_pmf": (lambda k,n,p: _binom_pmf(k,n,p), 1e-2),
+    "binomial_cdf": (lambda k,n,p: _binom_cdf(k,n,p), 1e-2),
+    "geometric_pmf": (lambda k,p: _geom_pmf(k,p), 1e-2),
+}
+
+def main(require_all=False):
+    rows = {}
+    tokens = [t for t in sys.stdin.read().split() if not t.startswith("#")]
+    i = 0; N = len(tokens)
+    while i < N:
+        fn = tokens[i]
+        if fn not in REF: i += 1; continue
+        nargs = int(tokens[i+1])
+        args = [bits_to_f64(tokens[i+2+j]) for j in range(nargs)]
+        value = bits_to_f64(tokens[i+2+nargs]); i += 2+nargs+1
+        ref = float(REF[fn][0](*[mp.mpf(a) for a in args]))
+        rel = abs(value-ref)/max(abs(ref),1e-300)
+        rows.setdefault(fn, []).append((args, value, ref, rel))
+    fail = 0
+    print(f"{'function':<26}{'points':>7}{'max_rel_err':>16}  verdict")
+    for fn in REF:
+        pts = rows.get(fn, [])
+        if not pts:
+            print(f"{fn:<26}{0:>7}{'NO DATA':>16}  {'FAIL(no-data)' if require_all else 'SKIP'}")
+            if require_all: fail = 1
+            continue
+        worst = max(pts, key=lambda r: r[3]); mre = worst[3]; thr = REF[fn][1]
+        ok = mre <= thr
+        print(f"{fn:<26}{len(pts):>7}{mre:>16.3e}  {'PASS' if ok else 'FAIL(thr=%.0e)'%thr}")
+        if not ok: fail = 1
+    print("STATS_DIST_PARITY_OK" if not fail else "STATS_DIST_PARITY_FAIL")
+    return fail
+
+def selftest():
+    v = float(mp.ncdf(1.0))
+    line = f"standard_normal_cdf 1 {_bits(1.0)} {_bits(v)}\n"
+    import io; sys.stdin = io.StringIO(line)
+    assert main() == 0, "selftest: standard_normal_cdf(1) should pass"
+    print("STATS_REF_SELFTEST_OK")
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv: selftest()
+    else: sys.exit(main(require_all=("--require-all" in sys.argv)))

--- a/scripts/stats_dist_parity_gate.sh
+++ b/scripts/stats_dist_parity_gate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# stats↔mpmath distribution parity gate. Reference = mpmath (dps=30).
+# lean_single-LOCKED (reuses the #1210 bit-exact bridge). Dev-tier; not in ci.yml.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+export SOUNIO_SOUC_ENGINE=lean_single
+SOUC="${SOUNIO_TEST_SOUC_BIN:-./bin/souc}"
+REF="scripts/parity/stats_parity_ref.py"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+python3 -c 'import mpmath' 2>/dev/null || { echo "SKIP: mpmath not installed"; exit 0; }
+
+emit_all() { : > "$OUT/emit.txt"
+  for fam in "$@"; do
+    src="tests/parity/stats_parity_${fam}.sio"
+    if ! "$SOUC" compile "$src" -o "$OUT/$fam.elf" >/dev/null 2>&1; then
+      echo "FAIL compile $src"; return 1; fi
+    chmod +x "$OUT/$fam.elf"; "$OUT/$fam.elf" >> "$OUT/emit.txt" 2>/dev/null || { echo "FAIL run $src"; return 1; }
+  done
+}
+
+FAMILIES="${PARITY_FAMILIES:-continuous1 stdnormal continuous2 continuous3 discrete}"
+REQ=""; [ "${REQUIRE_ALL:-1}" = "1" ] && REQ="--require-all"
+emit_all $FAMILIES || exit 1
+python3 "$REF" $REQ < "$OUT/emit.txt" | tee "$OUT/report.txt"
+grep -q "STATS_DIST_PARITY_OK" "$OUT/report.txt" \
+  && echo "STATS_DIST_PARITY_GATE_OK" || { echo "GATE FAILED"; exit 1; }

--- a/stdlib/stats/distributions.sio
+++ b/stdlib/stats/distributions.sio
@@ -92,7 +92,9 @@ pub fn standard_normal_cdf(z: f64) -> f64 with Mut, Div, Panic {
     let a4 = -1.453152027
     let a5 = 1.061405429
 
-    let abs_z = dist_abs(z)
+    // This is the A&S 7.1.26 rational approximation for erf(u); the normal
+    // CDF is Phi(z) = 0.5*(1+erf(z/sqrt2)), so u = |z|/sqrt(2), not |z|.
+    let abs_z = dist_abs(z) / 1.4142135623730951
     let t = 1.0 / (1.0 + p * abs_z)
     let t2 = t * t
     let t3 = t2 * t

--- a/tests/parity/stats_parity_continuous1.sio
+++ b/tests/parity/stats_parity_continuous1.sio
@@ -1,0 +1,29 @@
+//@ run-pass
+use stats::densities::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let xs = [-1.0, 0.0, 0.5, 1.0, 2.0]
+    var j = 0
+    while j < 5 {
+        let x = xs[j]
+        let np = normal_pdf(x, 0.0, 1.0)
+        let nc = normal_cdf_at(x, 0.0, 1.0)
+        let np2 = normal_pdf(x, 1.0, 2.0)
+        emit3("normal_pdf", f64_to_bits(x), f64_to_bits(0.0), f64_to_bits(1.0), f64_to_bits(np))
+        emit3("normal_cdf_at", f64_to_bits(x), f64_to_bits(0.0), f64_to_bits(1.0), f64_to_bits(nc))
+        emit3("normal_pdf", f64_to_bits(x), f64_to_bits(1.0), f64_to_bits(2.0), f64_to_bits(np2))
+        j = j + 1
+    }
+    let exs = [0.0, 0.5, 1.0, 2.0, 5.0]
+    var m = 0
+    while m < 5 {
+        let x = exs[m]
+        let ep = exponential_pdf(x, 1.5)
+        let ec = exponential_cdf(x, 1.5)
+        emit2("exponential_pdf", f64_to_bits(x), f64_to_bits(1.5), f64_to_bits(ep))
+        emit2("exponential_cdf", f64_to_bits(x), f64_to_bits(1.5), f64_to_bits(ec))
+        m = m + 1
+    }
+    return 0
+}

--- a/tests/parity/stats_parity_continuous2.sio
+++ b/tests/parity/stats_parity_continuous2.sio
@@ -1,0 +1,43 @@
+//@ run-pass
+use stats::densities::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let gsh = [2.0, 2.0, 0.5, 5.0]
+    let grt = [1.0, 2.0, 1.0, 1.0]
+    let gx = [0.5, 1.0, 2.0, 5.0]
+    var i = 0
+    while i < 4 {
+        let sh = gsh[i]
+        let rt = grt[i]
+        var j = 0
+        while j < 4 {
+            let x = gx[j]
+            let gp = gamma_pdf(x, sh, rt)
+            let gc = gamma_cdf(x, sh, rt)
+            emit3("gamma_pdf", f64_to_bits(x), f64_to_bits(sh), f64_to_bits(rt), f64_to_bits(gp))
+            emit3("gamma_cdf", f64_to_bits(x), f64_to_bits(sh), f64_to_bits(rt), f64_to_bits(gc))
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let ba = [2.0, 0.5, 5.0]
+    let bb = [3.0, 0.5, 2.0]
+    let bx = [0.1, 0.25, 0.5, 0.75, 0.9]
+    var k = 0
+    while k < 3 {
+        let a = ba[k]
+        let b = bb[k]
+        var m = 0
+        while m < 5 {
+            let x = bx[m]
+            let bp = beta_pdf(x, a, b)
+            let bc = beta_cdf(x, a, b)
+            emit3("beta_pdf", f64_to_bits(x), f64_to_bits(a), f64_to_bits(b), f64_to_bits(bp))
+            emit3("beta_cdf", f64_to_bits(x), f64_to_bits(a), f64_to_bits(b), f64_to_bits(bc))
+            m = m + 1
+        }
+        k = k + 1
+    }
+    return 0
+}

--- a/tests/parity/stats_parity_continuous3.sio
+++ b/tests/parity/stats_parity_continuous3.sio
@@ -1,0 +1,43 @@
+//@ run-pass
+use stats::densities::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let lmu = [0.0, 0.0, 1.0]
+    let lsg = [1.0, 0.5, 1.0]
+    let lx = [0.5, 1.0, 2.0, 5.0]
+    var i = 0
+    while i < 3 {
+        let mu = lmu[i]
+        let sg = lsg[i]
+        var j = 0
+        while j < 4 {
+            let x = lx[j]
+            let lp = lognormal_pdf(x, mu, sg)
+            let lc = lognormal_cdf(x, mu, sg)
+            emit3("lognormal_pdf", f64_to_bits(x), f64_to_bits(mu), f64_to_bits(sg), f64_to_bits(lp))
+            emit3("lognormal_cdf", f64_to_bits(x), f64_to_bits(mu), f64_to_bits(sg), f64_to_bits(lc))
+            j = j + 1
+        }
+        i = i + 1
+    }
+    let ua = [0.0, 2.0]
+    let ub = [1.0, 5.0]
+    let ux = [-1.0, 0.5, 1.5, 3.0, 6.0]
+    var k = 0
+    while k < 2 {
+        let a = ua[k]
+        let b = ub[k]
+        var m = 0
+        while m < 5 {
+            let x = ux[m]
+            let up = uniform_pdf(x, a, b)
+            let uc = uniform_cdf(x, a, b)
+            emit3("uniform_pdf", f64_to_bits(x), f64_to_bits(a), f64_to_bits(b), f64_to_bits(up))
+            emit3("uniform_cdf", f64_to_bits(x), f64_to_bits(a), f64_to_bits(b), f64_to_bits(uc))
+            m = m + 1
+        }
+        k = k + 1
+    }
+    return 0
+}

--- a/tests/parity/stats_parity_discrete.sio
+++ b/tests/parity/stats_parity_discrete.sio
@@ -1,0 +1,59 @@
+//@ run-pass
+use stats::densities::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let lams = [1.0, 4.0]
+    let pk = [0, 1, 2, 4, 8]
+    var li = 0
+    while li < 2 {
+        let lam = lams[li]
+        var ki = 0
+        while ki < 5 {
+            let k = pk[ki]
+            let pm = poisson_pmf(k, lam)
+            let pc = poisson_cdf(k, lam)
+            let kf = k as f64
+            emit2("poisson_pmf", f64_to_bits(kf), f64_to_bits(lam), f64_to_bits(pm))
+            emit2("poisson_cdf", f64_to_bits(kf), f64_to_bits(lam), f64_to_bits(pc))
+            ki = ki + 1
+        }
+        li = li + 1
+    }
+    let bn = [10, 20]
+    let bp = [0.3, 0.5]
+    let bk = [0, 3, 5, 10]
+    var bi = 0
+    while bi < 2 {
+        let n = bn[bi]
+        let p = bp[bi]
+        var kj = 0
+        while kj < 4 {
+            let k = bk[kj]
+            let bpm = binomial_pmf(k, n, p)
+            let bcm = binomial_cdf(k, n, p)
+            let kf = k as f64
+            let nf = n as f64
+            emit3("binomial_pmf", f64_to_bits(kf), f64_to_bits(nf), f64_to_bits(p), f64_to_bits(bpm))
+            emit3("binomial_cdf", f64_to_bits(kf), f64_to_bits(nf), f64_to_bits(p), f64_to_bits(bcm))
+            kj = kj + 1
+        }
+        bi = bi + 1
+    }
+    let gpv = [0.3, 0.5]
+    let gk = [0, 1, 2, 5]
+    var gi = 0
+    while gi < 2 {
+        let p = gpv[gi]
+        var km = 0
+        while km < 4 {
+            let k = gk[km]
+            let gm = geometric_pmf(k, p)
+            let kf = k as f64
+            emit2("geometric_pmf", f64_to_bits(kf), f64_to_bits(p), f64_to_bits(gm))
+            km = km + 1
+        }
+        gi = gi + 1
+    }
+    return 0
+}

--- a/tests/parity/stats_parity_stdnormal.sio
+++ b/tests/parity/stats_parity_stdnormal.sio
@@ -1,0 +1,31 @@
+//@ run-pass
+// Sibling of stats_parity_continuous1: standard_normal_cdf / inverse_standard_normal_cdf
+// live in stats::distributions, which also defines its own struct-typed
+// normal_pdf(NormalDist, x) / beta_pdf(BetaDist, x). Bundling stats::distributions
+// together with stats::densities in one compile unit collides on those shared
+// bare names (the bundler's flat symbol table doesn't disambiguate two
+// same-named pub fns of different arity across modules) and breaks
+// distributions.sio's own internal self-tests. Kept in a separate family file
+// so this module never bundles with stats::densities.
+use stats::distributions::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let zs = [-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 1.96, 2.0]
+    var i = 0
+    while i < 8 {
+        let z = zs[i]
+        let c = standard_normal_cdf(z)
+        emit1("standard_normal_cdf", f64_to_bits(z), f64_to_bits(c))
+        i = i + 1
+    }
+    let ps = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.975]
+    var k = 0
+    while k < 7 {
+        let p = ps[k]
+        let q = inverse_standard_normal_cdf(p)
+        emit1("inverse_standard_normal_cdf", f64_to_bits(p), f64_to_bits(q))
+        k = k + 1
+    }
+    return 0
+}

--- a/tests/parity/stats_probe.sio
+++ b/tests/parity/stats_probe.sio
@@ -1,0 +1,23 @@
+//@ run-pass
+use stats::densities::*
+use parity::emit::*
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // Step 1: bridge sanity — normal_cdf_at(1,0,1) should be Phi(1) ~= 0.8413447
+    let v = normal_cdf_at(1.0, 0.0, 1.0)
+    emit3("normal_cdf_at", f64_to_bits(1.0), f64_to_bits(0.0), f64_to_bits(1.0), f64_to_bits(v))
+
+    // Step 2: gamma_cdf convention (rate vs scale)
+    let gv = gamma_cdf(2.0, 2.0, 2.0)
+    emit3("gamma_cdf", f64_to_bits(2.0), f64_to_bits(2.0), f64_to_bits(2.0), f64_to_bits(gv))
+
+    // Step 2: geometric_pmf convention (from-0 vs from-1)
+    let pv = geometric_pmf(2, 0.3)
+    emit2("geometric_pmf", f64_to_bits(2.0), f64_to_bits(0.3), f64_to_bits(pv))
+
+    // Step 2: poisson_pmf anchor sanity
+    let ppv = poisson_pmf(0, 2.0)
+    emit2("poisson_pmf", f64_to_bits(0.0), f64_to_bits(2.0), f64_to_bits(ppv))
+
+    return 0
+}


### PR DESCRIPTION
## What

A per-function accuracy map of `stdlib/stats` **probability distributions** vs an arbitrary-precision **mpmath (dps=30)** reference (computed from each distribution's closed form) — the ground truth `scipy.stats` is validated against (scipy not installed). **19 functions across 9 distributions**, all green under a deterministic, coverage-complete gate. Reuses the special-function parity harness from #1210.

## Defect found & fixed

**`standard_normal_cdf`** applied the Abramowitz & Stegun 7.1.26 erf approximation to `|z|` instead of `|z|/√2` — computing `0.5(1+erf(|z|))` instead of `Φ(z)=0.5(1+erf(z/√2))`. The standard normal CDF was **~90 % wrong** (max_rel_err **8.97e-01**), a load-bearing function across the stats module. One-line fix → **3.04e-06**; no regression in `tests/stdlib/stats/test_distributions.sio`. (`fix(stats): scale by 1/sqrt(2) …`, reaches users on the normal build path.)

## Coverage (all PASS vs mpmath dps=30)

normal pdf/cdf (3.9e-16 / 7e-8), standard_normal_cdf 3e-6, normal quantile 2.6e-8, exponential pdf/cdf (~1e-16), gamma[**rate**] pdf/cdf (2e-15 / 8e-13), beta pdf/cdf (~1e-15), lognormal pdf/cdf (6e-16 / 7e-7), uniform pdf/cdf (0), poisson pmf/cdf (3e-15 / 1e-12), binomial pmf/cdf (~1e-14), geometric[**from-0**] pmf (1e-15). Full table + method in `docs/research/2026-07-19-stats-dist-parity.md`.

## Also surfaced (worked around, flagged for a separate fix)

The **lean_single bundler flat-symbol-table defect**: importing both `stats::densities` and `stats::distributions` in one compile unit collides (both define same-named different-arity `normal_pdf`/`beta_pdf`; fully-qualified call syntax unsupported). Worked around by one-module-per-emitter — no stdlib API change. Worth a dedicated compiler fix.

## Infra (tests/scripts/docs only — nothing ships into the prebuilt)

`scripts/parity/stats_parity_ref.py` (mpmath distribution comparator, `--require-all` coverage + `--selftest`), `scripts/stats_dist_parity_gate.sh` (→ `STATS_DIST_PARITY_GATE_OK`, lean_single-locked, deterministic), `tests/parity/stats_parity_*.sio` emitters (reuse `stdlib/parity/emit.sio` unchanged). Conventions verified in Phase 0: gamma=rate, geometric=from-0. Dev-tier (needs mpmath); not wired into ci.yml.