### PR TITLE
fix(check): reject unknown methods at multi-module check (E011)

### DIFF
--- a/artifacts/compiler/madaros_unknown_method_check_receipt.v1.json
+++ b/artifacts/compiler/madaros_unknown_method_check_receipt.v1.json
@@ -1,0 +1,19 @@
+{
+  "schema": "madaros_unknown_method_check_receipt.v1",
+  "status": "pass",
+  "engine": "madaros_default",
+  "commit": "822d138ba2cc8dd25935c63933edcac40ab7b73c",
+  "claims": [
+    "unknown_method_rejected_at_check",
+    "unknown_method_name_rejected_under_untyped_receiver",
+    "known_method_e_val_still_ok",
+    "dual_gum_knowledge_e_val_still_ok",
+    "root2_multimodule_method_still_ok"
+  ],
+  "claims_not_made": [
+    "ufcs_instance_method_as_type_path",
+    "exhaustive_stdlib_method_census",
+    "imported_associated_Type_method_always_typed",
+    "lean_single_fixed_point_after_change"
+  ]
+}

--- a/docs/audit/MADAROS_DUAL_GUM_KNOWLEDGE_IMPORT_2026-07-19.md
+++ b/docs/audit/MADAROS_DUAL_GUM_KNOWLEDGE_IMPORT_2026-07-19.md
@@ -159,7 +159,7 @@ verdict=0. Private-fn negative control still E175.
 
 - Exhaustive census of all same-named private helpers across stdlib
 - Resolution of #854 (EISA E5 multi-module E175 graph) beyond the name-collision class
-- **Unknown method calls rejected at multi-module check** (still accepted; lower SEGV residual)
+- ~~**Unknown method calls rejected at multi-module check**~~ — closed by `fix/madaros-unknown-method-check` (associated `Type::method` return typing + E011); gate `scripts/madaros_unknown_method_check_gate.sh`
 - Compact emitter / remaining imported-module native defects (D1–D4 residual classes)
 - lean_single fixed-point identity after the checker change
 - Native run for every dual stdlib pair beyond gum+knowledge

--- a/scripts/madaros_unknown_method_check_gate.sh
+++ b/scripts/madaros_unknown_method_check_gate.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# scripts/madaros_unknown_method_check_gate.sh
+#
+# Unknown instance methods must fail at multi-module Madaros *check* (E011 /
+# verdict=1), not SEGV at native lower preseed. Known methods (e.val, e.std)
+# and associated constructors (Epistemic::measured) stay green.
+#
+# Root cause fixed: Type::method path callees were typed as the first path
+# segment only (often TyUnknown for imports), so receivers stayed unknown and
+# method resolution silently accepted any name.
+#
+# Requires current-source Madaros (artifacts/self-hosted/madaros or
+# MADAROS_RAW_BIN). Checked-in bin/madaros-linux-x86_64 may predate the fix.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+unset SOUNIO_SOUC_ENGINE || true
+
+ulimit -s unlimited 2>/dev/null || ulimit -s 131072 2>/dev/null || true
+
+SOUC="${SOUC:-$ROOT/bin/souc}"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+echo "== madaros_unknown_method_check_gate =="
+"$SOUC" --version 2>&1 | head -2 || true
+
+RAW=""
+for cand in "${MADAROS_RAW_BIN:-}" "${SOUNIO_MADAROS_BIN:-}" \
+            "$ROOT/artifacts/self-hosted/madaros" "$ROOT/bin/madaros-linux-x86_64"; do
+  if [[ -n "$cand" && -x "$cand" && "$(head -c2 "$cand" 2>/dev/null || true)" != '#!' ]]; then
+    RAW="$cand"
+    break
+  fi
+done
+if [[ -z "$RAW" ]]; then
+  echo "MADAROS_UNKNOWN_METHOD_CHECK_GATE_BLOCKED reason=no_raw_madaros" >&2
+  exit 1
+fi
+echo "raw_elf=$RAW"
+echo "raw_elf_sha256=$(sha256sum "$RAW" | awk '{print $1}')"
+echo "git_sha=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+check_must_fail() {
+  local name="$1" src="$2"
+  echo "== check-fail: $name =="
+  set +e
+  "$SOUC" check "$src" >"$OUT/c.log" 2>&1
+  local rc=$?
+  set -e
+  if grep -qE 'error\[E011|no method named|verdict=1' "$OUT/c.log" 2>/dev/null; then
+    echo "PASS: $name rejected at check"
+    return
+  fi
+  if grep -q 'verdict=0' "$OUT/c.log" 2>/dev/null || grep -q 'check: OK' "$OUT/c.log" 2>/dev/null; then
+    echo "FAIL: $name was accepted at check (expected E011 / verdict=1)"
+    tail -25 "$OUT/c.log" || true
+    fail=1
+    return
+  fi
+  if [[ $rc -ne 0 ]]; then
+    echo "PASS: $name check non-zero (rc=$rc)"
+    return
+  fi
+  echo "FAIL: $name unclear check result"
+  tail -25 "$OUT/c.log" || true
+  fail=1
+}
+
+check_ok() {
+  local name="$1" src="$2"
+  echo "== check: $name =="
+  if ! "$SOUC" check "$src" >"$OUT/c.log" 2>&1; then
+    echo "FAIL: check $src"
+    tail -20 "$OUT/c.log" || true
+    fail=1
+    return
+  fi
+  if grep -q 'verdict=1' "$OUT/c.log" 2>/dev/null; then
+    echo "FAIL: check $src (verdict=1)"
+    tail -20 "$OUT/c.log" || true
+    fail=1
+    return
+  fi
+  echo "PASS: check $name"
+}
+
+run_ok() {
+  local name="$1" src="$2" sentinel="$3"
+  echo "== run: $name =="
+  if ! "$SOUC" compile "$src" -o "$OUT/t.elf" >"$OUT/c.log" 2>&1; then
+    echo "FAIL: compile $src"
+    tail -20 "$OUT/c.log" || true
+    fail=1
+    return
+  fi
+  chmod +x "$OUT/t.elf"
+  if ! "$OUT/t.elf" >"$OUT/r.log" 2>&1 || ! grep -q "$sentinel" "$OUT/r.log"; then
+    echo "FAIL: run $src"
+    cat "$OUT/r.log" || true
+    fail=1
+    return
+  fi
+  echo "PASS: $sentinel"
+}
+
+# Negative: multi-module Epistemic.mean (nonexistent)
+check_must_fail "multi-module e.mean()" \
+  tests/ui/type/unknown_method_multimodule.sio
+
+# Negative: local associated constructor then unknown method
+check_must_fail "local E::of + e.no_such_method()" \
+  tests/ui/type/unknown_method_after_associated.sio
+
+# Negative: dual-shaped free program with e.mean()
+cat >"$OUT/dual_mean.sio" <<'EOF'
+use epistemic::knowledge::{Epistemic}
+use epistemic::gum::{gum_type_a, gum_type_b, gum_combine2, gum_k95}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let ua = gum_type_a(0.070710, 5)
+    let ub = gum_type_b(0.05)
+    let r = gum_combine2(98.3, ua, ub)
+    let k = gum_k95(r)
+    let e = Epistemic::measured(10.0, 0.5)
+    let m = e.mean()
+    if k <= 0.0 { return 1 }
+    if m < 9.0 { return 1 }
+    print("SHOULD_NOT\n")
+    return 0
+}
+EOF
+check_must_fail "dual gum+knowledge e.mean()" "$OUT/dual_mean.sio"
+
+# Positive: known methods still check+run
+check_ok "known methods multi-module" \
+  tests/run-pass/madaros_unknown_method_known_ok.sio
+run_ok "known methods multi-module run" \
+  tests/run-pass/madaros_unknown_method_known_ok.sio \
+  KNOWN_METHOD_OK
+
+# Positive: dual with e.val() still green
+check_ok "dual gum+knowledge e.val()" \
+  tests/run-pass/madaros_dual_gum_knowledge.sio
+run_ok "dual gum+knowledge e.val() run" \
+  tests/run-pass/madaros_dual_gum_knowledge.sio \
+  DUAL_GUM_KNOWLEDGE_OK
+
+# Positive: Root2 multimodule methods still green
+check_ok "root2 multimodule methods" \
+  tests/run-pass/madaros_root2_multimodule_method.sio
+run_ok "root2 multimodule methods run" \
+  tests/run-pass/madaros_root2_multimodule_method.sio \
+  ROOT2_MULTIMODULE_METHOD_OK
+
+mkdir -p "$ROOT/artifacts/compiler"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+STATUS=fail
+[[ $fail -eq 0 ]] && STATUS=pass
+cat >"$ROOT/artifacts/compiler/madaros_unknown_method_check_receipt.v1.json" <<EOF
+{
+  "schema": "madaros_unknown_method_check_receipt.v1",
+  "status": "$STATUS",
+  "engine": "madaros_default",
+  "commit": "$COMMIT",
+  "claims": [
+    "unknown_method_rejected_at_check",
+    "unknown_method_name_rejected_under_untyped_receiver",
+    "known_method_e_val_still_ok",
+    "dual_gum_knowledge_e_val_still_ok",
+    "root2_multimodule_method_still_ok"
+  ],
+  "claims_not_made": [
+    "ufcs_instance_method_as_type_path",
+    "exhaustive_stdlib_method_census",
+    "imported_associated_Type_method_always_typed",
+    "lean_single_fixed_point_after_change"
+  ]
+}
+EOF
+echo "receipt: $ROOT/artifacts/compiler/madaros_unknown_method_check_receipt.v1.json"
+
+if [[ $fail -eq 0 ]]; then
+  echo "MADAROS_UNKNOWN_METHOD_CHECK_GATE_OK"
+  exit 0
+fi
+exit 1

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -6103,6 +6103,19 @@ fn checker_check_method_call_with_base_ty_inplace(c: *mut Checker, e: Expr, base
             ty_error()
         }
     } else if is_error_or_unknown(base_ty) {
+        // Receiver failed to type (common multi-module residual when
+        // Type::method associated constructors leave TyUnknown). Still reject
+        // method names that match *no* registered impl method — so e.mean()
+        // fails at check (E011) instead of SEGV at lower preseed — while
+        // known names (e.val / e.std / e.add) soft-accept for cascade.
+        // See docs/audit/MADAROS_DUAL_GUM_KNOWLEDGE_IMPORT_2026-07-19.md.
+        if !fn_sig_table_has_method_name((*c).fn_sigs, e.name) {
+            checker_report_error_at_inplace(c, e.span, 11, 0, 0, 0)
+            let call_start_borrows = (*c).borrows
+            checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
+            checker_release_call_arg_borrows_inplace(c, e.args, None, call_start_borrows)
+            return ty_error()
+        }
         let call_start_borrows = (*c).borrows
         checker_check_expr_list_no_type_no_linear_consume_inplace(c, e.args)
         checker_release_call_arg_borrows_inplace(c, e.args, None, call_start_borrows)
@@ -6662,10 +6675,23 @@ fn checker_check_call_expr_inplace(c: *mut Checker, e: Expr) -> TypeEntry with M
         }
     }
     var direct_sig_id: i64 = -1
+    // Type::method associated-function path (e.g. E::of / Epistemic::measured).
+    // When the method is registered, resolve it so the return type is known and
+    // subsequent instance methods typecheck. When lookup misses (multi-module
+    // residual for some imported associated forms), fall through to the legacy
+    // path-as-first-segment behaviour rather than hard-rejecting — unknown
+    // *instance* methods are rejected in checker_check_method_call_with_base_ty
+    // even under TyUnknown receivers (see is_error_or_unknown branch).
     match e.left {
         Some(callee_expr) => {
             if (*callee_expr).kind == ExprKind::ExprIdent {
                 direct_sig_id = checker_fn_sigs_find_inplace(c, (*callee_expr).name)
+            } else if (*callee_expr).kind == ExprKind::ExprPath && (*callee_expr).path.seg_count >= 2 {
+                let path_type_name = checker_copy_string_list_to_name((*callee_expr).path.segments)
+                let path_method_name = checker_copy_string_list_tail_to_name((*callee_expr).path.segments)
+                // Prefer semantic match (kind+name) then name-only self_type_name.
+                let recv_ty = ty_named(path_type_name)
+                direct_sig_id = fn_sig_table_find_method_semantic((*c).fn_sigs, recv_ty, path_method_name)
             }
         }
         None => {}
@@ -19422,6 +19448,14 @@ impl Checker {
                 (c, ty_error())
             }
         } else if is_error_or_unknown(base_ty) {
+            // Mirror inplace: reject nonexistent method names under untyped receivers.
+            if !fn_sig_table_has_method_name(c.fn_sigs, e.name) {
+                c = c.report_error_at(e.span, 11, 0, 0, 0)
+                let call_start_borrows = c.borrows
+                c = c.check_expr_list_no_type_no_linear_consume(e.args)
+                c = c.release_call_arg_borrows(e.args, None, call_start_borrows)
+                return (c, ty_error())
+            }
             let call_start_borrows = c.borrows
             c = c.check_expr_list_no_type_no_linear_consume(e.args)
             c = c.release_call_arg_borrows(e.args, None, call_start_borrows)
@@ -19550,6 +19584,14 @@ impl Checker {
                 (c, ty_error())
             }
         } else if is_error_or_unknown(base_ty) {
+            // Mirror inplace: reject nonexistent method names under untyped receivers.
+            if !fn_sig_table_has_method_name(c.fn_sigs, e.name) {
+                c = c.report_error_at(e.span, 11, 0, 0, 0)
+                let call_start_borrows = c.borrows
+                c = c.check_expr_list_no_type_no_linear_consume(e.args)
+                c = c.release_call_arg_borrows(e.args, None, call_start_borrows)
+                return (c, ty_error())
+            }
             let call_start_borrows = c.borrows
             c = c.check_expr_list_no_type_no_linear_consume(e.args)
             c = c.release_call_arg_borrows(e.args, None, call_start_borrows)

--- a/self-hosted/check/defs.sio
+++ b/self-hosted/check/defs.sio
@@ -1514,6 +1514,29 @@ fn fn_sig_table_find_method_semantic(t: *mut FnSigTable, receiver_ty: TypeEntry,
     fn_sig_table_find_method(t, receiver_ty.name, method_name)
 }
 
+// Any-type method name probe: true if some registered impl method has this name.
+// Used when the receiver failed to type (TyUnknown/TyError) so that nonexistent
+// methods (e.mean) still fail at multi-module check with E011, while known
+// method names (e.val) remain soft-accepted under an untyped receiver.
+fn fn_sig_table_has_method_name(t: *mut FnSigTable, method_name: Name) -> bool with Mut, Panic, Div {
+    var gi: i64 = 0
+    var cur = (*t).head
+    while gi < (*t).count {
+        if cur == (0 as *mut FnSigChunk) { return false }
+        var local: i64 = 0
+        while local < 512 && gi < (*t).count {
+            if (*cur).entries[local as usize].is_method
+                && name_eq((*cur).entries[local as usize].name, method_name) {
+                return true
+            }
+            local = local + 1
+            gi = gi + 1
+        }
+        cur = (*cur).next
+    }
+    false
+}
+
 fn fn_sig_table_get_visibility(t: *mut FnSigTable, idx: i64) -> Visibility with Mut, Panic, Div {
     if idx < 0 || idx >= (*t).count {
         return visibility_private()

--- a/tests/run-pass/madaros_unknown_method_known_ok.sio
+++ b/tests/run-pass/madaros_unknown_method_known_ok.sio
@@ -1,0 +1,22 @@
+//@ run-pass
+//@ requires: madaros
+// Positive control for unknown-method check hardening: Epistemic::measured + e.val()
+// must still check and run under multi-module Madaros after associated-path resolution.
+
+use epistemic::knowledge::{Epistemic}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let e = Epistemic::measured(10.0, 0.5)
+    let m = e.val()
+    if m < 9.0 || m > 11.0 {
+        print("FAIL_VAL\n")
+        return 1
+    }
+    let st = e.std()
+    if st < 0.4 || st > 0.6 {
+        print("FAIL_STD\n")
+        return 1
+    }
+    print("KNOWN_METHOD_OK\n")
+    return 0
+}

--- a/tests/ui/type/unknown_method_after_associated.sio
+++ b/tests/ui/type/unknown_method_after_associated.sio
@@ -1,0 +1,25 @@
+//@ compile-fail
+//@ error-pattern: method
+//@ description: SELFHOST_PASS
+// Associated constructor Type::method must type the receiver so unknown
+// instance methods fail at check (E011), not silently pass.
+
+struct E {
+    v: f64,
+}
+
+impl E {
+    fn of(v: f64) -> E {
+        E { v: v }
+    }
+    fn val(self: &E) -> f64 {
+        self.v
+    }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let e = E::of(10.0)
+    let m = e.no_such_method()
+    print("SHOULD_NOT_REACH\n")
+    return 0
+}

--- a/tests/ui/type/unknown_method_multimodule.sio
+++ b/tests/ui/type/unknown_method_multimodule.sio
@@ -1,0 +1,16 @@
+//@ compile-fail
+//@ error-pattern: method
+//@ requires: madaros
+//@ description: Multi-module unknown instance method must fail at check (E011), not SEGV at lower
+// Regression for #1257 residual: dual gum+knowledge called e.mean() which is not
+// an Epistemic method; multi-module check accepted it (associated Type::method
+// left the receiver TyUnknown so method calls were silent). Canonical API is e.val().
+
+use epistemic::knowledge::{Epistemic}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let e = Epistemic::measured(10.0, 0.5)
+    let m = e.mean()
+    print("SHOULD_NOT_REACH\n")
+    return 0
+}


### PR DESCRIPTION
## Summary

Closes the #1257 residual: multi-module Madaros **accepted** nonexistent instance methods (`e.mean()`, `obj.no_such_method()`) at check, then **SEGV**'d at native lower method preseed.

**Root cause (measured):** when the receiver types as `TyUnknown`/`TyError` (common after multi-module `Type::method` associated constructors on imported types), method resolution soft-accepted every method name. Known methods still ran because lower mangles by name; unknown names crashed at preseed.

**Fix (surgical):**
1. `fn_sig_table_has_method_name` — probe whether any registered impl method has the call name
2. In method-call check (inplace + by-value): under `is_error_or_unknown` receiver, **E011** if the name matches no method; soft-accept if a real method name exists (preserves `e.val()` / Root2 / dual under residual untyped receivers)
3. Associated `Type::method` path callees: resolve via `find_method_semantic` when registered (same-module `E::of` return typing)

Does **not** claim full imported-associated always-typed; residual documented in receipt `claims_not_made`.

## Evidence

```
SOUNIO_BUILD_LOCK=/tmp/sounio-unkmethod-build.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
# Madaros ready: artifacts/self-hosted/madaros

bash scripts/madaros_unknown_method_check_gate.sh
# → MADAROS_UNKNOWN_METHOD_CHECK_GATE_OK
#   PASS: multi-module e.mean() rejected at check
#   PASS: dual gum+knowledge e.mean() rejected
#   PASS: KNOWN_METHOD_OK / DUAL_GUM_KNOWLEDGE_OK / ROOT2_MULTIMODULE_METHOD_OK

bash scripts/madaros_dual_import_gate.sh
# → MADAROS_DUAL_IMPORT_GATE_OK

bash scripts/madaros_root2_multimodule_method_gate.sh
# → MADAROS_ROOT2_MULTIMODULE_METHOD_GATE_OK

bash scripts/dev/check_docs_registry.sh   # pass
bash scripts/dev/check_docs_consistency.sh # pass
```

## Test plan

- [x] Rebuild current-source Madaros
- [x] Unknown method → check E011 / verdict=1 (multi-module Epistemic.mean, dual shape, local after associated)
- [x] Known methods e.val / dual / Root2 still check+run green
- [x] Gate script + receipt
- [ ] CI on this PR

## Files

| File | Change |
|---|---|
| `self-hosted/check/defs.sio` | `fn_sig_table_has_method_name` |
| `self-hosted/check/check.sio` | unknown-receiver E011; Type::method semantic resolve |
| `scripts/madaros_unknown_method_check_gate.sh` | gate |
| `tests/ui/type/unknown_method_*.sio` | compile-fail witnesses |
| `tests/run-pass/madaros_unknown_method_known_ok.sio` | positive control |
| `docs/audit/MADAROS_DUAL_GUM_KNOWLEDGE_IMPORT_2026-07-19.md` | claims_not_made update |
| `artifacts/compiler/madaros_unknown_method_check_receipt.v1.json` | receipt |