### PR TITLE
docs(handoff): correct sqrt dispatch — P0 CORRECTNESS bug (wrong for large args), not just slow

### DIFF
--- a/docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md
+++ b/docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md
@@ -7,75 +7,74 @@ validated_by: A2
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.handoff.souc-sqrt-extern-to-sqrtsd-codex-dispatch-2026-07-19
 -->
 
-# Dispatch to CODEX-2 — `sqrt` is an extern libc call (~244 ns/element), not the hardware `sqrtsd` instruction
+# Dispatch to CODEX-2 — `sqrt` is WRONG for large arguments (P0 correctness) and also slow
+
+> **UPDATED 2026-07-19 — this is now a P0 CORRECTNESS bug, not just a perf issue.** The original
+> version of this dispatch claimed `sqrt` was "bit-identical to libm, just an extern call, ~244 ns."
+> That was **wrong**: `sqrt(x)` returns a **numerically incorrect result for |x| ≳ 1e6**. Do NOT preserve
+> the current behaviour. The perf ask (lower to `sqrtsd`) is retained below because the correct hardware
+> instruction fixes *both* the correctness and the speed at once.
 
 **Date:** 2026-07-19
 **Owner:** CODEX-2 (compiler back-end / codegen for math builtins; `self-hosted/`)
-**Author:** data-science lane (surfaced building `data::bigframe_ops::bf_expanding_std`)
-**Status:** confirmed perf defect, minimal repro + microbenchmark included — codegen, low blast radius
+**Author:** data-science lane (surfaced while validating `bf_corr` on large-magnitude columns)
+**Status:** confirmed P0 correctness defect + perf defect, minimal repro included
 
 ---
 
 ## TL;DR
 
-Sounio's `sqrt(x: f64) -> f64` is lowered as an **extern libc/libm call** (through the PLT, with
-full call-site register save/restore), costing **~244 ns per element**. The correct lowering is a
-single hardware instruction — `sqrtsd` on x86-64, `fsqrt` on arm64 — which is ~**1–4 ns** and
-already correctly-rounded IEEE-754 (bit-identical to libm `sqrt`). This one call sits on the hot path
-of *every* statistical / geometric verb, so fixing it is a broad, cheap win with zero accuracy change.
+`sqrt(x: f64) -> f64` is **correct for small `x` (≲ 1e6) but silently returns a wrong value for large
+`x`** — e.g. `sqrt(1e12)` gives `1279996.5` instead of `1000000`, `sqrt(1e20)` gives `9.54e13` instead
+of `1e10`. The magnitude of the error grows with `x`. This is a **silent-wrong** result (no crash, no
+NaN), so it corrupts any statistic whose intermediate exceeds ~1e6 without any signal. It is *also*
+slow (~244 ns/call vs a ~1–4 ns hardware instruction). Lowering the f64 `sqrt` builtin to the hardware
+`sqrtsd` (x86-64) / `fsqrt` (arm64) instruction fixes **both** — `sqrtsd` is IEEE-754 correctly-rounded
+at every magnitude.
 
-## Evidence (reproducible now)
+## Evidence — correctness (reproducible now, `lean_single` engine)
 
-**1. Microbenchmark — 30,000,000 `sqrt` calls in a tight loop:**
+`sqrt(<v>)` vs CPython `math.sqrt`:
 
-| variant | time | per call |
-|---|---|---|
-| `sqrt(x)` (current extern) | **7336 ms** | **~244 ns** |
-| inline Newton–Raphson (bit-hack seed + 5 iters, no call) | 1579 ms | ~52 ns |
-
-The inline version does *more* floating-point work (5 iterations of `0.5*(y + x/y)`) yet is **~5×
-faster** — because it has no call. That isolates the cost as **call-site overhead**, not the math.
-(The hardware `sqrtsd` would beat both by another ~10×.)
-
-**2. End-to-end — `data::bigframe_ops` expanding stats over 1,000,000 rows:**
-
-| op | Sounio | pandas | ratio |
+| input `v` | `sqrt(v)` (souc) | correct | status |
 |---|---|---|---|
-| `bf_expanding_var` (Welford, no sqrt) | 14.9 ms | 14.9 ms | **1.00× (parity)** |
-| `bf_expanding_std` (**same Welford + one `sqrt` per row**) | **256 ms** | 19.7 ms | **13.0×** |
+| 4 | 2 | 2 | ok |
+| 100 | 10 | 10 | ok |
+| 1e6 | 1000 | 1000 | ok (boundary) |
+| **1e12** | **1279996.53** | **1000000** | **WRONG** |
+| **2.5e19** | **2.384e13** | **5e9** | **WRONG** |
+| **1e20** | **9.537e13** | **1e10** | **WRONG** |
+| **2.777778e28** | **2.649e22** | **1.667e14** | **WRONG** |
+| **1e30** | **9.537e23** | **1e15** | **WRONG** |
 
-`var` and `std` are the identical single-pass Welford recurrence; the *only* difference is the
-per-element `sqrt`. It alone turns a parity result into a 13× loss.
-
-## Repro programs (either engine; lean_single shown)
-
-Extern (hot):
+Repro (either engine that compiles it; confirmed on `lean_single`):
 ```
-fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
-    var acc = 0.0; var i: i64 = 0
-    while i < 30000000 { acc = acc + sqrt((i%1000+1) as f64); i = i + 1 }
-    print(acc); print("\n"); return 0
+fn main() -> i32 with IO, Mut, Panic, Div {
+    print(sqrt(1000000000000.0)); print(" "); print(sqrt(1e20)); print("\n"); return 0
 }
+// prints "1279996.526738 95367431990150.328125"; correct is "1000000 10000000000"
 ```
-Inline Newton (for the ~5× comparison; needs an 8-byte scratch cell for the bit reinterpret):
-```
-fn nsqrt(x: f64, scratch: *mut f64) -> f64 with Mut, Div, Panic {
-    if x <= 0.0 { return 0.0 }
-    let b = f64_to_bits(x); let s = (b >> 1) + 2303591209400008704
-    write_i64(scratch as *mut i64, 0, s); var y = read_f64(scratch, 0)
-    y = 0.5*(y + x/y); y = 0.5*(y + x/y); y = 0.5*(y + x/y); y = 0.5*(y + x/y); y = 0.5*(y + x/y)
-    y
-}
-```
-Build: `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc compile f.sio -o out && ./out`, then `time ./out`.
+(On the default `madaros` engine this exact single-file probe hit an unrelated `E137` at compile; the
+correctness bug is confirmed on `lean_single`, which is the engine the data stack uses. Please also
+check `madaros` once it compiles.)
 
-## Root-cause hypothesis
+## Evidence — end-to-end impact
 
-`sqrt` resolves to a global builtin that the back-end emits as an **extern function call** (libm
-`sqrt`) rather than an intrinsic. The `x86-64` codegen already emits inline instruction sequences for
-other primitives (e.g. `emit_memcpy_a64` at `self-hosted/compiler/lean_single.sio:2104`), so emitting
-`sqrtsd xmm, xmm` for `sqrt` is the same class of change — recognise the `sqrt` builtin at the call
-site and emit the instruction on the f64 in the xmm register instead of setting up a call.
+`bf_corr` on two **perfectly correlated** large-magnitude columns (`x = 1e9 + i`, `y = 1e9 + 2i`,
+n = 100000) returned **6.29e-9** instead of **1.0**. The covariance/co-moment intermediates
+(`cxx`, `cyy`, `cxy`) were all correct to full precision (verified against CPython); the *only* wrong
+step was `sqrt(cxx*cyy)` with `cxx*cyy ≈ 2.78e28` → souc returned `2.649e22` instead of `1.667e14`.
+
+## Root-cause hypothesis (REVISED)
+
+The earlier "extern libc call, PLT overhead" hypothesis is **suspect** — a real `libm` `sqrt` would be
+correct at all magnitudes. A result that is *correct for small `x` and drifts for large `x`* is the
+signature of a **hand-rolled approximation** (e.g. a bit-hack seed with too few Newton-Raphson
+refinement steps, or a reduced-precision / single-iteration path), not a call into `libm`. CODEX-2 to
+confirm what `sqrt` actually lowers to. (An independent inline Newton-Raphson with the same bit-hack
+seed but **6** iterations is correct to ≤ 1 ULP at every magnitude — so if the current path is
+under-iterated, adding iterations would also fix correctness, but the hardware instruction is the right
+answer.)
 
 ## The ask
 
@@ -83,34 +82,33 @@ Lower the `f64` `sqrt` builtin to the hardware square-root instruction:
 - **x86-64:** `sqrtsd %xmmSrc, %xmmDst` (or `vsqrtsd`).
 - **arm64:** `fsqrt d_dst, d_src`.
 
-Keep the extern fallback only if the argument type isn't a register f64. `sqrtsd` is IEEE-754
-correctly-rounded, so results stay **bit-identical** to today's libm path (no accuracy regression).
-
-If `fabs`, `floor`, `ceil`, `trunc`, `rint`/`round`, and `min`/`max` share the same extern-lowering
-path, they lower to single instructions too (`andpd`/`roundsd`/`minsd`/`maxsd`) — same fix, same file.
+`sqrtsd`/`fsqrt` are IEEE-754 correctly-rounded, so the result is correct at every magnitude and ~1–4 ns.
+This resolves the correctness bug and the perf issue together. If `fabs`, `floor`, `ceil`, `trunc`,
+`rint`/`round`, `min`/`max` share the same (approximation) path, audit them for the same correctness
+problem and lower them to their single instructions too.
 
 ## Acceptance
 
-- The 30M-call `sqrt` loop drops from ~7.3 s to well under ~1 s (ideally ~0.1 s).
-- `bf_expanding_std` at 1M rows lands within ~1.3× of pandas (from 13×), matching `bf_expanding_var`.
-- Results bit-identical to the current libm path on a fuzz set of positive doubles + edge cases
-  (0.0, +inf, subnormals; `sqrt(-x)` stays NaN).
+- `sqrt(v)` is correctly-rounded (matches CPython `math.sqrt` bits, ≤ 0.5 ULP) across a magnitude
+  sweep from subnormals to ~1e300, INCLUDING the large values in the table above.
+- `bf_corr` on the perfectly-correlated large-magnitude columns returns 1.0.
+- The 30M-call `sqrt` loop drops from ~7.3 s to well under ~1 s.
 
 ## Scope / impact
 
-- **Low blast radius:** codegen for one (or a few) math builtins; no front-end or type changes.
-- **Broad payoff:** every sqrt-bound verb flips from loss to competitive — expanding/rolling `std`,
-  RMS, L2 norm, Euclidean distance, correlation/covariance normalisation, z-score / Grubbs' outlier
-  tests, and the GUM uncertainty combine (`u_c = sqrt(Σ u_i²)`), which is core to the measurement-data
-  thesis.
-- Complements the other two open perf dispatches — `mem_copy` builtin
-  (`docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md`, which `bf_shift` is bound by) and C3
-  SIMD auto-vectorisation (`docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md`, which
-  `bf_diff` is bound by). Together they close the three known bigframe losses.
+- **P0 correctness:** silent-wrong `sqrt` corrupts every call site whose argument exceeds ~1e6. Known
+  stdlib call sites (grep `fn sqrt`): `stdlib/optimize/{uncertainty,differential_evolution,nelder_mead,
+  levenberg_marquardt}.sio`, `stdlib/fusion/eeg_fmri.sio`, and — most importantly for the measurement
+  thesis — the **GUM uncertainty combine** `u_c = sqrt(Σ u_i²)` (`epistemic::gum` / `formal/GUM.lean`):
+  any of these on large-magnitude inputs is silently wrong today. `stdlib/data/bigframe_ops.sio`
+  (`bf_expanding_std`, and `bf_corr`) has been given a correct in-stdlib Newton `bf_sqrt` as a stopgap;
+  the compiler fix lets those revert to the builtin.
+- **Low blast radius to fix:** codegen for one (or a few) math builtins; no front-end or type changes.
+- Complements the `mem_copy` builtin (`docs/handoff/mem_copy_builtin_codex_dispatch_2026-07-19.md`,
+  `bf_shift`) and C3 SIMD auto-vectorisation (`bf_diff`) dispatches.
 
 ## Pointers
 
-- Repro + microbenchmark: this file.
-- Verb that surfaced it: `stdlib/data/bigframe_ops.sio::bf_expanding_std` (vs `bf_expanding_var`).
-- Benchmark table: `scripts/bench/RESULTS.md` (expanding rows + the "expanding" honest-read bullet).
-- Existing inline-instruction precedent: `self-hosted/compiler/lean_single.sio:2104` (`emit_memcpy_a64`).
+- Repro + magnitude table: this file.
+- Correct stopgap: `stdlib/data/bigframe_ops.sio::bf_sqrt` (bit-hack seed + 6 Newton iterations, ≤ 1 ULP).
+- Impacted verbs: `bf_expanding_std`, `bf_corr` (both now route through `bf_sqrt`).


### PR DESCRIPTION
## What

Corrects the merged sqrt dispatch (`docs/handoff/souc_sqrt_extern_to_sqrtsd_codex_dispatch_2026-07-19.md`). The original framed sqrt as *"bit-identical to libm, just slow"* and asked CODEX-2 for a perf lowering with acceptance *"results stay bit-identical"* — which would have told them to **preserve a bug**.

## Why

`sqrt(x)` is **silently wrong for |x| ≳ 1e6**:

| input | souc `sqrt` | correct |
|---|---|---|
| 1e6 | 1000 | 1000 (boundary ok) |
| 1e12 | **1279996.5** | 1000000 |
| 1e20 | **9.54e13** | 1e10 |
| 2.78e28 | **2.649e22** | 1.667e14 |

No crash, no NaN — it just returns a wrong number. End-to-end: `bf_corr` on perfectly-correlated large-magnitude columns returned **6.29e-9 instead of 1.0** (all co-moment intermediates were correct; only `sqrt(cxx*cyy)` was wrong).

## Impact (why P0)

Silent-wrong sqrt corrupts every call site whose argument exceeds ~1e6 — `optimize/{uncertainty,differential_evolution,nelder_mead,levenberg_marquardt}`, `fusion/eeg_fmri`, and most importantly the **GUM uncertainty combine `u_c = sqrt(Σ u_i²)`**, the centerpiece of the measurement thesis.

## Changes to the ask

- Root-cause hypothesis revised: not a libm extern (that would be correct) but a **hand-rolled approximation** (bit-hack seed + too few Newton steps). An independent inline Newton with 6 iterations is correct to ≤1 ULP at every magnitude.
- The ask (lower to `sqrtsd`/`fsqrt`) is **retained** — the hardware instruction fixes correctness *and* speed together.
- Confirmed on `lean_single` (madaros probe hit an unrelated E137).

Docs only; meta header unchanged (no registry regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)