### PR TITLE
docs(probe): negative holds at H=256 + exposes an architectural confound in the LSTM target

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1063
-- Repo-backed topics: 913
+- Total governed topics: 1064
+- Repo-backed topics: 914
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 234
+- Authority count `historical`: 235
 - Authority count `repo_only`: 641
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 268 topics
+- A6: 269 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -786,6 +786,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.primitive-zd-gap-resolution | historical | docs/research/PRIMITIVE_ZD_GAP_RESOLUTION.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.private-evidence-envelope-2026-06-23 | historical | docs/research/private-evidence-envelope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-corrected-protocol | historical | docs/research/probe-corrected-protocol.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.probe-result-h256-scale | historical | docs/research/PROBE-RESULT-h256-scale.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-result-lstm-adding | historical | docs/research/PROBE-RESULT-lstm-adding.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-usage | historical | docs/research/probe-usage.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.proof-checker-family-matrix-2026-06-23 | historical | docs/research/proof-checker-family-matrix-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17413,6 +17413,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.probe-result-h256-scale",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/PROBE-RESULT-h256-scale.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.probe-result-lstm-adding",
       "collection": "repo",
       "repo_doc_path": "docs/research/PROBE-RESULT-lstm-adding.md",

--- a/docs/research/PROBE-RESULT-h256-scale.md
+++ b/docs/research/PROBE-RESULT-h256-scale.md
@@ -1,0 +1,53 @@
+<!-- docs:meta
+topic_id: repo.docs.research.probe-result-h256-scale
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-result-h256-scale
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# The negative holds at scale (H=256, T=200) — and it exposes an architectural confound in the LSTM target
+
+*Follow-up to `PROBE-RESULT-lstm-adding.md` (the H=40 negative). The decisive control — is the h→h
+alignment architectural (present at init) — needs no training and no torch: the analytic LSTM Jacobian
+(validated to 7e-8 vs autograd) is computed on a random H=256 net in pure numpy. It confirms the negative,
+and reveals why the LSTM is not the confounder-free target it was taken to be.*
+
+## Result — untrained H=256, T=200, align(k) (init/architectural control)
+| k | 1 | 2 | 4 | 8 | 16 | 32 | 63 |
+|---|---|---|---|---|---|---|---|
+| baseline √(k/2H) | 0.04 | 0.06 | 0.09 | 0.12 | 0.18 | 0.25 | 0.35 |
+| **INIT h→h** | 0.99 | 0.99 | **1.00** | 1.00 | 1.00 | 1.00 | **1.00** |
+| INIT c→c | 0.78 | 0.83 | 0.83 | 0.82 | 0.81 | 0.85 | 0.90 |
+
+In a **random** LSTM the h→h Jacobian alignment is **≈1.0 at every k** (1…63) while the baseline is 0.04–0.35.
+No small-k shoulder, no fall to baseline — the low-rank/architectural shape, pushed to its extreme. The
+negative is not only intact at scale, it is sharper.
+
+## Why — a shared recurrent backbone (refines the target)
+The LSTM applies the **same** recurrent matrix `W_hh` at every step; the gates modulate it, but the backbone
+is shared, so consecutive Jacobians `∂h_{t+1}/∂h_t ≈ diag(gate_t)·(structure of W_hh)` share their singular
+subspaces **by construction**, before any training. This is a *partial* version of the S4/Mamba
+disqualification (shared eigenvectors): the "dense, input-dependent, genuinely distinct" argument for the
+LSTM underweighted the shared `W_hh`. A truly confound-free target needs **distinct weights per step/layer**
+— a deep feedforward net probed on its **branches** `F'_l = J_l − I`. The LSTM is not clean.
+
+## Verdict at scale
+The negative confirms: the trained-LSTM h→h alignment (the d=56 "positive" at H=40) is architectural and
+low-rank, and at H=256 it is architecturally ≈1 everywhere — the sedenion-predicted small-k shoulder with a
+healthy bulk is absent. No training can invert an alignment that is already ≈1 at init (verified at H=40,
+where training slightly *reduced* it). The structural annihilation signature is not present in these RNN
+Jacobians; the vanishing gradient is magnitude + rank + a shared-weight architectural alignment.
+
+## On the compute path (recorded honestly)
+The SLURM GPU nodes (RTX 4000 Ada) are bare: no pip/ensurepip, no internet, no shared filesystem — PyTorch
+cannot be installed there, and the canonical `beagle-sounio` image is the Sounio compiler, not an ML image.
+So the GPU-via-SLURM route does not run torch without a purpose-built container. It did not matter: the
+decisive control (init/architectural) is training-free and torch-free via the analytic Jacobian, and it
+answered the question. Harness `probe_h256_init.py` (pure numpy, analytic LSTM Jacobian).

--- a/docs/research/PROBE-RESULT-lstm-adding.md
+++ b/docs/research/PROBE-RESULT-lstm-adding.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-result-lstm-adding
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/probe_h256_init.py
+++ b/docs/research/probe_h256_init.py
@@ -1,0 +1,40 @@
+import numpy as np
+sig=lambda z:1/(1+np.exp(-z))
+def lstm_init(H, seed=0):
+    rng=np.random.default_rng(seed); k=1/np.sqrt(H)
+    return dict(Wih=rng.uniform(-k,k,(4*H,2)), Whh=rng.uniform(-k,k,(4*H,H)),
+                bih=rng.uniform(-k,k,4*H), bhh=rng.uniform(-k,k,4*H), H=H)
+def Vts(W, X):                       # right singular vectors (Vt) of each per-step Jacobian, computed ONCE
+    H=W['H']; Whi,Whf,Whg,Who=W['Whh'][:H],W['Whh'][H:2*H],W['Whh'][2*H:3*H],W['Whh'][3*H:4*H]
+    h=np.zeros(H); c=np.zeros(H); VH=[]; VC=[]
+    for t in range(X.shape[0]):
+        pre=W['Wih']@X[t]+W['Whh']@h+W['bih']+W['bhh']
+        i=sig(pre[:H]); f=sig(pre[H:2*H]); g=np.tanh(pre[2*H:3*H]); o=sig(pre[3*H:4*H])
+        cp=f*c+i*g; tc=np.tanh(cp); dtc=1-tc*tc
+        di=(i*(1-i))[:,None]*Whi; df=(f*(1-f))[:,None]*Whf; dg=(1-g*g)[:,None]*Whg; do=(o*(1-o))[:,None]*Who
+        dcp_dh=c[:,None]*df+g[:,None]*di+i[:,None]*dg
+        dhp_dh=tc[:,None]*do+(o*dtc)[:,None]*dcp_dh
+        VH.append(np.linalg.svd(dhp_dh)[2]); VC.append(np.linalg.svd(np.diag(f))[2]); h,c=o*tc,cp
+    return VH,VC                       # h→h block SVD, c→c block (diagonal)
+def align_from_Vt(Vt_list, ks):
+    return np.array([np.mean([np.linalg.svd(Vt_list[l][-k:]@Vt_list[l+1][-k:].T,compute_uv=False).mean()
+                    for l in range(len(Vt_list)-1)]) for k in ks])
+def gen_adding(T,rng):
+    v=rng.random(T).astype('float32'); mk=np.zeros(T,'float32'); mk[rng.choice(T,2,replace=False)]=1
+    return np.stack([v,mk],-1)
+H=256;T=200;ks=list(range(1,64)); HH=[];CC=[]
+for s in range(6):
+    W=lstm_init(H,seed=100+s); X=gen_adding(T,np.random.default_rng(500+s))
+    vh,vc=Vts(W,X); HH.append(align_from_Vt(vh,ks)); CC.append(align_from_Vt(vc,[k for k in ks if k<H]))
+    print(f"  seq {s+1}/6 done",flush=True)
+hh=np.array(HH).mean(0); cc=np.array(CC).mean(0); base=np.array([np.sqrt(k/(2*H)) for k in ks])
+show=[1,2,4,8,16,32,63]
+print(f"\nUNTRAINED H=256, T=200 — align(k) (init/architectural control):")
+print(f"  k          "+" ".join(f"{k:>5}" for k in show))
+print(f"  baseline   "+" ".join(f"{np.sqrt(k/(2*H)):5.2f}" for k in show))
+print(f"  INIT h→h   "+" ".join(f"{hh[ks.index(k)]:5.2f}" for k in show))
+print(f"  INIT c→c   "+" ".join(f"{cc[ks.index(k)]:5.2f}" for k in show if k<H))
+sh=ks[int(np.argmax((hh-base)[:-1]-(hh-base)[1:]))]
+print(f"\n  shoulder k={sh}; align@4={hh[3]:.2f} @32={hh[31]:.2f} @63={hh[62]:.2f} (base@63={np.sqrt(63/512):.2f})")
+print(f"  → {'LOW-RANK / architectural (high to large k, no small-k shoulder)' if hh[31]>0.55 else 'annihilation shape (falls to base by k=32)'}")
+print("DONE",flush=True)


### PR DESCRIPTION
The decisive init control at scale (H=256,T=200), via the analytic LSTM Jacobian (validated 7e-8 vs autograd) in pure numpy — no torch/GPU needed. **Untrained** h→h align(k) ≈ **1.0 at every k** (baseline 0.04–0.35): low-rank/architectural extreme, no small-k shoulder → the negative holds, sharper. **Why:** the LSTM shares W_hh every step → consecutive Jacobians share singular subspaces by construction (a partial S4/Mamba confound the 'dense RNN' argument underweighted); a confound-free target needs distinct per-step/layer weights (deep FFN, probe branches F'_l=J_l−I). **Verdict:** no structural annihilation; alignment is architectural+low-rank+shared-weight; training can't invert align≈1-at-init. **SLURM note:** GPU nodes (RTX 4000 Ada) are bare (no pip/internet/FS) → torch uninstallable; the decisive control is training-free anyway. 🤖 Generated with [Claude Code](https://claude.com/claude-code)