### PR TITLE
feat(stdlib): bigframe grouped ngroup / descending cumcount (both beat pandas)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -69,6 +69,8 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | transform_std_by (1M rows, 1000 dense keys) | | ~18 | ~20 | **0.93x — Sounio wins** | two-pass exact Σ(x-mean)² + bf_sqrt |
 | cummax_by / cummin_by (1M rows, 1000 dense keys) | | ~11 | ~19 | **0.59x — Sounio wins** | dense direct-index running extreme, row-aligned |
 | rank_by (1M rows, 1000 groups, average) | | ~130 | ~68 | **~1.9x — loss (sort-bound)** | per-region mergesort vs pandas Cython group-rank; C3 radix-sort would close it |
+| ngroup_by (1M rows, 1000 dense keys) | | ~8.2 | ~13.2 | **0.62x — Sounio wins** | dense direct-index, sorted-key compacted numbering |
+| cumcount_desc_by (1M rows, 1000 dense keys) | | ~10.7 | ~40.5 | **0.27x — Sounio wins (3.7x)** | dense direct-index reverse cumcount |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -13,7 +13,7 @@
 // rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
-// grouped cumulative min / max; grouped rank.
+// grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -3945,5 +3945,61 @@ pub fn bf_rank_by(src: &BigFrame, key_col: i64, val_col: i64, method: i64) -> Bi
     heap_free(vb as *mut i8)
     heap_free(ia as *mut i8)
     heap_free(ib as *mut i8)
+    out
+}
+
+/// Per-row group NUMBER (like pandas df.groupby(key).ngroup()): out[i] = the 0-based
+/// index of row i's group, groups numbered in ASCENDING key order (pandas' sort=True
+/// default). DENSE integer keys 0..1023 (direct-index, no hashing -- the same fast
+/// dense-key contract as bf_groupby_sum; a row whose key is outside [0,1024) gets -1).
+/// For sparse keys the numbering is the compacted sorted rank of the distinct keys.
+/// O(n), two passes. Returns a 1-column BigFrame of length n. NATIVE + lean_single only.
+pub fn bf_ngroup_by(src: &BigFrame, key_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var seen: [i64; 1024] = [0; 1024]
+    var gnum: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= bf_ncols(src) || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { seen[k] = 1 } i = i + 1 }
+    var g: f64 = 0.0
+    var k2: i64 = 0
+    while k2 < 1024 { if seen[k2] == 1 { gnum[k2] = g; g = g + 1.0 } k2 = k2 + 1 }   // ascending key -> ascending number
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { write_f64(op, i, gnum[k]) } else { write_f64(op, i, 0.0 - 1.0) }
+        i = i + 1
+    }
+    out
+}
+
+/// Per-group DESCENDING running count (like pandas df.groupby(key).cumcount(ascending=
+/// False)): out[i] = the number of LATER rows sharing row i's `key_col` value (so the
+/// last row of each group gets 0 and the first gets size-1). DENSE integer keys 0..1023
+/// (direct-index, no hashing -- the same fast dense-key contract as bf_groupby_sum; a row
+/// whose key is outside [0,1024) gets 0). O(n), two passes (count sizes, then walk).
+/// Returns a 1-column BigFrame of length n. NATIVE + lean_single only (heap).
+pub fn bf_cumcount_desc_by(src: &BigFrame, key_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var sz:  [f64; 1024] = [0.0; 1024]
+    var cur: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= bf_ncols(src) || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { sz[k] = sz[k] + 1.0 } i = i + 1 }
+    i = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 { write_f64(op, i, sz[k] - 1.0 - cur[k]); cur[k] = cur[k] + 1.0 }
+        else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -950,6 +950,25 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
         if d != 0 { print("FAIL rank_vs_ungrouped\n"); return 337 }
         rmm = rmm + 1
     }
+    // NGROUP / DESCENDING CUMCOUNT. sparse keys {0,10,20} (compacted -> groups 0,1,2).
+    var ngf = bf_new(2, 16)
+    var ngi: i64 = 0
+    while ngi < 30 { var ngr:[f64;64]=[0.0;64]; ngr[0]=(10*(ngi%3)) as f64; ngr[1]=ngi as f64; bf_push_row(&!ngf,&ngr,2); ngi=ngi+1 }
+    let ng = bf_ngroup_by(&ngf, 0)
+    if bf_nrows(&ng) != 30 { print("FAIL ngroup_n\n"); return 338 }
+    // rows: key cycles 0,10,20,0,10,20,... -> ngroup 0,1,2,0,1,2,... (sorted-key compacted)
+    if bf_get(&ng, 0, 0) != 0.0 || bf_get(&ng, 1, 0) != 1.0 || bf_get(&ng, 2, 0) != 2.0 { print("FAIL ngroup_first\n"); return 339 }
+    if bf_get(&ng, 3, 0) != 0.0 || bf_get(&ng, 29, 0) != 2.0 { print("FAIL ngroup_cycle\n"); return 340 }
+    // each of the 3 groups has 10 rows. descending cumcount: group's rows get 9,8,...,0.
+    let cd = bf_cumcount_desc_by(&ngf, 0)
+    if bf_get(&cd, 0, 0) != 9.0 { print("FAIL ccdesc_first\n"); return 341 }   // key0 occ 0 -> 9 later
+    if bf_get(&cd, 3, 0) != 8.0 { print("FAIL ccdesc_second\n"); return 342 }  // key0 occ 1 -> 8 later
+    if bf_get(&cd, 27, 0) != 0.0 { print("FAIL ccdesc_last\n"); return 343 }   // key0 occ 9 (last) -> 0 later
+    // CROSS-CHECK: forward cumcount + descending cumcount == size-1 for every row.
+    let fc = bf_cumcount_by(&ngf, 0)
+    var ccd: i64 = 0; var ccj: i64 = 0
+    while ccj < 30 { if bf_get(&fc, ccj, 0) + bf_get(&cd, ccj, 0) != 9.0 { ccd = ccd + 1 } ccj = ccj + 1 }
+    if ccd != 0 { print("FAIL ccdesc_sum\n"); return 344 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

Two companion groupby helpers in `data::bigframe_ops`, row-aligned:

- **`bf_ngroup_by`** (pandas `df.groupby(key).ngroup()`): `out[i]` = the 0-based index of row i's group, groups numbered in **ascending key order** (pandas' `sort=True` default). For sparse keys the numbering is the compacted sorted rank of the distinct keys.
- **`bf_cumcount_desc_by`** (pandas `df.groupby(key).cumcount(ascending=False)`): `out[i]` = the number of **later** rows sharing row i's key — the last row of each group gets 0, the first gets `size-1`.

Both are **dense direct-index** (keys 0..1023, no hashing — same fast dense-key contract as `bf_groupby_sum`), O(n).

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- sparse keys {0,10,20} → ngroup compacts to 0,1,2 cycling with the key; descending cumcount over 10-row groups gives 9,8,…,0;
- a cross-check that `forward cumcount + descending cumcount == size-1` for every row;
- (offline) both matched pandas `ngroup` / `cumcount(ascending=False)` over 12k rows with sparse keys = **0 diffs**.

## Benchmark (1M rows, 1000 dense keys)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| ngroup_by | ~8.2 | ~13.2 | **0.62× — win** |
| cumcount_desc_by | ~10.7 | ~40.5 | **0.27× — win (3.7×)** |

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)