### PR TITLE
feat(probe): QR/Lyapunov spectrum (no numerical ceiling) + reposition as Lyapunov+CLV analysis + LSTM block control

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1060
-- Repo-backed topics: 910
+- Total governed topics: 1061
+- Repo-backed topics: 911
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 231
+- Authority count `historical`: 232
 - Authority count `repo_only`: 641
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 265 topics
+- A6: 266 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -752,6 +752,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.lorenz-i256-y-step-z0-bridge-2026-06-24 | historical | docs/research/lorenz-i256-y-step-z0-bridge-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.lorenz-i256-z-derivative-bounded-bridge-2026-06-24 | historical | docs/research/lorenz-i256-z-derivative-bounded-bridge-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.lorenz-i256-z-step-bounded-bridge-2026-06-24 | historical | docs/research/lorenz-i256-z-step-bounded-bridge-2026-06-24.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.lyapunov-repositioning | historical | docs/research/lyapunov-repositioning.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.m0-baseline-inventory | historical | docs/research/m0_baseline_inventory.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.m3-naturality-residual | historical | docs/research/m3_naturality_residual.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.m4-validation-framework | historical | docs/research/m4_validation_framework.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -16665,6 +16665,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.lyapunov-repositioning",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/lyapunov-repositioning.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.m0-baseline-inventory",
       "collection": "repo",
       "repo_doc_path": "docs/research/m0_baseline_inventory.md",

--- a/docs/research/lstm_probe.py
+++ b/docs/research/lstm_probe.py
@@ -29,3 +29,25 @@ def lstm_step_jacobians(cell, x_seq, h0=None, c0=None):
 if __name__=='__main__':
     print("import lstm_step_jacobians, build/load a trained LSTMCell, run over many fixed sequences,")
     print("feed the per-step Jacobians to align_curve(...) and record the SHOULDER position per sequence.")
+# closed system is (h,c) — compute the FULL Jacobians (lstm_step_jacobians), then report alignment BY BLOCK:
+#   h→h : dense — the only place subspace death can live; the signature is claimable ONLY here.
+#   c→c : diagonal by architecture (gates depend on h_{t-1},x_t, never on c_{t-1}) — a FREE internal
+#         positive control: it will read align≈1 trivially; if the FULL-state alignment matches c→c while
+#         h→h sits at the null, the alignment is entirely architectural, found in the same computation.
+import numpy as np
+def bottomV(A,k): return np.linalg.svd(A)[2][-k:]
+def align_curve_of(mats,ks,dim):
+    base=np.sqrt(np.array(ks)/dim); out=[]
+    for k in ks:
+        cs=[np.linalg.svd(bottomV(mats[l],k)@bottomV(mats[l+1],k).T,compute_uv=False).mean() for l in range(len(mats)-1)]
+        out.append(np.mean(cs))
+    return np.array(out), base
+def block_report(state_jacs, H, ks=None):
+    """state_jacs: list of (2H,2H) per-step Jacobians. Reports align(k) for the h→h block, the c→c block,
+    and the full state. c→c is the free positive control; the signature is claimable only in h→h."""
+    ks=ks or list(range(1,2*H))
+    hh=[J[:H,:H] for J in state_jacs]; cc=[J[H:,H:] for J in state_jacs]
+    ah,_=align_curve_of(hh,[k for k in ks if k<H],H)
+    ac,_=align_curve_of(cc,[k for k in ks if k<H],H)
+    af,_=align_curve_of(state_jacs,ks,2*H)
+    return dict(hh=ah, cc=ac, full=af)   # look for a SMALL-k shoulder in hh; cc≈1 is architectural

--- a/docs/research/lyapunov-repositioning.md
+++ b/docs/research/lyapunov-repositioning.md
@@ -1,0 +1,69 @@
+<!-- docs:meta
+topic_id: repo.docs.research.lyapunov-repositioning
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.lyapunov-repositioning
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The instrument is Lyapunov-spectrum + covariant-Lyapunov-vector analysis — position it, and fix the numerical ceiling
+
+*Four corrections (OPUS-4.8-EXTRA). The first removes a censorship that amputated the primary result; the
+second removes a citation gap that would make the whole thing read as rediscovery; the last two are minutes.
+The verdict from before stands and is recorded first: the product-spectrum gap is dead as a discriminant
+(the rotating control killed it); the principal-angle alignment survived.*
+
+## §1 (mandatory) — do not form the product; use discrete QR (`lyapunov_qr.py`)
+Forming `P_T = J_T…J_1` explicitly destroys the tail: the condition number passes machine epsilon and the
+small singular values stop being resolved, so `gap(T)` **censors at ~12–16 decades** — exactly where the
+signature should be strongest. The fix is the standard Lyapunov-spectrum algorithm: `Q_0=I`,
+`J_t Q_{t-1}=Q_t R_t`, `log σ_i(P_T) ≈ Σ_t log|R_t[i,i]|`, reorthonormalizing each step. Validated:
+
+| T | direct min log₁₀σ | **QR min log₁₀σ** | QR gap(σ4→σ5) |
+|---|---|---|---|
+| 16 | −16.7 (censored) | **−19.6** | 0.1 |
+| 64 | −16.8 (censored) | **−78.8** | 6.3 |
+| 256 | −19.5 (censored) | **−312.7** | 34.6 |
+
+The direct method saturates at machine epsilon; QR descends **linearly in T** (`log σ_i ≈ λ_i·T`), so the
+gap grows without a ceiling. Same cost (one QR per step), and the `Q_t` frames are the leading Oseledets
+directions the alignment needs — no SVD of the product.
+
+## §2 (mandatory) — this IS Lyapunov analysis; cite it or be read as rediscovery
+With §1 the object is explicit: `G(T) = α + βT` where **`β = λ_{m+1} − λ_m`, a Lyapunov-exponent
+difference** (measured slope on the aligned test stack: `β ≈ 0.146` decades/step). RNN Lyapunov spectra are
+established — **Engelken, Wolf & Abbott**; **Vogt et al.** (exponents ↔ trainability). And the
+subspace-alignment measure that survived the rotating control is essentially **covariant Lyapunov vectors**
+(**Ginelli et al.**) — the alignment of the Oseledets subspaces. So: the spectrum is not the novelty, and
+neither is the alignment per se. The only claimable contribution is the **specific gap structure** (a
+small-`k` shoulder with a healthy bulk, motivated by the algebra's `4/8/4`) and its interpretation — and
+even that must be **positioned against CLVs, not claimed fresh**. Without these citations the reviewer
+supplies them and the paper is a rediscovery.
+
+## §3 (minutes) — decompose the LSTM state, don't choose it (`lstm_probe.py: block_report`)
+The closed system is `(h,c)`; compute the full `P_T`, then report alignment **by block**. The `c→c` block
+is **diagonal by architecture** (gates depend on `h_{t-1},x_t`, never on `c_{t-1}`) — a **free internal
+positive control**: it reads `align≈1` trivially. The signature is claimable **only in the dense `h→h`
+block**. If the full-state alignment matches `c→c` while `h→h` sits at the null, the alignment is entirely
+architectural — discovered inside the same computation, no extra experiment.
+
+## §4 (already done) — sweep all m
+`align_curve.py` already sweeps `k = 1…d-1`; there was never an `m ≤ D/4` cut in this repo's version (that
+was inherited from the `4/16` sedenion ratio, which does not translate to LSTM width `H`). The shoulder
+position `m*/D` is whole data, not a chosen parameter.
+
+## Status — ready to run, positioned honestly
+The instrument now: (i) measures the spectrum by QR without a numerical ceiling, (ii) is positioned as
+Lyapunov-spectrum + CLV analysis with the contribution narrowed to the structural gap hypothesis, (iii)
+decomposes the LSTM state with a free positive control, (iv) sweeps all `m`. Primary target: a dense RNN
+(LSTM/GRU) trained on a long-dependency task; S4/Mamba disqualified (diagonal `Ā`); S-SSM as declared
+calibration. The next thing is not more method — it is a checkpoint and an afternoon of GPU. Five negatives
+have been worth more than any positive on this line; the sixth, or the first positive, is one run away, and
+only the data decides. Harnesses `lyapunov_qr.py`, `lstm_probe.py` (`lstm_step_jacobians`, `block_report`),
+`align_curve.py`.

--- a/docs/research/lyapunov_qr.py
+++ b/docs/research/lyapunov_qr.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Correction §1 (MANDATORY): do NOT form the product P_T (its condition number blows past machine epsilon,
+# the small σ stop being resolved, and gap(T) censors ~12–14 decades). Use the discrete-QR method — the
+# standard Lyapunov-spectrum algorithm: Q0=I; J_t Q_{t-1}=Q_t R_t; log σ_i(P_T) ≈ Σ_t log|R_t[i,i]|.
+# Reorthonormalize each step → essentially unlimited dynamic range at the same cost, and the Q_t frames are
+# the leading Oseledets directions (covariant Lyapunov vectors; Ginelli et al.) that the alignment needs —
+# no SVD of the product. This whole instrument IS Lyapunov-spectrum + CLV analysis of RNNs (Engelken/Wolf/
+# Abbott; Vogt et al.); position, don't claim.
+import numpy as np
+np.seterr(all='ignore')
+def cds(a,b,bits=4):
+    s=1
+    while bits>0:
+        if a==0 or b==0: return s
+        if bits==1: return -s
+        h=1<<(bits-1);ah=a>=h;bh=b>=h;al=a&(h-1);bl=b&(h-1)
+        if not ah and not bh:a,b=al,bl
+        elif not ah and bh:a,b=bl,al
+        elif ah and not bh:(a,b,s)=((al,0,s) if bl==0 else (al,bl,-s))
+        else:(a,b,s)=((0,al,-s) if bl==0 else (bl,al,s))
+        bits-=1
+    return s
+SIG=np.array([[cds(i,j) for j in range(16)] for i in range(16)]);M=np.zeros((16,16,16))
+for k in range(16):
+    for b in range(16): M[k,k^b,b]=SIG[k,b]
+def Lx(x): return np.tensordot(x,M,axes=(0,0))
+def normed(A): return A/np.linalg.svd(A,compute_uv=False)[0]
+def qr_logspectrum(Jlist):
+    """log10 σ_i(P_T) via discrete QR, WITHOUT forming P_T. Returns (log-σ descending, list of Q frames)."""
+    n=Jlist[0].shape[0]; Q=np.eye(n); logs=np.zeros(n); Qs=[Q.copy()]
+    for J in Jlist:
+        A=J@Q; Q,R=np.linalg.qr(A); d=np.diag(R); sgn=np.sign(d); sgn[sgn==0]=1
+        Q=Q*sgn; logs+=np.log10(np.abs(d)+1e-300); Qs.append(Q.copy())
+    idx=np.argsort(logs)[::-1]; return logs[idx], Qs
+def direct_logspectrum(Jlist):
+    P=np.eye(Jlist[0].shape[0])
+    for J in Jlist: P=J@P
+    return np.log10(np.sort(np.linalg.svd(P,compute_uv=False))[::-1]+1e-300)
+rng=np.random.default_rng(1); z=np.zeros(16); z[1]=1; z[10]=1; z/=np.linalg.norm(z)
+def near(delta):
+    r=rng.standard_normal(16); r-=(r@z)*z; r/=np.linalg.norm(r); x=z+delta*r; return x/np.linalg.norm(x)
+big=[normed(Lx(near(0.15))) for _ in range(256)]
+print("min log10 σ(P_T) — DIRECT product (censored at machine eps) vs QR method (uncensored):")
+print(f"  {'T':>4} | {'direct min-logσ':>16} | {'QR min-logσ':>12} | {'QR gap(σ4→σ5) dec':>18}")
+for T in [8,16,32,64,128,256]:
+    dl=direct_logspectrum(big[:T]); ql,_=qr_logspectrum(big[:T])
+    gap=ql[3]-ql[4]                      # the 4→5 gap (the algebra's low-mult boundary), in decades
+    print(f"  {T:>4} | {dl.min():16.1f} | {ql.min():12.1f} | {gap:18.1f}")
+print("\n→ direct saturates near −14 (machine epsilon); QR keeps descending linearly in T (log σ_i ≈ λ_i·T),")
+print("  so the gap grows without a numerical ceiling. β = λ_4 − λ_5 (a Lyapunov-exponent difference) is the")
+print("  slope, read cleanly at any depth. G(T)=α+βT is the signature; the ceiling was censoring it.")
+# β (Lyapunov exponent gap) from a linear fit of gap(T)
+Ts=np.array([16,32,64,128,256]); gaps=[]
+for T in Ts:
+    ql,_=qr_logspectrum(big[:T]); gaps.append(ql[3]-ql[4])
+beta=np.polyfit(Ts,gaps,1)[0]
+print(f"\nβ = λ_4 − λ_5 (slope of gap(T)) = {beta:.4f} decades/step  (nonzero ⇒ a persistent spectral gap; the")
+print("  covariant-Lyapunov-vector alignment of the two Oseledets subspaces is the mechanism, not the gap).")


### PR DESCRIPTION
Four corrections (OPUS-4.8-EXTRA). First fixes a censorship that amputated the primary result; second fixes a citation gap that would make it read as rediscovery.

**§1 (mandatory) — QR, don't form the product** (`lyapunov_qr.py`). Forming `P_T` blows the condition number past machine-eps → `gap(T)` censors at ~16 decades. Discrete-QR Lyapunov method (`Q_0=I; J_tQ_{t-1}=Q_tR_t; log σ_i≈Σ log|R_t[i,i]|`) removes it:
| T | direct min-logσ | QR min-logσ |
|---|---|---|
| 16 | −16.7 (censored) | −19.6 |
| 64 | −16.8 | −78.8 |
| 256 | −19.5 | −312.7 |
Linear in T (`log σ_i≈λ_i·T`), same cost, and the `Q_t` frames are the Oseledets directions the alignment needs.

**§2 (mandatory) — position, don't claim.** This IS **Lyapunov-spectrum** analysis (Engelken/Wolf/Abbott; Vogt): `G(T)=α+βT`, `β=λ_{m+1}−λ_m` (measured ≈0.146 dec/step). The alignment measure IS **covariant Lyapunov vectors** (Ginelli). Spectrum & alignment are not novel; only the **structural gap hypothesis** (small-k shoulder + healthy bulk from `4/8/4`) is, positioned vs CLVs.

**§3 (minutes) — LSTM block control** (`block_report`): `c→c` is diagonal by architecture = **free positive control**; the signature is claimable **only in dense `h→h`**. If full-state alignment matches `c→c` while `h→h` is at the null, it is architectural — found in the same computation.

**§4 — already done:** `align_curve.py` sweeps all `k` (no `D/4` cut; that was the sedenion `4/16` residue).

Ready to run — needs a checkpoint, not more method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)