### PR TITLE
fix(madaros): wave9 ship global-init residual (cast/ident, fail-closed, i8 BSS)

### DIFF
--- a/scripts/dev/madaros_global_array_init_gate.sh
+++ b/scripts/dev/madaros_global_array_init_gate.sh
@@ -151,4 +151,63 @@ fn main() -> i64 with IO {
 ' '-1 -2 3'
 
 
+# 9) Wave9: cast element-list (`1 as i64`) — was fully dropped → zeros
+run_case "cast_list" '
+var A: [i64; 2] = [1 as i64, 2 as i64]
+fn main() -> i64 with IO {
+  print_int(A[0]); print(" "); print_int(A[1]); print("
+")
+  if A[0] != 1 { return 1 }
+  if A[1] != 2 { return 2 }
+  0
+}
+' '1 2'
+
+# 10) Wave9: ident of earlier scalar global in element-list
+run_case "ident_list" '
+var X: i64 = 7
+var A: [i64; 3] = [X, 20, 30]
+fn main() -> i64 with IO {
+  print_int(A[0]); print(" "); print_int(A[1]); print(" "); print_int(A[2]); print("
+")
+  if A[0] != 7 { return 1 }
+  if A[1] != 20 { return 2 }
+  if A[2] != 30 { return 3 }
+  0
+}
+' '7 20 30'
+
+# 11) Wave9: non-const element-list is fail-closed (no left-shift of remaining words)
+# `[ten(), 20, 30]` must NOT become `20 30 0`. Residual runtime init → all zero.
+run_case "nonconst_failclosed" '
+fn ten() -> i64 { 10 }
+var A: [i64; 3] = [ten(), 20, 30]
+fn main() -> i64 with IO {
+  print_int(A[0]); print(" "); print_int(A[1]); print(" "); print_int(A[2]); print("
+")
+  // Fail-closed: no partial record → BSS zero (not shifted 20 30 0).
+  if A[0] != 0 { return 1 }
+  if A[1] != 0 { return 2 }
+  if A[2] != 0 { return 3 }
+  0
+}
+' '0 0 0'
+
+# 12) Wave9: packed i8 BSS size is physical (adjacent arrays independent + dense)
+run_case "i8_adjacent" '
+var A: [i8; 4] = [1, 2, 3, 4]
+var B: [i8; 4] = [10, 20, 30, 40]
+fn main() -> i64 with IO {
+  print_int(A[0] as i64); print(" "); print_int(A[3] as i64); print(" ");
+  print_int(B[0] as i64); print(" "); print_int(B[3] as i64); print("
+")
+  if A[0] as i64 != 1 { return 1 }
+  if A[3] as i64 != 4 { return 2 }
+  if B[0] as i64 != 10 { return 3 }
+  if B[3] as i64 != 40 { return 4 }
+  0
+}
+' '1 4 10 40'
+
+
 echo "GLOBAL_ARRAY_INIT_GATE_OK"

--- a/self-hosted/ir/lower.sio
+++ b/self-hosted/ir/lower.sio
@@ -1216,6 +1216,10 @@ fn lowerer_preseed_impl_method_summaries_mut(
     }
 }
 
+// BSS allocation size for a type expression. Packed globals (i8/u8/bool/char)
+// must report physical width 1 so `[i8; N]` reserves N bytes, not N*8.
+// (Wave8 fixed IndexGet/init *stride* via hyper_algebra_kind; wave9 closes the
+// residual over-alloc from always returning 8 for TypeNamed.)
 fn lower_typeexpr_byte_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Div {
     match *ty_opt {
         Some(ty) => {
@@ -1229,6 +1233,27 @@ fn lower_typeexpr_byte_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Div {
                         return inner_size * 1024
                     }
                     _ => { return 8 }
+                }
+            }
+            if (*ty).kind == TypeExprKind::TypeNamed {
+                let name = ir_path_first_name((*ty).path)
+                // i8 / u8
+                if name.len == 2 {
+                    let first = name.buf[0] as i64
+                    let second = name.buf[1] as i64
+                    if (first == 105 || first == 117) && second == 56 {
+                        return 1
+                    }
+                }
+                // bool / char
+                if name.len == 4 {
+                    let is_bool = name.buf[0] == 98 as i8 && name.buf[1] == 111 as i8
+                        && name.buf[2] == 111 as i8 && name.buf[3] == 108 as i8
+                    let is_char = name.buf[0] == 99 as i8 && name.buf[1] == 104 as i8
+                        && name.buf[2] == 97 as i8 && name.buf[3] == 114 as i8
+                    if is_bool || is_char {
+                        return 1
+                    }
                 }
             }
             return 8
@@ -1371,6 +1396,21 @@ fn lower_bss_elem_is_signed_byte(kind: i64) -> bool {
     kind == 17
 }
 
+// True when a BSS slot is an aggregate base (array), not a scalar value load.
+// Historically `bss_size > 8` was the only discriminator — fine when every
+// element reserved 8 bytes, but wave9 packs i8/u8 at physical width so
+// `[i8; 4]` has size 4 and would be mis-read as a scalar (base = first byte
+// value → IndexGet SEGV). Packed byte arrays set hyper_algebra_kind 1/17.
+fn lower_bss_slot_is_aggregate(bss_size: i64, hyper_kind: i64) -> bool {
+    if bss_size > 8 {
+        return true
+    }
+    if hyper_kind == 1 || hyper_kind == 17 {
+        return true
+    }
+    false
+}
+
 fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Panic, Div {
     match *ty_opt {
         Some(ty) => {
@@ -1388,6 +1428,18 @@ fn lower_typeexpr_bss_elem_size(ty_opt: &Option<Box<TypeExpr>>) -> i64 with Pani
                             }
                             // 'u' '8' → unsigned packed byte (movzx on load)
                             if first == 117 && second == 56 {
+                                return 1
+                            }
+                        }
+                        // bool / char → packed unsigned byte (movzx); also marks
+                        // the slot as aggregate under lower_bss_slot_is_aggregate
+                        // even when N*1 ≤ 8 (wave9).
+                        if name.len == 4 {
+                            let is_bool = name.buf[0] == 98 as i8 && name.buf[1] == 111 as i8
+                                && name.buf[2] == 111 as i8 && name.buf[3] == 108 as i8
+                            let is_char = name.buf[0] == 99 as i8 && name.buf[1] == 104 as i8
+                                && name.buf[2] == 97 as i8 && name.buf[3] == 114 as i8
+                            if is_bool || is_char {
                                 return 1
                             }
                         }
@@ -5791,10 +5843,15 @@ impl Lowerer {
             return 0
         }
         // Aggregate bases (arrays/structs) are not print scalars.
-        if self.module.functions[fn_id as usize].bss_size > 8 {
+        // Packed [i8;N]/[u8;N] can have bss_size ≤ 8 — use hyper kind too (#1353).
+        // Type-table array kinds (incl. [T;1]) are also non-scalar (#1350).
+        let gkind = lower_global_type_table_lookup(&(*self.global_types), fn_id)
+        if lower_bss_slot_is_aggregate(
+            self.module.functions[fn_id as usize].bss_size,
+            self.module.functions[fn_id as usize].hyper_algebra_kind
+        ) || lower_global_kind_is_array_base(gkind) {
             return 0
         }
-        let gkind = lower_global_type_table_lookup(&(*self.global_types), fn_id)
         if gkind == LOWER_GLOBAL_SCALAR_F64 {
             return 2
         }
@@ -10705,16 +10762,20 @@ impl Lowerer {
                 // global metadata for stores. A callee can update the backing
                 // slot, so reads must reload it instead of using that stale
                 // per-function snapshot. Aggregate bindings remain base pointers.
-                // 1-element arrays have bss_size <= 8 but are still aggregates —
-                // reloading the init word would make IndexGet treat it as a ptr.
-                if self.lookup_local_is_global(e.name) && self.lookup_local_global_bss_size(e.name) <= 8 {
-                    let local_g_fn = lowerer_lookup_fn_id_by_name_ref(&self, e.name)
-                    let local_g_kind = if local_g_fn >= 0 {
-                        lower_global_type_table_lookup(&(*self.global_types), local_g_fn)
-                    } else {
-                        0
+                // Scalar reload only for true scalars. Aggregates keep base pointers:
+                // - multi-word BSS (gsize > 8)
+                // - packed [i8;N]/[u8;N]/bool/char (hyper 1/17) even when size ≤ 8 (#1353)
+                // - any fixed array incl. [T; 1] via type-table LOWER_GLOBAL_ARRAY (#1350)
+                if self.lookup_local_is_global(e.name) {
+                    let gsize = self.lookup_local_global_bss_size(e.name)
+                    var hyper_kind: i64 = 8
+                    var local_g_kind: i64 = 0
+                    let gfn = lowerer_lookup_fn_id_by_name_ref(&self, e.name)
+                    if gfn >= 0 && gfn < self.module.fn_count {
+                        hyper_kind = self.module.functions[gfn as usize].hyper_algebra_kind
+                        local_g_kind = lower_global_type_table_lookup(&(*self.global_types), gfn)
                     }
-                    if !lower_global_kind_is_array_base(local_g_kind) {
+                    if !lower_bss_slot_is_aggregate(gsize, hyper_kind) && !lower_global_kind_is_array_base(local_g_kind) {
                         let bss_off = self.lookup_local_global_bss_offset(e.name)
                         let pair = self.fresh_reg()
                         let lo = pair.0
@@ -10734,16 +10795,16 @@ impl Lowerer {
                     if fn_strategy == IR_STRATEGY_BSS_GLOBAL {
                         let bss_off = self.module.functions[fn_id as usize].param_count
                         let gsize = self.module.functions[fn_id as usize].bss_size
+                        let hyper_kind = self.module.functions[fn_id as usize].hyper_algebra_kind
                         let global_elem_kind = lower_global_type_table_lookup(&(*self.global_types), fn_id)
                         let ref_pair = self.fresh_reg()
                         let lo2 = ref_pair.0
                         let ref_reg = ref_pair.1
                         var lo3 = lo2
-                        // Multi-word BSS (gsize > 8) and *all* array globals —
-                        // including `[T; 1]` where gsize == elem_size <= 8 —
-                        // must materialize the BSS base address for IndexGet.
-                        // Scalar path loads the stored word (correct for `var G: i64`).
-                        if gsize > 8 || lower_global_kind_is_array_base(global_elem_kind) {
+                        // Aggregate → absolute BSS base pointer. Scalar → load value.
+                        // Multi-word, packed byte arrays (#1353), and any array kind
+                        // including `[T; 1]` (#1350) must not take the scalar load path.
+                        if lower_bss_slot_is_aggregate(gsize, hyper_kind) || lower_global_kind_is_array_base(global_elem_kind) {
                             lo3 = lo2.emit(ir_load_imm(ref_reg, BSS_BASE_LINUX + bss_off))
                         } else {
                             lo3 = lo2.emit(ir_load_global(ref_reg, bss_off, e.name))

--- a/self-hosted/parser/items.sio
+++ b/self-hosted/parser/items.sio
@@ -17,7 +17,11 @@ fn items_reverse_item_list_opt(items: Option<Box<ItemList>>) -> Option<Box<ItemL
 // Returns (ok, word). Covers the Sounio negative idiom `0 - n` (no unary-minus
 // in the style guide) so element-list packing does not silently drop slots and
 // collapse into a wrong array-repeat fill of the remaining literal.
-// Non-const expressions return ok=false (caller skips — residual for runtime inits).
+//
+// Wave9: also folds `as T` casts of const words, and Ident referring to a
+// previously recorded *scalar* global init (`var X: i64 = 7; [X, 20, 30]`).
+// True non-const (calls, multi-word idents) return ok=false — element-list
+// recording is fail-closed (all slots or none), not partial skip/shift.
 fn items_eval_global_init_word(e: &Expr) -> (bool, i64) with Div {
     if (*e).kind == ExprKind::ExprIntLit {
         return (true, (*e).int_val)
@@ -30,6 +34,29 @@ fn items_eval_global_init_word(e: &Expr) -> (bool, i64) with Div {
     }
     if (*e).kind == ExprKind::ExprBoolFalse {
         return (true, 0)
+    }
+    // Cast of a const word keeps the init word (identity on BSS fill bits).
+    // Unblocks `[1 as i64, 2 as i64]` which wave8 still dropped entirely.
+    if (*e).kind == ExprKind::ExprCast {
+        match (*e).left {
+            Some(operand) => {
+                let pair = items_eval_global_init_word(&(*operand))
+                if pair.0 {
+                    return (true, pair.1)
+                }
+            }
+            _ => {}
+        }
+        return (false, 0)
+    }
+    // Scalar global already recorded earlier in the same compile unit.
+    // Only count==1 (scalar / array-repeat fill word) is safe to re-use.
+    if (*e).kind == ExprKind::ExprIdent {
+        let c = ast_global_var_init_count((*e).name)
+        if c == 1 {
+            return (true, ast_global_var_init_nth((*e).name, 0))
+        }
+        return (false, 0)
     }
     if (*e).kind == ExprKind::ExprUnary && (*e).un_op == UnaryOp::OpNeg {
         match (*e).left {
@@ -125,7 +152,10 @@ fn items_eval_global_init_word(e: &Expr) -> (bool, i64) with Div {
 //   - scalar `42` / `-42` / `0 - n` / `1.5` / unary-neg floats / true|false
 //   - array-repeat `[V; N]`  → one fill word (i64 value or f64 bits)
 //   - element-list `[a, b, c]` → one word per element, same name hash, source order
-// Non-const elements are silently skipped (BSS stays zero for those slots).
+//   - cast/ident of the above (wave9)
+// Element-list is fail-closed: every slot must const-fold or *none* are recorded.
+// (Wave8 partial skip shifted remaining words left — `[f(),20,30]` → `20 30 0`.)
+// True runtime inits (calls) remain a residual: BSS stays zero, no silent shift.
 fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
     if (*init).kind == ExprKind::ExprArrayLit {
         // Repeat form: left = fill value, right = count → single fill word
@@ -134,16 +164,37 @@ fn items_record_global_int_init(name: Name, init: &Expr) with Mut, Div {
                 items_record_global_int_init(name, &(*repeat_val))
             }
             None => {
-                // Element-list form: [a, b, c] — record each const word in source order
+                // Element-list form: [a, b, c] — evaluate all slots first.
                 // (args is already reversed into source order by parse_array_literal).
                 var cur = (*init).args
+                var words: [i64; 128] = [0; 128]
+                var n: i64 = 0
+                var all_ok = true
                 while true {
                     match cur {
                         Some(node) => {
-                            items_record_global_int_init(name, &(*node).head)
+                            let pair = items_eval_global_init_word(&(*node).head)
+                            if !pair.0 {
+                                all_ok = false
+                                break
+                            }
+                            if n < 128 {
+                                words[n as usize] = pair.1
+                                n = n + 1
+                            } else {
+                                all_ok = false
+                                break
+                            }
                             cur = (*node).tail
                         }
                         None => { break }
+                    }
+                }
+                if all_ok {
+                    var i: i64 = 0
+                    while i < n {
+                        ast_record_global_var_init(name, words[i as usize])
+                        i = i + 1
                     }
                 }
             }

--- a/tests/run-pass/global_array_element_list_cast.sio
+++ b/tests/run-pass/global_array_element_list_cast.sio
@@ -1,0 +1,25 @@
+//@ requires:madaros
+// Wave9: global element-list slots with `as T` casts must const-fold.
+// Pre-wave9 stock Madaros dropped cast slots entirely → zeros.
+
+var A: [i64; 2] = [1 as i64, 2 as i64]
+var B: [i64; 3] = [10 as i64, 0 - 2, 30 as i64]
+
+fn main() -> i64 with IO {
+    print_int(A[0])
+    print(" ")
+    print_int(A[1])
+    print("\n")
+    print_int(B[0])
+    print(" ")
+    print_int(B[1])
+    print(" ")
+    print_int(B[2])
+    print("\n")
+    if A[0] != 1 { return 1 }
+    if A[1] != 2 { return 2 }
+    if B[0] != 10 { return 3 }
+    if B[1] != 0 - 2 { return 4 }
+    if B[2] != 30 { return 5 }
+    0
+}

--- a/tests/run-pass/global_array_element_list_ident.sio
+++ b/tests/run-pass/global_array_element_list_ident.sio
@@ -1,0 +1,19 @@
+//@ requires:madaros
+// Wave9: element-list may reference an earlier scalar global by Ident.
+
+var X: i64 = 7
+var Y: i64 = 0 - 3
+var A: [i64; 3] = [X, 20, Y]
+
+fn main() -> i64 with IO {
+    print_int(A[0])
+    print(" ")
+    print_int(A[1])
+    print(" ")
+    print_int(A[2])
+    print("\n")
+    if A[0] != 7 { return 1 }
+    if A[1] != 20 { return 2 }
+    if A[2] != 0 - 3 { return 3 }
+    0
+}

--- a/tests/run-pass/global_array_element_list_nonconst_failclosed.sio
+++ b/tests/run-pass/global_array_element_list_nonconst_failclosed.sio
@@ -1,0 +1,24 @@
+//@ requires:madaros
+// Wave9: non-const element-list must not left-shift remaining const words.
+// Pre-wave9: `var A: [i64;3] = [ten(), 20, 30]` ran as `20 30 0` (silent miscompile).
+// Wave9 fail-closed: any non-const slot → no partial record → BSS zero.
+// True runtime global inits remain a residual (honest zero, not wrong data).
+
+fn ten() -> i64 {
+    10
+}
+
+var A: [i64; 3] = [ten(), 20, 30]
+
+fn main() -> i64 with IO {
+    print_int(A[0])
+    print(" ")
+    print_int(A[1])
+    print(" ")
+    print_int(A[2])
+    print("\n")
+    if A[0] != 0 { return 1 }
+    if A[1] != 0 { return 2 }
+    if A[2] != 0 { return 3 }
+    0
+}


### PR DESCRIPTION
## Summary

**Wave9 Agent D** — highest I×F residual still OPEN on `origin/main` after wave8.

### Measured on stock `origin/main` (before)

| Case | Expected | Stock binary |
|---|---|---|
| `var N: [i8;4] = [-1,-128,127,0]` | `-1 -128 127` | `255 128 127` (movzx) |
| `var A: [i64;3] = [0-1, 0-2, 3]` | `-1 -2 3` | `3 3 3` (partial skip → rep-fill) |
| `var G: f64 = 1.5; print(G)` | `1.500000` | **SEGV 139** |
| `madaros_global_array_init_gate` | OK | **FAIL** `scalar_f64_print` |
| `var A = [1 as i64, 2 as i64]` | `1 2` | `0 0` (cast slots dropped) |
| `var A = [X, 20, 30]` (X global) | `7 20 30` | `20 30 0` (shift) |
| `var A = [ten(), 20, 30]` | honest residual | **`20 30 0` silent miscompile** |

Root of the gate-red state: wave8 source (#1337 signed i8 + constfold, #1338 scalar f64 print) was on `main` but **`bin/madaros-linux-x86_64` was left at the pre-wave8 ELF** after merge conflicts dropped the binary.

Plus open **source** residual after wave8 const-fold only:

1. Cast / Ident element-list slots still skipped  
2. Partial non-const lists **left-shifted** remaining words  
3. `lower_typeexpr_byte_size` always returned 8 for `TypeNamed` → `[i8;N]` over-alloc; packing + `bss_size > 8` aggregate discriminator SEGV'd for `N ≤ 8`

### Fix

| Layer | Change |
|---|---|
| **Parser** (`items.sio`) | Fold `ExprCast` + scalar `Ident` (prior global); element-list **all-or-nothing** (no partial record / shift) |
| **Lower** (`lower.sio`) | Physical BSS size for i8/u8/bool/char; `lower_bss_slot_is_aggregate` uses hyper kind `1`/`17` when size ≤ 8; bool/char arrays kind=1 |
| **Binary** | Rebuild modular Madaros → `bin/madaros-linux-x86_64` |
| **Gate + tests** | cast / ident / nonconst_failclosed / i8_adjacent + three `requires:madaros` run-pass files |

### Evidence

```
bash scripts/dev/madaros_global_array_init_gate.sh
# GLOBAL_ARRAY_INIT_GATE_OK
# (12 cases incl. wave8 + wave9)

bash scripts/madaros_dual_import_gate.sh
# MADAROS_DUAL_IMPORT_GATE_OK / DUAL_GUM_KNOWLEDGE_OK

bash scripts/epistemic_knowledge_madaros_e2e_gate.sh
# EPISTEMIC_KNOWLEDGE_MADAROS_E2E_GATE_OK (32/32 knowledge selftest)
```

### Non-overlap (wave9)

Does **not** touch:
- module_frontend densify / merge (Agent A)
- arena_reset (Agent B)
- opt_cleanup peels (Agent C)

### Honest residual

- True **runtime** global element-list inits (function calls) remain BSS-zero fail-closed (no silent wrong data). Full runtime init emit is a later lane.
- Knowledge method-form: gate notes Root 2 may already be fixed under stock path — trust-map refresh is separate (not this PR).

## Test plan

- [x] `bash scripts/dev/madaros_global_array_init_gate.sh` → `GLOBAL_ARRAY_INIT_GATE_OK`
- [x] run-pass: constfold / i8_signed / cast / ident / nonconst_failclosed / scalar_f64_print
- [x] dual import + knowledge e2e non-regression
- [x] modular Madaros rebuild installed as `bin/madaros-linux-x86_64`