### PR TITLE
coordination: add live cross-worktree lane leases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
         run: bash scripts/dev/worktree_branch_audit.sh --check
       - name: Compiler lane status contract
         run: bash scripts/ci/compiler_lane_status_gate.sh
+      - name: Live lane coordination self-test
+        run: bash scripts/ci/sounio_coord_selftest.sh
       - name: Portable compiler build lock self-test
         run: python3 scripts/ci/souc_build_lock_selftest.py
       - name: CI watch receipt self-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,30 @@ Use `bash scripts/dev/sounio_semantic_status.sh` before assigning overlapping
 semantic work. Scanner output is observational; dirty worktrees are potential
 writers, not automatic ownership claims.
 
+### Live lane coordination
+
+`bin/sounio-coord` is the live, cross-worktree coordination surface. It stores
+short-lived leases outside Git, keyed by the repository's shared Git directory,
+so attached worktrees see the same active claims.
+
+Before the first write in an implementation lane:
+
+1. Run `bin/sounio-coord brief` (also shown by `./sounio-whereami --quick`).
+2. Claim the exact write set:
+   `bin/sounio-coord claim --agent <id> --lane <id> --intent "<goal>" --files <paths...>`.
+3. Keep long-running work alive with
+   `bin/sounio-coord heartbeat --agent <id> --lane <id>`.
+4. Release on completion, abort, or handoff with
+   `bin/sounio-coord release --agent <id> --lane <id> --reason "<result>"`.
+
+Put `--files` last and quote glob scopes such as
+`'self-hosted/compiler/**'`. The command refuses overlapping active claims.
+Claims expire after four hours by default; expiry makes abandoned work visible,
+but does not authorize overwriting dirty files. Git status and executable repo
+truth still outrank coordination metadata. Treat this as runtime presence, not a
+durable handoff record; blockers and consequential handoffs still belong in the
+repository contracts named below.
+
 If an agent leaves a blocker for another agent, it must use that contract's
 Blocker-ID, severity, class, evidence, owner, worktree, branch, acceptance gate,
 and next-action fields.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -72,7 +72,20 @@ IR ou claims científicas, leia também
 ## 7. Coordenação multi-agente
 
 - Múltiplas sessões Opus/Codex rodam concorrentes neste repo.
-- **Coordene antes de editar arquivos compartilhados.** Re-cheque `git status` antes de stage.
+- O `./sounio-whereami --quick` já mostra o resumo vivo de coordenação.
+- Antes da primeira edição, reserve a lane e seu conjunto de escrita:
+  `bin/sounio-coord claim --agent <id> --lane <id> --intent "<objetivo>" --files <caminhos...>`.
+- Mantenha tarefas longas vivas com
+  `bin/sounio-coord heartbeat --agent <id> --lane <id>`.
+- Ao terminar, abortar ou entregar a lane, rode
+  `bin/sounio-coord release --agent <id> --lane <id> --reason "<resultado ou handoff>"`.
+- Use `bin/sounio-coord check` antes de editar uma superfície compartilhada.
+- Claims são leases operacionais, não prova de atividade eterna. O TTL padrão é quatro horas;
+  claims vencidos aparecem como `STALE` e podem ser removidos com `bin/sounio-coord prune`.
+- Coloque `--files` por último e proteja globs com aspas, por exemplo
+  `'self-hosted/compiler/**'`.
+- **Re-cheque `git status` antes de stage.** Nunca trate uma claim como licença para
+  sobrescrever mudanças já presentes na worktree.
 - Edits podem aparecer no commit de outro agente sob mensagens não-relacionadas. Não brigue com a história.
 
 ## 8. Precedência quando docs divergem

--- a/bin/sounio-coord
+++ b/bin/sounio-coord
@@ -1,0 +1,603 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/sounio-coord <command> [options]
+
+Small shared coordination bus for Sounio worktrees. Claims live outside Git
+so every worktree attached to the same repository can see the same leases.
+
+Commands:
+  brief                          show the startup-sized coordination summary
+  status                         show claims, conflicts, and relevant worktrees
+  status --all-worktrees         include a full (slower) worktree scan
+  check                          status, then fail when active file conflicts exist
+  claim   --agent ID --lane ID --intent TEXT --files PATH [PATH ...]
+                                 reserve a file set for one lane
+  heartbeat --agent ID --lane ID
+                                 refresh an existing claim
+  release --agent ID --lane ID --reason TEXT
+                                 release a claim and record the handoff event
+  prune                          remove expired claims
+
+Environment:
+  SOUNIO_AGENT_ID                default agent identifier for claim commands
+  SOUNIO_COORD_TTL_SECONDS       claim lease duration (default: 14400)
+  SOUNIO_COORD_DIR               shared state directory override
+
+Examples:
+  bin/sounio-coord status
+  bin/sounio-coord claim --agent codex-1 --lane parser-fix \
+    --intent "isolate parser regression" --files 'self-hosted/parser/**' tests/compile-fail/foo.sio
+  bin/sounio-coord heartbeat --agent codex-1 --lane parser-fix
+  bin/sounio-coord release --agent codex-1 --lane parser-fix --reason "handed to shepherd"
+USAGE
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_arg() {
+  local option="$1"
+  (($# >= 2)) || die "$option requires a value"
+  [[ -n "$2" ]] || die "$option requires a non-empty value"
+}
+
+WORKTREE="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -n "$WORKTREE" ]] || die "run this command from a Sounio worktree"
+WORKTREE="$(cd "$WORKTREE" && pwd -P)"
+
+GIT_COMMON_DIR="$(git -C "$WORKTREE" rev-parse --git-common-dir 2>/dev/null || true)"
+[[ -n "$GIT_COMMON_DIR" ]] || die "cannot resolve the shared Git directory"
+case "$GIT_COMMON_DIR" in
+  /*) ;;
+  *) GIT_COMMON_DIR="$(cd "$WORKTREE/$GIT_COMMON_DIR" && pwd -P)" ;;
+esac
+
+REPO_KEY="$(printf '%s' "$GIT_COMMON_DIR" | cksum | awk '{print $1}')"
+STATE_DIR="${SOUNIO_COORD_DIR:-${TMPDIR:-/tmp}/sounio-coord/$REPO_KEY}"
+CLAIMS_DIR="$STATE_DIR/claims"
+EVENT_LOG="$STATE_DIR/events.log"
+mkdir -p "$CLAIMS_DIR"
+
+NOW_EPOCH="$(date +%s)"
+NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+shopt -s nullglob
+LOCK_TO_CLEAN=''
+LOCK_FD=''
+
+cleanup_lock() {
+  if [[ -n "$LOCK_FD" ]]; then
+    flock -u "$LOCK_FD" 2>/dev/null || true
+  fi
+  if [[ -n "$LOCK_TO_CLEAN" ]]; then
+    rmdir "$LOCK_TO_CLEAN" 2>/dev/null || true
+    LOCK_TO_CLEAN=''
+  fi
+}
+
+trap cleanup_lock EXIT
+
+acquire_state_lock() {
+  local action="$1" lock_dir lock_epoch
+  if command -v flock >/dev/null 2>&1; then
+    exec {LOCK_FD}>"$STATE_DIR/.claims.lock"
+    flock -n "$LOCK_FD" || die "coordination state is being changed; retry $action"
+    return 0
+  fi
+
+  lock_dir="$STATE_DIR/.claims.lock.d"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    lock_epoch="$(stat -c %Y "$lock_dir" 2>/dev/null || printf 0)"
+    if [[ "$lock_epoch" =~ ^[0-9]+$ ]] && ((NOW_EPOCH - lock_epoch > 30)); then
+      rmdir "$lock_dir" 2>/dev/null || true
+    fi
+    mkdir "$lock_dir" 2>/dev/null || die "coordination state is being changed; retry $action"
+  fi
+  LOCK_TO_CLEAN="$lock_dir"
+}
+
+current_branch() {
+  local branch
+  branch="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
+  if [[ -n "$branch" ]]; then
+    printf '%s' "$branch"
+  else
+    printf 'detached@%s' "$(git -C "$WORKTREE" rev-parse --short=10 HEAD 2>/dev/null || printf unknown)"
+  fi
+}
+
+current_sha() {
+  git -C "$WORKTREE" rev-parse --short=12 HEAD 2>/dev/null || printf unknown
+}
+
+slug() {
+  local value
+  value="$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_' | cut -c1-80)"
+  [[ -n "$value" ]] || value=unnamed
+  printf '%s' "$value"
+}
+
+claim_id_for() {
+  printf '%s--%s' "$(slug "$1")" "$(slug "$2")"
+}
+
+normalize_path() {
+  local path="$1"
+  case "$path" in
+    "$WORKTREE"/*) printf '%s' "${path#"$WORKTREE"/}" ;;
+    /*) printf '%s' "$path" ;;
+    ./*) printf '%s' "${path#./}" ;;
+    *) printf '%s' "$path" ;;
+  esac
+}
+
+validate_value() {
+  local label="$1" value="$2"
+  case "$value" in
+    *$'\n'*|*$'\r'*|*$'\t'*) die "$label cannot contain tabs or newlines" ;;
+  esac
+}
+
+join_files() {
+  local output='' file
+  for file in "${C_FILES[@]}"; do
+    if [[ -n "$output" ]]; then
+      output="$output,$file"
+    else
+      output="$file"
+    fi
+  done
+  printf '%s' "$output"
+}
+
+load_claim() {
+  local claim_file="$1" line
+  C_ID=''
+  C_AGENT=''
+  C_LANE=''
+  C_WORKTREE=''
+  C_BRANCH=''
+  C_SHA=''
+  C_CREATED_UTC=''
+  C_LAST_UTC=''
+  C_LAST_EPOCH=0
+  C_TTL=0
+  C_INTENT=''
+  C_FILES=()
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      claim_id=*) C_ID="${line#claim_id=}" ;;
+      agent=*) C_AGENT="${line#agent=}" ;;
+      lane=*) C_LANE="${line#lane=}" ;;
+      worktree=*) C_WORKTREE="${line#worktree=}" ;;
+      branch=*) C_BRANCH="${line#branch=}" ;;
+      sha=*) C_SHA="${line#sha=}" ;;
+      created_utc=*) C_CREATED_UTC="${line#created_utc=}" ;;
+      last_seen_utc=*) C_LAST_UTC="${line#last_seen_utc=}" ;;
+      last_seen_epoch=*) C_LAST_EPOCH="${line#last_seen_epoch=}" ;;
+      ttl_seconds=*) C_TTL="${line#ttl_seconds=}" ;;
+      intent=*) C_INTENT="${line#intent=}" ;;
+      file=*) C_FILES+=("${line#file=}") ;;
+    esac
+  done < "$claim_file"
+}
+
+claim_expired() {
+  local ttl="${C_TTL:-0}" last="${C_LAST_EPOCH:-0}"
+  [[ "$ttl" =~ ^[0-9]+$ && "$last" =~ ^[0-9]+$ ]] || return 0
+  if (( NOW_EPOCH > last + ttl )); then
+    return 0
+  fi
+  return 1
+}
+
+path_scope() {
+  local path="$1"
+  case "$path" in
+    */\*\*) path="${path%/**}" ;;
+  esac
+  while [[ "$path" == */ ]]; do path="${path%/}"; done
+  printf '%s' "$path"
+}
+
+paths_overlap() {
+  local left right
+  left="$(path_scope "$1")"
+  right="$(path_scope "$2")"
+  [[ "$left" == "$right" ]] && return 0
+  [[ "$left" == "$right"/* ]] && return 0
+  [[ "$right" == "$left"/* ]] && return 0
+  return 1
+}
+
+write_claim() {
+  local claim_file="$1" tmp_file
+  tmp_file="$(mktemp "$CLAIMS_DIR/.claim-write.XXXXXX")"
+  {
+    printf 'claim_id=%s\n' "$C_ID"
+    printf 'agent=%s\n' "$C_AGENT"
+    printf 'lane=%s\n' "$C_LANE"
+    printf 'worktree=%s\n' "$C_WORKTREE"
+    printf 'branch=%s\n' "$C_BRANCH"
+    printf 'sha=%s\n' "$C_SHA"
+    printf 'created_utc=%s\n' "$C_CREATED_UTC"
+    printf 'last_seen_utc=%s\n' "$C_LAST_UTC"
+    printf 'last_seen_epoch=%s\n' "$C_LAST_EPOCH"
+    printf 'ttl_seconds=%s\n' "$C_TTL"
+    printf 'intent=%s\n' "$C_INTENT"
+    printf 'file=%s\n' "${C_FILES[@]}"
+  } > "$tmp_file"
+  mv "$tmp_file" "$claim_file"
+}
+
+append_event() {
+  local event="$1" reason="${2:-}"
+  printf 'utc=%s event=%s agent=%s lane=%s worktree=%s branch=%s sha=%s files=%s intent=%s reason=%s\n' \
+    "$NOW_UTC" "$event" "$C_AGENT" "$C_LANE" "$C_WORKTREE" "$C_BRANCH" \
+    "$C_SHA" "$(join_files)" "$C_INTENT" "$reason" >> "$EVENT_LOG"
+}
+
+claim_paths=()
+refresh_claim_paths() {
+  claim_paths=("$CLAIMS_DIR"/*.claim)
+}
+
+worktree_has_claim() {
+  local candidate="$1" claim_file
+  refresh_claim_paths
+  for claim_file in "${claim_paths[@]}"; do
+    [[ -f "$claim_file" ]] || continue
+    load_claim "$claim_file"
+    claim_expired && continue
+    [[ "$C_WORKTREE" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+worktree_in_list() {
+  local candidate="$1" item
+  for item in "${inspect_worktrees[@]}"; do
+    [[ "$item" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+claim_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' intent='' ttl="${SOUNIO_COORD_TTL_SECONDS:-14400}"
+  local file claim_file existing old_file new_file conflict=0
+  local files=()
+
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      --intent) require_arg "$1" "$2"; intent="$2"; shift 2 ;;
+      --ttl-seconds) require_arg "$1" "$2"; ttl="$2"; shift 2 ;;
+      --files)
+        shift
+        while (($#)); do files+=("$(normalize_path "$1")"); shift; done
+        ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown claim option: $1 (put paths after --files)" ;;
+    esac
+  done
+
+  [[ -n "$agent" ]] || die "claim requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "claim requires --lane"
+  [[ -n "$intent" ]] || die "claim requires --intent"
+  ((${#files[@]} > 0)) || die "claim requires at least one path after --files"
+  [[ "$ttl" =~ ^[1-9][0-9]*$ ]] || die "--ttl-seconds must be a positive integer"
+  validate_value agent "$agent"
+  validate_value lane "$lane"
+  validate_value intent "$intent"
+  for file in "${files[@]}"; do validate_value file "$file"; done
+
+  C_ID="$(claim_id_for "$agent" "$lane")"
+  claim_file="$CLAIMS_DIR/$C_ID.claim"
+  acquire_state_lock "the claim"
+  [[ ! -e "$claim_file" ]] || die "claim already exists: $C_ID (use heartbeat or release it first)"
+
+  refresh_claim_paths
+  for existing in "${claim_paths[@]}"; do
+    [[ -f "$existing" ]] || continue
+    load_claim "$existing"
+    claim_expired && continue
+    [[ "$C_ID" == "$(claim_id_for "$agent" "$lane")" ]] && continue
+    for new_file in "${files[@]}"; do
+      for old_file in "${C_FILES[@]}"; do
+        if paths_overlap "$new_file" "$old_file"; then
+          printf 'CONFLICT existing_claim=%s agent=%s lane=%s path=%s requested_by=%s requested_lane=%s\n' \
+            "$C_ID" "$C_AGENT" "$C_LANE" "$old_file" "$agent" "$lane" >&2
+          conflict=1
+        fi
+      done
+    done
+  done
+  ((conflict == 0)) || die "requested file set overlaps an active claim"
+
+  C_AGENT="$agent"
+  C_LANE="$lane"
+  C_WORKTREE="$WORKTREE"
+  C_BRANCH="$(current_branch)"
+  C_SHA="$(current_sha)"
+  C_CREATED_UTC="$NOW_UTC"
+  C_LAST_UTC="$NOW_UTC"
+  C_LAST_EPOCH="$NOW_EPOCH"
+  C_TTL="$ttl"
+  C_INTENT="$intent"
+  C_FILES=("${files[@]}")
+  C_ID="$(claim_id_for "$agent" "$lane")"
+  write_claim "$claim_file"
+  append_event CLAIM
+  printf 'CLAIMED claim_id=%s\n' "$C_ID"
+  printf 'agent=%s lane=%s worktree=%s branch=%s sha=%s\n' "$agent" "$lane" "$WORKTREE" "$C_BRANCH" "$C_SHA"
+  printf 'files=%s\n' "$(join_files)"
+  printf 'state_dir=%s\n' "$STATE_DIR"
+  printf 'next=bin/sounio-coord heartbeat --agent %s --lane %s\n' "$agent" "$lane"
+}
+
+heartbeat_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' claim_file
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown heartbeat option: $1" ;;
+    esac
+  done
+  [[ -n "$agent" ]] || die "heartbeat requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "heartbeat requires --lane"
+  claim_file="$CLAIMS_DIR/$(claim_id_for "$agent" "$lane").claim"
+  [[ -f "$claim_file" ]] || die "claim not found: $(claim_id_for "$agent" "$lane")"
+  load_claim "$claim_file"
+  [[ "$C_AGENT" == "$agent" ]] || die "claim owner mismatch: $C_AGENT"
+  [[ "$C_WORKTREE" == "$WORKTREE" ]] || die "claim belongs to worktree $C_WORKTREE"
+  [[ "$C_BRANCH" == "$(current_branch)" ]] || die "branch changed from $C_BRANCH; release and claim again"
+
+  acquire_state_lock "the heartbeat"
+  C_LAST_UTC="$NOW_UTC"
+  C_LAST_EPOCH="$NOW_EPOCH"
+  C_SHA="$(current_sha)"
+  write_claim "$claim_file"
+  append_event HEARTBEAT
+  printf 'HEARTBEAT claim_id=%s last_seen=%s sha=%s\n' "$C_ID" "$C_LAST_UTC" "$C_SHA"
+}
+
+release_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' reason='' claim_file
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      --reason) require_arg "$1" "$2"; reason="$2"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown release option: $1" ;;
+    esac
+  done
+  [[ -n "$agent" ]] || die "release requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "release requires --lane"
+  [[ -n "$reason" ]] || die "release requires --reason"
+  validate_value reason "$reason"
+  claim_file="$CLAIMS_DIR/$(claim_id_for "$agent" "$lane").claim"
+  [[ -f "$claim_file" ]] || die "claim not found: $(claim_id_for "$agent" "$lane")"
+  load_claim "$claim_file"
+  [[ "$C_AGENT" == "$agent" ]] || die "claim owner mismatch: $C_AGENT"
+  [[ "$C_WORKTREE" == "$WORKTREE" ]] || die "claim belongs to worktree $C_WORKTREE"
+  acquire_state_lock "the release"
+  C_BRANCH="$(current_branch)"
+  C_SHA="$(current_sha)"
+  append_event RELEASE "$reason"
+  unlink "$claim_file"
+  printf 'RELEASED claim_id=%s reason=%s\n' "$C_ID" "${reason:-unspecified}"
+}
+
+prune_command() {
+  local removed=0 claim_file
+  acquire_state_lock "prune"
+  refresh_claim_paths
+  for claim_file in "${claim_paths[@]}"; do
+    [[ -f "$claim_file" ]] || continue
+    load_claim "$claim_file"
+    if claim_expired; then
+      append_event EXPIRED "lease expired"
+      unlink "$claim_file"
+      removed=$((removed + 1))
+      printf 'PRUNED claim_id=%s agent=%s lane=%s\n' "$C_ID" "$C_AGENT" "$C_LANE"
+    fi
+  done
+  printf 'pruned=%s\n' "$removed"
+}
+
+status_command() {
+  local claim_file existing other_file wt branch dirty head marker context_branch file local_conflict
+  local active=0 stale=0 conflicts=0 total_wt=0 dirty_wt=0 claimed_wt=0 shown_wt=0 relevant_wt=0 max_rows
+  local brief=0 inspect_all=0 worktree_scan='current-and-claimed'
+  local -a worktrees=() inspect_worktrees=() first_files=() second_files=()
+  max_rows="${SOUNIO_COORD_MAX_WORKTREE_ROWS:-40}"
+
+  while (($#)); do
+    case "$1" in
+      --all-worktrees)
+        inspect_all=1
+        worktree_scan='all'
+        shift
+        ;;
+      --brief)
+        brief=1
+        shift
+        ;;
+      --max-rows)
+        require_arg "$1" "$2"
+        max_rows="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      *) die "unknown status option: $1" ;;
+    esac
+  done
+  [[ "$max_rows" =~ ^[1-9][0-9]*$ ]] || die "--max-rows must be a positive integer"
+
+  printf 'Sounio coordination status\n'
+  printf 'snapshot_utc=%s\n' "$NOW_UTC"
+  printf 'repo_root=%s\n' "$WORKTREE"
+  printf 'git_common_dir=%s\n' "$GIT_COMMON_DIR"
+  printf 'state_dir=%s\n' "$STATE_DIR"
+  printf 'current_worktree=%s\n' "$WORKTREE"
+  printf 'current_branch=%s\n' "$(current_branch)"
+  printf 'current_sha=%s\n' "$(current_sha)"
+
+  context_branch=''
+  if [[ -f "$WORKTREE/.beagle/context/current-context-packet.json" ]]; then
+    context_branch="$(sed -n 's|.*\"branch\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*|\1|p' "$WORKTREE/.beagle/context/current-context-packet.json" | head -1)"
+  fi
+  if [[ -n "$context_branch" ]]; then
+    printf 'beagle_context_branch=%s\n' "$context_branch"
+    if [[ "$context_branch" != "$(current_branch)" ]]; then
+      printf 'WARNING context_branch_mismatch=git:%s beagle:%s\n' "$(current_branch)" "$context_branch"
+    fi
+  fi
+
+  printf '\n== Claims ==\n'
+  refresh_claim_paths
+  for claim_file in "${claim_paths[@]}"; do
+    [[ -f "$claim_file" ]] || continue
+    load_claim "$claim_file"
+    if claim_expired; then
+      stale=$((stale + 1))
+      printf 'STALE claim_id=%s agent=%s lane=%s last_seen=%s worktree=%s files=%s\n' \
+        "$C_ID" "$C_AGENT" "$C_LANE" "$C_LAST_UTC" "$C_WORKTREE" "$(join_files)"
+    else
+      active=$((active + 1))
+      printf 'ACTIVE claim_id=%s agent=%s lane=%s last_seen=%s branch=%s sha=%s worktree=%s files=%s\n' \
+        "$C_ID" "$C_AGENT" "$C_LANE" "$C_LAST_UTC" "$C_BRANCH" "$C_SHA" "$C_WORKTREE" "$(join_files)"
+    fi
+  done
+  ((active + stale > 0)) || printf 'NONE\n'
+
+  printf '\n== Active conflicts ==\n'
+  for existing in "${claim_paths[@]}"; do
+    [[ -f "$existing" ]] || continue
+    load_claim "$existing"
+    claim_expired && continue
+    for other_file in "${claim_paths[@]}"; do
+      [[ -f "$other_file" && "$other_file" > "$existing" ]] || continue
+      load_claim "$other_file"
+      claim_expired && continue
+      second_files=("${C_FILES[@]}")
+      load_claim "$existing"
+      first_files=("${C_FILES[@]}")
+      local_conflict=0
+      for file in "${first_files[@]}"; do
+        for wt in "${second_files[@]}"; do
+          if paths_overlap "$file" "$wt"; then local_conflict=1; fi
+        done
+      done
+      if ((local_conflict)); then
+        load_claim "$existing"
+        printf 'CONFLICT claim_id=%s agent=%s lane=%s with_claim=%s\n' \
+          "$C_ID" "$C_AGENT" "$C_LANE" "$(basename "$other_file" .claim)"
+        conflicts=$((conflicts + 1))
+      fi
+    done
+  done
+  ((conflicts > 0)) || printf 'NONE\n'
+
+  printf '\n== Worktrees ==\n'
+  mapfile -t worktrees < <(git -C "$WORKTREE" worktree list --porcelain | sed -n 's/^worktree //p')
+  total_wt="${#worktrees[@]}"
+  inspect_worktrees=("$WORKTREE")
+  if ((inspect_all)); then
+    inspect_worktrees=("${worktrees[@]}")
+  else
+    for claim_file in "${claim_paths[@]}"; do
+      [[ -f "$claim_file" ]] || continue
+      load_claim "$claim_file"
+      claim_expired && continue
+      if ! worktree_in_list "$C_WORKTREE"; then
+        inspect_worktrees+=("$C_WORKTREE")
+      fi
+    done
+  fi
+  printf 'worktree_scan=%s\n' "$worktree_scan"
+  for wt in "${inspect_worktrees[@]}"; do
+    [[ -d "$wt" ]] || continue
+    dirty="$(git -C "$wt" status --porcelain=v1 --untracked-files=all 2>/dev/null | wc -l | tr -d ' ')"
+    ((dirty > 0)) && dirty_wt=$((dirty_wt + 1))
+    marker=''
+    [[ "$wt" == "$WORKTREE" ]] && marker=' CURRENT'
+    if worktree_has_claim "$wt"; then
+      marker="$marker CLAIMED"
+      claimed_wt=$((claimed_wt + 1))
+    fi
+    if ((dirty > 0)) || [[ "$wt" == "$WORKTREE" ]] || [[ "$marker" == *CLAIMED* ]]; then
+      relevant_wt=$((relevant_wt + 1))
+      if ((shown_wt < max_rows)); then
+        branch="$(git -C "$wt" branch --show-current 2>/dev/null || true)"
+        [[ -n "$branch" ]] || branch="detached@$(git -C "$wt" rev-parse --short=10 HEAD 2>/dev/null || printf unknown)"
+        head="$(git -C "$wt" rev-parse --short=10 HEAD 2>/dev/null || printf unknown)"
+        printf 'WORKTREE%s path=%s branch=%s head=%s dirty=%s\n' "$marker" "$wt" "$branch" "$head" "$dirty"
+        if ((dirty > 0 && brief == 0)); then
+          git -C "$wt" status --porcelain=v1 --untracked-files=all 2>/dev/null | sed -n '1,6s/^/  change=/'
+        fi
+        shown_wt=$((shown_wt + 1))
+      fi
+    fi
+  done
+  if ((relevant_wt > shown_wt)); then
+    printf 'WORKTREE_OUTPUT_TRUNCATED max_rows=%s\n' "$max_rows"
+  fi
+  printf 'worktrees_total=%s worktrees_inspected=%s worktrees_dirty=%s worktrees_claimed=%s\n' \
+    "$total_wt" "${#inspect_worktrees[@]}" "$dirty_wt" "$claimed_wt"
+
+  if ((brief == 0)); then
+    printf '\n== Recent events ==\n'
+    if [[ -s "$EVENT_LOG" ]]; then
+      tail -12 "$EVENT_LOG"
+    else
+      printf 'NONE\n'
+    fi
+  fi
+  printf '\nsummary=active_claims:%s stale_claims:%s conflicts:%s\n' "$active" "$stale" "$conflicts"
+  STATUS_CONFLICTS="$conflicts"
+}
+
+STATUS_CONFLICTS=0
+command="${1:-status}"
+if (($#)); then shift; fi
+
+case "$command" in
+  brief)
+    status_command --brief "$@"
+    ;;
+  status|list)
+    status_command "$@"
+    ;;
+  check)
+    status_command "$@"
+    if ((STATUS_CONFLICTS > 0)); then
+      printf 'COORDINATION_CHECK=FAIL conflicts=%s\n' "$STATUS_CONFLICTS" >&2
+      exit 3
+    fi
+    printf 'COORDINATION_CHECK=PASS\n'
+    ;;
+  claim) claim_command "$@" ;;
+  heartbeat) heartbeat_command "$@" ;;
+  release) release_command "$@" ;;
+  prune)
+    (($# == 0)) || die "prune does not accept arguments"
+    prune_command
+    ;;
+  -h|--help|help) usage ;;
+  *) die "unknown command: $command (try brief, status, check, claim, heartbeat, release, or prune)" ;;
+esac

--- a/scripts/ci/sounio_coord_selftest.sh
+++ b/scripts/ci/sounio_coord_selftest.sh
@@ -38,7 +38,7 @@ output="$(
   run_coord claim --agent agent-a --lane parser --ttl-seconds 600 \
     --intent 'parser ownership' --files 'self-hosted/parser/**'
 )"
-rg -q '^CLAIMED claim_id=agent-a--parser$' <<< "$output" || fail 'first claim was not created'
+grep -qE '^CLAIMED claim_id=agent-a--parser$' <<< "$output" || fail 'first claim was not created'
 
 if (
   cd "$TEST_ROOT/second-worktree"
@@ -53,13 +53,13 @@ output="$(
   run_coord claim --agent agent-b --lane codegen --ttl-seconds 600 \
     --intent 'disjoint ownership' --files 'self-hosted/codegen/**'
 )"
-rg -q '^CLAIMED claim_id=agent-b--codegen$' <<< "$output" || fail 'disjoint claim was rejected'
+grep -qE '^CLAIMED claim_id=agent-b--codegen$' <<< "$output" || fail 'disjoint claim was rejected'
 
 output="$(
   cd "$TEST_ROOT/second-worktree"
   run_coord brief --max-rows 4
 )"
-rg -q 'ACTIVE claim_id=agent-a--parser' <<< "$output" || fail 'claim was not visible across worktrees'
+grep -qE 'ACTIVE claim_id=agent-a--parser' <<< "$output" || fail 'claim was not visible across worktrees'
 
 if (
   cd "$TEST_ROOT/second-worktree"
@@ -72,30 +72,30 @@ output="$(
   cd "$REPO"
   run_coord heartbeat --agent agent-a --lane parser
 )"
-rg -q '^HEARTBEAT claim_id=agent-a--parser' <<< "$output" || fail 'heartbeat failed'
+grep -qE '^HEARTBEAT claim_id=agent-a--parser' <<< "$output" || fail 'heartbeat failed'
 
 output="$(
   cd "$REPO"
   run_coord check --brief --max-rows 4
 )"
-rg -q '^COORDINATION_CHECK=PASS$' <<< "$output" || fail 'coordination check failed'
+grep -qE '^COORDINATION_CHECK=PASS$' <<< "$output" || fail 'coordination check failed'
 
 output="$(
   cd "$REPO"
   run_coord release --agent agent-a --lane parser --reason 'selftest complete'
 )"
-rg -q '^RELEASED claim_id=agent-a--parser' <<< "$output" || fail 'first release failed'
+grep -qE '^RELEASED claim_id=agent-a--parser' <<< "$output" || fail 'first release failed'
 
 output="$(
   cd "$TEST_ROOT/second-worktree"
   run_coord release --agent agent-b --lane codegen --reason 'selftest complete'
 )"
-rg -q '^RELEASED claim_id=agent-b--codegen' <<< "$output" || fail 'second release failed'
+grep -qE '^RELEASED claim_id=agent-b--codegen' <<< "$output" || fail 'second release failed'
 
 output="$(
   cd "$REPO"
   run_coord brief --max-rows 4
 )"
-rg -q '^summary=active_claims:0 stale_claims:0 conflicts:0$' <<< "$output" || fail 'claims remained active'
+grep -qE '^summary=active_claims:0 stale_claims:0 conflicts:0$' <<< "$output" || fail 'claims remained active'
 
 echo 'sounio-coord-selftest: PASS'

--- a/scripts/ci/sounio_coord_selftest.sh
+++ b/scripts/ci/sounio_coord_selftest.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TOOL="$ROOT_DIR/bin/sounio-coord"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sounio-coord-selftest.XXXXXX")"
+REPO="$TEST_ROOT/repo"
+STATE="$TEST_ROOT/state"
+
+cleanup() {
+  git -C "$REPO" worktree remove --force "$TEST_ROOT/second-worktree" >/dev/null 2>&1 || true
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "sounio-coord-selftest: FAIL: $*" >&2
+  exit 1
+}
+
+bash -n "$TOOL"
+mkdir -p "$REPO/self-hosted/parser" "$REPO/self-hosted/codegen"
+git -C "$REPO" init -q
+git -C "$REPO" config user.name 'Sounio Coordination Selftest'
+git -C "$REPO" config user.email 'coord-selftest@sounio.local'
+printf 'seed\n' > "$REPO/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit -qm 'seed'
+git -C "$REPO" worktree add -q -b second-lane "$TEST_ROOT/second-worktree"
+
+run_coord() {
+  SOUNIO_COORD_DIR="$STATE" "$TOOL" "$@"
+}
+
+output="$(
+  cd "$REPO"
+  run_coord claim --agent agent-a --lane parser --ttl-seconds 600 \
+    --intent 'parser ownership' --files 'self-hosted/parser/**'
+)"
+rg -q '^CLAIMED claim_id=agent-a--parser$' <<< "$output" || fail 'first claim was not created'
+
+if (
+  cd "$TEST_ROOT/second-worktree"
+  run_coord claim --agent agent-b --lane parser-child --ttl-seconds 600 \
+    --intent 'must conflict' --files self-hosted/parser/example.sio
+) >/dev/null 2>&1; then
+  fail 'overlapping claim was accepted'
+fi
+
+output="$(
+  cd "$TEST_ROOT/second-worktree"
+  run_coord claim --agent agent-b --lane codegen --ttl-seconds 600 \
+    --intent 'disjoint ownership' --files 'self-hosted/codegen/**'
+)"
+rg -q '^CLAIMED claim_id=agent-b--codegen$' <<< "$output" || fail 'disjoint claim was rejected'
+
+output="$(
+  cd "$TEST_ROOT/second-worktree"
+  run_coord brief --max-rows 4
+)"
+rg -q 'ACTIVE claim_id=agent-a--parser' <<< "$output" || fail 'claim was not visible across worktrees'
+
+if (
+  cd "$TEST_ROOT/second-worktree"
+  run_coord release --agent agent-a --lane parser --reason 'wrong worktree'
+) >/dev/null 2>&1; then
+  fail 'claim was released from a non-owning worktree'
+fi
+
+output="$(
+  cd "$REPO"
+  run_coord heartbeat --agent agent-a --lane parser
+)"
+rg -q '^HEARTBEAT claim_id=agent-a--parser' <<< "$output" || fail 'heartbeat failed'
+
+output="$(
+  cd "$REPO"
+  run_coord check --brief --max-rows 4
+)"
+rg -q '^COORDINATION_CHECK=PASS$' <<< "$output" || fail 'coordination check failed'
+
+output="$(
+  cd "$REPO"
+  run_coord release --agent agent-a --lane parser --reason 'selftest complete'
+)"
+rg -q '^RELEASED claim_id=agent-a--parser' <<< "$output" || fail 'first release failed'
+
+output="$(
+  cd "$TEST_ROOT/second-worktree"
+  run_coord release --agent agent-b --lane codegen --reason 'selftest complete'
+)"
+rg -q '^RELEASED claim_id=agent-b--codegen' <<< "$output" || fail 'second release failed'
+
+output="$(
+  cd "$REPO"
+  run_coord brief --max-rows 4
+)"
+rg -q '^summary=active_claims:0 stale_claims:0 conflicts:0$' <<< "$output" || fail 'claims remained active'
+
+echo 'sounio-coord-selftest: PASS'

--- a/sounio-whereami
+++ b/sounio-whereami
@@ -253,6 +253,14 @@ EOF
 section "Repo State"
 git status --short --branch | sed -n '1,80p'
 
+section "Agent Coordination"
+if [[ -x "${ROOT}/bin/sounio-coord" ]]; then
+  with_timeout 8s "${ROOT}/bin/sounio-coord" brief --max-rows 6 ||
+    echo "coordination summary unavailable; run bin/sounio-coord status directly"
+else
+  echo "bin/sounio-coord is unavailable in this checkout"
+fi
+
 section "Compiler"
 compiler_summary "${ROOT}"
 


### PR DESCRIPTION
## What changed

- add `bin/sounio-coord`, a cross-worktree claim/heartbeat/release CLI backed by short-lived leases outside Git
- show a compact live coordination summary from `./sounio-whereami --quick`
- make the claim lifecycle part of `AGENTS.md` and `ONBOARDING.md`
- add a two-worktree self-test and run it in the Contracts CI job

## Why

Sounio had several durable coordination documents but no small live source showing which agent currently owned which write set. Stale handoff matrices, hundreds of worktrees, and branch metadata drift made duplicate work and file collisions easy.

The new runtime surface refuses overlapping active claims, records handoffs, expires abandoned leases, and keeps Git status plus the existing blocker contracts authoritative.

## Validation

- `bash -n bin/sounio-coord sounio-whereami scripts/ci/sounio_coord_selftest.sh`
- `bash scripts/ci/sounio_coord_selftest.sh`
- `bash scripts/dev/check_workflow_script_refs.sh` (72 references)
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh` (baseline plus 5 failure scenarios)
- `bin/sounio-coord check --brief --max-rows 6`
- `./sounio-whereami --quick`
- `git diff --check`

All checks passed from an isolated worktree based on current `origin/main`.