### PR TITLE
docs(governance): re-sync stale metadata headers on 5 research docs

### DIFF
--- a/docs/research/PREREG-piloto1-addendum1.md
+++ b/docs/research/PREREG-piloto1-addendum1.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.prereg-piloto1-addendum1
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/PREREG-piloto1-addendum2.md
+++ b/docs/research/PREREG-piloto1-addendum2.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.prereg-piloto1-addendum2
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/PREREG-piloto1-semantic-barriers.md
+++ b/docs/research/PREREG-piloto1-semantic-barriers.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.prereg-piloto1-semantic-barriers
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/PROGRAM-REGISTRY-mercyful-learning.md
+++ b/docs/research/PROGRAM-REGISTRY-mercyful-learning.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.program-registry-mercyful-learning
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.

--- a/docs/research/probe-preprint-draft.md
+++ b/docs/research/probe-preprint-draft.md
@@ -7,6 +7,7 @@ validated_by: A6
 source_of_truth: docs/governance/topic-registry.v1.json#repo.docs.research.probe-preprint-draft
 -->
 
+
 <!-- docs:status-note:start -->
 > Docs status: `historical`
 > This page is preserved for lineage. Start at [Docs Authority Matrix](../governance/DOCS_AUTHORITY_MATRIX.md) and [docs index](../README.md) for the current canonical surface for this topic.


### PR DESCRIPTION
Regenerates the `docs:meta` blocks for five research docs whose committed headers had drifted from the current `sync_governance_metadata.mjs` output — the standard post-merge governance staleness noted in the repo's own tooling. Restores the `check_docs_registry` (Contracts) gate to green.

Files (headers only, no body content changed):
- `docs/research/PREREG-piloto1-addendum1.md`
- `docs/research/PREREG-piloto1-addendum2.md`
- `docs/research/PREREG-piloto1-semantic-barriers.md`
- `docs/research/PROGRAM-REGISTRY-mercyful-learning.md`
- `docs/research/probe-preprint-draft.md`

Produced by `node scripts/docs/sync_governance_metadata.mjs`; the registry/matrix/acceptance files were already fresh on main, so this touches only the five doc headers. No conflict with #1367 (edits those files' bodies) or #1369 (edits the governance JSON/matrix) — different regions/files, verified clean in both merge orders.