### PR TITLE
fix(parser): bare `var` as binding name (unblocks knightian)

### DIFF
--- a/scripts/dev/let_var_binding_gate.sh
+++ b/scripts/dev/let_var_binding_gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Gate: bare `let var =` binding + `var` as expression under Madaros.
+# Also re-checks stdlib/epistemic/knightian.sio parses cleanly.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+SOUC="${SOUC:-$ROOT/bin/souc}"
+
+echo "=== A. let var binding run-pass ==="
+out="$("$SOUC" run tests/run-pass/let_var_binding_name.sio 2>/tmp/let_var_gate.err | grep -E 'LET_VAR_BINDING_OK' || true)"
+if [[ "$out" != *LET_VAR_BINDING_OK* ]]; then
+  echo "LET_VAR_BINDING_GATE_FAIL: run-pass" >&2
+  cat /tmp/let_var_gate.err >&2 || true
+  exit 1
+fi
+echo "PASS let var binding run"
+
+echo "=== B. knightian.sio check (was parse-fail on let var) ==="
+set +e
+"$SOUC" check stdlib/epistemic/knightian.sio >/tmp/knightian_check.out 2>/tmp/knightian_check.err
+rc=$?
+set -e
+if grep -q 'parse error' /tmp/knightian_check.out /tmp/knightian_check.err 2>/dev/null; then
+  echo "LET_VAR_BINDING_GATE_FAIL: knightian still has parse errors" >&2
+  rg 'parse error' /tmp/knightian_check.out /tmp/knightian_check.err >&2 || true
+  exit 1
+fi
+if ! grep -q 'check: OK\|Type check complete\|verdict=0' /tmp/knightian_check.out /tmp/knightian_check.err 2>/dev/null; then
+  # Madaros library check may still advisory-warn; reject only hard parse errors (above)
+  # Accept if no parse error and exit 0-ish or AST closure complete
+  if rg -q 'AST closure incomplete' /tmp/knightian_check.out /tmp/knightian_check.err 2>/dev/null; then
+    echo "LET_VAR_BINDING_GATE_FAIL: knightian AST incomplete" >&2
+    tail -30 /tmp/knightian_check.out >&2
+    exit 1
+  fi
+fi
+echo "PASS knightian.sio no parse error (rc=$rc)"
+
+echo "=== C. knightian_trust import+run ==="
+set +e
+trust_out="$("$SOUC" run tests/epistemic_trust/knightian_trust.sio 2>/tmp/knightian_trust.err)"
+trc=$?
+set -e
+if [[ $trc -ne 0 ]] || ! echo "$trust_out" | grep -q 'KNIGHTIAN_TRUST_OK'; then
+  echo "LET_VAR_BINDING_GATE_FAIL: knightian_trust" >&2
+  echo "$trust_out" >&2
+  cat /tmp/knightian_trust.err >&2 || true
+  exit 1
+fi
+echo "PASS knightian_trust"
+
+echo "LET_VAR_BINDING_GATE_PASS"

--- a/self-hosted/parser/exprs.sio
+++ b/self-hosted/parser/exprs.sio
@@ -306,8 +306,11 @@ impl Parser {
         } else if k == TokenKind::ContestLower {
             self.parse_contest_expr()
         }
-        // Identifier (variable, function name, enum path, struct literal)
-        else if k == TokenKind::Ident || k == TokenKind::Knowledge || k == TokenKind::Close || k == TokenKind::Unit || k == TokenKind::Kernel {
+        // Identifier (variable, function name, enum path, struct literal).
+        // TokenKind::Var is included so bare `var` works as a binding *use*
+        // after `let var = ...` (contextual keyword; see patterns.sio).
+        // Statement `var x = ...` is dispatched from parse_stmt, not here.
+        else if k == TokenKind::Ident || k == TokenKind::Knowledge || k == TokenKind::Close || k == TokenKind::Unit || k == TokenKind::Kernel || k == TokenKind::Var {
             self.parse_ident_expr()
         }
         // Error recovery: advance past unrecognized token to avoid infinite loops

--- a/self-hosted/parser/patterns.sio
+++ b/self-hosted/parser/patterns.sio
@@ -103,7 +103,25 @@ impl Parser {
         } else if k == TokenKind::Ident || k == TokenKind::Handle || k == TokenKind::Unit || k == TokenKind::Kernel {
             self.parse_ident_or_enum_pattern()
         } else if k == TokenKind::Var {
-            self.parse_mut_binding_pattern()
+            // Contextual keyword: `var name` is a mutable binding pattern, but bare
+            // `var` followed by `=` / `:` / pattern terminators is an identifier
+            // named "var". Scientific code (knightian p-box, stats variance) uses
+            // `let var = ...`; treating every `var` as mut-introducer made Madaros
+            // reject those modules (expected `=`, got the next keyword/ident token).
+            // lean_single already accepted bare `var` bindings.
+            let next = parser_peek_ahead(self, 1)
+            if next == TokenKind::Eq
+                || next == TokenKind::Colon
+                || next == TokenKind::Comma
+                || next == TokenKind::RParen
+                || next == TokenKind::RBrace
+                || next == TokenKind::Pipe
+                || next == TokenKind::FatArrow
+            {
+                self.parse_var_as_ident_binding_pattern()
+            } else {
+                self.parse_mut_binding_pattern()
+            }
         } else {
             // Error recovery: advance past unrecognized token to avoid infinite loops
             let span = self.current_span()
@@ -462,6 +480,25 @@ impl Parser {
             sub_patterns: None,
             pat_fields: None,
             is_mut: true,
+        })
+    }
+
+    // Bare `var` as a binding name (not mut-introducer). Source span of the
+    // TokenKind::Var token yields name "var" via current_name().
+    fn parse_var_as_ident_binding_pattern(self) -> (Parser, Pattern) with Mut, IO, Panic, Div {
+        let start = self.current_span()
+        let name = self.current_name()
+        var p = self.advance()  // consume `var` as the binding name
+        let span = p.span_from(start)
+        (p, Pattern {
+            kind: PatternKind::PatBinding,
+            span: span,
+            name: name,
+            int_val: 0,
+            path: empty_path(),
+            sub_patterns: None,
+            pat_fields: None,
+            is_mut: false,
         })
     }
 }

--- a/tests/run-pass/let_var_binding_name.sio
+++ b/tests/run-pass/let_var_binding_name.sio
@@ -1,0 +1,25 @@
+// Regression: bare `var` is a valid binding name under Madaros (contextual keyword).
+// Knightian / stats modules use `let var = ...` for variance temporaries.
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let var = 42
+    if var != 42 {
+        println("FAIL: let var binding")
+        return 1
+    }
+    // mutable binding form still works
+    var x = 7
+    x = x + 1
+    if x != 8 {
+        println("FAIL: var x mut binding")
+        return 2
+    }
+    // struct field init with var as expression
+    // (mirrors PBox { variance: var, ... })
+    let variance = var
+    if variance != 42 {
+        println("FAIL: var as expression")
+        return 3
+    }
+    println("LET_VAR_BINDING_OK")
+    return 0
+}


### PR DESCRIPTION
## Summary

Wave-5 residual: **knightian parse fail** under default Madaros (candidate list item 4; explore rank mop-up after #890 claimed by another agent).

### Symptom (origin/main prebuilt)

```
./bin/souc check stdlib/epistemic/knightian.sio
parse error: expected token at line 307:15  expected=Eq actual=Valid
# ×3 (all `let var = pb_max(...)` sites)
run_check_mode: AST closure incomplete
```

`tests/epistemic_trust/knightian_trust.sio` then fails visibility preflight / native run.

### Root cause

`TokenKind::Var` in pattern position always entered `parse_mut_binding_pattern` (`var name` → mutable binding). Scientific code binds the **name** `var` itself:

```sounio
let var = pb_max(x.variance, y.variance)
PBox { ..., variance: var, ... }
```

Parser consumed `var` as mut-introducer, left `=` stranded → bare expected-token errors. lean_single already accepted bare `var` bindings.

### Fix

1. **`patterns.sio`**: contextual keyword — bare `var` before `=` / `:` / `,` / `)` / `}` / `|` / `=>` is a `PatBinding` named `"var"`; `var name` remains mut-binding.
2. **`exprs.sio`**: allow `TokenKind::Var` in identifier expressions so uses like `variance: var` resolve.
3. Gate + run-pass regression.

### Acceptance (measured)

Source-fresh Madaros (`bash scripts/ci/build_modular_madaros.sh`):

```
bash scripts/dev/let_var_binding_gate.sh
# === A. let var binding run-pass === PASS
# === B. knightian.sio check === PASS (no parse error)
# === C. knightian_trust import+run === PASS KNIGHTIAN_TRUST_OK
LET_VAR_BINDING_GATE_PASS
```

Also verified: `var x = …` mutable form still works in the run-pass fixture.

### Claim boundary

- Parser surface only (`self-hosted/parser/{patterns,exprs}.sio`).
- Does **not** ship a refreshed `bin/madaros-linux-x86_64` (bot / separate build commit).
- Gate requires source-fresh Madaros after this lands (same pattern as other Madaros source PRs).
- Does not claim full knightian Monte-Carlo / all p-box APIs under multi-module; only that the module **parses** and the existing trust sentinel **runs**.

### Non-overlap

- Did **not** touch `codegen_x86_linux.sio` (Agent on `fix/madaros-print-negative-f64` owns #890).
- Did not touch SSA/vreg or propagate lanes.

## Test plan

- [x] Prebuilt main: `let var = 1` / knightian parse **fail** (baseline)
- [x] Source-fresh Madaros: `bash scripts/dev/let_var_binding_gate.sh` → `LET_VAR_BINDING_GATE_PASS`
- [x] `var x` mut binding still works in run-pass
- [ ] CI / post-merge prebuilt refresh picks up parser for default `bin/souc`