### PR TITLE
fix(madaros): signed i8 BSS load + const-fold global element-list (wave8)

### DIFF
--- a/scripts/dev/madaros_global_array_init_gate.sh
+++ b/scripts/dev/madaros_global_array_init_gate.sh
@@ -90,4 +90,35 @@ fn main() -> i64 with IO {
 }
 ' '42'
 
+# 5) Wave8: packed i8 signed load (movsx) + u8 zero-extend (#1325 residual)
+run_case "i8_signed" '
+var NEG: [i8; 4] = [-1, -128, 127, 0]
+var UPOS: [u8; 2] = [255, 128]
+fn main() -> i64 with IO {
+  print_int(NEG[0] as i64); print(" "); print_int(NEG[1] as i64); print(" "); print_int(NEG[2] as i64); print("\n")
+  print_int(UPOS[0] as i64); print(" "); print_int(UPOS[1] as i64); print("\n")
+  if NEG[0] as i64 != 0 - 1 { return 1 }
+  if NEG[1] as i64 != 0 - 128 { return 2 }
+  if NEG[2] as i64 != 127 { return 3 }
+  if UPOS[0] as i64 != 255 { return 4 }
+  if UPOS[1] as i64 != 128 { return 5 }
+  0
+}
+' '-1 -128 127'
+
+# 6) Wave8: const-fold element-list (`0 - n`, bool, binary arith)
+run_case "constfold_list" '
+var A: [i64; 3] = [0 - 1, 0 - 2, 3]
+var B: [bool; 2] = [true, false]
+fn main() -> i64 with IO {
+  print_int(A[0]); print(" "); print_int(A[1]); print(" "); print_int(A[2]); print("\n")
+  if A[0] != 0 - 1 { return 1 }
+  if A[1] != 0 - 2 { return 2 }
+  if A[2] != 3 { return 3 }
+  if !B[0] { return 4 }
+  if B[1] { return 5 }
+  0
+}
+' '-1 -2 3'
+
 echo "GLOBAL_ARRAY_INIT_GATE_OK"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1298,6 +1298,25 @@ fn lower_array_literal_word_scalar_ref(e: &Expr, repeat_ident_scalar_kind: i64) 
     }
 }
 
+// BSS hyper_algebra_kind encoding for packed globals (physical size + signedness):
+//   1  = u8  — physical 1 byte, IndexGet label_id=3 (movzx)
+//   17 = i8  — physical 1 byte, IndexGet label_id=4 (movsx)
+//   8  = i64/f64/other — physical 8 bytes, IndexGet label_id=2
+// Init emit must use lower_bss_elem_physical_size so i8 is not treated as 17-byte stride.
+fn lower_bss_elem_physical_size(kind: i64) -> i64 {
+    if kind == 1 || kind == 17 {
+        1
+    } else if kind <= 0 {
+        8
+    } else {
+        kind
+    }
+}
+
+fn lower_bss_elem_is_signed_byte(kind: i64) -> bool {
+    kind == 17
+}
+
 fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Panic, Div {
     match *ty_opt {
         Some(ty) => {
@@ -1308,7 +1327,13 @@ fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Pani
                         let name = ir_path_first_name((*elem).path)
                         if name.len == 2 {
                             let first = name.buf[0] as i64
-                            if (first == 105 || first == 117) && (name.buf[1] as i64) == 56 {
+                            let second = name.buf[1] as i64
+                            // 'i' '8' → signed packed byte (movsx on load)
+                            if first == 105 && second == 56 {
+                                return 17
+                            }
+                            // 'u' '8' → unsigned packed byte (movzx on load)
+                            if first == 117 && second == 56 {
                                 return 1
                             }
                         }
@@ -7961,7 +7986,8 @@ impl Lowerer {
                         if target_base_is_string {
                             index_set_instr.label_id = 3
                         } else if target_global_elem_size > 0 {
-                            index_set_instr.label_id = if target_global_elem_size == 1 { 3 } else { 2 }
+                            // Byte store is size-only (i8 and u8 both write al).
+                            index_set_instr.label_id = if lower_bss_elem_physical_size(target_global_elem_size) == 1 { 3 } else { 2 }
                         } else if target_base_is_ref {
                             index_set_instr.label_id = 1
                         }
@@ -9827,14 +9853,22 @@ impl Lowerer {
         let dst = pair_d.1
         var instr = ir_index_get(dst, base, idx)
         // label_id routing for native-v2 codegen_x86_linux IrIndexGet:
-        //   3 = raw byte load  movzx rax, byte [base+idx]   (packed *u8 / BSS i8)
-        //   2 = raw word load  mov  rax, [base+idx*8]       (BSS non-byte)
-        //   1 = ref array      deref handle slot then *8
+        //   4 = raw signed byte load  movsx rax, byte [base+idx]  (BSS i8)
+        //   3 = raw byte load         movzx rax, byte [base+idx]  (packed *u8 / BSS u8)
+        //   2 = raw word load         mov  rax, [base+idx*8]      (BSS non-byte)
+        //   1 = ref array             deref handle slot then *8
         //   0 = local/param GC handle resolve then *8
+        // hyper_algebra_kind 17 = i8 (signed), 1 = u8 (unsigned); both physical size 1.
         if base_is_string {
             instr.label_id = 3
         } else if global_elem_size > 0 {
-            instr.label_id = if global_elem_size == 1 { 3 } else { 2 }
+            if lower_bss_elem_is_signed_byte(global_elem_size) {
+                instr.label_id = 4
+            } else if lower_bss_elem_physical_size(global_elem_size) == 1 {
+                instr.label_id = 3
+            } else {
+                instr.label_id = 2
+            }
         } else if base_is_ref {
             instr.label_id = 1
         }

--- a/self-hosted/native/codegen_x86_linux.sio
+++ b/self-hosted/native/codegen_x86_linux.sio
@@ -2070,6 +2070,16 @@ fn nc_emit_movzx_rax_byte_rdx_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
     nc_emit_byte(nc, 0x1a)
 }
 
+// MOVSX RAX, BYTE [RDX + RBX] — signed packed i8 BSS / raw-byte load
+// Encoding: REX.W 0F BE /r  with SIB [rdx+rbx] → 48 0f be 04 1a
+fn nc_emit_movsx_rax_byte_rdx_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
+    nc_emit_byte(nc, 0x48)
+    nc_emit_byte(nc, 0x0f)
+    nc_emit_byte(nc, 0xbe)
+    nc_emit_byte(nc, 0x04)
+    nc_emit_byte(nc, 0x1a)
+}
+
 fn nc_emit_store_al_mem_rdx_rbx(nc: &! NativeCompiler) with Mut, Panic, Div {
     nc_emit_byte(nc, 0x88)
     nc_emit_byte(nc, 0x04)
@@ -7215,7 +7225,15 @@ pub fn compile_ir_function_v2_core_ir_into(nc: &! NativeCompiler, func: &IrFunct
             }
         } else if instr_op == IrOpcode::IrIndexGet {
             let base_reg = (*func).instrs[i as usize].src1
-            if (*func).instrs[i as usize].label_id == 3 {
+            if (*func).instrs[i as usize].label_id == 4 {
+                // BSS i8: sign-extend packed byte (parity with local [i8;N] box path).
+                native_v2_core_emit_raw_signed_byte_array_load_into(
+                    nc,
+                    (*func).instrs[i as usize].dst,
+                    base_reg,
+                    (*func).instrs[i as usize].src2,
+                )
+            } else if (*func).instrs[i as usize].label_id == 3 {
                 native_v2_core_emit_raw_byte_array_load_into(
                     nc,
                     (*func).instrs[i as usize].dst,
@@ -8665,6 +8683,17 @@ pub fn native_v2_core_emit_raw_byte_array_load_into(nc: &! NativeCompiler, dst: 
     nc_core_store_rax_to_temp(nc, dst)
 }
 
+// Signed packed-byte load for BSS `[i8; N]` (label_id=4). Zero-extend would turn
+// -1 into 255 and break `i8 as i64` / signed compares vs local-array parity.
+pub fn native_v2_core_emit_raw_signed_byte_array_load_into(nc: &! NativeCompiler, dst: i64, base_reg: i64, idx_reg: i64) with Mut, Panic, Div {
+    nc_core_load_temp_to_rax(nc, base_reg)
+    nc_emit_mov_reg_reg(nc, 2, 0)
+    nc_core_load_temp_to_rax(nc, idx_reg)
+    nc_emit_mov_reg_reg(nc, 3, 0)
+    nc_emit_movsx_rax_byte_rdx_rbx(nc)
+    nc_core_store_rax_to_temp(nc, dst)
+}
+
 pub fn native_v2_core_emit_raw_byte_array_store_into(nc: &! NativeCompiler, base_reg: i64, idx_reg: i64, src: i64) with Mut, Panic, Div {
     nc_core_load_temp_to_rax(nc, base_reg)
     nc_emit_mov_reg_reg(nc, 2, 0)
@@ -9208,6 +9237,7 @@ fn emit_entry_trampoline_split_into(nc: &! NativeCompiler, main_fn_index: i64) w
 //   - scalar / 1-elem: single 8-byte store of prof_counter_id
 //   - array-repeat `[V; N]` (instr_count == 0, bss_size > elem): rep stosq/stosb
 // f64 values are stored as IEEE-754 bit patterns (same path as i64 words).
+// hyper_algebra_kind: 1=u8, 17=i8 (both physical size 1), 8=qword.
 fn emit_global_var_inits_into(nc: &! NativeCompiler, module: &IrModule) with Mut, Panic, Div {
     var fi: i64 = 0
     while fi < (*module).fn_count {
@@ -9218,6 +9248,10 @@ fn emit_global_var_inits_into(nc: &! NativeCompiler, module: &IrModule) with Mut
             let init_val = func.prof_counter_id
             let total = func.bss_size
             var elem = func.hyper_algebra_kind
+            // i8 uses kind 17 (signed); physical stride is still 1 byte.
+            if elem == 17 {
+                elem = 1
+            }
             if elem <= 0 {
                 elem = 8
             }

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -13,38 +13,120 @@ fn items_reverse_item_list_opt(items: Option<Box<ItemList>>) -> Option<Box<ItemL
     items_reverse_item_list_loop(items, None)
 }
 
-// Record a compile-time integer/float global initializer for native BSS fill.
-// Covers:
-//   - scalar `42` / `-42` / `1.5` / unary-neg floats
-//   - array-repeat `[V; N]`  → one fill word (i64 value or f64 bits)
-//   - element-list `[a, b, c]` → one word per element, same name hash, source order
-// Non-literal elements are silently skipped (BSS stays zero for those slots).
-fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
-    if (*init).kind == ExprKind::ExprIntLit {
-        ast_record_global_var_init(name, (*init).int_val)
-        return
+// Const-fold a global-init expression to one i64 word (int value or f64 bits).
+// Returns (ok, word). Covers the Sounio negative idiom `0 - n` (no unary-minus
+// in the style guide) so element-list packing does not silently drop slots and
+// collapse into a wrong array-repeat fill of the remaining literal.
+// Non-const expressions return ok=false (caller skips — residual for runtime inits).
+fn items_eval_global_init_word(e: &Expr) -> (bool, i64) with Div {
+    if (*e).kind == ExprKind::ExprIntLit {
+        return (true, (*e).int_val)
     }
-    if (*init).kind == ExprKind::ExprFloatLit {
-        // Module-level `let/var X: f64 = <lit>`: record the IEEE-754 bits so the
-        // BSS-global initializer emits the value. int_val is 0 for a float literal,
-        // so without this branch f64 globals silently read 0.
-        // Also covers f64 array-repeat fill: `[1.5; N]` recurses into this branch.
-        ast_record_global_var_init(name, f64_to_bits((*init).float_val))
-        return
+    if (*e).kind == ExprKind::ExprFloatLit {
+        return (true, f64_to_bits((*e).float_val))
     }
-    if (*init).kind == ExprKind::ExprUnary && (*init).un_op == UnaryOp::OpNeg {
-        match (*init).left {
+    if (*e).kind == ExprKind::ExprBoolTrue {
+        return (true, 1)
+    }
+    if (*e).kind == ExprKind::ExprBoolFalse {
+        return (true, 0)
+    }
+    if (*e).kind == ExprKind::ExprUnary && (*e).un_op == UnaryOp::OpNeg {
+        match (*e).left {
             Some(operand) => {
-                if (*operand).kind == ExprKind::ExprIntLit {
-                    ast_record_global_var_init(name, 0 - (*operand).int_val)
-                } else if (*operand).kind == ExprKind::ExprFloatLit {
-                    ast_record_global_var_init(name, f64_to_bits(0.0 - (*operand).float_val))
+                let pair = items_eval_global_init_word(&(*operand))
+                if pair.0 {
+                    // Integers: arithmetic negate. Floats: re-negate via bits
+                    // only when the operand was a float lit (bits path above).
+                    if (*operand).kind == ExprKind::ExprFloatLit {
+                        return (true, f64_to_bits(0.0 - (*operand).float_val))
+                    }
+                    return (true, 0 - pair.1)
                 }
             }
             _ => {}
         }
-        return
+        return (false, 0)
     }
+    if (*e).kind == ExprKind::ExprBinary {
+        match (*e).left {
+            Some(lhs) => {
+                match (*e).right {
+                    Some(rhs) => {
+                        let lp = items_eval_global_init_word(&(*lhs))
+                        let rp = items_eval_global_init_word(&(*rhs))
+                        if !lp.0 || !rp.0 {
+                            return (false, 0)
+                        }
+                        // Float binary: both sides float lits → fold bits.
+                        if (*lhs).kind == ExprKind::ExprFloatLit && (*rhs).kind == ExprKind::ExprFloatLit {
+                            let a = (*lhs).float_val
+                            let b = (*rhs).float_val
+                            if (*e).bin_op == BinaryOp::OpAdd {
+                                return (true, f64_to_bits(a + b))
+                            }
+                            if (*e).bin_op == BinaryOp::OpSub {
+                                return (true, f64_to_bits(a - b))
+                            }
+                            if (*e).bin_op == BinaryOp::OpMul {
+                                return (true, f64_to_bits(a * b))
+                            }
+                            if (*e).bin_op == BinaryOp::OpDiv {
+                                return (true, f64_to_bits(a / b))
+                            }
+                            return (false, 0)
+                        }
+                        // Integer / mixed-folded int words.
+                        let a = lp.1
+                        let b = rp.1
+                        if (*e).bin_op == BinaryOp::OpAdd {
+                            return (true, a + b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpSub {
+                            return (true, a - b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpMul {
+                            return (true, a * b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpDiv {
+                            if b == 0 {
+                                return (false, 0)
+                            }
+                            return (true, a / b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpRem {
+                            if b == 0 {
+                                return (false, 0)
+                            }
+                            return (true, a % b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpBitAnd {
+                            return (true, a & b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpBitOr {
+                            return (true, a | b)
+                        }
+                        if (*e).bin_op == BinaryOp::OpBitXor {
+                            return (true, a ^ b)
+                        }
+                        return (false, 0)
+                    }
+                    None => { return (false, 0) }
+                }
+            }
+            None => { return (false, 0) }
+        }
+    }
+    (false, 0)
+}
+
+// Record a compile-time integer/float/bool global initializer for native BSS fill.
+// Covers:
+//   - scalar `42` / `-42` / `0 - n` / `1.5` / unary-neg floats / true|false
+//   - array-repeat `[V; N]`  → one fill word (i64 value or f64 bits)
+//   - element-list `[a, b, c]` → one word per element, same name hash, source order
+// Non-const elements are silently skipped (BSS stays zero for those slots).
+fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
     if (*init).kind == ExprKind::ExprArrayLit {
         // Repeat form: left = fill value, right = count → single fill word
         match (*init).left {
@@ -52,7 +134,7 @@ fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
                 items_record_global_int_init(name, &(*repeat_val))
             }
             None => {
-                // Element-list form: [a, b, c] — record each literal in source order
+                // Element-list form: [a, b, c] — record each const word in source order
                 // (args is already reversed into source order by parse_array_literal).
                 var cur = (*init).args
                 while true {
@@ -66,6 +148,11 @@ fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
                 }
             }
         }
+        return
+    }
+    let pair = items_eval_global_init_word(init)
+    if pair.0 {
+        ast_record_global_var_init(name, pair.1)
     }
 }
 

--- a/tests/run-pass/global_array_element_list_constfold.sio
+++ b/tests/run-pass/global_array_element_list_constfold.sio
@@ -1,0 +1,54 @@
+// requires: madaros
+// Wave8 residual after #1325: element-list slots that are const binary
+// expressions (Sounio negative idiom `0 - n`, bool lits) must be recorded.
+// Pre-fix, non-IntLit slots were skipped and a partial list collapsed into
+// a wrong array-repeat fill of the remaining literal.
+
+var A: [i64; 3] = [0 - 1, 0 - 2, 3]
+var B: [i8; 3] = [0 - 1, 0 - 128, 127]
+var C: [bool; 3] = [true, false, true]
+var D: [i64; 3] = [1 + 2, 3 * 4, 10 - 3]
+
+fn main() -> i64 with IO {
+    print_int(A[0])
+    print(" ")
+    print_int(A[1])
+    print(" ")
+    print_int(A[2])
+    print("\n")
+    if A[0] != 0 - 1 { return 1 }
+    if A[1] != 0 - 2 { return 2 }
+    if A[2] != 3 { return 3 }
+
+    print_int(B[0] as i64)
+    print(" ")
+    print_int(B[1] as i64)
+    print(" ")
+    print_int(B[2] as i64)
+    print("\n")
+    if B[0] as i64 != 0 - 1 { return 4 }
+    if B[1] as i64 != 0 - 128 { return 5 }
+    if B[2] as i64 != 127 { return 6 }
+
+    if C[0] { print_int(1) } else { print_int(0) }
+    print(" ")
+    if C[1] { print_int(1) } else { print_int(0) }
+    print(" ")
+    if C[2] { print_int(1) } else { print_int(0) }
+    print("\n")
+    if !C[0] { return 7 }
+    if C[1] { return 8 }
+    if !C[2] { return 9 }
+
+    print_int(D[0])
+    print(" ")
+    print_int(D[1])
+    print(" ")
+    print_int(D[2])
+    print("\n")
+    if D[0] != 3 { return 10 }
+    if D[1] != 12 { return 11 }
+    if D[2] != 7 { return 12 }
+
+    0
+}

--- a/tests/run-pass/global_array_i8_signed_element_list.sio
+++ b/tests/run-pass/global_array_i8_signed_element_list.sio
@@ -1,0 +1,35 @@
+// requires: madaros
+// Wave8 residual after #1325: BSS [i8;N] element-list must sign-extend on load
+// (local [i8;N] boxes already keep full i64; packed global path used movzx).
+
+var NEG: [i8; 4] = [-1, -128, 127, 0]
+var UPOS: [u8; 3] = [255, 128, 1]
+
+fn main() -> i64 with IO {
+    // Signed i8 loads: match local-array parity
+    print_int(NEG[0] as i64)
+    print(" ")
+    print_int(NEG[1] as i64)
+    print(" ")
+    print_int(NEG[2] as i64)
+    print(" ")
+    print_int(NEG[3] as i64)
+    print("\n")
+    if NEG[0] as i64 != 0 - 1 { return 1 }
+    if NEG[1] as i64 != 0 - 128 { return 2 }
+    if NEG[2] as i64 != 127 { return 3 }
+    if NEG[3] as i64 != 0 { return 4 }
+
+    // u8 stays zero-extended
+    print_int(UPOS[0] as i64)
+    print(" ")
+    print_int(UPOS[1] as i64)
+    print(" ")
+    print_int(UPOS[2] as i64)
+    print("\n")
+    if UPOS[0] as i64 != 255 { return 5 }
+    if UPOS[1] as i64 != 128 { return 6 }
+    if UPOS[2] as i64 != 1 { return 7 }
+
+    0
+}


### PR DESCRIPTION
## Summary

Wave8 residual after #1325 (`fix/madaros-global-array-init-f64`): packed global element-lists still misbehaved for **signed i8** and for **const non-IntLit slots**.

Measured on `origin/main` (post-#1325 shipped Madaros):

| Case | Before | After |
|------|--------|-------|
| `var N: [i8;4] = [-1,-128,127,0]` then `N[0] as i64` | `255` (movzx) | `-1` (movsx) |
| `var A: [i64;3] = [0-1, 0-2, 3]` | `3 3 3` (partial skip → wrong rep-fill) | `-1 -2 3` |
| `var B: [bool;3] = [true,false,true]` | zeros / wrong | `1 0 1` |
| Positive i8 / u8 / i64 / f64 lists | still green | preserved |

### Root causes

1. **Signed i8 BSS IndexGet** — `hyper_algebra_kind` treated both `i8` and `u8` as size `1` → `label_id=3` → `movzx`. Local `[i8;N]` boxes already keep full i64, so global packed path silently lost sign.
2. **Const-fold gap** — parse-time recorder only accepted IntLit/FloatLit/unary-neg. Sounio’s preferred negative idiom is binary `0 - n`; those slots were skipped. Partial lists then collapsed into an array-repeat of the remaining literal.

### Fix

- **Parser** (`items.sio`): recursive `items_eval_global_init_word` for int/float/bool/unary/binary const words.
- **Lower** (`lower.sio`): `hyper_algebra_kind` `17=i8` (signed) / `1=u8` (unsigned); IndexGet `label_id=4` for movsx; physical-size helper so init emit still strides 1 byte.
- **Codegen** (`codegen_x86_linux.sio`): `nc_emit_movsx_rax_byte_rdx_rbx` + raw signed-byte load path; init emit normalizes kind 17 → size 1.
- **Gate + regressions**: extended `madaros_global_array_init_gate.sh`; two `requires:madaros` run-pass tests.
- Refreshes `bin/madaros-linux-x86_64` from rebuilt modular Madaros.

### Non-overlap (wave8)

Does **not** touch:
- `opt_cleanup` / `-O`
- IR merge byref densify
- global scalar f64 print

## Test plan

- [x] `bash scripts/dev/madaros_global_array_init_gate.sh` → `GLOBAL_ARRAY_INIT_GATE_OK`
- [x] `./bin/souc compile` + run `tests/run-pass/global_array_i8_signed_element_list.sio` → `-1 -128 127 0` / `255 128 1` rc=0
- [x] `./bin/souc compile` + run `tests/run-pass/global_array_element_list_constfold.sio` → `-1 -2 3` / `-1 -128 127` / `1 0 1` / `3 12 7` rc=0
- [x] Positive control `[i8;4]=[72,105,10,0]` still `72 105`
- [x] Rebuilt modular Madaros under private build lock; installed to `bin/madaros-linux-x86_64`