### PR TITLE
feat(clinical): ousadia — Epistemic methods drive RX under default Madaros

### DIFF
--- a/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json
+++ b/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json
@@ -1,0 +1,21 @@
+{
+  "schema": "ousadia_epistemic_method_rx_receipt.v1",
+  "status": "pass",
+  "engine": "madaros_default",
+  "lean_single_pin": false,
+  "commit": "afc04ef51c034b25e415b95e7db6ae1d44c7081e",
+  "claims": [
+    "epistemic_methods_under_madaros_multimodule",
+    "measured_val_std_add_is_credible_drive_decision",
+    "type_a_u95_t4_band_adjust",
+    "renal_refuse_same_mg_per_kg",
+    "compile_fail_confidence_witnesses_present"
+  ],
+  "claims_not_made": [
+    "dual_gum_and_knowledge_import_under_madaros",
+    "bedside_dosing_product",
+    "nonmem_foce",
+    "language_knowledge_t_generic",
+    "numpy_sklearn"
+  ]
+}

--- a/docs/audit/OUSADIA_EPISTEMIC_METHOD_RX_MADAROS_2026-07-19.md
+++ b/docs/audit/OUSADIA_EPISTEMIC_METHOD_RX_MADAROS_2026-07-19.md
@@ -1,0 +1,50 @@
+<!-- docs:meta
+topic_id: repo.docs.audit.ousadia-epistemic-method-rx-madaros-2026-07-19
+authority: repo_only
+audience: users
+last_validated: 2026-03-07
+validated_by: A2
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.ousadia-epistemic-method-rx-madaros-2026-07-19
+-->
+
+# Ousadia: Epistemic methods → dose decision under default Madaros — 2026-07-19
+
+## The claim (no alibi)
+
+> Under **default Madaros multi-module import**, the flagship type is used **as methods**:
+> `Epistemic::measured`, `.val()`, `.std()`, `.add()`, `.is_credible()` — and those
+> results **drive ADMIT/ADJUST/REFUSE** on a vancomycin AUC/MIC scaffold.
+> Over-confident prescribe paths remain compile-fail witnesses.
+
+This is the vertical that was impossible until Root 2 multi-module (#1227).
+
+## Measured (Madaros v0.80.0, no lean_single)
+
+```
+OUSADIA_RX ep_q=532.97 ep_std=79.95 typeA_u95=99.25 k95_table=2.776 decide=ADJUST
+OUSADIA_RX ep_q_ren=2006.88 decide=REFUSE
+OUSADIA_EPISTEMIC_METHOD_RX_CHAIN_OK
+K95 k95=2.776 dof=4  (gum alone)
+```
+
+## Gate
+
+```bash
+bash scripts/ousadia_epistemic_method_rx_gate.sh
+# → OUSADIA_EPISTEMIC_METHOD_RX_GATE_OK
+```
+
+## Residual (honest)
+
+| Item | Status |
+|---|---|
+| Dual `use epistemic::gum` + `use epistemic::knowledge` | Madaros **E175** private preflight — Type-A U95 uses JCGM t₄=2.776 table; gum k95 smoked alone |
+| Bedside / NONMEM / numpy | claims_not_made |
+
+## Stack this sits on
+
+1. GUM D1 k95 (#1198)
+2. Knowledge free API (#1203)
+3. Root 2 same-module methods (#1219)
+4. Root 2 multi-module methods (#1227)
+5. **This ousadia vertical** — methods → decision

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1039
-- Repo-backed topics: 889
+- Total governed topics: 1040
+- Repo-backed topics: 890
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 215
-- Authority count `repo_only`: 636
+- Authority count `repo_only`: 637
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 655 topics
+- A2: 656 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1040
-- Repo-backed topics: 890
+- Total governed topics: 1042
+- Repo-backed topics: 892
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 215
-- Authority count `repo_only`: 637
+- Authority count `repo_only`: 639
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 656 topics
+- A2: 658 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -362,11 +362,13 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.gpu.batched-hyper-syntax | repo_only | docs/gpu/BATCHED_HYPER_SYNTAX.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.borromean-ainfinity | repo_only | docs/gpu/BORROMEAN_AINFINITY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.bracketing-task | repo_only | docs/gpu/BRACKETING_TASK.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.gpu.dyck-ssm-poc | repo_only | docs/gpu/DYCK_SSM_POC.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hyper-matvec-design | repo_only | docs/gpu/HYPER_MATVEC_DESIGN.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.hypercomplex-ssm-novelty | repo_only | docs/gpu/HYPERCOMPLEX_SSM_NOVELTY.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.nonassoc-benchmark | repo_only | docs/gpu/NONASSOC_BENCHMARK.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.nonassoc-headtohead | repo_only | docs/gpu/NONASSOC_HEADTOHEAD.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.gpu.oct-wmma-validate.gb10-receipt-20260716 | repo_only | docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.gpu.octonion-signature-bridge | repo_only | docs/gpu/OCTONION_SIGNATURE_BRIDGE.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.check-sounio-guide | repo_only | docs/guide/CHECK_SOUNIO_GUIDE.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.egc-depth-guide | repo_only | docs/guide/EGC_DEPTH_GUIDE.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.guide.getting-started-pt | repo_only | docs/guide/getting-started_PT.md | - | A5 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -190,6 +190,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.audit.modular-pipe-coverage-map-2026-06-01 | repo_only | docs/audit/MODULAR_PIPE_COVERAGE_MAP_2026-06-01.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.mut-refactor-execution-plan-2026-05-31 | repo_only | docs/audit/MUT_REFACTOR_EXECUTION_PLAN_2026-05-31.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.ode-epistemic-zero-params-2026-06-02 | repo_only | docs/audit/ODE_EPISTEMIC_ZERO_PARAMS_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.audit.ousadia-epistemic-method-rx-madaros-2026-07-19 | repo_only | docs/audit/OUSADIA_EPISTEMIC_METHOD_RX_MADAROS_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.pbpk-dissertation-session-notes-2026-06-28 | repo_only | docs/audit/PBPK_DISSERTATION_SESSION_NOTES_2026-06-28.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.pbpk-rapamycin-triage-2026-06-02 | repo_only | docs/audit/PBPK_RAPAMYCIN_TRIAGE_2026-06-02.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.audit.pbpk14-identifiability-2026-06-14 | repo_only | docs/audit/PBPK14_IDENTIFIABILITY_2026-06-14.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -7811,6 +7811,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.gpu.dyck-ssm-poc",
+      "collection": "repo",
+      "repo_doc_path": "docs/gpu/DYCK_SSM_POC.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.gpu.hyper-matvec-design",
       "collection": "repo",
       "repo_doc_path": "docs/gpu/HYPER_MATVEC_DESIGN.md",
@@ -7906,6 +7929,29 @@
       "topic_id": "repo.docs.gpu.oct-wmma-validate.gb10-receipt-20260716",
       "collection": "repo",
       "repo_doc_path": "docs/gpu/oct_wmma_validate.gb10-receipt-20260716.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.gpu.octonion-signature-bridge",
+      "collection": "repo",
+      "repo_doc_path": "docs/gpu/OCTONION_SIGNATURE_BRIDGE.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "users",

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -3834,6 +3834,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.audit.ousadia-epistemic-method-rx-madaros-2026-07-19",
+      "collection": "repo",
+      "repo_doc_path": "docs/audit/OUSADIA_EPISTEMIC_METHOD_RX_MADAROS_2026-07-19.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.audit.pbpk-dissertation-session-notes-2026-06-28",
       "collection": "repo",
       "repo_doc_path": "docs/audit/PBPK_DISSERTATION_SESSION_NOTES_2026-06-28.md",

--- a/scripts/ousadia_epistemic_method_rx_gate.sh
+++ b/scripts/ousadia_epistemic_method_rx_gate.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/ousadia_epistemic_method_rx_gate.sh
+#
+# OUSADIA gate: Epistemic methods under default Madaros drive ADMIT/ADJUST/REFUSE.
+# No lean_single pin. Dual gum+knowledge import residual documented.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+unset SOUNIO_SOUC_ENGINE || true
+SOUC="${SOUC:-$ROOT/bin/souc}"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+echo "== ousadia_epistemic_method_rx_gate =="
+echo "== engine: default Madaros (no lean_single) =="
+"$SOUC" --version 2>&1 | head -2 || true
+
+# 1) Flagship chain
+SRC="tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio"
+echo "== method RX chain $SRC =="
+if ! "$SOUC" compile "$SRC" -o "$OUT/rx.elf" >"$OUT/rxc.log" 2>&1; then
+  echo "FAIL: compile"; tail -30 "$OUT/rxc.log" || true; fail=1
+else
+  chmod +x "$OUT/rx.elf"
+  if ! "$OUT/rx.elf" >"$OUT/rx.log" 2>&1 || ! grep -q "OUSADIA_EPISTEMIC_METHOD_RX_CHAIN_OK" "$OUT/rx.log"; then
+    echo "FAIL: run"; cat "$OUT/rx.log" || true; fail=1
+  else
+    grep '^OUSADIA_RX' "$OUT/rx.log" || true
+  fi
+fi
+
+# 2) GUM k95 still correct alone (D1 site)
+echo "== GUM k95 multi-module smoke =="
+cat >"$OUT/k95.sio" <<'EOF'
+use epistemic::gum::{gum_type_a, gum_type_b, gum_combine2, gum_k95, gum_dof}
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let a = gum_type_a(2.0, 5)
+    let z = gum_type_b(0.0)
+    let r = gum_combine2(100.0, a, z)
+    let k = gum_k95(r)
+    let d = gum_dof(r)
+    print("K95 k95="); print(k); print(" dof="); print(d); print("\n")
+    if k < 2.5 { return 1 }
+    if d < 3.5 || d > 4.5 { return 2 }
+    print("K95_OK\n")
+    return 0
+}
+EOF
+if ! "$SOUC" compile "$OUT/k95.sio" -o "$OUT/k95.elf" >"$OUT/k95c.log" 2>&1; then
+  echo "FAIL: k95 compile"; tail -15 "$OUT/k95c.log" || true; fail=1
+else
+  chmod +x "$OUT/k95.elf"
+  if ! "$OUT/k95.elf" >"$OUT/k95.log" 2>&1 || ! grep -q "K95_OK" "$OUT/k95.log"; then
+    echo "FAIL: k95 run"; cat "$OUT/k95.log" || true; fail=1
+  else
+    grep 'K95' "$OUT/k95.log" || true
+  fi
+fi
+
+# 3) Compile-fail confidence witnesses
+for f in \
+  tests/compile-fail/med/vancomycin_low_conf_refusal.sio \
+  tests/compile-fail/med/vancomycin_weak_evidence_refusal.sio
+do
+  if [[ ! -f "$f" ]]; then echo "FAIL: missing $f"; fail=1
+  else echo "OK witness: $f"; fi
+done
+
+# 4) Dual import residual (expect Madaros E175 / fail — do not require green)
+echo "== dual gum+knowledge import residual =="
+cat >"$OUT/dual.sio" <<'EOF'
+use epistemic::knowledge::{Epistemic}
+use epistemic::gum::{gum_type_a}
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let e = Epistemic::measured(1.0, 0.1)
+    let _a = gum_type_a(1.0, 5)
+    print(e.val()); print("\n")
+    return 0
+}
+EOF
+if "$SOUC" compile "$OUT/dual.sio" -o "$OUT/dual.elf" >"$OUT/dualc.log" 2>&1; then
+  echo "NOTE: dual gum+knowledge import now works — update claims_not_made"
+else
+  echo "OK dual import still blocked under Madaros (E175 residual documented)"
+fi
+
+mkdir -p "$ROOT/artifacts/clinical"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+STATUS=fail
+[[ $fail -eq 0 ]] && STATUS=pass
+cat >"$ROOT/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json" <<EOF
+{
+  "schema": "ousadia_epistemic_method_rx_receipt.v1",
+  "status": "$STATUS",
+  "engine": "madaros_default",
+  "lean_single_pin": false,
+  "commit": "$COMMIT",
+  "claims": [
+    "epistemic_methods_under_madaros_multimodule",
+    "measured_val_std_add_is_credible_drive_decision",
+    "type_a_u95_t4_band_adjust",
+    "renal_refuse_same_mg_per_kg",
+    "compile_fail_confidence_witnesses_present"
+  ],
+  "claims_not_made": [
+    "dual_gum_and_knowledge_import_under_madaros",
+    "bedside_dosing_product",
+    "nonmem_foce",
+    "language_knowledge_t_generic",
+    "numpy_sklearn"
+  ]
+}
+EOF
+echo "receipt: $ROOT/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json"
+
+if [[ $fail -eq 0 ]]; then
+  echo "OUSADIA_EPISTEMIC_METHOD_RX_GATE_OK"
+  exit 0
+fi
+exit 1

--- a/tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio
+++ b/tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio
@@ -1,0 +1,177 @@
+//@ run-pass
+// ═══════════════════════════════════════════════════════════════════════════
+// OUSADIA: Epistemic METHODS reach the dose decision under DEFAULT Madaros.
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// What was blocked until Root 2 multi-module:
+//   use epistemic::knowledge::{Epistemic}
+//   let e = Epistemic::measured(...)
+//   e.val() / e.std() / e.add(...) / e.is_credible(...)
+//
+// This E2E is the proof that alibi is dead. Engine: default Madaros, no lean_single.
+//
+// Dual import epistemic::gum + epistemic::knowledge still trips Madaros E175
+// (private-function preflight across two modules) — Type-A expanded U is therefore
+// computed here with the published t_0.975,4 = 2.776 table value, same as gum_k95
+// for n=5 Type-A only. Gate separately smokes gum k95 alone.
+//
+// Chain:
+//   Epistemic::measured(Q) → .val/.std/.add/.is_credible
+//   Type-A U95 (ν=4, k=2.776) → band + Knightian → ADMIT/ADJUST/REFUSE
+//   Renal CrCl=20 same mg/kg → REFUSE
+//
+// Literature: Matzke 1984 CL; ASHP/SIDP/IDSA 2020 AUC/MIC 400–600; JCGM 100:2008 t table
+// claims_not_made: bedside; NONMEM; numpy; dual gum+knowledge import under Madaros;
+//                  language Knowledge<T> generic; Bayesian TDM
+
+use epistemic::knowledge::{Epistemic}
+
+fn fail(code: i32) -> i32 with IO {
+    if code == 1 { print("FAIL code=1 ep_val\n"); return 1 }
+    if code == 2 { print("FAIL code=2 ep_std\n"); return 2 }
+    if code == 3 { print("FAIL code=3 ep_add\n"); return 3 }
+    if code == 4 { print("FAIL code=4 conf\n"); return 4 }
+    if code == 5 { print("FAIL code=5 decide_std\n"); return 5 }
+    if code == 6 { print("FAIL code=6 band\n"); return 6 }
+    if code == 10 { print("FAIL code=10 renal\n"); return 10 }
+    if code == 11 { print("FAIL code=11 renal_q\n"); return 11 }
+    print("FAIL code=unknown\n")
+    return code
+}
+
+fn abs_f64(x: f64) -> f64 {
+    if x < 0.0 { return 0.0 - x }
+    return x
+}
+
+fn sqrt_f64(x: f64) -> f64 with Mut, Div, Panic {
+    if x <= 0.0 { return 0.0 }
+    var y = x
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y = 0.5 * (y + x / y)
+    y
+}
+
+// Matzke 1984 CL (mL/min) → L/h
+fn cl_lh(crcl: f64) -> f64 {
+    return (0.689 * crcl + 3.66) * 0.06
+}
+
+fn auc_mic(dose_mg: f64, crcl: f64, mic: f64) -> f64 with Mut, Div, Panic {
+    let cl = cl_lh(crcl)
+    return (2.0 * dose_mg / cl) / mic
+}
+
+// Type-A: u = s/√n ; n=5 → ν=4 → k95 = t_0.975,4 = 2.776 (JCGM table)
+fn type_a_u95(std_dev: f64, n: f64) -> f64 with Mut, Div, Panic {
+    let u = std_dev / sqrt_f64(n)
+    return 2.776 * u
+}
+
+// ASHP band [400, 600]
+fn band_decide(q: f64, u95: f64) -> i32 {
+    let lo = q - u95
+    let hi = q + u95
+    if lo > 600.0 { return 2 }
+    if hi < 400.0 { return 2 }
+    if hi > 600.0 { return 1 }
+    if lo < 400.0 { return 1 }
+    return 0
+}
+
+// Illustrative Knightian ±25% CV on CL
+fn knightian_decide(dose_mg: f64, crcl: f64, mic: f64) -> i32 with Mut, Div, Panic {
+    let cl = cl_lh(crcl)
+    let sigma = 0.25 * cl
+    let cl_hi = cl + sigma
+    let cl_lo = cl - sigma
+    if cl_lo <= 0.0 { return 2 }
+    let q_lo = (2.0 * dose_mg / cl_hi) / mic
+    let q_hi = (2.0 * dose_mg / cl_lo) / mic
+    if q_lo > 600.0 { return 2 }
+    if q_hi > 600.0 { return 1 }
+    return 0
+}
+
+fn conf_decide(e: Epistemic) -> i32 {
+    if e.is_credible(700) { return 0 }
+    if e.is_credible(500) { return 1 }
+    return 2
+}
+
+fn merge3(a: i32, b: i32, c: i32) -> i32 {
+    var m = a
+    if b > m { m = b }
+    if c > m { m = c }
+    return m
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let wt = 70.0
+    let dose = 15.0 * wt
+    let mic = 1.0
+
+    // ── Flagship type, multi-module Madaros methods ──────────────────────
+    let q_pt = auc_mic(dose, 90.0, mic)
+    let s_obs = 0.15 * q_pt
+    let q_ep = Epistemic::measured(q_pt, s_obs)
+    let dose_ep = Epistemic::measured(dose, 0.02 * dose)
+    let mic_ep = Epistemic::certain(mic)
+
+    // Method reads
+    let qv = q_ep.val()
+    let qs = q_ep.std()
+    if abs_f64(qv - q_pt) > 1e-9 { return fail(1) }
+    if abs_f64(qs - s_obs) > 1e-6 { return fail(2) }
+
+    // Method arithmetic
+    let stack = dose_ep.add(&mic_ep)
+    if stack.val() < dose - 1.0 { return fail(3) }
+    if conf_decide(q_ep) != 0 { return fail(4) }
+
+    // Type-A expanded U (ν=4) — same k as gum_k95 for Type-A-only n=5
+    let u95 = type_a_u95(s_obs, 5.0)
+    let dec_band = band_decide(qv, u95)
+    let dec_kn = knightian_decide(dose, 90.0, mic)
+    let dec_cf = conf_decide(q_ep)
+    let dec = merge3(dec_band, dec_kn, dec_cf)
+    // q≈533, u95≈k*s/√5 ≈ 2.776*0.15*533/√5 ≈ 99.2 → hi>600 → ADJUST
+    if dec_band != 1 { return fail(6) }
+    if dec != 1 { return fail(5) }
+
+    print("OUSADIA_RX ep_q=")
+    print(qv)
+    print(" ep_std=")
+    print(qs)
+    print(" typeA_u95=")
+    print(u95)
+    print(" k95_table=2.776")
+    print(" decide=ADJUST\n")
+
+    // ── Renal: same mg/kg → REFUSE ───────────────────────────────────────
+    let q_ren = auc_mic(dose, 20.0, mic)
+    let q_ren_ep = Epistemic::measured(q_ren, 0.15 * q_ren)
+    let u95_r = type_a_u95(0.15 * q_ren, 5.0)
+    let dec_ren = merge3(
+        band_decide(q_ren_ep.val(), u95_r),
+        knightian_decide(dose, 20.0, mic),
+        conf_decide(q_ren_ep)
+    )
+    if dec_ren != 2 { return fail(10) }
+    if q_ren <= 600.0 { return fail(11) }
+
+    print("OUSADIA_RX ep_q_ren=")
+    print(q_ren_ep.val())
+    print(" decide=REFUSE\n")
+
+    print("OUSADIA_RX engine=madaros_default multi_module=epistemic_knowledge\n")
+    print("OUSADIA_RX methods=measured,certain,val,std,add,is_credible\n")
+    print("OUSADIA_RX dual_gum_import=E175_residual (gate smokes gum alone)\n")
+    print("OUSADIA_RX compile_fail=vancomycin_low_conf_refusal,vancomycin_weak_evidence_refusal\n")
+    print("OUSADIA_EPISTEMIC_METHOD_RX_CHAIN_OK\n")
+    return 0
+}

--- a/tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio
+++ b/tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio
@@ -104,10 +104,9 @@ fn conf_decide(e: Epistemic) -> i32 {
 }
 
 fn merge3(a: i32, b: i32, c: i32) -> i32 {
-    var m = a
-    if b > m { m = b }
-    if c > m { m = c }
-    return m
+    // Pure (no Mut) so lean_single/stage2 CI harness accepts the helper.
+    let ab = if a > b { a } else { b }
+    if ab > c { ab } else { c }
 }
 
 fn main() -> i32 with IO, Mut, Div, Panic {


### PR DESCRIPTION
## Ousadia

Until Root 2 multi-module, the flagship type could not be **used as methods** across import under default Madaros. That alibi is dead.

```
OUSADIA_RX ep_q=532.97 ep_std=79.95 typeA_u95=99.25 decide=ADJUST
OUSADIA_RX ep_q_ren=2006.88 decide=REFUSE
OUSADIA_EPISTEMIC_METHOD_RX_CHAIN_OK
```

### What this proves
- `Epistemic::measured` / `.val` / `.std` / `.add` / `.is_credible` under **default Madaros multi-module**
- Those values **drive** Knightian + Type-A U95 band → ADJUST (standard) / REFUSE (renal)
- GUM k95≈2.776 still correct alone (n=5 Type-A)
- Compile-fail confidence witnesses present

### Residual (honest)
Dual `use epistemic::gum` + `use epistemic::knowledge` still **E175** under Madaros — U95 uses published t₄=2.776; gum smoked in isolation in the gate.

### Stack
#1198 GUM D1 · #1203 free API · #1219/#1227 Root 2 methods · **this vertical**

### Gate
```bash
bash scripts/ousadia_epistemic_method_rx_gate.sh
```

Requires current-source Madaros (post-#1227).