### PR TITLE
docs(probe): THE RUN — no subspace death; the instrument caught its own false positive (6th negative)

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1062
-- Repo-backed topics: 912
+- Total governed topics: 1063
+- Repo-backed topics: 913
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 233
+- Authority count `historical`: 234
 - Authority count `repo_only`: 641
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 267 topics
+- A6: 268 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -786,6 +786,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.primitive-zd-gap-resolution | historical | docs/research/PRIMITIVE_ZD_GAP_RESOLUTION.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.private-evidence-envelope-2026-06-23 | historical | docs/research/private-evidence-envelope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-corrected-protocol | historical | docs/research/probe-corrected-protocol.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.probe-result-lstm-adding | historical | docs/research/PROBE-RESULT-lstm-adding.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-usage | historical | docs/research/probe-usage.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.proof-checker-family-matrix-2026-06-23 | historical | docs/research/proof-checker-family-matrix-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.proof-checker-microkernel-suite-2026-06-23 | historical | docs/research/proof-checker-microkernel-suite-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17413,6 +17413,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.probe-result-lstm-adding",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/PROBE-RESULT-lstm-adding.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.probe-usage",
       "collection": "repo",
       "repo_doc_path": "docs/research/probe-usage.md",

--- a/docs/research/PROBE-RESULT-lstm-adding.md
+++ b/docs/research/PROBE-RESULT-lstm-adding.md
@@ -1,0 +1,57 @@
+<!-- docs:meta
+topic_id: repo.docs.research.probe-result-lstm-adding
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-result-lstm-adding
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The run: no subspace death — the corrected instrument caught its own false positive (the 6th negative)
+
+*The probe was run end-to-end on an LSTM trained (to MSE 8e-4, chance 0.17) on the adding problem. The
+naive readout said SUBSPACE DEATH with Cohen d = 56. The full controls demolish it. This is the payoff of
+the whole methodological line: the corrected instrument reads a negative that the incomplete instrument
+would have shipped as a discovery.*
+
+## The false positive, and what killed it
+Naive probe (orientation-scramble null, single frozen `m†=4`): trained h→h alignment `0.92` vs scramble
+null `0.27`, **Cohen d = +56** → "SUBSPACE DEATH". Then the three mandatory controls (`run_probe_full.py`):
+
+`align(k)` (baseline `√(k/H)`), averaged over 40 sequences, H=40:
+| k | 1 | 2 | 3 | 4 | 6 | 8 | 12 |
+|---|---|---|---|---|---|---|---|
+| baseline | 0.16 | 0.22 | 0.27 | 0.32 | 0.39 | 0.45 | 0.55 |
+| **trained h→h** | 0.76 | 0.84 | 0.90 | 0.92 | 0.95 | 0.96 | **0.97** |
+| trained c→c | 0.51 | 0.92 | 0.83 | 0.79 | 0.81 | 0.84 | 0.88 |
+| **init h→h** | 0.99 | 0.96 | 0.94 | **1.00** | 1.00 | 1.00 | 1.00 |
+
+- **(i) shape = LOW EFFECTIVE RANK, not annihilation.** Trained h→h stays high (`0.9→0.97`) all the way to
+  `k=12`, never falling toward the baseline (`0.55`). Annihilation would peak at small `k` then drop to a
+  healthy bulk; this does not. The earlier `m†=4` "shoulder" was spurious — the max-drop of a flat-high
+  curve. **This is exactly the confounder the `align(k)` curve was built to catch.**
+- **(iii) it is already at init — the decisive control FAILS.** The *untrained* net's h→h alignment is
+  `0.99–1.00`, **higher than the trained `0.92`**. The alignment is **architectural** (present in a random
+  LSTM); training did not create it, if anything it slightly reduced it.
+- (ii) trained h→h `0.92` > c→c `0.79` — passes marginally, moot given (i) and (iii).
+
+## Verdict
+**No structural subspace death.** The trained LSTM's h→h Jacobian alignment on this task is low effective
+rank plus architecture — not the sedenion-predicted small-`k` shoulder with a healthy bulk. The vanishing
+gradient here is (as classical theory holds) magnitude/rank, not annihilation. The **orientation-scramble
+null alone is insufficient** — it only asks "is there *any* shared subspace", which low rank and
+architecture pass trivially; the **`align(k)` curve and the untrained-init control** are what discriminate,
+and they say no.
+
+## Why this is the result, not a disappointment
+The incomplete instrument (scramble null, single `m†`) reported `d=56` SUBSPACE DEATH — a false positive it
+would have shipped. The **corrected** instrument, with the two controls added under the eleven critiques
+(the full curve; the init control), **caught it.** That is the entire value of the line: an instrument that
+reads its own negatives. The sixth negative is worth more than the false positive would have been. And the
+honest standing conclusion holds — the algebra is good geometry of 𝕊 (conatus, per the Spinoza reading);
+the *training* signature it predicts is, on this target, absent. Harness `run_probe_full.py`.

--- a/docs/research/run_probe_full.py
+++ b/docs/research/run_probe_full.py
@@ -1,0 +1,32 @@
+# Stress-test the d=56 positive: the full align(k) curve + the c→c control + the untrained-init control.
+# A genuine LEARNED subspace-death claim needs ALL of: (i) h→h shoulder at SMALL k with a healthy bulk above
+# (annihilation shape, not the large-k rise of low rank); (ii) h→h alignment >> the c→c diagonal block
+# (architectural free control); (iii) trained h→h >> untrained-init h→h (learning, not architecture).
+import importlib.util as u, numpy as np, torch
+spec=u.spec_from_file_location("m","train_and_probe_lstm.py"); m=u.module_from_spec(spec); spec.loader.exec_module(m)
+dev='cpu'
+def curves(net, n_seq=40, T=30, seed=1):
+    H=net.H; ks=list(range(1,H)); base=np.sqrt(np.array(ks)/H)
+    HH=[]; CC=[]
+    for s in range(n_seq):
+        X,_=m.gen_adding(1,T,np.random.default_rng(30000+s)); Xt=torch.tensor(X[0],device=dev)
+        J=m.state_jacobians(net,Xt,dev)
+        hh=[j[:H,:H] for j in J]; cc=[j[H:,H:] for j in J]
+        ah,_=m.align_curve(hh,ks); ac,_=m.align_curve(cc,ks); HH.append(ah); CC.append(ac)
+    return ks,base,np.array(HH).mean(0),np.array(CC).mean(0)
+print("training…",flush=True); net=m.train(H=40,T=30,steps=2500,dev=dev)
+print("untrained control net…",flush=True); net0=m.Net(40).to(dev)
+ks,base,hh,cc=curves(net); _,_,hh0,cc0=curves(net0)
+sh=lambda a: ks[int(np.argmax((a-base)[:-1]-(a-base)[1:]))]
+print("\nalign(k), k=1..12   (baseline √(k/H)):")
+print("  k        " + " ".join(f"{k:>5}" for k in ks[:12]))
+print("  baseline " + " ".join(f"{v:5.2f}" for v in base[:12]))
+print("  TRAINED h→h " + " ".join(f"{v:5.2f}" for v in hh[:12]) + f"   shoulder k={sh(hh)}")
+print("  TRAINED c→c " + " ".join(f"{v:5.2f}" for v in cc[:12]) + f"   (diagonal architectural control)")
+print("  INIT   h→h  " + " ".join(f"{v:5.2f}" for v in hh0[:12]) + f"   shoulder k={sh(hh0)}")
+print("  INIT   c→c  " + " ".join(f"{v:5.2f}" for v in cc0[:12]))
+print(f"\nverdict checks:")
+print(f"  (i)  trained h→h shoulder at small k with healthy bulk?  shoulder k={sh(hh)}, align@4={hh[3]:.2f}, align@12={hh[11]:.2f} (bulk should fall toward baseline {base[11]:.2f})")
+print(f"  (ii) trained h→h >> c→c at k=4?   h→h {hh[3]:.2f}  vs  c→c {cc[3]:.2f}   {'PASS' if hh[3]-cc[3]>0.1 else 'FAIL — c→c is also aligned (architectural)'}")
+print(f"  (iii) trained h→h >> untrained-init h→h at k=4?   trained {hh[3]:.2f}  vs  init {hh0[3]:.2f}   {'PASS (learned)' if hh[3]-hh0[3]>0.1 else 'FAIL — already present at init (architecture, not learning)'}")
+print("DONE",flush=True)

--- a/docs/research/train-and-probe-usage.md
+++ b/docs/research/train-and-probe-usage.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.train-and-probe-usage
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.


### PR DESCRIPTION
Ran the probe end-to-end on an LSTM trained on the adding problem (MSE 8e-4). Naive readout (orientation-scramble null, single m†): trained h→h align 0.92 vs null 0.27 = **Cohen d +56** = 'SUBSPACE DEATH'. The three mandatory controls demolish it: **(i)** align(k) stays high to k=12 (0.9→0.97, never →baseline 0.55) = **low-rank shape, not annihilation** (the m†=4 shoulder was spurious); **(iii)** untrained-init h→h = 0.99–1.00, **higher than trained 0.92** → **architectural, not learned** (decisive control FAILS); (ii) h→h>c→c marginal, moot. **Verdict: no structural subspace death** — magnitude/rank+architecture, exactly what the orientation-scramble null alone can't rule out and the align(k) curve + init control catch. The corrected instrument caught a false positive the naive version would have shipped — the payoff of the whole line. 🤖 Generated with [Claude Code](https://claude.com/claude-code)