### PR TITLE
feat(stdlib): bigframe grouped pct_change (beats pandas 7.6x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -71,6 +71,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | rank_by (1M rows, 1000 groups, average) | | ~130 | ~68 | **~1.9x — loss (sort-bound)** | per-region mergesort vs pandas Cython group-rank; C3 radix-sort would close it |
 | ngroup_by (1M rows, 1000 dense keys) | | ~8.2 | ~13.2 | **0.62x — Sounio wins** | dense direct-index, sorted-key compacted numbering |
 | cumcount_desc_by (1M rows, 1000 dense keys) | | ~10.7 | ~40.5 | **0.27x — Sounio wins (3.7x)** | dense direct-index reverse cumcount |
+| pct_change_by (1M rows, 1000 dense keys) | | ~13.3 | ~101.7 | **0.13x — Sounio wins (7.6x)** | dense direct-index per-group prev-value tracker |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -13,7 +13,8 @@
 // rolling correlation, rolling covariance / skewness / kurtosis, rolling quantile,
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
-// grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount.
+// grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount;
+// grouped pct_change.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -3999,6 +4000,40 @@ pub fn bf_cumcount_desc_by(src: &BigFrame, key_col: i64) -> BigFrame with Alloc,
         let k = read_f64(kp, i) as i64
         if k >= 0 && k < 1024 { write_f64(op, i, sz[k] - 1.0 - cur[k]); cur[k] = cur[k] + 1.0 }
         else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    out
+}
+
+/// Per-group fractional change between consecutive rows of a group (like pandas
+/// df.groupby(key)[val].pct_change()): out[i] = (val[i] - prev) / prev, where `prev` is
+/// the previous row of row i's group in input order. The first row of each group takes
+/// `fill`; a zero prior value yields inf/nan (as in pandas). DENSE integer keys 0..1023
+/// (direct-index last-value tracker, no hashing -- the same fast dense-key contract as
+/// bf_groupby_sum; a row whose key is outside [0,1024) takes `fill`). O(n), one pass.
+/// Returns a 1-column BigFrame of length n. NATIVE + lean_single only (heap).
+pub fn bf_pct_change_by(src: &BigFrame, key_col: i64, val_col: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var prev: [f64; 1024] = [0.0; 1024]
+    var seen: [i64; 1024] = [0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 {
+            if seen[k] == 0 { seen[k] = 1; write_f64(op, i, fill) }
+            else { let p = prev[k]; write_f64(op, i, (v - p) / p) }
+            prev[k] = v
+        } else {
+            write_f64(op, i, fill)
+        }
         i = i + 1
     }
     out

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -969,6 +969,32 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var ccd: i64 = 0; var ccj: i64 = 0
     while ccj < 30 { if bf_get(&fc, ccj, 0) + bf_get(&cd, ccj, 0) != 9.0 { ccd = ccd + 1 } ccj = ccj + 1 }
     if ccd != 0 { print("FAIL ccdesc_sum\n"); return 344 }
+    // GROUPED PCT_CHANGE. 2 groups (key=r%2): group 0 (even rows) vals 10,20,40,...(doubling
+    // per group step), group 1 (odd rows) vals 5,10,20,... -> pct_change within group = 1.0
+    // (each is 2x prior); first-in-group -> fill.
+    var pcf = bf_new(2, 16)
+    var pci: i64 = 0
+    while pci < 20 { var pcr:[f64;64]=[0.0;64]; pcr[0]=(pci%2) as f64
+        var occ2 = pci/2
+        var vv = 10.0; var e2: i64 = 0; while e2 < occ2 { vv = vv*2.0; e2 = e2+1 }   // 10,20,40,... for group 0
+        if pci%2==1 { vv = vv/2.0 }                                                   // 5,10,20,... for group 1
+        pcr[1]=vv; bf_push_row(&!pcf,&pcr,2); pci=pci+1 }
+    let pc = bf_pct_change_by(&pcf, 0, 1, 0.0 - 999.0)
+    if bf_nrows(&pc) != 20 { print("FAIL pctchg_n\n"); return 345 }
+    if bf_get(&pc, 0, 0) != (0.0 - 999.0) { print("FAIL pctchg_fill0\n"); return 346 }  // group 0 first
+    if bf_get(&pc, 1, 0) != (0.0 - 999.0) { print("FAIL pctchg_fill1\n"); return 347 }  // group 1 first
+    if !approx_eq(bf_get(&pc, 2, 0), 1.0) { print("FAIL pctchg_g0\n"); return 348 }      // 20/10 - 1 = 1
+    if !approx_eq(bf_get(&pc, 3, 0), 1.0) { print("FAIL pctchg_g1\n"); return 349 }      // 10/5 - 1 = 1
+    if !approx_eq(bf_get(&pc, 18, 0), 1.0) { print("FAIL pctchg_g0_last\n"); return 350 }// still 2x prior
+    // CROSS-CHECK: single-group pct_change_by == ungrouped bf_pct_change.
+    var pgf = bf_new(2, 16)
+    var pgk: i64 = 0
+    while pgk < 300 { var pr:[f64;64]=[0.0;64]; pr[0]=0.0; pr[1]=((pgk*13)%89 + 1) as f64; bf_push_row(&!pgf,&pr,2); pgk=pgk+1 }
+    let pgb = bf_pct_change_by(&pgf, 0, 1, 0.0 - 999.0)
+    let pgu = bf_pct_change(&pgf, 1, 0.0 - 999.0)
+    var pgd: i64 = 0; var pgj: i64 = 0
+    while pgj < 300 { if !approx_eq(bf_get(&pgb, pgj, 0), bf_get(&pgu, pgj, 0)) { pgd = pgd + 1 } pgj = pgj + 1 }
+    if pgd != 0 { print("FAIL pctchg_vs_ungrouped\n"); return 351 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_pct_change_by` in `data::bigframe_ops` — per-group **fractional change** between consecutive rows of a group (pandas `df.groupby(key)[val].pct_change()`): `out[i] = (val[i] - prev) / prev`, where `prev` is the previous row of row i's group in input order. The first row of each group takes `fill`; a zero prior yields inf/nan (as in pandas).

**Dense direct-index** per-group last-value tracker over keys 0..1023 (no hashing — the same fast dense-key contract as `bf_groupby_sum`), O(n) single pass.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups whose values double within each group → pct_change = 1.0 everywhere except the first-in-group (`fill`);
- a **single-group cross-check** that `bf_pct_change_by` == the ungrouped `bf_pct_change`;
- (offline) matched pandas `groupby pct_change` over 18k rows / 60 groups = **0 diffs** (at 1e-5, since Sounio's printed f64 is 6-decimal; the computation is full-precision).

## Benchmark (1M rows, 1000 dense keys)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| pct_change_by | ~13.3 | ~101.7 | **0.13× — Sounio wins (7.6×)** |

pandas' `groupby pct_change` is notably slow; the dense per-group prev-value tracker touches each row once.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)