### PR TITLE
fix(madaros): length-1 BSS global array IndexGet (address, not value)

### DIFF
--- a/scripts/dev/madaros_len1_global_array_gate.sh
+++ b/scripts/dev/madaros_len1_global_array_gate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Gate: Madaros length-1 BSS global array IndexGet (Wave9 residual).
+# Exit 0 only when compile+run of [T;1] globals yields correct values (no SEGV).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+export SOUNIO_STDLIB_PATH="${SOUNIO_STDLIB_PATH:-$ROOT/stdlib}"
+SOUC="${SOUC:-$ROOT/bin/souc}"
+TMP="${TMPDIR:-/tmp}/madaros_len1_global_array_gate_$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "LEN1_GLOBAL_ARRAY_GATE_FAIL $*"
+  exit 1
+}
+
+run_case() {
+  local name="$1" src="$2" expect="$3"
+  local f="$TMP/${name}.sio"
+  local elf="$TMP/${name}.elf"
+  printf '%s\n' "$src" > "$f"
+  echo "[gate] $name"
+  "$SOUC" compile "$f" -o "$elf"
+  chmod +x "$elf"
+  local out rc
+  set +e
+  out="$("$elf" 2>&1)"
+  rc=$?
+  set -e
+  echo "[gate]   stdout: $out"
+  echo "[gate]   rc: $rc"
+  [[ "$rc" -eq 0 ]] || fail "$name rc=$rc out=$out"
+  [[ "$out" == *"$expect"* ]] || fail "$name expected '$expect' got: $out"
+}
+
+# 1) The measured residual: [i64;1] read-only IndexGet
+run_case "i64_len1_ro" '
+var A: [i64; 1] = [7; 1]
+fn main() -> i64 with IO {
+  print_int(A[0])
+  print("\n")
+  if A[0] != 7 { return 1 }
+  0
+}
+' '7'
+
+# 2) Write via helper then read (original #891-class note)
+run_case "i64_len1_write" '
+var A: [i64; 1] = [7; 1]
+fn set() with Mut { A[0] = 9 }
+fn main() -> i64 with IO, Mut {
+  set()
+  print_int(A[0])
+  print("\n")
+  if A[0] != 9 { return 1 }
+  0
+}
+' '9'
+
+# 3) f64 length-1 (same gsize<=8 trap)
+run_case "f64_len1" '
+var F: [f64; 1] = [1.5; 1]
+fn set() with Mut { F[0] = 2.5 }
+fn main() -> i64 with IO, Mut {
+  set()
+  print(F[0])
+  print("\n")
+  if F[0] != 2.5 { return 1 }
+  0
+}
+' '2.500000'
+
+# 4) element-list form [V] not only [V;1]
+run_case "i64_len1_elemlist" '
+var A: [i64; 1] = [42]
+fn main() -> i64 with IO {
+  print_int(A[0])
+  print("\n")
+  if A[0] != 42 { return 1 }
+  0
+}
+' '42'
+
+# 5) N=2 control (must stay green)
+run_case "i64_len2_control" '
+var A: [i64; 2] = [7; 2]
+fn set() with Mut { A[0] = 9 }
+fn main() -> i64 with IO, Mut {
+  set()
+  print_int(A[0])
+  print(" ")
+  print_int(A[1])
+  print("\n")
+  if A[0] != 9 { return 1 }
+  if A[1] != 7 { return 2 }
+  0
+}
+' '9 7'
+
+# 6) Scalar control (must still load the *value*, not SEGV on print_int)
+run_case "scalar_i64_control" '
+var G: i64 = 42
+fn main() -> i64 with IO {
+  print_int(G)
+  print("\n")
+  if G != 42 { return 1 }
+  0
+}
+' '42'
+
+echo "LEN1_GLOBAL_ARRAY_GATE_OK"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -136,6 +136,11 @@ let LOWER_GLOBAL_SCALAR_F64: i64 = 3
 // Word-size integer scalar global (`var G: i64 = …`). Distinct from 0/unknown so
 // `print(G)` / `println(G)` can select print_int instead of the char* printer.
 let LOWER_GLOBAL_SCALAR_I64: i64 = 1
+// Non-f64 fixed array global (`var A: [i64; N] = …`, including N=1). Distinct from
+// scalar kinds so Ident lowering loads the BSS *address* for IndexGet, not the
+// stored element value. Without this, `[T; 1]` (bss_size <= 8) took the scalar
+// load path and IndexGet treated the init word as a pointer → SEGV.
+let LOWER_GLOBAL_ARRAY: i64 = 4
 
 pub struct LowerGlobalTypeTable {
     // Indexed by IrModule.functions slot. Keep this aligned with IR_MAX_FUNCS;
@@ -2889,11 +2894,29 @@ fn lower_type_expr_is_array_of_f64(te: &TypeExpr) -> bool with Mut, Panic, Div {
     }
 }
 
+fn lower_type_expr_is_array(te: &TypeExpr) -> bool with Mut, Panic, Div {
+    if (*te).kind == TypeExprKind::TypeReference || (*te).kind == TypeExprKind::TypeRefMut {
+        match (*te).inner {
+            Some(inner_ty) => return lower_type_expr_is_array(&(*inner_ty)),
+            None => return false,
+        }
+    }
+    (*te).kind == TypeExprKind::TypeArray
+}
+
+fn lower_global_kind_is_array_base(kind: i64) -> bool {
+    // Bases that IndexGet must address via BSS_BASE+off (not load the init word).
+    kind == LOWER_GLOBAL_ELEM_F64 || kind == LOWER_GLOBAL_ARRAY
+}
+
 fn lower_global_elem_kind(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Mut, Panic, Div {
     match *ty_opt {
         Some(ty) => {
             if lower_type_expr_is_f64(&(*ty)) { return LOWER_GLOBAL_SCALAR_F64 }
             if lower_type_expr_is_array_of_f64(&(*ty)) { return LOWER_GLOBAL_ELEM_F64 }
+            // Any fixed array (incl. [i64; 1], [i8; N], …) needs address form.
+            // Must precede the integer-scalar check: TypeArray is not TypeNamed.
+            if lower_type_expr_is_array(&(*ty)) { return LOWER_GLOBAL_ARRAY }
             // Scalar integers: needed so print/println of `var G: i64` routes to
             // print_int (same SEGV class as untyped f64 → char*).
             if lower_type_expr_is_integer(&(*ty)) { return LOWER_GLOBAL_SCALAR_I64 }
@@ -10636,16 +10659,26 @@ impl Lowerer {
                 // global metadata for stores. A callee can update the backing
                 // slot, so reads must reload it instead of using that stale
                 // per-function snapshot. Aggregate bindings remain base pointers.
+                // 1-element arrays have bss_size <= 8 but are still aggregates —
+                // reloading the init word would make IndexGet treat it as a ptr.
                 if self.lookup_local_is_global(e.name) && self.lookup_local_global_bss_size(e.name) <= 8 {
-                    let bss_off = self.lookup_local_global_bss_offset(e.name)
-                    let pair = self.fresh_reg()
-                    let lo = pair.0
-                    let reg = pair.1
-                    let lo2 = lo.emit(ir_load_global(reg, bss_off, e.name))
-                    if self.lookup_local_scalar_kind(e.name) == 2 || self.bss_global_scalar_kind(e.name) == 2 {
-                        return (lo2.emit(ir_mark_float_reg(reg)), reg)
+                    let local_g_fn = lowerer_lookup_fn_id_by_name_ref(&self, e.name)
+                    let local_g_kind = if local_g_fn >= 0 {
+                        lower_global_type_table_lookup(&(*self.global_types), local_g_fn)
+                    } else {
+                        0
                     }
-                    return (lo2, reg)
+                    if !lower_global_kind_is_array_base(local_g_kind) {
+                        let bss_off = self.lookup_local_global_bss_offset(e.name)
+                        let pair = self.fresh_reg()
+                        let lo = pair.0
+                        let reg = pair.1
+                        let lo2 = lo.emit(ir_load_global(reg, bss_off, e.name))
+                        if self.lookup_local_scalar_kind(e.name) == 2 || self.bss_global_scalar_kind(e.name) == 2 {
+                            return (lo2.emit(ir_mark_float_reg(reg)), reg)
+                        }
+                        return (lo2, reg)
+                    }
                 }
                 (self, src)
             } else {
@@ -10655,18 +10688,22 @@ impl Lowerer {
                     if fn_strategy == IR_STRATEGY_BSS_GLOBAL {
                         let bss_off = self.module.functions[fn_id as usize].param_count
                         let gsize = self.module.functions[fn_id as usize].bss_size
+                        let global_elem_kind = lower_global_type_table_lookup(&(*self.global_types), fn_id)
                         let ref_pair = self.fresh_reg()
                         let lo2 = ref_pair.0
                         let ref_reg = ref_pair.1
                         var lo3 = lo2
-                        if gsize > 8 {
+                        // Multi-word BSS (gsize > 8) and *all* array globals —
+                        // including `[T; 1]` where gsize == elem_size <= 8 —
+                        // must materialize the BSS base address for IndexGet.
+                        // Scalar path loads the stored word (correct for `var G: i64`).
+                        if gsize > 8 || lower_global_kind_is_array_base(global_elem_kind) {
                             lo3 = lo2.emit(ir_load_imm(ref_reg, BSS_BASE_LINUX + bss_off))
                         } else {
                             lo3 = lo2.emit(ir_load_global(ref_reg, bss_off, e.name))
                         }
                         // BSS metadata is applied only when the global is used;
                         // eagerly loading every global can exhaust main's IR budget.
-                        let global_elem_kind = lower_global_type_table_lookup(&(*lo3.global_types), fn_id)
                         if global_elem_kind == LOWER_GLOBAL_SCALAR_F64 {
                             lo3 = lo3.emit(ir_mark_float_reg(ref_reg))
                         } else if global_elem_kind == LOWER_GLOBAL_ELEM_F64 {

--- a/tests/run-pass/global_array_len1_index.sio
+++ b/tests/run-pass/global_array_len1_index.sio
@@ -1,0 +1,43 @@
+//@ run-pass
+// Wave9 residual: length-1 BSS global array IndexGet SEGV under Madaros.
+//
+// Root cause: Ident of a BSS global with bss_size <= 8 took the scalar
+// `ir_load_global` path (load the stored word). For `var A: [i64; 1] = [7; 1]`
+// that word is 7; IndexGet then treated 7 as a base pointer → SEGV.
+// Multi-element arrays (bss_size > 8) already loaded BSS_BASE+off and worked.
+//
+// Fix: type-table marks array globals (LOWER_GLOBAL_ARRAY / ELEM_F64) so Ident
+// always materializes the BSS address, even when N=1.
+//@ requires: madaros
+//@ expect-stdout: 9 2.500000 3
+//@ expect-stdout: LEN1_OK
+
+var A: [i64; 1] = [7; 1]
+var F: [f64; 1] = [1.5; 1]
+var B: [i64; 1] = [3]
+
+fn set_a() with Mut { A[0] = 9 }
+fn set_f() with Mut { F[0] = 2.5 }
+
+fn main() -> i64 with IO, Mut {
+    // Read-only before mutate (pure SEGV repro on pre-fix)
+    if A[0] != 7 { return 1 }
+    if F[0] != 1.5 { return 2 }
+    if B[0] != 3 { return 3 }
+
+    set_a()
+    set_f()
+
+    print_int(A[0])
+    print(" ")
+    print(F[0])
+    print(" ")
+    print_int(B[0])
+    print("\n")
+
+    if A[0] != 9 { return 4 }
+    if F[0] != 2.5 { return 5 }
+    if B[0] != 3 { return 6 }
+    print("LEN1_OK\n")
+    0
+}


### PR DESCRIPTION
## Summary

Wave9 Agent E — second bold residual (non-overlapping with densify / arena / opt_cleanup / global-init element-list).

**Measured on `origin/main` under default Madaros prebuilt:**

```sounio
var A: [i64; 1] = [7; 1]
fn main() -> i64 with IO {
  print_int(A[0])   // SEGV rc=139
  0
}
```

| Case | Before | After |
|---|---|---|
| `var A: [i64; 1] = [7; 1]; A[0]` | SEGV 139 | `7` rc=0 |
| write via helper then read | SEGV 139 | `9` rc=0 |
| `var F: [f64; 1]` IndexGet | SEGV 139 | works |
| element-list `[42]` N=1 | SEGV 139 | works |
| `var A: [i64; 2]` (control) | green | green |
| `var G: i64` scalar `print_int` | green | green |

Also noted in issue #891 related bugs list (length-1 array global SEGV). Distinct from the scalar `print(G)` residual (#1338) and from Agent D's packed-BSS / element-list work.

## Root cause

In `lower.sio` Ident path for `IR_STRATEGY_BSS_GLOBAL`:

```text
if gsize > 8  →  load imm BSS_BASE+off   (array base address)
else          →  ir_load_global          (stored *value*)
```

`[i64; 1]` has `bss_size == 8`, so it took the **scalar value** path. IndexGet (`label_id=2` raw word load) then used the init word (e.g. `7`) as a pointer → SEGV. N≥2 arrays have `bss_size > 8` and already worked.

## Fix

1. `LOWER_GLOBAL_ARRAY = 4` — type-table kind for non-f64 fixed array globals (including N=1)
2. `lower_global_elem_kind` records it for any `TypeArray` (f64 arrays still use `ELEM_F64`)
3. Ident load uses **address** when `gsize > 8 || is_array_base(kind)`; scalars still load the value
4. Local-global scalar-reload path skips array bases for the same reason
5. Rebuild `bin/madaros-linux-x86_64` from modular Madaros with this source

No codegen change required — IndexGet label_id=2 was already correct once the base is an address.

## Test plan

- [x] `bash scripts/dev/madaros_len1_global_array_gate.sh` → `LEN1_GLOBAL_ARRAY_GATE_OK` (with rebuilt prebuilt; fails SEGV on pre-fix prebuilt)
- [x] `SOUNIO_MADAROS_AVAILABLE=1 bash scripts/run_sio_test_suite.sh global_array_len1 --verbose` → PASS
- [x] Non-regression: `global_array_repeat_init`, `global_scalar_f64_print` PASS
- [x] Default `bin/souc` (no `MADAROS_RAW_BIN`) reproduces the fix via refreshed prebuilt

## Out of scope (honest)

- Agent D: packed i8 BSS size + element-list cast/ident/fail-closed (parallel lane)
- Full `-O` peels residual (Agent C / #1070)
- Prebuilt lag for #1337/#1338 alone (partially absorbed by this rebuild, not the claim)