### PR TITLE
feat(probe): align(k) curve resolves the low-rank confounder; target = dense RNN (S4/Mamba disqualified)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,25 +19,25 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1058
-- Repo-backed topics: 908
+- Total governed topics: 1060
+- Repo-backed topics: 910
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 230
-- Authority count `repo_only`: 640
+- Authority count `historical`: 231
+- Authority count `repo_only`: 641
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 659 topics
+- A2: 660 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 264 topics
+- A6: 265 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -623,6 +623,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.preprint.rapamycin-des-combo-outline | repo_only | docs/preprint/rapamycin_des_combo_outline.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.epistemic-meta-analysis | repo_only | docs/proposals/epistemic-meta-analysis.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.epistemic-workflows | repo_only | docs/proposals/epistemic-workflows.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.proposals.global-array-literal-init-2026-07-20 | repo_only | docs/proposals/GLOBAL_ARRAY_LITERAL_INIT_2026-07-20.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.native-heap-allocation-2026-07-12 | repo_only | docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.nma-nonassociative-algebra-note | repo_only | docs/proposals/nma_nonassociative_algebra_note.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.proposals.pbpk-osp-interop-roadmap | repo_only | docs/proposals/pbpk-osp-interop-roadmap.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
@@ -644,6 +645,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.2026-07-19-linalg-parity | historical | docs/research/2026-07-19-linalg-parity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.2026-07-19-special-scipy-parity | historical | docs/research/2026-07-19-special-scipy-parity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.2026-07-19-stats-dist-parity | historical | docs/research/2026-07-19-stats-dist-parity.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.align-curve-and-target | historical | docs/research/align-curve-and-target.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.associator-spectral-bound-status | historical | docs/research/associator_spectral_bound_status.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.bbb-pbpk-dissertation-chapter | historical | docs/research/bbb_pbpk_dissertation_chapter.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.beta0-octonion-gum-derivation | historical | docs/research/beta0_octonion_gum_derivation.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -13808,6 +13808,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.proposals.global-array-literal-init-2026-07-20",
+      "collection": "repo",
+      "repo_doc_path": "docs/proposals/GLOBAL_ARRAY_LITERAL_INIT_2026-07-20.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.proposals.native-heap-allocation-2026-07-12",
       "collection": "repo",
       "repo_doc_path": "docs/proposals/NATIVE_HEAP_ALLOCATION_2026-07-12.md",
@@ -14268,6 +14291,28 @@
       "topic_id": "repo.docs.research.2026-07-19-stats-dist-parity",
       "collection": "repo",
       "repo_doc_path": "docs/research/2026-07-19-stats-dist-parity.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
+      "topic_id": "repo.docs.research.align-curve-and-target",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/align-curve-and-target.md",
       "website_slug": null,
       "website_paths": {},
       "audience": "researchers",

--- a/docs/proposals/GLOBAL_ARRAY_LITERAL_INIT_2026-07-20.md
+++ b/docs/proposals/GLOBAL_ARRAY_LITERAL_INIT_2026-07-20.md
@@ -1,10 +1,10 @@
 <!-- docs:meta
-topic_id: repo.docs.proposals.global-array-literal-init
+topic_id: repo.docs.proposals.global-array-literal-init-2026-07-20
 authority: repo_only
 audience: users
-last_validated: 2026-07-20
+last_validated: 2026-03-07
 validated_by: A2
-source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.proposals.global-array-literal-init
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.proposals.global-array-literal-init-2026-07-20
 -->
 
 # Proposal: Global Array Literal Initialization

--- a/docs/research/align-curve-and-target.md
+++ b/docs/research/align-curve-and-target.md
@@ -1,0 +1,68 @@
+<!-- docs:meta
+topic_id: repo.docs.research.align-curve-and-target
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.align-curve-and-target
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# align(k) as a curve resolves the low-rank confounder; the target is a dense RNN, not S4/Mamba
+
+*Recorded verdict first: the product-spectrum gap is **dead** as a discriminant — the rotating control
+(4/8/4 per factor, dead subspaces rotating) killed it (gap_dominance 99 > genuine 5.7, null P(>1)=97%). The
+**principal-angle alignment** is what survived. This adds the confounder the three nulls missed and the
+target correction. Implements OPUS-4.8-EXTRA.*
+
+## The missing null: low effective rank
+Alignment ≈ 1 has two readings: (A) a shared **dead** subspace (annihilation), or (B) **low effective
+rank** — signal in a few directions, the weak complement shared trivially, so any layer's bottom subspace
+lies in it. Low rank is the most documented property of trained nets, and the existing nulls miss it:
+shuffled weights and untrained init are both **full-rank** → low alignment → exactly the contrast one would
+misread as structure.
+
+## The fix needs no new null: read align(k) as a curve, find the shoulder (`align_curve.py`)
+Sweep `k` and look for the **shoulder** (the drop in `align(k)` above the `√(k/d)` baseline). Validated on
+three depth-12 stacks:
+
+| stack | shoulder at k | reading |
+|---|---|---|
+| aligned near-ZD sedenions (dead≈4) | **k=4** (align 0.99→0.85, peak ≫ baseline 0.50) | **annihilation** — small dead subspace, healthy bulk above |
+| shared-complement low rank (r=6, dead≈10) | k=10 | **low effective rank** — shoulder only at large k |
+| real Gaussian | none (tracks baseline) | **nothing** |
+
+The **shoulder position is the dead-subspace dimension** — a small-k shoulder with a healthy bulk is
+annihilation; a large-k shoulder is low rank; a flat baseline is magnitude. This also dispenses with
+choosing `k`: 𝕊's "4" does not translate to width 512, and the datum becomes *is there a small-k shoulder*
+and *where*, not a preset `k`.
+
+## The target: LSTM / GRU / dense RNN — not S4/Mamba
+S4 and Mamba use a **diagonal** (or diagonal-plus-low-rank) state matrix for the associative scan: S4's
+`∂h_{t+1}/∂h_t = Ā` is the *same* matrix each step; Mamba's `Ā_t = exp(Δ_t A)` with `A` diagonal changes
+eigenvalues but **keeps eigenvectors**. So the singular subspaces coincide at every step and **alignment = 1
+by architecture, not learning** — the same circularity as the S-SSM, subtler. **Point at a dense RNN
+(LSTM/GRU):** input-dependent dense transition, per-step Jacobians genuinely distinct, nothing forcing
+alignment — and LSTM vanishing gradient is known but conceptually unresolved ("magnitude, or subspace
+death?"), so the question has real content and an unknown answer there. `lstm_probe.py` extracts the
+per-step state Jacobians `∂[h;c]_{t+1}/∂[h;c]_t` for `align_curve`.
+
+**Feedforward caveat:** for ResNet/transformer, `J_l = I + F'_l`; the residual anchors every layer in the
+same basis and inflates alignment by architecture — measure the **branches** `F'_l = J_l − I`, not the full
+`J_l`.
+
+## Final protocol
+1. `align(k)` as a curve — find the shoulder, not a value.
+2. Nulls as a distribution: rotating, shuffled, untrained-init, **and planted-low-rank** (the decisive one).
+3. Primary target: **dense RNN (LSTM/GRU)**. S4/Mamba **disqualified** (diagonal). S-SSM only as declared
+   positive control.
+4. `gap(T)` as a curve over hundreds of sequences (`∂h_T/∂h_0` depends on the whole path).
+5. The performance link last — does the shoulder predict a loss plateau, long-sequence degradation, or
+   specific unlearned examples? Only then is it a diagnostic, not a spectrum shape.
+
+Start with an LSTM trained on a long-dependency task, where vanishing gradient is known to operate — if
+subspace death exists anywhere, it is there. Harnesses `align_curve.py`, `lstm_probe.py`.

--- a/docs/research/align_curve.py
+++ b/docs/research/align_curve.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# align(k) as a CURVE — the shoulder distinguishes annihilation from low effective rank (OPUS-4.8-EXTRA).
+# Alignment ≈1 at one k is ambiguous: shared DEAD subspace (annihilation, small dead dim + healthy bulk) OR
+# low effective rank (large shared weak complement). Shuffled-weights & untrained-init nulls are full-rank
+# → they miss the low-rank confounder. The fix needs no new null: sweep k, and read the SHOULDER position.
+#   annihilation  : high for k ≤ m (small), DROPS for k > m — a shoulder at small k, healthy bulk above
+#   low eff. rank : high up to k = d − r (LARGE), shoulder only at large k
+#   nothing       : flat at the baseline √(k/d)
+# The shoulder POSITION is the datum (the dead-subspace dimension), not a chosen k.
+import numpy as np
+np.seterr(all='ignore')
+def cds(a,b,bits=4):
+    s=1
+    while bits>0:
+        if a==0 or b==0: return s
+        if bits==1: return -s
+        h=1<<(bits-1);ah=a>=h;bh=b>=h;al=a&(h-1);bl=b&(h-1)
+        if not ah and not bh:a,b=al,bl
+        elif not ah and bh:a,b=bl,al
+        elif ah and not bh:(a,b,s)=((al,0,s) if bl==0 else (al,bl,-s))
+        else:(a,b,s)=((0,al,-s) if bl==0 else (bl,al,s))
+        bits-=1
+    return s
+SIG=np.array([[cds(i,j) for j in range(16)] for i in range(16)]);M=np.zeros((16,16,16))
+for k in range(16):
+    for b in range(16): M[k,k^b,b]=SIG[k,b]
+def Lx(x): return np.tensordot(x,M,axes=(0,0))
+def normed(A): return A/np.linalg.svd(A,compute_uv=False)[0]
+rng=np.random.default_rng(1); D=12; dim=16
+def botV(A,k): return np.linalg.svd(A)[2][-k:]
+def align_curve(mats,ks):
+    out=[]
+    for k in ks:
+        cs=[np.linalg.svd(botV(mats[l],k)@botV(mats[l+1],k).T,compute_uv=False).mean() for l in range(len(mats)-1)]
+        out.append(np.mean(cs))
+    return np.array(out)
+# (1) genuine annihilation: aligned near-ZD sedenions — dead dim 4, healthy bulk 12
+z=np.zeros(16); z[1]=1; z[10]=1; z/=np.linalg.norm(z)
+def near(delta):
+    r=rng.standard_normal(16); r-=(r@z)*z; r/=np.linalg.norm(r); x=z+delta*r; return x/np.linalg.norm(x)
+sed=[normed(Lx(near(0.15))) for _ in range(D)]
+# (2) low effective rank: signal in r rotating dims, a SHARED dead complement Q_dead of dim d−r
+r=6; Qd=np.linalg.qr(rng.standard_normal((dim,dim)))[0][:,r:]     # shared dead subspace (dim 10)
+def lowrank():
+    Usig=np.linalg.qr(rng.standard_normal((dim,dim)))[0][:,:r]     # rotating signal dirs
+    Usig=Usig-Qd@(Qd.T@Usig); Usig=np.linalg.qr(Usig)[0][:,:r]     # orthogonal to the shared dead subspace
+    sig=np.diag(np.abs(rng.standard_normal(r))+0.5)
+    A=Usig@sig@Usig.T + 1e-4*Qd@rng.standard_normal((dim-r,dim))   # rank-r signal + tiny on Q_dead
+    return normed(A)
+low=[lowrank() for _ in range(D)]
+# (3) nothing: real Gaussian (full rank)
+gau=[normed(rng.standard_normal((16,16))) for _ in range(D)]
+ks=list(range(1,16))
+base=np.sqrt(np.array(ks)/dim)
+print("align(k) — mean cos(principal angle) of the bottom-k subspaces between consecutive Jacobians:")
+print(f"  {'k':>3} " + " ".join(f"{k:>4}" for k in ks))
+for name,mats in [('ANNIHILATION (dead≈4)',sed),('LOW-RANK (r=6, dead≈10)',low),('GAUSSIAN (nothing)',gau)]:
+    a=align_curve(mats,ks)
+    print(f"  {name:22s} " + " ".join(f"{v:4.2f}" for v in a))
+print(f"  {'baseline √(k/d)':22s} " + " ".join(f"{v:4.2f}" for v in base))
+# shoulder detection: largest drop in align(k) above baseline
+def shoulder(mats):
+    a=align_curve(mats,ks); excess=a-base; drop=excess[:-1]-excess[1:]; ki=int(np.argmax(drop))
+    return ks[ki], round(float(a[ki]),2), round(float(a[ki+1]),2)
+print("\nshoulder (k where align drops most, above baseline) — the dead-subspace dimension:")
+for name,mats in [('ANNIHILATION',sed),('LOW-RANK',low),('GAUSSIAN',gau)]:
+    k,hi,lo=shoulder(mats); print(f"  {name:14s}: shoulder at k={k}  (align {hi}→{lo})")
+print("\n→ a shoulder at SMALL k with a healthy bulk above = annihilation; shoulder only at LARGE k = low")
+print("  effective rank; no shoulder (flat on baseline) = nothing. The confounder is resolved by the CURVE.")

--- a/docs/research/lstm_probe.py
+++ b/docs/research/lstm_probe.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# LSTM probe (torch) — the target the corrected protocol points at. Dense, input-dependent transition, so
+# the per-step Jacobians are genuinely distinct and nothing forces alignment (unlike S4/Mamba, whose
+# diagonal Ā shares eigenvectors → alignment=1 by architecture; and unlike the S-SSM, whose L_x is 4/8/4 by
+# algebra). Vanishing gradient in LSTMs is known and conceptually unresolved: is it magnitude, or subspace
+# death? This measures which. Use align_curve (from align_curve.py) on the per-step state Jacobians and read
+# the SHOULDER position: small-k shoulder + healthy bulk = structural annihilation; large-k = low rank; none
+# = magnitude. Run over hundreds of sequences and report the distribution of the shoulder position.
+import numpy as np
+def lstm_step_jacobians(cell, x_seq, h0=None, c0=None):
+    """cell: torch.nn.LSTMCell. x_seq: (T, input_size) tensor. Returns list of per-step STATE Jacobians
+    J_t = ∂[h_{t+1};c_{t+1}] / ∂[h_t;c_t] (dim 2H×2H) at the realized inputs — the genuine factors of ∂h_T/∂h_0."""
+    import torch
+    H=cell.hidden_size; T=x_seq.shape[0]
+    h=torch.zeros(H) if h0 is None else h0; c=torch.zeros(H) if c0 is None else c0
+    Js=[]
+    for t in range(T):
+        st=torch.cat([h,c]).detach().requires_grad_(True)
+        def step(s):
+            hh,cc=s[:H],s[H:]; nh,nc=cell(x_seq[t].unsqueeze(0),(hh.unsqueeze(0),cc.unsqueeze(0)))
+            return torch.cat([nh.squeeze(0),nc.squeeze(0)])
+        J=torch.autograd.functional.jacobian(step, st, vectorize=True)
+        Js.append(J.detach().cpu().numpy())
+        with torch.no_grad(): out=step(st); h,c=out[:H],out[H:]
+    return Js
+# NOTE — residual caveat (§4): if you probe a ResNet/transformer instead, J_l = I + F'_l and the residual
+# anchors every layer in the same basis → alignment inflates by architecture. Measure the alignment of the
+# BRANCHES F'_l (= J_l − I), not the full J_l, or you are measuring the identity.
+if __name__=='__main__':
+    print("import lstm_step_jacobians, build/load a trained LSTMCell, run over many fixed sequences,")
+    print("feed the per-step Jacobians to align_curve(...) and record the SHOULDER position per sequence.")

--- a/docs/research/probe-corrected-protocol.md
+++ b/docs/research/probe-corrected-protocol.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-corrected-protocol
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.


### PR DESCRIPTION
Verdict recorded first: the product-spectrum **gap is dead** as a discriminant (the rotating control killed it, #1288); the **principal-angle alignment** survived. This closes the confounder the three nulls missed and corrects the target.

**Missing null — low effective rank.** align≈1 = shared dead subspace (annihilation) OR low effective rank (weak complement shared trivially). Shuffled-weights & untrained-init are both full-rank → they miss it.

**Fix (no new null): align(k) as a curve, read the shoulder** (`align_curve.py`, validated depth-12):
| stack | shoulder | reading |
|---|---|---|
| near-ZD sedenions (dead≈4) | **k=4** (0.99→0.85, ≫baseline 0.50) | annihilation |
| shared-complement low rank (r=6) | k=10 | low effective rank |
| real Gaussian | none | nothing |

The **shoulder position = dead-subspace dimension**; small-k shoulder + healthy bulk = annihilation. Also dispenses with choosing `k` (𝕊's "4" ≠ width 512).

**Target: dense RNN (LSTM/GRU) — NOT S4/Mamba.** Diagonal `Ā` shares eigenvectors → alignment=1 by architecture (circular, like S-SSM). Dense RNN has genuinely distinct per-step Jacobians; LSTM vanishing gradient is known but conceptually unresolved. `lstm_probe.py` extracts per-step `∂[h;c]_{t+1}/∂[h;c]_t`. **Residual caveat:** ResNet/transformer → measure branches `F'_l = J_l − I`, not `J_l`.

**Protocol:** align(k) curve → nulls incl. planted-low-rank → dense RNN primary → gap(T) over hundreds of sequences → performance link last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)