### PR TITLE
feat(probe): CORRECTED — the gap is a false positive; subspace alignment is the mechanism; S-SSM is calibration not target

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1057
-- Repo-backed topics: 907
+- Total governed topics: 1058
+- Repo-backed topics: 908
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 229
+- Authority count `historical`: 230
 - Authority count `repo_only`: 640
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 263 topics
+- A6: 264 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -782,6 +782,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.petitot-semantic-potential | historical | docs/research/petitot-semantic-potential.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.primitive-zd-gap-resolution | historical | docs/research/PRIMITIVE_ZD_GAP_RESOLUTION.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.private-evidence-envelope-2026-06-23 | historical | docs/research/private-evidence-envelope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.probe-corrected-protocol | historical | docs/research/probe-corrected-protocol.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-usage | historical | docs/research/probe-usage.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.proof-checker-family-matrix-2026-06-23 | historical | docs/research/proof-checker-family-matrix-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.proof-checker-microkernel-suite-2026-06-23 | historical | docs/research/proof-checker-microkernel-suite-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17324,6 +17324,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.probe-corrected-protocol",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/probe-corrected-protocol.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.probe-usage",
       "collection": "repo",
       "repo_doc_path": "docs/research/probe-usage.md",

--- a/docs/research/mechanism_analysis.py
+++ b/docs/research/mechanism_analysis.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Corrected probe analysis (OPUS-4.8-EXTRA revised protocol). The product-spectrum classifier reads a
+# POSITIVE but cannot read a NEGATIVE: a uniform slide is ambiguous (no dead subspace, OR dead subspaces
+# that ROTATE between factors and so don't compose). The mechanism is SUBSPACE ALIGNMENT, and the signature
+# is not a gap at one T but its GEOMETRIC GROWTH with T. This measures both, plus a null distribution — and
+# validates that it separates genuine composing structure from a matched-4/8/4-but-rotating control that a
+# naive spectrum classifier would false-positive on.
+import numpy as np
+np.seterr(all='ignore')
+def cds(a,b,bits=4):
+    s=1
+    while bits>0:
+        if a==0 or b==0: return s
+        if bits==1: return -s
+        h=1<<(bits-1);ah=a>=h;bh=b>=h;al=a&(h-1);bl=b&(h-1)
+        if not ah and not bh:a,b=al,bl
+        elif not ah and bh:a,b=bl,al
+        elif ah and not bh:(a,b,s)=((al,0,s) if bl==0 else (al,bl,-s))
+        else:(a,b,s)=((0,al,-s) if bl==0 else (bl,al,s))
+        bits-=1
+    return s
+SIG=np.array([[cds(i,j) for j in range(16)] for i in range(16)]);M=np.zeros((16,16,16))
+for k in range(16):
+    for b in range(16): M[k,k^b,b]=SIG[k,b]
+def Lx(x): return np.tensordot(x,M,axes=(0,0))
+def zdiv(rng):                                  # a random-ish sedenion zero divisor via unit-pair structure
+    i,j=1,10; z=np.zeros(16); z[i]=1; z[j]=rng.choice([-1,1]); return z/np.linalg.norm(z)
+def near(z,delta,rng):
+    r=rng.standard_normal(16); r-=(r@z)*z; r/=np.linalg.norm(r); x=z+delta*r; return x/np.linalg.norm(x)
+def bottomV(A,k=4):                              # bottom-k right singular subspace (the dying directions)
+    U,s,Vt=np.linalg.svd(A); return Vt[-k:]
+def principal_cos(V1,V2):                        # cosines of principal angles between two row-subspaces
+    return np.linalg.svd(V1@V2.T,compute_uv=False)
+def normed(A): return A/np.linalg.svd(A,compute_uv=False)[0]
+def product(mats):
+    P=np.eye(16)
+    for A in mats: P=A@P
+    return P
+def gap_dominance(sv):
+    s=np.sort(sv)[::-1]; s=s/s[0]; logs=np.log10(s+1e-30); g=logs[:-1]-logs[1:]; gi=int(np.argmax(g))
+    return float(g[gi])/(float(logs[0]-logs[gi])+1e-9)
+# ---- three stacks of DEPTH up to 32 ----
+rng=np.random.default_rng(1); D=32; delta=0.15
+z0=zdiv(rng)
+aligned=[normed(Lx(near(z0,delta,rng))) for _ in range(D)]                    # SAME zero divisor → shared dying subspace
+rotating=[normed(Lx(near(zdiv(np.random.default_rng(100+l)),delta,rng))) for l in range(D)]  # DIFFERENT z each layer
+realg=[normed(rng.standard_normal((16,16))) for _ in range(D)]
+# ---- §6.1 principal angles between consecutive dying subspaces (the mechanism) ----
+def mean_align(mats):
+    cs=[principal_cos(bottomV(mats[l]),bottomV(mats[l+1])).mean() for l in range(len(mats)-1)]
+    return np.mean(cs)
+print("§ mechanism — mean cos(principal angle) between consecutive dying 4-subspaces (1=aligned, 0=orthogonal):")
+print(f"    aligned (same zero divisor) : {mean_align(aligned):.3f}")
+print(f"    rotating (different z/layer) : {mean_align(rotating):.3f}")
+print(f"    real Gaussian               : {mean_align(realg):.3f}")
+# ---- §4b gap(T): geometric growth (shared subspace) vs saturation (rotating) ----
+print("\n§ signature — gap_dominance vs number of composed factors T (growth = composing structure):")
+Ts=[1,2,4,8,16,32]; print(f"    {'T':>3} | aligned | rotating | realGauss")
+for T in Ts:
+    ga=gap_dominance(np.linalg.svd(product(aligned[:T]),compute_uv=False))
+    gr=gap_dominance(np.linalg.svd(product(rotating[:T]),compute_uv=False))
+    gg=gap_dominance(np.linalg.svd(product(realg[:T]),compute_uv=False))
+    print(f"    {T:>3} | {ga:7.2f} | {gr:8.2f} | {gg:8.2f}")
+# ---- §2 null distribution of gap_dominance (false-positive rate for the LOW-MULT-GAP label) ----
+print("\n§ null — distribution of gap_dominance for random products (T=16), to set a FP-controlled threshold:")
+def null_dist(kind,n=300):
+    out=[]
+    for s in range(n):
+        rg=np.random.default_rng(1000+s)
+        if kind=='gauss': mats=[normed(rg.standard_normal((16,16))) for _ in range(16)]
+        elif kind=='rot': mats=[normed(Lx(near(zdiv(np.random.default_rng(2000+s*17+l)),delta,rg))) for l in range(16)]
+        out.append(gap_dominance(np.linalg.svd(product(mats),compute_uv=False)))
+    return np.array(out)
+for kind,lab in [('gauss','random Gaussian'),('rot','matched-4/8/4 but ROTATING (the key control)')]:
+    d=null_dist(kind); print(f"    {lab:42s}: gap_dom  median {np.median(d):.2f}  95th %ile {np.percentile(d,95):.2f}  P(>1) {100*(d>1).mean():.0f}%")
+ga16=gap_dominance(np.linalg.svd(product(aligned[:16]),compute_uv=False))
+print(f"    genuine aligned structure (T=16)          : gap_dom {ga16:.2f}")
+print("\n→ verdict is legible only against the null + the gap(T) growth curve + the alignment, NOT a point label.")
+print("  The rotating control has 4/8/4 PER FACTOR yet must NOT read as structure — the mechanism catches it.")

--- a/docs/research/probe-corrected-protocol.md
+++ b/docs/research/probe-corrected-protocol.md
@@ -1,0 +1,65 @@
+<!-- docs:meta
+topic_id: repo.docs.research.probe-corrected-protocol
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-corrected-protocol
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The probe, corrected: the gap alone is a false positive — the mechanism is subspace alignment
+
+*The first probe was built to read a POSITIVE and could not read a NEGATIVE (OPUS-4.8-EXTRA revised
+protocol). The product-spectrum gap is refuted as a discriminant; the valid one is the principal-angle
+alignment of consecutive dying subspaces. And the S-SSM is the worst target, not the best — its 4/8/4 is
+put there by algebra. Corrected here.*
+
+## The refutation (`mechanism_analysis.py`)
+A stack of matrices each with a low-multiplicity tail (4/8/4 per factor) but with the dead directions
+**rotating** between factors is the decisive control: it has the algebraic structure per-factor but the
+dead subspaces do **not** compose. Measured over depth 32:
+
+| stack | mean cos(principal angle), dying 4-subspaces | gap_dominance (T=16) | gap_dominance null P(>1) |
+|---|---|---|---|
+| **aligned** (same zero divisor — genuine composing annihilation) | **0.988** | 5.71 | — |
+| **rotating** (different z per layer — 4/8/4 per factor, no composition) | 0.530 | **99.4** | **97%** |
+| real Gaussian | 0.415 | 0.33 | 1% |
+
+Two things this settles: (1) **`gap_dominance` is not a valid discriminant** — the rotating control's gap is
+*larger* than genuine structure (99 vs 6) and exceeds 1 in 97% of nulls; against a Gaussian null it looked
+significant (1% FP), against the *right* control it is noise. (2) **the principal-angle alignment separates
+them cleanly** — `0.988` (genuine) vs `~0.5` baseline (rotating, real). The gap only means "composing
+annihilation" if the dead subspaces are **aligned**; the spectrum alone cannot tell composition from
+rotation, which are opposite conclusions. So the corrected probe measures **`subspace_alignment` first**.
+
+## gap(T): a curve, not a point
+`gap(T)` for the genuine aligned stack stays high and roughly flat (the gap *survives* composition) while
+the real Gaussian decays (`0.93→0.33` — the gap dies under composition); the rotating control spuriously
+inflates. So "the gap survives/grows with T" separates aligned+rotating from real, but only alignment
+separates aligned from rotating. Report the **gap(T) curve alongside the alignment**, never a single-T
+label.
+
+## Corrected protocol (in order)
+1. **Principal angles first** (`subspace_alignment`) — the mechanism; it disambiguates a UNIFORM-SLIDE
+   (no dead subspace *vs* dead subspaces that rotate — opposite meanings the spectrum conflates).
+2. **Nulls, reported as a distribution** of the discriminant, not a label: random Gaussian, shuffled
+   weights, untrained init, and the **matched-4/8/4-but-rotating** control (the one that breaks the naive
+   gap). If the signature is already at init, it is architecture, not learning.
+3. **Primary target: a NON-sedenion model** (LSTM, S4/Mamba, linear attention, vanilla RNN) — where 4/8/4
+   has no reason to appear, so its appearance would be discovery. The **S-SSM is only a declared positive
+   control** (its 4/8/4 is architectural; reading it back is the compiler working, not evidence).
+4. **`gap(T)` over hundreds of input sequences** (∂h_T/∂h_0 depends on the whole path) — report consistency
+   and the scaling curve; a verdict over "a few paths" is an uncharacterized small sample.
+5. **Only then, the link to performance**: does the alignment/gap predict a loss plateau, long-sequence
+   degradation, or specific unlearned examples? Without that link it is a spectrum shape, not a diagnostic.
+
+## Status
+The instrument now measures the mechanism (alignment), carries a null (the rotating control), reads the
+gap as a curve in `T`, and is aimed at the informative target. `make_forward` should be written for the
+LSTM / S4 first; the S-SSM second, labeled calibration. Harnesses `mechanism_analysis.py` (the refutation)
+and `probe_jacobian_spectrum.py` (`subspace_alignment`, `gap_vs_T`).

--- a/docs/research/probe-usage.md
+++ b/docs/research/probe-usage.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-usage
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/probe_jacobian_spectrum.py
+++ b/docs/research/probe_jacobian_spectrum.py
@@ -71,6 +71,35 @@ def probe_checkpoint(build_model, ckpt_path, make_forward, sample_inputs, n_path
     print(f"checkpoint {ckpt_path}: verdicts over {n_paths} paths → {verdicts}")
     return verdicts
 
+
+# ============================ the MECHANISM: subspace alignment (the valid discriminant) ============================
+# The product-spectrum gap is NOT sufficient: a stack of matrices each with a low-mult tail but with the
+# dead directions ROTATING between factors produces a large product gap WITHOUT any composing structure
+# (validated: the rotating control's gap_dominance exceeds genuine structure). The gap only means
+# "composing annihilation" if consecutive dead subspaces are ALIGNED. Measure that directly.
+def dying_subspace(J, k=4):
+    import numpy as np
+    U,sv,Vt=np.linalg.svd(J); return Vt[-k:]                     # bottom-k right singular vectors
+def subspace_alignment(J_list, k=4):
+    """mean cos(principal angle) between the dying k-subspaces of consecutive Jacobians.
+    ~1 = aligned (dead directions compose → genuine structural annihilation);
+    ~sqrt(k/dim) = baseline (dead directions rotate → gap is an artifact, NOT structure)."""
+    import numpy as np
+    cs=[np.linalg.svd(dying_subspace(J_list[l],k)@dying_subspace(J_list[l+1],k).T,compute_uv=False).mean()
+        for l in range(len(J_list)-1)]
+    return float(np.mean(cs)), np.sqrt(k/J_list[0].shape[1])     # (measured, baseline)
+def gap_vs_T(J_list, Ts=(1,2,4,8,16,32)):
+    """gap_dominance of the product of the first T factors — report the CURVE, not a point."""
+    import numpy as np
+    def gd(A):
+        sv=np.linalg.svd(A,compute_uv=False); s=np.sort(sv)[::-1]; s/=s[0]; lg=np.log10(s+1e-30)
+        g=lg[:-1]-lg[1:]; gi=int(np.argmax(g)); return float(g[gi])/(float(lg[0]-lg[gi])+1e-9)
+    P=np.eye(J_list[0].shape[0]); out={}
+    for t in range(1,max(Ts)+1):
+        P=J_list[t-1]@P
+        if t in Ts: out[t]=gd(np.linalg.svd(P,compute_uv=False)) if False else gd(P)
+    return out
+
 # ============================ self-contained validation (numpy, runs now) ============================
 if __name__=='__main__':
     import sys


### PR DESCRIPTION
The first probe was built to read a POSITIVE and could not read a NEGATIVE (OPUS-4.8-EXTRA revised protocol). Corrected.

**Refutation (`mechanism_analysis.py`).** A matched control — matrices with 4/8/4 *per factor* but dead directions **rotating** between factors — decides it:
| stack | cos(principal angle) dying-subspaces | gap_dominance T=16 | null P(>1) |
|---|---|---|---|
| **aligned** (genuine composing annihilation) | **0.988** | 5.7 | — |
| **rotating** (4/8/4/factor, no composition) | 0.530 | **99.4** | **97%** |
| real Gaussian | 0.415 | 0.33 | 1% |

`gap_dominance` is **invalid**: the rotating control's gap is *larger* than genuine structure and exceeds the threshold 97% of the time — against a Gaussian null it looked significant (1% FP), against the *right* control it is noise. The **principal-angle alignment** separates cleanly (0.988 vs ~0.5 baseline). The spectrum alone conflates composition with rotation — opposite conclusions.

**Corrected probe:** added `subspace_alignment` (the mechanism, measured first) and `gap_vs_T` (report the curve, not a point). **Corrected protocol:** (1) principal angles first (disambiguates the null); (2) nulls as a *distribution* incl. the matched-rotating control, shuffled weights, untrained init; (3) primary target = **non-sedenion** (LSTM/S4/Mamba/RNN) — S-SSM only as *declared calibration* (its 4/8/4 is architectural, reading it back is circular); (4) gap(T) over hundreds of sequences; (5) then the performance link. **The probe can now read a negative.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)