### PR TITLE
test(madaros): close Epistemic method-form residual (free/method parity gate)

### DIFF
--- a/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json
+++ b/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json
@@ -3,16 +3,16 @@
   "status": "pass",
   "engine": "madaros_default",
   "lean_single_pin": false,
-  "commit": "afc04ef51c034b25e415b95e7db6ae1d44c7081e",
+  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
   "claims": [
     "epistemic_methods_under_madaros_multimodule",
     "measured_val_std_add_is_credible_drive_decision",
     "type_a_u95_t4_band_adjust",
     "renal_refuse_same_mg_per_kg",
-    "compile_fail_confidence_witnesses_present"
+    "compile_fail_confidence_witnesses_present",
+    "dual_gum_and_knowledge_import_under_madaros"
   ],
   "claims_not_made": [
-    "dual_gum_and_knowledge_import_under_madaros",
     "bedside_dosing_product",
     "nonmem_foce",
     "language_knowledge_t_generic",

--- a/artifacts/compiler/madaros_dual_import_receipt.v1.json
+++ b/artifacts/compiler/madaros_dual_import_receipt.v1.json
@@ -2,8 +2,8 @@
   "schema": "madaros_dual_import_receipt.v1",
   "status": "pass",
   "engine": "madaros_default",
-  "commit": "4935931d7f245d23fc8d52e1636c239b0f7c86c1",
-  "raw_elf": "/workspace/.home/openvscode-server/.agents/grok-cli1/.grok/worktrees/workspace-sounio/subagent-019f7d20-c98b-7a00-93a2-003cfc28c7f4/artifacts/self-hosted/madaros",
+  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
+  "raw_elf": "/workspace/.home/openvscode-server/.agents/grok-cli1/.grok/worktrees/workspace-sounio/subagent-019f81ff-771f-77b2-a834-a7236faa7ce3/bin/madaros-linux-x86_64",
   "native_run": 1,
   "claims": [
     "dual_gum_knowledge_check_ok",

--- a/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json
+++ b/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json
@@ -1,0 +1,20 @@
+{
+  "schema": "madaros_knowledge_method_residual_receipt.v1",
+  "status": "pass",
+  "engine": "madaros_default",
+  "lean_single_pin": false,
+  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
+  "verdict": "FIXED_ALREADY",
+  "claims": [
+    "epistemic_method_form_multimodule_import",
+    "epistemic_measured_val_add_mul_std_method_path",
+    "free_vs_method_numeric_parity",
+    "legacy_method_witness_now_required_green"
+  ],
+  "claims_not_made": [
+    "language_knowledge_t_generic_import",
+    "gum_k95_f64_i64_cast_fixed",
+    "full_root2_census_closed",
+    "enum_ctor_path"
+  ]
+}

--- a/artifacts/compiler/madaros_root2_method_receipt.v1.json
+++ b/artifacts/compiler/madaros_root2_method_receipt.v1.json
@@ -2,16 +2,17 @@
   "schema": "madaros_root2_method_receipt.v1",
   "status": "pass",
   "engine": "madaros_default",
-  "commit": "77ad9ff750e1221b8b6e8568aa4a2e679f64b038",
+  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
   "claims": [
     "same_module_self_ref_method_call",
     "same_module_associated_type_method",
     "same_module_method_on_method_return",
-    "multimodule_associated_type_method_import"
+    "multimodule_associated_type_method_import",
+    "multimodule_instance_method_call",
+    "epistemic_method_form_multimodule"
   ],
   "claims_not_made": [
-    "multimodule_instance_method_call",
-    "full_root2_null_deref_closed",
+    "full_root2_census_closed",
     "enum_ctor_path"
   ]
 }

--- a/artifacts/compiler/madaros_root2_multimodule_method_receipt.v1.json
+++ b/artifacts/compiler/madaros_root2_multimodule_method_receipt.v1.json
@@ -2,7 +2,7 @@
   "schema": "madaros_root2_multimodule_method_receipt.v1",
   "status": "pass",
   "engine": "madaros_default",
-  "commit": "7d9443c54271175facc046b3ec1b1061ca2954b6",
+  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
   "claims": [
     "multimodule_instance_method_call",
     "multimodule_method_f64_print",

--- a/artifacts/epistemic/knowledge_madaros_e2e_receipt.v1.json
+++ b/artifacts/epistemic/knowledge_madaros_e2e_receipt.v1.json
@@ -3,18 +3,19 @@
   "status": "pass",
   "engine": "madaros_default",
   "lean_single_pin": false,
-  "commit": "55e3102c33bb63bf06cc9acf7b594099bfb5046f",
-  "d3_scope": "free_function_epistemic_api",
+  "commit": "45ad6e084426461b942d3fa0fbae2819e60d7668",
+  "d3_scope": "free_and_method_epistemic_api",
   "claims": [
     "madaros_multimodule_import_epistemic_knowledge_free_api",
+    "madaros_multimodule_import_epistemic_knowledge_method_api",
     "ep_measured_add_mul_merge_gate_numeric",
+    "free_vs_method_numeric_parity",
     "knowledge_sio_selftest_all_pass_under_madaros"
   ],
   "claims_not_made": [
-    "method_call_form_epistemic_measured_under_madaros",
     "language_knowledge_t_generic_import",
-    "full_root2_method_lowering_fix",
-    "propagate_import_without_further_work",
+    "full_root2_census_closed",
+    "gum_k95_f64_i64_cast_fixed",
     "numpy_sklearn"
   ]
 }

--- a/docs/audit/EPISTEMIC_KNOWLEDGE_MADAROS_D3_2026-07-19.md
+++ b/docs/audit/EPISTEMIC_KNOWLEDGE_MADAROS_D3_2026-07-19.md
@@ -11,9 +11,10 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.epistemi
 
 ## Claim
 
-> The flagship **`Epistemic` free-function API** imports and runs correctly under
-> **default Madaros multi-module** (no lean_single pin). Method-call form remains
-> blocked by Madaros Root 2.
+> The flagship **`Epistemic` free-function API** and **method form**
+> (`Epistemic::measured` / `e.val()` / `e.add`) import and run correctly under
+> **default Madaros multi-module** (no lean_single pin). Method residual closed
+> (Wave9; Root 2 multi-module methods + free/method parity gate).
 
 ## Root cause (re-diagnosed)
 
@@ -21,12 +22,13 @@ source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.audit.epistemi
 |---|---|
 | Tiny free-function module import | OK |
 | `impl Epistemic { … }` methods **defined, never called** | OK |
-| Any **method call site** (`Epistemic::measured`, `e.val()`) | **SEGV** in `lower_array: seed_begin` |
-| `ulimit -s unlimited` | does **not** help (Root 2, not Root 1 stack) |
+| Any **method call site** (`Epistemic::measured`, `e.val()`) | historically **SEGV** in `lower_array: seed_begin`; **now green** |
 | Free-function call sites (`ep_measured`, `ep_val`) | OK under multi-module |
+| Free vs method numeric parity | OK under multi-module |
 
-This is **not** “module has use deps” (knowledge is self-contained). It is Madaros
-**method-call lowering** (Root 2 in `MADAROS_SRET_ROOT_SYNTHESIS_2026-06-20`).
+Historical cause was Madaros **method-call lowering** (Root 2 in
+`MADAROS_SRET_ROOT_SYNTHESIS_2026-06-20`), closed by multi-module method
+preseed + related Root 2 work (`MADAROS_ROOT2_MULTIMODULE_METHOD_2026-07-19`).
 
 Name clash: do **not** export a free function named `measure` — collides with the
 language `Knowledge<T>` builtin (`found &Knowledge<f64>`).
@@ -39,8 +41,8 @@ language `Knowledge<T>` builtin (`found &Knowledge<f64>`).
 `ep_std`, `ep_add`/`sub`/`mul`/`div`, `ep_scale`/`shift`/`square`/`sqrt_ep`,
 `ep_gate`, `ep_merge`, …
 
-Thin `impl Epistemic` wrappers remain for lean_single / source-compat (definitions
-only; call sites under Madaros still SEGV).
+Thin `impl Epistemic` wrappers call the free functions; method call sites under
+Madaros multi-module are **TRUSTWORTHY** (Wave9 residual closeout).
 
 Selftests use **free functions only**; avoid `print(i64)` under Madaros.
 
@@ -51,17 +53,22 @@ bash scripts/epistemic_knowledge_madaros_e2e_gate.sh
 # → EPISTEMIC_KNOWLEDGE_MADAROS_E2E_GATE_OK
 
 bash scripts/epistemic_trust_gate.sh
-# Section A includes knowledge free API
+# Section A includes knowledge free + method API
+
+bash scripts/madaros_knowledge_method_residual_gate.sh
+# → MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK
 ```
 
-### 3. Residual
+### 3. Residual (closed / remaining)
 
 | Path | Status |
 |---|---|
 | Free-function import | **TRUSTWORTHY** under Madaros |
-| Method-call import | **blocked** (Root 2) — `witness_import_knowledge_method` |
-| `order_spread_exact` / `propagate` | still blocked (depend on further work) |
+| Method-call import | **TRUSTWORTHY** under Madaros (Wave9 closeout) |
+| Free vs method parity | **TRUSTWORTHY** — `knowledge_method_parity.sio` |
+| `order_spread` / `propagate` free leaves | **TRUSTWORTHY** (later promotions) |
 | Language `Knowledge<T>` / `measure` | separate from stdlib `Epistemic` |
+| gum k95 f64→i64 cast | still corrupted under native import (trust map §B) |
 
 ## Measured (Madaros v0.80.0)
 
@@ -74,13 +81,12 @@ KNOWLEDGE_MADAROS_IMPORT_E2E_OK
 
 ## claims_not_made
 
-- Method-call form under Madaros  
-- Full Root 2 compiler fix  
-- `propagate` / `order_spread_exact` native import  
 - Language generic `Knowledge<T>`  
+- Full Root 2 census closed (enum ctor paths, etc.)  
+- gum k95 f64→i64 cast fixed  
 - Bedside / numpy  
 
 ## Priority next (compiler)
 
-Root 2 method-call null-deref in `self-hosted/ir/lower.sio` (and related).
-Then re-enable method form and promote `propagate`.
+Other Madaros native-import defects (D1 gum k95 cast, residual census items).
+Method form residual is closed — keep `madaros_knowledge_method_residual_gate.sh` green.

--- a/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
+++ b/docs/audit/EPISTEMIC_TRUST_MAP_2026-07-14.md
@@ -47,17 +47,19 @@ A result is usable under native import iff **both** hold:
 | `correlation` | `covariance` of independents = 0 | self-contained; this is the **analytic** (shared-source) covariance, exact 0 for no shared variable — not a finite-sample estimator, so the exact-zero check is appropriate |
 | `knightian` (p-box) | `pb_gap`, `pb_midpoint` | self-contained |
 | `covariance` | `cov_new` and accessors | self-contained |
-| `knowledge` (**free-function** `ep_*` API) | `ep_measured` / `ep_add` / `ep_mul` / `ep_merge` / `ep_gate` | **D3 partial 2026-07-19** — free-function surface imports under Madaros; see `EPISTEMIC_KNOWLEDGE_MADAROS_D3_2026-07-19` |
-| `order_spread_exact` (`order_spread4`) | CPC N=4 exact spread ≈ `2.044226` (scaled µ-units `2044225`/`2044226`) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `OsOct` (no `algebra::` use). Gate: `scripts/madaros_order_spread_native_gate.sh` + Section A `ORDER_SPREAD_TRUST_OK`. `product4_exact` remains available (pulls free-function `knowledge`); method-form `Epistemic::measured` still Root-2. |
+| `knowledge` (**free-function** `ep_*` API) | `ep_measured` / `ep_add` / `ep_mul` / `ep_merge` / `ep_gate` | **D3 2026-07-19** — free-function surface imports under Madaros; see `EPISTEMIC_KNOWLEDGE_MADAROS_D3_2026-07-19` |
+| `knowledge` (**method** form) | `Epistemic::measured` / `e.val()` / `e.add` / `e.mul` / `e.std` | **Wave9 residual closeout** — free vs method parity under multi-module Madaros. Gate: `scripts/madaros_knowledge_method_residual_gate.sh` + Section A `KNOWLEDGE_METHOD_PARITY_OK` / `KNOWLEDGE_METHOD_OK` |
+| `order_spread_exact` (`order_spread4`) | CPC N=4 exact spread ≈ `2.044226` (scaled µ-units `2044225`/`2044226`) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `OsOct` (no `algebra::` use). Gate: `scripts/madaros_order_spread_native_gate.sh` + Section A `ORDER_SPREAD_TRUST_OK`. `product4_exact` remains available (pulls free-function `knowledge`); method-form `Epistemic::measured` is also green (Wave9). |
 | `product_nonassoc` (structural variance) | Fano variance `0.25` / non-Fano `4.25` (κ=1, base σ²=0.25) | **stdlib leaf 2026-07-20** — algebra inlined via field-wise `PnOct` (no `algebra::` use). Gate: `scripts/madaros_product_nonassoc_native_gate.sh` + Section A `PRODUCT_NONASSOC_TRUST_OK`. Knowledge-free `product_nonassoc_augment` is the hard numeric witness; `product_nonassoc(Epistemic,…)` uses field-form `Epistemic` under Madaros (direct `ep_*` + leaf multi-import trips E035). Historic `epistemic::propagate::product_nonassoc` removed. |
 | `propagate` (delta-method + MC) | product `6`/`0.25`; `exp_delta(1,σ²=0.01)` → `e` / `e²·0.01`; MC identity mean≈`1` var≈`0.01`; MC square E[X²]≈`4.01` var≈`0.16` | **2026-07-20 multi-module green** for free-function `Epistemic` + `exp_delta`/`product`/`ln`/`sin`/`cos_delta` and value-style LCG MC kernels (`monte_carlo_identity`, `monte_carlo_square`). Gate: `scripts/madaros_propagate_native_gate.sh` + Section A `PROPAGATE_TRUST_OK`. Caveats (pre-Wave6-C): literal `exp`/`cos` SEGV — **fixed** (empty-stub builtins only); remaining: exclusive-ref xoshiro inside imported bodies untrustworthy (MC uses Knuth LCG+CLT); generic `monte_carlo(x,f,n)` fn-ptr still fragile. |
 | `algebra::associator_field` | non-Fano ‖α‖²=`4`, g2=`2`, aug var=`4.25`; pentagon (e1,e2,e4,e1) var=`0.96` | **2026-07-20 multi-module green** after #1274 oct_mul lo/hi split + pub API surface (`assoc_field_*`, `pentagon_*`, `af_*`). Gate: `scripts/madaros_associator_field_native_gate.sh`. L0: `associator_field_octonion` + `associator_field_pentagon`. |
 | `algebra::octonion` (`oct_mul`, `oct_associator`, …) | e1·e2→e3; non-Fano ‖[e1,e2,e4]‖²=`4` | **2026-07-20** lo/hi frame split. Gate: `scripts/madaros_algebra_octonion_import_gate.sh`. |
 
 Heuristic: **self-contained modules (no stdlib `use` deps) that avoid `f64→i64`
-casts and method-call sites import cleanly and return correct numbers.**
-(`order_spread_exact` / `product_nonassoc` remain self-contained leaves for CPC
-independence; `algebra::associator_field` is now also importable under default
+casts import cleanly and return correct numbers.** Method-call form on
+`Epistemic` is now TRUSTWORTHY under multi-module Madaros (Wave9 residual
+closeout). (`order_spread_exact` / `product_nonassoc` remain self-contained leaves
+for CPC independence; `algebra::associator_field` is also importable under default
 Madaros for programs that want the shared seven-window artifact.)
 
 **Update 2026-07-20 (oct_mul):** `algebra::octonion::oct_mul` imports cleanly under
@@ -84,26 +86,25 @@ makes `use algebra::associator_field` compile+run with correct sentinels.
 
 | Module / form | Failure | Consequence |
 |---|---|---|
-| `knowledge` **method-call** form (`Epistemic::measured`, `e.val()`) | SEGV in method-call lowering (Root 2) | use free `ep_*` API under Madaros; methods still OK under lean_single |
 | `propagate` **export names** `exp` / `cos` (call site) | **FIXED Wave6 C** — empty-stub builtins only (`instr_count==0`); user-bodied `exp`/`cos` keep IR | call `exp`/`cos` freely under multi-module Madaros; `exp_delta`/`cos_delta` remain aliases |
 | `propagate::monte_carlo` (generic fn-ptr form) | fragile / NaN under multi-module when combined with exclusive-ref RNG | use `monte_carlo_identity` / `monte_carlo_square` (value-style LCG) |
 | `uncertain_eq` | method / multi-module path | equality-under-uncertainty native-import-blocked |
 
-Method-form and remaining modules are usable today only by **free-function rewrite**,
-**inlining into `main()`**, or via the **lean_single** engine.
+Stdlib `Epistemic` method form is TRUSTWORTHY under multi-module Madaros (Wave9).
+Language generic `Knowledge<T>` method form is a separate surface — do not
+conflate with `epistemic::knowledge::Epistemic`. Remaining fragile modules still
+need free-function rewrite, inlining into `main()`, or lean_single.
 
 ## Blast radius
 
-The remaining corruption/blockage is not peripheral. Method-form `Knowledge<T>`
-still SEGV's (Root 2); `gum`'s coverage intervals are **silently wrong** for finite
-samples; literal `exp`/`cos` import names and exclusive-ref xoshiro inside module
-bodies remain traps. What works under native import today is the free-function
-numeric core: GUM point+`u_c`, correlation/covariance, p-box dispersion,
-`order_spread4`, `product_nonassoc`, and **`propagate` delta-method + value-style
-MC kernels** (`exp_delta`, `product`, `monte_carlo_identity` / `_square`). A real
-PBPK/GUM pipeline can import free-function `knowledge` + `propagate` under
-default Madaros when it uses those surfaces — method-form APIs and `gum` U95 still
-need lean_single or workarounds.
+The remaining corruption/blockage is not peripheral. `gum`'s coverage intervals
+are **silently wrong** for finite samples (f64→i64 cast); exclusive-ref xoshiro
+inside module bodies remain traps. What works under native import today includes
+the free-function **and method-form** `Epistemic` numeric core, GUM point+`u_c`,
+correlation/covariance, p-box dispersion, `order_spread4`, `product_nonassoc`,
+and **`propagate` delta-method + value-style MC kernels**. A real PBPK/GUM
+pipeline can import `knowledge` + `propagate` under default Madaros when it uses
+those surfaces — `gum` U95 still needs a cast fix or lean_single/workaround.
 
 Every failure here reduces to one of three already-filed compiler dispatches:
 

--- a/scripts/epistemic_knowledge_madaros_e2e_gate.sh
+++ b/scripts/epistemic_knowledge_madaros_e2e_gate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # scripts/epistemic_knowledge_madaros_e2e_gate.sh
 #
-# D3 partial: free-function Epistemic API imports under default Madaros.
-# Does NOT pin lean_single. Method-call form remains blocked (Root 2).
+# D3 + Wave9 residual closeout: free-function AND method-form Epistemic API
+# under default Madaros multi-module. Does NOT pin lean_single.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
@@ -56,12 +56,30 @@ else
   fi
 fi
 
-# --- Residual method-call trip-wire (expected fail under Madaros) ---
-echo "== method-call residual (expect fail) =="
-if "$SOUC" compile tests/epistemic_trust/witness_import_knowledge_method.sio -o "$OUT/meth.elf" >"$OUT/methc.log" 2>&1; then
-  echo "NOTE: method-call form compiled — Root 2 may be FIXED; update trust map"
+# --- Method-call form (Wave9 residual closeout: required green) ---
+echo "== method-call form (required) =="
+if ! "$SOUC" compile tests/epistemic_trust/witness_import_knowledge_method.sio -o "$OUT/meth.elf" >"$OUT/methc.log" 2>&1; then
+  echo "FAIL: method-call form compile"; tail -20 "$OUT/methc.log" || true; fail=1
 else
-  echo "OK method-call form still blocked under Madaros (Root 2 residual)"
+  chmod +x "$OUT/meth.elf"
+  if ! "$OUT/meth.elf" >"$OUT/meth.log" 2>&1 || ! grep -q "KNOWLEDGE_METHOD_OK" "$OUT/meth.log"; then
+    echo "FAIL: method-call form run"; cat "$OUT/meth.log" || true; fail=1
+  else
+    echo "PASS: KNOWLEDGE_METHOD_OK"
+  fi
+fi
+
+# Free vs method parity
+echo "== free vs method parity =="
+if ! "$SOUC" compile tests/epistemic_trust/knowledge_method_parity.sio -o "$OUT/par.elf" >"$OUT/parc.log" 2>&1; then
+  echo "FAIL: method parity compile"; tail -20 "$OUT/parc.log" || true; fail=1
+else
+  chmod +x "$OUT/par.elf"
+  if ! "$OUT/par.elf" >"$OUT/par.log" 2>&1 || ! grep -q "KNOWLEDGE_METHOD_PARITY_OK" "$OUT/par.log"; then
+    echo "FAIL: method parity run"; cat "$OUT/par.log" || true; fail=1
+  else
+    echo "PASS: KNOWLEDGE_METHOD_PARITY_OK"
+  fi
 fi
 
 mkdir -p "$ROOT/artifacts/epistemic"
@@ -76,17 +94,18 @@ cat >"$ROOT/artifacts/epistemic/knowledge_madaros_e2e_receipt.v1.json" <<EOF
   "engine": "madaros_default",
   "lean_single_pin": false,
   "commit": "$COMMIT",
-  "d3_scope": "free_function_epistemic_api",
+  "d3_scope": "free_and_method_epistemic_api",
   "claims": [
     "madaros_multimodule_import_epistemic_knowledge_free_api",
+    "madaros_multimodule_import_epistemic_knowledge_method_api",
     "ep_measured_add_mul_merge_gate_numeric",
+    "free_vs_method_numeric_parity",
     "knowledge_sio_selftest_all_pass_under_madaros"
   ],
   "claims_not_made": [
-    "method_call_form_epistemic_measured_under_madaros",
     "language_knowledge_t_generic_import",
-    "full_root2_method_lowering_fix",
-    "propagate_import_without_further_work",
+    "full_root2_census_closed",
+    "gum_k95_f64_i64_cast_fixed",
     "numpy_sklearn"
   ]
 }

--- a/scripts/epistemic_trust_gate.sh
+++ b/scripts/epistemic_trust_gate.sh
@@ -28,6 +28,9 @@ runproof "gum: value + u_c"          tests/epistemic_trust/gum_trust.sio        
 runproof "correlation: covariance"   tests/epistemic_trust/correlation_trust.sio CORRELATION_TRUST_OK
 runproof "knightian: p-box"          tests/epistemic_trust/knightian_trust.sio   KNIGHTIAN_TRUST_OK
 runproof "knowledge: free Epistemic" tests/epistemic_trust/knowledge_trust.sio   KNOWLEDGE_TRUST_OK
+# Method form + free/method parity (Wave9 residual closeout — was Root-2 blocked).
+runproof "knowledge: method Epistemic" tests/epistemic_trust/knowledge_method_parity.sio KNOWLEDGE_METHOD_PARITY_OK
+runproof "knowledge: method witness" tests/epistemic_trust/witness_import_knowledge_method.sio KNOWLEDGE_METHOD_OK
 # CPC N=4 exact-spread leaf (2026-07-20): self-contained OsOct path; no algebra:: use.
 runproof "order_spread4: CPC N=4"    tests/epistemic_trust/order_spread_trust.sio ORDER_SPREAD_TRUST_OK
 # Structural nonassoc variance leaf (2026-07-20): self-contained PnOct path; no algebra:: use.
@@ -43,21 +46,15 @@ if $SOUC compile tests/epistemic_trust/witness_gum_k95.sio -o "$OUT/k.elf" >/dev
   else echo "!! k95=$k95 — coverage factor may be FIXED; update trust map + re-enable U95"; fi
 else echo "witness_gum_k95 failed to compile (unexpected)"; fi
 
-echo "### C. KNOWN-UNIMPORTABLE trip-wire (informational) ###"
-# Free-function knowledge import is now Section A. Residual: method-call form (Root 2).
-echo "== witness_import_knowledge_method (expected: native compile FAILS) =="
-if $SOUC compile tests/epistemic_trust/witness_import_knowledge_method.sio -o "$OUT/w.elf" >/dev/null 2>&1; then
-  echo "!! method-call knowledge now COMPILES — Root 2 may be FIXED; update trust map"
-else echo "CONFIRMED unimportable (method-call form, as documented)"; fi
+echo "### C. promoted witnesses (must stay green) ###"
+# order_spread_exact + product_nonassoc + knowledge free + knowledge method → Section A.
+# Residual multi-module: gum k95 f64→i64 cast (Section B); do not reintroduce algebra:: uses
+# that still SEGV under exclusive-ref import chains without current-source evidence.
 
-# order_spread_exact + product_nonassoc promoted to Section A.
-# Residual multi-module: algebra::associator_field / algebra::octonion exclusive-ref
-# import chain still SEGV at runtime under Madaros — do not reintroduce algebra:: uses.
-
-# Legacy free-function witness should now succeed (informational flip)
-echo "== witness_import_knowledge free API (expected: now COMPILES) =="
+# Legacy free-function witness must still succeed
+echo "== witness_import_knowledge free API =="
 if $SOUC compile tests/epistemic_trust/witness_import_knowledge.sio -o "$OUT/w.elf" >/dev/null 2>&1; then
-  echo "OK free-function knowledge import COMPILES (promoted to Section A)"
+  echo "OK free-function knowledge import COMPILES (Section A)"
 else echo "FAIL unexpected: free knowledge import broke"; fail=1; fi
 
 echo

--- a/scripts/madaros_knowledge_method_residual_gate.sh
+++ b/scripts/madaros_knowledge_method_residual_gate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/madaros_knowledge_method_residual_gate.sh
+#
+# Wave9 residual closeout: Epistemic method form under default Madaros multi-module
+# must compile, run, and match free-function ep_* numerics.
+#
+# FIXED_ALREADY on origin/main (Root 2 multi-module methods + dual import landings).
+# This gate hard-requires the former residual; it must not silently degrade to free-only.
+#
+# Does not pin lean_single. Does not rebuild Madaros (uses bin/souc default engine).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+unset SOUNIO_SOUC_ENGINE || true
+ulimit -s unlimited 2>/dev/null || ulimit -s 131072 2>/dev/null || true
+SOUC="${SOUC:-$ROOT/bin/souc}"
+OUT="$(mktemp -d)"; trap 'rm -rf "$OUT"' EXIT
+fail=0
+
+echo "== madaros_knowledge_method_residual_gate =="
+echo "== engine: default Madaros (no lean_single pin) =="
+"$SOUC" --version 2>&1 | head -2 || true
+
+run_ok() {
+  local name="$1" src="$2" sentinel="$3"
+  echo "== $name =="
+  if ! "$SOUC" compile "$src" -o "$OUT/t.elf" >"$OUT/c.log" 2>&1; then
+    echo "FAIL: compile $src"
+    tail -20 "$OUT/c.log" || true
+    fail=1
+    return
+  fi
+  chmod +x "$OUT/t.elf"
+  if ! "$OUT/t.elf" >"$OUT/r.log" 2>&1 || ! grep -q "$sentinel" "$OUT/r.log"; then
+    echo "FAIL: run $src"
+    cat "$OUT/r.log" || true
+    fail=1
+    return
+  fi
+  grep -E 'OK|METHOD|KNOW|ROOT2|DUAL' "$OUT/r.log" || true
+  echo "PASS: $sentinel"
+}
+
+# Primary residual: free vs method numeric parity (measured/val/add/mul/std/variance)
+run_ok "free vs method parity" \
+  tests/epistemic_trust/knowledge_method_parity.sio \
+  KNOWLEDGE_METHOD_PARITY_OK
+
+# Method-form smoke (associated + instance under multi-mod import)
+run_ok "method form multi-mod" \
+  tests/run-pass/madaros_knowledge_method_form.sio \
+  KNOWLEDGE_METHOD_FORM_OK
+
+# Legacy Root-2 trip-wire now required green
+run_ok "legacy witness_import_knowledge_method" \
+  tests/epistemic_trust/witness_import_knowledge_method.sio \
+  KNOWLEDGE_METHOD_OK
+
+# Free-function control must stay green (method promotion must not regress free path)
+run_ok "free-function knowledge control" \
+  tests/epistemic_trust/knowledge_trust.sio \
+  KNOWLEDGE_TRUST_OK
+
+# Sibling Root-2 multi-module method must not regress
+if [[ -f tests/run-pass/madaros_root2_multimodule_method.sio ]]; then
+  run_ok "root2 multimodule method regression" \
+    tests/run-pass/madaros_root2_multimodule_method.sio \
+    ROOT2_MULTIMODULE_METHOD_OK
+fi
+
+mkdir -p "$ROOT/artifacts/compiler"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+STATUS=fail
+[[ $fail -eq 0 ]] && STATUS=pass
+cat >"$ROOT/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json" <<EOF
+{
+  "schema": "madaros_knowledge_method_residual_receipt.v1",
+  "status": "$STATUS",
+  "engine": "madaros_default",
+  "lean_single_pin": false,
+  "commit": "$COMMIT",
+  "verdict": "FIXED_ALREADY",
+  "claims": [
+    "epistemic_method_form_multimodule_import",
+    "epistemic_measured_val_add_mul_std_method_path",
+    "free_vs_method_numeric_parity",
+    "legacy_method_witness_now_required_green"
+  ],
+  "claims_not_made": [
+    "language_knowledge_t_generic_import",
+    "gum_k95_f64_i64_cast_fixed",
+    "full_root2_census_closed",
+    "enum_ctor_path"
+  ]
+}
+EOF
+echo "receipt: $ROOT/artifacts/compiler/madaros_knowledge_method_residual_receipt.v1.json"
+
+if [[ $fail -eq 0 ]]; then
+  echo "MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK"
+  exit 0
+fi
+exit 1

--- a/scripts/madaros_root2_method_gate.sh
+++ b/scripts/madaros_root2_method_gate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # scripts/madaros_root2_method_gate.sh
 #
-# Madaros Root 2 gate: associated Type::method + same-module &self methods.
-# Multi-module instance method calls remain residual (document, do not fail gate).
+# Madaros Root 2 gate: associated Type::method + same-module &self methods +
+# multi-module instance methods (Wave9 residual closeout — required green).
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
@@ -36,23 +36,14 @@ run_ok "multi-module associated import" \
   tests/run-pass/madaros_root2_associated_import.sio \
   ROOT2_ASSOCIATED_IMPORT_OK
 
-# Residual: multi-module instance method — expected compile fail under Madaros
-echo "== residual multi-module instance method (expect fail) =="
-cat >"$OUT/mm.sio" <<'EOF'
-use epistemic::knowledge::{Epistemic, ep_measured}
-fn main() -> i32 with IO, Mut, Div, Panic {
-    let e = ep_measured(10.0, 0.5)
-    print(e.val())
-    print("\n")
-    print("UNEXPECTED_MM_METHOD_OK\n")
-    return 0
-}
-EOF
-if "$SOUC" compile "$OUT/mm.sio" -o "$OUT/mm.elf" >"$OUT/mmc.log" 2>&1; then
-  echo "NOTE: multi-module instance method COMPILED — residual may be FIXED; update audit"
-else
-  echo "OK multi-module instance method still blocked (residual documented)"
-fi
+# Multi-module instance method (was residual; now required)
+run_ok "multi-module instance method" \
+  tests/run-pass/madaros_root2_multimodule_method.sio \
+  ROOT2_MULTIMODULE_METHOD_OK
+
+run_ok "knowledge method form" \
+  tests/run-pass/madaros_knowledge_method_form.sio \
+  KNOWLEDGE_METHOD_FORM_OK
 
 mkdir -p "$ROOT/artifacts/compiler"
 COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
@@ -68,11 +59,12 @@ cat >"$ROOT/artifacts/compiler/madaros_root2_method_receipt.v1.json" <<EOF
     "same_module_self_ref_method_call",
     "same_module_associated_type_method",
     "same_module_method_on_method_return",
-    "multimodule_associated_type_method_import"
+    "multimodule_associated_type_method_import",
+    "multimodule_instance_method_call",
+    "epistemic_method_form_multimodule"
   ],
   "claims_not_made": [
-    "multimodule_instance_method_call",
-    "full_root2_null_deref_closed",
+    "full_root2_census_closed",
     "enum_ctor_path"
   ]
 }

--- a/scripts/ousadia_epistemic_method_rx_gate.sh
+++ b/scripts/ousadia_epistemic_method_rx_gate.sh
@@ -67,22 +67,17 @@ do
   else echo "OK witness: $f"; fi
 done
 
-# 4) Dual import residual (expect Madaros E175 / fail — do not require green)
-echo "== dual gum+knowledge import residual =="
-cat >"$OUT/dual.sio" <<'EOF'
-use epistemic::knowledge::{Epistemic}
-use epistemic::gum::{gum_type_a}
-fn main() -> i32 with IO, Mut, Div, Panic {
-    let e = Epistemic::measured(1.0, 0.1)
-    let _a = gum_type_a(1.0, 5)
-    print(e.val()); print("\n")
-    return 0
-}
-EOF
-if "$SOUC" compile "$OUT/dual.sio" -o "$OUT/dual.elf" >"$OUT/dualc.log" 2>&1; then
-  echo "NOTE: dual gum+knowledge import now works — update claims_not_made"
+# 4) Dual gum+knowledge import (required green — dual_import landing; do not regress)
+echo "== dual gum+knowledge import (required) =="
+if ! "$SOUC" compile tests/run-pass/madaros_dual_gum_knowledge.sio -o "$OUT/dual.elf" >"$OUT/dualc.log" 2>&1; then
+  echo "FAIL: dual gum+knowledge compile"; tail -20 "$OUT/dualc.log" || true; fail=1
 else
-  echo "OK dual import still blocked under Madaros (E175 residual documented)"
+  chmod +x "$OUT/dual.elf"
+  if ! "$OUT/dual.elf" >"$OUT/dual.log" 2>&1 || ! grep -q "DUAL_GUM_KNOWLEDGE_OK" "$OUT/dual.log"; then
+    echo "FAIL: dual gum+knowledge run"; cat "$OUT/dual.log" || true; fail=1
+  else
+    echo "PASS: DUAL_GUM_KNOWLEDGE_OK"
+  fi
 fi
 
 mkdir -p "$ROOT/artifacts/clinical"
@@ -101,10 +96,10 @@ cat >"$ROOT/artifacts/clinical/ousadia_epistemic_method_rx_receipt.v1.json" <<EO
     "measured_val_std_add_is_credible_drive_decision",
     "type_a_u95_t4_band_adjust",
     "renal_refuse_same_mg_per_kg",
-    "compile_fail_confidence_witnesses_present"
+    "compile_fail_confidence_witnesses_present",
+    "dual_gum_and_knowledge_import_under_madaros"
   ],
   "claims_not_made": [
-    "dual_gum_and_knowledge_import_under_madaros",
     "bedside_dosing_product",
     "nonmem_foce",
     "language_knowledge_t_generic",

--- a/stdlib/epistemic/knowledge.sio
+++ b/stdlib/epistemic/knowledge.sio
@@ -220,9 +220,11 @@ pub fn ep_combine(c1: i64, c2: i64) -> i64 {
 }
 
 // ============================================================================
-// THIN IMPL WRAPPERS — lean_single / source-compat only
-// Method *call sites* under Madaros multi-module still SEGV (Root 2). Definitions
-// alone are safe; free-function API is the Madaros path.
+// THIN IMPL WRAPPERS — free-function bodies + method call sites
+// Free functions remain the preferred portable surface. Method form
+// (Epistemic::measured / e.val() / e.add) is TRUSTWORTHY under default Madaros
+// multi-module after Root 2 multi-module method landing (Wave9 residual closeout).
+// Parity gate: scripts/madaros_knowledge_method_residual_gate.sh
 // ============================================================================
 
 impl Epistemic {

--- a/tests/epistemic_trust/knowledge_method_parity.sio
+++ b/tests/epistemic_trust/knowledge_method_parity.sio
@@ -1,0 +1,47 @@
+// TRUSTWORTHY under default Madaros multi-module (Wave9 residual closeout):
+// Epistemic method form must match free-function ep_* numerics.
+// Covers Epistemic::measured, e.val(), e.add, e.mul, e.std, e.variance.
+// Historical residual: method call sites SEGV'd at lower_array:seed_begin
+// (Root 2). Free API was the only Madaros path; method form is now green.
+// See scripts/madaros_knowledge_method_residual_gate.sh.
+
+use epistemic::knowledge::{
+    Epistemic, ep_measured, ep_val, ep_variance, ep_std, ep_add, ep_mul
+}
+
+fn approx_eq(a: f64, b: f64, tol: f64) -> i64 {
+    let d = a - b
+    let d2 = if d < 0.0 { 0.0 - d } else { d }
+    if d2 <= tol { 1 } else { 0 }
+}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    // --- free-function path ---
+    let xf = ep_measured(10.0, 0.5)
+    let yf = ep_measured(4.0, 0.2)
+    let sf = ep_add(&xf, &yf)
+    let pf = ep_mul(&xf, &yf)
+
+    // --- method form (multi-module import of stdlib Epistemic) ---
+    let xm = Epistemic::measured(10.0, 0.5)
+    let ym = Epistemic::measured(4.0, 0.2)
+    let sm = xm.add(&ym)
+    let pm = xm.mul(&ym)
+
+    if approx_eq(ep_val(&xf), xm.val(), 1e-12) == 0 { print("F_VAL\n"); return 1 }
+    if approx_eq(ep_variance(&xf), xm.variance(), 1e-12) == 0 { print("F_VAR\n"); return 2 }
+    if approx_eq(ep_std(&xf), xm.std(), 1e-9) == 0 { print("F_STD\n"); return 3 }
+    if approx_eq(ep_val(&sf), sm.val(), 1e-12) == 0 { print("F_ADD\n"); return 4 }
+    if approx_eq(ep_variance(&sf), sm.variance(), 1e-12) == 0 { print("F_ADD_VAR\n"); return 5 }
+    if approx_eq(ep_val(&pf), pm.val(), 1e-12) == 0 { print("F_MUL\n"); return 6 }
+    if approx_eq(ep_variance(&pf), pm.variance(), 1e-10) == 0 { print("F_MUL_VAR\n"); return 7 }
+
+    // Absolute anchors (same first-principles values as knowledge_trust)
+    if approx_eq(xm.val(), 10.0, 1e-12) == 0 { print("F_ABS_VAL\n"); return 8 }
+    if approx_eq(sm.val(), 14.0, 1e-12) == 0 { print("F_ABS_SUM\n"); return 9 }
+    if approx_eq(pm.val(), 40.0, 1e-12) == 0 { print("F_ABS_PROD\n"); return 10 }
+    if approx_eq(sm.variance(), 0.29, 1e-12) == 0 { print("F_ABS_SUM_VAR\n"); return 11 }
+
+    print("KNOWLEDGE_METHOD_PARITY_OK\n")
+    return 0
+}

--- a/tests/epistemic_trust/knowledge_trust.sio
+++ b/tests/epistemic_trust/knowledge_trust.sio
@@ -1,5 +1,6 @@
-// TRUSTWORTHY under default Madaros: free-function Epistemic API
-// (D3 partial — method-call form still Root-2 blocked; see audit).
+// TRUSTWORTHY under default Madaros: free-function Epistemic API.
+// Method form is also TRUSTWORTHY — see knowledge_method_parity.sio and
+// scripts/madaros_knowledge_method_residual_gate.sh (Wave9 residual closeout).
 use epistemic::knowledge::{
     ep_measured, ep_val, ep_variance, ep_std, ep_add, ep_mul, ep_gate, ep_certain, ep_merge
 }

--- a/tests/epistemic_trust/witness_import_knowledge_method.sio
+++ b/tests/epistemic_trust/witness_import_knowledge_method.sio
@@ -1,13 +1,18 @@
-// Residual D3 / Root-2 trip-wire: method-call form under Madaros multi-module
-// still SEGV at lower_array seed_begin (MADAROS_SRET_ROOT_SYNTHESIS Root 2).
-// Free-function API is TRUSTWORTHY — see knowledge_trust.sio.
-// Expected under default Madaros: compile FAILS (segfault in lower).
+// Method-call form under Madaros multi-module — now TRUSTWORTHY (Wave9 residual closeout).
+// Historical residual: SEGV at lower_array:seed_begin (Root 2 / MADAROS_SRET_ROOT_SYNTHESIS).
+// Free-function API remains in knowledge_trust.sio; free vs method parity is
+// knowledge_method_parity.sio. Gate: scripts/madaros_knowledge_method_residual_gate.sh.
 use epistemic::knowledge::{Epistemic}
 
 fn main() -> i32 with IO, Mut, Div, Panic {
     let e = Epistemic::measured(10.0, 0.5)
-    print(e.val())
+    let v = e.val()
+    print(v)
     print("\n")
-    print("UNEXPECTED_METHOD_OK\n")
+    if v < 9.999 || v > 10.001 {
+        print("FAIL_METHOD_VAL\n")
+        return 1
+    }
+    print("KNOWLEDGE_METHOD_OK\n")
     return 0
 }

--- a/tests/run-pass/madaros_knowledge_method_form.sio
+++ b/tests/run-pass/madaros_knowledge_method_form.sio
@@ -1,0 +1,23 @@
+//@ run-pass
+//@ requires: madaros
+// Wave9 residual closeout: Epistemic method form under default Madaros multi-module.
+// Locks Epistemic::measured / e.val() / e.add / e.std (formerly Root-2 residual).
+// Free-function parity is gated by tests/epistemic_trust/knowledge_method_parity.sio.
+
+use epistemic::knowledge::{Epistemic}
+
+fn main() -> i32 with IO, Mut, Div, Panic {
+    let a = Epistemic::measured(10.0, 0.5)
+    let b = Epistemic::measured(4.0, 0.2)
+    let va = a.val()
+    let sa = a.std()
+    if va < 9.999 || va > 10.001 { print("FAIL_VAL\n"); return 1 }
+    if sa < 0.499 || sa > 0.501 { print("FAIL_STD\n"); return 2 }
+    let s = a.add(&b)
+    let vs = s.val()
+    if vs < 13.999 || vs > 14.001 { print("FAIL_ADD\n"); return 3 }
+    let c = Epistemic::certain(1.0)
+    if c.val() < 0.999 || c.val() > 1.001 { print("FAIL_CERTAIN\n"); return 4 }
+    print("KNOWLEDGE_METHOD_FORM_OK\n")
+    return 0
+}

--- a/tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio
+++ b/tests/stdlib/clinical/test_epistemic_method_rx_chain_e2e.sio
@@ -169,7 +169,7 @@ fn main() -> i32 with IO, Mut, Div, Panic {
 
     print("OUSADIA_RX engine=madaros_default multi_module=epistemic_knowledge\n")
     print("OUSADIA_RX methods=measured,certain,val,std,add,is_credible\n")
-    print("OUSADIA_RX dual_gum_import=E175_residual (gate smokes gum alone)\n")
+    print("OUSADIA_RX dual_gum_import=OK (madaros_dual_import_gate)\n")
     print("OUSADIA_RX compile_fail=vancomycin_low_conf_refusal,vancomycin_weak_evidence_refusal\n")
     print("OUSADIA_EPISTEMIC_METHOD_RX_CHAIN_OK\n")
     return 0

--- a/tests/stdlib/epistemic/test_knowledge_madaros_import_e2e.sio
+++ b/tests/stdlib/epistemic/test_knowledge_madaros_import_e2e.sio
@@ -1,7 +1,7 @@
 //@ run-pass
 // D3: Epistemic free-function API under default Madaros multi-module import.
-// claims_not_made: method-call form (Epistemic::measured / e.val()); Knowledge<T>
-// language builtin; full Root-2 compiler fix; lean_single-only code paths.
+// Method form is gated separately (knowledge_method_parity / residual gate).
+// claims_not_made: Knowledge<T> language builtin; full Root-2 census closed.
 use epistemic::knowledge::{
     ep_measured, ep_val, ep_variance, ep_std, ep_add, ep_mul, ep_gate, ep_certain, ep_merge
 }


### PR DESCRIPTION
## Summary

**Verdict: FIXED_ALREADY** on `origin/main` (Madaros v0.80.0). Wave9 Agent F residual for Epistemic method form under multi-module is closed by measurement + hard regression gate — no compiler patch required.

Measured under default Madaros (no lean_single pin):

| Form | Result |
|---|---|
| free `ep_measured` / `ep_val` / `ep_add` | `FREE_OK` |
| `Epistemic::measured` / `e.val()` | `METHOD_MIN_OK` |
| `e.add` / `e.mul` / `e.std` multi-mod | `METHOD_OK` / parity |
| free vs method numeric parity | exact match (val/add/mul/std/variance) |
| legacy `witness_import_knowledge_method` | green (`KNOWLEDGE_METHOD_OK`) |

Historical residual (Root 2 method SEGV at `lower_array:seed_begin`) was already closed by prior Root 2 multi-module method + dual-import landings; trip-wires still said "expect fail".

## Changes

- **New gate:** `scripts/madaros_knowledge_method_residual_gate.sh` → `MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK`
- **New tests:** free/method parity + method-form multi-mod smoke
- **Promote** method witnesses in:
  - `scripts/epistemic_trust_gate.sh` (Section A)
  - `scripts/epistemic_knowledge_madaros_e2e_gate.sh` (required green)
  - `scripts/madaros_root2_method_gate.sh` (multi-mod instance methods required)
  - `scripts/ousadia_epistemic_method_rx_gate.sh` (dual import required)
- Trust map + D3 audit residual tables updated; `knowledge.sio` comments un-staled

## Evidence

```bash
bash scripts/madaros_knowledge_method_residual_gate.sh
# MADAROS_KNOWLEDGE_METHOD_RESIDUAL_GATE_OK

bash scripts/epistemic_trust_gate.sh              # EPISTEMIC_TRUST_GATE_OK
bash scripts/epistemic_knowledge_madaros_e2e_gate.sh
bash scripts/madaros_root2_method_gate.sh
bash scripts/madaros_root2_multimodule_method_gate.sh
bash scripts/madaros_dual_import_gate.sh
bash scripts/ousadia_epistemic_method_rx_gate.sh
```

All sibling gates green; dual_import / ousadia / root2 method not regressed.

## claims_not_made

- Language generic `Knowledge<T>` method form
- gum k95 f64→i64 cast fixed (still Section B corrupt)
- Full Root 2 census closed (enum ctor paths, etc.)
- Compiler lower/check patch in this PR (not needed)

## Test plan

- [x] residual gate green on Madaros default
- [x] free vs method parity numeric anchors (10, 14, 40, var 0.29)
- [x] dual_import / ousadia / root2 multimodule method still green
- [x] epistemic trust Section A includes method form