### PR TITLE
fix(madaros): global f64 array-repeat + element-list init

### DIFF
--- a/scripts/dev/madaros_global_array_init_gate.sh
+++ b/scripts/dev/madaros_global_array_init_gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Gate: Madaros native-v2 global array-repeat init `[V; N]`.
-# Exit 0 only when compile+run yields non-zero fill under default Madaros.
+# Gate: Madaros native-v2 global array init — scalar, i64/f64 array-repeat, element-list.
+# Exit 0 only when compile+run yields correct fills under default Madaros.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT"
@@ -10,7 +10,32 @@ TMP="${TMPDIR:-/tmp}/madaros_global_array_init_gate_$$"
 mkdir -p "$TMP"
 trap 'rm -rf "$TMP"' EXIT
 
-cat > "$TMP/repro.sio" << 'SIO'
+fail() {
+  echo "GLOBAL_ARRAY_INIT_GATE_FAIL $*"
+  exit 1
+}
+
+run_case() {
+  local name="$1" src="$2" expect="$3"
+  local f="$TMP/${name}.sio"
+  local elf="$TMP/${name}.elf"
+  printf '%s\n' "$src" > "$f"
+  echo "[gate] $name"
+  "$SOUC" compile "$f" -o "$elf"
+  chmod +x "$elf"
+  local out rc
+  set +e
+  out="$("$elf" 2>&1)"
+  rc=$?
+  set -e
+  echo "[gate]   stdout: $out"
+  echo "[gate]   rc: $rc"
+  [[ "$rc" -eq 0 ]] || fail "$name rc=$rc out=$out"
+  [[ "$out" == *"$expect"* ]] || fail "$name expected '$expect' got: $out"
+}
+
+# 1) i64 array-repeat + f64 print coexistence (#1305)
+run_case "i64_repeat" '
 var CT: [i64; 2] = [42; 2]
 fn main() -> i64 with IO {
   let p = 5.7
@@ -22,20 +47,47 @@ fn main() -> i64 with IO {
   if CT[1] != 42 { return 2 }
   0
 }
-SIO
+' '5.700000 (42)'
 
-echo "[gate] compile $TMP/repro.sio under default Madaros"
-"$SOUC" compile "$TMP/repro.sio" -o "$TMP/repro.elf"
-chmod +x "$TMP/repro.elf"
-out="$("$TMP/repro.elf")"; rc=$?
-echo "[gate] stdout: $out"
-echo "[gate] rc: $rc"
-if [[ "$rc" -ne 0 ]]; then
-  echo "GLOBAL_ARRAY_INIT_GATE_FAIL rc=$rc"
-  exit 1
-fi
-if [[ "$out" != *"5.700000 (42)"* ]]; then
-  echo "GLOBAL_ARRAY_INIT_GATE_FAIL expected '5.700000 (42)' got: $out"
-  exit 1
-fi
+# 2) f64 array-repeat residual
+run_case "f64_repeat" '
+var F: [f64; 2] = [1.5; 2]
+fn main() -> i64 with IO {
+  print(F[0])
+  print(" ")
+  print(F[1])
+  print("\n")
+  if F[0] != 1.5 { return 1 }
+  if F[1] != 1.5 { return 2 }
+  0
+}
+' '1.500000 1.500000'
+
+# 3) element-list i64 + f64
+run_case "elem_list" '
+var A: [i64; 3] = [10, 20, 30]
+var B: [f64; 2] = [1.5, 2.5]
+fn main() -> i64 with IO {
+  print_int(A[0]); print(" "); print_int(A[1]); print(" "); print_int(A[2]); print("\n")
+  print(B[0]); print(" "); print(B[1]); print("\n")
+  if A[0] != 10 { return 1 }
+  if A[1] != 20 { return 2 }
+  if A[2] != 30 { return 3 }
+  if B[0] != 1.5 { return 4 }
+  if B[1] != 2.5 { return 5 }
+  0
+}
+' '10 20 30'
+
+# 4) scalar control
+run_case "scalar" '
+var G: i64 = 42
+fn main() -> i64 with IO {
+  print_int(G)
+  print("\n")
+  if G != 42 { return 1 }
+  0
+}
+' '42'
+
 echo "GLOBAL_ARRAY_INIT_GATE_OK"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -599,6 +599,17 @@ fn lowerer_seed_module_from_summary(lo_in: Lowerer, summary: &IrProgramSummary) 
         func.hyper_algebra_kind = (*summary.module).functions[i as usize].hyper_algebra_kind
         func.bss_size = (*summary.module).functions[i as usize].bss_size
         func.first_param_is_ref = (*summary.module).functions[i as usize].first_param_is_ref
+        // Preserve element-list init words packed into BSS slot instrs[]
+        // (count>1 → per-element stores in emit_global_var_inits_into).
+        let ic = (*summary.module).functions[i as usize].instr_count
+        if ic > 0 {
+            var ji: i64 = 0
+            while ji < ic && ji < IR_MAX_INSTRS {
+                func.instrs[ji as usize] = (*summary.module).functions[i as usize].instrs[ji as usize]
+                ji = ji + 1
+            }
+            func.instr_count = ic
+        }
         (*module_box).functions[i as usize] = func
         i = i + 1
     }
@@ -688,6 +699,16 @@ fn lowerer_new_from_program_summary_flat(summary: &IrProgramSummaryFlat, epistem
         func.hyper_algebra_kind = summary.module.functions[i as usize].hyper_algebra_kind
         func.bss_size = summary.module.functions[i as usize].bss_size
         func.first_param_is_ref = summary.module.functions[i as usize].first_param_is_ref
+        // Preserve element-list init words packed into BSS slot instrs[].
+        let ic = summary.module.functions[i as usize].instr_count
+        if ic > 0 {
+            var ji: i64 = 0
+            while ji < ic && ji < IR_MAX_INSTRS {
+                func.instrs[ji as usize] = summary.module.functions[i as usize].instrs[ji as usize]
+                ji = ji + 1
+            }
+            func.instr_count = ic
+        }
         (*module_box).functions[i as usize] = func
         i = i + 1
     }
@@ -1301,6 +1322,30 @@ fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Pani
     }
 }
 
+// Apply parse-time GLOBAL_VAR_INIT_* side-table data onto a BSS global slot.
+// - count == 0: no recorded init (BSS stays zero)
+// - count == 1: scalar or array-repeat fill → returns_float=1, prof_counter_id=word
+// - count  > 1: element-list → also pack words into instrs[] for per-element stores
+// Presence uses count (not value!=0) so a list starting with 0 still inits.
+fn lower_apply_global_var_init(slot: &! IrFunction, name: Name) with Mut, Div {
+    let count = ast_global_var_init_count(name)
+    if count <= 0 {
+        return
+    }
+    (*slot).returns_float = 1
+    (*slot).prof_counter_id = ast_global_var_init_nth(name, 0)
+    if count > 1 {
+        var j: i64 = 0
+        while j < count && j < IR_MAX_INSTRS {
+            var instr = (*slot).instrs[j as usize]
+            instr.imm_i64 = ast_global_var_init_nth(name, j)
+            (*slot).instrs[j as usize] = instr
+            j = j + 1
+        }
+        (*slot).instr_count = j
+    }
+}
+
 fn lowerer_preseed_program_items_mut(
     lo: &! Lowerer,
     items: &Option<Box<ItemList>>,
@@ -1377,11 +1422,7 @@ fn lowerer_preseed_program_items_mut(
                                     bss_slot.param_count = bss_off
                                     bss_slot.bss_size = bss_size
                                     bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&head.type_alias_ty)
-                                    let init_val = ast_lookup_global_var_init(name)
-                                    if init_val != 0 {
-                                        bss_slot.returns_float = 1
-                                        bss_slot.prof_counter_id = init_val
-                                    }
+                                    lower_apply_global_var_init(&! bss_slot, name)
                                     (*mbox2).functions[bss_fn_id as usize] = bss_slot
                                     (*mbox2).bss_total_size = bss_off + aligned_size
                                     (*lo).module = mbox2
@@ -1816,11 +1857,7 @@ fn ir_fast_summary_preseed_items_seed_owned(
                                         bss_slot.param_count = bss_mod.bss_total_size
                                         bss_slot.bss_size = bss_size
                                         bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&item.type_alias_ty)
-                                        let init_val = ast_lookup_global_var_init(name)
-                                        if init_val != 0 {
-                                            bss_slot.returns_float = 1
-                                            bss_slot.prof_counter_id = init_val
-                                        }
+                                        lower_apply_global_var_init(&! bss_slot, name)
                                         bss_mod.functions[bss_fid as usize] = bss_slot
                                         bss_mod.fn_count = bss_fid + 1
                                         bss_mod.bss_total_size = bss_mod.bss_total_size + aligned_size
@@ -1932,11 +1969,7 @@ fn lower_program_to_ir_summary_flat_owned_with_epistemic_ref(
                                 bss_slot.param_count = bss_mod.bss_total_size
                                 bss_slot.bss_size = bss_size
                                 bss_slot.hyper_algebra_kind = lower_typeexpr_bss_elem_size(&item.type_alias_ty)
-                                let init_val = ast_lookup_global_var_init(name)
-                                if init_val != 0 {
-                                    bss_slot.returns_float = 1
-                                    bss_slot.prof_counter_id = init_val
-                                }
+                                lower_apply_global_var_init(&! bss_slot, name)
                                 bss_mod.functions[bss_fid as usize] = bss_slot
                                 bss_mod.fn_count = bss_fid + 1
                                 bss_mod.bss_total_size = bss_mod.bss_total_size + aligned_size
@@ -5646,7 +5679,21 @@ impl Lowerer {
         match *base_opt {
             Some(base_expr) => {
                 if (*base_expr).kind == ExprKind::ExprIdent {
-                    return self.lookup_local_array_elem_float((*base_expr).name)
+                    if self.lookup_local_array_elem_float((*base_expr).name) {
+                        return true
+                    }
+                    // Module-level `var F: [f64; N]`: not always bound as a local with
+                    // array_elem_float=1. Fall back to the preseed global type table so
+                    // `print(F[i])` routes to print_f64 (IEEE bits → dtoa) instead of
+                    // print_int (raw bit pattern as decimal).
+                    let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, (*base_expr).name)
+                    if fn_id >= 0 {
+                        let gkind = lower_global_type_table_lookup(&(*self.global_types), fn_id)
+                        if gkind == LOWER_GLOBAL_ELEM_F64 {
+                            return true
+                        }
+                    }
+                    return false
                 }
                 if (*base_expr).kind == ExprKind::ExprFieldAccess {
                     return self.field_array_elem_is_float_for_base_ref(&(*base_expr).left, (*base_expr).name)

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -9201,9 +9201,13 @@ fn emit_entry_trampoline_split_into(nc: &! NativeCompiler, main_fn_index: i64) w
     emit_entry_trampoline_call_exit_into(nc, main_fn_index)
 }
 
-// Emit entry-time BSS fills for globals with a recorded non-zero scalar init
-// (returns_float==1 is the "has init" flag; prof_counter_id holds the fill value).
-// Scalars: single 8-byte store. Array-repeat `[V; N]`: rep stosq/stosb over bss_size.
+// Emit entry-time BSS fills for globals with a recorded init
+// (returns_float==1 is the "has init" flag; prof_counter_id holds the fill/first value).
+// Paths:
+//   - element-list (instr_count > 1): sequential stores of instrs[i].imm_i64
+//   - scalar / 1-elem: single 8-byte store of prof_counter_id
+//   - array-repeat `[V; N]` (instr_count == 0, bss_size > elem): rep stosq/stosb
+// f64 values are stored as IEEE-754 bit patterns (same path as i64 words).
 fn emit_global_var_inits_into(nc: &! NativeCompiler, module: &IrModule) with Mut, Panic, Div {
     var fi: i64 = 0
     while fi < (*module).fn_count {
@@ -9217,14 +9221,33 @@ fn emit_global_var_inits_into(nc: &! NativeCompiler, module: &IrModule) with Mut
             if elem <= 0 {
                 elem = 8
             }
-            // Single word (scalar or 1-element array of 8-byte elems): one store.
-            if total <= 8 && elem >= 8 {
+            // Element-list form: distinct per-element words packed into instrs[].
+            // Prefer this over rep-stos fill even when bss_size is multi-word.
+            if func.instr_count > 1 {
+                var ei: i64 = 0
+                while ei < func.instr_count {
+                    let word = func.instrs[ei as usize].imm_i64
+                    let addr = abs_addr + ei * elem
+                    nc_emit_mov_rax_imm(nc, word)
+                    nc_emit_mov_reg_imm(nc, 3, addr)
+                    if elem == 1 {
+                        // byte store: mov [rbx], al
+                        nc_emit_byte(nc, 0x88)
+                        nc_emit_byte(nc, 0x03)
+                    } else {
+                        nc_emit_store_rax_mem_rbx_disp32(nc, 0)
+                    }
+                    ei = ei + 1
+                }
+            } else if total <= 8 && elem >= 8 {
+                // Single word (scalar or 1-element array of 8-byte elems): one store.
                 nc_emit_mov_rax_imm(nc, init_val)
                 nc_emit_mov_reg_imm(nc, 3, abs_addr)
                 nc_emit_store_rax_mem_rbx_disp32(nc, 0)
             } else if total > 0 {
-                // Multi-element fill. DF=0 (ascending) is the process default.
+                // Array-repeat fill. DF=0 (ascending) is the process default.
                 // rax = fill value, rdi = dest, rcx = element count.
+                // Covers i64 and f64 fills (same 8-byte word path via rep stosq).
                 let count = total / elem
                 if count > 0 {
                     nc_emit_mov_rax_imm(nc, init_val)

--- a/self-hosted/parser/ast.sio
+++ b/self-hosted/parser/ast.sio
@@ -1407,3 +1407,36 @@ pub fn ast_lookup_global_var_init(name: Name) -> i64 with Div {
     }
     0
 }
+
+// Count of recorded init words for `name`. Scalar / array-repeat → 1;
+// element-list `[a,b,c]` → N. Zero means "no recorded initializer".
+// Distinct from lookup(value)==0: a recorded zero fill still counts as present.
+pub fn ast_global_var_init_count(name: Name) -> i64 with Div {
+    let h = ast_name_hash(name)
+    var n: i64 = 0
+    var i: i64 = 0
+    while i < GLOBAL_VAR_INIT_COUNT {
+        if GLOBAL_VAR_INIT_HASHES[i as usize] == h {
+            n = n + 1
+        }
+        i = i + 1
+    }
+    n
+}
+
+// Nth recorded init word for `name` (0-based, source order). Returns 0 if out of range.
+pub fn ast_global_var_init_nth(name: Name, index: i64) -> i64 with Div {
+    let h = ast_name_hash(name)
+    var seen: i64 = 0
+    var i: i64 = 0
+    while i < GLOBAL_VAR_INIT_COUNT {
+        if GLOBAL_VAR_INIT_HASHES[i as usize] == h {
+            if seen == index {
+                return GLOBAL_VAR_INIT_VALUES[i as usize]
+            }
+            seen = seen + 1
+        }
+        i = i + 1
+    }
+    0
+}

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -13,9 +13,12 @@ fn items_reverse_item_list_opt(items: Option<Box<ItemList>>) -> Option<Box<ItemL
     items_reverse_item_list_loop(items, None)
 }
 
-// Record a compile-time integer global initializer for native BSS fill.
-// Covers: scalar `42` / `-42`, and array-repeat `[42; N]` / `[0 - 42; N]`.
-// Element-list forms `[a, b, c]` are not recorded (fill emission is repeat-only).
+// Record a compile-time integer/float global initializer for native BSS fill.
+// Covers:
+//   - scalar `42` / `-42` / `1.5` / unary-neg floats
+//   - array-repeat `[V; N]`  → one fill word (i64 value or f64 bits)
+//   - element-list `[a, b, c]` → one word per element, same name hash, source order
+// Non-literal elements are silently skipped (BSS stays zero for those slots).
 fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
     if (*init).kind == ExprKind::ExprIntLit {
         ast_record_global_var_init(name, (*init).int_val)
@@ -25,6 +28,7 @@ fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
         // Module-level `let/var X: f64 = <lit>`: record the IEEE-754 bits so the
         // BSS-global initializer emits the value. int_val is 0 for a float literal,
         // so without this branch f64 globals silently read 0.
+        // Also covers f64 array-repeat fill: `[1.5; N]` recurses into this branch.
         ast_record_global_var_init(name, f64_to_bits((*init).float_val))
         return
     }
@@ -42,12 +46,25 @@ fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
         return
     }
     if (*init).kind == ExprKind::ExprArrayLit {
-        // Repeat form: left = fill value, right = count
+        // Repeat form: left = fill value, right = count → single fill word
         match (*init).left {
             Some(repeat_val) => {
                 items_record_global_int_init(name, &(*repeat_val))
             }
-            _ => {}
+            None => {
+                // Element-list form: [a, b, c] — record each literal in source order
+                // (args is already reversed into source order by parse_array_literal).
+                var cur = (*init).args
+                while true {
+                    match cur {
+                        Some(node) => {
+                            items_record_global_int_init(name, &(*node).head)
+                            cur = (*node).tail
+                        }
+                        None => { break }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/run-pass/global_array_element_list_init.sio
+++ b/tests/run-pass/global_array_element_list_init.sio
@@ -1,0 +1,29 @@
+//@ run-pass
+// Madaros native-v2 must honour global element-list initializers `[a, b, c]`.
+// Residual after #1305 (repeat-only): distinct per-element words.
+//@ expect-stdout: 10 20 30
+//@ expect-stdout: 1.500000 2.500000
+//@ expect-stdout: LIST_OK
+
+var A: [i64; 3] = [10, 20, 30]
+var B: [f64; 2] = [1.5, 2.5]
+
+fn main() -> i64 with IO {
+    print_int(A[0])
+    print(" ")
+    print_int(A[1])
+    print(" ")
+    print_int(A[2])
+    print("\n")
+    print(B[0])
+    print(" ")
+    print(B[1])
+    print("\n")
+    if A[0] != 10 { return 1 }
+    if A[1] != 20 { return 2 }
+    if A[2] != 30 { return 3 }
+    if B[0] != 1.5 { return 4 }
+    if B[1] != 2.5 { return 5 }
+    print("LIST_OK\n")
+    0
+}

--- a/tests/run-pass/global_array_element_list_init.sio
+++ b/tests/run-pass/global_array_element_list_init.sio
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ requires: madaros
 // Madaros native-v2 must honour global element-list initializers `[a, b, c]`.
 // Residual after #1305 (repeat-only): distinct per-element words.
 //@ expect-stdout: 10 20 30

--- a/tests/run-pass/global_array_f64_repeat_init.sio
+++ b/tests/run-pass/global_array_f64_repeat_init.sio
@@ -1,0 +1,18 @@
+//@ run-pass
+// Madaros native-v2 must honour f64 global array-repeat initializers `[V; N]`.
+// Residual after #1305 (i64 only): f64 fill bits must land via rep stosq of IEEE bits.
+//@ expect-stdout: 1.500000 1.500000
+//@ expect-stdout: F64_OK
+
+var F: [f64; 2] = [1.5; 2]
+
+fn main() -> i64 with IO {
+    print(F[0])
+    print(" ")
+    print(F[1])
+    print("\n")
+    if F[0] != 1.5 { return 1 }
+    if F[1] != 1.5 { return 2 }
+    print("F64_OK\n")
+    0
+}

--- a/tests/run-pass/global_array_f64_repeat_init.sio
+++ b/tests/run-pass/global_array_f64_repeat_init.sio
@@ -1,4 +1,5 @@
 //@ run-pass
+//@ requires: madaros
 // Madaros native-v2 must honour f64 global array-repeat initializers `[V; N]`.
 // Residual after #1305 (i64 only): f64 fill bits must land via rep stosq of IEEE bits.
 //@ expect-stdout: 1.500000 1.500000


### PR DESCRIPTION
## Summary

Wave7 Agent C — residual after #1305 (i64 array-repeat only).

**Bug (measured on `origin/main` under default Madaros):**

```sounio
var F: [f64; 2] = [1.5; 2]
// print(F[0]) → 4609434218613702656   (IEEE bits via print_int)
// OR (stale binary) → 0.000000

var A: [i64; 3] = [10, 20, 30]
// print → 0 0 0  (or first-value fill 10 10 10)
```

Scalars, local arrays, and i64 array-repeat (with #1305 source rebuilt) worked.

**Root cause**

1. **f64 array-repeat fill** was already recorded as IEEE bits after #1299, but `print(F[i])` classified global f64 index as int (`index_base_elem_is_float_ref` only checked locals, not the preseed global type table).
2. **Element-list** `[a,b,c]` was not recorded at parse time (repeat-only side table).
3. List words packed into BSS slot `instrs[]` were **dropped** when summary→module seed copied metadata without `instr_count`/`instrs`, so emit fell back to single-word `rep stos` of the first element.

**Fix**

- `parser/items.sio` + `ast.sio`: record element-list words (same name hash, source order); `ast_global_var_init_count` / `_nth` (no new large BSS tables — avoids the bootstrap crash documented in the design proposal).
- `ir/lower.sio`: pack multi-word inits into BSS `instrs[]`; preserve them through summary seed; route global f64 index print to `print_f64`.
- `codegen_x86_linux.sio`: sequential stores when `instr_count > 1`; keep `rep stosq` for array-repeat fill (i64 and f64 bits).
- Refresh `bin/madaros-linux-x86_64` from rebuilt modular Madaros.

## Measured before → after

| Case | Before | After |
|---|---|---|
| `var F: [f64;2]=[1.5;2]` print | bits or `0 0` | `1.500000 1.500000` rc=0 |
| `var A: [i64;3]=[10,20,30]` | `0 0 0` / `10 10 10` | `10 20 30` rc=0 |
| `var B: [f64;2]=[1.5,2.5]` | `0 0` | `1.500000 2.500000` rc=0 |
| `var CT: [i64;2]=[42;2]` | `42 42` (preserved) | `42 42` |
| `var G: i64 = 42` | `42` | `42` |

## Test plan

- [x] `bash scripts/dev/madaros_global_array_init_gate.sh` → `GLOBAL_ARRAY_INIT_GATE_OK`
- [x] `bash scripts/run_sio_test_suite.sh global_array --verbose` → 3/3 PASS
- [x] `bash scripts/run_sio_test_suite.sh global_scalar --verbose` → PASS
- [x] Installed `bin/madaros-linux-x86_64` reproduces without `MADAROS_RAW_BIN`

## Out of scope (honest)

- i8 packed element-lists smaller than qword (byte store path exists; not gate-covered)
- Full `-O` cleanup SEGV (#1070)
- Scalar global f64 `print(G)` SEGV residual (pre-existing; not this lane)