### PR TITLE
feat(stdlib): bigframe per-group idxmax / idxmin (bf_idxmax_by / bf_idxmin_by)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -30,6 +30,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | cumprod (1M rows, ungrouped) | | ~8 | ~7 | **~1.1x — parity** | (new verb) |
 | cumprod_by (1M rows, 1000 groups) | | ~35 | ~19 | **~1.8x** | (new verb) |
 | nunique_by (1M rows, 1000 groups) | | ~140 | ~42 | **~3.4x** | double-hash (pair-set + key-count) |
+| idxmax_by / idxmin_by (1M rows, 1000 groups) | | ~42 | ~17 | **~2.4x** | (new verb) |
 | cummax (1M rows, ungrouped) | | 4.8 | 11.3 | **0.42x — Sounio wins** | (new verb) |
 | cummin (1M rows, ungrouped) | | 4.9 | 10.6 | **0.46x — Sounio wins** | (new verb) |
 | cummax_by / cummin_by (1M rows, 1000 groups) | | ~34 | ~21 | **1.6x** | (new verb) |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -9,7 +9,7 @@
 // exponentially weighted moving mean, expanding mean / var / std, rank,
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
 // rolling variance / std, rolling median, cumulative product, and
-// per-group distinct-count (nunique).
+// per-group distinct-count (nunique), and per-group idxmax / idxmin.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2079,5 +2079,139 @@ pub fn bf_nunique_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame wit
     heap_free(ko as *mut i8)
     heap_free(kk as *mut i8)
     heap_free(kc as *mut i8)
+    out
+}
+
+/// Per-group index of the MAXIMUM value: for each distinct `key_col`, the ORIGINAL
+/// row index where `val_col` is maximal in that group (like pandas
+/// groupby(key)[val].idxmax()). Ties resolve to the FIRST (lowest-index) occurrence
+/// (strict `>` only updates on a strictly greater value). Returns a 2-column
+/// [key, row_index] BigFrame. One open-addressing pass mapping key -> (best value,
+/// best index). O(n) expected. NATIVE + lean_single only (heap).
+pub fn bf_idxmax_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(2, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hv  = heap_alloc(size * 8) as *mut f64      // best value per key
+    let hi  = heap_alloc(size * 8) as *mut f64      // row index of that best value
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    var nd: i64 = 0
+    var i: i64 = 0
+    while i < nr {
+        let k = read_f64(kp, i)
+        let v = read_f64(vp, i)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hv, slot, v)
+                write_f64(hi, slot, i as f64)
+                nd = nd + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    if v > read_f64(hv, slot) {     // strict -> first occurrence wins a tie
+                        write_f64(hv, slot, v)
+                        write_f64(hi, slot, i as f64)
+                    }
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        i = i + 1
+    }
+    var cap = nd
+    if cap < 1 { cap = 1 }
+    var out = bf_new(2, cap)
+    var s: i64 = 0
+    while s < size {
+        if read_f64(occ, s) == 1.0 {
+            var row: [f64; 64] = [0.0; 64]
+            row[0] = read_f64(hk, s)
+            row[1] = read_f64(hi, s)
+            bf_push_row(&!out, &row, 2)
+        }
+        s = s + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hv as *mut i8)
+    heap_free(hi as *mut i8)
+    out
+}
+
+/// Per-group index of the MINIMUM value (like pandas groupby(key)[val].idxmin()):
+/// for each distinct `key_col`, the original row index where `val_col` is minimal in
+/// that group. Ties resolve to the FIRST occurrence. Returns [key, row_index]. O(n)
+/// expected. NATIVE + lean_single only (heap).
+pub fn bf_idxmin_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(2, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hv  = heap_alloc(size * 8) as *mut f64
+    let hi  = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    var nd: i64 = 0
+    var i: i64 = 0
+    while i < nr {
+        let k = read_f64(kp, i)
+        let v = read_f64(vp, i)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hv, slot, v)
+                write_f64(hi, slot, i as f64)
+                nd = nd + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    if v < read_f64(hv, slot) {     // strict -> first occurrence wins a tie
+                        write_f64(hv, slot, v)
+                        write_f64(hi, slot, i as f64)
+                    }
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        i = i + 1
+    }
+    var cap = nd
+    if cap < 1 { cap = 1 }
+    var out = bf_new(2, cap)
+    var s: i64 = 0
+    while s < size {
+        if read_f64(occ, s) == 1.0 {
+            var row: [f64; 64] = [0.0; 64]
+            row[0] = read_f64(hk, s)
+            row[1] = read_f64(hi, s)
+            bf_push_row(&!out, &row, 2)
+        }
+        s = s + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hv as *mut i8)
+    heap_free(hi as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -47,6 +47,13 @@ fn naive_rolling_median(src: &BigFrame, col: i64, window: i64, fill: f64) -> Big
     out
 }
 
+// look up col1 for the row whose col0 == key in a [key, value] result (hash-order).
+fn lookup2(t: &BigFrame, key: f64) -> f64 with Mut, Div, Panic {
+    var r: i64 = 0
+    while r < bf_nrows(t) { if bf_get(t, r, 0) == key { return bf_get(t, r, 1) } r = r + 1 }
+    return 0.0 - 1.0
+}
+
 fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let n: i64 = 1000000
 
@@ -593,6 +600,25 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let nv = bf_nunique_by(&nvf, 0, 1)
     if bf_nrows(&nv) != 7 { print("FAIL nunique_var_ngroups\n"); return 220 }
     if !approx_eq(bf_col_sum(&nv, 1), 91.0) { print("FAIL nunique_var_total\n"); return 221 }  // 7 groups x 13
+    // IDXMAX / IDXMIN PER GROUP. key=i%1000, val=i -> per group k: max at i=k+999000, min at i=k.
+    var ixf = bf_new(2, 16)
+    var ixi: i64 = 0
+    while ixi < 1000000 { var ixr:[f64;64]=[0.0;64]; ixr[0]=(ixi%1000) as f64; ixr[1]=ixi as f64; bf_push_row(&!ixf,&ixr,2); ixi=ixi+1 }
+    let imx = bf_idxmax_by(&ixf, 0, 1)
+    let imn = bf_idxmin_by(&ixf, 0, 1)
+    if bf_nrows(&imx) != 1000 { print("FAIL idxmax_n\n"); return 222 }
+    if !approx_eq(lookup2(&imx, 0.0), 999000.0) { print("FAIL idxmax_g0\n"); return 223 }     // max of group 0 at row 999000
+    if !approx_eq(lookup2(&imx, 500.0), 999500.0) { print("FAIL idxmax_g500\n"); return 224 }
+    if !approx_eq(lookup2(&imn, 0.0), 0.0) { print("FAIL idxmin_g0\n"); return 225 }           // min of group 0 at row 0
+    if !approx_eq(lookup2(&imn, 500.0), 500.0) { print("FAIL idxmin_g500\n"); return 226 }
+    // TIE: constant val -> both idxmax and idxmin return the FIRST index of the group.
+    var itf = bf_new(2, 16)
+    var iti: i64 = 0
+    while iti < 10000 { var itr:[f64;64]=[0.0;64]; itr[0]=(iti%100) as f64; itr[1]=5.0; bf_push_row(&!itf,&itr,2); iti=iti+1 }
+    let timx = bf_idxmax_by(&itf, 0, 1)
+    let timn = bf_idxmin_by(&itf, 0, 1)
+    if !approx_eq(lookup2(&timx, 7.0), 7.0) { print("FAIL idxmax_tie\n"); return 227 }   // first row of group 7 is index 7
+    if !approx_eq(lookup2(&timn, 7.0), 7.0) { print("FAIL idxmin_tie\n"); return 228 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_idxmax_by` and `bf_idxmin_by` in `data::bigframe_ops` — for each distinct `key_col`, the **original row index** where `val_col` is maximal / minimal in that group (pandas `groupby(key)[val].idxmax()` / `.idxmin()`). Returns a 2-column `[key, row_index]` BigFrame. **Ties resolve to the first (lowest-index) occurrence** (strict `>`/`<` only updates on a strictly better value), matching pandas.

One open-addressing pass mapping key → (best value, best index).

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

`key=i%1000`, `val=i` over 1M rows → per group k, max at row `k+999000` (idxmax g0=999000, g500=999500) and min at row `k` (idxmin g0=0, g500=500); plus a **tie** case (constant val) where both return the first index of the group. Both pandas-exact.

## Benchmark (1M rows, 1000 groups)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| idxmax_by / idxmin_by | ~42 | ~17 | **~2.4×** |

A single hash pass with a compare + two-field conditional update per row; pandas' groupby idxmax is well-tuned. Fits the hash-verb family. Correct and scale-verified.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)