### PR TITLE
fix(madaros): raise NativeCompiler vreg tables 512→2048

### DIFF
--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -6165,7 +6165,7 @@ fn compiler_main_test_dce_removes_dead() -> bool with Mut, Div, Panic {
 // Sprint 52: verify regalloc assigns a preg when register pressure is low (1 vreg, 1 preg)
 fn compiler_main_test_regalloc_assigns_preg() -> bool with Mut, Div, Panic {
     // Build: r0 = 3, r1 = r0 + 4, return r1
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     ra_instrs[0 as usize] = ra_simple_instr(0, -1, -1)   // r0 = imm (def r0)
     ra_instrs[1 as usize] = ra_simple_instr(1, 0, -1)    // r1 = r0 + imm (def r1, use r0)
     ra_instrs[2 as usize] = ra_simple_instr(-1, 1, -1)   // return r1 (use r1)
@@ -6183,7 +6183,7 @@ fn compiler_main_test_regalloc_assigns_preg() -> bool with Mut, Div, Panic {
 // Sprint 52: verify regalloc spills when pressure exceeds available registers
 fn compiler_main_test_regalloc_spills_under_pressure() -> bool with Mut, Div, Panic {
     // Build: 6 live intervals all overlapping (start 0, end 10), only 1 preg
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     var i = 0
     while i < 6 {
         ra_instrs[i as usize] = ra_simple_instr(i, -1, -1)
@@ -6259,7 +6259,7 @@ fn compiler_main_test_multipreg_map() -> bool {
 
 // T31: 2 non-overlapping vregs → 2 pregs assigned, 0 spilled
 fn compiler_main_test_multipreg_two_fit() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     ra_instrs[0 as usize] = ra_simple_instr(0, -1, -1)
     ra_instrs[1 as usize] = ra_simple_instr(-1, 0, -1)
     ra_instrs[2 as usize] = ra_simple_instr(1, -1, -1)
@@ -6275,7 +6275,7 @@ fn compiler_main_test_multipreg_two_fit() -> bool with Mut, Div, Panic {
 
 // T32: 4 non-overlapping vregs → all 4 pregs used, 0 spilled
 fn compiler_main_test_multipreg_four_fit() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     var i = 0
     while i < 4 {
         ra_instrs[(i * 2) as usize]     = ra_simple_instr(i, -1, -1)
@@ -6293,7 +6293,7 @@ fn compiler_main_test_multipreg_four_fit() -> bool with Mut, Div, Panic {
 
 // T33: 5 overlapping vregs with 4 pregs → exactly 1 spill
 fn compiler_main_test_multipreg_spill_one() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     // Define all 5 at pos 0, use all at pos 1 (all live simultaneously)
     var i = 0
     while i < 5 {
@@ -6343,7 +6343,7 @@ fn compiler_main_test_multipreg_epilogue_bytes() -> bool with Mut, Panic, Div {
 
 // T37: regalloc_linear_scan(state, 4) produces valid state (regression + 4-preg)
 fn compiler_main_test_multipreg_regalloc_four() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     ra_instrs[0 as usize] = ra_simple_instr(0, -1, -1)
     ra_instrs[1 as usize] = ra_simple_instr(-1, 0, -1)
     var state = liveness_compute_intervals(ra_instrs, 2)

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -3291,7 +3291,7 @@ fn native_v2_local_frame_size(stack_slots: i64, spill_count: i64) -> i64 with Mu
 
 fn native_v2_load_temp_to_rax(nc: NativeCompiler, temp: i64) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    if temp < 0 || temp >= 512 {
+    if temp < 0 || temp >= NC_MAX_VREGS {
         c.code = emit_xor_rax_rax(c.code)
         return c
     }
@@ -3311,7 +3311,7 @@ fn native_v2_load_temp_to_rax(nc: NativeCompiler, temp: i64) -> NativeCompiler w
 
 fn native_v2_store_rax_to_temp(nc: NativeCompiler, temp: i64) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    if temp < 0 || temp >= 512 {
+    if temp < 0 || temp >= NC_MAX_VREGS {
         return c
     }
     let preg = c.vreg_to_preg[temp as usize]
@@ -3336,10 +3336,10 @@ fn native_v2_store_rax_to_stack_slot(nc: NativeCompiler, slot: i64) -> NativeCom
     c
 }
 
-fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 512], out_count: &! i64) with Mut, Panic, Div {
+fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 2048], out_count: &! i64) with Mut, Panic, Div {
     var count: i64 = 0
     var i: i64 = 0
-    while i < (*func).blocks[0].instr_count && count < 512 {
+    while i < (*func).blocks[0].instr_count && count < 2048 {
         let instr = (*func).blocks[0].instrs[i as usize]
         if instr.opcode == MIR_OP_LOAD_STACK || instr.opcode == MIR_OP_MOV_IMM || instr.opcode == MIR_OP_LOAD_DATA_ADDR ||
            instr.opcode == MIR_OP_CAPTURE_RET || instr.opcode == MIR_OP_ALLOC || instr.opcode == MIR_OP_LEA_STACK {
@@ -3367,7 +3367,7 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
         } else if instr.opcode == MIR_OP_INDEX_STORE {
             out[count as usize] = ra_simple_instr(-1, instr.src1.value, instr.src2.value)
             count = count + 1
-            if count < 512 {
+            if count < 2048 {
                 out[count as usize] = ra_simple_instr(-1, instr.aux.value, -1)
                 count = count + 1
             }
@@ -3377,8 +3377,8 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
     *out_count = count
 }
 
-fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 512], i64) with Mut, Panic, Div {
-    var out: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 2048], i64) with Mut, Panic, Div {
+    var out: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     var count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(&func, &! out, &! count)
     (out, count)
@@ -3396,7 +3396,7 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
     state = regalloc_linear_scan(state, native_target_policy_x86_allocation_order_count())
 
     var i: i64 = 0
-    while i < 512 {
+    while i < NC_MAX_VREGS {
         (*nc).vreg_to_preg[i as usize] = -2
         (*nc).vreg_spill_slots[i as usize] = -1
         i = i + 1
@@ -3406,7 +3406,7 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
     while v < state.count {
         let interval = state.intervals[v as usize]
         let vreg = interval.vreg
-        if vreg >= 0 && vreg < 512 {
+        if vreg >= 0 && vreg < NC_MAX_VREGS {
             if interval.assigned_preg >= 0 {
                 (*nc).vreg_to_preg[vreg as usize] = native_target_policy_x86_allocation_order_reg_id(interval.assigned_preg)
             } else {
@@ -3421,14 +3421,14 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
 }
 
 fn native_v2_run_machine_regalloc_ref_mut(nc: &! NativeCompiler, func: &MachineFunction) with Mut, Panic, Div {
-    var instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     var instr_count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(func, &! instrs, &! instr_count)
     var state = liveness_compute_intervals(instrs, instr_count)
     state = regalloc_linear_scan(state, native_target_policy_x86_allocation_order_count())
 
     var i: i64 = 0
-    while i < 512 {
+    while i < NC_MAX_VREGS {
         (*nc).vreg_to_preg[i as usize] = -2
         (*nc).vreg_spill_slots[i as usize] = -1
         i = i + 1
@@ -3438,7 +3438,7 @@ fn native_v2_run_machine_regalloc_ref_mut(nc: &! NativeCompiler, func: &MachineF
     while v < state.count {
         let interval = state.intervals[v as usize]
         let vreg = interval.vreg
-        if vreg >= 0 && vreg < 512 {
+        if vreg >= 0 && vreg < NC_MAX_VREGS {
             if interval.assigned_preg >= 0 {
                 (*nc).vreg_to_preg[vreg as usize] = native_target_policy_x86_allocation_order_reg_id(interval.assigned_preg)
             } else {
@@ -3977,13 +3977,13 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
     c.label_patch_count = 0
     c.current_frame_size = 0
     var rst_j = 0
-    while rst_j < 512 {
+    while rst_j < NC_MAX_VREGS {
         c.is_float_reg[rst_j as usize] = 0
         rst_j = rst_j + 1
     }
     c.current_strategy = 0
     var rst_ra = 0
-    while rst_ra < 512 {
+    while rst_ra < NC_MAX_VREGS {
         c.vreg_to_preg[rst_ra as usize] = -2
         c.vreg_spill_slots[rst_ra as usize] = -1
         rst_ra = rst_ra + 1
@@ -4025,7 +4025,7 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
     while ra_v < ra_state.count {
         let ra_interval = ra_state.intervals[ra_v as usize]
         let ra_vreg = ra_interval.vreg
-        if ra_vreg >= 0 && ra_vreg < 512 {
+        if ra_vreg >= 0 && ra_vreg < NC_MAX_VREGS {
             if ra_interval.assigned_preg >= 0 {
                 c.vreg_to_preg[ra_vreg as usize] = native_target_policy_x86_allocation_order_reg_id(ra_interval.assigned_preg)
             } else {

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -5315,7 +5315,7 @@ fn native_v2_local_frame_size(stack_slots: i64, spill_count: i64) -> i64 with Mu
 
 fn native_v2_load_temp_to_rax(nc: NativeCompiler, temp: i64) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    if temp < 0 || temp >= 512 {
+    if temp < 0 || temp >= NC_MAX_VREGS {
         c.code = emit_xor_rax_rax(c.code)
         return c
     }
@@ -5335,7 +5335,7 @@ fn native_v2_load_temp_to_rax(nc: NativeCompiler, temp: i64) -> NativeCompiler w
 
 fn native_v2_store_rax_to_temp(nc: NativeCompiler, temp: i64) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    if temp < 0 || temp >= 512 {
+    if temp < 0 || temp >= NC_MAX_VREGS {
         return c
     }
     let preg = c.vreg_to_preg[temp as usize]
@@ -5364,10 +5364,10 @@ fn native_v2_ra_simple(dst: i64, src1: i64, src2: i64) -> RaSimpleInstr {
     RaSimpleInstr { dst: dst, src1: src1, src2: src2 }
 }
 
-fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 512], out_count: &! i64) with Mut, Panic, Div {
+fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 2048], out_count: &! i64) with Mut, Panic, Div {
     var count: i64 = 0
     var i: i64 = 0
-    while i < (*func).blocks[0].instr_count && count < 512 {
+    while i < (*func).blocks[0].instr_count && count < 2048 {
         let instr = (*func).blocks[0].instrs[i as usize]
         if instr.opcode == MIR_OP_LOAD_STACK || instr.opcode == MIR_OP_MOV_IMM || instr.opcode == MIR_OP_LOAD_DATA_ADDR ||
            instr.opcode == MIR_OP_CAPTURE_RET || instr.opcode == MIR_OP_ALLOC || instr.opcode == MIR_OP_LEA_STACK {
@@ -5395,7 +5395,7 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
         } else if instr.opcode == MIR_OP_INDEX_STORE {
             out[count as usize] = native_v2_ra_simple(0 - 1, machine_instr_src1_value(instr), machine_instr_src2_value(instr))
             count = count + 1
-            if count < 512 {
+            if count < 2048 {
                 out[count as usize] = native_v2_ra_simple(0 - 1, machine_instr_aux_value(instr), 0 - 1)
                 count = count + 1
             }
@@ -5405,8 +5405,8 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
     *out_count = count
 }
 
-fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 512], i64) with Mut, Panic, Div {
-    var out: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 2048], i64) with Mut, Panic, Div {
+    var out: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     var count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(&func, &! out, &! count)
     (out, count)
@@ -5424,7 +5424,7 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
     state = regalloc_linear_scan(state, native_target_policy_x86_allocation_order_count())
 
     var i: i64 = 0
-    while i < 512 {
+    while i < NC_MAX_VREGS {
         (*nc).vreg_to_preg[i as usize] = -2
         (*nc).vreg_spill_slots[i as usize] = -1
         i = i + 1
@@ -5434,7 +5434,7 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
     while v < state.count {
         let interval = state.intervals[v as usize]
         let vreg = interval.vreg
-        if vreg >= 0 && vreg < 512 {
+        if vreg >= 0 && vreg < NC_MAX_VREGS {
             if interval.assigned_preg >= 0 {
                 (*nc).vreg_to_preg[vreg as usize] = native_target_policy_x86_allocation_order_reg_id(interval.assigned_preg)
             } else {
@@ -5449,14 +5449,14 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
 }
 
 fn native_v2_run_machine_regalloc_ref_mut(nc: &! NativeCompiler, func: &MachineFunction) with Mut, Panic, Div {
-    var instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     var instr_count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(func, &! instrs, &! instr_count)
     var state = liveness_compute_intervals(instrs, instr_count)
     state = regalloc_linear_scan(state, native_target_policy_x86_allocation_order_count())
 
     var i: i64 = 0
-    while i < 512 {
+    while i < NC_MAX_VREGS {
         (*nc).vreg_to_preg[i as usize] = -2
         (*nc).vreg_spill_slots[i as usize] = -1
         i = i + 1
@@ -5466,7 +5466,7 @@ fn native_v2_run_machine_regalloc_ref_mut(nc: &! NativeCompiler, func: &MachineF
     while v < state.count {
         let interval = state.intervals[v as usize]
         let vreg = interval.vreg
-        if vreg >= 0 && vreg < 512 {
+        if vreg >= 0 && vreg < NC_MAX_VREGS {
             if interval.assigned_preg >= 0 {
                 (*nc).vreg_to_preg[vreg as usize] = native_target_policy_x86_allocation_order_reg_id(interval.assigned_preg)
             } else {
@@ -6054,13 +6054,13 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
     c.label_patch_count = 0
     c.current_frame_size = 0
     var rst_j = 0
-    while rst_j < 512 {
+    while rst_j < NC_MAX_VREGS {
         c.is_float_reg[rst_j as usize] = 0
         rst_j = rst_j + 1
     }
     c.current_strategy = 0
     var rst_ra = 0
-    while rst_ra < 512 {
+    while rst_ra < NC_MAX_VREGS {
         c.vreg_to_preg[rst_ra as usize] = -2
         c.vreg_spill_slots[rst_ra as usize] = -1
         rst_ra = rst_ra + 1
@@ -6106,7 +6106,7 @@ pub fn compile_ir_function_v2(nc: NativeCompiler, func: IrFunction, machine_func
     while ra_v < ra_state.count {
         let ra_interval = ra_state.intervals[ra_v as usize]
         let ra_vreg = ra_interval.vreg
-        if ra_vreg >= 0 && ra_vreg < 512 {
+        if ra_vreg >= 0 && ra_vreg < NC_MAX_VREGS {
             if ra_interval.assigned_preg >= 0 {
                 c.vreg_to_preg[ra_vreg as usize] = native_target_policy_x86_allocation_order_reg_id(ra_interval.assigned_preg)
             } else {
@@ -6260,13 +6260,13 @@ fn nc_core_store_rax_to_temp(nc: &! NativeCompiler, temp: i64) with Mut, Panic, 
 }
 
 fn nc_core_mark_float_reg(nc: &! NativeCompiler, reg: i64) with Mut, Panic, Div {
-    if reg >= 0 && reg < 512 {
+    if reg >= 0 && reg < NC_MAX_VREGS {
         (*nc).is_float_reg[reg as usize] = 1
     }
 }
 
 fn nc_core_mark_int_reg(nc: &! NativeCompiler, reg: i64) with Mut, Panic, Div {
-    if reg >= 0 && reg < 512 {
+    if reg >= 0 && reg < NC_MAX_VREGS {
         (*nc).is_float_reg[reg as usize] = 2
     }
 }
@@ -6638,8 +6638,8 @@ fn nc_emit_core_binop(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64
     let flags = (*func).instrs[instr_index as usize].imm_flags
     let lhs_float_marked = (flags / 2) & 1
     let rhs_float_marked = (flags / 4) & 1
-    let lhs_known_int = if lhs >= 0 && lhs < 512 && (*nc).is_float_reg[lhs as usize] == 2 { 1 } else { 0 }
-    let rhs_known_int = if rhs >= 0 && rhs < 512 && (*nc).is_float_reg[rhs as usize] == 2 { 1 } else { 0 }
+    let lhs_known_int = if lhs >= 0 && lhs < NC_MAX_VREGS && (*nc).is_float_reg[lhs as usize] == 2 { 1 } else { 0 }
+    let rhs_known_int = if rhs >= 0 && rhs < NC_MAX_VREGS && (*nc).is_float_reg[rhs as usize] == 2 { 1 } else { 0 }
     // Path-sound float override: for arithmetic AND comparison ops, also count an
     // operand as float when the fixpoint typing (nc_compute_float_types) proved its
     // register is a pure FLOAT — every reaching definition is float. This rescues
@@ -6651,8 +6651,8 @@ fn nc_emit_core_binop(nc: &! NativeCompiler, func: &IrFunction, instr_index: i64
     let op_is_arith = if op == BinaryOp::OpAdd || op == BinaryOp::OpSub || op == BinaryOp::OpMul || op == BinaryOp::OpDiv { 1 } else { 0 }
     let op_is_compare = if op == BinaryOp::OpLt || op == BinaryOp::OpLe || op == BinaryOp::OpGt || op == BinaryOp::OpGe || op == BinaryOp::OpEq || op == BinaryOp::OpNe { 1 } else { 0 }
     let op_wants_float_typing = if op_is_arith == 1 || op_is_compare == 1 { 1 } else { 0 }
-    let lhs_typed_float = if op_wants_float_typing == 1 && lhs >= 0 && lhs < 512 && (*nc).reg_type[lhs as usize] == 1 { 1 } else { 0 }
-    let rhs_typed_float = if op_wants_float_typing == 1 && rhs >= 0 && rhs < 512 && (*nc).reg_type[rhs as usize] == 1 { 1 } else { 0 }
+    let lhs_typed_float = if op_wants_float_typing == 1 && lhs >= 0 && lhs < NC_MAX_VREGS && (*nc).reg_type[lhs as usize] == 1 { 1 } else { 0 }
+    let rhs_typed_float = if op_wants_float_typing == 1 && rhs >= 0 && rhs < NC_MAX_VREGS && (*nc).reg_type[rhs as usize] == 1 { 1 } else { 0 }
     let lhs_is_float = if (lhs_float_marked == 1 || lhs_typed_float == 1) && lhs_known_int == 0 { 1 } else { 0 }
     let rhs_is_float = if (rhs_float_marked == 1 || rhs_typed_float == 1) && rhs_known_int == 0 { 1 } else { 0 }
     if lhs_is_float == 1 || rhs_is_float == 1 {
@@ -6951,7 +6951,7 @@ fn nc_core_emit_println_i64_literal_sentinel_into(nc: &! NativeCompiler, value: 
 // every reaching definition is float. f64 float literals still reach SSE via the
 // lowering imm_flags bits (their loadimm+marker pair makes them CONFLICT here).
 fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Panic, Div {
-    var ty: [i64; 512] = [0; 512]
+    var ty: [i64; 2048] = [0; 2048]
     var changed = true
     var iters = 0
     while changed && iters < 24 {
@@ -6972,7 +6972,7 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
             } else if op == IrOpcode::IrUnaryOp {
                 let uop = (*func).instrs[i as usize].un_op
                 if uop == UnaryOp::OpNeg {
-                    let t1 = if s1 >= 0 && s1 < 512 { ty[s1 as usize] } else { 0 }
+                    let t1 = if s1 >= 0 && s1 < NC_MAX_VREGS { ty[s1 as usize] } else { 0 }
                     if t1 == 1 {
                         def = 1
                     } else if t1 == 2 {
@@ -6984,7 +6984,7 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
                     def = 2
                 }
             } else if op == IrOpcode::IrCopy {
-                if s1 >= 0 && s1 < 512 { def = ty[s1 as usize] }
+                if s1 >= 0 && s1 < NC_MAX_VREGS { def = ty[s1 as usize] }
             } else if op == IrOpcode::IrCall || op == IrOpcode::IrFieldGet || op == IrOpcode::IrIndexGet {
                 if fl == IR_FLOAT_REG_MARKER_FLAG { def = 1 } else { def = 2 }
             } else if op == IrOpcode::IrBinOp {
@@ -6992,8 +6992,8 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
                 if bop == BinaryOp::OpAdd || bop == BinaryOp::OpSub || bop == BinaryOp::OpMul || bop == BinaryOp::OpDiv {
                     let lf = ((fl / 2) & 1) == 1
                     let rf = ((fl / 4) & 1) == 1
-                    let t1 = if s1 >= 0 && s1 < 512 { ty[s1 as usize] } else { 0 }
-                    let t2 = if s2 >= 0 && s2 < 512 { ty[s2 as usize] } else { 0 }
+                    let t1 = if s1 >= 0 && s1 < NC_MAX_VREGS { ty[s1 as usize] } else { 0 }
+                    let t2 = if s2 >= 0 && s2 < NC_MAX_VREGS { ty[s2 as usize] } else { 0 }
                     if lf || rf || t1 == 1 || t2 == 1 {
                         def = 1
                     } else if t1 == 2 && t2 == 2 {
@@ -7005,7 +7005,7 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
                     def = 2
                 }
             }
-            if d >= 0 && d < 512 && def >= 0 {
+            if d >= 0 && d < NC_MAX_VREGS && def >= 0 {
                 let cur = ty[d as usize]
                 var nv = cur
                 if cur == 0 {
@@ -7027,7 +7027,7 @@ fn nc_compute_float_types(nc: &! NativeCompiler, func: &IrFunction) with Mut, Pa
         iters = iters + 1
     }
     var r = 0
-    while r < 512 {
+    while r < NC_MAX_VREGS {
         (*nc).reg_type[r as usize] = ty[r as usize]
         r = r + 1
     }
@@ -7135,7 +7135,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                 nc_emit_mov_reg_imm(nc, 3, (*func).instrs[i as usize].field_idx + native_v2_object_header_size() / 8)
                 nc_emit_store_rax_mem_rdx_rbx8(nc)
             }
-            if (*func).instrs[i as usize].src2 >= 0 && (*func).instrs[i as usize].src2 < 512 {
+            if (*func).instrs[i as usize].src2 >= 0 && (*func).instrs[i as usize].src2 < NC_MAX_VREGS {
                 if (*nc).is_float_reg[(*func).instrs[i as usize].src2 as usize] == 1 {
                     nc_core_mark_float_field(nc, (*func).instrs[i as usize].src1, (*func).instrs[i as usize].field_idx)
                 }
@@ -7178,7 +7178,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
                     (*func).instrs[i as usize].src2,
                 )
             }
-            let index_base_is_float_array = if base_reg >= 0 && base_reg < 512 { (*nc).is_float_reg[base_reg as usize] == 1 } else { false }
+            let index_base_is_float_array = if base_reg >= 0 && base_reg < NC_MAX_VREGS { (*nc).is_float_reg[base_reg as usize] == 1 } else { false }
             if (*func).instrs[i as usize].imm_flags == IR_FLOAT_REG_MARKER_FLAG || index_base_is_float_array {
                 nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
             } else {
@@ -7241,7 +7241,7 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
         } else if instr_op == IrOpcode::IrCopy {
             nc_core_load_temp_to_rax(nc, (*func).instrs[i as usize].src1)
             nc_core_store_rax_to_temp(nc, (*func).instrs[i as usize].dst)
-            if (*func).instrs[i as usize].src1 >= 0 && (*func).instrs[i as usize].src1 < 512 {
+            if (*func).instrs[i as usize].src1 >= 0 && (*func).instrs[i as usize].src1 < NC_MAX_VREGS {
                 if (*nc).is_float_reg[(*func).instrs[i as usize].src1 as usize] == 1 {
                     nc_core_mark_float_reg(nc, (*func).instrs[i as usize].dst)
                 } else {
@@ -7259,8 +7259,8 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             let uop = (*func).instrs[i as usize].un_op
             if uop == UnaryOp::OpNeg {
                 let src1 = (*func).instrs[i as usize].src1
-                let src1_marked_float = if src1 >= 0 && src1 < 512 && (*nc).is_float_reg[src1 as usize] == 1 { 1 } else { 0 }
-                let src1_typed_float = if src1 >= 0 && src1 < 512 && (*nc).reg_type[src1 as usize] == 1 { 1 } else { 0 }
+                let src1_marked_float = if src1 >= 0 && src1 < NC_MAX_VREGS && (*nc).is_float_reg[src1 as usize] == 1 { 1 } else { 0 }
+                let src1_typed_float = if src1 >= 0 && src1 < NC_MAX_VREGS && (*nc).reg_type[src1 as usize] == 1 { 1 } else { 0 }
                 if src1_marked_float == 1 || src1_typed_float == 1 {
                     nc_core_load_temp_to_rax(nc, src1)
                     nc_emit_movq_xmm1_rax(nc)

--- a/self-hosted/native/frame.sio
+++ b/self-hosted/native/frame.sio
@@ -12,6 +12,11 @@ use native::elf::{StringTable, string_table_new, SymbolData, symbol_data_new}
 use native::runtime_context::{runtime_context_global_slot_size}
 use native::target_policy::{native_target_policy_x86_allocatable_mask_for_reg}
 
+// Per-function virtual-register table capacity for NativeCompiler.
+// Must stay in sync with regalloc / codegen vreg index guards.
+// Historical silent wall was 512 (loads zeroed / stores dropped past it).
+pub let NC_MAX_VREGS: i64 = 2048
+
 // Stack frame state for a single function
 pub struct StackFrame {
     pub frame_size: i64,              // Total frame size (16-byte aligned)
@@ -258,13 +263,13 @@ pub struct NativeCompiler {
     pub entry_offset: i64,
 
     // Per-function: float register tracking (vreg index -> 1 if f64, 0 if i64)
-    pub is_float_reg: [i64; 512],
+    pub is_float_reg: [i64; 2048],
     // Per-function: path-sound register float typing computed by a fixpoint over
     // the IR (nc_compute_float_types). Lattice: 0 UNKNOWN, 1 FLOAT, 2 INT, 3
     // CONFLICT. A register is 1 (FLOAT) only if EVERY definition reaching it is
     // float — so the codegen binop override may treat it as float without the
     // path-insensitivity hazard of the linear is_float_reg scan.
-    pub reg_type: [i64; 512],
+    pub reg_type: [i64; 2048],
     pub field_float_base_regs: [i64; 256],
     pub field_float_indices: [i64; 256],
     pub field_float_count: i64,
@@ -312,8 +317,8 @@ pub struct NativeCompiler {
 
     // Sprint 52: register allocation — vreg → physical register mapping
     // RA_UNASSIGNED(-2) = not processed, RA_SPILLED(-1) = on stack, >=0 = x86 reg number
-    pub vreg_to_preg: [i64; 512],
-    pub vreg_spill_slots: [i64; 512],      // spill slot index when vreg_to_preg[v] == -1
+    pub vreg_to_preg: [i64; 2048],
+    pub vreg_spill_slots: [i64; 2048],      // spill slot index when vreg_to_preg[v] == -1
 
     // Native-v2 Machine IR frame metadata
     pub current_machine_base_slots: i64,
@@ -370,7 +375,7 @@ pub fn compiler_new() -> NativeCompiler {
         i = i + 1
     }
     i = 0
-    while i < 512 {
+    while i < NC_MAX_VREGS {
         out.vreg_to_preg[i as usize] = -2
         out.vreg_spill_slots[i as usize] = -1
         i = i + 1
@@ -392,7 +397,7 @@ pub fn reset_function_state_mut(nc: &! NativeCompiler) with Mut, Panic, Div {
     (*nc).label_patch_count = 0
     (*nc).current_frame_size = 0
     var j = 0
-    while j < 512 {
+    while j < NC_MAX_VREGS {
         (*nc).is_float_reg[j as usize] = 0
         j = j + 1
     }
@@ -405,7 +410,7 @@ pub fn reset_function_state_mut(nc: &! NativeCompiler) with Mut, Panic, Div {
     }
     (*nc).current_strategy = 0
     var ra = 0
-    while ra < 512 {
+    while ra < NC_MAX_VREGS {
         (*nc).vreg_to_preg[ra as usize] = -2
         (*nc).vreg_spill_slots[ra as usize] = -1
         ra = ra + 1

--- a/self-hosted/native/lower_ir.sio
+++ b/self-hosted/native/lower_ir.sio
@@ -42,10 +42,10 @@ pub fn preg_to_x86_reg(preg: i64) -> i64 {
 pub fn nc_run_regalloc(nc: NativeCompiler, func: IrFunction) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
     // 1. Build RaSimpleInstr array from IR instructions
-    var ra_instrs: [RaSimpleInstr; 512] = [ra_empty_simple_instr(); 512]
+    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
     let count = func.instr_count
     var i = 0
-    while i < count && i < 128 {
+    while i < count && i < 2048 {
         let instr = func.instrs[i as usize]
         ra_instrs[i as usize] = ra_simple_instr(instr.dst, instr.src1, instr.src2)
         i = i + 1
@@ -58,7 +58,7 @@ pub fn nc_run_regalloc(nc: NativeCompiler, func: IrFunction) -> NativeCompiler w
     while v < state.count {
         let interval = state.intervals[v as usize]
         let vreg = interval.vreg
-        if vreg >= 0 && vreg < 512 {
+        if vreg >= 0 && vreg < NC_MAX_VREGS {
             if interval.assigned_preg >= 0 {
                 // Map logical preg to x86 reg number
                 c.vreg_to_preg[vreg as usize] = preg_to_x86_reg(interval.assigned_preg)
@@ -73,7 +73,7 @@ pub fn nc_run_regalloc(nc: NativeCompiler, func: IrFunction) -> NativeCompiler w
     var pi = 0
     while pi < func.param_count {
         let pvreg = func.param_regs[pi as usize]
-        if pvreg >= 0 && pvreg < 512 {
+        if pvreg >= 0 && pvreg < NC_MAX_VREGS {
             c.vreg_to_preg[pvreg as usize] = -2    // RA_UNASSIGNED: use stack fallback
         }
         pi = pi + 1
@@ -84,7 +84,7 @@ pub fn nc_run_regalloc(nc: NativeCompiler, func: IrFunction) -> NativeCompiler w
 // Load vreg to rax. Uses the physical register if allocated, else falls back to stack slot.
 pub fn nc_load_vreg_to_rax(nc: NativeCompiler, vreg: i64) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    if vreg < 0 || vreg >= 512 {
+    if vreg < 0 || vreg >= NC_MAX_VREGS {
         c.code = emit_xor_rax_rax(c.code)
         return c
     }
@@ -107,7 +107,7 @@ pub fn nc_load_vreg_to_rax(nc: NativeCompiler, vreg: i64) -> NativeCompiler with
 // Store rax to vreg. Uses the physical register if allocated, else falls back to stack slot.
 pub fn nc_store_rax_to_vreg(nc: NativeCompiler, vreg: i64) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
-    if vreg < 0 || vreg >= 512 {
+    if vreg < 0 || vreg >= NC_MAX_VREGS {
         return c
     }
     let preg = c.vreg_to_preg[vreg as usize]
@@ -133,7 +133,7 @@ pub fn nc_store_rax_to_vreg(nc: NativeCompiler, vreg: i64) -> NativeCompiler wit
 pub fn nc_min_frame_size(nc: NativeCompiler, func: IrFunction) -> i64 with Mut, Panic, Div {
     var max_stack_vreg: i64 = -1
     var v: i64 = 0
-    while v < func.reg_count && v < 512 {
+    while v < func.reg_count && v < NC_MAX_VREGS {
         if nc.vreg_to_preg[v as usize] < 0 {
             max_stack_vreg = v
         }
@@ -625,7 +625,7 @@ pub fn lower_copy(nc: &! NativeCompiler, instr: IrInstr) with Mut, Panic, Div {
     if instr.dst >= 0 {
         c = nc_store_rax_to_vreg(c, instr.dst)
         // Propagate float type tracking
-        if instr.src1 >= 0 && instr.src1 < 512 {
+        if instr.src1 >= 0 && instr.src1 < NC_MAX_VREGS {
             c.is_float_reg[instr.dst as usize] = c.is_float_reg[instr.src1 as usize]
         }
     }
@@ -732,14 +732,14 @@ pub fn lower_ir_load_float_binop_operands(
 
     // Load lhs to xmm0: if it's an integer, convert via CVTSI2SD; else bit-move
     c = nc_load_vreg_to_rax(c, lhs)
-    if lhs >= 0 && lhs < 512 && c.is_float_reg[lhs as usize] == 0 {
+    if lhs >= 0 && lhs < NC_MAX_VREGS && c.is_float_reg[lhs as usize] == 0 {
         c.code = emit_cvtsi2sd_xmm0_rax(c.code)
     } else {
         c.code = emit_movq_xmm0_rax(c.code)
     }
     // Load rhs to xmm1: same pattern
     c = nc_load_vreg_to_rax(c, rhs)
-    if rhs >= 0 && rhs < 512 && c.is_float_reg[rhs as usize] == 0 {
+    if rhs >= 0 && rhs < NC_MAX_VREGS && c.is_float_reg[rhs as usize] == 0 {
         // Need rhs in xmm1, not xmm0 — use CVTSI2SD then move to xmm1
         c.code = emit_cvtsi2sd_xmm0_rax(c.code)
         c.code = emit_movq_rax_xmm0(c.code)     // xmm0 bits → rax
@@ -755,12 +755,12 @@ pub fn lower_ir_binop(nc: &! NativeCompiler, instr: IrInstr) with Mut, Panic, Di
 
     // Check if either operand is float
     var is_float = 0
-    if instr.src1 >= 0 && instr.src1 < 512 {
+    if instr.src1 >= 0 && instr.src1 < NC_MAX_VREGS {
         if c.is_float_reg[instr.src1 as usize] == 1 {
             is_float = 1
         }
     }
-    if instr.src2 >= 0 && instr.src2 < 512 {
+    if instr.src2 >= 0 && instr.src2 < NC_MAX_VREGS {
         if c.is_float_reg[instr.src2 as usize] == 1 {
             is_float = 1
         }

--- a/self-hosted/native/regalloc.sio
+++ b/self-hosted/native/regalloc.sio
@@ -13,7 +13,11 @@ module native::regalloc
 // Constants
 // ============================================================================
 
-pub let RA_MAX_INTERVALS: i64 = 512
+pub let RA_MAX_INTERVALS: i64 = 2048
+// Max distinct vreg ids tracked by liveness / RA (matches NC_MAX_VREGS).
+pub let RA_MAX_VREGS: i64 = 2048
+// Max RaSimpleInstr entries accepted by liveness_compute_intervals.
+pub let RA_MAX_SIMPLE_INSTRS: i64 = 2048
 pub let RA_MAX_ACTIVE: i64 = 64
 pub let RA_MAX_HINTS: i64 = 256
 pub let RA_SPILLED: i64 = 0 - 1          // sentinel: no physical register assigned
@@ -40,7 +44,7 @@ pub struct RegHint {
 
 // Full allocator state.
 pub struct RegAllocState {
-    pub intervals: [LiveInterval; 512],
+    pub intervals: [LiveInterval; 2048],
     pub count: i64,
     pub spill_count: i64,          // number of spill slots allocated so far
     pub num_pregs: i64,            // total physical registers available
@@ -76,7 +80,7 @@ pub fn empty_reg_hint() -> RegHint {
 
 pub fn regalloc_new() -> RegAllocState {
     RegAllocState {
-        intervals: [empty_live_interval(); 512],
+        intervals: [empty_live_interval(); 2048],
         count: 0,
         spill_count: 0,
         num_pregs: 14,
@@ -433,17 +437,17 @@ pub fn regalloc_spill_info(state: RegAllocState) -> SpillInfo {
 
 // Liveness workspace: tracks def/use per vreg to build intervals.
 pub struct LivenessMap {
-    pub defs: [i64; 512],    // first definition point per vreg
-    pub uses: [i64; 512],    // last use point per vreg
-    pub seen: [i64; 512],    // 1 if vreg has been seen, 0 otherwise
+    pub defs: [i64; 2048],    // first definition point per vreg
+    pub uses: [i64; 2048],    // last use point per vreg
+    pub seen: [i64; 2048],    // 1 if vreg has been seen, 0 otherwise
     pub max_vreg: i64,
 }
 
 pub fn liveness_map_new() -> LivenessMap {
     LivenessMap {
-        defs: [0; 512],
-        uses: [0; 512],
-        seen: [0; 512],
+        defs: [0; 2048],
+        uses: [0; 2048],
+        seen: [0; 2048],
         max_vreg: 0,
     }
 }
@@ -453,7 +457,7 @@ pub fn liveness_def_point(
     map: LivenessMap, vreg: i64, position: i64
 ) -> LivenessMap with Mut, Panic, Div {
     var m = map
-    if vreg >= 0 && vreg < 512 {
+    if vreg >= 0 && vreg < RA_MAX_VREGS {
         if m.seen[vreg as usize] == 0 {
             m.defs[vreg as usize] = position
             m.uses[vreg as usize] = position
@@ -475,7 +479,7 @@ pub fn liveness_use_point(
     map: LivenessMap, vreg: i64, position: i64
 ) -> LivenessMap with Mut, Panic, Div {
     var m = map
-    if vreg >= 0 && vreg < 512 {
+    if vreg >= 0 && vreg < RA_MAX_VREGS {
         if m.seen[vreg as usize] == 0 {
             // Use before def (parameter or phi): treat position as both
             m.defs[vreg as usize] = position
@@ -524,7 +528,7 @@ pub fn ra_empty_simple_instr() -> RaSimpleInstr {
 // High-level: compute intervals from an array of RaSimpleInstr.
 // Walks instructions sequentially, recording defs (dst) and uses (src1, src2).
 pub fn liveness_compute_intervals(
-    instrs: [RaSimpleInstr; 512], instr_count: i64
+    instrs: [RaSimpleInstr; 2048], instr_count: i64
 ) -> RegAllocState with Mut, Panic, Div {
     var map = liveness_map_new()
     var pos: i64 = 0


### PR DESCRIPTION
## Summary

Raises the Madaros native_v2 **per-function virtual-register table ceiling** from **512 to 2048** so ops with `vreg ≥ 512` no longer silently lose float typing / drop temps.

### Root cause (Agent A + handoff)

`NativeCompiler` state arrays were fixed at 512:

- `is_float_reg`, `reg_type`, `vreg_to_preg`, `vreg_spill_slots` in `frame.sio`
- Matching guards in `codegen_x86_linux.sio` / `codegen.sio` / `lower_ir.sio`
- RA liveness + `RA_MAX_INTERVALS` in `regalloc.sio`

Past that wall: loads zeroed (`xor rax,rax`), stores dropped, RA intervals discarded, frame scan truncated — silent miscompile / SEGV after stack probe for large unsplit bodies.

### Change

| Constant / table | Old | New |
|---|---:|---:|
| `NC_MAX_VREGS` (new) | — | **2048** |
| `is_float_reg` / `reg_type` / `vreg_to_preg` / `vreg_spill_slots` | 512 | **2048** |
| `RA_MAX_INTERVALS` / `RA_MAX_VREGS` / `RA_MAX_SIMPLE_INSTRS` | 512 | **2048** |
| Machine RA `RaSimpleInstr` buffers | 512 | **2048** |
| lower_ir RA instr scan cap | 128 | **2048** |

Aligned with existing `IR_MAX_INSTRS = 2048`.

**Kept:** `#1274` `oct_mul` lo/hi frame split in `stdlib/algebra/octonion.sio` (unchanged).

### Rebuild

```bash
SOUNIO_BUILD_LOCK=/tmp/sounio-vreg-build.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
# → Madaros ready (99448218 bytes)
```

### Gates (rebuilt Madaros)

| Gate | Result |
|------|--------|
| `scripts/madaros_large_frame_stack_probe_gate.sh` | **OK** |
| `scripts/madaros_dual_import_gate.sh` | **OK** |
| `scripts/madaros_order_spread_native_gate.sh` | **OK** (scaled 2044225) |
| `scripts/madaros_algebra_octonion_import_gate.sh` | **OK** (e1*e2→e3) |

### Honest residual — unsplit `oct_mul`

Informational single-file full 8-component exclusive-ref body (not stdlib):

- **compile OK**, frame max `0x1000` (probe) / body `0x120`
- **run fails** with recursive re-entry through `main` (prints `ENTER`/`BEFORE_MUL` until stack exhausts; rc=182)
- 4-component half body **PASS**
- Split `#1274` import path **PASS**

So the **512-table silent drop is lifted**, but **unsplit full oct_mul is still broken** for a separate reason (likely call-target / slot-reuse / large-body lowering residual — **next work**, not this PR).

## Test plan

- [x] Rebuild modular Madaros under build lock
- [x] large_frame_stack_probe
- [x] dual import / order_spread / algebra octonion import
- [x] Document unsplit residual (do not merge unsplit stdlib)