### PR TITLE
feat(stdlib): bigframe rolling correlation (bf_rolling_corr, Welford)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -50,6 +50,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rolling_var (1M rows, window 100, Welford) | | ~35 | ~42 | **~0.83x — win/parity** | (new verb) |
 | rolling_std (1M rows, window 100, +bf_sqrt) | | ~124 | ~44 | **~2.8x** | per-element sqrt-bound |
 | rolling_median (1M rows, window 100) | | ~330 | ~420 | **~0.8x — Sounio wins** | O(n·w) vs skip-list |
+| rolling_corr (1M rows, window 100, Welford) | | ~155 | ~95 | **~1.6x** | per-element sqrt-bound |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -9,7 +9,8 @@
 // exponentially weighted moving mean, expanding mean / var / std, rank,
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
 // rolling variance / std, rolling median, cumulative product, and
-// per-group distinct-count (nunique), per-group idxmax / idxmin, and per-group mode.
+// per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
+// and rolling correlation.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2319,5 +2320,73 @@ pub fn bf_mode_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with A
     heap_free(kk as *mut i8)
     heap_free(kbc as *mut i8)
     heap_free(kbv as *mut i8)
+    out
+}
+
+/// Rolling (sliding-window) Pearson correlation between columns `xcol` and `ycol`
+/// over `window` (like pandas x.rolling(window).corr(y)): out[i] = corr over the
+/// window ending at row i. A single pass with a WELFORD add/remove recurrence over
+/// two variables -- running means, the co-moment Cxy, and the two sums of squares
+/// Mx, My -- so it is numerically stable at every magnitude (never a difference of
+/// large sums). corr = Cxy / sqrt(Mx*My) via the correct bf_sqrt; a constant column
+/// (zero variance) yields 0. First window-1 rows take `fill`. O(n). NATIVE +
+/// lean_single only (heap).
+pub fn bf_rolling_corr(src: &BigFrame, xcol: i64, ycol: i64, window: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if xcol < 0 || xcol >= nc || ycol < 0 || ycol >= nc || n <= 0 || window <= 1 { return bf_new(1, 1) }
+    let xp = bf_col_ptr(src, xcol) as *mut f64
+    let yp = bf_col_ptr(src, ycol) as *mut f64
+    var out = bf_new(1, n)
+    out.n_rows = n
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64                 // scratch for bf_sqrt
+    var mx = 0.0
+    var my = 0.0
+    var cxy = 0.0
+    var mxx = 0.0
+    var myy = 0.0
+    var cnt: i64 = 0
+    var i: i64 = 0
+    while i < n {
+        if i >= window {                               // remove the pair leaving the window
+            let xo = read_f64(xp, i - window)
+            let yo = read_f64(yp, i - window)
+            cnt = cnt - 1
+            if cnt == 0 {
+                mx = 0.0
+                my = 0.0
+                cxy = 0.0
+                mxx = 0.0
+                myy = 0.0
+            } else {
+                let dx = xo - mx
+                let dy = yo - my
+                mx = mx - dx / (cnt as f64)
+                my = my - dy / (cnt as f64)
+                cxy = cxy - dx * (yo - my)
+                mxx = mxx - dx * (xo - mx)
+                myy = myy - dy * (yo - my)
+            }
+        }
+        let x = read_f64(xp, i)                        // add the entering pair
+        let y = read_f64(yp, i)
+        cnt = cnt + 1
+        let dx = x - mx
+        let dy = y - my
+        mx = mx + dx / (cnt as f64)
+        my = my + dy / (cnt as f64)
+        cxy = cxy + dx * (y - my)
+        mxx = mxx + dx * (x - mx)
+        myy = myy + dy * (y - my)
+        if i >= window - 1 {
+            let d = bf_sqrt(mxx * myy, sc)
+            if d == 0.0 { write_f64(op, i, 0.0) } else { write_f64(op, i, cxy / d) }
+        } else {
+            write_f64(op, i, fill)
+        }
+        i = i + 1
+    }
+    heap_free(sc as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -640,6 +640,30 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     while mti < 8 { var mtr:[f64;64]=[0.0;64]; mtr[0]=0.0; mtr[1]=mtv[mti]; bf_push_row(&!mtf,&mtr,2); mti=mti+1 }
     let mt = bf_mode_by(&mtf, 0, 1)
     if !approx_eq(lookup2(&mt, 0.0), 2.0) { print("FAIL mode_tie\n"); return 233 }
+    // ROLLING CORR. x=i, y=2i (perfectly correlated) -> rolling corr = 1.0 for every full window;
+    // y2=-i (anti) -> -1.0. window 50 over 5000 rows. fill=-2.0 sentinel.
+    var rcf = bf_new(3, 16)
+    var rcii: i64 = 0
+    while rcii < 5000 { var rcr:[f64;64]=[0.0;64]; rcr[0]=rcii as f64; rcr[1]=(2*rcii) as f64; rcr[2]=(0-rcii) as f64; bf_push_row(&!rcf,&rcr,3); rcii=rcii+1 }
+    let rcp = bf_rolling_corr(&rcf, 0, 1, 50, 0.0 - 2.0)
+    let rcn = bf_rolling_corr(&rcf, 0, 2, 50, 0.0 - 2.0)
+    if bf_nrows(&rcp) != 5000 { print("FAIL rcorr_n\n"); return 234 }
+    if bf_get(&rcp, 48, 0) != (0.0 - 2.0) { print("FAIL rcorr_fill\n"); return 235 }   // window not full
+    if !approx_eq(bf_get(&rcp, 49, 0), 1.0) { print("FAIL rcorr_pos49\n"); return 236 }
+    if !approx_eq(bf_get(&rcp, 2500, 0), 1.0) { print("FAIL rcorr_pos\n"); return 237 }
+    if !approx_eq(bf_get(&rcn, 2500, 0), 0.0 - 1.0) { print("FAIL rcorr_neg\n"); return 238 }
+    // varied (pandas-verified): x=(i*7)%13, y=(i*11)%17, window 100.
+    var rvf2 = bf_new(2, 16)
+    var rvfi2: i64 = 0
+    while rvfi2 < 5000 { var rvr2:[f64;64]=[0.0;64]; rvr2[0]=((rvfi2*7)%13) as f64; rvr2[1]=((rvfi2*11)%17) as f64; bf_push_row(&!rvf2,&rvr2,2); rvfi2=rvfi2+1 }
+    let rvc2 = bf_rolling_corr(&rvf2, 0, 1, 100, 0.0 - 2.0)
+    // references are pandas values rounded to 6 dp -> compare with a 1e-5 tolerance.
+    var rcd1 = bf_get(&rvc2, 100, 0) - 0.008766
+    if rcd1 < 0.0 { rcd1 = 0.0 - rcd1 }
+    if rcd1 > 0.00001 { print("FAIL rcorr_var100\n"); return 239 }
+    var rcd2 = bf_get(&rvc2, 2000, 0) - (0.0 - 0.033538)
+    if rcd2 < 0.0 { rcd2 = 0.0 - rcd2 }
+    if rcd2 > 0.00001 { print("FAIL rcorr_var2000\n"); return 240 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_rolling_corr(src, xcol, ycol, window, fill)` in `data::bigframe_ops` — rolling Pearson correlation between two columns over a sliding window (pandas `x.rolling(window).corr(y)`).

A single pass with a **Welford add/remove recurrence over two variables** (running means, the co-moment `Cxy`, and the two sums of squares `Mx`, `My`), so it stays numerically stable at every magnitude (never a difference of large sums). `corr = Cxy / sqrt(Mx·My)` via the correct `bf_sqrt`; a constant column yields 0. First `window-1` rows take `fill`.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- `x=i`, `y=2i` (perfectly correlated) → rolling corr = **1.0** for every full window;
- `y2=-i` → **−1.0**;
- varied data (`x=(i*7)%13`, `y=(i*11)%17`, window 100) matches pandas to 6 dp (0.008766, −0.033538);
- `fill` before the window fills.

## Benchmark (1M rows, window 100)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| rolling_corr | ~155 | ~95 | **~1.6×** |

Per-element `bf_sqrt` plus the six-accumulator co-moment; pandas rolling corr is itself heavy, so this is better than `rolling_std`'s 2.8×. The `sqrtsd` compiler fix would improve it further.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)