### PR TITLE
fix(madaros): compact-path kind 9 size+emit parity (thin-link F1)

### DIFF
--- a/self-hosted/compiler/module_native_driver.sio
+++ b/self-hosted/compiler/module_native_driver.sio
@@ -493,6 +493,12 @@ fn native_driver_imported_simple_fn_size(fi: i64) -> i64 with Panic {
     if kind == 23 {
         return 75
     }
+    // Kind 9: two-i64-literal call `callee(arg0, arg1)` — packed as
+    // (arg0 * 2^32) + arg1 by module_frontend. Size/emit must match
+    // module_native_simple_driver (thin-link compact-path parity).
+    if kind == 9 {
+        return 16
+    }
     if kind == 24 {
         return 16
     }
@@ -943,6 +949,37 @@ fn native_driver_emit_imported_simple_fn(
         native_driver_put_u8(bytes, off + 72, 1)
         native_driver_put_u8(bytes, off + 73, 216)
         native_driver_put_u8(bytes, off + 74, 195)
+        return true
+    }
+    // Kind 9: mov edi, arg0; mov esi, arg1; call target; ret
+    // Packed value uses high/low 32-bit lanes (not the decimal kind-24 packing).
+    if kind == 9 {
+        let target_hash = imported_simple_ir_global_fn_target_hash(fi)
+        var target: i64 = 0 - 1
+        var ti: i64 = 0
+        let count = imported_simple_ir_global_fn_count()
+        while ti < count {
+            if imported_simple_ir_global_fn_name_hash(ti) == target_hash {
+                target = ti
+                ti = count
+            } else {
+                ti = ti + 1
+            }
+        }
+        if target < 0 || target >= imported_simple_ir_global_fn_count() {
+            return false
+        }
+        let target_off = native_driver_imported_simple_fn_offset(func_start, target)
+        let packed = imported_simple_ir_global_fn_value(fi)
+        let arg0 = packed >> 32
+        let arg1 = packed & 4294967295
+        native_driver_put_u8(bytes, off, 191)
+        native_driver_put_u32(bytes, off + 1, arg0)
+        native_driver_put_u8(bytes, off + 5, 190)
+        native_driver_put_u32(bytes, off + 6, arg1)
+        native_driver_put_u8(bytes, off + 10, 232)
+        native_driver_put_u32(bytes, off + 11, target_off - (off + 15))
+        native_driver_put_u8(bytes, off + 15, 195)
         return true
     }
     if kind == 24 {

--- a/tests/multimodule/thin_single_main.sio
+++ b/tests/multimodule/thin_single_main.sio
@@ -1,4 +1,9 @@
 //@ run-pass
+// Compact-path kind-9 multimodule fixture:
+//   main body = two-i64-literal call  → kind 9 (arg0=3, arg1=4 packed high/low 32)
+//   add_public(a, b) { a + b }        → kind 13
+// Expected exit code: 7.
+// Regression for module_native_driver kind-9 parity with module_native_simple_driver.
 
 use thin_single_lib::{add_public}
 


### PR DESCRIPTION
## Summary

Highest-leverage surgical compact-path fix (**F1**): `module_native_driver.sio` (used by multi-module advanced / Madaros thin-link) was missing **kind 9** size+emit that `module_native_simple_driver.sio` already has.

Kind 9 is the frontend shape for a two-i64-literal call:
```sio
add_public(3, 4)   // → kind 9, packed (arg0<<32)|arg1
```
Without size+emit, the compact table path returns `-1` / `imported_simple_ir_emit_failed` for that shape.

## Change

| Site | Before | After |
|------|--------|-------|
| `native_driver_imported_simple_fn_size` kind 9 | missing → `-1` | `return 16` |
| `native_driver_emit_imported_simple_fn` kind 9 | missing → `false` | `mov edi,arg0; mov esi,arg1; call; ret` |
| packing | n/a | `arg0 = packed >> 32`, `arg1 = packed & 0xffffffff` (same as simple driver / frontend `arg0 * 2^32 + arg1`) |

Mirror is intentionally identical to `module_native_simple_driver.sio` (not the decimal kind-24 packing).

## Audit (other kinds)

Frontend assigns kinds: **1–18, 20, 23, 9**.

After this PR, simple and advanced driver kind-handler sets are **identical**.

- Kind **24** is present in both emitters but **never assigned** by the frontend (dead emit arm, left alone).
- No other assigned kind was missing from the advanced driver.

## Fixture

`tests/multimodule/thin_single_main.sio` is the kind-9 multimodule fixture:
- `main` → kind 9 (`add_public(3, 4)`)
- `add_public` → kind 13 (`a + b`)
- expected exit code **7**

Comment on that file documents the kind-9 regression role.

## Evidence (rebuilt Madaros)

Rebuild:
```bash
SOUNIO_BUILD_LOCK=/tmp/sounio-thinlink-build.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
# EXIT 0; 99214615-byte ELF
```

### Kind-9 compact path (opt-in)
```bash
export SOUNIO_ENABLE_COMPACT_IMPORTED_IR=1
./bin/souc compile tests/multimodule/thin_single_main.sio -o /tmp/k9.elf
# → compact modular IR table path; Native binary size: 157 bytes
/tmp/k9.elf; echo $?
# → 7
```
Also green on compact path: `thin_locals_main.sio`, `thin_expr_args_main.sio` (exit 7).

### #921 / rational+cd_sigma — residual F3 (honest)

```bash
# Default (compact OFF) — full IR path:
./bin/souc compile docs/handoff/repros/multimodule_thinlink_rc12_madaros.sio -o /tmp/x.elf
# → full IR path; compile ok; run prints 11, rc=0

# Compact ON:
SOUNIO_ENABLE_COMPACT_IMPORTED_IR=1 ./bin/souc compile \
  docs/handoff/repros/multimodule_thinlink_rc12_madaros.sio -o /tmp/x.elf
# → imported_simple_ir_emit_failed; compact rc=1;
#   falls back to full IR path → compile ok, run rc=0
```

**Kind 9 alone does not fix rational+cd_sigma on the compact path.**
Those modules (~44 compact-classified / ~113 full-IR fns) still hit unsupported shapes beyond kind 9 (residual **F3**). Compact remains experimental and **disabled by default**; full-IR fallback continues to work.

## What this does / does not claim

| Claim | Status |
|-------|--------|
| Compact-path kind-9 shape parity with simple driver | **Fixed** |
| `thin_single_main` under `SOUNIO_ENABLE_COMPACT_IMPORTED_IR=1` | **PASS** (exit 7, 157 B ELF) |
| Default multi-module path (compact off) | Unchanged (already full IR) |
| rational + cd_sigma compact emit success | **Still fails** (F3 residual) |
| rational + cd_sigma full-IR / default compile+run | **Works** on this build |

## Commits

1. `fix(madaros): compact-path kind 9 size+emit parity in module_native_driver`
2. `build(madaros): refresh prebuilt bin/madaros-linux-x86_64 [skip ci]`

No force-push. Branch from `origin/main`.

## Related

- Wave3 Agent E diagnosis: kind 9 missing from advanced driver
- Compact path gate: `SOUNIO_ENABLE_COMPACT_IMPORTED_IR=1`
- Residual F3 for complex multi-module graphs (rational+cd_sigma)
- Issues historically nearby: #921 / thin-link scale / imported-module native path
