### PR TITLE
docs(examples): grouped-analytics showcase — per-sensor measurement-QC pipeline over bigframe

### DIFF
--- a/examples/data/grouped_analytics_showcase.sio
+++ b/examples/data/grouped_analytics_showcase.sio
@@ -1,0 +1,88 @@
+// Grouped-analytics showcase: a per-sensor measurement-QC pipeline over data::bigframe,
+// composing ~10 of the ~130 grouped verbs end-to-end. All dense direct-index (heap
+// BigFrame, lean_single) -- each of these operations beats pandas' groupby at 1M rows.
+//
+// Scenario: 4 sensors (key col 0), each logging a reading (col 1) over time index (col 2)
+// with a per-reading weight/quality (col 3). Sensor 0 is a clean linear ramp; sensor 1
+// drifts then dips (a drawdown); sensor 2 is noisy around a mean; sensor 3 has an outlier.
+//
+// Run: SOUNIO_SOUC_ENGINE=lean_single ./bin/souc compile examples/data/grouped_analytics_showcase.sio -o out && ./out
+use data::bigframe::*
+use data::bigframe_ops::*
+
+fn approx(a: f64, b: f64) -> bool { let d=a-b; if d<0.0 { (0.0-d)<0.001 } else { d<0.001 } }
+
+fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
+    // Build 4 sensors x 6 readings = 24 rows. key=sensor, val=reading, t=time, w=weight.
+    var df = bf_new(4, 16)
+    // sensor 0: clean ramp 10,20,30,40,50,60 (slope 10/step)
+    // sensor 1: 100,110,120,90,80,95  (peak at 120 then drawdown to 80)
+    // sensor 2: 50,52,48,51,49,50      (noise ~50)
+    // sensor 3: 5,6,7,40,6,5           (outlier 40)
+    var s0: [f64;8] = [0.0;8]; s0[0]=10.0; s0[1]=20.0; s0[2]=30.0; s0[3]=40.0; s0[4]=50.0; s0[5]=60.0
+    var s1: [f64;8] = [0.0;8]; s1[0]=100.0; s1[1]=110.0; s1[2]=120.0; s1[3]=90.0; s1[4]=80.0; s1[5]=95.0
+    var s2: [f64;8] = [0.0;8]; s2[0]=50.0; s2[1]=52.0; s2[2]=48.0; s2[3]=51.0; s2[4]=49.0; s2[5]=50.0
+    var s3: [f64;8] = [0.0;8]; s3[0]=5.0; s3[1]=6.0; s3[2]=7.0; s3[3]=40.0; s3[4]=6.0; s3[5]=5.0
+    var sen: i64 = 0
+    while sen < 4 {
+        var j: i64 = 0
+        while j < 6 {
+            var row: [f64;64] = [0.0;64]
+            row[0] = sen as f64
+            if sen==0 { row[1]=s0[j] } else { if sen==1 { row[1]=s1[j] } else { if sen==2 { row[1]=s2[j] } else { row[1]=s3[j] } } }
+            row[2] = j as f64                     // time index within sensor
+            row[3] = 1.0                          // uniform weight
+            bf_push_row(&!df, &row, 4)
+            j = j + 1
+        }
+        sen = sen + 1
+    }
+
+    // 1. Per-sensor group id (sorted-key numbering).
+    let gid = bf_ngroup_by(&df, 0)
+    // 2. Per-sensor mean broadcast + z-score (population) for anomaly scoring.
+    let mean = bf_transform_mean_by(&df, 0, 1)
+    let z = bf_zscore_pop_by(&df, 0, 1)
+    // 3. 2-sigma outlier count per sensor (sensor 3's 40 should flag).
+    let nout = bf_count_outlier_2std_by(&df, 0, 1)
+    // 4. Drawdown: running peak-to-current (sensor 1 dips from 120 to 80 -> -40).
+    let dd = bf_max_drawdown_by(&df, 0, 1)
+    // 5. OLS trend: slope of reading vs time, and R^2 (sensor 0 is a perfect ramp).
+    let slope = bf_slope_by(&df, 0, 2, 1)
+    let r2 = bf_r2_by(&df, 0, 2, 1)
+    // 6. Dispersion: Fano factor (variance/mean) and coefficient of variation.
+    let fano = bf_fano_factor_by(&df, 0, 1)
+    let cv = bf_coefvar_by(&df, 0, 1)
+    // 7. Total variation (path length) -- how much the sensor moved overall.
+    let tv = bf_total_variation_by(&df, 0, 1)
+
+    // ---- run-proof: assert the headline per-sensor facts (row 0=sensor0, row6=sensor1, row18=sensor3) ----
+    if bf_get(&gid, 0, 0) != 0.0 || bf_get(&gid, 6, 0) != 1.0 { print("FAIL gid\n"); return 1 }
+    if !approx(bf_get(&mean, 0, 0), 35.0) { print("FAIL mean\n"); return 2 }         // sensor0 mean (10..60)
+    if bf_get(&z, 0, 0) >= 0.0 { print("FAIL zscore\n"); return 3 }                   // first ramp reading below mean
+    if bf_get(&nout, 18, 0) < 1.0 { print("FAIL outlier\n"); return 4 }              // sensor3 has the 40 outlier
+    if bf_get(&nout, 0, 0) != 0.0 { print("FAIL outlier_clean\n"); return 5 }         // sensor0 no outliers
+    if bf_get(&dd, 6, 0) != (0.0 - 40.0) { print("FAIL drawdown\n"); return 6 }       // sensor1 120->80
+    if !approx(bf_get(&slope, 0, 0), 10.0) { print("FAIL slope\n"); return 7 }        // sensor0 ramp slope 10
+    if !approx(bf_get(&r2, 0, 0), 1.0) { print("FAIL r2\n"); return 8 }               // sensor0 perfect fit
+    if bf_get(&fano, 2, 0) <= 0.0 { print("FAIL fano\n"); return 9 }
+
+    // ---- report ----
+    print("=== per-sensor measurement QC (composing grouped bigframe verbs) ===\n")
+    var srow: i64 = 0
+    while srow < 4 {
+        let base = srow * 6
+        print("sensor "); print(srow)
+        print(" | mean="); print(bf_get(&mean, base, 0) as i64)
+        print(" slope="); print(bf_get(&slope, base, 0) as i64)
+        print(" R2x100="); print((bf_get(&r2, base, 0) * 100.0) as i64)
+        print(" fanoX100="); print((bf_get(&fano, base, 0) * 100.0) as i64)
+        print(" maxdrawdown="); print(bf_get(&dd, base, 0) as i64)
+        print(" outliers2s="); print(bf_get(&nout, base, 0) as i64)
+        print(" totalvar="); print(bf_get(&tv, base, 0) as i64)
+        print("\n")
+        srow = srow + 1
+    }
+    print("SHOWCASE_OK\n")
+    return 0
+}


### PR DESCRIPTION
An end-to-end **per-sensor measurement-QC pipeline** composing ~10 grouped bigframe verbs (ngroup, transform_mean, zscore_pop, count_outlier_2std, max_drawdown, slope, r2, fano_factor, coefvar, total_variation) over a 4-sensor synthetic frame (clean ramp / drift-then-dip / noise / outlier).

Self-verifying (`SHOWCASE_OK`, exit 0): sensor 0 → mean 35, OLS slope 10, R² 1.0, 0 outliers; sensor 1 → max drawdown −40 (120→80); sensor 3 → flags its 40-reading as a 2σ outlier. Prints a per-sensor QC table. Proves the ~130-verb data lane composes into a real analytics workflow, not just isolated verbs.

New example file only — no stdlib/compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)