### PR TITLE
fix(madaros): println/print of computed integers route to print_int

### DIFF
--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -953,7 +953,7 @@ fn lowerer_preseed_external_struct_items_mut(
                                                 // instead of a direct load, corrupting the value. Compute
                                                 // the real class from the field type, matching
                                                 // ir_fast_summary_register_struct_fields_owned.
-                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_i64(&(*flist).head.ty) { 3 } else { 0 },
+                                                is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else { 0 },
                                             }
                                             fc = fc + 1
                                             fcur = (*flist).tail
@@ -1043,7 +1043,7 @@ fn lowerer_register_struct_fields_direct_mut(
                     // over the same struct_layouts table; a mismatch here would leave the
                     // FIRST-registered field entry — the one actually found by name lookup —
                     // without the i64 marker).
-                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_i64(&(*flist).head.ty) { 3 } else { 0 },
+                    is_float: if lower_type_expr_is_f64(&(*flist).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*flist).head.ty) { 2 } else if lower_type_expr_is_integer(&(*flist).head.ty) { 3 } else { 0 },
                 }
                 fc = fc + 1
                 fcur = &(*flist).tail
@@ -1096,7 +1096,7 @@ fn lowerer_register_struct_fields_mut(
                         name: (*list).head.name,
                         index: field_idx,
                         // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
-                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
+                        is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else { 0 },
                     }
                     (*(*lo).struct_layouts).entries[layout_idx as usize].field_count = fc + 1
                 } else {
@@ -1742,7 +1742,7 @@ fn ir_fast_summary_register_struct_fields_owned(
                     name: (*list).head.name,
                     index: idx,
                     // println i64-segfault fix: see note in lowerer_register_struct_fields_direct_mut.
-                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
+                    is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else { 0 },
                 }
                 lay_entry.field_count = fc + 1
                 table_value.entries[layout_idx as usize] = lay_entry
@@ -2295,10 +2295,11 @@ fn lowerer_lower_fn_params_mut(
                 // Box store. The by-value `(*lo) = (*lo).bind_local_scalar_kind(...)`
                 // RMW is dropped by the by-value-aggregate-store miscompile, leaving
                 // f64 params at kind 0 so `x as i64` bitcasts (IEEE payload) instead of
-                // truncating. Also bind i64→1 so println of i64 params stays on print_int.
+                // truncating. Bind any word-size integer (i32/i64/u64/…) → 1 so
+                // println of int params stays on print_int (i64-only left i32 at 0).
                 if lower_type_expr_is_f64(&(*list).head.ty) {
                     lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 2)
-                } else if lower_type_expr_is_i64(&(*list).head.ty) {
+                } else if lower_type_expr_is_integer(&(*list).head.ty) {
                     lowerer_mark_local_scalar_kind_mut(lo, (*list).head.name, 1)
                 }
                 if lower_type_expr_is_ref_like(&(*list).head.ty) {
@@ -2697,6 +2698,36 @@ fn lower_name_is_packed_string_producer(n: Name) -> bool with Div {
     false
 }
 
+// Word-size integer type names for println/print scalar_kind=1 dispatch.
+// Broader than i64-only: i8/i16/i32/i64, u8/u16/u32/u64, isize/usize.
+// Does NOT include f32/f64 (kind 2), string, bool, or char — those keep their
+// existing paths. Used when an annotated param/local or callee return is
+// known-integer so print_int is selected instead of char* strlen → SEGV.
+fn lower_name_is_integer_type(n: Name) -> bool with Div {
+    if n.len == 2 {
+        // i8 / u8
+        return (n.buf[0] == 105 as i8 || n.buf[0] == 117 as i8)
+            && n.buf[1] == 56 as i8
+    }
+    if n.len == 3 {
+        // i16/u16/i32/u32/i64/u64
+        if n.buf[0] != 105 as i8 && n.buf[0] != 117 as i8 {
+            return false
+        }
+        let is_16 = n.buf[1] == 49 as i8 && n.buf[2] == 54 as i8
+        let is_32 = n.buf[1] == 51 as i8 && n.buf[2] == 50 as i8
+        let is_64 = n.buf[1] == 54 as i8 && n.buf[2] == 52 as i8
+        return is_16 || is_32 || is_64
+    }
+    if n.len == 5 {
+        // isize / usize
+        let suffix = n.buf[1] == 115 as i8 && n.buf[2] == 105 as i8
+            && n.buf[3] == 122 as i8 && n.buf[4] == 101 as i8
+        return suffix && (n.buf[0] == 105 as i8 || n.buf[0] == 117 as i8)
+    }
+    false
+}
+
 fn lower_type_expr_is_string(te: &TypeExpr) -> bool with Mut, Panic, Div {
     if (*te).kind != TypeExprKind::TypeNamed { return false }
     let seg = (*te).path.segments
@@ -2713,6 +2744,18 @@ fn lower_type_expr_is_string(te: &TypeExpr) -> bool with Mut, Panic, Div {
 fn lower_opt_type_is_string(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
     match *opt {
         Some(te) => lower_type_expr_is_string(&(*te)),
+        None => false,
+    }
+}
+
+fn lower_type_expr_is_integer(te: &TypeExpr) -> bool with Mut, Panic, Div {
+    if (*te).kind != TypeExprKind::TypeNamed { return false }
+    lower_name_is_integer_type(ir_path_first_name((*te).path))
+}
+
+fn lower_cast_type_is_integer(ct: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *ct {
+        Some(te) => lower_type_expr_is_integer(&(*te)),
         None => false,
     }
 }
@@ -2785,6 +2828,13 @@ fn lower_opt_type_is_f64(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, D
 fn lower_opt_type_is_i64(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
     match *opt {
         Some(te) => lower_type_expr_is_i64(&(*te)),
+        None => false,
+    }
+}
+
+fn lower_opt_type_is_integer(opt: &Option<Box<TypeExpr>>) -> bool with Mut, Panic, Div {
+    match *opt {
+        Some(te) => lower_type_expr_is_integer(&(*te)),
         None => false,
     }
 }
@@ -4401,6 +4451,9 @@ impl Lowerer {
                 stk.wide_bits[idx as usize] = 0
                 stk.wide_signed[idx as usize] = 0
                 stk.is_ref[idx as usize] = 0
+                // Explicit 0: slot may be reused after scope-pop restores count.
+                // Callers that know a positive kind (for-IV int, float local) re-bind.
+                stk.scalar_kind[idx as usize] = 0
                 stk.variance_regs[idx as usize] = -1
                 stk.count = idx + 1
             lo.locals = Box::new(stk)
@@ -5732,24 +5785,26 @@ impl Lowerer {
         }
         if (*e).kind == ExprKind::ExprCast {
             if lower_cast_type_is_f64(&(*e).cast_type) { return 2 }
-            if lower_cast_type_is_i64(&(*e).cast_type) { return 1 }
+            // Any word-size integer cast target (i32/i64/u64/…) → print_int kind.
+            if lower_cast_type_is_integer(&(*e).cast_type) { return 1 }
             return 0
         }
         // println i64-segfault fix: resolve a call's/field's return type to the
-        // scalar-int kind when it is POSITIVELY known to be i64 (not merely "not
-        // float") — mirrors the float resolution in expr_result_is_float_ref
-        // (module.functions[fn_id].returns_float), using return_struct_name
-        // instead, since that field carries the return type's name for ANY
-        // TypeNamed return (see lower_opt_type_named_name), not only structs.
-        // When the type can't be resolved this way, fall through unchanged so
-        // string/bool/void/unresolved results keep routing to the char* printer.
+        // scalar-int kind when it is POSITIVELY known to be an integer type (not
+        // merely "not float") — mirrors the float resolution in
+        // expr_result_is_float_ref (module.functions[fn_id].returns_float), using
+        // return_struct_name instead, since that field carries the return type's
+        // name for ANY TypeNamed return (see lower_opt_type_named_name), not only
+        // structs. When the type can't be resolved this way, fall through
+        // unchanged so string/bool/void/unresolved results keep routing to the
+        // char* printer.
         if (*e).kind == ExprKind::ExprCall {
             match (*e).left {
                 Some(callee_expr) => {
                     let callee_name = self.expr_to_callee_name_ref(&(*callee_expr))
                     let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, callee_name)
                     if fn_id >= 0 && fn_id < self.module.fn_count {
-                        if lower_name_is_i64_type(self.module.functions[fn_id as usize].return_struct_name) {
+                        if lower_name_is_integer_type(self.module.functions[fn_id as usize].return_struct_name) {
                             return 1
                         }
                     }
@@ -5762,7 +5817,7 @@ impl Lowerer {
             let call_name = if recv_type.len > 0 { ir_mangle_method_name(recv_type, (*e).name) } else { (*e).name }
             let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, call_name)
             if fn_id >= 0 && fn_id < self.module.fn_count {
-                if lower_name_is_i64_type(self.module.functions[fn_id as usize].return_struct_name) {
+                if lower_name_is_integer_type(self.module.functions[fn_id as usize].return_struct_name) {
                     return 1
                 }
             }
@@ -5979,7 +6034,7 @@ impl Lowerer {
                             // with a new `3` marker for scalar-i64 fields (2 is already taken by
                             // f64-array). Existing consumers only test `== 1` / `== 2`, so this
                             // is inert for them; field_is_int_* below tests `== 3`.
-                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_i64(&(*list).head.ty) { 3 } else { 0 },
+                            is_float: if lower_type_expr_is_f64(&(*list).head.ty) { 1 } else if lower_type_expr_is_array_of_f64(&(*list).head.ty) { 2 } else if lower_type_expr_is_integer(&(*list).head.ty) { 3 } else { 0 },
                         }
                         lay_entry.field_count = fc + 1
                         (*lo.struct_layouts).entries[layout_idx as usize] = lay_entry
@@ -6704,11 +6759,12 @@ impl Lowerer {
                         locals.wide_signed[idx as usize] = 0
                         locals.is_ref[idx as usize] = if lower_type_expr_is_ref_like(&(*list).head.ty) { 1 } else { 0 }
                         // D5+D1 (#986+#983): f64 params → kind 2 (cast + float-print);
-                        // i64 params → kind 1 (println safety). Bare int `as i64` stays
-                        // identity because only kind 2 triggers IrFloatToInt.
+                        // word-size integer params (i8..i64/u8..u64/isize/usize) → kind 1
+                        // (println safety). Bare int `as i64` stays identity because only
+                        // kind 2 triggers IrFloatToInt. i32 was previously left at 0.
                         locals.scalar_kind[idx as usize] = if lower_type_expr_is_f64(&(*list).head.ty) {
                             2
-                        } else if lower_type_expr_is_i64(&(*list).head.ty) {
+                        } else if lower_type_expr_is_integer(&(*list).head.ty) {
                             1
                         } else {
                             0
@@ -7519,9 +7575,10 @@ impl Lowerer {
         }
         if lower_opt_type_is_f64(&s.ty) {
             lo = lo.bind_local_scalar_kind(s.name, 2)
-        } else if lower_opt_type_is_i64(&s.ty) {
-            // D5 (#986): annotated `var i: i64 = ...` is positively int (println +
-            // cast consumers). Mirrors f64 annotation binding above.
+        } else if lower_opt_type_is_integer(&s.ty) {
+            // Annotated `let y: i64 = x+11` / `var i: i32 = ...` is positively int
+            // (println + cast consumers). Broader than i64-only so i32 annotations
+            // also route println through print_int. Mirrors f64 annotation above.
             lo = lo.bind_local_scalar_kind(s.name, 1)
         } else if lower_opt_type_is_string(&s.ty) {
             // Annotated `let s: string = ...` is a packed *u8; track as kind 3 so
@@ -7534,11 +7591,11 @@ impl Lowerer {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if (*expr_box_sk).kind == ExprKind::ExprBoolTrue || (*expr_box_sk).kind == ExprKind::ExprBoolFalse {
                         lo = lo.bind_local_scalar_kind(s.name, 1)
-                    } else if (*expr_box_sk).kind == ExprKind::ExprCast && lower_cast_type_is_i64(&(*expr_box_sk).cast_type) {
-                        // D5 (#986): `var i = 0 as i64` is an int local. Without this
-                        // the cast RHS left kind 0, and once f64 params correctly carry
-                        // kind 2 the cross-fn variance/float-reg tables (or cast path)
-                        // could treat the counter as float.
+                    } else if (*expr_box_sk).kind == ExprKind::ExprCast && lower_cast_type_is_integer(&(*expr_box_sk).cast_type) {
+                        // D5 (#986) + residual: `var i = 0 as i64` / `as i32` is an int
+                        // local. Without this the cast RHS left kind 0, and once f64
+                        // params correctly carry kind 2 the cross-fn variance/float-reg
+                        // tables (or cast path) could treat the counter as float.
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if lo.expr_result_is_float_ref(&(*expr_box_sk)) {
                         lo = lo.bind_local_scalar_kind(s.name, 2)
@@ -7548,15 +7605,14 @@ impl Lowerer {
                         lo = lo.bind_local_scalar_kind(s.name, 3)
                     } else if ((*expr_box_sk).kind == ExprKind::ExprCall || (*expr_box_sk).kind == ExprKind::ExprMethodCall) && lo.expr_result_scalar_kind_ref(&(*expr_box_sk)) == 1 {
                         // `let r = f(..)` / `let r = x.m(..)` whose callee POSITIVELY
-                        // returns i64 (return_struct_name == "i64"). Without this the
-                        // local stayed kind 0 and `println(r)` routed the i64 through the
-                        // char* printer, dereferencing the integer as a pointer -> SIGSEGV
-                        // (e.g. `let r = use2::<i64>(2,3); println(r)` — primitive-receiver
-                        // trait dispatch result). Restricted to Call/MethodCall so an
-                        // indexed struct element cannot be misclassified as int.
+                        // returns an integer type. Without this the local stayed kind 0
+                        // and `println(r)` routed the int through the char* printer →
+                        // SIGSEGV (e.g. `let r = use2::<i64>(2,3); println(r)`).
+                        // Restricted to Call/MethodCall so an indexed struct element
+                        // cannot be misclassified as int.
                         lo = lo.bind_local_scalar_kind(s.name, 1)
                     } else if ((*expr_box_sk).kind == ExprKind::ExprBinary || (*expr_box_sk).kind == ExprKind::ExprUnary) {
-                        // `let y = x + 1` / `let y = 0 - x` without an i64 annotation:
+                        // `let y = x + 1` / `let y = 0 - x` without an integer annotation:
                         // expr_result_scalar_kind_ref now positively returns 1 for int
                         // arith (and 2/3 for float/string). Bind that kind so a later
                         // `print(y)` / `println(y)` routes to print_int rather than
@@ -9958,6 +10014,9 @@ impl Lowerer {
                 let iv = pair_iv.1
                 lo = lo.emit(ir_copy(iv, start_reg))
                 lo = lo.bind_local(e.name, iv, true)
+                // Range for-IV is always an integer index. Without kind 1,
+                // `for i in 0..n { println(i) }` routes i through print_str → SEGV.
+                lo = lo.bind_local_scalar_kind(e.name, 1)
 
                 let pair_end = lo.lower_opt_expr_ref(&(*iter_box).right)
                 lo = pair_end.0
@@ -10071,6 +10130,13 @@ impl Lowerer {
         let v_reg = pair_v.1
         lo = lo.emit(ir_index_get(v_reg, base_reg, iv))
         lo = lo.bind_local(e.name, v_reg, true)
+        // Element binding: float-element arrays → kind 2; otherwise treat the
+        // element as int so `for v in arr { println(v) }` does not SEGV.
+        if lo.lookup_local_array_elem_float((*iter).name) {
+            lo = lo.bind_local_scalar_kind(e.name, 2)
+        } else {
+            lo = lo.bind_local_scalar_kind(e.name, 1)
+        }
 
         lo = lo.push_loop_labels(l_cont, l_end)
         let for_block_opt: Option<Box<Block>> = e.block

--- a/tests/run-pass/println_int_arith_unannotated.sio
+++ b/tests/run-pass/println_int_arith_unannotated.sio
@@ -1,0 +1,28 @@
+//@ run-pass
+// Residual: unannotated `let y = x + 1; println(y)` and `println(x + 1)`.
+// Without positive kind-1 on Binary, Madaros routes through print_str → SEGV.
+//
+// Expected:
+//   42
+//   42
+//   42
+//   PASS
+
+fn show_arith(x: i64) with IO {
+    let y = x + 1
+    println(y)
+}
+
+fn show_binop(x: i64) with IO {
+    println(x + 1)
+}
+
+fn main() -> i64 with IO {
+    show_arith(41)
+    show_binop(41)
+    let a = 20
+    let b = a + 22
+    println(b)
+    println("PASS")
+    0
+}

--- a/tests/run-pass/println_int_computed_local.sio
+++ b/tests/run-pass/println_int_computed_local.sio
@@ -1,0 +1,54 @@
+//@ run-pass
+// Wave2 Agent I residual holes — println/print of computed integers under Madaros.
+// Root cause: scalar_kind=0 routes println through print_str (char* strlen) → SEGV.
+//
+// W1 annotated let i64 from arith
+// W2 for-loop IV
+// W3 i64 param
+// W4 bare arith binop
+// W5 i32 param + annotated i32 local
+//
+// Expected stdout (order stable):
+//   53
+//   0
+//   1
+//   2
+//   42
+//   12
+//   7
+//   20
+//   PASS
+
+fn show_param(x: i64) with IO {
+    println(x)
+}
+
+fn show_i32_param(x: i32) with IO {
+    println(x)
+}
+
+fn main() -> i64 with IO {
+    // W1: annotated let from binary arith — residual SEGV on main pre-fix
+    let x: i64 = 42
+    let y: i64 = x + 11
+    println(y)
+
+    // W2: for-loop IV
+    for i in 0..3 {
+        println(i)
+    }
+
+    // W3: i64 param
+    show_param(42)
+
+    // W4: bare arith binop (no intermediate local)
+    println(x + 0 - 30)
+
+    // W5: i32 param + annotated i32 local
+    show_i32_param(7)
+    let z: i32 = 20
+    println(z)
+
+    println("PASS")
+    0
+}


### PR DESCRIPTION
## Summary

Closes residual **`println`/`print` of computed integers → SEGV** under Madaros (Agent E diagnosis; Wave2 Agent I implementer).

Root cause: `println_dispatch_name` uses `expr_result_scalar_kind_ref`; when **scalar_kind=0**, the value is handed to the char\* `print`/`print_str` builtin, which `strlen`s the integer payload → SIGSEGV.

D5+D1 (#1252) already bound **i64 params** and **annotated i64 locals** to kind 1. Residual holes after that (still SEGV on prebuilt; arithmetic path still SEGV after rebuild of D5+D1 alone):

| Case | Prebuilt main | After this PR (rebuilt Madaros) |
|---|---|---|
| `let y: i64 = x+11; println(y)` | SEGV | `53` rc=0 |
| `for i in 0..3 { println(i) }` | SEGV | `0\n1\n2` rc=0 |
| `fn f(x: i64) { println(x) }` | depends on rebuild of #1252 | `42` rc=0 |
| `println(x + 1)` / `let y = x+1; println(y)` | SEGV | `42` rc=0 |
| `fn f(x: i32) { println(x) }` / `let z: i32 = 20` | SEGV (i64-only) | `7` / `20` rc=0 |
| `println_int_array_field` | green | green |
| string concat `a + b` | green | green |
| `println(3.5)` f64 local | green | green |

## Fix (`self-hosted/ir/lower.sio` only)

1. **`lower_name_is_integer_type` / `lower_type_expr_is_integer` / `lower_opt_type_is_integer` / `lower_cast_type_is_integer`** — word-size integers: i8/i16/i32/i64, u8/u16/u32/u64, isize/usize (not float/string/bool/char).
2. **Params** (path A mut + path B ref): integer types → kind 1 (was i64-only).
3. **Annotated lets**: `lower_opt_type_is_integer` → kind 1.
4. **`expr_result_scalar_kind_ref`**: cast/call/method returns use integer helper; non-float Binary → 1 (string concat first → 3); non-float Unary → 1.
5. **Let of Binary/Unary RHS** binds resolved scalar_kind (so `let y = x+1; println(y)` works without annotation).
6. **Range for-IV** → kind 1; **for-in array element** → 1 (or 2 if float-element array).
7. **`bind_local`** zeroes `scalar_kind` on new slots (scope-reuse hygiene).
8. Field layout `is_float=3` marker expanded from i64-only to all integer types (println of i32 fields).

Does **not** touch write_file, dual prefer_module, or D5 variance-table resets. Adjacent open work:
- #1259 (binary arith print) — this PR **subsumes** that lower.sio change and adds for-IV + i32 + broader integer classification.
- #1258 (string index) — different locus; rebase if it merges first.

## Tests

- `tests/run-pass/println_int_computed_local.sio` — W1–W5 combined residual suite
- `tests/run-pass/println_int_arith_unannotated.sio` — unannotated arith local + bare binop
- Keep green: `println_int_array_field`, int literal, string concat, f64 println

## Rebuild evidence

```bash
SOUNIO_BUILD_LOCK=/tmp/sounio-println-build.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
# Madaros ready: artifacts/self-hosted/madaros (99204596 bytes)

export SOUNIO_STDLIB_PATH=$(pwd)/stdlib
export MADAROS_RAW_BIN=$(pwd)/artifacts/self-hosted/madaros

./bin/souc run tests/run-pass/println_int_computed_local.sio
# 53 / 0 1 2 / 42 / 12 / 7 / 20 / PASS  rc=0

./bin/souc run tests/run-pass/println_int_arith_unannotated.sio
# 42 42 42 PASS  rc=0

./bin/souc run tests/run-pass/println_int_array_field.sio
# 30 7 elem PASS  rc=0
```

Prebuilt `bin/madaros-linux-x86_64` is **not** refreshed in this PR; CI / local need `make build-madaros` (or artifacts ELF) to exercise the residual path.

## Acceptance

- [x] Annotated computed i64 local println no SEGV
- [x] for-loop IV println no SEGV
- [x] i64 param println no SEGV
- [x] bare arith binop println no SEGV
- [x] i32 param / annotated i32 local println no SEGV
- [x] string `+` still routes to str_concat
- [x] f64 println still routes to print_f64
- [x] println_int_array_field green