### PR TITLE
feat(stdlib): bigframe cumulative product (bf_cumprod / bf_cumprod_by)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -27,6 +27,8 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | cumsum (1M rows, ungrouped) | | 5.0 | 9.0 | **0.56x — Sounio wins** | (new verb) |
 | cumcount_by (1M rows, 1000 groups) | | 32.5 | 46.3 | **0.70x — Sounio wins** | (new verb) |
 | cumsum_by (1M rows, 1000 groups) | | 36.1 | 22.3 | **1.62x** | (new verb) |
+| cumprod (1M rows, ungrouped) | | ~8 | ~7 | **~1.1x — parity** | (new verb) |
+| cumprod_by (1M rows, 1000 groups) | | ~35 | ~19 | **~1.8x** | (new verb) |
 | cummax (1M rows, ungrouped) | | 4.8 | 11.3 | **0.42x — Sounio wins** | (new verb) |
 | cummin (1M rows, ungrouped) | | 4.9 | 10.6 | **0.46x — Sounio wins** | (new verb) |
 | cummax_by / cummin_by (1M rows, 1000 groups) | | ~34 | ~21 | **1.6x** | (new verb) |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -8,7 +8,7 @@
 // rolling-window sum / mean / max / min, shift / diff / pct-change, an
 // exponentially weighted moving mean, expanding mean / var / std, rank,
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
-// rolling variance / std, and rolling median.
+// rolling variance / std, rolling median, and cumulative product.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -1913,5 +1913,78 @@ pub fn bf_rolling_median(src: &BigFrame, col: i64, window: i64, fill: f64) -> Bi
         i = i + 1
     }
     heap_free(win as *mut i8)
+    out
+}
+
+/// Running (cumulative) product of column `col`: out[i] = col[0]*col[1]*...*col[i]
+/// (like pandas Series.cumprod()). A single sequential multiply-accumulate, O(n). Note
+/// products overflow to inf (values >1) or underflow to 0 quickly -- inherent to
+/// cumprod, as in pandas. NATIVE + lean_single only (heap).
+pub fn bf_cumprod(src: &BigFrame, col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    if col < 0 || col >= bf_ncols(src) || n <= 0 { return bf_new(1, 1) }
+    var out = bf_new(1, n)
+    out.n_rows = n
+    let sp = bf_col_ptr(src, col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var acc = 1.0
+    var i: i64 = 0
+    while i < n {
+        acc = acc * read_f64(sp, i)
+        write_f64(op, i, acc)
+        i = i + 1
+    }
+    out
+}
+
+/// Per-group running product, aligned to input row order: out[i] = the product of
+/// `val_col` over all rows up to and including row i that share row i's `key_col`
+/// value (like pandas groupby(key)[val].cumprod()). One pass with an open-addressing
+/// table mapping key -> running product. Returns a 1-column BigFrame of length n.
+/// O(n) expected. NATIVE + lean_single only (heap).
+pub fn bf_cumprod_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return bf_new(1, 1) }
+    var size: i64 = 16
+    while size < n + n { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hp  = heap_alloc(size * 8) as *mut f64   // running product per key
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    var out = bf_new(1, n)
+    out.n_rows = n
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i)
+        let v = read_f64(vp, i)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hp, slot, v)
+                write_f64(op, i, v)
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    let p = read_f64(hp, slot) * v
+                    write_f64(hp, slot, p)
+                    write_f64(op, i, p)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        i = i + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hp as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -553,6 +553,27 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var rdd: i64 = 0; var rdj: i64 = 0
     while rdj < 3000 { if bf_get(&rda, rdj, 0) != bf_get(&rdb, rdj, 0) { rdd = rdd + 1 } rdj = rdj + 1 }
     if rdd != 0 { print("FAIL rmed_vs_naive\n"); return 207 }
+    // CUMPROD. col0 = 1.0 except [0]=2,[1]=3,[2]=4 -> cumprod 2,6,24,24,...,24 (stays exact under *1).
+    // col1 = i%1000 (key); col2 = 2.0 if (i/1000) even else 0.5 -> per-group product oscillates 2,1,2,1.
+    var cpf = bf_new(3, 16)
+    var cpi: i64 = 0
+    while cpi < 1000000 {
+        var cpr:[f64;64]=[0.0;64]
+        if cpi==0 { cpr[0]=2.0 } else { if cpi==1 { cpr[0]=3.0 } else { if cpi==2 { cpr[0]=4.0 } else { cpr[0]=1.0 } } }
+        cpr[1]=(cpi%1000) as f64
+        if (cpi/1000)-2*((cpi/1000)/2)==0 { cpr[2]=2.0 } else { cpr[2]=0.5 }
+        bf_push_row(&!cpf,&cpr,3); cpi=cpi+1
+    }
+    let cp = bf_cumprod(&cpf, 0)
+    if bf_nrows(&cp) != 1000000 { print("FAIL cumprod_n\n"); return 208 }
+    if !approx_eq(bf_get(&cp,0,0), 2.0) { print("FAIL cumprod0\n"); return 209 }
+    if !approx_eq(bf_get(&cp,1,0), 6.0) { print("FAIL cumprod1\n"); return 210 }
+    if !approx_eq(bf_get(&cp,2,0), 24.0) { print("FAIL cumprod2\n"); return 211 }
+    if !approx_eq(bf_get(&cp,999999,0), 24.0) { print("FAIL cumprod_last\n"); return 212 }
+    let cpb = bf_cumprod_by(&cpf, 1, 2)
+    if !approx_eq(bf_get(&cpb,0,0), 2.0) { print("FAIL cumprodby0\n"); return 213 }        // group 0, j=0: 2
+    if !approx_eq(bf_get(&cpb,1000,0), 1.0) { print("FAIL cumprodby1000\n"); return 214 }    // j=1: 2*0.5
+    if !approx_eq(bf_get(&cpb,2000,0), 2.0) { print("FAIL cumprodby2000\n"); return 215 }    // j=2: 1*2
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_cumprod` (ungrouped running product, pandas `Series.cumprod()`) and `bf_cumprod_by` (per-group running product, pandas `groupby(k)[v].cumprod()`) in `data::bigframe_ops`. Each returns a 1-column BigFrame aligned to input rows — `bf_cumprod` is a single multiply-accumulate, `bf_cumprod_by` is one pass over an open-addressing table mapping key → running product.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

1M rows: `col0 = 1.0` except `[0]=2,[1]=3,[2]=4` → cumprod `2,6,24,24,…,24` (stays exact multiplying by 1); `col1 = i%1000` (key), `col2 = 2.0 if (i/1000) even else 0.5` → per-group product oscillates `2,1,2` at rows 0/1000/2000. Both pandas-exact.

## Benchmark (1M rows)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| cumprod | ~8 | ~7 | **~1.1× — parity** |
| cumprod_by | ~35 | ~19 | ~1.8× |

Unlike `cumsum` (a win), `cumprod` lands at parity — pandas' Series cumprod is lean here. (cumprod of near-1 values is the only overflow-free way to bench at 1M — the same constraint applies to both sides.)

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)