### PR TITLE
feat(bigframe): dense-bucket median/q1/q3/iqr (no quickselect) — flips quantile loss to a win

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -111,6 +111,7 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | **batch-12 (10 verbs, set 4)** — count_le_mean, count/frac_within_1std, count_outlier_2std, cummax/cummin_pct, sum_recip, cumsum_recip, cumsum_sign, cumcount_ge_prev | | | | **all win** | dense threshold/reciprocal/running passes vs pandas per-group lambdas |
 | **batch-13 (10 verbs, set 5)** — net_over_gross, sum_pos_frac, mean_pos/neg, count_changes, max_abs_dev, sum_sq_dev, cumsum_dev_abs, cumcount_le_prev, cumcount_positive_frac | | | | **all win** | dense sign/deviation/running passes vs pandas per-group lambdas — completes the +50 push (~130 grouped verbs total) |
 | **curated (10 verbs)** — weighted_skew/kurt, lag-k autocorr, ratio_mean/sum **win** (weighted_skew 0.14x); median/q1/q3/iqr **~2.9x loss** (quantile-bound, pandas Cython) + mad_median (no native, wins) | | | | mixed | analytic dense verbs win; quantile family maps to the C3 select dispatch |
+| median_dense_by / q1/q3/iqr_dense (1M rows, 1000 dense keys, int values 0..100) | | ~13.4 | ~32.9 | **0.41x — Sounio wins (2.4x)** | histogram bucket + cumulative-count walk, NO quickselect (flips the general median_by ~2.9x loss to a win for dense int values) |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -30,7 +30,8 @@
 // grouped num-increases/decreases/total-variation/mean-abs-change; autocorr1; is-running-max/min/max-drawdown/max-runup; count-ge-mean;
 // grouped count-le-mean/within-1std/frac-within-1std/outlier-2std; cummax-pct/cummin-pct; sum-recip/cumsum-recip/cumsum-sign; cumcount-ge-prev;
 // grouped net-over-gross/pos-frac/mean-pos/mean-neg/count-changes; max-abs-dev/sum-sq-dev/cumsum-dev-abs; cumcount-le-prev/positive-frac;
-// grouped weighted-skew/kurt; lag-k autocorr; ratio-mean/sum; median/q1/q3/iqr/mad-median (quantile-bound).
+// grouped weighted-skew/kurt; lag-k autocorr; ratio-mean/sum; median/q1/q3/iqr/mad-median (quantile-bound);
+// grouped median/q1/q3/iqr DENSE (histogram bucket, no quickselect -- beats pandas for dense int keys+values).
 // Each is an O(n)-expected pass (or two), allocates its result on the heap via
 // bf_new, and scales to the millions of rows a BigFrame holds. The reductions/joins
 // gather COLUMN-MAJOR through the raw column pointers (bf_col_ptr + read_f64/
@@ -6811,3 +6812,83 @@ pub fn bf_iqr_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Al
 /// Per-group MEDIAN ABSOLUTE DEVIATION from the median (median|v−median|, robust spread),
 /// broadcast. NATIVE + lean_single only.
 pub fn bf_mad_median_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile(src, key_col, val_col, 4) }
+
+// Linear-interpolated q-quantile of a per-group value histogram (base..base+vm1), via a
+// cumulative-count walk -- no sort/select. Returns the q-quantile order statistic with
+// pandas' linear interpolation.
+fn bf_qpos_from_hist(hist: *mut i64, base: i64, vm1: i64, sz: i64, q: f64) -> f64 with Mut, Div, Panic {
+    let pos = q * ((sz - 1) as f64)
+    let lo = pos as i64
+    let fr = pos - (lo as f64)
+    var cum: i64 = 0
+    var vlo = 0.0
+    var vhi = 0.0
+    var gotlo = false
+    var v: i64 = 0
+    while v < vm1 {
+        cum = cum + read_i64(hist, base + v)
+        if !gotlo && cum > lo { vlo = v as f64; gotlo = true }
+        if cum > lo + 1 { vhi = v as f64; v = vm1 } else { v = v + 1 }
+    }
+    if fr > 0.0 { vlo + fr * (vhi - vlo) } else { vlo }
+}
+
+/// Per-group QUANTILE-family BUCKET engine (dense integer keys AND values) shared by
+/// bf_median_dense_by / bf_q1_dense_by / bf_q3_dense_by / bf_iqr_dense_by: mode 0 median,
+/// 1 q25, 2 q75, 3 IQR (q75−q25), broadcast, with pandas' linear interpolation. Requires
+/// DENSE integer keys 0..1023 and DENSE integer values 0..`vmax`; builds a per-group value
+/// HISTOGRAM (one heap [1024·(vmax+1)] i64 table) and reads each order statistic by a
+/// cumulative-count walk -- **no sort and no quickselect**, O(n + 1024·(vmax+1)). For this
+/// regime it BEATS pandas' quickselect-based groupby.median (~0.41x at 1M/1000-groups,
+/// vmax≈100), flipping the general bf_median_by ~2.9x loss to a win. Rows whose key/value
+/// fall outside the dense range are ignored (their output is the raw value). For arbitrary
+/// f64 values use bf_median_by (quickselect). NATIVE + lean_single only (heap).
+fn bf_group_quantile_dense(src: &BigFrame, kc: i64, vc: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    let vm1 = vmax + 1
+    var cnt: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let ncol = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if kc < 0 || kc >= ncol || vc < 0 || vc >= ncol || n <= 0 || vmax < 0 { return out }
+    let kp = bf_col_ptr(src, kc) as *mut f64
+    let vp = bf_col_ptr(src, vc) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && v >= 0 && v < vm1 { write_i64(hist, k * vm1 + v, read_i64(hist, k * vm1 + v) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    let res = heap_alloc(1024 * 8) as *mut f64
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let sz = cnt[g] as i64
+            let base = g * vm1
+            if mode == 0 { write_f64(res, g, bf_qpos_from_hist(hist, base, vm1, sz, 0.5)) }
+            else { if mode == 1 { write_f64(res, g, bf_qpos_from_hist(hist, base, vm1, sz, 0.25)) }
+            else { if mode == 2 { write_f64(res, g, bf_qpos_from_hist(hist, base, vm1, sz, 0.75)) }
+            else { write_f64(res, g, bf_qpos_from_hist(hist, base, vm1, sz, 0.75) - bf_qpos_from_hist(hist, base, vm1, sz, 0.25)) } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, read_f64(res, k)) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    heap_free(res as *mut i8)
+    out
+}
+/// Per-group MEDIAN via a value histogram (dense integer keys 0..1023 + integer values
+/// 0..vmax; no sort/quickselect). Beats pandas' groupby.median in this regime -- the fast
+/// alternative to the general bf_median_by. Broadcast, linear-interpolated. NATIVE +
+/// lean_single only.
+pub fn bf_median_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_dense(src, key_col, val_col, vmax, 0) }
+/// Per-group FIRST QUARTILE (q25) via histogram (dense integer keys+values). Broadcast. NATIVE + lean_single.
+pub fn bf_q1_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_dense(src, key_col, val_col, vmax, 1) }
+/// Per-group THIRD QUARTILE (q75) via histogram (dense integer keys+values). Broadcast. NATIVE + lean_single.
+pub fn bf_q3_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_dense(src, key_col, val_col, vmax, 2) }
+/// Per-group INTERQUARTILE RANGE (q75−q25) via histogram (dense integer keys+values). Broadcast. NATIVE + lean_single.
+pub fn bf_iqr_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_dense(src, key_col, val_col, vmax, 3) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1569,6 +1569,20 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     if bf_get(&iqb,0,0) != 4.0 { print("FAIL iqr\n"); return 570 }
     let mmb = bf_mad_median_by(&stf,0,1)
     if bf_get(&mmb,0,0) != 2.0 { print("FAIL madmedian\n"); return 571 }
+    // ===== DENSE-BUCKET QUANTILE (median_dense/q1/q3/iqr, no quickselect) on stf ({2,4,6,8,10}) =====
+    let mdd = bf_median_dense_by(&stf,0,1,10)
+    if bf_get(&mdd,0,0) != 6.0 { print("FAIL median_dense\n"); return 572 }
+    let q1d = bf_q1_dense_by(&stf,0,1,10)
+    if bf_get(&q1d,0,0) != 4.0 { print("FAIL q1_dense\n"); return 573 }
+    let q3d = bf_q3_dense_by(&stf,0,1,10)
+    if bf_get(&q3d,0,0) != 8.0 { print("FAIL q3_dense\n"); return 574 }
+    let iqd = bf_iqr_dense_by(&stf,0,1,10)
+    if bf_get(&iqd,0,0) != 4.0 { print("FAIL iqr_dense\n"); return 575 }
+    // CROSS-CHECK: dense-bucket == general quickselect median on integer data (same result).
+    var qcd: i64 = 0; var qcj: i64 = 0
+    while qcj < 10 { if bf_get(&mdd,qcj,0) != bf_get(&med,qcj,0) { qcd = qcd + 1 }
+                     if bf_get(&q1d,qcj,0) != bf_get(&q1b,qcj,0) { qcd = qcd + 1 } qcj = qcj + 1 }
+    if qcd != 0 { print("FAIL dense_vs_quickselect\n"); return 576 }
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
Grouped order-statistics (`bf_median_dense_by`, `bf_q1_dense_by`, `bf_q3_dense_by`, `bf_iqr_dense_by`) for the **dense-integer regime** (keys `0..1023`, values `0..vmax`) computed via a **histogram bucket + cumulative-count walk** — O(n + G·vrange), **no quickselect**.

## Why
The general `bf_median_by` pays a hand-rolled quickselect that loses to pandas' Cython selection (~2.9× slower). For dense integer keys+values — the common measurement/sensor case — a histogram walk avoids selection entirely and **flips the loss to a win**.

## Numbers (1M rows, 1000 dense keys, reproduced locally)
| verb | Sounio | pandas | ratio |
|------|--------|--------|-------|
| median/q1/q3/iqr dense | ~13.4 ms | ~32.9 ms | **0.41× — wins 2.4×** |

## Verified
- Gate `test_bigframe_ops_stdlib.sio` (return codes 572–576) → `BIGFRAME_OPS_GATE_OK`, exit 0
- median/q1/q3/iqr exact vs known group
- cross-check: dense-bucket result **==** general quickselect result on integer data
- benchmark reproduced myself (not copied)

Files: `stdlib/data/bigframe_ops.sio`, `tests/stdlib/data/test_bigframe_ops_stdlib.sio`, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)