### PR TITLE
fix(madaros): joint D5+D1 f64-param cast truncation (#986+#983)

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -2291,8 +2291,15 @@ fn lowerer_lower_fn_params_mut(
                     lowerer_mark_local_array_copy_word_scalar_mut(lo, (*list).head.name)
                 }
                 lowerer_bind_local_struct_type_mut(lo, (*list).head.name, lower_param_struct_type_name(&(*list).head.ty))
+                // D5+D1 (#986+#983): path-A param scalar_kind must use the single-level
+                // Box store. The by-value `(*lo) = (*lo).bind_local_scalar_kind(...)`
+                // RMW is dropped by the by-value-aggregate-store miscompile, leaving
+                // f64 params at kind 0 so `x as i64` bitcasts (IEEE payload) instead of
+                // truncating. Also bind i64→1 so println of i64 params stays on print_int.
                 if lower_type_expr_is_f64(&(*list).head.ty) {
-                    (*lo) = (*lo).bind_local_scalar_kind((*list).head.name, 2)
+                    lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 2)
+                } else if lower_type_expr_is_i64(&(*list).head.ty) {
+                    lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 1)
                 }
                 if lower_type_expr_is_ref_like(&(*list).head.ty) {
                     lowerer_mark_local_ref_mut(lo, (*list).head.name)
@@ -2360,6 +2367,15 @@ fn lowerer_lower_fn_item_mut(
     (*lo).locals = rst_locals
     (*lo).scope_depth = 0
     (*lo).loop_depth = 0
+    // D5 (#986): these tables are keyed by vreg number, which restarts at 0 in
+    // every function. Without a per-function reset, float/variance registrations
+    // from an earlier f64-param function (param reg 0, etc.) leak into later
+    // functions and make `var i = 0 as i64; i = i + 1` lower as float-add
+    // (IEEE 1.0 bits) once f64 params correctly carry scalar_kind=2.
+    (*lo).array_elem_float_reg_count = 0
+    (*lo).variance_base_reg_count = 0
+    (*lo).pending_variance_reg = -1
+    (*lo).pending_closure_fn_id = -1
     if lower_live_diag_enabled() {
         print("lower_live: fn_state_after_begin current_fn=")
         print_int((*lo).current_fn)
@@ -2690,6 +2706,13 @@ fn lowerer_record_global_type_mut(
 fn lower_opt_type_is_f64(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
     match *opt {
         Some(te) => lower_type_expr_is_f64(&(*te)),
+        None => false,
+    }
+}
+
+fn lower_opt_type_is_i64(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *opt {
+        Some(te) => lower_type_expr_is_i64(&(*te)),
         None => false,
     }
 }
@@ -3375,6 +3398,11 @@ impl Lowerer {
         lo.locals = Box::new(rst_locals)
         lo.scope_depth = 0
         lo.loop_depth = 0
+        // D5 (#986): per-function reset of vreg-keyed float/variance tables.
+        lo.array_elem_float_reg_count = 0
+        lo.variance_base_reg_count = 0
+        lo.pending_variance_reg = -1
+        lo.pending_closure_fn_id = -1
         lo
     }
 
@@ -6564,7 +6592,16 @@ impl Lowerer {
                         locals.wide_bits[idx as usize] = 0
                         locals.wide_signed[idx as usize] = 0
                         locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
-                        locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) { 2 } else { 0 }
+                        // D5+D1 (#986+#983): f64 params → kind 2 (cast + float-print);
+                        // i64 params → kind 1 (println safety). Bare int `as i64` stays
+                        // identity because only kind 2 triggers IrFloatToInt.
+                        locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) {
+                            2
+                        } else if lower_type_expr_is_i64(&(*list).head.ty) {
+                            1
+                        } else {
+                            0
+                        }
                         locals.count = idx + 1
                     } else {
                         lo = lo.report_error()
@@ -6752,6 +6789,11 @@ impl Lowerer {
         lo.locals = Box::new(rst_locals2)
         lo.scope_depth = 0
         lo.loop_depth = 0
+        // D5 (#986): per-function reset of vreg-keyed float/variance tables.
+        lo.array_elem_float_reg_count = 0
+        lo.variance_base_reg_count = 0
+        lo.pending_variance_reg = -1
+        lo.pending_closure_fn_id = -1
         if lower_live_diag_enabled() {
             print("lower_live: fn_after_begin name=")
             print(str_from_bytes(name.buf, name.len))
@@ -6941,6 +6983,11 @@ impl Lowerer {
         lo.locals = Box::new(rst_locals3)
         lo.scope_depth = 0
         lo.loop_depth = 0
+        // D5 (#986): per-function reset of vreg-keyed float/variance tables.
+        lo.array_elem_float_reg_count = 0
+        lo.variance_base_reg_count = 0
+        lo.pending_variance_reg = -1
+        lo.pending_closure_fn_id = -1
         if lower_body_diag_enabled() {
             lower_body_trace_append("fn_after_begin name=" + str_from_bytes(name.buf, name.len))
         }
@@ -7361,12 +7408,22 @@ impl Lowerer {
         }
         if lower_opt_type_is_f64(&s.ty) {
             lo = lo.bind_local_scalar_kind(s.name, 2)
+        } else if lower_opt_type_is_i64(&s.ty) {
+            // D5 (#986): annotated `var i: i64 = ...` is positively int (println +
+            // cast consumers). Mirrors f64 annotation binding above.
+            lo = lo.bind_local_scalar_kind(s.name, 1)
         } else {
             match s.expr {
                 Some(expr_box_sk) => {
                     if (*expr_box_sk).kind == ExprKind::ExprIntLit {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if (*expr_box_sk).kind == ExprKind::ExprBoolTrue || (*expr_box_sk).kind == ExprKind::ExprBoolFalse {
+                        lo = lo.bind_local_scalar_kind(s.name, 1)
+                    } else if (*expr_box_sk).kind == ExprKind::ExprCast && lower_cast_type_is_i64(&(*expr_box_sk).cast_type) {
+                        // D5 (#986): `var i = 0 as i64` is an int local. Without this
+                        // the cast RHS left kind 0, and once f64 params correctly carry
+                        // kind 2 the cross-fn variance/float-reg tables (or cast path)
+                        // could treat the counter as float.
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if lo.expr_result_is_float_ref(&(*expr_box_sk)) {
                         lo = lo.bind_local_scalar_kind(s.name, 2)
@@ -10435,6 +10492,11 @@ impl Lowerer {
         lo.locals = Box::new(empty_lower_local_stack())
         lo.scope_depth = 0
         lo.loop_depth = 0
+        // D5 (#986): per-function reset of vreg-keyed float/variance tables.
+        lo.array_elem_float_reg_count = 0
+        lo.variance_base_reg_count = 0
+        lo.pending_variance_reg = -1
+        lo.pending_closure_fn_id = -1
         lo.allow_direct_capturing_closure_literal = false
 
         // 3b. Bind captured variables as LEADING params of the synthetic fn, so the body's

--- a/tests/run-pass/f64_param_cast_truncation.sio
+++ b/tests/run-pass/f64_param_cast_truncation.sio
@@ -1,0 +1,35 @@
+//@ run-pass
+// D5+D1 (#986+#983): f64 parameter `as i64` must truncate, not bitcast.
+// Before fix: f(4.172) → 4616383272838735331 (IEEE payload of 4.172).
+// After fix:  f(4.172) → 4, f(-3.9) → -3 (toward zero). Bare int `as i64`
+// stays identity so ARIMA-style zeros do not emit IrFloatToInt.
+
+fn f64_to_i64(x: f64) -> i64 {
+    return x as i64
+}
+
+fn int_lit_as_i64() -> i64 {
+    return 0 as i64
+}
+
+fn main() -> i64 with IO, Mut, Div, Panic {
+    let a = f64_to_i64(4.172)
+    let b = f64_to_i64(0.0 - 3.9)
+    let c = int_lit_as_i64()
+    let local: f64 = 4.172
+    let d = local as i64
+
+    if a != 4 {
+        return 1
+    }
+    if b != (0 - 3) {
+        return 2
+    }
+    if c != 0 {
+        return 3
+    }
+    if d != 4 {
+        return 4
+    }
+    return 0
+}


### PR DESCRIPTION
## Summary

Joint fix for **#983 (D1)** and **#986 (D5)**: f64 parameter `as i64` was an IEEE bitcast; the scalar_kind-only fix is unsafe without D5.

### Root cause (Agent F + implementer measurement)

- Path A (`lowerer_lower_fn_params_mut`) set f64 param `scalar_kind` via `(*lo) = (*lo).bind_local_scalar_kind(...)`, a by-value RMW dropped by the aggregate-store miscompile → params stayed kind 0.
- `lower_cast_expr_ref` only emits `IrFloatToInt` when the source is a proven float (`scalar_kind==2`) → identity pass-through → bitcast (`4.172` → `4616383272838735331`).
- Landing kind 2 alone unmasks **D5**: vreg-keyed `variance_base_regs` / `array_elem_float_regs` were **not reset per function** (vregs restart at 0), so after any earlier f64-param function, `var i = 0 as i64; i = i + 1` became float-add (IEEE `1.0` bits → hang in ARIMA-style loops).

### Changes (`self-hosted/ir/lower.sio`)

1. **D1:** Bind param scalar_kind with `lowerer_mark_local_scalar_kind_mut` — f64→2, i64→1 — in path A; same mapping in `lower_fn_params_ref`.
2. Keep `ir_mark_float_reg` for f64 params only (unchanged).
3. Cast path unchanged: only kind 2 / float provenance → `IrFloatToInt`; bare `0 as i64` stays identity.
4. **D5:** Reset `array_elem_float_reg_count`, `variance_base_reg_count`, `pending_variance_reg`, `pending_closure_fn_id` at every function begin (all lower paths).
5. Bind kind 1 for annotated `i64` locals and `ExprCast` to i64.

**Not done (intentionally):** float-marker preservation in `ocp_compact_nops` — measured as unsafe (pollutes reg typing). stdlib `gum.sio` untouched.

### Test

- `tests/run-pass/f64_param_cast_truncation.sio` — param cast 4.172→4, −3.9→−3, int-lit identity, local cast.

## Evidence table

| Case | Before (clean rebuild) | After (this PR, rebuilt Madaros) |
|---|---|---|
| `f(4.172)` param helper | `4616383272838735331` | `4` |
| `f(-3.9)` | IEEE bits of −3.9 | `−3` |
| `0 as i64` / `1 as i64` | identity | identity |
| Local `let x: f64 = 4.172; x as i64` | `4` | `4` |
| GUM small-dof `k95*1000` (`gum_combine2(100, type_a(1,5), type_b(1e-4))`) | n/a (cast bug masked by `dof+0.5` workaround in stdlib; bare param cast broken) | `2776` (t95(4)); `dof*100=400` |
| Bare `dof as i64` (no +0.5) | bitcast | `4` |
| ARIMA `arima_levinson_ar2` | 6/6 PASS | 6/6 PASS |
| `0 as i64` after f64-param fn (D5) | PASS on clean | PASS (was hang/float-add without D5 reset) |
| println f64/i64 params | — | no SEGV (`3.5`, `42`, `−7`) |
| `f64_param_arithmetic_regression` | — | exit 0 |
| `autodiff_tape_basic` | — | exit 0 |

Note: committed `witness_gum_k95.sio` still prints `1960` because its Type-B dominates to infinite ν (correct k=1.960); use the small-dof trip-wire above for D1.

## Gate commands

```bash
SOUNIO_BUILD_LOCK=/tmp/sounio-d5d1-build.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros

export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
export MADAROS_RAW_BIN=$(pwd)/artifacts/self-hosted/madaros

./bin/souc run tests/run-pass/f64_param_cast_truncation.sio   # exit 0
./bin/souc run tests/run-pass/arima_levinson_ar2.sio          # 6/6 PASS
# minimal param cast:
#   fn f(x: f64) -> i64 { x as i64 }; f(4.172) → 4
```

## Residual risks

- Negative `print(f64)` still prints magnitude wrong (`-0.000000` for −2.25) — known separate defect (`MADAROS_PRINT_NEGATIVE_F64`), not SEGV.
- Existing `witness_gum_k95` is mis-designed for D1 flip detection (infinite-dof Type-B).
- `dof_to_i64` still uses `dof + 0.5` rounding; not changed (non-goal).
- Full suite not re-run here; ARIMA/autodiff/println smoke only for D5 class.

Closes #983, closes #986 (with #932 related).