### PR TITLE
docs(research): verify Piloto 1 + probe preprint citations

### DIFF
--- a/docs/research/PREREG-piloto1-semantic-barriers.md
+++ b/docs/research/PREREG-piloto1-semantic-barriers.md
@@ -195,11 +195,40 @@ Independente deste piloto e ainda em aberto desde o O-SSM: **demonstrar recupera
 
 Nota metodológica curta, com o negativo (se for o caso) em destaque e não em rodapé. Se positivo, é a §A.2 do registro deixando de ser conjectura — e a pergunta afiada que justifica uma submissão ao CEP.
 
+---
+
+## Apêndice — Referências (verificadas 2026-07-21)
+
+> **Nota de verificação.** As entradas abaixo fundamentam afirmações de literatura do corpo do
+> pré-registro e foram **acrescentadas após o registro** (não fazem parte do corpo carimbado de 20/07).
+> Verificação por checagem independente de título+autor: **existência, autoria, venue e DOI confirmados**;
+> retração/correção checada via scite (`retraction_notices` ausente = sem retração) para as entradas 1–3.
+> O DOI da entrada 3 foi **corrigido** nesta verificação — uma inferência inicial apontava para
+> `10.1038/s41598-019-40871-5` (*Sci Rep*), que o registro real resolve para um artigo não relacionado;
+> o correto é *Nat Commun* abaixo.
+
+1. **Sonho como modelo de psicose** (§2, §7) — Scarone S, Manzone ML, Gambini O, Kantzas I, Limosani I,
+   D'Agostino A, Hobson JA. The dream as a model for psychosis: an experimental approach using bizarreness
+   as a cognitive marker. *Schizophr Bull*. 2008;34(3):515–22. doi:10.1093/schbul/sbm116. *(sem retração)*
+2. **Falha de monitorização da fonte** (§2) — Johnson MK, Hashtroudi S, Lindsay DS. Source monitoring.
+   *Psychol Bull*. 1993;114(1):3–28. doi:10.1037/0033-2909.114.1.3. *(sem retração)*
+3. **Curvatura de Ollivier–Ricci com precedente em psicopatologia** (§3.2) — Farooq H, Chen Y, Georgiou TT,
+   Tannenbaum A, Lenglet C. Network curvature as a hallmark of brain structural connectivity.
+   *Nat Commun*. 2019;10:4937. doi:10.1038/s41467-019-12915-x. *(sem retração)* — **Ressalva:** o precedente
+   firme é conectividade estrutural/envelhecimento e transtornos do neurodesenvolvimento (p.ex. TEA), **não**
+   depressão. Ler §3.2 como "precedente em psicopatologia geral", não "em depressão".
+4. **Normas Hall/Van de Castle e disponibilização no DreamBank** (§2) — Domhoff GW. *The Scientific Study of
+   Dreams: Neural Networks, Cognitive Development, and Content Analysis*. Washington, DC: American
+   Psychological Association; 2003.
+
 ## Divulgação de uso de IA (GAIDeT / ICMJE 2025)
 
 - **Claude Opus 4.8 (Claude Code)** — verificação dos termos de uso e do inventário de séries do DreamBank
   por tamanho (resolução do `[FILL]` bloqueante de §2), fixação dos parâmetros de execução (§3.1, §4, §6.2),
   formatação e registro deste pré-registro. Implementação e execução do pipeline (pós-registro) sob a mesma
   divulgação.
+- **Claude Fable 5 (Claude Code)** — verificação bibliográfica do Apêndice de Referências (2026-07-21) via
+  scite MCP + busca independente por WebSearch; correção do DOI da entrada 3. Nenhuma citação foi gerada sem
+  recuperação do registro real.
 
 O autor revisou, verificou e assume responsabilidade integral pelo conteúdo, incluindo todos os resultados numéricos e sua interpretação.

--- a/docs/research/probe-preprint-draft.md
+++ b/docs/research/probe-preprint-draft.md
@@ -66,15 +66,15 @@ We regard (4) and (6) as the substantive contributions. (6) in particular: the i
 
 ## 2. Related work
 
-**Dynamical isometry.** Saxe et al. and Pennington et al. established the programme of controlling the entire singular spectrum of the input–output Jacobian near unity, and the mean-field machinery for predicting when this is achievable. The criterion is by construction a bulk criterion: it is satisfied by a composition in which a low-dimensional subspace has been extinguished, provided the remaining directions are well conditioned. [CHECK: exact statements and citations]
+**Dynamical isometry.** Saxe et al. and Pennington et al. established the programme of controlling the entire singular spectrum of the input–output Jacobian near unity, and the mean-field machinery for predicting when this is achievable. The criterion is by construction a bulk criterion: it is satisfied by a composition in which a low-dimensional subspace has been extinguished, provided the remaining directions are well conditioned. [1,2]
 
-**Lyapunov spectra of recurrent networks.** The spectrum of $P_T$ as $T$ grows is, up to normalisation, the Lyapunov spectrum of the recurrent map, and this has been computed for RNNs — including in relation to trainability and chaos. Our $G_m(T)$ growth coefficient $\beta$ is a difference of Lyapunov exponents, $\lambda_{m+1}-\lambda_m$. We therefore make no claim of novelty for the spectral measurement itself; the contribution lies in the discriminant and the null. [CHECK: Engelken, Wolf & Abbott; Vogt et al. — exact references]
+**Lyapunov spectra of recurrent networks.** The spectrum of $P_T$ as $T$ grows is, up to normalisation, the Lyapunov spectrum of the recurrent map, and this has been computed for RNNs — including in relation to trainability and chaos. Our $G_m(T)$ growth coefficient $\beta$ is a difference of Lyapunov exponents, $\lambda_{m+1}-\lambda_m$. We therefore make no claim of novelty for the spectral measurement itself; the contribution lies in the discriminant and the null. [3,4]
 
-**Covariant Lyapunov vectors.** The question of whether the contracting directions of successive factors align is, in dynamical-systems language, a question about the Oseledets filtration and its covariant vectors. Our $A^{\mathrm{carry}}$ is a finite-$T$, network-adapted version of this measurement. [CHECK: Ginelli et al.]
+**Covariant Lyapunov vectors.** The question of whether the contracting directions of successive factors align is, in dynamical-systems language, a question about the Oseledets filtration and its covariant vectors. Our $A^{\mathrm{carry}}$ is a finite-$T$, network-adapted version of this measurement. [5]
 
-**Rank collapse.** Dong et al. showed that pure attention degenerates doubly exponentially towards rank one. This is the opposite limiting case to the one we probe: total collapse of the bulk, rather than extinction of a small subspace with a healthy bulk. Our classifier is designed to separate the two. [CHECK]
+**Rank collapse.** Dong et al. showed that pure attention degenerates doubly exponentially towards rank one. This is the opposite limiting case to the one we probe: total collapse of the bulk, rather than extinction of a small subspace with a healthy bulk. Our classifier is designed to separate the two. [6]
 
-**Low intrinsic dimensionality.** Trained networks are widely reported to have low effective rank. This is the principal confounder for any alignment-based measurement, because a shared low-rank signal subspace forces the *complementary* subspaces to align trivially. Section 3.4 addresses it. [CHECK]
+**Low intrinsic dimensionality.** Trained networks are widely reported to have low effective rank. This is the principal confounder for any alignment-based measurement, because a shared low-rank signal subspace forces the *complementary* subspaces to align trivially. Section 3.4 addresses it. [9]
 
 ---
 
@@ -332,13 +332,20 @@ The author reviewed, verified and takes full responsibility for all content, inc
 
 ## References
 
-[FILL — Vancouver]
+> **Verification note (2026-07-21).** All entries below were verified by independent
+> title+author search (bibliographic details cross-checked against the publisher/arXiv
+> record, not against a page summary — the appendix pattern of the program registry).
+> The scite MCP was the intended verifier but was quota-blocked; WebSearch was used
+> instead, so **Smart-Citation tallies (supporting/contrasting) are not attached** — only
+> existence, authorship, venue and DOI are confirmed. Ref 9 (Ansuini et al.) is newly added
+> to close the §2 "low intrinsic dimensionality" [CHECK].
 
-1. Saxe AM, McClelland JL, Ganguli S. [CHECK]
-2. Pennington J, Schoenholz SS, Ganguli S. [CHECK]
-3. Engelken R, Wolf F, Abbott LF. [CHECK]
-4. Vogt R, et al. [CHECK]
-5. Ginelli F, et al. [CHECK]
-6. Dong Y, Cordonnier J-B, Loukas A. [CHECK]
-7. Benettin G, Galgani L, Giorgilli A, Strelcyn J-M. [CHECK]
-8. Dieci L, Van Vleck ES. [CHECK]
+1. Saxe AM, McClelland JL, Ganguli S. Exact solutions to the nonlinear dynamics of learning in deep linear neural networks. In: 2nd International Conference on Learning Representations (ICLR); 2014. arXiv:1312.6120.
+2. Pennington J, Schoenholz SS, Ganguli S. Resurrecting the sigmoid in deep learning through dynamical isometry: theory and practice. In: Advances in Neural Information Processing Systems 30 (NIPS 2017); 2017. p. 4785–95.
+3. Engelken R, Wolf F, Abbott LF. Lyapunov spectra of chaotic recurrent neural networks. Phys Rev Res. 2023;5(4):043044. doi:10.1103/PhysRevResearch.5.043044.
+4. Vogt R, Puelma Touzel M, Shlizerman E, Lajoie G. On Lyapunov exponents for RNNs: understanding information propagation using dynamical systems tools. Front Appl Math Stat. 2022;8:818799. doi:10.3389/fams.2022.818799.
+5. Ginelli F, Poggi P, Turchi A, Chaté H, Livi R, Politi A. Characterizing dynamics with covariant Lyapunov vectors. Phys Rev Lett. 2007;99(13):130601. doi:10.1103/PhysRevLett.99.130601.
+6. Dong Y, Cordonnier J-B, Loukas A. Attention is not all you need: pure attention loses rank doubly exponentially with depth. In: Proceedings of the 38th International Conference on Machine Learning (ICML); PMLR 139; 2021. p. 2793–803.
+7. Benettin G, Galgani L, Giorgilli A, Strelcyn J-M. Lyapunov characteristic exponents for smooth dynamical systems and for Hamiltonian systems; a method for computing all of them. Part 1: Theory. Meccanica. 1980;15(1):9–20. doi:10.1007/BF02128236. [Part 2: Numerical application. Meccanica. 1980;15(1):21–30. doi:10.1007/BF02128237.]
+8. Dieci L, Van Vleck ES. Computation of a few Lyapunov exponents for continuous and discrete dynamical systems. Appl Numer Math. 1995;17(3):275–91. doi:10.1016/0168-9274(95)00033-Q.
+9. Ansuini A, Laio A, Macke JH, Zoccolan D. Intrinsic dimension of data representations in deep neural networks. In: Advances in Neural Information Processing Systems 32 (NeurIPS 2019); 2019. p. 6109–19. arXiv:1905.12784.

--- a/docs/research/probe-preprint-draft.md
+++ b/docs/research/probe-preprint-draft.md
@@ -338,7 +338,10 @@ The author reviewed, verified and takes full responsibility for all content, inc
 > The scite MCP was the intended verifier but was quota-blocked; WebSearch was used
 > instead, so **Smart-Citation tallies (supporting/contrasting) are not attached** — only
 > existence, authorship, venue and DOI are confirmed. Ref 9 (Ansuini et al.) is newly added
-> to close the §2 "low intrinsic dimensionality" [CHECK].
+> to close the §2 "low intrinsic dimensionality" [CHECK]. A subsequent scite pass (2026-07-21)
+> completed the mandatory retraction/correction check **clean** for refs 3 (Engelken), 7
+> (Benettin, Part 1) and 8 (Dieci–Van Vleck) — `retraction_notices` absent; tallies still not
+> attached (scite backend was intermittent).
 
 1. Saxe AM, McClelland JL, Ganguli S. Exact solutions to the nonlinear dynamics of learning in deep linear neural networks. In: 2nd International Conference on Learning Representations (ICLR); 2014. arXiv:1312.6120.
 2. Pennington J, Schoenholz SS, Ganguli S. Resurrecting the sigmoid in deep learning through dynamical isometry: theory and practice. In: Advances in Neural Information Processing Systems 30 (NIPS 2017); 2017. p. 4785–95.


### PR DESCRIPTION
## Summary

Closes the citation-verification debt left after the Piloto 1 / Mercyful Learning research lane:

- **`docs/research/probe-preprint-draft.md`**: fill Vancouver references for the §2 related-work cites; resolve all §2 `[CHECK]` markers to numbered refs; add Ansuini et al. (NeurIPS 2019) for low intrinsic dimensionality; record a clean scite retraction check for refs 3/7/8.
- **`docs/research/PREREG-piloto1-semantic-barriers.md`**: add a **post-registration** dated references appendix (does not alter the stamped prereg body). Corrects Farooq DOI to `10.1038/s41467-019-12915-x` (*Nat Commun*, not the Sci Rep DOI that a guess produced).

No code, no science results, no change to the Piloto 1 **NO BARRIER** verdict (already on `main` via #1314/#1330/#1341).

## Remaining deliberately open (not this PR)

- Probe preprint still has run-artefact `[FILL]` numbers (depth, align, residual accuracy, etc.) — not citations.
- scite Smart-Citation tallies not attached (backend intermittent / free-tier limits).

## Test plan

- [x] Rebase onto current `origin/main` (clean; 2 files only)
- [x] No conflict markers; appendix sits after §10 deliverable, before GAIDeT disclosure
- [ ] Docs-only CI / human skim of the two files on the PR diff
- [ ] Confirm Farooq DOI resolves to Nat Commun 10:4937 (not Sci Rep)