### PR TITLE
feat(stdlib): bigframe rolling kurtosis (bf_rolling_kurt)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -53,6 +53,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rolling_corr (1M rows, window 100, Welford) | | ~155 | ~95 | **~1.6x** | per-element sqrt-bound |
 | rolling_cov (1M rows, window 100, Welford) | | ~75 | ~100 | **~0.7x — Sounio wins** | no sqrt (vs rolling_corr) |
 | rolling_skew (1M rows, window 100) | | ~130 | ~35 | **~3.8x** | per-element sqrt-bound |
+| rolling_kurt (1M rows, window 100) | | ~78 | ~28 | **~2.7x** | 4th-power sums; pandas Cython roll_kurt |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -10,7 +10,7 @@
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
 // rolling variance / std, rolling median, cumulative product, and
 // per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
-// rolling correlation, and rolling covariance / skewness.
+// rolling correlation, and rolling covariance / skewness / kurtosis.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2493,5 +2493,66 @@ pub fn bf_rolling_skew(src: &BigFrame, col: i64, window: i64, fill: f64) -> BigF
         i = i + 1
     }
     heap_free(sc as *mut i8)
+    out
+}
+
+/// Rolling (sliding-window) sample excess KURTOSIS of column `col` over `window`
+/// (like pandas col.rolling(window).kurt()): the bias-corrected Fisher excess
+/// kurtosis G2 = (w-1)/((w-2)(w-3)) * [(w+1)*(m4/m2^2 - 3) + 6], from the window's
+/// 2nd and 4th central moments. Sliding power sums S1/S2/S3/S4 (add entering,
+/// subtract leaving), shifted by the global mean (moments are shift-invariant) for
+/// conditioning. NO sqrt (it is a ratio of even moments). A zero-variance window
+/// yields 0. Requires window >= 4; first window-1 rows take `fill`. O(n). NATIVE +
+/// lean_single only (heap).
+pub fn bf_rolling_kurt(src: &BigFrame, col: i64, window: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    if col < 0 || col >= bf_ncols(src) || n <= 0 || window <= 3 { return bf_new(1, 1) }
+    let sp = bf_col_ptr(src, col) as *mut f64
+    var out = bf_new(1, n)
+    out.n_rows = n
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var gs = 0.0
+    var g: i64 = 0
+    while g < n { gs = gs + read_f64(sp, g); g = g + 1 }
+    let k = gs / (n as f64)                             // global-mean shift
+    let wf = window as f64
+    let c1 = (wf - 1.0) / ((wf - 2.0) * (wf - 3.0))     // bias factor, constant
+    var s1 = 0.0
+    var s2 = 0.0
+    var s3 = 0.0
+    var s4 = 0.0
+    var i: i64 = 0
+    while i < n {
+        let d = read_f64(sp, i) - k
+        let d2 = d * d
+        s1 = s1 + d
+        s2 = s2 + d2
+        s3 = s3 + d2 * d
+        s4 = s4 + d2 * d2
+        if i >= window {
+            let o = read_f64(sp, i - window) - k
+            let o2 = o * o
+            s1 = s1 - o
+            s2 = s2 - o2
+            s3 = s3 - o2 * o
+            s4 = s4 - o2 * o2
+        }
+        if i >= window - 1 {
+            let m = s1 / wf
+            let m2s = s2 - s1 * m                       // Σ(x-x̄)² over the window
+            let m4s = s4 - 4.0 * m * s3 + 6.0 * m * m * s2 - 4.0 * m * m * m * s1 + wf * m * m * m * m
+            if m2s <= 0.0 {
+                write_f64(op, i, 0.0)
+            } else {
+                let m2b = m2s / wf
+                let m4b = m4s / wf
+                let g2 = m4b / (m2b * m2b) - 3.0
+                write_f64(op, i, c1 * ((wf + 1.0) * g2 + 6.0))
+            }
+        } else {
+            write_f64(op, i, fill)
+        }
+        i = i + 1
+    }
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -686,6 +686,19 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var skd2 = bf_get(&sk, 2000, 0) - (0.0 - 0.012472)
     if skd2 < 0.0 { skd2 = 0.0 - skd2 }
     if skd2 > 0.00001 { print("FAIL rskew_2000\n"); return 246 }
+    // ROLLING KURT. varied data matches pandas to 6 dp (1e-5 tol). window 100.
+    var kuf = bf_new(1, 16)
+    var kui: i64 = 0
+    while kui < 5000 { var kur:[f64;64]=[0.0;64]; kur[0]=((kui*7)%13 + (kui%5)) as f64; bf_push_row(&!kuf,&kur,1); kui=kui+1 }
+    let ku = bf_rolling_kurt(&kuf, 0, 100, 0.0 - 999.0)
+    if bf_nrows(&ku) != 5000 { print("FAIL rkurt_n\n"); return 247 }
+    if bf_get(&ku, 98, 0) != (0.0 - 999.0) { print("FAIL rkurt_fill\n"); return 248 }   // window not full
+    var kud1 = bf_get(&ku, 100, 0) - (0.0 - 0.913665)
+    if kud1 < 0.0 { kud1 = 0.0 - kud1 }
+    if kud1 > 0.00001 { print("FAIL rkurt_100\n"); return 249 }
+    var kud2 = bf_get(&ku, 4999, 0) - (0.0 - 0.990208)
+    if kud2 < 0.0 { kud2 = 0.0 - kud2 }
+    if kud2 > 0.00001 { print("FAIL rkurt_4999\n"); return 250 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_rolling_kurt(src, col, window, fill)` in `data::bigframe_ops` — rolling **bias-corrected sample excess kurtosis** (pandas `col.rolling(window).kurt()`): `G2 = (w-1)/((w-2)(w-3)) · [(w+1)·(m4/m2² − 3) + 6]`, from the window's 2nd and 4th central moments. Sliding power sums S1/S2/S3/S4 (add entering, subtract leaving), shifted by the global mean (moments are shift-invariant) for conditioning. **No sqrt** (a ratio of even moments). Requires `window >= 4`.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

Varied data (`x=(i*7)%13 + i%5`, window 100) matches pandas to 6 dp (−0.913665, −0.990208); `fill` before the window fills.

## Benchmark (1M rows, window 100)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| rolling_kurt | ~78 | ~28 | **~2.7×** |

No sqrt, but the per-element 4th-power sums (S1..S4) are heavy and pandas' Cython `roll_kurt` is fast. Correct and gate-verified.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

This completes the rolling statistical surface: sum · mean · max · min · var · std · median · corr · cov · skew · kurt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)