### PR TITLE
feat(stdlib): bigframe grouped ffill / bfill (beat pandas 3.1x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -74,6 +74,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | pct_change_by (1M rows, 1000 dense keys) | | ~13.3 | ~101.7 | **0.13x — Sounio wins (7.6x)** | dense direct-index per-group prev-value tracker |
 | diff_by (1M rows, 1000 dense keys, periods=1) | | ~13.8 | ~20.9 | **0.66x — Sounio wins** | dense stack prev tracker (fast path); ring for periods>1 |
 | shift_by (1M rows, 1000 dense keys, periods=1) | | ~13.5 | ~22.0 | **0.62x — Sounio wins** | dense stack tracker; fwd lag / rev lead ring for \|p\|>1 |
+| ffill_by / bfill_by (1M rows, 1000 dense keys) | | ~30.7 | ~96.3 | **0.32x — Sounio wins (3.1x)** | dense last/next-valid tracker; sentinel-marked NA |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -14,7 +14,7 @@
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
 // grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount;
-// grouped pct_change; grouped diff; grouped shift.
+// grouped pct_change; grouped diff; grouped shift; grouped ffill / bfill.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -4182,5 +4182,71 @@ pub fn bf_shift_by(src: &BigFrame, key_col: i64, val_col: i64, periods: i64, fil
         }
     }
     heap_free(hist as *mut i8)
+    out
+}
+
+/// Per-group FORWARD-FILL of missing cells (like pandas df.groupby(key)[val].ffill()):
+/// a cell equal to the sentinel `na` is replaced by the last non-`na` value earlier in
+/// its group; a leading run of `na` in a group (no prior valid value) stays `na`. (Sounio
+/// f64 comparison does not follow IEEE NaN semantics -- `NaN == NaN` is true and NaN does
+/// not survive a column round-trip -- so missing is marked by a caller-chosen sentinel,
+/// not IEEE NaN.) DENSE integer keys 0..1023 (direct-index, no hashing -- the same fast
+/// dense-key contract as bf_groupby_sum). O(n), one forward pass. Returns a 1-column
+/// BigFrame of length n. NATIVE + lean_single only (heap).
+pub fn bf_ffill_by(src: &BigFrame, key_col: i64, val_col: i64, na: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var last: [f64; 1024] = [0.0; 1024]
+    var has:  [i64; 1024] = [0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 {
+            if v == na { if has[k] == 1 { write_f64(op, i, last[k]) } else { write_f64(op, i, na) } }
+            else { write_f64(op, i, v); last[k] = v; has[k] = 1 }
+        } else {
+            write_f64(op, i, v)
+        }
+        i = i + 1
+    }
+    out
+}
+
+/// Per-group BACKWARD-FILL of missing cells (like pandas df.groupby(key)[val].bfill()):
+/// a cell equal to the sentinel `na` is replaced by the next non-`na` value later in its
+/// group; a trailing run of `na` in a group (no later valid value) stays `na`. Missing is
+/// marked by the caller-chosen sentinel `na` (see bf_ffill_by on Sounio's NaN handling).
+/// DENSE integer keys 0..1023 (direct-index, no hashing). O(n), one BACKWARD pass. Returns
+/// a 1-column BigFrame of length n. NATIVE + lean_single only (heap).
+pub fn bf_bfill_by(src: &BigFrame, key_col: i64, val_col: i64, na: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var nxt: [f64; 1024] = [0.0; 1024]
+    var has: [i64; 1024] = [0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = n - 1
+    while i >= 0 {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 {
+            if v == na { if has[k] == 1 { write_f64(op, i, nxt[k]) } else { write_f64(op, i, na) } }
+            else { write_f64(op, i, v); nxt[k] = v; has[k] = 1 }
+        } else {
+            write_f64(op, i, v)
+        }
+        i = i - 1
+    }
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1047,6 +1047,29 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var sgd2: i64 = 0; var sgj2: i64 = 0
     while sgj2 < 300 { if bf_get(&sgb, sgj2, 0) != bf_get(&sgu, sgj2, 0) { sgd2 = sgd2 + 1 } sgj2 = sgj2 + 1 }
     if sgd2 != 0 { print("FAIL shift_vs_ungrouped\n"); return 370 }
+    // GROUPED FFILL / BFILL. 2 groups (key=r%2), na=-7. Build a pattern per group with
+    // leading/interior/trailing missing to exercise both fill directions.
+    // rows (r,key,val): use val = r unless marked missing. Mark rows 0,2 (group 0 first two)
+    // and rows 16,18 (group 0 last two) missing; group 1 all valid.
+    var flf = bf_new(2, 16)
+    var fli: i64 = 0
+    while fli < 20 { var flr:[f64;64]=[0.0;64]; flr[0]=(fli%2) as f64
+        if fli==0 || fli==2 || fli==16 || fli==18 { flr[1]=0.0-7.0 } else { flr[1]=fli as f64 }
+        bf_push_row(&!flf,&flr,2); fli=fli+1 }
+    let ff = bf_ffill_by(&flf, 0, 1, 0.0 - 7.0)
+    if bf_nrows(&ff) != 20 { print("FAIL ffill_n\n"); return 371 }
+    // group 0 rows: 0(na),2(na),4,6,8,10,12,14,16(na),18(na). ffill: 0,2 leading na stay na;
+    // 4->4; 16,18 -> last valid = 14.
+    if bf_get(&ff, 0, 0) != (0.0 - 7.0) || bf_get(&ff, 2, 0) != (0.0 - 7.0) { print("FAIL ffill_lead\n"); return 372 }
+    if bf_get(&ff, 4, 0) != 4.0 { print("FAIL ffill_valid\n"); return 373 }
+    if bf_get(&ff, 16, 0) != 14.0 || bf_get(&ff, 18, 0) != 14.0 { print("FAIL ffill_trail\n"); return 374 } // carried 14
+    let bf2 = bf_bfill_by(&flf, 0, 1, 0.0 - 7.0)
+    // bfill: 0,2 -> next valid = 4; 16,18 trailing na stay na.
+    if bf_get(&bf2, 0, 0) != 4.0 || bf_get(&bf2, 2, 0) != 4.0 { print("FAIL bfill_lead\n"); return 375 }
+    if bf_get(&bf2, 16, 0) != (0.0 - 7.0) || bf_get(&bf2, 18, 0) != (0.0 - 7.0) { print("FAIL bfill_trail\n"); return 376 }
+    if bf_get(&bf2, 4, 0) != 4.0 { print("FAIL bfill_valid\n"); return 377 }
+    // group 1 (all valid) is untouched by either fill.
+    if bf_get(&ff, 5, 0) != 5.0 || bf_get(&bf2, 5, 0) != 5.0 { print("FAIL fill_g1\n"); return 378 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_ffill_by` and `bf_bfill_by` in `data::bigframe_ops` — per-group **forward / backward fill** of missing cells (pandas `df.groupby(key)[val].ffill()` / `.bfill()`): a cell equal to the caller-chosen sentinel `na` is replaced by the last (ffill) / next (bfill) non-`na` value in its group; a leading run (ffill) / trailing run (bfill) of `na` in a group stays `na`.

**Missing is marked by a sentinel, not IEEE NaN.** Sounio's f64 comparison does not follow IEEE NaN semantics (`NaN == NaN` is true, and NaN does not survive a bigframe column round-trip — verified), so a NaN-based fillna would be unreliable. The sentinel `na` is compared with the compiler's exact `==`, correct for finite values.

**Dense direct-index** over keys 0..1023 (no hashing — same fast dense-key contract as `bf_groupby_sum`), O(n): ffill one forward pass, bfill one **backward** pass, each tracking the last/next valid value per group.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups with leading, interior and trailing missing → ffill carries the last valid forward and leaves leading na as na; bfill carries the next valid backward and leaves trailing na as na; a fully-valid group is untouched;
- (offline) both matched pandas `groupby ffill/bfill` (na↔NaN) over 12k rows / 40 groups = **0 diffs**.

## Benchmark (1M rows, 1000 dense keys, 1/3 missing)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| ffill_by / bfill_by | ~30.7 | ~96.3 | **0.32× — Sounio wins (3.1×)** |

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)