### PR TITLE
coordination: automate agent leases and messaging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,73 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/dev/sounio_coord_agent_hook.py\" --agent claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/dev/sounio_coord_agent_hook.py\" --agent claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/dev/sounio_coord_agent_hook.py\" --agent claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/dev/sounio_coord_agent_hook.py\" --agent claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/dev/sounio_coord_agent_hook.py\" --agent claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/dev/sounio_coord_agent_hook.py\" --agent claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,65 @@
+{
+  "description": "Live Sounio lane presence, automatic write scopes, and agent messages.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/dev/sounio_coord_agent_hook.py\" --agent codex",
+            "timeout": 10,
+            "statusMessage": "Joining Sounio coordination"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/dev/sounio_coord_agent_hook.py\" --agent codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "apply_patch|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/dev/sounio_coord_agent_hook.py\" --agent codex",
+            "timeout": 10,
+            "statusMessage": "Checking Sounio lane ownership"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/dev/sounio_coord_agent_hook.py\" --agent codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/scripts/dev/sounio_coord_agent_hook.py\" --agent codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
         run: bash scripts/ci/compiler_lane_status_gate.sh
       - name: Live lane coordination self-test
         run: bash scripts/ci/sounio_coord_selftest.sh
+
+      - name: Agent coordination hook self-test
+        run: bash scripts/ci/sounio_coord_agent_hook_selftest.sh
       - name: Portable compiler build lock self-test
         run: python3 scripts/ci/souc_build_lock_selftest.py
       - name: CI watch receipt self-test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,34 @@ truth still outrank coordination metadata. Treat this as runtime presence, not a
 durable handoff record; blockers and consequential handoffs still belong in the
 repository contracts named below.
 
+Project hooks in `.codex/hooks.json` and `.claude/settings.json` automate the
+common path. They register session presence, refresh a 30-minute lease during
+active turns, and reserve files before structured `Write`, `Edit`, or
+`apply_patch` calls. Claude releases its session lease on `SessionEnd`; Codex
+currently has no session-end event, so its inactive hook lease expires. Codex
+users must review and trust the project hook with `/hooks` once per hook hash.
+Shell commands can write arbitrary files and cannot be scoped reliably, so a
+manual exact scope remains mandatory before write-bearing Bash commands. The
+startup hook prints the session's agent/lane identity; reuse it with
+`bin/sounio-coord scope --agent <session-agent> --lane <session-lane> --intent "<goal>" --files <paths...>`
+instead of creating a second overlapping lease.
+
+Agents can exchange live messages across worktrees:
+
+- Send a directed request with
+  `bin/sounio-coord send --agent <id> --lane <id> --to-agent <id> --to-lane <id> --kind request --message "<text>"`.
+- Read pending messages with
+  `bin/sounio-coord inbox --agent <id> --lane <id>`.
+- After acting on a message, acknowledge it with
+  `bin/sounio-coord ack --agent <id> --lane <id> --message <message-id>`.
+
+Prompt and post-tool hooks inject unread messages into the agent's active turn.
+A rejected structured write also sends a request to the current owner
+automatically. Use
+`info`, `request`, `reply`, `blocker`, or `handoff` as message kinds. Messages
+coordinate work in progress; durable blockers still require the blocker
+contract.
+
 If an agent leaves a blocker for another agent, it must use that contract's
 Blocker-ID, severity, class, evidence, owner, worktree, branch, acceptance gate,
 and next-action fields.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -84,6 +84,14 @@ IR ou claims científicas, leia também
   claims vencidos aparecem como `STALE` e podem ser removidos com `bin/sounio-coord prune`.
 - Coloque `--files` por último e proteja globs com aspas, por exemplo
   `'self-hosted/compiler/**'`.
+- Hooks de projeto registram automaticamente sessões Claude/Codex e reservam arquivos antes de
+  `Write`, `Edit` e `apply_patch`. No Codex, abra `/hooks` e aprove o hook quando seu hash mudar.
+- Escritas feitas dentro de comandos Bash continuam exigindo claim manual, pois o hook não pode
+  inferir com segurança todos os efeitos de um comando de shell. Reuse o agent/lane exibido pelo
+  hook de startup com `bin/sounio-coord scope`, evitando criar uma segunda lease sobreposta.
+- Para conversar com outra lane durante o trabalho, use `bin/sounio-coord send`; mensagens não
+  lidas entram automaticamente no próximo turno ou passo de ferramenta do destinatário. Consulte com
+  `bin/sounio-coord inbox` e confirme o tratamento com `bin/sounio-coord ack`.
 - **Re-cheque `git status` antes de stage.** Nunca trate uma claim como licença para
   sobrescrever mudanças já presentes na worktree.
 - Edits podem aparecer no commit de outro agente sob mensagens não-relacionadas. Não brigue com a história.

--- a/bin/sounio-coord
+++ b/bin/sounio-coord
@@ -17,10 +17,19 @@ Commands:
   check                          status, then fail when active file conflicts exist
   claim   --agent ID --lane ID --intent TEXT --files PATH [PATH ...]
                                  reserve a file set for one lane
+  scope   --agent ID --lane ID --intent TEXT [--files PATH ...]
+                                 create or extend a session-aware lease
   heartbeat --agent ID --lane ID
                                  refresh an existing claim
   release --agent ID --lane ID --reason TEXT
                                  release a claim and record the handoff event
+  send    --agent ID --lane ID [--to-agent ID] [--to-lane ID]
+          --kind KIND --message TEXT
+                                 send a message to another lane or broadcast
+  inbox   --agent ID --lane ID [--all]
+                                 show unread messages for one lane
+  ack     --agent ID --lane ID --message ID
+                                 mark a message as read by one lane
   prune                          remove expired claims
 
 Environment:
@@ -32,7 +41,12 @@ Examples:
   bin/sounio-coord status
   bin/sounio-coord claim --agent codex-1 --lane parser-fix \
     --intent "isolate parser regression" --files 'self-hosted/parser/**' tests/compile-fail/foo.sio
+  bin/sounio-coord scope --agent codex --lane session-abc123 \
+    --intent "active Codex session" --files self-hosted/parser/ast.sio
   bin/sounio-coord heartbeat --agent codex-1 --lane parser-fix
+  bin/sounio-coord send --agent codex-1 --lane parser-fix \
+    --to-agent claude --kind request --message "Can you review the parser boundary?"
+  bin/sounio-coord inbox --agent claude --lane integration
   bin/sounio-coord release --agent codex-1 --lane parser-fix --reason "handed to shepherd"
 USAGE
 }
@@ -62,8 +76,10 @@ esac
 REPO_KEY="$(printf '%s' "$GIT_COMMON_DIR" | cksum | awk '{print $1}')"
 STATE_DIR="${SOUNIO_COORD_DIR:-${TMPDIR:-/tmp}/sounio-coord/$REPO_KEY}"
 CLAIMS_DIR="$STATE_DIR/claims"
+MESSAGES_DIR="$STATE_DIR/messages"
+ACKS_DIR="$STATE_DIR/message-acks"
 EVENT_LOG="$STATE_DIR/events.log"
-mkdir -p "$CLAIMS_DIR"
+mkdir -p "$CLAIMS_DIR" "$MESSAGES_DIR" "$ACKS_DIR"
 
 NOW_EPOCH="$(date +%s)"
 NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -218,7 +234,7 @@ paths_overlap() {
 }
 
 write_claim() {
-  local claim_file="$1" tmp_file
+  local claim_file="$1" tmp_file file
   tmp_file="$(mktemp "$CLAIMS_DIR/.claim-write.XXXXXX")"
   {
     printf 'claim_id=%s\n' "$C_ID"
@@ -232,9 +248,20 @@ write_claim() {
     printf 'last_seen_epoch=%s\n' "$C_LAST_EPOCH"
     printf 'ttl_seconds=%s\n' "$C_TTL"
     printf 'intent=%s\n' "$C_INTENT"
-    printf 'file=%s\n' "${C_FILES[@]}"
+    for file in "${C_FILES[@]}"; do
+      [[ -n "$file" ]] && printf 'file=%s\n' "$file"
+    done
   } > "$tmp_file"
   mv "$tmp_file" "$claim_file"
+}
+
+array_contains() {
+  local needle="$1" item
+  shift
+  for item in "$@"; do
+    [[ "$item" == "$needle" ]] && return 0
+  done
+  return 1
 }
 
 append_event() {
@@ -242,6 +269,48 @@ append_event() {
   printf 'utc=%s event=%s agent=%s lane=%s worktree=%s branch=%s sha=%s files=%s intent=%s reason=%s\n' \
     "$NOW_UTC" "$event" "$C_AGENT" "$C_LANE" "$C_WORKTREE" "$C_BRANCH" \
     "$C_SHA" "$(join_files)" "$C_INTENT" "$reason" >> "$EVENT_LOG"
+}
+
+load_message() {
+  local message_file="$1" line
+  M_ID=''
+  M_CREATED_UTC=''
+  M_CREATED_EPOCH=0
+  M_TTL=0
+  M_FROM_AGENT=''
+  M_FROM_LANE=''
+  M_FROM_WORKTREE=''
+  M_FROM_BRANCH=''
+  M_TO_AGENT=''
+  M_TO_LANE=''
+  M_KIND=''
+  M_TEXT=''
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      message_id=*) M_ID="${line#message_id=}" ;;
+      created_utc=*) M_CREATED_UTC="${line#created_utc=}" ;;
+      created_epoch=*) M_CREATED_EPOCH="${line#created_epoch=}" ;;
+      ttl_seconds=*) M_TTL="${line#ttl_seconds=}" ;;
+      from_agent=*) M_FROM_AGENT="${line#from_agent=}" ;;
+      from_lane=*) M_FROM_LANE="${line#from_lane=}" ;;
+      from_worktree=*) M_FROM_WORKTREE="${line#from_worktree=}" ;;
+      from_branch=*) M_FROM_BRANCH="${line#from_branch=}" ;;
+      to_agent=*) M_TO_AGENT="${line#to_agent=}" ;;
+      to_lane=*) M_TO_LANE="${line#to_lane=}" ;;
+      kind=*) M_KIND="${line#kind=}" ;;
+      text=*) M_TEXT="${line#text=}" ;;
+    esac
+  done < "$message_file"
+}
+
+message_expired() {
+  [[ "$M_TTL" =~ ^[0-9]+$ && "$M_CREATED_EPOCH" =~ ^[0-9]+$ ]] || return 0
+  ((NOW_EPOCH > M_CREATED_EPOCH + M_TTL))
+}
+
+message_ack_path() {
+  printf '%s/%s--%s--%s.ack' "$ACKS_DIR" "$(slug "$1")" "$(slug "$2")" "$(slug "$3")"
 }
 
 claim_paths=()
@@ -343,6 +412,102 @@ claim_command() {
   printf 'next=bin/sounio-coord heartbeat --agent %s --lane %s\n' "$agent" "$lane"
 }
 
+scope_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' intent='' ttl="${SOUNIO_COORD_TTL_SECONDS:-14400}"
+  local file claim_file existing old_file new_file requested_id created_utc event='SCOPE' conflict=0
+  local files=() merged_files=() existing_files=()
+
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      --intent) require_arg "$1" "$2"; intent="$2"; shift 2 ;;
+      --ttl-seconds) require_arg "$1" "$2"; ttl="$2"; shift 2 ;;
+      --files)
+        shift
+        while (($#)); do files+=("$(normalize_path "$1")"); shift; done
+        ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown scope option: $1 (put paths after --files)" ;;
+    esac
+  done
+
+  [[ -n "$agent" ]] || die "scope requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "scope requires --lane"
+  [[ -n "$intent" ]] || die "scope requires --intent"
+  [[ "$ttl" =~ ^[1-9][0-9]*$ ]] || die "--ttl-seconds must be a positive integer"
+  validate_value agent "$agent"
+  validate_value lane "$lane"
+  validate_value intent "$intent"
+  for file in "${files[@]}"; do validate_value file "$file"; done
+
+  requested_id="$(claim_id_for "$agent" "$lane")"
+  claim_file="$CLAIMS_DIR/$requested_id.claim"
+  acquire_state_lock "the scope update"
+
+  if [[ -f "$claim_file" ]]; then
+    load_claim "$claim_file"
+    if claim_expired; then
+      append_event EXPIRED "lease expired before scope refresh"
+      unlink "$claim_file"
+      created_utc="$NOW_UTC"
+      event='CLAIM'
+    else
+      [[ "$C_AGENT" == "$agent" ]] || die "claim owner mismatch: $C_AGENT"
+      [[ "$C_WORKTREE" == "$WORKTREE" ]] || die "claim belongs to worktree $C_WORKTREE"
+      [[ "$C_BRANCH" == "$(current_branch)" ]] || die "branch changed from $C_BRANCH; release and scope again"
+      existing_files=("${C_FILES[@]}")
+      created_utc="${C_CREATED_UTC:-$NOW_UTC}"
+    fi
+  else
+    created_utc="$NOW_UTC"
+    event='CLAIM'
+  fi
+
+  merged_files=("${existing_files[@]}")
+  for file in "${files[@]}"; do
+    [[ -n "$file" ]] || continue
+    if ! array_contains "$file" "${merged_files[@]}"; then
+      merged_files+=("$file")
+    fi
+  done
+
+  refresh_claim_paths
+  for existing in "${claim_paths[@]}"; do
+    [[ -f "$existing" && "$existing" != "$claim_file" ]] || continue
+    load_claim "$existing"
+    claim_expired && continue
+    for new_file in "${merged_files[@]}"; do
+      [[ -n "$new_file" ]] || continue
+      for old_file in "${C_FILES[@]}"; do
+        [[ -n "$old_file" ]] || continue
+        if paths_overlap "$new_file" "$old_file"; then
+          printf 'CONFLICT existing_claim=%s agent=%s lane=%s path=%s requested_by=%s requested_lane=%s\n' \
+            "$C_ID" "$C_AGENT" "$C_LANE" "$old_file" "$agent" "$lane" >&2
+          conflict=1
+        fi
+      done
+    done
+  done
+  ((conflict == 0)) || die "requested file set overlaps an active claim"
+
+  C_ID="$requested_id"
+  C_AGENT="$agent"
+  C_LANE="$lane"
+  C_WORKTREE="$WORKTREE"
+  C_BRANCH="$(current_branch)"
+  C_SHA="$(current_sha)"
+  C_CREATED_UTC="$created_utc"
+  C_LAST_UTC="$NOW_UTC"
+  C_LAST_EPOCH="$NOW_EPOCH"
+  C_TTL="$ttl"
+  C_INTENT="$intent"
+  C_FILES=("${merged_files[@]}")
+  write_claim "$claim_file"
+  append_event "$event"
+  printf 'SCOPED claim_id=%s files=%s last_seen=%s\n' "$C_ID" "$(join_files)" "$C_LAST_UTC"
+}
+
 heartbeat_command() {
   local agent="${SOUNIO_AGENT_ID:-}" lane='' claim_file
   while (($#)); do
@@ -399,8 +564,122 @@ release_command() {
   printf 'RELEASED claim_id=%s reason=%s\n' "$C_ID" "${reason:-unspecified}"
 }
 
+send_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' to_agent='' to_lane=''
+  local kind='info' message='' ttl="${SOUNIO_COORD_MESSAGE_TTL_SECONDS:-604800}"
+  local message_id message_file tmp_file
+
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      --to-agent) require_arg "$1" "$2"; to_agent="$2"; shift 2 ;;
+      --to-lane) require_arg "$1" "$2"; to_lane="$2"; shift 2 ;;
+      --kind) require_arg "$1" "$2"; kind="$2"; shift 2 ;;
+      --message) require_arg "$1" "$2"; message="$2"; shift 2 ;;
+      --ttl-seconds) require_arg "$1" "$2"; ttl="$2"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown send option: $1" ;;
+    esac
+  done
+
+  [[ -n "$agent" ]] || die "send requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "send requires --lane"
+  [[ -n "$message" ]] || die "send requires --message"
+  [[ "$kind" =~ ^(info|request|reply|blocker|handoff)$ ]] || \
+    die "--kind must be info, request, reply, blocker, or handoff"
+  [[ "$ttl" =~ ^[1-9][0-9]*$ ]] || die "--ttl-seconds must be a positive integer"
+  validate_value agent "$agent"
+  validate_value lane "$lane"
+  validate_value to-agent "$to_agent"
+  validate_value to-lane "$to_lane"
+  validate_value message "$message"
+
+  message_id="msg-${NOW_EPOCH}-$$-${RANDOM}"
+  message_file="$MESSAGES_DIR/$message_id.message"
+  acquire_state_lock "the message"
+  tmp_file="$(mktemp "$MESSAGES_DIR/.message-write.XXXXXX")"
+  {
+    printf 'message_id=%s\n' "$message_id"
+    printf 'created_utc=%s\n' "$NOW_UTC"
+    printf 'created_epoch=%s\n' "$NOW_EPOCH"
+    printf 'ttl_seconds=%s\n' "$ttl"
+    printf 'from_agent=%s\n' "$agent"
+    printf 'from_lane=%s\n' "$lane"
+    printf 'from_worktree=%s\n' "$WORKTREE"
+    printf 'from_branch=%s\n' "$(current_branch)"
+    printf 'to_agent=%s\n' "$to_agent"
+    printf 'to_lane=%s\n' "$to_lane"
+    printf 'kind=%s\n' "$kind"
+    printf 'text=%s\n' "$message"
+  } > "$tmp_file"
+  mv "$tmp_file" "$message_file"
+  printf 'utc=%s event=MESSAGE message_id=%s from_agent=%s from_lane=%s to_agent=%s to_lane=%s kind=%s\n' \
+    "$NOW_UTC" "$message_id" "$agent" "$lane" "$to_agent" "$to_lane" "$kind" >> "$EVENT_LOG"
+  printf 'SENT message_id=%s to_agent=%s to_lane=%s kind=%s\n' \
+    "$message_id" "${to_agent:-*}" "${to_lane:-*}" "$kind"
+}
+
+inbox_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' show_all=0 message_file ack_file shown=0
+  local -a message_paths=()
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      --all) show_all=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown inbox option: $1" ;;
+    esac
+  done
+  [[ -n "$agent" ]] || die "inbox requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "inbox requires --lane"
+
+  message_paths=("$MESSAGES_DIR"/*.message)
+  for message_file in "${message_paths[@]}"; do
+    [[ -f "$message_file" ]] || continue
+    load_message "$message_file"
+    message_expired && continue
+    [[ -z "$M_TO_AGENT" || "$M_TO_AGENT" == "$agent" ]] || continue
+    [[ -z "$M_TO_LANE" || "$M_TO_LANE" == "$lane" ]] || continue
+    [[ "$M_FROM_AGENT" != "$agent" || "$M_FROM_LANE" != "$lane" ]] || continue
+    ack_file="$(message_ack_path "$M_ID" "$agent" "$lane")"
+    ((show_all)) || [[ ! -f "$ack_file" ]] || continue
+    printf 'MESSAGE id=%s utc=%s from_agent=%s from_lane=%s kind=%s text=%s\n' \
+      "$M_ID" "$M_CREATED_UTC" "$M_FROM_AGENT" "$M_FROM_LANE" "$M_KIND" "$M_TEXT"
+    shown=$((shown + 1))
+  done
+  printf 'inbox_messages=%s\n' "$shown"
+}
+
+ack_command() {
+  local agent="${SOUNIO_AGENT_ID:-}" lane='' message_id='' message_file ack_file
+  while (($#)); do
+    case "$1" in
+      --agent) require_arg "$1" "$2"; agent="$2"; shift 2 ;;
+      --lane) require_arg "$1" "$2"; lane="$2"; shift 2 ;;
+      --message) require_arg "$1" "$2"; message_id="$2"; shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *) die "unknown ack option: $1" ;;
+    esac
+  done
+  [[ -n "$agent" ]] || die "ack requires --agent or SOUNIO_AGENT_ID"
+  [[ -n "$lane" ]] || die "ack requires --lane"
+  [[ -n "$message_id" ]] || die "ack requires --message"
+  message_file="$MESSAGES_DIR/$(slug "$message_id").message"
+  [[ -f "$message_file" ]] || die "message not found: $message_id"
+  load_message "$message_file"
+  [[ -z "$M_TO_AGENT" || "$M_TO_AGENT" == "$agent" ]] || die "message is addressed to agent $M_TO_AGENT"
+  [[ -z "$M_TO_LANE" || "$M_TO_LANE" == "$lane" ]] || die "message is addressed to lane $M_TO_LANE"
+  acquire_state_lock "the acknowledgement"
+  ack_file="$(message_ack_path "$M_ID" "$agent" "$lane")"
+  printf 'utc=%s agent=%s lane=%s\n' "$NOW_UTC" "$agent" "$lane" > "$ack_file"
+  printf 'ACKED message_id=%s agent=%s lane=%s\n' "$M_ID" "$agent" "$lane"
+}
+
 prune_command() {
-  local removed=0 claim_file
+  local removed=0 messages_removed=0 claim_file message_file ack_file
+  local -a message_paths=() ack_paths=()
   acquire_state_lock "prune"
   refresh_claim_paths
   for claim_file in "${claim_paths[@]}"; do
@@ -413,7 +692,21 @@ prune_command() {
       printf 'PRUNED claim_id=%s agent=%s lane=%s\n' "$C_ID" "$C_AGENT" "$C_LANE"
     fi
   done
-  printf 'pruned=%s\n' "$removed"
+  message_paths=("$MESSAGES_DIR"/*.message)
+  for message_file in "${message_paths[@]}"; do
+    [[ -f "$message_file" ]] || continue
+    load_message "$message_file"
+    if message_expired; then
+      unlink "$message_file"
+      ack_paths=("$ACKS_DIR/$(slug "$M_ID")"--*.ack)
+      for ack_file in "${ack_paths[@]}"; do
+        [[ -f "$ack_file" ]] && unlink "$ack_file"
+      done
+      messages_removed=$((messages_removed + 1))
+      printf 'PRUNED_MESSAGE message_id=%s\n' "$M_ID"
+    fi
+  done
+  printf 'pruned=%s pruned_messages=%s\n' "$removed" "$messages_removed"
 }
 
 status_command() {
@@ -592,12 +885,16 @@ case "$command" in
     printf 'COORDINATION_CHECK=PASS\n'
     ;;
   claim) claim_command "$@" ;;
+  scope) scope_command "$@" ;;
   heartbeat) heartbeat_command "$@" ;;
   release) release_command "$@" ;;
+  send) send_command "$@" ;;
+  inbox) inbox_command "$@" ;;
+  ack) ack_command "$@" ;;
   prune)
     (($# == 0)) || die "prune does not accept arguments"
     prune_command
     ;;
   -h|--help|help) usage ;;
-  *) die "unknown command: $command (try brief, status, check, claim, heartbeat, release, or prune)" ;;
+  *) die "unknown command: $command (try brief, status, check, claim, scope, heartbeat, release, send, inbox, ack, or prune)" ;;
 esac

--- a/scripts/ci/sounio_coord_agent_hook_selftest.sh
+++ b/scripts/ci/sounio_coord_agent_hook_selftest.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/sounio-coord-hook-selftest.XXXXXX")"
+REPO="$TEST_ROOT/repo"
+SECOND="$TEST_ROOT/second-worktree"
+STATE="$TEST_ROOT/state"
+
+cleanup() {
+  git -C "$REPO" worktree remove --force "$SECOND" >/dev/null 2>&1 || true
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "sounio-coord-agent-hook-selftest: FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "$REPO/bin" "$REPO/scripts/dev" "$REPO/self-hosted/parser"
+cp "$ROOT_DIR/bin/sounio-coord" "$REPO/bin/sounio-coord"
+cp "$ROOT_DIR/scripts/dev/sounio_coord_agent_hook.py" "$REPO/scripts/dev/"
+chmod +x "$REPO/bin/sounio-coord" "$REPO/scripts/dev/sounio_coord_agent_hook.py"
+git -C "$REPO" init -q
+git -C "$REPO" config user.name 'Sounio Hook Selftest'
+git -C "$REPO" config user.email 'coord-hook-selftest@sounio.local'
+printf 'seed\n' > "$REPO/README.md"
+printf 'parser\n' > "$REPO/self-hosted/parser/ast.sio"
+printf 'items\n' > "$REPO/self-hosted/parser/items.sio"
+git -C "$REPO" add .
+git -C "$REPO" commit -qm seed
+git -C "$REPO" worktree add -q -b second-lane "$SECOND"
+
+run_hook() {
+  local agent="$1" cwd="$2" payload="$3"
+  printf '%s\n' "$payload" | SOUNIO_COORD_DIR="$STATE" \
+    python3 "$cwd/scripts/dev/sounio_coord_agent_hook.py" --agent "$agent"
+}
+
+run_coord() {
+  local cwd="$1"
+  shift
+  (cd "$cwd" && SOUNIO_COORD_DIR="$STATE" bin/sounio-coord "$@")
+}
+
+output="$(run_hook codex "$REPO" \
+  "{\"session_id\":\"codex-a\",\"cwd\":\"$REPO\",\"hook_event_name\":\"SessionStart\"}")"
+grep -q 'agent=codex lane=session-codex-a' <<< "$output" || \
+  fail 'Codex session identity was not injected'
+output="$(run_coord "$REPO" brief --max-rows 4)"
+grep -q 'ACTIVE claim_id=codex--session-codex-a' <<< "$output" || \
+  fail 'Codex session presence was not registered'
+
+run_hook codex "$REPO" \
+  "{\"session_id\":\"codex-a\",\"cwd\":\"$REPO\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"apply_patch\",\"tool_input\":{\"patch\":\"*** Update File: self-hosted/parser/ast.sio\"}}"
+run_hook codex "$REPO" \
+  "{\"session_id\":\"codex-a\",\"cwd\":\"$REPO\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"apply_patch\",\"tool_input\":{\"patch\":\"*** Update File: self-hosted/parser/items.sio\"}}"
+output="$(run_coord "$REPO" brief --max-rows 4)"
+grep -q 'files=self-hosted/parser/ast.sio,self-hosted/parser/items.sio' <<< "$output" || \
+  fail 'automatic write scope did not accumulate files'
+
+output="$(run_hook claude "$SECOND" \
+  "{\"session_id\":\"claude-b\",\"cwd\":\"$SECOND\",\"hook_event_name\":\"SessionStart\"}")"
+grep -q 'agent=claude lane=session-claude-b' <<< "$output" || \
+  fail 'Claude session identity was not injected'
+send_output="$(run_coord "$REPO" send --agent codex --lane session-codex-a \
+  --to-agent claude --to-lane session-claude-b --kind request \
+  --message 'Please review the parser ownership boundary')"
+message_id="$(sed -n 's/^SENT message_id=\([^ ]*\).*/\1/p' <<< "$send_output")"
+[[ -n "$message_id" ]] || fail 'message id was not returned'
+
+output="$(run_hook claude "$SECOND" \
+  "{\"session_id\":\"claude-b\",\"cwd\":\"$SECOND\",\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"Read\",\"tool_input\":{}}")"
+grep -q "MESSAGE id=$message_id" <<< "$output" || fail 'message was not delivered to Claude'
+run_coord "$SECOND" ack --agent claude --lane session-claude-b --message "$message_id" >/dev/null
+output="$(run_coord "$SECOND" inbox --agent claude --lane session-claude-b)"
+grep -q '^inbox_messages=0$' <<< "$output" || fail 'acknowledged message remained unread'
+
+set +e
+conflict_output="$(run_hook claude "$SECOND" \
+  "{\"session_id\":\"claude-b\",\"cwd\":\"$SECOND\",\"hook_event_name\":\"PreToolUse\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"self-hosted/parser/ast.sio\"}}" 2>&1)"
+conflict_rc=$?
+set -e
+[[ "$conflict_rc" -eq 2 ]] || fail "conflicting write returned $conflict_rc instead of 2"
+grep -q 'requested file set overlaps an active claim' <<< "$conflict_output" || \
+  fail 'conflicting write did not explain the ownership collision'
+output="$(run_coord "$REPO" inbox --agent codex --lane session-codex-a)"
+grep -q 'kind=request text=Write conflict requested by claude/session-claude-b' <<< "$output" || \
+  fail 'conflict owner did not receive an automatic message'
+
+run_hook claude "$SECOND" \
+  "{\"session_id\":\"claude-b\",\"cwd\":\"$SECOND\",\"hook_event_name\":\"SessionEnd\"}"
+output="$(run_coord "$SECOND" brief --max-rows 4)"
+grep -q 'ACTIVE claim_id=claude--session-claude-b' <<< "$output" && \
+  fail 'Claude session claim survived SessionEnd'
+
+run_coord "$REPO" send --agent codex --lane session-codex-a --kind info \
+  --ttl-seconds 1 --message 'ephemeral selftest message' >/dev/null
+sleep 2
+output="$(run_coord "$REPO" prune)"
+grep -q 'pruned_messages=1$' <<< "$output" || fail 'expired message was not pruned'
+
+echo 'sounio-coord-agent-hook-selftest: PASS'

--- a/scripts/dev/sounio_coord_agent_hook.py
+++ b/scripts/dev/sounio_coord_agent_hook.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Bridge Claude Code and Codex lifecycle hooks to bin/sounio-coord."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PATCH_PATH = re.compile(r"^\*\*\* (?:Add|Update|Delete) File: (.+)$", re.MULTILINE)
+CONFLICT_OWNER = re.compile(r"existing_claim=\S+ agent=(\S+) lane=(\S+)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--agent", required=True)
+    return parser.parse_args()
+
+
+def read_event() -> dict[str, Any]:
+    try:
+        value = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def repo_root(cwd: str) -> Path | None:
+    result = subprocess.run(
+        ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def safe_token(value: str, limit: int = 24) -> str:
+    token = re.sub(r"[^A-Za-z0-9._-]", "_", value)[:limit]
+    return token or "unknown"
+
+
+def run_coord(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["SOUNIO_COORD_TTL_SECONDS"] = env.get(
+        "SOUNIO_COORD_HOOK_TTL_SECONDS", "1800"
+    )
+    return subprocess.run(
+        [str(root / "bin" / "sounio-coord"), *args],
+        cwd=root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def scope_args(agent: str, lane: str, intent: str) -> list[str]:
+    return ["--agent", agent, "--lane", lane, "--intent", intent]
+
+
+def extract_paths(event: dict[str, Any]) -> list[str]:
+    tool_name = str(event.get("tool_name", ""))
+    tool_input = event.get("tool_input", {})
+    paths: list[str] = []
+
+    if isinstance(tool_input, dict):
+        for key in ("file_path", "notebook_path"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value:
+                paths.append(value)
+
+    if tool_name in {"apply_patch", "Edit", "Write"}:
+        patch = ""
+        if isinstance(tool_input, str):
+            patch = tool_input
+        elif isinstance(tool_input, dict):
+            for key in ("patch", "input"):
+                value = tool_input.get(key)
+                if isinstance(value, str):
+                    patch = value
+                    break
+        paths.extend(PATCH_PATH.findall(patch))
+
+    return list(dict.fromkeys(paths))
+
+
+def notify_conflict(
+    root: Path,
+    agent: str,
+    lane: str,
+    paths: list[str],
+    stderr: str,
+) -> None:
+    owner = CONFLICT_OWNER.search(stderr)
+    if not owner:
+        return
+    to_agent, to_lane = owner.groups()
+    message = f"Write conflict requested by {agent}/{lane}: {', '.join(paths)}"
+    run_coord(
+        root,
+        "send",
+        "--agent",
+        agent,
+        "--lane",
+        lane,
+        "--to-agent",
+        to_agent,
+        "--to-lane",
+        to_lane,
+        "--kind",
+        "request",
+        "--message",
+        message,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    event = read_event()
+    cwd = str(event.get("cwd") or os.getcwd())
+    root = repo_root(cwd)
+    if root is None or not (root / "bin" / "sounio-coord").is_file():
+        return 0
+
+    event_name = str(event.get("hook_event_name", ""))
+    session_id = safe_token(str(event.get("session_id", "unknown")))
+    agent = safe_token(args.agent)
+    lane = f"session-{session_id}"
+    intent = f"active {agent} session"
+    common = scope_args(agent, lane, intent)
+
+    if event_name == "SessionEnd":
+        run_coord(
+            root,
+            "release",
+            "--agent",
+            agent,
+            "--lane",
+            lane,
+            "--reason",
+            "agent session ended",
+        )
+        return 0
+
+    if event_name == "PreToolUse":
+        paths = extract_paths(event)
+        if not paths:
+            return 0
+        result = run_coord(root, "scope", *common, "--files", *paths)
+        if result.returncode != 0:
+            notify_conflict(root, agent, lane, paths, result.stderr)
+            sys.stderr.write(result.stderr or "coordination scope update failed\n")
+            return 2
+        return 0
+
+    if event_name == "SessionStart":
+        result = run_coord(root, "scope", *common)
+    else:
+        result = run_coord(
+            root, "heartbeat", "--agent", agent, "--lane", lane
+        )
+        if result.returncode != 0:
+            result = run_coord(root, "scope", *common)
+    if result.returncode != 0:
+        sys.stderr.write(f"sounio coordination warning: {result.stderr}")
+        return 0
+
+    if event_name == "SessionStart":
+        print(
+            f"Sounio coordination joined: agent={agent} lane={lane}. "
+            "Use this same agent/lane with `bin/sounio-coord scope` before "
+            "write-bearing Bash commands."
+        )
+
+    if event_name in {"UserPromptSubmit", "PostToolUse"}:
+        inbox = run_coord(
+            root, "inbox", "--agent", agent, "--lane", lane
+        )
+        lines = [line for line in inbox.stdout.splitlines() if line.startswith("MESSAGE ")]
+        if lines:
+            print("Sounio lane messages waiting for this agent:")
+            print("\n".join(lines))
+            print(
+                "After handling one, acknowledge it with "
+                f"bin/sounio-coord ack --agent {agent} --lane {lane} --message <id>."
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- registers Claude Code and Codex sessions as short-lived live leases
- automatically extends a session lease before structured file writes
- adds cross-worktree `send`, `inbox`, and `ack` messaging
- injects unread messages after prompts and tool calls while agents work
- notifies the current owner when another lane attempts an overlapping write
- adds lifecycle and two-worktree conversation coverage to the Contracts job

## Why

Parallel lanes could see static handoffs but could not reliably discover active work, reserve files, or ask each other questions during execution. This turns the coordination lease into a live collaboration channel while keeping shell writes explicit.

## Validation

- `bash scripts/ci/sounio_coord_selftest.sh`
- `bash scripts/ci/sounio_coord_agent_hook_selftest.sh`
- `bash scripts/dev/check_workflow_script_refs.sh`
- `bash scripts/dev/check_docs_consistency.sh`
- `bash scripts/dev/check_docs_registry.sh`
- `bash -n bin/sounio-coord scripts/ci/sounio_coord_agent_hook_selftest.sh`
- `python3 -m py_compile scripts/dev/sounio_coord_agent_hook.py`
- `jq empty .claude/settings.json .codex/hooks.json`
- `git diff --check`

## Operational note

Codex requires users to review a new project-hook hash with `/hooks`. Claude Code loads the committed project settings. Write-bearing Bash commands still require an explicit `scope` because arbitrary shell effects cannot be inferred safely.
