### PR TITLE
docs(research): the river = variational-not-search + the ordering test (falsified, honest null) + the erosion mechanism it localizes

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1051
-- Repo-backed topics: 901
+- Total governed topics: 1052
+- Repo-backed topics: 902
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 223
+- Authority count `historical`: 224
 - Authority count `repo_only`: 640
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 257 topics
+- A6: 258 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -786,6 +786,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.quaternion-neural-networks | historical | docs/research/QUATERNION_NEURAL_NETWORKS.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.relational-annihilation-geometry | historical | docs/research/relational-annihilation-geometry.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.research-validation-summary | repo_only | docs/research/RESEARCH_VALIDATION_SUMMARY.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.river-variational-and-the-ordering-null | historical | docs/research/river-variational-and-the-ordering-null.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.runtime-abi-gate-blocker-2026-06-23 | historical | docs/research/runtime-abi-gate-blocker-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.runtime-abi-gate-blocker-query-envelope-2026-06-24 | historical | docs/research/runtime-abi-gate-blocker-query-envelope-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.rupture-as-singularity | historical | docs/research/rupture-as-singularity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17413,6 +17413,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.river-variational-and-the-ordering-null",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/river-variational-and-the-ordering-null.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.runtime-abi-gate-blocker-2026-06-23",
       "collection": "repo",
       "repo_doc_path": "docs/research/runtime-abi-gate-blocker-2026-06-23.md",

--- a/docs/research/affective_ordering.py
+++ b/docs/research/affective_ordering.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# The order-is-content test (OPUS-4.8-EXTRA critique #6, §5). Standard training SHUFFLES data — it treats
+# order as noise to remove. The non-associativity thesis says order is content. Testable and cheap:
+#   Does affectively-COHERENT ordering (a continuous VAD trajectory, no abrupt affective jumps between
+#   consecutive examples) beat SHUFFLING — same data, same compute, same seeds?
+# Setup: each example carries an affective coordinate a∈[-1,1]³ (valence/arousal/dominance); the target rule
+# drifts SMOOTHLY with mood, y = sign(w(a)·x), w(a) a smooth mood-dependent weight. The model sees [x;a].
+# Single-pass online SGD (the regime where order matters most). Coherent = greedy nearest-neighbour VAD
+# path; shuffled = random; anti-coherent = maximally jumpy (control). Honest either way.
+import numpy as np
+np.seterr(all='ignore')
+def make_data(rng,N,d,Wm):
+    a=rng.uniform(-1,1,(N,3)); X=rng.standard_normal((N,d))
+    A1=np.concatenate([a,np.ones((N,1))],1)          # [a;1]
+    W=np.tanh(A1@Wm)                                  # (N,d) mood-dependent weight
+    y=(np.sum(W*X,1)>0).astype(float)
+    return X,a,y
+def coherent_order(a):                                # greedy nearest-neighbour path in VAD space
+    N=len(a); used=np.zeros(N,bool); order=[0]; used[0]=True
+    for _ in range(N-1):
+        last=a[order[-1]]; dist=np.sum((a-last)**2,1); dist[used]=1e9
+        nxt=int(np.argmin(dist)); order.append(nxt); used[nxt]=True
+    return np.array(order)
+def anti_order(a):                                    # maximally-jumpy: always go to the FARTHEST unvisited
+    N=len(a); used=np.zeros(N,bool); order=[0]; used[0]=True
+    for _ in range(N-1):
+        last=a[order[-1]]; dist=np.sum((a-last)**2,1); dist[used]=-1
+        order.append(int(np.argmax(dist))); used[order[-1]]=True
+    return np.array(order)
+class MLP:
+    def __init__(s,D,H,rng):
+        s.W1=rng.standard_normal((D,H))*0.3; s.b1=np.zeros(H); s.W2=rng.standard_normal(H)*0.3; s.b2=0.0
+    def step(s,x,y,lr):
+        h=np.tanh(x@s.W1+s.b1); logit=h@s.W2+s.b2; p=1/(1+np.exp(-logit)); dL=p-y
+        gW2=h*dL; gb2=dL; dh=dL*s.W2*(1-h*h); gW1=np.outer(x,dh); gb1=dh
+        s.W2-=lr*gW2; s.b2-=lr*gb2; s.W1-=lr*gW1; s.b1-=lr*gb1
+    def acc(s,X,Y):
+        h=np.tanh(X@s.W1+s.b1); p=(h@s.W2+s.b2)>0; return (p==Y).mean()
+def run(seed):
+    rng=np.random.default_rng(seed); d=16; H=64; N=4000; lr=0.05
+    Wm=rng.standard_normal((4,d))                     # the smooth mood→weight map (shared across conditions)
+    Xtr,atr,ytr=make_data(rng,N,d,Wm); Xte,ate,yte=make_data(rng,1000,d,Wm)
+    Ftr=np.concatenate([Xtr,atr],1); Fte=np.concatenate([Xte,ate],1); D=d+3
+    W1_0=rng.standard_normal((D,H))*0.3; b1_0=np.zeros(H); W2_0=rng.standard_normal(H)*0.3  # shared init
+    orders={'coherent':coherent_order(atr),'shuffled':rng.permutation(N),'anti-coherent':anti_order(atr)}
+    res={}
+    for name,order in orders.items():
+        m=MLP(D,H,rng); m.W1=W1_0.copy(); m.b1=b1_0.copy(); m.W2=W2_0.copy(); m.b2=0.0   # identical start
+        for i in order: m.step(Ftr[i],ytr[i],lr)      # single pass, in the given order
+        res[name]=m.acc(Fte,yte)
+    return res
+print("Order-is-content: single-pass online SGD, identical data/init/steps — only the ORDER differs.")
+print("Target rule drifts smoothly with affective coordinate (VAD). Test accuracy (chance=50%):")
+seeds=range(8); R={k:[] for k in ['coherent','shuffled','anti-coherent']}
+for s in seeds:
+    r=run(s)
+    for k in r: R[k].append(r[k])
+for k in ['coherent','shuffled','anti-coherent']:
+    v=np.array(R[k])*100; print(f"  {k:15s}: {v.mean():5.2f}% ± {v.std():4.2f}   (per-seed {np.round(v,1)})")
+co=np.array(R['coherent']); sh=np.array(R['shuffled'])
+diff=(co-sh)*100
+print(f"\ncoherent − shuffled: {diff.mean():+.2f} pp ± {diff.std():.2f}   wins {int((diff>0).sum())}/8 seeds")
+print("→ if coherent > shuffled: training composition is ORDER-DEPENDENT in a way current practice (shuffle) discards.")
+print("  if not: affective non-associativity does not manifest in small-scale single-pass training — an honest null.")

--- a/docs/research/codimension-and-the-bits-functional.md
+++ b/docs/research/codimension-and-the-bits-functional.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.codimension-and-the-bits-functional
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/river-variational-and-the-ordering-null.md
+++ b/docs/research/river-variational-and-the-ordering-null.md
@@ -1,0 +1,91 @@
+<!-- docs:meta
+topic_id: repo.docs.research.river-variational-and-the-ordering-null
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.river-variational-and-the-ordering-null
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The river: variational principle, not search — and the ordering test that falsified its naive form
+
+*The "how did the river learn?" question, answered, and the cheap community-facing test it implies, run.
+The test's naive form fails — informatively. Implements OPUS-4.8-EXTRA critique #6.*
+
+## 1. The river satisfies a variational principle without running an optimizer
+
+A river network minimizes total energy dissipation (Optimal Channel Networks — Rodríguez-Iturbe &
+Rinaldo) and reproduces Horton's laws, Hack's law, fractal scaling — with **no objective evaluation, no
+search, no downstream credit assignment**. Water descends the local gradient; faster water erodes more; a
+deeper channel captures more water; positive feedback. Two facts that matter here: the outcomes are
+**feasible (local) optima**, yet they carry the **same statistical/fractal structure as the global
+optimum** — global search is *not* required for the right structure; and Bejan's **constructal law** (1996)
+states this as physics of form generation across rivers, lungs, vasculature, lightning — explicitly *not*
+optimization.
+
+## 2. This is the exact distinction between the program and RL — and it was already written
+
+When `g = (1+λs)·δ` was proposed, it was identified as **Fermat's principle** with refractive index
+`n = √(1+λs)`. Light does not *search* for the fastest path; it *takes* it — no evaluation of alternatives,
+no reward gradient, no softmax over trajectories. The geodesic is not the result of a search; it is what the
+local dynamics do. **RL evaluates, compares, back-assigns credit, and chooses; a variational system follows
+the structure of the space it is in.** "Not RL" does not mean rejecting optimization — it means **replacing
+search with geometry**: build the space so that the merciful path *is* the local path, and mercy happens
+without being optimized for.
+
+## 3. The community-facing test (§5) — and its honest falsification
+
+Standard training **shuffles** data — it treats order as noise. The thesis says order is content. Testable,
+cheap: does affectively-**coherent** ordering (a continuous VAD trajectory, no abrupt affective jumps) beat
+shuffling, same data / compute / seeds? Setup: examples carry a VAD coordinate; the target rule drifts
+smoothly with mood (`y = sign(w(a)·x)`); single-pass online SGD (order matters most). `affective_ordering.py`,
+8 seeds, test accuracy (chance 50%):
+
+| ordering | test acc |
+|---|---|
+| **coherent** (smooth VAD trajectory) | 67.85% ± 5.22 |
+| shuffled (standard) | 72.39% ± 2.50 |
+| anti-coherent (maximally jumpy) | **74.19% ± 2.04** |
+
+`coherent − shuffled = −4.54 pp` (coherent wins only 2/8 seeds). **The naive prediction is falsified:**
+coherent ordering *loses*, and *maximal jumping wins*. This is the textbook **interleaving-beats-blocking /
+anti-forgetting** result (Kornell & Bjork): a smooth affective trajectory lets the model specialize to the
+current mood-region and forget the rest; mixing gives coverage. The R$30-of-GPU answer: **affective
+non-associativity does not manifest as an example-ordering advantage in small-scale single-pass training.**
+Reported as a null, not hidden.
+
+## 4. Why it fails is the point — the missing ingredient is erosion (§3)
+
+The river's power is that **the flow reshapes the bed**: water carves the channel and the channel redirects
+the water — reciprocal coupling. Standard training has a **fixed** loss landscape; only the parameters
+move. So "coherent ordering" *without* the reciprocal coupling is merely **blocking**, and blocking causes
+forgetting — exactly what the table shows. The experiment therefore does not refute the thesis; it
+**localizes the missing mechanism**: not the ordering, but the **erosion** — the crossing should *lower the
+suffering field along the path traversed*, so that what was composed without annihilating becomes easier to
+recompose (a merciful path makes future paths more merciful). This is old and marginalized, not refuted:
+**Hebb** (what fires together wires together; the traversed path becomes easier) *is* erosion — local,
+reward-free, trajectory-dependent. The next test adds a Hebbian/consolidation coupling and asks whether
+coherent ordering *then* wins; without it, blocking-forgetting dominates and it should not.
+
+## 5. The lineage, and the competitor to face by name
+
+Hebb → Hopfield → self-organizing maps → predictive coding (Rao & Ballard) → **free-energy / active
+inference (Friston)**. The last is the real incumbent: it already positions as an RL alternative, already
+minimizes surprise instead of maximizing reward, and already dominates the computational-psychiatry niche
+this program targets. Presenting "learning without reward" as new invites "why is this not active inference
+renamed?" The clean differentiation: active inference lives in `ℝⁿ` with probability distributions and its
+path-dependence is *emergent from dynamics*; here the state space is **non-associative** and path-dependence
+is **structural** — nesting is content before any dynamics — and **annihilation has no free-energy analog**
+(high surprise is not a zero product). State this up front.
+
+## Honest status
+The variational-not-search framing (§1–2) is conceptual and stands. The community-facing ordering claim
+(§3) is **falsified** in the tested regime — a genuine, cheap negative. The constructive reading (§4): the
+missing ingredient is erosion (reciprocal flow↔landscape coupling; Hebb), which is the next experiment.
+The clinical bridge remains the aggregation critique + the mountain pass (`mountain_pass.py`), not `σ_min` —
+not to be spent on now. Harness `affective_ordering.py`.


### PR DESCRIPTION
Answers "how did the river learn?" and runs the cheap community-facing test it implies. The test's naive form fails — informatively (critique #6).

**§1-2 The river satisfies a variational principle without an optimizer.** OCN (Rodríguez-Iturbe & Rinaldo): feasible *local* optima carry the *global* fractal structure — global search unneeded; Bejan's constructal law = physics of form, explicitly not optimization. This is **Fermat's principle** (already written for `g=(1+λs)δ`, `n=√(1+λs)`): light *takes* the path, doesn't search. **The real "not RL" is variational-vs-search: replace search with geometry** so the merciful path *is* the local path.

**§3 The ordering test — falsified.** Standard training shuffles (order = noise); the thesis says order is content. `affective_ordering.py`, single-pass online SGD, target drifting smoothly with VAD, 8 seeds:
| ordering | acc |
|---|---|
| coherent (smooth VAD) | 67.85 ± 5.22 |
| shuffled | 72.39 ± 2.50 |
| anti-coherent (jumpy) | **74.19 ± 2.04** |

`coherent − shuffled = −4.54 pp`. Coherent **loses**, maximal-jumping **wins** — textbook interleaving-beats-blocking / anti-forgetting. **The naive prediction is falsified** in this regime. Honest null, R$30 of GPU.

**§4 Why it fails localizes the missing mechanism: EROSION.** The river's flow *reshapes the bed* (reciprocal coupling); fixed-landscape training lacks it, so coherent ordering is mere *blocking* → forgetting. The traversed path should *lower* the field (Hebb = erosion; local, reward-free, trajectory-dependent). Next test adds the coupling.

**§5 Face active inference (Friston) by name:** it already claims "learning without reward." Differentiation: non-associative **structural** path-dependence vs ℝⁿ **emergent**; annihilation ≠ high surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)