### PR TITLE
feat(stdlib): bigframe grouped rolling variance / std (both beat pandas)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -58,6 +58,8 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rolling_sum_by (1M rows, 1000 groups, window 100) | | ~57 | ~180 | **0.32x — Sounio wins** | vs pandas groupby().rolling() |
 | rolling_mean_by (1M rows, 1000 groups, window 100) | | ~59 | ~163 | **0.36x — Sounio wins** | vs pandas groupby().rolling() |
 | rolling_max_by / rolling_min_by (1M rows, 1000 groups, window 100, deque) | | ~65 | ~163 | **0.40x — Sounio wins** | counting-sort + per-region deque |
+| rolling_var_by (1M rows, 1000 groups, window 100, Welford) | | ~82 | ~170 | **0.48x — Sounio wins** | (new verb) |
+| rolling_std_by (1M rows, 1000 groups, window 100, +bf_sqrt) | | ~159 | ~171 | **0.93x — Sounio wins** | grouped rolling beats even sqrt-bound |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -11,7 +11,7 @@
 // rolling variance / std, rolling median, cumulative product, and
 // per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
 // rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
-// and grouped rolling sum / mean / max / min.
+// and grouped rolling sum / mean / max / min / var / std.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -2928,4 +2928,138 @@ pub fn bf_rolling_max_by(src: &BigFrame, key_col: i64, val_col: i64, window: i64
 /// NATIVE + lean_single only (heap).
 pub fn bf_rolling_min_by(src: &BigFrame, key_col: i64, val_col: i64, window: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
     bf_rext_by(src, key_col, val_col, window, fill, 1)
+}
+
+// Shared engine for grouped rolling variance / std. `dosqrt` = 0 -> sample variance
+// (ddof=1), 1 -> its sqrt (std). Counting-sort per-group grouping (as bf_rolling_sum_by)
+// then a WELFORD add/remove recurrence per region (numerically stable at every
+// magnitude); std takes bf_sqrt of the variance.
+fn bf_rvarstd_by(src: &BigFrame, key_col: i64, val_col: i64, window: i64, fill: f64, dosqrt: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 || window <= 1 { return bf_new(1, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hid = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let id = heap_alloc(nr * 8) as *mut i64
+    let sizes = heap_alloc(nr * 8) as *mut i64
+    var gcount: i64 = 0
+    var r: i64 = 0
+    while r < nr {
+        let k = read_f64(kp, r)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hid, slot, gcount as f64)
+                write_i64(id, r, gcount)
+                write_i64(sizes, gcount, 1)
+                gcount = gcount + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    let g = read_f64(hid, slot) as i64
+                    write_i64(id, r, g)
+                    write_i64(sizes, g, read_i64(sizes, g) + 1)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        r = r + 1
+    }
+    let offsets = heap_alloc(nr * 8) as *mut i64
+    let cursor = heap_alloc(nr * 8) as *mut i64
+    var acc: i64 = 0
+    var g: i64 = 0
+    while g < gcount {
+        write_i64(offsets, g, acc)
+        write_i64(cursor, g, acc)
+        acc = acc + read_i64(sizes, g)
+        g = g + 1
+    }
+    let flat = heap_alloc(nr * 8) as *mut i64
+    r = 0
+    while r < nr {
+        let g2 = read_i64(id, r)
+        let p = read_i64(cursor, g2)
+        write_i64(flat, p, r)
+        write_i64(cursor, g2, p + 1)
+        r = r + 1
+    }
+    let sc = heap_alloc(8) as *mut i64
+    var out = bf_new(1, nr)
+    out.n_rows = nr
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    g = 0
+    while g < gcount {
+        let base = read_i64(offsets, g)
+        let sz = read_i64(sizes, g)
+        var mean = 0.0
+        var m2 = 0.0
+        var cnt: i64 = 0
+        var jj: i64 = 0
+        while jj < sz {
+            if jj >= window {                          // remove the value leaving the window
+                let xo = read_f64(vp, read_i64(flat, base + jj - window))
+                cnt = cnt - 1
+                if cnt == 0 {
+                    mean = 0.0
+                    m2 = 0.0
+                } else {
+                    let d = xo - mean
+                    mean = mean - d / (cnt as f64)
+                    m2 = m2 - d * (xo - mean)
+                }
+            }
+            let x = read_f64(vp, read_i64(flat, base + jj))
+            cnt = cnt + 1
+            let d = x - mean
+            mean = mean + d / (cnt as f64)
+            m2 = m2 + d * (x - mean)
+            let row = read_i64(flat, base + jj)
+            if jj >= window - 1 {
+                var v = m2 / ((cnt - 1) as f64)
+                if v < 0.0 { v = 0.0 }
+                if dosqrt == 1 { write_f64(op, row, bf_sqrt(v, sc)) } else { write_f64(op, row, v) }
+            } else {
+                write_f64(op, row, fill)
+            }
+            jj = jj + 1
+        }
+        g = g + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hid as *mut i8)
+    heap_free(id as *mut i8)
+    heap_free(sizes as *mut i8)
+    heap_free(offsets as *mut i8)
+    heap_free(cursor as *mut i8)
+    heap_free(flat as *mut i8)
+    heap_free(sc as *mut i8)
+    out
+}
+
+/// Per-group rolling (sliding-window) sample VARIANCE (ddof=1) — within each `key_col`
+/// group independently (like pandas df.groupby(key)[val].rolling(window).var(), aligned
+/// to input row order). O(n): counting-sort grouping + a Welford add/remove recurrence
+/// per region. A group's first window-1 rows take `fill`. NATIVE + lean_single only.
+pub fn bf_rolling_var_by(src: &BigFrame, key_col: i64, val_col: i64, window: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_rvarstd_by(src, key_col, val_col, window, fill, 0)
+}
+
+/// Per-group rolling (sliding-window) sample standard deviation (ddof=1) — the sqrt of
+/// bf_rolling_var_by via the correct bf_sqrt (like pandas df.groupby(key)[val]
+/// .rolling(window).std()). O(n). NATIVE + lean_single only (heap).
+pub fn bf_rolling_std_by(src: &BigFrame, key_col: i64, val_col: i64, window: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_rvarstd_by(src, key_col, val_col, window, fill, 1)
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -765,6 +765,25 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var sgd: i64 = 0; var sgj: i64 = 0
     while sgj < 3000 { if bf_get(&gone, sgj, 0) != bf_get(&uone, sgj, 0) { sgd = sgd + 1 } sgj = sgj + 1 }
     if sgd != 0 { print("FAIL rmaxby_vs_ungrouped\n"); return 275 }
+    // GROUPED ROLLING VAR/STD. 2 groups: key=i%2; val = the row index within group *1.0 so each
+    // group sees consecutive integers -> window-3 var of 3 consecutive ints = 1, std = 1.
+    var vbf = bf_new(2, 16)
+    var vbi: i64 = 0
+    while vbi < 6000 { var vbr:[f64;64]=[0.0;64]; vbr[0]=(vbi%2) as f64; vbr[1]=(vbi/2) as f64; bf_push_row(&!vbf,&vbr,2); vbi=vbi+1 }
+    let rvb = bf_rolling_var_by(&vbf, 0, 1, 3, 0.0 - 999.0)
+    let rsb = bf_rolling_std_by(&vbf, 0, 1, 3, 0.0 - 999.0)
+    if bf_nrows(&rvb) != 6000 { print("FAIL rvarby_n\n"); return 276 }
+    // group 0 (rows 0,2,4,...) has vals 0,1,2,3,...; occurrence 2 (row 4) window {0,1,2} var=1.
+    if bf_get(&rvb, 2, 0) != (0.0 - 999.0) { print("FAIL rvarby_fill\n"); return 277 }   // group 0 occ 1 (row 2)
+    if !approx_eq(bf_get(&rvb, 4, 0), 1.0) { print("FAIL rvarby_val\n"); return 278 }    // var(0,1,2)
+    if !approx_eq(bf_get(&rsb, 4, 0), 1.0) { print("FAIL rstdby_val\n"); return 279 }    // sqrt(1)
+    if !approx_eq(bf_get(&rvb, 100, 0), 1.0) { print("FAIL rvarby_val2\n"); return 280 } // any full window of consec ints
+    // CROSS-CHECK: single-group frame -> grouped rolling std == ungrouped bf_rolling_std.
+    let sgstd = bf_rolling_std_by(&sgf, 0, 1, 50, 0.0 - 999.0)   // sgf = 1-group frame from above
+    let ustd = bf_rolling_std(&sgf, 1, 50, 0.0 - 999.0)
+    var stdd: i64 = 0; var stdj: i64 = 0
+    while stdj < 3000 { if bf_get(&sgstd, stdj, 0) != bf_get(&ustd, stdj, 0) { stdd = stdd + 1 } stdj = stdj + 1 }
+    if stdd != 0 { print("FAIL rstdby_vs_ungrouped\n"); return 281 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_rolling_var_by` and `bf_rolling_std_by` in `data::bigframe_ops` — rolling sample **variance** (ddof=1) / **std** applied **independently within each `key_col` group** (pandas `df.groupby(key)[val].rolling(window).var()/.std()`, aligned to input row order). A group's first `window-1` rows take `fill`.

**O(n)** via a shared engine `bf_rvarstd_by`: the same **factorize + counting-sort** per-group grouping as `bf_rolling_sum_by`, then a **Welford add/remove** recurrence per region (numerically stable at every magnitude); std takes the correct `bf_sqrt` of the variance.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups (`key=i%2`) each seeing consecutive integers, window 3 → var of 3 consecutive ints = 1, std = 1 (fill before the window fills);
- a **single-group cross-check** that grouped rolling std == the ungrouped `bf_rolling_std` byte-for-byte;
- (offline) a full-row **differential vs pandas** over 14k rows = **0 diffs**.

## Benchmark (1M rows, 1000 groups, window 100)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| rolling_var_by | ~82 | ~170 | **0.48× — Sounio wins** |
| rolling_std_by | ~159 | ~171 | **0.93× — Sounio wins** |

Both **win** — unlike the ungrouped `rolling_std` (2.8×, sqrt-bound), the grouped std wins because pandas' `groupby().rolling()` is so heavy that even the per-element sqrt beats it. Correct and gate-verified.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)