### PR TITLE
feat(stdlib): bigframe rolling quantile (bf_rolling_quantile)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -54,6 +54,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rolling_cov (1M rows, window 100, Welford) | | ~75 | ~100 | **~0.7x — Sounio wins** | no sqrt (vs rolling_corr) |
 | rolling_skew (1M rows, window 100) | | ~130 | ~35 | **~3.8x** | per-element sqrt-bound |
 | rolling_kurt (1M rows, window 100) | | ~78 | ~28 | **~2.7x** | 4th-power sums; pandas Cython roll_kurt |
+| rolling_quantile (1M rows, window 100, q=0.9) | | 305 | 402 | **0.76x — Sounio wins** | sorted-window vs skip-list |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -10,7 +10,7 @@
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
 // rolling variance / std, rolling median, cumulative product, and
 // per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
-// rolling correlation, and rolling covariance / skewness / kurtosis.
+// rolling correlation, rolling covariance / skewness / kurtosis, and rolling quantile.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2554,5 +2554,55 @@ pub fn bf_rolling_kurt(src: &BigFrame, col: i64, window: i64, fill: f64) -> BigF
         }
         i = i + 1
     }
+    out
+}
+
+/// Rolling (sliding-window) `q`-quantile of column `col` over `window` (q in [0,1],
+/// like pandas col.rolling(window).quantile(q)) with pandas' default LINEAR
+/// interpolation. Generalises bf_rolling_median (which is q=0.5): a single sorted
+/// window buffer is maintained by binary-search insert/remove of the entering/leaving
+/// value each step, then the result is read (and interpolated) at position q*(w-1).
+/// O(n*window) from the shift -- at typical window sizes this beats pandas' skip-list.
+/// First window-1 rows take `fill`. NATIVE + lean_single only (heap).
+pub fn bf_rolling_quantile(src: &BigFrame, col: i64, window: i64, q: f64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    if col < 0 || col >= bf_ncols(src) || n <= 0 || window <= 0 { return bf_new(1, 1) }
+    var qq = q
+    if qq < 0.0 { qq = 0.0 }
+    if qq > 1.0 { qq = 1.0 }
+    let sp = bf_col_ptr(src, col) as *mut f64
+    var out = bf_new(1, n)
+    out.n_rows = n
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let win = heap_alloc(window * 8) as *mut f64       // the current window, kept sorted
+    let pos = qq * ((window - 1) as f64)
+    let lo = pos as i64
+    let frac = pos - (lo as f64)
+    var cnt: i64 = 0
+    var i: i64 = 0
+    while i < n {
+        if i >= window {                               // remove the leaving value
+            let xo = read_f64(sp, i - window)
+            let p = bf_lbound(win, cnt, xo)
+            var j = p
+            while j < cnt - 1 { write_f64(win, j, read_f64(win, j + 1)); j = j + 1 }
+            cnt = cnt - 1
+        }
+        let x = read_f64(sp, i)                         // insert the entering value
+        let ins = bf_lbound(win, cnt, x)
+        var j = cnt
+        while j > ins { write_f64(win, j, read_f64(win, j - 1)); j = j - 1 }
+        write_f64(win, ins, x)
+        cnt = cnt + 1
+        if i >= window - 1 {
+            var v = read_f64(win, lo)
+            if frac > 0.0 { v = v + frac * (read_f64(win, lo + 1) - read_f64(win, lo)) }
+            write_f64(op, i, v)
+        } else {
+            write_f64(op, i, fill)
+        }
+        i = i + 1
+    }
+    heap_free(win as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -699,6 +699,32 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var kud2 = bf_get(&ku, 4999, 0) - (0.0 - 0.990208)
     if kud2 < 0.0 { kud2 = 0.0 - kud2 }
     if kud2 > 0.00001 { print("FAIL rkurt_4999\n"); return 250 }
+    // ROLLING QUANTILE. col=i, window 101 -> window [i-100,i] already sorted; q*100 integer for
+    // these q so exact: q0=i-100, q0.25=i-75, q0.5=i-50, q0.9=i-10, q1=i.
+    var rqf = bf_new(1, 16)
+    var rqi: i64 = 0
+    while rqi < 5000 { var rqr:[f64;64]=[0.0;64]; rqr[0]=rqi as f64; bf_push_row(&!rqf,&rqr,1); rqi=rqi+1 }
+    let q0  = bf_rolling_quantile(&rqf, 0, 101, 0.0, 0.0 - 1.0)
+    let q25 = bf_rolling_quantile(&rqf, 0, 101, 0.25, 0.0 - 1.0)
+    let q50 = bf_rolling_quantile(&rqf, 0, 101, 0.5, 0.0 - 1.0)
+    let q90 = bf_rolling_quantile(&rqf, 0, 101, 0.9, 0.0 - 1.0)
+    let q1  = bf_rolling_quantile(&rqf, 0, 101, 1.0, 0.0 - 1.0)
+    if bf_nrows(&q50) != 5000 { print("FAIL rq_n\n"); return 251 }
+    if bf_get(&q50, 99, 0) != (0.0 - 1.0) { print("FAIL rq_fill\n"); return 252 }   // window not full
+    if !approx_eq(bf_get(&q0, 500, 0), 400.0) { print("FAIL rq0\n"); return 253 }
+    if !approx_eq(bf_get(&q25, 500, 0), 425.0) { print("FAIL rq25\n"); return 254 }
+    if !approx_eq(bf_get(&q50, 500, 0), 450.0) { print("FAIL rq50\n"); return 255 }
+    if !approx_eq(bf_get(&q90, 500, 0), 490.0) { print("FAIL rq90\n"); return 256 }
+    if !approx_eq(bf_get(&q1, 500, 0), 500.0) { print("FAIL rq1\n"); return 257 }
+    // DIFFERENTIAL: rolling_quantile(0.5) must equal the shipped rolling_median on scrambled data.
+    var rqs = bf_new(1, 16)
+    var rqsi: i64 = 0
+    while rqsi < 3000 { var rsr:[f64;64]=[0.0;64]; rsr[0]=((rqsi*2654435761)%100) as f64; bf_push_row(&!rqs,&rsr,1); rqsi=rqsi+1 }
+    let rqm = bf_rolling_quantile(&rqs, 0, 51, 0.5, 0.0 - 1.0)   // odd window -> median = win[mid]
+    let rmd = bf_rolling_median(&rqs, 0, 51, 0.0 - 1.0)
+    var rqd: i64 = 0; var rqj: i64 = 0
+    while rqj < 3000 { if bf_get(&rqm, rqj, 0) != bf_get(&rmd, rqj, 0) { rqd = rqd + 1 } rqj = rqj + 1 }
+    if rqd != 0 { print("FAIL rq_vs_median\n"); return 258 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_rolling_quantile(src, col, window, q, fill)` in `data::bigframe_ops` — the **q-quantile** (q ∈ [0,1]) over a sliding window with pandas' default **linear interpolation** (pandas `col.rolling(window).quantile(q)`). Generalises `bf_rolling_median` (q=0.5): a single **sorted window buffer** maintained by binary-search insert/remove of the entering/leaving value each step, then the result read (and interpolated) at position `q·(window-1)`. `O(n·window)` from the shift.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- `col=i`, window 101 (window already sorted) → exact `q0=i-100`, `q0.25=i-75`, `q0.5=i-50`, `q0.9=i-10`, `q1=i` (checked at row 500: 400/425/450/490/500);
- a **differential** that `rolling_quantile(0.5)` equals the shipped `bf_rolling_median` byte-for-byte on scrambled data (odd window);
- `fill` before the window fills.

## Benchmark (1M rows, window 100, q=0.9)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| rolling_quantile | 305 | 402 | **0.76× — Sounio wins** |

Like `rolling_median`, the tight sorted-window shift beats pandas' skip-list at typical windows (would flip for very large windows). Correct and gate-verified.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)