### PR TITLE
feat(stdlib): bigframe grouped cumulative min / max (beat pandas 0.59x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -67,6 +67,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | nth_by(k) (1M rows, 1000 groups, k=2) | | ~45 | ~46 | **0.98x — parity/win** | counting-sort + positional pick, any key/any k |
 | transform_mean/sum/min/max/count_by (1M rows, 1000 dense keys) | | ~10 | ~23 | **0.43x — Sounio wins (2.3x)** | dense direct-index broadcast, no hashing |
 | transform_std_by (1M rows, 1000 dense keys) | | ~18 | ~20 | **0.93x — Sounio wins** | two-pass exact Σ(x-mean)² + bf_sqrt |
+| cummax_by / cummin_by (1M rows, 1000 dense keys) | | ~11 | ~19 | **0.59x — Sounio wins** | dense direct-index running extreme, row-aligned |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -12,7 +12,8 @@
 // per-group distinct-count (nunique), per-group idxmax / idxmin, per-group mode,
 // rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
-// grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast).
+// grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
+// grouped cumulative min / max.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -3694,4 +3695,52 @@ pub fn bf_transform_count_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigF
 /// 0..1023. NATIVE + lean_single only.
 pub fn bf_transform_std_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
     bf_transform_by(src, key_col, val_col, 5)
+}
+
+/// Per-group cumulative min/max engine shared by bf_cummin_by / bf_cummax_by: a
+/// row-aligned running extreme WITHIN each key_col group (like pandas
+/// df.groupby(key)[val].cummin() / .cummax()): out[i] = min/max of val over the rows of
+/// row i's group up to and including i. ismax=1 -> cummax, 0 -> cummin. DENSE integer keys
+/// 0..1023 only (direct-index running array, no hashing -- the same fast dense-key
+/// contract as bf_groupby_sum; a row whose key is outside [0,1024) gets its own value).
+/// O(n), a single pass. Returns a 1-column BigFrame of length n. NATIVE + lean_single only.
+fn bf_cumextrema_by(src: &BigFrame, key_col: i64, val_col: i64, ismax: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var run: [f64; 1024] = [0.0; 1024]
+    var seen: [i64; 1024] = [0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 {
+            if seen[k] == 0 { seen[k] = 1; run[k] = v }
+            else { if ismax == 1 { if v > run[k] { run[k] = v } } else { if v < run[k] { run[k] = v } } }
+            write_f64(op, i, run[k])
+        } else {
+            write_f64(op, i, v)
+        }
+        i = i + 1
+    }
+    out
+}
+
+/// Per-group cumulative MAXIMUM (pandas df.groupby(key)[val].cummax()): out[i] = the max
+/// of val over row i's group up to and including i, row-aligned. Dense integer keys
+/// 0..1023 (see bf_cumextrema_by). NATIVE + lean_single only.
+pub fn bf_cummax_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_cumextrema_by(src, key_col, val_col, 1)
+}
+
+/// Per-group cumulative MINIMUM (pandas df.groupby(key)[val].cummin()): out[i] = the min
+/// of val over row i's group up to and including i, row-aligned. Dense integer keys
+/// 0..1023 (see bf_cumextrema_by). NATIVE + lean_single only.
+pub fn bf_cummin_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_cumextrema_by(src, key_col, val_col, 0)
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -883,6 +883,26 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     // so group std ~ 12.1106. all rows same.
     if !approx_eq(bf_get(&tsd, 0, 0), bf_get(&tsd, 4, 0)) { print("FAIL tstd_uniform\n"); return 320 }
     if bf_get(&tsd, 0, 0) < 12.0 || bf_get(&tsd, 0, 0) > 12.2 { print("FAIL tstd_val\n"); return 321 }
+    // GROUPED CUMULATIVE MIN / MAX. 2 groups (key=r%2). val for group 0 (even rows) descends
+    // 100,99,98,...; group 1 (odd rows) ascends 0,1,2,... -> cummin group0 keeps dropping,
+    // cummax group0 stays 100; cummax group1 keeps rising, cummin group1 stays 0.
+    var cef = bf_new(2, 16)
+    var cei: i64 = 0
+    while cei < 200 { var cer:[f64;64]=[0.0;64]; cer[0]=(cei%2) as f64
+        if cei%2==0 { cer[1]=(100 - cei/2) as f64 } else { cer[1]=(cei/2) as f64 }
+        bf_push_row(&!cef,&cer,2); cei=cei+1 }
+    let cmx = bf_cummax_by(&cef, 0, 1)
+    let cmn = bf_cummin_by(&cef, 0, 1)
+    if bf_nrows(&cmx) != 200 { print("FAIL cumext_n\n"); return 322 }               // row-aligned
+    // group 0 rows are even indices; occurrence j (row 2j) has val 100-j.
+    if bf_get(&cmx, 0, 0) != 100.0 { print("FAIL cmx_g0_first\n"); return 323 }      // max so far = 100
+    if bf_get(&cmx, 20, 0) != 100.0 { print("FAIL cmx_g0_stay\n"); return 324 }      // still 100 (descending vals)
+    if bf_get(&cmn, 0, 0) != 100.0 { print("FAIL cmn_g0_first\n"); return 325 }      // min so far = 100
+    if bf_get(&cmn, 20, 0) != 90.0 { print("FAIL cmn_g0_drop\n"); return 326 }       // row 20 = occ 10 -> val 90, min so far 90
+    // group 1 rows are odd indices; occurrence j (row 2j+1) has val j.
+    if bf_get(&cmn, 1, 0) != 0.0 { print("FAIL cmn_g1_first\n"); return 327 }        // min = 0
+    if bf_get(&cmn, 21, 0) != 0.0 { print("FAIL cmn_g1_stay\n"); return 328 }        // still 0 (ascending)
+    if bf_get(&cmx, 21, 0) != 10.0 { print("FAIL cmx_g1_rise\n"); return 329 }       // row 21 = occ 10 -> val 10, max 10
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_cummax_by` / `bf_cummin_by` in `data::bigframe_ops` — a **row-aligned running extreme within each `key_col` group** (pandas `df.groupby(key)[val].cummax()` / `.cummin()`): `out[i]` = the max/min of val over the rows of row i's group up to and including i.

Shared engine `bf_cumextrema_by(ismax)`: a **dense direct-index** running array over keys 0..1023 (no hashing — same fast dense-key contract as `bf_groupby_sum`). One pass, O(n). This wins where the older hash-based `bf_cumsum_by` loses: for a cheap row-aligned cumulative, the per-row hash probe is the whole cost, and the dense direct-index skips it entirely.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups (`key=r%2`) — group 0 vals descend 100,99,98,…, group 1 vals ascend 0,1,2,… → cummax group 0 stays 100, cummin group 0 drops (row 20 → 90); cummin group 1 stays 0, cummax group 1 rises (row 21 → 10).
- (offline) cummax and cummin matched pandas `groupby` cummax/cummin over **30k rows / 100 groups = 0 diffs**.

## Benchmark (1M rows, 1000 dense keys)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| cummax_by / cummin_by | ~11 | ~19 | **0.59× — Sounio wins** |

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)