### PR TITLE
feat(stdlib): bigframe grouped analytics batch-13 — final 10 verbs (sign/deviation, completes +50)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -109,6 +109,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | **batch-10 (20 verbs)** — sum_sq/cube, count_zero, sum_pos/neg, peak/trough_ratio, normalize_mean, row_number(+rev), cumcount_neg/nonzero, range_over_std, cumcount_above_mean, cumsum_centered_sq, cosine/euclid/manhattan/chebyshev/cross_mean | | | | **all win** | dense one/two-pass reductions + 2-col distances vs pandas per-group lambdas |
 | **batch-11 (10 verbs, set 3)** — num_increases/decreases, total_variation, mean_abs_change, autocorr1, is_running_max/min, max_drawdown, max_runup, count_ge_mean | | | | **all win** | dense change/running-extreme/autocorr passes vs pandas per-group lambdas/apply |
 | **batch-12 (10 verbs, set 4)** — count_le_mean, count/frac_within_1std, count_outlier_2std, cummax/cummin_pct, sum_recip, cumsum_recip, cumsum_sign, cumcount_ge_prev | | | | **all win** | dense threshold/reciprocal/running passes vs pandas per-group lambdas |
+| **batch-13 (10 verbs, set 5)** — net_over_gross, sum_pos_frac, mean_pos/neg, count_changes, max_abs_dev, sum_sq_dev, cumsum_dev_abs, cumcount_le_prev, cumcount_positive_frac | | | | **all win** | dense sign/deviation/running passes vs pandas per-group lambdas — completes the +50 push (~130 grouped verbs total) |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -28,7 +28,8 @@
 // grouped fano / snr / cv2; drawdown / drawdown-pct / runup / running-argmax; cumcount-positive / cumsum-neg / count-negative;
 // grouped runcount x4; sum-sq/cube/count-zero/sum-pos/neg/peak/trough-ratio; normalize-mean; cosine/euclid/manhattan/chebyshev/cross-mean; range-over-std/cumcount-above-mean/cumsum-centered-sq;
 // grouped num-increases/decreases/total-variation/mean-abs-change; autocorr1; is-running-max/min/max-drawdown/max-runup; count-ge-mean;
-// grouped count-le-mean/within-1std/frac-within-1std/outlier-2std; cummax-pct/cummin-pct; sum-recip/cumsum-recip/cumsum-sign; cumcount-ge-prev.
+// grouped count-le-mean/within-1std/frac-within-1std/outlier-2std; cummax-pct/cummin-pct; sum-recip/cumsum-recip/cumsum-sign; cumcount-ge-prev;
+// grouped net-over-gross/pos-frac/mean-pos/mean-neg/count-changes; max-abs-dev/sum-sq-dev/cumsum-dev-abs; cumcount-le-prev/positive-frac.
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -6608,3 +6609,79 @@ pub fn bf_cumcount_ge_prev_by(src: &BigFrame, key_col: i64, val_col: i64) -> Big
     while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let v=read_f64(vp,i); if seen[k]==1 { if v>=prev[k] {c[k]=c[k]+1.0} } prev[k]=v; seen[k]=1; write_f64(op,i,c[k]) } else {write_f64(op,i,read_f64(vp,i))} i=i+1 }
     out
 }
+
+/// Per-group SIGN/CHANGE reduction engine shared by bf_net_over_gross_by /
+/// bf_sum_pos_frac_by / bf_mean_pos_by / bf_mean_neg_by / bf_count_changes_by: mode 0
+/// net-over-gross (Σval/Σ|val|, directional strength in [-1,1]), 1 positive fraction of
+/// gross (Σ positive / Σ|val|), 2 mean of the positive values, 3 mean of the negative
+/// values, 4 count of value changes (val != previous-in-group), broadcast. DENSE keys
+/// 0..1023 (no hashing -- the bf_groupby_sum contract). O(n). NATIVE + lean_single only.
+fn bf_group_signred(src: &BigFrame, kc: i64, vc: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var sum: [f64;1024]=[0.0;1024]; var sab: [f64;1024]=[0.0;1024]; var sp: [f64;1024]=[0.0;1024]; var np: [f64;1024]=[0.0;1024]; var sn: [f64;1024]=[0.0;1024]; var nn: [f64;1024]=[0.0;1024]
+    var prev: [f64;1024]=[0.0;1024]; var seen: [i64;1024]=[0;1024]; var ch: [f64;1024]=[0.0;1024]; var res: [f64;1024]=[0.0;1024]
+    let n=bf_nrows(src); var out=bf_new(1,n); out.n_rows=n
+    if kc<0||kc>=bf_ncols(src)||vc<0||vc>=bf_ncols(src)||n<=0 { return out }
+    let kp=bf_col_ptr(src,kc) as *mut f64; let vp=bf_col_ptr(src,vc) as *mut f64; let op=bf_col_ptr(&out,0) as *mut f64
+    var i: i64=0
+    while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let v=read_f64(vp,i); sum[k]=sum[k]+v; sab[k]=sab[k]+bf_fabs(v); if v>0.0 {sp[k]=sp[k]+v; np[k]=np[k]+1.0} if v<0.0 {sn[k]=sn[k]+v; nn[k]=nn[k]+1.0}
+        if seen[k]==1 { if v!=prev[k] {ch[k]=ch[k]+1.0} } prev[k]=v; seen[k]=1 } i=i+1 }
+    var g: i64=0
+    while g<1024 { if mode==0 { if sab[g]>0.0 {res[g]=sum[g]/sab[g]} } else { if mode==1 { if sab[g]>0.0 {res[g]=sp[g]/sab[g]} } else { if mode==2 { if np[g]>0.0 {res[g]=sp[g]/np[g]} } else { if mode==3 { if nn[g]>0.0 {res[g]=sn[g]/nn[g]} } else {res[g]=ch[g]} } } } g=g+1 }
+    i=0; while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 {write_f64(op,i,res[k])} else {write_f64(op,i,read_f64(vp,i))} i=i+1 }
+    out
+}
+/// Per-group NET-OVER-GROSS (Σval/Σ|val|, directional strength in [-1,1]), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_net_over_gross_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_signred(src, key_col, val_col, 0) }
+/// Per-group POSITIVE FRACTION OF GROSS (Σ positive / Σ|val|), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_sum_pos_frac_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_signred(src, key_col, val_col, 1) }
+/// Per-group MEAN OF POSITIVE values, broadcast. Dense. NATIVE + lean_single.
+pub fn bf_mean_pos_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_signred(src, key_col, val_col, 2) }
+/// Per-group MEAN OF NEGATIVE values, broadcast. Dense. NATIVE + lean_single.
+pub fn bf_mean_neg_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_signred(src, key_col, val_col, 3) }
+/// Per-group COUNT of VALUE CHANGES (val != previous-in-group), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_count_changes_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_signred(src, key_col, val_col, 4) }
+
+/// Per-group DEVIATION engine shared by bf_max_abs_dev_by / bf_sum_sq_dev_by /
+/// bf_cumsum_dev_abs_by: mode 0 max|val-mean| (broadcast), 1 Σ(val-mean)² (broadcast; =
+/// (n-1)·sample-variance), 2 running Σ|val-mean| (cumulative absolute deviation). DENSE keys
+/// 0..1023 (two-pass: group mean, then deviations). O(n). NATIVE + lean_single only.
+fn bf_group_dev(src: &BigFrame, kc: i64, vc: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var sum: [f64;1024]=[0.0;1024]; var cnt: [f64;1024]=[0.0;1024]; var mean: [f64;1024]=[0.0;1024]; var mad: [f64;1024]=[0.0;1024]; var ssd: [f64;1024]=[0.0;1024]; var run: [f64;1024]=[0.0;1024]
+    let n=bf_nrows(src); var out=bf_new(1,n); out.n_rows=n
+    if kc<0||kc>=bf_ncols(src)||vc<0||vc>=bf_ncols(src)||n<=0 { return out }
+    let kp=bf_col_ptr(src,kc) as *mut f64; let vp=bf_col_ptr(src,vc) as *mut f64; let op=bf_col_ptr(&out,0) as *mut f64
+    var i: i64=0
+    while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { sum[k]=sum[k]+read_f64(vp,i); cnt[k]=cnt[k]+1.0 } i=i+1 }
+    var g: i64=0; while g<1024 { if cnt[g]>0.0 {mean[g]=sum[g]/cnt[g]} g=g+1 }
+    if mode==2 { i=0; while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { run[k]=run[k]+bf_fabs(read_f64(vp,i)-mean[k]); write_f64(op,i,run[k]) } else {write_f64(op,i,read_f64(vp,i))} i=i+1 } return out }
+    i=0
+    while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let d=bf_fabs(read_f64(vp,i)-mean[k]); if d>mad[k]{mad[k]=d} ssd[k]=ssd[k]+d*d } i=i+1 }
+    i=0; while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { if mode==0 {write_f64(op,i,mad[k])} else {write_f64(op,i,ssd[k])} } else {write_f64(op,i,read_f64(vp,i))} i=i+1 }
+    out
+}
+/// Per-group MAX ABSOLUTE DEVIATION (max|val-mean|), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_max_abs_dev_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dev(src, key_col, val_col, 0) }
+/// Per-group Σ(val-mean)² (total sum of squared deviations), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_sum_sq_dev_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dev(src, key_col, val_col, 1) }
+/// Per-group running Σ|val-mean| (cumulative absolute deviation). Dense. NATIVE + lean_single.
+pub fn bf_cumsum_dev_abs_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dev(src, key_col, val_col, 2) }
+
+/// Per-group running engine shared by bf_cumcount_le_prev_by / bf_cumcount_positive_frac_by:
+/// mode 0 running count of val≤previous-in-group, 1 running fraction of positive values so
+/// far (running #>0 / running count). DENSE keys 0..1023 (no hashing). O(n). NATIVE +
+/// lean_single only.
+fn bf_group_run2(src: &BigFrame, kc: i64, vc: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var prev: [f64;1024]=[0.0;1024]; var seen: [i64;1024]=[0;1024]; var c: [f64;1024]=[0.0;1024]; var cp: [f64;1024]=[0.0;1024]; var cnt: [f64;1024]=[0.0;1024]
+    let n=bf_nrows(src); var out=bf_new(1,n); out.n_rows=n
+    if kc<0||kc>=bf_ncols(src)||vc<0||vc>=bf_ncols(src)||n<=0 { return out }
+    let kp=bf_col_ptr(src,kc) as *mut f64; let vp=bf_col_ptr(src,vc) as *mut f64; let op=bf_col_ptr(&out,0) as *mut f64
+    var i: i64=0
+    while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let v=read_f64(vp,i)
+        if mode==0 { if seen[k]==1 { if v<=prev[k] {c[k]=c[k]+1.0} } prev[k]=v; seen[k]=1; write_f64(op,i,c[k]) }
+        else { if v>0.0 {cp[k]=cp[k]+1.0} cnt[k]=cnt[k]+1.0; write_f64(op,i,cp[k]/cnt[k]) } } else {write_f64(op,i,read_f64(vp,i))} i=i+1 }
+    out
+}
+/// Per-group running COUNT of val≤previous-in-group. Dense. NATIVE + lean_single.
+pub fn bf_cumcount_le_prev_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_run2(src, key_col, val_col, 0) }
+/// Per-group running FRACTION of positive values so far (running #>0 / running count). Dense. NATIVE + lean_single.
+pub fn bf_cumcount_positive_frac_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_run2(src, key_col, val_col, 1) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1521,6 +1521,29 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if bf_get(&cssg,0,0) != 1.0 || bf_get(&cssg,8,0) != 5.0 { print("FAIL cumsumsign\n"); return 550 }
     let cgp = bf_cumcount_ge_prev_by(&stf,0,1)
     if bf_get(&cgp,0,0) != 0.0 || bf_get(&cgp,8,0) != 4.0 { print("FAIL cumcountgeprev\n"); return 551 }  // monotone up
+    // ===== GROUPED ANALYTICS BATCH-13 (10 verbs, set 5) =====
+    // sign/change on sgb ({-3,5,-2,4}: sum 4, gross 14, Σpos 9/#2, Σneg -5/#2, 3 changes).
+    let nog = bf_net_over_gross_by(&sgb,0,1)
+    if !approx_eq(bf_get(&nog,0,0), 4.0/14.0) { print("FAIL netovergross\n"); return 552 }
+    let spf = bf_sum_pos_frac_by(&sgb,0,1)
+    if !approx_eq(bf_get(&spf,0,0), 9.0/14.0) { print("FAIL sumposfrac\n"); return 553 }
+    let mpb = bf_mean_pos_by(&sgb,0,1)
+    if !approx_eq(bf_get(&mpb,0,0), 4.5) { print("FAIL meanpos\n"); return 554 }   // 9/2
+    let mnb = bf_mean_neg_by(&sgb,0,1)
+    if !approx_eq(bf_get(&mnb,0,0), 0.0-2.5) { print("FAIL meanneg\n"); return 555 }  // -5/2
+    let cch = bf_count_changes_by(&sgb,0,1)
+    if bf_get(&cch,0,0) != 3.0 { print("FAIL countchanges\n"); return 556 }        // all distinct
+    // deviation on stf ({2,4,6,8,10}, mean 6).
+    let mad2 = bf_max_abs_dev_by(&stf,0,1)
+    if bf_get(&mad2,0,0) != 4.0 { print("FAIL maxabsdev\n"); return 557 }          // |2-6|=|10-6|=4
+    let ssd = bf_sum_sq_dev_by(&stf,0,1)
+    if bf_get(&ssd,0,0) != 40.0 { print("FAIL sumsqdev\n"); return 558 }           // 16+4+0+4+16
+    let cda = bf_cumsum_dev_abs_by(&stf,0,1)
+    if bf_get(&cda,0,0) != 4.0 || bf_get(&cda,8,0) != 12.0 { print("FAIL cumsumdevabs\n"); return 559 }
+    let clp = bf_cumcount_le_prev_by(&stf,0,1)
+    if bf_get(&clp,0,0) != 0.0 || bf_get(&clp,8,0) != 0.0 { print("FAIL cumcountleprev\n"); return 560 }  // monotone up
+    let cpf = bf_cumcount_positive_frac_by(&stf,0,1)
+    if !approx_eq(bf_get(&cpf,0,0), 1.0) || !approx_eq(bf_get(&cpf,8,0), 1.0) { print("FAIL cumcountposfrac\n"); return 561 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
The final 10 per-group verbs of the 50-verb push, all dense + all beating pandas: `bf_net_over_gross_by`, `bf_sum_pos_frac_by`, `bf_mean_pos_by`, `bf_mean_neg_by`, `bf_count_changes_by`, `bf_max_abs_dev_by`, `bf_sum_sq_dev_by`, `bf_cumsum_dev_abs_by`, `bf_cumcount_le_prev_by`, `bf_cumcount_positive_frac_by`. Gate: on {-3,5,-2,4} → net_over_gross 4/14, sum_pos_frac 9/14, mean_pos 4.5, mean_neg -2.5, count_changes 3; on {2,4,6,8,10} → max_abs_dev 4, sum_sq_dev 40, cumsum_dev_abs 4..12. Offline: all match pandas over 8k rows = 0 diffs. Completes the +50 (PRs #1349/#1351/#1352/this). stdlib only, no compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)