### PR TITLE
feat(stdlib): bigframe per-group mode (bf_mode_by)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -31,6 +31,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | cumprod_by (1M rows, 1000 groups) | | ~35 | ~19 | **~1.8x** | (new verb) |
 | nunique_by (1M rows, 1000 groups) | | ~140 | ~42 | **~3.4x** | double-hash (pair-set + key-count) |
 | idxmax_by / idxmin_by (1M rows, 1000 groups) | | ~42 | ~17 | **~2.4x** | (new verb) |
+| mode_by (1M rows, 1000 groups) | | ~92 | ~89 | **~1.0x — parity** | pandas has no vectorized groupby-mode |
 | cummax (1M rows, ungrouped) | | 4.8 | 11.3 | **0.42x — Sounio wins** | (new verb) |
 | cummin (1M rows, ungrouped) | | 4.9 | 10.6 | **0.46x — Sounio wins** | (new verb) |
 | cummax_by / cummin_by (1M rows, 1000 groups) | | ~34 | ~21 | **1.6x** | (new verb) |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -9,7 +9,7 @@
 // exponentially weighted moving mean, expanding mean / var / std, rank,
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
 // rolling variance / std, rolling median, cumulative product, and
-// per-group distinct-count (nunique), and per-group idxmax / idxmin.
+// per-group distinct-count (nunique), per-group idxmax / idxmin, and per-group mode.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2213,5 +2213,111 @@ pub fn bf_idxmin_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with
     heap_free(hk as *mut i8)
     heap_free(hv as *mut i8)
     heap_free(hi as *mut i8)
+    out
+}
+
+/// Per-group MODE: for each distinct `key_col`, the most frequently occurring
+/// `val_col` value in that group (like pandas groupby(key)[val].mode()). On a
+/// frequency tie the SMALLEST value wins (matching pandas' sorted mode taken first).
+/// Returns a 2-column [key, mode] BigFrame. Two passes: count occurrences per
+/// (key,val) pair (bf_pairhash), then reduce each key to its max-count value. O(n)
+/// expected. NATIVE + lean_single only (heap).
+pub fn bf_mode_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(2, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let po = heap_alloc(size * 8) as *mut f64      // (key,val) -> occurrence count
+    let pk = heap_alloc(size * 8) as *mut f64
+    let pv = heap_alloc(size * 8) as *mut f64
+    let pc = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    var r: i64 = 0
+    while r < nr {
+        let k = read_f64(kp, r)
+        let v = read_f64(vp, r)
+        var slot = bf_pairhash(k, v, mask)
+        var done = false
+        while !done {
+            if read_f64(po, slot) == 0.0 {
+                write_f64(po, slot, 1.0)
+                write_f64(pk, slot, k)
+                write_f64(pv, slot, v)
+                write_f64(pc, slot, 1.0)
+                done = true
+            } else {
+                if read_f64(pk, slot) == k && read_f64(pv, slot) == v {
+                    write_f64(pc, slot, read_f64(pc, slot) + 1.0)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        r = r + 1
+    }
+    // Reduce per key: the value with the max count (tie -> smaller value).
+    let ko  = heap_alloc(size * 8) as *mut f64
+    let kk  = heap_alloc(size * 8) as *mut f64
+    let kbc = heap_alloc(size * 8) as *mut f64     // best count
+    let kbv = heap_alloc(size * 8) as *mut f64     // value achieving it
+    var nd: i64 = 0
+    var s: i64 = 0
+    while s < size {
+        if read_f64(po, s) == 1.0 {
+            let k = read_f64(pk, s)
+            let v = read_f64(pv, s)
+            let c = read_f64(pc, s)
+            var s2 = bf_ghash(k, mask)
+            var done2 = false
+            while !done2 {
+                if read_f64(ko, s2) == 0.0 {
+                    write_f64(ko, s2, 1.0)
+                    write_f64(kk, s2, k)
+                    write_f64(kbc, s2, c)
+                    write_f64(kbv, s2, v)
+                    nd = nd + 1
+                    done2 = true
+                } else {
+                    if read_f64(kk, s2) == k {
+                        let bc = read_f64(kbc, s2)
+                        let bv = read_f64(kbv, s2)
+                        if c > bc || (c == bc && v < bv) {
+                            write_f64(kbc, s2, c)
+                            write_f64(kbv, s2, v)
+                        }
+                        done2 = true
+                    } else {
+                        s2 = (s2 + 1) & mask
+                    }
+                }
+            }
+        }
+        s = s + 1
+    }
+    var cap = nd
+    if cap < 1 { cap = 1 }
+    var out = bf_new(2, cap)
+    s = 0
+    while s < size {
+        if read_f64(ko, s) == 1.0 {
+            var row: [f64; 64] = [0.0; 64]
+            row[0] = read_f64(kk, s)
+            row[1] = read_f64(kbv, s)
+            bf_push_row(&!out, &row, 2)
+        }
+        s = s + 1
+    }
+    heap_free(po as *mut i8)
+    heap_free(pk as *mut i8)
+    heap_free(pv as *mut i8)
+    heap_free(pc as *mut i8)
+    heap_free(ko as *mut i8)
+    heap_free(kk as *mut i8)
+    heap_free(kbc as *mut i8)
+    heap_free(kbv as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -619,6 +619,27 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     let timn = bf_idxmin_by(&itf, 0, 1)
     if !approx_eq(lookup2(&timx, 7.0), 7.0) { print("FAIL idxmax_tie\n"); return 227 }   // first row of group 7 is index 7
     if !approx_eq(lookup2(&timn, 7.0), 7.0) { print("FAIL idxmin_tie\n"); return 228 }
+    // MODE PER GROUP. key=i%1000, val = 7 if (i/1000)<500 else (i/1000)%3 -> value 7 appears 500x
+    // per group (others ~166x) -> mode=7 for all 1000 groups.
+    var mof = bf_new(2, 16)
+    var moi: i64 = 0
+    while moi < 1000000 {
+        var mor:[f64;64]=[0.0;64]; mor[0]=(moi%1000) as f64; let mj=moi/1000
+        if mj < 500 { mor[1]=7.0 } else { mor[1]=(mj-3*(mj/3)) as f64 }
+        bf_push_row(&!mof,&mor,2); moi=moi+1
+    }
+    let mo = bf_mode_by(&mof, 0, 1)
+    if bf_nrows(&mo) != 1000 { print("FAIL mode_ngroups\n"); return 229 }
+    if !approx_eq(lookup2(&mo, 0.0), 7.0) { print("FAIL mode_g0\n"); return 230 }
+    if !approx_eq(lookup2(&mo, 500.0), 7.0) { print("FAIL mode_g500\n"); return 231 }
+    if !approx_eq(bf_col_sum(&mo, 1), 7000.0) { print("FAIL mode_total\n"); return 232 }  // 1000 groups x mode 7
+    // TIE: values 2 and 5 each appear 3x (max), 9 twice -> mode = 2 (smaller wins).
+    var mtf = bf_new(2, 16)
+    var mtv:[f64;8] = [2.0,5.0,2.0,5.0,2.0,5.0,9.0,9.0]
+    var mti: i64 = 0
+    while mti < 8 { var mtr:[f64;64]=[0.0;64]; mtr[0]=0.0; mtr[1]=mtv[mti]; bf_push_row(&!mtf,&mtr,2); mti=mti+1 }
+    let mt = bf_mode_by(&mtf, 0, 1)
+    if !approx_eq(lookup2(&mt, 0.0), 2.0) { print("FAIL mode_tie\n"); return 233 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_mode_by(src, key_col, val_col)` in `data::bigframe_ops` — for each distinct `key_col`, the most frequently occurring `val_col` value in that group (pandas `groupby(key)[val].mode()`). **On a frequency tie the smallest value wins** (matching pandas' sorted mode taken first). Returns a 2-column `[key, mode]` BigFrame.

Two passes: count occurrences per **(key,val) pair** (reusing `bf_pairhash`), then reduce each key to its max-count value (tie → smaller value). `O(n)` expected.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

`key=i%1000`, `val = 7 if (i/1000)<500 else (i/1000)%3` → value 7 appears 500× per group (others ~166×) → mode=7 for all 1000 groups (total 7000); plus a **tie** case (values 2 and 5 each 3×, 9 twice) → mode=2 (smaller wins). Both pandas-exact.

## Benchmark (1M rows, 1000 groups)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| mode_by | ~92 | ~89 | **~1.0× — parity** |

pandas has no vectorized groupby-mode, so the idiomatic path is a per-group Python lambda (`.agg(lambda x: x.mode().iloc[0])`), which Sounio's two-hash-pass matches.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)