### PR TITLE
feat(epistemic): Madaros-native CPC order_spread4 leaf

### DIFF
--- a/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
+++ b/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
@@ -48,9 +48,14 @@ A result is usable under native import iff **both** hold:
 | `knightian` (p-box) | `pb_gap`, `pb_midpoint` | self-contained |
 | `covariance` | `cov_new` and accessors | self-contained |
 | `knowledge` (**free-function** `ep_*` API) | `ep_measured` / `ep_add` / `ep_mul` / `ep_merge` / `ep_gate` | **D3 partial 2026-07-19** — free-function surface imports under Madaros; see `EPISTEMIC_KNOWLEDGE_MADAROS_D3_2026-07-19` |
+| `order_spread_exact` (`order_spread4`) | CPC N=4 exact spread ≈ `2.044226` (scaled µ-units `2044225`/`2044226`) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `OsOct` (no `algebra::` use). Gate: `scripts/madaros_order_spread_native_gate.sh` + Section A `ORDER_SPREAD_TRUST_OK`. `product4_exact` remains available (pulls free-function `knowledge`); method-form `Epistemic::measured` still Root-2. |
 
 Heuristic: **self-contained modules (no stdlib `use` deps) that avoid `f64→i64`
 casts and method-call sites import cleanly and return correct numbers.**
+(`order_spread_exact` is the measured exception that may `use` free-function
+`knowledge` while keeping the multiply path fully local — do **not** reintroduce
+`algebra::associator_field` / `algebra::octonion` uses; those still SEGV at
+runtime under Madaros multi-module native emit.)
 
 ### ⚠️ Importable but specific outputs CORRUPTED
 
@@ -67,7 +72,7 @@ casts and method-call sites import cleanly and return correct numbers.**
 |---|---|---|
 | `knowledge` **method-call** form (`Epistemic::measured`, `e.val()`) | SEGV in method-call lowering (Root 2) | use free `ep_*` API under Madaros; methods still OK under lean_single |
 | `propagate` | blocked / fragile multi-module | propagation layer not yet native-trustworthy |
-| `order_spread_exact` | **segfault** (uses `knowledge`+`algebra`) | works only via lean_single, not native import |
+| `algebra::associator_field` / `algebra::octonion` (imported exclusive-ref path) | **runtime SEGV** after successful native compile | CPC N=4 no longer depends on this path — use `epistemic::order_spread_exact::order_spread4` instead |
 | `uncertain_eq` | method / multi-module path | equality-under-uncertainty native-import-blocked |
 
 Method-form and remaining modules are usable today only by **free-function rewrite**,

--- a/scripts/epistemic_trust_gate.sh
+++ b/scripts/epistemic_trust_gate.sh
@@ -28,6 +28,8 @@ runproof "gum: value + u_c"          tests/epistemic_trust/gum_trust.sio        
 runproof "correlation: covariance"   tests/epistemic_trust/correlation_trust.sio CORRELATION_TRUST_OK
 runproof "knightian: p-box"          tests/epistemic_trust/knightian_trust.sio   KNIGHTIAN_TRUST_OK
 runproof "knowledge: free Epistemic" tests/epistemic_trust/knowledge_trust.sio   KNOWLEDGE_TRUST_OK
+# CPC N=4 exact-spread leaf (2026-07-20): self-contained OsOct path; no algebra:: use.
+runproof "order_spread4: CPC N=4"    tests/epistemic_trust/order_spread_trust.sio ORDER_SPREAD_TRUST_OK
 
 echo "### B. KNOWN-CORRUPTED trip-wire (informational) ###"
 echo "== gum k95 coverage factor (should be 2776 = t95(4); bug gives 1960) =="
@@ -44,10 +46,9 @@ if $SOUC compile tests/epistemic_trust/witness_import_knowledge_method.sio -o "$
   echo "!! method-call knowledge now COMPILES — Root 2 may be FIXED; update trust map"
 else echo "CONFIRMED unimportable (method-call form, as documented)"; fi
 
-echo "== witness_import_order_spread (trip-wire; may compile after knowledge free-API) =="
-if $SOUC compile tests/epistemic_trust/witness_import_order_spread.sio -o "$OUT/w.elf" >/dev/null 2>&1; then
-  echo "NOTE: order_spread_exact COMPILES under native import — re-classify in trust map when numeric gate exists"
-else echo "CONFIRMED unimportable (native compile fails, as documented)"; fi
+# order_spread_exact promoted to Section A (numeric gate ORDER_SPREAD_TRUST_OK).
+# Residual multi-module: algebra::associator_field / algebra::octonion exclusive-ref
+# import chain still SEGV at runtime under Madaros — do not reintroduce algebra:: uses.
 
 # Legacy free-function witness should now succeed (informational flip)
 echo "== witness_import_knowledge free API (expected: now COMPILES) =="

--- a/scripts/madaros_order_spread_native_gate.sh
+++ b/scripts/madaros_order_spread_native_gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Madaros native gate — CPC order_spread4 under default Madaros (not lean_single).
+#
+# Acceptance:
+#   - Default ./bin/souc (Madaros) compile+run of the CPC generic 4-tuple witness
+#     prints scaled micro-units 2044225 or 2044226 (exact spread ≈ 2.044226).
+#   - TRUST sentinel ORDER_SPREAD_TRUST_OK from tests/epistemic_trust/order_spread_trust.sio
+#
+# Does NOT claim lean_single is Madaros. Rebuild of Madaros is not required for
+# this stdlib-only leaf; measure with the current default engine.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+SOUC=./bin/souc
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+# Refuse to silently run lean_single — this gate is Madaros-only.
+engine_line="$($SOUC --version 2>&1 | head -1 || true)"
+if echo "$engine_line" | grep -qi lean_single; then
+  echo "FAIL: gate must run under default Madaros, not lean_single ($engine_line)"
+  exit 1
+fi
+if ! echo "$engine_line" | grep -qi Madaros; then
+  echo "WARN: version string does not mention Madaros: $engine_line"
+fi
+echo "engine: $engine_line"
+
+fail=0
+
+echo "== witness_import_order_spread (scaled micro-units) =="
+if $SOUC compile tests/epistemic_trust/witness_import_order_spread.sio -o "$OUT/w.elf" >"$OUT/w.compile" 2>&1; then
+  scaled="$("$OUT/w.elf" | tr -d '[:space:]')"
+  echo "scaled=$scaled"
+  if [ "$scaled" = "2044225" ] || [ "$scaled" = "2044226" ]; then
+    echo "PASS: exact spread ~2.044226 (scaled $scaled)"
+  else
+    echo "FAIL: unexpected scaled value $scaled (want 2044225|2044226)"
+    fail=1
+  fi
+else
+  echo "FAIL: native compile"
+  tail -20 "$OUT/w.compile"
+  fail=1
+fi
+
+echo "== order_spread_trust sentinel =="
+if $SOUC compile tests/epistemic_trust/order_spread_trust.sio -o "$OUT/t.elf" >"$OUT/t.compile" 2>&1; then
+  if "$OUT/t.elf" | grep -q 'ORDER_SPREAD_TRUST_OK'; then
+    echo "PASS: ORDER_SPREAD_TRUST_OK"
+  else
+    echo "FAIL: sentinel missing"
+    "$OUT/t.elf" || true
+    fail=1
+  fi
+else
+  echo "FAIL: trust compile"
+  tail -20 "$OUT/t.compile"
+  fail=1
+fi
+
+# Optional: souc run path (wrapper)
+echo "== souc run trust driver =="
+if $SOUC run tests/epistemic_trust/order_spread_trust.sio >"$OUT/run.out" 2>"$OUT/run.err"; then
+  if grep -q 'ORDER_SPREAD_TRUST_OK' "$OUT/run.out"; then
+    echo "PASS: souc run"
+  else
+    echo "FAIL: souc run missing sentinel"
+    cat "$OUT/run.out"
+    fail=1
+  fi
+else
+  echo "FAIL: souc run"
+  tail -20 "$OUT/run.err"
+  fail=1
+fi
+
+echo
+if [ $fail -eq 0 ]; then
+  echo "MADAROS_ORDER_SPREAD_NATIVE_GATE_OK"
+  exit 0
+fi
+echo "MADAROS_ORDER_SPREAD_NATIVE_GATE_FAIL"
+exit 1

--- a/stdlib/epistemic/order_spread_exact.sio
+++ b/stdlib/epistemic/order_spread_exact.sio
@@ -5,8 +5,7 @@
 // parenthesizations of a·b·c·d give five different variances). The EXACT,
 // parenthesization-INDEPENDENT order-spread for a 4-factor octonion product is
 // the associahedron K4 (pentagon) vertex variance — the variance over all five
-// parenthesizations. This module exposes that as the exact N=4 path, reusing the
-// verified pentagon primitives in algebra::associator_field.
+// parenthesizations. This module exposes that as the exact N=4 path.
 //
 // Convention note: this reports the population VARIANCE of the 5 vertices, which
 // differs in normalization from the triple / DAG path (which reports κ·‖[a,b,c]‖²
@@ -15,28 +14,178 @@
 // Use the DAG for incremental products that are order-safe through triples; use
 // this for an EXACT N=4 spread.
 //
-// Execution-verified (self-contained build, real octonion arithmetic): a generic
-// 4-tuple gives order_spread4 = 2.044226 (matches the associator_field pentagon
-// investigation), and it is parenthesization-independent by construction — it
-// evaluates every parenthesization.
+// Madaros native-import leaf (2026-07-20):
+//   Previously this module `use`d algebra::associator_field (and transitively
+//   algebra::octonion). That multi-module chain COMPILES under Madaros but the
+//   emitted ELF SEGV's at runtime (exclusive-ref &![f64;8] oct_mul path plus
+//   large dep closure). The CPC N=4 receipt therefore lived only on lean_single.
+//
+//   Fix: self-contain the octonion multiply + K4 pentagon variance here using a
+//   field-wise Oct struct (return-by-value). Canonical math is identical to
+//   algebra::associator_field::{pentagon_products, pentagon_variance}. product4_exact
+//   still needs Epistemic from knowledge (self-contained, free-function-safe under
+//   Madaros D3 partial). No algebra `use` remains.
+//
+// Execution-verified (Madaros native import + lean_single): a generic 4-tuple
+// gives order_spread4 ≈ 2.044226 (scaled micro-units print 2044225 / 2044226),
+// parenthesization-independent by construction.
 
-use algebra::associator_field::{pentagon_products, pentagon_variance}
 use epistemic::knowledge::{Epistemic}
+
+// ---------------------------------------------------------------------------
+// Local octonion — field-wise struct (Madaros-safe). Do NOT use &![f64; 8]
+// exclusive-ref mutation for the multiply body under default Madaros native.
+// ---------------------------------------------------------------------------
+
+struct OsOct {
+    c0: f64
+    c1: f64
+    c2: f64
+    c3: f64
+    c4: f64
+    c5: f64
+    c6: f64
+    c7: f64
+}
+
+// Cayley–Dickson / Fano-plane octonion product (same expansion as algebra::octonion::oct_mul).
+fn os_oct_mul(a: &OsOct, b: &OsOct) -> OsOct with Mut, Div {
+    var r0 = a.c0 * b.c0
+    r0 = r0 - a.c1 * b.c1
+    r0 = r0 - a.c2 * b.c2
+    r0 = r0 - a.c3 * b.c3
+    r0 = r0 - a.c4 * b.c4
+    r0 = r0 - a.c5 * b.c5
+    r0 = r0 - a.c6 * b.c6
+    r0 = r0 - a.c7 * b.c7
+    var r1 = a.c0 * b.c1 + a.c1 * b.c0
+    r1 = r1 + a.c2 * b.c3 - a.c3 * b.c2
+    r1 = r1 + a.c4 * b.c5 - a.c5 * b.c4
+    r1 = r1 - a.c6 * b.c7 + a.c7 * b.c6
+    var r2 = a.c0 * b.c2 + a.c2 * b.c0
+    r2 = r2 - a.c1 * b.c3 + a.c3 * b.c1
+    r2 = r2 + a.c4 * b.c6 - a.c6 * b.c4
+    r2 = r2 + a.c5 * b.c7 - a.c7 * b.c5
+    var r3 = a.c0 * b.c3 + a.c3 * b.c0
+    r3 = r3 + a.c1 * b.c2 - a.c2 * b.c1
+    r3 = r3 + a.c4 * b.c7 - a.c7 * b.c4
+    r3 = r3 - a.c5 * b.c6 + a.c6 * b.c5
+    var r4 = a.c0 * b.c4 + a.c4 * b.c0
+    r4 = r4 - a.c1 * b.c5 + a.c5 * b.c1
+    r4 = r4 - a.c2 * b.c6 + a.c6 * b.c2
+    r4 = r4 - a.c3 * b.c7 + a.c7 * b.c3
+    var r5 = a.c0 * b.c5 + a.c5 * b.c0
+    r5 = r5 + a.c1 * b.c4 - a.c4 * b.c1
+    r5 = r5 - a.c2 * b.c7 + a.c7 * b.c2
+    r5 = r5 + a.c3 * b.c6 - a.c6 * b.c3
+    var r6 = a.c0 * b.c6 + a.c6 * b.c0
+    r6 = r6 + a.c1 * b.c7 - a.c7 * b.c1
+    r6 = r6 + a.c2 * b.c4 - a.c4 * b.c2
+    r6 = r6 - a.c3 * b.c5 + a.c5 * b.c3
+    var r7 = a.c0 * b.c7 + a.c7 * b.c0
+    r7 = r7 - a.c1 * b.c6 + a.c6 * b.c1
+    r7 = r7 + a.c2 * b.c5 - a.c5 * b.c2
+    r7 = r7 + a.c3 * b.c4 - a.c4 * b.c3
+    OsOct { c0: r0, c1: r1, c2: r2, c3: r3, c4: r4, c5: r5, c6: r6, c7: r7 }
+}
+
+fn os_oct_from_arr(a: &[f64; 8]) -> OsOct {
+    OsOct {
+        c0: a[0], c1: a[1], c2: a[2], c3: a[3],
+        c4: a[4], c5: a[5], c6: a[6], c7: a[7],
+    }
+}
+
+// Five parenthesizations of w·x·y·z (associahedron K4 vertices):
+//   P0 = ((wx)y)z   P1 = (w(xy))z   P2 = (wx)(yz)   P3 = w((xy)z)   P4 = w(x(yz))
+// Population variance of the five octonion products (component-wise centroid).
+fn os_pentagon_variance(w: &OsOct, x: &OsOct, y: &OsOct, z: &OsOct) -> f64 with Mut, Div {
+    let wx = os_oct_mul(w, x)
+    let wxy = os_oct_mul(&wx, y)
+    let p0 = os_oct_mul(&wxy, z)
+    let xy = os_oct_mul(x, y)
+    let w_xy = os_oct_mul(w, &xy)
+    let p1 = os_oct_mul(&w_xy, z)
+    let yz = os_oct_mul(y, z)
+    let p2 = os_oct_mul(&wx, &yz)
+    let xy_z = os_oct_mul(&xy, z)
+    let p3 = os_oct_mul(w, &xy_z)
+    let x_yz = os_oct_mul(x, &yz)
+    let p4 = os_oct_mul(w, &x_yz)
+
+    let m0 = (p0.c0 + p1.c0 + p2.c0 + p3.c0 + p4.c0) / 5.0
+    let m1 = (p0.c1 + p1.c1 + p2.c1 + p3.c1 + p4.c1) / 5.0
+    let m2 = (p0.c2 + p1.c2 + p2.c2 + p3.c2 + p4.c2) / 5.0
+    let m3 = (p0.c3 + p1.c3 + p2.c3 + p3.c3 + p4.c3) / 5.0
+    let m4 = (p0.c4 + p1.c4 + p2.c4 + p3.c4 + p4.c4) / 5.0
+    let m5 = (p0.c5 + p1.c5 + p2.c5 + p3.c5 + p4.c5) / 5.0
+    let m6 = (p0.c6 + p1.c6 + p2.c6 + p3.c6 + p4.c6) / 5.0
+    let m7 = (p0.c7 + p1.c7 + p2.c7 + p3.c7 + p4.c7) / 5.0
+
+    var v: f64 = 0.0
+    var d = p0.c0 - m0; v = v + d * d
+    d = p0.c1 - m1; v = v + d * d
+    d = p0.c2 - m2; v = v + d * d
+    d = p0.c3 - m3; v = v + d * d
+    d = p0.c4 - m4; v = v + d * d
+    d = p0.c5 - m5; v = v + d * d
+    d = p0.c6 - m6; v = v + d * d
+    d = p0.c7 - m7; v = v + d * d
+    d = p1.c0 - m0; v = v + d * d
+    d = p1.c1 - m1; v = v + d * d
+    d = p1.c2 - m2; v = v + d * d
+    d = p1.c3 - m3; v = v + d * d
+    d = p1.c4 - m4; v = v + d * d
+    d = p1.c5 - m5; v = v + d * d
+    d = p1.c6 - m6; v = v + d * d
+    d = p1.c7 - m7; v = v + d * d
+    d = p2.c0 - m0; v = v + d * d
+    d = p2.c1 - m1; v = v + d * d
+    d = p2.c2 - m2; v = v + d * d
+    d = p2.c3 - m3; v = v + d * d
+    d = p2.c4 - m4; v = v + d * d
+    d = p2.c5 - m5; v = v + d * d
+    d = p2.c6 - m6; v = v + d * d
+    d = p2.c7 - m7; v = v + d * d
+    d = p3.c0 - m0; v = v + d * d
+    d = p3.c1 - m1; v = v + d * d
+    d = p3.c2 - m2; v = v + d * d
+    d = p3.c3 - m3; v = v + d * d
+    d = p3.c4 - m4; v = v + d * d
+    d = p3.c5 - m5; v = v + d * d
+    d = p3.c6 - m6; v = v + d * d
+    d = p3.c7 - m7; v = v + d * d
+    d = p4.c0 - m0; v = v + d * d
+    d = p4.c1 - m1; v = v + d * d
+    d = p4.c2 - m2; v = v + d * d
+    d = p4.c3 - m3; v = v + d * d
+    d = p4.c4 - m4; v = v + d * d
+    d = p4.c5 - m5; v = v + d * d
+    d = p4.c6 - m6; v = v + d * d
+    d = p4.c7 - m7; v = v + d * d
+    v / 5.0
+}
 
 // Exact, parenthesization-independent order-spread of (a·b·c·d): the K4 pentagon
 // vertex variance over all five parenthesizations.
 pub fn order_spread4(
     a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], d: &[f64; 8],
 ) -> f64 with Mut, Div, Panic, NonAssoc {
-    var ps: [f64; 40] = [0.0; 40]
-    pentagon_products(a, b, c, d, &!ps)
-    pentagon_variance(&ps)
+    let oa = os_oct_from_arr(a)
+    let ob = os_oct_from_arr(b)
+    let oc = os_oct_from_arr(c)
+    let od = os_oct_from_arr(d)
+    os_pentagon_variance(&oa, &ob, &oc, &od)
 }
 
 // Augment a scalar observable computed through a 4-factor non-associative product
 // with the EXACT order-ambiguity variance κ·spread. Parenthesization-independent,
 // hence order-safe at N=4 by construction (unlike the incremental DAG, which is
 // exact only through triples).
+//
+// Madaros note: free-function / field form of Epistemic is the native-safe surface
+// (D3 partial 2026-07-19). Callers under Madaros should build base via ep_measured
+// rather than Epistemic::measured method form.
 pub fn product4_exact(
     base: Epistemic,
     a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], d: &[f64; 8],
@@ -45,7 +194,7 @@ pub fn product4_exact(
     let total = base.variance + kappa * order_spread4(a, b, c, d)
     Epistemic {
         val: base.val,
-        variance: if total < 0.0 { 0.0 } else { total },   // variance ≥ 0 (guards κ<0 / FP drift)
+        variance: if total < 0.0 { 0.0 } else { total },
         confidence: base.confidence,
     }
 }

--- a/tests/epistemic_trust/order_spread_trust.sio
+++ b/tests/epistemic_trust/order_spread_trust.sio
@@ -1,0 +1,22 @@
+// TRUSTWORTHY under default Madaros: order_spread4 (CPC N=4 exact-spread leaf).
+// Self-contained algebra inlined into epistemic::order_spread_exact (no algebra:: use).
+// Sentinel: ORDER_SPREAD_TRUST_OK when scaled micro-units ∈ {2044225, 2044226}
+// (float→i64 truncation of 2.044226 * 1e6 is engine-rounding-sensitive by 1).
+use epistemic::order_spread_exact::{order_spread4}
+
+fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
+    let a: [f64; 8] = [0.3, 0.1, 0.4, 0.1, 0.5, 0.9, 0.2, 0.6]
+    let b: [f64; 8] = [0.2, 0.7, 0.1, 0.8, 0.2, 0.8, 0.1, 0.9]
+    let c: [f64; 8] = [0.1, 0.6, 0.1, 0.8, 0.0, 0.3, 0.9, 0.7]
+    let d: [f64; 8] = [0.5, 0.7, 0.2, 0.9, 0.1, 0.4, 0.6, 0.3]
+    let s = order_spread4(&a, &b, &c, &d)
+    let scaled = (s * 1000000.0) as i64
+    // accept either truncation of 2.044226e6
+    if scaled == 2044225 || scaled == 2044226 {
+        print("ORDER_SPREAD_TRUST_OK\n")
+        return 0
+    }
+    print_int(scaled)
+    print("\n")
+    return 1
+}

--- a/tests/epistemic_trust/witness_import_order_spread.sio
+++ b/tests/epistemic_trust/witness_import_order_spread.sio
@@ -1,10 +1,17 @@
-// Unimportable witness: epistemic::order_spread_exact (CPC N=4 exact-spread
-// receipt) segfaults the native compiler on import (pulls in epistemic::knowledge
-// + algebra). Works only via lean_single. Expected: native compile FAILS.
-use epistemic::order_spread_exact::*
+// Native-import witness: epistemic::order_spread_exact (CPC N=4 exact-spread).
+// After the 2026-07-20 leaf rewrite (no algebra:: use; struct OsOct multiply),
+// default Madaros compile+run must succeed and print the scaled spread.
+// CPC generic 4-tuple → order_spread4 ≈ 2.044226 → micro-units 2044225/2044226.
+use epistemic::order_spread_exact::{order_spread4}
+
 fn main() -> i32 with IO, Mut, Div, Panic, NonAssoc {
-    var a: [f64; 8] = [1.0; 8]
-    print_int((order_spread4(&a, &a, &a, &a) * 1000000.0) as i64)
+    let a: [f64; 8] = [0.3, 0.1, 0.4, 0.1, 0.5, 0.9, 0.2, 0.6]
+    let b: [f64; 8] = [0.2, 0.7, 0.1, 0.8, 0.2, 0.8, 0.1, 0.9]
+    let c: [f64; 8] = [0.1, 0.6, 0.1, 0.8, 0.0, 0.3, 0.9, 0.7]
+    let d: [f64; 8] = [0.5, 0.7, 0.2, 0.9, 0.1, 0.4, 0.6, 0.3]
+    let s = order_spread4(&a, &b, &c, &d)
+    // print_int of scaled f64 — prefer over print(f64) (negative-float print is flaky under Madaros)
+    print_int((s * 1000000.0) as i64)
     print("\n")
     return 0
 }


### PR DESCRIPTION
## Summary

Unlocks **CPC order_spread4** under **default Madaros** without the full algebra multi-module graph.

`stdlib/epistemic/order_spread_exact.sio` previously `use`d `algebra::associator_field` (→ `algebra::octonion`). Under Madaros that chain **compiles then SEGV's at runtime** (exclusive-ref `&![f64;8]` oct_mul path + multi-module residual). CPC N=4 therefore lived only on lean_single.

### Fix (stdlib-only; no Madaros rebuild)

- Inline octonion multiply + K4 pentagon variance as field-wise `OsOct` (return-by-value) — same math as `associator_field::{pentagon_products, pentagon_variance}`
- Drop all `algebra::` uses
- Keep `product4_exact` via free-function `epistemic::knowledge` (Madaros D3-partial safe)
- Do **not** reintroduce `algebra::associator_field` / `octonion` imports on this path

## Evidence (default Madaros v0.80.0)

```text
$ bash scripts/madaros_order_spread_native_gate.sh
engine: Madaros v0.80.0 -- the Sounio self-hosted compiler
scaled=2044225
PASS: exact spread ~2.044226 (scaled 2044225)
PASS: ORDER_SPREAD_TRUST_OK
MADAROS_ORDER_SPREAD_NATIVE_GATE_OK
```

lean_single CPC receipt still green:

```text
$ SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tests/run-pass/order_spread_exact_n4.sio
exact spread = 2.044226: PASS ... ALL PASS
```

`product4_exact` + free `ep_*` under Madaros: variance micro-units `2294225` (≈ 0.25 + 2.044226).

## Trust map

- `order_spread4` promoted to **Section A TRUSTWORTHY** (`ORDER_SPREAD_TRUST_OK`)
- Residual broken path documented: raw `algebra::associator_field` / `octonion` exclusive-ref import still SEGV
- `scripts/epistemic_trust_gate.sh` updated accordingly

## Files

| Path | Change |
|---|---|
| `stdlib/epistemic/order_spread_exact.sio` | self-contained leaf |
| `tests/epistemic_trust/order_spread_trust.sio` | Section A numeric gate |
| `tests/epistemic_trust/witness_import_order_spread.sio` | CPC 4-tuple scaled witness |
| `scripts/madaros_order_spread_native_gate.sh` | dedicated Madaros gate |
| `scripts/epistemic_trust_gate.sh` | promote to Section A |
| `docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md` | honest flip |

## Note

Pre-existing on `main` (unrelated): `knightian_trust.sio` currently fails Madaros parse on `fn(f64,f64)->f64` higher-order helpers in `knightian.sio` — not touched here.

## Test plan

- [x] `bash scripts/madaros_order_spread_native_gate.sh` → `MADAROS_ORDER_SPREAD_NATIVE_GATE_OK`
- [x] `ORDER_SPREAD_TRUST_OK` under `./bin/souc` (Madaros)
- [x] `SOUNIO_SOUC_ENGINE=lean_single ./bin/souc run tests/run-pass/order_spread_exact_n4.sio` → ALL PASS
- [ ] CI epistemic_trust (knightian pre-existing may still fail until fixed separately)