### PR TITLE
feat(stdlib): bigframe grouped reverse cumsum (beats pandas 4.1x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -78,6 +78,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | winsorize_by (1M rows, 1000 groups, q=[.05,.95]) | | ~1220 | ~1010 | **~1.2x — near-parity loss** | counting-sort + 2 quickselects/group; quantile-bound, C3 select would close it |
 | sample_n_by (1M rows, 1000 groups, n=10) | | ~732 | ~1193 | **0.61x — Sounio wins** | seeded hash-priority top-n; pandas groupby.sample is slow |
 | sample_n_by (1M rows, 1000 groups, n=100) | | ~1564 | ~1298 | **~1.2x — loss** | O(sz·n) bounded buffer at large n; quickselect-threshold would flatten |
+| cumsum_rev_by (1M rows, 1000 dense keys) | | ~69 | ~286 | **0.24x — Sounio wins (4.1x)** | dense reverse-pass suffix-sum vs pandas double-reverse+cumsum |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -15,7 +15,7 @@
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
 // grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount;
 // grouped pct_change; grouped diff; grouped shift; grouped ffill / bfill;
-// grouped winsorize (quantile-clip); grouped sample.
+// grouped winsorize (quantile-clip); grouped sample; grouped reverse cumsum.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -4500,5 +4500,33 @@ pub fn bf_sample_n_by(src: &BigFrame, key_col: i64, n: i64, seed: i64) -> BigFra
     heap_free(flat as *mut i8)
     heap_free(bc as *mut i8)
     heap_free(br as *mut i8)
+    out
+}
+
+/// Per-group REVERSE cumulative sum (like pandas df[::-1].groupby(key)[val].cumsum()[::-1]
+/// -- the suffix sum within each group): out[i] = the sum of `val_col` over all rows from
+/// row i to the LAST row of row i's group in input order, so the first row of a group gets
+/// the group total and the last gets its own value. DENSE integer keys 0..1023 (direct-
+/// index accumulator, no hashing -- the same fast dense-key contract as bf_groupby_sum; a
+/// row whose key is outside [0,1024) gets its own value). O(n), one BACKWARD pass. Returns
+/// a 1-column BigFrame of length n. NATIVE + lean_single only (heap).
+pub fn bf_cumsum_rev_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var acc: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = n - 1
+    while i >= 0 {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 { acc[k] = acc[k] + v; write_f64(op, i, acc[k]) }
+        else { write_f64(op, i, v) }
+        i = i - 1
+    }
     out
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1122,6 +1122,25 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var allsel: i64 = 0; var ai: i64 = 0
     while ai < 5000 { if bf_get(&smAll, ai, 0) == 1.0 { allsel = allsel + 1 } ai = ai + 1 }
     if allsel != 5000 { print("FAIL sample_all\n"); return 391 }
+    // GROUPED REVERSE CUMSUM. 2 groups (key=r%2), val=1.0 -> within a 10-row group the
+    // suffix sums are 10,9,8,...,1 (first row = total 10, last = 1).
+    var rcf = bf_new(2, 16)
+    var rci: i64 = 0
+    while rci < 20 { var rcr:[f64;64]=[0.0;64]; rcr[0]=(rci%2) as f64; rcr[1]=1.0; bf_push_row(&!rcf,&rcr,2); rci=rci+1 }
+    let rc = bf_cumsum_rev_by(&rcf, 0, 1)
+    if bf_nrows(&rc) != 20 { print("FAIL revcs_n\n"); return 392 }
+    if bf_get(&rc, 0, 0) != 10.0 { print("FAIL revcs_first\n"); return 393 }   // group 0 first row = total 10
+    if bf_get(&rc, 2, 0) != 9.0 { print("FAIL revcs_second\n"); return 394 }   // next -> 9 remaining
+    if bf_get(&rc, 18, 0) != 1.0 { print("FAIL revcs_last\n"); return 395 }    // group 0 last row = 1
+    if bf_get(&rc, 1, 0) != 10.0 { print("FAIL revcs_g1\n"); return 396 }      // group 1 first = 10
+    // CROSS-CHECK: reverse cumsum + forward cumsum == group_total + val (each row counted
+    // once forward, once reverse, with row i shared) -> revcs[i] + cumsum[i] = total + val[i].
+    // Simpler check: for a constant-1 group of size 10, forward cumsum is 1..10 and reverse
+    // is 10..1, so their sum is always 11.
+    let fcs = bf_cumsum_by(&rcf, 0, 1)
+    var rcd: i64 = 0; var rcj: i64 = 0
+    while rcj < 20 { if bf_get(&rc, rcj, 0) + bf_get(&fcs, rcj, 0) != 11.0 { rcd = rcd + 1 } rcj = rcj + 1 }
+    if rcd != 0 { print("FAIL revcs_sum\n"); return 397 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

`bf_cumsum_rev_by` in `data::bigframe_ops` — per-group **reverse cumulative sum** (the suffix sum within each group, pandas `df[::-1].groupby(key)[val].cumsum()[::-1]`): `out[i]` = the sum of val over all rows from row i to the **last** row of row i's group, so the first row of a group gets the group total and the last gets its own value.

**Dense direct-index** accumulator over keys 0..1023 (no hashing — same fast dense-key contract as `bf_groupby_sum`), O(n) single **backward** pass. Where pandas needs two array reversals around a groupby cumsum, this is one reverse scan.

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups of ten `1.0`s → suffix sums 10,9,…,1 (first row = total, last = 1);
- a cross-check that `reverse cumsum + forward cumsum == 11` for every row of a constant-1 size-10 group;
- (offline) matched pandas reverse cumsum over 15k rows / 50 groups = **0 diffs**.

## Benchmark (1M rows, 1000 dense keys)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| cumsum_rev_by | ~69 | ~286 | **0.24× — Sounio wins (4.1×)** |

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)