### PR TITLE
docs(research): the σ_min composition-failure field + min-path in full 16-dim 𝕊 (the load-bearing step)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1048
-- Repo-backed topics: 898
+- Total governed topics: 1049
+- Repo-backed topics: 899
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 220
+- Authority count `historical`: 221
 - Authority count `repo_only`: 640
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 254 topics
+- A6: 255 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -660,6 +660,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.cd-tower-seam | historical | docs/research/cd_tower_seam.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.chi5-mathlib-free-novelty-2026-05-30 | historical | docs/research/chi5-mathlib-free-novelty-2026-05-30.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.commutator-associator-identity | historical | docs/research/commutator_associator_identity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.composition-failure-field | historical | docs/research/composition-failure-field.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.cpc2026-orc-group-preregistration-2026-07-11 | historical | docs/research/cpc2026_orc_group_preregistration_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.cpc2026-yale-evidence-dossier-2026-07-11 | historical | docs/research/cpc2026_yale_evidence_dossier_2026-07-11.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.delta-epistemic-gradual-compilation-paper | historical | docs/research/delta_epistemic_gradual_compilation_paper.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14639,6 +14639,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.composition-failure-field",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/composition-failure-field.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.cpc2026-orc-group-preregistration-2026-07-11",
       "collection": "repo",
       "repo_doc_path": "docs/research/cpc2026_orc_group_preregistration_2026-07-11.md",

--- a/docs/research/composition-failure-field.md
+++ b/docs/research/composition-failure-field.md
@@ -1,0 +1,76 @@
+<!-- docs:meta
+topic_id: repo.docs.research.composition-failure-field
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.composition-failure-field
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The suffering field from the algebra — σ_min composition-failure, and the min-path in full 16-dim 𝕊
+
+*The load-bearing step. Everything prior demonstrated properties of an invented 2D field; this derives the
+field from the algebraic object and computes the minimum-suffering path in the **full** sedenion space —
+the only step that makes the result a claim about the algebra rather than about a chosen picture.
+Implements OPUS-4.8-EXTRA critique #3 (§4b+c, §5) and its technical correction.*
+
+## The correct field (not `det L_x`)
+
+`det L_x` is the wrong object: it is a degree-16 polynomial (magnitude dominated by `‖x‖`, not by proximity
+to annihilation), and `det = ∏σᵢ` can be small for a uniformly small operator with no near-singularity.
+The correct object is the **smallest singular value**. By **Eckart–Young–Mirsky**, `σ_min(L_x)` is exactly
+the spectral-norm distance from `L_x` to the nearest singular operator — the distance to annihilation.
+Scale-invariant field on the unit sphere:
+
+    s(x) = − log σ_min(L_x)          (‖x‖ = 1)
+
+**This closes the conceptual loop the whole program needed.** Composition failure — `‖xy‖ ≠ ‖x‖·‖y‖`,
+precisely what separates 𝕊 from the normed division algebras — is measured by the **dispersion of the
+singular values of `L_x`**: in a composition algebra all `σᵢ` coincide and `L_x` is a similarity; in 𝕊 they
+spread, and `σ_min` is the extreme of that spread. So the σ-field is not a numerical convenience — it is the
+**direct quantification of composition failure**, which was the missing bridge between the algebra and the
+notion of suffering. The technical correction and the epistemological bridge are the same object.
+
+## Method — full space, no slice, no grid (`neb_sigmin.py`)
+
+Fast marching dies above 3–4 dimensions and any 2D slice re-synthesizes the field under another name; so
+the path is computed by a **trajectory optimizer in the full 16-dim space** (dimension-agnostic, no grid
+anisotropy — this also settles the §4a numerical-hygiene concern). Concretely: the **string method** on the
+unit sphere `S¹⁵` (robust where NEB tangled — the perpendicular force diverges at `σ_min→0`), with an
+**analytic `σ_min` gradient** `∂σ_min/∂x_k = uₘᵢₙᵀ M_k vₘᵢₙ` (`M_k` the constant structure matrices,
+`L_x = Σ x_k M_k`; one SVD per image). No arbitrary slice: the endpoints are placed by the algebra
+(symmetric about a genuine zero divisor `z`, so the geodesic passes through annihilation).
+
+## Result (real σ_min field, converged)
+
+| path | peak s (= c*) | ∫s ds | length (rad) |
+|---|---|---|---|
+| straight (great circle, through `z`) — reward/shortest | 4.175 | 1.840 | 1.200 |
+| min-energy path (string method) | **0.688** | 0.238 | 3.420 |
+
+- **Annihilation is avoidable** between same-`det`-component endpoints: `c* = 0.688`, finite and far below the
+  straight-through peak `4.175`. And the **structural dichotomy**: were `A, B` in *opposite* `det`-components,
+  `c*` would diverge — annihilation would be **unavoidable**. Whether relational annihilation can be escaped
+  is decided by whether the two states lie in the same sign-component of the multiplication determinant.
+- **Mercy Pareto-dominates reward** on *both* suffering axes (peak `4.18→0.69` **and** `∫s 1.84→0.24`),
+  paying only in length (`+185%`). So on the real locus the tension is not utilitarian-vs-Rawlsian (both
+  criteria avoid the ridge) but **efficiency-vs-suffering**: the short path plows through near-annihilation,
+  and minimizing suffering by either criterion demands a substantial detour reward-maximization would never
+  take. This is the real-algebra analog of `mountain_pass.py`'s §1 — reward-efficiency is blind to the
+  ridge here too, but now on a field that is *derived*, not invented.
+
+## Honest scope
+
+Settled: the field is algebraic (σ_min = composition failure, Eckart–Young), the computation is full-space
+and slice-free, annihilation is avoidable/`c*` finite for same-component states (unavoidable across
+components), and mercy strictly dominates reward on both suffering axes. **Not yet settled:** whether the
+aggregation (`min ∫s`) and maximin (`min max s`) criteria *diverge* on the real locus — the thin/thick
+regime of the critique's taxonomy — which needs the separate `min ∫s` path in full space and is **not**
+claimed from the reward-vs-MEP comparison here. That, and a climbing-image refinement of `c*` (the
+transition-state proper), are the next cut. The Alveo-U250 HLS backend stays last: engineering that pays
+only once the object being computed is known — and now it is (the σ_min field, in full 𝕊).

--- a/docs/research/mercyful-learning.md
+++ b/docs/research/mercyful-learning.md
@@ -226,3 +226,36 @@ maximin paid `0.460` (bottleneck algorithms return an arbitrary representative o
 **Honest reframing (owed).** "The algebra does not determine the ethics" is a conceptual thesis the figure
 *illustrates*, not proves. What the figure *demonstrates* is the §1 Proposition — a stronger and citable
 result. State it that way.
+
+## μ*, L_lex, and the field taxonomy (third review)
+
+**The price of mercy is a decision threshold, not "cheap."** For a decider with peak-aversion `μ`, criterion
+`K = ∫s + μ·max s`: the aggregative path costs `0.098 + 2.713μ`, the leximin costs `0.144 + 0.552μ`, so
+leximin wins iff `μ > 0.046/2.161 = 0.021`. The "price of mercy" **is** `μ*`, the **critical peak-aversion**,
+and the aggregative criterion is exactly `μ = 0`. Publishable form:
+
+> Choosing the aggregative trajectory on this field requires holding that one unit of *peak* suffering is
+> worth **less than 2.1%** of one unit of accumulated suffering — a position no reflective agent and no
+> clinical protocol sustains. Aggregationism is defeated not by moral appeal but by **revealed preference
+> over a computed threshold**: "is your peak-aversion above 0.021?" — obviously yes.
+
+**Missing number, now reported:** the leximin path length `L_lex = 1.128`. It is obligatory — without it the
+reader cannot reconstruct `J(λ) = L + λ∫s` or verify dominance. And the dominance is **structural, not
+lucky**: `J_lex − J_straight = (L_lex − 0.842) + λ(0.144 − 0.098)`; the straight segment is the Euclidean
+length-minimizer so any deviation has `ΔL > 0` by definition, and `Δ∫s > 0` too, so the horizontal λ-sweep
+is guaranteed by geometry.
+
+**The taxonomy the frontier authorizes** (diagnosable from the field *before* choosing an ethics; barrier
+cross-section `∼H·w` and detour geometry are independent):
+
+| barrier | detour | consequence |
+|---|---|---|
+| thin | cheap | aggregation crosses the agony; maximin protection ~free — *the 2D-toy regime* |
+| thin | expensive | the criteria diverge and it matters — the hard case |
+| thick | cheap | both avoid; nothing to discuss |
+| thick | expensive | both accept the pain; the question is only *where* to cross |
+
+So the strong thesis is not "the algebra makes ethics explicit" but: **the geometry of the field determines
+whether the ethical choice is consequential**, and there is a regime where Rawlsian protection comes at
+utilitarian price. Which regime the *real* algebraic locus (`composition-failure-field.md`) occupies is the
+open question that computation, not rhetoric, must answer.

--- a/docs/research/neb_sigmin.py
+++ b/docs/research/neb_sigmin.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# The load-bearing step (OPUS-4.8-EXTRA critique #3, §4b+c+§5): the suffering field derived FROM THE
+# ALGEBRA, and the minimum-suffering path computed by NEB in the FULL 16-dim sedenion space — no grid, no
+# arbitrary slice. Field (critique §5): s(x) = −log σ_min(L_x) on the unit sphere (scale-invariant). By
+# Eckart–Young–Mirsky σ_min(L_x) is the spectral-norm distance to the nearest singular operator; and the
+# DISPERSION of the singular values of L_x IS the failure of composition (|xy|≠|x||y|, what separates 𝕊
+# from the normed division algebras) — so this field is the direct quantification of composition failure,
+# not a numerical convenience. NOT det L_x (degree-16, scale-blows-up, det=∏σ measures the wrong thing).
+import numpy as np
+np.seterr(all='ignore')
+def cds(a,b,bits=4):
+    s=1
+    while bits>0:
+        if a==0 or b==0: return s
+        if bits==1: return -s
+        h=1<<(bits-1);ah=a>=h;bh=b>=h;al=a&(h-1);bl=b&(h-1)
+        if not ah and not bh:a,b=al,bl
+        elif not ah and bh:a,b=bl,al
+        elif ah and not bh:(a,b,s)=((al,0,s) if bl==0 else (al,bl,-s))
+        else:(a,b,s)=((0,al,-s) if bl==0 else (bl,al,s))
+        bits-=1
+    return s
+SIG=np.array([[cds(i,j) for j in range(16)] for i in range(16)])
+# L_x = Σ_k x_k M_k with M_k[a,b] = σ(k,b)·[a = k^b]
+M=np.zeros((16,16,16))
+for k in range(16):
+    for b in range(16): M[k, k^b, b]=SIG[k,b]
+def Lx(x): return np.tensordot(x,M,axes=(0,0))           # (16,16)
+FLOOR=1e-6
+def sval(x):                                              # s, and analytic grad wrt x (on the sphere)
+    L=Lx(x); U,sv,Vt=np.linalg.svd(L); smin=max(sv[-1],FLOOR)
+    u=U[:,-1]; v=Vt[-1]
+    dsig=np.array([u@M[k]@v for k in range(16)])          # ∂σ_min/∂x_k = uᵀ M_k v
+    s=-np.log(smin); grad=-dsig/smin                      # ∂(−log σ)/∂x = −dσ/σ
+    return s, grad
+def proj(x,g): return g-(g@x)*x                           # tangent projection on unit sphere
+def sphere_s(x): return sval(x/np.linalg.norm(x))[0]
+# ---- endpoints symmetric about a zero divisor z, so the geodesic PASSES THROUGH annihilation ----
+rng=np.random.default_rng(3)
+z=np.zeros(16); z[1]=1; z[10]=1; z/=np.linalg.norm(z)     # a zero divisor: σ_min(L_z)=0
+w=rng.standard_normal(16); w=proj(z,w); w/=np.linalg.norm(w)
+th=0.6
+A=np.cos(th)*z+np.sin(th)*w; B=np.cos(th)*z-np.sin(th)*w  # geodesic midpoint = z (annihilation)
+A/=np.linalg.norm(A); B/=np.linalg.norm(B)
+print(f"z is zero divisor: σ_min(L_z) = {np.linalg.svd(Lx(z),compute_uv=False)[-1]:.2e}")
+print(f"det sign  A: {np.sign(np.linalg.det(Lx(A))):+.0f}   B: {np.sign(np.linalg.det(Lx(B))):+.0f}  "
+      f"({'same component' if np.sign(np.linalg.det(Lx(A)))==np.sign(np.linalg.det(Lx(B))) else 'DIFFERENT components → annihilation unavoidable'})")
+# ---- straight (great-circle) reference ----
+def geodesic(A,B,N):
+    om=np.arccos(np.clip(A@B,-1,1)); return [ (np.sin((1-t)*om)*A+np.sin(t*om)*B)/np.sin(om) for t in np.linspace(0,1,N)]
+def path_stats(P):
+    ss=[sphere_s(p) for p in P]; ln=sum(np.arccos(np.clip(P[k]@P[k+1],-1,1)) for k in range(len(P)-1))
+    integ=sum(0.5*(ss[k]+ss[k+1])*np.arccos(np.clip(P[k]@P[k+1],-1,1)) for k in range(len(P)-1))
+    return max(ss), integ, ln
+N=40; straight=geodesic(A,B,N)
+pk_s,in_s,ln_s=path_stats(straight)
+# ---- STRING METHOD on the sphere (robust where NEB tangles): descend s, then reparametrize by arclength ----
+def slerp(p,q,t):
+    om=np.arccos(np.clip(p@q,-1,1))
+    if om<1e-9: return p
+    return (np.sin((1-t)*om)*p+np.sin(t*om)*q)/np.sin(om)
+def reparam(band):
+    Ls=[0.0]
+    for k in range(len(band)-1): Ls.append(Ls[-1]+np.arccos(np.clip(band[k]@band[k+1],-1,1)))
+    tot=Ls[-1]; out=[band[0]]
+    for i in range(1,len(band)-1):
+        target=tot*i/(len(band)-1); k=0
+        while k<len(Ls)-2 and Ls[k+1]<target: k+=1
+        seg=Ls[k+1]-Ls[k]; t=0.0 if seg<1e-12 else (target-Ls[k])/seg
+        out.append(slerp(band[k],band[k+1],t))
+    out.append(band[-1]); return out
+band=[p.copy() for p in straight]; dt=0.03; MAXSTEP=0.05
+for it in range(3000):
+    for i in range(1,N-1):
+        _,g=sval(band[i]); step=-proj(band[i],g)
+        nrm=np.linalg.norm(step)
+        if nrm>MAXSTEP: step=step/nrm*MAXSTEP
+        band[i]=band[i]+dt*step; band[i]/=np.linalg.norm(band[i])
+    band=reparam(band)
+pk_n,in_n,ln_n=path_stats(band)
+print(f"\n{'path':<22}{'peak s (=c*)':>13}{'∫s ds':>10}{'length(rad)':>13}")
+print(f"{'STRAIGHT (reward)':<22}{pk_s:>13.3f}{in_s:>10.3f}{ln_s:>13.3f}")
+print(f"{'NEB min-energy path':<22}{pk_n:>13.3f}{in_n:>10.3f}{ln_n:>13.3f}")
+dpk=pk_s-pk_n; dlen=ln_n-ln_s
+print(f"\nREAL-ALGEBRA field (σ_min of L_x, full 16-dim 𝕊 — the load-bearing step; not an invented field):")
+print(f"  • annihilation is AVOIDABLE between same-component endpoints: c* (min-energy saddle) = {pk_n:.3f},")
+print(f"    finite and far below the straight-through-annihilation peak {pk_s:.3f}. (Were A,B in opposite")
+print(f"    det-components, c* would diverge — annihilation unavoidable; a real structural dichotomy.)")
+if in_n<in_s and pk_n<pk_s:
+    print(f"  • the merciful (min-energy) path PARETO-DOMINATES the reward/shortest path on BOTH suffering axes")
+    print(f"    (peak {pk_s:.2f}→{pk_n:.2f} AND ∫s {in_s:.2f}→{in_n:.2f}); it pays ONLY in length (+{100*dlen/ln_s:.0f}%).")
+    print(f"  • so in the real field the tension is NOT utilitarian-vs-Rawlsian (both avoid the ridge) but")
+    print(f"    EFFICIENCY-vs-SUFFERING: the short path plows through near-annihilation; minimizing suffering")
+    print(f"    (either criterion) demands a substantial detour that reward-maximization would never take.")
+print(f"  • HONEST SCOPE: this settles that annihilation is avoidable and mercy≫reward on the real locus.")
+print(f"    Whether aggregation(min ∫s) and maximin(min max s) DIVERGE here (the thin/thick regime) needs")
+print(f"    the separate min-∫s path — deferred; not claimed from a reward-vs-MEP comparison.")


### PR DESCRIPTION
The step that makes the result a claim about the **algebra**, not an invented field. Implements critique #3 (§4b+c, §5).

**Correct field (not `det L_x`).** `det` is degree-16 (scale-blows-up) and `∏σ` measures the wrong thing. The correct object is **`σ_min(L_x)`** — by **Eckart–Young–Mirsky** the spectral-norm distance to the nearest singular operator. Field `s(x) = −log σ_min(L_x)` on `S¹⁵`. And this **closes the conceptual loop**: composition failure (`‖xy‖≠‖x‖‖y‖`, what separates 𝕊 from division algebras) *is* the dispersion of `L_x`'s singular values — so the σ-field is the direct quantification of composition failure, the missing bridge algebra↔suffering.

**Full space, no slice, no grid.** String method on `S¹⁵` (robust where NEB tangled) with analytic `σ_min` gradient (`∂σ/∂x_k = uᵀM_k v`); endpoints placed by the algebra (symmetric about a genuine zero divisor).

**Result:**
| path | peak (c*) | ∫s | length |
|---|---|---|---|
| straight (reward) | 4.175 | 1.840 | 1.200 |
| min-energy | **0.688** | 0.238 | 3.420 |

- **Annihilation avoidable** (same det-component): `c*=0.688` finite ≪ 4.175. Structural dichotomy: opposite components → `c*=∞` (unavoidable).
- **Mercy Pareto-dominates reward** on *both* suffering axes, paying only +185% length. Real tension = efficiency-vs-suffering (both criteria avoid the ridge).

**Honest scope:** the aggregation-vs-maximin *divergence* (thin/thick regime) needs the separate `min ∫s` path — deferred, not claimed. Also adds μ*=peak-aversion threshold (0.021), `L_lex=1.128`, the field taxonomy (critique #3 §1–3) to `mercyful-learning.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)