### PR TITLE
feat(bigframe): batch 11 — distributional + boolean positivity (10 verbs, all win)

### DIFF
--- a/scripts/bench/RESULTS.md
+++ b/scripts/bench/RESULTS.md
@@ -112,6 +112,11 @@ directly (not taken from a subagent). col_sum agrees with pandas bit-for-bit (49
 | **batch-13 (10 verbs, set 5)** — net_over_gross, sum_pos_frac, mean_pos/neg, count_changes, max_abs_dev, sum_sq_dev, cumsum_dev_abs, cumcount_le_prev, cumcount_positive_frac | | | | **all win** | dense sign/deviation/running passes vs pandas per-group lambdas — completes the +50 push (~130 grouped verbs total) |
 | **curated (10 verbs)** — weighted_skew/kurt, lag-k autocorr, ratio_mean/sum **win** (weighted_skew 0.14x); median/q1/q3/iqr **~2.9x loss** (quantile-bound, pandas Cython) + mad_median (no native, wins) | | | | mixed | analytic dense verbs win; quantile family maps to the C3 select dispatch |
 | median_dense_by / q1/q3/iqr_dense (1M rows, 1000 dense keys, int values 0..100) | | ~13.4 | ~32.9 | **0.41x — Sounio wins (2.4x)** | histogram bucket + cumulative-count walk, NO quickselect (flips the general median_by ~2.9x loss to a win for dense int values) |
+| nunique_dense_by (1M rows, 1000 dense keys, vmax=100) | | ~14.3 | ~42.8 | **0.33x — wins 3x** | value histogram, no sort |
+| mode_dense_by / mode_count/mode_frac | | ~14.3 | ~164 | **0.09x — wins 11x** | pandas mode = per-group lambda |
+| gini_impurity_dense_by / simpson_dense | | ~14.2 | ~261 | **0.05x — wins 20x** | pandas = value_counts lambda |
+| any_positive_by / all_positive_by | | ~11.3 | ~13.6 | **0.83x — wins** | dense boolean reduction (beats native transform-max) |
+| cumany_positive_by / cumall_positive_by | | ~7.9 | ~18.0 | **0.44x — wins 2.3x** | single ordered pass (beats groupby.cummax) |
 | cov (1M rows, two-pass mean-shift) | | 6.7 | 8.5 | **0.78x — Sounio wins** | (new verb) |
 | corr (1M rows, two-pass + bf_sqrt) | | 10.3 | 8.0 | **~1.3x** | (new verb) |
 | median (1M rows, quickselect) | | ~34 | ~16 | **~2.2x** | numpy SIMD introselect |

--- a/stdlib/data/bigframe_ops.sio
+++ b/stdlib/data/bigframe_ops.sio
@@ -6892,3 +6892,153 @@ pub fn bf_q1_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> 
 pub fn bf_q3_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_dense(src, key_col, val_col, vmax, 2) }
 /// Per-group INTERQUARTILE RANGE (q75−q25) via histogram (dense integer keys+values). Broadcast. NATIVE + lean_single.
 pub fn bf_iqr_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_quantile_dense(src, key_col, val_col, vmax, 3) }
+
+/// Per-group value-DISTRIBUTION statistics via a value histogram (dense integer keys 0..1023
+/// + integer values 0..vmax; no sort). Pass 1 fills hist[k*vm1+v]++ and cnt[k]; per-group
+/// scan of the vm1 buckets derives distinct-count, mode (argmax value, smallest on ties), mode
+/// frequency and Σfreq² (for concentration/impurity). Broadcast per key. O(n + G·vrange).
+/// modes: 0=nunique 1=mode(value) 2=mode_count 3=mode_frac 4=gini_impurity(1-Σp²) 5=simpson(Σp²).
+/// NATIVE + lean_single only.
+fn bf_group_dist_dense(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt:  [f64; 1024] = [0.0; 1024]
+    var dist: [f64; 1024] = [0.0; 1024]
+    var mval: [f64; 1024] = [0.0; 1024]
+    var mfrq: [f64; 1024] = [0.0; 1024]
+    var ssq:  [f64; 1024] = [0.0; 1024]
+    var res:  [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 || vmax < 0 { return out }
+    let vm1 = vmax + 1
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    let hist = heap_alloc(1024 * vm1 * 8) as *mut i64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        let v = read_f64(vp, i) as i64
+        if k >= 0 && k < 1024 && v >= 0 && v < vm1 { write_i64(hist, k * vm1 + v, read_i64(hist, k * vm1 + v) + 1); cnt[k] = cnt[k] + 1.0 }
+        i = i + 1
+    }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            let base = g * vm1
+            var v: i64 = 0
+            var best: i64 = 0
+            var bestv: i64 = 0
+            var nd = 0.0
+            var sq = 0.0
+            while v < vm1 {
+                let f = read_i64(hist, base + v)
+                if f > 0 {
+                    nd = nd + 1.0
+                    sq = sq + (f as f64) * (f as f64)
+                    if f > best { best = f; bestv = v }
+                }
+                v = v + 1
+            }
+            dist[g] = nd
+            mval[g] = bestv as f64
+            mfrq[g] = best as f64
+            ssq[g] = sq
+        }
+        g = g + 1
+    }
+    g = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            if mode == 0 { res[g] = dist[g] }
+            else { if mode == 1 { res[g] = mval[g] }
+            else { if mode == 2 { res[g] = mfrq[g] }
+            else { if mode == 3 { res[g] = mfrq[g] / cnt[g] }
+            else { if mode == 4 { res[g] = 1.0 - ssq[g] / (cnt[g] * cnt[g]) }
+            else { res[g] = ssq[g] / (cnt[g] * cnt[g]) } } } } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, read_f64(vp, i)) } i = i + 1 }
+    heap_free(hist as *mut i8)
+    out
+}
+/// Per-group number of DISTINCT integer values (pandas groupby.nunique), broadcast. Dense
+/// keys 0..1023 + values 0..vmax via a value histogram (no sort). NATIVE + lean_single only.
+pub fn bf_nunique_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dist_dense(src, key_col, val_col, vmax, 0) }
+/// Per-group MODE (most-frequent integer value, smallest on ties), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_mode_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dist_dense(src, key_col, val_col, vmax, 1) }
+/// Per-group MODE FREQUENCY (count of the most-frequent value), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_mode_count_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dist_dense(src, key_col, val_col, vmax, 2) }
+/// Per-group PLURALITY SHARE (mode frequency / group size), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_mode_frac_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dist_dense(src, key_col, val_col, vmax, 3) }
+/// Per-group GINI IMPURITY (1 − Σpᵢ² over the value distribution), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_gini_impurity_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dist_dense(src, key_col, val_col, vmax, 4) }
+/// Per-group SIMPSON CONCENTRATION (Σpᵢ² / Herfindahl over the value distribution), broadcast. Dense histogram. NATIVE + lean_single.
+pub fn bf_simpson_dense_by(src: &BigFrame, key_col: i64, val_col: i64, vmax: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_dist_dense(src, key_col, val_col, vmax, 5) }
+
+/// Per-group BOOLEAN POSITIVITY reductions, broadcast. Dense keys 0..1023. One pass counts
+/// per-group size and #positive; mode 0 = any(v>0)?1:0, mode 1 = all(v>0)?1:0. O(n).
+/// NATIVE + lean_single only.
+fn bf_group_boolpos(src: &BigFrame, key_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var cnt: [f64; 1024] = [0.0; 1024]
+    var pos: [f64; 1024] = [0.0; 1024]
+    var res: [f64; 1024] = [0.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { cnt[k] = cnt[k] + 1.0; if read_f64(vp, i) > 0.0 { pos[k] = pos[k] + 1.0 } } i = i + 1 }
+    var g: i64 = 0
+    while g < 1024 {
+        if cnt[g] > 0.0 {
+            if mode == 0 { if pos[g] > 0.0 { res[g] = 1.0 } } else { if pos[g] == cnt[g] { res[g] = 1.0 } }
+        }
+        g = g + 1
+    }
+    i = 0
+    while i < n { let k = read_f64(kp, i) as i64; if k >= 0 && k < 1024 { write_f64(op, i, res[k]) } else { write_f64(op, i, 0.0) } i = i + 1 }
+    out
+}
+/// Per-group ANY-POSITIVE flag (1 if any value > 0 in the group, else 0), broadcast. Dense keys. NATIVE + lean_single.
+pub fn bf_any_positive_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_boolpos(src, key_col, val_col, 0) }
+/// Per-group ALL-POSITIVE flag (1 if every value > 0 in the group, else 0), broadcast. Dense keys. NATIVE + lean_single.
+pub fn bf_all_positive_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_group_boolpos(src, key_col, val_col, 1) }
+
+/// Per-group CUMULATIVE BOOLEAN positivity in row order (dense keys 0..1023). Single ordered
+/// pass keeps per-group running state; mode 0 = cum-ANY (1 once a positive has appeared),
+/// mode 1 = cum-ALL (1 while every value so far is positive). O(n). NATIVE + lean_single only.
+fn bf_cumboolpos(src: &BigFrame, key_col: i64, val_col: i64, mode: i64) -> BigFrame with Alloc, Mut, Div, Panic {
+    var seen: [f64; 1024] = [0.0; 1024]
+    var allp: [f64; 1024] = [1.0; 1024]
+    let n = bf_nrows(src)
+    let nc = bf_ncols(src)
+    var out = bf_new(1, n)
+    out.n_rows = n
+    if key_col < 0 || key_col >= nc || val_col < 0 || val_col >= nc || n <= 0 { return out }
+    let kp = bf_col_ptr(src, key_col) as *mut f64
+    let vp = bf_col_ptr(src, val_col) as *mut f64
+    let op = bf_col_ptr(&out, 0) as *mut f64
+    var i: i64 = 0
+    while i < n {
+        let k = read_f64(kp, i) as i64
+        if k >= 0 && k < 1024 {
+            let v = read_f64(vp, i)
+            if v > 0.0 { seen[k] = 1.0 } else { allp[k] = 0.0 }
+            if mode == 0 { write_f64(op, i, seen[k]) } else { write_f64(op, i, allp[k]) }
+        } else { write_f64(op, i, 0.0) }
+        i = i + 1
+    }
+    out
+}
+/// Per-group CUMULATIVE ANY-POSITIVE (1 from the first positive onward, in row order), per row. Dense keys. NATIVE + lean_single.
+pub fn bf_cumany_positive_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_cumboolpos(src, key_col, val_col, 0) }
+/// Per-group CUMULATIVE ALL-POSITIVE (1 while every value seen so far is positive, in row order), per row. Dense keys. NATIVE + lean_single.
+pub fn bf_cumall_positive_by(src: &BigFrame, key_col: i64, val_col: i64) -> BigFrame with Alloc, Mut, Div, Panic { bf_cumboolpos(src, key_col, val_col, 1) }

--- a/tests/stdlib/data/test_bigframe_ops_stdlib.sio
+++ b/tests/stdlib/data/test_bigframe_ops_stdlib.sio
@@ -1583,6 +1583,59 @@ fn main() -> i32 with IO, Mut, Div, Panic, Alloc {
     while qcj < 10 { if bf_get(&mdd,qcj,0) != bf_get(&med,qcj,0) { qcd = qcd + 1 }
                      if bf_get(&q1d,qcj,0) != bf_get(&q1b,qcj,0) { qcd = qcd + 1 } qcj = qcj + 1 }
     if qcd != 0 { print("FAIL dense_vs_quickselect\n"); return 576 }
+    // ===== BATCH 11: distributional (dense histogram) + boolean positivity =====
+    // dist frame: g0 vals {2,2,3,0}, g1 vals {5,5,5,5}. vmax=5.
+    var dbf = bf_new(2, 8)
+    var dr0:[f64;64]=[0.0;64]; dr0[0]=0.0; dr0[1]=2.0; bf_push_row(&!dbf,&dr0,2)
+    var dr1:[f64;64]=[0.0;64]; dr1[0]=0.0; dr1[1]=2.0; bf_push_row(&!dbf,&dr1,2)
+    var dr2:[f64;64]=[0.0;64]; dr2[0]=0.0; dr2[1]=3.0; bf_push_row(&!dbf,&dr2,2)
+    var dr3:[f64;64]=[0.0;64]; dr3[0]=0.0; dr3[1]=0.0; bf_push_row(&!dbf,&dr3,2)
+    var dr4:[f64;64]=[0.0;64]; dr4[0]=1.0; dr4[1]=5.0; bf_push_row(&!dbf,&dr4,2)
+    var dr5:[f64;64]=[0.0;64]; dr5[0]=1.0; dr5[1]=5.0; bf_push_row(&!dbf,&dr5,2)
+    var dr6:[f64;64]=[0.0;64]; dr6[0]=1.0; dr6[1]=5.0; bf_push_row(&!dbf,&dr6,2)
+    var dr7:[f64;64]=[0.0;64]; dr7[0]=1.0; dr7[1]=5.0; bf_push_row(&!dbf,&dr7,2)
+    let nud = bf_nunique_dense_by(&dbf,0,1,5)
+    if bf_get(&nud,0,0) != 3.0 { print("FAIL nunique_g0\n"); return 577 }   // {0,2,3}
+    if bf_get(&nud,4,0) != 1.0 { print("FAIL nunique_g1\n"); return 578 }   // {5}
+    let mod1 = bf_mode_dense_by(&dbf,0,1,5)
+    if bf_get(&mod1,0,0) != 2.0 { print("FAIL mode_g0\n"); return 579 }     // 2 appears twice
+    if bf_get(&mod1,4,0) != 5.0 { print("FAIL mode_g1\n"); return 580 }
+    let mcd = bf_mode_count_dense_by(&dbf,0,1,5)
+    if bf_get(&mcd,0,0) != 2.0 { print("FAIL modecount_g0\n"); return 581 }
+    if bf_get(&mcd,4,0) != 4.0 { print("FAIL modecount_g1\n"); return 582 }
+    let mfd = bf_mode_frac_dense_by(&dbf,0,1,5)
+    if !approx_eq(bf_get(&mfd,0,0), 0.5) { print("FAIL modefrac_g0\n"); return 583 }   // 2/4
+    if !approx_eq(bf_get(&mfd,4,0), 1.0) { print("FAIL modefrac_g1\n"); return 584 }
+    let gid = bf_gini_impurity_dense_by(&dbf,0,1,5)
+    if !approx_eq(bf_get(&gid,0,0), 0.625) { print("FAIL gini_g0\n"); return 585 }     // 1-(1+4+1)/16
+    if !approx_eq(bf_get(&gid,4,0), 0.0) { print("FAIL gini_g1\n"); return 586 }        // pure
+    let sid = bf_simpson_dense_by(&dbf,0,1,5)
+    if !approx_eq(bf_get(&sid,0,0), 0.375) { print("FAIL simpson_g0\n"); return 587 }
+    if !approx_eq(bf_get(&sid,4,0), 1.0) { print("FAIL simpson_g1\n"); return 588 }
+    // boolean positivity frame: g0={-1,2,-3}, g1={4,5,6}, g2={-1,-2}. row order per group preserved.
+    var bpf = bf_new(2, 8)
+    var br0:[f64;64]=[0.0;64]; br0[0]=0.0; br0[1]=0.0-1.0; bf_push_row(&!bpf,&br0,2)  // idx0 g0
+    var br1:[f64;64]=[0.0;64]; br1[0]=1.0; br1[1]=4.0;     bf_push_row(&!bpf,&br1,2)  // idx1 g1
+    var br2:[f64;64]=[0.0;64]; br2[0]=0.0; br2[1]=2.0;     bf_push_row(&!bpf,&br2,2)  // idx2 g0
+    var br3:[f64;64]=[0.0;64]; br3[0]=1.0; br3[1]=5.0;     bf_push_row(&!bpf,&br3,2)  // idx3 g1
+    var br4:[f64;64]=[0.0;64]; br4[0]=0.0; br4[1]=0.0-3.0; bf_push_row(&!bpf,&br4,2)  // idx4 g0
+    var br5:[f64;64]=[0.0;64]; br5[0]=1.0; br5[1]=6.0;     bf_push_row(&!bpf,&br5,2)  // idx5 g1
+    var br6:[f64;64]=[0.0;64]; br6[0]=2.0; br6[1]=0.0-1.0; bf_push_row(&!bpf,&br6,2)  // idx6 g2
+    var br7:[f64;64]=[0.0;64]; br7[0]=2.0; br7[1]=0.0-2.0; bf_push_row(&!bpf,&br7,2)  // idx7 g2
+    let anyp = bf_any_positive_by(&bpf,0,1)
+    if bf_get(&anyp,0,0) != 1.0 { print("FAIL anypos_g0\n"); return 589 }
+    if bf_get(&anyp,6,0) != 0.0 { print("FAIL anypos_g2\n"); return 590 }
+    let allp = bf_all_positive_by(&bpf,0,1)
+    if bf_get(&allp,0,0) != 0.0 { print("FAIL allpos_g0\n"); return 591 }
+    if bf_get(&allp,1,0) != 1.0 { print("FAIL allpos_g1\n"); return 592 }
+    let cany = bf_cumany_positive_by(&bpf,0,1)
+    if bf_get(&cany,0,0) != 0.0 { print("FAIL cumany_g0r0\n"); return 593 }   // -1
+    if bf_get(&cany,2,0) != 1.0 { print("FAIL cumany_g0r1\n"); return 594 }   // 2 seen
+    if bf_get(&cany,4,0) != 1.0 { print("FAIL cumany_g0r2\n"); return 595 }   // stays 1
+    let call = bf_cumall_positive_by(&bpf,0,1)
+    if bf_get(&call,1,0) != 1.0 { print("FAIL cumall_g1r0\n"); return 596 }   // 4>0
+    if bf_get(&call,0,0) != 0.0 { print("FAIL cumall_g0r0\n"); return 597 }   // -1
+    if bf_get(&call,6,0) != 0.0 { print("FAIL cumall_g2r0\n"); return 598 }   // -1
     print("BIGFRAME_OPS_GATE_OK\n")
     } else {
         print("BIGFRAME_OPS_FAIL\n")


### PR DESCRIPTION
## What
10 new grouped verbs across 3 dense engines — all beating pandas at 1M rows.

**Distributional** (`bf_group_dist_dense`, value histogram, no sort):
- `bf_nunique_dense_by` — distinct value count
- `bf_mode_dense_by` / `bf_mode_count_dense_by` / `bf_mode_frac_dense_by` — mode, its frequency, plurality share
- `bf_gini_impurity_dense_by` (1−Σp²) / `bf_simpson_dense_by` (Σp², Herfindahl)

**Boolean positivity** (`bf_group_boolpos`, dense reduction):
- `bf_any_positive_by` / `bf_all_positive_by`

**Cumulative boolean** (`bf_cumboolpos`, single ordered pass):
- `bf_cumany_positive_by` / `bf_cumall_positive_by`

## Numbers (1M rows, 1000 dense keys, values 0..100, reproduced locally)
| verb | Sounio | pandas 3.0.3 | ratio |
|---|---|---|---|
| nunique_dense | 14.3 ms | 42.8 ms | **0.33× (3×)** |
| mode_dense | 14.3 ms | 164 ms | **0.09× (11×)** |
| gini_impurity_dense | 14.2 ms | 261 ms | **0.05× (20×)** |
| any_positive | 11.3 ms | 13.6 ms | **0.83×** |
| cumany_positive | 7.9 ms | 18.0 ms | **0.44× (2.3×)** |

pandas has no fast native for mode / value-count distributions (per-group lambda), so those are landslides; the boolean verbs beat even pandas' native `transform('max')` / `groupby.cummax`.

## Verified
- Gate `test_bigframe_ops_stdlib.sio` return codes **577–598** → `BIGFRAME_OPS_GATE_OK`, exit 0
- distributional exact vs hand-computed groups `{2,2,3,0}`/`{5,5,5,5}`
- boolean/cumulative exact vs mixed-sign groups with per-group row order checked
- benchmarks reproduced myself (not copied)

Files: `stdlib/data/bigframe_ops.sio`, its gate test, `scripts/bench/RESULTS.md` (my disjoint lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)