### PR TITLE
fix(madaros): D4 path-form named import + print_f64 multi-module E137

### DIFF
--- a/scripts/dev/named_path_import_print_f64_gate.sh
+++ b/scripts/dev/named_path_import_print_f64_gate.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scripts/dev/named_path_import_print_f64_gate.sh
+#
+# Regression gate for path-form named imports under multi-module Madaros.
+#
+# Covers the residual D4 papercut after #1239 (visibility builtin allow-list):
+# bare `use module::symbol` (no braces) combined with print_f64 and a local
+# helper function. Pre-fix: AST closure treated the symbol as a path segment
+# (mod/half.sio missing) → E137 / incomplete closure. Brace form
+# `use mod::{half}` already worked.
+#
+# PASS = check rc=0, compile+run rc=0, stdout contains 1.500000.
+# See docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FIXTURE_DIR="$REPO_ROOT/tests/compiler/named_path_import_print_f64_gate"
+MAIN_SRC="$FIXTURE_DIR/main.sio"
+SCRATCH_DIR="$(mktemp -d /tmp/named-path-import-gate.XXXXXX)"
+trap 'rm -rf "$SCRATCH_DIR"' EXIT
+
+log()  { printf '[gate] %s\n' "$*" >&2; }
+
+RAW=""
+for cand in "$REPO_ROOT/artifacts/self-hosted/madaros" "$REPO_ROOT/bin/madaros-linux-x86_64"; do
+  if [[ -x "$cand" && "$(head -c2 "$cand" 2>/dev/null)" != '#!' ]]; then
+    RAW="$cand"; break
+  fi
+done
+
+if [[ -z "$RAW" ]]; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=no_raw_madaros" >&2
+  exit 1
+fi
+
+RAW_SHA256="$(sha256sum "$RAW" | awk '{print $1}')"
+GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+log "raw_elf=$RAW"
+log "raw_elf_sha256=$RAW_SHA256"
+log "git_sha=$GIT_SHA"
+
+echo "=== path-form named import check ==="
+"$RAW" --check "$MAIN_SRC" >"$SCRATCH_DIR/check.stdout" 2>"$SCRATCH_DIR/check.stderr"
+CHECK_RC=$?
+if [[ $CHECK_RC -ne 0 ]]; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=check_failed check_rc=$CHECK_RC" >&2
+  tail -15 "$SCRATCH_DIR/check.stderr" >&2
+  exit 1
+fi
+if grep -qE 'error\[E[0-9]+\]|AST closure incomplete' "$SCRATCH_DIR/check.stdout" "$SCRATCH_DIR/check.stderr"; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=check_emitted_error_or_incomplete_closure" >&2
+  tail -15 "$SCRATCH_DIR/check.stderr" >&2
+  exit 1
+fi
+log "check: PASS"
+
+# Default (non -O) compile is the acceptance path. The -O cleanup lane currently
+# SIGSEGVs after lower for this multi-module shape — that is a separate optimizer
+# defect, not the named-import/E137 subject of this gate.
+echo "=== path-form named import compile + run (default native) ==="
+OUT="$SCRATCH_DIR/named_path_import.elf"
+"$RAW" "$MAIN_SRC" -o "$OUT" >"$SCRATCH_DIR/cc.stdout" 2>"$SCRATCH_DIR/cc.stderr"
+CC_RC=$?
+if [[ $CC_RC -ne 0 ]]; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=compile_fail cc_rc=$CC_RC" >&2
+  tail -15 "$SCRATCH_DIR/cc.stderr" >&2
+  exit 1
+fi
+if [[ ! -s "$OUT" ]]; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=no_elf_emitted" >&2
+  exit 1
+fi
+
+chmod +x "$OUT"
+"$OUT" >"$SCRATCH_DIR/run.out" 2>/dev/null
+RUN_RC=$?
+if [[ $RUN_RC -ne 0 ]]; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=run_fail run_rc=$RUN_RC" >&2
+  exit 1
+fi
+
+if ! grep -q '1\.500000' "$SCRATCH_DIR/run.out"; then
+  echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=stdout_missing_expected_value" >&2
+  cat "$SCRATCH_DIR/run.out" >&2
+  exit 1
+fi
+
+echo "NAMED_PATH_IMPORT_GATE_PASS raw_sha256=${RAW_SHA256:0:16} stdout=$(tr -d '\n' < "$SCRATCH_DIR/run.out")"
+exit 0

--- a/self-hosted/check/check.sio
+++ b/self-hosted/check/check.sio
@@ -3236,6 +3236,18 @@ fn checker_collect_known_module_backing_imports_inplace(c: *mut Checker, path: A
 
 fn checker_collect_use_item_inplace(c: *mut Checker, item: Item) with Mut, Panic, Div {
     checker_collect_import_item_list_inplace(c, item.use_items)
+    // Path-form named import `use module::symbol` (no braces, no glob): the
+    // parser leaves the symbol as the last path segment with use_items=None.
+    // Bind that last segment so visibility preflight does not E137 it when the
+    // multi-module collector has not yet (or will not) surface the export as a
+    // free fn. Whole-module multi-segment imports that resolve as real files
+    // still work: binding an extra name is harmless if unused.
+    if !item.use_glob && item.use_items == None && item.use_path.seg_count >= 2 {
+        let last = checker_copy_string_list_tail_to_name(item.use_path.segments)
+        if !name_is_empty(last) {
+            checker_bind_import_unknown_inplace(c, last)
+        }
+    }
     checker_collect_known_module_backing_imports_inplace(c, item.use_path)
 }
 

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -509,12 +509,55 @@ fn module_frontend_resolve_ast_import_relpath(rel_path: string, cur_dir: string)
     module_frontend_resolve_import_relpath(str_slice(rel_path, offset, rel_len), base_dir)
 }
 
+// Strip the final path segment of a ".sio" relpath produced by
+// module_frontend_ast_import_relpath. Used as the named-import fallback for
+// bare `use module::symbol` forms that are token-identical to whole-file
+// imports: when `mod/half.sio` does not exist, retry `mod.sio`.
+// Returns "" when there is no parent segment to strip.
+fn module_frontend_relpath_strip_last_segment(rel_path: string) -> string with Mut, Panic, Div {
+    let len = str_len(rel_path)
+    if len < 5 {
+        return ""
+    }
+    var last_slash: i64 = 0 - 1
+    var i: i64 = 0
+    while i < len {
+        if str_char_at(rel_path, i) == 47 {
+            last_slash = i
+        }
+        i = i + 1
+    }
+    if last_slash < 0 {
+        return ""
+    }
+    str_concat(str_slice(rel_path, 0, last_slash), ".sio")
+}
+
 fn resolve_import_file_path(path: AstPath, cur_dir: string) -> string with IO, Mut, Panic, Div, Alloc {
     let rel_path = module_frontend_ast_import_relpath(path)
     if str_len(rel_path) == 0 {
         return ""
     }
-    module_frontend_resolve_ast_import_relpath(rel_path, cur_dir)
+    let resolved = module_frontend_resolve_ast_import_relpath(rel_path, cur_dir)
+    if file_exists(resolved) {
+        return resolved
+    }
+    // Named-import fallback (Madaros port of lean_single Bug C / #601):
+    // `use mod::half` is ambiguous with whole-file `use mod::half` where the
+    // last segment is a real file. Prefer the whole-file hit above; only when
+    // that misses, drop the last segment and retry so the parent module file
+    // loads. See docs/audit/LEAN_SINGLE_NAMED_USE_IMPORT_2026-07-05.md and
+    // docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md defect 1.
+    if path.seg_count >= 2 {
+        let parent_rel = module_frontend_relpath_strip_last_segment(rel_path)
+        if str_len(parent_rel) > 0 {
+            let parent_resolved = module_frontend_resolve_ast_import_relpath(parent_rel, cur_dir)
+            if file_exists(parent_resolved) {
+                return parent_resolved
+            }
+        }
+    }
+    resolved
 }
 
 fn mf_empty_program() -> Program {
@@ -2205,7 +2248,19 @@ pub fn module_frontend_import_files_from_source(path: string) -> ImportPathList 
             if path_start >= 0 {
                 let rel_path = module_frontend_extract_relpath_from_loaded(path_start, line_end)
                 if str_len(rel_path) > 0 {
-                    let dep_path = module_frontend_resolve_import_relpath(rel_path, cur_dir)
+                    var dep_path = module_frontend_resolve_import_relpath(rel_path, cur_dir)
+                    // Named-import fallback: bare `use pkg::mod::sym` embeds the
+                    // symbol as a path segment; strip it when the full relpath
+                    // does not exist on disk (same rule as resolve_import_file_path).
+                    if !file_exists(dep_path) {
+                        let parent_rel = module_frontend_relpath_strip_last_segment(rel_path)
+                        if str_len(parent_rel) > 0 {
+                            let parent_dep = module_frontend_resolve_import_relpath(parent_rel, cur_dir)
+                            if file_exists(parent_dep) {
+                                dep_path = parent_dep
+                            }
+                        }
+                    }
                     if file_exists(dep_path) && !import_path_list_contains(imports, dep_path) {
                         imports.paths[imports.count] = dep_path
                         imports.count = imports.count + 1

--- a/self-hosted/compiler/module_loader.sio
+++ b/self-hosted/compiler/module_loader.sio
@@ -253,6 +253,55 @@ fn file_path_mod_fallback(path: string) -> string with Mut, Panic, Div {
     str_concat(str_concat(base, "/mod"), ".sio")
 }
 
+// Drop the last segment of an AstPath. Returns (parent_path, true) when a
+// parent exists (original had >= 2 segments).
+fn ast_path_drop_last_segment(path: AstPath) -> (AstPath, bool) with Mut, Panic, Div, Alloc {
+    if path.seg_count < 2 {
+        return (path, false)
+    }
+    let segs = path.segments
+    match segs.tail {
+        None => (path, false)
+        Some(rest1) => {
+            match (*rest1).tail {
+                None => {
+                    // path was [head, last] → parent is [head]
+                    let parent = AstPath {
+                        segments: StringList {
+                            head_buf: segs.head_buf,
+                            head_len: segs.head_len,
+                            tail: None,
+                        },
+                        seg_count: 1,
+                    }
+                    (parent, true)
+                }
+                Some(_) => {
+                    // path was [head, ..., last] with >= 3 segments.
+                    let nested = AstPath {
+                        segments: *rest1,
+                        seg_count: path.seg_count - 1,
+                    }
+                    let nested_pair = ast_path_drop_last_segment(nested)
+                    if !nested_pair.1 {
+                        return (path, false)
+                    }
+                    let parent_tail = nested_pair.0.segments
+                    let parent = AstPath {
+                        segments: StringList {
+                            head_buf: segs.head_buf,
+                            head_len: segs.head_len,
+                            tail: Some(Box::new(parent_tail)),
+                        },
+                        seg_count: path.seg_count - 1,
+                    }
+                    (parent, true)
+                }
+            }
+        }
+    }
+}
+
 fn resolve_import_file_path(path: AstPath, cur_dir: string) -> string with IO, Mut, Panic, Div, Alloc {
     let local = use_path_to_file_path(path, cur_dir)
     if file_exists(local) {
@@ -269,6 +318,30 @@ fn resolve_import_file_path(path: AstPath, cur_dir: string) -> string with IO, M
     let pkg_mod = file_path_mod_fallback(pkg)
     if file_exists(pkg_mod) {
         return pkg_mod
+    }
+    // Named-import fallback (see module_frontend.resolve_import_file_path):
+    // bare `use mod::symbol` when `mod/symbol.sio` is missing → load `mod.sio`.
+    if path.seg_count >= 2 {
+        let parent_pair = ast_path_drop_last_segment(path)
+        if parent_pair.1 {
+            let parent = parent_pair.0
+            let parent_local = use_path_to_file_path(parent, cur_dir)
+            if file_exists(parent_local) {
+                return parent_local
+            }
+            let parent_stdlib = use_path_to_file_path(parent, "stdlib")
+            if file_exists(parent_stdlib) {
+                return parent_stdlib
+            }
+            let parent_pkg = use_path_to_package_file_path(parent)
+            if file_exists(parent_pkg) {
+                return parent_pkg
+            }
+            let parent_pkg_mod = file_path_mod_fallback(parent_pkg)
+            if file_exists(parent_pkg_mod) {
+                return parent_pkg_mod
+            }
+        }
     }
     local
 }

--- a/stdlib/epistemic/gum.sio
+++ b/stdlib/epistemic/gum.sio
@@ -12,9 +12,10 @@
 //
 // Reference: JCGM 100:2008 (GUM)
 //
-// USAGE: import with `use epistemic::gum::*` (single-symbol `use epistemic::gum::name`
-// currently fails to resolve — Madaros bug, docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md).
-// Print floats with print(x)/println(x); do NOT use print_f64 in an importing program.
+// USAGE: `use epistemic::gum::*`, `use epistemic::gum::{name}`, or path-form
+// `use epistemic::gum::name` (path-form named import fixed under Madaros D4;
+// see docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md).
+// print_f64 is allowed in multi-module programs after the visibility allow-list fix (#1239).
 
 // ============================================================================
 // HELPERS

--- a/tests/compiler/named_path_import_print_f64_gate/main.sio
+++ b/tests/compiler/named_path_import_print_f64_gate/main.sio
@@ -1,0 +1,23 @@
+// Regression for D4 residual: bare path-form named import + print_f64 + helper.
+//
+// Pre-fix under Madaros:
+//   use mod::half
+// resolved as filesystem path mod/half.sio (missing) → AST closure incomplete
+// / E137, even though use mod::{half} worked after #1239.
+//
+// Audit: docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md defect 1
+// (single-symbol use) combined with defect 2 (print_f64) and defect 3 (helper).
+
+use mod::half
+use mod::add1
+
+fn wrap(x: f64) -> f64 {
+    add1(x)
+}
+
+fn main() -> i64 with IO {
+    // Expected stdout first line: 1.500000
+    print_f64(wrap(half()))
+    print_char(10)
+    0
+}

--- a/tests/compiler/named_path_import_print_f64_gate/mod.sio
+++ b/tests/compiler/named_path_import_print_f64_gate/mod.sio
@@ -1,0 +1,11 @@
+// Leaf module for path-form named-import regression.
+// The parent main uses `use mod::half` (no braces) — the shape that used to
+// treat `half` as a filesystem path segment and fail AST closure / E137.
+
+pub fn half() -> f64 {
+    0.5
+}
+
+pub fn add1(x: f64) -> f64 {
+    x + 1.0
+}


### PR DESCRIPTION
## Summary

Closes residual **D4 / #862** multi-module papercuts after #1239:

| Shape | Before (main) | After |
|---|---|---|
| `use mod::{half}` + `print_f64` + helper | OK (#1239) | OK |
| `use mod::half` (path form) + `print_f64` + helper | AST closure incomplete / E137 | **check+run OK** |
| `use epistemic::gum::gum_*` path form + `print_f64` | unresolved | **run → `0.290401`** |
| Whole-module multi-seg (`use mesh::pure::types`) | OK | OK (full path still preferred when file exists) |

### Root cause

Bare `use module::symbol` is token-identical to whole-file `use module::file`. Madaros AST `resolve_import_file_path` always joined every segment into a `.sio` path, so `use mod::half` looked for `mod/half.sio` and failed AST closure. Brace form has an explicit terminator and already worked. lean_single had a Bug C strip-last fallback (#601 / #626) that Madaros never received on the AST path.

### Fix

1. **`module_frontend.sio` / `module_loader.sio`**: last-resort strip of the final path segment when the full relpath misses and the parent module file exists.
2. **`check.sio`**: visibility collect binds the last path segment for path-form `use` (no braces / no glob).
3. Regression gate + fixture: `scripts/dev/named_path_import_print_f64_gate.sh`.

### Claim boundary

- Default native **check + compile + run** only.
- `-O` full-IR cleanup still SIGSEGVs after lower on this multi-module shape (separate optimizer defect; not claimed here).
- Does not claim numerical correctness of transcendental builtins beyond the existing #1239 gate.

## Test plan

- [x] `bash scripts/dev/named_path_import_print_f64_gate.sh` → `NAMED_PATH_IMPORT_GATE_PASS` stdout `1.500000`
- [x] `bash scripts/dev/visibility_builtin_allowlist_gate.sh` → PASS (no regression)
- [x] Local path-form + helper + `print_f64` via `./bin/souc run`
- [x] Stdlib path-form gum import + `print_f64` + helper → `0.290401`
- [x] `use mesh::pure::types` whole-module multi-seg still check+run
- [x] `tests/run-pass/uncertain_octonion_auto.sio` check: verdict=0 (3 modules; was unresolved=2)

## Refs

- Audit: `docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md` (defects 1–3)
- Prior: #1239 (print_f64 allow-list), #601/#626 (lean_single named import)
- Tracking: #862 (D4)