### PR TITLE
feat(stdlib): bigframe grouped diff (beats pandas 0.66x; general periods)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -72,6 +72,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | ngroup_by (1M rows, 1000 dense keys) | | ~8.2 | ~13.2 | **0.62x — Sounio wins** | dense direct-index, sorted-key compacted numbering |
 | cumcount_desc_by (1M rows, 1000 dense keys) | | ~10.7 | ~40.5 | **0.27x — Sounio wins (3.7x)** | dense direct-index reverse cumcount |
 | pct_change_by (1M rows, 1000 dense keys) | | ~13.3 | ~101.7 | **0.13x — Sounio wins (7.6x)** | dense direct-index per-group prev-value tracker |
+| diff_by (1M rows, 1000 dense keys, periods=1) | | ~13.8 | ~20.9 | **0.66x — Sounio wins** | dense stack prev tracker (fast path); ring for periods>1 |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -14,7 +14,7 @@
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
 // grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount;
-// grouped pct_change.
+// grouped pct_change; grouped diff.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -4036,5 +4036,62 @@ pub fn bf_pct_change_by(src: &BigFrame, key_col: i64, val_col: i64, fill: f64) -
         }
         i = i + 1
     }
+    out
+}
+
+/// Per-group difference between a row and the row `periods` earlier IN ITS GROUP (like
+/// pandas df.groupby(key)[val].diff(periods)): out[i] = val[i] - val[periods-back in
+/// group]. The first `periods` rows of each group take `fill`. DENSE integer keys 0..1023
+/// (direct-index, no hashing -- the same fast dense-key contract as bf_groupby_sum; a row
+/// whose key is outside [0,1024) takes `fill`). O(n), one pass: periods==1 uses a stack
+/// last-value tracker (the fast common path); periods>1 uses a per-group ring buffer of
+/// the last `periods` values on the heap. Returns a 1-column BigFrame of length n. NATIVE
+/// + lean_single only (heap).
+pub fn bf_diff_by(src: &BigFrame, key_col: i64, val_col: i64, periods: i64, fill: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    var p = periods
+    if p < 1 { p = 1 }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    if p == 1 {                                        // fast path: stack last-value tracker
+        var prev: [f64; 1024] = [0.0; 1024]
+        var seen: [i64; 1024] = [0; 1024]
+        var i: i64 = 0
+        while i < n {
+            let k = read_f64(kp, i) as i64
+            let v = read_f64(vp, i)
+            if k >= 0 && k < 1024 {
+                if seen[k] == 0 { seen[k] = 1; write_f64(op, i, fill) } else { write_f64(op, i, v - prev[k]) }
+                prev[k] = v
+            } else {
+                write_f64(op, i, fill)
+            }
+            i = i + 1
+        }
+        return out
+    }
+    var occ: [i64; 1024] = [0; 1024]                   // general path: per-group ring of last `periods`
+    let hist = heap_alloc(1024 * p * 8) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 {
+            let j = occ[k]
+            let idx = k * p + (j - p * (j / p))        // ring slot = k*p + (j mod p)
+            if j >= p { write_f64(op, i, v - read_f64(hist, idx)) } else { write_f64(op, i, fill) }
+            write_f64(hist, idx, v)
+            occ[k] = j + 1
+        } else {
+            write_f64(op, i, fill)
+        }
+        i = i + 1
+    }
+    heap_free(hist as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -995,6 +995,29 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var pgd: i64 = 0; var pgj: i64 = 0
     while pgj < 300 { if !approx_eq(bf_get(&pgb, pgj, 0), bf_get(&pgu, pgj, 0)) { pgd = pgd + 1 } pgj = pgj + 1 }
     if pgd != 0 { print("FAIL pctchg_vs_ungrouped\n"); return 351 }
+    // GROUPED DIFF. 2 groups (key=r%2), val=r -> within group consecutive members differ by
+    // 2 (rows g, g+2, g+4,...). periods=1 -> diff 2 (first-in-group fill); periods=2 -> diff 4.
+    var dff = bf_new(2, 16)
+    var dfi: i64 = 0
+    while dfi < 20 { var dfr:[f64;64]=[0.0;64]; dfr[0]=(dfi%2) as f64; dfr[1]=dfi as f64; bf_push_row(&!dff,&dfr,2); dfi=dfi+1 }
+    let d1 = bf_diff_by(&dff, 0, 1, 1, 0.0 - 999.0)
+    if bf_nrows(&d1) != 20 { print("FAIL diff_n\n"); return 352 }
+    if bf_get(&d1, 0, 0) != (0.0 - 999.0) || bf_get(&d1, 1, 0) != (0.0 - 999.0) { print("FAIL diff_fill\n"); return 353 } // first of each group
+    if bf_get(&d1, 2, 0) != 2.0 || bf_get(&d1, 3, 0) != 2.0 { print("FAIL diff_p1\n"); return 354 }  // g0: 2-0=2, g1: 3-1=2
+    if bf_get(&d1, 18, 0) != 2.0 { print("FAIL diff_p1_last\n"); return 355 }
+    let d2 = bf_diff_by(&dff, 0, 1, 2, 0.0 - 999.0)   // periods 2 (ring path)
+    if bf_get(&d2, 2, 0) != (0.0 - 999.0) { print("FAIL diff_p2_fill\n"); return 356 }   // group 0 occ 1 < 2 -> fill
+    if bf_get(&d2, 4, 0) != 4.0 { print("FAIL diff_p2\n"); return 357 }                   // g0 occ2: row4(val4)-row0(val0)=4
+    if bf_get(&d2, 6, 0) != 4.0 { print("FAIL diff_p2b\n"); return 358 }                  // g0 occ3: val6-val2=4
+    // CROSS-CHECK: single-group diff_by(periods=1) == ungrouped bf_diff(periods=1).
+    var dgf = bf_new(2, 16)
+    var dgk: i64 = 0
+    while dgk < 300 { var dr:[f64;64]=[0.0;64]; dr[0]=0.0; dr[1]=((dgk*17)%71) as f64; bf_push_row(&!dgf,&dr,2); dgk=dgk+1 }
+    let dgb = bf_diff_by(&dgf, 0, 1, 1, 0.0 - 999.0)
+    let dgu = bf_diff(&dgf, 1, 1, 0.0 - 999.0)
+    var dgd: i64 = 0; var dgj: i64 = 0
+    while dgj < 300 { if bf_get(&dgb, dgj, 0) != bf_get(&dgu, dgj, 0) { dgd = dgd + 1 } dgj = dgj + 1 }
+    if dgd != 0 { print("FAIL diff_vs_ungrouped\n"); return 359 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_diff_by` in `data::bigframe_ops` — per-group **difference** between a row and the row `periods` earlier **in its group** (pandas `df.groupby(key)[val].diff(periods)`): `out[i] = val[i] - val[periods-back in group]`. The first `periods` rows of each group take `fill`.

**Dense direct-index** over keys 0..1023 (no hashing — same fast dense-key contract as `bf_groupby_sum`), O(n) single pass. `periods==1` uses a **stack last-value tracker** (the fast common path); `periods>1` uses a **per-group ring buffer** of the last `periods` values on the heap.

Notably, the **ungrouped** `bf_diff` loses to pandas (SIMD-friendly elementwise), but **grouped diff wins** — pandas' `groupby diff` carries per-group machinery the dense tracker skips.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups whose members differ by 2 → diff(1)=2 (first-in-group `fill`), diff(2)=4 (exercises the ring path, occ<2 → `fill`);
- a **single-group cross-check** that `bf_diff_by(periods=1)` == the ungrouped `bf_diff`;
- (offline) matched pandas `groupby diff` for periods 1 and 3 over 18k rows / 60 groups = **0 diffs**.

## Benchmark (1M rows, 1000 dense keys, periods=1)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| diff_by | ~13.8 | ~20.9 | **0.66× — Sounio wins** |

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)