### PR TITLE
fix(madaros): scalar global f64/i64 print via type-table dispatch

### DIFF
--- a/scripts/dev/madaros_global_array_init_gate.sh
+++ b/scripts/dev/madaros_global_array_init_gate.sh
@@ -79,12 +79,36 @@ fn main() -> i64 with IO {
 }
 ' '10 20 30'
 
-# 4) scalar control
+# 4) scalar control (explicit print_int — always worked)
 run_case "scalar" '
 var G: i64 = 42
 fn main() -> i64 with IO {
   print_int(G)
   print("\n")
+  if G != 42 { return 1 }
+  0
+}
+' '42'
+
+# 5) scalar f64 print/println via auto-dispatch (#1325 residual)
+run_case "scalar_f64_print" '
+var G: f64 = 1.5
+fn main() -> i64 with IO {
+  print(G)
+  print("\n")
+  println(G)
+  if G != 1.5 { return 1 }
+  0
+}
+' '1.500000'
+
+# 6) scalar i64 print/println via auto-dispatch (same class as f64 char* SEGV)
+run_case "scalar_i64_print" '
+var G: i64 = 42
+fn main() -> i64 with IO {
+  print(G)
+  print("\n")
+  println(G)
   if G != 42 { return 1 }
   0
 }

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -133,6 +133,9 @@ fn empty_lower_loop_labels() -> LowerLoopLabels {
 
 let LOWER_GLOBAL_ELEM_F64: i64 = 2
 let LOWER_GLOBAL_SCALAR_F64: i64 = 3
+// Word-size integer scalar global (`var G: i64 = …`). Distinct from 0/unknown so
+// `print(G)` / `println(G)` can select print_int instead of the char* printer.
+let LOWER_GLOBAL_SCALAR_I64: i64 = 1
 
 pub struct LowerGlobalTypeTable {
     // Indexed by IrModule.functions slot. Keep this aligned with IR_MAX_FUNCS;
@@ -2866,6 +2869,9 @@ fn lower_global_elem_kind(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic
         Some(ty) => {
             if lower_type_expr_is_f64(&(*ty)) { return LOWER_GLOBAL_SCALAR_F64 }
             if lower_type_expr_is_array_of_f64(&(*ty)) { return LOWER_GLOBAL_ELEM_F64 }
+            // Scalar integers: needed so print/println of `var G: i64` routes to
+            // print_int (same SEGV class as untyped f64 → char*).
+            if lower_type_expr_is_integer(&(*ty)) { return LOWER_GLOBAL_SCALAR_I64 }
             0
         }
         _ => 0,
@@ -5675,6 +5681,35 @@ impl Lowerer {
         }
     }
 
+    // Scalar kind for a module-level BSS global identified by name.
+    // Returns 2 for `var G: f64`, 1 for word-size integer scalars, else 0.
+    // Locals already carry scalar_kind; this is the print/println dispatch
+    // fallback that #1325 did for array-element indexing only.
+    fn bss_global_scalar_kind(self, name: Name) -> i64 with Mut, Panic, Div, Alloc {
+        let fn_id = lowerer_lookup_fn_id_by_name_ref(&self, name)
+        if fn_id < 0 {
+            return 0
+        }
+        if fn_id >= self.module.fn_count {
+            return 0
+        }
+        if self.module.functions[fn_id as usize].compile_strategy != IR_STRATEGY_BSS_GLOBAL {
+            return 0
+        }
+        // Aggregate bases (arrays/structs) are not print scalars.
+        if self.module.functions[fn_id as usize].bss_size > 8 {
+            return 0
+        }
+        let gkind = lower_global_type_table_lookup(&(*self.global_types), fn_id)
+        if gkind == LOWER_GLOBAL_SCALAR_F64 {
+            return 2
+        }
+        if gkind == LOWER_GLOBAL_SCALAR_I64 {
+            return 1
+        }
+        0
+    }
+
     fn index_base_elem_is_float_ref(self, base_opt: &Option<Box<Expr>>) -> bool with Mut, Panic, Div, Alloc {
         match *base_opt {
             Some(base_expr) => {
@@ -5775,7 +5810,13 @@ impl Lowerer {
             return true
         }
         if (*e).kind == ExprKind::ExprIdent {
-            return self.lookup_local_scalar_kind((*e).name) == 2
+            if self.lookup_local_scalar_kind((*e).name) == 2 {
+                return true
+            }
+            // Module-level `var G: f64` is a BSS slot, not a local with scalar_kind=2.
+            // Without this fallback, `print(G)` stays on the char* printer and SEGVs
+            // (array path already falls back via index_base_elem_is_float_ref).
+            return self.bss_global_scalar_kind((*e).name) == 2
         }
         if (*e).kind == ExprKind::ExprCast {
             return lower_cast_type_is_f64(&(*e).cast_type)
@@ -5879,7 +5920,12 @@ impl Lowerer {
             return 3
         }
         if (*e).kind == ExprKind::ExprIdent {
-            return self.lookup_local_scalar_kind((*e).name)
+            let local_sk = self.lookup_local_scalar_kind((*e).name)
+            if local_sk != 0 {
+                return local_sk
+            }
+            // BSS scalar global fallback: see bss_global_scalar_kind.
+            return self.bss_global_scalar_kind((*e).name)
         }
         if (*e).kind == ExprKind::ExprCast {
             if lower_cast_type_is_f64(&(*e).cast_type) { return 2 }
@@ -10562,7 +10608,7 @@ impl Lowerer {
                     let lo = pair.0
                     let reg = pair.1
                     let lo2 = lo.emit(ir_load_global(reg, bss_off, e.name))
-                    if self.lookup_local_scalar_kind(e.name) == 2 {
+                    if self.lookup_local_scalar_kind(e.name) == 2 || self.bss_global_scalar_kind(e.name) == 2 {
                         return (lo2.emit(ir_mark_float_reg(reg)), reg)
                     }
                     return (lo2, reg)

--- a/tests/run-pass/global_scalar_f64_print.sio
+++ b/tests/run-pass/global_scalar_f64_print.sio
@@ -1,0 +1,23 @@
+//@ run-pass
+// Scalar global f64 must print via print_f64 under Madaros (not char* → SEGV).
+// Residual after #1325 (array index path only).
+//@ requires: madaros
+//@ expect-stdout: 1.500000
+//@ expect-stdout: 42
+//@ expect-stdout: SCALAR_F64_PRINT_OK
+
+var G: f64 = 1.5
+var N: i64 = 42
+
+fn main() -> i64 with IO {
+    print(G)
+    print("\n")
+    println(G)
+    print(N)
+    print("\n")
+    println(N)
+    if G != 1.5 { return 1 }
+    if N != 42 { return 2 }
+    print("SCALAR_F64_PRINT_OK\n")
+    0
+}


### PR DESCRIPTION
## Summary

Wave8 Agent C — residual after #1325 (global f64 array-repeat + element-list).

**Bug (measured on `origin/main` under default Madaros):**

```sounio
var G: f64 = 1.5
fn main() with IO {
    print(G)     // SEGV rc=139
    println(G)   // SEGV rc=139
}
// Arithmetic already worked: G + 0.5 → 2.000000
// Array path already worked after #1325: print(F[0]) → 1.500000
// Explicit print_int(G) for i64 also worked
```

Same SEGV class for `var N: i64 = 42; print(N)` (char* printer on integer bits).

**Root cause**

`println_dispatch_name` / `expr_result_scalar_kind_ref` classify `ExprIdent` via local `scalar_kind` only. Module-level BSS globals are **not** bound as locals with scalar_kind set. #1325 already:

1. recorded `LOWER_GLOBAL_SCALAR_F64` in the preseed type table
2. used it for load-time `ir_mark_float_reg`
3. fixed **array** index print via `index_base_elem_is_float_ref` global-table fallback

…but left scalar `print(G)` on the default char* `print` builtin → SEGV.

**Fix**

- `lower_global_elem_kind`: also record word-size integer scalars as `LOWER_GLOBAL_SCALAR_I64`
- `bss_global_scalar_kind`: BSS slot + type table → print kind 2 (f64) / 1 (int)
- `expr_result_is_float_ref` / `expr_result_scalar_kind_ref`: Ident falls back to that helper
- rebuild `bin/madaros-linux-x86_64` from modular Madaros

No codegen change required — emit paths for `print_f64` / `print_int` already correct once dispatch selects them.

## Measured before → after

| Case | Before | After |
|---|---|---|
| `var G: f64 = 1.5; print(G)` | SEGV 139 | `1.500000` rc=0 |
| `println(G)` (f64) | SEGV 139 | `1.500000` rc=0 |
| `var N: i64 = 42; print(N)` | SEGV 139 | `42` rc=0 |
| `G + 0.5` | `2.000000` | `2.000000` (preserved) |
| `var F: [f64;2]=[1.5;2]` print | `1.500000 1.500000` | preserved |
| element-list arrays | green (#1325) | preserved |

## Test plan

- [x] `bash scripts/dev/madaros_global_array_init_gate.sh` → `GLOBAL_ARRAY_INIT_GATE_OK` (includes new scalar_f64_print + scalar_i64_print)
- [x] `SOUNIO_MADAROS_AVAILABLE=1 bash scripts/run_sio_test_suite.sh global_scalar --verbose` → 2/2 PASS
- [x] `SOUNIO_MADAROS_AVAILABLE=1 bash scripts/run_sio_test_suite.sh global_array --verbose` → 3/3 PASS
- [x] Installed `bin/madaros-linux-x86_64` reproduces without `MADAROS_RAW_BIN`

## Out of scope (honest)

- Full `-O` cleanup SEGV (#1070)
- i8 packed element-lists smaller than qword (still not gate-covered; separate residual lane if open)