### PR TITLE
feat(stdlib): bigframe grouped winsorize / quantile-clip (near-parity, honest)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -75,6 +75,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | diff_by (1M rows, 1000 dense keys, periods=1) | | ~13.8 | ~20.9 | **0.66x — Sounio wins** | dense stack prev tracker (fast path); ring for periods>1 |
 | shift_by (1M rows, 1000 dense keys, periods=1) | | ~13.5 | ~22.0 | **0.62x — Sounio wins** | dense stack tracker; fwd lag / rev lead ring for \|p\|>1 |
 | ffill_by / bfill_by (1M rows, 1000 dense keys) | | ~30.7 | ~96.3 | **0.32x — Sounio wins (3.1x)** | dense last/next-valid tracker; sentinel-marked NA |
+| winsorize_by (1M rows, 1000 groups, q=[.05,.95]) | | ~1220 | ~1010 | **~1.2x — near-parity loss** | counting-sort + 2 quickselects/group; quantile-bound, C3 select would close it |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -14,7 +14,8 @@
 // and grouped rolling sum / mean / max / min / var / std / median / quantile;
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
 // grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount;
-// grouped pct_change; grouped diff; grouped shift; grouped ffill / bfill.
+// grouped pct_change; grouped diff; grouped shift; grouped ffill / bfill;
+// grouped winsorize (quantile-clip).
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -4248,5 +4249,131 @@ pub fn bf_bfill_by(src: &BigFrame, key_col: i64, val_col: i64, na: f64) -> BigFr
         }
         i = i - 1
     }
+    out
+}
+
+/// Per-group WINSORIZE / quantile-CLIP of `val_col` (robust outlier capping): each value
+/// is clamped to its GROUP's [q_lo, q_hi] quantile band (pandas-linear interpolation), so
+/// out[i] = min(max(val[i], lo_g), hi_g) where lo_g/hi_g are row i's group's q_lo/q_hi
+/// quantiles. Matches pandas df.groupby(key)[val].transform(lambda s: s.clip(*s.quantile(
+/// [q_lo, q_hi]))). O(n + Σ sz): an O(n) factorize + counting-sort into contiguous
+/// per-group regions (values gathered in the same pass), then TWO quickselects per region
+/// (bf_quickselect -- O(sz), not a full sort) to read the two quantile order-statistics,
+/// and a clamp pass. Handles ANY f64 key. (Quantile-bound: this trails pandas' specialised
+/// groupby-quantile by ~1.2x near parity; a compiler select/SIMD path -- the C3 dispatch --
+/// would close it.) Returns a 1-column BigFrame aligned to input rows. NATIVE + lean_single
+/// only (heap).
+pub fn bf_winsorize_by(src: &BigFrame, key_col: i64, val_col: i64, q_lo: f64, q_hi: f64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr = bf_nrows(src)
+    let nc = bf_ncols(src)
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || nr <= 0 { return bf_new(1, 1) }
+    var size: i64 = 16
+    while size < nr + nr { size = size * 2 }
+    let mask = size - 1
+    let occ = heap_alloc(size * 8) as *mut f64
+    let hk  = heap_alloc(size * 8) as *mut f64
+    let hid = heap_alloc(size * 8) as *mut f64
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let id = heap_alloc(nr * 8) as *mut i64
+    let sizes = heap_alloc(nr * 8) as *mut i64
+    var gcount: i64 = 0
+    var r: i64 = 0
+    while r < nr {
+        let k = read_f64(kp, r)
+        var slot = bf_ghash(k, mask)
+        var done = false
+        while !done {
+            if read_f64(occ, slot) == 0.0 {
+                write_f64(occ, slot, 1.0)
+                write_f64(hk, slot, k)
+                write_f64(hid, slot, gcount as f64)
+                write_i64(id, r, gcount)
+                write_i64(sizes, gcount, 1)
+                gcount = gcount + 1
+                done = true
+            } else {
+                if read_f64(hk, slot) == k {
+                    let g = read_f64(hid, slot) as i64
+                    write_i64(id, r, g)
+                    write_i64(sizes, g, read_i64(sizes, g) + 1)
+                    done = true
+                } else {
+                    slot = (slot + 1) & mask
+                }
+            }
+        }
+        r = r + 1
+    }
+    let offsets = heap_alloc(nr * 8) as *mut i64
+    let cursor = heap_alloc(nr * 8) as *mut i64
+    var acc: i64 = 0
+    var g: i64 = 0
+    while g < gcount {
+        write_i64(offsets, g, acc)
+        write_i64(cursor, g, acc)
+        acc = acc + read_i64(sizes, g)
+        g = g + 1
+    }
+    let flat = heap_alloc(nr * 8) as *mut i64
+    let fval = heap_alloc(nr * 8) as *mut f64
+    r = 0
+    while r < nr {
+        let g2 = read_i64(id, r)
+        let p = read_i64(cursor, g2)
+        write_i64(flat, p, r)
+        write_f64(fval, p, read_f64(vp, r))
+        write_i64(cursor, g2, p + 1)
+        r = r + 1
+    }
+    let sc = heap_alloc(nr * 8) as *mut f64     // per-group base-0 scratch for quickselect, reused
+    var out = bf_new(1, nr)
+    out.n_rows = nr
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    g = 0
+    while g < gcount {
+        let base = read_i64(offsets, g)
+        let sz = read_i64(sizes, g)
+        var j: i64 = 0
+        while j < sz { write_f64(sc, j, read_f64(fval, base + j)); j = j + 1 }   // single copy
+        let phi = q_hi * ((sz - 1) as f64)
+        let ihi = phi as i64
+        let fhi = phi - (ihi as f64)
+        var vhi = bf_quickselect(sc, sz, ihi)
+        if fhi > 0.0 {                                                           // ceil order-stat = min of upper partition
+            var mn = read_f64(sc, ihi + 1); var t = ihi + 2
+            while t < sz { let x = read_f64(sc, t); if x < mn { mn = x } t = t + 1 }
+            vhi = vhi + fhi * (mn - vhi)
+        }
+        let plo = q_lo * ((sz - 1) as f64)
+        let ilo = plo as i64
+        let flo = plo - (ilo as f64)
+        var vlo = bf_quickselect(sc, sz, ilo)                                    // re-partitions sc; ok
+        if flo > 0.0 {
+            var mn = read_f64(sc, ilo + 1); var t = ilo + 2
+            while t < sz { let x = read_f64(sc, t); if x < mn { mn = x } t = t + 1 }
+            vlo = vlo + flo * (mn - vlo)
+        }
+        j = 0
+        while j < sz {
+            let row = read_i64(flat, base + j)
+            var v = read_f64(vp, row)
+            if v < vlo { v = vlo }
+            if v > vhi { v = vhi }
+            write_f64(op, row, v)
+            j = j + 1
+        }
+        g = g + 1
+    }
+    heap_free(occ as *mut i8)
+    heap_free(hk as *mut i8)
+    heap_free(hid as *mut i8)
+    heap_free(id as *mut i8)
+    heap_free(sizes as *mut i8)
+    heap_free(offsets as *mut i8)
+    heap_free(cursor as *mut i8)
+    heap_free(flat as *mut i8)
+    heap_free(fval as *mut i8)
+    heap_free(sc as *mut i8)
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1070,6 +1070,24 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if bf_get(&bf2, 4, 0) != 4.0 { print("FAIL bfill_valid\n"); return 377 }
     // group 1 (all valid) is untouched by either fill.
     if bf_get(&ff, 5, 0) != 5.0 || bf_get(&bf2, 5, 0) != 5.0 { print("FAIL fill_g1\n"); return 378 }
+    // GROUPED WINSORIZE. 2 groups (key=r%2), 100 rows each: group 0 occ j (row 2j) -> val j
+    // (0..99); group 1 occ j (row 2j+1) -> val 100+j (100..199). q=[0.1,0.9] over 0..99 ->
+    // lo = 9 + 0.9 = 9.9, hi = 89 + 0.1 = 89.1 (linear interp at pos 9.9 / 89.1).
+    var wzf = bf_new(2, 16)
+    var wzi: i64 = 0
+    while wzi < 200 { var wzr:[f64;64]=[0.0;64]; wzr[0]=(wzi%2) as f64
+        var occ3 = wzi/2
+        if wzi%2==0 { wzr[1]=occ3 as f64 } else { wzr[1]=(100 + occ3) as f64 }
+        bf_push_row(&!wzf,&wzr,2); wzi=wzi+1 }
+    let wz = bf_winsorize_by(&wzf, 0, 1, 0.1, 0.9)
+    if bf_nrows(&wz) != 200 { print("FAIL wz_n\n"); return 379 }
+    // group 0: row 0 (val 0) clamped up to lo=9.9; row 100 (val 50) unchanged; row 198 (val 99) down to hi=89.1
+    if !approx_eq(bf_get(&wz, 0, 0), 9.9) { print("FAIL wz_lo\n"); return 380 }
+    if !approx_eq(bf_get(&wz, 100, 0), 50.0) { print("FAIL wz_mid\n"); return 381 }
+    if !approx_eq(bf_get(&wz, 198, 0), 89.1) { print("FAIL wz_hi\n"); return 382 }
+    // group 1 (vals 100..199): lo=109.9, hi=189.1
+    if !approx_eq(bf_get(&wz, 1, 0), 109.9) { print("FAIL wz_g1_lo\n"); return 383 }   // row1 val100 -> 109.9
+    if !approx_eq(bf_get(&wz, 199, 0), 189.1) { print("FAIL wz_g1_hi\n"); return 384 } // row199 val199 -> 189.1
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_winsorize_by` in `data::bigframe_ops` — per-group **robust outlier capping**: each value is clamped to its **group's** `[q_lo, q_hi]` quantile band (pandas-linear interp), so `out[i] = clip(val[i], lo_g, hi_g)` where `lo_g`/`hi_g` are row i's group's quantiles. Matches pandas `df.groupby(key)[val].transform(lambda s: s.clip(*s.quantile([q_lo,q_hi])))`.

**O(n + Σ sz)**: an O(n) factorize + counting-sort into contiguous per-group regions (values gathered in the same pass), then **two quickselects per region** (`bf_quickselect` — O(sz), **not** a full sort) reading the two quantile order-statistics (ceil order-stat = min of the upper partition, for linear interpolation), and a clamp pass. Handles any f64 key.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups of 100 values (0..99 and 100..199) with q=[0.1,0.9] → each value clamped to its group's `[9.9, 89.1]` (resp. `[109.9, 189.1]`) linear-interp quantile band; low outliers raised, high lowered, interior untouched;
- (offline) matched pandas grouped winsorize over 12k rows / 40 groups = **0 diffs**.

## Benchmark (1M rows, 1000 groups, q=[0.05,0.95]) — near-parity honest loss

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| winsorize_by | ~1220 | ~1010 | **~1.2× — near-parity loss** |

Winsorize is **quantile-bound** and pandas' specialised `groupby.quantile` is optimised C. Using quickselect (not a full per-group sort) and a single per-group copy brings it from ~1.5× to ~1.2×; a compiler select/SIMD path (the **C3 dispatch**) would close the rest. Shipped for **capability parity** (correct, general, linear-interp) with the small perf gap documented.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)