### PR TITLE
feat(stdlib): bigframe grouped first / last / nth (first&last beat pandas 4.5x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -63,6 +63,8 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rolling_median_by (1M rows, 1000 groups, window 100, sorted-window) | | ~336 | ~474 | **0.71x — Sounio wins** | counting-sort + per-region sorted window |
 | rolling_quantile_by (1M rows, 1000 groups, window 100, q=0.9) | | ~346 | ~484 | **0.72x — Sounio wins** | generalises median_by; interp at q*(w-1) |
 | nlargest_by / nsmallest_by (1M rows, 1000 groups, n=10) | | ~52 | ~335 | **0.15x — Sounio wins (6.5x)** | bounded top-n buffer vs pandas per-group sort |
+| first_by / last_by (1M rows, 1000 dense keys) | | ~3.3 | ~15 | **0.22x — Sounio wins (4.5x)** | dense direct-index, no hashing (keys 0..1023) |
+| nth_by(k) (1M rows, 1000 groups, k=2) | | ~45 | ~46 | **0.98x — parity/win** | counting-sort + positional pick, any key/any k |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -12,7 +12,7 @@
 // per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
 // rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
-// grouped nlargest / nsmallest.
+// grouped nlargest / nsmallest; grouped first / last / nth.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -3443,4 +3443,146 @@ pub fn bf_nlargest_by(src: &BigFrame, key_col: i64, val_col: i64, n: i64) -> Big
 /// with up to n rows per group. O(n_rows * n). NATIVE + lean_single only (heap).
 pub fn bf_nsmallest_by(src: &BigFrame, key_col: i64, val_col: i64, n: i64) -> BigFrame with Alloc, Mut, Div, Panic {
     bf_ntop_by(src, key_col, val_col, n, 0.0 - 1.0)
+}
+
+/// Per-group FIRST / LAST value (like pandas df.groupby(key)[val].first() / .last()):
+/// for each distinct `key_col`, the `val_col` at the earliest (keepfirst=1) / latest
+/// (keepfirst=0) row of that group in input order. DENSE integer keys 0..1023 only
+/// (direct-index accumulator, no hashing -- the same fast dense-key contract as
+/// bf_groupby_sum; keys outside [0,1024) are skipped). Returns [key, value] ascending by
+/// key. O(n), a single pass. NATIVE + lean_single only (heap for the output frame).
+fn bf_firstlast_by(src: &BigFrame, key_col: i64, val_col: i64, keepfirst: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var vals: [f64; 1024] = [0.0; 1024]
+    var seen: [i64; 1024] = [0; 1024]
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(2, 16)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    var i: i64 = 0
+    while i < nr {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            if seen[k] == 0 { seen[k] = 1; vals[k] = read_f64(vp, i) }
+            else { if keepfirst == 0 { vals[k] = read_f64(vp, i) } }
+        }
+        i = i + 1
+    }
+    var row: [f64; 64] = [0.0; 64]
+    var k2: i64 = 0
+    while k2 < 1024 {
+        if seen[k2] == 1 { row[0] = k2 as f64; row[1] = vals[k2]; bf_push_row(&!out, &row, 2) }
+        k2 = k2 + 1
+    }
+    out
+}
+
+/// Per-group FIRST value (pandas df.groupby(key)[val].first()): the val at the earliest
+/// row of each group. Dense integer keys 0..1023 (see bf_firstlast_by). Returns
+/// [key, value] ascending by key. NATIVE + lean_single only.
+pub fn bf_first_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_firstlast_by(src, key_col, val_col, 1)
+}
+
+/// Per-group LAST value (pandas df.groupby(key)[val].last()): the val at the latest row
+/// of each group. Dense integer keys 0..1023 (see bf_firstlast_by). Returns [key, value]
+/// ascending by key. NATIVE + lean_single only.
+pub fn bf_last_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_firstlast_by(src, key_col, val_col, 0)
+}
+
+/// Per-group NTH value (like pandas df.groupby(key)[val].nth(k)): for each distinct
+/// `key_col`, the `val_col` at position `k` within that group in input order. `k>=0`
+/// counts from the group start (0 = first); `k<0` counts from the end (-1 = last). A
+/// group with fewer than |k|+1 (for k>=0: k+1) elements is omitted. Handles ANY f64 key
+/// (unlike first/last). O(n) via factorize + counting-sort of row indices into contiguous
+/// per-group regions, then a direct positional pick. Returns [key, value] in first-seen
+/// group order. NATIVE + lean_single only (heap).
+pub fn bf_nth_by(src: &BigFrame, key_col: i64, val_col: i64, k: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(2, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hid = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let id = heap_alloc(nr * 8) as *mut i64
+    let sizes = heap_alloc(nr * 8) as *mut i64
+    var gcount: i64 = 0
+    var r: i64 = 0
+    while r < nr {
+        let kk = read_f64(kp, r)
+        var slot = bf_ghash(kk, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, kk)
+                write_f64(hid, slot, gcount as f64)
+                write_i64(id, r, gcount)
+                write_i64(sizes, gcount, 1)
+                gcount = gcount + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == kk {
+                    let g = read_f64(hid, slot) as i64
+                    write_i64(id, r, g)
+                    write_i64(sizes, g, read_i64(sizes, g) + 1)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        r = r + 1
+    }
+    let offsets = heap_alloc(nr * 8) as *mut i64
+    let cursor = heap_alloc(nr * 8) as *mut i64
+    var acc: i64 = 0
+    var g: i64 = 0
+    while g < gcount {
+        write_i64(offsets, g, acc)
+        write_i64(cursor, g, acc)
+        acc = acc + read_i64(sizes, g)
+        g = g + 1
+    }
+    let flat = heap_alloc(nr * 8) as *mut i64
+    r = 0
+    while r < nr {
+        let g2 = read_i64(id, r)
+        let p = read_i64(cursor, g2)
+        write_i64(flat, p, r)
+        write_i64(cursor, g2, p + 1)
+        r = r + 1
+    }
+    var out = bf_new(2, gcount)
+    g = 0
+    while g < gcount {
+        let base = read_i64(offsets, g)
+        let sz = read_i64(sizes, g)
+        var target = k
+        if k < 0 { target = sz + k }
+        if target >= 0 && target < sz {
+            let row = read_i64(flat, base + target)
+            var rw: [f64; 64] = [0.0; 64]
+            rw[0] = read_f64(kp, row)
+            rw[1] = read_f64(vp, row)
+            bf_push_row(&!out, &rw, 2)
+        }
+        g = g + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hid as *mut i8)
+    heap_free(id as *mut i8)
+    heap_free(sizes as *mut i8)
+    heap_free(offsets as *mut i8)
+    heap_free(cursor as *mut i8)
+    heap_free(flat as *mut i8)
+    out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -834,6 +834,30 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     // n >= group size returns the whole group sorted (10 per group -> 30 rows for n=100)
     let nlgall = bf_nlargest_by(&ntf, 0, 1, 100)
     if bf_nrows(&nlgall) != 30 { print("FAIL nlargest_all\n"); return 301 }
+    // GROUPED FIRST / LAST / NTH. 4 groups (key=r%4), val=r over 40 rows -> group g has rows
+    // g, g+4, ..., g+36 (10 rows). first=g, last=g+36; nth(2)=g+8; nth(-1)=last=g+36.
+    var flf = bf_new(2, 16)
+    var fli: i64 = 0
+    while fli < 40 { var flr:[f64;64]=[0.0;64]; flr[0]=(fli-4*(fli/4)) as f64; flr[1]=fli as f64; bf_push_row(&!flf,&flr,2); fli=fli+1 }
+    let fb = bf_first_by(&flf, 0, 1)
+    let lb = bf_last_by(&flf, 0, 1)
+    if bf_nrows(&fb) != 4 { print("FAIL first_n\n"); return 302 }
+    if lookup2(&fb, 0.0) != 0.0 || lookup2(&fb, 3.0) != 3.0 { print("FAIL first_val\n"); return 303 }   // first of group g = g
+    if lookup2(&lb, 0.0) != 36.0 || lookup2(&lb, 3.0) != 39.0 { print("FAIL last_val\n"); return 304 }  // last of group g = g+36
+    let n2 = bf_nth_by(&flf, 0, 1, 2)
+    if bf_nrows(&n2) != 4 { print("FAIL nth_n\n"); return 305 }
+    if lookup2(&n2, 0.0) != 8.0 || lookup2(&n2, 3.0) != 11.0 { print("FAIL nth2_val\n"); return 306 }    // nth(2) of group g = g+8
+    let nneg = bf_nth_by(&flf, 0, 1, 0 - 1)
+    if lookup2(&nneg, 0.0) != 36.0 || lookup2(&nneg, 2.0) != 38.0 { print("FAIL nthneg_val\n"); return 307 } // nth(-1)=last
+    // CROSS-CHECK: nth(0) values == first values; nth(-1) values == last values (per key).
+    let n0 = bf_nth_by(&flf, 0, 1, 0)
+    var fcd: i64 = 0; var fck: i64 = 0
+    while fck < 4 { if lookup2(&n0, fck as f64) != lookup2(&fb, fck as f64) { fcd = fcd + 1 }
+                    if lookup2(&nneg, fck as f64) != lookup2(&lb, fck as f64) { fcd = fcd + 1 } fck = fck + 1 }
+    if fcd != 0 { print("FAIL nth_vs_firstlast\n"); return 308 }
+    // nth beyond group size -> group omitted (each group has 10 rows; nth(10) -> 0 rows)
+    let nbig = bf_nth_by(&flf, 0, 1, 10)
+    if bf_nrows(&nbig) != 0 { print("FAIL nth_oob\n"); return 309 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_first_by`, `bf_last_by`, `bf_nth_by` in `data::bigframe_ops` — per-group positional selection like pandas `df.groupby(key)[val].first()` / `.last()` / `.nth(k)`.

- **first / last**: the val at the earliest / latest row of each group in input order, via a **dense direct-index accumulator** (keys 0..1023, no hashing — the same fast dense-key contract as `bf_groupby_sum`). Returns `[key, value]` ascending by key. One pass, O(n).
- **nth(k)**: the val at position `k` within each group (`k>=0` from the start, `k<0` from the end; a group shorter than needed is omitted). Handles **any f64 key** via factorize + counting-sort into per-group regions, then a positional pick. Returns `[key, value]` in first-seen group order.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 4 groups (`key=r%4`), `val=r` → first=g, last=g+36, nth(2)=g+8, nth(-1)=last;
- cross-check `nth(0)==first` and `nth(-1)==last` per key; nth beyond the group size → 0 rows.
- (offline) first/last matched pandas `.first()`/`.last()` and nth(0/2/−1) matched pandas `groupby.nth` over 14k rows / 7 groups.

## Benchmark (1M rows, 1000 groups)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| first_by / last_by | ~3.3 | ~15 | **0.22× — Sounio wins (4.5×)** |
| nth_by(2) | ~45 | ~46 | **0.98× — parity/win** |

first/last: the dense direct-index skips pandas' groupby machinery. nth: pandas `.nth` is heavier than `.first`, so the counting-sort reaches parity.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)