### PR TITLE
docs(research): deep-FFN branch probe — NEGATIVE on the confound-free target

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,13 +19,13 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1064
-- Repo-backed topics: 914
+- Total governed topics: 1065
+- Repo-backed topics: 915
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
-- Authority count `historical`: 235
+- Authority count `historical`: 236
 - Authority count `repo_only`: 641
 - Authority count `website_only`: 150
 
@@ -37,7 +37,7 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics
-- A6: 269 topics
+- A6: 270 topics
 - A7: 57 topics
 
 ## Locale Acceptance

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -786,6 +786,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.research.primitive-zd-gap-resolution | historical | docs/research/PRIMITIVE_ZD_GAP_RESOLUTION.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.private-evidence-envelope-2026-06-23 | historical | docs/research/private-evidence-envelope-2026-06-23.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-corrected-protocol | historical | docs/research/probe-corrected-protocol.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.research.probe-result-deep-ffn | historical | docs/research/PROBE-RESULT-deep-ffn.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-result-h256-scale | historical | docs/research/PROBE-RESULT-h256-scale.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-result-lstm-adding | historical | docs/research/PROBE-RESULT-lstm-adding.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.research.probe-usage | historical | docs/research/probe-usage.md | - | A6 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -17413,6 +17413,28 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.research.probe-result-deep-ffn",
+      "collection": "repo",
+      "repo_doc_path": "docs/research/PROBE-RESULT-deep-ffn.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "researchers",
+      "authority": "historical",
+      "owner_agent": "A6",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.research.probe-result-h256-scale",
       "collection": "repo",
       "repo_doc_path": "docs/research/PROBE-RESULT-h256-scale.md",

--- a/docs/research/PROBE-RESULT-deep-ffn.md
+++ b/docs/research/PROBE-RESULT-deep-ffn.md
@@ -1,0 +1,118 @@
+<!-- docs:meta
+topic_id: repo.docs.research.probe-result-deep-ffn
+authority: historical
+audience: researchers
+last_validated: 2026-03-07
+validated_by: A6
+source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-result-deep-ffn
+-->
+
+<!-- docs:status-note:start -->
+> Docs status: `historical`
+> This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.
+<!-- docs:status-note:end -->
+
+# Probe result — deep residual FFN, the confound-free target
+
+**Status: NEGATIVE.** On the one target free of the shared-backbone confound — a deep residual MLP with
+**distinct weights per layer**, trained to 96 % on a genuinely nonlinear task — the branch-Jacobian
+subspace-alignment signature of composition annihilation is **absent**: trained is indistinguishable from
+untrained init *and* from the orientation-scramble null at every rank `k`.
+
+This is the terminal result of the Jacobian-probe line. It closes the empirical question the H=256 LSTM
+left open.
+
+## Why this target, and why it is the decisive one
+
+The probe asks whether a trained network's per-step (or per-layer) Jacobians share a *dying subspace* —
+consecutive maps annihilating the *same* low-dim directions, the finite-dimensional shadow of a sedenion
+zero-divisor `x·y = 0`. Measured as principal-angle alignment of the bottom-`k` right singular subspaces
+of consecutive Jacobians, as a **curve** `align(k)` (a small-`k` shoulder with a healthy bulk = genuine
+subspace death; high-to-large-`k` = mere low rank; flat `√(k/d)` = nothing).
+
+Every earlier target was confounded — the alignment was written into the architecture before any training:
+
+- **S4 / Mamba** — diagonal `Ā` shares eigenvectors across steps by construction → `align ≡ 1`. Disqualified.
+- **LSTM / dense RNN** — shares one recurrent matrix `W_hh` every step. The H=256 run
+  ([`PROBE-RESULT-h256-scale.md`](PROBE-RESULT-h256-scale.md)) found `align(k) ≈ 1.0` at *all* `k`, but the
+  init/untrained control was equally ≈ 1.0 → **architectural**, not learned. The shared backbone forces
+  consecutive Jacobians to share singular subspaces regardless of training.
+
+The only clean target has **distinct weights at every layer**, so there is no shared matrix to manufacture
+alignment. A residual net `z_{l+1} = z_l + F_l(z_l)` fits: its layer Jacobian is `J_l = I + F'_l`, and the
+residual identity `I` anchors *all* `J_l` to the same basis — so we must probe the **branch**
+`F'_l = J_l − I`, never the full `J_l` (probing `J_l` would recover the identity's trivial alignment).
+
+## The clean-target proof (`deep_ffn_probe.py`)
+
+Untrained deep residual FFN, distinct random weights per layer, branch `F'_l` alignment:
+
+```
+  k              1     2     4     8    16    32
+  baseline    0.12  0.18  0.25  0.35  0.50  0.71     √(k/d)
+  INIT F'_l   0.10  0.15  0.21  0.30  0.43  0.64
+  max excess over baseline: −0.02
+```
+
+Init sits **at (slightly below) baseline** at every `k` — distinct weights ⇒ **no architectural alignment**.
+Contrast the LSTM init (≈ 1.0 everywhere). The target is clean: any alignment above baseline in a *trained*
+net would be a genuine learned signal, not the architecture.
+
+## Trained result (`deep_ffn_train.py`)
+
+ResMLP (`W=96`, `L=8`, embed→8 residual `tanh` blocks→readout), distinct weights per layer, trained with
+Adam to **96 % test accuracy** on `y = sign(x₀x₁ + x₂x₃ − x₄x₅)` (a genuinely nonlinear 6-dim signal in
+`d=64` that rewards depth — a linear readout scores chance, confirmed).
+
+```
+ResMLP branch F'_l align(k)   W=96, L=8, acc=0.96:
+  k              1     2     4     6     8    16    32    48
+  baseline    0.10  0.14  0.20  0.25  0.29  0.41  0.58  0.71
+  TRAINED     0.09  0.12  0.17  0.22  0.25  0.36  0.53  0.66
+  INIT        0.08  0.12  0.17  0.21  0.25  0.35  0.51  0.64
+  SCRAMBLE    0.08  0.12  0.17  0.21  0.24  0.35  0.51  0.64
+  trained max excess over baseline: −0.00
+```
+
+- **TRAINED ≈ INIT** at every `k` — learning to 96 % adds **no** shared dying subspace.
+- **TRAINED ≈ SCRAMBLE** — the orientation-scramble null (`F'_l → O_{l+1} F'_l O_lᵀ`, spectrum-preserving,
+  alignment-destroying) is *not beaten*: whatever alignment exists is the residual measure-concentration
+  baseline `√(k/W)`, not structure.
+- No small-`k` shoulder, no high-`k` low-rank plateau, no architectural inflation.
+
+**Verdict: NEGATIVE.** A genuinely trained standard deep net, once the shared-backbone confound is removed,
+does **not** develop the composition-annihilation signature.
+
+## What this establishes (and what it does not)
+
+- **The instrument works and is honest.** It survived ~12 successive refutations (gap-dominance →
+  subspace alignment → `align(k)` curve → QR/Lyapunov de-censoring → target disqualification), caught its own
+  H=40 `d=56` false positive via controls, correctly attributed the H=256 LSTM `align≈1` to architecture, and
+  now — pointed at the one target where the answer is *not* pre-written — returns a clean negative that beats
+  no null. This is what a working instrument returning "absent" looks like.
+- **The hypothesis it tested is falsified on standard nets.** "Training deep networks on ordinary tasks
+  leaves a sedenion-zero-divisor fingerprint (a shared dying Jacobian subspace)" is **not** supported. Vanishing
+  gradients in these nets are magnitude decay and/or ordinary low rank, distributed across *unaligned*
+  directions — not annihilation by composition onto a common subspace.
+- **What stands is untouched.** The rupture algebra (associator = graded composition-failure signature;
+  sedenion ZD variety ≅ `G₂/V₂(ℝ⁷)`), the compiler/𝕊-arithmetic, and the Spinoza/conatus geometry of the
+  `σ_min` field (norm-preservation `‖xy‖=‖x‖‖y‖`, connectivity = "no condemnation") are theory and stand on
+  their own. This negative concerns only the narrower empirical claim that *ordinary gradient-trained nets*
+  carry the signature — they do not.
+
+The connection between non-associative annihilation and learning dynamics, if it exists, is **not** visible in
+the Jacobian spectra of standard trained networks. It would have to be engineered into an architecture or a
+loss, not discovered as a fingerprint of vanilla training. That is a sharper, more honest place to stand than
+a claimed positive would have been.
+
+## Reproduce
+
+```
+python3 docs/research/deep_ffn_probe.py    # clean-target proof: init branch align at baseline
+python3 docs/research/deep_ffn_train.py    # train ResMLP→96%, TRAINED vs INIT vs SCRAMBLE branch align(k)
+```
+
+Analytic branch Jacobian `F'_l = B_l·diag(1−tanh²(A_l z))·A_l` (numpy, exact); alignment via bottom-`k`
+right-singular-subspace principal angles; orientation-scramble null as the spectrum-preserving control.
+See also [`probe-corrected-protocol.md`](probe-corrected-protocol.md),
+[`lyapunov-repositioning.md`](lyapunov-repositioning.md).

--- a/docs/research/deep_ffn_probe.py
+++ b/docs/research/deep_ffn_probe.py
@@ -1,0 +1,33 @@
+# Confound-free target: a deep RESIDUAL feedforward net with DISTINCT weights per layer, probing the
+# BRANCH Jacobians F'_l = J_l − I (not J_l — the residual anchors J_l to I and would inflate alignment).
+# Distinct per-layer weights ⇒ NO shared backbone (unlike the LSTM's shared W_hh), so the init control
+# should sit at BASELINE — a clean target where any trained alignment above baseline is a real signal.
+# Branch: F_l(x)=V_l·tanh(U_l·x);  F'_l(x)=V_l·diag(1−tanh²(U_l x))·U_l  (analytic, numpy).
+import numpy as np
+np.seterr(all='ignore')
+def make_net(L,d,h,seed):
+    rng=np.random.default_rng(seed)
+    return [(rng.standard_normal((h,d))/np.sqrt(d), rng.standard_normal((d,h))/np.sqrt(h)*0.4) for _ in range(L)]
+def branch_jacs(net, x):                 # propagate x through the residual stack; return per-layer F'_l
+    Js=[]
+    for U,V in net:
+        pre=U@x; a=np.tanh(pre); Fp=V@(( 1-a*a)[:,None]*U); Js.append(Fp); x=x+V@a
+    return Js
+def botV(A,k): return np.linalg.svd(A)[2][-k:]
+def align_curve(mats,ks):
+    Vt=[np.linalg.svd(A)[2] for A in mats]
+    return np.array([np.mean([np.linalg.svd(Vt[l][-k:]@Vt[l+1][-k:].T,compute_uv=False).mean()
+                    for l in range(len(Vt)-1)]) for k in ks])
+L,d,h=24,64,128; ks=list(range(1,40)); base=np.sqrt(np.array(ks)/d)
+net=make_net(L,d,h,seed=0); rng=np.random.default_rng(9)
+HH=[align_curve(branch_jacs(net, rng.standard_normal(d)*0.3), ks) for _ in range(12)]
+hh=np.array(HH).mean(0)
+show=[1,2,4,8,16,32]
+print(f"INIT (untrained) deep residual FFN, distinct weights/layer — branch F'_l align(k):")
+print(f"  k          "+" ".join(f"{k:>5}" for k in show))
+print(f"  baseline   "+" ".join(f"{np.sqrt(k/d):5.2f}" for k in show))
+print(f"  INIT F'_l  "+" ".join(f"{hh[ks.index(k)]:5.2f}" for k in show))
+excess=(hh-base); print(f"\n  max excess over baseline: {excess.max():.2f}  at k={ks[int(np.argmax(excess))]}")
+clean = excess.max()<0.15
+print(f"  → target is {'CLEAN (init at baseline — distinct weights, no architectural alignment) → any trained signal is real' if clean else 'STILL CONFOUNDED (init above baseline)'}")
+print("DONE",flush=True)

--- a/docs/research/deep_ffn_train.py
+++ b/docs/research/deep_ffn_train.py
@@ -1,0 +1,73 @@
+# Confound-free target: deep RESIDUAL MLP (ResMLP), DISTINCT weights per layer — no shared backbone
+# (unlike the LSTM's shared W_hh → architectural align≈1). Probe the BRANCH Jacobians F'_l = J_l − I
+# (J_l = I + F'_l; the residual anchors J_l to I, so we measure the branch, per the §4 caveat).
+#   block:  z_{l+1} = z_l + B_l·tanh(A_l·z_l);   F'_l(z) = B_l·diag(1−tanh²(A_l z))·A_l   (W×W)
+# Init sits at BASELINE (clean target — proven below). Question: does LEARNING create a shared dying
+# subspace (annihilation → small-k shoulder above baseline) or low-rank (high to large k) or nothing?
+import numpy as np, torch, torch.nn as nn
+np.seterr(all='ignore')
+d,W,L=64,96,8
+class ResMLP(nn.Module):
+    def __init__(s):
+        super().__init__(); s.emb=nn.Linear(d,W)
+        s.A=nn.ParameterList([nn.Parameter(torch.randn(W,W)/W**0.5) for _ in range(L)])
+        s.B=nn.ParameterList([nn.Parameter(torch.randn(W,W)/W**0.5*0.5) for _ in range(L)])
+        s.rd=nn.Linear(W,1)
+    def forward(s,x):
+        z=s.emb(x)
+        for A,B in zip(s.A,s.B): z=z+torch.tanh(z@A.t())@B.t()
+        return s.rd(z).squeeze(-1)
+def gen(n,rng):     # nonlinear 6-dim signal (rewards depth): y = sign(x0x1 + x2x3 − x4x5)
+    X=rng.standard_normal((n,d)).astype('float32')
+    s_=X[:,0]*X[:,1]+X[:,2]*X[:,3]-X[:,4]*X[:,5]
+    return torch.tensor(X),torch.tensor((s_>0).astype('float32'))
+rng=np.random.default_rng(0); torch.manual_seed(0)
+net=ResMLP(); opt=torch.optim.Adam(net.parameters(),2e-3); lossf=nn.BCEWithLogitsLoss()
+Xte,yte=gen(4000,np.random.default_rng(1)); acc=0.0
+for it in range(5000):
+    X,y=gen(256,rng); opt.zero_grad(); l=lossf(net(X),y); l.backward(); opt.step()
+    if it%1000==0 or it==4999:
+        with torch.no_grad(): acc=((net(Xte)>0).float()==yte).float().mean().item()
+        print(f"  step {it:4d}  test acc {acc:.3f}",flush=True)
+CONVERGED=acc>0.85
+print(f"  CONVERGENCE: test acc {acc:.3f} → {'LEARNED (probe meaningful)' if CONVERGED else 'NOT LEARNED'}",flush=True)
+# ---- analytic branch Jacobians (numpy) from trained + init weights ----
+def branch_jacs(embW,embb,A,B,x):
+    z=embW@x+embb; Js=[]
+    for Al,Bl in zip(A,B):
+        a=np.tanh(Al@z); Js.append(Bl@((1-a*a)[:,None]*Al)); z=z+Bl@a
+    return Js
+def align_curve(mats,ks):
+    Vt=[np.linalg.svd(A)[2] for A in mats]
+    return np.array([np.mean([np.linalg.svd(Vt[l][-k:]@Vt[l+1][-k:].T,compute_uv=False).mean() for l in range(len(Vt)-1)]) for k in ks])
+def scramble(mats,rng):    # orientation-scramble null: F'_l → O_{l+1} F'_l O_l^T (preserves spectrum, kills alignment)
+    Os=[np.linalg.qr(rng.standard_normal((W,W)))[0] for _ in range(len(mats)+1)]
+    return [Os[l+1]@mats[l]@Os[l].T for l in range(len(mats))]
+emb=net.emb.weight.detach().numpy(); embb=net.emb.bias.detach().numpy()
+At=[p.detach().numpy() for p in net.A]; Bt=[p.detach().numpy() for p in net.B]
+net0=ResMLP(); e0=net0.emb.weight.detach().numpy(); b0=net0.emb.bias.detach().numpy()
+A0=[p.detach().numpy() for p in net0.A]; B0=[p.detach().numpy() for p in net0.B]
+ks=list(range(1,W)); base=np.sqrt(np.array(ks)/W); rr=np.random.default_rng(7)
+TR=np.array([align_curve(branch_jacs(emb,embb,At,Bt, rr.standard_normal(d)),ks) for _ in range(16)]).mean(0)
+IN=np.array([align_curve(branch_jacs(e0,b0,A0,B0, rr.standard_normal(d)),ks) for _ in range(16)]).mean(0)
+SC=np.array([align_curve(scramble(branch_jacs(emb,embb,At,Bt, rr.standard_normal(d)),rr),ks) for _ in range(16)]).mean(0)
+show=[1,2,4,6,8,16,32,48]
+def row(a): return " ".join(f"{a[ks.index(k)]:5.2f}" for k in show)
+print(f"\nResMLP branch F'_l align(k)   W={W}, L={L}, task y=sign(x0x1+x2x3−x4x5), acc={acc:.2f}:")
+print(f"  k          "+" ".join(f"{k:>5}" for k in show))
+print(f"  baseline   "+" ".join(f"{np.sqrt(k/W):5.2f}" for k in show))
+print(f"  TRAINED    "+row(TR))
+print(f"  INIT       "+row(IN))
+print(f"  SCRAMBLE   "+row(SC))
+exc=TR-base; kmax=ks[int(np.argmax(exc))]
+print(f"\n  trained max excess over baseline {exc.max():+.2f} at k={kmax}; trained−init@{kmax}={TR[ks.index(kmax)]-IN[ks.index(kmax)]:+.2f}")
+if exc.max()<0.10:
+    verdict="NEGATIVE — branch alignment at baseline even after training (no shared dying subspace)."
+elif TR[ks.index(48)]>base[ks.index(48)]+0.15:
+    verdict="LOW-RANK — alignment high to large k (magnitude/rank), not a small-k annihilation shoulder."
+elif TR[ks.index(kmax)]-IN[ks.index(kmax)]<0.10:
+    verdict="ARCHITECTURAL — trained ≈ init, not learned."
+else:
+    verdict=f"POSITIVE — small-k shoulder at k≈{kmax} above baseline AND above init/scramble: learned subspace annihilation."
+print(f"  → {verdict}")
+print("DONE",flush=True)


### PR DESCRIPTION
## The terminal result of the Jacobian composition-annihilation probe line

The probe asks whether a trained network's per-layer Jacobians share a **dying subspace** — consecutive maps annihilating the *same* low-dim directions, the finite-dimensional shadow of a sedenion zero-divisor `x·y = 0`. Measured as principal-angle alignment of the bottom-`k` right singular subspaces of consecutive branch Jacobians, as a curve `align(k)`.

Every earlier target was **confounded** — alignment was written into the architecture before any training:
- **S4/Mamba** — diagonal `Ā` shares eigenvectors → `align ≡ 1`. Disqualified.
- **LSTM** — shares one `W_hh` every step. The H=256 run found `align ≈ 1.0` at all `k`, but its *untrained init control* was equally ≈ 1.0 → architectural, not learned.

The only clean target has **distinct weights per layer**. A residual net `z_{l+1}=z_l+F_l(z_l)` has `J_l = I + F'_l`; the identity anchors all `J_l`, so we probe the **branch** `F'_l = J_l − I`, never the full `J_l`.

### Clean-target proof (`deep_ffn_probe.py`)
Untrained deep residual FFN, distinct weights, branch align(k) sits **at baseline** `√(k/d)` (max excess −0.02) — no architectural alignment, unlike the LSTM's ≈1.0. The target is clean.

### Trained result (`deep_ffn_train.py`)
ResMLP (`W=96, L=8`) trained with Adam to **96% test acc** on `y=sign(x₀x₁+x₂x₃−x₄x₅)`:

```
  k              1     2     4     8    16    32    48
  baseline    0.10  0.14  0.20  0.29  0.41  0.58  0.71
  TRAINED     0.09  0.12  0.17  0.25  0.36  0.53  0.66
  INIT        0.08  0.12  0.17  0.25  0.35  0.51  0.64
  SCRAMBLE    0.08  0.12  0.17  0.24  0.35  0.51  0.64
  trained max excess over baseline: −0.00
```

**TRAINED ≈ INIT ≈ orientation-scramble null** at every `k`. No small-`k` shoulder, no low-rank plateau. **Verdict: NEGATIVE.**

### What this establishes
- **The instrument is honest.** It survived ~12 refutations, caught its own H=40 `d=56` false positive, correctly attributed the H=256 LSTM `align≈1` to architecture, and now returns a clean negative that beats no null.
- **The hypothesis is falsified on standard nets.** Ordinary gradient training does *not* leave a sedenion-zero-divisor fingerprint. Vanishing gradients here are magnitude/low-rank across *unaligned* directions, not composition annihilation onto a shared subspace.
- **What stands is untouched** — the rupture algebra, the compiler/𝕊-arithmetic, and the Spinoza/conatus geometry are theory and stand on their own. This negative concerns only the narrow empirical claim about vanilla training.

Docs + reproducible numpy/torch scripts only. Reproduce: `python3 docs/research/deep_ffn_{probe,train}.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)