### PR TITLE
feat(stdlib): bigframe per-group distinct count (bf_nunique_by)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -29,6 +29,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | cumsum_by (1M rows, 1000 groups) | | 36.1 | 22.3 | **1.62x** | (new verb) |
 | cumprod (1M rows, ungrouped) | | ~8 | ~7 | **~1.1x — parity** | (new verb) |
 | cumprod_by (1M rows, 1000 groups) | | ~35 | ~19 | **~1.8x** | (new verb) |
+| nunique_by (1M rows, 1000 groups) | | ~140 | ~42 | **~3.4x** | double-hash (pair-set + key-count) |
 | cummax (1M rows, ungrouped) | | 4.8 | 11.3 | **0.42x — Sounio wins** | (new verb) |
 | cummin (1M rows, ungrouped) | | 4.9 | 10.6 | **0.46x — Sounio wins** | (new verb) |
 | cummax_by / cummin_by (1M rows, 1000 groups) | | ~34 | ~21 | **1.6x** | (new verb) |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -8,7 +8,8 @@
 // rolling-window sum / mean / max / min, shift / diff / pct-change, an
 // exponentially weighted moving mean, expanding mean / var / std, rank,
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
-// rolling variance / std, rolling median, and cumulative product.
+// rolling variance / std, rolling median, cumulative product, and
+// per-group distinct-count (nunique).
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -1986,5 +1987,97 @@ pub fn bf_cumprod_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame wit
     heap_free(occ as *mut i8)
     heap_free(hk as *mut i8)
     heap_free(hp as *mut i8)
+    out
+}
+
+// Combined hash of a (key, val) pair -> [0, mask].
+fn bf_pairhash(k: f64, v: f64, mask: i64) -> i64 with Mut, Div, Panic {
+    var h = f64_to_bits(k) * (0 - 7046029254386353131)
+    h = h ^ (f64_to_bits(v) * (0 - 4417766517339476365))
+    h = h ^ (h >> 29)
+    h & mask
+}
+
+/// Per-group count of DISTINCT `val_col` values (like pandas groupby(key)[val]
+/// .nunique()): for each distinct `key_col`, how many distinct `val_col` values occur
+/// in that group. Returns a 2-column [key, nunique] BigFrame. Two open-addressing
+/// tables: a SET of (key,val) pairs (each first-seen pair is a new distinct value) and
+/// a key -> distinct-count table incremented on each new pair. O(n) expected. NATIVE +
+/// lean_single only (heap).
+pub fn bf_nunique_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(2, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let po = heap_alloc(size * 8) as *mut f64      // pair set: occupancy / key / val
+    let pk = heap_alloc(size * 8) as *mut f64
+    let pv = heap_alloc(size * 8) as *mut f64
+    let ko = heap_alloc(size * 8) as *mut f64      // key -> distinct count: occ / key / count
+    let kk = heap_alloc(size * 8) as *mut f64
+    let kc = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    var nd: i64 = 0
+    var r: i64 = 0
+    while r < nr {
+        let k = read_f64(kp, r)
+        let v = read_f64(vp, r)
+        var slot = bf_pairhash(k, v, mask)         // is (k,v) a new distinct pair?
+        var isnew = false
+        var done = false
+        while !done {
+            if read_f64(po, slot) == 0.0 {
+                write_f64(po, slot, 1.0)
+                write_f64(pk, slot, k)
+                write_f64(pv, slot, v)
+                isnew = true
+                done = true
+            } else {
+                if read_f64(pk, slot) == k && read_f64(pv, slot) == v { done = true } else { slot = (slot + 1) & mask }
+            }
+        }
+        if isnew {                                 // count it against key k
+            var s2 = bf_ghash(k, mask)
+            var done2 = false
+            while !done2 {
+                if read_f64(ko, s2) == 0.0 {
+                    write_f64(ko, s2, 1.0)
+                    write_f64(kk, s2, k)
+                    write_f64(kc, s2, 1.0)
+                    nd = nd + 1
+                    done2 = true
+                } else {
+                    if read_f64(kk, s2) == k {
+                        write_f64(kc, s2, read_f64(kc, s2) + 1.0)
+                        done2 = true
+                    } else {
+                        s2 = (s2 + 1) & mask
+                    }
+                }
+            }
+        }
+        r = r + 1
+    }
+    var cap = nd
+    if cap < 1 { cap = 1 }
+    var out = bf_new(2, cap)
+    var s: i64 = 0
+    while s < size {
+        if read_f64(ko, s) == 1.0 {
+            var row: [f64; 64] = [0.0; 64]
+            row[0] = read_f64(kk, s)
+            row[1] = read_f64(kc, s)
+            bf_push_row(&!out, &row, 2)
+        }
+        s = s + 1
+    }
+    heap_free(po as *mut i8)
+    heap_free(pk as *mut i8)
+    heap_free(pv as *mut i8)
+    heap_free(ko as *mut i8)
+    heap_free(kk as *mut i8)
+    heap_free(kc as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -574,6 +574,25 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if !approx_eq(bf_get(&cpb,0,0), 2.0) { print("FAIL cumprodby0\n"); return 213 }        // group 0, j=0: 2
     if !approx_eq(bf_get(&cpb,1000,0), 1.0) { print("FAIL cumprodby1000\n"); return 214 }    // j=1: 2*0.5
     if !approx_eq(bf_get(&cpb,2000,0), 2.0) { print("FAIL cumprodby2000\n"); return 215 }    // j=2: 1*2
+    // NUNIQUE PER GROUP. key=i%1000, val=(i/1000)%5 -> each of 1000 groups sees vals 0..4 -> nunique=5.
+    var nqf = bf_new(2, 16)
+    var nqi: i64 = 0
+    while nqi < 1000000 { var nqr:[f64;64]=[0.0;64]; nqr[0]=(nqi%1000) as f64; nqr[1]=((nqi/1000)-5*((nqi/1000)/5)) as f64; bf_push_row(&!nqf,&nqr,2); nqi=nqi+1 }
+    let nq = bf_nunique_by(&nqf, 0, 1)
+    if bf_nrows(&nq) != 1000 { print("FAIL nunique_ngroups\n"); return 216 }
+    if bf_ncols(&nq) != 2 { print("FAIL nunique_c\n"); return 217 }
+    if !approx_eq(bf_col_sum(&nq, 1), 5000.0) { print("FAIL nunique_total\n"); return 218 }   // 1000 groups x 5
+    // every group's nunique == 5.
+    var nqbad: i64 = 0; var nqj: i64 = 0
+    while nqj < bf_nrows(&nq) { if !approx_eq(bf_get(&nq, nqj, 1), 5.0) { nqbad = nqbad + 1 } nqj = nqj + 1 }
+    if nqbad != 0 { print("FAIL nunique_per_group\n"); return 219 }
+    // varied: key=i%7, val=i%13 (3000 rows) -> gcd(7,13)=1 so each group sees all 13 vals -> nunique=13.
+    var nvf = bf_new(2, 16)
+    var nvi: i64 = 0
+    while nvi < 3000 { var nvr:[f64;64]=[0.0;64]; nvr[0]=(nvi-7*(nvi/7)) as f64; nvr[1]=(nvi-13*(nvi/13)) as f64; bf_push_row(&!nvf,&nvr,2); nvi=nvi+1 }
+    let nv = bf_nunique_by(&nvf, 0, 1)
+    if bf_nrows(&nv) != 7 { print("FAIL nunique_var_ngroups\n"); return 220 }
+    if !approx_eq(bf_col_sum(&nv, 1), 91.0) { print("FAIL nunique_var_total\n"); return 221 }  // 7 groups x 13
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_nunique_by(src, key_col, val_col)` in `data::bigframe_ops` — for each distinct `key_col`, the number of distinct `val_col` values in that group (pandas `groupby(key)[val].nunique()`). Returns a 2-column `[key, nunique]` BigFrame.

**Two open-addressing tables in one pass:** a **set of (key,val) pairs** (each first-seen pair is a new distinct value for that key, via a combined `bf_pairhash`) and a **key → distinct-count** table incremented on each new pair. `O(n)` expected.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- `key=i%1000`, `val=(i/1000)%5` over 1M rows → 1000 groups each with `nunique=5` (total 5000, **every** group checked);
- varied: `key=i%7`, `val=i%13` (gcd 1) → 7 groups each `nunique=13` (total 91).

Both pandas-exact.

## Benchmark (1M rows, 1000 groups)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| nunique_by | ~140 | ~42 | **~3.4×** |

It's a **double-hash** op (a pair-set lookup *plus* a key-count lookup per row), heavier than a single groupby, so it lands a bit above the other hash verbs (unique 3.3×, value_counts 3.0×). Correct and scale-verified.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)