### PR TITLE
feat(stdlib): bigframe grouped expanding sum/mean/var/std (mean beats pandas 16x)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -79,6 +79,8 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | sample_n_by (1M rows, 1000 groups, n=10) | | ~732 | ~1193 | **0.61x — Sounio wins** | seeded hash-priority top-n; pandas groupby.sample is slow |
 | sample_n_by (1M rows, 1000 groups, n=100) | | ~1564 | ~1298 | **~1.2x — loss** | O(sz·n) bounded buffer at large n; quickselect-threshold would flatten |
 | cumsum_rev_by (1M rows, 1000 dense keys) | | ~69 | ~286 | **0.24x — Sounio wins (4.1x)** | dense reverse-pass suffix-sum vs pandas double-reverse+cumsum |
+| expanding_mean_by (1M rows, 1000 dense keys) | | ~31 | ~496 | **0.06x — Sounio wins (16x)** | dense Welford; pandas groupby.expanding().mean() very slow |
+| expanding_std_by (1M rows, 1000 dense keys) | | ~281 | ~521 | **0.54x — Sounio wins** | dense Welford + bf_sqrt (expanding sum ≡ cumsum_by) |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -15,7 +15,8 @@
 // grouped nlargest / nsmallest; grouped first / last / nth; grouped transform (broadcast);
 // grouped cumulative min / max; grouped rank; grouped ngroup / descending cumcount;
 // grouped pct_change; grouped diff; grouped shift; grouped ffill / bfill;
-// grouped winsorize (quantile-clip); grouped sample; grouped reverse cumsum.
+// grouped winsorize (quantile-clip); grouped sample; grouped reverse cumsum;
+// grouped expanding sum / mean / var / std.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -4529,4 +4530,79 @@ pub fn bf_cumsum_rev_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame 
         i = i - 1
     }
     out
+}
+
+/// Per-group EXPANDING mean/var/std engine shared by bf_expanding_*_by: a row-aligned
+/// expanding (cumulative) window WITHIN each group (like pandas
+/// df.groupby(key)[val].expanding().mean()/.var()/.std()): out[i] uses all rows of row
+/// i's group from its start up to and including i. mode 0 mean, 1 var (ddof=1), 2 std.
+/// A DENSE direct-index Welford recurrence over keys 0..1023 (no hashing -- the same fast
+/// dense-key contract as bf_groupby_sum; a row whose key is outside [0,1024) gets its own
+/// value). For var/std the first row of a group (count 1) yields 0 (pandas yields NaN
+/// there). O(n), one pass. Returns a 1-column BigFrame of length n. NATIVE + lean_single.
+fn bf_expanding_by(src: &BigFrame, key_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt:  [f64; 1024] = [0.0; 1024]
+    var mean: [f64; 1024] = [0.0; 1024]
+    var m2:   [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let sc = heap_alloc(8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i)
+        if k >= 0 && k < 1024 {
+            cnt[k] = cnt[k] + 1.0
+            let d = v - mean[k]
+            mean[k] = mean[k] + d / cnt[k]
+            m2[k] = m2[k] + d * (v - mean[k])
+            if mode == 0 { write_f64(op, i, mean[k]) }
+            else {
+                if cnt[k] > 1.0 {
+                    let va = m2[k] / (cnt[k] - 1.0)
+                    if mode == 1 { write_f64(op, i, va) } else { write_f64(op, i, bf_sqrt(va, sc)) }
+                } else { write_f64(op, i, 0.0) }
+            }
+        } else {
+            write_f64(op, i, v)
+        }
+        i = i + 1
+    }
+    heap_free(sc as *mut i8)
+    out
+}
+
+/// Per-group EXPANDING sum (pandas df.groupby(key)[val].expanding().sum()): out[i] = the
+/// sum of val over row i's group from its start to i. This is exactly the per-group
+/// cumulative sum, so it delegates to bf_cumsum_by (dense direct-index, O(n)). NATIVE +
+/// lean_single only.
+pub fn bf_expanding_sum_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_cumsum_by(src, key_col, val_col)
+}
+
+/// Per-group EXPANDING mean (pandas df.groupby(key)[val].expanding().mean()): each row
+/// gets the mean of its group's values so far. Dense direct-index (see bf_expanding_by).
+/// NATIVE + lean_single only.
+pub fn bf_expanding_mean_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_expanding_by(src, key_col, val_col, 0)
+}
+
+/// Per-group EXPANDING variance (sample, ddof=1; pandas .expanding().var()): each row gets
+/// the variance of its group's values so far (0 for a group's first row). Dense direct-
+/// index Welford (see bf_expanding_by). NATIVE + lean_single only.
+pub fn bf_expanding_var_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_expanding_by(src, key_col, val_col, 1)
+}
+
+/// Per-group EXPANDING standard deviation (sample, ddof=1; pandas .expanding().std()): each
+/// row gets the std of its group's values so far (0 for a group's first row). Dense direct-
+/// index Welford + bf_sqrt (see bf_expanding_by). NATIVE + lean_single only.
+pub fn bf_expanding_std_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    bf_expanding_by(src, key_col, val_col, 2)
 }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1141,6 +1141,30 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     var rcd: i64 = 0; var rcj: i64 = 0
     while rcj < 20 { if bf_get(&rc, rcj, 0) + bf_get(&fcs, rcj, 0) != 11.0 { rcd = rcd + 1 } rcj = rcj + 1 }
     if rcd != 0 { print("FAIL revcs_sum\n"); return 397 }
+    // GROUPED EXPANDING sum/mean/var/std. 2 groups (key=r%2), group members see consecutive
+    // integers (val = occurrence within group). expanding of 0,1,2,3,...: at occurrence 3
+    // (4 values 0,1,2,3) sum=6, mean=1.5, var(0,1,2,3)=1.6667, std=1.2910.
+    var exf = bf_new(2, 16)
+    var exi: i64 = 0
+    while exi < 40 { var exr:[f64;64]=[0.0;64]; exr[0]=(exi%2) as f64; exr[1]=(exi/2) as f64; bf_push_row(&!exf,&exr,2); exi=exi+1 }
+    let es = bf_expanding_sum_by(&exf, 0, 1)
+    let em = bf_expanding_mean_by(&exf, 0, 1)
+    let ev = bf_expanding_var_by(&exf, 0, 1)
+    let ed = bf_expanding_std_by(&exf, 0, 1)
+    if bf_nrows(&em) != 40 { print("FAIL exp_n\n"); return 398 }
+    // group 0 rows are even indices; occurrence 3 = row 6, values 0,1,2,3.
+    if bf_get(&es, 6, 0) != 6.0 { print("FAIL exp_sum\n"); return 399 }             // 0+1+2+3
+    if !approx_eq(bf_get(&em, 6, 0), 1.5) { print("FAIL exp_mean\n"); return 400 }   // mean 0..3
+    if !approx_eq(bf_get(&ev, 6, 0), 1.6666666667) { print("FAIL exp_var\n"); return 401 }  // var ddof1
+    if bf_get(&ed, 6, 0) < 1.29 || bf_get(&ed, 6, 0) > 1.292 { print("FAIL exp_std\n"); return 402 }  // ~1.2910
+    // first-in-group: mean = the value, var/std = 0.
+    if bf_get(&em, 0, 0) != 0.0 { print("FAIL exp_mean_first\n"); return 403 }
+    if bf_get(&ev, 0, 0) != 0.0 || bf_get(&ed, 0, 0) != 0.0 { print("FAIL exp_var_first\n"); return 404 }
+    // CROSS-CHECK: expanding_sum_by == cumsum_by (they are the same operation).
+    let ecs = bf_cumsum_by(&exf, 0, 1)
+    var exd: i64 = 0; var exj: i64 = 0
+    while exj < 40 { if bf_get(&es, exj, 0) != bf_get(&ecs, exj, 0) { exd = exd + 1 } exj = exj + 1 }
+    if exd != 0 { print("FAIL exp_sum_vs_cumsum\n"); return 405 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What

The per-group **expanding** family in `data::bigframe_ops`: `bf_expanding_sum_by`, `bf_expanding_mean_by`, `bf_expanding_var_by`, `bf_expanding_std_by` — a row-aligned expanding (cumulative) window within each group (pandas `df.groupby(key)[val].expanding().sum()/.mean()/.var()/.std()`): `out[i]` uses all rows of row i's group from its start up to and including i.

- `expanding_sum_by` == the per-group cumulative sum, so it delegates to `bf_cumsum_by`.
- mean/var/std share a **dense direct-index Welford** recurrence over keys 0..1023 (no hashing — same fast dense-key contract as `bf_groupby_sum`), one pass, numerically stable at every magnitude; var/std are ddof=1 and yield 0 for a group's first row (pandas yields NaN there).

## Run-proof (ops gate, `BIGFRAME_OPS_GATE_OK`)

- 2 groups each seeing 0,1,2,3,… → at the 4th value (0,1,2,3): sum=6, mean=1.5, var=1.6667, std≈1.2910; a group's first row gives mean=value, var=std=0;
- a cross-check that `expanding_sum_by` == `cumsum_by`;
- (offline) expanding mean/var/std matched pandas `groupby expanding` over 12k rows / 40 groups = **0 diffs**.

## Benchmark (1M rows, 1000 dense keys)

| op | Sounio ms | pandas ms | ratio |
|---|---|---|---|
| expanding_mean_by | ~31 | ~496 | **0.06× — Sounio wins (16×)** |
| expanding_std_by | ~281 | ~521 | **0.54× — Sounio wins** |

pandas' `groupby().expanding().mean()` materialises windows and is very slow.

## Scope
- stdlib only — **no compiler changes**. Heap ⇒ NATIVE + `lean_single` engine.
- Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)