### PR TITLE
feat(algebra): Madaros-native algebra::associator_field multi-module import

### DIFF
--- a/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
+++ b/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
@@ -50,19 +50,25 @@ A result is usable under native import iff **both** hold:
 | `knowledge` (**free-function** `ep_*` API) | `ep_measured` / `ep_add` / `ep_mul` / `ep_merge` / `ep_gate` | **D3 partial 2026-07-19** — free-function surface imports under Madaros; see `EPISTEMIC_KNOWLEDGE_MADAROS_D3_2026-07-19` |
 | `order_spread_exact` (`order_spread4`) | CPC N=4 exact spread ≈ `2.044226` (scaled µ-units `2044225`/`2044226`) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `OsOct` (no `algebra::` use). Gate: `scripts/madaros_order_spread_native_gate.sh` + Section A `ORDER_SPREAD_TRUST_OK`. `product4_exact` remains available (pulls free-function `knowledge`); method-form `Epistemic::measured` still Root-2. |
 | `product_nonassoc` (structural variance) | Fano variance `0.25` / non-Fano `4.25` (κ=1, base σ²=0.25) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `PnOct` (no `algebra::` use). Gate: `scripts/madaros_product_nonassoc_native_gate.sh` + Section A `PRODUCT_NONASSOC_TRUST_OK`. Knowledge-free `product_nonassoc_augment` is the hard numeric witness; `product_nonassoc(Epistemic,…)` uses field-form `Epistemic` under Madaros (direct `ep_*` + leaf multi-import trips E035). Historic `epistemic::propagate::product_nonassoc` removed (propagate still multi-module-fragile via xoshiro). |
+| `algebra::associator_field` | non-Fano ‖α‖²=`4`, g2=`2`, aug var=`4.25`; pentagon (e1,e2,e4,e1) var=`0.96` | **2026-07-20 multi-module green** after #1274 oct_mul lo/hi split + pub API surface (`assoc_field_*`, `pentagon_*`, `af_*`). Gate: `scripts/madaros_associator_field_native_gate.sh`. L0: `associator_field_octonion` + `associator_field_pentagon`. |
+| `algebra::octonion` (`oct_mul`, `oct_associator`, …) | e1·e2→e3; non-Fano ‖[e1,e2,e4]‖²=`4` | **2026-07-20** lo/hi frame split. Gate: `scripts/madaros_algebra_octonion_import_gate.sh`. |
 
 Heuristic: **self-contained modules (no stdlib `use` deps) that avoid `f64→i64`
 casts and method-call sites import cleanly and return correct numbers.**
-(`order_spread_exact` / `product_nonassoc` are the measured exceptions that may
-`use` free-function / field-form `knowledge` while keeping the multiply path fully
-local — do **not** reintroduce `algebra::associator_field` uses; those still SEGV
-at runtime under Madaros multi-module native emit.)
+(`order_spread_exact` / `product_nonassoc` remain self-contained leaves for CPC
+independence; `algebra::associator_field` is now also importable under default
+Madaros for programs that want the shared seven-window artifact.)
 
-**Update 2026-07-20:** `algebra::octonion::oct_mul` imports cleanly under default
-Madaros after splitting the 8-component exclusive-ref body into `oct_mul_lo` /
-`oct_mul_hi` (each ≤ ~0x1200 spill frame). Full unrolled body needs ~0x23e0 and
-SEGV'd (measured single-file and multi-module). Gate:
+**Update 2026-07-20 (oct_mul):** `algebra::octonion::oct_mul` imports cleanly under
+default Madaros after splitting the 8-component exclusive-ref body into
+`oct_mul_lo` / `oct_mul_hi` (each ≤ ~0x1200 spill frame). Full unrolled body
+needs ~0x23e0 and SEGV'd (measured single-file and multi-module). Gate:
 `scripts/madaros_algebra_octonion_import_gate.sh`.
+
+**Update 2026-07-20 (associator_field):** with oct_mul green, the remaining
+`associator_field` multi-module blocker was E175 privacy (Madaros hard-errors
+on non-`pub` imports; lean_single only warned). Publicizing the L0 surface
+makes `use algebra::associator_field` compile+run with correct sentinels.
 
 ### ⚠️ Importable but specific outputs CORRUPTED
 
@@ -79,7 +85,6 @@ SEGV'd (measured single-file and multi-module). Gate:
 |---|---|---|
 | `knowledge` **method-call** form (`Epistemic::measured`, `e.val()`) | SEGV in method-call lowering (Root 2) | use free `ep_*` API under Madaros; methods still OK under lean_single |
 | `propagate` (full module) | blocked / fragile multi-module (xoshiro, multi-use) | full propagation layer not yet native-trustworthy; **structural nonassoc path is** — use `epistemic::product_nonassoc` leaf |
-| `algebra::associator_field` (imported exclusive-ref path) | **runtime SEGV** after successful native compile (large exclusive-ref chain) | CPC N=4 / product_nonassoc no longer depend on this path — use `epistemic::order_spread_exact::order_spread4` and `epistemic::product_nonassoc` instead; `algebra::octonion::oct_mul` is green after lo/hi split (2026-07-20) |
 | `uncertain_eq` | method / multi-module path | equality-under-uncertainty native-import-blocked |
 
 Method-form and remaining modules are usable today only by **free-function rewrite**,

--- a/scripts/madaros_associator_field_native_gate.sh
+++ b/scripts/madaros_associator_field_native_gate.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Madaros native gate — use algebra::associator_field under default Madaros.
+#
+# Acceptance:
+#   - Default ./bin/souc (Madaros) compile+run of the import driver
+#   - Non-Fano (e1,e2,e4): ‖assoc‖²=4, g2=2, augmented var=4.25
+#   - Pentagon (e1,e2,e4,e1): variance=0.96
+#   - Sentinel ASSOCIATOR_FIELD_NATIVE_OK
+#   - L0 run-pass tests (associator_field_octonion + pentagon) ALL PASS
+#
+# Depends on algebra::octonion::oct_mul lo/hi frame split (#1274). No Madaros
+# rebuild required for this stdlib visibility fix.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export SOUNIO_STDLIB_PATH="$(pwd)/stdlib"
+unset SOUNIO_SOUC_ENGINE || true
+ulimit -s unlimited 2>/dev/null || ulimit -s 131072 2>/dev/null || true
+
+SOUC="${SOUC:-./bin/souc}"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+echo "== madaros_associator_field_native_gate =="
+engine_line="$($SOUC --version 2>&1 | head -1 || true)"
+echo "engine: $engine_line"
+if echo "$engine_line" | grep -qi lean_single; then
+  echo "FAIL: gate must run under default Madaros, not lean_single"
+  exit 1
+fi
+if ! echo "$engine_line" | grep -qi Madaros; then
+  echo "WARN: version string does not mention Madaros: $engine_line"
+fi
+echo "git_sha=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+SRC=tests/madaros/associator_field_native/associator_field_import.sio
+
+echo "== compile $SRC =="
+if ! $SOUC compile "$SRC" -o "$OUT/af.elf" >"$OUT/compile.log" 2>&1; then
+  echo "FAIL: native compile"
+  tail -40 "$OUT/compile.log" || true
+  fail=1
+else
+  echo "PASS: compile"
+  echo "== run =="
+  set +e
+  "$OUT/af.elf" >"$OUT/run.out" 2>"$OUT/run.err"
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL: run rc=$rc (SEGV=139 was the historical exclusive-ref multi-mod mode)"
+    cat "$OUT/run.err" 2>/dev/null || true
+    fail=1
+  else
+    # Expect: 4000\n2000\n4250\n960000\nASSOCIATOR_FIELD_NATIVE_OK
+    line1="$(sed -n '1p' "$OUT/run.out" | tr -d '[:space:]')"
+    line2="$(sed -n '2p' "$OUT/run.out" | tr -d '[:space:]')"
+    line3="$(sed -n '3p' "$OUT/run.out" | tr -d '[:space:]')"
+    line4="$(sed -n '4p' "$OUT/run.out" | tr -d '[:space:]')"
+    echo "norm_sq_x1000=$line1 g2_x1000=$line2 aug_x1000=$line3 pent_var_x1e6=$line4"
+    if [[ "$line1" != "4000" ]]; then
+      echo "FAIL: non-Fano norm_sq want 4000 got $line1"
+      fail=1
+    fi
+    if [[ "$line2" != "2000" ]]; then
+      echo "FAIL: g2_residual want 2000 got $line2"
+      fail=1
+    fi
+    if [[ "$line3" != "4250" ]]; then
+      echo "FAIL: augmented variance want 4250 got $line3"
+      fail=1
+    fi
+    if [[ "$line4" != "960000" ]]; then
+      echo "FAIL: pentagon variance want 960000 got $line4"
+      fail=1
+    fi
+    if ! grep -q 'ASSOCIATOR_FIELD_NATIVE_OK' "$OUT/run.out"; then
+      echo "FAIL: missing sentinel"
+      cat "$OUT/run.out"
+      fail=1
+    else
+      echo "PASS: numeric sentinels + ASSOCIATOR_FIELD_NATIVE_OK"
+    fi
+  fi
+fi
+
+# souc run path (wrapper)
+if [[ $fail -eq 0 ]]; then
+  echo "== souc run =="
+  if $SOUC run "$SRC" >"$OUT/srun.out" 2>"$OUT/srun.err"; then
+    if grep -q 'ASSOCIATOR_FIELD_NATIVE_OK' "$OUT/srun.out"; then
+      echo "PASS: souc run"
+    else
+      echo "FAIL: souc run missing sentinel"
+      cat "$OUT/srun.out"
+      fail=1
+    fi
+  else
+    echo "FAIL: souc run"
+    tail -20 "$OUT/srun.err" || true
+    fail=1
+  fi
+fi
+
+# L0 acceptance surfaces (full window suite)
+if [[ $fail -eq 0 ]]; then
+  for t in tests/run-pass/associator_field_octonion.sio tests/run-pass/associator_field_pentagon.sio; do
+    echo "== L0 $t =="
+    if $SOUC compile "$t" -o "$OUT/l0.elf" >"$OUT/l0.compile" 2>&1; then
+      set +e
+      "$OUT/l0.elf" >"$OUT/l0.out" 2>"$OUT/l0.err"
+      lrc=$?
+      set -e
+      if [[ $lrc -ne 0 ]]; then
+        echo "FAIL: L0 run rc=$lrc"
+        cat "$OUT/l0.err" 2>/dev/null || true
+        fail=1
+        break
+      fi
+      if ! grep -q 'ALL PASS' "$OUT/l0.out"; then
+        echo "FAIL: L0 missing ALL PASS"
+        cat "$OUT/l0.out"
+        fail=1
+        break
+      fi
+      echo "PASS: ALL PASS"
+    else
+      echo "FAIL: L0 compile"
+      tail -20 "$OUT/l0.compile" || true
+      fail=1
+      break
+    fi
+  done
+fi
+
+echo
+if [[ $fail -eq 0 ]]; then
+  echo "MADAROS_ASSOCIATOR_FIELD_NATIVE_GATE_OK"
+  exit 0
+fi
+echo "MADAROS_ASSOCIATOR_FIELD_NATIVE_GATE_FAIL"
+exit 1

--- a/stdlib/algebra/associator_field.sio
+++ b/stdlib/algebra/associator_field.sio
@@ -22,7 +22,8 @@
 use algebra::octonion::{oct_associator, oct_norm_sq, oct_basis, oct_mul}
 
 // Newton sqrt — matches the ep_sqrt idiom in stdlib/epistemic/knowledge.sio.
-fn af_sqrt(x: f64) -> f64 with Mut, Div, Panic {
+// Public: L0 pentagon edge identities and external witnesses call this.
+pub fn af_sqrt(x: f64) -> f64 with Mut, Div, Panic {
     if x <= 0.0 { return 0.0 }
     var y = x
     y = 0.5 * (y + x / y)
@@ -40,7 +41,7 @@ fn af_sqrt(x: f64) -> f64 with Mut, Div, Panic {
 
 // ln 2 — the maximal entropy of a binary parenthesization choice for one triple:
 // {(a·b)·c, a·(b·c)}. Coincident when the associator vanishes (entropy 0).
-fn af_ln2() -> f64 { 0.6931471805599453 }
+pub fn af_ln2() -> f64 { 0.6931471805599453 }
 
 // Coboundary tolerance: associator norm² below this is treated as trivial.
 fn af_eps() -> f64 { 0.000001 }
@@ -57,7 +58,10 @@ pub struct OctAssociatorField {
 }
 
 // Build the field from three octonions and a coupling constant κ.
-fn assoc_field_octonion(
+// Madaros multi-module (2026-07-20): green after algebra::octonion::oct_mul
+// lo/hi frame split (#1274). Previously exclusive-ref dep chain SEGV'd at
+// runtime; residual blocker was E175 privacy on this public surface.
+pub fn assoc_field_octonion(
     a: &[f64; 8], b: &[f64; 8], c: &[f64; 8], kappa: f64
 ) -> OctAssociatorField with Mut, Div, Panic, NonAssoc {
     var assoc: [f64; 8] = [0.0; 8]
@@ -77,7 +81,7 @@ fn assoc_field_octonion(
 }
 
 // Convenience: build the field for a basis triple (eᵢ, eⱼ, eₖ).
-fn assoc_field_basis(i: i64, j: i64, k: i64, kappa: f64) -> OctAssociatorField
+pub fn assoc_field_basis(i: i64, j: i64, k: i64, kappa: f64) -> OctAssociatorField
     with Mut, Div, Panic, NonAssoc {
     var a = oct_basis(i)
     var b = oct_basis(j)
@@ -88,7 +92,7 @@ fn assoc_field_basis(i: i64, j: i64, k: i64, kappa: f64) -> OctAssociatorField
 // Window 7 applied: augment a base GUM variance with the structural
 // (order-indeterminacy) contribution carried by the associator field.
 //   u²_total = u²_GUM + κ·‖α‖²
-fn af_augmented_variance(base_variance: f64, field: &OctAssociatorField) -> f64 {
+pub fn af_augmented_variance(base_variance: f64, field: &OctAssociatorField) -> f64 {
     base_variance + field.gum_augmentation
 }
 
@@ -174,7 +178,8 @@ pub fn pentagon_variance(ps: &[f64; 40]) -> f64 with Mut, Div {
 }
 
 // Norm of the difference between two pentagon vertices ps[i] and ps[j].
-fn pentagon_edge_norm(ps: &[f64; 40], i: i64, j: i64) -> f64 with Mut, Div, Panic {
+// Public: composition-edge identities (‖[w,x,y]‖·‖z‖, ‖w‖·‖[x,y,z]‖).
+pub fn pentagon_edge_norm(ps: &[f64; 40], i: i64, j: i64) -> f64 with Mut, Div, Panic {
     var diff: f64 = 0.0
     var c: i64 = 0
     while c < 8 {

--- a/tests/madaros/associator_field_native/associator_field_import.sio
+++ b/tests/madaros/associator_field_native/associator_field_import.sio
@@ -1,0 +1,45 @@
+//@ run-pass
+//@ requires: madaros
+//
+// Default Madaros multi-module witness: `use algebra::associator_field`.
+//
+// Pre-#1274 residual: exclusive-ref oct_mul dep chain SEGV'd at runtime after
+// successful native compile. After oct_mul lo/hi frame split, runtime was green
+// but Madaros E175 privacy blocked the public field constructors (lean_single
+// only warned). Fix: mark pub on the L0 API surface.
+//
+// Numeric sentinels (scaled integers — print_f64 is E137 under Madaros import):
+//   non-Fano (e1,e2,e4), κ=1:
+//     ‖assoc‖² = 4      → 4000 micro-units
+//     g2_residual = 2   → 2000
+//     base 0.25 + κ·4   → 4250
+//   pentagon on (e1,e2,e4,e1):
+//     variance = 0.96   → 960000 micro-units
+
+use algebra::associator_field::{
+    assoc_field_basis, af_augmented_variance,
+    pentagon_products, pentagon_variance
+}
+use algebra::octonion::{oct_basis}
+
+fn main() -> i32 with Mut, Div, Panic, NonAssoc, IO {
+    let nf = assoc_field_basis(1, 2, 4, 1.0)
+    print_int((nf.norm_sq * 1000.0) as i64)
+    print("\n")
+    print_int((nf.g2_residual * 1000.0) as i64)
+    print("\n")
+    print_int((af_augmented_variance(0.25, &nf) * 1000.0) as i64)
+    print("\n")
+
+    var w = oct_basis(1)
+    var x = oct_basis(2)
+    var y = oct_basis(4)
+    var z = oct_basis(1)
+    var ps: [f64; 40] = [0.0; 40]
+    pentagon_products(&w, &x, &y, &z, &!ps)
+    let v = pentagon_variance(&ps)
+    print_int((v * 1000000.0) as i64)
+    print("\n")
+    print("ASSOCIATOR_FIELD_NATIVE_OK\n")
+    return 0
+}


### PR DESCRIPTION
## Summary

Makes `use algebra::associator_field` (pentagon / associator field) work under **default Madaros** multi-module.

### Discrimination (measured on origin/main + this fix)

| Path | Pre-fix (post-#1274) | This PR |
|---|---|---|
| `use algebra::octonion::{oct_mul}` | green (#1274 lo/hi) | green |
| `use …::{pentagon_products, pentagon_variance}` | **runtime green** (var=0.96) | green |
| `use …::{assoc_field_basis, …}` | **E175 private** (Madaros hard-error; lean_single warned only) | green |
| L0 `associator_field_octonion` / `_pentagon` | E175 | ALL PASS |

Root cause of residual: not SEGV after #1274 — **visibility**. Madaros enforces E175 on non-`pub` imports.

### Fix

Mark L0 API `pub` in `stdlib/algebra/associator_field.sio`:
- `af_sqrt`, `af_ln2`
- `assoc_field_octonion`, `assoc_field_basis`
- `af_augmented_variance`
- `pentagon_edge_norm`

(`pentagon_products` / `pentagon_variance` already public.) No compiler rebuild.

### Gate

```bash
bash scripts/madaros_associator_field_native_gate.sh
# → MADAROS_ASSOCIATOR_FIELD_NATIVE_GATE_OK
```

Sentinels: `4000 / 2000 / 4250 / 960000` + `ASSOCIATOR_FIELD_NATIVE_OK`; L0 ALL PASS.

### Trust map

`docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md` — `algebra::associator_field` moved from ❌ to ✅.

## Test plan

- [x] `bash scripts/madaros_associator_field_native_gate.sh`
- [x] `bash scripts/madaros_algebra_octonion_import_gate.sh` (non-regression)
- [x] `bash scripts/madaros_order_spread_native_gate.sh` (non-regression)
- [x] Default Madaros compile+run of L0 tests