### PR TITLE
fix(madaros): print/println of i64 binary arith routes to print_int

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -5701,6 +5701,22 @@ impl Lowerer {
             if self.expr_result_is_float_ref(e) {
                 return 2
             }
+            // String concat (`s + t` / `s ++ t`) is a string result — keep it on
+            // the char* printer. Remaining non-float binary ops are integer
+            // arithmetic/bitwise; without this positive kind-1 mark, `print(x+1)`
+            // and `let y = x + 1; print(y)` fall to kind 0 → strlen(char*) SEGV.
+            if self.expr_result_is_string_ref(e) {
+                return 3
+            }
+            return 1
+        }
+        // Unary integer negation / bitwise-not of an int yields int. Float
+        // unary is already covered by expr_result_is_float_ref below.
+        if (*e).kind == ExprKind::ExprUnary {
+            if self.expr_result_is_float_ref(e) {
+                return 2
+            }
+            return 1
         }
         if self.expr_result_is_float_ref(e) {
             return 2
@@ -7439,6 +7455,16 @@ impl Lowerer {
                         // trait dispatch result). Restricted to Call/MethodCall so an
                         // indexed struct element cannot be misclassified as int.
                         lo = lo.bind_local_scalar_kind(s.name, 1)
+                    } else if ((*expr_box_sk).kind == ExprKind::ExprBinary || (*expr_box_sk).kind == ExprKind::ExprUnary) {
+                        // `let y = x + 1` / `let y = 0 - x` without an i64 annotation:
+                        // expr_result_scalar_kind_ref now positively returns 1 for int
+                        // arith (and 2/3 for float/string). Bind that kind so a later
+                        // `print(y)` / `println(y)` routes to print_int rather than
+                        // strlen-as-char* (SEGV on the integer payload).
+                        let sk_bin = lo.expr_result_scalar_kind_ref(&(*expr_box_sk))
+                        if sk_bin == 1 || sk_bin == 2 || sk_bin == 3 {
+                            lo = lo.bind_local_scalar_kind(s.name, sk_bin)
+                        }
                     }
                 }
                 _ => {}

--- a/tests/run-pass/print_i64_arith_local.sio
+++ b/tests/run-pass/print_i64_arith_local.sio
@@ -1,0 +1,34 @@
+//@ run-pass
+// Regression: print / println of unannotated i64 arithmetic locals.
+// Without positive scalar_kind=1 on binary/unary results, Madaros routes
+// these through the char* printer and SIGSEGVs (integer payload as pointer).
+
+fn show_param(x: i64) with IO {
+    print(x)
+    print("\n")
+}
+
+fn show_arith(x: i64) with IO {
+    let y = x + 1
+    print(y)
+    print("\n")
+}
+
+fn show_binop(x: i64) with IO {
+    print(x + 1)
+    print("\n")
+}
+
+fn show_println(x: i64) with IO {
+    println(x + 2)
+}
+
+fn main() -> i64 with IO {
+    show_param(42)
+    show_arith(41)
+    show_binop(41)
+    show_println(40)
+    print_int(99)
+    print("\n")
+    0
+}

--- a/tests/run-pass/print_int_multimodule.sio
+++ b/tests/run-pass/print_int_multimodule.sio
@@ -1,0 +1,40 @@
+//@ run-pass
+// Regression: multi-module i64 print under Madaros.
+//
+// Acceptance (Wave2 Agent G):
+//   - import + print_int of i64 works, exit 0
+//   - print / println of i64 param in an imported body routes to print_int
+//     (not char* strlen → SEGV). D5+D1 (#1252) binds param scalar_kind=1;
+//     this suite also covers unannotated `let y = x + 1; print(y)` which
+//     previously stayed kind 0 and segfaulted even after D5+D1.
+//
+// Expected stdout (order stable):
+//   42   # print_int(give_i64())
+//   42   # print_int(give_param(41))
+//   42   # print_int_param(42) in leaf
+//   42   # print_param(42) in leaf
+//   42   # print_arith_local(41) → 42
+//   7    # println_param(7)
+//   42   # print(give_i64()) seed-module path
+
+use print_int_multimodule_leaf
+
+fn main() -> i64 with IO {
+    let v = give_i64()
+    print_int(v)
+    print("\n")
+
+    let w = give_param(41)
+    print_int(w)
+    print("\n")
+
+    print_int_param(42)
+    print_param(42)
+    print_arith_local(41)
+    println_param(7)
+
+    // Direct print of imported return (seed-module path)
+    print(give_i64())
+    print("\n")
+    0
+}

--- a/tests/run-pass/print_int_multimodule_leaf.sio
+++ b/tests/run-pass/print_int_multimodule_leaf.sio
@@ -1,0 +1,39 @@
+//@ run-pass
+// Library for multi-module integer print regression (Wave2 Agent G).
+// Standalone: arithmetic + IO print helpers for i64 params.
+
+pub fn give_i64() -> i64 {
+    42
+}
+
+pub fn give_param(x: i64) -> i64 {
+    x + 1
+}
+
+pub fn print_int_param(x: i64) with IO {
+    print_int(x)
+    print("\n")
+}
+
+pub fn print_param(x: i64) with IO {
+    print(x)
+    print("\n")
+}
+
+pub fn print_arith_local(x: i64) with IO {
+    let y = x + 1
+    print(y)
+    print("\n")
+}
+
+pub fn println_param(x: i64) with IO {
+    println(x)
+}
+
+fn main() -> i64 with IO {
+    print_int_param(41)
+    print_param(42)
+    print_arith_local(41)
+    println_param(7)
+    0
+}


### PR DESCRIPTION
## Summary

Closes the residual **`print` / `println` of i64 integer arithmetic → SEGV** under Madaros (single- and multi-module), which sat just past the D5+D1 param `scalar_kind=1` fix (#1252 / PR #1252).

### Measurement first

| Case | Prebuilt main (`bin/madaros-linux-x86_64` @ pre-D5) | D5+D1 rebuilt ELF | This PR (rebuilt) |
|---|---|---|---|
| `import` + `print_int(i64)` | **OK** (acceptance) | OK | OK |
| imported body `print_int(x: i64)` | OK | OK | OK |
| imported body `print(x: i64)` / `println(x)` | **SEGV** | **OK** (D5+D1) | OK |
| `let y = x + 1; print(y)` / `print(x + 1)` | SEGV | **SEGV** (residual) | **OK** |

Root cause for the residual: `expr_result_scalar_kind_ref` returned **0** for non-compare, non-float `ExprBinary`, so `println_dispatch_name` picked the char\* `print` builtin and strlen'd the integer payload.

### Fix (surgical, `self-hosted/ir/lower.sio` only)

1. **Binary**: after float check, string-concat → kind 3; else → kind 1 (int arith/bitwise).
2. **Unary**: non-float → kind 1.
3. **Let-bind**: when RHS is `Binary`/`Unary`, bind the resolved scalar_kind so later `print(y)` as an Ident hits kind 1.

Does **not** touch dual-import / string-index loci. No ousadia/clinical changes.

### Tests

- `tests/run-pass/print_int_multimodule.sio` + `_leaf.sio` — import + `print_int` + imported `print`/`println`/arith local
- `tests/run-pass/print_i64_arith_local.sio` — single-module param / arith / binop / println residual

Harness:

```text
PASS  print_int_multimodule.sio
PASS  print_int_multimodule_leaf.sio
PASS  print_i64_arith_local.sio
```

### Rebuild evidence

```bash
SOUNIO_BUILD_LOCK=/tmp/sounio-printint-build.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
# Madaros ready: artifacts/self-hosted/madaros (99200439 bytes)
```

Prebuilt `bin/madaros-linux-x86_64` is **not** refreshed in this PR (bot path). CI / local need `make build-madaros` (or artifacts ELF) for the residual path; D5+D1 source is already on `main` for params.

### Acceptance

- import + `print_int` of i64 works, exit 0 ✅  
- residual `print(i64 arith)` no longer SEGV under rebuilt Madaros ✅