### PR TITLE
fix(madaros): MIR_MAX_INSTRS 1024→4096 + fail-closed overflow (wave7)

### DIFF
--- a/scripts/ci/irfunction_instr_capacity_coherence_gate.sh
+++ b/scripts/ci/irfunction_instr_capacity_coherence_gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SOURCE="${IRFUNCTION_INSTR_CAPACITY_SOURCE:-$ROOT/self-hosted/ir/ir.sio}"
-EXPECTED_CAPACITY=2048
+EXPECTED_CAPACITY=4096
 
 fail() {
   printf 'IRFUNCTION_INSTR_CAPACITY_FAIL reason=%s\n' "$1" >&2
@@ -103,5 +103,5 @@ fi
 
 printf '%s\n' \
   'IRFUNCTION_INSTR_CAPACITY_BOUNDARY storage_coherence=proved runtime_readback=not_claimed soir_v6=unchanged legacy=preserved'
-printf 'IRFUNCTION_INSTR_CAPACITY_PASS source=%s source_sha256=%s expected=2048 head=%s tree=%s worktree=%s\n' \
+printf 'IRFUNCTION_INSTR_CAPACITY_PASS source=%s source_sha256=%s expected=4096 head=%s tree=%s worktree=%s\n' \
   "$SOURCE" "$source_sha256" "$head_sha" "$tree_sha" "$worktree_state"

--- a/scripts/ci/mir_instr_capacity_coherence_gate.sh
+++ b/scripts/ci/mir_instr_capacity_coherence_gate.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="${MIR_INSTR_CAPACITY_SOURCE:-$ROOT/self-hosted/native/machine_ir.sio}"
+EXPECTED_CAPACITY=4096
+
+fail() {
+  printf 'MIR_INSTR_CAPACITY_FAIL reason=%s\n' "$1" >&2
+  exit 1
+}
+
+[[ -f "$SOURCE" ]] || fail source_missing
+command -v python3 >/dev/null 2>&1 || fail python3_missing
+
+python3 - "$SOURCE" "$EXPECTED_CAPACITY" <<'PY' || exit $?
+import pathlib
+import re
+import sys
+
+source = pathlib.Path(sys.argv[1])
+expected = int(sys.argv[2])
+text = source.read_text(encoding="utf-8")
+
+
+def fail(reason: str) -> None:
+    print(f"MIR_INSTR_CAPACITY_FAIL reason={reason}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def unique(pattern: str, subject: str, reason: str, flags: int = 0) -> re.Match:
+    matches = list(re.finditer(pattern, subject, flags))
+    if len(matches) != 1:
+        fail(f"{reason}_count_{len(matches)}")
+    return matches[0]
+
+
+cap_match = unique(
+    r"^pub let MIR_MAX_INSTRS: i64 = ([0-9]+)\s*$",
+    text,
+    "mir_max_instrs",
+    re.MULTILINE,
+)
+
+struct_match = unique(
+    r"^pub struct MachineBlock\s*\{(?P<body>.*?)^\}\s*$",
+    text,
+    "machineblock_struct",
+    re.MULTILINE | re.DOTALL,
+)
+type_match = unique(
+    r"^\s*pub instrs:\s*\[MachineInstr;\s*([0-9]+)\],\s*$",
+    struct_match.group("body"),
+    "machineblock_instrs_field",
+    re.MULTILINE,
+)
+
+fn_starts = list(re.finditer(r"^pub fn machine_block_new\(\) -> MachineBlock(?:\s+with[^{]+)?\s*\{", text, re.MULTILINE))
+if len(fn_starts) != 1:
+    fail(f"machine_block_new_count_{len(fn_starts)}")
+next_fn = text.find("\npub fn machine_function_new()", fn_starts[0].end())
+if next_fn < 0:
+    fail("machine_block_new_end_missing")
+body = text[fn_starts[0].end():next_fn]
+init_match = unique(
+    r"^\s*instrs:\s*\[machine_empty_instr\(\);\s*([0-9]+)\],\s*$",
+    body,
+    "machine_block_new_instrs_initializer",
+    re.MULTILINE,
+)
+
+# Fail-closed overflow sites must mention mir_instr_capacity
+fail_closed = len(re.findall(r'mir_instr_capacity', text))
+if fail_closed < 3:
+    fail(f"fail_closed_sites_expected_ge_3_got_{fail_closed}")
+
+cap = int(cap_match.group(1))
+field = int(type_match.group(1))
+initializer = int(init_match.group(1))
+
+if cap != expected:
+    fail(f"mir_max_instrs_expected_{expected}_got_{cap}")
+if field != expected:
+    fail(f"machineblock_field_expected_{expected}_got_{field}")
+if initializer != expected:
+    fail(f"initializer_expected_{expected}_got_{initializer}")
+if not (cap == field == initializer):
+    fail(f"divergent_cap_{cap}_field_{field}_initializer_{initializer}")
+
+print(
+    "MIR_INSTR_CAPACITY_CHECK "
+    f"cap={cap} field={field} initializer={initializer} "
+    f"fail_closed_sites={fail_closed} coherent=pass"
+)
+PY
+
+source_sha256="$(sha256sum "$SOURCE" | awk '{print $1}')"
+head_sha="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || printf not_available)"
+printf 'MIR_INSTR_CAPACITY_PASS source=%s source_sha256=%s expected=%s head=%s\n' \
+  "$SOURCE" "$source_sha256" "$EXPECTED_CAPACITY" "$head_sha"

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -6165,7 +6165,7 @@ fn compiler_main_test_dce_removes_dead() -> bool with Mut, Div, Panic {
 // Sprint 52: verify regalloc assigns a preg when register pressure is low (1 vreg, 1 preg)
 fn compiler_main_test_regalloc_assigns_preg() -> bool with Mut, Div, Panic {
     // Build: r0 = 3, r1 = r0 + 4, return r1
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     ra_instrs[0 as usize] = ra_simple_instr(0, -1, -1)   // r0 = imm (def r0)
     ra_instrs[1 as usize] = ra_simple_instr(1, 0, -1)    // r1 = r0 + imm (def r1, use r0)
     ra_instrs[2 as usize] = ra_simple_instr(-1, 1, -1)   // return r1 (use r1)
@@ -6183,7 +6183,7 @@ fn compiler_main_test_regalloc_assigns_preg() -> bool with Mut, Div, Panic {
 // Sprint 52: verify regalloc spills when pressure exceeds available registers
 fn compiler_main_test_regalloc_spills_under_pressure() -> bool with Mut, Div, Panic {
     // Build: 6 live intervals all overlapping (start 0, end 10), only 1 preg
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     var i = 0
     while i < 6 {
         ra_instrs[i as usize] = ra_simple_instr(i, -1, -1)
@@ -6259,7 +6259,7 @@ fn compiler_main_test_multipreg_map() -> bool {
 
 // T31: 2 non-overlapping vregs → 2 pregs assigned, 0 spilled
 fn compiler_main_test_multipreg_two_fit() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     ra_instrs[0 as usize] = ra_simple_instr(0, -1, -1)
     ra_instrs[1 as usize] = ra_simple_instr(-1, 0, -1)
     ra_instrs[2 as usize] = ra_simple_instr(1, -1, -1)
@@ -6275,7 +6275,7 @@ fn compiler_main_test_multipreg_two_fit() -> bool with Mut, Div, Panic {
 
 // T32: 4 non-overlapping vregs → all 4 pregs used, 0 spilled
 fn compiler_main_test_multipreg_four_fit() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     var i = 0
     while i < 4 {
         ra_instrs[(i * 2) as usize]     = ra_simple_instr(i, -1, -1)
@@ -6293,7 +6293,7 @@ fn compiler_main_test_multipreg_four_fit() -> bool with Mut, Div, Panic {
 
 // T33: 5 overlapping vregs with 4 pregs → exactly 1 spill
 fn compiler_main_test_multipreg_spill_one() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     // Define all 5 at pos 0, use all at pos 1 (all live simultaneously)
     var i = 0
     while i < 5 {
@@ -6343,7 +6343,7 @@ fn compiler_main_test_multipreg_epilogue_bytes() -> bool with Mut, Panic, Div {
 
 // T37: regalloc_linear_scan(state, 4) produces valid state (regression + 4-preg)
 fn compiler_main_test_multipreg_regalloc_four() -> bool with Mut, Div, Panic {
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     ra_instrs[0 as usize] = ra_simple_instr(0, -1, -1)
     ra_instrs[1 as usize] = ra_simple_instr(-1, 0, -1)
     var state = liveness_compute_intervals(ra_instrs, 2)

--- a/self-hosted/native/codegen.sio
+++ b/self-hosted/native/codegen.sio
@@ -3387,10 +3387,10 @@ fn native_v2_store_rax_to_stack_slot(nc: NativeCompiler, slot: i64) -> NativeCom
     c
 }
 
-fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 2048], out_count: &! i64) with Mut, Panic, Div {
+fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 4096], out_count: &! i64) with Mut, Panic, Div {
     var count: i64 = 0
     var i: i64 = 0
-    while i < (*func).blocks[0].instr_count && count < 2048 {
+    while i < (*func).blocks[0].instr_count && count < RA_MAX_SIMPLE_INSTRS {
         let instr = (*func).blocks[0].instrs[i as usize]
         if instr.opcode == MIR_OP_LOAD_STACK || instr.opcode == MIR_OP_MOV_IMM || instr.opcode == MIR_OP_LOAD_DATA_ADDR ||
            instr.opcode == MIR_OP_CAPTURE_RET || instr.opcode == MIR_OP_ALLOC || instr.opcode == MIR_OP_LEA_STACK {
@@ -3418,7 +3418,7 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
         } else if instr.opcode == MIR_OP_INDEX_STORE {
             out[count as usize] = ra_simple_instr(-1, instr.src1.value, instr.src2.value)
             count = count + 1
-            if count < 2048 {
+            if count < RA_MAX_SIMPLE_INSTRS {
                 out[count as usize] = ra_simple_instr(-1, instr.aux.value, -1)
                 count = count + 1
             }
@@ -3428,8 +3428,8 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
     *out_count = count
 }
 
-fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 2048], i64) with Mut, Panic, Div {
-    var out: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 4096], i64) with Mut, Panic, Div {
+    var out: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     var count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(&func, &! out, &! count)
     (out, count)
@@ -3472,7 +3472,7 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
 }
 
 fn native_v2_run_machine_regalloc_ref_mut(nc: &! NativeCompiler, func: &MachineFunction) with Mut, Panic, Div {
-    var instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     var instr_count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(func, &! instrs, &! instr_count)
     var state = liveness_compute_intervals(instrs, instr_count)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -5426,10 +5426,10 @@ fn native_v2_ra_simple(dst: i64, src1: i64, src2: i64) -> RaSimpleInstr {
     RaSimpleInstr { dst: dst, src1: src1, src2: src2 }
 }
 
-fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 2048], out_count: &! i64) with Mut, Panic, Div {
+fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpleInstr; 4096], out_count: &! i64) with Mut, Panic, Div {
     var count: i64 = 0
     var i: i64 = 0
-    while i < (*func).blocks[0].instr_count && count < 2048 {
+    while i < (*func).blocks[0].instr_count && count < RA_MAX_SIMPLE_INSTRS {
         let instr = (*func).blocks[0].instrs[i as usize]
         if instr.opcode == MIR_OP_LOAD_STACK || instr.opcode == MIR_OP_MOV_IMM || instr.opcode == MIR_OP_LOAD_DATA_ADDR ||
            instr.opcode == MIR_OP_CAPTURE_RET || instr.opcode == MIR_OP_ALLOC || instr.opcode == MIR_OP_LEA_STACK {
@@ -5457,7 +5457,7 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
         } else if instr.opcode == MIR_OP_INDEX_STORE {
             out[count as usize] = native_v2_ra_simple(0 - 1, machine_instr_src1_value(instr), machine_instr_src2_value(instr))
             count = count + 1
-            if count < 2048 {
+            if count < RA_MAX_SIMPLE_INSTRS {
                 out[count as usize] = native_v2_ra_simple(0 - 1, machine_instr_aux_value(instr), 0 - 1)
                 count = count + 1
             }
@@ -5467,8 +5467,8 @@ fn native_v2_machine_ra_instrs_into_ref(func: &MachineFunction, out: &! [RaSimpl
     *out_count = count
 }
 
-fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 2048], i64) with Mut, Panic, Div {
-    var out: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+fn native_v2_machine_ra_instrs(func: MachineFunction) -> ([RaSimpleInstr; 4096], i64) with Mut, Panic, Div {
+    var out: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     var count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(&func, &! out, &! count)
     (out, count)
@@ -5511,7 +5511,7 @@ fn native_v2_run_machine_regalloc_mut(nc: &! NativeCompiler, func: MachineFuncti
 }
 
 fn native_v2_run_machine_regalloc_ref_mut(nc: &! NativeCompiler, func: &MachineFunction) with Mut, Panic, Div {
-    var instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     var instr_count: i64 = 0
     native_v2_machine_ra_instrs_into_ref(func, &! instrs, &! instr_count)
     var state = liveness_compute_intervals(instrs, instr_count)

--- a/self-hosted/native/lower_ir.sio
+++ b/self-hosted/native/lower_ir.sio
@@ -42,10 +42,10 @@ pub fn preg_to_x86_reg(preg: i64) -> i64 {
 pub fn nc_run_regalloc(nc: NativeCompiler, func: IrFunction) -> NativeCompiler with Mut, Panic, Div {
     var c = nc
     // 1. Build RaSimpleInstr array from IR instructions
-    var ra_instrs: [RaSimpleInstr; 2048] = [ra_empty_simple_instr(); 2048]
+    var ra_instrs: [RaSimpleInstr; 4096] = [ra_empty_simple_instr(); 4096]
     let count = func.instr_count
     var i = 0
-    while i < count && i < RA_MAX_SIMPLE_INSTRS && i < 2048 {
+    while i < count && i < RA_MAX_SIMPLE_INSTRS && i < 4096 {
         let instr = func.instrs[i as usize]
         ra_instrs[i as usize] = ra_simple_instr(instr.dst, instr.src1, instr.src2)
         i = i + 1

--- a/self-hosted/native/machine_ir.sio
+++ b/self-hosted/native/machine_ir.sio
@@ -8,7 +8,13 @@ use parser::ast::{Name, BinaryOp, UnaryOp, empty_name}
 use ir::ir::{IrModule, IrFunction, IrInstr, IrOpcode, IrRegList, BSS_BASE_LINUX, IR_FLOAT_REG_MARKER_FLAG}
 
 pub let MIR_MAX_BLOCKS: i64 = 1
-pub let MIR_MAX_INSTRS: i64 = 1024
+// MIR_MAX_INSTRS history:
+//   1024 (silent drop past wall) → 4096 (2026-07-20, align with IR_MAX_INSTRS).
+// Multi-module streaming / machine_ir legalize still materialises one block of
+// MachineInstr; under 1024 the tail (incl. ret) was dropped with no diagnostic.
+// Legalize expands some IR ops 2–4×, so dense full-IR bodies may still trip the
+// wall — overflow is now fail-closed (supported=false, mir_instr_capacity).
+pub let MIR_MAX_INSTRS: i64 = 4096
 pub let MIR_MAX_CALL_ARGS: i64 = 8
 
 pub let MIR_OPERAND_NONE: i64 = 0
@@ -107,7 +113,7 @@ pub struct MachineInstr {
 }
 
 pub struct MachineBlock {
-    pub instrs: [MachineInstr; 1024],
+    pub instrs: [MachineInstr; 4096],
     pub instr_count: i64,
 }
 
@@ -241,7 +247,7 @@ pub fn machine_empty_instr() -> MachineInstr with Mut, Panic, Div {
 
 pub fn machine_block_new() -> MachineBlock with Mut, Panic, Div {
     MachineBlock {
-        instrs: [machine_empty_instr(); 1024],
+        instrs: [machine_empty_instr(); 4096],
         instr_count: 0,
     }
 }
@@ -294,6 +300,10 @@ pub fn machine_function_add_instr_mut(func: &! MachineFunction, instr: MachineIn
         block.instrs[idx as usize] = instr
         block.instr_count = idx + 1
         (*func).blocks[0] = block
+    } else {
+        // Fail closed: never silently drop ret / tail (was silent miscompile wall).
+        (*func).supported = false
+        (*func).unsupported_detail = "mir_instr_capacity"
     }
 }
 
@@ -603,6 +613,9 @@ pub fn _emit_legal_byval(func: MachineFunction, instr: MachineInstr) -> MachineF
         block.instr_count = idx + 1
         f.blocks[0] = block
         f.legal_instr_count = f.legal_instr_count + 1
+    } else {
+        f.supported = false
+        f.unsupported_detail = "mir_instr_capacity"
     }
     f
 }
@@ -615,6 +628,9 @@ pub fn _add_instr_byval(func: MachineFunction, instr: MachineInstr) -> MachineFu
         block.instrs[idx as usize] = instr
         block.instr_count = idx + 1
         f.blocks[0] = block
+    } else {
+        f.supported = false
+        f.unsupported_detail = "mir_instr_capacity"
     }
     f
 }

--- a/self-hosted/native/regalloc.sio
+++ b/self-hosted/native/regalloc.sio
@@ -17,9 +17,11 @@ pub let RA_MAX_INTERVALS: i64 = 2048
 // Max distinct vreg ids tracked by liveness / RA (matches NC_MAX_VREGS).
 pub let RA_MAX_VREGS: i64 = 2048
 // Max RaSimpleInstr entries accepted by liveness_compute_intervals.
+// Align with MIR_MAX_INSTRS so the machine_ir / streaming path does not
+// silently truncate liveness after the MIR buffer was raised past 2048.
 // Note: Madaros core_ir path (compile_ir_function_v2_core_ir_into) does not use
 // RA; large straight-line bodies are gated by IR_MAX_INSTRS instead.
-pub let RA_MAX_SIMPLE_INSTRS: i64 = 2048
+pub let RA_MAX_SIMPLE_INSTRS: i64 = 4096
 pub let RA_MAX_ACTIVE: i64 = 64
 pub let RA_MAX_HINTS: i64 = 256
 pub let RA_SPILLED: i64 = 0 - 1          // sentinel: no physical register assigned
@@ -530,7 +532,7 @@ pub fn ra_empty_simple_instr() -> RaSimpleInstr {
 // High-level: compute intervals from an array of RaSimpleInstr.
 // Walks instructions sequentially, recording defs (dst) and uses (src1, src2).
 pub fn liveness_compute_intervals(
-    instrs: [RaSimpleInstr; 2048], instr_count: i64
+    instrs: [RaSimpleInstr; 4096], instr_count: i64
 ) -> RegAllocState with Mut, Panic, Div {
     var map = liveness_map_new()
     var pos: i64 = 0


### PR DESCRIPTION
## Summary

**Wave7 Agent D** — highest remaining I×F residual after wave6 capacity work (#1292 vreg 512→2048, #1304 IR_MAX 2048→4096):

### Root cause

`MIR_MAX_INSTRS` stayed at **1024** while `IR_MAX_INSTRS` is now **4096**. The multi-module streaming / machine_ir legalize path materialises one `MachineBlock` of `MachineInstr`s; past 1024 every append was a **silent no-op** (ret / tail dropped → wrong control flow / incomplete bodies). Same silent-drop class as the pre-#1304 IR wall that re-entered `main` on unsplit `oct_mul`.

Measured on `origin/main` (`35e962a62`):

| Cap | Value | Status |
|---|---:|---|
| `IR_MAX_INSTRS` | 4096 | raised #1304 |
| `MIR_MAX_INSTRS` | **1024** | **OPEN residual** |
| `RA_MAX_SIMPLE_INSTRS` | 2048 | would re-truncate after MIR raise |
| IR coherence gate `EXPECTED` | **2048** | **stale** — fails on main after #1304 |

### Fix

1. **`MIR_MAX_INSTRS` / `MachineBlock.instrs` 1024 → 4096** (`self-hosted/native/machine_ir.sio`)
2. **Fail-closed overflow**: `supported=false`, `unsupported_detail="mir_instr_capacity"` in `machine_function_add_instr_mut`, `_emit_legal_byval`, `_add_instr_byval` (streaming already rejects `!supported`)
3. **`RA_MAX_SIMPLE_INSTRS` + `RaSimpleInstr` buffers 2048 → 4096** so machine RA does not re-truncate
4. **IR coherence gate** `EXPECTED_CAPACITY` 2048 → 4096
5. **New** `scripts/ci/mir_instr_capacity_coherence_gate.sh`

Avoided: `-O` / `opt_cleanup` multi-mod (Agent A lane).

### Gates (structural — run anytime)

```
bash scripts/ci/mir_instr_capacity_coherence_gate.sh
# MIR_INSTR_CAPACITY_CHECK cap=4096 field=4096 initializer=4096 fail_closed_sites=4 coherent=pass

bash scripts/ci/irfunction_instr_capacity_coherence_gate.sh
# IRFUNCTION_INSTR_CAPACITY_CHECK cap=4096 field=4096 initializer=4096 coherent=pass
```

### Rebuild + runtime non-regression

Modular Madaros rebuild under `SOUNIO_BUILD_LOCK` in flight on the agent worktree; will push binary + dual/large_frame/unsplit/algebra gate receipts in a follow-up commit when green.

```bash
SOUNIO_BUILD_LOCK=/tmp/sounio-wave7-agent-d-mir.lock \
  bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros
```

### Honest residual

- Legalize expands some IR ops 2–4×; densest full-IR bodies may still hit `mir_instr_capacity` — now **loud**, not silent.
- Single-file `core_ir` path is independent of this wall (already uses `IR_MAX_INSTRS=4096`).
- `is_float_slot: [i64; 256]` remains a separate float-typing wall (not this PR).

## Test plan

- [x] `bash scripts/ci/mir_instr_capacity_coherence_gate.sh`
- [x] `bash scripts/ci/irfunction_instr_capacity_coherence_gate.sh`
- [ ] Rebuild modular Madaros under build lock
- [ ] `scripts/madaros_dual_import_gate.sh`
- [ ] `scripts/madaros_large_frame_stack_probe_gate.sh`
- [ ] `scripts/madaros_unsplit_oct_mul_gate.sh`
- [ ] `scripts/madaros_algebra_octonion_import_gate.sh`