### PR TITLE
feat(stdlib): bigframe grouped curated batch — 10 verbs (weighted skew/kurt, lag-k autocorr, ratio, quantile family)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -110,6 +110,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | **batch-11 (10 verbs, set 3)** — num_increases/decreases, total_variation, mean_abs_change, autocorr1, is_running_max/min, max_drawdown, max_runup, count_ge_mean | | | | **all win** | dense change/running-extreme/autocorr passes vs pandas per-group lambdas/apply |
 | **batch-12 (10 verbs, set 4)** — count_le_mean, count/frac_within_1std, count_outlier_2std, cummax/cummin_pct, sum_recip, cumsum_recip, cumsum_sign, cumcount_ge_prev | | | | **all win** | dense threshold/reciprocal/running passes vs pandas per-group lambdas |
 | **batch-13 (10 verbs, set 5)** — net_over_gross, sum_pos_frac, mean_pos/neg, count_changes, max_abs_dev, sum_sq_dev, cumsum_dev_abs, cumcount_le_prev, cumcount_positive_frac | | | | **all win** | dense sign/deviation/running passes vs pandas per-group lambdas — completes the +50 push (~130 grouped verbs total) |
+| **curated (10 verbs)** — weighted_skew/kurt, lag-k autocorr, ratio_mean/sum **win** (weighted_skew 0.14x); median/q1/q3/iqr **~2.9x loss** (quantile-bound, pandas Cython) + mad_median (no native, wins) | | | | mixed | analytic dense verbs win; quantile family maps to the C3 select dispatch |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -29,7 +29,8 @@
 // grouped runcount x4; sum-sq/cube/count-zero/sum-pos/neg/peak/trough-ratio; normalize-mean; cosine/euclid/manhattan/chebyshev/cross-mean; range-over-std/cumcount-above-mean/cumsum-centered-sq;
 // grouped num-increases/decreases/total-variation/mean-abs-change; autocorr1; is-running-max/min/max-drawdown/max-runup; count-ge-mean;
 // grouped count-le-mean/within-1std/frac-within-1std/outlier-2std; cummax-pct/cummin-pct; sum-recip/cumsum-recip/cumsum-sign; cumcount-ge-prev;
-// grouped net-over-gross/pos-frac/mean-pos/mean-neg/count-changes; max-abs-dev/sum-sq-dev/cumsum-dev-abs; cumcount-le-prev/positive-frac.
+// grouped net-over-gross/pos-frac/mean-pos/mean-neg/count-changes; max-abs-dev/sum-sq-dev/cumsum-dev-abs; cumcount-le-prev/positive-frac;
+// grouped weighted-skew/kurt; lag-k autocorr; ratio-mean/sum; median/q1/q3/iqr/mad-median (quantile-bound).
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -6685,3 +6686,128 @@ fn bf_group_run2(src: &BigFrame, kc: i64, vc: i64, mode: i64) -> BigFrame with A
 pub fn bf_cumcount_le_prev_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_run2(src, key_col, val_col, 0) }
 /// Per-group running FRACTION of positive values so far (running #>0 / running count). Dense. NATIVE + lean_single.
 pub fn bf_cumcount_positive_frac_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_run2(src, key_col, val_col, 1) }
+
+/// Per-group WEIGHTED higher-moment engine shared by bf_weighted_skew_by /
+/// bf_weighted_kurt_by (two columns: value + weight): the weighted skewness (m3/m2^1.5) /
+/// weighted excess kurtosis (m4/m2² − 3), where m_r = Σw·(v−wmean)^r / Σw and wmean =
+/// Σw·v/Σw, broadcast. DENSE keys 0..1023 (dense two-pass, no hashing -- the bf_groupby_sum
+/// contract). O(n). NATIVE + lean_single only.
+fn bf_group_wmom(src: &BigFrame, kc: i64, vc: i64, wc: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var sw: [f64;1024]=[0.0;1024]; var swv: [f64;1024]=[0.0;1024]; var wm: [f64;1024]=[0.0;1024]
+    var m2: [f64;1024]=[0.0;1024]; var m3: [f64;1024]=[0.0;1024]; var m4: [f64;1024]=[0.0;1024]; var res: [f64;1024]=[0.0;1024]
+    let n=bf_nrows(src); var out=bf_new(1,n); out.n_rows=n
+    if kc<0||kc>=bf_ncols(src)||vc<0||vc>=bf_ncols(src)||wc<0||wc>=bf_ncols(src)||n<=0 { return out }
+    let kp=bf_col_ptr(src,kc) as *mut f64; let vp=bf_col_ptr(src,vc) as *mut f64; let wp=bf_col_ptr(src,wc) as *mut f64; let op=bf_col_ptr(&out,0) as *mut f64; let sc=heap_alloc(8) as *mut i64
+    var i: i64=0
+    while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let w=read_f64(wp,i); sw[k]=sw[k]+w; swv[k]=swv[k]+w*read_f64(vp,i) } i=i+1 }
+    var g: i64=0; while g<1024 { if sw[g]>0.0 {wm[g]=swv[g]/sw[g]} g=g+1 }
+    i=0; while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let w=read_f64(wp,i); let d=read_f64(vp,i)-wm[k]; let d2=d*d; m2[k]=m2[k]+w*d2; m3[k]=m3[k]+w*d2*d; m4[k]=m4[k]+w*d2*d2 } i=i+1 }
+    g=0; while g<1024 { if sw[g]>0.0 { let v2=m2[g]/sw[g]; if v2>0.0 { if mode==0 {res[g]=(m3[g]/sw[g])/(v2*bf_sqrt(v2,sc))} else {res[g]=(m4[g]/sw[g])/(v2*v2)-3.0} } } g=g+1 }
+    i=0; while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 {write_f64(op,i,res[k])} else {write_f64(op,i,0.0)} i=i+1 }
+    heap_free(sc as *mut i8)
+    out
+}
+/// Per-group WEIGHTED SKEWNESS (m3/m2^1.5 with weights), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_weighted_skew_by(src: &BigFrame, key_col: i64, val_col: i64, weight_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_wmom(src, key_col, val_col, weight_col, 0) }
+/// Per-group WEIGHTED EXCESS KURTOSIS (m4/m2²−3 with weights), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_weighted_kurt_by(src: &BigFrame, key_col: i64, val_col: i64, weight_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_wmom(src, key_col, val_col, weight_col, 1) }
+
+/// Per-group LAG-k AUTOCORRELATION (Pearson correlation of the value with its value k steps
+/// earlier within the group, like pandas Series.autocorr(k) per group; generalises
+/// bf_autocorr1_by), broadcast. `k`>=1. DENSE keys 0..1023 via a per-group ring buffer of
+/// the last k values (Σprev, Σcur, Σprev·cur, Σprev², Σcur² over the lag-k pairs). O(n).
+/// NATIVE + lean_single only.
+pub fn bf_lagk_autocorr_by(src: &BigFrame, key_col: i64, val_col: i64, k: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var occ: [i64;1024]=[0;1024]; var sp: [f64;1024]=[0.0;1024]; var scu: [f64;1024]=[0.0;1024]; var spc: [f64;1024]=[0.0;1024]; var sp2: [f64;1024]=[0.0;1024]; var sc2: [f64;1024]=[0.0;1024]; var np: [f64;1024]=[0.0;1024]; var res: [f64;1024]=[0.0;1024]
+    let n=bf_nrows(src); var out=bf_new(1,n); out.n_rows=n
+    if key_col<0||key_col>=bf_ncols(src)||val_col<0||val_col>=bf_ncols(src)||n<=0||k<1 { return out }
+    let kp=bf_col_ptr(src,key_col) as *mut f64; let vp=bf_col_ptr(src,val_col) as *mut f64; let op=bf_col_ptr(&out,0) as *mut f64; let sc=heap_alloc(8) as *mut i64
+    let hist=heap_alloc(1024*k*8) as *mut f64
+    var i: i64=0
+    while i<n { let kk=read_f64(kp,i) as i64; if kk>=0&&kk<1024 { let v=read_f64(vp,i); let j=occ[kk]; let idx=kk*k+(j-k*(j/k))
+        if j>=k { let p=read_f64(hist,idx); sp[kk]=sp[kk]+p; scu[kk]=scu[kk]+v; spc[kk]=spc[kk]+p*v; sp2[kk]=sp2[kk]+p*p; sc2[kk]=sc2[kk]+v*v; np[kk]=np[kk]+1.0 }
+        write_f64(hist,idx,v); occ[kk]=j+1 } i=i+1 }
+    var g: i64=0; while g<1024 { if np[g]>1.0 { let m=np[g]; let cov=m*spc[g]-sp[g]*scu[g]; let vp2=m*sp2[g]-sp[g]*sp[g]; let vc2=m*sc2[g]-scu[g]*scu[g]; let den=bf_sqrt(vp2*vc2,sc); if den>0.0 {res[g]=cov/den} } g=g+1 }
+    i=0; while i<n { let kk=read_f64(kp,i) as i64; if kk>=0&&kk<1024 {write_f64(op,i,res[kk])} else {write_f64(op,i,0.0)} i=i+1 }
+    heap_free(sc as *mut i8); heap_free(hist as *mut i8)
+    out
+}
+
+/// Per-group RATIO engine shared by bf_ratio_mean_by / bf_ratio_sum_by (two columns x,y):
+/// mode 0 mean of x/y, 1 Σ(x/y), broadcast (y==0 terms skipped). DENSE keys 0..1023. O(n).
+/// NATIVE + lean_single only.
+fn bf_group_ratio2(src: &BigFrame, kc: i64, xc: i64, yc: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var s: [f64;1024]=[0.0;1024]; var cnt: [f64;1024]=[0.0;1024]; var res: [f64;1024]=[0.0;1024]
+    let n=bf_nrows(src); var out=bf_new(1,n); out.n_rows=n
+    if kc<0||kc>=bf_ncols(src)||xc<0||xc>=bf_ncols(src)||yc<0||yc>=bf_ncols(src)||n<=0 { return out }
+    let kp=bf_col_ptr(src,kc) as *mut f64; let xp=bf_col_ptr(src,xc) as *mut f64; let yp=bf_col_ptr(src,yc) as *mut f64; let op=bf_col_ptr(&out,0) as *mut f64
+    var i: i64=0
+    while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 { let y=read_f64(yp,i); if y!=0.0 {s[k]=s[k]+read_f64(xp,i)/y} cnt[k]=cnt[k]+1.0 } i=i+1 }
+    var g: i64=0; while g<1024 { if cnt[g]>0.0 { if mode==0 {res[g]=s[g]/cnt[g]} else {res[g]=s[g]} } g=g+1 }
+    i=0; while i<n { let k=read_f64(kp,i) as i64; if k>=0&&k<1024 {write_f64(op,i,res[k])} else {write_f64(op,i,0.0)} i=i+1 }
+    out
+}
+/// Per-group MEAN of x/y (two columns), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_ratio_mean_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ratio2(src, key_col, x_col, y_col, 0) }
+/// Per-group Σ(x/y) (two columns), broadcast. Dense. NATIVE + lean_single.
+pub fn bf_ratio_sum_by(src: &BigFrame, key_col: i64, x_col: i64, y_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_ratio2(src, key_col, x_col, y_col, 1) }
+
+// linear-interpolated q-quantile of a[0..sz) via bf_quickselect (a is mutated).
+fn bf_qat(a: *mut f64, sz: i64, q: f64, sc: *mut i64) -> f64 with Mut, Div, Panic {
+    let pos=q*((sz-1) as f64); let lo=pos as i64; let fr=pos-(lo as f64)
+    var v=bf_quickselect(a,sz,lo)
+    if fr>0.0 { var mn=read_f64(a,lo+1); var t=lo+2; while t<sz { let x=read_f64(a,t); if x<mn {mn=x} t=t+1 } v=v+fr*(mn-v) }
+    v
+}
+/// Per-group QUANTILE-family broadcast engine shared by bf_median_by / bf_q1_by / bf_q3_by /
+/// bf_iqr_by / bf_mad_median_by: mode 0 median, 1 first quartile (q25), 2 third quartile
+/// (q75), 3 interquartile range (q75−q25), 4 median absolute deviation from the median
+/// (median|v−median|, robust dispersion), broadcast. O(n + Σ sz) via factorize + counting-
+/// sort into per-group regions, then bf_quickselect for each order statistic. Handles ANY
+/// f64 key. (Quantile-bound: ~2-3x behind pandas' specialised groupby-median/quantile, like
+/// bf_winsorize_by; the C3 select/radix dispatch would close it. mad_median has no native
+/// pandas path and wins.) NATIVE + lean_single only.
+fn bf_group_quantile(src: &BigFrame, kc: i64, vc: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let nr=bf_nrows(src); let nc=bf_ncols(src)
+    if kc<0||kc>=nc||vc<0||vc>=nc||nr<=0 { return bf_new(1,1) }
+    var size: i64=16; while size<nr+nr { size=size*2 }
+    let mask=size-1
+    let occ=heap_alloc(size*8) as *mut f64; let hk=heap_alloc(size*8) as *mut f64; let hid=heap_alloc(size*8) as *mut f64
+    let kp=bf_col_ptr(src,kc) as *mut f64; let vp=bf_col_ptr(src,vc) as *mut f64
+    let id=heap_alloc(nr*8) as *mut i64; let sizes=heap_alloc(nr*8) as *mut i64
+    var G: i64=0; var r: i64=0
+    while r<nr { let k=read_f64(kp,r); var slot=bf_ghash(k,mask); var done=false
+        while !done { if read_f64(occ,slot)==0.0 { write_f64(occ,slot,1.0); write_f64(hk,slot,k); write_f64(hid,slot,G as f64); write_i64(id,r,G); write_i64(sizes,G,1); G=G+1; done=true }
+            else { if read_f64(hk,slot)==k { let g=read_f64(hid,slot) as i64; write_i64(id,r,g); write_i64(sizes,g,read_i64(sizes,g)+1); done=true } else { slot=(slot+1)&mask } } }
+        r=r+1 }
+    let offsets=heap_alloc(nr*8) as *mut i64; let cursor=heap_alloc(nr*8) as *mut i64
+    var acc: i64=0; var g: i64=0
+    while g<G { write_i64(offsets,g,acc); write_i64(cursor,g,acc); acc=acc+read_i64(sizes,g); g=g+1 }
+    let flat=heap_alloc(nr*8) as *mut i64; let fval=heap_alloc(nr*8) as *mut f64
+    r=0; while r<nr { let g2=read_i64(id,r); let p=read_i64(cursor,g2); write_i64(flat,p,r); write_f64(fval,p,read_f64(vp,r)); write_i64(cursor,g2,p+1); r=r+1 }
+    let scr=heap_alloc(nr*8) as *mut f64; let sc=heap_alloc(8) as *mut i64; let res=heap_alloc(G*8) as *mut f64
+    g=0
+    while g<G { let base=read_i64(offsets,g); let sz=read_i64(sizes,g)
+        var j: i64=0; while j<sz { write_f64(scr,j,read_f64(fval,base+j)); j=j+1 }
+        if mode==0 { write_f64(res,g,bf_qat(scr,sz,0.5,sc)) }
+        else { if mode==1 { write_f64(res,g,bf_qat(scr,sz,0.25,sc)) }
+        else { if mode==2 { write_f64(res,g,bf_qat(scr,sz,0.75,sc)) }
+        else { if mode==3 { let q1=bf_qat(scr,sz,0.25,sc); j=0; while j<sz { write_f64(scr,j,read_f64(fval,base+j)); j=j+1 } let q3=bf_qat(scr,sz,0.75,sc); write_f64(res,g,q3-q1) }
+        else { let med=bf_qat(scr,sz,0.5,sc); j=0; while j<sz { let d=read_f64(fval,base+j)-med; if d<0.0 {write_f64(scr,j,0.0-d)} else {write_f64(scr,j,d)} j=j+1 } write_f64(res,g,bf_qat(scr,sz,0.5,sc)) } } } }
+        g=g+1 }
+    var out=bf_new(1,nr); out.n_rows=nr; let op=bf_col_ptr(&out,0) as *mut f64
+    r=0; while r<nr { write_f64(op,r,read_f64(res,read_i64(id,r))); r=r+1 }
+    heap_free(occ as *mut i8); heap_free(hk as *mut i8); heap_free(hid as *mut i8); heap_free(id as *mut i8); heap_free(sizes as *mut i8); heap_free(offsets as *mut i8); heap_free(cursor as *mut i8); heap_free(flat as *mut i8); heap_free(fval as *mut i8); heap_free(scr as *mut i8); heap_free(sc as *mut i8); heap_free(res as *mut i8)
+    out
+}
+/// Per-group MEDIAN, broadcast. Dense counting-sort + quickselect. NATIVE + lean_single.
+pub fn bf_median_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile(src, key_col, val_col, 0) }
+/// Per-group FIRST QUARTILE (q25), broadcast. NATIVE + lean_single.
+pub fn bf_q1_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile(src, key_col, val_col, 1) }
+/// Per-group THIRD QUARTILE (q75), broadcast. NATIVE + lean_single.
+pub fn bf_q3_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile(src, key_col, val_col, 2) }
+/// Per-group INTERQUARTILE RANGE (q75−q25), broadcast. NATIVE + lean_single.
+pub fn bf_iqr_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile(src, key_col, val_col, 3) }
+/// Per-group MEDIAN ABSOLUTE DEVIATION from the median (median|v−median|, robust spread),
+/// broadcast. NATIVE + lean_single only.
+pub fn bf_mad_median_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile(src, key_col, val_col, 4) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1544,6 +1544,31 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if bf_get(&clp,0,0) != 0.0 || bf_get(&clp,8,0) != 0.0 { print("FAIL cumcountleprev\n"); return 560 }  // monotone up
     let cpf = bf_cumcount_positive_frac_by(&stf,0,1)
     if !approx_eq(bf_get(&cpf,0,0), 1.0) || !approx_eq(bf_get(&cpf,8,0), 1.0) { print("FAIL cumcountposfrac\n"); return 561 }
+    // ===== CURATED BATCH (10 verbs) =====
+    // weighted skew/kurt on ccf (x={1,2,3,4} weighted by y={2,4,6,8}, wmean 3): wskew -0.6, wkurt -0.8.
+    let wsk = bf_weighted_skew_by(&ccf,0,1,2)
+    if !approx_eq(bf_get(&wsk,0,0), 0.0-0.6) { print("FAIL wskew\n"); return 562 }
+    let wku = bf_weighted_kurt_by(&ccf,0,1,2)
+    if !approx_eq(bf_get(&wku,0,0), 0.0-0.8) { print("FAIL wkurt\n"); return 563 }
+    // ratio mean/sum on ccf: x/y all 0.5 -> mean 0.5, sum 2.0.
+    let rmn = bf_ratio_mean_by(&ccf,0,1,2)
+    if !approx_eq(bf_get(&rmn,0,0), 0.5) { print("FAIL ratiomean\n"); return 564 }
+    let rsm = bf_ratio_sum_by(&ccf,0,1,2)
+    if !approx_eq(bf_get(&rsm,0,0), 2.0) { print("FAIL ratiosum\n"); return 565 }
+    // lag-2 autocorr on stf ({2,4,6,8,10} linear -> pairs perfectly correlated -> 1.0).
+    let lk = bf_lagk_autocorr_by(&stf,0,1,2)
+    if !approx_eq(bf_get(&lk,0,0), 1.0) { print("FAIL lagk\n"); return 566 }
+    // quantile family on stf: median 6, q1 4, q3 8, iqr 4, mad_median 2.
+    let med = bf_median_by(&stf,0,1)
+    if bf_get(&med,0,0) != 6.0 { print("FAIL median\n"); return 567 }
+    let q1b = bf_q1_by(&stf,0,1)
+    if bf_get(&q1b,0,0) != 4.0 { print("FAIL q1\n"); return 568 }
+    let q3b = bf_q3_by(&stf,0,1)
+    if bf_get(&q3b,0,0) != 8.0 { print("FAIL q3\n"); return 569 }
+    let iqb = bf_iqr_by(&stf,0,1)
+    if bf_get(&iqb,0,0) != 4.0 { print("FAIL iqr\n"); return 570 }
+    let mmb = bf_mad_median_by(&stf,0,1)
+    if bf_get(&mmb,0,0) != 2.0 { print("FAIL madmedian\n"); return 571 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
Curated higher-value per-group verbs (quality over count). **Analytic (win):** `bf_weighted_skew_by`/`bf_weighted_kurt_by` (2-col weighted moments), `bf_lagk_autocorr_by(k)`, `bf_ratio_mean_by`/`bf_ratio_sum_by` (x/y). **Robust quantile family (counting-sort + quickselect):** `bf_median_by`, `bf_q1_by`, `bf_q3_by`, `bf_iqr_by`, `bf_mad_median_by`. Gate: weighted skew −0.6/kurt −0.8, ratio_mean 0.5, lag-2 autocorr 1.0, median 6/q1 4/q3 8/iqr 4/mad_median 2. Offline: all match pandas/numpy over 8k rows = 0 diffs. Bench: weighted_skew 0.14× (win); median ~2.9× **honest loss** (quantile-bound, pandas Cython — maps to the C3 select dispatch). stdlib only, no compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)