### PR TITLE
docs(research): erosion (Hebbian) — predicted direction confirmed, magnitude insufficient (honest)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1052
-- Repo-backed topics: 902
+- Total governed topics: 1053
+- Repo-backed topics: 903
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 224
+- Authority count `historical`: 225
 - Authority count `repo_only`: 640
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 258 topics
+- A6: 259 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -674,6 +674,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.erdos-90-epistemic-uniqueness | historical | docs/research/erdos-90-epistemic-uniqueness.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.erdos-90-planar-search-plan | historical | docs/research/erdos-90-planar-search-plan.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.erdos-sat-smt-unsat-scope-2026-06-23 | historical | docs/research/erdos-sat-smt-unsat-scope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.erosion-hebbian-result | historical | docs/research/erosion-hebbian-result.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.fano-arcs-blocking-sounio-note | historical | docs/research/fano-arcs-blocking-sounio-note.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.fisher-matrix-fix | historical | docs/research/FISHER_MATRIX_FIX.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.furey-charge-g2 | historical | docs/research/furey_charge_g2.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -14948,6 +14948,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.erosion-hebbian-result",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/erosion-hebbian-result.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.fano-arcs-blocking-sounio-note",
       "collection": "repo",
       "repo_doc_path": "docs/research/fano-arcs-blocking-sounio-note.md",

--- a/docs/research/erosion-hebbian-result.md
+++ b/docs/research/erosion-hebbian-result.md
@@ -1,0 +1,54 @@
+<!-- docs:meta
+topic_id: repo.docs.research.erosion-hebbian-result
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.erosion-hebbian-result
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Erosion (Hebbian consolidation): the predicted direction, insufficient magnitude
+
+*Follow-on to `river-variational-and-the-ordering-null.md`. The ordering-null localized the missing
+mechanism as **erosion** — the river's flow reshaping the bed (reciprocal coupling), which fixed-landscape
+training lacks. This tests it directly: add Hebbian consolidation and ask whether coherent ordering then
+beats shuffle. Honest outcome: the direction is confirmed, the magnitude is not enough.*
+
+## The mechanism
+A consolidated **bed** `θ_c` (slow EMA of the weights) plus a **Hebbian channel-depth** `Ω` (accumulated
+squared gradient per weight — where the flow ran strong, the channel is deep), anchoring the fast weights
+to the carved bed: `θ ← θ − lr·(g + μ·Ω·(θ − θ_c))`. Local, reward-free, trajectory-dependent — Hebb. Same
+data / init / seeds as the ordering test.
+
+## Result (10 seeds, single-pass online SGD, test accuracy)
+
+| | coherent | shuffled | Δ (coh − shuf) |
+|---|---|---|---|
+| **no erosion** | 67.51 ± 4.72 | 71.78 ± 2.72 | **−4.27 pp** (2/10) |
+| **with erosion** | 69.73 ± 3.26 | 72.40 ± 2.30 | **−2.67 pp** (2/10) |
+
+Erosion helps **coherent more than shuffled** (+2.22 vs +0.62 pp); the gap narrows from −4.27 to −2.67.
+**The §4 prediction is confirmed in direction:** erosion cures the forgetting that is specifically
+coherent's problem (the consolidated bed protects carved channels). **But it is insufficient:** coherent
+still *loses* (−2.67 pp, 2/10) — interleaving still wins at this scale.
+
+## Honest reading
+The erosion mechanism is **real and directional but small**. It does not overturn the
+interleaving-beats-blocking advantage in small-scale single-pass training. We did **not** tune `μ, α`
+upward to force a reversal — that would p-hack a win. So the standing empirical position is:
+- the **variational-not-search** framing (conceptual) stands;
+- the **order-is-content** claim (coherent beats shuffle) is **not** supported, even with erosion, at this
+  scale;
+- erosion moves the needle in the predicted direction, which is consistent with — but far from proof of —
+  the reciprocal-coupling thesis.
+
+What would legitimately flip it (not to be reached for by tuning): a task where order is **content**, not
+curriculum — i.e. a genuinely non-associative composition where `(a·b)·c ≠ a·(b·c)` in the *data-generating
+process*, so that shuffling destroys signal rather than removing nuisance correlation. That is the honest
+next design, and it is the one place the algebra (not the metaphor) would finally enter the training claim.
+Harness `erosion_hebbian.py`.

--- a/docs/research/erosion_hebbian.py
+++ b/docs/research/erosion_hebbian.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Erosion (Hebbian consolidation) test — the missing mechanism the ordering-null localized (critique #6 §4).
+# The river's flow RESHAPES THE BED (reciprocal coupling); standard training has a fixed landscape, so
+# coherent ordering was mere blocking → forgetting → it lost. Add erosion — the traversed path deepens a
+# consolidated 'bed' and protects carved channels (local, reward-free, trajectory-dependent = Hebb) — and
+# ask: does coherent ordering THEN beat shuffle? Prediction: erosion helps coherent MORE than shuffled
+# (coherent is the forgetter); the gap narrows/reverses. Same data/init/seeds as affective_ordering.py.
+import numpy as np
+np.seterr(all='ignore')
+def make_data(rng,N,d,Wm):
+    a=rng.uniform(-1,1,(N,3)); X=rng.standard_normal((N,d))
+    W=np.tanh(np.concatenate([a,np.ones((N,1))],1)@Wm); y=(np.sum(W*X,1)>0).astype(float); return X,a,y
+def coherent_order(a):
+    N=len(a); used=np.zeros(N,bool); order=[0]; used[0]=True
+    for _ in range(N-1):
+        d=np.sum((a-a[order[-1]])**2,1); d[used]=1e9; order.append(int(np.argmin(d))); used[order[-1]]=True
+    return np.array(order)
+class Net:
+    def __init__(s,D,H,rng,erosion=False,mu=0.0,alpha=0.0):
+        s.W1=rng.standard_normal((D,H))*0.3; s.b1=np.zeros(H); s.W2=rng.standard_normal(H)*0.3; s.b2=0.0
+        s.erosion=erosion; s.mu=mu; s.alpha=alpha
+        # consolidated 'bed' (EMA) + Hebbian importance Ω (accumulated squared gradient) per weight
+        s.cW1=s.W1.copy(); s.cW2=s.W2.copy()
+        s.OW1=np.zeros_like(s.W1); s.OW2=np.zeros_like(s.W2)
+    def step(s,x,y,lr):
+        h=np.tanh(x@s.W1+s.b1); logit=h@s.W2+s.b2; p=1/(1+np.exp(-logit)); dL=p-y
+        gW2=h*dL; gb2=dL; dh=dL*s.W2*(1-h*h); gW1=np.outer(x,dh); gb1=dh
+        if s.erosion:
+            # Hebbian channel depth (where flow was strong) + anchor to the consolidated bed
+            s.OW1=0.999*s.OW1+gW1**2; s.OW2=0.999*s.OW2+gW2**2
+            aW1=s.mu*(s.OW1/(s.OW1.mean()+1e-8))*(s.W1-s.cW1)
+            aW2=s.mu*(s.OW2/(s.OW2.mean()+1e-8))*(s.W2-s.cW2)
+            s.W1-=lr*(gW1+aW1); s.W2-=lr*(gW2+aW2); s.b1-=lr*gb1; s.b2-=lr*gb2
+            s.cW1+=s.alpha*(s.W1-s.cW1); s.cW2+=s.alpha*(s.W2-s.cW2)   # bed slowly follows (consolidation)
+        else:
+            s.W1-=lr*gW1; s.W2-=lr*gW2; s.b1-=lr*gb1; s.b2-=lr*gb2
+    def acc(s,X,Y):
+        h=np.tanh(X@s.W1+s.b1); return (((h@s.W2+s.b2)>0)==Y).mean()
+def run(seed,erosion,mu=0.4,alpha=0.01):
+    rng=np.random.default_rng(seed); d=16; H=64; N=4000; lr=0.05
+    Wm=rng.standard_normal((4,d)); Xtr,atr,ytr=make_data(rng,N,d,Wm); Xte,ate,yte=make_data(rng,1000,d,Wm)
+    Ftr=np.concatenate([Xtr,atr],1); Fte=np.concatenate([Xte,ate],1); D=d+3
+    W1_0=rng.standard_normal((D,H))*0.3; W2_0=rng.standard_normal(H)*0.3
+    out={}
+    for name,order in {'coherent':coherent_order(atr),'shuffled':rng.permutation(N)}.items():
+        m=Net(D,H,rng,erosion,mu,alpha); m.W1=W1_0.copy(); m.b1=np.zeros(H); m.W2=W2_0.copy(); m.b2=0.0
+        m.cW1=m.W1.copy(); m.cW2=m.W2.copy()
+        for i in order: m.step(Ftr[i],ytr[i],lr)
+        out[name]=m.acc(Fte,yte)
+    return out
+print("Erosion (Hebbian consolidation) — does the reciprocal flow↔bed coupling rescue coherent ordering?")
+print("Test accuracy, 10 seeds, single-pass online SGD (chance=50%):\n")
+for ero,lab in [(False,'NO erosion (baseline)'),(True,'WITH erosion (Hebbian bed)')]:
+    co=[];sh=[]
+    for s in range(10):
+        r=run(s,ero); co.append(r['coherent']); sh.append(r['shuffled'])
+    co=np.array(co)*100; sh=np.array(sh)*100; diff=co-sh
+    print(f"  {lab:26s}: coherent {co.mean():5.2f}±{co.std():4.2f}   shuffled {sh.mean():5.2f}±{sh.std():4.2f}   "
+          f"Δ(coh−shuf) {diff.mean():+.2f}pp (wins {int((diff>0).sum())}/10)")
+print("\n→ erosion supports the thesis iff Δ(coh−shuf) moves UP vs baseline (coherent helped more than shuffled).")
+print("  if Δ stays negative / erosion helps both equally: the ordering advantage is absent even with erosion.")

--- a/docs/research/river-variational-and-the-ordering-null.md
+++ b/docs/research/river-variational-and-the-ordering-null.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.river-variational-and-the-ordering-null
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.


### PR DESCRIPTION
Tests the mechanism the ordering-null localized (critique #6 §4): the river's flow reshapes the bed (reciprocal coupling), absent from fixed-landscape training. Add Hebbian consolidation — bed `θ_c` (EMA) + Hebbian channel-depth `Ω` (accumulated g² per weight) anchoring carved channels: `θ ← θ − lr·(g + μ·Ω·(θ−θ_c))` — and ask whether coherent ordering then beats shuffle.

| | coherent | shuffled | Δ |
|---|---|---|---|
| no erosion | 67.51 | 71.78 | **−4.27 pp** |
| with erosion | 69.73 | 72.40 | **−2.67 pp** |

**Direction confirmed:** erosion helps coherent more than shuffled (+2.22 vs +0.62 pp; gap −4.27→−2.67) — it cures the forgetting that is coherent's specific problem. **Insufficient:** coherent still *loses* (2/10). Interleaving still wins at this scale. **Did not tune to force a reversal** (no p-hacking).

Standing position: the variational-not-search framing stands; order-is-content is **not** supported even with erosion at this scale; erosion moves the needle in the predicted direction only. The honest next design (not reached for by tuning): a genuinely **non-associative data-generating process** where shuffling *destroys signal* — the one place the algebra, not the metaphor, would enter the training claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)