### PR TITLE
feat(stdlib): bigframe grouped rolling sum (bf_rolling_sum_by) — beats pandas 0.32x

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -55,6 +55,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rolling_skew (1M rows, window 100) | | ~130 | ~35 | **~3.8x** | per-element sqrt-bound |
 | rolling_kurt (1M rows, window 100) | | ~78 | ~28 | **~2.7x** | 4th-power sums; pandas Cython roll_kurt |
 | rolling_quantile (1M rows, window 100, q=0.9) | | 305 | 402 | **0.76x — Sounio wins** | sorted-window vs skip-list |
+| rolling_sum_by (1M rows, 1000 groups, window 100) | | ~57 | ~180 | **0.32x — Sounio wins** | vs pandas groupby().rolling() |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -10,7 +10,8 @@
 // quantile / median, covariance / correlation (+ a correct bf_sqrt), and
 // rolling variance / std, rolling median, cumulative product, and
 // per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
-// rolling correlation, rolling covariance / skewness / kurtosis, and rolling quantile.
+// rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
+// and grouped rolling sum.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2604,5 +2605,106 @@ pub fn bf_rolling_quantile(src: &BigFrame, col: i64, window: i64, q: f64, fill: 
         i = i + 1
     }
     heap_free(win as *mut i8)
+    out
+}
+
+/// Per-group rolling (sliding-window) sum: within each `key_col` group independently,
+/// out[i] = the sum of `val_col` over the last `window` rows of that group ending at
+/// row i (like pandas df.groupby(key)[val].rolling(window).sum(), aligned to input row
+/// order). A group's first window-1 rows take `fill`. O(n) via a factorize +
+/// counting-sort of row indices into contiguous per-group regions (order-preserving),
+/// then a sliding sum within each region -- so it scales to any group distribution and
+/// avoids pandas' heavy per-group rolling machinery. Returns a 1-column BigFrame of
+/// length n. NATIVE + lean_single only (heap).
+pub fn bf_rolling_sum_by(src: &BigFrame, key_col: i64, val_col: i64, window: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 || window <= 0 { return bf_new(1, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64      // key table -> compact group id
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hid = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let id = heap_alloc(nr * 8) as *mut i64          // compact group id per row
+    let sizes = heap_alloc(nr * 8) as *mut i64       // rows per compact id (calloc 0)
+    var gcount: i64 = 0
+    var r: i64 = 0
+    while r < nr {
+        let k = read_f64(kp, r)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hid, slot, gcount as f64)
+                write_i64(id, r, gcount)
+                write_i64(sizes, gcount, 1)
+                gcount = gcount + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    let g = read_f64(hid, slot) as i64
+                    write_i64(id, r, g)
+                    write_i64(sizes, g, read_i64(sizes, g) + 1)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        r = r + 1
+    }
+    // region offsets = prefix sum of group sizes; cursor tracks the scatter position.
+    let offsets = heap_alloc(nr * 8) as *mut i64
+    let cursor = heap_alloc(nr * 8) as *mut i64
+    var acc: i64 = 0
+    var g: i64 = 0
+    while g < gcount {
+        write_i64(offsets, g, acc)
+        write_i64(cursor, g, acc)
+        acc = acc + read_i64(sizes, g)
+        g = g + 1
+    }
+    // scatter row indices into their group's region, preserving input order.
+    let flat = heap_alloc(nr * 8) as *mut i64
+    r = 0
+    while r < nr {
+        let g2 = read_i64(id, r)
+        let p = read_i64(cursor, g2)
+        write_i64(flat, p, r)
+        write_i64(cursor, g2, p + 1)
+        r = r + 1
+    }
+    var out = bf_new(1, nr)
+    out.n_rows = nr
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    // per-group sliding sum over the (order-preserved) region.
+    g = 0
+    while g < gcount {
+        let base = read_i64(offsets, g)
+        let sz = read_i64(sizes, g)
+        var wsum = 0.0
+        var jj: i64 = 0
+        while jj < sz {
+            let row = read_i64(flat, base + jj)
+            wsum = wsum + read_f64(vp, row)
+            if jj >= window { wsum = wsum - read_f64(vp, read_i64(flat, base + jj - window)) }
+            if jj >= window - 1 { write_f64(op, row, wsum) } else { write_f64(op, row, fill) }
+            jj = jj + 1
+        }
+        g = g + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hid as *mut i8)
+    heap_free(id as *mut i8)
+    heap_free(sizes as *mut i8)
+    heap_free(offsets as *mut i8)
+    heap_free(cursor as *mut i8)
+    heap_free(flat as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -725,6 +725,21 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var rqd: i64 = 0; var rqj: i64 = 0
     while rqj < 3000 { if bf_get(&rqm, rqj, 0) != bf_get(&rmd, rqj, 0) { rqd = rqd + 1 } rqj = rqj + 1 }
     if rqd != 0 { print("FAIL rq_vs_median\n"); return 258 }
+    // GROUPED ROLLING SUM. key=i%1000, val=i, window 3. Per group k (rows k, k+1000, ...):
+    // the j-th occurrence sums vals of occurrences j-2..j; occurrence j=i/1000 has val=i.
+    var gsf = bf_new(2, 16)
+    var gsi: i64 = 0
+    while gsi < 100000 { var gsr:[f64;64]=[0.0;64]; gsr[0]=(gsi%1000) as f64; gsr[1]=gsi as f64; bf_push_row(&!gsf,&gsr,2); gsi=gsi+1 }
+    let gs = bf_rolling_sum_by(&gsf, 0, 1, 3, 0.0 - 1.0)
+    if bf_nrows(&gs) != 100000 { print("FAIL rsumby_n\n"); return 259 }
+    if bf_get(&gs, 1000, 0) != (0.0 - 1.0) { print("FAIL rsumby_fill\n"); return 260 }   // group 0 occ 1, window not full
+    if !approx_eq(bf_get(&gs, 2000, 0), 3000.0) { print("FAIL rsumby_2000\n"); return 261 }  // 0+1000+2000
+    if !approx_eq(bf_get(&gs, 3000, 0), 6000.0) { print("FAIL rsumby_3000\n"); return 262 }  // 1000+2000+3000
+    if !approx_eq(bf_get(&gs, 99500, 0), 295500.0) { print("FAIL rsumby_last\n"); return 263 } // group 500 last window
+    // total: each group contributes sum over its rows minus the first 2 occurrences per group.
+    // spot a second group: row 7 (group 7 occ 0) -> fill; row 2007 (group 7 occ 2) -> 7+1007+2007=3021.
+    if bf_get(&gs, 7, 0) != (0.0 - 1.0) { print("FAIL rsumby_g7fill\n"); return 264 }
+    if !approx_eq(bf_get(&gs, 2007, 0), 3021.0) { print("FAIL rsumby_g7\n"); return 265 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_rolling_sum_by(src, key_col, val_col, window, fill)` in `data::bigframe_ops` — a rolling window sum applied **independently within each `key_col` group** (pandas `df.groupby(key)[val].rolling(window).sum()`, aligned to input row order). A group's first `window-1` rows take `fill`.

**O(n) and scalable** to any group distribution: a **factorize + counting-sort** of row indices into contiguous per-group regions (order-preserving), then a **sliding sum within each region** — avoiding pandas' heavy per-group rolling machinery.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

`key=i%1000`, `val=i`, window 3, 100k rows → per group k the j-th occurrence sums occurrences j-2..j: row 1000 (occ 1) = **fill**; row 2000 = 0+1000+2000 = **3000**; row 3000 = **6000**; row 99500 = **295500**; group 7: row 7 = fill, row 2007 = 7+1007+2007 = **3021**. Plus a full-row differential vs pandas over 20k rows (key=i%7, val=(i*13)%100, window 5) = **0 diffs**.

## Benchmark (1M rows, 1000 groups, window 100)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| rolling_sum_by | ~57 | ~180 | **0.32× — Sounio wins** |

pandas' `groupby().rolling()` is notoriously heavy; the O(n) counting-sort + per-group slide is ~3× faster. Correct and gate-verified.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)