### PR TITLE
fix(madaros): multi-module -O full peels (const-fold/SCCP/compact)

### DIFF
--- a/scripts/dev/named_path_import_print_f64_gate.sh
+++ b/scripts/dev/named_path_import_print_f64_gate.sh
@@ -9,13 +9,15 @@
 # (mod/half.sio missing) → E137 / incomplete closure. Brace form
 # `use mod::{half}` already worked.
 #
-# Also covers multi-module -O: opt_cleanup_module_inplace must not SEGV after
-# lower_done and must still print 1.500000. Root cause was by-value IrFunction
-# copies (Box/call_args, A8 family) plus miscompiled `&! functions[fi]` array-
-# element exclusive refs; cleanup mutates via module+fi field access only.
+# Also covers multi-module -O full peels (Wave9): opt_cleanup_module_inplace
+# must not SEGV after lower_done and must still print 1.500000, plus integer
+# const-fold surface 42 and SCCP-lite branch surface 7. Root cause was by-value
+# IrFunction copies (Box/call_args, A8 family) plus miscompiled
+# `&! functions[fi]` array-element exclusive refs; cleanup mutates via
+# module+fi field peels only (dedup/copy/DSE/control/CSE/DCE + const-fold +
+# SCCP-lite + compact_nops).
 #
-# PASS = check rc=0, default compile+run rc=0 with 1.500000, -O compile+run
-# rc=0 with 1.500000.
+# PASS = check rc=0, default compile+run rc=0 with 1.500000/42/7, -O same.
 # See docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md.
 
 set -uo pipefail
@@ -98,15 +100,29 @@ run_compile_and_execute() {
     cat "$run_out" >&2
     exit 1
   fi
+  # Const-fold surface (folded_sum → 42) and SCCP-lite branch surface (7).
+  local line2 line3
+  line2="$(sed -n '2p' "$run_out" | tr -d '\r')"
+  line3="$(sed -n '3p' "$run_out" | tr -d '\r')"
+  if [[ "$line2" != "42" ]]; then
+    echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=stdout_missing_constfold_42 label=${label} line2=${line2}" >&2
+    cat "$run_out" >&2
+    exit 1
+  fi
+  if [[ "$line3" != "7" ]]; then
+    echo "NAMED_PATH_IMPORT_GATE_BLOCKED reason=stdout_missing_sccp_7 label=${label} line3=${line3}" >&2
+    cat "$run_out" >&2
+    exit 1
+  fi
 
-  log "${label}: PASS stdout=$(tr -d '\n' < "$run_out")"
+  log "${label}: PASS stdout=$(tr '\n' '|' < "$run_out")"
 }
 
 # Default (no -O) must stay green.
 run_compile_and_execute "default"
 
-# -O multi-module opt_cleanup path: must also emit 1.500000 (no SEGV).
+# -O multi-module opt_cleanup full peels: 1.500000 + constfold 42 + sccp 7.
 run_compile_and_execute "opt" -O
 
-echo "NAMED_PATH_IMPORT_GATE_PASS raw_sha256=${RAW_SHA256:0:16} default+opt"
+echo "NAMED_PATH_IMPORT_GATE_PASS raw_sha256=${RAW_SHA256:0:16} default+opt full_peels"
 exit 0

--- a/self-hosted/ir/opt_cleanup.sio
+++ b/self-hosted/ir/opt_cleanup.sio
@@ -9022,10 +9022,12 @@ fn ocp_compact_nops(func: IrFunction) -> IrFunction with Mut, Div, Panic {
 // and never forms an intermediate `&! IrFunction` to a module array slot, never
 // copies a whole `IrFunction` or a whole `IrInstr` with live call_args.
 //
-// Pass set is the safe scalar/control subset: constructor writebacks
-// (`ir_nop` / `ir_copy` / `ir_load_imm` / `ir_return`) and scalar field stores
-// (`.src1` / `.src2`). Full const-fold / SCCP / compact_nops / e-graph stay on
-// the by-value stack-local path used by main.sio self-tests.
+// Pass set (Wave9 full peels): constructor writebacks
+// (`ir_nop` / `ir_copy` / `ir_load_imm` / `ir_return` / `ir_jump` / `ir_binop`)
+// and scalar field stores (`.src1` / `.src2` / compact field-wise moves).
+// Full e-graph / mul3_sr / LICM / epistemic rewrites stay on the by-value
+// stack-local path used by main.sio self-tests. Const-fold / SCCP-lite /
+// compact_nops are now field-wise (never by-value IrFunction).
 
 // Dedup IrLoadImm → IrCopy when an earlier reg already holds the same imm.
 fn ocp_mfi_dedup_imm(module: &! IrModule, fi: i64) with Mut, Div, Panic {
@@ -9320,6 +9322,336 @@ fn ocp_mfi_dce_once(module: &! IrModule, fi: i64) -> i64 with Mut, Div, Panic {
     removed
 }
 
+// Core integer const-fold via module+fi peels (no by-value IrFunction).
+// Subset of ocp_const_fold_pass_b both-const arithmetic/bitwise/compare plus
+// partial-constant identity/annihilation. Heavy chain rewrites (Block L/M/…)
+// stay on the by-value self-test spine.
+fn ocp_mfi_const_fold(module: &! IrModule, fi: i64) with Mut, Div, Panic {
+    var is_const: [bool; 256] = [false; 256]
+    var const_val: [i64; 256] = [0; 256]
+    var i: i64 = 0
+    while i < (*module).functions[fi as usize].instr_count {
+        let op = (*module).functions[fi as usize].instrs[i as usize].op
+        let dst = (*module).functions[fi as usize].instrs[i as usize].dst
+        if dst >= 0 && dst < 256 {
+            is_const[dst as usize] = false
+        }
+        if ocp_is_load_imm(op) || op == IrOpcode::IrLoadBool {
+            if dst >= 0 && dst < 256 {
+                is_const[dst as usize] = true
+                const_val[dst as usize] = (*module).functions[fi as usize].instrs[i as usize].imm_i64
+            }
+        }
+        if op == IrOpcode::IrCopy {
+            let s1 = (*module).functions[fi as usize].instrs[i as usize].src1
+            if s1 >= 0 && s1 < 256 && is_const[s1 as usize] {
+                if dst >= 0 && dst < 256 {
+                    let v = const_val[s1 as usize]
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_load_imm(dst, v)
+                    is_const[dst as usize] = true
+                    const_val[dst as usize] = v
+                }
+            }
+        }
+        if ocp_is_binop(op) {
+            let s1 = (*module).functions[fi as usize].instrs[i as usize].src1
+            let s2 = (*module).functions[fi as usize].instrs[i as usize].src2
+            let bin = (*module).functions[fi as usize].instrs[i as usize].bin_op
+            let s1_ok = s1 >= 0 && s1 < 256
+            let s2_ok = s2 >= 0 && s2 < 256
+            let s1_known = s1_ok && is_const[s1 as usize]
+            let s2_known = s2_ok && is_const[s2 as usize]
+            // Both-constant fold (integer lattice).
+            if s1_known && s2_known {
+                let v1 = const_val[s1 as usize]
+                let v2 = const_val[s2 as usize]
+                var fold_val: i64 = 0
+                var did_fold = false
+                if bin == BinaryOp::OpAdd {
+                    fold_val = v1 + v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpSub {
+                    fold_val = v1 - v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpMul {
+                    fold_val = v1 * v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpDiv && v2 != 0 {
+                    fold_val = v1 / v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpRem && v2 != 0 {
+                    fold_val = v1 % v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpBitAnd {
+                    fold_val = v1 & v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpBitOr {
+                    fold_val = v1 | v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpBitXor {
+                    fold_val = v1 ^ v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpShl && v2 >= 0 && v2 < 64 {
+                    fold_val = v1 << v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpShr && v2 >= 0 && v2 < 64 {
+                    fold_val = v1 >> v2
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpEq {
+                    fold_val = if v1 == v2 { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpNe {
+                    fold_val = if v1 != v2 { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpLt {
+                    fold_val = if v1 < v2 { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpLe {
+                    fold_val = if v1 <= v2 { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpGt {
+                    fold_val = if v1 > v2 { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpGe {
+                    fold_val = if v1 >= v2 { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpAnd {
+                    fold_val = if (v1 != 0) && (v2 != 0) { 1 } else { 0 }
+                    did_fold = true
+                }
+                if bin == BinaryOp::OpOr {
+                    fold_val = if (v1 != 0) || (v2 != 0) { 1 } else { 0 }
+                    did_fold = true
+                }
+                if did_fold && dst >= 0 && dst < 256 {
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_load_imm(dst, fold_val)
+                    is_const[dst as usize] = true
+                    const_val[dst as usize] = fold_val
+                }
+            }
+            // Partial-constant identity / annihilation (exactly one side known).
+            if (s1_known && !s2_known) || (!s1_known && s2_known) {
+                let v1 = if s1_known { const_val[s1 as usize] } else { 0 }
+                let v2 = if s2_known { const_val[s2 as usize] } else { 0 }
+                if bin == BinaryOp::OpMul {
+                    if s2_known && v2 == 1 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s1)
+                    }
+                    if s1_known && v1 == 1 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s2)
+                    }
+                    if s2_known && v2 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_load_imm(dst, 0)
+                        if dst >= 0 && dst < 256 {
+                            is_const[dst as usize] = true
+                            const_val[dst as usize] = 0
+                        }
+                    }
+                    if s1_known && v1 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_load_imm(dst, 0)
+                        if dst >= 0 && dst < 256 {
+                            is_const[dst as usize] = true
+                            const_val[dst as usize] = 0
+                        }
+                    }
+                }
+                if bin == BinaryOp::OpAdd {
+                    if s2_known && v2 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s1)
+                    }
+                    if s1_known && v1 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s2)
+                    }
+                }
+                if bin == BinaryOp::OpSub {
+                    if s2_known && v2 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s1)
+                    }
+                }
+                if bin == BinaryOp::OpBitOr {
+                    if s2_known && v2 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s1)
+                    }
+                    if s1_known && v1 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s2)
+                    }
+                }
+                if bin == BinaryOp::OpBitAnd {
+                    if (s2_known && v2 == 0) || (s1_known && v1 == 0) {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_load_imm(dst, 0)
+                        if dst >= 0 && dst < 256 {
+                            is_const[dst as usize] = true
+                            const_val[dst as usize] = 0
+                        }
+                    }
+                }
+                if bin == BinaryOp::OpBitXor {
+                    if s2_known && v2 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s1)
+                    }
+                    if s1_known && v1 == 0 {
+                        (*module).functions[fi as usize].instrs[i as usize] = ir_copy(dst, s2)
+                    }
+                }
+            }
+        }
+        // Unary OpNeg of a known constant.
+        if op == IrOpcode::IrUnaryOp {
+            let un = (*module).functions[fi as usize].instrs[i as usize].un_op
+            let s1 = (*module).functions[fi as usize].instrs[i as usize].src1
+            if un == UnaryOp::OpNeg && s1 >= 0 && s1 < 256 && is_const[s1 as usize] {
+                if dst >= 0 && dst < 256 {
+                    let v = 0 - const_val[s1 as usize]
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_load_imm(dst, v)
+                    is_const[dst as usize] = true
+                    const_val[dst as usize] = v
+                }
+            }
+        }
+        i = i + 1
+    }
+}
+
+// SCCP-lite (Wegman & Zadeck style lattice over a linear scan): fold branches
+// whose condition is a known constant; re-fold binops after copy chains.
+// Does not form &! functions[fi] or invoke cp_optimize_function (by-value).
+fn ocp_mfi_sccp(module: &! IrModule, fi: i64) with Mut, Div, Panic {
+    // Pass 1: rebuild lattice + fold remaining both-const / copy-of-const.
+    ocp_mfi_const_fold(module, fi)
+    // Pass 2: branch folding on known conditions.
+    var is_const: [bool; 256] = [false; 256]
+    var const_val: [i64; 256] = [0; 256]
+    var i: i64 = 0
+    while i < (*module).functions[fi as usize].instr_count {
+        let op = (*module).functions[fi as usize].instrs[i as usize].op
+        let dst = (*module).functions[fi as usize].instrs[i as usize].dst
+        if dst >= 0 && dst < 256 {
+            is_const[dst as usize] = false
+        }
+        if ocp_is_load_imm(op) || op == IrOpcode::IrLoadBool {
+            if dst >= 0 && dst < 256 {
+                is_const[dst as usize] = true
+                const_val[dst as usize] = (*module).functions[fi as usize].instrs[i as usize].imm_i64
+            }
+        }
+        if op == IrOpcode::IrCopy {
+            let s1 = (*module).functions[fi as usize].instrs[i as usize].src1
+            if s1 >= 0 && s1 < 256 && is_const[s1 as usize] && dst >= 0 && dst < 256 {
+                is_const[dst as usize] = true
+                const_val[dst as usize] = const_val[s1 as usize]
+            }
+        }
+        if op == IrOpcode::IrBranchTrue {
+            let cond = (*module).functions[fi as usize].instrs[i as usize].src1
+            let lab = (*module).functions[fi as usize].instrs[i as usize].label_id
+            if cond >= 0 && cond < 256 && is_const[cond as usize] {
+                if const_val[cond as usize] != 0 {
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_jump(lab)
+                } else {
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_nop()
+                }
+            }
+        }
+        if op == IrOpcode::IrBranchFalse {
+            let cond = (*module).functions[fi as usize].instrs[i as usize].src1
+            let lab = (*module).functions[fi as usize].instrs[i as usize].label_id
+            if cond >= 0 && cond < 256 && is_const[cond as usize] {
+                if const_val[cond as usize] == 0 {
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_jump(lab)
+                } else {
+                    (*module).functions[fi as usize].instrs[i as usize] = ir_nop()
+                }
+            }
+        }
+        i = i + 1
+    }
+    // Pass 3: unreachable after unconditional jump/return (SCCP reachability).
+    ocp_mfi_dead_after_jump(module, fi)
+}
+
+// Field-wise instruction move for compact_nops: never whole-IrInstr copy.
+// Transfers call_args by field assign then clears the source slot (module_frontend
+// already uses this pattern for call_args rebuild).
+fn ocp_mfi_instr_move_fields(module: &! IrModule, fi: i64, dst_i: i64, src_i: i64) with Mut, Div, Panic {
+    let op = (*module).functions[fi as usize].instrs[src_i as usize].op
+    let dst = (*module).functions[fi as usize].instrs[src_i as usize].dst
+    let s1 = (*module).functions[fi as usize].instrs[src_i as usize].src1
+    let s2 = (*module).functions[fi as usize].instrs[src_i as usize].src2
+    let imm = (*module).functions[fi as usize].instrs[src_i as usize].imm_i64
+    let immf = (*module).functions[fi as usize].instrs[src_i as usize].imm_f64
+    let lab = (*module).functions[fi as usize].instrs[src_i as usize].label_id
+    let fnid = (*module).functions[fi as usize].instrs[src_i as usize].fn_id
+    let fidx = (*module).functions[fi as usize].instrs[src_i as usize].field_idx
+    let flags = (*module).functions[fi as usize].instrs[src_i as usize].imm_flags
+    let bin = (*module).functions[fi as usize].instrs[src_i as usize].bin_op
+    let un = (*module).functions[fi as usize].instrs[src_i as usize].un_op
+    let nm = (*module).functions[fi as usize].instrs[src_i as usize].name
+    let ac = (*module).functions[fi as usize].instrs[src_i as usize].arg_count
+    (*module).functions[fi as usize].instrs[dst_i as usize].op = op
+    (*module).functions[fi as usize].instrs[dst_i as usize].dst = dst
+    (*module).functions[fi as usize].instrs[dst_i as usize].src1 = s1
+    (*module).functions[fi as usize].instrs[dst_i as usize].src2 = s2
+    (*module).functions[fi as usize].instrs[dst_i as usize].imm_i64 = imm
+    (*module).functions[fi as usize].instrs[dst_i as usize].imm_f64 = immf
+    (*module).functions[fi as usize].instrs[dst_i as usize].label_id = lab
+    (*module).functions[fi as usize].instrs[dst_i as usize].fn_id = fnid
+    (*module).functions[fi as usize].instrs[dst_i as usize].field_idx = fidx
+    (*module).functions[fi as usize].instrs[dst_i as usize].imm_flags = flags
+    (*module).functions[fi as usize].instrs[dst_i as usize].bin_op = bin
+    (*module).functions[fi as usize].instrs[dst_i as usize].un_op = un
+    (*module).functions[fi as usize].instrs[dst_i as usize].name = nm
+    (*module).functions[fi as usize].instrs[dst_i as usize].arg_count = ac
+    // Move call_args ownership: field assign then clear source before NOP.
+    // (Same field-level call_args write pattern as module_frontend arebox.)
+    if ac > 0 {
+        (*module).functions[fi as usize].instrs[dst_i as usize].call_args =
+            (*module).functions[fi as usize].instrs[src_i as usize].call_args
+        (*module).functions[fi as usize].instrs[src_i as usize].call_args = None
+        (*module).functions[fi as usize].instrs[src_i as usize].arg_count = 0
+    } else {
+        (*module).functions[fi as usize].instrs[dst_i as usize].call_args = None
+    }
+}
+
+// Compact IrNop holes by field-wise dense packing. Label ids are symbolic.
+fn ocp_mfi_compact_nops(module: &! IrModule, fi: i64) with Mut, Div, Panic {
+    var write: i64 = 0
+    var read: i64 = 0
+    let ic = (*module).functions[fi as usize].instr_count
+    while read < ic {
+        let op = (*module).functions[fi as usize].instrs[read as usize].op
+        if op != IrOpcode::IrNop {
+            if write != read {
+                ocp_mfi_instr_move_fields(module, fi, write, read)
+            }
+            write = write + 1
+        }
+        read = read + 1
+    }
+    var fill = write
+    while fill < ic {
+        (*module).functions[fi as usize].instrs[fill as usize] = ir_nop()
+        fill = fill + 1
+    }
+    (*module).functions[fi as usize].instr_count = write
+}
+
 // Safe multi-module function cleanup via module+fi field access only.
 fn opt_cleanup_function_mfi(module: &! IrModule, fi: i64) with Mut, Div, Panic {
     let ic = (*module).functions[fi as usize].instr_count
@@ -9327,6 +9659,7 @@ fn opt_cleanup_function_mfi(module: &! IrModule, fi: i64) with Mut, Div, Panic {
         return
     }
     ocp_mfi_dedup_imm(module, fi)
+    ocp_mfi_const_fold(module, fi)
     ocp_mfi_copy_prop(module, fi)
     ocp_mfi_dse(module, fi)
     ocp_mfi_redundant_jump(module, fi)
@@ -9342,6 +9675,10 @@ fn opt_cleanup_function_mfi(module: &! IrModule, fi: i64) with Mut, Div, Panic {
         }
         iter = iter + 1
     }
+    // SCCP-lite + compact: previously deferred (by-value path only).
+    ocp_mfi_sccp(module, fi)
+    let _ = ocp_mfi_dce_once(module, fi)
+    ocp_mfi_compact_nops(module, fi)
 }
 
 // Run safe field-wise cleanup on every function without copying IrModule or
@@ -9349,7 +9686,8 @@ fn opt_cleanup_function_mfi(module: &! IrModule, fi: i64) with Mut, Div, Panic {
 pub fn opt_cleanup_module_inplace(module: &! IrModule) -> OcpCleanupModuleReceipt with Mut, Div, Panic {
     // Exact-bitwise rebracket audit still lives on the by-value const-fold
     // spine (self-test / pipeline probe path). Multi-module -O uses mfi peels
-    // only, so audit deltas stay zero here until that spine is field-wise.
+    // (including core const-fold / SCCP-lite / compact_nops); heavy Block-L
+    // rebracket authority is not yet field-wise, so audit deltas stay zero.
     var audit = ocp_empty_exact_bitwise_rebracket_pass_audit()
     var last_application_function_index: i64 = -1
     var transaction_ontology_parameter_link_count: i64 = 0

--- a/tests/compiler/named_path_import_print_f64_gate/main.sio
+++ b/tests/compiler/named_path_import_print_f64_gate/main.sio
@@ -7,9 +7,14 @@
 //
 // Audit: docs/audit/MADAROS_MULTIMODULE_PRINT_IMPORT_BUGS_2026-07-13.md defect 1
 // (single-symbol use) combined with defect 2 (print_f64) and defect 3 (helper).
+//
+// Also exercises multi-module -O full peels (const-fold / SCCP-lite / compact):
+// integer folded_sum=42 and branch_const=7 must survive -O without SEGV.
 
 use mod::half
 use mod::add1
+use mod::folded_sum
+use mod::branch_const
 
 fn wrap(x: f64) -> f64 {
     add1(x)
@@ -18,6 +23,12 @@ fn wrap(x: f64) -> f64 {
 fn main() -> i64 with IO {
     // Expected stdout first line: 1.500000
     print_f64(wrap(half()))
+    print_char(10)
+    // Const-fold benefit surface: 42 under integer both-const peel.
+    print_int(folded_sum())
+    print_char(10)
+    // SCCP-lite branch surface: 7
+    print_int(branch_const())
     print_char(10)
     0
 }

--- a/tests/compiler/named_path_import_print_f64_gate/mod.sio
+++ b/tests/compiler/named_path_import_print_f64_gate/mod.sio
@@ -1,6 +1,9 @@
 // Leaf module for path-form named-import regression.
 // The parent main uses `use mod::half` (no braces) — the shape that used to
 // treat `half` as a filesystem path segment and fail AST closure / E137.
+//
+// folded_sum / branch_const exercise multi-module -O const-fold + SCCP-lite
+// peels (integer lattice) without changing the 1.500000 f64 oracle.
 
 pub fn half() -> f64 {
     0.5
@@ -8,4 +11,23 @@ pub fn half() -> f64 {
 
 pub fn add1(x: f64) -> f64 {
     x + 1.0
+}
+
+// (20 + 22) → 42 under both-const fold. Correct with or without -O; -O must
+// not SEGV while folding these LoadImm+BinOp pairs.
+pub fn folded_sum() -> i64 {
+    let a = 20
+    let b = 22
+    a + b
+}
+
+// SCCP-lite branch fold: cond is compile-time true, so then-branch is live.
+// Returns 7 either way; -O peels BranchTrue on known const.
+pub fn branch_const() -> i64 {
+    let c = 1
+    if c != 0 {
+        7
+    } else {
+        0
+    }
 }


### PR DESCRIPTION
## Summary

#1334 shipped safe multi-module `-O` peels (dedup/copy/DSE/control/CSE/DCE) and deferred **const-fold / SCCP / compact_nops** because by-value `IrFunction` and `&! functions[fi]` SEGV after `lower_done`.

This PR extends the module+fi peel set with those deferred passes **without** by-value `IrFunction`:

| Peel | What it does |
|---|---|
| `ocp_mfi_const_fold` | Both-const integer binops (+ bit/compare/bool), partial identity/annihilation (`x*0`, `x+0`, …), copy-of-const → LoadImm, unary neg-of-const |
| `ocp_mfi_sccp` | SCCP-lite: re-run lattice, fold `BranchTrue`/`BranchFalse` on known conditions, dead-after-jump |
| `ocp_mfi_compact_nops` | Field-wise dense packing; `call_args` moved via field assign (no whole-`IrInstr` copy) |

Heavy e-graph / mul3_sr / LICM / Block-L rebracket authority stay on the by-value self-test spine (`opt_cleanup_function_with_algebras_and_audit`).

## Gate

`scripts/dev/named_path_import_print_f64_gate.sh` now requires for **both** default and `-O`:

```
1.500000
42
7
```

- `1.500000` — path-form named import + `print_f64` (unchanged oracle)
- `42` — `folded_sum()` integer both-const surface
- `7` — `branch_const()` SCCP-lite branch surface

## Evidence

```bash
export SOUNIO_BUILD_LOCK=/tmp/sounio-w9-opeels.lock
make build-madaros
# Madaros ready: artifacts/self-hosted/madaros (100680756 bytes)

bash scripts/dev/named_path_import_print_f64_gate.sh
# NAMED_PATH_IMPORT_GATE_PASS … default+opt full_peels
# opt: PASS stdout=1.500000|42|7|
```

Acceptance: multi-mod `-O` still `1.500000`; no SEGV; more peels run on multi-mod path.

## Test plan

- [x] `make build-madaros` under `/tmp/sounio-w9-opeels.lock`
- [x] `bash scripts/dev/named_path_import_print_f64_gate.sh` → PASS default+opt full_peels
- [ ] CI green on PR