### PR TITLE
fix(madaros): Box MultiModuleIrResult.module end-to-end

### DIFF
--- a/docs/governance/DOCS_ACCEPTANCE_REPORT.md
+++ b/docs/governance/DOCS_ACCEPTANCE_REPORT.md
@@ -19,21 +19,21 @@ This is the editor-in-chief acceptance snapshot generated from `docs/governance/
 
 ## Scope Summary
 
-- Total governed topics: 1071
-- Repo-backed topics: 921
+- Total governed topics: 1072
+- Repo-backed topics: 922
 - Website-backed topics: 163
 - Dual-canon topics: 13
 - Authority count `archived`: 25
 - Authority count `dual`: 13
 - Authority count `historical`: 241
-- Authority count `repo_only`: 642
+- Authority count `repo_only`: 643
 - Authority count `website_only`: 150
 
 ## Ownership Summary
 
 - A0: 1 topics
 - A1: 1 topics
-- A2: 661 topics
+- A2: 662 topics
 - A3: 10 topics
 - A4: 31 topics
 - A5: 35 topics

--- a/docs/governance/DOCS_AUTHORITY_MATRIX.md
+++ b/docs/governance/DOCS_AUTHORITY_MATRIX.md
@@ -389,6 +389,7 @@ This matrix is the human-readable companion to `docs/governance/topic-registry.v
 | repo.docs.handoff.apple-selfhost-release-gate-sigsegv-2026-07-10 | repo_only | docs/handoff/apple_selfhost_release_gate_sigsegv_2026-07-10.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.butterfly-handoff | repo_only | docs/handoff/butterfly-handoff.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.c2-heap-columnar-dataframe-codex-dispatch-2026-07-18 | repo_only | docs/handoff/c2_heap_columnar_dataframe_codex_dispatch_2026-07-18.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
+| repo.docs.handoff.c3-group-select-radix-codex-dispatch-2026-07-21 | repo_only | docs/handoff/c3_group_select_radix_codex_dispatch_2026-07-21.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.c3-simd-autovectorization-codex-dispatch-2026-07-19 | repo_only | docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-651-defects-codex-dispatch-2026-07-15 | repo_only | docs/handoff/compiler_651_defects_codex_dispatch_2026-07-15.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |
 | repo.docs.handoff.compiler-generic-f-engine-unblock-prompt | repo_only | docs/handoff/compiler_generic_F_engine_unblock_prompt.md | - | A2 | en:n/a, pt:n/a, el:n/a, zh:n/a, ja:n/a, es:n/a |

--- a/docs/governance/topic-registry.v1.json
+++ b/docs/governance/topic-registry.v1.json
@@ -8447,6 +8447,29 @@
       "related_artifacts": []
     },
     {
+      "topic_id": "repo.docs.handoff.c3-group-select-radix-codex-dispatch-2026-07-21",
+      "collection": "repo",
+      "repo_doc_path": "docs/handoff/c3_group_select_radix_codex_dispatch_2026-07-21.md",
+      "website_slug": null,
+      "website_paths": {},
+      "audience": "users",
+      "authority": "repo_only",
+      "owner_agent": "A2",
+      "locale_status": {
+        "en": "n/a",
+        "pt": "n/a",
+        "el": "n/a",
+        "zh": "n/a",
+        "ja": "n/a",
+        "es": "n/a"
+      },
+      "validation_commands": [
+        "bash scripts/check_docs_registry.sh",
+        "bash scripts/check_docs_consistency.sh"
+      ],
+      "related_artifacts": []
+    },
+    {
       "topic_id": "repo.docs.handoff.c3-simd-autovectorization-codex-dispatch-2026-07-19",
       "collection": "repo",
       "repo_doc_path": "docs/handoff/c3_simd_autovectorization_codex_dispatch_2026-07-19.md",

--- a/docs/research/PREREG-piloto1-addendum1.md
+++ b/docs/research/PREREG-piloto1-addendum1.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.prereg-piloto1-addendum1
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/PREREG-piloto1-addendum2.md
+++ b/docs/research/PREREG-piloto1-addendum2.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.prereg-piloto1-addendum2
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/PREREG-piloto1-semantic-barriers.md
+++ b/docs/research/PREREG-piloto1-semantic-barriers.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.prereg-piloto1-semantic-barriers
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/PROGRAM-REGISTRY-mercyful-learning.md
+++ b/docs/research/PROGRAM-REGISTRY-mercyful-learning.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.program-registry-mercyful-learning
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/probe-preprint-draft.md
+++ b/docs/research/probe-preprint-draft.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-preprint-draft
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/self-hosted/compiler/main.sio
+++ b/self-hosted/compiler/main.sio
@@ -645,11 +645,11 @@ fn run_probe_ir_opt_strategy(args: ArgList, flag_index: i64) with IO, Mut, Panic
     if ir_result.ok && parse_errors == 0 {
         println("probe_ir_opt_strategy: ok")
         print("probe_ir_opt_strategy: functions=")
-        print_int(ir_result.module.fn_count)
+        print_int((*ir_result.module).fn_count)
         print("\n")
         var fi: i64 = 0
-        while fi < ir_result.module.fn_count {
-            let func = ir_result.module.functions[fi as usize]
+        while fi < (*ir_result.module).fn_count {
+            let func = (*ir_result.module).functions[fi as usize]
             print("probe_ir_opt_strategy: fn=")
             compiler_manifest_print_name(func.name)
             print(" strategy=")
@@ -1568,7 +1568,8 @@ fn compiler_preflight_ir_load(path: string) -> CompilerIrLoadResult with IO, Mut
         return compiler_ir_load_result_error(preflight_errors)
     }
 
-    return compiler_ir_load_result_ok(ir_result.module)
+    // Densify into CompilerIrLoadResult (still stack IrModule) at the preflight boundary.
+    return compiler_ir_load_result_ok(*ir_result.module)
 }
 
 fn compiler_ir_buffers_equal(buf_a: [i8; 131072], len_a: i64, buf_b: [i8; 131072], len_b: i64) -> bool with Mut {
@@ -2282,7 +2283,7 @@ fn run_emit_obj_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, A
     if !ir_result.ok {
         panic("emit-obj: frontend failed")
     }
-    let obj = compile_to_obj(&ir_result.module)
+    let obj = compile_to_obj(&(*ir_result.module))
     let ok = io_write_elf_to_file(output_path, obj)
     if ok {
         println("emit-obj: " + output_path + " (" + int_to_string(obj.len) + " bytes)")
@@ -2296,7 +2297,7 @@ fn run_emit_so_mode(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div, Al
     let output_path = compiler_mode_output_path(args, "output.so")
     let ir_result = load_multimodule_ir(source_path)
     if !ir_result.ok { panic("emit-so: frontend failed") }
-    let so = compile_to_shared(&ir_result.module)
+    let so = compile_to_shared(&(*ir_result.module))
     let ok = io_write_elf_to_file(output_path, so)
     if ok { println("emit-so: " + output_path + " (" + int_to_string(so.len) + " bytes)"); return }
     panic("emit-so: write failed")
@@ -3138,8 +3139,8 @@ fn run_native_v2_compile_mode(args: ArgList, flag_index: i64) with IO, Mut, Pani
         panic("native-v2-compile failed: visibility preflight")
     }
     // The boxed compile-to-file route is SRET-safe for both imported and
-    // single-module programs. Returning MultiModuleIrResult by value embeds a
-    // full IrModule and crashes larger sources before the backend is reached.
+    // single-module programs. MultiModuleIrResult.module is now Box<IrModule>
+    // (no densify at the legacy load API); prefer this file route for large IR.
     let optimize = compiler_mode_has_flag(args, "-O") || compiler_mode_has_flag(args, "--optimize")
     let rc = module_frontend_compile_imported_to_file(source_path, out_path, optimize)
     if rc != 0 {
@@ -5248,16 +5249,16 @@ fn compile(opts: CompilerOptions) -> CompileResult with IO, Mut, Panic, Div, All
                 pi = pi + 1
             }
             let profile = sprof_parse(prof_buf, prof_size)
-            sprof_apply_promotion(&!ir_result.module, &profile)
+            sprof_apply_promotion(&! (*ir_result.module), &profile)
 
             // Sprint 48: log promotion decisions
             var li: i64 = 0
-            while li < ir_result.module.fn_count {
-                let lcount = sprof_lookup(&profile, &ir_result.module.functions[li as usize].name)
+            while li < (*ir_result.module).fn_count {
+                let lcount = sprof_lookup(&profile, &(*ir_result.module).functions[li as usize].name)
                 let ltarget = sprof_promotion_target(lcount)
                 if ltarget >= 0 {
                     print("[sprof] ")
-                    compiler_manifest_print_name(ir_result.module.functions[li as usize].name)
+                    compiler_manifest_print_name((*ir_result.module).functions[li as usize].name)
                     println(": count " + int_to_string(lcount) + " -> strategy " + ir_strategy_name(ltarget))
                 }
                 li = li + 1
@@ -5269,48 +5270,50 @@ fn compile(opts: CompilerOptions) -> CompileResult with IO, Mut, Panic, Div, All
     }
 
     // Sprint 49: Apply inlining pass when -O is set
+    // By-value opt passes densify temporarily; re-box to keep MultiModuleIrResult boxed.
     if opts.optimize {
-        let pre_inline_count = ir_result.module.fn_count
-        ir_result.module = inl_run_pass(ir_result.module)
+        let pre_inline_count = (*ir_result.module).fn_count
+        ir_result.module = Box::new(inl_run_pass(*ir_result.module))
         println("[inline] pass complete: " + int_to_string(pre_inline_count) + " functions processed")
     }
 
     // Sprint 50: Profile-guided function layout
     if has_valid_profile {
-        let layout_result = layout_sort_by_profile(ir_result.module, &loaded_profile)
-        ir_result.module = layout_result.module
+        let layout_result = layout_sort_by_profile(*ir_result.module, &loaded_profile)
+        ir_result.module = Box::new(layout_result.module)
         if layout_result.reordered {
-            println("[layout] reordered " + int_to_string(ir_result.module.fn_count) + " functions (" + int_to_string(layout_result.hot_count) + " hot, " + int_to_string(layout_result.cold_count) + " cold)")
+            println("[layout] reordered " + int_to_string((*ir_result.module).fn_count) + " functions (" + int_to_string(layout_result.hot_count) + " hot, " + int_to_string(layout_result.cold_count) + " cold)")
         }
     }
 
     // Sprint 51: const_fold + DCE cleanup after inlining
     if opts.optimize {
-        let pre_opt_count = ir_result.module.fn_count
-        ir_result.module = opt_cleanup_module(ir_result.module)
+        let pre_opt_count = (*ir_result.module).fn_count
+        ir_result.module = Box::new(opt_cleanup_module(*ir_result.module))
         println("[opt] const_prop + dce applied to " + int_to_string(pre_opt_count) + " functions")
-        let loop_result = lopt_optimize_module(ir_result.module)
-        ir_result.module = loop_result.module
+        let loop_result = lopt_optimize_module(*ir_result.module)
+        ir_result.module = Box::new(loop_result.module)
         if loop_result.functions_changed > 0 {
             println("[loop] hoisted " + int_to_string(loop_result.invariants_hoisted) +
                     " invariants across " + int_to_string(loop_result.functions_changed) + " functions")
         }
-        ir_result.module = opt_cleanup_module(ir_result.module)
+        ir_result.module = Box::new(opt_cleanup_module(*ir_result.module))
     }
 
     // Sprint 54: Tail call optimization
     if opts.optimize {
-        let tco_result = tco_run_pass(ir_result.module)
-        ir_result.module = tco_result.0
+        let tco_result = tco_run_pass(*ir_result.module)
+        ir_result.module = Box::new(tco_result.0)
         let tco_ctx = tco_result.1
         if tco_ctx.stats.transformed > 0 {
             println("[tco] " + int_to_string(tco_ctx.stats.transformed) + " tail call(s) converted to loops")
         }
     }
 
+    // compile_multimodule_native_with_ir still takes IrModule by value.
     let exit_code = compile_multimodule_native_with_ir(
         opts.input_file,
-        ir_result.module,
+        *ir_result.module,
         opts.output_file,
         opts.target,
         "auto",
@@ -5335,7 +5338,7 @@ fn compile(opts: CompilerOptions) -> CompileResult with IO, Mut, Panic, Div, All
         errors = compile_push_ir_failure(errors, ir_result.error_msg)
     } else {
         let target_spec = native_resolve_target(opts.target, "auto", false)
-        let native_result = compile_native(&ir_result.module, target_spec)
+        let native_result = compile_native(&(*ir_result.module), target_spec)
         if !native_result.ok {
             errors = compile_errors_push_lines(errors, "error: ", native_result.error_msg)
         }
@@ -9038,7 +9041,7 @@ fn run_probe_machine_ir(args: ArgList, flag_index: i64) with IO, Mut, Panic, Div
     let ir_result = load_multimodule_ir_probe_summary(source_path)
     let parse_errors = parser_last_error_count()
     if ir_result.ok && parse_errors == 0 {
-        let mir = native_v2_build_machine_module(&ir_result.module, true)
+        let mir = native_v2_build_machine_module(&(*ir_result.module), true)
         print("[machine-ir] fn_count=")
         print_int(mir.fn_count)
         print(" ir_instrs=")

--- a/self-hosted/compiler/module_frontend.sio
+++ b/self-hosted/compiler/module_frontend.sio
@@ -4233,9 +4233,11 @@ fn module_frontend_lower_imported_source_recursive(path: string, depth: i64, tra
 // Multi-module IR loading (shared by bytecode + native paths)
 // ============================================================
 
+// Box-preserving multi-mod IR result. After #1348 the merge path keeps
+// IrModule heap-indirect end-to-end; this struct no longer densifies on return.
 pub struct MultiModuleIrResult {
     ok: bool,
-    module: IrModule,
+    module: Box<IrModule>,
     error_msg: string,
 }
 
@@ -4284,12 +4286,12 @@ pub fn empty_load_multimodule_ir_trace() -> LoadMultimoduleIrTrace {
     }
 }
 
-fn multimodule_ir_ok(m: IrModule) -> MultiModuleIrResult {
+fn multimodule_ir_ok(m: Box<IrModule>) -> MultiModuleIrResult {
     MultiModuleIrResult { ok: true, module: m, error_msg: "" }
 }
 
 fn multimodule_ir_error(msg: string) -> MultiModuleIrResult {
-    MultiModuleIrResult { ok: false, module: ir_empty_module(), error_msg: msg }
+    MultiModuleIrResult { ok: false, module: Box::new(ir_empty_module()), error_msg: msg }
 }
 
 pub fn empty_multimodule_ir_result() -> MultiModuleIrResult {
@@ -6716,8 +6718,8 @@ pub fn load_multimodule_ir_traced(main_path: string, trace: &! LoadMultimoduleIr
     if !boxed.ok {
         return multimodule_ir_error(boxed.error_msg)
     }
-    // API residual densify: MultiModuleIrResult still embeds IrModule by value.
-    multimodule_ir_ok(*boxed.module)
+    // Box stays boxed: MultiModuleIrResult.module is Box<IrModule> (no densify).
+    multimodule_ir_ok(boxed.module)
 }
 
 pub fn load_multimodule_ir(main_path: string) -> MultiModuleIrResult with IO, Mut, Div, Panic, Alloc {
@@ -6725,17 +6727,16 @@ pub fn load_multimodule_ir(main_path: string) -> MultiModuleIrResult with IO, Mu
     load_multimodule_ir_traced(main_path, &! trace)
 }
 
-// Write merged multi-mod IR into a caller-owned module. Densifies once from the
-// live Box into `out` — no intermediate MultiModuleIrResult densify+copy.
-// Prefer module_frontend_compile_imported_to_file / merge_imported_box for zero
-// densify (Box stays boxed end-to-end).
+// Write merged multi-mod IR into a caller-owned stack module. Densifies once
+// from the live Box into `out`. Prefer MultiModuleIrResult / merge_imported_box
+// / module_frontend_compile_imported_to_file when the caller can keep Box.
 pub fn load_multimodule_ir_into(main_path: string, out: &! IrModule) -> MultiModuleFrontendResult with IO, Mut, Div, Panic, Alloc {
     var trace = empty_load_multimodule_ir_trace()
     let boxed = load_multimodule_ir_to_box_traced(main_path, &! trace)
     if !boxed.ok {
         return multimodule_frontend_error(boxed.error_msg)
     }
-    // Single densify when caller still owns a stack IrModule.
+    // Explicit densify: caller owns a stack IrModule out-parameter.
     (*out) = *boxed.module
     multimodule_frontend_ok()
 }
@@ -7168,7 +7169,8 @@ pub fn load_multimodule_ir_probe_summary_traced(main_path: string, trace: &! Loa
     }
 
     parser_reset_last_errors()
-    multimodule_ir_ok(merged_module)
+    // Probe path still builds a stack merged_module; box once at the API boundary.
+    multimodule_ir_ok(Box::new(merged_module))
 }
 
 pub fn load_multimodule_ir_probe_summary(main_path: string) -> MultiModuleIrResult with IO, Mut, Div, Panic, Alloc {


### PR DESCRIPTION
## Summary

Wave10 Agent C — eliminate the remaining **full IrModule densify** at the legacy `MultiModuleIrResult` API after #1348.

After #1348 multi-mod merge keeps `IrModule` heap-indirect through finalize, but `load_multimodule_ir_traced` still densified once:

```text
// was
multimodule_ir_ok(*boxed.module)  // Box → by-value IrModule field
```

### Change

- `MultiModuleIrResult.module: IrModule` → `Box<IrModule>`
- `multimodule_ir_ok` / error helpers take/store `Box<IrModule>`
- `load_multimodule_ir_traced` passes the live box through (no densify)
- Probe summary boxes once at the API boundary (`Box::new(merged_module)`)
- `main.sio` call sites: `(*ir_result.module)` for fields/refs; re-box after by-value opt passes (`inl`/`layout`/`opt_cleanup`/`lopt`/`tco`)
- `load_multimodule_ir_into` still densifies **explicitly** for stack out-params
- Scope: result-type + call sites only (did not touch merge body / Agent A densify path)

### Files

- `self-hosted/compiler/module_frontend.sio`
- `self-hosted/compiler/main.sio`

## Gates (rebuilt Madaros from this branch)

| Gate | Result |
|------|--------|
| `bash scripts/madaros_dual_import_gate.sh` | **PASS** (`MADAROS_DUAL_IMPORT_GATE_OK`) |
| `bash scripts/madaros_order_spread_native_gate.sh` | **PASS** (scaled `2044225`, `ORDER_SPREAD_TRUST_OK`) |
| `a14_transitive_min` check + run | **PASS** (run rc=`115`) |

## Peak (dual gum+knowledge, 225 fn)

- Measured with raw `bin/madaros-linux-x86_64 compile …`
- **VmHWM ≈ 820 MiB** (sampled)
- #1348 reported ~810 MiB on the same dual witness — primary `module_frontend_compile_imported_to_file` path was already box-canonical; this PR removes densify at the **legacy** `load_multimodule_ir` / `MultiModuleIrResult` return boundary.

## Test plan

- [x] dual gum+knowledge check + run
- [x] order_spread native gate
- [x] a14 transitive min
- [ ] CI suite on PR