### PR TITLE
feat(stdlib): bigframe grouped rank (all 4 methods; sort-bound ~1.9x loss, honest)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -68,6 +68,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | transform_mean/sum/min/max/count_by (1M rows, 1000 dense keys) | | ~10 | ~23 | **0.43x — Sounio wins (2.3x)** | dense direct-index broadcast, no hashing |
 | transform_std_by (1M rows, 1000 dense keys) | | ~18 | ~20 | **0.93x — Sounio wins** | two-pass exact Σ(x-mean)² + bf_sqrt |
 | cummax_by / cummin_by (1M rows, 1000 dense keys) | | ~11 | ~19 | **0.59x — Sounio wins** | dense direct-index running extreme, row-aligned |
+| rank_by (1M rows, 1000 groups, average) | | ~130 | ~68 | **~1.9x — loss (sort-bound)** | per-region mergesort vs pandas Cython group-rank; C3 radix-sort would close it |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -13,7 +13,7 @@
 // rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
-// grouped cumulative min / max.
+// grouped cumulative min / max; grouped rank.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -3794,4 +3794,156 @@ pub fn bf_cummax_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with
 /// 0..1023 (see bf_cumextrema_by). NATIVE + lean_single only.
 pub fn bf_cummin_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
     bf_cumextrema_by(src, key_col, val_col, 0)
+}
+
+/// Per-group RANK of `val_col`, ascending, 1-based within each `key_col` group (like
+/// pandas df.groupby(key)[val].rank(method=...)): out[i] = the rank of row i's value
+/// among its group. `method`: 0 = average (default -- ties share the mean of their
+/// positions), 1 = min, 2 = max, 3 = dense. Handles ANY f64 key. O(n + Σ sz·log sz):
+/// an O(n) factorize + counting-sort of row indices into contiguous per-group regions
+/// (with each region's values gathered in the same pass), then a LOCAL bottom-up
+/// stable mergesort per region and one tie-run pass assigning ranks. (Sort-bound: this
+/// trails pandas' specialised Cython group-rank by ~2x; a compiler radix-sort / SIMD
+/// path -- the same C3 dispatch as ungrouped sort/quantile -- would close it. The
+/// ordinal `first` method is intentionally omitted, as in bf_rank.) Returns a 1-column
+/// f64 BigFrame aligned to input rows. NATIVE + lean_single only (heap).
+pub fn bf_rank_by(src: &BigFrame, key_col: i64, val_col: i64, method: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(1, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hid = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let id = heap_alloc(nr * 8) as *mut i64
+    let sizes = heap_alloc(nr * 8) as *mut i64
+    var gcount: i64 = 0
+    var r: i64 = 0
+    while r < nr {
+        let k = read_f64(kp, r)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hid, slot, gcount as f64)
+                write_i64(id, r, gcount)
+                write_i64(sizes, gcount, 1)
+                gcount = gcount + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    let g = read_f64(hid, slot) as i64
+                    write_i64(id, r, g)
+                    write_i64(sizes, g, read_i64(sizes, g) + 1)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        r = r + 1
+    }
+    let offsets = heap_alloc(nr * 8) as *mut i64
+    let cursor = heap_alloc(nr * 8) as *mut i64
+    var acc: i64 = 0
+    var g: i64 = 0
+    while g < gcount {
+        write_i64(offsets, g, acc)
+        write_i64(cursor, g, acc)
+        acc = acc + read_i64(sizes, g)
+        g = g + 1
+    }
+    let flat = heap_alloc(nr * 8) as *mut i64
+    let fval = heap_alloc(nr * 8) as *mut f64   // group-ordered values (gathered sequentially here)
+    r = 0
+    while r < nr {
+        let g2 = read_i64(id, r)
+        let p = read_i64(cursor, g2)
+        write_i64(flat, p, r)
+        write_f64(fval, p, read_f64(vp, r))
+        write_i64(cursor, g2, p + 1)
+        r = r + 1
+    }
+    let va = heap_alloc(nr * 8) as *mut f64      // per-region sort buffers, ping-pong a<->b
+    let vb = heap_alloc(nr * 8) as *mut f64
+    let ia = heap_alloc(nr * 8) as *mut i64
+    let ib = heap_alloc(nr * 8) as *mut i64
+    var out = bf_new(1, nr)
+    out.n_rows = nr
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    g = 0
+    while g < gcount {
+        let base = read_i64(offsets, g)
+        let sz = read_i64(sizes, g)
+        var j: i64 = 0
+        while j < sz { write_f64(va, base + j, read_f64(fval, base + j)); write_i64(ia, base + j, read_i64(flat, base + j)); j = j + 1 }
+        var curV = va
+        var curI = ia
+        var dstV = vb
+        var dstI = ib
+        var width: i64 = 1
+        while width < sz {
+            var lo: i64 = 0
+            while lo < sz {
+                var mid = lo + width
+                if mid > sz { mid = sz }
+                var hi = lo + width + width
+                if hi > sz { hi = sz }
+                var a = base + lo
+                var b = base + mid
+                let amax = base + mid
+                let bmax = base + hi
+                var k = base + lo
+                while a < amax && b < bmax {
+                    let x = read_f64(curV, a)
+                    let y = read_f64(curV, b)
+                    if x <= y { write_f64(dstV, k, x); write_i64(dstI, k, read_i64(curI, a)); a = a + 1 }
+                    else { write_f64(dstV, k, y); write_i64(dstI, k, read_i64(curI, b)); b = b + 1 }
+                    k = k + 1
+                }
+                while a < amax { write_f64(dstV, k, read_f64(curV, a)); write_i64(dstI, k, read_i64(curI, a)); a = a + 1; k = k + 1 }
+                while b < bmax { write_f64(dstV, k, read_f64(curV, b)); write_i64(dstI, k, read_i64(curI, b)); b = b + 1; k = k + 1 }
+                lo = lo + width + width
+            }
+            let tv = curV; curV = dstV; dstV = tv
+            let ti = curI; curI = dstI; dstI = ti
+            width = width + width
+        }
+        var dense: f64 = 0.0
+        var q: i64 = 0
+        while q < sz {
+            var e = q
+            while e + 1 < sz && read_f64(curV, base + e + 1) == read_f64(curV, base + q) { e = e + 1 }
+            dense = dense + 1.0
+            let minr = (q + 1) as f64
+            let maxr = (e + 1) as f64
+            var rr = 0.0
+            if method == 1 { rr = minr }
+            else { if method == 2 { rr = maxr } else { if method == 3 { rr = dense } else { rr = (minr + maxr) / 2.0 } } }
+            var t = q
+            while t <= e { write_f64(op, read_i64(curI, base + t), rr); t = t + 1 }
+            q = e + 1
+        }
+        g = g + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hid as *mut i8)
+    heap_free(id as *mut i8)
+    heap_free(sizes as *mut i8)
+    heap_free(offsets as *mut i8)
+    heap_free(cursor as *mut i8)
+    heap_free(flat as *mut i8)
+    heap_free(fval as *mut i8)
+    heap_free(va as *mut i8)
+    heap_free(vb as *mut i8)
+    heap_free(ia as *mut i8)
+    heap_free(ib as *mut i8)
+    out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -917,6 +917,39 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if bf_get(&cmn, 1, 0) != 0.0 { print("FAIL cmn_g1_first\n"); return 327 }        // min = 0
     if bf_get(&cmn, 21, 0) != 0.0 { print("FAIL cmn_g1_stay\n"); return 328 }        // still 0 (ascending)
     if bf_get(&cmx, 21, 0) != 10.0 { print("FAIL cmx_g1_rise\n"); return 329 }       // row 21 = occ 10 -> val 10, max 10
+    // GROUPED RANK. 2 groups (key=r%2). group 0 rows {0,2,4} vals {10,30,20} -> ranks
+    // 10->1,20->2,30->3 (row0=1,row4=2,row2=3). group 1 rows {1,3,5} vals {5,5,8}: tie at 5.
+    var rkf = bf_new(2, 16)
+    var rkr0:[f64;64]=[0.0;64]; rkr0[0]=0.0; rkr0[1]=10.0; bf_push_row(&!rkf,&rkr0,2)
+    var rkr1:[f64;64]=[0.0;64]; rkr1[0]=1.0; rkr1[1]=5.0;  bf_push_row(&!rkf,&rkr1,2)
+    var rkr2:[f64;64]=[0.0;64]; rkr2[0]=0.0; rkr2[1]=30.0; bf_push_row(&!rkf,&rkr2,2)
+    var rkr3:[f64;64]=[0.0;64]; rkr3[0]=1.0; rkr3[1]=5.0;  bf_push_row(&!rkf,&rkr3,2)
+    var rkr4:[f64;64]=[0.0;64]; rkr4[0]=0.0; rkr4[1]=20.0; bf_push_row(&!rkf,&rkr4,2)
+    var rkr5:[f64;64]=[0.0;64]; rkr5[0]=1.0; rkr5[1]=8.0;  bf_push_row(&!rkf,&rkr5,2)
+    let rav = bf_rank_by(&rkf, 0, 1, 0)   // average
+    if bf_nrows(&rav) != 6 { print("FAIL rank_n\n"); return 330 }
+    if bf_get(&rav, 0, 0) != 1.0 || bf_get(&rav, 4, 0) != 2.0 || bf_get(&rav, 2, 0) != 3.0 { print("FAIL rank_g0\n"); return 331 }
+    if !approx_eq(bf_get(&rav, 1, 0), 1.5) || !approx_eq(bf_get(&rav, 3, 0), 1.5) { print("FAIL rank_avg_tie\n"); return 332 } // two 5s
+    if bf_get(&rav, 5, 0) != 3.0 { print("FAIL rank_avg_top\n"); return 333 }
+    let rmin = bf_rank_by(&rkf, 0, 1, 1)  // min: tie 5 -> 1
+    if bf_get(&rmin, 1, 0) != 1.0 || bf_get(&rmin, 3, 0) != 1.0 || bf_get(&rmin, 5, 0) != 3.0 { print("FAIL rank_min\n"); return 334 }
+    let rmax = bf_rank_by(&rkf, 0, 1, 2)  // max: tie 5 -> 2
+    if bf_get(&rmax, 1, 0) != 2.0 || bf_get(&rmax, 3, 0) != 2.0 || bf_get(&rmax, 5, 0) != 3.0 { print("FAIL rank_max\n"); return 335 }
+    let rden = bf_rank_by(&rkf, 0, 1, 3)  // dense: 5->1, 8->2
+    if bf_get(&rden, 1, 0) != 1.0 || bf_get(&rden, 5, 0) != 2.0 { print("FAIL rank_dense\n"); return 336 }
+    // CROSS-CHECK: single-group rank_by == ungrouped bf_rank (all methods), value-by-value.
+    var sgr = bf_new(2, 16)
+    var sgk: i64 = 0
+    while sgk < 400 { var sr:[f64;64]=[0.0;64]; sr[0]=0.0; sr[1]=((sgk*29)%53) as f64; bf_push_row(&!sgr,&sr,2); sgk=sgk+1 }
+    var rmm: i64 = 0
+    while rmm < 4 {
+        let a = bf_rank_by(&sgr, 0, 1, rmm)
+        let b = bf_rank(&sgr, 1, rmm)
+        var d: i64 = 0; var jx: i64 = 0
+        while jx < 400 { if bf_get(&a, jx, 0) != bf_get(&b, jx, 0) { d = d + 1 } jx = jx + 1 }
+        if d != 0 { print("FAIL rank_vs_ungrouped\n"); return 337 }
+        rmm = rmm + 1
+    }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_rank_by` in `data::bigframe_ops` — per-group ascending 1-based **rank** of `val_col` within each `key_col` group (pandas `df.groupby(key)[val].rank(method=...)`): method 0 = average (default), 1 = min, 2 = max, 3 = dense. Handles **any f64 key**.

**O(n + Σ sz·log sz)**: an O(n) factorize + counting-sort of row indices into contiguous per-group regions (gathering each region's values in the same pass), then a **local bottom-up stable mergesort per region** and one tie-run pass assigning ranks. Sorting per region (Σ sz·log sz) rather than globally (n·log n) is what keeps it competitive.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups with a known tie pattern → average/min/max/dense all give pandas' exact ranks (two tied 5s → 1.5/1.5 average, 1/1 min, 2/2 max, dense 1);
- a **single-group cross-check** that `bf_rank_by` == the ungrouped `bf_rank` value-for-value across all 4 methods;
- (offline) all 4 methods matched pandas `groupby.rank` over 20k rows / 50 groups = **0 diffs**.

## Benchmark (1M rows, 1000 groups, average) — honest loss

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| rank_by | ~130 | ~68 | **~1.9× — loss (sort-bound)** |

This is an **honest loss**: grouped rank is sort-bound and pandas' specialised Cython `group_rank` wins. Confirmed it is **not** fixable overhead — a sequential-gather variant did not move it, and the mergesort itself is the cost. Maps to the same **C3 radix-sort / SIMD compiler dispatch** as the ungrouped sort/quantile losses; a hardware sort would close it. Shipped for **capability parity** (correct, general, all 4 methods) with the perf gap documented — consistent with how the other sort-bound verbs were shipped.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)