### PR TITLE
fix(madaros): cut per-dep empty IrModule + densify residuals

### DIFF
--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -11,7 +11,7 @@ use ir::opt_cleanup::{OcpCleanupModuleReceipt, opt_cleanup_module_inplace}
 use io::env::{read_env}
 use io::trace::{io_trace_i64_string}
 use check::mod::{check_items_verdict_boot4, check_items_verdict_boot4_with_ontocache_sidecar, check_modules_verdict_boot4, check_program_epistemic_into, check_program_with_artifacts, checker_to_ir_epistemic_into, checker_apply_ir_metadata, checker_apply_ir_ontology_parameter_links_from_items}
-use ir::lower::{lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref}
+use ir::lower::{lower_program_to_ir_trace, lower_program_to_ir_with_epistemic_trace, lower_program_to_ir_summary_flat_owned_with_epistemic_ref, lower_program_bodies_from_summary_flat_with_epistemic_ref, lower_program_bodies_from_summary_with_epistemic_boxed_owned}
 use native::codegen_x86_linux::{compile_native_v2_preview_to_file, native_resolve_target, native_v2_builtin_id_for_name}
 use check::knowledge_context::{knowledge_context_validate_items, knowledge_context_validate_items_values_only}
 use resolve::mod::{resolve_modules}
@@ -4416,10 +4416,10 @@ fn module_frontend_lower_program_box_traced_with_epistemic(
     trace.summary_seeded_modules = trace.summary_seeded_modules + 1
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
-    var summary_val = (*summary_result.summary)
-    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
+    // Consume summary Box: reuse its IrModule for body lower (no second empty).
+    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_owned(
         program,
-        &summary_val,
+        *summary_result.summary,
         epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
@@ -4479,10 +4479,10 @@ fn module_frontend_lower_program_items_box_traced(
     trace.summary_seeded_modules = trace.summary_seeded_modules + 1
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
-    var summary_val = (*summary_result.summary)
-    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
+    // Consume summary Box: reuse its IrModule for body lower (no second empty).
+    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_owned(
         &program,
-        &summary_val,
+        *summary_result.summary,
         &epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
@@ -4530,10 +4530,10 @@ fn module_frontend_lower_program_box_traced_with_externs(
     trace.summary_seeded_modules = trace.summary_seeded_modules + 1
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
-    var summary_val = (*summary_result.summary)
-    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
+    // Consume summary Box: reuse its IrModule for body lower (no second empty).
+    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_owned(
         program,
-        &summary_val,
+        *summary_result.summary,
         &epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
@@ -4582,10 +4582,10 @@ fn module_frontend_lower_program_items_box_traced_with_externs(
     trace.summary_seeded_modules = trace.summary_seeded_modules + 1
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
-    var summary_val = (*summary_result.summary)
-    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
+    // Consume summary Box: reuse its IrModule for body lower (no second empty).
+    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_owned(
         &program,
-        &summary_val,
+        *summary_result.summary,
         &epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
@@ -5011,15 +5011,17 @@ fn module_frontend_lower_programs_array_boxed(
 }
 
 fn bridge_lower_imported_modules_box(main_path: string, trace: &! LoadMultimoduleIrTrace) -> ModuleFrontendLowerBoxResult with IO, Mut, Div, Panic, Alloc {
-    let ir_result = load_multimodule_ir_traced(main_path, trace)
-    if !ir_result.ok {
-        return module_frontend_lower_box_error(ir_result.error_msg)
+    // Keep the merged Box canonical — do not densify through MultiModuleIrResult
+    // then Box::new again (was a full second materialization).
+    let boxed = load_multimodule_ir_to_box_traced(main_path, trace)
+    if !boxed.ok {
+        return module_frontend_lower_box_error(boxed.error_msg)
     }
-    if ir_result.module.fn_count <= 0 {
+    if (*boxed.module).fn_count <= 0 {
         return module_frontend_lower_box_error("ir_lowering_failed")
     }
     trace.last_stage = "done"
-    module_frontend_lower_box_ok(Box::new(ir_result.module), ir_empty_validated_patch_stats())
+    module_frontend_lower_box_ok(boxed.module, ir_empty_validated_patch_stats())
 }
 
 pub fn bridge_lower_module_box(main_path: string, trace: &! LoadMultimoduleIrTrace) -> ModuleFrontendLowerBoxResult with IO, Mut, Div, Panic, Alloc {
@@ -5092,10 +5094,10 @@ fn module_frontend_lower_program_full_traced(
     trace.summary_seeded_modules = trace.summary_seeded_modules + 1
     trace.last_stage = "lower_bodies"
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_begin\n") }
-    var summary_val = (*summary_result.summary)
-    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_ref(
+    // Consume summary Box: reuse its IrModule for body lower (no second empty).
+    let body_result = lower_program_bodies_from_summary_with_epistemic_boxed_owned(
         &program,
-        &summary_val,
+        *summary_result.summary,
         &epistemic
     )
     if module_frontend_lower_trace_enabled() { print("module_frontend_lower: bodies_done\n") }
@@ -5230,9 +5232,9 @@ fn module_frontend_merge_imported_into(
     if !merged.ok {
         return false
     }
-    // Residual densify for callers that still own a stack IrModule (legacy
-    // MultiModuleIrResult). Prefer module_frontend_merge_imported_box / the
-    // compile-to-file path which never densifies.
+    // Residual densify only when the caller still owns a stack IrModule.
+    // Prefer merge_imported_box / merge_imported_into_box / compile-to-file
+    // (and load_multimodule_ir_to_box_traced) which keep the Box canonical.
     (*out_module) = *merged.module
     true
 }
@@ -6313,7 +6315,10 @@ pub fn preflight_multimodule_frontend(main_path: string) -> MultiModuleFrontendR
     multimodule_frontend_error(imported_summary.error_msg)
 }
 
-pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIrTrace) -> MultiModuleIrResult with IO, Mut, Div, Panic, Alloc {
+// Box-preserving multi-mod load. Single-module paths still densify once into a
+// fresh Box (legacy load_multimodule_lower_program_traced returns IrModule by
+// value). Multi-mod keeps the merge Box end-to-end — no empty+densify pair.
+fn load_multimodule_ir_to_box_traced(main_path: string, trace: &! LoadMultimoduleIrTrace) -> ModuleFrontendLowerDirectBoxResult with IO, Mut, Div, Panic, Alloc {
     parser_reset_last_errors()
     var main_prog = load_module_file(main_path)
     let main_parse_errors = parser_last_error_count()
@@ -6321,7 +6326,7 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         print("Parse failed during IR lowering for module 0: ")
         print_int(main_parse_errors)
         print(" errors\n")
-        return multimodule_ir_error("parse_failed")
+        return module_frontend_lower_direct_box_error("parse_failed")
     }
     if module_frontend_lower_trace_enabled() { print("module_frontend_full: main_loaded\n") }
     trace.loaded_modules = 1
@@ -6338,14 +6343,14 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         if module_frontend_lower_trace_enabled() { print("module_frontend_lower: typecheck_done\n") }
         if single_verdict_no_use != 0 {
             print("Type check failed during IR lowering for module 0\n")
-            return multimodule_ir_error("type_check_failed")
+            return module_frontend_lower_direct_box_error("type_check_failed")
         }
         trace.typechecked_modules = 1
         trace.last_stage = "lower_single"
         var single_lower_result_no_use = load_multimodule_lower_program_traced(main_prog, single_epistemic_no_use, 0, trace)
         if single_lower_result_no_use.fn_count <= 0 {
             print("IR lowering failed for module 0\n")
-            return multimodule_ir_error("ir_lowering_failed")
+            return module_frontend_lower_direct_box_error("ir_lowering_failed")
         }
         trace.merged_modules = 1
         trace.last_stage = "done"
@@ -6354,10 +6359,11 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         print(" functions\n")
         if single_lower_result_no_use.fn_count <= 0 {
             print("IR lowering produced empty module\n")
-            return multimodule_ir_error("ir_lowering_empty_module")
+            return module_frontend_lower_direct_box_error("ir_lowering_empty_module")
         }
         parser_reset_last_errors()
-        return multimodule_ir_ok(single_lower_result_no_use)
+        // Single densify residual: flat lower returns IrModule by value.
+        return module_frontend_lower_direct_box_ok(Box::new(single_lower_result_no_use), ir_empty_validated_patch_stats())
     }
 
     let main_imports_fast = module_frontend_import_files_from_source(main_path)
@@ -6371,14 +6377,14 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         if module_frontend_lower_trace_enabled() { print("module_frontend_lower: typecheck_done\n") }
         if single_verdict != 0 {
             print("Type check failed during IR lowering for module 0\n")
-            return multimodule_ir_error("type_check_failed")
+            return module_frontend_lower_direct_box_error("type_check_failed")
         }
         trace.typechecked_modules = 1
         trace.last_stage = "lower_single"
         var single_lower_result = load_multimodule_lower_program_traced(main_prog, single_epistemic, 0, trace)
         if single_lower_result.fn_count <= 0 {
             print("IR lowering failed for module 0\n")
-            return multimodule_ir_error("ir_lowering_failed")
+            return module_frontend_lower_direct_box_error("ir_lowering_failed")
         }
         trace.merged_modules = 1
         trace.last_stage = "done"
@@ -6387,10 +6393,10 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
         print(" functions\n")
         if single_lower_result.fn_count <= 0 {
             print("IR lowering produced empty module\n")
-            return multimodule_ir_error("ir_lowering_empty_module")
+            return module_frontend_lower_direct_box_error("ir_lowering_empty_module")
         }
         parser_reset_last_errors()
-        return multimodule_ir_ok(single_lower_result)
+        return module_frontend_lower_direct_box_ok(Box::new(single_lower_result), ir_empty_validated_patch_stats())
     }
 
     var programs: [Program; 256] = [mf_empty_program(); 256]
@@ -6441,15 +6447,13 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
 
     if loaded <= 0 {
         trace.last_stage = "empty"
-        return multimodule_ir_error("no_modules_loaded")
+        return module_frontend_lower_direct_box_error("no_modules_loaded")
     }
 
-    // Keep the merged module in a Box through finalize. Densify only once into
-    // MultiModuleIrResult at the API boundary (legacy callers still take IrModule
-    // by value). Avoids: empty stack module + densify into it + return densify.
+    // Multi-mod: Box stays boxed through finalize. No densify here.
     let merged = module_frontend_merge_imported_box(&! programs, loaded, trace)
     if !merged.ok {
-        return multimodule_ir_error("ir_lowering_failed")
+        return module_frontend_lower_direct_box_error("ir_lowering_failed")
     }
     let module_box = merged.module
 
@@ -6461,12 +6465,20 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
 
     if (*module_box).fn_count <= 0 {
         print("IR lowering produced empty module\n")
-        return multimodule_ir_error("ir_lowering_empty_module")
+        return module_frontend_lower_direct_box_error("ir_lowering_empty_module")
     }
 
     parser_reset_last_errors()
-    // Single densify: Box → MultiModuleIrResult.module (API residual).
-    multimodule_ir_ok(*module_box)
+    module_frontend_lower_direct_box_ok(module_box, ir_empty_validated_patch_stats())
+}
+
+pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIrTrace) -> MultiModuleIrResult with IO, Mut, Div, Panic, Alloc {
+    let boxed = load_multimodule_ir_to_box_traced(main_path, trace)
+    if !boxed.ok {
+        return multimodule_ir_error(boxed.error_msg)
+    }
+    // API residual densify: MultiModuleIrResult still embeds IrModule by value.
+    multimodule_ir_ok(*boxed.module)
 }
 
 pub fn load_multimodule_ir(main_path: string) -> MultiModuleIrResult with IO, Mut, Div, Panic, Alloc {
@@ -6474,18 +6486,18 @@ pub fn load_multimodule_ir(main_path: string) -> MultiModuleIrResult with IO, Mu
     load_multimodule_ir_traced(main_path, &! trace)
 }
 
-// Write merged multi-mod IR into a caller-owned module. One densify from the
-// live Box into MultiModuleIrResult happens inside load_multimodule_ir_traced,
-// then this moves that module into `out`. Prefer
-// module_frontend_compile_imported_to_file / merge_imported_box for zero densify
-// (Box stays boxed end-to-end).
+// Write merged multi-mod IR into a caller-owned module. Densifies once from the
+// live Box into `out` — no intermediate MultiModuleIrResult densify+copy.
+// Prefer module_frontend_compile_imported_to_file / merge_imported_box for zero
+// densify (Box stays boxed end-to-end).
 pub fn load_multimodule_ir_into(main_path: string, out: &! IrModule) -> MultiModuleFrontendResult with IO, Mut, Div, Panic, Alloc {
     var trace = empty_load_multimodule_ir_trace()
-    let result = load_multimodule_ir_traced(main_path, &! trace)
-    if !result.ok {
-        return multimodule_frontend_error(result.error_msg)
+    let boxed = load_multimodule_ir_to_box_traced(main_path, &! trace)
+    if !boxed.ok {
+        return multimodule_frontend_error(boxed.error_msg)
     }
-    (*out) = result.module
+    // Single densify when caller still owns a stack IrModule.
+    (*out) = *boxed.module
     multimodule_frontend_ok()
 }
 

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -675,6 +675,52 @@ fn lowerer_new_from_program_summary(summary: &IrProgramSummary, epistemic: &IrEp
     lo
 }
 
+// Memory wall residual (post-#1319/#1336): body lower used to call lowerer_new()
+// (full empty IrModule) then seed stubs from the summary module — a second full
+// empty materialization per dep while the summary Box still held the first.
+// Consume the owned summary and reuse its live Boxes. string_count is zeroed to
+// match seed behaviour (body lower rebuilds the string table).
+fn lowerer_new_from_program_summary_owned(summary: IrProgramSummary, epistemic: &IrEpistemicSection) -> Lowerer with Alloc, Mut, Panic, Div, IO {
+    var lo = Lowerer {
+        module: summary.module,
+        epistemic_contests: Box::new(empty_lower_epistemic_contest_index()),
+        current_fn: IR_INVALID_FN,
+        current_func: Box::new(ir_empty_function()),
+        current_func_loaded: false,
+        env: None,
+        locals: Box::new(empty_lower_local_stack()),
+        scope_depth: 0,
+        loop_labels: Box::new(empty_lower_loop_labels()),
+        loop_depth: 0,
+        error_count: 0,
+        had_error: false,
+        enum_variants: summary.enum_variants,
+        struct_layouts: summary.struct_layouts,
+        global_types: summary.global_types,
+        array_elem_float_regs: [IR_INVALID_REG; 512],
+        array_elem_float_reg_count: 0,
+        variance_base_regs: [IR_INVALID_REG; 1024],
+        variance_value_regs: [IR_INVALID_REG; 1024],
+        variance_base_reg_count: 0,
+        debug_mode: false,
+        probe_mode: summary.probe_mode,
+        closure_caps: Box::new(empty_closure_cap_table()),
+        pending_closure_fn_id: -1,
+        allow_direct_capturing_closure_literal: false,
+        pending_variance_reg: -1,
+    }
+    (*lo.module).epistemic = (*epistemic)
+    lo.epistemic_contests = lower_epistemic_contest_index_from_ref(epistemic)
+    if lower_live_diag_enabled() {
+        print("CONTEST_IR_INDEX_BIND constructor=summary_owned contest_count=")
+        print_int((*lo.epistemic_contests).contest_count)
+        print("\n")
+    }
+    // Match lowerer_seed_module_from_summary: body path rebuilds strings.
+    (*lo.module).string_count = 0
+    lo
+}
+
 fn lowerer_new_from_program_summary_flat(summary: &IrProgramSummaryFlat, epistemic: IrEpistemicSection) -> Lowerer with Alloc, Mut, Panic, Div {
     var lo = lowerer_new()
     var module_box = lo.module
@@ -11358,15 +11404,14 @@ fn lower_program_to_ir_summary_box_with_epistemic_ref(prog: &Program, epistemic:
     lowerer_preseed_program_items_mut(&! lo, &prog.items, ir_empty_name())
     let error_count = lo.error_count
     let had_error = lo.had_error
+    // Memory wall residual: do NOT Box::new(ir_empty_program_summary()) then
+    // overwrite fields. ir_empty_program_summary materializes a full empty
+    // IrModule (~[IrFunction;2048]) that is immediately discarded — a second
+    // empty module per dep on top of lowerer_new. Box the live summary Boxes
+    // directly (probe path already does this).
     let inner = ir_program_summary_from_lowerer(lo)
-    var summary_box = Box::new(ir_empty_program_summary())
-    (*summary_box).module = inner.module
-    (*summary_box).enum_variants = inner.enum_variants
-    (*summary_box).struct_layouts = inner.struct_layouts
-    (*summary_box).global_types = inner.global_types
-    (*summary_box).probe_mode = inner.probe_mode
     IrProgramSummaryBoxResult {
-        summary: summary_box,
+        summary: Box::new(inner),
         error_count: error_count,
         had_error: had_error,
     }
@@ -11394,15 +11439,10 @@ fn lower_program_to_ir_summary_box_with_externs_ref(
     lowerer_preseed_program_items_mut(&! lo, &prog.items, ir_empty_name())
     let error_count = lo.error_count
     let had_error = lo.had_error
+    // Same residual as with_epistemic_ref: skip empty IrProgramSummary densify.
     let inner = ir_program_summary_from_lowerer(lo)
-    var summary_box = Box::new(ir_empty_program_summary())
-    (*summary_box).module = inner.module
-    (*summary_box).enum_variants = inner.enum_variants
-    (*summary_box).struct_layouts = inner.struct_layouts
-    (*summary_box).global_types = inner.global_types
-    (*summary_box).probe_mode = inner.probe_mode
     IrProgramSummaryBoxResult {
-        summary: summary_box,
+        summary: Box::new(inner),
         error_count: error_count,
         had_error: had_error,
     }
@@ -11639,6 +11679,29 @@ fn lower_program_bodies_from_summary_with_epistemic_boxed_ref(
     epistemic: &IrEpistemicSection
 ) -> IrLowerBoxResult with Mut, Panic, Div, Alloc, IO {
     let lo = lowerer_new_from_program_summary(summary, epistemic)
+    var lo2 = lo.lower_program_bodies_ref(&prog.items)
+    var patch_stats = ir_empty_validated_patch_stats()
+    if !lo2.had_error {
+        var module_box = lo2.module
+        patch_stats = ir_patch_validated_calls(&! (*module_box))
+        lo2.module = module_box
+    }
+    IrLowerBoxResult {
+        module: lo2.module,
+        error_count: lo2.error_count,
+        had_error: lo2.had_error,
+        patch_stats: patch_stats,
+    }
+}
+
+// Prefer this on multi-mod hot paths: consumes the summary and reuses its
+// IrModule Box so body lower does not allocate a second empty IrModule.
+fn lower_program_bodies_from_summary_with_epistemic_boxed_owned(
+    prog: &Program,
+    summary: IrProgramSummary,
+    epistemic: &IrEpistemicSection
+) -> IrLowerBoxResult with Mut, Panic, Div, Alloc, IO {
+    let lo = lowerer_new_from_program_summary_owned(summary, epistemic)
     var lo2 = lo.lower_program_bodies_ref(&prog.items)
     var patch_stats = ir_empty_validated_patch_stats()
     if !lo2.had_error {


### PR DESCRIPTION
## Summary

Memory wall residual after **#1319 finalize-byref** and **#1336 merge-byref** (Wave9 Agent A — OUSAR MAIS).

Per dependency, multi-mod still materialised **two full empty `IrModule`s** (~`[IrFunction; 2048]` each) on top of the live summary module:

| Site | Before | After |
|---|---|---|
| `lower_program_to_ir_summary_box_with_{epistemic,externs}_ref` | `Box::new(ir_empty_program_summary())` then overwrite fields (throws away a full empty module) | `Box::new(ir_program_summary_from_lowerer(lo))` — probe path pattern |
| body lower (`module_frontend_lower_program_*`) | `lowerer_new()` empty + seed stubs while summary Box still live | `lowerer_new_from_program_summary_owned` **consumes** summary Boxes; reuses the live `IrModule` |
| `bridge_lower_imported_modules_box` | densify via `MultiModuleIrResult` then `Box::new` again | `load_multimodule_ir_to_box_traced` keeps Box canonical |
| `load_multimodule_ir_into` | densify into `MultiModuleIrResult` then copy to `out` | densify **once** from Box into `out` |

Primary compile path (`module_frontend_compile_imported_to_file`) already stayed on Box end-to-end; this PR clears the remaining per-dep empty pair and the densify+rebox bridges.

### A14 safety

Whole-function writeback unchanged. Owned body lower reuses preseeded stubs (including BSS instr packs) instead of re-seeding into a fresh empty module. Does not reintroduce by-value `IrInstr` rebind.

### Measurement

| Workload | Peak VmRSS (this PR) | Prior (#1336 receipt) |
|---|---:|---:|
| dual gum+knowledge (225 fn) | **~810 MiB** | ~1593 MiB |
| order_spread witness compile | ~795 MiB | (not recorded) |

Rebuild: `SOUNIO_BUILD_LOCK=/tmp/sounio-w9-densify.lock` → `artifacts/self-hosted/madaros-densify-residual`.

### Honest residual

- `MultiModuleIrResult.module: IrModule` still embeds a full module by value (legacy load API densify at boundary).
- Single-module flat lower (`load_multimodule_lower_program_traced`) still returns `IrModule` by value then `Box::new` once.
- `module_frontend_merge_imported_into` densifies once for stack-owned callers (prefer `merge_imported_into_box` / compile-to-file).
- Per-dep body lower still needs one live full `Box<IrModule>` (necessary for staged lower).
- Broader body-lowering memory wall at `cd_exact` scale remains OPEN.
- Does not touch `opt_cleanup`.

## Test plan

- [x] Rebuild Madaros: `SOUNIO_BUILD_LOCK=/tmp/sounio-w9-densify.lock bash scripts/ci/build_modular_madaros.sh artifacts/self-hosted/madaros-densify-residual`
- [x] `bash scripts/madaros_dual_import_gate.sh` → `MADAROS_DUAL_IMPORT_GATE_OK`
- [x] `bash scripts/madaros_order_spread_native_gate.sh` → `MADAROS_ORDER_SPREAD_NATIVE_GATE_OK`
- [x] `a14_transitive_min.sio` compile+run rc=0 (prints `115`)
- [x] `sret_forwarding_cross_module_min.sio` → `CROSS_SRET_MIN_OK`
- [x] Peak RSS dual gum+knowledge ~810 MiB

## Files

- `self-hosted/ir/lower.sio`
- `self-hosted/compiler/module_frontend.sio`
